### PR TITLE
Fix parsing .editorconfig EOL

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,7 +2,7 @@
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the MIT license. See License.txt in the project root for full license information. -->
 <Project>
   <PropertyGroup>
-    <VersionPrefix>17.12.0</VersionPrefix><DotNetFinalVersionKind>release</DotNetFinalVersionKind>
+    <VersionPrefix>17.12.1</VersionPrefix><DotNetFinalVersionKind>release</DotNetFinalVersionKind>
     <PackageValidationBaselineVersion>17.11.4</PackageValidationBaselineVersion>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>

--- a/src/Build/BuildCheck/Infrastructure/EditorConfig/EditorConfigFile.cs
+++ b/src/Build/BuildCheck/Infrastructure/EditorConfig/EditorConfigFile.cs
@@ -81,7 +81,7 @@ private static partial Regex GetPropertyMatcherRegex();
         // dictionary, but we also use a case-insensitive key comparer when doing lookups
         var activeSectionProperties = ImmutableDictionary.CreateBuilder<string, string>(StringComparer.OrdinalIgnoreCase);
         string activeSectionName = "";
-        var lines = string.IsNullOrEmpty(text) ? Array.Empty<string>() : text.Split(new string[] { Environment.NewLine }, StringSplitOptions.None);
+        var lines = string.IsNullOrEmpty(text) ? Array.Empty<string>() : text.Split(new string[] { "\r\n", "\n" }, StringSplitOptions.None);
 
         foreach(var line in lines)
         {

--- a/src/BuildCheck.UnitTests/EditorConfigParser_Tests.cs
+++ b/src/BuildCheck.UnitTests/EditorConfigParser_Tests.cs
@@ -81,7 +81,7 @@ public class EditorConfigParser_Tests
         """);
 
         var parser = new EditorConfigParser();
-        var listOfEditorConfigFile = parser.DiscoverEditorConfigFiles(Path.Combine(workFolder1.Path, "subfolder", "projectfile.proj") ).ToList();
+        var listOfEditorConfigFile = parser.DiscoverEditorConfigFiles(Path.Combine(workFolder1.Path, "subfolder", "projectfile.proj")).ToList();
         // should be one because root=true so we do not need to go further
         listOfEditorConfigFile.Count.ShouldBe(1);
         listOfEditorConfigFile[0].IsRoot.ShouldBeTrue();
@@ -115,5 +115,32 @@ public class EditorConfigParser_Tests
         listOfEditorConfigFile.Count.ShouldBe(2);
         listOfEditorConfigFile[0].IsRoot.ShouldBeFalse();
         listOfEditorConfigFile[0].NamedSections[0].Name.ShouldBe("*.csproj");
+    }
+
+    [Fact]
+    public void Parse_HandlesDifferentLineEndings()
+    {
+        var mixedEndingsText = "root = true\r\n" +
+                           "[*.cs]\n" +
+                           "indent_style = space\r\n" +
+                           "indent_size = 4\n" +
+                           "[*.md]\r\n" +
+                           "trim_trailing_whitespace = true";
+
+        var result = EditorConfigFile.Parse(mixedEndingsText);
+
+        result.IsRoot.ShouldBeTrue("Root property should be true");
+        result.NamedSections.Length.ShouldBe(2);
+
+        var csSection = result.NamedSections.FirstOrDefault(s => s.Name == "*.cs");
+        csSection.ShouldNotBeNull();
+        csSection.Properties.Count.ShouldBe(2);
+        csSection.Properties["indent_style"].ShouldBe("space");
+        csSection.Properties["indent_size"].ShouldBe("4");
+
+        var mdSection = result.NamedSections.FirstOrDefault(s => s.Name == "*.md");
+        mdSection.ShouldNotBeNull();
+        mdSection.Properties.Count.ShouldBe(1);
+        mdSection.Properties["trim_trailing_whitespace"].ShouldBe("true");
     }
 }


### PR DESCRIPTION
Fixes #10684 

### Summary
.editorconfig is ignored when it's EOLs don't match the system, because it's lines are parsed according to the local environment (`\n` vs `\r\n`). This fix splits lines in both locales.

### Customer Impact
Multiplatform usability. Example of a silent failure this fix addresses: a Windows user copying .editorconfig from unix or from some configurations of git.

### Regression?
No

### Testing
Manual +
Unit test

### Risk
Low, fixes edge case of intended behavior in BuildCheck feature.