### PR TITLE
Make the cancelation can be executed before the task is done

### DIFF
--- a/src/Tasks.UnitTests/DownloadFile_Tests.cs
+++ b/src/Tasks.UnitTests/DownloadFile_Tests.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Build.Tasks.UnitTests
                     DestinationFolder = new TaskItem(folder.Path),
                     HttpMessageHandler = new MockHttpMessageHandler((message, token) => new HttpResponseMessage(HttpStatusCode.OK)
                     {
-                        Content = new StringContent(new String('!', 0xfffffff)),
+                        Content = new StreamContent(new MemoryStream(Encoding.UTF8.GetBytes(new String('!', 0xfffffff)))),
                         RequestMessage = new HttpRequestMessage(HttpMethod.Get, "http://largedownload/foo.txt")
                     }),
                     SourceUrl = "http://largedownload/foo.txt"

--- a/src/Tasks.UnitTests/DownloadFile_Tests.cs
+++ b/src/Tasks.UnitTests/DownloadFile_Tests.cs
@@ -421,7 +421,9 @@ namespace Microsoft.Build.Tasks.UnitTests
 
         public override int Read(byte[] buffer, int offset, int count)
         {
-            buffer[Position % count] = (byte)('A' + Position % 26);
+            // Simulate infinite stream by keeping providing a single character to the beginning of the requested destination.
+            // Writes next char A ~ Z in alphabet into the begining of requested destination. The count could be ignored.
+            buffer[offset] = (byte)('A' + Position % 26);
             Position++;
             Task.Delay(delayMilliseconds).Wait();
             return 1;

--- a/src/Tasks.UnitTests/DownloadFile_Tests.cs
+++ b/src/Tasks.UnitTests/DownloadFile_Tests.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Build.Tasks.UnitTests
 
                 downloadFile.Cancel();
 
-                task.Wait(TimeSpan.FromSeconds(1500)).ShouldBeTrue();
+                task.Wait(TimeSpan.FromMilliseconds(1500)).ShouldBeTrue();
 
                 task.Result.ShouldBeFalse();
             }

--- a/src/Tasks.UnitTests/DownloadFile_Tests.cs
+++ b/src/Tasks.UnitTests/DownloadFile_Tests.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Build.Tasks.UnitTests
                     DestinationFolder = new TaskItem(folder.Path),
                     HttpMessageHandler = new MockHttpMessageHandler((message, token) => new HttpResponseMessage(HttpStatusCode.OK)
                     {
-                        Content = new StringContent(new String('!', 10000000)),
+                        Content = new StringContent(new String('!', 0xfffffff)),
                         RequestMessage = new HttpRequestMessage(HttpMethod.Get, "http://largedownload/foo.txt")
                     }),
                     SourceUrl = "http://largedownload/foo.txt"
@@ -47,7 +47,7 @@ namespace Microsoft.Build.Tasks.UnitTests
 
                 downloadFile.Cancel();
 
-                task.Wait(TimeSpan.FromSeconds(1)).ShouldBeTrue();
+                task.Wait(TimeSpan.FromMilliseconds(1500)).ShouldBeTrue();
 
                 task.Result.ShouldBeFalse();
             }

--- a/src/Tasks.UnitTests/DownloadFile_Tests.cs
+++ b/src/Tasks.UnitTests/DownloadFile_Tests.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Build.Tasks.UnitTests
                     DestinationFolder = new TaskItem(folder.Path),
                     HttpMessageHandler = new MockHttpMessageHandler((message, token) => new HttpResponseMessage(HttpStatusCode.OK)
                     {
-                        Content = new StreamContent(new MemoryStream(Encoding.UTF8.GetBytes(new String('!', 0xfffffff)))),
+                        Content = new StreamContent(new FakeStream()),
                         RequestMessage = new HttpRequestMessage(HttpMethod.Get, "http://largedownload/foo.txt")
                     }),
                     SourceUrl = "http://largedownload/foo.txt"
@@ -47,7 +47,7 @@ namespace Microsoft.Build.Tasks.UnitTests
 
                 downloadFile.Cancel();
 
-                task.Wait(TimeSpan.FromMilliseconds(1500)).ShouldBeTrue();
+                task.Wait(TimeSpan.FromSeconds(1500)).ShouldBeTrue();
 
                 task.Result.ShouldBeFalse();
             }
@@ -400,5 +400,39 @@ namespace Microsoft.Build.Tasks.UnitTests
                 return Task.FromResult(_func(request, cancellationToken));
             }
         }
+    }
+
+    // Fake stream that simulates providing a single character A~Z per a couple of milliseconds without high memory cost.
+    public class FakeStream : Stream
+    {
+        private readonly int delayMilliseconds;
+
+        public FakeStream(int delayInMilliseconds = 20)
+        {
+            delayMilliseconds = delayInMilliseconds;
+            Position = 0;
+        }
+
+        public override bool CanRead => true;
+        public override bool CanSeek => true;
+        public override bool CanWrite => false;
+        public override long Length => long.MaxValue;
+        public override long Position { get; set; }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            buffer[Position % count] = (byte)('A' + Position % 26);
+            Position++;
+            Task.Delay(delayMilliseconds).Wait();
+            return 1;
+        }
+
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotImplementedException();
+
+        public override void SetLength(long value) => throw new NotImplementedException();
+
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotImplementedException();
+
+        public override void Flush() => throw new NotImplementedException();
     }
 }


### PR DESCRIPTION
Fixes #11018

### Context
Test result `Shouldly.ShouldAssertException : task.Result\r\n    should be\r\nFalse\r\n    but was\r\nTrue` indicates that the task is done quickly before the cancelation is executed, though the test cancels it right after it is started. 
 
### Changes Made
Make a fake stream that provides a single character A~Z per a couple of milliseconds infinitely without high memory cost as the content of http response message and increase the task timeout a little so that the cancellation can be executed.

### Testing
N/A

### Notes
