### PR TITLE
Proto/buildcheck warns promotability

### DIFF
--- a/src/Build.UnitTests/BackEnd/MockLoggingService.cs
+++ b/src/Build.UnitTests/BackEnd/MockLoggingService.cs
@@ -550,6 +550,33 @@ namespace Microsoft.Build.UnitTests.BackEnd
             return new BuildEventContext(0, 0, 0, 0);
         }
 
+        public void LogProjectStarted(ProjectStartedEventArgs args)
+        { }
+
+        public ProjectStartedEventArgs CreateProjectStarted(
+            BuildEventContext nodeBuildEventContext,
+            int submissionId,
+            int configurationId,
+            BuildEventContext parentBuildEventContext,
+            string projectFile,
+            string targetNames,
+            IEnumerable<DictionaryEntry> properties,
+            IEnumerable<DictionaryEntry> items,
+            int evaluationId = BuildEventContext.InvalidEvaluationId,
+            int projectContextId = BuildEventContext.InvalidProjectContextId)
+        {
+            var ctx = new BuildEventContext(0, 0, 0, 0);
+            return new ProjectStartedEventArgs(
+                configurationId,
+                message: null,
+                helpKeyword: null,
+                projectFile,
+                targetNames,
+                properties,
+                items,
+                parentBuildEventContext);
+        }
+
         /// <summary>
         /// Logs a project finished event
         /// </summary>

--- a/src/Build.UnitTests/BackEnd/MockLoggingService.cs
+++ b/src/Build.UnitTests/BackEnd/MockLoggingService.cs
@@ -565,7 +565,6 @@ namespace Microsoft.Build.UnitTests.BackEnd
             int evaluationId = BuildEventContext.InvalidEvaluationId,
             int projectContextId = BuildEventContext.InvalidProjectContextId)
         {
-            var ctx = new BuildEventContext(0, 0, 0, 0);
             return new ProjectStartedEventArgs(
                 configurationId,
                 message: null,

--- a/src/Build/BackEnd/Components/Logging/ILoggingService.cs
+++ b/src/Build/BackEnd/Components/Logging/ILoggingService.cs
@@ -555,6 +555,20 @@ namespace Microsoft.Build.BackEnd.Logging
             int evaluationId = BuildEventContext.InvalidEvaluationId,
             int projectContextId = BuildEventContext.InvalidProjectContextId);
 
+        void LogProjectStarted(ProjectStartedEventArgs args);
+
+        ProjectStartedEventArgs CreateProjectStarted(
+            BuildEventContext nodeBuildEventContext,
+            int submissionId,
+            int configurationId,
+            BuildEventContext parentBuildEventContext,
+            string projectFile,
+            string targetNames,
+            IEnumerable<DictionaryEntry> properties,
+            IEnumerable<DictionaryEntry> items,
+            int evaluationId = BuildEventContext.InvalidEvaluationId,
+            int projectContextId = BuildEventContext.InvalidProjectContextId);
+
         /// <summary>
         /// Log that the project has finished
         /// </summary>

--- a/src/Build/BackEnd/Components/Logging/LoggingService.cs
+++ b/src/Build/BackEnd/Components/Logging/LoggingService.cs
@@ -212,6 +212,11 @@ namespace Microsoft.Build.BackEnd.Logging
         private readonly ISet<int> _buildSubmissionIdsThatHaveLoggedErrors = new HashSet<int>();
 
         /// <summary>
+        /// A list of build submission IDs that have logged errors through buildcheck.  If an error is logged outside of a submission, the submission ID is <see cref="BuildEventContext.InvalidSubmissionId"/>.
+        /// </summary>
+        private readonly ISet<int> _buildSubmissionIdsThatHaveLoggedBuildcheckErrors = new HashSet<int>();
+
+        /// <summary>
         /// A list of warnings to treat as errors for an associated <see cref="BuildEventContext"/>.  If an empty set, all warnings are treated as errors.
         /// </summary>
         private IDictionary<WarningsConfigKey, ISet<string>> _warningsAsErrorsByProject;
@@ -620,8 +625,16 @@ namespace Microsoft.Build.BackEnd.Logging
         /// <returns><code>true</code> if the build submission logged an errors, otherwise <code>false</code>.</returns>
         public bool HasBuildSubmissionLoggedErrors(int submissionId)
         {
-            // Do not condition this based on warnAsErrors - as for buildcheck errors those do happen only in main node
-            // and hence the build result from remote node is returned as succeeded
+            if (_buildSubmissionIdsThatHaveLoggedBuildcheckErrors.Contains(submissionId))
+            {
+                return true;
+            }
+
+            // Warnings as errors are not tracked if the user did not specify to do so
+            if (WarningsAsErrors == null && _warningsAsErrorsByProject == null)
+            {
+                return false;
+            }
 
             // Determine if any of the event sinks have logged an error with this submission ID
             return _buildSubmissionIdsThatHaveLoggedErrors?.Contains(submissionId) == true;
@@ -1640,8 +1653,17 @@ namespace Microsoft.Build.BackEnd.Logging
 
             if (buildEventArgs is BuildErrorEventArgs errorEvent)
             {
-                // Keep track of build submissions that have logged errors.  If there is no build context, add BuildEventContext.InvalidSubmissionId.
-                _buildSubmissionIdsThatHaveLoggedErrors.Add(errorEvent.BuildEventContext?.SubmissionId ?? BuildEventContext.InvalidSubmissionId);
+                int submissionId = errorEvent.BuildEventContext?.SubmissionId ?? BuildEventContext.InvalidSubmissionId;
+
+                if (buildEventArgs is BuildCheckResultError)
+                {
+                    _buildSubmissionIdsThatHaveLoggedBuildcheckErrors.Add(submissionId);
+                }
+                else
+                {
+                    // Keep track of build submissions that have logged errors.  If there is no build context, add BuildEventContext.InvalidSubmissionId.
+                    _buildSubmissionIdsThatHaveLoggedErrors.Add(submissionId);
+                }
             }
 
             // If this is BuildCheck-ed build - add the warnings promotability/demotability to the service

--- a/src/Build/BackEnd/Components/Logging/LoggingService.cs
+++ b/src/Build/BackEnd/Components/Logging/LoggingService.cs
@@ -620,11 +620,8 @@ namespace Microsoft.Build.BackEnd.Logging
         /// <returns><code>true</code> if the build submission logged an errors, otherwise <code>false</code>.</returns>
         public bool HasBuildSubmissionLoggedErrors(int submissionId)
         {
-            // Warnings as errors are not tracked if the user did not specify to do so
-            if (WarningsAsErrors == null && _warningsAsErrorsByProject == null)
-            {
-                return false;
-            }
+            // Do not condition this based on warnAsErrors - as for buildcheck errors those do happen only in main node
+            // and hence the build result from remote node is returned as succeeded
 
             // Determine if any of the event sinks have logged an error with this submission ID
             return _buildSubmissionIdsThatHaveLoggedErrors?.Contains(submissionId) == true;

--- a/src/Build/BackEnd/Components/Logging/LoggingServiceLogMethods.cs
+++ b/src/Build/BackEnd/Components/Logging/LoggingServiceLogMethods.cs
@@ -498,6 +498,39 @@ namespace Microsoft.Build.BackEnd.Logging
             int evaluationId = BuildEventContext.InvalidEvaluationId,
             int projectContextId = BuildEventContext.InvalidProjectContextId)
         {
+            var args = CreateProjectStarted(nodeBuildEventContext,
+                submissionId,
+                configurationId,
+                parentBuildEventContext,
+                projectFile,
+                targetNames,
+                properties,
+                items,
+                evaluationId,
+                projectContextId);
+
+            this.LogProjectStarted(args);
+
+            return args.BuildEventContext;
+        }
+
+        public void LogProjectStarted(ProjectStartedEventArgs buildEvent)
+        {
+            ProcessLoggingEvent(buildEvent);
+        }
+
+        public ProjectStartedEventArgs CreateProjectStarted(
+            BuildEventContext nodeBuildEventContext,
+            int submissionId,
+            int configurationId,
+            BuildEventContext parentBuildEventContext,
+            string projectFile,
+            string targetNames,
+            IEnumerable<DictionaryEntry> properties,
+            IEnumerable<DictionaryEntry> items,
+            int evaluationId = BuildEventContext.InvalidEvaluationId,
+            int projectContextId = BuildEventContext.InvalidProjectContextId)
+        {
             ErrorUtilities.VerifyThrow(nodeBuildEventContext != null, "Need a nodeBuildEventContext");
 
             if (projectContextId == BuildEventContext.InvalidProjectContextId)
@@ -560,9 +593,7 @@ namespace Microsoft.Build.BackEnd.Logging
                     buildRequestConfiguration.ToolsVersion);
             buildEvent.BuildEventContext = projectBuildEventContext;
 
-            ProcessLoggingEvent(buildEvent);
-
-            return projectBuildEventContext;
+            return buildEvent;
         }
 
         /// <summary>

--- a/src/Build/BackEnd/Components/Logging/NodeLoggingContext.cs
+++ b/src/Build/BackEnd/Components/Logging/NodeLoggingContext.cs
@@ -58,8 +58,15 @@ namespace Microsoft.Build.BackEnd.Logging
         /// <returns>The BuildEventContext to use for this project.</returns>
         internal ProjectLoggingContext LogProjectStarted(BuildRequestEntry requestEntry)
         {
+            (ProjectStartedEventArgs arg, ProjectLoggingContext ctx) = CreateProjectLoggingContext(requestEntry);
+            LoggingService.LogProjectStarted(arg);
+            return ctx;
+        }
+
+        internal (ProjectStartedEventArgs, ProjectLoggingContext) CreateProjectLoggingContext(BuildRequestEntry requestEntry)
+        {
             ErrorUtilities.VerifyThrow(this.IsValid, "Build not started.");
-            return new ProjectLoggingContext(this, requestEntry);
+            return ProjectLoggingContext.CreateLoggingContext(this, requestEntry);
         }
 
         /// <summary>

--- a/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
@@ -1106,11 +1106,11 @@ namespace Microsoft.Build.BackEnd
             ErrorUtilities.VerifyThrow(_targetBuilder != null, "Target builder is null");
 
             // We consider this the entrypoint for the project build for purposes of BuildCheck processing 
-            bool isRestoring = _requestEntry.RequestConfiguration.GlobalProperties[MSBuildConstants.MSBuildIsRestoring] is null;
+            bool isRestoring = _requestEntry.RequestConfiguration.GlobalProperties[MSBuildConstants.MSBuildIsRestoring] is not null;
 
             var buildCheckManager = isRestoring
-                ? (_componentHost.GetComponent(BuildComponentType.BuildCheckManagerProvider) as IBuildCheckManagerProvider)!.Instance
-                : null;
+                ? null
+                : (_componentHost.GetComponent(BuildComponentType.BuildCheckManagerProvider) as IBuildCheckManagerProvider)!.Instance;
 
             buildCheckManager?.SetDataSource(BuildCheckDataSource.BuildExecution);
 
@@ -1155,15 +1155,10 @@ namespace Microsoft.Build.BackEnd
                     _requestEntry.Request.BuildEventContext);
             }
 
-            _projectLoggingContext = _nodeLoggingContext.LogProjectStarted(_requestEntry);
-            buildCheckManager?.StartProjectRequest(
-                new CheckLoggingContext(_nodeLoggingContext.LoggingService, _projectLoggingContext.BuildEventContext),
-                _requestEntry.RequestConfiguration.ProjectFullPath);
-
+            
             try
             {
-                // Now that the project has started, parse a few known properties which indicate warning codes to treat as errors or messages
-                ConfigureWarningsAsErrorsAndMessages();
+                HandleProjectStarted(buildCheckManager);
 
                 // Make sure to extract known immutable folders from properties and register them for fast up-to-date check
                 ConfigureKnownImmutableFolders();
@@ -1272,6 +1267,31 @@ namespace Microsoft.Build.BackEnd
                 _requestEntry.RequestConfiguration.SavedCurrentDirectory = NativeMethodsShared.GetCurrentDirectory();
                 _requestEntry.RequestConfiguration.SavedEnvironmentVariables = CommunicationsUtilities.GetEnvironmentVariables();
             }
+        }
+
+        private void HandleProjectStarted(IBuildCheckManager buildCheckManager)
+        {
+            (ProjectStartedEventArgs args, ProjectLoggingContext ctx) = _nodeLoggingContext.CreateProjectLoggingContext(_requestEntry);
+
+            _projectLoggingContext = ctx;
+            ConfigureWarningsAsErrorsAndMessages();
+            ILoggingService loggingService = _projectLoggingContext?.LoggingService;
+            BuildEventContext projectBuildEventContext = _projectLoggingContext?.BuildEventContext;
+
+            // We can set the warning as errors and messages only after the project logging context has been created (as it creates the new ProjectContextId)
+            if (buildCheckManager != null && loggingService != null && projectBuildEventContext != null)
+            {
+                args.WarningsAsErrors = loggingService.GetWarningsAsErrors(projectBuildEventContext).ToHashSet(StringComparer.OrdinalIgnoreCase);
+                args.WarningsAsMessages = loggingService.GetWarningsAsMessages(projectBuildEventContext).ToHashSet(StringComparer.OrdinalIgnoreCase);
+                args.WarningsNotAsErrors = loggingService.GetWarningsNotAsErrors(projectBuildEventContext).ToHashSet(StringComparer.OrdinalIgnoreCase);
+            }
+
+            // We can log the event only after the warning as errors and messages have been set and added
+            loggingService?.LogProjectStarted(args);
+
+            buildCheckManager?.StartProjectRequest(
+                new CheckLoggingContext(_nodeLoggingContext.LoggingService, _projectLoggingContext!.BuildEventContext),
+                _requestEntry.RequestConfiguration.ProjectFullPath);
         }
 
         /// <summary>
@@ -1410,7 +1430,7 @@ namespace Microsoft.Build.BackEnd
             }
         }
 
-        private ISet<string> ParseWarningCodes(string warnings)
+        private static ISet<string> ParseWarningCodes(string warnings)
         {
             if (String.IsNullOrWhiteSpace(warnings))
             {

--- a/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -1156,7 +1157,7 @@ namespace Microsoft.Build.BackEnd
 
             _projectLoggingContext = _nodeLoggingContext.LogProjectStarted(_requestEntry);
             buildCheckManager?.StartProjectRequest(
-                _projectLoggingContext.BuildEventContext,
+                new CheckLoggingContext(_nodeLoggingContext.LoggingService, _projectLoggingContext.BuildEventContext),
                 _requestEntry.RequestConfiguration.ProjectFullPath);
 
             try

--- a/src/Build/BuildCheck/Infrastructure/BuildCheckBuildEventHandler.cs
+++ b/src/Build/BuildCheck/Infrastructure/BuildCheckBuildEventHandler.cs
@@ -36,7 +36,7 @@ internal class BuildCheckBuildEventHandler
             { typeof(ProjectEvaluationFinishedEventArgs), (BuildEventArgs e) => HandleProjectEvaluationFinishedEvent((ProjectEvaluationFinishedEventArgs)e) },
             { typeof(ProjectEvaluationStartedEventArgs), (BuildEventArgs e) => HandleProjectEvaluationStartedEvent((ProjectEvaluationStartedEventArgs)e) },
             { typeof(EnvironmentVariableReadEventArgs), (BuildEventArgs e) => HandleEnvironmentVariableReadEvent((EnvironmentVariableReadEventArgs)e) },
-            { typeof(ProjectStartedEventArgs), (BuildEventArgs e) => _buildCheckManager.StartProjectRequest(e.BuildEventContext!, ((ProjectStartedEventArgs)e).ProjectFile!) },
+            { typeof(ProjectStartedEventArgs), (BuildEventArgs e) => HandleProjectStartedRequest((ProjectStartedEventArgs)e) },
             { typeof(ProjectFinishedEventArgs), (BuildEventArgs e) => HandleProjectFinishedRequest((ProjectFinishedEventArgs)e) },
             { typeof(BuildCheckTracingEventArgs), (BuildEventArgs e) => HandleBuildCheckTracingEvent((BuildCheckTracingEventArgs)e) },
             { typeof(BuildCheckAcquisitionEventArgs), (BuildEventArgs e) => HandleBuildCheckAcquisitionEvent((BuildCheckAcquisitionEventArgs)e) },
@@ -97,6 +97,11 @@ internal class BuildCheckBuildEventHandler
                 eventArgs.ProjectFile!);
         }
     }
+
+    private void HandleProjectStartedRequest(ProjectStartedEventArgs eventArgs)
+        => _buildCheckManager.StartProjectRequest(
+            _checkContextFactory.CreateCheckContext(eventArgs.BuildEventContext!),
+            eventArgs!.ProjectFile!);
 
     private void HandleProjectFinishedRequest(ProjectFinishedEventArgs eventArgs)
         => _buildCheckManager.EndProjectRequest(

--- a/src/Build/BuildCheck/Infrastructure/CheckWrapper.cs
+++ b/src/Build/BuildCheck/Infrastructure/CheckWrapper.cs
@@ -39,9 +39,12 @@ internal sealed class CheckWrapper
     /// </summary>
     private readonly bool _limitReportsNumber = !Traits.Instance.EscapeHatches.DoNotLimitBuildCheckResultsNumber;
 
-    public CheckWrapper(Check check)
+    private readonly IResultReporter _resultReporter;
+
+    public CheckWrapper(Check check, IResultReporter resultReporter)
     {
         Check = check;
+        _resultReporter = resultReporter;
         _ruleTelemetryData = new BuildCheckRuleTelemetryData[check.SupportedRules.Count];
 
         InitializeTelemetryData(_ruleTelemetryData, check);
@@ -157,7 +160,7 @@ internal sealed class CheckWrapper
             _reportsCount++;
             BuildEventArgs eventArgs = result.ToEventArgs(config.Severity);
             eventArgs.BuildEventContext = checkContext.BuildEventContext;
-            checkContext.DispatchBuildEvent(eventArgs);
+            _resultReporter.ReportResult(eventArgs, checkContext);
 
             // Big amount of build check messages may lead to build hang.
             // See issue https://github.com/dotnet/msbuild/issues/10414

--- a/src/Build/BuildCheck/Infrastructure/IBuildCheckManager.cs
+++ b/src/Build/BuildCheck/Infrastructure/IBuildCheckManager.cs
@@ -79,7 +79,7 @@ internal interface IBuildCheckManager
 
     void EndProjectEvaluation(BuildEventContext buildEventContext);
 
-    void StartProjectRequest(BuildEventContext buildEventContext, string projectFullPath);
+    void StartProjectRequest(ICheckContext checksContext, string projectFullPath);
 
     void EndProjectRequest(ICheckContext checksContext, string projectFullPath);
 

--- a/src/Build/BuildCheck/Infrastructure/NullBuildCheckManager.cs
+++ b/src/Build/BuildCheck/Infrastructure/NullBuildCheckManager.cs
@@ -71,7 +71,7 @@ internal class NullBuildCheckManager : IBuildCheckManager, IBuildEngineDataRoute
     {
     }
 
-    public void StartProjectRequest(BuildEventContext buildEventContext, string projectFullPath)
+    public void StartProjectRequest(ICheckContext checksContext, string projectFullPath)
     {
     }
 

--- a/src/BuildCheck.UnitTests/TestAssets/SampleCheckIntegrationTest/Project1.csproj
+++ b/src/BuildCheck.UnitTests/TestAssets/SampleCheckIntegrationTest/Project1.csproj
@@ -15,6 +15,7 @@
 
     <PropertyGroup>
         <ReadFromEnv>$(TestFromEvaluation)</ReadFromEnv>
+        <MSBuildWarningsAsErrors>$(warn2err)</MSBuildWarningsAsErrors>
     </PropertyGroup>
 
    <Target Name="Hello">

--- a/src/BuildCheck.UnitTests/TestAssets/SampleCheckIntegrationTest/Project1.csproj
+++ b/src/BuildCheck.UnitTests/TestAssets/SampleCheckIntegrationTest/Project1.csproj
@@ -16,6 +16,7 @@
     <PropertyGroup>
         <ReadFromEnv>$(TestFromEvaluation)</ReadFromEnv>
         <MSBuildWarningsAsErrors>$(warn2err)</MSBuildWarningsAsErrors>
+        <MSBuildWarningsAsMessages>$(warn2msg)</MSBuildWarningsAsMessages>
     </PropertyGroup>
 
    <Target Name="Hello">

--- a/src/Framework/BuildCheck/BuildCheckEventArgs.cs
+++ b/src/Framework/BuildCheck/BuildCheckEventArgs.cs
@@ -102,22 +102,14 @@ internal sealed class BuildCheckTracingEventArgs(
             DiagnosticSeverity defaultSeverity = (DiagnosticSeverity)reader.Read7BitEncodedInt();
             int explicitSeveritiesCount = reader.Read7BitEncodedInt();
             HashSet<DiagnosticSeverity> explicitSeverities =
-#if NETSTANDARD2_0
-                new HashSet<DiagnosticSeverity>();
-#else
-                new HashSet<DiagnosticSeverity>(explicitSeveritiesCount);
-#endif
+                EnumerableExtensions.NewHashSet<DiagnosticSeverity>(explicitSeveritiesCount);
             for (int j = 0; j < explicitSeveritiesCount; j++)
             {
                 explicitSeverities.Add((DiagnosticSeverity)reader.Read7BitEncodedInt());
             }
             int projectNamesWhereEnabledCount = reader.Read7BitEncodedInt();
             HashSet<string> projectNamesWhereEnabled =
-#if NETSTANDARD2_0
-                new HashSet<string>();
-#else
-                new HashSet<string>(projectNamesWhereEnabledCount);
-#endif
+                EnumerableExtensions.NewHashSet<string>(projectNamesWhereEnabledCount);
             for (int j = 0; j < projectNamesWhereEnabledCount; j++)
             {
                 projectNamesWhereEnabled.Add(reader.ReadString());

--- a/src/Framework/BuildCheck/EnumerableExtensions.cs
+++ b/src/Framework/BuildCheck/EnumerableExtensions.cs
@@ -32,6 +32,36 @@ internal static class EnumerableExtensions
         yield return item;
     }
 
+    public static HashSet<T> NewHashSet<T>(int capacity)
+        => NewHashSet<T>(capacity, null);
+
+    public static HashSet<T> NewHashSet<T>(IEqualityComparer<T> equalityComparer)
+        => NewHashSet<T>(0, equalityComparer);
+
+    public static HashSet<T> NewHashSet<T>(int capacity, IEqualityComparer<T>? equalityComparer)
+    {
+#if NETSTANDARD2_0
+        return new HashSet<T>(equalityComparer);
+#else
+        return new HashSet<T>(capacity, equalityComparer);
+#endif
+    }
+
+    public static HashSet<T>? ToHashSet<T>(this ICollection<T>? source, IEqualityComparer<T>? equalityComparer = null)
+    {
+        if (source is null)
+        {
+            return null;
+        }
+
+        if (source is HashSet<T> set)
+        {
+            return set;
+        }
+
+        return new HashSet<T>(source, equalityComparer);
+    }
+
 #if !NET
     /// <summary>
     /// Returns a read-only <see cref="ReadOnlyDictionary{TKey, TValue}"/> wrapper

--- a/src/Framework/BuildEventContext.cs
+++ b/src/Framework/BuildEventContext.cs
@@ -115,11 +115,15 @@ namespace Microsoft.Build.Framework
         }
 
         #endregion
-
-        internal BuildEventContext WithInstanceId(int projectInstanceId)
+        internal BuildEventContext WithInstanceIdAndContextId(int projectInstanceId, int projectContextId)
         {
-            return new BuildEventContext(_submissionId, _nodeId, _evaluationId, projectInstanceId, _projectContextId,
+            return new BuildEventContext(_submissionId, _nodeId, _evaluationId, projectInstanceId, projectContextId,
                 _targetId, _taskId);
+        }
+
+        internal BuildEventContext WithInstanceIdAndContextId(BuildEventContext other)
+        {
+            return WithInstanceIdAndContextId(other.ProjectInstanceId, other.ProjectContextId);
         }
 
         #region Properties

--- a/src/Framework/BuildEventContext.cs
+++ b/src/Framework/BuildEventContext.cs
@@ -116,6 +116,12 @@ namespace Microsoft.Build.Framework
 
         #endregion
 
+        internal BuildEventContext WithInstanceId(int projectInstanceId)
+        {
+            return new BuildEventContext(_submissionId, _nodeId, _evaluationId, projectInstanceId, _projectContextId,
+                _targetId, _taskId);
+        }
+
         #region Properties
 
         /// <summary>

--- a/src/Framework/ProjectStartedEventArgs.cs
+++ b/src/Framework/ProjectStartedEventArgs.cs
@@ -399,9 +399,9 @@ namespace Microsoft.Build.Framework
                 }
             }
 
-            WriteSet(writer, WarningsAsErrors);
-            WriteSet(writer, WarningsNotAsErrors);
-            WriteSet(writer, WarningsAsMessages);
+            WriteCollection(writer, WarningsAsErrors);
+            WriteCollection(writer, WarningsNotAsErrors);
+            WriteCollection(writer, WarningsAsMessages);
         }
 
         /// <summary>
@@ -471,29 +471,29 @@ namespace Microsoft.Build.Framework
                 properties = dictionaryList;
             }
 
-            WarningsAsErrors = ReadSet(reader);
-            WarningsNotAsErrors = ReadSet(reader);
-            WarningsAsMessages = ReadSet(reader);
+            WarningsAsErrors = ReadStringSet(reader);
+            WarningsNotAsErrors = ReadStringSet(reader);
+            WarningsAsMessages = ReadStringSet(reader);
         }
 
-        private static void WriteSet(BinaryWriter writer, ICollection<string>? set)
+        private static void WriteCollection(BinaryWriter writer, ICollection<string>? collection)
         {
-            if (set == null)
+            if (collection == null)
             {
                 writer.Write((byte)0);
             }
             else
             {
                 writer.Write((byte)1);
-                writer.Write(set.Count);
-                foreach (string item in set)
+                writer.Write(collection.Count);
+                foreach (string item in collection)
                 {
                     writer.Write(item);
                 }
             }
         }
 
-        private static ISet<string>? ReadSet(BinaryReader reader)
+        private static ISet<string>? ReadStringSet(BinaryReader reader)
         {
             if (reader.ReadByte() == 0)
             {


### PR DESCRIPTION
Fixes #10618 and #10071

### Context
There are 2 problems:

* BuildCheck diagnostics created during evaluation, couldn't be promoted/demoted - as Warn2Errors/Warn2Messages is only set AFTER evaluation is done.
* The WarnAsErrors and WarnAsMessges and others (WarningsNotAsErrors, global, per code, per project ...) used to be set only in the logging service that performed the build request, but not in the main node. Hence if buildcheck errors were created in main node - there were not properly processed

### Changes Made
* BuildCheck warnings created during evaluation are buffered and reported deffered, only once the Evaluation is done
* Warn2Errors/Warn2Messages state is being (de)serialized and communicated from worker node to main node via `ProjectStartedEventArgs`

### Alternatives

We still need the delayed reporting of the BuildCheckWarnings that happens during evaluation - there is no way around it (otherwise they would not respect WarnAsError property that's only recognized during evaluation).

We as well need to send the WarnAsError information back to main node - as it is only present in the worker node, but the BuildCheck creates diagnostics in the main node.

There are alternatives in how we send the WarnAsError information back to main node:

1. Sending it before `ProjectEvaluationFinishedEventArgs` - only a tailored event for this specific eval info would be possible (as no other event has guarantee of such data being available) - that has disadvantages of introducing new event + disadvantages of using `ProjectEvaluationFinishedEventArgs`
2. We could send that with `ProjectEvaluationFinishedEventArgs` - however at that point of time we do not yet have `ProjectContextId` available (it's only created with creation of `ProjectStartedEventArgs`) - so we would not be able to fully mount the data in receiving LoggingService
3. `ProjectStartedEventArgs` - current implementation
4. post `ProjectStartedEventArgs` - then all info is available, but we are unnecesarily holding of too long. Hence some buildchek diagnostics can be created post evaluation, but prior this event.

### Testing
Tailored E2E test added for promoting/demoting of diagnostic warning created during evaluation.
