### PR TITLE
Support custom culture in RAR

### DIFF
--- a/documentation/wiki/ChangeWaves.md
+++ b/documentation/wiki/ChangeWaves.md
@@ -26,6 +26,7 @@ A wave of features is set to "rotate out" (i.e. become standard functionality) t
 ### 17.14
 - [.SLNX support - use the new parser for .sln and .slnx](https://github.com/dotnet/msbuild/pull/10836)
 - [TreatWarningsAsErrors, WarningsAsMessages, WarningsAsErrors, WarningsNotAsErrors are now supported on the engine side of MSBuild](https://github.com/dotnet/msbuild/pull/10942)
+- [Support custom culture in RAR](https://github.com/dotnet/msbuild/pull/11000)
 
 ### 17.12
 - [Log TaskParameterEvent for scalar parameters](https://github.com/dotnet/msbuild/pull/9908)
@@ -34,7 +35,6 @@ A wave of features is set to "rotate out" (i.e. become standard functionality) t
 - [Add ParameterName and PropertyName to TaskParameterEventArgs](https://github.com/dotnet/msbuild/pull/10130)
 - [Emit eval props if requested by any sink](https://github.com/dotnet/msbuild/pull/10243)
 - [Load Microsoft.DotNet.MSBuildSdkResolver into default load context (MSBuild.exe only)](https://github.com/dotnet/msbuild/pull/10603)
-- [Support custom culture in RAR](https://github.com/dotnet/msbuild/pull/11000)
 
 ### 17.10
 - [AppDomain configuration is serialized without using BinFmt](https://github.com/dotnet/msbuild/pull/9320) - feature can be opted out only if [BinaryFormatter](https://learn.microsoft.com/en-us/dotnet/api/system.runtime.serialization.formatters.binary.binaryformatter) is allowed at runtime by editing `MSBuild.runtimeconfig.json`. **Please note that [any usage of BinaryFormatter is insecure](https://learn.microsoft.com/dotnet/standard/serialization/binaryformatter-security-guide).**

--- a/documentation/wiki/ChangeWaves.md
+++ b/documentation/wiki/ChangeWaves.md
@@ -33,6 +33,7 @@ A wave of features is set to "rotate out" (i.e. become standard functionality) t
 - [Add ParameterName and PropertyName to TaskParameterEventArgs](https://github.com/dotnet/msbuild/pull/10130)
 - [Emit eval props if requested by any sink](https://github.com/dotnet/msbuild/pull/10243)
 - [Load Microsoft.DotNet.MSBuildSdkResolver into default load context (MSBuild.exe only)](https://github.com/dotnet/msbuild/pull/10603)
+- [Support custom culture in RAR](https://github.com/dotnet/msbuild/pull/11000)
 
 ### 17.10
 - [AppDomain configuration is serialized without using BinFmt](https://github.com/dotnet/msbuild/pull/9320) - feature can be opted out only if [BinaryFormatter](https://learn.microsoft.com/en-us/dotnet/api/system.runtime.serialization.formatters.binary.binaryformatter) is allowed at runtime by editing `MSBuild.runtimeconfig.json`. **Please note that [any usage of BinaryFormatter is insecure](https://learn.microsoft.com/dotnet/standard/serialization/binaryformatter-security-guide).**

--- a/src/BuildCheck.UnitTests/EndToEndTests.cs
+++ b/src/BuildCheck.UnitTests/EndToEndTests.cs
@@ -64,54 +64,102 @@ public class EndToEndTests : IDisposable
         Regex.Matches(output, "BC0203 .* Property").Count.ShouldBe(2);
     }
 
-    // <EmbeddedResource Update = "Resource1.cs.resx" />
-
     [Theory]
+    // The culture is not set explicitly, but the extension is a known culture
+    //  - a buildcheck warning will occur, but otherwise works
     [InlineData(
         "cs",
         "cs",
         """<EmbeddedResource Update = "Resource1.cs.resx" />""",
-        "warning BC0105: .* 'Resource1\\.cs\\.resx'")]
-    // Following tests are prepared after the EmbeddedCulture handling fix is merged: https://github.com/dotnet/msbuild/pull/11000
-    ////[InlineData(
-    ////    "xyz",
-    ////    "xyz",
-    ////    """<EmbeddedResource Update = "Resource1.xyz.resx" />""",
-    ////    "warning BC0105: .* 'Resource1\\.xyz\\.resx'")]
-    ////[InlineData(
-    ////    "xyz",
-    ////    "zyx",
-    ////    """<EmbeddedResource Update = "Resource1.zyx.resx" Culture="xyz" />""",
-    ////    "")]
-    public void EmbeddedResourceCheckTest(string culture, string resourceExtension, string resourceElement, string expectedDiagnostic)
+        false,
+        "warning BC0105: .* 'Resource1\\.cs\\.resx'",
+        true)]
+    // The culture is not set explicitly, and is not a known culture
+    //  - a buildcheck warning will occur, and resource is not recognized as culture specific - won't be copied around
+    [InlineData(
+        "xyz",
+        "xyz",
+        """<EmbeddedResource Update = "Resource1.xyz.resx" />""",
+        false,
+        "warning BC0105: .* 'Resource1\\.xyz\\.resx'",
+        false)]
+    // The culture is explicitly set, and it is not a known culture, but $(RespectAlreadyAssignedItemCulture) is set to true
+    //  - no warning will occur, and resource is recognized as culture specific - and copied around
+    [InlineData(
+        "xyz",
+        "xyz",
+        """<EmbeddedResource Update = "Resource1.xyz.resx" Culture="xyz" />""",
+        true,
+        "",
+        true)]
+    // The culture is explicitly set, and it is not a known culture and $(RespectAlreadyAssignedItemCulture) is not set to true
+    //  - so culture is overwritten, and resource is not recognized as culture specific - won't be copied around
+    [InlineData(
+        "xyz",
+        "zyx",
+        """<EmbeddedResource Update = "Resource1.zyx.resx" Culture="xyz" />""",
+        false,
+        "warning MSB3002: Explicitly set culture .* was overwritten",
+        false)]
+    // The culture is explicitly set, and it is not a known culture, but $(RespectAlreadyAssignedItemCulture) is set to true
+    //  - no warning will occur, and resource is recognized as culture specific - and copied around
+    [InlineData(
+        "xyz",
+        "zyx",
+        """<EmbeddedResource Update = "Resource1.zyx.resx" Culture="xyz" />""",
+        true,
+        "",
+        true)]
+    public void EmbeddedResourceCheckTest(
+        string culture,
+        string resourceExtension,
+        string resourceElement,
+        bool respectAssignedCulturePropSet,
+        string expectedDiagnostic,
+        bool resourceExpectedToBeRecognizedAsSatelite)
     {
-        EmbedResourceTestOutput output = RunEmbeddedResourceTest(resourceElement, resourceExtension);
+        EmbedResourceTestOutput output = RunEmbeddedResourceTest(resourceElement, resourceExtension, respectAssignedCulturePropSet);
 
+        int expectedWarningsCount = 0;
         // each finding should be found just once - but reported twice, due to summary
         if (!string.IsNullOrEmpty(expectedDiagnostic))
         {
             Regex.Matches(output.LogOutput, expectedDiagnostic).Count.ShouldBe(2);
+            expectedWarningsCount = 1;
         }
 
-        AssertHasResourceForCulture("en");
-        AssertHasResourceForCulture(culture);
-        output.DepsJsonResources.Count.ShouldBe(2);
+        AssertHasResourceForCulture("en", true);
+        AssertHasResourceForCulture(culture, resourceExpectedToBeRecognizedAsSatelite);
+        output.DepsJsonResources.Count.ShouldBe(resourceExpectedToBeRecognizedAsSatelite ? 2 : 1);
+        GetWarningsCount(output.LogOutput).ShouldBe(expectedWarningsCount);
 
-        void AssertHasResourceForCulture(string culture)
+        void AssertHasResourceForCulture(string culture, bool isResourceExpected)
         {
             KeyValuePair<string, JsonNode?> resource = output.DepsJsonResources.FirstOrDefault(
                 o => o.Value?["locale"]?.ToString().Equals(culture, StringComparison.Ordinal) ?? false);
-            resource.Equals(default(KeyValuePair<string, JsonNode?>)).ShouldBe(false,
-                $"Resource for culture {culture} was not found in deps.json:{Environment.NewLine}{output.DepsJsonResources.ToString()}");
+            // if not found - the KVP will be default
+            resource.Equals(default(KeyValuePair<string, JsonNode?>)).ShouldBe(!isResourceExpected,
+                $"Resource for culture {culture} was {(isResourceExpected ? "not " : "")}found in deps.json:{Environment.NewLine}{output.DepsJsonResources.ToString()}");
 
-            resource.Key.ShouldBeEquivalentTo($"{culture}/ReferencedProject.resources.dll",
-                $"Unexpected resource for culture {culture} was found in deps.json:{Environment.NewLine}{output.DepsJsonResources.ToString()}");
+            if (isResourceExpected)
+            {
+                resource.Key.ShouldBeEquivalentTo($"{culture}/ReferencedProject.resources.dll",
+                    $"Unexpected resource for culture {culture} was found in deps.json:{Environment.NewLine}{output.DepsJsonResources.ToString()}");
+            }
+        }
+
+        int GetWarningsCount(string output)
+        {
+            Regex regex = new Regex(@"(\d+) Warning\(s\)");
+            Match match = regex.Match(output);
+            match.Success.ShouldBeTrue("Expected Warnings section not found in the build output.");
+            return int.Parse(match.Groups[1].Value);
         }
     }
 
     private readonly record struct EmbedResourceTestOutput(String LogOutput, JsonObject DepsJsonResources);
 
-    private EmbedResourceTestOutput RunEmbeddedResourceTest(string resourceXmlToAdd, string resourceExtension)
+    private EmbedResourceTestOutput RunEmbeddedResourceTest(string resourceXmlToAdd, string resourceExtension, bool respectCulture)
     {
         string testAssetsFolderName = "EmbeddedResourceTest";
         const string entryProjectName = "EntryProject";
@@ -128,7 +176,7 @@ public class EndToEndTests : IDisposable
 
         _env.SetCurrentDirectory(Path.Combine(workFolder.Path, entryProjectName));
 
-        string output = RunnerUtilities.ExecBootstrapedMSBuild("-check -restore", out bool success);
+        string output = RunnerUtilities.ExecBootstrapedMSBuild("-check -restore /p:RespectCulture=" + (respectCulture ? "True" : "\"\""), out bool success);
         _env.Output.WriteLine(output);
         _env.Output.WriteLine("=========================");
         success.ShouldBeTrue();

--- a/src/BuildCheck.UnitTests/TestAssets/EmbeddedResourceTest/ReferencedProject/ReferencedProject.csproj
+++ b/src/BuildCheck.UnitTests/TestAssets/EmbeddedResourceTest/ReferencedProject/ReferencedProject.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <!-- Target net8.0 - as from net9.0 the RespectAlreadyAssignedItemCulture is added by common targets. -->
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
@@ -15,7 +16,7 @@
   </ItemGroup>
 
 	<PropertyGroup>
-		<RespectAlreadyAssignedItemCulture>True</RespectAlreadyAssignedItemCulture>
+		<RespectAlreadyAssignedItemCulture>$(RespectCulture)</RespectAlreadyAssignedItemCulture>
 	</PropertyGroup>
 
   <ItemGroup>

--- a/src/Framework/StringUtils.cs
+++ b/src/Framework/StringUtils.cs
@@ -41,7 +41,7 @@ internal static class StringUtils
     /// <returns>The original string (if no occurrences found) or a new string, with last instance of <paramref name="substring"/> removed.</returns>
     internal static string RemoveLastInstanceOf(this string fromString, string substring, StringComparison comparison = StringComparison.Ordinal)
     {
-        int lastOccurrenceIndex = fromString.LastIndexOf(substring, StringComparison.Ordinal);
+        int lastOccurrenceIndex = fromString.LastIndexOf(substring, comparison);
 
         if (lastOccurrenceIndex != -1)
         {

--- a/src/Framework/StringUtils.cs
+++ b/src/Framework/StringUtils.cs
@@ -31,4 +31,24 @@ internal static class StringUtils
         string randomBase64String = Convert.ToBase64String(randomBytes).Replace('/', '_');
         return randomBase64String.Substring(0, length);
     }
+
+    /// <summary>
+    /// Removes last occurence of <paramref name="substring"/> from <paramref name="fromString"/>, if present.
+    /// </summary>
+    /// <param name="fromString">String to be altered.</param>
+    /// <param name="substring">String to be removed.</param>
+    /// <param name="comparison">The comparison to use for finding.</param>
+    /// <returns>The original string (if no occurrences found) or a new string, with last instance of <paramref name="substring"/> removed.</returns>
+    internal static string RemoveLastInstanceOf(this string fromString, string substring, StringComparison comparison = StringComparison.Ordinal)
+    {
+        int lastOccurrenceIndex = fromString.LastIndexOf(substring, StringComparison.Ordinal);
+
+        if (lastOccurrenceIndex != -1)
+        {
+            fromString = fromString.Substring(0, lastOccurrenceIndex) +
+                         fromString.Substring(lastOccurrenceIndex + substring.Length);
+        }
+
+        return fromString;
+    }
 }

--- a/src/Tasks/AssemblyDependency/ReferenceTable.cs
+++ b/src/Tasks/AssemblyDependency/ReferenceTable.cs
@@ -971,7 +971,8 @@ namespace Microsoft.Build.Tasks
                     // Is there a candidate satellite in that folder?
                     string cultureName = Path.GetFileName(subDirectory);
 
-                    if (CultureInfoCache.IsValidCultureString(cultureName))
+                    // Custom or unknown cultures can be met as well
+                    if (ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_14) || CultureInfoCache.IsValidCultureString(cultureName))
                     {
                         string satelliteAssembly = Path.Combine(subDirectory, satelliteFilename);
                         if (_fileExists(satelliteAssembly))

--- a/src/Tasks/AssignCulture.cs
+++ b/src/Tasks/AssignCulture.cs
@@ -164,7 +164,7 @@ namespace Microsoft.Build.Tasks
                             !MSBuildNameIgnoreCaseComparer.Default.Equals(existingCulture, info.culture) &&
                             ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_14))
                         {
-                            Log.LogWarningFromResources("AssignCulture.CultureOverwritten",
+                            Log.LogWarningWithCodeFromResources("AssignCulture.CultureOverwritten",
                                 existingCulture, AssignedFiles[i].ItemSpec, info.culture);
                         }
 

--- a/src/Tasks/AssignCulture.cs
+++ b/src/Tasks/AssignCulture.cs
@@ -160,9 +160,9 @@ namespace Microsoft.Build.Tasks
                             ConversionUtilities.ValidBooleanFalse(AssignedFiles[i].GetMetadata(ItemMetadataNames.withCulture)));
 
                         // The culture was explicitly specified, but not opted in via 'RespectAlreadyAssignedItemCulture' and different will be used
-                        if (!string.IsNullOrEmpty(existingCulture) &&
-                            !MSBuildNameIgnoreCaseComparer.Default.Equals(existingCulture, info.culture) &&
-                            ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_14))
+                        if (ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_14) &&
+                            !string.IsNullOrEmpty(existingCulture) &&
+                            !MSBuildNameIgnoreCaseComparer.Default.Equals(existingCulture, info.culture))
                         {
                             Log.LogWarningWithCodeFromResources("AssignCulture.CultureOverwritten",
                                 existingCulture, AssignedFiles[i].ItemSpec, info.culture);

--- a/src/Tasks/AssignCulture.cs
+++ b/src/Tasks/AssignCulture.cs
@@ -166,6 +166,11 @@ namespace Microsoft.Build.Tasks
                         {
                             Log.LogWarningWithCodeFromResources("AssignCulture.CultureOverwritten",
                                 existingCulture, AssignedFiles[i].ItemSpec, info.culture);
+                            // Remove the culture if it's not recognized
+                            if (string.IsNullOrEmpty(info.culture))
+                            {
+                                AssignedFiles[i].RemoveMetadata(ItemMetadataNames.culture);
+                            }
                         }
 
                         if (!string.IsNullOrEmpty(info.culture))

--- a/src/Tasks/AssignCulture.cs
+++ b/src/Tasks/AssignCulture.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using Microsoft.Build.Collections;
 #if DEBUG
 using System.Diagnostics;
 #endif
@@ -157,6 +158,15 @@ namespace Microsoft.Build.Tasks
                             // If 'WithCulture' is explicitly set to false, treat as 'culture-neutral' and keep the original name of the resource.
                             // https://github.com/dotnet/msbuild/issues/3064
                             ConversionUtilities.ValidBooleanFalse(AssignedFiles[i].GetMetadata(ItemMetadataNames.withCulture)));
+
+                        // The culture was explicitly specified, but not opted in via 'RespectAlreadyAssignedItemCulture' and different will be used
+                        if (!string.IsNullOrEmpty(existingCulture) &&
+                            !MSBuildNameIgnoreCaseComparer.Default.Equals(existingCulture, info.culture) &&
+                            ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_14))
+                        {
+                            Log.LogWarningFromResources("AssignCulture.CultureOverwritten",
+                                existingCulture, AssignedFiles[i].ItemSpec, info.culture);
+                        }
 
                         if (!string.IsNullOrEmpty(info.culture))
                         {

--- a/src/Tasks/CreateCSharpManifestResourceName.cs
+++ b/src/Tasks/CreateCSharpManifestResourceName.cs
@@ -101,12 +101,25 @@ namespace Microsoft.Build.Tasks
             }
 
             dependentUponFileName = FileUtilities.FixFilePath(dependentUponFileName);
-            Culture.ItemCultureInfo info = Culture.GetItemCultureInfo(embeddedFileName, dependentUponFileName, treatAsCultureNeutral);
+            Culture.ItemCultureInfo info;
 
-            // If the item has a culture override, respect that.
-            if (!string.IsNullOrEmpty(culture))
+            if (!string.IsNullOrEmpty(culture) && ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_14))
             {
-                info.culture = culture;
+                info = new Culture.ItemCultureInfo()
+                {
+                    culture = culture,
+                    cultureNeutralFilename =
+                        embeddedFileName.RemoveLastInstanceOf("." + culture, StringComparison.OrdinalIgnoreCase)
+                };
+            }
+            else
+            {
+                info = Culture.GetItemCultureInfo(embeddedFileName, dependentUponFileName, treatAsCultureNeutral);
+                // If the item has a culture override, respect that.
+                if (!string.IsNullOrEmpty(culture))
+                {
+                    info.culture = culture;
+                }
             }
 
             var manifestName = StringBuilderCache.Acquire();

--- a/src/Tasks/CreateCSharpManifestResourceName.cs
+++ b/src/Tasks/CreateCSharpManifestResourceName.cs
@@ -116,6 +116,7 @@ namespace Microsoft.Build.Tasks
             {
                 info = Culture.GetItemCultureInfo(embeddedFileName, dependentUponFileName, treatAsCultureNeutral);
                 // If the item has a culture override, respect that.
+                // We need to recheck here due to changewave in condition above - after Wave17_14 removal, this should be unconditional.
                 if (!string.IsNullOrEmpty(culture))
                 {
                     info.culture = culture;

--- a/src/Tasks/CreateVisualBasicManifestResourceName.cs
+++ b/src/Tasks/CreateVisualBasicManifestResourceName.cs
@@ -115,6 +115,7 @@ namespace Microsoft.Build.Tasks
             {
                 info = Culture.GetItemCultureInfo(embeddedFileName, dependentUponFileName, treatAsCultureNeutral);
                 // If the item has a culture override, respect that.
+                // We need to recheck here due to changewave in condition above - after Wave17_14 removal, this should be unconditional.
                 if (!string.IsNullOrEmpty(culture))
                 {
                     info.culture = culture;

--- a/src/Tasks/CreateVisualBasicManifestResourceName.cs
+++ b/src/Tasks/CreateVisualBasicManifestResourceName.cs
@@ -99,12 +99,26 @@ namespace Microsoft.Build.Tasks
                 embeddedFileName = fileName;
             }
 
-            Culture.ItemCultureInfo info = Culture.GetItemCultureInfo(embeddedFileName, dependentUponFileName, treatAsCultureNeutral);
+            dependentUponFileName = FileUtilities.FixFilePath(dependentUponFileName);
+            Culture.ItemCultureInfo info;
 
-            // If the item has a culture override, respect that.
-            if (!string.IsNullOrEmpty(culture))
+            if (!string.IsNullOrEmpty(culture) && ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_14))
             {
-                info.culture = culture;
+                info = new Culture.ItemCultureInfo()
+                {
+                    culture = culture,
+                    cultureNeutralFilename =
+                        embeddedFileName.RemoveLastInstanceOf("." + culture, StringComparison.OrdinalIgnoreCase)
+                };
+            }
+            else
+            {
+                info = Culture.GetItemCultureInfo(embeddedFileName, dependentUponFileName, treatAsCultureNeutral);
+                // If the item has a culture override, respect that.
+                if (!string.IsNullOrEmpty(culture))
+                {
+                    info.culture = culture;
+                }
             }
 
             var manifestName = StringBuilderCache.Acquire();

--- a/src/Tasks/Resources/Strings.resx
+++ b/src/Tasks/Resources/Strings.resx
@@ -149,6 +149,13 @@
   <data name="AssignCulture.Comment">
     <value>Culture of "{0}" was assigned to file "{1}".</value>
   </data>
+  <data name="AssignCulture.CultureOverwritten">
+    <value>MSB3002: Explicitly set culture "{0}" for item "{1}" was overwritten with inferred culture "{2}", because 'RespectAlreadyAssignedItemCulture' property was not set.</value>
+    <comment>
+	{StrBegin="MSB3002: "}
+	'RespectAlreadyAssignedItemCulture' should not be translated
+	</comment>
+  </data>
   <!--
         The AxImp message bucket is: MSB3656 - MSB3660.
 

--- a/src/Tasks/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Resources/xlf/Strings.cs.xlf
@@ -37,6 +37,14 @@
         <target state="translated">Došlo k potížím při analýze atributu newVersion. {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="AssignCulture.CultureOverwritten">
+        <source>MSB3002: Explicitly set culture "{0}" for item "{1}" was overwritten with inferred culture "{2}", because 'RespectAlreadyAssignedItemCulture' property was not set.</source>
+        <target state="new">MSB3002: Explicitly set culture "{0}" for item "{1}" was overwritten with inferred culture "{2}", because 'RespectAlreadyAssignedItemCulture' property was not set.</target>
+        <note>
+	{StrBegin="MSB3002: "}
+	'RespectAlreadyAssignedItemCulture' should not be translated
+	</note>
+      </trans-unit>
       <trans-unit id="AssignProjectConfiguration.IllegalMappingString">
         <source>The platform mapping "{0}" in the platform mapping list "{1}" is malformed.  Please only pass in a semicolon-delimited list of constant string values separated by "=", e.g., "foo=bar;foo2=bar2".</source>
         <target state="translated">Mapování platformy {0} v seznamu mapování platforem {1} má chybný tvar.  Smí se předat jenom seznam dvojic řetězcových konstant oddělených znakem =, které jsou od sebe odděleny středníkem, např. foo=bar;foo2=bar2.</target>

--- a/src/Tasks/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Resources/xlf/Strings.de.xlf
@@ -37,6 +37,14 @@
         <target state="translated">Problem beim Analysieren des newVersion-Attributs. {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="AssignCulture.CultureOverwritten">
+        <source>MSB3002: Explicitly set culture "{0}" for item "{1}" was overwritten with inferred culture "{2}", because 'RespectAlreadyAssignedItemCulture' property was not set.</source>
+        <target state="new">MSB3002: Explicitly set culture "{0}" for item "{1}" was overwritten with inferred culture "{2}", because 'RespectAlreadyAssignedItemCulture' property was not set.</target>
+        <note>
+	{StrBegin="MSB3002: "}
+	'RespectAlreadyAssignedItemCulture' should not be translated
+	</note>
+      </trans-unit>
       <trans-unit id="AssignProjectConfiguration.IllegalMappingString">
         <source>The platform mapping "{0}" in the platform mapping list "{1}" is malformed.  Please only pass in a semicolon-delimited list of constant string values separated by "=", e.g., "foo=bar;foo2=bar2".</source>
         <target state="translated">Die Plattformzuordnung "{0}" in der Plattformzuordnungsliste "{1}" ist falsch formatiert.  Übergeben Sie nur eine durch Semikolons getrennte Liste von konstanten Zeichenfolgenwerten, die durch "=" getrennt sind, z. B. "foo=bar;foo2=bar2".</target>

--- a/src/Tasks/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Resources/xlf/Strings.es.xlf
@@ -37,6 +37,14 @@
         <target state="translated">Error al analizar el atributo newVersion. {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="AssignCulture.CultureOverwritten">
+        <source>MSB3002: Explicitly set culture "{0}" for item "{1}" was overwritten with inferred culture "{2}", because 'RespectAlreadyAssignedItemCulture' property was not set.</source>
+        <target state="new">MSB3002: Explicitly set culture "{0}" for item "{1}" was overwritten with inferred culture "{2}", because 'RespectAlreadyAssignedItemCulture' property was not set.</target>
+        <note>
+	{StrBegin="MSB3002: "}
+	'RespectAlreadyAssignedItemCulture' should not be translated
+	</note>
+      </trans-unit>
       <trans-unit id="AssignProjectConfiguration.IllegalMappingString">
         <source>The platform mapping "{0}" in the platform mapping list "{1}" is malformed.  Please only pass in a semicolon-delimited list of constant string values separated by "=", e.g., "foo=bar;foo2=bar2".</source>
         <target state="translated">El formato de la asignación de plataforma "{0}" de la lista de asignaciones de plataforma "{1}" es incorrecto.  Pase solamente una lista de valores de cadena constantes delimitados por signos de punto y coma y separados por "=", p. ej., "foo=bar;foo2=bar2".</target>

--- a/src/Tasks/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Resources/xlf/Strings.fr.xlf
@@ -37,6 +37,14 @@
         <target state="translated">Un problème s'est produit lors de l'analyse de l'attribut newVersion. {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="AssignCulture.CultureOverwritten">
+        <source>MSB3002: Explicitly set culture "{0}" for item "{1}" was overwritten with inferred culture "{2}", because 'RespectAlreadyAssignedItemCulture' property was not set.</source>
+        <target state="new">MSB3002: Explicitly set culture "{0}" for item "{1}" was overwritten with inferred culture "{2}", because 'RespectAlreadyAssignedItemCulture' property was not set.</target>
+        <note>
+	{StrBegin="MSB3002: "}
+	'RespectAlreadyAssignedItemCulture' should not be translated
+	</note>
+      </trans-unit>
       <trans-unit id="AssignProjectConfiguration.IllegalMappingString">
         <source>The platform mapping "{0}" in the platform mapping list "{1}" is malformed.  Please only pass in a semicolon-delimited list of constant string values separated by "=", e.g., "foo=bar;foo2=bar2".</source>
         <target state="translated">Le mappage de plateforme "{0}" de la liste de mappage de plateforme "{1}" est incorrect.  Passez uniquement une liste séparée par des points-virgules contenant des valeurs de chaîne constantes séparées par "=" (par exemple, "foo=bar;foo2=bar2").</target>

--- a/src/Tasks/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Resources/xlf/Strings.it.xlf
@@ -37,6 +37,14 @@
         <target state="translated">Problema durante l'analisi dell'attributo newVersion. {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="AssignCulture.CultureOverwritten">
+        <source>MSB3002: Explicitly set culture "{0}" for item "{1}" was overwritten with inferred culture "{2}", because 'RespectAlreadyAssignedItemCulture' property was not set.</source>
+        <target state="new">MSB3002: Explicitly set culture "{0}" for item "{1}" was overwritten with inferred culture "{2}", because 'RespectAlreadyAssignedItemCulture' property was not set.</target>
+        <note>
+	{StrBegin="MSB3002: "}
+	'RespectAlreadyAssignedItemCulture' should not be translated
+	</note>
+      </trans-unit>
       <trans-unit id="AssignProjectConfiguration.IllegalMappingString">
         <source>The platform mapping "{0}" in the platform mapping list "{1}" is malformed.  Please only pass in a semicolon-delimited list of constant string values separated by "=", e.g., "foo=bar;foo2=bar2".</source>
         <target state="translated">Il mapping di piattaforma "{0}" nell'elenco dei mapping di piattaforma "{1}" non è valido. Passare solo un elenco di valori stringa costanti delimitati da punti e virgola e separati da "=", ad esempio "foo=bar;foo2=bar2".</target>

--- a/src/Tasks/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ja.xlf
@@ -37,6 +37,14 @@
         <target state="translated">newVersion 属性の解析中に問題が発生しました。{0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="AssignCulture.CultureOverwritten">
+        <source>MSB3002: Explicitly set culture "{0}" for item "{1}" was overwritten with inferred culture "{2}", because 'RespectAlreadyAssignedItemCulture' property was not set.</source>
+        <target state="new">MSB3002: Explicitly set culture "{0}" for item "{1}" was overwritten with inferred culture "{2}", because 'RespectAlreadyAssignedItemCulture' property was not set.</target>
+        <note>
+	{StrBegin="MSB3002: "}
+	'RespectAlreadyAssignedItemCulture' should not be translated
+	</note>
+      </trans-unit>
       <trans-unit id="AssignProjectConfiguration.IllegalMappingString">
         <source>The platform mapping "{0}" in the platform mapping list "{1}" is malformed.  Please only pass in a semicolon-delimited list of constant string values separated by "=", e.g., "foo=bar;foo2=bar2".</source>
         <target state="translated">プラットフォーム マッピング リスト "{1}" のプラットフォーム マッピング "{0}" の形式が正しくありません。定数文字列値が "=" で分けられたセミコロン区切りリストのみ渡してください (例: "foo=bar;foo2=bar2")。</target>

--- a/src/Tasks/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ko.xlf
@@ -37,6 +37,14 @@
         <target state="translated">newVersion 특성을 구문 분석하는 동안 문제가 발생했습니다. {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="AssignCulture.CultureOverwritten">
+        <source>MSB3002: Explicitly set culture "{0}" for item "{1}" was overwritten with inferred culture "{2}", because 'RespectAlreadyAssignedItemCulture' property was not set.</source>
+        <target state="new">MSB3002: Explicitly set culture "{0}" for item "{1}" was overwritten with inferred culture "{2}", because 'RespectAlreadyAssignedItemCulture' property was not set.</target>
+        <note>
+	{StrBegin="MSB3002: "}
+	'RespectAlreadyAssignedItemCulture' should not be translated
+	</note>
+      </trans-unit>
       <trans-unit id="AssignProjectConfiguration.IllegalMappingString">
         <source>The platform mapping "{0}" in the platform mapping list "{1}" is malformed.  Please only pass in a semicolon-delimited list of constant string values separated by "=", e.g., "foo=bar;foo2=bar2".</source>
         <target state="translated">플랫폼 매핑 목록 "{1}"에 있는 플랫폼 매핑 "{0}"의 형식이 잘못되었습니다.  세미콜론으로 구분된 상수 문자열 값 목록만 "="로 구분하여 전달하세요. 예: "foo=bar;foo2=bar2"</target>

--- a/src/Tasks/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Resources/xlf/Strings.pl.xlf
@@ -37,6 +37,14 @@
         <target state="translated">Wystąpił problem z analizowaniem atrybutu newVersion. {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="AssignCulture.CultureOverwritten">
+        <source>MSB3002: Explicitly set culture "{0}" for item "{1}" was overwritten with inferred culture "{2}", because 'RespectAlreadyAssignedItemCulture' property was not set.</source>
+        <target state="new">MSB3002: Explicitly set culture "{0}" for item "{1}" was overwritten with inferred culture "{2}", because 'RespectAlreadyAssignedItemCulture' property was not set.</target>
+        <note>
+	{StrBegin="MSB3002: "}
+	'RespectAlreadyAssignedItemCulture' should not be translated
+	</note>
+      </trans-unit>
       <trans-unit id="AssignProjectConfiguration.IllegalMappingString">
         <source>The platform mapping "{0}" in the platform mapping list "{1}" is malformed.  Please only pass in a semicolon-delimited list of constant string values separated by "=", e.g., "foo=bar;foo2=bar2".</source>
         <target state="translated">Mapowanie platformy „{0}” na liście mapowania platform „{1}” ma zły format.  Przekaż tylko listę stałych wartości ciągów rozdzielonych znakiem „=” i oddzielonych średnikami (np. „foo=bar;foo2=bar2”).</target>

--- a/src/Tasks/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Resources/xlf/Strings.pt-BR.xlf
@@ -37,6 +37,14 @@
         <target state="translated">Houve um problema ao analisar o atributo newVersion. {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="AssignCulture.CultureOverwritten">
+        <source>MSB3002: Explicitly set culture "{0}" for item "{1}" was overwritten with inferred culture "{2}", because 'RespectAlreadyAssignedItemCulture' property was not set.</source>
+        <target state="new">MSB3002: Explicitly set culture "{0}" for item "{1}" was overwritten with inferred culture "{2}", because 'RespectAlreadyAssignedItemCulture' property was not set.</target>
+        <note>
+	{StrBegin="MSB3002: "}
+	'RespectAlreadyAssignedItemCulture' should not be translated
+	</note>
+      </trans-unit>
       <trans-unit id="AssignProjectConfiguration.IllegalMappingString">
         <source>The platform mapping "{0}" in the platform mapping list "{1}" is malformed.  Please only pass in a semicolon-delimited list of constant string values separated by "=", e.g., "foo=bar;foo2=bar2".</source>
         <target state="translated">O mapeamento de plataforma "{0}" da lista de mapeamentos de plataforma "{1}" está malformado.  Passe apenas uma lista delimitada por ponto e vírgula de valores de cadeia de caracteres constantes separados por "=", por exemplo, "foo=bar;foo2=bar2".</target>

--- a/src/Tasks/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ru.xlf
@@ -37,6 +37,14 @@
         <target state="translated">При синтаксическом анализе атрибута newVersion произошла ошибка. {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="AssignCulture.CultureOverwritten">
+        <source>MSB3002: Explicitly set culture "{0}" for item "{1}" was overwritten with inferred culture "{2}", because 'RespectAlreadyAssignedItemCulture' property was not set.</source>
+        <target state="new">MSB3002: Explicitly set culture "{0}" for item "{1}" was overwritten with inferred culture "{2}", because 'RespectAlreadyAssignedItemCulture' property was not set.</target>
+        <note>
+	{StrBegin="MSB3002: "}
+	'RespectAlreadyAssignedItemCulture' should not be translated
+	</note>
+      </trans-unit>
       <trans-unit id="AssignProjectConfiguration.IllegalMappingString">
         <source>The platform mapping "{0}" in the platform mapping list "{1}" is malformed.  Please only pass in a semicolon-delimited list of constant string values separated by "=", e.g., "foo=bar;foo2=bar2".</source>
         <target state="translated">Неправильный формат сопоставления платформы "{0}" в списке сопоставлений платформ "{1}".  Данные должны передаваться только в виде списка, разделенного точкой с запятой, строковых констант, разделенных знаком "=". Например, "foo=bar;foo2=bar2".</target>

--- a/src/Tasks/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Resources/xlf/Strings.tr.xlf
@@ -37,6 +37,14 @@
         <target state="translated">newVersion özniteliğinin ayrıştırılmasında bir sorun oluştu. {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="AssignCulture.CultureOverwritten">
+        <source>MSB3002: Explicitly set culture "{0}" for item "{1}" was overwritten with inferred culture "{2}", because 'RespectAlreadyAssignedItemCulture' property was not set.</source>
+        <target state="new">MSB3002: Explicitly set culture "{0}" for item "{1}" was overwritten with inferred culture "{2}", because 'RespectAlreadyAssignedItemCulture' property was not set.</target>
+        <note>
+	{StrBegin="MSB3002: "}
+	'RespectAlreadyAssignedItemCulture' should not be translated
+	</note>
+      </trans-unit>
       <trans-unit id="AssignProjectConfiguration.IllegalMappingString">
         <source>The platform mapping "{0}" in the platform mapping list "{1}" is malformed.  Please only pass in a semicolon-delimited list of constant string values separated by "=", e.g., "foo=bar;foo2=bar2".</source>
         <target state="translated">"{1}" platform eşleme listesindeki "{0}" platform eşlemesinin biçimi bozuk.  Lütfen yalnızca "=" ile ayrılan ve noktalı virgül ile sınırlandırılmış bir sabit dize değerleri listesi geçirin. Örneğin, "foo=bar;foo2=bar2".</target>

--- a/src/Tasks/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Resources/xlf/Strings.zh-Hans.xlf
@@ -37,6 +37,14 @@
         <target state="translated">分析 newVersion 特性时出现问题。{0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="AssignCulture.CultureOverwritten">
+        <source>MSB3002: Explicitly set culture "{0}" for item "{1}" was overwritten with inferred culture "{2}", because 'RespectAlreadyAssignedItemCulture' property was not set.</source>
+        <target state="new">MSB3002: Explicitly set culture "{0}" for item "{1}" was overwritten with inferred culture "{2}", because 'RespectAlreadyAssignedItemCulture' property was not set.</target>
+        <note>
+	{StrBegin="MSB3002: "}
+	'RespectAlreadyAssignedItemCulture' should not be translated
+	</note>
+      </trans-unit>
       <trans-unit id="AssignProjectConfiguration.IllegalMappingString">
         <source>The platform mapping "{0}" in the platform mapping list "{1}" is malformed.  Please only pass in a semicolon-delimited list of constant string values separated by "=", e.g., "foo=bar;foo2=bar2".</source>
         <target state="translated">平台映射列表“{1}”中平台映射“{0}”的格式不正确。请只传入分号分隔的常量字符串值列表，常量字符串值以“=”分隔，例如“foo=bar;foo2=bar2”。</target>

--- a/src/Tasks/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Resources/xlf/Strings.zh-Hant.xlf
@@ -37,6 +37,14 @@
         <target state="translated">剖析 newVersion 屬性時發生問題。{0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="AssignCulture.CultureOverwritten">
+        <source>MSB3002: Explicitly set culture "{0}" for item "{1}" was overwritten with inferred culture "{2}", because 'RespectAlreadyAssignedItemCulture' property was not set.</source>
+        <target state="new">MSB3002: Explicitly set culture "{0}" for item "{1}" was overwritten with inferred culture "{2}", because 'RespectAlreadyAssignedItemCulture' property was not set.</target>
+        <note>
+	{StrBegin="MSB3002: "}
+	'RespectAlreadyAssignedItemCulture' should not be translated
+	</note>
+      </trans-unit>
       <trans-unit id="AssignProjectConfiguration.IllegalMappingString">
         <source>The platform mapping "{0}" in the platform mapping list "{1}" is malformed.  Please only pass in a semicolon-delimited list of constant string values separated by "=", e.g., "foo=bar;foo2=bar2".</source>
         <target state="translated">平台對應清單 "{1}" 中的平台對應 "{0}" 格式不正確。請只傳入以 "=" 分隔常數字串值的分號分隔清單，例如 "foo=bar;foo2=bar2"。</target>


### PR DESCRIPTION
Fixes #10536
Contributes to https://github.com/dotnet/msbuild/issues/10996

### Context
Custom culture on EmbeddedResource items is supported by `AssignTask` (from https://github.com/dotnet/msbuild/pull/10026), but it's then ignored by RAR task (and CreateManifestResourceName as well) 

### Changes Made
We are no more checking the recoginzed culture against the known list. Putting this behind changewave - as it has pottential to break esoteric scenarios of binaries with .resource.dll existing in subdirs, but actually not being a satelite assemblies


### Testing
Manual testing on a scenario from the bug
Tailored tests added in https://github.com/dotnet/msbuild/pull/11023 (will be uncommented after merging this PR)

