### PR TITLE
Update README.md to render on NuGet.org

### DIFF
--- a/template_feed/README.md
+++ b/template_feed/README.md
@@ -1,9 +1,10 @@
 ## MSBuild Custom Check Template Package
 
 The package contains the template designed to streamline the creation of MSBuild check libraries.
-| Template name | Short name | Description|
-|---|---|---|
-|MSBuild Custom Check Template|`msbuildcheck`|A project for creating a MSBuild check library that targets .NET Standard.|
+
+| Template name | Short name | Description |
+| --- | --- | --- |
+| MSBuild Custom Check Template | `msbuildcheck` | A project for creating a MSBuild check library that targets .NET Standard. |
 
 The package is available for download from nuget.org.
 Please feel to contribute or provide the feedback in discussions or via opening the issue in dotnet/msbuild repo.


### PR DESCRIPTION
The Table rendering on the NuGet Gallery needed some more whitespace to render HTML instead of raw text.

Fixes #10613

### Testing

I tested this with a sample FSI script that mimics the NuGet Gallery markdown rendering:

<details>
<summary>F# Script for testing</summary>

```fsharp
#r "nuget: Markdig"

open Markdig
open Markdig.Renderers
open Markdig.Syntax
open System.IO
open Markdig.Extensions.EmphasisExtras

let text1 =
    """## MSBuild Custom Check Template Package

The package contains the template designed to streamline the creation of MSBuild check libraries.
| Template name | Short name | Description|
|---|---|---|
|MSBuild Custom Check Template|`msbuildcheck`|A project for creating a MSBuild check library that targets .NET Standard.|

The package is available for download from nuget.org.
Please feel to contribute or provide the feedback in discussions or via opening the issue in dotnet/msbuild repo.

"""

let text2 =
    """## MSBuild Custom Check Template Package

The package contains the template designed to streamline the creation of MSBuild check libraries.

| Template name | Short name | Description |
| --- | --- | --- |
| MSBuild Custom Check Template | `msbuildcheck` | A project for creating a MSBuild check library that targets .NET Standard. |

The package is available for download from nuget.org.
Please feel to contribute or provide the feedback in discussions or via opening the issue in dotnet/msbuild repo.

"""

let render text =
    let pipeline =
        MarkdownPipelineBuilder()
            .UseGridTables()
            .UsePipeTables()
            .UseListExtras()
            .UseTaskLists()
            .UseEmojiAndSmiley()
            .UseAutoLinks()
            .UseReferralLinks("noopener noreferrer nofollow")
            .UseAutoIdentifiers()
            .UseEmphasisExtras(EmphasisExtraOptions.Strikethrough)
            .DisableHtml()
            .UseBootstrap()
            .Build()

    use writer = new StringWriter()
    let renderer = new HtmlRenderer(writer)
    pipeline.Setup(renderer)
    let document = Markdown.Parse(text, pipeline)
    renderer.Render(document) |> ignore
    writer.ToString()

let html1 = render text1
let html2 = render text2

System.Console.WriteLine $"""first text has pipes: {html1.Contains "|"}"""

System.Console.WriteLine $"""second text has tables: {html2.Contains "<table"}"""
```
</details>

When run via `dotnet fsi <path to script>` this should write:

```
first text has pipes: True
second text has tables: True
```
