### PR TITLE
Use CallerArgumentExpression for internal assert-like constructs

### DIFF
--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -287,7 +287,7 @@ namespace Microsoft.Build.Execution
         /// </summary>
         public BuildManager(string hostName)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(hostName, nameof(hostName));
+            ErrorUtilities.VerifyThrowArgumentNull(hostName);
             _hostName = hostName;
             _buildManagerState = BuildManagerState.Idle;
             _buildSubmissions = new Dictionary<int, BuildSubmissionBase>();
@@ -888,7 +888,7 @@ namespace Microsoft.Build.Execution
         {
             lock (_syncLock)
             {
-                ErrorUtilities.VerifyThrowArgumentNull(requestData, nameof(requestData));
+                ErrorUtilities.VerifyThrowArgumentNull(requestData);
                 ErrorIfState(BuildManagerState.WaitingForBuildToComplete, "WaitingForEndOfBuild");
                 ErrorIfState(BuildManagerState.Idle, "NoBuildInProgress");
                 VerifyStateInternal(BuildManagerState.Building);
@@ -1230,7 +1230,7 @@ namespace Microsoft.Build.Execution
         [SuppressMessage("Microsoft.Maintainability", "CA1506:AvoidExcessiveClassCoupling", Justification = "Complex class might need refactoring to separate scheduling elements from submission elements.")]
         private void ExecuteSubmission(BuildSubmission submission, bool allowMainThreadBuild)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(submission, nameof(submission));
+            ErrorUtilities.VerifyThrowArgumentNull(submission);
             ErrorUtilities.VerifyThrow(!submission.IsCompleted, "Submission already complete.");
 
             BuildRequestConfiguration? resolvedConfiguration = null;

--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -3163,7 +3163,7 @@ namespace Microsoft.Build.Execution
         {
             Debug.Assert(Monitor.IsEntered(_syncLock));
 
-            ErrorUtilities.VerifyThrowInternalNull(inputCacheFiles, nameof(inputCacheFiles));
+            ErrorUtilities.VerifyThrowInternalNull(inputCacheFiles);
             ErrorUtilities.VerifyThrow(_configCache == null, "caches must not be set at this point");
             ErrorUtilities.VerifyThrow(_resultsCache == null, "caches must not be set at this point");
 

--- a/src/Build/BackEnd/BuildManager/BuildParameters.cs
+++ b/src/Build/BackEnd/BuildManager/BuildParameters.cs
@@ -240,7 +240,7 @@ namespace Microsoft.Build.Execution
         /// <param name="projectCollection">The ProjectCollection from which the BuildParameters should populate itself.</param>
         public BuildParameters(ProjectCollection projectCollection)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(projectCollection, nameof(projectCollection));
+            ErrorUtilities.VerifyThrowArgumentNull(projectCollection);
 
             Initialize(new PropertyDictionary<ProjectPropertyInstance>(projectCollection.EnvironmentProperties), projectCollection.ProjectRootElementCache, new ToolsetProvider(projectCollection.Toolsets));
 

--- a/src/Build/BackEnd/BuildManager/BuildParameters.cs
+++ b/src/Build/BackEnd/BuildManager/BuildParameters.cs
@@ -265,7 +265,7 @@ namespace Microsoft.Build.Execution
         /// </summary>
         internal BuildParameters(BuildParameters other, bool resetEnvironment = false)
         {
-            ErrorUtilities.VerifyThrowInternalNull(other, nameof(other));
+            ErrorUtilities.VerifyThrowInternalNull(other);
 
             _buildId = other._buildId;
             _culture = other._culture;

--- a/src/Build/BackEnd/BuildManager/BuildRequestData.cs
+++ b/src/Build/BackEnd/BuildManager/BuildRequestData.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Build.Execution
         public BuildRequestData(ProjectInstance projectInstance, string[] targetsToBuild, HostServices? hostServices, BuildRequestDataFlags flags, IEnumerable<string>? propertiesToTransfer)
             : this(targetsToBuild, hostServices, flags, projectInstance.FullPath)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(projectInstance, nameof(projectInstance));
+            ErrorUtilities.VerifyThrowArgumentNull(projectInstance);
 
             foreach (string targetName in targetsToBuild)
             {
@@ -93,7 +93,7 @@ namespace Microsoft.Build.Execution
         public BuildRequestData(ProjectInstance projectInstance, string[] targetsToBuild, HostServices? hostServices, BuildRequestDataFlags flags, IEnumerable<string>? propertiesToTransfer, RequestedProjectState requestedProjectState)
             : this(projectInstance, targetsToBuild, hostServices, flags, propertiesToTransfer)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(requestedProjectState, nameof(requestedProjectState));
+            ErrorUtilities.VerifyThrowArgumentNull(requestedProjectState);
 
             RequestedProjectState = requestedProjectState;
         }
@@ -127,7 +127,7 @@ namespace Microsoft.Build.Execution
             RequestedProjectState requestedProjectState)
             : this(projectFullPath, globalProperties, toolsVersion, targetsToBuild, hostServices, flags)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(requestedProjectState, nameof(requestedProjectState));
+            ErrorUtilities.VerifyThrowArgumentNull(requestedProjectState);
 
             RequestedProjectState = requestedProjectState;
         }
@@ -145,7 +145,7 @@ namespace Microsoft.Build.Execution
             : this(targetsToBuild, hostServices, flags, FileUtilities.NormalizePath(projectFullPath)!)
         {
             ErrorUtilities.VerifyThrowArgumentLength(projectFullPath, nameof(projectFullPath));
-            ErrorUtilities.VerifyThrowArgumentNull(globalProperties, nameof(globalProperties));
+            ErrorUtilities.VerifyThrowArgumentNull(globalProperties);
 
             GlobalPropertiesDictionary = new PropertyDictionary<ProjectPropertyInstance>(globalProperties.Count);
             foreach (KeyValuePair<string, string?> propertyPair in globalProperties)

--- a/src/Build/BackEnd/BuildManager/BuildRequestData.cs
+++ b/src/Build/BackEnd/BuildManager/BuildRequestData.cs
@@ -144,7 +144,7 @@ namespace Microsoft.Build.Execution
         public BuildRequestData(string projectFullPath, IDictionary<string, string?> globalProperties, string? toolsVersion, string[] targetsToBuild, HostServices? hostServices, BuildRequestDataFlags flags)
             : this(targetsToBuild, hostServices, flags, FileUtilities.NormalizePath(projectFullPath)!)
         {
-            ErrorUtilities.VerifyThrowArgumentLength(projectFullPath, nameof(projectFullPath));
+            ErrorUtilities.VerifyThrowArgumentLength(projectFullPath);
             ErrorUtilities.VerifyThrowArgumentNull(globalProperties);
 
             GlobalPropertiesDictionary = new PropertyDictionary<ProjectPropertyInstance>(globalProperties.Count);

--- a/src/Build/BackEnd/BuildManager/BuildRequestDataBase.cs
+++ b/src/Build/BackEnd/BuildManager/BuildRequestDataBase.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Build.Execution
             BuildRequestDataFlags flags,
             HostServices? hostServices)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(targetNames, nameof(targetNames));
+            ErrorUtilities.VerifyThrowArgumentNull(targetNames);
             foreach (string targetName in targetNames)
             {
                 ErrorUtilities.VerifyThrowArgumentNull(targetName, "target");

--- a/src/Build/BackEnd/BuildManager/BuildSubmission.cs
+++ b/src/Build/BackEnd/BuildManager/BuildSubmission.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Build.Execution
         protected internal BuildSubmissionBase(BuildManager buildManager, int submissionId, TRequestData requestData)
             : base(buildManager, submissionId)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(requestData, nameof(requestData));
+            ErrorUtilities.VerifyThrowArgumentNull(requestData);
             BuildRequestData = requestData;
         }
 
@@ -77,7 +77,7 @@ namespace Microsoft.Build.Execution
         /// </summary>
         internal void CompleteResults(TResultData result)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(result, nameof(result));
+            ErrorUtilities.VerifyThrowArgumentNull(result);
             CheckResultValidForCompletion(result);
 
             BuildResult ??= result;

--- a/src/Build/BackEnd/BuildManager/BuildSubmissionBase.cs
+++ b/src/Build/BackEnd/BuildManager/BuildSubmissionBase.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Build.Execution
         /// </summary>
         protected internal BuildSubmissionBase(BuildManager buildManager, int submissionId)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(buildManager, nameof(buildManager));
+            ErrorUtilities.VerifyThrowArgumentNull(buildManager);
 
             BuildManager = buildManager;
             SubmissionId = submissionId;

--- a/src/Build/BackEnd/BuildManager/CacheAggregator.cs
+++ b/src/Build/BackEnd/BuildManager/CacheAggregator.cs
@@ -29,8 +29,8 @@ namespace Microsoft.Build.Execution
 
         public void Add(IConfigCache configCache, IResultsCache resultsCache)
         {
-            ErrorUtilities.VerifyThrowInternalNull(configCache, nameof(configCache));
-            ErrorUtilities.VerifyThrowInternalNull(resultsCache, nameof(resultsCache));
+            ErrorUtilities.VerifyThrowInternalNull(configCache);
+            ErrorUtilities.VerifyThrowInternalNull(resultsCache);
             ErrorUtilities.VerifyThrow(!_aggregated, "Cannot add after aggregation");
 
             _inputCaches.Add((configCache, resultsCache));

--- a/src/Build/BackEnd/BuildManager/CacheSerialization.cs
+++ b/src/Build/BackEnd/BuildManager/CacheSerialization.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Build.Execution
             string outputCacheFile,
             ProjectIsolationMode projectIsolationMode)
         {
-            ErrorUtilities.VerifyThrowInternalNull(outputCacheFile, nameof(outputCacheFile));
+            ErrorUtilities.VerifyThrowInternalNull(outputCacheFile);
 
             try
             {
@@ -127,8 +127,8 @@ namespace Microsoft.Build.Execution
                     translator.Translate(ref resultsCache);
                 }
 
-                ErrorUtilities.VerifyThrowInternalNull(configCache, nameof(configCache));
-                ErrorUtilities.VerifyThrowInternalNull(resultsCache, nameof(resultsCache));
+                ErrorUtilities.VerifyThrowInternalNull(configCache);
+                ErrorUtilities.VerifyThrowInternalNull(resultsCache);
 
                 return (configCache, resultsCache, null);
             }

--- a/src/Build/BackEnd/Client/MSBuildClientPacketPump.cs
+++ b/src/Build/BackEnd/Client/MSBuildClientPacketPump.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Build.BackEnd.Client
 
         public MSBuildClientPacketPump(Stream stream)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(stream, nameof(stream));
+            ErrorUtilities.VerifyThrowArgumentNull(stream);
 
             _stream = stream;
             _isServerDisconnecting = false;

--- a/src/Build/BackEnd/Components/BuildRequestEngine/BuildRequestEngine.cs
+++ b/src/Build/BackEnd/Components/BuildRequestEngine/BuildRequestEngine.cs
@@ -590,7 +590,7 @@ namespace Microsoft.Build.BackEnd
         /// <param name="host">The host.</param>
         public void InitializeComponent(IBuildComponentHost host)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(host, nameof(host));
+            ErrorUtilities.VerifyThrowArgumentNull(host);
             ErrorUtilities.VerifyThrow(_componentHost == null, "BuildRequestEngine already initialized!");
             _componentHost = host;
             _configCache = (IConfigCache)host.GetComponent(BuildComponentType.ConfigCache);
@@ -1330,7 +1330,7 @@ namespace Microsoft.Build.BackEnd
         private void IssueConfigurationRequest(BuildRequestConfiguration config)
         {
             ErrorUtilities.VerifyThrow(config.WasGeneratedByNode, "InvalidConfigurationId");
-            ErrorUtilities.VerifyThrowArgumentNull(config, nameof(config));
+            ErrorUtilities.VerifyThrowArgumentNull(config);
             ErrorUtilities.VerifyThrow(_unresolvedConfigurations.HasConfiguration(config.ConfigurationId), "NoUnresolvedConfiguration");
             TraceEngine("Issuing configuration request for node config {0}", config.ConfigurationId);
             RaiseNewConfigurationRequest(config);
@@ -1342,7 +1342,7 @@ namespace Microsoft.Build.BackEnd
         /// <param name="blocker">The information about why the request is blocked.</param>
         private void IssueBuildRequest(BuildRequestBlocker blocker)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(blocker, nameof(blocker));
+            ErrorUtilities.VerifyThrowArgumentNull(blocker);
 
             if (blocker.BuildRequests == null)
             {

--- a/src/Build/BackEnd/Components/BuildRequestEngine/BuildRequestEntry.cs
+++ b/src/Build/BackEnd/Components/BuildRequestEngine/BuildRequestEntry.cs
@@ -122,8 +122,8 @@ namespace Microsoft.Build.BackEnd
         /// <param name="requestConfiguration">The build request configuration.</param>
         internal BuildRequestEntry(BuildRequest request, BuildRequestConfiguration requestConfiguration)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(request, nameof(request));
-            ErrorUtilities.VerifyThrowArgumentNull(requestConfiguration, nameof(requestConfiguration));
+            ErrorUtilities.VerifyThrowArgumentNull(request);
+            ErrorUtilities.VerifyThrowArgumentNull(requestConfiguration);
             ErrorUtilities.VerifyThrow(requestConfiguration.ConfigurationId == request.ConfigurationId, "Configuration id mismatch");
 
             GlobalLock = new Object();
@@ -303,7 +303,7 @@ namespace Microsoft.Build.BackEnd
         {
             lock (GlobalLock)
             {
-                ErrorUtilities.VerifyThrowArgumentNull(result, nameof(result));
+                ErrorUtilities.VerifyThrowArgumentNull(result);
                 ErrorUtilities.VerifyThrow(State == BuildRequestEntryState.Waiting || _outstandingRequests == null, "Entry must be in the Waiting state to report results, or we must have flushed our requests due to an error. Config: {0} State: {1} Requests: {2}", RequestConfiguration.ConfigurationId, State, _outstandingRequests != null);
 
                 // If the matching request is in the issue list, remove it so we don't try to ask for it to be built.
@@ -471,7 +471,7 @@ namespace Microsoft.Build.BackEnd
         {
             lock (GlobalLock)
             {
-                ErrorUtilities.VerifyThrowArgumentNull(result, nameof(result));
+                ErrorUtilities.VerifyThrowArgumentNull(result);
                 ErrorUtilities.VerifyThrow(Result == null, "Entry already Completed.");
 
                 // If this request is determined to be a success, then all outstanding items must have been taken care of

--- a/src/Build/BackEnd/Components/BuildRequestEngine/FullyQualifiedBuildRequest.cs
+++ b/src/Build/BackEnd/Components/BuildRequestEngine/FullyQualifiedBuildRequest.cs
@@ -35,8 +35,8 @@ namespace Microsoft.Build.BackEnd
             bool skipStaticGraphIsolationConstraints = false,
             BuildRequestDataFlags flags = BuildRequestDataFlags.None)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(config, nameof(config));
-            ErrorUtilities.VerifyThrowArgumentNull(targets, nameof(targets));
+            ErrorUtilities.VerifyThrowArgumentNull(config);
+            ErrorUtilities.VerifyThrowArgumentNull(targets);
 
             Config = config;
             Targets = targets;

--- a/src/Build/BackEnd/Components/Caching/ConfigCache.cs
+++ b/src/Build/BackEnd/Components/Caching/ConfigCache.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Build.BackEnd
         /// <param name="config">The configuration to add.</param>
         public void AddConfiguration(BuildRequestConfiguration config)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(config, nameof(config));
+            ErrorUtilities.VerifyThrowArgumentNull(config);
             ErrorUtilities.VerifyThrow(config.ConfigurationId != 0, "Invalid configuration ID");
 
             lock (_lockObject)
@@ -107,7 +107,7 @@ namespace Microsoft.Build.BackEnd
         /// <returns>A matching configuration if one exists, null otherwise.</returns>
         public BuildRequestConfiguration GetMatchingConfiguration(BuildRequestConfiguration config)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(config, nameof(config));
+            ErrorUtilities.VerifyThrowArgumentNull(config);
             return GetMatchingConfiguration(new ConfigurationMetadata(config));
         }
 
@@ -118,7 +118,7 @@ namespace Microsoft.Build.BackEnd
         /// <returns>A matching configuration if one exists, null otherwise.</returns>
         public BuildRequestConfiguration GetMatchingConfiguration(ConfigurationMetadata configMetadata)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(configMetadata, nameof(configMetadata));
+            ErrorUtilities.VerifyThrowArgumentNull(configMetadata);
             lock (_lockObject)
             {
                 if (!_configurationIdsByMetadata.TryGetValue(configMetadata, out int configId))
@@ -341,7 +341,7 @@ namespace Microsoft.Build.BackEnd
         /// <param name="host">The build component host.</param>
         public void InitializeComponent(IBuildComponentHost host)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(host, nameof(host));
+            ErrorUtilities.VerifyThrowArgumentNull(host);
         }
 
         /// <summary>

--- a/src/Build/BackEnd/Components/Caching/ResultsCache.cs
+++ b/src/Build/BackEnd/Components/Caching/ResultsCache.cs
@@ -281,7 +281,7 @@ namespace Microsoft.Build.BackEnd
         /// <param name="host">The component host.</param>
         public void InitializeComponent(IBuildComponentHost host)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(host, nameof(host));
+            ErrorUtilities.VerifyThrowArgumentNull(host);
         }
 
         /// <summary>
@@ -350,7 +350,7 @@ namespace Microsoft.Build.BackEnd
         /// <param name="buildResult">The candidate build result.</param>
         /// <returns>True if the flags and project state filter of the build request is compatible with the build result.</returns>
         private static bool AreBuildResultFlagsCompatible(BuildRequest buildRequest, BuildResult buildResult)
-        { 
+        {
             if (buildResult.BuildRequestDataFlags is null)
             {
                 return true;

--- a/src/Build/BackEnd/Components/Communications/NodeEndpointInProc.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeEndpointInProc.cs
@@ -162,7 +162,7 @@ namespace Microsoft.Build.BackEnd
         /// <param name="factory">Unused</param>
         public void Listen(INodePacketFactory factory)
         {
-            ErrorUtilities.VerifyThrowInternalNull(factory, nameof(factory));
+            ErrorUtilities.VerifyThrowInternalNull(factory);
             _packetFactory = factory;
 
             // Initialize our thread in async mode so we are ready when the Node-side endpoint "connects".
@@ -180,7 +180,7 @@ namespace Microsoft.Build.BackEnd
         /// <param name="factory">Unused</param>
         public void Connect(INodePacketFactory factory)
         {
-            ErrorUtilities.VerifyThrowInternalNull(factory, nameof(factory));
+            ErrorUtilities.VerifyThrowInternalNull(factory);
             _packetFactory = factory;
 
             // Set up asynchronous packet pump, if necessary.

--- a/src/Build/BackEnd/Components/Communications/NodeEndpointInProc.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeEndpointInProc.cs
@@ -101,7 +101,7 @@ namespace Microsoft.Build.BackEnd
         /// <param name="host">The component host.</param>
         private NodeEndpointInProc(EndpointMode commMode, IBuildComponentHost host)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(host, nameof(host));
+            ErrorUtilities.VerifyThrowArgumentNull(host);
 
             _status = LinkStatus.Inactive;
             _mode = commMode;
@@ -331,7 +331,7 @@ namespace Microsoft.Build.BackEnd
         /// <param name="packet">The packet to be transmitted.</param>
         private void EnqueuePacket(INodePacket packet)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(packet, nameof(packet));
+            ErrorUtilities.VerifyThrowArgumentNull(packet);
             ErrorUtilities.VerifyThrow(_mode == EndpointMode.Asynchronous, "EndPoint mode is synchronous, should be asynchronous");
             ErrorUtilities.VerifyThrow(_packetQueue != null, "packetQueue is null");
             ErrorUtilities.VerifyThrow(_packetAvailable != null, "packetAvailable is null");

--- a/src/Build/BackEnd/Components/Communications/NodeProviderInProc.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderInProc.cs
@@ -157,7 +157,7 @@ namespace Microsoft.Build.BackEnd
         public void SendData(int nodeId, INodePacket packet)
         {
             ErrorUtilities.VerifyThrowArgumentOutOfRange(nodeId == _inProcNodeId, "node");
-            ErrorUtilities.VerifyThrowArgumentNull(packet, nameof(packet));
+            ErrorUtilities.VerifyThrowArgumentNull(packet);
 
             if (_inProcNode == null)
             {

--- a/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProc.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProc.cs
@@ -78,7 +78,7 @@ namespace Microsoft.Build.BackEnd
         /// </summary>
         public IList<NodeInfo> CreateNodes(int nextNodeId, INodePacketFactory factory, Func<NodeInfo, NodeConfiguration> configurationFactory, int numberOfNodesToCreate)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(factory, nameof(factory));
+            ErrorUtilities.VerifyThrowArgumentNull(factory);
 
             // This can run concurrently. To be properly detect internal bug when we create more nodes than allowed
             //   we add into _nodeContexts premise of future node and verify that it will not cross limits.

--- a/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
@@ -95,7 +95,7 @@ namespace Microsoft.Build.BackEnd
         /// <param name="packet">The packet to send.</param>
         protected void SendData(NodeContext context, INodePacket packet)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(packet, nameof(packet));
+            ErrorUtilities.VerifyThrowArgumentNull(packet);
             context.SendData(packet);
         }
 

--- a/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcTaskHost.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcTaskHost.cs
@@ -527,7 +527,7 @@ namespace Microsoft.Build.BackEnd
         /// </summary>
         internal bool CreateNode(HandshakeOptions hostContext, INodePacketFactory factory, INodePacketHandler handler, TaskHostConfiguration configuration)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(factory, nameof(factory));
+            ErrorUtilities.VerifyThrowArgumentNull(factory);
             ErrorUtilities.VerifyThrow(!_nodeIdToPacketFactory.ContainsKey((int)hostContext), "We should not already have a factory for this context!  Did we forget to call DisconnectFromHost somewhere?");
 
             if (AvailableNodes <= 0)

--- a/src/Build/BackEnd/Components/Logging/ForwardingLoggerRecord.cs
+++ b/src/Build/BackEnd/Components/Logging/ForwardingLoggerRecord.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Build.Logging
         public ForwardingLoggerRecord(ILogger centralLogger, LoggerDescription forwardingLoggerDescription)
         {
             // The logging service allows a null central logger, so we don't check for it here.
-            ErrorUtilities.VerifyThrowArgumentNull(forwardingLoggerDescription, nameof(forwardingLoggerDescription));
+            ErrorUtilities.VerifyThrowArgumentNull(forwardingLoggerDescription);
 
             this.CentralLogger = centralLogger;
             this.ForwardingLoggerDescription = forwardingLoggerDescription;

--- a/src/Build/BackEnd/Components/Logging/LoggingContext.cs
+++ b/src/Build/BackEnd/Components/Logging/LoggingContext.cs
@@ -42,8 +42,8 @@ namespace Microsoft.Build.BackEnd.Logging
         /// <param name="eventContext">The event context</param>
         public LoggingContext(ILoggingService loggingService, BuildEventContext eventContext)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(loggingService, nameof(loggingService));
-            ErrorUtilities.VerifyThrowArgumentNull(eventContext, nameof(eventContext));
+            ErrorUtilities.VerifyThrowArgumentNull(loggingService);
+            ErrorUtilities.VerifyThrowArgumentNull(eventContext);
 
             _loggingService = loggingService;
             _eventContext = eventContext;

--- a/src/Build/BackEnd/Components/ProjectCache/CacheResult.cs
+++ b/src/Build/BackEnd/Components/ProjectCache/CacheResult.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Build.Experimental.ProjectCache
 
         public static CacheResult IndicateCacheHit(IReadOnlyCollection<PluginTargetResult> targetResults)
         {
-            ErrorUtilities.VerifyThrowArgumentLength(targetResults, nameof(targetResults));
+            ErrorUtilities.VerifyThrowArgumentLength(targetResults);
 
             return new CacheResult(CacheResultType.CacheHit, ConstructBuildResult(targetResults));
         }

--- a/src/Build/BackEnd/Components/ProjectCache/ProxyTargets.cs
+++ b/src/Build/BackEnd/Components/ProjectCache/ProxyTargets.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Build.Experimental.ProjectCache
 
         public ProxyTargets(IReadOnlyDictionary<string, string> proxyTargetToRealTargetMap)
         {
-            ErrorUtilities.VerifyThrowArgumentLength(proxyTargetToRealTargetMap, nameof(proxyTargetToRealTargetMap));
+            ErrorUtilities.VerifyThrowArgumentLength(proxyTargetToRealTargetMap);
 
             _proxyTargetToRealTargetMap = proxyTargetToRealTargetMap.ToDictionary(kvp => kvp.Key, kvp => kvp.Value, StringComparer.OrdinalIgnoreCase);
         }

--- a/src/Build/BackEnd/Components/RequestBuilder/Lookup.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/Lookup.cs
@@ -90,8 +90,8 @@ namespace Microsoft.Build.BackEnd
         /// </summary>
         internal Lookup(IItemDictionary<ProjectItemInstance> projectItems, PropertyDictionary<ProjectPropertyInstance> properties)
         {
-            ErrorUtilities.VerifyThrowInternalNull(projectItems, nameof(projectItems));
-            ErrorUtilities.VerifyThrowInternalNull(properties, nameof(properties));
+            ErrorUtilities.VerifyThrowInternalNull(projectItems);
+            ErrorUtilities.VerifyThrowInternalNull(properties);
 
             Lookup.Scope scope = new Lookup.Scope(this, "Lookup()", projectItems, properties);
             _lookupScopes.AddFirst(scope);

--- a/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
@@ -196,8 +196,8 @@ namespace Microsoft.Build.BackEnd
         /// <param name="entry">The entry to build.</param>
         public void BuildRequest(NodeLoggingContext loggingContext, BuildRequestEntry entry)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(loggingContext, nameof(loggingContext));
-            ErrorUtilities.VerifyThrowArgumentNull(entry, nameof(entry));
+            ErrorUtilities.VerifyThrowArgumentNull(loggingContext);
+            ErrorUtilities.VerifyThrowArgumentNull(entry);
             ErrorUtilities.VerifyThrow(_componentHost != null, "Host not set.");
             ErrorUtilities.VerifyThrow(_targetBuilder == null, "targetBuilder not null");
             ErrorUtilities.VerifyThrow(_nodeLoggingContext == null, "nodeLoggingContext not null");
@@ -332,10 +332,10 @@ namespace Microsoft.Build.BackEnd
         public async Task<BuildResult[]> BuildProjects(string[] projectFiles, PropertyDictionary<ProjectPropertyInstance>[] properties, string[] toolsVersions, string[] targets, bool waitForResults, bool skipNonexistentTargets = false)
         {
             VerifyIsNotZombie();
-            ErrorUtilities.VerifyThrowArgumentNull(projectFiles, nameof(projectFiles));
-            ErrorUtilities.VerifyThrowArgumentNull(properties, nameof(properties));
-            ErrorUtilities.VerifyThrowArgumentNull(targets, nameof(targets));
-            ErrorUtilities.VerifyThrowArgumentNull(toolsVersions, nameof(toolsVersions));
+            ErrorUtilities.VerifyThrowArgumentNull(projectFiles);
+            ErrorUtilities.VerifyThrowArgumentNull(properties);
+            ErrorUtilities.VerifyThrowArgumentNull(targets);
+            ErrorUtilities.VerifyThrowArgumentNull(toolsVersions);
             ErrorUtilities.VerifyThrow(_componentHost != null, "No host object set");
             ErrorUtilities.VerifyThrow(projectFiles.Length == properties.Length, "Properties and project counts not the same");
             ErrorUtilities.VerifyThrow(projectFiles.Length == toolsVersions.Length, "Tools versions and project counts not the same");
@@ -550,7 +550,7 @@ namespace Microsoft.Build.BackEnd
         /// <param name="host">The component host.</param>
         public void InitializeComponent(IBuildComponentHost host)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(host, nameof(host));
+            ErrorUtilities.VerifyThrowArgumentNull(host);
             ErrorUtilities.VerifyThrow(_componentHost == null, "RequestBuilder already initialized.");
             _componentHost = host;
         }
@@ -1105,7 +1105,7 @@ namespace Microsoft.Build.BackEnd
         {
             ErrorUtilities.VerifyThrow(_targetBuilder != null, "Target builder is null");
 
-            // We consider this the entrypoint for the project build for purposes of BuildCheck processing 
+            // We consider this the entrypoint for the project build for purposes of BuildCheck processing
             bool isRestoring = _requestEntry.RequestConfiguration.GlobalProperties[MSBuildConstants.MSBuildIsRestoring] is not null;
 
             var buildCheckManager = isRestoring
@@ -1155,7 +1155,7 @@ namespace Microsoft.Build.BackEnd
                     _requestEntry.Request.BuildEventContext);
             }
 
-            
+
             try
             {
                 HandleProjectStarted(buildCheckManager);

--- a/src/Build/BackEnd/Components/RequestBuilder/TargetBuilder.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TargetBuilder.cs
@@ -103,10 +103,10 @@ namespace Microsoft.Build.BackEnd
         public async Task<BuildResult> BuildTargets(ProjectLoggingContext loggingContext, BuildRequestEntry entry, IRequestBuilderCallback callback, (string name, TargetBuiltReason reason)[] targetNames, Lookup baseLookup, CancellationToken cancellationToken)
         {
             ErrorUtilities.VerifyThrowArgumentNull(loggingContext, "projectLoggingContext");
-            ErrorUtilities.VerifyThrowArgumentNull(entry, nameof(entry));
+            ErrorUtilities.VerifyThrowArgumentNull(entry);
             ErrorUtilities.VerifyThrowArgumentNull(callback, "requestBuilderCallback");
-            ErrorUtilities.VerifyThrowArgumentNull(targetNames, nameof(targetNames));
-            ErrorUtilities.VerifyThrowArgumentNull(baseLookup, nameof(baseLookup));
+            ErrorUtilities.VerifyThrowArgumentNull(targetNames);
+            ErrorUtilities.VerifyThrowArgumentNull(baseLookup);
             ErrorUtilities.VerifyThrow(targetNames.Length > 0, "List of targets must be non-empty");
             ErrorUtilities.VerifyThrow(_componentHost != null, "InitializeComponent must be called before building targets.");
 
@@ -212,7 +212,7 @@ namespace Microsoft.Build.BackEnd
         /// <param name="host">The component host.</param>
         public void InitializeComponent(IBuildComponentHost host)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(host, nameof(host));
+            ErrorUtilities.VerifyThrowArgumentNull(host);
             _componentHost = host;
         }
 

--- a/src/Build/BackEnd/Components/RequestBuilder/TargetEntry.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TargetEntry.cs
@@ -175,11 +175,11 @@ namespace Microsoft.Build.BackEnd
             LoggingContext loggingContext,
             bool stopProcessingOnCompletion)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(requestEntry, nameof(requestEntry));
-            ErrorUtilities.VerifyThrowArgumentNull(targetBuilderCallback, nameof(targetBuilderCallback));
+            ErrorUtilities.VerifyThrowArgumentNull(requestEntry);
+            ErrorUtilities.VerifyThrowArgumentNull(targetBuilderCallback);
             ErrorUtilities.VerifyThrowArgumentNull(targetSpecification, "targetName");
             ErrorUtilities.VerifyThrowArgumentNull(baseLookup, "lookup");
-            ErrorUtilities.VerifyThrowArgumentNull(host, nameof(host));
+            ErrorUtilities.VerifyThrowArgumentNull(host);
 
             _requestEntry = requestEntry;
             _targetBuilderCallback = targetBuilderCallback;

--- a/src/Build/BackEnd/Components/RequestBuilder/TargetSpecification.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TargetSpecification.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Build.BackEnd
         /// <param name="targetBuiltReason">Reason the target is being built</param>
         internal TargetSpecification(string targetName, ElementLocation referenceLocation, TargetBuiltReason targetBuiltReason = TargetBuiltReason.None)
         {
-            ErrorUtilities.VerifyThrowArgumentLength(targetName, nameof(targetName));
+            ErrorUtilities.VerifyThrowArgumentLength(targetName);
             ErrorUtilities.VerifyThrowArgumentNull(referenceLocation);
 
             this._targetName = targetName;

--- a/src/Build/BackEnd/Components/RequestBuilder/TargetSpecification.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TargetSpecification.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Build.BackEnd
         internal TargetSpecification(string targetName, ElementLocation referenceLocation, TargetBuiltReason targetBuiltReason = TargetBuiltReason.None)
         {
             ErrorUtilities.VerifyThrowArgumentLength(targetName, nameof(targetName));
-            ErrorUtilities.VerifyThrowArgumentNull(referenceLocation, nameof(referenceLocation));
+            ErrorUtilities.VerifyThrowArgumentNull(referenceLocation);
 
             this._targetName = targetName;
             this._referenceLocation = referenceLocation;

--- a/src/Build/BackEnd/Components/RequestBuilder/TaskBuilder.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TaskBuilder.cs
@@ -293,7 +293,7 @@ namespace Microsoft.Build.BackEnd
         /// <returns>true, if successful</returns>
         private async Task<WorkUnitResult> ExecuteTask(TaskExecutionMode mode, Lookup lookup)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(lookup, nameof(lookup));
+            ErrorUtilities.VerifyThrowArgumentNull(lookup);
 
             WorkUnitResult taskResult = new WorkUnitResult(WorkUnitResultCode.Failed, WorkUnitActionCode.Stop, null);
             TaskHost taskHost = null;

--- a/src/Build/BackEnd/Components/RequestBuilder/TaskHost.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TaskHost.cs
@@ -114,8 +114,8 @@ namespace Microsoft.Build.BackEnd
         /// <param name="targetBuilderCallback">An <see cref="ITargetBuilderCallback"/> to use to invoke targets and build projects.</param>
         public TaskHost(IBuildComponentHost host, BuildRequestEntry requestEntry, ElementLocation taskLocation, ITargetBuilderCallback targetBuilderCallback)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(host, nameof(host));
-            ErrorUtilities.VerifyThrowArgumentNull(requestEntry, nameof(requestEntry));
+            ErrorUtilities.VerifyThrowArgumentNull(host);
+            ErrorUtilities.VerifyThrowArgumentNull(requestEntry);
             ErrorUtilities.VerifyThrowInternalNull(taskLocation, nameof(taskLocation));
 
             _host = host;
@@ -408,7 +408,7 @@ namespace Microsoft.Build.BackEnd
         {
             lock (_callbackMonitor)
             {
-                ErrorUtilities.VerifyThrowArgumentNull(e, nameof(e));
+                ErrorUtilities.VerifyThrowArgumentNull(e);
 
                 if (!_activeProxy)
                 {
@@ -478,7 +478,7 @@ namespace Microsoft.Build.BackEnd
         {
             lock (_callbackMonitor)
             {
-                ErrorUtilities.VerifyThrowArgumentNull(e, nameof(e));
+                ErrorUtilities.VerifyThrowArgumentNull(e);
 
                 if (!_activeProxy)
                 {
@@ -519,7 +519,7 @@ namespace Microsoft.Build.BackEnd
         {
             lock (_callbackMonitor)
             {
-                ErrorUtilities.VerifyThrowArgumentNull(e, nameof(e));
+                ErrorUtilities.VerifyThrowArgumentNull(e);
 
                 if (!_activeProxy)
                 {
@@ -560,7 +560,7 @@ namespace Microsoft.Build.BackEnd
         {
             lock (_callbackMonitor)
             {
-                ErrorUtilities.VerifyThrowArgumentNull(e, nameof(e));
+                ErrorUtilities.VerifyThrowArgumentNull(e);
 
                 if (!_activeProxy)
                 {
@@ -651,7 +651,7 @@ namespace Microsoft.Build.BackEnd
         {
             lock (_callbackMonitor)
             {
-                ErrorUtilities.VerifyThrowArgumentNull(eventName, nameof(eventName));
+                ErrorUtilities.VerifyThrowArgumentNull(eventName);
 
                 if (!_activeProxy)
                 {
@@ -965,8 +965,8 @@ namespace Microsoft.Build.BackEnd
         /// </summary>
         public async Task<BuildEngineResult> InternalBuildProjects(string[] projectFileNames, string[] targetNames, IDictionary[] globalProperties, IList<String>[] undefineProperties, string[] toolsVersion, bool returnTargetOutputs, bool skipNonexistentTargets = false)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(projectFileNames, nameof(projectFileNames));
-            ErrorUtilities.VerifyThrowArgumentNull(globalProperties, nameof(globalProperties));
+            ErrorUtilities.VerifyThrowArgumentNull(projectFileNames);
+            ErrorUtilities.VerifyThrowArgumentNull(globalProperties);
             VerifyActiveProxy();
 
             BuildEngineResult result;
@@ -1138,8 +1138,8 @@ namespace Microsoft.Build.BackEnd
         /// <returns>A Task returning a structure containing the result of the build, success or failure and the list of target outputs per project</returns>
         private async Task<BuildEngineResult> BuildProjectFilesInParallelAsync(string[] projectFileNames, string[] targetNames, IDictionary[] globalProperties, IList<String>[] undefineProperties, string[] toolsVersion, bool returnTargetOutputs, bool skipNonexistentTargets = false)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(projectFileNames, nameof(projectFileNames));
-            ErrorUtilities.VerifyThrowArgumentNull(globalProperties, nameof(globalProperties));
+            ErrorUtilities.VerifyThrowArgumentNull(projectFileNames);
+            ErrorUtilities.VerifyThrowArgumentNull(globalProperties);
             VerifyActiveProxy();
 
             List<IDictionary<string, ITaskItem[]>> targetOutputsPerProject = null;

--- a/src/Build/BackEnd/Components/RequestBuilder/TaskHost.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TaskHost.cs
@@ -116,7 +116,7 @@ namespace Microsoft.Build.BackEnd
         {
             ErrorUtilities.VerifyThrowArgumentNull(host);
             ErrorUtilities.VerifyThrowArgumentNull(requestEntry);
-            ErrorUtilities.VerifyThrowInternalNull(taskLocation, nameof(taskLocation));
+            ErrorUtilities.VerifyThrowInternalNull(taskLocation);
 
             _host = host;
             _requestEntry = requestEntry;

--- a/src/Build/BackEnd/Components/Scheduler/SchedulableRequest.cs
+++ b/src/Build/BackEnd/Components/Scheduler/SchedulableRequest.cs
@@ -126,8 +126,8 @@ namespace Microsoft.Build.BackEnd
         /// </summary>
         public SchedulableRequest(SchedulingData collection, BuildRequest request, SchedulableRequest parent)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(collection, nameof(collection));
-            ErrorUtilities.VerifyThrowArgumentNull(request, nameof(request));
+            ErrorUtilities.VerifyThrowArgumentNull(collection);
+            ErrorUtilities.VerifyThrowArgumentNull(request);
             ErrorUtilities.VerifyThrow((parent == null) || (parent._schedulingData == collection), "Parent request does not belong to the same collection.");
 
             _schedulingData = collection;
@@ -311,7 +311,7 @@ namespace Microsoft.Build.BackEnd
         public void Yield(string[] activeTargets)
         {
             VerifyState(SchedulableRequestState.Executing);
-            ErrorUtilities.VerifyThrowArgumentNull(activeTargets, nameof(activeTargets));
+            ErrorUtilities.VerifyThrowArgumentNull(activeTargets);
             _activeTargetsWhenBlocked = activeTargets;
             ChangeToState(SchedulableRequestState.Yielding);
         }
@@ -335,8 +335,8 @@ namespace Microsoft.Build.BackEnd
         public void BlockByRequest(SchedulableRequest blockingRequest, string[] activeTargets, string blockingTarget = null)
         {
             VerifyOneOfStates([SchedulableRequestState.Blocked, SchedulableRequestState.Executing]);
-            ErrorUtilities.VerifyThrowArgumentNull(blockingRequest, nameof(blockingRequest));
-            ErrorUtilities.VerifyThrowArgumentNull(activeTargets, nameof(activeTargets));
+            ErrorUtilities.VerifyThrowArgumentNull(blockingRequest);
+            ErrorUtilities.VerifyThrowArgumentNull(activeTargets);
             ErrorUtilities.VerifyThrow(BlockingTarget == null, "Cannot block again if we're already blocked on a target");
 
             // Note that the blocking request will typically be our parent UNLESS it is a request we blocked on because it was executing a target we wanted to execute.
@@ -372,7 +372,7 @@ namespace Microsoft.Build.BackEnd
         public void UnblockWithPartialResultForBlockingTarget(BuildResult result)
         {
             VerifyOneOfStates([SchedulableRequestState.Blocked, SchedulableRequestState.Unscheduled]);
-            ErrorUtilities.VerifyThrowArgumentNull(result, nameof(result));
+            ErrorUtilities.VerifyThrowArgumentNull(result);
 
             BlockingRequestKey key = new BlockingRequestKey(result);
             DisconnectRequestWeAreBlockedBy(key);
@@ -385,7 +385,7 @@ namespace Microsoft.Build.BackEnd
         public void UnblockWithResult(BuildResult result)
         {
             VerifyOneOfStates([SchedulableRequestState.Blocked, SchedulableRequestState.Unscheduled]);
-            ErrorUtilities.VerifyThrowArgumentNull(result, nameof(result));
+            ErrorUtilities.VerifyThrowArgumentNull(result);
 
             BlockingRequestKey key = new BlockingRequestKey(result);
             DisconnectRequestWeAreBlockedBy(key);

--- a/src/Build/BackEnd/Components/Scheduler/Scheduler.cs
+++ b/src/Build/BackEnd/Components/Scheduler/Scheduler.cs
@@ -2033,7 +2033,7 @@ namespace Microsoft.Build.BackEnd
                 SchedulableRequest parentRequest = _schedulingData.BlockedRequests.FirstOrDefault(r => r.BuildRequest.GlobalRequestId == request.ParentGlobalRequestId)
                     ?? _schedulingData.ExecutingRequests.FirstOrDefault(r => r.BuildRequest.GlobalRequestId == request.ParentGlobalRequestId);
 
-                ErrorUtilities.VerifyThrowInternalNull(parentRequest, nameof(parentRequest));
+                ErrorUtilities.VerifyThrowInternalNull(parentRequest);
                 ErrorUtilities.VerifyThrow(
                     configCache.HasConfiguration(parentRequest.BuildRequest.ConfigurationId),
                     "All non root requests should have a parent with a loaded configuration");

--- a/src/Build/BackEnd/Components/Scheduler/Scheduler.cs
+++ b/src/Build/BackEnd/Components/Scheduler/Scheduler.cs
@@ -1354,8 +1354,8 @@ namespace Microsoft.Build.BackEnd
         /// </summary>
         private void AssignUnscheduledRequestToNode(SchedulableRequest request, int nodeId, List<ScheduleResponse> responses)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(request, nameof(request));
-            ErrorUtilities.VerifyThrowArgumentNull(responses, nameof(responses));
+            ErrorUtilities.VerifyThrowArgumentNull(request);
+            ErrorUtilities.VerifyThrowArgumentNull(responses);
             ErrorUtilities.VerifyThrow(nodeId != InvalidNodeId, "Invalid node id specified.");
 
             request.VerifyState(SchedulableRequestState.Unscheduled);
@@ -1619,8 +1619,8 @@ namespace Microsoft.Build.BackEnd
         /// </summary>
         private void HandleRequestBlockedOnInProgressTarget(SchedulableRequest blockedRequest, BuildRequestBlocker blocker)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(blockedRequest, nameof(blockedRequest));
-            ErrorUtilities.VerifyThrowArgumentNull(blocker, nameof(blocker));
+            ErrorUtilities.VerifyThrowArgumentNull(blockedRequest);
+            ErrorUtilities.VerifyThrowArgumentNull(blocker);
 
             // We are blocked on an in-progress request building a target whose results we need.
             SchedulableRequest blockingRequest = _schedulingData.GetScheduledRequest(blocker.BlockingRequestId);
@@ -1678,8 +1678,8 @@ namespace Microsoft.Build.BackEnd
         /// </summary>
         private void HandleRequestBlockedByNewRequests(SchedulableRequest parentRequest, BuildRequestBlocker blocker, List<ScheduleResponse> responses)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(blocker, nameof(blocker));
-            ErrorUtilities.VerifyThrowArgumentNull(responses, nameof(responses));
+            ErrorUtilities.VerifyThrowArgumentNull(blocker);
+            ErrorUtilities.VerifyThrowArgumentNull(responses);
 
             // The request is waiting on new requests.
             bool abortRequestBatch = false;

--- a/src/Build/BackEnd/Components/SdkResolution/MainNodeSdkResolverService.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/MainNodeSdkResolverService.cs
@@ -98,9 +98,9 @@ namespace Microsoft.Build.BackEnd.SdkResolution
         /// <inheritdoc cref="ISdkResolverService.ResolveSdk"/>
         public override SdkResult ResolveSdk(int submissionId, SdkReference sdk, LoggingContext loggingContext, ElementLocation sdkReferenceLocation, string solutionPath, string projectPath, bool interactive, bool isRunningInVisualStudio, bool failOnUnresolvedSdk)
         {
-            ErrorUtilities.VerifyThrowInternalNull(sdk, nameof(sdk));
-            ErrorUtilities.VerifyThrowInternalNull(loggingContext, nameof(loggingContext));
-            ErrorUtilities.VerifyThrowInternalNull(sdkReferenceLocation, nameof(sdkReferenceLocation));
+            ErrorUtilities.VerifyThrowInternalNull(sdk);
+            ErrorUtilities.VerifyThrowInternalNull(loggingContext);
+            ErrorUtilities.VerifyThrowInternalNull(sdkReferenceLocation);
             ErrorUtilities.VerifyThrowInternalLength(projectPath, nameof(projectPath));
 
             return _cachedSdkResolver.ResolveSdk(submissionId, sdk, loggingContext, sdkReferenceLocation, solutionPath, projectPath, interactive, isRunningInVisualStudio, failOnUnresolvedSdk);

--- a/src/Build/BackEnd/Components/SdkResolution/OutOfProcNodeSdkResolverService.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/OutOfProcNodeSdkResolverService.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Build.BackEnd.SdkResolution
         /// <param name="sendPacket">A <see cref="Action{INodePacket}"/> to use when sending packets to the main node.</param>
         public OutOfProcNodeSdkResolverService(Action<INodePacket> sendPacket)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(sendPacket, nameof(sendPacket));
+            ErrorUtilities.VerifyThrowArgumentNull(sendPacket);
 
             SendPacket = sendPacket;
         }

--- a/src/Build/BackEnd/Node/ServerNodeBuildCommand.cs
+++ b/src/Build/BackEnd/Node/ServerNodeBuildCommand.cs
@@ -90,7 +90,7 @@ namespace Microsoft.Build.BackEnd
             TargetConsoleConfiguration consoleConfiguration,
             PartialBuildTelemetry? partialBuildTelemetry)
         {
-            ErrorUtilities.VerifyThrowInternalNull(consoleConfiguration, nameof(consoleConfiguration));
+            ErrorUtilities.VerifyThrowInternalNull(consoleConfiguration);
 
             _commandLine = commandLine;
             _startupDirectory = startupDirectory;

--- a/src/Build/BackEnd/Shared/BuildRequest.cs
+++ b/src/Build/BackEnd/Shared/BuildRequest.cs
@@ -185,7 +185,7 @@ namespace Microsoft.Build.BackEnd
         : this(submissionId, nodeRequestId, configurationId, hostServices, buildRequestDataFlags, requestedProjectState, projectContextId)
         {
             ErrorUtilities.VerifyThrowArgumentNull(escapedTargets, "targets");
-            ErrorUtilities.VerifyThrowArgumentNull(parentBuildEventContext, nameof(parentBuildEventContext));
+            ErrorUtilities.VerifyThrowArgumentNull(parentBuildEventContext);
 
             // When targets come into a build request, we unescape them.
             _targets = new List<string>(escapedTargets.Count);

--- a/src/Build/BackEnd/Shared/BuildRequestConfiguration.cs
+++ b/src/Build/BackEnd/Shared/BuildRequestConfiguration.cs
@@ -808,7 +808,7 @@ namespace Microsoft.Build.BackEnd
 
         public bool ShouldSkipIsolationConstraintsForReference(string referenceFullPath)
         {
-            ErrorUtilities.VerifyThrowInternalNull(Project, nameof(Project));
+            ErrorUtilities.VerifyThrowInternalNull(Project);
             ErrorUtilities.VerifyThrowInternalLength(referenceFullPath, nameof(referenceFullPath));
             ErrorUtilities.VerifyThrow(Path.IsPathRooted(referenceFullPath), "Method does not treat path normalization cases");
 

--- a/src/Build/BackEnd/Shared/BuildRequestConfiguration.cs
+++ b/src/Build/BackEnd/Shared/BuildRequestConfiguration.cs
@@ -167,7 +167,7 @@ namespace Microsoft.Build.BackEnd
         /// <param name="defaultToolsVersion">The default ToolsVersion to use as a fallback</param>
         internal BuildRequestConfiguration(int configId, BuildRequestData data, string defaultToolsVersion)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(data, nameof(data));
+            ErrorUtilities.VerifyThrowArgumentNull(data);
             ErrorUtilities.VerifyThrowInternalLength(data.ProjectFullPath, "data.ProjectFullPath");
 
             _configId = configId;
@@ -209,7 +209,7 @@ namespace Microsoft.Build.BackEnd
         /// <param name="instance">The project instance.</param>
         internal BuildRequestConfiguration(int configId, ProjectInstance instance)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(instance, nameof(instance));
+            ErrorUtilities.VerifyThrowArgumentNull(instance);
 
             _configId = configId;
             _projectFullPath = instance.FullPath;
@@ -230,7 +230,7 @@ namespace Microsoft.Build.BackEnd
         private BuildRequestConfiguration(int configId, BuildRequestConfiguration other)
         {
             ErrorUtilities.VerifyThrow(configId != InvalidConfigurationId, "Configuration ID must not be invalid when using this constructor.");
-            ErrorUtilities.VerifyThrowArgumentNull(other, nameof(other));
+            ErrorUtilities.VerifyThrowArgumentNull(other);
             ErrorUtilities.VerifyThrow(other._transferredState == null, "Unexpected transferred state still set on other configuration.");
 
             _project = other._project;

--- a/src/Build/BackEnd/Shared/BuildRequestUnblocker.cs
+++ b/src/Build/BackEnd/Shared/BuildRequestUnblocker.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Build.BackEnd
         /// </summary>
         internal BuildRequestUnblocker(BuildResult buildResult)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(buildResult, nameof(buildResult));
+            ErrorUtilities.VerifyThrowArgumentNull(buildResult);
             _buildResult = buildResult;
             _blockedGlobalRequestId = buildResult.ParentGlobalRequestId;
         }
@@ -63,7 +63,7 @@ namespace Microsoft.Build.BackEnd
         internal BuildRequestUnblocker(BuildRequest parentRequest, BuildResult buildResult)
             : this(buildResult)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(parentRequest, nameof(parentRequest));
+            ErrorUtilities.VerifyThrowArgumentNull(parentRequest);
             _blockedGlobalRequestId = parentRequest.GlobalRequestId;
         }
 

--- a/src/Build/BackEnd/Shared/BuildResult.cs
+++ b/src/Build/BackEnd/Shared/BuildResult.cs
@@ -523,8 +523,8 @@ namespace Microsoft.Build.Execution
         /// <param name="result">The results for the target.</param>
         public void AddResultsForTarget(string target, TargetResult result)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(target, nameof(target));
-            ErrorUtilities.VerifyThrowArgumentNull(result, nameof(result));
+            ErrorUtilities.VerifyThrowArgumentNull(target);
+            ErrorUtilities.VerifyThrowArgumentNull(result);
 
             lock (this)
             {
@@ -564,7 +564,7 @@ namespace Microsoft.Build.Execution
         /// <param name="results">The results to merge in.</param>
         public void MergeResults(BuildResult results)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(results, nameof(results));
+            ErrorUtilities.VerifyThrowArgumentNull(results);
             ErrorUtilities.VerifyThrow(results.ConfigurationId == ConfigurationId, "Result configurations don't match");
 
             // If we are merging with ourself or with a shallow clone, do nothing.

--- a/src/Build/BackEnd/Shared/ConfigurationMetadata.cs
+++ b/src/Build/BackEnd/Shared/ConfigurationMetadata.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Build.BackEnd
         /// </summary>
         public ConfigurationMetadata(string projectFullPath, PropertyDictionary<ProjectPropertyInstance> globalProperties)
         {
-            ErrorUtilities.VerifyThrowArgumentLength(projectFullPath, nameof(projectFullPath));
+            ErrorUtilities.VerifyThrowArgumentLength(projectFullPath);
             ErrorUtilities.VerifyThrowArgumentNull(globalProperties);
 
             _projectFullPath = projectFullPath;

--- a/src/Build/BackEnd/Shared/ConfigurationMetadata.cs
+++ b/src/Build/BackEnd/Shared/ConfigurationMetadata.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Build.BackEnd
         /// </summary>
         public ConfigurationMetadata(BuildRequestConfiguration configuration)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(configuration, nameof(configuration));
+            ErrorUtilities.VerifyThrowArgumentNull(configuration);
             _globalProperties = new PropertyDictionary<ProjectPropertyInstance>(configuration.GlobalProperties);
             _projectFullPath = FileUtilities.NormalizePath(configuration.ProjectFullPath);
             _toolsVersion = configuration.ToolsVersion;
@@ -35,7 +35,7 @@ namespace Microsoft.Build.BackEnd
         /// </summary>
         public ConfigurationMetadata(Project project)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(project, nameof(project));
+            ErrorUtilities.VerifyThrowArgumentNull(project);
             _globalProperties = new PropertyDictionary<ProjectPropertyInstance>(project.GlobalPropertiesCount);
             foreach (KeyValuePair<string, string> entry in project.GlobalPropertiesEnumerable)
             {
@@ -52,7 +52,7 @@ namespace Microsoft.Build.BackEnd
         public ConfigurationMetadata(string projectFullPath, PropertyDictionary<ProjectPropertyInstance> globalProperties)
         {
             ErrorUtilities.VerifyThrowArgumentLength(projectFullPath, nameof(projectFullPath));
-            ErrorUtilities.VerifyThrowArgumentNull(globalProperties, nameof(globalProperties));
+            ErrorUtilities.VerifyThrowArgumentNull(globalProperties);
 
             _projectFullPath = projectFullPath;
             _toolsVersion = MSBuildConstants.CurrentToolsVersion;

--- a/src/Build/BackEnd/Shared/EventsCreatorHelper.cs
+++ b/src/Build/BackEnd/Shared/EventsCreatorHelper.cs
@@ -15,8 +15,8 @@ internal static class EventsCreatorHelper
 {
     public static BuildMessageEventArgs CreateMessageEventFromText(BuildEventContext buildEventContext, MessageImportance importance, string message, params object?[]? messageArgs)
     {
-        ErrorUtilities.VerifyThrowInternalNull(buildEventContext, nameof(buildEventContext));
-        ErrorUtilities.VerifyThrowInternalNull(message, nameof(message));
+        ErrorUtilities.VerifyThrowInternalNull(buildEventContext);
+        ErrorUtilities.VerifyThrowInternalNull(message);
 
         BuildMessageEventArgs buildEvent = new BuildMessageEventArgs(
                 message,
@@ -32,9 +32,9 @@ internal static class EventsCreatorHelper
 
     public static BuildErrorEventArgs CreateErrorEventFromText(BuildEventContext buildEventContext, string? subcategoryResourceName, string? errorCode, string? helpKeyword, BuildEventFileInfo file, string message)
     {
-        ErrorUtilities.VerifyThrowInternalNull(buildEventContext, nameof(buildEventContext));
-        ErrorUtilities.VerifyThrowInternalNull(file, nameof(file));
-        ErrorUtilities.VerifyThrowInternalNull(message, nameof(message));
+        ErrorUtilities.VerifyThrowInternalNull(buildEventContext);
+        ErrorUtilities.VerifyThrowInternalNull(file);
+        ErrorUtilities.VerifyThrowInternalNull(message);
 
         string? subcategory = null;
 
@@ -63,9 +63,9 @@ internal static class EventsCreatorHelper
 
     public static BuildWarningEventArgs CreateWarningEventFromText(BuildEventContext buildEventContext, string? subcategoryResourceName, string? errorCode, string? helpKeyword, BuildEventFileInfo file, string message)
     {
-        ErrorUtilities.VerifyThrowInternalNull(buildEventContext, nameof(buildEventContext));
-        ErrorUtilities.VerifyThrowInternalNull(file, nameof(file));
-        ErrorUtilities.VerifyThrowInternalNull(message, nameof(message));
+        ErrorUtilities.VerifyThrowInternalNull(buildEventContext);
+        ErrorUtilities.VerifyThrowInternalNull(file);
+        ErrorUtilities.VerifyThrowInternalNull(message);
 
         string? subcategory = null;
 

--- a/src/Build/BackEnd/Shared/TargetResult.cs
+++ b/src/Build/BackEnd/Shared/TargetResult.cs
@@ -65,8 +65,8 @@ namespace Microsoft.Build.Execution
         /// </param>
         internal TargetResult(TaskItem[] items, WorkUnitResult result, BuildEventContext originalBuildEventContext = null)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(items, nameof(items));
-            ErrorUtilities.VerifyThrowArgumentNull(result, nameof(result));
+            ErrorUtilities.VerifyThrowArgumentNull(items);
+            ErrorUtilities.VerifyThrowArgumentNull(result);
             _items = items;
             _result = result;
             _originalBuildEventContext = originalBuildEventContext;

--- a/src/Build/BackEnd/TaskExecutionHost/TaskExecutionHost.cs
+++ b/src/Build/BackEnd/TaskExecutionHost/TaskExecutionHost.cs
@@ -299,8 +299,8 @@ namespace Microsoft.Build.BackEnd
         /// </summary>
         public bool InitializeForBatch(TaskLoggingContext loggingContext, ItemBucket batchBucket, IDictionary<string, string> taskIdentityParameters)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(loggingContext, nameof(loggingContext));
-            ErrorUtilities.VerifyThrowArgumentNull(batchBucket, nameof(batchBucket));
+            ErrorUtilities.VerifyThrowArgumentNull(loggingContext);
+            ErrorUtilities.VerifyThrowArgumentNull(batchBucket);
 
             _taskLoggingContext = loggingContext;
             _batchBucket = batchBucket;
@@ -352,7 +352,7 @@ namespace Microsoft.Build.BackEnd
         /// <returns>True if the parameters were set correctly, false otherwise.</returns>
         public bool SetTaskParameters(IDictionary<string, (string, ElementLocation)> parameters)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(parameters, nameof(parameters));
+            ErrorUtilities.VerifyThrowArgumentNull(parameters);
 
             bool taskInitialized = true;
 

--- a/src/Build/BuildCheck/Infrastructure/CheckContext/CheckDispatchingContext.cs
+++ b/src/Build/BuildCheck/Infrastructure/CheckContext/CheckDispatchingContext.cs
@@ -34,7 +34,7 @@ internal class CheckDispatchingContext : ICheckContext
 
     public void DispatchBuildEvent(BuildEventArgs buildEvent)
     {
-        ErrorUtilities.VerifyThrowInternalNull(buildEvent, nameof(buildEvent));
+        ErrorUtilities.VerifyThrowInternalNull(buildEvent);
 
         _eventDispatcher.Dispatch(buildEvent);
     }

--- a/src/Build/Collections/CopyOnReadEnumerable.cs
+++ b/src/Build/Collections/CopyOnReadEnumerable.cs
@@ -44,8 +44,8 @@ namespace Microsoft.Build.Collections
         /// <param name="selector">function to translate items in the backing collection to the resulting type.</param>
         public CopyOnReadEnumerable(IEnumerable<TSource> backingEnumerable, object syncRoot, Func<TSource, TResult> selector)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(backingEnumerable, nameof(backingEnumerable));
-            ErrorUtilities.VerifyThrowArgumentNull(syncRoot, nameof(syncRoot));
+            ErrorUtilities.VerifyThrowArgumentNull(backingEnumerable);
+            ErrorUtilities.VerifyThrowArgumentNull(syncRoot);
 
             _backingEnumerable = backingEnumerable;
             _syncRoot = syncRoot;

--- a/src/Build/Collections/CopyOnWritePropertyDictionary.cs
+++ b/src/Build/Collections/CopyOnWritePropertyDictionary.cs
@@ -324,7 +324,7 @@ namespace Microsoft.Build.Collections
         /// </summary>
         public bool Remove(string name)
         {
-            ErrorUtilities.VerifyThrowArgumentLength(name, nameof(name));
+            ErrorUtilities.VerifyThrowArgumentLength(name);
 
             return ImmutableInterlocked.TryRemove(ref _backing, name, out _);
         }

--- a/src/Build/Collections/CopyOnWritePropertyDictionary.cs
+++ b/src/Build/Collections/CopyOnWritePropertyDictionary.cs
@@ -336,7 +336,7 @@ namespace Microsoft.Build.Collections
         /// </summary>
         public void Set(T projectProperty)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(projectProperty, nameof(projectProperty));
+            ErrorUtilities.VerifyThrowArgumentNull(projectProperty);
 
             _backing = _backing.SetItem(projectProperty.Key, projectProperty);
         }

--- a/src/Build/Collections/PropertyDictionary.cs
+++ b/src/Build/Collections/PropertyDictionary.cs
@@ -459,7 +459,7 @@ namespace Microsoft.Build.Collections
         /// </summary>
         internal bool Remove(string name)
         {
-            ErrorUtilities.VerifyThrowArgumentLength(name, nameof(name));
+            ErrorUtilities.VerifyThrowArgumentLength(name);
 
             lock (_properties)
             {

--- a/src/Build/Collections/PropertyDictionary.cs
+++ b/src/Build/Collections/PropertyDictionary.cs
@@ -475,7 +475,7 @@ namespace Microsoft.Build.Collections
         /// </summary>
         internal void Set(T projectProperty)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(projectProperty, nameof(projectProperty));
+            ErrorUtilities.VerifyThrowArgumentNull(projectProperty);
 
             lock (_properties)
             {

--- a/src/Build/Collections/ReadOnlyConvertingDictionary.cs
+++ b/src/Build/Collections/ReadOnlyConvertingDictionary.cs
@@ -34,8 +34,8 @@ namespace Microsoft.Build.Collections
         /// </summary>
         internal ReadOnlyConvertingDictionary(IDictionary<K, V> backing, Func<V, N> converter)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(backing, nameof(backing));
-            ErrorUtilities.VerifyThrowArgumentNull(converter, nameof(converter));
+            ErrorUtilities.VerifyThrowArgumentNull(backing);
+            ErrorUtilities.VerifyThrowArgumentNull(converter);
 
             _backing = backing;
             _converter = converter;

--- a/src/Build/Construction/ProjectChooseElement.cs
+++ b/src/Build/Construction/ProjectChooseElement.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Build.Construction
         internal ProjectChooseElement(XmlElement xmlElement, ProjectElementContainer parent, ProjectRootElement containingProject)
             : base(xmlElement, parent, containingProject)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(parent, nameof(parent));
+            ErrorUtilities.VerifyThrowArgumentNull(parent);
         }
 
         /// <summary>

--- a/src/Build/Construction/ProjectElement.cs
+++ b/src/Build/Construction/ProjectElement.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Build.Construction
         /// </summary>
         internal ProjectElement(ProjectElementLink link)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(link, nameof(link));
+            ErrorUtilities.VerifyThrowArgumentNull(link);
 
             _xmlSource = link;
         }
@@ -60,8 +60,8 @@ namespace Microsoft.Build.Construction
         /// </summary>
         internal ProjectElement(XmlElement xmlElement, ProjectElementContainer parent, ProjectRootElement containingProject)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(xmlElement, nameof(xmlElement));
-            ErrorUtilities.VerifyThrowArgumentNull(containingProject, nameof(containingProject));
+            ErrorUtilities.VerifyThrowArgumentNull(xmlElement);
+            ErrorUtilities.VerifyThrowArgumentNull(containingProject);
 
             _xmlSource = (XmlElementWithLocation)xmlElement;
             _parent = parent;
@@ -350,7 +350,7 @@ namespace Microsoft.Build.Construction
         /// <param name="element">The element to act as a template to copy from.</param>
         public virtual void CopyFrom(ProjectElement element)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(element, nameof(element));
+            ErrorUtilities.VerifyThrowArgumentNull(element);
             ErrorUtilities.VerifyThrowArgument(GetType().IsEquivalentTo(element.GetType()), "CannotCopyFromElementOfThatType");
 
             if (this == element)

--- a/src/Build/Construction/ProjectElement.cs
+++ b/src/Build/Construction/ProjectElement.cs
@@ -617,7 +617,7 @@ namespace Microsoft.Build.Construction
             /// </summary>
             internal WrapperForProjectRootElement(ProjectRootElement containingProject)
             {
-                ErrorUtilities.VerifyThrowInternalNull(containingProject, nameof(containingProject));
+                ErrorUtilities.VerifyThrowInternalNull(containingProject);
                 ContainingProject = containingProject;
             }
 

--- a/src/Build/Construction/ProjectElementContainer.cs
+++ b/src/Build/Construction/ProjectElementContainer.cs
@@ -142,7 +142,7 @@ namespace Microsoft.Build.Construction
         /// </remarks>
         public void InsertAfterChild(ProjectElement child, ProjectElement reference)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(child, nameof(child));
+            ErrorUtilities.VerifyThrowArgumentNull(child);
             if (Link != null)
             {
                 ContainerLink.InsertAfterChild(child, reference);
@@ -197,7 +197,7 @@ namespace Microsoft.Build.Construction
         /// </remarks>
         public void InsertBeforeChild(ProjectElement child, ProjectElement reference)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(child, nameof(child));
+            ErrorUtilities.VerifyThrowArgumentNull(child);
 
             if (Link != null)
             {
@@ -292,7 +292,7 @@ namespace Microsoft.Build.Construction
         /// </remarks>
         public void RemoveChild(ProjectElement child)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(child, nameof(child));
+            ErrorUtilities.VerifyThrowArgumentNull(child);
 
             ErrorUtilities.VerifyThrowArgument(child.Parent == this, "OM_NodeNotAlreadyParentedByThis");
 
@@ -351,7 +351,7 @@ namespace Microsoft.Build.Construction
         /// <param name="element">The element to act as a template to copy from.</param>
         public virtual void DeepCopyFrom(ProjectElementContainer element)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(element, nameof(element));
+            ErrorUtilities.VerifyThrowArgumentNull(element);
             ErrorUtilities.VerifyThrowArgument(GetType().IsEquivalentTo(element.GetType()), "CannotCopyFromElementOfThatType");
 
             if (this == element)
@@ -835,7 +835,7 @@ namespace Microsoft.Build.Construction
 
             public void CopyTo(T[] array, int arrayIndex)
             {
-                ErrorUtilities.VerifyThrowArgumentNull(array, nameof(array));
+                ErrorUtilities.VerifyThrowArgumentNull(array);
 
                 if (_realizedElements != null)
                 {
@@ -864,7 +864,7 @@ namespace Microsoft.Build.Construction
 
             void ICollection.CopyTo(Array array, int index)
             {
-                ErrorUtilities.VerifyThrowArgumentNull(array, nameof(array));
+                ErrorUtilities.VerifyThrowArgumentNull(array);
 
                 int i = index;
                 foreach (T entry in this)

--- a/src/Build/Construction/ProjectExtensionsElement.cs
+++ b/src/Build/Construction/ProjectExtensionsElement.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Build.Construction
         internal ProjectExtensionsElement(XmlElement xmlElement, ProjectRootElement parent, ProjectRootElement project)
             : base(xmlElement, parent, project)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(parent, nameof(parent));
+            ErrorUtilities.VerifyThrowArgumentNull(parent);
         }
 
         /// <summary>
@@ -161,7 +161,7 @@ namespace Microsoft.Build.Construction
         /// <inheritdoc/>
         public override void CopyFrom(ProjectElement element)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(element, nameof(element));
+            ErrorUtilities.VerifyThrowArgumentNull(element);
             ErrorUtilities.VerifyThrowArgument(GetType().IsEquivalentTo(element.GetType()), "CannotCopyFromElementOfThatType");
 
             if (this == element)

--- a/src/Build/Construction/ProjectExtensionsElement.cs
+++ b/src/Build/Construction/ProjectExtensionsElement.cs
@@ -101,7 +101,7 @@ namespace Microsoft.Build.Construction
         {
             get
             {
-                ErrorUtilities.VerifyThrowArgumentLength(name, nameof(name));
+                ErrorUtilities.VerifyThrowArgumentLength(name);
 
                 if (Link != null)
                 {
@@ -116,7 +116,7 @@ namespace Microsoft.Build.Construction
 
             set
             {
-                ErrorUtilities.VerifyThrowArgumentLength(name, nameof(name));
+                ErrorUtilities.VerifyThrowArgumentLength(name);
                 ErrorUtilities.VerifyThrowArgumentNull(value, "value");
 
                 if (Link != null)

--- a/src/Build/Construction/ProjectImportElement.cs
+++ b/src/Build/Construction/ProjectImportElement.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Build.Construction
         internal ProjectImportElement(XmlElementWithLocation xmlElement, ProjectElementContainer parent, ProjectRootElement containingProject, SdkReference sdkReference = null)
             : base(xmlElement, parent, containingProject)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(parent, nameof(parent));
+            ErrorUtilities.VerifyThrowArgumentNull(parent);
             SdkReference = sdkReference;
         }
 

--- a/src/Build/Construction/ProjectImportGroupElement.cs
+++ b/src/Build/Construction/ProjectImportGroupElement.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Build.Construction
         internal ProjectImportGroupElement(XmlElementWithLocation xmlElement, ProjectElementContainer parent, ProjectRootElement containingProject)
             : base(xmlElement, parent, containingProject)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(parent, nameof(parent));
+            ErrorUtilities.VerifyThrowArgumentNull(parent);
         }
 
         /// <summary>

--- a/src/Build/Construction/ProjectImportGroupElement.cs
+++ b/src/Build/Construction/ProjectImportGroupElement.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Build.Construction
         /// </summary>
         public ProjectImportElement AddImport(string project)
         {
-            ErrorUtilities.VerifyThrowArgumentLength(project, nameof(project));
+            ErrorUtilities.VerifyThrowArgumentLength(project);
 
             ProjectImportElement newImport = ContainingProject.CreateImportElement(project);
             AppendChild(newImport);

--- a/src/Build/Construction/ProjectItemDefinitionElement.cs
+++ b/src/Build/Construction/ProjectItemDefinitionElement.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Build.Construction
         internal ProjectItemDefinitionElement(XmlElement xmlElement, ProjectItemDefinitionGroupElement parent, ProjectRootElement containingProject)
             : base(xmlElement, parent, containingProject)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(parent, nameof(parent));
+            ErrorUtilities.VerifyThrowArgumentNull(parent);
         }
 
         /// <summary>
@@ -73,7 +73,7 @@ namespace Microsoft.Build.Construction
         public ProjectMetadataElement AddMetadata(string name, string unevaluatedValue, bool expressAsAttribute)
         {
             ErrorUtilities.VerifyThrowArgumentLength(name, nameof(name));
-            ErrorUtilities.VerifyThrowArgumentNull(unevaluatedValue, nameof(unevaluatedValue));
+            ErrorUtilities.VerifyThrowArgumentNull(unevaluatedValue);
 
             if (expressAsAttribute)
             {

--- a/src/Build/Construction/ProjectItemDefinitionElement.cs
+++ b/src/Build/Construction/ProjectItemDefinitionElement.cs
@@ -72,7 +72,7 @@ namespace Microsoft.Build.Construction
         /// </param>
         public ProjectMetadataElement AddMetadata(string name, string unevaluatedValue, bool expressAsAttribute)
         {
-            ErrorUtilities.VerifyThrowArgumentLength(name, nameof(name));
+            ErrorUtilities.VerifyThrowArgumentLength(name);
             ErrorUtilities.VerifyThrowArgumentNull(unevaluatedValue);
 
             if (expressAsAttribute)

--- a/src/Build/Construction/ProjectItemDefinitionGroupElement.cs
+++ b/src/Build/Construction/ProjectItemDefinitionGroupElement.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Build.Construction
         internal ProjectItemDefinitionGroupElement(XmlElement xmlElement, ProjectElementContainer parent, ProjectRootElement containingProject)
             : base(xmlElement, parent, containingProject)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(parent, nameof(parent));
+            ErrorUtilities.VerifyThrowArgumentNull(parent);
         }
 
         /// <summary>

--- a/src/Build/Construction/ProjectItemElement.cs
+++ b/src/Build/Construction/ProjectItemElement.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Build.Construction
         internal ProjectItemElement(XmlElementWithLocation xmlElement, ProjectItemGroupElement parent, ProjectRootElement containingProject)
             : base(xmlElement, parent, containingProject)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(parent, nameof(parent));
+            ErrorUtilities.VerifyThrowArgumentNull(parent);
         }
 
         /// <summary>
@@ -390,7 +390,7 @@ namespace Microsoft.Build.Construction
         public ProjectMetadataElement AddMetadata(string name, string unevaluatedValue, bool expressAsAttribute)
         {
             ErrorUtilities.VerifyThrowArgumentLength(name, nameof(name));
-            ErrorUtilities.VerifyThrowArgumentNull(unevaluatedValue, nameof(unevaluatedValue));
+            ErrorUtilities.VerifyThrowArgumentNull(unevaluatedValue);
 
             if (expressAsAttribute)
             {

--- a/src/Build/Construction/ProjectItemElement.cs
+++ b/src/Build/Construction/ProjectItemElement.cs
@@ -389,7 +389,7 @@ namespace Microsoft.Build.Construction
         /// </param>
         public ProjectMetadataElement AddMetadata(string name, string unevaluatedValue, bool expressAsAttribute)
         {
-            ErrorUtilities.VerifyThrowArgumentLength(name, nameof(name));
+            ErrorUtilities.VerifyThrowArgumentLength(name);
             ErrorUtilities.VerifyThrowArgumentNull(unevaluatedValue);
 
             if (expressAsAttribute)
@@ -439,7 +439,7 @@ namespace Microsoft.Build.Construction
         /// </remarks>
         internal void ChangeItemType(string newItemType)
         {
-            ErrorUtilities.VerifyThrowArgumentLength(newItemType, nameof(newItemType));
+            ErrorUtilities.VerifyThrowArgumentLength(newItemType);
             XmlUtilities.VerifyThrowArgumentValidElementName(newItemType);
             ErrorUtilities.VerifyThrowArgument(!XMakeElements.ReservedItemNames.Contains(newItemType), "CannotModifyReservedItem", newItemType);
             if (Link != null)

--- a/src/Build/Construction/ProjectItemGroupElement.cs
+++ b/src/Build/Construction/ProjectItemGroupElement.cs
@@ -99,8 +99,8 @@ namespace Microsoft.Build.Construction
         /// </summary>
         public ProjectItemElement AddItem(string itemType, string include, IEnumerable<KeyValuePair<string, string>> metadata)
         {
-            ErrorUtilities.VerifyThrowArgumentLength(itemType, nameof(itemType));
-            ErrorUtilities.VerifyThrowArgumentLength(include, nameof(include));
+            ErrorUtilities.VerifyThrowArgumentLength(itemType);
+            ErrorUtilities.VerifyThrowArgumentLength(include);
 
             // If there are no items, or it turns out that there are only items with
             // item types that sort earlier, then we should go after the last child

--- a/src/Build/Construction/ProjectItemGroupElement.cs
+++ b/src/Build/Construction/ProjectItemGroupElement.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Build.Construction
         internal ProjectItemGroupElement(XmlElementWithLocation xmlElement, ProjectElementContainer parent, ProjectRootElement containingProject)
             : base(xmlElement, parent, containingProject)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(parent, nameof(parent));
+            ErrorUtilities.VerifyThrowArgumentNull(parent);
         }
 
         /// <summary>

--- a/src/Build/Construction/ProjectMetadataElement.cs
+++ b/src/Build/Construction/ProjectMetadataElement.cs
@@ -119,7 +119,7 @@ namespace Microsoft.Build.Construction
         /// </remarks>
         internal void ChangeName(string newName)
         {
-            ErrorUtilities.VerifyThrowArgumentLength(newName, nameof(newName));
+            ErrorUtilities.VerifyThrowArgumentLength(newName);
             XmlUtilities.VerifyThrowArgumentValidElementName(newName);
             ErrorUtilities.VerifyThrowArgument(!XMakeElements.ReservedItemNames.Contains(newName), "CannotModifyReservedItemMetadata", newName);
 

--- a/src/Build/Construction/ProjectMetadataElement.cs
+++ b/src/Build/Construction/ProjectMetadataElement.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Build.Construction
         internal ProjectMetadataElement(XmlElementWithLocation xmlElement, ProjectElementContainer parent, ProjectRootElement project)
             : base(xmlElement, parent, project)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(parent, nameof(parent));
+            ErrorUtilities.VerifyThrowArgumentNull(parent);
         }
 
         /// <summary>
@@ -89,7 +89,7 @@ namespace Microsoft.Build.Construction
                     return;
                 }
 
-                ErrorUtilities.VerifyThrowArgumentNull(value, nameof(Value));
+                ErrorUtilities.VerifyThrowArgumentNull(value);
                 Internal.Utilities.SetXmlNodeInnerContents(XmlElement, value);
                 Parent?.UpdateElementValue(this);
                 MarkDirty("Set metadata Value {0}", value);

--- a/src/Build/Construction/ProjectOnErrorElement.cs
+++ b/src/Build/Construction/ProjectOnErrorElement.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Build.Construction
         internal ProjectOnErrorElement(XmlElementWithLocation xmlElement, ProjectTargetElement parent, ProjectRootElement project)
             : base(xmlElement, parent, project)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(parent, nameof(parent));
+            ErrorUtilities.VerifyThrowArgumentNull(parent);
         }
 
         /// <summary>

--- a/src/Build/Construction/ProjectOtherwiseElement.cs
+++ b/src/Build/Construction/ProjectOtherwiseElement.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Build.Construction
         internal ProjectOtherwiseElement(XmlElementWithLocation xmlElement, ProjectElementContainer parent, ProjectRootElement project)
             : base(xmlElement, parent, project)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(parent, nameof(parent));
+            ErrorUtilities.VerifyThrowArgumentNull(parent);
         }
 
         /// <summary>

--- a/src/Build/Construction/ProjectOutputElement.cs
+++ b/src/Build/Construction/ProjectOutputElement.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Build.Construction
             [DebuggerStepThrough]
             set
             {
-                ErrorUtilities.VerifyThrowArgumentLength(value, nameof(value));
+                ErrorUtilities.VerifyThrowArgumentLength(value);
                 SetOrRemoveAttribute(XMakeAttributes.taskParameter, value, "Set Output TaskParameter {0}", value);
             }
         }

--- a/src/Build/Construction/ProjectOutputElement.cs
+++ b/src/Build/Construction/ProjectOutputElement.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Build.Construction
         internal ProjectOutputElement(XmlElement xmlElement, ProjectTaskElement parent, ProjectRootElement containingProject)
             : base(xmlElement, parent, containingProject)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(parent, nameof(parent));
+            ErrorUtilities.VerifyThrowArgumentNull(parent);
         }
 
         /// <summary>

--- a/src/Build/Construction/ProjectPropertyElement.cs
+++ b/src/Build/Construction/ProjectPropertyElement.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Build.Construction
         internal ProjectPropertyElement(XmlElementWithLocation xmlElement, ProjectPropertyGroupElement parent, ProjectRootElement containingProject)
             : base(xmlElement, parent, containingProject)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(parent, nameof(parent));
+            ErrorUtilities.VerifyThrowArgumentNull(parent);
         }
 
         /// <summary>
@@ -69,7 +69,7 @@ namespace Microsoft.Build.Construction
 
             set
             {
-                ErrorUtilities.VerifyThrowArgumentNull(value, nameof(Value));
+                ErrorUtilities.VerifyThrowArgumentNull(value);
                 if (Link != null)
                 {
                     PropertyLink.Value = value;

--- a/src/Build/Construction/ProjectPropertyElement.cs
+++ b/src/Build/Construction/ProjectPropertyElement.cs
@@ -109,7 +109,7 @@ namespace Microsoft.Build.Construction
         /// </remarks>
         internal void ChangeName(string newName)
         {
-            ErrorUtilities.VerifyThrowArgumentLength(newName, nameof(newName));
+            ErrorUtilities.VerifyThrowArgumentLength(newName);
             XmlUtilities.VerifyThrowArgumentValidElementName(newName);
             ErrorUtilities.VerifyThrowArgument(!XMakeElements.ReservedItemNames.Contains(newName), "CannotModifyReservedProperty", newName);
             if (Link != null)

--- a/src/Build/Construction/ProjectPropertyGroupElement.cs
+++ b/src/Build/Construction/ProjectPropertyGroupElement.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Build.Construction
         /// </summary>
         public ProjectPropertyElement AddProperty(string name, string unevaluatedValue)
         {
-            ErrorUtilities.VerifyThrowArgumentLength(name, nameof(name));
+            ErrorUtilities.VerifyThrowArgumentLength(name);
             ErrorUtilities.VerifyThrowArgumentNull(unevaluatedValue);
 
             ProjectPropertyElement newProperty = ContainingProject.CreatePropertyElement(name);
@@ -75,7 +75,7 @@ namespace Microsoft.Build.Construction
         /// </summary>
         public ProjectPropertyElement SetProperty(string name, string unevaluatedValue)
         {
-            ErrorUtilities.VerifyThrowArgumentLength(name, nameof(name));
+            ErrorUtilities.VerifyThrowArgumentLength(name);
             ErrorUtilities.VerifyThrowArgumentNull(unevaluatedValue);
 
             foreach (ProjectPropertyElement property in Properties)

--- a/src/Build/Construction/ProjectPropertyGroupElement.cs
+++ b/src/Build/Construction/ProjectPropertyGroupElement.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Build.Construction
         internal ProjectPropertyGroupElement(XmlElementWithLocation xmlElement, ProjectElementContainer parent, ProjectRootElement containingProject)
             : base(xmlElement, parent, containingProject)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(parent, nameof(parent));
+            ErrorUtilities.VerifyThrowArgumentNull(parent);
         }
 
         /// <summary>
@@ -59,7 +59,7 @@ namespace Microsoft.Build.Construction
         public ProjectPropertyElement AddProperty(string name, string unevaluatedValue)
         {
             ErrorUtilities.VerifyThrowArgumentLength(name, nameof(name));
-            ErrorUtilities.VerifyThrowArgumentNull(unevaluatedValue, nameof(unevaluatedValue));
+            ErrorUtilities.VerifyThrowArgumentNull(unevaluatedValue);
 
             ProjectPropertyElement newProperty = ContainingProject.CreatePropertyElement(name);
             newProperty.Value = unevaluatedValue;
@@ -76,7 +76,7 @@ namespace Microsoft.Build.Construction
         public ProjectPropertyElement SetProperty(string name, string unevaluatedValue)
         {
             ErrorUtilities.VerifyThrowArgumentLength(name, nameof(name));
-            ErrorUtilities.VerifyThrowArgumentNull(unevaluatedValue, nameof(unevaluatedValue));
+            ErrorUtilities.VerifyThrowArgumentNull(unevaluatedValue);
 
             foreach (ProjectPropertyElement property in Properties)
             {

--- a/src/Build/Construction/ProjectRootElement.cs
+++ b/src/Build/Construction/ProjectRootElement.cs
@@ -214,7 +214,7 @@ namespace Microsoft.Build.Construction
                 ProjectRootElementCacheBase projectRootElementCache,
                 bool preserveFormatting)
         {
-            ErrorUtilities.VerifyThrowArgumentLength(path, nameof(path));
+            ErrorUtilities.VerifyThrowArgumentLength(path);
             ErrorUtilities.VerifyThrowInternalRooted(path);
             ErrorUtilities.VerifyThrowArgumentNull(projectRootElementCache);
             ProjectRootElementCache = projectRootElementCache;
@@ -397,7 +397,7 @@ namespace Microsoft.Build.Construction
 
             set
             {
-                ErrorUtilities.VerifyThrowArgumentLength(value, nameof(value));
+                ErrorUtilities.VerifyThrowArgumentLength(value);
                 if (Link != null)
                 {
                     RootLink.FullPath = value;
@@ -782,7 +782,7 @@ namespace Microsoft.Build.Construction
         /// </summary>
         public static ProjectRootElement Create(string path, ProjectCollection projectCollection, NewProjectFileOptions newProjectFileOptions)
         {
-            ErrorUtilities.VerifyThrowArgumentLength(path, nameof(path));
+            ErrorUtilities.VerifyThrowArgumentLength(path);
             ErrorUtilities.VerifyThrowArgumentNull(projectCollection);
 
             var projectRootElement = new ProjectRootElement(
@@ -853,7 +853,7 @@ namespace Microsoft.Build.Construction
         /// </summary>
         public static ProjectRootElement Open(string path, ProjectCollection projectCollection, bool? preserveFormatting)
         {
-            ErrorUtilities.VerifyThrowArgumentLength(path, nameof(path));
+            ErrorUtilities.VerifyThrowArgumentLength(path);
             ErrorUtilities.VerifyThrowArgumentNull(projectCollection);
 
             path = FileUtilities.NormalizePath(path);
@@ -873,7 +873,7 @@ namespace Microsoft.Build.Construction
         /// </remarks>
         public static ProjectRootElement TryOpen(string path)
         {
-            ErrorUtilities.VerifyThrowArgumentLength(path, nameof(path));
+            ErrorUtilities.VerifyThrowArgumentLength(path);
 
             return TryOpen(path, ProjectCollection.GlobalProjectCollection);
         }
@@ -910,7 +910,7 @@ namespace Microsoft.Build.Construction
         /// </remarks>
         public static ProjectRootElement TryOpen(string path, ProjectCollection projectCollection, bool? preserveFormatting)
         {
-            ErrorUtilities.VerifyThrowArgumentLength(path, nameof(path));
+            ErrorUtilities.VerifyThrowArgumentLength(path);
             ErrorUtilities.VerifyThrowArgumentNull(projectCollection);
 
             path = FileUtilities.NormalizePath(path);
@@ -927,7 +927,7 @@ namespace Microsoft.Build.Construction
         /// </summary>
         public ProjectImportElement AddImport(string project)
         {
-            ErrorUtilities.VerifyThrowArgumentLength(project, nameof(project));
+            ErrorUtilities.VerifyThrowArgumentLength(project);
 
             ProjectImportGroupElement importGroupToAddTo =
                 ImportGroupsReversed.FirstOrDefault(importGroup => importGroup.Condition.Length <= 0);
@@ -984,8 +984,8 @@ namespace Microsoft.Build.Construction
         /// </remarks>
         public ProjectItemElement AddItem(string itemType, string include, IEnumerable<KeyValuePair<string, string>> metadata)
         {
-            ErrorUtilities.VerifyThrowArgumentLength(itemType, nameof(itemType));
-            ErrorUtilities.VerifyThrowArgumentLength(include, nameof(include));
+            ErrorUtilities.VerifyThrowArgumentLength(itemType);
+            ErrorUtilities.VerifyThrowArgumentLength(include);
 
             ProjectItemGroupElement itemGroupToAddTo = null;
 
@@ -1061,7 +1061,7 @@ namespace Microsoft.Build.Construction
         /// </summary>
         public ProjectItemDefinitionElement AddItemDefinition(string itemType)
         {
-            ErrorUtilities.VerifyThrowArgumentLength(itemType, nameof(itemType));
+            ErrorUtilities.VerifyThrowArgumentLength(itemType);
 
             ProjectItemDefinitionGroupElement itemDefinitionGroupToAddTo = null;
 

--- a/src/Build/Construction/ProjectRootElement.cs
+++ b/src/Build/Construction/ProjectRootElement.cs
@@ -163,8 +163,8 @@ namespace Microsoft.Build.Construction
         internal ProjectRootElement(XmlReader xmlReader, ProjectRootElementCacheBase projectRootElementCache, bool isExplicitlyLoaded,
             bool preserveFormatting)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(xmlReader, nameof(xmlReader));
-            ErrorUtilities.VerifyThrowArgumentNull(projectRootElementCache, nameof(projectRootElementCache));
+            ErrorUtilities.VerifyThrowArgumentNull(xmlReader);
+            ErrorUtilities.VerifyThrowArgumentNull(projectRootElementCache);
 
             IsExplicitlyLoaded = isExplicitlyLoaded;
             ProjectRootElementCache = projectRootElementCache;
@@ -182,7 +182,7 @@ namespace Microsoft.Build.Construction
         /// </summary>
         private ProjectRootElement(ProjectRootElementCacheBase projectRootElementCache, NewProjectFileOptions projectFileOptions)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(projectRootElementCache, nameof(projectRootElementCache));
+            ErrorUtilities.VerifyThrowArgumentNull(projectRootElementCache);
 
             ProjectRootElementCache = projectRootElementCache;
             _directory = NativeMethodsShared.GetCurrentDirectory();
@@ -216,7 +216,7 @@ namespace Microsoft.Build.Construction
         {
             ErrorUtilities.VerifyThrowArgumentLength(path, nameof(path));
             ErrorUtilities.VerifyThrowInternalRooted(path);
-            ErrorUtilities.VerifyThrowArgumentNull(projectRootElementCache, nameof(projectRootElementCache));
+            ErrorUtilities.VerifyThrowArgumentNull(projectRootElementCache);
             ProjectRootElementCache = projectRootElementCache;
 
             IncrementVersion();
@@ -238,8 +238,8 @@ namespace Microsoft.Build.Construction
         /// </remarks>
         private ProjectRootElement(XmlDocumentWithLocation document, ProjectRootElementCacheBase projectRootElementCache)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(document, nameof(document));
-            ErrorUtilities.VerifyThrowArgumentNull(projectRootElementCache, nameof(projectRootElementCache));
+            ErrorUtilities.VerifyThrowArgumentNull(document);
+            ErrorUtilities.VerifyThrowArgumentNull(projectRootElementCache);
 
             ProjectRootElementCache = projectRootElementCache;
             _directory = NativeMethodsShared.GetCurrentDirectory();
@@ -744,7 +744,7 @@ namespace Microsoft.Build.Construction
         /// </summary>
         public static ProjectRootElement Create(ProjectCollection projectCollection, NewProjectFileOptions projectFileOptions)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(projectCollection, nameof(projectCollection));
+            ErrorUtilities.VerifyThrowArgumentNull(projectCollection);
 
             return Create(projectCollection.ProjectRootElementCache, projectFileOptions);
         }
@@ -783,7 +783,7 @@ namespace Microsoft.Build.Construction
         public static ProjectRootElement Create(string path, ProjectCollection projectCollection, NewProjectFileOptions newProjectFileOptions)
         {
             ErrorUtilities.VerifyThrowArgumentLength(path, nameof(path));
-            ErrorUtilities.VerifyThrowArgumentNull(projectCollection, nameof(projectCollection));
+            ErrorUtilities.VerifyThrowArgumentNull(projectCollection);
 
             var projectRootElement = new ProjectRootElement(
                 projectCollection.ProjectRootElementCache,
@@ -820,7 +820,7 @@ namespace Microsoft.Build.Construction
         /// </summary>
         public static ProjectRootElement Create(XmlReader xmlReader, ProjectCollection projectCollection, bool preserveFormatting)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(projectCollection, nameof(projectCollection));
+            ErrorUtilities.VerifyThrowArgumentNull(projectCollection);
 
             return new ProjectRootElement(xmlReader, projectCollection.ProjectRootElementCache, true /*Explicitly loaded*/,
                 preserveFormatting);
@@ -854,7 +854,7 @@ namespace Microsoft.Build.Construction
         public static ProjectRootElement Open(string path, ProjectCollection projectCollection, bool? preserveFormatting)
         {
             ErrorUtilities.VerifyThrowArgumentLength(path, nameof(path));
-            ErrorUtilities.VerifyThrowArgumentNull(projectCollection, nameof(projectCollection));
+            ErrorUtilities.VerifyThrowArgumentNull(projectCollection);
 
             path = FileUtilities.NormalizePath(path);
 
@@ -911,7 +911,7 @@ namespace Microsoft.Build.Construction
         public static ProjectRootElement TryOpen(string path, ProjectCollection projectCollection, bool? preserveFormatting)
         {
             ErrorUtilities.VerifyThrowArgumentLength(path, nameof(path));
-            ErrorUtilities.VerifyThrowArgumentNull(projectCollection, nameof(projectCollection));
+            ErrorUtilities.VerifyThrowArgumentNull(projectCollection);
 
             path = FileUtilities.NormalizePath(path);
 
@@ -1847,7 +1847,7 @@ namespace Microsoft.Build.Construction
         /// <param name="project">The dirtied project.</param>
         internal void MarkProjectDirty(Project project)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(project, nameof(project));
+            ErrorUtilities.VerifyThrowArgumentNull(project);
             ErrorUtilities.VerifyThrow(Link == null, "Attempt to edit a document that is not backed by a local xml is disallowed.");
 
             // Only bubble this event up if the cache knows about this PRE, which is equivalent to

--- a/src/Build/Construction/ProjectSdkElement.cs
+++ b/src/Build/Construction/ProjectSdkElement.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Build.Construction
             ProjectRootElement containingProject)
             : base(xmlElement, parent, containingProject)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(parent, nameof(parent));
+            ErrorUtilities.VerifyThrowArgumentNull(parent);
         }
 
         /// <summary>

--- a/src/Build/Construction/ProjectTargetElement.cs
+++ b/src/Build/Construction/ProjectTargetElement.cs
@@ -97,7 +97,7 @@ namespace Microsoft.Build.Construction
 
             set
             {
-                ErrorUtilities.VerifyThrowArgumentLength(value, nameof(value));
+                ErrorUtilities.VerifyThrowArgumentLength(value);
                 if (Link != null)
                 {
                     TargetLink.Name = value;
@@ -378,7 +378,7 @@ namespace Microsoft.Build.Construction
         /// </summary>
         public ProjectTaskElement AddTask(string taskName)
         {
-            ErrorUtilities.VerifyThrowArgumentLength(taskName, nameof(taskName));
+            ErrorUtilities.VerifyThrowArgumentLength(taskName);
 
             ProjectTaskElement task = ContainingProject.CreateTaskElement(taskName);
 

--- a/src/Build/Construction/ProjectTargetElement.cs
+++ b/src/Build/Construction/ProjectTargetElement.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Build.Construction
         internal ProjectTargetElement(XmlElementWithLocation xmlElement, ProjectRootElement parent, ProjectRootElement containingProject)
             : base(xmlElement, parent, containingProject)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(parent, nameof(parent));
+            ErrorUtilities.VerifyThrowArgumentNull(parent);
         }
 
         /// <summary>

--- a/src/Build/Construction/ProjectTaskElement.cs
+++ b/src/Build/Construction/ProjectTaskElement.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Build.Construction
         internal ProjectTaskElement(XmlElementWithLocation xmlElement, ProjectTargetElement parent, ProjectRootElement containingProject)
             : base(xmlElement, parent, containingProject)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(parent, nameof(parent));
+            ErrorUtilities.VerifyThrowArgumentNull(parent);
         }
 
         /// <summary>
@@ -323,7 +323,7 @@ namespace Microsoft.Build.Construction
             lock (_locker)
             {
                 ErrorUtilities.VerifyThrowArgumentLength(name, nameof(name));
-                ErrorUtilities.VerifyThrowArgumentNull(unevaluatedValue, nameof(unevaluatedValue));
+                ErrorUtilities.VerifyThrowArgumentNull(unevaluatedValue);
                 ErrorUtilities.VerifyThrowArgument(!XMakeAttributes.IsSpecialTaskAttribute(name), "CannotAccessKnownAttributes", name);
 
                 _parameters = null;

--- a/src/Build/Construction/ProjectTaskElement.cs
+++ b/src/Build/Construction/ProjectTaskElement.cs
@@ -229,8 +229,8 @@ namespace Microsoft.Build.Construction
         /// </summary>
         public ProjectOutputElement AddOutputItem(string taskParameter, string itemType)
         {
-            ErrorUtilities.VerifyThrowArgumentLength(taskParameter, nameof(taskParameter));
-            ErrorUtilities.VerifyThrowArgumentLength(itemType, nameof(itemType));
+            ErrorUtilities.VerifyThrowArgumentLength(taskParameter);
+            ErrorUtilities.VerifyThrowArgumentLength(itemType);
 
             return AddOutputItem(taskParameter, itemType, null);
         }
@@ -259,8 +259,8 @@ namespace Microsoft.Build.Construction
         /// </summary>
         public ProjectOutputElement AddOutputProperty(string taskParameter, string propertyName)
         {
-            ErrorUtilities.VerifyThrowArgumentLength(taskParameter, nameof(taskParameter));
-            ErrorUtilities.VerifyThrowArgumentLength(propertyName, nameof(propertyName));
+            ErrorUtilities.VerifyThrowArgumentLength(taskParameter);
+            ErrorUtilities.VerifyThrowArgumentLength(propertyName);
 
             return AddOutputProperty(taskParameter, propertyName, null);
         }
@@ -296,7 +296,7 @@ namespace Microsoft.Build.Construction
 
             lock (_locker)
             {
-                ErrorUtilities.VerifyThrowArgumentLength(name, nameof(name));
+                ErrorUtilities.VerifyThrowArgumentLength(name);
 
                 EnsureParametersInitialized();
 
@@ -322,7 +322,7 @@ namespace Microsoft.Build.Construction
 
             lock (_locker)
             {
-                ErrorUtilities.VerifyThrowArgumentLength(name, nameof(name));
+                ErrorUtilities.VerifyThrowArgumentLength(name);
                 ErrorUtilities.VerifyThrowArgumentNull(unevaluatedValue);
                 ErrorUtilities.VerifyThrowArgument(!XMakeAttributes.IsSpecialTaskAttribute(name), "CannotAccessKnownAttributes", name);
 
@@ -411,7 +411,7 @@ namespace Microsoft.Build.Construction
         /// </remarks>
         internal static ProjectTaskElement CreateDisconnected(string name, ProjectRootElement containingProject)
         {
-            ErrorUtilities.VerifyThrowArgumentLength(name, nameof(name));
+            ErrorUtilities.VerifyThrowArgumentLength(name);
 
             XmlElementWithLocation element = containingProject.CreateElement(name);
 

--- a/src/Build/Construction/ProjectUsingTaskBodyElement.cs
+++ b/src/Build/Construction/ProjectUsingTaskBodyElement.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Build.Construction
         internal ProjectUsingTaskBodyElement(XmlElementWithLocation xmlElement, ProjectUsingTaskElement parent, ProjectRootElement containingProject)
             : base(xmlElement, parent, containingProject)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(parent, nameof(parent));
+            ErrorUtilities.VerifyThrowArgumentNull(parent);
             VerifyCorrectParent(parent);
         }
 

--- a/src/Build/Construction/ProjectUsingTaskElement.cs
+++ b/src/Build/Construction/ProjectUsingTaskElement.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Build.Construction
         internal ProjectUsingTaskElement(XmlElementWithLocation xmlElement, ProjectRootElement parent, ProjectRootElement containingProject)
             : base(xmlElement, parent, containingProject)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(parent, nameof(parent));
+            ErrorUtilities.VerifyThrowArgumentNull(parent);
         }
 
         /// <summary>

--- a/src/Build/Construction/ProjectUsingTaskParameterElement.cs
+++ b/src/Build/Construction/ProjectUsingTaskParameterElement.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Build.Construction
         internal ProjectUsingTaskParameterElement(XmlElementWithLocation xmlElement, UsingTaskParameterGroupElement parent, ProjectRootElement containingProject)
             : base(xmlElement, parent, containingProject)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(parent, nameof(parent));
+            ErrorUtilities.VerifyThrowArgumentNull(parent);
         }
 
         /// <summary>

--- a/src/Build/Construction/ProjectWhenElement.cs
+++ b/src/Build/Construction/ProjectWhenElement.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Build.Construction
         internal ProjectWhenElement(XmlElement xmlElement, ProjectChooseElement parent, ProjectRootElement containingProject)
             : base(xmlElement, parent, containingProject)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(parent, nameof(parent));
+            ErrorUtilities.VerifyThrowArgumentNull(parent);
         }
 
         /// <summary>

--- a/src/Build/Construction/Solution/ProjectInSolution.cs
+++ b/src/Build/Construction/Solution/ProjectInSolution.cs
@@ -477,7 +477,7 @@ namespace Microsoft.Build.Construction
         /// </summary>
         internal void UpdateUniqueProjectName(string newUniqueName)
         {
-            ErrorUtilities.VerifyThrowArgumentLength(newUniqueName, nameof(newUniqueName));
+            ErrorUtilities.VerifyThrowArgumentLength(newUniqueName);
 
             _uniqueProjectName = newUniqueName;
         }

--- a/src/Build/Construction/UsingTaskParameterGroupElement.cs
+++ b/src/Build/Construction/UsingTaskParameterGroupElement.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Build.Construction
         internal UsingTaskParameterGroupElement(XmlElementWithLocation xmlElement, ProjectElementContainer parent, ProjectRootElement containingProject)
             : base(xmlElement, parent, containingProject)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(parent, nameof(parent));
+            ErrorUtilities.VerifyThrowArgumentNull(parent);
             VerifyCorrectParent(parent);
         }
 

--- a/src/Build/Construction/UsingTaskParameterGroupElement.cs
+++ b/src/Build/Construction/UsingTaskParameterGroupElement.cs
@@ -77,7 +77,7 @@ namespace Microsoft.Build.Construction
         /// </summary>
         public ProjectUsingTaskParameterElement AddParameter(string name, string output, string required, string parameterType)
         {
-            ErrorUtilities.VerifyThrowArgumentLength(name, nameof(name));
+            ErrorUtilities.VerifyThrowArgumentLength(name);
 
             ProjectUsingTaskParameterElement newParameter = ContainingProject.CreateUsingTaskParameterElement(name, output, required, parameterType);
             AppendChild(newParameter);

--- a/src/Build/Definition/Project.cs
+++ b/src/Build/Definition/Project.cs
@@ -1805,7 +1805,7 @@ namespace Microsoft.Build.Evaluation
         /// </summary>
         internal void VerifyThrowInvalidOperationNotImported(ProjectRootElement otherXml)
         {
-            ErrorUtilities.VerifyThrowInternalNull(otherXml, nameof(otherXml));
+            ErrorUtilities.VerifyThrowInternalNull(otherXml);
             ErrorUtilities.VerifyThrowInvalidOperation(ReferenceEquals(Xml, otherXml), "OM_CannotModifyEvaluatedObjectInImportedFile", otherXml.Location.File);
         }
 
@@ -3581,7 +3581,7 @@ namespace Microsoft.Build.Evaluation
             /// </summary>
             internal void VerifyThrowInvalidOperationNotImported(ProjectRootElement otherXml)
             {
-                ErrorUtilities.VerifyThrowInternalNull(otherXml, nameof(otherXml));
+                ErrorUtilities.VerifyThrowInternalNull(otherXml);
                 ErrorUtilities.VerifyThrowInvalidOperation(ReferenceEquals(Xml, otherXml), "OM_CannotModifyEvaluatedObjectInImportedFile", otherXml.Location.File);
             }
 
@@ -4385,7 +4385,7 @@ namespace Microsoft.Build.Evaluation
             /// </summary>
             public void AddToAllEvaluatedPropertiesList(ProjectProperty property)
             {
-                ErrorUtilities.VerifyThrowInternalNull(property, nameof(property));
+                ErrorUtilities.VerifyThrowInternalNull(property);
                 AllEvaluatedProperties.Add(property);
             }
 
@@ -4397,7 +4397,7 @@ namespace Microsoft.Build.Evaluation
             /// </summary>
             public void AddToAllEvaluatedItemDefinitionMetadataList(ProjectMetadata itemDefinitionMetadatum)
             {
-                ErrorUtilities.VerifyThrowInternalNull(itemDefinitionMetadatum, nameof(itemDefinitionMetadatum));
+                ErrorUtilities.VerifyThrowInternalNull(itemDefinitionMetadatum);
                 AllEvaluatedItemDefinitionMetadata.Add(itemDefinitionMetadatum);
             }
 
@@ -4409,7 +4409,7 @@ namespace Microsoft.Build.Evaluation
             /// </summary>
             public void AddToAllEvaluatedItemsList(ProjectItem item)
             {
-                ErrorUtilities.VerifyThrowInternalNull(item, nameof(item));
+                ErrorUtilities.VerifyThrowInternalNull(item);
                 AllEvaluatedItems.Add(item);
             }
 

--- a/src/Build/Definition/Project.cs
+++ b/src/Build/Definition/Project.cs
@@ -108,8 +108,8 @@ namespace Microsoft.Build.Evaluation
 
         internal Project(ProjectCollection projectCollection, ProjectLink link)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(projectCollection, nameof(projectCollection));
-            ErrorUtilities.VerifyThrowArgumentNull(link, nameof(link));
+            ErrorUtilities.VerifyThrowArgumentNull(projectCollection);
+            ErrorUtilities.VerifyThrowArgumentNull(link);
             ProjectCollection = projectCollection;
             implementationInternal = new ProjectLinkInternalNotImplemented();
             implementation = link;
@@ -264,9 +264,9 @@ namespace Microsoft.Build.Evaluation
         private Project(ProjectRootElement xml, IDictionary<string, string> globalProperties, string toolsVersion, string subToolsetVersion, ProjectCollection projectCollection, ProjectLoadSettings loadSettings,
             EvaluationContext evaluationContext, IDirectoryCacheFactory directoryCacheFactory, bool interactive)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(xml, nameof(xml));
+            ErrorUtilities.VerifyThrowArgumentNull(xml);
             ErrorUtilities.VerifyThrowArgumentLengthIfNotNull(toolsVersion, nameof(toolsVersion));
-            ErrorUtilities.VerifyThrowArgumentNull(projectCollection, nameof(projectCollection));
+            ErrorUtilities.VerifyThrowArgumentNull(projectCollection);
             ProjectCollection = projectCollection;
             var defaultImplementation = new ProjectImpl(this, xml, globalProperties, toolsVersion, subToolsetVersion, loadSettings);
             implementationInternal = (IProjectLinkInternal)defaultImplementation;
@@ -358,9 +358,9 @@ namespace Microsoft.Build.Evaluation
         private Project(XmlReader xmlReader, IDictionary<string, string> globalProperties, string toolsVersion, string subToolsetVersion, ProjectCollection projectCollection, ProjectLoadSettings loadSettings,
             EvaluationContext evaluationContext, IDirectoryCacheFactory directoryCacheFactory, bool interactive)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(xmlReader, nameof(xmlReader));
+            ErrorUtilities.VerifyThrowArgumentNull(xmlReader);
             ErrorUtilities.VerifyThrowArgumentLengthIfNotNull(toolsVersion, nameof(toolsVersion));
-            ErrorUtilities.VerifyThrowArgumentNull(projectCollection, nameof(projectCollection));
+            ErrorUtilities.VerifyThrowArgumentNull(projectCollection);
             ProjectCollection = projectCollection;
             var defaultImplementation = new ProjectImpl(this, xmlReader, globalProperties, toolsVersion, subToolsetVersion, loadSettings, evaluationContext);
             implementationInternal = (IProjectLinkInternal)defaultImplementation;
@@ -454,9 +454,9 @@ namespace Microsoft.Build.Evaluation
         private Project(string projectFile, IDictionary<string, string> globalProperties, string toolsVersion, string subToolsetVersion, ProjectCollection projectCollection, ProjectLoadSettings loadSettings,
             EvaluationContext evaluationContext, IDirectoryCacheFactory directoryCacheFactory, bool interactive)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(projectFile, nameof(projectFile));
+            ErrorUtilities.VerifyThrowArgumentNull(projectFile);
             ErrorUtilities.VerifyThrowArgumentLengthIfNotNull(toolsVersion, nameof(toolsVersion));
-            ErrorUtilities.VerifyThrowArgumentNull(projectCollection, nameof(projectCollection));
+            ErrorUtilities.VerifyThrowArgumentNull(projectCollection);
 
             ProjectCollection = projectCollection;
             var defaultImplementation = new ProjectImpl(this, projectFile, globalProperties, toolsVersion, subToolsetVersion, loadSettings, evaluationContext);
@@ -850,7 +850,7 @@ namespace Microsoft.Build.Evaluation
         [SuppressMessage("Microsoft.Design", "CA1011:ConsiderPassingBaseTypesAsParameters", Justification = "IItem is an internal interface; this is less confusing to outside customers. ")]
         public static string GetEvaluatedItemIncludeEscaped(ProjectItem item)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(item, nameof(item));
+            ErrorUtilities.VerifyThrowArgumentNull(item);
 
             return ((IItem)item).EvaluatedIncludeEscaped;
         }
@@ -860,7 +860,7 @@ namespace Microsoft.Build.Evaluation
         /// </summary>
         public static string GetEvaluatedItemIncludeEscaped(ProjectItemDefinition item)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(item, nameof(item));
+            ErrorUtilities.VerifyThrowArgumentNull(item);
 
             return ((IItem)item).EvaluatedIncludeEscaped;
         }
@@ -1077,7 +1077,7 @@ namespace Microsoft.Build.Evaluation
         /// </summary>
         public static string GetMetadataValueEscaped(ProjectMetadata metadatum)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(metadatum, nameof(metadatum));
+            ErrorUtilities.VerifyThrowArgumentNull(metadatum);
 
             return metadatum.EvaluatedValueEscaped;
         }
@@ -1088,7 +1088,7 @@ namespace Microsoft.Build.Evaluation
         [SuppressMessage("Microsoft.Design", "CA1011:ConsiderPassingBaseTypesAsParameters", Justification = "IItem is an internal interface; this is less confusing to outside customers. ")]
         public static string GetMetadataValueEscaped(ProjectItem item, string name)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(item, nameof(item));
+            ErrorUtilities.VerifyThrowArgumentNull(item);
 
             return ((IItem)item).GetMetadataValueEscaped(name);
         }
@@ -1098,7 +1098,7 @@ namespace Microsoft.Build.Evaluation
         /// </summary>
         public static string GetMetadataValueEscaped(ProjectItemDefinition item, string name)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(item, nameof(item));
+            ErrorUtilities.VerifyThrowArgumentNull(item);
 
             return ((IItem)item).GetMetadataValueEscaped(name);
         }
@@ -1109,7 +1109,7 @@ namespace Microsoft.Build.Evaluation
         [SuppressMessage("Microsoft.Design", "CA1011:ConsiderPassingBaseTypesAsParameters", Justification = "IProperty is an internal interface; this is less confusing to outside customers. ")]
         public static string GetPropertyValueEscaped(ProjectProperty property)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(property, nameof(property));
+            ErrorUtilities.VerifyThrowArgumentNull(property);
 
             return ((IProperty)property).EvaluatedValueEscaped;
         }
@@ -1879,9 +1879,9 @@ namespace Microsoft.Build.Evaluation
             /// <param name="loadSettings">The <see cref="ProjectLoadSettings"/> to use for evaluation.</param>
             public ProjectImpl(Project owner, ProjectRootElement xml, IDictionary<string, string> globalProperties, string toolsVersion, string subToolsetVersion, ProjectLoadSettings loadSettings)
             {
-                ErrorUtilities.VerifyThrowArgumentNull(xml, nameof(xml));
+                ErrorUtilities.VerifyThrowArgumentNull(xml);
                 ErrorUtilities.VerifyThrowArgumentLengthIfNotNull(toolsVersion, nameof(toolsVersion));
-                ErrorUtilities.VerifyThrowArgumentNull(owner, nameof(owner));
+                ErrorUtilities.VerifyThrowArgumentNull(owner);
 
                 Xml = xml;
                 Owner = owner;
@@ -1903,9 +1903,9 @@ namespace Microsoft.Build.Evaluation
             /// <param name="evaluationContext">The evaluation context to use in case reevaluation is required.</param>
             public ProjectImpl(Project owner, XmlReader xmlReader, IDictionary<string, string> globalProperties, string toolsVersion, string subToolsetVersion, ProjectLoadSettings loadSettings, EvaluationContext evaluationContext)
             {
-                ErrorUtilities.VerifyThrowArgumentNull(xmlReader, nameof(xmlReader));
+                ErrorUtilities.VerifyThrowArgumentNull(xmlReader);
                 ErrorUtilities.VerifyThrowArgumentLengthIfNotNull(toolsVersion, nameof(toolsVersion));
-                ErrorUtilities.VerifyThrowArgumentNull(owner, nameof(owner));
+                ErrorUtilities.VerifyThrowArgumentNull(owner);
 
                 Owner = owner;
 
@@ -1938,9 +1938,9 @@ namespace Microsoft.Build.Evaluation
             /// <param name="evaluationContext">The evaluation context to use in case reevaluation is required.</param>
             public ProjectImpl(Project owner, string projectFile, IDictionary<string, string> globalProperties, string toolsVersion, string subToolsetVersion, ProjectLoadSettings loadSettings, EvaluationContext evaluationContext)
             {
-                ErrorUtilities.VerifyThrowArgumentNull(projectFile, nameof(projectFile));
+                ErrorUtilities.VerifyThrowArgumentNull(projectFile);
                 ErrorUtilities.VerifyThrowArgumentLengthIfNotNull(toolsVersion, nameof(toolsVersion));
-                ErrorUtilities.VerifyThrowArgumentNull(owner, nameof(owner));
+                ErrorUtilities.VerifyThrowArgumentNull(owner);
 
                 Owner = owner;
 
@@ -2925,7 +2925,7 @@ namespace Microsoft.Build.Evaluation
             public override ProjectProperty SetProperty(string name, string unevaluatedValue)
             {
                 ErrorUtilities.VerifyThrowArgumentLength(name, nameof(name));
-                ErrorUtilities.VerifyThrowArgumentNull(unevaluatedValue, nameof(unevaluatedValue));
+                ErrorUtilities.VerifyThrowArgumentNull(unevaluatedValue);
 
                 ProjectProperty property = _data.Properties[name];
 
@@ -3152,7 +3152,7 @@ namespace Microsoft.Build.Evaluation
             /// </summary>
             public override bool RemoveProperty(ProjectProperty property)
             {
-                ErrorUtilities.VerifyThrowArgumentNull(property, nameof(property));
+                ErrorUtilities.VerifyThrowArgumentNull(property);
                 ErrorUtilities.VerifyThrowInvalidOperation(!property.IsReservedProperty, "OM_ReservedName", property.Name);
                 ErrorUtilities.VerifyThrowInvalidOperation(!property.IsGlobalProperty, "OM_GlobalProperty", property.Name);
                 ErrorUtilities.VerifyThrowArgument(property.Xml.Parent != null, "OM_IncorrectObjectAssociation", "ProjectProperty", "Project");
@@ -3214,7 +3214,7 @@ namespace Microsoft.Build.Evaluation
             /// </remarks>
             public override bool RemoveItem(ProjectItem item)
             {
-                ErrorUtilities.VerifyThrowArgumentNull(item, nameof(item));
+                ErrorUtilities.VerifyThrowArgumentNull(item);
                 ErrorUtilities.VerifyThrowArgument(item.Project == Owner, "OM_IncorrectObjectAssociation", "ProjectItem", "Project");
 
                 bool result = RemoveItemHelper(item);
@@ -3234,7 +3234,7 @@ namespace Microsoft.Build.Evaluation
             /// </remarks>
             public override void RemoveItems(IEnumerable<ProjectItem> items)
             {
-                ErrorUtilities.VerifyThrowArgumentNull(items, nameof(items));
+                ErrorUtilities.VerifyThrowArgumentNull(items);
 
                 // Copying to a list makes it possible to remove
                 // all items of a particular type with
@@ -3257,7 +3257,7 @@ namespace Microsoft.Build.Evaluation
             /// </summary>
             public override string ExpandString(string unexpandedValue)
             {
-                ErrorUtilities.VerifyThrowArgumentNull(unexpandedValue, nameof(unexpandedValue));
+                ErrorUtilities.VerifyThrowArgumentNull(unexpandedValue);
 
                 string result = _data.Expander.ExpandIntoStringAndUnescape(unexpandedValue, ExpanderOptions.ExpandPropertiesAndItems, ProjectFileLocation);
 
@@ -3633,7 +3633,7 @@ namespace Microsoft.Build.Evaluation
             /// </summary>
             private bool RemoveItemHelper(ProjectItem item)
             {
-                ErrorUtilities.VerifyThrowArgumentNull(item, nameof(item));
+                ErrorUtilities.VerifyThrowArgumentNull(item);
 
                 if (item.Project == null || item.Xml.Parent == null)
                 {

--- a/src/Build/Definition/Project.cs
+++ b/src/Build/Definition/Project.cs
@@ -2924,7 +2924,7 @@ namespace Microsoft.Build.Evaluation
             /// </summary>
             public override ProjectProperty SetProperty(string name, string unevaluatedValue)
             {
-                ErrorUtilities.VerifyThrowArgumentLength(name, nameof(name));
+                ErrorUtilities.VerifyThrowArgumentLength(name);
                 ErrorUtilities.VerifyThrowArgumentNull(unevaluatedValue);
 
                 ProjectProperty property = _data.Properties[name];
@@ -3052,8 +3052,8 @@ namespace Microsoft.Build.Evaluation
             /// </summary>
             public override IList<ProjectItem> AddItemFast(string itemType, string unevaluatedInclude, IEnumerable<KeyValuePair<string, string>> metadata)
             {
-                ErrorUtilities.VerifyThrowArgumentLength(itemType, nameof(itemType));
-                ErrorUtilities.VerifyThrowArgumentLength(unevaluatedInclude, nameof(unevaluatedInclude));
+                ErrorUtilities.VerifyThrowArgumentLength(itemType);
+                ErrorUtilities.VerifyThrowArgumentLength(unevaluatedInclude);
 
                 ProjectItemGroupElement groupToAppendTo = null;
 
@@ -3179,7 +3179,7 @@ namespace Microsoft.Build.Evaluation
             /// </summary>
             public override bool RemoveGlobalProperty(string name)
             {
-                ErrorUtilities.VerifyThrowArgumentLength(name, nameof(name));
+                ErrorUtilities.VerifyThrowArgumentLength(name);
 
                 bool result = _data.GlobalPropertiesDictionary.Remove(name);
 
@@ -4623,7 +4623,7 @@ namespace Microsoft.Build.Evaluation
             /// </remarks>
             internal string GetPropertyValue(string name)
             {
-                ErrorUtilities.VerifyThrowArgumentLength(name, nameof(name));
+                ErrorUtilities.VerifyThrowArgumentLength(name);
 
                 ProjectProperty property = Properties[name];
                 string value = property?.EvaluatedValue ?? String.Empty;

--- a/src/Build/Definition/ProjectCollection.cs
+++ b/src/Build/Definition/ProjectCollection.cs
@@ -1026,7 +1026,7 @@ namespace Microsoft.Build.Evaluation
         /// </summary>
         public bool RemoveToolset(string toolsVersion)
         {
-            ErrorUtilities.VerifyThrowArgumentLength(toolsVersion, nameof(toolsVersion));
+            ErrorUtilities.VerifyThrowArgumentLength(toolsVersion);
 
             bool changed;
             using (_locker.EnterDisposableWriteLock())
@@ -1070,7 +1070,7 @@ namespace Microsoft.Build.Evaluation
         /// </summary>
         public Toolset GetToolset(string toolsVersion)
         {
-            ErrorUtilities.VerifyThrowArgumentLength(toolsVersion, nameof(toolsVersion));
+            ErrorUtilities.VerifyThrowArgumentLength(toolsVersion);
             using (_locker.EnterDisposableWriteLock())
             {
                 _toolsets.TryGetValue(toolsVersion, out var toolset);
@@ -1157,7 +1157,7 @@ namespace Microsoft.Build.Evaluation
         /// <returns>A loaded project.</returns>
         public Project LoadProject(string fileName, IDictionary<string, string> globalProperties, string toolsVersion)
         {
-            ErrorUtilities.VerifyThrowArgumentLength(fileName, nameof(fileName));
+            ErrorUtilities.VerifyThrowArgumentLength(fileName);
             fileName = FileUtilities.NormalizePath(fileName);
 
             using (_locker.EnterDisposableWriteLock())

--- a/src/Build/Definition/ProjectCollection.cs
+++ b/src/Build/Definition/ProjectCollection.cs
@@ -1010,7 +1010,7 @@ namespace Microsoft.Build.Evaluation
         /// </summary>
         public void AddToolset(Toolset toolset)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(toolset, nameof(toolset));
+            ErrorUtilities.VerifyThrowArgumentNull(toolset);
             using (_locker.EnterDisposableWriteLock())
             {
                 _toolsets[toolset.ToolsVersion] = toolset;
@@ -1379,7 +1379,7 @@ namespace Microsoft.Build.Evaluation
         /// </remarks>
         public void UnloadProject(ProjectRootElement projectRootElement)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(projectRootElement, nameof(projectRootElement));
+            ErrorUtilities.VerifyThrowArgumentNull(projectRootElement);
             if (projectRootElement.Link != null)
             {
                 return;
@@ -1529,7 +1529,7 @@ namespace Microsoft.Build.Evaluation
         /// <param name="projectRootElement">The project XML root element to unload.</param>
         public bool TryUnloadProject(ProjectRootElement projectRootElement)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(projectRootElement, nameof(projectRootElement));
+            ErrorUtilities.VerifyThrowArgumentNull(projectRootElement);
             if (projectRootElement.Link != null)
             {
                 return false;
@@ -1668,7 +1668,7 @@ namespace Microsoft.Build.Evaluation
         /// </summary>
         private void RegisterLoggerInternal(ILogger logger)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(logger, nameof(logger));
+            ErrorUtilities.VerifyThrowArgumentNull(logger);
             Debug.Assert(_locker.IsWriteLockHeld);
             _loggingService.RegisterLogger(new ReusableLogger(logger));
         }
@@ -1942,7 +1942,7 @@ namespace Microsoft.Build.Evaluation
             /// </summary>
             public ReusableLogger(ILogger originalLogger)
             {
-                ErrorUtilities.VerifyThrowArgumentNull(originalLogger, nameof(originalLogger));
+                ErrorUtilities.VerifyThrowArgumentNull(originalLogger);
                 _originalLogger = originalLogger;
             }
 

--- a/src/Build/Definition/ProjectImportPathMatch.cs
+++ b/src/Build/Definition/ProjectImportPathMatch.cs
@@ -29,8 +29,8 @@ namespace Microsoft.Build.Evaluation
 
         internal ProjectImportPathMatch(string propertyName, List<string> searchPaths)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(propertyName, nameof(propertyName));
-            ErrorUtilities.VerifyThrowArgumentNull(searchPaths, nameof(searchPaths));
+            ErrorUtilities.VerifyThrowArgumentNull(propertyName);
+            ErrorUtilities.VerifyThrowArgumentNull(searchPaths);
 
             _propertyName = propertyName;
             _searchPaths = searchPaths;

--- a/src/Build/Definition/ProjectItem.cs
+++ b/src/Build/Definition/ProjectItem.cs
@@ -126,7 +126,7 @@ namespace Microsoft.Build.Evaluation
                              PropertyDictionary<ProjectMetadata> directMetadataCloned,
                              List<ProjectItemDefinition> inheritedItemDefinitionsCloned)
         {
-            ErrorUtilities.VerifyThrowInternalNull(project, nameof(project));
+            ErrorUtilities.VerifyThrowInternalNull(project);
             ErrorUtilities.VerifyThrowArgumentNull(xml);
 
             // Orcas accidentally allowed empty includes if they resulted from expansion: we preserve that bug

--- a/src/Build/Definition/ProjectItem.cs
+++ b/src/Build/Definition/ProjectItem.cs
@@ -127,11 +127,11 @@ namespace Microsoft.Build.Evaluation
                              List<ProjectItemDefinition> inheritedItemDefinitionsCloned)
         {
             ErrorUtilities.VerifyThrowInternalNull(project, nameof(project));
-            ErrorUtilities.VerifyThrowArgumentNull(xml, nameof(xml));
+            ErrorUtilities.VerifyThrowArgumentNull(xml);
 
             // Orcas accidentally allowed empty includes if they resulted from expansion: we preserve that bug
-            ErrorUtilities.VerifyThrowArgumentNull(evaluatedIncludeEscaped, nameof(evaluatedIncludeEscaped));
-            ErrorUtilities.VerifyThrowArgumentNull(evaluatedIncludeBeforeWildcardExpansionEscaped, nameof(evaluatedIncludeBeforeWildcardExpansionEscaped));
+            ErrorUtilities.VerifyThrowArgumentNull(evaluatedIncludeEscaped);
+            ErrorUtilities.VerifyThrowArgumentNull(evaluatedIncludeBeforeWildcardExpansionEscaped);
 
             _xml = xml;
             _project = project;

--- a/src/Build/Definition/ProjectItem.cs
+++ b/src/Build/Definition/ProjectItem.cs
@@ -407,7 +407,7 @@ namespace Microsoft.Build.Evaluation
                 return Link.GetMetadata(name);
             }
 
-            ErrorUtilities.VerifyThrowArgumentLength(name, nameof(name));
+            ErrorUtilities.VerifyThrowArgumentLength(name);
 
             ProjectMetadata result = null;
 
@@ -473,7 +473,7 @@ namespace Microsoft.Build.Evaluation
         /// </summary>
         string IItem.GetMetadataValueEscaped(string name)
         {
-            ErrorUtilities.VerifyThrowArgumentLength(name, nameof(name));
+            ErrorUtilities.VerifyThrowArgumentLength(name);
 
             string value = null;
 
@@ -635,7 +635,7 @@ namespace Microsoft.Build.Evaluation
                 return Link.RemoveMetadata(name);
             }
 
-            ErrorUtilities.VerifyThrowArgumentLength(name, nameof(name));
+            ErrorUtilities.VerifyThrowArgumentLength(name);
             ErrorUtilities.VerifyThrowArgument(!FileUtilities.ItemSpecModifiers.IsItemSpecModifier(name), "ItemSpecModifierCannotBeCustomMetadata", name);
             Project.VerifyThrowInvalidOperationNotImported(_xml.ContainingProject);
             ErrorUtilities.VerifyThrowInvalidOperation(_xml.Parent?.Parent != null, "OM_ObjectIsNoLongerActive");

--- a/src/Build/Definition/ProjectItemDefinition.cs
+++ b/src/Build/Definition/ProjectItemDefinition.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Build.Evaluation
         /// </remarks>
         internal ProjectItemDefinition(Project project, string itemType)
         {
-            ErrorUtilities.VerifyThrowInternalNull(project, nameof(project));
+            ErrorUtilities.VerifyThrowInternalNull(project);
             ErrorUtilities.VerifyThrowArgumentLength(itemType);
 
             _project = project;

--- a/src/Build/Definition/ProjectItemDefinition.cs
+++ b/src/Build/Definition/ProjectItemDefinition.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Build.Evaluation
         internal ProjectItemDefinition(Project project, string itemType)
         {
             ErrorUtilities.VerifyThrowInternalNull(project, nameof(project));
-            ErrorUtilities.VerifyThrowArgumentLength(itemType, nameof(itemType));
+            ErrorUtilities.VerifyThrowArgumentLength(itemType);
 
             _project = project;
             _itemType = itemType;

--- a/src/Build/Definition/ProjectMetadata.cs
+++ b/src/Build/Definition/ProjectMetadata.cs
@@ -57,8 +57,8 @@ namespace Microsoft.Build.Evaluation
         /// </summary>
         internal ProjectMetadata(object parent, ProjectMetadataElement xml)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(parent, nameof(parent));
-            ErrorUtilities.VerifyThrowArgumentNull(xml, nameof(xml));
+            ErrorUtilities.VerifyThrowArgumentNull(parent);
+            ErrorUtilities.VerifyThrowArgumentNull(xml);
 
             _parent = (IProjectMetadataParent)parent;
             _xml = xml;
@@ -70,9 +70,9 @@ namespace Microsoft.Build.Evaluation
         /// </summary>
         internal ProjectMetadata(IProjectMetadataParent parent, ProjectMetadataElement xml, string evaluatedValueEscaped, ProjectMetadata predecessor)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(parent, nameof(parent));
-            ErrorUtilities.VerifyThrowArgumentNull(xml, nameof(xml));
-            ErrorUtilities.VerifyThrowArgumentNull(evaluatedValueEscaped, nameof(evaluatedValueEscaped));
+            ErrorUtilities.VerifyThrowArgumentNull(parent);
+            ErrorUtilities.VerifyThrowArgumentNull(xml);
+            ErrorUtilities.VerifyThrowArgumentNull(evaluatedValueEscaped);
 
             _parent = parent;
             _xml = xml;

--- a/src/Build/Definition/ProjectProperty.cs
+++ b/src/Build/Definition/ProjectProperty.cs
@@ -544,7 +544,7 @@ namespace Microsoft.Build.Evaluation
             internal ProjectPropertyNotXmlBacked(Project project, string name, string evaluatedValueEscaped, bool isGlobalProperty, bool mayBeReserved)
                 : base(project, evaluatedValueEscaped)
             {
-                ErrorUtilities.VerifyThrowArgumentLength(name, nameof(name));
+                ErrorUtilities.VerifyThrowArgumentLength(name);
                 ErrorUtilities.VerifyThrowInvalidOperation(isGlobalProperty || !ProjectHasMatchingGlobalProperty(project, name), "OM_GlobalProperty", name);
                 ErrorUtilities.VerifyThrowArgument(!XMakeElements.ReservedItemNames.Contains(name), "OM_ReservedName", name);
                 ErrorUtilities.VerifyThrowArgument(mayBeReserved || !ReservedPropertyNames.IsReservedProperty(name), "OM_ReservedName", name);

--- a/src/Build/Definition/ProjectProperty.cs
+++ b/src/Build/Definition/ProjectProperty.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Build.Evaluation
 
         internal ProjectProperty(Project project)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(project, nameof(project));
+            ErrorUtilities.VerifyThrowArgumentNull(project);
             _project = project;
         }
 
@@ -49,8 +49,8 @@ namespace Microsoft.Build.Evaluation
         /// </summary>
         internal ProjectProperty(Project project, string evaluatedValueEscaped)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(project, nameof(project));
-            ErrorUtilities.VerifyThrowArgumentNull(evaluatedValueEscaped, nameof(evaluatedValueEscaped));
+            ErrorUtilities.VerifyThrowArgumentNull(project);
+            ErrorUtilities.VerifyThrowArgumentNull(evaluatedValueEscaped);
 
             _project = project;
             _evaluatedValueEscaped = evaluatedValueEscaped;
@@ -359,7 +359,7 @@ namespace Microsoft.Build.Evaluation
             internal ProjectPropertyXmlBacked(Project project, ProjectPropertyElement xml, string evaluatedValueEscaped)
                 : base(project, evaluatedValueEscaped)
             {
-                ErrorUtilities.VerifyThrowArgumentNull(xml, nameof(xml));
+                ErrorUtilities.VerifyThrowArgumentNull(xml);
                 ErrorUtilities.VerifyThrowInvalidOperation(!ProjectHasMatchingGlobalProperty(project, xml.Name), "OM_GlobalProperty", xml.Name);
 
                 _xml = xml;
@@ -504,7 +504,7 @@ namespace Microsoft.Build.Evaluation
             internal ProjectPropertyXmlBackedWithPredecessor(Project project, ProjectPropertyElement xml, string evaluatedValueEscaped, ProjectProperty predecessor)
                 : base(project, xml, evaluatedValueEscaped)
             {
-                ErrorUtilities.VerifyThrowArgumentNull(predecessor, nameof(predecessor));
+                ErrorUtilities.VerifyThrowArgumentNull(predecessor);
 
                 _predecessor = predecessor;
             }

--- a/src/Build/Definition/SubToolset.cs
+++ b/src/Build/Definition/SubToolset.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Build.Evaluation
         /// </summary>
         internal SubToolset(string subToolsetVersion, PropertyDictionary<ProjectPropertyInstance> properties)
         {
-            ErrorUtilities.VerifyThrowArgumentLength(subToolsetVersion, nameof(subToolsetVersion));
+            ErrorUtilities.VerifyThrowArgumentLength(subToolsetVersion);
 
             _subToolsetVersion = subToolsetVersion;
             _properties = properties;

--- a/src/Build/Definition/Toolset.cs
+++ b/src/Build/Definition/Toolset.cs
@@ -272,8 +272,8 @@ namespace Microsoft.Build.Evaluation
         {
             ErrorUtilities.VerifyThrowArgumentLength(toolsVersion, nameof(toolsVersion));
             ErrorUtilities.VerifyThrowArgumentLength(toolsPath, nameof(toolsPath));
-            ErrorUtilities.VerifyThrowArgumentNull(environmentProperties, nameof(environmentProperties));
-            ErrorUtilities.VerifyThrowArgumentNull(globalProperties, nameof(globalProperties));
+            ErrorUtilities.VerifyThrowArgumentNull(environmentProperties);
+            ErrorUtilities.VerifyThrowArgumentNull(globalProperties);
 
             _toolsVersion = toolsVersion;
             this.ToolsPath = toolsPath;

--- a/src/Build/Definition/Toolset.cs
+++ b/src/Build/Definition/Toolset.cs
@@ -349,8 +349,8 @@ namespace Microsoft.Build.Evaluation
         internal Toolset(string toolsVersion, string toolsPath, PropertyDictionary<ProjectPropertyInstance> buildProperties, ProjectCollection projectCollection, DirectoryGetFiles getFiles, LoadXmlFromPath loadXmlFromPath, string msbuildOverrideTasksPath, DirectoryExists directoryExists)
             : this(toolsVersion, toolsPath, buildProperties, projectCollection.EnvironmentProperties, projectCollection.GlobalPropertiesCollection, null, msbuildOverrideTasksPath, null)
         {
-            ErrorUtilities.VerifyThrowInternalNull(getFiles, nameof(getFiles));
-            ErrorUtilities.VerifyThrowInternalNull(loadXmlFromPath, nameof(loadXmlFromPath));
+            ErrorUtilities.VerifyThrowInternalNull(getFiles);
+            ErrorUtilities.VerifyThrowInternalNull(loadXmlFromPath);
 
             _directoryExists = directoryExists;
             _getFiles = getFiles;

--- a/src/Build/Definition/Toolset.cs
+++ b/src/Build/Definition/Toolset.cs
@@ -270,8 +270,8 @@ namespace Microsoft.Build.Evaluation
         /// <param name="defaultOverrideToolsVersion">ToolsVersion to use as the default ToolsVersion for this version of MSBuild.</param>
         internal Toolset(string toolsVersion, string toolsPath, PropertyDictionary<ProjectPropertyInstance> environmentProperties, PropertyDictionary<ProjectPropertyInstance> globalProperties, string msbuildOverrideTasksPath, string defaultOverrideToolsVersion)
         {
-            ErrorUtilities.VerifyThrowArgumentLength(toolsVersion, nameof(toolsVersion));
-            ErrorUtilities.VerifyThrowArgumentLength(toolsPath, nameof(toolsPath));
+            ErrorUtilities.VerifyThrowArgumentLength(toolsVersion);
+            ErrorUtilities.VerifyThrowArgumentLength(toolsPath);
             ErrorUtilities.VerifyThrowArgumentNull(environmentProperties);
             ErrorUtilities.VerifyThrowArgumentNull(globalProperties);
 

--- a/src/Build/Definition/ToolsetConfigurationReader.cs
+++ b/src/Build/Definition/ToolsetConfigurationReader.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Build.Evaluation
         internal ToolsetConfigurationReader(PropertyDictionary<ProjectPropertyInstance> environmentProperties, PropertyDictionary<ProjectPropertyInstance> globalProperties, Func<Configuration> readApplicationConfiguration)
             : base(environmentProperties, globalProperties)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(readApplicationConfiguration, nameof(readApplicationConfiguration));
+            ErrorUtilities.VerifyThrowArgumentNull(readApplicationConfiguration);
             _readApplicationConfiguration = readApplicationConfiguration;
             _projectImportSearchPathsCache = new Dictionary<string, Dictionary<string, ProjectImportPathMatch>>(StringComparer.OrdinalIgnoreCase);
         }

--- a/src/Build/Definition/ToolsetPropertyDefinition.cs
+++ b/src/Build/Definition/ToolsetPropertyDefinition.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Build.Evaluation
         /// <param name="source">The property source</param>
         public ToolsetPropertyDefinition(string name, string value, IElementLocation source)
         {
-            ErrorUtilities.VerifyThrowArgumentLength(name, nameof(name));
+            ErrorUtilities.VerifyThrowArgumentLength(name);
             ErrorUtilities.VerifyThrowArgumentNull(source);
 
             // value can be the empty string but not null

--- a/src/Build/Definition/ToolsetPropertyDefinition.cs
+++ b/src/Build/Definition/ToolsetPropertyDefinition.cs
@@ -39,10 +39,10 @@ namespace Microsoft.Build.Evaluation
         public ToolsetPropertyDefinition(string name, string value, IElementLocation source)
         {
             ErrorUtilities.VerifyThrowArgumentLength(name, nameof(name));
-            ErrorUtilities.VerifyThrowArgumentNull(source, nameof(source));
+            ErrorUtilities.VerifyThrowArgumentNull(source);
 
             // value can be the empty string but not null
-            ErrorUtilities.VerifyThrowArgumentNull(value, nameof(value));
+            ErrorUtilities.VerifyThrowArgumentNull(value);
 
             _name = name;
             _value = value;

--- a/src/Build/Definition/ToolsetRegistryReader.cs
+++ b/src/Build/Definition/ToolsetRegistryReader.cs
@@ -235,7 +235,7 @@ namespace Microsoft.Build.Evaluation
         /// <returns>An enumeration of property definitions.</returns>
         protected override IEnumerable<ToolsetPropertyDefinition> GetSubToolsetPropertyDefinitions(string toolsVersion, string subToolsetVersion)
         {
-            ErrorUtilities.VerifyThrowArgumentLength(subToolsetVersion, nameof(subToolsetVersion));
+            ErrorUtilities.VerifyThrowArgumentLength(subToolsetVersion);
 
             RegistryKeyWrapper toolsVersionWrapper = null;
             RegistryKeyWrapper subToolsetWrapper = null;

--- a/src/Build/Errors/InvalidProjectFileException.cs
+++ b/src/Build/Errors/InvalidProjectFileException.cs
@@ -216,7 +216,7 @@ namespace Microsoft.Build.Exceptions
             Exception innerException) : base(message, innerException)
         {
             ErrorUtilities.VerifyThrowArgumentNull(projectFile);
-            ErrorUtilities.VerifyThrowArgumentLength(message, nameof(message));
+            ErrorUtilities.VerifyThrowArgumentLength(message);
 
             // Try to helpfully provide a full path if possible, but do so robustly.
             // This exception might be because the path was invalid!

--- a/src/Build/Errors/InvalidProjectFileException.cs
+++ b/src/Build/Errors/InvalidProjectFileException.cs
@@ -215,7 +215,7 @@ namespace Microsoft.Build.Exceptions
             string helpKeyword,
             Exception innerException) : base(message, innerException)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(projectFile, nameof(projectFile));
+            ErrorUtilities.VerifyThrowArgumentNull(projectFile);
             ErrorUtilities.VerifyThrowArgumentLength(message, nameof(message));
 
             // Try to helpfully provide a full path if possible, but do so robustly.

--- a/src/Build/Errors/InvalidToolsetDefinitionException.cs
+++ b/src/Build/Errors/InvalidToolsetDefinitionException.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Build.Exceptions
         protected InvalidToolsetDefinitionException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(info, nameof(info));
+            ErrorUtilities.VerifyThrowArgumentNull(info);
 
             errorCode = info.GetString("errorCode");
         }
@@ -103,7 +103,7 @@ namespace Microsoft.Build.Exceptions
 #endif
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(info, nameof(info));
+            ErrorUtilities.VerifyThrowArgumentNull(info);
 
             base.GetObjectData(info, context);
 

--- a/src/Build/Evaluation/ConditionEvaluator.cs
+++ b/src/Build/Evaluation/ConditionEvaluator.cs
@@ -226,8 +226,8 @@ namespace Microsoft.Build.Evaluation
             where P : class, IProperty
             where I : class, IItem
         {
-            ErrorUtilities.VerifyThrowArgumentNull(condition, nameof(condition));
-            ErrorUtilities.VerifyThrowArgumentNull(expander, nameof(expander));
+            ErrorUtilities.VerifyThrowArgumentNull(condition);
+            ErrorUtilities.VerifyThrowArgumentNull(expander);
             ErrorUtilities.VerifyThrowArgumentLength(evaluationDirectory, nameof(evaluationDirectory));
 
             // An empty condition is equivalent to a "true" condition.
@@ -237,7 +237,7 @@ namespace Microsoft.Build.Evaluation
             }
 
             // If the condition wasn't empty, there must be a location for it
-            ErrorUtilities.VerifyThrowArgumentNull(elementLocation, nameof(elementLocation));
+            ErrorUtilities.VerifyThrowArgumentNull(elementLocation);
 
             // Get the expression tree cache for the current parsing options.
             var cachedExpressionTreesForCurrentOptions = s_cachedExpressionTrees.GetOrAdd(
@@ -427,10 +427,10 @@ namespace Microsoft.Build.Evaluation
                 IFileSystem fileSystem,
                 ProjectRootElementCacheBase? projectRootElementCache = null)
             {
-                ErrorUtilities.VerifyThrowArgumentNull(condition, nameof(condition));
-                ErrorUtilities.VerifyThrowArgumentNull(expander, nameof(expander));
-                ErrorUtilities.VerifyThrowArgumentNull(evaluationDirectory, nameof(evaluationDirectory));
-                ErrorUtilities.VerifyThrowArgumentNull(elementLocation, nameof(elementLocation));
+                ErrorUtilities.VerifyThrowArgumentNull(condition);
+                ErrorUtilities.VerifyThrowArgumentNull(expander);
+                ErrorUtilities.VerifyThrowArgumentNull(evaluationDirectory);
+                ErrorUtilities.VerifyThrowArgumentNull(elementLocation);
 
                 Condition = condition;
                 _expander = expander;

--- a/src/Build/Evaluation/ConditionEvaluator.cs
+++ b/src/Build/Evaluation/ConditionEvaluator.cs
@@ -228,7 +228,7 @@ namespace Microsoft.Build.Evaluation
         {
             ErrorUtilities.VerifyThrowArgumentNull(condition);
             ErrorUtilities.VerifyThrowArgumentNull(expander);
-            ErrorUtilities.VerifyThrowArgumentLength(evaluationDirectory, nameof(evaluationDirectory));
+            ErrorUtilities.VerifyThrowArgumentLength(evaluationDirectory);
 
             // An empty condition is equivalent to a "true" condition.
             if (condition.Length == 0)

--- a/src/Build/Evaluation/Conditionals/Token.cs
+++ b/src/Build/Evaluation/Conditionals/Token.cs
@@ -99,7 +99,7 @@ namespace Microsoft.Build.Evaluation
                 type == TokenType.Function,
                 "Unexpected token type");
 
-            ErrorUtilities.VerifyThrowInternalNull(tokenString, nameof(tokenString));
+            ErrorUtilities.VerifyThrowInternalNull(tokenString);
 
             _tokenType = type;
             _tokenString = tokenString;

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -362,7 +362,7 @@ namespace Microsoft.Build.Evaluation
         /// </summary>
         internal static List<I> CreateItemsFromInclude(string rootDirectory, ProjectItemElement itemElement, IItemFactory<I, I> itemFactory, string unevaluatedIncludeEscaped, Expander<P, I> expander, ILoggingService loggingService, string buildEventFileInfoFullPath, BuildEventContext buildEventContext)
         {
-            ErrorUtilities.VerifyThrowArgumentLength(unevaluatedIncludeEscaped, nameof(unevaluatedIncludeEscaped));
+            ErrorUtilities.VerifyThrowArgumentLength(unevaluatedIncludeEscaped);
 
             List<I> items = new List<I>();
             itemFactory.ItemElement = itemElement;

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -213,11 +213,11 @@ namespace Microsoft.Build.Evaluation
             ILoggingService loggingService,
             BuildEventContext buildEventContext)
         {
-            ErrorUtilities.VerifyThrowInternalNull(data, nameof(data));
-            ErrorUtilities.VerifyThrowInternalNull(projectRootElementCache, nameof(projectRootElementCache));
-            ErrorUtilities.VerifyThrowInternalNull(evaluationContext, nameof(evaluationContext));
-            ErrorUtilities.VerifyThrowInternalNull(loggingService, nameof(loggingService));
-            ErrorUtilities.VerifyThrowInternalNull(buildEventContext, nameof(buildEventContext));
+            ErrorUtilities.VerifyThrowInternalNull(data);
+            ErrorUtilities.VerifyThrowInternalNull(projectRootElementCache);
+            ErrorUtilities.VerifyThrowInternalNull(evaluationContext);
+            ErrorUtilities.VerifyThrowInternalNull(loggingService);
+            ErrorUtilities.VerifyThrowInternalNull(buildEventContext);
 
             _evaluationLoggingContext = new EvaluationLoggingContext(
                 loggingService,

--- a/src/Build/Evaluation/Expander.cs
+++ b/src/Build/Evaluation/Expander.cs
@@ -493,7 +493,7 @@ namespace Microsoft.Build.Evaluation
                 return String.Empty;
             }
 
-            ErrorUtilities.VerifyThrowInternalNull(elementLocation, nameof(elementLocation));
+            ErrorUtilities.VerifyThrowInternalNull(elementLocation);
 
             string result = MetadataExpander.ExpandMetadataLeaveEscaped(expression, _metadata, options, elementLocation, _loggingContext);
             result = PropertyExpander<P>.ExpandPropertiesLeaveEscaped(result, _properties, options, elementLocation, _propertiesUseTracker, _fileSystem);
@@ -514,7 +514,7 @@ namespace Microsoft.Build.Evaluation
                 return String.Empty;
             }
 
-            ErrorUtilities.VerifyThrowInternalNull(elementLocation, nameof(elementLocation));
+            ErrorUtilities.VerifyThrowInternalNull(elementLocation);
 
             string metaExpanded = MetadataExpander.ExpandMetadataLeaveEscaped(expression, _metadata, options, elementLocation);
             return PropertyExpander<P>.ExpandPropertiesLeaveTypedAndEscaped(metaExpanded, _properties, options, elementLocation, _propertiesUseTracker, _fileSystem);
@@ -562,7 +562,7 @@ namespace Microsoft.Build.Evaluation
                 return Array.Empty<T>();
             }
 
-            ErrorUtilities.VerifyThrowInternalNull(elementLocation, nameof(elementLocation));
+            ErrorUtilities.VerifyThrowInternalNull(elementLocation);
 
             expression = MetadataExpander.ExpandMetadataLeaveEscaped(expression, _metadata, options, elementLocation);
             expression = PropertyExpander<P>.ExpandPropertiesLeaveEscaped(expression, _properties, options, elementLocation, _propertiesUseTracker, _fileSystem);
@@ -636,7 +636,7 @@ namespace Microsoft.Build.Evaluation
                 return Array.Empty<T>();
             }
 
-            ErrorUtilities.VerifyThrowInternalNull(elementLocation, nameof(elementLocation));
+            ErrorUtilities.VerifyThrowInternalNull(elementLocation);
 
             return ItemExpander.ExpandSingleItemVectorExpressionIntoItems(this, expression, _items, itemFactory, options, includeNullItems, out isTransformExpression, elementLocation);
         }

--- a/src/Build/Evaluation/ProjectChangedEventArgs.cs
+++ b/src/Build/Evaluation/ProjectChangedEventArgs.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Build.Evaluation
         /// <param name="project">The changed project.</param>
         internal ProjectChangedEventArgs(Project project)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(project, nameof(project));
+            ErrorUtilities.VerifyThrowArgumentNull(project);
 
             Project = project;
         }

--- a/src/Build/Evaluation/ProjectParser.cs
+++ b/src/Build/Evaluation/ProjectParser.cs
@@ -96,8 +96,8 @@ namespace Microsoft.Build.Construction
         /// </summary>
         private ProjectParser(XmlDocumentWithLocation document, ProjectRootElement project)
         {
-            ErrorUtilities.VerifyThrowInternalNull(project, nameof(project));
-            ErrorUtilities.VerifyThrowInternalNull(document, nameof(document));
+            ErrorUtilities.VerifyThrowInternalNull(project);
+            ErrorUtilities.VerifyThrowInternalNull(document);
 
             _document = document;
             _project = project;

--- a/src/Build/Evaluation/ProjectRootElementCache.cs
+++ b/src/Build/Evaluation/ProjectRootElementCache.cs
@@ -515,7 +515,7 @@ namespace Microsoft.Build.Evaluation
         /// </remarks>
         internal override void DiscardAnyWeakReference(ProjectRootElement projectRootElement)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(projectRootElement, nameof(projectRootElement));
+            ErrorUtilities.VerifyThrowArgumentNull(projectRootElement);
 
             // A PRE may be unnamed if it was only used in memory.
             if (projectRootElement.FullPath != null)

--- a/src/Build/Evaluation/ProjectRootElementCache.cs
+++ b/src/Build/Evaluation/ProjectRootElementCache.cs
@@ -395,7 +395,7 @@ namespace Microsoft.Build.Evaluation
         {
             lock (_locker)
             {
-                ErrorUtilities.VerifyThrowArgumentLength(oldFullPath, nameof(oldFullPath));
+                ErrorUtilities.VerifyThrowArgumentLength(oldFullPath);
                 RenameEntryInternal(oldFullPath, projectRootElement);
             }
         }

--- a/src/Build/Evaluation/ProjectXmlChangedEventArgs.cs
+++ b/src/Build/Evaluation/ProjectXmlChangedEventArgs.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Build.Evaluation
         /// <param name="formattingParameter">The formatting parameter to use with <paramref name="unformattedReason"/>.</param>
         internal ProjectXmlChangedEventArgs(ProjectRootElement projectXml, string unformattedReason, string formattingParameter)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(projectXml, nameof(projectXml));
+            ErrorUtilities.VerifyThrowArgumentNull(projectXml);
 
             this.ProjectXml = projectXml;
             _unformattedReason = unformattedReason;

--- a/src/Build/Evaluation/PropertyTrackingEvaluatorDataWrapper.cs
+++ b/src/Build/Evaluation/PropertyTrackingEvaluatorDataWrapper.cs
@@ -43,8 +43,8 @@ namespace Microsoft.Build.Evaluation
         /// <param name="settingValue">Property tracking setting value</param>
         public PropertyTrackingEvaluatorDataWrapper(IEvaluatorData<P, I, M, D> dataToWrap, EvaluationLoggingContext evaluationLoggingContext, int settingValue)
         {
-            ErrorUtilities.VerifyThrowInternalNull(dataToWrap, nameof(dataToWrap));
-            ErrorUtilities.VerifyThrowInternalNull(evaluationLoggingContext, nameof(evaluationLoggingContext));
+            ErrorUtilities.VerifyThrowInternalNull(dataToWrap);
+            ErrorUtilities.VerifyThrowInternalNull(evaluationLoggingContext);
 
             _wrapped = dataToWrap;
             _evaluationLoggingContext = evaluationLoggingContext;

--- a/src/Build/Evaluation/SimpleProjectRootElementCache.cs
+++ b/src/Build/Evaluation/SimpleProjectRootElementCache.cs
@@ -121,7 +121,7 @@ namespace Microsoft.Build.Evaluation
 
         internal override void DiscardAnyWeakReference(ProjectRootElement projectRootElement)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(projectRootElement, nameof(projectRootElement));
+            ErrorUtilities.VerifyThrowArgumentNull(projectRootElement);
 
             // A PRE may be unnamed if it was only used in memory.
             if (projectRootElement.FullPath != null)

--- a/src/Build/Evaluation/ToolsetProvider.cs
+++ b/src/Build/Evaluation/ToolsetProvider.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Build.Evaluation
         /// </summary>
         public Toolset GetToolset(string toolsVersion)
         {
-            ErrorUtilities.VerifyThrowArgumentLength(toolsVersion, nameof(toolsVersion));
+            ErrorUtilities.VerifyThrowArgumentLength(toolsVersion);
             _toolsets.TryGetValue(toolsVersion, out var toolset);
 
             return toolset;

--- a/src/Build/Globbing/CompositeGlob.cs
+++ b/src/Build/Globbing/CompositeGlob.cs
@@ -85,7 +85,7 @@ namespace Microsoft.Build.Globbing
         /// <returns>The logical disjunction of the input globs.</returns>
         public static IMSBuildGlob Create(IEnumerable<IMSBuildGlob> globs)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(globs, nameof(globs));
+            ErrorUtilities.VerifyThrowArgumentNull(globs);
 
             if (globs is ImmutableArray<IMSBuildGlob> immutableGlobs)
             {

--- a/src/Build/Globbing/MSBuildGlob.cs
+++ b/src/Build/Globbing/MSBuildGlob.cs
@@ -91,7 +91,7 @@ namespace Microsoft.Build.Globbing
         /// <inheritdoc />
         public bool IsMatch(string stringToMatch)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(stringToMatch, nameof(stringToMatch));
+            ErrorUtilities.VerifyThrowArgumentNull(stringToMatch);
 
             if (!IsLegal)
             {
@@ -115,7 +115,7 @@ namespace Microsoft.Build.Globbing
         /// <returns></returns>
         public MatchInfoResult MatchInfo(string stringToMatch)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(stringToMatch, nameof(stringToMatch));
+            ErrorUtilities.VerifyThrowArgumentNull(stringToMatch);
 
             if (FileUtilities.PathIsInvalid(stringToMatch) || !IsLegal)
             {
@@ -168,8 +168,8 @@ namespace Microsoft.Build.Globbing
         /// <returns></returns>
         public static MSBuildGlob Parse(string globRoot, string fileSpec)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(globRoot, nameof(globRoot));
-            ErrorUtilities.VerifyThrowArgumentNull(fileSpec, nameof(fileSpec));
+            ErrorUtilities.VerifyThrowArgumentNull(globRoot);
+            ErrorUtilities.VerifyThrowArgumentNull(fileSpec);
             ErrorUtilities.VerifyThrowArgumentInvalidPath(globRoot, nameof(globRoot));
 
             if (string.IsNullOrEmpty(globRoot))

--- a/src/Build/Globbing/MSBuildGlobWithGaps.cs
+++ b/src/Build/Globbing/MSBuildGlobWithGaps.cs
@@ -41,8 +41,8 @@ namespace Microsoft.Build.Globbing
         /// <param name="gaps">The gap glob</param>
         internal MSBuildGlobWithGaps(IMSBuildGlob mainGlob, IMSBuildGlob gaps)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(mainGlob, nameof(mainGlob));
-            ErrorUtilities.VerifyThrowArgumentNull(gaps, nameof(gaps));
+            ErrorUtilities.VerifyThrowArgumentNull(mainGlob);
+            ErrorUtilities.VerifyThrowArgumentNull(gaps);
 
             MainGlob = mainGlob;
             Gaps = gaps;
@@ -55,8 +55,8 @@ namespace Microsoft.Build.Globbing
         /// <param name="gaps">The gap glob</param>
         public MSBuildGlobWithGaps(IMSBuildGlob mainGlob, IEnumerable<IMSBuildGlob> gaps)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(mainGlob, nameof(mainGlob));
-            ErrorUtilities.VerifyThrowArgumentNull(gaps, nameof(gaps));
+            ErrorUtilities.VerifyThrowArgumentNull(mainGlob);
+            ErrorUtilities.VerifyThrowArgumentNull(gaps);
 
             MainGlob = mainGlob;
             Gaps = CompositeGlob.Create(gaps);

--- a/src/Build/Graph/GraphBuildRequestData.cs
+++ b/src/Build/Graph/GraphBuildRequestData.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Build.Graph
         public GraphBuildRequestData(ProjectGraph projectGraph, ICollection<string> targetsToBuild, HostServices? hostServices, BuildRequestDataFlags flags)
             : this(targetsToBuild, hostServices, flags)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(projectGraph, nameof(projectGraph));
+            ErrorUtilities.VerifyThrowArgumentNull(projectGraph);
 
             ProjectGraph = projectGraph;
         }
@@ -149,7 +149,7 @@ namespace Microsoft.Build.Graph
         public GraphBuildRequestData(IEnumerable<ProjectGraphEntryPoint> projectGraphEntryPoints, ICollection<string> targetsToBuild, HostServices? hostServices, BuildRequestDataFlags flags)
             : this(targetsToBuild, hostServices, flags)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(projectGraphEntryPoints, nameof(projectGraphEntryPoints));
+            ErrorUtilities.VerifyThrowArgumentNull(projectGraphEntryPoints);
 
             ProjectGraphEntryPoints = projectGraphEntryPoints;
         }
@@ -157,7 +157,7 @@ namespace Microsoft.Build.Graph
         public GraphBuildRequestData(IEnumerable<ProjectGraphEntryPoint> projectGraphEntryPoints, ICollection<string> targetsToBuild, HostServices? hostServices, BuildRequestDataFlags flags, GraphBuildOptions graphBuildOptions)
             : this(targetsToBuild, hostServices, flags, graphBuildOptions)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(projectGraphEntryPoints, nameof(projectGraphEntryPoints));
+            ErrorUtilities.VerifyThrowArgumentNull(projectGraphEntryPoints);
 
             ProjectGraphEntryPoints = projectGraphEntryPoints.ToList();
         }

--- a/src/Build/Graph/ProjectGraph.cs
+++ b/src/Build/Graph/ProjectGraph.cs
@@ -421,7 +421,7 @@ namespace Microsoft.Build.Graph
             int degreeOfParallelism,
             CancellationToken cancellationToken)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(projectCollection, nameof(projectCollection));
+            ErrorUtilities.VerifyThrowArgumentNull(projectCollection);
 
             var measurementInfo = BeginMeasurement();
 
@@ -498,7 +498,7 @@ namespace Microsoft.Build.Graph
             Func<ProjectGraphNode, string> nodeIdProvider,
             IReadOnlyDictionary<ProjectGraphNode, ImmutableList<string>> targetsPerNode = null)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(nodeIdProvider, nameof(nodeIdProvider));
+            ErrorUtilities.VerifyThrowArgumentNull(nodeIdProvider);
 
             var nodeIds = new ConcurrentDictionary<ProjectGraphNode, string>();
 

--- a/src/Build/Graph/ProjectGraphEntryPoint.cs
+++ b/src/Build/Graph/ProjectGraphEntryPoint.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Build.Graph
         /// <param name="globalProperties">The global properties to use for this entry point. May be null.</param>
         public ProjectGraphEntryPoint(string projectFile, IDictionary<string, string> globalProperties)
         {
-            ErrorUtilities.VerifyThrowArgumentLength(projectFile, nameof(projectFile));
+            ErrorUtilities.VerifyThrowArgumentLength(projectFile);
 
             ProjectFile = FileUtilities.NormalizePath(projectFile);
             GlobalProperties = globalProperties;

--- a/src/Build/Graph/ProjectGraphNode.cs
+++ b/src/Build/Graph/ProjectGraphNode.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Build.Graph
         // No public creation.
         internal ProjectGraphNode(ProjectInstance projectInstance)
         {
-            ErrorUtilities.VerifyThrowInternalNull(projectInstance, nameof(projectInstance));
+            ErrorUtilities.VerifyThrowInternalNull(projectInstance);
             ProjectInstance = projectInstance;
 
             ProjectType = ProjectInterpretation.GetProjectType(projectInstance);

--- a/src/Build/Graph/ProjectInterpretation.cs
+++ b/src/Build/Graph/ProjectInterpretation.cs
@@ -383,7 +383,7 @@ namespace Microsoft.Build.Graph
             IEnumerable<GlobalPropertiesModifier> globalPropertyModifiers)
         {
             ErrorUtilities.VerifyThrowInternalNull(projectReference, nameof(projectReference));
-            ErrorUtilities.VerifyThrowArgumentNull(requesterGlobalProperties, nameof(requesterGlobalProperties));
+            ErrorUtilities.VerifyThrowArgumentNull(requesterGlobalProperties);
 
             var properties = SplitPropertyNameValuePairs(ItemMetadataNames.PropertiesMetadataName, projectReference.GetMetadataValue(ItemMetadataNames.PropertiesMetadataName));
             var additionalProperties = SplitPropertyNameValuePairs(ItemMetadataNames.AdditionalPropertiesMetadataName, projectReference.GetMetadataValue(ItemMetadataNames.AdditionalPropertiesMetadataName));

--- a/src/Build/Graph/ProjectInterpretation.cs
+++ b/src/Build/Graph/ProjectInterpretation.cs
@@ -382,7 +382,7 @@ namespace Microsoft.Build.Graph
             bool allowCollectionReuse,
             IEnumerable<GlobalPropertiesModifier> globalPropertyModifiers)
         {
-            ErrorUtilities.VerifyThrowInternalNull(projectReference, nameof(projectReference));
+            ErrorUtilities.VerifyThrowInternalNull(projectReference);
             ErrorUtilities.VerifyThrowArgumentNull(requesterGlobalProperties);
 
             var properties = SplitPropertyNameValuePairs(ItemMetadataNames.PropertiesMetadataName, projectReference.GetMetadataValue(ItemMetadataNames.PropertiesMetadataName));

--- a/src/Build/Instance/HostServices.cs
+++ b/src/Build/Instance/HostServices.cs
@@ -66,9 +66,9 @@ namespace Microsoft.Build.Execution
         /// </summary>
         public ITaskHost GetHostObject(string projectFile, string targetName, string taskName)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(projectFile, nameof(projectFile));
-            ErrorUtilities.VerifyThrowArgumentNull(targetName, nameof(targetName));
-            ErrorUtilities.VerifyThrowArgumentNull(taskName, nameof(taskName));
+            ErrorUtilities.VerifyThrowArgumentNull(projectFile);
+            ErrorUtilities.VerifyThrowArgumentNull(targetName);
+            ErrorUtilities.VerifyThrowArgumentNull(taskName);
 
             HostObjects hostObjects;
             if (_hostObjectMap == null || !_hostObjectMap.TryGetValue(projectFile, out hostObjects))
@@ -131,9 +131,9 @@ namespace Microsoft.Build.Execution
                         ErrorUtilities.VerifyThrowArgumentNull(projectFile, "projectFile));
                         ErrorUtilities.VerifyThrowArgumentNull(targetName, "targetName));
             */
-            ErrorUtilities.VerifyThrowArgumentNull(projectFile, nameof(projectFile));
-            ErrorUtilities.VerifyThrowArgumentNull(targetName, nameof(targetName));
-            ErrorUtilities.VerifyThrowArgumentNull(taskName, nameof(taskName));
+            ErrorUtilities.VerifyThrowArgumentNull(projectFile);
+            ErrorUtilities.VerifyThrowArgumentNull(targetName);
+            ErrorUtilities.VerifyThrowArgumentNull(taskName);
 
             // We can only set the host object to a non-null value if the affinity for the project is not out of proc, or if it is, it is only implicitly
             // out of proc, in which case it will become in-proc after this call completes.  See GetNodeAffinity.
@@ -164,10 +164,10 @@ namespace Microsoft.Build.Execution
         [SupportedOSPlatform("windows")]
         public void RegisterHostObject(string projectFile, string targetName, string taskName, string monikerName)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(projectFile, nameof(projectFile));
-            ErrorUtilities.VerifyThrowArgumentNull(targetName, nameof(targetName));
-            ErrorUtilities.VerifyThrowArgumentNull(taskName, nameof(taskName));
-            ErrorUtilities.VerifyThrowArgumentNull(monikerName, nameof(monikerName));
+            ErrorUtilities.VerifyThrowArgumentNull(projectFile);
+            ErrorUtilities.VerifyThrowArgumentNull(targetName);
+            ErrorUtilities.VerifyThrowArgumentNull(taskName);
+            ErrorUtilities.VerifyThrowArgumentNull(monikerName);
 
             _hostObjectMap ??= new Dictionary<string, HostObjects>(StringComparer.OrdinalIgnoreCase);
 

--- a/src/Build/Instance/ImmutableProjectCollections/ImmutableItemDefinitionsListConverter.cs
+++ b/src/Build/Instance/ImmutableProjectCollections/ImmutableItemDefinitionsListConverter.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Build.Instance
             TCached? itemTypeDefinition,
             Func<TCached, T> getInstance)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(getInstance, nameof(getInstance));
+            ErrorUtilities.VerifyThrowArgumentNull(getInstance);
 
             _itemList = itemList;
             _itemTypeDefinition = itemTypeDefinition;

--- a/src/Build/Instance/ProjectInstance.cs
+++ b/src/Build/Instance/ProjectInstance.cs
@@ -294,7 +294,7 @@ namespace Microsoft.Build.Execution
         private ProjectInstance(string projectFile, IDictionary<string, string> globalProperties, string toolsVersion, string subToolsetVersion, ProjectCollection projectCollection,
             ProjectLoadSettings? projectLoadSettings, EvaluationContext evaluationContext, IDirectoryCacheFactory directoryCacheFactory, bool interactive)
         {
-            ErrorUtilities.VerifyThrowArgumentLength(projectFile, nameof(projectFile));
+            ErrorUtilities.VerifyThrowArgumentLength(projectFile);
             ErrorUtilities.VerifyThrowArgumentLengthIfNotNull(toolsVersion, nameof(toolsVersion));
 
             // We do not control the current directory at this point, but assume that if we were
@@ -612,7 +612,7 @@ namespace Microsoft.Build.Execution
         /// </summary>
         internal ProjectInstance(string projectFile, IDictionary<string, string> globalProperties, string toolsVersion, BuildParameters buildParameters, ILoggingService loggingService, BuildEventContext buildEventContext, ISdkResolverService sdkResolverService, int submissionId, ProjectLoadSettings? projectLoadSettings)
         {
-            ErrorUtilities.VerifyThrowArgumentLength(projectFile, nameof(projectFile));
+            ErrorUtilities.VerifyThrowArgumentLength(projectFile);
             ErrorUtilities.VerifyThrowArgumentLengthIfNotNull(toolsVersion, nameof(toolsVersion));
             ErrorUtilities.VerifyThrowArgumentNull(buildParameters);
 
@@ -2537,7 +2537,7 @@ namespace Microsoft.Build.Execution
             ISdkResolverService sdkResolverService,
             int submissionId)
         {
-            ErrorUtilities.VerifyThrowArgumentLength(projectFile, nameof(projectFile));
+            ErrorUtilities.VerifyThrowArgumentLength(projectFile);
             ErrorUtilities.VerifyThrowArgumentNull(globalPropertiesInstances);
             ErrorUtilities.VerifyThrowArgumentLengthIfNotNull(toolsVersion, nameof(toolsVersion));
             ErrorUtilities.VerifyThrowArgumentNull(buildParameters);

--- a/src/Build/Instance/ProjectInstance.cs
+++ b/src/Build/Instance/ProjectInstance.cs
@@ -614,7 +614,7 @@ namespace Microsoft.Build.Execution
         {
             ErrorUtilities.VerifyThrowArgumentLength(projectFile, nameof(projectFile));
             ErrorUtilities.VerifyThrowArgumentLengthIfNotNull(toolsVersion, nameof(toolsVersion));
-            ErrorUtilities.VerifyThrowArgumentNull(buildParameters, nameof(buildParameters));
+            ErrorUtilities.VerifyThrowArgumentNull(buildParameters);
 
             ProjectRootElement xml = ProjectRootElement.OpenProjectOrSolution(projectFile, globalProperties, toolsVersion, buildParameters.ProjectRootElementCache, false /*Not explicitly loaded*/);
 
@@ -628,9 +628,9 @@ namespace Microsoft.Build.Execution
         /// </summary>
         internal ProjectInstance(ProjectRootElement xml, IDictionary<string, string> globalProperties, string toolsVersion, BuildParameters buildParameters, ILoggingService loggingService, BuildEventContext buildEventContext, ISdkResolverService sdkResolverService, int submissionId)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(xml, nameof(xml));
+            ErrorUtilities.VerifyThrowArgumentNull(xml);
             ErrorUtilities.VerifyThrowArgumentLengthIfNotNull(toolsVersion, nameof(toolsVersion));
-            ErrorUtilities.VerifyThrowArgumentNull(buildParameters, nameof(buildParameters));
+            ErrorUtilities.VerifyThrowArgumentNull(buildParameters);
             Initialize(xml, globalProperties, toolsVersion, null, 0 /* no solution version specified */, buildParameters, loggingService, buildEventContext, sdkResolverService, submissionId);
         }
 
@@ -1609,7 +1609,7 @@ namespace Microsoft.Build.Execution
         [SuppressMessage("Microsoft.Design", "CA1011:ConsiderPassingBaseTypesAsParameters", Justification = "IItem is an internal interface; this is less confusing to outside customers. ")]
         public static string GetEvaluatedItemIncludeEscaped(ProjectItemInstance item)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(item, nameof(item));
+            ErrorUtilities.VerifyThrowArgumentNull(item);
 
             return ((IItem)item).EvaluatedIncludeEscaped;
         }
@@ -1619,7 +1619,7 @@ namespace Microsoft.Build.Execution
         /// </summary>
         public static string GetEvaluatedItemIncludeEscaped(ProjectItemDefinitionInstance item)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(item, nameof(item));
+            ErrorUtilities.VerifyThrowArgumentNull(item);
 
             return ((IItem)item).EvaluatedIncludeEscaped;
         }
@@ -1629,7 +1629,7 @@ namespace Microsoft.Build.Execution
         /// </summary>
         public static string GetMetadataValueEscaped(ProjectMetadataInstance metadatum)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(metadatum, nameof(metadatum));
+            ErrorUtilities.VerifyThrowArgumentNull(metadatum);
 
             return metadatum.EvaluatedValueEscaped;
         }
@@ -1640,7 +1640,7 @@ namespace Microsoft.Build.Execution
         [SuppressMessage("Microsoft.Design", "CA1011:ConsiderPassingBaseTypesAsParameters", Justification = "IItem is an internal interface; this is less confusing to outside customers. ")]
         public static string GetMetadataValueEscaped(ProjectItemInstance item, string name)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(item, nameof(item));
+            ErrorUtilities.VerifyThrowArgumentNull(item);
 
             return ((IItem)item).GetMetadataValueEscaped(name);
         }
@@ -1650,7 +1650,7 @@ namespace Microsoft.Build.Execution
         /// </summary>
         public static string GetMetadataValueEscaped(ProjectItemDefinitionInstance item, string name)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(item, nameof(item));
+            ErrorUtilities.VerifyThrowArgumentNull(item);
 
             return ((IItem)item).GetMetadataValueEscaped(name);
         }
@@ -1661,7 +1661,7 @@ namespace Microsoft.Build.Execution
         [SuppressMessage("Microsoft.Design", "CA1011:ConsiderPassingBaseTypesAsParameters", Justification = "IProperty is an internal interface; this is less confusing to outside customers. ")]
         public static string GetPropertyValueEscaped(ProjectPropertyInstance property)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(property, nameof(property));
+            ErrorUtilities.VerifyThrowArgumentNull(property);
 
             return ((IProperty)property).EvaluatedValueEscaped;
         }
@@ -2538,9 +2538,9 @@ namespace Microsoft.Build.Execution
             int submissionId)
         {
             ErrorUtilities.VerifyThrowArgumentLength(projectFile, nameof(projectFile));
-            ErrorUtilities.VerifyThrowArgumentNull(globalPropertiesInstances, nameof(globalPropertiesInstances));
+            ErrorUtilities.VerifyThrowArgumentNull(globalPropertiesInstances);
             ErrorUtilities.VerifyThrowArgumentLengthIfNotNull(toolsVersion, nameof(toolsVersion));
-            ErrorUtilities.VerifyThrowArgumentNull(buildParameters, nameof(buildParameters));
+            ErrorUtilities.VerifyThrowArgumentNull(buildParameters);
             ErrorUtilities.VerifyThrow(FileUtilities.IsSolutionFilename(projectFile), "Project file {0} is not a solution.", projectFile);
 
             ProjectInstance[] projectInstances = null;
@@ -3044,9 +3044,9 @@ namespace Microsoft.Build.Execution
             EvaluationContext evaluationContext = null,
             IDirectoryCacheFactory directoryCacheFactory = null)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(xml, nameof(xml));
+            ErrorUtilities.VerifyThrowArgumentNull(xml);
             ErrorUtilities.VerifyThrowArgumentLengthIfNotNull(explicitToolsVersion, "toolsVersion");
-            ErrorUtilities.VerifyThrowArgumentNull(buildParameters, nameof(buildParameters));
+            ErrorUtilities.VerifyThrowArgumentNull(buildParameters);
 
             _directory = xml.DirectoryPath;
             _projectFileLocation = xml.ProjectFileLocation ?? ElementLocation.EmptyLocation;

--- a/src/Build/Instance/ProjectInstance.cs
+++ b/src/Build/Instance/ProjectInstance.cs
@@ -368,7 +368,7 @@ namespace Microsoft.Build.Execution
         /// </summary>
         public ProjectInstance(Project project, ProjectInstanceSettings settings)
         {
-            ErrorUtilities.VerifyThrowInternalNull(project, nameof(project));
+            ErrorUtilities.VerifyThrowInternalNull(project);
 
             var projectPath = project.FullPath;
             _directory = Path.GetDirectoryName(projectPath);
@@ -425,7 +425,7 @@ namespace Microsoft.Build.Execution
         /// <param name="fastItemLookupNeeded">Whether the fast item lookup cache is required.</param>
         private ProjectInstance(Project linkedProject, bool fastItemLookupNeeded)
         {
-            ErrorUtilities.VerifyThrowInternalNull(linkedProject, nameof(linkedProject));
+            ErrorUtilities.VerifyThrowInternalNull(linkedProject);
 
             var projectPath = linkedProject.FullPath;
             _directory = Path.GetDirectoryName(projectPath);
@@ -640,7 +640,7 @@ namespace Microsoft.Build.Execution
         /// </summary>
         internal ProjectInstance(Evaluation.Project.Data data, string directory, string fullPath, HostServices hostServices, PropertyDictionary<ProjectPropertyInstance> environmentVariableProperties, ProjectInstanceSettings settings)
         {
-            ErrorUtilities.VerifyThrowInternalNull(data, nameof(data));
+            ErrorUtilities.VerifyThrowInternalNull(data);
             ErrorUtilities.VerifyThrowInternalLength(directory, nameof(directory));
             ErrorUtilities.VerifyThrowArgumentLengthIfNotNull(fullPath, nameof(fullPath));
 

--- a/src/Build/Instance/ProjectItemDefinitionInstance.cs
+++ b/src/Build/Instance/ProjectItemDefinitionInstance.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Build.Execution
         /// <param name="itemType">The type of item this definition object represents.</param>
         internal ProjectItemDefinitionInstance(string itemType)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(itemType, nameof(itemType));
+            ErrorUtilities.VerifyThrowArgumentNull(itemType);
 
             _itemType = itemType;
         }

--- a/src/Build/Instance/ProjectItemGroupTaskInstance.cs
+++ b/src/Build/Instance/ProjectItemGroupTaskInstance.cs
@@ -50,9 +50,9 @@ namespace Microsoft.Build.Execution
             ElementLocation conditionLocation,
             List<ProjectItemGroupTaskItemInstance> items)
         {
-            ErrorUtilities.VerifyThrowInternalNull(condition, nameof(condition));
-            ErrorUtilities.VerifyThrowInternalNull(location, nameof(location));
-            ErrorUtilities.VerifyThrowInternalNull(items, nameof(items));
+            ErrorUtilities.VerifyThrowInternalNull(condition);
+            ErrorUtilities.VerifyThrowInternalNull(location);
+            ErrorUtilities.VerifyThrowInternalNull(items);
 
             _condition = condition;
             _location = location;

--- a/src/Build/Instance/ProjectItemGroupTaskItemInstance.cs
+++ b/src/Build/Instance/ProjectItemGroupTaskItemInstance.cs
@@ -159,15 +159,15 @@ namespace Microsoft.Build.Execution
             ElementLocation conditionLocation,
             List<ProjectItemGroupTaskMetadataInstance> metadata)
         {
-            ErrorUtilities.VerifyThrowInternalNull(itemType, nameof(itemType));
-            ErrorUtilities.VerifyThrowInternalNull(include, nameof(include));
-            ErrorUtilities.VerifyThrowInternalNull(exclude, nameof(exclude));
-            ErrorUtilities.VerifyThrowInternalNull(remove, nameof(remove));
-            ErrorUtilities.VerifyThrowInternalNull(keepMetadata, nameof(keepMetadata));
-            ErrorUtilities.VerifyThrowInternalNull(removeMetadata, nameof(removeMetadata));
-            ErrorUtilities.VerifyThrowInternalNull(keepDuplicates, nameof(keepDuplicates));
-            ErrorUtilities.VerifyThrowInternalNull(condition, nameof(condition));
-            ErrorUtilities.VerifyThrowInternalNull(location, nameof(location));
+            ErrorUtilities.VerifyThrowInternalNull(itemType);
+            ErrorUtilities.VerifyThrowInternalNull(include);
+            ErrorUtilities.VerifyThrowInternalNull(exclude);
+            ErrorUtilities.VerifyThrowInternalNull(remove);
+            ErrorUtilities.VerifyThrowInternalNull(keepMetadata);
+            ErrorUtilities.VerifyThrowInternalNull(removeMetadata);
+            ErrorUtilities.VerifyThrowInternalNull(keepDuplicates);
+            ErrorUtilities.VerifyThrowInternalNull(condition);
+            ErrorUtilities.VerifyThrowInternalNull(location);
 
             _itemType = itemType;
             _include = include;

--- a/src/Build/Instance/ProjectItemGroupTaskMetadataInstance.cs
+++ b/src/Build/Instance/ProjectItemGroupTaskMetadataInstance.cs
@@ -47,10 +47,10 @@ namespace Microsoft.Build.Execution
         /// </summary>
         internal ProjectItemGroupTaskMetadataInstance(string name, string value, string condition, ElementLocation location, ElementLocation conditionLocation)
         {
-            ErrorUtilities.VerifyThrowInternalNull(name, nameof(name));
-            ErrorUtilities.VerifyThrowInternalNull(value, nameof(value));
-            ErrorUtilities.VerifyThrowInternalNull(condition, nameof(condition));
-            ErrorUtilities.VerifyThrowInternalNull(location, nameof(location));
+            ErrorUtilities.VerifyThrowInternalNull(name);
+            ErrorUtilities.VerifyThrowInternalNull(value);
+            ErrorUtilities.VerifyThrowInternalNull(condition);
+            ErrorUtilities.VerifyThrowInternalNull(location);
 
             _name = name;
             _value = value;

--- a/src/Build/Instance/ProjectItemInstance.cs
+++ b/src/Build/Instance/ProjectItemInstance.cs
@@ -2070,7 +2070,7 @@ namespace Microsoft.Build.Execution
                 private ProjectItemInstance CreateItem(string includeEscaped, string includeBeforeWildcardExpansionEscaped, ProjectItemInstance source, string definingProject)
                 {
                     ErrorUtilities.VerifyThrowInternalLength(ItemType, "ItemType");
-                    ErrorUtilities.VerifyThrowInternalNull(source, nameof(source));
+                    ErrorUtilities.VerifyThrowInternalNull(source);
 
                     // The new item inherits any metadata originating in item definitions, which
                     // takes precedence over its own item definition metadata.

--- a/src/Build/Instance/ProjectItemInstance.cs
+++ b/src/Build/Instance/ProjectItemInstance.cs
@@ -828,8 +828,8 @@ namespace Microsoft.Build.Execution
                               bool immutable,
                               string definingFileEscaped) // the actual project file (or import) that defines this item.
             {
-                ErrorUtilities.VerifyThrowArgumentLength(includeEscaped, nameof(includeEscaped));
-                ErrorUtilities.VerifyThrowArgumentLength(includeBeforeWildcardExpansionEscaped, nameof(includeBeforeWildcardExpansionEscaped));
+                ErrorUtilities.VerifyThrowArgumentLength(includeEscaped);
+                ErrorUtilities.VerifyThrowArgumentLength(includeBeforeWildcardExpansionEscaped);
 
                 _includeEscaped = FileUtilities.FixFilePath(includeEscaped);
                 _includeBeforeWildcardExpansionEscaped = FileUtilities.FixFilePath(includeBeforeWildcardExpansionEscaped);
@@ -1312,7 +1312,7 @@ namespace Microsoft.Build.Execution
             {
                 if (string.IsNullOrEmpty(metadataName))
                 {
-                    ErrorUtilities.VerifyThrowArgumentLength(metadataName, nameof(metadataName));
+                    ErrorUtilities.VerifyThrowArgumentLength(metadataName);
                 }
 
                 if (_directMetadata != null)

--- a/src/Build/Instance/ProjectItemInstance.cs
+++ b/src/Build/Instance/ProjectItemInstance.cs
@@ -1406,7 +1406,7 @@ namespace Microsoft.Build.Execution
             /// </param>
             public void CopyMetadataTo(ITaskItem destinationItem, bool addOriginalItemSpec)
             {
-                ErrorUtilities.VerifyThrowArgumentNull(destinationItem, nameof(destinationItem));
+                ErrorUtilities.VerifyThrowArgumentNull(destinationItem);
 
                 string originalItemSpec = null;
                 if (addOriginalItemSpec)

--- a/src/Build/Instance/ProjectMetadataInstance.cs
+++ b/src/Build/Instance/ProjectMetadataInstance.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Build.Execution
         /// </remarks>
         internal ProjectMetadataInstance(string name, string escapedValue, bool allowItemSpecModifiers)
         {
-            ErrorUtilities.VerifyThrowArgumentLength(name, nameof(name));
+            ErrorUtilities.VerifyThrowArgumentLength(name);
 
             if (allowItemSpecModifiers)
             {

--- a/src/Build/Instance/ProjectOnErrorInstance.cs
+++ b/src/Build/Instance/ProjectOnErrorInstance.cs
@@ -56,8 +56,8 @@ namespace Microsoft.Build.Execution
             ElementLocation conditionLocation)
         {
             ErrorUtilities.VerifyThrowInternalLength(executeTargets, nameof(executeTargets));
-            ErrorUtilities.VerifyThrowInternalNull(condition, nameof(condition));
-            ErrorUtilities.VerifyThrowInternalNull(location, nameof(location));
+            ErrorUtilities.VerifyThrowInternalNull(condition);
+            ErrorUtilities.VerifyThrowInternalNull(location);
 
             _executeTargets = executeTargets;
             _condition = condition;

--- a/src/Build/Instance/ProjectPropertyGroupTaskInstance.cs
+++ b/src/Build/Instance/ProjectPropertyGroupTaskInstance.cs
@@ -50,9 +50,9 @@ namespace Microsoft.Build.Execution
             ElementLocation conditionLocation,
             List<ProjectPropertyGroupTaskPropertyInstance> properties)
         {
-            ErrorUtilities.VerifyThrowInternalNull(condition, nameof(condition));
-            ErrorUtilities.VerifyThrowInternalNull(location, nameof(location));
-            ErrorUtilities.VerifyThrowInternalNull(properties, nameof(properties));
+            ErrorUtilities.VerifyThrowInternalNull(condition);
+            ErrorUtilities.VerifyThrowInternalNull(location);
+            ErrorUtilities.VerifyThrowInternalNull(properties);
 
             _condition = condition;
             _location = location;

--- a/src/Build/Instance/ProjectPropertyGroupTaskPropertyInstance.cs
+++ b/src/Build/Instance/ProjectPropertyGroupTaskPropertyInstance.cs
@@ -47,10 +47,10 @@ namespace Microsoft.Build.Execution
         /// </summary>
         internal ProjectPropertyGroupTaskPropertyInstance(string name, string value, string condition, ElementLocation location, ElementLocation conditionLocation)
         {
-            ErrorUtilities.VerifyThrowInternalNull(name, nameof(name));
-            ErrorUtilities.VerifyThrowInternalNull(value, nameof(value));
-            ErrorUtilities.VerifyThrowInternalNull(condition, nameof(condition));
-            ErrorUtilities.VerifyThrowInternalNull(location, nameof(location));
+            ErrorUtilities.VerifyThrowInternalNull(name);
+            ErrorUtilities.VerifyThrowInternalNull(value);
+            ErrorUtilities.VerifyThrowInternalNull(condition);
+            ErrorUtilities.VerifyThrowInternalNull(location);
 
             _name = name;
             _value = value;

--- a/src/Build/Instance/ProjectPropertyInstance.cs
+++ b/src/Build/Instance/ProjectPropertyInstance.cs
@@ -74,7 +74,7 @@ namespace Microsoft.Build.Execution
             set
             {
                 ProjectInstance.VerifyThrowNotImmutable(IsImmutable);
-                ErrorUtilities.VerifyThrowArgumentNull(value, nameof(value));
+                ErrorUtilities.VerifyThrowArgumentNull(value);
                 _escapedValue = EscapingUtilities.Escape(value);
             }
         }
@@ -322,7 +322,7 @@ namespace Microsoft.Build.Execution
         private static ProjectPropertyInstance Create(string name, string escapedValue, bool mayBeReserved, ElementLocation location, bool isImmutable, bool isEnvironmentProperty = false, LoggingContext loggingContext = null)
         {
             // Does not check immutability as this is only called during build (which is already protected) or evaluation
-            ErrorUtilities.VerifyThrowArgumentNull(escapedValue, nameof(escapedValue));
+            ErrorUtilities.VerifyThrowArgumentNull(escapedValue);
             if (location == null)
             {
                 ErrorUtilities.VerifyThrowArgument(!XMakeElements.ReservedItemNames.Contains(name), "OM_ReservedName", name);

--- a/src/Build/Instance/ProjectTargetInstance.cs
+++ b/src/Build/Instance/ProjectTargetInstance.cs
@@ -163,16 +163,16 @@ namespace Microsoft.Build.Execution
             bool parentProjectSupportsReturnsAttribute)
         {
             ErrorUtilities.VerifyThrowInternalLength(name, nameof(name));
-            ErrorUtilities.VerifyThrowInternalNull(condition, nameof(condition));
-            ErrorUtilities.VerifyThrowInternalNull(inputs, nameof(inputs));
-            ErrorUtilities.VerifyThrowInternalNull(outputs, nameof(outputs));
-            ErrorUtilities.VerifyThrowInternalNull(keepDuplicateOutputs, nameof(keepDuplicateOutputs));
-            ErrorUtilities.VerifyThrowInternalNull(dependsOnTargets, nameof(dependsOnTargets));
-            ErrorUtilities.VerifyThrowInternalNull(beforeTargets, nameof(beforeTargets));
-            ErrorUtilities.VerifyThrowInternalNull(afterTargets, nameof(afterTargets));
-            ErrorUtilities.VerifyThrowInternalNull(location, nameof(location));
-            ErrorUtilities.VerifyThrowInternalNull(children, nameof(children));
-            ErrorUtilities.VerifyThrowInternalNull(onErrorChildren, nameof(onErrorChildren));
+            ErrorUtilities.VerifyThrowInternalNull(condition);
+            ErrorUtilities.VerifyThrowInternalNull(inputs);
+            ErrorUtilities.VerifyThrowInternalNull(outputs);
+            ErrorUtilities.VerifyThrowInternalNull(keepDuplicateOutputs);
+            ErrorUtilities.VerifyThrowInternalNull(dependsOnTargets);
+            ErrorUtilities.VerifyThrowInternalNull(beforeTargets);
+            ErrorUtilities.VerifyThrowInternalNull(afterTargets);
+            ErrorUtilities.VerifyThrowInternalNull(location);
+            ErrorUtilities.VerifyThrowInternalNull(children);
+            ErrorUtilities.VerifyThrowInternalNull(onErrorChildren);
 
             _name = name;
             _condition = condition;

--- a/src/Build/Instance/ProjectTaskInstance.cs
+++ b/src/Build/Instance/ProjectTaskInstance.cs
@@ -162,8 +162,8 @@ namespace Microsoft.Build.Execution
             ElementLocation msbuildArchitectureLocation)
         {
             ErrorUtilities.VerifyThrowArgumentLength(name, nameof(name));
-            ErrorUtilities.VerifyThrowArgumentNull(condition, nameof(condition));
-            ErrorUtilities.VerifyThrowArgumentNull(continueOnError, nameof(continueOnError));
+            ErrorUtilities.VerifyThrowArgumentNull(condition);
+            ErrorUtilities.VerifyThrowArgumentNull(continueOnError);
 
             _name = name;
             _condition = condition;

--- a/src/Build/Instance/ProjectTaskInstance.cs
+++ b/src/Build/Instance/ProjectTaskInstance.cs
@@ -98,8 +98,8 @@ namespace Microsoft.Build.Execution
             ProjectTaskElement element,
             IList<ProjectTaskInstanceChild> outputs)
         {
-            ErrorUtilities.VerifyThrowInternalNull(element, nameof(element));
-            ErrorUtilities.VerifyThrowInternalNull(outputs, nameof(outputs));
+            ErrorUtilities.VerifyThrowInternalNull(element);
+            ErrorUtilities.VerifyThrowInternalNull(outputs);
 
             // These are all immutable
             _name = element.Name;

--- a/src/Build/Instance/ProjectTaskInstance.cs
+++ b/src/Build/Instance/ProjectTaskInstance.cs
@@ -161,7 +161,7 @@ namespace Microsoft.Build.Execution
             ElementLocation msbuildRuntimeLocation,
             ElementLocation msbuildArchitectureLocation)
         {
-            ErrorUtilities.VerifyThrowArgumentLength(name, nameof(name));
+            ErrorUtilities.VerifyThrowArgumentLength(name);
             ErrorUtilities.VerifyThrowArgumentNull(condition);
             ErrorUtilities.VerifyThrowArgumentNull(continueOnError);
 
@@ -337,8 +337,8 @@ namespace Microsoft.Build.Execution
         /// <param name="condition">The condition.</param>
         internal void AddOutputItem(string taskOutputParameterName, string itemName, string condition)
         {
-            ErrorUtilities.VerifyThrowArgumentLength(taskOutputParameterName, nameof(taskOutputParameterName));
-            ErrorUtilities.VerifyThrowArgumentLength(itemName, nameof(itemName));
+            ErrorUtilities.VerifyThrowArgumentLength(taskOutputParameterName);
+            ErrorUtilities.VerifyThrowArgumentLength(itemName);
             _outputs.Add(new ProjectTaskOutputItemInstance(itemName, taskOutputParameterName, condition ?? String.Empty, ElementLocation.EmptyLocation, ElementLocation.EmptyLocation, ElementLocation.EmptyLocation, condition == null ? null : ElementLocation.EmptyLocation));
         }
 
@@ -350,8 +350,8 @@ namespace Microsoft.Build.Execution
         /// <param name="condition">The condition.</param>
         internal void AddOutputProperty(string taskOutputParameterName, string propertyName, string condition)
         {
-            ErrorUtilities.VerifyThrowArgumentLength(taskOutputParameterName, nameof(taskOutputParameterName));
-            ErrorUtilities.VerifyThrowArgumentLength(propertyName, nameof(propertyName));
+            ErrorUtilities.VerifyThrowArgumentLength(taskOutputParameterName);
+            ErrorUtilities.VerifyThrowArgumentLength(propertyName);
             _outputs.Add(new ProjectTaskOutputPropertyInstance(propertyName, taskOutputParameterName, condition ?? String.Empty, ElementLocation.EmptyLocation, ElementLocation.EmptyLocation, ElementLocation.EmptyLocation, condition == null ? null : ElementLocation.EmptyLocation));
         }
 

--- a/src/Build/Instance/ProjectTaskOutputItemInstance.cs
+++ b/src/Build/Instance/ProjectTaskOutputItemInstance.cs
@@ -59,9 +59,9 @@ namespace Microsoft.Build.Execution
         {
             ErrorUtilities.VerifyThrowInternalLength(itemType, nameof(itemType));
             ErrorUtilities.VerifyThrowInternalLength(taskParameter, nameof(taskParameter));
-            ErrorUtilities.VerifyThrowInternalNull(location, nameof(location));
-            ErrorUtilities.VerifyThrowInternalNull(itemTypeLocation, nameof(itemTypeLocation));
-            ErrorUtilities.VerifyThrowInternalNull(taskParameterLocation, nameof(taskParameterLocation));
+            ErrorUtilities.VerifyThrowInternalNull(location);
+            ErrorUtilities.VerifyThrowInternalNull(itemTypeLocation);
+            ErrorUtilities.VerifyThrowInternalNull(taskParameterLocation);
 
             _itemType = itemType;
             _taskParameter = taskParameter;

--- a/src/Build/Instance/ProjectTaskOutputPropertyInstance.cs
+++ b/src/Build/Instance/ProjectTaskOutputPropertyInstance.cs
@@ -59,9 +59,9 @@ namespace Microsoft.Build.Execution
         {
             ErrorUtilities.VerifyThrowInternalLength(propertyName, nameof(propertyName));
             ErrorUtilities.VerifyThrowInternalLength(taskParameter, nameof(taskParameter));
-            ErrorUtilities.VerifyThrowInternalNull(location, nameof(location));
-            ErrorUtilities.VerifyThrowInternalNull(propertyNameLocation, nameof(propertyNameLocation));
-            ErrorUtilities.VerifyThrowInternalNull(taskParameterLocation, nameof(taskParameterLocation));
+            ErrorUtilities.VerifyThrowInternalNull(location);
+            ErrorUtilities.VerifyThrowInternalNull(propertyNameLocation);
+            ErrorUtilities.VerifyThrowInternalNull(taskParameterLocation);
 
             _propertyName = propertyName;
             _taskParameter = taskParameter;

--- a/src/Build/Instance/ReflectableTaskPropertyInfo.cs
+++ b/src/Build/Instance/ReflectableTaskPropertyInfo.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Build.Execution
         internal ReflectableTaskPropertyInfo(TaskPropertyInfo taskPropertyInfo, Type taskType)
             : base(taskPropertyInfo.Name, taskPropertyInfo.PropertyType, taskPropertyInfo.Output, taskPropertyInfo.Required)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(taskType, nameof(taskType));
+            ErrorUtilities.VerifyThrowArgumentNull(taskType);
             _taskType = taskType;
         }
 

--- a/src/Build/Instance/TaskFactories/AssemblyTaskFactory.cs
+++ b/src/Build/Instance/TaskFactories/AssemblyTaskFactory.cs
@@ -344,7 +344,7 @@ namespace Microsoft.Build.BackEnd
 
             if (useTaskFactory)
             {
-                ErrorUtilities.VerifyThrowInternalNull(buildComponentHost, nameof(buildComponentHost));
+                ErrorUtilities.VerifyThrowInternalNull(buildComponentHost);
 
                 mergedParameters ??= new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 

--- a/src/Build/Instance/TaskFactories/AssemblyTaskFactory.cs
+++ b/src/Build/Instance/TaskFactories/AssemblyTaskFactory.cs
@@ -202,7 +202,7 @@ namespace Microsoft.Build.BackEnd
         /// </remarks>
         public void CleanupTask(ITask task)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(task, nameof(task));
+            ErrorUtilities.VerifyThrowArgumentNull(task);
 #if FEATURE_APPDOMAIN
             AppDomain appDomain;
             if (_tasksAndAppDomains.TryGetValue(task, out appDomain))
@@ -257,7 +257,7 @@ namespace Microsoft.Build.BackEnd
                 ElementLocation elementLocation,
                 string taskProjectFile)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(loadInfo, nameof(loadInfo));
+            ErrorUtilities.VerifyThrowArgumentNull(loadInfo);
             VerifyThrowIdentityParametersValid(taskFactoryIdentityParameters, elementLocation, taskName, "Runtime", "Architecture");
 
             if (taskFactoryIdentityParameters != null)

--- a/src/Build/Instance/TaskFactories/AssemblyTaskFactory.cs
+++ b/src/Build/Instance/TaskFactories/AssemblyTaskFactory.cs
@@ -269,7 +269,7 @@ namespace Microsoft.Build.BackEnd
 
             try
             {
-                ErrorUtilities.VerifyThrowArgumentLength(taskName, nameof(taskName));
+                ErrorUtilities.VerifyThrowArgumentLength(taskName);
                 _taskName = taskName;
 
                 string assemblyName = loadInfo.AssemblyName ?? Path.GetFileName(loadInfo.AssemblyFile);

--- a/src/Build/Instance/TaskFactories/TaskHostTask.cs
+++ b/src/Build/Instance/TaskFactories/TaskHostTask.cs
@@ -139,7 +139,7 @@ namespace Microsoft.Build.BackEnd
             )
 #pragma warning disable SA1111, SA1009 // Closing parenthesis should be on line of last parameter
         {
-            ErrorUtilities.VerifyThrowInternalNull(taskType, nameof(taskType));
+            ErrorUtilities.VerifyThrowInternalNull(taskType);
 
             _taskLocation = taskLocation;
             _taskLoggingContext = taskLoggingContext;

--- a/src/Build/Instance/TaskFactoryLoggingHost.cs
+++ b/src/Build/Instance/TaskFactoryLoggingHost.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Build.BackEnd
         public TaskFactoryLoggingHost(bool isRunningWithMultipleNodes, ElementLocation elementLocation, BuildLoggingContext loggingContext)
         {
             ErrorUtilities.VerifyThrowArgumentNull(loggingContext);
-            ErrorUtilities.VerifyThrowInternalNull(elementLocation, nameof(elementLocation));
+            ErrorUtilities.VerifyThrowInternalNull(elementLocation);
 
             _activeProxy = true;
             _isRunningWithMultipleNodes = isRunningWithMultipleNodes;

--- a/src/Build/Instance/TaskFactoryLoggingHost.cs
+++ b/src/Build/Instance/TaskFactoryLoggingHost.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Build.BackEnd
         /// </summary>
         public TaskFactoryLoggingHost(bool isRunningWithMultipleNodes, ElementLocation elementLocation, BuildLoggingContext loggingContext)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(loggingContext, nameof(loggingContext));
+            ErrorUtilities.VerifyThrowArgumentNull(loggingContext);
             ErrorUtilities.VerifyThrowInternalNull(elementLocation, nameof(elementLocation));
 
             _activeProxy = true;
@@ -154,7 +154,7 @@ namespace Microsoft.Build.BackEnd
         /// <param name="e">The event args</param>
         public void LogErrorEvent(Microsoft.Build.Framework.BuildErrorEventArgs e)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(e, nameof(e));
+            ErrorUtilities.VerifyThrowArgumentNull(e);
             VerifyActiveProxy();
 
             // If we are in building across process we need the events to be serializable. This method will
@@ -175,7 +175,7 @@ namespace Microsoft.Build.BackEnd
         /// <param name="e">The event args</param>
         public void LogWarningEvent(Microsoft.Build.Framework.BuildWarningEventArgs e)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(e, nameof(e));
+            ErrorUtilities.VerifyThrowArgumentNull(e);
             VerifyActiveProxy();
 
             // If we are in building across process we need the events to be serializable. This method will
@@ -196,7 +196,7 @@ namespace Microsoft.Build.BackEnd
         /// <param name="e">The event args</param>
         public void LogMessageEvent(Microsoft.Build.Framework.BuildMessageEventArgs e)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(e, nameof(e));
+            ErrorUtilities.VerifyThrowArgumentNull(e);
             VerifyActiveProxy();
 
             // If we are in building across process we need the events to be serializable. This method will
@@ -217,7 +217,7 @@ namespace Microsoft.Build.BackEnd
         /// <param name="e">The event args</param>
         public void LogCustomEvent(Microsoft.Build.Framework.CustomBuildEventArgs e)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(e, nameof(e));
+            ErrorUtilities.VerifyThrowArgumentNull(e);
             VerifyActiveProxy();
 
             // If we are in building across process we need the events to be serializable. This method will

--- a/src/Build/Instance/TaskFactoryWrapper.cs
+++ b/src/Build/Instance/TaskFactoryWrapper.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Build.Execution
         /// </summary>
         internal TaskFactoryWrapper(ITaskFactory taskFactory, LoadedType taskFactoryLoadInfo, string taskName, IDictionary<string, string> factoryIdentityParameters)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(taskFactory, nameof(taskFactory));
+            ErrorUtilities.VerifyThrowArgumentNull(taskFactory);
             ErrorUtilities.VerifyThrowArgumentLength(taskName, nameof(taskName));
             _taskFactory = taskFactory;
             _taskName = taskName;
@@ -197,8 +197,8 @@ namespace Microsoft.Build.Execution
         /// </summary>
         internal void SetPropertyValue(ITask task, TaskPropertyInfo property, object value)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(task, nameof(task));
-            ErrorUtilities.VerifyThrowArgumentNull(property, nameof(property));
+            ErrorUtilities.VerifyThrowArgumentNull(task);
+            ErrorUtilities.VerifyThrowArgumentNull(property);
 
             IGeneratedTask? generatedTask = task as IGeneratedTask;
             if (generatedTask != null)
@@ -217,8 +217,8 @@ namespace Microsoft.Build.Execution
         /// </summary>
         internal object? GetPropertyValue(ITask task, TaskPropertyInfo property)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(task, nameof(task));
-            ErrorUtilities.VerifyThrowArgumentNull(property, nameof(property));
+            ErrorUtilities.VerifyThrowArgumentNull(task);
+            ErrorUtilities.VerifyThrowArgumentNull(property);
 
             IGeneratedTask? generatedTask = task as IGeneratedTask;
             if (generatedTask != null)

--- a/src/Build/Instance/TaskFactoryWrapper.cs
+++ b/src/Build/Instance/TaskFactoryWrapper.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Build.Execution
         internal TaskFactoryWrapper(ITaskFactory taskFactory, LoadedType taskFactoryLoadInfo, string taskName, IDictionary<string, string> factoryIdentityParameters)
         {
             ErrorUtilities.VerifyThrowArgumentNull(taskFactory);
-            ErrorUtilities.VerifyThrowArgumentLength(taskName, nameof(taskName));
+            ErrorUtilities.VerifyThrowArgumentLength(taskName);
             _taskFactory = taskFactory;
             _taskName = taskName;
             TaskFactoryLoadedType = taskFactoryLoadInfo;

--- a/src/Build/Instance/TaskRegistry.cs
+++ b/src/Build/Instance/TaskRegistry.cs
@@ -1613,8 +1613,8 @@ namespace Microsoft.Build.Execution
                     where P : class, IProperty
                     where I : class, IItem
                 {
-                    ErrorUtilities.VerifyThrowArgumentNull(projectUsingTaskXml, nameof(projectUsingTaskXml));
-                    ErrorUtilities.VerifyThrowArgumentNull(expander, nameof(expander));
+                    ErrorUtilities.VerifyThrowArgumentNull(projectUsingTaskXml);
+                    ErrorUtilities.VerifyThrowArgumentNull(expander);
 
                     ProjectUsingTaskBodyElement taskElement = projectUsingTaskXml.TaskBody;
                     if (taskElement != null)

--- a/src/Build/Instance/TaskRegistry.cs
+++ b/src/Build/Instance/TaskRegistry.cs
@@ -182,7 +182,7 @@ namespace Microsoft.Build.Execution
         /// </summary>
         internal TaskRegistry(ProjectRootElementCacheBase projectRootElementCache)
         {
-            ErrorUtilities.VerifyThrowInternalNull(projectRootElementCache, nameof(projectRootElementCache));
+            ErrorUtilities.VerifyThrowInternalNull(projectRootElementCache);
 
             RootElementCache = projectRootElementCache;
         }
@@ -202,8 +202,8 @@ namespace Microsoft.Build.Execution
         /// <param name="projectRootElementCache">The <see cref="ProjectRootElementCache"/> to use.</param>
         internal TaskRegistry(Toolset toolset, ProjectRootElementCacheBase projectRootElementCache)
         {
-            ErrorUtilities.VerifyThrowInternalNull(projectRootElementCache, nameof(projectRootElementCache));
-            ErrorUtilities.VerifyThrowInternalNull(toolset, nameof(toolset));
+            ErrorUtilities.VerifyThrowInternalNull(projectRootElementCache);
+            ErrorUtilities.VerifyThrowInternalNull(toolset);
 
             RootElementCache = projectRootElementCache;
             _toolset = toolset;
@@ -293,7 +293,7 @@ namespace Microsoft.Build.Execution
             where P : class, IProperty
             where I : class, IItem
         {
-            ErrorUtilities.VerifyThrowInternalNull(directoryOfImportingFile, nameof(directoryOfImportingFile));
+            ErrorUtilities.VerifyThrowInternalNull(directoryOfImportingFile);
 #if DEBUG
             ErrorUtilities.VerifyThrowInternalError(!taskRegistry._isInitialized, "Attempt to modify TaskRegistry after it was initialized.");
 #endif
@@ -689,7 +689,7 @@ namespace Microsoft.Build.Execution
             bool overrideTask = false)
         {
             ErrorUtilities.VerifyThrowInternalLength(taskName, nameof(taskName));
-            ErrorUtilities.VerifyThrowInternalNull(assemblyLoadInfo, nameof(assemblyLoadInfo));
+            ErrorUtilities.VerifyThrowInternalNull(assemblyLoadInfo);
 
             // Lazily allocate the hashtable
             if (_taskRegistrations == null)

--- a/src/Build/Logging/BaseConsoleLogger.cs
+++ b/src/Build/Logging/BaseConsoleLogger.cs
@@ -964,7 +964,7 @@ namespace Microsoft.Build.BackEnd.Logging
         /// </summary>
         internal virtual bool ApplyParameter(string parameterName, string parameterValue)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(parameterName, nameof(parameterName));
+            ErrorUtilities.VerifyThrowArgumentNull(parameterName);
 
             switch (parameterName.ToUpperInvariant())
             {

--- a/src/Build/Logging/DistributedLoggers/ConfigurableForwardingLogger.cs
+++ b/src/Build/Logging/DistributedLoggers/ConfigurableForwardingLogger.cs
@@ -105,7 +105,7 @@ namespace Microsoft.Build.Logging
         /// </summary>
         private void ApplyParameter(IEventSource eventSource, string parameterName)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(parameterName, nameof(parameterName));
+            ErrorUtilities.VerifyThrowArgumentNull(parameterName);
 
             bool isEventForwardingParameter = true;
 
@@ -202,7 +202,7 @@ namespace Microsoft.Build.Logging
         /// </summary>
         public virtual void Initialize(IEventSource eventSource)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(eventSource, nameof(eventSource));
+            ErrorUtilities.VerifyThrowArgumentNull(eventSource);
 
             ParseParameters(eventSource);
 

--- a/src/Build/Logging/DistributedLoggers/DistributedFileLogger.cs
+++ b/src/Build/Logging/DistributedLoggers/DistributedFileLogger.cs
@@ -94,7 +94,7 @@ namespace Microsoft.Build.Logging
         /// </summary>
         public void Initialize(IEventSource eventSource)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(eventSource, nameof(eventSource));
+            ErrorUtilities.VerifyThrowArgumentNull(eventSource);
             ParseFileLoggerParameters();
             string fileName = _logFile;
 

--- a/src/Build/Logging/FileLogger.cs
+++ b/src/Build/Logging/FileLogger.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Build.Logging
         /// <param name="eventSource">Available events.</param>
         public override void Initialize(IEventSource eventSource)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(eventSource, nameof(eventSource));
+            ErrorUtilities.VerifyThrowArgumentNull(eventSource);
             eventSource.BuildFinished += FileLoggerBuildFinished;
             InitializeFileLogger(eventSource, 1);
         }

--- a/src/Build/Utilities/RegistryKeyWrapper.cs
+++ b/src/Build/Utilities/RegistryKeyWrapper.cs
@@ -160,7 +160,7 @@ namespace Microsoft.Build.Internal
         /// <returns></returns>
         public virtual RegistryKeyWrapper OpenSubKey(string name)
         {
-            ErrorUtilities.VerifyThrowArgumentLength(name, nameof(name));
+            ErrorUtilities.VerifyThrowArgumentLength(name);
 
             RegistryKeyWrapper wrapper = this;
             string[] keyNames = name.Split(MSBuildConstants.BackslashChar, StringSplitOptions.RemoveEmptyEntries);

--- a/src/Build/Utilities/RegistryKeyWrapper.cs
+++ b/src/Build/Utilities/RegistryKeyWrapper.cs
@@ -66,8 +66,8 @@ namespace Microsoft.Build.Internal
         /// </summary>
         internal RegistryKeyWrapper(string registryKeyPath, RegistryKey registryHive)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(registryKeyPath, nameof(registryKeyPath));
-            ErrorUtilities.VerifyThrowArgumentNull(registryHive, nameof(registryHive));
+            ErrorUtilities.VerifyThrowArgumentNull(registryKeyPath);
+            ErrorUtilities.VerifyThrowArgumentNull(registryHive);
 
             _registryKeyPath = registryKeyPath;
             _registryHive = registryHive;

--- a/src/Framework/AssemblyUtilities.cs
+++ b/src/Framework/AssemblyUtilities.cs
@@ -168,7 +168,8 @@ namespace Microsoft.Build.Shared
 
             var cultures = s_cultureInfoGetCultureMethod.Invoke(null, [allCulturesEnumValue]) as CultureInfo[];
 
-            FrameworkErrorUtilities.VerifyThrowInternalNull(cultures, "CultureInfo.GetCultures should work if all reflection checks pass");
+            // CultureInfo.GetCultures should work if all reflection checks pass
+            FrameworkErrorUtilities.VerifyThrowInternalNull(cultures);
 
             return cultures;
         }

--- a/src/Framework/ErrorUtilities.cs
+++ b/src/Framework/ErrorUtilities.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 
 namespace Microsoft.Build.Framework
 {
@@ -36,7 +37,7 @@ namespace Microsoft.Build.Framework
         /// </summary>
         /// <param name="parameter">The value of the argument.</param>
         /// <param name="parameterName">Parameter that should not be null.</param>
-        internal static void VerifyThrowInternalNull([NotNull] object? parameter, string parameterName)
+        internal static void VerifyThrowInternalNull([NotNull] object? parameter, [CallerArgumentExpression(nameof(parameter))] string? parameterName = null)
         {
             if (parameter is null)
             {

--- a/src/Framework/Polyfills/CallerArgumentExpressionAttribute.cs
+++ b/src/Framework/Polyfills/CallerArgumentExpressionAttribute.cs
@@ -1,0 +1,17 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Runtime.CompilerServices;
+
+#if !NET
+[AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false, Inherited = false)]
+internal sealed class CallerArgumentExpressionAttribute : Attribute
+{
+    public CallerArgumentExpressionAttribute(string parameterName)
+    {
+        ParameterName = parameterName;
+    }
+
+    public string ParameterName { get; }
+}
+#endif

--- a/src/Framework/ReuseableStringBuilder.cs
+++ b/src/Framework/ReuseableStringBuilder.cs
@@ -298,9 +298,9 @@ namespace Microsoft.Build.Framework
                 int balance = Interlocked.Decrement(ref s_getVsReleaseBalance);
                 Debug.Assert(balance == 0, "Unbalanced Get vs Release. Either forgotten Release or used from multiple threads concurrently.");
 #endif
-                FrameworkErrorUtilities.VerifyThrowInternalNull(returning._borrowedBuilder, nameof(returning._borrowedBuilder));
+                FrameworkErrorUtilities.VerifyThrowInternalNull(returning._borrowedBuilder);
 
-                StringBuilder returningBuilder = returning._borrowedBuilder!;
+                StringBuilder returningBuilder = returning._borrowedBuilder;
                 int returningLength = returningBuilder.Length;
 
                 // It's possible for someone to cause the builder to

--- a/src/MSBuild/CommandLineSwitchException.cs
+++ b/src/MSBuild/CommandLineSwitchException.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Build.CommandLine
             StreamingContext context) :
             base(info, context)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(info, nameof(info));
+            ErrorUtilities.VerifyThrowArgumentNull(info);
 
             commandLineArg = info.GetString("commandLineArg");
         }

--- a/src/MSBuild/InitializationException.cs
+++ b/src/MSBuild/InitializationException.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Build.CommandLine
             StreamingContext context) :
             base(info, context)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(info, nameof(info));
+            ErrorUtilities.VerifyThrowArgumentNull(info);
 
             invalidSwitch = info.GetString("invalidSwitch");
         }

--- a/src/MSBuild/ProjectSchemaValidationHandler.cs
+++ b/src/MSBuild/ProjectSchemaValidationHandler.cs
@@ -38,8 +38,8 @@ namespace Microsoft.Build.CommandLine
             string schemaFile,
             string binPath)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(projectFile, nameof(projectFile));
-            ErrorUtilities.VerifyThrowArgumentNull(binPath, nameof(binPath));
+            ErrorUtilities.VerifyThrowArgumentNull(projectFile);
+            ErrorUtilities.VerifyThrowArgumentNull(binPath);
 
             if (string.IsNullOrEmpty(schemaFile))
             {
@@ -72,8 +72,8 @@ namespace Microsoft.Build.CommandLine
             string projectFile,
             string schemaFile)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(schemaFile, nameof(schemaFile));
-            ErrorUtilities.VerifyThrowArgumentNull(projectFile, nameof(projectFile));
+            ErrorUtilities.VerifyThrowArgumentNull(schemaFile);
+            ErrorUtilities.VerifyThrowArgumentNull(projectFile);
 
             // Options for XmlReader object can be set only in constructor. After the object is created, they
             // become read-only. Because of that we need to create

--- a/src/MSBuild/TerminalLogger/TerminalLogger.cs
+++ b/src/MSBuild/TerminalLogger/TerminalLogger.cs
@@ -217,7 +217,7 @@ internal sealed partial class TerminalLogger : INodeLogger
     private bool _hasUsedCache = false;
 
     /// <summary>
-    /// Whether to show TaskCommandLineEventArgs high-priority messages. 
+    /// Whether to show TaskCommandLineEventArgs high-priority messages.
     /// </summary>
     private bool _showCommandLine = false;
 
@@ -309,7 +309,7 @@ internal sealed partial class TerminalLogger : INodeLogger
     /// </remark>
     private void ApplyParameter(string parameterName, string? parameterValue)
     {
-        ErrorUtilities.VerifyThrowArgumentNull(parameterName, nameof(parameterName));
+        ErrorUtilities.VerifyThrowArgumentNull(parameterName);
 
         switch (parameterName.ToUpperInvariant())
         {

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -663,7 +663,7 @@ namespace Microsoft.Build.CommandLine
             Environment.SetEnvironmentVariable("MSBuildLoadMicrosoftTargetsReadOnly", "true");
 
 #if FEATURE_GET_COMMANDLINE
-            ErrorUtilities.VerifyThrowArgumentLength(commandLine, nameof(commandLine));
+            ErrorUtilities.VerifyThrowArgumentLength(commandLine);
 #endif
 
             AppDomain.CurrentDomain.UnhandledException += ExceptionHandling.UnhandledExceptionHandler;

--- a/src/MSBuildTaskHost/TypeLoader.cs
+++ b/src/MSBuildTaskHost/TypeLoader.cs
@@ -221,7 +221,7 @@ namespace Microsoft.Build.Shared
             internal AssemblyInfoToLoadedTypes(TypeFilter typeFilter, AssemblyLoadInfo loadInfo)
             {
                 ErrorUtilities.VerifyThrowArgumentNull(typeFilter, "typefilter");
-                ErrorUtilities.VerifyThrowArgumentNull(loadInfo, nameof(loadInfo));
+                ErrorUtilities.VerifyThrowArgumentNull(loadInfo);
 
                 _isDesiredType = typeFilter;
                 _assemblyLoadInfo = loadInfo;
@@ -234,7 +234,7 @@ namespace Microsoft.Build.Shared
             /// </summary>
             internal LoadedType GetLoadedTypeByTypeName(string typeName)
             {
-                ErrorUtilities.VerifyThrowArgumentNull(typeName, nameof(typeName));
+                ErrorUtilities.VerifyThrowArgumentNull(typeName);
 
                 // Only one thread should be doing operations on this instance of the object at a time.
 

--- a/src/Shared/AssemblyFolders/AssemblyFoldersFromConfig.cs
+++ b/src/Shared/AssemblyFolders/AssemblyFoldersFromConfig.cs
@@ -29,8 +29,8 @@ namespace Microsoft.Build.Tasks.AssemblyFoldersFromConfig
         /// <param name="targetArchitecture">The <see cref="ProcessorArchitecture"/> to target.</param>
         internal AssemblyFoldersFromConfig(string configFile, string targetRuntimeVersion, ProcessorArchitecture targetArchitecture)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(configFile, nameof(configFile));
-            ErrorUtilities.VerifyThrowArgumentNull(targetRuntimeVersion, nameof(targetRuntimeVersion));
+            ErrorUtilities.VerifyThrowArgumentNull(configFile);
+            ErrorUtilities.VerifyThrowArgumentNull(targetRuntimeVersion);
 
             var collection = AssemblyFolderCollection.Load(configFile);
             var assemblyTargets = GatherVersionStrings(targetRuntimeVersion, collection);

--- a/src/Shared/AwaitExtensions.cs
+++ b/src/Shared/AwaitExtensions.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Build.Shared
         /// <returns>The awaiter.</returns>
         internal static TaskAwaiter GetAwaiter(this WaitHandle handle)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(handle, nameof(handle));
+            ErrorUtilities.VerifyThrowArgumentNull(handle);
             return handle.ToTask().GetAwaiter();
         }
 

--- a/src/Shared/BuildEventFileInfo.cs
+++ b/src/Shared/BuildEventFileInfo.cs
@@ -97,7 +97,7 @@ namespace Microsoft.Build.Shared
         /// </summary>
         internal BuildEventFileInfo(string file, XmlException e) : this(e)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(file, nameof(file));
+            ErrorUtilities.VerifyThrowArgumentNull(file);
 
             _file = file;
         }

--- a/src/Shared/Debugging/PrintLineDebugger.cs
+++ b/src/Shared/Debugging/PrintLineDebugger.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Build.Shared.Debugging
 
                 var propertyInfo = commonWriterType.GetProperty("Writer", BindingFlags.Public | BindingFlags.Static);
 
-                ErrorUtilities.VerifyThrowInternalNull(propertyInfo, nameof(propertyInfo));
+                ErrorUtilities.VerifyThrowInternalNull(propertyInfo);
 
                 return propertyInfo;
             });

--- a/src/Shared/ErrorUtilities.cs
+++ b/src/Shared/ErrorUtilities.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using Microsoft.Build.Framework;
 
@@ -115,7 +116,7 @@ namespace Microsoft.Build.Shared
         /// </summary>
         /// <param name="parameter">The value of the argument.</param>
         /// <param name="parameterName">Parameter that should not be null</param>
-        internal static void VerifyThrowInternalNull([NotNull] object? parameter, string parameterName)
+        internal static void VerifyThrowInternalNull([NotNull] object? parameter, [CallerArgumentExpression(nameof(parameter))] string? parameterName = null)
         {
             if (parameter is null)
             {
@@ -146,7 +147,7 @@ namespace Microsoft.Build.Shared
         /// </summary>
         /// <param name="parameterValue">The value of the argument.</param>
         /// <param name="parameterName">Parameter that should not be null or zero length</param>
-        internal static void VerifyThrowInternalLength([NotNull] string? parameterValue, string parameterName)
+        internal static void VerifyThrowInternalLength([NotNull] string? parameterValue, [CallerArgumentExpression(nameof(parameterValue))] string? parameterName = null)
         {
             VerifyThrowInternalNull(parameterValue, parameterName);
 
@@ -156,7 +157,7 @@ namespace Microsoft.Build.Shared
             }
         }
 
-        public static void VerifyThrowInternalLength<T>([NotNull] T[]? parameterValue, string parameterName)
+        public static void VerifyThrowInternalLength<T>([NotNull] T[]? parameterValue, [CallerArgumentExpression(nameof(parameterValue))] string? parameterName = null)
         {
             VerifyThrowInternalNull(parameterValue, parameterName);
 
@@ -467,7 +468,7 @@ namespace Microsoft.Build.Shared
         /// Throws an argument out of range exception.
         /// </summary>
         [DoesNotReturn]
-        internal static void ThrowArgumentOutOfRange(string parameterName)
+        internal static void ThrowArgumentOutOfRange(string? parameterName)
         {
             throw new ArgumentOutOfRangeException(parameterName);
         }
@@ -476,7 +477,7 @@ namespace Microsoft.Build.Shared
         /// Throws an ArgumentOutOfRangeException using the given parameter name
         /// if the condition is false.
         /// </summary>
-        internal static void VerifyThrowArgumentOutOfRange([DoesNotReturnIf(false)] bool condition, string parameterName)
+        internal static void VerifyThrowArgumentOutOfRange([DoesNotReturnIf(false)] bool condition, [CallerArgumentExpression(nameof(condition))] string? parameterName = null)
         {
             if (!condition)
             {
@@ -488,7 +489,7 @@ namespace Microsoft.Build.Shared
         /// Throws an ArgumentNullException if the given string parameter is null
         /// and ArgumentException if it has zero length.
         /// </summary>
-        internal static void VerifyThrowArgumentLength([NotNull] string? parameter, string parameterName)
+        internal static void VerifyThrowArgumentLength([NotNull] string? parameter, [CallerArgumentExpression(nameof(parameter))] string? parameterName = null)
         {
             VerifyThrowArgumentNull(parameter, parameterName);
 
@@ -503,7 +504,7 @@ namespace Microsoft.Build.Shared
         /// Throws an ArgumentNullException if the given collection is null
         /// and ArgumentException if it has zero length.
         /// </summary>
-        internal static void VerifyThrowArgumentLength<T>([NotNull] IReadOnlyCollection<T> parameter, string parameterName)
+        internal static void VerifyThrowArgumentLength<T>([NotNull] IReadOnlyCollection<T> parameter, [CallerArgumentExpression(nameof(parameter))] string? parameterName = null)
         {
             VerifyThrowArgumentNull(parameter, parameterName);
 
@@ -516,7 +517,7 @@ namespace Microsoft.Build.Shared
         /// <summary>
         /// Throws an ArgumentException if the given collection is not null but of zero length.
         /// </summary>
-        internal static void VerifyThrowArgumentLengthIfNotNull<T>([MaybeNull] IReadOnlyCollection<T>? parameter, string parameterName)
+        internal static void VerifyThrowArgumentLengthIfNotNull<T>([MaybeNull] IReadOnlyCollection<T>? parameter, [CallerArgumentExpression(nameof(parameter))] string? parameterName = null)
         {
             if (parameter?.Count == 0)
             {
@@ -526,7 +527,7 @@ namespace Microsoft.Build.Shared
 #endif
 
         [DoesNotReturn]
-        private static void ThrowArgumentLength(string parameterName)
+        private static void ThrowArgumentLength(string? parameterName)
         {
             throw new ArgumentException(ResourceUtilities.FormatResourceStringStripCodeAndKeyword("Shared.ParameterCannotHaveZeroLength", parameterName));
         }
@@ -535,7 +536,7 @@ namespace Microsoft.Build.Shared
         /// Throws an ArgumentNullException if the given string parameter is null
         /// and ArgumentException if it has zero length.
         /// </summary>
-        internal static void VerifyThrowArgumentInvalidPath([NotNull] string parameter, string parameterName)
+        internal static void VerifyThrowArgumentInvalidPath([NotNull] string parameter, [CallerArgumentExpression(nameof(parameter))] string? parameterName = null)
         {
             VerifyThrowArgumentNull(parameter, parameterName);
 
@@ -549,7 +550,7 @@ namespace Microsoft.Build.Shared
         /// Throws an ArgumentException if the string has zero length, unless it is
         /// null, in which case no exception is thrown.
         /// </summary>
-        internal static void VerifyThrowArgumentLengthIfNotNull(string? parameter, string parameterName)
+        internal static void VerifyThrowArgumentLengthIfNotNull(string? parameter, [CallerArgumentExpression(nameof(parameter))] string? parameterName = null)
         {
             if (parameter?.Length == 0)
             {
@@ -560,7 +561,7 @@ namespace Microsoft.Build.Shared
         /// <summary>
         /// Throws an ArgumentNullException if the given parameter is null.
         /// </summary>
-        internal static void VerifyThrowArgumentNull([NotNull] object? parameter, string parameterName)
+        internal static void VerifyThrowArgumentNull([NotNull] object? parameter, [CallerArgumentExpression(nameof(parameter))] string? parameterName = null)
         {
             VerifyThrowArgumentNull(parameter, parameterName, "Shared.ParameterCannotBeNull");
         }
@@ -568,7 +569,7 @@ namespace Microsoft.Build.Shared
         /// <summary>
         /// Throws an ArgumentNullException if the given parameter is null.
         /// </summary>
-        internal static void VerifyThrowArgumentNull([NotNull] object? parameter, string parameterName, string resourceName)
+        internal static void VerifyThrowArgumentNull([NotNull] object? parameter, string? parameterName, string resourceName)
         {
             ResourceUtilities.VerifyResourceStringExists(resourceName);
             if (parameter is null)

--- a/src/Shared/EventArgsFormatting.cs
+++ b/src/Shared/EventArgsFormatting.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Build.Shared
         /// <returns>The formatted message string.</returns>
         internal static string FormatEventMessage(BuildErrorEventArgs e)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(e, nameof(e));
+            ErrorUtilities.VerifyThrowArgumentNull(e);
 
             // "error" should not be localized
             return FormatEventMessage("error", e.Subcategory, e.Message,
@@ -86,7 +86,7 @@ namespace Microsoft.Build.Shared
         /// <returns>The formatted message string.</returns>
         internal static string FormatEventMessage(BuildErrorEventArgs e, bool showProjectFile)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(e, nameof(e));
+            ErrorUtilities.VerifyThrowArgumentNull(e);
 
             // "error" should not be localized
             return FormatEventMessage("error", e.Subcategory, e.Message,
@@ -102,7 +102,7 @@ namespace Microsoft.Build.Shared
         /// <returns>The formatted message string.</returns>
         internal static string FormatEventMessage(BuildWarningEventArgs e)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(e, nameof(e));
+            ErrorUtilities.VerifyThrowArgumentNull(e);
 
             // "warning" should not be localized
             return FormatEventMessage("warning", e.Subcategory, e.Message,
@@ -119,7 +119,7 @@ namespace Microsoft.Build.Shared
         /// <returns>The formatted message string.</returns>
         internal static string FormatEventMessage(BuildWarningEventArgs e, bool showProjectFile)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(e, nameof(e));
+            ErrorUtilities.VerifyThrowArgumentNull(e);
 
             // "warning" should not be localized
             return FormatEventMessage("warning", e.Subcategory, e.Message,
@@ -148,7 +148,7 @@ namespace Microsoft.Build.Shared
         /// <returns>The formatted message string.</returns>
         internal static string FormatEventMessage(BuildMessageEventArgs e, bool showProjectFile, string nonNullMessage = null)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(e, nameof(e));
+            ErrorUtilities.VerifyThrowArgumentNull(e);
 
             // "message" should not be localized
             return FormatEventMessage("message", e.Subcategory, nonNullMessage ?? e.Message,

--- a/src/Shared/ExtensionFoldersRegistryKey.cs
+++ b/src/Shared/ExtensionFoldersRegistryKey.cs
@@ -17,8 +17,8 @@ namespace Microsoft.Build.Shared
         /// </summary>
         internal ExtensionFoldersRegistryKey(string registryKey, Version targetFrameworkVersion)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(registryKey, nameof(registryKey));
-            ErrorUtilities.VerifyThrowArgumentNull(targetFrameworkVersion, nameof(targetFrameworkVersion));
+            ErrorUtilities.VerifyThrowArgumentNull(registryKey);
+            ErrorUtilities.VerifyThrowArgumentNull(targetFrameworkVersion);
 
             RegistryKey = registryKey;
             TargetFrameworkVersion = targetFrameworkVersion;

--- a/src/Shared/FileUtilities.cs
+++ b/src/Shared/FileUtilities.cs
@@ -1125,7 +1125,7 @@ namespace Microsoft.Build.Shared
         /// <returns>relative path (can be the full path)</returns>
         internal static string MakeRelative(string basePath, string path)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(basePath, nameof(basePath));
+            ErrorUtilities.VerifyThrowArgumentNull(basePath);
             ErrorUtilities.VerifyThrowArgumentLength(path, nameof(path));
 
             string fullBase = Path.GetFullPath(basePath);
@@ -1263,8 +1263,8 @@ namespace Microsoft.Build.Shared
         /// <returns>Combined path.</returns>
         internal static string CombinePaths(string root, params string[] paths)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(root, nameof(root));
-            ErrorUtilities.VerifyThrowArgumentNull(paths, nameof(paths));
+            ErrorUtilities.VerifyThrowArgumentNull(root);
+            ErrorUtilities.VerifyThrowArgumentNull(paths);
 
             return paths.Aggregate(root, Path.Combine);
         }

--- a/src/Shared/FileUtilities.cs
+++ b/src/Shared/FileUtilities.cs
@@ -461,7 +461,7 @@ namespace Microsoft.Build.Shared
         /// </summary>
         internal static string NormalizePath(string path)
         {
-            ErrorUtilities.VerifyThrowArgumentLength(path, nameof(path));
+            ErrorUtilities.VerifyThrowArgumentLength(path);
             string fullPath = GetFullPath(path);
             return FixFilePath(fullPath);
         }
@@ -1126,7 +1126,7 @@ namespace Microsoft.Build.Shared
         internal static string MakeRelative(string basePath, string path)
         {
             ErrorUtilities.VerifyThrowArgumentNull(basePath);
-            ErrorUtilities.VerifyThrowArgumentLength(path, nameof(path));
+            ErrorUtilities.VerifyThrowArgumentLength(path);
 
             string fullBase = Path.GetFullPath(basePath);
             string fullPath = Path.GetFullPath(path);

--- a/src/Shared/FrameworkLocationHelper.cs
+++ b/src/Shared/FrameworkLocationHelper.cs
@@ -972,8 +972,8 @@ namespace Microsoft.Build.Shared
         /// <returns>The path to the reference assembly location</returns>
         internal static string GenerateReferenceAssemblyPath(string targetFrameworkRootPath, FrameworkName frameworkName)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(targetFrameworkRootPath, nameof(targetFrameworkRootPath));
-            ErrorUtilities.VerifyThrowArgumentNull(frameworkName, nameof(frameworkName));
+            ErrorUtilities.VerifyThrowArgumentNull(targetFrameworkRootPath);
+            ErrorUtilities.VerifyThrowArgumentNull(frameworkName);
 
             try
             {

--- a/src/Shared/NodeEndpointOutOfProcBase.cs
+++ b/src/Shared/NodeEndpointOutOfProcBase.cs
@@ -152,7 +152,7 @@ namespace Microsoft.Build.BackEnd
         public void Listen(INodePacketFactory factory)
         {
             ErrorUtilities.VerifyThrow(_status == LinkStatus.Inactive, "Link not inactive.  Status is {0}", _status);
-            ErrorUtilities.VerifyThrowArgumentNull(factory, nameof(factory));
+            ErrorUtilities.VerifyThrowArgumentNull(factory);
             _packetFactory = factory;
 
             InitializeAsyncPacketThread();
@@ -314,7 +314,7 @@ namespace Microsoft.Build.BackEnd
         /// <param name="packet">The packet to be transmitted.</param>
         private void EnqueuePacket(INodePacket packet)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(packet, nameof(packet));
+            ErrorUtilities.VerifyThrowArgumentNull(packet);
             ErrorUtilities.VerifyThrow(_packetQueue != null, "packetQueue is null");
             ErrorUtilities.VerifyThrow(_packetAvailable != null, "packetAvailable is null");
             _packetQueue.Enqueue(packet);

--- a/src/Shared/OutOfProcTaskHostTaskResult.cs
+++ b/src/Shared/OutOfProcTaskHostTaskResult.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Build.Shared
                 result == TaskCompleteType.CrashedDuringExecution ||
                 result == TaskCompleteType.CrashedAfterExecution)
             {
-                ErrorUtilities.VerifyThrowInternalNull(taskException, nameof(taskException));
+                ErrorUtilities.VerifyThrowInternalNull(taskException);
             }
 
             if (exceptionMessage != null)

--- a/src/Shared/ProjectErrorUtilities.cs
+++ b/src/Shared/ProjectErrorUtilities.cs
@@ -252,7 +252,7 @@ namespace Microsoft.Build.Shared
         /// <param name="args">Extra arguments for formatting the error message.</param>
         private static void ThrowInvalidProject(string errorSubCategoryResourceName, IElementLocation elementLocation, string resourceName, params object[] args)
         {
-            ErrorUtilities.VerifyThrowInternalNull(elementLocation, nameof(elementLocation));
+            ErrorUtilities.VerifyThrowInternalNull(elementLocation);
 #if DEBUG
             if (errorSubCategoryResourceName != null)
             {

--- a/src/Shared/ReadOnlyCollection.cs
+++ b/src/Shared/ReadOnlyCollection.cs
@@ -129,7 +129,7 @@ namespace Microsoft.Build.Collections
         /// </summary>
         public void CopyTo(T[] array, int arrayIndex)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(array, nameof(array));
+            ErrorUtilities.VerifyThrowArgumentNull(array);
 
             ICollection<T> backingCollection = _backing as ICollection<T>;
             if (backingCollection != null)
@@ -185,7 +185,7 @@ namespace Microsoft.Build.Collections
         /// </summary>
         void ICollection.CopyTo(Array array, int index)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(array, nameof(array));
+            ErrorUtilities.VerifyThrowArgumentNull(array);
 
             int i = index;
             foreach (T entry in _backing)

--- a/src/Shared/ResourceUtilities.cs
+++ b/src/Shared/ResourceUtilities.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Build.Shared
         internal static string ExtractMessageCode(bool msbuildCodeOnly, string message, out string code)
         {
 #if !BUILDINGAPPXTASKS
-            ErrorUtilities.VerifyThrowInternalNull(message, nameof(message));
+            ErrorUtilities.VerifyThrowInternalNull(message);
 #endif
 
             code = null;

--- a/src/Shared/StringExtensions.cs
+++ b/src/Shared/StringExtensions.cs
@@ -15,8 +15,8 @@ namespace Microsoft.Build.Shared
     {
         public static string Replace(this string aString, string oldValue, string newValue, StringComparison stringComparison)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(aString, nameof(aString));
-            ErrorUtilities.VerifyThrowArgumentNull(oldValue, nameof(oldValue));
+            ErrorUtilities.VerifyThrowArgumentNull(aString);
+            ErrorUtilities.VerifyThrowArgumentNull(oldValue);
             ErrorUtilities.VerifyThrowArgumentLength(oldValue, nameof(oldValue));
 
             if (newValue == null)

--- a/src/Shared/StringExtensions.cs
+++ b/src/Shared/StringExtensions.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Build.Shared
         {
             ErrorUtilities.VerifyThrowArgumentNull(aString);
             ErrorUtilities.VerifyThrowArgumentNull(oldValue);
-            ErrorUtilities.VerifyThrowArgumentLength(oldValue, nameof(oldValue));
+            ErrorUtilities.VerifyThrowArgumentLength(oldValue);
 
             if (newValue == null)
             {

--- a/src/Shared/TaskHostTaskComplete.cs
+++ b/src/Shared/TaskHostTaskComplete.cs
@@ -105,7 +105,7 @@ namespace Microsoft.Build.BackEnd
 #endif
             IDictionary<string, string> buildProcessEnvironment)
         {
-            ErrorUtilities.VerifyThrowInternalNull(result, nameof(result));
+            ErrorUtilities.VerifyThrowInternalNull(result);
 
             _taskResult = result.Result;
             _taskException = result.TaskException;

--- a/src/Shared/TaskLoggingHelper.cs
+++ b/src/Shared/TaskLoggingHelper.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Build.Utilities
         public TaskLoggingHelper(IBuildEngine buildEngine, string taskName)
         {
             ErrorUtilities.VerifyThrowArgumentNull(buildEngine);
-            ErrorUtilities.VerifyThrowArgumentLength(taskName, nameof(taskName));
+            ErrorUtilities.VerifyThrowArgumentLength(taskName);
             TaskName = taskName;
             _buildEngine = buildEngine;
         }

--- a/src/Shared/TaskLoggingHelper.cs
+++ b/src/Shared/TaskLoggingHelper.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Build.Utilities
         /// <param name="taskInstance">task containing an instance of this class</param>
         public TaskLoggingHelper(ITask taskInstance)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(taskInstance, nameof(taskInstance));
+            ErrorUtilities.VerifyThrowArgumentNull(taskInstance);
             _taskInstance = taskInstance;
             TaskName = taskInstance.GetType().Name;
         }
@@ -58,7 +58,7 @@ namespace Microsoft.Build.Utilities
         /// </summary>
         public TaskLoggingHelper(IBuildEngine buildEngine, string taskName)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(buildEngine, nameof(buildEngine));
+            ErrorUtilities.VerifyThrowArgumentNull(buildEngine);
             ErrorUtilities.VerifyThrowArgumentLength(taskName, nameof(taskName));
             TaskName = taskName;
             _buildEngine = buildEngine;
@@ -177,7 +177,7 @@ namespace Microsoft.Build.Utilities
         /// <exception cref="ArgumentNullException">Thrown when <c>message</c> is null.</exception>
         public string ExtractMessageCode(string message, out string messageWithoutCodePrefix)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(message, nameof(message));
+            ErrorUtilities.VerifyThrowArgumentNull(message);
 
             messageWithoutCodePrefix = ResourceUtilities.ExtractMessageCode(false /* any code */, message, out string code);
 
@@ -201,7 +201,7 @@ namespace Microsoft.Build.Utilities
         /// <exception cref="InvalidOperationException">Thrown when the <c>TaskResources</c> property of the owner task is not set.</exception>
         public virtual string FormatResourceString(string resourceName, params object[] args)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(resourceName, nameof(resourceName));
+            ErrorUtilities.VerifyThrowArgumentNull(resourceName);
             ErrorUtilities.VerifyThrowInvalidOperation(TaskResources != null, "Shared.TaskResourcesNotRegistered", TaskName);
 
             string resourceString = TaskResources.GetString(resourceName, CultureInfo.CurrentUICulture);
@@ -221,7 +221,7 @@ namespace Microsoft.Build.Utilities
         /// <exception cref="ArgumentNullException">Thrown when <c>unformatted</c> is null.</exception>
         public virtual string FormatString(string unformatted, params object[] args)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(unformatted, nameof(unformatted));
+            ErrorUtilities.VerifyThrowArgumentNull(unformatted);
 
             return ResourceUtilities.FormatString(unformatted, args);
         }
@@ -290,7 +290,7 @@ namespace Microsoft.Build.Utilities
         public void LogMessage(MessageImportance importance, string message, params object[] messageArgs)
         {
             // No lock needed, as BuildEngine methods from v4.5 onwards are thread safe.
-            ErrorUtilities.VerifyThrowArgumentNull(message, nameof(message));
+            ErrorUtilities.VerifyThrowArgumentNull(message);
 #if DEBUG
             if (messageArgs?.Length > 0)
             {
@@ -360,7 +360,7 @@ namespace Microsoft.Build.Utilities
             params object[] messageArgs)
         {
             // No lock needed, as BuildEngine methods from v4.5 onwards are thread safe.
-            ErrorUtilities.VerifyThrowArgumentNull(message, nameof(message));
+            ErrorUtilities.VerifyThrowArgumentNull(message);
 
             if (!LogsMessagesOfImportance(importance))
             {
@@ -422,7 +422,7 @@ namespace Microsoft.Build.Utilities
             params object[] messageArgs)
         {
             // No lock needed, as BuildEngine methods from v4.5 onwards are thread safe.
-            ErrorUtilities.VerifyThrowArgumentNull(message, nameof(message));
+            ErrorUtilities.VerifyThrowArgumentNull(message);
 
             // If BuildEngine is null, task attempted to log before it was set on it,
             // presumably in its constructor. This is not allowed, and all
@@ -486,7 +486,7 @@ namespace Microsoft.Build.Utilities
         {
             // No lock needed, as the logging methods are thread safe and the rest does not modify
             // global state.
-            ErrorUtilities.VerifyThrowArgumentNull(messageResourceName, nameof(messageResourceName));
+            ErrorUtilities.VerifyThrowArgumentNull(messageResourceName);
 
             if (!LogsMessagesOfImportance(importance))
             {
@@ -510,8 +510,8 @@ namespace Microsoft.Build.Utilities
         /// <param name="content">The content of the file.</param>
         public void LogIncludeGeneratedFile(string filePath, string content)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(filePath, nameof(filePath));
-            ErrorUtilities.VerifyThrowArgumentNull(content, nameof(content));
+            ErrorUtilities.VerifyThrowArgumentNull(filePath);
+            ErrorUtilities.VerifyThrowArgumentNull(content);
 
             var e = new GeneratedFileUsedEventArgs(filePath, content);
 
@@ -601,7 +601,7 @@ namespace Microsoft.Build.Utilities
         public void LogCommandLine(MessageImportance importance, string commandLine)
         {
             // No lock needed, as BuildEngine methods from v4.5 onwards are thread safe.
-            ErrorUtilities.VerifyThrowArgumentNull(commandLine, nameof(commandLine));
+            ErrorUtilities.VerifyThrowArgumentNull(commandLine);
 
             if (!LogsMessagesOfImportance(importance))
             {
@@ -697,7 +697,7 @@ namespace Microsoft.Build.Utilities
             params object[] messageArgs)
         {
             // No lock needed, as BuildEngine methods from v4.5 onwards are thread safe.
-            ErrorUtilities.VerifyThrowArgumentNull(message, nameof(message));
+            ErrorUtilities.VerifyThrowArgumentNull(message);
 
             // If BuildEngine is null, task attempted to log before it was set on it,
             // presumably in its constructor. This is not allowed, and all
@@ -774,7 +774,7 @@ namespace Microsoft.Build.Utilities
         {
             // No lock needed, as the logging methods are thread safe and the rest does not modify
             // global state.
-            ErrorUtilities.VerifyThrowArgumentNull(messageResourceName, nameof(messageResourceName));
+            ErrorUtilities.VerifyThrowArgumentNull(messageResourceName);
 
             string subcategory = null;
 
@@ -857,7 +857,7 @@ namespace Microsoft.Build.Utilities
         {
             // No lock needed, as the logging methods are thread safe and the rest does not modify
             // global state.
-            ErrorUtilities.VerifyThrowArgumentNull(messageResourceName, nameof(messageResourceName));
+            ErrorUtilities.VerifyThrowArgumentNull(messageResourceName);
 
             string subcategory = null;
 
@@ -925,7 +925,7 @@ namespace Microsoft.Build.Utilities
         {
             // No lock needed, as the logging methods are thread safe and the rest does not modify
             // global state.
-            ErrorUtilities.VerifyThrowArgumentNull(exception, nameof(exception));
+            ErrorUtilities.VerifyThrowArgumentNull(exception);
 
             // For an AggregateException call LogErrorFromException on each inner exception
             if (exception is AggregateException aggregateException)
@@ -1048,7 +1048,7 @@ namespace Microsoft.Build.Utilities
             params object[] messageArgs)
         {
             // No lock needed, as BuildEngine methods from v4.5 onwards are thread safe.
-            ErrorUtilities.VerifyThrowArgumentNull(message, nameof(message));
+            ErrorUtilities.VerifyThrowArgumentNull(message);
 
             // If BuildEngine is null, task attempted to log before it was set on it,
             // presumably in its constructor. This is not allowed, and all
@@ -1144,7 +1144,7 @@ namespace Microsoft.Build.Utilities
         {
             // No lock needed, as log methods are thread safe and the rest does not modify
             // global state.
-            ErrorUtilities.VerifyThrowArgumentNull(messageResourceName, nameof(messageResourceName));
+            ErrorUtilities.VerifyThrowArgumentNull(messageResourceName);
 
             string subcategory = null;
 
@@ -1225,7 +1225,7 @@ namespace Microsoft.Build.Utilities
         {
             // No lock needed, as log methods are thread safe and the rest does not modify
             // global state.
-            ErrorUtilities.VerifyThrowArgumentNull(messageResourceName, nameof(messageResourceName));
+            ErrorUtilities.VerifyThrowArgumentNull(messageResourceName);
 
             string subcategory = null;
 
@@ -1277,7 +1277,7 @@ namespace Microsoft.Build.Utilities
         {
             // No lock needed, as log methods are thread safe and the rest does not modify
             // global state.
-            ErrorUtilities.VerifyThrowArgumentNull(exception, nameof(exception));
+            ErrorUtilities.VerifyThrowArgumentNull(exception);
 
             string message = exception.Message;
 
@@ -1319,7 +1319,7 @@ namespace Microsoft.Build.Utilities
         {
             // No lock needed, as log methods are thread safe and the rest does not modify
             // global state.
-            ErrorUtilities.VerifyThrowArgumentNull(fileName, nameof(fileName));
+            ErrorUtilities.VerifyThrowArgumentNull(fileName);
 
             bool errorsFound;
 
@@ -1346,7 +1346,7 @@ namespace Microsoft.Build.Utilities
         {
             // No lock needed, as log methods are thread safe and the rest does not modify
             // global state.
-            ErrorUtilities.VerifyThrowArgumentNull(stream, nameof(stream));
+            ErrorUtilities.VerifyThrowArgumentNull(stream);
 
             bool errorsFound = false;
             string lineOfText;
@@ -1374,7 +1374,7 @@ namespace Microsoft.Build.Utilities
         {
             // No lock needed, as log methods are thread safe and the rest does not modify
             // global state.
-            ErrorUtilities.VerifyThrowArgumentNull(lineOfText, nameof(lineOfText));
+            ErrorUtilities.VerifyThrowArgumentNull(lineOfText);
 
             bool isError = false;
             CanonicalError.Parts messageParts = CanonicalError.Parse(lineOfText);

--- a/src/Shared/TaskLoggingHelperExtension.cs
+++ b/src/Shared/TaskLoggingHelperExtension.cs
@@ -90,7 +90,7 @@ namespace Microsoft.Build.Tasks
         /// <exception cref="InvalidOperationException">Thrown when the <c>TaskResources</c> property of the owner task is not set.</exception>
         public override string FormatResourceString(string resourceName, params object[] args)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(resourceName, nameof(resourceName));
+            ErrorUtilities.VerifyThrowArgumentNull(resourceName);
             ErrorUtilities.VerifyThrowInvalidOperation(TaskResources != null, "Shared.TaskResourcesNotRegistered", TaskName);
             ErrorUtilities.VerifyThrowInvalidOperation(TaskSharedResources != null, "Shared.TaskResourcesNotRegistered", TaskName);
 

--- a/src/Shared/TaskParameter.cs
+++ b/src/Shared/TaskParameter.cs
@@ -754,7 +754,7 @@ namespace Microsoft.Build.BackEnd
             /// </summary>
             public TaskParameterTaskItem(string escapedItemSpec, string escapedDefiningProject, Dictionary<string, string> escapedMetadata)
             {
-                ErrorUtilities.VerifyThrowInternalNull(escapedItemSpec, nameof(escapedItemSpec));
+                ErrorUtilities.VerifyThrowInternalNull(escapedItemSpec);
 
                 _escapedItemSpec = escapedItemSpec;
                 _escapedDefiningProject = escapedDefiningProject;

--- a/src/Shared/TaskParameter.cs
+++ b/src/Shared/TaskParameter.cs
@@ -845,7 +845,7 @@ namespace Microsoft.Build.BackEnd
             /// <param name="metadataValue">The metadata value.</param>
             public void SetMetadata(string metadataName, string metadataValue)
             {
-                ErrorUtilities.VerifyThrowArgumentLength(metadataName, nameof(metadataName));
+                ErrorUtilities.VerifyThrowArgumentLength(metadataName);
 
                 // Non-derivable metadata can only be set at construction time.
                 // That's why this is IsItemSpecModifier and not IsDerivableItemSpecModifier.

--- a/src/Shared/TaskParameter.cs
+++ b/src/Shared/TaskParameter.cs
@@ -862,7 +862,7 @@ namespace Microsoft.Build.BackEnd
             /// <param name="metadataName">The name of the metadata to remove.</param>
             public void RemoveMetadata(string metadataName)
             {
-                ErrorUtilities.VerifyThrowArgumentNull(metadataName, nameof(metadataName));
+                ErrorUtilities.VerifyThrowArgumentNull(metadataName);
                 ErrorUtilities.VerifyThrowArgument(!FileUtilities.ItemSpecModifiers.IsItemSpecModifier(metadataName), "Shared.CannotChangeItemSpecModifiers", metadataName);
 
                 if (_customEscapedMetadata == null)
@@ -885,7 +885,7 @@ namespace Microsoft.Build.BackEnd
             /// <param name="destinationItem">The item to copy metadata to.</param>
             public void CopyMetadataTo(ITaskItem destinationItem)
             {
-                ErrorUtilities.VerifyThrowArgumentNull(destinationItem, nameof(destinationItem));
+                ErrorUtilities.VerifyThrowArgumentNull(destinationItem);
 
                 // also copy the original item-spec under a "magic" metadata -- this is useful for tasks that forward metadata
                 // between items, and need to know the source item where the metadata came from
@@ -952,7 +952,7 @@ namespace Microsoft.Build.BackEnd
             /// </summary>
             string ITaskItem2.GetMetadataValueEscaped(string metadataName)
             {
-                ErrorUtilities.VerifyThrowArgumentNull(metadataName, nameof(metadataName));
+                ErrorUtilities.VerifyThrowArgumentNull(metadataName);
 
                 string metadataValue = null;
 

--- a/src/Shared/TypeLoader.cs
+++ b/src/Shared/TypeLoader.cs
@@ -307,7 +307,7 @@ namespace Microsoft.Build.Shared
             internal AssemblyInfoToLoadedTypes(Func<Type, object, bool> typeFilter, AssemblyLoadInfo loadInfo)
             {
                 ErrorUtilities.VerifyThrowArgumentNull(typeFilter, "typefilter");
-                ErrorUtilities.VerifyThrowArgumentNull(loadInfo, nameof(loadInfo));
+                ErrorUtilities.VerifyThrowArgumentNull(loadInfo);
 
                 _isDesiredType = typeFilter;
                 _assemblyLoadInfo = loadInfo;
@@ -321,7 +321,7 @@ namespace Microsoft.Build.Shared
             /// </summary>
             internal LoadedType GetLoadedTypeByTypeName(string typeName, bool useTaskHost)
             {
-                ErrorUtilities.VerifyThrowArgumentNull(typeName, nameof(typeName));
+                ErrorUtilities.VerifyThrowArgumentNull(typeName);
 
                 if (useTaskHost && _assemblyLoadInfo.AssemblyFile is not null)
                 {

--- a/src/Shared/XmlUtilities.cs
+++ b/src/Shared/XmlUtilities.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Build.Shared
         /// <param name="name">name to validate</param>
         internal static void VerifyThrowArgumentValidElementName(string name)
         {
-            ErrorUtilities.VerifyThrowArgumentLength(name, nameof(name));
+            ErrorUtilities.VerifyThrowArgumentLength(name);
 
             int firstInvalidCharLocation = LocateFirstInvalidElementNameCharacter(name);
 
@@ -88,7 +88,7 @@ namespace Microsoft.Build.Shared
         /// </remarks>
         internal static void VerifyThrowProjectValidElementName(string name, IElementLocation location)
         {
-            ErrorUtilities.VerifyThrowArgumentLength(name, nameof(name));
+            ErrorUtilities.VerifyThrowArgumentLength(name);
             int firstInvalidCharLocation = LocateFirstInvalidElementNameCharacter(name);
 
             if (-1 != firstInvalidCharLocation)

--- a/src/Tasks/AssemblyDependency/AssemblyInformation.cs
+++ b/src/Tasks/AssemblyDependency/AssemblyInformation.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Build.Tasks
         internal AssemblyInformation(string sourceFile)
         {
             // Extra checks for PInvoke-destined data.
-            ErrorUtilities.VerifyThrowArgumentNull(sourceFile, nameof(sourceFile));
+            ErrorUtilities.VerifyThrowArgumentNull(sourceFile);
             _sourceFile = sourceFile;
 
 #if !FEATURE_ASSEMBLYLOADCONTEXT

--- a/src/Tasks/AssemblyDependency/GlobalAssemblyCache.cs
+++ b/src/Tasks/AssemblyDependency/GlobalAssemblyCache.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Build.Tasks
         private static string GetLocationImpl(AssemblyNameExtension assemblyName, string targetProcessorArchitecture, GetAssemblyRuntimeVersion getRuntimeVersion, Version targetedRuntime, FileExists fileExists, GetPathFromFusionName getPathFromFusionName, GetGacEnumerator getGacEnumerator, bool specificVersion)
         {
             // Extra checks for PInvoke-destined data.
-            ErrorUtilities.VerifyThrowArgumentNull(assemblyName, nameof(assemblyName));
+            ErrorUtilities.VerifyThrowArgumentNull(assemblyName);
             ErrorUtilities.VerifyThrow(assemblyName.FullName != null, "Got a null assembly name fullname.");
 
             string strongName = assemblyName.FullName;
@@ -117,7 +117,7 @@ namespace Microsoft.Build.Tasks
         /// </summary>
         private static SortedDictionary<Version, SortedDictionary<AssemblyNameExtension, string>> GenerateListOfAssembliesByRuntime(string strongName, GetAssemblyRuntimeVersion getRuntimeVersion, Version targetedRuntime, FileExists fileExists, GetPathFromFusionName getPathFromFusionName, GetGacEnumerator getGacEnumerator, bool specificVersion)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(targetedRuntime, nameof(targetedRuntime));
+            ErrorUtilities.VerifyThrowArgumentNull(targetedRuntime);
 
             IEnumerable<AssemblyNameExtension> gacEnum = getGacEnumerator(strongName);
 
@@ -178,7 +178,7 @@ namespace Microsoft.Build.Tasks
         internal static string RetrievePathFromFusionName(string strongName)
         {
             // Extra checks for PInvoke-destined data.
-            ErrorUtilities.VerifyThrowArgumentNull(strongName, nameof(strongName));
+            ErrorUtilities.VerifyThrowArgumentNull(strongName);
 
             string value;
 

--- a/src/Tasks/AssemblyDependency/ReferenceTable.cs
+++ b/src/Tasks/AssemblyDependency/ReferenceTable.cs
@@ -2541,8 +2541,8 @@ namespace Microsoft.Build.Tasks
         /// </summary>
         private bool CompareAssembliesIgnoringVersion(AssemblyName a, AssemblyName b)
         {
-            ErrorUtilities.VerifyThrowInternalNull(a, nameof(a));
-            ErrorUtilities.VerifyThrowInternalNull(b, nameof(b));
+            ErrorUtilities.VerifyThrowInternalNull(a);
+            ErrorUtilities.VerifyThrowInternalNull(b);
 
             if (a == b)
             {

--- a/src/Tasks/AssemblyDependency/ResolveAssemblyReference.cs
+++ b/src/Tasks/AssemblyDependency/ResolveAssemblyReference.cs
@@ -1325,7 +1325,7 @@ namespace Microsoft.Build.Tasks
         /// </summary>
         private void LogReferenceDependenciesAndSourceItemsToStringBuilder(string fusionName, Reference conflictCandidate, StringBuilder log, bool referenceIsUnified = false)
         {
-            ErrorUtilities.VerifyThrowInternalNull(conflictCandidate, nameof(conflictCandidate));
+            ErrorUtilities.VerifyThrowInternalNull(conflictCandidate);
             log.Append(Strings.FourSpaces);
 
             string resource = referenceIsUnified ? "ResolveAssemblyReference.UnifiedReferenceDependsOn" : "ResolveAssemblyReference.ReferenceDependsOn";

--- a/src/Tasks/AssemblyDependency/ResolveAssemblyReference.cs
+++ b/src/Tasks/AssemblyDependency/ResolveAssemblyReference.cs
@@ -1746,7 +1746,7 @@ namespace Microsoft.Build.Tasks
         /// <param name="importance">The importance of the message.</param>
         private void LogFullName(Reference reference, MessageImportance importance)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(reference, nameof(reference));
+            ErrorUtilities.VerifyThrowArgumentNull(reference);
 
             if (reference.IsResolved)
             {
@@ -1801,7 +1801,7 @@ namespace Microsoft.Build.Tasks
                         else
                         {
                             Log.LogMessage(importance, Strings.SearchPath, lastSearchPath);
-                        }                 
+                        }
                         if (logAssemblyFoldersMinimal)
                         {
                             Log.LogMessage(importance, Strings.SearchedAssemblyFoldersEx);

--- a/src/Tasks/AssemblyRegistrationCache.cs
+++ b/src/Tasks/AssemblyRegistrationCache.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Build.Tasks
 
         public override void Translate(ITranslator translator)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(translator, nameof(translator));
+            ErrorUtilities.VerifyThrowArgumentNull(translator);
             translator.Translate(ref _assemblies);
             translator.Translate(ref _typeLibraries);
         }

--- a/src/Tasks/CodeTaskFactory.cs
+++ b/src/Tasks/CodeTaskFactory.cs
@@ -344,7 +344,7 @@ namespace Microsoft.Build.Tasks
         /// </remarks>
         public void CleanupTask(ITask task)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(task, nameof(task));
+            ErrorUtilities.VerifyThrowArgumentNull(task);
         }
 
         /// <summary>

--- a/src/Tasks/ComReferenceInfo.cs
+++ b/src/Tasks/ComReferenceInfo.cs
@@ -134,7 +134,7 @@ namespace Microsoft.Build.Tasks
         /// </summary>
         internal bool InitializeWithPath(TaskLoggingHelper log, bool silent, string path, ITaskItem originalTaskItem, string targetProcessorArchitecture)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(path, nameof(path));
+            ErrorUtilities.VerifyThrowArgumentNull(path);
 
             this.taskItem = originalTaskItem;
 

--- a/src/Tasks/CreateManifestResourceName.cs
+++ b/src/Tasks/CreateManifestResourceName.cs
@@ -295,7 +295,7 @@ namespace Microsoft.Build.Tasks
         /// </summary>
         private static void MakeValidEverettSubFolderIdentifier(StringBuilder builder, string subName)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(subName, nameof(subName));
+            ErrorUtilities.VerifyThrowArgumentNull(subName);
 
             if (string.IsNullOrEmpty(subName)) { return; }
 
@@ -333,7 +333,7 @@ namespace Microsoft.Build.Tasks
         /// </summary>
         internal static void MakeValidEverettFolderIdentifier(StringBuilder builder, string name)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(name, nameof(name));
+            ErrorUtilities.VerifyThrowArgumentNull(name);
 
             if (string.IsNullOrEmpty(name)) { return; }
 
@@ -365,7 +365,7 @@ namespace Microsoft.Build.Tasks
         /// </summary>
         public static string MakeValidEverettIdentifier(string name)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(name, nameof(name));
+            ErrorUtilities.VerifyThrowArgumentNull(name);
             if (string.IsNullOrEmpty(name)) { return name; }
 
             var everettId = new StringBuilder(name.Length);

--- a/src/Tasks/FileState.cs
+++ b/src/Tasks/FileState.cs
@@ -247,7 +247,7 @@ namespace Microsoft.Build.Tasks
         /// </summary>
         internal FileState(string filename)
         {
-            ErrorUtilities.VerifyThrowArgumentLength(filename, nameof(filename));
+            ErrorUtilities.VerifyThrowArgumentLength(filename);
             _filename = filename;
             _data = new Lazy<FileDirInfo>(() => new FileDirInfo(_filename));
         }

--- a/src/Tasks/GenerateResource.cs
+++ b/src/Tasks/GenerateResource.cs
@@ -617,7 +617,7 @@ namespace Microsoft.Build.Tasks
         {
             // Throw an internal error, since this method should only ever get called by other aspects of this task, not
             // anything that the user touches.
-            ErrorUtilities.VerifyThrowInternalNull(resGenCommand, nameof(resGenCommand));
+            ErrorUtilities.VerifyThrowInternalNull(resGenCommand);
 
             // append the /useSourcePath flag if requested.
             if (UseSourcePath)

--- a/src/Tasks/RedistList.cs
+++ b/src/Tasks/RedistList.cs
@@ -291,7 +291,7 @@ namespace Microsoft.Build.Tasks
         /// <returns>Array of paths to redist lists under given framework directory.</returns>
         public static string[] GetRedistListPathsFromDisk(string frameworkDirectory)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(frameworkDirectory, nameof(frameworkDirectory));
+            ErrorUtilities.VerifyThrowArgumentNull(frameworkDirectory);
 
             lock (s_locker)
             {
@@ -429,7 +429,7 @@ namespace Microsoft.Build.Tasks
         /// </summary>
         public bool FrameworkAssemblyEntryInRedist(AssemblyNameExtension assemblyName)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(assemblyName, nameof(assemblyName));
+            ErrorUtilities.VerifyThrowArgumentNull(assemblyName);
 
             if (!_assemblyNameInRedist.TryGetValue(assemblyName, out bool isAssemblyNameInRedist))
             {
@@ -991,7 +991,7 @@ namespace Microsoft.Build.Tasks
         /// found in the target framework directories. This can happen if the subsets are instead passed in as InstalledDefaultSubsetTables</param>
         internal SubsetListFinder(string[] subsetToSearchFor)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(subsetToSearchFor, nameof(subsetToSearchFor));
+            ErrorUtilities.VerifyThrowArgumentNull(subsetToSearchFor);
             _subsetToSearchFor = subsetToSearchFor;
         }
 
@@ -1015,7 +1015,7 @@ namespace Microsoft.Build.Tasks
         /// <returns>Array of paths locations to subset lists under the given framework directory.</returns>
         public string[] GetSubsetListPathsFromDisk(string frameworkDirectory)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(frameworkDirectory, nameof(frameworkDirectory));
+            ErrorUtilities.VerifyThrowArgumentNull(frameworkDirectory);
 
             // Make sure we have some subset names to search for it is possible that no subsets are asked for
             // so we should return as quickly as possible in that case.

--- a/src/Tasks/RegisterAssembly.cs
+++ b/src/Tasks/RegisterAssembly.cs
@@ -192,7 +192,7 @@ namespace Microsoft.Build.Tasks
         /// </comment>
         public object ResolveRef(Assembly assemblyToResolve)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(assemblyToResolve, nameof(assemblyToResolve));
+            ErrorUtilities.VerifyThrowArgumentNull(assemblyToResolve);
 
             Log.LogErrorWithCodeFromResources("RegisterAssembly.AssemblyNotRegisteredForComInterop", assemblyToResolve.GetName().FullName);
             _typeLibExportFailed = true;
@@ -208,7 +208,7 @@ namespace Microsoft.Build.Tasks
         /// </summary>
         private bool Register(string assemblyPath, string typeLibPath)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(typeLibPath, nameof(typeLibPath));
+            ErrorUtilities.VerifyThrowArgumentNull(typeLibPath);
 
             Log.LogMessageFromResources(MessageImportance.Low, "RegisterAssembly.RegisteringAssembly", assemblyPath);
 

--- a/src/Tasks/ResolveComReferenceCache.cs
+++ b/src/Tasks/ResolveComReferenceCache.cs
@@ -41,8 +41,8 @@ namespace Microsoft.Build.Tasks
         /// </summary>
         internal ResolveComReferenceCache(string tlbImpPath, string axImpPath)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(tlbImpPath, nameof(tlbImpPath));
-            ErrorUtilities.VerifyThrowArgumentNull(axImpPath, nameof(axImpPath));
+            ErrorUtilities.VerifyThrowArgumentNull(tlbImpPath);
+            ErrorUtilities.VerifyThrowArgumentNull(axImpPath);
 
             tlbImpLocation = tlbImpPath;
             axImpLocation = axImpPath;

--- a/src/Tasks/ResolveSDKReference.cs
+++ b/src/Tasks/ResolveSDKReference.cs
@@ -726,7 +726,7 @@ namespace Microsoft.Build.Tasks
             /// </summary>
             public SDKReference(ITaskItem taskItem, string sdkName, string sdkVersion)
             {
-                ErrorUtilities.VerifyThrowArgumentNull(taskItem, nameof(taskItem));
+                ErrorUtilities.VerifyThrowArgumentNull(taskItem);
                 ErrorUtilities.VerifyThrowArgumentLength(sdkName, nameof(sdkName));
                 ErrorUtilities.VerifyThrowArgumentLength(sdkVersion, nameof(sdkVersion));
 

--- a/src/Tasks/ResolveSDKReference.cs
+++ b/src/Tasks/ResolveSDKReference.cs
@@ -727,8 +727,8 @@ namespace Microsoft.Build.Tasks
             public SDKReference(ITaskItem taskItem, string sdkName, string sdkVersion)
             {
                 ErrorUtilities.VerifyThrowArgumentNull(taskItem);
-                ErrorUtilities.VerifyThrowArgumentLength(sdkName, nameof(sdkName));
-                ErrorUtilities.VerifyThrowArgumentLength(sdkVersion, nameof(sdkVersion));
+                ErrorUtilities.VerifyThrowArgumentLength(sdkName);
+                ErrorUtilities.VerifyThrowArgumentLength(sdkVersion);
 
                 ReferenceItem = taskItem;
                 SimpleName = sdkName;

--- a/src/Tasks/StrongNameUtils.cs
+++ b/src/Tasks/StrongNameUtils.cs
@@ -137,7 +137,7 @@ namespace Microsoft.Build.Tasks
         /// <returns></returns>
         internal static StrongNameLevel GetAssemblyStrongNameLevel(string assemblyPath)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(assemblyPath, nameof(assemblyPath));
+            ErrorUtilities.VerifyThrowArgumentNull(assemblyPath);
 
             StrongNameLevel snLevel = StrongNameLevel.Unknown;
             IntPtr fileHandle = NativeMethods.InvalidIntPtr;

--- a/src/Tasks/SystemState.cs
+++ b/src/Tasks/SystemState.cs
@@ -168,7 +168,7 @@ namespace Microsoft.Build.Tasks
             /// </summary>
             public void Translate(ITranslator translator)
             {
-                ErrorUtilities.VerifyThrowArgumentNull(translator, nameof(translator));
+                ErrorUtilities.VerifyThrowArgumentNull(translator);
 
                 translator.Translate(ref lastModified);
                 translator.Translate(ref assemblyName,

--- a/src/Tasks/UnregisterAssembly.cs
+++ b/src/Tasks/UnregisterAssembly.cs
@@ -150,7 +150,7 @@ namespace Microsoft.Build.Tasks
         /// </summary>
         private bool Unregister(string assemblyPath, string typeLibPath)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(typeLibPath, nameof(typeLibPath));
+            ErrorUtilities.VerifyThrowArgumentNull(typeLibPath);
 
             Log.LogMessageFromResources(MessageImportance.Low, "UnregisterAssembly.UnregisteringAssembly", assemblyPath);
 

--- a/src/Tasks/XamlTaskFactory/CommandLineGenerator.cs
+++ b/src/Tasks/XamlTaskFactory/CommandLineGenerator.cs
@@ -37,8 +37,8 @@ namespace Microsoft.Build.Tasks.Xaml
         /// </summary>
         public CommandLineGenerator(Rule rule, Dictionary<string, Object> parameterValues)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(rule, nameof(rule));
-            ErrorUtilities.VerifyThrowArgumentNull(parameterValues, nameof(parameterValues));
+            ErrorUtilities.VerifyThrowArgumentNull(rule);
+            ErrorUtilities.VerifyThrowArgumentNull(parameterValues);
 
             // Parse the Xaml file
             var parser = new TaskParser();

--- a/src/Tasks/XamlTaskFactory/TaskParser.cs
+++ b/src/Tasks/XamlTaskFactory/TaskParser.cs
@@ -89,8 +89,8 @@ namespace Microsoft.Build.Tasks.Xaml
         /// </summary>
         public bool Parse(string contentOrFile, string desiredRule)
         {
-            ErrorUtilities.VerifyThrowArgumentLength(contentOrFile, nameof(contentOrFile));
-            ErrorUtilities.VerifyThrowArgumentLength(desiredRule, nameof(desiredRule));
+            ErrorUtilities.VerifyThrowArgumentLength(contentOrFile);
+            ErrorUtilities.VerifyThrowArgumentLength(desiredRule);
 
             bool parseSuccessful = ParseAsContentOrFile(contentOrFile, desiredRule);
             if (!parseSuccessful)
@@ -187,7 +187,7 @@ namespace Microsoft.Build.Tasks.Xaml
         internal bool ParseXamlDocument(TextReader reader, string desiredRule)
         {
             ErrorUtilities.VerifyThrowArgumentNull(reader);
-            ErrorUtilities.VerifyThrowArgumentLength(desiredRule, nameof(desiredRule));
+            ErrorUtilities.VerifyThrowArgumentLength(desiredRule);
 
             object rootObject = XamlServices.Load(reader);
             if (rootObject != null)

--- a/src/Tasks/XamlTaskFactory/TaskParser.cs
+++ b/src/Tasks/XamlTaskFactory/TaskParser.cs
@@ -186,7 +186,7 @@ namespace Microsoft.Build.Tasks.Xaml
         /// </summary>
         internal bool ParseXamlDocument(TextReader reader, string desiredRule)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(reader, nameof(reader));
+            ErrorUtilities.VerifyThrowArgumentNull(reader);
             ErrorUtilities.VerifyThrowArgumentLength(desiredRule, nameof(desiredRule));
 
             object rootObject = XamlServices.Load(reader);

--- a/src/Tasks/XamlTaskFactory/XamlTaskFactory.cs
+++ b/src/Tasks/XamlTaskFactory/XamlTaskFactory.cs
@@ -84,8 +84,8 @@ namespace Microsoft.Build.Tasks
         /// </summary>
         public bool Initialize(string taskName, IDictionary<string, TaskPropertyInfo> taskParameters, string taskElementContents, IBuildEngine taskFactoryLoggingHost)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(taskName, nameof(taskName));
-            ErrorUtilities.VerifyThrowArgumentNull(taskParameters, nameof(taskParameters));
+            ErrorUtilities.VerifyThrowArgumentNull(taskName);
+            ErrorUtilities.VerifyThrowArgumentNull(taskParameters);
 
             var log = new TaskLoggingHelper(taskFactoryLoggingHost, taskName)
             {
@@ -210,7 +210,7 @@ namespace Microsoft.Build.Tasks
         /// </remarks>
         public void CleanupTask(ITask task)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(task, nameof(task));
+            ErrorUtilities.VerifyThrowArgumentNull(task);
         }
 
         /// <summary>

--- a/src/UnitTests.Shared/ObjectModelHelpers.cs
+++ b/src/UnitTests.Shared/ObjectModelHelpers.cs
@@ -1127,7 +1127,7 @@ namespace Microsoft.Build.UnitTests
     {
         public static string Format(this string s, params object[] formatItems)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(s, nameof(s));
+            ErrorUtilities.VerifyThrowArgumentNull(s);
 
             return string.Format(s, formatItems);
         }

--- a/src/UnitTests.Shared/TestEnvironment.cs
+++ b/src/UnitTests.Shared/TestEnvironment.cs
@@ -315,7 +315,7 @@ namespace Microsoft.Build.UnitTests
         /// Will not work for out of proc nodes since the output writer does not reach into those
         public TransientPrintLineDebugger CreatePrintLineDebuggerWithTestOutputHelper()
         {
-            ErrorUtilities.VerifyThrowInternalNull(Output, nameof(Output));
+            ErrorUtilities.VerifyThrowInternalNull(Output);
             return WithTransientTestState(new TransientPrintLineDebugger(this, OutPutHelperWriter(Output)));
 
             CommonWriterType OutPutHelperWriter(ITestOutputHelper output)

--- a/src/Utilities.UnitTests/TaskItem_Tests.cs
+++ b/src/Utilities.UnitTests/TaskItem_Tests.cs
@@ -428,7 +428,7 @@ namespace Microsoft.Build.UnitTests
             /// </summary>
             public void Run(string[] includes, IDictionary<string, string> metadataToAdd)
             {
-                ErrorUtilities.VerifyThrowArgumentNull(includes, nameof(includes));
+                ErrorUtilities.VerifyThrowArgumentNull(includes);
 
                 CreatedTaskItems = new TaskItem[includes.Length];
 

--- a/src/Utilities/AssemblyFolders/AssemblyFoldersExInfo.cs
+++ b/src/Utilities/AssemblyFolders/AssemblyFoldersExInfo.cs
@@ -21,9 +21,9 @@ namespace Microsoft.Build.Utilities
         /// </summary>
         public AssemblyFoldersExInfo(RegistryHive hive, RegistryView view, string registryKey, string directoryPath, Version targetFrameworkVersion)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(registryKey, nameof(registryKey));
-            ErrorUtilities.VerifyThrowArgumentNull(directoryPath, nameof(directoryPath));
-            ErrorUtilities.VerifyThrowArgumentNull(targetFrameworkVersion, nameof(targetFrameworkVersion));
+            ErrorUtilities.VerifyThrowArgumentNull(registryKey);
+            ErrorUtilities.VerifyThrowArgumentNull(directoryPath);
+            ErrorUtilities.VerifyThrowArgumentNull(targetFrameworkVersion);
 
             Hive = hive;
             View = view;

--- a/src/Utilities/AssemblyFolders/AssemblyFoldersFromConfigInfo.cs
+++ b/src/Utilities/AssemblyFolders/AssemblyFoldersFromConfigInfo.cs
@@ -23,8 +23,8 @@ namespace Microsoft.Build.Utilities
         /// <param name="targetFrameworkVersion">The <see cref="Version"/> of the target framework.</param>
         public AssemblyFoldersFromConfigInfo(string directoryPath, Version targetFrameworkVersion)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(directoryPath, nameof(directoryPath));
-            ErrorUtilities.VerifyThrowArgumentNull(targetFrameworkVersion, nameof(targetFrameworkVersion));
+            ErrorUtilities.VerifyThrowArgumentNull(directoryPath);
+            ErrorUtilities.VerifyThrowArgumentNull(targetFrameworkVersion);
 
             // When we get a path, it may be relative to Visual Studio (i.e. reference assemblies). If the
             // VSInstallDir environment is used, replace with our known location to Visual Studio.

--- a/src/Utilities/AssemblyResources.cs
+++ b/src/Utilities/AssemblyResources.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Build.Shared
         /// <returns>The formatted string.</returns>
         internal static string FormatString(string unformatted, params object[] args)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(unformatted, nameof(unformatted));
+            ErrorUtilities.VerifyThrowArgumentNull(unformatted);
 
             return ResourceUtilities.FormatString(unformatted, args);
         }
@@ -72,7 +72,7 @@ namespace Microsoft.Build.Shared
         /// <returns>The formatted string.</returns>
         internal static string FormatResourceString(string resourceName, params object[] args)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(resourceName, nameof(resourceName));
+            ErrorUtilities.VerifyThrowArgumentNull(resourceName);
 
             // NOTE: the ResourceManager.GetString() method is thread-safe
             string resourceString = GetString(resourceName);

--- a/src/Utilities/CommandLineBuilder.cs
+++ b/src/Utilities/CommandLineBuilder.cs
@@ -247,7 +247,7 @@ namespace Microsoft.Build.Utilities
         /// <param name="unquotedTextToAppend"></param>
         protected void AppendQuotedTextToBuffer(StringBuilder buffer, string unquotedTextToAppend)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(buffer, nameof(buffer));
+            ErrorUtilities.VerifyThrowArgumentNull(buffer);
 
             if (unquotedTextToAppend != null)
             {
@@ -399,7 +399,7 @@ namespace Microsoft.Build.Utilities
         /// <param name="delimiter">The delimiter between file names</param>
         public void AppendFileNamesIfNotNull(string[] fileNames, string delimiter)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(delimiter, nameof(delimiter));
+            ErrorUtilities.VerifyThrowArgumentNull(delimiter);
 
             if (fileNames?.Length > 0)
             {
@@ -434,7 +434,7 @@ namespace Microsoft.Build.Utilities
         /// <param name="delimiter">Delimiter to put between items in the command line</param>
         public void AppendFileNamesIfNotNull(ITaskItem[] fileItems, string delimiter)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(delimiter, nameof(delimiter));
+            ErrorUtilities.VerifyThrowArgumentNull(delimiter);
 
             if (fileItems?.Length > 0)
             {
@@ -478,7 +478,7 @@ namespace Microsoft.Build.Utilities
         /// <param name="switchName">The switch to append to the command line, may not be null</param>
         public void AppendSwitch(string switchName)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(switchName, nameof(switchName));
+            ErrorUtilities.VerifyThrowArgumentNull(switchName);
 
             AppendSpaceIfNotEmpty();
             AppendTextUnquoted(switchName);
@@ -495,7 +495,7 @@ namespace Microsoft.Build.Utilities
         /// <param name="parameter">Switch parameter to append, quoted if necessary. If null, this method has no effect.</param>
         public void AppendSwitchIfNotNull(string switchName, string parameter)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(switchName, nameof(switchName));
+            ErrorUtilities.VerifyThrowArgumentNull(switchName);
 
             if (parameter != null)
             {
@@ -544,7 +544,7 @@ namespace Microsoft.Build.Utilities
         /// <param name="parameter">Switch parameter to append, quoted if necessary. If null, this method has no effect.</param>
         public void AppendSwitchIfNotNull(string switchName, ITaskItem parameter)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(switchName, nameof(switchName));
+            ErrorUtilities.VerifyThrowArgumentNull(switchName);
 
             if (parameter != null)
             {
@@ -565,8 +565,8 @@ namespace Microsoft.Build.Utilities
         /// <param name="delimiter">Delimiter to put between individual parameters, may not be null (may be empty)</param>
         public void AppendSwitchIfNotNull(string switchName, string[] parameters, string delimiter)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(switchName, nameof(switchName));
-            ErrorUtilities.VerifyThrowArgumentNull(delimiter, nameof(delimiter));
+            ErrorUtilities.VerifyThrowArgumentNull(switchName);
+            ErrorUtilities.VerifyThrowArgumentNull(delimiter);
 
             if (parameters?.Length > 0)
             {
@@ -597,8 +597,8 @@ namespace Microsoft.Build.Utilities
         /// <param name="delimiter">Delimiter to put between individual parameters, may not be null (may be empty)</param>
         public void AppendSwitchIfNotNull(string switchName, ITaskItem[] parameters, string delimiter)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(switchName, nameof(switchName));
-            ErrorUtilities.VerifyThrowArgumentNull(delimiter, nameof(delimiter));
+            ErrorUtilities.VerifyThrowArgumentNull(switchName);
+            ErrorUtilities.VerifyThrowArgumentNull(delimiter);
 
             if (parameters?.Length > 0)
             {
@@ -635,7 +635,7 @@ namespace Microsoft.Build.Utilities
         /// <param name="parameter">Switch parameter to append, not quoted. If null, this method has no effect.</param>
         public void AppendSwitchUnquotedIfNotNull(string switchName, string parameter)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(switchName, nameof(switchName));
+            ErrorUtilities.VerifyThrowArgumentNull(switchName);
 
             if (parameter != null)
             {
@@ -656,7 +656,7 @@ namespace Microsoft.Build.Utilities
         /// <param name="parameter">Switch parameter to append, not quoted. If null, this method has no effect.</param>
         public void AppendSwitchUnquotedIfNotNull(string switchName, ITaskItem parameter)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(switchName, nameof(switchName));
+            ErrorUtilities.VerifyThrowArgumentNull(switchName);
 
             if (parameter != null)
             {
@@ -676,8 +676,8 @@ namespace Microsoft.Build.Utilities
         /// <param name="delimiter">Delimiter to put between individual parameters, may not be null (may be empty)</param>
         public void AppendSwitchUnquotedIfNotNull(string switchName, string[] parameters, string delimiter)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(switchName, nameof(switchName));
-            ErrorUtilities.VerifyThrowArgumentNull(delimiter, nameof(delimiter));
+            ErrorUtilities.VerifyThrowArgumentNull(switchName);
+            ErrorUtilities.VerifyThrowArgumentNull(delimiter);
 
             if (parameters?.Length > 0)
             {
@@ -707,8 +707,8 @@ namespace Microsoft.Build.Utilities
         /// <param name="delimiter">Delimiter to put between individual parameters, may not be null (may be empty)</param>
         public void AppendSwitchUnquotedIfNotNull(string switchName, ITaskItem[] parameters, string delimiter)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(switchName, nameof(switchName));
-            ErrorUtilities.VerifyThrowArgumentNull(delimiter, nameof(delimiter));
+            ErrorUtilities.VerifyThrowArgumentNull(switchName);
+            ErrorUtilities.VerifyThrowArgumentNull(delimiter);
 
             if (parameters?.Length > 0)
             {

--- a/src/Utilities/PlatformManifest.cs
+++ b/src/Utilities/PlatformManifest.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Build.Utilities
         /// </summary>
         public PlatformManifest(string pathToManifest)
         {
-            ErrorUtilities.VerifyThrowArgumentLength(pathToManifest, nameof(pathToManifest));
+            ErrorUtilities.VerifyThrowArgumentLength(pathToManifest);
             _pathToManifest = pathToManifest;
             LoadManifestFile();
         }

--- a/src/Utilities/SDKManifest.cs
+++ b/src/Utilities/SDKManifest.cs
@@ -108,7 +108,7 @@ namespace Microsoft.Build.Utilities
         /// </summary>
         public SDKManifest(string pathToSdk)
         {
-            ErrorUtilities.VerifyThrowArgumentLength(pathToSdk, nameof(pathToSdk));
+            ErrorUtilities.VerifyThrowArgumentLength(pathToSdk);
             _pathToSdk = pathToSdk;
             LoadManifestFile();
         }

--- a/src/Utilities/TargetPlatformSDK.cs
+++ b/src/Utilities/TargetPlatformSDK.cs
@@ -42,8 +42,8 @@ namespace Microsoft.Build.Utilities
         /// </summary>
         public TargetPlatformSDK(string targetPlatformIdentifier, Version targetPlatformVersion, string path)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(targetPlatformIdentifier, nameof(targetPlatformIdentifier));
-            ErrorUtilities.VerifyThrowArgumentNull(targetPlatformVersion, nameof(targetPlatformVersion));
+            ErrorUtilities.VerifyThrowArgumentNull(targetPlatformIdentifier);
+            ErrorUtilities.VerifyThrowArgumentNull(targetPlatformVersion);
             TargetPlatformIdentifier = targetPlatformIdentifier;
             TargetPlatformVersion = targetPlatformVersion;
             Path = path;

--- a/src/Utilities/TaskItem.cs
+++ b/src/Utilities/TaskItem.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Build.Utilities
         public TaskItem(
             string itemSpec)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(itemSpec, nameof(itemSpec));
+            ErrorUtilities.VerifyThrowArgumentNull(itemSpec);
 
             _itemSpec = FileUtilities.FixFilePath(itemSpec);
         }
@@ -99,7 +99,7 @@ namespace Microsoft.Build.Utilities
             IDictionary itemMetadata) :
             this(itemSpec)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(itemMetadata, nameof(itemMetadata));
+            ErrorUtilities.VerifyThrowArgumentNull(itemMetadata);
 
             if (itemMetadata.Count > 0)
             {
@@ -124,7 +124,7 @@ namespace Microsoft.Build.Utilities
         public TaskItem(
             ITaskItem sourceItem)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(sourceItem, nameof(sourceItem));
+            ErrorUtilities.VerifyThrowArgumentNull(sourceItem);
 
             // Attempt to preserve escaped state
             if (!(sourceItem is ITaskItem2 sourceItemAsITaskItem2))
@@ -243,7 +243,7 @@ namespace Microsoft.Build.Utilities
         /// <param name="metadataName">Name of metadata to remove.</param>
         public void RemoveMetadata(string metadataName)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(metadataName, nameof(metadataName));
+            ErrorUtilities.VerifyThrowArgumentNull(metadataName);
             ErrorUtilities.VerifyThrowArgument(!FileUtilities.ItemSpecModifiers.IsItemSpecModifier(metadataName),
                 "Shared.CannotChangeItemSpecModifiers", metadataName);
 
@@ -296,7 +296,7 @@ namespace Microsoft.Build.Utilities
         /// <param name="destinationItem">The item to copy metadata to.</param>
         public void CopyMetadataTo(ITaskItem destinationItem)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(destinationItem, nameof(destinationItem));
+            ErrorUtilities.VerifyThrowArgumentNull(destinationItem);
 
             // also copy the original item-spec under a "magic" metadata -- this is useful for tasks that forward metadata
             // between items, and need to know the source item where the metadata came from
@@ -419,7 +419,7 @@ namespace Microsoft.Build.Utilities
         /// <returns>The item-spec of the item.</returns>
         public static explicit operator string(TaskItem taskItemToCast)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(taskItemToCast, nameof(taskItemToCast));
+            ErrorUtilities.VerifyThrowArgumentNull(taskItemToCast);
             return taskItemToCast.ItemSpec;
         }
 
@@ -432,7 +432,7 @@ namespace Microsoft.Build.Utilities
         /// </summary>
         string ITaskItem2.GetMetadataValueEscaped(string metadataName)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(metadataName, nameof(metadataName));
+            ErrorUtilities.VerifyThrowArgumentNull(metadataName);
 
             string metadataValue = null;
 

--- a/src/Utilities/TaskItem.cs
+++ b/src/Utilities/TaskItem.cs
@@ -262,7 +262,7 @@ namespace Microsoft.Build.Utilities
             string metadataName,
             string metadataValue)
         {
-            ErrorUtilities.VerifyThrowArgumentLength(metadataName, nameof(metadataName));
+            ErrorUtilities.VerifyThrowArgumentLength(metadataName);
 
             // Non-derivable metadata can only be set at construction time.
             // That's why this is IsItemSpecModifier and not IsDerivableItemSpecModifier.

--- a/src/Utilities/ToolLocationHelper.cs
+++ b/src/Utilities/ToolLocationHelper.cs
@@ -461,7 +461,7 @@ namespace Microsoft.Build.Utilities
         private static IEnumerable<TargetPlatformSDK> GetTargetPlatformMonikers(string[] diskRoots, string[] extensionDiskRoots, string registryRoot, string targetPlatformIdentifier, Version targetPlatformVersion)
         {
             ErrorUtilities.VerifyThrowArgumentLength(targetPlatformIdentifier, nameof(targetPlatformIdentifier));
-            ErrorUtilities.VerifyThrowArgumentNull(targetPlatformVersion, nameof(targetPlatformVersion));
+            ErrorUtilities.VerifyThrowArgumentNull(targetPlatformVersion);
 
             string targetPlatformVersionString = targetPlatformVersion.ToString();
 
@@ -519,7 +519,7 @@ namespace Microsoft.Build.Utilities
         public static string GetPlatformExtensionSDKLocation(string sdkMoniker, string targetPlatformIdentifier, Version targetPlatformVersion, string[] diskRoots, string[] extensionDiskRoots, string registryRoot)
         {
             ErrorUtilities.VerifyThrowArgumentLength(targetPlatformIdentifier, nameof(targetPlatformIdentifier));
-            ErrorUtilities.VerifyThrowArgumentNull(targetPlatformVersion, nameof(targetPlatformVersion));
+            ErrorUtilities.VerifyThrowArgumentNull(targetPlatformVersion);
             ErrorUtilities.VerifyThrowArgumentLength(sdkMoniker, nameof(sdkMoniker));
 
             IEnumerable<TargetPlatformSDK> targetPlatforms = RetrieveTargetPlatformList(diskRoots, extensionDiskRoots, registryRoot);
@@ -583,7 +583,7 @@ namespace Microsoft.Build.Utilities
         [SuppressMessage("Microsoft.Naming", "CA1709:IdentifiersShouldBeCasedCorrectly", MessageId = "SDK", Justification = "Shipped this way in Dev11 Beta (go-live)")]
         public static string GetPlatformExtensionSDKLocation(string sdkMoniker, string targetPlatformIdentifier, string targetPlatformVersion, string diskRoots, string extensionDiskRoots, string registryRoot)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(targetPlatformVersion, nameof(targetPlatformVersion));
+            ErrorUtilities.VerifyThrowArgumentNull(targetPlatformVersion);
 
             string[] sdkDiskRoots = null;
             if (!string.IsNullOrEmpty(diskRoots))
@@ -1282,7 +1282,7 @@ namespace Microsoft.Build.Utilities
         [SuppressMessage("Microsoft.Naming", "CA1709:IdentifiersShouldBeCasedCorrectly", MessageId = "SDK", Justification = "Shipped this way in Dev11 Beta (go-live)")]
         public static string GetPlatformSDKLocation(string targetPlatformIdentifier, string targetPlatformVersion, string diskRoots, string registryRoot)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(targetPlatformVersion, nameof(targetPlatformVersion));
+            ErrorUtilities.VerifyThrowArgumentNull(targetPlatformVersion);
 
             string[] sdkDiskRoots = null;
             if (!string.IsNullOrEmpty(diskRoots))
@@ -1331,8 +1331,8 @@ namespace Microsoft.Build.Utilities
         /// <returns>A list of keys for the installed platforms for the given SDK</returns>
         public static IEnumerable<string> GetPlatformsForSDK(string sdkIdentifier, Version sdkVersion, string[] diskRoots, string registryRoot)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(sdkIdentifier, nameof(sdkIdentifier));
-            ErrorUtilities.VerifyThrowArgumentNull(sdkVersion, nameof(sdkVersion));
+            ErrorUtilities.VerifyThrowArgumentNull(sdkIdentifier);
+            ErrorUtilities.VerifyThrowArgumentNull(sdkVersion);
 
             IEnumerable<TargetPlatformSDK> targetPlatformSDKs = RetrieveTargetPlatformList(diskRoots, null, registryRoot);
 
@@ -1370,8 +1370,8 @@ namespace Microsoft.Build.Utilities
         /// <returns>The latest installed version for the given SDK</returns>
         public static string GetLatestSDKTargetPlatformVersion(string sdkIdentifier, string sdkVersion, string[] sdkRoots)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(sdkIdentifier, nameof(sdkIdentifier));
-            ErrorUtilities.VerifyThrowArgumentNull(sdkVersion, nameof(sdkVersion));
+            ErrorUtilities.VerifyThrowArgumentNull(sdkIdentifier);
+            ErrorUtilities.VerifyThrowArgumentNull(sdkVersion);
 
             var availablePlatformVersions = new List<Version>();
             IEnumerable<string> platformMonikerList = GetPlatformsForSDK(sdkIdentifier, new Version(sdkVersion), sdkRoots, null);
@@ -1554,7 +1554,7 @@ namespace Microsoft.Build.Utilities
         /// </summary>
         private static TargetPlatformSDK GetMatchingPlatformSDK(string targetPlatformIdentifier, string targetPlatformVersion, string diskRoots, string multiPlatformDiskRoots, string registryRoot)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(targetPlatformVersion, nameof(targetPlatformVersion));
+            ErrorUtilities.VerifyThrowArgumentNull(targetPlatformVersion);
 
             string[] sdkDiskRoots = null;
             if (!string.IsNullOrEmpty(diskRoots))
@@ -1583,7 +1583,7 @@ namespace Microsoft.Build.Utilities
         private static TargetPlatformSDK GetMatchingPlatformSDK(string targetPlatformIdentifier, Version targetPlatformVersion, string[] diskRoots, string[] multiPlatformDiskRoots, string registryRoot)
         {
             ErrorUtilities.VerifyThrowArgumentLength(targetPlatformIdentifier, nameof(targetPlatformIdentifier));
-            ErrorUtilities.VerifyThrowArgumentNull(targetPlatformVersion, nameof(targetPlatformVersion));
+            ErrorUtilities.VerifyThrowArgumentNull(targetPlatformVersion);
 
             IEnumerable<TargetPlatformSDK> targetPlatforms = RetrieveTargetPlatformList(diskRoots, multiPlatformDiskRoots, registryRoot);
 
@@ -1913,7 +1913,7 @@ namespace Microsoft.Build.Utilities
         {
             ErrorUtilities.VerifyThrowArgumentLength(targetFrameworkVersion, nameof(targetFrameworkVersion));
             ErrorUtilities.VerifyThrowArgumentLength(targetFrameworkIdentifier, nameof(targetFrameworkIdentifier));
-            ErrorUtilities.VerifyThrowArgumentNull(targetFrameworkProfile, nameof(targetFrameworkProfile));
+            ErrorUtilities.VerifyThrowArgumentNull(targetFrameworkProfile);
 
             Version frameworkVersion = ConvertTargetFrameworkVersionToVersion(targetFrameworkVersion);
             FrameworkNameVersioning targetFrameworkName = new FrameworkNameVersioning(targetFrameworkIdentifier, frameworkVersion, targetFrameworkProfile);
@@ -1933,7 +1933,7 @@ namespace Microsoft.Build.Utilities
         public static IList<string> GetPathToReferenceAssemblies(FrameworkNameVersioning frameworkName)
         {
             // Verify the framework class passed in is not null. Other than being null the class will ensure the framework moniker is correct
-            ErrorUtilities.VerifyThrowArgumentNull(frameworkName, nameof(frameworkName));
+            ErrorUtilities.VerifyThrowArgumentNull(frameworkName);
             IList<string> paths =
                 GetPathToReferenceAssemblies(
                     FrameworkLocationHelper.programFilesReferenceAssemblyLocation,
@@ -2213,7 +2213,7 @@ namespace Microsoft.Build.Utilities
             // Verify the root path is not null throw an ArgumentNullException if the given string parameter is null and ArgumentException if it has zero length.
             ErrorUtilities.VerifyThrowArgumentLength(targetFrameworkRootPath, nameof(targetFrameworkRootPath));
             // Verify the framework class passed in is not null. Other than being null the class will ensure it is consistent and the internal state is correct
-            ErrorUtilities.VerifyThrowArgumentNull(frameworkName, nameof(frameworkName));
+            ErrorUtilities.VerifyThrowArgumentNull(frameworkName);
 
             string referenceAssemblyCacheKey = GenerateReferenceAssemblyCacheKey(targetFrameworkRootPath, frameworkName);
             CreateReferenceAssemblyPathsCache();

--- a/src/Utilities/ToolLocationHelper.cs
+++ b/src/Utilities/ToolLocationHelper.cs
@@ -322,9 +322,9 @@ namespace Microsoft.Build.Utilities
         [SupportedOSPlatform("windows")]
         public static IList<AssemblyFoldersExInfo> GetAssemblyFoldersExInfo(string registryRoot, string targetFrameworkVersion, string registryKeySuffix, string osVersion, string platform, System.Reflection.ProcessorArchitecture targetProcessorArchitecture)
         {
-            ErrorUtilities.VerifyThrowArgumentLength(registryRoot, nameof(registryRoot));
-            ErrorUtilities.VerifyThrowArgumentLength(registryKeySuffix, nameof(registryKeySuffix));
-            ErrorUtilities.VerifyThrowArgumentLength(targetFrameworkVersion, nameof(targetFrameworkVersion));
+            ErrorUtilities.VerifyThrowArgumentLength(registryRoot);
+            ErrorUtilities.VerifyThrowArgumentLength(registryKeySuffix);
+            ErrorUtilities.VerifyThrowArgumentLength(targetFrameworkVersion);
 
             AssemblyFoldersEx assemblyFoldersEx = new AssemblyFoldersEx(registryRoot, targetFrameworkVersion, registryKeySuffix, osVersion, platform, new GetRegistrySubKeyNames(RegistryHelper.GetSubKeyNames), new GetRegistrySubKeyDefaultValue(RegistryHelper.GetDefaultValue), targetProcessorArchitecture, new OpenBaseKey(RegistryHelper.OpenBaseKey));
 
@@ -354,8 +354,8 @@ namespace Microsoft.Build.Utilities
         /// <returns>List of AssemblyFoldersFromConfigInfo</returns>
         public static IList<AssemblyFoldersFromConfigInfo> GetAssemblyFoldersFromConfigInfo(string configFile, string targetFrameworkVersion, System.Reflection.ProcessorArchitecture targetProcessorArchitecture)
         {
-            ErrorUtilities.VerifyThrowArgumentLength(configFile, nameof(configFile));
-            ErrorUtilities.VerifyThrowArgumentLength(targetFrameworkVersion, nameof(targetFrameworkVersion));
+            ErrorUtilities.VerifyThrowArgumentLength(configFile);
+            ErrorUtilities.VerifyThrowArgumentLength(targetFrameworkVersion);
 
             var assemblyFoldersInfos = new AssemblyFoldersFromConfig(configFile, targetFrameworkVersion, targetProcessorArchitecture);
 
@@ -460,7 +460,7 @@ namespace Microsoft.Build.Utilities
         /// </summary>
         private static IEnumerable<TargetPlatformSDK> GetTargetPlatformMonikers(string[] diskRoots, string[] extensionDiskRoots, string registryRoot, string targetPlatformIdentifier, Version targetPlatformVersion)
         {
-            ErrorUtilities.VerifyThrowArgumentLength(targetPlatformIdentifier, nameof(targetPlatformIdentifier));
+            ErrorUtilities.VerifyThrowArgumentLength(targetPlatformIdentifier);
             ErrorUtilities.VerifyThrowArgumentNull(targetPlatformVersion);
 
             string targetPlatformVersionString = targetPlatformVersion.ToString();
@@ -518,9 +518,9 @@ namespace Microsoft.Build.Utilities
         [SuppressMessage("Microsoft.Naming", "CA1709:IdentifiersShouldBeCasedCorrectly", MessageId = "SDK", Justification = "Shipped this way in Dev11 Beta (go-live)")]
         public static string GetPlatformExtensionSDKLocation(string sdkMoniker, string targetPlatformIdentifier, Version targetPlatformVersion, string[] diskRoots, string[] extensionDiskRoots, string registryRoot)
         {
-            ErrorUtilities.VerifyThrowArgumentLength(targetPlatformIdentifier, nameof(targetPlatformIdentifier));
+            ErrorUtilities.VerifyThrowArgumentLength(targetPlatformIdentifier);
             ErrorUtilities.VerifyThrowArgumentNull(targetPlatformVersion);
-            ErrorUtilities.VerifyThrowArgumentLength(sdkMoniker, nameof(sdkMoniker));
+            ErrorUtilities.VerifyThrowArgumentLength(sdkMoniker);
 
             IEnumerable<TargetPlatformSDK> targetPlatforms = RetrieveTargetPlatformList(diskRoots, extensionDiskRoots, registryRoot);
             var targetPlatformMoniker = targetPlatforms.Where<TargetPlatformSDK>(
@@ -650,9 +650,9 @@ namespace Microsoft.Build.Utilities
         [SuppressMessage("Microsoft.Naming", "CA1709:IdentifiersShouldBeCasedCorrectly", MessageId = "SDK", Justification = "Shipped this way in Dev11 Beta (go-live)")]
         public static IList<string> GetSDKReferenceFolders(string sdkRoot, string targetConfiguration, string targetArchitecture)
         {
-            ErrorUtilities.VerifyThrowArgumentLength(sdkRoot, nameof(sdkRoot));
-            ErrorUtilities.VerifyThrowArgumentLength(targetConfiguration, nameof(targetConfiguration));
-            ErrorUtilities.VerifyThrowArgumentLength(targetArchitecture, nameof(targetArchitecture));
+            ErrorUtilities.VerifyThrowArgumentLength(sdkRoot);
+            ErrorUtilities.VerifyThrowArgumentLength(targetConfiguration);
+            ErrorUtilities.VerifyThrowArgumentLength(targetArchitecture);
 
             var referenceDirectories = new List<string>(4);
 
@@ -714,9 +714,9 @@ namespace Microsoft.Build.Utilities
         [SuppressMessage("Microsoft.Naming", "CA1709:IdentifiersShouldBeCasedCorrectly", MessageId = "SDK", Justification = "Shipped this way in Dev11 Beta (go-live)")]
         public static IList<string> GetSDKRedistFolders(string sdkRoot, string targetConfiguration, string targetArchitecture)
         {
-            ErrorUtilities.VerifyThrowArgumentLength(sdkRoot, nameof(sdkRoot));
-            ErrorUtilities.VerifyThrowArgumentLength(targetConfiguration, nameof(targetConfiguration));
-            ErrorUtilities.VerifyThrowArgumentLength(targetArchitecture, nameof(targetArchitecture));
+            ErrorUtilities.VerifyThrowArgumentLength(sdkRoot);
+            ErrorUtilities.VerifyThrowArgumentLength(targetConfiguration);
+            ErrorUtilities.VerifyThrowArgumentLength(targetArchitecture);
 
             var redistDirectories = new List<string>(4);
 
@@ -744,9 +744,9 @@ namespace Microsoft.Build.Utilities
         [SuppressMessage("Microsoft.Naming", "CA1709:IdentifiersShouldBeCasedCorrectly", MessageId = "SDK", Justification = "Shipped this way in Dev11 Beta (go-live)")]
         public static IList<string> GetSDKDesignTimeFolders(string sdkRoot, string targetConfiguration, string targetArchitecture)
         {
-            ErrorUtilities.VerifyThrowArgumentLength(sdkRoot, nameof(sdkRoot));
-            ErrorUtilities.VerifyThrowArgumentLength(targetConfiguration, nameof(targetConfiguration));
-            ErrorUtilities.VerifyThrowArgumentLength(targetArchitecture, nameof(targetArchitecture));
+            ErrorUtilities.VerifyThrowArgumentLength(sdkRoot);
+            ErrorUtilities.VerifyThrowArgumentLength(targetConfiguration);
+            ErrorUtilities.VerifyThrowArgumentLength(targetArchitecture);
 
             var designTimeDirectories = new List<string>(4);
 
@@ -821,8 +821,8 @@ namespace Microsoft.Build.Utilities
         /// <returns>Location of the target platform SDK props file without .props filename</returns>
         public static string GetPlatformSDKPropsFileLocation(string sdkIdentifier, string sdkVersion, string targetPlatformIdentifier, string targetPlatformMinVersion, string targetPlatformVersion, string diskRoots, string registryRoot)
         {
-            ErrorUtilities.VerifyThrowArgumentLength(targetPlatformIdentifier, nameof(targetPlatformIdentifier));
-            ErrorUtilities.VerifyThrowArgumentLength(targetPlatformVersion, nameof(targetPlatformVersion));
+            ErrorUtilities.VerifyThrowArgumentLength(targetPlatformIdentifier);
+            ErrorUtilities.VerifyThrowArgumentLength(targetPlatformVersion);
 
             string propsFileLocation;
             try
@@ -1020,8 +1020,8 @@ namespace Microsoft.Build.Utilities
         /// </summary>
         private static string[] GetLegacyTargetPlatformReferences(string targetPlatformIdentifier, string targetPlatformVersion, string diskRoots, string registryRoot)
         {
-            ErrorUtilities.VerifyThrowArgumentLength(targetPlatformIdentifier, nameof(targetPlatformIdentifier));
-            ErrorUtilities.VerifyThrowArgumentLength(targetPlatformVersion, nameof(targetPlatformVersion));
+            ErrorUtilities.VerifyThrowArgumentLength(targetPlatformIdentifier);
+            ErrorUtilities.VerifyThrowArgumentLength(targetPlatformVersion);
 
             try
             {
@@ -1076,10 +1076,10 @@ namespace Microsoft.Build.Utilities
                 string diskRoots,
                 string registryRoot)
         {
-            ErrorUtilities.VerifyThrowArgumentLength(sdkIdentifier, nameof(sdkIdentifier));
-            ErrorUtilities.VerifyThrowArgumentLength(sdkVersion, nameof(sdkVersion));
-            ErrorUtilities.VerifyThrowArgumentLength(targetPlatformIdentifier, nameof(targetPlatformIdentifier));
-            ErrorUtilities.VerifyThrowArgumentLength(targetPlatformVersion, nameof(targetPlatformVersion));
+            ErrorUtilities.VerifyThrowArgumentLength(sdkIdentifier);
+            ErrorUtilities.VerifyThrowArgumentLength(sdkVersion);
+            ErrorUtilities.VerifyThrowArgumentLength(targetPlatformIdentifier);
+            ErrorUtilities.VerifyThrowArgumentLength(targetPlatformVersion);
 
             string[] contractWinMDs = [];
 
@@ -1203,8 +1203,8 @@ namespace Microsoft.Build.Utilities
               string folderName,
               string diskRoot = null)
         {
-            ErrorUtilities.VerifyThrowArgumentLength(sdkIdentifier, nameof(sdkIdentifier));
-            ErrorUtilities.VerifyThrowArgumentLength(sdkVersion, nameof(sdkVersion));
+            ErrorUtilities.VerifyThrowArgumentLength(sdkIdentifier);
+            ErrorUtilities.VerifyThrowArgumentLength(sdkVersion);
 
             // Avoid exception in Path.Combine
             if (folderName == null)
@@ -1219,8 +1219,8 @@ namespace Microsoft.Build.Utilities
                 return Path.Combine(sdkLocation, folderName);
             }
 
-            ErrorUtilities.VerifyThrowArgumentLength(targetPlatformIdentifier, nameof(targetPlatformIdentifier));
-            ErrorUtilities.VerifyThrowArgumentLength(targetPlatformVersion, nameof(targetPlatformVersion));
+            ErrorUtilities.VerifyThrowArgumentLength(targetPlatformIdentifier);
+            ErrorUtilities.VerifyThrowArgumentLength(targetPlatformVersion);
 
             string sdkContentFolderPath = null;
 
@@ -1582,7 +1582,7 @@ namespace Microsoft.Build.Utilities
         /// </summary>
         private static TargetPlatformSDK GetMatchingPlatformSDK(string targetPlatformIdentifier, Version targetPlatformVersion, string[] diskRoots, string[] multiPlatformDiskRoots, string registryRoot)
         {
-            ErrorUtilities.VerifyThrowArgumentLength(targetPlatformIdentifier, nameof(targetPlatformIdentifier));
+            ErrorUtilities.VerifyThrowArgumentLength(targetPlatformIdentifier);
             ErrorUtilities.VerifyThrowArgumentNull(targetPlatformVersion);
 
             IEnumerable<TargetPlatformSDK> targetPlatforms = RetrieveTargetPlatformList(diskRoots, multiPlatformDiskRoots, registryRoot);
@@ -1808,8 +1808,8 @@ namespace Microsoft.Build.Utilities
         /// <returns>Collection of reference assembly locations.</returns>
         public static string GetPathToStandardLibraries(string targetFrameworkIdentifier, string targetFrameworkVersion, string targetFrameworkProfile, string platformTarget, string targetFrameworkRootPath, string targetFrameworkFallbackSearchPaths)
         {
-            ErrorUtilities.VerifyThrowArgumentLength(targetFrameworkIdentifier, nameof(targetFrameworkIdentifier));
-            ErrorUtilities.VerifyThrowArgumentLength(targetFrameworkVersion, nameof(targetFrameworkVersion));
+            ErrorUtilities.VerifyThrowArgumentLength(targetFrameworkIdentifier);
+            ErrorUtilities.VerifyThrowArgumentLength(targetFrameworkVersion);
 
             Version frameworkVersion = ConvertTargetFrameworkVersionToVersion(targetFrameworkVersion);
             // For .net framework less than 4 the mscorlib should be found in the .net 2.0 directory
@@ -1911,8 +1911,8 @@ namespace Microsoft.Build.Utilities
         /// <returns>Collection of reference assembly locations.</returns>
         public static IList<string> GetPathToReferenceAssemblies(string targetFrameworkIdentifier, string targetFrameworkVersion, string targetFrameworkProfile, string targetFrameworkRootPath, string targetFrameworkFallbackSearchPaths)
         {
-            ErrorUtilities.VerifyThrowArgumentLength(targetFrameworkVersion, nameof(targetFrameworkVersion));
-            ErrorUtilities.VerifyThrowArgumentLength(targetFrameworkIdentifier, nameof(targetFrameworkIdentifier));
+            ErrorUtilities.VerifyThrowArgumentLength(targetFrameworkVersion);
+            ErrorUtilities.VerifyThrowArgumentLength(targetFrameworkIdentifier);
             ErrorUtilities.VerifyThrowArgumentNull(targetFrameworkProfile);
 
             Version frameworkVersion = ConvertTargetFrameworkVersionToVersion(targetFrameworkVersion);
@@ -2211,7 +2211,7 @@ namespace Microsoft.Build.Utilities
         public static IList<string> GetPathToReferenceAssemblies(string targetFrameworkRootPath, FrameworkNameVersioning frameworkName)
         {
             // Verify the root path is not null throw an ArgumentNullException if the given string parameter is null and ArgumentException if it has zero length.
-            ErrorUtilities.VerifyThrowArgumentLength(targetFrameworkRootPath, nameof(targetFrameworkRootPath));
+            ErrorUtilities.VerifyThrowArgumentLength(targetFrameworkRootPath);
             // Verify the framework class passed in is not null. Other than being null the class will ensure it is consistent and the internal state is correct
             ErrorUtilities.VerifyThrowArgumentNull(frameworkName);
 
@@ -3660,8 +3660,8 @@ namespace Microsoft.Build.Utilities
         /// </summary>
         public static FrameworkNameVersioning HighestVersionOfTargetFrameworkIdentifier(string targetFrameworkRootDirectory, string frameworkIdentifier)
         {
-            ErrorUtilities.VerifyThrowArgumentLength(targetFrameworkRootDirectory, nameof(targetFrameworkRootDirectory));
-            ErrorUtilities.VerifyThrowArgumentLength(frameworkIdentifier, nameof(frameworkIdentifier));
+            ErrorUtilities.VerifyThrowArgumentLength(targetFrameworkRootDirectory);
+            ErrorUtilities.VerifyThrowArgumentLength(frameworkIdentifier);
 
             string key = targetFrameworkRootDirectory + ";" + frameworkIdentifier;
             FrameworkNameVersioning highestFrameworkName = null;

--- a/src/Utilities/TrackedDependencies/CanonicalTrackedOutputFiles.cs
+++ b/src/Utilities/TrackedDependencies/CanonicalTrackedOutputFiles.cs
@@ -272,7 +272,7 @@ namespace Microsoft.Build.Utilities
         /// <returns>An array of the rooting markers that were removed.</returns>
         public string[] RemoveRootsWithSharedOutputs(ITaskItem[] sources)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(sources, nameof(sources));
+            ErrorUtilities.VerifyThrowArgumentNull(sources);
 
             var removedMarkers = new List<string>();
             string currentRoot = FileTracker.FormatRootingMarker(sources);

--- a/src/Utilities/TrackedDependencies/FileTracker.cs
+++ b/src/Utilities/TrackedDependencies/FileTracker.cs
@@ -310,7 +310,7 @@ namespace Microsoft.Build.Utilities
         /// <param name="outputs">ITaskItem array of outputs.</param>
         public static string FormatRootingMarker(ITaskItem[] sources, ITaskItem[] outputs)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(sources, nameof(sources));
+            ErrorUtilities.VerifyThrowArgumentNull(sources);
 
             // So we don't have to deal with null checks.
             outputs ??= Array.Empty<ITaskItem>();
@@ -729,7 +729,7 @@ namespace Microsoft.Build.Utilities
             // Only log when we have been passed a TaskLoggingHelper
             if (Log != null)
             {
-                ErrorUtilities.VerifyThrowArgumentNull(messageResourceName, nameof(messageResourceName));
+                ErrorUtilities.VerifyThrowArgumentNull(messageResourceName);
 
                 Log.LogMessage(importance, AssemblyResources.GetString(messageResourceName), messageArgs);
             }


### PR DESCRIPTION
[`CallerArgumentExpression`](https://learn.microsoft.com/dotnet/csharp/language-reference/proposals/csharp-10.0/caller-argument-expression) is a new (C# 10) language feature that allows us to simplify a bunch of our assert-like code to drop the redundant specifications of, like, "which argument is `null`?".

I *strongly* recommend reviewing commit-by-commit; the bulk of the changes are a regex replace on top of a framework that is fairly small.