### PR TITLE
Get life proc output in integration tests

### DIFF
--- a/src/BuildCheck.UnitTests/EndToEndTests.cs
+++ b/src/BuildCheck.UnitTests/EndToEndTests.cs
@@ -121,7 +121,7 @@ public class EndToEndTests : IDisposable
         _env.SetEnvironmentVariable("MSBUILDLOGPROPERTIESANDITEMSAFTEREVALUATION", "1");
         string output = RunnerUtilities.ExecBootstrapedMSBuild(
             $"{Path.GetFileName(projectFile.Path)} /m:1 -nr:False -restore" +
-            (analysisRequested ? " -analyze" : string.Empty), out bool success);
+            (analysisRequested ? " -analyze" : string.Empty), out bool success, false, _env.Output);
         _env.Output.WriteLine(output);
         success.ShouldBeTrue();
         // The conflicting outputs warning appears - but only if analysis was requested

--- a/src/UnitTests.Shared/RunnerUtilities.cs
+++ b/src/UnitTests.Shared/RunnerUtilities.cs
@@ -112,6 +112,7 @@ namespace Microsoft.Build.UnitTests.Shared
                 {
                     if (args != null)
                     {
+                        WriteOutput(args.Data);
                         output += args.Data + "\r\n";
                     }
                 };
@@ -119,9 +120,8 @@ namespace Microsoft.Build.UnitTests.Shared
                 p.OutputDataReceived += handler;
                 p.ErrorDataReceived += handler;
 
-                outputHelper?.WriteLine("Executing [{0} {1}]", process, parameters);
-                Console.WriteLine("Executing [{0} {1}]", process, parameters);
-
+                WriteOutput( $"Executing [{process} {parameters}]");
+                WriteOutput("==== OUTPUT ====");
                 p.Start();
                 p.BeginOutputReadLine();
                 p.BeginErrorReadLine();
@@ -148,18 +148,17 @@ namespace Microsoft.Build.UnitTests.Shared
                 successfulExit = p.ExitCode == 0;
             }
 
-            outputHelper?.WriteLine("==== OUTPUT ====");
-            outputHelper?.WriteLine(output);
-            outputHelper?.WriteLine("Process ID is " + pid + "\r\n");
-            outputHelper?.WriteLine("==============");
-
-            Console.WriteLine("==== OUTPUT ====");
-            Console.WriteLine(output);
-            Console.WriteLine("Process ID is " + pid + "\r\n");
-            Console.WriteLine("==============");
+            WriteOutput("Process ID is " + pid + "\r\n");
+            WriteOutput("==============");
 
             output += "Process ID is " + pid + "\r\n";
             return output;
+
+            void WriteOutput(string data)
+            {
+                outputHelper?.WriteLine(data);
+                Console.WriteLine(data);
+            }
         }
     }
 }

--- a/src/UnitTests.Shared/RunnerUtilities.cs
+++ b/src/UnitTests.Shared/RunnerUtilities.cs
@@ -110,7 +110,7 @@ namespace Microsoft.Build.UnitTests.Shared
             {
                 DataReceivedEventHandler handler = delegate (object sender, DataReceivedEventArgs args)
                 {
-                    if (args != null)
+                    if (args != null && args.Data != null)
                     {
                         WriteOutput(args.Data);
                         output += args.Data + "\r\n";


### PR DESCRIPTION

### Context
Simplifies troubleshooting of timeouting integration tests (like e.g. https://github.com/dotnet/msbuild/issues/10036)
