### PR TITLE
Use Microsoft.IO.Redist in XMake.cs

### DIFF
--- a/src/Build/Logging/ProfilerLogger.cs
+++ b/src/Build/Logging/ProfilerLogger.cs
@@ -301,7 +301,8 @@ namespace Microsoft.Build.Logging
                 DirectoryNotFoundException or
                 IOException or
                 UnauthorizedAccessException or
-                SecurityException)
+                SecurityException or
+                ArgumentException)
             {
                 Console.WriteLine(ResourceUtilities.FormatResourceStringStripCodeAndKeyword("ErrorWritingProfilerReport", ex.Message));
             }

--- a/src/Build/Logging/ProfilerLogger.cs
+++ b/src/Build/Logging/ProfilerLogger.cs
@@ -297,19 +297,11 @@ namespace Microsoft.Build.Logging
 
                 Console.WriteLine(ResourceUtilities.GetResourceString("WritingProfilerReportDone"));
             }
-            catch (DirectoryNotFoundException ex)
-            {
-                Console.WriteLine(ResourceUtilities.FormatResourceStringStripCodeAndKeyword("ErrorWritingProfilerReport", ex.Message));
-            }
-            catch (IOException ex)
-            {
-                Console.WriteLine(ResourceUtilities.FormatResourceStringStripCodeAndKeyword("ErrorWritingProfilerReport", ex.Message));
-            }
-            catch (UnauthorizedAccessException ex)
-            {
-                Console.WriteLine(ResourceUtilities.FormatResourceStringStripCodeAndKeyword("ErrorWritingProfilerReport", ex.Message));
-            }
-            catch (SecurityException ex)
+            catch (Exception ex) when (ex is
+                DirectoryNotFoundException or
+                IOException or
+                UnauthorizedAccessException or
+                SecurityException)
             {
                 Console.WriteLine(ResourceUtilities.FormatResourceStringStripCodeAndKeyword("ErrorWritingProfilerReport", ex.Message));
             }

--- a/src/MSBuild.UnitTests/CommandLineSwitches_Tests.cs
+++ b/src/MSBuild.UnitTests/CommandLineSwitches_Tests.cs
@@ -1532,25 +1532,6 @@ namespace Microsoft.Build.UnitTests
         }
 
         /// <summary>
-        /// Verifies that when the /profileevaluation switch is used with invalid filenames an error is shown.
-        /// </summary>
-        [MemberData(nameof(GetInvalidFilenames))]
-        [WindowsFullFrameworkOnlyTheory(additionalMessage: ".NET Core 2.1+ no longer validates paths: https://github.com/dotnet/corefx/issues/27779#issuecomment-371253486.")]
-        public void ProcessProfileEvaluationInvalidFilename(string filename)
-        {
-            bool enableProfiler = false;
-            Should.Throw(
-                () => MSBuildApp.ProcessProfileEvaluationSwitch(new[] { filename }, new List<ILogger>(), out enableProfiler),
-                typeof(CommandLineSwitchException));
-        }
-
-        public static IEnumerable<object[]> GetInvalidFilenames()
-        {
-            yield return new object[] { $"a_file_with${Path.GetInvalidFileNameChars().First()}invalid_chars" };
-            yield return new object[] { $"C:\\a_path\\with{Path.GetInvalidPathChars().First()}invalid\\chars" };
-        }
-
-        /// <summary>
         /// Verifies that help messages are correctly formed with the right width and leading spaces.
         /// </summary>
         [Fact]

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -43,6 +43,17 @@ using LoggerDescription = Microsoft.Build.Logging.LoggerDescription;
 using SimpleErrorLogger = Microsoft.Build.Logging.SimpleErrorLogger.SimpleErrorLogger;
 using TerminalLogger = Microsoft.Build.Logging.TerminalLogger.TerminalLogger;
 
+#if NETFRAMEWORK
+// Use I/O operations from Microsoft.IO.Redist which is generally higher perf
+// and also works around https://github.com/dotnet/msbuild/issues/10540.
+// Unnecessary on .NET 6+ because the perf improvements are in-box there.
+using Microsoft.IO;
+using Directory = Microsoft.IO.Directory;
+using File = Microsoft.IO.File;
+using FileInfo = Microsoft.IO.FileInfo;
+using Path = Microsoft.IO.Path;
+#endif
+
 #nullable disable
 
 namespace Microsoft.Build.CommandLine


### PR DESCRIPTION
This will fix #10540--it looks like M.IO.Redist has the same fix that .NET 9 has that avoids the failed root enumeration. As a bonus it's generally higher performance/less allocatey (but I don't _know_ that that has a specific positive impact in this file).
