### PR TITLE
[vs17.8] disallow inserting pkgs twice in VS insertion

### DIFF
--- a/azure-pipelines/vs-insertion.yml
+++ b/azure-pipelines/vs-insertion.yml
@@ -2,9 +2,9 @@
 # To achieve insertion automation, this pipeline definition yml has to be on servicing branches and main.
 
 
-# Runs in 3 modes: 
+# Runs in 3 modes:
 # 1. daily main insertion from latest main CI.
-#   - can be disabled in the UI by adding a custom schedule for any branch. 
+#   - can be disabled in the UI by adding a custom schedule for any branch.
 # 2. trigger insert as a followup to a servicing CI run.
 #   - can be disabled in the UI by adding a custom CI trigger.
 # 3. manual insertion - select manually the TargetBranch and inserted CI run.
@@ -56,6 +56,10 @@ parameters:
     default: 183
     type: number
     displayName: 'Drop Retention Days (do not set to < 90)'
+  - name: SkipUploadingPackages
+    default: false
+    type: boolean
+    displayName: 'Skip uploading packages (set to true if inserting the same version multiple times)'
 
 variables:
   # `auto` should work every time and selecting a branch in parameters is likely to fail due to incompatible versions in MSBuild and VS
@@ -95,8 +99,8 @@ variables:
     value: $(resources.pipeline.MSBuild.sourceCommit)
   - name: ArtifactPackagesPath
     value: $(Build.ArtifactStagingDirectory)/PackageArtifacts
-  
-  - name: MSBuildPackagePattern 
+
+  - name: MSBuildPackagePattern
     value: '$(ArtifactPackagesPath)/Microsoft.Build.*.nupkg'
   - name: StringToolsPackagePattern
     value: '$(ArtifactPackagesPath)/Microsoft.NET.StringTools*.nupkg'
@@ -200,7 +204,7 @@ extends:
               $MicrosoftNETStringToolsPackageVersion = $packageFile.BaseName.TrimStart("Microsoft.NET.StringTools")
               Write-Host "Setting MicrosoftNETStringToolsPackageVersion to '$MicrosoftNETStringToolsPackageVersion'"
               Write-Host "##vso[task.setvariable variable=MicrosoftNETStringToolsPackageVersion]$($MicrosoftNETStringToolsPackageVersion)"
-              
+
               $props = @(
                       "VS.ExternalAPIs.MSBuild=$MSBuild_ExtApisPackageVersion",
                       "Microsoft.Build=$MicrosoftNETStringToolsPackageVersion",
@@ -223,24 +227,26 @@ extends:
               Write-Host "##vso[task.setvariable variable=InsertPackagePropsValues]$($propsValue)"
         - task: 1ES.PublishNuGet@1
           displayName: 'Push MSBuild CoreXT packages'
+          condition: ${{ eq(parameters.SkipUploadingPackages, false) }}
           inputs:
             packageParentPath: '$(Build.ArtifactStagingDirectory)'
             packagesToPush: $(MSBuildPackagePattern);$(StringToolsPackagePattern);$(ExternalAPIsPackagePattern)
             nuGetFeedType: internal
             publishVstsFeed: VS
-            allowPackageConflicts: true
+            allowPackageConflicts: false
         - template: /azure-pipelines/WIFtoPATauth.yml@self
           parameters:
             wifServiceConnectionName: azure-public/vside package push
             deadPATServiceConnectionId: 42175e93-c771-4a4f-a132-3cca78f44b3b
         - task: 1ES.PublishNuGet@1
+          condition: ${{ eq(parameters.SkipUploadingPackages, false) }}
           displayName: 'Push MSBuild packages to VSSDK'
           inputs:
             packageParentPath: '$(Build.ArtifactStagingDirectory)'
             packagesToPush: $(MSBuildPackagePattern);$(StringToolsPackagePattern)
             nuGetFeedType: external
             publishFeedCredentials: azure-public/vssdk
-            allowPackageConflicts: true
+            allowPackageConflicts: false
         - task: PowerShell@2
           name: PrintTargetBranch
           inputs:


### PR DESCRIPTION
Fixes #11136
will propagate via mergeflow

### Context
This prevents wrong behavior of the VS insertion with an override for edge cases.

### Changes Made
Fail on package conflicts when pushing them to feeds and add an override parameter which skips the pushing stage 

### Testing
https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_build/results?buildId=10716305&view=results

### Notes
