### PR TITLE
Ensure buildcheck lifetime per build

### DIFF
--- a/src/Build/BackEnd/Components/BuildRequestEngine/BuildRequestEngine.cs
+++ b/src/Build/BackEnd/Components/BuildRequestEngine/BuildRequestEngine.cs
@@ -283,8 +283,11 @@ namespace Microsoft.Build.BackEnd
                         throw new AggregateException(deactivateExceptions);
                     }
 
-                    var buildCheckManager = (_componentHost.GetComponent(BuildComponentType.BuildCheckManagerProvider) as IBuildCheckManagerProvider)!.Instance;
+                    IBuildCheckManagerProvider buildCheckProvider = (_componentHost.GetComponent(BuildComponentType.BuildCheckManagerProvider) as IBuildCheckManagerProvider);
+                    var buildCheckManager = buildCheckProvider!.Instance;
                     buildCheckManager.FinalizeProcessing(_nodeLoggingContext);
+                    // Clears the instance so that next call (on node reuse) to 'GetComponent' leads to reinitialization.
+                    buildCheckProvider.ShutdownComponent();
                 },
                 isLastTask: true);
 

--- a/src/Build/BackEnd/Components/Logging/LoggingService.cs
+++ b/src/Build/BackEnd/Components/Logging/LoggingService.cs
@@ -854,6 +854,8 @@ namespace Microsoft.Build.BackEnd.Logging
                 _onlyLogCriticalEvents = buildComponentHost.BuildParameters.OnlyLogCriticalEvents;
 
                 _serviceState = LoggingServiceState.Initialized;
+
+                _buildEngineDataRouter = (buildComponentHost.GetComponent(BuildComponentType.BuildCheckManagerProvider) as IBuildCheckManagerProvider)?.BuildEngineDataRouter;
             }
         }
 

--- a/src/Build/BackEnd/Components/Logging/LoggingServiceLogMethods.cs
+++ b/src/Build/BackEnd/Components/Logging/LoggingServiceLogMethods.cs
@@ -798,13 +798,17 @@ namespace Microsoft.Build.BackEnd.Logging
 
         #endregion
 
+#nullable enable
+        private IBuildEngineDataRouter? _buildEngineDataRouter;
+
         public void ProcessPropertyRead(PropertyReadInfo propertyReadInfo, CheckLoggingContext checkContext)
-            => BuildCheckManagerProvider.GlobalBuildEngineDataRouter?.ProcessPropertyRead(propertyReadInfo, checkContext);
+            => _buildEngineDataRouter?.ProcessPropertyRead(propertyReadInfo, checkContext);
 
         public void ProcessPropertyWrite(PropertyWriteInfo propertyWriteInfo, CheckLoggingContext checkContext)
-            => BuildCheckManagerProvider.GlobalBuildEngineDataRouter?.ProcessPropertyWrite(propertyWriteInfo, checkContext);
+            => _buildEngineDataRouter?.ProcessPropertyWrite(propertyWriteInfo, checkContext);
 
         public void ProcessProjectEvaluationStarted(ICheckContext checkContext, string projectFullPath)
-            => BuildCheckManagerProvider.GlobalBuildEngineDataRouter?.ProcessProjectEvaluationStarted(checkContext, projectFullPath);
+            => _buildEngineDataRouter?.ProcessProjectEvaluationStarted(checkContext, projectFullPath);
+#nullable disable
     }
 }


### PR DESCRIPTION
Fixes #10317

### Context
BuildCheckManager was accessed as a singleton in some cases - this could lead to reusal of configuration and opt-in


### Changes Made
* Got rid of the singleton
* Ensured that the component is cleared upon build end

### Testing
End-2-end test verifying the proper picking of opt-in and editorconfig changes (the test is failing without the fix)

### Notes
MSBuild server scenario might need a closer look - more details in the issue
