### PR TITLE
OM unification Bugfix - Fix result validity check

### DIFF
--- a/src/Build/BackEnd/BuildManager/BuildSubmission.cs
+++ b/src/Build/BackEnd/BuildManager/BuildSubmission.cs
@@ -215,8 +215,6 @@ namespace Microsoft.Build.Execution
             // rather flexible in how users are allowed to submit multiple requests for the same configuration.  In this case, the
             // request id of the result will match the first request, even though it will contain results for all requests (including
             // this one.)
-            ErrorUtilities.VerifyThrow(result.ConfigurationId == BuildRequest?.ConfigurationId, "BuildResult doesn't match BuildRequest configuration");
-
             if (result.ConfigurationId != BuildRequest?.ConfigurationId)
             {
                 ErrorUtilities.ThrowInternalError("BuildResult configuration ({0}) doesn't match BuildRequest configuration ({1})",

--- a/src/Build/BackEnd/BuildManager/BuildSubmission.cs
+++ b/src/Build/BackEnd/BuildManager/BuildSubmission.cs
@@ -78,13 +78,14 @@ namespace Microsoft.Build.Execution
         internal void CompleteResults(TResultData result)
         {
             ErrorUtilities.VerifyThrowArgumentNull(result, nameof(result));
-            ErrorUtilities.VerifyThrow(result.SubmissionId == SubmissionId,
-                "GraphBuildResult's submission id doesn't match GraphBuildSubmission's");
+            CheckResultValidForCompletion(result);
 
             BuildResult ??= result;
 
             CheckForCompletion();
         }
+
+        protected internal abstract void CheckResultValidForCompletion(TResultData result);
 
         protected internal abstract TResultData CreateFailedResult(Exception exception);
 
@@ -207,7 +208,21 @@ namespace Microsoft.Build.Execution
                 "BuildRequest is not populated while reporting failed result.");
             return new(BuildRequest!, exception);
         }
-        
+
+        protected internal override void CheckResultValidForCompletion(BuildResult result)
+        {
+            // We verify that we got results from the same configuration, but not necessarily the same request, because we are
+            // rather flexible in how users are allowed to submit multiple requests for the same configuration.  In this case, the
+            // request id of the result will match the first request, even though it will contain results for all requests (including
+            // this one.)
+            ErrorUtilities.VerifyThrow(result.ConfigurationId == BuildRequest?.ConfigurationId, "BuildResult doesn't match BuildRequest configuration");
+
+            if (result.ConfigurationId != BuildRequest?.ConfigurationId)
+            {
+                ErrorUtilities.ThrowInternalError("BuildResult configuration ({0}) doesn't match BuildRequest configuration ({1})",
+                    result.ConfigurationId, BuildRequest?.ConfigurationId);
+            }
+        }
 
         protected internal override void OnCompletition()
         {

--- a/src/Build/Graph/GraphBuildSubmission.cs
+++ b/src/Build/Graph/GraphBuildSubmission.cs
@@ -62,6 +62,12 @@ namespace Microsoft.Build.Graph
             return BuildResult!;
         }
 
+        protected internal override void CheckResultValidForCompletion(GraphBuildResult result)
+        {
+            ErrorUtilities.VerifyThrow(result.SubmissionId == SubmissionId,
+                "GraphBuildResult's submission id doesn't match GraphBuildSubmission's");
+        }
+
         protected internal override GraphBuildResult CreateFailedResult(Exception exception)
             => new(SubmissionId, exception);
     }


### PR DESCRIPTION
Fixes [#AB2134191](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2134191/?view=edit), [#AB2134571](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2134571)

### Context
The OM unification (https://github.com/dotnet/msbuild/pull/10172) unified check for validity of the result. However result created from exception has slightly different propertis on GraphBuild and standard build - so the check should not have been unified

### Changes Made
Split the result validity check

### Testing
Will be done through exp VS insertion - https://devdiv.visualstudio.com/DevDiv/_git/VS/pullrequest/564498
