### PR TITLE
Require Microsoft.IO.Redist > 6.0.0 (CVE-2024-38081)

### DIFF
--- a/src/Utilities/Microsoft.Build.Utilities.csproj
+++ b/src/Utilities/Microsoft.Build.Utilities.csproj
@@ -22,7 +22,7 @@
     <ProjectReference Include="..\Framework\Microsoft.Build.Framework.csproj" />
     <ProjectReference Include="..\StringTools\StringTools.csproj" />
 
-    <PackageReference Include="Microsoft.IO.Redist" Condition="'$(FeatureMSIORedist)' == 'true'" />
+    <PackageReference Include="Microsoft.IO.Redist" Condition="'$(FeatureMSIORedist)' == 'true'" Version="(6.0.0,)" />
     <PackageReference Include="System.Collections.Immutable" />
     <PackageReference Include="System.Configuration.ConfigurationManager" />
   </ItemGroup>


### PR DESCRIPTION
Fixes https://github.com/dotnet/msbuild/issues/10443

Set the minimum version of Microsoft.IO.Redist to > 6.0.0  

### Context

[CVE-2024-38081](https://github.com/advisories/GHSA-hq7w-xv5x-g34j)

### Changes Made

Require [Microsoft.IO.Redist](https://www.nuget.org/packages/Microsoft.IO.Redist/#versions-body-tab) to be above but not including 6.0.0.

![image](https://github.com/user-attachments/assets/754bca8f-b51c-4294-8f50-b343bc6958aa)

