### PR TITLE
add WarningsAsMessages, WarningsAsErrors, WarningsNotAsErrors and Tre…

### DIFF
--- a/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
@@ -1390,7 +1390,8 @@ namespace Microsoft.Build.BackEnd
             // Ensure everything that is required is available at this time
             if (project != null && buildEventContext != null && loggingService != null && buildEventContext.ProjectInstanceId != BuildEventContext.InvalidProjectInstanceId)
             {
-                if (String.Equals(project.GetEngineRequiredPropertyValue(MSBuildConstants.TreatWarningsAsErrors)?.Trim(), "true", StringComparison.OrdinalIgnoreCase))
+                if (String.Equals(project.GetEngineRequiredPropertyValue(MSBuildConstants.TreatWarningsAsErrors)?.Trim(), "true", StringComparison.OrdinalIgnoreCase) ||
+                    String.Equals(project.GetEngineRequiredPropertyValue(MSBuildConstants.TreatWarningsAsErrorsNoPrefix)?.Trim(), "true", StringComparison.OrdinalIgnoreCase))
                 {
                     // If <MSBuildTreatWarningsAsErrors was specified then an empty ISet<string> signals the IEventSourceSink to treat all warnings as errors
                     loggingService.AddWarningsAsErrors(buildEventContext, new HashSet<string>());
@@ -1398,6 +1399,20 @@ namespace Microsoft.Build.BackEnd
                 else
                 {
                     ISet<string> warningsAsErrors = ParseWarningCodes(project.GetEngineRequiredPropertyValue(MSBuildConstants.WarningsAsErrors));
+                    var warningsAsErrorsNoPrefix = ParseWarningCodes(project.GetEngineRequiredPropertyValue(MSBuildConstants.WarningsAsErrorsNoPrefix));
+                    if (warningsAsErrorsNoPrefix != null)
+                    {
+                        if (warningsAsErrors != null)
+                        {
+                            warningsAsErrors.UnionWith(warningsAsErrorsNoPrefix);
+                        }
+                        else
+                        {
+                            warningsAsErrors = warningsAsErrorsNoPrefix;
+                        }
+                    }
+
+
 
                     if (warningsAsErrors?.Count > 0)
                     {
@@ -1406,6 +1421,20 @@ namespace Microsoft.Build.BackEnd
                 }
 
                 ISet<string> warningsNotAsErrors = ParseWarningCodes(project.GetEngineRequiredPropertyValue(MSBuildConstants.WarningsNotAsErrors));
+                var warningsNotAsErrorsNoPrefix = ParseWarningCodes(project.GetEngineRequiredPropertyValue(MSBuildConstants.WarningsNotAsErrorsNoPrefix));
+                if (warningsNotAsErrorsNoPrefix != null)
+                {
+                    if (warningsNotAsErrors != null)
+                    {
+                        warningsNotAsErrors.UnionWith(warningsNotAsErrorsNoPrefix);
+                    }
+                    else
+                    {
+                        warningsNotAsErrors = warningsNotAsErrorsNoPrefix;
+                    }
+                }
+
+
 
                 if (warningsNotAsErrors?.Count > 0)
                 {
@@ -1413,6 +1442,12 @@ namespace Microsoft.Build.BackEnd
                 }
 
                 ISet<string> warningsAsMessages = ParseWarningCodes(project.GetEngineRequiredPropertyValue(MSBuildConstants.WarningsAsMessages));
+                var warningsAsMessagesNoPrefix = ParseWarningCodes(project.GetEngineRequiredPropertyValue(MSBuildConstants.WarningsAsMessagesNoPrefix));
+                if (warningsAsMessagesNoPrefix != null)
+                {
+                    warningsAsMessages?.UnionWith(warningsAsMessagesNoPrefix);
+                    warningsAsMessages ??= warningsAsMessagesNoPrefix;
+                }
 
                 if (warningsAsMessages?.Count > 0)
                 {

--- a/src/Shared/Constants.cs
+++ b/src/Shared/Constants.cs
@@ -34,9 +34,19 @@ namespace Microsoft.Build.Shared
         internal const string TreatWarningsAsErrors = "MSBuildTreatWarningsAsErrors";
 
         /// <summary>
+        /// Name of the property that indicates that all warnings should be treated as errors.
+        /// </summary>
+        internal const string TreatWarningsAsErrorsNoPrefix = "TreatWarningsAsErrors";
+
+        /// <summary>
         /// Name of the property that indicates a list of warnings to treat as errors.
         /// </summary>
         internal const string WarningsAsErrors = "MSBuildWarningsAsErrors";
+
+        /// <summary>
+        /// Name of the property that indicates a list of warnings to treat as errors.
+        /// </summary>
+        internal const string WarningsAsErrorsNoPrefix = "WarningsAsErrors";
 
         /// <summary>
         /// Name of the property that indicates a list of warnings to not treat as errors.
@@ -44,9 +54,20 @@ namespace Microsoft.Build.Shared
         internal const string WarningsNotAsErrors = "MSBuildWarningsNotAsErrors";
 
         /// <summary>
+        /// Name of the property that indicates a list of warnings to not treat as errors.
+        /// </summary>
+        internal const string WarningsNotAsErrorsNoPrefix = "WarningsNotAsErrors";
+
+        /// <summary>
         /// Name of the property that indicates the list of warnings to treat as messages.
         /// </summary>
         internal const string WarningsAsMessages = "MSBuildWarningsAsMessages";
+
+
+        /// <summary>
+        /// Name of the property that indicates the list of warnings to treat as messages.
+        /// </summary>
+        internal const string WarningsAsMessagesNoPrefix = "WarningsAsMessages";
 
         /// <summary>
         /// The name of the environment variable that users can specify to override where NuGet assemblies are loaded from in the NuGetSdkResolver.


### PR DESCRIPTION
…atWarningsAsErrors to the engine (e.g. variant without prefix). test those so that nothing breaks

Fixes #10877

### Context
adding MSBuildWarnings... variants without prefix to the engine.

### Changes Made
added WarningsAsMessages, WarningsAsErrors, WarningsNotAsErrors, TreatWarningsAsErrors to the engine parsing.


### Testing
added a series of unit tests to ensure that these are consistent with the original behavior
further added unit tests to test the interaction & compatibility between the two.

### Notes
