### PR TITLE
Manual update dependencies from dotnet/arcade

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -432,3 +432,5 @@ dotnet_diagnostic.xUnit2020.severity = none
 dotnet_diagnostic.xUnit1031.severity = none
 dotnet_diagnostic.xUnit1012.severity = none
 dotnet_diagnostic.xUnit2029.severity = none
+# Do not use equality check to check for collection size.
+dotnet_diagnostic.xUnit2013.severity = none

--- a/.editorconfig
+++ b/.editorconfig
@@ -432,5 +432,3 @@ dotnet_diagnostic.xUnit2020.severity = none
 dotnet_diagnostic.xUnit1031.severity = none
 dotnet_diagnostic.xUnit1012.severity = none
 dotnet_diagnostic.xUnit2029.severity = none
-dotnet_diagnostic.xUnit1048.severity = none
-dotnet_diagnostic.xUnit1048.severity = none

--- a/.editorconfig
+++ b/.editorconfig
@@ -425,3 +425,12 @@ dotnet_diagnostic.IDE0073.severity = error
 
 # Use 'System.Threading.Lock'
 dotnet_diagnostic.IDE0330.severity = suggestion
+
+
+# xunit to supress temp
+dotnet_diagnostic.xUnit2020.severity = none
+dotnet_diagnostic.xUnit1031.severity = none
+dotnet_diagnostic.xUnit1012.severity = none
+dotnet_diagnostic.xUnit2029.severity = none
+dotnet_diagnostic.xUnit1048.severity = none
+dotnet_diagnostic.xUnit1048.severity = none

--- a/eng/Common.globalconfig
+++ b/eng/Common.globalconfig
@@ -1103,6 +1103,3 @@ dotnet_diagnostic.SA1643.severity = suggestion
 dotnet_diagnostic.SA1649.severity = suggestion
 
 dotnet_diagnostic.SA1652.severity = none
-
-# Do not use equality check to check for collection size.
-dotnet_diagnostic.xUnit2013.severity = none

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -71,14 +71,14 @@
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="9.0.0-beta.24423.2">
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="9.0.0-beta.24426.3">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>91599268652b51969b8d8088d4f2f2ba7b3ebb19</Sha>
+      <Sha>e3bdd9a0f2a65fe037ba1adb2261eea48a840fa4</Sha>
     </Dependency>
     <!-- Intermediate is necessary for source build. -->
-    <Dependency Name="Microsoft.SourceBuild.Intermediate.arcade" Version="9.0.0-beta.24423.2">
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.arcade" Version="9.0.0-beta.24426.3">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>91599268652b51969b8d8088d4f2f2ba7b3ebb19</Sha>
+      <Sha>e3bdd9a0f2a65fe037ba1adb2261eea48a840fa4</Sha>
       <SourceBuild RepoName="arcade" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="Microsoft.DotNet.XliffTasks" Version="1.0.0-beta.23475.1" CoherentParentDependency="Microsoft.DotNet.Arcade.Sdk">
@@ -104,9 +104,9 @@
       <Sha>13b65d3b5638457d94c83b545235f47f0d11e483</Sha>
       <SourceBuild RepoName="roslyn" ManagedOnly="true" />
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="8.0.0-beta.24421.4">
+    <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="9.0.0-beta.24426.3">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>4460b755f3c7c89e9660d9580ff79afc4218dd85</Sha>
+      <Sha>e3bdd9a0f2a65fe037ba1adb2261eea48a840fa4</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -49,7 +49,7 @@
          Otherwise, this version of dotnet will not be installed and the build will error out. -->
     <DotNetCliVersion>$([System.Text.RegularExpressions.Regex]::Match($([System.IO.File]::ReadAllText('$(MSBuildThisFileDirectory)..\global.json')), '"dotnet": "([^"]*)"').Groups.get_Item(1))</DotNetCliVersion>
     <MicrosoftCodeAnalysisCollectionsVersion>4.2.0-1.22102.8</MicrosoftCodeAnalysisCollectionsVersion>
-    <MicrosoftDotNetXUnitExtensionsVersion>8.0.0-beta.24421.4</MicrosoftDotNetXUnitExtensionsVersion>
+    <MicrosoftDotNetXUnitExtensionsVersion>9.0.0-beta.24426.3</MicrosoftDotNetXUnitExtensionsVersion>
     <MicrosoftExtensionsDependencyModelVersion>7.0.0</MicrosoftExtensionsDependencyModelVersion>
     <MicrosoftIORedistVersion>6.0.1</MicrosoftIORedistVersion>
     <MicrosoftNetCompilersToolsetVersion>4.12.0-2.24425.4</MicrosoftNetCompilersToolsetVersion>
@@ -75,13 +75,4 @@
       <FileVersion>$(VersionPrefix).$(FileVersion.Split('.')[3])</FileVersion>
     </PropertyGroup>
   </Target>
-  <!--  Freeze the version for the current upgrade of the sdk. 
-        TODO:Delete the lines below once the Retargeting merged. 
-  -->
-  <PropertyGroup>
-    <XUnitVersion>2.4.2</XUnitVersion>
-    <XUnitAnalyzersVersion>1.1.0</XUnitAnalyzersVersion>
-    <XUnitRunnerConsoleVersion>$(XUnitVersion)</XUnitRunnerConsoleVersion>
-    <XUnitRunnerVisualStudioVersion>2.4.3</XUnitRunnerVisualStudioVersion>
-  </PropertyGroup>
 </Project>

--- a/eng/common/SetupNugetSources.ps1
+++ b/eng/common/SetupNugetSources.ps1
@@ -157,7 +157,7 @@ if ($dotnet31Source -ne $null) {
     AddPackageSource -Sources $sources -SourceName "dotnet3.1-internal-transport" -SourceEndPoint "https://pkgs.dev.azure.com/dnceng/_packaging/dotnet3.1-internal-transport/nuget/v2" -Creds $creds -Username $userName -pwd $Password
 }
 
-$dotnetVersions = @('5','6','7','8')
+$dotnetVersions = @('5','6','7','8','9')
 
 foreach ($dotnetVersion in $dotnetVersions) {
     $feedPrefix = "dotnet" + $dotnetVersion;

--- a/eng/common/SetupNugetSources.sh
+++ b/eng/common/SetupNugetSources.sh
@@ -99,7 +99,7 @@ if [ "$?" == "0" ]; then
     PackageSources+=('dotnet3.1-internal-transport')
 fi
 
-DotNetVersions=('5' '6' '7' '8')
+DotNetVersions=('5' '6' '7' '8' '9')
 
 for DotNetVersion in ${DotNetVersions[@]} ; do
     FeedPrefix="dotnet${DotNetVersion}";

--- a/eng/common/core-templates/job/job.yml
+++ b/eng/common/core-templates/job/job.yml
@@ -33,11 +33,6 @@ parameters:
   artifactPublishSteps: []
   runAsPublic: false
 
-# Sbom related params
-  enableSbom: true
-  PackageVersion: 9.0.0
-  BuildDropPath: '$(Build.SourcesDirectory)/artifacts'
-
 # 1es specific parameters
   is1ESPipeline: ''
 

--- a/eng/common/darc-init.ps1
+++ b/eng/common/darc-init.ps1
@@ -1,6 +1,6 @@
 param (
     $darcVersion = $null,
-    $versionEndpoint = 'https://maestro.dot.net/api/assets/darc-version?api-version=2019-01-16',
+    $versionEndpoint = 'https://maestro.dot.net/api/assets/darc-version?api-version=2020-02-20',
     $verbosity = 'minimal',
     $toolpath = $null
 )

--- a/eng/common/darc-init.sh
+++ b/eng/common/darc-init.sh
@@ -2,7 +2,7 @@
 
 source="${BASH_SOURCE[0]}"
 darcVersion=''
-versionEndpoint='https://maestro.dot.net/api/assets/darc-version?api-version=2019-01-16'
+versionEndpoint='https://maestro.dot.net/api/assets/darc-version?api-version=2020-02-20'
 verbosity='minimal'
 
 while [[ $# > 0 ]]; do

--- a/eng/common/internal/Tools.csproj
+++ b/eng/common/internal/Tools.csproj
@@ -4,6 +4,7 @@
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
     <AutomaticallyUseReferenceAssemblyPackages>false</AutomaticallyUseReferenceAssemblyPackages>
+    <BuildWithNetFrameworkHostedCompiler>false</BuildWithNetFrameworkHostedCompiler>
   </PropertyGroup>
   <ItemGroup>
     <!-- Clear references, the SDK may add some depending on UsuingToolXxx settings, but we only want to restore the following -->

--- a/eng/common/templates-official/job/job.yml
+++ b/eng/common/templates-official/job/job.yml
@@ -1,7 +1,21 @@
+parameters:
+# Sbom related params
+  enableSbom: true
+  PackageVersion: 9.0.0
+  BuildDropPath: '$(Build.SourcesDirectory)/artifacts'
+
 jobs:
 - template: /eng/common/core-templates/job/job.yml
   parameters:
     is1ESPipeline: true
+
+    componentGovernanceSteps:
+    - ${{ if and(eq(parameters.runAsPublic, 'false'), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), eq(parameters.enableSbom, 'true')) }}:
+      - template: /eng/common/templates/steps/generate-sbom.yml
+        parameters:
+          PackageVersion: ${{ parameters.packageVersion }}
+          BuildDropPath: ${{ parameters.buildDropPath }}
+          publishArtifacts: false
 
     # publish artifacts
     # for 1ES managed templates, use the templateContext.output to handle multiple outputs.

--- a/eng/common/templates/job/job.yml
+++ b/eng/common/templates/job/job.yml
@@ -19,71 +19,63 @@ jobs:
     steps:
     - ${{ each step in parameters.steps }}:
       - ${{ step }}
-    
+
     componentGovernanceSteps:
-      - template: /eng/common/templates/steps/component-governance.yml
-        parameters:
-          ${{ if eq(parameters.disableComponentGovernance, '') }}:
-            ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), eq(parameters.runAsPublic, 'false'), or(startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/dotnet/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/microsoft/'), eq(variables['Build.SourceBranch'], 'refs/heads/main'))) }}:
-              disableComponentGovernance: false
-            ${{ else }}:
-              disableComponentGovernance: true
+    - template: /eng/common/templates/steps/component-governance.yml
+      parameters:
+        ${{ if eq(parameters.disableComponentGovernance, '') }}:
+          ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), eq(parameters.runAsPublic, 'false'), or(startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/dotnet/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/microsoft/'), eq(variables['Build.SourceBranch'], 'refs/heads/main'))) }}:
+            disableComponentGovernance: false
           ${{ else }}:
-            disableComponentGovernance: ${{ parameters.disableComponentGovernance }}
-          componentGovernanceIgnoreDirectories: ${{ parameters.componentGovernanceIgnoreDirectories }}
-
-      - ${{ if and(eq(parameters.runAsPublic, 'false'), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), eq(parameters.enableSbom, 'true')) }}:
-        - template: /eng/common/templates/steps/generate-sbom.yml
-          parameters:
-            PackageVersion: ${{ parameters.packageVersion }}
-            BuildDropPath: ${{ parameters.buildDropPath }}
-            publishArtifacts: false
-
+            disableComponentGovernance: true
+        ${{ else }}:
+          disableComponentGovernance: ${{ parameters.disableComponentGovernance }}
+        componentGovernanceIgnoreDirectories: ${{ parameters.componentGovernanceIgnoreDirectories }}
 
     artifactPublishSteps:
-      - ${{ if ne(parameters.artifacts.publish, '') }}:
-        - ${{ if and(ne(parameters.artifacts.publish.artifacts, 'false'), ne(parameters.artifacts.publish.artifacts, '')) }}:
-          - template: /eng/common/core-templates/steps/publish-build-artifacts.yml
-            parameters:
-              is1ESPipeline: false
-              args:
-                displayName: Publish pipeline artifacts
-                pathToPublish: '$(Build.ArtifactStagingDirectory)/artifacts'
-                publishLocation: Container
-                artifactName: ${{ coalesce(parameters.artifacts.publish.artifacts.name , 'Artifacts_$(Agent.Os)_$(_BuildConfig)') }}
-                continueOnError: true
-                condition: always()
-        - ${{ if and(ne(parameters.artifacts.publish.logs, 'false'), ne(parameters.artifacts.publish.logs, '')) }}:
-          - template: /eng/common/core-templates/steps/publish-pipeline-artifacts.yml
-            parameters:
-              is1ESPipeline: false
-              args:
-                targetPath: '$(Build.ArtifactStagingDirectory)/artifacts/log'
-                artifactName: ${{ coalesce(parameters.artifacts.publish.logs.name, 'Logs_Build_$(Agent.Os)_$(_BuildConfig)') }}
-                displayName: 'Publish logs'
-                continueOnError: true
-                condition: always()
-                sbomEnabled: false  # we don't need SBOM for logs
-
-      - ${{ if ne(parameters.enablePublishBuildArtifacts, 'false') }}:
+    - ${{ if ne(parameters.artifacts.publish, '') }}:
+      - ${{ if and(ne(parameters.artifacts.publish.artifacts, 'false'), ne(parameters.artifacts.publish.artifacts, '')) }}:
         - template: /eng/common/core-templates/steps/publish-build-artifacts.yml
           parameters:
             is1ESPipeline: false
             args:
-              displayName: Publish Logs
-              pathToPublish: '$(Build.ArtifactStagingDirectory)/artifacts/log/$(_BuildConfig)'
+              displayName: Publish pipeline artifacts
+              pathToPublish: '$(Build.ArtifactStagingDirectory)/artifacts'
               publishLocation: Container
-              artifactName: ${{ coalesce(parameters.enablePublishBuildArtifacts.artifactName, '$(Agent.Os)_$(Agent.JobName)' ) }}
+              artifactName: ${{ coalesce(parameters.artifacts.publish.artifacts.name , 'Artifacts_$(Agent.Os)_$(_BuildConfig)') }}
               continueOnError: true
               condition: always()
-
-      - ${{ if eq(parameters.enableBuildRetry, 'true') }}:
+      - ${{ if and(ne(parameters.artifacts.publish.logs, 'false'), ne(parameters.artifacts.publish.logs, '')) }}:
         - template: /eng/common/core-templates/steps/publish-pipeline-artifacts.yml
           parameters:
             is1ESPipeline: false
             args:
-              targetPath: '$(Build.SourcesDirectory)\eng\common\BuildConfiguration'
-              artifactName: 'BuildConfiguration'
-              displayName: 'Publish build retry configuration'
+              targetPath: '$(Build.ArtifactStagingDirectory)/artifacts/log'
+              artifactName: ${{ coalesce(parameters.artifacts.publish.logs.name, 'Logs_Build_$(Agent.Os)_$(_BuildConfig)') }}
+              displayName: 'Publish logs'
               continueOnError: true
-              sbomEnabled: false  # we don't need SBOM for BuildConfiguration
+              condition: always()
+              sbomEnabled: false  # we don't need SBOM for logs
+
+    - ${{ if ne(parameters.enablePublishBuildArtifacts, 'false') }}:
+      - template: /eng/common/core-templates/steps/publish-build-artifacts.yml
+        parameters:
+          is1ESPipeline: false
+          args:
+            displayName: Publish Logs
+            pathToPublish: '$(Build.ArtifactStagingDirectory)/artifacts/log/$(_BuildConfig)'
+            publishLocation: Container
+            artifactName: ${{ coalesce(parameters.enablePublishBuildArtifacts.artifactName, '$(Agent.Os)_$(Agent.JobName)' ) }}
+            continueOnError: true
+            condition: always()
+
+    - ${{ if eq(parameters.enableBuildRetry, 'true') }}:
+      - template: /eng/common/core-templates/steps/publish-pipeline-artifacts.yml
+        parameters:
+          is1ESPipeline: false
+          args:
+            targetPath: '$(Build.SourcesDirectory)\eng\common\BuildConfiguration'
+            artifactName: 'BuildConfiguration'
+            displayName: 'Publish build retry configuration'
+            continueOnError: true
+            sbomEnabled: false  # we don't need SBOM for BuildConfiguration

--- a/global.json
+++ b/global.json
@@ -10,6 +10,6 @@
     "xcopy-msbuild": "17.8.5"
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Arcade.Sdk": "9.0.0-beta.24423.2"
+    "Microsoft.DotNet.Arcade.Sdk": "9.0.0-beta.24426.3"
   }
 }

--- a/src/Build.UnitTests/BackEnd/BuildManager_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/BuildManager_Tests.cs
@@ -1513,7 +1513,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             _buildManager.EndBuild();
         }
 
-#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
+#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously: needs to be async for xunit's timeout system
         /// <summary>
         /// A canceled build
         /// </summary>

--- a/src/Build.UnitTests/BackEnd/BuildManager_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/BuildManager_Tests.cs
@@ -1513,11 +1513,13 @@ namespace Microsoft.Build.UnitTests.BackEnd
             _buildManager.EndBuild();
         }
 
+#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
         /// <summary>
         /// A canceled build
         /// </summary>
         [Fact(Timeout = 20_000)]
-        public void CancelledBuild()
+        public async System.Threading.Tasks.Task CancelledBuild()
+#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
         {
             Console.WriteLine("Starting CancelledBuild test that is known to hang.");
             string contents = CleanupFileContents(@"

--- a/src/Build.UnitTests/Evaluation/Evaluator_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/Evaluator_Tests.cs
@@ -4400,7 +4400,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         /// </summary>
         [Fact]
         [ActiveIssue("https://github.com/dotnet/msbuild/issues/7623")]
-        public async void VerifyDTDProcessingIsDisabled2()
+        public async Task VerifyDTDProcessingIsDisabled2()
         {
             string projectContents = ObjectModelHelpers.CleanupFileContents(@"<?xml version=""1.0"" encoding=""utf-8""?>
                                 <!DOCTYPE Project [


### PR DESCRIPTION
### Context
After merging the retargeting to dotnet 9 PR the build failed:
https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=10122195&view=results

Additionally automated updates: https://github.com/dotnet/msbuild/pull/10575
Also failing due to the version conflicts of Xunit.

### Changes Made
Commands: 
- `darc update-dependencies --channel ".NET Eng - Latest" --name "Microsoft.DotNet.Arcade.Sdk"`
- `darc update-dependencies --channel ".NET Eng - Latest" --name "Microsoft.SourceBuild.Intermediate.arcade"`
- `darc update-dependencies --channel ".NET Eng - Latest" --name "Microsoft.DotNet.XUnitExtensions"`

Temproary disabling the rules of xUnit. and will be solved as part of the: https://github.com/dotnet/msbuild/issues/10557

### Testing
- Existing tests should pass
- Build was tested on the exp insertion https://github.com/dotnet/msbuild/tree/exp/f-alizada/arcade-dependencies-retargeting 