### PR TITLE
fix: Update json syntax of merge-flow config

### DIFF
--- a/.config/git-merge-flow-config.jsonc
+++ b/.config/git-merge-flow-config.jsonc
@@ -33,7 +33,7 @@
         // Automate opening PRs to merge msbuild's vs17.12 (SDK 9.0.1xx) into vs17.13 (SDK 9.0.2xx)
         "vs17.12": {
             "MergeToBranch": "vs17.13"
-        }
+        },
         // MSBuild latest release to main
         "vs17.13": {
             "MergeToBranch": "main"


### PR DESCRIPTION
### Context
The merge-flow does not work at the moment due to the syntax error in config file. 
![image](https://github.com/user-attachments/assets/d78d4ab2-b179-44a2-a8c6-9422f9863de5)

Example run: https://github.com/dotnet/msbuild/actions/runs/12409721811/job/34643898223

### Changes Made
Add the missing comma

### Testing
VS Code manual check of valid json