### PR TITLE
Revert + adjust "Ensure slash in PublishDir"

### DIFF
--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -497,7 +497,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <!-- Output location for publish target. -->
   <PropertyGroup>
     <PublishDir Condition="'$(PublishDir)' != '' and !HasTrailingSlash('$(PublishDir)')">$(PublishDir)\</PublishDir>
-    <PublishDir Condition="'$(PublishDir)'==''">$([MSBuild]::EnsureTrailingSlash($([MSBuild]::NormalizePath('$(OutputPath)', 'app.publish'))))</PublishDir>
+    <PublishDir Condition="'$(PublishDir)'==''">$(OutputPath)app.publish\</PublishDir>
   </PropertyGroup>
 
   <!--

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -497,7 +497,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <!-- Output location for publish target. -->
   <PropertyGroup>
     <PublishDir Condition="'$(PublishDir)' != '' and !HasTrailingSlash('$(PublishDir)')">$(PublishDir)\</PublishDir>
-    <PublishDir Condition="'$(PublishDir)'==''">$(OutputPath)app.publish\</PublishDir>
+    <PublishDir Condition="'$(PublishDir)'==''">$([MSBuild]::EnsureTrailingSlash('$(OutputPath)'))app.publish\</PublishDir>
   </PropertyGroup>
 
   <!--


### PR DESCRIPTION

### Context
dotnet/msbuild#11248 broke ClickOnce publishing - https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2359773
The breakage is caused by the 'NormalizePath' part - as it can change relative path to absolute.

### Changes made
- reverted
- added the original change, which just ensures the slash
 