### PR TITLE
 ConcurrentDictionary.Count bypass

### DIFF
--- a/src/StringTools/WeakStringCache.Concurrent.cs
+++ b/src/StringTools/WeakStringCache.Concurrent.cs
@@ -86,6 +86,11 @@ namespace Microsoft.NET.StringTools
                     {
                         // And do this again when the number of handles reaches double the current after-scavenge number.
                         _scavengeThreshold = _stringsByHashCode.Count * 2;
+
+                        // This count is not exact, since there can be some Interlocked.Increment(ref _count);
+                        // calls happening due to this not being behind a lock.
+                        // e.g. code checks if (_stringsByHashCode.TryAdd(hashCode, handle)), we set the _count here and the code increments
+                        // however since this is just a threshold to scavenge, it should be fine to be off by few even if that happens.
                         _count = _stringsByHashCode.Count;
                     }
                 }


### PR DESCRIPTION
profiler was repeatedly complaining about ConcurrentDictionary.Count taking locks too often.
This PR introduces an approximate counter to remedy that

### Context
![concurrentDictionary](https://github.com/user-attachments/assets/825fe314-4c65-443e-ba1c-0020347c6837)
ConcurrentDictionary.Count locks all its internal locks to have the count accurate and up to date.
However we only use the count to check if there is a reason to clean up the cache - e.g. we should be fine with a variable that is almost-in-sync with the .Count, that we can update atomically and then read without locking. 
The increment is atomic, the read is accurate enough and the "flush cache" section is already behind a lock.


### Changes Made
Introduced  _count variable that lists the same value as ConcurrentDictionary.Count would.


### Testing
Now that I looked at this, we didn't have a test for the scavenge threshold. We only ever tested the .scavenge directly.
Do we want to remedy that or are we fine as is?

