### PR TITLE
Remove NotImplementedException in SimpleProjectRootElementCache.cs

### DIFF
--- a/src/Build/Evaluation/SimpleProjectRootElementCache.cs
+++ b/src/Build/Evaluation/SimpleProjectRootElementCache.cs
@@ -116,7 +116,8 @@ namespace Microsoft.Build.Evaluation
 
         internal override void DiscardImplicitReferences()
         {
-            throw new NotImplementedException();
+            // Neither _strongCache or _weakCache are presented in this implementation, we have nothing to discard.
+            return;
         }
 
         internal override void DiscardAnyWeakReference(ProjectRootElement projectRootElement)


### PR DESCRIPTION
Fixes #
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1124043

### Context
SimpleProjectRootElementCache throws NotImplementedException on DiscardImplicitReferences.
This method in invoked in BuildManager on BeginBuild() and ResetCaches() 
It has a high hit rate in VS

### Changes Made
remove exception throwing

### Testing
n/a
