### PR TITLE
removing the delegate from the function signature 

### DIFF
--- a/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
@@ -68,12 +68,6 @@ namespace Microsoft.Build.BackEnd
         private readonly ConcurrentDictionary<string, byte /*void*/> _processesToIgnore = new();
 
         /// <summary>
-        /// Delegate used to tell the node provider that a context has been created.
-        /// </summary>
-        /// <param name="context">The created node context.</param>
-        internal delegate void NodeContextCreatedDelegate(NodeContext context);
-
-        /// <summary>
         /// Delegate used to tell the node provider that a context has terminated.
         /// </summary>
         /// <param name="nodeId">The id of the node which terminated.</param>
@@ -180,6 +174,8 @@ namespace Microsoft.Build.BackEnd
             }
         }
 
+        protected abstract void CreateNode(NodeContext context);
+
         /// <summary>
         /// Finds or creates a child processes which can act as a node.
         /// </summary>
@@ -188,7 +184,6 @@ namespace Microsoft.Build.BackEnd
             int nextNodeId,
             INodePacketFactory factory,
             Handshake hostHandshake,
-            NodeContextCreatedDelegate createNode,
             NodeContextTerminateDelegate terminateNode,
             int numberOfNodesToCreate)
         {
@@ -380,7 +375,7 @@ namespace Microsoft.Build.BackEnd
             {
                 NodeContext nodeContext = new(nodeId, nodeToReuse, nodeStream, factory, terminateNode);
                 nodeContexts.Enqueue(nodeContext);
-                createNode(nodeContext);
+                CreateNode(nodeContext);
             }
         }
 

--- a/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcTaskHost.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcTaskHost.cs
@@ -558,7 +558,6 @@ namespace Microsoft.Build.BackEnd
                 nodeId,
                 this,
                 new Handshake(hostContext),
-                NodeContextCreated,
                 NodeContextTerminated,
                 1);
 
@@ -568,7 +567,7 @@ namespace Microsoft.Build.BackEnd
         /// <summary>
         /// Method called when a context created.
         /// </summary>
-        private void NodeContextCreated(NodeContext context)
+        protected override void CreateNode(NodeContext context)
         {
             _nodeContexts[(HandshakeOptions)context.NodeId] = context;
 


### PR DESCRIPTION
and making it into an abstract overrridden function instead

### Context
While going through the review for Eric's performance PRs I've had some difficulties in tracking to code flow due to the delegate usage. This is a PR to open a discussion about a possibility of replacing some of the delegates with a combination of an abstract function + override.
The downside is an introduction of a variable to store the factory which is otherwise used from a closure. Refactoring this factory away collides with nodeInProc/nodeOutOfProc separation and could result in code duplication. 
If there is a better way to pass the factory around, I'm open to suggestions.

### Changes Made
replaced internal delegate void NodeContextCreatedDelegate(NodeContext context);
with 
protected abstract void CreateNode(NodeContext context);
so that I keep the idea of NodeProviderOutOfProc & NodeProviderOutOfProcTaskHost can use the same structure while removing the delegate since tracking it add additional level of indirection to the code flow.

### Testing
If current tests still work then I will take that as a sign that I didn't break anything.

### Notes
A quick PR to open a discussion about some of the delegates we have.
There is at least one similar delegate in place I would like to remove as well if we find this approach reasonable.
