### PR TITLE
Fix CData recognition

### DIFF
--- a/src/Build/Utilities/Utilities.cs
+++ b/src/Build/Utilities/Utilities.cs
@@ -223,7 +223,7 @@ namespace Microsoft.Build.Internal
             }
 
             // ...or it looks like the whole thing is a big CDATA tag ...
-            bool startsWithCData = (innerXml.IndexOf("<![CDATA[", StringComparison.Ordinal) == 0);
+            bool startsWithCData = innerXml.AsSpan().TrimStart().StartsWith("<![CDATA[".AsSpan(), StringComparison.Ordinal);
 
             if (startsWithCData)
             {


### PR DESCRIPTION
Fixes https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1980399/

### Context
MSBuild has custom xml parsing logic that is trying to distinguish whether the element content should be treated as regular xml element content (`XmlNode.InnerText`) or whether we want to allow users to pass in the actual unescaped xml (`XmlNode.InnerXml`)

The second option feels as not very good choice (allowing to specify xml recognized sequences within xml script, without properly escaping them) - but since it is already preexisting behavior, let's keep it.

The recgnition of CData section was inefficient and defective - not allowing leading whitespaces - so I've fixed at least that one

### Changes Made
CData recognition now skips the leading whitespaces.

### Testing
Manual testing - loaded the repro project from the case into VS with and without fix and verified this is fixing the issue
