### PR TITLE
Adjust conversion message

### DIFF
--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -850,7 +850,7 @@
     <value>Task name cannot be empty.</value>
   </data>
   <data name="ProjectUpgradeNeeded" xml:space="preserve">
-    <value>MSB4075: The project file "{0}" must be opened in version of Visual Studio IDE that supports it and converted to the latest version before it can be built by MSBuild. More info: https://aka.ms/DeprecatedProjectConversion</value>
+    <value>MSB4075: The project file "{0}" must be opened in a version of Visual Studio IDE that supports it and converted to the latest version before it can be built by MSBuild. More info: https://aka.ms/DeprecatedProjectConversion</value>
     <comment>{StrBegin="MSB4075: "}</comment>
   </data>
   <data name="ProjectUpgradeNeededToVcxProj" xml:space="preserve">

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -850,7 +850,7 @@
     <value>Task name cannot be empty.</value>
   </data>
   <data name="ProjectUpgradeNeeded" xml:space="preserve">
-    <value>MSB4075: The project file "{0}" must be opened in the Visual Studio IDE and converted to the latest version before it can be built by MSBuild.</value>
+    <value>MSB4075: The project file "{0}" must be opened in version of Visual Studio IDE that supports it and converted to the latest version before it can be built by MSBuild. More info: https://aka.ms/DeprecatedProjectConversion</value>
     <comment>{StrBegin="MSB4075: "}</comment>
   </data>
   <data name="ProjectUpgradeNeededToVcxProj" xml:space="preserve">

--- a/src/Build/Resources/xlf/Strings.cs.xlf
+++ b/src/Build/Resources/xlf/Strings.cs.xlf
@@ -1579,7 +1579,7 @@ Chyby: {3}</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectUpgradeNeeded">
-        <source>MSB4075: The project file "{0}" must be opened in version of Visual Studio IDE that supports it and converted to the latest version before it can be built by MSBuild. More info: https://aka.ms/DeprecatedProjectConversion</source>
+        <source>MSB4075: The project file "{0}" must be opened in a version of Visual Studio IDE that supports it and converted to the latest version before it can be built by MSBuild. More info: https://aka.ms/DeprecatedProjectConversion</source>
         <target state="needs-review-translation">MSB4075: Před sestavením pomocí nástroje MSBuild musí být soubor projektu {0} otevřen v prostředí Visual Studio IDE a převeden na nejnovější verzi.</target>
         <note>{StrBegin="MSB4075: "}</note>
       </trans-unit>

--- a/src/Build/Resources/xlf/Strings.cs.xlf
+++ b/src/Build/Resources/xlf/Strings.cs.xlf
@@ -1579,8 +1579,8 @@ Chyby: {3}</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectUpgradeNeeded">
-        <source>MSB4075: The project file "{0}" must be opened in the Visual Studio IDE and converted to the latest version before it can be built by MSBuild.</source>
-        <target state="translated">MSB4075: Před sestavením pomocí nástroje MSBuild musí být soubor projektu {0} otevřen v prostředí Visual Studio IDE a převeden na nejnovější verzi.</target>
+        <source>MSB4075: The project file "{0}" must be opened in version of Visual Studio IDE that supports it and converted to the latest version before it can be built by MSBuild. More info: https://aka.ms/DeprecatedProjectConversion</source>
+        <target state="needs-review-translation">MSB4075: Před sestavením pomocí nástroje MSBuild musí být soubor projektu {0} otevřen v prostředí Visual Studio IDE a převeden na nejnovější verzi.</target>
         <note>{StrBegin="MSB4075: "}</note>
       </trans-unit>
       <trans-unit id="ProjectUpgradeNeededToVcxProj">

--- a/src/Build/Resources/xlf/Strings.de.xlf
+++ b/src/Build/Resources/xlf/Strings.de.xlf
@@ -1579,7 +1579,7 @@ Fehler: {3}</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectUpgradeNeeded">
-        <source>MSB4075: The project file "{0}" must be opened in version of Visual Studio IDE that supports it and converted to the latest version before it can be built by MSBuild. More info: https://aka.ms/DeprecatedProjectConversion</source>
+        <source>MSB4075: The project file "{0}" must be opened in a version of Visual Studio IDE that supports it and converted to the latest version before it can be built by MSBuild. More info: https://aka.ms/DeprecatedProjectConversion</source>
         <target state="needs-review-translation">MSB4075: Die Projektdatei "{0}" muss in der Visual Studio IDE geöffnet und in die neuste Version konvertiert werden, bevor sie von MSBuild erstellt werden kann.</target>
         <note>{StrBegin="MSB4075: "}</note>
       </trans-unit>

--- a/src/Build/Resources/xlf/Strings.de.xlf
+++ b/src/Build/Resources/xlf/Strings.de.xlf
@@ -1579,8 +1579,8 @@ Fehler: {3}</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectUpgradeNeeded">
-        <source>MSB4075: The project file "{0}" must be opened in the Visual Studio IDE and converted to the latest version before it can be built by MSBuild.</source>
-        <target state="translated">MSB4075: Die Projektdatei "{0}" muss in der Visual Studio IDE geöffnet und in die neuste Version konvertiert werden, bevor sie von MSBuild erstellt werden kann.</target>
+        <source>MSB4075: The project file "{0}" must be opened in version of Visual Studio IDE that supports it and converted to the latest version before it can be built by MSBuild. More info: https://aka.ms/DeprecatedProjectConversion</source>
+        <target state="needs-review-translation">MSB4075: Die Projektdatei "{0}" muss in der Visual Studio IDE geöffnet und in die neuste Version konvertiert werden, bevor sie von MSBuild erstellt werden kann.</target>
         <note>{StrBegin="MSB4075: "}</note>
       </trans-unit>
       <trans-unit id="ProjectUpgradeNeededToVcxProj">

--- a/src/Build/Resources/xlf/Strings.es.xlf
+++ b/src/Build/Resources/xlf/Strings.es.xlf
@@ -1579,7 +1579,7 @@ Errores: {3}</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectUpgradeNeeded">
-        <source>MSB4075: The project file "{0}" must be opened in version of Visual Studio IDE that supports it and converted to the latest version before it can be built by MSBuild. More info: https://aka.ms/DeprecatedProjectConversion</source>
+        <source>MSB4075: The project file "{0}" must be opened in a version of Visual Studio IDE that supports it and converted to the latest version before it can be built by MSBuild. More info: https://aka.ms/DeprecatedProjectConversion</source>
         <target state="needs-review-translation">MSB4075: El archivo del proyecto "{0}" debe abrirse en el IDE de Visual Studio y convertirse a la versión más reciente para que MSBuild lo pueda compilar.</target>
         <note>{StrBegin="MSB4075: "}</note>
       </trans-unit>

--- a/src/Build/Resources/xlf/Strings.es.xlf
+++ b/src/Build/Resources/xlf/Strings.es.xlf
@@ -1579,8 +1579,8 @@ Errores: {3}</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectUpgradeNeeded">
-        <source>MSB4075: The project file "{0}" must be opened in the Visual Studio IDE and converted to the latest version before it can be built by MSBuild.</source>
-        <target state="translated">MSB4075: El archivo del proyecto "{0}" debe abrirse en el IDE de Visual Studio y convertirse a la versión más reciente para que MSBuild lo pueda compilar.</target>
+        <source>MSB4075: The project file "{0}" must be opened in version of Visual Studio IDE that supports it and converted to the latest version before it can be built by MSBuild. More info: https://aka.ms/DeprecatedProjectConversion</source>
+        <target state="needs-review-translation">MSB4075: El archivo del proyecto "{0}" debe abrirse en el IDE de Visual Studio y convertirse a la versión más reciente para que MSBuild lo pueda compilar.</target>
         <note>{StrBegin="MSB4075: "}</note>
       </trans-unit>
       <trans-unit id="ProjectUpgradeNeededToVcxProj">

--- a/src/Build/Resources/xlf/Strings.fr.xlf
+++ b/src/Build/Resources/xlf/Strings.fr.xlf
@@ -1579,7 +1579,7 @@ Erreurs : {3}</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectUpgradeNeeded">
-        <source>MSB4075: The project file "{0}" must be opened in version of Visual Studio IDE that supports it and converted to the latest version before it can be built by MSBuild. More info: https://aka.ms/DeprecatedProjectConversion</source>
+        <source>MSB4075: The project file "{0}" must be opened in a version of Visual Studio IDE that supports it and converted to the latest version before it can be built by MSBuild. More info: https://aka.ms/DeprecatedProjectConversion</source>
         <target state="needs-review-translation">MSB4075: Le fichier projet "{0}" doit être ouvert dans Visual Studio IDE et converti dans la dernière version avant de pouvoir être généré par MSBuild.</target>
         <note>{StrBegin="MSB4075: "}</note>
       </trans-unit>

--- a/src/Build/Resources/xlf/Strings.fr.xlf
+++ b/src/Build/Resources/xlf/Strings.fr.xlf
@@ -1579,8 +1579,8 @@ Erreurs : {3}</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectUpgradeNeeded">
-        <source>MSB4075: The project file "{0}" must be opened in the Visual Studio IDE and converted to the latest version before it can be built by MSBuild.</source>
-        <target state="translated">MSB4075: Le fichier projet "{0}" doit être ouvert dans Visual Studio IDE et converti dans la dernière version avant de pouvoir être généré par MSBuild.</target>
+        <source>MSB4075: The project file "{0}" must be opened in version of Visual Studio IDE that supports it and converted to the latest version before it can be built by MSBuild. More info: https://aka.ms/DeprecatedProjectConversion</source>
+        <target state="needs-review-translation">MSB4075: Le fichier projet "{0}" doit être ouvert dans Visual Studio IDE et converti dans la dernière version avant de pouvoir être généré par MSBuild.</target>
         <note>{StrBegin="MSB4075: "}</note>
       </trans-unit>
       <trans-unit id="ProjectUpgradeNeededToVcxProj">

--- a/src/Build/Resources/xlf/Strings.it.xlf
+++ b/src/Build/Resources/xlf/Strings.it.xlf
@@ -1579,7 +1579,7 @@ Errori: {3}</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectUpgradeNeeded">
-        <source>MSB4075: The project file "{0}" must be opened in version of Visual Studio IDE that supports it and converted to the latest version before it can be built by MSBuild. More info: https://aka.ms/DeprecatedProjectConversion</source>
+        <source>MSB4075: The project file "{0}" must be opened in a version of Visual Studio IDE that supports it and converted to the latest version before it can be built by MSBuild. More info: https://aka.ms/DeprecatedProjectConversion</source>
         <target state="needs-review-translation">MSB4075: prima di compilare il file di progetto "{0}" con MSBuild, è necessario aprirlo in Visual Studio IDE e convertirlo alla versione più recente.</target>
         <note>{StrBegin="MSB4075: "}</note>
       </trans-unit>

--- a/src/Build/Resources/xlf/Strings.it.xlf
+++ b/src/Build/Resources/xlf/Strings.it.xlf
@@ -1579,8 +1579,8 @@ Errori: {3}</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectUpgradeNeeded">
-        <source>MSB4075: The project file "{0}" must be opened in the Visual Studio IDE and converted to the latest version before it can be built by MSBuild.</source>
-        <target state="translated">MSB4075: prima di compilare il file di progetto "{0}" con MSBuild, è necessario aprirlo in Visual Studio IDE e convertirlo alla versione più recente.</target>
+        <source>MSB4075: The project file "{0}" must be opened in version of Visual Studio IDE that supports it and converted to the latest version before it can be built by MSBuild. More info: https://aka.ms/DeprecatedProjectConversion</source>
+        <target state="needs-review-translation">MSB4075: prima di compilare il file di progetto "{0}" con MSBuild, è necessario aprirlo in Visual Studio IDE e convertirlo alla versione più recente.</target>
         <note>{StrBegin="MSB4075: "}</note>
       </trans-unit>
       <trans-unit id="ProjectUpgradeNeededToVcxProj">

--- a/src/Build/Resources/xlf/Strings.ja.xlf
+++ b/src/Build/Resources/xlf/Strings.ja.xlf
@@ -1579,7 +1579,7 @@ Errors: {3}</source>
         <note />
       </trans-unit>
       <trans-unit id="ProjectUpgradeNeeded">
-        <source>MSB4075: The project file "{0}" must be opened in version of Visual Studio IDE that supports it and converted to the latest version before it can be built by MSBuild. More info: https://aka.ms/DeprecatedProjectConversion</source>
+        <source>MSB4075: The project file "{0}" must be opened in a version of Visual Studio IDE that supports it and converted to the latest version before it can be built by MSBuild. More info: https://aka.ms/DeprecatedProjectConversion</source>
         <target state="needs-review-translation">MSB4075: プロジェクト ファイル "{0}" を MSBuild でビルドできるようにするには、Visual Studio IDE でプロジェクト ファイルを開き、最新バージョンに変換しなければなりません。</target>
         <note>{StrBegin="MSB4075: "}</note>
       </trans-unit>

--- a/src/Build/Resources/xlf/Strings.ja.xlf
+++ b/src/Build/Resources/xlf/Strings.ja.xlf
@@ -1579,8 +1579,8 @@ Errors: {3}</source>
         <note />
       </trans-unit>
       <trans-unit id="ProjectUpgradeNeeded">
-        <source>MSB4075: The project file "{0}" must be opened in the Visual Studio IDE and converted to the latest version before it can be built by MSBuild.</source>
-        <target state="translated">MSB4075: プロジェクト ファイル "{0}" を MSBuild でビルドできるようにするには、Visual Studio IDE でプロジェクト ファイルを開き、最新バージョンに変換しなければなりません。</target>
+        <source>MSB4075: The project file "{0}" must be opened in version of Visual Studio IDE that supports it and converted to the latest version before it can be built by MSBuild. More info: https://aka.ms/DeprecatedProjectConversion</source>
+        <target state="needs-review-translation">MSB4075: プロジェクト ファイル "{0}" を MSBuild でビルドできるようにするには、Visual Studio IDE でプロジェクト ファイルを開き、最新バージョンに変換しなければなりません。</target>
         <note>{StrBegin="MSB4075: "}</note>
       </trans-unit>
       <trans-unit id="ProjectUpgradeNeededToVcxProj">

--- a/src/Build/Resources/xlf/Strings.ko.xlf
+++ b/src/Build/Resources/xlf/Strings.ko.xlf
@@ -1579,7 +1579,7 @@ Errors: {3}</source>
         <note />
       </trans-unit>
       <trans-unit id="ProjectUpgradeNeeded">
-        <source>MSB4075: The project file "{0}" must be opened in version of Visual Studio IDE that supports it and converted to the latest version before it can be built by MSBuild. More info: https://aka.ms/DeprecatedProjectConversion</source>
+        <source>MSB4075: The project file "{0}" must be opened in a version of Visual Studio IDE that supports it and converted to the latest version before it can be built by MSBuild. More info: https://aka.ms/DeprecatedProjectConversion</source>
         <target state="needs-review-translation">MSB4075: 프로젝트 파일 "{0}"을(를) MSBuild로 빌드하려면 파일을 Visual Studio IDE에서 열어 최신 버전으로 변환해야 합니다.</target>
         <note>{StrBegin="MSB4075: "}</note>
       </trans-unit>

--- a/src/Build/Resources/xlf/Strings.ko.xlf
+++ b/src/Build/Resources/xlf/Strings.ko.xlf
@@ -1579,8 +1579,8 @@ Errors: {3}</source>
         <note />
       </trans-unit>
       <trans-unit id="ProjectUpgradeNeeded">
-        <source>MSB4075: The project file "{0}" must be opened in the Visual Studio IDE and converted to the latest version before it can be built by MSBuild.</source>
-        <target state="translated">MSB4075: 프로젝트 파일 "{0}"을(를) MSBuild로 빌드하려면 파일을 Visual Studio IDE에서 열어 최신 버전으로 변환해야 합니다.</target>
+        <source>MSB4075: The project file "{0}" must be opened in version of Visual Studio IDE that supports it and converted to the latest version before it can be built by MSBuild. More info: https://aka.ms/DeprecatedProjectConversion</source>
+        <target state="needs-review-translation">MSB4075: 프로젝트 파일 "{0}"을(를) MSBuild로 빌드하려면 파일을 Visual Studio IDE에서 열어 최신 버전으로 변환해야 합니다.</target>
         <note>{StrBegin="MSB4075: "}</note>
       </trans-unit>
       <trans-unit id="ProjectUpgradeNeededToVcxProj">

--- a/src/Build/Resources/xlf/Strings.pl.xlf
+++ b/src/Build/Resources/xlf/Strings.pl.xlf
@@ -1579,7 +1579,7 @@ Błędy: {3}</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectUpgradeNeeded">
-        <source>MSB4075: The project file "{0}" must be opened in version of Visual Studio IDE that supports it and converted to the latest version before it can be built by MSBuild. More info: https://aka.ms/DeprecatedProjectConversion</source>
+        <source>MSB4075: The project file "{0}" must be opened in a version of Visual Studio IDE that supports it and converted to the latest version before it can be built by MSBuild. More info: https://aka.ms/DeprecatedProjectConversion</source>
         <target state="needs-review-translation">MSB4075: Plik projektu „{0}” musi zostać otwarty w programie Visual Studio IDE i przekształcony do najnowszej wersji, zanim będzie mógł być skompilowany w programie MSBuild.</target>
         <note>{StrBegin="MSB4075: "}</note>
       </trans-unit>

--- a/src/Build/Resources/xlf/Strings.pl.xlf
+++ b/src/Build/Resources/xlf/Strings.pl.xlf
@@ -1579,8 +1579,8 @@ Błędy: {3}</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectUpgradeNeeded">
-        <source>MSB4075: The project file "{0}" must be opened in the Visual Studio IDE and converted to the latest version before it can be built by MSBuild.</source>
-        <target state="translated">MSB4075: Plik projektu „{0}” musi zostać otwarty w programie Visual Studio IDE i przekształcony do najnowszej wersji, zanim będzie mógł być skompilowany w programie MSBuild.</target>
+        <source>MSB4075: The project file "{0}" must be opened in version of Visual Studio IDE that supports it and converted to the latest version before it can be built by MSBuild. More info: https://aka.ms/DeprecatedProjectConversion</source>
+        <target state="needs-review-translation">MSB4075: Plik projektu „{0}” musi zostać otwarty w programie Visual Studio IDE i przekształcony do najnowszej wersji, zanim będzie mógł być skompilowany w programie MSBuild.</target>
         <note>{StrBegin="MSB4075: "}</note>
       </trans-unit>
       <trans-unit id="ProjectUpgradeNeededToVcxProj">

--- a/src/Build/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Build/Resources/xlf/Strings.pt-BR.xlf
@@ -1579,7 +1579,7 @@ Erros: {3}</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectUpgradeNeeded">
-        <source>MSB4075: The project file "{0}" must be opened in version of Visual Studio IDE that supports it and converted to the latest version before it can be built by MSBuild. More info: https://aka.ms/DeprecatedProjectConversion</source>
+        <source>MSB4075: The project file "{0}" must be opened in a version of Visual Studio IDE that supports it and converted to the latest version before it can be built by MSBuild. More info: https://aka.ms/DeprecatedProjectConversion</source>
         <target state="needs-review-translation">MSB4075: O arquivo de projeto "{0}" must deve ser aberto no IDE do Visual Studio e convertido na versão mais recente, para que possa ser compilado pelo MSBuild.</target>
         <note>{StrBegin="MSB4075: "}</note>
       </trans-unit>

--- a/src/Build/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Build/Resources/xlf/Strings.pt-BR.xlf
@@ -1579,8 +1579,8 @@ Erros: {3}</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectUpgradeNeeded">
-        <source>MSB4075: The project file "{0}" must be opened in the Visual Studio IDE and converted to the latest version before it can be built by MSBuild.</source>
-        <target state="translated">MSB4075: O arquivo de projeto "{0}" must deve ser aberto no IDE do Visual Studio e convertido na versão mais recente, para que possa ser compilado pelo MSBuild.</target>
+        <source>MSB4075: The project file "{0}" must be opened in version of Visual Studio IDE that supports it and converted to the latest version before it can be built by MSBuild. More info: https://aka.ms/DeprecatedProjectConversion</source>
+        <target state="needs-review-translation">MSB4075: O arquivo de projeto "{0}" must deve ser aberto no IDE do Visual Studio e convertido na versão mais recente, para que possa ser compilado pelo MSBuild.</target>
         <note>{StrBegin="MSB4075: "}</note>
       </trans-unit>
       <trans-unit id="ProjectUpgradeNeededToVcxProj">

--- a/src/Build/Resources/xlf/Strings.ru.xlf
+++ b/src/Build/Resources/xlf/Strings.ru.xlf
@@ -1579,7 +1579,7 @@ Errors: {3}</source>
         <note />
       </trans-unit>
       <trans-unit id="ProjectUpgradeNeeded">
-        <source>MSB4075: The project file "{0}" must be opened in version of Visual Studio IDE that supports it and converted to the latest version before it can be built by MSBuild. More info: https://aka.ms/DeprecatedProjectConversion</source>
+        <source>MSB4075: The project file "{0}" must be opened in a version of Visual Studio IDE that supports it and converted to the latest version before it can be built by MSBuild. More info: https://aka.ms/DeprecatedProjectConversion</source>
         <target state="needs-review-translation">MSB4075: файл проекта "{0}" должен быть открыт в среде Visual Studio и преобразован в последнюю версию, прежде чем программа MSBuild сможет построить этот проект.</target>
         <note>{StrBegin="MSB4075: "}</note>
       </trans-unit>

--- a/src/Build/Resources/xlf/Strings.ru.xlf
+++ b/src/Build/Resources/xlf/Strings.ru.xlf
@@ -1579,8 +1579,8 @@ Errors: {3}</source>
         <note />
       </trans-unit>
       <trans-unit id="ProjectUpgradeNeeded">
-        <source>MSB4075: The project file "{0}" must be opened in the Visual Studio IDE and converted to the latest version before it can be built by MSBuild.</source>
-        <target state="translated">MSB4075: файл проекта "{0}" должен быть открыт в среде Visual Studio и преобразован в последнюю версию, прежде чем программа MSBuild сможет построить этот проект.</target>
+        <source>MSB4075: The project file "{0}" must be opened in version of Visual Studio IDE that supports it and converted to the latest version before it can be built by MSBuild. More info: https://aka.ms/DeprecatedProjectConversion</source>
+        <target state="needs-review-translation">MSB4075: файл проекта "{0}" должен быть открыт в среде Visual Studio и преобразован в последнюю версию, прежде чем программа MSBuild сможет построить этот проект.</target>
         <note>{StrBegin="MSB4075: "}</note>
       </trans-unit>
       <trans-unit id="ProjectUpgradeNeededToVcxProj">

--- a/src/Build/Resources/xlf/Strings.tr.xlf
+++ b/src/Build/Resources/xlf/Strings.tr.xlf
@@ -1579,7 +1579,7 @@ Hatalar: {3}</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectUpgradeNeeded">
-        <source>MSB4075: The project file "{0}" must be opened in version of Visual Studio IDE that supports it and converted to the latest version before it can be built by MSBuild. More info: https://aka.ms/DeprecatedProjectConversion</source>
+        <source>MSB4075: The project file "{0}" must be opened in a version of Visual Studio IDE that supports it and converted to the latest version before it can be built by MSBuild. More info: https://aka.ms/DeprecatedProjectConversion</source>
         <target state="needs-review-translation">MSB4075: MSBuild tarafından derlenebilmesi için, "{0}" proje dosyasının Visual Studio IDE içinde açılması ve en son sürüme dönüştürülmesi gerekir.</target>
         <note>{StrBegin="MSB4075: "}</note>
       </trans-unit>

--- a/src/Build/Resources/xlf/Strings.tr.xlf
+++ b/src/Build/Resources/xlf/Strings.tr.xlf
@@ -1579,8 +1579,8 @@ Hatalar: {3}</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectUpgradeNeeded">
-        <source>MSB4075: The project file "{0}" must be opened in the Visual Studio IDE and converted to the latest version before it can be built by MSBuild.</source>
-        <target state="translated">MSB4075: MSBuild tarafından derlenebilmesi için, "{0}" proje dosyasının Visual Studio IDE içinde açılması ve en son sürüme dönüştürülmesi gerekir.</target>
+        <source>MSB4075: The project file "{0}" must be opened in version of Visual Studio IDE that supports it and converted to the latest version before it can be built by MSBuild. More info: https://aka.ms/DeprecatedProjectConversion</source>
+        <target state="needs-review-translation">MSB4075: MSBuild tarafından derlenebilmesi için, "{0}" proje dosyasının Visual Studio IDE içinde açılması ve en son sürüme dönüştürülmesi gerekir.</target>
         <note>{StrBegin="MSB4075: "}</note>
       </trans-unit>
       <trans-unit id="ProjectUpgradeNeededToVcxProj">

--- a/src/Build/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hans.xlf
@@ -1579,7 +1579,7 @@ Errors: {3}</source>
         <note />
       </trans-unit>
       <trans-unit id="ProjectUpgradeNeeded">
-        <source>MSB4075: The project file "{0}" must be opened in version of Visual Studio IDE that supports it and converted to the latest version before it can be built by MSBuild. More info: https://aka.ms/DeprecatedProjectConversion</source>
+        <source>MSB4075: The project file "{0}" must be opened in a version of Visual Studio IDE that supports it and converted to the latest version before it can be built by MSBuild. More info: https://aka.ms/DeprecatedProjectConversion</source>
         <target state="needs-review-translation">MSB4075: 必须在 Visual Studio IDE 中打开项目文件“{0}”，并将其转换为最新版本，然后才能使用 MSBuild 生成该项目文件。</target>
         <note>{StrBegin="MSB4075: "}</note>
       </trans-unit>

--- a/src/Build/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hans.xlf
@@ -1579,8 +1579,8 @@ Errors: {3}</source>
         <note />
       </trans-unit>
       <trans-unit id="ProjectUpgradeNeeded">
-        <source>MSB4075: The project file "{0}" must be opened in the Visual Studio IDE and converted to the latest version before it can be built by MSBuild.</source>
-        <target state="translated">MSB4075: 必须在 Visual Studio IDE 中打开项目文件“{0}”，并将其转换为最新版本，然后才能使用 MSBuild 生成该项目文件。</target>
+        <source>MSB4075: The project file "{0}" must be opened in version of Visual Studio IDE that supports it and converted to the latest version before it can be built by MSBuild. More info: https://aka.ms/DeprecatedProjectConversion</source>
+        <target state="needs-review-translation">MSB4075: 必须在 Visual Studio IDE 中打开项目文件“{0}”，并将其转换为最新版本，然后才能使用 MSBuild 生成该项目文件。</target>
         <note>{StrBegin="MSB4075: "}</note>
       </trans-unit>
       <trans-unit id="ProjectUpgradeNeededToVcxProj">

--- a/src/Build/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hant.xlf
@@ -1579,7 +1579,7 @@ Errors: {3}</source>
         <note />
       </trans-unit>
       <trans-unit id="ProjectUpgradeNeeded">
-        <source>MSB4075: The project file "{0}" must be opened in version of Visual Studio IDE that supports it and converted to the latest version before it can be built by MSBuild. More info: https://aka.ms/DeprecatedProjectConversion</source>
+        <source>MSB4075: The project file "{0}" must be opened in a version of Visual Studio IDE that supports it and converted to the latest version before it can be built by MSBuild. More info: https://aka.ms/DeprecatedProjectConversion</source>
         <target state="needs-review-translation">MSB4075: 專案檔 "{0}" 必須在 Visual Studio IDE 中開啟，並轉換成最新版本，然後才能由 MSBuild 建置。</target>
         <note>{StrBegin="MSB4075: "}</note>
       </trans-unit>

--- a/src/Build/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hant.xlf
@@ -1579,8 +1579,8 @@ Errors: {3}</source>
         <note />
       </trans-unit>
       <trans-unit id="ProjectUpgradeNeeded">
-        <source>MSB4075: The project file "{0}" must be opened in the Visual Studio IDE and converted to the latest version before it can be built by MSBuild.</source>
-        <target state="translated">MSB4075: 專案檔 "{0}" 必須在 Visual Studio IDE 中開啟，並轉換成最新版本，然後才能由 MSBuild 建置。</target>
+        <source>MSB4075: The project file "{0}" must be opened in version of Visual Studio IDE that supports it and converted to the latest version before it can be built by MSBuild. More info: https://aka.ms/DeprecatedProjectConversion</source>
+        <target state="needs-review-translation">MSB4075: 專案檔 "{0}" 必須在 Visual Studio IDE 中開啟，並轉換成最新版本，然後才能由 MSBuild 建置。</target>
         <note>{StrBegin="MSB4075: "}</note>
       </trans-unit>
       <trans-unit id="ProjectUpgradeNeededToVcxProj">


### PR DESCRIPTION
## Context
After removing the deprecated msbuild engine, the message in VS should be adjusted on the attempt to open pre-msbuild message.
![image](https://github.com/user-attachments/assets/bae01be6-d878-40ad-98be-76919c056970)

## Fix
The message contains the help link for the customer.