### PR TITLE
Avoid creating a HashSet object on each ResultsCacheResponse

### DIFF
--- a/src/Build/BackEnd/Components/Caching/ResultsCache.cs
+++ b/src/Build/BackEnd/Components/Caching/ResultsCache.cs
@@ -178,7 +178,7 @@ namespace Microsoft.Build.BackEnd
                     if (buildDataFlagsSatisfied)
                     {
                         // Check for targets explicitly specified.
-                        bool explicitTargetsSatisfied = CheckResults(allResults, request.Targets, response.ExplicitTargetsToBuild, skippedResultsDoNotCauseCacheMiss);
+                        bool explicitTargetsSatisfied = CheckResults(allResults, request.Targets, checkTargetsMissingResults: true, skippedResultsDoNotCauseCacheMiss);
 
                         if (explicitTargetsSatisfied)
                         {
@@ -186,7 +186,7 @@ namespace Microsoft.Build.BackEnd
                             response.Type = ResultsCacheResponseType.Satisfied;
 
                             // Check for the initial targets.  If we don't know what the initial targets are, we assume they are not satisfied.
-                            if (configInitialTargets == null || !CheckResults(allResults, configInitialTargets, null, skippedResultsDoNotCauseCacheMiss))
+                            if (configInitialTargets == null || !CheckResults(allResults, configInitialTargets, checkTargetsMissingResults: false, skippedResultsDoNotCauseCacheMiss))
                             {
                                 response.Type = ResultsCacheResponseType.NotSatisfied;
                             }
@@ -196,7 +196,7 @@ namespace Microsoft.Build.BackEnd
                             {
                                 // Check for the default target, if necessary.  If we don't know what the default targets are, we
                                 // assume they are not satisfied.
-                                if (configDefaultTargets == null || !CheckResults(allResults, configDefaultTargets, null, skippedResultsDoNotCauseCacheMiss))
+                                if (configDefaultTargets == null || !CheckResults(allResults, configDefaultTargets, checkTargetsMissingResults: false, skippedResultsDoNotCauseCacheMiss))
                                 {
                                     response.Type = ResultsCacheResponseType.NotSatisfied;
                                 }
@@ -308,20 +308,21 @@ namespace Microsoft.Build.BackEnd
         /// </summary>
         /// <param name="result">The result to examine</param>
         /// <param name="targets">The targets to search for</param>
-        /// <param name="targetsMissingResults">An optional list to be populated with missing targets</param>
+        /// <param name="checkTargetsMissingResults">If missing targets will be checked for.</param>
         /// <param name="skippedResultsAreOK">If true, a status of "skipped" counts as having valid results
         /// for that target.  Otherwise, a skipped target is treated as equivalent to a missing target.</param>
         /// <returns>False if there were missing results, true otherwise.</returns>
-        private static bool CheckResults(BuildResult result, List<string> targets, HashSet<string> targetsMissingResults, bool skippedResultsAreOK)
+        private static bool CheckResults(BuildResult result, List<string> targets, bool checkTargetsMissingResults, bool skippedResultsAreOK)
         {
             bool returnValue = true;
+            bool missingTargetFound = false;
             foreach (string target in targets)
             {
                 if (!result.HasResultsForTarget(target) || (result[target].ResultCode == TargetResultCode.Skipped && !skippedResultsAreOK))
                 {
-                    if (targetsMissingResults != null)
+                    if (checkTargetsMissingResults)
                     {
-                        targetsMissingResults.Add(target);
+                        missingTargetFound = true;
                         returnValue = false;
                     }
                     else
@@ -333,7 +334,7 @@ namespace Microsoft.Build.BackEnd
                 {
                     // If the result was a failure and we have not seen any skipped targets up to this point, then we conclude we do
                     // have results for this request, and they indicate failure.
-                    if (result[target].ResultCode == TargetResultCode.Failure && (targetsMissingResults == null || targetsMissingResults.Count == 0))
+                    if (result[target].ResultCode == TargetResultCode.Failure && (!checkTargetsMissingResults || !missingTargetFound))
                     {
                         return true;
                     }

--- a/src/Build/BackEnd/Components/Caching/ResultsCacheResponse.cs
+++ b/src/Build/BackEnd/Components/Caching/ResultsCacheResponse.cs
@@ -42,11 +42,6 @@ namespace Microsoft.Build.BackEnd
         public BuildResult Results;
 
         /// <summary>
-        /// The subset of explicit targets which must be built because there are no results for them in the cache.
-        /// </summary>
-        public HashSet<string> ExplicitTargetsToBuild;
-
-        /// <summary>
         /// Constructor.
         /// </summary>
         /// <param name="type">The response type.</param>
@@ -54,7 +49,6 @@ namespace Microsoft.Build.BackEnd
         {
             Type = type;
             Results = null;
-            ExplicitTargetsToBuild = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         }
     }
 }


### PR DESCRIPTION
Fixes #

### Context


### Changes Made


### Testing


### Notes
