### PR TITLE
Reenable customcheck tests

### DIFF
--- a/src/BuildCheck.UnitTests/EndToEndTests.cs
+++ b/src/BuildCheck.UnitTests/EndToEndTests.cs
@@ -439,7 +439,7 @@ public class EndToEndTests : IDisposable
         }
     }
 
-    [Fact(Skip = "https://github.com/dotnet/msbuild/issues/10702")]
+    [Fact]
     public void CheckHasAccessToAllConfigs()
     {
         using (var env = TestEnvironment.Create())
@@ -617,7 +617,7 @@ public class EndToEndTests : IDisposable
         }
     }
 
-    [Theory(Skip = "https://github.com/dotnet/msbuild/issues/10702")]
+    [Theory]
     [InlineData("CheckCandidate", new[] { "CustomRule1", "CustomRule2" })]
     [InlineData("CheckCandidateWithMultipleChecksInjected", new[] { "CustomRule1", "CustomRule2", "CustomRule3" }, true)]
     public void CustomCheckTest_NoEditorConfig(string checkCandidate, string[] expectedRegisteredRules, bool expectedRejectedChecks = false)


### PR DESCRIPTION
Fixes #10702


### Context
The PR reenables the CustomCheck tests that were disabled due to failing on version bump.
