### PR TITLE
Add lock on _checkRegistry operations

### DIFF
--- a/src/Build/BuildCheck/Infrastructure/BuildCheckManagerProvider.cs
+++ b/src/Build/BuildCheck/Infrastructure/BuildCheckManagerProvider.cs
@@ -367,21 +367,32 @@ internal sealed class BuildCheckManagerProvider : IBuildCheckManagerProvider
         {
             if (checksToRemove is not null)
             {
-                foreach (CheckWrapper check in checksToRemove)
+                lock (_checkRegistryLock)
                 {
-                    var checkFactory = _checkRegistry.Find(c => c.MaterializedCheck == check);
-                    if (checkFactory is not null)
+                    foreach (CheckWrapper check in checksToRemove)
                     {
-                        checkContext.DispatchAsCommentFromText(MessageImportance.High, $"Dismounting check '{check.Check.FriendlyName}'. The check has thrown an unhandled exception while executing registered actions.");
-                        RemoveCheck(checkFactory);
+                        var checkFactory = _checkRegistry.Find(c => c.MaterializedCheck == check);
+                        if (checkFactory is not null)
+                        {
+                            checkContext.DispatchAsCommentFromText(MessageImportance.High, $"Dismounting check '{check.Check.FriendlyName}'. The check has thrown an unhandled exception while executing registered actions.");
+                            RemoveCheck(checkFactory);
+                        }
                     }
                 }
             }
 
-            foreach (var throttledCheck in _checkRegistry.FindAll(c => c.MaterializedCheck?.IsThrottled ?? false))
+            lock (_checkRegistryLock)
             {
-                checkContext.DispatchAsCommentFromText(MessageImportance.Normal, $"Dismounting check '{throttledCheck.FriendlyName}'. The check has exceeded the maximum number of results allowed. Any additional results will not be displayed.");
-                RemoveCheck(throttledCheck);
+                // Create a separate list of checks to materialize the list before modifications
+                var throttledChecks = _checkRegistry
+                .Where(c => c.MaterializedCheck?.IsThrottled ?? false)
+                .ToList();
+
+                foreach (var throttledCheck in throttledChecks)
+                {
+                    checkContext.DispatchAsCommentFromText(MessageImportance.Normal, $"Dismounting check '{throttledCheck.FriendlyName}'. The check has exceeded the maximum number of results allowed. Any additional results will not be displayed.");
+                    RemoveCheck(throttledCheck);
+                }
             }
         }
 

--- a/src/Build/BuildCheck/Infrastructure/BuildCheckManagerProvider.cs
+++ b/src/Build/BuildCheck/Infrastructure/BuildCheckManagerProvider.cs
@@ -66,6 +66,7 @@ internal sealed class BuildCheckManagerProvider : IBuildCheckManagerProvider
         private readonly IConfigurationProvider _configurationProvider = new ConfigurationProvider();
         private readonly BuildCheckCentralContext _buildCheckCentralContext;
         private readonly List<CheckFactoryContext> _checkRegistry;
+        private readonly object _checkRegistryLock = new();
         private readonly bool[] _enabledDataSources = new bool[(int)BuildCheckDataSource.ValuesCount];
         private readonly BuildEventsProcessor _buildEventsProcessor;
         private readonly IBuildCheckAcquisitionModule _acquisitionModule;
@@ -170,15 +171,18 @@ internal sealed class BuildCheckManagerProvider : IBuildCheckManagerProvider
 
         private void RegisterBuiltInChecks(BuildCheckDataSource buildCheckDataSource)
         {
-            _checkRegistry.AddRange(
+            lock (_checkRegistryLock)
+            {
+                _checkRegistry.AddRange(
                 s_builtInFactoriesPerDataSource[(int)buildCheckDataSource]
                     .Select(v => new CheckFactoryContext(v.Factory, v.RuleIds, v.DefaultEnablement)));
 
-            if (s_testFactoriesPerDataSource is not null)
-            {
-                _checkRegistry.AddRange(
-                    s_testFactoriesPerDataSource[(int)buildCheckDataSource]
-                        .Select(v => new CheckFactoryContext(v.Factory, v.RuleIds, v.DefaultEnablement)));
+                if (s_testFactoriesPerDataSource is not null)
+                {
+                    _checkRegistry.AddRange(
+                        s_testFactoriesPerDataSource[(int)buildCheckDataSource]
+                            .Select(v => new CheckFactoryContext(v.Factory, v.RuleIds, v.DefaultEnablement)));
+                }
             }
         }
 
@@ -211,7 +215,11 @@ internal sealed class BuildCheckManagerProvider : IBuildCheckManagerProvider
 
                         if (checkFactoryContext != null)
                         {
-                            _checkRegistry.Add(checkFactoryContext);
+                            lock (_checkRegistryLock)
+                            {
+                                _checkRegistry.Add(checkFactoryContext);
+                            }
+
                             try
                             {
                                 SetupSingleCheck(checkFactoryContext, projectPath);
@@ -379,7 +387,10 @@ internal sealed class BuildCheckManagerProvider : IBuildCheckManagerProvider
 
         private void RemoveCheck(CheckFactoryContext checkToRemove)
         {
-            _checkRegistry.Remove(checkToRemove);
+            lock (_checkRegistryLock)
+            {
+                _checkRegistry.Remove(checkToRemove);
+            }
 
             if (checkToRemove.MaterializedCheck is not null)
             {


### PR DESCRIPTION
Fixes #https://github.com/dotnet/msbuild/issues/11319

### Context
It looks like the environment modifies `_checkRegistry` concurrently due to throttling logic

https://github.com/dotnet/msbuild/blob/404236379df1389c0988adca6c1f8cc0e1ef1011/src/Build/BuildCheck/Infrastructure/BuildCheckManagerProvider.cs#L373

and 
https://github.com/dotnet/msbuild/blob/404236379df1389c0988adca6c1f8cc0e1ef1011/src/Build/BuildCheck/Infrastructure/BuildCheckManagerProvider.cs#L380

In `RemoveChecksAfterExecutedActions` the code is processing throttled checks and `RemoveCheck` method is modifying the `_checkRegistry` while the `FindAll` loop is still iterating over it.

### Changes Made
add lock for the `_checkRegistry` operations to avoid issues with synchronization.
