### PR TITLE
Fix test to take warning MSB5018

### DIFF
--- a/src/Tasks.UnitTests/Exec_Tests.cs
+++ b/src/Tasks.UnitTests/Exec_Tests.cs
@@ -158,7 +158,7 @@ namespace Microsoft.Build.UnitTests
         }
 
         [Fact]
-        public void Timeout1()
+        public void Timeout()
         {
             // On non-Windows the exit code of a killed process is SIGKILL (137)
             int expectedExitCode = NativeMethodsShared.IsWindows ? -1 : 137;

--- a/src/Tasks.UnitTests/Exec_Tests.cs
+++ b/src/Tasks.UnitTests/Exec_Tests.cs
@@ -158,7 +158,7 @@ namespace Microsoft.Build.UnitTests
         }
 
         [Fact]
-        public void Timeout()
+        public void Timeout1()
         {
             // On non-Windows the exit code of a killed process is SIGKILL (137)
             int expectedExitCode = NativeMethodsShared.IsWindows ? -1 : 137;
@@ -171,9 +171,20 @@ namespace Microsoft.Build.UnitTests
             Assert.Equal(expectedExitCode, exec.ExitCode);
             ((MockEngine)exec.BuildEngine).AssertLogContains("MSB5002");
             int warningsCount = ((MockEngine)exec.BuildEngine).Warnings;
-            warningsCount.ShouldBe(1,
+            if (warningsCount == 1)
+            {
+                warningsCount.ShouldBe(1,
                 $"Expected 1 warning, encountered {warningsCount}: " + string.Join(",",
                     ((MockEngine)exec.BuildEngine).WarningEvents.Select(w => w.Message)));
+            }
+            else
+            {
+                // Occasionally temp files fail to delete because of virus checkers, so generate MSB5018 warning
+                ((MockEngine)exec.BuildEngine).AssertLogContains("MSB5018");
+                warningsCount.ShouldBe(2,
+                $"Expected 2 warnings, encountered {warningsCount}: " + string.Join(",",
+                    ((MockEngine)exec.BuildEngine).WarningEvents.Select(w => w.Message)));
+            }
 
             // ToolTask does not log an error on timeout.
             Assert.Equal(0, ((MockEngine)exec.BuildEngine).Errors);


### PR DESCRIPTION
Fixes [#9176](https://github.com/dotnet/msbuild/issues/9176)

### Context
Occasionally temp files fail to delete because of virus checkers, so generate MSB5018 warning.
The commit https://github.com/dotnet/msbuild/commit/d7788d644e1b463b996107e7dcce358b8eaeccaa#diff-3abd8382aac3bdfa59d5c1ca41dd089795d6ca539a00b3c50eab4fd6a0996314 including string lockedFileMessage = LockCheck.GetLockedFileMessage(fileName); doesn't output the related process.

### Changes Made
Add the warning MSB5018
