### PR TITLE
Workaround for "MSB4166: Child node "1" exited prematurely"

### DIFF
--- a/src/Build/BackEnd/Components/Logging/LoggingService.cs
+++ b/src/Build/BackEnd/Components/Logging/LoggingService.cs
@@ -73,6 +73,11 @@ namespace Microsoft.Build.BackEnd.Logging
     internal partial class LoggingService : ILoggingService, INodePacketHandler
     {
         /// <summary>
+        /// Gets or sets a value if BuildCheck is enabled. The presence of this flag influences the logging logic.
+        /// </summary>
+        private bool _buildCheckEnabled;
+
+        /// <summary>
         /// The default maximum size for the logging event queue.
         /// </summary>
         private const uint DefaultQueueCapacity = 200000;
@@ -474,11 +479,6 @@ namespace Microsoft.Build.BackEnd.Logging
         public bool Question { get; set; }
 
         /// <summary>
-        /// Gets or sets a value if BuildCheck is enabled. The presence of this flag influences the logging logic.
-        /// </summary>
-        internal bool BuildCheckEnabled { get; set; }
-
-        /// <summary>
         /// The list of descriptions which describe how to create forwarding loggers on a node.
         /// This is used by the node provider to get a list of registered descriptions so that
         /// they can be transmitted to child nodes.
@@ -877,7 +877,7 @@ namespace Microsoft.Build.BackEnd.Logging
 
                 _buildEngineDataRouter = (buildComponentHost.GetComponent(BuildComponentType.BuildCheckManagerProvider) as IBuildCheckManagerProvider)?.BuildEngineDataRouter;
 
-                BuildCheckEnabled = buildComponentHost.BuildParameters!.IsBuildCheckEnabled;
+                _buildCheckEnabled = buildComponentHost.BuildParameters!.IsBuildCheckEnabled;
             }
         }
 

--- a/src/Build/BackEnd/Components/Logging/LoggingService.cs
+++ b/src/Build/BackEnd/Components/Logging/LoggingService.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -877,7 +877,7 @@ namespace Microsoft.Build.BackEnd.Logging
 
                 _buildEngineDataRouter = (buildComponentHost.GetComponent(BuildComponentType.BuildCheckManagerProvider) as IBuildCheckManagerProvider)?.BuildEngineDataRouter;
 
-                _buildCheckEnabled = buildComponentHost.BuildParameters!.IsBuildCheckEnabled;
+                _buildCheckEnabled = buildComponentHost.BuildParameters.IsBuildCheckEnabled;
             }
         }
 

--- a/src/Build/BackEnd/Components/Logging/LoggingService.cs
+++ b/src/Build/BackEnd/Components/Logging/LoggingService.cs
@@ -474,6 +474,11 @@ namespace Microsoft.Build.BackEnd.Logging
         public bool Question { get; set; }
 
         /// <summary>
+        /// Gets or sets a value if BuildCheck is enabled. The presence of this flag influences the logging logic.
+        /// </summary>
+        internal bool BuildCheckEnabled { get; set; }
+
+        /// <summary>
         /// The list of descriptions which describe how to create forwarding loggers on a node.
         /// This is used by the node provider to get a list of registered descriptions so that
         /// they can be transmitted to child nodes.
@@ -871,6 +876,8 @@ namespace Microsoft.Build.BackEnd.Logging
                 _serviceState = LoggingServiceState.Initialized;
 
                 _buildEngineDataRouter = (buildComponentHost.GetComponent(BuildComponentType.BuildCheckManagerProvider) as IBuildCheckManagerProvider)?.BuildEngineDataRouter;
+
+                BuildCheckEnabled = buildComponentHost.BuildParameters!.IsBuildCheckEnabled;
             }
         }
 

--- a/src/Build/BackEnd/Components/Logging/LoggingServiceLogMethods.cs
+++ b/src/Build/BackEnd/Components/Logging/LoggingServiceLogMethods.cs
@@ -617,7 +617,7 @@ namespace Microsoft.Build.BackEnd.Logging
 
             // BuildCheck can still emit some LogBuildEvent(s) after ProjectFinishedEventArgs was reported.
             // Due to GetAndVerifyProjectFileFromContext validation, these checks break the build.
-            if (!BuildCheckEnabled)
+            if (!_buildCheckEnabled)
             {
                 // PERF: Not using VerifyThrow to avoid boxing of projectBuildEventContext.ProjectContextId in the non-error case.
                 if (!_projectFileMap.TryRemove(projectBuildEventContext.ProjectContextId, out _))

--- a/src/Build/BackEnd/Components/Logging/LoggingServiceLogMethods.cs
+++ b/src/Build/BackEnd/Components/Logging/LoggingServiceLogMethods.cs
@@ -615,10 +615,15 @@ namespace Microsoft.Build.BackEnd.Logging
             buildEvent.BuildEventContext = projectBuildEventContext;
             ProcessLoggingEvent(buildEvent);
 
-            // PERF: Not using VerifyThrow to avoid boxing of projectBuildEventContext.ProjectContextId in the non-error case.
-            if (!_projectFileMap.TryRemove(projectBuildEventContext.ProjectContextId, out _))
+            // BuildCheck can still emit some LogBuildEvent(s) after ProjectFinishedEventArgs was reported.
+            // Due to GetAndVerifyProjectFileFromContext validation, these checks break the build.
+            if (!BuildCheckEnabled)
             {
-                ErrorUtilities.ThrowInternalError("ContextID {0} for project {1} should be in the ID-to-file mapping!", projectBuildEventContext.ProjectContextId, projectFile);
+                // PERF: Not using VerifyThrow to avoid boxing of projectBuildEventContext.ProjectContextId in the non-error case.
+                if (!_projectFileMap.TryRemove(projectBuildEventContext.ProjectContextId, out _))
+                {
+                    ErrorUtilities.ThrowInternalError("ContextID {0} for project {1} should be in the ID-to-file mapping!", projectBuildEventContext.ProjectContextId, projectFile);
+                }
             }
         }
 


### PR DESCRIPTION
Fixes #11326

### Context
BuildCheck can still emit some LogBuildEvent(s) after `ProjectFinishedEventArgs` was reported and entries from `_projectFileMap` were cleaned up.
Due to `GetAndVerifyProjectFileFromContext` validation, these checks break the build.

### Changes Made
If `BuildCheck` is enabled, `_projectFileMap` won't be cleaned up. If it brings significant perf overhead , this approach will be reconsidered.

### Testing
n/a
