### PR TITLE
Reapply "Load Microsoft.DotNet.MSBuildSdkResolver into default load context"

### DIFF
--- a/documentation/wiki/ChangeWaves.md
+++ b/documentation/wiki/ChangeWaves.md
@@ -29,6 +29,7 @@ A wave of features is set to "rotate out" (i.e. become standard functionality) t
 - [Fix oversharing of build results in ResultsCache](https://github.com/dotnet/msbuild/pull/9987)
 - [Add ParameterName and PropertyName to TaskParameterEventArgs](https://github.com/dotnet/msbuild/pull/10130)
 - [Emit eval props if requested by any sink](https://github.com/dotnet/msbuild/pull/10243)
+- [Load Microsoft.DotNet.MSBuildSdkResolver into default load context (MSBuild.exe only)](https://github.com/dotnet/msbuild/pull/NNNN)
 
 ### 17.10
 - [AppDomain configuration is serialized without using BinFmt](https://github.com/dotnet/msbuild/pull/9320) - feature can be opted out only if [BinaryFormatter](https://learn.microsoft.com/en-us/dotnet/api/system.runtime.serialization.formatters.binary.binaryformatter) is allowed at runtime by editing `MSBuild.runtimeconfig.json`. **Please note that [any usage of BinaryFormatter is insecure](https://learn.microsoft.com/dotnet/standard/serialization/binaryformatter-security-guide).**

--- a/documentation/wiki/ChangeWaves.md
+++ b/documentation/wiki/ChangeWaves.md
@@ -29,7 +29,7 @@ A wave of features is set to "rotate out" (i.e. become standard functionality) t
 - [Fix oversharing of build results in ResultsCache](https://github.com/dotnet/msbuild/pull/9987)
 - [Add ParameterName and PropertyName to TaskParameterEventArgs](https://github.com/dotnet/msbuild/pull/10130)
 - [Emit eval props if requested by any sink](https://github.com/dotnet/msbuild/pull/10243)
-- [Load Microsoft.DotNet.MSBuildSdkResolver into default load context (MSBuild.exe only)](https://github.com/dotnet/msbuild/pull/NNNN)
+- [Load Microsoft.DotNet.MSBuildSdkResolver into default load context (MSBuild.exe only)](https://github.com/dotnet/msbuild/pull/10603)
 
 ### 17.10
 - [AppDomain configuration is serialized without using BinFmt](https://github.com/dotnet/msbuild/pull/9320) - feature can be opted out only if [BinaryFormatter](https://learn.microsoft.com/en-us/dotnet/api/system.runtime.serialization.formatters.binary.binaryformatter) is allowed at runtime by editing `MSBuild.runtimeconfig.json`. **Please note that [any usage of BinaryFormatter is insecure](https://learn.microsoft.com/dotnet/standard/serialization/binaryformatter-security-guide).**

--- a/src/Build/BackEnd/Components/SdkResolution/SdkResolverLoader.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/SdkResolverLoader.cs
@@ -232,6 +232,20 @@ namespace Microsoft.Build.BackEnd.SdkResolution
         protected virtual Assembly LoadResolverAssembly(string resolverPath)
         {
 #if !FEATURE_ASSEMBLYLOADCONTEXT
+            if (ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_12))
+            {
+                string resolverFileName = Path.GetFileNameWithoutExtension(resolverPath);
+                if (resolverFileName.Equals("Microsoft.DotNet.MSBuildSdkResolver", StringComparison.OrdinalIgnoreCase))
+                {
+                    // This will load the resolver assembly into the default load context if possible, and fall back to LoadFrom context.
+                    // We very much prefer the default load context because it allows native images to be used by the CLR, improving startup perf.
+                    AssemblyName assemblyName = new AssemblyName(resolverFileName)
+                    {
+                        CodeBase = resolverPath,
+                    };
+                    return Assembly.Load(assemblyName);
+                }
+            }
             return Assembly.LoadFrom(resolverPath);
 #else
             return s_loader.LoadFromPath(resolverPath);

--- a/src/MSBuild/app.amd64.config
+++ b/src/MSBuild/app.amd64.config
@@ -184,6 +184,17 @@
           <assemblyIdentity name="Microsoft.VisualStudio.CodeAnalysis.Sdk" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
           <codeBase version="17.0.0.0" href="..\..\..\Microsoft\VisualStudio\v17.0\CodeAnalysis\Microsoft.VisualStudio.CodeAnalysis.Sdk.dll" />
         </dependentAssembly>
+
+        <!-- Redirects for SDK resolver components -->
+        <qualifyAssembly partialName="Microsoft.DotNet.MSBuildSdkResolver" fullName="Microsoft.DotNet.MSBuildSdkResolver, Version=8.0.100.0, Culture=neutral, PublicKeyToken=adb9793829ddae60" />
+        <dependentAssembly>
+          <assemblyIdentity name="Microsoft.DotNet.MSBuildSdkResolver" culture="neutral" publicKeyToken="adb9793829ddae60" />
+          <codeBase version="8.0.100.0" href="..\SdkResolvers\Microsoft.DotNet.MSBuildSdkResolver\Microsoft.DotNet.MSBuildSdkResolver.dll" />
+        </dependentAssembly>
+        <dependentAssembly>
+          <assemblyIdentity name="Microsoft.Deployment.DotNet.Releases" culture="neutral" publicKeyToken="31bf3856ad364e35" />
+          <codeBase version="2.0.0.0" href="..\SdkResolvers\Microsoft.DotNet.MSBuildSdkResolver\Microsoft.Deployment.DotNet.Releases.dll" />
+        </dependentAssembly>
       </assemblyBinding>
     </runtime>
     <!-- To define one or more new toolsets, add an 'msbuildToolsets' element in this file. -->

--- a/src/MSBuild/app.amd64.config
+++ b/src/MSBuild/app.amd64.config
@@ -185,7 +185,7 @@
           <codeBase version="17.0.0.0" href="..\..\..\Microsoft\VisualStudio\v17.0\CodeAnalysis\Microsoft.VisualStudio.CodeAnalysis.Sdk.dll" />
         </dependentAssembly>
 
-        <!-- Redirects for SDK resolver components -->
+        <!-- Redirects for SDK resolver components, see https://github.com/dotnet/msbuild/blob/main/documentation/NETFramework-NGEN.md#microsoftdotnetmsbuildsdkresolver for details -->
         <qualifyAssembly partialName="Microsoft.DotNet.MSBuildSdkResolver" fullName="Microsoft.DotNet.MSBuildSdkResolver, Version=8.0.100.0, Culture=neutral, PublicKeyToken=adb9793829ddae60" />
         <dependentAssembly>
           <assemblyIdentity name="Microsoft.DotNet.MSBuildSdkResolver" culture="neutral" publicKeyToken="adb9793829ddae60" />

--- a/src/MSBuild/app.config
+++ b/src/MSBuild/app.config
@@ -137,6 +137,17 @@
           <assemblyIdentity name="Microsoft.VisualStudio.CodeAnalysis.Sdk" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
           <codeBase version="17.0.0.0" href="..\..\Microsoft\VisualStudio\v17.0\CodeAnalysis\Microsoft.VisualStudio.CodeAnalysis.Sdk.dll" />
         </dependentAssembly>
+
+        <!-- Redirects for SDK resolver components -->
+        <qualifyAssembly partialName="Microsoft.DotNet.MSBuildSdkResolver" fullName="Microsoft.DotNet.MSBuildSdkResolver, Version=8.0.100.0, Culture=neutral, PublicKeyToken=adb9793829ddae60" />
+        <dependentAssembly>
+          <assemblyIdentity name="Microsoft.DotNet.MSBuildSdkResolver" culture="neutral" publicKeyToken="adb9793829ddae60" />
+          <codeBase version="8.0.100.0" href=".\SdkResolvers\Microsoft.DotNet.MSBuildSdkResolver\Microsoft.DotNet.MSBuildSdkResolver.dll" />
+        </dependentAssembly>
+        <dependentAssembly>
+          <assemblyIdentity name="Microsoft.Deployment.DotNet.Releases" culture="neutral" publicKeyToken="31bf3856ad364e35" />
+          <codeBase version="2.0.0.0" href=".\SdkResolvers\Microsoft.DotNet.MSBuildSdkResolver\Microsoft.Deployment.DotNet.Releases.dll" />
+        </dependentAssembly>
       </assemblyBinding>
     </runtime>
     <!-- To define one or more new toolsets, add an 'msbuildToolsets' element in this file. -->

--- a/src/MSBuild/app.config
+++ b/src/MSBuild/app.config
@@ -138,7 +138,7 @@
           <codeBase version="17.0.0.0" href="..\..\Microsoft\VisualStudio\v17.0\CodeAnalysis\Microsoft.VisualStudio.CodeAnalysis.Sdk.dll" />
         </dependentAssembly>
 
-        <!-- Redirects for SDK resolver components -->
+        <!-- Redirects for SDK resolver components, see https://github.com/dotnet/msbuild/blob/main/documentation/NETFramework-NGEN.md#microsoftdotnetmsbuildsdkresolver for details -->
         <qualifyAssembly partialName="Microsoft.DotNet.MSBuildSdkResolver" fullName="Microsoft.DotNet.MSBuildSdkResolver, Version=8.0.100.0, Culture=neutral, PublicKeyToken=adb9793829ddae60" />
         <dependentAssembly>
           <assemblyIdentity name="Microsoft.DotNet.MSBuildSdkResolver" culture="neutral" publicKeyToken="adb9793829ddae60" />


### PR DESCRIPTION
### Context

Now that https://github.com/dotnet/sdk/pull/39573 has made it into VS, we can finally enable loading `Microsoft.DotNet.MSBuildSdkResolver` by assembly name, as opposed to file path, which makes it possible to use its NGEN image.

### Changes Made

Re-did #9439 which had to be reverted because of the problematic dependency on `Newtonsoft.Json`. The .NET SDK resolver does not depend on `Newtonsoft.Json` anymore. All the other pieces are already in place:
- `Microsoft.DotNet.MSBuildSdkResolver` is NGENed, both for MSBuild.exe and for devenv.exe.
- `devenv.exe.config` contains binding redirects analogous to what's added in this PR.

### Testing

Experimentally inserted into VS and verified that `Microsoft.DotNet.MSBuildSdkResolver` is no longer JITted, saving ~50-100 ms of MSBuild.exe startup time.