### PR TITLE
Fix tests running on version freeze

### DIFF
--- a/src/BuildCheck.UnitTests/Microsoft.Build.BuildCheck.UnitTests.csproj
+++ b/src/BuildCheck.UnitTests/Microsoft.Build.BuildCheck.UnitTests.csproj
@@ -15,6 +15,10 @@
     <ProjectReference Include="..\UnitTests.Shared\Microsoft.Build.UnitTests.Shared.csproj" />
     <ProjectReference Include="..\Xunit.NetCore.Extensions\Xunit.NetCore.Extensions.csproj" />
   </ItemGroup>
+
+  <PropertyGroup>
+    <ArtifactsNonShippingPackagesDir>$(ArtifactsBinDir)Microsoft.Build.BuildCheck.UnitTests\CustomChecks</ArtifactsNonShippingPackagesDir>
+  </PropertyGroup>
   
   <ItemGroup Label="TestAssests">
     <ProjectReference Include=".\TestAssets\CustomCheck\CustomCheck.csproj" />
@@ -45,5 +49,11 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
+
+  <Target Name="MSBuildPackagesForTests" AfterTargets="Build">
+    <Exec Command="dotnet pack &quot;..\Build\Microsoft.Build.csproj&quot; -o &quot;$(ArtifactsNonShippingPackagesDir)&quot;" />
+    <Exec Command="dotnet pack &quot;..\Framework\Microsoft.Build.Framework.csproj&quot; -o &quot;$(ArtifactsNonShippingPackagesDir)&quot;"/>
+    <Exec Command="dotnet pack &quot;..\StringTools\StringTools.csproj&quot; -o &quot;$(ArtifactsNonShippingPackagesDir)&quot;"/>
+  </Target>
 
 </Project>

--- a/src/BuildCheck.UnitTests/Microsoft.Build.BuildCheck.UnitTests.csproj
+++ b/src/BuildCheck.UnitTests/Microsoft.Build.BuildCheck.UnitTests.csproj
@@ -15,10 +15,6 @@
     <ProjectReference Include="..\UnitTests.Shared\Microsoft.Build.UnitTests.Shared.csproj" />
     <ProjectReference Include="..\Xunit.NetCore.Extensions\Xunit.NetCore.Extensions.csproj" />
   </ItemGroup>
-
-  <PropertyGroup>
-    <ArtifactsNonShippingPackagesDir>$(ArtifactsBinDir)Microsoft.Build.BuildCheck.UnitTests\CustomChecks</ArtifactsNonShippingPackagesDir>
-  </PropertyGroup>
   
   <ItemGroup Label="TestAssests">
     <ProjectReference Include=".\TestAssets\CustomCheck\CustomCheck.csproj" />
@@ -50,10 +46,30 @@
     </None>
   </ItemGroup>
 
-  <Target Name="MSBuildPackagesForTests" AfterTargets="Build">
-    <Exec Command="dotnet pack &quot;..\Build\Microsoft.Build.csproj&quot; -o &quot;$(ArtifactsNonShippingPackagesDir)&quot;" />
-    <Exec Command="dotnet pack &quot;..\Framework\Microsoft.Build.Framework.csproj&quot; -o &quot;$(ArtifactsNonShippingPackagesDir)&quot;"/>
-    <Exec Command="dotnet pack &quot;..\StringTools\StringTools.csproj&quot; -o &quot;$(ArtifactsNonShippingPackagesDir)&quot;"/>
+  <!-- This target creates packages needed for e2e testing. Inputs and outputs are defined to enable incremental builds. -->
+
+  <PropertyGroup Label="TestAssests">
+    <ArtifactsNonShippingPackagesDir>$(ArtifactsBinDir)Microsoft.Build.BuildCheck.UnitTests\CustomChecks</ArtifactsNonShippingPackagesDir>
+  </PropertyGroup>
+
+  <ItemGroup Label="TestAssets">
+    <ProjectsToPack Include="..\Build\Microsoft.Build.csproj" />
+    <ProjectsToPack Include="..\Framework\Microsoft.Build.Framework.csproj" />
+    <ProjectsToPack Include="..\StringTools\StringTools.csproj" />
+  </ItemGroup>
+
+  <Target Name="GetSourceFilesForPacking">
+    <ItemGroup>
+      <SourceFilesForPacking Include="%(ProjectsToPack.RootDir)%(ProjectsToPack.Directory)**\*.cs" />
+    </ItemGroup>
   </Target>
 
+  <Target Name="MSBuildPackagesForTests"
+          AfterTargets="Build"
+          DependsOnTargets="GetSourceFilesForPacking"
+          Inputs="@(ProjectsToPack);@(SourceFilesForPacking)"
+          Outputs="$(ArtifactsNonShippingPackagesDir)\Microsoft.Build.$(Version).nupkg;$(ArtifactsNonShippingPackagesDir)\Microsoft.Build.Framework.$(Version).nupkg;$(ArtifactsNonShippingPackagesDir)\Microsoft.NET.StringTools.$(Version).nupkg">
+    <Exec Command="dotnet pack &quot;%(ProjectsToPack.Identity)&quot; -o &quot;$(ArtifactsNonShippingPackagesDir)&quot; -p:PackageVersion=$(PackageVersion)" />
+  </Target>
+  
 </Project>

--- a/src/BuildCheck.UnitTests/TestAssets/Common/CommonTest.props
+++ b/src/BuildCheck.UnitTests/TestAssets/Common/CommonTest.props
@@ -11,7 +11,7 @@
 
   <!-- In the real world scenario, the dependencies are added as Nuget PackageReference, modified for test purposes only. -->
   <ItemGroup>
-    <ProjectReference Include="..\..\..\Build\Microsoft.Build.csproj" IncludeInPackage="true" />
+    <ProjectReference Include="..\..\..\Build\Microsoft.Build.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Fixes #[10702](https://github.com/dotnet/msbuild/issues/10702)

## Context
The issue stemmed from a missing Microsoft.Build package during the test execution. CustomCheck is compiled using a specific version of Microsoft.Build, but during the CheckCandidate run, this package couldn't be restored. This mismatch led to the problem.
`
Build FAILED. "/Users/runner/work/1/s/artifacts/bin/Microsoft.Build.BuildCheck.UnitTests/Debug/net9.0/TestAssets/CheckCandidate/CheckCandidate.csproj" (Restore target) (1) -> (Restore target) -> /Users/runner/work/1/s/artifacts/bin/Microsoft.Build.BuildCheck.UnitTests/Debug/net9.0/TestAssets/CheckCandidate/CheckCandidate.csproj : warning NU1701: Package 'Microsoft.IO.Redist 6.0.1' was restored using '.NETFramework,Version=v4.6.1, .NETFramework,Version=v4.6.2, .NETFramework,Version=v4.7, .NETFramework,Version=v4.7.1, .NETFramework,Version=v4.7.2, .NETFramework,Version=v4.8, .NETFramework,Version=v4.8.1' instead of the project target framework 'net8.0'. This package may not be fully compatible with your project. "/Users/runner/work/1/s/artifacts/bin/Microsoft.Build.BuildCheck.UnitTests/Debug/net9.0/TestAssets/CheckCandidate/CheckCandidate.csproj" (Restore target) (1) -> (Restore target) -> /Users/runner/work/1/s/artifacts/bin/Microsoft.Build.BuildCheck.UnitTests/Debug/net9.0/TestAssets/CheckCandidate/CheckCandidate.csproj : error NU1102: Unable to find package Microsoft.Build with version (>= 17.12.0)
`
## Solution
Pack Microsoft.Build and it's dependencies for the tests to a specific location. 