### PR TITLE
Fix backward compat of EnvironmentVariableReadEventArgs reading

### DIFF
--- a/src/Build/Logging/BinaryLogger/BuildEventArgsReader.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsReader.cs
@@ -1091,7 +1091,7 @@ namespace Microsoft.Build.Logging
 
         private BuildEventArgs ReadEnvironmentVariableReadEventArgs()
         {
-            var fields = ReadBuildEventArgsFields();
+            var fields = ReadBuildEventArgsFields(readImportance: true);
 
             string? environmentVariableName = ReadDeduplicatedString();
             int line = 0;

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsReader.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsReader.cs
@@ -1094,9 +1094,15 @@ namespace Microsoft.Build.Logging
             var fields = ReadBuildEventArgsFields();
 
             string? environmentVariableName = ReadDeduplicatedString();
-            int line = ReadInt32();
-            int column = ReadInt32();
-            string? fileName = ReadDeduplicatedString();
+            int line = 0;
+            int column = 0;
+            string? fileName = null;
+            if (_fileFormatVersion >= 22)
+            {
+                line = ReadInt32();
+                column = ReadInt32();
+                fileName = ReadDeduplicatedString();
+            }
 
             BuildEventArgs e = new EnvironmentVariableReadEventArgs(
                     environmentVariableName ?? string.Empty,


### PR DESCRIPTION
Fixes - binlog reading issue introduced in https://github.com/dotnet/msbuild/pull/10307

### Context
When changing readers/writers of BinaryLog format, we need to keep the old formats operatable.

### Changes made
Intoroduced back-compat reading of EnvironmentVariableReadEventArgs 
