### PR TITLE
Buildcheck - ProjectImported OM fixes

### DIFF
--- a/src/Build/BuildCheck/Infrastructure/BuildCheckBuildEventHandler.cs
+++ b/src/Build/BuildCheck/Infrastructure/BuildCheckBuildEventHandler.cs
@@ -91,6 +91,7 @@ internal class BuildCheckBuildEventHandler
                 eventArgs.ProjectFile!);
 
             _buildCheckManager.ProcessProjectEvaluationStarted(
+                BuildCheckDataSource.EventArgs,
                 checkContext,
                 eventArgs.ProjectFile!);
         }

--- a/src/Build/BuildCheck/Infrastructure/BuildCheckForwardingLogger.cs
+++ b/src/Build/BuildCheck/Infrastructure/BuildCheckForwardingLogger.cs
@@ -43,7 +43,6 @@ internal class BuildCheckForwardingLogger : IForwardingLogger
         typeof(TaskFinishedEventArgs),
         typeof(TaskParameterEventArgs),
         typeof(ProjectImportedEventArgs),
-        typeof(ProjectImportedEventArgs),
     ];
 
     public void Initialize(IEventSource eventSource, int nodeCount) => Initialize(eventSource);

--- a/src/Build/BuildCheck/Infrastructure/BuildCheckForwardingLogger.cs
+++ b/src/Build/BuildCheck/Infrastructure/BuildCheckForwardingLogger.cs
@@ -43,6 +43,7 @@ internal class BuildCheckForwardingLogger : IForwardingLogger
         typeof(TaskFinishedEventArgs),
         typeof(TaskParameterEventArgs),
         typeof(ProjectImportedEventArgs),
+        typeof(ProjectImportedEventArgs),
     ];
 
     public void Initialize(IEventSource eventSource, int nodeCount) => Initialize(eventSource);

--- a/src/Build/BuildCheck/Infrastructure/BuildCheckManagerProvider.cs
+++ b/src/Build/BuildCheck/Infrastructure/BuildCheckManagerProvider.cs
@@ -629,8 +629,7 @@ internal sealed class BuildCheckManagerProvider : IBuildCheckManagerProvider
         private void PropagateImport(int evaluationId, string originalProjectFile, string newImportedProjectFile)
         {
             if (_deferredProjectEvalIdToImportedProjects.TryGetValue(evaluationId,
-                    out HashSet<string>? importedProjects)
-                && importedProjects.Contains(originalProjectFile))
+                    out HashSet<string>? importedProjects))
             {
                 importedProjects.Add(newImportedProjectFile);
             }

--- a/src/Build/BuildCheck/Infrastructure/BuildCheckManagerProvider.cs
+++ b/src/Build/BuildCheck/Infrastructure/BuildCheckManagerProvider.cs
@@ -502,6 +502,7 @@ internal sealed class BuildCheckManagerProvider : IBuildCheckManagerProvider
         private readonly ConcurrentDictionary<int, string> _projectsByInstanceId = new();
         private readonly ConcurrentDictionary<int, string> _projectsByEvaluationId = new();
         // We are receiving project imported data only from the logger events - hence always in a single threaded context
+        //  (https://github.com/dotnet/msbuild/blob/main/documentation/wiki/Logging-Internals.md)
         private readonly Dictionary<int, HashSet<string>> _deferredProjectEvalIdToImportedProjects = new();
 
         /// <summary>
@@ -619,19 +620,17 @@ internal sealed class BuildCheckManagerProvider : IBuildCheckManagerProvider
         private readonly Dictionary<int, List<BuildEventArgs>> _deferredEvalDiagnostics = new();
 
         /// <summary>
-        /// Propagates a newly imported project file to all projects that import the original project file.
-        /// This method ensures that if Project A imports Project B, and Project B now imports Project C,
-        /// then Project A will also show Project C as an import.
+        /// Registers the logic import by a project file.
         /// </summary>
         /// <param name="evaluationId">The evaluation id is associated with the root project path.</param>
-        /// <param name="originalProjectFile">The path of the project file that is importing a new project.</param>
-        /// <param name="newImportedProjectFile">The path of the newly imported project file.</param>
-        private void PropagateImport(int evaluationId, string originalProjectFile, string newImportedProjectFile)
+        /// <param name="importingProjectFile">The path of the project file that is importing a new project.</param>
+        /// <param name="importedFile">The path of the imported project file.</param>
+        private void PropagateImport(int evaluationId, string importingProjectFile, string importedFile)
         {
             if (_deferredProjectEvalIdToImportedProjects.TryGetValue(evaluationId,
                     out HashSet<string>? importedProjects))
             {
-                importedProjects.Add(newImportedProjectFile);
+                importedProjects.Add(importedFile);
             }
         }
 

--- a/src/Build/BuildCheck/Infrastructure/IBuildCheckManager.cs
+++ b/src/Build/BuildCheck/Infrastructure/IBuildCheckManager.cs
@@ -74,7 +74,7 @@ internal interface IBuildCheckManager
     //  - but we still need to know about it, hence the dedicated event.
     void ProjectFirstEncountered(BuildCheckDataSource buildCheckDataSource, ICheckContext analysisContext, string projectFullPath);
 
-    void ProcessProjectEvaluationStarted(ICheckContext checksContext, string projectFullPath);
+    void ProcessProjectEvaluationStarted(BuildCheckDataSource buildCheckDataSource, ICheckContext checksContext, string projectFullPath);
 
     void EndProjectEvaluation(BuildEventContext buildEventContext);
 

--- a/src/Build/BuildCheck/Infrastructure/NullBuildCheckManager.cs
+++ b/src/Build/BuildCheck/Infrastructure/NullBuildCheckManager.cs
@@ -61,6 +61,10 @@ internal class NullBuildCheckManager : IBuildCheckManager, IBuildEngineDataRoute
     }
 
     public void ProcessProjectEvaluationStarted(ICheckContext checkContext, string projectFullPath)
+    { 
+    }
+
+    public void ProcessProjectEvaluationStarted(BuildCheckDataSource buildCheckDataSource, ICheckContext checkContext, string projectFullPath)
     {
     }
 


### PR DESCRIPTION
Fixes #10960, #10935

### Context
 * ProjectImported OM wasn't properly propagated if binlog wasn't specified
 * ProjectImported OM should only be handled in single threaded context of main node logger

### Testing
Preexisting tests
