### PR TITLE
Add inter-branch merge flow file

### DIFF
--- a/.github/workflows/inter-branch-merge-flow.yml
+++ b/.github/workflows/inter-branch-merge-flow.yml
@@ -1,0 +1,15 @@
+name: Inter-branch merge workflow
+on:
+  push:
+    branches:
+      - vs1**
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  Merge:
+    uses: dotnet/arcade/.github/workflows/inter-branch-merge-base.yml@main
+    with:
+      configuration_file_path: '.config/git-merge-flow-config.jsonc'


### PR DESCRIPTION
Fixes # auto merge flow doesn't  run for vs17.8

### Context
According to https://github.com/dotnet/arcade/blob/main/Documentation/Maestro/New-Inter-Branch-Merge-Approach.md#onboarding, the workflow file accordingly should be created in branches where the inter-merge should be available.

### Changes Made
Add inter-branch merge flow file

### Testing
N/A

### Notes
