### PR TITLE
Add comment about localization

### DIFF
--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -34,7 +34,7 @@ variables:
     - name: SourceBranch
       value: ''
   - name: EnableReleaseOneLocBuild
-    value: true
+    value: true # Enable loc for vs17.12
   - name: Codeql.Enabled
     value: true
   - group: DotNet-MSBuild-SDLValidation-Params


### PR DESCRIPTION
Adding a comment about localization in order to cause a merge conflict in the next release branch, when we will be disabling the localization in the previous release branch and the change flows automatically to later releases and main. 

See https://github.com/dotnet/msbuild/pull/10269#discussion_r1646558936