### PR TITLE
Ensure slash in PublishDir

### DIFF
--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -497,7 +497,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <!-- Output location for publish target. -->
   <PropertyGroup>
     <PublishDir Condition="'$(PublishDir)' != '' and !HasTrailingSlash('$(PublishDir)')">$(PublishDir)\</PublishDir>
-    <PublishDir Condition="'$(PublishDir)'==''">$(OutputPath)app.publish\</PublishDir>
+    <PublishDir Condition="'$(PublishDir)'==''">$([MSBuild]::EnsureTrailingSlash('$(OutputPath)'))app.publish\</PublishDir>
   </PropertyGroup>
 
   <!--

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -497,7 +497,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <!-- Output location for publish target. -->
   <PropertyGroup>
     <PublishDir Condition="'$(PublishDir)' != '' and !HasTrailingSlash('$(PublishDir)')">$(PublishDir)\</PublishDir>
-    <PublishDir Condition="'$(PublishDir)'==''">$([MSBuild]::EnsureTrailingSlash('$(OutputPath)'))app.publish\</PublishDir>
+    <PublishDir Condition="'$(PublishDir)'==''">$([MSBuild]::EnsureTrailingSlash($([MSBuild]::NormalizePath('$(OutputPath)', 'app.publish'))))</PublishDir>
   </PropertyGroup>
 
   <!--


### PR DESCRIPTION
Contributes to #11057

### Context
`OutputPath` is not guaranteed to end with slash when specified as a global property. So making sure the path composition using it is correct
