### PR TITLE
Disable workload resolver for net472 boostrap too

### DIFF
--- a/eng/BootStrapMsBuild.targets
+++ b/eng/BootStrapMsBuild.targets
@@ -193,6 +193,7 @@
 
     <!-- Disable workload resolver until we can figure out whether it can work in the bootstrap
          https://github.com/dotnet/msbuild/issues/6566 -->
+    <MakeDir Directories="$(BootstrapDestination)$(TargetMSBuildToolsVersion)\Bin\SdkResolvers\Microsoft.DotNet.MSBuildSdkResolver" />
     <Touch Files="$(BootstrapDestination)$(TargetMSBuildToolsVersion)\Bin\SdkResolvers\Microsoft.DotNet.MSBuildSdkResolver\DisableWorkloadResolver.sentinel"
            AlwaysCreate="true" />
   </Target>

--- a/eng/BootStrapMsBuild.targets
+++ b/eng/BootStrapMsBuild.targets
@@ -191,6 +191,10 @@
           DestinationFiles="@(FreshlyBuiltProjects -> '$(BootstrapDestination)$(TargetMSBuildToolsVersion)\Bin\arm64\%(RecursiveDir)%(Filename)%(Extension)')"
           SkipUnchangedFiles="true" />
 
+    <!-- Disable workload resolver until we can figure out whether it can work in the bootstrap
+         https://github.com/dotnet/msbuild/issues/6566 -->
+    <Touch Files="$(BootstrapDestination)$(TargetMSBuildToolsVersion)\Bin\SdkResolvers\Microsoft.DotNet.MSBuildSdkResolver\DisableWorkloadResolver.sentinel"
+           AlwaysCreate="true" />
   </Target>
 
   <Target Name="BootstrapNetCore" DependsOnTargets="CleanBootstrapFolder">


### PR DESCRIPTION
This has been long done for .NET (core); extend it to the location that the .NET Framework copy of the SDK resolver looks for it too.

Closes #7988.
