### PR TITLE
Fix the crash in the Terminal Logger during shutdown.

### DIFF
--- a/src/MSBuild/TerminalLogger/Terminal.cs
+++ b/src/MSBuild/TerminalLogger/Terminal.cs
@@ -200,6 +200,15 @@ internal sealed class Terminal : ITerminal
     /// <inheritdoc/>
     public void Dispose()
     {
-        Console.OutputEncoding = _originalOutputEncoding;
+        try
+        {
+            Console.OutputEncoding = _originalOutputEncoding;
+        }
+        catch
+        {
+            // In some terminal emulators setting back the previous console output encoding fails.
+            // See https://github.com/dotnet/msbuild/issues/9662.
+            // We do not want to throw an exception if it happens, since it is a non-essentual failure in the logger.
+        }
     }
 }


### PR DESCRIPTION
Fixes #9662

### Context
When we use TL, we save the console output encoding to a variable, change the encoding
 to UTF8 for the logging duration and attempt to set it back to the previous value during the Terminal Logger shutdown. It fails in some terminal emulators. It seems to be either a bug of the terminal emulator or Console.OutputEncoding property.

### Changes Made
Wrapped the setting of the console output in try-catch block.

### Testing
Unit tests
