### PR TITLE
Enable xUnit2029 rule

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -432,8 +432,11 @@ dotnet_diagnostic.xUnit1012.severity = warning
 # Use Assert.Fail() instead of Assert.True(false) or Assert.False(true)
 dotnet_diagnostic.xUnit2020.severity = warning
 
+# Use Assert.DoesNotContain instead of Assert.Empty on filtered collections
+dotnet_diagnostic.xUnit2029.severity = warning
+
 # xunit to supress temp
 dotnet_diagnostic.xUnit1031.severity = none
-dotnet_diagnostic.xUnit2029.severity = none
+
 # Do not use equality check to check for collection size.
 dotnet_diagnostic.xUnit2013.severity = none

--- a/src/Tasks.UnitTests/GetSDKReference_Tests.cs
+++ b/src/Tasks.UnitTests/GetSDKReference_Tests.cs
@@ -634,7 +634,7 @@ namespace Microsoft.Build.UnitTests.GetSDKReferenceFiles_Tests
             // References from the two builds should not overlap, otherwise the cache files are being misused
             foreach (var ref2 in references2)
             {
-                Assert.Empty(references1.Where(i => i.ItemSpec.Equals(ref2.ItemSpec, StringComparison.InvariantCultureIgnoreCase)));
+                Assert.DoesNotContain(references1, i => i.ItemSpec.Equals(ref2.ItemSpec, StringComparison.InvariantCultureIgnoreCase));
             }
 
             Thread.Sleep(100);


### PR DESCRIPTION
Fixes #10599

### Context
During the retargeting work from net8 to net9 new tools brought new rules and warnings to the build. Not to introduce a lot of changes in one PR the rules were disabled.

### Changes Made
This PR enables one of them xUnit2029 https://xunit.net/xunit.analyzers/rules/xUnit2029 and addresses the warnings

### Testing
All tests should pass
