### PR TITLE
Implement adaptive node timeout

### DIFF
--- a/src/Build/BackEnd/Components/Communications/NodeEndpointOutOfProc.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeEndpointOutOfProc.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using Microsoft.Build.Internal;
 using Microsoft.Build.Shared;
 
@@ -18,9 +19,11 @@ namespace Microsoft.Build.BackEnd
         /// <summary>
         /// Instantiates an endpoint to act as a client.
         /// </summary>
+        /// <param name="nodeHostStartTime">The time when a node in this process first started.</param>
         /// <param name="enableReuse">Whether this node may be reused for a later build.</param>
         /// <param name="lowPriority">Whether this node is low priority.</param>
-        internal NodeEndpointOutOfProc(bool enableReuse, bool lowPriority)
+        internal NodeEndpointOutOfProc(DateTime nodeHostStartTime, bool enableReuse, bool lowPriority)
+            : base(nodeHostStartTime)
         {
             _enableReuse = enableReuse;
             LowPriority = lowPriority;

--- a/src/Build/BackEnd/Components/Communications/NodeProviderInProc.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderInProc.cs
@@ -392,7 +392,7 @@ namespace Microsoft.Build.BackEnd
 
             _inProcNodeEndpoint.Connect(this);
 
-            int connectionTimeout = CommunicationsUtilities.NodeConnectionTimeout;
+            int connectionTimeout = CommunicationsUtilities.MaximumNodeConnectionTimeout;
             bool connected = _endpointConnectedEvent.WaitOne(connectionTimeout);
             ErrorUtilities.VerifyThrow(connected, "In-proc node failed to start up within {0}ms", connectionTimeout);
             return true;

--- a/src/Build/BackEnd/Node/OutOfProcNode.cs
+++ b/src/Build/BackEnd/Node/OutOfProcNode.cs
@@ -222,7 +222,7 @@ namespace Microsoft.Build.Execution
         /// <returns>The reason for shutting down.</returns>
         public NodeEngineShutdownReason Run(out Exception shutdownException)
         {
-            return Run(false, false, out shutdownException);
+            return Run(DateTime.UtcNow, false, false, out shutdownException);
         }
 
         /// <summary>
@@ -234,19 +234,20 @@ namespace Microsoft.Build.Execution
         /// <returns>The reason for shutting down.</returns>
         public NodeEngineShutdownReason Run(bool enableReuse, out Exception shutdownException)
         {
-            return Run(enableReuse, false, out shutdownException);
+            return Run(DateTime.UtcNow, enableReuse, false, out shutdownException);
         }
 
         /// <summary>
         /// Starts up the node and processes messages until the node is requested to shut down.
         /// </summary>
+        /// <param name="nodeHostStartTime">The time when a node in this process first started.</param>
         /// <param name="enableReuse">Whether this node is eligible for reuse later.</param>
         /// <param name="lowPriority">Whether this node should be running with low priority.</param>
         /// <param name="shutdownException">The exception which caused shutdown, if any.</param>
         /// <returns>The reason for shutting down.</returns>
-        public NodeEngineShutdownReason Run(bool enableReuse, bool lowPriority, out Exception shutdownException)
+        public NodeEngineShutdownReason Run(DateTime nodeHostStartTime, bool enableReuse, bool lowPriority, out Exception shutdownException)
         {
-            _nodeEndpoint = new NodeEndpointOutOfProc(enableReuse, lowPriority);
+            _nodeEndpoint = new NodeEndpointOutOfProc(nodeHostStartTime, enableReuse, lowPriority);
             _nodeEndpoint.OnLinkStatusChanged += OnLinkStatusChanged;
             _nodeEndpoint.Listen(this);
 

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -3356,6 +3356,8 @@ namespace Microsoft.Build.CommandLine
                 CommandLineSwitchException.VerifyThrow(nodeModeNumber >= 0, "InvalidNodeNumberValueIsNegative", input[0]);
             }
 
+            DateTime startTime = DateTime.UtcNow;
+
             bool restart = true;
             while (restart)
             {
@@ -3368,7 +3370,7 @@ namespace Microsoft.Build.CommandLine
                     // If FEATURE_NODE_REUSE is OFF, just validates that the switch is OK, and always returns False
                     bool nodeReuse = ProcessNodeReuseSwitch(commandLineSwitches[CommandLineSwitches.ParameterizedSwitch.NodeReuse]);
                     OutOfProcNode node = new OutOfProcNode();
-                    shutdownReason = node.Run(nodeReuse, lowpriority, out nodeException);
+                    shutdownReason = node.Run(startTime, nodeReuse, lowpriority, out nodeException);
 
                     FileUtilities.ClearCacheDirectory();
                 }

--- a/src/Shared/CommunicationsUtilities.cs
+++ b/src/Shared/CommunicationsUtilities.cs
@@ -203,9 +203,14 @@ namespace Microsoft.Build.Internal
         internal const byte handshakeVersion = 0x01;
 
         /// <summary>
-        /// The timeout to connect to a node.
+        /// The timeout to connect to a node. Also the timeout to wait before shutting down an idle node (upper bound).
         /// </summary>
-        private const int DefaultNodeConnectionTimeout = 900 * 1000; // 15 minutes; enough time that a dev will typically do another build in this time
+        private const int DefaultMaximumNodeConnectionTimeout = 900 * 1000; // 15 minutes; enough time that a dev will typically do another build in this time
+
+        /// <summary>
+        /// The timeout to wait before shutting down an idle node (lower bound).
+        /// </summary>
+        private const int DefaultMinimumNodeConnectionTimeout = 60 * 1000; // 1 minute; to not make the process linger for too long after an isolated build
 
         /// <summary>
         /// Whether to trace communications
@@ -233,11 +238,19 @@ namespace Microsoft.Build.Internal
         internal delegate void LogDebugCommunications(string format, params object[] stuff);
 
         /// <summary>
-        /// Gets or sets the node connection timeout.
+        /// Gets the maximum node connection timeout.
         /// </summary>
-        internal static int NodeConnectionTimeout
+        internal static int MaximumNodeConnectionTimeout
         {
-            get { return GetIntegerVariableOrDefault("MSBUILDNODECONNECTIONTIMEOUT", DefaultNodeConnectionTimeout); }
+            get { return GetIntegerVariableOrDefault("MSBUILDNODECONNECTIONTIMEOUT", DefaultMaximumNodeConnectionTimeout); }
+        }
+
+        /// <summary>
+        /// Gets the minimum node connection timeout.
+        /// </summary>
+        internal static int MinimumNodeConnectionTimeout
+        {
+            get { return GetIntegerVariableOrDefault("MSBUILDMINNODECONNECTIONTIMEOUT", DefaultMinimumNodeConnectionTimeout); }
         }
 
 #if NETFRAMEWORK


### PR DESCRIPTION
Contributes to #9922

### Context

MSBuild currently uses a fixed timeout of 15 minutes, after which idle nodes shut themselves down. This works well for cases where the build is invoked repeatedly and the nodes stay alive for a long time. However, for one-off builds the timeout may be perceived as excessive.

### Changes Made

This PR makes the timeout "adaptive". We assume that the process is expected to live for about double it's current up time, meaning that the timeout automatically increases as the node is processing build requests. For example, if the process has been running for 5 minutes, we set the timeout for 5 minutes.

The default maximum timeout is 15 minutes and the default minimum timeout is 1 minute. Both can be overridden with environment variables.

### Testing

Manual verification.
