### PR TITLE
Use documented item group in FindInvalidProjectReferences

### DIFF
--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -2736,7 +2736,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
      <FindInvalidProjectReferences
          TargetPlatformVersion="$(TargetPlatformVersion)"
          TargetPlatformIdentifier="$(TargetPlatformIdentifier)"
-         ProjectReferences="@(TargetPathWithTargetPlatformMoniker)">
+         ProjectReferences="@(_ProjectReferenceTargetPlatformMonikers)">
        <Output TaskParameter="InvalidReferences" ItemName="InvalidProjectReferences" />
      </FindInvalidProjectReferences>
 
@@ -2753,7 +2753,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       BuildInParallel="$(BuildInParallel)"
       ContinueOnError="!$(BuildingProject)"
       RemoveProperties="%(_MSBuildProjectReferenceExistent.GlobalPropertiesToRemove)$(_GlobalPropertiesToRemoveFromProjectReferences)">
-      <Output TaskParameter="TargetOutputs" ItemName="TargetPathWithTargetPlatformMoniker" />
+      <Output TaskParameter="TargetOutputs" ItemName="_ProjectReferenceTargetPlatformMonikers" />
     </MSBuild>
   </Target>
 


### PR DESCRIPTION
### Context

Today, `GetReferenceTargetPlatformMonikers` and `FindInvalidProjectReferences` use `TargetPathWithTargetPlatformMoniker` instead of the documented `_ProjectReferenceTargetPlatformMonikers` item group for the project reference gathering/validation.

This causes a violation in the ProjectReference protocol, leading to multiple items being returned from `GetTargetPath` and the default (`Build`) target. Returning multiple items from these targets can cause usability problems and unexpected behaviors.

Below is a simplified use case of the one that hit this bug:

A/A.csproj:

```xml
<Project Sdk="Microsoft.NET.Sdk">
      <PropertyGroup>
          <TargetFramework>net8.0</TargetFramework>
      </PropertyGroup>
</Project>
```

B/B.csproj:

```xml
<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
       <FindInvalidProjectReferences>true</FindInvalidProjectReferences>
       <TargetFramework>net8.0-windows10.0.22621.0</TargetFramework>
       <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
    </PropertyGroup>
   <ItemGroup>
       <ProjectReference Include="../A/A.csproj" />
   </ItemGroup>
</Project>
```

C/C.csproj

```xml
<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
       <OutputType>Exe</OutputType>
       <TargetFramework>net8.0-windows10.0.22621.0</TargetFramework>
       <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
    </PropertyGroup>
   <ItemGroup>
       <ProjectReference Include="../A/A.csproj" Aliases="A" />
       <ProjectReference Include="../B/B.csproj" Aliases="B" />
   </ItemGroup>
</Project>
```

C/Program.cs
```csharp
extern alias A; // Csc errors here with "alias not found"
                       // because the reference to B.csproj added items for A.dll and B.dll with the B alias metadata
                       // which overrode the item returned by A.csproj, the A.dll with the A alias metadata
Console.WriteLine("Hello world");
```


### Changes Made

Use the documented item group instead of reusing `TargetPathWithTargetPlatformMoniker`.

### Testing

Local hacking. I'd like to add an end-to-end test, but I'm not sure where is the best place to do so here.

### Notes

This was discovered in a project that uses the Microsoft.WindowsAppSdk, which sets `FindInvalidProjectReferences` to `true` in some scenarios.

The user was able to work around this bug by changing the order of the `ProjectReference` items in their equivalent of `C.csproj`.