### PR TITLE
Revert changes in common targets for binding redirect

### DIFF
--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -2568,24 +2568,6 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <AppConfig Condition="$(_NewGenerateBindingRedirectsIntermediateAppConfig) == 'true'">$(_GenerateBindingRedirectsIntermediateAppConfig)</AppConfig>
     </PropertyGroup>
 
-    <PropertyGroup>
-      <ConfigFileExists Condition="Exists('@(AppConfigWithTargetPath->'$(OutDir)%(TargetPath)')')">true</ConfigFileExists>
-      <HasNoBindingRedirects Condition="'@(SuggestedBindingRedirects)' == ''">true</HasNoBindingRedirects>
-    </PropertyGroup>
-
-    <!-- Overwrites .config file with a App.config content if RAR returned empty @(SuggestedBindingRedirects). -->
-    <Copy
-      SourceFiles="@(AppConfigWithTargetPath->'%(FullPath)')"
-      DestinationFiles="$(_GenerateBindingRedirectsIntermediateAppConfig)"
-      SkipUnchangedFiles="true"
-      Condition="'$(ConfigFileExists)' == 'true' and '$(HasNoBindingRedirects)' == 'true'">
-      <Output TaskParameter="CopiedFiles" ItemName="FileWrites"/>
-    </Copy>
-    <Touch
-      Files="$(_GenerateBindingRedirectsIntermediateAppConfig)"
-      AlwaysCreate="true"
-      Condition="'$(ConfigFileExists)' == 'true' and '$(HasNoBindingRedirects)' == 'true'"/>
-
     <ItemGroup Condition="$(_NewGenerateBindingRedirectsIntermediateAppConfig) == 'true'">
       <AppConfigWithTargetPath Remove="@(AppConfigWithTargetPath)" />
       <AppConfigWithTargetPath Include="$(AppConfig)">


### PR DESCRIPTION
Reverts https://github.com/dotnet/msbuild/pull/11012, which should fix https://github.com/dotnet/msbuild/issues/11362.

Need to remove this change due to unforeseen consequents for DTB in VS:
https://github.com/dotnet/msbuild/issues/11362#issuecomment-2628406941