### PR TITLE
[BuildCheck] Limit number of emitted messages per rule.

### DIFF
--- a/src/Build/BuildCheck/Infrastructure/BuildCheckCentralContext.cs
+++ b/src/Build/BuildCheck/Infrastructure/BuildCheckCentralContext.cs
@@ -49,7 +49,7 @@ internal sealed class BuildCheckCentralContext
 
     // In a future we can have callbacks per project as well
     private readonly CallbackRegistry _globalCallbacks = new();
-    private Action<ICheckContext> _removeThrottledChecks;
+    private readonly Action<ICheckContext> _removeThrottledChecks;
 
     // This we can potentially use to subscribe for receiving evaluated props in the
     //  build event args. However - this needs to be done early on, when checks might not be known yet

--- a/src/Build/BuildCheck/Infrastructure/BuildCheckManagerProvider.cs
+++ b/src/Build/BuildCheck/Infrastructure/BuildCheckManagerProvider.cs
@@ -603,7 +603,6 @@ internal sealed class BuildCheckManagerProvider : IBuildCheckManagerProvider
                     throw new BuildCheckConfigurationException(
                         $"The Check '{ba.FriendlyName}' failed to initialize: {e.Message}", e);
                 }
-
                 return new CheckWrapper(ba);
             }
 

--- a/src/Build/BuildCheck/Infrastructure/BuildCheckManagerProvider.cs
+++ b/src/Build/BuildCheck/Infrastructure/BuildCheckManagerProvider.cs
@@ -573,7 +573,10 @@ internal sealed class BuildCheckManagerProvider : IBuildCheckManagerProvider
                     throw new BuildCheckConfigurationException(
                         $"The Check '{ba.FriendlyName}' failed to initialize: {e.Message}", e);
                 }
-                return new CheckWrapper(ba);
+
+                CheckWrapper wrapper = new(ba);
+                wrapper.Initialize();
+                return wrapper;
             }
 
             public CheckWrapper? MaterializedCheck { get; set; }

--- a/src/Build/BuildCheck/Infrastructure/BuildCheckManagerProvider.cs
+++ b/src/Build/BuildCheck/Infrastructure/BuildCheckManagerProvider.cs
@@ -589,9 +589,7 @@ internal sealed class BuildCheckManagerProvider : IBuildCheckManagerProvider
                         $"The Check '{ba.FriendlyName}' failed to initialize: {e.Message}", e);
                 }
 
-                CheckWrapper wrapper = new(ba);
-                wrapper.Initialize();
-                return wrapper;
+                return new CheckWrapper(ba);
             }
 
             public CheckWrapper? MaterializedCheck { get; set; }

--- a/src/Build/BuildCheck/Infrastructure/BuildEventsProcessor.cs
+++ b/src/Build/BuildCheck/Infrastructure/BuildEventsProcessor.cs
@@ -242,10 +242,6 @@ internal class BuildEventsProcessor(BuildCheckCentralContext buildCheckCentralCo
             return;
         }
 
-        BuildEventArgs eventArgs = result.ToEventArgs(config.Severity);
-
-        eventArgs.BuildEventContext = checkContext.BuildEventContext;
-
-        checkContext.DispatchBuildEvent(eventArgs);
+        checkWrapper.ReportResult(result, checkContext, config);
     }
 }

--- a/src/Build/BuildCheck/Infrastructure/CheckWrapper.cs
+++ b/src/Build/BuildCheck/Infrastructure/CheckWrapper.cs
@@ -26,14 +26,13 @@ internal sealed class CheckWrapper
     /// <summary>
     /// Keeps track of number of reports sent per rule.
     /// </summary>
-    private Dictionary<string, int>? _reportsCountPerRule;
+    private Dictionary<string, int> _reportsCountPerRule = new();
 
-    private readonly bool _limitReportsNumber;
+    private readonly bool _limitReportsNumber = !Traits.Instance.EscapeHatches.DoNotLimitBuildCheckResultsNumber;
 
     public CheckWrapper(Check check)
     {
         Check = check;
-        _limitReportsNumber = !Traits.Instance.EscapeHatches.DoNotLimitBuildCheckResultsNumber;
     }
 
     internal Check Check { get; }
@@ -42,15 +41,6 @@ internal sealed class CheckWrapper
     // Let's optimize for the scenario where users have a single .editorconfig file that applies to the whole solution.
     // In such case - configuration will be same for all projects. So we do not need to store it per project in a collection.
     internal CheckConfigurationEffective? CommonConfig { get; private set; }
-
-    internal void Initialize()
-    {
-        if (_limitReportsNumber)
-        {
-            _reportsCountPerRule = new Dictionary<string, int>();
-        }
-        _areStatsInitialized = false;
-    }
 
     // start new project
     internal void StartNewProject(
@@ -77,22 +67,23 @@ internal sealed class CheckWrapper
 
     internal void ReportResult(BuildCheckResult result, ICheckContext checkContext, CheckConfigurationEffective config)
     {
-        if (_reportsCountPerRule is not null)
+        if (_limitReportsNumber)
         {
-            if (!_reportsCountPerRule.ContainsKey(result.CheckRule.Id))
+            if (!_reportsCountPerRule.TryGetValue(result.CheckRule.Id, out int currentCount))
             {
-                _reportsCountPerRule[result.CheckRule.Id] = 0;
+                currentCount = 0;
             }
-            _reportsCountPerRule[result.CheckRule.Id]++;
 
-            if (_reportsCountPerRule[result.CheckRule.Id] == MaxReportsNumberPerRule + 1)
+            if (currentCount > MaxReportsNumberPerRule)
             {
-                checkContext.DispatchAsCommentFromText(MessageImportance.Normal, $"The check '{Check.FriendlyName}' has exceeded the maximum number of results allowed for the rule '{result.CheckRule.Id}'. Any additional results will not be displayed.");
                 return;
             }
 
-            if (_reportsCountPerRule[result.CheckRule.Id] > MaxReportsNumberPerRule + 1)
+            _reportsCountPerRule[result.CheckRule.Id] = currentCount + 1;
+
+            if (currentCount == MaxReportsNumberPerRule)
             {
+                checkContext.DispatchAsCommentFromText(MessageImportance.Normal, $"The check '{Check.FriendlyName}' has exceeded the maximum number of results allowed for the rule '{result.CheckRule.Id}'. Any additional results will not be displayed.");
                 return;
             }
         }

--- a/src/Build/BuildCheck/Infrastructure/CheckWrapper.cs
+++ b/src/Build/BuildCheck/Infrastructure/CheckWrapper.cs
@@ -21,7 +21,7 @@ internal sealed class CheckWrapper
     /// <summary>
     /// Maximum amount of messages that could be sent per check rule.
     /// </summary>
-    public const int MaxMessageCountPerRule = 10;
+    public const int MaxReportsNumberPerRule = 10;
 
     /// <summary>
     /// Keeps track of number of reports sent per rule.
@@ -85,13 +85,13 @@ internal sealed class CheckWrapper
             }
             _reportsCountPerRule[result.CheckRule.Id]++;
 
-            if (_reportsCountPerRule[result.CheckRule.Id] == MaxMessageCountPerRule + 1)
+            if (_reportsCountPerRule[result.CheckRule.Id] == MaxReportsNumberPerRule + 1)
             {
                 checkContext.DispatchAsCommentFromText(MessageImportance.Normal, $"The check '{Check.FriendlyName}' has exceeded the maximum number of results allowed for the rule '{result.CheckRule.Id}'. Any additional results will not be displayed.");
                 return;
             }
 
-            if (_reportsCountPerRule[result.CheckRule.Id] > MaxMessageCountPerRule + 1)
+            if (_reportsCountPerRule[result.CheckRule.Id] > MaxReportsNumberPerRule + 1)
             {
                 return;
             }

--- a/src/Build/BuildCheck/Infrastructure/CheckWrapper.cs
+++ b/src/Build/BuildCheck/Infrastructure/CheckWrapper.cs
@@ -83,6 +83,9 @@ internal sealed class CheckWrapper
             eventArgs.BuildEventContext = checkContext.BuildEventContext;
             checkContext.DispatchBuildEvent(eventArgs);
 
+            // Big amount of build check messages may lead to build hang.
+            // See issue https://github.com/dotnet/msbuild/issues/10414
+            // As a temporary fix, we will limit the number of messages that could be reported by the check.
             if (_limitReportsNumber)
             {
                 if (_reportsCount >= MaxReportsNumberPerRule)

--- a/src/BuildCheck.UnitTests/EndToEndTests.cs
+++ b/src/BuildCheck.UnitTests/EndToEndTests.cs
@@ -95,7 +95,7 @@ public class EndToEndTests : IDisposable
         // each finding should be found just once - but reported twice, due to summary
         if (limitReportsCount)
         {
-            output.ShouldMatch(@"has exceeded the maximum number of results allowed for the rule");
+            output.ShouldMatch(@"has exceeded the maximum number of results allowed");
             Regex.Matches(output, "BC0202: .* Property").Count.ShouldBe(2);
             Regex.Matches(output, "BC0203: .* Property").Count.ShouldBe(38);
         }

--- a/src/BuildCheck.UnitTests/EndToEndTests.cs
+++ b/src/BuildCheck.UnitTests/EndToEndTests.cs
@@ -62,6 +62,30 @@ public class EndToEndTests : IDisposable
         Regex.Matches(output, "BC0203 .* Property").Count.ShouldBe(2);
     }
 
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void WarningsCountExceedsLimitTest(bool buildInOutOfProcessNode)
+    {
+        PrepareSampleProjectsAndConfig(
+            buildInOutOfProcessNode,
+            out TransientTestFile projectFile,
+            "PropsCheckTestWithLimit.csproj");
+
+        string output = RunnerUtilities.ExecBootstrapedMSBuild($"{projectFile.Path} -check", out bool success);
+        _env.Output.WriteLine(output);
+        _env.Output.WriteLine("=========================");
+        success.ShouldBeTrue(output);
+
+        output.ShouldMatch(@"has exceeded the maximum number of results allowed for the rule");
+
+        // each finding should be found just once - but reported twice, due to summary
+        Regex.Matches(output, "BC0202: .* Property").Count.ShouldBe(2);
+        Regex.Matches(output, "BC0203: .* Property").Count.ShouldBe(20);
+    }
+
+
     [Theory]
     [InlineData(true, true)]
     [InlineData(false, true)]

--- a/src/BuildCheck.UnitTests/EndToEndTests.cs
+++ b/src/BuildCheck.UnitTests/EndToEndTests.cs
@@ -97,12 +97,12 @@ public class EndToEndTests : IDisposable
         {
             output.ShouldMatch(@"has exceeded the maximum number of results allowed for the rule");
             Regex.Matches(output, "BC0202: .* Property").Count.ShouldBe(2);
-            Regex.Matches(output, "BC0203: .* Property").Count.ShouldBe(20);
+            Regex.Matches(output, "BC0203: .* Property").Count.ShouldBe(38);
         }
         else
         {
             Regex.Matches(output, "BC0202: .* Property").Count.ShouldBe(2);
-            Regex.Matches(output, "BC0203: .* Property").Count.ShouldBe(22);
+            Regex.Matches(output, "BC0203: .* Property").Count.ShouldBe(42);
         }
     }
 

--- a/src/BuildCheck.UnitTests/EndToEndTests.cs
+++ b/src/BuildCheck.UnitTests/EndToEndTests.cs
@@ -74,6 +74,7 @@ public class EndToEndTests : IDisposable
         PrepareSampleProjectsAndConfig(
             buildInOutOfProcessNode,
             out TransientTestFile projectFile,
+            out _,
             "PropsCheckTestWithLimit.csproj");
 
         if (limitReportsCount)

--- a/src/BuildCheck.UnitTests/TestAssets/SampleCheckIntegrationTest/PropsCheckTestWithLimit.csproj
+++ b/src/BuildCheck.UnitTests/TestAssets/SampleCheckIntegrationTest/PropsCheckTestWithLimit.csproj
@@ -11,6 +11,16 @@
         <MyProp09>$(MyProp09)</MyProp09>
         <MyProp10>$(MyProp10)</MyProp10>
         <MyProp11>$(MyProp11)</MyProp11>
+        <MyProp12>$(MyProp12)</MyProp12>
+        <MyProp13>$(MyProp13)</MyProp13>
+        <MyProp14>$(MyProp14)</MyProp14>
+        <MyProp15>$(MyProp15)</MyProp15>
+        <MyProp16>$(MyProp16)</MyProp16>
+        <MyProp17>$(MyProp17)</MyProp17>
+        <MyProp18>$(MyProp18)</MyProp18>
+        <MyProp19>$(MyProp19)</MyProp19>
+        <MyProp20>$(MyProp20)</MyProp20>
+        <MyProp21>$(MyProp21)</MyProp21>
     </PropertyGroup>
 
     <Target Name="PrintEnvVar">

--- a/src/BuildCheck.UnitTests/TestAssets/SampleCheckIntegrationTest/PropsCheckTestWithLimit.csproj
+++ b/src/BuildCheck.UnitTests/TestAssets/SampleCheckIntegrationTest/PropsCheckTestWithLimit.csproj
@@ -1,0 +1,22 @@
+<Project DefaultTargets="PrintEnvVar">
+    <PropertyGroup>
+        <MyProp01>$(MyProp01)</MyProp01>
+        <MyProp02>$(MyProp02)</MyProp02>
+        <MyProp03>$(MyProp03)</MyProp03>
+        <MyProp04>$(MyProp04)</MyProp04>
+        <MyProp05>$(MyProp05)</MyProp05>
+        <MyProp06>$(MyProp06)</MyProp06>
+        <MyProp07>$(MyProp07)</MyProp07>
+        <MyProp08>$(MyProp08)</MyProp08>
+        <MyProp09>$(MyProp09)</MyProp09>
+        <MyProp10>$(MyProp10)</MyProp10>
+        <MyProp11>$(MyProp11)</MyProp11>
+    </PropertyGroup>
+
+    <Target Name="PrintEnvVar">
+        <Message Text="MyPropT2 has value $(MyPropT2)" Importance="High" />
+        <PropertyGroup>
+            <MyPropT2>SomeValue</MyPropT2>
+        </PropertyGroup>
+    </Target>
+</Project>

--- a/src/Framework/Traits.cs
+++ b/src/Framework/Traits.cs
@@ -364,6 +364,11 @@ namespace Microsoft.Build.Framework
         /// </remarks>
         public readonly bool DoNotVersionBuildResult = Environment.GetEnvironmentVariable("MSBUILDDONOTVERSIONBUILDRESULT") == "1";
 
+        /// <summary>
+        /// Escape hatch to ensure build check does not limit amount of results.
+        /// </summary>
+        public readonly bool DoNotLimitBuildCheckResultsNumber = Environment.GetEnvironmentVariable("MSBUILDDONOTLIMITBUILDCHECKRESULTSNUMBER") == "1";
+
         private bool _sdkReferencePropertyExpansionInitialized;
         private SdkReferencePropertyExpansionMode? _sdkReferencePropertyExpansionValue;
 

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -2721,6 +2721,13 @@ namespace Microsoft.Build.CommandLine
 
                     isBuildCheckEnabled = IsBuildCheckEnabled(commandLineSwitches);
 
+                    // BuildCheck is not compatible with node reusing, see #10317.
+                    // Disable node reuse when build check is on.
+                    if (isBuildCheckEnabled)
+                    {
+                        enableNodeReuse = false;
+                    }
+
                     inputResultsCaches = ProcessInputResultsCaches(commandLineSwitches);
 
                     outputResultsCache = ProcessOutputResultsCache(commandLineSwitches);

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -2721,13 +2721,6 @@ namespace Microsoft.Build.CommandLine
 
                     isBuildCheckEnabled = IsBuildCheckEnabled(commandLineSwitches);
 
-                    // BuildCheck is not compatible with node reusing, see #10317.
-                    // Disable node reuse when build check is on.
-                    if (isBuildCheckEnabled)
-                    {
-                        enableNodeReuse = false;
-                    }
-
                     inputResultsCaches = ProcessInputResultsCaches(commandLineSwitches);
 
                     outputResultsCache = ProcessOutputResultsCache(commandLineSwitches);


### PR DESCRIPTION
Temporary fixes #10414

### Context
If BuildCheck emits a lot of messages, it is possible that the build will hang. Since the real reason of the hang is yet unclear, we have decided to limit number of messages emitted by build-in checks.

### Changes Made
- Enhanced a wrapper class `CheckWrapper` so that we can limit number of messages per check. 
- Added unit test.

### Testing
unit tests + manual testing