### PR TITLE
Revert "Specify ngen configs for exes (#11182)"

### DIFF
--- a/src/Package/MSBuild.VSSetup.Arm64/files.arm64.swr
+++ b/src/Package/MSBuild.VSSetup.Arm64/files.arm64.swr
@@ -10,7 +10,7 @@ vs.relatedProcessFiles
   vs.relatedProcessFile Path="[InstallDir]\MSBuild\Current\Bin\arm64\Microsoft.Build.Tasks.Core.dll"
 
 folder InstallDir:\MSBuild\Current\Bin\arm64
-  file source=$(Arm64BinPath)MSBuild.exe vs.file.ngenApplications="[installDir]\MSBuild\Current\Bin\arm64\MSBuild.exe" vs.file.ngenArchitecture=arm64
+  file source=$(Arm64BinPath)MSBuild.exe vs.file.ngenArchitecture=arm64
   file source=$(Arm64BinPath)MSBuild.exe.config
 
   file source=$(FrameworkBinPath)x64\Microsoft.Build.Framework.tlb

--- a/src/Package/MSBuild.VSSetup/files.swr
+++ b/src/Package/MSBuild.VSSetup/files.swr
@@ -32,7 +32,7 @@ folder InstallDir:\MSBuild\Current\Bin
   file source=$(X86BinPath)Microsoft.Build.Tasks.Core.dll vs.file.ngenApplications="[installDir]\Common7\IDE\vsn.exe" vs.file.ngenApplications="[installDir]\MSBuild\Current\Bin\MSBuild.exe" vs.file.ngenArchitecture=all vs.file.ngenPriority=1
   file source=$(X86BinPath)Microsoft.Build.Utilities.Core.dll vs.file.ngenApplications="[installDir]\Common7\IDE\vsn.exe" vs.file.ngenApplications="[installDir]\MSBuild\Current\Bin\MSBuild.exe" vs.file.ngenArchitecture=all vs.file.ngenPriority=1
   file source=$(X86BinPath)Microsoft.IO.Redist.dll vs.file.ngenApplications="[installDir]\Common7\IDE\vsn.exe" vs.file.ngenApplications="[installDir]\MSBuild\Current\Bin\MSBuild.exe" vs.file.ngenArchitecture=all vs.file.ngenPriority=1
-  file source=$(X86BinPath)MSBuild.exe vs.file.ngenApplications="[installDir]\MSBuild\Current\Bin\MSBuild.exe" vs.file.ngenArchitecture=x86 vs.file.ngenPriority=1
+  file source=$(X86BinPath)MSBuild.exe vs.file.ngenArchitecture=x86 vs.file.ngenPriority=1
   file source=$(X86BinPath)MSBuild.exe.config
   file source=$(TaskHostBinPath)MSBuildTaskHost.exe
   file source=$(TaskHostBinPath)MSBuildTaskHost.exe.config
@@ -178,7 +178,7 @@ folder InstallDir:\MSBuild\Current\Bin\zh-Hant
   file source=$(TaskHostBinPath)zh-Hant\MSBuildTaskHost.resources.dll
 
 folder InstallDir:\MSBuild\Current\Bin\amd64
-  file source=$(X64BinPath)MSBuild.exe vs.file.ngenApplications="[installDir]\MSBuild\Current\Bin\amd64\MSBuild.exe" vs.file.ngenArchitecture=x64
+  file source=$(X64BinPath)MSBuild.exe vs.file.ngenArchitecture=x64
   file source=$(TaskHostX64BinPath)MSBuildTaskHost.exe
   file source=$(X64BinPath)MSBuild.exe.config
   file source=$(TaskHostX64BinPath)MSBuildTaskHost.exe.config


### PR DESCRIPTION
This reverts commit 6bed355f6bb313c1f6e7b887da460f9b49ec8f6b.

### Context
#11182  likely caused images loaded regression in VS insertion https://devdiv.visualstudio.com/DevDiv/_git/VS/pullrequest/606630


### Changes Made


### Testing
experimental insertion perf passed
https://dev.azure.com/devdiv/DevDiv/_git/VS/pullrequest/606667

### Notes
