### PR TITLE
Don't reference S.S.Principal.Windows on .NETCoreApp

### DIFF
--- a/src/Build/Microsoft.Build.csproj
+++ b/src/Build/Microsoft.Build.csproj
@@ -33,7 +33,6 @@
 
     <PackageReference Include="System.Collections.Immutable" />
     <PackageReference Include="System.Configuration.ConfigurationManager" />
-    <PackageReference Include="System.Security.Principal.Windows" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" />
 
     <PackageReference Include="System.Reflection.MetadataLoadContext" />
@@ -49,6 +48,7 @@
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
     <Reference Include="System.IO.Compression" />
     <PackageReference Include="System.Memory" />
+    <PackageReference Include="System.Security.Principal.Windows" />
     <PackageReference Include="System.Text.Json" />
   </ItemGroup>
 


### PR DESCRIPTION
S.Security.Principal.Windows moved inbox with .NET 6 and doesn't need to be referenced anymore.

This helps with keeping the dependency graph fresh:
![image](https://github.com/dotnet/msbuild/assets/7412651/e65ebb75-30d7-433a-85fb-fd929edd6184)

