### PR TITLE
Register Microsoft.VisualStudio.SolutionPersistence for VS

### DIFF
--- a/documentation/wiki/UnGAC.md
+++ b/documentation/wiki/UnGAC.md
@@ -24,6 +24,7 @@ Run the [EnumerateMSBuild powershell script](https://github.com/dotnet/msbuild/b
     gacutil /u "BuildXL.Processes, Version=1.0.0.0"
     gacutil /u "BuildXL.Utilities.Core, Version=1.0.0.0"
     gacutil /u "BuildXL.Native, Version=1.0.0.0"
+    gacutil /u "Microsoft.VisualStudio.SolutionPersistence, Version=1.0.0.0"
     ```
 3. If you want to do this 'safely', move the folder out of the GAC and return it if it doesn't resolve the issue.
 

--- a/src/Build/Microsoft.Build.pkgdef
+++ b/src/Build/Microsoft.Build.pkgdef
@@ -29,3 +29,11 @@
 "culture"="neutral"
 "oldVersion"="0.0.0.0-1.0.0.0"
 "newVersion"="1.0.0.0"
+
+[$RootKey$\RuntimeConfiguration\dependentAssembly\bindingRedirection\{AA8C2479-DD4C-45C2-A591-E656F1B7D90A}]
+"name"="Microsoft.VisualStudio.SolutionPersistence"
+"codeBase"="$BaseInstallDir$\MSBuild\Current\Bin\Microsoft.VisualStudio.SolutionPersistence.dll"
+"publicKeyToken"="b03f5f7f11d50a3a"
+"culture"="neutral"
+"oldVersion"="0.0.0.0-1.0.0.0"
+"newVersion"="1.0.0.0"

--- a/src/MSBuild/app.amd64.config
+++ b/src/MSBuild/app.amd64.config
@@ -67,6 +67,10 @@
           <codeBase version="1.0.0.0" href="..\BuildXL.Utilities.Core.dll"/>
         </dependentAssembly>
         <dependentAssembly>
+          <assemblyIdentity name="Microsoft.VisualStudio.SolutionPersistence" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+          <codeBase version="1.0.0.0" href="..\Microsoft.VisualStudio.SolutionPersistence.dll"/>
+        </dependentAssembly>
+        <dependentAssembly>
           <assemblyIdentity name="Microsoft.Bcl.AsyncInterfaces" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
           <bindingRedirect oldVersion="0.0.0.0-8.0.0.0" newVersion="8.0.0.0" />
           <codeBase version="8.0.0.0" href="..\Microsoft.Bcl.AsyncInterfaces.dll"/>

--- a/src/Package/MSBuild.VSSetup/files.swr
+++ b/src/Package/MSBuild.VSSetup/files.swr
@@ -39,6 +39,7 @@ folder InstallDir:\MSBuild\Current\Bin
   file source=$(X86BinPath)BuildXL.Native.dll
   file source=$(X86BinPath)BuildXL.Processes.dll
   file source=$(X86BinPath)BuildXL.Utilities.Core.dll
+  file source=$(X86BinPath)Microsoft.VisualStudio.SolutionPersistence.dll
   file source=$(X86BinPath)RuntimeContracts.dll
   file source=$(X86BinPath)System.Buffers.dll vs.file.ngenApplications="[installDir]\MSBuild\Current\Bin\MSBuild.exe" vs.file.ngenArchitecture=all vs.file.ngenPriority=1
   file source=$(X86BinPath)System.Memory.dll vs.file.ngenApplications="[installDir]\MSBuild\Current\Bin\MSBuild.exe" vs.file.ngenArchitecture=all vs.file.ngenPriority=1

--- a/src/Package/Microsoft.Build.UnGAC/Program.cs
+++ b/src/Package/Microsoft.Build.UnGAC/Program.cs
@@ -30,7 +30,8 @@ namespace Microsoft.Build.UnGAC
                     "Microsoft.NET.StringTools, Version=1.0.0.0",
                     "BuildXL.Processes, Version=1.0.0.0",
                     "BuildXL.Utilities.Core, Version=1.0.0.0",
-                    "BuildXL.Native, Version=1.0.0.0"
+                    "BuildXL.Native, Version=1.0.0.0",
+                    "Microsoft.VisualStudio.SolutionPersistence, Version=1.0.0.0"
                 };
 
                 uint hresult = NativeMethods.CreateAssemblyCache(out IAssemblyCache assemblyCache, 0);


### PR DESCRIPTION
Fixes #
VS insertion fails with invalid assembly count
https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_git/VS/pullRequest/585993#1729185437

It must be attributed to adding  Microsoft.VisualStudio.SolutionPersistence in scope of slnx PR: https://github.com/dotnet/msbuild/pull/10794/files#diff-52cc55d60d91e826b8fe4b773f4ee868a6e1cd76f6da82771841395fe8a9c0ef


## Solution
add registration for Microsoft.VisualStudio.SolutionPersistence.dll