### PR TITLE
[vs17.13] Don't mark synthesized projects dirty when SDKs define properties

### DIFF
--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -126,6 +126,9 @@ extends:
         steps:
         - task: NuGetToolInstaller@1
           displayName: 'Install NuGet.exe'
+        - pwsh: Get-MpComputerStatus
+
+        - pwsh: Set-MpPreference -DisableRealtimeMonitoring $true
 
         - task: PowerShell@2
           displayName: Setup Private Feeds Credentials

--- a/src/Build.UnitTests/Construction/ProjectRootElement_Tests.cs
+++ b/src/Build.UnitTests/Construction/ProjectRootElement_Tests.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Text;
 using Microsoft.Build.Construction;
+using Microsoft.Build.Evaluation;
 using Xunit;
 
 #nullable disable
@@ -120,7 +121,7 @@ bar", false)]
         [Fact]
         public void CreateNotDirtyCannotBeDirtied()
         {
-            var projectRootElement = ProjectRootElement.CreateNotDirty();
+            var projectRootElement = ProjectRootElement.CreateNotDirty(ProjectCollection.GlobalProjectCollection.ProjectRootElementCache);
             var versionBeforeMarkDirty = projectRootElement.Version;
 
             projectRootElement.MarkDirty("test", "test");

--- a/src/Build.UnitTests/Construction/ProjectRootElement_Tests.cs
+++ b/src/Build.UnitTests/Construction/ProjectRootElement_Tests.cs
@@ -116,5 +116,16 @@ bar", false)]
                 Assert.Equal(string.Empty, children[0].ChildNodes[1].Value);
             }
         }
+
+        [Fact]
+        public void CreateNotDirtyCannotBeDirtied()
+        {
+            var projectRootElement = ProjectRootElement.CreateNotDirty();
+            var versionBeforeMarkDirty = projectRootElement.Version;
+
+            projectRootElement.MarkDirty("test", "test");
+
+            Assert.Equal(projectRootElement.Version, versionBeforeMarkDirty);
+        }
     }
 }

--- a/src/Build/Construction/ProjectRootElement.cs
+++ b/src/Build/Construction/ProjectRootElement.cs
@@ -176,12 +176,12 @@ namespace Microsoft.Build.Construction
             ProjectParser.Parse(document, this);
         }
 
-        private readonly bool _cannotBeDirty = false;
+        private readonly bool _cannotBeDirtied = false;
 
         private ProjectRootElement(ProjectRootElementCacheBase projectRootElementCache, NewProjectFileOptions projectFileOptions, bool canBeDirty)
             : this(projectRootElementCache, projectFileOptions)
         {
-            _cannotBeDirty = canBeDirty;
+            _cannotBeDirtied = canBeDirty;
         }
 
         /// <summary>
@@ -1837,7 +1837,7 @@ namespace Microsoft.Build.Construction
         /// </remarks>
         internal sealed override void MarkDirty(string reason, string param)
         {
-            if (_cannotBeDirty)
+            if (_cannotBeDirtied)
             {
                 return;
             }

--- a/src/Build/Construction/ProjectRootElement.cs
+++ b/src/Build/Construction/ProjectRootElement.cs
@@ -725,11 +725,11 @@ namespace Microsoft.Build.Construction
         /// The ProjectRootElement will not be marked dirty.
         /// Uses the global project collection.
         /// </summary>
-        internal static ProjectRootElement CreateNotDirty()
+        internal static ProjectRootElement CreateNotDirty(ProjectRootElementCacheBase projectRootElementCache)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(ProjectCollection.GlobalProjectCollection);
+            ErrorUtilities.VerifyThrowArgumentNull(projectRootElementCache);
 
-            return new ProjectRootElement(ProjectCollection.GlobalProjectCollection.ProjectRootElementCache, Project.DefaultNewProjectTemplateOptions, true);
+            return new ProjectRootElement(projectRootElementCache, Project.DefaultNewProjectTemplateOptions, true);
         }
 
         /// <summary>

--- a/src/Build/Construction/ProjectRootElement.cs
+++ b/src/Build/Construction/ProjectRootElement.cs
@@ -721,7 +721,7 @@ namespace Microsoft.Build.Construction
             => _dirtyReason == null ? null : String.Format(CultureInfo.InvariantCulture, _dirtyReason, _dirtyParameter);
 
         /// <summary>
-        /// Initialize an in-memory, empty ProjectRootElement instance that can be saved later.
+        /// Initialize an in-memory, empty ProjectRootElement instance that CANNOT be saved later.
         /// The ProjectRootElement will not be marked dirty.
         /// Uses the global project collection.
         /// </summary>

--- a/src/Build/Construction/ProjectRootElement.cs
+++ b/src/Build/Construction/ProjectRootElement.cs
@@ -176,6 +176,14 @@ namespace Microsoft.Build.Construction
             ProjectParser.Parse(document, this);
         }
 
+        private readonly bool _cannotBeDirty = false;
+
+        private ProjectRootElement(ProjectRootElementCacheBase projectRootElementCache, NewProjectFileOptions projectFileOptions, bool canBeDirty)
+            : this(projectRootElementCache, projectFileOptions)
+        {
+            _cannotBeDirty = canBeDirty;
+        }
+
         /// <summary>
         /// Initialize an in-memory, empty ProjectRootElement instance that can be saved later.
         /// Leaves the project dirty, indicating there are unsaved changes.
@@ -711,6 +719,18 @@ namespace Microsoft.Build.Construction
         /// </summary>
         internal string LastDirtyReason
             => _dirtyReason == null ? null : String.Format(CultureInfo.InvariantCulture, _dirtyReason, _dirtyParameter);
+
+        /// <summary>
+        /// Initialize an in-memory, empty ProjectRootElement instance that can be saved later.
+        /// The ProjectRootElement will not be marked dirty.
+        /// Uses the global project collection.
+        /// </summary>
+        internal static ProjectRootElement CreateNotDirty()
+        {
+            ErrorUtilities.VerifyThrowArgumentNull(ProjectCollection.GlobalProjectCollection);
+
+            return new ProjectRootElement(ProjectCollection.GlobalProjectCollection.ProjectRootElementCache, Project.DefaultNewProjectTemplateOptions, true);
+        }
 
         /// <summary>
         /// Initialize an in-memory, empty ProjectRootElement instance that can be saved later.
@@ -1817,6 +1837,11 @@ namespace Microsoft.Build.Construction
         /// </remarks>
         internal sealed override void MarkDirty(string reason, string param)
         {
+            if (_cannotBeDirty)
+            {
+                return;
+            }
+
             if (Link != null)
             {
                 RootLink.MarkDirty(reason, param);

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -1917,7 +1917,7 @@ namespace Microsoft.Build.Evaluation
 
             ProjectRootElement InnerCreate(string _, ProjectRootElementCacheBase __)
             {
-                ProjectRootElement project = ProjectRootElement.Create();
+                ProjectRootElement project = ProjectRootElement.CreateNotDirty();
                 project.FullPath = projectPath;
 
                 if (sdkResult.PropertiesToAdd?.Any() == true)

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -1917,7 +1917,7 @@ namespace Microsoft.Build.Evaluation
 
             ProjectRootElement InnerCreate(string _, ProjectRootElementCacheBase __)
             {
-                ProjectRootElement project = ProjectRootElement.CreateNotDirty();
+                ProjectRootElement project = ProjectRootElement.CreateNotDirty(_projectRootElementCache);
                 project.FullPath = projectPath;
 
                 if (sdkResult.PropertiesToAdd?.Any() == true)


### PR DESCRIPTION
### Context
Fixes #11394
This is a regression. The bug appeared after [Expand MSBuildSdkResolver](https://github.com/dotnet/sdk/pull/45364). 

### Customer impact
Without this fix the customers that opt-into `MsBuildUseSimpleProjectRootElementCacheConcurrency` will get `System.NotImplementedException`. This includes `slngen` and `quickbuild`.

### Details
The `NotImplementedException` is thrown here:
https://github.com/dotnet/msbuild/blob/aff54559404d31214c71aa2ea6d2caa6003b0334/src/Build/Evaluation/SimpleProjectRootElementCache.cs#L133-L136
Previously the `SdkResult` of `MSBuildSdkResolver` was empty and `ProjectRootElement` was never created for it. Now, it contains 2 properties, and when `ProjectRootElement` is created, every change marks it as dirty. The fix is not to mark it dirty when it is from `SdkResult`

### Changes made
Implemented internal `CreateNotDirty` that creates `ProjectRootElement` that cannot be dirtied.

### Testing
Added unit test for `CreateNotDirty`. Also manually tested that the exception is not thrown anymore.

Risks
_Low_ - existing tests ensure that other scenarios are not broken, added new test, also tested manually this exact case.

