### PR TITLE
Permit erroring on missing project reference Fixes #7528

### DIFF
--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -2172,10 +2172,14 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       </_ResolvedProjectReferencePaths>
     </ItemGroup>
 
-    <!-- Issue a warning for each non-existent project. -->
+    <!-- Issue a warning or error for each non-existent project. -->
     <Warning
         Text="The referenced project '%(_MSBuildProjectReferenceNonexistent.Identity)' does not exist."
-        Condition="'@(ProjectReferenceWithConfiguration)' != '' and '@(_MSBuildProjectReferenceNonexistent)' != ''"/>
+        Condition="'$(ErrorOnMissingProjectReference)' != 'True' and '@(ProjectReferenceWithConfiguration)' != '' and '@(_MSBuildProjectReferenceNonexistent)' != ''"/>
+
+    <Error
+        Text="The referenced project '%(_MSBuildProjectReferenceNonexistent.Identity)' does not exist."
+        Condition="'$(ErrorOnMissingProjectReference)' == 'True' and '@(ProjectReferenceWithConfiguration)' != '' and '@(_MSBuildProjectReferenceNonexistent)' != ''"/>
 
   </Target>
 

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -2175,11 +2175,13 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <!-- Issue a warning or error for each non-existent project. -->
     <Warning
         Text="The referenced project '%(_MSBuildProjectReferenceNonexistent.Identity)' does not exist."
-        Condition="'$(ErrorOnMissingProjectReference)' != 'True' and '@(ProjectReferenceWithConfiguration)' != '' and '@(_MSBuildProjectReferenceNonexistent)' != ''"/>
+        Code="MSB9008"
+        Condition="'@(ProjectReferenceWithConfiguration)' != '' and '@(_MSBuildProjectReferenceNonexistent)' != '' and '$(ErrorOnMissingProjectReference)' != 'True'"/>
 
     <Error
         Text="The referenced project '%(_MSBuildProjectReferenceNonexistent.Identity)' does not exist."
-        Condition="'$(ErrorOnMissingProjectReference)' == 'True' and '@(ProjectReferenceWithConfiguration)' != '' and '@(_MSBuildProjectReferenceNonexistent)' != ''"/>
+        Code="MSB9008"
+        Condition="'@(ProjectReferenceWithConfiguration)' != '' and '@(_MSBuildProjectReferenceNonexistent)' != '' and '$(ErrorOnMissingProjectReference)' == 'True'"/>
 
   </Target>
 


### PR DESCRIPTION
Fixes #7528

### Context
If a project reference does not exist, we currently throw a warning. It was requested in #7528 that there should at least be an option to make it an error.

### Changes Made
Throws a warning or an error, depending on the ErrorOnMissingProjectReference property, if a ProjectReference does not exist.

### Testing
Tried building a project with a nonexistent project reference with and without that property set to True.

### Notes
I don't think the discussion on the issue had fully resolved, but I suspect it won't resolve any time soon. Regardless, if you think this is hurtful in any way, feel free to just close it.