### PR TITLE
Improve the message when UsingTask Reference Include is empty

### DIFF
--- a/src/Tasks.UnitTests/CodeTaskFactoryTests.cs
+++ b/src/Tasks.UnitTests/CodeTaskFactoryTests.cs
@@ -283,30 +283,34 @@ namespace Microsoft.Build.UnitTests
         /// <summary>
         /// Verify we get an error if a reference is missing an include attribute is set but it is empty
         /// </summary>
-        [Fact]
-        public void EmptyReferenceInclude()
+        [Theory]
+        [InlineData("")]
+        [InlineData("Include=\"\"")]
+        [InlineData("Include=\" \"")]
+        public void EmptyReferenceInclude(string includeSetting)
         {
-            string projectFileContents = @"
+            string taskName = "CustomTaskFromCodeFactory_EmptyReferenceInclude";
+            string projectFileContents = @$"
                     <Project ToolsVersion='msbuilddefaulttoolsversion'>
-                        <UsingTask TaskName=`CustomTaskFromCodeFactory_EmptyReferenceInclude` TaskFactory=`CodeTaskFactory` AssemblyFile=`$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll` >
+                        <UsingTask TaskName=`{taskName}` TaskFactory=`CodeTaskFactory` AssemblyFile=`$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll` >
                          <ParameterGroup>
                              <Text/>
                           </ParameterGroup>
                             <Task>
-                                 <Reference/>
+                                 <Reference {includeSetting}/>
                                 <Code>
                                        Log.LogMessage(MessageImportance.High, Text);
                                 </Code>
                             </Task>
                         </UsingTask>
                         <Target Name=`Build`>
-                            <CustomTaskFromCodeFactory_EmptyReferenceInclude/>
+                            <{taskName}/>
                         </Target>
                     </Project>";
 
             MockLogger mockLogger = Helpers.BuildProjectWithNewOMExpectFailure(projectFileContents, false);
-            string unformattedMessage = ResourceUtilities.GetResourceString("CodeTaskFactory.AttributeEmpty");
-            mockLogger.AssertLogContains(String.Format(unformattedMessage, "Include"));
+            string unformattedMessage = ResourceUtilities.GetResourceString("CodeTaskFactory.AttributeEmptyWithTaskElement");
+            mockLogger.AssertLogContains(String.Format(unformattedMessage, "Include", "Reference", taskName));
         }
 
         /// <summary>

--- a/src/Tasks.UnitTests/RoslynCodeTaskFactory_Tests.cs
+++ b/src/Tasks.UnitTests/RoslynCodeTaskFactory_Tests.cs
@@ -438,12 +438,15 @@ Log.LogError(Class1.ToPrint());
                 expectedErrorMessage: "You must specify source code within the Code element or a path to a file containing source code.");
         }
 
-        [Fact]
-        public void EmptyIncludeAttributeOnReferenceElement()
+        [Theory]
+        [InlineData("")]
+        [InlineData("Include=\"\"")]
+        [InlineData("Include=\" \"")]
+        public void EmptyIncludeAttributeOnReferenceElement(string includeSetting)
         {
             TryLoadTaskBodyAndExpectFailure(
-                taskBody: "<Reference Include=\"\" />",
-                expectedErrorMessage: "The \"Include\" attribute of the <Reference> element has been set but is empty. If the \"Include\" attribute is set it must not be empty.");
+                taskBody: $"<Reference {includeSetting} />",
+                expectedErrorMessage: $"The \"Include\" attribute of the <Reference> element in the task \"{TaskName}\" has been set but is empty. Make sure the attribute has a proper value.");
         }
 
         [Fact]

--- a/src/Tasks/CodeTaskFactory.cs
+++ b/src/Tasks/CodeTaskFactory.cs
@@ -436,9 +436,9 @@ namespace Microsoft.Build.Tasks
                     return null;
                 }
 
-                if (attribute == null || attribute.Value.Length == 0)
+                if (string.IsNullOrWhiteSpace(attribute?.Value))
                 {
-                    _log.LogErrorWithCodeFromResources("CodeTaskFactory.AttributeEmpty", "Include");
+                    _log.LogErrorWithCodeFromResources("CodeTaskFactory.AttributeEmptyWithTaskElement", "Include", "Reference", _nameOfTask);
                     return null;
                 }
 

--- a/src/Tasks/Resources/Strings.resx
+++ b/src/Tasks/Resources/Strings.resx
@@ -2480,6 +2480,10 @@
     <value>MSB3752: The "{0}" attribute of the &lt;{1}&gt; element has been set but is empty. If the "{0}" attribute is set it must not be empty.</value>
     <comment>{StrBegin="MSB3752: "}</comment>
   </data>
+  <data name="CodeTaskFactory.AttributeEmptyWithTaskElement" xml:space="preserve">
+    <value>MSB3752: The "{0}" attribute of the &lt;{1}&gt; element in the task "{2}" has been set but is empty. Make sure the attribute has a proper value.</value>
+    <comment>{StrBegin="MSB3752: "}</comment>
+  </data>
   <data name="CodeTaskFactory.NeedsITaskInterface" xml:space="preserve">
     <value>MSB3753: The task could not be instantiated because it does not implement the ITask interface. Make sure the task implements the Microsoft.Build.Framework.ITask interface.</value>
     <comment>{StrBegin="MSB3753: "}</comment>

--- a/src/Tasks/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Resources/xlf/Strings.cs.xlf
@@ -131,6 +131,11 @@
         <target state="translated">MSB3654: Pozdržené podepisování požaduje, aby byl určen alespoň veřejný klíč.  Zadejte veřejný klíč pomocí vlastnosti KeyFile nebo KeyContainer, nebo zakažte pozdržené podepisování.</target>
         <note>{StrBegin="MSB3654: "}</note>
       </trans-unit>
+      <trans-unit id="CodeTaskFactory.AttributeEmptyWithTaskElement">
+        <source>MSB3752: The "{0}" attribute of the &lt;{1}&gt; element in the task "{2}" has been set but is empty. Make sure the attribute has a proper value.</source>
+        <target state="new">MSB3752: The "{0}" attribute of the &lt;{1}&gt; element in the task "{2}" has been set but is empty. Make sure the attribute has a proper value.</target>
+        <note>{StrBegin="MSB3752: "}</note>
+      </trans-unit>
       <trans-unit id="CombineTargetFrameworkInfoProperties.NotNullAndEmptyRootElementName">
         <source>MSB3991: '{0}' is not set or empty. When {1} is false, make sure to set a non-empty value for '{0}'.</source>
         <target state="translated">MSB3991: Hodnota {0} není nastavena nebo je prázdná. Pokud {1} má hodnotu false, nezapomeňte pro hodnotu {0} nastavit neprázdnou hodnotu.</target>

--- a/src/Tasks/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Resources/xlf/Strings.de.xlf
@@ -131,6 +131,11 @@
         <target state="translated">MSB3654: Für verzögertes Signieren muss mindestens ein öffentlicher Schlüssel angegeben werden.  Geben Sie entweder einen öffentlichen Schlüssel mithilfe der KeyFile- oder KeyContainer-Eigenschaft an, oder deaktivieren Sie verzögertes Signieren.</target>
         <note>{StrBegin="MSB3654: "}</note>
       </trans-unit>
+      <trans-unit id="CodeTaskFactory.AttributeEmptyWithTaskElement">
+        <source>MSB3752: The "{0}" attribute of the &lt;{1}&gt; element in the task "{2}" has been set but is empty. Make sure the attribute has a proper value.</source>
+        <target state="new">MSB3752: The "{0}" attribute of the &lt;{1}&gt; element in the task "{2}" has been set but is empty. Make sure the attribute has a proper value.</target>
+        <note>{StrBegin="MSB3752: "}</note>
+      </trans-unit>
       <trans-unit id="CombineTargetFrameworkInfoProperties.NotNullAndEmptyRootElementName">
         <source>MSB3991: '{0}' is not set or empty. When {1} is false, make sure to set a non-empty value for '{0}'.</source>
         <target state="translated">MSB3991: „{0}“ ist nicht festgelegt oder leer. Wenn {1} falsch ist, legen Sie für „{0}“ auf keinen Fall einen leeren Wert fest.</target>

--- a/src/Tasks/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Resources/xlf/Strings.es.xlf
@@ -131,6 +131,11 @@
         <target state="translated">MSB3654: La firma retardada requiere que se especifique al menos una clave pública.  Proporcione una clave pública mediante las propiedades KeyFile o KeyContainer, o deshabilite la firma retardada.</target>
         <note>{StrBegin="MSB3654: "}</note>
       </trans-unit>
+      <trans-unit id="CodeTaskFactory.AttributeEmptyWithTaskElement">
+        <source>MSB3752: The "{0}" attribute of the &lt;{1}&gt; element in the task "{2}" has been set but is empty. Make sure the attribute has a proper value.</source>
+        <target state="new">MSB3752: The "{0}" attribute of the &lt;{1}&gt; element in the task "{2}" has been set but is empty. Make sure the attribute has a proper value.</target>
+        <note>{StrBegin="MSB3752: "}</note>
+      </trans-unit>
       <trans-unit id="CombineTargetFrameworkInfoProperties.NotNullAndEmptyRootElementName">
         <source>MSB3991: '{0}' is not set or empty. When {1} is false, make sure to set a non-empty value for '{0}'.</source>
         <target state="translated">MSB3991: "{0}" no se ha establecido o está vacío. Cuando {1} sea false, asegúrese de establecer un valor que no esté vacío para "{0}".</target>

--- a/src/Tasks/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Resources/xlf/Strings.fr.xlf
@@ -131,6 +131,11 @@
         <target state="translated">MSB3654: La signature différée nécessite qu'au moins une clé publique soit spécifiée.  Indiquez une clé publique à l'aide des propriétés KeyFile ou KeyContainer, ou désactivez la signature différée.</target>
         <note>{StrBegin="MSB3654: "}</note>
       </trans-unit>
+      <trans-unit id="CodeTaskFactory.AttributeEmptyWithTaskElement">
+        <source>MSB3752: The "{0}" attribute of the &lt;{1}&gt; element in the task "{2}" has been set but is empty. Make sure the attribute has a proper value.</source>
+        <target state="new">MSB3752: The "{0}" attribute of the &lt;{1}&gt; element in the task "{2}" has been set but is empty. Make sure the attribute has a proper value.</target>
+        <note>{StrBegin="MSB3752: "}</note>
+      </trans-unit>
       <trans-unit id="CombineTargetFrameworkInfoProperties.NotNullAndEmptyRootElementName">
         <source>MSB3991: '{0}' is not set or empty. When {1} is false, make sure to set a non-empty value for '{0}'.</source>
         <target state="translated">MSB3991: « {0} » n’est pas défini ou vide. Quand la valeur de {1} est false, veillez à définir une valeur non vide pour « {0} ».</target>

--- a/src/Tasks/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Resources/xlf/Strings.it.xlf
@@ -131,6 +131,11 @@
         <target state="translated">MSB3654: la firma ritardata richiede che sia specificata almeno una chiave pubblica. Fornire una chiave pubblica usando le proprietà KeyFile o KeyContainer oppure disabilitare la firma ritardata.</target>
         <note>{StrBegin="MSB3654: "}</note>
       </trans-unit>
+      <trans-unit id="CodeTaskFactory.AttributeEmptyWithTaskElement">
+        <source>MSB3752: The "{0}" attribute of the &lt;{1}&gt; element in the task "{2}" has been set but is empty. Make sure the attribute has a proper value.</source>
+        <target state="new">MSB3752: The "{0}" attribute of the &lt;{1}&gt; element in the task "{2}" has been set but is empty. Make sure the attribute has a proper value.</target>
+        <note>{StrBegin="MSB3752: "}</note>
+      </trans-unit>
       <trans-unit id="CombineTargetFrameworkInfoProperties.NotNullAndEmptyRootElementName">
         <source>MSB3991: '{0}' is not set or empty. When {1} is false, make sure to set a non-empty value for '{0}'.</source>
         <target state="translated">MSB3991: '{0}' non è impostato o è vuoto. Quando {1} è false, assicurarsi di impostare un valore non vuoto per '{0}'.</target>

--- a/src/Tasks/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ja.xlf
@@ -131,6 +131,11 @@
         <target state="translated">MSB3654: 遅延署名には、最低でも 1 つの公開キーを指定する必要があります。KeyFile または KeyContainer プロパティを使用して公開キーを提供するか、遅延署名を無効にしてください。</target>
         <note>{StrBegin="MSB3654: "}</note>
       </trans-unit>
+      <trans-unit id="CodeTaskFactory.AttributeEmptyWithTaskElement">
+        <source>MSB3752: The "{0}" attribute of the &lt;{1}&gt; element in the task "{2}" has been set but is empty. Make sure the attribute has a proper value.</source>
+        <target state="new">MSB3752: The "{0}" attribute of the &lt;{1}&gt; element in the task "{2}" has been set but is empty. Make sure the attribute has a proper value.</target>
+        <note>{StrBegin="MSB3752: "}</note>
+      </trans-unit>
       <trans-unit id="CombineTargetFrameworkInfoProperties.NotNullAndEmptyRootElementName">
         <source>MSB3991: '{0}' is not set or empty. When {1} is false, make sure to set a non-empty value for '{0}'.</source>
         <target state="translated">MSB3991: '{0}' が設定されていないか、空です。{1} が false の場合は、'{0}' に空でない値を設定してください。</target>

--- a/src/Tasks/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ko.xlf
@@ -131,6 +131,11 @@
         <target state="translated">MSB3654: 서명을 연기하려면 적어도 공개 키를 지정해야 합니다.  KeyFile 또는 KeyContainer 속성을 사용하여 공개 키를 제공하거나 서명 연기를 비활성화하세요.</target>
         <note>{StrBegin="MSB3654: "}</note>
       </trans-unit>
+      <trans-unit id="CodeTaskFactory.AttributeEmptyWithTaskElement">
+        <source>MSB3752: The "{0}" attribute of the &lt;{1}&gt; element in the task "{2}" has been set but is empty. Make sure the attribute has a proper value.</source>
+        <target state="new">MSB3752: The "{0}" attribute of the &lt;{1}&gt; element in the task "{2}" has been set but is empty. Make sure the attribute has a proper value.</target>
+        <note>{StrBegin="MSB3752: "}</note>
+      </trans-unit>
       <trans-unit id="CombineTargetFrameworkInfoProperties.NotNullAndEmptyRootElementName">
         <source>MSB3991: '{0}' is not set or empty. When {1} is false, make sure to set a non-empty value for '{0}'.</source>
         <target state="translated">MSB3991: '{0}'이(가) 설정되지 않았거나 비어 있습니다. {1}이(가) false인 경우 '{0}'에 비어 있지 않은 값을 설정해야 합니다.</target>

--- a/src/Tasks/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Resources/xlf/Strings.pl.xlf
@@ -131,6 +131,11 @@
         <target state="translated">MSB3654: Podpisywanie opóźnione wymaga określenia przynajmniej klucza publicznego.  Podaj klucz publiczny przy użyciu właściwości KeyFile lub KeyContainer albo wyłącz podpisywanie opóźnione.</target>
         <note>{StrBegin="MSB3654: "}</note>
       </trans-unit>
+      <trans-unit id="CodeTaskFactory.AttributeEmptyWithTaskElement">
+        <source>MSB3752: The "{0}" attribute of the &lt;{1}&gt; element in the task "{2}" has been set but is empty. Make sure the attribute has a proper value.</source>
+        <target state="new">MSB3752: The "{0}" attribute of the &lt;{1}&gt; element in the task "{2}" has been set but is empty. Make sure the attribute has a proper value.</target>
+        <note>{StrBegin="MSB3752: "}</note>
+      </trans-unit>
       <trans-unit id="CombineTargetFrameworkInfoProperties.NotNullAndEmptyRootElementName">
         <source>MSB3991: '{0}' is not set or empty. When {1} is false, make sure to set a non-empty value for '{0}'.</source>
         <target state="translated">MSB3991: „{0}” nie jest ustawiony ani pusty. Jeśli {1} ma wartość false, ustaw wartość, która nie jest pusta dla „{0}”.</target>

--- a/src/Tasks/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Resources/xlf/Strings.pt-BR.xlf
@@ -131,6 +131,11 @@
         <target state="translated">MSB3654: A assinatura atrasada requer que pelo menos uma chave pública seja especificada.  Forneça uma chave pública usando as propriedades KeyFile ou KeyContainer ou desabilite a assinatura atrasada.</target>
         <note>{StrBegin="MSB3654: "}</note>
       </trans-unit>
+      <trans-unit id="CodeTaskFactory.AttributeEmptyWithTaskElement">
+        <source>MSB3752: The "{0}" attribute of the &lt;{1}&gt; element in the task "{2}" has been set but is empty. Make sure the attribute has a proper value.</source>
+        <target state="new">MSB3752: The "{0}" attribute of the &lt;{1}&gt; element in the task "{2}" has been set but is empty. Make sure the attribute has a proper value.</target>
+        <note>{StrBegin="MSB3752: "}</note>
+      </trans-unit>
       <trans-unit id="CombineTargetFrameworkInfoProperties.NotNullAndEmptyRootElementName">
         <source>MSB3991: '{0}' is not set or empty. When {1} is false, make sure to set a non-empty value for '{0}'.</source>
         <target state="translated">MSB3991: '{0}' não está definido ou está vazio. Quando {1} for falso, certifique-se de definir um valor não vazio para '{0}'.</target>

--- a/src/Tasks/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ru.xlf
@@ -131,6 +131,11 @@
         <target state="translated">MSB3654: для отложенного подписывания необходимо указать хотя бы один открытый ключ.  Укажите открытый ключ с помощью свойства KeyFile или KeyContainer либо отключите отложенное подписывание.</target>
         <note>{StrBegin="MSB3654: "}</note>
       </trans-unit>
+      <trans-unit id="CodeTaskFactory.AttributeEmptyWithTaskElement">
+        <source>MSB3752: The "{0}" attribute of the &lt;{1}&gt; element in the task "{2}" has been set but is empty. Make sure the attribute has a proper value.</source>
+        <target state="new">MSB3752: The "{0}" attribute of the &lt;{1}&gt; element in the task "{2}" has been set but is empty. Make sure the attribute has a proper value.</target>
+        <note>{StrBegin="MSB3752: "}</note>
+      </trans-unit>
       <trans-unit id="CombineTargetFrameworkInfoProperties.NotNullAndEmptyRootElementName">
         <source>MSB3991: '{0}' is not set or empty. When {1} is false, make sure to set a non-empty value for '{0}'.</source>
         <target state="translated">MSB3991: "{0}" не настроено или пусто. Если для {1} присвоено значение false, настройте непустое значение для "{0}".</target>

--- a/src/Tasks/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Resources/xlf/Strings.tr.xlf
@@ -131,6 +131,11 @@
         <target state="translated">MSB3654: Gecikmeli imzalama, en azından bir ortak anahtar belirtilmesini gerektirir.  Lütfen KeyFile veya KeyContainer özelliklerini kullanarak bir ortak anahtar sağlayın veya gecikmeli imzalamayı devre dışı bırakın.</target>
         <note>{StrBegin="MSB3654: "}</note>
       </trans-unit>
+      <trans-unit id="CodeTaskFactory.AttributeEmptyWithTaskElement">
+        <source>MSB3752: The "{0}" attribute of the &lt;{1}&gt; element in the task "{2}" has been set but is empty. Make sure the attribute has a proper value.</source>
+        <target state="new">MSB3752: The "{0}" attribute of the &lt;{1}&gt; element in the task "{2}" has been set but is empty. Make sure the attribute has a proper value.</target>
+        <note>{StrBegin="MSB3752: "}</note>
+      </trans-unit>
       <trans-unit id="CombineTargetFrameworkInfoProperties.NotNullAndEmptyRootElementName">
         <source>MSB3991: '{0}' is not set or empty. When {1} is false, make sure to set a non-empty value for '{0}'.</source>
         <target state="translated">MSB3991: '{0}' ayarlanmamış veya boş. {1} yanlış olduğunda, '{0}' için boş olmayan bir değer ayarlandığından emin olun.</target>

--- a/src/Tasks/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Resources/xlf/Strings.zh-Hans.xlf
@@ -131,6 +131,11 @@
         <target state="translated">MSB3654: 延迟签名要求至少指定一个公钥。请使用 KeyFile 或 KeyContainer 属性提供一个公钥，或者禁用延迟签名。</target>
         <note>{StrBegin="MSB3654: "}</note>
       </trans-unit>
+      <trans-unit id="CodeTaskFactory.AttributeEmptyWithTaskElement">
+        <source>MSB3752: The "{0}" attribute of the &lt;{1}&gt; element in the task "{2}" has been set but is empty. Make sure the attribute has a proper value.</source>
+        <target state="new">MSB3752: The "{0}" attribute of the &lt;{1}&gt; element in the task "{2}" has been set but is empty. Make sure the attribute has a proper value.</target>
+        <note>{StrBegin="MSB3752: "}</note>
+      </trans-unit>
       <trans-unit id="CombineTargetFrameworkInfoProperties.NotNullAndEmptyRootElementName">
         <source>MSB3991: '{0}' is not set or empty. When {1} is false, make sure to set a non-empty value for '{0}'.</source>
         <target state="translated">MSB3991: "{0}" 未设置或为空。如果 {1} 为 false，请确保为 "{0}" 设置非空值。</target>

--- a/src/Tasks/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Resources/xlf/Strings.zh-Hant.xlf
@@ -131,6 +131,11 @@
         <target state="translated">MSB3654: 延遲簽署需要至少指定一個公開金鑰。請使用 KeyFile 或 KeyContainer 屬性提供公開金鑰，或停用延遲簽署。</target>
         <note>{StrBegin="MSB3654: "}</note>
       </trans-unit>
+      <trans-unit id="CodeTaskFactory.AttributeEmptyWithTaskElement">
+        <source>MSB3752: The "{0}" attribute of the &lt;{1}&gt; element in the task "{2}" has been set but is empty. Make sure the attribute has a proper value.</source>
+        <target state="new">MSB3752: The "{0}" attribute of the &lt;{1}&gt; element in the task "{2}" has been set but is empty. Make sure the attribute has a proper value.</target>
+        <note>{StrBegin="MSB3752: "}</note>
+      </trans-unit>
       <trans-unit id="CombineTargetFrameworkInfoProperties.NotNullAndEmptyRootElementName">
         <source>MSB3991: '{0}' is not set or empty. When {1} is false, make sure to set a non-empty value for '{0}'.</source>
         <target state="translated">MSB3991: 未設定 '{0}' 或空白。當 {1} 為 false 時，請務必將 '{0}' 設定非空白值。</target>

--- a/src/Tasks/RoslynCodeTaskFactory/RoslynCodeTaskFactory.cs
+++ b/src/Tasks/RoslynCodeTaskFactory/RoslynCodeTaskFactory.cs
@@ -350,7 +350,7 @@ namespace Microsoft.Build.Tasks
                             if (String.IsNullOrWhiteSpace(includeAttribute?.Value))
                             {
                                 // A <Reference Include="" /> is not allowed.
-                                log.LogErrorWithCodeFromResources("CodeTaskFactory.AttributeEmptyWithElement", "Include", "Reference");
+                                log.LogErrorWithCodeFromResources("CodeTaskFactory.AttributeEmptyWithTaskElement", "Include", "Reference", taskName);
                                 return false;
                             }
 


### PR DESCRIPTION
Fixes #10343

### Context
When the attribute `Include` of the element `Reference` in `UsingTask` is empty, the error message is a little repetitive and it doesn't point out the task name.

### Changes Made
Re-phrase the error message with task name.

### Testing
Modified existing tests.

### Notes
