### PR TITLE
Dispose FileStream in ProjectInSolution and SolutionFile

### DIFF
--- a/src/Build/Construction/Solution/ProjectInSolution.cs
+++ b/src/Build/Construction/Solution/ProjectInSolution.cs
@@ -302,7 +302,7 @@ namespace Microsoft.Build.Construction
                 var xrSettings = new XmlReaderSettings { DtdProcessing = DtdProcessing.Ignore, CloseInput = true };
                 var projectDocument = new XmlDocument();
 
-                FileStream fs = File.OpenRead(AbsolutePath);
+                using (FileStream fs = File.OpenRead(AbsolutePath))
                 using (XmlReader xmlReader = XmlReader.Create(fs, xrSettings))
                 {
                     // Load the project file and get the first node

--- a/src/Build/Construction/Solution/SolutionFile.cs
+++ b/src/Build/Construction/Solution/SolutionFile.cs
@@ -891,7 +891,7 @@ namespace Microsoft.Build.Construction
                 var readerSettings = new XmlReaderSettings { DtdProcessing = DtdProcessing.Ignore, CloseInput = true };
 
                 // Load the .etp project file thru the XML reader
-                FileStream fs = File.OpenRead(fullPathToEtpProj);
+                using (FileStream fs = File.OpenRead(fullPathToEtpProj))
                 using (XmlReader xmlReader = XmlReader.Create(fs, readerSettings))
                 {
                     etpProjectDocument.Load(xmlReader);


### PR DESCRIPTION
The docs on XmlReader.Create() aren't clear about what happens to the supplied Stream and whether it's Dispose()d on XmlReader.Dispose(). So lets Dispose it explicitly.
