### PR TITLE
Better handle event reset in LoggingService

### DIFF
--- a/src/Build/BackEnd/Components/Logging/LoggingService.cs
+++ b/src/Build/BackEnd/Components/Logging/LoggingService.cs
@@ -1401,29 +1401,43 @@ namespace Microsoft.Build.BackEnd.Logging
 
                 do
                 {
-                    if (_eventQueue.TryDequeue(out object ev))
+                    lock (_lockObject)
                     {
-                        LoggingEventProcessor(ev);
-                        _dequeueEvent?.Set();
-                    }
-                    else
-                    {
-                        _emptyQueueEvent?.Set();
-
-                        // Wait for next event, or finish.
-                        if (!completeAdding.IsCancellationRequested && _eventQueue.IsEmpty)
+                        if (_eventQueue.TryDequeue(out object ev))
                         {
-                            WaitHandle.WaitAny(waitHandlesForNextEvent);
+                            LoggingEventProcessor(ev);
+                            _dequeueEvent?.Set();
                         }
-
-                        lock (_lockObject)
+                        else
                         {
-                            _emptyQueueEvent?.Reset();
+                            _emptyQueueEvent?.Set();
+
+                            // Release lock before potentially long wait
+                            Monitor.Exit(_lockObject);
+                            try
+                            {
+                                // Only wait if we still need to
+                                if (!completeAdding.IsCancellationRequested && _eventQueue.IsEmpty)
+                                {
+                                    WaitHandle.WaitAny(waitHandlesForNextEvent);
+                                }
+                            }
+                            finally
+                            {
+                                // Reacquire lock
+                                Monitor.Enter(_lockObject);
+
+                                // Reset the event if we are not shutting down
+                                _emptyQueueEvent?.Reset();
+                            }
                         }
                     }
                 } while (!_eventQueue.IsEmpty || !completeAdding.IsCancellationRequested);
 
-                _emptyQueueEvent?.Set();
+                lock (_lockObject)
+                {
+                    _emptyQueueEvent?.Set();
+                }
             }
         }
 

--- a/src/Build/BackEnd/Components/Logging/LoggingService.cs
+++ b/src/Build/BackEnd/Components/Logging/LoggingService.cs
@@ -1389,7 +1389,6 @@ namespace Microsoft.Build.BackEnd.Logging
             _emptyQueueEvent = new ManualResetEvent(false);
             _enqueueEvent = new AutoResetEvent(false);
             _loggingEventProcessingCancellation = new CancellationTokenSource();
-
             _loggingEventProcessingThread = new Thread(LoggingEventProc);
             _loggingEventProcessingThread.Name = $"MSBuild LoggingService events queue pump: {this.GetHashCode()}";
             _loggingEventProcessingThread.IsBackground = true;
@@ -1399,41 +1398,40 @@ namespace Microsoft.Build.BackEnd.Logging
             {
                 var completeAdding = _loggingEventProcessingCancellation.Token;
                 WaitHandle[] waitHandlesForNextEvent = { completeAdding.WaitHandle, _enqueueEvent };
-
                 do
                 {
                     if (_eventQueue.TryDequeue(out object ev))
                     {
                         LoggingEventProcessor(ev);
-                        _dequeueEvent.Set();
+                        lock (_lockObject)
+                        {
+                            _dequeueEvent?.Set();
+                        }
                     }
                     else
                     {
-                        _emptyQueueEvent.Set();
-
+                        lock (_lockObject)
+                        {
+                            _emptyQueueEvent?.Set();
+                        }
                         // Wait for next event, or finish.
                         if (!completeAdding.IsCancellationRequested && _eventQueue.IsEmpty)
                         {
                             WaitHandle.WaitAny(waitHandlesForNextEvent);
                         }
-
-                        try 
+                        lock (_lockObject)
                         {
-                            _emptyQueueEvent.Reset();
-                        }
-                        catch (IOException)
-                        {
-                            // The handle has been invalidated or closed
-                            // Since we're likely in shutdown, just continue
-                            continue;
+                            _emptyQueueEvent?.Reset();
                         }
                     }
                 } while (!_eventQueue.IsEmpty || !completeAdding.IsCancellationRequested);
 
-                _emptyQueueEvent.Set();
+                lock (_lockObject)
+                {
+                    _emptyQueueEvent?.Set();
+                }
             }
         }
-
 
         /// <summary>
         /// Clean resources used for logging event processing queue.

--- a/src/Build/BackEnd/Components/Logging/LoggingService.cs
+++ b/src/Build/BackEnd/Components/Logging/LoggingService.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -1398,37 +1398,22 @@ namespace Microsoft.Build.BackEnd.Logging
             {
                 var completeAdding = _loggingEventProcessingCancellation.Token;
                 WaitHandle[] waitHandlesForNextEvent = { completeAdding.WaitHandle, _enqueueEvent };
-                do
+                lock (_lockObject)
                 {
                     if (_eventQueue.TryDequeue(out object ev))
                     {
                         LoggingEventProcessor(ev);
-                        lock (_lockObject)
-                        {
-                            _dequeueEvent?.Set();
-                        }
+                        _dequeueEvent?.Set();
                     }
                     else
                     {
-                        lock (_lockObject)
-                        {
-                            _emptyQueueEvent?.Set();
-                        }
-                        // Wait for next event, or finish.
+                        _emptyQueueEvent?.Set();
                         if (!completeAdding.IsCancellationRequested && _eventQueue.IsEmpty)
                         {
                             WaitHandle.WaitAny(waitHandlesForNextEvent);
                         }
-                        lock (_lockObject)
-                        {
-                            _emptyQueueEvent?.Reset();
-                        }
+                        _emptyQueueEvent?.Reset();
                     }
-                } while (!_eventQueue.IsEmpty || !completeAdding.IsCancellationRequested);
-
-                lock (_lockObject)
-                {
-                    _emptyQueueEvent?.Set();
                 }
             }
         }

--- a/src/Build/BackEnd/Components/Logging/LoggingService.cs
+++ b/src/Build/BackEnd/Components/Logging/LoggingService.cs
@@ -1417,7 +1417,16 @@ namespace Microsoft.Build.BackEnd.Logging
                             WaitHandle.WaitAny(waitHandlesForNextEvent);
                         }
 
-                        _emptyQueueEvent.Reset();
+                        try 
+                        {
+                            _emptyQueueEvent.Reset();
+                        }
+                        catch (IOException)
+                        {
+                            // The handle has been invalidated or closed
+                            // Since we're likely in shutdown, just continue
+                            continue;
+                        }
                     }
                 } while (!_eventQueue.IsEmpty || !completeAdding.IsCancellationRequested);
 

--- a/src/Build/BackEnd/Components/Logging/LoggingService.cs
+++ b/src/Build/BackEnd/Components/Logging/LoggingService.cs
@@ -10,12 +10,12 @@ using System.Reflection;
 using System.Threading;
 using Microsoft.Build.BackEnd.Components.RequestBuilder;
 using Microsoft.Build.Evaluation;
+using Microsoft.Build.Experimental.BuildCheck;
 using Microsoft.Build.Experimental.BuildCheck.Infrastructure;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
 using InternalLoggerException = Microsoft.Build.Exceptions.InternalLoggerException;
 using LoggerDescription = Microsoft.Build.Logging.LoggerDescription;
-using Microsoft.Build.Experimental.BuildCheck;
 
 #nullable disable
 
@@ -1398,22 +1398,31 @@ namespace Microsoft.Build.BackEnd.Logging
             {
                 var completeAdding = _loggingEventProcessingCancellation.Token;
                 WaitHandle[] waitHandlesForNextEvent = { completeAdding.WaitHandle, _enqueueEvent };
+
                 lock (_lockObject)
                 {
-                    if (_eventQueue.TryDequeue(out object ev))
+                    do
                     {
-                        LoggingEventProcessor(ev);
-                        _dequeueEvent?.Set();
-                    }
-                    else
-                    {
-                        _emptyQueueEvent?.Set();
-                        if (!completeAdding.IsCancellationRequested && _eventQueue.IsEmpty)
+                        if (_eventQueue.TryDequeue(out object ev))
                         {
-                            WaitHandle.WaitAny(waitHandlesForNextEvent);
+                            LoggingEventProcessor(ev);
+                            _dequeueEvent.Set();
                         }
-                        _emptyQueueEvent?.Reset();
-                    }
+                        else
+                        {
+                            _emptyQueueEvent.Set();
+
+                            // Wait for next event, or finish.
+                            if (!completeAdding.IsCancellationRequested && _eventQueue.IsEmpty)
+                            {
+                                WaitHandle.WaitAny(waitHandlesForNextEvent);
+                            }
+
+                            _emptyQueueEvent.Reset();
+                        }
+                    } while (!_eventQueue.IsEmpty || !completeAdding.IsCancellationRequested);
+
+                    _emptyQueueEvent.Set();
                 }
             }
         }

--- a/src/Build/BackEnd/Components/Logging/LoggingService.cs
+++ b/src/Build/BackEnd/Components/Logging/LoggingService.cs
@@ -1401,43 +1401,36 @@ namespace Microsoft.Build.BackEnd.Logging
 
                 do
                 {
-                    lock (_lockObject)
+                    if (_eventQueue.TryDequeue(out object ev))
                     {
-                        if (_eventQueue.TryDequeue(out object ev))
-                        {
-                            LoggingEventProcessor(ev);
-                            _dequeueEvent?.Set();
-                        }
-                        else
-                        {
-                            _emptyQueueEvent?.Set();
+                        LoggingEventProcessor(ev);
+                        _dequeueEvent?.Set();
+                    }
+                    else
+                    {
+                        _emptyQueueEvent?.Set();
 
-                            // Release lock before potentially long wait
-                            Monitor.Exit(_lockObject);
+                        if (!completeAdding.IsCancellationRequested && _eventQueue.IsEmpty)
+                        {
+                            WaitHandle.WaitAny(waitHandlesForNextEvent);
+                        }
+
+                        lock (_lockObject)
+                        {
                             try
                             {
-                                // Only wait if we still need to
-                                if (!completeAdding.IsCancellationRequested && _eventQueue.IsEmpty)
-                                {
-                                    WaitHandle.WaitAny(waitHandlesForNextEvent);
-                                }
-                            }
-                            finally
-                            {
-                                // Reacquire lock
-                                Monitor.Enter(_lockObject);
-
-                                // Reset the event if we are not shutting down
                                 _emptyQueueEvent?.Reset();
+                            }
+                            catch (ObjectDisposedException)
+                            {
+                                // Might be thrown if the event was set as null in shutdown.
+                                break;
                             }
                         }
                     }
                 } while (!_eventQueue.IsEmpty || !completeAdding.IsCancellationRequested);
 
-                lock (_lockObject)
-                {
-                    _emptyQueueEvent?.Set();
-                }
+                _emptyQueueEvent?.Set();
             }
         }
 


### PR DESCRIPTION
Fixes #
https://dev.azure.com/devdiv/DevDiv/_workitems/edit/2320135/

### Context
`Reset()` method invocation sometimes causes exception `System.IO.IOException: 'The handle is invalid.'`.
Very likely it happens on application shutdown.
The assumption is:
- [ShutdownComponent](https://github.com/dotnet/msbuild/blob/71e99de14ceadc86db7ee46551bd709a788bb95a/src/Build/BackEnd/Components/Logging/LoggingService.cs#L888) starts and gets the _lockObject
- It cleans up/disposes the events
- _Meanwhile_ our logging thread is trying to use those same [events ](https://github.com/dotnet/msbuild/blob/71e99de14ceadc86db7ee46551bd709a788bb95a/src/Build/BackEnd/Components/Logging/LoggingService.cs#L1432) without checking _lockObject in context of StartLoggingEventProcessing()

### Changes Made
use the same lock in StartLoggingEventProcessing() to protect a handle from invalid state.

### Testing
n/a
