### PR TITLE
Add Expander fast paths for expressions used in .NET SDK 9

### DIFF
--- a/src/Build.UnitTests/Evaluation/Expander_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/Expander_Tests.cs
@@ -5070,8 +5070,6 @@ $(
         [InlineData("$([System.String]::new('Hi').Equals('Hello'))")]
         [InlineData("$([System.IO.Path]::GetFileNameWithoutExtension('C:\\folder\\file.txt'))")]
         [InlineData("$([System.Int32]::new(123).ToString('mm')")]
-        [InlineData("$([Microsoft.Build.Utilities.ToolLocationHelper]::GetPlatformSDKLocation('10.0.19041.0', 'Windows'))")]
-        [InlineData("$([Microsoft.Build.Utilities.ToolLocationHelper]::GetPlatformSDKDisplayName('10.0.19041.0', 'Windows'))")]
         [InlineData("$([Microsoft.Build.Evaluation.IntrinsicFunctions]::NormalizeDirectory('C:/folder1/./folder2/'))")]
         [InlineData("$([Microsoft.Build.Evaluation.IntrinsicFunctions]::IsOSPlatform('Windows'))")]
         public void FastPathValidationTest(string methodInvocationMetadata)

--- a/src/Build.UnitTests/Evaluation/Expander_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/Expander_Tests.cs
@@ -7,7 +7,6 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.ComTypes;
 using System.Runtime.Versioning;
 using System.Text;
 using System.Threading;

--- a/src/Build/Evaluation/Expander.cs
+++ b/src/Build/Evaluation/Expander.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
@@ -20,6 +21,7 @@ using Microsoft.Build.Framework;
 using Microsoft.Build.Internal;
 using Microsoft.Build.Shared;
 using Microsoft.Build.Shared.FileSystem;
+using Microsoft.Build.Utilities;
 using Microsoft.NET.StringTools;
 using Microsoft.Win32;
 using AvailableStaticMethods = Microsoft.Build.Internal.AvailableStaticMethods;
@@ -3566,6 +3568,7 @@ namespace Microsoft.Build.Evaluation
                     }
                     else
                     {
+                        Debugger.Launch();
                         bool wellKnownFunctionSuccess = false;
 
                         try
@@ -3861,6 +3864,14 @@ namespace Microsoft.Build.Evaluation
                         if (TryGetArg(args, out int index))
                         {
                             returnVal = text[index];
+                            return true;
+                        }
+                    }
+                    else if (string.Equals(_methodMethodName, nameof(String.Equals), StringComparison.OrdinalIgnoreCase))
+                    {
+                        if (TryGetArg(args, out string arg0))
+                        {
+                            returnVal = text.Equals(arg0);
                             return true;
                         }
                     }
@@ -4310,6 +4321,22 @@ namespace Microsoft.Build.Evaluation
                                 return true;
                             }
                         }
+                        else if (string.Equals(_methodMethodName, nameof(IntrinsicFunctions.NormalizeDirectory), StringComparison.OrdinalIgnoreCase) && args.Length == 1)
+                        {
+                            if (TryGetArg(args, out string arg0))
+                            {
+                                returnVal = IntrinsicFunctions.NormalizeDirectory(arg0);
+                                return true;
+                            }
+                        }
+                        else if (string.Equals(_methodMethodName, nameof(IntrinsicFunctions.IsOSPlatform), StringComparison.OrdinalIgnoreCase) && args.Length == 1)
+                        {
+                            if (TryGetArg(args, out string arg0))
+                            {
+                                returnVal = IntrinsicFunctions.IsOSPlatform(arg0);
+                                return true;
+                            }
+                        }
                     }
                     else if (_receiverType == typeof(Path))
                     {
@@ -4407,6 +4434,14 @@ namespace Microsoft.Build.Evaluation
                                 return true;
                             }
                         }
+                        else if (string.Equals(_methodMethodName, nameof(Path.GetFileNameWithoutExtension), StringComparison.OrdinalIgnoreCase))
+                        {
+                            if (TryGetArg(args, out string arg0))
+                            {
+                                returnVal = Path.GetFileNameWithoutExtension(arg0);
+                                return true;
+                            }
+                        }
                     }
                     else if (_receiverType == typeof(Version))
                     {
@@ -4419,7 +4454,7 @@ namespace Microsoft.Build.Evaluation
                             }
                         }
                     }
-                    else if (_receiverType == typeof(System.Guid))
+                    else if (_receiverType == typeof(Guid))
                     {
                         if (string.Equals(_methodMethodName, nameof(Guid.NewGuid), StringComparison.OrdinalIgnoreCase))
                         {
@@ -4430,8 +4465,50 @@ namespace Microsoft.Build.Evaluation
                             }
                         }
                     }
+                    else if (_receiverType == typeof(ToolLocationHelper))
+                    {
+                        if (string.Equals(_methodMethodName, nameof(ToolLocationHelper.GetPlatformSDKLocation), StringComparison.OrdinalIgnoreCase))
+                        {
+                            if (TryGetArg([args[0]], out string arg0) && TryGetArg([args[1]], out string arg1))
+                            {
+                                returnVal = ToolLocationHelper.GetPlatformSDKLocation(arg0, arg1);
+                                return true;
+                            }
+                        }
+                        else if (string.Equals(_methodMethodName, nameof(ToolLocationHelper.GetPlatformSDKDisplayName), StringComparison.OrdinalIgnoreCase))
+                        {
+                            if (TryGetArg([args[0]], out string arg0) && TryGetArg([args[1]], out string arg1))
+                            {
+                                returnVal = ToolLocationHelper.GetPlatformSDKDisplayName(arg0, arg1);
+                                return true;
+                            }
+                        }
+                    }
                 }
-
+                else if (string.Equals(_methodMethodName, nameof(Version.ToString), StringComparison.OrdinalIgnoreCase) && objectInstance is Version v)
+                {
+                    if (TryGetArg(args, out int arg0))
+                    {
+                        returnVal = v.ToString(arg0);
+                        return true;
+                    }
+                }
+                else if (string.Equals(_methodMethodName, nameof(Regex.Replace), StringComparison.OrdinalIgnoreCase) && args.Length == 3)
+                {
+                    if (TryGetArg([args[0]], out string arg1) && TryGetArg([args[1]], out string arg2) && TryGetArg([args[2]], out string arg3))
+                    {
+                        returnVal = Regex.Replace(arg1, arg2, arg3);
+                        return true;
+                    }
+                }
+                else if (string.Equals(_methodMethodName, nameof(Int32.ToString), StringComparison.OrdinalIgnoreCase) && objectInstance is int i)
+                {
+                    if (TryGetArg(args, out string arg0))
+                    {
+                        returnVal = i.ToString(arg0);
+                        return true;
+                    }
+                }
                 if (Traits.Instance.LogPropertyFunctionsRequiringReflection)
                 {
                     LogFunctionCall("PropertyFunctionsRequiringReflection", objectInstance, args);

--- a/src/Build/Evaluation/Expander.cs
+++ b/src/Build/Evaluation/Expander.cs
@@ -20,7 +20,6 @@ using Microsoft.Build.Framework;
 using Microsoft.Build.Internal;
 using Microsoft.Build.Shared;
 using Microsoft.Build.Shared.FileSystem;
-using Microsoft.Build.Utilities;
 using Microsoft.NET.StringTools;
 using Microsoft.Win32;
 using AvailableStaticMethods = Microsoft.Build.Internal.AvailableStaticMethods;
@@ -4459,26 +4458,6 @@ namespace Microsoft.Build.Evaluation
                             if (args.Length == 0)
                             {
                                 returnVal = Guid.NewGuid();
-                                return true;
-                            }
-                        }
-                    }
-                    // Length check needed due to existing overloads. 
-                    else if (_receiverType == typeof(ToolLocationHelper))
-                    {
-                        if (string.Equals(_methodMethodName, nameof(ToolLocationHelper.GetPlatformSDKLocation), StringComparison.OrdinalIgnoreCase) && args.Length == 2)
-                        {
-                            if (TryGetArg([args[0]], out string arg0) && TryGetArg([args[1]], out string arg1))
-                            {
-                                returnVal = ToolLocationHelper.GetPlatformSDKLocation(arg0, arg1);
-                                return true;
-                            }
-                        }
-                        else if (string.Equals(_methodMethodName, nameof(ToolLocationHelper.GetPlatformSDKDisplayName), StringComparison.OrdinalIgnoreCase) && args.Length == 2)
-                        {
-                            if (TryGetArg([args[0]], out string arg0) && TryGetArg([args[1]], out string arg1))
-                            {
-                                returnVal = ToolLocationHelper.GetPlatformSDKDisplayName(arg0, arg1);
                                 return true;
                             }
                         }

--- a/src/Build/Evaluation/Expander.cs
+++ b/src/Build/Evaluation/Expander.cs
@@ -4463,9 +4463,10 @@ namespace Microsoft.Build.Evaluation
                             }
                         }
                     }
+                    // Length check needed due to existing overloads. 
                     else if (_receiverType == typeof(ToolLocationHelper))
                     {
-                        if (string.Equals(_methodMethodName, nameof(ToolLocationHelper.GetPlatformSDKLocation), StringComparison.OrdinalIgnoreCase))
+                        if (string.Equals(_methodMethodName, nameof(ToolLocationHelper.GetPlatformSDKLocation), StringComparison.OrdinalIgnoreCase) && args.Length == 2)
                         {
                             if (TryGetArg([args[0]], out string arg0) && TryGetArg([args[1]], out string arg1))
                             {
@@ -4473,7 +4474,7 @@ namespace Microsoft.Build.Evaluation
                                 return true;
                             }
                         }
-                        else if (string.Equals(_methodMethodName, nameof(ToolLocationHelper.GetPlatformSDKDisplayName), StringComparison.OrdinalIgnoreCase))
+                        else if (string.Equals(_methodMethodName, nameof(ToolLocationHelper.GetPlatformSDKDisplayName), StringComparison.OrdinalIgnoreCase) && args.Length == 2)
                         {
                             if (TryGetArg([args[0]], out string arg0) && TryGetArg([args[1]], out string arg1))
                             {

--- a/src/Build/Evaluation/Expander.cs
+++ b/src/Build/Evaluation/Expander.cs
@@ -4319,7 +4319,7 @@ namespace Microsoft.Build.Evaluation
                                 return true;
                             }
                         }
-                        else if (string.Equals(_methodMethodName, nameof(IntrinsicFunctions.NormalizeDirectory), StringComparison.OrdinalIgnoreCase) && args.Length == 1)
+                        else if (string.Equals(_methodMethodName, nameof(IntrinsicFunctions.NormalizeDirectory), StringComparison.OrdinalIgnoreCase))
                         {
                             if (TryGetArg(args, out string arg0))
                             {
@@ -4327,7 +4327,7 @@ namespace Microsoft.Build.Evaluation
                                 return true;
                             }
                         }
-                        else if (string.Equals(_methodMethodName, nameof(IntrinsicFunctions.IsOSPlatform), StringComparison.OrdinalIgnoreCase) && args.Length == 1)
+                        else if (string.Equals(_methodMethodName, nameof(IntrinsicFunctions.IsOSPlatform), StringComparison.OrdinalIgnoreCase))
                         {
                             if (TryGetArg(args, out string arg0))
                             {

--- a/src/Build/Evaluation/Expander.cs
+++ b/src/Build/Evaluation/Expander.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;

--- a/src/Build/Evaluation/Expander.cs
+++ b/src/Build/Evaluation/Expander.cs
@@ -3568,7 +3568,6 @@ namespace Microsoft.Build.Evaluation
                     }
                     else
                     {
-                        Debugger.Launch();
                         bool wellKnownFunctionSuccess = false;
 
                         try
@@ -3867,7 +3866,7 @@ namespace Microsoft.Build.Evaluation
                             return true;
                         }
                     }
-                    else if (string.Equals(_methodMethodName, nameof(String.Equals), StringComparison.OrdinalIgnoreCase))
+                    else if (string.Equals(_methodMethodName, nameof(string.Equals), StringComparison.OrdinalIgnoreCase))
                     {
                         if (TryGetArg(args, out string arg0))
                         {
@@ -4484,20 +4483,20 @@ namespace Microsoft.Build.Evaluation
                             }
                         }
                     }
+                    else if (string.Equals(_methodMethodName, nameof(Regex.Replace), StringComparison.OrdinalIgnoreCase) && args.Length == 3)
+                    {
+                        if (TryGetArg([args[0]], out string arg1) && TryGetArg([args[1]], out string arg2) && TryGetArg([args[2]], out string arg3))
+                        {
+                            returnVal = Regex.Replace(arg1, arg2, arg3);
+                            return true;
+                        }
+                    }
                 }
                 else if (string.Equals(_methodMethodName, nameof(Version.ToString), StringComparison.OrdinalIgnoreCase) && objectInstance is Version v)
                 {
                     if (TryGetArg(args, out int arg0))
                     {
                         returnVal = v.ToString(arg0);
-                        return true;
-                    }
-                }
-                else if (string.Equals(_methodMethodName, nameof(Regex.Replace), StringComparison.OrdinalIgnoreCase) && args.Length == 3)
-                {
-                    if (TryGetArg([args[0]], out string arg1) && TryGetArg([args[1]], out string arg2) && TryGetArg([args[2]], out string arg3))
-                    {
-                        returnVal = Regex.Replace(arg1, arg2, arg3);
                         return true;
                     }
                 }

--- a/src/Build/Microsoft.Build.csproj
+++ b/src/Build/Microsoft.Build.csproj
@@ -30,7 +30,6 @@
   <ItemGroup>
     <ProjectReference Include="..\Framework\Microsoft.Build.Framework.csproj" />
     <ProjectReference Include="..\StringTools\StringTools.csproj" />
-    <ProjectReference Include="..\Utilities\Microsoft.Build.Utilities.csproj" />
     <PackageReference Include="System.Configuration.ConfigurationManager" />
 
     <PackageReference Include="System.Reflection.MetadataLoadContext" />

--- a/src/Build/Microsoft.Build.csproj
+++ b/src/Build/Microsoft.Build.csproj
@@ -30,6 +30,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Framework\Microsoft.Build.Framework.csproj" />
     <ProjectReference Include="..\StringTools\StringTools.csproj" />
+    <ProjectReference Include="..\Utilities\Microsoft.Build.Utilities.csproj" />
     <PackageReference Include="System.Configuration.ConfigurationManager" />
 
     <PackageReference Include="System.Reflection.MetadataLoadContext" />


### PR DESCRIPTION
Fixes #10398

### Context
Is fastpath isn't added for the method, it gets resoled by using reflection that is an expensive operation.
Since the covered methods are actively used by the main customers, they were added to MSBuild.

### Changes Made
Add the method from the linked tickets.

### Testing
Covered with unit tests.
