### PR TITLE
Bump `StyleCop.Analyzers` to `1.2.0-beta.556`

### DIFF
--- a/eng/dependabot/Packages.props
+++ b/eng/dependabot/Packages.props
@@ -66,7 +66,7 @@
 
   <ItemGroup Condition="'$(DotNetBuildSourceOnly)' != 'true' AND $(ProjectIsDeprecated) != 'true'">
     <GlobalPackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="3.3.4" />
-    <GlobalPackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.507" PrivateAssets="all"/>
+    <GlobalPackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556" PrivateAssets="all"/>
     <GlobalPackageReference Include="Microsoft.VisualStudio.SDK.EmbedInteropTypes" Version="15.0.36" PrivateAssets="All" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'" />
   </ItemGroup>
 


### PR DESCRIPTION
https://github.com/DotNetAnalyzers/StyleCopAnalyzers/releases/tag/1.2.0-beta.556
