### PR TITLE
Add missing type of EnvironmentVariableReadEventArgs to BuildCheckForwardingLogger events

### DIFF
--- a/src/Build/BuildCheck/Infrastructure/BuildCheckForwardingLogger.cs
+++ b/src/Build/BuildCheck/Infrastructure/BuildCheckForwardingLogger.cs
@@ -37,6 +37,7 @@ internal class BuildCheckForwardingLogger : IForwardingLogger
     /// </summary>
     private HashSet<Type> _eventsToForward = new HashSet<Type>
     {
+        typeof(EnvironmentVariableReadEventArgs),
         typeof(ProjectEvaluationFinishedEventArgs),
         typeof(ProjectEvaluationStartedEventArgs),
         typeof(ProjectStartedEventArgs),


### PR DESCRIPTION
Fixes #10471

### Context
BuildCheckForwardingLogger events lacks the type of EnvironmentVariableReadEventArgs for used environment variable check and causes test failures https://dev.azure.com/dnceng-public/public/_build/results?buildId=761438&view=ms.vss-test-web.build-test-results-tab.

### Changes Made
Add the missing type.

### Testing
Existing tests.

### Notes
