### PR TITLE
Normalize paths to remove \ on UNIX when fetching them from props in BuildCheck

### DIFF
--- a/src/Build/BuildCheck/Analyzers/SharedOutputPathAnalyzer.cs
+++ b/src/Build/BuildCheck/Analyzers/SharedOutputPathAnalyzer.cs
@@ -9,6 +9,7 @@ using System.IO;
 using Microsoft.Build.Experimental.BuildCheck.Infrastructure;
 using Microsoft.Build.Construction;
 using Microsoft.Build.Experimental.BuildCheck;
+using Microsoft.Build.Shared;
 
 namespace Microsoft.Build.Experimental.BuildCheck.Analyzers;
 
@@ -44,9 +45,8 @@ internal sealed class SharedOutputPathAnalyzer : BuildAnalyzer
         }
 
         string? binPath, objPath;
-
-        context.Data.EvaluatedProperties.TryGetValue("OutputPath", out binPath);
-        context.Data.EvaluatedProperties.TryGetValue("IntermediateOutputPath", out objPath);
+        context.Data.EvaluatedProperties.TryGetPathValue("OutputPath", out binPath);
+        context.Data.EvaluatedProperties.TryGetPathValue("IntermediateOutputPath", out objPath);
 
         string? absoluteBinPath = CheckAndAddFullOutputPath(binPath, context);
         if (

--- a/src/Shared/FileUtilities.cs
+++ b/src/Shared/FileUtilities.cs
@@ -577,6 +577,26 @@ namespace Microsoft.Build.Shared
         }
 
         /// <summary>
+        /// Gets the path value that is associated with the specified key in a dictionary with <see cref="string"/> values.
+        /// Normalizes the value as a path.
+        /// </summary>
+        /// <param name="dictionary">The dictionary to search.</param>
+        /// <param name="key">The key to locate.</param>
+        /// <param name="value">When this method returns, the value associated with the specified key normalized as a path, if the key is found; otherwise <see langword="null"/>.</param>
+        /// <returns><see langword="true"/> if the dictionary contains an element that has the specified key; otherwise, <see langword="false"/>.</returns>
+        /// <remarks>Use this method to get paths from dictionaries of properties whose default values may contain backslashes.</remarks>
+        internal static bool TryGetPathValue<TKey>(this IReadOnlyDictionary<TKey, string> dictionary, TKey key, out string value)
+        {
+            bool result = dictionary.TryGetValue(key, out value);
+            if (result)
+            {
+                value = NormalizePath(value);
+            }
+
+            return result;
+        }
+
+        /// <summary>
         /// If on Unix, convert backslashes to slashes for strings that resemble paths.
         /// This overload takes and returns ReadOnlyMemory of characters.
         /// </summary>


### PR DESCRIPTION
Fixes #10072 

### Context
Background: the \ appears due to targets and properties default values having hardcoded \ in them.


### Changes Made
Added an extension TryGetPathValue method  for dictionaries with string values to FileUtilities which normalizes the value to a path. Use this method to get the value in SharedOutputPathAnalyzer (BuildCheck).

### Testing
Manually tested it fixes the issue on UNIX.

### Notes
This seems like a hack. Removing all \ from targets and props would solve the issue at its root, but I can't see the consequences of that.
If the extension method is an acceptable solution we might want to make it public so other BuildCheckAnalyzer creators can use it.