### PR TITLE
Fix BuildRequest in in-node BuildCheck

### DIFF
--- a/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
@@ -1123,7 +1123,7 @@ namespace Microsoft.Build.BackEnd
                 {
                     buildCheckManager.StartProjectEvaluation(
                         BuildCheckDataSource.BuildExecution,
-                        new AnalysisLoggingContext(_nodeLoggingContext.LoggingService, _requestEntry.Request.ParentBuildEventContext),
+                        new AnalysisLoggingContext(_nodeLoggingContext.LoggingService, _requestEntry.Request.BuildEventContext),
                         _requestEntry.RequestConfiguration.ProjectFullPath);
 
                     _requestEntry.RequestConfiguration.LoadProjectIntoConfiguration(
@@ -1148,13 +1148,13 @@ namespace Microsoft.Build.BackEnd
             {
                 buildCheckManager.EndProjectEvaluation(
                     BuildCheckDataSource.BuildExecution,
-                    _requestEntry.Request.ParentBuildEventContext);
+                    _requestEntry.Request.BuildEventContext);
             }
 
             _projectLoggingContext = _nodeLoggingContext.LogProjectStarted(_requestEntry);
             buildCheckManager.StartProjectRequest(
                 BuildCheckDataSource.BuildExecution,
-                _requestEntry.Request.ParentBuildEventContext,
+                _requestEntry.Request.BuildEventContext,
                 _requestEntry.RequestConfiguration.ProjectFullPath);
 
             try
@@ -1226,7 +1226,7 @@ namespace Microsoft.Build.BackEnd
             {
                 buildCheckManager.EndProjectRequest(
                     BuildCheckDataSource.BuildExecution,
-                    new AnalysisLoggingContext(_nodeLoggingContext.LoggingService, _requestEntry.Request.ParentBuildEventContext),
+                    new AnalysisLoggingContext(_nodeLoggingContext.LoggingService, _requestEntry.Request.BuildEventContext),
                     _requestEntry.RequestConfiguration.ProjectFullPath);
             }
 


### PR DESCRIPTION
### Context
Context for the in-node events were set incorrectly.
This wasn't yet used in any actual processing - so no issue was encountered with this yet
