### PR TITLE
Fix item update evaluation when path contains parenthesis and add test coverage

### DIFF
--- a/src/Build/Evaluation/LazyItemEvaluator.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.cs
@@ -384,7 +384,7 @@ namespace Microsoft.Build.Evaluation
                                 break;
                             }
 
-                            string fullPath = FileUtilities.GetFullPath(frag.TextFragment, frag.ProjectDirectory);
+                            string fullPath = FileUtilities.NormalizePathForComparisonNoThrow(frag.TextFragment, frag.ProjectDirectory);
                             if (itemsWithNoWildcards.ContainsKey(fullPath))
                             {
                                 // Another update will already happen on this path. Make that happen before evaluating this one.


### PR DESCRIPTION
Fixes https://github.com/dotnet/msbuild/issues/11237

### Context

Currently we put **a non-normalized** path in the dictionary
[msbuild/src/Build/Evaluation/LazyItemEvaluator.cs](https://github.com/dotnet/msbuild/blob/ec6b2a31a9388c298c4cab5be34ec2402372c5ce/src/Build/Evaluation/LazyItemEvaluator.cs#L387)

and later attempt to pull from it a **normalized** version
[msbuild/src/Build/Evaluation/LazyItemEvaluator.cs](https://github.com/dotnet/msbuild/blob/ec6b2a31a9388c298c4cab5be34ec2402372c5ce/src/Build/Evaluation/LazyItemEvaluator.cs#L443)

In runtime it looks like this when path contains parenthesis:
we **put** C:\msbuild\msbuild_yk\msbuild\artifacts\bin\bootstrap\core\CheckSignApk%28\Microsoft.NETCore.App
we **pull** C:\msbuild\msbuild_yk\msbuild\artifacts\bin\bootstrap\core\CheckSignApk(\Microsoft.NETCore.App

### Changes Made
adjust operation of adding to the dictionary and pulling values from it.

### Testing
UI + manual
