### PR TITLE
Fix possible ToolTask hang

### DIFF
--- a/documentation/wiki/ChangeWaves.md
+++ b/documentation/wiki/ChangeWaves.md
@@ -28,7 +28,7 @@ A wave of features is set to "rotate out" (i.e. become standard functionality) t
 - [Convert.ToString during a property evaluation uses the InvariantCulture for all types](https://github.com/dotnet/msbuild/pull/9874)
 - [Fix oversharing of build results in ResultsCache](https://github.com/dotnet/msbuild/pull/9987)
 - [Add ParameterName and PropertyName to TaskParameterEventArgs](https://github.com/dotnet/msbuild/pull/10130)
-- [The ToolTask only waits to terminate for its child process](https://github.com/dotnet/msbuild/pull/10297)
+- [The ToolTask only waits for its child process to end before returning, instead of waiting for grandchildren](https://github.com/dotnet/msbuild/pull/10297)
 
 ### 17.10
 - [AppDomain configuration is serialized without using BinFmt](https://github.com/dotnet/msbuild/pull/9320) - feature can be opted out only if [BinaryFormatter](https://learn.microsoft.com/en-us/dotnet/api/system.runtime.serialization.formatters.binary.binaryformatter) is allowed at runtime by editing `MSBuild.runtimeconfig.json`

--- a/documentation/wiki/ChangeWaves.md
+++ b/documentation/wiki/ChangeWaves.md
@@ -28,6 +28,7 @@ A wave of features is set to "rotate out" (i.e. become standard functionality) t
 - [Convert.ToString during a property evaluation uses the InvariantCulture for all types](https://github.com/dotnet/msbuild/pull/9874)
 - [Fix oversharing of build results in ResultsCache](https://github.com/dotnet/msbuild/pull/9987)
 - [Add ParameterName and PropertyName to TaskParameterEventArgs](https://github.com/dotnet/msbuild/pull/10130)
+- [The ToolTask only waits to terminate for its child process](https://github.com/dotnet/msbuild/pull/10297)
 
 ### 17.10
 - [AppDomain configuration is serialized without using BinFmt](https://github.com/dotnet/msbuild/pull/9320) - feature can be opted out only if [BinaryFormatter](https://learn.microsoft.com/en-us/dotnet/api/system.runtime.serialization.formatters.binary.binaryformatter) is allowed at runtime by editing `MSBuild.runtimeconfig.json`

--- a/src/Utilities/ToolTask.cs
+++ b/src/Utilities/ToolTask.cs
@@ -1053,9 +1053,16 @@ namespace Microsoft.Build.Utilities
         /// <param name="proc"></param>
         private static void WaitForProcessExit(Process proc)
         {
-            // Using overload with timeout prevents hanging in case that grandchild process is still running
-            // See https://github.com/dotnet/runtime/issues/51277 and https://github.com/dotnet/msbuild/issues/2981#issuecomment-818581362
-            proc.WaitForExit(int.MaxValue);
+            if (ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_12))
+            {
+                // Using overload with timeout prevents hanging in case that grandchild process is still running
+                // See https://github.com/dotnet/runtime/issues/51277 and https://github.com/dotnet/msbuild/issues/2981#issuecomment-818581362
+                proc.WaitForExit(int.MaxValue);
+            }
+            else
+            {
+                proc.WaitForExit();
+            }
 
             // Process.WaitForExit() may return prematurely. We need to check to be sure.
             while (!proc.HasExited)

--- a/src/Utilities/ToolTask.cs
+++ b/src/Utilities/ToolTask.cs
@@ -1053,7 +1053,9 @@ namespace Microsoft.Build.Utilities
         /// <param name="proc"></param>
         private static void WaitForProcessExit(Process proc)
         {
-            proc.WaitForExit();
+            // Using overload with timeout prevents hanging in case that grandchild process is still running
+            // See https://github.com/dotnet/runtime/issues/51277 and https://github.com/dotnet/msbuild/issues/2981#issuecomment-818581362
+            proc.WaitForExit(int.MaxValue);
 
             // Process.WaitForExit() may return prematurely. We need to check to be sure.
             while (!proc.HasExited)


### PR DESCRIPTION
Fixes #2981
and probably #10286

### Context
`ToolTask` can hang when child process spawns a grandchild process that doesn't exit.

### Changes Made
Using different overload of `WaitForExit` to avoid situation when grandchild process is keeping the MSBuild waiting.
See https://github.com/dotnet/runtime/issues/51277 and https://github.com/dotnet/msbuild/issues/2981#issuecomment-818581362

### Testing
Manual testing with custom `ToolTask` implementation. This tasks starts process that starts another process with longer lifetime.

### Notes
