### PR TITLE
Update triggers in VS insertion pipelines

### DIFF
--- a/azure-pipelines/vs-insertion.yml
+++ b/azure-pipelines/vs-insertion.yml
@@ -1,13 +1,17 @@
-# Create a VS insertion (DotNet-MSBuild-Trusted -> VS) from a build artifact on main or any servicing branch.
-# When triggering manually, trigger from main, set MSBuild resource to desired CI run and set corresponding TargetBranch. 
-# To acheive insertion automation, this pipeline defeinition yml has to be on servicing branches and main.
+# Create a VS insertion (DotNet-MSBuild-Trusted -> VS) from a CI run on main or any servicing branch.
+# To achieve insertion automation, this pipeline definition yml has to be on servicing branches and main.
+
+
+# Runs in 3 modes: 
+# 1. daily main insertion from latest main CI.
+#   - can be disabled in the UI by adding a custom schedule for any branch. 
+# 2. trigger insert as a followup to a servicing CI run.
+#   - can be disabled in the UI by adding a custom CI trigger.
+# 3. manual insertion - select manually the TargetBranch and inserted CI run.
 trigger: none
 pr: none
 name: $(Date:yyyyMMdd).$(Rev:r)
 
-# trigger in 2 modes: 
-# 1. daily main insertion
-# 2. insert as a followup to servicing CI run
 schedules:
   - cron: '0 3 * * 1-5' # Runs every weekday at 3AM UTC
     displayName: Daily VS insertion main
@@ -36,7 +40,7 @@ parameters:
   - name: TargetBranch
     default: auto
     type: string
-    displayName: 'Insertion Target Branch (recommended to use `auto`)'
+    displayName: 'Insertion Target Branch (select for manual insertion)'
     values:
       - auto
       - main
@@ -98,6 +102,11 @@ variables:
     value: '$(ArtifactPackagesPath)/Microsoft.NET.StringTools*.nupkg'
   - name: ExternalAPIsPackagePattern
     value: '$(ArtifactPackagesPath)/VS.ExternalAPIs.*.nupkg'
+  # servicing branches until 17.12 also include Microsoft.Build.Engine and Microsoft.Build.Conversion.Core
+  - name: EngineIncludedProps
+    value: VS.ExternalAPIs.MSBuild=$(MSBuild_ExtApisPackageVersion);Microsoft.Build=$(MicrosoftNETStringToolsPackageVersion);Microsoft.Build.Conversion.Core=$(MicrosoftNETStringToolsPackageVersion);Microsoft.Build.Engine=$(MicrosoftNETStringToolsPackageVersion);Microsoft.Build.Framework=$(MicrosoftNETStringToolsPackageVersion);Microsoft.Build.Tasks.Core=$(MicrosoftNETStringToolsPackageVersion);Microsoft.Build.Utilities.Core=$(MicrosoftNETStringToolsPackageVersion);Microsoft.NET.StringTools=$(MicrosoftNETStringToolsPackageVersion)
+  - name: NoEngineProps
+    value: VS.ExternalAPIs.MSBuild=$(MSBuild_ExtApisPackageVersion);Microsoft.Build=$(MicrosoftNETStringToolsPackageVersion);Microsoft.Build.Framework=$(MicrosoftNETStringToolsPackageVersion);Microsoft.Build.Tasks.Core=$(MicrosoftNETStringToolsPackageVersion);Microsoft.Build.Utilities.Core=$(MicrosoftNETStringToolsPackageVersion);Microsoft.NET.StringTools=$(MicrosoftNETStringToolsPackageVersion)
 
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
@@ -196,6 +205,14 @@ extends:
               $packageVersion = $packageFile.BaseName.TrimStart("Microsoft.NET.StringTools")
               Write-Host "Setting MicrosoftNETStringToolsPackageVersion to '$packageVersion'"
               Write-Host "##vso[task.setvariable variable=MicrosoftNETStringToolsPackageVersion]$($packageVersion)"
+              if ("$(InsertTargetBranch)" -in @("vs17.0", "vs17.3", "vs17.6", "vs17.8", "vs17.10", "vs17.11", "vs17.12"))
+              {
+                  Write-Host "##vso[task.setvariable variable=InsertPackagePropsValues]$($EngineIncludedProps)"
+              }
+              else
+              {
+                  Write-Host "##vso[task.setvariable variable=InsertPackagePropsValues]$($NoEngineProps)"
+              }
         - task: 1ES.PublishNuGet@1
           displayName: 'Push MSBuild CoreXT packages'
           inputs:
@@ -231,11 +248,7 @@ extends:
             TeamEmail: $(TeamEmail)
             TargetBranch: $(InsertTargetBranch)
             InsertionPayloadName: $(InsertPayloadName)
-            # servicing branches until 17.12 also include Microsoft.Build.Engine and Microsoft.Build.Conversion.Core
-            ${{ if or(eq(variables['Build.SourceBranchName'], 'vs17.0'),  eq(variables['Build.SourceBranchName'], 'vs17.3'), eq(variables['Build.SourceBranchName'], 'vs17.6'),  eq(variables['Build.SourceBranchName'], 'vs17.8'), eq(variables['Build.SourceBranchName'], 'vs17.10'), eq(variables['Build.SourceBranchName'], 'vs17.11'), eq(variables['Build.SourceBranchName'], 'vs17.12')) }}: 
-              PackagePropsValues: VS.ExternalAPIs.MSBuild=$(MSBuild_ExtApisPackageVersion);Microsoft.Build=$(MicrosoftNETStringToolsPackageVersion);Microsoft.Build.Conversion.Core=$(MicrosoftNETStringToolsPackageVersion);Microsoft.Build.Engine=$(MicrosoftNETStringToolsPackageVersion);Microsoft.Build.Framework=$(MicrosoftNETStringToolsPackageVersion);Microsoft.Build.Tasks.Core=$(MicrosoftNETStringToolsPackageVersion);Microsoft.Build.Utilities.Core=$(MicrosoftNETStringToolsPackageVersion);Microsoft.NET.StringTools=$(MicrosoftNETStringToolsPackageVersion)
-            ${{ else }}:
-              PackagePropsValues: VS.ExternalAPIs.MSBuild=$(MSBuild_ExtApisPackageVersion);Microsoft.Build=$(MicrosoftNETStringToolsPackageVersion);Microsoft.Build.Framework=$(MicrosoftNETStringToolsPackageVersion);Microsoft.Build.Tasks.Core=$(MicrosoftNETStringToolsPackageVersion);Microsoft.Build.Utilities.Core=$(MicrosoftNETStringToolsPackageVersion);Microsoft.NET.StringTools=$(MicrosoftNETStringToolsPackageVersion)
+            PackagePropsValues: $(InsertPackagePropsValues)
             InsertionDescription: $(InsertDescription)
             ComponentJsonValues: $(InsertJsonValues)
             DefaultConfigValues: $(InsertConfigValues)

--- a/azure-pipelines/vs-insertion.yml
+++ b/azure-pipelines/vs-insertion.yml
@@ -1,26 +1,36 @@
-# Create a VS insertion (DotNet-MSBuild-Trusted -> VS) from a build artifact on main or any servicing branch. 
+# Create a VS insertion (DotNet-MSBuild-Trusted -> VS) from a build artifact on main or any servicing branch.
+# When triggering manually, trigger from main, set MSBuild resource to desired CI run and set corresponding TargetBranch. 
+# To acheive insertion automation, this pipeline defeinition yml has to be on servicing branches and main.
 trigger: none
+pr: none
 name: $(Date:yyyyMMdd).$(Rev:r)
+
+# trigger in 2 modes: 
+# 1. daily main insertion
+# 2. insert as a followup to servicing CI run
+schedules:
+  - cron: '0 3 * * 1-5' # Runs every weekday at 3AM UTC
+    displayName: Daily VS insertion main
+    branches:
+      include:
+        - main
+    always: false # Don't run if there are no code changes
 
 resources:
   pipelines:
   - pipeline: 'MSBuild'
     project: 'DevDiv'
     source: 'MSBuild'
+    branch: main # for daily main scheduled insertion
+    trigger:
+      branches:
+        include: # trigger as a followup to servicing CI
+          - vs*
   repositories:
   - repository: 1ESPipelineTemplates
     type: git
     name: 1ESPipelineTemplates/1ESPipelineTemplates
     ref: refs/tags/release
-
-schedules:
-  - cron: '0 3 * * *'   # Runs every day at 3AM UTC
-    displayName: Daily VS insertion
-    branches:
-      include:
-        - main
-        - vs*
-    always: false # Don't run if there are no code changes
 
 parameters:
   - name: TargetBranch

--- a/documentation/release-checklist.md
+++ b/documentation/release-checklist.md
@@ -14,9 +14,9 @@
 ## At release time
 Before starting the process:
 - [ ] If the release is being cut more than a few days before the VS-side snap, run insertions manually OR redirect MSBuild release branch 
-  - [ ]  Disabling automated run of [MSBuild VS Insertion pipeline](https://devdiv.visualstudio.com/DevDiv/_build?definitionId=24295) (our {{NEXT_VERSION}} builds don't have a place to go in VS yet) is done by: Edit -> ... -> Triggers -> add a schedule on a dead branch (this overrides the YAML defined once-per-day schedule). Manual pipeline run: select as input resource the inserted "MSBuild" pipeline run on branch `vs{{THIS_RELEASE_VERSION}}` and VS TargetBranch `main`.
+  - [ ]  Disable scheduled run of [MSBuild VS Insertion pipeline](https://devdiv.visualstudio.com/DevDiv/_build?definitionId=24295) (our {{NEXT_VERSION}} builds don't have a place to go in VS yet) by: Edit -> ... -> Triggers -> add a schedule on a dead branch (this overrides the YAML defined once-per-day schedule for main). Manual pipeline run: select as input resource the to-be-inserted "MSBuild" pipeline run on branch `vs{{THIS_RELEASE_VERSION}}` and VS TargetBranch `main`.
 OR
-  - [ ]  If the release is being cut more than couple of weeks modify [YAML](https://github.com/dotnet/msbuild/tree/main/azure-pipelines/vs-insertion.yml) (and merge to affected MSBuild branches) of the [VS insertion pipeline](https://devdiv.visualstudio.com/DevDiv/_build?definitionId=24295) so that it flows from MSBuild `vs{{THIS_RELEASE_VERSION}}` to VS `main` [in the MSBuild VS Insertion pipeline](https://devdiv.visualstudio.com/DevDiv/_build?definitionId=24295) and keep scheduled insertions to simplify your workflow.
+  - [ ]  If the release is being cut more than couple of weeks modify [YAML](https://github.com/dotnet/msbuild/tree/main/azure-pipelines/vs-insertion.yml) (and merge to affected MSBuild branches) of the [VS insertion pipeline](https://devdiv.visualstudio.com/DevDiv/_build?definitionId=24295) so that it schedules insertions from MSBuild `vs{{THIS_RELEASE_VERSION}}` to VS `main`. Keep scheduled daily insertions to simplify your workflow and exclude `vs{{THIS_RELEASE_VERSION}}` from triggering insertion on each commit.
 
 ### Branching from main
 - [ ]  If the new version's branch was created before the Visual Studio fork: fast-forward merge the correct commit (the one that is currently inserted to VS main) to the `vs{{THIS_RELEASE_VERSION}}` branch \
@@ -28,6 +28,7 @@ _(This is for the case where we create the branch too early and want it to be ba
 `dotnet pack MSBuild.Dev.slnf /p:ApiCompatGenerateSuppressionFile=true`. 
   - [ ]  When VS main snaps to {{THIS_RELEASE_VERSION}} and updates its version to {{NEXT_VERSION}}, modify the [MSBuild VS Insertion pipeline](https://devdiv.visualstudio.com/DevDiv/_build?definitionId=24295) YAML so that it flows from MSBuild main to VS main.
     - [ ]  Update AutoTargetBranch selection in the [YAML](https://github.com/dotnet/msbuild/tree/main/azure-pipelines/vs-insertion.yml) (add to parameters and make new AutoTargetBranch rule by copying it from existing ones) of the [MSBuild VS Insertion pipeline](https://devdiv.visualstudio.com/DevDiv/_build?definitionId=24295) to insert MSBuild `vs{{THIS_RELEASE_VERSION}}` to the corresponding VS branch `rel/d{{THIS_RELEASE_VERSION}}`.
+    - [ ] Set scheduled insertion for main and remove exclusion of `vs{{THIS_RELEASE_VERSION}}` triggering on each commit if added earlier.
 - [ ]  Merge {{NEXT_VERSION}} branding PR
 
 ### Adjust DARC channels and subscriptions


### PR DESCRIPTION
### Context
https://github.com/dotnet/msbuild/pull/10966
https://github.com/dotnet/msbuild/pull/10919
https://github.com/dotnet/msbuild/pull/10920
Without this change the scheduled runs on main inputs CI from any branch that had the last successful run which is wrong. 


### Notes for review
Desired functionality:
1. Manually trigger from AzDO UI, ability to select as input resource pipeline a specific MSBuild CI run and specify to which branch to insert.
2. Scheduled run on main every weekday inputting the last successful CI on main.
3. Triggered runs after CI run finished in release branches (vs*)
4. Ability to disable 2.,3. via AzDO UI by setting custom triggers and schedule.


### Changes Made
Set schedules and triggers.
Changes logic to trigger servicing insertion on each commit to release branch.

### Testing
Manually tested scenarios in a playground AzDO org.

- Main last build, scheduled on main
- release last build, scheduled on main
- release last build, triggered by ci
- multiple release branches - no double triggers
- new release branch
- manual run