### PR TITLE
Remove blocking parallelization

### DIFF
--- a/src/Build/BuildCheck/Infrastructure/BuildCheckCentralContext.cs
+++ b/src/Build/BuildCheck/Infrastructure/BuildCheckCentralContext.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -34,7 +34,9 @@ internal sealed class BuildCheckCentralContext
     // This we can potentially use to subscribe for receiving evaluated props in the
     //  build event args. However - this needs to be done early on, when analyzers might not be known yet
     internal bool HasEvaluatedPropertiesActions => _globalCallbacks.EvaluatedPropertiesActions.Count > 0;
+
     internal bool HasParsedItemsActions => _globalCallbacks.ParsedItemsActions.Count > 0;
+
     internal bool HasTaskInvocationActions => _globalCallbacks.TaskInvocationActions.Count > 0;
 
     internal void RegisterEvaluatedPropertiesAction(BuildAnalyzerWrapper analyzer, Action<BuildCheckDataContext<EvaluatedPropertiesAnalysisData>> evaluatedPropertiesAction)
@@ -106,51 +108,46 @@ internal sealed class BuildCheckCentralContext
     {
         string projectFullPath = analysisData.ProjectFilePath;
 
-        // Alternatively we might want to actually do this all in serial, but asynchronously (blocking queue)
-        Parallel.ForEach(
-            registeredCallbacks,
-            new ParallelOptions { MaxDegreeOfParallelism = Environment.ProcessorCount },
-            /* (BuildAnalyzerWrapper2, Action<BuildAnalysisContext<T>>) */
-            analyzerCallback =>
+        foreach (var analyzerCallback in registeredCallbacks)
+        {
+            // Tracing - https://github.com/dotnet/msbuild/issues/9629 - we might want to account this entire block
+            //  to the relevant analyzer (with only the currently accounted part as being the 'core-execution' subspan)
+
+            BuildAnalyzerConfigurationInternal? commonConfig = analyzerCallback.Item1.CommonConfig;
+            BuildAnalyzerConfigurationInternal[] configPerRule;
+
+            if (commonConfig != null)
             {
-                // Tracing - https://github.com/dotnet/msbuild/issues/9629 - we might want to account this entire block
-                //  to the relevant analyzer (with only the currently accounted part as being the 'core-execution' subspan)
-
-                BuildAnalyzerConfigurationInternal? commonConfig = analyzerCallback.Item1.CommonConfig;
-                BuildAnalyzerConfigurationInternal[] configPerRule;
-
-                if (commonConfig != null)
+                if (!commonConfig.IsEnabled)
                 {
-                    if (!commonConfig.IsEnabled)
-                    {
-                        return;
-                    }
-
-                    configPerRule = new[] { commonConfig };
-                }
-                else
-                {
-                    configPerRule =
-                        _configurationProvider.GetMergedConfigurations(projectFullPath,
-                            analyzerCallback.Item1.BuildAnalyzer);
-                    if (configPerRule.All(c => !c.IsEnabled))
-                    {
-                        return;
-                    }
+                    return;
                 }
 
-                // Here we might want to check the configPerRule[0].EvaluationAnalysisScope - if the input data supports that
-                // The decision and implementation depends on the outcome of the investigation tracked in:
-                // https://github.com/orgs/dotnet/projects/373/views/1?pane=issue&itemId=57851137
+                configPerRule = new[] { commonConfig };
+            }
+            else
+            {
+                configPerRule =
+                    _configurationProvider.GetMergedConfigurations(projectFullPath,
+                        analyzerCallback.Item1.BuildAnalyzer);
+                if (configPerRule.All(c => !c.IsEnabled))
+                {
+                    return;
+                }
+            }
 
-                BuildCheckDataContext<T> context = new BuildCheckDataContext<T>(
-                    analyzerCallback.Item1,
-                    analysisContext,
-                    configPerRule,
-                    resultHandler,
-                    analysisData);
+            // Here we might want to check the configPerRule[0].EvaluationAnalysisScope - if the input data supports that
+            // The decision and implementation depends on the outcome of the investigation tracked in:
+            // https://github.com/orgs/dotnet/projects/373/views/1?pane=issue&itemId=57851137
 
-                analyzerCallback.Item2(context);
-            });
+            BuildCheckDataContext<T> context = new BuildCheckDataContext<T>(
+                analyzerCallback.Item1,
+                analysisContext,
+                configPerRule,
+                resultHandler,
+                analysisData);
+
+            analyzerCallback.Item2(context);
+        }
     }
 }


### PR DESCRIPTION
## Fixes
BuildCheck E2E tests

##Context

The tests from this class were handing on the CI build periodically
https://github.com/dotnet/msbuild/blob/c2f9b76bb511c2ef4419abe468e81855781c40a1/src/BuildCheck.UnitTests/EndToEndTests.cs#L16

But after adding another build-in analyzer, I was able to spot (thanks to @JanKrivanek !) the deadlock in the Parallel invocation.

