### PR TITLE
Handle the case for updated binding redirects

### DIFF
--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -2557,12 +2557,31 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <AppConfig Condition="$(_NewGenerateBindingRedirectsIntermediateAppConfig) == 'true'">$(_GenerateBindingRedirectsIntermediateAppConfig)</AppConfig>
     </PropertyGroup>
 
+    <PropertyGroup>
+      <ConfigFileExists Condition="Exists('@(AppConfigWithTargetPath->'$(OutDir)%(TargetPath)')')">true</ConfigFileExists>
+      <HasNoBindingRedirects Condition="'@(SuggestedBindingRedirects)' == ''">true</HasNoBindingRedirects>
+    </PropertyGroup>
+
+    <!-- Overwrites .config file with a App.config content if RAR did not return @(SuggestedBindingRedirects). -->
+    <Copy
+      SourceFiles="@(AppConfigWithTargetPath->'%(FullPath)')"
+      DestinationFiles="$(_GenerateBindingRedirectsIntermediateAppConfig)"
+      Condition="'$(ConfigFileExists)' == 'true' and '$(HasNoBindingRedirects)' == 'true'">
+      <Output TaskParameter="CopiedFiles" ItemName="FileWrites"/>
+    </Copy>
+    <Touch
+      Files="$(_GenerateBindingRedirectsIntermediateAppConfig)"
+      AlwaysCreate="true"
+      Condition="'$(ConfigFileExists)' == 'true' and '$(HasNoBindingRedirects)' == 'true'"/>
+
     <ItemGroup Condition="$(_NewGenerateBindingRedirectsIntermediateAppConfig) == 'true'">
       <AppConfigWithTargetPath Remove="@(AppConfigWithTargetPath)" />
       <AppConfigWithTargetPath Include="$(AppConfig)">
         <TargetPath>$(TargetFileName).config</TargetPath>
       </AppConfigWithTargetPath>
     </ItemGroup>
+
+
   </Target>
 
   <!--

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -2566,6 +2566,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <Copy
       SourceFiles="@(AppConfigWithTargetPath->'%(FullPath)')"
       DestinationFiles="$(_GenerateBindingRedirectsIntermediateAppConfig)"
+      SkipUnchangedFiles="true"
       Condition="'$(ConfigFileExists)' == 'true' and '$(HasNoBindingRedirects)' == 'true'">
       <Output TaskParameter="CopiedFiles" ItemName="FileWrites"/>
     </Copy>

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -2562,7 +2562,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <HasNoBindingRedirects Condition="'@(SuggestedBindingRedirects)' == ''">true</HasNoBindingRedirects>
     </PropertyGroup>
 
-    <!-- Overwrites .config file with a App.config content if RAR did not return @(SuggestedBindingRedirects). -->
+    <!-- Overwrites .config file with a App.config content if RAR returned empty @(SuggestedBindingRedirects). -->
     <Copy
       SourceFiles="@(AppConfigWithTargetPath->'%(FullPath)')"
       DestinationFiles="$(_GenerateBindingRedirectsIntermediateAppConfig)"

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -2580,8 +2580,6 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         <TargetPath>$(TargetFileName).config</TargetPath>
       </AppConfigWithTargetPath>
     </ItemGroup>
-
-
   </Target>
 
   <!--


### PR DESCRIPTION
Fixes https://github.com/dotnet/msbuild/issues/9773

### Context
When a project's references are modified in a way that eliminates version conflicts, the existing binding redirects in the `exe.config` file in `bin `folder are not automatically removed during the next build. This PR ensures that binding redirects are properly removed when they are no longer needed.

### Changes Made
Prevent `.exe.config` removal from obj folder by incremental clean by changing it's content with the original App.config when RAR returns empty `SuggestedBindingRedirects`.

### Testing
Manual.
