### PR TITLE
Remove BuildXL feed

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -18,7 +18,6 @@
     <add key="dotnet8" value="https://dnceng.pkgs.visualstudio.com/public/_packaging/dotnet8/nuget/v3/index.json" />
     <add key="dotnet8-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8-transport/nuget/v3/index.json" />
     <add key="dotnet9" value="https://dnceng.pkgs.visualstudio.com/public/_packaging/dotnet9/nuget/v3/index.json" />
-    <add key="BuildXL" value="https://pkgs.dev.azure.com/ms/BuildXL/_packaging/BuildXL/nuget/v3/index.json" />
     <add key="msbuild17.12" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-DotNet-msbuild-Trusted-95c7bf01-1/nuget/v3/index.json" />
   </packageSources>
   <disabledPackageSources>


### PR DESCRIPTION
### Context
BuildXL feed is going to be moved . To shield devs from future feed changes - we have had the BuildXL packages pushed to dotnet-tools feed.

### Testing
No testing - successful build on clean build machine without cache is enough

FYI @dfederm 
