### PR TITLE
Upgrade Microsoft.VisualStudio.SolutionPersistence to 1.0.28

### DIFF
--- a/eng/SourceBuildPrebuiltBaseline.xml
+++ b/eng/SourceBuildPrebuiltBaseline.xml
@@ -18,6 +18,7 @@
     <UsagePattern IdentityGlob="System.Text.Json/*8.0.5*" />
     <UsagePattern IdentityGlob="System.Threading.Tasks.Dataflow/*8.0.0*" />
     <UsagePattern IdentityGlob="System.Formats.Asn1/*8.0.1*" />
+    <UsagePattern IdentityGlob="Microsoft.VisualStudio.SolutionPersistence/*1.0.*" />
   </IgnorePatterns>
   <Usages>
   </Usages>

--- a/eng/SourceBuildPrebuiltBaseline.xml
+++ b/eng/SourceBuildPrebuiltBaseline.xml
@@ -18,7 +18,6 @@
     <UsagePattern IdentityGlob="System.Text.Json/*8.0.5*" />
     <UsagePattern IdentityGlob="System.Threading.Tasks.Dataflow/*8.0.0*" />
     <UsagePattern IdentityGlob="System.Formats.Asn1/*8.0.1*" />
-	  <UsagePattern IdentityGlob="Microsoft.VisualStudio.SolutionPersistence/*1.0.9*" />
   </IgnorePatterns>
   <Usages>
   </Usages>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -40,7 +40,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <MicrosoftIORedistVersion>6.0.1</MicrosoftIORedistVersion>
-    <MicrosoftVisualStudioSolutionPersistenceVersion>1.0.9</MicrosoftVisualStudioSolutionPersistenceVersion>
+    <MicrosoftVisualStudioSolutionPersistenceVersion>1.0.28</MicrosoftVisualStudioSolutionPersistenceVersion>
     <SystemCollectionsImmutableVersion>8.0.0</SystemCollectionsImmutableVersion>
     <SystemConfigurationConfigurationManagerVersion>8.0.0</SystemConfigurationConfigurationManagerVersion>
     <SystemFormatsAsn1Version>8.0.1</SystemFormatsAsn1Version>


### PR DESCRIPTION
This version needs to match what is referenced in the sdk repo in order to avoid prebuilts in source build: https://github.com/dotnet/dotnet/blob/bcd01151a1cdde7d885b4fa1b157722fe4c0d3b4/src/sdk/Directory.Packages.props#L72