### PR TITLE
Fix nullref exception in expander refactoring

### DIFF
--- a/src/Build/Evaluation/Conditionals/OperatorExpressionNode.cs
+++ b/src/Build/Evaluation/Conditionals/OperatorExpressionNode.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Build.Evaluation
 
         /// <inheritdoc cref="GenericExpressionNode"/>
         internal override bool IsUnexpandedValueEmpty()
-            => LeftChild.IsUnexpandedValueEmpty() && RightChild.IsUnexpandedValueEmpty();
+            => (LeftChild?.IsUnexpandedValueEmpty() ?? true) && (RightChild?.IsUnexpandedValueEmpty() ?? true);
 
         /// <summary>
         /// Value before any item and property expressions are expanded


### PR DESCRIPTION
Fixes - insertion issue

### Context

Dereferencing null can happen

```
D:\VS\src\ConfigData\BuildTargets\Microsoft.DevDiv.Common.Targets(800,5): error MSB4018: System.NullReferenceException: Object reference not set to an instance of an object. [D:\VS\src\edev\diagnostics\intellitrace\Tests\Functional\ProfilerTypeSpecTestsCodeGen\ProfilerTypeSpecTestsCodeGen.csproj]
D:\VS\src\ConfigData\BuildTargets\Microsoft.DevDiv.Common.Targets(800,5): error MSB4018:    at Microsoft.Build.Evaluation.OperatorExpressionNode.IsUnexpandedValueEmpty() [D:\VS\src\edev\diagnostics\intellitrace\Tests\Functional\ProfilerTypeSpecTestsCodeGen\ProfilerTypeSpecTestsCodeGen.csproj]
```

https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=9615450&view=logs&j=018464ba-1ca1-5561-2761-cd93078ac78a&t=3574efd9-071a-5092-469d-6ae99dc3b0cf&l=71278