### PR TITLE
Bypass logcontext validity check

### DIFF
--- a/src/Build/BackEnd/Components/Logging/TargetLoggingContext.cs
+++ b/src/Build/BackEnd/Components/Logging/TargetLoggingContext.cs
@@ -91,7 +91,7 @@ namespace Microsoft.Build.BackEnd.Logging
         /// </summary>
         internal void LogTargetBatchFinished(string projectFullPath, bool success, IEnumerable<TaskItem> targetOutputs)
         {
-            ErrorUtilities.VerifyThrow(IsValid, "Should be valid");
+            this.CheckValidity();
 
             TargetOutputItemsInstanceEnumeratorProxy targetOutputWrapper = null;
 
@@ -110,7 +110,7 @@ namespace Microsoft.Build.BackEnd.Logging
         /// </summary>
         internal TaskLoggingContext LogTaskBatchStarted(string projectFullPath, ProjectTargetInstanceChild task, string taskAssemblyLocation)
         {
-            ErrorUtilities.VerifyThrow(IsValid, "Should be valid");
+            this.CheckValidity();
 
             return new TaskLoggingContext(this, projectFullPath, task, taskAssemblyLocation);
         }

--- a/src/Build/BackEnd/Components/RequestBuilder/AssemblyLoadsTracker.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/AssemblyLoadsTracker.cs
@@ -171,7 +171,8 @@ namespace Microsoft.Build.BackEnd.Components.RequestBuilder
             if (_loggingContext?.BuildEventContext != null)
             {
                 buildArgs.BuildEventContext = _loggingContext.BuildEventContext;
-                _loggingContext.LogBuildEvent(buildArgs);
+                // bypass the logging context validity check
+                _loggingContext.LoggingService.LogBuildEvent(buildArgs);
             }
             _loggingService?.LogBuildEvent(buildArgs);
         }

--- a/src/Build/BackEnd/Components/RequestBuilder/AssemblyLoadsTracker.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/AssemblyLoadsTracker.cs
@@ -171,7 +171,8 @@ namespace Microsoft.Build.BackEnd.Components.RequestBuilder
             if (_loggingContext?.BuildEventContext != null)
             {
                 buildArgs.BuildEventContext = _loggingContext.BuildEventContext;
-                // bypass the logging context validity check
+                // bypass the logging context validity check: it's possible that the load happened
+                // on a thread unrelated to the context we're tracking loads in
                 _loggingContext.LoggingService.LogBuildEvent(buildArgs);
             }
             _loggingService?.LogBuildEvent(buildArgs);


### PR DESCRIPTION
Fixes #10342

### Context
This change workarounds the attempts to log assembly loads via LoggingContext that was invalidated

### Theory for rootcause
The `AssemblyLoad` is AppDomain wide - and doesn't 'respect' current thread nor async context. So if we mount it in one execution context and concurrently executing code leads to assembly loading - it'll still be reported. The handler is executed synchronously - meaning the originally mounting code can be continuing execution and eventually invalidating the passed LoggingContext.

### Analysis Details
The added diagnostic showed the context tha was invalid was `TaskLoggingContext`, it as well showed that it was happening in msbuild within sdk (hence core version).

The `TaskLoggingContext` is passed to Tracker in 2 locations:

https://github.com/dotnet/msbuild/blob/486dbb4a9a7885b8fdcb1f8affd4d63444d8d8e4/src/Build/Instance/TaskFactories/AssemblyTaskFactory.cs#L389-L392

This is not part of core version - so out of question for us

And

https://github.com/dotnet/msbuild/blob/486dbb4a9a7885b8fdcb1f8affd4d63444d8d8e4/src/Build/BackEnd/Components/RequestBuilder/TaskBuilder.cs#L648-L671

Here the tracker is wrapped in using - so the LoggingContex would need to be invalidated in this scope (or passed already invalid).

`TaskLoggingContext` is allways created valid (`IsValid` set to `true` in constructor) and only invalidated in

https://github.com/dotnet/msbuild/blob/486dbb4a9a7885b8fdcb1f8affd4d63444d8d8e4/src/Build/BackEnd/Components/Logging/TaskLoggingContext.cs#L125-L136

which is called in a single place - in `ExecuteBucket`, which is outer scope for `InitializeAndExecuteTask` that contains the tracker call. The `InitializeAndExecuteTask` is async - but it doesn't influence the Dispose scope.

BUT - the fact that the mounting method (`InitializeAndExecuteTask`) is async suggest that there likely might be concurrently executing code.

This points to tracker actually logging an assembly load event from unrelated thread - supported by the fact that the AssemblyLoadsTracker seems to be on the very 'bottom' of the stack:

<img width="446" alt="image" src="https://github.com/user-attachments/assets/4ba9110a-3578-4532-9520-2f7850f56830">


While the handler should be executed synchronously - so we'd expect the `TaskBuilder` frames below the tracker frames.


Simple unrelated test of trying to mount `AssemblyLoad` event in main function with simple console output, shows that the assembly loads can be reported from unrelated threads (while those 'hide' their frames, as they are not considered 'user code'):

<img width="407" alt="image" src="https://github.com/user-attachments/assets/8d6a7d1a-99cc-4bdc-b87c-2d1dda1b93fd">


Based on the stats from builds - this was happening as well in the past - just not that often. So it's not a new regression, just some change (our or arcade) increased parallel execution or loading of assemblies on other threads.

In ideal situation we'd 'somehow' filter out the assembly load events that are from different `AsyncContext`/`ExecutionContext`/`SynchronizationContext` than the one requesting the tracking - but it is currently not worth the efforts.