### PR TITLE
Remove redundant creation of Forwarding logger with NullLogger

### DIFF
--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -3057,7 +3057,7 @@ namespace Microsoft.Build.Execution
 
                 // The forwarding loggers that are registered are unknown to us - we cannot make any assumptions.
                 // So to be on a sure side - we need to add ours.
-                if (result.Any(l => l.ForwardingLoggerDescription.Name.Contains(engineAssemblyName)))
+                if (!result.Any(l => l.ForwardingLoggerDescription.Name.Contains(engineAssemblyName)))
                 {
                     result.Add(CreateMinimalForwarder());
                     return result;

--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -3017,7 +3017,8 @@ namespace Microsoft.Build.Execution
                     }
                 }
 
-                if (loggingService.Loggers.Count == 0)
+                forwardingLoggers = forwardingLoggers?.ToList();
+                if (loggingService.Loggers.Count == 0 && (forwardingLoggers?.Count() ?? 0) == 0)
                 {
                     // We need to register SOME logger if we don't have any. This ensures the out of proc nodes will still send us message,
                     // ensuring we receive project started and finished events.

--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -3042,16 +3042,18 @@ namespace Microsoft.Build.Execution
 
             // We need to register SOME logger if we don't have any. This ensures the out of proc nodes will still send us message,
             // ensuring we receive project started and finished events.
-            List<ForwardingLoggerRecord> ProcessForwardingLoggers(IEnumerable<ForwardingLoggerRecord> forwarders)
+            static List<ForwardingLoggerRecord> ProcessForwardingLoggers(IEnumerable<ForwardingLoggerRecord> forwarders)
             {
+                Type configurableLoggerType = typeof(ConfigurableForwardingLogger);
+                string engineAssemblyName = configurableLoggerType.GetTypeInfo().Assembly.GetName().FullName;
+                string configurableLoggerName = configurableLoggerType.FullName;
+
                 if (forwarders == null)
                 {
                     return [CreateMinimalForwarder()];
                 }
 
                 List<ForwardingLoggerRecord> result = forwarders.ToList();
-
-                string engineAssemblyName = typeof(ConfigurableForwardingLogger).GetTypeInfo().Assembly.GetName().FullName;
 
                 // The forwarding loggers that are registered are unknown to us - we cannot make any assumptions.
                 // So to be on a sure side - we need to add ours.
@@ -3065,7 +3067,7 @@ namespace Microsoft.Build.Execution
                 if (result.Any(l =>
                         l.ForwardingLoggerDescription.Name.Contains(typeof(CentralForwardingLogger).FullName)
                         ||
-                        (l.ForwardingLoggerDescription.Name.Contains(typeof(ConfigurableForwardingLogger).FullName)
+                        (l.ForwardingLoggerDescription.Name.Contains(configurableLoggerName)
                          &&
                          l.ForwardingLoggerDescription.LoggerSwitchParameters.Contains("PROJECTSTARTEDEVENT")
                          &&
@@ -3079,7 +3081,7 @@ namespace Microsoft.Build.Execution
 
                 // In case there is a ConfigurableForwardingLogger, that is not configured as we'd need - we can adjust the config
                 ForwardingLoggerRecord configurableLogger = result.FirstOrDefault(l =>
-                    l.ForwardingLoggerDescription.Name.Contains(typeof(ConfigurableForwardingLogger).FullName));
+                    l.ForwardingLoggerDescription.Name.Contains(configurableLoggerName));
 
                 // If there is not - we need to add our own.
                 if (configurableLogger == null)
@@ -3097,8 +3099,8 @@ namespace Microsoft.Build.Execution
                     // We need to register SOME logger if we don't have any. This ensures the out of proc nodes will still send us message,
                     // ensuring we receive project started and finished events.
                     LoggerDescription forwardingLoggerDescription = new LoggerDescription(
-                        loggerClassName: typeof(ConfigurableForwardingLogger).FullName,
-                        loggerAssemblyName: typeof(ConfigurableForwardingLogger).GetTypeInfo().Assembly.GetName().FullName,
+                        loggerClassName: configurableLoggerName,
+                        loggerAssemblyName: engineAssemblyName,
                         loggerAssemblyFile: null,
                         loggerSwitchParameters: "PROJECTSTARTEDEVENT;PROJECTFINISHEDEVENT;FORWARDPROJECTCONTEXTEVENTS",
                         verbosity: LoggerVerbosity.Quiet);

--- a/src/Build/Logging/DistributedLoggers/ConfigurableForwardingLogger.cs
+++ b/src/Build/Logging/DistributedLoggers/ConfigurableForwardingLogger.cs
@@ -182,6 +182,10 @@ namespace Microsoft.Build.Logging
                     _forwardProjectContext = true;
                     isEventForwardingParameter = false;
                     break;
+                case RespectVerbosityDescription:
+                    _respectVerbosity = true;
+                    isEventForwardingParameter = false;
+                    break;
                 default:
                     isEventForwardingParameter = false;
                     break;
@@ -202,7 +206,7 @@ namespace Microsoft.Build.Logging
 
             ParseParameters(eventSource);
 
-            if (!_forwardingSetFromParameters)
+            if (_respectVerbosity || !_forwardingSetFromParameters)
             {
                 SetForwardingBasedOnVerbosity(eventSource);
             }
@@ -421,6 +425,7 @@ namespace Microsoft.Build.Logging
         private const string NoSummaryDescription = "NOSUMMARY";
         private const string ShowCommandLineDescription = "SHOWCOMMANDLINE";
         private const string ForwardProjectContextDescription = "FORWARDPROJECTCONTEXTEVENTS";
+        private const string RespectVerbosityDescription = "RESPECTVERBOSITY";
 
         #region Per-build Members
 
@@ -434,6 +439,12 @@ namespace Microsoft.Build.Logging
         /// if this is false the events to forward are based on verbosity else verbosity settings will be ignored
         /// </summary>
         private bool _forwardingSetFromParameters;
+
+        /// <summary>
+        /// Indicates if the parameters explicitly specified respecting of the verbosity (forwarding will
+        ///  be set based on verbosity, in addition to explicitly configured forwarding via parameters).
+        /// </summary>
+        private bool _respectVerbosity;
 
         /// <summary>
         /// Indicates if the events to forward should include project context events, if not

--- a/src/Build/Logging/LoggerDescription.cs
+++ b/src/Build/Logging/LoggerDescription.cs
@@ -118,6 +118,10 @@ namespace Microsoft.Build.Logging
             {
                 return _loggerSwitchParameters;
             }
+            internal set
+            {
+                _loggerSwitchParameters = value;
+            }
         }
 
         public bool IsOptional


### PR DESCRIPTION
### Context
Random discovery - we create NullLogger even when we have other logger(s) registered (e.g. ConsoleLogger, TerminalLogger ...).

We need to make sure that Projcet started and finished events are being transfered - we can 'hijack' the existing registration of ConfigurableLForwardingLogger for that - we just need to inspect and adjust existing registration

### Motivation
Build with just the built-in loggers (TerminalLogger, ConsoleLogger, FileLogger) is probably the most common configuration - and we are injecting extra forwarder to each such a build - so while it's likely very small savings (as only couple events was redundantly de/serialized, rest was quickly skipped) - it applies very broadly.

## Perf

Following measurements were done using the OrchardCore and bootstrapped release MSBuild.exe with following 3 scenarios:
* MSBuild.exe -m
* MSBuild.exe -v:m -m
* MSBuild.exe -tl -m

Each scenario for each branch for 3 runs after the warmup run. Clean and kill of msbuild/dotnet/vbcscompiler processes between each individual runs. Median value choosed for each scenario.

The versions that has been tested were:
* main (https://github.com/dotnet/msbuild/commit/a8e224f80e753c4c52b6cc8a3a62c11780aff6d6)
* Logging Svc fix (This PR)
* Expanders refactor (https://github.com/dotnet/msbuild/pull/10102)


|  | MSBuild.exe -m | MSBuild.exe -v:m -m  | MSBuild.exe -tl -m
| :-- | --: | --: | --: |
| Main                       | 00:00:36.02 | 00:00:31.86 | 00:00:33.22 |
| Logging Svc fix       | 00:00:35.57 | 00:00:30.89 | 00:00:33.79 | 
| Expanders refactor | 00:00:36.66 | 00:00:32.43 | 00:00:32.49 |

### Testing
Pre-existing tests