### PR TITLE
Hide and warn about TaskItem ctor

### DIFF
--- a/src/Utilities/TaskItem.cs
+++ b/src/Utilities/TaskItem.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 #if FEATURE_SECURITY_PERMISSIONS
 using System.Security;
@@ -60,8 +61,12 @@ namespace Microsoft.Build.Utilities
         #region Constructors
 
         /// <summary>
-        /// Default constructor -- we need it so this type is COM-createable.
+        /// Default constructor -- do not use.
         /// </summary>
+        /// <remarks>
+        /// This constructor exists only so that the type is COM-creatable. Prefer <see cref="TaskItem(string)"/>.
+        /// </remarks>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public TaskItem()
         {
             _itemSpec = string.Empty;


### PR DESCRIPTION
The doc comment mentioned that the parameterless constructor existed only for COM but it was still easy to find, causing problems like #10660. Hide it from IDE completion and extend the comment.
