### PR TITLE
Handle the case for unsuccessful custom analyzer registration + change e2e tests

### DIFF
--- a/src/Build/BuildCheck/Acquisition/BuildCheckAcquisitionModule.cs
+++ b/src/Build/BuildCheck/Acquisition/BuildCheckAcquisitionModule.cs
@@ -32,7 +32,7 @@ internal class BuildCheckAcquisitionModule : IBuildCheckAcquisitionModule
     /// </summary>
     public List<BuildAnalyzerFactory> CreateBuildAnalyzerFactories(AnalyzerAcquisitionData analyzerAcquisitionData, BuildEventContext buildEventContext)
     {
-        var analyzersFactories = new List<BuildAnalyzerFactory?>();
+        var analyzersFactories = new List<BuildAnalyzerFactory>();
 
         try
         {

--- a/src/Build/BuildCheck/Acquisition/BuildCheckAcquisitionModule.cs
+++ b/src/Build/BuildCheck/Acquisition/BuildCheckAcquisitionModule.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using Microsoft.Build.BackEnd.Logging;
@@ -31,7 +32,7 @@ internal class BuildCheckAcquisitionModule : IBuildCheckAcquisitionModule
     /// </summary>
     public List<BuildAnalyzerFactory> CreateBuildAnalyzerFactories(AnalyzerAcquisitionData analyzerAcquisitionData, BuildEventContext buildEventContext)
     {
-        var analyzersFactories = new List<BuildAnalyzerFactory>();
+        var analyzersFactories = new List<BuildAnalyzerFactory?>();
 
         try
         {
@@ -42,12 +43,13 @@ internal class BuildCheckAcquisitionModule : IBuildCheckAcquisitionModule
             assembly = Assembly.LoadFrom(analyzerAcquisitionData.AssemblyPath);
 #endif
 
+            Debugger.Launch();
             IList<Type> availableTypes = assembly.GetExportedTypes();
             IList<Type> analyzerTypes = availableTypes.Where(t => typeof(BuildAnalyzer).IsAssignableFrom(t)).ToArray();
 
             foreach (Type analyzerCandidate in analyzerTypes)
             {
-                analyzersFactories.Add(() => (BuildAnalyzer)Activator.CreateInstance(analyzerCandidate));
+                analyzersFactories.Add(() => (BuildAnalyzer)Activator.CreateInstance(analyzerCandidate)!);
             }
 
             if (availableTypes.Count != analyzerTypes.Count)

--- a/src/Build/BuildCheck/Acquisition/BuildCheckAcquisitionModule.cs
+++ b/src/Build/BuildCheck/Acquisition/BuildCheckAcquisitionModule.cs
@@ -42,18 +42,17 @@ internal class BuildCheckAcquisitionModule : IBuildCheckAcquisitionModule
             assembly = Assembly.LoadFrom(analyzerAcquisitionData.AssemblyPath);
 #endif
 
-            IEnumerable<Type> analyzerCandidates = assembly.GetExportedTypes();
+            IList<Type> availableTypes = assembly.GetExportedTypes();
+            IList<Type> analyzerTypes = availableTypes.Where(t => typeof(BuildAnalyzer).IsAssignableFrom(t)).ToArray();
 
-            foreach (Type analyzerCandidate in analyzerCandidates)
+            foreach (Type analyzerCandidate in analyzerTypes)
             {
-                if (Activator.CreateInstance(analyzerCandidate) is BuildAnalyzer instance)
-                {
-                    analyzersFactories.Add(() => instance);
-                }
-                else
-                {
-                    _loggingService.LogComment(buildEventContext, MessageImportance.Normal, "CustomAnalyzerBaseTypeNotAssignable", analyzerCandidate.FullName);
-                }
+                analyzersFactories.Add(() => (BuildAnalyzer)Activator.CreateInstance(analyzerCandidate));
+            }
+
+            if (availableTypes.Count != analyzerTypes.Count)
+            {
+                availableTypes.Except(analyzerTypes).ToList().ForEach(t => _loggingService.LogComment(buildEventContext, MessageImportance.Normal, "CustomAnalyzerBaseTypeNotAssignable", t.Name, t.Assembly));
             }
         }
         catch (ReflectionTypeLoadException ex)

--- a/src/Build/BuildCheck/Acquisition/BuildCheckAcquisitionModule.cs
+++ b/src/Build/BuildCheck/Acquisition/BuildCheckAcquisitionModule.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using Microsoft.Build.BackEnd.Logging;
@@ -43,7 +42,6 @@ internal class BuildCheckAcquisitionModule : IBuildCheckAcquisitionModule
             assembly = Assembly.LoadFrom(analyzerAcquisitionData.AssemblyPath);
 #endif
 
-            Debugger.Launch();
             IList<Type> availableTypes = assembly.GetExportedTypes();
             IList<Type> analyzerTypes = availableTypes.Where(t => typeof(BuildAnalyzer).IsAssignableFrom(t)).ToArray();
 

--- a/src/Build/BuildCheck/Acquisition/BuildCheckAcquisitionModule.cs
+++ b/src/Build/BuildCheck/Acquisition/BuildCheckAcquisitionModule.cs
@@ -43,7 +43,7 @@ internal class BuildCheckAcquisitionModule : IBuildCheckAcquisitionModule
 #endif
 
             IList<Type> availableTypes = assembly.GetExportedTypes();
-            IList<Type> analyzerTypes = availableTypes.Where(t => typeof(BuildAnalyzer).IsAssignableFrom(t)).ToArray();
+            IList<Type> analyzerTypes = availableTypes.Where(t => t.IsInstanceOfType(typeof(BuildAnalyzer))).ToList();
 
             foreach (Type analyzerCandidate in analyzerTypes)
             {

--- a/src/Build/BuildCheck/Acquisition/BuildCheckAcquisitionModule.cs
+++ b/src/Build/BuildCheck/Acquisition/BuildCheckAcquisitionModule.cs
@@ -43,7 +43,7 @@ internal class BuildCheckAcquisitionModule : IBuildCheckAcquisitionModule
 #endif
 
             IList<Type> availableTypes = assembly.GetExportedTypes();
-            IList<Type> analyzerTypes = availableTypes.Where(t => t.IsInstanceOfType(typeof(BuildAnalyzer))).ToList();
+            IList<Type> analyzerTypes = availableTypes.Where(t => typeof(BuildAnalyzer).IsAssignableFrom(t)).ToArray();
 
             foreach (Type analyzerCandidate in analyzerTypes)
             {

--- a/src/Build/BuildCheck/Acquisition/BuildCheckAcquisitionModule.cs
+++ b/src/Build/BuildCheck/Acquisition/BuildCheckAcquisitionModule.cs
@@ -42,17 +42,17 @@ internal class BuildCheckAcquisitionModule : IBuildCheckAcquisitionModule
             assembly = Assembly.LoadFrom(analyzerAcquisitionData.AssemblyPath);
 #endif
 
-            IEnumerable<Type> analyzerTypes = assembly.GetExportedTypes().Where(t => typeof(BuildAnalyzer).IsAssignableFrom(t));
+            IEnumerable<Type> analyzerCandidates = assembly.GetExportedTypes();
 
-            foreach (Type analyzerType in analyzerTypes)
+            foreach (Type analyzerCandidate in analyzerCandidates)
             {
-                if (Activator.CreateInstance(analyzerType) is BuildAnalyzer instance)
+                if (Activator.CreateInstance(analyzerCandidate) is BuildAnalyzer instance)
                 {
                     analyzersFactories.Add(() => instance);
                 }
                 else
                 {
-                    throw new InvalidOperationException($"Failed to create an instance of type {analyzerType.FullName} as BuildAnalyzer.");
+                    _loggingService.LogComment(buildEventContext, MessageImportance.Normal, "CustomAnalyzerBaseTypeNotAssignable", analyzerCandidate.FullName);
                 }
             }
         }

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -2112,7 +2112,7 @@ Utilization:          {0} Average Utilization: {1:###.0}</value>
     <comment>The message is emitted when the custom analyzer assembly can not be found.</comment>
   </data>
   <data name="CustomAnalyzerBaseTypeNotAssignable" xml:space="preserve">
-    <value>Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</value>
+    <value>Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. If it is not intended to be a custom analyzer, than it should not be exposed. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</value>
     <comment>The message is emitted when the custom analyzer assembly can not be successfully registered.</comment>
   </data>
   <data name="TaskAssemblyLocationMismatch" xml:space="preserve">

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -2111,6 +2111,10 @@ Utilization:          {0} Average Utilization: {1:###.0}</value>
     <value>Failed to find the specified custom analyzer assembly: {0}. Please check if it exists.</value>
     <comment>The message is emitted when the custom analyzer assembly can not be found.</comment>
   </data>
+  <data name="CustomAnalyzerBaseTypeNotAssignable" xml:space="preserve">
+    <value>Failed to load the specified custom analyzer assembly: {0}. Make sure it inherits BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</value>
+    <comment>The message is emitted when the custom analyzer assembly can not be found.</comment>
+  </data>
   <data name="TaskAssemblyLocationMismatch" xml:space="preserve">
     <value>Task assembly was loaded from '{0}' while the desired location was '{1}'.</value>
   </data>

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -2113,7 +2113,7 @@ Utilization:          {0} Average Utilization: {1:###.0}</value>
   </data>
   <data name="CustomAnalyzerBaseTypeNotAssignable" xml:space="preserve">
     <value>Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</value>
-    <comment>The message is emitted when the custom analyzer assembly can not be found.</comment>
+    <comment>The message is emitted when the custom analyzer assembly can not be successfully registered.</comment>
   </data>
   <data name="TaskAssemblyLocationMismatch" xml:space="preserve">
     <value>Task assembly was loaded from '{0}' while the desired location was '{1}'.</value>

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -2112,7 +2112,7 @@ Utilization:          {0} Average Utilization: {1:###.0}</value>
     <comment>The message is emitted when the custom analyzer assembly can not be found.</comment>
   </data>
   <data name="CustomAnalyzerBaseTypeNotAssignable" xml:space="preserve">
-    <value>Failed to load the specified custom analyzer assembly: {0}. Make sure it inherits BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</value>
+    <value>Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</value>
     <comment>The message is emitted when the custom analyzer assembly can not be found.</comment>
   </data>
   <data name="TaskAssemblyLocationMismatch" xml:space="preserve">

--- a/src/Build/Resources/xlf/Strings.cs.xlf
+++ b/src/Build/Resources/xlf/Strings.cs.xlf
@@ -215,7 +215,7 @@
       <trans-unit id="CustomAnalyzerBaseTypeNotAssignable">
         <source>Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</source>
         <target state="new">Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</target>
-        <note>The message is emitted when the custom analyzer assembly can not be found.</note>
+        <note>The message is emitted when the custom analyzer assembly can not be successfully registered.</note>
       </trans-unit>
       <trans-unit id="CustomAnalyzerFailedAcquisition">
         <source>Failed to register the custom analyzer: {0}.</source>

--- a/src/Build/Resources/xlf/Strings.cs.xlf
+++ b/src/Build/Resources/xlf/Strings.cs.xlf
@@ -212,6 +212,11 @@
         <target state="translated">Nepodařilo se najít zadané sestavení vlastního analyzátoru: {0}. Zkontrolujte prosím, jestli existuje.</target>
         <note>The message is emitted when the custom analyzer assembly can not be found.</note>
       </trans-unit>
+      <trans-unit id="CustomAnalyzerBaseTypeNotAssignable">
+        <source>Failed to load the specified custom analyzer assembly: {0}. Make sure it inherits BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</source>
+        <target state="new">Failed to load the specified custom analyzer assembly: {0}. Make sure it inherits BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</target>
+        <note>The message is emitted when the custom analyzer assembly can not be found.</note>
+      </trans-unit>
       <trans-unit id="CustomAnalyzerFailedAcquisition">
         <source>Failed to register the custom analyzer: {0}.</source>
         <target state="translated">Nepodařilo se zaregistrovat vlastní analyzátor: {0}.</target>

--- a/src/Build/Resources/xlf/Strings.cs.xlf
+++ b/src/Build/Resources/xlf/Strings.cs.xlf
@@ -213,8 +213,8 @@
         <note>The message is emitted when the custom analyzer assembly can not be found.</note>
       </trans-unit>
       <trans-unit id="CustomAnalyzerBaseTypeNotAssignable">
-        <source>Failed to load the specified custom analyzer assembly: {0}. Make sure it inherits BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</source>
-        <target state="new">Failed to load the specified custom analyzer assembly: {0}. Make sure it inherits BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</target>
+        <source>Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</source>
+        <target state="new">Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</target>
         <note>The message is emitted when the custom analyzer assembly can not be found.</note>
       </trans-unit>
       <trans-unit id="CustomAnalyzerFailedAcquisition">

--- a/src/Build/Resources/xlf/Strings.cs.xlf
+++ b/src/Build/Resources/xlf/Strings.cs.xlf
@@ -213,8 +213,8 @@
         <note>The message is emitted when the custom analyzer assembly can not be found.</note>
       </trans-unit>
       <trans-unit id="CustomAnalyzerBaseTypeNotAssignable">
-        <source>Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</source>
-        <target state="new">Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</target>
+        <source>Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. If it is not intended to be a custom analyzer, than it should not be exposed. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</source>
+        <target state="new">Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. If it is not intended to be a custom analyzer, than it should not be exposed. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</target>
         <note>The message is emitted when the custom analyzer assembly can not be successfully registered.</note>
       </trans-unit>
       <trans-unit id="CustomAnalyzerFailedAcquisition">

--- a/src/Build/Resources/xlf/Strings.de.xlf
+++ b/src/Build/Resources/xlf/Strings.de.xlf
@@ -212,6 +212,11 @@
         <target state="translated">Fehler beim Suchen der angegebenen benutzerdefinierten Analysetoolassembly: {0}. Überprüfen Sie, ob sie vorhanden ist.</target>
         <note>The message is emitted when the custom analyzer assembly can not be found.</note>
       </trans-unit>
+      <trans-unit id="CustomAnalyzerBaseTypeNotAssignable">
+        <source>Failed to load the specified custom analyzer assembly: {0}. Make sure it inherits BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</source>
+        <target state="new">Failed to load the specified custom analyzer assembly: {0}. Make sure it inherits BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</target>
+        <note>The message is emitted when the custom analyzer assembly can not be found.</note>
+      </trans-unit>
       <trans-unit id="CustomAnalyzerFailedAcquisition">
         <source>Failed to register the custom analyzer: {0}.</source>
         <target state="translated">Fehler beim Registrieren des benutzerdefinierten Analysetools: {0}.</target>

--- a/src/Build/Resources/xlf/Strings.de.xlf
+++ b/src/Build/Resources/xlf/Strings.de.xlf
@@ -215,7 +215,7 @@
       <trans-unit id="CustomAnalyzerBaseTypeNotAssignable">
         <source>Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</source>
         <target state="new">Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</target>
-        <note>The message is emitted when the custom analyzer assembly can not be found.</note>
+        <note>The message is emitted when the custom analyzer assembly can not be successfully registered.</note>
       </trans-unit>
       <trans-unit id="CustomAnalyzerFailedAcquisition">
         <source>Failed to register the custom analyzer: {0}.</source>

--- a/src/Build/Resources/xlf/Strings.de.xlf
+++ b/src/Build/Resources/xlf/Strings.de.xlf
@@ -213,8 +213,8 @@
         <note>The message is emitted when the custom analyzer assembly can not be found.</note>
       </trans-unit>
       <trans-unit id="CustomAnalyzerBaseTypeNotAssignable">
-        <source>Failed to load the specified custom analyzer assembly: {0}. Make sure it inherits BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</source>
-        <target state="new">Failed to load the specified custom analyzer assembly: {0}. Make sure it inherits BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</target>
+        <source>Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</source>
+        <target state="new">Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</target>
         <note>The message is emitted when the custom analyzer assembly can not be found.</note>
       </trans-unit>
       <trans-unit id="CustomAnalyzerFailedAcquisition">

--- a/src/Build/Resources/xlf/Strings.de.xlf
+++ b/src/Build/Resources/xlf/Strings.de.xlf
@@ -213,8 +213,8 @@
         <note>The message is emitted when the custom analyzer assembly can not be found.</note>
       </trans-unit>
       <trans-unit id="CustomAnalyzerBaseTypeNotAssignable">
-        <source>Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</source>
-        <target state="new">Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</target>
+        <source>Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. If it is not intended to be a custom analyzer, than it should not be exposed. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</source>
+        <target state="new">Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. If it is not intended to be a custom analyzer, than it should not be exposed. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</target>
         <note>The message is emitted when the custom analyzer assembly can not be successfully registered.</note>
       </trans-unit>
       <trans-unit id="CustomAnalyzerFailedAcquisition">

--- a/src/Build/Resources/xlf/Strings.es.xlf
+++ b/src/Build/Resources/xlf/Strings.es.xlf
@@ -215,7 +215,7 @@
       <trans-unit id="CustomAnalyzerBaseTypeNotAssignable">
         <source>Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</source>
         <target state="new">Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</target>
-        <note>The message is emitted when the custom analyzer assembly can not be found.</note>
+        <note>The message is emitted when the custom analyzer assembly can not be successfully registered.</note>
       </trans-unit>
       <trans-unit id="CustomAnalyzerFailedAcquisition">
         <source>Failed to register the custom analyzer: {0}.</source>

--- a/src/Build/Resources/xlf/Strings.es.xlf
+++ b/src/Build/Resources/xlf/Strings.es.xlf
@@ -212,6 +212,11 @@
         <target state="translated">No se ha podido encontrar el ensamblado del analizador personalizado especificado: {0}. Compruebe si existe.</target>
         <note>The message is emitted when the custom analyzer assembly can not be found.</note>
       </trans-unit>
+      <trans-unit id="CustomAnalyzerBaseTypeNotAssignable">
+        <source>Failed to load the specified custom analyzer assembly: {0}. Make sure it inherits BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</source>
+        <target state="new">Failed to load the specified custom analyzer assembly: {0}. Make sure it inherits BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</target>
+        <note>The message is emitted when the custom analyzer assembly can not be found.</note>
+      </trans-unit>
       <trans-unit id="CustomAnalyzerFailedAcquisition">
         <source>Failed to register the custom analyzer: {0}.</source>
         <target state="translated">No se ha podido registrar el analizador personalizado: {0}.</target>

--- a/src/Build/Resources/xlf/Strings.es.xlf
+++ b/src/Build/Resources/xlf/Strings.es.xlf
@@ -213,8 +213,8 @@
         <note>The message is emitted when the custom analyzer assembly can not be found.</note>
       </trans-unit>
       <trans-unit id="CustomAnalyzerBaseTypeNotAssignable">
-        <source>Failed to load the specified custom analyzer assembly: {0}. Make sure it inherits BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</source>
-        <target state="new">Failed to load the specified custom analyzer assembly: {0}. Make sure it inherits BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</target>
+        <source>Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</source>
+        <target state="new">Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</target>
         <note>The message is emitted when the custom analyzer assembly can not be found.</note>
       </trans-unit>
       <trans-unit id="CustomAnalyzerFailedAcquisition">

--- a/src/Build/Resources/xlf/Strings.es.xlf
+++ b/src/Build/Resources/xlf/Strings.es.xlf
@@ -213,8 +213,8 @@
         <note>The message is emitted when the custom analyzer assembly can not be found.</note>
       </trans-unit>
       <trans-unit id="CustomAnalyzerBaseTypeNotAssignable">
-        <source>Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</source>
-        <target state="new">Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</target>
+        <source>Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. If it is not intended to be a custom analyzer, than it should not be exposed. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</source>
+        <target state="new">Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. If it is not intended to be a custom analyzer, than it should not be exposed. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</target>
         <note>The message is emitted when the custom analyzer assembly can not be successfully registered.</note>
       </trans-unit>
       <trans-unit id="CustomAnalyzerFailedAcquisition">

--- a/src/Build/Resources/xlf/Strings.fr.xlf
+++ b/src/Build/Resources/xlf/Strings.fr.xlf
@@ -215,7 +215,7 @@
       <trans-unit id="CustomAnalyzerBaseTypeNotAssignable">
         <source>Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</source>
         <target state="new">Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</target>
-        <note>The message is emitted when the custom analyzer assembly can not be found.</note>
+        <note>The message is emitted when the custom analyzer assembly can not be successfully registered.</note>
       </trans-unit>
       <trans-unit id="CustomAnalyzerFailedAcquisition">
         <source>Failed to register the custom analyzer: {0}.</source>

--- a/src/Build/Resources/xlf/Strings.fr.xlf
+++ b/src/Build/Resources/xlf/Strings.fr.xlf
@@ -213,8 +213,8 @@
         <note>The message is emitted when the custom analyzer assembly can not be found.</note>
       </trans-unit>
       <trans-unit id="CustomAnalyzerBaseTypeNotAssignable">
-        <source>Failed to load the specified custom analyzer assembly: {0}. Make sure it inherits BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</source>
-        <target state="new">Failed to load the specified custom analyzer assembly: {0}. Make sure it inherits BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</target>
+        <source>Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</source>
+        <target state="new">Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</target>
         <note>The message is emitted when the custom analyzer assembly can not be found.</note>
       </trans-unit>
       <trans-unit id="CustomAnalyzerFailedAcquisition">

--- a/src/Build/Resources/xlf/Strings.fr.xlf
+++ b/src/Build/Resources/xlf/Strings.fr.xlf
@@ -212,6 +212,11 @@
         <target state="translated">Impossible de trouver l’assemblée d'analyseur personnalisé spécifié : {0}. Vérifiez s’il existe.</target>
         <note>The message is emitted when the custom analyzer assembly can not be found.</note>
       </trans-unit>
+      <trans-unit id="CustomAnalyzerBaseTypeNotAssignable">
+        <source>Failed to load the specified custom analyzer assembly: {0}. Make sure it inherits BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</source>
+        <target state="new">Failed to load the specified custom analyzer assembly: {0}. Make sure it inherits BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</target>
+        <note>The message is emitted when the custom analyzer assembly can not be found.</note>
+      </trans-unit>
       <trans-unit id="CustomAnalyzerFailedAcquisition">
         <source>Failed to register the custom analyzer: {0}.</source>
         <target state="translated">Échec de l’inscription de l’analyseur personnalisé : {0}.</target>

--- a/src/Build/Resources/xlf/Strings.fr.xlf
+++ b/src/Build/Resources/xlf/Strings.fr.xlf
@@ -213,8 +213,8 @@
         <note>The message is emitted when the custom analyzer assembly can not be found.</note>
       </trans-unit>
       <trans-unit id="CustomAnalyzerBaseTypeNotAssignable">
-        <source>Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</source>
-        <target state="new">Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</target>
+        <source>Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. If it is not intended to be a custom analyzer, than it should not be exposed. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</source>
+        <target state="new">Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. If it is not intended to be a custom analyzer, than it should not be exposed. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</target>
         <note>The message is emitted when the custom analyzer assembly can not be successfully registered.</note>
       </trans-unit>
       <trans-unit id="CustomAnalyzerFailedAcquisition">

--- a/src/Build/Resources/xlf/Strings.it.xlf
+++ b/src/Build/Resources/xlf/Strings.it.xlf
@@ -212,6 +212,11 @@
         <target state="translated">Impossibile trovare l'assembly dell'analizzatore personalizzato specificato: {0}. Verificare se esiste.</target>
         <note>The message is emitted when the custom analyzer assembly can not be found.</note>
       </trans-unit>
+      <trans-unit id="CustomAnalyzerBaseTypeNotAssignable">
+        <source>Failed to load the specified custom analyzer assembly: {0}. Make sure it inherits BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</source>
+        <target state="new">Failed to load the specified custom analyzer assembly: {0}. Make sure it inherits BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</target>
+        <note>The message is emitted when the custom analyzer assembly can not be found.</note>
+      </trans-unit>
       <trans-unit id="CustomAnalyzerFailedAcquisition">
         <source>Failed to register the custom analyzer: {0}.</source>
         <target state="translated">Impossibile registrare l'analizzatore personalizzato: {0}.</target>

--- a/src/Build/Resources/xlf/Strings.it.xlf
+++ b/src/Build/Resources/xlf/Strings.it.xlf
@@ -215,7 +215,7 @@
       <trans-unit id="CustomAnalyzerBaseTypeNotAssignable">
         <source>Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</source>
         <target state="new">Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</target>
-        <note>The message is emitted when the custom analyzer assembly can not be found.</note>
+        <note>The message is emitted when the custom analyzer assembly can not be successfully registered.</note>
       </trans-unit>
       <trans-unit id="CustomAnalyzerFailedAcquisition">
         <source>Failed to register the custom analyzer: {0}.</source>

--- a/src/Build/Resources/xlf/Strings.it.xlf
+++ b/src/Build/Resources/xlf/Strings.it.xlf
@@ -213,8 +213,8 @@
         <note>The message is emitted when the custom analyzer assembly can not be found.</note>
       </trans-unit>
       <trans-unit id="CustomAnalyzerBaseTypeNotAssignable">
-        <source>Failed to load the specified custom analyzer assembly: {0}. Make sure it inherits BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</source>
-        <target state="new">Failed to load the specified custom analyzer assembly: {0}. Make sure it inherits BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</target>
+        <source>Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</source>
+        <target state="new">Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</target>
         <note>The message is emitted when the custom analyzer assembly can not be found.</note>
       </trans-unit>
       <trans-unit id="CustomAnalyzerFailedAcquisition">

--- a/src/Build/Resources/xlf/Strings.it.xlf
+++ b/src/Build/Resources/xlf/Strings.it.xlf
@@ -213,8 +213,8 @@
         <note>The message is emitted when the custom analyzer assembly can not be found.</note>
       </trans-unit>
       <trans-unit id="CustomAnalyzerBaseTypeNotAssignable">
-        <source>Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</source>
-        <target state="new">Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</target>
+        <source>Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. If it is not intended to be a custom analyzer, than it should not be exposed. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</source>
+        <target state="new">Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. If it is not intended to be a custom analyzer, than it should not be exposed. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</target>
         <note>The message is emitted when the custom analyzer assembly can not be successfully registered.</note>
       </trans-unit>
       <trans-unit id="CustomAnalyzerFailedAcquisition">

--- a/src/Build/Resources/xlf/Strings.ja.xlf
+++ b/src/Build/Resources/xlf/Strings.ja.xlf
@@ -215,7 +215,7 @@
       <trans-unit id="CustomAnalyzerBaseTypeNotAssignable">
         <source>Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</source>
         <target state="new">Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</target>
-        <note>The message is emitted when the custom analyzer assembly can not be found.</note>
+        <note>The message is emitted when the custom analyzer assembly can not be successfully registered.</note>
       </trans-unit>
       <trans-unit id="CustomAnalyzerFailedAcquisition">
         <source>Failed to register the custom analyzer: {0}.</source>

--- a/src/Build/Resources/xlf/Strings.ja.xlf
+++ b/src/Build/Resources/xlf/Strings.ja.xlf
@@ -213,8 +213,8 @@
         <note>The message is emitted when the custom analyzer assembly can not be found.</note>
       </trans-unit>
       <trans-unit id="CustomAnalyzerBaseTypeNotAssignable">
-        <source>Failed to load the specified custom analyzer assembly: {0}. Make sure it inherits BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</source>
-        <target state="new">Failed to load the specified custom analyzer assembly: {0}. Make sure it inherits BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</target>
+        <source>Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</source>
+        <target state="new">Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</target>
         <note>The message is emitted when the custom analyzer assembly can not be found.</note>
       </trans-unit>
       <trans-unit id="CustomAnalyzerFailedAcquisition">

--- a/src/Build/Resources/xlf/Strings.ja.xlf
+++ b/src/Build/Resources/xlf/Strings.ja.xlf
@@ -212,6 +212,11 @@
         <target state="translated">指定されたカスタム アナライザー アセンブリが見つかりませんでした: {0}。存在するかどうか確認してください。</target>
         <note>The message is emitted when the custom analyzer assembly can not be found.</note>
       </trans-unit>
+      <trans-unit id="CustomAnalyzerBaseTypeNotAssignable">
+        <source>Failed to load the specified custom analyzer assembly: {0}. Make sure it inherits BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</source>
+        <target state="new">Failed to load the specified custom analyzer assembly: {0}. Make sure it inherits BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</target>
+        <note>The message is emitted when the custom analyzer assembly can not be found.</note>
+      </trans-unit>
       <trans-unit id="CustomAnalyzerFailedAcquisition">
         <source>Failed to register the custom analyzer: {0}.</source>
         <target state="translated">カスタム アナライザーを登録できませんでした: {0}</target>

--- a/src/Build/Resources/xlf/Strings.ja.xlf
+++ b/src/Build/Resources/xlf/Strings.ja.xlf
@@ -213,8 +213,8 @@
         <note>The message is emitted when the custom analyzer assembly can not be found.</note>
       </trans-unit>
       <trans-unit id="CustomAnalyzerBaseTypeNotAssignable">
-        <source>Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</source>
-        <target state="new">Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</target>
+        <source>Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. If it is not intended to be a custom analyzer, than it should not be exposed. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</source>
+        <target state="new">Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. If it is not intended to be a custom analyzer, than it should not be exposed. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</target>
         <note>The message is emitted when the custom analyzer assembly can not be successfully registered.</note>
       </trans-unit>
       <trans-unit id="CustomAnalyzerFailedAcquisition">

--- a/src/Build/Resources/xlf/Strings.ko.xlf
+++ b/src/Build/Resources/xlf/Strings.ko.xlf
@@ -215,7 +215,7 @@
       <trans-unit id="CustomAnalyzerBaseTypeNotAssignable">
         <source>Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</source>
         <target state="new">Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</target>
-        <note>The message is emitted when the custom analyzer assembly can not be found.</note>
+        <note>The message is emitted when the custom analyzer assembly can not be successfully registered.</note>
       </trans-unit>
       <trans-unit id="CustomAnalyzerFailedAcquisition">
         <source>Failed to register the custom analyzer: {0}.</source>

--- a/src/Build/Resources/xlf/Strings.ko.xlf
+++ b/src/Build/Resources/xlf/Strings.ko.xlf
@@ -212,6 +212,11 @@
         <target state="translated">지정한 사용자 지정 분석기 어셈블리를 찾지 못했습니다. {0}. 존재하는지 확인하세요.</target>
         <note>The message is emitted when the custom analyzer assembly can not be found.</note>
       </trans-unit>
+      <trans-unit id="CustomAnalyzerBaseTypeNotAssignable">
+        <source>Failed to load the specified custom analyzer assembly: {0}. Make sure it inherits BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</source>
+        <target state="new">Failed to load the specified custom analyzer assembly: {0}. Make sure it inherits BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</target>
+        <note>The message is emitted when the custom analyzer assembly can not be found.</note>
+      </trans-unit>
       <trans-unit id="CustomAnalyzerFailedAcquisition">
         <source>Failed to register the custom analyzer: {0}.</source>
         <target state="translated">사용자 지정 분석기를 등록하지 못했습니다. {0}.</target>

--- a/src/Build/Resources/xlf/Strings.ko.xlf
+++ b/src/Build/Resources/xlf/Strings.ko.xlf
@@ -213,8 +213,8 @@
         <note>The message is emitted when the custom analyzer assembly can not be found.</note>
       </trans-unit>
       <trans-unit id="CustomAnalyzerBaseTypeNotAssignable">
-        <source>Failed to load the specified custom analyzer assembly: {0}. Make sure it inherits BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</source>
-        <target state="new">Failed to load the specified custom analyzer assembly: {0}. Make sure it inherits BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</target>
+        <source>Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</source>
+        <target state="new">Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</target>
         <note>The message is emitted when the custom analyzer assembly can not be found.</note>
       </trans-unit>
       <trans-unit id="CustomAnalyzerFailedAcquisition">

--- a/src/Build/Resources/xlf/Strings.ko.xlf
+++ b/src/Build/Resources/xlf/Strings.ko.xlf
@@ -213,8 +213,8 @@
         <note>The message is emitted when the custom analyzer assembly can not be found.</note>
       </trans-unit>
       <trans-unit id="CustomAnalyzerBaseTypeNotAssignable">
-        <source>Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</source>
-        <target state="new">Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</target>
+        <source>Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. If it is not intended to be a custom analyzer, than it should not be exposed. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</source>
+        <target state="new">Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. If it is not intended to be a custom analyzer, than it should not be exposed. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</target>
         <note>The message is emitted when the custom analyzer assembly can not be successfully registered.</note>
       </trans-unit>
       <trans-unit id="CustomAnalyzerFailedAcquisition">

--- a/src/Build/Resources/xlf/Strings.pl.xlf
+++ b/src/Build/Resources/xlf/Strings.pl.xlf
@@ -215,7 +215,7 @@
       <trans-unit id="CustomAnalyzerBaseTypeNotAssignable">
         <source>Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</source>
         <target state="new">Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</target>
-        <note>The message is emitted when the custom analyzer assembly can not be found.</note>
+        <note>The message is emitted when the custom analyzer assembly can not be successfully registered.</note>
       </trans-unit>
       <trans-unit id="CustomAnalyzerFailedAcquisition">
         <source>Failed to register the custom analyzer: {0}.</source>

--- a/src/Build/Resources/xlf/Strings.pl.xlf
+++ b/src/Build/Resources/xlf/Strings.pl.xlf
@@ -213,8 +213,8 @@
         <note>The message is emitted when the custom analyzer assembly can not be found.</note>
       </trans-unit>
       <trans-unit id="CustomAnalyzerBaseTypeNotAssignable">
-        <source>Failed to load the specified custom analyzer assembly: {0}. Make sure it inherits BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</source>
-        <target state="new">Failed to load the specified custom analyzer assembly: {0}. Make sure it inherits BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</target>
+        <source>Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</source>
+        <target state="new">Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</target>
         <note>The message is emitted when the custom analyzer assembly can not be found.</note>
       </trans-unit>
       <trans-unit id="CustomAnalyzerFailedAcquisition">

--- a/src/Build/Resources/xlf/Strings.pl.xlf
+++ b/src/Build/Resources/xlf/Strings.pl.xlf
@@ -212,6 +212,11 @@
         <target state="translated">Nie można odnaleźć określonego zestawu analizatora niestandardowego: {0}. Sprawdź, czy istnieje.</target>
         <note>The message is emitted when the custom analyzer assembly can not be found.</note>
       </trans-unit>
+      <trans-unit id="CustomAnalyzerBaseTypeNotAssignable">
+        <source>Failed to load the specified custom analyzer assembly: {0}. Make sure it inherits BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</source>
+        <target state="new">Failed to load the specified custom analyzer assembly: {0}. Make sure it inherits BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</target>
+        <note>The message is emitted when the custom analyzer assembly can not be found.</note>
+      </trans-unit>
       <trans-unit id="CustomAnalyzerFailedAcquisition">
         <source>Failed to register the custom analyzer: {0}.</source>
         <target state="translated">Nie można zarejestrować analizatora niestandardowego: {0}.</target>

--- a/src/Build/Resources/xlf/Strings.pl.xlf
+++ b/src/Build/Resources/xlf/Strings.pl.xlf
@@ -213,8 +213,8 @@
         <note>The message is emitted when the custom analyzer assembly can not be found.</note>
       </trans-unit>
       <trans-unit id="CustomAnalyzerBaseTypeNotAssignable">
-        <source>Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</source>
-        <target state="new">Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</target>
+        <source>Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. If it is not intended to be a custom analyzer, than it should not be exposed. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</source>
+        <target state="new">Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. If it is not intended to be a custom analyzer, than it should not be exposed. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</target>
         <note>The message is emitted when the custom analyzer assembly can not be successfully registered.</note>
       </trans-unit>
       <trans-unit id="CustomAnalyzerFailedAcquisition">

--- a/src/Build/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Build/Resources/xlf/Strings.pt-BR.xlf
@@ -212,6 +212,11 @@
         <target state="translated">Falha ao localizar o assembly do analisador personalizado especificado: {0}. Verifique se existe.</target>
         <note>The message is emitted when the custom analyzer assembly can not be found.</note>
       </trans-unit>
+      <trans-unit id="CustomAnalyzerBaseTypeNotAssignable">
+        <source>Failed to load the specified custom analyzer assembly: {0}. Make sure it inherits BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</source>
+        <target state="new">Failed to load the specified custom analyzer assembly: {0}. Make sure it inherits BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</target>
+        <note>The message is emitted when the custom analyzer assembly can not be found.</note>
+      </trans-unit>
       <trans-unit id="CustomAnalyzerFailedAcquisition">
         <source>Failed to register the custom analyzer: {0}.</source>
         <target state="translated">Falha ao registrar o analisador personalizado: {0}.</target>

--- a/src/Build/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Build/Resources/xlf/Strings.pt-BR.xlf
@@ -215,7 +215,7 @@
       <trans-unit id="CustomAnalyzerBaseTypeNotAssignable">
         <source>Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</source>
         <target state="new">Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</target>
-        <note>The message is emitted when the custom analyzer assembly can not be found.</note>
+        <note>The message is emitted when the custom analyzer assembly can not be successfully registered.</note>
       </trans-unit>
       <trans-unit id="CustomAnalyzerFailedAcquisition">
         <source>Failed to register the custom analyzer: {0}.</source>

--- a/src/Build/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Build/Resources/xlf/Strings.pt-BR.xlf
@@ -213,8 +213,8 @@
         <note>The message is emitted when the custom analyzer assembly can not be found.</note>
       </trans-unit>
       <trans-unit id="CustomAnalyzerBaseTypeNotAssignable">
-        <source>Failed to load the specified custom analyzer assembly: {0}. Make sure it inherits BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</source>
-        <target state="new">Failed to load the specified custom analyzer assembly: {0}. Make sure it inherits BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</target>
+        <source>Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</source>
+        <target state="new">Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</target>
         <note>The message is emitted when the custom analyzer assembly can not be found.</note>
       </trans-unit>
       <trans-unit id="CustomAnalyzerFailedAcquisition">

--- a/src/Build/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Build/Resources/xlf/Strings.pt-BR.xlf
@@ -213,8 +213,8 @@
         <note>The message is emitted when the custom analyzer assembly can not be found.</note>
       </trans-unit>
       <trans-unit id="CustomAnalyzerBaseTypeNotAssignable">
-        <source>Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</source>
-        <target state="new">Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</target>
+        <source>Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. If it is not intended to be a custom analyzer, than it should not be exposed. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</source>
+        <target state="new">Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. If it is not intended to be a custom analyzer, than it should not be exposed. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</target>
         <note>The message is emitted when the custom analyzer assembly can not be successfully registered.</note>
       </trans-unit>
       <trans-unit id="CustomAnalyzerFailedAcquisition">

--- a/src/Build/Resources/xlf/Strings.ru.xlf
+++ b/src/Build/Resources/xlf/Strings.ru.xlf
@@ -212,6 +212,11 @@
         <target state="translated">Не удалось найти указанную сборку настраиваемого анализатора: {0}. Убедитесь, что она существует.</target>
         <note>The message is emitted when the custom analyzer assembly can not be found.</note>
       </trans-unit>
+      <trans-unit id="CustomAnalyzerBaseTypeNotAssignable">
+        <source>Failed to load the specified custom analyzer assembly: {0}. Make sure it inherits BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</source>
+        <target state="new">Failed to load the specified custom analyzer assembly: {0}. Make sure it inherits BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</target>
+        <note>The message is emitted when the custom analyzer assembly can not be found.</note>
+      </trans-unit>
       <trans-unit id="CustomAnalyzerFailedAcquisition">
         <source>Failed to register the custom analyzer: {0}.</source>
         <target state="translated">Не удалось зарегистрировать настраиваемый анализатор: {0}.</target>

--- a/src/Build/Resources/xlf/Strings.ru.xlf
+++ b/src/Build/Resources/xlf/Strings.ru.xlf
@@ -215,7 +215,7 @@
       <trans-unit id="CustomAnalyzerBaseTypeNotAssignable">
         <source>Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</source>
         <target state="new">Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</target>
-        <note>The message is emitted when the custom analyzer assembly can not be found.</note>
+        <note>The message is emitted when the custom analyzer assembly can not be successfully registered.</note>
       </trans-unit>
       <trans-unit id="CustomAnalyzerFailedAcquisition">
         <source>Failed to register the custom analyzer: {0}.</source>

--- a/src/Build/Resources/xlf/Strings.ru.xlf
+++ b/src/Build/Resources/xlf/Strings.ru.xlf
@@ -213,8 +213,8 @@
         <note>The message is emitted when the custom analyzer assembly can not be found.</note>
       </trans-unit>
       <trans-unit id="CustomAnalyzerBaseTypeNotAssignable">
-        <source>Failed to load the specified custom analyzer assembly: {0}. Make sure it inherits BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</source>
-        <target state="new">Failed to load the specified custom analyzer assembly: {0}. Make sure it inherits BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</target>
+        <source>Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</source>
+        <target state="new">Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</target>
         <note>The message is emitted when the custom analyzer assembly can not be found.</note>
       </trans-unit>
       <trans-unit id="CustomAnalyzerFailedAcquisition">

--- a/src/Build/Resources/xlf/Strings.ru.xlf
+++ b/src/Build/Resources/xlf/Strings.ru.xlf
@@ -213,8 +213,8 @@
         <note>The message is emitted when the custom analyzer assembly can not be found.</note>
       </trans-unit>
       <trans-unit id="CustomAnalyzerBaseTypeNotAssignable">
-        <source>Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</source>
-        <target state="new">Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</target>
+        <source>Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. If it is not intended to be a custom analyzer, than it should not be exposed. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</source>
+        <target state="new">Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. If it is not intended to be a custom analyzer, than it should not be exposed. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</target>
         <note>The message is emitted when the custom analyzer assembly can not be successfully registered.</note>
       </trans-unit>
       <trans-unit id="CustomAnalyzerFailedAcquisition">

--- a/src/Build/Resources/xlf/Strings.tr.xlf
+++ b/src/Build/Resources/xlf/Strings.tr.xlf
@@ -215,7 +215,7 @@
       <trans-unit id="CustomAnalyzerBaseTypeNotAssignable">
         <source>Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</source>
         <target state="new">Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</target>
-        <note>The message is emitted when the custom analyzer assembly can not be found.</note>
+        <note>The message is emitted when the custom analyzer assembly can not be successfully registered.</note>
       </trans-unit>
       <trans-unit id="CustomAnalyzerFailedAcquisition">
         <source>Failed to register the custom analyzer: {0}.</source>

--- a/src/Build/Resources/xlf/Strings.tr.xlf
+++ b/src/Build/Resources/xlf/Strings.tr.xlf
@@ -213,8 +213,8 @@
         <note>The message is emitted when the custom analyzer assembly can not be found.</note>
       </trans-unit>
       <trans-unit id="CustomAnalyzerBaseTypeNotAssignable">
-        <source>Failed to load the specified custom analyzer assembly: {0}. Make sure it inherits BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</source>
-        <target state="new">Failed to load the specified custom analyzer assembly: {0}. Make sure it inherits BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</target>
+        <source>Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</source>
+        <target state="new">Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</target>
         <note>The message is emitted when the custom analyzer assembly can not be found.</note>
       </trans-unit>
       <trans-unit id="CustomAnalyzerFailedAcquisition">

--- a/src/Build/Resources/xlf/Strings.tr.xlf
+++ b/src/Build/Resources/xlf/Strings.tr.xlf
@@ -212,6 +212,11 @@
         <target state="translated">Belirtilen {0} özel çözümleyici derlemesi bulunamadı. Lütfen var olup olmadığını kontrol edin.</target>
         <note>The message is emitted when the custom analyzer assembly can not be found.</note>
       </trans-unit>
+      <trans-unit id="CustomAnalyzerBaseTypeNotAssignable">
+        <source>Failed to load the specified custom analyzer assembly: {0}. Make sure it inherits BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</source>
+        <target state="new">Failed to load the specified custom analyzer assembly: {0}. Make sure it inherits BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</target>
+        <note>The message is emitted when the custom analyzer assembly can not be found.</note>
+      </trans-unit>
       <trans-unit id="CustomAnalyzerFailedAcquisition">
         <source>Failed to register the custom analyzer: {0}.</source>
         <target state="translated">Özel çözümleyici kaydedilemedi: {0}.</target>

--- a/src/Build/Resources/xlf/Strings.tr.xlf
+++ b/src/Build/Resources/xlf/Strings.tr.xlf
@@ -213,8 +213,8 @@
         <note>The message is emitted when the custom analyzer assembly can not be found.</note>
       </trans-unit>
       <trans-unit id="CustomAnalyzerBaseTypeNotAssignable">
-        <source>Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</source>
-        <target state="new">Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</target>
+        <source>Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. If it is not intended to be a custom analyzer, than it should not be exposed. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</source>
+        <target state="new">Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. If it is not intended to be a custom analyzer, than it should not be exposed. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</target>
         <note>The message is emitted when the custom analyzer assembly can not be successfully registered.</note>
       </trans-unit>
       <trans-unit id="CustomAnalyzerFailedAcquisition">

--- a/src/Build/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hans.xlf
@@ -215,7 +215,7 @@
       <trans-unit id="CustomAnalyzerBaseTypeNotAssignable">
         <source>Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</source>
         <target state="new">Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</target>
-        <note>The message is emitted when the custom analyzer assembly can not be found.</note>
+        <note>The message is emitted when the custom analyzer assembly can not be successfully registered.</note>
       </trans-unit>
       <trans-unit id="CustomAnalyzerFailedAcquisition">
         <source>Failed to register the custom analyzer: {0}.</source>

--- a/src/Build/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hans.xlf
@@ -212,6 +212,11 @@
         <target state="translated">找不到指定的自定义分析器程序集: {0}。请检查它是否存在。</target>
         <note>The message is emitted when the custom analyzer assembly can not be found.</note>
       </trans-unit>
+      <trans-unit id="CustomAnalyzerBaseTypeNotAssignable">
+        <source>Failed to load the specified custom analyzer assembly: {0}. Make sure it inherits BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</source>
+        <target state="new">Failed to load the specified custom analyzer assembly: {0}. Make sure it inherits BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</target>
+        <note>The message is emitted when the custom analyzer assembly can not be found.</note>
+      </trans-unit>
       <trans-unit id="CustomAnalyzerFailedAcquisition">
         <source>Failed to register the custom analyzer: {0}.</source>
         <target state="translated">无法注册自定义分析器: {0}。</target>

--- a/src/Build/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hans.xlf
@@ -213,8 +213,8 @@
         <note>The message is emitted when the custom analyzer assembly can not be found.</note>
       </trans-unit>
       <trans-unit id="CustomAnalyzerBaseTypeNotAssignable">
-        <source>Failed to load the specified custom analyzer assembly: {0}. Make sure it inherits BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</source>
-        <target state="new">Failed to load the specified custom analyzer assembly: {0}. Make sure it inherits BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</target>
+        <source>Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</source>
+        <target state="new">Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</target>
         <note>The message is emitted when the custom analyzer assembly can not be found.</note>
       </trans-unit>
       <trans-unit id="CustomAnalyzerFailedAcquisition">

--- a/src/Build/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hans.xlf
@@ -213,8 +213,8 @@
         <note>The message is emitted when the custom analyzer assembly can not be found.</note>
       </trans-unit>
       <trans-unit id="CustomAnalyzerBaseTypeNotAssignable">
-        <source>Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</source>
-        <target state="new">Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</target>
+        <source>Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. If it is not intended to be a custom analyzer, than it should not be exposed. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</source>
+        <target state="new">Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. If it is not intended to be a custom analyzer, than it should not be exposed. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</target>
         <note>The message is emitted when the custom analyzer assembly can not be successfully registered.</note>
       </trans-unit>
       <trans-unit id="CustomAnalyzerFailedAcquisition">

--- a/src/Build/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hant.xlf
@@ -212,6 +212,11 @@
         <target state="translated">找不到指定的自訂分析器組件: {0}。請檢查它是否存在。</target>
         <note>The message is emitted when the custom analyzer assembly can not be found.</note>
       </trans-unit>
+      <trans-unit id="CustomAnalyzerBaseTypeNotAssignable">
+        <source>Failed to load the specified custom analyzer assembly: {0}. Make sure it inherits BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</source>
+        <target state="new">Failed to load the specified custom analyzer assembly: {0}. Make sure it inherits BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</target>
+        <note>The message is emitted when the custom analyzer assembly can not be found.</note>
+      </trans-unit>
       <trans-unit id="CustomAnalyzerFailedAcquisition">
         <source>Failed to register the custom analyzer: {0}.</source>
         <target state="translated">無法登錄自訂分析器: {0}。</target>

--- a/src/Build/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hant.xlf
@@ -215,7 +215,7 @@
       <trans-unit id="CustomAnalyzerBaseTypeNotAssignable">
         <source>Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</source>
         <target state="new">Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</target>
-        <note>The message is emitted when the custom analyzer assembly can not be found.</note>
+        <note>The message is emitted when the custom analyzer assembly can not be successfully registered.</note>
       </trans-unit>
       <trans-unit id="CustomAnalyzerFailedAcquisition">
         <source>Failed to register the custom analyzer: {0}.</source>

--- a/src/Build/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hant.xlf
@@ -213,8 +213,8 @@
         <note>The message is emitted when the custom analyzer assembly can not be found.</note>
       </trans-unit>
       <trans-unit id="CustomAnalyzerBaseTypeNotAssignable">
-        <source>Failed to load the specified custom analyzer assembly: {0}. Make sure it inherits BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</source>
-        <target state="new">Failed to load the specified custom analyzer assembly: {0}. Make sure it inherits BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</target>
+        <source>Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</source>
+        <target state="new">Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</target>
         <note>The message is emitted when the custom analyzer assembly can not be found.</note>
       </trans-unit>
       <trans-unit id="CustomAnalyzerFailedAcquisition">

--- a/src/Build/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hant.xlf
@@ -213,8 +213,8 @@
         <note>The message is emitted when the custom analyzer assembly can not be found.</note>
       </trans-unit>
       <trans-unit id="CustomAnalyzerBaseTypeNotAssignable">
-        <source>Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</source>
-        <target state="new">Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</target>
+        <source>Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. If it is not intended to be a custom analyzer, than it should not be exposed. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</source>
+        <target state="new">Failed to load the custom analyzer type: {0} from the assembly: {1}. Make sure it inherits the Microsoft.Build.Experimental.BuildCheck.BuildAnalyzer base class. If it is not intended to be a custom analyzer, than it should not be exposed. More info: https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck-Architecture.md#acquisition</target>
         <note>The message is emitted when the custom analyzer assembly can not be successfully registered.</note>
       </trans-unit>
       <trans-unit id="CustomAnalyzerFailedAcquisition">

--- a/src/BuildCheck.UnitTests/EndToEndTests.cs
+++ b/src/BuildCheck.UnitTests/EndToEndTests.cs
@@ -138,8 +138,8 @@ public class EndToEndTests : IDisposable
 
     [Theory]
     [InlineData(new[] { "CustomAnalyzer" }, "AnalysisCandidate", new[] { "CustomRule1", "CustomRule2" })]
-    [InlineData(new[] { "CustomAnalyzer", "CustomAnalyzer2", "InvalidCustomAnalyzer" }, "AnalysisCandidateWithMultipleAnalyzersInjected", new[] { "CustomRule1", "CustomRule2", "CustomRule3" }, new[] { "InvalidCustomAnalyzer.InvalidAnalyzer" })]
-    public void CustomAnalyzerTest(string[] customAnalyzerNames, string analysisCandidate, string[] expectedRegisteredRules, string[]? expectedRejectedRules = null)
+    [InlineData(new[] { "CustomAnalyzer", "CustomAnalyzer2", "InvalidCustomAnalyzer" }, "AnalysisCandidateWithMultipleAnalyzersInjected", new[] { "CustomRule1", "CustomRule2", "CustomRule3" }, true)]
+    public void CustomAnalyzerTest(string[] customAnalyzerNames, string analysisCandidate, string[] expectedRegisteredRules, bool expectedRejectedAnalyzers = false)
     {
         using (var env = TestEnvironment.Create())
         {
@@ -160,12 +160,9 @@ public class EndToEndTests : IDisposable
                 projectAnalysisBuildLog.ShouldContain(ResourceUtilities.FormatResourceStringStripCodeAndKeyword("CustomAnalyzerSuccessfulAcquisition", registeredRule));
             }
 
-            if (expectedRejectedRules != null)
+            if (expectedRejectedAnalyzers)
             {
-                foreach (string rejectedRule in expectedRejectedRules)
-                {
-                    projectAnalysisBuildLog.ShouldContain(ResourceUtilities.FormatResourceStringStripCodeAndKeyword("CustomAnalyzerBaseTypeNotAssignable", rejectedRule));
-                }
+                projectAnalysisBuildLog.ShouldContain(ResourceUtilities.FormatResourceStringStripCodeAndKeyword("CustomAnalyzerBaseTypeNotAssignable", "InvalidAnalyzer", "InvalidCustomAnalyzer, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null"));
             }
         }
     }

--- a/src/BuildCheck.UnitTests/EndToEndTests.cs
+++ b/src/BuildCheck.UnitTests/EndToEndTests.cs
@@ -149,7 +149,7 @@ public class EndToEndTests : IDisposable
             string projectAnalysisBuildLog = RunnerUtilities.ExecBootstrapedMSBuild(
                 $"{Path.Combine(analysisCandidatePath, $"{analysisCandidate}.csproj")} /m:1 -nr:False -restore /p:OutputPath={env.CreateFolder().Path} -analyze -verbosity:d",
                 out bool successBuild);
-            successBuild.ShouldBeTrue();
+            successBuild.ShouldBeTrue(projectAnalysisBuildLog);
 
             foreach (string registeredRule in expectedRegisteredRules)
             {

--- a/src/BuildCheck.UnitTests/EndToEndTests.cs
+++ b/src/BuildCheck.UnitTests/EndToEndTests.cs
@@ -138,7 +138,7 @@ public class EndToEndTests : IDisposable
 
     [Theory]
     [InlineData(new[] { "CustomAnalyzer" }, "AnalysisCandidate", new[] { "CustomRule1", "CustomRule2" })]
-    [InlineData(new[] { "CustomAnalyzer", "CustomAnalyzer2", "InvalidCustomAnalyzer" }, "AnalysisCandidateWithMultipleAnalyzersInjected", new[] { "CustomRule1", "CustomRule2", "CustomRule3" }, new[] { "InvalidCustomAnalyzer" })]
+    [InlineData(new[] { "CustomAnalyzer", "CustomAnalyzer2", "InvalidCustomAnalyzer" }, "AnalysisCandidateWithMultipleAnalyzersInjected", new[] { "CustomRule1", "CustomRule2", "CustomRule3" }, new[] { "InvalidCustomAnalyzer.InvalidAnalyzer" })]
     public void CustomAnalyzerTest(string[] customAnalyzerNames, string analysisCandidate, string[] expectedRegisteredRules, string[]? expectedRejectedRules = null)
     {
         using (var env = TestEnvironment.Create())

--- a/src/BuildCheck.UnitTests/EndToEndTests.cs
+++ b/src/BuildCheck.UnitTests/EndToEndTests.cs
@@ -2,13 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Xml;
 using Microsoft.Build.Shared;
 using Microsoft.Build.UnitTests;
 using Microsoft.Build.UnitTests.Shared;
-using Newtonsoft.Json.Linq;
 using Shouldly;
 using Xunit;
 using Xunit.Abstractions;
@@ -27,7 +25,9 @@ public class EndToEndTests : IDisposable
         _env.WithEnvironmentInvariant();
     }
 
-    private static string TestAssetsRootPath { get; } = Path.Combine(Path.GetDirectoryName(typeof(EndToEndTests).Assembly.Location) ?? AppContext.BaseDirectory, "TestAssets");
+    private static string AssemblyLocation { get; } = Path.Combine(Path.GetDirectoryName(typeof(EndToEndTests).Assembly.Location) ?? AppContext.BaseDirectory);
+
+    private static string TestAssetsRootPath { get; } = Path.Combine(AssemblyLocation, "TestAssets");
 
     public void Dispose() => _env.Dispose();
 
@@ -137,18 +137,14 @@ public class EndToEndTests : IDisposable
     }
 
     [Theory]
-    [InlineData(new[] { "CustomAnalyzer" }, "AnalysisCandidate", new[] { "CustomRule1", "CustomRule2" })]
-    [InlineData(new[] { "CustomAnalyzer", "CustomAnalyzer2", "InvalidCustomAnalyzer" }, "AnalysisCandidateWithMultipleAnalyzersInjected", new[] { "CustomRule1", "CustomRule2", "CustomRule3" }, true)]
-    public void CustomAnalyzerTest(string[] customAnalyzerNames, string analysisCandidate, string[] expectedRegisteredRules, bool expectedRejectedAnalyzers = false)
+    [InlineData("AnalysisCandidate", new[] { "CustomRule1", "CustomRule2" })]
+    [InlineData("AnalysisCandidateWithMultipleAnalyzersInjected", new[] { "CustomRule1", "CustomRule2", "CustomRule3" }, true)]
+    public void CustomAnalyzerTest(string analysisCandidate, string[] expectedRegisteredRules, bool expectedRejectedAnalyzers = false)
     {
         using (var env = TestEnvironment.Create())
         {
-            var candidatesNugetFullPaths = BuildAnalyzerRules(env, customAnalyzerNames);
-
-            candidatesNugetFullPaths.ShouldNotBeEmpty("Nuget package with custom analyzer was not generated or detected.");
-
             var analysisCandidatePath = Path.Combine(TestAssetsRootPath, analysisCandidate);
-            AddCustomDataSourceToNugetConfig(analysisCandidatePath, candidatesNugetFullPaths);
+            AddCustomDataSourceToNugetConfig(analysisCandidatePath);
 
             string projectAnalysisBuildLog = RunnerUtilities.ExecBootstrapedMSBuild(
                 $"{Path.Combine(analysisCandidatePath, $"{analysisCandidate}.csproj")} /m:1 -nr:False -restore /p:OutputPath={env.CreateFolder().Path} -analyze -verbosity:d",
@@ -162,33 +158,12 @@ public class EndToEndTests : IDisposable
 
             if (expectedRejectedAnalyzers)
             {
-                projectAnalysisBuildLog.ShouldContain(ResourceUtilities.FormatResourceStringStripCodeAndKeyword("CustomAnalyzerBaseTypeNotAssignable", "InvalidAnalyzer", "InvalidCustomAnalyzer, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null"));
+                projectAnalysisBuildLog.ShouldContain(ResourceUtilities.FormatResourceStringStripCodeAndKeyword("CustomAnalyzerBaseTypeNotAssignable", "InvalidAnalyzer", "InvalidCustomAnalyzer, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"));
             }
         }
     }
 
-    private IList<string> BuildAnalyzerRules(TestEnvironment env, string[] customAnalyzerNames)
-    {
-        var candidatesNugetFullPaths = new List<string>();
-
-        foreach (var customAnalyzerName in customAnalyzerNames)
-        {
-            var candidateAnalysisProjectPath = Path.Combine(TestAssetsRootPath, customAnalyzerName, $"{customAnalyzerName}.csproj");
-            var nugetPackResults = RunnerUtilities.ExecBootstrapedMSBuild(
-                 $"{candidateAnalysisProjectPath} /m:1 -nr:False -restore /p:OutputPath={env.CreateFolder().Path} -getTargetResult:Build", out bool success, attachProcessId: false);
-
-            success.ShouldBeTrue();
-
-            string? candidatesNugetPackageFullPath = (string?)(JObject.Parse(nugetPackResults)?["TargetResults"]?["Build"]?["Items"]?[0]?["RelativeDir"] ?? string.Empty);
-
-            candidatesNugetPackageFullPath.ShouldNotBeNull();
-            candidatesNugetFullPaths.Add(candidatesNugetPackageFullPath);
-        }
-
-        return candidatesNugetFullPaths;
-    }
-
-    private void AddCustomDataSourceToNugetConfig(string analysisCandidatePath, IList<string> candidatesNugetPackageFullPaths)
+    private void AddCustomDataSourceToNugetConfig(string analysisCandidatePath)
     {
         var nugetTemplatePath = Path.Combine(analysisCandidatePath, "nugetTemplate.config");
 
@@ -197,10 +172,10 @@ public class EndToEndTests : IDisposable
         if (doc.DocumentElement != null)
         {
             XmlNode? packageSourcesNode = doc.SelectSingleNode("//packageSources");
-            for (int i = 0; i < candidatesNugetPackageFullPaths.Count; i++)
-            {
-                AddPackageSource(doc, packageSourcesNode, $"Key{i}", Path.GetDirectoryName(candidatesNugetPackageFullPaths[i]) ?? string.Empty);
-            }
+
+            // The test packages are generated during the build and saved in CustomAnalyzers folder.
+            string analyzersPath = Path.Combine(Directory.GetParent(AssemblyLocation)?.FullName ?? string.Empty, "CustomAnalyzers");
+            AddPackageSource(doc, packageSourcesNode, "Key", AssemblyLocation);
 
             doc.Save(Path.Combine(analysisCandidatePath, "nuget.config"));
         }

--- a/src/BuildCheck.UnitTests/EndToEndTests.cs
+++ b/src/BuildCheck.UnitTests/EndToEndTests.cs
@@ -173,9 +173,9 @@ public class EndToEndTests : IDisposable
         {
             XmlNode? packageSourcesNode = doc.SelectSingleNode("//packageSources");
 
-            // The test packages are generated during the build and saved in CustomAnalyzers folder.
-            string analyzersPath = Path.Combine(Directory.GetParent(AssemblyLocation)?.FullName ?? string.Empty, "CustomAnalyzers");
-            AddPackageSource(doc, packageSourcesNode, "Key", AssemblyLocation);
+            // The test packages are generated during the test project build and saved in CustomAnalyzers folder.
+            string analyzersPackagesPath = Path.Combine(Directory.GetParent(AssemblyLocation)?.FullName ?? string.Empty, "CustomAnalyzers");
+            AddPackageSource(doc, packageSourcesNode, "Key", analyzersPackagesPath);
 
             doc.Save(Path.Combine(analysisCandidatePath, "nuget.config"));
         }

--- a/src/BuildCheck.UnitTests/EndToEndTests.cs
+++ b/src/BuildCheck.UnitTests/EndToEndTests.cs
@@ -136,7 +136,7 @@ public class EndToEndTests : IDisposable
         }
     }
 
-    [DotNetOnlyTheory]
+    [Theory]
     [InlineData("AnalysisCandidate", new[] { "CustomRule1", "CustomRule2" })]
     [InlineData("AnalysisCandidateWithMultipleAnalyzersInjected", new[] { "CustomRule1", "CustomRule2", "CustomRule3" }, true)]
     public void CustomAnalyzerTest(string analysisCandidate, string[] expectedRegisteredRules, bool expectedRejectedAnalyzers = false)
@@ -174,7 +174,7 @@ public class EndToEndTests : IDisposable
             XmlNode? packageSourcesNode = doc.SelectSingleNode("//packageSources");
 
             // The test packages are generated during the test project build and saved in CustomAnalyzers folder.
-            string analyzersPackagesPath = Path.Combine(Directory.GetParent(AssemblyLocation)?.FullName ?? string.Empty, "CustomAnalyzers");
+            string analyzersPackagesPath = Path.Combine(Directory.GetParent(AssemblyLocation)?.Parent?.FullName ?? string.Empty, "CustomAnalyzers");
             AddPackageSource(doc, packageSourcesNode, "Key", analyzersPackagesPath);
 
             doc.Save(Path.Combine(analysisCandidatePath, "nuget.config"));

--- a/src/BuildCheck.UnitTests/EndToEndTests.cs
+++ b/src/BuildCheck.UnitTests/EndToEndTests.cs
@@ -136,7 +136,7 @@ public class EndToEndTests : IDisposable
         }
     }
 
-    [Theory]
+    [DotNetOnlyTheory]
     [InlineData("AnalysisCandidate", new[] { "CustomRule1", "CustomRule2" })]
     [InlineData("AnalysisCandidateWithMultipleAnalyzersInjected", new[] { "CustomRule1", "CustomRule2", "CustomRule3" }, true)]
     public void CustomAnalyzerTest(string analysisCandidate, string[] expectedRegisteredRules, bool expectedRejectedAnalyzers = false)

--- a/src/BuildCheck.UnitTests/Microsoft.Build.BuildCheck.UnitTests.csproj
+++ b/src/BuildCheck.UnitTests/Microsoft.Build.BuildCheck.UnitTests.csproj
@@ -14,6 +14,12 @@
     <ProjectReference Include="..\UnitTests.Shared\Microsoft.Build.UnitTests.Shared.csproj" />
     <ProjectReference Include="..\Xunit.NetCore.Extensions\Xunit.NetCore.Extensions.csproj" />
   </ItemGroup>
+  
+  <ItemGroup Label="TestAssests">
+    <ProjectReference Include=".\TestAssets\CustomAnalyzer\CustomAnalyzer.csproj" />
+    <ProjectReference Include=".\TestAssets\CustomAnalyzer2\CustomAnalyzer2.csproj" />
+    <ProjectReference Include=".\TestAssets\InvalidCustomAnalyzer\InvalidCustomAnalyzer.csproj" />
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="System.Collections.Immutable" />
@@ -37,19 +43,5 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-
-  <!-- Check on .net core only now-->
-  <Target Name="BuildTestAssets" AfterTargets="Build" Condition="'$(TargetFramework)' == '$(LatestDotNetCoreForMSBuild)'">
-    <ItemGroup>
-      <TestAssetProject Include="$(RepoRoot)src\BuildCheck.UnitTests\TestAssets\CustomAnalyzer\CustomAnalyzer.csproj" />
-      <TestAssetProject Include="$(RepoRoot)src\BuildCheck.UnitTests\TestAssets\CustomAnalyzer2\CustomAnalyzer2.csproj" />
-      <TestAssetProject Include="$(RepoRoot)src\BuildCheck.UnitTests\TestAssets\InvalidCustomAnalyzer\InvalidCustomAnalyzer.csproj" />
-    </ItemGroup>
-
-    <MSBuild Projects="@(TestAssetProject)"
-             Properties="PackageOutputPath=$(ArtifactsBinDir)Microsoft.Build.BuildCheck.UnitTests\$(Configuration)\CustomAnalyzers;Version=1.0.0"
-             Targets="Restore;Build;Pack" />
-
-  </Target>
 
 </Project>

--- a/src/BuildCheck.UnitTests/Microsoft.Build.BuildCheck.UnitTests.csproj
+++ b/src/BuildCheck.UnitTests/Microsoft.Build.BuildCheck.UnitTests.csproj
@@ -38,4 +38,18 @@
     </None>
   </ItemGroup>
 
+  <!-- Custom Analyzers target netstandard2.0, so we don't need to build it as mutitarget.-->
+  <Target Name="BuildTestAssets" AfterTargets="Build" Condition="'$(TargetFramework)' == '$(LatestDotNetCoreForMSBuild)'">
+    <ItemGroup>
+      <TestAssetProject Include="$(RepoRoot)src\BuildCheck.UnitTests\TestAssets\CustomAnalyzer\CustomAnalyzer.csproj" />
+      <TestAssetProject Include="$(RepoRoot)src\BuildCheck.UnitTests\TestAssets\CustomAnalyzer2\CustomAnalyzer2.csproj" />
+      <TestAssetProject Include="$(RepoRoot)src\BuildCheck.UnitTests\TestAssets\InvalidCustomAnalyzer\InvalidCustomAnalyzer.csproj" />
+    </ItemGroup>
+
+    <MSBuild Projects="@(TestAssetProject)"
+             Properties="PackageOutputPath=$(ArtifactsBinDir)Microsoft.Build.BuildCheck.UnitTests\$(Configuration)\CustomAnalyzers;Version=1.0.0"
+             Targets="Restore;Build;Pack" />
+
+  </Target>
+
 </Project>

--- a/src/BuildCheck.UnitTests/Microsoft.Build.BuildCheck.UnitTests.csproj
+++ b/src/BuildCheck.UnitTests/Microsoft.Build.BuildCheck.UnitTests.csproj
@@ -38,7 +38,7 @@
     </None>
   </ItemGroup>
 
-  <!-- Custom Analyzers target netstandard2.0, so we don't need to build it as mutitarget.-->
+  <!-- Check on .net core only now-->
   <Target Name="BuildTestAssets" AfterTargets="Build" Condition="'$(TargetFramework)' == '$(LatestDotNetCoreForMSBuild)'">
     <ItemGroup>
       <TestAssetProject Include="$(RepoRoot)src\BuildCheck.UnitTests\TestAssets\CustomAnalyzer\CustomAnalyzer.csproj" />

--- a/src/BuildCheck.UnitTests/TestAssets/AnalysisCandidate/nugetTemplate.config
+++ b/src/BuildCheck.UnitTests/TestAssets/AnalysisCandidate/nugetTemplate.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
-   <packageSources>
-
+  <packageSources>
+    <clear />
   </packageSources>
 </configuration>

--- a/src/BuildCheck.UnitTests/TestAssets/AnalysisCandidate/nugetTemplate.config
+++ b/src/BuildCheck.UnitTests/TestAssets/AnalysisCandidate/nugetTemplate.config
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
-    <clear />
   </packageSources>
 </configuration>

--- a/src/BuildCheck.UnitTests/TestAssets/AnalysisCandidateWithMultipleAnalyzersInjected/AnalysisCandidateWithMultipleAnalyzersInjected.csproj
+++ b/src/BuildCheck.UnitTests/TestAssets/AnalysisCandidateWithMultipleAnalyzersInjected/AnalysisCandidateWithMultipleAnalyzersInjected.csproj
@@ -8,6 +8,7 @@
   <ItemGroup>
     <PackageReference Include="CustomAnalyzer" Version="1.0.0"/>
     <PackageReference Include="CustomAnalyzer2" Version="1.0.0"/>
+    <PackageReference Include="InvalidCustomAnalyzer" Version="1.0.0"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/BuildCheck.UnitTests/TestAssets/AnalysisCandidateWithMultipleAnalyzersInjected/nugetTemplate.config
+++ b/src/BuildCheck.UnitTests/TestAssets/AnalysisCandidateWithMultipleAnalyzersInjected/nugetTemplate.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
    <packageSources>
-
+     <clear />
   </packageSources>
 </configuration>

--- a/src/BuildCheck.UnitTests/TestAssets/AnalysisCandidateWithMultipleAnalyzersInjected/nugetTemplate.config
+++ b/src/BuildCheck.UnitTests/TestAssets/AnalysisCandidateWithMultipleAnalyzersInjected/nugetTemplate.config
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
    <packageSources>
-     <clear />
   </packageSources>
 </configuration>

--- a/src/BuildCheck.UnitTests/TestAssets/Common/CommonTest.props
+++ b/src/BuildCheck.UnitTests/TestAssets/Common/CommonTest.props
@@ -1,0 +1,17 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <!-- The properties need to be redefined to have a nuget package built as a part of MSBuild build. -->
+  <PropertyGroup>
+    <IsPackable>true</IsPackable>
+    <IsShipping>false</IsShipping>
+    <PackageVersion>1.0.0</PackageVersion>
+    <ArtifactsNonShippingPackagesDir>$(ArtifactsBinDir)Microsoft.Build.BuildCheck.UnitTests\CustomAnalyzers</ArtifactsNonShippingPackagesDir>
+    <NoWarn>NU5101;NU5128;MSB3277;NU1507;NU1701;NU1702;NU5104</NoWarn>
+  </PropertyGroup>
+
+  <!-- In the real world scenario, the dependencies are added as Nuget PackageReference, modified for test purposes only. -->
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Build\Microsoft.Build.csproj" IncludeInPackage="true" />
+  </ItemGroup>
+
+</Project>

--- a/src/BuildCheck.UnitTests/TestAssets/Common/CommonTest.targets
+++ b/src/BuildCheck.UnitTests/TestAssets/Common/CommonTest.targets
@@ -1,0 +1,41 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <Target Name="AddNuGetDlls" BeforeTargets="_GetPackageFiles">
+    <!-- Resolve the project references to get their output DLL paths -->
+    <ItemGroup>
+      <ResolvedProjectReference Include="@(ReferencePath)" Condition="%(ReferencePath.ReferenceSourceTarget) == 'ProjectReference'">
+        <OutputPath>%(ReferencePath.OriginalItemSpec)</OutputPath>
+      </ResolvedProjectReference>
+
+      <!-- Add the DLL produced by the referenced project to the _PackagesToPack list -->
+      <_PackagesToPack Include="@(ResolvedProjectReference->'%(OutputPath)')">
+          <NuGetPackageId>@(ResolvedProjectReference->'%(AssemblyName)')</NuGetPackageId>
+      </_PackagesToPack>
+    </ItemGroup>
+    
+    <!-- Merge the collection of PackageReference and Assemblies using the NuGetPackageId key.
+       This produces a new list containing the DLL path and the "IncludeInPackage" metadata-->
+    <JoinItems Left="@(ResolvedCompileFileDefinitions)" LeftKey="NuGetPackageId" LeftMetadata="*" Right="@(ProjectReference)" RightKey="" RightMetadata="*" ItemSpecToUse="Left">
+      <Output TaskParameter="JoinResult" ItemName="_PackagesToPack" />
+    </JoinItems>
+
+    <ItemGroup>
+      <Message Importance="High" Text="Adding DLLs from the following packages: @(_PackagesToPack->'%(NuGetPackageId)')" />
+
+      <!-- Remove NETStandard DLLs -->
+      <_PackagesToPack Remove="@(_PackagesToPack)" Condition="%(NuGetPackageId) == 'NETStandard.Library'" />
+      <_PackagesToPack Remove="@(_PackagesToPack)" Condition="%(_PackagesToPack.IncludeInPackage) != 'true'" />
+    </ItemGroup>
+
+    <Message Importance="High" Text="Adding DLLs from the following packages: @(ResolvedProjectReferences->'%(OutputPath)%(AssemblyName).dll')" />
+
+    <ItemGroup>
+      <!-- Update the collection of items to pack with the DLLs from the NuGet packages -->
+      <None Include="@(_PackagesToPack)" Pack="true" PackagePath="build" Visible="false" />
+
+      <!-- Add the DLL produced by the current project to the NuGet package -->
+      <None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="build" Visible="false" />
+    </ItemGroup>
+  </Target>
+
+</Project>

--- a/src/BuildCheck.UnitTests/TestAssets/CustomAnalyzer/CustomAnalyzer.csproj
+++ b/src/BuildCheck.UnitTests/TestAssets/CustomAnalyzer/CustomAnalyzer.csproj
@@ -2,20 +2,20 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <IncludeBuildOutput>false</IncludeBuildOutput>
-    <!-- The output structure was modified for msbuild development needs.-->
-    <NoWarn>NU5101;NU5128;MSB3277</NoWarn>
+    <!-- The property set for nuget package production on build.-->
+    <IsPackable>true</IsPackable>
+    <NoWarn>NU5101;NU5128;MSB3277;NU1507</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
     <None Include="CustomAnalyzer.props" Pack="true" PackagePath="build\CustomAnalyzer.props" />
+    <Content Include="README.md" />
   </ItemGroup>
 
   <ItemGroup>
     <!-- In the real world scenario, the DLLs are added as PackageReference, modified for test purposes only. -->
     <Reference Include="Microsoft.Build">
-      <HintPath>$(MSBuildProjectDirectory)\..\..\Microsoft.Build.dll</HintPath>
+      <HintPath>$(ArtifactsBinDir)Microsoft.Build\$(Configuration)\$(TargetFramework)\Microsoft.Build.dll</HintPath>
     </Reference>
   </ItemGroup>
 
@@ -25,5 +25,6 @@
       <None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="build" Visible="false" />
     </ItemGroup>
   </Target>
+  <Target Name="UpdateXlf" />
 
 </Project>

--- a/src/BuildCheck.UnitTests/TestAssets/CustomAnalyzer/CustomAnalyzer.csproj
+++ b/src/BuildCheck.UnitTests/TestAssets/CustomAnalyzer/CustomAnalyzer.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <Import Project="..\Common\CommonTest.props" />
+
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <!-- The property set for nuget package production on build.-->
-    <IsPackable>true</IsPackable>
-    <NoWarn>NU5101;NU5128;MSB3277;NU1507</NoWarn>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <ItemGroup>
@@ -12,19 +12,6 @@
     <Content Include="README.md" />
   </ItemGroup>
 
-  <ItemGroup>
-    <!-- In the real world scenario, the DLLs are added as PackageReference, modified for test purposes only. -->
-    <Reference Include="Microsoft.Build">
-      <HintPath>$(ArtifactsBinDir)Microsoft.Build\$(Configuration)\$(TargetFramework)\Microsoft.Build.dll</HintPath>
-    </Reference>
-  </ItemGroup>
-
-  <Target Name="AddNuGetDlls" BeforeTargets="_GetPackageFiles">
-    <ItemGroup>
-      <!-- Add the DLL produced by the current project to the NuGet package -->
-      <None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="build" Visible="false" />
-    </ItemGroup>
-  </Target>
-  <Target Name="UpdateXlf" />
+  <Import Project="..\Common\CommonTest.targets" />
 
 </Project>

--- a/src/BuildCheck.UnitTests/TestAssets/CustomAnalyzer/README.md
+++ b/src/BuildCheck.UnitTests/TestAssets/CustomAnalyzer/README.md
@@ -1,0 +1,21 @@
+# MSBuild Custom Analyzer Template
+
+## Overview
+MSBuild Custom Analyzer Template is a .NET template designed to streamline the creation of MSBuild analyzer libraries. This template facilitates the development of custom analyzers targeting .NET Standard, enabling developers to inspect and enforce conventions, standards, or patterns within their MSBuild builds.
+
+## Features
+- Simplified template for creating MSBuild analyzer libraries.
+- Targeting .NET Standard for cross-platform compatibility.
+- Provides a starting point for implementing custom analysis rules.
+
+## Getting Started
+To use the MSBuild Custom Analyzer Template, follow these steps:
+1. Install the template using the following command:
+   ```bash
+   dotnet new install msbuildanalyzer
+2. Instantiate a custom template:
+   ```bash
+   dotnet new msbuildanalyzer -n <ProjectName>
+
+### Prerequisites
+- .NET SDK installed on your machine.

--- a/src/BuildCheck.UnitTests/TestAssets/CustomAnalyzer2/CustomAnalyzer2.csproj
+++ b/src/BuildCheck.UnitTests/TestAssets/CustomAnalyzer2/CustomAnalyzer2.csproj
@@ -2,19 +2,20 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <!-- The output structure was modified for msbuild development needs.-->
-    <NoWarn>NU5101;NU5128;MSB3277</NoWarn>
+    <!-- The property set for nuget package production on build.-->
+    <IsPackable>true</IsPackable>
+    <NoWarn>NU5101;NU5128;MSB3277;NU1507</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
     <None Include="CustomAnalyzer2.props" Pack="true" PackagePath="build\CustomAnalyzer2.props" />
+    <Content Include="README.md" />
   </ItemGroup>
 
   <ItemGroup>
     <!-- In the real world scenario, the DLLs are added as PackageReference, modified for test purposes only. -->
     <Reference Include="Microsoft.Build">
-      <HintPath>$(MSBuildProjectDirectory)\..\..\Microsoft.Build.dll</HintPath>
+      <HintPath>$(ArtifactsBinDir)Microsoft.Build\$(Configuration)\$(TargetFramework)\Microsoft.Build.dll</HintPath>
     </Reference>
   </ItemGroup>
 
@@ -24,5 +25,6 @@
       <None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="build" Visible="false" />
     </ItemGroup>
   </Target>
+  <Target Name="UpdateXlf" />
 
 </Project>

--- a/src/BuildCheck.UnitTests/TestAssets/CustomAnalyzer2/CustomAnalyzer2.csproj
+++ b/src/BuildCheck.UnitTests/TestAssets/CustomAnalyzer2/CustomAnalyzer2.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <Import Project="..\Common\CommonTest.props" />
+
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <!-- The property set for nuget package production on build.-->
-    <IsPackable>true</IsPackable>
-    <NoWarn>NU5101;NU5128;MSB3277;NU1507</NoWarn>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <ItemGroup>
@@ -12,19 +12,6 @@
     <Content Include="README.md" />
   </ItemGroup>
 
-  <ItemGroup>
-    <!-- In the real world scenario, the DLLs are added as PackageReference, modified for test purposes only. -->
-    <Reference Include="Microsoft.Build">
-      <HintPath>$(ArtifactsBinDir)Microsoft.Build\$(Configuration)\$(TargetFramework)\Microsoft.Build.dll</HintPath>
-    </Reference>
-  </ItemGroup>
-
-  <Target Name="AddNuGetDlls" BeforeTargets="_GetPackageFiles">
-    <ItemGroup>
-      <!-- Add the DLL produced by the current project to the NuGet package -->
-      <None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="build" Visible="false" />
-    </ItemGroup>
-  </Target>
-  <Target Name="UpdateXlf" />
-
+  <Import Project="..\Common\CommonTest.targets" />
+  
 </Project>

--- a/src/BuildCheck.UnitTests/TestAssets/CustomAnalyzer2/README.md
+++ b/src/BuildCheck.UnitTests/TestAssets/CustomAnalyzer2/README.md
@@ -1,0 +1,21 @@
+# MSBuild Custom Analyzer Template
+
+## Overview
+MSBuild Custom Analyzer Template is a .NET template designed to streamline the creation of MSBuild analyzer libraries. This template facilitates the development of custom analyzers targeting .NET Standard, enabling developers to inspect and enforce conventions, standards, or patterns within their MSBuild builds.
+
+## Features
+- Simplified template for creating MSBuild analyzer libraries.
+- Targeting .NET Standard for cross-platform compatibility.
+- Provides a starting point for implementing custom analysis rules.
+
+## Getting Started
+To use the MSBuild Custom Analyzer Template, follow these steps:
+1. Install the template using the following command:
+   ```bash
+   dotnet new install msbuildanalyzer
+2. Instantiate a custom template:
+   ```bash
+   dotnet new msbuildanalyzer -n <ProjectName>
+
+### Prerequisites
+- .NET SDK installed on your machine.

--- a/src/BuildCheck.UnitTests/TestAssets/InvalidCustomAnalyzer/InvalidAnalyzer.cs
+++ b/src/BuildCheck.UnitTests/TestAssets/InvalidCustomAnalyzer/InvalidAnalyzer.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections.Generic;
+using Microsoft.Build.Construction;
+using Microsoft.Build.Experimental.BuildCheck;
+
+namespace InvalidCustomAnalyzer
+{
+    public sealed class InvalidAnalyzer
+    {
+        public static BuildAnalyzerRule SupportedRule = new BuildAnalyzerRule(
+            "X01235",
+            "Title",
+            "Description",
+            "Message format: {0}",
+            new BuildAnalyzerConfiguration());
+
+        public string FriendlyName => "InvalidAnalyzer";
+    }
+}

--- a/src/BuildCheck.UnitTests/TestAssets/InvalidCustomAnalyzer/InvalidAnalyzer.cs
+++ b/src/BuildCheck.UnitTests/TestAssets/InvalidCustomAnalyzer/InvalidAnalyzer.cs
@@ -1,18 +1,9 @@
 ﻿using System.Collections.Generic;
-using Microsoft.Build.Construction;
-using Microsoft.Build.Experimental.BuildCheck;
 
 namespace InvalidCustomAnalyzer
 {
     public sealed class InvalidAnalyzer
     {
-        public static BuildAnalyzerRule SupportedRule = new BuildAnalyzerRule(
-            "X01235",
-            "Title",
-            "Description",
-            "Message format: {0}",
-            new BuildAnalyzerConfiguration());
-
         public string FriendlyName => "InvalidAnalyzer";
     }
 }

--- a/src/BuildCheck.UnitTests/TestAssets/InvalidCustomAnalyzer/InvalidCustomAnalyzer.csproj
+++ b/src/BuildCheck.UnitTests/TestAssets/InvalidCustomAnalyzer/InvalidCustomAnalyzer.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <Import Project="..\Common\CommonTest.props" />
+
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <!-- The property set for nuget package production on build.-->
-    <IsPackable>true</IsPackable>
-    <NoWarn>NU5101;NU5128;MSB3277;NU1507</NoWarn>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <ItemGroup>
@@ -12,21 +12,6 @@
     <Content Include="README.md" />
   </ItemGroup>
 
-  <ItemGroup>
-    <!-- In the real world scenario, the DLLs are added as PackageReference, modified for test purposes only. -->
-    <Reference Include="Microsoft.Build">
-      <HintPath>$(ArtifactsBinDir)Microsoft.Build\$(Configuration)\$(TargetFramework)\Microsoft.Build.dll</HintPath>
-    </Reference>
-  </ItemGroup>
-
-  <Target Name="AddNuGetDlls" BeforeTargets="_GetPackageFiles">
-    <ItemGroup>
-      <!-- Add the DLL produced by the current project to the NuGet package -->
-      <None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="build" Visible="false" />
-    </ItemGroup>
-  </Target>
-  <Target Name="UpdateXlf" />
-
-  <Target Name="Pack" />
+  <Import Project="..\Common\CommonTest.targets" />
 
 </Project>

--- a/src/BuildCheck.UnitTests/TestAssets/InvalidCustomAnalyzer/InvalidCustomAnalyzer.csproj
+++ b/src/BuildCheck.UnitTests/TestAssets/InvalidCustomAnalyzer/InvalidCustomAnalyzer.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+    <!-- The output structure was modified for msbuild development needs.-->
+    <NoWarn>NU5101;NU5128;MSB3277</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="InvalidCustomAnalyzer.props" Pack="true" PackagePath="build\InvalidCustomAnalyzer.props" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- In the real world scenario, the DLLs are added as PackageReference, modified for test purposes only. -->
+    <Reference Include="Microsoft.Build">
+      <HintPath>$(MSBuildProjectDirectory)\..\..\Microsoft.Build.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+
+  <Target Name="AddNuGetDlls" BeforeTargets="_GetPackageFiles">
+    <ItemGroup>
+      <!-- Add the DLL produced by the current project to the NuGet package -->
+      <None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="build" Visible="false" />
+    </ItemGroup>
+  </Target>
+
+</Project>

--- a/src/BuildCheck.UnitTests/TestAssets/InvalidCustomAnalyzer/InvalidCustomAnalyzer.csproj
+++ b/src/BuildCheck.UnitTests/TestAssets/InvalidCustomAnalyzer/InvalidCustomAnalyzer.csproj
@@ -2,19 +2,20 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <!-- The output structure was modified for msbuild development needs.-->
-    <NoWarn>NU5101;NU5128;MSB3277</NoWarn>
+    <!-- The property set for nuget package production on build.-->
+    <IsPackable>true</IsPackable>
+    <NoWarn>NU5101;NU5128;MSB3277;NU1507</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
     <None Include="InvalidCustomAnalyzer.props" Pack="true" PackagePath="build\InvalidCustomAnalyzer.props" />
+    <Content Include="README.md" />
   </ItemGroup>
 
   <ItemGroup>
     <!-- In the real world scenario, the DLLs are added as PackageReference, modified for test purposes only. -->
     <Reference Include="Microsoft.Build">
-      <HintPath>$(MSBuildProjectDirectory)\..\..\Microsoft.Build.dll</HintPath>
+      <HintPath>$(ArtifactsBinDir)Microsoft.Build\$(Configuration)\$(TargetFramework)\Microsoft.Build.dll</HintPath>
     </Reference>
   </ItemGroup>
 
@@ -24,5 +25,8 @@
       <None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="build" Visible="false" />
     </ItemGroup>
   </Target>
+  <Target Name="UpdateXlf" />
+
+  <Target Name="Pack" />
 
 </Project>

--- a/src/BuildCheck.UnitTests/TestAssets/InvalidCustomAnalyzer/InvalidCustomAnalyzer.props
+++ b/src/BuildCheck.UnitTests/TestAssets/InvalidCustomAnalyzer/InvalidCustomAnalyzer.props
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <PropertyGroup>
+	  <MSBuildAnalyzer>$([MSBuild]::RegisterBuildCheck($(MSBuildThisFileDirectory)InvalidCustomAnalyzer.dll))</MSBuildAnalyzer>
+  </PropertyGroup>
+</Project>

--- a/src/BuildCheck.UnitTests/TestAssets/InvalidCustomAnalyzer/README.md
+++ b/src/BuildCheck.UnitTests/TestAssets/InvalidCustomAnalyzer/README.md
@@ -1,0 +1,21 @@
+# MSBuild Custom Analyzer Template
+
+## Overview
+MSBuild Custom Analyzer Template is a .NET template designed to streamline the creation of MSBuild analyzer libraries. This template facilitates the development of custom analyzers targeting .NET Standard, enabling developers to inspect and enforce conventions, standards, or patterns within their MSBuild builds.
+
+## Features
+- Simplified template for creating MSBuild analyzer libraries.
+- Targeting .NET Standard for cross-platform compatibility.
+- Provides a starting point for implementing custom analysis rules.
+
+## Getting Started
+To use the MSBuild Custom Analyzer Template, follow these steps:
+1. Install the template using the following command:
+   ```bash
+   dotnet new install msbuildanalyzer
+2. Instantiate a custom template:
+   ```bash
+   dotnet new msbuildanalyzer -n <ProjectName>
+
+### Prerequisites
+- .NET SDK installed on your machine.


### PR DESCRIPTION
## Fixes
The case, mentioned in documentation: https://github.com/dotnet/msbuild/pull/10078#discussion_r1581121235 and build CustomAnalyzer test assets during the build to reduce the test running time.