### PR TITLE
Expose processes leveraged by BuildManager

### DIFF
--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -820,6 +820,13 @@ namespace Microsoft.Build.Execution
         }
 
         /// <summary>
+        /// Point in time snapshot of all worker processes leveraged by this BuildManager.
+        /// </summary>
+        /// <returns>Enumeration of <see cref="Process"/> objects that were valid during the time of call to this function.</returns>
+        public IEnumerable<Process> GetWorkerProcesses()
+            => (_nodeManager?.GetProcesses() ?? []).Concat(_taskHostNodeManager?.GetProcesses() ?? []);
+
+        /// <summary>
         /// Clears out all of the cached information.
         /// </summary>
         public void ResetCaches()

--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -821,6 +821,8 @@ namespace Microsoft.Build.Execution
 
         /// <summary>
         /// Point in time snapshot of all worker processes leveraged by this BuildManager.
+        /// This is meant to be used by VS. External users should not this is only best-effort, point-in-time functionality
+        ///  without guarantee of 100% correctness and safety.
         /// </summary>
         /// <returns>Enumeration of <see cref="Process"/> objects that were valid during the time of call to this function.</returns>
         public IEnumerable<Process> GetWorkerProcesses()


### PR DESCRIPTION
Fixes #11051

### Context
For various hangs detection we need worker processes dumps. Let's unblock VS perf team in enabling automatic collection of worker processes dumps.

### Testing
No tests provided.
This is best effort, point in time functionality, that should be used so


FYI @davkean 
