### PR TITLE
Write output from tests

### DIFF
--- a/src/MSBuild/TerminalLogger/TerminalLogger.cs
+++ b/src/MSBuild/TerminalLogger/TerminalLogger.cs
@@ -398,14 +398,14 @@ internal sealed partial class TerminalLogger : INodeLogger
 
         Terminal.BeginUpdate();
         try
-        { 
+        {
             if (Verbosity > LoggerVerbosity.Quiet)
             {
                 string duration = (e.Timestamp - _buildStartTime).TotalSeconds.ToString("F1");
                 string buildResult = RenderBuildResult(e.Succeeded, _buildErrorsCount, _buildWarningsCount);
 
                 Terminal.WriteLine("");
-                if(_testRunSummaries.Any())
+                if (_testRunSummaries.Any())
                 {
                     var total = _testRunSummaries.Sum(t => t.Total);
                     var failed = _testRunSummaries.Sum(t => t.Failed);
@@ -864,7 +864,16 @@ internal sealed partial class TerminalLogger : INodeLogger
                                             : e.Timestamp > _testEndTime
                                                 ? e.Timestamp : _testEndTime;
                                 }
-                                
+
+                                break;
+                            }
+
+                        case "TLTESTOUTPUT":
+                            {
+                                if (e.Message != null && Verbosity > LoggerVerbosity.Quiet)
+                                {
+                                    RenderImmediateMessage(e.Message);
+                                }
                                 break;
                             }
                     }
@@ -936,7 +945,7 @@ internal sealed partial class TerminalLogger : INodeLogger
     private void ErrorRaised(object sender, BuildErrorEventArgs e)
     {
         BuildEventContext? buildEventContext = e.BuildEventContext;
-        
+
         if (buildEventContext is not null
             && _projects.TryGetValue(new ProjectContext(buildEventContext), out Project? project)
             && Verbosity > LoggerVerbosity.Quiet)
@@ -951,7 +960,7 @@ internal sealed partial class TerminalLogger : INodeLogger
         }
     }
 
-#endregion
+    #endregion
 
     #region Refresher thread implementation
 


### PR DESCRIPTION
### Context

Both VSTest and testing frameworks (especially xunit) write additional information to screen. Either by writing to console, or by sending Test messages. 

Until now users cannot see the messages on screen which degrades the experience to them. 

This includes not being able to see discovered tests when `--list-tests` is used, or not being able to see output written by tests. 

### Changes Made
Adds a test specific message type that we can use to write an immediate message. This is probably not the best fit, but it is the most unified with what is existing on TL right now.

### Testing
No new tests, I am leaning on what is already there.

### Notes
This is how it looks like when someone has few tests written in MSTest and Xunit. 

![msbuild_output](https://github.com/dotnet/msbuild/assets/5735905/adf857cb-b185-47d7-916e-ba6c1654d233)

