### PR TITLE
Log glob failures

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -89,13 +89,13 @@
       <Uri>https://github.com/nuget/nuget.client</Uri>
       <Sha>acc521c647aa484fc2202024f624c7a56bf9fe0f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Net.Compilers.Toolset" Version="4.13.0-3.24575.2">
+    <Dependency Name="Microsoft.Net.Compilers.Toolset" Version="4.13.0-3.24607.3">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>f86856dda7a9acbe86f2bbf356420596d9d72c23</Sha>
+      <Sha>31f8433cb625e2aa74d148005003b21d5e3f67b7</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.SourceBuild.Intermediate.roslyn" Version="4.13.0-3.24575.2">
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.roslyn" Version="4.13.0-3.24607.3">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>f86856dda7a9acbe86f2bbf356420596d9d72c23</Sha>
+      <Sha>31f8433cb625e2aa74d148005003b21d5e3f67b7</Sha>
       <SourceBuild RepoName="roslyn" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="9.0.0-beta.24572.2">

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -62,7 +62,7 @@
     <DotNetCliVersion>$([System.Text.RegularExpressions.Regex]::Match($([System.IO.File]::ReadAllText('$(MSBuildThisFileDirectory)..\global.json')), '"dotnet": "([^"]*)"').Groups.get_Item(1))</DotNetCliVersion>
     <MicrosoftCodeAnalysisCollectionsVersion>4.2.0-1.22102.8</MicrosoftCodeAnalysisCollectionsVersion>
     <MicrosoftDotNetXUnitExtensionsVersion>9.0.0-beta.24572.2</MicrosoftDotNetXUnitExtensionsVersion>
-    <MicrosoftNetCompilersToolsetVersion>4.13.0-3.24575.2</MicrosoftNetCompilersToolsetVersion>
+    <MicrosoftNetCompilersToolsetVersion>4.13.0-3.24607.3</MicrosoftNetCompilersToolsetVersion>
     <NuGetBuildTasksVersion>6.13.0-rc.93</NuGetBuildTasksVersion>
   </PropertyGroup>
   <PropertyGroup Condition="!$(TargetFramework.StartsWith('net4'))">

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -2219,6 +2219,9 @@ Utilization:          {0} Average Utilization: {1:###.0}</value>
   <data name="GlobExpansionFailed" xml:space="preserve">
     <value>An exception occurred while expanding a fileSpec with globs: fileSpec: "{0}", assuming it is a file name. Exception: {1}</value>
   </data>
+  <data name="UnknownLoggingType" xml:space="preserve">
+    <value>Logging type {0} is not understood by {1}.</value>
+  </data>
   <!--
         The Build message bucket is: MSB4000 - MSB4999
 

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -2147,7 +2147,7 @@ Utilization:          {0} Average Utilization: {1:###.0}</value>
   </data>
   <data name="BuildCheck_BC0101_Title" xml:space="preserve">
     <value>Two projects should not share their 'OutputPath' nor 'IntermediateOutputPath' locations.</value>
-	<comment>'OutputPath' and 'IntermediateOutputPath' not to be translated.</comment>
+    <comment>'OutputPath' and 'IntermediateOutputPath' not to be translated.</comment>
   </data>
   <data name="BuildCheck_BC0101_MessageFmt" xml:space="preserve">
     <value>Projects {0} and {1} have conflicting output paths: {2}.</value>
@@ -2166,7 +2166,7 @@ Utilization:          {0} Average Utilization: {1:###.0}</value>
   </data>
   <data name="BuildCheck_BC0103_MessageAddendum" xml:space="preserve">
     <value>'{0}' with value: '{1}'</value>
-	<comment>Will be used as a parameter {0} in previous message.</comment>
+    <comment>Will be used as a parameter {0} in previous message.</comment>
   </data>
   <data name="BuildCheck_BC0104_Title" xml:space="preserve">
     <value>A project should not be referenced via 'Reference' to its output, but rather directly via 'ProjectReference'.</value>
@@ -2176,19 +2176,19 @@ Utilization:          {0} Average Utilization: {1:###.0}</value>
   </data>
   <data name="BuildCheck_BC0105_Title" xml:space="preserve">
     <value>It is recommended to specify explicit 'Culture' metadata, or 'WithCulture=false' metadata with 'EmbeddedResource' item in order to avoid wrong or nondeterministic culture estimation.</value>
-	<comment>Terms in quotes are not to be translated.</comment>
+    <comment>Terms in quotes are not to be translated.</comment>
   </data>
   <data name="BuildCheck_BC0105_MessageFmt" xml:space="preserve">
     <value>Project {0} specifies 'EmbeddedResource' item '{1}', that has possibly a culture denoting extension ('{2}'), but explicit 'Culture' nor 'WithCulture=false' metadata are not specified.</value>
-	<comment>Terms in quotes are not to be translated.</comment>
+    <comment>Terms in quotes are not to be translated.</comment>
   </data>
   <data name="BuildCheck_BC0107_Title" xml:space="preserve">
     <value>'TargetFramework' (singular) and 'TargetFrameworks' (plural) properties should not be specified in the scripts at the same time.</value>
-	  <comment>Terms in quotes are not to be translated.</comment>
+    <comment>Terms in quotes are not to be translated.</comment>
   </data>
   <data name="BuildCheck_BC0107_MessageFmt" xml:space="preserve">
     <value>Project {0} specifies 'TargetFrameworks' property '{1}' and 'TargetFramework' property '{2}' at the same time. This will lead to 'TargetFrameworks' being ignored and build will behave as single-targeted.</value>
-	  <comment>Terms in quotes are not to be translated.</comment>
+    <comment>Terms in quotes are not to be translated.</comment>
   </data>
   <data name="BuildCheck_BC0201_Title" xml:space="preserve">
     <value>A property that is accessed should be declared first.</value>
@@ -2207,6 +2207,9 @@ Utilization:          {0} Average Utilization: {1:###.0}</value>
   </data>
   <data name="BuildCheck_BC0203_MessageFmt" xml:space="preserve">
     <value>Property: '{0}' was declared/initialized, but it was never used.</value>
+  </data>
+  <data name="GlobExpansionFailed" xml:space="preserve">
+    <value>An exception occurred while expanding a fileSpec with globs: fileSpec: "{0}", assuming it is a file name. Exception: {1}</value>
   </data>
   <!--
         The Build message bucket is: MSB4000 - MSB4999

--- a/src/Build/Resources/xlf/Strings.cs.xlf
+++ b/src/Build/Resources/xlf/Strings.cs.xlf
@@ -813,6 +813,11 @@ Chyby: {3}</target>
         <target state="translated">Číst neinicializovanou vlastnost {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="UnknownLoggingType">
+        <source>Logging type {0} is not understood by {1}.</source>
+        <target state="new">Logging type {0} is not understood by {1}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UsingInputCaches">
         <source>Using input build results caches: {0}</source>
         <target state="translated">Použití vstupních mezipamětí pro výsledky sestavení: {0}</target>

--- a/src/Build/Resources/xlf/Strings.cs.xlf
+++ b/src/Build/Resources/xlf/Strings.cs.xlf
@@ -403,6 +403,11 @@
         <target state="translated">MSB3094: Položka {2} odkazuje na {0} položek a položka {3} odkazuje na {1} položek. Musí mít stejný počet položek.</target>
         <note>{StrBegin="MSB3094: "}</note>
       </trans-unit>
+      <trans-unit id="GlobExpansionFailed">
+        <source>An exception occurred while expanding a fileSpec with globs: fileSpec: "{0}", assuming it is a file name. Exception: {1}</source>
+        <target state="new">An exception occurred while expanding a fileSpec with globs: fileSpec: "{0}", assuming it is a file name. Exception: {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IllFormedPropertySpaceInCondition">
         <source>MSB4259: Unexpected space at position "{1}" of condition "{0}". Did you forget to remove a space?</source>
         <target state="translated">MSB4259: Na pozici {1} podmínky {0} je neočekávaná mezera. Nezapomněli jste ji odebrat?</target>

--- a/src/Build/Resources/xlf/Strings.de.xlf
+++ b/src/Build/Resources/xlf/Strings.de.xlf
@@ -813,6 +813,11 @@ Fehler: {3}</target>
         <target state="translated">Nicht initialisierte Eigenschaft "{0}" lesen</target>
         <note />
       </trans-unit>
+      <trans-unit id="UnknownLoggingType">
+        <source>Logging type {0} is not understood by {1}.</source>
+        <target state="new">Logging type {0} is not understood by {1}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UsingInputCaches">
         <source>Using input build results caches: {0}</source>
         <target state="translated">Verwendete Eingabecaches für Buildergebnisse: {0}</target>

--- a/src/Build/Resources/xlf/Strings.de.xlf
+++ b/src/Build/Resources/xlf/Strings.de.xlf
@@ -403,6 +403,11 @@
         <target state="translated">MSB3094: "{2}" verweist auf {0} Element(e), und "{3}" verweist auf {1} Element(e). Die Anzahl von Elementen muss identisch sein.</target>
         <note>{StrBegin="MSB3094: "}</note>
       </trans-unit>
+      <trans-unit id="GlobExpansionFailed">
+        <source>An exception occurred while expanding a fileSpec with globs: fileSpec: "{0}", assuming it is a file name. Exception: {1}</source>
+        <target state="new">An exception occurred while expanding a fileSpec with globs: fileSpec: "{0}", assuming it is a file name. Exception: {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IllFormedPropertySpaceInCondition">
         <source>MSB4259: Unexpected space at position "{1}" of condition "{0}". Did you forget to remove a space?</source>
         <target state="translated">MSB4259: Unerwartetes Leerzeichen an Position "{1}" der Bedingung "{0}". Haben Sie vergessen, ein Leerzeichen zu entfernen?</target>

--- a/src/Build/Resources/xlf/Strings.es.xlf
+++ b/src/Build/Resources/xlf/Strings.es.xlf
@@ -403,6 +403,11 @@
         <target state="translated">MSB3094: "{2}" hace referencia a {0} elementos y "{3}" hace referencia a {1} elementos. Deben tener el mismo número de elementos.</target>
         <note>{StrBegin="MSB3094: "}</note>
       </trans-unit>
+      <trans-unit id="GlobExpansionFailed">
+        <source>An exception occurred while expanding a fileSpec with globs: fileSpec: "{0}", assuming it is a file name. Exception: {1}</source>
+        <target state="new">An exception occurred while expanding a fileSpec with globs: fileSpec: "{0}", assuming it is a file name. Exception: {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IllFormedPropertySpaceInCondition">
         <source>MSB4259: Unexpected space at position "{1}" of condition "{0}". Did you forget to remove a space?</source>
         <target state="translated">MSB4259: Espacio inesperado en la posición "{1}" de la condición "{0}". ¿Olvidó quitar un espacio?</target>

--- a/src/Build/Resources/xlf/Strings.es.xlf
+++ b/src/Build/Resources/xlf/Strings.es.xlf
@@ -813,6 +813,11 @@ Errores: {3}</target>
         <target state="translated">Leer la propiedad no inicializada "{0}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="UnknownLoggingType">
+        <source>Logging type {0} is not understood by {1}.</source>
+        <target state="new">Logging type {0} is not understood by {1}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UsingInputCaches">
         <source>Using input build results caches: {0}</source>
         <target state="translated">Usando las cachés de resultados de compilación: {0}</target>

--- a/src/Build/Resources/xlf/Strings.fr.xlf
+++ b/src/Build/Resources/xlf/Strings.fr.xlf
@@ -403,6 +403,11 @@
         <target state="translated">MSB3094: "{2}" fait référence à {0} élément(s) et "{3}", à {1} élément(s). Ils doivent avoir le même nombre d'éléments.</target>
         <note>{StrBegin="MSB3094: "}</note>
       </trans-unit>
+      <trans-unit id="GlobExpansionFailed">
+        <source>An exception occurred while expanding a fileSpec with globs: fileSpec: "{0}", assuming it is a file name. Exception: {1}</source>
+        <target state="new">An exception occurred while expanding a fileSpec with globs: fileSpec: "{0}", assuming it is a file name. Exception: {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IllFormedPropertySpaceInCondition">
         <source>MSB4259: Unexpected space at position "{1}" of condition "{0}". Did you forget to remove a space?</source>
         <target state="translated">MSB4259: espace inattendu à la position "{1}" de la condition "{0}". Avez-vous oublié de supprimer un espace ?</target>

--- a/src/Build/Resources/xlf/Strings.fr.xlf
+++ b/src/Build/Resources/xlf/Strings.fr.xlf
@@ -813,6 +813,11 @@ Erreurs : {3}</target>
         <target state="translated">Lire la propriété non initialisée "{0}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="UnknownLoggingType">
+        <source>Logging type {0} is not understood by {1}.</source>
+        <target state="new">Logging type {0} is not understood by {1}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UsingInputCaches">
         <source>Using input build results caches: {0}</source>
         <target state="translated">Utilisation des caches de résultats de la build d'entrée : {0}</target>

--- a/src/Build/Resources/xlf/Strings.it.xlf
+++ b/src/Build/Resources/xlf/Strings.it.xlf
@@ -403,6 +403,11 @@
         <target state="translated">MSB3094: "{2}" fa riferimento a {0} elemento/i, mentre "{3}" fa riferimento a {1} elemento/i. Devono avere lo stesso numero di elementi.</target>
         <note>{StrBegin="MSB3094: "}</note>
       </trans-unit>
+      <trans-unit id="GlobExpansionFailed">
+        <source>An exception occurred while expanding a fileSpec with globs: fileSpec: "{0}", assuming it is a file name. Exception: {1}</source>
+        <target state="new">An exception occurred while expanding a fileSpec with globs: fileSpec: "{0}", assuming it is a file name. Exception: {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IllFormedPropertySpaceInCondition">
         <source>MSB4259: Unexpected space at position "{1}" of condition "{0}". Did you forget to remove a space?</source>
         <target state="translated">MSB4259: spazio imprevisto alla posizione "{1}" della condizione "{0}". Si è dimenticato di rimuovere uno spazio?</target>

--- a/src/Build/Resources/xlf/Strings.it.xlf
+++ b/src/Build/Resources/xlf/Strings.it.xlf
@@ -813,6 +813,11 @@ Errori: {3}</target>
         <target state="translated">Legge la proprietà non inizializzata "{0}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="UnknownLoggingType">
+        <source>Logging type {0} is not understood by {1}.</source>
+        <target state="new">Logging type {0} is not understood by {1}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UsingInputCaches">
         <source>Using input build results caches: {0}</source>
         <target state="translated">Uso delle cache dei risultati di compilazione di input: {0}</target>

--- a/src/Build/Resources/xlf/Strings.ja.xlf
+++ b/src/Build/Resources/xlf/Strings.ja.xlf
@@ -813,6 +813,11 @@ Errors: {3}</source>
         <target state="translated">初期化されていないプロパティ "{0}" の読み取り</target>
         <note />
       </trans-unit>
+      <trans-unit id="UnknownLoggingType">
+        <source>Logging type {0} is not understood by {1}.</source>
+        <target state="new">Logging type {0} is not understood by {1}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UsingInputCaches">
         <source>Using input build results caches: {0}</source>
         <target state="translated">次の入力ビルド結果キャッシュを使用しています: {0}</target>

--- a/src/Build/Resources/xlf/Strings.ja.xlf
+++ b/src/Build/Resources/xlf/Strings.ja.xlf
@@ -403,6 +403,11 @@
         <target state="translated">MSB3094: "{2}" は {0} 項目を参照し、"{3}" は {1} 項目を参照します。これらは同じ項目数を持たなければなりません。</target>
         <note>{StrBegin="MSB3094: "}</note>
       </trans-unit>
+      <trans-unit id="GlobExpansionFailed">
+        <source>An exception occurred while expanding a fileSpec with globs: fileSpec: "{0}", assuming it is a file name. Exception: {1}</source>
+        <target state="new">An exception occurred while expanding a fileSpec with globs: fileSpec: "{0}", assuming it is a file name. Exception: {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IllFormedPropertySpaceInCondition">
         <source>MSB4259: Unexpected space at position "{1}" of condition "{0}". Did you forget to remove a space?</source>
         <target state="translated">MSB4259: 条件 "{0}" の位置 "{1}" に予期しないスペースがあります。スペースを削除したか確認してください。</target>

--- a/src/Build/Resources/xlf/Strings.ko.xlf
+++ b/src/Build/Resources/xlf/Strings.ko.xlf
@@ -403,6 +403,11 @@
         <target state="translated">MSB3094: "{2}"은(는) 항목을 {0}개 참조하고 "{3}"은(는) 항목을 {1}개 참조합니다. 참조하는 항목 수는 같아야 합니다.</target>
         <note>{StrBegin="MSB3094: "}</note>
       </trans-unit>
+      <trans-unit id="GlobExpansionFailed">
+        <source>An exception occurred while expanding a fileSpec with globs: fileSpec: "{0}", assuming it is a file name. Exception: {1}</source>
+        <target state="new">An exception occurred while expanding a fileSpec with globs: fileSpec: "{0}", assuming it is a file name. Exception: {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IllFormedPropertySpaceInCondition">
         <source>MSB4259: Unexpected space at position "{1}" of condition "{0}". Did you forget to remove a space?</source>
         <target state="translated">MSB4259: "{0}" 조건의 "{1}" 위치에 예기치 않은 공백이 있습니다. 공백을 제거했는지 확인하세요.</target>

--- a/src/Build/Resources/xlf/Strings.ko.xlf
+++ b/src/Build/Resources/xlf/Strings.ko.xlf
@@ -813,6 +813,11 @@ Errors: {3}</source>
         <target state="translated">초기화되지 않은 속성 "{0}" 읽기</target>
         <note />
       </trans-unit>
+      <trans-unit id="UnknownLoggingType">
+        <source>Logging type {0} is not understood by {1}.</source>
+        <target state="new">Logging type {0} is not understood by {1}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UsingInputCaches">
         <source>Using input build results caches: {0}</source>
         <target state="translated">입력 빌드 결과 캐시 사용: {0}</target>

--- a/src/Build/Resources/xlf/Strings.pl.xlf
+++ b/src/Build/Resources/xlf/Strings.pl.xlf
@@ -403,6 +403,11 @@
         <target state="translated">MSB3094: „{2}” odwołuje się do następującej liczby elementów: {0}, a „{3}” odwołuje się do następującej liczby elementów: {1}. Liczba tych elementów musi być taka sama.</target>
         <note>{StrBegin="MSB3094: "}</note>
       </trans-unit>
+      <trans-unit id="GlobExpansionFailed">
+        <source>An exception occurred while expanding a fileSpec with globs: fileSpec: "{0}", assuming it is a file name. Exception: {1}</source>
+        <target state="new">An exception occurred while expanding a fileSpec with globs: fileSpec: "{0}", assuming it is a file name. Exception: {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IllFormedPropertySpaceInCondition">
         <source>MSB4259: Unexpected space at position "{1}" of condition "{0}". Did you forget to remove a space?</source>
         <target state="translated">MSB4259: Nieoczekiwana spacja na pozycji „{1}” warunku „{0}”. Czy zapomniano o usunięciu spacji?</target>

--- a/src/Build/Resources/xlf/Strings.pl.xlf
+++ b/src/Build/Resources/xlf/Strings.pl.xlf
@@ -813,6 +813,11 @@ Błędy: {3}</target>
         <target state="translated">Odczytaj niezainicjowaną właściwość „{0}”</target>
         <note />
       </trans-unit>
+      <trans-unit id="UnknownLoggingType">
+        <source>Logging type {0} is not understood by {1}.</source>
+        <target state="new">Logging type {0} is not understood by {1}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UsingInputCaches">
         <source>Using input build results caches: {0}</source>
         <target state="translated">Używanie wejściowych pamięci podręcznych wyników kompilacji: {0}</target>

--- a/src/Build/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Build/Resources/xlf/Strings.pt-BR.xlf
@@ -403,6 +403,11 @@
         <target state="translated">MSB3094: "{2}" refere-se ao(s) item(ns) {0} e "{3}" refere-se ao(s) item(ns) {1}. Eles devem ter o mesmo número de itens.</target>
         <note>{StrBegin="MSB3094: "}</note>
       </trans-unit>
+      <trans-unit id="GlobExpansionFailed">
+        <source>An exception occurred while expanding a fileSpec with globs: fileSpec: "{0}", assuming it is a file name. Exception: {1}</source>
+        <target state="new">An exception occurred while expanding a fileSpec with globs: fileSpec: "{0}", assuming it is a file name. Exception: {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IllFormedPropertySpaceInCondition">
         <source>MSB4259: Unexpected space at position "{1}" of condition "{0}". Did you forget to remove a space?</source>
         <target state="translated">MSB4259: espaço inesperado na posição "{1}" da condição "{0}". Você esqueceu de remover um espaço?</target>

--- a/src/Build/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Build/Resources/xlf/Strings.pt-BR.xlf
@@ -813,6 +813,11 @@ Erros: {3}</target>
         <target state="translated">Ler a propriedade não inicializada "{0}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="UnknownLoggingType">
+        <source>Logging type {0} is not understood by {1}.</source>
+        <target state="new">Logging type {0} is not understood by {1}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UsingInputCaches">
         <source>Using input build results caches: {0}</source>
         <target state="translated">Usando caches de resultados de build de entrada: {0}</target>

--- a/src/Build/Resources/xlf/Strings.ru.xlf
+++ b/src/Build/Resources/xlf/Strings.ru.xlf
@@ -403,6 +403,11 @@
         <target state="translated">MSB3094: "{2}" ссылается на следующее число элементов: {0}, а "{3}" — на {1}. Число элементов должно быть одинаковым.</target>
         <note>{StrBegin="MSB3094: "}</note>
       </trans-unit>
+      <trans-unit id="GlobExpansionFailed">
+        <source>An exception occurred while expanding a fileSpec with globs: fileSpec: "{0}", assuming it is a file name. Exception: {1}</source>
+        <target state="new">An exception occurred while expanding a fileSpec with globs: fileSpec: "{0}", assuming it is a file name. Exception: {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IllFormedPropertySpaceInCondition">
         <source>MSB4259: Unexpected space at position "{1}" of condition "{0}". Did you forget to remove a space?</source>
         <target state="translated">MSB4259: неожиданный пробел в позиции "{1}" условия "{0}". Вы забыли удалить пробел?</target>

--- a/src/Build/Resources/xlf/Strings.ru.xlf
+++ b/src/Build/Resources/xlf/Strings.ru.xlf
@@ -813,6 +813,11 @@ Errors: {3}</source>
         <target state="translated">Чтение неинициализированного свойства "{0}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="UnknownLoggingType">
+        <source>Logging type {0} is not understood by {1}.</source>
+        <target state="new">Logging type {0} is not understood by {1}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UsingInputCaches">
         <source>Using input build results caches: {0}</source>
         <target state="translated">Используются входные файлы кэша результатов сборки: {0}</target>

--- a/src/Build/Resources/xlf/Strings.tr.xlf
+++ b/src/Build/Resources/xlf/Strings.tr.xlf
@@ -813,6 +813,11 @@ Hatalar: {3}</target>
         <target state="translated">"{0}" başlatılmamış özelliğini oku</target>
         <note />
       </trans-unit>
+      <trans-unit id="UnknownLoggingType">
+        <source>Logging type {0} is not understood by {1}.</source>
+        <target state="new">Logging type {0} is not understood by {1}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UsingInputCaches">
         <source>Using input build results caches: {0}</source>
         <target state="translated">Giriş derleme sonuçları önbellekleri kullanılıyor: {0}</target>

--- a/src/Build/Resources/xlf/Strings.tr.xlf
+++ b/src/Build/Resources/xlf/Strings.tr.xlf
@@ -403,6 +403,11 @@
         <target state="translated">MSB3094: "{2}", {0} öğeye; "{3}", {1} öğeye başvuruyor. Aynı sayıda öğeye sahip olmaları gerekir.</target>
         <note>{StrBegin="MSB3094: "}</note>
       </trans-unit>
+      <trans-unit id="GlobExpansionFailed">
+        <source>An exception occurred while expanding a fileSpec with globs: fileSpec: "{0}", assuming it is a file name. Exception: {1}</source>
+        <target state="new">An exception occurred while expanding a fileSpec with globs: fileSpec: "{0}", assuming it is a file name. Exception: {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IllFormedPropertySpaceInCondition">
         <source>MSB4259: Unexpected space at position "{1}" of condition "{0}". Did you forget to remove a space?</source>
         <target state="translated">MSB4259: "{0}" koşulunun "{1}" konumunda beklenmeyen boşluk var. Boşluğu kaldırmayı unutmuş olabilirsiniz.</target>

--- a/src/Build/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hans.xlf
@@ -403,6 +403,11 @@
         <target state="translated">MSB3094: “{2}”引用 {0} 个项，而“{3}”引用 {1} 个项。它们必须具有相同的项数。</target>
         <note>{StrBegin="MSB3094: "}</note>
       </trans-unit>
+      <trans-unit id="GlobExpansionFailed">
+        <source>An exception occurred while expanding a fileSpec with globs: fileSpec: "{0}", assuming it is a file name. Exception: {1}</source>
+        <target state="new">An exception occurred while expanding a fileSpec with globs: fileSpec: "{0}", assuming it is a file name. Exception: {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IllFormedPropertySpaceInCondition">
         <source>MSB4259: Unexpected space at position "{1}" of condition "{0}". Did you forget to remove a space?</source>
         <target state="translated">MSB4259: 在条件“{0}”的位置“{1}”处出现意外空格。是否忘记了删除空格?</target>

--- a/src/Build/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hans.xlf
@@ -813,6 +813,11 @@ Errors: {3}</source>
         <target state="translated">读取未初始化的属性“{0}”</target>
         <note />
       </trans-unit>
+      <trans-unit id="UnknownLoggingType">
+        <source>Logging type {0} is not understood by {1}.</source>
+        <target state="new">Logging type {0} is not understood by {1}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UsingInputCaches">
         <source>Using input build results caches: {0}</source>
         <target state="translated">Using 输入生成结果缓存: {0}</target>

--- a/src/Build/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hant.xlf
@@ -813,6 +813,11 @@ Errors: {3}</source>
         <target state="translated">讀取未初始化的屬性 "{0}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="UnknownLoggingType">
+        <source>Logging type {0} is not understood by {1}.</source>
+        <target state="new">Logging type {0} is not understood by {1}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UsingInputCaches">
         <source>Using input build results caches: {0}</source>
         <target state="translated">使用輸入組建結果快取: {0}</target>

--- a/src/Build/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hant.xlf
@@ -403,6 +403,11 @@
         <target state="translated">MSB3094: "{2}" 參考 {0} 個項目，"{3}" 則參考 {1} 個項目。兩者參考的項目數目必須相同。</target>
         <note>{StrBegin="MSB3094: "}</note>
       </trans-unit>
+      <trans-unit id="GlobExpansionFailed">
+        <source>An exception occurred while expanding a fileSpec with globs: fileSpec: "{0}", assuming it is a file name. Exception: {1}</source>
+        <target state="new">An exception occurred while expanding a fileSpec with globs: fileSpec: "{0}", assuming it is a file name. Exception: {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IllFormedPropertySpaceInCondition">
         <source>MSB4259: Unexpected space at position "{1}" of condition "{0}". Did you forget to remove a space?</source>
         <target state="translated">MSB4259: 條件 "{0}" 的位置 "{1}" 出現非預期的空格。忘記移除空格了嗎?</target>

--- a/src/Build/Utilities/EngineFileUtilities.cs
+++ b/src/Build/Utilities/EngineFileUtilities.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -284,7 +284,10 @@ namespace Microsoft.Build.Internal
                             break;
 
                         default:
-                            throw new InternalErrorException($"Logging type {loggingMechanism.GetType()} is not understood by {nameof(GetFileList)}.");
+                            throw new InternalErrorException(ResourceUtilities.FormatResourceStringIgnoreCodeAndKeyword(
+                                "UnknownLoggingType",
+                                loggingMechanism.GetType(),
+                                nameof(GetFileList)));
                     }
                 }
 
@@ -322,7 +325,10 @@ namespace Microsoft.Build.Internal
                             break;
 
                         default:
-                            throw new InternalErrorException($"Logging type {loggingMechanism.GetType()} is not understood by {nameof(GetFileList)}.");
+                            throw new InternalErrorException(ResourceUtilities.FormatResourceStringIgnoreCodeAndKeyword(
+                                "UnknownLoggingType",
+                                loggingMechanism.GetType(),
+                                nameof(GetFileList)));
                     }
                 }
                 else
@@ -349,7 +355,10 @@ namespace Microsoft.Build.Internal
                                 evaluationLoggingContext.LogCommentFromText(MessageImportance.Low, globFailure);
                                 break;
                             default:
-                                throw new InternalErrorException($"Logging type {loggingMechanism.GetType()} is not understood by {nameof(GetFileList)}.");
+                                throw new InternalErrorException(ResourceUtilities.FormatResourceStringIgnoreCodeAndKeyword(
+                                    "UnknownLoggingType",
+                                    loggingMechanism.GetType(),
+                                    nameof(GetFileList)));
                         }
                     }
 

--- a/src/Build/Utilities/EngineFileUtilities.cs
+++ b/src/Build/Utilities/EngineFileUtilities.cs
@@ -332,22 +332,21 @@ namespace Microsoft.Build.Internal
                     // as a relative path, we will get back a bunch of relative paths.
                     // If the filespec started out as an absolute path, we will get
                     // back a bunch of absolute paths
-                    // IEnumerable<BuildMessageEventArgs> events;
-                    (fileList, _, _, BuildMessageEventArgs globFailure) = fileMatcher.GetFiles(directoryUnescaped, filespecUnescaped, excludeSpecsUnescaped);
+                    (fileList, _, _, string globFailure) = fileMatcher.GetFiles(directoryUnescaped, filespecUnescaped, excludeSpecsUnescaped);
 
-                    // log globbing failure with the present logging mechanism
+                    // log globing failure with the present logging mechanism
                     if (globFailure != null)
                     {
                         switch (loggingMechanism)
                         {
                             case TargetLoggingContext targetLoggingContext:
-                                targetLoggingContext.LogCommentFromText(globFailure.Importance, globFailure.Message);
+                                targetLoggingContext.LogCommentFromText(MessageImportance.Low, globFailure);
                                 break;
                             case ILoggingService loggingService:
-                                loggingService.LogCommentFromText(buildEventContext, globFailure.Importance, globFailure.Message);
+                                loggingService.LogCommentFromText(buildEventContext, MessageImportance.Low, globFailure);
                                 break;
                             case EvaluationLoggingContext evaluationLoggingContext:
-                                evaluationLoggingContext.LogCommentFromText(globFailure.Importance, globFailure.Message);
+                                evaluationLoggingContext.LogCommentFromText(MessageImportance.Low, globFailure);
                                 break;
                             default:
                                 throw new InternalErrorException($"Logging type {loggingMechanism.GetType()} is not understood by {nameof(GetFileList)}.");

--- a/src/Shared/FileMatcher.cs
+++ b/src/Shared/FileMatcher.cs
@@ -1896,6 +1896,7 @@ namespace Microsoft.Build.Shared
             public int MaxTasksPerIteration;
         }
 
+#nullable enable
         /// <summary>
         /// Given a filespec, find the files that match.
         /// Will never throw IO exceptions: if there is no match, returns the input verbatim.
@@ -1904,10 +1905,10 @@ namespace Microsoft.Build.Shared
         /// <param name="filespecUnescaped">Get files that match the given file spec.</param>
         /// <param name="excludeSpecsUnescaped">Exclude files that match this file spec.</param>
         /// <returns>The search action, array of files, Exclude file spec (if applicable), and glob failure message (if applicable) .</returns>
-        internal (string[] FileList, SearchAction Action, string ExcludeFileSpec, string GlobFailure) GetFiles(
-            string projectDirectoryUnescaped,
+        internal (string[] FileList, SearchAction Action, string ExcludeFileSpec, string? GlobFailure) GetFiles(
+            string? projectDirectoryUnescaped,
             string filespecUnescaped,
-            List<string> excludeSpecsUnescaped = null)
+            List<string>? excludeSpecsUnescaped = null)
         {
             // For performance. Short-circuit iff there is no wildcard.
             if (!HasWildcards(filespecUnescaped))
@@ -1925,11 +1926,11 @@ namespace Microsoft.Build.Shared
 
             var enumerationKey = ComputeFileEnumerationCacheKey(projectDirectoryUnescaped, filespecUnescaped, excludeSpecsUnescaped);
 
-            IReadOnlyList<string> files;
+            IReadOnlyList<string>? files;
             string[] fileList;
             SearchAction action = SearchAction.None;
             string excludeFileSpec = string.Empty;
-            string globFailure = null;
+            string? globFailure = null;
             if (!_cachedGlobExpansions.TryGetValue(enumerationKey, out files))
             {
                 // avoid parallel evaluations of the same wildcard by using a unique lock for each wildcard
@@ -1958,6 +1959,7 @@ namespace Microsoft.Build.Shared
 
             return (filesToReturn, action, excludeFileSpec, globFailure);
         }
+#nullable disable
 
         private static string ComputeFileEnumerationCacheKey(string projectDirectoryUnescaped, string filespecUnescaped, List<string> excludes)
         {
@@ -2355,6 +2357,7 @@ namespace Microsoft.Build.Shared
             return [filespecUnescaped];
         }
 
+#nullable enable
         /// <summary>
         /// Given a filespec, find the files that match.
         /// Will never throw IO exceptions: if there is no match, returns the input verbatim.
@@ -2362,11 +2365,11 @@ namespace Microsoft.Build.Shared
         /// <param name="projectDirectoryUnescaped">The project directory.</param>
         /// <param name="filespecUnescaped">Get files that match the given file spec.</param>
         /// <param name="excludeSpecsUnescaped">Exclude files that match this file spec.</param>
-        /// <returns>The search action, array of files, and Exclude file spec (if applicable).</returns>
-        private (string[] FileList, SearchAction Action, string ExcludeFileSpec, string globFailureEvent) GetFilesImplementation(
-            string projectDirectoryUnescaped,
+        /// <returns>The search action, array of files, Exclude file spec (if applicable), and glob failure message (if applicable).</returns>
+        private (string[] FileList, SearchAction Action, string ExcludeFileSpec, string? globFailureEvent) GetFilesImplementation(
+            string? projectDirectoryUnescaped,
             string filespecUnescaped,
-            List<string> excludeSpecsUnescaped)
+            List<string>? excludeSpecsUnescaped)
         {
             // UNDONE (perf): Short circuit the complex processing when we only have a path and a wildcarded filename
 
@@ -2394,17 +2397,17 @@ namespace Microsoft.Build.Shared
                 throw new NotSupportedException(action.ToString());
             }
 
-            List<RecursionState> searchesToExclude = null;
+            List<RecursionState>? searchesToExclude = null;
 
             // Exclude searches which will become active when the recursive search reaches their BaseDirectory.
             //  The BaseDirectory of the exclude search is the key for this dictionary.
-            Dictionary<string, List<RecursionState>> searchesToExcludeInSubdirs = null;
+            Dictionary<string, List<RecursionState>>? searchesToExcludeInSubdirs = null;
 
             // Track the search action and exclude file spec for proper detection and logging of drive enumerating wildcards.
             SearchAction trackSearchAction = action;
             string trackExcludeFileSpec = string.Empty;
 
-            HashSet<string> resultsToExclude = null;
+            HashSet<string>? resultsToExclude = null;
             if (excludeSpecsUnescaped != null)
             {
                 searchesToExclude = new List<RecursionState>();
@@ -2478,7 +2481,7 @@ namespace Microsoft.Build.Shared
                             {
                                 searchesToExcludeInSubdirs = new Dictionary<string, List<RecursionState>>(StringComparer.OrdinalIgnoreCase);
                             }
-                            List<RecursionState> listForSubdir;
+                            List<RecursionState>? listForSubdir;
                             if (!searchesToExcludeInSubdirs.TryGetValue(excludeBaseDirectory, out listForSubdir))
                             {
                                 listForSubdir = new List<RecursionState>();
@@ -2622,6 +2625,7 @@ namespace Microsoft.Build.Shared
                 : listOfFiles.SelectMany(list => list).ToArray();
             return (files, trackSearchAction, trackExcludeFileSpec, null);
         }
+#nullable disable
 
         private bool InnerExceptionsAreAllIoRelated(AggregateException ex)
         {

--- a/src/Shared/UnitTests/FileMatcher_Tests.cs
+++ b/src/Shared/UnitTests/FileMatcher_Tests.cs
@@ -1353,7 +1353,7 @@ namespace Microsoft.Build.UnitTests
                     // Set env var to fail on drive enumerating wildcard detection
                     Helpers.ResetStateForDriveEnumeratingWildcardTests(env, "1");
 
-                    (string[] fileList, FileMatcher.SearchAction action, string excludeFileSpec) = FileMatcher.Default.GetFiles(
+                    (string[] fileList, FileMatcher.SearchAction action, string excludeFileSpec, _) = FileMatcher.Default.GetFiles(
                         string.Empty,
                         driveEnumeratingWildcard);
 
@@ -1362,7 +1362,7 @@ namespace Microsoft.Build.UnitTests
                     excludeFileSpec.ShouldBe(string.Empty);
 
                     // Handle failing with drive enumerating exclude
-                    (fileList, action, excludeFileSpec) = FileMatcher.Default.GetFiles(
+                    (fileList, action, excludeFileSpec, _) = FileMatcher.Default.GetFiles(
                         string.Empty,
                         @"/*/*.cs",
                         new List<string> { driveEnumeratingWildcard });
@@ -1394,7 +1394,7 @@ namespace Microsoft.Build.UnitTests
                     // Set env var to log on drive enumerating wildcard detection
                     Helpers.ResetStateForDriveEnumeratingWildcardTests(env, "0");
 
-                    (_, FileMatcher.SearchAction action, string excludeFileSpec) = FileMatcher.Default.GetFiles(
+                    (_, FileMatcher.SearchAction action, string excludeFileSpec, _) = FileMatcher.Default.GetFiles(
                         string.Empty,
                         driveEnumeratingWildcard);
 
@@ -1402,7 +1402,7 @@ namespace Microsoft.Build.UnitTests
                     excludeFileSpec.ShouldBe(string.Empty);
 
                     // Handle logging with drive enumerating exclude
-                    (_, action, excludeFileSpec) = FileMatcher.Default.GetFiles(
+                    (_, action, excludeFileSpec, _) = FileMatcher.Default.GetFiles(
                         string.Empty,
                         @"/*/*.cs",
                         new List<string> { driveEnumeratingWildcard });

--- a/src/Tasks/Copy.cs
+++ b/src/Tasks/Copy.cs
@@ -754,10 +754,10 @@ namespace Microsoft.Build.Tasks
                         string src = FileUtilities.NormalizePath(sourceFolder.ItemSpec);
                         string srcName = Path.GetFileName(src);
 
-                        (string[] filesInFolder, _, _, BuildMessageEventArgs globFailure) = FileMatcher.Default.GetFiles(src, "**");
+                        (string[] filesInFolder, _, _, string globFailure) = FileMatcher.Default.GetFiles(src, "**");
                         if (globFailure != null)
                         {
-                            BuildEngine.LogMessageEvent(globFailure);
+                            Log.LogMessage(MessageImportance.Low, globFailure);
                         }
 
                         foreach (string file in filesInFolder)

--- a/src/Tasks/Copy.cs
+++ b/src/Tasks/Copy.cs
@@ -754,7 +754,11 @@ namespace Microsoft.Build.Tasks
                         string src = FileUtilities.NormalizePath(sourceFolder.ItemSpec);
                         string srcName = Path.GetFileName(src);
 
-                        (string[] filesInFolder, _, _) = FileMatcher.Default.GetFiles(src, "**");
+                        (string[] filesInFolder, _, _, BuildMessageEventArgs globFailure) = FileMatcher.Default.GetFiles(src, "**");
+                        if (globFailure != null)
+                        {
+                            BuildEngine.LogMessageEvent(globFailure);
+                        }
 
                         foreach (string file in filesInFolder)
                         {

--- a/src/Tasks/CreateItem.cs
+++ b/src/Tasks/CreateItem.cs
@@ -178,10 +178,10 @@ namespace Microsoft.Build.Tasks
                         }
                         else if (isLegalFileSpec)
                         {
-                            (files, action, _, BuildMessageEventArgs globFailure) = FileMatcher.Default.GetFiles(null /* use current directory */, i.ItemSpec);
+                            (files, action, _, string globFailure) = FileMatcher.Default.GetFiles(null /* use current directory */, i.ItemSpec);
                             if (globFailure != null)
                             {
-                                BuildEngine.LogMessageEvent(globFailure);
+                                Log.LogMessage(globFailure);
                             }
 
                             foreach (string file in files)

--- a/src/Tasks/CreateItem.cs
+++ b/src/Tasks/CreateItem.cs
@@ -178,7 +178,11 @@ namespace Microsoft.Build.Tasks
                         }
                         else if (isLegalFileSpec)
                         {
-                            (files, action, _) = FileMatcher.Default.GetFiles(null /* use current directory */, i.ItemSpec);
+                            (files, action, _, BuildMessageEventArgs globFailure) = FileMatcher.Default.GetFiles(null /* use current directory */, i.ItemSpec);
+                            if (globFailure != null)
+                            {
+                                BuildEngine.LogMessageEvent(globFailure);
+                            }
 
                             foreach (string file in files)
                             {

--- a/src/Tasks/CreateItem.cs
+++ b/src/Tasks/CreateItem.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -94,6 +94,7 @@ namespace Microsoft.Build.Tasks
             return !Log.HasLoggedErrors;
         }
 
+#nullable enable
         /// <summary>
         /// Create the list of output items.
         /// </summary>
@@ -137,11 +138,10 @@ namespace Microsoft.Build.Tasks
         /// <summary>
         /// Expand wildcards in the item list.
         /// </summary>
-        private (ITaskItem[] Element, bool NoLoggedErrors) TryExpandWildcards(ITaskItem[] expand, string attributeType)
+        private (ITaskItem[]? Element, bool NoLoggedErrors) TryExpandWildcards(ITaskItem[]? expand, string attributeType)
         {
             // Used to detect and log drive enumerating wildcard patterns.
             string[] files;
-            FileMatcher.SearchAction action = FileMatcher.SearchAction.None;
             string itemSpec = string.Empty;
 
             if (expand == null)
@@ -178,7 +178,7 @@ namespace Microsoft.Build.Tasks
                         }
                         else if (isLegalFileSpec)
                         {
-                            (files, action, _, string globFailure) = FileMatcher.Default.GetFiles(null /* use current directory */, i.ItemSpec);
+                            (files, _, _, string? globFailure) = FileMatcher.Default.GetFiles(null /* use current directory */, i.ItemSpec);
                             if (globFailure != null)
                             {
                                 Log.LogMessage(MessageImportance.Low, globFailure);

--- a/src/Tasks/CreateItem.cs
+++ b/src/Tasks/CreateItem.cs
@@ -181,7 +181,7 @@ namespace Microsoft.Build.Tasks
                             (files, action, _, string globFailure) = FileMatcher.Default.GetFiles(null /* use current directory */, i.ItemSpec);
                             if (globFailure != null)
                             {
-                                Log.LogMessage(globFailure);
+                                Log.LogMessage(MessageImportance.Low, globFailure);
                             }
 
                             foreach (string file in files)

--- a/src/Utilities/TrackedDependencies/CanonicalTrackedInputFiles.cs
+++ b/src/Utilities/TrackedDependencies/CanonicalTrackedInputFiles.cs
@@ -151,7 +151,7 @@ namespace Microsoft.Build.Utilities
                 };
             }
 
-            _tlogFiles = TrackedDependencies.ExpandWildcards(tlogFiles);
+            _tlogFiles = TrackedDependencies.ExpandWildcards(tlogFiles, ownerTask.BuildEngine.LogMessageEvent);
             _tlogAvailable = TrackedDependencies.ItemsExist(_tlogFiles);
             _sourceFiles = sourceFiles;
             _outputs = outputs;

--- a/src/Utilities/TrackedDependencies/CanonicalTrackedInputFiles.cs
+++ b/src/Utilities/TrackedDependencies/CanonicalTrackedInputFiles.cs
@@ -151,7 +151,7 @@ namespace Microsoft.Build.Utilities
                 };
             }
 
-            _tlogFiles = TrackedDependencies.ExpandWildcards(tlogFiles, ownerTask.BuildEngine.LogMessageEvent);
+            _tlogFiles = TrackedDependencies.ExpandWildcards(tlogFiles, _log);
             _tlogAvailable = TrackedDependencies.ItemsExist(_tlogFiles);
             _sourceFiles = sourceFiles;
             _outputs = outputs;

--- a/src/Utilities/TrackedDependencies/CanonicalTrackedOutputFiles.cs
+++ b/src/Utilities/TrackedDependencies/CanonicalTrackedOutputFiles.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Build.Utilities
                 };
             }
 
-            _tlogFiles = TrackedDependencies.ExpandWildcards(tlogFiles);
+            _tlogFiles = TrackedDependencies.ExpandWildcards(tlogFiles, ownerTask.BuildEngine.LogMessageEvent);
             _tlogAvailable = TrackedDependencies.ItemsExist(_tlogFiles);
             DependencyTable = new Dictionary<string, Dictionary<string, DateTime>>(StringComparer.OrdinalIgnoreCase);
             if (_tlogFiles != null && constructOutputsFromTLogs)

--- a/src/Utilities/TrackedDependencies/CanonicalTrackedOutputFiles.cs
+++ b/src/Utilities/TrackedDependencies/CanonicalTrackedOutputFiles.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Build.Utilities
                 };
             }
 
-            _tlogFiles = TrackedDependencies.ExpandWildcards(tlogFiles, ownerTask.BuildEngine.LogMessageEvent);
+            _tlogFiles = TrackedDependencies.ExpandWildcards(tlogFiles, _log);
             _tlogAvailable = TrackedDependencies.ItemsExist(_tlogFiles);
             DependencyTable = new Dictionary<string, Dictionary<string, DateTime>>(StringComparer.OrdinalIgnoreCase);
             if (_tlogFiles != null && constructOutputsFromTLogs)

--- a/src/Utilities/TrackedDependencies/FlatTrackingData.cs
+++ b/src/Utilities/TrackedDependencies/FlatTrackingData.cs
@@ -269,11 +269,11 @@ namespace Microsoft.Build.Utilities
                 };
             }
 
-            ITaskItem[] expandedTlogFiles = TrackedDependencies.ExpandWildcards(tlogFilesLocal, ownerTask.BuildEngine.LogMessageEvent);
+            ITaskItem[] expandedTlogFiles = TrackedDependencies.ExpandWildcards(tlogFilesLocal, _log);
 
             if (tlogFilesToIgnore != null)
             {
-                ITaskItem[] expandedTlogFilesToIgnore = TrackedDependencies.ExpandWildcards(tlogFilesToIgnore, ownerTask.BuildEngine.LogMessageEvent);
+                ITaskItem[] expandedTlogFilesToIgnore = TrackedDependencies.ExpandWildcards(tlogFilesToIgnore, _log);
 
                 if (expandedTlogFilesToIgnore.Length > 0)
                 {

--- a/src/Utilities/TrackedDependencies/FlatTrackingData.cs
+++ b/src/Utilities/TrackedDependencies/FlatTrackingData.cs
@@ -269,11 +269,11 @@ namespace Microsoft.Build.Utilities
                 };
             }
 
-            ITaskItem[] expandedTlogFiles = TrackedDependencies.ExpandWildcards(tlogFilesLocal);
+            ITaskItem[] expandedTlogFiles = TrackedDependencies.ExpandWildcards(tlogFilesLocal, ownerTask.BuildEngine.LogMessageEvent);
 
             if (tlogFilesToIgnore != null)
             {
-                ITaskItem[] expandedTlogFilesToIgnore = TrackedDependencies.ExpandWildcards(tlogFilesToIgnore);
+                ITaskItem[] expandedTlogFilesToIgnore = TrackedDependencies.ExpandWildcards(tlogFilesToIgnore, ownerTask.BuildEngine.LogMessageEvent);
 
                 if (expandedTlogFilesToIgnore.Length > 0)
                 {

--- a/src/Utilities/TrackedDependencies/TrackedDependencies.cs
+++ b/src/Utilities/TrackedDependencies/TrackedDependencies.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Collections.Generic;
 using System.IO;
 
@@ -51,7 +50,7 @@ namespace Microsoft.Build.Utilities
                     }
                     else
                     {
-                        (files, _, _, var globFailure) = FileMatcher.Default.GetFiles(null, item.ItemSpec);
+                        (files, _, _, string globFailure) = FileMatcher.Default.GetFiles(null, item.ItemSpec);
                         if (globFailure != null && log != null)
                         {
                             log.LogMessage(MessageImportance.Low, globFailure);

--- a/src/Utilities/TrackedDependencies/TrackedDependencies.cs
+++ b/src/Utilities/TrackedDependencies/TrackedDependencies.cs
@@ -24,9 +24,9 @@ namespace Microsoft.Build.Utilities
         /// Expand wildcards in the item list.
         /// </summary>
         /// <param name="expand"></param>
-        /// <param name="logMessageFunction">For logging glob failures.</param>
+        /// <param name="log">For logging glob failures.</param>
         /// <returns>Array of items expanded</returns>
-        public static ITaskItem[] ExpandWildcards(ITaskItem[] expand, Action<BuildMessageEventArgs> logMessageFunction)
+        public static ITaskItem[] ExpandWildcards(ITaskItem[] expand, TaskLoggingHelper log)
         {
             if (expand == null)
             {
@@ -51,10 +51,10 @@ namespace Microsoft.Build.Utilities
                     }
                     else
                     {
-                        (files, _, _, BuildMessageEventArgs globFailure) = FileMatcher.Default.GetFiles(null, item.ItemSpec);
-                        if (globFailure != null)
+                        (files, _, _, var globFailure) = FileMatcher.Default.GetFiles(null, item.ItemSpec);
+                        if (globFailure != null && log != null)
                         {
-                            logMessageFunction(globFailure);
+                            log.LogMessage(MessageImportance.Low, globFailure);
                         }
                     }
 

--- a/src/Utilities/TrackedDependencies/TrackedDependencies.cs
+++ b/src/Utilities/TrackedDependencies/TrackedDependencies.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 
@@ -23,8 +24,9 @@ namespace Microsoft.Build.Utilities
         /// Expand wildcards in the item list.
         /// </summary>
         /// <param name="expand"></param>
+        /// <param name="logMessageFunction">For logging glob failures.</param>
         /// <returns>Array of items expanded</returns>
-        public static ITaskItem[] ExpandWildcards(ITaskItem[] expand)
+        public static ITaskItem[] ExpandWildcards(ITaskItem[] expand, Action<BuildMessageEventArgs> logMessageFunction)
         {
             if (expand == null)
             {
@@ -49,7 +51,11 @@ namespace Microsoft.Build.Utilities
                     }
                     else
                     {
-                        files = FileMatcher.Default.GetFiles(null, item.ItemSpec).FileList;
+                        (files, _, _, BuildMessageEventArgs globFailure) = FileMatcher.Default.GetFiles(null, item.ItemSpec);
+                        if (globFailure != null)
+                        {
+                            logMessageFunction(globFailure);
+                        }
                     }
 
                     foreach (string file in files)

--- a/src/Utilities/TrackedDependencies/TrackedDependencies.cs
+++ b/src/Utilities/TrackedDependencies/TrackedDependencies.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
@@ -7,8 +7,6 @@ using System.IO;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
 using Microsoft.Build.Shared.FileSystem;
-
-#nullable disable
 
 namespace Microsoft.Build.Utilities
 {
@@ -23,9 +21,9 @@ namespace Microsoft.Build.Utilities
         /// Expand wildcards in the item list and log glob failures.
         /// </summary>
         /// <param name="expand"></param>
-        /// <param name="log">For logging glob failures.</param>
+        /// <param name="log">For logging glob failures. Can be null if called by external code or in tests.</param>
         /// <returns>Array of items expanded</returns>
-        public static ITaskItem[] ExpandWildcards(ITaskItem[] expand, TaskLoggingHelper log)
+        internal static ITaskItem[]? ExpandWildcards(ITaskItem[] expand, TaskLoggingHelper? log)
         {
             if (expand == null)
             {
@@ -38,7 +36,7 @@ namespace Microsoft.Build.Utilities
                 if (FileMatcher.HasWildcards(item.ItemSpec))
                 {
                     string[] files;
-                    string directoryName = Path.GetDirectoryName(item.ItemSpec);
+                    string? directoryName = Path.GetDirectoryName(item.ItemSpec);
                     string searchPattern = Path.GetFileName(item.ItemSpec);
 
                     // Very often with TLog files we're talking about
@@ -46,11 +44,11 @@ namespace Microsoft.Build.Utilities
                     // Optimize for that case here.
                     if (!FileMatcher.HasWildcards(directoryName) && FileSystems.Default.DirectoryExists(directoryName))
                     {
-                        files = Directory.GetFiles(directoryName, searchPattern);
+                        files = Directory.GetFiles(directoryName!, searchPattern);
                     }
                     else
                     {
-                        (files, _, _, string globFailure) = FileMatcher.Default.GetFiles(null, item.ItemSpec);
+                        (files, _, _, string? globFailure) = FileMatcher.Default.GetFiles(null, item.ItemSpec);
                         if (globFailure != null && log != null)
                         {
                             log.LogMessage(MessageImportance.Low, globFailure);
@@ -69,13 +67,6 @@ namespace Microsoft.Build.Utilities
             }
             return expanded.ToArray();
         }
-
-        /// <summary>
-        /// Expand wildcards in the item list.
-        /// </summary>
-        /// <param name="expand"></param>
-        /// <returns>Array of items expanded</returns>
-        public static ITaskItem[] ExpandWildcards(ITaskItem[] expand) => ExpandWildcards(expand, null);
 
         /// <summary>
         /// This method checks that all the files exist
@@ -103,6 +94,13 @@ namespace Microsoft.Build.Utilities
             }
             return allExist;
         }
+#nullable disable
+        /// <summary>
+        /// Expand wildcards in the item list.
+        /// </summary>
+        /// <param name="expand"></param>
+        /// <returns>Array of items expanded</returns>
+        public static ITaskItem[] ExpandWildcards(ITaskItem[] expand) => ExpandWildcards(expand, null);
         #endregion
 #pragma warning restore format
     }

--- a/src/Utilities/TrackedDependencies/TrackedDependencies.cs
+++ b/src/Utilities/TrackedDependencies/TrackedDependencies.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Build.Utilities
 #pragma warning disable format // region formatting is different in net7.0 and net472, and cannot be fixed for both
         #region Methods
         /// <summary>
-        /// Expand wildcards in the item list.
+        /// Expand wildcards in the item list and log glob failures.
         /// </summary>
         /// <param name="expand"></param>
         /// <param name="log">For logging glob failures.</param>
@@ -69,6 +69,13 @@ namespace Microsoft.Build.Utilities
             }
             return expanded.ToArray();
         }
+
+        /// <summary>
+        /// Expand wildcards in the item list.
+        /// </summary>
+        /// <param name="expand"></param>
+        /// <returns>Array of items expanded</returns>
+        public static ITaskItem[] ExpandWildcards(ITaskItem[] expand) => ExpandWildcards(expand, null);
 
         /// <summary>
         /// This method checks that all the files exist


### PR DESCRIPTION
Fixes #9609

### Context
Logging when glob expansions fail is useful for debugging.
Log it quietly (as a message with low priority).

### Changes Made
FileMatcher.GetFiles returns a message if an exception occurs when matching files, it's callers log it.

### Testing
Covered by existing tests.
Failures which would be logged are rare.
Tested manually triggering an exception in the critical section and the message displays in binlog:
![image](https://github.com/user-attachments/assets/d528a028-4f8f-4343-b4b9-79b53f030188)

### Notes
Figuring out how to log is a bit tricky with some of the code being in static, some in singleton contexts and there are multiple logging mechanisms.