### PR TITLE
Several changes to reduce allocations

### DIFF
--- a/src/Build/BackEnd/Components/BuildRequestEngine/BuildRequestEngine.cs
+++ b/src/Build/BackEnd/Components/BuildRequestEngine/BuildRequestEngine.cs
@@ -1128,8 +1128,8 @@ namespace Microsoft.Build.BackEnd
             // to the entry rather than a series of them.
             lock (issuingEntry.GlobalLock)
             {
-                var existingResultsToReport = new List<BuildResult>();
-                var unresolvedConfigurationsAdded = new HashSet<int>();
+                List<BuildResult> existingResultsToReport = null;
+                HashSet<int> unresolvedConfigurationsAdded = new HashSet<int>();
 
                 foreach (FullyQualifiedBuildRequest request in newRequests)
                 {
@@ -1232,6 +1232,7 @@ namespace Microsoft.Build.BackEnd
 
                             // Can't report the result directly here, because that could cause the request to go from
                             // Waiting to Ready.
+                            existingResultsToReport ??= new List<BuildResult>();
                             existingResultsToReport.Add(response.Results);
                         }
                         else
@@ -1243,9 +1244,12 @@ namespace Microsoft.Build.BackEnd
                 }
 
                 // If we have any results we had to report, do so now.
-                foreach (BuildResult existingResult in existingResultsToReport)
+                if (existingResultsToReport is not null)
                 {
-                    issuingEntry.ReportResult(existingResult);
+                    foreach (BuildResult existingResult in existingResultsToReport)
+                    {
+                        issuingEntry.ReportResult(existingResult);
+                    }
                 }
 
                 // Issue any configuration requests we may still need.

--- a/src/Build/BackEnd/Components/Caching/ResultsCache.cs
+++ b/src/Build/BackEnd/Components/Caching/ResultsCache.cs
@@ -178,7 +178,7 @@ namespace Microsoft.Build.BackEnd
                     if (buildDataFlagsSatisfied)
                     {
                         // Check for targets explicitly specified.
-                        bool explicitTargetsSatisfied = CheckResults(allResults, request.Targets, response.ExplicitTargetsToBuild, skippedResultsDoNotCauseCacheMiss);
+                        bool explicitTargetsSatisfied = CheckResults(allResults, request.Targets, checkTargetsMissingResults: true, skippedResultsDoNotCauseCacheMiss);
 
                         if (explicitTargetsSatisfied)
                         {
@@ -186,7 +186,7 @@ namespace Microsoft.Build.BackEnd
                             response.Type = ResultsCacheResponseType.Satisfied;
 
                             // Check for the initial targets.  If we don't know what the initial targets are, we assume they are not satisfied.
-                            if (configInitialTargets == null || !CheckResults(allResults, configInitialTargets, null, skippedResultsDoNotCauseCacheMiss))
+                            if (configInitialTargets == null || !CheckResults(allResults, configInitialTargets, checkTargetsMissingResults: false, skippedResultsDoNotCauseCacheMiss))
                             {
                                 response.Type = ResultsCacheResponseType.NotSatisfied;
                             }
@@ -196,7 +196,7 @@ namespace Microsoft.Build.BackEnd
                             {
                                 // Check for the default target, if necessary.  If we don't know what the default targets are, we
                                 // assume they are not satisfied.
-                                if (configDefaultTargets == null || !CheckResults(allResults, configDefaultTargets, null, skippedResultsDoNotCauseCacheMiss))
+                                if (configDefaultTargets == null || !CheckResults(allResults, configDefaultTargets, checkTargetsMissingResults: false, skippedResultsDoNotCauseCacheMiss))
                                 {
                                     response.Type = ResultsCacheResponseType.NotSatisfied;
                                 }
@@ -308,20 +308,21 @@ namespace Microsoft.Build.BackEnd
         /// </summary>
         /// <param name="result">The result to examine</param>
         /// <param name="targets">The targets to search for</param>
-        /// <param name="targetsMissingResults">An optional list to be populated with missing targets</param>
+        /// <param name="checkTargetsMissingResults">If missing targets will be checked for.</param>
         /// <param name="skippedResultsAreOK">If true, a status of "skipped" counts as having valid results
         /// for that target.  Otherwise, a skipped target is treated as equivalent to a missing target.</param>
         /// <returns>False if there were missing results, true otherwise.</returns>
-        private static bool CheckResults(BuildResult result, List<string> targets, HashSet<string> targetsMissingResults, bool skippedResultsAreOK)
+        private static bool CheckResults(BuildResult result, List<string> targets, bool checkTargetsMissingResults, bool skippedResultsAreOK)
         {
             bool returnValue = true;
+            bool missingTargetFound = false;
             foreach (string target in targets)
             {
                 if (!result.HasResultsForTarget(target) || (result[target].ResultCode == TargetResultCode.Skipped && !skippedResultsAreOK))
                 {
-                    if (targetsMissingResults != null)
+                    if (checkTargetsMissingResults)
                     {
-                        targetsMissingResults.Add(target);
+                        missingTargetFound = true;
                         returnValue = false;
                     }
                     else
@@ -333,7 +334,7 @@ namespace Microsoft.Build.BackEnd
                 {
                     // If the result was a failure and we have not seen any skipped targets up to this point, then we conclude we do
                     // have results for this request, and they indicate failure.
-                    if (result[target].ResultCode == TargetResultCode.Failure && (targetsMissingResults == null || targetsMissingResults.Count == 0))
+                    if (result[target].ResultCode == TargetResultCode.Failure && (!checkTargetsMissingResults || !missingTargetFound))
                     {
                         return true;
                     }

--- a/src/Build/BackEnd/Components/Caching/ResultsCacheResponse.cs
+++ b/src/Build/BackEnd/Components/Caching/ResultsCacheResponse.cs
@@ -42,11 +42,6 @@ namespace Microsoft.Build.BackEnd
         public BuildResult Results;
 
         /// <summary>
-        /// The subset of explicit targets which must be built because there are no results for them in the cache.
-        /// </summary>
-        public HashSet<string> ExplicitTargetsToBuild;
-
-        /// <summary>
         /// Constructor.
         /// </summary>
         /// <param name="type">The response type.</param>
@@ -54,7 +49,6 @@ namespace Microsoft.Build.BackEnd
         {
             Type = type;
             Results = null;
-            ExplicitTargetsToBuild = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         }
     }
 }

--- a/src/Build/BackEnd/Components/RequestBuilder/BatchingEngine.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/BatchingEngine.cs
@@ -259,7 +259,7 @@ namespace Microsoft.Build.BackEnd
                             if (items != null)
                             {
                                 // Loop through all the items in the BuildItemGroup.
-                                foreach (ProjectItemInstance item in items)
+                                foreach (ProjectItemInstance item in items.GetStructEnumerable())
                                 {
                                     ProjectErrorUtilities.VerifyThrowInvalidProject(
                                         item.HasMetadata(consumedMetadataReference.MetadataName),
@@ -319,7 +319,7 @@ namespace Microsoft.Build.BackEnd
 
                 if (items != null)
                 {
-                    foreach (ProjectItemInstance item in items)
+                    foreach (ProjectItemInstance item in items.GetStructEnumerable())
                     {
                         // Get this item's values for all the metadata consumed by the batchable object.
                         Dictionary<string, string> itemMetadataValues = GetItemMetadataValues(item, consumedMetadataReferences, elementLocation);

--- a/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupIntrinsicTask.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupIntrinsicTask.cs
@@ -479,10 +479,12 @@ namespace Microsoft.Build.BackEnd
             {
                 foreach (var item in items)
                 {
-                    var metadataToRemove = item.MetadataNames.Where(name => !keepMetadata.Contains(name));
-                    foreach (var metadataName in metadataToRemove)
+                    foreach (var metadataName in item.MetadataNames)
                     {
-                        item.RemoveMetadata(metadataName);
+                        if (!keepMetadata.Contains(metadataName))
+                        {
+                            item.RemoveMetadata(metadataName);
+                        }
                     }
                 }
             }
@@ -490,10 +492,12 @@ namespace Microsoft.Build.BackEnd
             {
                 foreach (var item in items)
                 {
-                    var metadataToRemove = item.MetadataNames.Where(name => removeMetadata.Contains(name));
-                    foreach (var metadataName in metadataToRemove)
+                    foreach (var metadataName in item.MetadataNames)
                     {
-                        item.RemoveMetadata(metadataName);
+                        if (removeMetadata.Contains(metadataName))
+                        {
+                            item.RemoveMetadata(metadataName);
+                        }
                     }
                 }
             }
@@ -510,7 +514,7 @@ namespace Microsoft.Build.BackEnd
         /// <returns>A list of matching items</returns>
         private HashSet<string> EvaluateExcludePaths(IReadOnlyList<string> excludes, ElementLocation excludeLocation)
         {
-            HashSet<string> excludesUnescapedForComparison = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            HashSet<string> excludesUnescapedForComparison = new HashSet<string>(excludes.Count, StringComparer.OrdinalIgnoreCase);
             foreach (string excludeSplit in excludes)
             {
                 string[] excludeSplitFiles = EngineFileUtilities.GetFileListUnescaped(
@@ -588,7 +592,7 @@ namespace Microsoft.Build.BackEnd
             // filename in the remove list.
             List<ProjectItemInstance> itemsRemoved = new List<ProjectItemInstance>();
 
-            foreach (ProjectItemInstance item in items)
+            foreach (ProjectItemInstance item in items.GetStructEnumerable())
             {
                 // Even if the case for the excluded files is different, they
                 // will still get excluded, as expected.  However, if the excluded path

--- a/src/Build/BackEnd/Components/RequestBuilder/Lookup.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/Lookup.cs
@@ -480,8 +480,14 @@ namespace Microsoft.Build.BackEnd
                     ICollection<ProjectItemInstance> adds = scope.Adds[itemType];
                     if (adds.Count != 0)
                     {
-                        allAdds ??= new List<ProjectItemInstance>(adds.Count);
-                        allAdds.AddRange(adds);
+                        if (allAdds == null)
+                        {
+                            allAdds = new List<ProjectItemInstance>(adds);
+                        }
+                        else
+                        {
+                            allAdds.AddRange(adds);
+                        }
                     }
                 }
 
@@ -491,8 +497,14 @@ namespace Microsoft.Build.BackEnd
                     ICollection<ProjectItemInstance> removes = scope.Removes[itemType];
                     if (removes.Count != 0)
                     {
-                        allRemoves ??= new List<ProjectItemInstance>(removes.Count);
-                        allRemoves.AddRange(removes);
+                        if (allRemoves == null)
+                        {
+                            allRemoves = new List<ProjectItemInstance>(removes);
+                        }
+                        else
+                        {
+                            allRemoves.AddRange(removes);
+                        }
                     }
                 }
 
@@ -696,7 +708,7 @@ namespace Microsoft.Build.BackEnd
         /// </summary>
         internal void RemoveItems(IEnumerable<ProjectItemInstance> items)
         {
-            foreach (ProjectItemInstance item in items)
+            foreach (ProjectItemInstance item in items.GetStructEnumerable())
             {
                 RemoveItem(item);
             }

--- a/src/Build/BackEnd/Shared/BuildRequestConfiguration.cs
+++ b/src/Build/BackEnd/Shared/BuildRequestConfiguration.cs
@@ -299,7 +299,11 @@ namespace Microsoft.Build.BackEnd
             {
                 if (!_isTraversalProject.HasValue)
                 {
-                    if (String.Equals(Path.GetFileName(ProjectFullPath), "dirs.proj", StringComparison.OrdinalIgnoreCase))
+#if NET471_OR_GREATER
+                    if (MemoryExtensions.Equals(Microsoft.IO.Path.GetFileName(ProjectFullPath.AsSpan()), "dirs.proj".AsSpan(), StringComparison.OrdinalIgnoreCase))
+#else
+                    if (MemoryExtensions.Equals(Path.GetFileName(ProjectFullPath.AsSpan()), "dirs.proj", StringComparison.OrdinalIgnoreCase))
+#endif
                     {
                         // dirs.proj are assumed to be traversals
                         _isTraversalProject = true;

--- a/src/Build/BackEnd/Shared/BuildResult.cs
+++ b/src/Build/BackEnd/Shared/BuildResult.cs
@@ -10,6 +10,7 @@ using Microsoft.Build.BackEnd;
 using Microsoft.Build.Shared;
 using Microsoft.Build.Shared.FileSystem;
 using Microsoft.Build.Framework;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Build.Execution
 {

--- a/src/Build/BackEnd/TaskExecutionHost/TaskExecutionHost.cs
+++ b/src/Build/BackEnd/TaskExecutionHost/TaskExecutionHost.cs
@@ -15,6 +15,7 @@ using System.Text;
 using System.Threading;
 
 using Microsoft.Build.BackEnd.Logging;
+using Microsoft.Build.Collections;
 using Microsoft.Build.Construction;
 using Microsoft.Build.Evaluation;
 using Microsoft.Build.Exceptions;
@@ -1223,15 +1224,18 @@ namespace Microsoft.Build.BackEnd
 
             string taskAndParameterName = _taskName + "_" + parameter.Name;
             string key = "DisableLogTaskParameter_" + taskAndParameterName;
-            string metadataKey = "DisableLogTaskParameterItemMetadata_" + taskAndParameterName;
 
             if (string.Equals(lookup.GetProperty(key)?.EvaluatedValue, "true", StringComparison.OrdinalIgnoreCase))
             {
                 parameter.Log = false;
             }
-            else if (string.Equals(lookup.GetProperty(metadataKey)?.EvaluatedValue, "true", StringComparison.OrdinalIgnoreCase))
+            else
             {
-                parameter.LogItemMetadata = false;
+                string metadataKey = "DisableLogTaskParameterItemMetadata_" + taskAndParameterName;
+                if (string.Equals(lookup.GetProperty(metadataKey)?.EvaluatedValue, "true", StringComparison.OrdinalIgnoreCase))
+                {
+                    parameter.LogItemMetadata = false;
+                }
             }
         }
 
@@ -1416,9 +1420,26 @@ namespace Microsoft.Build.BackEnd
 
                                     static IEnumerable<KeyValuePair<string, string>> EnumerateMetadata(IDictionary customMetadata)
                                     {
-                                        foreach (DictionaryEntry de in customMetadata)
+                                        if (customMetadata is CopyOnWriteDictionary<string> copyOnWriteDictionary)
                                         {
-                                            yield return new KeyValuePair<string, string>((string)de.Key, EscapingUtilities.Escape((string)de.Value));
+                                            foreach (KeyValuePair<string, string> kvp in copyOnWriteDictionary)
+                                            {
+                                                yield return new KeyValuePair<string, string>(kvp.Key, EscapingUtilities.Escape(kvp.Value));
+                                            }
+                                        }
+                                        else if (customMetadata is Dictionary<string, string> dictionary)
+                                        {
+                                            foreach (KeyValuePair<string, string> kvp in dictionary)
+                                            {
+                                                yield return new KeyValuePair<string, string>(kvp.Key, EscapingUtilities.Escape(kvp.Value));
+                                            }
+                                        }
+                                        else
+                                        {
+                                            foreach (DictionaryEntry de in customMetadata)
+                                            {
+                                                yield return new KeyValuePair<string, string>((string)de.Key, EscapingUtilities.Escape((string)de.Value));
+                                            }
                                         }
                                     }
                                 }

--- a/src/Build/Collections/CopyOnReadEnumerable.cs
+++ b/src/Build/Collections/CopyOnReadEnumerable.cs
@@ -72,6 +72,10 @@ namespace Microsoft.Build.Collections
 #endif
                 list = new List<TResult>(count);
             }
+            else if (_backingEnumerable is IReadOnlyCollection<TSource> readOnlyCollection)
+            {
+                list = new List<TResult>(readOnlyCollection.Count);
+            }
             else
             {
                 list = new List<TResult>();

--- a/src/Build/Collections/CopyOnWritePropertyDictionary.cs
+++ b/src/Build/Collections/CopyOnWritePropertyDictionary.cs
@@ -137,12 +137,18 @@ namespace Microsoft.Build.Collections
         /// Gets an enumerator over all the properties in the collection
         /// Enumeration is in undefined order
         /// </summary>
-        public IEnumerator<T> GetEnumerator() => _backing.Values.GetEnumerator();
+        public ImmutableDictionary<string, T>.Enumerator GetEnumerator() => _backing.GetEnumerator();
+
+        /// <summary>
+        /// Gets an enumerator over all the properties in the collection
+        /// Enumeration is in undefined order
+        /// </summary>
+        IEnumerator<T> IEnumerable<T>.GetEnumerator() => new Enumerator(this);
 
         /// <summary>
         /// Get an enumerator over entries
         /// </summary>
-        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+        IEnumerator IEnumerable.GetEnumerator() => new Enumerator(this);
 
         #region IEquatable<CopyOnWritePropertyDictionary<T>> Members
 
@@ -347,9 +353,24 @@ namespace Microsoft.Build.Collections
         /// <param name="other">An enumerator over the properties to add.</param>
         public void ImportProperties(IEnumerable<T> other)
         {
-            _backing = _backing.SetItems(Items());
+            if (other is CopyOnWritePropertyDictionary<T> copyOnWriteDictionary)
+            {
+                _backing = _backing.SetItems(DictionaryItems(copyOnWriteDictionary));
+            }
+            else
+            {
+                _backing = _backing.SetItems(Items(other));
+            }
 
-            IEnumerable<KeyValuePair<string, T>> Items()
+            static IEnumerable<KeyValuePair<string, T>> DictionaryItems(CopyOnWritePropertyDictionary<T> copyOnWriteDictionary)
+            {
+                foreach (KeyValuePair<string, T> kvp in copyOnWriteDictionary)
+                {
+                    yield return new(kvp.Value.Key, kvp.Value);
+                }
+            }
+
+            static IEnumerable<KeyValuePair<string, T>> Items(IEnumerable<T> other)
             {
                 foreach (T property in other)
                 {
@@ -365,6 +386,37 @@ namespace Microsoft.Build.Collections
         public ICopyOnWritePropertyDictionary<T> DeepClone()
         {
             return new CopyOnWritePropertyDictionary<T>(this);
+        }
+
+        public struct Enumerator : IEnumerator<T>
+        {
+            private ImmutableDictionary<string, T>.Enumerator _dictionaryEnumerator;
+            public Enumerator(CopyOnWritePropertyDictionary<T> dictionary)
+            {
+                _dictionaryEnumerator = dictionary._backing.GetEnumerator();
+            }
+
+            public T Current { get; private set; }
+
+            readonly object IEnumerator.Current => Current;
+
+            public void Dispose() => _dictionaryEnumerator.Dispose();
+
+            public readonly Enumerator GetEnumerator() => this;
+
+            public bool MoveNext()
+            {
+                if (_dictionaryEnumerator.MoveNext())
+                {
+                    Current = _dictionaryEnumerator.Current.Value;
+
+                    return true;
+                }
+
+                return false;
+            }
+
+            public void Reset() => _dictionaryEnumerator.Reset();
         }
     }
 }

--- a/src/Build/Collections/ItemDictionary.cs
+++ b/src/Build/Collections/ItemDictionary.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Build.Collections
     /// </remarks>
     /// <typeparam name="T">Item class type to store</typeparam>
     [DebuggerDisplay("#Item types={ItemTypes.Count} #Items={Count}")]
-    internal sealed class ItemDictionary<T> : IItemDictionary<T>
+    internal sealed class ItemDictionary<T> : IItemDictionary<T>, IReadOnlyCollection<T>
         where T : class, IKeyed, IItem
     {
         /// <summary>
@@ -322,7 +322,7 @@ namespace Microsoft.Build.Collections
                     _itemLists[itemType] = list;
                 }
 
-                foreach (T item in items)
+                foreach (T item in items.GetStructEnumerable())
                 {
 #if DEBUG
                     // Debug only: hot code path
@@ -340,7 +340,7 @@ namespace Microsoft.Build.Collections
         /// <param name="other">An enumerator over the items to remove.</param>
         public void RemoveItems(IEnumerable<T> other)
         {
-            foreach (T item in other)
+            foreach (T item in other.GetStructEnumerable())
             {
                 Remove(item);
             }

--- a/src/Build/Collections/PropertyDictionary.cs
+++ b/src/Build/Collections/PropertyDictionary.cs
@@ -542,19 +542,34 @@ namespace Microsoft.Build.Collections
 
         internal IEnumerable<TResult> Filter<TResult>(Func<T, bool> filter, Func<T, TResult> selector)
         {
-            List<TResult> result = new();
             lock (_properties)
             {
-                foreach (T property in (ICollection<T>)_properties)
+                ICollection<T> propertiesCollection = (ICollection<T>)_properties;
+                List<TResult> result = new(propertiesCollection.Count);
+                if (_properties is RetrievableValuedEntryHashSet<T> hashSet)
                 {
-                    if (filter(property))
+                    foreach (T property in hashSet)
                     {
-                        result.Add(selector(property));
+                        if (filter(property))
+                        {
+                            result.Add(selector(property));
+                        }
                     }
                 }
-            }
+                else
+                {
+                    foreach (T property in propertiesCollection)
+                    {
+                        if (filter(property))
+                        {
+                            result.Add(selector(property));
+                        }
+                    }
+                }
+                
 
-            return result;
+                return result;
+            }
         }
     }
 }

--- a/src/Build/Construction/ProjectElementContainer.cs
+++ b/src/Build/Construction/ProjectElementContainer.cs
@@ -841,7 +841,9 @@ namespace Microsoft.Build.Construction
                 return false;
             }
 
-            public IEnumerator<T> GetEnumerator() => new Enumerator(_initial, _forwards);
+            public Enumerator GetEnumerator() => new Enumerator(_initial, _forwards);
+
+            IEnumerator<T> IEnumerable<T>.GetEnumerator() => GetEnumerator();
 
             IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
@@ -931,12 +933,17 @@ namespace Microsoft.Build.Construction
             /// <summary>
             /// Get enumerator
             /// </summary>
-            public readonly IEnumerator<ProjectElement> GetEnumerator() => _enumerator;
+            public readonly Enumerator GetEnumerator() => _enumerator;
 
             /// <summary>
             /// Get non generic enumerator
             /// </summary>
             IEnumerator IEnumerable.GetEnumerator() => _enumerator;
+
+            /// <summary>
+            /// Get enumerator
+            /// </summary>
+            IEnumerator<ProjectElement> IEnumerable<ProjectElement>.GetEnumerator() => _enumerator;
 
             /// <summary>
             /// Enumerator over a series of sibling ProjectElement objects

--- a/src/Build/Evaluation/ExpressionShredder.cs
+++ b/src/Build/Evaluation/ExpressionShredder.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.Build.Collections;
+using Microsoft.Build.Construction;
 using Microsoft.Build.Shared;
 
 #nullable disable
@@ -68,7 +69,7 @@ namespace Microsoft.Build.Evaluation
         {
             ItemsAndMetadataPair pair = new ItemsAndMetadataPair(null, null);
 
-            foreach (string expression in expressions)
+            foreach (string expression in expressions.GetStructEnumerable())
             {
                 GetReferencedItemNamesAndMetadata(expression, 0, expression.Length, ref pair, ShredderOptions.All);
             }

--- a/src/Build/Microsoft.Build.csproj
+++ b/src/Build/Microsoft.Build.csproj
@@ -81,6 +81,9 @@
     <Compile Include="..\Shared\IConstrainedEqualityComparer.cs">
       <Link>IConstrainedEqualityComparer.cs</Link>
     </Compile>
+    <Compile Include="..\Shared\IEnumerableExtensions.cs">
+      <Link>IEnumerableExtensions.cs</Link>
+    </Compile>
     <Compile Include="..\Shared\PropertyParser.cs">
       <Link>BackEnd\Components\RequestBuilder\IntrinsicTasks\PropertyParser.cs</Link>
     </Compile>

--- a/src/Build/Utilities/Utilities.cs
+++ b/src/Build/Utilities/Utilities.cs
@@ -701,6 +701,16 @@ namespace Microsoft.Build.Internal
                     }
                 });
             }
+            else if (items is IEnumerable<DictionaryEntry> dictionaryEntryEnumerable)
+            {
+                foreach (DictionaryEntry dictionaryEntry in dictionaryEntryEnumerable)
+                {
+                    if (dictionaryEntry.Key is string key && key.Length > 0)
+                    {
+                        callback(new DictionaryEntry(key, dictionaryEntry.Value));
+                    }
+                }
+            }
             else
             {
                 foreach (var item in items)

--- a/src/Framework/BinaryTranslator.cs
+++ b/src/Framework/BinaryTranslator.cs
@@ -299,7 +299,11 @@ namespace Microsoft.Build.BackEnd
                 }
 
                 int count = _reader.ReadInt32();
+#if NET472_OR_GREATER || NET9_0_OR_GREATER
+                set = new HashSet<string>(count);
+#else
                 set = new HashSet<string>();
+#endif
 
                 for (int i = 0; i < count; i++)
                 {

--- a/src/Shared/CopyOnWriteDictionary.cs
+++ b/src/Shared/CopyOnWriteDictionary.cs
@@ -294,13 +294,26 @@ namespace Microsoft.Build.Collections
             return initial != _backing; // whether the removal occured
         }
 
+#if NET472_OR_GREATER || NETCOREAPP
         /// <summary>
         /// Implementation of generic IEnumerable.GetEnumerator()
         /// </summary>
+        public ImmutableDictionary<string, V>.Enumerator GetEnumerator()
+        {
+            return _backing.GetEnumerator();
+        }
+
+        IEnumerator<KeyValuePair<string, V>> IEnumerable<KeyValuePair<string, V>>.GetEnumerator()
+        {
+            ImmutableDictionary<string, V>.Enumerator enumerator = _backing.GetEnumerator();
+            return _backing.GetEnumerator();
+        }
+#else
         public IEnumerator<KeyValuePair<string, V>> GetEnumerator()
         {
             return _backing.GetEnumerator();
         }
+#endif
 
         /// <summary>
         /// Implementation of IEnumerable.GetEnumerator()

--- a/src/Shared/IEnumerableExtensions.cs
+++ b/src/Shared/IEnumerableExtensions.cs
@@ -1,0 +1,237 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+
+namespace Microsoft.Build.Collections
+{
+    /// <summary>
+    /// A set of extension methods for working with immutable dictionaries.
+    /// </summary>
+    internal static class IEnumerableExtensions
+    {
+        /// <summary>
+        /// Avoids allocating an enumerator when enumerating an <see cref="IEnumerable{T}"/> in many cases.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// The <see langword="foreach"/> statement enumerates types that implement <see cref="IEnumerable{T}"/>,
+        /// but will also enumerate any type that has the required methods. Several collection types take advantage of this
+        /// to avoid allocating an enumerator on the heap when used with <see langword="foreach"/> by returning a
+        /// <see langword="struct"/> enumerator. This is in contrast to the interface-based enumerator
+        /// <see cref="IEnumerator{T}"/> which will always be allocated on the heap.
+        /// </para>
+        /// <para>
+        /// This extension method attempts to create a non-allocating struct enumerator to enumerate
+        /// <paramref name="collection"/>. It checks the concrete type of the collection and provides a
+        /// non-allocating path in several cases.
+        /// </para>
+        /// <para>
+        /// Types that can be enumerated without allocation are:
+        /// </para>
+        /// <list type="bullet">
+        ///     <item><description><see cref="IList{T}"/> (and by extension <see cref="List{T}"/> and other popular implementations)</description></item>
+        ///     <item><description><see cref="LinkedList{T}"/></description></item>
+        ///     <item><description><see cref="ImmutableHashSet{T}"/></description></item>
+        ///     <item><description><see cref="ImmutableList{T}"/></description></item>
+        ///     <item><description><see cref="ICollection{T}"/> or <see cref="IReadOnlyCollection{T}"/> having zero count</description></item>
+        /// </list>
+        /// <para>
+        /// If <paramref name="collection"/> is not one of the supported types, the returned enumerator falls back to the
+        /// interface-based enumerator, which will heap allocate. Benchmarking shows the overhead in such cases is low enough
+        /// to be within the measurement error.
+        /// </para>
+        /// </remarks>
+        /// <example>
+        /// <code>
+        /// <![CDATA[IEnumerable<string> collection = ...;
+        ///
+        /// foreach (string item in collection.GetStructEnumerable())
+        /// {
+        ///     // ...
+        /// }]]>
+        /// </code>
+        /// </example>
+        /// <typeparam name="T">The item type that is enumerated.</typeparam>
+        /// <param name="collection">The collections that will be enumerated.</param>
+        /// <returns>The enumerator for the collection.</returns>
+        public static Enumerable<T> GetStructEnumerable<T>(this IEnumerable<T> collection)
+        {
+            if (collection is null)
+            {
+                throw new ArgumentNullException(nameof(collection));
+            }
+
+            return Enumerable<T>.Create(collection);
+        }
+
+        /// <summary>
+        /// Provides a struct-based enumerator for use with <see cref="IEnumerable{T}"/>.
+        /// Do not use this type directly. Use <see cref="GetStructEnumerable{T}"/> instead.
+        /// </summary>
+        /// <typeparam name="T">The item type that is enumerated.</typeparam>
+        public readonly ref struct Enumerable<T>
+        {
+            private readonly IEnumerable<T> collection;
+
+            private Enumerable(IEnumerable<T> collection) => this.collection = collection;
+
+            /// <summary>
+            /// Constructs an <see cref="Enumerable{T}"/> that can be enumerated.
+            /// </summary>
+            /// <param name="collection">The collections that will be enumerated.</param>
+            /// <returns><see cref="Enumerable{T}"/>.</returns>
+            public static Enumerable<T> Create(IEnumerable<T> collection)
+            {
+                return new Enumerable<T>(collection);
+            }
+
+            /// <summary>
+            /// Gets the Enumerator.
+            /// </summary>
+            /// <returns><see cref="Enumerator"/>.</returns>
+            public Enumerator GetEnumerator() => new(this.collection);
+
+            /// <summary>
+            /// A struct-based enumerator for use with <see cref="IEnumerable{T}"/>.
+            /// Do not use this type directly. Use <see cref="GetStructEnumerable{T}"/> instead.
+            /// </summary>
+            public struct Enumerator : IDisposable
+            {
+                private readonly Type enumeratorType;
+                private readonly IEnumerator<T>? fallbackEnumerator;
+                private readonly IList<T>? iList;
+                private int listIndex;
+
+                private LinkedList<T>.Enumerator concreteLinkedListEnumerator;
+                private ImmutableHashSet<T>.Enumerator concreteImmutableHashSetEnumerator;
+                private ImmutableList<T>.Enumerator concreteImmutableListEnumerator;
+                private HashSet<T>.Enumerator concreteHashSetEnumerator;
+
+                /// <summary>
+                /// Initializes a new instance of the <see cref="Enumerator"/> struct.
+                /// </summary>
+                /// <param name="collection">The collection that will be enumerated.</param>
+                internal Enumerator(IEnumerable<T> collection)
+                {
+                    this.concreteLinkedListEnumerator = default;
+                    this.concreteImmutableHashSetEnumerator = default;
+                    this.concreteImmutableListEnumerator = default;
+                    this.concreteHashSetEnumerator = default;
+                    this.fallbackEnumerator = null;
+                    this.iList = null;
+                    this.listIndex = -1;
+
+                    switch (collection)
+                    {
+                        case ICollection<T> sizedCollection when sizedCollection.Count == 0:
+                        case IReadOnlyCollection<T> readOnlyCollection when readOnlyCollection.Count == 0:
+                            // The collection is empty, just return false from MoveNext.
+                            this.enumeratorType = Type.Empty;
+                            break;
+                        case LinkedList<T> concreteLinkedList:
+                            this.enumeratorType = Type.LinkedList;
+                            this.concreteLinkedListEnumerator = concreteLinkedList.GetEnumerator();
+                            break;
+                        case ImmutableHashSet<T> concreteImmutableHashSet:
+                            this.enumeratorType = Type.ImmutableHashSet;
+                            this.concreteImmutableHashSetEnumerator = concreteImmutableHashSet.GetEnumerator();
+                            break;
+                        case ImmutableList<T> concreteImmutableList:
+                            this.enumeratorType = Type.ImmutableList;
+                            this.concreteImmutableListEnumerator = concreteImmutableList.GetEnumerator();
+                            break;
+                        case HashSet<T> concreteHashSet:
+                            this.enumeratorType = Type.HashSet;
+                            this.concreteHashSetEnumerator = concreteHashSet.GetEnumerator();
+                            break;
+                        case IList<T> list:
+                            this.enumeratorType = Type.IList;
+                            this.iList = list;
+                            break;
+                        default:
+                            this.enumeratorType = Type.Fallback;
+                            this.fallbackEnumerator = collection.GetEnumerator();
+                            break;
+                    }
+                }
+
+                private enum Type : byte
+                {
+                    Empty,
+                    IList,
+                    LinkedList,
+                    ImmutableHashSet,
+                    ImmutableList,
+                    HashSet,
+                    Fallback,
+                }
+
+                /// <summary>
+                /// Gets the element in the <see cref="IEnumerable{T}"/> at the current position of the enumerator.
+                /// </summary>
+                public T Current =>
+                    this.enumeratorType switch
+                    {
+                        Type.IList => (uint)this.listIndex < this.iList!.Count ? this.iList![this.listIndex] : default!,
+                        Type.LinkedList => this.concreteLinkedListEnumerator.Current,
+                        Type.ImmutableHashSet => this.concreteImmutableHashSetEnumerator.Current,
+                        Type.ImmutableList => this.concreteImmutableListEnumerator.Current,
+                        Type.HashSet => this.concreteHashSetEnumerator.Current,
+                        Type.Fallback => this.fallbackEnumerator!.Current,
+                        _ => default!,
+                    };
+
+                /// <summary>
+                /// Advances the enumerator to the next element of the <see cref="IEnumerable{T}"/>.
+                /// </summary>
+                /// <returns><see langword="true"/> if the enumerator was successfully advanced to the next element; <see langword="false"/> if
+                /// the enumerator has passed the end of the <see cref="IEnumerable{T}"/>.</returns>
+                public bool MoveNext() =>
+                    this.enumeratorType switch
+                    {
+                        Type.IList => ++this.listIndex < this.iList!.Count,
+                        Type.LinkedList => this.concreteLinkedListEnumerator.MoveNext(),
+                        Type.ImmutableHashSet => this.concreteImmutableHashSetEnumerator.MoveNext(),
+                        Type.ImmutableList => this.concreteImmutableListEnumerator.MoveNext(),
+                        Type.HashSet => this.concreteHashSetEnumerator.MoveNext(),
+                        Type.Fallback => this.fallbackEnumerator!.MoveNext(),
+                        _ => false,
+                    };
+
+                /// <summary>
+                /// Disposes the underlying enumerator.
+                /// </summary>
+                public void Dispose()
+                {
+                    switch (this.enumeratorType)
+                    {
+                        case Type.LinkedList:
+                            this.concreteLinkedListEnumerator.Dispose();
+                            break;
+
+                        case Type.ImmutableHashSet:
+                            this.concreteImmutableHashSetEnumerator.Dispose();
+                            break;
+
+                        case Type.ImmutableList:
+                            this.concreteImmutableListEnumerator.Dispose();
+                            break;
+
+                        case Type.HashSet:
+                            this.concreteHashSetEnumerator.Dispose();
+                            break;
+
+                        case Type.Fallback:
+                            this.fallbackEnumerator!.Dispose();
+                            break;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Tasks/SystemState.cs
+++ b/src/Tasks/SystemState.cs
@@ -456,9 +456,7 @@ namespace Microsoft.Build.Tasks
             // then we can short-circuit the File IO involved with GetAssemblyName()
             if (redistList != null)
             {
-                string extension = Path.GetExtension(path);
-
-                if (string.Equals(extension, ".dll", StringComparison.OrdinalIgnoreCase))
+                if (!string.IsNullOrEmpty(path) && path.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
                 {
                     IEnumerable<AssemblyEntry> assemblyNames = redistList.FindAssemblyNameFromSimpleName(
                             Path.GetFileNameWithoutExtension(path));


### PR DESCRIPTION
Fixes #

### Context
There is an appreciable amount of time all of the MSBuild process nodes spend doing GC during a build. Taking steps to reduce allocations. This PR contains a mix of approaches that reduce allocations in several areas.

### Changes Made


### Testing


### Notes
