### PR TITLE
Rename - fix casing of IMSBuildElementLocation

### DIFF
--- a/src/Build/BuildCheck/API/BuildCheckResult.cs
+++ b/src/Build/BuildCheck/API/BuildCheckResult.cs
@@ -17,12 +17,12 @@ namespace Microsoft.Build.Experimental.BuildCheck;
 /// </summary>
 public sealed class BuildCheckResult : IBuildCheckResult
 {
-    public static BuildCheckResult Create(CheckRule rule, IMsBuildElementLocation location, params string[] messageArgs)
+    public static BuildCheckResult Create(CheckRule rule, IMSBuildElementLocation location, params string[] messageArgs)
     {
         return new BuildCheckResult(rule, location, messageArgs);
     }
 
-    public BuildCheckResult(CheckRule checkConfig, IMsBuildElementLocation location, string[] messageArgs)
+    public BuildCheckResult(CheckRule checkConfig, IMSBuildElementLocation location, string[] messageArgs)
     {
         CheckRule = checkConfig;
         Location = location;
@@ -43,7 +43,7 @@ public sealed class BuildCheckResult : IBuildCheckResult
     /// <summary>
     /// Optional location of the finding (in near future we might need to support multiple locations).
     /// </summary>
-    public IMsBuildElementLocation Location { get; }
+    public IMSBuildElementLocation Location { get; }
 
     public string LocationString => Location.LocationString;
 

--- a/src/Build/BuildCheck/Checks/PropertiesUsageCheck.cs
+++ b/src/Build/BuildCheck/Checks/PropertiesUsageCheck.cs
@@ -118,13 +118,13 @@ internal class PropertiesUsageCheck : InternalCheck
         }
     }
 
-    private Dictionary<string, IMsBuildElementLocation?> _writenProperties = new(MSBuildNameIgnoreCaseComparer.Default);
+    private Dictionary<string, IMSBuildElementLocation?> _writenProperties = new(MSBuildNameIgnoreCaseComparer.Default);
     private HashSet<string> _readProperties = new(MSBuildNameIgnoreCaseComparer.Default);
     // For the 'Property Initialized after used' check - we are interested in cases where:
     //   1. Property is read anywhere and then initialized in the checked scope.
     //   2. Property is read in the checked scope and then initialized anywhere.
-    private Dictionary<string, IMsBuildElementLocation> _uninitializedReadsInScope = new(MSBuildNameIgnoreCaseComparer.Default);
-    private Dictionary<string, IMsBuildElementLocation> _uninitializedReadsOutOfScope = new(MSBuildNameIgnoreCaseComparer.Default);
+    private Dictionary<string, IMSBuildElementLocation> _uninitializedReadsInScope = new(MSBuildNameIgnoreCaseComparer.Default);
+    private Dictionary<string, IMSBuildElementLocation> _uninitializedReadsOutOfScope = new(MSBuildNameIgnoreCaseComparer.Default);
 
     private void ProcessPropertyWrite(BuildCheckDataContext<PropertyWriteData> context)
     {
@@ -142,7 +142,7 @@ internal class PropertiesUsageCheck : InternalCheck
             // For initialized after used check - we can remove the read from dictionary after hitting write - because
             //  once the property is written it should no more be uninitialized (so shouldn't be added again).
 
-            if (_uninitializedReadsInScope.TryGetValue(writeData.PropertyName, out IMsBuildElementLocation? uninitInScopeReadLocation))
+            if (_uninitializedReadsInScope.TryGetValue(writeData.PropertyName, out IMSBuildElementLocation? uninitInScopeReadLocation))
             {
                 _uninitializedReadsInScope.Remove(writeData.PropertyName);
 
@@ -154,7 +154,7 @@ internal class PropertiesUsageCheck : InternalCheck
 
             if (CheckScopeClassifier.IsActionInObservedScope(_initializedAfterUseScope,
                     writeData.ElementLocation, writeData.ProjectFilePath) &&
-                _uninitializedReadsOutOfScope.TryGetValue(writeData.PropertyName, out IMsBuildElementLocation? uninitOutScopeReadLocation))
+                _uninitializedReadsOutOfScope.TryGetValue(writeData.PropertyName, out IMSBuildElementLocation? uninitOutScopeReadLocation))
             {
                 _uninitializedReadsOutOfScope.Remove(writeData.PropertyName);
 
@@ -236,7 +236,7 @@ internal class PropertiesUsageCheck : InternalCheck
         }
 
         _readProperties = new HashSet<string>(MSBuildNameIgnoreCaseComparer.Default);
-        _writenProperties = new Dictionary<string, IMsBuildElementLocation?>(MSBuildNameIgnoreCaseComparer.Default);
-        _uninitializedReadsInScope = new Dictionary<string, IMsBuildElementLocation>(MSBuildNameIgnoreCaseComparer.Default);
+        _writenProperties = new Dictionary<string, IMSBuildElementLocation?>(MSBuildNameIgnoreCaseComparer.Default);
+        _uninitializedReadsInScope = new Dictionary<string, IMSBuildElementLocation>(MSBuildNameIgnoreCaseComparer.Default);
     }
 }

--- a/src/Build/BuildCheck/Infrastructure/CheckScopeClassifier.cs
+++ b/src/Build/BuildCheck/Infrastructure/CheckScopeClassifier.cs
@@ -19,7 +19,7 @@ internal static class CheckScopeClassifier
     /// <exception cref="ArgumentOutOfRangeException"></exception>
     internal static bool IsActionInObservedScope(
         EvaluationCheckScope scope,
-        IMsBuildElementLocation? location,
+        IMSBuildElementLocation? location,
         string projectFileFullPath)
         => IsActionInObservedScope(scope, location?.File, projectFileFullPath);
 

--- a/src/Build/BuildCheck/Infrastructure/InternalOM/PropertyReadInfo.cs
+++ b/src/Build/BuildCheck/Infrastructure/InternalOM/PropertyReadInfo.cs
@@ -19,6 +19,6 @@ internal readonly record struct PropertyReadInfo(
     string PropertyName,
     int StartIndex,
     int EndIndex,
-    IMsBuildElementLocation ElementLocation,
+    IMSBuildElementLocation ElementLocation,
     bool IsUninitialized,
     PropertyReadContext PropertyReadContext);

--- a/src/Build/BuildCheck/Infrastructure/InternalOM/PropertyWriteInfo.cs
+++ b/src/Build/BuildCheck/Infrastructure/InternalOM/PropertyWriteInfo.cs
@@ -14,4 +14,4 @@ namespace Microsoft.Build.Experimental.BuildCheck.Infrastructure;
 internal readonly record struct PropertyWriteInfo(
     string PropertyName,
     bool IsEmpty,
-    IMsBuildElementLocation? ElementLocation);
+    IMSBuildElementLocation? ElementLocation);

--- a/src/Build/BuildCheck/OM/PropertyReadData.cs
+++ b/src/Build/BuildCheck/OM/PropertyReadData.cs
@@ -15,7 +15,7 @@ internal class PropertyReadData(
     string projectFilePath,
     int? projectConfigurationId,
     string propertyName,
-    IMsBuildElementLocation elementLocation,
+    IMSBuildElementLocation elementLocation,
     bool isUninitialized,
     PropertyReadContext propertyReadContext)
     : CheckData(projectFilePath, projectConfigurationId)
@@ -40,7 +40,7 @@ internal class PropertyReadData(
     /// <summary>
     /// Location of the property access.
     /// </summary>
-    public IMsBuildElementLocation ElementLocation { get; } = elementLocation;
+    public IMSBuildElementLocation ElementLocation { get; } = elementLocation;
 
     /// <summary>
     /// Indicates whether the property was accessed before being initialized.

--- a/src/Build/BuildCheck/OM/PropertyWriteData.cs
+++ b/src/Build/BuildCheck/OM/PropertyWriteData.cs
@@ -15,7 +15,7 @@ internal class PropertyWriteData(
     string projectFilePath,
     int? projectConfigurationId,
     string propertyName,
-    IMsBuildElementLocation? elementLocation,
+    IMSBuildElementLocation? elementLocation,
     bool isEmpty)
     : CheckData(projectFilePath, projectConfigurationId)
 {
@@ -37,7 +37,7 @@ internal class PropertyWriteData(
     /// If the location is null, it means that the property doesn't come from xml, but rather other sources
     ///  (environment variable, global property, toolset properties etc.).
     /// </summary>
-    public IMsBuildElementLocation? ElementLocation { get; } = elementLocation;
+    public IMSBuildElementLocation? ElementLocation { get; } = elementLocation;
 
     /// <summary>
     /// Was any value written? (E.g. if we set propA with value propB, while propB is undefined - the isEmpty will be true).

--- a/src/Shared/IElementLocation.cs
+++ b/src/Shared/IElementLocation.cs
@@ -7,7 +7,7 @@ using Microsoft.Build.BackEnd;
 
 namespace Microsoft.Build.Shared
 {
-    internal interface IElementLocation : IMsBuildElementLocation, ITranslatable { }
+    internal interface IElementLocation : IMSBuildElementLocation, ITranslatable { }
 
     /// <summary>
     /// Represents the location information for error reporting purposes.  This is normally used to
@@ -20,7 +20,7 @@ namespace Microsoft.Build.Shared
     /// This is currently internal - but it is prepared to be made public once it will be needed by other public BuildCheck OM
     /// (e.g. by property read/write OM)
     /// </remarks>
-    public interface IMsBuildElementLocation
+    public interface IMSBuildElementLocation
     {
         /// <summary>
         /// The file from which this particular element originated.  It may


### PR DESCRIPTION
Fixes https://github.com/dotnet/msbuild/pull/10457#discussion_r1696497647

### Context

Renaming only change.
Casing of `IMSBuildElementLocation` was incorrect (`IMsBuildElementLocation`)

FYI @Nirmal4G (thx for bringing this up)
