### PR TITLE
Fix AfterTarget parent

### DIFF
--- a/src/Build/BackEnd/Components/RequestBuilder/TargetBuilder.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TargetBuilder.cs
@@ -429,7 +429,7 @@ namespace Microsoft.Build.BackEnd
 
                             // Push our after targets, if any.  Our parent is the parent of the target after which we are running.
                             IList<TargetSpecification> afterTargets = _requestEntry.RequestConfiguration.Project.GetTargetsWhichRunAfter(currentTargetEntry.Name);
-                            bool didPushTargets = await PushTargets(afterTargets, currentTargetEntry.ParentEntry, currentTargetEntry.Lookup, currentTargetEntry.ErrorTarget, currentTargetEntry.StopProcessingOnCompletion, TargetBuiltReason.AfterTargets);
+                            bool didPushTargets = await PushTargets(afterTargets, currentTargetEntry, currentTargetEntry.Lookup, currentTargetEntry.ErrorTarget, currentTargetEntry.StopProcessingOnCompletion, TargetBuiltReason.AfterTargets);
 
                             // If we have after targets, the last one to run will inherit the stopProcessing flag and we will reset ours.  If we didn't push any targets, then we shouldn't clear the
                             // flag because it means we are still on the bottom of this CallTarget stack.


### PR DESCRIPTION
Fixes https://github.com/KirillOsenkov/MSBuildStructuredLog/issues/762

### Context
On a specific edge case, where a target is an after target of the build's entry target, the parent target does not show.

Using the example from the issue
![image](https://github.com/dotnet/msbuild/assets/10743736/47a32680-483f-4a4a-bff6-118b601929a9)

Target1 is the entry target for the build.
Target4 is an after target from target1.
Since target1 is the entry point, the parent of target4 is registered as null.

### Changes Made
When pushing after targets to the stack, we currently register the parent of the parent. The change will register just the parent.

### Notes
In the code there is a comment that explicitly states that we are pushing the parent of the parent. We are not sure of the historical reason for this, but it does not make a lot of sense. This PR is to run all the tests and just check if things don't break.