### PR TITLE
Add initial Buildcheck codes

### DIFF
--- a/documentation/specs/proposed/BuildCheck/Codes.md
+++ b/documentation/specs/proposed/BuildCheck/Codes.md
@@ -20,16 +20,16 @@ dotnet build -bl -analyze
 
 "Two projects should not share their OutputPath nor IntermediateOutputPath locations"
 
-It is not recommended to share output path nor intermediate output path between multiple projects. Such practice can lead to silent overwrites of the outputs. Such overwrites will depepend on the order of the build, that might not be guaranteed (if not explicitly configured) and hence it can cause nondeterministic behavior of the build.
+It is not recommended to share output path nor intermediate output path between multiple projects. Such practice can lead to silent overwrites of the outputs. Such overwrites will depend on the order of the build, that might not be guaranteed (if not explicitly configured) and hence it can cause nondeterministic behavior of the build.
 
-If you want to produce outputs in a consolidated output folder - you might be looking for [Artifacts output layout](https://learn.microsoft.com/en-us/dotnet/core/sdk/artifacts-output) and/or [Microsoft.Build.Artifacts SDK](https://github.com/microsoft/MSBuildSdks/tree/main/src/Artifacts).
+If you want to produce outputs in a consolidated output folder - consider using the [Artifacts output layout](https://learn.microsoft.com/en-us/dotnet/core/sdk/artifacts-output) and/or [Microsoft.Build.Artifacts SDK](https://github.com/microsoft/MSBuildSdks/tree/main/src/Artifacts).
 
 
 ## <a name="BC0102"></a>BC0102 - Double writes.
 
 "Two tasks should not write the same file"
 
-This is a similar problem as ['BC0101 - Shared output path'](#BC0101) - however with higher granularity. It is not recomended that multiple tasks attempts to write to a single file - as such behavior might lead to nondeterminism of a build (as result can be dependant on the order of the tasks execution if those belong to independent projects) or/and to a lost updates.
+This is a similar problem as ['BC0101 - Shared output path'](#BC0101) - however with higher granularity. It is not recomended that multiple tasks attempt to write to a single file - as such behavior might lead to nondeterminism of a build (as result can be dependent on the order of the tasks execution if those belong to independent projects) or/and to a lost updates.
 
 If you want multiple tasks to update file in a one-by-one pipeline fashion, it is recommended to give each intermediate output a distinct name - preventing silent mixups if any of the tasks in the chain are skipped or removed.
 

--- a/documentation/specs/proposed/BuildCheck/Codes.md
+++ b/documentation/specs/proposed/BuildCheck/Codes.md
@@ -1,0 +1,43 @@
+# `BuildCheck` reports codes and their meaning
+
+Report codes are chosen to conform to suggested guidelines. Those guidelines are currently in revew: https://github.com/dotnet/msbuild/pull/10088
+
+| Exit&nbsp;Code | Reason |
+|:-----|----------|
+| 0 | Success |
+| [BC0101](#BC0101) | Shared output path. |
+| [BC0102](#BC0102) | Double writes. |
+
+
+To enable verbose logging in order to troubleshoot issue(s), enable [binary logging](https://github.com/dotnet/msbuild/blob/main/documentation/wiki/Binary-Log.md#msbuild-binary-log-overview)
+
+_Cmd:_
+```cmd
+dotnet build -bl -analyze
+```
+
+## <a name="BC0101"></a>BC0101 - Shared output path.
+
+"Two projects should not share their OutputPath nor IntermediateOutputPath locations"
+
+It is not recommended to share output path nor intermediate output path between multiple projects. Such practice can lead to silent overwrites of the outputs. Such overwrites will depepend on the order of the build, that might not be guaranteed (if not explicitly configured) and hence it can cause nondeterministic behavior of the build.
+
+If you want to produce outputs in a consolidated output folder - you might be looking for [Artifacts output layout](https://learn.microsoft.com/en-us/dotnet/core/sdk/artifacts-output) and/or [Microsoft.Build.Artifacts SDK](https://github.com/microsoft/MSBuildSdks/tree/main/src/Artifacts).
+
+
+## <a name="BC0102"></a>BC0102 - Double writes.
+
+"Two tasks should not write the same file"
+
+This is a similar problem as ['BC0101 - Shared output path'](#BC0101) - however with higher granularity. It is not recomended that multiple tasks attempts to write to a single file - as such behavior might lead to nondeterminism of a build (as result can be dependant on the order of the tasks execution if those belong to independent projects) or/and to a lost updates.
+
+If you want multiple tasks to update file in a one-by-one pipeline fashion, it is recommended to give each intermediate output a distinct name - preventing silent mixups if any of the tasks in the chain are skipped or removed.
+
+
+
+<BR/>
+<BR/>
+<BR/>
+
+### Related Resources
+* [BuildCheck documentation](https://github.com/dotnet/msbuild/blob/main/documentation/specs/proposed/BuildCheck.md)

--- a/src/Build/BuildCheck/API/BuildCheckResult.cs
+++ b/src/Build/BuildCheck/API/BuildCheckResult.cs
@@ -49,8 +49,9 @@ public sealed class BuildCheckResult : IBuildCheckResult
     public string[] MessageArgs { get; }
     public string MessageFormat => BuildAnalyzerRule.MessageFormat;
 
+    // Here we will provide different link for built-in rules and custom rules - once we have the base classes differentiated.
     public string FormatMessage() =>
-        _message ??= $"{(Equals(Location ?? ElementLocation.EmptyLocation, ElementLocation.EmptyLocation) ? string.Empty : (Location!.LocationString + ": "))}{BuildAnalyzerRule.Id}: {string.Format(BuildAnalyzerRule.MessageFormat, MessageArgs)}";
+        _message ??= $"{(Equals(Location ?? ElementLocation.EmptyLocation, ElementLocation.EmptyLocation) ? string.Empty : (Location!.LocationString + ": "))}{BuildAnalyzerRule.Id}: https://aka.ms/buildcheck/codes#{BuildAnalyzerRule.Id} - {string.Format(BuildAnalyzerRule.MessageFormat, MessageArgs)}";
 
     private string? _message;
 }


### PR DESCRIPTION
Contributes to #10240

### Context
Customer requested to have understandable documentation of individual imposed rules.
Let's follow similar practice we introduced in template engine - with adding short hyperlinks to the outputs, that can then include rich information, that can freely evolve off-cycle.

### Changes Made
Added initial document
Added initial code adding the hyperlink

### What remains TBD for the bug (but out of scope of this PR)

* [ ] Adding a document for custom codes (that will not have enumeration, but just an overview of what custom analyzer are, how they can appear in your build and how you can understand and troubleshoot the reports)
* [ ] Conditionalize the link adding code - so that it uses different link for custom analyzers (this will be easy after https://github.com/dotnet/msbuild/issues/9883 is done - as it'll introduce internal overload of the base class, that will be used by built-in analyzers) 
* [ ] Adding a link to finalized guidelines - once https://github.com/dotnet/msbuild/pull/10088 is finalized

### UX

![image](https://github.com/dotnet/msbuild/assets/3809076/4f96bbc2-93b0-4ceb-bd00-2cacc27f7da6)

