### PR TITLE
Update build check custom template and tests

### DIFF
--- a/src/BuildCheck.UnitTests/TestAssets/Common/CommonTest.targets
+++ b/src/BuildCheck.UnitTests/TestAssets/Common/CommonTest.targets
@@ -1,33 +1,17 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <Target Name="AddNuGetDlls" BeforeTargets="_GetPackageFiles">
-    <!-- Resolve the project references to get their output DLL paths -->
-    <ItemGroup>
-      <ResolvedProjectReference Include="@(ReferencePath)" Condition="%(ReferencePath.ReferenceSourceTarget) == 'ProjectReference'">
-        <OutputPath>%(ReferencePath.OriginalItemSpec)</OutputPath>
-      </ResolvedProjectReference>
-
-      <!-- Add the DLL produced by the referenced project to the _PackagesToPack list -->
-      <_PackagesToPack Include="@(ResolvedProjectReference->'%(OutputPath)')">
-          <NuGetPackageId>@(ResolvedProjectReference->'%(AssemblyName)')</NuGetPackageId>
-      </_PackagesToPack>
-    </ItemGroup>
-    
-    <!-- Merge the collection of PackageReference and Assemblies using the NuGetPackageId key.
-       This produces a new list containing the DLL path and the "IncludeInPackage" metadata-->
-    <JoinItems Left="@(ResolvedCompileFileDefinitions)" LeftKey="NuGetPackageId" LeftMetadata="*" Right="@(ProjectReference)" RightKey="" RightMetadata="*" ItemSpecToUse="Left">
+    <!-- Merge the collection of PackageReference and Assemblies using the NuGetPackageId key. This produces a new list containing the DLL path and the "IncludeInPackage" metadata-->
+    <JoinItems Left="@(ResolvedCompileFileDefinitions)" LeftKey="NuGetPackageId" LeftMetadata="*" Right="@(PackageReference)" RightKey="" RightMetadata="*" ItemSpecToUse="Left">
       <Output TaskParameter="JoinResult" ItemName="_PackagesToPack" />
     </JoinItems>
 
     <ItemGroup>
-      <Message Importance="High" Text="Adding DLLs from the following packages: @(_PackagesToPack->'%(NuGetPackageId)')" />
-
-      <!-- Remove NETStandard DLLs -->
-      <_PackagesToPack Remove="@(_PackagesToPack)" Condition="%(NuGetPackageId) == 'NETStandard.Library'" />
-      <_PackagesToPack Remove="@(_PackagesToPack)" Condition="%(_PackagesToPack.IncludeInPackage) != 'true'" />
+      <!-- Remove packages, except those with IncludeInPackage=true -->
+      <_PackagesToPack Remove="@(_PackagesToPack)" Condition="'%(_PackagesToPack.IncludeInPackage)' != 'true'" />
     </ItemGroup>
 
-    <Message Importance="High" Text="Adding DLLs from the following packages: @(ResolvedProjectReferences->'%(OutputPath)%(AssemblyName).dll')" />
+    <Message Importance="High" Text="Adding DLLs from the following packages: @(_PackagesToPack->'%(NuGetPackageId)')" />
 
     <ItemGroup>
       <!-- Update the collection of items to pack with the DLLs from the NuGet packages -->
@@ -37,5 +21,4 @@
       <None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="build" Visible="false" />
     </ItemGroup>
   </Target>
-
 </Project>

--- a/src/BuildCheck.UnitTests/TestAssets/CustomCheck/CustomCheck.csproj
+++ b/src/BuildCheck.UnitTests/TestAssets/CustomCheck/CustomCheck.csproj
@@ -9,9 +9,9 @@
 
   <ItemGroup>
     <None Include="CustomCheck.props" Pack="true" PackagePath="build\CustomCheck.props" />
-    <Content Include="README.md" />
+    <None Include="README.md" />
   </ItemGroup>
 
   <Import Project="..\Common\CommonTest.targets" />
-
+  
 </Project>

--- a/src/BuildCheck.UnitTests/TestAssets/CustomCheck2/CustomCheck2.csproj
+++ b/src/BuildCheck.UnitTests/TestAssets/CustomCheck2/CustomCheck2.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <None Include="CustomCheck2.props" Pack="true" PackagePath="build\CustomCheck2.props" />
-    <Content Include="README.md" />
+    <None Include="README.md" />
   </ItemGroup>
 
   <Import Project="..\Common\CommonTest.targets" />

--- a/src/BuildCheck.UnitTests/TestAssets/ErrorCustomCheck/ErrorCustomCheck.csproj
+++ b/src/BuildCheck.UnitTests/TestAssets/ErrorCustomCheck/ErrorCustomCheck.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <None Include="ErrorCustomCheck.props" Pack="true" PackagePath="build\ErrorCustomCheck.props" />
-    <Content Include="README.md" />
+    <None Include="README.md" />
   </ItemGroup>
 
   <Import Project="..\Common\CommonTest.targets" />

--- a/src/BuildCheck.UnitTests/TestAssets/InvalidCustomCheck/InvalidCustomCheck.csproj
+++ b/src/BuildCheck.UnitTests/TestAssets/InvalidCustomCheck/InvalidCustomCheck.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <None Include="InvalidCustomCheck.props" Pack="true" PackagePath="build\InvalidCustomCheck.props" />
-    <Content Include="README.md" />
+    <None Include="README.md" />
   </ItemGroup>
 
   <Import Project="..\Common\CommonTest.targets" />

--- a/template_feed/content/Microsoft.CheckTemplate/Company.CheckTemplate.csproj
+++ b/template_feed/content/Microsoft.CheckTemplate/Company.CheckTemplate.csproj
@@ -12,12 +12,14 @@
 
   <ItemGroup>
     <None Include="Company.CheckTemplate.props" Pack="true" PackagePath="build\Company.CheckTemplate.props" />
-    <Content Include="README.md" />
+    <None Include="README.md" />
   </ItemGroup>
 
   <ItemGroup>
-    <!-- Please add IncludeInPackage field to all third party dependencies. See the example below.-->
-    <PackageReference Include="Microsoft.Build" PrivateAssets="all" IncludeInPackage="true" />
+    <PackageReference Include="Microsoft.Build" PrivateAssets="all" />
+
+    <!-- Please add IncludeInPackage field to all third party dependencies. It will help MSBuild to discover them in runtime. -->
+    <!-- <PackageReference Include="DummyDependency" PrivateAssets="all" IncludeInPackage="true"/> -->
   </ItemGroup>
 
   <Target Name="AddNuGetDlls" BeforeTargets="_GetPackageFiles">


### PR DESCRIPTION
Fixes https://github.com/dotnet/msbuild/issues/10900

### Context
We mistakenly redistributed Microsoft.Build.dll and Readme.md in the custom build check package (both test/original one).

### Changes Made
Exclude Microsoft.Build.dll from the package and remove the redundant Readme.md files.

### Testing
Covered by existing tests.

