### PR TITLE
Add result for target stop event trace

### DIFF
--- a/src/Build/BackEnd/Components/RequestBuilder/TargetBuilder.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TargetBuilder.cs
@@ -484,7 +484,7 @@ namespace Microsoft.Build.BackEnd
                             // Execute all of the tasks on this target.
                             MSBuildEventSource.Log.TargetStart(currentTargetEntry.Name);
                             await currentTargetEntry.ExecuteTarget(taskBuilder, _requestEntry, _projectLoggingContext, _cancellationToken);
-                            MSBuildEventSource.Log.TargetStop(currentTargetEntry.Name, currentTargetEntry.Result.ResultCode.ToString());
+                            MSBuildEventSource.Log.TargetStop(currentTargetEntry.Name, currentTargetEntry.Result?.ResultCode.ToString() ?? string.Empty);
                         }
 
                         break;

--- a/src/Build/BackEnd/Components/RequestBuilder/TargetBuilder.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TargetBuilder.cs
@@ -484,7 +484,7 @@ namespace Microsoft.Build.BackEnd
                             // Execute all of the tasks on this target.
                             MSBuildEventSource.Log.TargetStart(currentTargetEntry.Name);
                             await currentTargetEntry.ExecuteTarget(taskBuilder, _requestEntry, _projectLoggingContext, _cancellationToken);
-                            MSBuildEventSource.Log.TargetStop(currentTargetEntry.Name);
+                            MSBuildEventSource.Log.TargetStop(currentTargetEntry.Name, currentTargetEntry.Result.ResultCode.ToString());
                         }
 
                         break;

--- a/src/Framework/MSBuildEventSource.cs
+++ b/src/Framework/MSBuildEventSource.cs
@@ -363,7 +363,7 @@ namespace Microsoft.Build.Eventing
 
         /// <param name="targetName">The name of the target being executed.</param>
         /// <param name="result">Target stop result.</param>
-        [Event(44, Keywords = Keywords.All | Keywords.PerformanceLog, Version = 2)]
+        [Event(44, Keywords = Keywords.All | Keywords.PerformanceLog, Version = 1)]
         public void TargetStop(string targetName, string result)
         {
             WriteEvent(44, targetName, result);

--- a/src/Framework/MSBuildEventSource.cs
+++ b/src/Framework/MSBuildEventSource.cs
@@ -362,10 +362,11 @@ namespace Microsoft.Build.Eventing
         }
 
         /// <param name="targetName">The name of the target being executed.</param>
-        [Event(44, Keywords = Keywords.All | Keywords.PerformanceLog)]
-        public void TargetStop(string targetName)
+        /// <param name="result">Target stop result.</param>
+        [Event(44, Keywords = Keywords.All | Keywords.PerformanceLog, Version = 2)]
+        public void TargetStop(string targetName, string result)
         {
-            WriteEvent(44, targetName);
+            WriteEvent(44, targetName, result);
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes [#10975](https://github.com/dotnet/msbuild/issues/10975)

### Context
The stop events didn't report success or failure.

### Changes Made
Pass parameter currentTargetEntry.Result.ResultCode.ToString() to the event log

### Testing

![image](https://github.com/user-attachments/assets/5970c6fc-2817-4695-9cdd-89f56f1ac50d)

### Notes
