### PR TITLE
Bump VS and xcopy-msbuild version to 17.12.0

### DIFF
--- a/global.json
+++ b/global.json
@@ -5,7 +5,7 @@
   "tools": {
     "dotnet": "9.0.100",
     "vs": {
-      "version": "17.10.0"
+      "version": "17.12.0"
     },
     "xcopy-msbuild": "17.10.0-pre.4.0"
   },

--- a/global.json
+++ b/global.json
@@ -7,7 +7,7 @@
     "vs": {
       "version": "17.12.0"
     },
-    "xcopy-msbuild": "17.10.0-pre.4.0"
+    "xcopy-msbuild": "17.12.0"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "9.0.0-beta.24572.2"


### PR DESCRIPTION
Fixes #

### Context
After updating dotnet to 9.0.100, internal run has the following issues:
1. Targeting .NET 9.0 or higher in Visual Studio 2022 17.11 is not supported. See https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=10668003&view=logs&j=bb592630-4b9d-53ad-3960-d954a70a95cf&t=94418e61-6648-5751-f7d4-a14f4e5e2bb7.
```
D:\a\_work\1\s\.dotnet\sdk\9.0.100\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.Sdk.DefaultItems.targets(135,5): error NETSDK1223: Targeting .NET 9.0 or higher in Visual Studio 2022 17.11 is not supported. [D:\a\_work\1\s\src\Build.UnitTests\Microsoft.Build.Engine.UnitTests.csproj::TargetFramework=net9.0]
```
2. Version 9.0.100 of the .NET SDK requires at least version 17.11.0 of MSBuild. The current available version of MSBuild is 17.10.2.21103. Change the .NET SDK specified in global.json to an older version that requires the MSBuild version currently available. See https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=10677564&view=logs&j=bb592630-4b9d-53ad-3960-d954a70a95cf&t=94418e61-6648-5751-f7d4-a14f4e5e2bb7.
```
MSB4276: The default SDK resolver failed to resolve SDK "Microsoft.NET.Sdk" because directory "D:\a\_work\1\s\.tools\msbuild\17.10.0-pre.4.0\tools\MSBuild\Sdks\Microsoft.NET.Sdk\Sdk" did not exist.
##[error]eng\common\internal\Tools.csproj(0,0): error : Could not resolve SDK "Microsoft.NET.Sdk". Exactly one of the probing messages below indicates why we could not resolve the SDK. Investigate and resolve that message to correctly specify the SDK.
  Version 9.0.100 of the .NET SDK requires at least version 17.11.0 of MSBuild. The current available version of MSBuild is 17.10.2.21103. Change the .NET SDK specified in global.json to an older version that requires the MSBuild version currently available.
  The NuGetSdkResolver did not resolve this SDK because there was no version specified in the project or global.json.
```

### Changes Made
Update VS version to 17.12.0.
Update xcopy-msbuild version to 17.12.0

### Testing
Verified with this experimental branch.
 
### Notes
