### PR TITLE
Update the build template

### DIFF
--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -57,6 +57,9 @@ extends:
       # We generate SBOM ourselves, so don't need steps injected by 1ES.
       sbom:
         enabled: false
+      codeSignValidation:
+        enabled: true
+        break: true
 
     stages:
     - stage: build
@@ -176,9 +179,14 @@ extends:
             channelName: $(VisualStudio.ChannelName)
             manifests: $(VisualStudio.SetupManifestList)
             outputFolder: '$(Build.SourcesDirectory)\artifacts\VSSetup\$(BuildConfiguration)\Insertion'
-            bootstrapperCoreVersion:
           displayName: 'OptProf - Build VS bootstrapper'
           condition: succeeded()
+
+        - task: PowerShell@2
+          displayName: Delete the file
+          inputs:
+            targetType: 'inline'
+            script: Get-ChildItem -Path "$(Build.SourcesDirectory)\artifacts\VSSetup\$(BuildConfiguration)\Insertion\bootstrapper" -Recurse -Filter "vs_enterprise.exe" | Remove-Item -Verbose
 
         # Publish run settings
         - task: PowerShell@2
@@ -206,13 +214,6 @@ extends:
           inputs:
             PathtoPublish: 'artifacts\log\$(BuildConfiguration)'
             ArtifactName: logs
-          condition: succeededOrFailed()
-
-        - task: 1ES.PublishPipelineArtifact@1
-          displayName: 'Publish Artifact: bin'
-          inputs:
-            path: 'artifacts\bin'
-            artifactName: bin
           condition: succeededOrFailed()
 
         # Publishes setup VSIXes to a drop.

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -2,6 +2,8 @@
   <ItemGroup>
     <ItemsToSign Include="$(VisualStudioSetupInsertionPath)Microsoft.Build.UnGAC.exe" />
 
+    <ItemsToSign Include="$(ArtifactsDir)\xsd\Update-MSBuildXsds.ps1" />
+
     <FileSignInfo Include="RuntimeContracts.dll" CertificateName="3PartySHA2" />
   </ItemGroup>
 


### PR DESCRIPTION
Fixes #10229 

### Context
The builds started to receive warnings. 

### Changes Made
Update the build and what we are publishing in artifacts: 
- Removed the bin folder completely. 
- Removed the file that is not generated by msbuild steps, however was not signed.
- Add item to sign after build. 

### Testing
Tested on experimental branch: exp/f-alizada/code-sign-validation
