### PR TITLE
[17.8] Unblock opt-prof in release branches

### DIFF
--- a/.opt-prof.yml
+++ b/.opt-prof.yml
@@ -55,7 +55,7 @@ stages:
     optOptimizationInputsDropName: $(OptimizationInputsDropName)
     testLabPoolName: VS-Platform # The test lab pool to run your tests in
     testMachineCleanUpStrategy: ${{parameters.testMachineCleanUpStrategy}}
-    testMachineImageName: Windows-10-Enterprise-20H2
+    testMachineImageName: Windows-11-Enterprise-23H2
     visualStudioSigning: Test
     variables:
     - name: branchName # The branch in the VS repo the bootstrapper was based on


### PR DESCRIPTION

### Context
OptProf pipeline is blocked since older os images have been removed from the test lab.
