### PR TITLE
Pass PoliCheck exclusion file to 1ES PT

### DIFF
--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -56,6 +56,7 @@ extends:
     sdl:
       policheck:
         enabled: true
+        exclusionsFile: $(Build.SourcesDirectory)\eng\policheck_exclusions.xml
       tsa:
         enabled: true
       # We generate SBOM ourselves, so don't need steps injected by 1ES.

--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -37,7 +37,6 @@ variables:
     value: true # Enable loc for vs17.13
   - name: Codeql.Enabled
     value: true
-  - group: DotNet-MSBuild-SDLValidation-Params
 
 resources:
   repositories:
@@ -311,18 +310,3 @@ extends:
         enableSymbolValidation: true
         enableSourceLinkValidation: false
         enableNugetValidation: false
-        SDLValidationParameters:
-          enable: true
-          continueOnError: false
-          params: ' -SourceToolsList @("policheck","credscan")
-          -TsaInstanceURL "$(_TsaInstanceURL)"
-          -TsaProjectName "$(_TsaProjectName)"
-          -TsaNotificationEmail "$(_TsaNotificationEmail)"
-          -TsaCodebaseAdmin "$(_TsaCodebaseAdmin)"
-          -TsaBugAreaPath "$(_TsaBugAreaPath)"
-          -TsaIterationPath "$(_TsaIterationPath)"
-          -TsaRepositoryName "dotnet-msbuild"
-          -TsaCodebaseName "dotnet-msbuild"
-          -TsaPublish $True
-          -CrScanAdditionalRunConfigParams @("SuppressionsPath < $(Build.SourcesDirectory)\eng\CredScanSuppressions.json")
-          -PoliCheckAdditionalRunConfigParams @("UserExclusionPath < $(Build.SourcesDirectory)\eng\policheck_exclusions.xml")'


### PR DESCRIPTION
Fixes #
[Queries - Boards (visualstudio.com)](https://devdiv.visualstudio.com/DevDiv/_queries/query/?_a=query&wiql=%20SELECT%20ID%2CSeverity%2CState%2C%5BAssigned%20To%5D%2CTitle%20FROM%20WorkItem%20WHERE%20Tags%20Contains%27TSA-MSBuild-PoliCheckSARIF-Official%27%20)

### Context
For PoliCheck errors in the query, we have PoliCheck exclusions to skip the check on them. After adapting 1ES PT and enabling PoliCheck in it, we need to pass the PoliCheck exclusion file to 1ES PT.

### Changes Made
Pass PoliCheck exclusion file to 1ES PT and remove the PoliCheck & Credscan from eng\common template.

### Testing
Verified with the run on this experimental branch.

### Notes
