### PR TITLE
Fix optimisation in SmallElementLocation

### DIFF
--- a/src/Build/ElementLocation/ElementLocation.cs
+++ b/src/Build/ElementLocation/ElementLocation.cs
@@ -91,7 +91,7 @@ namespace Microsoft.Build.Construction
         public override int GetHashCode()
         {
             // Line and column are good enough
-            return Line.GetHashCode() ^ Column.GetHashCode();
+            return Line ^ Column;
         }
 
         /// <summary>

--- a/src/Build/ElementLocation/ElementLocation.cs
+++ b/src/Build/ElementLocation/ElementLocation.cs
@@ -100,11 +100,6 @@ namespace Microsoft.Build.Construction
         /// </summary>
         public override bool Equals(object obj)
         {
-            if (obj == null)
-            {
-                return false;
-            }
-
             IElementLocation that = obj as IElementLocation;
 
             if (that == null)

--- a/src/Build/ElementLocation/ElementLocation.cs
+++ b/src/Build/ElementLocation/ElementLocation.cs
@@ -7,8 +7,6 @@ using Microsoft.Build.BackEnd;
 using Microsoft.Build.Collections;
 using Microsoft.Build.Shared;
 
-#nullable disable
-
 namespace Microsoft.Build.Construction
 {
     /// <summary>
@@ -98,9 +96,9 @@ namespace Microsoft.Build.Construction
         /// Override Equals so that identical
         /// fields imply equal objects.
         /// </summary>
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
-            IElementLocation that = obj as IElementLocation;
+            IElementLocation? that = obj as IElementLocation;
 
             if (that == null)
             {
@@ -151,7 +149,7 @@ namespace Microsoft.Build.Construction
         /// </summary>
         internal static ElementLocation FactoryForDeserialization(ITranslator translator)
         {
-            string file = null;
+            string? file = null;
             int line = 0;
             int column = 0;
             translator.Translate(ref file);
@@ -180,7 +178,7 @@ namespace Microsoft.Build.Construction
         /// In AG there are 600 locations that have a file but zero line and column.
         /// In theory yet another derived class could be made for these to save 4 bytes each.
         /// </remarks>
-        internal static ElementLocation Create(string file, int line, int column)
+        internal static ElementLocation Create(string? file, int line, int column)
         {
             if (string.IsNullOrEmpty(file) && line == 0 && column == 0)
             {
@@ -247,7 +245,7 @@ namespace Microsoft.Build.Construction
             /// Numerical values must be 1-based, non-negative; 0 indicates unknown
             /// File may be null, indicating the file was not loaded from disk.
             /// </summary>
-            internal RegularElementLocation(string file, int line, int column)
+            internal RegularElementLocation(string? file, int line, int column)
             {
                 ErrorUtilities.VerifyThrowArgumentLengthIfNotNull(file, nameof(file));
                 ErrorUtilities.VerifyThrow(line > -1 && column > -1, "Use zero for unknown");
@@ -323,7 +321,7 @@ namespace Microsoft.Build.Construction
             /// Numerical values must be 1-based, non-negative; 0 indicates unknown
             /// File may be null or empty, indicating the file was not loaded from disk.
             /// </summary>
-            internal SmallElementLocation(string file, int line, int column)
+            internal SmallElementLocation(string? file, int line, int column)
             {
                 ErrorUtilities.VerifyThrow(line > -1 && column > -1, "Use zero for unknown");
                 ErrorUtilities.VerifyThrow(line <= 65535 && column <= 65535, "Use ElementLocation instead");

--- a/src/Build/ElementLocation/ElementLocation.cs
+++ b/src/Build/ElementLocation/ElementLocation.cs
@@ -130,13 +130,13 @@ namespace Microsoft.Build.Construction
 
         /// <summary>
         /// Writes the packet to the serializer.
-        /// Always send as ints, even if ushorts are being used: otherwise it'd
-        /// need a byte to discriminate and the savings would be microscopic.
         /// </summary>
         void ITranslatable.Translate(ITranslator translator)
         {
             ErrorUtilities.VerifyThrow(translator.Mode == TranslationDirection.WriteToStream, "write only");
 
+            // Translate int, even if ushort is being used.
+            // Internally, the translator uses a variable length (prefix) encoding.
             string file = File;
             int line = Line;
             int column = Column;

--- a/src/Build/ElementLocation/ElementLocation.cs
+++ b/src/Build/ElementLocation/ElementLocation.cs
@@ -307,14 +307,15 @@ namespace Microsoft.Build.Construction
             private string file;
 
             /// <summary>
-            /// The source line.
+            /// Packs both the line and column values into a single four-byte element.
+            /// The high two bytes are the line, and low two bytes are the column.
             /// </summary>
-            private ushort line;
-
-            /// <summary>
-            /// The source column.
-            /// </summary>
-            private ushort column;
+            /// <remarks>
+            /// If we had two <see cref="ushort"/> fields, the CLR would pad them each to
+            /// four-byte boundaries, meaning no space would actually be saved here.
+            /// So instead, we pack them manually.
+            /// </remarks>
+            private int packedData;
 
             /// <summary>
             /// Constructor for the case where we have most or all information.
@@ -327,8 +328,7 @@ namespace Microsoft.Build.Construction
                 ErrorUtilities.VerifyThrow(line <= 65535 && column <= 65535, "Use ElementLocation instead");
 
                 this.file = file ?? String.Empty;
-                this.line = Convert.ToUInt16(line);
-                this.column = Convert.ToUInt16(column);
+                packedData = (line << 16) | column;
             }
 
             /// <summary>
@@ -351,7 +351,7 @@ namespace Microsoft.Build.Construction
             [DebuggerBrowsable(DebuggerBrowsableState.Never)]
             public override int Line
             {
-                get { return (int)line; }
+                get { return (packedData >> 16) & 0xFFFF; }
             }
 
             /// <summary>
@@ -362,7 +362,7 @@ namespace Microsoft.Build.Construction
             [DebuggerBrowsable(DebuggerBrowsableState.Never)]
             public override int Column
             {
-                get { return (int)column; }
+                get { return packedData & ushort.MaxValue; }
             }
         }
     }

--- a/src/Shared/ErrorUtilities.cs
+++ b/src/Shared/ErrorUtilities.cs
@@ -537,17 +537,19 @@ namespace Microsoft.Build.Shared
             }
         }
 
+#nullable enable
         /// <summary>
         /// Throws an ArgumentException if the string has zero length, unless it is
         /// null, in which case no exception is thrown.
         /// </summary>
-        internal static void VerifyThrowArgumentLengthIfNotNull(string parameter, string parameterName)
+        internal static void VerifyThrowArgumentLengthIfNotNull(string? parameter, string parameterName)
         {
             if (parameter?.Length == 0)
             {
                 ThrowArgumentLength(parameterName);
             }
         }
+#nullable disable
 
         /// <summary>
         /// Throws an ArgumentNullException if the given parameter is null.


### PR DESCRIPTION
Fixes #10028

### Context

Pack line and column values into four bytes

The `SmallElementLocation` class exists because very few element locations require 32 bits to store the line/column values. It uses `ushort` (2 bytes) instead of `int` (4 bytes) for each value, in an attempt to reduce memory usage.

However the CLR aligns `ushort` fields on classes at four-byte boundaries on most (all?) architectures, meaning the optimisation has no effect.

This commit explicitly packs the two values into four bytes to ensure that four bytes is saved per instance.

### Changes Made

- Manually pack two `ushort` values into a single `int32` field.
- Null annotate file
- Remove some redundant code
- Fix an incorrect comment

### Testing

Unit test coverage looks good.