### PR TITLE
Add BuildCheck PackageTag to BuildCheck template

### DIFF
--- a/template_feed/content/Microsoft.CheckTemplate/Company.CheckTemplate.csproj
+++ b/template_feed/content/Microsoft.CheckTemplate/Company.CheckTemplate.csproj
@@ -5,6 +5,7 @@
     <DevelopmentDependency>true</DevelopmentDependency>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+    <PackageTags>BuildCheck</PackageTags>
     <!-- The output structure was modified for msbuild development needs.-->
     <NoWarn>NU5101;NU5128</NoWarn>
   </PropertyGroup>


### PR DESCRIPTION
### Context
It may be hard to search NuGet.org or other package feeds for buildchecks without some common tag - we should put a set of common tags in the template so that BuildCheck consumers can easily find BuildChecks.

### Changes Made

Added `PackageTags` property with a default value

### Testing

None

### Notes
