### PR TITLE
Fix excessive reporting about used environment variable

### DIFF
--- a/src/Framework/BuildMessageEventArgs.cs
+++ b/src/Framework/BuildMessageEventArgs.cs
@@ -219,9 +219,11 @@ namespace Microsoft.Build.Framework
            string message,
            string file,
            int lineNumber,
-           int columnNumber)
+           int columnNumber,
+           MessageImportance importance)
             : base(message, helpKeyword: null, senderName: null)
         {
+            this.importance = importance;
             this.file = file;
             this.lineNumber = lineNumber;
             this.columnNumber = columnNumber;

--- a/src/Framework/EnvironmentVariableReadEventArgs.cs
+++ b/src/Framework/EnvironmentVariableReadEventArgs.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Build.Framework
             string file,
             int line,
             int column)
-            : base(environmentVarValue, file, line, column) => EnvironmentVariableName = environmentVarName;
+            : base(environmentVarValue, file, line, column, MessageImportance.Low) => EnvironmentVariableName = environmentVarName;
 
         /// <summary>
         /// The name of the environment variable that was read.


### PR DESCRIPTION
Fixes:

sdk insertion
https://github.com/dotnet/sdk/pull/42215

### Context
If importance isn't specified forEnvironmentVariableReadEventArgs , the extra message is emitted.

### Changes Made
Return setup the default message severity

### Testing
Local manual testing