### PR TITLE
Fix incorrect use of GetOrAdd

### DIFF
--- a/src/Build/Evaluation/ProjectRootElementCache.cs
+++ b/src/Build/Evaluation/ProjectRootElementCache.cs
@@ -273,7 +273,7 @@ namespace Microsoft.Build.Evaluation
             try
             {
                 // We are about to load. Take a per-file lock to prevent multiple threads from duplicating the work multiple times.
-                object perFileLock = _fileLoadLocks.GetOrAdd(projectFile, () => new object());
+                object perFileLock = _fileLoadLocks.GetOrAdd(projectFile, static _ => new object());
                 lock (perFileLock)
                 {
                     // Call GetOrLoad again, this time with the OpenProjectRootElement callback.


### PR DESCRIPTION
The method `GetOrAdd` has two overloads with two arguments:

```csharp
GetOrAdd(string key, object value);
GetOrAdd(string key, Func<string, object> valueFactory);
```

The lambda here does not take an argument hence it's not compatible with `Func<string, object>`. It is compatible with `object` though because a delegate can convert to `object`.

This is problematic because there is no guarantee the delegate here is unqiue. The compiler is free to cache instantiations of delegates, particularly ones like this which capture no state. That means different keys could very well be sharing the same value.

Fixes #

### Context


### Changes Made


### Testing


### Notes
