### PR TITLE
Enable xUnit1012 rule 

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -426,11 +426,12 @@ dotnet_diagnostic.IDE0073.severity = error
 # Use 'System.Threading.Lock'
 dotnet_diagnostic.IDE0330.severity = suggestion
 
+# Value types are incompatible with null values. https://xunit.net/xunit.analyzers/rules/xUnit1012
+dotnet_diagnostic.xUnit1012.severity = warning
 
 # xunit to supress temp
 dotnet_diagnostic.xUnit2020.severity = none
 dotnet_diagnostic.xUnit1031.severity = none
-dotnet_diagnostic.xUnit1012.severity = none
 dotnet_diagnostic.xUnit2029.severity = none
 # Do not use equality check to check for collection size.
 dotnet_diagnostic.xUnit2013.severity = none

--- a/src/Build.UnitTests/BackEnd/NodeConfiguration_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/NodeConfiguration_Tests.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
         [Theory]
         [InlineData(new byte[] { 1, 2, 3 })]
         [InlineData(null)]
-        public void TestTranslationWithAppDomainSetup(byte[] configBytes)
+        public void TestTranslationWithAppDomainSetup(byte[]? configBytes)
         {
             AppDomainSetup setup = new AppDomainSetup();
 

--- a/src/BuildCheck.UnitTests/EndToEndTests.cs
+++ b/src/BuildCheck.UnitTests/EndToEndTests.cs
@@ -148,7 +148,7 @@ public class EndToEndTests : IDisposable
     [InlineData("suggestion", "BC0101", new string[] { "error BC0101", "warning BC0101" })]
     [InlineData("default", "warning BC0101", new string[] { "error BC0101" })]
     [InlineData("none", null, new string[] { "BC0101" })]
-    public void EditorConfig_SeverityAppliedCorrectly(string BC0101Severity, string expectedOutputValues, string[] unexpectedOutputValues)
+    public void EditorConfig_SeverityAppliedCorrectly(string BC0101Severity, string? expectedOutputValues, string[] unexpectedOutputValues)
     {
         PrepareSampleProjectsAndConfig(true, out TransientTestFile projectFile, new List<(string, string)>() { ("BC0101", BC0101Severity) });
 
@@ -163,7 +163,7 @@ public class EndToEndTests : IDisposable
 
         if (!string.IsNullOrEmpty(expectedOutputValues))
         {
-            output.ShouldContain(expectedOutputValues);
+            output.ShouldContain(expectedOutputValues!);
         }
 
         foreach (string unexpectedOutputValue in unexpectedOutputValues)

--- a/src/Tasks.UnitTests/AddToWin32Manifest_Tests.cs
+++ b/src/Tasks.UnitTests/AddToWin32Manifest_Tests.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Build.Tasks.UnitTests
         [InlineData("testManifestSavesTheCurrentNodesPositions.manifest", true)]
         [InlineData("testManifestNoPrefixes.manifest", true)]
         [InlineData(null, true)]
-        public void ManifestPopulationCheck(string manifestName, bool expectedResult)
+        public void ManifestPopulationCheck(string? manifestName, bool expectedResult)
         {
             AddToWin32Manifest task = new AddToWin32Manifest()
             {
@@ -75,7 +75,7 @@ namespace Microsoft.Build.Tasks.UnitTests
         [InlineData(null, true)]
         [InlineData("buildIn.manifest", true)]
         [InlineData("testManifestWithValidSupportedArchs.manifest", true)]
-        public void E2EScenarioTests(string manifestName, bool expectedResult)
+        public void E2EScenarioTests(string? manifestName, bool expectedResult)
         {
             using (TestEnvironment env = TestEnvironment.Create())
             {

--- a/src/Tasks.UnitTests/CombineTargetFrameworkInfoProperties_Tests.cs
+++ b/src/Tasks.UnitTests/CombineTargetFrameworkInfoProperties_Tests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Build.UnitTests
         [InlineData(null, false, "MSB3991")]
         [InlineData("", false, "MSB3991")]
         [InlineData(null, true, "MSB3992")]
-        public void RootElementNameNotValid(string rootElementName, bool UseAttributeForTargetFrameworkInfoPropertyNames, string errorCode)
+        public void RootElementNameNotValid(string? rootElementName, bool UseAttributeForTargetFrameworkInfoPropertyNames, string errorCode)
         {
             MockEngine e = new MockEngine();
             var task = new CombineTargetFrameworkInfoProperties();


### PR DESCRIPTION
Fixes #10589 

### Context
During the retargeting work from net8 to net9 new tools brought new rules and warnings to the build. Not to introduce a lot of changes in one PR the rules were disabled.

### Changes Made
This PR enables one of them xunit1012 https://xunit.net/xunit.analyzers/rules/xunit1012 and addresses the warnings

### Testing
All tests should pass