### PR TITLE
Added eventSource to BuildCheck logger

### DIFF
--- a/src/Build/BuildCheck/Infrastructure/BuildCheckConnectorLogger.cs
+++ b/src/Build/BuildCheck/Infrastructure/BuildCheckConnectorLogger.cs
@@ -22,6 +22,11 @@ internal sealed class BuildCheckConnectorLogger(IBuildAnalysisLoggingContextFact
     {
         eventSource.AnyEventRaised += EventSource_AnyEventRaised;
         eventSource.BuildFinished += EventSource_BuildFinished;
+
+        if (eventSource is IEventSource4 eventSource4)
+        {
+            eventSource4.IncludeEvaluationPropertiesAndItems();
+        }
     }
 
     private void EventSource_AnyEventRaised(object sender, BuildEventArgs e)


### PR DESCRIPTION
### Context
In some cases when running BuildCheck during build (non restore phase), the analyzers will not receive any property information and therefore will not trigger correctly.
This is caused by backwards compatibility logger stuff, so " subscribing"  the logger to a newer data format lets the analyzer receive all necessary information to run correctly.

### Changes Made
Subscribed logger to newer eventSource version during initialization.


