### PR TITLE
RAR-as-a-service draft

### DIFF
--- a/MSBuild.sln
+++ b/MSBuild.sln
@@ -84,6 +84,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Build.BuildCheck.
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Build.Templates", "template_feed\Microsoft.Build.Templates.csproj", "{A86EE74A-AEF0-42ED-A5A7-7A54BC0773D8}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{4D013D5D-E085-4F4F-B36B-9484F7E51657}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RarTest", "src\RarTest\RarTest.csproj", "{20D438A5-B93B-4972-BFAD-373954BD6117}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -916,6 +920,30 @@ Global
 		{A86EE74A-AEF0-42ED-A5A7-7A54BC0773D8}.Release|x64.Build.0 = Release|Any CPU
 		{A86EE74A-AEF0-42ED-A5A7-7A54BC0773D8}.Release|x86.ActiveCfg = Release|Any CPU
 		{A86EE74A-AEF0-42ED-A5A7-7A54BC0773D8}.Release|x86.Build.0 = Release|Any CPU
+		{20D438A5-B93B-4972-BFAD-373954BD6117}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{20D438A5-B93B-4972-BFAD-373954BD6117}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{20D438A5-B93B-4972-BFAD-373954BD6117}.Debug|ARM64.ActiveCfg = Debug|arm64
+		{20D438A5-B93B-4972-BFAD-373954BD6117}.Debug|ARM64.Build.0 = Debug|arm64
+		{20D438A5-B93B-4972-BFAD-373954BD6117}.Debug|x64.ActiveCfg = Debug|x64
+		{20D438A5-B93B-4972-BFAD-373954BD6117}.Debug|x64.Build.0 = Debug|x64
+		{20D438A5-B93B-4972-BFAD-373954BD6117}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{20D438A5-B93B-4972-BFAD-373954BD6117}.Debug|x86.Build.0 = Debug|Any CPU
+		{20D438A5-B93B-4972-BFAD-373954BD6117}.MachineIndependent|Any CPU.ActiveCfg = MachineIndependent|Any CPU
+		{20D438A5-B93B-4972-BFAD-373954BD6117}.MachineIndependent|Any CPU.Build.0 = MachineIndependent|Any CPU
+		{20D438A5-B93B-4972-BFAD-373954BD6117}.MachineIndependent|ARM64.ActiveCfg = MachineIndependent|arm64
+		{20D438A5-B93B-4972-BFAD-373954BD6117}.MachineIndependent|ARM64.Build.0 = MachineIndependent|arm64
+		{20D438A5-B93B-4972-BFAD-373954BD6117}.MachineIndependent|x64.ActiveCfg = MachineIndependent|x64
+		{20D438A5-B93B-4972-BFAD-373954BD6117}.MachineIndependent|x64.Build.0 = MachineIndependent|x64
+		{20D438A5-B93B-4972-BFAD-373954BD6117}.MachineIndependent|x86.ActiveCfg = MachineIndependent|Any CPU
+		{20D438A5-B93B-4972-BFAD-373954BD6117}.MachineIndependent|x86.Build.0 = MachineIndependent|Any CPU
+		{20D438A5-B93B-4972-BFAD-373954BD6117}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{20D438A5-B93B-4972-BFAD-373954BD6117}.Release|Any CPU.Build.0 = Release|Any CPU
+		{20D438A5-B93B-4972-BFAD-373954BD6117}.Release|ARM64.ActiveCfg = Release|arm64
+		{20D438A5-B93B-4972-BFAD-373954BD6117}.Release|ARM64.Build.0 = Release|arm64
+		{20D438A5-B93B-4972-BFAD-373954BD6117}.Release|x64.ActiveCfg = Release|x64
+		{20D438A5-B93B-4972-BFAD-373954BD6117}.Release|x64.Build.0 = Release|x64
+		{20D438A5-B93B-4972-BFAD-373954BD6117}.Release|x86.ActiveCfg = Release|Any CPU
+		{20D438A5-B93B-4972-BFAD-373954BD6117}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -934,6 +962,7 @@ Global
 		{B60173F0-F9F0-4688-9DF8-9ADDD57BD45F} = {9BAD9352-DEFB-45E5-B8A4-4816B9B22A33}
 		{F47E1A0A-7D81-40CF-B8B3-A0F4B5ADE943} = {760FF85D-8BEB-4992-8095-A9678F88FD47}
 		{71E59632-D644-491B-AF93-22BC93167C56} = {9BAD9352-DEFB-45E5-B8A4-4816B9B22A33}
+		{20D438A5-B93B-4972-BFAD-373954BD6117} = {4D013D5D-E085-4F4F-B36B-9484F7E51657}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {F948D667-14E3-4F98-BA50-3F3C948BF4C2}

--- a/eng/Packages.props
+++ b/eng/Packages.props
@@ -20,6 +20,7 @@
     <PackageVersion Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" />
     <PackageVersion Include="System.Configuration.ConfigurationManager" Version="$(SystemConfigurationConfigurationManagerVersion)" />
     <PackageVersion Include="System.Formats.Asn1" Version="$(SystemFormatsAsn1Version)" />
+    <PackageVersion Include="System.IO.Hashing" Version="$(SystemIOHashingVersion)" />
     <PackageVersion Include="System.Memory" Version="$(SystemMemoryVersion)" />
     <PackageVersion Include="System.Net.Http" Version="$(SystemNetHttpVersion)" />
     <PackageVersion Include="System.Reflection.Metadata" Version="$(SystemReflectionMetadataVersion)" />

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -32,6 +32,7 @@
         When updating the version of System.Memory file a breaking change here: https://github.com/dotnet/docs/issues/new?assignees=gewarren&labels=breaking-change%2CPri1%2Cdoc-idea&template=breaking-change.yml&title=%5BBreaking+change%5D%3A+
         and follow the guidelines written here (internal-link): https://dev.azure.com/devdiv/DevDiv/_wiki/wikis/DevDiv.wiki/1796/How-to-add-a-Known-Issue
     -->
+    <SystemIOHashingVersion>8.0.0</SystemIOHashingVersion>
     <SystemMemoryVersion>4.5.5</SystemMemoryVersion>
     <SystemNetHttpVersion>4.3.4</SystemNetHttpVersion>
     <SystemReflectionMetadataLoadContextVersion>8.0.0</SystemReflectionMetadataLoadContextVersion>

--- a/src/Build/BackEnd/Components/Communications/RarNodeLauncher.cs
+++ b/src/Build/BackEnd/Components/Communications/RarNodeLauncher.cs
@@ -1,0 +1,77 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.IO.Pipes;
+using System.Linq;
+using System.Security.Principal;
+using System.Threading;
+using Microsoft.Build.BackEnd;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Framework.Telemetry;
+using Microsoft.Build.Internal;
+using Microsoft.Build.Shared;
+
+namespace Microsoft.Build.BackEnd.Client
+{
+    public sealed class RarNodeLauncher
+    {
+        public static void LaunchServer()
+        {
+            CommunicationsUtilities.Trace("Checking for RAR server...");
+            RarNodeHandshake handshake = new(HandshakeOptions.None);
+
+            if (IsPipeExists(handshake))
+            {
+                CommunicationsUtilities.Trace($"Existing RAR server found.");
+                return;
+            }
+
+            string serverLaunchMutexName = $@"Global\msbuild-rar-server-launch-{handshake.ComputeHash()}";
+
+            // Then, check if another MSBuild process has started the server launch.
+            // This accounts for any delay between the server starting and opening its mutex.
+            using Mutex serverLaunchMutex = new(
+                initiallyOwned: true,
+                name: serverLaunchMutexName,
+                createdNew: out bool createdNew);
+
+            if (!createdNew)
+            {
+                CommunicationsUtilities.Trace("Another process launching the RAR server.");
+                return;
+            }
+
+            CommunicationsUtilities.Trace("Starting Server...");
+
+            string msbuildLocation = BuildEnvironmentHelper.Instance.CurrentMSBuildExePath;
+            string commandLineArgs = string.Join(" ", ["/nologo", "/nodemode:3"]);
+
+            NodeLauncher nodeLauncher = new();
+            Process msbuildProcess = nodeLauncher.Start(msbuildLocation, commandLineArgs, nodeId: 0);
+
+            CommunicationsUtilities.Trace("RAR Server started with PID: {0}", msbuildProcess.Id);
+        }
+
+        private static bool IsPipeExists(RarNodeHandshake handshake)
+        {
+            string[] pipes = Directory.GetFiles(@"\\.\pipe\");
+
+            return pipes.Contains(Path.Combine(@"\\.\pipe\", $"msbuild-rar-{handshake.ComputeHash()}"));
+        }
+
+        private static bool IsServerRunning(ServerNodeHandshake handshake)
+        {
+            string serverRunningMutexName = $@"Global\msbuild-rar-server-running-{handshake.ComputeHash()}";
+
+            // First, check if the server has created the mutex.
+            // Use a mutex to avoid using a timeout or checking a max pipe instance exception.
+            bool isRunning = Mutex.TryOpenExisting(serverRunningMutexName, out Mutex? mutex);
+            mutex?.Dispose();
+
+            return isRunning;
+        }
+    }
+}

--- a/src/Build/Microsoft.Build.csproj
+++ b/src/Build/Microsoft.Build.csproj
@@ -147,6 +147,7 @@
     <Compile Include="BackEnd\Components\ProjectCache\*.cs" />
     <Compile Include="BackEnd\Components\Communications\CurrentHost.cs" />
     <Compile Include="BackEnd\Components\Communications\DetouredNodeLauncher.cs" />
+    <Compile Include="BackEnd\Components\Communications\RarNodeLauncher.cs" />
     <Compile Include="BackEnd\Components\Communications\SerializationContractInitializer.cs" />
     <Compile Include="BackEnd\Components\Communications\ServerNodeEndpointOutOfProc.cs" />
     <Compile Include="BackEnd\Components\FileAccesses\IFileAccessManager.cs" />

--- a/src/Framework/Traits.cs
+++ b/src/Framework/Traits.cs
@@ -127,6 +127,11 @@ namespace Microsoft.Build.Framework
         /// </summary>
         public const string UseMSBuildServerEnvVarName = "MSBUILDUSESERVER";
 
+        /// <summary>
+        /// Internally set if ResolveAssemblyReference tasks should forward requests to the out-of-proc node.
+        /// </summary>
+        public const string ExecuteRAROutOFProcessEnvVarName = "MSBUILDEXECUTERAROUTOFPROC";
+
         public readonly bool DebugEngine = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("MSBuildDebugEngine"));
         public readonly bool DebugScheduler;
         public readonly bool DebugNodeCommunication;

--- a/src/MSBuild.UnitTests/CommandLineSwitches_Tests.cs
+++ b/src/MSBuild.UnitTests/CommandLineSwitches_Tests.cs
@@ -1186,6 +1186,7 @@ namespace Microsoft.Build.UnitTests
                                         lowPriority: false,
                                         question: false,
                                         isBuildCheckEnabled: false,
+                                        enableRarService: false,
                                         inputResultsCaches: null,
                                         outputResultsCache: null,
                                         saveProjectResult: false,

--- a/src/MSBuild/CommandLineSwitches.cs
+++ b/src/MSBuild/CommandLineSwitches.cs
@@ -120,6 +120,7 @@ namespace Microsoft.Build.CommandLine
             GetTargetResult,
             GetResultOutputFile,
             FeatureAvailability,
+            EnableRarService,
             // This has to be kept as last enum value
             NumberOfParameterizedSwitches,
         }
@@ -296,6 +297,7 @@ namespace Microsoft.Build.CommandLine
             new ParameterizedSwitchInfo(  ["getItem"],                           ParameterizedSwitch.GetItem,                    null,                           true,           "MissingGetItemError",                 true,   false,   "HelpMessage_44_GetItemSwitch"),
             new ParameterizedSwitchInfo(  ["getTargetResult"],                   ParameterizedSwitch.GetTargetResult,            null,                           true,           "MissingGetTargetResultError",         true,   false,   "HelpMessage_45_GetTargetResultSwitch"),
             new ParameterizedSwitchInfo(  ["getResultOutputFile"],               ParameterizedSwitch.GetResultOutputFile,        null,                           true,           "MissingGetResultFileError",           true,   false,   "HelpMessage_51_GetResultOutputFileSwitch"),
+            new ParameterizedSwitchInfo(  ["enableRarService"],                  ParameterizedSwitch.EnableRarService,           null,                           true,            null,                                 true,   false,   "HelpMessage_53_EnableRarServiceSwitch"),
             new ParameterizedSwitchInfo(  ["featureAvailability", "fa"],         ParameterizedSwitch.FeatureAvailability,        null,                           true,           "MissingFeatureAvailabilityError",     true,   false,   "HelpMessage_46_FeatureAvailabilitySwitch")
         };
 

--- a/src/MSBuild/MSBuild/Microsoft.Build.CommonTypes.xsd
+++ b/src/MSBuild/MSBuild/Microsoft.Build.CommonTypes.xsd
@@ -3322,6 +3322,7 @@ elementFormDefault="qualified">
                     <xs:attribute name="ProfileName" />
                     <xs:attribute name="PublicKeysRestrictedForGlobalLocation" />
                     <xs:attribute name="SearchPaths" use="required" />
+                    <xs:attribute name="ShouldExecuteInProcess" type="msb:boolean" />
                     <xs:attribute name="Silent" type="msb:boolean" />
                     <xs:attribute name="StateFile" />
                     <xs:attribute name="TargetedRuntimeVersion" />

--- a/src/MSBuild/Resources/Strings.resx
+++ b/src/MSBuild/Resources/Strings.resx
@@ -1052,6 +1052,18 @@
       LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
     </comment>
   </data>
+  <data name="HelpMessage_53_EnableRarServiceSwitch" xml:space="preserve">
+    <value>  -rarService[:True|False]
+                     Causes MSBuild to run a persistent service for the ResolveAssemblyReference task.
+
+                     This flag is experimental and may not work as intended.
+    </value>
+    <comment>
+      LOCALIZATION: "MSBuild" should not be localized.
+      LOCALIZATION: "-rarService" should not be localized.
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </comment>
+  </data>
   <data name="InvalidConfigurationFile" xml:space="preserve">
     <value>MSBUILD : Configuration error MSB1043: The application could not start. {0}</value>
     <comment>
@@ -1496,6 +1508,14 @@
       LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </comment>
   </data>
+  <data name="InvalidRarServiceValue" xml:space="preserve">
+    <value>MSBUILD : error MSB1069: Enable RAR service value is not valid. {0}.</value>
+    <comment>{StrBegin="MSBUILD : error MSB1069: "}
+     UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+     This error is shown when a user specifies a node reuse value that is not equivilant to Boolean.TrueString or Boolean.FalseString.
+     LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+  </comment>
+  </data>
   <data name="InvalidPreprocessPath" xml:space="preserve">
     <value>MSBUILD : error MSB1047: File to preprocess to is not valid. {0}</value>
     <comment>{StrBegin="MSBUILD : error MSB1047: "}</comment>
@@ -1812,7 +1832,7 @@
     <!--
         The command line message bucket is: MSB1001 - MSB1999
 
-        Next error code should be MSB1069.
+        Next error code should be MSB1070.
 
         Don't forget to update this comment after using the new code.
   -->

--- a/src/MSBuild/Resources/xlf/Strings.cs.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.cs.xlf
@@ -329,6 +329,23 @@
     LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
   </note>
       </trans-unit>
+      <trans-unit id="HelpMessage_53_EnableRarServiceSwitch">
+        <source>  -rarService[:True|False]
+                     Causes MSBuild to run a persistent service for the ResolveAssemblyReference task.
+
+                     This flag is experimental and may not work as intended.
+    </source>
+        <target state="new">  -rarService[:True|False]
+                     Causes MSBuild to run a persistent service for the ResolveAssemblyReference task.
+
+                     This flag is experimental and may not work as intended.
+    </target>
+        <note>
+      LOCALIZATION: "MSBuild" should not be localized.
+      LOCALIZATION: "-rarService" should not be localized.
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
       <trans-unit id="InvalidLowPriorityValue">
         <source>MSBUILD : error MSB1064: Low priority value is not valid. {0}</source>
         <target state="translated">MSBUILD : error MSB1064: Hodnota s nízkou prioritou není platná. {0}</target>
@@ -338,6 +355,15 @@
       This error is shown when a user specifies a value for the lowPriority parameter that is not equivalent to Boolean.TrueString or Boolean.FalseString.
       LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </note>
+      </trans-unit>
+      <trans-unit id="InvalidRarServiceValue">
+        <source>MSBUILD : error MSB1069: Enable RAR service value is not valid. {0}.</source>
+        <target state="new">MSBUILD : error MSB1069: Enable RAR service value is not valid. {0}.</target>
+        <note>{StrBegin="MSBUILD : error MSB1069: "}
+     UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+     This error is shown when a user specifies a node reuse value that is not equivilant to Boolean.TrueString or Boolean.FalseString.
+     LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+  </note>
       </trans-unit>
       <trans-unit id="InvalidTerminalLoggerValue">
         <source>MSBUILD : error MSB1065: Terminal logger value is not valid. It should be one of 'auto', 'true', or 'false'. {0}</source>

--- a/src/MSBuild/Resources/xlf/Strings.de.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.de.xlf
@@ -329,6 +329,23 @@
     LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
   </note>
       </trans-unit>
+      <trans-unit id="HelpMessage_53_EnableRarServiceSwitch">
+        <source>  -rarService[:True|False]
+                     Causes MSBuild to run a persistent service for the ResolveAssemblyReference task.
+
+                     This flag is experimental and may not work as intended.
+    </source>
+        <target state="new">  -rarService[:True|False]
+                     Causes MSBuild to run a persistent service for the ResolveAssemblyReference task.
+
+                     This flag is experimental and may not work as intended.
+    </target>
+        <note>
+      LOCALIZATION: "MSBuild" should not be localized.
+      LOCALIZATION: "-rarService" should not be localized.
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
       <trans-unit id="InvalidLowPriorityValue">
         <source>MSBUILD : error MSB1064: Low priority value is not valid. {0}</source>
         <target state="translated">MSBUILD : error MSB1064: Der Wert mit niedriger Priorität ist ungültig. {0}</target>
@@ -338,6 +355,15 @@
       This error is shown when a user specifies a value for the lowPriority parameter that is not equivalent to Boolean.TrueString or Boolean.FalseString.
       LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </note>
+      </trans-unit>
+      <trans-unit id="InvalidRarServiceValue">
+        <source>MSBUILD : error MSB1069: Enable RAR service value is not valid. {0}.</source>
+        <target state="new">MSBUILD : error MSB1069: Enable RAR service value is not valid. {0}.</target>
+        <note>{StrBegin="MSBUILD : error MSB1069: "}
+     UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+     This error is shown when a user specifies a node reuse value that is not equivilant to Boolean.TrueString or Boolean.FalseString.
+     LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+  </note>
       </trans-unit>
       <trans-unit id="InvalidTerminalLoggerValue">
         <source>MSBUILD : error MSB1065: Terminal logger value is not valid. It should be one of 'auto', 'true', or 'false'. {0}</source>

--- a/src/MSBuild/Resources/xlf/Strings.es.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.es.xlf
@@ -328,6 +328,23 @@ Esta marca es experimental y puede que no funcione según lo previsto.
     LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
   </note>
       </trans-unit>
+      <trans-unit id="HelpMessage_53_EnableRarServiceSwitch">
+        <source>  -rarService[:True|False]
+                     Causes MSBuild to run a persistent service for the ResolveAssemblyReference task.
+
+                     This flag is experimental and may not work as intended.
+    </source>
+        <target state="new">  -rarService[:True|False]
+                     Causes MSBuild to run a persistent service for the ResolveAssemblyReference task.
+
+                     This flag is experimental and may not work as intended.
+    </target>
+        <note>
+      LOCALIZATION: "MSBuild" should not be localized.
+      LOCALIZATION: "-rarService" should not be localized.
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
       <trans-unit id="InvalidLowPriorityValue">
         <source>MSBUILD : error MSB1064: Low priority value is not valid. {0}</source>
         <target state="translated">MSBUILD : error MSB1064: El valor de prioridad baja no es válido. {0}.</target>
@@ -337,6 +354,15 @@ Esta marca es experimental y puede que no funcione según lo previsto.
       This error is shown when a user specifies a value for the lowPriority parameter that is not equivalent to Boolean.TrueString or Boolean.FalseString.
       LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </note>
+      </trans-unit>
+      <trans-unit id="InvalidRarServiceValue">
+        <source>MSBUILD : error MSB1069: Enable RAR service value is not valid. {0}.</source>
+        <target state="new">MSBUILD : error MSB1069: Enable RAR service value is not valid. {0}.</target>
+        <note>{StrBegin="MSBUILD : error MSB1069: "}
+     UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+     This error is shown when a user specifies a node reuse value that is not equivilant to Boolean.TrueString or Boolean.FalseString.
+     LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+  </note>
       </trans-unit>
       <trans-unit id="InvalidTerminalLoggerValue">
         <source>MSBUILD : error MSB1065: Terminal logger value is not valid. It should be one of 'auto', 'true', or 'false'. {0}</source>

--- a/src/MSBuild/Resources/xlf/Strings.fr.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.fr.xlf
@@ -329,6 +329,23 @@ futures
     LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
   </note>
       </trans-unit>
+      <trans-unit id="HelpMessage_53_EnableRarServiceSwitch">
+        <source>  -rarService[:True|False]
+                     Causes MSBuild to run a persistent service for the ResolveAssemblyReference task.
+
+                     This flag is experimental and may not work as intended.
+    </source>
+        <target state="new">  -rarService[:True|False]
+                     Causes MSBuild to run a persistent service for the ResolveAssemblyReference task.
+
+                     This flag is experimental and may not work as intended.
+    </target>
+        <note>
+      LOCALIZATION: "MSBuild" should not be localized.
+      LOCALIZATION: "-rarService" should not be localized.
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
       <trans-unit id="InvalidLowPriorityValue">
         <source>MSBUILD : error MSB1064: Low priority value is not valid. {0}</source>
         <target state="translated">MSBUILD : error MSB1064: la valeur basse priorité n’est pas valide. {0}</target>
@@ -338,6 +355,15 @@ futures
       This error is shown when a user specifies a value for the lowPriority parameter that is not equivalent to Boolean.TrueString or Boolean.FalseString.
       LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </note>
+      </trans-unit>
+      <trans-unit id="InvalidRarServiceValue">
+        <source>MSBUILD : error MSB1069: Enable RAR service value is not valid. {0}.</source>
+        <target state="new">MSBUILD : error MSB1069: Enable RAR service value is not valid. {0}.</target>
+        <note>{StrBegin="MSBUILD : error MSB1069: "}
+     UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+     This error is shown when a user specifies a node reuse value that is not equivilant to Boolean.TrueString or Boolean.FalseString.
+     LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+  </note>
       </trans-unit>
       <trans-unit id="InvalidTerminalLoggerValue">
         <source>MSBUILD : error MSB1065: Terminal logger value is not valid. It should be one of 'auto', 'true', or 'false'. {0}</source>

--- a/src/MSBuild/Resources/xlf/Strings.it.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.it.xlf
@@ -329,6 +329,23 @@ Questo flag è sperimentale e potrebbe non funzionare come previsto.
     LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
   </note>
       </trans-unit>
+      <trans-unit id="HelpMessage_53_EnableRarServiceSwitch">
+        <source>  -rarService[:True|False]
+                     Causes MSBuild to run a persistent service for the ResolveAssemblyReference task.
+
+                     This flag is experimental and may not work as intended.
+    </source>
+        <target state="new">  -rarService[:True|False]
+                     Causes MSBuild to run a persistent service for the ResolveAssemblyReference task.
+
+                     This flag is experimental and may not work as intended.
+    </target>
+        <note>
+      LOCALIZATION: "MSBuild" should not be localized.
+      LOCALIZATION: "-rarService" should not be localized.
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
       <trans-unit id="InvalidLowPriorityValue">
         <source>MSBUILD : error MSB1064: Low priority value is not valid. {0}</source>
         <target state="translated">MSBUILD : error MSB1064: il valore di priorità bassa non è valido. {0}</target>
@@ -338,6 +355,15 @@ Questo flag è sperimentale e potrebbe non funzionare come previsto.
       This error is shown when a user specifies a value for the lowPriority parameter that is not equivalent to Boolean.TrueString or Boolean.FalseString.
       LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </note>
+      </trans-unit>
+      <trans-unit id="InvalidRarServiceValue">
+        <source>MSBUILD : error MSB1069: Enable RAR service value is not valid. {0}.</source>
+        <target state="new">MSBUILD : error MSB1069: Enable RAR service value is not valid. {0}.</target>
+        <note>{StrBegin="MSBUILD : error MSB1069: "}
+     UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+     This error is shown when a user specifies a node reuse value that is not equivilant to Boolean.TrueString or Boolean.FalseString.
+     LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+  </note>
       </trans-unit>
       <trans-unit id="InvalidTerminalLoggerValue">
         <source>MSBUILD : error MSB1065: Terminal logger value is not valid. It should be one of 'auto', 'true', or 'false'. {0}</source>

--- a/src/MSBuild/Resources/xlf/Strings.ja.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.ja.xlf
@@ -330,6 +330,23 @@
     LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
   </note>
       </trans-unit>
+      <trans-unit id="HelpMessage_53_EnableRarServiceSwitch">
+        <source>  -rarService[:True|False]
+                     Causes MSBuild to run a persistent service for the ResolveAssemblyReference task.
+
+                     This flag is experimental and may not work as intended.
+    </source>
+        <target state="new">  -rarService[:True|False]
+                     Causes MSBuild to run a persistent service for the ResolveAssemblyReference task.
+
+                     This flag is experimental and may not work as intended.
+    </target>
+        <note>
+      LOCALIZATION: "MSBuild" should not be localized.
+      LOCALIZATION: "-rarService" should not be localized.
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
       <trans-unit id="InvalidLowPriorityValue">
         <source>MSBUILD : error MSB1064: Low priority value is not valid. {0}</source>
         <target state="translated">MSBUILD : error MSB1064: 低優先度値が無効です。 {0}</target>
@@ -339,6 +356,15 @@
       This error is shown when a user specifies a value for the lowPriority parameter that is not equivalent to Boolean.TrueString or Boolean.FalseString.
       LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </note>
+      </trans-unit>
+      <trans-unit id="InvalidRarServiceValue">
+        <source>MSBUILD : error MSB1069: Enable RAR service value is not valid. {0}.</source>
+        <target state="new">MSBUILD : error MSB1069: Enable RAR service value is not valid. {0}.</target>
+        <note>{StrBegin="MSBUILD : error MSB1069: "}
+     UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+     This error is shown when a user specifies a node reuse value that is not equivilant to Boolean.TrueString or Boolean.FalseString.
+     LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+  </note>
       </trans-unit>
       <trans-unit id="InvalidTerminalLoggerValue">
         <source>MSBUILD : error MSB1065: Terminal logger value is not valid. It should be one of 'auto', 'true', or 'false'. {0}</source>

--- a/src/MSBuild/Resources/xlf/Strings.ko.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.ko.xlf
@@ -329,6 +329,23 @@
     LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
   </note>
       </trans-unit>
+      <trans-unit id="HelpMessage_53_EnableRarServiceSwitch">
+        <source>  -rarService[:True|False]
+                     Causes MSBuild to run a persistent service for the ResolveAssemblyReference task.
+
+                     This flag is experimental and may not work as intended.
+    </source>
+        <target state="new">  -rarService[:True|False]
+                     Causes MSBuild to run a persistent service for the ResolveAssemblyReference task.
+
+                     This flag is experimental and may not work as intended.
+    </target>
+        <note>
+      LOCALIZATION: "MSBuild" should not be localized.
+      LOCALIZATION: "-rarService" should not be localized.
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
       <trans-unit id="InvalidLowPriorityValue">
         <source>MSBUILD : error MSB1064: Low priority value is not valid. {0}</source>
         <target state="translated">MSBUILD : error MSB1064: 낮은 우선 순위 값이 유효하지 않습니다. {0}</target>
@@ -338,6 +355,15 @@
       This error is shown when a user specifies a value for the lowPriority parameter that is not equivalent to Boolean.TrueString or Boolean.FalseString.
       LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </note>
+      </trans-unit>
+      <trans-unit id="InvalidRarServiceValue">
+        <source>MSBUILD : error MSB1069: Enable RAR service value is not valid. {0}.</source>
+        <target state="new">MSBUILD : error MSB1069: Enable RAR service value is not valid. {0}.</target>
+        <note>{StrBegin="MSBUILD : error MSB1069: "}
+     UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+     This error is shown when a user specifies a node reuse value that is not equivilant to Boolean.TrueString or Boolean.FalseString.
+     LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+  </note>
       </trans-unit>
       <trans-unit id="InvalidTerminalLoggerValue">
         <source>MSBUILD : error MSB1065: Terminal logger value is not valid. It should be one of 'auto', 'true', or 'false'. {0}</source>

--- a/src/MSBuild/Resources/xlf/Strings.pl.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.pl.xlf
@@ -328,6 +328,23 @@ Ta flaga jest eksperymentalna i może nie działać zgodnie z oczekiwaniami.
     LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
   </note>
       </trans-unit>
+      <trans-unit id="HelpMessage_53_EnableRarServiceSwitch">
+        <source>  -rarService[:True|False]
+                     Causes MSBuild to run a persistent service for the ResolveAssemblyReference task.
+
+                     This flag is experimental and may not work as intended.
+    </source>
+        <target state="new">  -rarService[:True|False]
+                     Causes MSBuild to run a persistent service for the ResolveAssemblyReference task.
+
+                     This flag is experimental and may not work as intended.
+    </target>
+        <note>
+      LOCALIZATION: "MSBuild" should not be localized.
+      LOCALIZATION: "-rarService" should not be localized.
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
       <trans-unit id="InvalidLowPriorityValue">
         <source>MSBUILD : error MSB1064: Low priority value is not valid. {0}</source>
         <target state="translated">MSBUILD : error MSB1064: wartość niskiego priorytetu jest nieprawidłowa. {0}</target>
@@ -337,6 +354,15 @@ Ta flaga jest eksperymentalna i może nie działać zgodnie z oczekiwaniami.
       This error is shown when a user specifies a value for the lowPriority parameter that is not equivalent to Boolean.TrueString or Boolean.FalseString.
       LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </note>
+      </trans-unit>
+      <trans-unit id="InvalidRarServiceValue">
+        <source>MSBUILD : error MSB1069: Enable RAR service value is not valid. {0}.</source>
+        <target state="new">MSBUILD : error MSB1069: Enable RAR service value is not valid. {0}.</target>
+        <note>{StrBegin="MSBUILD : error MSB1069: "}
+     UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+     This error is shown when a user specifies a node reuse value that is not equivilant to Boolean.TrueString or Boolean.FalseString.
+     LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+  </note>
       </trans-unit>
       <trans-unit id="InvalidTerminalLoggerValue">
         <source>MSBUILD : error MSB1065: Terminal logger value is not valid. It should be one of 'auto', 'true', or 'false'. {0}</source>

--- a/src/MSBuild/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.pt-BR.xlf
@@ -328,6 +328,23 @@
     LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
   </note>
       </trans-unit>
+      <trans-unit id="HelpMessage_53_EnableRarServiceSwitch">
+        <source>  -rarService[:True|False]
+                     Causes MSBuild to run a persistent service for the ResolveAssemblyReference task.
+
+                     This flag is experimental and may not work as intended.
+    </source>
+        <target state="new">  -rarService[:True|False]
+                     Causes MSBuild to run a persistent service for the ResolveAssemblyReference task.
+
+                     This flag is experimental and may not work as intended.
+    </target>
+        <note>
+      LOCALIZATION: "MSBuild" should not be localized.
+      LOCALIZATION: "-rarService" should not be localized.
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
       <trans-unit id="InvalidLowPriorityValue">
         <source>MSBUILD : error MSB1064: Low priority value is not valid. {0}</source>
         <target state="translated">MSBUILD : error MSB1064: o valor de baixa prioridade não é válido. {0}</target>
@@ -337,6 +354,15 @@
       This error is shown when a user specifies a value for the lowPriority parameter that is not equivalent to Boolean.TrueString or Boolean.FalseString.
       LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </note>
+      </trans-unit>
+      <trans-unit id="InvalidRarServiceValue">
+        <source>MSBUILD : error MSB1069: Enable RAR service value is not valid. {0}.</source>
+        <target state="new">MSBUILD : error MSB1069: Enable RAR service value is not valid. {0}.</target>
+        <note>{StrBegin="MSBUILD : error MSB1069: "}
+     UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+     This error is shown when a user specifies a node reuse value that is not equivilant to Boolean.TrueString or Boolean.FalseString.
+     LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+  </note>
       </trans-unit>
       <trans-unit id="InvalidTerminalLoggerValue">
         <source>MSBUILD : error MSB1065: Terminal logger value is not valid. It should be one of 'auto', 'true', or 'false'. {0}</source>

--- a/src/MSBuild/Resources/xlf/Strings.ru.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.ru.xlf
@@ -328,6 +328,23 @@
     LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
   </note>
       </trans-unit>
+      <trans-unit id="HelpMessage_53_EnableRarServiceSwitch">
+        <source>  -rarService[:True|False]
+                     Causes MSBuild to run a persistent service for the ResolveAssemblyReference task.
+
+                     This flag is experimental and may not work as intended.
+    </source>
+        <target state="new">  -rarService[:True|False]
+                     Causes MSBuild to run a persistent service for the ResolveAssemblyReference task.
+
+                     This flag is experimental and may not work as intended.
+    </target>
+        <note>
+      LOCALIZATION: "MSBuild" should not be localized.
+      LOCALIZATION: "-rarService" should not be localized.
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
       <trans-unit id="InvalidLowPriorityValue">
         <source>MSBUILD : error MSB1064: Low priority value is not valid. {0}</source>
         <target state="translated">MSBUILD : error MSB1064: недопустимое значение низкого приоритета. {0}</target>
@@ -337,6 +354,15 @@
       This error is shown when a user specifies a value for the lowPriority parameter that is not equivalent to Boolean.TrueString or Boolean.FalseString.
       LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </note>
+      </trans-unit>
+      <trans-unit id="InvalidRarServiceValue">
+        <source>MSBUILD : error MSB1069: Enable RAR service value is not valid. {0}.</source>
+        <target state="new">MSBUILD : error MSB1069: Enable RAR service value is not valid. {0}.</target>
+        <note>{StrBegin="MSBUILD : error MSB1069: "}
+     UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+     This error is shown when a user specifies a node reuse value that is not equivilant to Boolean.TrueString or Boolean.FalseString.
+     LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+  </note>
       </trans-unit>
       <trans-unit id="InvalidTerminalLoggerValue">
         <source>MSBUILD : error MSB1065: Terminal logger value is not valid. It should be one of 'auto', 'true', or 'false'. {0}</source>

--- a/src/MSBuild/Resources/xlf/Strings.tr.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.tr.xlf
@@ -329,6 +329,23 @@
     LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
   </note>
       </trans-unit>
+      <trans-unit id="HelpMessage_53_EnableRarServiceSwitch">
+        <source>  -rarService[:True|False]
+                     Causes MSBuild to run a persistent service for the ResolveAssemblyReference task.
+
+                     This flag is experimental and may not work as intended.
+    </source>
+        <target state="new">  -rarService[:True|False]
+                     Causes MSBuild to run a persistent service for the ResolveAssemblyReference task.
+
+                     This flag is experimental and may not work as intended.
+    </target>
+        <note>
+      LOCALIZATION: "MSBuild" should not be localized.
+      LOCALIZATION: "-rarService" should not be localized.
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
       <trans-unit id="InvalidLowPriorityValue">
         <source>MSBUILD : error MSB1064: Low priority value is not valid. {0}</source>
         <target state="translated">MSBUILD : error MSB1064: Düşük öncelikli değer geçerli değil. {0}</target>
@@ -338,6 +355,15 @@
       This error is shown when a user specifies a value for the lowPriority parameter that is not equivalent to Boolean.TrueString or Boolean.FalseString.
       LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </note>
+      </trans-unit>
+      <trans-unit id="InvalidRarServiceValue">
+        <source>MSBUILD : error MSB1069: Enable RAR service value is not valid. {0}.</source>
+        <target state="new">MSBUILD : error MSB1069: Enable RAR service value is not valid. {0}.</target>
+        <note>{StrBegin="MSBUILD : error MSB1069: "}
+     UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+     This error is shown when a user specifies a node reuse value that is not equivilant to Boolean.TrueString or Boolean.FalseString.
+     LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+  </note>
       </trans-unit>
       <trans-unit id="InvalidTerminalLoggerValue">
         <source>MSBUILD : error MSB1065: Terminal logger value is not valid. It should be one of 'auto', 'true', or 'false'. {0}</source>

--- a/src/MSBuild/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.zh-Hans.xlf
@@ -328,6 +328,23 @@
     LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
   </note>
       </trans-unit>
+      <trans-unit id="HelpMessage_53_EnableRarServiceSwitch">
+        <source>  -rarService[:True|False]
+                     Causes MSBuild to run a persistent service for the ResolveAssemblyReference task.
+
+                     This flag is experimental and may not work as intended.
+    </source>
+        <target state="new">  -rarService[:True|False]
+                     Causes MSBuild to run a persistent service for the ResolveAssemblyReference task.
+
+                     This flag is experimental and may not work as intended.
+    </target>
+        <note>
+      LOCALIZATION: "MSBuild" should not be localized.
+      LOCALIZATION: "-rarService" should not be localized.
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
       <trans-unit id="InvalidLowPriorityValue">
         <source>MSBUILD : error MSB1064: Low priority value is not valid. {0}</source>
         <target state="translated">MSBUILD : error MSB1064: 低优先级值无效。{0}</target>
@@ -337,6 +354,15 @@
       This error is shown when a user specifies a value for the lowPriority parameter that is not equivalent to Boolean.TrueString or Boolean.FalseString.
       LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </note>
+      </trans-unit>
+      <trans-unit id="InvalidRarServiceValue">
+        <source>MSBUILD : error MSB1069: Enable RAR service value is not valid. {0}.</source>
+        <target state="new">MSBUILD : error MSB1069: Enable RAR service value is not valid. {0}.</target>
+        <note>{StrBegin="MSBUILD : error MSB1069: "}
+     UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+     This error is shown when a user specifies a node reuse value that is not equivilant to Boolean.TrueString or Boolean.FalseString.
+     LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+  </note>
       </trans-unit>
       <trans-unit id="InvalidTerminalLoggerValue">
         <source>MSBUILD : error MSB1065: Terminal logger value is not valid. It should be one of 'auto', 'true', or 'false'. {0}</source>

--- a/src/MSBuild/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.zh-Hant.xlf
@@ -329,6 +329,23 @@
     LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
   </note>
       </trans-unit>
+      <trans-unit id="HelpMessage_53_EnableRarServiceSwitch">
+        <source>  -rarService[:True|False]
+                     Causes MSBuild to run a persistent service for the ResolveAssemblyReference task.
+
+                     This flag is experimental and may not work as intended.
+    </source>
+        <target state="new">  -rarService[:True|False]
+                     Causes MSBuild to run a persistent service for the ResolveAssemblyReference task.
+
+                     This flag is experimental and may not work as intended.
+    </target>
+        <note>
+      LOCALIZATION: "MSBuild" should not be localized.
+      LOCALIZATION: "-rarService" should not be localized.
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
       <trans-unit id="InvalidLowPriorityValue">
         <source>MSBUILD : error MSB1064: Low priority value is not valid. {0}</source>
         <target state="translated">MSBUILD : error MSB1064: 低優先順序值無效。{0}</target>
@@ -338,6 +355,15 @@
       This error is shown when a user specifies a value for the lowPriority parameter that is not equivalent to Boolean.TrueString or Boolean.FalseString.
       LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </note>
+      </trans-unit>
+      <trans-unit id="InvalidRarServiceValue">
+        <source>MSBUILD : error MSB1069: Enable RAR service value is not valid. {0}.</source>
+        <target state="new">MSBUILD : error MSB1069: Enable RAR service value is not valid. {0}.</target>
+        <note>{StrBegin="MSBUILD : error MSB1069: "}
+     UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+     This error is shown when a user specifies a node reuse value that is not equivilant to Boolean.TrueString or Boolean.FalseString.
+     LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+  </note>
       </trans-unit>
       <trans-unit id="InvalidTerminalLoggerValue">
         <source>MSBUILD : error MSB1065: Terminal logger value is not valid. It should be one of 'auto', 'true', or 'false'. {0}</source>

--- a/src/RarTest/Program.cs
+++ b/src/RarTest/Program.cs
@@ -1,0 +1,14 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Build.Tasks.AssemblyDependency;
+
+using CancellationTokenSource cts = new();
+Console.CancelKeyPress += (object? sender, ConsoleCancelEventArgs args) =>
+{
+    args.Cancel = true;
+    cts.Cancel();
+};
+
+using ResolveAssemblyReferenceService rarService = new();
+await rarService.ExecuteAsync(cts.Token);

--- a/src/RarTest/RarTest.csproj
+++ b/src/RarTest/RarTest.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../Tasks/Microsoft.Build.Tasks.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Shared/INodePacket.cs
+++ b/src/Shared/INodePacket.cs
@@ -200,6 +200,11 @@ namespace Microsoft.Build.BackEnd
         /// </summary>
         ProcessReport,
 
+        // TODO: Remove if using own named pipe implementation?
+        RarNodeExecutionRequest,
+
+        RarNodeExecutionResponse,
+
         /// <summary>
         /// Command in form of MSBuild command line for server node - MSBuild Server.
         /// Keep this enum value constant intact as this is part of contract with dotnet CLI

--- a/src/Tasks.UnitTests/AssemblyDependency/Miscellaneous.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/Miscellaneous.cs
@@ -8620,7 +8620,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             rar.ResolvedFiles[0].GetMetadata("FusionName").ShouldBe("System.Candy, Version=8.1.2.3, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a");
 
             // The reference is not worth persisting in the per-instance cache.
-            rar._cache.IsDirty.ShouldBeFalse();
+            rar.Cache.IsDirty.ShouldBeFalse();
         }
 
         [Fact]

--- a/src/Tasks.UnitTests/RARPrecomputedCache_Tests.cs
+++ b/src/Tasks.UnitTests/RARPrecomputedCache_Tests.cs
@@ -25,15 +25,15 @@ namespace Microsoft.Build.Tasks.UnitTests
                 TransientTestFile standardCache = env.CreateFile(".cache");
                 ResolveAssemblyReference t = new ResolveAssemblyReference()
                 {
-                    _cache = new SystemState()
+                    Cache = new SystemState()
                 };
-                t._cache.instanceLocalFileStateCache = new Dictionary<string, SystemState.FileState>() {
+                t.Cache.instanceLocalFileStateCache = new Dictionary<string, SystemState.FileState>() {
                     { Path.Combine(standardCache.Path, "assembly1"), new SystemState.FileState(now) },
                     { Path.Combine(standardCache.Path, "assembly2"), new SystemState.FileState(now) { Assembly = new Shared.AssemblyNameExtension("hi") } } };
-                t._cache.SetGetLastWriteTime(_ => now);
-                _ = t._cache.GetFileState("assembly1");
-                _ = t._cache.GetFileState("assembly2");
-                t._cache.IsDirty = true;
+                t.Cache.SetGetLastWriteTime(_ => now);
+                _ = t.Cache.GetFileState("assembly1");
+                _ = t.Cache.GetFileState("assembly2");
+                t.Cache.IsDirty = true;
                 t.StateFile = standardCache.Path;
                 t.WriteStateFile();
                 int standardLen = File.ReadAllText(standardCache.Path).Length;
@@ -41,7 +41,7 @@ namespace Microsoft.Build.Tasks.UnitTests
                 standardLen.ShouldBeGreaterThan(0);
 
                 string precomputedPath = standardCache.Path + ".cache";
-                t._cache.IsDirty = true;
+                t.Cache.IsDirty = true;
                 t.AssemblyInformationCacheOutputPath = precomputedPath;
                 t.WriteStateFile();
                 File.Exists(standardCache.Path).ShouldBeFalse();
@@ -60,20 +60,20 @@ namespace Microsoft.Build.Tasks.UnitTests
                 TransientTestFile standardCache = env.CreateFile(".cache");
                 ResolveAssemblyReference rarWriterTask = new ResolveAssemblyReference()
                 {
-                    _cache = new SystemState()
+                    Cache = new SystemState()
                 };
-                rarWriterTask._cache.instanceLocalFileStateCache = new() {
+                rarWriterTask.Cache.instanceLocalFileStateCache = new() {
                     { "path1", new SystemState.FileState(now) },
                 };
-                rarWriterTask._cache.SetGetLastWriteTime(_ => now);
+                rarWriterTask.Cache.SetGetLastWriteTime(_ => now);
                 rarWriterTask.StateFile = standardCache.Path;
-                _ = rarWriterTask._cache.GetFileState("path1");
-                rarWriterTask._cache.IsDirty = true;
+                _ = rarWriterTask.Cache.GetFileState("path1");
+                rarWriterTask.Cache.IsDirty = true;
                 // Write standard cache
                 rarWriterTask.WriteStateFile();
 
                 string dllName = Path.Combine(Path.GetDirectoryName(standardCache.Path), "randomFolder", "dll.dll");
-                rarWriterTask._cache.instanceLocalFileStateCache.Add(dllName,
+                rarWriterTask.Cache.instanceLocalFileStateCache.Add(dllName,
                     new SystemState.FileState(DateTime.Now)
                     {
                         Assembly = null,
@@ -83,7 +83,7 @@ namespace Microsoft.Build.Tasks.UnitTests
                     });
                 string precomputedCachePath = standardCache.Path + ".cache";
                 rarWriterTask.AssemblyInformationCacheOutputPath = precomputedCachePath;
-                rarWriterTask._cache.IsDirty = true;
+                rarWriterTask.Cache.IsDirty = true;
                 // Write precomputed cache
                 rarWriterTask.WriteStateFile();
 
@@ -99,7 +99,7 @@ namespace Microsoft.Build.Tasks.UnitTests
                 // the normal cache does not have dll.dll, whereas the precomputed cache does, so it should not be
                 // present when we read it.
                 rarReaderTask.ReadStateFile(p => true);
-                rarReaderTask._cache.instanceLocalFileStateCache.ShouldNotContainKey(dllName);
+                rarReaderTask.Cache.instanceLocalFileStateCache.ShouldNotContainKey(dllName);
             }
         }
 
@@ -111,10 +111,10 @@ namespace Microsoft.Build.Tasks.UnitTests
                 TransientTestFile precomputedCache = env.CreateFile(".cache");
                 ResolveAssemblyReference rarWriterTask = new ResolveAssemblyReference()
                 {
-                    _cache = new SystemState()
+                    Cache = new SystemState()
                 };
                 string dllName = Path.Combine(Path.GetDirectoryName(precomputedCache.Path), "randomFolder", "dll.dll");
-                rarWriterTask._cache.instanceLocalFileStateCache = new Dictionary<string, SystemState.FileState>() {
+                rarWriterTask.Cache.instanceLocalFileStateCache = new Dictionary<string, SystemState.FileState>() {
                     { Path.Combine(precomputedCache.Path, "..", "assembly1", "assembly1"), new SystemState.FileState(DateTime.Now) },
                     { Path.Combine(precomputedCache.Path, "assembly2"), new SystemState.FileState(DateTime.Now) { Assembly = new Shared.AssemblyNameExtension("hi") } },
                     { dllName, new SystemState.FileState(DateTime.Now) {
@@ -124,7 +124,7 @@ namespace Microsoft.Build.Tasks.UnitTests
                         scatterFiles = new string[] { "first", "second" } } } };
 
                 rarWriterTask.AssemblyInformationCacheOutputPath = precomputedCache.Path;
-                rarWriterTask._cache.IsDirty = true;
+                rarWriterTask.Cache.IsDirty = true;
 
                 // Throws an exception because precomputedCache.Path already exists.
                 Should.Throw<InvalidOperationException>(() => rarWriterTask.WriteStateFile());
@@ -141,8 +141,8 @@ namespace Microsoft.Build.Tasks.UnitTests
                 // At this point, the standard cache does not exist, so it defaults to reading the "precomputed" cache.
                 // Then we verify that the information contained in that cache matches what we'd expect.
                 rarReaderTask.ReadStateFile(p => true);
-                rarReaderTask._cache.instanceLocalFileStateCache.ShouldContainKey(dllName);
-                SystemState.FileState assembly3 = rarReaderTask._cache.instanceLocalFileStateCache[dllName];
+                rarReaderTask.Cache.instanceLocalFileStateCache.ShouldContainKey(dllName);
+                SystemState.FileState assembly3 = rarReaderTask.Cache.instanceLocalFileStateCache[dllName];
                 assembly3.Assembly.ShouldBeNull();
                 assembly3.RuntimeVersion.ShouldBe("v4.0.30319");
                 assembly3.FrameworkNameAttribute.Version.ShouldBe(Version.Parse("4.7.2"));

--- a/src/Tasks/AssemblyDependency/Client/ResolveAssemblyReferenceClient.cs
+++ b/src/Tasks/AssemblyDependency/Client/ResolveAssemblyReferenceClient.cs
@@ -1,0 +1,339 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.IO.Pipes;
+using System.Linq;
+using System.Net.Http;
+using System.Security.Principal;
+using System.Text;
+using System.Xml.Serialization;
+using Microsoft.Build.BackEnd;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Internal;
+using Microsoft.Build.Utilities;
+
+namespace Microsoft.Build.Tasks.AssemblyDependency
+{
+    internal class ResolveAssemblyReferenceClient : ResolveAssemblyReferenceNodeBase, IDisposable
+    {
+        private static readonly byte[] ReusableBuffer = new byte[DefaultBufferSizeInBytes];
+
+        private readonly MemoryStream _memoryStream = new(DefaultBufferSizeInBytes);
+
+        private readonly NamedPipeClientStream _pipe;
+
+        internal ResolveAssemblyReferenceClient()
+        {
+#pragma warning disable SA1111, SA1009 // Closing parenthesis should be on line of last parameter
+            _pipe = new(
+                serverName: ".",
+                _pipeName,
+                PipeDirection.InOut,
+                PipeOptions.None
+#if FEATURE_PIPEOPTIONS_CURRENTUSERONLY
+                | PipeOptions.CurrentUserOnly
+#endif
+            );
+#pragma warning restore SA1111, SA1009 // Closing parenthesis should be on line of last parameter
+        }
+
+        public bool Execute(ResolveAssemblyReference rarTask)
+        {
+            // RAR service may have a different working directory, so convert potential relative paths to absolute.
+            string? appConfigFile = rarTask.AppConfigFile != null ? Path.GetFullPath(rarTask.AppConfigFile) : null;
+            string? stateFile = rarTask.StateFile != null ? Path.GetFullPath(rarTask.StateFile) : null;
+
+            // Allow the service to avoid processing messages which would never be logged by the client.
+            MessageImportance minimumMessageImportance = GetMinimumMessageImportance(rarTask.Log);
+
+            RarExecutionRequest req = new()
+            {
+                AutoUnify = rarTask.AutoUnify,
+                CopyLocalDependenciesWhenParentReferenceInGac = rarTask.CopyLocalDependenciesWhenParentReferenceInGac,
+                DoNotCopyLocalIfInGac = rarTask.DoNotCopyLocalIfInGac,
+                FindDependencies = rarTask.FindDependencies,
+                FindDependenciesOfExternallyResolvedReferences = rarTask.FindDependenciesOfExternallyResolvedReferences,
+                FindRelatedFiles = rarTask.FindRelatedFiles,
+                FindSatellites = rarTask.FindSatellites,
+                FindSerializationAssemblies = rarTask.FindSerializationAssemblies,
+                IgnoreDefaultInstalledAssemblySubsetTables = rarTask.IgnoreDefaultInstalledAssemblySubsetTables,
+                IgnoreDefaultInstalledAssemblyTables = rarTask.IgnoreDefaultInstalledAssemblyTables,
+                IgnoreTargetFrameworkAttributeVersionMismatch = rarTask.IgnoreTargetFrameworkAttributeVersionMismatch,
+                IgnoreVersionForFrameworkReferences = rarTask.IgnoreVersionForFrameworkReferences,
+                Silent = rarTask.Silent,
+                SupportsBindingRedirectGeneration = rarTask.SupportsBindingRedirectGeneration,
+                UnresolveFrameworkAssembliesFromHigherFrameworks = rarTask.UnresolveFrameworkAssembliesFromHigherFrameworks,
+                IsTaskLoggingEnabled = rarTask.Log.IsTaskInputLoggingEnabled,
+                MinimumMessageImportance = minimumMessageImportance,
+                TargetPath = rarTask.TargetPath,
+                AppConfigFile = appConfigFile,
+                ProfileName = rarTask.ProfileName,
+                StateFile = stateFile,
+                TargetedRuntimeVersion = rarTask.TargetedRuntimeVersion,
+                TargetFrameworkMoniker = rarTask.TargetFrameworkMoniker,
+                TargetFrameworkMonikerDisplayName = rarTask.TargetFrameworkMonikerDisplayName,
+                TargetFrameworkVersion = rarTask.TargetFrameworkVersion,
+                TargetProcessorArchitecture = rarTask.TargetProcessorArchitecture,
+                WarnOrErrorOnTargetArchitectureMismatch = rarTask.WarnOrErrorOnTargetArchitectureMismatch,
+                AllowedAssemblyExtensions = rarTask.AllowedAssemblyExtensions,
+                AllowedRelatedFileExtensions = rarTask.AllowedRelatedFileExtensions,
+                Assemblies = ConvertTaskItems(rarTask.Assemblies),
+                AssemblyFiles = ConvertTaskItems(rarTask.AssemblyFiles),
+                CandidateAssemblyFiles = rarTask.CandidateAssemblyFiles,
+                FullFrameworkAssemblyTables = ConvertTaskItems(rarTask.FullFrameworkAssemblyTables),
+                FullFrameworkFolders = rarTask.FullFrameworkFolders,
+                FullTargetFrameworkSubsetNames = rarTask.FullTargetFrameworkSubsetNames,
+                InstalledAssemblyTables = ConvertTaskItems(rarTask.InstalledAssemblyTables),
+                InstalledAssemblySubsetTables = ConvertTaskItems(rarTask.InstalledAssemblySubsetTables),
+                LatestTargetFrameworkDirectories = rarTask.LatestTargetFrameworkDirectories,
+                ResolvedSDKReferences = ConvertTaskItems(rarTask.ResolvedSDKReferences),
+                SearchPaths = rarTask.SearchPaths,
+                TargetFrameworkDirectories = rarTask.TargetFrameworkDirectories,
+                TargetFrameworkSubsets = rarTask.TargetFrameworkSubsets,
+            };
+
+            RarExecutionResponse resp = ResolveAssemblyReferences(req, rarTask.BuildEngine);
+            SetTaskOutputs(rarTask, resp);
+
+            return resp.Success;
+
+            static RarTaskItemInput[] ConvertTaskItems(ITaskItem[] taskItems)
+            {
+                RarTaskItemInput[] requestItems = new RarTaskItemInput[taskItems.Length];
+
+                for (int i = 0; i < taskItems.Length; i++)
+                {
+                    requestItems[i] = new RarTaskItemInput(taskItems[i]);
+                }
+
+                return requestItems;
+            }
+        }
+
+        private MessageImportance GetMinimumMessageImportance(TaskLoggingHelper log) =>
+            log.LogsMessagesOfImportance(MessageImportance.Low) ? MessageImportance.Low
+                : log.LogsMessagesOfImportance(MessageImportance.Normal) ? MessageImportance.Normal
+                : MessageImportance.High;
+
+        private RarExecutionResponse ResolveAssemblyReferences(RarExecutionRequest request, IBuildEngine buildEngine)
+        {
+            ConnectToServer();
+
+            SendRequest(request);
+            RarExecutionResponse response = ReadResponse();
+
+            // The RAR service will reply with queued build events before the task has completed.
+            // Process these while waiting for completion.
+            while (!response.IsComplete)
+            {
+                LogBuildEvents(buildEngine, response.BuildEventArgsQueue);
+                response = ReadResponse();
+            }
+
+            LogBuildEvents(buildEngine, response.BuildEventArgsQueue);
+
+            return response;
+        }
+
+        private void ConnectToServer()
+        {
+            CommunicationsUtilities.Trace("Attempting connect to pipe {1} with timeout {2} ms", _pipeName, _pipeName, ClientConnectTimeout);
+
+            _pipe.Connect(ClientConnectTimeout);
+
+#if !FEATURE_PIPEOPTIONS_CURRENTUSERONLY
+            if (NativeMethodsShared.IsWindows)
+            {
+                // Verify that the owner of the pipe is us.  This prevents a security hole where a remote node has
+                // been faked up with ACLs that would let us attach to it.  It could then issue fake build requests back to
+                // us, potentially causing us to execute builds that do harmful or unexpected things.  The pipe owner can
+                // only be set to the user's own SID by a normal, unprivileged process.  The conditions where a faked up
+                // remote node could set the owner to something else would also let it change owners on other objects, so
+                // this would be a security flaw upstream of us.
+                ValidateRemotePipeSecurityOnWindows();
+            }
+#endif
+
+            PerformHandshake();
+        }
+
+        private void PerformHandshake()
+        {
+            int[] handshakeComponents = _handshake.RetrieveHandshakeComponents();
+
+            for (int i = 0; i < handshakeComponents.Length; i++)
+            {
+                CommunicationsUtilities.Trace("Writing handshake part {0} ({1}) to pipe {2}", i, handshakeComponents[i], _pipeName);
+                _pipe.WriteIntForHandshake(handshakeComponents[i]);
+            }
+
+            _pipe.WriteEndOfHandshakeSignal();
+
+            CommunicationsUtilities.Trace("Reading handshake from pipe {0}", _pipeName);
+
+#if NETCOREAPP2_1_OR_GREATER
+            _pipe.ReadEndOfHandshakeSignal(true, ClientConnectTimeout);
+#else
+            _pipe.ReadEndOfHandshakeSignal(true);
+#endif
+            CommunicationsUtilities.Trace("Successfully connected to pipe {0}...!", _pipeName);
+        }
+
+#if !FEATURE_PIPEOPTIONS_CURRENTUSERONLY
+        // This code needs to be in a separate method so that we don't try (and fail) to load the Windows-only APIs when JIT-ing the code
+        //  on non-Windows operating systems
+        private void ValidateRemotePipeSecurityOnWindows()
+        {
+            SecurityIdentifier identifier = WindowsIdentity.GetCurrent().Owner;
+#if FEATURE_PIPE_SECURITY
+            PipeSecurity remoteSecurity = _pipe.GetAccessControl();
+#else
+            var remoteSecurity = new PipeSecurity(_pipe.SafePipeHandle, System.Security.AccessControl.AccessControlSections.Access |
+                System.Security.AccessControl.AccessControlSections.Owner | System.Security.AccessControl.AccessControlSections.Group);
+#endif
+            IdentityReference remoteOwner = remoteSecurity.GetOwner(typeof(SecurityIdentifier));
+            if (remoteOwner != identifier)
+            {
+                CommunicationsUtilities.Trace("The remote pipe owner {0} does not match {1}", remoteOwner.Value, identifier.Value);
+                throw new UnauthorizedAccessException();
+            }
+        }
+#endif
+
+        private void SendRequest(RarExecutionRequest request)
+        {
+            // Serialize to temporary buffer to reduce IO calls.
+            Serialize(request, _memoryStream);
+            SetMessageLength(_memoryStream);
+            WritePipe(_pipe, _memoryStream);
+        }
+
+        private RarExecutionResponse ReadResponse()
+        {
+            // Read raw bytes to a temporary buffer to reduce IO calls.
+            int bytesRead = ReadPipe(_pipe, ReusableBuffer, 0, MessageOffsetInBytes);
+            int messageLength = ParseMessageLength(ReusableBuffer);
+
+            // Additional reads for the remaining message.
+            byte[] buffer = EnsureBufferSize(ReusableBuffer, messageLength);
+            bytesRead = ReadPipe(_pipe, buffer, bytesRead, messageLength);
+
+            if (bytesRead > messageLength)
+            {
+                // TODO: Check event args are handled correctly. Server may send multiple responses for one request.
+                throw new Exception("Should not be reading into next message!");
+            }
+
+            return Deserialize<RarExecutionResponse>(buffer, messageLength);
+        }
+
+        private static void SetTaskOutputs(ResolveAssemblyReference rarTask, RarExecutionResponse response)
+        {
+            rarTask.DependsOnNETStandard = response.DependsOnNetStandard;
+            rarTask.DependsOnSystemRuntime = response.DependsOnSystemRuntime;
+            List<ITaskItem> copyLocalFiles = new(response.NumCopyLocalFiles);
+            rarTask.FilesWritten = ExtractTaskItems(response.FilesWritten);
+            rarTask.RelatedFiles = ExtractTaskItems(response.RelatedFiles);
+            rarTask.ResolvedDependencyFiles = ExtractTaskItems(response.ResolvedDependencyFiles);
+            rarTask.ResolvedFiles = ExtractTaskItems(response.ResolvedFiles);
+            rarTask.SatelliteFiles = ExtractTaskItems(response.SatelliteFiles);
+            rarTask.ScatterFiles = ExtractTaskItems(response.ScatterFiles);
+            rarTask.SerializationAssemblyFiles = ExtractTaskItems(response.SerializationAssemblyFiles);
+            rarTask.SuggestedRedirects = ExtractTaskItems(response.SuggestedRedirects);
+            rarTask.UnresolvedAssemblyConflicts = ExtractTaskItems(response.UnresolvedAssemblyConflicts);
+
+            ITaskItem[] ExtractTaskItems(RarTaskItemOutput[] responseItems)
+            {
+                ITaskItem[] taskItems = new ITaskItem[responseItems.Length];
+
+                for (int i = 0; i < responseItems.Length; i++)
+                {
+                    RarTaskItemOutput responseItem = responseItems[i];
+
+                    TaskItem taskItem = new(responseItem.EvaluatedIncludeEscaped);
+                    taskItems[i] = taskItem;
+
+                    if (responseItem.IsCopyLocalFile)
+                    {
+                        copyLocalFiles.Add(taskItem);
+                    }
+                }
+
+                return taskItems;
+            }
+        }
+
+        private static void LogBuildEvents(IBuildEngine buildEngine, RarBuildEventArgs[] buildEventsArgsQueue)
+        {
+            foreach (RarBuildEventArgs buildEventArgs in buildEventsArgsQueue)
+            {
+                DateTime eventTimestamp = new(buildEventArgs.EventTimestamp, DateTimeKind.Utc);
+
+                switch (buildEventArgs.EventType)
+                {
+                    case RarBuildEventArgsType.Message:
+                        BuildMessageEventArgs messageEventArgs = new(
+                            buildEventArgs.Subcategory,
+                            buildEventArgs.Code,
+                            buildEventArgs.File,
+                            buildEventArgs.LineNumber,
+                            buildEventArgs.ColumnNumber,
+                            buildEventArgs.EndLineNumber,
+                            buildEventArgs.EndColumnNumber,
+                            buildEventArgs.Message,
+                            buildEventArgs.HelpKeyword,
+                            buildEventArgs.SenderName,
+                            (MessageImportance)buildEventArgs.Importance,
+                            eventTimestamp,
+                            buildEventArgs.MessageArgs);
+
+                        buildEngine.LogMessageEvent(messageEventArgs);
+                        break;
+                    case RarBuildEventArgsType.Warning:
+                        BuildWarningEventArgs warningEventArgs = new(
+                            buildEventArgs.Subcategory,
+                            buildEventArgs.Code,
+                            buildEventArgs.File,
+                            buildEventArgs.LineNumber,
+                            buildEventArgs.ColumnNumber,
+                            buildEventArgs.EndLineNumber,
+                            buildEventArgs.EndColumnNumber,
+                            buildEventArgs.Message,
+                            buildEventArgs.HelpKeyword,
+                            buildEventArgs.SenderName,
+                            eventTimestamp,
+                            buildEventArgs.MessageArgs);
+
+                        buildEngine.LogWarningEvent(warningEventArgs);
+                        break;
+                    case RarBuildEventArgsType.Error:
+                        BuildErrorEventArgs errorEventArgs = new(
+                            buildEventArgs.Subcategory,
+                            buildEventArgs.Code,
+                            buildEventArgs.File,
+                            buildEventArgs.LineNumber,
+                            buildEventArgs.ColumnNumber,
+                            buildEventArgs.EndLineNumber,
+                            buildEventArgs.EndColumnNumber,
+                            buildEventArgs.Message,
+                            buildEventArgs.HelpKeyword,
+                            buildEventArgs.SenderName,
+                            eventTimestamp,
+                            buildEventArgs.MessageArgs);
+
+                        buildEngine.LogErrorEvent(errorEventArgs);
+                        break;
+                }
+            }
+        }
+
+        public void Dispose()
+        {
+            _pipe.Dispose();
+        }
+    }
+}

--- a/src/Tasks/AssemblyDependency/ReferenceTable.cs
+++ b/src/Tasks/AssemblyDependency/ReferenceTable.cs
@@ -875,6 +875,8 @@ namespace Microsoft.Build.Tasks
                 AssemblyNameExtension assemblyName = NameAssemblyFileReference(
                     reference,
                     itemSpec);  // Contains the assembly file name.
+                // TODO: Don't know where this line change came from? Maybe after a rebase.
+                reference.ReferenceVersion = assemblyName.Version;
 
                 // Embed Interop Types aka "NOPIAs" support is not available for Fx < 4.0
                 // So, we just ignore this setting on down-level platforms
@@ -2724,7 +2726,7 @@ namespace Microsoft.Build.Tasks
                 }
             }
 
-            referenceItem.SetMetadata(ItemMetadataNames.version, reference.ReferenceVersion == null ? string.Empty : reference.ReferenceVersion.ToString());
+            referenceItem.SetMetadata(ItemMetadataNames.version, assemblyName.Version?.ToString());
 
             // Unset fusionName so we don't have to unset it later.
             referenceItem.RemoveMetadata(ItemMetadataNames.fusionName);

--- a/src/Tasks/AssemblyDependency/Serialization/RarBuildEventArgs.cs
+++ b/src/Tasks/AssemblyDependency/Serialization/RarBuildEventArgs.cs
@@ -1,0 +1,71 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Build.BackEnd;
+
+namespace Microsoft.Build.Tasks.AssemblyDependency
+{
+    internal class RarBuildEventArgs : ITranslatable
+    {
+        private RarBuildEventArgsType _eventType;
+        private string? _subcategory;
+        private string? _code;
+        private string? _file;
+        private int _lineNumber;
+        private int _columnNumber;
+        private int _endLineNumber;
+        private int _endColumnNumber;
+        private string? _message;
+        private string? _helpKeyword;
+        private string? _senderName;
+        private int _importance;
+        private long _eventTimestamp;
+        private string[]? _messageArgs;
+
+        public RarBuildEventArgsType EventType { get => _eventType; set => _eventType = value; }
+
+        public string? Subcategory { get => _subcategory; set => _subcategory = value; }
+
+        public string? Code { get => _code; set => _code = value; }
+
+        public string? File { get => _file; set => _file = value; }
+
+        public int LineNumber { get => _lineNumber; set => _lineNumber = value; }
+
+        public int ColumnNumber { get => _columnNumber; set => _columnNumber = value; }
+
+        public int EndLineNumber { get => _endLineNumber; set => _endLineNumber = value; }
+
+        public int EndColumnNumber { get => _endColumnNumber; set => _endColumnNumber = value; }
+
+        public string? Message { get => _message; set => _message = value; }
+
+        public string? HelpKeyword { get => _helpKeyword; set => _helpKeyword = value; }
+
+        public string? SenderName { get => _senderName; set => _senderName = value; }
+
+        public int Importance { get => _importance; set => _importance = value; }
+
+        public long EventTimestamp { get => _eventTimestamp; set => _eventTimestamp = value; }
+
+        public string[]? MessageArgs { get => _messageArgs; set => _messageArgs = value; }
+
+        public void Translate(ITranslator translator)
+        {
+            translator.TranslateEnum(ref _eventType, (int)_eventType);
+            translator.Translate(ref _subcategory);
+            translator.Translate(ref _code);
+            translator.Translate(ref _file);
+            translator.Translate(ref _lineNumber);
+            translator.Translate(ref _columnNumber);
+            translator.Translate(ref _endLineNumber);
+            translator.Translate(ref _endColumnNumber);
+            translator.Translate(ref _message);
+            translator.Translate(ref _helpKeyword);
+            translator.Translate(ref _senderName);
+            translator.Translate(ref _importance);
+            translator.Translate(ref _eventTimestamp);
+            translator.Translate(ref _messageArgs);
+        }
+    }
+}

--- a/src/Tasks/AssemblyDependency/Serialization/RarBuildEventArgsType.cs
+++ b/src/Tasks/AssemblyDependency/Serialization/RarBuildEventArgsType.cs
@@ -1,0 +1,12 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Build.Tasks.AssemblyDependency
+{
+    internal enum RarBuildEventArgsType
+    {
+        Message,
+        Warning,
+        Error,
+    }
+}

--- a/src/Tasks/AssemblyDependency/Serialization/RarExecutionRequest.cs
+++ b/src/Tasks/AssemblyDependency/Serialization/RarExecutionRequest.cs
@@ -1,0 +1,237 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Microsoft.Build.BackEnd;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Shared;
+using Microsoft.Build.Tasks.Deployment.ManifestUtilities;
+using Microsoft.Build.Utilities;
+
+namespace Microsoft.Build.Tasks.AssemblyDependency
+{
+    internal class RarExecutionRequest : RarSerializableMessageBase
+    {
+        private bool _enableMetadataInterning;
+        private bool _autoUnify;
+        private bool _copyLocalDependenciesWhenParentReferenceInGac;
+        private bool _doNotCopyLocalIfInGac;
+        private bool _findDependencies;
+        private bool _findDependenciesOfExternallyResolvedReferences;
+        private bool _findRelatedFiles;
+        private bool _findSatellites;
+        private bool _findSerializationAssemblies;
+        private bool _ignoreDefaultInstalledAssemblySubsetTables;
+        private bool _ignoreDefaultInstalledAssemblyTables;
+        private bool _ignoreTargetFrameworkAttributeVersionMismatch;
+        private bool _ignoreVersionForFrameworkReferences;
+        private bool _silent;
+        private bool _supportsBindingRedirectGeneration;
+        private bool _unresolveFrameworkAssembliesFromHigherFrameworks;
+        private bool _isTaskLoggingEnabled;
+        private MessageImportance _minimumMessageImportance;
+        private string _msBuildProjectFile = string.Empty;
+        private string? _appConfigFile;
+        private string? _profileName;
+        private string? _stateFile;
+        private string? _targetedRuntimeVersion;
+        private string? _targetFrameworkMoniker;
+        private string? _targetFrameworkMonikerDisplayName;
+        private string? _targetFrameworkVersion;
+        private string? _targetProcessorArchitecture;
+        private string? _warnOrErrorOnTargetArchitectureMismatch;
+        private string[] _allowedAssemblyExtensions = [];
+        private string[] _allowedRelatedFileExtensions = [];
+        private RarTaskItemInput[] _assemblies = [];
+        private RarTaskItemInput[] _assemblyFiles = [];
+        private string[] _candidateAssemblyFiles = [];
+        private RarTaskItemInput[] _fullFrameworkAssemblyTables = [];
+        private string[] _fullFrameworkFolders = [];
+        private string[] _fullTargetFrameworkSubsetNames = [];
+        private RarTaskItemInput[] _installedAssemblySubsetTables = [];
+        private RarTaskItemInput[] _installedAssemblyTables = [];
+        private string[] _searchPaths = [];
+        private string[] _targetFrameworkDirectories = [];
+        private RarTaskItemInput[] _resolvedSDKReferences = [];
+        private string[] _latestTargetFrameworkDirectories = [];
+        private string[] _targetFrameworkSubsets = [];
+
+        public bool AutoUnify { get => _autoUnify; set => _autoUnify = value; }
+
+        public bool CopyLocalDependenciesWhenParentReferenceInGac { get => _copyLocalDependenciesWhenParentReferenceInGac; set => _copyLocalDependenciesWhenParentReferenceInGac = value; }
+
+        public bool DoNotCopyLocalIfInGac { get => _doNotCopyLocalIfInGac; set => _doNotCopyLocalIfInGac = value; }
+
+        public bool FindDependencies { get => _findDependencies; set => _findDependencies = value; }
+
+        public bool FindDependenciesOfExternallyResolvedReferences { get => _findDependenciesOfExternallyResolvedReferences; set => _findDependenciesOfExternallyResolvedReferences = value; }
+
+        public bool FindRelatedFiles { get => _findRelatedFiles; set => _findRelatedFiles = value; }
+
+        public bool FindSatellites { get => _findSatellites; set => _findSatellites = value; }
+
+        public bool FindSerializationAssemblies { get => _findSerializationAssemblies; set => _findSerializationAssemblies = value; }
+
+        public bool IgnoreDefaultInstalledAssemblySubsetTables { get => _ignoreDefaultInstalledAssemblySubsetTables; set => _ignoreDefaultInstalledAssemblySubsetTables = value; }
+
+        public bool IgnoreDefaultInstalledAssemblyTables { get => _ignoreDefaultInstalledAssemblyTables; set => _ignoreDefaultInstalledAssemblyTables = value; }
+
+        public bool IgnoreTargetFrameworkAttributeVersionMismatch { get => _ignoreTargetFrameworkAttributeVersionMismatch; set => _ignoreTargetFrameworkAttributeVersionMismatch = value; }
+
+        public bool IgnoreVersionForFrameworkReferences { get => _ignoreVersionForFrameworkReferences; set => _ignoreVersionForFrameworkReferences = value; }
+
+        public bool Silent { get => _silent; set => _silent = value; }
+
+        public bool SupportsBindingRedirectGeneration { get => _supportsBindingRedirectGeneration; set => _supportsBindingRedirectGeneration = value; }
+
+        public bool UnresolveFrameworkAssembliesFromHigherFrameworks { get => _unresolveFrameworkAssembliesFromHigherFrameworks; set => _unresolveFrameworkAssembliesFromHigherFrameworks = value; }
+
+        public bool IsTaskLoggingEnabled { get => _isTaskLoggingEnabled; set => _isTaskLoggingEnabled = value; }
+
+        public MessageImportance MinimumMessageImportance { get => _minimumMessageImportance; set => _minimumMessageImportance = value; }
+
+        public string TargetPath { get => _msBuildProjectFile; set => _msBuildProjectFile = value; }
+
+        public string? AppConfigFile { get => _appConfigFile; set => _appConfigFile = value; }
+
+        public string? ProfileName { get => _profileName; set => _profileName = value; }
+
+        public string? StateFile { get => _stateFile; set => _stateFile = value; }
+
+        public string? TargetedRuntimeVersion { get => _targetedRuntimeVersion; set => _targetedRuntimeVersion = value; }
+
+        public string? TargetFrameworkMoniker { get => _targetFrameworkMoniker; set => _targetFrameworkMoniker = value; }
+
+        public string? TargetFrameworkMonikerDisplayName { get => _targetFrameworkMonikerDisplayName; set => _targetFrameworkMonikerDisplayName = value; }
+
+        public string? TargetFrameworkVersion { get => _targetFrameworkVersion; set => _targetFrameworkVersion = value; }
+
+        public string? TargetProcessorArchitecture { get => _targetProcessorArchitecture; set => _targetProcessorArchitecture = value; }
+
+        public string? WarnOrErrorOnTargetArchitectureMismatch { get => _warnOrErrorOnTargetArchitectureMismatch; set => _warnOrErrorOnTargetArchitectureMismatch = value; }
+
+        public string[] AllowedAssemblyExtensions { get => _allowedAssemblyExtensions; set => _allowedAssemblyExtensions = value; }
+
+        public string[] AllowedRelatedFileExtensions { get => _allowedRelatedFileExtensions; set => _allowedRelatedFileExtensions = value; }
+
+        public RarTaskItemInput[] Assemblies { get => _assemblies; set => _assemblies = value; }
+
+        public RarTaskItemInput[] AssemblyFiles { get => _assemblyFiles; set => _assemblyFiles = value; }
+
+        public string[] CandidateAssemblyFiles { get => _candidateAssemblyFiles; set => _candidateAssemblyFiles = value; }
+
+        public RarTaskItemInput[] FullFrameworkAssemblyTables { get => _fullFrameworkAssemblyTables; set => _fullFrameworkAssemblyTables = value; }
+
+        public string[] FullFrameworkFolders { get => _fullFrameworkFolders; set => _fullFrameworkFolders = value; }
+
+        public string[] FullTargetFrameworkSubsetNames { get => _fullTargetFrameworkSubsetNames; set => _fullTargetFrameworkSubsetNames = value; }
+
+        public RarTaskItemInput[] InstalledAssemblyTables { get => _installedAssemblyTables; set => _installedAssemblyTables = value; }
+
+        public RarTaskItemInput[] InstalledAssemblySubsetTables { get => _installedAssemblySubsetTables; set => _installedAssemblySubsetTables = value; }
+
+        public string[] LatestTargetFrameworkDirectories { get => _latestTargetFrameworkDirectories; set => _latestTargetFrameworkDirectories = value; }
+
+        public RarTaskItemInput[] ResolvedSDKReferences { get => _resolvedSDKReferences; set => _resolvedSDKReferences = value; }
+
+        public string[] SearchPaths { get => _searchPaths; set => _searchPaths = value; }
+
+        public string[] TargetFrameworkDirectories { get => _targetFrameworkDirectories; set => _targetFrameworkDirectories = value; }
+
+        public string[] TargetFrameworkSubsets { get => _targetFrameworkSubsets; set => _targetFrameworkSubsets = value; }
+
+        public bool EnableMetadataInterning { get => _enableMetadataInterning; set => _enableMetadataInterning = value; }
+
+        public override NodePacketType Type => NodePacketType.RarNodeExecutionRequest;
+
+        public override void Translate(ITranslator translator)
+        {
+            // TODO: String interning needs further design and should only apply to metadata known to contain duplicates.
+            // TODO: For now it is always disabled.
+            translator.Translate(ref _enableMetadataInterning);
+            RarMetadataInternCache? internCache = _enableMetadataInterning ? new() : null;
+
+            if (internCache != null)
+            {
+                internCache = new();
+
+                if (translator.Mode == TranslationDirection.WriteToStream)
+                {
+                    InternTaskItems(_assemblies, internCache);
+                    InternTaskItems(_assemblyFiles, internCache);
+                    InternTaskItems(_fullFrameworkAssemblyTables, internCache);
+                    InternTaskItems(_installedAssemblyTables, internCache);
+                    InternTaskItems(_installedAssemblySubsetTables, internCache);
+                    InternTaskItems(_resolvedSDKReferences, internCache);
+                }
+
+                translator.Translate(ref internCache);
+            }
+
+            translator.Translate(ref _autoUnify);
+            translator.Translate(ref _copyLocalDependenciesWhenParentReferenceInGac);
+            translator.Translate(ref _doNotCopyLocalIfInGac);
+            translator.Translate(ref _findDependencies);
+            translator.Translate(ref _findDependenciesOfExternallyResolvedReferences);
+            translator.Translate(ref _findRelatedFiles);
+            translator.Translate(ref _findSatellites);
+            translator.Translate(ref _findSerializationAssemblies);
+            translator.Translate(ref _ignoreDefaultInstalledAssemblySubsetTables);
+            translator.Translate(ref _ignoreDefaultInstalledAssemblyTables);
+            translator.Translate(ref _ignoreTargetFrameworkAttributeVersionMismatch);
+            translator.Translate(ref _ignoreVersionForFrameworkReferences);
+            translator.Translate(ref _silent);
+            translator.Translate(ref _supportsBindingRedirectGeneration);
+            translator.Translate(ref _unresolveFrameworkAssembliesFromHigherFrameworks);
+            translator.Translate(ref _isTaskLoggingEnabled);
+            translator.TranslateEnum(ref _minimumMessageImportance, (int)_minimumMessageImportance);
+            translator.Translate(ref _msBuildProjectFile);
+            translator.Translate(ref _appConfigFile);
+            translator.Translate(ref _profileName);
+            translator.Translate(ref _stateFile);
+            translator.Translate(ref _targetedRuntimeVersion);
+            translator.Translate(ref _targetFrameworkMoniker);
+            translator.Translate(ref _targetFrameworkMonikerDisplayName);
+            translator.Translate(ref _targetFrameworkVersion);
+            translator.Translate(ref _targetProcessorArchitecture);
+            translator.Translate(ref _warnOrErrorOnTargetArchitectureMismatch);
+            translator.Translate(ref _allowedAssemblyExtensions);
+            translator.Translate(ref _allowedRelatedFileExtensions);
+            translator.TranslateArray(ref _assemblies);
+            translator.TranslateArray(ref _assemblyFiles);
+            translator.Translate(ref _candidateAssemblyFiles);
+            translator.TranslateArray(ref _fullFrameworkAssemblyTables);
+            translator.Translate(ref _fullFrameworkFolders);
+            translator.Translate(ref _fullTargetFrameworkSubsetNames);
+            translator.TranslateArray(ref _installedAssemblyTables);
+            translator.TranslateArray(ref _installedAssemblySubsetTables);
+            translator.Translate(ref _latestTargetFrameworkDirectories);
+            translator.TranslateArray(ref _resolvedSDKReferences);
+            translator.Translate(ref _searchPaths);
+            translator.Translate(ref _targetFrameworkDirectories);
+            translator.Translate(ref _targetFrameworkSubsets);
+
+            if (internCache != null && translator.Mode == TranslationDirection.ReadFromStream)
+            {
+                PopulateTaskItems(_assemblies, internCache);
+                PopulateTaskItems(_assemblyFiles, internCache);
+                PopulateTaskItems(_fullFrameworkAssemblyTables, internCache);
+                PopulateTaskItems(_installedAssemblyTables, internCache);
+                PopulateTaskItems(_installedAssemblySubsetTables, internCache);
+                PopulateTaskItems(_resolvedSDKReferences, internCache);
+            }
+        }
+
+        internal static INodePacket FactoryForDeserialization(ITranslator translator)
+        {
+            RarExecutionRequest request = new();
+            request.Translate(translator);
+
+            return request;
+        }
+    }
+}

--- a/src/Tasks/AssemblyDependency/Serialization/RarExecutionResponse.cs
+++ b/src/Tasks/AssemblyDependency/Serialization/RarExecutionResponse.cs
@@ -1,0 +1,136 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Microsoft.Build.BackEnd;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Shared;
+using Microsoft.Build.Utilities;
+
+namespace Microsoft.Build.Tasks.AssemblyDependency
+{
+    internal class RarExecutionResponse : RarSerializableMessageBase, ITranslatable
+    {
+        private bool _enableMetadataInterning;
+        private bool _isComplete;
+        private bool _success;
+        private string? _dependsOnNetStandard;
+        private string? _dependsOnSystemRuntime;
+        private int _numCopyLocalFiles;
+        private RarTaskItemOutput[] _copyLocalFiles = [];
+        private RarTaskItemOutput[] _filesWritten = [];
+        private RarTaskItemOutput[] _relatedFiles = [];
+        private RarTaskItemOutput[] _resolvedDependencyFiles = [];
+        private RarTaskItemOutput[] _resolvedFiles = [];
+        private RarTaskItemOutput[] _satelliteFiles = [];
+        private RarTaskItemOutput[] _scatterFiles = [];
+        private RarTaskItemOutput[] _serializationAssemblyFiles = [];
+        private RarTaskItemOutput[] _suggestedRedirects = [];
+        private RarTaskItemOutput[] _unresolvedAssemblyConflicts = [];
+        private RarBuildEventArgs[] _buildEventArgsQueue = [];
+
+        public bool IsComplete { get => _isComplete; set => _isComplete = value; }
+
+        public bool Success { get => _success; set => _success = value; }
+
+        public string? DependsOnNetStandard { get => _dependsOnNetStandard; set => _dependsOnNetStandard = value; }
+
+        public string? DependsOnSystemRuntime { get => _dependsOnSystemRuntime; set => _dependsOnSystemRuntime = value; }
+
+        public int NumCopyLocalFiles { get => _numCopyLocalFiles; set => _numCopyLocalFiles = value; }
+
+        public RarTaskItemOutput[] CopyLocalFiles { get => _copyLocalFiles; set => _copyLocalFiles = value; }
+
+        public RarTaskItemOutput[] FilesWritten { get => _filesWritten; set => _filesWritten = value; }
+
+        public RarTaskItemOutput[] RelatedFiles { get => _relatedFiles; set => _relatedFiles = value; }
+
+        public RarTaskItemOutput[] ResolvedDependencyFiles { get => _resolvedDependencyFiles; set => _resolvedDependencyFiles = value; }
+
+        public RarTaskItemOutput[] ResolvedFiles { get => _resolvedFiles; set => _resolvedFiles = value; }
+
+        public RarTaskItemOutput[] SatelliteFiles { get => _satelliteFiles; set => _satelliteFiles = value; }
+
+        public RarTaskItemOutput[] ScatterFiles { get => _scatterFiles; set => _scatterFiles = value; }
+
+        public RarTaskItemOutput[] SerializationAssemblyFiles { get => _serializationAssemblyFiles; set => _serializationAssemblyFiles = value; }
+
+        public RarTaskItemOutput[] SuggestedRedirects { get => _suggestedRedirects; set => _suggestedRedirects = value; }
+
+        public RarTaskItemOutput[] UnresolvedAssemblyConflicts { get => _unresolvedAssemblyConflicts; set => _unresolvedAssemblyConflicts = value; }
+
+        public RarBuildEventArgs[] BuildEventArgsQueue { get => _buildEventArgsQueue; set => _buildEventArgsQueue = value; }
+
+        internal SystemState? Cache { get; set; }
+
+        public bool EnableMetadataInterning { get => _enableMetadataInterning; set => _enableMetadataInterning = value; }
+
+        public override NodePacketType Type => NodePacketType.RarNodeExecutionResponse;
+
+        public override void Translate(ITranslator translator)
+        {
+            // TODO: String interning needs further design and should only apply to metadata known to contain duplicates.
+            // TODO: For now it is always disabled.
+            translator.Translate(ref _enableMetadataInterning);
+            RarMetadataInternCache? internCache = _enableMetadataInterning ? new() : null;
+
+            if (internCache != null)
+            {
+                if (translator.Mode == TranslationDirection.WriteToStream)
+                {
+                    InternTaskItems(_filesWritten, internCache);
+                    InternTaskItems(_relatedFiles, internCache);
+                    InternTaskItems(_resolvedDependencyFiles, internCache);
+                    InternTaskItems(_resolvedFiles, internCache);
+                    InternTaskItems(_satelliteFiles, internCache);
+                    InternTaskItems(_scatterFiles, internCache);
+                    InternTaskItems(_serializationAssemblyFiles, internCache);
+                    InternTaskItems(_suggestedRedirects, internCache);
+                    InternTaskItems(_unresolvedAssemblyConflicts, internCache);
+                }
+            }
+
+            translator.Translate(ref internCache);
+            translator.Translate(ref _isComplete);
+            translator.Translate(ref _success);
+            translator.Translate(ref _dependsOnNetStandard);
+            translator.Translate(ref _dependsOnSystemRuntime);
+            translator.Translate(ref _numCopyLocalFiles);
+            translator.TranslateArray(ref _filesWritten);
+            translator.TranslateArray(ref _relatedFiles);
+            translator.TranslateArray(ref _resolvedDependencyFiles);
+            translator.TranslateArray(ref _resolvedFiles);
+            translator.TranslateArray(ref _satelliteFiles);
+            translator.TranslateArray(ref _scatterFiles);
+            translator.TranslateArray(ref _serializationAssemblyFiles);
+            translator.TranslateArray(ref _suggestedRedirects);
+            translator.TranslateArray(ref _unresolvedAssemblyConflicts);
+            translator.TranslateArray(ref _buildEventArgsQueue);
+
+            if (internCache != null && translator.Mode == TranslationDirection.ReadFromStream)
+            {
+                PopulateTaskItems(_filesWritten, internCache);
+                PopulateTaskItems(_relatedFiles, internCache);
+                PopulateTaskItems(_resolvedDependencyFiles, internCache);
+                PopulateTaskItems(_resolvedFiles, internCache);
+                PopulateTaskItems(_satelliteFiles, internCache);
+                PopulateTaskItems(_scatterFiles, internCache);
+                PopulateTaskItems(_serializationAssemblyFiles, internCache);
+                PopulateTaskItems(_suggestedRedirects, internCache);
+                PopulateTaskItems(_unresolvedAssemblyConflicts, internCache);
+            }
+        }
+
+        internal static INodePacket FactoryForDeserialization(ITranslator translator)
+        {
+            RarExecutionResponse response = new();
+            response.Translate(translator);
+
+            return response;
+        }
+    }
+}

--- a/src/Tasks/AssemblyDependency/Serialization/RarInternedMetadata.cs
+++ b/src/Tasks/AssemblyDependency/Serialization/RarInternedMetadata.cs
@@ -1,0 +1,12 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Build.BackEnd;
+
+namespace Microsoft.Build.Tasks.AssemblyDependency
+{
+    internal class RarInternedMetadata : ITranslatable
+    {
+        public void Translate(ITranslator translator) => throw new System.NotImplementedException();
+    }
+}

--- a/src/Tasks/AssemblyDependency/Serialization/RarInternedMetadataCache.cs
+++ b/src/Tasks/AssemblyDependency/Serialization/RarInternedMetadataCache.cs
@@ -1,0 +1,54 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Build.BackEnd;
+
+namespace Microsoft.Build.Tasks.AssemblyDependency
+{
+    internal class RarMetadataInternCache : ITranslatable
+    {
+        private Dictionary<string, int> _stringToId = new(StringComparer.Ordinal);
+
+        private List<string> _idToString = [];
+
+        public void Translate(ITranslator translator)
+        {
+            translator.Translate(ref _idToString);
+
+            if (translator.Mode == TranslationDirection.ReadFromStream)
+            {
+                if (_stringToId.Count != _idToString.Count)
+                {
+                    _stringToId = new Dictionary<string, int>(_idToString.Count, StringComparer.Ordinal);
+
+                    for (int i = 0; i < _idToString.Count; i++)
+                    {
+                        string str = _idToString[i];
+                        _stringToId[str] = i;
+                    }
+                }
+            }
+        }
+
+        internal string GetString(int id)
+        {
+            return _idToString[id];
+        }
+
+        internal int Intern(string str)
+        {
+            if (_stringToId.TryGetValue(str, out int id))
+            {
+                return id;
+            }
+
+            id = _idToString.Count;
+            _idToString.Add(str);
+            _stringToId[str] = id;
+
+            return id;
+        }
+    }
+}

--- a/src/Tasks/AssemblyDependency/Serialization/RarSerializableMessageBase.cs
+++ b/src/Tasks/AssemblyDependency/Serialization/RarSerializableMessageBase.cs
@@ -1,0 +1,46 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Text;
+using System.IO.Hashing;
+using Microsoft.Build.BackEnd;
+
+namespace Microsoft.Build.Tasks.AssemblyDependency
+{
+    internal abstract class RarSerializableMessageBase : INodePacket
+    {
+        internal ulong ByteHash { get; private set; }
+
+        internal byte[]? ByteArray { get; private set; }
+
+        public abstract NodePacketType Type { get; }
+
+        public abstract void Translate(ITranslator translator);
+
+        internal void SetByteString(byte[] buffer, int sourceIndex, int messageLength)
+        {
+            ByteArray = new byte[messageLength];
+            Array.Copy(buffer, sourceIndex, ByteArray, 0, messageLength);
+
+            // TODO: Properly implement IEquatable
+            ByteHash = XxHash64.HashToUInt64(ByteArray);
+        }
+
+        protected void InternTaskItems(RarTaskItemBase[] taskItems, RarMetadataInternCache internCache)
+        {
+            foreach (RarTaskItemBase taskItem in taskItems)
+            {
+                taskItem.InternMetadata(internCache);
+            }
+        }
+
+        protected void PopulateTaskItems(RarTaskItemBase[] taskItems, RarMetadataInternCache internCache)
+        {
+            foreach (RarTaskItemBase taskItem in taskItems)
+            {
+                taskItem.PopulateMetadata(internCache);
+            }
+        }
+    }
+}

--- a/src/Tasks/AssemblyDependency/Serialization/RarTaskItemBase.cs
+++ b/src/Tasks/AssemblyDependency/Serialization/RarTaskItemBase.cs
@@ -1,0 +1,94 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections;
+using System.Collections.Generic;
+using Microsoft.Build.BackEnd;
+using Microsoft.Build.Collections;
+using Microsoft.Build.Framework;
+
+namespace Microsoft.Build.Tasks.AssemblyDependency
+{
+    internal abstract class RarTaskItemBase : ITaskItem2, ITranslatable
+    {
+        protected Dictionary<string, string> _metadata;
+
+        private Dictionary<int, int> _internedMetadata;
+
+        private bool _enableMetadataInterning = false;
+
+        public RarTaskItemBase()
+        {
+            _metadata = [];
+            _internedMetadata = [];
+        }
+
+        public virtual string EvaluatedIncludeEscaped { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
+
+        public virtual string ItemSpec { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
+
+        public virtual ICollection MetadataNames => throw new System.NotImplementedException();
+
+        public virtual int MetadataCount => throw new System.NotImplementedException();
+
+        public IDictionary CloneCustomMetadata() => throw new System.NotImplementedException();
+
+        public IDictionary CloneCustomMetadataEscaped() => throw new System.NotImplementedException();
+
+        public virtual void CopyMetadataTo(ITaskItem destinationItem) => throw new System.NotImplementedException();
+
+        public virtual string GetMetadata(string metadataName) => throw new System.NotImplementedException();
+
+        public virtual string GetMetadataValueEscaped(string metadataName) => throw new System.NotImplementedException();
+
+        public virtual void RemoveMetadata(string metadataName) => throw new System.NotImplementedException();
+
+        public virtual void SetMetadata(string metadataName, string metadataValue) => throw new System.NotImplementedException();
+
+        public virtual void SetMetadataValueLiteral(string metadataName, string metadataValue) => throw new System.NotImplementedException();
+
+        public virtual void Translate(ITranslator translator)
+        {
+            // TODO: String interning needs further design and should only apply to metadata known to contain duplicates.
+            // TODO: For now it is always disabled.
+            if (_enableMetadataInterning)
+            {
+                IDictionary<int, int> internedMetadataRef = _internedMetadata;
+
+                translator.TranslateDictionary(
+                    ref internedMetadataRef,
+                    (ITranslator aTranslator, ref int keyId) => aTranslator.Translate(ref keyId),
+                    (ITranslator aTranslator, ref int valueId) => aTranslator.Translate(ref valueId),
+                    capacity => new Dictionary<int, int>(capacity));
+            }
+            else
+            {
+                translator.TranslateDictionary(ref _metadata, MSBuildNameIgnoreCaseComparer.Default);
+            }
+        }
+
+        public void InternMetadata(RarMetadataInternCache internCache)
+        {
+            _internedMetadata = new(_metadata.Count);
+
+            foreach (KeyValuePair<string, string> kvp in _metadata)
+            {
+                int keyId = internCache.Intern(kvp.Key);
+                int valueId = internCache.Intern(kvp.Value);
+                _internedMetadata[keyId] = valueId;
+            }
+        }
+
+        public void PopulateMetadata(RarMetadataInternCache internCache)
+        {
+            _metadata = new(_internedMetadata.Count, MSBuildNameIgnoreCaseComparer.Default);
+
+            foreach (KeyValuePair<int, int> kvp in _internedMetadata)
+            {
+                string key = internCache.GetString(kvp.Key);
+                string value = internCache.GetString(kvp.Value);
+                _metadata[key] = value;
+            }
+        }
+    }
+}

--- a/src/Tasks/AssemblyDependency/Serialization/RarTaskItemInput.cs
+++ b/src/Tasks/AssemblyDependency/Serialization/RarTaskItemInput.cs
@@ -1,0 +1,111 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Xml.Serialization;
+using Microsoft.Build.BackEnd;
+using Microsoft.Build.Collections;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Shared;
+using Microsoft.Build.Utilities;
+
+namespace Microsoft.Build.Tasks.AssemblyDependency
+{
+    // Minimal shim for ProjectItemInstance.TaskItem, which is used for RAR inputs.
+    // Code paths not hit by RAR are unimplmeneted and will throw an exception.
+    // This allows us to emit a smaller serialization payload and optimize hot paths.
+    internal class RarTaskItemInput : RarTaskItemBase
+    {
+        private string _evaluatedIncludeEscaped;
+
+        private string _evaluatedIncludeUnescaped;
+
+        public RarTaskItemInput()
+            : base()
+        {
+            _evaluatedIncludeEscaped = string.Empty;
+            _evaluatedIncludeUnescaped = string.Empty;
+        }
+
+        public RarTaskItemInput(ITaskItem taskItem)
+        {
+            // This should only be called with a ProjectItemInstance.TaskItem.
+            if (taskItem is not ITaskItem2 taskItem2)
+            {
+                throw new ArgumentException("Type does not implement 'ITaskItem2'.", nameof(taskItem));
+            }
+
+            if (taskItem2.CloneCustomMetadataEscaped() is not Dictionary<string, string> metadata)
+            {
+                throw new ArgumentException(
+                    "Implementation of 'ITaskItem2.CloneCustomMetadataEscaped()' is not of type 'Dictionary<string, string>'.",
+                    nameof(taskItem));
+            }
+
+            // Store the unescaped value, as this is frequently used by RAR and is immutable.
+            // TODO: How many times does this get hit?
+            _evaluatedIncludeUnescaped = taskItem.ItemSpec;
+            _evaluatedIncludeEscaped = taskItem2.EvaluatedIncludeEscaped;
+            _metadata = metadata;
+        }
+
+        public override string ItemSpec
+        {
+            get => _evaluatedIncludeUnescaped;
+            set => throw new NotImplementedException();
+        }
+
+        public Dictionary<string, string> Metadata => _metadata;
+
+        public override int MetadataCount => _metadata.Count;
+
+        public override void CopyMetadataTo(ITaskItem destinationItem)
+        {
+            // This should only by called with a Utilities.TaskItem.
+            if (destinationItem is not IMetadataContainer metadataContainer)
+            {
+                throw new ArgumentException("Type does not implement 'IMetadataContainer'.", nameof(destinationItem));
+            }
+
+            metadataContainer.ImportMetadata(_metadata);
+        }
+
+        public override string GetMetadata(string metadataName) =>
+            EscapingUtilities.UnescapeAll(GetMetadataValueEscaped(metadataName));
+
+        public override string GetMetadataValueEscaped(string metadataName)
+        {
+            if (_metadata.TryGetValue(metadataName, out string? metadataValue))
+            {
+                return metadataValue;
+            }
+
+            if (FileUtilities.ItemSpecModifiers.IsItemSpecModifier(metadataName))
+            {
+                // Current directory is only required full full path evaluation
+                // Because we cache the full path ahead of time, it will never be called.
+                string? dummy = null;
+                metadataValue = FileUtilities.ItemSpecModifiers.GetItemSpecModifier(
+                    null,
+                    _evaluatedIncludeEscaped, // TODO: Is any defining project modifier called?
+                    null,
+                    metadataName,
+                    ref dummy);
+
+                return metadataValue ?? string.Empty;
+            }
+
+            return string.Empty;
+        }
+
+        public override void Translate(ITranslator translator)
+        {
+            translator.Translate(ref _evaluatedIncludeUnescaped);
+            translator.Translate(ref _evaluatedIncludeEscaped);
+            base.Translate(translator);
+        }
+    }
+}

--- a/src/Tasks/AssemblyDependency/Serialization/RarTaskItemOutput.cs
+++ b/src/Tasks/AssemblyDependency/Serialization/RarTaskItemOutput.cs
@@ -1,0 +1,87 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Xml.Serialization;
+using Microsoft.Build.BackEnd;
+using Microsoft.Build.Collections;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Shared;
+using Microsoft.Build.Utilities;
+
+namespace Microsoft.Build.Tasks.AssemblyDependency
+{
+    // Minimal shim for Utilities.TaskItem, which is used for RAR outputs.
+    // Code paths not hit by RAR are unimplmeneted and will throw an exception.
+    // This allows us to emit a smaller serialization payload and optimize hot paths.
+    internal class RarTaskItemOutput : RarTaskItemBase
+    {
+        private bool _isCopyLocalFile;
+
+        private string _evaluatedIncludeEscaped;
+
+        public RarTaskItemOutput()
+            : base()
+        {
+            _evaluatedIncludeEscaped = string.Empty;
+        }
+
+        public RarTaskItemOutput(ITaskItem taskItem, bool isCopyLocalFile)
+        {
+            // This should only be called with a Utilities.TaskItem.
+            if (taskItem is not ITaskItem2 taskItem2)
+            {
+                throw new ArgumentException("Type does not implement 'ITaskItem2'.", nameof(taskItem));
+            }
+
+            _isCopyLocalFile = isCopyLocalFile;
+            _evaluatedIncludeEscaped = taskItem2.EvaluatedIncludeEscaped;
+            _metadata = new Dictionary<string, string>(taskItem2.MetadataCount);
+
+            foreach (DictionaryEntry metadataNameWithValue in taskItem2.CloneCustomMetadataEscaped())
+            {
+                _metadata[(string)metadataNameWithValue.Key!] = (string)metadataNameWithValue.Value!;
+            }
+        }
+
+        public override string EvaluatedIncludeEscaped
+        {
+            get => _evaluatedIncludeEscaped;
+            set => throw new NotImplementedException();
+        }
+
+        public bool IsCopyLocalFile => _isCopyLocalFile;
+
+        public override void CopyMetadataTo(ITaskItem destinationItem)
+        {
+            // This should only be called with a Utilities.TaskItem.
+            if (destinationItem is not IMetadataContainer metadataContainer)
+            {
+                throw new ArgumentException("Type does not implement 'IMetadataContainer'.", nameof(destinationItem));
+            }
+
+            metadataContainer.ImportMetadata(_metadata);
+        }
+
+        public override string GetMetadataValueEscaped(string metadataName)
+        {
+            if (!metadataName.Equals(FileUtilities.ItemSpecModifiers.DefiningProjectFullPath, StringComparison.OrdinalIgnoreCase))
+            {
+                throw new NotImplementedException();
+            }
+
+            // TaskItems created by RAR do not have a defining project.
+            return string.Empty;
+        }
+
+        public override void Translate(ITranslator translator)
+        {
+            translator.Translate(ref _isCopyLocalFile);
+            translator.Translate(ref _evaluatedIncludeEscaped);
+            base.Translate(translator);
+        }
+    }
+}

--- a/src/Tasks/AssemblyDependency/Service/EventQueueBuildEngine.cs
+++ b/src/Tasks/AssemblyDependency/Service/EventQueueBuildEngine.cs
@@ -1,0 +1,195 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using Microsoft.Build.Framework;
+
+namespace Microsoft.Build.Tasks.AssemblyDependency
+{
+    /// <summary>
+    /// Minimal build engine implementation to collect logging events.
+    /// </summary>
+    internal class EventQueueBuildEngine : IBuildEngine10
+    {
+        private class EngineServicesImpl(MessageImportance minimumImportance, bool isTaskInputLoggingEnabled) : EngineServices
+        {
+            public override bool IsTaskInputLoggingEnabled => isTaskInputLoggingEnabled;
+
+            public override bool LogsMessagesOfImportance(MessageImportance importance) => importance <= minimumImportance;
+        }
+
+        internal EventQueueBuildEngine(MessageImportance minimumMessageImportance, bool isTaskInputLoggingEnabled)
+        {
+            EngineServices = new EngineServicesImpl(minimumMessageImportance, isTaskInputLoggingEnabled);
+
+            UnboundedChannelOptions channelOptions = new()
+            {
+                SingleWriter = true,
+                SingleReader = true,
+            };
+            _channel = Channel.CreateUnbounded<RarBuildEventArgs>(channelOptions);
+        }
+
+        public bool IsRunningMultipleNodes => throw new NotImplementedException();
+
+        public bool ContinueOnError => throw new NotImplementedException();
+
+        public int LineNumberOfTaskNode => 0;
+
+        public int ColumnNumberOfTaskNode => 0;
+
+        public string ProjectFileOfTaskNode => string.Empty;
+
+        public bool AllowFailureWithoutError { get; set; }
+
+        public EngineServices EngineServices { get; }
+
+        internal ChannelReader<RarBuildEventArgs> EventQueue => _channel.Reader;
+
+        private readonly Channel<RarBuildEventArgs> _channel;
+
+        public bool BuildProjectFile(
+            string projectFileName,
+            string[] targetNames,
+            IDictionary globalProperties,
+            IDictionary targetOutputs,
+            string toolsVersion) => throw new NotImplementedException();
+
+        public bool BuildProjectFile(
+            string projectFileName,
+            string[] targetNames,
+            IDictionary globalProperties,
+            IDictionary targetOutputs) => throw new NotImplementedException();
+
+        public BuildEngineResult BuildProjectFilesInParallel(
+            string[] projectFileNames,
+            string[] targetNames,
+            IDictionary[] globalProperties,
+            IList<string>[] removeGlobalProperties,
+            string[] toolsVersion,
+            bool returnTargetOutputs) => throw new NotImplementedException();
+
+        public bool BuildProjectFilesInParallel(
+            string[] projectFileNames,
+            string[] targetNames,
+            IDictionary[] globalProperties,
+            IDictionary[] targetOutputsPerProject,
+            string[] toolsVersion,
+            bool useResultsCache,
+            bool unloadProjectsOnCompletion) => throw new NotImplementedException();
+
+        public object GetRegisteredTaskObject(object key, RegisteredTaskObjectLifetime lifetime) => throw new NotImplementedException();
+
+        public void LogCustomEvent(CustomBuildEventArgs e) => throw new NotImplementedException();
+
+        public void LogErrorEvent(BuildErrorEventArgs e)
+        {
+            RarBuildEventArgs buildEventArgs = new()
+            {
+                EventType = RarBuildEventArgsType.Error,
+                Subcategory = e.Subcategory,
+                Code = e.Code,
+                File = e.File,
+                LineNumber = e.LineNumber,
+                ColumnNumber = e.ColumnNumber,
+                EndLineNumber = e.EndLineNumber,
+                EndColumnNumber = e.EndColumnNumber,
+                Message = e.RawMessage,
+                HelpKeyword = e.HelpKeyword,
+                SenderName = e.SenderName,
+                EventTimestamp = e.RawTimestamp.Ticks,
+                MessageArgs = ParseMessageArgs(e.RawArguments),
+            };
+            _channel.Writer.TryWrite(buildEventArgs);
+        }
+
+        public void LogMessageEvent(BuildMessageEventArgs e)
+        {
+            RarBuildEventArgs buildEventArgs = new()
+            {
+                EventType = RarBuildEventArgsType.Message,
+                Subcategory = e.Subcategory,
+                Code = e.Code,
+                File = e.File,
+                LineNumber = e.LineNumber,
+                ColumnNumber = e.ColumnNumber,
+                EndLineNumber = e.EndLineNumber,
+                EndColumnNumber = e.EndColumnNumber,
+                Message = e.RawMessage,
+                HelpKeyword = e.HelpKeyword,
+                SenderName = e.SenderName,
+                Importance = (int)e.Importance,
+                EventTimestamp = e.RawTimestamp.Ticks,
+                MessageArgs = ParseMessageArgs(e.RawArguments),
+            };
+            _channel.Writer.TryWrite(buildEventArgs);
+        }
+
+        public void LogTelemetry(string eventName, IDictionary<string, string> properties) => throw new NotImplementedException();
+
+        public void LogWarningEvent(BuildWarningEventArgs e)
+        {
+            RarBuildEventArgs buildEventArgs = new()
+            {
+                EventType = RarBuildEventArgsType.Warning,
+                Subcategory = e.Subcategory,
+                Code = e.Code,
+                File = e.File,
+                LineNumber = e.LineNumber,
+                ColumnNumber = e.ColumnNumber,
+                EndLineNumber = e.EndLineNumber,
+                EndColumnNumber = e.EndColumnNumber,
+                Message = e.RawMessage,
+                HelpKeyword = e.HelpKeyword,
+                SenderName = e.SenderName,
+                EventTimestamp = e.RawTimestamp.Ticks,
+                MessageArgs = ParseMessageArgs(e.RawArguments),
+            };
+            _channel.Writer.TryWrite(buildEventArgs);
+        }
+
+        private static string[]? ParseMessageArgs(object[]? rawArgs)
+        {
+            if (rawArgs == null)
+            {
+                return null;
+            }
+
+            string[] messageArgs = new string[rawArgs.Length];
+
+            for (int i = 0; i < rawArgs.Length; i++)
+            {
+                messageArgs[i] = Convert.ToString(rawArgs[i], CultureInfo.CurrentCulture) ?? string.Empty;
+            }
+
+            return messageArgs;
+        }
+
+        public void Reacquire() => throw new NotImplementedException();
+
+        public void RegisterTaskObject(object key, object obj, RegisteredTaskObjectLifetime lifetime, bool allowEarlyCollection) =>
+            throw new NotImplementedException();
+
+        public object UnregisterTaskObject(object key, RegisteredTaskObjectLifetime lifetime) => throw new NotImplementedException();
+
+        public void Yield() => throw new NotImplementedException();
+
+        public int RequestCores(int requestedCores) => throw new NotImplementedException();
+
+        public void ReleaseCores(int coresToRelease) => throw new NotImplementedException();
+
+        public bool ShouldTreatWarningAsError(string warningCode) => false;
+
+        public IReadOnlyDictionary<string, string> GetGlobalProperties() => throw new NotImplementedException();
+
+        internal void Complete() => _channel.Writer.Complete();
+    }
+}

--- a/src/Tasks/AssemblyDependency/Service/RarExecutionCache.cs
+++ b/src/Tasks/AssemblyDependency/Service/RarExecutionCache.cs
@@ -1,0 +1,141 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using Microsoft.Build.Shared;
+using Microsoft.Build.Shared.FileSystem;
+
+namespace Microsoft.Build.Tasks.AssemblyDependency
+{
+    internal class RarExecutionCache
+    {
+        private ConcurrentDictionary<ulong, RarExecutionResponse> _evaluationCache { get; } = [];
+
+        private readonly SemaphoreSlim _ioSemaphore;
+
+        internal RarExecutionCache(int ioParallelism)
+        {
+            _ioSemaphore = new SemaphoreSlim(ioParallelism);
+        }
+
+        public async Task<RarExecutionResponse?> GetCachedEvaluation(RarExecutionRequest request)
+        {
+            if (request.ByteHash == 0 || !_evaluationCache.TryGetValue(request.ByteHash, out RarExecutionResponse? cachedEvaluation))
+            {
+                return null;
+            }
+
+            return await IsCacheUpToDate(cachedEvaluation) ? cachedEvaluation : null;
+        }
+
+        private async Task<bool> IsCacheUpToDate(RarExecutionResponse cachedEvaluation)
+        {
+            SystemState cache = cachedEvaluation.Cache!;
+            List<Task<bool>> workerTasks = new(cache.instanceLocalFileStateCache.Count);
+
+            foreach (KeyValuePair<string, SystemState.FileState> kvp in cache.instanceLocalFileStateCache)
+            {
+                string filePath = kvp.Key;
+                DateTime cachedLastWriteTimeUtc = kvp.Value.LastModified;
+
+                workerTasks.Add(Task.Run(async () =>
+                {
+                    await _ioSemaphore.WaitAsync();
+
+                    try
+                    {
+                        bool result = NativeMethodsShared.GetLastWriteFileUtcTime(filePath) == cachedLastWriteTimeUtc;
+
+                        if (!result)
+                        {
+                            Console.WriteLine($"File:'{filePath}',Expected:'{cachedLastWriteTimeUtc}'");
+                        }
+
+                        return result;
+                    }
+                    finally
+                    {
+                        _ioSemaphore.Release();
+                    }
+                }));
+            }
+
+            foreach (KeyValuePair<string, bool> kvp in cache.instanceLocalDirectoryExists)
+            {
+                string directoryPath = kvp.Key;
+                bool cachedDirectoryExists = kvp.Value;
+
+                workerTasks.Add(Task.Run(async () =>
+                {
+                    await _ioSemaphore.WaitAsync();
+
+                    try
+                    {
+                        bool result = FileUtilities.DirectoryExistsNoThrow(directoryPath) == cachedDirectoryExists;
+
+                        if (!result)
+                        {
+                            Console.WriteLine($"Directory:'{directoryPath}',Expected:'{cachedDirectoryExists}'");
+                        }
+
+                        return result;
+                    }
+                    finally
+                    {
+                        _ioSemaphore.Release();
+                    }
+                }));
+            }
+
+            foreach (KeyValuePair<string, string[]> kvp in cache.instanceLocalDirectories)
+            {
+                string directoryPath = kvp.Key;
+                string[] cachedDirectoryEnumeration = kvp.Value;
+
+                workerTasks.Add(Task.Run(async () =>
+                {
+                    await _ioSemaphore.WaitAsync();
+
+                    try
+                    {
+                        bool result = FileSystems.Default.EnumerateDirectories(directoryPath)
+                            .SequenceEqual(cachedDirectoryEnumeration);
+
+                        if (!result)
+                        {
+                            Console.WriteLine($"Enumeration:'{directoryPath}',Expected:'{cachedDirectoryEnumeration}'");
+                        }
+
+                        return result;
+                    }
+                    finally
+                    {
+                        _ioSemaphore.Release();
+                    }
+                }));
+            }
+
+            await Task.WhenAll([.. workerTasks]);
+
+            return workerTasks.All(task => task.Result);
+        }
+
+        public void CacheEvaluation(RarExecutionRequest request, RarExecutionResponse response)
+        {
+            if (request.ByteHash == 0)
+            {
+                return;
+            }
+
+            _evaluationCache[request.ByteHash] = response;
+        }
+    }
+}

--- a/src/Tasks/AssemblyDependency/Service/ResolveAssemblyReferenceNodeBase.cs
+++ b/src/Tasks/AssemblyDependency/Service/ResolveAssemblyReferenceNodeBase.cs
@@ -1,0 +1,140 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.IO.Pipes;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using System.Xml.Serialization;
+using Microsoft.Build.BackEnd;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Internal;
+
+namespace Microsoft.Build.Tasks.AssemblyDependency
+{
+    internal class ResolveAssemblyReferenceNodeBase
+    {
+        protected const int DefaultBufferSizeInBytes = 81_920;
+
+        protected const int ClientConnectTimeout = 5_000;
+
+        protected const int MessageOffsetInBytes = 4;
+
+        protected readonly RarNodeHandshake _handshake = new(HandshakeOptions.None);
+
+        protected readonly string _pipeName;
+
+        protected ResolveAssemblyReferenceNodeBase()
+        {
+            _pipeName = $"msbuild-rar-{_handshake.ComputeHash()}";
+        }
+
+        protected static void Serialize<T>(T message, MemoryStream memoryStream, bool setHash = false)
+            where T : RarSerializableMessageBase, INodePacket, new()
+        {
+            memoryStream.SetLength(MessageOffsetInBytes);
+            memoryStream.Position = MessageOffsetInBytes;
+
+            ITranslator translator = BinaryTranslator.GetWriteTranslator(memoryStream);
+
+            // Skip serialization if the result is cached. 
+            if (message.ByteArray != null)
+            {
+                using BinaryWriter binaryWriter = new(memoryStream, Encoding.Default, leaveOpen: true);
+                binaryWriter.Write(message.ByteArray);
+
+                return;
+            }
+
+            translator.Translate(ref message);
+
+            if (setHash)
+            {
+                message.SetByteString(memoryStream.GetBuffer(), MessageOffsetInBytes, (int)memoryStream.Length - MessageOffsetInBytes);
+            }
+        }
+
+        protected static T Deserialize<T>(byte[] buffer, int messageLength, bool setHash = false)
+            where T : RarSerializableMessageBase, INodePacket, new()
+        {
+            T message = new();
+            using MemoryStream memoryStream = new(buffer, 0, messageLength, writable: true, publiclyVisible: true);
+            memoryStream.Position = MessageOffsetInBytes;
+            ITranslator translator = BinaryTranslator.GetReadTranslator(memoryStream, InterningBinaryReader.PoolingBuffer);
+            translator.Translate(ref message);
+
+            if (setHash)
+            {
+                message.SetByteString(buffer, MessageOffsetInBytes, messageLength - MessageOffsetInBytes);
+            }
+
+            return message;
+        }
+
+        protected static void WritePipe(PipeStream pipe, MemoryStream memoryStream)
+        {
+            memoryStream.Position = 0;
+            memoryStream.CopyTo(pipe);
+        }
+
+        protected static int ReadPipe(PipeStream pipe, byte[] buffer, int offset, int minBytesToRead)
+        {
+            int bytesRead = offset;
+
+            while (bytesRead < minBytesToRead)
+            {
+                int n = pipe.Read(buffer, bytesRead, buffer.Length - bytesRead);
+
+                // If the connection is broken, read operations will not explicitly throw.
+                // This matches the exception thrown by a broken write operation.
+                if (n == 0)
+                {
+                    throw new IOException("Pipe is broken.");
+                }
+
+                bytesRead += n;
+            }
+
+            return bytesRead;
+        }
+
+        protected static void SetMessageLength(MemoryStream memoryStream)
+        {
+            int messageLength = (int)memoryStream.Length - MessageOffsetInBytes;
+
+            memoryStream.Position = 0;
+            using BinaryWriter binaryWriter = new(memoryStream, Encoding.Default, leaveOpen: true);
+            binaryWriter.Write(messageLength);
+        }
+
+        protected static int ParseMessageLength(byte[] buffer)
+        {
+            using MemoryStream memoryStream = new(buffer, 0, MessageOffsetInBytes);
+            using BinaryReader binaryReader = new(memoryStream);
+
+            return MessageOffsetInBytes + binaryReader.ReadInt32();
+        }
+
+        protected static byte[] EnsureBufferSize(byte[] buffer, int requiredSize)
+        {
+            if (requiredSize <= buffer.Length)
+            {
+                return buffer;
+            }
+
+            byte[] newBuffer = new byte[requiredSize];
+            buffer.CopyTo(newBuffer, 0);
+
+            return newBuffer;
+        }
+    }
+}

--- a/src/Tasks/AssemblyDependency/Service/ResolveAssemblyReferenceService.cs
+++ b/src/Tasks/AssemblyDependency/Service/ResolveAssemblyReferenceService.cs
@@ -1,0 +1,101 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.IO.Pipes;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using System.Xml.Serialization;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Internal;
+
+namespace Microsoft.Build.Tasks.AssemblyDependency
+{
+    public class ResolveAssemblyReferenceService : IDisposable
+    {
+        private readonly ResolveAssemblyReferenceServiceWorker[] _workers;
+
+        public ResolveAssemblyReferenceService()
+            : this(Environment.ProcessorCount)
+        {
+        }
+
+        public ResolveAssemblyReferenceService(int degreeOfParallelism)
+        {
+            ConcurrentDictionary<string, byte> seenStateFiles = new(StringComparer.OrdinalIgnoreCase);
+            RarExecutionCache evaluationCache = new(degreeOfParallelism);
+            _workers = new ResolveAssemblyReferenceServiceWorker[degreeOfParallelism];
+
+            for (int i = 0; i < _workers.Length; i++)
+            {
+                ResolveAssemblyReferenceServiceWorker worker = new(
+                    workerId: i.ToString(),
+                    degreeOfParallelism,
+                    evaluationCache,
+                    seenStateFiles);
+                _workers[i] = worker;
+            }
+        }
+
+        public async Task ExecuteAsync(CancellationToken cancellationToken = default)
+        {
+            if (IsServerRunning())
+            {
+                return;
+            }
+
+            Console.WriteLine($"Service started.");
+
+            Task[] serverTasks = new Task[_workers.Length];
+
+            for (int i = 0; i < _workers.Length; i++)
+            {
+                // Force new Tasks to avoid delaying setup if a client immediately connects.
+                // Avoid referencing indexer in the closure.
+                ResolveAssemblyReferenceServiceWorker worker = _workers[i];
+                serverTasks[i] = Task.Run(
+                    () => worker.RunServerAsync(cancellationToken), cancellationToken);
+            }
+
+            try
+            {
+                await Task.WhenAll(serverTasks);
+            }
+            catch (OperationCanceledException)
+            {
+                // Could land here if Task.Run() itself was cancelled and the worker never started.
+            }
+
+            Console.WriteLine($"All workers successfully stopped. Exiting.");
+        }
+
+        private bool IsServerRunning()
+        {
+            return false;
+            // string serverRunningMutexName = $@"Global\msbuild-rar-server-running-{_handshake.ComputeHash()}";
+
+            // // First, check if the server has created the mutex.
+            // // Use a mutex to avoid using a timeout or checking a max pipe instance exception.
+            // bool isRunning = Mutex.TryOpenExisting(serverRunningMutexName, out Mutex? mutex);
+            // mutex?.Dispose();
+
+            // return isRunning;
+        }
+
+        public void Dispose()
+        {
+            foreach (ResolveAssemblyReferenceServiceWorker worker in _workers)
+            {
+                worker.Dispose();
+            }
+        }
+    }
+}

--- a/src/Tasks/AssemblyDependency/Service/ResolveAssemblyReferenceServiceWorker.cs
+++ b/src/Tasks/AssemblyDependency/Service/ResolveAssemblyReferenceServiceWorker.cs
@@ -1,0 +1,432 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.IO.Pipes;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Security.AccessControl;
+using System.Security.Principal;
+using System.Text;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using System.Xml.Serialization;
+using Microsoft.Build.BackEnd;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Internal;
+
+namespace Microsoft.Build.Tasks.AssemblyDependency
+{
+    internal class ResolveAssemblyReferenceServiceWorker : ResolveAssemblyReferenceNodeBase, IDisposable
+    {
+        private const int MaxBuildEventsBeforeFlush = 100;
+
+        private readonly string _workerId;
+
+        private readonly NamedPipeServerStream _pipe;
+
+        private readonly ConcurrentDictionary<string, byte> _seenStateFiles;
+
+        private readonly RarExecutionCache _evaluationCache;
+
+        private readonly Queue<RarBuildEventArgs> _buildEventQueue;
+
+        private readonly byte[] _resuableBuffer = new byte[DefaultBufferSizeInBytes];
+
+        private readonly MemoryStream _memoryStream = new(DefaultBufferSizeInBytes);
+
+        internal ResolveAssemblyReferenceServiceWorker(
+            string workerId,
+            int maxNumberOfServerInstances,
+            RarExecutionCache evaluationCache,
+            ConcurrentDictionary<string, byte> seenStateFiles)
+        {
+            _workerId = workerId;
+            _evaluationCache = evaluationCache;
+            _seenStateFiles = seenStateFiles;
+            _buildEventQueue = new(MaxBuildEventsBeforeFlush);
+
+#if FEATURE_PIPE_SECURITY && FEATURE_NAMED_PIPE_SECURITY_CONSTRUCTOR
+            SecurityIdentifier identifier = WindowsIdentity.GetCurrent().Owner;
+            PipeSecurity security = new();
+
+            // Restrict access to just this account.  We set the owner specifically here, and on the
+            // pipe client side they will check the owner against this one - they must have identical
+            // SIDs or the client will reject this server.  This is used to avoid attacks where a
+            // hacked server creates a less restricted pipe in an attempt to lure us into using it and
+            // then sending build requests to the real pipe client (which is the MSBuild Build Manager.)
+            PipeAccessRule rule = new(identifier, PipeAccessRights.ReadWrite, AccessControlType.Allow);
+            security.AddAccessRule(rule);
+            security.SetOwner(identifier);
+
+            _pipe = new(
+                _pipeName,
+                PipeDirection.InOut,
+                maxNumberOfServerInstances,
+                PipeTransmissionMode.Byte,
+                PipeOptions.None
+#if FEATURE_PIPEOPTIONS_CURRENTUSERONLY
+                | PipeOptions.CurrentUserOnly
+#endif
+                ,
+                0, // Default input buffer
+                0);  // Default output buffer
+                     // TODO: Settings pipe security breaks client connection for unknown reason.
+                     // TODO: Unknown why this breaks, as this is mostly taken from MSBuild Server implementation.
+                     // TODO: Might be an issue on the client implementation and not the server?
+                     // security,
+                     // HandleInheritability.None);
+#else
+            _pipe = new(
+                _pipeName,
+                PipeDirection.InOut,
+                maxNumberOfServerInstances,
+                PipeTransmissionMode.Byte,
+                PipeOptions.None
+#if FEATURE_PIPEOPTIONS_CURRENTUSERONLY
+                | PipeOptions.CurrentUserOnly
+#endif
+                ,
+                0,
+                0);
+#endif
+        }
+
+        internal async Task RunServerAsync(CancellationToken cancellationToken)
+        {
+            try
+            {
+                while (!cancellationToken.IsCancellationRequested)
+                {
+                    await WaitForConnectionAsync(cancellationToken);
+
+                    Stopwatch e2eTime = new();
+                    e2eTime.Start();
+                    Console.WriteLine($"({_workerId}) Connected to client.");
+
+                    try
+                    {
+
+                        RarExecutionRequest request = ReadRequest();
+                        RarExecutionResponse response = await ResolveAssemblyReferencesAsync(request, cancellationToken);
+                        SendResponse(response);
+
+                        // Avoid replaying build events on future runs.
+                        response.BuildEventArgsQueue = [];
+
+                        if (NativeMethodsShared.IsWindows)
+                        {
+                            _pipe.WaitForPipeDrain();
+                        }
+
+                        e2eTime.Stop();
+                        Console.WriteLine($"({_workerId}) Request completed for '{request.TargetPath}' in {e2eTime.ElapsedMilliseconds} ms.");
+                    }
+                    catch (Exception e) when (e is not OperationCanceledException)
+                    {
+                        Console.Error.WriteLine(e);
+                    }
+
+                    _pipe.Disconnect();
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                // Swallow cancellation excpetions for now. We're using this as a simple way to gracefully shutdown the
+                // server, instead of having to implement separate Start / Stop methods and deferring to the caller.
+                // Can reevaluate if we need more granular control over cancellation vs shutdown.
+            }
+        }
+
+        private async Task WaitForConnectionAsync(CancellationToken cancellationToken)
+        {
+            await _pipe.WaitForConnectionAsync(cancellationToken);
+            bool gotValidConnection = false;
+
+            while (!gotValidConnection)
+            {
+                try
+                {
+                    gotValidConnection = PerformHandshake();
+                }
+                catch (IOException e)
+                {
+                    // We will get here when:
+                    // 1. The host (OOP main node) connects to us, it immediately checks for user privileges
+                    //    and if they don't match it disconnects immediately leaving us still trying to read the blank handshake
+                    // 2. The host is too old sending us bits we automatically reject in the handshake
+                    // 3. We expected to read the EndOfHandshake signal, but we received something else
+                    CommunicationsUtilities.Trace("Client connection failed but we will wait for another connection. Exception: {0}", e.Message);
+                }
+                catch (InvalidOperationException)
+                {
+                }
+
+                if (!gotValidConnection && _pipe.IsConnected)
+                {
+                    if (NativeMethodsShared.IsWindows)
+                    {
+                        _pipe.WaitForPipeDrain();
+                    }
+
+                    _pipe.Disconnect();
+                }
+            }
+        }
+
+        private bool PerformHandshake()
+        {
+            int[] handshakeComponents = _handshake.RetrieveHandshakeComponents();
+            for (int i = 0; i < handshakeComponents.Length; i++)
+            {
+#pragma warning disable SA1111, SA1009 // Closing parenthesis should be on line of last parameter
+                int handshakePart = _pipe.ReadIntForHandshake(
+                    byteToAccept: i == 0 ? CommunicationsUtilities.handshakeVersion : null /* this will disconnect a < 16.8 host; it expects leading 00 or F5 or 06. 0x00 is a wildcard */
+#if NETCOREAPP2_1_OR_GREATER
+                , ClientConnectTimeout /* wait a long time for the handshake from this side */
+#endif
+                );
+#pragma warning restore SA1111, SA1009 // Closing parenthesis should be on line of last parameter
+
+                if (handshakePart != handshakeComponents[i])
+                {
+                    CommunicationsUtilities.Trace("Handshake failed. Received {0} from host not {1}. Probably the host is a different MSBuild build.", handshakePart, handshakeComponents[i]);
+                    _pipe.WriteIntForHandshake(i + 1);
+                    return false;
+                }
+            }
+
+            // To ensure that our handshake and theirs have the same number of bytes, receive and send a magic number indicating EOS.
+#if NETCOREAPP2_1_OR_GREATER
+            _pipe.ReadEndOfHandshakeSignal(false, ClientConnectTimeout); /* wait a long time for the handshake from this side */
+#else
+            _pipe.ReadEndOfHandshakeSignal(false);
+#endif
+            _pipe.WriteEndOfHandshakeSignal();
+
+#if FEATURE_SECURITY_PERMISSIONS
+            // We will only talk to a host that was started by the same user as us.  Even though the pipe access is set to only allow this user, we want to ensure they
+            // haven't attempted to change those permissions out from under us.  This ensures that the only way they can truly gain access is to be impersonating the
+            // user we were started by.
+            WindowsIdentity currentIdentity = WindowsIdentity.GetCurrent();
+            WindowsIdentity? clientIdentity = null;
+            _pipe.RunAsClient(() =>
+            {
+                clientIdentity = WindowsIdentity.GetCurrent(true);
+            });
+
+            if (clientIdentity == null || !string.Equals(clientIdentity.Name, currentIdentity.Name, StringComparison.OrdinalIgnoreCase))
+            {
+                CommunicationsUtilities.Trace("Handshake failed. Host user is {0} but we were created by {1}.", (clientIdentity == null) ? "<unknown>" : clientIdentity.Name, currentIdentity.Name);
+                return false;
+            }
+#endif
+            return true;
+        }
+
+        private RarExecutionRequest ReadRequest()
+        {
+            // Read raw bytes to a temporary buffer to reduce IO calls.
+            int bytesRead = ReadPipe(_pipe, _resuableBuffer, 0, MessageOffsetInBytes);
+            int messageLength = ParseMessageLength(_resuableBuffer);
+
+            // Additional reads for the remaining message.
+            byte[] buffer = EnsureBufferSize(_resuableBuffer, messageLength);
+            ReadPipe(_pipe, buffer, bytesRead, messageLength);
+
+            Console.WriteLine($"({_workerId}) Received request of size: '{messageLength}'");
+
+            return Deserialize<RarExecutionRequest>(buffer, messageLength, setHash: true);
+        }
+
+        private void SendResponse(RarExecutionResponse response)
+        {
+            // Serialize to temporary buffer to reduce IO calls.
+            Serialize(response, _memoryStream, setHash: true);
+            SetMessageLength(_memoryStream);
+            WritePipe(_pipe, _memoryStream);
+
+            Console.WriteLine($"({_workerId}) Sent response of size: '{_memoryStream.Length}'");
+        }
+
+        private async Task<RarExecutionResponse> ResolveAssemblyReferencesAsync(RarExecutionRequest request, CancellationToken cancellationToken)
+        {
+            bool isCacheable = request.StateFile != null;
+
+            if (isCacheable)
+            {
+                RarExecutionResponse? cachedResult = await _evaluationCache.GetCachedEvaluation(request);
+
+                if (cachedResult != null)
+                {
+                    Console.WriteLine($"({_workerId}) Cache hit for '{request.TargetPath}'. Skipping RAR.')");
+                    return cachedResult;
+                }
+            }
+
+            Console.WriteLine($"({_workerId}) Executing RAR for '{request.TargetPath}'.");
+            Stopwatch execTime = new();
+            execTime.Start();
+
+            EventQueueBuildEngine buildEngine = new(
+                (MessageImportance)request.MinimumMessageImportance,
+                request.IsTaskLoggingEnabled);
+            Task buildEventTask = Task.Run(
+                () => ProcessBuildEvents(buildEngine, cancellationToken),
+                cancellationToken);
+            RarExecutionResponse result = HandleRequest(request, buildEngine);
+
+            execTime.Stop();
+            Console.WriteLine($"({_workerId}) RAR completed for '{request.TargetPath}' in {execTime.ElapsedMilliseconds} ms.'");
+            buildEngine.Complete();
+
+            await buildEventTask;
+
+            result.BuildEventArgsQueue = [.. _buildEventQueue];
+            _buildEventQueue.Clear();
+
+            if (isCacheable)
+            {
+                _evaluationCache.CacheEvaluation(request, result);
+            }
+
+            return result;
+        }
+
+        private async Task ProcessBuildEvents(EventQueueBuildEngine buildEngine, CancellationToken cancellationToken)
+        {
+            try
+            {
+                while (cancellationToken.IsCancellationRequested)
+                {
+                    RarBuildEventArgs buildEventArgs = await buildEngine.EventQueue.ReadAsync(cancellationToken);
+                    _buildEventQueue.Enqueue(buildEventArgs);
+
+                    if (_buildEventQueue.Count == MaxBuildEventsBeforeFlush)
+                    {
+                        Console.WriteLine($"({_workerId}) Flushing build events.");
+                        RarExecutionResponse response = new()
+                        {
+                            BuildEventArgsQueue = [.. _buildEventQueue],
+                        };
+                        SendResponse(response);
+                        _buildEventQueue.Clear();
+                    }
+                }
+            }
+            catch (ChannelClosedException)
+            {
+            }
+        }
+
+        private RarExecutionResponse HandleRequest(RarExecutionRequest request, EventQueueBuildEngine buildEngine)
+        {
+            // Only load the state file on the first run.
+            bool shouldLoadStateFile = !string.IsNullOrEmpty(request.StateFile) && _seenStateFiles.TryAdd(request.StateFile!, 0);
+
+            ResolveAssemblyReference rarTask = new()
+            {
+                ShouldExecuteOutOfProcess = false,
+                AllowedAssemblyExtensions = [.. request.AllowedAssemblyExtensions],
+                AllowedRelatedFileExtensions = [.. request.AllowedRelatedFileExtensions],
+                AppConfigFile = request.AppConfigFile,
+                Assemblies = [.. request.Assemblies],
+                AssemblyFiles = [.. request.AssemblyFiles],
+                AutoUnify = request.AutoUnify,
+                BuildEngine = buildEngine,
+                CandidateAssemblyFiles = [.. request.CandidateAssemblyFiles],
+                CopyLocalDependenciesWhenParentReferenceInGac = request.CopyLocalDependenciesWhenParentReferenceInGac,
+                DoNotCopyLocalIfInGac = request.DoNotCopyLocalIfInGac,
+                FindDependencies = request.FindDependencies,
+                FindDependenciesOfExternallyResolvedReferences = request.FindDependenciesOfExternallyResolvedReferences,
+                FindRelatedFiles = request.FindRelatedFiles,
+                FindSatellites = request.FindSatellites,
+                FindSerializationAssemblies = request.FindSerializationAssemblies,
+                FullFrameworkAssemblyTables = [.. request.FullFrameworkAssemblyTables],
+                FullFrameworkFolders = [.. request.FullFrameworkFolders],
+                FullTargetFrameworkSubsetNames = [.. request.FullTargetFrameworkSubsetNames],
+                IgnoreDefaultInstalledAssemblySubsetTables = request.IgnoreDefaultInstalledAssemblySubsetTables,
+                IgnoreDefaultInstalledAssemblyTables = request.IgnoreDefaultInstalledAssemblyTables,
+                IgnoreTargetFrameworkAttributeVersionMismatch = request.IgnoreTargetFrameworkAttributeVersionMismatch,
+                IgnoreVersionForFrameworkReferences = request.IgnoreVersionForFrameworkReferences,
+                InstalledAssemblyTables = [.. request.InstalledAssemblyTables],
+                InstalledAssemblySubsetTables = [.. request.InstalledAssemblySubsetTables],
+                LatestTargetFrameworkDirectories = [.. request.LatestTargetFrameworkDirectories],
+                ProfileName = request.ProfileName,
+                ResolvedSDKReferences = [.. request.ResolvedSDKReferences],
+                SearchPaths = [.. request.SearchPaths],
+                Silent = request.Silent,
+                StateFile = shouldLoadStateFile ? request.StateFile : null,
+                SupportsBindingRedirectGeneration = request.SupportsBindingRedirectGeneration,
+                TargetFrameworkDirectories = [.. request.TargetFrameworkDirectories],
+                TargetFrameworkMoniker = request.TargetFrameworkMoniker,
+                TargetFrameworkMonikerDisplayName = request.TargetFrameworkMonikerDisplayName,
+                TargetFrameworkSubsets = [.. request.TargetFrameworkSubsets],
+                TargetFrameworkVersion = request.TargetFrameworkVersion,
+                TargetProcessorArchitecture = request.TargetProcessorArchitecture,
+                TargetedRuntimeVersion = request.TargetedRuntimeVersion,
+                UnresolveFrameworkAssembliesFromHigherFrameworks = request.UnresolveFrameworkAssembliesFromHigherFrameworks,
+                WarnOrErrorOnTargetArchitectureMismatch = request.WarnOrErrorOnTargetArchitectureMismatch,
+            };
+
+            bool success = rarTask.ExecuteInProcess();
+
+            RarExecutionResponse resp = CreateResponse(rarTask, buildEngine, success);
+
+            return resp;
+        }
+
+        private static RarExecutionResponse CreateResponse(
+            ResolveAssemblyReference rarTask,
+            EventQueueBuildEngine buildEngine,
+            bool success)
+        {
+            HashSet<ITaskItem> copyLocalFiles = new(rarTask.CopyLocalFiles);
+
+            RarExecutionResponse resp = new()
+            {
+                IsComplete = true,
+                Success = success,
+                NumCopyLocalFiles = rarTask.CopyLocalFiles.Length,
+                DependsOnNetStandard = rarTask.DependsOnNETStandard,
+                DependsOnSystemRuntime = rarTask.DependsOnSystemRuntime,
+                FilesWritten = ConvertTaskItems(rarTask.FilesWritten),
+                RelatedFiles = ConvertTaskItems(rarTask.RelatedFiles),
+                ResolvedDependencyFiles = ConvertTaskItems(rarTask.ResolvedDependencyFiles),
+                ResolvedFiles = ConvertTaskItems(rarTask.ResolvedFiles),
+                SatelliteFiles = ConvertTaskItems(rarTask.SatelliteFiles),
+                ScatterFiles = ConvertTaskItems(rarTask.ScatterFiles),
+                SerializationAssemblyFiles = ConvertTaskItems(rarTask.SerializationAssemblyFiles),
+                SuggestedRedirects = ConvertTaskItems(rarTask.SuggestedRedirects),
+                UnresolvedAssemblyConflicts = ConvertTaskItems(rarTask.UnresolvedAssemblyConflicts),
+                Cache = rarTask.Cache,
+            };
+
+            return resp;
+
+            RarTaskItemOutput[] ConvertTaskItems(ITaskItem[] taskItems)
+            {
+                RarTaskItemOutput[] responseItems = new RarTaskItemOutput[taskItems.Length];
+
+                for (int i = 0; i < taskItems.Length; i++)
+                {
+                    ITaskItem taskItem = taskItems[i];
+                    responseItems[i] = new RarTaskItemOutput(taskItem, copyLocalFiles.Contains(taskItem));
+                }
+
+                return responseItems;
+            }
+        }
+
+        public void Dispose()
+        {
+            _pipe.Dispose();
+        }
+    }
+}

--- a/src/Tasks/Microsoft.Build.Tasks.csproj
+++ b/src/Tasks/Microsoft.Build.Tasks.csproj
@@ -34,6 +34,11 @@
     <!-- Binary serialization by ITranslatable -->
     <Compile Include="..\Shared\InterningBinaryReader.cs" />
     <Compile Include="..\Shared\TranslatorHelpers.cs" />
+
+    <!-- Node communication -->
+    <Compile Include="..\Shared\CommunicationsUtilities.cs" />
+    <Compile Include="..\Shared\INodePacket.cs" />
+    <Compile Include="..\Shared\NamedPipeUtil.cs" />
   </ItemGroup>
   <ItemGroup>
     <!-- Source Files -->
@@ -66,9 +71,26 @@
     </Compile>
     <Compile Include="AssemblyDependency\AssemblyAttributes.cs" />
     <Compile Include="AssemblyDependency\AssemblyMetadata.cs" />
+    <Compile Include="AssemblyDependency\Client\ResolveAssemblyReferenceClient.cs" />
+    <Compile Include="AssemblyDependency\Serialization\RarBuildEventArgsType.cs" />
+    <Compile Include="AssemblyDependency\Serialization\RarBuildEventArgs.cs" />
+    <Compile Include="AssemblyDependency\Serialization\RarInternedMetadata.cs" />
+    <Compile Include="AssemblyDependency\Serialization\RarInternedMetadataCache.cs" />
+    <Compile Include="AssemblyDependency\Serialization\RarSerializableMessageBase.cs" />
+    <Compile Include="AssemblyDependency\Serialization\RarTaskItemBase.cs" />
+    <Compile Include="AssemblyDependency\Serialization\RarTaskItemInput.cs" />
+    <Compile Include="AssemblyDependency\Serialization\RarTaskItemOutput.cs" />
+    <Compile Include="AssemblyDependency\Serialization\RarExecutionRequest.cs" />
+    <Compile Include="AssemblyDependency\Serialization\RarExecutionResponse.cs" />
+    <Compile Include="AssemblyDependency\Service\EventQueueBuildEngine.cs" />
+    <Compile Include="AssemblyDependency\Service\RarExecutionCache.cs" />
+    <Compile Include="AssemblyDependency\Service\ResolveAssemblyReferenceNodeBase.cs" />
+    <Compile Include="AssemblyDependency\Service\ResolveAssemblyReferenceService.cs" />
+    <Compile Include="AssemblyDependency\Service\ResolveAssemblyReferenceServiceWorker.cs" />
     <Compile Include="CombineTargetFrameworkInfoProperties.cs" />
     <Compile Include="CombineXmlElements.cs" />
     <Compile Include="ConvertToAbsolutePath.cs" />
+    <Compile Include="..\Shared\BuiltInMetadata.cs" />
     <Compile Include="..\Shared\CopyOnWriteDictionary.cs" />
     <Compile Include="..\Shared\ExtensionFoldersRegistryKey.cs">
       <Link>ExtensionFoldersRegistryKey.cs</Link>
@@ -711,5 +733,10 @@
       to include third party notices.
     -->
     <Content Update="@(Content)" Pack="false" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.IO.Hashing" />
+    <PackageReference Include="System.Threading.Channels" />
   </ItemGroup>
 </Project>

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -2373,6 +2373,10 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <ResolveAssemblyReferencesStateFile Condition="'$(DisableRarCache)'!='true' and '$(ResolveAssemblyReferencesStateFile)' == ''">$(IntermediateOutputPath)$(MSBuildProjectFile).AssemblyReference.cache</ResolveAssemblyReferencesStateFile>
     </PropertyGroup>
 
+    <PropertyGroup>
+      <ResolveAssemblyReferencesOutOfProcess Condition="'$(ResolveAssemblyReferencesOutOfProcess)' == ''">false</ResolveAssemblyReferencesOutOfProcess>
+    </PropertyGroup>
+
     <!-- Make an App.Config item that exists when AutoUnify is false. -->
     <ItemGroup>
       <_ResolveAssemblyReferencesApplicationConfigFileForExes Include="@(AppConfigWithTargetPath)" Condition="'$(AutoGenerateBindingRedirects)'=='true' or '$(AutoUnifyAssemblyReferences)'=='false'"/>
@@ -2453,6 +2457,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         FindDependenciesOfExternallyResolvedReferences="$(FindDependenciesOfExternallyResolvedReferences)"
         ContinueOnError="$(ContinueOnError)"
         OutputUnresolvedAssemblyConflicts="$(ResolveAssemblyReferenceOutputUnresolvedAssemblyConflicts)"
+        ShouldExecuteOutOfProcess="$(ResolveAssemblyReferencesOutOfProcess)"
+        TargetPath="$(TargetPath)"
         Condition="'@(Reference)'!='' or '@(_ResolvedProjectReferencePaths)'!='' or '@(_ExplicitReference)' != ''"
         >
 

--- a/src/Tasks/Resources/Strings.resx
+++ b/src/Tasks/Resources/Strings.resx
@@ -1777,6 +1777,9 @@
     <value>Assembly file '{0}' could not be opened -- PE image doesn't contain managed metadata.</value>
     <comment></comment>
   </data>
+  <data name="ResolveAssemblyReference.OutOfProcConnectionTimeout">
+    <value>Connecting to out-of-proc named pipe failed. Falling back to executing in-proc.</value>
+  </data>
   <!--
         The ResolveComReference message bucket is: MSB3281 - MSB3320
 

--- a/src/Tasks/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Resources/xlf/Strings.cs.xlf
@@ -1731,6 +1731,11 @@
       LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
     </note>
       </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.OutOfProcConnectionTimeout">
+        <source>Connecting to out-of-proc named pipe failed. Falling back to executing in-proc.</source>
+        <target state="new">Connecting to out-of-proc named pipe failed. Falling back to executing in-proc.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResolveAssemblyReference.SearchPathAddedByParentAssembly">
         <source>For SearchPath "{0}" (added by referencing assembly "{1}").</source>
         <target state="translated">Pro SearchPath „{0}“ (přidáno odkazem na sestavení „{1}“)</target>

--- a/src/Tasks/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Resources/xlf/Strings.de.xlf
@@ -1731,6 +1731,11 @@
       LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
     </note>
       </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.OutOfProcConnectionTimeout">
+        <source>Connecting to out-of-proc named pipe failed. Falling back to executing in-proc.</source>
+        <target state="new">Connecting to out-of-proc named pipe failed. Falling back to executing in-proc.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResolveAssemblyReference.SearchPathAddedByParentAssembly">
         <source>For SearchPath "{0}" (added by referencing assembly "{1}").</source>
         <target state="translated">Für SearchPath "{0}" (hinzugefügt durch Verweis auf Assembly "{1}").</target>

--- a/src/Tasks/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Resources/xlf/Strings.es.xlf
@@ -1731,6 +1731,11 @@
       LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
     </note>
       </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.OutOfProcConnectionTimeout">
+        <source>Connecting to out-of-proc named pipe failed. Falling back to executing in-proc.</source>
+        <target state="new">Connecting to out-of-proc named pipe failed. Falling back to executing in-proc.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResolveAssemblyReference.SearchPathAddedByParentAssembly">
         <source>For SearchPath "{0}" (added by referencing assembly "{1}").</source>
         <target state="translated">Para SearchPath "{0}" (agregado por el ensamblado de referencia "{1}").</target>

--- a/src/Tasks/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Resources/xlf/Strings.fr.xlf
@@ -1731,6 +1731,11 @@
       LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
     </note>
       </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.OutOfProcConnectionTimeout">
+        <source>Connecting to out-of-proc named pipe failed. Falling back to executing in-proc.</source>
+        <target state="new">Connecting to out-of-proc named pipe failed. Falling back to executing in-proc.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResolveAssemblyReference.SearchPathAddedByParentAssembly">
         <source>For SearchPath "{0}" (added by referencing assembly "{1}").</source>
         <target state="translated">Pour SearchPath « {0} » (ajouté en référençant l’assembly « {1} »).</target>

--- a/src/Tasks/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Resources/xlf/Strings.it.xlf
@@ -1731,6 +1731,11 @@
       LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
     </note>
       </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.OutOfProcConnectionTimeout">
+        <source>Connecting to out-of-proc named pipe failed. Falling back to executing in-proc.</source>
+        <target state="new">Connecting to out-of-proc named pipe failed. Falling back to executing in-proc.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResolveAssemblyReference.SearchPathAddedByParentAssembly">
         <source>For SearchPath "{0}" (added by referencing assembly "{1}").</source>
         <target state="translated">Per SearchPath "{0}" (aggiunto facendo riferimento all'assembly "{1}").</target>

--- a/src/Tasks/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ja.xlf
@@ -1731,6 +1731,11 @@
       LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
     </note>
       </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.OutOfProcConnectionTimeout">
+        <source>Connecting to out-of-proc named pipe failed. Falling back to executing in-proc.</source>
+        <target state="new">Connecting to out-of-proc named pipe failed. Falling back to executing in-proc.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResolveAssemblyReference.SearchPathAddedByParentAssembly">
         <source>For SearchPath "{0}" (added by referencing assembly "{1}").</source>
         <target state="translated">SearchPath "{0}" の場合 (アセンブリ "{1}" を参照して追加)。</target>

--- a/src/Tasks/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ko.xlf
@@ -1731,6 +1731,11 @@
       LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
     </note>
       </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.OutOfProcConnectionTimeout">
+        <source>Connecting to out-of-proc named pipe failed. Falling back to executing in-proc.</source>
+        <target state="new">Connecting to out-of-proc named pipe failed. Falling back to executing in-proc.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResolveAssemblyReference.SearchPathAddedByParentAssembly">
         <source>For SearchPath "{0}" (added by referencing assembly "{1}").</source>
         <target state="translated">SearchPath "{0}"의 경우(어셈블리 "{1}"을(를) 참조하여 추가됨).</target>

--- a/src/Tasks/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Resources/xlf/Strings.pl.xlf
@@ -1731,6 +1731,11 @@
       LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
     </note>
       </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.OutOfProcConnectionTimeout">
+        <source>Connecting to out-of-proc named pipe failed. Falling back to executing in-proc.</source>
+        <target state="new">Connecting to out-of-proc named pipe failed. Falling back to executing in-proc.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResolveAssemblyReference.SearchPathAddedByParentAssembly">
         <source>For SearchPath "{0}" (added by referencing assembly "{1}").</source>
         <target state="translated">Dla elementu SearchPath „{0}” (dodanego przez odwołanie do zestawu „{1}”).</target>

--- a/src/Tasks/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Resources/xlf/Strings.pt-BR.xlf
@@ -1731,6 +1731,11 @@
       LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
     </note>
       </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.OutOfProcConnectionTimeout">
+        <source>Connecting to out-of-proc named pipe failed. Falling back to executing in-proc.</source>
+        <target state="new">Connecting to out-of-proc named pipe failed. Falling back to executing in-proc.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResolveAssemblyReference.SearchPathAddedByParentAssembly">
         <source>For SearchPath "{0}" (added by referencing assembly "{1}").</source>
         <target state="translated">Para o SearchPath "{0}" (adicionado ao fazer referência ao assembly "{1}").</target>

--- a/src/Tasks/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ru.xlf
@@ -1731,6 +1731,11 @@
       LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
     </note>
       </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.OutOfProcConnectionTimeout">
+        <source>Connecting to out-of-proc named pipe failed. Falling back to executing in-proc.</source>
+        <target state="new">Connecting to out-of-proc named pipe failed. Falling back to executing in-proc.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResolveAssemblyReference.SearchPathAddedByParentAssembly">
         <source>For SearchPath "{0}" (added by referencing assembly "{1}").</source>
         <target state="translated">Для SearchPath "{0}" (добавлено путем ссылки на сборку "{1}").</target>

--- a/src/Tasks/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Resources/xlf/Strings.tr.xlf
@@ -1731,6 +1731,11 @@
       LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
     </note>
       </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.OutOfProcConnectionTimeout">
+        <source>Connecting to out-of-proc named pipe failed. Falling back to executing in-proc.</source>
+        <target state="new">Connecting to out-of-proc named pipe failed. Falling back to executing in-proc.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResolveAssemblyReference.SearchPathAddedByParentAssembly">
         <source>For SearchPath "{0}" (added by referencing assembly "{1}").</source>
         <target state="translated">"{0}" SearchPath için ("{1}" başvuru derlemesi tarafından eklendi).</target>

--- a/src/Tasks/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Resources/xlf/Strings.zh-Hans.xlf
@@ -1731,6 +1731,11 @@
       LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
     </note>
       </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.OutOfProcConnectionTimeout">
+        <source>Connecting to out-of-proc named pipe failed. Falling back to executing in-proc.</source>
+        <target state="new">Connecting to out-of-proc named pipe failed. Falling back to executing in-proc.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResolveAssemblyReference.SearchPathAddedByParentAssembly">
         <source>For SearchPath "{0}" (added by referencing assembly "{1}").</source>
         <target state="translated">对于 SearchPath“{0}”(通过引用程序集“{1}”添加)。</target>

--- a/src/Tasks/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Resources/xlf/Strings.zh-Hant.xlf
@@ -1731,6 +1731,11 @@
       LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
     </note>
       </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.OutOfProcConnectionTimeout">
+        <source>Connecting to out-of-proc named pipe failed. Falling back to executing in-proc.</source>
+        <target state="new">Connecting to out-of-proc named pipe failed. Falling back to executing in-proc.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResolveAssemblyReference.SearchPathAddedByParentAssembly">
         <source>For SearchPath "{0}" (added by referencing assembly "{1}").</source>
         <target state="translated">針對 SearchPath "{0}" (由參考組件 "{1}" 新增)。</target>

--- a/src/Tasks/SystemState.cs
+++ b/src/Tasks/SystemState.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Build.Tasks
         /// Cache at the SystemState instance level. Has the same contents as <see cref="instanceLocalFileStateCache"/>.
         /// It acts as a flag to enforce that an entry has been checked for staleness only once.
         /// </summary>
-        private Dictionary<string, FileState> upToDateLocalFileStateCache = new Dictionary<string, FileState>(StringComparer.OrdinalIgnoreCase);
+        internal Dictionary<string, FileState> upToDateLocalFileStateCache = new Dictionary<string, FileState>(StringComparer.OrdinalIgnoreCase);
 
         /// <summary>
         /// Cache at the SystemState instance level.
@@ -51,21 +51,21 @@ namespace Microsoft.Build.Tasks
         /// cache this for long periods of time since there's no way (without actually
         /// calling File.GetLastWriteTimeUtc) to tell whether the cache is out-of-date.
         /// </summary>
-        private Dictionary<string, DateTime> instanceLocalLastModifiedCache = new Dictionary<string, DateTime>(StringComparer.OrdinalIgnoreCase);
+        internal Dictionary<string, DateTime> instanceLocalLastModifiedCache = new Dictionary<string, DateTime>(StringComparer.OrdinalIgnoreCase);
 
         /// <summary>
         /// DirectoryExists information is purely instance-local. It doesn't make sense to
         /// cache this for long periods of time since there's no way (without actually
         /// calling Directory.Exists) to tell whether the cache is out-of-date.
         /// </summary>
-        private Dictionary<string, bool> instanceLocalDirectoryExists = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
+        internal Dictionary<string, bool> instanceLocalDirectoryExists = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
 
         /// <summary>
         /// GetDirectories information is also purely instance-local. This information
         /// is only considered good for the lifetime of the task (or whatever) that owns
         /// this instance.
         /// </summary>
-        private Dictionary<string, string[]> instanceLocalDirectories = new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase);
+        internal Dictionary<string, string[]> instanceLocalDirectories = new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase);
 
         /// <summary>
         /// Additional level of caching kept at the process level.

--- a/src/Utilities/TaskItem.cs
+++ b/src/Utilities/TaskItem.cs
@@ -13,6 +13,7 @@ using System.Security;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
 using Microsoft.Build.Collections;
+using System.IO;
 
 #nullable disable
 
@@ -138,6 +139,7 @@ namespace Microsoft.Build.Utilities
                 _definingProject = sourceItemAsITaskItem2.GetMetadataValueEscaped(FileUtilities.ItemSpecModifiers.DefiningProjectFullPath);
             }
 
+            _metadata = new CopyOnWriteDictionary<string>(MSBuildNameIgnoreCaseComparer.Default);
             sourceItem.CopyMetadataTo(this);
         }
 


### PR DESCRIPTION
Draft implementation for RAR-as-a-service.

### Known issues

The MSBuild node integration was the last piece implemented, so isn't as thoroughly designed / tested as everything else. I've largely tested this project as a standalone process (the executable produced by `RarTest.csproj`) to use as a baseline for performance. The node integration is still WIP and I'm moving stuff around, but here are the active items:

- [ ] Right now there's multiple options of command line flag, MSBuild property, and environment variable to enable / disable the RAR server, since I've been testing different approaches. There's a trickiness here since the *RAR Task* needs to be able to know whether the current build should run out-of-proc, but there doesn't seem to be a very clean way to propagate this.
- [ ] Node exclusivity isn't fully worked out e.g. still playing with using mutex vs just named pipe existence. Some of this is commented out. Needs to work for the quickbuild scenario where MSBuild is invoked per-project, so we need to avoid race conditions.
- [ ] RAR MSBuild node performs worse on first, even second run, compared to manually running `RarTest.exe` which is functionally the same. Unsure what causes this difference since the node is always done with setup by the time the RAR task is reached. Possibly related to multiple nodes being launched.
- [ ] Passing the RAR flag appears to cause multiple long-lived nodes to be launched from a single /m:1 MSBuild invocation. I suspect these are duplicate RAR nodes, but I haven't figured out what code path is triggering this or an easy way to validate since the processes are all `MSBuild.exe`.
- [ ] As such, haven't tested MSBuild node implementation on multi-proc.
- [ ] Logging needs to be standardized and doesn't seem to be produced under the `Temp\MSBuildTemp\` dir despite using `CommunicationsUtilities.Trace().
- [ ] Passing `PipeSecurity` to named pipe breaks ability to connect, so temporarily commented out (unknown why this pattern doesn't affect other node implementations)
- [ ] The client and server are similar to `BackEnd\Components\Communications\NodeProviderOutOfProcBase` and  `Shared\NodeEndpointOutOfProcBase`, so would ideally be derived. Unfortunately, the former has too many dependencies in `Microsoft.Build.csproj` to easily refactor into `Shared`. The latter forces the named pipe to have a single server and keep a long-lived connection to the client, and is written around this assumption. This model does not work given multiple MSBuild nodes must send/receive on the pipe at any given time, even with an internal message queue (I've tried).

