### PR TITLE
Microsoft.Common.CurrentVersion.targets: _SplitProjectReferencesByFileExistence DependsOn AssignProjectConfiguration

### DIFF
--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -1639,7 +1639,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     -->
 
   <Target
-    Name="_SplitProjectReferencesByFileExistence">
+    Name="_SplitProjectReferencesByFileExistence"
+    DependsOnTargets="AssignProjectConfiguration">
 
     <!--
         Use this task for matching projects with pre-resolved project outputs set by the IDE


### PR DESCRIPTION
When [GetCopyToPublishDirectoryItems from Microsoft.NET.Publish.targets](https://github.com/dotnet/sdk/blob/124be385f90f2c305dde2b817cb470e4d11d2d6b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets#L788) is called on its own, the depends tree terminates at _SplitProjectReferencesByFileExistence
[_SplitProjectReferencesByFileExistence tries to use @(ProjectReferenceWithConfiguration) ](https://github.com/dotnet/msbuild/blob/main/src/Tasks/Microsoft.Common.CurrentVersion.targets#L1642), which is empty, because it is emitted by AssignProjectConfiguration, which isn't actually called.
This causes the Publish action to not pick up output of project's ProjectReferences, since they are completely ignored.

### Failed call missing projectreferences, AssignProjectConfiguration is not called:
![image](https://github.com/user-attachments/assets/4d3b6347-fa00-4810-9108-e8662a2897ab)
### Normal call as part of Publish, AssignProjectConfiguration runs as a dependency of ResolveReferences:
![Screenshot 2024-12-18 111137](https://github.com/user-attachments/assets/b8f85ef1-1abb-4c99-85a5-359d02491b8b)
![image](https://github.com/user-attachments/assets/e9e8c5ac-fb63-4652-9c05-36e5e946ffb3)

Add the target to the dependson list to ensure that @(ProjectReferenceWithConfiguration) contains something and all projectreferences output is picked up as expected.