### PR TITLE
Emit eval props if requested by any sink

### DIFF
--- a/documentation/wiki/ChangeWaves.md
+++ b/documentation/wiki/ChangeWaves.md
@@ -28,6 +28,7 @@ A wave of features is set to "rotate out" (i.e. become standard functionality) t
 - [Convert.ToString during a property evaluation uses the InvariantCulture for all types](https://github.com/dotnet/msbuild/pull/9874)
 - [Fix oversharing of build results in ResultsCache](https://github.com/dotnet/msbuild/pull/9987)
 - [Add ParameterName and PropertyName to TaskParameterEventArgs](https://github.com/dotnet/msbuild/pull/10130)
+- [Emit eval props if requested by any sink](https://github.com/dotnet/msbuild/pull/10243)
 
 ### 17.10
 - [AppDomain configuration is serialized without using BinFmt](https://github.com/dotnet/msbuild/pull/9320) - feature can be opted out only if [BinaryFormatter](https://learn.microsoft.com/en-us/dotnet/api/system.runtime.serialization.formatters.binary.binaryformatter) is allowed at runtime by editing `MSBuild.runtimeconfig.json`

--- a/src/Build.UnitTests/BackEnd/BuildManager_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/BuildManager_Tests.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
                 EnableNodeReuse = false
             };
             _buildManager = new BuildManager();
-            _projectCollection = new ProjectCollection(null, _parameters.Loggers, ToolsetDefinitionLocations.Default);
+            _projectCollection = new ProjectCollection(globalProperties:null, _parameters.Loggers, ToolsetDefinitionLocations.Default);
 
             _env = TestEnvironment.Create(output);
             _inProcEnvCheckTransientEnvironmentVariable = _env.SetEnvironmentVariable("MSBUILDINPROCENVCHECK", "1");

--- a/src/Build.UnitTests/BackEnd/BuildManager_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/BuildManager_Tests.cs
@@ -769,14 +769,14 @@ namespace Microsoft.Build.UnitTests.BackEnd
             _logger.AssertLogContains("[success]");
             Assert.Equal(3, _logger.EvaluationFinishedEvents.Count);
 
-            ProjectEvaluationFinishedEventArgs evalFinishedEvent = _logger.EvaluationFinishedEvents[1];
+            ProjectStartedEventArgs projectStartedEvent = _logger.ProjectStartedEvents[1];
 
             // After conversion to xunit, this test sometimes fails at this assertion.
             // Related to shared state that the test touches that's getting handled
             // differently in xunit?
-            Assert.NotNull(evalFinishedEvent.Properties);
+            Assert.NotNull(projectStartedEvent.Properties);
 
-            Dictionary<string, string> properties = ExtractProjectStartedPropertyList(evalFinishedEvent.Properties);
+            Dictionary<string, string> properties = ExtractProjectStartedPropertyList(projectStartedEvent.Properties);
 
             Assert.NotNull(properties);
             Assert.Single(properties);
@@ -784,8 +784,8 @@ namespace Microsoft.Build.UnitTests.BackEnd
             Assert.True(properties.TryGetValue("InitialProperty3", out string propertyValue));
             Assert.Equal("InitialProperty3", propertyValue);
 
-            evalFinishedEvent = _logger.EvaluationFinishedEvents[2];
-            Assert.Null(evalFinishedEvent.Properties);
+            projectStartedEvent = _logger.ProjectStartedEvents[2];
+            Assert.Null(projectStartedEvent.Properties);
         }
 
         /// <summary>

--- a/src/Build.UnitTests/BackEnd/BuildManager_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/BuildManager_Tests.cs
@@ -672,11 +672,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
         /// Make sure when if the environment variable MsBuildForwardPropertiesFromChild is set to a value and
         /// we launch a child node that we get only that value.
         /// </summary>
-#if RUNTIME_TYPE_NETCORE
-        [Fact(Skip = "https://github.com/dotnet/msbuild/issues/1976")]
-#else
         [Fact]
-#endif
         public void OutOfProcNodeForwardCertainproperties()
         {
             string contents = CleanupFileContents(@"
@@ -704,7 +700,15 @@ namespace Microsoft.Build.UnitTests.BackEnd
             var data = new BuildRequestData(project.FullPath, new Dictionary<string, string>(),
                 MSBuildDefaultToolsVersion, Array.Empty<string>(), null);
 
-            BuildResult result = _buildManager.Build(_parameters, data);
+            // We need to recreate build parameters to ensure proper capturing of newly set environment variables
+            BuildParameters parameters = new BuildParameters
+            {
+                ShutdownInProcNodeOnBuildFinish = true,
+                Loggers = new ILogger[] { _logger },
+                EnableNodeReuse = false
+            };
+
+            BuildResult result = _buildManager.Build(parameters, data);
             Assert.Equal(BuildResultCode.Success, result.OverallResult);
             _logger.AssertLogContains("[success]");
             Assert.Single(_logger.ProjectStartedEvents);
@@ -723,11 +727,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
         /// we launch a child node that we get only that value. Also, make sure that when a project is pulled from the results cache
         /// and we have a list of properties to serialize that we do not crash. This is to prevent a regression of 826594
         /// </summary>
-#if RUNTIME_TYPE_NETCORE
-        [Fact(Skip = "https://github.com/dotnet/msbuild/issues/1976")]
-#else
         [Fact]
-#endif
         public void OutOfProcNodeForwardCertainpropertiesAlsoGetResultsFromCache()
         {
             string tempProject = _env.CreateFile(".proj").Path;
@@ -766,7 +766,15 @@ namespace Microsoft.Build.UnitTests.BackEnd
             var data = new BuildRequestData(project.FullPath, new Dictionary<string, string>(),
                 MSBuildDefaultToolsVersion, Array.Empty<string>(), null);
 
-            BuildResult result = _buildManager.Build(_parameters, data);
+            // We need to recreate build parameters to ensure proper capturing of newly set environment variables
+            BuildParameters parameters = new BuildParameters
+            {
+                ShutdownInProcNodeOnBuildFinish = true,
+                Loggers = new ILogger[] { _logger },
+                EnableNodeReuse = false
+            };
+
+            BuildResult result = _buildManager.Build(parameters, data);
             Assert.Equal(BuildResultCode.Success, result.OverallResult);
             _logger.AssertLogContains("[success]");
             Assert.Equal(3, _logger.ProjectStartedEvents.Count);

--- a/src/Build.UnitTests/BackEnd/BuildManager_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/BuildManager_Tests.cs
@@ -760,6 +760,8 @@ namespace Microsoft.Build.UnitTests.BackEnd
             _env.SetEnvironmentVariable("MsBuildForwardPropertiesFromChild", "InitialProperty3;IAMNOTREAL");
             _env.SetEnvironmentVariable("MSBUILDNOINPROCNODE", "1");
 
+            _env.SetEnvironmentVariable("MSBUILDLOGPROPERTIESANDITEMSAFTEREVALUATION", "0");
+
             var project = CreateProject(contents, null, _projectCollection, false);
             var data = new BuildRequestData(project.FullPath, new Dictionary<string, string>(),
                 MSBuildDefaultToolsVersion, Array.Empty<string>(), null);
@@ -767,7 +769,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             BuildResult result = _buildManager.Build(_parameters, data);
             Assert.Equal(BuildResultCode.Success, result.OverallResult);
             _logger.AssertLogContains("[success]");
-            Assert.Equal(3, _logger.EvaluationFinishedEvents.Count);
+            Assert.Equal(3, _logger.ProjectStartedEvents.Count);
 
             ProjectStartedEventArgs projectStartedEvent = _logger.ProjectStartedEvents[1];
 
@@ -785,7 +787,8 @@ namespace Microsoft.Build.UnitTests.BackEnd
             Assert.Equal("InitialProperty3", propertyValue);
 
             projectStartedEvent = _logger.ProjectStartedEvents[2];
-            Assert.Null(projectStartedEvent.Properties);
+            properties = ExtractProjectStartedPropertyList(projectStartedEvent.Properties);
+            (properties == null || properties.Count == 0).ShouldBeTrue();
         }
 
         /// <summary>

--- a/src/Build.UnitTests/BackEnd/BuildManager_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/BuildManager_Tests.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
                 EnableNodeReuse = false
             };
             _buildManager = new BuildManager();
-            _projectCollection = new ProjectCollection(globalProperties:null, _parameters.Loggers, ToolsetDefinitionLocations.Default);
+            _projectCollection = new ProjectCollection(globalProperties: null, _parameters.Loggers, ToolsetDefinitionLocations.Default);
 
             _env = TestEnvironment.Create(output);
             _inProcEnvCheckTransientEnvironmentVariable = _env.SetEnvironmentVariable("MSBUILDINPROCENVCHECK", "1");

--- a/src/Build.UnitTests/BackEnd/BuildManager_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/BuildManager_Tests.cs
@@ -672,7 +672,11 @@ namespace Microsoft.Build.UnitTests.BackEnd
         /// Make sure when if the environment variable MsBuildForwardPropertiesFromChild is set to a value and
         /// we launch a child node that we get only that value.
         /// </summary>
+#if RUNTIME_TYPE_NETCORE
+        [Fact(Skip = "https://github.com/dotnet/msbuild/issues/1976")]
+#else
         [Fact]
+#endif
         public void OutOfProcNodeForwardCertainproperties()
         {
             string contents = CleanupFileContents(@"
@@ -727,7 +731,11 @@ namespace Microsoft.Build.UnitTests.BackEnd
         /// we launch a child node that we get only that value. Also, make sure that when a project is pulled from the results cache
         /// and we have a list of properties to serialize that we do not crash. This is to prevent a regression of 826594
         /// </summary>
+#if RUNTIME_TYPE_NETCORE
+        [Fact(Skip = "https://github.com/dotnet/msbuild/issues/1976")]
+#else
         [Fact]
+#endif
         public void OutOfProcNodeForwardCertainpropertiesAlsoGetResultsFromCache()
         {
             string tempProject = _env.CreateFile(".proj").Path;

--- a/src/Build.UnitTests/BackEnd/MockLoggingService.cs
+++ b/src/Build.UnitTests/BackEnd/MockLoggingService.cs
@@ -215,14 +215,21 @@ namespace Microsoft.Build.UnitTests.BackEnd
             set { }
         }
 
-        /// <summary>
-        /// Log properties and items on ProjectEvaluationFinishedEventArgs
-        /// instead of ProjectStartedEventArgs.
-        /// </summary>
-        public bool IncludeEvaluationPropertiesAndItems
+        /// <inheritdoc cref="ILoggingService.SetIncludeEvaluationPropertiesAndItemsInEvents"/>
+        public void SetIncludeEvaluationPropertiesAndItemsInEvents(bool inProjectStartedEvent,
+            bool inEvaluationFinishedEvent)
+        { }
+
+        /// <inheritdoc cref="ILoggingService.IncludeEvaluationPropertiesAndItemsInProjectStartedEvent"/>
+        public bool IncludeEvaluationPropertiesAndItemsInProjectStartedEvent
         {
             get => false;
-            set { }
+        }
+
+        /// <inheritdoc cref="ILoggingService.IncludeEvaluationPropertiesAndItemsInEvaluationFinishedEvent"/>
+        public bool IncludeEvaluationPropertiesAndItemsInEvaluationFinishedEvent
+        {
+            get => false;
         }
 
         /// <summary>

--- a/src/Build.UnitTests/ConsoleLogger_Tests.cs
+++ b/src/Build.UnitTests/ConsoleLogger_Tests.cs
@@ -277,7 +277,7 @@ namespace Microsoft.Build.UnitTests
 
             if (includeEvaluationPropertiesAndItems)
             {
-                pc.Collection.LoggingService.IncludeEvaluationPropertiesAndItems = true;
+                pc.Collection.LoggingService.SetIncludeEvaluationPropertiesAndItemsInEvents(inProjectStartedEvent: false, inEvaluationFinishedEvent: true);
             }
 
             var project = env.CreateTestProjectWithFiles(@"

--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -2757,7 +2757,8 @@ namespace Microsoft.Build.Execution
                 , new LoggingNodeConfiguration(
                     loggingService.IncludeEvaluationMetaprojects,
                     loggingService.IncludeEvaluationProfile,
-                    loggingService.IncludeEvaluationPropertiesAndItems,
+                    loggingService.IncludeEvaluationPropertiesAndItemsInProjectStartedEvent,
+                    loggingService.IncludeEvaluationPropertiesAndItemsInEvaluationFinishedEvent,
                     loggingService.IncludeTaskInputs));
             }
 

--- a/src/Build/BackEnd/Components/Logging/ILoggingService.cs
+++ b/src/Build/BackEnd/Components/Logging/ILoggingService.cs
@@ -200,12 +200,24 @@ namespace Microsoft.Build.BackEnd.Logging
 
         /// <summary>
         /// Should properties and items be logged on <see cref="ProjectEvaluationFinishedEventArgs"/>
-        /// instead of <see cref="ProjectStartedEventArgs"/>?
+        /// or/and <see cref="ProjectStartedEventArgs"/>?
         /// </summary>
-        bool IncludeEvaluationPropertiesAndItems
+        void SetIncludeEvaluationPropertiesAndItemsInEvents(bool inProjectStartedEvent, bool inEvaluationFinishedEvent);
+
+        /// <summary>
+        /// Indicates whether properties and items should be logged on <see cref="ProjectStartedEventArgs"/>.
+        /// </summary>
+        bool IncludeEvaluationPropertiesAndItemsInProjectStartedEvent
         {
             get;
-            set;
+        }
+
+        /// <summary>
+        /// Indicates whether properties and items should be logged on <see cref="ProjectEvaluationFinishedEventArgs"/>.
+        /// </summary>
+        bool IncludeEvaluationPropertiesAndItemsInEvaluationFinishedEvent
+        {
+            get;
         }
 
         /// <summary>

--- a/src/Build/BackEnd/Components/Logging/LoggingService.cs
+++ b/src/Build/BackEnd/Components/Logging/LoggingService.cs
@@ -559,8 +559,8 @@ namespace Microsoft.Build.BackEnd.Logging
                     else
                     {
                         var sinks = _eventSinkDictionary.Values.OfType<EventSourceSink>();
-                        // .All() on an empty list defaults to true, we want to default to false
-                        _includeEvaluationPropertiesAndItems = sinks.Any() && sinks.All(sink => sink.IncludeEvaluationPropertiesAndItems);
+                        // If any sink requested the data - we need to emit them
+                        _includeEvaluationPropertiesAndItems = sinks.Any(sink => sink.IncludeEvaluationPropertiesAndItems);
                     }
                 }
 

--- a/src/Build/BackEnd/Components/Logging/LoggingService.cs
+++ b/src/Build/BackEnd/Components/Logging/LoggingService.cs
@@ -552,6 +552,9 @@ namespace Microsoft.Build.BackEnd.Logging
             {
                 return;
             }
+            // Set this right away - to prevent SO exception in case of any future refactoring
+            //  that would refer to the IncludeEvaluation... properties here
+            _evalDataBehaviorSet = true;
 
             bool? escapeHatch = Traits.Instance.EscapeHatches.LogPropertiesAndItemsAfterEvaluation;
             if (escapeHatch.HasValue)
@@ -575,14 +578,12 @@ namespace Microsoft.Build.BackEnd.Logging
                 }
                 else
                 {
-                    IncludeEvaluationPropertiesAndItemsInEvaluationFinishedEvent =
-                        sinks.Any() && sinks.All(sink => sink.IncludeEvaluationPropertiesAndItems);
-                    IncludeEvaluationPropertiesAndItemsInProjectStartedEvent =
-                        !IncludeEvaluationPropertiesAndItemsInEvaluationFinishedEvent;
+                    bool allSinksIncludeEvalData = sinks.Any() && sinks.All(sink => sink.IncludeEvaluationPropertiesAndItems);
+
+                    IncludeEvaluationPropertiesAndItemsInEvaluationFinishedEvent = allSinksIncludeEvalData;
+                    IncludeEvaluationPropertiesAndItemsInProjectStartedEvent = !allSinksIncludeEvalData;
                 }
             }
-
-            _evalDataBehaviorSet = true;
         }
 
         /// <inheritdoc cref="ILoggingService.IncludeEvaluationPropertiesAndItemsInProjectStartedEvent"/>

--- a/src/Build/BackEnd/Components/Logging/LoggingService.cs
+++ b/src/Build/BackEnd/Components/Logging/LoggingService.cs
@@ -202,12 +202,6 @@ namespace Microsoft.Build.BackEnd.Logging
         private bool? _includeEvaluationProfile;
 
         /// <summary>
-        /// Whether properties and items should be logged on <see cref="ProjectEvaluationFinishedEventArgs"/>
-        /// instead of <see cref="ProjectStartedEventArgs"/>.
-        /// </summary>
-        private bool? _includeEvaluationPropertiesAndItems;
-
-        /// <summary>
         /// Whether to include task inputs in task events.
         /// </summary>
         private bool? _includeTaskInputs;
@@ -541,36 +535,76 @@ namespace Microsoft.Build.BackEnd.Logging
             set => _includeTaskInputs = value;
         }
 
-        /// <summary>
-        /// Should properties and items be logged on <see cref="ProjectEvaluationFinishedEventArgs"/>
-        /// instead of <see cref="ProjectStartedEventArgs"/>?
-        /// </summary>
-        public bool IncludeEvaluationPropertiesAndItems
+        /// <inheritdoc cref="ILoggingService.SetIncludeEvaluationPropertiesAndItemsInEvents"/>
+        public void SetIncludeEvaluationPropertiesAndItemsInEvents(bool inProjectStartedEvent, bool inEvaluationFinishedEvent)
+        {
+            _evalDataBehaviorSet = true;
+            IncludeEvaluationPropertiesAndItemsInEvaluationFinishedEvent = inEvaluationFinishedEvent;
+            IncludeEvaluationPropertiesAndItemsInProjectStartedEvent = inProjectStartedEvent;
+        }
+
+        private bool _evalDataBehaviorSet;
+        private bool _includeEvaluationPropertiesAndItemsInProjectStartedEvent;
+        private bool _includeEvaluationPropertiesAndItemsInEvaluationFinishedEvent;
+        private void InferEvalDataBehavior()
+        {
+            if (_evalDataBehaviorSet)
+            {
+                return;
+            }
+
+            bool? escapeHatch = Traits.Instance.EscapeHatches.LogPropertiesAndItemsAfterEvaluation;
+            if (escapeHatch.HasValue)
+            {
+                IncludeEvaluationPropertiesAndItemsInEvaluationFinishedEvent = escapeHatch.Value;
+                IncludeEvaluationPropertiesAndItemsInProjectStartedEvent = !escapeHatch.Value;
+            }
+            else
+            {
+                var sinks = _eventSinkDictionary.Values.OfType<EventSourceSink>().ToList();
+
+                if (ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_12))
+                {
+                    // If any logger requested the data - we need to emit them
+                    IncludeEvaluationPropertiesAndItemsInEvaluationFinishedEvent =
+                        sinks.Any(sink => sink.IncludeEvaluationPropertiesAndItems);
+                    // If any logger didn't request the data - hence it's likely legacy logger
+                    //  - we need to populate the data in legacy way
+                    IncludeEvaluationPropertiesAndItemsInProjectStartedEvent =
+                        sinks.Any(sink => !sink.IncludeEvaluationPropertiesAndItems);
+                }
+                else
+                {
+                    IncludeEvaluationPropertiesAndItemsInEvaluationFinishedEvent =
+                        sinks.Any() && sinks.All(sink => sink.IncludeEvaluationPropertiesAndItems);
+                    IncludeEvaluationPropertiesAndItemsInProjectStartedEvent =
+                        !IncludeEvaluationPropertiesAndItemsInEvaluationFinishedEvent;
+                }
+            }
+
+            _evalDataBehaviorSet = true;
+        }
+
+        /// <inheritdoc cref="ILoggingService.IncludeEvaluationPropertiesAndItemsInProjectStartedEvent"/>
+        public bool IncludeEvaluationPropertiesAndItemsInProjectStartedEvent
         {
             get
             {
-                if (_includeEvaluationPropertiesAndItems == null)
-                {
-                    var escapeHatch = Traits.Instance.EscapeHatches.LogPropertiesAndItemsAfterEvaluation;
-                    if (escapeHatch.HasValue)
-                    {
-                        _includeEvaluationPropertiesAndItems = escapeHatch.Value;
-                    }
-                    else
-                    {
-                        var sinks = _eventSinkDictionary.Values.OfType<EventSourceSink>();
-                        // If any sink requested the data - we need to emit them
-                        _includeEvaluationPropertiesAndItems =
-                            ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_12)
-                                ? sinks.Any(sink => sink.IncludeEvaluationPropertiesAndItems)
-                                : sinks.Any() && sinks.All(sink => sink.IncludeEvaluationPropertiesAndItems);
-                    }
-                }
-
-                return _includeEvaluationPropertiesAndItems ?? false;
+                InferEvalDataBehavior();
+                return _includeEvaluationPropertiesAndItemsInProjectStartedEvent;
             }
+            private set => _includeEvaluationPropertiesAndItemsInProjectStartedEvent = value;
+        }
 
-            set => _includeEvaluationPropertiesAndItems = value;
+        /// <inheritdoc cref="ILoggingService.IncludeEvaluationPropertiesAndItemsInEvaluationFinishedEvent"/>
+        public bool IncludeEvaluationPropertiesAndItemsInEvaluationFinishedEvent
+        {
+            get
+            {
+                InferEvalDataBehavior();
+                return _includeEvaluationPropertiesAndItemsInEvaluationFinishedEvent;
+            }
+            private set => _includeEvaluationPropertiesAndItemsInEvaluationFinishedEvent = value;
         }
 
         /// <summary>
@@ -611,6 +645,7 @@ namespace Microsoft.Build.BackEnd.Logging
         {
             return GetWarningsForProject(context, _warningsNotAsErrorsByProject, WarningsNotAsErrors);
         }
+
 
         /// <summary>
         /// Returns a collection of warnings to be demoted to messages for the specified build context.

--- a/src/Build/BackEnd/Components/Logging/LoggingService.cs
+++ b/src/Build/BackEnd/Components/Logging/LoggingService.cs
@@ -560,7 +560,10 @@ namespace Microsoft.Build.BackEnd.Logging
                     {
                         var sinks = _eventSinkDictionary.Values.OfType<EventSourceSink>();
                         // If any sink requested the data - we need to emit them
-                        _includeEvaluationPropertiesAndItems = sinks.Any(sink => sink.IncludeEvaluationPropertiesAndItems);
+                        _includeEvaluationPropertiesAndItems =
+                            ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_12)
+                                ? sinks.Any(sink => sink.IncludeEvaluationPropertiesAndItems)
+                                : sinks.Any() && sinks.All(sink => sink.IncludeEvaluationPropertiesAndItems);
                     }
                 }
 

--- a/src/Build/BackEnd/Components/Logging/ProjectLoggingContext.cs
+++ b/src/Build/BackEnd/Components/Logging/ProjectLoggingContext.cs
@@ -96,7 +96,7 @@ namespace Microsoft.Build.BackEnd.Logging
 
             // If we are only logging critical events lets not pass back the items or properties
             if (!LoggingService.OnlyLogCriticalEvents &&
-                !LoggingService.IncludeEvaluationPropertiesAndItems &&
+                LoggingService.IncludeEvaluationPropertiesAndItemsInProjectStartedEvent &&
                 (!LoggingService.RunningOnRemoteNode || LoggingService.SerializeAllProperties))
             {
                 if (projectProperties is null)
@@ -116,7 +116,7 @@ namespace Microsoft.Build.BackEnd.Logging
             }
 
             if (projectProperties != null &&
-                !LoggingService.IncludeEvaluationPropertiesAndItems &&
+                LoggingService.IncludeEvaluationPropertiesAndItemsInProjectStartedEvent &&
                 propertiesToSerialize?.Length > 0 &&
                 !LoggingService.SerializeAllProperties)
             {

--- a/src/Build/BackEnd/Node/LoggingNodeConfiguration.cs
+++ b/src/Build/BackEnd/Node/LoggingNodeConfiguration.cs
@@ -9,12 +9,14 @@ namespace Microsoft.Build.BackEnd
     {
         private bool _includeEvaluationMetaprojects;
         private bool _includeEvaluationProfiles;
-        private bool _includeEvaluationPropertiesAndItems;
+        private bool _includeEvaluationPropertiesAndItemsInProjectStartedEvent;
+        private bool _includeEvaluationPropertiesAndItemsInEvaluationFinishedEvent;
         private bool _includeTaskInputs;
 
         public bool IncludeEvaluationMetaprojects => _includeEvaluationMetaprojects;
         public bool IncludeEvaluationProfiles => _includeEvaluationProfiles;
-        public bool IncludeEvaluationPropertiesAndItems => _includeEvaluationPropertiesAndItems;
+        public bool IncludeEvaluationPropertiesAndItemsInProjectStartedEvent => _includeEvaluationPropertiesAndItemsInProjectStartedEvent;
+        public bool IncludeEvaluationPropertiesAndItemsInEvaluationFinishedEvent => _includeEvaluationPropertiesAndItemsInEvaluationFinishedEvent;
         public bool IncludeTaskInputs => _includeTaskInputs;
 
         public LoggingNodeConfiguration()
@@ -24,12 +26,14 @@ namespace Microsoft.Build.BackEnd
         public LoggingNodeConfiguration(
             bool includeEvaluationMetaprojects,
             bool includeEvaluationProfiles,
-            bool includeEvaluationPropertiesAndItems,
+            bool includeEvaluationPropertiesAndItemsInProjectStartedEvent,
+            bool includeEvaluationPropertiesAndItemsInEvaluationFinishedEvent,
             bool includeTaskInputs)
         {
             _includeEvaluationMetaprojects = includeEvaluationMetaprojects;
             _includeEvaluationProfiles = includeEvaluationProfiles;
-            _includeEvaluationPropertiesAndItems = includeEvaluationPropertiesAndItems;
+            _includeEvaluationPropertiesAndItemsInProjectStartedEvent = includeEvaluationPropertiesAndItemsInProjectStartedEvent;
+            _includeEvaluationPropertiesAndItemsInEvaluationFinishedEvent = includeEvaluationPropertiesAndItemsInEvaluationFinishedEvent;
             _includeTaskInputs = includeTaskInputs;
         }
 
@@ -37,7 +41,8 @@ namespace Microsoft.Build.BackEnd
         {
             translator.Translate(ref _includeEvaluationMetaprojects);
             translator.Translate(ref _includeEvaluationProfiles);
-            translator.Translate(ref _includeEvaluationPropertiesAndItems);
+            translator.Translate(ref _includeEvaluationPropertiesAndItemsInProjectStartedEvent);
+            translator.Translate(ref _includeEvaluationPropertiesAndItemsInEvaluationFinishedEvent);
             translator.Translate(ref _includeTaskInputs);
         }
     }

--- a/src/Build/BackEnd/Node/OutOfProcNode.cs
+++ b/src/Build/BackEnd/Node/OutOfProcNode.cs
@@ -781,9 +781,12 @@ namespace Microsoft.Build.Execution
                 _loggingService.IncludeTaskInputs = true;
             }
 
-            if (configuration.LoggingNodeConfiguration.IncludeEvaluationPropertiesAndItems)
+            if (configuration.LoggingNodeConfiguration.IncludeEvaluationPropertiesAndItemsInEvaluationFinishedEvent)
             {
-                _loggingService.IncludeEvaluationPropertiesAndItems = true;
+                _loggingService.SetIncludeEvaluationPropertiesAndItemsInEvents(
+                    configuration.LoggingNodeConfiguration.IncludeEvaluationPropertiesAndItemsInProjectStartedEvent,
+                    configuration.LoggingNodeConfiguration
+                        .IncludeEvaluationPropertiesAndItemsInEvaluationFinishedEvent);
             }
 
             try

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -343,7 +343,7 @@ namespace Microsoft.Build.Evaluation
                 IEnumerable properties = null;
                 IEnumerable items = null;
 
-                if (evaluator._evaluationLoggingContext.LoggingService.IncludeEvaluationPropertiesAndItems)
+                if (evaluator._evaluationLoggingContext.LoggingService.IncludeEvaluationPropertiesAndItemsInEvaluationFinishedEvent)
                 {
                     globalProperties = evaluator._data.GlobalPropertiesDictionary;
                     properties = Traits.LogAllEnvironmentVariables ? evaluator._data.Properties : evaluator.FilterOutEnvironmentDerivedProperties(evaluator._data.Properties);

--- a/src/Framework.UnitTests/ProjectStartedEventArgs_Tests.cs
+++ b/src/Framework.UnitTests/ProjectStartedEventArgs_Tests.cs
@@ -51,30 +51,6 @@ namespace Microsoft.Build.UnitTests
         }
 
         /// <summary>
-        /// Verify different Items and properties are not taken into account in the equals comparison. They should
-        /// not be considered as part of the equals evaluation
-        /// </summary>
-        [Fact]
-        public void ItemsAndPropertiesDifferentEquals()
-        {
-            ArrayList itemsList = new ArrayList();
-            ArrayList propertiesList = new ArrayList();
-            ProjectStartedEventArgs differentItemsAndProperties = new ProjectStartedEventArgs(
-                  s_baseProjectStartedEvent.ProjectId,
-                  s_baseProjectStartedEvent.Message,
-                  s_baseProjectStartedEvent.HelpKeyword,
-                  s_baseProjectStartedEvent.ProjectFile,
-                  s_baseProjectStartedEvent.TargetNames,
-                  propertiesList,
-                  itemsList,
-                  s_baseProjectStartedEvent.ParentProjectBuildEventContext,
-                  s_baseProjectStartedEvent.Timestamp);
-
-            s_baseProjectStartedEvent.Properties.ShouldNotBe(propertiesList);
-            s_baseProjectStartedEvent.Items.ShouldNotBe(itemsList);
-        }
-
-        /// <summary>
         /// Create a derived class so that we can test the default constructor in order to increase code coverage and
         /// verify this code path does not cause any exceptions.
         /// </summary>

--- a/src/Framework/ProjectStartedEventArgs.cs
+++ b/src/Framework/ProjectStartedEventArgs.cs
@@ -250,7 +250,9 @@ namespace Microsoft.Build.Framework
         {
             get
             {
-                return globalProperties ?? ImmutableDictionary<string, string>.Empty;
+                return globalProperties ?? (ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_12)
+                    ? ImmutableDictionary<string, string>.Empty
+                    : null);
             }
 
             internal set
@@ -299,7 +301,9 @@ namespace Microsoft.Build.Framework
                 // up the live list of properties from the loaded project, which is stored in the configuration as well.
                 // By doing this, we no longer need to transmit properties using this message because they've already
                 // been transmitted as part of the BuildRequestConfiguration.
-                return properties ?? Enumerable.Empty<DictionaryEntry>();
+                return properties ?? (ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_12)
+                    ? Enumerable.Empty<DictionaryEntry>()
+                    : null);
             }
         }
 
@@ -323,7 +327,9 @@ namespace Microsoft.Build.Framework
                 // case, this access is to the live list.  For the central logger in the multi-proc case, the main node
                 // has likely not loaded this project, and therefore the live items would not be available to them, which is
                 // the same as the current functionality.
-                return items ?? Enumerable.Empty<DictionaryEntry>();
+                return items ?? (ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_12)
+                    ? Enumerable.Empty<DictionaryEntry>()
+                    : null);
             }
         }
 

--- a/src/Framework/ProjectStartedEventArgs.cs
+++ b/src/Framework/ProjectStartedEventArgs.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using System.Runtime.Serialization;
@@ -249,7 +250,7 @@ namespace Microsoft.Build.Framework
         {
             get
             {
-                return globalProperties;
+                return globalProperties ?? ImmutableDictionary<string, string>.Empty;
             }
 
             internal set
@@ -298,7 +299,7 @@ namespace Microsoft.Build.Framework
                 // up the live list of properties from the loaded project, which is stored in the configuration as well.
                 // By doing this, we no longer need to transmit properties using this message because they've already
                 // been transmitted as part of the BuildRequestConfiguration.
-                return properties;
+                return properties ?? Enumerable.Empty<DictionaryEntry>();
             }
         }
 
@@ -322,7 +323,7 @@ namespace Microsoft.Build.Framework
                 // case, this access is to the live list.  For the central logger in the multi-proc case, the main node
                 // has likely not loaded this project, and therefore the live items would not be available to them, which is
                 // the same as the current functionality.
-                return items;
+                return items ?? Enumerable.Empty<DictionaryEntry>();
             }
         }
 

--- a/src/Shared/UnitTests/TestAssemblyInfo.cs
+++ b/src/Shared/UnitTests/TestAssemblyInfo.cs
@@ -41,6 +41,12 @@ namespace Microsoft.Build.UnitTests
             var runningTestsField = testInfoType.GetField("s_runningTests", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static);
             runningTestsField.SetValue(null, true);
 
+            // Set the field in BuildEnvironmentState - as it might have been already preintialized by the data preparation of data driven tests
+            testInfoType = frameworkAssembly.GetType("Microsoft.Build.Framework.BuildEnvironmentState");
+            runningTestsField = testInfoType.GetField("s_runningTests", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static);
+            runningTestsField.SetValue(null, true);
+            
+
             // Note: build error files will be initialized in test environments for particular tests, also we don't have output to report error files into anyway...
             _testEnvironment = TestEnvironment.Create(output: null, ignoreBuildErrorFiles: true);
 

--- a/src/UnitTests.Shared/MockLogger.cs
+++ b/src/UnitTests.Shared/MockLogger.cs
@@ -213,6 +213,11 @@ namespace Microsoft.Build.UnitTests
             {
                 _reportTelemetry = true;
             }
+
+            if (eventSource is IEventSource4 eventSource4)
+            {
+                eventSource4.IncludeEvaluationPropertiesAndItems();
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #10225, ~~#1976~~

### Context
The eval props/items were not attached to `ProjectEvaluationFinishedEventargs` if any logger didn't request `IncludeEvaluationPropertiesAndItems`

In case of VS - the `MuxLogger` is attached as well. So in case that one doesn't set the property (it might be a recent change in VS - I'm not sure) - the values are not being sent neither to binary logger.

### Changes Made
Make sure the values are emitted and attached if any logger requests them

### Testing
Manual (VS with injected Msbuild)
**Experimental VS insertion:** https://devdiv.visualstudio.com/DevDiv/_git/VS/pullrequest/558711
**Experimental VS insertion for the version which can add properties on both event types:** https://devdiv.visualstudio.com/DevDiv/_git/VS/pullrequest/565788 (yet another: https://devdiv.visualstudio.com/DevDiv/_git/VS/pullrequest/566698)

### Notes
The change was introduced long ago - https://github.com/dotnet/msbuild/commit/794abcbb005017cf3a75850a9f001419bb47bd38 - and it mentiones possible regression concerns if applied to all loggers. I might not have understood it properly - but it seems the concern is more about `ProjectEvaluationStartedEventArgs` - which do not attach the props/items anymore. Having extra data in `ProjectEvaluationFinishedEventargs` even for loggers do not requesting it feels like very low opportunity for breakage (somebody would need to explicitly break on non-null data).
FYI @KirillOsenkov  - in case my thinking is flawed
