### PR TITLE
Stop overriding Arcade VSSDK

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -18,9 +18,6 @@
     <UsingToolMicrosoftNetCompilers>true</UsingToolMicrosoftNetCompilers>
     <UsingToolSymbolUploader>true</UsingToolSymbolUploader>
     <UsingToolVSSDK>true</UsingToolVSSDK>
-    <!-- Override Arcade's default VSSDK version with one that supports client enablement.
-         Can be removed after Arcade moves up. -->
-    <MicrosoftVSSDKBuildToolsVersion>16.7.13</MicrosoftVSSDKBuildToolsVersion>
   </PropertyGroup>
   <!-- Production Dependencies -->
   <PropertyGroup>


### PR DESCRIPTION
This was needed long ago but Arcade bumped past this in https://github.com/dotnet/arcade/pull/7056.
