### PR TITLE
Renamed fix to Check Template

### DIFF
--- a/template_feed/content/Microsoft.CheckTemplate/Check1.cs
+++ b/template_feed/content/Microsoft.CheckTemplate/Check1.cs
@@ -6,12 +6,12 @@ namespace Company.CheckTemplate
 {
     public sealed class Check1 : Check
     {
-        public static BuildCheckRule SupportedRule = new CheckRule(
+        public static CheckRule SupportedRule = new CheckRule(
             "X01234",
             "Title",
             "Description",
             "Message format: {0}",
-            new BuildCheckConfiguration());
+            new CheckConfiguration());
 
         public override string FriendlyName => "Company.Check1";
 


### PR DESCRIPTION
### Summary
Fixes https://github.com/dotnet/msbuild/issues/10537
Change classes to match the new naming convention for BuildCheck , otherwise the template won't be working.

### Customer Impact
When a customer instantiates a template, it's not buildable due to the changed naming in MSBuild API.

### Regression?
Yes, was introduced in scope of renaming: https://github.com/dotnet/msbuild/pull/10491

### Testing
Locally, the template isn't covered by MSBuild yet.

### Risk
No risks, doesn't contain any changes in logic.

