### PR TITLE
Improve support for loading MSBuild in a non-default ALC.

### DIFF
--- a/src/Shared/CoreCLRAssemblyLoader.cs
+++ b/src/Shared/CoreCLRAssemblyLoader.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Build.Shared
             {
                 if (!_resolvingHandlerHookedUp)
                 {
-                    AssemblyLoadContext.Default.Resolving += TryResolveAssembly;
+                    MSBuildLoadContext.ThisAssemblyLoadContext.Resolving += TryResolveAssembly;
                     _resolvingHandlerHookedUp = true;
                 }
 
@@ -81,7 +81,7 @@ namespace Microsoft.Build.Shared
                     return assembly;
                 }
 
-                return LoadAndCache(AssemblyLoadContext.Default, fullPath);
+                return LoadAndCache(MSBuildLoadContext.ThisAssemblyLoadContext, fullPath);
             }
         }
 

--- a/src/Shared/MSBuildLoadContext.cs
+++ b/src/Shared/MSBuildLoadContext.cs
@@ -30,6 +30,11 @@ namespace Microsoft.Build.Shared
             "Microsoft.Build.Utilities.Core",
         ];
 
+        /// <summary>
+        /// The <see cref="AssemblyLoadContext"/> in which the MSBuild assemblies are loaded.
+        /// </summary>
+        internal static AssemblyLoadContext ThisAssemblyLoadContext => GetLoadContext(typeof(MSBuildLoadContext).Assembly)!;
+
         public MSBuildLoadContext(string assemblyPath)
             : base($"MSBuild plugin {assemblyPath}")
         {
@@ -50,12 +55,12 @@ namespace Microsoft.Build.Shared
         {
             if (WellKnownAssemblyNames.Contains(assemblyName.Name!))
             {
-                // Force MSBuild assemblies to be loaded in the default ALC
+                // Force MSBuild assemblies to be loaded in the same ALC
                 // and unify to the current version.
-                return null;
+                return ThisAssemblyLoadContext.LoadFromAssemblyName(assemblyName);
             }
 
-            // respect plugin.dll.json with the AssemblyDependencyResolver
+            // respect plugin.deps.json with the AssemblyDependencyResolver
             string? assemblyPath = _resolver?.ResolveAssemblyToPath(assemblyName);
             if (assemblyPath != null)
             {
@@ -83,7 +88,7 @@ namespace Microsoft.Build.Shared
                     continue;
                 }
 
-                AssemblyName candidateAssemblyName = AssemblyLoadContext.GetAssemblyName(candidatePath);
+                AssemblyName candidateAssemblyName = GetAssemblyName(candidatePath);
                 if (candidateAssemblyName.Version != assemblyName.Version)
                 {
                     continue;
@@ -95,13 +100,13 @@ namespace Microsoft.Build.Shared
             // If the Assembly is provided via a file path, the following rules are used to load the assembly:
             // - the assembly from the user specified path is loaded, if it exists, into the custom ALC, or
             // - if the simple name of the assembly exists in the same folder as msbuild.exe, then that assembly gets loaded
-            //   into the default ALC (so it's shared with other uses).
+            //   into MSBuild's ALC (so it's shared with other uses).
             var assemblyNameInExecutableDirectory = Path.Combine(BuildEnvironmentHelper.Instance.CurrentMSBuildToolsDirectory,
                 $"{assemblyName.Name}.dll");
 
             if (FileSystems.Default.FileExists(assemblyNameInExecutableDirectory))
             {
-                return AssemblyLoadContext.Default.LoadFromAssemblyPath(assemblyNameInExecutableDirectory);
+                return ThisAssemblyLoadContext.LoadFromAssemblyPath(assemblyNameInExecutableDirectory);
             }
 
             return null;

--- a/src/Shared/MSBuildLoadContext.cs
+++ b/src/Shared/MSBuildLoadContext.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Build.Shared
         internal static AssemblyLoadContext ThisAssemblyLoadContext => GetLoadContext(typeof(MSBuildLoadContext).Assembly)!;
 
         public MSBuildLoadContext(string assemblyPath)
-            : base($"MSBuild plugin {assemblyPath}")
+            : base($"MSBuild plugin {assemblyPath}", ThisAssemblyLoadContext.IsCollectible)
         {
             _directory = Directory.GetParent(assemblyPath)!.FullName;
 

--- a/src/Shared/TaskEngineAssemblyResolver.cs
+++ b/src/Shared/TaskEngineAssemblyResolver.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Build.BackEnd.Logging
 #else
             _eventHandler = new Func<AssemblyLoadContext, AssemblyName, Assembly>(ResolveAssembly);
 
-            AssemblyLoadContext.Default.Resolving += _eventHandler;
+            AssemblyLoadContext.GetLoadContext(typeof(TaskEngineAssemblyResolver).Assembly).Resolving += _eventHandler;
 #endif
         }
 
@@ -75,7 +75,7 @@ namespace Microsoft.Build.BackEnd.Logging
 #if FEATURE_APPDOMAIN
                 AppDomain.CurrentDomain.AssemblyResolve -= _eventHandler;
 #else
-                AssemblyLoadContext.Default.Resolving -= _eventHandler;
+                AssemblyLoadContext.GetLoadContext(typeof(TaskEngineAssemblyResolver).Assembly).Resolving -= _eventHandler;
 #endif
                 _eventHandler = null;
             }
@@ -125,7 +125,7 @@ namespace Microsoft.Build.BackEnd.Logging
                         AssemblyNameExtension argAssemblyName = new AssemblyNameExtension(assemblyName);
                         if (taskAssemblyName.Equals(argAssemblyName))
                         {
-                            return AssemblyLoadContext.Default.LoadFromAssemblyPath(_taskAssemblyFile);
+                            return assemblyLoadContext.LoadFromAssemblyPath(_taskAssemblyFile);
                         }
 #endif
                     }


### PR DESCRIPTION
Fixes #6794.

* Instead of `AssemblyLoadContext.Default` we use the ALC that hosts MSBuild's own assemblies.
* `MSBuildLoadContext` is created as unloadable if the ALC that hosts MSBuild's own assemblies is unloadable.
  * We don't do that always to avoid impacting performance and compatibility when not necessary, and plugin load contexts cannot be unloaded individually without more changes either way.

In most cases, including when running the MSBuild CLI, MSBuild is already loaded in the default ALC so this PR wouldn't change any behavior.