### PR TITLE
Remove hardcoded values from bootstrap scripts

### DIFF
--- a/eng/cibuild_bootstrapped_msbuild.ps1
+++ b/eng/cibuild_bootstrapped_msbuild.ps1
@@ -85,7 +85,7 @@ try {
   else
   {
     $buildToolPath = "$bootstrapRoot\core\dotnet.exe"
-    $propsFile = Join-Path $PSScriptRoot "Vesions.props"
+    $propsFile = Join-Path $PSScriptRoot "Versions.props"
     $bootstrapSdkVersion = ([xml](Get-Content $propsFile)).SelectSingleNode("//PropertyGroup/BootstrapSdkVersion").InnerText
     $buildToolCommand = "$bootstrapRoot\core\sdk\$bootstrapSdkVersion\MSBuild.dll"
     $buildToolFramework = "net9.0"

--- a/eng/cibuild_bootstrapped_msbuild.ps1
+++ b/eng/cibuild_bootstrapped_msbuild.ps1
@@ -84,9 +84,10 @@ try {
   }
   else
   {
-    $buildToolPath = Join-Path $bootstrapRoot "core\dotnet.exe"
-    # The version must be consistent with BootstrapSdkVersion
-    $buildToolCommand = Join-Path $bootstrapRoot "core\sdk\9.0.200-preview.0.24523.19\MSBuild.dll"
+    $buildToolPath = Join-Path $bootstrapRoot "core" "dotnet.exe"
+    $propsFile = Join-Path $PSScriptRoot "Vesions.props"
+    $bootstrapSdkVersion = ([xml](Get-Content $propsFile)).SelectSingleNode("//PropertyGroup/BootstrapSdkVersion").InnerText
+    $buildToolCommand = Join-Path $bootstrapRoot "core" "sdk" $bootstrapSdkVersion "MSBuild.dll"
     $buildToolFramework = "net9.0"
   }
 

--- a/eng/cibuild_bootstrapped_msbuild.ps1
+++ b/eng/cibuild_bootstrapped_msbuild.ps1
@@ -84,10 +84,10 @@ try {
   }
   else
   {
-    $buildToolPath = Join-Path $bootstrapRoot "core" "dotnet.exe"
+    $buildToolPath = "$bootstrapRoot\core\dotnet.exe"
     $propsFile = Join-Path $PSScriptRoot "Vesions.props"
     $bootstrapSdkVersion = ([xml](Get-Content $propsFile)).SelectSingleNode("//PropertyGroup/BootstrapSdkVersion").InnerText
-    $buildToolCommand = Join-Path $bootstrapRoot "core" "sdk" $bootstrapSdkVersion "MSBuild.dll"
+    $buildToolCommand = "$bootstrapRoot\core\sdk\$bootstrapSdkVersion\MSBuild.dll"
     $buildToolFramework = "net9.0"
   }
 

--- a/eng/cibuild_bootstrapped_msbuild.sh
+++ b/eng/cibuild_bootstrapped_msbuild.sh
@@ -58,7 +58,8 @@ bootstrapRoot="$Stage1Dir/bin/bootstrap"
 
 if [ $host_type = "core" ]
 then
-  props_file="$(dirname "$0")/Versions.props"
+  script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+  props_file="$script_dir/Versions.props"
   sdk_version=$(grep -A1 "BootstrapSdkVersion" "$props_file" | grep -o ">.*<" | sed 's/[><]//g')
 
   _InitializeBuildTool="${bootstrapRoot}/core/dotnet"

--- a/eng/cibuild_bootstrapped_msbuild.sh
+++ b/eng/cibuild_bootstrapped_msbuild.sh
@@ -58,9 +58,11 @@ bootstrapRoot="$Stage1Dir/bin/bootstrap"
 
 if [ $host_type = "core" ]
 then
-  _InitializeBuildTool="$bootstrapRoot/core/dotnet"
-  # The version must be consistent with BootstrapSdkVersion
-  _InitializeBuildToolCommand="$bootstrapRoot/core/sdk/9.0.200-preview.0.24523.19/MSBuild.dll"
+  props_file="$(dirname "$0")/Versions.props"
+  sdk_version=$(grep -A1 "BootstrapSdkVersion" "$props_file" | grep -o ">.*<" | sed 's/[><]//g')
+
+  _InitializeBuildTool="${bootstrapRoot}/core/dotnet"
+  _InitializeBuildToolCommand="${bootstrapRoot}/core/sdk/${sdk_version}/MSBuild.dll"
   _InitializeBuildToolFramework="net9.0"
 else
   echo "Unsupported hostType ($host_type)"


### PR DESCRIPTION
## Context
Bootstrap improvements. Now we should update the version in 3 places, this change allows to update `BootstrapSdkVersion `property only in Version.props. The scripts read the value from this file.

The initial idea was to get rid on the logic that points to a specific MSBuild.dll, but it isn't not realistic for the local development, when in core/sdk folders might be several different versions.