### PR TITLE
Update the CodeSign validation parameters

### DIFF
--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -60,6 +60,7 @@ extends:
       codeSignValidation:
         enabled: true
         break: true
+        additionalTargetsGlobPattern: -|**\bootstrapper\**\vs_enterprise.exe
 
     stages:
     - stage: build
@@ -181,12 +182,6 @@ extends:
             outputFolder: '$(Build.SourcesDirectory)\artifacts\VSSetup\$(BuildConfiguration)\Insertion'
           displayName: 'OptProf - Build VS bootstrapper'
           condition: succeeded()
-
-        - task: PowerShell@2
-          displayName: Delete the file
-          inputs:
-            targetType: 'inline'
-            script: Get-ChildItem -Path "$(Build.SourcesDirectory)\artifacts\VSSetup\$(BuildConfiguration)\Insertion\bootstrapper" -Recurse -Filter "vs_enterprise.exe" | Remove-Item -Verbose
 
         # Publish run settings
         - task: PowerShell@2


### PR DESCRIPTION
### Context
The optprof pipeline: https://github.com/dotnet/msbuild/blob/main/.opt-prof.yml
Started failing and the error states that vs installer is not found. This is closely related to the changes made for code-sign validation updates: https://github.com/dotnet/msbuild/pull/10299

### Changes Made
- Remove the deletion of `vs_enterprise.exe` file step from pipeline
- Add `vs_enterprise.exe` to exclusion list for code-sign validation

### Testing
experimental build: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=9895530&view=results