### PR TITLE
Increase the timeout of running process for investigating buildcheck tests

### DIFF
--- a/src/BuildCheck.UnitTests/EndToEndTests.cs
+++ b/src/BuildCheck.UnitTests/EndToEndTests.cs
@@ -121,7 +121,7 @@ public class EndToEndTests : IDisposable
         _env.SetEnvironmentVariable("MSBUILDLOGPROPERTIESANDITEMSAFTEREVALUATION", "1");
         string output = RunnerUtilities.ExecBootstrapedMSBuild(
             $"{Path.GetFileName(projectFile.Path)} /m:1 -nr:False -restore" +
-            (analysisRequested ? " -analyze" : string.Empty), out bool success, false, _env.Output);
+            (analysisRequested ? " -analyze" : string.Empty), out bool success, false, _env.Output, timeoutMilliseconds: 120_000);
         _env.Output.WriteLine(output);
         success.ShouldBeTrue();
         // The conflicting outputs warning appears - but only if analysis was requested

--- a/src/UnitTests.Shared/RunnerUtilities.cs
+++ b/src/UnitTests.Shared/RunnerUtilities.cs
@@ -57,7 +57,8 @@ namespace Microsoft.Build.UnitTests.Shared
             out bool successfulExit,
             bool shellExecute = false,
             ITestOutputHelper outputHelper = null,
-            bool attachProcessId = true)
+            bool attachProcessId = true,
+            int timeoutMilliseconds = 30_000)
         {
             BootstrapLocationAttribute attribute = Assembly.GetExecutingAssembly().GetCustomAttribute<BootstrapLocationAttribute>()
                                                    ?? throw new InvalidOperationException("This test assembly does not have the BootstrapLocationAttribute");
@@ -69,7 +70,7 @@ namespace Microsoft.Build.UnitTests.Shared
 #else
             string pathToExecutable = Path.Combine(binaryFolder, "MSBuild.exe");
 #endif
-            return RunProcessAndGetOutput(pathToExecutable, msbuildParameters, out successfulExit, shellExecute, outputHelper, attachProcessId);
+            return RunProcessAndGetOutput(pathToExecutable, msbuildParameters, out successfulExit, shellExecute, outputHelper, attachProcessId, timeoutMilliseconds);
         }
 
         private static void AdjustForShellExecution(ref string pathToExecutable, ref string arguments)
@@ -97,7 +98,8 @@ namespace Microsoft.Build.UnitTests.Shared
             out bool successfulExit,
             bool shellExecute = false,
             ITestOutputHelper outputHelper = null,
-            bool attachProcessId = true)
+            bool attachProcessId = true,
+            int timeoutMilliseconds = 30_000)
         {
             if (shellExecute)
             {
@@ -142,7 +144,7 @@ namespace Microsoft.Build.UnitTests.Shared
                 {
                     p.WaitForExit();
                 }
-                else if (!p.WaitForExit(30_000))
+                else if (!p.WaitForExit(timeoutMilliseconds))
                 {
                     // Let's not create a unit test for which we need more than 30 sec to execute.
                     // Please consider carefully if you would like to increase the timeout.


### PR DESCRIPTION
Investigation #10036

### Context
It's puzzling that the process runs for over 30 seconds. We need to observe further after increasing the timeout to see if still fails.

### Changes Made
Increase the timeout of running process for observing the tests furhter.

### Testing
N/A

### Notes
