### PR TITLE
Make BuildCheckForwardingLogger filter the events 

### DIFF
--- a/src/Build/BuildCheck/Infrastructure/BuildCheckConnectorLogger.cs
+++ b/src/Build/BuildCheck/Infrastructure/BuildCheckConnectorLogger.cs
@@ -12,6 +12,14 @@ using Microsoft.Build.Framework;
 
 namespace Microsoft.Build.Experimental.BuildCheck.Infrastructure;
 
+/// <summary>
+/// Central logger for the build check infrastructure.
+/// Receives events from the <see cref="BuildCheckForwardingLogger"/>.
+/// Processes the events and forwards them to the <see cref="IBuildCheckManager"/> and registered analyzers.
+/// </summary>
+/// <remarks>
+/// Ensure that the consuming events are in sync with <see cref="BuildCheckForwardingLogger"/>.
+/// </remarks>
 internal sealed class BuildCheckConnectorLogger : ILogger
 {
     private readonly Dictionary<Type, Action<BuildEventArgs>> _eventHandlers;

--- a/src/Build/BuildCheck/Infrastructure/BuildCheckForwardingLogger.cs
+++ b/src/Build/BuildCheck/Infrastructure/BuildCheckForwardingLogger.cs
@@ -48,31 +48,17 @@ internal class BuildCheckForwardingLogger : IForwardingLogger
         typeof(TaskParameterEventArgs)
     };
 
-    private bool _customAnalyzerDetected;
-
     public void Initialize(IEventSource eventSource, int nodeCount) => Initialize(eventSource);
 
     public void Initialize(IEventSource eventSource)
     {
-        _customAnalyzerDetected = false;
         eventSource.AnyEventRaised += EventSource_AnyEventRaised;
     }
 
     public void EventSource_AnyEventRaised(object sender, BuildEventArgs buildEvent)
     {
-        if (_customAnalyzerDetected)
-        {
-            BuildEventRedirector?.ForwardEvent(buildEvent);
-            return;
-        }
-
         if (_eventsToForward.Contains(buildEvent.GetType()))
         {
-            if (buildEvent is BuildCheckAcquisitionEventArgs)
-            {
-                _customAnalyzerDetected = true;
-            }
-
             BuildEventRedirector?.ForwardEvent(buildEvent);
         }
     }

--- a/src/Build/BuildCheck/Infrastructure/BuildCheckForwardingLogger.cs
+++ b/src/Build/BuildCheck/Infrastructure/BuildCheckForwardingLogger.cs
@@ -7,13 +7,75 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Build.BackEnd.Logging;
+using Microsoft.Build.Experimental.BuildCheck.Acquisition;
+using Microsoft.Build.Framework;
+using static Microsoft.Build.Experimental.BuildCheck.Infrastructure.BuildCheckManagerProvider;
 
 namespace Microsoft.Build.Experimental.BuildCheck.Infrastructure;
 
 /// <summary>
 /// Forwarding logger for the build check infrastructure.
-/// For now we jus want to forward all events, while disable verbose logging of tasks.
+/// For now we just want to forward all events that are needed for BuildCheckConnectorLogger and filter out all other.
+/// If the custom analyzer is detected, starts to unconditionally forward all events.
 /// In the future we may need more specific behavior.
 /// </summary>
-internal class BuildCheckForwardingLogger : CentralForwardingLogger
-{ }
+/// <remarks>
+/// Ensure that events filtering is in sync with <see cref="BuildCheckConnectorLogger"/>
+/// </remarks>
+internal class BuildCheckForwardingLogger : IForwardingLogger
+{
+    public IEventRedirector? BuildEventRedirector { get; set; }
+
+    public int NodeId { get; set; }
+
+    public LoggerVerbosity Verbosity { get => LoggerVerbosity.Quiet; set { return; } }
+
+    public string? Parameters { get; set; }
+
+    /// <summary>
+    /// Set of events to be forwarded to  <see cref="BuildCheckConnectorLogger"/>
+    /// </summary>
+    private HashSet<Type> _eventsToForward = new HashSet<Type>
+    {
+        typeof(ProjectEvaluationFinishedEventArgs),
+        typeof(ProjectEvaluationStartedEventArgs),
+        typeof(ProjectStartedEventArgs),
+        typeof(ProjectFinishedEventArgs),
+        typeof(BuildCheckTracingEventArgs),
+        typeof(BuildCheckAcquisitionEventArgs),
+        typeof(TaskStartedEventArgs),
+        typeof(TaskFinishedEventArgs),
+        typeof(TaskParameterEventArgs)
+    };
+
+    private bool _customAnalyzerDetected;
+
+    public void Initialize(IEventSource eventSource, int nodeCount) => Initialize(eventSource);
+
+    public void Initialize(IEventSource eventSource)
+    {
+        _customAnalyzerDetected = false;
+        eventSource.AnyEventRaised += EventSource_AnyEventRaised;
+    }
+
+    public void EventSource_AnyEventRaised(object sender, BuildEventArgs buildEvent)
+    {
+        if (_customAnalyzerDetected)
+        {
+            BuildEventRedirector?.ForwardEvent(buildEvent);
+            return;
+        }
+
+        if (_eventsToForward.Contains(buildEvent.GetType()))
+        {
+            if (buildEvent is BuildCheckAcquisitionEventArgs)
+            {
+                _customAnalyzerDetected = true;
+            }
+
+            BuildEventRedirector?.ForwardEvent(buildEvent);
+        }
+    }
+
+    public void Shutdown() { }
+}


### PR DESCRIPTION
Fixes #10068

### Context
Currently BuildCheckForwardingLogger does not filter out any of the events, which results in extra perf owerhead.

### Changes Made
Made BuildCheckForwardingLogger filter out the events that are not used in BuildCheckConnectorLogger.

### Testing
Unit tests & manual runs 