### PR TITLE
Expose Properties and Items data enumeration

### DIFF
--- a/src/Build/Collections/ItemDictionary.cs
+++ b/src/Build/Collections/ItemDictionary.cs
@@ -172,11 +172,7 @@ namespace Microsoft.Build.Collections
         /// <summary>
         /// Enumerates item lists per each item type under the lock.
         /// </summary>
-        /// <param name="itemTypeCallback">
-        /// A delegate that accepts the item type string and a list of items of that type.
-        /// Will be called for each item type in the list.
-        /// </param>
-        public void EnumerateItemsPerType(Action<string, IEnumerable<T>> itemTypeCallback)
+        public IEnumerable<(string itemType, IEnumerable<T> itemValue)> EnumerateItemsPerType()
         {
             lock (_itemLists)
             {
@@ -188,8 +184,23 @@ namespace Microsoft.Build.Collections
                         continue;
                     }
 
-                    itemTypeCallback(itemTypeBucket.Key, itemTypeBucket.Value);
+                    yield return (itemTypeBucket.Key, itemTypeBucket.Value);
                 }
+            }
+        }
+
+        /// <summary>
+        /// Enumerates item lists per each item type under the lock.
+        /// </summary>
+        /// <param name="itemTypeCallback">
+        /// A delegate that accepts the item type string and a list of items of that type.
+        /// Will be called for each item type in the list.
+        /// </param>
+        public void EnumerateItemsPerType(Action<string, IEnumerable<T>> itemTypeCallback)
+        {
+            foreach (var tuple in EnumerateItemsPerType())
+            {
+                itemTypeCallback(tuple.itemType, tuple.itemValue);
             }
         }
 

--- a/src/Build/Collections/PropertyDictionary.cs
+++ b/src/Build/Collections/PropertyDictionary.cs
@@ -529,14 +529,22 @@ namespace Microsoft.Build.Collections
             }
         }
 
-        internal void Enumerate(Action<string, string> keyValueCallback)
+        internal IEnumerable<(string propertyName, string propertyValue)> Enumerate()
         {
             lock (_properties)
             {
                 foreach (var kvp in (ICollection<T>)_properties)
                 {
-                    keyValueCallback(kvp.Key, EscapingUtilities.UnescapeAll(kvp.EscapedValue));
+                    yield return (kvp.Key, EscapingUtilities.UnescapeAll(kvp.EscapedValue));
                 }
+            }
+        }
+
+        internal void Enumerate(Action<string, string> keyValueCallback)
+        {
+            foreach (var tuple in Enumerate())
+            {
+                keyValueCallback(tuple.propertyName, tuple.propertyValue);
             }
         }
 

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsExtensions.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsExtensions.cs
@@ -1,0 +1,54 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using Microsoft.Build.Framework;
+
+namespace Microsoft.Build.Logging;
+
+/// <summary>
+/// Helper extension methods for working with data passed via
+/// <see cref="ProjectEvaluationFinishedEventArgs"/> and <see cref="ProjectStartedEventArgs"/>
+/// </summary>
+public static class BuildEventArgsExtensions
+{
+    /// <summary>
+    /// Lazy enumerates and strong types properties from Properties property.
+    /// </summary>
+    public static IEnumerable<(string propertyName, string propertyValue)> EnumerateProperties(
+        this ProjectEvaluationFinishedEventArgs eventArgs)
+        => EnumerateProperties(eventArgs.Properties);
+
+    /// <summary>
+    /// Lazy enumerates and strong types properties from Properties property.
+    /// </summary>
+    public static IEnumerable<(string propertyName, string propertyValue)> EnumerateProperties(
+        this ProjectStartedEventArgs eventArgs)
+        => EnumerateProperties(eventArgs.Properties);
+
+    /// <summary>
+    /// Lazy enumerates and partially strong types items from Items property.
+    /// The actual item value is of nongeneric <see cref="object"/> type.
+    /// The actual type need to be inferred during runtime based on the itemType.
+    /// </summary>
+    public static IEnumerable<(string itemType, object itemValue)> EnumerateItems(
+        this ProjectEvaluationFinishedEventArgs eventArgs)
+        => EnumerateItems(eventArgs.Items);
+
+    /// <summary>
+    /// Lazy enumerates and partially strong types items from Items property.
+    /// The actual item value is of nongeneric <see cref="object"/> type.
+    /// The actual type need to be inferred during runtime based on the itemType.
+    /// </summary>
+    public static IEnumerable<(string itemType, object itemValue)> EnumerateItems(
+        this ProjectStartedEventArgs eventArgs)
+        => EnumerateItems(eventArgs.Items);
+
+    private static IEnumerable<(string propertyName, string propertyValue)> EnumerateProperties(IEnumerable? properties)
+        => Internal.Utilities.EnumerateProperties(properties);
+
+    private static IEnumerable<(string itemType, object itemValue)> EnumerateItems(IEnumerable? items)
+        => Internal.Utilities.EnumerateItems(items);
+}

--- a/src/Build/Microsoft.Build.csproj
+++ b/src/Build/Microsoft.Build.csproj
@@ -170,6 +170,7 @@
     <Compile Include="FileAccess\ReportedFileOperation.cs" />
     <Compile Include="FileAccess\RequestedAccess.cs" />
     <Compile Include="Instance\IPropertyElementWithLocation.cs" />
+    <Compile Include="Logging\BinaryLogger\BuildEventArgsExtensions.cs" />
     <Compile Include="Utilities\ReaderWriterLockSlimExtensions.cs" />
     <Compile Include="BackEnd\Node\ConsoleOutput.cs" />
     <Compile Include="BackEnd\Node\PartialBuildTelemetry.cs" />


### PR DESCRIPTION
Fixes #10770

### Context
The `ProjectEvaluationFinishedEventArgs` and `ProjectStartedEventArgs` Properties and Items members are nongeneric and need involved custom code to enumerate.

While we do not want to expose exact internals to prevent ourselves from future changes - we should at least expose the way how the data can be traversed in string form.

### Testing
Manual (via project the prototype project that cosumed the data)


FYI @jakubch1 
