### PR TITLE
CG alert cleaning on VS17.0

### DIFF
--- a/eng/Packages.props
+++ b/eng/Packages.props
@@ -26,6 +26,7 @@
     <PackageReference Update="System.CodeDom" Version="4.4.0" />
     <PackageReference Update="System.Collections.Immutable" Version="5.0.0" />
     <PackageReference Update="System.Configuration.ConfigurationManager" Version="4.7.0" />
+    <PackageReference Update="System.Formats.Asn1" Version="$(SystemFormatsAsn1Version)" />
     <PackageReference Update="System.Net.Http" Version="4.3.4" />
     <PackageReference Update="System.Memory" Version="4.5.4" />
     <PackageReference Update="System.Reflection.Metadata" Version="1.6.0" />

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -22,5 +22,9 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>e438144bbffb29ed5d7c113dc4947b51650344dc</Sha>
     </Dependency>
+    <Dependency Name="System.Formats.Asn1" Version="6.0.1">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha />
+    </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -26,6 +26,7 @@
   <!-- Production Dependencies -->
   <PropertyGroup>
     <SystemResourcesExtensionsPackageVersion>4.6.0</SystemResourcesExtensionsPackageVersion>
+    <SystemFormatsAsn1Version>8.0.1</SystemFormatsAsn1Version>
   </PropertyGroup>
   <!-- Toolset Dependencies -->
   <PropertyGroup>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,7 +2,8 @@
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the MIT license. See License.txt in the project root for full license information. -->
 <Project>
   <PropertyGroup>
-    <VersionPrefix>17.0.4</VersionPrefix><DotNetFinalVersionKind>release</DotNetFinalVersionKind>
+    <VersionPrefix>17.0.4</VersionPrefix>
+    <DotNetFinalVersionKind>release</DotNetFinalVersionKind>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
     <DotNetUseShippingVersions>true</DotNetUseShippingVersions>
@@ -26,7 +27,7 @@
   <!-- Production Dependencies -->
   <PropertyGroup>
     <SystemResourcesExtensionsPackageVersion>4.6.0</SystemResourcesExtensionsPackageVersion>
-    <SystemFormatsAsn1Version>8.0.1</SystemFormatsAsn1Version>
+    <SystemFormatsAsn1Version>6.0.1</SystemFormatsAsn1Version>
   </PropertyGroup>
   <!-- Toolset Dependencies -->
   <PropertyGroup>

--- a/src/MSBuild.Bootstrap/MSBuild.Bootstrap.csproj
+++ b/src/MSBuild.Bootstrap/MSBuild.Bootstrap.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>$(RuntimeOutputTargetFrameworks)</TargetFrameworks>
@@ -22,6 +22,8 @@
     <!-- This is because according to semver, 2.1.0-preview is not >= 2.1.0 -->
     <Content Include="$(RepoRoot).dotnet\sdk\$(DotNetCliVersion)\Microsoft.NETCoreSdk.BundledVersions.props" CopyToOutputDirectory="PreserveNewest" />
 
+    <PackageReference Include="System.Formats.Asn1" />
+    
     <!-- Include NuGet build tasks -->
     <PackageReference Include="NuGet.Build.Tasks" />
     <PackageReference Include="Microsoft.Build.NuGetSdkResolver" />

--- a/src/Tasks/Microsoft.Build.Tasks.csproj
+++ b/src/Tasks/Microsoft.Build.Tasks.csproj
@@ -989,6 +989,7 @@
     <ProjectReference Include="..\StringTools\StringTools.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="System.Formats.Asn1" />
     <PackageReference Include="System.Collections.Immutable" />
     <PackageReference Include="System.Resources.Extensions" />
   </ItemGroup>


### PR DESCRIPTION
Fixes #
CVE-2024-38095

Summary
MSBuild 17.0 uses dependency with known vulnerabilities.

Customer Impact
Using software without known vulnerabilities.

Regression?
No.

Testing
Existing automated tests.

Risk
Low - there are no functional changes.

Changes Made
Upgrade System.Formats.Asn1 from 6.0.0 to 6.0.1.