### PR TITLE
Wrap DumpExceptionToFile with try/catch for outofmemory

### DIFF
--- a/src/Shared/ExceptionHandling.cs
+++ b/src/Shared/ExceptionHandling.cs
@@ -372,9 +372,8 @@ namespace Microsoft.Build.Shared
                     }
                 }
             }
-            catch (OutOfMemoryException)
+            catch
             {
-                throw;
             }
         }
 

--- a/src/Shared/ExceptionHandling.cs
+++ b/src/Shared/ExceptionHandling.cs
@@ -374,7 +374,8 @@ namespace Microsoft.Build.Shared
             }
             
             // Some customers experience exceptions such as 'OutOfMemory' errors when msbuild attempts to log errors to a local file.
-            // This catch helps to prevent the application from crashing.
+            // This catch helps to prevent the application from crashing in this best-effort dump-diagnostics path,
+            // but doesn't prevent the overall crash from going to Watson.
             catch
             {
             }

--- a/src/Shared/ExceptionHandling.cs
+++ b/src/Shared/ExceptionHandling.cs
@@ -372,6 +372,9 @@ namespace Microsoft.Build.Shared
                     }
                 }
             }
+            
+            // Some customers experience exceptions such as 'OutOfMemory' errors when msbuild attempts to log errors to a local file.
+            // This catch helps to prevent the application from crashing.
             catch
             {
             }

--- a/src/Shared/ExceptionHandling.cs
+++ b/src/Shared/ExceptionHandling.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #nullable disable
@@ -335,39 +335,46 @@ namespace Microsoft.Build.Shared
         /// </summary>
         internal static void DumpExceptionToFile(Exception ex)
         {
-            // Locking on a type is not recommended.  However, we are doing it here to be extra cautious about compatibility because
-            //  this method previously had a [MethodImpl(MethodImplOptions.Synchronized)] attribute, which does lock on the type when
-            //  applied to a static method.
-            lock (typeof(ExceptionHandling))
+            try
             {
-                if (s_dumpFileName == null)
+                // Locking on a type is not recommended.  However, we are doing it here to be extra cautious about compatibility because
+                //  this method previously had a [MethodImpl(MethodImplOptions.Synchronized)] attribute, which does lock on the type when
+                //  applied to a static method.
+                lock (typeof(ExceptionHandling))
                 {
-                    Guid guid = Guid.NewGuid();
+                    if (s_dumpFileName == null)
+                    {
+                        Guid guid = Guid.NewGuid();
 
-                    // For some reason we get Watson buckets because GetTempPath gives us a folder here that doesn't exist.
-                    // Either because %TMP% is misdefined, or because they deleted the temp folder during the build.
-                    // If this throws, no sense catching it, we can't log it now, and we're here
-                    // because we're a child node with no console to log to, so die
-                    Directory.CreateDirectory(DebugDumpPath);
+                        // For some reason we get Watson buckets because GetTempPath gives us a folder here that doesn't exist.
+                        // Either because %TMP% is misdefined, or because they deleted the temp folder during the build.
+                        // If this throws, no sense catching it, we can't log it now, and we're here
+                        // because we're a child node with no console to log to, so die
+                        Directory.CreateDirectory(DebugDumpPath);
 
-                    var pid = Process.GetCurrentProcess().Id;
-                    // This naming pattern is assumed in ReadAnyExceptionFromFile
-                    s_dumpFileName = Path.Combine(DebugDumpPath, $"MSBuild_pid-{pid}_{guid:n}.failure.txt");
+                        var pid = Process.GetCurrentProcess().Id;
+                        // This naming pattern is assumed in ReadAnyExceptionFromFile
+                        s_dumpFileName = Path.Combine(DebugDumpPath, $"MSBuild_pid-{pid}_{guid:n}.failure.txt");
+
+                        using (StreamWriter writer = FileUtilities.OpenWrite(s_dumpFileName, append: true))
+                        {
+                            writer.WriteLine("UNHANDLED EXCEPTIONS FROM PROCESS {0}:", pid);
+                            writer.WriteLine("=====================");
+                        }
+                    }
 
                     using (StreamWriter writer = FileUtilities.OpenWrite(s_dumpFileName, append: true))
                     {
-                        writer.WriteLine("UNHANDLED EXCEPTIONS FROM PROCESS {0}:", pid);
-                        writer.WriteLine("=====================");
+                        // "G" format is, e.g., 6/15/2008 9:15:07 PM
+                        writer.WriteLine(DateTime.Now.ToString("G", CultureInfo.CurrentCulture));
+                        writer.WriteLine(ex.ToString());
+                        writer.WriteLine("===================");
                     }
                 }
-
-                using (StreamWriter writer = FileUtilities.OpenWrite(s_dumpFileName, append: true))
-                {
-                    // "G" format is, e.g., 6/15/2008 9:15:07 PM
-                    writer.WriteLine(DateTime.Now.ToString("G", CultureInfo.CurrentCulture));
-                    writer.WriteLine(ex.ToString());
-                    writer.WriteLine("===================");
-                }
+            }
+            catch (OutOfMemoryException)
+            {
+                throw;
             }
         }
 


### PR DESCRIPTION
Fixes #
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1748184

## Context
Some customers catch out of memory on our attempt to dump errors to local file.
This change prevents a crash from that.