### PR TITLE
XmlPeek: escape items correctly

### DIFF
--- a/src/Tasks.UnitTests/XmlPeek_Tests.cs
+++ b/src/Tasks.UnitTests/XmlPeek_Tests.cs
@@ -3,8 +3,10 @@
 
 using System;
 using System.IO;
+using System.Linq;
 
 using Microsoft.Build.Evaluation;
+using Microsoft.Build.Framework;
 using Microsoft.Build.Tasks;
 using Microsoft.Build.Utilities;
 
@@ -48,6 +50,13 @@ namespace Microsoft.Build.UnitTests
   <variable Type='String' Name='c'></variable>
   <method AccessModifier='public static' Name='GetVal' />
 </class>
+";
+        private readonly string _xmlFileRequiresEscaping = @"
+<Root>
+  <Key>abcdefg</Key>
+  <Key>a$(d)fg</Key>
+  <Key>a$(d.f)</Key>
+</Root>
 ";
 
         [Fact]
@@ -330,6 +339,24 @@ namespace Microsoft.Build.UnitTests
             project.Build().ShouldBeFalse();
             log.AssertLogContains("MSB4044");
             log.AssertLogContains("\"Query\"");
+        }
+
+        [Fact]
+        public void PeekEscapesCorrectly()
+        {
+            MockEngine engine = new MockEngine(true);
+            string xmlInputPath;
+            Prepare(_xmlFileRequiresEscaping, out xmlInputPath);
+
+            XmlPeek p = new XmlPeek();
+            p.BuildEngine = engine;
+
+            p.XmlInputPath = new TaskItem(xmlInputPath);
+            p.Query = "//Key/text()";
+
+            Assert.True(p.Execute());
+            Assert.Equal(["abcdefg", "a$(d)fg", "a$(d.f)"], p.Result.Select(x => x.ItemSpec));
+            Assert.Equal(["abcdefg", "a%24%28d%29fg", "a%24%28d.f%29"], p.Result.Cast<TaskItem>().Select(x => x.ToString()));
         }
 
         private void Prepare(string xmlFile, out string xmlInputPath)

--- a/src/Tasks/XmlPeek.cs
+++ b/src/Tasks/XmlPeek.cs
@@ -150,7 +150,7 @@ namespace Microsoft.Build.Tasks
             int i = 0;
             foreach (string item in peekValues)
             {
-                Result[i++] = new TaskItem(item);
+                Result[i++] = new TaskItem(EscapingUtilities.Escape(item));
 
                 // This can be logged a lot, so low importance
                 Log.LogMessageFromResources(MessageImportance.Low, "XmlPeek.Found", item);


### PR DESCRIPTION
Fixes #10313

TaskItem constructor assumes item spec to be escaped, but it was not.

https://github.com/dotnet/msbuild/blob/049835be350eb60f66b63e2e9adbd89094b4b127/src/Utilities/TaskItem.cs#L73-L76