### PR TITLE
Enum.ToString method is resulting in slow performance. Fix it.

### DIFF
--- a/src/Build/BackEnd/Components/RequestBuilder/TargetBuilder.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TargetBuilder.cs
@@ -484,7 +484,7 @@ namespace Microsoft.Build.BackEnd
                             // Execute all of the tasks on this target.
                             MSBuildEventSource.Log.TargetStart(currentTargetEntry.Name);
                             await currentTargetEntry.ExecuteTarget(taskBuilder, _requestEntry, _projectLoggingContext, _cancellationToken);
-                            MSBuildEventSource.Log.TargetStop(currentTargetEntry.Name, currentTargetEntry.Result?.ResultCode.ToString() ?? string.Empty);
+                            MSBuildEventSource.Log.TargetStop(currentTargetEntry.Name, currentTargetEntry.Result?.TargetResultCodeToString() ?? string.Empty);
                         }
 
                         break;

--- a/src/Build/BackEnd/Shared/TargetResult.cs
+++ b/src/Build/BackEnd/Shared/TargetResult.cs
@@ -147,7 +147,8 @@ namespace Microsoft.Build.Execution
                 case TargetResultCode.Success:
                     return nameof(TargetResultCode.Success);
                 default:
-                    return "";
+                    Debug.Fail($"Unknown enum value: {ResultCode}");
+                    return ResultCode.ToString();
             }
         }
 

--- a/src/Build/BackEnd/Shared/TargetResult.cs
+++ b/src/Build/BackEnd/Shared/TargetResult.cs
@@ -141,11 +141,11 @@ namespace Microsoft.Build.Execution
             switch (ResultCode)
             {
                 case TargetResultCode.Failure:
-                    return "Failure";
+                    return nameof(TargetResultCode.Failure);
                 case TargetResultCode.Skipped:
-                    return "Skipped";
+                    return nameof(TargetResultCode.Skipped);
                 case TargetResultCode.Success:
-                    return "Success";
+                    return nameof(TargetResultCode.Success);
                 default:
                     return "";
             }

--- a/src/Build/BackEnd/Shared/TargetResult.cs
+++ b/src/Build/BackEnd/Shared/TargetResult.cs
@@ -136,6 +136,21 @@ namespace Microsoft.Build.Execution
             }
         }
 
+        public string TargetResultCodeToString()
+        {
+            switch (ResultCode)
+            {
+                case TargetResultCode.Failure:
+                    return "Failure";
+                case TargetResultCode.Skipped:
+                    return "Skipped";
+                case TargetResultCode.Success:
+                    return "Success";
+                default:
+                    return "";
+            }
+        }
+
         /// <summary>
         /// Returns the internal result for the target.
         /// </summary>


### PR DESCRIPTION
### Context
We recently merged https://github.com/dotnet/msbuild/pull/11202
While profiling, the VS profiler started complaining about the Enum.ToString() with a perf cost 0.14%
![EnumToString](https://github.com/user-attachments/assets/7ebf97bd-3f33-4d30-a67c-0ebc7c2dcbc2)
See also here:
https://learn.microsoft.com/en-us/visualstudio/profiling/performance-insights-enum-tostring?view=vs-2022

### Changes Made
Introduced a function to do the conversion in a Reflection-less way.

