### PR TITLE
Enable xunit2020 rule with severity=warning

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -427,8 +427,10 @@ dotnet_diagnostic.IDE0073.severity = error
 dotnet_diagnostic.IDE0330.severity = suggestion
 
 
+# Use Assert.Fail() instead of Assert.True(false) or Assert.False(true)
+dotnet_diagnostic.xUnit2020.severity = warning
+
 # xunit to supress temp
-dotnet_diagnostic.xUnit2020.severity = none
 dotnet_diagnostic.xUnit1031.severity = none
 dotnet_diagnostic.xUnit1012.severity = none
 dotnet_diagnostic.xUnit2029.severity = none

--- a/src/Build.OM.UnitTests/Construction/ProjectUsingTaskElement_Tests.cs
+++ b/src/Build.OM.UnitTests/Construction/ProjectUsingTaskElement_Tests.cs
@@ -356,7 +356,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
                     </Project>
                 ";
                 ProjectRootElement.Create(XmlReader.Create(new StringReader(content)));
-                Assert.True(false);
+                Assert.Fail();
             });
         }
         /// <summary>
@@ -376,7 +376,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
                     </Project>
                 ";
                 ProjectRootElement.Create(XmlReader.Create(new StringReader(content)));
-                Assert.True(false);
+                Assert.Fail();
             });
         }
         /// <summary>
@@ -395,7 +395,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
                     </Project>
                 ";
                 ProjectRootElement.Create(XmlReader.Create(new StringReader(content)));
-                Assert.True(false);
+                Assert.Fail();
             });
         }
         /// <summary>
@@ -444,7 +444,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
 
                 ProjectRootElement project = ProjectRootElement.Create(XmlReader.Create(new StringReader(content)));
                 Helpers.GetFirst(project.Children);
-                Assert.True(false);
+                Assert.Fail();
             });
         }
         /// <summary>
@@ -465,7 +465,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
 
                 ProjectRootElement project = ProjectRootElement.Create(XmlReader.Create(new StringReader(content)));
                 Helpers.GetFirst(project.Children);
-                Assert.True(false);
+                Assert.Fail();
             });
         }
         /// <summary>

--- a/src/Build.OM.UnitTests/Construction/SolutionFile_Tests.cs
+++ b/src/Build.OM.UnitTests/Construction/SolutionFile_Tests.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Build.UnitTests.Construction
                 ";
 
                 ParseSolutionHelper(solutionFileContents);
-                Assert.True(false, "Should not get here");
+                Assert.Fail("Should not get here");
             });
         }
         /// <summary>
@@ -273,7 +273,7 @@ namespace Microsoft.Build.UnitTests.Construction
             }
             catch (Exception ex)
             {
-                Assert.True(false, "Failed to parse solution containing description information. Error: " + ex.Message);
+                Assert.Fail("Failed to parse solution containing description information. Error: " + ex.Message);
             }
         }
 
@@ -551,7 +551,7 @@ namespace Microsoft.Build.UnitTests.Construction
             }
 
             // Should not get here
-            Assert.True(false);
+            Assert.Fail();
         }
 
         /// <summary>

--- a/src/Build.OM.UnitTests/Construction/UsingTaskBodyElement_Tests.cs
+++ b/src/Build.OM.UnitTests/Construction/UsingTaskBodyElement_Tests.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
                 ";
 
                 ProjectRootElement.Create(XmlReader.Create(new StringReader(content)));
-                Assert.True(false);
+                Assert.Fail();
             });
         }
         /// <summary>
@@ -106,7 +106,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
             {
                 ProjectUsingTaskBodyElement body = GetBodyXml();
                 body.TaskBody = null;
-                Assert.True(false);
+                Assert.Fail();
             });
         }
         /// <summary>

--- a/src/Build.OM.UnitTests/Construction/UsingTaskParameterElement_Tests.cs
+++ b/src/Build.OM.UnitTests/Construction/UsingTaskParameterElement_Tests.cs
@@ -90,7 +90,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
                 ";
 
                 ProjectRootElement.Create(XmlReader.Create(new StringReader(content)));
-                Assert.True(false);
+                Assert.Fail();
             });
         }
         /// <summary>

--- a/src/Build.OM.UnitTests/Construction/UsingTaskParameterGroup_Tests.cs
+++ b/src/Build.OM.UnitTests/Construction/UsingTaskParameterGroup_Tests.cs
@@ -107,7 +107,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
             Assert.Throws<InvalidProjectFileException>(() =>
             {
                 GetParameterGroupXml(s_contentDuplicateParameters);
-                Assert.True(false);
+                Assert.Fail();
             });
         }
         /// <summary>
@@ -127,7 +127,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
                 ";
 
                 ProjectRootElement.Create(XmlReader.Create(new StringReader(content)));
-                Assert.True(false);
+                Assert.Fail();
             });
         }
         /// <summary>

--- a/src/Build.OM.UnitTests/Definition/ProjectCollection_Tests.cs
+++ b/src/Build.OM.UnitTests/Definition/ProjectCollection_Tests.cs
@@ -724,7 +724,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
                 // an attempt to load it by the pretend filename should fail,
                 // so it makes a good test to see that the UnloadProject method worked.
                 ProjectCollection.GlobalProjectCollection.LoadProject(xml.FullPath);
-                Assert.True(false, "An InvalidProjectFileException was expected.");
+                Assert.Fail("An InvalidProjectFileException was expected.");
             }
             catch (InvalidProjectFileException)
             {

--- a/src/Build.UnitTests/BackEnd/BuildRequestEngine_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/BuildRequestEngine_Tests.cs
@@ -212,7 +212,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             {
                 if (!_builderThread.Join(5000))
                 {
-                    Assert.True(false, "Builder thread did not terminate on cancel.");
+                    Assert.Fail("Builder thread did not terminate on cancel.");
 #if FEATURE_THREAD_ABORT
                     _builderThread.Abort();
 #endif
@@ -535,11 +535,11 @@ namespace Microsoft.Build.UnitTests.BackEnd
             int index = WaitHandle.WaitAny(events, 5000);
             if (WaitHandle.WaitTimeout == index)
             {
-                Assert.True(false, "Did not receive " + eventName + " callback before the timeout expired.");
+                Assert.Fail("Did not receive " + eventName + " callback before the timeout expired.");
             }
             else if (index == 0)
             {
-                Assert.True(false, "Received engine exception " + _engineException_Exception);
+                Assert.Fail("Received engine exception " + _engineException_Exception);
             }
         }
 

--- a/src/Build.UnitTests/BackEnd/LoggingService_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/LoggingService_Tests.cs
@@ -1123,13 +1123,13 @@ namespace Microsoft.Build.UnitTests.Logging
             try
             {
                 _initializedService.ShutdownComponent();
-                Assert.True(false, "No Exceptions Generated");
+                Assert.Fail("No Exceptions Generated");
             }
             catch (Exception e)
             {
                 if (e.GetType() != expectedExceptionType)
                 {
-                    Assert.True(false, "Expected a " + expectedExceptionType + " but got a " + e.GetType() + " Stack:" + e.ToString());
+                    Assert.Fail("Expected a " + expectedExceptionType + " but got a " + e.GetType() + " Stack:" + e.ToString());
                 }
             }
         }

--- a/src/Build.UnitTests/BackEnd/NodeEndpointInProc_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/NodeEndpointInProc_Tests.cs
@@ -332,7 +332,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             endpoints.ManagerEndpoint.SendData(managerPacket);
             if (!_host.DataReceivedEvent.WaitOne(1000))
             {
-                Assert.True(false, "Data not received before timeout expired.");
+                Assert.Fail("Data not received before timeout expired.");
             }
             Assert.Equal(_host.DataReceivedContext.packet, managerPacket);
             Assert.NotEqual(_host.DataReceivedContext.thread.ManagedThreadId, Thread.CurrentThread.ManagedThreadId);
@@ -342,7 +342,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             endpoints.NodeEndpoint.SendData(nodePacket);
             if (!_host.DataReceivedEvent.WaitOne(1000))
             {
-                Assert.True(false, "Data not received before timeout expired.");
+                Assert.Fail("Data not received before timeout expired.");
             }
             Assert.Equal(_host.DataReceivedContext.packet, nodePacket);
             Assert.NotEqual(_host.DataReceivedContext.thread.ManagedThreadId, Thread.CurrentThread.ManagedThreadId);

--- a/src/Build.UnitTests/BackEnd/RequestBuilder_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/RequestBuilder_Tests.cs
@@ -327,7 +327,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
         {
             if (!evt.WaitOne(5000))
             {
-                Assert.True(false, "Did not receive " + eventName + " callback before the timeout expired.");
+                Assert.Fail("Did not receive " + eventName + " callback before the timeout expired.");
             }
         }
 

--- a/src/Build.UnitTests/BackEnd/TaskHostConfiguration_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/TaskHostConfiguration_Tests.cs
@@ -739,12 +739,12 @@ namespace Microsoft.Build.UnitTests.BackEnd
 
                 if (x == null || y == null)
                 {
-                    Assert.True(false, "The two item lists are not equal -- one of them is null");
+                    Assert.Fail("The two item lists are not equal -- one of them is null");
                 }
 
                 if (x.Length != y.Length)
                 {
-                    Assert.True(false, "The two item lists have different lengths, so they cannot be equal");
+                    Assert.Fail("The two item lists have different lengths, so they cannot be equal");
                 }
 
                 for (int i = 0; i < x.Length; i++)
@@ -765,7 +765,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
 
                 if (x == null || y == null)
                 {
-                    Assert.True(false, "The two items are not equal -- one of them is null");
+                    Assert.Fail("The two items are not equal -- one of them is null");
                 }
 
                 Assert.Equal(x.ItemSpec, y.ItemSpec);
@@ -779,7 +779,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
                 {
                     if (!metadataFromY.Contains(metadataName))
                     {
-                        Assert.True(false, string.Format("Only one item contains the '{0}' metadata", metadataName));
+                        Assert.Fail(string.Format("Only one item contains the '{0}' metadata", metadataName));
                     }
                     else
                     {

--- a/src/Build.UnitTests/BackEnd/TaskRegistry_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/TaskRegistry_Tests.cs
@@ -1380,7 +1380,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
 
                 List<ProjectUsingTaskElement> elementList = CreateParameterElementWithAttributes(output, required, type);
                 CreateTaskRegistryAndRegisterTasks(elementList);
-                Assert.True(false);
+                Assert.Fail();
             });
         }
         /// <summary>
@@ -1423,7 +1423,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
 
                 List<ProjectUsingTaskElement> elementList = CreateParameterElementWithAttributes(output, required, type);
                 TaskRegistry registry = CreateTaskRegistryAndRegisterTasks(elementList);
-                Assert.True(false);
+                Assert.Fail();
             });
         }
         /// <summary>
@@ -1469,7 +1469,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
 
                 List<ProjectUsingTaskElement> elementList = CreateParameterElementWithAttributes(output, required, type);
                 TaskRegistry registry = CreateTaskRegistryAndRegisterTasks(elementList);
-                Assert.True(false);
+                Assert.Fail();
             });
         }
         /// <summary>
@@ -1487,7 +1487,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
 
                 List<ProjectUsingTaskElement> elementList = CreateParameterElementWithAttributes(output, required, type);
                 TaskRegistry registry = CreateTaskRegistryAndRegisterTasks(elementList);
-                Assert.True(false);
+                Assert.Fail();
             });
         }
         /// <summary>
@@ -1558,7 +1558,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
 
                 List<ProjectUsingTaskElement> elementList = CreateParameterElementWithAttributes(output, required, type);
                 TaskRegistry registry = CreateTaskRegistryAndRegisterTasks(elementList);
-                Assert.True(false);
+                Assert.Fail();
             });
         }
         /// <summary>
@@ -1605,7 +1605,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
 
                 List<ProjectUsingTaskElement> elementList = CreateParameterElementWithAttributes(output, required, type);
                 CreateTaskRegistryAndRegisterTasks(elementList);
-                Assert.True(false);
+                Assert.Fail();
             });
         }
         /// <summary>
@@ -1652,7 +1652,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
 
                 List<ProjectUsingTaskElement> elementList = CreateParameterElementWithAttributes(output, required, type);
                 CreateTaskRegistryAndRegisterTasks(elementList);
-                Assert.True(false);
+                Assert.Fail();
             });
         }
         /// <summary>
@@ -1809,7 +1809,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
                 string evaluate = "RandomStuff";
                 List<ProjectUsingTaskElement> elementList = CreateTaskBodyElementWithAttributes(evaluate, "");
                 CreateTaskRegistryAndRegisterTasks(elementList);
-                Assert.True(false);
+                Assert.Fail();
             });
         }
         /// <summary>

--- a/src/Build.UnitTests/Collections/MultiDictionary_Tests.cs
+++ b/src/Build.UnitTests/Collections/MultiDictionary_Tests.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Build.UnitTests.OM.Collections
 
             foreach (string value in dictionary["x"])
             {
-                Assert.True(false);
+                Assert.Fail();
             }
         }
 

--- a/src/Build.UnitTests/Construction/SolutionProjectGenerator_Tests.cs
+++ b/src/Build.UnitTests/Construction/SolutionProjectGenerator_Tests.cs
@@ -1264,7 +1264,7 @@ EndGlobal
                 }
                 else
                 {
-                    Assert.True(false, "Unexpected project seen:" + item.ItemSpec);
+                    Assert.Fail("Unexpected project seen:" + item.ItemSpec);
                 }
             }
         }
@@ -1910,7 +1910,7 @@ EndGlobal
                 }
                 else
                 {
-                    Assert.True(false, "Something went really wrong!  The SolutionFile wasn't even created!");
+                    Assert.Fail("Something went really wrong!  The SolutionFile wasn't even created!");
                 }
             }
         }
@@ -2762,7 +2762,7 @@ EndProject";
                 }
             }
 
-            Assert.True(false);
+            Assert.Fail();
         }
 
         /// <summary>

--- a/src/Build.UnitTests/Definition/Toolset_Tests.cs
+++ b/src/Build.UnitTests/Definition/Toolset_Tests.cs
@@ -145,7 +145,7 @@ namespace Microsoft.Build.UnitTests.Definition
                 }
                 else
                 {
-                    Assert.True(false, $"Sub-toolset {key} was lost in translation.");
+                    Assert.Fail($"Sub-toolset {key} was lost in translation.");
                 }
             }
 

--- a/src/Build.UnitTests/Evaluation/Evaluator_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/Evaluator_Tests.cs
@@ -1937,11 +1937,11 @@ namespace Microsoft.Build.UnitTests.Evaluation
 
                 if (!allEvaluatedPropertiesWithNoBackingXmlAndNoDuplicates.TryGetValue(property.Name, out propertyFromAllEvaluated))
                 {
-                    Assert.True(false, String.Format("project.Properties contained property {0}, but AllEvaluatedProperties did not.", property.Name));
+                    Assert.Fail(String.Format("project.Properties contained property {0}, but AllEvaluatedProperties did not.", property.Name));
                 }
                 else if (!property.Equals(propertyFromAllEvaluated))
                 {
-                    Assert.True(false, String.Format("The properties in project.Properties and AllEvaluatedProperties for property {0} were different.", property.Name));
+                    Assert.Fail(String.Format("The properties in project.Properties and AllEvaluatedProperties for property {0} were different.", property.Name));
                 }
             }
 
@@ -2101,11 +2101,11 @@ namespace Microsoft.Build.UnitTests.Evaluation
 
                     if (!allEvaluatedPropertiesWithNoBackingXmlAndNoDuplicates.TryGetValue(property.Name, out propertyFromAllEvaluated))
                     {
-                        Assert.True(false, String.Format("project.Properties contained property {0}, but AllEvaluatedProperties did not.", property.Name));
+                        Assert.Fail(String.Format("project.Properties contained property {0}, but AllEvaluatedProperties did not.", property.Name));
                     }
                     else if (!property.Equals(propertyFromAllEvaluated))
                     {
-                        Assert.True(false, String.Format("The properties in project.Properties and AllEvaluatedProperties for property {0} were different.", property.Name));
+                        Assert.Fail(String.Format("The properties in project.Properties and AllEvaluatedProperties for property {0} were different.", property.Name));
                     }
                 }
 
@@ -3142,7 +3142,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
                 project.Build(logger);
 
                 // Should not reach this point.
-                Assert.True(false);
+                Assert.Fail();
             });
         }
         /// <summary>
@@ -4385,7 +4385,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             catch (XmlException)
             {
                 // XmlException thrown when invalid DTD statement is parsed: it means DTD processing was enabled
-                Assert.True(false);
+                Assert.Fail();
             }
         }
 
@@ -4475,7 +4475,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
                     MockElementLocation.Instance,
                     FileSystems.Default,
                     new TestLoggingContext(null!, new BuildEventContext(1, 2, 3, 4)));
-                Assert.True(false, "Expect exception due to the value of property \"TargetOSFamily\" is not a number.");
+                Assert.Fail("Expect exception due to the value of property \"TargetOSFamily\" is not a number.");
             }
             catch (InvalidProjectFileException e)
             {

--- a/src/Build.UnitTests/Evaluation/Expander_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/Expander_Tests.cs
@@ -1263,7 +1263,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
                 return;
             }
 
-            Assert.True(false);
+            Assert.Fail();
         }
 
         /// <summary>
@@ -1290,7 +1290,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
                 return;
             }
 
-            Assert.True(false);
+            Assert.Fail();
         }
         /// <summary>
         /// Creates a set of complicated item metadata and properties, and items to exercise
@@ -3586,7 +3586,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
                 expander.ExpandIntoStringLeaveEscaped(@"$([MSBuild]::DoesTaskHostExist('ASDF', 'CurrentArchitecture'))", ExpanderOptions.ExpandProperties, MockElementLocation.Instance);
 
                 // We should have failed before now
-                Assert.True(false);
+                Assert.Fail();
             });
         }
 
@@ -4250,7 +4250,7 @@ $(
                 {
                     string message = "FAILURE: " + validTests[i][0] + " expanded to '" + result + "' instead of '" + validTests[i][1] + "'";
                     Console.WriteLine(message);
-                    Assert.True(false, message);
+                    Assert.Fail(message);
                 }
                 else
                 {

--- a/src/Build.UnitTests/FileLogger_Tests.cs
+++ b/src/Build.UnitTests/FileLogger_Tests.cs
@@ -537,7 +537,7 @@ namespace Microsoft.Build.UnitTests
                 fileLogger.NodeId = 1;
                 fileLogger.Parameters = "logfile=";
                 fileLogger.Initialize(new EventSourceSink());
-                Assert.True(false);
+                Assert.Fail();
             });
         }
         #endregion

--- a/src/Build.UnitTests/InvalidProjectFileException_Tests.cs
+++ b/src/Build.UnitTests/InvalidProjectFileException_Tests.cs
@@ -72,7 +72,7 @@ namespace Microsoft.Build.UnitTests
                 MockLogger logger = new MockLogger(_testOutput);
                 ObjectModelHelpers.BuildTempProjectFileExpectFailure(file, logger);
 
-                Assert.True(false, "Loading an invalid project should have thrown an InvalidProjectFileException.");
+                Assert.Fail("Loading an invalid project should have thrown an InvalidProjectFileException.");
             }
             catch (InvalidProjectFileException e)
             {

--- a/src/BuildCheck.UnitTests/EditorConfig_Tests.cs
+++ b/src/BuildCheck.UnitTests/EditorConfig_Tests.cs
@@ -716,7 +716,7 @@ public class EditorConfig_Tests
             return;
         }
 
-        Assert.True(false, message);
+        Assert.Fail(message);
     }
 
     private static bool SequenceEqual<T>(IEnumerable<T> expected, IEnumerable<T> actual, IEqualityComparer<T> comparer = null)

--- a/src/Shared/UnitTests/ErrorUtilities_Tests.cs
+++ b/src/Shared/UnitTests/ErrorUtilities_Tests.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Build.UnitTests
                 return;
             }
 
-            Assert.True(false, "Should have thrown an exception");
+            Assert.Fail("Should have thrown an exception");
         }
 
         [Fact]

--- a/src/Shared/UnitTests/FileMatcher_Tests.cs
+++ b/src/Shared/UnitTests/FileMatcher_Tests.cs
@@ -649,7 +649,7 @@ namespace Microsoft.Build.UnitTests
             else
             {
                 Console.WriteLine("GetFileSystemEntries('{0}', '{1}')", path, pattern);
-                Assert.True(false, "Unexpected input into GetFileSystemEntries");
+                Assert.Fail("Unexpected input into GetFileSystemEntries");
             }
             return new string[] { "<undefined>" };
         }
@@ -2116,7 +2116,7 @@ namespace Microsoft.Build.UnitTests
                             }
                             else
                             {
-                                Assert.True(false, String.Format("Unhandled case in GetMatchingFiles: {0}", pattern));
+                                Assert.Fail(String.Format("Unhandled case in GetMatchingFiles: {0}", pattern));
                             }
                         }
                     }
@@ -2173,7 +2173,7 @@ namespace Microsoft.Build.UnitTests
                                 }
                                 else
                                 {
-                                    Assert.True(false, String.Format("Unhandled case in GetMatchingDirectories: {0}", pattern));
+                                    Assert.Fail(String.Format("Unhandled case in GetMatchingDirectories: {0}", pattern));
                                 }
                             }
                         }
@@ -2496,7 +2496,7 @@ namespace Microsoft.Build.UnitTests
                 Console.WriteLine("Expect Fixed '{0}' got '{1}'", expectedFixedDirectoryPart, fixedDirectoryPart);
                 Console.WriteLine("Expect Wildcard '{0}' got '{1}'", expectedWildcardDirectoryPart, wildcardDirectoryPart);
                 Console.WriteLine("Expect Filename '{0}' got '{1}'", expectedFilenamePart, filenamePart);
-                Assert.True(false, "FileMatcher Regression: Failure while validating SplitFileSpec.");
+                Assert.Fail("FileMatcher Regression: Failure while validating SplitFileSpec.");
             }
         }
 
@@ -2524,7 +2524,7 @@ namespace Microsoft.Build.UnitTests
         {
             if (!IsFileMatchAssertIfIllegal(filespec, fileToMatch, shouldBeRecursive))
             {
-                Assert.True(false, "FileMatcher Regression: Failure while validating that files match.");
+                Assert.Fail("FileMatcher Regression: Failure while validating that files match.");
             }
 
             // Now, simulate a filesystem with only fileToMatch. Make sure the file exists that way.
@@ -2549,7 +2549,7 @@ namespace Microsoft.Build.UnitTests
         {
             if (IsFileMatchAssertIfIllegal(filespec, fileToMatch, shouldBeRecursive))
             {
-                Assert.True(false, "FileMatcher Regression: Failure while validating that files don't match.");
+                Assert.Fail("FileMatcher Regression: Failure while validating that files don't match.");
             }
 
             // Now, simulate a filesystem with only fileToMatch. Make sure the file doesn't exist that way.
@@ -2577,7 +2577,7 @@ namespace Microsoft.Build.UnitTests
 
             if (isLegalFileSpec)
             {
-                Assert.True(false, "FileMatcher Regression: Expected an illegal filespec, but got a legal one.");
+                Assert.Fail("FileMatcher Regression: Expected an illegal filespec, but got a legal one.");
             }
 
             // Now, FileMatcher is supposed to take any legal file name and just return it immediately.
@@ -2602,7 +2602,7 @@ namespace Microsoft.Build.UnitTests
             if (!match.isLegalFileSpec)
             {
                 Console.WriteLine("Checking FileSpec: '{0}' against '{1}'", filespec, fileToMatch);
-                Assert.True(false, "FileMatcher Regression: Invalid filespec.");
+                Assert.Fail("FileMatcher Regression: Invalid filespec.");
             }
             if (shouldBeRecursive != match.isFileSpecRecursive)
             {

--- a/src/Shared/UnitTests/NativeMethodsShared_Tests.cs
+++ b/src/Shared/UnitTests/NativeMethodsShared_Tests.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Build.UnitTests
                 }
                 else
                 {
-                    Assert.True(false);
+                    Assert.Fail();
                 }
 
                 // Make sure the pointer passed back for the method is not null

--- a/src/Tasks.UnitTests/AssemblyDependency/Miscellaneous.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/Miscellaneous.cs
@@ -553,17 +553,17 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 {
                     // The version of System.Xml.dll in C:\MyProject is an older version.
                     // This version is not a match. When want the current version which should have been in a different directory.
-                    Assert.True(false, "Wrong version of System.Xml.dll matched--version was wrong");
+                    Assert.Fail("Wrong version of System.Xml.dll matched--version was wrong");
                 }
                 else if (String.Equals(item.ItemSpec, Path.Combine(s_myProjectPath, "System.Data.dll"), StringComparison.OrdinalIgnoreCase))
                 {
                     // The version of System.Data.dll in C:\MyProject has an incorrect PKT
                     // This version is not a match.
-                    Assert.True(false, "Wrong version of System.Data.dll matched--public key token was wrong");
+                    Assert.Fail("Wrong version of System.Data.dll matched--public key token was wrong");
                 }
                 else
                 {
-                    Assert.True(false, String.Format("A new resolved file called '{0}' was found. If this is intentional, then add unittests above.", item.ItemSpec));
+                    Assert.Fail(String.Format("A new resolved file called '{0}' was found. If this is intentional, then add unittests above.", item.ItemSpec));
                 }
             }
 
@@ -593,14 +593,14 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 }
                 else
                 {
-                    Assert.True(false, String.Format("A new dependency called '{0}' was found. If this is intentional, then add unittests above.", item.ItemSpec));
+                    Assert.Fail(String.Format("A new dependency called '{0}' was found. If this is intentional, then add unittests above.", item.ItemSpec));
                 }
             }
 
             // Process the related files.
             foreach (ITaskItem item in t.RelatedFiles)
             {
-                Assert.True(false, String.Format("A new dependency called '{0}' was found. If this is intentional, then add unittests above.", item.ItemSpec));
+                Assert.Fail(String.Format("A new dependency called '{0}' was found. If this is intentional, then add unittests above.", item.ItemSpec));
             }
 
             // Process the satellites.
@@ -622,7 +622,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 }
                 else
                 {
-                    Assert.True(false, String.Format("A new dependency called '{0}' was found. If this is intentional, then add unittests above.", item.ItemSpec));
+                    Assert.Fail(String.Format("A new dependency called '{0}' was found. If this is intentional, then add unittests above.", item.ItemSpec));
                 }
             }
 
@@ -786,7 +786,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 
                     if (j == assembliesCount)
                     {
-                        Assert.True(false, String.Format("{0}: A new resolved file called '{1}' was found. If this is intentional, then add unittests above.", fxVersion, item.ItemSpec));
+                        Assert.Fail(String.Format("{0}: A new resolved file called '{1}' was found. If this is intentional, then add unittests above.", fxVersion, item.ItemSpec));
                     }
                 }
 

--- a/src/Tasks.UnitTests/AssemblyDependency/ResolveAssemblyReferenceTestFixture.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/ResolveAssemblyReferenceTestFixture.cs
@@ -325,7 +325,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 if (count > ioThreshold)
                 {
                     string message = String.Format("File.Exists() was called {0} times with path {1}.", count, path);
-                    Assert.True(false, message);
+                    Assert.Fail(message);
                 }
             }
 
@@ -346,7 +346,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 if (count > 0)
                 {
                     string message = String.Format("File.Exists() was called {0} times with path {1}.", count, path);
-                    Assert.True(false, message);
+                    Assert.Fail(message);
                 }
             }
 
@@ -358,7 +358,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 if (count > 0)
                 {
                     string message = String.Format("GetAssemblyName() was called {0} times with path {1}.", count, path);
-                    Assert.True(false, message);
+                    Assert.Fail(message);
                 }
             }
 
@@ -644,7 +644,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             }
             else
             {
-                Assert.True(false, "Unsupported GetFiles pattern " + pattern);
+                Assert.Fail("Unsupported GetFiles pattern " + pattern);
             }
 
             ArrayList matches = new ArrayList();
@@ -2769,7 +2769,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 }
             }
 
-            Assert.True(false, $"New GetRegistrySubKeyNames parameters encountered, need to add unittesting support for subKey={subKey}");
+            Assert.Fail($"New GetRegistrySubKeyNames parameters encountered, need to add unittesting support for subKey={subKey}");
             return null;
         }
 
@@ -2908,7 +2908,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 }
             }
 
-            Assert.True(false, $"New GetRegistrySubKeyDefaultValue parameters encountered, need to add unittesting support for subKey={subKey}");
+            Assert.Fail($"New GetRegistrySubKeyDefaultValue parameters encountered, need to add unittesting support for subKey={subKey}");
             return null;
         }
 

--- a/src/Tasks.UnitTests/AxTlbBaseTask_Tests.cs
+++ b/src/Tasks.UnitTests/AxTlbBaseTask_Tests.cs
@@ -81,7 +81,7 @@ namespace Microsoft.Build.UnitTests.AxTlbImp_Tests
                 }
                 else
                 {
-                    Assert.True(false, "Key container could not be created (perhaps you are not running as admin).");
+                    Assert.Fail("Key container could not be created (perhaps you are not running as admin).");
                 }
             }
             finally

--- a/src/Tasks.UnitTests/CommandLineBuilderExtension_Tests.cs
+++ b/src/Tasks.UnitTests/CommandLineBuilderExtension_Tests.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Build.UnitTests
                 }
                 catch (ArgumentException e)
                 {
-                    Assert.True(false, "Got an unexpected exception:" + e.Message);
+                    Assert.Fail("Got an unexpected exception:" + e.Message);
                 }
 
                 // Now try a bogus boolean.

--- a/src/Tasks.UnitTests/CommandLine_Support.cs
+++ b/src/Tasks.UnitTests/CommandLine_Support.cs
@@ -96,7 +96,7 @@ namespace Microsoft.Build.UnitTests
 
             msg += "Not found!\r\n";
             Console.WriteLine(msg);
-            Assert.True(false, msg); // Could not find the parameter.
+            Assert.Fail(msg); // Could not find the parameter.
 
             return 0;
         }
@@ -185,7 +185,7 @@ namespace Microsoft.Build.UnitTests
                     {
                         msg += String.Format(" Found something!\r\n");
                         Console.WriteLine(msg);
-                        Assert.True(false, msg); // Found the startsWith but shouldn't have.
+                        Assert.Fail(msg); // Found the startsWith but shouldn't have.
                         return;
                     }
                 }
@@ -221,7 +221,7 @@ namespace Microsoft.Build.UnitTests
             {
                 msg += "Not found!\r\n";
                 Console.WriteLine(msg);
-                Assert.True(false, msg);
+                Assert.Fail(msg);
             }
         }
 
@@ -253,7 +253,7 @@ namespace Microsoft.Build.UnitTests
             {
                 msg += "Found!\r\n";
                 Console.WriteLine(msg);
-                Assert.True(false, msg);
+                Assert.Fail(msg);
             }
         }
 
@@ -284,7 +284,7 @@ namespace Microsoft.Build.UnitTests
             {
                 msg += "Does not match!\r\n";
                 Console.WriteLine(msg);
-                Assert.True(false, msg);
+                Assert.Fail(msg);
             }
         }
 

--- a/src/Tasks.UnitTests/CreateCSharpManifestResourceName_Tests.cs
+++ b/src/Tasks.UnitTests/CreateCSharpManifestResourceName_Tests.cs
@@ -780,7 +780,7 @@ namespace ClassLibrary3
             {
                 return StreamHelpers.StringToStream("namespace MyStuff.Namespace { class Class {} }");
             }
-            Assert.True(false, String.Format("Encountered a new path {0}, needs unittesting support", path));
+            Assert.Fail(String.Format("Encountered a new path {0}, needs unittesting support", path));
             return null;
         }
 

--- a/src/Tasks.UnitTests/CreateVisualBasicManifestResourceName_Tests.cs
+++ b/src/Tasks.UnitTests/CreateVisualBasicManifestResourceName_Tests.cs
@@ -424,7 +424,7 @@ End Namespace
 ");
             }
 
-            Assert.True(false, String.Format("Encountered a new path {0}, needs unittesting support", path));
+            Assert.Fail(String.Format("Encountered a new path {0}, needs unittesting support", path));
             return null;
         }
 

--- a/src/Tasks.UnitTests/MockTypeInfo.cs
+++ b/src/Tasks.UnitTests/MockTypeInfo.cs
@@ -278,7 +278,7 @@ namespace Microsoft.Build.UnitTests
             else
             {
                 ppTI = null;
-                Assert.True(false, "unexpected hRef value");
+                Assert.Fail("unexpected hRef value");
             }
         }
 
@@ -345,7 +345,7 @@ namespace Microsoft.Build.UnitTests
             else
             {
                 ppTI = null;
-                Assert.True(false, "unexpected hRef value");
+                Assert.Fail("unexpected hRef value");
             }
         }
 

--- a/src/Tasks.UnitTests/MockTypeLib.cs
+++ b/src/Tasks.UnitTests/MockTypeLib.cs
@@ -223,7 +223,7 @@ namespace Microsoft.Build.UnitTests
             }
             else
             {
-                Assert.True(false, "unexpected guid in ITypeLib2.GetCustData");
+                Assert.Fail("unexpected guid in ITypeLib2.GetCustData");
                 pVarVal = null;
             }
         }

--- a/src/Tasks.UnitTests/Touch_Tests.cs
+++ b/src/Tasks.UnitTests/Touch_Tests.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Build.UnitTests
             {
                 return true;
             }
-            Assert.True(false, "Unexpected file exists: " + path);
+            Assert.Fail("Unexpected file exists: " + path);
 
             return true;
         }
@@ -87,7 +87,7 @@ namespace Microsoft.Build.UnitTests
             }
 
 
-            Assert.True(false, "Unexpected file create: " + path);
+            Assert.Fail("Unexpected file create: " + path);
             return null;
         }
 
@@ -114,7 +114,7 @@ namespace Microsoft.Build.UnitTests
                 return System.IO.FileAttributes.ReadOnly;
             }
 
-            Assert.True(false, "Unexpected file attributes: " + path);
+            Assert.Fail("Unexpected file attributes: " + path);
             return a;
         }
 
@@ -128,7 +128,7 @@ namespace Microsoft.Build.UnitTests
             {
                 return;
             }
-            Assert.True(false, "Unexpected set file attributes: " + path);
+            Assert.Fail("Unexpected set file attributes: " + path);
         }
 
         /// <summary>
@@ -153,7 +153,7 @@ namespace Microsoft.Build.UnitTests
                 throw new IOException();
             }
 
-            Assert.True(false, "Unexpected set last access time: " + path);
+            Assert.Fail("Unexpected set last access time: " + path);
         }
 
         /// <summary>
@@ -178,7 +178,7 @@ namespace Microsoft.Build.UnitTests
             }
 
 
-            Assert.True(false, "Unexpected set last write time: " + path);
+            Assert.Fail("Unexpected set last write time: " + path);
         }
 
         [Fact]

--- a/src/Tasks.UnitTests/XamlTestHelpers.cs
+++ b/src/Tasks.UnitTests/XamlTestHelpers.cs
@@ -121,7 +121,7 @@ namespace Microsoft.Build.UnitTests
             }
             catch (XamlParseException)
             {
-                Assert.True(false, "Parse of FakeTask XML failed");
+                Assert.Fail("Parse of FakeTask XML failed");
             }
 
             TaskGenerator tg = new TaskGenerator(tp);

--- a/src/Tasks.UnitTests/XslTransformation_Tests.cs
+++ b/src/Tasks.UnitTests/XslTransformation_Tests.cs
@@ -126,7 +126,7 @@ namespace Microsoft.Build.UnitTests
                             t.XmlInputPaths = (TaskItem[])xmlValue;
                             break;
                         default:
-                            Assert.True(false, "Test error");
+                            Assert.Fail("Test error");
                             break;
                     }
 
@@ -142,7 +142,7 @@ namespace Microsoft.Build.UnitTests
                             t.XslCompiledDllPath = (TaskItem)xslValue;
                             break;
                         default:
-                            Assert.True(false, "Test error");
+                            Assert.Fail("Test error");
                             break;
                     }
 
@@ -187,7 +187,7 @@ namespace Microsoft.Build.UnitTests
                         t.XmlInputPaths = (TaskItem[])xmlValue;
                         break;
                     default:
-                        Assert.True(false, "Test error");
+                        Assert.Fail("Test error");
                         break;
                 }
 
@@ -236,7 +236,7 @@ namespace Microsoft.Build.UnitTests
                         t.XslCompiledDllPath = (TaskItem)xslValue;
                         break;
                     default:
-                        Assert.True(false, "Test error");
+                        Assert.Fail("Test error");
                         break;
                 }
 
@@ -1212,7 +1212,7 @@ namespace Microsoft.Build.UnitTests
             }
             catch (Exception e)
             {
-                Assert.True(false, "Compiler didn't work" + e.ToString());
+                Assert.Fail("Compiler didn't work" + e.ToString());
             }
 
             asmBldr.Save(Path.GetFileName(outputFile), PortableExecutableKinds.ILOnly, ImageFileMachine.I386);

--- a/src/UnitTests.Shared/MockLogger.cs
+++ b/src/UnitTests.Shared/MockLogger.cs
@@ -538,7 +538,7 @@ namespace Microsoft.Build.UnitTests
                         PrintFullLog();
                     }
 
-                    Assert.True(false, $"Log was not expected to contain '{contains}', but did.");
+                    Assert.Fail($"Log was not expected to contain '{contains}', but did.");
                 }
             }
         }

--- a/src/UnitTests.Shared/ObjectModelHelpers.cs
+++ b/src/UnitTests.Shared/ObjectModelHelpers.cs
@@ -442,7 +442,7 @@ namespace Microsoft.Build.UnitTests
             // Log an error for any leftover items in the expectedItems collection.
             foreach (ITaskItem expectedItem in expectedItems)
             {
-                Assert.True(false, string.Format("Item '{0}' was expected but not returned.", expectedItem.ItemSpec));
+                Assert.Fail(string.Format("Item '{0}' was expected but not returned.", expectedItem.ItemSpec));
             }
 
             if (outOfOrder)
@@ -450,7 +450,7 @@ namespace Microsoft.Build.UnitTests
                 Console.WriteLine("ERROR:  Items were returned in the incorrect order...");
                 Console.WriteLine("Expected:  " + expectedItemSpecs);
                 Console.WriteLine("Actual:    " + actualItemSpecs);
-                Assert.True(false, "Items were returned in the incorrect order.  See 'Standard Out' tab for more details.");
+                Assert.Fail("Items were returned in the incorrect order.  See 'Standard Out' tab for more details.");
             }
         }
 
@@ -1150,7 +1150,7 @@ namespace Microsoft.Build.UnitTests
             }
             else
             {
-                Assert.True(false, "unrecognized current platform");
+                Assert.Fail("unrecognized current platform");
             }
 
             return currentPlatformString;
@@ -1896,7 +1896,7 @@ namespace Microsoft.Build.UnitTests
 
             if (ex1 == null && ex2 == null)
             {
-                Assert.True(false, "Neither threw");
+                Assert.Fail("Neither threw");
             }
 
             Assert.NotNull(ex1); // "First method did not throw, second: {0}", ex2 == null ? "" : ex2.GetType() + ex2.Message);
@@ -1954,7 +1954,7 @@ namespace Microsoft.Build.UnitTests
                 string output = "\r\n#################################Expected#################################\n" + string.Join("\r\n", expectedLines);
                 output += "\r\n#################################Actual#################################\n" + string.Join("\r\n", actualLines);
 
-                Assert.True(false, output);
+                Assert.Fail(output);
             }
 
             if (actualLines.Length > expectedLines.Length)
@@ -1962,14 +1962,14 @@ namespace Microsoft.Build.UnitTests
                 LogLine("\n#################################Expected#################################\n" + string.Join("\n", expectedLines));
                 LogLine("#################################Actual#################################\n" + string.Join("\n", actualLines));
 
-                Assert.True(false, "Expected content was shorter, actual had this extra line: '" + actualLines[expectedLines.Length] + "'");
+                Assert.Fail("Expected content was shorter, actual had this extra line: '" + actualLines[expectedLines.Length] + "'");
             }
             else if (actualLines.Length < expectedLines.Length)
             {
                 LogLine("\n#################################Expected#################################\n" + string.Join("\n", expectedLines));
                 LogLine("#################################Actual#################################\n" + string.Join("\n", actualLines));
 
-                Assert.True(false, "Actual content was shorter, expected had this extra line: '" + expectedLines[actualLines.Length] + "'");
+                Assert.Fail("Actual content was shorter, expected had this extra line: '" + expectedLines[actualLines.Length] + "'");
             }
         }
 

--- a/src/Utilities.UnitTests/TrackedDependencies/FileTrackerTests.cs
+++ b/src/Utilities.UnitTests/TrackedDependencies/FileTrackerTests.cs
@@ -2526,7 +2526,7 @@ namespace ConsoleApplication4
             {
                 if (file.Equals(lines[i], StringComparison.OrdinalIgnoreCase))
                 {
-                    Assert.True(false, "Found string '" + file + "' in '" + tlog + "' at line " + i + ", when it shouldn't have been in the log at all.");
+                    Assert.Fail("Found string '" + file + "' in '" + tlog + "' at line " + i + ", when it shouldn't have been in the log at all.");
                 }
             }
         }
@@ -2551,7 +2551,7 @@ namespace ConsoleApplication4
 
             if (timesFound != timesFoundSoFar)
             {
-                Assert.True(false, "Searched " + tlog + " but didn't find " + timesFound + " instances of " + file);
+                Assert.Fail("Searched " + tlog + " but didn't find " + timesFound + " instances of " + file);
             }
         }
 


### PR DESCRIPTION
Fixes #10586

### Context
During the retargeting work from net8 to net9 new tools brought new rules and warnings to the build. Not to introduce a lot of changes in one PR the rules were disabled.
This PR enables one of them `xunit2020` https://xunit.net/xunit.analyzers/rules/xUnit2020 and addresses the issues

### Changes Made
Find -> Replace 
   - `Assert.True(false,  -> Assert.Fail(`
   - `Assert.True(false)  -> Assert.Fail()`

### Testing
Existing tests should be green

### Notes
