### PR TITLE
Fix namespace and public typename conflict

### DIFF
--- a/src/Build.UnitTests/BackEnd/MockHost.cs
+++ b/src/Build.UnitTests/BackEnd/MockHost.cs
@@ -9,7 +9,7 @@ using Microsoft.Build.Experimental.BuildCheck.Infrastructure;
 using Microsoft.Build.Engine.UnitTests.BackEnd;
 using Microsoft.Build.Evaluation;
 using Microsoft.Build.Execution;
-using Microsoft.Build.Telemetry;
+using Microsoft.Build.TelemetryInfra;
 using LegacyThreadingData = Microsoft.Build.Execution.LegacyThreadingData;
 
 #nullable disable

--- a/src/Build/BackEnd/Components/BuildComponentFactoryCollection.cs
+++ b/src/Build/BackEnd/Components/BuildComponentFactoryCollection.cs
@@ -7,7 +7,7 @@ using Microsoft.Build.BackEnd.SdkResolution;
 using Microsoft.Build.Experimental.BuildCheck.Infrastructure;
 using Microsoft.Build.FileAccesses;
 using Microsoft.Build.Shared;
-using Microsoft.Build.Telemetry;
+using Microsoft.Build.TelemetryInfra;
 
 #nullable disable
 

--- a/src/Build/BackEnd/Components/BuildRequestEngine/BuildRequestEngine.cs
+++ b/src/Build/BackEnd/Components/BuildRequestEngine/BuildRequestEngine.cs
@@ -15,7 +15,7 @@ using Microsoft.Build.Execution;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
 using Microsoft.Build.Shared.Debugging;
-using Microsoft.Build.Telemetry;
+using Microsoft.Build.TelemetryInfra;
 using BuildAbortedException = Microsoft.Build.Exceptions.BuildAbortedException;
 
 #nullable disable

--- a/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
@@ -21,7 +21,7 @@ using Microsoft.Build.Experimental.BuildCheck.Infrastructure;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Internal;
 using Microsoft.Build.Shared;
-using Microsoft.Build.Telemetry;
+using Microsoft.Build.TelemetryInfra;
 using NodeLoggingContext = Microsoft.Build.BackEnd.Logging.NodeLoggingContext;
 using ProjectLoggingContext = Microsoft.Build.BackEnd.Logging.ProjectLoggingContext;
 

--- a/src/Build/Microsoft.Build.csproj
+++ b/src/Build/Microsoft.Build.csproj
@@ -173,8 +173,8 @@
     <Compile Include="FileAccess\RequestedAccess.cs" />
     <Compile Include="Instance\IPropertyElementWithLocation.cs" />
     <Compile Include="Logging\BuildEventArgsExtensions.cs" />
-    <Compile Include="Telemetry\ITelemetryForwarder.cs" />
-    <Compile Include="Telemetry\TelemetryForwarderProvider.cs" />
+    <Compile Include="TelemetryInfra\ITelemetryForwarder.cs" />
+    <Compile Include="TelemetryInfra\TelemetryForwarderProvider.cs" />
     <Compile Include="Utilities\ReaderWriterLockSlimExtensions.cs" />
     <Compile Include="BackEnd\Node\ConsoleOutput.cs" />
     <Compile Include="BackEnd\Node\PartialBuildTelemetry.cs" />

--- a/src/Build/TelemetryInfra/ITelemetryForwarder.cs
+++ b/src/Build/TelemetryInfra/ITelemetryForwarder.cs
@@ -4,7 +4,7 @@
 using System;
 using Microsoft.Build.BackEnd.Logging;
 
-namespace Microsoft.Build.Telemetry;
+namespace Microsoft.Build.TelemetryInfra;
 
 /// <summary>
 /// A build component responsible for accumulating telemetry data from worker node and then sending it to main node

--- a/src/Build/TelemetryInfra/TelemetryForwarderProvider.cs
+++ b/src/Build/TelemetryInfra/TelemetryForwarderProvider.cs
@@ -7,7 +7,7 @@ using Microsoft.Build.BackEnd.Logging;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
 
-namespace Microsoft.Build.Telemetry;
+namespace Microsoft.Build.TelemetryInfra;
 
 /// <summary>
 /// A build component responsible for accumulating telemetry data from worker node and then sending it to main node


### PR DESCRIPTION
Fixes failing VS insertion https://devdiv.visualstudio.com/DevDiv/_git/VS/pullrequest/612802

### Context
The https://github.com/dotnet/msbuild/pull/11359 introduced `Microsoft.Build.Telemetry` namespace, but there was preexisting public type with the same name - extrnal consumers could get broken


### Changes Made
Renamed
