### PR TITLE
Add CQ suppression for Deprecated code

### DIFF
--- a/src/Deprecated/Engine/Engine/NodeLoggingEvent.cs
+++ b/src/Deprecated/Engine/Engine/NodeLoggingEvent.cs
@@ -261,6 +261,8 @@ namespace Microsoft.Build.BuildEngine
                 }
                 try
                 {
+                    // codeql[cs/dangerous-binary-deserialization] BinaryFormatter is still present due to the skip-release deprecation requirement of Visual Studio. Removal has been scheduled for Oct 2024 in conjunction with VS 17.3 branching.
+                    object result = binaryFormatter.Deserialize(memoryStream);
                     e = (BuildEventArgs)binaryFormatter.Deserialize(reader.BaseStream);
                 }
                 finally

--- a/src/Deprecated/Engine/Engine/NodeLoggingEvent.cs
+++ b/src/Deprecated/Engine/Engine/NodeLoggingEvent.cs
@@ -262,7 +262,6 @@ namespace Microsoft.Build.BuildEngine
                 try
                 {
                     // codeql[cs/dangerous-binary-deserialization] BinaryFormatter is still present due to the skip-release deprecation requirement of Visual Studio. Removal has been scheduled for Oct 2024 in conjunction with VS 17.3 branching.
-                    object result = binaryFormatter.Deserialize(memoryStream);
                     e = (BuildEventArgs)binaryFormatter.Deserialize(reader.BaseStream);
                 }
                 finally

--- a/src/Deprecated/Engine/Introspector/NodeStatus.cs
+++ b/src/Deprecated/Engine/Introspector/NodeStatus.cs
@@ -328,6 +328,7 @@ namespace Microsoft.Build.BuildEngine
             }
             else
             {
+                // codeql[cs/dangerous-binary-deserialization] BinaryFormatter is still present due to the skip-release deprecation requirement of Visual Studio. Removal has been scheduled for Oct 2024 in conjunction with VS 17.3 branching.
                 status.unhandledException = (Exception)formatter.Deserialize(reader.BaseStream);
             }
             return status;

--- a/src/Deprecated/Engine/LocalProvider/LocalCallDescriptor.cs
+++ b/src/Deprecated/Engine/LocalProvider/LocalCallDescriptor.cs
@@ -254,6 +254,7 @@ namespace Microsoft.Build.BuildEngine
                 }
                 else
                 {
+                    // codeql[cs/dangerous-binary-deserialization] BinaryFormatter is still present due to the skip-release deprecation requirement of Visual Studio. Removal has been scheduled for Oct 2024 in conjunction with VS 17.3 branching.
                     replyData = formatter.Deserialize(reader.BaseStream);
                 }
             }

--- a/src/Deprecated/Engine/LocalProvider/SharedMemory.cs
+++ b/src/Deprecated/Engine/LocalProvider/SharedMemory.cs
@@ -812,6 +812,7 @@ namespace Microsoft.Build.BuildEngine
             switch ((ObjectType)objectId)
             {
                 case ObjectType.NetSerialization:
+                    // codeql[cs/dangerous-binary-deserialization] BinaryFormatter is still present due to the skip-release deprecation requirement of Visual Studio. Removal has been scheduled for Oct 2024 in conjunction with VS 17.3 branching.
                     objectRead = binaryFormatter.Deserialize(readStream);
                     break;
                 case ObjectType.FrameMarker:


### PR DESCRIPTION
### Context
We are actively working on removing the whole 'src/Deprecated' code in scope of https://github.com/dotnet/msbuild/issues/8826
That work however must conform to VS deprecation mandate - so we'll need to wait 2 more months. Adding the CQ suppressions for the meantime
