### PR TITLE
Fix the possible nullref on completing failed results

### DIFF
--- a/src/Build/BackEnd/BuildManager/BuildSubmission.cs
+++ b/src/Build/BackEnd/BuildManager/BuildSubmission.cs
@@ -202,6 +202,16 @@ namespace Microsoft.Build.Execution
             return BuildResult!;
         }
 
+        /// <summary>
+        /// Whether the build has started.
+        /// </summary>
+        internal override bool IsStarted
+        {
+            get => BuildRequest != null;
+            // Ignore the set - the submission is started once the BuildRequest is set.
+            set { }
+        }
+
         protected internal override BuildResult CreateFailedResult(Exception exception)
         {
             ErrorUtilities.VerifyThrow(BuildRequest != null,

--- a/src/Build/BackEnd/BuildManager/BuildSubmissionBase.cs
+++ b/src/Build/BackEnd/BuildManager/BuildSubmissionBase.cs
@@ -77,7 +77,7 @@ namespace Microsoft.Build.Execution
         /// <summary>
         /// Whether the build has started.
         /// </summary>
-        internal bool IsStarted { get; set; }
+        internal abstract bool IsStarted { get; set; }
 
         /// <summary>
         /// Indicates that all logging events for this submission are complete.

--- a/src/Build/Graph/GraphBuildSubmission.cs
+++ b/src/Build/Graph/GraphBuildSubmission.cs
@@ -71,6 +71,11 @@ namespace Microsoft.Build.Graph
         protected internal override GraphBuildResult CreateFailedResult(Exception exception)
             => new(SubmissionId, exception);
 
+        /// <summary>
+        /// Whether the build has started.
+        /// </summary>
+        internal override bool IsStarted { get; set; }
+
         // WARNING!: Do not remove the below proxy properties.
         //  They are required to make the OM forward compatible
         //  (code built against this OM should run against binaries with previous version of OM).


### PR DESCRIPTION
Fixes [AB#2172446](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2172446)

### Context
The OM unification (https://github.com/dotnet/msbuild/pull/10172) unified check for readiness of BuildSubmission - it newly skipped checking of `BuiltRequest` not being null - expecting that during submitting the submission the `BuiltResult` is eventaully set.
This was covering the happy path, however result created from exception might be requested too early - before `BuiltRequest` is attached (but afet `IsStarted` was set). So we reintroduced the nun-null check

### Changes Made
The removed  `BuiltRequest` null check was reintroduced - it was just pulled to the internals of the `BuildSubmission` type.
