### PR TITLE
CG alert cleaning on VS17.11

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,7 +2,7 @@
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the MIT license. See License.txt in the project root for full license information. -->
 <Project>
   <PropertyGroup>
-    <VersionPrefix>17.11.10</VersionPrefix><DotNetFinalVersionKind>release</DotNetFinalVersionKind>
+    <VersionPrefix>17.11.11</VersionPrefix><DotNetFinalVersionKind>release</DotNetFinalVersionKind>
     <PackageValidationBaselineVersion>17.10.4</PackageValidationBaselineVersion>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>
     <PreReleaseVersionLabel>servicing</PreReleaseVersionLabel>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -51,7 +51,7 @@
     <MicrosoftCodeAnalysisCollectionsVersion>4.2.0-1.22102.8</MicrosoftCodeAnalysisCollectionsVersion>
     <MicrosoftDotNetXUnitExtensionsVersion>8.0.0-beta.24460.4</MicrosoftDotNetXUnitExtensionsVersion>
     <MicrosoftExtensionsDependencyModelVersion>7.0.0</MicrosoftExtensionsDependencyModelVersion>
-    <MicrosoftIORedistVersion>6.0.0</MicrosoftIORedistVersion>
+    <MicrosoftIORedistVersion>6.0.1</MicrosoftIORedistVersion>
     <MicrosoftNetCompilersToolsetVersion>4.11.0-3.24313.9</MicrosoftNetCompilersToolsetVersion>
     <NuGetBuildTasksVersion>6.11.0-rc.101</NuGetBuildTasksVersion>
     <SystemRuntimeCompilerServicesUnsafeVersion>6.0.0</SystemRuntimeCompilerServicesUnsafeVersion>

--- a/src/MSBuild/app.amd64.config
+++ b/src/MSBuild/app.amd64.config
@@ -49,7 +49,7 @@
 
         <dependentAssembly>
           <assemblyIdentity name="Microsoft.IO.Redist" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-          <bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="6.0.0.1" />
+          <bindingRedirect oldVersion="0.0.0.0-6.0.0.1" newVersion="6.0.0.1" />
           <codeBase version="6.0.0.1" href="..\Microsoft.IO.Redist.dll"/>
         </dependentAssembly>
 

--- a/src/MSBuild/app.amd64.config
+++ b/src/MSBuild/app.amd64.config
@@ -49,8 +49,8 @@
 
         <dependentAssembly>
           <assemblyIdentity name="Microsoft.IO.Redist" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-          <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
-          <codeBase version="6.0.0.0" href="..\Microsoft.IO.Redist.dll"/>
+          <bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="6.0.0.1" />
+          <codeBase version="6.0.0.1" href="..\Microsoft.IO.Redist.dll"/>
         </dependentAssembly>
 
         <!-- Redirects for assemblies redistributed by MSBuild (in the .vsix). -->

--- a/src/MSBuild/app.config
+++ b/src/MSBuild/app.config
@@ -45,7 +45,7 @@
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="Microsoft.IO.Redist" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-          <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+          <bindingRedirect oldVersion="0.0.0.0-6.0.0.1" newVersion="6.0.0.1" />
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="Microsoft.NET.StringTools" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />


### PR DESCRIPTION
Fixes
[CVE-2024-38081](https://devdiv.visualstudio.com/DevDiv/_componentGovernance/DotNet-msbuild-Trusted/alert/9977344?typeId=22822795&pipelinesTrackingFilter=1)

### Summary
MSBuild 17.11 uses dependency with known vulnerabilities.

### Customer Impact
Using software without known vulnerabilities.

### Regression?
No.

### Testing
Existing automated tests.

### Risk
Low - there are no functional changes.

### Changes Made
Upgrade `Microsoft.IO.Redist` from 6.0.0 to 6.0.1 to fix the vulnerability.
