### PR TITLE
Revert ".slnx support - use the new parser for .sln and .slnx (#10836)"

### DIFF
--- a/documentation/wiki/ChangeWaves.md
+++ b/documentation/wiki/ChangeWaves.md
@@ -24,7 +24,7 @@ A wave of features is set to "rotate out" (i.e. become standard functionality) t
 ## Current Rotation of Change Waves
 
 ### 17.14
-- [.SLNX support - use the new parser for .sln and .slnx](https://github.com/dotnet/msbuild/pull/10836)
+- ~[.SLNX support - use the new parser for .sln and .slnx](https://github.com/dotnet/msbuild/pull/10836)~ reverted after compat problems discovered
 - [Support custom culture in RAR](https://github.com/dotnet/msbuild/pull/11000)
 
 ### 17.12

--- a/eng/BootStrapMsBuild.targets
+++ b/eng/BootStrapMsBuild.targets
@@ -35,8 +35,7 @@
         <_NuGetRuntimeDependencies Include="%(RuntimeCopyLocalItems.Identity)" Condition="'@(RuntimeCopyLocalItems->Contains('Newtonsoft.Json'))' == 'true'" />
         <_NuGetRuntimeDependencies Include="%(RuntimeCopyLocalItems.Identity)" Condition="'@(RuntimeCopyLocalItems->Contains('NuGetSdkResolver'))' == 'true'" />
         <_NuGetRuntimeDependencies Include="%(RuntimeCopyLocalItems.Identity)" Condition="'@(RuntimeCopyLocalItems->Contains('Microsoft.Extensions.'))' == 'true'" />
-        <_NuGetRuntimeDependencies Include="%(RuntimeCopyLocalItems.Identity)" Condition="'@(RuntimeCopyLocalItems->Contains('Microsoft.VisualStudio.SolutionPersistence'))' == 'true'" />
-      
+
         <!-- NuGet.targets and NuGet.RestoreEx.targets will be in the RuntimeTargetsCopyLocalItems ItemGroup -->
         <_NuGetRuntimeDependencies Include="%(RuntimeTargetsCopyLocalItems.Identity)" Condition="'@(RuntimeTargetsCopyLocalItems->Contains('NuGet.'))' == 'true'" />
 
@@ -49,7 +48,7 @@
 
   <Target Name="RemoveExtraAssemblyReferences" BeforeTargets="ResolveAssemblyReferences">
     <!-- This is really hacky, but these references will cause issues when trying to 'build' this project.
-         To acquire the NuGet binaries we depend on for local run-time ('bootstrap'), we are using a PackageReference (to
+         To acquire the NuGet binaries we depend on for local run-time ('bootstrap'), we we are using a PackageReference (to
          'NuGet.Build.Tasks' and 'Microsoft.Build.NuGetSdkResolver'). This has the advantage of using NuGets compatibility
          check to ensure we choose the right version of those assemblies. But, at 'bootstrap' time these runtime dependencies
          need to be in a specific location that does not mesh with NuGet. To resolve this, we include the default

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,7 +2,7 @@
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the MIT license. See License.txt in the project root for full license information. -->
 <Project>
   <PropertyGroup>
-    <VersionPrefix>17.13.14</VersionPrefix>
+    <VersionPrefix>17.13.15</VersionPrefix>
     <DotNetFinalVersionKind>release</DotNetFinalVersionKind>
     <PackageValidationBaselineVersion>17.12.6</PackageValidationBaselineVersion>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>

--- a/src/Build.OM.UnitTests/Construction/SolutionFile_Tests.cs
+++ b/src/Build.OM.UnitTests/Construction/SolutionFile_Tests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -32,31 +31,31 @@ namespace Microsoft.Build.UnitTests.Construction
         [Fact]
         public void ParseSolution_VC()
         {
-            string solutionFileContents =
-            """
-            Microsoft Visual Studio Solution File, Format Version 9.00
-            # Visual Studio 2005
-            Project('{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}') = 'Project name.vcproj', 'Relative path\to\Project name.vcproj', '{0ABED153-9451-483C-8140-9E8D7306B216}'
-            EndProject
-            Global
-                GlobalSection(SolutionConfigurationPlatforms) = preSolution
-                    Debug|AnyCPU = Debug|AnyCPU
-                    Release|AnyCPU = Release|AnyCPU
-                EndGlobalSection
-                GlobalSection(ProjectConfigurationPlatforms) = postSolution
-                    {0ABED153-9451-483C-8140-9E8D7306B216}.Debug|AnyCPU.ActiveCfg = Debug|AnyCPU
-                    {0ABED153-9451-483C-8140-9E8D7306B216}.Debug|AnyCPU.Build.0 = Debug|AnyCPU
-                    {0ABED153-9451-483C-8140-9E8D7306B216}.Release|AnyCPU.ActiveCfg = Release|AnyCPU
-                    {0ABED153-9451-483C-8140-9E8D7306B216}.Release|AnyCPU.Build.0 = Release|AnyCPU
-                EndGlobalSection
-                GlobalSection(SolutionProperties) = preSolution
-                    HideSolutionNode = FALSE
-                EndGlobalSection
-            EndGlobalf
-            """;
-
             Assert.Throws<InvalidProjectFileException>(() =>
             {
+                string solutionFileContents =
+                    @"
+                Microsoft Visual Studio Solution File, Format Version 9.00
+                # Visual Studio 2005
+                Project('{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}') = 'Project name.vcproj', 'Relative path\to\Project name.vcproj', '{0ABED153-9451-483C-8140-9E8D7306B216}'
+                EndProject
+                Global
+                    GlobalSection(SolutionConfigurationPlatforms) = preSolution
+                        Debug|AnyCPU = Debug|AnyCPU
+                        Release|AnyCPU = Release|AnyCPU
+                    EndGlobalSection
+                    GlobalSection(ProjectConfigurationPlatforms) = postSolution
+                        {0ABED153-9451-483C-8140-9E8D7306B216}.Debug|AnyCPU.ActiveCfg = Debug|AnyCPU
+                        {0ABED153-9451-483C-8140-9E8D7306B216}.Debug|AnyCPU.Build.0 = Debug|AnyCPU
+                        {0ABED153-9451-483C-8140-9E8D7306B216}.Release|AnyCPU.ActiveCfg = Release|AnyCPU
+                        {0ABED153-9451-483C-8140-9E8D7306B216}.Release|AnyCPU.Build.0 = Release|AnyCPU
+                    EndGlobalSection
+                    GlobalSection(SolutionProperties) = preSolution
+                        HideSolutionNode = FALSE
+                    EndGlobalSection
+                EndGlobal
+                ";
+
                 ParseSolutionHelper(solutionFileContents);
                 Assert.Fail("Should not get here");
             });
@@ -97,12 +96,48 @@ namespace Microsoft.Build.UnitTests.Construction
 
             string expectedProjectName = convertToSlnx ? "Project name" : "Project name.myvctype";
             Assert.Equal(expectedProjectName, solution.ProjectsInOrder[0].ProjectName);
-            Assert.Equal(ConvertToUnixPathIfNeeded("Relative path\\to\\Project name.myvctype"), solution.ProjectsInOrder[0].RelativePath);
+            Assert.Equal(ConvertToUnixPathIfNeeded("Relative path\\to\\Project name.myvctype", convertToSlnx), solution.ProjectsInOrder[0].RelativePath);
             if (!convertToSlnx)
             {
                 // When converting to SLNX, the project GUID is not preserved.
                 Assert.Equal("{0ABED153-9451-483C-8140-9E8D7306B216}", solution.ProjectsInOrder[0].ProjectGuid);
             }
+        }
+
+        /// <summary>
+        /// A slightly more complicated test where there is some different whitespace.
+        /// </summary>
+        [Fact]
+        public void ParseSolutionWithDifferentSpacing()
+        {
+            string solutionFileContents =
+                @"
+                Microsoft Visual Studio Solution File, Format Version 9.00
+                # Visual Studio 2005
+                Project(' { Project GUID} ')  = ' Project name ',  ' Relative path to project file '    , ' {0ABED153-9451-483C-8140-9E8D7306B216} '
+                EndProject
+                Global
+                    GlobalSection(SolutionConfigurationPlatforms) = preSolution
+                        Debug|AnyCPU = Debug|AnyCPU
+                        Release|AnyCPU = Release|AnyCPU
+                    EndGlobalSection
+                    GlobalSection(ProjectConfigurationPlatforms) = postSolution
+                        {0ABED153-9451-483C-8140-9E8D7306B216}.Debug|AnyCPU.ActiveCfg = Debug|AnyCPU
+                        {0ABED153-9451-483C-8140-9E8D7306B216}.Debug|AnyCPU.Build.0 = Debug|AnyCPU
+                        {0ABED153-9451-483C-8140-9E8D7306B216}.Release|AnyCPU.ActiveCfg = Release|AnyCPU
+                        {0ABED153-9451-483C-8140-9E8D7306B216}.Release|AnyCPU.Build.0 = Release|AnyCPU
+                    EndGlobalSection
+                    GlobalSection(SolutionProperties) = preSolution
+                        HideSolutionNode = FALSE
+                    EndGlobalSection
+                EndGlobal
+                ";
+
+            SolutionFile solution = ParseSolutionHelper(solutionFileContents);
+
+            Assert.Equal("Project name", solution.ProjectsInOrder[0].ProjectName);
+            Assert.Equal("Relative path to project file", solution.ProjectsInOrder[0].RelativePath);
+            Assert.Equal("{0ABED153-9451-483C-8140-9E8D7306B216}", solution.ProjectsInOrder[0].ProjectGuid);
         }
 
         /// <summary>
@@ -113,32 +148,145 @@ namespace Microsoft.Build.UnitTests.Construction
         public void ParseSolution_EmptyProjectName()
         {
             string solutionFileContents =
-            """
-            Microsoft Visual Studio Solution File, Format Version 9.00
-            # Visual Studio 2005
-            Project('{Project GUID}') = '', 'src\.proj', '{0ABED153-9451-483C-8140-9E8D7306B216}'
-            EndProject
-            Global
-                GlobalSection(SolutionConfigurationPlatforms) = preSolution
-                    Debug|AnyCPU = Debug|AnyCPU
-                    Release|AnyCPU = Release|AnyCPU
-                EndGlobalSection
-                GlobalSection(ProjectConfigurationPlatforms) = postSolution
-                    {0ABED153-9451-483C-8140-9E8D7306B216}.Debug|AnyCPU.ActiveCfg = Debug|AnyCPU
-                    {0ABED153-9451-483C-8140-9E8D7306B216}.Debug|AnyCPU.Build.0 = Debug|AnyCPU
-                    {0ABED153-9451-483C-8140-9E8D7306B216}.Release|AnyCPU.ActiveCfg = Release|AnyCPU
-                    {0ABED153-9451-483C-8140-9E8D7306B216}.Release|AnyCPU.Build.0 = Release|AnyCPU
-                EndGlobalSection
-                GlobalSection(SolutionProperties) = preSolution
-                    HideSolutionNode = FALSE
-                EndGlobalSection
-            EndGlobal
-            """;
+                           @"
+                Microsoft Visual Studio Solution File, Format Version 9.00
+                # Visual Studio 2005
+                Project('{Project GUID}') = '', 'src\.proj', '{0ABED153-9451-483C-8140-9E8D7306B216}'
+                EndProject
+                Global
+                    GlobalSection(SolutionConfigurationPlatforms) = preSolution
+                        Debug|AnyCPU = Debug|AnyCPU
+                        Release|AnyCPU = Release|AnyCPU
+                    EndGlobalSection
+                    GlobalSection(ProjectConfigurationPlatforms) = postSolution
+                        {0ABED153-9451-483C-8140-9E8D7306B216}.Debug|AnyCPU.ActiveCfg = Debug|AnyCPU
+                        {0ABED153-9451-483C-8140-9E8D7306B216}.Debug|AnyCPU.Build.0 = Debug|AnyCPU
+                        {0ABED153-9451-483C-8140-9E8D7306B216}.Release|AnyCPU.ActiveCfg = Release|AnyCPU
+                        {0ABED153-9451-483C-8140-9E8D7306B216}.Release|AnyCPU.Build.0 = Release|AnyCPU
+                    EndGlobalSection
+                    GlobalSection(SolutionProperties) = preSolution
+                        HideSolutionNode = FALSE
+                    EndGlobalSection
+                EndGlobal
+                ";
 
+            SolutionFile solution = ParseSolutionHelper(solutionFileContents);
+
+            Assert.StartsWith("EmptyProjectName", solution.ProjectsInOrder[0].ProjectName);
+            Assert.Equal("src\\.proj", solution.ProjectsInOrder[0].RelativePath);
+            Assert.Equal("{0ABED153-9451-483C-8140-9E8D7306B216}", solution.ProjectsInOrder[0].ProjectGuid);
+        }
+
+        /// <summary>
+        /// Test some characters that are valid in a file name but that also could be
+        /// considered a delimiter by a parser. Does quoting work for special characters?
+        /// </summary>
+        [Fact]
+        public void ParseSolutionWhereProjectNameHasSpecialCharacters()
+        {
+            string solutionFileContents =
+                           @"
+                Microsoft Visual Studio Solution File, Format Version 9.00
+                # Visual Studio 2005
+                Project('{Project GUID}')  = 'MyProject,(=IsGreat)',  'Relative path to project file'    , '{0ABED153-9451-483C-8140-9E8D7306B216}'
+                EndProject
+                Global
+                    GlobalSection(SolutionConfigurationPlatforms) = preSolution
+                        Debug|AnyCPU = Debug|AnyCPU
+                        Release|AnyCPU = Release|AnyCPU
+                    EndGlobalSection
+                    GlobalSection(ProjectConfigurationPlatforms) = postSolution
+                        {0ABED153-9451-483C-8140-9E8D7306B216}.Debug|AnyCPU.ActiveCfg = Debug|AnyCPU
+                        {0ABED153-9451-483C-8140-9E8D7306B216}.Debug|AnyCPU.Build.0 = Debug|AnyCPU
+                        {0ABED153-9451-483C-8140-9E8D7306B216}.Release|AnyCPU.ActiveCfg = Release|AnyCPU
+                        {0ABED153-9451-483C-8140-9E8D7306B216}.Release|AnyCPU.Build.0 = Release|AnyCPU
+                    EndGlobalSection
+                    GlobalSection(SolutionProperties) = preSolution
+                        HideSolutionNode = FALSE
+                    EndGlobalSection
+                EndGlobal
+                ";
+
+            SolutionFile solution = ParseSolutionHelper(solutionFileContents);
+
+            Assert.Equal("MyProject,(=IsGreat)", solution.ProjectsInOrder[0].ProjectName);
+            Assert.Equal("Relative path to project file", solution.ProjectsInOrder[0].RelativePath);
+            Assert.Equal("{0ABED153-9451-483C-8140-9E8D7306B216}", solution.ProjectsInOrder[0].ProjectGuid);
+        }
+
+        /// <summary>
+        /// Ensure that a bogus version stamp in the .SLN file results in an
+        /// InvalidProjectFileException.
+        /// </summary>
+        [Fact]
+        public void BadVersionStamp()
+        {
             Assert.Throws<InvalidProjectFileException>(() =>
             {
-                SolutionFile solution = ParseSolutionHelper(solutionFileContents);
+                string solutionFileContents =
+                    @"
+                Microsoft Visual Studio Solution File, Format Version a.b
+                # Visual Studio 2005
+                ";
+
+                ParseSolutionHelper(solutionFileContents);
             });
+        }
+        /// <summary>
+        /// Expected version numbers less than 7 to cause an invalid project file exception.
+        /// </summary>
+        [Fact]
+        public void VersionTooLow()
+        {
+            Assert.Throws<InvalidProjectFileException>(() =>
+            {
+                string solutionFileContents =
+                    @"
+                Microsoft Visual Studio Solution File, Format Version 6.0
+                # Visual Studio 2005
+                ";
+
+                ParseSolutionHelper(solutionFileContents);
+            });
+        }
+        /// <summary>
+        /// Test to parse a very basic .sln file to validate that description property in a solution file
+        /// is properly handled.
+        /// </summary>
+        [Fact]
+        public void ParseSolutionFileWithDescriptionInformation()
+        {
+            string solutionFileContents =
+                @"
+                Microsoft Visual Studio Solution File, Format Version 9.00
+                # Visual Studio 2005
+                Project('{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}') = 'AnyProject', 'AnyProject\AnyProject.csproj', '{2CAB0FBD-15D8-458B-8E63-1B5B840E9798}'
+                EndProject
+                Global
+	                GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		                Debug|Any CPU = Debug|Any CPU
+		                Release|Any CPU = Release|Any CPU
+		                Description = Some description of this solution
+	                EndGlobalSection
+	                GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		                {2CAB0FBD-15D8-458B-8E63-1B5B840E9798}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		                {2CAB0FBD-15D8-458B-8E63-1B5B840E9798}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		                {2CAB0FBD-15D8-458B-8E63-1B5B840E9798}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		                {2CAB0FBD-15D8-458B-8E63-1B5B840E9798}.Release|Any CPU.Build.0 = Release|Any CPU
+	                EndGlobalSection
+	                GlobalSection(SolutionProperties) = preSolution
+		                HideSolutionNode = FALSE
+	                EndGlobalSection
+                EndGlobal
+                ";
+            try
+            {
+                ParseSolutionHelper(solutionFileContents);
+            }
+            catch (Exception ex)
+            {
+                Assert.Fail("Failed to parse solution containing description information. Error: " + ex.Message);
+            }
         }
 
         /// <summary>
@@ -190,17 +338,17 @@ namespace Microsoft.Build.UnitTests.Construction
 
             // When converting to slnx, the order of the projects is not preserved.
             ProjectInSolution consoleApplication1 = solution.ProjectsInOrder.First(p => p.ProjectName == "ConsoleApplication1");
-            Assert.Equal(ConvertToUnixPathIfNeeded("ConsoleApplication1\\ConsoleApplication1.vbproj"), consoleApplication1.RelativePath);
+            Assert.Equal(ConvertToUnixPathIfNeeded("ConsoleApplication1\\ConsoleApplication1.vbproj", convertToSlnx), consoleApplication1.RelativePath);
             Assert.Empty(consoleApplication1.Dependencies);
             Assert.Null(consoleApplication1.ParentProjectGuid);
 
             ProjectInSolution vbClassLibrary = solution.ProjectsInOrder.First(p => p.ProjectName == "vbClassLibrary");
-            Assert.Equal(ConvertToUnixPathIfNeeded("vbClassLibrary\\vbClassLibrary.vbproj"), vbClassLibrary.RelativePath);
+            Assert.Equal(ConvertToUnixPathIfNeeded("vbClassLibrary\\vbClassLibrary.vbproj", convertToSlnx), vbClassLibrary.RelativePath);
             Assert.Empty(vbClassLibrary.Dependencies);
             Assert.Null(vbClassLibrary.ParentProjectGuid);
 
             ProjectInSolution classLibrary1 = solution.ProjectsInOrder.First(p => p.ProjectName == "ClassLibrary1");
-            Assert.Equal(ConvertToUnixPathIfNeeded("ClassLibrary1\\ClassLibrary1.csproj"), classLibrary1.RelativePath);
+            Assert.Equal(ConvertToUnixPathIfNeeded("ClassLibrary1\\ClassLibrary1.csproj", convertToSlnx), classLibrary1.RelativePath);
             Assert.Empty(classLibrary1.Dependencies);
             Assert.Null(classLibrary1.ParentProjectGuid);
 
@@ -217,10 +365,88 @@ namespace Microsoft.Build.UnitTests.Construction
         /// solution folders will get correctly uniquified.
         /// For the new parser, solution folders are not included to ProjectsInOrder or ProjectsByGuid.
         /// </summary>
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public void SolutionFolders(bool convertToSlnx)
+        [Fact]
+        public void SolutionFolders()
+        {
+            string solutionFileContents =
+                @"
+                Microsoft Visual Studio Solution File, Format Version 9.00
+                # Visual Studio 2005
+                Project('{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}') = 'ClassLibrary1', 'ClassLibrary1\ClassLibrary1.csproj', '{34E0D07D-CF8F-459D-9449-C4188D8C5564}'
+                EndProject
+                Project('{2150E333-8FDC-42A3-9474-1A3956D46DE8}') = 'MySlnFolder', 'MySlnFolder', '{E0F97730-25D2-418A-A7BD-02CAFDC6E470}'
+                EndProject
+                Project('{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}') = 'ClassLibrary1', 'MyPhysicalFolder\ClassLibrary1\ClassLibrary1.csproj', '{A5EE8128-B08E-4533-86C5-E46714981680}'
+                EndProject
+                Project('{2150E333-8FDC-42A3-9474-1A3956D46DE8}') = 'MySubSlnFolder', 'MySubSlnFolder', '{2AE8D6C4-FB43-430C-8AEB-15E5EEDAAE4B}'
+                EndProject
+                Project('{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}') = 'ClassLibrary2', 'ClassLibrary2\ClassLibrary2.csproj', '{6DB98C35-FDCC-4818-B5D4-1F0A385FDFD4}'
+                EndProject
+                Global
+                    GlobalSection(SolutionConfigurationPlatforms) = preSolution
+                        Debug|Any CPU = Debug|Any CPU
+                        Release|Any CPU = Release|Any CPU
+                    EndGlobalSection
+                    GlobalSection(ProjectConfigurationPlatforms) = postSolution
+                        {34E0D07D-CF8F-459D-9449-C4188D8C5564}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                        {34E0D07D-CF8F-459D-9449-C4188D8C5564}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                        {34E0D07D-CF8F-459D-9449-C4188D8C5564}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                        {34E0D07D-CF8F-459D-9449-C4188D8C5564}.Release|Any CPU.Build.0 = Release|Any CPU
+                        {A5EE8128-B08E-4533-86C5-E46714981680}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                        {A5EE8128-B08E-4533-86C5-E46714981680}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                        {A5EE8128-B08E-4533-86C5-E46714981680}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                        {A5EE8128-B08E-4533-86C5-E46714981680}.Release|Any CPU.Build.0 = Release|Any CPU
+                        {6DB98C35-FDCC-4818-B5D4-1F0A385FDFD4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                        {6DB98C35-FDCC-4818-B5D4-1F0A385FDFD4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                        {6DB98C35-FDCC-4818-B5D4-1F0A385FDFD4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                        {6DB98C35-FDCC-4818-B5D4-1F0A385FDFD4}.Release|Any CPU.Build.0 = Release|Any CPU
+                    EndGlobalSection
+                    GlobalSection(SolutionProperties) = preSolution
+                        HideSolutionNode = FALSE
+                    EndGlobalSection
+                    GlobalSection(NestedProjects) = preSolution
+                        {A5EE8128-B08E-4533-86C5-E46714981680} = {E0F97730-25D2-418A-A7BD-02CAFDC6E470}
+                        {2AE8D6C4-FB43-430C-8AEB-15E5EEDAAE4B} = {E0F97730-25D2-418A-A7BD-02CAFDC6E470}
+                        {6DB98C35-FDCC-4818-B5D4-1F0A385FDFD4} = {2AE8D6C4-FB43-430C-8AEB-15E5EEDAAE4B}
+                    EndGlobalSection
+                EndGlobal
+                ";
+
+            SolutionFile solution = ParseSolutionHelper(solutionFileContents);
+
+            Assert.Equal(5, solution.ProjectsInOrder.Count);
+
+            Assert.Equal(ConvertToUnixPathIfNeeded("ClassLibrary1\\ClassLibrary1.csproj", false), solution.ProjectsInOrder[0].RelativePath);
+            Assert.Equal("{34E0D07D-CF8F-459D-9449-C4188D8C5564}", solution.ProjectsInOrder[0].ProjectGuid);
+            Assert.Empty(solution.ProjectsInOrder[0].Dependencies);
+            Assert.Null(solution.ProjectsInOrder[0].ParentProjectGuid);
+
+            Assert.Equal("{E0F97730-25D2-418A-A7BD-02CAFDC6E470}", solution.ProjectsInOrder[1].ProjectGuid);
+            Assert.Empty(solution.ProjectsInOrder[1].Dependencies);
+            Assert.Null(solution.ProjectsInOrder[1].ParentProjectGuid);
+
+            Assert.Equal(ConvertToUnixPathIfNeeded("MyPhysicalFolder\\ClassLibrary1\\ClassLibrary1.csproj", false), solution.ProjectsInOrder[2].RelativePath);
+            Assert.Equal("{A5EE8128-B08E-4533-86C5-E46714981680}", solution.ProjectsInOrder[2].ProjectGuid);
+            Assert.Empty(solution.ProjectsInOrder[2].Dependencies);
+            Assert.Equal("{E0F97730-25D2-418A-A7BD-02CAFDC6E470}", solution.ProjectsInOrder[2].ParentProjectGuid);
+
+            Assert.Equal("{2AE8D6C4-FB43-430C-8AEB-15E5EEDAAE4B}", solution.ProjectsInOrder[3].ProjectGuid);
+            Assert.Empty(solution.ProjectsInOrder[3].Dependencies);
+            Assert.Equal("{E0F97730-25D2-418A-A7BD-02CAFDC6E470}", solution.ProjectsInOrder[3].ParentProjectGuid);
+
+            Assert.Equal(ConvertToUnixPathIfNeeded("ClassLibrary2\\ClassLibrary2.csproj", false), solution.ProjectsInOrder[4].RelativePath);
+            Assert.Equal("{6DB98C35-FDCC-4818-B5D4-1F0A385FDFD4}", solution.ProjectsInOrder[4].ProjectGuid);
+            Assert.Empty(solution.ProjectsInOrder[4].Dependencies);
+            Assert.Equal("{2AE8D6C4-FB43-430C-8AEB-15E5EEDAAE4B}", solution.ProjectsInOrder[4].ParentProjectGuid);
+        }
+
+        /// <summary>
+        /// Exercises solution folders, and makes sure that samely named projects in different
+        /// solution folders will get correctly uniquified.
+        /// For the new parser, solution folders are not included to ProjectsInOrder or ProjectsByGuid.
+        /// </summary>
+        [Fact]
+        public void SolutionFoldersSlnx()
         {
             string solutionFileContents =
                 """
@@ -266,38 +492,164 @@ namespace Microsoft.Build.UnitTests.Construction
                 EndGlobal
                 """;
 
-            SolutionFile solution = ParseSolutionHelper(solutionFileContents, convertToSlnx);
+            SolutionFile solution = ParseSolutionHelper(solutionFileContents, true);
 
             Assert.Equal(3, solution.ProjectsInOrder.Count);
 
             var classLibrary1 = solution.ProjectsInOrder
-                .FirstOrDefault(p => p.RelativePath == ConvertToUnixPathIfNeeded("ClassLibrary1\\ClassLibrary1.csproj"));
+                .FirstOrDefault(p => p.RelativePath == ConvertToUnixPathIfNeeded("ClassLibrary1\\ClassLibrary1.csproj", true));
             Assert.NotNull(classLibrary1);
             Assert.Empty(classLibrary1.Dependencies);
             Assert.Null(classLibrary1.ParentProjectGuid);
 
             var myPhysicalFolderClassLibrary1 = solution.ProjectsInOrder
-                .FirstOrDefault(p => p.RelativePath == ConvertToUnixPathIfNeeded("MyPhysicalFolder\\ClassLibrary1\\ClassLibrary1.csproj"));
+                .FirstOrDefault(p => p.RelativePath == ConvertToUnixPathIfNeeded("MyPhysicalFolder\\ClassLibrary1\\ClassLibrary1.csproj", true));
             Assert.NotNull(myPhysicalFolderClassLibrary1);
             Assert.Empty(myPhysicalFolderClassLibrary1.Dependencies);
 
             var classLibrary2 = solution.ProjectsInOrder
-                .FirstOrDefault(p => p.RelativePath == ConvertToUnixPathIfNeeded("ClassLibrary2\\ClassLibrary2.csproj"));
+                .FirstOrDefault(p => p.RelativePath == ConvertToUnixPathIfNeeded("ClassLibrary2\\ClassLibrary2.csproj", true));
             Assert.NotNull(classLibrary2);
             Assert.Empty(classLibrary2.Dependencies);
 
             // When converting to slnx, the guids are not preserved.
-            if (!convertToSlnx)
+            // try at list assert not null
+            Assert.NotNull(myPhysicalFolderClassLibrary1.ParentProjectGuid);
+            Assert.NotNull(classLibrary2.ParentProjectGuid);
+        }
+
+        /// <summary>
+        /// Exercises shared projects.
+        /// </summary>
+        [Fact]
+        public void SharedProjects()
+        {
+            string solutionFileContents =
+                @"
+                Microsoft Visual Studio Solution File, Format Version 12.00
+                # Visual Studio 15
+                VisualStudioVersion = 15.0.27610.1
+                MinimumVisualStudioVersion = 10.0.40219.1
+                Project('{D954291E-2A0B-460D-934E-DC6B0785DB48}') = 'SharedProject1', 'SharedProject1\SharedProject1.shproj', '{14686F51-D0C2-4832-BBAA-6FBAEC676995}'
+                EndProject
+                Project('{D954291E-2A0B-460D-934E-DC6B0785DB48}') = 'SharedProject2', 'SharedProject2\SharedProject2.shproj', '{BAE750E8-4656-4947-B06B-3961E1051DF7}'
+                EndProject
+                Project('{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}') = 'ClassLibrary1', 'ClassLibrary1\ClassLibrary1.csproj', '{3A0EC360-A42A-417F-BDEF-619682CF6119}'
+                EndProject
+                Project('{F184B08F-C81C-45F6-A57F-5ABD9991F28F}') = 'ClassLibrary2', 'ClassLibrary2\ClassLibrary2.vbproj', '{6DEF6DE8-FBF0-4240-B469-282DEE87899C}'
+                EndProject
+                Global
+                    GlobalSection(SharedMSBuildProjectFiles) = preSolution
+                        SharedProject1\SharedProject1.projitems*{14686f51-d0c2-4832-bbaa-6fbaec676995}*SharedItemsImports = 13
+                        SharedProject1\SharedProject1.projitems*{3a0ec360-a42a-417f-bdef-619682cf6119}*SharedItemsImports = 4
+                        SharedProject2\SharedProject2.projitems*{6def6de8-fbf0-4240-b469-282dee87899c}*SharedItemsImports = 4
+                        SharedProject2\SharedProject2.projitems*{bae750e8-4656-4947-b06b-3961e1051df7}*SharedItemsImports = 13
+                    EndGlobalSection
+                    GlobalSection(SolutionConfigurationPlatforms) = preSolution
+                        Debug|Any CPU = Debug|Any CPU
+                        Release|Any CPU = Release|Any CPU
+                    EndGlobalSection
+                    GlobalSection(ProjectConfigurationPlatforms) = postSolution
+                        {3A0EC360-A42A-417F-BDEF-619682CF6119}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                        {3A0EC360-A42A-417F-BDEF-619682CF6119}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                        {3A0EC360-A42A-417F-BDEF-619682CF6119}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                        {3A0EC360-A42A-417F-BDEF-619682CF6119}.Release|Any CPU.Build.0 = Release|Any CPU
+                        {6DEF6DE8-FBF0-4240-B469-282DEE87899C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                        {6DEF6DE8-FBF0-4240-B469-282DEE87899C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                        {6DEF6DE8-FBF0-4240-B469-282DEE87899C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                        {6DEF6DE8-FBF0-4240-B469-282DEE87899C}.Release|Any CPU.Build.0 = Release|Any CPU
+                    EndGlobalSection
+                    GlobalSection(SolutionProperties) = preSolution
+                        HideSolutionNode = FALSE
+                    EndGlobalSection
+                    GlobalSection(ExtensibilityGlobals) = postSolution
+                        SolutionGuid = {1B671EF6-A62A-4497-8351-3EE8679CA86F}
+                    EndGlobalSection
+                EndGlobal
+                ";
+
+            SolutionFile solution = ParseSolutionHelper(solutionFileContents);
+
+            Assert.Equal(4, solution.ProjectsInOrder.Count);
+
+            Assert.Equal(@"SharedProject1\SharedProject1.shproj", solution.ProjectsInOrder[0].RelativePath);
+            Assert.Equal("{14686F51-D0C2-4832-BBAA-6FBAEC676995}", solution.ProjectsInOrder[0].ProjectGuid);
+            Assert.Empty(solution.ProjectsInOrder[0].Dependencies);
+            Assert.Null(solution.ProjectsInOrder[0].ParentProjectGuid);
+
+            Assert.Equal(@"SharedProject2\SharedProject2.shproj", solution.ProjectsInOrder[1].RelativePath);
+            Assert.Equal("{BAE750E8-4656-4947-B06B-3961E1051DF7}", solution.ProjectsInOrder[1].ProjectGuid);
+            Assert.Empty(solution.ProjectsInOrder[1].Dependencies);
+            Assert.Null(solution.ProjectsInOrder[1].ParentProjectGuid);
+
+            Assert.Equal(@"ClassLibrary1\ClassLibrary1.csproj", solution.ProjectsInOrder[2].RelativePath);
+            Assert.Equal("{3A0EC360-A42A-417F-BDEF-619682CF6119}", solution.ProjectsInOrder[2].ProjectGuid);
+            Assert.Empty(solution.ProjectsInOrder[2].Dependencies);
+            Assert.Null(solution.ProjectsInOrder[2].ParentProjectGuid);
+
+            Assert.Equal(@"ClassLibrary2\ClassLibrary2.vbproj", solution.ProjectsInOrder[3].RelativePath);
+            Assert.Equal("{6DEF6DE8-FBF0-4240-B469-282DEE87899C}", solution.ProjectsInOrder[3].ProjectGuid);
+            Assert.Empty(solution.ProjectsInOrder[3].Dependencies);
+            Assert.Null(solution.ProjectsInOrder[3].ParentProjectGuid);
+        }
+
+        /// <summary>
+        /// Tests situation where there's a nonexistent project listed in the solution folders.  We should
+        /// error with a useful message.
+        /// </summary>
+        [Fact]
+        public void MissingNestedProject()
+        {
+            string solutionFileContents =
+                @"
+                Microsoft Visual Studio Solution File, Format Version 9.00
+                # Visual Studio 2005
+                Project('{2150E333-8FDC-42A3-9474-1A3956D46DE8}') = 'MySlnFolder', 'MySlnFolder', '{E0F97730-25D2-418A-A7BD-02CAFDC6E470}'
+                EndProject
+                Project('{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}') = 'ClassLibrary1', 'MyPhysicalFolder\ClassLibrary1\ClassLibrary1.csproj', '{A5EE8128-B08E-4533-86C5-E46714981680}'
+                EndProject
+                Global
+                    GlobalSection(SolutionConfigurationPlatforms) = preSolution
+                        Debug|Any CPU = Debug|Any CPU
+                        Release|Any CPU = Release|Any CPU
+                    EndGlobalSection
+                    GlobalSection(ProjectConfigurationPlatforms) = postSolution
+                        {34E0D07D-CF8F-459D-9449-C4188D8C5564}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                        {34E0D07D-CF8F-459D-9449-C4188D8C5564}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                        {34E0D07D-CF8F-459D-9449-C4188D8C5564}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                        {34E0D07D-CF8F-459D-9449-C4188D8C5564}.Release|Any CPU.Build.0 = Release|Any CPU
+                        {A5EE8128-B08E-4533-86C5-E46714981680}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                        {A5EE8128-B08E-4533-86C5-E46714981680}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                        {A5EE8128-B08E-4533-86C5-E46714981680}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                        {A5EE8128-B08E-4533-86C5-E46714981680}.Release|Any CPU.Build.0 = Release|Any CPU
+                        {6DB98C35-FDCC-4818-B5D4-1F0A385FDFD4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                        {6DB98C35-FDCC-4818-B5D4-1F0A385FDFD4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                        {6DB98C35-FDCC-4818-B5D4-1F0A385FDFD4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                        {6DB98C35-FDCC-4818-B5D4-1F0A385FDFD4}.Release|Any CPU.Build.0 = Release|Any CPU
+                    EndGlobalSection
+                    GlobalSection(SolutionProperties) = preSolution
+                        HideSolutionNode = FALSE
+                    EndGlobalSection
+                    GlobalSection(NestedProjects) = preSolution
+                        {A5EE8128-B08E-4533-86C5-E46714981680} = {E0F97730-25D2-418A-A7BD-02CAFDC6E470}
+                        {2AE8D6C4-FB43-430C-8AEB-15E5EEDAAE4B} = {E0F97730-25D2-418A-A7BD-02CAFDC6E470}
+                    EndGlobalSection
+                EndGlobal
+                ";
+
+            try
             {
-                Assert.Equal("{E0F97730-25D2-418A-A7BD-02CAFDC6E470}", myPhysicalFolderClassLibrary1.ParentProjectGuid);
-                Assert.Equal("{2AE8D6C4-FB43-430C-8AEB-15E5EEDAAE4B}", classLibrary2.ParentProjectGuid);
+                ParseSolutionHelper(solutionFileContents);
             }
-            else
+            catch (InvalidProjectFileException e)
             {
-                // try at least assert not null
-                Assert.NotNull(myPhysicalFolderClassLibrary1.ParentProjectGuid);
-                Assert.NotNull(classLibrary2.ParentProjectGuid);
+                Assert.Equal("MSB5023", e.ErrorCode);
+                Assert.Contains("{2AE8D6C4-FB43-430C-8AEB-15E5EEDAAE4B}", e.Message);
+                return;
             }
+
+            // Should not get here
+            Assert.Fail();
         }
 
         /// <summary>
@@ -359,19 +711,19 @@ namespace Microsoft.Build.UnitTests.Construction
             var classLibrary2 = solution.ProjectsInOrder.First(p => p.ProjectName == "ClassLibrary2");
             var classLibrary3 = solution.ProjectsInOrder.First(p => p.ProjectName == "ClassLibrary3");
 
-            Assert.Equal(ConvertToUnixPathIfNeeded("ClassLibrary1\\ClassLibrary1.csproj"), classLibrary1.RelativePath);
+            Assert.Equal(ConvertToUnixPathIfNeeded("ClassLibrary1\\ClassLibrary1.csproj", convertToSlnx), classLibrary1.RelativePath);
             Assert.Single(classLibrary1.Dependencies);
             Assert.Equal(classLibrary3.ProjectGuid, classLibrary1.Dependencies[0]);
             Assert.Null(solution.ProjectsInOrder[0].ParentProjectGuid);
 
-            Assert.Equal(ConvertToUnixPathIfNeeded("ClassLibrary2\\ClassLibrary2.csproj"), classLibrary2.RelativePath);
+            Assert.Equal(ConvertToUnixPathIfNeeded("ClassLibrary2\\ClassLibrary2.csproj", convertToSlnx), classLibrary2.RelativePath);
             Assert.Equal(2, classLibrary2.Dependencies.Count);
             // When converting to SLNX, the projects dependencies order is not preserved.
             Assert.Contains(classLibrary3.ProjectGuid, classLibrary2.Dependencies);
             Assert.Contains(classLibrary1.ProjectGuid, classLibrary2.Dependencies);
             Assert.Null(solution.ProjectsInOrder[1].ParentProjectGuid);
 
-            Assert.Equal(ConvertToUnixPathIfNeeded("ClassLibrary3\\ClassLibrary3.csproj"), solution.ProjectsInOrder[2].RelativePath);
+            Assert.Equal(ConvertToUnixPathIfNeeded("ClassLibrary3\\ClassLibrary3.csproj", convertToSlnx), solution.ProjectsInOrder[2].RelativePath);
             Assert.Empty(solution.ProjectsInOrder[2].Dependencies);
             Assert.Null(solution.ProjectsInOrder[2].ParentProjectGuid);
         }
@@ -516,6 +868,85 @@ namespace Microsoft.Build.UnitTests.Construction
         }
 
         /// <summary>
+        /// Test some invalid cases for solution configuration parsing.
+        /// There can be only one '=' character in a sln cfg entry, separating two identical names
+        /// </summary>
+        [Fact]
+        public void ParseInvalidSolutionConfigurations1()
+        {
+            Assert.Throws<InvalidProjectFileException>(() =>
+            {
+                string solutionFileContents =
+                    @"
+                Microsoft Visual Studio Solution File, Format Version 9.00
+                # Visual Studio 2005
+                Project('{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}') = 'ClassLibrary1', 'ClassLibrary1\ClassLibrary1.csproj', '{6185CC21-BE89-448A-B3C0-D1C27112E595}'
+                EndProject
+                Global
+                    GlobalSection(SolutionConfigurationPlatforms) = preSolution
+                        Debug|Any=CPU = Debug|Any=CPU
+                        Release|Any CPU = Release|Any CPU
+                    EndGlobalSection
+                EndGlobal
+                ";
+
+                ParseSolutionHelper(solutionFileContents);
+            });
+        }
+        /// <summary>
+        /// Test some invalid cases for solution configuration parsing
+        /// There can be only one '=' character in a sln cfg entry, separating two identical names
+        /// </summary>
+        [Fact]
+        public void ParseInvalidSolutionConfigurations2()
+        {
+            Assert.Throws<InvalidProjectFileException>(() =>
+            {
+                string solutionFileContents =
+                    @"
+                Microsoft Visual Studio Solution File, Format Version 9.00
+                # Visual Studio 2005
+                Project('{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}') = 'ClassLibrary1', 'ClassLibrary1\ClassLibrary1.csproj', '{6185CC21-BE89-448A-B3C0-D1C27112E595}'
+                EndProject
+                Global
+                    GlobalSection(SolutionConfigurationPlatforms) = preSolution
+                        Debug|Any CPU = Something|Else
+                        Release|Any CPU = Release|Any CPU
+                    EndGlobalSection
+                EndGlobal
+                ";
+
+                ParseSolutionHelper(solutionFileContents);
+            });
+        }
+        /// <summary>
+        /// Test some invalid cases for solution configuration parsing
+        /// Solution configurations must include the platform part
+        /// </summary>
+        [Fact]
+        public void ParseInvalidSolutionConfigurations3()
+        {
+            Assert.Throws<InvalidProjectFileException>(() =>
+            {
+                string solutionFileContents =
+                    @"
+                Microsoft Visual Studio Solution File, Format Version 9.00
+                # Visual Studio 2005
+                Project('{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}') = 'ClassLibrary1', 'ClassLibrary1\ClassLibrary1.csproj', '{6185CC21-BE89-448A-B3C0-D1C27112E595}'
+                EndProject
+                Global
+                    GlobalSection(SolutionConfigurationPlatforms) = preSolution
+                        Debug = Debug
+                        Release|Any CPU = Release|Any CPU
+                    EndGlobalSection
+                EndGlobal
+                ";
+
+                ParseSolutionHelper(solutionFileContents);
+            });
+        }
+
+        /// <summary>
         /// Make sure the project configurations in solution configurations get parsed correctly
         /// for a simple mixed C#/VC solution
         /// </summary>
@@ -615,10 +1046,69 @@ namespace Microsoft.Build.UnitTests.Construction
             Assert.True(vcProject.ProjectConfigurations["Release|Win32"].IncludeInBuild);
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public void ParseProjectConfigurationsInSolutionConfigurations2(bool convertToSlnx)
+        /// <summary>
+        /// Make sure the project configurations in solution configurations get parsed correctly
+        /// for a more tricky solution
+        /// </summary>
+        [Fact]
+        public void ParseProjectConfigurationsInSolutionConfigurations2()
+        {
+            string solutionFileContents =
+                @"
+                Microsoft Visual Studio Solution File, Format Version 9.00
+                # Visual Studio 2005
+                Project('{E24C65DC-7377-472B-9ABA-BC803B73C61A}') = 'C:\solutions\WebSite1\', '..\WebSite1\', '{E8E75132-67E4-4D6F-9CAE-8DA4C883F418}'
+                EndProject
+                Project('{E24C65DC-7377-472B-9ABA-BC803B73C61A}') = 'C:\solutions\WebSite2\', '..\WebSite2\', '{E8E75132-67E4-4D6F-9CAE-8DA4C883F419}'
+                EndProject
+                Project('{2150E333-8FDC-42A3-9474-1A3956D46DE8}') = 'NewFolder1', 'NewFolder1', '{54D20FFE-84BE-4066-A51E-B25D040A4235}'
+                EndProject
+                Project('{2150E333-8FDC-42A3-9474-1A3956D46DE8}') = 'NewFolder2', 'NewFolder2', '{D2633E4D-46FF-4C4E-8340-4BC7CDF78615}'
+                EndProject
+                Project('{8BC9CEB9-8B4A-11D0-8D11-00A0C91BC942}') = 'MSBuild.exe', '..\..\dd\binaries.x86dbg\bin\i386\MSBuild.exe', '{25FD9E7C-F37E-48E0-9A7C-607FE4AACCC0}'
+                EndProject
+                Global
+                    GlobalSection(SolutionConfigurationPlatforms) = preSolution
+                        Debug|.NET = Debug|.NET
+                    EndGlobalSection
+                    GlobalSection(ProjectConfigurationPlatforms) = postSolution
+                        {E8E75132-67E4-4D6F-9CAE-8DA4C883F418}.Debug|.NET.ActiveCfg = Debug|.NET
+                        {E8E75132-67E4-4D6F-9CAE-8DA4C883F418}.Debug|.NET.Build.0 = Debug|.NET
+                        {25FD9E7C-F37E-48E0-9A7C-607FE4AACCC0}.Debug|.NET.ActiveCfg = Debug
+                    EndGlobalSection
+                    GlobalSection(SolutionProperties) = preSolution
+                        HideSolutionNode = FALSE
+                    EndGlobalSection
+                    GlobalSection(NestedProjects) = preSolution
+                        {25FD9E7C-F37E-48E0-9A7C-607FE4AACCC0} = {D2633E4D-46FF-4C4E-8340-4BC7CDF78615}
+                    EndGlobalSection
+                EndGlobal
+                ";
+
+            SolutionFile solution = ParseSolutionHelper(solutionFileContents);
+
+            ProjectInSolution webProject = (ProjectInSolution)solution.ProjectsByGuid["{E8E75132-67E4-4D6F-9CAE-8DA4C883F418}"];
+            ProjectInSolution exeProject = (ProjectInSolution)solution.ProjectsByGuid["{25FD9E7C-F37E-48E0-9A7C-607FE4AACCC0}"];
+            ProjectInSolution missingWebProject = (ProjectInSolution)solution.ProjectsByGuid["{E8E75132-67E4-4D6F-9CAE-8DA4C883F419}"];
+
+            Assert.Single(webProject.ProjectConfigurations);
+
+            Assert.Equal("Debug|.NET", webProject.ProjectConfigurations["Debug|.NET"].FullName);
+            Assert.True(webProject.ProjectConfigurations["Debug|.NET"].IncludeInBuild);
+
+            Assert.Single(exeProject.ProjectConfigurations);
+
+            Assert.Equal("Debug", exeProject.ProjectConfigurations["Debug|.NET"].FullName);
+            Assert.False(exeProject.ProjectConfigurations["Debug|.NET"].IncludeInBuild);
+
+            Assert.Empty(missingWebProject.ProjectConfigurations);
+
+            Assert.Equal("Debug", solution.GetDefaultConfigurationName()); // "Default solution configuration"
+            Assert.Equal(".NET", solution.GetDefaultPlatformName()); // "Default solution platform"
+        }
+
+        [Fact]
+        public void ParseProjectConfigurationsInSolutionConfigurationsSlnx()
         {
             string solutionFileContents =
                 """
@@ -654,7 +1144,7 @@ namespace Microsoft.Build.UnitTests.Construction
                 EndGlobal
                 """;
 
-            SolutionFile solution = ParseSolutionHelper(solutionFileContents, convertToSlnx);
+            SolutionFile solution = ParseSolutionHelper(solutionFileContents, true);
 
             ProjectInSolution winFormsApp1 = solution.ProjectsInOrder.First(p => p.ProjectName == "WinFormsApp1");
             ProjectInSolution classLibrary1 = solution.ProjectsInOrder.First(p => p.ProjectName == "ClassLibrary1");
@@ -674,6 +1164,59 @@ namespace Microsoft.Build.UnitTests.Construction
 
             Assert.Equal("Release|AnyCPU", classLibrary1.ProjectConfigurations["Release|Any CPU"].FullName);
             Assert.False(classLibrary1.ProjectConfigurations["Release|Any CPU"].IncludeInBuild);
+        }
+
+        /// <summary>
+        /// Parse solution file with comments
+        /// </summary>
+        [Fact]
+        public void ParseSolutionWithComments()
+        {
+            const string solutionFileContent = @"
+                    Microsoft Visual Studio Solution File, Format Version 12.00
+                    # Visual Studio Version 16
+                    VisualStudioVersion = 16.0.29123.89
+                    MinimumVisualStudioVersion = 10.0.40219.1
+                    Project('{9A19103F-16F7-4668-BE54-9A1E7A4F7556}') = 'SlnCommentTest', 'SlnCommentTest.csproj', '{00000000-0000-0000-FFFF-FFFFFFFFFFFF}'
+                    EndProject
+                    Project('{2150E333-8FDC-42A3-9474-1A3956D46DE8}') = 'Solution Items', 'Solution Items', '{054DED3B-B890-4652-B449-839F581E5D86}'
+	                    ProjectSection(SolutionItems) = preProject
+		                    SlnFile.txt = SlnFile.txt
+	                    EndProjectSection
+                    EndProject
+                    Global
+	                    GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		                    Debug|Any CPU = Debug|Any CPU
+		                    Release|Any CPU = Release|Any CPU
+	                    EndGlobalSection
+	                    GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		                    {00000000-0000-0000-FFFF-FFFFFFFFFFFF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		                    {00000000-0000-0000-FFFF-FFFFFFFFFFFF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		                    {00000000-0000-0000-FFFF-FFFFFFFFFFFF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		                    {00000000-0000-0000-FFFF-FFFFFFFFFFFF}.Release|Any CPU.Build.0 = Release|Any CPU
+	                    EndGlobalSection
+	                    GlobalSection(SolutionProperties) = preSolution
+		                    HideSolutionNode = FALSE
+	                    EndGlobalSection
+	                    GlobalSection(ExtensibilityGlobals) = postSolution
+		                    SolutionGuid = {FFFFFFFF-FFFF-FFFF-0000-000000000000}
+	                    EndGlobalSection
+                    EndGlobal
+                    ";
+
+            StringBuilder stringBuilder = new StringBuilder();
+
+            // Put comment between all lines
+            const string comment = "\t# comment";
+            string[] lines = solutionFileContent.Split(new string[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries);
+            for (int i = 0; i < lines.Length; i++)
+            {
+                stringBuilder.AppendLine(comment);
+                stringBuilder.AppendLine(lines[i]);
+            }
+            stringBuilder.AppendLine(comment);
+
+            Should.NotThrow(() => ParseSolutionHelper(stringBuilder.ToString()));
         }
 
         /// <summary>
@@ -703,10 +1246,11 @@ namespace Microsoft.Build.UnitTests.Construction
             return slnxPath;
         }
 
-        private static string ConvertToUnixPathIfNeeded(string path)
+        private static string ConvertToUnixPathIfNeeded(string path, bool isConvertedToSlnx)
         {
             // In the new parser, ProjectModel.FilePath is converted to Unix-style.
-            return !NativeMethodsShared.IsWindows ? path.Replace('\\', '/') : path;
+            // we are using the new parser only for slnx files.
+            return !NativeMethodsShared.IsWindows && isConvertedToSlnx ? path.Replace('\\', '/') : path;
         }
     }
 }

--- a/src/Build.UnitTests/Construction/SolutionFile_Tests.cs
+++ b/src/Build.UnitTests/Construction/SolutionFile_Tests.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
-using System.Text;
 using Microsoft.Build.Construction;
 using Microsoft.Build.Exceptions;
 using Microsoft.Build.Shared;
@@ -17,11 +16,11 @@ using Xunit.Abstractions;
 
 namespace Microsoft.Build.UnitTests.Construction
 {
-    public class SolutionFile_OldParser_Tests
+    public class SolutionFile_Tests
     {
         public ITestOutputHelper TestOutputHelper { get; }
 
-        public SolutionFile_OldParser_Tests(ITestOutputHelper testOutputHelper)
+        public SolutionFile_Tests(ITestOutputHelper testOutputHelper)
         {
             TestOutputHelper = testOutputHelper;
         }
@@ -103,42 +102,6 @@ namespace Microsoft.Build.UnitTests.Construction
             proj.ProjectName.ShouldBe("Project name");
             proj.RelativePath.ShouldBe("Relative path to project file");
             proj.ProjectGuid.ShouldBe("Unique name-GUID");
-        }
-
-        /// <summary>
-        /// A slightly more complicated test where there is some different whitespace.
-        /// </summary>
-        [Fact]
-        public void ParseSolutionWithDifferentSpacing()
-        {
-            string solutionFileContents =
-                @"
-                Microsoft Visual Studio Solution File, Format Version 9.00
-                # Visual Studio 2005
-                Project(' { Project GUID} ')  = ' Project name ',  ' Relative path to project file '    , ' {0ABED153-9451-483C-8140-9E8D7306B216} '
-                EndProject
-                Global
-                    GlobalSection(SolutionConfigurationPlatforms) = preSolution
-                        Debug|AnyCPU = Debug|AnyCPU
-                        Release|AnyCPU = Release|AnyCPU
-                    EndGlobalSection
-                    GlobalSection(ProjectConfigurationPlatforms) = postSolution
-                        {0ABED153-9451-483C-8140-9E8D7306B216}.Debug|AnyCPU.ActiveCfg = Debug|AnyCPU
-                        {0ABED153-9451-483C-8140-9E8D7306B216}.Debug|AnyCPU.Build.0 = Debug|AnyCPU
-                        {0ABED153-9451-483C-8140-9E8D7306B216}.Release|AnyCPU.ActiveCfg = Release|AnyCPU
-                        {0ABED153-9451-483C-8140-9E8D7306B216}.Release|AnyCPU.Build.0 = Release|AnyCPU
-                    EndGlobalSection
-                    GlobalSection(SolutionProperties) = preSolution
-                        HideSolutionNode = FALSE
-                    EndGlobalSection
-                EndGlobal
-                ";
-
-            SolutionFile solution = ParseSolutionHelper(solutionFileContents);
-
-            Assert.Equal("Project name", solution.ProjectsInOrder[0].ProjectName);
-            Assert.Equal("Relative path to project file", solution.ProjectsInOrder[0].RelativePath);
-            Assert.Equal("{0ABED153-9451-483C-8140-9E8D7306B216}", solution.ProjectsInOrder[0].ProjectGuid);
         }
 
         /// <summary>
@@ -722,43 +685,6 @@ namespace Microsoft.Build.UnitTests.Construction
             proj.ProjectName.ShouldBe("MyProject,(=IsGreat)");
             proj.RelativePath.ShouldBe("Relative path to project file");
             proj.ProjectGuid.ShouldBe("Unique name-GUID");
-        }
-
-        /// <summary>
-        /// Test some characters that are valid in a file name but that also could be
-        /// considered a delimiter by a parser. Does quoting work for special characters?
-        /// </summary>
-        [Fact]
-        public void ParseSolutionWhereProjectNameHasSpecialCharacters()
-        {
-            string solutionFileContents =
-                           @"
-                Microsoft Visual Studio Solution File, Format Version 9.00
-                # Visual Studio 2005
-                Project('{Project GUID}')  = 'MyProject,(=IsGreat)',  'Relative path to project file'    , '{0ABED153-9451-483C-8140-9E8D7306B216}'
-                EndProject
-                Global
-                    GlobalSection(SolutionConfigurationPlatforms) = preSolution
-                        Debug|AnyCPU = Debug|AnyCPU
-                        Release|AnyCPU = Release|AnyCPU
-                    EndGlobalSection
-                    GlobalSection(ProjectConfigurationPlatforms) = postSolution
-                        {0ABED153-9451-483C-8140-9E8D7306B216}.Debug|AnyCPU.ActiveCfg = Debug|AnyCPU
-                        {0ABED153-9451-483C-8140-9E8D7306B216}.Debug|AnyCPU.Build.0 = Debug|AnyCPU
-                        {0ABED153-9451-483C-8140-9E8D7306B216}.Release|AnyCPU.ActiveCfg = Release|AnyCPU
-                        {0ABED153-9451-483C-8140-9E8D7306B216}.Release|AnyCPU.Build.0 = Release|AnyCPU
-                    EndGlobalSection
-                    GlobalSection(SolutionProperties) = preSolution
-                        HideSolutionNode = FALSE
-                    EndGlobalSection
-                EndGlobal
-                ";
-
-            SolutionFile solution = ParseSolutionHelper(solutionFileContents);
-
-            Assert.Equal("MyProject,(=IsGreat)", solution.ProjectsInOrder[0].ProjectName);
-            Assert.Equal("Relative path to project file", solution.ProjectsInOrder[0].RelativePath);
-            Assert.Equal("{0ABED153-9451-483C-8140-9E8D7306B216}", solution.ProjectsInOrder[0].ProjectGuid);
         }
 
         /// <summary>
@@ -2428,59 +2354,6 @@ EndGlobal
             solution.ProjectsInOrder[0].RelativePath.ShouldBe(expectedRelativePath);
             solution.ProjectsInOrder[0].AbsolutePath.ShouldBe(Path.GetFullPath(Path.Combine(Path.GetDirectoryName(solution.FullPath)!, expectedRelativePath)));
             solution.ProjectsInOrder[0].ProjectGuid.ShouldBe("{0ABED153-9451-483C-8140-9E8D7306B216}");
-        }
-
-        /// <summary>
-        /// Parse solution file with comments
-        /// </summary>
-        [Fact]
-        public void ParseSolutionWithComments()
-        {
-            const string solutionFileContent = @"
-                    Microsoft Visual Studio Solution File, Format Version 12.00
-                    # Visual Studio Version 16
-                    VisualStudioVersion = 16.0.29123.89
-                    MinimumVisualStudioVersion = 10.0.40219.1
-                    Project('{9A19103F-16F7-4668-BE54-9A1E7A4F7556}') = 'SlnCommentTest', 'SlnCommentTest.csproj', '{00000000-0000-0000-FFFF-FFFFFFFFFFFF}'
-                    EndProject
-                    Project('{2150E333-8FDC-42A3-9474-1A3956D46DE8}') = 'Solution Items', 'Solution Items', '{054DED3B-B890-4652-B449-839F581E5D86}'
-	                    ProjectSection(SolutionItems) = preProject
-		                    SlnFile.txt = SlnFile.txt
-	                    EndProjectSection
-                    EndProject
-                    Global
-	                    GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		                    Debug|Any CPU = Debug|Any CPU
-		                    Release|Any CPU = Release|Any CPU
-	                    EndGlobalSection
-	                    GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		                    {00000000-0000-0000-FFFF-FFFFFFFFFFFF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		                    {00000000-0000-0000-FFFF-FFFFFFFFFFFF}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		                    {00000000-0000-0000-FFFF-FFFFFFFFFFFF}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		                    {00000000-0000-0000-FFFF-FFFFFFFFFFFF}.Release|Any CPU.Build.0 = Release|Any CPU
-	                    EndGlobalSection
-	                    GlobalSection(SolutionProperties) = preSolution
-		                    HideSolutionNode = FALSE
-	                    EndGlobalSection
-	                    GlobalSection(ExtensibilityGlobals) = postSolution
-		                    SolutionGuid = {FFFFFFFF-FFFF-FFFF-0000-000000000000}
-	                    EndGlobalSection
-                    EndGlobal
-                    ";
-
-            StringBuilder stringBuilder = new StringBuilder();
-
-            // Put comment between all lines
-            const string comment = "\t# comment";
-            string[] lines = solutionFileContent.Split(new string[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries);
-            for (int i = 0; i < lines.Length; i++)
-            {
-                stringBuilder.AppendLine(comment);
-                stringBuilder.AppendLine(lines[i]);
-            }
-            stringBuilder.AppendLine(comment);
-
-            Should.NotThrow(() => ParseSolutionHelper(stringBuilder.ToString()));
         }
     }
 }

--- a/src/Build.UnitTests/Construction/SolutionFilter_Tests.cs
+++ b/src/Build.UnitTests/Construction/SolutionFilter_Tests.cs
@@ -72,14 +72,14 @@ namespace Microsoft.Build.Engine.UnitTests.Construction
                     ");
                 // Slashes here (and in the .slnf) are hardcoded as backslashes intentionally to support the common case.
                 TransientTestFile solutionFile = testEnvironment.CreateFile(simpleProjectFolder, "SimpleProject.sln",
-                    """
+                    @"
                     Microsoft Visual Studio Solution File, Format Version 12.00
                     # Visual Studio Version 16
                     VisualStudioVersion = 16.0.29326.124
                     MinimumVisualStudioVersion = 10.0.40219.1
-                    Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SimpleProject", "SimpleProject\SimpleProject.csproj", "{79B5EBA6-5D27-4976-BC31-14422245A59A}"
+                    Project(""{9A19103F-16F7-4668-BE54-9A1E7A4F7556}"") = ""SimpleProject"", ""SimpleProject\SimpleProject.csproj"", ""{79B5EBA6-5D27-4976-BC31-14422245A59A}""
                     EndProject
-                    Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ClassLibrary", "..\ClassLibrary\ClassLibrary\ClassLibrary.csproj", "{8EFCCA22-9D51-4268-90F7-A595E11FCB2D}"
+                    Project(""{9A19103F-16F7-4668-BE54-9A1E7A4F7556}"") = ""ClassLibrary"", ""..\ClassLibrary\ClassLibrary\ClassLibrary.csproj"", ""{8EFCCA22-9D51-4268-90F7-A595E11FCB2D}""
                     EndProject
                     Global
                         GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -107,7 +107,7 @@ namespace Microsoft.Build.Engine.UnitTests.Construction
                             SolutionGuid = {DE7234EC-0C4D-4070-B66A-DCF1B4F0CFEF}
                         EndGlobalSection
                     EndGlobal
-                    """);
+                ");
                 TransientTestFile filterFile = testEnvironment.CreateFile(folder, "solutionFilter.slnf",
                     /*lang=json*/
                                   """

--- a/src/Build.UnitTests/Construction/SolutionProjectGenerator_Tests.cs
+++ b/src/Build.UnitTests/Construction/SolutionProjectGenerator_Tests.cs
@@ -38,8 +38,6 @@ namespace Microsoft.Build.UnitTests.Construction
 
         private static readonly BuildEventContext _buildEventContext = new BuildEventContext(0, 0, BuildEventContext.InvalidProjectContextId, 0);
 
-        private const string _longLineString = "a-really-long-string-a-really-long-string-a-really-long-string-a-really-long-string-a-really-long-string-a-really-long-string-a-really-long-string-a-really-long-string-a-really-long-string-a-really-long-string-a-really-long-string-a-really-long-string-a-really-long-string-a-really-long-string-a-really-long-string-a-really-long-string-a-really-long-string-a-really-long-string-a-really-long-string-a-really-long-string-a-really-long-string-a-really-long-string-a-really-long-string-a-really-long-string-a-really-long-string-a-really-long-string-a-really-long-string-a-really-long-string-a-really-long-string-";
-
         public SolutionProjectGenerator_Tests(ITestOutputHelper output)
         {
             this.output = output;
@@ -67,14 +65,12 @@ namespace Microsoft.Build.UnitTests.Construction
             using (TestEnvironment testEnvironment = TestEnvironment.Create())
             {
                 TransientTestFolder folder = testEnvironment.CreateFolder(createFolder: true);
-                TransientTestFile sln = testEnvironment.CreateFile(folder, "MySln.sln", "Microsoft Visual Studio Solution File, Format Version 12.00");
+                TransientTestFile sln = testEnvironment.CreateFile(folder, "MySln.sln", @"Microsoft Visual Studio Solution File, Format Version 16.00");
                 TransientTestFile targetsFile = testEnvironment.CreateFile(folder, name,
-                      """
-                      <Project>
-                        <Target Name="Build" AfterTargets="NonsenseTarget">
+                    @"<Project>
+                        <Target Name=""Build"" AfterTargets=""NonsenseTarget"">
                         </Target>
-                      </Project>
-                      """);
+                      </Project>");
                 ProjectInstance[] instances = SolutionProjectGenerator.Generate(SolutionFile.Parse(sln.Path), null, null, _buildEventContext, CreateMockLoggingService());
                 instances.ShouldHaveSingleItem();
                 instances[0].Targets["Build"].AfterTargets.ShouldBe(string.Empty);
@@ -91,35 +87,33 @@ namespace Microsoft.Build.UnitTests.Construction
                 TransientTestFolder folder = testEnvironment.CreateFolder(createFolder: true);
                 TransientTestFolder classLibFolder = testEnvironment.CreateFolder(Path.Combine(folder.Path, "classlib"), createFolder: true);
                 TransientTestFile classLibrary = testEnvironment.CreateFile(classLibFolder, "classlib.csproj",
-                  """
-                  <Project>
-                  <Target Name="ClassLibraryTarget">
-                      <Message Text="ClassLibraryBuilt"/>
+                    @"<Project>
+                  <Target Name=""ClassLibraryTarget"">
+                      <Message Text=""ClassLibraryBuilt""/>
                   </Target>
                   </Project>
-                  """);
+                    ");
 
                 TransientTestFolder simpleProjectFolder = testEnvironment.CreateFolder(Path.Combine(folder.Path, "simpleProject"), createFolder: true);
                 TransientTestFile simpleProject = testEnvironment.CreateFile(simpleProjectFolder, "simpleProject.csproj",
-                  """
-                  <Project>
-                  <Target Name="SimpleProjectTarget">
-                      <Message Text="SimpleProjectBuilt"/>
+                    @"<Project>
+                  <Target Name=""SimpleProjectTarget"">
+                      <Message Text=""SimpleProjectBuilt""/>
                   </Target>
                   </Project>
-                  """);
+                    ");
 
                 TransientTestFile solutionFile = testEnvironment.CreateFile(folder, "testFolder.sln",
-                    """
-                    Microsoft Visual Studio Solution File, Format Version 12.00
-                    # Visual Studio Version 16
-                    VisualStudioVersion = 16.6.30114.105
-                    MinimumVisualStudioVersion = 10.0.40219.1
-                    Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "simpleProject", "simpleProject\simpleProject.csproj", "{AA52A05F-A9C0-4C89-9933-BF976A304C91}"
-                    EndProject
-                    Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "classlib", "classlib\classlib.csproj", "{80B8E6B8-E46D-4456-91B1-848FD35C4AB9}"
-                    EndProject
-                    """);
+                    @"
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.6.30114.105
+MinimumVisualStudioVersion = 10.0.40219.1
+Project(""{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}"") = ""simpleProject"", ""simpleProject\simpleProject.csproj"", ""{AA52A05F-A9C0-4C89-9933-BF976A304C91}""
+EndProject
+Project(""{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}"") = ""classlib"", ""classlib\classlib.csproj"", ""{80B8E6B8-E46D-4456-91B1-848FD35C4AB9}""
+EndProject
+                ");
                 RunnerUtilities.ExecMSBuild(solutionFile.Path + " /t:classlib", out bool success);
                 success.ShouldBeTrue();
             }
@@ -136,58 +130,56 @@ namespace Microsoft.Build.UnitTests.Construction
                 TransientTestFolder folder = testEnvironment.CreateFolder(createFolder: true);
                 TransientTestFolder classLibFolder = testEnvironment.CreateFolder(Path.Combine(folder.Path, "classlib"), createFolder: true);
                 TransientTestFile classLibrary = testEnvironment.CreateFile(classLibFolder, "classlib.csproj",
-                  """
-                  <Project>
-                  <Target Name="Build">
-                      <Message Text="classlib.Build"/>
+                    @"<Project>
+                  <Target Name=""Build"">
+                      <Message Text=""classlib.Build""/>
                   </Target>
-                  <Target Name="Clean">
-                      <Message Text="classlib.Clean"/>
+                  <Target Name=""Clean"">
+                      <Message Text=""classlib.Clean""/>
                   </Target>
-                  <Target Name="Custom">
-                      <Message Text="classlib.Custom"/>
+                  <Target Name=""Custom"">
+                      <Message Text=""classlib.Custom""/>
                   </Target>
                   </Project>
-                  """);
+                    ");
 
                 TransientTestFolder simpleProjectFolder = testEnvironment.CreateFolder(Path.Combine(folder.Path, "simpleProject"), createFolder: true);
                 TransientTestFile simpleProject = testEnvironment.CreateFile(simpleProjectFolder, "simpleProject.csproj",
-                  """
-                  <Project>
-                  <Target Name="Build">
-                      <Message Text="simpleProject.Build"/>
+                    @"<Project>
+                  <Target Name=""Build"">
+                      <Message Text=""simpleProject.Build""/>
                   </Target>
-                  <Target Name="Clean">
-                      <Message Text="simpleProject.Clean"/>
+                  <Target Name=""Clean"">
+                      <Message Text=""simpleProject.Clean""/>
                   </Target>
-                  <Target Name="Custom">
-                      <Message Text="simpleProject.Custom"/>
+                  <Target Name=""Custom"">
+                      <Message Text=""simpleProject.Custom""/>
                   </Target>
                   </Project>
-                  """);
+                    ");
 
                 TransientTestFile solutionFile = testEnvironment.CreateFile(folder, "testFolder.sln",
-                    """
-                    Microsoft Visual Studio Solution File, Format Version 12.00
-                    # Visual Studio Version 16
-                    VisualStudioVersion = 16.6.30114.105
-                    MinimumVisualStudioVersion = 10.0.40219.1
-                    Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "simpleProject", "simpleProject\simpleProject.csproj", "{AA52A05F-A9C0-4C89-9933-BF976A304C91}"
-                    EndProject
-                    Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "classlib", "classlib\classlib.csproj", "{80B8E6B8-E46D-4456-91B1-848FD35C4AB9}"
-                    EndProject
-                    Global
-                        GlobalSection(SolutionConfigurationPlatforms) = preSolution
-                            Debug|x86 = Debug|x86
-                        EndGlobalSection
-                        GlobalSection(ProjectConfigurationPlatforms) = postSolution
-                            {AA52A05F-A9C0-4C89-9933-BF976A304C91}.Debug|x86.ActiveCfg = Debug|x86
-                            {AA52A05F-A9C0-4C89-9933-BF976A304C91}.Debug|x86.Build.0 = Debug|x86
-                            {80B8E6B8-E46D-4456-91B1-848FD35C4AB9}.Debug|x86.ActiveCfg = Debug|x86
-                            {80B8E6B8-E46D-4456-91B1-848FD35C4AB9}.Debug|x86.Build.0 = Debug|x86
-                        EndGlobalSection
-                        EndGlobal
-                    """);
+                    @"
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.6.30114.105
+MinimumVisualStudioVersion = 10.0.40219.1
+Project(""{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}"") = ""simpleProject"", ""simpleProject\simpleProject.csproj"", ""{AA52A05F-A9C0-4C89-9933-BF976A304C91}""
+EndProject
+Project(""{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}"") = ""classlib"", ""classlib\classlib.csproj"", ""{80B8E6B8-E46D-4456-91B1-848FD35C4AB9}""
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x86 = Debug|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{AA52A05F-A9C0-4C89-9933-BF976A304C91}.Debug|x86.ActiveCfg = Debug|x86
+		{AA52A05F-A9C0-4C89-9933-BF976A304C91}.Debug|x86.Build.0 = Debug|x86
+		{80B8E6B8-E46D-4456-91B1-848FD35C4AB9}.Debug|x86.ActiveCfg = Debug|x86
+		{80B8E6B8-E46D-4456-91B1-848FD35C4AB9}.Debug|x86.Build.0 = Debug|x86
+	EndGlobalSection
+EndGlobal
+                ");
 
                 string output = RunnerUtilities.ExecMSBuild(solutionFile.Path + " /t:Clean;Build;Custom", out bool success);
                 success.ShouldBeTrue();
@@ -212,58 +204,56 @@ namespace Microsoft.Build.UnitTests.Construction
                 TransientTestFolder folder = testEnvironment.CreateFolder(createFolder: true);
                 TransientTestFolder classLibFolder = testEnvironment.CreateFolder(Path.Combine(folder.Path, "classlib"), createFolder: true);
                 TransientTestFile classLibrary = testEnvironment.CreateFile(classLibFolder, "classlib.csproj",
-                  """
-                  <Project>
-                  <Target Name="Build">
-                      <Message Text="classlib.Build"/>
+                    @"<Project>
+                  <Target Name=""Build"">
+                      <Message Text=""classlib.Build""/>
                   </Target>
-                  <Target Name="Clean">
-                      <Message Text="classlib.Clean"/>
+                  <Target Name=""Clean"">
+                      <Message Text=""classlib.Clean""/>
                   </Target>
-                  <Target Name="Custom">
-                      <Message Text="classlib.Custom"/>
+                  <Target Name=""Custom"">
+                      <Message Text=""classlib.Custom""/>
                   </Target>
                   </Project>
-                  """);
+                    ");
 
                 TransientTestFolder simpleProjectFolder = testEnvironment.CreateFolder(Path.Combine(folder.Path, "simpleProject"), createFolder: true);
                 TransientTestFile simpleProject = testEnvironment.CreateFile(simpleProjectFolder, "simpleProject.csproj",
-                  """
-                  <Project>
-                  <Target Name="Build">
-                      <Message Text="simpleProject.Build"/>
+                    @"<Project>
+                  <Target Name=""Build"">
+                      <Message Text=""simpleProject.Build""/>
                   </Target>
-                  <Target Name="Clean">
-                      <Message Text="simpleProject.Clean"/>
+                  <Target Name=""Clean"">
+                      <Message Text=""simpleProject.Clean""/>
                   </Target>
-                  <Target Name="Custom">
-                      <Message Text="simpleProject.Custom"/>
+                  <Target Name=""Custom"">
+                      <Message Text=""simpleProject.Custom""/>
                   </Target>
                   </Project>
-                  """);
+                    ");
 
                 TransientTestFile solutionFile = testEnvironment.CreateFile(folder, "testFolder.sln",
-                    """
-                    Microsoft Visual Studio Solution File, Format Version 12.00
-                    # Visual Studio Version 16
-                    VisualStudioVersion = 16.6.30114.105
-                    MinimumVisualStudioVersion = 10.0.40219.1
-                    Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "simpleProject", "simpleProject\simpleProject.csproj", "{AA52A05F-A9C0-4C89-9933-BF976A304C91}"
-                    EndProject
-                    Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "classlib", "classlib\classlib.csproj", "{80B8E6B8-E46D-4456-91B1-848FD35C4AB9}"
-                    EndProject
-                    Global
-                        GlobalSection(SolutionConfigurationPlatforms) = preSolution
-                            Debug|x86 = Debug|x86
-                        EndGlobalSection
-                        GlobalSection(ProjectConfigurationPlatforms) = postSolution
-                            {AA52A05F-A9C0-4C89-9933-BF976A304C91}.Debug|x86.ActiveCfg = Debug|x86
-                            {AA52A05F-A9C0-4C89-9933-BF976A304C91}.Debug|x86.Build.0 = Debug|x86
-                            {80B8E6B8-E46D-4456-91B1-848FD35C4AB9}.Debug|x86.ActiveCfg = Debug|x86
-                            {80B8E6B8-E46D-4456-91B1-848FD35C4AB9}.Debug|x86.Build.0 = Debug|x86
-                        EndGlobalSection
-                    EndGlobal
-                    """);
+                    @"
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.6.30114.105
+MinimumVisualStudioVersion = 10.0.40219.1
+Project(""{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}"") = ""simpleProject"", ""simpleProject\simpleProject.csproj"", ""{AA52A05F-A9C0-4C89-9933-BF976A304C91}""
+EndProject
+Project(""{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}"") = ""classlib"", ""classlib\classlib.csproj"", ""{80B8E6B8-E46D-4456-91B1-848FD35C4AB9}""
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x86 = Debug|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{AA52A05F-A9C0-4C89-9933-BF976A304C91}.Debug|x86.ActiveCfg = Debug|x86
+		{AA52A05F-A9C0-4C89-9933-BF976A304C91}.Debug|x86.Build.0 = Debug|x86
+		{80B8E6B8-E46D-4456-91B1-848FD35C4AB9}.Debug|x86.ActiveCfg = Debug|x86
+		{80B8E6B8-E46D-4456-91B1-848FD35C4AB9}.Debug|x86.Build.0 = Debug|x86
+	EndGlobalSection
+EndGlobal
+                ");
 
                 try
                 {
@@ -341,12 +331,10 @@ namespace Microsoft.Build.UnitTests.Construction
         /// Test to make sure we properly set the ToolsVersion attribute on the in-memory project based
         /// on the Solution File Format Version.
         /// </summary>
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
+        [Fact]
         [Trait("Category", "netcore-osx-failing")]
         [Trait("Category", "netcore-linux-failing")]
-        public void EmitToolsVersionAttributeToInMemoryProject9(bool useNewParser)
+        public void EmitToolsVersionAttributeToInMemoryProject9()
         {
             if (FrameworkLocationHelper.PathToDotNetFrameworkV35 == null)
             {
@@ -355,7 +343,7 @@ namespace Microsoft.Build.UnitTests.Construction
             }
 
             string solutionFileContents =
-                """
+                @"
                 Microsoft Visual Studio Solution File, Format Version 9.00
                 Global
                     GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -365,9 +353,9 @@ namespace Microsoft.Build.UnitTests.Construction
                         Other|Win32 = Other|Win32
                     EndGlobalSection
                 EndGlobal
-                """;
+                ";
 
-            SolutionFile solution = ParseSolutionHelper(solutionFileContents, useNewParser);
+            SolutionFile solution = SolutionFile_Tests.ParseSolutionHelper(solutionFileContents);
 
             ProjectInstance[] instances = SolutionProjectGenerator.Generate(solution, null, "3.5", _buildEventContext, CreateMockLoggingService());
 
@@ -378,12 +366,10 @@ namespace Microsoft.Build.UnitTests.Construction
         /// Test to make sure we properly set the ToolsVersion attribute on the in-memory project based
         /// on the Solution File Format Version.
         /// </summary>
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
+        [Fact]
         [Trait("Category", "netcore-osx-failing")]
         [Trait("Category", "netcore-linux-failing")]
-        public void EmitToolsVersionAttributeToInMemoryProject10(bool useNewParser)
+        public void EmitToolsVersionAttributeToInMemoryProject10()
         {
             if (FrameworkLocationHelper.PathToDotNetFrameworkV35 == null)
             {
@@ -392,7 +378,7 @@ namespace Microsoft.Build.UnitTests.Construction
             }
 
             string solutionFileContents =
-                """
+                @"
                 Microsoft Visual Studio Solution File, Format Version 10.00
                 Global
                     GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -402,9 +388,9 @@ namespace Microsoft.Build.UnitTests.Construction
                         Other|Win32 = Other|Win32
                     EndGlobalSection
                 EndGlobal
-                """;
+                ";
 
-            SolutionFile solution = ParseSolutionHelper(solutionFileContents, useNewParser);
+            SolutionFile solution = SolutionFile_Tests.ParseSolutionHelper(solutionFileContents);
 
             ProjectInstance[] instances = SolutionProjectGenerator.Generate(solution, null, "3.5", _buildEventContext, CreateMockLoggingService());
 
@@ -421,7 +407,7 @@ namespace Microsoft.Build.UnitTests.Construction
             Environment.SetEnvironmentVariable("VisualStudioVersion", null);
 
             string solutionFileContents =
-                """
+                @"
                 Microsoft Visual Studio Solution File, Format Version 10.00
                 Global
                     GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -431,9 +417,9 @@ namespace Microsoft.Build.UnitTests.Construction
                         Other|Win32 = Other|Win32
                     EndGlobalSection
                 EndGlobal
-                """;
+                ";
 
-            SolutionFile solution = SolutionFile_OldParser_Tests.ParseSolutionHelper(solutionFileContents);
+            SolutionFile solution = SolutionFile_Tests.ParseSolutionHelper(solutionFileContents);
 
             ProjectInstance[] instances = SolutionProjectGenerator.Generate(solution, null, null, _buildEventContext, CreateMockLoggingService());
 
@@ -457,15 +443,13 @@ namespace Microsoft.Build.UnitTests.Construction
         /// Test to make sure that if the solution version corresponds to an existing sub-toolset version,
         /// barring other factors that might override, the sub-toolset will be based on the solution version.
         /// </summary>
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public void SubToolsetSetBySolutionVersion(bool useNewParser)
+        [Fact]
+        public void SubToolsetSetBySolutionVersion()
         {
             Environment.SetEnvironmentVariable("VisualStudioVersion", null);
 
             string solutionFileContents =
-                """
+                @"
                 Microsoft Visual Studio Solution File, Format Version 12.00
                 Global
                     GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -475,9 +459,9 @@ namespace Microsoft.Build.UnitTests.Construction
                         Other|Win32 = Other|Win32
                     EndGlobalSection
                 EndGlobal
-                """;
+                ";
 
-            SolutionFile solution = ParseSolutionHelper(solutionFileContents, useNewParser);
+            SolutionFile solution = SolutionFile_Tests.ParseSolutionHelper(solutionFileContents);
 
             ProjectInstance[] instances = SolutionProjectGenerator.Generate(solution, null, null, _buildEventContext, CreateMockLoggingService());
 
@@ -494,15 +478,13 @@ namespace Microsoft.Build.UnitTests.Construction
         /// <summary>
         /// Test to make sure that even if the solution version corresponds to an existing sub-toolset version,
         /// </summary>
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public void SolutionBasedSubToolsetVersionOverriddenByEnvironment(bool useNewParser)
+        [Fact]
+        public void SolutionBasedSubToolsetVersionOverriddenByEnvironment()
         {
             Environment.SetEnvironmentVariable("VisualStudioVersion", "ABC");
 
             string solutionFileContents =
-                """
+                @"
                 Microsoft Visual Studio Solution File, Format Version 12.00
                 Global
                     GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -512,9 +494,9 @@ namespace Microsoft.Build.UnitTests.Construction
                         Other|Win32 = Other|Win32
                     EndGlobalSection
                 EndGlobal
-                """;
+                ";
 
-            SolutionFile solution = ParseSolutionHelper(solutionFileContents, useNewParser);
+            SolutionFile solution = SolutionFile_Tests.ParseSolutionHelper(solutionFileContents);
 
             ProjectInstance[] instances = SolutionProjectGenerator.Generate(solution, null, null, _buildEventContext, CreateMockLoggingService());
 
@@ -737,45 +719,44 @@ namespace Microsoft.Build.UnitTests.Construction
         /// Verify that we throw the appropriate error if the solution declares a dependency
         /// on a project that doesn't exist.
         /// </summary>
-        /// <remarks>This test would only work for the old parser. In the new parser the dependency is not added if it was not in the solution file.</remarks>
         [Fact]
         public void SolutionWithMissingDependencies()
         {
             Assert.Throws<InvalidProjectFileException>(() =>
             {
                 string solutionFileContents =
-                    """
-                    Microsoft Visual Studio Solution File, Format Version 12.00
-                    # Visual Studio 11
-                    Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "B", "Project2\B.csproj", "{881C1674-4ECA-451D-85B6-D7C59B7F16FA}"
-                        ProjectSection(ProjectDependencies) = postProject
-                            {4A727FF8-65F2-401E-95AD-7C8BBFBE3167} = {4A727FF8-65F2-401E-95AD-7C8BBFBE3167}
-                        EndProjectSection
-                    EndProject
-                    Global
-                        GlobalSection(SolutionConfigurationPlatforms) = preSolution
-                            Debug|Any CPU = Debug|Any CPU
-                            Debug|x64 = Debug|x64
-                            Release|Any CPU = Release|Any CPU
-                            Release|x64 = Release|x64
-                        EndGlobalSection
-                        GlobalSection(ProjectConfigurationPlatforms) = preSolution
-                            {881C1674-4ECA-451D-85B6-D7C59B7F16FA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-                            {881C1674-4ECA-451D-85B6-D7C59B7F16FA}.Debug|Any CPU.Build.0 = Debug|Any CPU
-                            {881C1674-4ECA-451D-85B6-D7C59B7F16FA}.Debug|x64.ActiveCfg = Debug|Any CPU
-                            {881C1674-4ECA-451D-85B6-D7C59B7F16FA}.Debug|x64.Build.0 = Debug|Any CPU
-                            {881C1674-4ECA-451D-85B6-D7C59B7F16FA}.Release|Any CPU.ActiveCfg = Release|Any CPU
-                            {881C1674-4ECA-451D-85B6-D7C59B7F16FA}.Release|Any CPU.Build.0 = Release|Any CPU
-                            {881C1674-4ECA-451D-85B6-D7C59B7F16FA}.Release|x64.ActiveCfg = Release|Any CPU
-                            {881C1674-4ECA-451D-85B6-D7C59B7F16FA}.Release|x64.Build.0 = Release|Any CPU
-                        EndGlobalSection
-                        GlobalSection(SolutionProperties) = preSolution
-                            HideSolutionNode = FALSE
-                        EndGlobalSection
-                    EndGlobal
-                    """;
+                    @"
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 11
+Project(`{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}`) = `B`, `Project2\B.csproj`, `{881C1674-4ECA-451D-85B6-D7C59B7F16FA}`
+    ProjectSection(ProjectDependencies) = postProject
+        {4A727FF8-65F2-401E-95AD-7C8BBFBE3167} = {4A727FF8-65F2-401E-95AD-7C8BBFBE3167}
+    EndProjectSection
+EndProject
+Global
+    GlobalSection(SolutionConfigurationPlatforms) = preSolution
+        Debug|Any CPU = Debug|Any CPU
+        Debug|x64 = Debug|x64
+        Release|Any CPU = Release|Any CPU
+        Release|x64 = Release|x64
+    EndGlobalSection
+    GlobalSection(ProjectConfigurationPlatforms) = preSolution
+        {881C1674-4ECA-451D-85B6-D7C59B7F16FA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {881C1674-4ECA-451D-85B6-D7C59B7F16FA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {881C1674-4ECA-451D-85B6-D7C59B7F16FA}.Debug|x64.ActiveCfg = Debug|Any CPU
+        {881C1674-4ECA-451D-85B6-D7C59B7F16FA}.Debug|x64.Build.0 = Debug|Any CPU
+        {881C1674-4ECA-451D-85B6-D7C59B7F16FA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {881C1674-4ECA-451D-85B6-D7C59B7F16FA}.Release|Any CPU.Build.0 = Release|Any CPU
+        {881C1674-4ECA-451D-85B6-D7C59B7F16FA}.Release|x64.ActiveCfg = Release|Any CPU
+        {881C1674-4ECA-451D-85B6-D7C59B7F16FA}.Release|x64.Build.0 = Release|Any CPU
+    EndGlobalSection
+    GlobalSection(SolutionProperties) = preSolution
+        HideSolutionNode = FALSE
+    EndGlobalSection
+EndGlobal
+".Replace("`", "\"");
 
-                SolutionFile sp = SolutionFile_OldParser_Tests.ParseSolutionHelper(solutionFileContents);
+                SolutionFile sp = SolutionFile_Tests.ParseSolutionHelper(solutionFileContents);
                 ProjectInstance[] instances = SolutionProjectGenerator.Generate(sp, null, null, _buildEventContext, CreateMockLoggingService());
             });
         }
@@ -783,64 +764,62 @@ namespace Microsoft.Build.UnitTests.Construction
         /// Blob should contain dependency info
         /// Here B depends on C
         /// </summary>
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public void SolutionConfigurationWithDependencies(bool useNewParser)
+        [Fact]
+        public void SolutionConfigurationWithDependencies()
         {
             string solutionFileContents =
-                """
-                Microsoft Visual Studio Solution File, Format Version 12.00
-                # Visual Studio 11
-                Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "A", "Project1\A.csproj", "{786E302A-96CE-43DC-B640-D6B6CC9BF6C0}"
-                EndProject
-                Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "B", "Project2\B.csproj", "{881C1674-4ECA-451D-85B6-D7C59B7F16FA}"
-                    ProjectSection(ProjectDependencies) = postProject
-                        {4A727FF8-65F2-401E-95AD-7C8BBFBE3167} = {4A727FF8-65F2-401E-95AD-7C8BBFBE3167}
-                    EndProjectSection
-                EndProject
-                Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "C", "Project3\C.csproj", "{4A727FF8-65F2-401E-95AD-7C8BBFBE3167}"
-                EndProject
-                Global
-                    GlobalSection(SolutionConfigurationPlatforms) = preSolution
-                        Debug|Any CPU = Debug|Any CPU
-                        Debug|x64 = Debug|x64
-                        Release|Any CPU = Release|Any CPU
-                        Release|x64 = Release|x64
-                    EndGlobalSection
-                    GlobalSection(ProjectConfigurationPlatforms) = preSolution
-                        {4A727FF8-65F2-401E-95AD-7C8BBFBE3167}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-                        {4A727FF8-65F2-401E-95AD-7C8BBFBE3167}.Debug|Any CPU.Build.0 = Debug|Any CPU
-                        {4A727FF8-65F2-401E-95AD-7C8BBFBE3167}.Debug|x64.ActiveCfg = Debug|Any CPU
-                        {4A727FF8-65F2-401E-95AD-7C8BBFBE3167}.Debug|x64.Build.0 = Debug|Any CPU
-                        {4A727FF8-65F2-401E-95AD-7C8BBFBE3167}.Release|Any CPU.ActiveCfg = Release|Any CPU
-                        {4A727FF8-65F2-401E-95AD-7C8BBFBE3167}.Release|Any CPU.Build.0 = Release|Any CPU
-                        {4A727FF8-65F2-401E-95AD-7C8BBFBE3167}.Release|x64.ActiveCfg = Release|Any CPU
-                        {4A727FF8-65F2-401E-95AD-7C8BBFBE3167}.Release|x64.Build.0 = Release|Any CPU
-                        {786E302A-96CE-43DC-B640-D6B6CC9BF6C0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-                        {786E302A-96CE-43DC-B640-D6B6CC9BF6C0}.Debug|Any CPU.Build.0 = Debug|Any CPU
-                        {786E302A-96CE-43DC-B640-D6B6CC9BF6C0}.Debug|x64.ActiveCfg = Debug|Any CPU
-                        {786E302A-96CE-43DC-B640-D6B6CC9BF6C0}.Debug|x64.Build.0 = Debug|Any CPU
-                        {786E302A-96CE-43DC-B640-D6B6CC9BF6C0}.Release|Any CPU.ActiveCfg = Release|Any CPU
-                        {786E302A-96CE-43DC-B640-D6B6CC9BF6C0}.Release|Any CPU.Build.0 = Release|Any CPU
-                        {786E302A-96CE-43DC-B640-D6B6CC9BF6C0}.Release|x64.ActiveCfg = Release|Any CPU
-                        {786E302A-96CE-43DC-B640-D6B6CC9BF6C0}.Release|x64.Build.0 = Release|Any CPU
-                        {881C1674-4ECA-451D-85B6-D7C59B7F16FA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-                        {881C1674-4ECA-451D-85B6-D7C59B7F16FA}.Debug|Any CPU.Build.0 = Debug|Any CPU
-                        {881C1674-4ECA-451D-85B6-D7C59B7F16FA}.Debug|x64.ActiveCfg = Debug|Any CPU
-                        {881C1674-4ECA-451D-85B6-D7C59B7F16FA}.Debug|x64.Build.0 = Debug|Any CPU
-                        {881C1674-4ECA-451D-85B6-D7C59B7F16FA}.Release|Any CPU.ActiveCfg = Release|Any CPU
-                        {881C1674-4ECA-451D-85B6-D7C59B7F16FA}.Release|Any CPU.Build.0 = Release|Any CPU
-                        {881C1674-4ECA-451D-85B6-D7C59B7F16FA}.Release|x64.ActiveCfg = Release|Any CPU
-                        {881C1674-4ECA-451D-85B6-D7C59B7F16FA}.Release|x64.Build.0 = Release|Any CPU
-                    EndGlobalSection
-                    GlobalSection(SolutionProperties) = preSolution
-                        HideSolutionNode = FALSE
-                    EndGlobalSection
-                EndGlobal
-                """;
+                @"
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 11
+Project(`{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}`) = `A`, `Project1\A.csproj`, `{786E302A-96CE-43DC-B640-D6B6CC9BF6C0}`
+EndProject
+Project(`{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}`) = `B`, `Project2\B.csproj`, `{881C1674-4ECA-451D-85B6-D7C59B7F16FA}`
+    ProjectSection(ProjectDependencies) = postProject
+        {4A727FF8-65F2-401E-95AD-7C8BBFBE3167} = {4A727FF8-65F2-401E-95AD-7C8BBFBE3167}
+    EndProjectSection
+EndProject
+Project(`{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}`) = `C`, `Project3\C.csproj`, `{4A727FF8-65F2-401E-95AD-7C8BBFBE3167}`
+EndProject
+Global
+    GlobalSection(SolutionConfigurationPlatforms) = preSolution
+        Debug|Any CPU = Debug|Any CPU
+        Debug|x64 = Debug|x64
+        Release|Any CPU = Release|Any CPU
+        Release|x64 = Release|x64
+    EndGlobalSection
+    GlobalSection(ProjectConfigurationPlatforms) = preSolution
+        {4A727FF8-65F2-401E-95AD-7C8BBFBE3167}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {4A727FF8-65F2-401E-95AD-7C8BBFBE3167}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {4A727FF8-65F2-401E-95AD-7C8BBFBE3167}.Debug|x64.ActiveCfg = Debug|Any CPU
+        {4A727FF8-65F2-401E-95AD-7C8BBFBE3167}.Debug|x64.Build.0 = Debug|Any CPU
+        {4A727FF8-65F2-401E-95AD-7C8BBFBE3167}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {4A727FF8-65F2-401E-95AD-7C8BBFBE3167}.Release|Any CPU.Build.0 = Release|Any CPU
+        {4A727FF8-65F2-401E-95AD-7C8BBFBE3167}.Release|x64.ActiveCfg = Release|Any CPU
+        {4A727FF8-65F2-401E-95AD-7C8BBFBE3167}.Release|x64.Build.0 = Release|Any CPU
+        {786E302A-96CE-43DC-B640-D6B6CC9BF6C0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {786E302A-96CE-43DC-B640-D6B6CC9BF6C0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {786E302A-96CE-43DC-B640-D6B6CC9BF6C0}.Debug|x64.ActiveCfg = Debug|Any CPU
+        {786E302A-96CE-43DC-B640-D6B6CC9BF6C0}.Debug|x64.Build.0 = Debug|Any CPU
+        {786E302A-96CE-43DC-B640-D6B6CC9BF6C0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {786E302A-96CE-43DC-B640-D6B6CC9BF6C0}.Release|Any CPU.Build.0 = Release|Any CPU
+        {786E302A-96CE-43DC-B640-D6B6CC9BF6C0}.Release|x64.ActiveCfg = Release|Any CPU
+        {786E302A-96CE-43DC-B640-D6B6CC9BF6C0}.Release|x64.Build.0 = Release|Any CPU
+        {881C1674-4ECA-451D-85B6-D7C59B7F16FA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {881C1674-4ECA-451D-85B6-D7C59B7F16FA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {881C1674-4ECA-451D-85B6-D7C59B7F16FA}.Debug|x64.ActiveCfg = Debug|Any CPU
+        {881C1674-4ECA-451D-85B6-D7C59B7F16FA}.Debug|x64.Build.0 = Debug|Any CPU
+        {881C1674-4ECA-451D-85B6-D7C59B7F16FA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {881C1674-4ECA-451D-85B6-D7C59B7F16FA}.Release|Any CPU.Build.0 = Release|Any CPU
+        {881C1674-4ECA-451D-85B6-D7C59B7F16FA}.Release|x64.ActiveCfg = Release|Any CPU
+        {881C1674-4ECA-451D-85B6-D7C59B7F16FA}.Release|x64.Build.0 = Release|Any CPU
+    EndGlobalSection
+    GlobalSection(SolutionProperties) = preSolution
+        HideSolutionNode = FALSE
+    EndGlobalSection
+EndGlobal
+".Replace("`", "\"");
 
-            SolutionFile solution = ParseSolutionHelper(solutionFileContents, useNewParser);
+            SolutionFile solution = SolutionFile_Tests.ParseSolutionHelper(solutionFileContents);
 
             ProjectRootElement projectXml = ProjectRootElement.Create();
 
@@ -859,14 +838,11 @@ namespace Microsoft.Build.UnitTests.Construction
             string solutionConfigurationContents = msbuildProject.GetPropertyValue("CurrentSolutionConfigurationContents");
 
             // Only the specified solution configuration is represented in THE BLOB: nothing for x64 in this case
-            string expected =
-                $$"""
-                <SolutionConfiguration>
-                  <ProjectConfiguration Project="{786E302A-96CE-43DC-B640-D6B6CC9BF6C0}" AbsolutePath="##temp##{{Path.Combine("Project1", "A.csproj")}}" BuildProjectInSolution="True">Debug|AnyCPU</ProjectConfiguration>
-                  <ProjectConfiguration Project="{881C1674-4ECA-451D-85B6-D7C59B7F16FA}" AbsolutePath="##temp##{{Path.Combine("Project2", "B.csproj")}}" BuildProjectInSolution="True">Debug|AnyCPU<ProjectDependency Project="{4A727FF8-65F2-401E-95AD-7C8BBFBE3167}" /></ProjectConfiguration>
-                  <ProjectConfiguration Project="{4A727FF8-65F2-401E-95AD-7C8BBFBE3167}" AbsolutePath="##temp##{{Path.Combine("Project3", "C.csproj")}}" BuildProjectInSolution="True">Debug|AnyCPU</ProjectConfiguration>
-                </SolutionConfiguration>
-                """.Replace("##temp##", FileUtilities.TempFileDirectory);
+            string expected = $@"<SolutionConfiguration>
+  <ProjectConfiguration Project=`{{786E302A-96CE-43DC-B640-D6B6CC9BF6C0}}` AbsolutePath=`##temp##{Path.Combine("Project1", "A.csproj")}` BuildProjectInSolution=`True`>Debug|AnyCPU</ProjectConfiguration>
+  <ProjectConfiguration Project=`{{881C1674-4ECA-451D-85B6-D7C59B7F16FA}}` AbsolutePath=`##temp##{Path.Combine("Project2", "B.csproj")}` BuildProjectInSolution=`True`>Debug|AnyCPU<ProjectDependency Project=`{{4A727FF8-65F2-401E-95AD-7C8BBFBE3167}}` /></ProjectConfiguration>
+  <ProjectConfiguration Project=`{{4A727FF8-65F2-401E-95AD-7C8BBFBE3167}}` AbsolutePath=`##temp##{Path.Combine("Project3", "C.csproj")}` BuildProjectInSolution=`True`>Debug|AnyCPU</ProjectConfiguration>
+</SolutionConfiguration>".Replace("`", "\"").Replace("##temp##", FileUtilities.TempFileDirectory);
 
             Helpers.VerifyAssertLineByLine(expected, solutionConfigurationContents);
         }
@@ -884,19 +860,19 @@ namespace Microsoft.Build.UnitTests.Construction
                 TransientTestFile proj2 = env.CreateFile("B.csproj", @"<Project><Target Name=""Printer""><Message Importance=""high"" Text=""print string"" /></Target></Project>");
                 TransientTestFile proj3 = env.CreateFile("C.csproj", @"<Project><Target Name=""Printer""><Message Importance=""high"" Text=""print string"" /></Target></Project>");
                 TransientTestFile proj = env.CreateFile("mysln.sln",
-                    $$"""
-                    Microsoft Visual Studio Solution File, Format Version 12.00
-                    # Visual Studio 11
-                    Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "A", "{{proj1.Path}}", "{786E302A-96CE-43DC-B640-D6B6CC9BF6C0}"
-                    EndProject
-                    Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "B", "{{proj2.Path}}", "{881C1674-4ECA-451D-85B6-D7C59B7F16FA}"
-                        ProjectSection(ProjectDependencies) = postProject
-                            {"{4A727FF8-65F2-401E-95AD-7C8BBFBE3167}"} = {"{4A727FF8-65F2-401E-95AD-7C8BBFBE3167}"}
-                        EndProjectSection
-                    EndProject
-                    Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "C", "{{proj3.Path}}", "{4A727FF8-65F2-401E-95AD-7C8BBFBE3167}"
-                    EndProject
-                    """);
+                @$"
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 11
+Project(`{"{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}"}`) = `A`, `{proj1.Path}`, `{"{786E302A-96CE-43DC-B640-D6B6CC9BF6C0}"}`
+EndProject
+Project(`{"{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}"}`) = `B`, `{proj2.Path}`, `{"{881C1674-4ECA-451D-85B6-D7C59B7F16FA}"}`
+    ProjectSection(ProjectDependencies) = postProject
+        {"{4A727FF8-65F2-401E-95AD-7C8BBFBE3167}"} = {"{4A727FF8-65F2-401E-95AD-7C8BBFBE3167}"}
+    EndProjectSection
+EndProject
+Project(`{"{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}"}`) = `C`, `{proj3.Path}`, `{"{4A727FF8-65F2-401E-95AD-7C8BBFBE3167}"}`
+EndProject
+".Replace("`", "\""));
                 RunnerUtilities.ExecMSBuild("\"" + proj.Path + "\"", out bool successfulExit);
                 successfulExit.ShouldBeTrue();
             }
@@ -914,37 +890,37 @@ namespace Microsoft.Build.UnitTests.Construction
         {
             #region Large strings representing solution & projects
             const string solutionFileContents =
-                """
-                Microsoft Visual Studio Solution File, Format Version 12.00
-                # Visual Studio 11
-                Project(`{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}`) = `B`, `B.csproj`, `{881C1674-4ECA-451D-85B6-D7C59B7F16FA}`
-                    ProjectSection(ProjectDependencies) = postProject
-                        {4A727FF8-65F2-401E-95AD-7C8BBFBE3167} = {4A727FF8-65F2-401E-95AD-7C8BBFBE3167}
-                    EndProjectSection
-                EndProject
-                Project(`{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}`) = `C`, `C.csproj`, `{4A727FF8-65F2-401E-95AD-7C8BBFBE3167}`
-                EndProject
-                Project(`{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}`) = `D`, `D.csproj`, `{B6E7E06F-FC0B-48F1-911A-55E0E1566F00}`
-                EndProject
-                Global
-                    GlobalSection(SolutionConfigurationPlatforms) = preSolution
-                        Debug|Any CPU = Debug|Any CPU
-                    EndGlobalSection
-                    GlobalSection(ProjectConfigurationPlatforms) = preSolution
-                        {4A727FF8-65F2-401E-95AD-7C8BBFBE3167}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-                        {4A727FF8-65F2-401E-95AD-7C8BBFBE3167}.Debug|Any CPU.Build.0 = Debug|Any CPU
-                        {881C1674-4ECA-451D-85B6-D7C59B7F16FA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-                        {881C1674-4ECA-451D-85B6-D7C59B7F16FA}.Debug|Any CPU.Build.0 = Debug|Any CPU
-                        {B6E7E06F-FC0B-48F1-911A-55E0E1566F00}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-                        {B6E7E06F-FC0B-48F1-911A-55E0E1566F00}.Debug|Any CPU.Build.0 = Debug|Any CPU
-                    EndGlobalSection
-                    GlobalSection(SolutionProperties) = preSolution
-                        HideSolutionNode = FALSE
-                    EndGlobalSection
-                EndGlobal
-                """;
+                @"
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 11
+Project(`{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}`) = `B`, `B.csproj`, `{881C1674-4ECA-451D-85B6-D7C59B7F16FA}`
+    ProjectSection(ProjectDependencies) = postProject
+        {4A727FF8-65F2-401E-95AD-7C8BBFBE3167} = {4A727FF8-65F2-401E-95AD-7C8BBFBE3167}
+    EndProjectSection
+EndProject
+Project(`{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}`) = `C`, `C.csproj`, `{4A727FF8-65F2-401E-95AD-7C8BBFBE3167}`
+EndProject
+Project(`{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}`) = `D`, `D.csproj`, `{B6E7E06F-FC0B-48F1-911A-55E0E1566F00}`
+EndProject
+Global
+    GlobalSection(SolutionConfigurationPlatforms) = preSolution
+        Debug|Any CPU = Debug|Any CPU
+    EndGlobalSection
+    GlobalSection(ProjectConfigurationPlatforms) = preSolution
+        {4A727FF8-65F2-401E-95AD-7C8BBFBE3167}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {4A727FF8-65F2-401E-95AD-7C8BBFBE3167}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {881C1674-4ECA-451D-85B6-D7C59B7F16FA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {881C1674-4ECA-451D-85B6-D7C59B7F16FA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {B6E7E06F-FC0B-48F1-911A-55E0E1566F00}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {B6E7E06F-FC0B-48F1-911A-55E0E1566F00}.Debug|Any CPU.Build.0 = Debug|Any CPU
+    EndGlobalSection
+    GlobalSection(SolutionProperties) = preSolution
+        HideSolutionNode = FALSE
+    EndGlobalSection
+EndGlobal
+";
             const string projectBravoFileContents =
-                    """
+                    @"
                         <Project ToolsVersion='msbuilddefaulttoolsversion' DefaultTargets='Build' xmlns='msbuildnamespace'>
                             <Target Name='Build' Outputs='@(ComputedQuestion)'>
                                 <ItemGroup>
@@ -958,9 +934,9 @@ namespace Microsoft.Build.UnitTests.Construction
                                 </ProjectReference>
                             </ItemGroup>
                         </Project>
-                    """;
+                    ";
             const string projectCharlieFileContents =
-                    """
+                    @"
                         <Project ToolsVersion='msbuilddefaulttoolsversion' DefaultTargets='Build' xmlns='msbuildnamespace'>
                             <Target Name='Build' Outputs='@(ComputedAnswer)'>
                                 <ItemGroup>
@@ -968,9 +944,9 @@ namespace Microsoft.Build.UnitTests.Construction
                                 </ItemGroup>
                             </Target>
                         </Project>
-                    """;
+                    ";
             const string projectDeltaFileContents =
-                    """
+                    @"
                         <Project ToolsVersion='msbuilddefaulttoolsversion' DefaultTargets='Build' xmlns='msbuildnamespace'>
                             <PropertyGroup>
                                 <ProjectGuid>{B6E7E06F-FC0B-48F1-911A-55E0E1566F00}</ProjectGuid>
@@ -981,62 +957,60 @@ namespace Microsoft.Build.UnitTests.Construction
                                 </ItemGroup>
                             </Target>
                         </Project>
-                    """;
-            const string automaticProjectFileContents =
-                """
-                <Project ToolsVersion='msbuilddefaulttoolsversion' DefaultTargets='compile' xmlns='msbuildnamespace'>
-                    <Target Name='compile'>
-                        <!-- Build projects to get a baseline for their output -->
-                        <MSBuild Projects='B.csproj' Targets='Build'>
-                            <Output
-                                TaskParameter='TargetOutputs'
-                                ItemName='BravoProjectOutputs' />
-                        </MSBuild>
-                        <Message Importance='high' Text='BravoProjectOutputs: @(BravoProjectOutputs)' />
+                    ";
+            const string automaticProjectFileContents = @"
+<Project ToolsVersion='msbuilddefaulttoolsversion' DefaultTargets='compile' xmlns='msbuildnamespace'>
+    <Target Name='compile'>
+        <!-- Build projects to get a baseline for their output -->
+        <MSBuild Projects='B.csproj' Targets='Build'>
+            <Output
+                TaskParameter='TargetOutputs'
+                ItemName='BravoProjectOutputs' />
+        </MSBuild>
+        <Message Importance='high' Text='BravoProjectOutputs: @(BravoProjectOutputs)' />
 
-                        <MSBuild Projects='C.csproj' Targets='Build'>
-                            <Output
-                                TaskParameter='TargetOutputs'
-                                ItemName='CharlieProjectOutputs' />
-                        </MSBuild>
-                        <Message Importance='high' Text='CharlieProjectOutputs: @(CharlieProjectOutputs)' />
+        <MSBuild Projects='C.csproj' Targets='Build'>
+            <Output
+                TaskParameter='TargetOutputs'
+                ItemName='CharlieProjectOutputs' />
+        </MSBuild>
+        <Message Importance='high' Text='CharlieProjectOutputs: @(CharlieProjectOutputs)' />
 
-                        <MSBuild Projects='D.csproj' Targets='Build'>
-                            <Output
-                                TaskParameter='TargetOutputs'
-                                ItemName='DeltaProjectOutputs' />
-                        </MSBuild>
-                        <Message Importance='high' Text='DeltaProjectOutputs: @(DeltaProjectOutputs)' />
+        <MSBuild Projects='D.csproj' Targets='Build'>
+            <Output
+                TaskParameter='TargetOutputs'
+                ItemName='DeltaProjectOutputs' />
+        </MSBuild>
+        <Message Importance='high' Text='DeltaProjectOutputs: @(DeltaProjectOutputs)' />
 
-                        <PropertyGroup>
-                            <StringifiedBravoProjectOutputs>@(BravoProjectOutputs)</StringifiedBravoProjectOutputs>
-                            <StringifiedCharlieProjectOutputs>@(CharlieProjectOutputs)</StringifiedCharlieProjectOutputs>
-                            <StringifiedDeltaProjectOutputs>@(DeltaProjectOutputs)</StringifiedDeltaProjectOutputs>
-                        </PropertyGroup>
+        <PropertyGroup>
+            <StringifiedBravoProjectOutputs>@(BravoProjectOutputs)</StringifiedBravoProjectOutputs>
+            <StringifiedCharlieProjectOutputs>@(CharlieProjectOutputs)</StringifiedCharlieProjectOutputs>
+            <StringifiedDeltaProjectOutputs>@(DeltaProjectOutputs)</StringifiedDeltaProjectOutputs>
+        </PropertyGroup>
 
-                        <!-- Explicitly build the metaproject generated for B -->
-                        <MSBuild Projects='B.csproj.metaproj' Targets='Build'>
-                            <Output
-                                TaskParameter='TargetOutputs'
-                                ItemName='BravoMetaProjectOutputs' />
-                        </MSBuild>
-                        <Message Importance='high' Text='BravoMetaProjectOutputs: @(BravoMetaProjectOutputs)' />
-                        <Error Condition=` '@(BravoProjectOutputs)' != '@(BravoMetaProjectOutputs)' ` Text='Metaproj outputs must match outputs of normal project build.' />
+        <!-- Explicitly build the metaproject generated for B -->
+        <MSBuild Projects='B.csproj.metaproj' Targets='Build'>
+            <Output
+                TaskParameter='TargetOutputs'
+                ItemName='BravoMetaProjectOutputs' />
+        </MSBuild>
+        <Message Importance='high' Text='BravoMetaProjectOutputs: @(BravoMetaProjectOutputs)' />
+        <Error Condition=` '@(BravoProjectOutputs)' != '@(BravoMetaProjectOutputs)' ` Text='Metaproj outputs must match outputs of normal project build.' />
 
-                        <!-- Build the solution as a whole (which will build the metaproj and return overall outputs) -->
-                        <MSBuild Projects='MSBuildIssue.sln'>
-                            <Output
-                                TaskParameter='TargetOutputs'
-                                ItemName='SolutionProjectOutputs' />
-                        </MSBuild>
-                        <Message Importance='high' Text='SolutionProjectOutputs: @(SolutionProjectOutputs)' />
-                        <Error Condition=` '@(SolutionProjectOutputs->Count())' != '3' ` Text='Overall sln outputs must include outputs of each referenced project (there should be 3).' />
-                        <Error Condition=` '@(SolutionProjectOutputs->AnyHaveMetadataValue('Identity', '$(StringifiedBravoProjectOutputs)'))' != 'true'` Text='Overall sln outputs must include outputs of normal project build of project B.' />
-                        <Error Condition=` '@(SolutionProjectOutputs->AnyHaveMetadataValue('Identity', '$(StringifiedCharlieProjectOutputs)'))' != 'true' ` Text='Overall sln outputs must include outputs of normal project build of project C.' />
-                        <Error Condition=` '@(SolutionProjectOutputs->AnyHaveMetadataValue('Identity', '$(StringifiedDeltaProjectOutputs)'))' != 'true' ` Text='Overall sln outputs must include outputs of normal project build of project D.' />
-                    </Target>
-                </Project>
-                """;
+        <!-- Build the solution as a whole (which will build the metaproj and return overall outputs) -->
+        <MSBuild Projects='MSBuildIssue.sln'>
+            <Output
+                TaskParameter='TargetOutputs'
+                ItemName='SolutionProjectOutputs' />
+        </MSBuild>
+        <Message Importance='high' Text='SolutionProjectOutputs: @(SolutionProjectOutputs)' />
+        <Error Condition=` '@(SolutionProjectOutputs->Count())' != '3' ` Text='Overall sln outputs must include outputs of each referenced project (there should be 3).' />
+        <Error Condition=` '@(SolutionProjectOutputs->AnyHaveMetadataValue('Identity', '$(StringifiedBravoProjectOutputs)'))' != 'true'` Text='Overall sln outputs must include outputs of normal project build of project B.' />
+        <Error Condition=` '@(SolutionProjectOutputs->AnyHaveMetadataValue('Identity', '$(StringifiedCharlieProjectOutputs)'))' != 'true' ` Text='Overall sln outputs must include outputs of normal project build of project C.' />
+        <Error Condition=` '@(SolutionProjectOutputs->AnyHaveMetadataValue('Identity', '$(StringifiedDeltaProjectOutputs)'))' != 'true' ` Text='Overall sln outputs must include outputs of normal project build of project D.' />
+    </Target>
+</Project>";
             #endregion
 
             var logger = new MockLogger(output);
@@ -1065,13 +1039,11 @@ namespace Microsoft.Build.UnitTests.Construction
         /// <summary>
         /// Test the SolutionProjectGenerator.AddPropertyGroupForSolutionConfiguration method
         /// </summary>
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public void TestAddPropertyGroupForSolutionConfiguration(bool useNewParser)
+        [Fact]
+        public void TestAddPropertyGroupForSolutionConfiguration()
         {
             string solutionFileContents =
-                """
+                @"
                 Microsoft Visual Studio Solution File, Format Version 9.00
                 # Visual Studio 2005
                 Project('{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}') = 'ClassLibrary1', 'ClassLibrary1\ClassLibrary1.csproj', '{6185CC21-BE89-448A-B3C0-D1C27112E595}'
@@ -1091,9 +1063,9 @@ namespace Microsoft.Build.UnitTests.Construction
                         {A6F99D27-47B9-4EA4-BFC9-25157CBDC281}.Debug|Mixed Platforms.Build.0 = VCConfig1|Win32
                     EndGlobalSection
                 EndGlobal
-                """;
+                ";
 
-            SolutionFile solution = ParseSolutionHelper(solutionFileContents, useNewParser);
+            SolutionFile solution = SolutionFile_Tests.ParseSolutionHelper(solutionFileContents);
 
             ProjectRootElement projectXml = ProjectRootElement.Create();
 
@@ -1140,13 +1112,11 @@ namespace Microsoft.Build.UnitTests.Construction
         /// <summary>
         /// Make sure that BuildProjectInSolution is set to true of the Build.0 entry is in the solution configuration.
         /// </summary>
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public void TestAddPropertyGroupForSolutionConfigurationBuildProjectInSolutionSet(bool useNewParser)
+        [Fact]
+        public void TestAddPropertyGroupForSolutionConfigurationBuildProjectInSolutionSet()
         {
             string solutionFileContents =
-                """
+                @"
                 Microsoft Visual Studio Solution File, Format Version 9.00
                 # Visual Studio 2005
                 Project('{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}') = 'ClassLibrary1', 'ClassLibrary1\ClassLibrary1.csproj', '{6185CC21-BE89-448A-B3C0-D1C27112E595}'
@@ -1161,9 +1131,9 @@ namespace Microsoft.Build.UnitTests.Construction
                         {6185CC21-BE89-448A-B3C0-D1C27112E595}.Debug|Mixed Platforms.Build.0 = CSConfig1|Any CPU
                     EndGlobalSection
                 EndGlobal
-                """;
+                ";
 
-            SolutionFile solution = ParseSolutionHelper(solutionFileContents, useNewParser);
+            SolutionFile solution = SolutionFile_Tests.ParseSolutionHelper(solutionFileContents);
 
             ProjectRootElement projectXml = ProjectRootElement.Create();
 
@@ -1186,13 +1156,11 @@ namespace Microsoft.Build.UnitTests.Construction
         /// <summary>
         /// Make sure that BuildProjectInSolution is set to false of the Build.0 entry is in the solution configuration.
         /// </summary>
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public void TestAddPropertyGroupForSolutionConfigurationBuildProjectInSolutionNotSet(bool useNewParser)
+        [Fact]
+        public void TestAddPropertyGroupForSolutionConfigurationBuildProjectInSolutionNotSet()
         {
             string solutionFileContents =
-                """
+                @"
                 Microsoft Visual Studio Solution File, Format Version 9.00
                 # Visual Studio 2005
                 Project('{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}') = 'ClassLibrary1', 'ClassLibrary1\ClassLibrary1.csproj', '{6185CC21-BE89-448A-B3C0-D1C27112E595}'
@@ -1206,9 +1174,9 @@ namespace Microsoft.Build.UnitTests.Construction
                         {6185CC21-BE89-448A-B3C0-D1C27112E595}.Debug|Mixed Platforms.ActiveCfg = CSConfig1|Any CPU
                     EndGlobalSection
                 EndGlobal
-                """;
+                ";
 
-            SolutionFile solution = ParseSolutionHelper(solutionFileContents, useNewParser);
+            SolutionFile solution = SolutionFile_Tests.ParseSolutionHelper(solutionFileContents);
 
             ProjectRootElement projectXml = ProjectRootElement.Create();
 
@@ -1232,12 +1200,10 @@ namespace Microsoft.Build.UnitTests.Construction
         /// In this bug, SkipNonexistentProjects was always set to 'Build'. It should be 'Build' for metaprojects and 'True' for everything else.
         /// The repro below has one of each case. WebProjects can't build so they are set as SkipNonexistentProjects='Build'
         /// </summary>
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
+        [Fact]
         [Trait("Category", "netcore-osx-failing")]
         [Trait("Category", "netcore-linux-failing")]
-        public void Regress751742_SkipNonexistentProjects(bool useNewParser)
+        public void Regress751742_SkipNonexistentProjects()
         {
             if (FrameworkLocationHelper.PathToDotNetFrameworkV20 == null)
             {
@@ -1246,7 +1212,7 @@ namespace Microsoft.Build.UnitTests.Construction
             }
 
             var solutionFileContents =
-                """
+                @"
                 Microsoft Visual Studio Solution File, Format Version 9.00
                 # Visual Studio 2005
                 Project('{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}') = 'ClassLibrary1', 'ClassLibrary1\ClassLibrary1.csproj', '{6185CC21-BE89-448A-B3C0-D1C27112E595}'
@@ -1266,10 +1232,10 @@ namespace Microsoft.Build.UnitTests.Construction
                         {A6F99D27-47B9-4EA4-BFC9-25157CBDC281}.Debug|Mixed Platforms.Build.0 = VCConfig1|Win32
                     EndGlobalSection
                 EndGlobal
-                """;
+                ";
 
             // We're not passing in a /tv:xx switch, so the solution project will have tools version 2.0
-            SolutionFile solution = ParseSolutionHelper(solutionFileContents, useNewParser);
+            var solution = SolutionFile_Tests.ParseSolutionHelper(solutionFileContents);
 
             var instance = SolutionProjectGenerator.Generate(solution, null, ObjectModelHelpers.MSBuildDefaultToolsVersion, _buildEventContext, CreateMockLoggingService())[0];
 
@@ -1308,13 +1274,11 @@ namespace Microsoft.Build.UnitTests.Construction
         /// if set when building a solution, will be specified as the ToolsVersion on the MSBuild task when
         /// building the projects contained within the solution.
         /// </summary>
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public void ToolsVersionOverrideShouldBeSpecifiedOnMSBuildTaskInvocations(bool useNewParser)
+        [Fact]
+        public void ToolsVersionOverrideShouldBeSpecifiedOnMSBuildTaskInvocations()
         {
             string solutionFileContents =
-                """
+                @"
                 Microsoft Visual Studio Solution File, Format Version 9.00
                 # Visual Studio 2005
                 Project('{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}') = 'ClassLibrary1', 'ClassLibrary1\ClassLibrary1.csproj', '{6185CC21-BE89-448A-B3C0-D1C27112E595}'
@@ -1334,10 +1298,10 @@ namespace Microsoft.Build.UnitTests.Construction
                         {A6F99D27-47B9-4EA4-BFC9-25157CBDC281}.Debug|Mixed Platforms.Build.0 = VCConfig1|Win32
                     EndGlobalSection
                 EndGlobal
-                """;
+                ";
 
             // We're not passing in a /tv:xx switch, so the solution project will have tools version 2.0
-            SolutionFile solution = ParseSolutionHelper(solutionFileContents, useNewParser);
+            SolutionFile solution = SolutionFile_Tests.ParseSolutionHelper(solutionFileContents);
 
             ProjectInstance[] instances = SolutionProjectGenerator.Generate(solution, null, ObjectModelHelpers.MSBuildDefaultToolsVersion, _buildEventContext, CreateMockLoggingService());
 
@@ -1376,44 +1340,42 @@ namespace Microsoft.Build.UnitTests.Construction
         /// <summary>
         /// Make sure that whatever the solution ToolsVersion is, it gets mapped to all its metaprojs, too.
         /// </summary>
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public void SolutionWithDependenciesHasCorrectToolsVersionInMetaprojs(bool useNewParser)
+        [Fact]
+        public void SolutionWithDependenciesHasCorrectToolsVersionInMetaprojs()
         {
             string solutionFileContents =
-                """
-                Microsoft Visual Studio Solution File, Format Version 12.00
-                Project('{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}') = 'ConsoleApplication2', 'ConsoleApplication2\ConsoleApplication2.csproj', '{5B97A3C7-3DEE-47A4-870F-5CB6384FE6A4}'
-                    ProjectSection(ProjectDependencies) = postProject
-                        {E0D295A1-CAFA-4E68-9929-468657DAAC6C} = {E0D295A1-CAFA-4E68-9929-468657DAAC6C}
-                    EndProjectSection
-                EndProject
-                Project('{F184B08F-C81C-45F6-A57F-5ABD9991F28F}') = 'ConsoleApplication1', 'ConsoleApplication1\ConsoleApplication1.vbproj', '{E0D295A1-CAFA-4E68-9929-468657DAAC6C}'
-                EndProject
-                Global
-                    GlobalSection(SolutionConfigurationPlatforms) = preSolution
-                        Debug|Any CPU = Debug|Any CPU
-                        Release|Any CPU = Release|Any CPU
-                    EndGlobalSection
-                    GlobalSection(ProjectConfigurationPlatforms) = postSolution
-                        {5B97A3C7-3DEE-47A4-870F-5CB6384FE6A4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-                        {5B97A3C7-3DEE-47A4-870F-5CB6384FE6A4}.Debug|Any CPU.Build.0 = Debug|Any CPU
-                        {5B97A3C7-3DEE-47A4-870F-5CB6384FE6A4}.Release|Any CPU.ActiveCfg = Release|Any CPU
-                        {5B97A3C7-3DEE-47A4-870F-5CB6384FE6A4}.Release|Any CPU.Build.0 = Release|Any CPU
-                        {E0D295A1-CAFA-4E68-9929-468657DAAC6C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-                        {E0D295A1-CAFA-4E68-9929-468657DAAC6C}.Debug|Any CPU.Build.0 = Debug|Any CPU
-                        {E0D295A1-CAFA-4E68-9929-468657DAAC6C}.Release|Any CPU.ActiveCfg = Release|Any CPU
-                        {E0D295A1-CAFA-4E68-9929-468657DAAC6C}.Release|Any CPU.Build.0 = Release|Any CPU
-                    EndGlobalSection
-                    GlobalSection(SolutionProperties) = preSolution
-                        HideSolutionNode = FALSE
-                    EndGlobalSection
-                EndGlobal
-                """;
+                @"
+Microsoft Visual Studio Solution File, Format Version 12.00
+Project('{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}') = 'ConsoleApplication2', 'ConsoleApplication2\ConsoleApplication2.csproj', '{5B97A3C7-3DEE-47A4-870F-5CB6384FE6A4}'
+    ProjectSection(ProjectDependencies) = postProject
+        {E0D295A1-CAFA-4E68-9929-468657DAAC6C} = {E0D295A1-CAFA-4E68-9929-468657DAAC6C}
+    EndProjectSection
+EndProject
+Project('{F184B08F-C81C-45F6-A57F-5ABD9991F28F}') = 'ConsoleApplication1', 'ConsoleApplication1\ConsoleApplication1.vbproj', '{E0D295A1-CAFA-4E68-9929-468657DAAC6C}'
+EndProject
+Global
+    GlobalSection(SolutionConfigurationPlatforms) = preSolution
+        Debug|Any CPU = Debug|Any CPU
+        Release|Any CPU = Release|Any CPU
+    EndGlobalSection
+    GlobalSection(ProjectConfigurationPlatforms) = postSolution
+        {5B97A3C7-3DEE-47A4-870F-5CB6384FE6A4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {5B97A3C7-3DEE-47A4-870F-5CB6384FE6A4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {5B97A3C7-3DEE-47A4-870F-5CB6384FE6A4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {5B97A3C7-3DEE-47A4-870F-5CB6384FE6A4}.Release|Any CPU.Build.0 = Release|Any CPU
+        {E0D295A1-CAFA-4E68-9929-468657DAAC6C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {E0D295A1-CAFA-4E68-9929-468657DAAC6C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {E0D295A1-CAFA-4E68-9929-468657DAAC6C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {E0D295A1-CAFA-4E68-9929-468657DAAC6C}.Release|Any CPU.Build.0 = Release|Any CPU
+    EndGlobalSection
+    GlobalSection(SolutionProperties) = preSolution
+        HideSolutionNode = FALSE
+    EndGlobalSection
+EndGlobal
+                ";
 
             // We're not passing in a /tv:xx switch, so the solution project will have tools version 2.0
-            SolutionFile solution = ParseSolutionHelper(solutionFileContents, useNewParser);
+            SolutionFile solution = SolutionFile_Tests.ParseSolutionHelper(solutionFileContents);
 
             string[] solutionToolsVersions = { "4.0", ObjectModelHelpers.MSBuildDefaultToolsVersion };
 
@@ -1447,13 +1409,11 @@ namespace Microsoft.Build.UnitTests.Construction
         /// <summary>
         /// Test the SolutionProjectGenerator.Generate method has its toolset redirected correctly.
         /// </summary>
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public void ToolsVersionOverrideCausesToolsetRedirect(bool useNewParser)
+        [Fact]
+        public void ToolsVersionOverrideCausesToolsetRedirect()
         {
             string solutionFileContents =
-                """
+                @"
                 Microsoft Visual Studio Solution File, Format Version 9.00
                 # Visual Studio 2005
                 Project('{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}') = 'ClassLibrary1', 'ClassLibrary1\ClassLibrary1.csproj', '{6185CC21-BE89-448A-B3C0-D1C27112E595}'
@@ -1473,8 +1433,8 @@ namespace Microsoft.Build.UnitTests.Construction
                         {A6F99D27-47B9-4EA4-BFC9-25157CBDC281}.Debug|Mixed Platforms.Build.0 = VCConfig1|Win32
                     EndGlobalSection
                 EndGlobal
-                """;
-            SolutionFile solution = ParseSolutionHelper(solutionFileContents, useNewParser);
+                ";
+            SolutionFile solution = SolutionFile_Tests.ParseSolutionHelper(solutionFileContents);
             bool caughtException = false;
 
             try
@@ -1494,13 +1454,11 @@ namespace Microsoft.Build.UnitTests.Construction
         /// <summary>
         /// Test the SolutionProjectGenerator.AddPropertyGroupForSolutionConfiguration method
         /// </summary>
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public void TestDisambiguateProjectTargetName(bool useNewParser)
+        [Fact]
+        public void TestDisambiguateProjectTargetName()
         {
             string solutionFileContents =
-                """
+                @"
                 Microsoft Visual Studio Solution File, Format Version 9.00
                 # Visual Studio 2005
                 Project('{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}') = 'Build', 'Build\Build.csproj', '{21397922-C38F-4A0E-B950-77B3FBD51881}'
@@ -1520,9 +1478,9 @@ namespace Microsoft.Build.UnitTests.Construction
                                 HideSolutionNode = FALSE
                         EndGlobalSection
                 EndGlobal
-                """;
+                ";
 
-            SolutionFile solution = ParseSolutionHelper(solutionFileContents, useNewParser);
+            SolutionFile solution = SolutionFile_Tests.ParseSolutionHelper(solutionFileContents);
 
             ProjectInstance[] instances = SolutionProjectGenerator.Generate(solution, null, null, BuildEventContext.Invalid, CreateMockLoggingService());
 
@@ -1576,13 +1534,11 @@ namespace Microsoft.Build.UnitTests.Construction
         /// <summary>
         /// Tests the algorithm for choosing default configuration/platform values for solutions
         /// </summary>
-        /// <remarks>This test would only work for the old parser. In the new parser SolutionConfigurations are not available,
-        /// and constructed from projects configurations.</remarks>
         [Fact]
         public void TestConfigurationPlatformDefaults1()
         {
             string solutionFileContents =
-                """
+                @"
                 Microsoft Visual Studio Solution File, Format Version 9.00
                 Global
                     GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -1594,9 +1550,9 @@ namespace Microsoft.Build.UnitTests.Construction
                         Release|Win32 = Release|Win32
                     EndGlobalSection
                 EndGlobal
-                """;
+                ";
 
-            SolutionFile solution = SolutionFile_OldParser_Tests.ParseSolutionHelper(solutionFileContents);
+            SolutionFile solution = SolutionFile_Tests.ParseSolutionHelper(solutionFileContents);
 
             // These used to exist on the engine, but now need to be passed in explicitly
             IDictionary<string, string> globalProperties = new Dictionary<string, string>();
@@ -1616,13 +1572,11 @@ namespace Microsoft.Build.UnitTests.Construction
         /// <summary>
         /// Tests the algorithm for choosing default configuration/platform values for solutions
         /// </summary>
-        /// <remarks>This test would only work for the old parser. In the new parser SolutionConfigurations are not available,
-        /// and constructed from projects configurations.</remarks>
         [Fact]
         public void TestConfigurationPlatformDefaults2()
         {
             string solutionFileContents =
-                """
+                @"
                 Microsoft Visual Studio Solution File, Format Version 9.00
                 Global
                     GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -1632,9 +1586,9 @@ namespace Microsoft.Build.UnitTests.Construction
                         Other|Win32 = Other|Win32
                     EndGlobalSection
                 EndGlobal
-                """;
+                ";
 
-            SolutionFile solution = SolutionFile_OldParser_Tests.ParseSolutionHelper(solutionFileContents);
+            SolutionFile solution = SolutionFile_Tests.ParseSolutionHelper(solutionFileContents);
 
             ProjectInstance[] instances = SolutionProjectGenerator.Generate(solution, null, null, BuildEventContext.Invalid, CreateMockLoggingService());
 
@@ -1648,12 +1602,10 @@ namespace Microsoft.Build.UnitTests.Construction
         /// <summary>
         /// Tests the algorithm for choosing default Venus configuration values for solutions
         /// </summary>
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
+        [Fact]
         [Trait("Category", "netcore-osx-failing")]
         [Trait("Category", "netcore-linux-failing")]
-        public void TestVenusConfigurationDefaults(bool useNewParser)
+        public void TestVenusConfigurationDefaults()
         {
             if (FrameworkLocationHelper.PathToDotNetFrameworkV20 == null)
             {
@@ -1663,13 +1615,13 @@ namespace Microsoft.Build.UnitTests.Construction
 
             Dictionary<string, string> globalProperties = new Dictionary<string, string>();
             globalProperties["Configuration"] = "Debug";
-            ProjectInstance msbuildProject = CreateVenusSolutionProject(globalProperties, useNewParser);
+            ProjectInstance msbuildProject = CreateVenusSolutionProject(globalProperties);
 
             // ASP.NET configuration should match the selected solution configuration
             Assert.Equal("Debug", msbuildProject.GetPropertyValue("AspNetConfiguration"));
 
             globalProperties["Configuration"] = "Release";
-            msbuildProject = CreateVenusSolutionProject(globalProperties, useNewParser);
+            msbuildProject = CreateVenusSolutionProject(globalProperties);
             Assert.Equal("Release", msbuildProject.GetPropertyValue("AspNetConfiguration"));
 
             // Check that the two standard Asp.net configurations are represented on the targets
@@ -1680,12 +1632,10 @@ namespace Microsoft.Build.UnitTests.Construction
         /// <summary>
         /// Tests that the correct value for TargetFrameworkVersion gets set when creating Venus solutions
         /// </summary>
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
+        [Fact]
         [Trait("Category", "netcore-osx-failing")]
         [Trait("Category", "netcore-linux-failing")]
-        public void VenusSolutionDefaultTargetFrameworkVersion(bool useNewParser)
+        public void VenusSolutionDefaultTargetFrameworkVersion()
         {
             if (FrameworkLocationHelper.PathToDotNetFrameworkV20 == null)
             {
@@ -1694,7 +1644,7 @@ namespace Microsoft.Build.UnitTests.Construction
             }
 
             // v4.0 by default
-            ProjectInstance msbuildProject = CreateVenusSolutionProject(useNewParser);
+            ProjectInstance msbuildProject = CreateVenusSolutionProject();
             Assert.Equal("v4.0", msbuildProject.GetPropertyValue("TargetFrameworkVersion"));
 
             if (FrameworkLocationHelper.PathToDotNetFrameworkV35 == null)
@@ -1704,36 +1654,34 @@ namespace Microsoft.Build.UnitTests.Construction
             }
 
             // v3.5 if MSBuildToolsVersion is 3.5
-            msbuildProject = CreateVenusSolutionProject("3.5", useNewParser);
+            msbuildProject = CreateVenusSolutionProject("3.5");
             Assert.Equal("v3.5", msbuildProject.GetPropertyValue("TargetFrameworkVersion"));
 
             // v2.0 if MSBuildToolsVersion is 2.0
-            msbuildProject = CreateVenusSolutionProject("2.0", useNewParser);
+            msbuildProject = CreateVenusSolutionProject("2.0");
             Assert.Equal("v2.0", msbuildProject.GetPropertyValue("TargetFrameworkVersion"));
 
             // may be user defined
             IDictionary<string, string> globalProperties = new Dictionary<string, string>();
             globalProperties.Add("TargetFrameworkVersion", "userdefined");
-            msbuildProject = CreateVenusSolutionProject(globalProperties, useNewParser);
+            msbuildProject = CreateVenusSolutionProject(globalProperties);
             Assert.Equal("userdefined", msbuildProject.GetPropertyValue("TargetFrameworkVersion"));
         }
 
         /// <summary>
         /// Tests the algorithm for choosing target framework paths for ResolveAssemblyReferences for Venus
         /// </summary>
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
+        [Fact]
         [Trait("Category", "netcore-osx-failing")]
         [Trait("Category", "netcore-linux-failing")]
-        public void TestTargetFrameworkPaths0(bool useNewParser)
+        public void TestTargetFrameworkPaths0()
         {
             if (FrameworkLocationHelper.PathToDotNetFrameworkSdkV20 != null)
             {
                 IDictionary<string, string> globalProperties = new Dictionary<string, string>();
                 globalProperties.Add("TargetFrameworkVersion", "v2.0");
 
-                ProjectInstance msbuildProject = CreateVenusSolutionProject("2.0", useNewParser);
+                ProjectInstance msbuildProject = CreateVenusSolutionProject("2.0");
 
                 // ToolsVersion is 2.0, TargetFrameworkVersion is v2.0 --> one item pointing to v2.0
                 Assert.Equal("2.0", msbuildProject.ToolsVersion);
@@ -1748,12 +1696,10 @@ namespace Microsoft.Build.UnitTests.Construction
         /// <summary>
         /// Tests the algorithm for choosing target framework paths for ResolveAssemblyReferences for Venus
         /// </summary>
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
+        [Fact]
         [Trait("Category", "netcore-osx-failing")]
         [Trait("Category", "netcore-linux-failing")]
-        public void TestTargetFrameworkPaths1(bool useNewParser)
+        public void TestTargetFrameworkPaths1()
         {
             if (FrameworkLocationHelper.PathToDotNetFrameworkV20 == null)
             {
@@ -1761,7 +1707,7 @@ namespace Microsoft.Build.UnitTests.Construction
                 return;
             }
 
-            ProjectInstance msbuildProject = CreateVenusSolutionProject(useNewParser);
+            ProjectInstance msbuildProject = CreateVenusSolutionProject();
 
             // ToolsVersion is 4.0, TargetFrameworkVersion is v2.0 --> one item pointing to v2.0
             msbuildProject.SetProperty("TargetFrameworkVersion", "v2.0");
@@ -1776,12 +1722,10 @@ namespace Microsoft.Build.UnitTests.Construction
         /// <summary>
         /// Tests the algorithm for choosing target framework paths for ResolveAssemblyReferences for Venus
         /// </summary>
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
+        [Fact]
         [Trait("Category", "netcore-osx-failing")]
         [Trait("Category", "netcore-linux-failing")]
-        public void TestTargetFrameworkPaths2(bool useNewParser)
+        public void TestTargetFrameworkPaths2()
         {
             if (FrameworkLocationHelper.PathToDotNetFrameworkV20 == null)
             {
@@ -1789,7 +1733,7 @@ namespace Microsoft.Build.UnitTests.Construction
                 return;
             }
 
-            ProjectInstance msbuildProject = CreateVenusSolutionProject(useNewParser);
+            ProjectInstance msbuildProject = CreateVenusSolutionProject();
 
             // ToolsVersion is 4.0, TargetFrameworkVersion is v4.0 --> items for v2.0 and v4.0
             msbuildProject.SetProperty("TargetFrameworkVersion", "v4.0");
@@ -1827,13 +1771,11 @@ namespace Microsoft.Build.UnitTests.Construction
         /// <summary>
         /// Test the PredictActiveSolutionConfigurationName method
         /// </summary>
-        /// <remarks>This test would only work for the old parser.
-        /// In the new parser SolutionConfigurations are not available, and constructed from projects configurations.</remarks>
         [Fact]
         public void TestPredictSolutionConfigurationName()
         {
             string solutionFileContents =
-                """
+                @"
                 Microsoft Visual Studio Solution File, Format Version 9.00
                 Global
                     GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -1843,9 +1785,9 @@ namespace Microsoft.Build.UnitTests.Construction
                         Debug|Win32 = Debug|Win32
                     EndGlobalSection
                 EndGlobal
-                """;
+                ";
 
-            SolutionFile solution = SolutionFile_OldParser_Tests.ParseSolutionHelper(solutionFileContents);
+            SolutionFile solution = SolutionFile_Tests.ParseSolutionHelper(solutionFileContents);
 
             IDictionary<string, string> globalProperties = new Dictionary<string, string>();
 
@@ -1864,13 +1806,11 @@ namespace Microsoft.Build.UnitTests.Construction
         /// <summary>
         /// Verifies that the SolutionProjectGenerator will correctly escape project file paths
         /// </summary>
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public void SolutionGeneratorEscapingProjectFilePaths(bool useNewParser)
+        [Fact]
+        public void SolutionGeneratorEscapingProjectFilePaths()
         {
             string solutionFileContents =
-                """
+                @"
                 Microsoft Visual Studio Solution File, Format Version 9.00
                 # Visual Studio 2005
                 Project('{F184B08F-C81C-45F6-A57F-5ABD9991F28F}') = 'ConsoleApplication1', '%abtest\ConsoleApplication1.vbproj', '{AB3413A6-D689-486D-B7F0-A095371B3F13}'
@@ -1890,9 +1830,9 @@ namespace Microsoft.Build.UnitTests.Construction
                         HideSolutionNode = FALSE
                     EndGlobalSection
                 EndGlobal
-                """;
+                ";
 
-            SolutionFile solution = ParseSolutionHelper(solutionFileContents, useNewParser);
+            SolutionFile solution = SolutionFile_Tests.ParseSolutionHelper(solutionFileContents);
 
             // Creating a ProjectRootElement shouldn't affect the ProjectCollection at all
             Assert.Empty(ProjectCollection.GlobalProjectCollection.LoadedProjects);
@@ -1909,10 +1849,8 @@ namespace Microsoft.Build.UnitTests.Construction
         /// <summary>
         /// Verifies that the SolutionProjectGenerator will emit a solution file.
         /// </summary>
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public void SolutionGeneratorCanEmitSolutions(bool useNewParser)
+        [Fact]
+        public void SolutionGeneratorCanEmitSolutions()
         {
             string oldValueForMSBuildEmitSolution = Environment.GetEnvironmentVariable("MSBuildEmitSolution");
 
@@ -1920,7 +1858,7 @@ namespace Microsoft.Build.UnitTests.Construction
             ProjectCollection.GlobalProjectCollection.UnloadAllProjects();
 
             string solutionFileContents =
-                """
+                @"
                 Microsoft Visual Studio Solution File, Format Version 9.00
                 # Visual Studio 2005
                 Project('{F184B08F-C81C-45F6-A57F-5ABD9991F28F}') = 'ConsoleApplication1', 'ConsoleApplication1\ConsoleApplication1.vbproj', '{AB3413A6-D689-486D-B7F0-A095371B3F13}'
@@ -1940,7 +1878,7 @@ namespace Microsoft.Build.UnitTests.Construction
                         HideSolutionNode = FALSE
                     EndGlobalSection
                 EndGlobal
-                """;
+                ";
 
             SolutionFile solution = null;
             using ProjectCollection collection = new ProjectCollection();
@@ -1949,7 +1887,7 @@ namespace Microsoft.Build.UnitTests.Construction
             {
                 Environment.SetEnvironmentVariable("MSBuildEmitSolution", "1");
 
-                solution = ParseSolutionHelper(solutionFileContents, useNewParser);
+                solution = SolutionFile_Tests.ParseSolutionHelper(solutionFileContents);
 
                 // Creating a ProjectRootElement shouldn't affect the ProjectCollection at all
                 Assert.Empty(ProjectCollection.GlobalProjectCollection.LoadedProjects);
@@ -1981,18 +1919,16 @@ namespace Microsoft.Build.UnitTests.Construction
         /// Make sure that we output a warning and don't build anything when we're given an invalid
         /// solution configuration and SkipInvalidConfigurations is set to true.
         /// </summary>
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
+        [Fact]
         [Trait("Category", "netcore-osx-failing")]
         [Trait("Category", "netcore-linux-failing")]
-        public void TestSkipInvalidConfigurationsCase(bool useNewParser)
+        public void TestSkipInvalidConfigurationsCase()
         {
             string tmpFileName = FileUtilities.GetTemporaryFileName();
             string projectFilePath = tmpFileName + ".sln";
 
-            string solutionFileContents =
-                """
+            string solutionContents =
+                @"
                 Microsoft Visual Studio Solution File, Format Version 11.00
                 # Visual Studio 2005
                 Project('{E24C65DC-7377-472B-9ABA-BC803B73C61A}') = 'C:\solutions\WebSite2\', '..\..\solutions\WebSite2\', '{F90528C4-6989-4D33-AFE8-F53173597CC2}'
@@ -2023,8 +1959,7 @@ namespace Microsoft.Build.UnitTests.Construction
                         {F90528C4-6989-4D33-AFE8-F53173597CC2}.Debug|Any CPU.ActiveCfg = Debug|.NET
                         {F90528C4-6989-4D33-AFE8-F53173597CC2}.Debug|Any CPU.Build.0 = Debug|.NET
                     EndGlobalSection
-                EndGlobal
-                """;
+                EndGlobal";
 
             try
             {
@@ -2034,7 +1969,7 @@ namespace Microsoft.Build.UnitTests.Construction
                 globalProperties["Configuration"] = "Nonexistent";
                 globalProperties["SkipInvalidConfigurations"] = "true";
 
-                SolutionFile solution = ParseSolutionHelper(solutionFileContents, useNewParser);
+                SolutionFile solution = SolutionFile_Tests.ParseSolutionHelper(solutionContents.Replace('\'', '"'));
                 ProjectInstance[] instances = SolutionProjectGenerator.Generate(solution, globalProperties, null, BuildEventContext.Invalid, CreateMockLoggingService());
                 ProjectInstance msbuildProject = instances[0];
 
@@ -2238,52 +2173,50 @@ EndGlobal
         /// Bug indicated that when a target framework version greater than 4.0 was used then the solution project generator would crash.
         /// this test is to make sure the fix is not regressed.
         /// </summary>
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public void TestTargetFrameworkVersionGreaterThan4(bool useNewParser)
+        [Fact]
+        public void TestTargetFrameworkVersionGreaterThan4()
         {
             string tmpFileName = FileUtilities.GetTemporaryFileName();
             string projectFilePath = tmpFileName + ".sln";
 
             string solutionFileContents =
-               """
-                Microsoft Visual Studio Solution File, Format Version 11.00
-                # Visual Studio 2010
-                Project('{E24C65DC-7377-472B-9ABA-BC803B73C61A}') = 'WebSite1', '..\WebSite1\', '{6B8F98F2-C976-4029-9321-5CCD73A174DA}'
-                    ProjectSection(WebsiteProperties) = preProject
-                        TargetFrameworkMoniker = '.NETFramework,Version=v4.34'
-                        Debug.AspNetCompiler.VirtualPath = '/WebSite1'
-                        Debug.AspNetCompiler.PhysicalPath = '..\WebSite1\'
-                        Debug.AspNetCompiler.TargetPath = 'PrecompiledWeb\WebSite1\'
-                        Debug.AspNetCompiler.Updateable = 'true'
-                        Debug.AspNetCompiler.ForceOverwrite = 'true'
-                        Debug.AspNetCompiler.FixedNames = 'false'
-                        Debug.AspNetCompiler.Debug = 'True'
-                        Release.AspNetCompiler.VirtualPath = '/WebSite1'
-                        Release.AspNetCompiler.PhysicalPath = '..\WebSite1\'
-                        Release.AspNetCompiler.TargetPath = 'PrecompiledWeb\WebSite1\'
-                        Release.AspNetCompiler.Updateable = 'true'
-                        Release.AspNetCompiler.ForceOverwrite = 'true'
-                        Release.AspNetCompiler.FixedNames = 'false'
-                        Release.AspNetCompiler.Debug = 'False'
-                        VWDPort = '45602'
-                        DefaultWebSiteLanguage = 'Visual Basic'
-                    EndProjectSection
-                EndProject
-                Global
-                    GlobalSection(SolutionConfigurationPlatforms) = preSolution
-                        Debug|Any CPU = Debug|Any CPU
-                    EndGlobalSection
-                    GlobalSection(ProjectConfigurationPlatforms) = postSolution
-                        {6B8F98F2-C976-4029-9321-5CCD73A174DA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-                        {6B8F98F2-C976-4029-9321-5CCD73A174DA}.Debug|Any CPU.Build.0 = Debug|Any CPU
-                    EndGlobalSection
-                    GlobalSection(SolutionProperties) = preSolution
-                        HideSolutionNode = FALSE
-                    EndGlobalSection
-                EndGlobal
-                """;
+               @"
+Microsoft Visual Studio Solution File, Format Version 11.00
+# Visual Studio 2010
+Project('{E24C65DC-7377-472B-9ABA-BC803B73C61A}') = 'WebSite1', '..\WebSite1\', '{6B8F98F2-C976-4029-9321-5CCD73A174DA}'
+    ProjectSection(WebsiteProperties) = preProject
+        TargetFrameworkMoniker = '.NETFramework,Version=v4.34'
+        Debug.AspNetCompiler.VirtualPath = '/WebSite1'
+        Debug.AspNetCompiler.PhysicalPath = '..\WebSite1\'
+        Debug.AspNetCompiler.TargetPath = 'PrecompiledWeb\WebSite1\'
+        Debug.AspNetCompiler.Updateable = 'true'
+        Debug.AspNetCompiler.ForceOverwrite = 'true'
+        Debug.AspNetCompiler.FixedNames = 'false'
+        Debug.AspNetCompiler.Debug = 'True'
+        Release.AspNetCompiler.VirtualPath = '/WebSite1'
+        Release.AspNetCompiler.PhysicalPath = '..\WebSite1\'
+        Release.AspNetCompiler.TargetPath = 'PrecompiledWeb\WebSite1\'
+        Release.AspNetCompiler.Updateable = 'true'
+        Release.AspNetCompiler.ForceOverwrite = 'true'
+        Release.AspNetCompiler.FixedNames = 'false'
+        Release.AspNetCompiler.Debug = 'False'
+        VWDPort = '45602'
+        DefaultWebSiteLanguage = 'Visual Basic'
+    EndProjectSection
+EndProject
+Global
+    GlobalSection(SolutionConfigurationPlatforms) = preSolution
+        Debug|Any CPU = Debug|Any CPU
+    EndGlobalSection
+    GlobalSection(ProjectConfigurationPlatforms) = postSolution
+        {6B8F98F2-C976-4029-9321-5CCD73A174DA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {6B8F98F2-C976-4029-9321-5CCD73A174DA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+    EndGlobalSection
+    GlobalSection(SolutionProperties) = preSolution
+        HideSolutionNode = FALSE
+    EndGlobalSection
+EndGlobal
+                ";
 
             try
             {
@@ -2293,9 +2226,7 @@ EndGlobal
                 globalProperties["Configuration"] = "Release";
                 globalProperties["SkipInvalidConfigurations"] = "true";
 
-
-                SolutionFile solution = ParseSolutionHelper(solutionFileContents, useNewParser);
-
+                SolutionFile solution = SolutionFile_Tests.ParseSolutionHelper(solutionFileContents.Replace('\'', '"'));
                 using ProjectCollection collection = new ProjectCollection();
                 collection.RegisterLogger(logger);
 
@@ -2325,16 +2256,14 @@ EndGlobal
         /// <summary>
         /// Verifies that when target names are specified they end up in the metaproj.
         /// </summary>
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public void CustomTargetNamesAreInInMetaproj(bool useNewParser)
+        [Fact]
+        public void CustomTargetNamesAreInInMetaproj()
         {
-            string solutionFileContents =
-                """
-                Microsoft Visual Studio Solution File, Format Version 12.00
+            SolutionFile solution = SolutionFile_Tests.ParseSolutionHelper(
+            @"
+                Microsoft Visual Studio Solution File, Format Version 14.00
                 # Visual Studio 2015
-                Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ClassLibrary1", "ClassLibrary1.csproj", "{6185CC21-BE89-448A-B3C0-D1C27112E595}"
+                Project(""{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}"") = ""ClassLibrary1"", ""ClassLibrary1.csproj"", ""{6185CC21-BE89-448A-B3C0-D1C27112E595}""
                 EndProject
                 Global
                     GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -2346,9 +2275,7 @@ EndGlobal
                         {6185CC21-BE89-448A-B3C0-D1C27112E595}.Release|Any CPU.ActiveCfg = CSConfig2|Any CPU
                     EndGlobalSection
                 EndGlobal
-                """;
-
-            SolutionFile solution = ParseSolutionHelper(solutionFileContents, useNewParser);
+            ");
 
             ProjectInstance[] instances = SolutionProjectGenerator.Generate(solution, null, null, BuildEventContext.Invalid, CreateMockLoggingService(), new List<string> { "One" });
 
@@ -2377,16 +2304,14 @@ EndGlobal
         /// <summary>
         /// Verifies that disambiguated target names are used when a project name matches a standard solution entry point.
         /// </summary>
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public void DisambiguatedTargetNamesAreInMetaproj(bool useNewParser)
+        [Fact]
+        public void DisambiguatedTargetNamesAreInInMetaproj()
         {
-            foreach (string projectName in ProjectInSolution.projectNamesToDisambiguate)
+            foreach(string projectName in ProjectInSolution.projectNamesToDisambiguate)
             {
-                string solutionFileContents =
-                    $$"""
-                    Microsoft Visual Studio Solution File, Format Version 12.00
+                SolutionFile solution = SolutionFile_Tests.ParseSolutionHelper(
+                $$"""
+                    Microsoft Visual Studio Solution File, Format Version 14.00
                     # Visual Studio 2015
                     Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "{{projectName}}", "{{projectName}}.csproj", "{6185CC21-BE89-448A-B3C0-D1C27112E595}"
                     EndProject
@@ -2401,9 +2326,7 @@ EndGlobal
                             {6185CC21-BE89-448A-B3C0-D1C27112E595}.Release|Any CPU.Build.0 = Release|Any CPU
                         EndGlobalSection
                     EndGlobal
-                    """;
-
-                SolutionFile solution = ParseSolutionHelper(solutionFileContents, useNewParser);
+                """);
 
                 ProjectInstance[] instances = SolutionProjectGenerator.Generate(solution, null, null, BuildEventContext.Invalid, CreateMockLoggingService(), null);
 
@@ -2426,33 +2349,29 @@ EndGlobal
         /// Verifies that illegal user target names (the ones already used internally) don't crash the SolutionProjectGenerator
         /// </summary>
         [Theory]
-        [InlineData(false, false)]
-        [InlineData(true, false)]
-        [InlineData(false, true)]
-        [InlineData(true, true)]
-        public void IllegalUserTargetNamesDoNotThrow(bool forceCaseDifference, bool useNewParser)
+        [InlineData(false)]
+        [InlineData(true)]
+        public void IllegalUserTargetNamesDoNotThrow(bool forceCaseDifference)
         {
-            string solutionFileContents =
-                """
-                Microsoft Visual Studio Solution File, Format Version 12.00
+            SolutionFile solution = SolutionFile_Tests.ParseSolutionHelper(
+            @"
+                Microsoft Visual Studio Solution File, Format Version 14.00
                 # Visual Studio 2015
-                Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ClassLibrary1", "ClassLibrary1.csproj", "{6185CC21-BE89-448A-B3C0-D1C27112E595}"
+                Project(""{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}"") = ""ClassLibrary1"", ""ClassLibrary1.csproj"", ""{6185CC21-BE89-448A-B3C0-D1C27112E595}""
                 EndProject
                 Global
-                    GlobalSection(SolutionConfigurationPlatforms) = preSolution
-                        Debug|Any CPU = Debug|Any CPU
-                        Release|Any CPU = Release|Any CPU
-                    EndGlobalSection
-                    GlobalSection(ProjectConfigurationPlatforms) = postSolution
-                        {6185CC21-BE89-448A-B3C0-D1C27112E595}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-                        {6185CC21-BE89-448A-B3C0-D1C27112E595}.Debug|Any CPU.Build.0 = Debug|Any CPU
-                        {6185CC21-BE89-448A-B3C0-D1C27112E595}.Release|Any CPU.ActiveCfg = Release|Any CPU
-                        {6185CC21-BE89-448A-B3C0-D1C27112E595}.Release|Any CPU.Build.0 = Release|Any CPU
-                    EndGlobalSection
+	                GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		                Debug|Any CPU = Debug|Any CPU
+		                Release|Any CPU = Release|Any CPU
+	                EndGlobalSection
+	                GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		                {6185CC21-BE89-448A-B3C0-D1C27112E595}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		                {6185CC21-BE89-448A-B3C0-D1C27112E595}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		                {6185CC21-BE89-448A-B3C0-D1C27112E595}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		                {6185CC21-BE89-448A-B3C0-D1C27112E595}.Release|Any CPU.Build.0 = Release|Any CPU
+	                EndGlobalSection
                 EndGlobal
-                """;
-
-            SolutionFile solution = ParseSolutionHelper(solutionFileContents, useNewParser);
+            ");
 
             ProjectInstance[] instances;
 
@@ -2507,34 +2426,31 @@ EndGlobal
         {
             string baseDirectory = Guid.NewGuid().ToString("N");
 
-            string solutionFilePath = ObjectModelHelpers.CreateFileInTempProjectDirectory(Path.Combine(baseDirectory, $"{Guid.NewGuid():N}.sln"),
-                """
-                Microsoft Visual Studio Solution File, Format Version 12.00
+            string solutionFilePath = ObjectModelHelpers.CreateFileInTempProjectDirectory(Path.Combine(baseDirectory, $"{Guid.NewGuid():N}.sln"), @"
+                Microsoft Visual Studio Solution File, Format Version 14.00
                 # Visual Studio 2015
-                Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ClassLibrary1", "ClassLibrary1.csproj", "{6185CC21-BE89-448A-B3C0-D1C27112E595}"
+                Project(""{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}"") = ""ClassLibrary1"", ""ClassLibrary1.csproj"", ""{6185CC21-BE89-448A-B3C0-D1C27112E595}""
                 EndProject
                 Global
-                    GlobalSection(SolutionConfigurationPlatforms) = preSolution
-                        Debug|Any CPU = Debug|Any CPU
-                        Release|Any CPU = Release|Any CPU
-                    EndGlobalSection
-                    GlobalSection(ProjectConfigurationPlatforms) = postSolution
-                        {6185CC21-BE89-448A-B3C0-D1C27112E595}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-                        {6185CC21-BE89-448A-B3C0-D1C27112E595}.Debug|Any CPU.Build.0 = Debug|Any CPU
-                        {6185CC21-BE89-448A-B3C0-D1C27112E595}.Release|Any CPU.ActiveCfg = Release|Any CPU
-                        {6185CC21-BE89-448A-B3C0-D1C27112E595}.Release|Any CPU.Build.0 = Release|Any CPU
-                    EndGlobalSection
+	                GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		                Debug|Any CPU = Debug|Any CPU
+		                Release|Any CPU = Release|Any CPU
+	                EndGlobalSection
+	                GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		                {6185CC21-BE89-448A-B3C0-D1C27112E595}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		                {6185CC21-BE89-448A-B3C0-D1C27112E595}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		                {6185CC21-BE89-448A-B3C0-D1C27112E595}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		                {6185CC21-BE89-448A-B3C0-D1C27112E595}.Release|Any CPU.Build.0 = Release|Any CPU
+	                EndGlobalSection
                 EndGlobal
-                """);
+            ");
 
-            ObjectModelHelpers.CreateFileInTempProjectDirectory(Path.Combine(baseDirectory, $"after.{Path.GetFileName(solutionFilePath)}.targets"),
-                """
-                <Project ToolsVersion="msbuilddefaulttoolsversion" xmlns="msbuildnamespace">
-                    <Target Name="MyTarget">
+            ObjectModelHelpers.CreateFileInTempProjectDirectory(Path.Combine(baseDirectory, $"after.{Path.GetFileName(solutionFilePath)}.targets"), @"
+                <Project ToolsVersion=""msbuilddefaulttoolsversion"" xmlns=""msbuildnamespace"">
+                    <Target Name=""MyTarget"">
                         <MyTask />
                     </Target>
-                </Project>
-                """);
+                </Project>");
 
             try
             {
@@ -2566,34 +2482,31 @@ EndGlobal
         {
             string baseDirectory = Guid.NewGuid().ToString("N");
 
-            string solutionFilePath = ObjectModelHelpers.CreateFileInTempProjectDirectory(Path.Combine(baseDirectory, $"{Guid.NewGuid():N}.sln"),
-                """
-                Microsoft Visual Studio Solution File, Format Version 12.00
+            string solutionFilePath = ObjectModelHelpers.CreateFileInTempProjectDirectory(Path.Combine(baseDirectory, $"{Guid.NewGuid():N}.sln"), @"
+                Microsoft Visual Studio Solution File, Format Version 14.00
                 # Visual Studio 2015
-                Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ClassLibrary1", "ClassLibrary1.csproj", "{6185CC21-BE89-448A-B3C0-D1C27112E595}"
+                Project(""{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}"") = ""ClassLibrary1"", ""ClassLibrary1.csproj"", ""{6185CC21-BE89-448A-B3C0-D1C27112E595}""
                 EndProject
                 Global
-                    GlobalSection(SolutionConfigurationPlatforms) = preSolution
-                        Debug|Any CPU = Debug|Any CPU
-                        Release|Any CPU = Release|Any CPU
-                    EndGlobalSection
-                    GlobalSection(ProjectConfigurationPlatforms) = postSolution
-                        {6185CC21-BE89-448A-B3C0-D1C27112E595}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-                        {6185CC21-BE89-448A-B3C0-D1C27112E595}.Debug|Any CPU.Build.0 = Debug|Any CPU
-                        {6185CC21-BE89-448A-B3C0-D1C27112E595}.Release|Any CPU.ActiveCfg = Release|Any CPU
-                        {6185CC21-BE89-448A-B3C0-D1C27112E595}.Release|Any CPU.Build.0 = Release|Any CPU
-                    EndGlobalSection
+	                GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		                Debug|Any CPU = Debug|Any CPU
+		                Release|Any CPU = Release|Any CPU
+	                EndGlobalSection
+	                GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		                {6185CC21-BE89-448A-B3C0-D1C27112E595}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		                {6185CC21-BE89-448A-B3C0-D1C27112E595}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		                {6185CC21-BE89-448A-B3C0-D1C27112E595}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		                {6185CC21-BE89-448A-B3C0-D1C27112E595}.Release|Any CPU.Build.0 = Release|Any CPU
+	                EndGlobalSection
                 EndGlobal
-                """);
+            ");
 
-            ObjectModelHelpers.CreateFileInTempProjectDirectory(Path.Combine(baseDirectory, $"after.{Path.GetFileName(solutionFilePath)}.targets"),
-                """
-                <Project ToolsVersion="msbuilddefaulttoolsversion" xmlns="msbuildnamespace">
-                    <Target Name="MyTarget" BeforeTargets="DynamicTraversalTarget">
-                        <Warning Text="Message from MyTarget" />
+            ObjectModelHelpers.CreateFileInTempProjectDirectory(Path.Combine(baseDirectory, $"after.{Path.GetFileName(solutionFilePath)}.targets"), @"
+                <Project ToolsVersion=""msbuilddefaulttoolsversion"" xmlns=""msbuildnamespace"">
+                    <Target Name=""MyTarget"" BeforeTargets=""DynamicTraversalTarget"">
+                        <Warning Text=""Message from MyTarget"" />
                     </Target>
-                </Project>
-                """);
+                </Project>");
 
             try
             {
@@ -2644,55 +2557,48 @@ EndGlobal
 
             string baseDirectory = Guid.NewGuid().ToString("N");
 
-            string solutionFilePath = ObjectModelHelpers.CreateFileInTempProjectDirectory(Path.Combine(baseDirectory, $"{Guid.NewGuid():N}.sln"),
-                """
-                Microsoft Visual Studio Solution File, Format Version 12.00
+            string solutionFilePath = ObjectModelHelpers.CreateFileInTempProjectDirectory(Path.Combine(baseDirectory, $"{Guid.NewGuid():N}.sln"), @"
+                Microsoft Visual Studio Solution File, Format Version 14.00
                 # Visual Studio 2015
-                Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ClassLibrary1", "ClassLibrary1.csproj", "{6185CC21-BE89-448A-B3C0-D1C27112E595}"
+                Project(""{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}"") = ""ClassLibrary1"", ""ClassLibrary1.csproj"", ""{6185CC21-BE89-448A-B3C0-D1C27112E595}""
                 EndProject
                 Global
-                    GlobalSection(SolutionConfigurationPlatforms) = preSolution
-                        Debug|Any CPU = Debug|Any CPU
-                        Release|Any CPU = Release|Any CPU
-                    EndGlobalSection
-                    GlobalSection(ProjectConfigurationPlatforms) = postSolution
-                        {6185CC21-BE89-448A-B3C0-D1C27112E595}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-                        {6185CC21-BE89-448A-B3C0-D1C27112E595}.Debug|Any CPU.Build.0 = Debug|Any CPU
-                        {6185CC21-BE89-448A-B3C0-D1C27112E595}.Release|Any CPU.ActiveCfg = Release|Any CPU
-                        {6185CC21-BE89-448A-B3C0-D1C27112E595}.Release|Any CPU.Build.0 = Release|Any CPU
-                    EndGlobalSection
+	                GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		                Debug|Any CPU = Debug|Any CPU
+		                Release|Any CPU = Release|Any CPU
+	                EndGlobalSection
+	                GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		                {6185CC21-BE89-448A-B3C0-D1C27112E595}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		                {6185CC21-BE89-448A-B3C0-D1C27112E595}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		                {6185CC21-BE89-448A-B3C0-D1C27112E595}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		                {6185CC21-BE89-448A-B3C0-D1C27112E595}.Release|Any CPU.Build.0 = Release|Any CPU
+	                EndGlobalSection
                 EndGlobal
-                """);
+            ");
 
-            string projectPath = ObjectModelHelpers.CreateFileInTempProjectDirectory(Path.Combine(baseDirectory, projectName),
-                $$"""
-                <Project ToolsVersion="msbuilddefaulttoolsversion" xmlns="msbuildnamespace">
+            string projectPath = ObjectModelHelpers.CreateFileInTempProjectDirectory(Path.Combine(baseDirectory, projectName), $@"
+                <Project ToolsVersion=""msbuilddefaulttoolsversion"" xmlns=""msbuildnamespace"">
                     <PropertyGroup>
-                        <PropertyA>{{expectedPropertyValue}}</PropertyA>
+                        <PropertyA>{expectedPropertyValue}</PropertyA>
                     </PropertyGroup>
-                </Project>
-                """);
+                </Project>");
 
             if (projectPath.StartsWith("Custom", StringComparison.OrdinalIgnoreCase))
             {
                 // If a custom file name was given, create a Directory.Solution.props and Directory.Build.targets to ensure that they aren't imported
-                ObjectModelHelpers.CreateFileInTempProjectDirectory(Path.Combine(baseDirectory, "Directory.Solution.props"),
-                    """
-                    <Project ToolsVersion="msbuilddefaulttoolsversion" xmlns="msbuildnamespace">
-                        <PropertyGroup>
-                            <PropertyA>This file should not be imported</PropertyA>
-                        </PropertyGroup>
-                    </Project>
-                    """);
+                ObjectModelHelpers.CreateFileInTempProjectDirectory(Path.Combine(baseDirectory, "Directory.Solution.props"), $@"
+                <Project ToolsVersion=""msbuilddefaulttoolsversion"" xmlns=""msbuildnamespace"">
+                    <PropertyGroup>
+                        <PropertyA>This file should not be imported</PropertyA>
+                    </PropertyGroup>
+                </Project>");
 
-                ObjectModelHelpers.CreateFileInTempProjectDirectory(Path.Combine(baseDirectory, "Directory.Solution.targets"),
-                    """
-                    <Project ToolsVersion="msbuilddefaulttoolsversion" xmlns="msbuildnamespace">
-                        <PropertyGroup>
-                            <PropertyA>This file should not be imported</PropertyA>
-                        </PropertyGroup>
-                    </Project>
-                    """);
+                ObjectModelHelpers.CreateFileInTempProjectDirectory(Path.Combine(baseDirectory, "Directory.Solution.targets"), $@"
+                <Project ToolsVersion=""msbuilddefaulttoolsversion"" xmlns=""msbuildnamespace"">
+                    <PropertyGroup>
+                        <PropertyA>This file should not be imported</PropertyA>
+                    </PropertyGroup>
+                </Project>");
             }
 
             try
@@ -2734,23 +2640,20 @@ EndGlobal
         /// Regression test for https://github.com/dotnet/msbuild/issues/6236
         /// </summary>
         [Theory]
-        [InlineData("http://localhost:8080", false)]
-        [InlineData("http://localhost:8080", true)]
-        [InlineData(_longLineString, false)]
-        [InlineData(_longLineString, true)]
-        public void AbsolutePathWorksForUnsupportedPaths(string relativePath, bool useNewParser)
+        [InlineData("http://localhost:8080")]
+        [InlineData("a-really-long-string-a-really-long-string-a-really-long-string-a-really-long-string-a-really-long-string-a-really-long-string-a-really-long-string-a-really-long-string-a-really-long-string-a-really-long-string-a-really-long-string-a-really-long-string-a-really-long-string-a-really-long-string-a-really-long-string-a-really-long-string-a-really-long-string-a-really-long-string-a-really-long-string-a-really-long-string-a-really-long-string-a-really-long-string-a-really-long-string-a-really-long-string-a-really-long-string-a-really-long-string-a-really-long-string-a-really-long-string-a-really-long-string-")]
+        public void AbsolutePathWorksForUnsupportedPaths(string relativePath)
         {
             string solutionFileContents =
-                $$"""
-                Microsoft Visual Studio Solution File, Format Version 12.00
-                # Visual Studio Version 16
-                VisualStudioVersion = 16.0.31025.194
-                MinimumVisualStudioVersion = 10.0.40219.1
-                Project("{E24C65DC-7377-472B-9ABA-BC803B73C61A}") = "WebSite1", "{{relativePath}}", "{96E0707C-2E9C-4704-946F-FA583147737F}"
-                EndProject
-                """;
+                $@"
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31025.194
+MinimumVisualStudioVersion = 10.0.40219.1
+Project(""{{E24C65DC-7377-472B-9ABA-BC803B73C61A}}"") = ""WebSite1"", ""{relativePath}"", ""{{{{96E0707C-2E9C-4704-946F-FA583147737F}}}}""
+EndProject";
 
-            SolutionFile solution = ParseSolutionHelper(solutionFileContents, useNewParser);
+            SolutionFile solution = SolutionFile_Tests.ParseSolutionHelper(solutionFileContents);
 
             ProjectInSolution projectInSolution = solution.ProjectsInOrder.ShouldHaveSingleItem();
 
@@ -2762,25 +2665,25 @@ EndGlobal
         /// <summary>
         /// Create a Project derived from a Venus solution
         /// </summary>
-        private ProjectInstance CreateVenusSolutionProject(bool useNewParser)
+        private ProjectInstance CreateVenusSolutionProject()
         {
-            return CreateVenusSolutionProject(null, null, useNewParser);
+            return CreateVenusSolutionProject(null, null);
         }
 
         /// <summary>
         /// Create a Project derived from a Venus solution
         /// </summary>
-        private ProjectInstance CreateVenusSolutionProject(IDictionary<string, string> globalProperties, bool useNewParser)
+        private ProjectInstance CreateVenusSolutionProject(IDictionary<string, string> globalProperties)
         {
-            return CreateVenusSolutionProject(globalProperties, null, useNewParser);
+            return CreateVenusSolutionProject(globalProperties, null);
         }
 
         /// <summary>
         /// Create a Project derived from a Venus solution
         /// </summary>
-        private ProjectInstance CreateVenusSolutionProject(string toolsVersion, bool useNewParser)
+        private ProjectInstance CreateVenusSolutionProject(string toolsVersion)
         {
-            return CreateVenusSolutionProject(null, toolsVersion, useNewParser);
+            return CreateVenusSolutionProject(null, toolsVersion);
         }
 
         /// <summary>
@@ -2789,10 +2692,10 @@ EndGlobal
         /// </summary>
         /// <param name="globalProperties">The dictionary of global properties.  May be null.</param>
         /// <param name="toolsVersion">The ToolsVersion override value.  May be null.</param>
-        private ProjectInstance CreateVenusSolutionProject(IDictionary<string, string> globalProperties, string toolsVersion, bool useNewParser)
+        private ProjectInstance CreateVenusSolutionProject(IDictionary<string, string> globalProperties, string toolsVersion)
         {
             string solutionFileContents =
-                """
+                @"
                 Microsoft Visual Studio Solution File, Format Version 9.00
                 # Visual Studio 2005
                 Project('{E24C65DC-7377-472B-9ABA-BC803B73C61A}') = 'C:\solutions\WebSite2\', '..\..\solutions\WebSite2\', '{F90528C4-6989-4D33-AFE8-F53173597CC2}'
@@ -2824,9 +2727,9 @@ EndGlobal
                         {F90528C4-6989-4D33-AFE8-F53173597CC2}.Debug|Any CPU.Build.0 = Debug|.NET
                     EndGlobalSection
                 EndGlobal
-                """;
+                ";
 
-            SolutionFile solution = ParseSolutionHelper(solutionFileContents, useNewParser);
+            SolutionFile solution = SolutionFile_Tests.ParseSolutionHelper(solutionFileContents);
 
             ProjectInstance[] instances = SolutionProjectGenerator.Generate(solution, globalProperties, toolsVersion, BuildEventContext.Invalid, CreateMockLoggingService());
 
@@ -2871,12 +2774,6 @@ EndGlobal
             IEnumerable<ProjectItemInstance> itemGroup = msbuildProject.GetItems(itemType);
             Assert.NotNull(itemGroup);
             Assert.Equal(count, itemGroup.Count());
-        }
-
-        private SolutionFile ParseSolutionHelper(string solutionFileContents, bool useNewParser)
-        {
-            return useNewParser ? SolutionFile_NewParser_Tests.ParseSolutionHelper(solutionFileContents) :
-                SolutionFile_OldParser_Tests.ParseSolutionHelper(solutionFileContents);
         }
 
         #endregion // Helper Functions

--- a/src/Build.UnitTests/Graph/GetCompatiblePlatformGraph_Tests.cs
+++ b/src/Build.UnitTests/Graph/GetCompatiblePlatformGraph_Tests.cs
@@ -402,14 +402,14 @@ namespace Microsoft.Build.Graph.UnitTests
 
                 // Slashes here (and in the .slnf) are hardcoded as backslashes intentionally to support the common case.
                 TransientTestFile solutionFile = testEnvironment.CreateFile(folder, "SimpleProject.sln",
-                    """
+                    @"
                     Microsoft Visual Studio Solution File, Format Version 12.00
                     # Visual Studio Version 16
                     VisualStudioVersion = 16.0.29326.124
                     MinimumVisualStudioVersion = 10.0.40219.1
-                    Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Project1", "1\1\1.csproj", "{79B5EBA6-5D27-4976-BC31-14422245A59A}"
+                    Project(""{9A19103F-16F7-4668-BE54-9A1E7A4F7556}"") = ""Project1"", ""1\1\1.csproj"", ""{79B5EBA6-5D27-4976-BC31-14422245A59A}""
                     EndProject
-                    Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "2", "2\2\2.proj", "{8EFCCA22-9D51-4268-90F7-A595E11FCB2D}"
+                    Project(""{9A19103F-16F7-4668-BE54-9A1E7A4F7556}"") = ""2"", ""2\2\2.proj"", ""{8EFCCA22-9D51-4268-90F7-A595E11FCB2D}""
                     EndProject
                     Global
                         GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -434,7 +434,7 @@ namespace Microsoft.Build.Graph.UnitTests
                             SolutionGuid = {DE7234EC-0C4D-4070-B66A-DCF1B4F0CFEF}
                         EndGlobalSection
                     EndGlobal
-                    """);
+                ");
 
                 ProjectCollection projectCollection = testEnvironment.CreateProjectCollection().Collection;
                 MockLogger logger = new();

--- a/src/Build.UnitTests/Graph/GraphLoadedFromSolution_tests.cs
+++ b/src/Build.UnitTests/Graph/GraphLoadedFromSolution_tests.cs
@@ -59,8 +59,7 @@ namespace Microsoft.Build.Graph.UnitTests
                     new ProjectGraph("nonExistent.sln");
                 });
 
-            exception.Message.ShouldContain("The project file could not be loaded.");
-            exception.Message.ShouldContain("Could not find file");
+            exception.Message.ShouldContain("The project file could not be loaded. Could not find file");
         }
 
         [Fact]
@@ -645,6 +644,28 @@ namespace Microsoft.Build.Graph.UnitTests
             {
                 return edgeInfos.Where(e => e.Key.Item2.Equals(node.ToConfigurationMetadata())).Select(e => e.Value);
             }
+        }
+
+        [Fact]
+        public void GraphConstructionShouldThrowOnMissingSolutionDependencies()
+        {
+            var solutionContents = SolutionFileBuilder.FromGraphEdges(
+                _env,
+                new Dictionary<int, int[]> { { 1, null }, { 2, null } },
+                new[] { ("1", new[] { Guid.NewGuid().ToString("B") }) }).BuildSolution();
+
+            var solutionFile = _env.CreateFile(
+                "solution.sln",
+                solutionContents)
+                .Path;
+
+            var exception = Should.Throw<InvalidProjectFileException>(
+                () =>
+                {
+                    new ProjectGraph(solutionFile);
+                });
+
+            exception.Message.ShouldContain("but a project with this GUID was not found in the .SLN file");
         }
 
         private static bool IsSolutionItemReference(ProjectItemInstance edgeItem)

--- a/src/Build/Construction/Solution/SolutionFile.cs
+++ b/src/Build/Construction/Solution/SolutionFile.cs
@@ -193,7 +193,7 @@ namespace Microsoft.Build.Construction
 
         internal bool UseNewParser => ShouldUseNewParser(_solutionFile);
 
-        internal static bool ShouldUseNewParser(string solutionFile) => ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_14) || FileUtilities.IsSolutionXFilename(solutionFile);
+        internal static bool ShouldUseNewParser(string solutionFile) => FileUtilities.IsSolutionXFilename(solutionFile);
 
         /// <summary>
         /// All projects in this solution, in the order they appeared in the solution file
@@ -221,10 +221,6 @@ namespace Microsoft.Build.Construction
 
             set
             {
-                if (ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_14) && string.IsNullOrEmpty(value))
-                {
-                    throw new ArgumentNullException(nameof(FullPath));
-                }
                 // Should already be canonicalized to a full path
                 ErrorUtilities.VerifyThrowInternalRooted(value);
                 // To reduce code duplication, this should be


### PR DESCRIPTION
Don't use the new parser from `Microsoft.VisualStudio.SolutionPersistence` to parse `.sln` files.

Fixes #11463

Work item (Internal use): AB#2397817

### Summary
Revert #10836 to return to the longstanding MSBuild private `.sln` parser (but keep using the SolutionPersistence library for `.slnx`).

### Customer Impact

Three categories of problem:

* Some older `NuGet.exe` restores failed because they couldn't find the library (fixed in newer versions but reported via VS Feedback and https://github.com/microsoft/dotnet-framework-docker/issues/1213.
* Current `NuGet.exe` restores can fail if the path to 64-bit MSBuild is specified explicitly
* Various bugs in the solution parser (e.g. https://github.com/microsoft/vs-solutionpersistence/issues/96) that don't hit in the legacy MSBuild parser.

All manifest as build or NuGet restore breaks with no obvious workaround (but once discovered the changewave opt-out environment variable works).

### Regression?
Yes, in 17.13/9.0.200 due to adopting the common SolutionPersistence library instead of our homegrown sln parser.

### Testing
Unit tests + manual scenario tests.

### Risk
Low, clean revert to earlier behavior for `.sln`.