### PR TITLE
Fix build with langversion preview

### DIFF
--- a/src/Build/Definition/ToolsetRegistryReader.cs
+++ b/src/Build/Definition/ToolsetRegistryReader.cs
@@ -11,7 +11,6 @@ using Microsoft.Build.Execution;
 using Microsoft.Build.Internal;
 using Microsoft.Build.Shared;
 using Constants = Microsoft.Build.Internal.Constants;
-using error = Microsoft.Build.Shared.ErrorUtilities;
 using InvalidToolsetDefinitionException = Microsoft.Build.Exceptions.InvalidToolsetDefinitionException;
 using RegistryException = Microsoft.Build.Exceptions.RegistryException;
 using RegistryKeyWrapper = Microsoft.Build.Internal.RegistryKeyWrapper;
@@ -63,7 +62,7 @@ namespace Microsoft.Build.Evaluation
         internal ToolsetRegistryReader(PropertyDictionary<ProjectPropertyInstance> environmentProperties, PropertyDictionary<ProjectPropertyInstance> globalProperties, RegistryKeyWrapper msbuildRegistryWrapper)
             : base(environmentProperties, globalProperties)
         {
-            error.VerifyThrowArgumentNull(msbuildRegistryWrapper, nameof(msbuildRegistryWrapper));
+            ErrorUtilities.VerifyThrowArgumentNull(msbuildRegistryWrapper, nameof(msbuildRegistryWrapper));
 
             _msbuildRegistryWrapper = msbuildRegistryWrapper;
         }

--- a/src/Build/Evaluation/Profiler/EvaluationLocationPrettyPrinterBase.cs
+++ b/src/Build/Evaluation/Profiler/EvaluationLocationPrettyPrinterBase.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Build.Evaluation
         protected void AppendDefaultHeaderWithSeparator(StringBuilder stringBuilder, string separator)
         {
             stringBuilder.AppendLine(
-                string.Join(separator, ["Id", "ParentId", "Pass", "File", "Line #", "Expression", "Inc (ms)", "Inc (%)", "Exc (ms)",
+                string.Join(separator, (string[])["Id", "ParentId", "Pass", "File", "Line #", "Expression", "Inc (ms)", "Inc (%)", "Exc (ms)",
                         "Exc (%)", "#", "Kind", "Bug"]));
         }
 

--- a/src/Build/Evaluation/Profiler/EvaluationLocationPrettyPrinterBase.cs
+++ b/src/Build/Evaluation/Profiler/EvaluationLocationPrettyPrinterBase.cs
@@ -75,8 +75,8 @@ namespace Microsoft.Build.Evaluation
         protected void AppendDefaultHeaderWithSeparator(StringBuilder stringBuilder, string separator)
         {
             stringBuilder.AppendLine(
-                string.Join(separator, (string[])["Id", "ParentId", "Pass", "File", "Line #", "Expression", "Inc (ms)", "Inc (%)", "Exc (ms)",
-                        "Exc (%)", "#", "Kind", "Bug"]));
+                string.Join(separator, "Id", "ParentId", "Pass", "File", "Line #", "Expression", "Inc (ms)", "Inc (%)", "Exc (ms)",
+                        "Exc (%)", "#", "Kind", "Bug"));
         }
 
         /// <summary>


### PR DESCRIPTION
> /vmr/src/msbuild/src/Build/Evaluation/Profiler/EvaluationLocationPrettyPrinterBase.cs(78,24): error CS0121: The call is ambiguous between the following methods or properties: 'string.Join(string?, params ReadOnlySpan<object?>)' and 'string.Join(string?, params ReadOnlySpan<string?>)' [/vmr/src/msbuild/src/Build/Microsoft.Build.csproj::TargetFramework=net9.0]

pr https://github.com/dotnet/sdk/pull/44011/checks?check_run_id=31628922599
build https://dev.azure.com/dnceng-public/public/_build/results?buildId=844822&view=logs&jobId=f0f4e1eb-2872-579b-17f7-75dc26fbb285&j=f0f4e1eb-2872-579b-17f7-75dc26fbb285&t=e5ca527a-fe4f-597c-4330-d9b726220892