### PR TITLE
[vs17.12] Consistently respect unprefixed Warning-as-error/message/warning properties

### DIFF
--- a/documentation/wiki/ChangeWaves.md
+++ b/documentation/wiki/ChangeWaves.md
@@ -23,6 +23,9 @@ A wave of features is set to "rotate out" (i.e. become standard functionality) t
 
 ## Current Rotation of Change Waves
 
+### 17.14
+- [TreatWarningsAsErrors, WarningsAsMessages, WarningsAsErrors, WarningsNotAsErrors are now supported on the engine side of MSBuild](https://github.com/dotnet/msbuild/pull/10942)
+
 ### 17.12
 - [Log TaskParameterEvent for scalar parameters](https://github.com/dotnet/msbuild/pull/9908)
 - [Convert.ToString during a property evaluation uses the InvariantCulture for all types](https://github.com/dotnet/msbuild/pull/9874)

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -3,7 +3,6 @@
 <Project>
   <PropertyGroup>
     <VersionPrefix>17.12.12</VersionPrefix><DotNetFinalVersionKind>release</DotNetFinalVersionKind>
-    <DotNetFinalVersionKind>release</DotNetFinalVersionKind>
     <PackageValidationBaselineVersion>17.11.4</PackageValidationBaselineVersion>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,7 +2,7 @@
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the MIT license. See License.txt in the project root for full license information. -->
 <Project>
   <PropertyGroup>
-    <VersionPrefix>17.12.12</VersionPrefix><DotNetFinalVersionKind>release</DotNetFinalVersionKind>
+    <VersionPrefix>17.12.12</VersionPrefix> <DotNetFinalVersionKind>release</DotNetFinalVersionKind>
     <PackageValidationBaselineVersion>17.11.4</PackageValidationBaselineVersion>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,7 +2,7 @@
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the MIT license. See License.txt in the project root for full license information. -->
 <Project>
   <PropertyGroup>
-    <VersionPrefix>17.12.12</VersionPrefix> <DotNetFinalVersionKind>release</DotNetFinalVersionKind>
+    <VersionPrefix>17.12.13</VersionPrefix><DotNetFinalVersionKind>release</DotNetFinalVersionKind>
     <PackageValidationBaselineVersion>17.11.4</PackageValidationBaselineVersion>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>

--- a/src/Build.UnitTests/WarningsAsMessagesAndErrors_Tests.cs
+++ b/src/Build.UnitTests/WarningsAsMessagesAndErrors_Tests.cs
@@ -35,6 +35,19 @@ namespace Microsoft.Build.Engine.UnitTests
             ObjectModelHelpers.BuildProjectExpectSuccess(GetTestProject(treatAllWarningsAsErrors: false));
         }
 
+        [Fact]
+        public void TreatAllWarningsAsErrorsNoPrefix()
+        {
+            MockLogger logger = ObjectModelHelpers.BuildProjectExpectFailure(GetTestProject(customProperties: new Dictionary<string, string>
+            {
+                {"TreatWarningsAsErrors", "true"},
+            }));
+
+            VerifyBuildErrorEvent(logger);
+
+            ObjectModelHelpers.BuildProjectExpectSuccess(GetTestProject(treatAllWarningsAsErrors: false));
+        }
+
         /// <summary>
         /// https://github.com/dotnet/msbuild/issues/2667
         /// </summary>
@@ -86,22 +99,6 @@ namespace Microsoft.Build.Engine.UnitTests
                     {
                         {"Foo", "true"},
                         {"MSBuildTreatWarningsAsErrors", "$(Foo)"}
-                    }));
-
-            VerifyBuildErrorEvent(logger);
-        }
-
-        [Fact]
-        public void TreatWarningsAsErrorsWhenSpecifiedThroughAdditiveProperty()
-        {
-            MockLogger logger = ObjectModelHelpers.BuildProjectExpectFailure(
-                GetTestProject(
-                    customProperties: new List<KeyValuePair<string, string>>
-                    {
-                        new KeyValuePair<string, string>("MSBuildWarningsAsErrors", "123"),
-                        new KeyValuePair<string, string>("MSBuildWarningsAsErrors", $@"$(MSBuildWarningsAsErrors);
-                                                                                       {ExpectedEventCode.ToLowerInvariant()}"),
-                        new KeyValuePair<string, string>("MSBuildWarningsAsErrors", "$(MSBuildWarningsAsErrors);ABC")
                     }));
 
             VerifyBuildErrorEvent(logger);
@@ -177,20 +174,97 @@ namespace Microsoft.Build.Engine.UnitTests
             VerifyBuildMessageEvent(logger);
         }
 
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void TreatWarningsAsMessagesWhenSpecifiedThroughAdditiveProperty(bool usePrefix)
+        {
+            string prefix = usePrefix ? "MSBuild" : "";
+            MockLogger logger = ObjectModelHelpers.BuildProjectExpectSuccess(
+                GetTestProject(
+                    customProperties: new List<KeyValuePair<string, string>>
+                    {
+                        new KeyValuePair<string, string>($"{prefix}WarningsAsMessages", "123"),
+                        new KeyValuePair<string, string>($"{prefix}WarningsAsMessages", $@"$({prefix}WarningsAsMessages);
+                                                                                       {ExpectedEventCode.ToLowerInvariant()}"),
+                        new KeyValuePair<string, string>($"{prefix}WarningsAsMessages", $"$({prefix}WarningsAsMessages);ABC")
+                    }));
+
+            VerifyBuildMessageEvent(logger);
+        }
+
         [Fact]
-        public void TreatWarningsAsMessagesWhenSpecifiedThroughAdditiveProperty()
+        ///
+        /// This is for chaining the properties together via addition.
+        /// Furthermore it is intended to check if the prefix and no prefix variant interacts properly with each other.
+        ///
+        public void TreatWarningsAsMessagesWhenSpecifiedThroughAdditivePropertyCombination()
         {
             MockLogger logger = ObjectModelHelpers.BuildProjectExpectSuccess(
                 GetTestProject(
                     customProperties: new List<KeyValuePair<string, string>>
                     {
                         new KeyValuePair<string, string>("MSBuildWarningsAsMessages", "123"),
-                        new KeyValuePair<string, string>("MSBuildWarningsAsMessages", $@"$(MSBuildWarningsAsMessages);
+                        new KeyValuePair<string, string>("WarningsAsMessages", $@"$(MSBuildWarningsAsMessages);
                                                                                        {ExpectedEventCode.ToLowerInvariant()}"),
-                        new KeyValuePair<string, string>("MSBuildWarningsAsMessages", "$(MSBuildWarningsAsMessages);ABC")
+                        new KeyValuePair<string, string>("MSBuildWarningsAsMessages", "$(WarningsAsMessages);ABC")
                     }));
 
             VerifyBuildMessageEvent(logger);
+        }
+
+        [Fact]
+        public void TreatWarningsNotAsErrorsWhenSpecifiedThroughAdditivePropertyCombination()
+        {
+            MockLogger logger = ObjectModelHelpers.BuildProjectExpectSuccess(
+                GetTestProject(
+                    customProperties: new List<KeyValuePair<string, string>>
+                    {
+                        new KeyValuePair<string, string>("MSBuildWarningsNotAsErrors", "123"),
+                        new KeyValuePair<string, string>("WarningsNotAsErrors", $@"$(MSBuildWarningsNotAsErrors);
+                                                                                       {ExpectedEventCode.ToLowerInvariant()}"),
+                        new KeyValuePair<string, string>("MSBuildWarningsNotAsErrors", "$(WarningsNotAsErrors);ABC")
+                    }),
+                _output);
+
+            VerifyBuildWarningEvent(logger);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void TreatWarningsAsErrorsWhenSpecifiedThroughAdditiveProperty(bool MSBuildPrefix)
+        {
+            string prefix = MSBuildPrefix ? "MSBuild" : "";
+            MockLogger logger = ObjectModelHelpers.BuildProjectExpectFailure(
+                GetTestProject(
+                    customProperties: new List<KeyValuePair<string, string>>
+                    {
+                        new KeyValuePair<string, string>($@"{prefix}WarningsAsErrors", "123"),
+                        new KeyValuePair<string, string>($@"{prefix}WarningsAsErrors", $@"$({prefix}WarningsAsErrors);
+                                                                                       {ExpectedEventCode.ToLowerInvariant()}"),
+                        new KeyValuePair<string, string>($@"{prefix}WarningsAsErrors", $@"$({prefix}WarningsAsErrors);ABC")
+                    }),
+                _output);
+
+            VerifyBuildErrorEvent(logger);
+        }
+
+        [Fact]
+        public void TreatWarningsAsErrorsWhenSpecifiedThroughAdditivePropertyCombination()
+        {
+            MockLogger logger = ObjectModelHelpers.BuildProjectExpectFailure(
+                GetTestProject(
+                    customProperties: new List<KeyValuePair<string, string>>
+                    {
+                        new KeyValuePair<string, string>("WarningsAsErrors", "123"),
+                        new KeyValuePair<string, string>("MSBuildWarningsAsErrors", $@"$(WarningsAsErrors);
+                                                                                       {ExpectedEventCode.ToLowerInvariant()}"),
+                        new KeyValuePair<string, string>("WarningsAsErrors", "$(MSBuildWarningsAsErrors);ABC")
+                    }),
+                _output);
+
+            VerifyBuildErrorEvent(logger);
         }
 
         [Fact]
@@ -202,7 +276,8 @@ namespace Microsoft.Build.Engine.UnitTests
                     {
                         new KeyValuePair<string, string>("MSBuildWarningsAsMessages", "123"),
                         new KeyValuePair<string, string>("MSBuildWarningsAsMessages", "$(MSBuildWarningsAsMessages);ABC")
-                    }));
+                    }),
+                _output);
 
             VerifyBuildWarningEvent(logger);
         }
@@ -273,27 +348,33 @@ namespace Microsoft.Build.Engine.UnitTests
             </Project>";
         }
 
+
         [Theory]
 
         [InlineData("MSB1235", "MSB1234", "MSB1234", "MSB1234", false)] // Log MSB1234, treat as error via MSBuildWarningsAsErrors
         [InlineData("MSB1235", "", "MSB1234", "MSB1234", true)] // Log MSB1234, expect MSB1234 as error via MSBuildTreatWarningsAsErrors
         [InlineData("MSB1234", "MSB1234", "MSB1234", "MSB4181", true)]// Log MSB1234, MSBuildWarningsAsMessages takes priority
+        [InlineData("MSB1235", "MSB1234", "MSB1234", "MSB1234", false, false)] // Log MSB1234, treat as error via BuildWarningsAsErrors
+        [InlineData("MSB1235", "", "MSB1234", "MSB1234", true, false)] // Log MSB1234, expect MSB1234 as error via BuildTreatWarningsAsErrors
+        [InlineData("MSB1234", "MSB1234", "MSB1234", "MSB4181", true, false)]// Log MSB1234, BuildWarningsAsMessages takes priority
         public void WarningsAsErrorsAndMessages_Tests(string WarningsAsMessages,
                                                       string WarningsAsErrors,
                                                       string WarningToLog,
                                                       string LogShouldContain,
-                                                      bool allWarningsAreErrors = false)
+                                                      bool allWarningsAreErrors = false,
+                                                      bool useMSPrefix = true)
         {
             using (TestEnvironment env = TestEnvironment.Create(_output))
             {
+                var prefix = useMSPrefix ? "MSBuild" : "";
                 TransientTestProjectWithFiles proj = env.CreateTestProjectWithFiles($@"
                 <Project>
                     <UsingTask TaskName = ""ReturnFailureWithoutLoggingErrorTask"" AssemblyName=""Microsoft.Build.Engine.UnitTests""/>
                     <UsingTask TaskName = ""CustomLogAndReturnTask"" AssemblyName=""Microsoft.Build.Engine.UnitTests""/>
                     <PropertyGroup>
-                        <MSBuildTreatWarningsAsErrors>{allWarningsAreErrors}</MSBuildTreatWarningsAsErrors>
-                        <MSBuildWarningsAsMessages>{WarningsAsMessages}</MSBuildWarningsAsMessages>
-                        <MSBuildWarningsAsErrors>{WarningsAsErrors}</MSBuildWarningsAsErrors>
+                        <{prefix}TreatWarningsAsErrors>{allWarningsAreErrors}</{prefix}TreatWarningsAsErrors>
+                        <{prefix}WarningsAsMessages>{WarningsAsMessages}</{prefix}WarningsAsMessages>
+                        <{prefix}WarningsAsErrors>{WarningsAsErrors}</{prefix}WarningsAsErrors>
                     </PropertyGroup>
                     <Target Name='Build'>
                         <CustomLogAndReturnTask Return=""true"" ReturnHasLoggedErrors=""true"" WarningCode=""{WarningToLog}""/>
@@ -307,6 +388,83 @@ namespace Microsoft.Build.Engine.UnitTests
                 logger.ErrorCount.ShouldBe(1);
 
                 logger.AssertLogContains(LogShouldContain);
+            }
+        }
+
+        [Theory]
+
+        [InlineData(true)]// Log MSB1234, BuildWarningsNotAsErrors takes priority
+        [InlineData(false)]
+        public void WarningsNotAsErrorsAndMessages_Tests(bool useMSPrefix)
+        {
+            string Warning = "MSB1235";
+            using (TestEnvironment env = TestEnvironment.Create(_output))
+            {
+                string prefix = useMSPrefix ? "MSBuild" : "";
+                TransientTestProjectWithFiles proj = env.CreateTestProjectWithFiles($@"
+                <Project>
+                    <PropertyGroup>
+                        <{prefix}TreatWarningsAsErrors>true</{prefix}TreatWarningsAsErrors>
+                        <{prefix}WarningsNotAsErrors>{Warning}</{prefix}WarningsNotAsErrors>
+                    </PropertyGroup>
+                    <Target Name='Build'>
+                        <Warning Text=""some random text"" Code='{Warning}' />
+                    </Target>
+                </Project>");
+
+                MockLogger logger = proj.BuildProjectExpectSuccess();
+
+                logger.WarningCount.ShouldBe(1);
+                logger.ErrorCount.ShouldBe(0);
+
+                logger.AssertLogContains(Warning);
+            }
+        }
+
+
+
+        [Theory]
+        [InlineData("TreatWarningsAsErrors", "true", false)] // All warnings are treated as errors
+        [InlineData("WarningsAsErrors", "MSB1007", false)]
+        [InlineData("WarningsAsMessages", "MSB1007", false)]
+        [InlineData("WarningsNotAsErrors", "MSB1007", true)]
+        [InlineData("WarningsNotAsErrors", "MSB1007", false)]
+        public void WarningsChangeWaveTest(string property, string propertyData, bool treatWarningsAsErrors)
+        {
+            using (TestEnvironment env = TestEnvironment.Create(_output))
+            {
+                string warningCode = "MSB1007";
+                string treatWarningsAsErrorsCodeProperty = treatWarningsAsErrors ? "<MSBuildTreatWarningsAsErrors>true</MSBuildTreatWarningsAsErrors>" : "";
+                env.SetEnvironmentVariable("MSBUILDDISABLEFEATURESFROMVERSION", ChangeWaves.Wave17_14.ToString());
+                TransientTestProjectWithFiles proj = env.CreateTestProjectWithFiles($@"
+                <Project>
+                    <PropertyGroup>
+                        {treatWarningsAsErrorsCodeProperty}
+                        <{property}>{propertyData}</{property}>
+                    </PropertyGroup>
+                    <Target Name='Build'>
+                        <Warning Text=""some random text"" Code='{warningCode}' />
+                    </Target>
+                </Project>");
+                if (treatWarningsAsErrors)
+                {
+                    // Since the "no prefix" variations can't do anything with the change wave disabled, this should always fail.
+                    MockLogger logger = proj.BuildProjectExpectFailure();
+                    logger.ErrorCount.ShouldBe(1);
+                    logger.AssertLogContains($"error {warningCode}");
+
+                    logger.AssertLogContains(warningCode);
+                }
+                else
+                {
+                    MockLogger logger = proj.BuildProjectExpectSuccess();
+
+                    logger.WarningCount.ShouldBe(1);
+                    logger.AssertLogContains($"warning {warningCode}");
+                    logger.ErrorCount.ShouldBe(0);
+
+                    logger.AssertLogContains(warningCode);
+                }
             }
         }
 
@@ -371,8 +529,11 @@ namespace Microsoft.Build.Engine.UnitTests
         [Theory]
         [InlineData("MSB1234", false, 1, 1)]
         [InlineData("MSB0000", true, 0, 2)]
-        public void TaskReturnsTrue_Tests(string warningsAsErrors, bool treatAllWarningsAsErrors, int warningCountShouldBe, int errorCountShouldBe)
+        [InlineData("MSB1234", false, 1, 1, false)]
+        [InlineData("MSB0000", true, 0, 2, false)]
+        public void TaskReturnsTrue_Tests(string warningsAsErrors, bool treatAllWarningsAsErrors, int warningCountShouldBe, int errorCountShouldBe, bool useMSPrefix = true)
         {
+            string prefix = useMSPrefix ? "MSBuild" : "";
             using (TestEnvironment env = TestEnvironment.Create(_output))
             {
                 TransientTestProjectWithFiles proj = env.CreateTestProjectWithFiles($@"
@@ -380,8 +541,8 @@ namespace Microsoft.Build.Engine.UnitTests
                     <UsingTask TaskName = ""ReturnFailureWithoutLoggingErrorTask"" AssemblyName=""Microsoft.Build.Engine.UnitTests""/>
                     <UsingTask TaskName = ""CustomLogAndReturnTask"" AssemblyName=""Microsoft.Build.Engine.UnitTests""/>
                     <PropertyGroup>
-                        <MSBuildTreatWarningsAsErrors>{treatAllWarningsAsErrors}</MSBuildTreatWarningsAsErrors>
-                        <MSBuildWarningsAsErrors>{warningsAsErrors}</MSBuildWarningsAsErrors>
+                        <{prefix}TreatWarningsAsErrors>{treatAllWarningsAsErrors}</{prefix}TreatWarningsAsErrors>
+                        <{prefix}WarningsAsErrors>{warningsAsErrors}</{prefix}WarningsAsErrors>
                     </PropertyGroup>
                     <Target Name='Build'>
                         <CustomLogAndReturnTask Return=""true"" WarningCode=""MSB1234""/>

--- a/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
@@ -1390,14 +1390,17 @@ namespace Microsoft.Build.BackEnd
             // Ensure everything that is required is available at this time
             if (project != null && buildEventContext != null && loggingService != null && buildEventContext.ProjectInstanceId != BuildEventContext.InvalidProjectInstanceId)
             {
-                if (String.Equals(project.GetEngineRequiredPropertyValue(MSBuildConstants.TreatWarningsAsErrors)?.Trim(), "true", StringComparison.OrdinalIgnoreCase))
+                if (String.Equals(project.GetEngineRequiredPropertyValue(MSBuildConstants.MSBuildPrefix + MSBuildConstants.TreatWarningsAsErrors)?.Trim(), "true", StringComparison.OrdinalIgnoreCase) ||
+                    (String.Equals(project.GetEngineRequiredPropertyValue(MSBuildConstants.TreatWarningsAsErrors)?.Trim(), "true", StringComparison.OrdinalIgnoreCase) &&
+                     ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_14)))
                 {
                     // If <MSBuildTreatWarningsAsErrors was specified then an empty ISet<string> signals the IEventSourceSink to treat all warnings as errors
                     loggingService.AddWarningsAsErrors(buildEventContext, new HashSet<string>());
                 }
                 else
                 {
-                    ISet<string> warningsAsErrors = ParseWarningCodes(project.GetEngineRequiredPropertyValue(MSBuildConstants.WarningsAsErrors));
+                    ISet<string> warningsAsErrors = ParseWarningCodes(project.GetEngineRequiredPropertyValue(MSBuildConstants.MSBuildPrefix + MSBuildConstants.WarningsAsErrors),
+                                                                      project.GetEngineRequiredPropertyValue(MSBuildConstants.WarningsAsErrors));
 
                     if (warningsAsErrors?.Count > 0)
                     {
@@ -1405,14 +1408,17 @@ namespace Microsoft.Build.BackEnd
                     }
                 }
 
-                ISet<string> warningsNotAsErrors = ParseWarningCodes(project.GetEngineRequiredPropertyValue(MSBuildConstants.WarningsNotAsErrors));
+                ISet<string> warningsNotAsErrors = ParseWarningCodes(project.GetEngineRequiredPropertyValue(MSBuildConstants.MSBuildPrefix + MSBuildConstants.WarningsNotAsErrors),
+                                                                     project.GetEngineRequiredPropertyValue(MSBuildConstants.WarningsNotAsErrors));
+
 
                 if (warningsNotAsErrors?.Count > 0)
                 {
                     loggingService.AddWarningsNotAsErrors(buildEventContext, warningsNotAsErrors);
                 }
 
-                ISet<string> warningsAsMessages = ParseWarningCodes(project.GetEngineRequiredPropertyValue(MSBuildConstants.WarningsAsMessages));
+                ISet<string> warningsAsMessages = ParseWarningCodes(project.GetEngineRequiredPropertyValue(MSBuildConstants.MSBuildPrefix + MSBuildConstants.WarningsAsMessages),
+                                                                    project.GetEngineRequiredPropertyValue(MSBuildConstants.WarningsAsMessages));
 
                 if (warningsAsMessages?.Count > 0)
                 {
@@ -1430,14 +1436,37 @@ namespace Microsoft.Build.BackEnd
             }
         }
 
-        private static ISet<string> ParseWarningCodes(string warnings)
+        private static ISet<string> ParseWarningCodes(string warnings, string warningsNoPrefix)
         {
-            if (String.IsNullOrWhiteSpace(warnings))
+            // When this changewave is rotated out and this gets deleted, please consider removing
+            // the <MSBuildWarningsAsMessages Condition="'$(MSBuildWarningsAsMessages)'==''">$(NoWarn)</MSBuildWarningsAsMessages>
+            // and the two following lines from the msbuild/src/Tasks/Microsoft.Common.CurrentVersion.targets
+            if (!ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_14))
             {
-                return null;
+                warningsNoPrefix = null;
             }
 
-            return new HashSet<string>(ExpressionShredder.SplitSemiColonSeparatedList(warnings), StringComparer.OrdinalIgnoreCase);
+            HashSet<string> result1 = null;
+            if (!String.IsNullOrWhiteSpace(warnings))
+            {
+                result1 = new HashSet<string>(ExpressionShredder.SplitSemiColonSeparatedList(warnings), StringComparer.OrdinalIgnoreCase);
+            }
+            HashSet<string> result2 = null;
+            if (!String.IsNullOrWhiteSpace(warningsNoPrefix))
+            {
+                result2 = new HashSet<string>(ExpressionShredder.SplitSemiColonSeparatedList(warningsNoPrefix), StringComparer.OrdinalIgnoreCase);
+            }
+
+            if (result1 != null)
+            {
+                if (result2 != null)
+                {
+                    result1.UnionWith(result2);
+                }
+                return result1;
+            }
+
+            return result2;
         }
 
         private sealed class DedicatedThreadsTaskScheduler : TaskScheduler

--- a/src/Framework/ChangeWaves.cs
+++ b/src/Framework/ChangeWaves.cs
@@ -27,7 +27,8 @@ namespace Microsoft.Build.Framework
     {
         internal static readonly Version Wave17_10 = new Version(17, 10);
         internal static readonly Version Wave17_12 = new Version(17, 12);
-        internal static readonly Version[] AllWaves = { Wave17_10, Wave17_12 };
+        internal static readonly Version Wave17_14 = new Version(17, 14);
+        internal static readonly Version[] AllWaves = { Wave17_10, Wave17_12, Wave17_14 };
 
         /// <summary>
         /// Special value indicating that all features behind all Change Waves should be enabled.

--- a/src/Shared/Constants.cs
+++ b/src/Shared/Constants.cs
@@ -29,24 +29,29 @@ namespace Microsoft.Build.Shared
         internal const string SdksPath = "MSBuildSDKsPath";
 
         /// <summary>
+        ///  The prefix that was originally used. Now extracted out for the purpose of allowing even the non-prefixed variant.
+        /// </summary>
+        internal const string MSBuildPrefix = "MSBuild";
+
+        /// <summary>
         /// Name of the property that indicates that all warnings should be treated as errors.
         /// </summary>
-        internal const string TreatWarningsAsErrors = "MSBuildTreatWarningsAsErrors";
+        internal const string TreatWarningsAsErrors = "TreatWarningsAsErrors";
 
         /// <summary>
         /// Name of the property that indicates a list of warnings to treat as errors.
         /// </summary>
-        internal const string WarningsAsErrors = "MSBuildWarningsAsErrors";
+        internal const string WarningsAsErrors = "WarningsAsErrors";
 
         /// <summary>
         /// Name of the property that indicates a list of warnings to not treat as errors.
         /// </summary>
-        internal const string WarningsNotAsErrors = "MSBuildWarningsNotAsErrors";
+        internal const string WarningsNotAsErrors = "WarningsNotAsErrors";
 
         /// <summary>
         /// Name of the property that indicates the list of warnings to treat as messages.
         /// </summary>
-        internal const string WarningsAsMessages = "MSBuildWarningsAsMessages";
+        internal const string WarningsAsMessages = "WarningsAsMessages";
 
         /// <summary>
         /// The name of the environment variable that users can specify to override where NuGet assemblies are loaded from in the NuGetSdkResolver.

--- a/src/UnitTests.Shared/ObjectModelHelpers.cs
+++ b/src/UnitTests.Shared/ObjectModelHelpers.cs
@@ -780,9 +780,9 @@ namespace Microsoft.Build.UnitTests
         /// </summary>
         /// <param name="projectContents">The project file content in string format.</param>
         /// <returns>The <see cref="MockLogger"/> that was used during evaluation and build.</returns>
-        public static MockLogger BuildProjectExpectFailure(string projectContents)
+        public static MockLogger BuildProjectExpectFailure(string projectContents, ITestOutputHelper testOutputHelper = null)
         {
-            MockLogger logger = new MockLogger();
+            MockLogger logger = new MockLogger(testOutputHelper);
             BuildProjectExpectFailure(projectContents, logger);
             return logger;
         }


### PR DESCRIPTION
Backport of  https://github.com/dotnet/msbuild/pull/10942.

Fixes https://github.com/dotnet/msbuild/issues/10877 and #10873.

Work item (Internal use): 

### Summary

Respect `WarningsAsMessages`, `WarningsAsErrors`, `WarningsNotAsErrors`, and `TreatWarningsAsErrors` in addition to their `MSBuild`-prefixed versions in all projects, not just ones that import `Microsoft.Common.CurrentVersion.targets`.

### Customer Impact

Reduced complexity in opting to keep warnings as warnings, making it easier to configure warnings how you expect.

### Regression?

No, this behavior is longstanding. It's higher severity now due to the NuGet Audit warnings, which are often created in one project (where a package is referenced) but raised in another (where the restore actually happened), which may have the easy-to-type form of the property but not the respected-before-this-change one.

### Testing

New and existing automated tests.

### Risk

Medium-low. Users almost certainly intended this behavior and it works this way in most project types. To mitigate risk further, the behavior can be reverted to the prior behavior with an environment variable (changewave).