### PR TITLE
Remove Conversion.Core registrations

### DIFF
--- a/src/Deprecated/Conversion/Microsoft.Build.Conversion.Core.pkgdef
+++ b/src/Deprecated/Conversion/Microsoft.Build.Conversion.Core.pkgdef
@@ -1,7 +1,0 @@
-[$RootKey$\RuntimeConfiguration\dependentAssembly\bindingRedirection\{69CFFD1A-343F-46C5-81B3-8437CD1272CD}]
-"name"="Microsoft.Build.Conversion.Core"
-"codeBase"="$BaseInstallDir$\MSBuild\Current\Bin\Microsoft.Build.Conversion.Core.dll"
-"publicKeyToken"="b03f5f7f11d50a3a"
-"culture"="neutral"
-"oldVersion"="0.0.0.0-99.9.9.9"
-"newVersion"="15.1.0.0"

--- a/src/Package/DevDivPackage/DevDivPackage.csproj
+++ b/src/Package/DevDivPackage/DevDivPackage.csproj
@@ -14,7 +14,6 @@
   <ItemGroup>
     <ProjectReference Include="..\..\MSBuild\MSBuild.csproj" />
     <ProjectReference Include="..\..\Framework\Microsoft.Build.Framework.csproj" />
-    <ProjectReference Include="..\..\Deprecated\Conversion\Microsoft.Build.Conversion.csproj" />
     <ProjectReference Include="..\..\Deprecated\Engine\Microsoft.Build.Engine.csproj" />
   </ItemGroup>
 

--- a/src/Package/DevDivPackage/VS.ExternalAPIs.MSBuild.nuspec
+++ b/src/Package/DevDivPackage/VS.ExternalAPIs.MSBuild.nuspec
@@ -22,7 +22,6 @@
 
     <!-- Obsolete but still referenced in the VS repo -->
     <file src="Microsoft.Build.Engine.dll" target="lib\net472" />
-    <file src="Microsoft.Build.Conversion.Core.dll" target="lib\net472" />
 
     <file src="Microsoft.Build.tlb" target="lib\net472" />
     <file src="Microsoft.Build.Framework.tlb" target="lib\net472" />

--- a/src/Package/GetBinPaths.targets
+++ b/src/Package/GetBinPaths.targets
@@ -19,11 +19,6 @@
                       ReferenceOutputAssembly="false"
                       OutputItemType="MSBuildTaskHostResolvedProjectReferencePath" />
 
-    <ProjectReference Include="$(MSBuildThisFileDirectory)\..\Deprecated\Conversion\Microsoft.Build.Conversion.csproj"
-                      Private="false"
-                      ReferenceOutputAssembly="false"
-                      OutputItemType="MSBuildConversionResolvedProjectReferencePath" />
-
     <!-- Set up items to build projects where the Platform is set to x64, when we need the x64 versions of the files.
          We have to treat these separately from normal project references, as the AssignProjectConfiguration task would overwrite
          the SetPlatform item metadata if they were ProjectReferences.
@@ -54,7 +49,6 @@
       <FrameworkBinPath>@(FrameworkResolvedProjectReferencePath->'%(RootDir)%(Directory)')</FrameworkBinPath>
       <MSBuildTaskHostBinPath>@(MSBuildTaskHostResolvedProjectReferencePath->'%(RootDir)%(Directory)')</MSBuildTaskHostBinPath>
       <MSBuildTaskHostX64BinPath>@(MSBuildTaskHostX64ResolvedProjectReferencePath->'%(RootDir)%(Directory)')</MSBuildTaskHostX64BinPath>
-      <MSBuildConversionBinPath>@(MSBuildConversionResolvedProjectReferencePath->'%(RootDir)%(Directory)')</MSBuildConversionBinPath>
     </PropertyGroup>
   </Target>
 

--- a/src/Package/MSBuild.VSSetup/MSBuild.VSSetup.csproj
+++ b/src/Package/MSBuild.VSSetup/MSBuild.VSSetup.csproj
@@ -37,7 +37,6 @@
       <SwrProperty Include="FrameworkBinPath=$(FrameworkBinPath)" />
       <SwrProperty Include="TaskHostBinPath=$(MSBuildTaskHostBinPath)" />
       <SwrProperty Include="TaskHostX64BinPath=$(MSBuildTaskHostX64BinPath)" />
-      <SwrProperty Include="MSBuildConversionBinPath=$(MSBuildConversionBinPath)" />
     </ItemGroup>
   </Target>
 

--- a/src/Package/MSBuild.VSSetup/MSBuild.clientenabledpkg
+++ b/src/Package/MSBuild.VSSetup/MSBuild.clientenabledpkg
@@ -3,5 +3,4 @@ Microsoft.Build.pkgdef
 Microsoft.Build.Tasks.Core.pkgdef
 System.Resources.Extensions.pkgdef
 Microsoft.Build.Utilities.Core.pkgdef
-Microsoft.Build.Conversion.Core.pkgdef
 Microsoft.Build.Engine.pkgdef

--- a/src/Package/MSBuild.VSSetup/files.swr
+++ b/src/Package/MSBuild.VSSetup/files.swr
@@ -26,9 +26,7 @@ folder InstallDir:\MSBuild\Current
   file source=$(ThirdPartyNotice)
 
 folder InstallDir:\MSBuild\Current\Bin
-  file source=$(MSBuildConversionBinPath)Microsoft.Build.Conversion.Core.dll vs.file.ngenApplications="[installDir]\Common7\IDE\vsn.exe" vs.file.ngenApplications="[installDir]\MSBuild\Current\Bin\MSBuild.exe" vs.file.ngenArchitecture=all
   file source=$(X86BinPath)Microsoft.Build.dll vs.file.ngenApplications="[installDir]\Common7\IDE\vsn.exe" vs.file.ngenApplications="[installDir]\MSBuild\Current\Bin\MSBuild.exe" vs.file.ngenArchitecture=all vs.file.ngenPriority=1
-  file source=$(MSBuildConversionBinPath)Microsoft.Build.Engine.dll vs.file.ngenApplications="[installDir]\Common7\IDE\vsn.exe" vs.file.ngenApplications="[installDir]\MSBuild\Current\Bin\MSBuild.exe" vs.file.ngenArchitecture=all
   file source=$(X86BinPath)Microsoft.Build.Framework.dll vs.file.ngenApplications="[installDir]\Common7\IDE\vsn.exe" vs.file.ngenApplications="[installDir]\MSBuild\Current\Bin\MSBuild.exe" vs.file.ngenArchitecture=all
   file source=$(X86BinPath)Microsoft.Build.Framework.tlb
   file source=$(X86BinPath)Microsoft.Build.Tasks.Core.dll vs.file.ngenApplications="[installDir]\Common7\IDE\vsn.exe" vs.file.ngenApplications="[installDir]\MSBuild\Current\Bin\MSBuild.exe" vs.file.ngenArchitecture=all vs.file.ngenPriority=1
@@ -184,9 +182,7 @@ folder InstallDir:\MSBuild\Current\Bin\amd64
   file source=$(X64BinPath)MSBuild.exe.config
   file source=$(TaskHostX64BinPath)MSBuildTaskHost.exe.config
 
-  file source=$(MSBuildConversionBinPath)Microsoft.Build.Conversion.Core.dll vs.file.ngenArchitecture=all
   file source=$(X86BinPath)Microsoft.Build.dll vs.file.ngenArchitecture=all
-  file source=$(MSBuildConversionBinPath)Microsoft.Build.Engine.dll vs.file.ngenArchitecture=all
   file source=$(X86BinPath)Microsoft.Build.Framework.dll vs.file.ngenArchitecture=all
   file source=$(FrameworkBinPath)x64\Microsoft.Build.Framework.tlb
   file source=$(X86BinPath)Microsoft.Build.Tasks.Core.dll vs.file.ngenArchitecture=all
@@ -335,5 +331,4 @@ folder InstallDir:\Common7\IDE\CommonExtensions\MSBuild
   file source=$(SourceDir)Tasks\Microsoft.Build.Tasks.Core.pkgdef
   file source=$(SourceDir)Tasks\System.Resources.Extensions.pkgdef
   file source=$(SourceDir)Utilities\Microsoft.Build.Utilities.Core.pkgdef
-  file source=$(SourceDir)Deprecated\Conversion\Microsoft.Build.Conversion.Core.pkgdef
   file source=$(SourceDir)Deprecated\Engine\Microsoft.Build.Engine.pkgdef


### PR DESCRIPTION
Contributes to #8826

### Context
Microsoft.Build.Conversion.Core was removed in VS codebase by https://devdiv.visualstudio.com/DevDiv/_git/VS/pullrequest/583701 However Microsoft.Build component still keeps dragging the binary to the VS install. Let's make sure Microsoft.Build.Conversion.Core.dll is not part of the VS install before we remove the code alltogether

### Changes Made
Removing the registrations of Microsoft.Build.Conversion.Core, that contributes to VS install
