### PR TITLE
Add a error/recap summary at the end of the build

### DIFF
--- a/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintBuildSummary_FailedWithErrorsAndDetailedSummary.Linux.verified.txt
+++ b/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintBuildSummary_FailedWithErrorsAndDetailedSummary.Linux.verified.txt
@@ -1,0 +1,10 @@
+﻿]9;4;3;\  project [31;1mfailed with 1 error(s)[m (0.2s)
+    directory/[1mfile[m(1,2,3,4): [31;1merror[m [31;1mAA0000[m: Error!
+[?25l[1F
+[?25h
+Build summary:
+  project
+    directory/[1mfile[m(1,2,3,4): [31;1merror[m [31;1mAA0000[m: Error!
+
+Build [31;1mfailed with 1 error(s)[m in 5.0s
+]9;4;0;\

--- a/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintBuildSummary_FailedWithErrorsAndDetailedSummary.OSX.verified.txt
+++ b/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintBuildSummary_FailedWithErrorsAndDetailedSummary.OSX.verified.txt
@@ -1,0 +1,10 @@
+﻿]9;4;3;\  project [31;1mfailed with 1 error(s)[m (0.2s)
+    directory/[1mfile[m(1,2,3,4): [31;1merror[m [31;1mAA0000[m: Error!
+[?25l[1F
+[?25h
+Build summary:
+  project
+    directory/[1mfile[m(1,2,3,4): [31;1merror[m [31;1mAA0000[m: Error!
+
+Build [31;1mfailed with 1 error(s)[m in 5.0s
+]9;4;0;\

--- a/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintBuildSummary_FailedWithErrorsAndDetailedSummary.Windows.verified.txt
+++ b/src/MSBuild.UnitTests/Snapshots/TerminalLogger_Tests.PrintBuildSummary_FailedWithErrorsAndDetailedSummary.Windows.verified.txt
@@ -1,0 +1,10 @@
+﻿]9;4;3;\  project [31;1mfailed with 1 error(s)[m (0.2s)
+    directory/[1mfile[m(1,2,3,4): [31;1merror[m [31;1mAA0000[m: Error!
+[?25l[1F
+[?25h
+Build summary:
+  project
+    directory/[1mfile[m(1,2,3,4): [31;1merror[m [31;1mAA0000[m: Error!
+
+Build [31;1mfailed with 1 error(s)[m in 5.0s
+]9;4;0;\

--- a/src/MSBuild.UnitTests/TerminalLogger_Tests.cs
+++ b/src/MSBuild.UnitTests/TerminalLogger_Tests.cs
@@ -415,6 +415,25 @@ namespace Microsoft.Build.UnitTests
         }
 
         [Fact]
+        public Task PrintBuildSummary_FailedWithErrorsAndDetailedSummary()
+        {
+            string? originalParameters = _terminallogger.Parameters;
+            _terminallogger.Parameters = "SUMMARY";
+            _terminallogger.ParseParameters();
+
+            InvokeLoggerCallbacksForSimpleProject(succeeded: false, () =>
+            {
+                ErrorRaised?.Invoke(_eventSender, MakeErrorEventArgs("Error!"));
+            });
+
+            // Restore original parameters
+            _terminallogger.Parameters = originalParameters;
+            _terminallogger.ParseParameters();
+
+            return Verify(_outputWriter.ToString(), _settings).UniqueForOSPlatform();
+        }
+
+        [Fact]
         public Task PrintBuildSummary_FailedWithErrorsAndWarnings()
         {
             InvokeLoggerCallbacksForSimpleProject(succeeded: false, () =>

--- a/src/MSBuild/Resources/Strings.resx
+++ b/src/MSBuild/Resources/Strings.resx
@@ -1661,6 +1661,12 @@
       's' should reflect the localized abbreviation for seconds
     </comment>
   </data>
+  <data name="BuildSummary" xml:space="preserve">
+    <value>Build summary:</value>
+    <comment>
+      A header used by Terminal Logger to introduce the build summary.
+    </comment>
+  </data>
   <data name="BuildResult_FailedWithErrors" xml:space="preserve">
     <value>failed with {0} error(s)</value>
     <comment>

--- a/src/MSBuild/Resources/xlf/Strings.cs.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.cs.xlf
@@ -67,6 +67,13 @@
       Part of Terminal Logger summary message: "Build {BuildResult_X} in {duration}s"
     </note>
       </trans-unit>
+      <trans-unit id="BuildSummary">
+        <source>Build summary:</source>
+        <target state="new">Build summary:</target>
+        <note>
+      A header used by Terminal Logger to introduce the build summary.
+    </note>
+      </trans-unit>
       <trans-unit id="CommandLine">
         <source>Command line arguments = "{0}"</source>
         <target state="translated">Argumenty příkazového řádku = {0}</target>

--- a/src/MSBuild/Resources/xlf/Strings.de.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.de.xlf
@@ -67,6 +67,13 @@
       Part of Terminal Logger summary message: "Build {BuildResult_X} in {duration}s"
     </note>
       </trans-unit>
+      <trans-unit id="BuildSummary">
+        <source>Build summary:</source>
+        <target state="new">Build summary:</target>
+        <note>
+      A header used by Terminal Logger to introduce the build summary.
+    </note>
+      </trans-unit>
       <trans-unit id="CommandLine">
         <source>Command line arguments = "{0}"</source>
         <target state="translated">Befehlszeilenargumente = "{0}"</target>

--- a/src/MSBuild/Resources/xlf/Strings.es.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.es.xlf
@@ -67,6 +67,13 @@
       Part of Terminal Logger summary message: "Build {BuildResult_X} in {duration}s"
     </note>
       </trans-unit>
+      <trans-unit id="BuildSummary">
+        <source>Build summary:</source>
+        <target state="new">Build summary:</target>
+        <note>
+      A header used by Terminal Logger to introduce the build summary.
+    </note>
+      </trans-unit>
       <trans-unit id="CommandLine">
         <source>Command line arguments = "{0}"</source>
         <target state="translated">Argumentos de la línea de comandos: "{0}"</target>

--- a/src/MSBuild/Resources/xlf/Strings.fr.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.fr.xlf
@@ -67,6 +67,13 @@
       Part of Terminal Logger summary message: "Build {BuildResult_X} in {duration}s"
     </note>
       </trans-unit>
+      <trans-unit id="BuildSummary">
+        <source>Build summary:</source>
+        <target state="new">Build summary:</target>
+        <note>
+      A header used by Terminal Logger to introduce the build summary.
+    </note>
+      </trans-unit>
       <trans-unit id="CommandLine">
         <source>Command line arguments = "{0}"</source>
         <target state="translated">Arguments de ligne de commande = "{0}"</target>

--- a/src/MSBuild/Resources/xlf/Strings.it.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.it.xlf
@@ -67,6 +67,13 @@
       Part of Terminal Logger summary message: "Build {BuildResult_X} in {duration}s"
     </note>
       </trans-unit>
+      <trans-unit id="BuildSummary">
+        <source>Build summary:</source>
+        <target state="new">Build summary:</target>
+        <note>
+      A header used by Terminal Logger to introduce the build summary.
+    </note>
+      </trans-unit>
       <trans-unit id="CommandLine">
         <source>Command line arguments = "{0}"</source>
         <target state="translated">Argomenti della riga di comando = "{0}"</target>

--- a/src/MSBuild/Resources/xlf/Strings.ja.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.ja.xlf
@@ -67,6 +67,13 @@
       Part of Terminal Logger summary message: "Build {BuildResult_X} in {duration}s"
     </note>
       </trans-unit>
+      <trans-unit id="BuildSummary">
+        <source>Build summary:</source>
+        <target state="new">Build summary:</target>
+        <note>
+      A header used by Terminal Logger to introduce the build summary.
+    </note>
+      </trans-unit>
       <trans-unit id="CommandLine">
         <source>Command line arguments = "{0}"</source>
         <target state="translated">コマンド ライン引数 = "{0}"</target>

--- a/src/MSBuild/Resources/xlf/Strings.ko.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.ko.xlf
@@ -67,6 +67,13 @@
       Part of Terminal Logger summary message: "Build {BuildResult_X} in {duration}s"
     </note>
       </trans-unit>
+      <trans-unit id="BuildSummary">
+        <source>Build summary:</source>
+        <target state="new">Build summary:</target>
+        <note>
+      A header used by Terminal Logger to introduce the build summary.
+    </note>
+      </trans-unit>
       <trans-unit id="CommandLine">
         <source>Command line arguments = "{0}"</source>
         <target state="translated">명령줄 인수 = "{0}"</target>

--- a/src/MSBuild/Resources/xlf/Strings.pl.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.pl.xlf
@@ -67,6 +67,13 @@
       Part of Terminal Logger summary message: "Build {BuildResult_X} in {duration}s"
     </note>
       </trans-unit>
+      <trans-unit id="BuildSummary">
+        <source>Build summary:</source>
+        <target state="new">Build summary:</target>
+        <note>
+      A header used by Terminal Logger to introduce the build summary.
+    </note>
+      </trans-unit>
       <trans-unit id="CommandLine">
         <source>Command line arguments = "{0}"</source>
         <target state="translated">Argumenty wiersza polecenia = „{0}”</target>

--- a/src/MSBuild/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.pt-BR.xlf
@@ -67,6 +67,13 @@
       Part of Terminal Logger summary message: "Build {BuildResult_X} in {duration}s"
     </note>
       </trans-unit>
+      <trans-unit id="BuildSummary">
+        <source>Build summary:</source>
+        <target state="new">Build summary:</target>
+        <note>
+      A header used by Terminal Logger to introduce the build summary.
+    </note>
+      </trans-unit>
       <trans-unit id="CommandLine">
         <source>Command line arguments = "{0}"</source>
         <target state="translated">Argumentos de linha de comando = "{0}"</target>

--- a/src/MSBuild/Resources/xlf/Strings.ru.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.ru.xlf
@@ -67,6 +67,13 @@
       Part of Terminal Logger summary message: "Build {BuildResult_X} in {duration}s"
     </note>
       </trans-unit>
+      <trans-unit id="BuildSummary">
+        <source>Build summary:</source>
+        <target state="new">Build summary:</target>
+        <note>
+      A header used by Terminal Logger to introduce the build summary.
+    </note>
+      </trans-unit>
       <trans-unit id="CommandLine">
         <source>Command line arguments = "{0}"</source>
         <target state="translated">Аргументы командной строки = "{0}"</target>

--- a/src/MSBuild/Resources/xlf/Strings.tr.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.tr.xlf
@@ -67,6 +67,13 @@
       Part of Terminal Logger summary message: "Build {BuildResult_X} in {duration}s"
     </note>
       </trans-unit>
+      <trans-unit id="BuildSummary">
+        <source>Build summary:</source>
+        <target state="new">Build summary:</target>
+        <note>
+      A header used by Terminal Logger to introduce the build summary.
+    </note>
+      </trans-unit>
       <trans-unit id="CommandLine">
         <source>Command line arguments = "{0}"</source>
         <target state="translated">Komut satırı bağımsız değişkenleri = "{0}"</target>

--- a/src/MSBuild/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.zh-Hans.xlf
@@ -67,6 +67,13 @@
       Part of Terminal Logger summary message: "Build {BuildResult_X} in {duration}s"
     </note>
       </trans-unit>
+      <trans-unit id="BuildSummary">
+        <source>Build summary:</source>
+        <target state="new">Build summary:</target>
+        <note>
+      A header used by Terminal Logger to introduce the build summary.
+    </note>
+      </trans-unit>
       <trans-unit id="CommandLine">
         <source>Command line arguments = "{0}"</source>
         <target state="translated">命令行参数 = "{0}"</target>

--- a/src/MSBuild/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.zh-Hant.xlf
@@ -67,6 +67,13 @@
       Part of Terminal Logger summary message: "Build {BuildResult_X} in {duration}s"
     </note>
       </trans-unit>
+      <trans-unit id="BuildSummary">
+        <source>Build summary:</source>
+        <target state="new">Build summary:</target>
+        <note>
+      A header used by Terminal Logger to introduce the build summary.
+    </note>
+      </trans-unit>
       <trans-unit id="CommandLine">
         <source>Command line arguments = "{0}"</source>
         <target state="translated">命令列引數 = "{0}"</target>

--- a/src/MSBuild/TerminalLogger/Project.cs
+++ b/src/MSBuild/TerminalLogger/Project.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 
 namespace Microsoft.Build.Logging.TerminalLogger;
 
@@ -16,8 +17,9 @@ internal sealed class Project
     /// Initialized a new <see cref="Project"/> with the given <paramref name="targetFramework"/>.
     /// </summary>
     /// <param name="targetFramework">The target framework of the project or null if not multi-targeting.</param>
-    public Project(string? targetFramework, StopwatchAbstraction? stopwatch)
+    public Project(string projectFile, string? targetFramework, StopwatchAbstraction? stopwatch)
     {
+        File = projectFile;
         TargetFramework = targetFramework;
 
         if (stopwatch is not null)
@@ -30,6 +32,8 @@ internal sealed class Project
             Stopwatch = SystemStopwatch.StartNew();
         }
     }
+
+    public string File { get; }
 
     /// <summary>
     /// A stopwatch to time the build of the project.
@@ -68,5 +72,16 @@ internal sealed class Project
     {
         BuildMessages ??= new List<BuildMessage>();
         BuildMessages.Add(new BuildMessage(severity, message));
+    }
+
+    /// <summary>
+    /// Filters the build messages to only include errors.
+    /// </summary>
+    /// <returns>A sequence of error build messages.</returns>
+    public IEnumerable<BuildMessage> GetBuildErrorMessages()
+    {
+        return BuildMessages is null ?
+            Enumerable.Empty<BuildMessage>() :
+            BuildMessages.Where(message => message.Severity == MessageSeverity.Error);
     }
 }

--- a/src/MSBuild/TerminalLogger/TerminalLogger.cs
+++ b/src/MSBuild/TerminalLogger/TerminalLogger.cs
@@ -224,7 +224,7 @@ internal sealed partial class TerminalLogger : INodeLogger
     /// <summary>
     /// Indicates whether to show the build summary.
     /// </summary>
-    private bool? showSummary;
+    private bool? _showSummary;
 
     private uint? _originalConsoleMode;
 
@@ -326,10 +326,10 @@ internal sealed partial class TerminalLogger : INodeLogger
                 TryApplyShowCommandLineParameter(parameterValue);
                 break;
             case "SUMMARY":
-                showSummary = true;
+                _showSummary = true;
                 break;
             case "NOSUMMARY":
-                showSummary = false;
+                _showSummary = false;
                 break;
         }
     }
@@ -444,7 +444,7 @@ internal sealed partial class TerminalLogger : INodeLogger
                     Terminal.WriteLine(string.Join(CultureInfo.CurrentCulture.TextInfo.ListSeparator + " ", summaryAndTotalText, failedText, passedText, skippedText, durationText));
                 }
 
-                if (showSummary == true)
+                if (_showSummary == true)
                 {
                     RenderBuildSummary();
                 }


### PR DESCRIPTION
Partially fixes #10681

### Context
In a very large build, errors may have scrolled well offscreen before the end of the build, leaving a terminal window with a sea of green "project succeeded" messages followed by an unhelpful "build failed with 8 errors".

### Changes Made
TL can now display a summary of all errors in a structured way when the build finishes. For now, the only way to enable it is to use the logger parameter `-tlp:Summary`. A heuristic method to determine when to automatically provide the summary will likely be added in a different PR.

### Testing
Manual testing + new automated test.
![image](https://github.com/user-attachments/assets/21a0d28c-49e5-40f0-be3a-352d6224e891)
