### PR TITLE
Fix ambiguous reference for ExceptionHandling class

### DIFF
--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -37,6 +37,7 @@ using Microsoft.Build.Logging;
 using Microsoft.Build.Shared;
 using Microsoft.Build.Shared.Debugging;
 using Microsoft.NET.StringTools;
+using ExceptionHandling = Microsoft.Build.Shared.ExceptionHandling;
 using ForwardingLoggerRecord = Microsoft.Build.Logging.ForwardingLoggerRecord;
 using LoggerDescription = Microsoft.Build.Logging.LoggerDescription;
 

--- a/src/Build/BackEnd/Components/ProjectCache/ProjectCacheService.cs
+++ b/src/Build/BackEnd/Components/ProjectCache/ProjectCacheService.cs
@@ -22,6 +22,7 @@ using Microsoft.Build.Framework;
 using Microsoft.Build.Graph;
 using Microsoft.Build.Internal;
 using Microsoft.Build.Shared;
+using ExceptionHandling = Microsoft.Build.Shared.ExceptionHandling;
 
 namespace Microsoft.Build.Experimental.ProjectCache
 {


### PR DESCRIPTION
The latest daily build of the .NET 10 SDK fails to build the msbuild repo due to the following build error:

```
/repos/dotnet/src/msbuild/src/Build/BackEnd/BuildManager/BuildManager.cs(1330,41): error CS0104: 'ExceptionHandling' is an ambiguous reference between 'Microsoft.Build.Shared.ExceptionHandling' and 'System.Runtime.ExceptionServices.ExceptionHandling' [/repos/dotnet/src/msbuild/src/Build/Microsoft.Build.csproj]
/repos/dotnet/src/msbuild/src/Build/BackEnd/Components/ProjectCache/ProjectCacheService.cs(875,17): error CS0104: 'ExceptionHandling' is an ambiguous reference between 'Microsoft.Build.Shared.ExceptionHandling' and 'System.Runtime.ExceptionServices.ExceptionHandling' [/repos/dotnet/src/msbuild/src/Build/Microsoft.Build.csproj]
/repos/dotnet/src/msbuild/src/Build/BackEnd/BuildManager/BuildManager.cs(1437,57): error CS0104: 'ExceptionHandling' is an ambiguous reference between 'Microsoft.Build.Shared.ExceptionHandling' and 'System.Runtime.ExceptionServices.ExceptionHandling' [/repos/dotnet/src/msbuild/src/Build/Microsoft.Build.csproj]
/repos/dotnet/src/msbuild/src/Build/BackEnd/BuildManager/BuildManager.cs(1448,41): error CS0104: 'ExceptionHandling' is an ambiguous reference between 'Microsoft.Build.Shared.ExceptionHandling' and 'System.Runtime.ExceptionServices.ExceptionHandling' [/repos/dotnet/src/msbuild/src/Build/Microsoft.Build.csproj]
/repos/dotnet/src/msbuild/src/Build/BackEnd/BuildManager/BuildManager.cs(1584,17): error CS0104: 'ExceptionHandling' is an ambiguous reference between 'Microsoft.Build.Shared.ExceptionHandling' and 'System.Runtime.ExceptionServices.ExceptionHandling' [/repos/dotnet/src/msbuild/src/Build/Microsoft.Build.csproj]
/repos/dotnet/src/msbuild/src/Build/BackEnd/BuildManager/BuildManager.cs(1806,49): error CS0104: 'ExceptionHandling' is an ambiguous reference between 'Microsoft.Build.Shared.ExceptionHandling' and 'System.Runtime.ExceptionServices.ExceptionHandling' [/repos/dotnet/src/msbuild/src/Build/Microsoft.Build.csproj]
/repos/dotnet/src/msbuild/src/Build/BackEnd/BuildManager/BuildManager.cs(1879,21): error CS0104: 'ExceptionHandling' is an ambiguous reference between 'Microsoft.Build.Shared.ExceptionHandling' and 'System.Runtime.ExceptionServices.ExceptionHandling' [/repos/dotnet/src/msbuild/src/Build/Microsoft.Build.csproj]
/repos/dotnet/src/msbuild/src/Build/BackEnd/BuildManager/BuildManager.cs(1879,66): error CS0104: 'ExceptionHandling' is an ambiguous reference between 'Microsoft.Build.Shared.ExceptionHandling' and 'System.Runtime.ExceptionServices.ExceptionHandling' [/repos/dotnet/src/msbuild/src/Build/Microsoft.Build.csproj]
/repos/dotnet/src/msbuild/src/Build/BackEnd/BuildManager/BuildManager.cs(2483,44): error CS0104: 'ExceptionHandling' is an ambiguous reference between 'Microsoft.Build.Shared.ExceptionHandling' and 'System.Runtime.ExceptionServices.ExceptionHandling' [/repos/dotnet/src/msbuild/src/Build/Microsoft.Build.csproj]
/repos/dotnet/src/msbuild/src/Build/BackEnd/BuildManager/BuildManager.cs(2484,161): error CS0104: 'ExceptionHandling' is an ambiguous reference between 'Microsoft.Build.Shared.ExceptionHandling' and 'System.Runtime.ExceptionServices.ExceptionHandling' [/repos/dotnet/src/msbuild/src/Build/Microsoft.Build.csproj]
/repos/dotnet/src/msbuild/src/Build/BackEnd/BuildManager/BuildManager.cs(2493,169): error CS0104: 'ExceptionHandling' is an ambiguous reference between 'Microsoft.Build.Shared.ExceptionHandling' and 'System.Runtime.ExceptionServices.ExceptionHandling' [/repos/dotnet/src/msbuild/src/Build/Microsoft.Build.csproj]
/repos/dotnet/src/msbuild/src/Build/BackEnd/BuildManager/BuildManager.cs(2976,41): error CS0104: 'ExceptionHandling' is an ambiguous reference between 'Microsoft.Build.Shared.ExceptionHandling' and 'System.Runtime.ExceptionServices.ExceptionHandling' [/repos/dotnet/src/msbuild/src/Build/Microsoft.Build.csproj]
```

This is due to a conflict in a class name with a new public class from runtime: https://github.com/dotnet/runtime/pull/109806

Fixed by explicitly defining the namespace to use.

This was found as part of the work on https://github.com/dotnet/sdk/pull/45435.