### PR TITLE
Opt-in CPM for buildcheck template

### DIFF
--- a/template_feed/content/Microsoft.CheckTemplate/Directory.Packages.props
+++ b/template_feed/content/Microsoft.CheckTemplate/Directory.Packages.props
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Microsoft.Build" Version="1.0.0-MicrosoftBuildPackageVersion" />
   </ItemGroup>


### PR DESCRIPTION
### Context

We are having Microsoft.Build package version managed centrally - but we do not opt-in to the feature - as a result restore will not respect our setting in Directory.Build.props.

### Testing
Manual runs

Before:

```
  C:\repro\Contoso.BuildChecks.csproj : warning NU1604: Project dependency Microsoft.Build does not contain an inclusive lower bound. Include a lower bound in the dependency version to ensure consistent restore results.

  (...)

  C:\repro\Contoso.BuildChecks\Check1.cs(2,23): error CS0234: The type or namespace name 'Experimental' does not exist in the namespace 'Microsoft.Build' (are you missing an assembly reference?)

  (...)
  Build failed with 8 error(s) and 2 warning(s) in 1.6s
```

After:

```
 (...)
 Build succeeded with 12 warning(s) in 3.0s
```

**Note:** The warnings in the sample above are caused by unrelated issues (will be tracked separately)