### PR TITLE
Update xcopy-msbuild version to 17.8.5

### DIFF
--- a/global.json
+++ b/global.json
@@ -7,7 +7,7 @@
     "vs": {
       "version": "17.8.0"
     },
-    "xcopy-msbuild": "17.8.0"
+    "xcopy-msbuild": "17.8.5"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "8.0.0-beta.24570.5"


### PR DESCRIPTION
Fixes #internal build failure

### Context
Internal build could not find the file RoslynTools.MSBuild.17.8.0.nupkg in package 'RoslynTools.MSBuild 17.8.0'.
https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=10681391&view=logs&j=b11b921d-8982-5bb3-754b-b114d42fd804&t=fb192a8b-e433-5fc8-e2b0-276ab015e7d5&l=14
```
Downloading RoslynTools.MSBuild 17.8.0
##[error](NETCORE_ENGINEERING_TELEMETRY=InitializeToolset) {"$id":"1","innerException":null,"message":"Cannot find the file RoslynTools.MSBuild.17.8.0.nupkg in package 'RoslynTools.MSBuild 17.8.0' in feed 'dotnet-eng'","typeName":"Microsoft.VisualStudio.Services.Packaging.Shared.WebApi.Exceptions.PackageNotFoundException, Microsoft.VisualStudio.Services.Packaging.Shared.WebApi","typeKey":"PackageNotFoundException","errorCode":0,"eventId":3000}
```

### Changes Made
Update xcopy-msbuild to 17.8.5 which exists in dotnet-eng feed.

### Testing
Verified with this experimental branch https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=10683706&view=results.

### Notes
