### PR TITLE
Error handling for failures on registered actions for Custom Checks

### DIFF
--- a/src/Build/BuildCheck/Infrastructure/BuildCheckCentralContext.cs
+++ b/src/Build/BuildCheck/Infrastructure/BuildCheckCentralContext.cs
@@ -193,7 +193,7 @@ internal sealed class BuildCheckCentralContext
     where T : CheckData
     {
         string projectFullPath = checkData.ProjectFilePath;
-        List<CheckWrapper> checksToRemove = null;
+        List<CheckWrapper>? checksToRemove = null;
 
         foreach (var checkCallback in registeredCallbacks)
         {

--- a/src/Build/BuildCheck/Infrastructure/BuildCheckManagerProvider.cs
+++ b/src/Build/BuildCheck/Infrastructure/BuildCheckManagerProvider.cs
@@ -272,7 +272,15 @@ internal sealed class BuildCheckManagerProvider : IBuildCheckManagerProvider
                 // Create the wrapper and register to central context
                 wrapper.StartNewProject(projectFullPath, configurations, userEditorConfigs);
                 var wrappedContext = new CheckRegistrationContext(wrapper, _buildCheckCentralContext);
-                check.RegisterActions(wrappedContext);
+                try
+                {
+                    check.RegisterActions(wrappedContext);
+                }
+                catch (Exception e)
+                {
+                    throw new BuildCheckConfigurationException(
+                        $"The check '{check.FriendlyName}' failed to register actions with the following message: '{e.Message}'");
+                }
             }
             else
             {

--- a/src/BuildCheck.UnitTests/EndToEndTests.cs
+++ b/src/BuildCheck.UnitTests/EndToEndTests.cs
@@ -515,10 +515,10 @@ public class EndToEndTests : IDisposable
     }
 
     [Theory]
-    [InlineData("X01236", "Something went wrong initializing")]
-    [InlineData("X01237", "something went wrong when executing registered action")]
-    [InlineData("X01238", "something went wrong when registering actions")]
-    public void CustomChecksFailGracefully(string ruleId, string expectedMessage)
+    [InlineData("X01236", "ErrorOnInitializeCheck", "Something went wrong initializing")]
+    [InlineData("X01237", "ErrorOnRegisteredAction", "something went wrong when executing registered action")]
+    [InlineData("X01238", "ErrorWhenRegisteringActions", "something went wrong when registering actions")]
+    public void CustomChecksFailGracefully(string ruleId, string friendlyName, string expectedMessage)
     {
         using (var env = TestEnvironment.Create())
         {
@@ -539,6 +539,7 @@ public class EndToEndTests : IDisposable
             success.ShouldBeTrue();
             projectCheckBuildLog.ShouldContain(expectedMessage);
             projectCheckBuildLog.ShouldNotContain("This check should have been disabled");
+            projectCheckBuildLog.ShouldContain($"Dismounting check '{friendlyName}'");
 
             // Cleanup
             File.Delete(editorConfigName);

--- a/src/BuildCheck.UnitTests/EndToEndTests.cs
+++ b/src/BuildCheck.UnitTests/EndToEndTests.cs
@@ -514,12 +514,10 @@ public class EndToEndTests : IDisposable
         }
     }
 
-    [Theory(Skip = "https://github.com/dotnet/msbuild/issues/10702")]
+    [Theory]
     [InlineData("X01236", "Something went wrong initializing")]
-    // These tests are for failure one different points, will be addressed in a different PR
-    // https://github.com/dotnet/msbuild/issues/10522
-    // [InlineData("X01237", "message")]
-    // [InlineData("X01238", "message")]
+    [InlineData("X01237", "something went wrong when executing registered action")]
+    [InlineData("X01238", "something went wrong when registering actions")]
     public void CustomChecksFailGracefully(string ruleId, string expectedMessage)
     {
         using (var env = TestEnvironment.Create())

--- a/src/BuildCheck.UnitTests/TestAssets/ErrorCustomCheck/ErrorOnRegisteredAction.cs
+++ b/src/BuildCheck.UnitTests/TestAssets/ErrorCustomCheck/ErrorOnRegisteredAction.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using Microsoft.Build.Construction;
 using Microsoft.Build.Experimental.BuildCheck;
 

--- a/src/BuildCheck.UnitTests/TestAssets/ErrorCustomCheck/ErrorOnRegisteredAction.cs
+++ b/src/BuildCheck.UnitTests/TestAssets/ErrorCustomCheck/ErrorOnRegisteredAction.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using Microsoft.Build.Construction;
 using Microsoft.Build.Experimental.BuildCheck;
 
@@ -33,7 +34,7 @@ namespace ErrorCustomCheck
 
         private void EvaluatedPropertiesAction(BuildCheckDataContext<EvaluatedPropertiesCheckData> context)
         {
-            throw new Exception("something went wrong");
+            throw new Exception("something went wrong when executing registered action");
         }
     }
 }

--- a/src/BuildCheck.UnitTests/TestAssets/ErrorCustomCheck/ErrorOnRegisteredAction.cs
+++ b/src/BuildCheck.UnitTests/TestAssets/ErrorCustomCheck/ErrorOnRegisteredAction.cs
@@ -17,7 +17,7 @@ namespace ErrorCustomCheck
             "Message format: {0}",
             new CheckConfiguration());
 
-        public override string FriendlyName => "ErrorOnEvaluatedPropertiesCheck";
+        public override string FriendlyName => "ErrorOnRegisteredAction";
 
         public override IReadOnlyList<CheckRule> SupportedRules { get; } = new List<CheckRule>() { SupportedRule };
 

--- a/src/BuildCheck.UnitTests/TestAssets/ErrorCustomCheck/ErrorWhenRegisteringActions.cs
+++ b/src/BuildCheck.UnitTests/TestAssets/ErrorCustomCheck/ErrorWhenRegisteringActions.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using Microsoft.Build.Construction;
 using Microsoft.Build.Experimental.BuildCheck;
 

--- a/src/BuildCheck.UnitTests/TestAssets/ErrorCustomCheck/ErrorWhenRegisteringActions.cs
+++ b/src/BuildCheck.UnitTests/TestAssets/ErrorCustomCheck/ErrorWhenRegisteringActions.cs
@@ -17,7 +17,7 @@ namespace ErrorCustomCheck
             "Message format: {0}",
             new CheckConfiguration());
 
-        public override string FriendlyName => "ErrorOnEvaluatedPropertiesCheck";
+        public override string FriendlyName => "ErrorWhenRegisteringActions";
 
         public override IReadOnlyList<CheckRule> SupportedRules { get; } = new List<CheckRule>() { SupportedRule };
 

--- a/src/BuildCheck.UnitTests/TestAssets/ErrorCustomCheck/ErrorWhenRegisteringActions.cs
+++ b/src/BuildCheck.UnitTests/TestAssets/ErrorCustomCheck/ErrorWhenRegisteringActions.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using Microsoft.Build.Construction;
 using Microsoft.Build.Experimental.BuildCheck;
 
@@ -29,7 +30,7 @@ namespace ErrorCustomCheck
         public override void RegisterActions(IBuildCheckRegistrationContext registrationContext)
         {
             registrationContext.RegisterEvaluatedPropertiesAction(EvaluatedPropertiesAction);
-            throw new Exception("something went wrong");
+            throw new Exception("something went wrong when registering actions");
         }
 
         private void EvaluatedPropertiesAction(BuildCheckDataContext<EvaluatedPropertiesCheckData> context)


### PR DESCRIPTION
Fixes https://github.com/dotnet/msbuild/issues/10522

### Context
Second PR for that issue. This PR covers the cases in a Custom Check where there is an exception while registering actions, and when running said actions.
Since actions are individuals, we do not deregister the whole analyzer when one fails.

It has been decided to expose these errors are warnings instead to not break the build where they show up.

### Changes Made
Added some try catch statements so errors do not break builds. Messages have been added to each case for more detail as we do not preserve anything else from the exception.

### Testing
Reenabled unit test and added the previously commented out cases.

### Notes
