### PR TITLE
Fix property expander when comparing between non-numeric and numeric properties

### DIFF
--- a/src/Build.UnitTests/Evaluation/Expander_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/Expander_Tests.cs
@@ -4088,7 +4088,10 @@ namespace Microsoft.Build.UnitTests.Evaluation
                 new string[] {"A$(Reg:AA)", "A"},
                 new string[] {"$(Reg:AA)", ""},
                 new string[] {"$(Reg:AAAA)", ""},
-                new string[] {"$(Reg:AAA)", ""}
+                new string[] {"$(Reg:AAA)", ""},
+                // Following two are comparison between non-numeric and numeric properties. More details: #10583
+                new string[] {"$(a.Equals($(c)))","False"},
+                new string[] {"$(a.CompareTo($(c)))","1"},
                                    };
 
             var errorTests = new List<string> {
@@ -5074,7 +5077,7 @@ $(
         {
             using (var env = TestEnvironment.Create())
             {
-                // Setting this env variable allows to track if expander was using reflection for a function invocation. 
+                // Setting this env variable allows to track if expander was using reflection for a function invocation.
                 env.SetEnvironmentVariable("MSBuildLogPropertyFunctionsRequiringReflection", "1");
 
                 var logger = new MockLogger();

--- a/src/Build/Evaluation/Expander.cs
+++ b/src/Build/Evaluation/Expander.cs
@@ -3525,10 +3525,13 @@ namespace Microsoft.Build.Evaluation
                     if (objectInstance != null && args.Length == 1 && (String.Equals("Equals", _methodMethodName, StringComparison.OrdinalIgnoreCase) || String.Equals("CompareTo", _methodMethodName, StringComparison.OrdinalIgnoreCase)))
                     {
                         // Support comparison when the lhs is an integer
-                        if (IsFloatingPointRepresentation(args[0]) && !IsFloatingPointRepresentation(objectInstance))
+                        if (IsFloatingPointRepresentation(args[0]))
                         {
-                            objectInstance = Convert.ChangeType(objectInstance, typeof(double), CultureInfo.InvariantCulture);
-                            _receiverType = objectInstance.GetType();
+                            if (double.TryParse(objectInstance.ToString(), NumberStyles.Number | NumberStyles.Float, CultureInfo.InvariantCulture.NumberFormat, out double result))
+                            {
+                                objectInstance = result;
+                                _receiverType = objectInstance.GetType();
+                            }
                         }
 
                         // change the type of the final unescaped string into the destination


### PR DESCRIPTION
Fixes [#10583](https://github.com/dotnet/msbuild/issues/10583)

### Context

Can't evaluate 
```
    <PropertyGroup>
      <Foo>Foo</Foo>

      <!-- This has to be numeric. -->
      <Bar>1234</Bar>

      <!-- This is a workaround. -->
      <Good>$([System.String]::Equals($(Foo), $(Bar)))</Good>

      <!-- This works on .NET 7 but on 8 it doesn't. -->
      <Bad>$(Foo.Equals($(Bar)))</Bad>
    </PropertyGroup>
```
### Changes Made
Use the double.TryParse instead of the convert method

### Testing
Add the test cases in the test method Medley()

### Notes
