### PR TITLE
Suppress CodeQL for BinaryFormatter in .resx

### DIFF
--- a/src/Tasks/GenerateResource.cs
+++ b/src/Tasks/GenerateResource.cs
@@ -2008,6 +2008,8 @@ namespace Microsoft.Build.Tasks
 
             using (MemoryStream memoryStream = new MemoryStream(serializedData))
             {
+                // CodeQL [SM03722] required trust of BinaryFormatter-serialized resources documented at https://learn.microsoft.com/visualstudio/msbuild/generateresource-task
+                // CodeQL [SM04191] required trust of BinaryFormatter-serialized resources documented at https://learn.microsoft.com/visualstudio/msbuild/generateresource-task
                 object result = binaryFormatter.Deserialize(memoryStream);
 
                 return result != null;


### PR DESCRIPTION
Suppress CodeQL for BinaryFormatter in .resx

The default .NET Framework build process deserializes resources in MSBuild, then reserializes them in an expected format for use at runtime. This is still supported, even though the dominant serialization mechanism in these projects is `BinaryFormatter`, to maintain build compatibility with older projects. The need to trust resources embedded in your application is documented in the MSBuild documentation.

Related (internal): https://github.com/MicrosoftDocs/visualstudio-docs-pr/pull/12924.

Closes #10528.