### PR TITLE
add CacheGet and CacheSet tasks

### DIFF
--- a/src/Tasks/CacheGet.cs
+++ b/src/Tasks/CacheGet.cs
@@ -1,0 +1,24 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Build.Framework;
+
+#nullable disable
+
+namespace Microsoft.Build.Tasks
+{
+    public class CacheGet : TaskExtension
+    {
+        [Required]
+        public string Key { get; set; }
+
+        [Output]
+        public string Value { get; set; }
+
+        public override bool Execute()
+        {
+            Value = (string)BuildEngine4.GetRegisteredTaskObject(Key, RegisteredTaskObjectLifetime.Build) ?? "";
+            return true;
+        }
+    }
+}

--- a/src/Tasks/CacheSet.cs
+++ b/src/Tasks/CacheSet.cs
@@ -1,0 +1,24 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Build.Framework;
+
+#nullable disable
+
+namespace Microsoft.Build.Tasks
+{
+    public class CacheSet : TaskExtension
+    {
+        [Required]
+        public string Key { get; set; }
+
+        [Required]
+        public string Value { get; set; }
+
+        public override bool Execute()
+        {
+            BuildEngine4.RegisterTaskObject(Key, Value, RegisteredTaskObjectLifetime.Build, allowEarlyCollection: true);
+            return true;
+        }
+    }
+}

--- a/src/Tasks/Microsoft.Build.Tasks.csproj
+++ b/src/Tasks/Microsoft.Build.Tasks.csproj
@@ -204,6 +204,8 @@
     <Compile Include="FileIO\VerifyFileHash.cs" />
     <Compile Include="FileState.cs" />
     <Compile Include="Copy.cs" />
+    <Compile Include="CacheGet.cs" />
+    <Compile Include="CacheSet.cs" />
     <Compile Include="CreateCSharpManifestResourceName.cs" />
     <Compile Include="CreateVisualBasicManifestResourceName.cs" />
     <Compile Include="CreateItem.cs" />


### PR DESCRIPTION
### Context

To allow MSBuild target authors to take advantage of the build cache without having to write custom tasks.

### Changes Made

Added `Microsoft.Build.Tasks.CacheGet` and `Microsoft.Build.Tasks.CacheSet`.

### Testing

None yet.

### Notes

I'm sure there's plenty to be done to get this into an acceptable state, but I wanted to start a discussion about the feasibility of this feature before proceeding further, and a draft PR seemed like the easiest way to demonstrate what I'm proposing.