### PR TITLE
Fix bin log population + emitting extra event on custom check registration

### DIFF
--- a/src/Build/BuildCheck/Infrastructure/BuildCheckManagerProvider.cs
+++ b/src/Build/BuildCheck/Infrastructure/BuildCheckManagerProvider.cs
@@ -191,16 +191,19 @@ internal sealed class BuildCheckManagerProvider : IBuildCheckManagerProvider
                 foreach (var factory in factories)
                 {
                     var instance = factory();
-                    var checkFactoryContext = new CheckFactoryContext(
-                        factory,
-                        instance.SupportedRules.Select(r => r.Id).ToArray(),
-                        instance.SupportedRules.Any(r => r.DefaultConfiguration.IsEnabled == true));
-
-                    if (checkFactoryContext != null)
+                    if (instance != null && instance.SupportedRules.Any())
                     {
-                        _checkRegistry.Add(checkFactoryContext);
-                        SetupSingleCheck(checkFactoryContext, projectPath);
-                        checkContext.DispatchAsComment(MessageImportance.Normal, "CustomCheckSuccessfulAcquisition", instance.FriendlyName);
+                        var checkFactoryContext = new CheckFactoryContext(
+                            factory,
+                            instance.SupportedRules.Select(r => r.Id).ToArray(),
+                            instance.SupportedRules.Any(r => r.DefaultConfiguration.IsEnabled == true));
+
+                        if (checkFactoryContext != null)
+                        {
+                            _checkRegistry.Add(checkFactoryContext);
+                            SetupSingleCheck(checkFactoryContext, projectPath);
+                            checkContext.DispatchAsComment(MessageImportance.Normal, "CustomCheckSuccessfulAcquisition", instance.FriendlyName);
+                        }
                     }
                 }
             }

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsReader.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsReader.cs
@@ -320,9 +320,9 @@ namespace Microsoft.Build.Logging
                 BinaryLogRecordKind.UninitializedPropertyRead => ReadUninitializedPropertyReadEventArgs(),
                 BinaryLogRecordKind.PropertyInitialValueSet => ReadPropertyInitialValueSetEventArgs(),
                 BinaryLogRecordKind.AssemblyLoad => ReadAssemblyLoadEventArgs(),
-                BinaryLogRecordKind.BuildCheckMessage => ReadBuildCheckMessageEventArgs(),
-                BinaryLogRecordKind.BuildCheckWarning => ReadBuildCheckWarningEventArgs(),
-                BinaryLogRecordKind.BuildCheckError => ReadBuildCheckErrorEventArgs(),
+                BinaryLogRecordKind.BuildCheckMessage => ReadBuildMessageEventArgs(),
+                BinaryLogRecordKind.BuildCheckWarning => ReadBuildWarningEventArgs(),
+                BinaryLogRecordKind.BuildCheckError => ReadBuildErrorEventArgs(),
                 BinaryLogRecordKind.BuildCheckTracing => ReadBuildCheckTracingEventArgs(),
                 BinaryLogRecordKind.BuildCheckAcquisition => ReadBuildCheckAcquisitionEventArgs(),
                 _ => null
@@ -1241,22 +1241,6 @@ namespace Microsoft.Build.Logging
 
             return e;
         }
-
-        private BuildEventArgs ReadBuildCheckEventArgs<T>(Func<BuildEventArgsFields, string, T> createEvent)
-            where T : BuildEventArgs
-        {
-            var fields = ReadBuildEventArgsFields();
-            var e = createEvent(fields, fields.Message);
-            SetCommonFields(e, fields);
-
-            return e;
-        }
-
-        private BuildEventArgs ReadBuildCheckMessageEventArgs() => ReadBuildCheckEventArgs((_, rawMessage) => new BuildCheckResultMessage(rawMessage));
-
-        private BuildEventArgs ReadBuildCheckWarningEventArgs() => ReadBuildCheckEventArgs((fields, rawMessage) => new BuildCheckResultWarning(rawMessage, fields.Code));
-
-        private BuildEventArgs ReadBuildCheckErrorEventArgs() => ReadBuildCheckEventArgs((fields, rawMessage) => new BuildCheckResultError(rawMessage, fields.Code));
 
         private BuildEventArgs ReadBuildCheckTracingEventArgs()
         {

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsReader.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsReader.cs
@@ -320,7 +320,7 @@ namespace Microsoft.Build.Logging
                 BinaryLogRecordKind.UninitializedPropertyRead => ReadUninitializedPropertyReadEventArgs(),
                 BinaryLogRecordKind.PropertyInitialValueSet => ReadPropertyInitialValueSetEventArgs(),
                 BinaryLogRecordKind.AssemblyLoad => ReadAssemblyLoadEventArgs(),
-                BinaryLogRecordKind.BuildCheckMessage => ReadBuildMessageEventArgs(),
+                BinaryLogRecordKind.BuildCheckMessage => ReadBuildCheckMessageEventArgs(),
                 BinaryLogRecordKind.BuildCheckWarning => ReadBuildWarningEventArgs(),
                 BinaryLogRecordKind.BuildCheckError => ReadBuildErrorEventArgs(),
                 BinaryLogRecordKind.BuildCheckTracing => ReadBuildCheckTracingEventArgs(),
@@ -1213,6 +1213,15 @@ namespace Microsoft.Build.Logging
                 fields.HelpKeyword,
                 fields.SenderName,
                 fields.Importance);
+            SetCommonFields(e, fields);
+
+            return e;
+        }
+
+        private BuildEventArgs ReadBuildCheckMessageEventArgs()
+        {
+            var fields = ReadBuildEventArgsFields();
+            var e = new BuildCheckResultMessage(fields.Message);
             SetCommonFields(e, fields);
 
             return e;

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
@@ -479,11 +479,6 @@ namespace Microsoft.Build.Logging
 
         private BinaryLogRecordKind Write(BuildErrorEventArgs e)
         {
-            if (e is BuildCheckResultError buildCheckError)
-            {
-                return Write(buildCheckError);
-            }
-
             WriteBuildEventArgsFields(e);
             WriteArguments(e.RawArguments);
             WriteDeduplicatedString(e.Subcategory);
@@ -500,11 +495,6 @@ namespace Microsoft.Build.Logging
 
         private BinaryLogRecordKind Write(BuildWarningEventArgs e)
         {
-            if (e is BuildCheckResultWarning buildCheckWarning)
-            {
-                return Write(buildCheckWarning);
-            }
-
             WriteBuildEventArgsFields(e);
             WriteArguments(e.RawArguments);
             WriteDeduplicatedString(e.Subcategory);


### PR DESCRIPTION
Change handling of BuildCheckError/BuildCheckWarning because it introduced issues with mapping in BinLogViewer.
Just reporting them as a part of BuildError/BuildWarning is enough. 

![image](https://github.com/user-attachments/assets/b5ed5f36-abe7-4d3d-8db5-0936477a2932)


