### PR TITLE
Add binlog message in case of failure to add embedded file

### DIFF
--- a/src/Build/Logging/BinaryLogger/BinaryLogger.cs
+++ b/src/Build/Logging/BinaryLogger/BinaryLogger.cs
@@ -188,6 +188,7 @@ namespace Microsoft.Build.Logging
                 if (CollectProjectImports != ProjectImportsCollectionMode.None && replayEventSource == null)
                 {
                     projectImportsCollector = new ProjectImportsCollector(FilePath, CollectProjectImports == ProjectImportsCollectionMode.ZipFile);
+                    projectImportsCollector.FileIOExceptionEvent += EventSource_AnyEventRaised;
                 }
 
                 if (eventSource is IEventSource3 eventSource3)
@@ -320,6 +321,7 @@ namespace Microsoft.Build.Logging
                     projectImportsCollector.DeleteArchive();
                 }
 
+                projectImportsCollector.FileIOExceptionEvent -= EventSource_AnyEventRaised;
                 projectImportsCollector = null;
             }
 

--- a/src/Build/Logging/BinaryLogger/ProjectImportsCollector.cs
+++ b/src/Build/Logging/BinaryLogger/ProjectImportsCollector.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.IO.Compression;
 using System.Text;
 using System.Threading.Tasks;
+using Microsoft.Build.BackEnd;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
 using Microsoft.Build.Shared.FileSystem;
@@ -147,7 +148,7 @@ namespace Microsoft.Build.Logging
                 }
                 catch (Exception e) when (ExceptionHandling.IsIoRelatedException(e))
                 {
-                    InvokeFileIOErrorEvent(filePath, e.ToString());
+                    InvokeFileIOErrorEvent(filePath, TaskLoggingHelper.GetInnerExceptionMessageString(e));
                 }
 
                 return false;

--- a/src/Build/Logging/BinaryLogger/ProjectImportsCollector.cs
+++ b/src/Build/Logging/BinaryLogger/ProjectImportsCollector.cs
@@ -147,7 +147,7 @@ namespace Microsoft.Build.Logging
                 }
                 catch (Exception e) when (ExceptionHandling.IsIoRelatedException(e))
                 {
-                    InvokeFileIOErrorEvent(filePath, e.Message);
+                    InvokeFileIOErrorEvent(filePath, e.ToString());
                 }
 
                 return false;

--- a/src/Build/Logging/BinaryLogger/ProjectImportsCollector.cs
+++ b/src/Build/Logging/BinaryLogger/ProjectImportsCollector.cs
@@ -142,10 +142,10 @@ namespace Microsoft.Build.Logging
             {
                 try
                 {
-                    addFileWorker(filePath); 
+                    addFileWorker(filePath);
                     return true;
                 }
-                catch (Exception e)
+                catch (Exception e) when (ExceptionHandling.IsIoRelatedException(e))
                 {
                     InvokeFileIOErrorEvent(filePath, e.Message);
                 }
@@ -169,7 +169,8 @@ namespace Microsoft.Build.Logging
             using FileStream content = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read | FileShare.Delete);
             AddFileData(filePath, content, null);
         }
-        private void InvokeFileIOErrorEvent( string filePath,string message)
+
+        private void InvokeFileIOErrorEvent(string filePath, string message)
         {
             BuildEventArgs args = new BuildMessageEventArgs(
                 ResourceUtilities.FormatResourceStringIgnoreCodeAndKeyword("ProjectImportsCollectorFileIOFail", filePath, message),

--- a/src/Build/Logging/BinaryLogger/ProjectImportsCollector.cs
+++ b/src/Build/Logging/BinaryLogger/ProjectImportsCollector.cs
@@ -174,8 +174,8 @@ namespace Microsoft.Build.Logging
         {
             BuildEventArgs args = new BuildMessageEventArgs(
                 ResourceUtilities.FormatResourceStringIgnoreCodeAndKeyword("ProjectImportsCollectorFileIOFail", filePath, message),
-                null,
-                nameof(ProjectImportsCollector),
+                helpKeyword: null,
+                senderName: nameof(ProjectImportsCollector),
                 MessageImportance.Low);
             FileIOExceptionEvent?.Invoke(this, args);
         }

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -2122,7 +2122,7 @@ Utilization:          {0} Average Utilization: {1:###.0}</value>
     <value>Task assembly was loaded from '{0}' while the desired location was '{1}'.</value>
   </data>
   <data name="ProjectImportsCollectorFileIOFail" xml:space="preserve">
-    <value>An exception occured when reading file {0}, message: {1}</value>
+    <value>An exception occurred when adding the file '{0}', Exception: '{1}'</value>
   </data>
   <!--
         The Build message bucket is: MSB4000 - MSB4999

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -2121,6 +2121,9 @@ Utilization:          {0} Average Utilization: {1:###.0}</value>
   <data name="TaskAssemblyLocationMismatch" xml:space="preserve">
     <value>Task assembly was loaded from '{0}' while the desired location was '{1}'.</value>
   </data>
+  <data name="ProjectImportsCollectorFileIOFail" xml:space="preserve">
+    <value>An exception occured when reading file {0}, message: {1}</value>
+  </data>
   <!--
         The Build message bucket is: MSB4000 - MSB4999
 

--- a/src/Build/Resources/xlf/Strings.cs.xlf
+++ b/src/Build/Resources/xlf/Strings.cs.xlf
@@ -515,8 +515,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectImportsCollectorFileIOFail">
-        <source>An exception occured when reading file {0}, message: {1}</source>
-        <target state="new">An exception occured when reading file {0}, message: {1}</target>
+        <source>An exception occurred when adding the file '{0}', Exception: '{1}'</source>
+        <target state="new">An exception occurred when adding the file '{0}', Exception: '{1}'</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertyAssignment">

--- a/src/Build/Resources/xlf/Strings.cs.xlf
+++ b/src/Build/Resources/xlf/Strings.cs.xlf
@@ -514,6 +514,11 @@
         <target state="translated">{1} neimportoval projekt {0} v ({2},{3}), protože se výraz vyhodnocuje na prázdný řetězec.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectImportsCollectorFileIOFail">
+        <source>An exception occured when reading file {0}, message: {1}</source>
+        <target state="new">An exception occured when reading file {0}, message: {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropertyAssignment">
         <source>Property initial value: $({0})="{1}" Source: {2}</source>
         <target state="translated">Počáteční hodnota vlastnosti: $({0})={1} Zdroj: {2}</target>

--- a/src/Build/Resources/xlf/Strings.de.xlf
+++ b/src/Build/Resources/xlf/Strings.de.xlf
@@ -515,8 +515,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectImportsCollectorFileIOFail">
-        <source>An exception occured when reading file {0}, message: {1}</source>
-        <target state="new">An exception occured when reading file {0}, message: {1}</target>
+        <source>An exception occurred when adding the file '{0}', Exception: '{1}'</source>
+        <target state="new">An exception occurred when adding the file '{0}', Exception: '{1}'</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertyAssignment">

--- a/src/Build/Resources/xlf/Strings.de.xlf
+++ b/src/Build/Resources/xlf/Strings.de.xlf
@@ -514,6 +514,11 @@
         <target state="translated">Das Projekt "{0}" wurde nicht von "{1}" bei ({2},{3}) importiert, weil der Ausdruck in eine leere Zeichenfolge ausgewertet wurde.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectImportsCollectorFileIOFail">
+        <source>An exception occured when reading file {0}, message: {1}</source>
+        <target state="new">An exception occured when reading file {0}, message: {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropertyAssignment">
         <source>Property initial value: $({0})="{1}" Source: {2}</source>
         <target state="translated">Anfangswert der Eigenschaft: $({0})="{1}", Quelle: {2}</target>

--- a/src/Build/Resources/xlf/Strings.es.xlf
+++ b/src/Build/Resources/xlf/Strings.es.xlf
@@ -515,8 +515,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectImportsCollectorFileIOFail">
-        <source>An exception occured when reading file {0}, message: {1}</source>
-        <target state="new">An exception occured when reading file {0}, message: {1}</target>
+        <source>An exception occurred when adding the file '{0}', Exception: '{1}'</source>
+        <target state="new">An exception occurred when adding the file '{0}', Exception: '{1}'</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertyAssignment">

--- a/src/Build/Resources/xlf/Strings.es.xlf
+++ b/src/Build/Resources/xlf/Strings.es.xlf
@@ -514,6 +514,11 @@
         <target state="translated">"{1}" no importó el proyecto "{0}" en ({2},{3}) porque la expresión se evalúa en una cadena vacía.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectImportsCollectorFileIOFail">
+        <source>An exception occured when reading file {0}, message: {1}</source>
+        <target state="new">An exception occured when reading file {0}, message: {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropertyAssignment">
         <source>Property initial value: $({0})="{1}" Source: {2}</source>
         <target state="translated">Valor inicial de la propiedad: $({0})="{1}" Origen: {2}</target>

--- a/src/Build/Resources/xlf/Strings.fr.xlf
+++ b/src/Build/Resources/xlf/Strings.fr.xlf
@@ -515,8 +515,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectImportsCollectorFileIOFail">
-        <source>An exception occured when reading file {0}, message: {1}</source>
-        <target state="new">An exception occured when reading file {0}, message: {1}</target>
+        <source>An exception occurred when adding the file '{0}', Exception: '{1}'</source>
+        <target state="new">An exception occurred when adding the file '{0}', Exception: '{1}'</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertyAssignment">

--- a/src/Build/Resources/xlf/Strings.fr.xlf
+++ b/src/Build/Resources/xlf/Strings.fr.xlf
@@ -514,6 +514,11 @@
         <target state="translated">Le projet "{0}" n'a pas été importé par "{1}" sur ({2},{3}), car l'expression a la valeur d'une chaîne vide.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectImportsCollectorFileIOFail">
+        <source>An exception occured when reading file {0}, message: {1}</source>
+        <target state="new">An exception occured when reading file {0}, message: {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropertyAssignment">
         <source>Property initial value: $({0})="{1}" Source: {2}</source>
         <target state="translated">Valeur initiale de la propriété : $({0})="{1}" Source : {2}</target>

--- a/src/Build/Resources/xlf/Strings.it.xlf
+++ b/src/Build/Resources/xlf/Strings.it.xlf
@@ -515,8 +515,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectImportsCollectorFileIOFail">
-        <source>An exception occured when reading file {0}, message: {1}</source>
-        <target state="new">An exception occured when reading file {0}, message: {1}</target>
+        <source>An exception occurred when adding the file '{0}', Exception: '{1}'</source>
+        <target state="new">An exception occurred when adding the file '{0}', Exception: '{1}'</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertyAssignment">

--- a/src/Build/Resources/xlf/Strings.it.xlf
+++ b/src/Build/Resources/xlf/Strings.it.xlf
@@ -514,6 +514,11 @@
         <target state="translated">Il progetto "{0}" non è stato importato da "{1}" alla posizione ({2},{3}) perché l'espressione restituisce una stringa vuota.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectImportsCollectorFileIOFail">
+        <source>An exception occured when reading file {0}, message: {1}</source>
+        <target state="new">An exception occured when reading file {0}, message: {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropertyAssignment">
         <source>Property initial value: $({0})="{1}" Source: {2}</source>
         <target state="translated">Valore iniziale della proprietà: $({0})="{1}". Origine: {2}</target>

--- a/src/Build/Resources/xlf/Strings.ja.xlf
+++ b/src/Build/Resources/xlf/Strings.ja.xlf
@@ -515,8 +515,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectImportsCollectorFileIOFail">
-        <source>An exception occured when reading file {0}, message: {1}</source>
-        <target state="new">An exception occured when reading file {0}, message: {1}</target>
+        <source>An exception occurred when adding the file '{0}', Exception: '{1}'</source>
+        <target state="new">An exception occurred when adding the file '{0}', Exception: '{1}'</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertyAssignment">

--- a/src/Build/Resources/xlf/Strings.ja.xlf
+++ b/src/Build/Resources/xlf/Strings.ja.xlf
@@ -514,6 +514,11 @@
         <target state="translated">式の評価結果が空の文字列になったため、プロジェクト "{0}" は "{1}" によって ({2},{3}) でインポートされませんでした。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectImportsCollectorFileIOFail">
+        <source>An exception occured when reading file {0}, message: {1}</source>
+        <target state="new">An exception occured when reading file {0}, message: {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropertyAssignment">
         <source>Property initial value: $({0})="{1}" Source: {2}</source>
         <target state="translated">プロパティの初期値: $({0})="{1}" ソース: {2}</target>

--- a/src/Build/Resources/xlf/Strings.ko.xlf
+++ b/src/Build/Resources/xlf/Strings.ko.xlf
@@ -515,8 +515,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectImportsCollectorFileIOFail">
-        <source>An exception occured when reading file {0}, message: {1}</source>
-        <target state="new">An exception occured when reading file {0}, message: {1}</target>
+        <source>An exception occurred when adding the file '{0}', Exception: '{1}'</source>
+        <target state="new">An exception occurred when adding the file '{0}', Exception: '{1}'</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertyAssignment">

--- a/src/Build/Resources/xlf/Strings.ko.xlf
+++ b/src/Build/Resources/xlf/Strings.ko.xlf
@@ -514,6 +514,11 @@
         <target state="translated">빈 문자열로 평가되는 식 때문에 ({2},{3})의 "{1}"이(가) 프로젝트 "{0}"을(를) 가져오지 않았습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectImportsCollectorFileIOFail">
+        <source>An exception occured when reading file {0}, message: {1}</source>
+        <target state="new">An exception occured when reading file {0}, message: {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropertyAssignment">
         <source>Property initial value: $({0})="{1}" Source: {2}</source>
         <target state="translated">속성 초기 값: $({0})="{1}" 소스: {2}</target>

--- a/src/Build/Resources/xlf/Strings.pl.xlf
+++ b/src/Build/Resources/xlf/Strings.pl.xlf
@@ -515,8 +515,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectImportsCollectorFileIOFail">
-        <source>An exception occured when reading file {0}, message: {1}</source>
-        <target state="new">An exception occured when reading file {0}, message: {1}</target>
+        <source>An exception occurred when adding the file '{0}', Exception: '{1}'</source>
+        <target state="new">An exception occurred when adding the file '{0}', Exception: '{1}'</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertyAssignment">

--- a/src/Build/Resources/xlf/Strings.pl.xlf
+++ b/src/Build/Resources/xlf/Strings.pl.xlf
@@ -514,6 +514,11 @@
         <target state="translated">Projekt „{0}” nie został zaimportowany przez projekt „{1}” o ({2},{3}) z powodu wyrażenia ocenianego jako pusty ciąg.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectImportsCollectorFileIOFail">
+        <source>An exception occured when reading file {0}, message: {1}</source>
+        <target state="new">An exception occured when reading file {0}, message: {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropertyAssignment">
         <source>Property initial value: $({0})="{1}" Source: {2}</source>
         <target state="translated">Wartość początkowa właściwości: $({0})=„{1}” Źródło: {2}</target>

--- a/src/Build/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Build/Resources/xlf/Strings.pt-BR.xlf
@@ -515,8 +515,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectImportsCollectorFileIOFail">
-        <source>An exception occured when reading file {0}, message: {1}</source>
-        <target state="new">An exception occured when reading file {0}, message: {1}</target>
+        <source>An exception occurred when adding the file '{0}', Exception: '{1}'</source>
+        <target state="new">An exception occurred when adding the file '{0}', Exception: '{1}'</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertyAssignment">

--- a/src/Build/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Build/Resources/xlf/Strings.pt-BR.xlf
@@ -514,6 +514,11 @@
         <target state="translated">O projeto "{0}" não foi importado por "{1}" em ({2},{3}), porque a expressão foi avaliada como uma cadeia de caracteres vazia.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectImportsCollectorFileIOFail">
+        <source>An exception occured when reading file {0}, message: {1}</source>
+        <target state="new">An exception occured when reading file {0}, message: {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropertyAssignment">
         <source>Property initial value: $({0})="{1}" Source: {2}</source>
         <target state="translated">Valor inicial da propriedade: $({0})="{1}" Origem: {2}</target>

--- a/src/Build/Resources/xlf/Strings.ru.xlf
+++ b/src/Build/Resources/xlf/Strings.ru.xlf
@@ -515,8 +515,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectImportsCollectorFileIOFail">
-        <source>An exception occured when reading file {0}, message: {1}</source>
-        <target state="new">An exception occured when reading file {0}, message: {1}</target>
+        <source>An exception occurred when adding the file '{0}', Exception: '{1}'</source>
+        <target state="new">An exception occurred when adding the file '{0}', Exception: '{1}'</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertyAssignment">

--- a/src/Build/Resources/xlf/Strings.ru.xlf
+++ b/src/Build/Resources/xlf/Strings.ru.xlf
@@ -514,6 +514,11 @@
         <target state="translated">Проект "{0}" не был импортирован "{1}" в ({2},{3}), так как результатом вычисления выражения была пустая строка.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectImportsCollectorFileIOFail">
+        <source>An exception occured when reading file {0}, message: {1}</source>
+        <target state="new">An exception occured when reading file {0}, message: {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropertyAssignment">
         <source>Property initial value: $({0})="{1}" Source: {2}</source>
         <target state="translated">Начальное значение свойства: $({0})="{1}" Источник: {2}</target>

--- a/src/Build/Resources/xlf/Strings.tr.xlf
+++ b/src/Build/Resources/xlf/Strings.tr.xlf
@@ -514,6 +514,11 @@
         <target state="translated">"{0}" adlı proje, ifadenin boş dize olarak değerlendirilmesi nedeniyle ({2},{3}) konumundaki "{1}" tarafından içeri aktarılmadı.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectImportsCollectorFileIOFail">
+        <source>An exception occured when reading file {0}, message: {1}</source>
+        <target state="new">An exception occured when reading file {0}, message: {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropertyAssignment">
         <source>Property initial value: $({0})="{1}" Source: {2}</source>
         <target state="translated">Özellik başlangıç değeri: $({0})="{1}" Kaynak: {2}</target>

--- a/src/Build/Resources/xlf/Strings.tr.xlf
+++ b/src/Build/Resources/xlf/Strings.tr.xlf
@@ -515,8 +515,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectImportsCollectorFileIOFail">
-        <source>An exception occured when reading file {0}, message: {1}</source>
-        <target state="new">An exception occured when reading file {0}, message: {1}</target>
+        <source>An exception occurred when adding the file '{0}', Exception: '{1}'</source>
+        <target state="new">An exception occurred when adding the file '{0}', Exception: '{1}'</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertyAssignment">

--- a/src/Build/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hans.xlf
@@ -514,6 +514,11 @@
         <target state="translated">由于表达式评估为空字符串，因此项目“{0}”不由 ({2}、{3}) 处的“{1}”导入。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectImportsCollectorFileIOFail">
+        <source>An exception occured when reading file {0}, message: {1}</source>
+        <target state="new">An exception occured when reading file {0}, message: {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropertyAssignment">
         <source>Property initial value: $({0})="{1}" Source: {2}</source>
         <target state="translated">属性初始值: $({0})=“{1}”，源: {2}</target>

--- a/src/Build/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hans.xlf
@@ -515,8 +515,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectImportsCollectorFileIOFail">
-        <source>An exception occured when reading file {0}, message: {1}</source>
-        <target state="new">An exception occured when reading file {0}, message: {1}</target>
+        <source>An exception occurred when adding the file '{0}', Exception: '{1}'</source>
+        <target state="new">An exception occurred when adding the file '{0}', Exception: '{1}'</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertyAssignment">

--- a/src/Build/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hant.xlf
@@ -514,6 +514,11 @@
         <target state="translated">因為運算式評估為空字串，所以專案 "{0}" 未在 ({2},{3}) 由 "{1}" 匯入。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectImportsCollectorFileIOFail">
+        <source>An exception occured when reading file {0}, message: {1}</source>
+        <target state="new">An exception occured when reading file {0}, message: {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropertyAssignment">
         <source>Property initial value: $({0})="{1}" Source: {2}</source>
         <target state="translated">屬性初始值: $({0})="{1}" 來源: {2}</target>

--- a/src/Build/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hant.xlf
@@ -515,8 +515,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectImportsCollectorFileIOFail">
-        <source>An exception occured when reading file {0}, message: {1}</source>
-        <target state="new">An exception occured when reading file {0}, message: {1}</target>
+        <source>An exception occurred when adding the file '{0}', Exception: '{1}'</source>
+        <target state="new">An exception occurred when adding the file '{0}', Exception: '{1}'</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertyAssignment">


### PR DESCRIPTION
Fixes #9450

### Context
in #9307 an empty catch was added in ProjectImportsCollector.cs

### Changes Made
create an event that adds a low priority message if an exception occurs there

### Testing
an exception in that place occurs only if weird things are happening with the files (e.g. they are edited while read)
did not manage to create an end-to-end test
looking for ideas to make an unit test

### Notes
