### PR TITLE
Always respect warning-as-error properties

### DIFF
--- a/src/Build/BackEnd/Components/Logging/LoggingService.cs
+++ b/src/Build/BackEnd/Components/Logging/LoggingService.cs
@@ -1666,8 +1666,8 @@ namespace Microsoft.Build.BackEnd.Logging
                 }
             }
 
-            // If this is BuildCheck-ed build - add the warnings promotability/demotability to the service
-            if (buildEventArgs is ProjectStartedEventArgs projectStartedEvent && this._componentHost.BuildParameters.IsBuildCheckEnabled)
+            // Respect warning-promotion properties from the remote project
+            if (buildEventArgs is ProjectStartedEventArgs projectStartedEvent)
             {
                 AddWarningsAsErrors(projectStartedEvent.BuildEventContext, projectStartedEvent.WarningsAsErrors);
                 AddWarningsAsMessages(projectStartedEvent.BuildEventContext, projectStartedEvent.WarningsAsMessages);

--- a/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
@@ -1105,7 +1105,7 @@ namespace Microsoft.Build.BackEnd
         {
             ErrorUtilities.VerifyThrow(_targetBuilder != null, "Target builder is null");
 
-            // We consider this the entrypoint for the project build for purposes of BuildCheck processing 
+            // We consider this the entrypoint for the project build for purposes of BuildCheck processing
             bool isRestoring = _requestEntry.RequestConfiguration.GlobalProperties[MSBuildConstants.MSBuildIsRestoring] is not null;
 
             var buildCheckManager = isRestoring
@@ -1155,7 +1155,7 @@ namespace Microsoft.Build.BackEnd
                     _requestEntry.Request.BuildEventContext);
             }
 
-            
+
             try
             {
                 HandleProjectStarted(buildCheckManager);
@@ -1279,7 +1279,7 @@ namespace Microsoft.Build.BackEnd
             BuildEventContext projectBuildEventContext = _projectLoggingContext?.BuildEventContext;
 
             // We can set the warning as errors and messages only after the project logging context has been created (as it creates the new ProjectContextId)
-            if (buildCheckManager != null && loggingService != null && projectBuildEventContext != null)
+            if (loggingService != null && projectBuildEventContext != null)
             {
                 args.WarningsAsErrors = loggingService.GetWarningsAsErrors(projectBuildEventContext).ToHashSet(StringComparer.OrdinalIgnoreCase);
                 args.WarningsAsMessages = loggingService.GetWarningsAsMessages(projectBuildEventContext).ToHashSet(StringComparer.OrdinalIgnoreCase);

--- a/src/Framework/ProjectStartedEventArgs.cs
+++ b/src/Framework/ProjectStartedEventArgs.cs
@@ -335,7 +335,7 @@ namespace Microsoft.Build.Framework
         }
 
         // Following 3 properties are intended only for internal transfer - to properly communicate the warn as error/msg
-        //  from the worker node, to the main node - that may be producing the buildcheck diagnostics.
+        //  from the worker node, to the main node.
         // They are not going to be in a binlog (at least not as of now).
 
         internal ISet<string>? WarningsAsErrors { get; set; }


### PR DESCRIPTION
Remote (built in another node) projects were not respecting MSBuildWarningsNotAsErrors configured  in the projects, when the API or CLI `-warnaserror` option was enabled.

Fixes #10874.
