### PR TITLE
[main] Run tests even if version is not bumped

### DIFF
--- a/.vsts-dotnet-ci.yml
+++ b/.vsts-dotnet-ci.yml
@@ -40,7 +40,6 @@ jobs:
     displayName: "Check if patch version is bumped up"
 
 - job: IfOnlyDocumentionChanged
-  dependsOn: CheckVersionBumpOnReleaseBranches
   displayName: "Check whether Test Results need to be executed"
   steps:
   - powershell: |


### PR DESCRIPTION
Fixes #11014 

### Context
Let's run tests even though version is not bumped.

(no effect on main but when future release branches branch from it they'll inherit the change)

backport to vs17.10, vs17.11, vs17.12 where this pipeline step is present