### PR TITLE
Official Build MpPreference workaround

### DIFF
--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -126,9 +126,9 @@ extends:
         steps:
         - task: NuGetToolInstaller@1
           displayName: 'Install NuGet.exe'
-        - script: Get-MpComputerStatus
+        - pwsh: Get-MpComputerStatus
 
-        - script: Set-MpPreference -DisableRealtimeMonitoring $true
+        - pwsh: Set-MpPreference -DisableRealtimeMonitoring $true
 
         - task: PowerShell@2
           displayName: Setup Private Feeds Credentials

--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -126,6 +126,9 @@ extends:
         steps:
         - task: NuGetToolInstaller@1
           displayName: 'Install NuGet.exe'
+        - script: Get-MpComputerStatus
+
+        - script: Set-MpPreference -DisableRealtimeMonitoring $true
 
         - task: PowerShell@2
           displayName: Setup Private Feeds Credentials


### PR DESCRIPTION
Try disabling AV in the official build script to avoid build breaks that manifest as

```
D:\a\_work\1\s\.packages\microsoft.dotnet.arcade.sdk\9.0.0-beta.24516.2\tools\Sign.proj(72,5): error MSB4018: The "Microsoft.DotNet.SignTool.SignToolTask" task failed unexpectedly.
System.Runtime.Serialization.SerializationException: Type 'System.AssemblyLoadEventArgs' in assembly 'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089' is not marked as serializable.
   at Microsoft.Build.BackEnd.Components.RequestBuilder.AssemblyLoadsTracker.CurrentDomainOnAssemblyLoad(Object sender, AssemblyLoadEventArgs args)
   at System.AppDomain.OnAssemblyLoadEvent(RuntimeAssembly LoadedAssembly)
   at Microsoft.Build.Framework.ITask.Execute()
   at Microsoft.Build.BackEnd.TaskExecutionHost.Execute()
   at Microsoft.Build.BackEnd.TaskBuilder.<ExecuteInstantiatedTask>d__26.MoveNext() [D:\a\_work\1\s\.packages\microsoft.dotnet.arcade.sdk\9.0.0-beta.24516.2\tools\Sign.proj]
```
