### PR TITLE
Upgrade system.text.json to 8.0.4

### DIFF
--- a/eng/SourceBuildPrebuiltBaseline.xml
+++ b/eng/SourceBuildPrebuiltBaseline.xml
@@ -15,7 +15,7 @@
     <UsagePattern IdentityGlob="System.Security.Cryptography.Pkcs/*8.0.0*" />
     <UsagePattern IdentityGlob="System.Security.Cryptography.ProtectedData/*8.0.0*" />
     <UsagePattern IdentityGlob="System.Security.Cryptography.Xml/*8.0.0*" />
-    <UsagePattern IdentityGlob="System.Text.Json/*8.0.3*" />
+    <UsagePattern IdentityGlob="System.Text.Json/*8.0.4*" />
     <UsagePattern IdentityGlob="System.Threading.Tasks.Dataflow/*8.0.0*" />
     <UsagePattern IdentityGlob="System.Formats.Asn1/*8.0.1*" />
   </IgnorePatterns>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -53,7 +53,7 @@
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-runtime</Uri>
       <Sha>5535e31a712343a63f5d7d796cd874e563e5ac14</Sha>
     </Dependency>
-    <Dependency Name="System.Text.Json" Version="8.0.3">
+    <Dependency Name="System.Text.Json" Version="8.0.4">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-runtime</Uri>
       <Sha>9f4b1f5d664afdfc80e1508ab7ed099dff210fbd</Sha>
     </Dependency>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,7 +2,7 @@
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the MIT license. See License.txt in the project root for full license information. -->
 <Project>
   <PropertyGroup>
-    <VersionPrefix>17.11.8</VersionPrefix><DotNetFinalVersionKind>release</DotNetFinalVersionKind>
+    <VersionPrefix>17.11.9</VersionPrefix><DotNetFinalVersionKind>release</DotNetFinalVersionKind>
     <PackageValidationBaselineVersion>17.10.4</PackageValidationBaselineVersion>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>
     <PreReleaseVersionLabel>servicing</PreReleaseVersionLabel>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,10 +2,10 @@
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the MIT license. See License.txt in the project root for full license information. -->
 <Project>
   <PropertyGroup>
-    <VersionPrefix>17.11.7</VersionPrefix><DotNetFinalVersionKind>release</DotNetFinalVersionKind>
+    <VersionPrefix>17.11.8</VersionPrefix><DotNetFinalVersionKind>release</DotNetFinalVersionKind>
     <PackageValidationBaselineVersion>17.10.4</PackageValidationBaselineVersion>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>
-    <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
+    <PreReleaseVersionLabel>servicing</PreReleaseVersionLabel>
     <DotNetUseShippingVersions>true</DotNetUseShippingVersions>
     <!-- Workaround for https://github.com/dotnet/roslyn/issues/35793 -->
     <SemanticVersioningV1>true</SemanticVersioningV1>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -38,7 +38,7 @@
     <SystemResourcesExtensionsVersion>8.0.0</SystemResourcesExtensionsVersion>
     <SystemSecurityPrincipalWindowsVersion>5.0.0</SystemSecurityPrincipalWindowsVersion>
     <SystemTextEncodingCodePagesVersion>7.0.0</SystemTextEncodingCodePagesVersion>
-    <SystemTextJsonVersion>8.0.3</SystemTextJsonVersion>
+    <SystemTextJsonVersion>8.0.4</SystemTextJsonVersion>
     <SystemThreadingChannelsVersion>8.0.0</SystemThreadingChannelsVersion>
     <SystemThreadingTasksDataflowVersion>8.0.0</SystemThreadingTasksDataflowVersion>
     <SystemFormatsAsn1Version>8.0.1</SystemFormatsAsn1Version>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,8 +2,7 @@
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the MIT license. See License.txt in the project root for full license information. -->
 <Project>
   <PropertyGroup>
-    <VersionPrefix>17.11.9</VersionPrefix>
-    <DotNetFinalVersionKind>release</DotNetFinalVersionKind>
+    <VersionPrefix>17.11.9</VersionPrefix><DotNetFinalVersionKind>release</DotNetFinalVersionKind>
     <PackageValidationBaselineVersion>17.10.4</PackageValidationBaselineVersion>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>
     <PreReleaseVersionLabel>servicing</PreReleaseVersionLabel>

--- a/src/MSBuild/app.amd64.config
+++ b/src/MSBuild/app.amd64.config
@@ -134,8 +134,8 @@
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="System.Text.Json" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-          <bindingRedirect oldVersion="0.0.0.0-8.0.0.3" newVersion="8.0.0.3" />
-          <codeBase version="8.0.0.3" href="..\System.Text.Json.dll"/>
+          <bindingRedirect oldVersion="0.0.0.0-8.0.0.4" newVersion="8.0.0.4" />
+          <codeBase version="8.0.0.4" href="..\System.Text.Json.dll"/>
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="System.Threading.Channels" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />

--- a/src/MSBuild/app.config
+++ b/src/MSBuild/app.config
@@ -94,7 +94,7 @@
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="System.Text.Json" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-          <bindingRedirect oldVersion="0.0.0.0-8.0.0.3" newVersion="8.0.0.3" />
+          <bindingRedirect oldVersion="0.0.0.0-8.0.0.4" newVersion="8.0.0.4" />
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="System.Threading.Tasks.Dataflow" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />


### PR DESCRIPTION
Work item (Internal use): DevDiv2239615
### Summary
Upgrading System.Text.Json to 8.0.4 due a project build error when using SDK 9.0 and VS17.11.

### Customer Impact
Unable to build / run projects within Visual Studio using the specified versions. Customer reported at https://github.com/dotnet/sdk/issues/43339.

### Regression?
Yes, from .NET SDK 9.0.100-preview.7, caused by https://github.com/NuGet/NuGet.Client/pull/5939 which updated the NuGet reference to `System.Text.Json` _on .NET Framework 4.7.2_ to a version between what VS 17.11 provides (8.0.0.3) and what the SDK provides (9.0.0.0).

### Testing
Existing tests; VS automated tests and a manual scenario test will be done before final VS merge.

### Risk
Low, package upgrade should not change any behavior within MSBuild but requires coordination with VS.