### PR TITLE
Keep ActivityId correlations in ETW

### DIFF
--- a/documentation/specs/event-source.md
+++ b/documentation/specs/event-source.md
@@ -45,7 +45,7 @@ EventSource is primarily used to profile code. For MSBuild specifically, a major
 
 One can run MSBuild with eventing using the following command:
 
-`PerfView /OnlyProviders=*Microsoft-Build run MSBuild.exe <project to build>`
+`PerfView /Providers=*Microsoft-Build run MSBuild.exe <project to build>`
 
 For example, if PerfView is one level up from my current directory (which has MSBuild.exe), and I want to build MSBuild.sln on Windows, I would use the following command:
 


### PR DESCRIPTION
With `/OnlyProviders`, the done-for-us `ActivityId`/`RelatedActivityId` correlations aren't done for us, and it's hard to, for example, correlate a task back to the target it's in.
