### PR TITLE
[9.0.1xx] Workaround for "MSB4166: Child node "1" exited prematurely for build check

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,7 +2,7 @@
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the MIT license. See License.txt in the project root for full license information. -->
 <Project>
   <PropertyGroup>
-    <VersionPrefix>17.12.26</VersionPrefix>
+    <VersionPrefix>17.12.27</VersionPrefix>
     <DotNetFinalVersionKind>release</DotNetFinalVersionKind>
     <PackageValidationBaselineVersion>17.11.4</PackageValidationBaselineVersion>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>

--- a/src/Build/BackEnd/Components/Logging/LoggingService.cs
+++ b/src/Build/BackEnd/Components/Logging/LoggingService.cs
@@ -73,6 +73,11 @@ namespace Microsoft.Build.BackEnd.Logging
     internal partial class LoggingService : ILoggingService, INodePacketHandler
     {
         /// <summary>
+        /// Gets or sets a value if BuildCheck is enabled. The presence of this flag influences the logging logic.
+        /// </summary>
+        private bool _buildCheckEnabled;
+
+        /// <summary>
         /// The default maximum size for the logging event queue.
         /// </summary>
         private const uint DefaultQueueCapacity = 200000;
@@ -871,6 +876,8 @@ namespace Microsoft.Build.BackEnd.Logging
                 _serviceState = LoggingServiceState.Initialized;
 
                 _buildEngineDataRouter = (buildComponentHost.GetComponent(BuildComponentType.BuildCheckManagerProvider) as IBuildCheckManagerProvider)?.BuildEngineDataRouter;
+
+                _buildCheckEnabled = buildComponentHost.BuildParameters.IsBuildCheckEnabled;
             }
         }
 


### PR DESCRIPTION
Backporting of https://github.com/dotnet/msbuild/pull/11353

### Summary
BuildCheck can still emit some LogBuildEvent(s) after ProjectFinishedEventArgs was reported and entries from _projectFileMap were cleaned up.
Due to GetAndVerifyProjectFileFromContext validation, these checks break the build for the middle/large size projects.
It was discovered on the attempt to dogfood BuildCheck. 

### Changes Made
If BuildCheck is enabled, _projectFileMap won't be cleaned up.

### Customer Impact
Failure of the build in buildcheck is enabled (for middle and large project sizes).

### Testing
Local testing with the patched msbuild.

### Risk
low: the feature is disabled by default and we need this fix to drive adaptation across dotnet org.

