### PR TITLE
Add initial scoping implementation

### DIFF
--- a/documentation/specs/BuildCheck/BuildCheck.md
+++ b/documentation/specs/BuildCheck/BuildCheck.md
@@ -209,7 +209,7 @@ Option `EvaluationAnalysisScope` with following possible options will be availab
 
 | EvaluationAnalysisScope (Solution Explorer)   | EditorConfig option      |  Behavior  | 
 | ------------- | ------------- |   ------------- |
-| ProjectFileOnly | `projectfile` | Only the data from currently analyzed project will be sent to the analyzer. Imports will be discarded. | 
+| ProjectFileOnly | `project_file` | Only the data from currently analyzed project will be sent to the analyzer. Imports will be discarded. | 
 | WorkTreeImports | `work_tree_imports` |  Only the data from currently analyzed project and imports from files not recognized to be in nuget cache or SDK install folder will be sent to the analyzer. Other imports will be discarded. |  
 | ProjectWithAllImports | `all` | All data will be sent to the analyzer. | 
 

--- a/documentation/specs/BuildCheck/BuildCheck.md
+++ b/documentation/specs/BuildCheck/BuildCheck.md
@@ -209,9 +209,8 @@ Option `EvaluationAnalysisScope` with following possible options will be availab
 
 | EvaluationAnalysisScope (Solution Explorer)   | EditorConfig option      |  Behavior  | 
 | ------------- | ------------- |   ------------- |
-| ProjectOnly | `project` | Only the data from currently analyzed project will be sent to the analyzer. Imports will be discarded. | 
-| ProjectWithImportsFromCurrentWorkTree | `current_imports` |  Only the data from currently analyzed project and imports from files under the entry project or solution will be sent to the analyzer. Other imports will be discarded. | 
-| ProjectWithImportsWithoutSdks | `without_sdks` | Imports from SDKs will not be sent to the analyzer. Other imports will be sent. | 
+| ProjectFileOnly | `projectfile` | Only the data from currently analyzed project will be sent to the analyzer. Imports will be discarded. | 
+| WorkTreeImports | `work_tree_imports` |  Only the data from currently analyzed project and imports from files not recognized to be in nuget cache or SDK install folder will be sent to the analyzer. Other imports will be discarded. |  
 | ProjectWithAllImports | `all` | All data will be sent to the analyzer. | 
 
 All rules of a single analyzer must have the `EvaluationAnalysisScope` configured to a same value. If any rule from the analyzer have the value configured differently - a warning will be issued during the build and analyzer will be deregistered.

--- a/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
@@ -1404,10 +1404,7 @@ namespace Microsoft.Build.BackEnd
             ProjectInstance project = _requestEntry?.RequestConfiguration?.Project;
             if (project != null)
             {
-                // example: C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.7.2
-                FileClassifier.Shared.RegisterImmutableDirectory(project.GetPropertyValue("FrameworkPathOverride")?.Trim());
-                // example: C:\Program Files\dotnet\
-                FileClassifier.Shared.RegisterImmutableDirectory(project.GetPropertyValue("NetCoreRoot")?.Trim());
+                FileClassifier.Shared.RegisterKnownImmutableLocations(project.GetPropertyValue);
             }
         }
 

--- a/src/Build/BuildCheck/API/BuildAnalyzerConfiguration.cs
+++ b/src/Build/BuildCheck/API/BuildAnalyzerConfiguration.cs
@@ -21,7 +21,7 @@ public class BuildAnalyzerConfiguration
     //  nor in the editorconfig configuration file.
     public static BuildAnalyzerConfiguration Default { get; } = new()
     {
-        EvaluationAnalysisScope = BuildCheck.EvaluationAnalysisScope.ProjectOnly,
+        EvaluationAnalysisScope = BuildCheck.EvaluationAnalysisScope.ProjectFileOnly,
         Severity = BuildAnalyzerResultSeverity.None
     };
 
@@ -84,14 +84,13 @@ public class BuildAnalyzerConfiguration
 
         switch (stringValue)
         {
-            case "project":
-                return BuildCheck.EvaluationAnalysisScope.ProjectOnly;
-            case "current_imports":
-                return BuildCheck.EvaluationAnalysisScope.ProjectWithImportsFromCurrentWorkTree;
-            case "without_sdks":
-                return BuildCheck.EvaluationAnalysisScope.ProjectWithImportsWithoutSdks;
+            case "projectfile":
+            case "project_file":
+                return BuildCheck.EvaluationAnalysisScope.ProjectFileOnly;
+            case "work_tree_imports":
+                return BuildCheck.EvaluationAnalysisScope.WorkTreeImports;
             case "all":
-                return BuildCheck.EvaluationAnalysisScope.ProjectWithAllImports;
+                return BuildCheck.EvaluationAnalysisScope.All;
             default:
                 ThrowIncorrectValueException(BuildCheckConstants.scopeConfigurationKey, stringValue);
                 break;

--- a/src/Build/BuildCheck/API/EvaluationAnalysisScope.cs
+++ b/src/Build/BuildCheck/API/EvaluationAnalysisScope.cs
@@ -14,20 +14,16 @@ public enum EvaluationAnalysisScope
     /// <summary>
     /// Only the data from currently analyzed project will be sent to the analyzer. Imports will be discarded.
     /// </summary>
-    ProjectOnly,
+    ProjectFileOnly,
 
     /// <summary>
-    /// Only the data from currently analyzed project and imports from files under the entry project or solution will be sent to the analyzer. Other imports will be discarded.
+    /// Only the data from currently analyzed project and imports from files not recognized to be in nuget cache or SDK install folder will be sent to the analyzer. Other imports will be discarded.
+    /// The generated nuget.g.props, nuget.g.targets will be ignored as well.
     /// </summary>
-    ProjectWithImportsFromCurrentWorkTree,
-
-    /// <summary>
-    /// Imports from SDKs will not be sent to the analyzer. Other imports will be sent.
-    /// </summary>
-    ProjectWithImportsWithoutSdks,
+    WorkTreeImports,
 
     /// <summary>
     /// All data will be sent to the analyzer.
     /// </summary>
-    ProjectWithAllImports,
+    All,
 }

--- a/src/Build/BuildCheck/Infrastructure/AnalysisScopeClassifier.cs
+++ b/src/Build/BuildCheck/Infrastructure/AnalysisScopeClassifier.cs
@@ -1,0 +1,46 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using Microsoft.Build.Experimental.BuildCheck;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Shared;
+
+namespace Microsoft.Build.BuildCheck.Infrastructure;
+internal static class AnalysisScopeClassifier
+{
+    /// <summary>
+    /// Indicates whether given location is in the observed scope, based on currently built project path.
+    /// </summary>
+    /// <param name="scope"></param>
+    /// <param name="location"></param>
+    /// <param name="projectFileFullPath"></param>
+    /// <returns></returns>
+    /// <exception cref="ArgumentOutOfRangeException"></exception>
+    internal static bool IsActionInObservedScope(
+        EvaluationAnalysisScope scope,
+        IMsBuildElementLocation? location,
+        string projectFileFullPath)
+    {
+        switch (scope)
+        {
+            case EvaluationAnalysisScope.ProjectFileOnly:
+                return location != null && location.File == projectFileFullPath;
+            case EvaluationAnalysisScope.WorkTreeImports:
+                return
+                    location != null &&
+                    !FileClassifier.Shared.IsNonModifiable(location.File) &&
+                    !IsGeneratedNugetImport(location.File);
+            case EvaluationAnalysisScope.All:
+                return true;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(scope), scope, null);
+        }
+    }
+
+    private static bool IsGeneratedNugetImport(string file)
+    {
+        return file.EndsWith("nuget.g.props", StringComparison.OrdinalIgnoreCase) ||
+               file.EndsWith("nuget.g.targets", StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/src/Build/BuildCheck/Infrastructure/BuildCheckManagerProvider.cs
+++ b/src/Build/BuildCheck/Infrastructure/BuildCheckManagerProvider.cs
@@ -337,8 +337,24 @@ internal sealed class BuildCheckManagerProvider : IBuildCheckManagerProvider
         public void ProcessEvaluationFinishedEventArgs(
             IAnalysisContext analysisContext,
             ProjectEvaluationFinishedEventArgs evaluationFinishedEventArgs)
-            => _buildEventsProcessor
-                .ProcessEvaluationFinishedEventArgs(analysisContext, evaluationFinishedEventArgs);
+        {
+            Dictionary<string, string>? propertiesLookup = null;
+            // The FileClassifier is normally initialized by executing build requests.
+            // However, if we are running in a main node that has no execution nodes - we need to initialize it here (from events).
+            if (!IsInProcNode)
+            {
+                propertiesLookup =
+                    BuildEventsProcessor.ExtractPropertiesLookup(evaluationFinishedEventArgs);
+                Func<string, string?> getPropertyValue = p =>
+                    propertiesLookup.TryGetValue(p, out string? value) ? value : null;
+
+                FileClassifier.Shared.RegisterFrameworkLocations(getPropertyValue);
+                FileClassifier.Shared.RegisterKnownImmutableLocations(getPropertyValue);
+            }
+
+            _buildEventsProcessor
+                .ProcessEvaluationFinishedEventArgs(analysisContext, evaluationFinishedEventArgs, propertiesLookup);
+        }
 
         public void ProcessEnvironmentVariableReadEventArgs(IAnalysisContext analysisContext, EnvironmentVariableReadEventArgs projectEvaluationEventArgs)
         {

--- a/src/Build/BuildCheck/Infrastructure/BuildEventsProcessor.cs
+++ b/src/Build/BuildCheck/Infrastructure/BuildEventsProcessor.cs
@@ -45,22 +45,33 @@ internal class BuildEventsProcessor(BuildCheckCentralContext buildCheckCentralCo
     /// </summary>
     private readonly Dictionary<TaskKey, ExecutingTaskData> _tasksBeingExecuted = [];
 
-    // This requires MSBUILDLOGPROPERTIESANDITEMSAFTEREVALUATION set to 1
-    internal void ProcessEvaluationFinishedEventArgs(
-        IAnalysisContext analysisContext,
-        ProjectEvaluationFinishedEventArgs evaluationFinishedEventArgs)
+    internal static Dictionary<string, string> ExtractPropertiesLookup(ProjectEvaluationFinishedEventArgs evaluationFinishedEventArgs)
     {
         Dictionary<string, string> propertiesLookup = new Dictionary<string, string>();
         Internal.Utilities.EnumerateProperties(evaluationFinishedEventArgs.Properties, propertiesLookup,
             static (dict, kvp) => dict.Add(kvp.Key, kvp.Value));
 
-        EvaluatedPropertiesAnalysisData analysisData =
-            new(evaluationFinishedEventArgs.ProjectFile!,
-                evaluationFinishedEventArgs.BuildEventContext?.ProjectInstanceId,
-                propertiesLookup,
-                _evaluatedEnvironmentVariables);
+        return propertiesLookup;
+    }
 
-        _buildCheckCentralContext.RunEvaluatedPropertiesActions(analysisData, analysisContext, ReportResult);
+    // This requires MSBUILDLOGPROPERTIESANDITEMSAFTEREVALUATION set to 1
+    internal void ProcessEvaluationFinishedEventArgs(
+        IAnalysisContext analysisContext,
+        ProjectEvaluationFinishedEventArgs evaluationFinishedEventArgs,
+        Dictionary<string, string>? propertiesLookup)
+    {
+        if (_buildCheckCentralContext.HasEvaluatedPropertiesActions)
+        {
+            propertiesLookup ??= ExtractPropertiesLookup(evaluationFinishedEventArgs);
+
+            EvaluatedPropertiesAnalysisData analysisData =
+                new(evaluationFinishedEventArgs.ProjectFile!,
+                    evaluationFinishedEventArgs.BuildEventContext?.ProjectInstanceId,
+                    propertiesLookup!,
+                    _evaluatedEnvironmentVariables);
+
+            _buildCheckCentralContext.RunEvaluatedPropertiesActions(analysisData, analysisContext, ReportResult);
+        }
 
         if (_buildCheckCentralContext.HasParsedItemsActions)
         {

--- a/src/Build/CompatibilitySuppressions.xml
+++ b/src/Build/CompatibilitySuppressions.xml
@@ -10,6 +10,34 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
+    <Target>F:Microsoft.Build.Experimental.BuildCheck.EvaluationAnalysisScope.ProjectOnly</Target>
+    <Left>lib/net472/Microsoft.Build.dll</Left>
+    <Right>lib/net472/Microsoft.Build.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>F:Microsoft.Build.Experimental.BuildCheck.EvaluationAnalysisScope.ProjectWithAllImports</Target>
+    <Left>lib/net472/Microsoft.Build.dll</Left>
+    <Right>lib/net472/Microsoft.Build.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>F:Microsoft.Build.Experimental.BuildCheck.EvaluationAnalysisScope.ProjectWithImportsFromCurrentWorkTree</Target>
+    <Left>lib/net472/Microsoft.Build.dll</Left>
+    <Right>lib/net472/Microsoft.Build.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>F:Microsoft.Build.Experimental.BuildCheck.EvaluationAnalysisScope.ProjectWithImportsWithoutSdks</Target>
+    <Left>lib/net472/Microsoft.Build.dll</Left>
+    <Right>lib/net472/Microsoft.Build.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Microsoft.Build.Execution.BuildResult.get_BuildRequestDataFlags</Target>
     <Left>lib/net472/Microsoft.Build.dll</Left>
     <Right>lib/net472/Microsoft.Build.dll</Right>
@@ -31,6 +59,34 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
+    <Target>F:Microsoft.Build.Experimental.BuildCheck.EvaluationAnalysisScope.ProjectOnly</Target>
+    <Left>lib/net8.0/Microsoft.Build.dll</Left>
+    <Right>lib/net8.0/Microsoft.Build.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>F:Microsoft.Build.Experimental.BuildCheck.EvaluationAnalysisScope.ProjectWithAllImports</Target>
+    <Left>lib/net8.0/Microsoft.Build.dll</Left>
+    <Right>lib/net8.0/Microsoft.Build.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>F:Microsoft.Build.Experimental.BuildCheck.EvaluationAnalysisScope.ProjectWithImportsFromCurrentWorkTree</Target>
+    <Left>lib/net8.0/Microsoft.Build.dll</Left>
+    <Right>lib/net8.0/Microsoft.Build.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>F:Microsoft.Build.Experimental.BuildCheck.EvaluationAnalysisScope.ProjectWithImportsWithoutSdks</Target>
+    <Left>lib/net8.0/Microsoft.Build.dll</Left>
+    <Right>lib/net8.0/Microsoft.Build.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Microsoft.Build.Execution.BuildResult.get_BuildRequestDataFlags</Target>
     <Left>lib/net8.0/Microsoft.Build.dll</Left>
     <Right>lib/net8.0/Microsoft.Build.dll</Right>
@@ -52,6 +108,34 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
+    <Target>F:Microsoft.Build.Experimental.BuildCheck.EvaluationAnalysisScope.ProjectOnly</Target>
+    <Left>ref/net472/Microsoft.Build.dll</Left>
+    <Right>ref/net472/Microsoft.Build.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>F:Microsoft.Build.Experimental.BuildCheck.EvaluationAnalysisScope.ProjectWithAllImports</Target>
+    <Left>ref/net472/Microsoft.Build.dll</Left>
+    <Right>ref/net472/Microsoft.Build.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>F:Microsoft.Build.Experimental.BuildCheck.EvaluationAnalysisScope.ProjectWithImportsFromCurrentWorkTree</Target>
+    <Left>ref/net472/Microsoft.Build.dll</Left>
+    <Right>ref/net472/Microsoft.Build.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>F:Microsoft.Build.Experimental.BuildCheck.EvaluationAnalysisScope.ProjectWithImportsWithoutSdks</Target>
+    <Left>ref/net472/Microsoft.Build.dll</Left>
+    <Right>ref/net472/Microsoft.Build.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Microsoft.Build.Execution.BuildResult.get_BuildRequestDataFlags</Target>
     <Left>ref/net472/Microsoft.Build.dll</Left>
     <Right>ref/net472/Microsoft.Build.dll</Right>
@@ -67,6 +151,34 @@
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
     <Target>F:Microsoft.Build.Experimental.BuildCheck.BuildAnalyzerResultSeverity.Info</Target>
+    <Left>ref/net8.0/Microsoft.Build.dll</Left>
+    <Right>ref/net8.0/Microsoft.Build.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>F:Microsoft.Build.Experimental.BuildCheck.EvaluationAnalysisScope.ProjectOnly</Target>
+    <Left>ref/net8.0/Microsoft.Build.dll</Left>
+    <Right>ref/net8.0/Microsoft.Build.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>F:Microsoft.Build.Experimental.BuildCheck.EvaluationAnalysisScope.ProjectWithAllImports</Target>
+    <Left>ref/net8.0/Microsoft.Build.dll</Left>
+    <Right>ref/net8.0/Microsoft.Build.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>F:Microsoft.Build.Experimental.BuildCheck.EvaluationAnalysisScope.ProjectWithImportsFromCurrentWorkTree</Target>
+    <Left>ref/net8.0/Microsoft.Build.dll</Left>
+    <Right>ref/net8.0/Microsoft.Build.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>F:Microsoft.Build.Experimental.BuildCheck.EvaluationAnalysisScope.ProjectWithImportsWithoutSdks</Target>
     <Left>ref/net8.0/Microsoft.Build.dll</Left>
     <Right>ref/net8.0/Microsoft.Build.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>

--- a/src/Build/Definition/ToolsetReader.cs
+++ b/src/Build/Definition/ToolsetReader.cs
@@ -419,44 +419,14 @@ namespace Microsoft.Build.Evaluation
 
                     Toolset toolset = ReadToolset(toolsVersion, globalProperties, initialPropertiesClone, accumulateProperties);
 
-                    // Register toolset paths into list of immutable directories
-                    // example: C:\Windows\Microsoft.NET\Framework
-                    string frameworksPathPrefix32 = existingRootOrNull(initialPropertiesClone.GetProperty("MSBuildFrameworkToolsPath32")?.EvaluatedValue?.Trim());
-                    FileClassifier.Shared.RegisterImmutableDirectory(frameworksPathPrefix32);
-                    // example: C:\Windows\Microsoft.NET\Framework64
-                    string frameworksPathPrefix64 = existingRootOrNull(initialPropertiesClone.GetProperty("MSBuildFrameworkToolsPath64")?.EvaluatedValue?.Trim());
-                    FileClassifier.Shared.RegisterImmutableDirectory(frameworksPathPrefix64);
-                    // example: C:\Windows\Microsoft.NET\FrameworkArm64
-                    string frameworksPathPrefixArm64 = existingRootOrNull(initialPropertiesClone.GetProperty("MSBuildFrameworkToolsPathArm64")?.EvaluatedValue?.Trim());
-                    FileClassifier.Shared.RegisterImmutableDirectory(frameworksPathPrefixArm64);
+                    FileClassifier.Shared.RegisterFrameworkLocations(p =>
+                        initialPropertiesClone.GetProperty(p)?.EvaluatedValue);
 
                     if (toolset != null)
                     {
                         toolsets[toolset.ToolsVersion] = toolset;
                     }
                 }
-            }
-
-            string existingRootOrNull(string path)
-            {
-                if (!string.IsNullOrEmpty(path))
-                {
-                    try
-                    {
-                        path = Directory.GetParent(FileUtilities.EnsureNoTrailingSlash(path))?.FullName;
-
-                        if (!Directory.Exists(path))
-                        {
-                            path = null;
-                        }
-                    }
-                    catch
-                    {
-                        path = null;
-                    }
-                }
-
-                return path;
             }
         }
 

--- a/src/BuildCheck.UnitTests/BuildAnalyzerConfigurationEffectiveTests.cs
+++ b/src/BuildCheck.UnitTests/BuildAnalyzerConfigurationEffectiveTests.cs
@@ -12,9 +12,9 @@ namespace Microsoft.Build.BuildCheck.UnitTests;
 public class BuildAnalyzerConfigurationEffectiveTests
 {
     [Theory]
-    [InlineData("ruleId", EvaluationAnalysisScope.ProjectOnly, BuildAnalyzerResultSeverity.Warning,  true)]
-    [InlineData("ruleId2", EvaluationAnalysisScope.ProjectOnly, BuildAnalyzerResultSeverity.Warning,  true)]
-    [InlineData("ruleId", EvaluationAnalysisScope.ProjectOnly, BuildAnalyzerResultSeverity.Error, false)]
+    [InlineData("ruleId", EvaluationAnalysisScope.ProjectFileOnly, BuildAnalyzerResultSeverity.Warning,  true)]
+    [InlineData("ruleId2", EvaluationAnalysisScope.ProjectFileOnly, BuildAnalyzerResultSeverity.Warning,  true)]
+    [InlineData("ruleId", EvaluationAnalysisScope.ProjectFileOnly, BuildAnalyzerResultSeverity.Error, false)]
     public void IsSameConfigurationAsTest(
         string secondRuleId,
         EvaluationAnalysisScope secondScope,
@@ -23,7 +23,7 @@ public class BuildAnalyzerConfigurationEffectiveTests
     {
         BuildAnalyzerConfigurationEffective configuration1 = new BuildAnalyzerConfigurationEffective(
                        ruleId: "ruleId",
-                       evaluationAnalysisScope: EvaluationAnalysisScope.ProjectOnly,
+                       evaluationAnalysisScope: EvaluationAnalysisScope.ProjectFileOnly,
                        severity: BuildAnalyzerResultSeverity.Warning);
 
         BuildAnalyzerConfigurationEffective configuration2 = new BuildAnalyzerConfigurationEffective(
@@ -43,7 +43,7 @@ public class BuildAnalyzerConfigurationEffectiveTests
     {
         BuildAnalyzerConfigurationEffective configuration = new BuildAnalyzerConfigurationEffective(
                        ruleId: "ruleId",
-                       evaluationAnalysisScope: EvaluationAnalysisScope.ProjectOnly,
+                       evaluationAnalysisScope: EvaluationAnalysisScope.ProjectFileOnly,
                        severity: severity);
 
         configuration.IsEnabled.ShouldBe(isEnabledExpected);
@@ -56,7 +56,7 @@ public class BuildAnalyzerConfigurationEffectiveTests
         {
             new BuildAnalyzerConfigurationEffective(
                         ruleId: "ruleId",
-                        evaluationAnalysisScope: EvaluationAnalysisScope.ProjectOnly,
+                        evaluationAnalysisScope: EvaluationAnalysisScope.ProjectFileOnly,
                         severity: BuildAnalyzerResultSeverity.Default);
         });
     }

--- a/src/BuildCheck.UnitTests/BuildAnalyzerConfiguration_Test.cs
+++ b/src/BuildCheck.UnitTests/BuildAnalyzerConfiguration_Test.cs
@@ -75,14 +75,12 @@ public class BuildAnalyzerConfiguration_Test
     }
 
     [Theory]
-    [InlineData("project", EvaluationAnalysisScope.ProjectOnly)]
-    [InlineData("PROJECT", EvaluationAnalysisScope.ProjectOnly)]
-    [InlineData("current_imports", EvaluationAnalysisScope.ProjectWithImportsFromCurrentWorkTree)]
-    [InlineData("CURRENT_IMPORTS", EvaluationAnalysisScope.ProjectWithImportsFromCurrentWorkTree)]
-    [InlineData("without_sdks", EvaluationAnalysisScope.ProjectWithImportsWithoutSdks)]
-    [InlineData("WITHOUT_SDKS", EvaluationAnalysisScope.ProjectWithImportsWithoutSdks)]
-    [InlineData("all", EvaluationAnalysisScope.ProjectWithAllImports)]
-    [InlineData("ALL", EvaluationAnalysisScope.ProjectWithAllImports)]
+    [InlineData("projectfile", EvaluationAnalysisScope.ProjectFileOnly)]
+    [InlineData("PROJECTFILE", EvaluationAnalysisScope.ProjectFileOnly)]
+    [InlineData("work_tree_imports", EvaluationAnalysisScope.WorkTreeImports)]
+    [InlineData("WORK_TREE_IMPORTS", EvaluationAnalysisScope.WorkTreeImports)]
+    [InlineData("all", EvaluationAnalysisScope.All)]
+    [InlineData("ALL", EvaluationAnalysisScope.All)]
     public void CreateBuildAnalyzerConfiguration_EvaluationAnalysisScope(string parameter, EvaluationAnalysisScope? expected)
     {
         var config = new Dictionary<string, string>()

--- a/src/BuildCheck.UnitTests/BuildAnalyzerConfiguration_Test.cs
+++ b/src/BuildCheck.UnitTests/BuildAnalyzerConfiguration_Test.cs
@@ -75,8 +75,9 @@ public class BuildAnalyzerConfiguration_Test
     }
 
     [Theory]
+    [InlineData("project_file", EvaluationAnalysisScope.ProjectFileOnly)]
     [InlineData("projectfile", EvaluationAnalysisScope.ProjectFileOnly)]
-    [InlineData("PROJECTFILE", EvaluationAnalysisScope.ProjectFileOnly)]
+    [InlineData("PROJECT_FILE", EvaluationAnalysisScope.ProjectFileOnly)]
     [InlineData("work_tree_imports", EvaluationAnalysisScope.WorkTreeImports)]
     [InlineData("WORK_TREE_IMPORTS", EvaluationAnalysisScope.WorkTreeImports)]
     [InlineData("all", EvaluationAnalysisScope.All)]

--- a/src/BuildCheck.UnitTests/ConfigurationProvider_Tests.cs
+++ b/src/BuildCheck.UnitTests/ConfigurationProvider_Tests.cs
@@ -108,7 +108,7 @@ public class ConfigurationProvider_Tests
 
         [*.csproj]
         build_check.rule_id.severity=error
-        build_check.rule_id.scope=projectfile
+        build_check.rule_id.scope=project_file
         """);
 
         var configurationProvider = new ConfigurationProvider();

--- a/src/BuildCheck.UnitTests/ConfigurationProvider_Tests.cs
+++ b/src/BuildCheck.UnitTests/ConfigurationProvider_Tests.cs
@@ -118,7 +118,7 @@ public class ConfigurationProvider_Tests
 
         buildConfig.IsEnabled.ShouldBe(true);
         buildConfig.Severity.ShouldBe(BuildAnalyzerResultSeverity.Error);
-        buildConfig.EvaluationAnalysisScope.ShouldBe(EvaluationAnalysisScope.ProjectOnly);
+        buildConfig.EvaluationAnalysisScope.ShouldBe(EvaluationAnalysisScope.ProjectFileOnly);
     }
 
     [Fact]

--- a/src/BuildCheck.UnitTests/ConfigurationProvider_Tests.cs
+++ b/src/BuildCheck.UnitTests/ConfigurationProvider_Tests.cs
@@ -108,7 +108,7 @@ public class ConfigurationProvider_Tests
 
         [*.csproj]
         build_check.rule_id.severity=error
-        build_check.rule_id.scope=project
+        build_check.rule_id.scope=projectfile
         """);
 
         var configurationProvider = new ConfigurationProvider();

--- a/src/Framework/FileClassifier.cs
+++ b/src/Framework/FileClassifier.cs
@@ -193,15 +193,96 @@ namespace Microsoft.Build.Framework
             }
         }
 
+        public void RegisterFrameworkLocations(Func<string, string?> getPropertyValue)
+        {
+            // Register toolset paths into list of immutable directories
+            // example: C:\Windows\Microsoft.NET\Framework
+            string? frameworksPathPrefix32 = GetExistingRootOrNull(getPropertyValue("MSBuildFrameworkToolsPath32")?.Trim());
+            RegisterImmutableDirectory(frameworksPathPrefix32);
+            // example: C:\Windows\Microsoft.NET\Framework64
+            string? frameworksPathPrefix64 = GetExistingRootOrNull(getPropertyValue("MSBuildFrameworkToolsPath64")?.Trim());
+            RegisterImmutableDirectory(frameworksPathPrefix64);
+            // example: C:\Windows\Microsoft.NET\FrameworkArm64
+            string? frameworksPathPrefixArm64 = GetExistingRootOrNull(getPropertyValue("MSBuildFrameworkToolsPathArm64")?.Trim());
+            RegisterImmutableDirectory(frameworksPathPrefixArm64);
+        }
+
+        public void RegisterKnownImmutableLocations(Func<string, string?> getPropertyValue)
+        {
+            // example: C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.7.2
+            RegisterImmutableDirectory(getPropertyValue("FrameworkPathOverride")?.Trim());
+            // example: C:\Program Files\dotnet\
+            RegisterImmutableDirectory(getPropertyValue("NetCoreRoot")?.Trim());
+            // example: C:\Users\<username>\.nuget\packages\
+            RegisterImmutableDirectory(getPropertyValue("NuGetPackageFolders")?.Trim());
+        }
+
+        private static string? GetExistingRootOrNull(string? path)
+        {
+            if (!string.IsNullOrEmpty(path))
+            {
+                try
+                {
+                    path = Directory.GetParent(EnsureNoTrailingSlash(path!))?.FullName;
+
+                    if (!Directory.Exists(path))
+                    {
+                        path = null;
+                    }
+                }
+                catch
+                {
+                    path = null;
+                }
+            }
+
+            return path;
+        }
+
+        /// <summary>
+        /// Ensures the path does not have a trailing slash.
+        /// </summary>
+        private static string EnsureNoTrailingSlash(string path)
+        {
+            path = FixFilePath(path);
+            if (EndsWithSlash(path))
+            {
+                path = path.Substring(0, path.Length - 1);
+            }
+
+            return path;
+        }
+
+        private static string FixFilePath(string path)
+        {
+            return string.IsNullOrEmpty(path) || Path.DirectorySeparatorChar == '\\' ? path : path.Replace('\\', '/'); // .Replace("//", "/");
+        }
+
+        /// <summary>
+        /// Indicates if the given file-spec ends with a slash.
+        /// </summary>
+        /// <param name="fileSpec">The file spec.</param>
+        /// <returns>true, if file-spec has trailing slash</returns>
+        private static bool EndsWithSlash(string fileSpec)
+        {
+            return (fileSpec.Length > 0) && IsSlash(fileSpec[fileSpec.Length - 1]);
+        }
+
+        /// <summary>
+        /// Indicates if the given character is a slash.
+        /// </summary>
+        /// <param name="c"></param>
+        /// <returns>true, if slash</returns>
+        private static bool IsSlash(char c)
+        {
+            return (c == Path.DirectorySeparatorChar) || (c == Path.AltDirectorySeparatorChar);
+        }
+
         private static string EnsureTrailingSlash(string fileSpec)
         {
-            if (fileSpec.Length >= 1)
+            if (fileSpec.Length >= 1 && !EndsWithSlash(fileSpec))
             {
-                char lastChar = fileSpec[fileSpec.Length - 1];
-                if (lastChar != Path.DirectorySeparatorChar && lastChar != Path.AltDirectorySeparatorChar)
-                {
-                    fileSpec += Path.DirectorySeparatorChar;
-                }
+                fileSpec += Path.DirectorySeparatorChar;
             }
 
             return fileSpec;


### PR DESCRIPTION
Contributes to #10469

### Context
This is a V1 simplistic implementation of BuildChecks evaluation scoping.
The description of the idea was addedd to the the design PR: https://github.com/dotnet/msbuild/pull/10139/files#diff-c490522e63a226575c540f316cf74f081452a701f25f46093e1781aef22a17adR49-R57

### Changes Made
 * FileClassifier recognizes nuget cache
 * FileClassifier is now responsible to know which properties conatin immutable locations (so that we can set them from EventArgs as well)
 * BuildCheck makes sure to initialize FileClassifier if SchedulerNode doesn have an implicit in-proc WorkerNode
 * FileClassifier is being leveraged to perform the classificaion


### Testing

Existing tests

### Notes
