### PR TITLE
Add line/column information to invalid project exception

### DIFF
--- a/src/Build/Construction/Solution/SolutionFile.cs
+++ b/src/Build/Construction/Solution/SolutionFile.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -322,7 +322,7 @@ namespace Microsoft.Build.Construction
                     ProjectFileErrorUtilities.ThrowInvalidProjectFile(
                         new BuildEventFileInfo(errorLocation),
                         "InvalidProjectFile",
-                        solutionEx.Message);
+                        solutionEx.ToString());
                 }
                 catch (Exception ex)
                 {

--- a/src/Build/Construction/Solution/SolutionFile.cs
+++ b/src/Build/Construction/Solution/SolutionFile.cs
@@ -302,27 +302,35 @@ namespace Microsoft.Build.Construction
         {
             ISolutionSerializer serializer = SolutionSerializers.GetSerializerByMoniker(FullPath);
 
-            if (serializer != null)
-            {
-                try
-                {
-                    SolutionModel solutionModel = serializer.OpenAsync(FullPath, CancellationToken.None).Result;
-                    ReadSolutionModel(solutionModel);
-                }
-                catch (Exception ex)
-                {
-                    ProjectFileErrorUtilities.ThrowInvalidProjectFile(
-                            new BuildEventFileInfo(FullPath),
-                            $"InvalidProjectFile",
-                            ex.ToString());
-                }
-            }
-            else if (serializer == null)
+            if (serializer == null)
             {
                 ProjectFileErrorUtilities.ThrowInvalidProjectFile(
                     new BuildEventFileInfo(FullPath),
                     $"InvalidProjectFile",
                     $"No solution serializer was found for {FullPath}");
+            }
+            else
+            {
+                try
+                {
+                    SolutionModel solutionModel = serializer.OpenAsync(FullPath, CancellationToken.None).GetAwaiter().GetResult();
+                    ReadSolutionModel(solutionModel);
+                }
+                catch (SolutionException solutionEx)
+                {
+                    var errorLocation = ElementLocation.Create(FullPath, solutionEx.Line ?? 0, solutionEx.Column ?? 0);
+                    ProjectFileErrorUtilities.ThrowInvalidProjectFile(
+                        new BuildEventFileInfo(errorLocation),
+                        "InvalidProjectFile",
+                        solutionEx.Message);
+                }
+                catch (Exception ex)
+                {
+                    ProjectFileErrorUtilities.ThrowInvalidProjectFile(
+                        new BuildEventFileInfo(FullPath),
+                        "InvalidProjectFile",
+                        ex.ToString());
+                }
             }
         }
 


### PR DESCRIPTION
Fixes #https://github.com/dotnet/msbuild/issues/11156

### Context
Due to serializer.OpenAsync(FullPath, CancellationToken.None).**Result**; usage, AggregateException was thrown with full callstack attached **without** location information:
![{82D7BB4A-77B4-4AE5-8997-48E4F943A72B}](https://github.com/user-attachments/assets/7139042c-ee50-4bd9-aa22-7adda05e6f8f)


### Changes Made
Switch to .GetAwaiter().GetResult(); to preserve original SolutionException that contains ElementLocation data.
![image](https://github.com/user-attachments/assets/35227f5c-c885-44b3-b9ea-8b083547b7c6)
### Testing
Manual.
