### PR TITLE
Reverting the culture removal in case of new culture is empty

### DIFF
--- a/src/Tasks/AssignCulture.cs
+++ b/src/Tasks/AssignCulture.cs
@@ -166,11 +166,6 @@ namespace Microsoft.Build.Tasks
                         {
                             Log.LogWarningWithCodeFromResources("AssignCulture.CultureOverwritten",
                                 existingCulture, AssignedFiles[i].ItemSpec, info.culture);
-                            // Remove the culture if it's not recognized
-                            if (string.IsNullOrEmpty(info.culture))
-                            {
-                                AssignedFiles[i].RemoveMetadata(ItemMetadataNames.culture);
-                            }
                         }
 
                         if (!string.IsNullOrEmpty(info.culture))

--- a/src/Tasks/AssignCulture.cs
+++ b/src/Tasks/AssignCulture.cs
@@ -166,6 +166,8 @@ namespace Microsoft.Build.Tasks
                         {
                             Log.LogWarningWithCodeFromResources("AssignCulture.CultureOverwritten",
                                 existingCulture, AssignedFiles[i].ItemSpec, info.culture);
+
+                            // Here we should have had removed the culture - let's do that behind trait
                         }
 
                         if (!string.IsNullOrEmpty(info.culture))


### PR DESCRIPTION
Fixes #11091 

### Context
Reverting the culture removal in case of new culture is empty - as this is still being used by some of the followup tasks