### PR TITLE
Handle access to vssps for PerfStar

### DIFF
--- a/.exp-insertions.yml
+++ b/.exp-insertions.yml
@@ -167,7 +167,7 @@ jobs:
       inlineScript: |
         # '499b84ac-1321-427f-aa17-267ca6975798' for Azure DevOps
         $token = az account get-access-token --query accessToken --resource 499b84ac-1321-427f-aa17-267ca6975798 -o tsv
-        Write-Host "Setting AzDO.DotnetPerfStarToken: ${token}"
+        Write-Host "Setting AzDO.DotnetPerfStarToken"
         Write-Host "##vso[task.setvariable variable=AzDO.DotnetPerfStarToken]${token}"
 
   - powershell: |

--- a/.exp-insertions.yml
+++ b/.exp-insertions.yml
@@ -155,6 +155,21 @@ jobs:
       nugetConfigPath: '$(Build.SourcesDirectory)\NuGet.config'
       restoreDirectory: '$(Build.SourcesDirectory)\.packages'
 
+  # https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/1es-security-configuration/configuration-guides/pat-burndown-guidance#authentication-from-pipelines
+  # Requires Azure client 2.x
+  - task: AzureCLI@2
+    displayName: 'Set AzDO.DotnetPerfStarToken'
+    enabled: true
+    inputs:
+      azureSubscription: 'dotnet-perfstar at app.vssps.visualstudio.com'   # Azure DevOps service connection
+      scriptType: 'pscore'
+      scriptLocation: 'inlineScript'
+      inlineScript: |
+        # '499b84ac-1321-427f-aa17-267ca6975798' for Azure DevOps
+        $token = az account get-access-token --query accessToken --resource 499b84ac-1321-427f-aa17-267ca6975798 -o tsv
+        Write-Host "Setting AzDO.DotnetPerfStarToken: ${token}"
+        Write-Host "##vso[task.setvariable variable=AzDO.DotnetPerfStarToken]${token}"
+
   - powershell: |
       mkdir "$(Pipeline.Workspace)/artifacts"
 
@@ -166,7 +181,7 @@ jobs:
       Write-Host "Detected drop.exe path: $dropExePath"
 
       Write-Host "Downloading VS msbuild"
-      $patAuthEnvVar = "SYSTEM_ACCESSTOKEN"
+      $patAuthEnvVar = "patVariable"
       & "$dropExePath" get --patAuthEnvVar $patAuthEnvVar -u "$(MSBuildDropPath)\$(VSVersion)" -d "$(System.ArtifactsDirectory)/VSMSBuildDrop"
       Write-Host "Download of VS msbuild finished"
 
@@ -175,7 +190,7 @@ jobs:
       Write-Host "Copy of VS msbuild finished"
     displayName: Download msbuild vs drop
     env:
-      SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+      patVariable: $(AzDO.DotnetPerfStarToken)
 
   - task: DownloadBuildArtifacts@1
     inputs:


### PR DESCRIPTION
## Fixes:
Issues with access to msbuild.exe bit for perfstar run.
In order to secure that, a new SP was created and added to the corresponding organization.

## Validation:
https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=9874247&view=logs&j=063f674e-38db-59b9-8dc6-bda499493784&t=d2d8d882-24a4-5280-d5d8-e137cda2c3ba