### PR TITLE
[8.0.4xx] Fix serialization of TelemetryEventArgs data packets across MSBuild worker nodes

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,7 +2,7 @@
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the MIT license. See License.txt in the project root for full license information. -->
 <Project>
   <PropertyGroup>
-    <VersionPrefix>17.11.3</VersionPrefix><DotNetFinalVersionKind>release</DotNetFinalVersionKind>
+    <VersionPrefix>17.11.4</VersionPrefix><DotNetFinalVersionKind>release</DotNetFinalVersionKind>
     <PackageValidationBaselineVersion>17.10.4</PackageValidationBaselineVersion>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>

--- a/src/Build.UnitTests/BuildEventArgsSerialization_Tests.cs
+++ b/src/Build.UnitTests/BuildEventArgsSerialization_Tests.cs
@@ -873,6 +873,7 @@ namespace Microsoft.Build.UnitTests
                 e => e.HelpKeyword,
                 e => e.SenderName);
         }
+
         [Fact]
         public void ReadingCorruptedStreamThrows()
         {

--- a/src/Framework.UnitTests/CustomEventArgSerialization_Tests.cs
+++ b/src/Framework.UnitTests/CustomEventArgSerialization_Tests.cs
@@ -974,5 +974,62 @@ namespace Microsoft.Build.UnitTests
             newGenericEvent.TaskFile.ShouldBe(genericEvent.TaskFile, StringCompareShould.IgnoreCase); // "Expected TaskFile to Match"
             newGenericEvent.TaskName.ShouldBe(genericEvent.TaskName, StringCompareShould.IgnoreCase); // "Expected TaskName to Match"
         }
+
+
+        [Fact]
+        public void TestTelemetryEventArgs()
+        {
+            // Test using reasonable values
+            TelemetryEventArgs genericEvent = new TelemetryEventArgs { EventName = "Good", Properties = new Dictionary<string, string> { { "Key", "Value" } } };
+            genericEvent.BuildEventContext = new BuildEventContext(5, 4, 3, 2);
+
+            // Serialize
+            genericEvent.WriteToStream(_writer);
+            long streamWriteEndPosition = _stream.Position;
+
+            // Deserialize and Verify
+            _stream.Position = 0;
+            TelemetryEventArgs newGenericEvent = new TelemetryEventArgs();
+            newGenericEvent.CreateFromStream(_reader, _eventArgVersion);
+            _stream.Position.ShouldBe(streamWriteEndPosition); // "Stream End Positions Should Match"
+            VerifyGenericEventArg(genericEvent, newGenericEvent);
+            VerifyTelemetryEvent(genericEvent, newGenericEvent);
+
+            // Test using null event name
+            _stream.Position = 0;
+            genericEvent = new TelemetryEventArgs { EventName = null, Properties = new Dictionary<string, string> { { "Key", "Value" } } };
+            // Serialize
+            genericEvent.WriteToStream(_writer);
+            streamWriteEndPosition = _stream.Position;
+
+            // Deserialize and Verify
+            _stream.Position = 0;
+            newGenericEvent = new TelemetryEventArgs();
+            newGenericEvent.CreateFromStream(_reader, _eventArgVersion);
+            _stream.Position.ShouldBe(streamWriteEndPosition); // "Stream End Positions Should Match"
+            VerifyGenericEventArg(genericEvent, newGenericEvent);
+            VerifyTelemetryEvent(genericEvent, newGenericEvent);
+
+            // Test using null property value name
+            _stream.Position = 0;
+            genericEvent = new TelemetryEventArgs { EventName = "Good", Properties = new Dictionary<string, string> { { "Key", null } } };
+            // Serialize
+            genericEvent.WriteToStream(_writer);
+            streamWriteEndPosition = _stream.Position;
+
+            // Deserialize and Verify
+            _stream.Position = 0;
+            newGenericEvent = new TelemetryEventArgs();
+            newGenericEvent.CreateFromStream(_reader, _eventArgVersion);
+            _stream.Position.ShouldBe(streamWriteEndPosition); // "Stream End Positions Should Match"
+            VerifyGenericEventArg(genericEvent, newGenericEvent);
+            VerifyTelemetryEvent(genericEvent, newGenericEvent);
+        }
+
+        private static void VerifyTelemetryEvent(TelemetryEventArgs expected, TelemetryEventArgs actual)
+        {
+            actual.EventName.ShouldBe(expected.EventName);
+            actual.Properties.ShouldBe(expected.Properties);
+        }
     }
 }

--- a/src/Framework.UnitTests/CustomEventArgSerialization_Tests.cs
+++ b/src/Framework.UnitTests/CustomEventArgSerialization_Tests.cs
@@ -977,53 +977,73 @@ namespace Microsoft.Build.UnitTests
 
 
         [Fact]
-        public void TestTelemetryEventArgs()
+        public void TestTelemetryEventArgs_AllProperties()
         {
             // Test using reasonable values
             TelemetryEventArgs genericEvent = new TelemetryEventArgs { EventName = "Good", Properties = new Dictionary<string, string> { { "Key", "Value" } } };
             genericEvent.BuildEventContext = new BuildEventContext(5, 4, 3, 2);
 
-            // Serialize
-            genericEvent.WriteToStream(_writer);
+            TelemetryEventArgs newGenericEvent = RoundTrip(genericEvent);
+
+            VerifyGenericEventArg(genericEvent, newGenericEvent);
+            VerifyTelemetryEvent(genericEvent, newGenericEvent);
+        }
+
+        [Fact]
+        public void TestTelemetryEventArgs_NullProperties()
+        {
+            // Test using reasonable values
+            TelemetryEventArgs genericEvent = new TelemetryEventArgs { EventName = "Good", Properties = null };
+            genericEvent.BuildEventContext = new BuildEventContext(5, 4, 3, 2);
+
+            TelemetryEventArgs newGenericEvent = RoundTrip(genericEvent);
+
+            // quirk - the properties dict is initialized to an empty dictionary by the default constructor, so it's not _really_ round-trippable.
+            // so we modify the source event for easier comparison here.
+            genericEvent.Properties = new Dictionary<string, string>();
+
+            VerifyGenericEventArg(genericEvent, newGenericEvent);
+            VerifyTelemetryEvent(genericEvent, newGenericEvent);
+        }
+
+        [Fact]
+        public void TestTelemetryEventArgs_NullEventName()
+        {
+            // Test using null event name
+            TelemetryEventArgs genericEvent = new TelemetryEventArgs { EventName = null, Properties = new Dictionary<string, string> { { "Key", "Value" } } };
+            genericEvent.BuildEventContext = new BuildEventContext(5, 4, 3, 2);
+
+            TelemetryEventArgs newGenericEvent = RoundTrip(genericEvent);
+
+            VerifyGenericEventArg(genericEvent, newGenericEvent);
+            VerifyTelemetryEvent(genericEvent, newGenericEvent);
+        }
+
+        [Fact]
+        public void TestTelemetryEventArgs_NullPropertyValue()
+        {
+            // Test using null property value name
+            TelemetryEventArgs genericEvent = new TelemetryEventArgs { EventName = "Good", Properties = new Dictionary<string, string> { { "Key", null } } };
+            genericEvent.BuildEventContext = new BuildEventContext(5, 4, 3, 2);
+
+            TelemetryEventArgs newGenericEvent = RoundTrip(genericEvent);
+
+            VerifyGenericEventArg(genericEvent, newGenericEvent);
+            VerifyTelemetryEvent(genericEvent, newGenericEvent);
+        }
+
+        private T RoundTrip<T>(T original)
+            where T : BuildEventArgs, new()
+        {
+            _stream.Position = 0;
+            original.WriteToStream(_writer);
             long streamWriteEndPosition = _stream.Position;
 
-            // Deserialize and Verify
             _stream.Position = 0;
-            TelemetryEventArgs newGenericEvent = new TelemetryEventArgs();
-            newGenericEvent.CreateFromStream(_reader, _eventArgVersion);
+            var actual = new T();
+            actual.CreateFromStream(_reader, _eventArgVersion);
             _stream.Position.ShouldBe(streamWriteEndPosition); // "Stream End Positions Should Match"
-            VerifyGenericEventArg(genericEvent, newGenericEvent);
-            VerifyTelemetryEvent(genericEvent, newGenericEvent);
-
-            // Test using null event name
-            _stream.Position = 0;
-            genericEvent = new TelemetryEventArgs { EventName = null, Properties = new Dictionary<string, string> { { "Key", "Value" } } };
-            // Serialize
-            genericEvent.WriteToStream(_writer);
-            streamWriteEndPosition = _stream.Position;
-
-            // Deserialize and Verify
-            _stream.Position = 0;
-            newGenericEvent = new TelemetryEventArgs();
-            newGenericEvent.CreateFromStream(_reader, _eventArgVersion);
-            _stream.Position.ShouldBe(streamWriteEndPosition); // "Stream End Positions Should Match"
-            VerifyGenericEventArg(genericEvent, newGenericEvent);
-            VerifyTelemetryEvent(genericEvent, newGenericEvent);
-
-            // Test using null property value name
-            _stream.Position = 0;
-            genericEvent = new TelemetryEventArgs { EventName = "Good", Properties = new Dictionary<string, string> { { "Key", null } } };
-            // Serialize
-            genericEvent.WriteToStream(_writer);
-            streamWriteEndPosition = _stream.Position;
-
-            // Deserialize and Verify
-            _stream.Position = 0;
-            newGenericEvent = new TelemetryEventArgs();
-            newGenericEvent.CreateFromStream(_reader, _eventArgVersion);
-            _stream.Position.ShouldBe(streamWriteEndPosition); // "Stream End Positions Should Match"
-            VerifyGenericEventArg(genericEvent, newGenericEvent);
-            VerifyTelemetryEvent(genericEvent, newGenericEvent);
+            return actual;
         }
 
         private static void VerifyTelemetryEvent(TelemetryEventArgs expected, TelemetryEventArgs actual)

--- a/src/Framework/TelemetryEventArgs.cs
+++ b/src/Framework/TelemetryEventArgs.cs
@@ -37,10 +37,9 @@ namespace Microsoft.Build.Framework
             foreach (var kvp in Properties)
             {
                 writer.Write(kvp.Key);
-                writer.Write(kvp.Value);
+                writer.WriteOptionalString(kvp.Value);
             }
         }
-
         internal override void CreateFromStream(BinaryReader reader, int version)
         {
             base.CreateFromStream(reader, version);
@@ -51,7 +50,7 @@ namespace Microsoft.Build.Framework
             for (int i = 0; i < count; i++)
             {
                 string key = reader.ReadString();
-                string value = reader.ReadString();
+                string value = reader.ReadOptionalString();
                 Properties.Add(key, value);
             }
         }

--- a/src/Framework/TelemetryEventArgs.cs
+++ b/src/Framework/TelemetryEventArgs.cs
@@ -6,8 +6,6 @@ using System.Collections.Generic;
 using System.IO;
 using Microsoft.Build.Shared;
 
-#nullable disable
-
 namespace Microsoft.Build.Framework
 {
     /// <summary>
@@ -19,12 +17,12 @@ namespace Microsoft.Build.Framework
         /// <summary>
         /// Gets or sets the name of the event.
         /// </summary>
-        public string EventName { get; set; }
+        public string? EventName { get; set; }
 
         /// <summary>
         /// Gets or sets a list of properties associated with the event.
         /// </summary>
-        public IDictionary<string, string> Properties { get; set; } = new Dictionary<string, string>();
+        public IDictionary<string, string?> Properties { get; set; } = new Dictionary<string, string?>();
 
         internal override void WriteToStream(BinaryWriter writer)
         {
@@ -33,6 +31,11 @@ namespace Microsoft.Build.Framework
             writer.WriteOptionalString(EventName);
             int count = Properties?.Count ?? 0;
             writer.Write7BitEncodedInt(count);
+
+            if (Properties == null)
+            {
+                return;
+            }
 
             foreach (var kvp in Properties)
             {
@@ -50,7 +53,7 @@ namespace Microsoft.Build.Framework
             for (int i = 0; i < count; i++)
             {
                 string key = reader.ReadString();
-                string value = reader.ReadOptionalString();
+                string? value = reader.ReadOptionalString();
                 Properties.Add(key, value);
             }
         }


### PR DESCRIPTION
Fixes [azdo#2174440](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2174440)

### Context

The serialization of telemetry events assumed that telemetry properties would always have a value - it seems like it's possible for callers to send null values, so we need to be able to handle that. This was triggered with the addition of containers telemetry added in 8.0.400.

### Changes Made

Optionally write and read the value string for the telemetry event payload.

### Testing

Added previously-nonexistent round-tripping tests for this event type.

### Notes
We'll want to take this to SDK Tactics for servicing, but then to VS QB to see if they want to align releases or let the VS side drift a bit.