### PR TITLE
[GB18030] Fix `SubstringByTextElements` - avoid `ArgumentOutOfRangeException`

### DIFF
--- a/src/Build.UnitTests/Evaluation/Expander_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/Expander_Tests.cs
@@ -4385,6 +4385,7 @@ $(
         [Theory]
         [InlineData("\u3407\ud840\udc60\ud86a\ude30\ud86e\udc0a\ud86e\udda0\ud879\udeae\u2fd5\u0023", 0, 3, "\u3407\ud840\udc60\ud86a\ude30")]
         [InlineData("\u3407\ud840\udc60\ud86a\ude30\ud86e\udc0a\ud86e\udda0\ud879\udeae\u2fd5\u0023", 2, 5, "\ud86a\ude30\ud86e\udc0a\ud86e\udda0\ud879\udeae\u2fd5")]
+        [InlineData("\ud83d\udc68\u200d\ud83d\udc68\u200d\ud83d\udc66\u200d\ud83d\udc66\ud83d\udc68\u200d\ud83d\udc68\u200d\ud83d\udc66\u200d\ud83d\udc66\u002e\u0070\u0072\u006f\u006a", 0, 8, "\ud83d\udc68\u200d\ud83d\udc68\u200d\ud83d\udc66\u200d\ud83d\udc66\ud83d\udc68\u200d\ud83d\udc68\u200d\ud83d\udc66\u200d\ud83d\udc66\u002e\u0070\u0072\u006f\u006a")]
         public void SubstringByTextElements(string featureName, int start, int length, string expected)
         {
             var expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(new PropertyDictionary<ProjectPropertyInstance>(), FileSystems.Default);

--- a/src/Build/Evaluation/IntrinsicFunctions.cs
+++ b/src/Build/Evaluation/IntrinsicFunctions.cs
@@ -632,7 +632,9 @@ namespace Microsoft.Build.Evaluation
         internal static string SubstringByTextElements(string input, int start, int length)
         {
             StringInfo stringInfo = new StringInfo(input);
-            return stringInfo.SubstringByTextElements(start, length);
+            if (stringInfo.LengthInTextElements > length + start)
+                return stringInfo.SubstringByTextElements(start, length);
+            return input;
         }
 
         internal static string CheckFeatureAvailability(string featureName)


### PR DESCRIPTION
Follow up for https://github.com/dotnet/msbuild/pull/10063, see the discussion.

### Context
The original PR was fixing `GB18030` issue but for project names with less text elements than 8 it would be throwing an exception.

### Changes Made
Fix: do not change project name if it's shorter than 8 text elements.

### Testing
Automatic test case added.

### Notes
Not sure if this fulfills the original requirement of short project names.