### PR TITLE
Assembly redirect fix

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,7 +2,7 @@
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the MIT license. See License.txt in the project root for full license information. -->
 <Project>
   <PropertyGroup>
-    <VersionPrefix>17.11.6</VersionPrefix><DotNetFinalVersionKind>release</DotNetFinalVersionKind>
+    <VersionPrefix>17.11.7</VersionPrefix><DotNetFinalVersionKind>release</DotNetFinalVersionKind>
     <PackageValidationBaselineVersion>17.10.4</PackageValidationBaselineVersion>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>

--- a/src/MSBuild/app.amd64.config
+++ b/src/MSBuild/app.amd64.config
@@ -49,7 +49,7 @@
 
         <dependentAssembly>
           <assemblyIdentity name="Microsoft.IO.Redist" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-          <bindingRedirect oldVersion="0.0.0.0-6.0.0.1" newVersion="6.0.0.0" />
+          <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
           <codeBase version="6.0.0.0" href="..\Microsoft.IO.Redist.dll"/>
         </dependentAssembly>
 

--- a/src/MSBuild/app.config
+++ b/src/MSBuild/app.config
@@ -45,7 +45,7 @@
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="Microsoft.IO.Redist" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-          <bindingRedirect oldVersion="0.0.0.0-6.0.0.1" newVersion="6.0.0.0" />
+          <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="Microsoft.NET.StringTools" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />


### PR DESCRIPTION
Fixes #10520

### Context
Original PR didn't allow to use newer version of MS.IO.Redirect even when it would be possible.

### Changes Made
Fix the redirect in a way that we haven't a range of the binding redirect beyond what we distribute.

### Testing


### Notes
@maridematte I'm expecting "I told you so" message, but the original value before my change wasn't valid too 😄 