### PR TITLE
Update YAML conditions

### DIFF
--- a/azure-pipelines/vs-insertion.yml
+++ b/azure-pipelines/vs-insertion.yml
@@ -63,7 +63,7 @@ variables:
   - name: AutoInsertTargetBranch
     ${{ if eq(variables['Build.SourceBranchName'], 'vs17.14') }}:
       value: 'rel/d17.14'
-    ${{ if eq(variables['Build.SourceBranchName'], 'vs17.13') }}:
+    ${{ elseif eq(variables['Build.SourceBranchName'], 'vs17.13') }}:
       value: 'rel/d17.13'
     ${{ elseif eq(variables['Build.SourceBranchName'], 'vs17.12') }}:
       value: 'rel/d17.12'


### PR DESCRIPTION
Prior version caused a failure on run:

```
/azure-pipelines/vs-insertion.yml (Line: 85, Col: 7): 'value' is already defined
```
