### PR TITLE
Add clarification of BuildCheck props check false positives

### DIFF
--- a/documentation/specs/BuildCheck/Codes.md
+++ b/documentation/specs/BuildCheck/Codes.md
@@ -91,7 +91,12 @@ If `BC0202` and [BC0201](#BC0201) are both enabled - then `BC0201` reports only 
 
 This check indicates that a property was defined in the observed scope (by default it's the project file only) and it was then not used anywhere in the build.
 
-This is a runtime check, not a static analysis check - so it can have false positives (as property not used in particular build might be needed in a build with different conditions). For this reasons it's currently only suggestion.
+This is a runtime check, not a static analysis check - so it can have false positives - for this reasons it's currently only suggestion.
+
+Common cases of false positives:
+ * Property not used in a particular build might be needed in a build with different conditions or a build of a different target (e.g. `dotnet pack /check` or `dotnet build /t:pack /check` accesses some additional properties as compared to ordinary `dotnet build /check`).
+ * Property accessing is tracked for each project build request. There might be multiple distinct build requests for a project in a single build. Specific case of this is a call to the [MSBuild task](https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-task) or [CallTarget task](https://learn.microsoft.com/en-us/visualstudio/msbuild/calltarget-task) that can request a result from a project build, while passing additional or different global properties and/or calling specific target. This happens often as part of common targets - e.g. for [multi-targeted project build parallelization](../../High-level-overview.md#parallelism)
+ * Incremental build might skip execution of some targets, that might have been accessing properties of interest.
 
 <BR/>
 <BR/>


### PR DESCRIPTION
Fixes #10597

### Context
Adding detailed clarification of cases where the `BC0203` BuildCheck reports false positives.
