### PR TITLE
Update vs/msbuild version

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,7 +2,7 @@
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the MIT license. See License.txt in the project root for full license information. -->
 <Project>
   <PropertyGroup>
-    <VersionPrefix>17.8.14</VersionPrefix>
+    <VersionPrefix>17.8.15</VersionPrefix>
     <DotNetFinalVersionKind>release</DotNetFinalVersionKind>
     <PackageValidationBaselineVersion>17.7.0</PackageValidationBaselineVersion>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>

--- a/global.json
+++ b/global.json
@@ -5,9 +5,9 @@
   "tools": {
     "dotnet": "8.0.110",
     "vs": {
-      "version": "17.6.0"
+      "version": "17.8.0"
     },
-    "xcopy-msbuild": "17.6.0-2"
+    "xcopy-msbuild": "17.8.0"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "8.0.0-beta.24570.5"


### PR DESCRIPTION
Fixes - failing internal build

### Context

Bumping vs/msbuild version in global.json to 17.8

```
D:\a\_work\1\s\.packages\microsoft.dotnet.arcade.sdk\8.0.0-beta.24570.5\tools\SdkTasks\SigningValidation.proj : error : Could not resolve SDK "Microsoft.NET.Sdk". Exactly one of the probing messages below indicates why we could not resolve the SDK. Investigate and resolve that message to correctly specify the SDK.
D:\a\_work\1\s\.packages\microsoft.dotnet.arcade.sdk\8.0.0-beta.24570.5\tools\SdkTasks\SigningValidation.proj : error :   Version 8.0.110 of the .NET SDK requires at least version 17.7.0 of MSBuild. The current available version of MSBuild is 17.6.3.22601. Change the .NET SDK specified in global.json to an older version that requires the MSBuild version currently available.
D:\a\_work\1\s\.packages\microsoft.dotnet.arcade.sdk\8.0.0-beta.24570.5\tools\SdkTasks\SigningValidation.proj : error :   The NuGetSdkResolver did not resolve this SDK because there was no version specified in the project or global.json.
D:\a\_work\1\s\.packages\microsoft.dotnet.arcade.sdk\8.0.0-beta.24570.5\tools\SdkTasks\SigningValidation.proj : error :   MSB4276: The default SDK resolver failed to resolve SDK "Microsoft.NET.Sdk" because directory "D:\a\_work\1\s\.tools\msbuild\17.6.0-2\tools\MSBuild\Sdks\Microsoft.NET.Sdk\Sdk" did not exist.
##[error].packages\microsoft.dotnet.arcade.sdk\8.0.0-beta.24570.5\tools\SdkTasks\SigningValidation.proj(0,0): error : Could not resolve SDK "Microsoft.NET.Sdk". Exactly one of the probing messages below indicates why we could not resolve the SDK. Investigate and resolve that message to correctly specify the SDK.
  Version 8.0.110 of the .NET SDK requires at least version 17.7.0 of MSBuild. The current available version of MSBuild is 17.6.3.22601. Change the .NET SDK specified in global.json to an older version that requires the MSBuild version currently available.
  The NuGetSdkResolver did not resolve this SDK because there was no version specified in the project or global.json.
  MSB4276: The default SDK resolver failed to resolve SDK "Microsoft.NET.Sdk" because directory "D:\a\_work\1\s\.tools\msbuild\17.6.0-2\tools\MSBuild\Sdks\Microsoft.NET.Sdk\Sdk" did not exist.
D:\a\_work\1\s\.packages\microsoft.dotnet.arcade.sdk\8.0.0-beta.24570.5\tools\SdkTasks\SigningValidation.proj : error MSB4236: The SDK 'Microsoft.NET.Sdk' specified could not be found.
##[error].packages\microsoft.dotnet.arcade.sdk\8.0.0-beta.24570.5\tools\SdkTasks\SigningValidation.proj(0,0): error MSB4236: The SDK 'Microsoft.NET.Sdk' specified could not be found.

```

https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=10679222&view=logs&j=b11b921d-8982-5bb3-754b-b114d42fd804&t=fb192a8b-e433-5fc8-e2b0-276ab015e7d5&l=36
