### PR TITLE
Bump maintenance-package dependency versions to latest conditioned to source build only

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -25,13 +25,11 @@
        already consuming the newest version of these same dependencies. -->
   <PropertyGroup Condition="'$(DotNetBuildSourceOnly)' == 'true'">
     <!-- Use newest package versions. -->
-    <MicrosoftIORedistVersion>6.1.0</MicrosoftIORedistVersion>
     <SystemMemoryVersion>4.6.0</SystemMemoryVersion>
     <SystemRuntimeCompilerServicesUnsafeVersion>6.1.0</SystemRuntimeCompilerServicesUnsafeVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(DotNetBuildSourceOnly)' != 'true'">
     <!-- Keep using older versions. Upgrade carefully. -->
-    <MicrosoftIORedistVersion>6.0.1</MicrosoftIORedistVersion>
     <!--
         Modifying the version of System.Memory is very high impact and causes downstream breaks in third-party tooling that uses the MSBuild API.
         When updating the version of System.Memory file a breaking change here: https://github.com/dotnet/docs/issues/new?assignees=gewarren&labels=breaking-change%2CPri1%2Cdoc-idea&template=breaking-change.yml&title=%5BBreaking+change%5D%3A+
@@ -41,6 +39,7 @@
     <SystemRuntimeCompilerServicesUnsafeVersion>6.0.0</SystemRuntimeCompilerServicesUnsafeVersion>
   </PropertyGroup>
   <PropertyGroup>
+    <MicrosoftIORedistVersion>6.0.1</MicrosoftIORedistVersion>
     <MicrosoftVisualStudioSolutionPersistenceVersion>1.0.9</MicrosoftVisualStudioSolutionPersistenceVersion>
     <SystemCollectionsImmutableVersion>8.0.0</SystemCollectionsImmutableVersion>
     <SystemConfigurationConfigurationManagerVersion>8.0.0</SystemConfigurationConfigurationManagerVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -20,23 +20,35 @@
     <UsingToolVSSDK>true</UsingToolVSSDK>
   </PropertyGroup>
   <!-- Production Dependencies -->
-  <PropertyGroup>
+  <!-- Condition consumption of maintenance-packages dependencies based on source build.
+       This is to prevent "package downgrade" errors coming from other packages that are
+       already consuming the newest version of these same dependencies. -->
+  <PropertyGroup Condition="'$(DotNetBuildSourceOnly)' == 'true'">
+    <!-- Use newest package versions. -->
+    <MicrosoftIORedistVersion>6.1.0</MicrosoftIORedistVersion>
+    <SystemMemoryVersion>4.6.0</SystemMemoryVersion>
+    <SystemRuntimeCompilerServicesUnsafeVersion>6.1.0</SystemRuntimeCompilerServicesUnsafeVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(DotNetBuildSourceOnly)' != 'true'">
+    <!-- Keep using older versions. Upgrade carefully. -->
     <MicrosoftIORedistVersion>6.0.1</MicrosoftIORedistVersion>
-    <MicrosoftVisualStudioSolutionPersistenceVersion>1.0.9</MicrosoftVisualStudioSolutionPersistenceVersion>
-    <SystemCollectionsImmutableVersion>8.0.0</SystemCollectionsImmutableVersion>
-    <SystemConfigurationConfigurationManagerVersion>8.0.0</SystemConfigurationConfigurationManagerVersion>
-    <SystemFormatsAsn1Version>8.0.1</SystemFormatsAsn1Version>
     <!--
         Modifying the version of System.Memory is very high impact and causes downstream breaks in third-party tooling that uses the MSBuild API.
         When updating the version of System.Memory file a breaking change here: https://github.com/dotnet/docs/issues/new?assignees=gewarren&labels=breaking-change%2CPri1%2Cdoc-idea&template=breaking-change.yml&title=%5BBreaking+change%5D%3A+
         and follow the guidelines written here (internal-link): https://dev.azure.com/devdiv/DevDiv/_wiki/wikis/DevDiv.wiki/1796/How-to-add-a-Known-Issue
     -->
     <SystemMemoryVersion>4.5.5</SystemMemoryVersion>
+    <SystemRuntimeCompilerServicesUnsafeVersion>6.0.0</SystemRuntimeCompilerServicesUnsafeVersion>
+  </PropertyGroup>
+  <PropertyGroup>
+    <MicrosoftVisualStudioSolutionPersistenceVersion>1.0.9</MicrosoftVisualStudioSolutionPersistenceVersion>
+    <SystemCollectionsImmutableVersion>8.0.0</SystemCollectionsImmutableVersion>
+    <SystemConfigurationConfigurationManagerVersion>8.0.0</SystemConfigurationConfigurationManagerVersion>
+    <SystemFormatsAsn1Version>8.0.1</SystemFormatsAsn1Version>
     <SystemNetHttpVersion>4.3.4</SystemNetHttpVersion>
     <SystemReflectionMetadataLoadContextVersion>8.0.0</SystemReflectionMetadataLoadContextVersion>
     <SystemReflectionMetadataVersion>8.0.0</SystemReflectionMetadataVersion>
     <SystemResourcesExtensionsVersion>8.0.0</SystemResourcesExtensionsVersion>
-    <SystemRuntimeCompilerServicesUnsafeVersion>6.0.0</SystemRuntimeCompilerServicesUnsafeVersion>
     <SystemSecurityPrincipalWindowsVersion>5.0.0</SystemSecurityPrincipalWindowsVersion>
     <SystemTextEncodingCodePagesVersion>7.0.0</SystemTextEncodingCodePagesVersion>
     <SystemTextRegularExpressionsVersion>4.3.1</SystemTextRegularExpressionsVersion>


### PR DESCRIPTION
Similar to https://github.com/dotnet/roslyn/pull/76076

Needed to unblock https://github.com/dotnet/sdk/pull/45042

Should solve error:
```
/vmr/src/msbuild/src/Utilities/Microsoft.Build.Utilities.csproj(0,0): error NU1109: (NETCORE_ENGINEERING_TELEMETRY=Restore) Detected package downgrade: System.Memory from 4.6.0 to centrally defined 4.5.5. Update the centrally managed package version to a higher version. 
 Microsoft.Build.Utilities.Core -> System.Collections.Immutable 10.0.0-alpha.1.24603.1 -> System.Memory (>= 4.6.0) 
 Microsoft.Build.Utilities.Core -> System.Memory (>= 4.5.5)
```

Will also create a patch containing these changes for the sdk PR.