### PR TITLE
Manually update System.Text.Json to 8.0.4

### DIFF
--- a/eng/SourceBuildPrebuiltBaseline.xml
+++ b/eng/SourceBuildPrebuiltBaseline.xml
@@ -15,7 +15,7 @@
     <UsagePattern IdentityGlob="System.Security.Cryptography.Pkcs/*8.0.0*" />
     <UsagePattern IdentityGlob="System.Security.Cryptography.ProtectedData/*8.0.0*" />
     <UsagePattern IdentityGlob="System.Security.Cryptography.Xml/*8.0.0*" />
-    <UsagePattern IdentityGlob="System.Text.Json/*8.0.3*" />
+    <UsagePattern IdentityGlob="System.Text.Json/*8.0.4*" />
     <UsagePattern IdentityGlob="System.Threading.Tasks.Dataflow/*8.0.0*" />
   </IgnorePatterns>
   <Usages>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -53,9 +53,9 @@
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-runtime</Uri>
       <Sha>5535e31a712343a63f5d7d796cd874e563e5ac14</Sha>
     </Dependency>
-    <Dependency Name="System.Text.Json" Version="8.0.3">
+    <Dependency Name="System.Text.Json" Version="8.0.4">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-runtime</Uri>
-      <Sha>9f4b1f5d664afdfc80e1508ab7ed099dff210fbd</Sha>
+      <Sha>2aade6beb02ea367fd97c4070a4198802fe61c03</Sha>
     </Dependency>
     <Dependency Name="System.Threading.Tasks.Dataflow" Version="8.0.0">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-runtime</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -38,7 +38,7 @@
     <SystemResourcesExtensionsVersion>8.0.0</SystemResourcesExtensionsVersion>
     <SystemSecurityPrincipalWindowsVersion>5.0.0</SystemSecurityPrincipalWindowsVersion>
     <SystemTextEncodingCodePagesVersion>7.0.0</SystemTextEncodingCodePagesVersion>
-    <SystemTextJsonVersion>8.0.3</SystemTextJsonVersion>
+    <SystemTextJsonVersion>8.0.4</SystemTextJsonVersion>
     <SystemThreadingChannelsVersion>8.0.0</SystemThreadingChannelsVersion>
     <SystemThreadingTasksDataflowVersion>8.0.0</SystemThreadingTasksDataflowVersion>
   </PropertyGroup>

--- a/src/MSBuild/app.amd64.config
+++ b/src/MSBuild/app.amd64.config
@@ -134,8 +134,8 @@
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="System.Text.Json" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-          <bindingRedirect oldVersion="0.0.0.0-8.0.0.3" newVersion="8.0.0.3" />
-          <codeBase version="8.0.0.3" href="..\System.Text.Json.dll"/>
+          <bindingRedirect oldVersion="0.0.0.0-8.0.0.4" newVersion="8.0.0.4" />
+          <codeBase version="8.0.0.4" href="..\System.Text.Json.dll"/>
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="System.Threading.Channels" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />

--- a/src/MSBuild/app.config
+++ b/src/MSBuild/app.config
@@ -94,7 +94,7 @@
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="System.Text.Json" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-          <bindingRedirect oldVersion="0.0.0.0-8.0.0.3" newVersion="8.0.0.3" />
+          <bindingRedirect oldVersion="0.0.0.0-8.0.0.4" newVersion="8.0.0.4" />
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="System.Threading.Tasks.Dataflow" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />


### PR DESCRIPTION
**8.0.3 is marked as vulnerable**

This is needed for https://github.com/dotnet/sdk/pull/42225:

> src\Resolvers\Microsoft.DotNet.MSBuildSdkResolver\Microsoft.DotNet.MSBuildSdkResolver.csproj(160,5): error : (NETCORE_ENGINEERING_TELEMETRY=Build) Microsoft.DotNet.MSBuildSdkResolver is expected to depend on System.Text.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51. This may have consequences for MSBuild.exe binding redirects, please get signoff from the MSBuild team.