### PR TITLE
Fix bug: No visible message when replaying analyzed build

### DIFF
--- a/MSBuild.Dev.slnf
+++ b/MSBuild.Dev.slnf
@@ -4,6 +4,7 @@
     "projects": [
       "src\\Build.OM.UnitTests\\Microsoft.Build.Engine.OM.UnitTests.csproj",
       "src\\Build.UnitTests\\Microsoft.Build.Engine.UnitTests.csproj",
+      "src\\BuildCheck.UnitTests\\Microsoft.Build.BuildCheck.UnitTests.csproj",
       "src\\Build\\Microsoft.Build.csproj",
       "src\\Framework.UnitTests\\Microsoft.Build.Framework.UnitTests.csproj",
       "src\\Framework\\Microsoft.Build.Framework.csproj",

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
@@ -12,7 +12,6 @@ using Microsoft.Build.BackEnd.Logging;
 using Microsoft.Build.Collections;
 using Microsoft.Build.Evaluation;
 using Microsoft.Build.Execution;
-using Microsoft.Build.Experimental.BuildCheck;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Framework.Profiler;
 using Microsoft.Build.Shared;

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
@@ -598,7 +598,7 @@ namespace Microsoft.Build.Logging
         {
             if ((flags & BuildEventArgsFieldFlags.Message) != 0)
             {
-                if (e is BuildCheckResultWarning)
+                if (e is BuildCheckResultWarning || e is BuildCheckResultError)
                 {
                     WriteDeduplicatedString(e.Message);
                 }

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
@@ -598,14 +598,7 @@ namespace Microsoft.Build.Logging
         {
             if ((flags & BuildEventArgsFieldFlags.Message) != 0)
             {
-                if (e is BuildCheckResultWarning || e is BuildCheckResultError)
-                {
-                    WriteDeduplicatedString(e.Message);
-                }
-                else
-                {
-                    WriteDeduplicatedString(e.RawMessage);
-                }
+                WriteDeduplicatedString(e.RawMessage);
             }
 
             if ((flags & BuildEventArgsFieldFlags.BuildEventContext) != 0)

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
@@ -12,6 +12,7 @@ using Microsoft.Build.BackEnd.Logging;
 using Microsoft.Build.Collections;
 using Microsoft.Build.Evaluation;
 using Microsoft.Build.Execution;
+using Microsoft.Build.Experimental.BuildCheck;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Framework.Profiler;
 using Microsoft.Build.Shared;
@@ -597,7 +598,14 @@ namespace Microsoft.Build.Logging
         {
             if ((flags & BuildEventArgsFieldFlags.Message) != 0)
             {
-                WriteDeduplicatedString(e.RawMessage);
+                if (e is BuildCheckResultWarning)
+                {
+                    WriteDeduplicatedString(e.Message);
+                }
+                else
+                {
+                    WriteDeduplicatedString(e.RawMessage);
+                }
             }
 
             if ((flags & BuildEventArgsFieldFlags.BuildEventContext) != 0)

--- a/src/BuildCheck.UnitTests/EndToEndTests.cs
+++ b/src/BuildCheck.UnitTests/EndToEndTests.cs
@@ -61,12 +61,14 @@ public class EndToEndTests : IDisposable
     }
 
     [Theory]
-    [InlineData(true, true)]
-    [InlineData(false, true)]
-    [InlineData(false, false)]
-    public void SampleAnalyzerIntegrationTest_ReplayBinaryLogOfAnalyzedBuild(bool buildInOutOfProcessNode, bool analysisRequested)
+    [InlineData(true, true, "warning")]
+    [InlineData(true, true, "error")]
+    [InlineData(false, true, "warning")]
+    [InlineData(false, true, "error")]
+    [InlineData(false, false, "warning")]
+    public void SampleAnalyzerIntegrationTest_ReplayBinaryLogOfAnalyzedBuild(bool buildInOutOfProcessNode, bool analysisRequested, string BC0101Severity)
     {
-        PrepareSampleProjectsAndConfig(buildInOutOfProcessNode, out TransientTestFile projectFile);
+        PrepareSampleProjectsAndConfig(buildInOutOfProcessNode, out TransientTestFile projectFile, BC0101Severity);
 
         var projectDirectory = Path.GetDirectoryName(projectFile.Path);
         string logFile = _env.ExpectFile(".binlog").Path;
@@ -96,7 +98,10 @@ public class EndToEndTests : IDisposable
         }
     }
 
-    private void PrepareSampleProjectsAndConfig(bool buildInOutOfProcessNode, out TransientTestFile projectFile)
+    private void PrepareSampleProjectsAndConfig(
+        bool buildInOutOfProcessNode,
+        out TransientTestFile projectFile,
+        string BC0101Severity = "warning")
     {
         TransientTestFolder workFolder = _env.CreateFolder(createFolder: true);
         TransientTestFile testFile = _env.CreateFile(workFolder, "somefile");
@@ -152,12 +157,12 @@ public class EndToEndTests : IDisposable
         TransientTestFile projectFile2 = _env.CreateFile(workFolder, "FooBar-Copy.csproj", contents2);
 
         TransientTestFile config = _env.CreateFile(workFolder, ".editorconfig",
-            """
+            $"""
             root=true
 
             [*.csproj]
             build_check.BC0101.IsEnabled=true
-            build_check.BC0101.Severity=warning
+            build_check.BC0101.Severity={BC0101Severity}
 
             build_check.BC0102.IsEnabled=true
             build_check.BC0102.Severity=warning

--- a/src/BuildCheck.UnitTests/EndToEndTests.cs
+++ b/src/BuildCheck.UnitTests/EndToEndTests.cs
@@ -31,8 +31,7 @@ public class EndToEndTests : IDisposable
 
     public void Dispose() => _env.Dispose();
 
-    // [Theory(Skip = "https://github.com/dotnet/msbuild/issues/10036")]
-    [Theory]
+    [Theory(Skip = "https://github.com/dotnet/msbuild/issues/10036")]
     [InlineData(true, true)]
     [InlineData(false, true)]
     [InlineData(false, false)]
@@ -60,7 +59,7 @@ public class EndToEndTests : IDisposable
         }
     }
 
-    [Theory]
+    [Theory(Skip = "https://github.com/dotnet/msbuild/issues/10036")]
     [InlineData(true, true, "warning")]
     [InlineData(true, true, "error")]
     [InlineData(true, true, "info")]

--- a/src/BuildCheck.UnitTests/EndToEndTests.cs
+++ b/src/BuildCheck.UnitTests/EndToEndTests.cs
@@ -31,11 +31,72 @@ public class EndToEndTests : IDisposable
 
     public void Dispose() => _env.Dispose();
 
-    [Theory(Skip = "https://github.com/dotnet/msbuild/issues/10036")]
+    // [Theory(Skip = "https://github.com/dotnet/msbuild/issues/10036")]
+    [Theory]
     [InlineData(true, true)]
     [InlineData(false, true)]
     [InlineData(false, false)]
-    public void SampleAnalyzerIntegrationTest(bool buildInOutOfProcessNode, bool analysisRequested)
+    public void SampleAnalyzerIntegrationTest_AnalyzeOnBuild(bool buildInOutOfProcessNode, bool analysisRequested)
+    {
+        PrepareSampleProjectsAndConfig(buildInOutOfProcessNode, out TransientTestFile projectFile);
+
+        string output = RunnerUtilities.ExecBootstrapedMSBuild(
+            $"{Path.GetFileName(projectFile.Path)} /m:1 -nr:False -restore" +
+            (analysisRequested ? " -analyze" : string.Empty), out bool success, false, _env.Output, timeoutMilliseconds: 120_000);
+        _env.Output.WriteLine(output);
+
+        success.ShouldBeTrue();
+
+        // The analyzer warnings should appear - but only if analysis was requested.
+        if (analysisRequested)
+        {
+            output.ShouldContain("BC0101");
+            output.ShouldContain("BC0102");
+        }
+        else
+        {
+            output.ShouldNotContain("BC0101");
+            output.ShouldNotContain("BC0102");
+        }
+    }
+
+    [Theory]
+    [InlineData(true, true)]
+    [InlineData(false, true)]
+    [InlineData(false, false)]
+    public void SampleAnalyzerIntegrationTest_ReplayBinaryLogOfAnalyzedBuild(bool buildInOutOfProcessNode, bool analysisRequested)
+    {
+        PrepareSampleProjectsAndConfig(buildInOutOfProcessNode, out TransientTestFile projectFile);
+
+        var projectDirectory = Path.GetDirectoryName(projectFile.Path);
+        string logFile = _env.ExpectFile(".binlog").Path;
+
+        RunnerUtilities.ExecBootstrapedMSBuild(
+            $"{Path.GetFileName(projectFile.Path)} /m:1 -nr:False -restore {(analysisRequested ? "-analyze" : string.Empty)} -bl:{logFile}",
+            out bool success);
+
+        success.ShouldBeTrue();
+
+        string output = RunnerUtilities.ExecBootstrapedMSBuild(
+         $"{logFile} -flp:logfile={Path.Combine(projectDirectory!, "logFile.log")};verbosity=diagnostic",
+         out success, false, _env.Output, timeoutMilliseconds: 130_000);
+
+        _env.Output.WriteLine(output);
+
+        success.ShouldBeTrue();
+
+        // The conflicting outputs warning appears - but only if analysis was requested
+        if (analysisRequested)
+        {
+            output.ShouldContain("BC0101");
+        }
+        else
+        {
+            output.ShouldNotContain("BC0101");
+        }
+    }
+
+    private void PrepareSampleProjectsAndConfig(bool buildInOutOfProcessNode, out TransientTestFile projectFile)
     {
         TransientTestFolder workFolder = _env.CreateFolder(createFolder: true);
         TransientTestFile testFile = _env.CreateFile(workFolder, "somefile");
@@ -87,7 +148,7 @@ public class EndToEndTests : IDisposable
                                
             </Project>
             """;
-        TransientTestFile projectFile = _env.CreateFile(workFolder, "FooBar.csproj", contents);
+        projectFile = _env.CreateFile(workFolder, "FooBar.csproj", contents);
         TransientTestFile projectFile2 = _env.CreateFile(workFolder, "FooBar-Copy.csproj", contents2);
 
         TransientTestFile config = _env.CreateFile(workFolder, ".editorconfig",
@@ -116,22 +177,6 @@ public class EndToEndTests : IDisposable
 
         _env.SetEnvironmentVariable("MSBUILDNOINPROCNODE", buildInOutOfProcessNode ? "1" : "0");
         _env.SetEnvironmentVariable("MSBUILDLOGPROPERTIESANDITEMSAFTEREVALUATION", "1");
-        string output = RunnerUtilities.ExecBootstrapedMSBuild(
-            $"{Path.GetFileName(projectFile.Path)} /m:1 -nr:False -restore" +
-            (analysisRequested ? " -analyze" : string.Empty), out bool success, false, _env.Output, timeoutMilliseconds: 120_000);
-        _env.Output.WriteLine(output);
-        success.ShouldBeTrue();
-        // The analyzer warnings should appear - but only if analysis was requested.
-        if (analysisRequested)
-        {
-            output.ShouldContain("BC0101");
-            output.ShouldContain("BC0102");
-        }
-        else
-        {
-            output.ShouldNotContain("BC0101");
-            output.ShouldNotContain("BC0102");
-        }
     }
 
     [Theory]

--- a/src/BuildCheck.UnitTests/EndToEndTests.cs
+++ b/src/BuildCheck.UnitTests/EndToEndTests.cs
@@ -63,8 +63,10 @@ public class EndToEndTests : IDisposable
     [Theory]
     [InlineData(true, true, "warning")]
     [InlineData(true, true, "error")]
+    [InlineData(true, true, "info")]
     [InlineData(false, true, "warning")]
     [InlineData(false, true, "error")]
+    [InlineData(false, true, "info")]
     [InlineData(false, false, "warning")]
     public void SampleAnalyzerIntegrationTest_ReplayBinaryLogOfAnalyzedBuild(bool buildInOutOfProcessNode, bool analysisRequested, string BC0101Severity)
     {
@@ -91,10 +93,12 @@ public class EndToEndTests : IDisposable
         if (analysisRequested)
         {
             output.ShouldContain("BC0101");
+            output.ShouldContain("BC0102");
         }
         else
         {
             output.ShouldNotContain("BC0101");
+            output.ShouldNotContain("BC0102");
         }
     }
 

--- a/src/BuildCheck.UnitTests/EndToEndTests.cs
+++ b/src/BuildCheck.UnitTests/EndToEndTests.cs
@@ -76,13 +76,13 @@ public class EndToEndTests : IDisposable
 
         RunnerUtilities.ExecBootstrapedMSBuild(
             $"{Path.GetFileName(projectFile.Path)} /m:1 -nr:False -restore {(analysisRequested ? "-analyze" : string.Empty)} -bl:{logFile}",
-            out bool success);
+            out bool success, false, _env.Output, timeoutMilliseconds: 120_000);
 
         success.ShouldBeTrue();
 
         string output = RunnerUtilities.ExecBootstrapedMSBuild(
          $"{logFile} -flp:logfile={Path.Combine(projectDirectory!, "logFile.log")};verbosity=diagnostic",
-         out success, false, _env.Output, timeoutMilliseconds: 130_000);
+         out success, false, _env.Output, timeoutMilliseconds: 120_000);
 
         _env.Output.WriteLine(output);
 

--- a/src/Framework/BuildCheck/BuildCheckEventArgs.cs
+++ b/src/Framework/BuildCheck/BuildCheckEventArgs.cs
@@ -109,7 +109,7 @@ internal sealed class BuildCheckResultWarning : BuildWarningEventArgs
 {
     public BuildCheckResultWarning(IBuildCheckResult result)
     {
-        this.Message = result.FormatMessage();
+        RawMessage = result.FormatMessage();
     }
 
     internal BuildCheckResultWarning() { }
@@ -118,24 +118,22 @@ internal sealed class BuildCheckResultWarning : BuildWarningEventArgs
     {
         base.WriteToStream(writer);
 
-        writer.Write(Message!);
+        writer.Write(RawMessage!);
     }
 
     internal override void CreateFromStream(BinaryReader reader, int version)
     {
         base.CreateFromStream(reader, version);
 
-        Message = reader.ReadString();
+        RawMessage = reader.ReadString();
     }
-
-    public override string? Message { get; protected set; }
 }
 
 internal sealed class BuildCheckResultError : BuildErrorEventArgs
 {
     public BuildCheckResultError(IBuildCheckResult result)
     {
-        this.Message = result.FormatMessage();
+        RawMessage = result.FormatMessage();
     }
 
     internal BuildCheckResultError() { }
@@ -144,24 +142,22 @@ internal sealed class BuildCheckResultError : BuildErrorEventArgs
     {
         base.WriteToStream(writer);
 
-        writer.Write(Message!);
+        writer.Write(RawMessage!);
     }
 
     internal override void CreateFromStream(BinaryReader reader, int version)
     {
         base.CreateFromStream(reader, version);
 
-        Message = reader.ReadString();
+        RawMessage = reader.ReadString();
     }
-
-    public override string? Message { get; protected set; }
 }
 
 internal sealed class BuildCheckResultMessage : BuildMessageEventArgs
 {
     public BuildCheckResultMessage(IBuildCheckResult result)
     {
-        this.Message = result.FormatMessage();
+        RawMessage = result.FormatMessage();
     }
 
     internal BuildCheckResultMessage() { }
@@ -170,15 +166,13 @@ internal sealed class BuildCheckResultMessage : BuildMessageEventArgs
     {
         base.WriteToStream(writer);
 
-        writer.Write(Message!);
+        writer.Write(RawMessage!);
     }
 
     internal override void CreateFromStream(BinaryReader reader, int version)
     {
         base.CreateFromStream(reader, version);
 
-        Message = reader.ReadString();
+        RawMessage = reader.ReadString();
     }
-
-    public override string? Message { get; protected set; }
 }


### PR DESCRIPTION
Fixes #10264

### Changes Made
The problem was that here in  `BuildEventArgsWriter.cs` the `RawMessage` is written. And we set `Message` for BuildCheck results not the `RawMessage`.
https://github.com/dotnet/msbuild/blob/4a45d56330882a5e596e97d05ba568ec32e0603c/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs#L596-L601

### Testing
Added test

### Notes
