### PR TITLE
Prevent reading from .rsp file for worker nodes

### DIFF
--- a/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProc.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProc.cs
@@ -94,7 +94,7 @@ namespace Microsoft.Build.BackEnd
             // want to start up just a standard MSBuild out-of-proc node.
             // Note: We need to always pass /nodeReuse to ensure the value for /nodeReuse from msbuild.rsp
             // (next to msbuild.exe) is ignored.
-            string commandLineArgs = $"/nologo /nodemode:1 /nodeReuse:{ComponentHost.BuildParameters.EnableNodeReuse.ToString().ToLower()} /low:{ComponentHost.BuildParameters.LowPriority.ToString().ToLower()}";
+            string commandLineArgs = $" /noautoresponse /nologo /nodemode:1 /nodeReuse:{ComponentHost.BuildParameters.EnableNodeReuse.ToString().ToLower()} /low:{ComponentHost.BuildParameters.LowPriority.ToString().ToLower()}";
 
             CommunicationsUtilities.Trace("Starting to acquire {1} new or existing node(s) to establish nodes from ID {0} to {2}...", nextNodeId, numberOfNodesToCreate, nextNodeId + numberOfNodesToCreate - 1);
 

--- a/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProc.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProc.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -94,7 +94,7 @@ namespace Microsoft.Build.BackEnd
             // want to start up just a standard MSBuild out-of-proc node.
             // Note: We need to always pass /nodeReuse to ensure the value for /nodeReuse from msbuild.rsp
             // (next to msbuild.exe) is ignored.
-            string commandLineArgs = $" /noautoresponse /nologo /nodemode:1 /nodeReuse:{ComponentHost.BuildParameters.EnableNodeReuse.ToString().ToLower()} /low:{ComponentHost.BuildParameters.LowPriority.ToString().ToLower()}";
+            string commandLineArgs = $"/noautoresponse /nologo /nodemode:1 /nodeReuse:{ComponentHost.BuildParameters.EnableNodeReuse.ToString().ToLower()} /low:{ComponentHost.BuildParameters.LowPriority.ToString().ToLower()}";
 
             CommunicationsUtilities.Trace("Starting to acquire {1} new or existing node(s) to establish nodes from ID {0} to {2}...", nextNodeId, numberOfNodesToCreate, nextNodeId + numberOfNodesToCreate - 1);
 

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -1973,7 +1973,9 @@ namespace Microsoft.Build.CommandLine
 #else
             string[] commandLine,
 #endif
-            out CommandLineSwitches switchesFromAutoResponseFile, out CommandLineSwitches switchesNotFromAutoResponseFile, out string fullCommandLine)
+            out CommandLineSwitches switchesFromAutoResponseFile,
+            out CommandLineSwitches switchesNotFromAutoResponseFile,
+            out string fullCommandLine)
         {
             ResetGatheringSwitchesState();
 
@@ -2011,12 +2013,17 @@ namespace Microsoft.Build.CommandLine
             switchesNotFromAutoResponseFile = new CommandLineSwitches();
             GatherCommandLineSwitches(commandLineArgs, switchesNotFromAutoResponseFile, fullCommandLine);
 
-            // parse the auto-response file (if "/noautoresponse" is not specified), and combine those switches with the
-            // switches on the command line
             switchesFromAutoResponseFile = new CommandLineSwitches();
-            if (!switchesNotFromAutoResponseFile[CommandLineSwitches.ParameterlessSwitch.NoAutoResponse])
+
+            // Response files should NOT be used on the worker nodes.
+            if (!commandLineArgs.Any(cla => cla.Contains("nodemode:") || cla.Contains("nmode:")))
             {
-                GatherAutoResponseFileSwitches(s_exePath, switchesFromAutoResponseFile, fullCommandLine);
+                // parse the auto-response file (if "/noautoresponse" is not specified), and combine those switches with the
+                // switches on the command line
+                if (!switchesNotFromAutoResponseFile[CommandLineSwitches.ParameterlessSwitch.NoAutoResponse])
+                {
+                    GatherAutoResponseFileSwitches(s_exePath, switchesFromAutoResponseFile, fullCommandLine);
+                }
             }
         }
 

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -1973,9 +1973,7 @@ namespace Microsoft.Build.CommandLine
 #else
             string[] commandLine,
 #endif
-            out CommandLineSwitches switchesFromAutoResponseFile,
-            out CommandLineSwitches switchesNotFromAutoResponseFile,
-            out string fullCommandLine)
+            out CommandLineSwitches switchesFromAutoResponseFile, out CommandLineSwitches switchesNotFromAutoResponseFile, out string fullCommandLine)
         {
             ResetGatheringSwitchesState();
 
@@ -2013,17 +2011,12 @@ namespace Microsoft.Build.CommandLine
             switchesNotFromAutoResponseFile = new CommandLineSwitches();
             GatherCommandLineSwitches(commandLineArgs, switchesNotFromAutoResponseFile, fullCommandLine);
 
+            // parse the auto-response file (if "/noautoresponse" is not specified), and combine those switches with the
+            // switches on the command line
             switchesFromAutoResponseFile = new CommandLineSwitches();
-
-            // Response files should NOT be used on the worker nodes.
-            if (!commandLineArgs.Any(cla => cla.Contains("nodemode:") || cla.Contains("nmode:")))
+            if (!switchesNotFromAutoResponseFile[CommandLineSwitches.ParameterlessSwitch.NoAutoResponse])
             {
-                // parse the auto-response file (if "/noautoresponse" is not specified), and combine those switches with the
-                // switches on the command line
-                if (!switchesNotFromAutoResponseFile[CommandLineSwitches.ParameterlessSwitch.NoAutoResponse])
-                {
-                    GatherAutoResponseFileSwitches(s_exePath, switchesFromAutoResponseFile, fullCommandLine);
-                }
+                GatherAutoResponseFileSwitches(s_exePath, switchesFromAutoResponseFile, fullCommandLine);
             }
         }
 


### PR DESCRIPTION
### Context
Sometimes Windows Defender blocks on `MSBuild.rsp` file reading operation (e.g. https://dev.azure.com/devdiv/DevDiv/_workitems/edit/2308633). 
Since response file content isn't needed for worker nodes, we can skip reading from t.

### Changes Made
Add a check for `nodemode:` arg in command like

### Testing
Local testing when rsp file is manually locked.
