### PR TITLE
Remove BinFmt opt-in for un-exposed data transfers

### DIFF
--- a/src/Build/BackEnd/Node/NodeConfiguration.cs
+++ b/src/Build/BackEnd/Node/NodeConfiguration.cs
@@ -162,27 +162,20 @@ namespace Microsoft.Build.BackEnd
             translator.Translate(ref _buildParameters, BuildParameters.FactoryForDeserialization);
             translator.TranslateArray(ref _forwardingLoggers, LoggerDescription.FactoryForTranslation);
 #if FEATURE_APPDOMAIN
-            if (ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_10))
+            byte[] appDomainConfigBytes = null;
+
+            // Set the configuration bytes just before serialization in case the SetConfigurationBytes was invoked during lifetime of this instance.
+            if (translator.Mode == TranslationDirection.WriteToStream)
             {
-                byte[] appDomainConfigBytes = null;
-
-                // Set the configuration bytes just before serialization in case the SetConfigurationBytes was invoked during lifetime of this instance.
-                if (translator.Mode == TranslationDirection.WriteToStream)
-                {
-                    appDomainConfigBytes = _appDomainSetup?.GetConfigurationBytes();
-                }
-
-                translator.Translate(ref appDomainConfigBytes);
-
-                if (translator.Mode == TranslationDirection.ReadFromStream)
-                {
-                    _appDomainSetup = new AppDomainSetup();
-                    _appDomainSetup.SetConfigurationBytes(appDomainConfigBytes);
-                }
+                appDomainConfigBytes = _appDomainSetup?.GetConfigurationBytes();
             }
-            else
+
+            translator.Translate(ref appDomainConfigBytes);
+
+            if (translator.Mode == TranslationDirection.ReadFromStream)
             {
-                translator.TranslateDotNet(ref _appDomainSetup);
+                _appDomainSetup = new AppDomainSetup();
+                _appDomainSetup.SetConfigurationBytes(appDomainConfigBytes);
             }
 #endif
             translator.Translate(ref _loggingNodeConfiguration);

--- a/src/Build/BackEnd/Node/NodeConfiguration.cs
+++ b/src/Build/BackEnd/Node/NodeConfiguration.cs
@@ -162,7 +162,7 @@ namespace Microsoft.Build.BackEnd
             translator.Translate(ref _buildParameters, BuildParameters.FactoryForDeserialization);
             translator.TranslateArray(ref _forwardingLoggers, LoggerDescription.FactoryForTranslation);
 #if FEATURE_APPDOMAIN
-            if (ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_10) || !Traits.Instance.EscapeHatches.IsBinaryFormatterSerializationAllowed)
+            if (ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_10))
             {
                 byte[] appDomainConfigBytes = null;
 

--- a/src/Framework/Traits.cs
+++ b/src/Framework/Traits.cs
@@ -423,26 +423,6 @@ namespace Microsoft.Build.Framework
             }
         }
 
-        private bool? _isBinaryFormatterSerializationAllowed;
-        public bool IsBinaryFormatterSerializationAllowed
-        {
-            get
-            {
-                if (!_isBinaryFormatterSerializationAllowed.HasValue)
-                {
-#if RUNTIME_TYPE_NETCORE
-                    AppContext.TryGetSwitch("System.Runtime.Serialization.EnableUnsafeBinaryFormatterSerialization",
-                        out bool enabled);
-                    _isBinaryFormatterSerializationAllowed = enabled;
-#else
-                    _isBinaryFormatterSerializationAllowed = true;
-#endif
-                }
-
-                return _isBinaryFormatterSerializationAllowed.Value;
-            }
-        }
-
 
         private static bool? ParseNullableBoolFromEnvironmentVariable(string environmentVariable)
         {

--- a/src/Shared/TaskHostConfiguration.cs
+++ b/src/Shared/TaskHostConfiguration.cs
@@ -417,7 +417,7 @@ namespace Microsoft.Build.BackEnd
             translator.TranslateCulture(ref _culture);
             translator.TranslateCulture(ref _uiCulture);
 #if FEATURE_APPDOMAIN
-            if (ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_10) || !Traits.Instance.EscapeHatches.IsBinaryFormatterSerializationAllowed)
+            if (ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_10))
             {
                 byte[] appDomainConfigBytes = null;
 

--- a/src/Shared/TaskHostConfiguration.cs
+++ b/src/Shared/TaskHostConfiguration.cs
@@ -417,27 +417,20 @@ namespace Microsoft.Build.BackEnd
             translator.TranslateCulture(ref _culture);
             translator.TranslateCulture(ref _uiCulture);
 #if FEATURE_APPDOMAIN
-            if (ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_10))
+            byte[] appDomainConfigBytes = null;
+
+            // Set the configuration bytes just before serialization in case the SetConfigurationBytes was invoked during lifetime of this instance.
+            if (translator.Mode == TranslationDirection.WriteToStream)
             {
-                byte[] appDomainConfigBytes = null;
-
-                // Set the configuration bytes just before serialization in case the SetConfigurationBytes was invoked during lifetime of this instance.
-                if (translator.Mode == TranslationDirection.WriteToStream)
-                {
-                    appDomainConfigBytes = _appDomainSetup?.GetConfigurationBytes();
-                }
-
-                translator.Translate(ref appDomainConfigBytes);
-
-                if (translator.Mode == TranslationDirection.ReadFromStream)
-                {
-                    _appDomainSetup = new AppDomainSetup();
-                    _appDomainSetup.SetConfigurationBytes(appDomainConfigBytes);
-                }
+                appDomainConfigBytes = _appDomainSetup?.GetConfigurationBytes();
             }
-            else
+
+            translator.Translate(ref appDomainConfigBytes);
+
+            if (translator.Mode == TranslationDirection.ReadFromStream)
             {
-                translator.TranslateDotNet(ref _appDomainSetup);
+                _appDomainSetup = new AppDomainSetup();
+                _appDomainSetup.SetConfigurationBytes(appDomainConfigBytes);
             }
 #endif
             translator.Translate(ref _lineNumberOfTask);


### PR DESCRIPTION
Fixes [#AB2263324](https://dev.azure.com/devdiv/DevDiv/_workitems/edit/2263324)

### Context
Opting out of 17.10 changewave might lead to opting out of BinaryFormatter deprecation. This can unintentionally break ppl builds by breaking NodeConfig or TaskHost config de/serialization.
Both of the types and their data transfer is internal to MSBuild - there is no need to opt out from the safer, proprietary de/serialization. Hence let's prevent the opt out altogether.

### Changes Made
Removed the opt-out option for NodeConfig and TaskHost config de/serialization

### Testing
Existing tests
