### PR TITLE
pass location information to EventArgs

### DIFF
--- a/src/Framework/BuildCheck/BuildCheckEventArgs.cs
+++ b/src/Framework/BuildCheck/BuildCheckEventArgs.cs
@@ -107,11 +107,11 @@ internal sealed class BuildCheckAcquisitionEventArgs(string acquisitionPath, str
 internal sealed class BuildCheckResultWarning : BuildWarningEventArgs
 {
     public BuildCheckResultWarning(IBuildCheckResult result, string code)
-        : base(subcategory: null, code: code, file: null, lineNumber: 0, columnNumber: 0, endLineNumber: 0, endColumnNumber: 0, message: result.FormatMessage(), helpKeyword: null, senderName: null) =>
+        : base(code: code, file: result.Location.File, lineNumber: result.Location.Line, columnNumber: result.Location.Column, message: result.FormatMessage()) =>
         RawMessage = result.FormatMessage();
 
     internal BuildCheckResultWarning(string formattedMessage, string code)
-        : base(subcategory: null, code: code, file: null, lineNumber: 0, columnNumber: 0, endLineNumber: 0, endColumnNumber: 0, message: formattedMessage, helpKeyword: null, senderName: null) =>
+        : base(code: code, file: null, lineNumber: 0, columnNumber: 0, message: formattedMessage) =>
         RawMessage = formattedMessage;
 
     internal BuildCheckResultWarning() { }
@@ -134,11 +134,11 @@ internal sealed class BuildCheckResultWarning : BuildWarningEventArgs
 internal sealed class BuildCheckResultError : BuildErrorEventArgs
 {
     public BuildCheckResultError(IBuildCheckResult result, string code)
-        : base(subcategory: null, code: code, file: null, lineNumber: 0, columnNumber: 0, endLineNumber: 0, endColumnNumber: 0, message: result.FormatMessage(), helpKeyword: null, senderName: null)
+        : base(code: code, file: result.Location.File, lineNumber: result.Location.Line, columnNumber: result.Location.Column, message: result.FormatMessage())
         => RawMessage = result.FormatMessage();
 
     internal BuildCheckResultError(string formattedMessage, string code)
-        : base(subcategory: null, code: code, file: null, lineNumber: 0, columnNumber: 0, endLineNumber: 0, endColumnNumber: 0, message: formattedMessage, helpKeyword: null, senderName: null)
+        : base(code: code, file: null, lineNumber: 0, columnNumber: 0, message: formattedMessage)
         => RawMessage = formattedMessage;
 
     internal BuildCheckResultError() { }
@@ -160,7 +160,10 @@ internal sealed class BuildCheckResultError : BuildErrorEventArgs
 
 internal sealed class BuildCheckResultMessage : BuildMessageEventArgs
 {
-    public BuildCheckResultMessage(IBuildCheckResult result) => RawMessage = result.FormatMessage();
+    public BuildCheckResultMessage(IBuildCheckResult result)
+        : base(message: result.FormatMessage(), file: result.Location.File, lineNumber: result.Location.Line, columnNumber: result.Location.Column, MessageImportance.High)
+        => RawMessage = result.FormatMessage();
+    
 
     internal BuildCheckResultMessage(string formattedMessage) => RawMessage = formattedMessage;
 

--- a/src/Framework/BuildCheck/IBuildCheckResult.cs
+++ b/src/Framework/BuildCheck/IBuildCheckResult.cs
@@ -1,11 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using Microsoft.Build.Shared;
 
 namespace Microsoft.Build.Experimental.BuildCheck;
 
@@ -18,6 +14,11 @@ internal interface IBuildCheckResult
     /// Optional location of the finding (in near future we might need to support multiple locations).
     /// </summary>
     string LocationString { get; }
+
+    /// <summary>
+    /// Location of the finding.
+    /// </summary>
+    IMSBuildElementLocation Location { get; }
     string[] MessageArgs { get; }
     string MessageFormat { get; }
 

--- a/src/Framework/BuildErrorEventArgs.cs
+++ b/src/Framework/BuildErrorEventArgs.cs
@@ -202,6 +202,29 @@ namespace Microsoft.Build.Framework
         }
 
         /// <summary>
+        /// This constructor allows event data without ends to be initialized.
+        /// </summary>
+        /// <param name="code">event code</param>
+        /// <param name="file">file associated with the event</param>
+        /// <param name="lineNumber">line number (0 if not applicable)</param>
+        /// <param name="columnNumber">column number (0 if not applicable)</param>
+        /// <param name="message">text message</param>
+        protected BuildErrorEventArgs(
+           string code,
+           string message,
+           string file,
+           int lineNumber,
+           int columnNumber
+           )
+            : base(message, helpKeyword: null, senderName: null)
+        {
+            this.code = code;
+            this.file = file;
+            this.lineNumber = lineNumber;
+            this.columnNumber = columnNumber;
+        }
+
+        /// <summary>
         /// Default constructor
         /// </summary>
         protected BuildErrorEventArgs()

--- a/src/Framework/BuildWarningEventArgs.cs
+++ b/src/Framework/BuildWarningEventArgs.cs
@@ -163,6 +163,20 @@ namespace Microsoft.Build.Framework
             this.helpLink = helpLink;
         }
 
+        /// <summary>
+        /// This constructor allows event data without ends to be initialized.
+        /// </summary>
+        /// <param name="code">event code</param>
+        /// <param name="file">file associated with the event</param>
+        /// <param name="lineNumber">line number (0 if not applicable)</param>
+        /// <param name="columnNumber">column number (0 if not applicable)</param>
+        /// <param name="message">text message</param>
+        public BuildWarningEventArgs(string code, string file, int lineNumber, int columnNumber, string message)
+            : this(subcategory: null, code: code, file: file, lineNumber: lineNumber, columnNumber: columnNumber, endLineNumber: 0, endColumnNumber: 0, message: message, helpKeyword: null, senderName: null)
+        {
+            // do nothing
+        }
+
         private string subcategory;
         private string code;
         private string file;

--- a/src/Framework/Microsoft.Build.Framework.csproj
+++ b/src/Framework/Microsoft.Build.Framework.csproj
@@ -39,6 +39,9 @@
     <Compile Include="..\Shared\BinaryWriterExtensions.cs">
       <Link>Shared\BinaryWriterExtensions.cs</Link>
     </Compile>
+    <Compile Include="..\Shared\IMSBuildElementLocation.cs">
+      <Link>Shared\IMSBuildElementLocation.cs</Link>
+    </Compile>
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETFramework'">

--- a/src/Shared/IElementLocation.cs
+++ b/src/Shared/IElementLocation.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Build.BackEnd;
+using Microsoft.Build.Framework;
 
 #nullable disable
 
@@ -9,58 +10,4 @@ namespace Microsoft.Build.Shared
 {
     internal interface IElementLocation : IMSBuildElementLocation, ITranslatable { }
 
-    /// <summary>
-    /// Represents the location information for error reporting purposes.  This is normally used to
-    /// associate a run-time error with the original XML.
-    /// This is not used for arbitrary errors from tasks, which store location in a BuildXXXXEventArgs.
-    /// All implementations should be IMMUTABLE.
-    /// Any editing of the project XML through the MSBuild API's will invalidate locations in that XML until the XML is reloaded.
-    /// </summary>
-    /// <remarks>
-    /// This is currently internal - but it is prepared to be made public once it will be needed by other public BuildCheck OM
-    /// (e.g. by property read/write OM).
-    /// </remarks>
-    public interface IMSBuildElementLocation
-    {
-        /// <summary>
-        /// The file from which this particular element originated.  It may
-        /// differ from the ProjectFile if, for instance, it was part of
-        /// an import or originated in a targets file.
-        /// Should always have a value.
-        /// If not known, returns empty string.
-        /// </summary>
-        string File
-        {
-            get;
-        }
-
-        /// <summary>
-        /// The line number where this element exists in its file.
-        /// The first line is numbered 1.
-        /// Zero indicates "unknown location".
-        /// </summary>
-        int Line
-        {
-            get;
-        }
-
-        /// <summary>
-        /// The column number where this element exists in its file.
-        /// The first column is numbered 1.
-        /// Zero indicates "unknown location".
-        /// </summary>
-        int Column
-        {
-            get;
-        }
-
-        /// <summary>
-        /// The location in a form suitable for replacement
-        /// into a message.
-        /// </summary>
-        string LocationString
-        {
-            get;
-        }
-    }
 }

--- a/src/Shared/IMSBuildElementLocation.cs
+++ b/src/Shared/IMSBuildElementLocation.cs
@@ -1,0 +1,56 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Build.Shared
+{
+    /// <summary>
+    /// Represents the location information for error reporting purposes.  This is normally used to
+    /// associate a run-time error with the original XML.
+    /// This is not used for arbitrary errors from tasks, which store location in a BuildXXXXEventArgs.
+    /// All implementations should be IMMUTABLE.
+    /// Any editing of the project XML through the MSBuild API's will invalidate locations in that XML until the XML is reloaded.
+    /// </summary>
+    public interface IMSBuildElementLocation
+    {
+        /// <summary>
+        /// The file from which this particular element originated.  It may
+        /// differ from the ProjectFile if, for instance, it was part of
+        /// an import or originated in a targets file.
+        /// Should always have a value.
+        /// If not known, returns empty string.
+        /// </summary>
+        string File
+        {
+            get;
+        }
+
+        /// <summary>
+        /// The line number where this element exists in its file.
+        /// The first line is numbered 1.
+        /// Zero indicates "unknown location".
+        /// </summary>
+        int Line
+        {
+            get;
+        }
+
+        /// <summary>
+        /// The column number where this element exists in its file.
+        /// The first column is numbered 1.
+        /// Zero indicates "unknown location".
+        /// </summary>
+        int Column
+        {
+            get;
+        }
+
+        /// <summary>
+        /// The location in a form suitable for replacement
+        /// into a message.
+        /// </summary>
+        string LocationString
+        {
+            get;
+        }
+    }
+}


### PR DESCRIPTION
Fixes #10529

### Context


### Changes Made
split IMSBuildElementLocation to separate file and added it to Framework .dll (kept in Microsoft.Build.BackEnd namespace, that should be moved eventually if desirable https://github.com/dotnet/msbuild/issues/10544 )

### Testing


### Notes
