### PR TITLE
Add Design Time target import

### DIFF
--- a/src/Tasks/Microsoft.CSharp.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.CSharp.CurrentVersion.targets
@@ -384,6 +384,8 @@ using System.Reflection%3b
         <_ExplicitReference Include="$(FrameworkPathOverride)\mscorlib.dll" />
     </ItemGroup>
 
+    <Import Project="$([MSBuild]::GetToolsDirectory32())\..\..\..\Common7\IDE\CommonExtensions\Microsoft\ProjectServices\Microsoft.DesignTime.targets" Condition="'$(DesignTimeBuild)' == 'true' and exists('$([MSBuild]::GetToolsDirectory32())\..\..\..\Common7\IDE\CommonExtensions\Microsoft\ProjectServices\Microsoft.DesignTime.targets')"/>
+
     <Import Project="$(CustomAfterMicrosoftCSharpTargets)" Condition="'$(CustomAfterMicrosoftCSharpTargets)' != '' and Exists('$(CustomAfterMicrosoftCSharpTargets)')" />
 
     <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.CSharp.targets\ImportAfter\*" Condition="'$(ImportByWildcardAfterMicrosoftCSharpTargets)' == 'true' and exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.CSharp.targets\ImportAfter')"/>


### PR DESCRIPTION
Fixes #
issue with build acceleration 

### Context
The separate design time targets file is needed for the case when .net workload was not installed, so these targets are missed for build acceleration feature.

![image](https://github.com/user-attachments/assets/90f3e635-3e6b-425f-8a1f-6fcd56467556)


### Changes Made
The main change is made in internal repo that comes with VS installation on empty workload selection
https://devdiv.visualstudio.com/DevDiv/_git/ProjectServices/pullrequest/580503

### Testing
Tested locally

