### PR TITLE
Option to avoid "fixing" \ in new TaskItem() 

### DIFF
--- a/src/Utilities/TaskItem.cs
+++ b/src/Utilities/TaskItem.cs
@@ -86,12 +86,12 @@ namespace Microsoft.Build.Utilities
         /// <comments>
         /// Assumes the itemspec passed in is escaped.
         /// If <see name="treatAsFilePath" /> is set to <see langword="true" />, the value in <see name="itemSpec" />
-        /// will be fixed up as path by having backslashes replaced with slashes.
+        /// will be fixed up as a path by having any backslashes replaced with slashes.
         /// </comments>
         /// <param name="itemSpec">The item-spec string.</param>
         /// <param name="treatAsFilePath">
         /// Specifies whether or not to treat the value in <see name="itemSpec" />
-        /// as a file path and attempt to normalize it.  Defaults to <see langword="true" />.
+        /// as a file path and attempt to normalize it.
         /// </param>
         public TaskItem(
             string itemSpec,

--- a/src/Utilities/TaskItem.cs
+++ b/src/Utilities/TaskItem.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Build.Utilities
         /// <summary>
         /// This constructor creates a new task item, given the item spec.
         /// </summary>
-        /// <comments>Assumes the itemspec passed in is escaped.</comments>
+        /// <comments>Assumes the itemspec passed in is escaped and represents a file path. </comments>
         /// <param name="itemSpec">The item-spec string.</param>
         public TaskItem(string itemSpec)
             : this(itemSpec, treatAsFilePath: true) { }

--- a/src/Utilities/TaskItem.cs
+++ b/src/Utilities/TaskItem.cs
@@ -94,7 +94,7 @@ namespace Microsoft.Build.Utilities
         /// </param>
         public TaskItem(
             string itemSpec,
-            bool treatAsFilePath = true)
+            bool treatAsFilePath)
         {
             ErrorUtilities.VerifyThrowArgumentNull(itemSpec);
 

--- a/src/Utilities/TaskItem.cs
+++ b/src/Utilities/TaskItem.cs
@@ -75,6 +75,13 @@ namespace Microsoft.Build.Utilities
         /// <summary>
         /// This constructor creates a new task item, given the item spec.
         /// </summary>
+        /// <comments>Assumes the itemspec passed in is escaped.</comments>
+        /// <param name="itemSpec">The item-spec string.</param>
+        public TaskItem(string itemSpec) => new TaskItem(itemSpec, treatAsFilePath: true);
+
+        /// <summary>
+        /// This constructor creates a new task item, given the item spec.
+        /// </summary>
         /// <comments>
         /// Assumes the itemspec passed in is escaped.
         /// If <see name="treatAsFilePath" /> is set to <see langword="true" />, the value in <see name="itemSpec" />

--- a/src/Utilities/TaskItem.cs
+++ b/src/Utilities/TaskItem.cs
@@ -77,7 +77,8 @@ namespace Microsoft.Build.Utilities
         /// </summary>
         /// <comments>Assumes the itemspec passed in is escaped.</comments>
         /// <param name="itemSpec">The item-spec string.</param>
-        public TaskItem(string itemSpec) => new TaskItem(itemSpec, treatAsFilePath: true);
+        public TaskItem(string itemSpec)
+            : this(itemSpec, treatAsFilePath: true) { }
 
         /// <summary>
         /// This constructor creates a new task item, given the item spec.

--- a/src/Utilities/TaskItem.cs
+++ b/src/Utilities/TaskItem.cs
@@ -77,21 +77,21 @@ namespace Microsoft.Build.Utilities
         /// </summary>
         /// <comments>
         /// Assumes the itemspec passed in is escaped.
-        /// If tratAsFilePath is set to true, it will try to fix itemSpac backslashes into slashes.
+        /// If <see name="treatAsFilePath" /> is set to <see langword="true" />, the value in <see name="itemSpec" />
+        /// will be fixed up as path by having backslashes replaced with slashes.
         /// </comments>
         /// <param name="itemSpec">The item-spec string.</param>
-        /// <param name="treatAsFilePath">If item-spec string is a path or not.</param>
+        /// <param name="treatAsFilePath">
+        /// Specifies whether or not to treat the value in <see name="itemSpec" />
+        /// as a file path and attempt to normalize it.  Defaults to <see langword="true" />.
+        /// </param>
         public TaskItem(
             string itemSpec,
             bool treatAsFilePath = true)
         {
             ErrorUtilities.VerifyThrowArgumentNull(itemSpec);
 
-            if (treatAsFilePath)
-            {
-
-                _itemSpec = FileUtilities.FixFilePath(itemSpec);
-            }
+            _itemSpec = treatAsFilePath ? FileUtilities.FixFilePath(itemSpec) : itemSpec;
         }
 
         /// <summary>

--- a/src/Utilities/TaskItem.cs
+++ b/src/Utilities/TaskItem.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Build.Utilities
         /// Default constructor -- do not use.
         /// </summary>
         /// <remarks>
-        /// This constructor exists only so that the type is COM-creatable. Prefer <see cref="TaskItem(string)"/>.
+        /// This constructor exists only so that the type is COM-creatable. Prefer <see cref="TaskItem(string, bool)"/>.
         /// </remarks>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public TaskItem()
@@ -75,14 +75,23 @@ namespace Microsoft.Build.Utilities
         /// <summary>
         /// This constructor creates a new task item, given the item spec.
         /// </summary>
-        /// <comments>Assumes the itemspec passed in is escaped.</comments>
+        /// <comments>
+        /// Assumes the itemspec passed in is escaped.
+        /// If tratAsFilePath is set to true, it will try to fix itemSpac backslashes into slashes.
+        /// </comments>
         /// <param name="itemSpec">The item-spec string.</param>
+        /// <param name="treatAsFilePath">If item-spec string is a path or not.</param>
         public TaskItem(
-            string itemSpec)
+            string itemSpec,
+            bool treatAsFilePath = true)
         {
             ErrorUtilities.VerifyThrowArgumentNull(itemSpec);
 
-            _itemSpec = FileUtilities.FixFilePath(itemSpec);
+            if (treatAsFilePath)
+            {
+
+                _itemSpec = FileUtilities.FixFilePath(itemSpec);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes https://github.com/dotnet/msbuild/issues/11083

### Context
Sometimes `TaskItems` are not file paths, and we currently treat all of them as file paths and try to fix backslashes into slashes. 

### Changes Made
Added an option where `TaskItems` can be created without a reference to a path, and it will not try to fix it.
