### PR TITLE
Expose ToolTask exit, stdout, and stderr handlers

### DIFF
--- a/src/Utilities.UnitTests/ToolTask_Tests.cs
+++ b/src/Utilities.UnitTests/ToolTask_Tests.cs
@@ -763,7 +763,7 @@ namespace Microsoft.Build.UnitTests
                 t.BuildEngine = engine;
                 t.MockCommandLineCommands = NativeMethodsShared.IsWindows
                     ? "/C echo hello_stdout & echo hello_stderr >&2"
-                    : "-c echo hello_stdout ; echo hello_stderr >&2";
+                    : "-c \"echo hello_stdout ; echo hello_stderr >&2\"";
 
                 t.Execute();
 

--- a/src/Utilities/ToolTask.cs
+++ b/src/Utilities/ToolTask.cs
@@ -1172,7 +1172,7 @@ namespace Microsoft.Build.Utilities
         /// <remarks>This method is used as a System.EventHandler delegate.</remarks>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        private void ReceiveExitNotification(object sender, EventArgs e)
+        protected void ReceiveExitNotification(object sender, EventArgs e)
         {
             ErrorUtilities.VerifyThrow(_toolExited != null,
                 "The signalling event for tool exit must be available.");
@@ -1195,7 +1195,7 @@ namespace Microsoft.Build.Utilities
         /// <remarks>This method is used as a System.Diagnostics.DataReceivedEventHandler delegate.</remarks>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        private void ReceiveStandardErrorData(object sender, DataReceivedEventArgs e) => ReceiveStandardErrorOrOutputData(e, _standardErrorData, _standardErrorDataAvailable);
+        protected void ReceiveStandardErrorData(object sender, DataReceivedEventArgs e) => ReceiveStandardErrorOrOutputData(e, _standardErrorData, _standardErrorDataAvailable);
 
         /// <summary>
         /// Queues up the output from the stdout stream of the process executing
@@ -1206,7 +1206,7 @@ namespace Microsoft.Build.Utilities
         /// <remarks>This method is used as a System.Diagnostics.DataReceivedEventHandler delegate.</remarks>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        private void ReceiveStandardOutputData(object sender, DataReceivedEventArgs e) => ReceiveStandardErrorOrOutputData(e, _standardOutputData, _standardOutputDataAvailable);
+        protected void ReceiveStandardOutputData(object sender, DataReceivedEventArgs e) => ReceiveStandardErrorOrOutputData(e, _standardOutputData, _standardOutputDataAvailable);
 
         /// <summary>
         /// Queues up the output from either the stderr or stdout stream of the


### PR DESCRIPTION
### Context

The `StartToolProcess` method added in #9649 does not allow subclasses to create and return equivalent processes because it does not have access to the exit, stdout, and stderr event handlers subscribed in the incoming `Process` object. In C# it is not possible to get the invocation list of an event outside of its declaring class.

### Changes Made

Made `ReceiveExitNotification`, `ReceiveStandardErrorData`, and `ReceiveStandardOutputData` protected to expose them to subclasses.

### Testing

A new unit test exercising the scenario.
