### PR TITLE
Support 'IfDifferent' for CopyToOutputDirectory

### DIFF
--- a/src/MSBuild/MSBuild/Microsoft.Build.CommonTypes.xsd
+++ b/src/MSBuild/MSBuild/Microsoft.Build.CommonTypes.xsd
@@ -768,6 +768,7 @@ elementFormDefault="qualified">
                                         <xs:enumeration value="Never" />
                                         <xs:enumeration value="Always" />
                                         <xs:enumeration value="PreserveNewest" />
+                                        <xs:enumeration value="IfDifferent" />
                                     </xs:restriction>
                                 </xs:simpleType>
                             </xs:element>
@@ -787,6 +788,7 @@ elementFormDefault="qualified">
                                 <xs:enumeration value="Never" />
                                 <xs:enumeration value="Always" />
                                 <xs:enumeration value="PreserveNewest" />
+                                <xs:enumeration value="IfDifferent" />
                             </xs:restriction>
                         </xs:simpleType>
                     </xs:attribute>
@@ -836,6 +838,7 @@ elementFormDefault="qualified">
                                         <xs:enumeration value="Never" />
                                         <xs:enumeration value="Always" />
                                         <xs:enumeration value="PreserveNewest" />
+                                        <xs:enumeration value="IfDifferent" />
                                     </xs:restriction>
                                 </xs:simpleType>
                             </xs:element>
@@ -855,6 +858,7 @@ elementFormDefault="qualified">
                                 <xs:enumeration value="Never" />
                                 <xs:enumeration value="Always" />
                                 <xs:enumeration value="PreserveNewest" />
+                                <xs:enumeration value="IfDifferent" />
                             </xs:restriction>
                         </xs:simpleType>
                     </xs:attribute>
@@ -906,6 +910,7 @@ elementFormDefault="qualified">
                                         <xs:enumeration value="Never" />
                                         <xs:enumeration value="Always" />
                                         <xs:enumeration value="PreserveNewest" />
+                                        <xs:enumeration value="IfDifferent" />
                                     </xs:restriction>
                                 </xs:simpleType>
                             </xs:element>
@@ -918,6 +923,7 @@ elementFormDefault="qualified">
                                         <xs:enumeration value="Never" />
                                         <xs:enumeration value="Always" />
                                         <xs:enumeration value="PreserveNewest" />
+                                        <xs:enumeration value="IfDifferent" />
                                     </xs:restriction>
                                 </xs:simpleType>
                             </xs:element>
@@ -936,6 +942,7 @@ elementFormDefault="qualified">
                                 <xs:enumeration value="Never" />
                                 <xs:enumeration value="Always" />
                                 <xs:enumeration value="PreserveNewest" />
+                                <xs:enumeration value="IfDifferent" />
                             </xs:restriction>
                         </xs:simpleType>
                     </xs:attribute>
@@ -976,6 +983,7 @@ elementFormDefault="qualified">
                                         <xs:enumeration value="Never" />
                                         <xs:enumeration value="Always" />
                                         <xs:enumeration value="PreserveNewest" />
+                                        <xs:enumeration value="IfDifferent" />
                                     </xs:restriction>
                                 </xs:simpleType>
                             </xs:element>
@@ -994,6 +1002,7 @@ elementFormDefault="qualified">
                                 <xs:enumeration value="Never" />
                                 <xs:enumeration value="Always" />
                                 <xs:enumeration value="PreserveNewest" />
+                                <xs:enumeration value="IfDifferent" />
                             </xs:restriction>
                         </xs:simpleType>
                     </xs:attribute>
@@ -1034,6 +1043,7 @@ elementFormDefault="qualified">
                                         <xs:enumeration value="Never" />
                                         <xs:enumeration value="Always" />
                                         <xs:enumeration value="PreserveNewest" />
+                                        <xs:enumeration value="IfDifferent" />
                                     </xs:restriction>
                                 </xs:simpleType>
                             </xs:element>
@@ -1052,6 +1062,7 @@ elementFormDefault="qualified">
                                 <xs:enumeration value="Never" />
                                 <xs:enumeration value="Always" />
                                 <xs:enumeration value="PreserveNewest" />
+                                <xs:enumeration value="IfDifferent" />
                             </xs:restriction>
                         </xs:simpleType>
                     </xs:attribute>
@@ -1092,6 +1103,7 @@ elementFormDefault="qualified">
                                         <xs:enumeration value="Never" />
                                         <xs:enumeration value="Always" />
                                         <xs:enumeration value="PreserveNewest" />
+                                        <xs:enumeration value="IfDifferent" />
                                     </xs:restriction>
                                 </xs:simpleType>
                             </xs:element>
@@ -1104,6 +1116,7 @@ elementFormDefault="qualified">
                                 <xs:enumeration value="Never" />
                                 <xs:enumeration value="Always" />
                                 <xs:enumeration value="PreserveNewest" />
+                                <xs:enumeration value="IfDifferent" />
                             </xs:restriction>
                         </xs:simpleType>
                     </xs:attribute>
@@ -1144,6 +1157,7 @@ elementFormDefault="qualified">
                                         <xs:enumeration value="Never" />
                                         <xs:enumeration value="Always" />
                                         <xs:enumeration value="PreserveNewest" />
+                                        <xs:enumeration value="IfDifferent" />
                                     </xs:restriction>
                                 </xs:simpleType>
                             </xs:element>

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -4565,7 +4565,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         The PublishProtocol property is available only in .NET>=5 so we will used that to exclude .NET FX 4.X case.
       -->
       <!-- Include items from None group for publishing -->
-      <_ClickOnceNoneItemsTemp Include="@(_NoneWithTargetPath->WithoutMetadataValue('CopyToPublishDirectory', 'Never')->'%(TargetPath)')" Condition="'$(PublishProtocol)'=='Clickonce' And ('%(_NoneWithTargetPath.CopyToOutputDirectory)'=='Always' or '%(_NoneWithTargetPath.CopyToOutputDirectory)'=='PreserveNewest')">
+      <_ClickOnceNoneItemsTemp Include="@(_NoneWithTargetPath->WithoutMetadataValue('CopyToPublishDirectory', 'Never')->'%(TargetPath)')" Condition="'$(PublishProtocol)'=='Clickonce' And ('%(_NoneWithTargetPath.CopyToOutputDirectory)'=='Always' or '%(_NoneWithTargetPath.CopyToOutputDirectory)'=='PreserveNewest' or '%(_NoneWithTargetPath.CopyToOutputDirectory)'=='IfDifferent')">
         <SavedIdentity>%(Identity)</SavedIdentity>
       </_ClickOnceNoneItemsTemp>
       <_ClickOnceNoneItems Include="@(_ClickOnceNoneItemsTemp->'%(SavedIdentity)')" Condition="'%(Identity)'=='@(PublishFile)' Or '%(Extension)'=='.exe' Or '%(Extension)'=='.dll'" />
@@ -5074,7 +5074,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       DependsOnTargets="
             GetCopyToOutputDirectoryItems;
             _CopyOutOfDateSourceItemsToOutputDirectory;
-            _CopyOutOfDateSourceItemsToOutputDirectoryAlways"/>
+            _CopyOutOfDateSourceItemsToOutputDirectoryAlways;
+            _CopyDifferingSourceItemsToOutputDirectory"/>
   <!--
     ============================================================
                                         GetCopyToOutputDirectoryItems
@@ -5155,6 +5156,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <ItemGroup>
       <_CopyToOutputDirectoryTransitiveItems   KeepDuplicates=" '$(_GCTODIKeepDuplicates)' != 'false' " KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(_AllChildProjectItemsWithTargetPath->'%(FullPath)')" Condition="'%(_AllChildProjectItemsWithTargetPath.CopyToOutputDirectory)'=='Always'"/>
       <_CopyToOutputDirectoryTransitiveItems   KeepDuplicates=" '$(_GCTODIKeepDuplicates)' != 'false' " KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(_AllChildProjectItemsWithTargetPath->'%(FullPath)')" Condition="'%(_AllChildProjectItemsWithTargetPath.CopyToOutputDirectory)'=='PreserveNewest'"/>
+        <_CopyToOutputDirectoryTransitiveItems   KeepDuplicates=" '$(_GCTODIKeepDuplicates)' != 'false' " KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(_AllChildProjectItemsWithTargetPath->'%(FullPath)')" Condition="'%(_AllChildProjectItemsWithTargetPath.CopyToOutputDirectory)'=='IfDifferent'"/>
     </ItemGroup>
 
     <!-- Remove items which we will never again use - they just sit around taking up memory otherwise -->
@@ -5166,15 +5168,17 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <ItemGroup>
       <_CopyToOutputDirectoryTransitiveItems       KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(ContentWithTargetPath->'%(FullPath)')" Condition="'%(ContentWithTargetPath.CopyToOutputDirectory)'=='Always' AND '%(ContentWithTargetPath.MSBuildSourceProjectFile)'!=''"/>
       <_CopyToOutputDirectoryTransitiveItems       KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(ContentWithTargetPath->'%(FullPath)')" Condition="'%(ContentWithTargetPath.CopyToOutputDirectory)'=='PreserveNewest' AND '%(ContentWithTargetPath.MSBuildSourceProjectFile)'!=''"/>
+        <_CopyToOutputDirectoryTransitiveItems       KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(ContentWithTargetPath->'%(FullPath)')" Condition="'%(ContentWithTargetPath.CopyToOutputDirectory)'=='IfDifferent' AND '%(ContentWithTargetPath.MSBuildSourceProjectFile)'!=''"/>
     </ItemGroup>
 
     <ItemGroup>
       <_CopyToOutputDirectoryTransitiveItems       KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(EmbeddedResource->'%(FullPath)')" Condition="'%(EmbeddedResource.CopyToOutputDirectory)'=='Always' AND '%(EmbeddedResource.MSBuildSourceProjectFile)'!=''"/>
       <_CopyToOutputDirectoryTransitiveItems       KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(EmbeddedResource->'%(FullPath)')" Condition="'%(EmbeddedResource.CopyToOutputDirectory)'=='PreserveNewest' AND '%(EmbeddedResource.MSBuildSourceProjectFile)'!=''"/>
+        <_CopyToOutputDirectoryTransitiveItems       KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(EmbeddedResource->'%(FullPath)')" Condition="'%(EmbeddedResource.CopyToOutputDirectory)'=='IfDifferent' AND '%(EmbeddedResource.MSBuildSourceProjectFile)'!=''"/>
     </ItemGroup>
 
     <ItemGroup>
-      <_CompileItemsToCopy Include="@(Compile->'%(FullPath)')" Condition="('%(Compile.CopyToOutputDirectory)'=='Always' or '%(Compile.CopyToOutputDirectory)'=='PreserveNewest') AND '%(Compile.MSBuildSourceProjectFile)'!=''"/>
+      <_CompileItemsToCopy Include="@(Compile->'%(FullPath)')" Condition="('%(Compile.CopyToOutputDirectory)'=='Always' or '%(Compile.CopyToOutputDirectory)'=='PreserveNewest' or '%(Compile.CopyToOutputDirectory)'=='IfDifferent') AND '%(Compile.MSBuildSourceProjectFile)'!=''"/>
     </ItemGroup>
 
     <AssignTargetPath Files="@(_CompileItemsToCopy)" RootFolder="$(MSBuildProjectDirectory)">
@@ -5184,11 +5188,13 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <ItemGroup>
       <_CopyToOutputDirectoryTransitiveItems       KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(_CompileItemsToCopyWithTargetPath)" Condition="'%(_CompileItemsToCopyWithTargetPath.CopyToOutputDirectory)'=='Always'"/>
       <_CopyToOutputDirectoryTransitiveItems       KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(_CompileItemsToCopyWithTargetPath)" Condition="'%(_CompileItemsToCopyWithTargetPath.CopyToOutputDirectory)'=='PreserveNewest'"/>
+      <_CopyToOutputDirectoryTransitiveItems       KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(_CompileItemsToCopyWithTargetPath)" Condition="'%(_CompileItemsToCopyWithTargetPath.CopyToOutputDirectory)'=='IfDifferent'"/>
     </ItemGroup>
 
     <ItemGroup>
       <_CopyToOutputDirectoryTransitiveItems       KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(_NoneWithTargetPath->'%(FullPath)')" Condition="'%(_NoneWithTargetPath.CopyToOutputDirectory)'=='Always' AND '%(_NoneWithTargetPath.MSBuildSourceProjectFile)'!=''"/>
       <_CopyToOutputDirectoryTransitiveItems       KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(_NoneWithTargetPath->'%(FullPath)')" Condition="'%(_NoneWithTargetPath.CopyToOutputDirectory)'=='PreserveNewest' AND '%(_NoneWithTargetPath.MSBuildSourceProjectFile)'!=''"/>
+      <_CopyToOutputDirectoryTransitiveItems       KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(_NoneWithTargetPath->'%(FullPath)')" Condition="'%(_NoneWithTargetPath.CopyToOutputDirectory)'=='IfDifferent' AND '%(_NoneWithTargetPath.MSBuildSourceProjectFile)'!=''"/>
     </ItemGroup>
 
   </Target>
@@ -5201,15 +5207,17 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <ItemGroup>
       <_ThisProjectItemsToCopyToOutputDirectory       KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(ContentWithTargetPath->'%(FullPath)')" Condition="'%(ContentWithTargetPath.CopyToOutputDirectory)'=='Always' AND '%(ContentWithTargetPath.MSBuildSourceProjectFile)'==''"/>
       <_ThisProjectItemsToCopyToOutputDirectory       KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(ContentWithTargetPath->'%(FullPath)')" Condition="'%(ContentWithTargetPath.CopyToOutputDirectory)'=='PreserveNewest' AND '%(ContentWithTargetPath.MSBuildSourceProjectFile)'==''"/>
+      <_ThisProjectItemsToCopyToOutputDirectory       KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(ContentWithTargetPath->'%(FullPath)')" Condition="'%(ContentWithTargetPath.CopyToOutputDirectory)'=='IfDifferent' AND '%(ContentWithTargetPath.MSBuildSourceProjectFile)'==''"/>
     </ItemGroup>
 
     <ItemGroup>
       <_ThisProjectItemsToCopyToOutputDirectory       KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(EmbeddedResource->'%(FullPath)')" Condition="'%(EmbeddedResource.CopyToOutputDirectory)'=='Always' AND '%(EmbeddedResource.MSBuildSourceProjectFile)'==''"/>
       <_ThisProjectItemsToCopyToOutputDirectory       KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(EmbeddedResource->'%(FullPath)')" Condition="'%(EmbeddedResource.CopyToOutputDirectory)'=='PreserveNewest' AND '%(EmbeddedResource.MSBuildSourceProjectFile)'==''"/>
+        <_ThisProjectItemsToCopyToOutputDirectory       KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(EmbeddedResource->'%(FullPath)')" Condition="'%(EmbeddedResource.CopyToOutputDirectory)'=='IfDifferent' AND '%(EmbeddedResource.MSBuildSourceProjectFile)'==''"/>
     </ItemGroup>
 
     <ItemGroup>
-      <_CompileItemsToCopy Include="@(Compile->'%(FullPath)')" Condition="('%(Compile.CopyToOutputDirectory)'=='Always' or '%(Compile.CopyToOutputDirectory)'=='PreserveNewest') AND '%(Compile.MSBuildSourceProjectFile)'==''"/>
+      <_CompileItemsToCopy Include="@(Compile->'%(FullPath)')" Condition="('%(Compile.CopyToOutputDirectory)'=='Always' or '%(Compile.CopyToOutputDirectory)'=='PreserveNewest' or '%(Compile.CopyToOutputDirectory)'=='IfDifferent') AND '%(Compile.MSBuildSourceProjectFile)'==''"/>
     </ItemGroup>
 
     <AssignTargetPath Files="@(_CompileItemsToCopy)" RootFolder="$(MSBuildProjectDirectory)">
@@ -5219,11 +5227,13 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <ItemGroup>
       <_ThisProjectItemsToCopyToOutputDirectory       KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(_CompileItemsToCopyWithTargetPath)" Condition="'%(_CompileItemsToCopyWithTargetPath.CopyToOutputDirectory)'=='Always'"/>
       <_ThisProjectItemsToCopyToOutputDirectory       KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(_CompileItemsToCopyWithTargetPath)" Condition="'%(_CompileItemsToCopyWithTargetPath.CopyToOutputDirectory)'=='PreserveNewest'"/>
+      <_ThisProjectItemsToCopyToOutputDirectory       KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(_CompileItemsToCopyWithTargetPath)" Condition="'%(_CompileItemsToCopyWithTargetPath.CopyToOutputDirectory)'=='IfDifferent'"/>
     </ItemGroup>
 
     <ItemGroup>
       <_ThisProjectItemsToCopyToOutputDirectory       KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(_NoneWithTargetPath->'%(FullPath)')" Condition="'%(_NoneWithTargetPath.CopyToOutputDirectory)'=='Always' AND '%(_NoneWithTargetPath.MSBuildSourceProjectFile)'==''"/>
       <_ThisProjectItemsToCopyToOutputDirectory       KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(_NoneWithTargetPath->'%(FullPath)')" Condition="'%(_NoneWithTargetPath.CopyToOutputDirectory)'=='PreserveNewest' AND '%(_NoneWithTargetPath.MSBuildSourceProjectFile)'==''"/>
+      <_ThisProjectItemsToCopyToOutputDirectory       KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(_NoneWithTargetPath->'%(FullPath)')" Condition="'%(_NoneWithTargetPath.CopyToOutputDirectory)'=='IfDifferent' AND '%(_NoneWithTargetPath.MSBuildSourceProjectFile)'==''"/>
     </ItemGroup>
 
   </Target>
@@ -5251,23 +5261,28 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <ItemGroup>
       <_TransitiveItemsToCopyToOutputDirectoryAlways               KeepDuplicates=" '$(_GCTODIKeepDuplicates)' != 'false' " KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(_TransitiveItemsToCopyToOutputDirectory->'%(FullPath)')" Condition="'%(_TransitiveItemsToCopyToOutputDirectory.CopyToOutputDirectory)'=='Always'"/>
       <_TransitiveItemsToCopyToOutputDirectoryPreserveNewest       KeepDuplicates=" '$(_GCTODIKeepDuplicates)' != 'false' " KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(_TransitiveItemsToCopyToOutputDirectory->'%(FullPath)')" Condition="'%(_TransitiveItemsToCopyToOutputDirectory.CopyToOutputDirectory)'=='PreserveNewest'"/>
+      <_TransitiveItemsToCopyToOutputDirectoryIfDifferent          KeepDuplicates=" '$(_GCTODIKeepDuplicates)' != 'false' " KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(_TransitiveItemsToCopyToOutputDirectory->'%(FullPath)')" Condition="'%(_TransitiveItemsToCopyToOutputDirectory.CopyToOutputDirectory)'=='IfDifferent'"/>
 
       <_ThisProjectItemsToCopyToOutputDirectoryAlways              KeepDuplicates=" '$(_GCTODIKeepDuplicates)' != 'false' " KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(_ThisProjectItemsToCopyToOutputDirectory->'%(FullPath)')" Condition="'%(_ThisProjectItemsToCopyToOutputDirectory.CopyToOutputDirectory)'=='Always'"/>
       <_ThisProjectItemsToCopyToOutputDirectoryPreserveNewest      KeepDuplicates=" '$(_GCTODIKeepDuplicates)' != 'false' " KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(_ThisProjectItemsToCopyToOutputDirectory->'%(FullPath)')" Condition="'%(_ThisProjectItemsToCopyToOutputDirectory.CopyToOutputDirectory)'=='PreserveNewest'"/>
+      <_ThisProjectItemsToCopyToOutputDirectoryIfDifferent         KeepDuplicates=" '$(_GCTODIKeepDuplicates)' != 'false' " KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(_ThisProjectItemsToCopyToOutputDirectory->'%(FullPath)')" Condition="'%(_ThisProjectItemsToCopyToOutputDirectory.CopyToOutputDirectory)'=='IfDifferent'"/>
 
       <!-- Append the items from this project last so that they will be copied last. -->
       <_SourceItemsToCopyToOutputDirectoryAlways                   Include="@(_TransitiveItemsToCopyToOutputDirectoryAlways);@(_ThisProjectItemsToCopyToOutputDirectoryAlways)"/>
       <_SourceItemsToCopyToOutputDirectory                         Include="@(_TransitiveItemsToCopyToOutputDirectoryPreserveNewest);@(_ThisProjectItemsToCopyToOutputDirectoryPreserveNewest)"/>
+      <_SourceItemsToCopyToOutputDirectoryIfDifferent              Include="@(_TransitiveItemsToCopyToOutputDirectoryIfDifferent);@(_ThisProjectItemsToCopyToOutputDirectoryIfDifferent)"/>
 
-      <AllItemsFullPathWithTargetPath                              Include="@(_SourceItemsToCopyToOutputDirectoryAlways->'%(FullPath)');@(_SourceItemsToCopyToOutputDirectory->'%(FullPath)')"/>
+      <AllItemsFullPathWithTargetPath                              Include="@(_SourceItemsToCopyToOutputDirectoryAlways->'%(FullPath)');@(_SourceItemsToCopyToOutputDirectory->'%(FullPath)');@(_SourceItemsToCopyToOutputDirectoryIfDifferent->'%(FullPath)')"/>
 
       <!-- Empty intermediate items to release memory -->
       <_TransitiveItemsToCopyToOutputDirectoryAlways               Remove="@(_TransitiveItemsToCopyToOutputDirectoryAlways)"/>
       <_TransitiveItemsToCopyToOutputDirectoryPreserveNewest       Remove="@(_TransitiveItemsToCopyToOutputDirectoryPreserveNewest)"/>
+      <_TransitiveItemsToCopyToOutputDirectoryIfDifferent          Remove="@(_TransitiveItemsToCopyToOutputDirectoryIfDifferent)"/>
 
       <_ThisProjectItemsToCopyToOutputDirectoryAlways              Remove="@(_ThisProjectItemsToCopyToOutputDirectoryAlways)"/>
       <_ThisProjectItemsToCopyToOutputDirectoryPreserveNewest      Remove="@(_ThisProjectItemsToCopyToOutputDirectoryPreserveNewest)"/>
       <_ThisProjectItemsToCopyToOutputDirectory                    Remove="@(_ThisProjectItemsToCopyToOutputDirectory)"/>
+      <_ThisProjectItemsToCopyToOutputDirectoryIfDifferent         Remove="@(_ThisProjectItemsToCopyToOutputDirectoryIfDifferent)"/>
     </ItemGroup>
 
   </Target>
@@ -5316,8 +5331,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       Outputs="@(_SourceItemsToCopyToOutputDirectory->'$(OutDir)%(TargetPath)')">
 
     <!--
-        Not using SkipUnchangedFiles="true" because the application may want to change
-        one of these files and not have an incremental build replace it.
+        Not using SkipUnchangedFiles="true" because we anyways copy only the ones with newer timestamp.
         -->
     <Copy
         SourceFiles = "@(_SourceItemsToCopyToOutputDirectory)"
@@ -5347,12 +5361,17 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       Condition=" '@(_SourceItemsToCopyToOutputDirectoryAlways)' != '' ">
 
     <!--
-        Not using SkipUnchangedFiles="true" because the application may want to change
-        one of these files and not have an incremental build replace it.
+        Not using SkipUnchangedFiles="true" by default for backwards compatibility.
         -->
+        
+    <PropertyGroup>
+      <SkipUnchangedFilesOnCopyAlways Condition="'$(SkipUnchangedFilesOnCopyAlways)' == ''">false</SkipUnchangedFilesOnCopyAlways>
+    </PropertyGroup>
+        
     <Copy
         SourceFiles = "@(_SourceItemsToCopyToOutputDirectoryAlways)"
         DestinationFiles = "@(_SourceItemsToCopyToOutputDirectoryAlways->'$(OutDir)%(TargetPath)')"
+        SkipUnchangedFiles="$(SkipUnchangedFilesOnCopyAlways)"
         OverwriteReadOnlyFiles="$(OverwriteReadOnlyFiles)"
         Retries="$(CopyRetryCount)"
         RetryDelayMilliseconds="$(CopyRetryDelayMilliseconds)"
@@ -5366,6 +5385,37 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
   </Target>
 
+  <!--
+    ============================================================
+                                        _CopyDifferingSourceItemsToOutputDirectory
+
+    Copy files that have the CopyToOutputDirectory attribute set to 'IfDifferent'.
+    ============================================================
+    -->
+  <Target
+      Name="_CopyDifferingSourceItemsToOutputDirectory"
+      Condition=" '@(_SourceItemsToCopyToOutputDirectoryIfDifferent)' != '' ">
+
+    <!--
+        Using SkipUnchangedFiles="true" because we want only differing files.
+        -->
+    <Copy
+        SourceFiles = "@(_SourceItemsToCopyToOutputDirectoryIfDifferent)"
+        DestinationFiles = "@(_SourceItemsToCopyToOutputDirectoryIfDifferent->'$(OutDir)%(TargetPath)')"
+        SkipUnchangedFiles="true"
+        OverwriteReadOnlyFiles="$(OverwriteReadOnlyFiles)"
+        Retries="$(CopyRetryCount)"
+        RetryDelayMilliseconds="$(CopyRetryDelayMilliseconds)"
+        UseHardlinksIfPossible="$(CreateHardLinksForAdditionalFilesIfPossible)"
+        UseSymboliclinksIfPossible="$(CreateSymbolicLinksForAdditionalFilesIfPossible)"
+            >
+
+      <Output TaskParameter="DestinationFiles" ItemName="FileWrites"/>
+
+    </Copy>
+
+  </Target>
+  
   <!--
     ============================================================
                                         _CopyAppConfigFile

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -5156,7 +5156,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <ItemGroup>
       <_CopyToOutputDirectoryTransitiveItems   KeepDuplicates=" '$(_GCTODIKeepDuplicates)' != 'false' " KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(_AllChildProjectItemsWithTargetPath->'%(FullPath)')" Condition="'%(_AllChildProjectItemsWithTargetPath.CopyToOutputDirectory)'=='Always'"/>
       <_CopyToOutputDirectoryTransitiveItems   KeepDuplicates=" '$(_GCTODIKeepDuplicates)' != 'false' " KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(_AllChildProjectItemsWithTargetPath->'%(FullPath)')" Condition="'%(_AllChildProjectItemsWithTargetPath.CopyToOutputDirectory)'=='PreserveNewest'"/>
-        <_CopyToOutputDirectoryTransitiveItems   KeepDuplicates=" '$(_GCTODIKeepDuplicates)' != 'false' " KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(_AllChildProjectItemsWithTargetPath->'%(FullPath)')" Condition="'%(_AllChildProjectItemsWithTargetPath.CopyToOutputDirectory)'=='IfDifferent'"/>
+      <_CopyToOutputDirectoryTransitiveItems   KeepDuplicates=" '$(_GCTODIKeepDuplicates)' != 'false' " KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(_AllChildProjectItemsWithTargetPath->'%(FullPath)')" Condition="'%(_AllChildProjectItemsWithTargetPath.CopyToOutputDirectory)'=='IfDifferent'"/>
     </ItemGroup>
 
     <!-- Remove items which we will never again use - they just sit around taking up memory otherwise -->
@@ -5168,7 +5168,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <ItemGroup>
       <_CopyToOutputDirectoryTransitiveItems       KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(ContentWithTargetPath->'%(FullPath)')" Condition="'%(ContentWithTargetPath.CopyToOutputDirectory)'=='Always' AND '%(ContentWithTargetPath.MSBuildSourceProjectFile)'!=''"/>
       <_CopyToOutputDirectoryTransitiveItems       KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(ContentWithTargetPath->'%(FullPath)')" Condition="'%(ContentWithTargetPath.CopyToOutputDirectory)'=='PreserveNewest' AND '%(ContentWithTargetPath.MSBuildSourceProjectFile)'!=''"/>
-        <_CopyToOutputDirectoryTransitiveItems       KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(ContentWithTargetPath->'%(FullPath)')" Condition="'%(ContentWithTargetPath.CopyToOutputDirectory)'=='IfDifferent' AND '%(ContentWithTargetPath.MSBuildSourceProjectFile)'!=''"/>
+      <_CopyToOutputDirectoryTransitiveItems       KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(ContentWithTargetPath->'%(FullPath)')" Condition="'%(ContentWithTargetPath.CopyToOutputDirectory)'=='IfDifferent' AND '%(ContentWithTargetPath.MSBuildSourceProjectFile)'!=''"/>
     </ItemGroup>
 
     <ItemGroup>
@@ -5213,7 +5213,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <ItemGroup>
       <_ThisProjectItemsToCopyToOutputDirectory       KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(EmbeddedResource->'%(FullPath)')" Condition="'%(EmbeddedResource.CopyToOutputDirectory)'=='Always' AND '%(EmbeddedResource.MSBuildSourceProjectFile)'==''"/>
       <_ThisProjectItemsToCopyToOutputDirectory       KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(EmbeddedResource->'%(FullPath)')" Condition="'%(EmbeddedResource.CopyToOutputDirectory)'=='PreserveNewest' AND '%(EmbeddedResource.MSBuildSourceProjectFile)'==''"/>
-        <_ThisProjectItemsToCopyToOutputDirectory       KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(EmbeddedResource->'%(FullPath)')" Condition="'%(EmbeddedResource.CopyToOutputDirectory)'=='IfDifferent' AND '%(EmbeddedResource.MSBuildSourceProjectFile)'==''"/>
+      <_ThisProjectItemsToCopyToOutputDirectory       KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(EmbeddedResource->'%(FullPath)')" Condition="'%(EmbeddedResource.CopyToOutputDirectory)'=='IfDifferent' AND '%(EmbeddedResource.MSBuildSourceProjectFile)'==''"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -5331,7 +5331,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       Outputs="@(_SourceItemsToCopyToOutputDirectory->'$(OutDir)%(TargetPath)')">
 
     <!--
-        Not using SkipUnchangedFiles="true" because we anyways copy only the ones with newer timestamp.
+        Not using SkipUnchangedFiles="true" because the items we pass in are already only those that have newer timestampts in the source (determined by _GetCopyToOutputDirectoryItemsFromThisProject).
         -->
     <Copy
         SourceFiles = "@(_SourceItemsToCopyToOutputDirectory)"


### PR DESCRIPTION
Fixes #8743

### Context
`CopyToOutputDirectory` currently has only `PreserveNewest` and `Always` (and `Never` - not considered here).
`Always` is unnecessery perf hit, but is only workaround for situations where destination file can change between builds (e.g. someone is copying DB, storage file, config file etc. - that can be altered during test runs).

So let's support a mode that allows copying if the file is different - doesn't have to be newer.

At the same time - `Always` should actually be only used in those cases - so let's make it possible to glabaly opt-in for such change in behavior.

### Changes Made
* Added 'IfDifferent' metadata and it's recognition
* Added $(SkipUnchangedFilesOnCopyAlways) property that changes behavior of `Always` to `IfDifferent`

### Testing
Tailored tests added in #11054

