### PR TITLE
Pass CredScanSuppressions.json to 1ES template

### DIFF
--- a/.config/guardian/.gdnbaselines
+++ b/.config/guardian/.gdnbaselines
@@ -11,48 +11,6 @@
     }
   },
   "results": {
-    "1757d0179485ad6618415e151de2453f25d5484071f7bae328fa9ca9d4d54688": {
-      "signature": "1757d0179485ad6618415e151de2453f25d5484071f7bae328fa9ca9d4d54688",
-      "alternativeSignatures": [],
-      "target": "src/Tasks.UnitTests/TestResources/mycert.pfx",
-      "line": 1,
-      "memberOf": [
-        "default"
-      ],
-      "tool": "credscan",
-      "ruleId": "CSCAN-GENERAL0020",
-      "createdDate": "2024-03-14 11:30:33Z",
-      "expirationDate": "2024-08-31 12:48:32Z",
-      "justification": "This error is baselined with an expiration date of 180 days from 2024-03-14 12:48:32Z"
-    },
-    "60d4d52e838e08dc19d3ac2b43b7c809b080db55f9c754b80bd60f30624e9687": {
-      "signature": "60d4d52e838e08dc19d3ac2b43b7c809b080db55f9c754b80bd60f30624e9687",
-      "alternativeSignatures": [],
-      "target": "artifacts/bin/Microsoft.Build.Tasks.UnitTests/Release/net472/TestResources/mycert.pfx",
-      "line": 1,
-      "memberOf": [
-        "default"
-      ],
-      "tool": "credscan",
-      "ruleId": "CSCAN-GENERAL0020",
-      "createdDate": "2024-03-14 12:01:14Z",
-      "expirationDate": "2024-08-31 12:48:32Z",
-      "justification": "This error is baselined with an expiration date of 180 days from 2024-03-14 12:48:32Z"
-    },
-    "7cb5d42a8744e4a214149aa27d3d8a1b7989914d1a2fee8cea13287368cbafff": {
-      "signature": "7cb5d42a8744e4a214149aa27d3d8a1b7989914d1a2fee8cea13287368cbafff",
-      "alternativeSignatures": [],
-      "target": "artifacts/bin/Microsoft.Build.Tasks.UnitTests/Release/net8.0/TestResources/mycert.pfx",
-      "line": 1,
-      "memberOf": [
-        "default"
-      ],
-      "tool": "credscan",
-      "ruleId": "CSCAN-GENERAL0020",
-      "createdDate": "2024-03-14 12:01:14Z",
-      "expirationDate": "2024-08-31 12:48:32Z",
-      "justification": "This error is baselined with an expiration date of 180 days from 2024-03-14 12:48:32Z"
-    },
     "24491acb7bf0f8b072d9fbd2f6efcf1bdf6e9506ff3f7a9f9c803445c55b7bd9": {
       "signature": "24491acb7bf0f8b072d9fbd2f6efcf1bdf6e9506ff3f7a9f9c803445c55b7bd9",
       "alternativeSignatures": [

--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -61,6 +61,8 @@ extends:
         enabled: true
         break: true
         additionalTargetsGlobPattern: -|**\bootstrapper\**\vs_enterprise.exe
+      credscan:
+        suppressionsFile: $(Build.SourcesDirectory)/eng/CredScanSuppressions.json
 
     stages:
     - stage: build


### PR DESCRIPTION
### Context
This allows us to remove the corresponding entries from .gdnbaselines.