### PR TITLE
Update the merge-flow configuration

### DIFF
--- a/.config/git-merge-flow-config.jsonc
+++ b/.config/git-merge-flow-config.jsonc
@@ -18,7 +18,7 @@
         "vs17.6": {
             "MergeToBranch": "vs17.8"
         },
-        // Automate opening PRs to merge msbuild's vs17.8 (SDK 8.0.2xx) into vs17.10 (SDK 8.0.3xx)
+        // Automate opening PRs to merge msbuild's vs17.8 (SDK 8.0.1xx) into vs17.10 (SDK 8.0.3xx)
         "vs17.8": {
             "MergeToBranch": "vs17.10"
         },

--- a/.config/git-merge-flow-config.jsonc
+++ b/.config/git-merge-flow-config.jsonc
@@ -10,12 +10,8 @@
         "vs17.0": {
             "MergeToBranch": "vs17.3"
         },
-        // Automate opening PRs to merge msbuild's vs17.3 (SDK 6.0.4xx) into vs17.4 (SDK 7.0.1xx until 5/2024, VS until 7/2024)
+        // Automate opening PRs to merge msbuild's vs17.3 (SDK 6.0.4xx) into vs17.6 (VS until 1/2025)
         "vs17.3": {
-            "MergeToBranch": "vs17.4"
-        },
-        // Automate opening PRs to merge msbuild's vs17.4 into vs17.6 (VS until 1/2025)
-        "vs17.4": {
             "MergeToBranch": "vs17.6"
         },
         // Automate opening PRs to merge msbuild's vs17.6 into vs17.8 (VS until 7/2025)

--- a/.config/git-merge-flow-config.jsonc
+++ b/.config/git-merge-flow-config.jsonc
@@ -18,12 +18,8 @@
         "vs17.6": {
             "MergeToBranch": "vs17.8"
         },
-        // Automate opening PRs to merge msbuild's vs17.8 (SDK 8.0.1xx) into vs17.9 (SDK 8.0.2xx)
+        // Automate opening PRs to merge msbuild's vs17.8 (SDK 8.0.2xx) into vs17.10 (SDK 8.0.3xx)
         "vs17.8": {
-            "MergeToBranch": "vs17.9"
-        },
-        // Automate opening PRs to merge msbuild's vs17.9 (SDK 8.0.2xx) into vs17.10 (SDK 8.0.3xx)
-        "vs17.9": {
             "MergeToBranch": "vs17.10"
         },
         // Automate opening PRs to merge msbuild's vs17.10 (SDK 8.0.3xx) into vs17.11 (SDK 8.0.4xx)


### PR DESCRIPTION
### Context
The branches: 
- `vs17.4` is [out of support](https://learn.microsoft.com/en-us/visualstudio/productinfo/vs-servicing#long-term-servicing-channel-ltsc-support). 
- `vs17.9`  is [out of support](https://learn.microsoft.com/en-us/dotnet/core/porting/versioning-sdk-msbuild-vs)
Once the release branch is out of support there is no need to keep it in the merge flow chain of the supported branches.

### Changes Made

## Current flow
```mermaid
graph LR;
    vs..-->vs17.3;
    vs17.3-->vs17.4;
    vs17.4-->vs17.6;
    vs17.6-->vs17.8;
    vs17.8-->vs17.9;
    vs17.9-->vs17.10;
    vs17.10-->vs...;
```

## Introduced flow
Removing the `vs17.4` and `vs17.9` from the merge flow chain.

```mermaid
graph LR;
    vs..-->vs17.3;
    vs17.3-->vs17.6;
    vs17.6-->vs17.8;
    vs17.8-->vs17.10;
    vs17.10-->vs...;
```

### Testing
No testing, its configuration file
