### PR TITLE
implement ContainsKey() in PropertyDictionary

### DIFF
--- a/src/Build/Collections/PropertyDictionary.cs
+++ b/src/Build/Collections/PropertyDictionary.cs
@@ -337,18 +337,18 @@ namespace Microsoft.Build.Collections
         /// <summary>
         /// Returns true if the dictionary contains the key
         /// </summary>
-        public bool ContainsKey(string key) => ((IDictionary<string, T>)this).ContainsKey(key);
-
-        /// <summary>
-        /// Returns true if the dictionary contains the key
-        /// </summary>
-        bool IDictionary<string, T>.ContainsKey(string key)
+        public bool ContainsKey(string key)
         {
             lock (_properties)
             {
                 return _properties.ContainsKey(key);
             }
         }
+
+        /// <summary>
+        /// Returns true if the dictionary contains the key
+        /// </summary>
+        bool IDictionary<string, T>.ContainsKey(string key) => ContainsKey(key);
 
         /// <summary>
         /// Removes a property


### PR DESCRIPTION
continuing on https://github.com/dotnet/msbuild/pull/10107

next error from installer / source-build test build https://dev.azure.com/dnceng-public/public/_build/results?buildId=667056&view=logs&j=609589e2-4f74-5576-cdb7-914bcaea778b

```
MSBUILD : error MSB1025: An internal failure occurred while running MSBuild. [/vmr/repo-projects/scenario-tests.proj]
  System.TypeLoadException: Method 'ContainsKey' in type 'Microsoft.Build.Collections.PropertyDictionary`1' from assembly 'Microsoft.Build, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' does not have an implementation.
     at Microsoft.Build.Evaluation.ProjectCollection..ctor(IDictionary`2 globalProperties, IEnumerable`1 loggers, IEnumerable`1 remoteLoggers, ToolsetDefinitionLocations toolsetDefinitionLocations, Int32 maxNodeCount, Boolean onlyLogCriticalEvents, Boolean loadProjectsReadOnly, Boolean useAsynchronousLogging, Boolean reuseProjectRootElementCache)
  Unhandled exception: System.TypeLoadException: Method 'ContainsKey' in type 'Microsoft.Build.Collections.PropertyDictionary`1' from assembly 'Microsoft.Build, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' does not have an implementation.
     at Microsoft.Build.Evaluation.ProjectCollection..ctor(IDictionary`2 globalProperties, IEnumerable`1 loggers, IEnumerable`1 remoteLoggers, ToolsetDefinitionLocations toolsetDefinitionLocations, Int32 maxNodeCount, Boolean onlyLogCriticalEvents, Boolean loadProjectsReadOnly, Boolean useAsynchronousLogging, Boolean reuseProjectRootElementCache)
     at Microsoft.Build.CommandLine.MSBuildApp.BuildProject(String projectFile, String[] targets, String toolsVersion, Dictionary`2 globalProperties, Dictionary`2 restoreProperties, ILogger[] loggers, LoggerVerbosity verbosity, DistributedLoggerRecord[] distributedLoggerRecords, Int32 cpuCount, Boolean enableNodeReuse, TextWriter preprocessWriter, TextWriter targetsWriter, Boolean detailedSummary, ISet`1 warningsAsErrors, ISet`1 warningsNotAsErrors, ISet`1 warningsAsMessages, Boolean enableRestore, ProfilerLogger profilerLogger, Boolean enableProfiler, Boolean interactive, ProjectIsolationMode isolateProjects, GraphBuildOptions graphBuildOptions, Boolean lowPriority, Boolean question, Boolean isBuildCheckEnabled, String[] inputResultsCaches, String outputResultsCache, Boolean saveProjectResult, BuildResult& result, String[] commandLine)
     at Microsoft.Build.CommandLine.MSBuildApp.Execute(String[] commandLine)
     at Microsoft.Build.CommandLine.MSBuildApp.Execute(String[] commandLine)
     at Microsoft.Build.CommandLine.MSBuildApp.Main(String[] args)
     at Microsoft.DotNet.Cli.Utils.MSBuildForwardingAppWithoutLogging.ExecuteInProc(String[] arguments)
     at Microsoft.Build.CommandLine.MSBuildApp.BuildProject(String projectFile, String[] targets, String toolsVersion, Dictionary`2 globalProperties, Dictionary`2 restoreProperties, ILogger[] loggers, LoggerVerbosity verbosity, DistributedLoggerRecord[] distributedLoggerRecords, Int32 cpuCount, Boolean enableNodeReuse, TextWriter preprocessWriter, TextWriter targetsWriter, Boolean detailedSummary, ISet`1 warningsAsErrors, ISet`1 warningsNotAsErrors, ISet`1 warningsAsMessages, Boolean enableRestore, ProfilerLogger profilerLogger, Boolean enableProfiler, Boolean interactive, ProjectIsolationMode isolateProjects, GraphBuildOptions graphBuildOptions, Boolean lowPriority, Boolean question, Boolean isBuildCheckEnabled, String[] inputResultsCaches, String outputResultsCache, Boolean saveProjectResult, BuildResult& result, String[] commandLine)
     at Microsoft.Build.CommandLine.MSBuildApp.Execute(String[] commandLine)
  Build failed with exit code 82. Check errors above.
```