### PR TITLE
[ClickOnce] Fix BootstrapperBuilder code to correctly return the list of products available in the packages folder

### DIFF
--- a/src/Tasks/BootstrapperUtil/BootstrapperBuilder.cs
+++ b/src/Tasks/BootstrapperUtil/BootstrapperBuilder.cs
@@ -829,81 +829,44 @@ namespace Microsoft.Build.Tasks.Deployment.Bootstrapper
 
                 if (fileExists)
                 {
-                    var xmlTextReader = new XmlTextReader(filePath) { DtdProcessing = DtdProcessing.Ignore };
-
-                    XmlReader xmlReader = xmlTextReader;
-
+                    XmlReaderSettings xmlReaderSettings = new XmlReaderSettings();
+                    xmlReaderSettings.DtdProcessing = DtdProcessing.Ignore;
                     if (validate)
                     {
-#pragma warning disable 618 // Using XmlValidatingReader. TODO: We need to switch to using XmlReader.Create() with validation.
-                        using var validatingReader = new XmlValidatingReader(xmlReader);
-#pragma warning restore 618
-                        var xrSettings = new XmlReaderSettings { DtdProcessing = DtdProcessing.Ignore, CloseInput = true };
-                        FileStream fs = File.OpenRead(schemaPath);
-                        using (XmlReader xr = XmlReader.Create(fs, xrSettings))
+                        xmlReaderSettings.ValidationType = ValidationType.Schema;
+                        xmlReaderSettings.XmlResolver = null;
+                        xmlReaderSettings.ValidationEventHandler += results.SchemaValidationEventHandler; ;
+                        xmlReaderSettings.Schemas.Add(null, schemaPath);
+                    }
+
+                    using (StreamReader streamReader = new StreamReader(filePath))
+                    {
+                        using (XmlReader xmlReader = XmlReader.Create(streamReader, xmlReaderSettings, filePath))
                         {
                             try
                             {
-                                // first, add our schema to the validating reader's collection of schemas
-                                var xmlSchema = validatingReader.Schemas.Add(null, xr);
-
-                                // if our schema namespace gets out of sync,
-                                //   then all of our calls to SelectNodes and SelectSingleNode will fail
-                                Debug.Assert((xmlSchema != null) &&
-                                    string.Equals(schemaNamespace, xmlSchema.TargetNamespace, StringComparison.Ordinal),
-                                    System.IO.Path.GetFileName(schemaPath) + " and BootstrapperBuilder.vb have mismatched namespaces, so the BootstrapperBuilder will fail to work.");
-
-                                // if we're supposed to be validating, then hook up our handler
-                                validatingReader.ValidationEventHandler += results.SchemaValidationEventHandler;
-
-                                // switch readers so the doc does the actual read over the validating
-                                //   reader so we get validation events as we load the document
-                                xmlReader = validatingReader;
+                                Debug.Assert(_document != null, "our document should have been created by now!");
+                                xmlDocument = new XmlDocument(_document.NameTable);
+                                xmlDocument.Load(xmlReader);
                             }
                             catch (XmlException ex)
                             {
-                                Debug.Fail("Failed to load schema '" + schemaPath + "' due to the following exception:\r\n" + ex.Message);
-                                validate = false;
+                                Debug.Fail("Failed to load document '" + filePath + "' due to the following exception:\r\n" + ex.Message);
+                                return null;
                             }
                             catch (System.Xml.Schema.XmlSchemaException ex)
                             {
-                                Debug.Fail("Failed to load schema '" + schemaPath + "' due to the following exception:\r\n" + ex.Message);
-                                validate = false;
+                                Debug.Fail("Failed to load document '" + filePath + "' due to the following exception:\r\n" + ex.Message);
+                                return null;
                             }
                         }
-                    }
-
-                    try
-                    {
-                        Debug.Assert(_document != null, "our document should have been created by now!");
-                        xmlDocument = new XmlDocument(_document.NameTable);
-                        xmlDocument.Load(xmlReader);
-                    }
-                    catch (XmlException ex)
-                    {
-                        Debug.Fail("Failed to load document '" + filePath + "' due to the following exception:\r\n" + ex.Message);
-                        return null;
-                    }
-                    catch (System.Xml.Schema.XmlSchemaException ex)
-                    {
-                        Debug.Fail("Failed to load document '" + filePath + "' due to the following exception:\r\n" + ex.Message);
-                        return null;
-                    }
-                    finally
-                    {
-                        xmlReader.Close();
                     }
 
                     // Note that the xml document's default namespace must match the schema namespace
                     //   or none of our SelectNodes/SelectSingleNode calls will succeed
                     Debug.Assert(xmlDocument.DocumentElement != null &&
-                        string.Equals(xmlDocument.DocumentElement.NamespaceURI, schemaNamespace, StringComparison.Ordinal),
-                        "'" + xmlDocument.DocumentElement.NamespaceURI + "' is not '" + schemaNamespace + "'...");
-
-                    if ((xmlDocument.DocumentElement == null) ||
-                       (!string.Equals(xmlDocument.DocumentElement.NamespaceURI, schemaNamespace, StringComparison.Ordinal)))
-                    {
-                    }
+                                string.Equals(xmlDocument.DocumentElement.NamespaceURI, schemaNamespace, StringComparison.Ordinal),
+                                "'" + xmlDocument.DocumentElement.NamespaceURI + "' is not '" + schemaNamespace + "'...");
                 }
             }
 


### PR DESCRIPTION
Fixes AB#2046752

### Context
#9983 introduced a regression in ClickOnce's bootstrapper packages builder code by disposing an XmlReader object while it's still in use.

### Changes Made
Fix the bootstrapper builder code that validates package/product XML against a schema file to use the XmlReaderSettings instead of the deprecated XmlValidatingReader class.

### Testing
Updated code has been verified against valid and invalid schema file. In addition, the ClickOnce publish with bootstrapper products included has been verified.

### Notes
