### PR TITLE
Bugfix SharedOutputPath analyzer

### DIFF
--- a/src/Build/BuildCheck/Analyzers/SharedOutputPathAnalyzer.cs
+++ b/src/Build/BuildCheck/Analyzers/SharedOutputPathAnalyzer.cs
@@ -49,6 +49,7 @@ internal sealed class SharedOutputPathAnalyzer : BuildAnalyzer
         context.Data.EvaluatedProperties.TryGetValue("IntermediateOutputPath", out objPath);
 
         string? absoluteBinPath = CheckAndAddFullOutputPath(binPath, context);
+        // Check objPath only if it is different from binPath
         if (
             !string.IsNullOrEmpty(objPath) && !string.IsNullOrEmpty(absoluteBinPath) &&
             !objPath.Equals(binPath, StringComparison.CurrentCultureIgnoreCase)
@@ -72,6 +73,9 @@ internal sealed class SharedOutputPathAnalyzer : BuildAnalyzer
         {
             path = Path.Combine(Path.GetDirectoryName(projectPath)!, path);
         }
+
+        // Normalize the path to avoid false negatives due to different path representations.
+        path = Path.GetFullPath(path);
 
         if (_projectsPerOutputPath.TryGetValue(path!, out string? conflictingProject))
         {


### PR DESCRIPTION
Fixes #10235

### Context
The analyzer didn't contain proper path normalization - so up directory referencing in a prop definition (e.g. `../someFolder`) could lead to 2 absolute paths perceived as different (e.g. `C:\myproj\lib1\..\common` and `C:\myproj\lib2\..\common`)

### Changes Made
Normalizing the path properly

### Testing
Just a quickfix