### PR TITLE
Improve the detection from TERM value

### DIFF
--- a/src/Framework/Logging/AnsiDetector.cs
+++ b/src/Framework/Logging/AnsiDetector.cs
@@ -7,11 +7,8 @@
 // https://github.com/keqingrong/supports-ansi/blob/master/index.js
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Text.RegularExpressions;
-using System.Threading.Tasks;
 
 namespace Microsoft.Build.Framework.Logging
 {
@@ -40,7 +37,7 @@ namespace Microsoft.Build.Framework.Logging
 
         internal static bool IsAnsiSupported(string termType)
         {
-            if (string.IsNullOrWhiteSpace(termType))
+            if (string.IsNullOrEmpty(termType))
             {
                 return false;
             }

--- a/src/Framework/Logging/AnsiDetector.cs
+++ b/src/Framework/Logging/AnsiDetector.cs
@@ -1,0 +1,56 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// Portions of the code in this file were ported from the spectre.console by Patrik Svensson, Phil Scott, Nils Andresen
+// https://github.com/spectreconsole/spectre.console/blob/main/src/Spectre.Console/Internal/Backends/Ansi/AnsiDetector.cs
+// and from the supports-ansi project by Qingrong Ke
+// https://github.com/keqingrong/supports-ansi/blob/master/index.js
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+
+namespace Microsoft.Build.Framework.Logging
+{
+    internal class AnsiDetector
+    {
+        private static readonly Regex[] terminalsRegexes =
+        {
+            new("^xterm"), // xterm, PuTTY, Mintty
+            new("^rxvt"), // RXVT
+            new("^(?!eterm-color).*eterm.*"), // Accepts eterm, but not eterm-color, which does not support moving the cursor, see #9950.
+            new("^screen"), // GNU screen, tmux
+            new("tmux"), // tmux
+            new("^vt100"), // DEC VT series
+            new("^vt102"), // DEC VT series
+            new("^vt220"), // DEC VT series
+            new("^vt320"), // DEC VT series
+            new("ansi"), // ANSI
+            new("scoansi"), // SCO ANSI
+            new("cygwin"), // Cygwin, MinGW
+            new("linux"), // Linux console
+            new("konsole"), // Konsole
+            new("bvterm"), // Bitvise SSH Client
+            new("^st-256color"), // Suckless Simple Terminal, st
+            new("alacritty"), // Alacritty
+        };
+
+        internal static bool IsAnsiSupported(string termType)
+        {
+            if (string.IsNullOrWhiteSpace(termType))
+            {
+                return false;
+            }
+
+            if (terminalsRegexes.Any(regex => regex.IsMatch(termType)))
+            {
+                return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/Framework/NativeMethods.cs
+++ b/src/Framework/NativeMethods.cs
@@ -10,7 +10,7 @@ using System.IO;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
-
+using Microsoft.Build.Framework.Logging;
 using Microsoft.Build.Shared;
 using Microsoft.Win32;
 using Microsoft.Win32.SafeHandles;
@@ -1493,8 +1493,8 @@ internal static class NativeMethods
         }
         else
         {
-            // On posix OSes we expect console always supports VT100 coloring unless it is explicitly marked as "dumb".
-            acceptAnsiColorCodes = Environment.GetEnvironmentVariable("TERM") != "dumb";
+            // On posix OSes detect whether the terminal supports VT100 from the value of the TERM environment variable.
+            acceptAnsiColorCodes = AnsiDetector.IsAnsiSupported(Environment.GetEnvironmentVariable("TERM"));
             // It wasn't redirected as tested above so we assume output is screen/console
             outputIsScreen = true;
         }

--- a/src/MSBuildTaskHost/MSBuildTaskHost.csproj
+++ b/src/MSBuildTaskHost/MSBuildTaskHost.csproj
@@ -136,6 +136,9 @@
     <Compile Include="..\Framework\NativeMethods.cs">
       <Link>NativeMethodsShared.cs</Link>
     </Compile>
+    <Compile Include="..\Framework\Logging\AnsiDetector.cs">
+      <Link>AnsiDetector.cs</Link>
+    </Compile>
     <Compile Include="..\Shared\NodeBuildComplete.cs">
       <Link>NodeBuildComplete.cs</Link>
     </Compile>


### PR DESCRIPTION
Fixes #9950

### Context
Improved detection of ansi support using the "TERM" environment variable.

### Changes Made
Added the list of supported terminal types.

### Testing
Manual tests
