### PR TITLE
Revert "Revert Emit eval props if requested by any sink (#10243)"

### DIFF
--- a/documentation/wiki/ChangeWaves.md
+++ b/documentation/wiki/ChangeWaves.md
@@ -28,6 +28,7 @@ A wave of features is set to "rotate out" (i.e. become standard functionality) t
 - [Convert.ToString during a property evaluation uses the InvariantCulture for all types](https://github.com/dotnet/msbuild/pull/9874)
 - [Fix oversharing of build results in ResultsCache](https://github.com/dotnet/msbuild/pull/9987)
 - [Add ParameterName and PropertyName to TaskParameterEventArgs](https://github.com/dotnet/msbuild/pull/10130)
+- [Emit eval props if requested by any sink](https://github.com/dotnet/msbuild/pull/10243)
 
 ### 17.10
 - [AppDomain configuration is serialized without using BinFmt](https://github.com/dotnet/msbuild/pull/9320) - feature can be opted out only if [BinaryFormatter](https://learn.microsoft.com/en-us/dotnet/api/system.runtime.serialization.formatters.binary.binaryformatter) is allowed at runtime by editing `MSBuild.runtimeconfig.json`

--- a/src/Build.UnitTests/BackEnd/MockLoggingService.cs
+++ b/src/Build.UnitTests/BackEnd/MockLoggingService.cs
@@ -222,14 +222,21 @@ namespace Microsoft.Build.UnitTests.BackEnd
             set { }
         }
 
-        /// <summary>
-        /// Log properties and items on ProjectEvaluationFinishedEventArgs
-        /// instead of ProjectStartedEventArgs.
-        /// </summary>
-        public bool IncludeEvaluationPropertiesAndItems
+        /// <inheritdoc cref="ILoggingService.SetIncludeEvaluationPropertiesAndItemsInEvents"/>
+        public void SetIncludeEvaluationPropertiesAndItemsInEvents(bool inProjectStartedEvent,
+            bool inEvaluationFinishedEvent)
+        { }
+
+        /// <inheritdoc cref="ILoggingService.IncludeEvaluationPropertiesAndItemsInProjectStartedEvent"/>
+        public bool IncludeEvaluationPropertiesAndItemsInProjectStartedEvent
         {
             get => false;
-            set { }
+        }
+
+        /// <inheritdoc cref="ILoggingService.IncludeEvaluationPropertiesAndItemsInEvaluationFinishedEvent"/>
+        public bool IncludeEvaluationPropertiesAndItemsInEvaluationFinishedEvent
+        {
+            get => false;
         }
 
         /// <summary>

--- a/src/Build.UnitTests/ConsoleLogger_Tests.cs
+++ b/src/Build.UnitTests/ConsoleLogger_Tests.cs
@@ -277,7 +277,7 @@ namespace Microsoft.Build.UnitTests
 
             if (includeEvaluationPropertiesAndItems)
             {
-                pc.Collection.LoggingService.IncludeEvaluationPropertiesAndItems = true;
+                pc.Collection.LoggingService.SetIncludeEvaluationPropertiesAndItemsInEvents(inProjectStartedEvent: false, inEvaluationFinishedEvent: true);
             }
 
             var project = env.CreateTestProjectWithFiles(@"

--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -2771,7 +2771,8 @@ namespace Microsoft.Build.Execution
                 , new LoggingNodeConfiguration(
                     loggingService.IncludeEvaluationMetaprojects,
                     loggingService.IncludeEvaluationProfile,
-                    loggingService.IncludeEvaluationPropertiesAndItems,
+                    loggingService.IncludeEvaluationPropertiesAndItemsInProjectStartedEvent,
+                    loggingService.IncludeEvaluationPropertiesAndItemsInEvaluationFinishedEvent,
                     loggingService.IncludeTaskInputs));
             }
 

--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -3280,25 +3280,19 @@ namespace Microsoft.Build.Execution
             /// </summary>
             public void Initialize(IEventSource eventSource)
             {
-                // The concrete type we get should always be our internal
-                // implementation and up-to-date, but we need to meet the
-                // external contract so can't specify that for the
-                // argument.
-
-                IEventSource4 eventSource4 = (IEventSource4)eventSource;
-
                 // Most checks in LoggingService are "does any attached logger
                 // specifically opt into this new behavior?". As such, the
                 // NullLogger shouldn't opt into them explicitly and should
                 // let other loggers opt in.
 
-                // IncludeEvaluationPropertiesAndItems is different though,
-                // because its check is "do ALL attached loggers opt into
-                // the new behavior?", since the new behavior removes
-                // information from old loggers. So the NullLogger must
-                // opt in to ensure it doesn't accidentally veto the new
-                // behavior.
-                eventSource4.IncludeEvaluationPropertiesAndItems();
+                // IncludeEvaluationPropertiesAndItems was different,
+                // because it checked "do ALL attached loggers opt into
+                // the new behavior?".
+                // It was fixed and hence we need to be careful not to opt in
+                // the behavior as it was done before - but let the other loggers choose.
+                //
+                // For this reason NullLogger MUST NOT call
+                // ((IEventSource4)eventSource).IncludeEvaluationPropertiesAndItems();
             }
 
             /// <summary>

--- a/src/Build/BackEnd/Components/Logging/ILoggingService.cs
+++ b/src/Build/BackEnd/Components/Logging/ILoggingService.cs
@@ -206,12 +206,24 @@ namespace Microsoft.Build.BackEnd.Logging
 
         /// <summary>
         /// Should properties and items be logged on <see cref="ProjectEvaluationFinishedEventArgs"/>
-        /// instead of <see cref="ProjectStartedEventArgs"/>?
+        /// or/and <see cref="ProjectStartedEventArgs"/>?
         /// </summary>
-        bool IncludeEvaluationPropertiesAndItems
+        void SetIncludeEvaluationPropertiesAndItemsInEvents(bool inProjectStartedEvent, bool inEvaluationFinishedEvent);
+
+        /// <summary>
+        /// Indicates whether properties and items should be logged on <see cref="ProjectStartedEventArgs"/>.
+        /// </summary>
+        bool IncludeEvaluationPropertiesAndItemsInProjectStartedEvent
         {
             get;
-            set;
+        }
+
+        /// <summary>
+        /// Indicates whether properties and items should be logged on <see cref="ProjectEvaluationFinishedEventArgs"/>.
+        /// </summary>
+        bool IncludeEvaluationPropertiesAndItemsInEvaluationFinishedEvent
+        {
+            get;
         }
 
         /// <summary>

--- a/src/Build/BackEnd/Components/Logging/LoggingService.cs
+++ b/src/Build/BackEnd/Components/Logging/LoggingService.cs
@@ -652,7 +652,6 @@ namespace Microsoft.Build.BackEnd.Logging
             return GetWarningsForProject(context, _warningsNotAsErrorsByProject, WarningsNotAsErrors);
         }
 
-
         /// <summary>
         /// Returns a collection of warnings to be demoted to messages for the specified build context.
         /// </summary>

--- a/src/Build/BackEnd/Components/Logging/LoggingService.cs
+++ b/src/Build/BackEnd/Components/Logging/LoggingService.cs
@@ -202,12 +202,6 @@ namespace Microsoft.Build.BackEnd.Logging
         private bool? _includeEvaluationProfile;
 
         /// <summary>
-        /// Whether properties and items should be logged on <see cref="ProjectEvaluationFinishedEventArgs"/>
-        /// instead of <see cref="ProjectStartedEventArgs"/>.
-        /// </summary>
-        private bool? _includeEvaluationPropertiesAndItems;
-
-        /// <summary>
         /// Whether to include task inputs in task events.
         /// </summary>
         private bool? _includeTaskInputs;
@@ -546,33 +540,77 @@ namespace Microsoft.Build.BackEnd.Logging
             set => _includeTaskInputs = value;
         }
 
-        /// <summary>
-        /// Should properties and items be logged on <see cref="ProjectEvaluationFinishedEventArgs"/>
-        /// instead of <see cref="ProjectStartedEventArgs"/>?
-        /// </summary>
-        public bool IncludeEvaluationPropertiesAndItems
+        /// <inheritdoc cref="ILoggingService.SetIncludeEvaluationPropertiesAndItemsInEvents"/>
+        public void SetIncludeEvaluationPropertiesAndItemsInEvents(bool inProjectStartedEvent, bool inEvaluationFinishedEvent)
+        {
+            _evalDataBehaviorSet = true;
+            IncludeEvaluationPropertiesAndItemsInEvaluationFinishedEvent = inEvaluationFinishedEvent;
+            IncludeEvaluationPropertiesAndItemsInProjectStartedEvent = inProjectStartedEvent;
+        }
+
+        private bool _evalDataBehaviorSet;
+        private bool _includeEvaluationPropertiesAndItemsInProjectStartedEvent;
+        private bool _includeEvaluationPropertiesAndItemsInEvaluationFinishedEvent;
+        private void InferEvalDataBehavior()
+        {
+            if (_evalDataBehaviorSet)
+            {
+                return;
+            }
+            // Set this right away - to prevent SO exception in case of any future refactoring
+            //  that would refer to the IncludeEvaluation... properties here
+            _evalDataBehaviorSet = true;
+
+            bool? escapeHatch = Traits.Instance.EscapeHatches.LogPropertiesAndItemsAfterEvaluation;
+            if (escapeHatch.HasValue)
+            {
+                IncludeEvaluationPropertiesAndItemsInEvaluationFinishedEvent = escapeHatch.Value;
+                IncludeEvaluationPropertiesAndItemsInProjectStartedEvent = !escapeHatch.Value;
+            }
+            else
+            {
+                var sinks = _eventSinkDictionary.Values.OfType<EventSourceSink>().ToList();
+
+                if (ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_12))
+                {
+                    // If any logger requested the data - we need to emit them
+                    IncludeEvaluationPropertiesAndItemsInEvaluationFinishedEvent =
+                        sinks.Any(sink => sink.IncludeEvaluationPropertiesAndItems);
+                    // If any logger didn't request the data - hence it's likely legacy logger
+                    //  - we need to populate the data in legacy way
+                    IncludeEvaluationPropertiesAndItemsInProjectStartedEvent =
+                        sinks.Any(sink => !sink.IncludeEvaluationPropertiesAndItems);
+                }
+                else
+                {
+                    bool allSinksIncludeEvalData = sinks.Any() && sinks.All(sink => sink.IncludeEvaluationPropertiesAndItems);
+
+                    IncludeEvaluationPropertiesAndItemsInEvaluationFinishedEvent = allSinksIncludeEvalData;
+                    IncludeEvaluationPropertiesAndItemsInProjectStartedEvent = !allSinksIncludeEvalData;
+                }
+            }
+        }
+
+        /// <inheritdoc cref="ILoggingService.IncludeEvaluationPropertiesAndItemsInProjectStartedEvent"/>
+        public bool IncludeEvaluationPropertiesAndItemsInProjectStartedEvent
         {
             get
             {
-                if (_includeEvaluationPropertiesAndItems == null)
-                {
-                    var escapeHatch = Traits.Instance.EscapeHatches.LogPropertiesAndItemsAfterEvaluation;
-                    if (escapeHatch.HasValue)
-                    {
-                        _includeEvaluationPropertiesAndItems = escapeHatch.Value;
-                    }
-                    else
-                    {
-                        var sinks = _eventSinkDictionary.Values.OfType<EventSourceSink>();
-                        // .All() on an empty list defaults to true, we want to default to false
-                        _includeEvaluationPropertiesAndItems = sinks.Any() && sinks.All(sink => sink.IncludeEvaluationPropertiesAndItems);
-                    }
-                }
-
-                return _includeEvaluationPropertiesAndItems ?? false;
+                InferEvalDataBehavior();
+                return _includeEvaluationPropertiesAndItemsInProjectStartedEvent;
             }
+            private set => _includeEvaluationPropertiesAndItemsInProjectStartedEvent = value;
+        }
 
-            set => _includeEvaluationPropertiesAndItems = value;
+        /// <inheritdoc cref="ILoggingService.IncludeEvaluationPropertiesAndItemsInEvaluationFinishedEvent"/>
+        public bool IncludeEvaluationPropertiesAndItemsInEvaluationFinishedEvent
+        {
+            get
+            {
+                InferEvalDataBehavior();
+                return _includeEvaluationPropertiesAndItemsInEvaluationFinishedEvent;
+            }
+            private set => _includeEvaluationPropertiesAndItemsInEvaluationFinishedEvent = value;
         }
 
         /// <summary>
@@ -613,6 +651,7 @@ namespace Microsoft.Build.BackEnd.Logging
         {
             return GetWarningsForProject(context, _warningsNotAsErrorsByProject, WarningsNotAsErrors);
         }
+
 
         /// <summary>
         /// Returns a collection of warnings to be demoted to messages for the specified build context.

--- a/src/Build/BackEnd/Components/Logging/ProjectLoggingContext.cs
+++ b/src/Build/BackEnd/Components/Logging/ProjectLoggingContext.cs
@@ -132,7 +132,7 @@ namespace Microsoft.Build.BackEnd.Logging
 
             // If we are only logging critical events lets not pass back the items or properties
             if (!loggingService.OnlyLogCriticalEvents &&
-                !loggingService.IncludeEvaluationPropertiesAndItems &&
+                loggingService.IncludeEvaluationPropertiesAndItemsInProjectStartedEvent &&
                 (!loggingService.RunningOnRemoteNode || loggingService.SerializeAllProperties))
             {
                 if (projectProperties is null)
@@ -152,7 +152,7 @@ namespace Microsoft.Build.BackEnd.Logging
             }
 
             if (projectProperties != null &&
-                !loggingService.IncludeEvaluationPropertiesAndItems &&
+                loggingService.IncludeEvaluationPropertiesAndItemsInProjectStartedEvent &&
                 propertiesToSerialize?.Length > 0 &&
                 !loggingService.SerializeAllProperties)
             {

--- a/src/Build/BackEnd/Node/LoggingNodeConfiguration.cs
+++ b/src/Build/BackEnd/Node/LoggingNodeConfiguration.cs
@@ -9,12 +9,14 @@ namespace Microsoft.Build.BackEnd
     {
         private bool _includeEvaluationMetaprojects;
         private bool _includeEvaluationProfiles;
-        private bool _includeEvaluationPropertiesAndItems;
+        private bool _includeEvaluationPropertiesAndItemsInProjectStartedEvent;
+        private bool _includeEvaluationPropertiesAndItemsInEvaluationFinishedEvent;
         private bool _includeTaskInputs;
 
         public bool IncludeEvaluationMetaprojects => _includeEvaluationMetaprojects;
         public bool IncludeEvaluationProfiles => _includeEvaluationProfiles;
-        public bool IncludeEvaluationPropertiesAndItems => _includeEvaluationPropertiesAndItems;
+        public bool IncludeEvaluationPropertiesAndItemsInProjectStartedEvent => _includeEvaluationPropertiesAndItemsInProjectStartedEvent;
+        public bool IncludeEvaluationPropertiesAndItemsInEvaluationFinishedEvent => _includeEvaluationPropertiesAndItemsInEvaluationFinishedEvent;
         public bool IncludeTaskInputs => _includeTaskInputs;
 
         public LoggingNodeConfiguration()
@@ -24,12 +26,14 @@ namespace Microsoft.Build.BackEnd
         public LoggingNodeConfiguration(
             bool includeEvaluationMetaprojects,
             bool includeEvaluationProfiles,
-            bool includeEvaluationPropertiesAndItems,
+            bool includeEvaluationPropertiesAndItemsInProjectStartedEvent,
+            bool includeEvaluationPropertiesAndItemsInEvaluationFinishedEvent,
             bool includeTaskInputs)
         {
             _includeEvaluationMetaprojects = includeEvaluationMetaprojects;
             _includeEvaluationProfiles = includeEvaluationProfiles;
-            _includeEvaluationPropertiesAndItems = includeEvaluationPropertiesAndItems;
+            _includeEvaluationPropertiesAndItemsInProjectStartedEvent = includeEvaluationPropertiesAndItemsInProjectStartedEvent;
+            _includeEvaluationPropertiesAndItemsInEvaluationFinishedEvent = includeEvaluationPropertiesAndItemsInEvaluationFinishedEvent;
             _includeTaskInputs = includeTaskInputs;
         }
 
@@ -37,7 +41,8 @@ namespace Microsoft.Build.BackEnd
         {
             translator.Translate(ref _includeEvaluationMetaprojects);
             translator.Translate(ref _includeEvaluationProfiles);
-            translator.Translate(ref _includeEvaluationPropertiesAndItems);
+            translator.Translate(ref _includeEvaluationPropertiesAndItemsInProjectStartedEvent);
+            translator.Translate(ref _includeEvaluationPropertiesAndItemsInEvaluationFinishedEvent);
             translator.Translate(ref _includeTaskInputs);
         }
     }

--- a/src/Build/BackEnd/Node/OutOfProcNode.cs
+++ b/src/Build/BackEnd/Node/OutOfProcNode.cs
@@ -779,9 +779,12 @@ namespace Microsoft.Build.Execution
                 _loggingService.IncludeTaskInputs = true;
             }
 
-            if (configuration.LoggingNodeConfiguration.IncludeEvaluationPropertiesAndItems)
+            if (configuration.LoggingNodeConfiguration.IncludeEvaluationPropertiesAndItemsInEvaluationFinishedEvent)
             {
-                _loggingService.IncludeEvaluationPropertiesAndItems = true;
+                _loggingService.SetIncludeEvaluationPropertiesAndItemsInEvents(
+                    configuration.LoggingNodeConfiguration.IncludeEvaluationPropertiesAndItemsInProjectStartedEvent,
+                    configuration.LoggingNodeConfiguration
+                        .IncludeEvaluationPropertiesAndItemsInEvaluationFinishedEvent);
             }
 
             try

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -343,7 +343,7 @@ namespace Microsoft.Build.Evaluation
                 IEnumerable properties = null;
                 IEnumerable items = null;
 
-                if (evaluator._evaluationLoggingContext.LoggingService.IncludeEvaluationPropertiesAndItems)
+                if (evaluator._evaluationLoggingContext.LoggingService.IncludeEvaluationPropertiesAndItemsInEvaluationFinishedEvent)
                 {
                     globalProperties = evaluator._data.GlobalPropertiesDictionary;
                     properties = Traits.LogAllEnvironmentVariables ? evaluator._data.Properties : evaluator.FilterOutEnvironmentDerivedProperties(evaluator._data.Properties);

--- a/src/Framework.UnitTests/ProjectStartedEventArgs_Tests.cs
+++ b/src/Framework.UnitTests/ProjectStartedEventArgs_Tests.cs
@@ -51,30 +51,6 @@ namespace Microsoft.Build.UnitTests
         }
 
         /// <summary>
-        /// Verify different Items and properties are not taken into account in the equals comparison. They should
-        /// not be considered as part of the equals evaluation
-        /// </summary>
-        [Fact]
-        public void ItemsAndPropertiesDifferentEquals()
-        {
-            ArrayList itemsList = new ArrayList();
-            ArrayList propertiesList = new ArrayList();
-            ProjectStartedEventArgs differentItemsAndProperties = new ProjectStartedEventArgs(
-                  s_baseProjectStartedEvent.ProjectId,
-                  s_baseProjectStartedEvent.Message,
-                  s_baseProjectStartedEvent.HelpKeyword,
-                  s_baseProjectStartedEvent.ProjectFile,
-                  s_baseProjectStartedEvent.TargetNames,
-                  propertiesList,
-                  itemsList,
-                  s_baseProjectStartedEvent.ParentProjectBuildEventContext,
-                  s_baseProjectStartedEvent.Timestamp);
-
-            s_baseProjectStartedEvent.Properties.ShouldNotBe(propertiesList);
-            s_baseProjectStartedEvent.Items.ShouldNotBe(itemsList);
-        }
-
-        /// <summary>
         /// Create a derived class so that we can test the default constructor in order to increase code coverage and
         /// verify this code path does not cause any exceptions.
         /// </summary>

--- a/src/Framework/ProjectStartedEventArgs.cs
+++ b/src/Framework/ProjectStartedEventArgs.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using System.Runtime.Serialization;
@@ -249,7 +250,9 @@ namespace Microsoft.Build.Framework
         {
             get
             {
-                return globalProperties;
+                return globalProperties ?? (ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_12)
+                    ? ImmutableDictionary<string, string>.Empty
+                    : null);
             }
 
             internal set
@@ -298,7 +301,9 @@ namespace Microsoft.Build.Framework
                 // up the live list of properties from the loaded project, which is stored in the configuration as well.
                 // By doing this, we no longer need to transmit properties using this message because they've already
                 // been transmitted as part of the BuildRequestConfiguration.
-                return properties;
+                return properties ?? (ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_12)
+                    ? Enumerable.Empty<DictionaryEntry>()
+                    : null);
             }
         }
 
@@ -322,7 +327,9 @@ namespace Microsoft.Build.Framework
                 // case, this access is to the live list.  For the central logger in the multi-proc case, the main node
                 // has likely not loaded this project, and therefore the live items would not be available to them, which is
                 // the same as the current functionality.
-                return items;
+                return items ?? (ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_12)
+                    ? Enumerable.Empty<DictionaryEntry>()
+                    : null);
             }
         }
 

--- a/src/Shared/UnitTests/TestAssemblyInfo.cs
+++ b/src/Shared/UnitTests/TestAssemblyInfo.cs
@@ -41,6 +41,12 @@ namespace Microsoft.Build.UnitTests
             var runningTestsField = testInfoType.GetField("s_runningTests", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static);
             runningTestsField.SetValue(null, true);
 
+            // Set the field in BuildEnvironmentState - as it might have been already preintialized by the data preparation of data driven tests
+            testInfoType = frameworkAssembly.GetType("Microsoft.Build.Framework.BuildEnvironmentState");
+            runningTestsField = testInfoType.GetField("s_runningTests", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static);
+            runningTestsField.SetValue(null, true);
+            
+
             // Note: build error files will be initialized in test environments for particular tests, also we don't have output to report error files into anyway...
             _testEnvironment = TestEnvironment.Create(output: null, ignoreBuildErrorFiles: true);
 

--- a/src/UnitTests.Shared/MockLogger.cs
+++ b/src/UnitTests.Shared/MockLogger.cs
@@ -213,6 +213,11 @@ namespace Microsoft.Build.UnitTests
             {
                 _reportTelemetry = true;
             }
+
+            if (eventSource is IEventSource4 eventSource4)
+            {
+                eventSource4.IncludeEvaluationPropertiesAndItems();
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Reverts dotnet/msbuild#10447
Reintroduces changes from #10243
Fixes #10225

### Context
#10243 introduced fix that ensured props/items attached to `ProjectEvaluationFinishedEventargs` if requested by any logger.
This however caused perf regression (https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems/edit/2173921) - as previously props/items were attached only when requested by ALL loggers. Such behavior would however break loggers requiring the props for correct functionality (e.g. BuildCheck logger).

### VS insertions

* Of the original fix (pure revert of revert): https://devdiv.visualstudio.com/DevDiv/_git/VS/pullrequest/571491 (still has the perf regression)
* Of the current fix (with NullLogger adjustment): https://devdiv.visualstudio.com/DevDiv/_git/VS/pullrequest/571724 - Speedometer shows no regression 🥳 