### PR TITLE
Fix item spec in project file

### DIFF
--- a/src/MSBuildTaskHost/MSBuildTaskHost.csproj
+++ b/src/MSBuildTaskHost/MSBuildTaskHost.csproj
@@ -241,7 +241,7 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <Content Include="..\MSBuild.ico" />
+    <Content Include="..\MSBuild\MSBuild.ico" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\StringTools\StringTools.csproj" />


### PR DESCRIPTION
This fixes incremental build for the MSBuildTaskHost project inside Visual Studio.

Previously, the VS FUTDC would find this input file missing and schedule a call to MSBuild:

> FastUpToDate: Input UpToDateCheckInput item 'D:\repos\msbuild\src\MSBuild.ico' does not exist and is required, not up-to-date.
