### PR TITLE
ToolTask UseUtf8Encoding value of 'true' is equal to 'always'

### DIFF
--- a/src/Framework/EncodingUtilities.cs
+++ b/src/Framework/EncodingUtilities.cs
@@ -30,6 +30,7 @@ namespace Microsoft.Build.Shared
         internal const string UseUtf8Never = "NEVER";
         internal const string UseUtf8Detect = "DETECT";
         internal const string UseUtf8System = "SYSTEM";
+        internal const string UseUtf8True = "TRUE";
 
         /// <summary>
         /// Get the current system locale code page, OEM version. OEM code pages are used for console-based input/output
@@ -241,6 +242,7 @@ namespace Microsoft.Build.Shared
             switch (useUtf8.ToUpperInvariant())
             {
                 case EncodingUtilities.UseUtf8Always:
+                case EncodingUtilities.UseUtf8True:
                     return EncodingUtilities.Utf8WithoutBom;
                 case EncodingUtilities.UseUtf8Never:
                 case EncodingUtilities.UseUtf8System:

--- a/src/Utilities.UnitTests/EncodingUtilities_Tests.cs
+++ b/src/Utilities.UnitTests/EncodingUtilities_Tests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Build.UnitTests
     public sealed class EncodingUtilities_Tests
     {
         /// <summary>
-        /// Test the CanEncode method with and without ANSI characters to determine if they can be encoded 
+        /// Test the CanEncode method with and without ANSI characters to determine if they can be encoded
         /// in the current system encoding.
         /// </summary>
         [WindowsOnlyFact]
@@ -52,6 +52,15 @@ namespace Microsoft.Build.UnitTests
             testEnvironment.SetEnvironmentVariable(DOTNET_CLI_UI_LANGUAGE, inputLanguage);
 
             EncodingUtilities.GetExternalOverriddenUILanguageIfSupportableWithEncoding().ShouldBeEquivalentTo(new CultureInfo(expectedLanguage));
+        }
+
+        [WindowsOnlyFact]
+        public void BatchFileEncoding_EncodingSpecificationTrueEqualsAlways()
+        {
+            const string content = @"example";
+
+            var alwaysEncoding = EncodingUtilities.BatchFileEncoding(content, EncodingUtilities.UseUtf8Always);
+            EncodingUtilities.BatchFileEncoding(content, EncodingUtilities.UseUtf8True).ShouldBe(alwaysEncoding);
         }
     }
 }


### PR DESCRIPTION
Fixes #10907

### Context
The `UseUtf8Encoding` property of the `Exec` task and other `ToolTask` derived tasks should accept `true` and equivalent to `always`.

### Changes Made
`ToolTask` doesn't validate or interpret the `UseUtf8Encoding` property. The value of the property is passed to and interpreted by `EncodingUtilities.BatchFileEncoding()`.

`EncodingUtilities` was modified to add a const string for `TRUE` and the `BatchFileEncoding()` method was modified to handle `TRUE` and `ALWAYS` the same.

### Testing
Created a unit test that compares the returns for `ALWAYS` and `TRUE`, confirmed that the unit test failed, modified the code, and confirmed the unit test passes.

Tested on Windows.

### Notes
On non-Windows platforms the `UseUtf8Encoding` property has no effect.