### PR TITLE
Remove DesignTimeBuild restriction

### DIFF
--- a/src/Tasks/Microsoft.CSharp.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.CSharp.CurrentVersion.targets
@@ -384,7 +384,7 @@ using System.Reflection%3b
         <_ExplicitReference Include="$(FrameworkPathOverride)\mscorlib.dll" />
     </ItemGroup>
 
-    <Import Project="$([MSBuild]::GetToolsDirectory32())\..\..\..\Common7\IDE\CommonExtensions\Microsoft\ProjectServices\Microsoft.DesignTime.targets" Condition="'$(DesignTimeBuild)' == 'true' and exists('$([MSBuild]::GetToolsDirectory32())\..\..\..\Common7\IDE\CommonExtensions\Microsoft\ProjectServices\Microsoft.DesignTime.targets')"/>
+    <Import Project="$([MSBuild]::GetToolsDirectory32())\..\..\..\Common7\IDE\CommonExtensions\Microsoft\ProjectServices\Microsoft.DesignTime.targets" Condition="exists('$([MSBuild]::GetToolsDirectory32())\..\..\..\Common7\IDE\CommonExtensions\Microsoft\ProjectServices\Microsoft.DesignTime.targets')"/>
 
     <Import Project="$(CustomAfterMicrosoftCSharpTargets)" Condition="'$(CustomAfterMicrosoftCSharpTargets)' != '' and Exists('$(CustomAfterMicrosoftCSharpTargets)')" />
 

--- a/src/Tasks/Microsoft.CSharp.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.CSharp.CurrentVersion.targets
@@ -384,7 +384,7 @@ using System.Reflection%3b
         <_ExplicitReference Include="$(FrameworkPathOverride)\mscorlib.dll" />
     </ItemGroup>
 
-    <Import Project="$([MSBuild]::GetToolsDirectory32())\..\..\..\Common7\IDE\CommonExtensions\Microsoft\ProjectServices\Microsoft.DesignTime.targets" Condition="exists('$([MSBuild]::GetToolsDirectory32())\..\..\..\Common7\IDE\CommonExtensions\Microsoft\ProjectServices\Microsoft.DesignTime.targets')"/>
+    <Import Project="$([MSBuild]::GetToolsDirectory32())\..\..\..\Common7\IDE\CommonExtensions\Microsoft\ProjectServices\Microsoft.DesignTime.targets" Condition="'$(MSBuildRuntimeType)' == 'Full' and exists('$([MSBuild]::GetToolsDirectory32())\..\..\..\Common7\IDE\CommonExtensions\Microsoft\ProjectServices\Microsoft.DesignTime.targets')"/>
 
     <Import Project="$(CustomAfterMicrosoftCSharpTargets)" Condition="'$(CustomAfterMicrosoftCSharpTargets)' != '' and Exists('$(CustomAfterMicrosoftCSharpTargets)')" />
 


### PR DESCRIPTION
It's related to adding a new target import: https://github.com/dotnet/msbuild/pull/10698
VS doesn't always emit "DesignTimeBuild" flag that cause an issue with importing for some cases (e.g. project load from UI).