### PR TITLE
Reverting PR #10297

### DIFF
--- a/documentation/wiki/ChangeWaves.md
+++ b/documentation/wiki/ChangeWaves.md
@@ -28,7 +28,6 @@ A wave of features is set to "rotate out" (i.e. become standard functionality) t
 - [Convert.ToString during a property evaluation uses the InvariantCulture for all types](https://github.com/dotnet/msbuild/pull/9874)
 - [Fix oversharing of build results in ResultsCache](https://github.com/dotnet/msbuild/pull/9987)
 - [Add ParameterName and PropertyName to TaskParameterEventArgs](https://github.com/dotnet/msbuild/pull/10130)
-- [The ToolTask only waits for its child process to end before returning, instead of waiting for grandchildren](https://github.com/dotnet/msbuild/pull/10297)
 
 ### 17.10
 - [AppDomain configuration is serialized without using BinFmt](https://github.com/dotnet/msbuild/pull/9320) - feature can be opted out only if [BinaryFormatter](https://learn.microsoft.com/en-us/dotnet/api/system.runtime.serialization.formatters.binary.binaryformatter) is allowed at runtime by editing `MSBuild.runtimeconfig.json`

--- a/src/Utilities/ToolTask.cs
+++ b/src/Utilities/ToolTask.cs
@@ -1053,16 +1053,7 @@ namespace Microsoft.Build.Utilities
         /// <param name="proc"></param>
         private static void WaitForProcessExit(Process proc)
         {
-            if (ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_12))
-            {
-                // Using overload with timeout prevents hanging in case that grandchild process is still running
-                // See https://github.com/dotnet/runtime/issues/51277 and https://github.com/dotnet/msbuild/issues/2981#issuecomment-818581362
-                proc.WaitForExit(int.MaxValue);
-            }
-            else
-            {
-                proc.WaitForExit();
-            }
+            proc.WaitForExit();
 
             // Process.WaitForExit() may return prematurely. We need to check to be sure.
             while (!proc.HasExited)


### PR DESCRIPTION
Fixes #10378

### Context
The original modification resulted in an incorrect exit code being returned in certain situations.

### Changes Made
Reverting back to original state.

### Testing


### Notes
