### PR TITLE
Respect warnings as errors warnings as messages and warnings not as errors

### DIFF
--- a/documentation/wiki/ChangeWaves.md
+++ b/documentation/wiki/ChangeWaves.md
@@ -27,6 +27,7 @@ A wave of features is set to "rotate out" (i.e. become standard functionality) t
 ### 17.14
 - [.SLNX support - use the new parser for .sln and .slnx](https://github.com/dotnet/msbuild/pull/10836)
 - [Support custom culture in RAR](https://github.com/dotnet/msbuild/pull/11000)
+- [WarningsAsMessages, WarningsAsErrors, WarningsNotAsErrors are now supported on the engine side of MSBuild](https://github.com/dotnet/msbuild/pull/10942)
 
 ### 17.12
 - [Log TaskParameterEvent for scalar parameters](https://github.com/dotnet/msbuild/pull/9908)

--- a/src/Build.UnitTests/WarningsAsMessagesAndErrors_Tests.cs
+++ b/src/Build.UnitTests/WarningsAsMessagesAndErrors_Tests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -9,7 +9,6 @@ using Microsoft.Build.UnitTests;
 using Shouldly;
 using Xunit;
 using Xunit.Abstractions;
-using static System.Net.WebRequestMethods;
 
 #nullable disable
 

--- a/src/Build.UnitTests/WarningsAsMessagesAndErrors_Tests.cs
+++ b/src/Build.UnitTests/WarningsAsMessagesAndErrors_Tests.cs
@@ -9,6 +9,7 @@ using Microsoft.Build.UnitTests;
 using Shouldly;
 using Xunit;
 using Xunit.Abstractions;
+using static System.Net.WebRequestMethods;
 
 #nullable disable
 
@@ -35,7 +36,7 @@ namespace Microsoft.Build.Engine.UnitTests
             ObjectModelHelpers.BuildProjectExpectSuccess(GetTestProject(treatAllWarningsAsErrors: false));
         }
 
-        [Fact]
+        [Fact (Skip = "TreatWarningAsErrors is excluded in the first wave of the unification. See https://github.com/dotnet/msbuild/issues/10871")]
         public void TreatAllWarningsAsErrorsNoPrefix()
         {
             MockLogger logger = ObjectModelHelpers.BuildProjectExpectFailure(GetTestProject(customProperties: new Dictionary<string, string>
@@ -354,9 +355,10 @@ namespace Microsoft.Build.Engine.UnitTests
         [InlineData("MSB1235", "MSB1234", "MSB1234", "MSB1234", false)] // Log MSB1234, treat as error via MSBuildWarningsAsErrors
         [InlineData("MSB1235", "", "MSB1234", "MSB1234", true)] // Log MSB1234, expect MSB1234 as error via MSBuildTreatWarningsAsErrors
         [InlineData("MSB1234", "MSB1234", "MSB1234", "MSB4181", true)]// Log MSB1234, MSBuildWarningsAsMessages takes priority
-        [InlineData("MSB1235", "MSB1234", "MSB1234", "MSB1234", false, false)] // Log MSB1234, treat as error via BuildWarningsAsErrors
-        [InlineData("MSB1235", "", "MSB1234", "MSB1234", true, false)] // Log MSB1234, expect MSB1234 as error via BuildTreatWarningsAsErrors
-        [InlineData("MSB1234", "MSB1234", "MSB1234", "MSB4181", true, false)]// Log MSB1234, BuildWarningsAsMessages takes priority
+        // TreatWarningAsErrors is excluded in the first wave of the unification.See https://github.com/dotnet/msbuild/issues/10871
+        // [InlineData("MSB1235", "MSB1234", "MSB1234", "MSB1234", false, false)] // Log MSB1234, treat as error via BuildWarningsAsErrors
+        // [InlineData("MSB1235", "", "MSB1234", "MSB1234", true, false)] // Log MSB1234, expect MSB1234 as error via BuildTreatWarningsAsErrors
+        // [InlineData("MSB1234", "MSB1234", "MSB1234", "MSB4181", true, false)]// Log MSB1234, BuildWarningsAsMessages takes priority
         public void WarningsAsErrorsAndMessages_Tests(string WarningsAsMessages,
                                                       string WarningsAsErrors,
                                                       string WarningToLog,
@@ -529,8 +531,9 @@ namespace Microsoft.Build.Engine.UnitTests
         [Theory]
         [InlineData("MSB1234", false, 1, 1)]
         [InlineData("MSB0000", true, 0, 2)]
-        [InlineData("MSB1234", false, 1, 1, false)]
-        [InlineData("MSB0000", true, 0, 2, false)]
+        // TreatWarningAsErrors is excluded in the first wave of the unification.See https://github.com/dotnet/msbuild/issues/10871
+        // [InlineData("MSB1234", false, 1, 1, false)  
+        // [InlineData("MSB0000", true, 0, 2, false)
         public void TaskReturnsTrue_Tests(string warningsAsErrors, bool treatAllWarningsAsErrors, int warningCountShouldBe, int errorCountShouldBe, bool useMSPrefix = true)
         {
             string prefix = useMSPrefix ? "MSBuild" : "";

--- a/src/Build.UnitTests/WarningsAsMessagesAndErrors_Tests.cs
+++ b/src/Build.UnitTests/WarningsAsMessagesAndErrors_Tests.cs
@@ -428,6 +428,7 @@ namespace Microsoft.Build.Engine.UnitTests
         [InlineData("WarningsAsErrors", "MSB1007", false)]
         [InlineData("WarningsAsMessages", "MSB1007", false)]
         [InlineData("WarningsNotAsErrors", "MSB1007", true)]
+        [InlineData("WarningsNotAsErrors", "MSB1007", false)]
         public void WarningsChangeWaveTest(string property, string propertyData, bool treatWarningsAsErrors)
         {
             using (TestEnvironment env = TestEnvironment.Create(_output))
@@ -449,6 +450,8 @@ namespace Microsoft.Build.Engine.UnitTests
                 {
                     // Since the "no prefix" variations can't do anything with the change wave disabled, this should always fail.
                     MockLogger logger = proj.BuildProjectExpectFailure();
+                    logger.ErrorCount.ShouldBe(1);
+                    logger.AssertLogContains(warningCode);
                 }
                 else
                 {
@@ -459,6 +462,7 @@ namespace Microsoft.Build.Engine.UnitTests
 
                     logger.AssertLogContains(warningCode);
                 }
+                ChangeWaves.ResetStateForTests();
             }
         }
 

--- a/src/Build.UnitTests/WarningsAsMessagesAndErrors_Tests.cs
+++ b/src/Build.UnitTests/WarningsAsMessagesAndErrors_Tests.cs
@@ -451,6 +451,8 @@ namespace Microsoft.Build.Engine.UnitTests
                     // Since the "no prefix" variations can't do anything with the change wave disabled, this should always fail.
                     MockLogger logger = proj.BuildProjectExpectFailure();
                     logger.ErrorCount.ShouldBe(1);
+                    logger.AssertLogContains($"error {warningCode}");
+
                     logger.AssertLogContains(warningCode);
                 }
                 else
@@ -458,11 +460,11 @@ namespace Microsoft.Build.Engine.UnitTests
                     MockLogger logger = proj.BuildProjectExpectSuccess();
 
                     logger.WarningCount.ShouldBe(1);
+                    logger.AssertLogContains($"warning {warningCode}");
                     logger.ErrorCount.ShouldBe(0);
 
                     logger.AssertLogContains(warningCode);
                 }
-                ChangeWaves.ResetStateForTests();
             }
         }
 

--- a/src/Build.UnitTests/WarningsAsMessagesAndErrors_Tests.cs
+++ b/src/Build.UnitTests/WarningsAsMessagesAndErrors_Tests.cs
@@ -252,7 +252,8 @@ namespace Microsoft.Build.Engine.UnitTests
                         new KeyValuePair<string, string>("WarningsNotAsErrors", $@"$(WarningsNotAsErrors);
                                                                                        {ExpectedEventCode.ToLowerInvariant()}"),
                         new KeyValuePair<string, string>("WarningsNotAsErrors", "$(WarningsNotAsErrors);ABC")
-                    }));
+                    }),
+                _output);
 
             VerifyBuildWarningEvent(logger);
         }
@@ -268,7 +269,8 @@ namespace Microsoft.Build.Engine.UnitTests
                         new KeyValuePair<string, string>("WarningsNotAsErrors", $@"$(MSBuildWarningsNotAsErrors);
                                                                                        {ExpectedEventCode.ToLowerInvariant()}"),
                         new KeyValuePair<string, string>("MSBuildWarningsNotAsErrors", "$(WarningsNotAsErrors);ABC")
-                    }));
+                    }),
+                _output);
 
             VerifyBuildWarningEvent(logger);
         }
@@ -287,7 +289,8 @@ namespace Microsoft.Build.Engine.UnitTests
                         new KeyValuePair<string, string>($@"{prefix}WarningsAsErrors", $@"$({prefix}WarningsAsErrors);
                                                                                        {ExpectedEventCode.ToLowerInvariant()}"),
                         new KeyValuePair<string, string>($@"{prefix}WarningsAsErrors", $@"$({prefix}WarningsAsErrors);ABC")
-                    }));
+                    }),
+                _output);
 
             VerifyBuildErrorEvent(logger);
         }
@@ -304,7 +307,8 @@ namespace Microsoft.Build.Engine.UnitTests
                         new KeyValuePair<string, string>("MSBuildWarningsAsErrors", $@"$(WarningsAsErrors);
                                                                                        {ExpectedEventCode.ToLowerInvariant()}"),
                         new KeyValuePair<string, string>("WarningsAsErrors", "$(MSBuildWarningsAsErrors);ABC")
-                    }));
+                    }),
+                _output);
 
             VerifyBuildErrorEvent(logger);
         }
@@ -318,7 +322,8 @@ namespace Microsoft.Build.Engine.UnitTests
                     {
                         new KeyValuePair<string, string>("MSBuildWarningsAsMessages", "123"),
                         new KeyValuePair<string, string>("MSBuildWarningsAsMessages", "$(MSBuildWarningsAsMessages);ABC")
-                    }));
+                    }),
+                _output);
 
             VerifyBuildWarningEvent(logger);
         }

--- a/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
@@ -1390,7 +1390,8 @@ namespace Microsoft.Build.BackEnd
             // Ensure everything that is required is available at this time
             if (project != null && buildEventContext != null && loggingService != null && buildEventContext.ProjectInstanceId != BuildEventContext.InvalidProjectInstanceId)
             {
-                if (String.Equals(project.GetEngineRequiredPropertyValue(MSBuildConstants.TreatWarningsAsErrors)?.Trim(), "true", StringComparison.OrdinalIgnoreCase))
+                if (String.Equals(project.GetEngineRequiredPropertyValue(MSBuildConstants.TreatWarningsAsErrors)?.Trim(), "true", StringComparison.OrdinalIgnoreCase) ||
+                    String.Equals(project.GetEngineRequiredPropertyValue(MSBuildConstants.TreatWarningsAsErrorsNoPrefix)?.Trim(), "true", StringComparison.OrdinalIgnoreCase))
                 {
                     // If <MSBuildTreatWarningsAsErrors was specified then an empty ISet<string> signals the IEventSourceSink to treat all warnings as errors
                     loggingService.AddWarningsAsErrors(buildEventContext, new HashSet<string>());
@@ -1398,6 +1399,20 @@ namespace Microsoft.Build.BackEnd
                 else
                 {
                     ISet<string> warningsAsErrors = ParseWarningCodes(project.GetEngineRequiredPropertyValue(MSBuildConstants.WarningsAsErrors));
+                    var warningsAsErrorsNoPrefix = ParseWarningCodes(project.GetEngineRequiredPropertyValue(MSBuildConstants.WarningsAsErrorsNoPrefix));
+                    if (warningsAsErrorsNoPrefix != null)
+                    {
+                        if (warningsAsErrors != null)
+                        {
+                            warningsAsErrors.UnionWith(warningsAsErrorsNoPrefix);
+                        }
+                        else
+                        {
+                            warningsAsErrors = warningsAsErrorsNoPrefix;
+                        }
+                    }
+
+
 
                     if (warningsAsErrors?.Count > 0)
                     {
@@ -1406,6 +1421,20 @@ namespace Microsoft.Build.BackEnd
                 }
 
                 ISet<string> warningsNotAsErrors = ParseWarningCodes(project.GetEngineRequiredPropertyValue(MSBuildConstants.WarningsNotAsErrors));
+                var warningsNotAsErrorsNoPrefix = ParseWarningCodes(project.GetEngineRequiredPropertyValue(MSBuildConstants.WarningsNotAsErrorsNoPrefix));
+                if (warningsNotAsErrorsNoPrefix != null)
+                {
+                    if (warningsNotAsErrors != null)
+                    {
+                        warningsNotAsErrors.UnionWith(warningsNotAsErrorsNoPrefix);
+                    }
+                    else
+                    {
+                        warningsNotAsErrors = warningsNotAsErrorsNoPrefix;
+                    }
+                }
+
+
 
                 if (warningsNotAsErrors?.Count > 0)
                 {
@@ -1413,6 +1442,12 @@ namespace Microsoft.Build.BackEnd
                 }
 
                 ISet<string> warningsAsMessages = ParseWarningCodes(project.GetEngineRequiredPropertyValue(MSBuildConstants.WarningsAsMessages));
+                var warningsAsMessagesNoPrefix = ParseWarningCodes(project.GetEngineRequiredPropertyValue(MSBuildConstants.WarningsAsMessagesNoPrefix));
+                if (warningsAsMessagesNoPrefix != null)
+                {
+                    warningsAsMessages?.UnionWith(warningsAsMessagesNoPrefix);
+                    warningsAsMessages ??= warningsAsMessagesNoPrefix;
+                }
 
                 if (warningsAsMessages?.Count > 0)
                 {

--- a/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
@@ -8,7 +8,6 @@ using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Linq;
-using System.Reflection.Metadata.Ecma335;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Build.BackEnd.Logging;
@@ -1469,7 +1468,6 @@ namespace Microsoft.Build.BackEnd
 
             return result2;
         }
-
 
         private sealed class DedicatedThreadsTaskScheduler : TaskScheduler
         {

--- a/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
@@ -1390,9 +1390,7 @@ namespace Microsoft.Build.BackEnd
             // Ensure everything that is required is available at this time
             if (project != null && buildEventContext != null && loggingService != null && buildEventContext.ProjectInstanceId != BuildEventContext.InvalidProjectInstanceId)
             {
-                if (String.Equals(project.GetEngineRequiredPropertyValue(MSBuildConstants.MSBuildPrefix + MSBuildConstants.TreatWarningsAsErrors)?.Trim(), "true", StringComparison.OrdinalIgnoreCase) ||
-                    (String.Equals(project.GetEngineRequiredPropertyValue(MSBuildConstants.TreatWarningsAsErrors)?.Trim(), "true", StringComparison.OrdinalIgnoreCase) &&
-                     ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_14)))
+                if (String.Equals(project.GetEngineRequiredPropertyValue(MSBuildConstants.MSBuildPrefix + MSBuildConstants.TreatWarningsAsErrors)?.Trim(), "true", StringComparison.OrdinalIgnoreCase))
                 {
                     // If <MSBuildTreatWarningsAsErrors was specified then an empty ISet<string> signals the IEventSourceSink to treat all warnings as errors
                     loggingService.AddWarningsAsErrors(buildEventContext, new HashSet<string>());

--- a/src/Shared/Constants.cs
+++ b/src/Shared/Constants.cs
@@ -29,45 +29,29 @@ namespace Microsoft.Build.Shared
         internal const string SdksPath = "MSBuildSDKsPath";
 
         /// <summary>
-        /// Name of the property that indicates that all warnings should be treated as errors.
+        ///  The prefix that was originally used. Now extracted out for the purpose of allowing even the non-prefixed variant.
         /// </summary>
-        internal const string TreatWarningsAsErrors = "MSBuildTreatWarningsAsErrors";
+        internal const string MSBuildPrefix = "MSBuild";
 
         /// <summary>
         /// Name of the property that indicates that all warnings should be treated as errors.
         /// </summary>
-        internal const string TreatWarningsAsErrorsNoPrefix = "TreatWarningsAsErrors";
+        internal const string TreatWarningsAsErrors = "TreatWarningsAsErrors";
 
         /// <summary>
         /// Name of the property that indicates a list of warnings to treat as errors.
         /// </summary>
-        internal const string WarningsAsErrors = "MSBuildWarningsAsErrors";
-
-        /// <summary>
-        /// Name of the property that indicates a list of warnings to treat as errors.
-        /// </summary>
-        internal const string WarningsAsErrorsNoPrefix = "WarningsAsErrors";
+        internal const string WarningsAsErrors = "WarningsAsErrors";
 
         /// <summary>
         /// Name of the property that indicates a list of warnings to not treat as errors.
         /// </summary>
-        internal const string WarningsNotAsErrors = "MSBuildWarningsNotAsErrors";
-
-        /// <summary>
-        /// Name of the property that indicates a list of warnings to not treat as errors.
-        /// </summary>
-        internal const string WarningsNotAsErrorsNoPrefix = "WarningsNotAsErrors";
+        internal const string WarningsNotAsErrors = "WarningsNotAsErrors";
 
         /// <summary>
         /// Name of the property that indicates the list of warnings to treat as messages.
         /// </summary>
-        internal const string WarningsAsMessages = "MSBuildWarningsAsMessages";
-
-
-        /// <summary>
-        /// Name of the property that indicates the list of warnings to treat as messages.
-        /// </summary>
-        internal const string WarningsAsMessagesNoPrefix = "WarningsAsMessages";
+        internal const string WarningsAsMessages = "WarningsAsMessages";
 
         /// <summary>
         /// The name of the environment variable that users can specify to override where NuGet assemblies are loaded from in the NuGetSdkResolver.

--- a/src/Shared/Constants.cs
+++ b/src/Shared/Constants.cs
@@ -34,9 +34,19 @@ namespace Microsoft.Build.Shared
         internal const string TreatWarningsAsErrors = "MSBuildTreatWarningsAsErrors";
 
         /// <summary>
+        /// Name of the property that indicates that all warnings should be treated as errors.
+        /// </summary>
+        internal const string TreatWarningsAsErrorsNoPrefix = "TreatWarningsAsErrors";
+
+        /// <summary>
         /// Name of the property that indicates a list of warnings to treat as errors.
         /// </summary>
         internal const string WarningsAsErrors = "MSBuildWarningsAsErrors";
+
+        /// <summary>
+        /// Name of the property that indicates a list of warnings to treat as errors.
+        /// </summary>
+        internal const string WarningsAsErrorsNoPrefix = "WarningsAsErrors";
 
         /// <summary>
         /// Name of the property that indicates a list of warnings to not treat as errors.
@@ -44,9 +54,20 @@ namespace Microsoft.Build.Shared
         internal const string WarningsNotAsErrors = "MSBuildWarningsNotAsErrors";
 
         /// <summary>
+        /// Name of the property that indicates a list of warnings to not treat as errors.
+        /// </summary>
+        internal const string WarningsNotAsErrorsNoPrefix = "WarningsNotAsErrors";
+
+        /// <summary>
         /// Name of the property that indicates the list of warnings to treat as messages.
         /// </summary>
         internal const string WarningsAsMessages = "MSBuildWarningsAsMessages";
+
+
+        /// <summary>
+        /// Name of the property that indicates the list of warnings to treat as messages.
+        /// </summary>
+        internal const string WarningsAsMessagesNoPrefix = "WarningsAsMessages";
 
         /// <summary>
         /// The name of the environment variable that users can specify to override where NuGet assemblies are loaded from in the NuGetSdkResolver.

--- a/src/UnitTests.Shared/ObjectModelHelpers.cs
+++ b/src/UnitTests.Shared/ObjectModelHelpers.cs
@@ -782,8 +782,13 @@ namespace Microsoft.Build.UnitTests
         /// expected to fail.
         /// </summary>
         /// <param name="projectContents">The project file content in string format.</param>
+        ///  <param name="testOutputHelper"><see cref="ITestOutputHelper"/> to log to.</param>
+        /// <param name="loggerVerbosity">The required logging verbosity.</param>
         /// <returns>The <see cref="MockLogger"/> that was used during evaluation and build.</returns>
-        public static MockLogger BuildProjectExpectFailure([StringSyntax(StringSyntaxAttribute.Xml)] string projectContents)
+        public static MockLogger BuildProjectExpectFailure(
+            [StringSyntax(StringSyntaxAttribute.Xml)] string projectContents,
+            ITestOutputHelper testOutputHelper = null,
+            LoggerVerbosity loggerVerbosity = LoggerVerbosity.Normal)
         {
             MockLogger logger = new MockLogger(testOutputHelper);
             BuildProjectExpectFailure(projectContents, logger);

--- a/src/UnitTests.Shared/ObjectModelHelpers.cs
+++ b/src/UnitTests.Shared/ObjectModelHelpers.cs
@@ -785,7 +785,7 @@ namespace Microsoft.Build.UnitTests
         /// <returns>The <see cref="MockLogger"/> that was used during evaluation and build.</returns>
         public static MockLogger BuildProjectExpectFailure([StringSyntax(StringSyntaxAttribute.Xml)] string projectContents)
         {
-            MockLogger logger = new MockLogger();
+            MockLogger logger = new MockLogger(testOutputHelper);
             BuildProjectExpectFailure(projectContents, logger);
             return logger;
         }


### PR DESCRIPTION
# Fixes https://github.com/dotnet/msbuild/issues/10871
Only a partial fix due to the TreatWarningsAsErrors issues, for more detail see the linked ticket.

### Context
The MSBuild currently has an odd way of handling the WarningsAsErrors, WarningsNotAsErrors and WarningsAsMessages properties as opposed to their MSBuild<> counterparts. This is due to the way that these are translated in a MSBuild target, which has some issues. See the linked tickets.
This is a PR to unify the behavior, with the caveat that the TreatWarningsAsErrors which is also an offender is excluded since it is currently a breaking change for many builds.

Hidden behind changewave 17.14

### Changes Made
Unification of
WarningsAsErrors
WarningsNotAsErrors
WarningsAsMessages
with their MSBuild<> counterpart on the engine level.

### Testing
Unit testing in WarningsAsMessagesAndErrors_Tests.cs

### Notes
I've left the tests for TreatWarningsAsErrors tests in a disabled / commented state. If we want to push forward with the further unification down the line, this will be useful. If this is too far in the future, I can remove them altogether.
