### PR TITLE
Hide ephemeral ProjectRootElements from import enumerations

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,7 +2,7 @@
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the MIT license. See License.txt in the project root for full license information. -->
 <Project>
   <PropertyGroup>
-    <VersionPrefix>17.13.17</VersionPrefix>
+    <VersionPrefix>17.13.18</VersionPrefix>
     <DotNetFinalVersionKind>release</DotNetFinalVersionKind>
     <PackageValidationBaselineVersion>17.12.6</PackageValidationBaselineVersion>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>

--- a/src/Build.UnitTests/Evaluation/Preprocessor_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/Preprocessor_Tests.cs
@@ -933,6 +933,7 @@ namespace Microsoft.Build.UnitTests.Preprocessor
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/msbuild/issues/11498")]
         public void SdkResolverItemsAndPropertiesAreInPreprocessedOutput()
         {
             using (TestEnvironment env = TestEnvironment.Create())

--- a/src/Build/Construction/ProjectRootElement.cs
+++ b/src/Build/Construction/ProjectRootElement.cs
@@ -329,6 +329,8 @@ namespace Microsoft.Build.Construction
         /// </summary>
         public ICollection<ProjectImportElement> Imports => new ReadOnlyCollection<ProjectImportElement>(GetAllChildrenOfType<ProjectImportElement>());
 
+        internal bool IsEphemeral => _isEphemeral;
+
         /// <summary>
         /// Get a read-only collection of the child property groups, if any.
         /// Does not include any that may not be at the root, i.e. inside Choose elements.

--- a/src/Build/Definition/Project.cs
+++ b/src/Build/Definition/Project.cs
@@ -2257,7 +2257,7 @@ namespace Microsoft.Build.Evaluation
 
                     foreach (ResolvedImport import in _data.ImportClosure)
                     {
-                        if (import.ImportingElement != null) // Exclude outer project itself
+                        if (import.ImportingElement != null && !import.ImportedProject.IsEphemeral) // Exclude outer project itself and SDK-resolver synthesized imports
                         {
                             imports.Add(import);
                         }
@@ -2280,7 +2280,7 @@ namespace Microsoft.Build.Evaluation
 
                     foreach (var import in _data.ImportClosureWithDuplicates)
                     {
-                        if (import.ImportingElement != null) // Exclude outer project itself
+                        if (import.ImportingElement != null && !import.ImportedProject.IsEphemeral) // Exclude outer project itself and SDK-resolver synthesized imports
                         {
                             imports.Add(import);
                         }


### PR DESCRIPTION
Work item (Internal use): AB#2381505

### Summary

Hides the in-memory-only `.props` file synthesized to support properties returned from an SDK resolver.

### Customer Impact

All C++/CLI builds in Visual Studio are marked as "not up to date", slowing customer builds.

### Regression?

Yes. Experience regressed in 17.13 after https://github.com/dotnet/sdk/pull/45364, which revealed this latent MSBuild bug (introduced in #5269 in 2020).

### Testing

Automated tests and manual C++/CLI VS scenario testing.

### Risk

Low: changes behavior only for elements that use the new flag adopted in #11478.