### PR TITLE
Improve custom Check authoring - enable setting defaults for Severity and Scope

### DIFF
--- a/src/Build/BuildCheck/API/CheckConfiguration.cs
+++ b/src/Build/BuildCheck/API/CheckConfiguration.cs
@@ -35,12 +35,12 @@ public class CheckConfiguration
     ///
     /// If not supported by the data source - then the setting is ignored
     /// </summary>
-    public EvaluationCheckScope? EvaluationCheckScope { get; internal init; }
+    public EvaluationCheckScope? EvaluationCheckScope { get; init; }
 
     /// <summary>
     /// The severity of the result for the rule.
     /// </summary>
-    public CheckResultSeverity? Severity { get; internal init; }
+    public CheckResultSeverity? Severity { get; init; }
 
     /// <summary>
     /// Whether the check rule is enabled.


### PR DESCRIPTION
### Context
Currently the Severity and Scope settings initializers are internal - making them inaccessible to check authors. This prevents check authors to be able to set sensible defaults - instead global defaults (Severity = Suggestion, Scope=ProjectFile) are allways used and this can be only overwritten via editorconfig.

