### PR TITLE
Declarations cleanup

### DIFF
--- a/eng/Packages.props
+++ b/eng/Packages.props
@@ -31,6 +31,6 @@
     <PackageVersion Include="System.Text.Json" Version="$(SystemTextJsonVersion)" />
     <PackageVersion Include="System.Threading.Channels" Version="$(SystemThreadingChannelsVersion)" />
     <PackageVersion Include="System.Threading.Tasks.Dataflow" Version="$(SystemThreadingTasksDataflowVersion)" />
-    <PackageVersion Include="xunit.console" Version="$(XUnitVersion)" />	
+    <PackageVersion Include="xunit.console" Version="$(XUnitVersion)" />
   </ItemGroup>
 </Project>

--- a/eng/SourceBuildPrebuiltBaseline.xml
+++ b/eng/SourceBuildPrebuiltBaseline.xml
@@ -8,7 +8,6 @@
     <UsagePattern IdentityGlob="System.Collections.Immutable/*8.0.0*" />
     <UsagePattern IdentityGlob="System.Configuration.ConfigurationManager/*8.0.0*" />
     <UsagePattern IdentityGlob="System.Diagnostics.EventLog/*8.0.0*" />
-    <UsagePattern IdentityGlob="System.Formats.Asn1/*8.0.0*" />
     <UsagePattern IdentityGlob="System.Formats.Asn1/*8.0.1*" />
     <UsagePattern IdentityGlob="System.Reflection.Metadata/*8.0.0*" />
     <UsagePattern IdentityGlob="System.Reflection.MetadataLoadContext/*8.0.0*" />

--- a/eng/SourceBuildPrebuiltBaseline.xml
+++ b/eng/SourceBuildPrebuiltBaseline.xml
@@ -9,6 +9,7 @@
     <UsagePattern IdentityGlob="System.Configuration.ConfigurationManager/*8.0.0*" />
     <UsagePattern IdentityGlob="System.Diagnostics.EventLog/*8.0.0*" />
     <UsagePattern IdentityGlob="System.Formats.Asn1/*8.0.0*" />
+    <UsagePattern IdentityGlob="System.Formats.Asn1/*8.0.1*" />
     <UsagePattern IdentityGlob="System.Reflection.Metadata/*8.0.0*" />
     <UsagePattern IdentityGlob="System.Reflection.MetadataLoadContext/*8.0.0*" />
     <UsagePattern IdentityGlob="System.Resources.Extensions/*8.0.0*" />
@@ -17,7 +18,6 @@
     <UsagePattern IdentityGlob="System.Security.Cryptography.Xml/*8.0.0*" />
     <UsagePattern IdentityGlob="System.Text.Json/*8.0.3*" />
     <UsagePattern IdentityGlob="System.Threading.Tasks.Dataflow/*8.0.0*" />
-    <UsagePattern IdentityGlob="System.Formats.Asn1/*8.0.1*" />
   </IgnorePatterns>
   <Usages>
   </Usages>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -26,6 +26,7 @@
   <PropertyGroup>
     <SystemCollectionsImmutableVersion>8.0.0</SystemCollectionsImmutableVersion>
     <SystemConfigurationConfigurationManagerVersion>8.0.0</SystemConfigurationConfigurationManagerVersion>
+    <SystemFormatsAsn1Version>8.0.1</SystemFormatsAsn1Version>
     <!--
         Modifying the version of System.Memory is very high impact and causes downstream breaks in third-party tooling that uses the MSBuild API.
         When updating the version of System.Memory file a breaking change here: https://github.com/dotnet/docs/issues/new?assignees=gewarren&labels=breaking-change%2CPri1%2Cdoc-idea&template=breaking-change.yml&title=%5BBreaking+change%5D%3A+
@@ -41,7 +42,6 @@
     <SystemTextJsonVersion>8.0.3</SystemTextJsonVersion>
     <SystemThreadingChannelsVersion>8.0.0</SystemThreadingChannelsVersion>
     <SystemThreadingTasksDataflowVersion>8.0.0</SystemThreadingTasksDataflowVersion>
-    <SystemFormatsAsn1Version>8.0.1</SystemFormatsAsn1Version>
   </PropertyGroup>
   <!-- Toolset Dependencies -->
   <PropertyGroup>


### PR DESCRIPTION
Fixes - some minor whitespaces/ordering mess introduced by https://github.com/dotnet/msbuild/pull/10396

### Context
* Extra whitespace removed
* Reordered SourceBuildPrebuiltBaseline.xml and Versions.props to stay alpha-ordered