### PR TITLE
Update source-build team references

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,8 @@
 # Users referenced in this file will automatically be requested as reviewers for PRs that modify the given paths.
 # See https://help.github.com/articles/about-code-owners/
 
-/eng/SourceBuild*       @dotnet/source-build-internal
+/eng/DotNetBuild.props  @dotnet/product-construction
+/eng/SourceBuild*       @dotnet/source-build
 /eng/                   @dotnet/kitten
 /.github/               @dotnet/kitten
 /global.json            @dotnet/kitten

--- a/eng/DotNetBuild.props
+++ b/eng/DotNetBuild.props
@@ -1,4 +1,4 @@
-<!-- Whenever altering this or other Source Build files, please include @dotnet/source-build-internal as a reviewer. -->
+<!-- When altering this file, include @dotnet/product-construction as a reviewer. -->
 
 <Project>
 

--- a/eng/SourceBuildPrebuiltBaseline.xml
+++ b/eng/SourceBuildPrebuiltBaseline.xml
@@ -1,4 +1,4 @@
-<!-- Whenever altering this or other Source Build files, please include @dotnet/source-build-internal as a reviewer. -->
+<!-- When altering this file or making other Source Build related changes, include @dotnet/source-build as a reviewer. -->
 <!-- See aka.ms/dotnet/prebuilts for guidance on what pre-builts are and how to eliminate them. -->
 
 <UsageData>


### PR DESCRIPTION
The @dotnet/source-build-internal team is being deprecated. All references to it were updated.

Related to https://github.com/dotnet/source-build/issues/4645

Repo admins, please grant @dotnet/product-construction and @dotnet/source-build write access. You can remove access granted to @dotnet/source-build-internal.