### PR TITLE
BuildCheck has better message when Check fails on Initialize

### DIFF
--- a/src/Build/BackEnd/Components/Logging/EventSourceSink.cs
+++ b/src/Build/BackEnd/Components/Logging/EventSourceSink.cs
@@ -8,7 +8,6 @@ using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
 
 using InternalLoggerException = Microsoft.Build.Exceptions.InternalLoggerException;
-using System.Diagnostics;
 
 #nullable disable
 

--- a/src/Build/BackEnd/Components/Logging/EventSourceSink.cs
+++ b/src/Build/BackEnd/Components/Logging/EventSourceSink.cs
@@ -8,6 +8,7 @@ using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
 
 using InternalLoggerException = Microsoft.Build.Exceptions.InternalLoggerException;
+using System.Diagnostics;
 
 #nullable disable
 

--- a/src/Build/BackEnd/Shared/EventsCreatorHelper.cs
+++ b/src/Build/BackEnd/Shared/EventsCreatorHelper.cs
@@ -60,4 +60,35 @@ internal static class EventsCreatorHelper
 
         return buildEvent;
     }
+
+    public static BuildWarningEventArgs CreateWarningEventFromText(BuildEventContext buildEventContext, string? subcategoryResourceName, string? errorCode, string? helpKeyword, BuildEventFileInfo file, string message)
+    {
+        ErrorUtilities.VerifyThrowInternalNull(buildEventContext, nameof(buildEventContext));
+        ErrorUtilities.VerifyThrowInternalNull(file, nameof(file));
+        ErrorUtilities.VerifyThrowInternalNull(message, nameof(message));
+
+        string? subcategory = null;
+
+        if (subcategoryResourceName != null)
+        {
+            subcategory = AssemblyResources.GetString(subcategoryResourceName);
+        }
+
+        BuildWarningEventArgs buildEvent =
+        new BuildWarningEventArgs(
+            subcategory,
+            errorCode,
+            file!.File,
+            file.Line,
+            file.Column,
+            file.EndLine,
+            file.EndColumn,
+            message,
+            helpKeyword,
+            "MSBuild");
+
+        buildEvent.BuildEventContext = buildEventContext;
+
+        return buildEvent;
+    }
 }

--- a/src/Build/BuildCheck/Infrastructure/BuildCheckManagerProvider.cs
+++ b/src/Build/BuildCheck/Infrastructure/BuildCheckManagerProvider.cs
@@ -188,6 +188,7 @@ internal sealed class BuildCheckManagerProvider : IBuildCheckManagerProvider
         {
             if (_enabledDataSources[(int)buildCheckDataSource])
             {
+                List<CheckFactoryContext> checksToRemove = new();
                 foreach (var factory in factories)
                 {
                     var instance = factory();
@@ -201,10 +202,24 @@ internal sealed class BuildCheckManagerProvider : IBuildCheckManagerProvider
                         if (checkFactoryContext != null)
                         {
                             _checkRegistry.Add(checkFactoryContext);
-                            SetupSingleCheck(checkFactoryContext, projectPath);
-                            checkContext.DispatchAsComment(MessageImportance.Normal, "CustomCheckSuccessfulAcquisition", instance.FriendlyName);
+                            try
+                            {
+                                SetupSingleCheck(checkFactoryContext, projectPath);
+                                checkContext.DispatchAsComment(MessageImportance.Normal, "CustomCheckSuccessfulAcquisition", instance.FriendlyName);
+                            }
+                            catch (BuildCheckConfigurationException e)
+                            {
+                                checkContext.DispatchAsWarningFromText(
+                                    null,
+                                    null,
+                                    null,
+                                    new BuildEventFileInfo(projectPath),
+                                    e.Message);
+                                checksToRemove.Add(checkFactoryContext);
+                            }
                         }
                     }
+                    RemoveChecks(checksToRemove, checkContext);
                 }
             }
         }
@@ -295,7 +310,7 @@ internal sealed class BuildCheckManagerProvider : IBuildCheckManagerProvider
                 }
                 catch (BuildCheckConfigurationException e)
                 {
-                    checkContext.DispatchAsErrorFromText(
+                    checkContext.DispatchAsWarningFromText(
                         null,
                         null,
                         null,
@@ -305,6 +320,14 @@ internal sealed class BuildCheckManagerProvider : IBuildCheckManagerProvider
                 }
             }
 
+            RemoveChecks(checksToRemove, checkContext);
+
+            stopwatch.Stop();
+            _tracingReporter.AddNewProjectStats(stopwatch.Elapsed);
+        }
+
+        private void RemoveChecks(List<CheckFactoryContext> checksToRemove, ICheckContext checkContext)
+        {
             checksToRemove.ForEach(c =>
             {
                 _checkRegistry.Remove(c);
@@ -316,9 +339,6 @@ internal sealed class BuildCheckManagerProvider : IBuildCheckManagerProvider
                 _tracingReporter.AddCheckStats(checkToRemove!.Check.FriendlyName, checkToRemove.Elapsed);
                 checkToRemove.Check.Dispose();
             }
-
-            stopwatch.Stop();
-            _tracingReporter.AddNewProjectStats(stopwatch.Elapsed);
         }
 
         public void ProcessEvaluationFinishedEventArgs(

--- a/src/Build/BuildCheck/Infrastructure/BuildCheckManagerProvider.cs
+++ b/src/Build/BuildCheck/Infrastructure/BuildCheckManagerProvider.cs
@@ -188,7 +188,7 @@ internal sealed class BuildCheckManagerProvider : IBuildCheckManagerProvider
         {
             if (_enabledDataSources[(int)buildCheckDataSource])
             {
-                List<CheckFactoryContext> checksToRemove = new();
+                List<CheckFactoryContext> invalidChecksToRemove = new();
                 foreach (var factory in factories)
                 {
                     var instance = factory();
@@ -215,11 +215,11 @@ internal sealed class BuildCheckManagerProvider : IBuildCheckManagerProvider
                                     null,
                                     new BuildEventFileInfo(projectPath),
                                     e.Message);
-                                checksToRemove.Add(checkFactoryContext);
+                                invalidChecksToRemove.Add(checkFactoryContext);
                             }
                         }
                     }
-                    RemoveChecks(checksToRemove, checkContext);
+                    RemoveChecks(invalidChecksToRemove, checkContext);
                 }
             }
         }
@@ -301,7 +301,7 @@ internal sealed class BuildCheckManagerProvider : IBuildCheckManagerProvider
 
             // If it's already constructed - just control the custom settings do not differ
             Stopwatch stopwatch = Stopwatch.StartNew();
-            List<CheckFactoryContext> checksToRemove = new();
+            List<CheckFactoryContext> invalidChecksToRemove = new();
             foreach (CheckFactoryContext checkFactoryContext in _checkRegistry)
             {
                 try
@@ -316,11 +316,11 @@ internal sealed class BuildCheckManagerProvider : IBuildCheckManagerProvider
                         null,
                         new BuildEventFileInfo(projectFullPath),
                         e.Message);
-                    checksToRemove.Add(checkFactoryContext);
+                    invalidChecksToRemove.Add(checkFactoryContext);
                 }
             }
 
-            RemoveChecks(checksToRemove, checkContext);
+            RemoveChecks(invalidChecksToRemove, checkContext);
 
             stopwatch.Stop();
             _tracingReporter.AddNewProjectStats(stopwatch.Elapsed);

--- a/src/Build/BuildCheck/Infrastructure/CheckContext/CheckDispatchingContext.cs
+++ b/src/Build/BuildCheck/Infrastructure/CheckContext/CheckDispatchingContext.cs
@@ -62,4 +62,11 @@ internal class CheckDispatchingContext : ICheckContext
 
         _eventDispatcher.Dispatch(buildEvent);
     }
+
+    public void DispatchAsWarningFromText(string? subcategoryResourceName, string? errorCode, string? helpKeyword, BuildEventFileInfo file, string message)
+    {
+        BuildWarningEventArgs buildEvent = EventsCreatorHelper.CreateWarningEventFromText(_eventContext, subcategoryResourceName, errorCode, helpKeyword, file, message);
+
+        _eventDispatcher.Dispatch(buildEvent);
+    }
 }

--- a/src/Build/BuildCheck/Infrastructure/CheckContext/CheckLoggingContext.cs
+++ b/src/Build/BuildCheck/Infrastructure/CheckContext/CheckLoggingContext.cs
@@ -39,4 +39,8 @@ internal readonly struct CheckLoggingContext(ILoggingService loggingService, Bui
     public void DispatchAsErrorFromText(string? subcategoryResourceName, string? errorCode, string? helpKeyword, BuildEventFileInfo file, string message)
         => loggingService
             .LogErrorFromText(eventContext, subcategoryResourceName, errorCode, helpKeyword, file, message);
+
+    public void DispatchAsWarningFromText(string? subcategoryResourceName, string? errorCode, string? helpKeyword, BuildEventFileInfo file, string message)
+        => loggingService
+            .LogWarningFromText(eventContext, subcategoryResourceName, errorCode, helpKeyword, file, message);
 }

--- a/src/Build/BuildCheck/Infrastructure/CheckContext/ICheckContext.cs
+++ b/src/Build/BuildCheck/Infrastructure/CheckContext/ICheckContext.cs
@@ -40,4 +40,9 @@ internal interface ICheckContext
     /// Dispatch the instance of <see cref="BuildEventContext"/> as a comment with provided text for the message.
     /// </summary>
     void DispatchAsCommentFromText(MessageImportance importance, string message);
+
+    /// <summary>
+    /// Dispatch the instance of <see cref="BuildEventContext"/> as a warning message.
+    /// </summary>
+    void DispatchAsWarningFromText(string? subcategoryResourceName, string? errorCode, string? helpKeyword, BuildEventFileInfo file, string message);
 }

--- a/src/BuildCheck.UnitTests/EndToEndTests.cs
+++ b/src/BuildCheck.UnitTests/EndToEndTests.cs
@@ -345,8 +345,8 @@ public class EndToEndTests : IDisposable
 
     [Theory]
     [InlineData("X01236", "Something went wrong initializing")]
-    [InlineData("X01237", "message")]
-    [InlineData("X01238", "message")]
+    // [InlineData("X01237", "message")]
+    // [InlineData("X01238", "message")]
     public void CustomChecksFailGracefully(string ruleId, string expectedMessage)
     {
         using (var env = TestEnvironment.Create())

--- a/src/BuildCheck.UnitTests/EndToEndTests.cs
+++ b/src/BuildCheck.UnitTests/EndToEndTests.cs
@@ -345,6 +345,8 @@ public class EndToEndTests : IDisposable
 
     [Theory]
     [InlineData("X01236", "Something went wrong initializing")]
+    // These tests are for failure one different points, will be addressed in a different PR
+    // https://github.com/dotnet/msbuild/issues/10522
     // [InlineData("X01237", "message")]
     // [InlineData("X01238", "message")]
     public void CustomChecksFailGracefully(string ruleId, string expectedMessage)

--- a/src/BuildCheck.UnitTests/Microsoft.Build.BuildCheck.UnitTests.csproj
+++ b/src/BuildCheck.UnitTests/Microsoft.Build.BuildCheck.UnitTests.csproj
@@ -20,6 +20,7 @@
     <ProjectReference Include=".\TestAssets\CustomCheck\CustomCheck.csproj" />
     <ProjectReference Include=".\TestAssets\CustomCheck2\CustomCheck2.csproj" />
     <ProjectReference Include=".\TestAssets\InvalidCustomCheck\InvalidCustomCheck.csproj" />
+    <ProjectReference Include=".\TestAssets\ErrorCustomCheck\ErrorCustomCheck.csproj" />
   </ItemGroup>
 
   <ItemGroup>
@@ -43,6 +44,10 @@
     <None Include="TestAssets\**\*">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="TestAssets\ErrorCustomCheck\ErrorWhenRegisteringActions.cs" />
   </ItemGroup>
 
 </Project>

--- a/src/BuildCheck.UnitTests/Microsoft.Build.BuildCheck.UnitTests.csproj
+++ b/src/BuildCheck.UnitTests/Microsoft.Build.BuildCheck.UnitTests.csproj
@@ -46,8 +46,4 @@
     </None>
   </ItemGroup>
 
-  <ItemGroup>
-    <Compile Remove="TestAssets\ErrorCustomCheck\ErrorWhenRegisteringActions.cs" />
-  </ItemGroup>
-
 </Project>

--- a/src/BuildCheck.UnitTests/TestAssets/CheckCandidateWithMultipleChecksInjected/.editorconfigtest
+++ b/src/BuildCheck.UnitTests/TestAssets/CheckCandidateWithMultipleChecksInjected/.editorconfigtest
@@ -2,3 +2,6 @@ root = true
 
 [*.csproj]
 build_check.X01234.Severity=X01234Severity
+
+build_check.X01235.Severity=warning
+build_check.X01236.Severity=warning

--- a/src/BuildCheck.UnitTests/TestAssets/CheckCandidateWithMultipleChecksInjected/.editorconfigtest
+++ b/src/BuildCheck.UnitTests/TestAssets/CheckCandidateWithMultipleChecksInjected/.editorconfigtest
@@ -3,5 +3,6 @@ root = true
 [*.csproj]
 build_check.X01234.Severity=X01234Severity
 
-build_check.X01235.Severity=warning
-build_check.X01236.Severity=warning
+build_check.X01236.Severity=X01236Severity
+build_check.X01237.Severity=X01237Severity
+build_check.X01238.Severity=X01238Severity

--- a/src/BuildCheck.UnitTests/TestAssets/CheckCandidateWithMultipleChecksInjected/CheckCandidateWithMultipleChecksInjected.csproj
+++ b/src/BuildCheck.UnitTests/TestAssets/CheckCandidateWithMultipleChecksInjected/CheckCandidateWithMultipleChecksInjected.csproj
@@ -9,6 +9,7 @@
     <PackageReference Include="CustomCheck" Version="1.0.0"/>
     <PackageReference Include="CustomCheck2" Version="1.0.0"/>
     <PackageReference Include="InvalidCustomCheck" Version="1.0.0"/>
+    <PackageReference Include="ErrorCustomCheck" Version="1.0.0"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/BuildCheck.UnitTests/TestAssets/ErrorCustomCheck/ErrorCustomCheck.csproj
+++ b/src/BuildCheck.UnitTests/TestAssets/ErrorCustomCheck/ErrorCustomCheck.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="..\Common\CommonTest.props" />
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="ErrorCustomCheck.props" Pack="true" PackagePath="build\ErrorCustomCheck.props" />
+    <Content Include="README.md" />
+  </ItemGroup>
+
+  <Import Project="..\Common\CommonTest.targets" />
+
+</Project>

--- a/src/BuildCheck.UnitTests/TestAssets/ErrorCustomCheck/ErrorCustomCheck.props
+++ b/src/BuildCheck.UnitTests/TestAssets/ErrorCustomCheck/ErrorCustomCheck.props
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <PropertyGroup>
+	  <MSBuildCheck>$([MSBuild]::RegisterBuildCheck($(MSBuildThisFileDirectory)ErrorCustomCheck.dll))</MSBuildCheck>
+  </PropertyGroup>
+</Project>

--- a/src/BuildCheck.UnitTests/TestAssets/ErrorCustomCheck/ErrorOnInitializeCheck.cs
+++ b/src/BuildCheck.UnitTests/TestAssets/ErrorCustomCheck/ErrorOnInitializeCheck.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.Build.Construction;
+using Microsoft.Build.Experimental.BuildCheck;
+
+namespace ErrorCustomCheck
+{
+    public sealed class ErrorOnInitializeCheck : Check
+    {
+        public static CheckRule SupportedRule = new CheckRule(
+            "X01236",
+            "Title",
+            "Description",
+            "Message format: {0}",
+            new CheckConfiguration());
+
+        public override string FriendlyName => "ErrorOnInitializeCheck";
+
+        public override IReadOnlyList<CheckRule> SupportedRules { get; } = new List<CheckRule>() { SupportedRule };
+
+        public override void Initialize(ConfigurationContext configurationContext)
+        {
+            // configurationContext to be used only if check needs external configuration data.
+            throw new Exception("Something went wrong initializing");
+        }
+
+        public override void RegisterActions(IBuildCheckRegistrationContext registrationContext)
+        {
+            registrationContext.RegisterEvaluatedPropertiesAction(EvaluatedPropertiesAction);
+        }
+
+        private void EvaluatedPropertiesAction(BuildCheckDataContext<EvaluatedPropertiesCheckData> context)
+        {
+            context.ReportResult(BuildCheckResult.Create(
+                SupportedRule,
+                ElementLocation.EmptyLocation,
+                "This check should have been disabled"));
+        }
+    }
+}

--- a/src/BuildCheck.UnitTests/TestAssets/ErrorCustomCheck/ErrorOnInitializeCheck.cs
+++ b/src/BuildCheck.UnitTests/TestAssets/ErrorCustomCheck/ErrorOnInitializeCheck.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
 using System.Collections.Generic;
 using Microsoft.Build.Construction;
 using Microsoft.Build.Experimental.BuildCheck;

--- a/src/BuildCheck.UnitTests/TestAssets/ErrorCustomCheck/ErrorOnRegisteredAction.cs
+++ b/src/BuildCheck.UnitTests/TestAssets/ErrorCustomCheck/ErrorOnRegisteredAction.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.Build.Construction;
+using Microsoft.Build.Experimental.BuildCheck;
+
+namespace ErrorCustomCheck
+{
+    public sealed class ErrorOnRegisteredAction : Check
+    {
+        public static CheckRule SupportedRule = new CheckRule(
+            "X01237",
+            "Title",
+            "Description",
+            "Message format: {0}",
+            new CheckConfiguration());
+
+        public override string FriendlyName => "ErrorOnEvaluatedPropertiesCheck";
+
+        public override IReadOnlyList<CheckRule> SupportedRules { get; } = new List<CheckRule>() { SupportedRule };
+
+        public override void Initialize(ConfigurationContext configurationContext)
+        {
+            // configurationContext to be used only if check needs external configuration data.
+        }
+
+        public override void RegisterActions(IBuildCheckRegistrationContext registrationContext)
+        {
+            registrationContext.RegisterEvaluatedPropertiesAction(EvaluatedPropertiesAction);
+        }
+
+        private void EvaluatedPropertiesAction(BuildCheckDataContext<EvaluatedPropertiesCheckData> context)
+        {
+            throw new Exception("something went wrong");
+        }
+    }
+}

--- a/src/BuildCheck.UnitTests/TestAssets/ErrorCustomCheck/ErrorOnRegisteredAction.cs
+++ b/src/BuildCheck.UnitTests/TestAssets/ErrorCustomCheck/ErrorOnRegisteredAction.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
 using System.Collections.Generic;
 using Microsoft.Build.Construction;
 using Microsoft.Build.Experimental.BuildCheck;

--- a/src/BuildCheck.UnitTests/TestAssets/ErrorCustomCheck/ErrorWhenRegisteringActions.cs
+++ b/src/BuildCheck.UnitTests/TestAssets/ErrorCustomCheck/ErrorWhenRegisteringActions.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
 using System.Collections.Generic;
 using Microsoft.Build.Construction;
 using Microsoft.Build.Experimental.BuildCheck;

--- a/src/BuildCheck.UnitTests/TestAssets/ErrorCustomCheck/ErrorWhenRegisteringActions.cs
+++ b/src/BuildCheck.UnitTests/TestAssets/ErrorCustomCheck/ErrorWhenRegisteringActions.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.Build.Construction;
+using Microsoft.Build.Experimental.BuildCheck;
+
+namespace ErrorCustomCheck
+{
+    public sealed class ErrorWhenRegisteringActions : Check
+    {
+        public static CheckRule SupportedRule = new CheckRule(
+            "X01238",
+            "Title",
+            "Description",
+            "Message format: {0}",
+            new CheckConfiguration());
+
+        public override string FriendlyName => "ErrorOnEvaluatedPropertiesCheck";
+
+        public override IReadOnlyList<CheckRule> SupportedRules { get; } = new List<CheckRule>() { SupportedRule };
+
+        public override void Initialize(ConfigurationContext configurationContext)
+        {
+            // configurationContext to be used only if check needs external configuration data.
+        }
+
+        public override void RegisterActions(IBuildCheckRegistrationContext registrationContext)
+        {
+            registrationContext.RegisterEvaluatedPropertiesAction(EvaluatedPropertiesAction);
+            throw new Exception("something went wrong");
+        }
+
+        private void EvaluatedPropertiesAction(BuildCheckDataContext<EvaluatedPropertiesCheckData> context)
+        {
+            context.ReportResult(BuildCheckResult.Create(
+                SupportedRule,
+                ElementLocation.EmptyLocation,
+                "This check should have been disabled"));
+        }
+    }
+}

--- a/src/BuildCheck.UnitTests/TestAssets/ErrorCustomCheck/README.md
+++ b/src/BuildCheck.UnitTests/TestAssets/ErrorCustomCheck/README.md
@@ -1,0 +1,21 @@
+# MSBuild Custom Check Template
+
+## Overview
+MSBuild Custom Check Template is a .NET template designed to streamline the creation of MSBuild check libraries. This template facilitates the development of custom checks targeting .NET Standard, enabling developers to inspect and enforce conventions, standards, or patterns within their MSBuild builds.
+
+## Features
+- Simplified template for creating MSBuild check libraries.
+- Targeting .NET Standard for cross-platform compatibility.
+- Provides a starting point for implementing custom check rules.
+
+## Getting Started
+To use the MSBuild Custom Check Template, follow these steps:
+1. Install the template using the following command:
+   ```bash
+   dotnet new install msbuildcheck
+2. Instantiate a custom template:
+   ```bash
+   dotnet new msbuildcheck -n <ProjectName>
+
+### Prerequisites
+- .NET SDK installed on your machine.


### PR DESCRIPTION
Partial fix of https://github.com/dotnet/msbuild/issues/10522

### Context
When a Check throws an exception it falls with an internal logger exception and crashes the build. This is not ideal. It decided that when a Check fails, we do not fail the build, just give a warning and deregister the check.

### Changes Made
Changed the BuildCheck logger to catch initialization exceptions, and dispatch them as warnings and not errors.

### Testing
Added end to end test with a sample custom check that throws an exception. 

### Notes
This is just a catch for exception on Check initialization. There are tests added for other cases but the fix will be different for them, so it will be done in another PR.