### PR TITLE
add binlog serialization for BuildCanceledEventArgs

### DIFF
--- a/src/Build.UnitTests/BackEnd/NodePackets_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/NodePackets_Tests.cs
@@ -79,6 +79,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             GeneratedFileUsedEventArgs generatedFileUsed = new GeneratedFileUsedEventArgs("path", "some content");
             BuildSubmissionStartedEventArgs buildSubmissionStarted = new(new Dictionary<string, string> { { "Value1", "Value2" } }, ["Path1"], ["TargetName"], BuildRequestDataFlags.ReplaceExistingProjectInstance, 123);
             BuildCheckTracingEventArgs buildCheckTracing = new();
+            BuildCanceledEventArgs buildCanceled = new("message", DateTime.UtcNow);
 
             VerifyLoggingPacket(buildFinished, LoggingEventType.BuildFinishedEvent);
             VerifyLoggingPacket(buildStarted, LoggingEventType.BuildStartedEvent);
@@ -114,6 +115,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             VerifyLoggingPacket(generatedFileUsed, LoggingEventType.GeneratedFileUsedEvent);
             VerifyLoggingPacket(buildSubmissionStarted, LoggingEventType.BuildSubmissionStartedEvent);
             VerifyLoggingPacket(buildCheckTracing, LoggingEventType.BuildCheckTracingEvent);
+            VerifyLoggingPacket(buildCanceled, LoggingEventType.BuildCanceledEvent);
         }
 
         private static BuildEventContext CreateBuildEventContext()

--- a/src/Build.UnitTests/BuildEventArgsSerialization_Tests.cs
+++ b/src/Build.UnitTests/BuildEventArgsSerialization_Tests.cs
@@ -98,6 +98,18 @@ namespace Microsoft.Build.UnitTests
         }
 
         [Fact]
+        public void RoundtripBuildCanceledEventArgs()
+        {
+            var args = new BuildCanceledEventArgs(
+                "Message",
+                eventTimestamp: DateTime.Parse("12/12/2015 06:11:56 PM"));
+
+            Roundtrip(args,
+                e => e.Message,
+                e => e.Timestamp.ToString());
+        }
+
+        [Fact]
         public void RoundtripBuildSubmissionStartedEventArgs()
         {
             var globalVariables = new Dictionary<string, string>

--- a/src/Build/Logging/BinaryLogger/BinaryLogRecordKind.cs
+++ b/src/Build/Logging/BinaryLogger/BinaryLogRecordKind.cs
@@ -46,5 +46,6 @@ namespace Microsoft.Build.Logging
         BuildCheckTracing,
         BuildCheckAcquisition,
         BuildSubmissionStarted,
+        BuildCanceled,
     }
 }

--- a/src/Build/Logging/BinaryLogger/BinaryLogger.cs
+++ b/src/Build/Logging/BinaryLogger/BinaryLogger.cs
@@ -78,6 +78,8 @@ namespace Microsoft.Build.Logging
         // version 23:
         //    - new record kinds: BuildCheckMessageEvent, BuildCheckWarningEvent, BuildCheckErrorEvent,
         //    BuildCheckTracingEvent, BuildCheckAcquisitionEvent, BuildSubmissionStartedEvent
+        // version 24:
+        //    - new record kind: BuildCanceledEventArgs
 
         // MAKE SURE YOU KEEP BuildEventArgsWriter AND StructuredLogViewer.BuildEventArgsWriter IN SYNC WITH THE CHANGES ABOVE.
         // Both components must stay in sync to avoid issues with logging or event handling in the products.
@@ -88,7 +90,7 @@ namespace Microsoft.Build.Logging
 
         // The current version of the binary log representation.
         // Changes with each update of the binary log format.
-        internal const int FileFormatVersion = 23;
+        internal const int FileFormatVersion = 24;
 
         // The minimum version of the binary log reader that can read log of above version.
         // This should be changed only when the binary log format is changed in a way that would prevent it from being

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsReader.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsReader.cs
@@ -325,6 +325,7 @@ namespace Microsoft.Build.Logging
                 BinaryLogRecordKind.BuildCheckError => ReadBuildErrorEventArgs(),
                 BinaryLogRecordKind.BuildCheckTracing => ReadBuildCheckTracingEventArgs(),
                 BinaryLogRecordKind.BuildCheckAcquisition => ReadBuildCheckAcquisitionEventArgs(),
+                BinaryLogRecordKind.BuildCanceled => ReadBuildCanceledEventArgs(),
                 _ => null
             };
 
@@ -1270,6 +1271,15 @@ namespace Microsoft.Build.Logging
             var acquisitionPath = ReadString();
             var projectPath = ReadString();
             var e = new BuildCheckAcquisitionEventArgs(acquisitionPath, projectPath);
+            SetCommonFields(e, fields);
+
+            return e;
+        }
+
+        private BuildEventArgs ReadBuildCanceledEventArgs()
+        {
+            var fields = ReadBuildEventArgsFields();
+            var e = new BuildCanceledEventArgs(fields.Message);
             SetCommonFields(e, fields);
 
             return e;

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
@@ -187,6 +187,7 @@ namespace Microsoft.Build.Logging
                     BuildSubmissionStarted
                     BuildStarted
                     BuildFinished
+                    BuildCanceled
                     ProjectEvaluationStarted
                     ProjectEvaluationFinished
                 BuildError
@@ -215,6 +216,7 @@ namespace Microsoft.Build.Logging
                 case BuildSubmissionStartedEventArgs buildSubmissionStarted: return Write(buildSubmissionStarted);
                 case BuildStartedEventArgs buildStarted: return Write(buildStarted);
                 case BuildFinishedEventArgs buildFinished: return Write(buildFinished);
+                case BuildCanceledEventArgs buildCanceled: return Write(buildCanceled);
                 case ProjectEvaluationStartedEventArgs projectEvaluationStarted: return Write(projectEvaluationStarted);
                 case ProjectEvaluationFinishedEventArgs projectEvaluationFinished: return Write(projectEvaluationFinished);
                 case BuildCheckTracingEventArgs buildCheckTracing: return Write(buildCheckTracing);
@@ -305,6 +307,13 @@ namespace Microsoft.Build.Logging
             Write(e.Succeeded);
 
             return BinaryLogRecordKind.BuildFinished;
+        }
+
+        private BinaryLogRecordKind Write(BuildCanceledEventArgs e)
+        {
+            WriteBuildEventArgsFields(e);
+
+            return BinaryLogRecordKind.BuildCanceled;
         }
 
         private BinaryLogRecordKind Write(ProjectEvaluationStartedEventArgs e)

--- a/src/Framework.UnitTests/BuildCanceledEventArgs_Tests.cs
+++ b/src/Framework.UnitTests/BuildCanceledEventArgs_Tests.cs
@@ -1,0 +1,41 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Shouldly;
+using Xunit;
+
+namespace Microsoft.Build.Framework.UnitTests
+{
+    public class BuildCanceledEventArgs_Tests
+    {
+        [Fact]
+        public void SerializationDeserializationTest()
+        {
+            var message = "message";
+            var datetime = DateTime.Today;
+
+            BuildCanceledEventArgs args = new(
+                message,
+                datetime
+                );
+            using MemoryStream stream = new MemoryStream();
+            using BinaryWriter bw = new BinaryWriter(stream);
+            args.WriteToStream(bw);
+
+            stream.Position = 0;
+            using BinaryReader br = new BinaryReader(stream);
+            BuildCanceledEventArgs argDeserialized = new("m");
+            int packetVersion = (Environment.Version.Major * 10) + Environment.Version.Minor;
+
+            argDeserialized.CreateFromStream(br, packetVersion);
+            argDeserialized.Message.ShouldBe(message);
+            argDeserialized.Timestamp.ShouldBe(datetime); 
+        }
+    }
+}

--- a/src/Framework.UnitTests/BuildSubmissionStartedEventArgs_Tests.cs
+++ b/src/Framework.UnitTests/BuildSubmissionStartedEventArgs_Tests.cs
@@ -12,7 +12,7 @@ using Xunit;
 
 namespace Microsoft.Build.Framework.UnitTests
 {
-    public class BuildSubmissionStartedEventAgs_Tests
+    public class BuildSubmissionStartedEventArgs_Tests
     {
         [Fact]
         public void SerializationDeserializationTest()

--- a/src/Shared/LogMessagePacketBase.cs
+++ b/src/Shared/LogMessagePacketBase.cs
@@ -244,6 +244,11 @@ namespace Microsoft.Build.Shared
         /// Event is <see cref="BuildSubmissionStartedEventArgs"/>.
         /// </summary>
         BuildSubmissionStartedEvent = 40,
+
+        /// <summary>
+        /// Event is <see cref="BuildCanceledEventArgs"/>
+        /// </summary>
+        BuildCanceledEvent = 41,
     }
     #endregion
 
@@ -656,6 +661,7 @@ namespace Microsoft.Build.Shared
                 LoggingEventType.BuildCheckTracingEvent => new BuildCheckTracingEventArgs(),
                 LoggingEventType.EnvironmentVariableReadEvent => new EnvironmentVariableReadEventArgs(),
                 LoggingEventType.BuildSubmissionStartedEvent => new BuildSubmissionStartedEventArgs(),
+                LoggingEventType.BuildCanceledEvent => new BuildCanceledEventArgs("Build canceled."),
 #endif
                 _ => throw new InternalErrorException("Should not get to the default of GetBuildEventArgFromId ID: " + _eventType)
             };
@@ -798,6 +804,10 @@ namespace Microsoft.Build.Shared
             else if (eventType == typeof(BuildSubmissionStartedEventArgs))
             {
                 return LoggingEventType.BuildSubmissionStartedEvent;
+            }
+            else if (eventType == typeof(BuildCanceledEventArgs))
+            {
+                return LoggingEventType.BuildCanceledEvent;
             }
 #endif
             else if (eventType == typeof(TargetStartedEventArgs))


### PR DESCRIPTION
Fixes #10244

### Context
BuildCanceledEventArgs was added in https://github.com/dotnet/msbuild/pull/10055 but the serialization was missing, this PR adds it

### Changes Made
implement the serialization in the same manner as for BuildSubmissionStarted event in https://github.com/dotnet/msbuild/pull/10424 

### Testing
Unit tests

### Notes
Adding support for this to MSBuild Structured Log Viewer PR https://github.com/KirillOsenkov/MSBuildStructuredLog/pull/824

also fixed a typo in BuildSubmissionStartedEventArgs_Tests