### PR TITLE
Removing last instances of the BinaryFormatter

### DIFF
--- a/src/Build.UnitTests/BackEnd/BuildManager_Logging_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/BuildManager_Logging_Tests.cs
@@ -78,8 +78,13 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
             _env = TestEnvironment.Create(output);
         }
 
-        [Fact]
-        public void Build_WithCustomBuildArgs_ShouldEmitError()
+        [DotNetOnlyFact]
+        public void Build_WithCustomBuildArgs_ShouldEmitErrorOnNetCore() => Build_WithCustomBuildArgs_ShouldEmitEvent<BuildErrorEventArgs>();
+
+        [WindowsFullFrameworkOnlyFact]
+        public void Build_WithCustomBuildArgs_ShouldEmitWarningOnFramework() => Build_WithCustomBuildArgs_ShouldEmitEvent<BuildWarningEventArgs>();
+
+        private void Build_WithCustomBuildArgs_ShouldEmitEvent<T>() where T : LazyFormattedBuildEventArgs
         {
             var testFiles = _env.CreateTestProjectWithFiles(string.Empty, ["main", "child1"], string.Empty);
 
@@ -111,8 +116,8 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
                 var result = submission.Execute();
                 var allEvents = _logger.AllBuildEvents;
 
-                allEvents.OfType<BuildErrorEventArgs>().ShouldHaveSingleItem();
-                allEvents.First(x => x is BuildErrorEventArgs).Message.ShouldContain(
+                allEvents.OfType<T>().ShouldHaveSingleItem();
+                allEvents.First(x => x is T).Message.ShouldContain(
                     string.Format(ResourceUtilities.GetResourceString("DeprecatedEventSerialization"),
                     "MyCustomBuildEventArgs"));
             }

--- a/src/Build.UnitTests/BackEnd/BuildManager_Logging_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/BuildManager_Logging_Tests.cs
@@ -115,7 +115,6 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
                 allEvents.First(x => x is BuildErrorEventArgs).Message.ShouldContain(
                     string.Format(ResourceUtilities.GetResourceString("DeprecatedEventSerialization"),
                     "MyCustomBuildEventArgs"));
-
             }
             finally
             {

--- a/src/Build/BackEnd/Components/Logging/LoggingService.cs
+++ b/src/Build/BackEnd/Components/Logging/LoggingService.cs
@@ -971,56 +971,9 @@ namespace Microsoft.Build.BackEnd.Logging
             LogMessagePacket loggingPacket = (LogMessagePacket)packet;
             InjectNonSerializedData(loggingPacket);
 
-            WarnOnDeprecatedCustomArgsSerialization(loggingPacket);
+            ErrorUtilities.VerifyThrow(loggingPacket.EventType != LoggingEventType.CustomEvent, "Custom event types are no longer supported. The check should be implemented in OutOfPRocNode.SendPacket");
 
             ProcessLoggingEvent(loggingPacket.NodeBuildEvent);
-        }
-
-        /// <summary>
-        /// Serializing unknown CustomEvent which has to use unsecure BinaryFormatter by TranslateDotNet.
-        /// Since BinaryFormatter is going to be deprecated, log warning so users can use new Extended*EventArgs instead of custom
-        /// EventArgs derived from existing EventArgs.
-        /// </summary>
-        private void WarnOnDeprecatedCustomArgsSerialization(LogMessagePacket loggingPacket)
-        {
-            if (loggingPacket.EventType == LoggingEventType.CustomEvent
-                && Traits.Instance.EscapeHatches.EnableWarningOnCustomBuildEvent)
-            {
-                BuildEventArgs buildEvent = loggingPacket.NodeBuildEvent.Value.Value;
-                BuildEventContext buildEventContext = buildEvent?.BuildEventContext ?? BuildEventContext.Invalid;
-
-                string message = ResourceUtilities.FormatResourceStringStripCodeAndKeyword(
-                    out string warningCode,
-                    out string helpKeyword,
-                    "DeprecatedEventSerialization",
-                    buildEvent?.GetType().Name ?? string.Empty);
-
-                BuildWarningEventArgs warning = new(
-                    null,
-                    warningCode,
-                    BuildEventFileInfo.Empty.File,
-                    BuildEventFileInfo.Empty.Line,
-                    BuildEventFileInfo.Empty.Column,
-                    BuildEventFileInfo.Empty.EndLine,
-                    BuildEventFileInfo.Empty.EndColumn,
-                    message,
-                    helpKeyword,
-                    "MSBuild");
-
-                warning.BuildEventContext = buildEventContext;
-                if (warning.ProjectFile == null && buildEventContext.ProjectContextId != BuildEventContext.InvalidProjectContextId)
-                {
-                    warning.ProjectFile = buildEvent switch
-                    {
-                        BuildMessageEventArgs buildMessageEvent => buildMessageEvent.ProjectFile,
-                        BuildErrorEventArgs buildErrorEvent => buildErrorEvent.ProjectFile,
-                        BuildWarningEventArgs buildWarningEvent => buildWarningEvent.ProjectFile,
-                        _ => null,
-                    };
-                }
-
-                ProcessLoggingEvent(warning);
-            }
         }
 
         /// <summary>

--- a/src/Build/BackEnd/Components/Logging/LoggingService.cs
+++ b/src/Build/BackEnd/Components/Logging/LoggingService.cs
@@ -971,7 +971,7 @@ namespace Microsoft.Build.BackEnd.Logging
             LogMessagePacket loggingPacket = (LogMessagePacket)packet;
             InjectNonSerializedData(loggingPacket);
 
-            ErrorUtilities.VerifyThrow(loggingPacket.EventType != LoggingEventType.CustomEvent, "Custom event types are no longer supported. The check should be implemented in OutOfPRocNode.SendPacket");
+            ErrorUtilities.VerifyThrow(loggingPacket.EventType != LoggingEventType.CustomEvent, "Custom event types are no longer supported. Does the sending node have a different version?");
 
             ProcessLoggingEvent(loggingPacket.NodeBuildEvent);
         }

--- a/src/Build/BackEnd/Node/OutOfProcNode.cs
+++ b/src/Build/BackEnd/Node/OutOfProcNode.cs
@@ -591,9 +591,14 @@ namespace Microsoft.Build.Execution
                     // Serializing unknown CustomEvent which has to use unsecure BinaryFormatter by TranslateDotNet<T>
                     // Since BinaryFormatter is deprecated in dotnet 8+, log error so users discover root cause easier
                     // then by reading CommTrace where it would be otherwise logged as critical infra error.
-                    _loggingService.LogError(_loggingContext?.BuildEventContext ?? BuildEventContext.Invalid, null, BuildEventFileInfo.Empty,
-                            "DeprecatedEventSerialization",
-                            buildEvent?.GetType().Name ?? string.Empty);
+#if RUNTIME_TYPE_NETCORE
+                    _loggingService.LogError(
+#else
+                    _loggingService.LogWarning(
+#endif
+                        _loggingContext?.BuildEventContext ?? BuildEventContext.Invalid, null, BuildEventFileInfo.Empty,
+                        "DeprecatedEventSerialization",
+                        buildEvent?.GetType().Name ?? string.Empty);
                 }
                 else
                 {

--- a/src/Build/BackEnd/Node/OutOfProcNode.cs
+++ b/src/Build/BackEnd/Node/OutOfProcNode.cs
@@ -583,10 +583,8 @@ namespace Microsoft.Build.Execution
         {
             if (_nodeEndpoint.LinkStatus == LinkStatus.Active)
             {
-#if RUNTIME_TYPE_NETCORE
                 if (packet is LogMessagePacketBase logMessage
-                    && logMessage.EventType == LoggingEventType.CustomEvent
-                    && Traits.Instance.EscapeHatches.EnableWarningOnCustomBuildEvent)
+                    && logMessage.EventType == LoggingEventType.CustomEvent)
                 {
                     BuildEventArgs buildEvent = logMessage.NodeBuildEvent.Value.Value;
 
@@ -601,9 +599,6 @@ namespace Microsoft.Build.Execution
                 {
                     _nodeEndpoint.SendData(packet);
                 }
-#else
-                _nodeEndpoint.SendData(packet);
-#endif
             }
         }
 

--- a/src/Framework/BinaryTranslator.cs
+++ b/src/Framework/BinaryTranslator.cs
@@ -493,22 +493,6 @@ namespace Microsoft.Build.BackEnd
                 value = (T)Enum.ToObject(enumType, numericValue);
             }
 
-            /// <summary>
-            /// Translates a value using the .Net binary formatter.
-            /// </summary>
-            /// <typeparam name="T">The reference type.</typeparam>
-            /// <param name="value">The value to be translated.</param>
-            public void TranslateDotNet<T>(ref T value)
-            {
-                if (!TranslateNullable(value))
-                {
-                    return;
-                }
-
-                BinaryFormatter formatter = new BinaryFormatter();
-                value = (T)formatter.Deserialize(_packetStream);
-            }
-
             public void TranslateException(ref Exception value)
             {
                 if (!TranslateNullable(value))
@@ -1188,26 +1172,6 @@ namespace Microsoft.Build.BackEnd
                 where T : struct, Enum
             {
                 _writer.Write(numericValue);
-            }
-
-            /// <summary>
-            /// Translates a value using the .Net binary formatter.
-            /// </summary>
-            /// <typeparam name="T">The reference type.</typeparam>
-            /// <param name="value">The value to be translated.</param>
-            public void TranslateDotNet<T>(ref T value)
-            {
-                // All the calling paths are already guarded by ChangeWaves.Wave17_10 - so it's a no-op adding it here as well.
-                // But let's have it here explicitly - so it's clearer for the CodeQL reviewers.
-                if (!TranslateNullable(value) || !ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_10))
-                {
-                    return;
-                }
-
-                // codeql[cs/dangerous-binary-deserialization] This code needs explicit opt-in to be used (ChangeWaves.Wave17_10). This exists as a temporary compat opt-in for old 3rd party loggers, before they are migrated based on documented guidance.
-                // The opt-in documentation: https://github.com/dotnet/msbuild/blob/main/documentation/wiki/ChangeWaves.md#1710
-                BinaryFormatter formatter = new BinaryFormatter();
-                formatter.Serialize(_packetStream, value);
             }
 
             public void TranslateException(ref Exception value)

--- a/src/Framework/ITranslator.cs
+++ b/src/Framework/ITranslator.cs
@@ -255,18 +255,6 @@ namespace Microsoft.Build.BackEnd
         void TranslateEnum<T>(ref T value, int numericValue)
             where T : struct, Enum;
 
-        /// <summary>
-        /// Translates a value using the .Net binary formatter.
-        /// </summary>
-        /// <typeparam name="T">The reference type.</typeparam>
-        /// <param name="value">The value to be translated.</param>
-        /// <remarks>
-        /// The primary purpose of this method is to support serialization of Exceptions and
-        /// custom build logging events, since these do not support our custom serialization
-        /// methods.
-        /// </remarks>
-        void TranslateDotNet<T>(ref T value);
-
         void TranslateException(ref Exception value);
 
         /// <summary>

--- a/src/Framework/Traits.cs
+++ b/src/Framework/Traits.cs
@@ -392,29 +392,6 @@ namespace Microsoft.Build.Framework
             }
         }
 
-        /// <summary>
-        /// Allows displaying the deprecation warning for BinaryFormatter in your current environment.
-        /// </summary>
-        public bool EnableWarningOnCustomBuildEvent
-        {
-            get
-            {
-                var value = Environment.GetEnvironmentVariable("MSBUILDCUSTOMBUILDEVENTWARNING");
-
-                if (value == null)
-                {
-                    // If variable is not set explicitly, for .NETCORE warning appears.
-#if RUNTIME_TYPE_NETCORE
-                    return true;
-#else
-                    return ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_10);
-#endif
-                }
-
-                return value == "1";
-            }
-        }
-
         public bool UnquoteTargetSwitchParameters
         {
             get

--- a/src/Shared/LogMessagePacketBase.cs
+++ b/src/Shared/LogMessagePacketBase.cs
@@ -276,23 +276,6 @@ namespace Microsoft.Build.Shared
         private static Dictionary<LoggingEventType, MethodInfo> s_writeMethodCache = new Dictionary<LoggingEventType, MethodInfo>();
 
         /// <summary>
-        /// Dictionary of assemblies we've added to the resolver.
-        /// </summary>
-        private static HashSet<string> s_customEventsLoaded = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-
-#if FEATURE_APPDOMAIN
-        /// <summary>
-        /// The resolver used to load custom event types.
-        /// </summary>
-        private static TaskEngineAssemblyResolver s_resolver;
-#endif
-
-        /// <summary>
-        /// The object used to synchronize access to shared data.
-        /// </summary>
-        private static object s_lockObject = new Object();
-
-        /// <summary>
         /// Delegate for translating targetfinished events.
         /// </summary>
         private TargetFinishedTranslator _targetFinishedTranslator = null;

--- a/src/Shared/LogMessagePacketBase.cs
+++ b/src/Shared/LogMessagePacketBase.cs
@@ -421,25 +421,25 @@ namespace Microsoft.Build.Shared
         /// </summary>
         internal void WriteToStream(ITranslator translator)
         {
-            if (_eventType != LoggingEventType.CustomEvent)
+            ErrorUtilities.VerifyThrow(_eventType != LoggingEventType.CustomEvent, "_eventType should not be a custom event");
+
+            MethodInfo methodInfo = null;
+            lock (s_writeMethodCache)
             {
-                MethodInfo methodInfo = null;
-                lock (s_writeMethodCache)
+                if (!s_writeMethodCache.TryGetValue(_eventType, out methodInfo))
                 {
-                    if (!s_writeMethodCache.TryGetValue(_eventType, out methodInfo))
-                    {
-                        Type eventDerivedType = _buildEvent.GetType();
-                        methodInfo = eventDerivedType.GetMethod("WriteToStream", BindingFlags.NonPublic | BindingFlags.Instance);
-                        s_writeMethodCache.Add(_eventType, methodInfo);
-                    }
+                    Type eventDerivedType = _buildEvent.GetType();
+                    methodInfo = eventDerivedType.GetMethod("WriteToStream", BindingFlags.NonPublic | BindingFlags.Instance);
+                    s_writeMethodCache.Add(_eventType, methodInfo);
                 }
+            }
 
-                int packetVersion = s_defaultPacketVersion;
+            int packetVersion = s_defaultPacketVersion;
 
-                // Make sure the other side knows what sort of serialization is coming
-                translator.Translate(ref packetVersion);
+            // Make sure the other side knows what sort of serialization is coming
+            translator.Translate(ref packetVersion);
 
-                bool eventCanSerializeItself = methodInfo != null;
+            bool eventCanSerializeItself = methodInfo != null;
 
 #if !TASKHOST && !MSBUILDENTRYPOINTEXE
                 if (_buildEvent is ProjectEvaluationStartedEventArgs
@@ -452,34 +452,22 @@ namespace Microsoft.Build.Shared
                 }
 #endif
 
-                translator.Translate(ref eventCanSerializeItself);
+            translator.Translate(ref eventCanSerializeItself);
 
-                if (eventCanSerializeItself)
-                {
-                    // 3.5 or later -- we have custom serialization methods, so let's use them.
-                    ArgsWriterDelegate writerMethod = (ArgsWriterDelegate)CreateDelegateRobust(typeof(ArgsWriterDelegate), _buildEvent, methodInfo);
-                    writerMethod(translator.Writer);
+            if (eventCanSerializeItself)
+            {
+                // 3.5 or later -- we have custom serialization methods, so let's use them.
+                ArgsWriterDelegate writerMethod = (ArgsWriterDelegate)CreateDelegateRobust(typeof(ArgsWriterDelegate), _buildEvent, methodInfo);
+                writerMethod(translator.Writer);
 
-                    if (_eventType == LoggingEventType.TargetFinishedEvent && _targetFinishedTranslator != null)
-                    {
-                        _targetFinishedTranslator(translator, (TargetFinishedEventArgs)_buildEvent);
-                    }
-                }
-                else
+                if (_eventType == LoggingEventType.TargetFinishedEvent && _targetFinishedTranslator != null)
                 {
-                    WriteEventToStream(_buildEvent, _eventType, translator);
+                    _targetFinishedTranslator(translator, (TargetFinishedEventArgs)_buildEvent);
                 }
             }
             else
             {
-#if FEATURE_ASSEMBLY_LOCATION
-                string assemblyLocation = _buildEvent.GetType().GetTypeInfo().Assembly.Location;
-                translator.Translate(ref assemblyLocation);
-#else
-                string assemblyName = _buildEvent.GetType().GetTypeInfo().Assembly.FullName;
-                translator.Translate(ref assemblyName);
-#endif
-                translator.TranslateDotNet(ref _buildEvent);
+                WriteEventToStream(_buildEvent, _eventType, translator);
             }
         }
 
@@ -488,88 +476,43 @@ namespace Microsoft.Build.Shared
         /// </summary>
         internal void ReadFromStream(ITranslator translator)
         {
-            if (LoggingEventType.CustomEvent != _eventType)
+            ErrorUtilities.VerifyThrow(_eventType != LoggingEventType.CustomEvent, "_eventType should not be a custom event");
+
+            _buildEvent = GetBuildEventArgFromId();
+
+            // The other side is telling us whether the event knows how to log itself, or whether we're going to have
+            // to do it manually
+            int packetVersion = s_defaultPacketVersion;
+            translator.Translate(ref packetVersion);
+
+            bool eventCanSerializeItself = true;
+            translator.Translate(ref eventCanSerializeItself);
+
+            if (eventCanSerializeItself)
             {
-                _buildEvent = GetBuildEventArgFromId();
-
-                // The other side is telling us whether the event knows how to log itself, or whether we're going to have
-                // to do it manually
-                int packetVersion = s_defaultPacketVersion;
-                translator.Translate(ref packetVersion);
-
-                bool eventCanSerializeItself = true;
-                translator.Translate(ref eventCanSerializeItself);
-
-                if (eventCanSerializeItself)
+                MethodInfo methodInfo = null;
+                lock (s_readMethodCache)
                 {
-                    MethodInfo methodInfo = null;
-                    lock (s_readMethodCache)
+                    if (!s_readMethodCache.TryGetValue(_eventType, out methodInfo))
                     {
-                        if (!s_readMethodCache.TryGetValue(_eventType, out methodInfo))
-                        {
-                            Type eventDerivedType = _buildEvent.GetType();
-                            methodInfo = eventDerivedType.GetMethod("CreateFromStream", BindingFlags.NonPublic | BindingFlags.Instance);
-                            s_readMethodCache.Add(_eventType, methodInfo);
-                        }
-                    }
-
-                    ArgsReaderDelegate readerMethod = (ArgsReaderDelegate)CreateDelegateRobust(typeof(ArgsReaderDelegate), _buildEvent, methodInfo);
-
-                    readerMethod(translator.Reader, packetVersion);
-                    if (_eventType == LoggingEventType.TargetFinishedEvent && _targetFinishedTranslator != null)
-                    {
-                        _targetFinishedTranslator(translator, (TargetFinishedEventArgs)_buildEvent);
+                        Type eventDerivedType = _buildEvent.GetType();
+                        methodInfo = eventDerivedType.GetMethod("CreateFromStream", BindingFlags.NonPublic | BindingFlags.Instance);
+                        s_readMethodCache.Add(_eventType, methodInfo);
                     }
                 }
-                else
+
+                ArgsReaderDelegate readerMethod = (ArgsReaderDelegate)CreateDelegateRobust(typeof(ArgsReaderDelegate), _buildEvent, methodInfo);
+
+                readerMethod(translator.Reader, packetVersion);
+                if (_eventType == LoggingEventType.TargetFinishedEvent && _targetFinishedTranslator != null)
                 {
-                    _buildEvent = ReadEventFromStream(_eventType, translator);
-                    ErrorUtilities.VerifyThrow(_buildEvent is not null, "Not Supported LoggingEventType {0}", _eventType.ToString());
+                    _targetFinishedTranslator(translator, (TargetFinishedEventArgs)_buildEvent);
                 }
             }
             else
             {
-                string fileLocation = null;
-                translator.Translate(ref fileLocation);
-
-                bool resolveAssembly = false;
-                lock (s_lockObject)
-                {
-                    if (!s_customEventsLoaded.Contains(fileLocation))
-                    {
-                        resolveAssembly = true;
-                    }
-
-                    // If we are to resolve the assembly add it to the list of assemblies resolved
-                    if (resolveAssembly)
-                    {
-                        s_customEventsLoaded.Add(fileLocation);
-                    }
-                }
-
-#if FEATURE_APPDOMAIN
-                if (resolveAssembly)
-                {
-                    s_resolver = new TaskEngineAssemblyResolver();
-                    s_resolver.InstallHandler();
-                    s_resolver.Initialize(fileLocation);
-                }
-#endif
-
-                try
-                {
-                    translator.TranslateDotNet(ref _buildEvent);
-                }
-                finally
-                {
-#if FEATURE_APPDOMAIN
-                    if (resolveAssembly)
-                    {
-                        s_resolver.RemoveHandler();
-                        s_resolver = null;
-                    }
-#endif
-                }
+                _buildEvent = ReadEventFromStream(_eventType, translator);
+                ErrorUtilities.VerifyThrow(_buildEvent is not null, "Not Supported LoggingEventType {0}", _eventType.ToString());
             }
 
             _eventType = GetLoggingEventId(_buildEvent);

--- a/src/Shared/Resources/Strings.shared.resx
+++ b/src/Shared/Resources/Strings.shared.resx
@@ -136,7 +136,7 @@
     <value>Event type "{0}" was expected to be serializable using the .NET serializer. The event was not serializable and has been ignored.</value>
   </data>
   <data name="DeprecatedEventSerialization" xml:space="preserve">
-    <value>Custom event type '{0}' is not supported as all custom event types were deprecated due to unsecure serialization. Please use Extended*EventArgs instead. More info: https://aka.ms/msbuild/eventargs</value>
+    <value>Custom event type '{0}' is not supported as all custom event types were deprecated. Please use Extended*EventArgs instead. More info: https://aka.ms/msbuild/eventargs</value>
   </data>
   <data name="FileLocation" xml:space="preserve">
     <value>{0} ({1},{2})</value>

--- a/src/Shared/Resources/Strings.shared.resx
+++ b/src/Shared/Resources/Strings.shared.resx
@@ -136,7 +136,7 @@
     <value>Event type "{0}" was expected to be serializable using the .NET serializer. The event was not serializable and has been ignored.</value>
   </data>
   <data name="DeprecatedEventSerialization" xml:space="preserve">
-    <value>Usage of unsecure BinaryFormatter during serialization of custom event type '{0}'. This will be deprecated soon. Please use Extended*EventArgs instead. More info: https://aka.ms/msbuild/eventargs</value>
+    <value>Custom event type '{0}' is not supported as all custom event types were deprecated due to unsecure serialization. Please use Extended*EventArgs instead. More info: https://aka.ms/msbuild/eventargs</value>
   </data>
   <data name="FileLocation" xml:space="preserve">
     <value>{0} ({1},{2})</value>

--- a/src/Shared/Resources/xlf/Strings.shared.cs.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.cs.xlf
@@ -28,8 +28,8 @@
         <note>{StrBegin="MSB4008: "}UE: This message is shown when the type/class of a task cannot be resolved uniquely from a single assembly.</note>
       </trans-unit>
       <trans-unit id="DeprecatedEventSerialization">
-        <source>Usage of unsecure BinaryFormatter during serialization of custom event type '{0}'. This will be deprecated soon. Please use Extended*EventArgs instead. More info: https://aka.ms/msbuild/eventargs</source>
-        <target state="translated">Použití nezabezpečeného BinaryFormatteru během serializace vlastního typu události {0}. Tento způsob bude brzy zastaralý. Místo toho prosím použijte Extended*EventArgs. Další informace najdete zde: https://aka.ms/msbuild/eventargs</target>
+        <source>Custom event type '{0}' is not supported as all custom event types were deprecated due to unsecure serialization. Please use Extended*EventArgs instead. More info: https://aka.ms/msbuild/eventargs</source>
+        <target state="needs-review-translation">Použití nezabezpečeného BinaryFormatteru během serializace vlastního typu události {0}. Tento způsob bude brzy zastaralý. Místo toho prosím použijte Extended*EventArgs. Další informace najdete zde: https://aka.ms/msbuild/eventargs</target>
         <note />
       </trans-unit>
       <trans-unit id="ExpectedEventToBeSerializable">

--- a/src/Shared/Resources/xlf/Strings.shared.cs.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.cs.xlf
@@ -28,7 +28,7 @@
         <note>{StrBegin="MSB4008: "}UE: This message is shown when the type/class of a task cannot be resolved uniquely from a single assembly.</note>
       </trans-unit>
       <trans-unit id="DeprecatedEventSerialization">
-        <source>Custom event type '{0}' is not supported as all custom event types were deprecated due to unsecure serialization. Please use Extended*EventArgs instead. More info: https://aka.ms/msbuild/eventargs</source>
+        <source>Custom event type '{0}' is not supported as all custom event types were deprecated. Please use Extended*EventArgs instead. More info: https://aka.ms/msbuild/eventargs</source>
         <target state="needs-review-translation">Použití nezabezpečeného BinaryFormatteru během serializace vlastního typu události {0}. Tento způsob bude brzy zastaralý. Místo toho prosím použijte Extended*EventArgs. Další informace najdete zde: https://aka.ms/msbuild/eventargs</target>
         <note />
       </trans-unit>

--- a/src/Shared/Resources/xlf/Strings.shared.de.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.de.xlf
@@ -28,8 +28,8 @@
         <note>{StrBegin="MSB4008: "}UE: This message is shown when the type/class of a task cannot be resolved uniquely from a single assembly.</note>
       </trans-unit>
       <trans-unit id="DeprecatedEventSerialization">
-        <source>Usage of unsecure BinaryFormatter during serialization of custom event type '{0}'. This will be deprecated soon. Please use Extended*EventArgs instead. More info: https://aka.ms/msbuild/eventargs</source>
-        <target state="translated">Verwendung eines unsicheren BinaryFormatter während der Serialisierung des benutzerdefinierten Ereignistyps '{0}'. Dies wird in Kürze eingestellt. Verwenden Sie stattdessen Extended*EventArgs. Weitere Informationen: https://aka.ms/msbuild/eventargs</target>
+        <source>Custom event type '{0}' is not supported as all custom event types were deprecated due to unsecure serialization. Please use Extended*EventArgs instead. More info: https://aka.ms/msbuild/eventargs</source>
+        <target state="needs-review-translation">Verwendung eines unsicheren BinaryFormatter während der Serialisierung des benutzerdefinierten Ereignistyps '{0}'. Dies wird in Kürze eingestellt. Verwenden Sie stattdessen Extended*EventArgs. Weitere Informationen: https://aka.ms/msbuild/eventargs</target>
         <note />
       </trans-unit>
       <trans-unit id="ExpectedEventToBeSerializable">

--- a/src/Shared/Resources/xlf/Strings.shared.de.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.de.xlf
@@ -28,7 +28,7 @@
         <note>{StrBegin="MSB4008: "}UE: This message is shown when the type/class of a task cannot be resolved uniquely from a single assembly.</note>
       </trans-unit>
       <trans-unit id="DeprecatedEventSerialization">
-        <source>Custom event type '{0}' is not supported as all custom event types were deprecated due to unsecure serialization. Please use Extended*EventArgs instead. More info: https://aka.ms/msbuild/eventargs</source>
+        <source>Custom event type '{0}' is not supported as all custom event types were deprecated. Please use Extended*EventArgs instead. More info: https://aka.ms/msbuild/eventargs</source>
         <target state="needs-review-translation">Verwendung eines unsicheren BinaryFormatter während der Serialisierung des benutzerdefinierten Ereignistyps '{0}'. Dies wird in Kürze eingestellt. Verwenden Sie stattdessen Extended*EventArgs. Weitere Informationen: https://aka.ms/msbuild/eventargs</target>
         <note />
       </trans-unit>

--- a/src/Shared/Resources/xlf/Strings.shared.es.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.es.xlf
@@ -28,7 +28,7 @@
         <note>{StrBegin="MSB4008: "}UE: This message is shown when the type/class of a task cannot be resolved uniquely from a single assembly.</note>
       </trans-unit>
       <trans-unit id="DeprecatedEventSerialization">
-        <source>Custom event type '{0}' is not supported as all custom event types were deprecated due to unsecure serialization. Please use Extended*EventArgs instead. More info: https://aka.ms/msbuild/eventargs</source>
+        <source>Custom event type '{0}' is not supported as all custom event types were deprecated. Please use Extended*EventArgs instead. More info: https://aka.ms/msbuild/eventargs</source>
         <target state="needs-review-translation">Uso de BinaryFormatter no seguro durante la serialización del tipo de evento personalizado "{0}". Esto estará en desuso pronto. En su lugar, use Extended*EventArgs. Más información: https://aka.ms/msbuild/eventargs</target>
         <note />
       </trans-unit>

--- a/src/Shared/Resources/xlf/Strings.shared.es.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.es.xlf
@@ -28,8 +28,8 @@
         <note>{StrBegin="MSB4008: "}UE: This message is shown when the type/class of a task cannot be resolved uniquely from a single assembly.</note>
       </trans-unit>
       <trans-unit id="DeprecatedEventSerialization">
-        <source>Usage of unsecure BinaryFormatter during serialization of custom event type '{0}'. This will be deprecated soon. Please use Extended*EventArgs instead. More info: https://aka.ms/msbuild/eventargs</source>
-        <target state="translated">Uso de BinaryFormatter no seguro durante la serialización del tipo de evento personalizado "{0}". Esto estará en desuso pronto. En su lugar, use Extended*EventArgs. Más información: https://aka.ms/msbuild/eventargs</target>
+        <source>Custom event type '{0}' is not supported as all custom event types were deprecated due to unsecure serialization. Please use Extended*EventArgs instead. More info: https://aka.ms/msbuild/eventargs</source>
+        <target state="needs-review-translation">Uso de BinaryFormatter no seguro durante la serialización del tipo de evento personalizado "{0}". Esto estará en desuso pronto. En su lugar, use Extended*EventArgs. Más información: https://aka.ms/msbuild/eventargs</target>
         <note />
       </trans-unit>
       <trans-unit id="ExpectedEventToBeSerializable">

--- a/src/Shared/Resources/xlf/Strings.shared.fr.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.fr.xlf
@@ -28,7 +28,7 @@
         <note>{StrBegin="MSB4008: "}UE: This message is shown when the type/class of a task cannot be resolved uniquely from a single assembly.</note>
       </trans-unit>
       <trans-unit id="DeprecatedEventSerialization">
-        <source>Custom event type '{0}' is not supported as all custom event types were deprecated due to unsecure serialization. Please use Extended*EventArgs instead. More info: https://aka.ms/msbuild/eventargs</source>
+        <source>Custom event type '{0}' is not supported as all custom event types were deprecated. Please use Extended*EventArgs instead. More info: https://aka.ms/msbuild/eventargs</source>
         <target state="needs-review-translation">Utilisation de BinaryFormatter non sécurisé lors de la sérialisation d’un type d’événement personnalisé '{0}'. Cette opération sera bientôt déconseillée. Utilisez Extended*EventArgs à la place. Plus d’informations : https://aka.ms/msbuild/eventargs</target>
         <note />
       </trans-unit>

--- a/src/Shared/Resources/xlf/Strings.shared.fr.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.fr.xlf
@@ -28,8 +28,8 @@
         <note>{StrBegin="MSB4008: "}UE: This message is shown when the type/class of a task cannot be resolved uniquely from a single assembly.</note>
       </trans-unit>
       <trans-unit id="DeprecatedEventSerialization">
-        <source>Usage of unsecure BinaryFormatter during serialization of custom event type '{0}'. This will be deprecated soon. Please use Extended*EventArgs instead. More info: https://aka.ms/msbuild/eventargs</source>
-        <target state="translated">Utilisation de BinaryFormatter non sécurisé lors de la sérialisation d’un type d’événement personnalisé '{0}'. Cette opération sera bientôt déconseillée. Utilisez Extended*EventArgs à la place. Plus d’informations : https://aka.ms/msbuild/eventargs</target>
+        <source>Custom event type '{0}' is not supported as all custom event types were deprecated due to unsecure serialization. Please use Extended*EventArgs instead. More info: https://aka.ms/msbuild/eventargs</source>
+        <target state="needs-review-translation">Utilisation de BinaryFormatter non sécurisé lors de la sérialisation d’un type d’événement personnalisé '{0}'. Cette opération sera bientôt déconseillée. Utilisez Extended*EventArgs à la place. Plus d’informations : https://aka.ms/msbuild/eventargs</target>
         <note />
       </trans-unit>
       <trans-unit id="ExpectedEventToBeSerializable">

--- a/src/Shared/Resources/xlf/Strings.shared.it.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.it.xlf
@@ -28,8 +28,8 @@
         <note>{StrBegin="MSB4008: "}UE: This message is shown when the type/class of a task cannot be resolved uniquely from a single assembly.</note>
       </trans-unit>
       <trans-unit id="DeprecatedEventSerialization">
-        <source>Usage of unsecure BinaryFormatter during serialization of custom event type '{0}'. This will be deprecated soon. Please use Extended*EventArgs instead. More info: https://aka.ms/msbuild/eventargs</source>
-        <target state="translated">Utilizzo di BinaryFormatter non sicuro durante la serializzazione del tipo di evento personalizzato '{0}'. Questa operazione verrà presto deprecata. Usare invece Extended*EventArgs. Altre informazioni: https://aka.ms/msbuild/eventargs</target>
+        <source>Custom event type '{0}' is not supported as all custom event types were deprecated due to unsecure serialization. Please use Extended*EventArgs instead. More info: https://aka.ms/msbuild/eventargs</source>
+        <target state="needs-review-translation">Utilizzo di BinaryFormatter non sicuro durante la serializzazione del tipo di evento personalizzato '{0}'. Questa operazione verrà presto deprecata. Usare invece Extended*EventArgs. Altre informazioni: https://aka.ms/msbuild/eventargs</target>
         <note />
       </trans-unit>
       <trans-unit id="ExpectedEventToBeSerializable">

--- a/src/Shared/Resources/xlf/Strings.shared.it.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.it.xlf
@@ -28,7 +28,7 @@
         <note>{StrBegin="MSB4008: "}UE: This message is shown when the type/class of a task cannot be resolved uniquely from a single assembly.</note>
       </trans-unit>
       <trans-unit id="DeprecatedEventSerialization">
-        <source>Custom event type '{0}' is not supported as all custom event types were deprecated due to unsecure serialization. Please use Extended*EventArgs instead. More info: https://aka.ms/msbuild/eventargs</source>
+        <source>Custom event type '{0}' is not supported as all custom event types were deprecated. Please use Extended*EventArgs instead. More info: https://aka.ms/msbuild/eventargs</source>
         <target state="needs-review-translation">Utilizzo di BinaryFormatter non sicuro durante la serializzazione del tipo di evento personalizzato '{0}'. Questa operazione verrà presto deprecata. Usare invece Extended*EventArgs. Altre informazioni: https://aka.ms/msbuild/eventargs</target>
         <note />
       </trans-unit>

--- a/src/Shared/Resources/xlf/Strings.shared.ja.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.ja.xlf
@@ -28,8 +28,8 @@
         <note>{StrBegin="MSB4008: "}UE: This message is shown when the type/class of a task cannot be resolved uniquely from a single assembly.</note>
       </trans-unit>
       <trans-unit id="DeprecatedEventSerialization">
-        <source>Usage of unsecure BinaryFormatter during serialization of custom event type '{0}'. This will be deprecated soon. Please use Extended*EventArgs instead. More info: https://aka.ms/msbuild/eventargs</source>
-        <target state="translated">カスタム イベントの種類 '{0}' のシリアル化中のセキュリティで保護されていない BinaryFormatter の使用。これは間もなく非推奨になります。代わりに Extended*EventArgs を使用してください。詳細情報: https://aka.ms/msbuild/eventargs</target>
+        <source>Custom event type '{0}' is not supported as all custom event types were deprecated due to unsecure serialization. Please use Extended*EventArgs instead. More info: https://aka.ms/msbuild/eventargs</source>
+        <target state="needs-review-translation">カスタム イベントの種類 '{0}' のシリアル化中のセキュリティで保護されていない BinaryFormatter の使用。これは間もなく非推奨になります。代わりに Extended*EventArgs を使用してください。詳細情報: https://aka.ms/msbuild/eventargs</target>
         <note />
       </trans-unit>
       <trans-unit id="ExpectedEventToBeSerializable">

--- a/src/Shared/Resources/xlf/Strings.shared.ja.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.ja.xlf
@@ -28,7 +28,7 @@
         <note>{StrBegin="MSB4008: "}UE: This message is shown when the type/class of a task cannot be resolved uniquely from a single assembly.</note>
       </trans-unit>
       <trans-unit id="DeprecatedEventSerialization">
-        <source>Custom event type '{0}' is not supported as all custom event types were deprecated due to unsecure serialization. Please use Extended*EventArgs instead. More info: https://aka.ms/msbuild/eventargs</source>
+        <source>Custom event type '{0}' is not supported as all custom event types were deprecated. Please use Extended*EventArgs instead. More info: https://aka.ms/msbuild/eventargs</source>
         <target state="needs-review-translation">カスタム イベントの種類 '{0}' のシリアル化中のセキュリティで保護されていない BinaryFormatter の使用。これは間もなく非推奨になります。代わりに Extended*EventArgs を使用してください。詳細情報: https://aka.ms/msbuild/eventargs</target>
         <note />
       </trans-unit>

--- a/src/Shared/Resources/xlf/Strings.shared.ko.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.ko.xlf
@@ -28,7 +28,7 @@
         <note>{StrBegin="MSB4008: "}UE: This message is shown when the type/class of a task cannot be resolved uniquely from a single assembly.</note>
       </trans-unit>
       <trans-unit id="DeprecatedEventSerialization">
-        <source>Custom event type '{0}' is not supported as all custom event types were deprecated due to unsecure serialization. Please use Extended*EventArgs instead. More info: https://aka.ms/msbuild/eventargs</source>
+        <source>Custom event type '{0}' is not supported as all custom event types were deprecated. Please use Extended*EventArgs instead. More info: https://aka.ms/msbuild/eventargs</source>
         <target state="needs-review-translation">사용자 지정 이벤트 유형 '{0}'의 직렬화 중 보안되지 않은 BinaryFormatter 사용. 이 항목은 곧 지원 중단될 예정입니다. 대신 Extended*EventArgs를 사용하세요. 추가 정보: https://aka.ms/msbuild/eventargs</target>
         <note />
       </trans-unit>

--- a/src/Shared/Resources/xlf/Strings.shared.ko.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.ko.xlf
@@ -28,8 +28,8 @@
         <note>{StrBegin="MSB4008: "}UE: This message is shown when the type/class of a task cannot be resolved uniquely from a single assembly.</note>
       </trans-unit>
       <trans-unit id="DeprecatedEventSerialization">
-        <source>Usage of unsecure BinaryFormatter during serialization of custom event type '{0}'. This will be deprecated soon. Please use Extended*EventArgs instead. More info: https://aka.ms/msbuild/eventargs</source>
-        <target state="translated">사용자 지정 이벤트 유형 '{0}'의 직렬화 중 보안되지 않은 BinaryFormatter 사용. 이 항목은 곧 지원 중단될 예정입니다. 대신 Extended*EventArgs를 사용하세요. 추가 정보: https://aka.ms/msbuild/eventargs</target>
+        <source>Custom event type '{0}' is not supported as all custom event types were deprecated due to unsecure serialization. Please use Extended*EventArgs instead. More info: https://aka.ms/msbuild/eventargs</source>
+        <target state="needs-review-translation">사용자 지정 이벤트 유형 '{0}'의 직렬화 중 보안되지 않은 BinaryFormatter 사용. 이 항목은 곧 지원 중단될 예정입니다. 대신 Extended*EventArgs를 사용하세요. 추가 정보: https://aka.ms/msbuild/eventargs</target>
         <note />
       </trans-unit>
       <trans-unit id="ExpectedEventToBeSerializable">

--- a/src/Shared/Resources/xlf/Strings.shared.pl.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.pl.xlf
@@ -28,7 +28,7 @@
         <note>{StrBegin="MSB4008: "}UE: This message is shown when the type/class of a task cannot be resolved uniquely from a single assembly.</note>
       </trans-unit>
       <trans-unit id="DeprecatedEventSerialization">
-        <source>Custom event type '{0}' is not supported as all custom event types were deprecated due to unsecure serialization. Please use Extended*EventArgs instead. More info: https://aka.ms/msbuild/eventargs</source>
+        <source>Custom event type '{0}' is not supported as all custom event types were deprecated. Please use Extended*EventArgs instead. More info: https://aka.ms/msbuild/eventargs</source>
         <target state="needs-review-translation">Użycie niezabezpieczonego formatu BinaryFormatter podczas serializacji niestandardowego typu zdarzenia „{0}”. Wkrótce ta funkcja będzie przestarzała. Zamiast tego należy użyć Extended*EventArgs. Więcej informacji: https://aka.ms/msbuild/eventargs</target>
         <note />
       </trans-unit>

--- a/src/Shared/Resources/xlf/Strings.shared.pl.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.pl.xlf
@@ -28,8 +28,8 @@
         <note>{StrBegin="MSB4008: "}UE: This message is shown when the type/class of a task cannot be resolved uniquely from a single assembly.</note>
       </trans-unit>
       <trans-unit id="DeprecatedEventSerialization">
-        <source>Usage of unsecure BinaryFormatter during serialization of custom event type '{0}'. This will be deprecated soon. Please use Extended*EventArgs instead. More info: https://aka.ms/msbuild/eventargs</source>
-        <target state="translated">Użycie niezabezpieczonego formatu BinaryFormatter podczas serializacji niestandardowego typu zdarzenia „{0}”. Wkrótce ta funkcja będzie przestarzała. Zamiast tego należy użyć Extended*EventArgs. Więcej informacji: https://aka.ms/msbuild/eventargs</target>
+        <source>Custom event type '{0}' is not supported as all custom event types were deprecated due to unsecure serialization. Please use Extended*EventArgs instead. More info: https://aka.ms/msbuild/eventargs</source>
+        <target state="needs-review-translation">Użycie niezabezpieczonego formatu BinaryFormatter podczas serializacji niestandardowego typu zdarzenia „{0}”. Wkrótce ta funkcja będzie przestarzała. Zamiast tego należy użyć Extended*EventArgs. Więcej informacji: https://aka.ms/msbuild/eventargs</target>
         <note />
       </trans-unit>
       <trans-unit id="ExpectedEventToBeSerializable">

--- a/src/Shared/Resources/xlf/Strings.shared.pt-BR.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.pt-BR.xlf
@@ -28,8 +28,8 @@
         <note>{StrBegin="MSB4008: "}UE: This message is shown when the type/class of a task cannot be resolved uniquely from a single assembly.</note>
       </trans-unit>
       <trans-unit id="DeprecatedEventSerialization">
-        <source>Usage of unsecure BinaryFormatter during serialization of custom event type '{0}'. This will be deprecated soon. Please use Extended*EventArgs instead. More info: https://aka.ms/msbuild/eventargs</source>
-        <target state="translated">Uso de BinaryFormatter não seguro durante a serialização do tipo de evento personalizado '{0}'. Isso será obsoleto em breve. Em vez disso, use Extended*EventArgs. Mais informações: https://aka.ms/msbuild/eventargs</target>
+        <source>Custom event type '{0}' is not supported as all custom event types were deprecated due to unsecure serialization. Please use Extended*EventArgs instead. More info: https://aka.ms/msbuild/eventargs</source>
+        <target state="needs-review-translation">Uso de BinaryFormatter não seguro durante a serialização do tipo de evento personalizado '{0}'. Isso será obsoleto em breve. Em vez disso, use Extended*EventArgs. Mais informações: https://aka.ms/msbuild/eventargs</target>
         <note />
       </trans-unit>
       <trans-unit id="ExpectedEventToBeSerializable">

--- a/src/Shared/Resources/xlf/Strings.shared.pt-BR.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.pt-BR.xlf
@@ -28,7 +28,7 @@
         <note>{StrBegin="MSB4008: "}UE: This message is shown when the type/class of a task cannot be resolved uniquely from a single assembly.</note>
       </trans-unit>
       <trans-unit id="DeprecatedEventSerialization">
-        <source>Custom event type '{0}' is not supported as all custom event types were deprecated due to unsecure serialization. Please use Extended*EventArgs instead. More info: https://aka.ms/msbuild/eventargs</source>
+        <source>Custom event type '{0}' is not supported as all custom event types were deprecated. Please use Extended*EventArgs instead. More info: https://aka.ms/msbuild/eventargs</source>
         <target state="needs-review-translation">Uso de BinaryFormatter não seguro durante a serialização do tipo de evento personalizado '{0}'. Isso será obsoleto em breve. Em vez disso, use Extended*EventArgs. Mais informações: https://aka.ms/msbuild/eventargs</target>
         <note />
       </trans-unit>

--- a/src/Shared/Resources/xlf/Strings.shared.ru.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.ru.xlf
@@ -28,7 +28,7 @@
         <note>{StrBegin="MSB4008: "}UE: This message is shown when the type/class of a task cannot be resolved uniquely from a single assembly.</note>
       </trans-unit>
       <trans-unit id="DeprecatedEventSerialization">
-        <source>Custom event type '{0}' is not supported as all custom event types were deprecated due to unsecure serialization. Please use Extended*EventArgs instead. More info: https://aka.ms/msbuild/eventargs</source>
+        <source>Custom event type '{0}' is not supported as all custom event types were deprecated. Please use Extended*EventArgs instead. More info: https://aka.ms/msbuild/eventargs</source>
         <target state="needs-review-translation">Использование небезопасного BinaryFormatter во время сериализации настраиваемого типа события "{0}". Скоро этот параметр станет нерекомендуемым. Вместо этого используйте Extended*EventArgs. Дополнительные сведения: https://aka.ms/msbuild/eventargs</target>
         <note />
       </trans-unit>

--- a/src/Shared/Resources/xlf/Strings.shared.ru.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.ru.xlf
@@ -28,8 +28,8 @@
         <note>{StrBegin="MSB4008: "}UE: This message is shown when the type/class of a task cannot be resolved uniquely from a single assembly.</note>
       </trans-unit>
       <trans-unit id="DeprecatedEventSerialization">
-        <source>Usage of unsecure BinaryFormatter during serialization of custom event type '{0}'. This will be deprecated soon. Please use Extended*EventArgs instead. More info: https://aka.ms/msbuild/eventargs</source>
-        <target state="translated">Использование небезопасного BinaryFormatter во время сериализации настраиваемого типа события "{0}". Скоро этот параметр станет нерекомендуемым. Вместо этого используйте Extended*EventArgs. Дополнительные сведения: https://aka.ms/msbuild/eventargs</target>
+        <source>Custom event type '{0}' is not supported as all custom event types were deprecated due to unsecure serialization. Please use Extended*EventArgs instead. More info: https://aka.ms/msbuild/eventargs</source>
+        <target state="needs-review-translation">Использование небезопасного BinaryFormatter во время сериализации настраиваемого типа события "{0}". Скоро этот параметр станет нерекомендуемым. Вместо этого используйте Extended*EventArgs. Дополнительные сведения: https://aka.ms/msbuild/eventargs</target>
         <note />
       </trans-unit>
       <trans-unit id="ExpectedEventToBeSerializable">

--- a/src/Shared/Resources/xlf/Strings.shared.tr.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.tr.xlf
@@ -28,8 +28,8 @@
         <note>{StrBegin="MSB4008: "}UE: This message is shown when the type/class of a task cannot be resolved uniquely from a single assembly.</note>
       </trans-unit>
       <trans-unit id="DeprecatedEventSerialization">
-        <source>Usage of unsecure BinaryFormatter during serialization of custom event type '{0}'. This will be deprecated soon. Please use Extended*EventArgs instead. More info: https://aka.ms/msbuild/eventargs</source>
-        <target state="translated">'{0}' özel olay türünü serileştirme işlemi sırasında güvenli olmayan BinaryFormatter kullanımı. Bu özellik yakında kullanımdan kaldırılacak. Lütfen bunun yerine Extended*EventArgs özelliğini kullanın. Daha fazla bilgi: https://aka.ms/msbuild/eventargs</target>
+        <source>Custom event type '{0}' is not supported as all custom event types were deprecated due to unsecure serialization. Please use Extended*EventArgs instead. More info: https://aka.ms/msbuild/eventargs</source>
+        <target state="needs-review-translation">'{0}' özel olay türünü serileştirme işlemi sırasında güvenli olmayan BinaryFormatter kullanımı. Bu özellik yakında kullanımdan kaldırılacak. Lütfen bunun yerine Extended*EventArgs özelliğini kullanın. Daha fazla bilgi: https://aka.ms/msbuild/eventargs</target>
         <note />
       </trans-unit>
       <trans-unit id="ExpectedEventToBeSerializable">

--- a/src/Shared/Resources/xlf/Strings.shared.tr.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.tr.xlf
@@ -28,7 +28,7 @@
         <note>{StrBegin="MSB4008: "}UE: This message is shown when the type/class of a task cannot be resolved uniquely from a single assembly.</note>
       </trans-unit>
       <trans-unit id="DeprecatedEventSerialization">
-        <source>Custom event type '{0}' is not supported as all custom event types were deprecated due to unsecure serialization. Please use Extended*EventArgs instead. More info: https://aka.ms/msbuild/eventargs</source>
+        <source>Custom event type '{0}' is not supported as all custom event types were deprecated. Please use Extended*EventArgs instead. More info: https://aka.ms/msbuild/eventargs</source>
         <target state="needs-review-translation">'{0}' özel olay türünü serileştirme işlemi sırasında güvenli olmayan BinaryFormatter kullanımı. Bu özellik yakında kullanımdan kaldırılacak. Lütfen bunun yerine Extended*EventArgs özelliğini kullanın. Daha fazla bilgi: https://aka.ms/msbuild/eventargs</target>
         <note />
       </trans-unit>

--- a/src/Shared/Resources/xlf/Strings.shared.zh-Hans.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.zh-Hans.xlf
@@ -28,8 +28,8 @@
         <note>{StrBegin="MSB4008: "}UE: This message is shown when the type/class of a task cannot be resolved uniquely from a single assembly.</note>
       </trans-unit>
       <trans-unit id="DeprecatedEventSerialization">
-        <source>Usage of unsecure BinaryFormatter during serialization of custom event type '{0}'. This will be deprecated soon. Please use Extended*EventArgs instead. More info: https://aka.ms/msbuild/eventargs</source>
-        <target state="translated">在自定义事件类型“{0}”的序列化期间使用了不安全的 BinaryFormatter。这将很快被弃用。请改用 Extended*EventArgs。详细信息: https://aka.ms/msbuild/eventargs</target>
+        <source>Custom event type '{0}' is not supported as all custom event types were deprecated due to unsecure serialization. Please use Extended*EventArgs instead. More info: https://aka.ms/msbuild/eventargs</source>
+        <target state="needs-review-translation">在自定义事件类型“{0}”的序列化期间使用了不安全的 BinaryFormatter。这将很快被弃用。请改用 Extended*EventArgs。详细信息: https://aka.ms/msbuild/eventargs</target>
         <note />
       </trans-unit>
       <trans-unit id="ExpectedEventToBeSerializable">

--- a/src/Shared/Resources/xlf/Strings.shared.zh-Hans.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.zh-Hans.xlf
@@ -28,7 +28,7 @@
         <note>{StrBegin="MSB4008: "}UE: This message is shown when the type/class of a task cannot be resolved uniquely from a single assembly.</note>
       </trans-unit>
       <trans-unit id="DeprecatedEventSerialization">
-        <source>Custom event type '{0}' is not supported as all custom event types were deprecated due to unsecure serialization. Please use Extended*EventArgs instead. More info: https://aka.ms/msbuild/eventargs</source>
+        <source>Custom event type '{0}' is not supported as all custom event types were deprecated. Please use Extended*EventArgs instead. More info: https://aka.ms/msbuild/eventargs</source>
         <target state="needs-review-translation">在自定义事件类型“{0}”的序列化期间使用了不安全的 BinaryFormatter。这将很快被弃用。请改用 Extended*EventArgs。详细信息: https://aka.ms/msbuild/eventargs</target>
         <note />
       </trans-unit>

--- a/src/Shared/Resources/xlf/Strings.shared.zh-Hant.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.zh-Hant.xlf
@@ -28,7 +28,7 @@
         <note>{StrBegin="MSB4008: "}UE: This message is shown when the type/class of a task cannot be resolved uniquely from a single assembly.</note>
       </trans-unit>
       <trans-unit id="DeprecatedEventSerialization">
-        <source>Custom event type '{0}' is not supported as all custom event types were deprecated due to unsecure serialization. Please use Extended*EventArgs instead. More info: https://aka.ms/msbuild/eventargs</source>
+        <source>Custom event type '{0}' is not supported as all custom event types were deprecated. Please use Extended*EventArgs instead. More info: https://aka.ms/msbuild/eventargs</source>
         <target state="needs-review-translation">自訂事件類型 '{0}' 序列化期間使用不安全的 BinaryFormatter。即將取代此項目。請改用 Extended*EventArgs。更多資訊: https://aka.ms/msbuild/eventargs</target>
         <note />
       </trans-unit>

--- a/src/Shared/Resources/xlf/Strings.shared.zh-Hant.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.zh-Hant.xlf
@@ -28,8 +28,8 @@
         <note>{StrBegin="MSB4008: "}UE: This message is shown when the type/class of a task cannot be resolved uniquely from a single assembly.</note>
       </trans-unit>
       <trans-unit id="DeprecatedEventSerialization">
-        <source>Usage of unsecure BinaryFormatter during serialization of custom event type '{0}'. This will be deprecated soon. Please use Extended*EventArgs instead. More info: https://aka.ms/msbuild/eventargs</source>
-        <target state="translated">自訂事件類型 '{0}' 序列化期間使用不安全的 BinaryFormatter。即將取代此項目。請改用 Extended*EventArgs。更多資訊: https://aka.ms/msbuild/eventargs</target>
+        <source>Custom event type '{0}' is not supported as all custom event types were deprecated due to unsecure serialization. Please use Extended*EventArgs instead. More info: https://aka.ms/msbuild/eventargs</source>
+        <target state="needs-review-translation">自訂事件類型 '{0}' 序列化期間使用不安全的 BinaryFormatter。即將取代此項目。請改用 Extended*EventArgs。更多資訊: https://aka.ms/msbuild/eventargs</target>
         <note />
       </trans-unit>
       <trans-unit id="ExpectedEventToBeSerializable">


### PR DESCRIPTION
Fixes #11323

### Context
We used `BinaryFormatter` in the serialization logic to support build custom events. With the VS 17.14, we can remove the last instances of the `BinaryFormatter` in our codebase.

### Changes Made
`TranslateDotNet` implementation was removed and `OutOfProcNode` now unconditionally emits build error instead of sending packets with the custom event. 

### Testing
Modified existing unit test.

### Notes
