### PR TITLE
[Documentation] Fix typo in sample config

### DIFF
--- a/documentation/specs/BuildCheck/BuildCheck.md
+++ b/documentation/specs/BuildCheck/BuildCheck.md
@@ -166,7 +166,7 @@ For the `.editorconfig` file configuration, following will apply:
 build_check.BC0101.severity=warning
 
 build_check.COND0543.severity=none
-build_check.COND0543.scope=project
+build_check.COND0543.scope=project_file
 build_check.COND0543.custom_switch=QWERTY
 ```
 


### PR DESCRIPTION
### Context
Fixing the sample configuration in documentation that is out of sync with the actual values.
