### PR TITLE
Removed scheduler debugger from MSBuildDebugEngine

### DIFF
--- a/documentation/wiki/MSBuild-Environment-Variables.md
+++ b/documentation/wiki/MSBuild-Environment-Variables.md
@@ -26,7 +26,7 @@ Some of the env variables listed here are unsupported, meaning there is no guara
    * Launches debugger on build start. Works on Windows operating systems only.  
    * Setting the value of 2 allows for manually attaching a debugger to a process ID. This works on Windows and non-Windows operating systems.
 * `MSBUILDDEBUGSCHEDULER=1` & `MSBUILDDEBUGPATH=<DIRECTORY>`
-   * Dumps scheduler state at specified directory (`MSBUILDDEBUGSCHEDULER` is implied by `MSBuildDebugEngine`).
+   * Dumps scheduler state at specified directory.
 
 * `MsBuildSkipEagerWildCardEvaluationRegexes`
   *  If specified, overrides the default behavior of glob expansion. During glob expansion, if the path with wildcards that is being processed matches one of the regular expressions provided in the [environment variable](#msbuildskipeagerwildcardevaluationregexes), the path is not processed (expanded). 

--- a/src/Framework/Traits.cs
+++ b/src/Framework/Traits.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Build.Framework
         {
             EscapeHatches = new EscapeHatches();
 
-            DebugScheduler = DebugEngine || !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("MSBUILDDEBUGSCHEDULER"));
+            DebugScheduler = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("MSBUILDDEBUGSCHEDULER"));
             DebugNodeCommunication = DebugEngine || !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("MSBUILDDEBUGCOMM"));
         }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/msbuild/issues/10639

### Context
There was an [internal ticket](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2253774/) that seems to originate from the scheduler logger. The team uses the engine debugger variable to keep track of their builds. However, it seems that the scheduler logger does not always work as expected and it is turned on when using `MSBuildDebugEngine`. Since we think there isn't a lot of information that is necessary from scheduler logger, we are trying to disable it when using the `MSBuildDebugEngine` variable, and leaving it on when explicitly turned on.


### Changes Made
Does not turn on scheduler debugger when using `MSBuildDebugEngine`

### Testing

