### PR TITLE
unGAC stringtools

### DIFF
--- a/documentation/wiki/UnGAC.md
+++ b/documentation/wiki/UnGAC.md
@@ -20,6 +20,10 @@ Run the [EnumerateMSBuild powershell script](https://github.com/dotnet/msbuild/b
     gacutil /u "Microsoft.Build.Tasks.Core, Version=15.1.0.0"
     gacutil /u "Microsoft.Build.Utilities.Core, Version=15.1.0.0"
     gacutil /u "Microsoft.Build.Framework, Version=15.1.0.0"
+    gacutil /u "Microsoft.NET.StringTools, Version=1.0.0.0"
+    gacutil /u "BuildXL.Processes, Version=1.0.0.0"
+    gacutil /u "BuildXL.Utilities.Core, Version=1.0.0.0"
+    gacutil /u "BuildXL.Native, Version=1.0.0.0"
     ```
 3. If you want to do this 'safely', move the folder out of the GAC and return it if it doesn't resolve the issue.
 

--- a/src/Package/Microsoft.Build.UnGAC/Program.cs
+++ b/src/Package/Microsoft.Build.UnGAC/Program.cs
@@ -26,7 +26,11 @@ namespace Microsoft.Build.UnGAC
                     "Microsoft.Build.Framework, Version=15.1.0.0",
                     "Microsoft.Build.Tasks.Core, Version=15.1.0.0",
                     "Microsoft.Build.Utilities.Core, Version=15.1.0.0",
-                    "Microsoft.Build.Conversion.Core, Version=15.1.0.0"
+                    "Microsoft.Build.Conversion.Core, Version=15.1.0.0",
+                    "Microsoft.NET.StringTools, Version=1.0.0.0",
+                    "BuildXL.Processes, Version=1.0.0.0",
+                    "BuildXL.Utilities.Core, Version=1.0.0.0",
+                    "BuildXL.Native, Version=1.0.0.0"
                 };
 
                 uint hresult = NativeMethods.CreateAssemblyCache(out IAssemblyCache assemblyCache, 0);


### PR DESCRIPTION
Fixes [AB#2065921
](https://dev.azure.com/devdiv/DevDiv/_workitems/edit/2065921)

### Context
There was a customer case where StringTools turned out to be GACed. Since they are of a fixed version they are unsuitable for GAC-ing. So let's proactively clear in case anybody GACed them manually.
Same applies for BuildXL binaries.

