### PR TITLE
Enable importing 'AppxPackage' tools for modern UWP class libraries

### DIFF
--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -6891,7 +6891,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <MsAppxPackageTargets Condition="'$(MsAppxPackageTargets)'==''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\AppxPackage\Microsoft.AppXPackage.Targets</MsAppxPackageTargets>
 
     <!-- Opt-out switch to allow disabling importing the 'AppxPackage' targets for UWP class libraries using modern .NET -->
-    <EnableAppxPackageTargetsForUwpClassLibraries Condition="'$(EnableAppxPackageTargetsForClassLibraries)' == ''">true</EnableAppxPackageTargetsForUwpClassLibraries>
+    <EnableAppxPackageTargetsForUwpClassLibraries Condition="'$(EnableAppxPackageTargetsForUwpClassLibraries)' == ''">true</EnableAppxPackageTargetsForUwpClassLibraries>
   </PropertyGroup>
 
   <!--

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -6890,7 +6890,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <PropertyGroup>
     <MsAppxPackageTargets Condition="'$(MsAppxPackageTargets)'==''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\AppxPackage\Microsoft.AppXPackage.Targets</MsAppxPackageTargets>
 
-    <!-- Opt-out switch to allow disabling importing the 'AppxPackage' targers for UWP class libraries using modern .NET -->
+    <!-- Opt-out switch to allow disabling importing the 'AppxPackage' targets for UWP class libraries using modern .NET -->
     <EnableAppxPackageTargetsForUwpClassLibraries Condition="'$(EnableAppxPackageTargetsForClassLibraries)' == ''">true</EnableAppxPackageTargetsForUwpClassLibraries>
   </PropertyGroup>
 

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -6889,9 +6889,20 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
   <PropertyGroup>
     <MsAppxPackageTargets Condition="'$(MsAppxPackageTargets)'==''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\AppxPackage\Microsoft.AppXPackage.Targets</MsAppxPackageTargets>
+
+    <!-- Opt-out switch to allow disabling importing the 'AppxPackage' targers for UWP class libraries using modern .NET -->
+    <EnableAppxPackageTargetsForClassLibraries Condition="'$(EnableAppxPackageTargetsForClassLibraries)' == ''">true</EnableAppxPackageTargetsForClassLibraries>
   </PropertyGroup>
 
-  <Import Project="$(MsAppxPackageTargets)" Condition="'$(WindowsAppContainer)' == 'true' and Exists('$(MsAppxPackageTargets)')" />
+  <!--
+    We want to import the 'AppXPackage' .targets in two scenarios:
+      - For legacy UWP, in all cases (original behavior). These projects will always set 'WindowsAppContainer' by default.
+      - For UWP (XAML) apps and libraries on modern .NET, we only enable this for class libraries. This allows the existing
+        .appx tooling to take care of generating .pri resources without the need to pull in WinAppSDK or other external tools.
+        We cannot use this for applications, because the rest of that tooling is not capable of handling modern .NET projects.
+        In that case, we either leverage the tooling in WinAppSDK, or DesktopBridge (via a .wapproj project for packaging).
+  -->
+  <Import Project="$(MsAppxPackageTargets)" Condition="('$(WindowsAppContainer)' == 'true' or ('$(UseUwpTools)' == 'true' and '$(OutputType)' == 'Library' and '$(EnableAppxPackageTargetsForClassLibraries)' != 'false')) and Exists('$(MsAppxPackageTargets)')" />
 
   <!-- This import is temporary and will be removed once it is moved into the silverlight targets -->
   <Import Project="$(MSBuildToolsPath)\Microsoft.Data.Entity.targets" Condition="'$(TargetFrameworkIdentifier)' == 'Silverlight' and Exists('$(MSBuildToolsPath)\Microsoft.Data.Entity.targets')"/>

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -6891,7 +6891,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <MsAppxPackageTargets Condition="'$(MsAppxPackageTargets)'==''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\AppxPackage\Microsoft.AppXPackage.Targets</MsAppxPackageTargets>
 
     <!-- Opt-out switch to allow disabling importing the 'AppxPackage' targers for UWP class libraries using modern .NET -->
-    <EnableAppxPackageTargetsForClassLibraries Condition="'$(EnableAppxPackageTargetsForClassLibraries)' == ''">true</EnableAppxPackageTargetsForClassLibraries>
+    <EnableAppxPackageTargetsForUwpClassLibraries Condition="'$(EnableAppxPackageTargetsForClassLibraries)' == ''">true</EnableAppxPackageTargetsForUwpClassLibraries>
   </PropertyGroup>
 
   <!--
@@ -6902,7 +6902,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         We cannot use this for applications, because the rest of that tooling is not capable of handling modern .NET projects.
         In that case, we either leverage the tooling in WinAppSDK, or DesktopBridge (via a .wapproj project for packaging).
   -->
-  <Import Project="$(MsAppxPackageTargets)" Condition="('$(WindowsAppContainer)' == 'true' or ('$(UseUwpTools)' == 'true' and '$(OutputType)' == 'Library' and '$(EnableAppxPackageTargetsForClassLibraries)' != 'false')) and Exists('$(MsAppxPackageTargets)')" />
+  <Import Project="$(MsAppxPackageTargets)" Condition="('$(WindowsAppContainer)' == 'true' or ('$(UseUwpTools)' == 'true' and '$(OutputType)' == 'Library' and '$(EnableAppxPackageTargetsForUwpClassLibraries)' != 'false')) and Exists('$(MsAppxPackageTargets)')" />
 
   <!-- This import is temporary and will be removed once it is moved into the silverlight targets -->
   <Import Project="$(MSBuildToolsPath)\Microsoft.Data.Entity.targets" Condition="'$(TargetFrameworkIdentifier)' == 'Silverlight' and Exists('$(MSBuildToolsPath)\Microsoft.Data.Entity.targets')"/>


### PR DESCRIPTION
Fixes https://task.ms/52765087

### Overview

This PR makes it possible to leverage the built-in APPX tooling for UWP class libraries using modern .NET (for .pri generation).

### Changes Made

Previously, `src/Tasks/Microsoft.Common.CurrentVersion.targets` would only import `Microsoft.AppXPackage.Targets` when `WindowsAppContainer` is set. This property is not used on modern .NET (as it also breaks a bunch of other tools that were only meant to work with the previous .NET and infrastructure for UWP). This PR updates the logic to also import the APPX targets for UWP class libraries using modern .NET, and includes an opt-out switch to allow developers to disable this updated functionality if needed (eg. if they wanted to skip .pri generation, or if they wanted to use the lifted toolset from WinAppSDK instead).

This is intentionally not enabled for applications, as they require either WinAppSDK or a .wapproj to be correctly packaged.

### Testing

Tested the changes locally by building a UWP class library and verifying the expected .pri files were produced.