### PR TITLE
Recognize direct properties access in ProjectInstance

### DIFF
--- a/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
@@ -1369,14 +1369,14 @@ namespace Microsoft.Build.BackEnd
             // Ensure everything that is required is available at this time
             if (project != null && buildEventContext != null && loggingService != null && buildEventContext.ProjectInstanceId != BuildEventContext.InvalidProjectInstanceId)
             {
-                if (String.Equals(project.GetPropertyValue(MSBuildConstants.TreatWarningsAsErrors)?.Trim(), "true", StringComparison.OrdinalIgnoreCase))
+                if (String.Equals(project.GetEngineRequiredPropertyValue(MSBuildConstants.TreatWarningsAsErrors)?.Trim(), "true", StringComparison.OrdinalIgnoreCase))
                 {
                     // If <MSBuildTreatWarningsAsErrors was specified then an empty ISet<string> signals the IEventSourceSink to treat all warnings as errors
                     loggingService.AddWarningsAsErrors(buildEventContext, new HashSet<string>());
                 }
                 else
                 {
-                    ISet<string> warningsAsErrors = ParseWarningCodes(project.GetPropertyValue(MSBuildConstants.WarningsAsErrors));
+                    ISet<string> warningsAsErrors = ParseWarningCodes(project.GetEngineRequiredPropertyValue(MSBuildConstants.WarningsAsErrors));
 
                     if (warningsAsErrors?.Count > 0)
                     {
@@ -1384,14 +1384,14 @@ namespace Microsoft.Build.BackEnd
                     }
                 }
 
-                ISet<string> warningsNotAsErrors = ParseWarningCodes(project.GetPropertyValue(MSBuildConstants.WarningsNotAsErrors));
+                ISet<string> warningsNotAsErrors = ParseWarningCodes(project.GetEngineRequiredPropertyValue(MSBuildConstants.WarningsNotAsErrors));
 
                 if (warningsNotAsErrors?.Count > 0)
                 {
                     loggingService.AddWarningsNotAsErrors(buildEventContext, warningsNotAsErrors);
                 }
 
-                ISet<string> warningsAsMessages = ParseWarningCodes(project.GetPropertyValue(MSBuildConstants.WarningsAsMessages));
+                ISet<string> warningsAsMessages = ParseWarningCodes(project.GetEngineRequiredPropertyValue(MSBuildConstants.WarningsAsMessages));
 
                 if (warningsAsMessages?.Count > 0)
                 {

--- a/src/Build/BuildCheck/Infrastructure/InternalOM/PropertyReadInfo.cs
+++ b/src/Build/BuildCheck/Infrastructure/InternalOM/PropertyReadInfo.cs
@@ -21,4 +21,13 @@ internal readonly record struct PropertyReadInfo(
     int EndIndex,
     IMSBuildElementLocation ElementLocation,
     bool IsUninitialized,
-    PropertyReadContext PropertyReadContext);
+    PropertyReadContext PropertyReadContext)
+{
+    internal PropertyReadInfo(
+        string PropertyName,
+        IMSBuildElementLocation ElementLocation,
+        bool IsUninitialized,
+        PropertyReadContext PropertyReadContext)
+        : this(PropertyName, 0, PropertyName.Length - 1, ElementLocation, IsUninitialized, PropertyReadContext)
+    { }
+}

--- a/src/Build/Graph/ProjectInterpretation.cs
+++ b/src/Build/Graph/ProjectInterpretation.cs
@@ -103,7 +103,7 @@ namespace Microsoft.Build.Graph
             }
 
             SolutionConfiguration solutionConfiguration = null;
-            string solutionConfigurationXml = requesterInstance.GetPropertyValue(SolutionProjectGenerator.CurrentSolutionConfigurationContents);
+            string solutionConfigurationXml = requesterInstance.GetEngineRequiredPropertyValue(SolutionProjectGenerator.CurrentSolutionConfigurationContents);
             if (!string.IsNullOrWhiteSpace(solutionConfigurationXml))
             {
                 solutionConfiguration = new SolutionConfiguration(solutionConfigurationXml);
@@ -123,7 +123,7 @@ namespace Microsoft.Build.Graph
                 }
 
                 string projectReferenceFullPath = projectReferenceItem.GetMetadataValue(FullPathMetadataName);
-                bool enableDynamicPlatformResolution = ConversionUtilities.ValidBooleanTrue(requesterInstance.GetPropertyValue(EnableDynamicPlatformResolutionPropertyName));
+                bool enableDynamicPlatformResolution = ConversionUtilities.ValidBooleanTrue(requesterInstance.GetEngineRequiredPropertyValue(EnableDynamicPlatformResolutionPropertyName));
 
                 PropertyDictionary<ProjectPropertyInstance> referenceGlobalProperties = GetGlobalPropertiesForItem(
                     projectReferenceItem,
@@ -161,7 +161,7 @@ namespace Microsoft.Build.Graph
                     else
                     {
                         // Note: ShouldUnsetParentConfigurationAndPlatform defaults to true in the AssignProjectConfiguration target when building a solution, so check that it's not false instead of checking that it's true.
-                        bool shouldUnsetParentConfigurationAndPlatform = !ConversionUtilities.ValidBooleanFalse(requesterInstance.GetPropertyValue(ShouldUnsetParentConfigurationAndPlatformPropertyName));
+                        bool shouldUnsetParentConfigurationAndPlatform = !ConversionUtilities.ValidBooleanFalse(requesterInstance.GetEngineRequiredPropertyValue(ShouldUnsetParentConfigurationAndPlatformPropertyName));
                         if (shouldUnsetParentConfigurationAndPlatform)
                         {
                             referenceGlobalProperties.Remove(ConfigurationMetadataName);
@@ -178,8 +178,8 @@ namespace Microsoft.Build.Graph
                 // unless the project isn't known to the solution.
                 if (enableDynamicPlatformResolution && !configurationDefined && !projectReferenceItem.HasMetadata(SetPlatformMetadataName))
                 {
-                    string requesterPlatform = requesterInstance.GetPropertyValue("Platform");
-                    string requesterPlatformLookupTable = requesterInstance.GetPropertyValue("PlatformLookupTable");
+                    string requesterPlatform = requesterInstance.GetEngineRequiredPropertyValue("Platform");
+                    string requesterPlatformLookupTable = requesterInstance.GetEngineRequiredPropertyValue("PlatformLookupTable");
 
                     var projectInstance = projectInstanceFactory(
                         projectReferenceFullPath,
@@ -188,7 +188,7 @@ namespace Microsoft.Build.Graph
 
                     string overridePlatformNegotiationMetadataValue = projectReferenceItem.GetMetadataValue(OverridePlatformNegotiationValue);
 
-                    var selectedPlatform = PlatformNegotiation.GetNearestPlatform(overridePlatformNegotiationMetadataValue, projectInstance.GetPropertyValue(PlatformMetadataName), projectInstance.GetPropertyValue(PlatformsMetadataName), projectInstance.GetPropertyValue(PlatformLookupTableMetadataName), requesterInstance.GetPropertyValue(PlatformLookupTableMetadataName), projectInstance.FullPath, requesterInstance.GetPropertyValue(PlatformMetadataName));
+                    var selectedPlatform = PlatformNegotiation.GetNearestPlatform(overridePlatformNegotiationMetadataValue, projectInstance.GetEngineRequiredPropertyValue(PlatformMetadataName), projectInstance.GetEngineRequiredPropertyValue(PlatformsMetadataName), projectInstance.GetEngineRequiredPropertyValue(PlatformLookupTableMetadataName), requesterInstance.GetEngineRequiredPropertyValue(PlatformLookupTableMetadataName), projectInstance.FullPath, requesterInstance.GetEngineRequiredPropertyValue(PlatformMetadataName));
 
                     if (selectedPlatform.Equals(String.Empty))
                     {
@@ -559,15 +559,15 @@ namespace Microsoft.Build.Graph
 
             // special case for Quickbuild which updates msbuild binaries independent of props/targets. Remove this when all QB repos will have
             // migrated to new enough Visual Studio versions whose Microsoft.Managed.After.Targets enable transitive references.
-            if (string.IsNullOrWhiteSpace(projectInstance.GetPropertyValue(AddTransitiveProjectReferencesInStaticGraphPropertyName)) &&
-                MSBuildStringIsTrue(projectInstance.GetPropertyValue("UsingMicrosoftNETSdk")) &&
-                MSBuildStringIsFalse(projectInstance.GetPropertyValue("DisableTransitiveProjectReferences")))
+            if (string.IsNullOrWhiteSpace(projectInstance.GetEngineRequiredPropertyValue(AddTransitiveProjectReferencesInStaticGraphPropertyName)) &&
+                MSBuildStringIsTrue(projectInstance.GetEngineRequiredPropertyValue("UsingMicrosoftNETSdk")) &&
+                MSBuildStringIsFalse(projectInstance.GetEngineRequiredPropertyValue("DisableTransitiveProjectReferences")))
             {
                 return true;
             }
 
             return MSBuildStringIsTrue(
-                projectInstance.GetPropertyValue(AddTransitiveProjectReferencesInStaticGraphPropertyName));
+                projectInstance.GetEngineRequiredPropertyValue(AddTransitiveProjectReferencesInStaticGraphPropertyName));
         }
 
         private static bool MSBuildStringIsTrue(string msbuildString) =>

--- a/src/Build/Instance/ProjectInstance.cs
+++ b/src/Build/Instance/ProjectInstance.cs
@@ -19,6 +19,7 @@ using Microsoft.Build.Construction;
 using Microsoft.Build.Definition;
 using Microsoft.Build.Evaluation;
 using Microsoft.Build.Evaluation.Context;
+using Microsoft.Build.Experimental.BuildCheck.Infrastructure;
 using Microsoft.Build.FileSystem;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Instance;
@@ -1894,6 +1895,11 @@ namespace Microsoft.Build.Execution
             {
                 unescapedValue = String.Empty;
             }
+            else
+            {
+                _loggingContext?.ProcessPropertyRead(
+                    new PropertyReadInfo(name, ElementLocation.EmptyLocation, false, PropertyReadContext.Other));
+            }
 
             return unescapedValue;
         }
@@ -1912,6 +1918,8 @@ namespace Microsoft.Build.Execution
 
             ProjectPropertyInstance property = ProjectPropertyInstance.Create(name, evaluatedValue, false /* may not be reserved */, _isImmutable);
             _properties.Set(property);
+
+            _loggingContext?.ProcessPropertyWrite(new PropertyWriteInfo(name, false, ElementLocation.EmptyLocation));
 
             return property;
         }

--- a/src/Build/Instance/ProjectInstance.cs
+++ b/src/Build/Instance/ProjectInstance.cs
@@ -1895,6 +1895,16 @@ namespace Microsoft.Build.Execution
             {
                 unescapedValue = String.Empty;
             }
+
+            return unescapedValue;
+        }
+
+        internal string GetEngineRequiredPropertyValue(string name)
+        {
+            if (!_properties.TryGetPropertyUnescapedValue(name, out string unescapedValue))
+            {
+                unescapedValue = String.Empty;
+            }
             else
             {
                 _loggingContext?.ProcessPropertyRead(

--- a/src/BuildCheck.UnitTests/TestAssets/SampleCheckIntegrationTest/PropsCheckTest.csproj
+++ b/src/BuildCheck.UnitTests/TestAssets/SampleCheckIntegrationTest/PropsCheckTest.csproj
@@ -9,6 +9,7 @@
 
     <PropertyGroup Condition="'$(MyProp12)' == ''">
         <MyProp13>$(MyProp11)</MyProp13>
+        <MSBuildTreatWarningsAsErrors>false</MSBuildTreatWarningsAsErrors>
     </PropertyGroup>
 
     <!--


### PR DESCRIPTION
Fixes #10604

### Context
`MSBuildTreatWarningsAsErrors` access was not recognized by PropertiesCheck - since it was bypassing Expander.

### Changes Made
Added routing of properties access to `ProjectInstance`

### Testing
Added unit test case specifically for `MSBuildTreatWarningsAsErrors` (fails without fix)

### Notes
Not handling accesses via `Project` - as that would get much more involved and is specific for API calls and VS - which are both currently unsupported scenarios