### PR TITLE
Drop MSBuildTaskHost resources from ARM64

### DIFF
--- a/src/Package/GetBinPaths.Arm64.targets
+++ b/src/Package/GetBinPaths.Arm64.targets
@@ -14,11 +14,6 @@
                       Private="false"
                       ReferenceOutputAssembly="false"
                       OutputItemType="FrameworkResolvedProjectReferencePath" />
-
-    <Arm64ProjectReference Include="$(MSBuildThisFileDirectory)\..\MSBuildTaskHost\MSBuildTaskHost.csproj"
-                      SetPlatform="Platform=arm64"
-                      OutputItemType="MSBuildTaskHostArm64ResolvedProjectReferencePath"
-                      GlobalPropertiesToRemove="TargetFramework" />
   </ItemGroup>
 
   <Target Name="SetBinPathsArm64" DependsOnTargets="ResolveProjectReferences">

--- a/src/Package/GetBinPaths.Arm64.targets
+++ b/src/Package/GetBinPaths.Arm64.targets
@@ -29,8 +29,6 @@
     <PropertyGroup>
       <FrameworkBinPath>@(FrameworkResolvedProjectReferencePath->'%(RootDir)%(Directory)')</FrameworkBinPath>
       <Arm64BinPath>@(MSBuildArm64ResolvedProjectReferencePath->'%(RootDir)%(Directory)')</Arm64BinPath>
-      <MSBuildTaskHostArm64BinPath>@(MSBuildTaskHostArm64ResolvedProjectReferencePath->'%(RootDir)%(Directory)')</MSBuildTaskHostArm64BinPath>
-
     </PropertyGroup>
   </Target>
 

--- a/src/Package/MSBuild.VSSetup.Arm64/MSBuild.VSSetup.Arm64.csproj
+++ b/src/Package/MSBuild.VSSetup.Arm64/MSBuild.VSSetup.Arm64.csproj
@@ -29,7 +29,6 @@
       <SwrProperty Include="Version=$(VsixVersion)" />
       <SwrProperty Include="FrameworkBinPath=$(FrameworkBinPath)" />
       <SwrProperty Include="Arm64BinPath=$(Arm64BinPath)" />
-      <SwrProperty Include="TaskHostArm64BinPath=$(MSBuildTaskHostArm64BinPath)" />
     </ItemGroup>
   </Target>
 

--- a/src/Package/MSBuild.VSSetup.Arm64/files.arm64.swr
+++ b/src/Package/MSBuild.VSSetup.Arm64/files.arm64.swr
@@ -54,76 +54,63 @@ folder InstallDir:\MSBuild\Current\Bin\arm64\cs
   file source=$(Arm64BinPath)cs\MSBuild.resources.dll
   file source=$(Arm64BinPath)cs\Microsoft.Build.Tasks.Core.resources.dll
   file source=$(Arm64BinPath)cs\Microsoft.Build.Utilities.Core.resources.dll
-  file source=$(TaskHostArm64BinPath)cs\MSBuildTaskHost.resources.dll
 folder InstallDir:\MSBuild\Current\Bin\arm64\de
   file source=$(Arm64BinPath)de\Microsoft.Build.resources.dll
   file source=$(Arm64BinPath)de\MSBuild.resources.dll
   file source=$(Arm64BinPath)de\Microsoft.Build.Tasks.Core.resources.dll
   file source=$(Arm64BinPath)de\Microsoft.Build.Utilities.Core.resources.dll
-  file source=$(TaskHostArm64BinPath)de\MSBuildTaskHost.resources.dll
 folder InstallDir:\MSBuild\Current\Bin\arm64\es
   file source=$(Arm64BinPath)es\Microsoft.Build.resources.dll
   file source=$(Arm64BinPath)es\MSBuild.resources.dll
   file source=$(Arm64BinPath)es\Microsoft.Build.Tasks.Core.resources.dll
   file source=$(Arm64BinPath)es\Microsoft.Build.Utilities.Core.resources.dll
-  file source=$(TaskHostArm64BinPath)es\MSBuildTaskHost.resources.dll
 folder InstallDir:\MSBuild\Current\Bin\arm64\fr
   file source=$(Arm64BinPath)fr\Microsoft.Build.resources.dll
   file source=$(Arm64BinPath)fr\MSBuild.resources.dll
   file source=$(Arm64BinPath)fr\Microsoft.Build.Tasks.Core.resources.dll
   file source=$(Arm64BinPath)fr\Microsoft.Build.Utilities.Core.resources.dll
-  file source=$(TaskHostArm64BinPath)fr\MSBuildTaskHost.resources.dll
 folder InstallDir:\MSBuild\Current\Bin\arm64\it
   file source=$(Arm64BinPath)it\Microsoft.Build.resources.dll
   file source=$(Arm64BinPath)it\MSBuild.resources.dll
   file source=$(Arm64BinPath)it\Microsoft.Build.Tasks.Core.resources.dll
   file source=$(Arm64BinPath)it\Microsoft.Build.Utilities.Core.resources.dll
-  file source=$(TaskHostArm64BinPath)it\MSBuildTaskHost.resources.dll
 folder InstallDir:\MSBuild\Current\Bin\arm64\ja
   file source=$(Arm64BinPath)ja\Microsoft.Build.resources.dll
   file source=$(Arm64BinPath)ja\MSBuild.resources.dll
   file source=$(Arm64BinPath)ja\Microsoft.Build.Tasks.Core.resources.dll
   file source=$(Arm64BinPath)ja\Microsoft.Build.Utilities.Core.resources.dll
-  file source=$(TaskHostArm64BinPath)ja\MSBuildTaskHost.resources.dll
 folder InstallDir:\MSBuild\Current\Bin\arm64\ko
   file source=$(Arm64BinPath)ko\Microsoft.Build.resources.dll
   file source=$(Arm64BinPath)ko\MSBuild.resources.dll
   file source=$(Arm64BinPath)ko\Microsoft.Build.Tasks.Core.resources.dll
   file source=$(Arm64BinPath)ko\Microsoft.Build.Utilities.Core.resources.dll
-  file source=$(TaskHostArm64BinPath)ko\MSBuildTaskHost.resources.dll
 folder InstallDir:\MSBuild\Current\Bin\arm64\pl
   file source=$(Arm64BinPath)pl\Microsoft.Build.resources.dll
   file source=$(Arm64BinPath)pl\MSBuild.resources.dll
   file source=$(Arm64BinPath)pl\Microsoft.Build.Tasks.Core.resources.dll
   file source=$(Arm64BinPath)pl\Microsoft.Build.Utilities.Core.resources.dll
-  file source=$(TaskHostArm64BinPath)pl\MSBuildTaskHost.resources.dll
 folder InstallDir:\MSBuild\Current\Bin\arm64\pt-BR
   file source=$(Arm64BinPath)pt-BR\Microsoft.Build.resources.dll
   file source=$(Arm64BinPath)pt-BR\MSBuild.resources.dll
   file source=$(Arm64BinPath)pt-BR\Microsoft.Build.Tasks.Core.resources.dll
   file source=$(Arm64BinPath)pt-BR\Microsoft.Build.Utilities.Core.resources.dll
-  file source=$(TaskHostArm64BinPath)pt-BR\MSBuildTaskHost.resources.dll
 folder InstallDir:\MSBuild\Current\Bin\arm64\ru
   file source=$(Arm64BinPath)ru\Microsoft.Build.resources.dll
   file source=$(Arm64BinPath)ru\MSBuild.resources.dll
   file source=$(Arm64BinPath)ru\Microsoft.Build.Tasks.Core.resources.dll
   file source=$(Arm64BinPath)ru\Microsoft.Build.Utilities.Core.resources.dll
-  file source=$(TaskHostArm64BinPath)ru\MSBuildTaskHost.resources.dll
 folder InstallDir:\MSBuild\Current\Bin\arm64\tr
   file source=$(Arm64BinPath)tr\Microsoft.Build.resources.dll
   file source=$(Arm64BinPath)tr\MSBuild.resources.dll
   file source=$(Arm64BinPath)tr\Microsoft.Build.Tasks.Core.resources.dll
   file source=$(Arm64BinPath)tr\Microsoft.Build.Utilities.Core.resources.dll
-  file source=$(TaskHostArm64BinPath)tr\MSBuildTaskHost.resources.dll
 folder InstallDir:\MSBuild\Current\Bin\arm64\zh-Hans
   file source=$(Arm64BinPath)zh-Hans\Microsoft.Build.resources.dll
   file source=$(Arm64BinPath)zh-Hans\MSBuild.resources.dll
   file source=$(Arm64BinPath)zh-Hans\Microsoft.Build.Tasks.Core.resources.dll
   file source=$(Arm64BinPath)zh-Hans\Microsoft.Build.Utilities.Core.resources.dll
-  file source=$(TaskHostArm64BinPath)zh-Hans\MSBuildTaskHost.resources.dll
 folder InstallDir:\MSBuild\Current\Bin\arm64\zh-Hant
   file source=$(Arm64BinPath)zh-Hant\Microsoft.Build.resources.dll
   file source=$(Arm64BinPath)zh-Hant\MSBuild.resources.dll
   file source=$(Arm64BinPath)zh-Hant\Microsoft.Build.Tasks.Core.resources.dll
   file source=$(Arm64BinPath)zh-Hant\Microsoft.Build.Utilities.Core.resources.dll
-  file source=$(TaskHostArm64BinPath)zh-Hant\MSBuildTaskHost.resources.dll


### PR DESCRIPTION
These resources were added to the ARM64 subfolder in #10023, but I don't think they're needed: there's no .NET Framework 3.5
for ARM64 and `MSBuildTaskHost.exe` isn't in the ARM64 folder itself, so I think we can remove these files.

There was also a build race condition involving the .resources.dll files, which is how I found this. The `Arm64ProjectReference` wasn't enough to get them built.
