### PR TITLE
remove CreateBootstrap opting-in 

### DIFF
--- a/documentation/Deploy-MSBuild.md
+++ b/documentation/Deploy-MSBuild.md
@@ -5,7 +5,7 @@
 [Deploy-MSBuild](https://github.com/dotnet/msbuild/blob/deploy-msbuild/scripts/Deploy-MSBuild.ps1) is a way to conveniently take private bits and install them into Visual Studio (VS) for testing. To use it:
 
 - If you haven't already, clone [MSBuild](https://github.com/dotnet/msbuild) and make the changes you want.
-- Build MSBuild with the changes you want using `build.cmd /p:CreateBootstrap=true`.
+- Build MSBuild with the changes you want using `build.cmd`.
 - In an administrator powershell window, navigate to the msbuild folder.
 - Run `scripts\Deploy-MSBuild.ps1 -destination {destination} -configuration {configuration}`.
   - Specify the Bin folder of MSBuild in your VS install as the destination. This is somewhere like `"C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin"`.

--- a/documentation/Deploy-MSBuild.md
+++ b/documentation/Deploy-MSBuild.md
@@ -5,7 +5,7 @@
 [Deploy-MSBuild](https://github.com/dotnet/msbuild/blob/deploy-msbuild/scripts/Deploy-MSBuild.ps1) is a way to conveniently take private bits and install them into Visual Studio (VS) for testing. To use it:
 
 - If you haven't already, clone [MSBuild](https://github.com/dotnet/msbuild) and make the changes you want.
-- Build MSBuild with the changes you want using `build.cmd`.
+- Build MSBuild with the changes you want using `build.cmd /p:CreateBootstrap=true`.
 - In an administrator powershell window, navigate to the msbuild folder.
 - Run `scripts\Deploy-MSBuild.ps1 -destination {destination} -configuration {configuration}`.
   - Specify the Bin folder of MSBuild in your VS install as the destination. This is somewhere like `"C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin"`.

--- a/documentation/wiki/Building-Testing-and-Debugging-on-Full-Framework-MSBuild.md
+++ b/documentation/wiki/Building-Testing-and-Debugging-on-Full-Framework-MSBuild.md
@@ -63,7 +63,7 @@ Please see [Contributing Code](https://github.com/dotnet/msbuild/blob/main/docum
 To build projects using the MSBuild binaries from the repository, you first need to do a build which produces
 a "bootstrap" directory. The "bootstrap" directory mimics a Visual Studio installation by acquiring additional
 dependencies (Roslyn compilers, NuGet, etc.) from packages or from your local machine (e.g. props/targets
-from Visual Studio). This will happen by default when running `.\build.cmd`. 
+from Visual Studio). This will happen by default when running `.\build.cmd`. The bootstrap can be disabled by running `.\build.cmd /p:CreateBootstrap=false`.
 
 Now, just point `artifacts\bin\bootstrap\net472\MSBuild\Current\Bin\MSBuild.exe` at a project file.
 

--- a/documentation/wiki/Building-Testing-and-Debugging-on-Full-Framework-MSBuild.md
+++ b/documentation/wiki/Building-Testing-and-Debugging-on-Full-Framework-MSBuild.md
@@ -63,7 +63,7 @@ Please see [Contributing Code](https://github.com/dotnet/msbuild/blob/main/docum
 To build projects using the MSBuild binaries from the repository, you first need to do a build which produces
 a "bootstrap" directory. The "bootstrap" directory mimics a Visual Studio installation by acquiring additional
 dependencies (Roslyn compilers, NuGet, etc.) from packages or from your local machine (e.g. props/targets
-from Visual Studio). This will happen by default when running `.\build.cmd`. The bootstrap can be disabled by running `.\build.cmd /p:CreateBootstrap=false`.
+from Visual Studio). This will happen by default when running `.\build.cmd`. 
 
 Now, just point `artifacts\bin\bootstrap\net472\MSBuild\Current\Bin\MSBuild.exe` at a project file.
 

--- a/eng/cibuild_bootstrapped_msbuild.ps1
+++ b/eng/cibuild_bootstrapped_msbuild.ps1
@@ -65,7 +65,7 @@ try {
 
   if ($buildStage1)
   {
-    & $PSScriptRoot\Common\Build.ps1 -restore -build -ci -msbuildEngine $msbuildEngine @properties
+    & $PSScriptRoot\Common\Build.ps1 -restore -build -ci -msbuildEngine $msbuildEngine /p:CreateBootstrap=true @properties
   }
 
   KillProcessesFromRepo
@@ -118,10 +118,10 @@ try {
   # - Turn off node reuse (so that bootstrapped MSBuild processes don't stay running and lock files)
   # - Create bootstrap environment as it's required when also running tests
   if ($onlyDocChanged) {
-    & $PSScriptRoot\Common\Build.ps1 -restore -build -ci /nr:false @properties
+    & $PSScriptRoot\Common\Build.ps1 -restore -build -ci /p:CreateBootstrap=false /nr:false @properties
   }
   else {
-    & $PSScriptRoot\Common\Build.ps1 -restore -build -test -ci /nr:false @properties
+    & $PSScriptRoot\Common\Build.ps1 -restore -build -test -ci /p:CreateBootstrap=true /nr:false @properties
   }
 
   exit $lastExitCode

--- a/eng/cibuild_bootstrapped_msbuild.ps1
+++ b/eng/cibuild_bootstrapped_msbuild.ps1
@@ -121,7 +121,7 @@ try {
     & $PSScriptRoot\Common\Build.ps1 -restore -build -ci /p:CreateBootstrap=false /nr:false @properties
   }
   else {
-    & $PSScriptRoot\Common\Build.ps1 -restore -build -test -ci /p:CreateBootstrap=true /nr:false @properties
+    & $PSScriptRoot\Common\Build.ps1 -restore -build -test -ci /nr:false @properties
   }
 
   exit $lastExitCode

--- a/eng/cibuild_bootstrapped_msbuild.ps1
+++ b/eng/cibuild_bootstrapped_msbuild.ps1
@@ -65,7 +65,7 @@ try {
 
   if ($buildStage1)
   {
-    & $PSScriptRoot\Common\Build.ps1 -restore -build -ci -msbuildEngine $msbuildEngine /p:CreateBootstrap=true @properties
+    & $PSScriptRoot\Common\Build.ps1 -restore -build -ci -msbuildEngine $msbuildEngine @properties
   }
 
   KillProcessesFromRepo
@@ -118,10 +118,10 @@ try {
   # - Turn off node reuse (so that bootstrapped MSBuild processes don't stay running and lock files)
   # - Create bootstrap environment as it's required when also running tests
   if ($onlyDocChanged) {
-    & $PSScriptRoot\Common\Build.ps1 -restore -build -ci /p:CreateBootstrap=false /nr:false @properties
+    & $PSScriptRoot\Common\Build.ps1 -restore -build -ci /nr:false @properties
   }
   else {
-    & $PSScriptRoot\Common\Build.ps1 -restore -build -test -ci /p:CreateBootstrap=true /nr:false @properties
+    & $PSScriptRoot\Common\Build.ps1 -restore -build -test -ci /nr:false @properties
   }
 
   exit $lastExitCode

--- a/eng/cibuild_bootstrapped_msbuild.sh
+++ b/eng/cibuild_bootstrapped_msbuild.sh
@@ -51,7 +51,7 @@ InitializeDotNetCli true
 
 if [[ $build_stage1 == true ]];
 then
-	/bin/bash "$ScriptRoot/common/build.sh" --restore --build --ci --configuration $configuration /p:CreateBootstrap=true $properties $extra_properties || exit $?
+	/bin/bash "$ScriptRoot/common/build.sh" --restore --build --ci --configuration $configuration $properties $extra_properties || exit $?
 fi
 
 bootstrapRoot="$Stage1Dir/bin/bootstrap"
@@ -84,8 +84,8 @@ export DOTNET_HOST_PATH="$_InitializeDotNetCli/dotnet"
 # - Create bootstrap environment as it's required when also running tests
 if [ $onlyDocChanged = 0 ]
 then
-    . "$ScriptRoot/common/build.sh" --restore --build --test --ci --nodereuse false --configuration $configuration /p:CreateBootstrap=true $properties $extra_properties
+    . "$ScriptRoot/common/build.sh" --restore --build --test --ci --nodereuse false --configuration $configuration $properties $extra_properties
 
 else
-    . "$ScriptRoot/common/build.sh" --restore --build --ci --nodereuse false --configuration $configuration /p:CreateBootstrap=false $properties $extra_properties
+    . "$ScriptRoot/common/build.sh" --restore --build --ci --nodereuse false --configuration $configuration $properties $extra_properties
 fi

--- a/eng/cibuild_bootstrapped_msbuild.sh
+++ b/eng/cibuild_bootstrapped_msbuild.sh
@@ -51,7 +51,7 @@ InitializeDotNetCli true
 
 if [[ $build_stage1 == true ]];
 then
-	/bin/bash "$ScriptRoot/common/build.sh" --restore --build --ci --configuration $configuration $properties $extra_properties || exit $?
+	/bin/bash "$ScriptRoot/common/build.sh" --restore --build --ci --configuration $configuration /p:CreateBootstrap=true $properties $extra_properties || exit $?
 fi
 
 bootstrapRoot="$Stage1Dir/bin/bootstrap"
@@ -84,8 +84,8 @@ export DOTNET_HOST_PATH="$_InitializeDotNetCli/dotnet"
 # - Create bootstrap environment as it's required when also running tests
 if [ $onlyDocChanged = 0 ]
 then
-    . "$ScriptRoot/common/build.sh" --restore --build --test --ci --nodereuse false --configuration $configuration $properties $extra_properties
+    . "$ScriptRoot/common/build.sh" --restore --build --test --ci --nodereuse false --configuration $configuration /p:CreateBootstrap=true $properties $extra_properties
 
 else
-    . "$ScriptRoot/common/build.sh" --restore --build --ci --nodereuse false --configuration $configuration $properties $extra_properties
+    . "$ScriptRoot/common/build.sh" --restore --build --ci --nodereuse false --configuration $configuration /p:CreateBootstrap=false $properties $extra_properties
 fi

--- a/eng/cibuild_bootstrapped_msbuild.sh
+++ b/eng/cibuild_bootstrapped_msbuild.sh
@@ -51,7 +51,7 @@ InitializeDotNetCli true
 
 if [[ $build_stage1 == true ]];
 then
-	/bin/bash "$ScriptRoot/common/build.sh" --restore --build --ci --configuration $configuration /p:CreateBootstrap=true $properties $extra_properties || exit $?
+	/bin/bash "$ScriptRoot/common/build.sh" --restore --build --ci --configuration $configuration $properties $extra_properties || exit $?
 fi
 
 bootstrapRoot="$Stage1Dir/bin/bootstrap"
@@ -84,7 +84,7 @@ export DOTNET_HOST_PATH="$_InitializeDotNetCli/dotnet"
 # - Create bootstrap environment as it's required when also running tests
 if [ $onlyDocChanged = 0 ]
 then
-    . "$ScriptRoot/common/build.sh" --restore --build --test --ci --nodereuse false --configuration $configuration /p:CreateBootstrap=true $properties $extra_properties
+    . "$ScriptRoot/common/build.sh" --restore --build --test --ci --nodereuse false --configuration $configuration $properties $extra_properties
 
 else
     . "$ScriptRoot/common/build.sh" --restore --build --ci --nodereuse false --configuration $configuration /p:CreateBootstrap=false $properties $extra_properties


### PR DESCRIPTION
Fixes #10751

### Context
Bootstrap is on by default, opt-in with arg `/p:CreateBootstrap=true` is unnecessary

### Changes made
docs, CI: remove instances of `CreateBootstrap=true`
