### PR TITLE
Fix casing for UTF8Output propery

### DIFF
--- a/src/MSBuild/MSBuild/Microsoft.Build.CommonTypes.xsd
+++ b/src/MSBuild/MSBuild/Microsoft.Build.CommonTypes.xsd
@@ -2199,7 +2199,7 @@ elementFormDefault="qualified">
     <xs:element name="UseWindowsForms" type="msb:boolean" substitutionGroup="msb:Property" />
     <xs:element name="UseWPF" type="msb:boolean" substitutionGroup="msb:Property" />
     <xs:element name="UseVSHostingProcess" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="UTF8OutPut" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+    <xs:element name="UTF8Output" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
     <xs:element name="VCTargetsPath" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
     <xs:element name="VSTO_TrustAssembliesLocation" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
     <xs:element name="WarningLevel" type="msb:StringPropertyType" substitutionGroup="msb:Property">


### PR DESCRIPTION
A quick search of the SDK installation shows that all usages of this property use the 'Output' form, not 'OutPut'. This doesn't matter from a functionality perspective, but for consistency we should clean it up.

A community member noticed this, so why not fix it up?