### PR TITLE
removing the dependency on IO.Redist from MSBuild GetPathToBuildToolsFile

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,7 +2,7 @@
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the MIT license. See License.txt in the project root for full license information. -->
 <Project>
   <PropertyGroup>
-    <VersionPrefix>17.13.5</VersionPrefix>
+    <VersionPrefix>17.13.6</VersionPrefix>
     <DotNetFinalVersionKind>release</DotNetFinalVersionKind>
     <PackageValidationBaselineVersion>17.12.6</PackageValidationBaselineVersion>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>

--- a/src/Shared/FrameworkLocationHelper.cs
+++ b/src/Shared/FrameworkLocationHelper.cs
@@ -1392,8 +1392,8 @@ namespace Microsoft.Build.Shared
                 // Context: https://github.com/dotnet/msbuild/pull/7689
                 if (this._hasMsBuild &&
                     generatedPathToDotNetFramework != null &&
-                    (!FileSystems.Default.FileExists(Path.Combine(generatedPathToDotNetFramework, NativeMethodsShared.IsWindows ? "MSBuild.exe" : "mcs.exe")) &&
-                     !FileSystems.Default.FileExists(Path.Combine(generatedPathToDotNetFramework, "Microsoft.Build.dll"))))
+                    (!File.Exists(Path.Combine(generatedPathToDotNetFramework, NativeMethodsShared.IsWindows ? "MSBuild.exe" : "mcs.exe")) &&
+                     !File.Exists(Path.Combine(generatedPathToDotNetFramework, "Microsoft.Build.dll"))))
                 {
                     return null;
                 }

--- a/src/Utilities/ToolLocationHelper.cs
+++ b/src/Utilities/ToolLocationHelper.cs
@@ -3584,7 +3584,7 @@ namespace Microsoft.Build.Utilities
             {
                 toolPath = Path.Combine(toolPath, fileName);
 
-                if (!FileSystems.Default.FileExists(toolPath))
+                if (!File.Exists(toolPath))
                 {
                     toolPath = null;
                 }


### PR DESCRIPTION
Fixes https://developercommunity.visualstudio.com/t/Unable-to-locate-MSBuild-path-with-Lates/10824132

Work item (Internal use): https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2343019

Related to:
https://github.com/microsoft/azure-pipelines-tasks/issues/20734?reload=1?reload=1

### Summary
The `Get-MsBuildPath` function used by the Azure Devops `MSBuild@1` task [uses reflection to load a MSBuild function](https://github.com/microsoft/azure-pipelines-tasks-common-packages/blob/f0e3508423ce927594a945f714b0e07be4bdb2fa/common-npm-packages/msbuildhelpers/PathFunctions.ps1#L29-L32) and then call it. 
MSBuild recently introduced (#9223) a dependency on `Microsoft.IO.Redist` in this codepath (it was used elsewhere in the assembly before). `Microsoft.IO.Redist` depends on `System.Memory`, which is in the MSBuild folder but at a higher version, so fails to load without binding redirects.

This will cause the AzDO function to use a fallback location method that will load a very-old MSBuild (from .NET Framework 4) and the whole pipeline will most likely fail.

### Customer Impact
Failure of Azure DevOps pipelines that use `MSBuild` or `VSBuild` AzDO tasks VS 17.13.

### Regression?
Yes, from 17.12 and 17.13-preview.1, caused by #9223.

### Testing
Manual testing with local versions of the AzDO script. VS experimental insertion for main branch has succeeded.

### Risk
low: switching to directly use System.IO methods instead of wrappers that may use Microsoft.IO.Redist
