### PR TITLE
Enable AssignCulture Task's property 'RespectAlreadyAssignedItemCulture' by default

### DIFF
--- a/documentation/wiki/ChangeWaves.md
+++ b/documentation/wiki/ChangeWaves.md
@@ -27,6 +27,7 @@ A wave of features is set to "rotate out" (i.e. become standard functionality) t
 - [Log TaskParameterEvent for scalar parameters](https://github.com/dotnet/msbuild/pull/9908)
 - [Convert.ToString during a property evaluation uses the InvariantCulture for all types](https://github.com/dotnet/msbuild/pull/9874)
 - [Fix oversharing of build results in ResultsCache](https://github.com/dotnet/msbuild/pull/9987)
+- [Default value of RespectAlreadyAssignedItemCulture property in AssignCulture task and CommonTargets set to true unless specified](https://github.com/dotnet/msbuild/pull/9987)
 
 ### 17.10
 - [AppDomain configuration is serialized without using BinFmt](https://github.com/dotnet/msbuild/pull/9320) - feature can be opted out only if [BinaryFormatter](https://learn.microsoft.com/en-us/dotnet/api/system.runtime.serialization.formatters.binary.binaryformatter) is allowed at runtime by editing `MSBuild.runtimeconfig.json`

--- a/src/Tasks/AssignCulture.cs
+++ b/src/Tasks/AssignCulture.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Build.Tasks
         /// If the flag set to 'true' the incoming list with existing Culture metadata will not be ammended and CultureNeutralAssignedFiles filename will be equal to the original.
         /// In case the Culture metadata was not provided, the logic of RespectAlreadyAssignedItemCulture will not take any effect.
         /// </summary>
-        public bool RespectAlreadyAssignedItemCulture { get; set; } = false;
+        public bool RespectAlreadyAssignedItemCulture { get; set; } = ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_12);
 
         /// <summary>
         /// This outgoing list of files is exactly the same as the incoming Files

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -3245,7 +3245,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       DependsOnTargets="AssignTargetPaths">
 
     <PropertyGroup>
-      <RespectAlreadyAssignedItemCulture Condition="'$(RespectAlreadyAssignedItemCulture)' == ''">false</RespectAlreadyAssignedItemCulture>
+      <RespectAlreadyAssignedItemCulture Condition="'$(RespectAlreadyAssignedItemCulture)' == '' and '$([MSBuild]::AreFeaturesEnabled(17.12))' != 'true'">false</RespectAlreadyAssignedItemCulture>
+      <RespectAlreadyAssignedItemCulture Condition="'$(RespectAlreadyAssignedItemCulture)' == '' and $([MSBuild]::AreFeaturesEnabled(17.12))">true</RespectAlreadyAssignedItemCulture>
     </PropertyGroup>
 
     <Warning Condition="'@(ResxWithNoCulture)'!=''" Code="MSB9000" Text="ResxWithNoCulture item type is deprecated. Use EmbeddedResource items instead."/>


### PR DESCRIPTION
### Context
The [PR](https://github.com/dotnet/msbuild/commit/65dfeb8a8dd5501ac1d28e5de1ce219cb5ef138f) that have introduced new property RespectAlreadyAssignedItemCulture is merged, but by default set to false:
- In Task default value
- In common targets

### Changes Made
Set RespectAlreadyAssignedItemCulture value to true by default in Common Targets and task.
The change is introduced under the ChangeWave 17.12

### Testing
Manual testing of Common targets. 
Updated unit test of AssignCulture tests
