### PR TITLE
Fixes writing unwanted characters to console when TerminalLogger is created directly

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,7 +2,7 @@
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the MIT license. See License.txt in the project root for full license information. -->
 <Project>
   <PropertyGroup>
-    <VersionPrefix>17.12.0</VersionPrefix>
+    <VersionPrefix>17.12.1</VersionPrefix>
     <PackageValidationBaselineVersion>17.11.4</PackageValidationBaselineVersion>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,7 +2,7 @@
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the MIT license. See License.txt in the project root for full license information. -->
 <Project>
   <PropertyGroup>
-    <VersionPrefix>17.12.1</VersionPrefix>
+    <VersionPrefix>17.12.0</VersionPrefix>
     <PackageValidationBaselineVersion>17.11.4</PackageValidationBaselineVersion>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>

--- a/src/MSBuild/TerminalLogger/TerminalLogger.cs
+++ b/src/MSBuild/TerminalLogger/TerminalLogger.cs
@@ -224,8 +224,10 @@ internal sealed partial class TerminalLogger : INodeLogger
     /// <summary>
     /// Default constructor, used by the MSBuild logger infra.
     /// </summary>
-    public TerminalLogger() : this(new Terminal())
+    public TerminalLogger()
     {
+        NativeMethodsShared.QueryIsScreenAndTryEnableAnsiColorCodes();
+        Terminal = new Terminal();
     }
 
     public TerminalLogger(LoggerVerbosity verbosity) : this()

--- a/src/MSBuild/TerminalLogger/TerminalLogger.cs
+++ b/src/MSBuild/TerminalLogger/TerminalLogger.cs
@@ -224,9 +224,8 @@ internal sealed partial class TerminalLogger : INodeLogger
     /// <summary>
     /// Default constructor, used by the MSBuild logger infra.
     /// </summary>
-    public TerminalLogger()
+    public TerminalLogger() : this(new Terminal())
     {
-        Terminal = new Terminal();
     }
 
     public TerminalLogger(LoggerVerbosity verbosity) : this()
@@ -239,6 +238,7 @@ internal sealed partial class TerminalLogger : INodeLogger
     /// </summary>
     internal TerminalLogger(ITerminal terminal)
     {
+        NativeMethodsShared.QueryIsScreenAndTryEnableAnsiColorCodes();
         Terminal = terminal;
         _manualRefresh = true;
     }


### PR DESCRIPTION
Fixes #10579

### Summary
Command `dotnet run` creates `TerminalLogger` instance and bypasses code that enables VIRTUAL_TERMINAL_PROCESSING on Windows. This can cause rendering of unwanted VT100 control codes in the console.

### Customer Impact
Customer see "weird" characters on terminal that doesn't have enabled VT100 support by default - mostly conhost. Reproduces in `dotnet new console && dotnet run` scenario.

### Regression?
Yes, in RC2 from enhanced console output in `dotnet run` in https://github.com/dotnet/sdk/pull/42240.

### Testing
Manual testing. Before and after the fix:
![image](https://github.com/user-attachments/assets/210ac769-e0be-4912-8f8e-1e454fb3a969)

### Risk
Low. The same logic is used when MSBuild is started via entry point.