### PR TITLE
Adjust embeddedresource culture warning

### DIFF
--- a/src/BuildCheck.UnitTests/EndToEndTests.cs
+++ b/src/BuildCheck.UnitTests/EndToEndTests.cs
@@ -169,7 +169,7 @@ public class EndToEndTests : IDisposable
 
         _env.SetCurrentDirectory(Path.Combine(workFolder.Path, entryProjectName));
 
-        string output = RunnerUtilities.ExecBootstrapedMSBuild("-check -restore /p:RespectCulture=" + (respectCulture ? "True" : "\"\""), out bool success);
+        string output = RunnerUtilities.ExecBootstrapedMSBuild("-check -restore /p:WarnOnCultureOverwritten=True /p:RespectCulture=" + (respectCulture ? "True" : "\"\""), out bool success);
         _env.Output.WriteLine(output);
         _env.Output.WriteLine("=========================");
         success.ShouldBeTrue();

--- a/src/Tasks/AssignCulture.cs
+++ b/src/Tasks/AssignCulture.cs
@@ -49,6 +49,11 @@ namespace Microsoft.Build.Tasks
         public bool RespectAlreadyAssignedItemCulture { get; set; } = false;
 
         /// <summary>
+        /// If the flag set to 'true' the task will log a warning when the culture metadata is overwritten by the task.
+        /// </summary>
+        public bool WarnOnCultureOverwritten { get; set; } = false;
+
+        /// <summary>
         /// This outgoing list of files is exactly the same as the incoming Files
         /// list except that an attribute name "Culture" will have been added if
         /// the particular file name is in the form:
@@ -160,7 +165,7 @@ namespace Microsoft.Build.Tasks
                             ConversionUtilities.ValidBooleanFalse(AssignedFiles[i].GetMetadata(ItemMetadataNames.withCulture)));
 
                         // The culture was explicitly specified, but not opted in via 'RespectAlreadyAssignedItemCulture' and different will be used
-                        if (ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_14) &&
+                        if (WarnOnCultureOverwritten &&
                             !string.IsNullOrEmpty(existingCulture) &&
                             !MSBuildNameIgnoreCaseComparer.Default.Equals(existingCulture, info.culture))
                         {

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -3287,6 +3287,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
     <PropertyGroup>
       <RespectAlreadyAssignedItemCulture Condition="'$(RespectAlreadyAssignedItemCulture)' == ''">false</RespectAlreadyAssignedItemCulture>
+      <WarnOnCultureOverwritten Condition="'$(WarnOnCultureOverwritten)' == ''">false</WarnOnCultureOverwritten>
     </PropertyGroup>
 
     <MSBuildInternalMessage Condition="'@(ResxWithNoCulture)'!=''" ResourceName="CommonSdk.SplitResourcesByCultureEmbeddedResourceMessage" Severity="Warning" FormatArguments="MSB9000;ResxWithNoCulture" />
@@ -3306,7 +3307,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       </EmbeddedResource>
     </ItemGroup>
 
-    <AssignCulture Files="@(EmbeddedResource)" Condition="'%(Extension)'!='.licx'"  RespectAlreadyAssignedItemCulture="$(RespectAlreadyAssignedItemCulture)">
+    <AssignCulture Files="@(EmbeddedResource)" Condition="'%(Extension)'!='.licx'"  RespectAlreadyAssignedItemCulture="$(RespectAlreadyAssignedItemCulture)" WarnOnCultureOverwritten="$(WarnOnCultureOverwritten)">
       <!-- Create the list of culture resx and embedded resource files -->
       <Output TaskParameter="AssignedFilesWithCulture" ItemName="_MixedResourceWithCulture"/>
       <!-- Create the list of non-culture resx and embedded resource files -->


### PR DESCRIPTION
Fixes  #11313

### Context
The newly added `MSB3002` has a breaking potential (while it's very correct). So making it an opt-in behavior
