### PR TITLE
Add BuildOM forward compatibility

### DIFF
--- a/src/Build.UnitTests/BackEnd/BuildOMCompatibility_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/BuildOMCompatibility_Tests.cs
@@ -1,0 +1,117 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Reflection;
+using Microsoft.Build.Execution;
+using Microsoft.Build.Graph;
+using Shouldly;
+using Xunit;
+
+namespace Microsoft.Build.Engine.UnitTests.BackEnd
+{
+    public class BuildOMCompatibility_Tests
+    {
+        [Theory]
+        [InlineData("ProjectInstance")]
+        [InlineData("ProjectFullPath")]
+        [InlineData("TargetNames")]
+        [InlineData("Flags")]
+        [InlineData("GlobalProperties")]
+        [InlineData("ExplicitlySpecifiedToolsVersion")]
+        [InlineData("HostServices")]
+        [InlineData("PropertiesToTransfer")]
+        [InlineData("RequestedProjectState")]
+        public void BuildRequestDataPropertyCompatTest(string propertyName)
+            => VerifyPropertyExists(typeof(BuildRequestData), propertyName);
+
+        [Theory]
+        [InlineData("ProjectGraph")]
+        [InlineData("ProjectGraphEntryPoints")]
+        [InlineData("TargetNames")]
+        [InlineData("Flags")]
+        [InlineData("GraphBuildOptions")]
+        [InlineData("HostServices")]
+        public void GraphBuildRequestDataPropertyCompatTest(string propertyName)
+            => VerifyPropertyExists(typeof(GraphBuildRequestData), propertyName);
+
+        [Theory]
+        [InlineData("BuildManager")]
+        [InlineData("SubmissionId")]
+        [InlineData("AsyncContext")]
+        [InlineData("WaitHandle")]
+        [InlineData("IsCompleted")]
+        [InlineData("BuildResult")]
+        public void BuildSubmissionDataPropertyCompatTest(string propertyName)
+            => VerifyPropertyExists(typeof(BuildSubmission), propertyName);
+
+        [Theory]
+        [InlineData("Execute")]
+        [InlineData("ExecuteAsync")]
+        public void BuildSubmissionDataMethodCompatTest(string methodName)
+            => VerifyMethodExists(typeof(BuildSubmission), methodName);
+
+        [Theory]
+        [InlineData("BuildManager")]
+        [InlineData("SubmissionId")]
+        [InlineData("AsyncContext")]
+        [InlineData("WaitHandle")]
+        [InlineData("IsCompleted")]
+        [InlineData("BuildResult")]
+        public void GraphBuildSubmissionDataPropertyCompatTest(string propertyName)
+            => VerifyPropertyExists(typeof(BuildSubmission), propertyName);
+
+        [Theory]
+        [InlineData("Execute")]
+        [InlineData("ExecuteAsync")]
+        public void GraphBuildSubmissionDataMethodCompatTest(string methodName)
+            => VerifyMethodExists(typeof(BuildSubmission), methodName);
+
+        [Theory]
+        [InlineData("SubmissionId")]
+        [InlineData("ConfigurationId")]
+        [InlineData("GlobalRequestId")]
+        [InlineData("ParentGlobalRequestId")]
+        [InlineData("NodeRequestId")]
+        [InlineData("Exception")]
+        [InlineData("CircularDependency")]
+        [InlineData("OverallResult")]
+        [InlineData("ResultsByTarget")]
+        [InlineData("ProjectStateAfterBuild")]
+        [InlineData("BuildRequestDataFlags")]
+        public void BuildResultPropertyCompatTest(string propertyName)
+            => VerifyPropertyExists(typeof(BuildResult), propertyName);
+
+        [Theory]
+        [InlineData("AddResultsForTarget")]
+        [InlineData("MergeResults")]
+        [InlineData("HasResultsForTarget")]
+        public void BuildResultMethodCompatTest(string methodName)
+            => VerifyMethodExists(typeof(BuildResult), methodName);
+
+        [Theory]
+        [InlineData("SubmissionId")]
+        [InlineData("Exception")]
+        [InlineData("CircularDependency")]
+        [InlineData("OverallResult")]
+        [InlineData("ResultsByNode")]
+        public void GraphBuildResultPropertyCompatTest(string propertyName)
+            => VerifyPropertyExists(typeof(GraphBuildResult), propertyName);
+
+        private void VerifyPropertyExists(Type type, string propertyName)
+        {
+            type.GetProperty(
+                    propertyName,
+                    BindingFlags.Instance | BindingFlags.Public | BindingFlags.DeclaredOnly)
+                .ShouldNotBeNull();
+        }
+
+        private void VerifyMethodExists(Type type, string propertyName)
+        {
+            type.GetMethod(
+                    propertyName,
+                    BindingFlags.Instance | BindingFlags.Public | BindingFlags.DeclaredOnly)
+                .ShouldNotBeNull();
+        }
+    }
+}

--- a/src/Build/BackEnd/BuildManager/BuildRequestData.cs
+++ b/src/Build/BackEnd/BuildManager/BuildRequestData.cs
@@ -301,5 +301,18 @@ namespace Microsoft.Build.Execution
         /// <inheritdoc cref="BuildRequestDataBase"/>
         public override IReadOnlyDictionary<string, string?> GlobalPropertiesLookup => _globalPropertiesLookup ??=
             Execution.GlobalPropertiesLookup.ToGlobalPropertiesLookup(GlobalPropertiesDictionary);
+
+        // WARNING!: Do not remove the below proxy properties.
+        //  They are required to make the OM forward compatible
+        //  (code built against this OM should run against binaries with previous version of OM).
+
+        /// <inheritdoc cref="BuildRequestDataBase.TargetNames"/>
+        public new ICollection<string> TargetNames => base.TargetNames;
+
+        /// <inheritdoc cref="BuildRequestDataBase.Flags"/>
+        public new BuildRequestDataFlags Flags => base.Flags;
+
+        /// <inheritdoc cref="BuildRequestDataBase.HostServices"/>
+        public new HostServices? HostServices => base.HostServices;
     }
 }

--- a/src/Build/BackEnd/BuildManager/BuildSubmission.cs
+++ b/src/Build/BackEnd/BuildManager/BuildSubmission.cs
@@ -232,5 +232,27 @@ namespace Microsoft.Build.Execution
                 BuildResult.SetOverallResult(overallResult: false);
             }
         }
+
+        // WARNING!: Do not remove the below proxy properties.
+        //  They are required to make the OM forward compatible
+        //  (code built against this OM should run against binaries with previous version of OM).
+
+        /// <inheritdoc cref="BuildSubmissionBase{BuildRequestData, BuildResult}.BuildResult"/>
+        public new BuildResult? BuildResult => base.BuildResult;
+
+        /// <inheritdoc cref="BuildSubmissionBase.BuildManager"/>
+        public new BuildManager BuildManager => base.BuildManager;
+
+        /// <inheritdoc cref="BuildSubmissionBase.SubmissionId"/>
+        public new int SubmissionId => base.SubmissionId;
+
+        /// <inheritdoc cref="BuildSubmissionBase.AsyncContext"/>
+        public new object? AsyncContext => base.AsyncContext;
+
+        /// <inheritdoc cref="BuildSubmissionBase.WaitHandle"/>
+        public new WaitHandle WaitHandle => base.WaitHandle;
+
+        /// <inheritdoc cref="BuildSubmissionBase.IsCompleted"/>
+        public new bool IsCompleted => base.IsCompleted;
     }
 }

--- a/src/Build/Graph/GraphBuildRequestData.cs
+++ b/src/Build/Graph/GraphBuildRequestData.cs
@@ -167,7 +167,7 @@ namespace Microsoft.Build.Graph
         private GraphBuildRequestData(ICollection<string> targetsToBuild, HostServices? hostServices, BuildRequestDataFlags flags, GraphBuildOptions? graphBuildOptions = null)
         : base(targetsToBuild, flags, hostServices)
         {
-            Flags = flags;
+            base.Flags = flags;
             GraphBuildOptions = graphBuildOptions ?? new GraphBuildOptions();
         }
 
@@ -235,5 +235,18 @@ namespace Microsoft.Build.Graph
         /// Options for how the graph should be built.
         /// </summary>
         public GraphBuildOptions GraphBuildOptions { get; }
+
+        // WARNING!: Do not remove the below proxy properties.
+        //  They are required to make the OM forward compatible
+        //  (code built against this OM should run against binaries with previous version of OM).
+
+        /// <inheritdoc cref="BuildRequestDataBase.TargetNames"/>
+        public new ICollection<string> TargetNames => base.TargetNames;
+
+        /// <inheritdoc cref="BuildRequestDataBase.Flags"/>
+        public new BuildRequestDataFlags Flags => base.Flags;
+
+        /// <inheritdoc cref="BuildRequestDataBase.HostServices"/>
+        public new HostServices? HostServices => base.HostServices;
     }
 }

--- a/src/Build/Graph/GraphBuildSubmission.cs
+++ b/src/Build/Graph/GraphBuildSubmission.cs
@@ -70,5 +70,27 @@ namespace Microsoft.Build.Graph
 
         protected internal override GraphBuildResult CreateFailedResult(Exception exception)
             => new(SubmissionId, exception);
+
+        // WARNING!: Do not remove the below proxy properties.
+        //  They are required to make the OM forward compatible
+        //  (code built against this OM should run against binaries with previous version of OM).
+
+        /// <inheritdoc cref="BuildSubmissionBase{GraphBuildRequestData, GraphBuildResult}.BuildResult"/>
+        public new GraphBuildResult? BuildResult => base.BuildResult;
+
+        /// <inheritdoc cref="BuildSubmissionBase.BuildManager"/>
+        public new BuildManager BuildManager => base.BuildManager;
+
+        /// <inheritdoc cref="BuildSubmissionBase.SubmissionId"/>
+        public new int SubmissionId => base.SubmissionId;
+
+        /// <inheritdoc cref="BuildSubmissionBase.AsyncContext"/>
+        public new object? AsyncContext => base.AsyncContext;
+
+        /// <inheritdoc cref="BuildSubmissionBase.WaitHandle"/>
+        public new WaitHandle WaitHandle => base.WaitHandle;
+
+        /// <inheritdoc cref="BuildSubmissionBase.IsCompleted"/>
+        public new bool IsCompleted => base.IsCompleted;
     }
 }


### PR DESCRIPTION
Fixes #10349

### Context
The OM unification work https://github.com/dotnet/msbuild/pull/10345 introduced backwards compatible unified OM (code compiled against old MSBuild binaries can be run against new MSBuild binaries), but it was not forward compatible (code compiled against new MSBuild binaries could not be run against old MSBuild binaries). This change is bridging such gap.

### Changes Made
Adding 'proxy' properties for those that have been pulled to base classes - so that the compiled code is not trying to reference base classes, that do not exist in the old version of MSBuild code.

### Testing
Manual testing of x-compatibility of the OM.

1. Add a binary (e.g. console app) with code that is using the OM and it's properties - e.g.:
```csharp
            Microsoft.Build.Graph.GraphBuildRequestData data =
                new(
                    projectFullPath: "a/b/c",
                    globalProperties: new Dictionary<string, string>() { { "a", "b"} },
                    targetsToBuild: new List<string>() { "t1", "t2"},
                    hostServices: null);

            Console.WriteLine("target names:" + data.TargetNames.FirstOrDefault());
```
2. Build and run the code (just sanity check) - on the new version of MSBuild and old version of MSBuild
3. Copy the created binary from the old version of MSBuild over to the output of new MSBuild (testing of backwards compatibility) and run
4. Copy the created binary from the new version of MSBuild over to the output of old MSBuild (testing of forward compatibility) and run

### Notes
Big thanks to @rainersigwald and @dfederm for the detailed help and ideas during troubleshooting the problem
