### PR TITLE
Fix warning in CustomBuildEventArgs

### DIFF
--- a/src/Framework/CustomBuildEventArgs.cs
+++ b/src/Framework/CustomBuildEventArgs.cs
@@ -13,10 +13,9 @@ namespace Microsoft.Build.Framework
     /// <remarks>
     /// <format type="text/markdown"><![CDATA[
     /// ## Remarks
-    /// > [!CAUTION]
-    /// In .NET 8 and later and Visual Studio 17.8 and later, this type is deprecated; instead use <xref:Microsoft.Build.Framework.ExtendedCustomBuildEventArgs>.
-    /// For more information, [this link](https://learn.microsoft.com/dotnet/core/compatibility/sdk/8.0/custombuildeventargs).
-    /// For recommended replacement, see [this link](https://learn.microsoft.com/dotnet/core/compatibility/sdk/8.0/custombuildeventargs#recommended-action).
+    /// > [!WARNING]
+    /// > In .NET 8 and later and Visual Studio 17.8 and later, this type is deprecated; instead use [ExtendedCustomBuildEventArgs](/dotnet/api/microsoft.build.framework.extendedcustombuildeventargs).
+    /// > For more information, see [MSBuild custom derived build events deprecated](/dotnet/core/compatibility/sdk/8.0/custombuildeventargs).
     /// ]]></format>
     /// </remarks>
     [Serializable]


### PR DESCRIPTION
Fixes badly formatted caution/warning note and links.

### Context

An XML doc comment was not rendering properly due to badly formatted Markdown in a CDATA section.


### Changes Made

Add proper formatting for warning note.
Change severity level from Caution to Warning (more appropriate for this situation)
Remove redundant third link 

### Testing

Tested the equivalent fix in the MSBuild API docs repo:
https://github.com/dotnet/msbuild-api-docs/pull/42

### Notes

The fix in the API docs repo can be promoted live right away.
The fix here in MSBuild source will take effect once we rebuild the MSBuild API docs XML from source after the next dot release when the NuGet packages are republished.
