### PR TITLE
Bump to Microsoft.DotNet.Arcade.MSBuild.Xcopy 17.10.0-pre4.0

### DIFF
--- a/global.json
+++ b/global.json
@@ -5,9 +5,9 @@
   "tools": {
     "dotnet": "9.0.100-preview.7.24407.12",
     "vs": {
-      "version": "17.8.0"
+      "version": "17.10.0"
     },
-    "xcopy-msbuild": "17.8.5"
+    "xcopy-msbuild": "17.10.0-pre.4.0"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "9.0.0-beta.24426.3"


### PR DESCRIPTION
Fixes #
CG alerts [CVE-2024-29415](https://devdiv.visualstudio.com/DevDiv/_componentGovernance/DotNet-msbuild-Trusted/alert/9734236?typeId=10653271), [CVE-2024-28863](https://devdiv.visualstudio.com/DevDiv/_componentGovernance/DotNet-msbuild-Trusted/alert/9495273?typeId=10653271), [CVE-2023-42282](https://devdiv.visualstudio.com/DevDiv/_componentGovernance/DotNet-msbuild-Trusted/alert/9296415?typeId=10653271) which are resulted from xcopy-msbuild 17.8.5. 
 
### Context
xcopy-msbuild ([Microsoft.DotNet.Arcade.MSBuild.Xcopy](https://dev.azure.com/dnceng/internal/_wiki/wikis/DNCEng%20Services%20Wiki/1074/Updating-Microsoft.DotNet.Arcade.MSBuild.Xcopy-WAS-RoslynTools.MSBuild-(xcopy-msbuild)-generation?anchor=troubleshooting)) higher version > 17.9.6 removed NodeJs modules under MSBuild\Microsoft\VisualStudio\NodeJs. The vulnerability didn't exist.

### Changes Made
Bump  Microsoft.DotNet.Arcade.MSBuild.Xcopy to 17.10.0-pre4.0 which is the latest available.

### Testing


### Notes
