### PR TITLE
Nullable annotations for ErrorUtilities

### DIFF
--- a/src/Framework/ErrorUtilities.cs
+++ b/src/Framework/ErrorUtilities.cs
@@ -2,8 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-
-#nullable disable
+using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Build.Framework
 {
@@ -22,11 +21,11 @@ namespace Microsoft.Build.Framework
         /// </summary>
         /// <param name="condition"></param>
         /// <param name="unformattedMessage"></param>
-        internal static void VerifyThrow(bool condition, string unformattedMessage)
+        internal static void VerifyThrow([DoesNotReturnIf(false)] bool condition, string unformattedMessage)
         {
             if (!condition)
             {
-                ThrowInternalError(unformattedMessage, null, null);
+                ThrowInternalError(unformattedMessage, innerException: null, args: null);
             }
         }
 
@@ -37,9 +36,9 @@ namespace Microsoft.Build.Framework
         /// </summary>
         /// <param name="parameter">The value of the argument.</param>
         /// <param name="parameterName">Parameter that should not be null.</param>
-        internal static void VerifyThrowInternalNull(object parameter, string parameterName)
+        internal static void VerifyThrowInternalNull([NotNull] object? parameter, string parameterName)
         {
-            if (parameter == null)
+            if (parameter is null)
             {
                 ThrowInternalError("{0} unexpectedly null", innerException: null, args: parameterName);
             }
@@ -49,9 +48,14 @@ namespace Microsoft.Build.Framework
         /// Throws InternalErrorException.
         /// This is only for situations that would mean that there is a bug in MSBuild itself.
         /// </summary>
-        internal static void ThrowInternalError(string message, Exception innerException, params object[] args)
+        [DoesNotReturn]
+        internal static void ThrowInternalError(string message, Exception? innerException, params object?[]? args)
         {
-            throw new InternalErrorException(string.Format(message, args), innerException);
+            throw new InternalErrorException(
+                args is null ?
+                    message :
+                    string.Format(message, args),
+                innerException);
         }
     }
 }

--- a/src/MSBuildTaskHost/MSBuildTaskHost.csproj
+++ b/src/MSBuildTaskHost/MSBuildTaskHost.csproj
@@ -66,6 +66,7 @@
       <Link>IExtendedBuildEventArgs.cs</Link>
     </Compile>
     <Compile Include="..\Framework\AssemblyUtilities.cs" />
+    <Compile Include="..\Framework\NullableAttributes.cs" />
     <Compile Include="..\Framework\ResponseFileUsedEventArgs.cs" />
     <Compile Include="..\Shared\BufferedReadStream.cs" />
     <Compile Include="..\Shared\CollectionHelpers.cs" />

--- a/src/Shared/ErrorUtilities.cs
+++ b/src/Shared/ErrorUtilities.cs
@@ -4,12 +4,11 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
 using System.Threading;
 using Microsoft.Build.Framework;
-
-#nullable disable
 
 #if BUILDINGAPPXTASKS
 namespace Microsoft.Build.AppxPackage.Shared
@@ -24,7 +23,7 @@ namespace Microsoft.Build.Shared
     {
         private static readonly bool s_enableMSBuildDebugTracing = !String.IsNullOrEmpty(Environment.GetEnvironmentVariable("MSBUILDENABLEDEBUGTRACING"));
 
-        public static void DebugTraceMessage(string category, string formatstring, params object[] parameters)
+        public static void DebugTraceMessage(string category, string formatstring, params object[]? parameters)
         {
             if (s_enableMSBuildDebugTracing)
             {
@@ -41,7 +40,7 @@ namespace Microsoft.Build.Shared
 
 #if !BUILDINGAPPXTASKS
 
-        internal static void VerifyThrowInternalError(bool condition, string message, params object[] args)
+        internal static void VerifyThrowInternalError([DoesNotReturnIf(false)] bool condition, string message, params object?[]? args)
         {
             if (!condition)
             {
@@ -53,7 +52,8 @@ namespace Microsoft.Build.Shared
         /// Throws InternalErrorException.
         /// This is only for situations that would mean that there is a bug in MSBuild itself.
         /// </summary>
-        internal static void ThrowInternalError(string message, params object[] args)
+        [DoesNotReturn]
+        internal static void ThrowInternalError(string message, params object?[]? args)
         {
             throw new InternalErrorException(ResourceUtilities.FormatString(message, args));
         }
@@ -62,7 +62,8 @@ namespace Microsoft.Build.Shared
         /// Throws InternalErrorException.
         /// This is only for situations that would mean that there is a bug in MSBuild itself.
         /// </summary>
-        internal static void ThrowInternalError(string message, Exception innerException, params object[] args)
+        [DoesNotReturn]
+        internal static void ThrowInternalError(string message, Exception? innerException, params object?[]? args)
         {
             throw new InternalErrorException(ResourceUtilities.FormatString(message, args), innerException);
         }
@@ -72,6 +73,7 @@ namespace Microsoft.Build.Shared
         /// Indicates the code path followed should not have been possible.
         /// This is only for situations that would mean that there is a bug in MSBuild itself.
         /// </summary>
+        [DoesNotReturn]
         internal static void ThrowInternalErrorUnreachable()
         {
             throw new InternalErrorException("Unreachable?");
@@ -82,7 +84,7 @@ namespace Microsoft.Build.Shared
         /// Indicates the code path followed should not have been possible.
         /// This is only for situations that would mean that there is a bug in MSBuild itself.
         /// </summary>
-        internal static void VerifyThrowInternalErrorUnreachable(bool condition)
+        internal static void VerifyThrowInternalErrorUnreachable([DoesNotReturnIf(false)] bool condition)
         {
             if (!condition)
             {
@@ -101,7 +103,7 @@ namespace Microsoft.Build.Shared
             // Check it has a real implementation of ToString()
             if (String.Equals(param.GetType().ToString(), param.ToString(), StringComparison.Ordinal))
             {
-                ThrowInternalError("This type does not implement ToString() properly {0}", param.GetType().FullName);
+                ThrowInternalError("This type does not implement ToString() properly {0}", param.GetType().FullName!);
             }
 #endif
         }
@@ -113,9 +115,9 @@ namespace Microsoft.Build.Shared
         /// </summary>
         /// <param name="parameter">The value of the argument.</param>
         /// <param name="parameterName">Parameter that should not be null</param>
-        internal static void VerifyThrowInternalNull(object parameter, string parameterName)
+        internal static void VerifyThrowInternalNull([NotNull] object? parameter, string parameterName)
         {
-            if (parameter == null)
+            if (parameter is null)
             {
                 ThrowInternalError("{0} unexpectedly null", parameterName);
             }
@@ -144,7 +146,7 @@ namespace Microsoft.Build.Shared
         /// </summary>
         /// <param name="parameterValue">The value of the argument.</param>
         /// <param name="parameterName">Parameter that should not be null or zero length</param>
-        internal static void VerifyThrowInternalLength(string parameterValue, string parameterName)
+        internal static void VerifyThrowInternalLength([NotNull] string? parameterValue, string parameterName)
         {
             VerifyThrowInternalNull(parameterValue, parameterName);
 
@@ -154,7 +156,7 @@ namespace Microsoft.Build.Shared
             }
         }
 
-        public static void VerifyThrowInternalLength<T>(T[] parameterValue, string parameterName)
+        public static void VerifyThrowInternalLength<T>([NotNull] T[]? parameterValue, string parameterName)
         {
             VerifyThrowInternalNull(parameterValue, parameterName);
 
@@ -185,7 +187,7 @@ namespace Microsoft.Build.Shared
         /// code somewhere. This should not be used to throw errors based on bad
         /// user input or anything that the user did wrong.
         /// </summary>
-        internal static void VerifyThrow(bool condition, string unformattedMessage)
+        internal static void VerifyThrow([DoesNotReturnIf(false)] bool condition, string unformattedMessage)
         {
             if (!condition)
             {
@@ -196,7 +198,7 @@ namespace Microsoft.Build.Shared
         /// <summary>
         /// Overload for one string format argument.
         /// </summary>
-        internal static void VerifyThrow(bool condition, string unformattedMessage, object arg0)
+        internal static void VerifyThrow([DoesNotReturnIf(false)] bool condition, string unformattedMessage, object arg0)
         {
             if (!condition)
             {
@@ -207,7 +209,7 @@ namespace Microsoft.Build.Shared
         /// <summary>
         /// Overload for two string format arguments.
         /// </summary>
-        internal static void VerifyThrow(bool condition, string unformattedMessage, object arg0, object arg1)
+        internal static void VerifyThrow([DoesNotReturnIf(false)] bool condition, string unformattedMessage, object arg0, object arg1)
         {
             if (!condition)
             {
@@ -218,7 +220,7 @@ namespace Microsoft.Build.Shared
         /// <summary>
         /// Overload for three string format arguments.
         /// </summary>
-        internal static void VerifyThrow(bool condition, string unformattedMessage, object arg0, object arg1, object arg2)
+        internal static void VerifyThrow([DoesNotReturnIf(false)] bool condition, string unformattedMessage, object arg0, object arg1, object arg2)
         {
             if (!condition)
             {
@@ -229,7 +231,7 @@ namespace Microsoft.Build.Shared
         /// <summary>
         /// Overload for four string format arguments.
         /// </summary>
-        internal static void VerifyThrow(bool condition, string unformattedMessage, object arg0, object arg1, object arg2, object arg3)
+        internal static void VerifyThrow([DoesNotReturnIf(false)] bool condition, string unformattedMessage, object arg0, object arg1, object arg2, object arg3)
         {
             if (!condition)
             {
@@ -242,7 +244,8 @@ namespace Microsoft.Build.Shared
         /// </summary>
         /// <param name="resourceName">Resource to use in the exception</param>
         /// <param name="args">Formatting args.</param>
-        internal static void ThrowInvalidOperation(string resourceName, params object[] args)
+        [DoesNotReturn]
+        internal static void ThrowInvalidOperation(string resourceName, params object?[]? args)
         {
             throw new InvalidOperationException(ResourceUtilities.FormatResourceStringStripCodeAndKeyword(resourceName, args));
         }
@@ -250,7 +253,7 @@ namespace Microsoft.Build.Shared
         /// <summary>
         /// Throws an InvalidOperationException if the given condition is false.
         /// </summary>
-        internal static void VerifyThrowInvalidOperation(bool condition, string resourceName)
+        internal static void VerifyThrowInvalidOperation([DoesNotReturnIf(false)] bool condition, string resourceName)
         {
             ResourceUtilities.VerifyResourceStringExists(resourceName);
             if (!condition)
@@ -262,7 +265,7 @@ namespace Microsoft.Build.Shared
         /// <summary>
         /// Overload for one string format argument.
         /// </summary>
-        internal static void VerifyThrowInvalidOperation(bool condition, string resourceName, object arg0)
+        internal static void VerifyThrowInvalidOperation([DoesNotReturnIf(false)] bool condition, string resourceName, object arg0)
         {
             ResourceUtilities.VerifyResourceStringExists(resourceName);
             // PERF NOTE: check the condition here instead of pushing it into
@@ -277,7 +280,7 @@ namespace Microsoft.Build.Shared
         /// <summary>
         /// Overload for two string format arguments.
         /// </summary>
-        internal static void VerifyThrowInvalidOperation(bool condition, string resourceName, object arg0, object arg1)
+        internal static void VerifyThrowInvalidOperation([DoesNotReturnIf(false)] bool condition, string resourceName, object arg0, object arg1)
         {
             ResourceUtilities.VerifyResourceStringExists(resourceName);
             // PERF NOTE: check the condition here instead of pushing it into
@@ -292,7 +295,7 @@ namespace Microsoft.Build.Shared
         /// <summary>
         /// Overload for three string format arguments.
         /// </summary>
-        internal static void VerifyThrowInvalidOperation(bool condition, string resourceName, object arg0, object arg1, object arg2)
+        internal static void VerifyThrowInvalidOperation([DoesNotReturnIf(false)] bool condition, string resourceName, object arg0, object arg1, object arg2)
         {
             ResourceUtilities.VerifyResourceStringExists(resourceName);
             // PERF NOTE: check the condition here instead of pushing it into
@@ -307,7 +310,7 @@ namespace Microsoft.Build.Shared
         /// <summary>
         /// Overload for four string format arguments.
         /// </summary>
-        internal static void VerifyThrowInvalidOperation(bool condition, string resourceName, object arg0, object arg1, object arg2, object arg3)
+        internal static void VerifyThrowInvalidOperation([DoesNotReturnIf(false)] bool condition, string resourceName, object arg0, object arg1, object arg2, object arg3)
         {
             ResourceUtilities.VerifyResourceStringExists(resourceName);
 
@@ -327,7 +330,8 @@ namespace Microsoft.Build.Shared
         /// is expensive, because memory is allocated for the array of arguments -- do
         /// not call this method repeatedly in performance-critical scenarios
         /// </summary>
-        internal static void ThrowArgument(string resourceName, params object[] args)
+        [DoesNotReturn]
+        internal static void ThrowArgument(string resourceName, params object?[]? args)
         {
             ThrowArgument(null, resourceName, args);
         }
@@ -345,7 +349,8 @@ namespace Microsoft.Build.Shared
         /// <param name="innerException">Can be null.</param>
         /// <param name="resourceName"></param>
         /// <param name="args"></param>
-        internal static void ThrowArgument(Exception innerException, string resourceName, params object[] args)
+        [DoesNotReturn]
+        internal static void ThrowArgument(Exception? innerException, string resourceName, params object?[]? args)
         {
             throw new ArgumentException(ResourceUtilities.FormatResourceStringStripCodeAndKeyword(resourceName, args), innerException);
         }
@@ -353,7 +358,7 @@ namespace Microsoft.Build.Shared
         /// <summary>
         /// Throws an ArgumentException if the given condition is false.
         /// </summary>
-        internal static void VerifyThrowArgument(bool condition, string resourceName)
+        internal static void VerifyThrowArgument([DoesNotReturnIf(false)] bool condition, string resourceName)
         {
             VerifyThrowArgument(condition, null, resourceName);
         }
@@ -361,7 +366,7 @@ namespace Microsoft.Build.Shared
         /// <summary>
         /// Overload for one string format argument.
         /// </summary>
-        internal static void VerifyThrowArgument(bool condition, string resourceName, object arg0)
+        internal static void VerifyThrowArgument([DoesNotReturnIf(false)] bool condition, string resourceName, object arg0)
         {
             VerifyThrowArgument(condition, null, resourceName, arg0);
         }
@@ -369,7 +374,7 @@ namespace Microsoft.Build.Shared
         /// <summary>
         /// Overload for two string format arguments.
         /// </summary>
-        internal static void VerifyThrowArgument(bool condition, string resourceName, object arg0, object arg1)
+        internal static void VerifyThrowArgument([DoesNotReturnIf(false)] bool condition, string resourceName, object arg0, object arg1)
         {
             VerifyThrowArgument(condition, null, resourceName, arg0, arg1);
         }
@@ -377,7 +382,7 @@ namespace Microsoft.Build.Shared
         /// <summary>
         /// Overload for three string format arguments.
         /// </summary>
-        internal static void VerifyThrowArgument(bool condition, string resourceName, object arg0, object arg1, object arg2)
+        internal static void VerifyThrowArgument([DoesNotReturnIf(false)] bool condition, string resourceName, object arg0, object arg1, object arg2)
         {
             VerifyThrowArgument(condition, null, resourceName, arg0, arg1, arg2);
         }
@@ -385,7 +390,7 @@ namespace Microsoft.Build.Shared
         /// <summary>
         /// Overload for four string format arguments.
         /// </summary>
-        internal static void VerifyThrowArgument(bool condition, string resourceName, object arg0, object arg1, object arg2, object arg3)
+        internal static void VerifyThrowArgument([DoesNotReturnIf(false)] bool condition, string resourceName, object arg0, object arg1, object arg2, object arg3)
         {
             VerifyThrowArgument(condition, null, resourceName, arg0, arg1, arg2, arg3);
         }
@@ -397,7 +402,7 @@ namespace Microsoft.Build.Shared
         /// <param name="condition"></param>
         /// <param name="innerException">Can be null.</param>
         /// <param name="resourceName"></param>
-        internal static void VerifyThrowArgument(bool condition, Exception innerException, string resourceName)
+        internal static void VerifyThrowArgument([DoesNotReturnIf(false)] bool condition, Exception? innerException, string resourceName)
         {
             ResourceUtilities.VerifyResourceStringExists(resourceName);
             if (!condition)
@@ -409,7 +414,7 @@ namespace Microsoft.Build.Shared
         /// <summary>
         /// Overload for one string format argument.
         /// </summary>
-        internal static void VerifyThrowArgument(bool condition, Exception innerException, string resourceName, object arg0)
+        internal static void VerifyThrowArgument([DoesNotReturnIf(false)] bool condition, Exception? innerException, string resourceName, object arg0)
         {
             ResourceUtilities.VerifyResourceStringExists(resourceName);
 
@@ -422,7 +427,7 @@ namespace Microsoft.Build.Shared
         /// <summary>
         /// Overload for two string format arguments.
         /// </summary>
-        internal static void VerifyThrowArgument(bool condition, Exception innerException, string resourceName, object arg0, object arg1)
+        internal static void VerifyThrowArgument([DoesNotReturnIf(false)] bool condition, Exception? innerException, string resourceName, object arg0, object arg1)
         {
             ResourceUtilities.VerifyResourceStringExists(resourceName);
 
@@ -435,7 +440,7 @@ namespace Microsoft.Build.Shared
         /// <summary>
         /// Overload for three string format arguments.
         /// </summary>
-        internal static void VerifyThrowArgument(bool condition, Exception innerException, string resourceName, object arg0, object arg1, object arg2)
+        internal static void VerifyThrowArgument([DoesNotReturnIf(false)] bool condition, Exception? innerException, string resourceName, object arg0, object arg1, object arg2)
         {
             ResourceUtilities.VerifyResourceStringExists(resourceName);
 
@@ -448,7 +453,7 @@ namespace Microsoft.Build.Shared
         /// <summary>
         /// Overload for four string format arguments.
         /// </summary>
-        internal static void VerifyThrowArgument(bool condition, Exception innerException, string resourceName, object arg0, object arg1, object arg2, object arg3)
+        internal static void VerifyThrowArgument([DoesNotReturnIf(false)] bool condition, Exception? innerException, string resourceName, object arg0, object arg1, object arg2, object arg3)
         {
             ResourceUtilities.VerifyResourceStringExists(resourceName);
 
@@ -461,6 +466,7 @@ namespace Microsoft.Build.Shared
         /// <summary>
         /// Throws an argument out of range exception.
         /// </summary>
+        [DoesNotReturn]
         internal static void ThrowArgumentOutOfRange(string parameterName)
         {
             throw new ArgumentOutOfRangeException(parameterName);
@@ -470,7 +476,7 @@ namespace Microsoft.Build.Shared
         /// Throws an ArgumentOutOfRangeException using the given parameter name
         /// if the condition is false.
         /// </summary>
-        internal static void VerifyThrowArgumentOutOfRange(bool condition, string parameterName)
+        internal static void VerifyThrowArgumentOutOfRange([DoesNotReturnIf(false)] bool condition, string parameterName)
         {
             if (!condition)
             {
@@ -482,7 +488,7 @@ namespace Microsoft.Build.Shared
         /// Throws an ArgumentNullException if the given string parameter is null
         /// and ArgumentException if it has zero length.
         /// </summary>
-        internal static void VerifyThrowArgumentLength(string parameter, string parameterName)
+        internal static void VerifyThrowArgumentLength([NotNull] string? parameter, string parameterName)
         {
             VerifyThrowArgumentNull(parameter, parameterName);
 
@@ -497,7 +503,7 @@ namespace Microsoft.Build.Shared
         /// Throws an ArgumentNullException if the given collection is null
         /// and ArgumentException if it has zero length.
         /// </summary>
-        internal static void VerifyThrowArgumentLength<T>(IReadOnlyCollection<T> parameter, string parameterName)
+        internal static void VerifyThrowArgumentLength<T>([NotNull] IReadOnlyCollection<T> parameter, string parameterName)
         {
             VerifyThrowArgumentNull(parameter, parameterName);
 
@@ -510,7 +516,7 @@ namespace Microsoft.Build.Shared
         /// <summary>
         /// Throws an ArgumentException if the given collection is not null but of zero length.
         /// </summary>
-        internal static void VerifyThrowArgumentLengthIfNotNull<T>(IReadOnlyCollection<T> parameter, string parameterName)
+        internal static void VerifyThrowArgumentLengthIfNotNull<T>([MaybeNull] IReadOnlyCollection<T>? parameter, string parameterName)
         {
             if (parameter?.Count == 0)
             {
@@ -518,6 +524,8 @@ namespace Microsoft.Build.Shared
             }
         }
 #endif
+
+        [DoesNotReturn]
         private static void ThrowArgumentLength(string parameterName)
         {
             throw new ArgumentException(ResourceUtilities.FormatResourceStringStripCodeAndKeyword("Shared.ParameterCannotHaveZeroLength", parameterName));
@@ -527,7 +535,7 @@ namespace Microsoft.Build.Shared
         /// Throws an ArgumentNullException if the given string parameter is null
         /// and ArgumentException if it has zero length.
         /// </summary>
-        internal static void VerifyThrowArgumentInvalidPath(string parameter, string parameterName)
+        internal static void VerifyThrowArgumentInvalidPath([NotNull] string parameter, string parameterName)
         {
             VerifyThrowArgumentNull(parameter, parameterName);
 
@@ -541,7 +549,7 @@ namespace Microsoft.Build.Shared
         /// Throws an ArgumentException if the string has zero length, unless it is
         /// null, in which case no exception is thrown.
         /// </summary>
-        internal static void VerifyThrowArgumentLengthIfNotNull(string parameter, string parameterName)
+        internal static void VerifyThrowArgumentLengthIfNotNull(string? parameter, string parameterName)
         {
             if (parameter?.Length == 0)
             {
@@ -552,7 +560,7 @@ namespace Microsoft.Build.Shared
         /// <summary>
         /// Throws an ArgumentNullException if the given parameter is null.
         /// </summary>
-        internal static void VerifyThrowArgumentNull(object parameter, string parameterName)
+        internal static void VerifyThrowArgumentNull([NotNull] object? parameter, string parameterName)
         {
             VerifyThrowArgumentNull(parameter, parameterName, "Shared.ParameterCannotBeNull");
         }
@@ -560,36 +568,23 @@ namespace Microsoft.Build.Shared
         /// <summary>
         /// Throws an ArgumentNullException if the given parameter is null.
         /// </summary>
-        internal static void VerifyThrowArgumentNull(object parameter, string parameterName, string resourceName)
+        internal static void VerifyThrowArgumentNull([NotNull] object? parameter, string parameterName, string resourceName)
         {
             ResourceUtilities.VerifyResourceStringExists(resourceName);
-            if (parameter == null)
+            if (parameter is null)
             {
                 ThrowArgumentNull(parameterName, resourceName);
             }
         }
 
-        internal static void ThrowArgumentNull(string parameterName, string resourceName)
+        [DoesNotReturn]
+        internal static void ThrowArgumentNull(string? parameterName, string resourceName)
         {
             // Most ArgumentNullException overloads append its own rather clunky multi-line message. So use the one overload that doesn't.
-            throw new ArgumentNullException(ResourceUtilities.FormatResourceStringStripCodeAndKeyword(resourceName, parameterName), (Exception)null);
+            throw new ArgumentNullException(ResourceUtilities.FormatResourceStringStripCodeAndKeyword(resourceName, parameterName), (Exception?)null);
         }
 
-        /// <summary>
-        /// Verifies the given arrays are not null and have the same length
-        /// </summary>
-        internal static void VerifyThrowArgumentArraysSameLength(Array parameter1, Array parameter2, string parameter1Name, string parameter2Name)
-        {
-            VerifyThrowArgumentNull(parameter1, parameter1Name);
-            VerifyThrowArgumentNull(parameter2, parameter2Name);
-
-            if (parameter1.Length != parameter2.Length)
-            {
-                ThrowArgument("Shared.ParametersMustHaveTheSameLength", parameter1Name, parameter2Name);
-            }
-        }
-
-        internal static void VerifyThrowObjectDisposed(bool condition, string objectName)
+        internal static void VerifyThrowObjectDisposed([DoesNotReturnIf(false)] bool condition, string objectName)
         {
             if (!condition)
             {
@@ -597,6 +592,7 @@ namespace Microsoft.Build.Shared
             }
         }
 
+        [DoesNotReturn]
         internal static void ThrowObjectDisposed(string objectName)
         {
             throw new ObjectDisposedException(objectName);
@@ -610,7 +606,7 @@ namespace Microsoft.Build.Shared
         /// <exception cref="ArgumentException">If there is insufficient capacity to copy the collection contents into <paramref name="array"/>
         /// when starting at <paramref name="arrayIndex"/>.</exception>
         internal static void VerifyCollectionCopyToArguments<T>(
-            T[] array,
+            [NotNull] T[]? array,
             string arrayParameterName,
             int arrayIndex,
             string arrayIndexParameterName,

--- a/src/Shared/UnitTests/ErrorUtilities_Tests.cs
+++ b/src/Shared/UnitTests/ErrorUtilities_Tests.cs
@@ -70,38 +70,5 @@ namespace Microsoft.Build.UnitTests
             // This shouldn't throw.
             ErrorUtilities.VerifyThrow(true, "{0}{1}{2}{3}", "a", "b", "c", "d");
         }
-
-        [Fact]
-        public void VerifyThrowArgumentArraysSameLength1()
-        {
-            Assert.Throws<ArgumentNullException>(() =>
-            {
-                ErrorUtilities.VerifyThrowArgumentArraysSameLength(null, new string[1], string.Empty, string.Empty);
-            });
-        }
-
-        [Fact]
-        public void VerifyThrowArgumentArraysSameLength2()
-        {
-            Assert.Throws<ArgumentNullException>(() =>
-            {
-                ErrorUtilities.VerifyThrowArgumentArraysSameLength(new string[1], null, string.Empty, string.Empty);
-            });
-        }
-
-        [Fact]
-        public void VerifyThrowArgumentArraysSameLength3()
-        {
-            Assert.Throws<ArgumentException>(() =>
-            {
-                ErrorUtilities.VerifyThrowArgumentArraysSameLength(new string[1], new string[2], string.Empty, string.Empty);
-            });
-        }
-
-        [Fact]
-        public void VerifyThrowArgumentArraysSameLength4()
-        {
-            ErrorUtilities.VerifyThrowArgumentArraysSameLength(new string[1], new string[1], string.Empty, string.Empty);
-        }
     }
 }


### PR DESCRIPTION
This will help with using these from new code that's nullable-
aware. The biggest helpful bit is the `[NotNull]` ones that let the
compiler know to assume that parameter is non-null in the rest
of the method, which should eliminate the need for some `!`s
after calling `VerifyThrowArgumentNull(whatever)`.
