### PR TITLE
Memory mapped files proof-of-concept

### DIFF
--- a/src/Build/BackEnd/Components/Communications/NodeManager.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeManager.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO.MemoryMappedFiles;
 using System.Threading;
 using Microsoft.Build.Execution;
 using Microsoft.Build.Shared;
@@ -35,6 +36,8 @@ namespace Microsoft.Build.BackEnd
         /// Mapping of manager-produced node IDs to the provider hosting the node.
         /// </summary>
         private readonly Dictionary<int, INodeProvider> _nodeIdToProvider;
+
+        private readonly List<MemoryMappedFile> _memoryMappedFiles = new List<MemoryMappedFile>();
 
         /// <summary>
         /// The packet factory used to translate and route packets

--- a/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProc.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProc.cs
@@ -118,6 +118,7 @@ namespace Microsoft.Build.BackEnd
 
                 // Start the asynchronous read.
                 context.BeginAsyncPacketRead();
+                context.StartDrainingQueue();
 
                 // Configure the node.
                 context.SendData(configurationFactory(nodeInfo));

--- a/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
@@ -4,6 +4,8 @@
 using System;
 using System.Buffers.Binary;
 using System.Collections.Concurrent;
+using System.Threading.Channels;
+
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
@@ -579,16 +581,14 @@ namespace Microsoft.Build.BackEnd
             private MemoryStream _writeBufferMemoryStream;
 
             /// <summary>
-            /// A queue used for enqueuing packets to write to the stream asynchronously.
+            /// A channel used for enqueuing packets to write to the stream asynchronously.
             /// </summary>
-            private ConcurrentQueue<INodePacket> _packetWriteQueue = new ConcurrentQueue<INodePacket>();
-
-            /// <summary>
-            /// A task representing the last packet write, so we can chain packet writes one after another.
-            /// We want to queue up writing packets on a separate thread asynchronously, but serially.
-            /// Each task drains the <see cref="_packetWriteQueue"/>
-            /// </summary>
-            private Task _packetWriteDrainTask = Task.CompletedTask;
+            private Channel<INodePacket> _packetChannel = Channel.CreateUnbounded<INodePacket>(new UnboundedChannelOptions()
+            {
+                SingleWriter = false,
+                SingleReader = true,
+                AllowSynchronousContinuations = false
+            });
 
             /// <summary>
             /// Delegate called when the context terminates.
@@ -628,6 +628,52 @@ namespace Microsoft.Build.BackEnd
             /// Id of node.
             /// </summary>
             public int NodeId => _nodeId;
+
+            public async void StartDrainingQueue()
+            {
+                while (await _packetChannel.Reader.WaitToReadAsync())
+                {
+                    while (_packetChannel.Reader.TryRead(out var packet))
+                    {
+                        // NodeContext context = (NodeContext)this;
+                        MemoryStream writeStream = this._writeBufferMemoryStream;
+                        writeStream.SetLength(0);
+                        ITranslator writeTranslator = BinaryTranslator.GetWriteTranslator(writeStream);
+                        try
+                        {
+                            writeStream.WriteByte((byte)packet.Type);
+                            // Pad for the packet length
+                            WriteInt32(writeStream, 0);
+                            packet.Translate(writeTranslator);
+                            int writeStreamLength = (int)writeStream.Position;
+                            // Now plug in the real packet length
+                            writeStream.Position = 1;
+                            WriteInt32(writeStream, writeStreamLength - 5);
+                            byte[] writeStreamBuffer = writeStream.GetBuffer();
+                            for (int i = 0; i < writeStreamLength; i += MaxPacketWriteSize)
+                            {
+                                int lengthToWrite = Math.Min(writeStreamLength - i, MaxPacketWriteSize);
+#pragma warning disable CA1835 // Prefer the 'Memory'-based overloads for 'ReadAsync' and 'WriteAsync'
+                                await _serverToClientStream.WriteAsync(writeStreamBuffer, i, lengthToWrite, CancellationToken.None);
+#pragma warning restore CA1835 // Prefer the 'Memory'-based overloads for 'ReadAsync' and 'WriteAsync'
+                            }
+                            if (IsExitPacket(packet))
+                            {
+                                _exitPacketState = ExitPacketState.ExitPacketSent;
+                            }
+                        }
+                        catch (IOException e)
+                        {
+                            // Do nothing here because any exception will be caught by the async read handler
+                            CommunicationsUtilities.Trace(_nodeId, "EXCEPTION in SendData: {0}", e);
+                        }
+                        catch (ObjectDisposedException) // This happens if a child dies unexpectedly
+                        {
+                            // Do nothing here because any exception will be caught by the async read handler
+                        }
+                    }
+                }
+            }
 
             /// <summary>
             /// Starts a new asynchronous read operation for this node.
@@ -716,85 +762,7 @@ namespace Microsoft.Build.BackEnd
                 {
                     _exitPacketState = ExitPacketState.ExitPacketQueued;
                 }
-                _packetWriteQueue.Enqueue(packet);
-                DrainPacketQueue();
-            }
-
-            /// <summary>
-            /// Schedule a task to drain the packet write queue. We could have had a
-            /// dedicated thread that would pump the queue constantly, but
-            /// we don't want to allocate a dedicated thread per node (1MB stack)
-            /// </summary>
-            /// <remarks>Usually there'll be a single packet in the queue, but sometimes
-            /// a burst of SendData comes in, with 10-20 packets scheduled. In this case
-            /// the first scheduled task will drain all of them, and subsequent tasks
-            /// will run on an empty queue. I tried to write logic that avoids queueing
-            /// a new task if the queue is already being drained, but it didn't show any
-            /// improvement and made things more complicated.</remarks>
-            private void DrainPacketQueue()
-            {
-                // this lock is only necessary to protect a write to _packetWriteDrainTask field
-                lock (_packetWriteQueue)
-                {
-                    // average latency between the moment this runs and when the delegate starts
-                    // running is about 100-200 microseconds (unless there's thread pool saturation)
-                    _packetWriteDrainTask = _packetWriteDrainTask.ContinueWith(
-                        SendDataCoreAsync,
-                        this,
-                        TaskScheduler.Default).Unwrap();
-
-                    static async Task SendDataCoreAsync(Task _, object state)
-                    {
-                        NodeContext context = (NodeContext)state;
-                        while (context._packetWriteQueue.TryDequeue(out var packet))
-                        {
-                            MemoryStream writeStream = context._writeBufferMemoryStream;
-
-                            // clear the buffer but keep the underlying capacity to avoid reallocations
-                            writeStream.SetLength(0);
-
-                            ITranslator writeTranslator = BinaryTranslator.GetWriteTranslator(writeStream);
-                            try
-                            {
-                                writeStream.WriteByte((byte)packet.Type);
-
-                                // Pad for the packet length
-                                WriteInt32(writeStream, 0);
-                                packet.Translate(writeTranslator);
-
-                                int writeStreamLength = (int)writeStream.Position;
-
-                                // Now plug in the real packet length
-                                writeStream.Position = 1;
-                                WriteInt32(writeStream, writeStreamLength - 5);
-
-                                byte[] writeStreamBuffer = writeStream.GetBuffer();
-
-                                for (int i = 0; i < writeStreamLength; i += MaxPacketWriteSize)
-                                {
-                                    int lengthToWrite = Math.Min(writeStreamLength - i, MaxPacketWriteSize);
-#pragma warning disable CA1835 // Prefer the 'Memory'-based overloads for 'ReadAsync' and 'WriteAsync'
-                                    await context._serverToClientStream.WriteAsync(writeStreamBuffer, i, lengthToWrite, CancellationToken.None);
-#pragma warning restore CA1835 // Prefer the 'Memory'-based overloads for 'ReadAsync' and 'WriteAsync'
-                                }
-
-                                if (IsExitPacket(packet))
-                                {
-                                    context._exitPacketState = ExitPacketState.ExitPacketSent;
-                                }
-                            }
-                            catch (IOException e)
-                            {
-                                // Do nothing here because any exception will be caught by the async read handler
-                                CommunicationsUtilities.Trace(context._nodeId, "EXCEPTION in SendData: {0}", e);
-                            }
-                            catch (ObjectDisposedException) // This happens if a child dies unexpectedly
-                            {
-                                // Do nothing here because any exception will be caught by the async read handler
-                            }
-                        }
-                    }
-                }
+                _packetChannel.Writer.TryWrite(packet);
             }
 
             private static bool IsExitPacket(INodePacket packet)

--- a/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcTaskHost.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcTaskHost.cs
@@ -584,6 +584,7 @@ namespace Microsoft.Build.BackEnd
 
             // Start the asynchronous read.
             context.BeginAsyncPacketRead();
+            context.StartDrainingQueue();
 
             lock (_activeNodes)
             {

--- a/src/Build/BackEnd/Node/NodeConfiguration.cs
+++ b/src/Build/BackEnd/Node/NodeConfiguration.cs
@@ -5,7 +5,7 @@
 using System;
 #endif
 using System.Diagnostics;
-
+using System.IO.MemoryMappedFiles;
 using Microsoft.Build.Execution;
 using Microsoft.Build.Logging;
 #nullable disable
@@ -22,6 +22,7 @@ namespace Microsoft.Build.BackEnd
         /// </summary>
         private int _nodeId;
 
+        public MemoryMappedFile _sideChannel;
         /// <summary>
         /// The system parameters which were defined on the host.
         /// </summary>

--- a/src/Build/BackEnd/Node/OutOfProcNode.cs
+++ b/src/Build/BackEnd/Node/OutOfProcNode.cs
@@ -708,6 +708,7 @@ namespace Microsoft.Build.Execution
 
             _buildParameters.ProjectRootElementCache = s_projectRootElementCacheBase;
 
+
             // Snapshot the current environment
             _savedEnvironment = CommunicationsUtilities.GetEnvironmentVariables();
 
@@ -846,6 +847,10 @@ namespace Microsoft.Build.Execution
             }
 
             _buildRequestEngine.InitializeForBuild(_loggingContext);
+
+#if NET472_OR_GREATER
+            _nodeEndpoint.currentNodeId = configuration.NodeId;
+#endif
 
             // Finally store off this configuration packet.
             _currentConfiguration = configuration;

--- a/src/Framework/BinaryTranslator.cs
+++ b/src/Framework/BinaryTranslator.cs
@@ -50,6 +50,11 @@ namespace Microsoft.Build.BackEnd
             return new BinaryWriteTranslator(stream);
         }
 
+        internal static ITranslator GetWriteTranslator(UnmanagedMemoryStream stream)
+        {
+            return new BinaryWriteTranslator(stream);
+        }
+
         /// <summary>
         /// Implementation of ITranslator for reading from a stream.
         /// </summary>

--- a/src/Shared/AssemblyLoadInfo.cs
+++ b/src/Shared/AssemblyLoadInfo.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Build.Shared
             ErrorUtilities.VerifyThrow((!string.IsNullOrEmpty(assemblyName)) || (!string.IsNullOrEmpty(assemblyFile)),
                 "We must have either the assembly name or the assembly file/path.");
             ErrorUtilities.VerifyThrow((assemblyName == null) || (assemblyFile == null),
-                "We must not have both the assembly name and the assembly file/path.");
+                String.Format("We must not have both the assembly name and the assembly file/path. {0}, {1}", assemblyName, assemblyFile));
 
             if (assemblyName != null)
             {

--- a/src/Shared/INodePacket.cs
+++ b/src/Shared/INodePacket.cs
@@ -201,6 +201,11 @@ namespace Microsoft.Build.BackEnd
         ProcessReport,
 
         /// <summary>
+        /// Message sent via a MMF
+        /// </summary>
+        MemoryMappedFilePacket,
+
+        /// <summary>
         /// Command in form of MSBuild command line for server node - MSBuild Server.
         /// Keep this enum value constant intact as this is part of contract with dotnet CLI
         /// </summary>

--- a/src/Shared/NodeEndpointOutOfProcBase.cs
+++ b/src/Shared/NodeEndpointOutOfProcBase.cs
@@ -8,6 +8,9 @@ using Microsoft.Build.Shared.Concurrent;
 #else
 using System.Collections.Concurrent;
 #endif
+using System.IO;
+using System.IO.Pipes;
+using System.Diagnostics;
 using System.Threading;
 using Microsoft.Build.Internal;
 using Microsoft.Build.Shared;
@@ -16,6 +19,15 @@ using System.IO;
 
 #if FEATURE_SECURITY_PERMISSIONS || FEATURE_PIPE_SECURITY
 using System.Security.AccessControl;
+using System.Diagnostics;
+#if NET472_OR_GREATER
+using System.IO.MemoryMappedFiles;
+using System.Collections.Generic;
+
+#endif
+
+
+
 #endif
 #if FEATURE_PIPE_SECURITY && FEATURE_NAMED_PIPE_SECURITY_CONSTRUCTOR
 using System.Security.Principal;
@@ -511,6 +523,25 @@ namespace Microsoft.Build.BackEnd
                 // We don't really care if Disconnect somehow fails, but it gives us a chance to do the right thing.
             }
         }
+#if NET472_OR_GREATER
+        private Dictionary<int, MemoryMappedFile> _sideChannels = new Dictionary<int, MemoryMappedFile>();
+
+        private MemoryMappedFile getOrOpenFile(int nodeId)
+        {
+            if (_sideChannels.TryGetValue(nodeId, out MemoryMappedFile MMF))
+            {
+                return MMF;
+            }
+            else
+            {
+                MMF = MemoryMappedFile.OpenExisting(String.Format("D:/bld/MSBuild_side_channel{0}", nodeId));
+                _sideChannels[nodeId] = MMF;
+                return MMF;
+            }
+        }
+
+
+#endif
 
         private void RunReadLoop(BufferedReadStream localReadPipe, NamedPipeServerStream localWritePipe,
             ConcurrentQueue<INodePacket> localPacketQueue, AutoResetEvent localPacketAvailable, AutoResetEvent localTerminatePacketPump)
@@ -597,21 +628,65 @@ namespace Microsoft.Build.BackEnd
                                 break;
                             }
 
-                            NodePacketType packetType = (NodePacketType)headerByte[0];
+                            NodePacketType packetType = (NodePacketType)Enum.ToObject(typeof(NodePacketType), headerByte[0]);
+#if NET472_OR_GREATER
+                            if (packetType == NodePacketType.MemoryMappedFilePacket)
+                            {
+                                /*
+                                var readTranslator = BinaryTranslator.GetReadTranslator(localReadPipe, _sharedReadBuffer);
 
-                            try
-                            {
-                                _packetFactory.DeserializeAndRoutePacket(0, packetType, BinaryTranslator.GetReadTranslator(localReadPipe, _sharedReadBuffer));
+                                var realPacketType = (NodePacketType)readTranslator.Reader.ReadByte();
+
+
+                                var nodeId = readTranslator.Reader.ReadInt32();
+                                var offset = readTranslator.Reader.ReadInt32();
+                                var length = readTranslator.Reader.ReadInt32();
+                                */
+                                
+
+                                var nodeId = 0;
+                                nodeId += (int)headerByte[1];
+                                nodeId += ((int)headerByte[2]) << 8;
+                                nodeId += ((int)headerByte[3]) << 16;
+                                nodeId += ((int)headerByte[4]) << 24;
+
+                                var offset = localReadPipe.ReadByte();
+                                offset += localReadPipe.ReadByte() << 8;
+                                offset += localReadPipe.ReadByte() << 16;
+                                offset += localReadPipe.ReadByte() << 24;
+                                // Debugger.Launch();
+
+                                // Debugger.Launch();
+                                var accessor = getOrOpenFile(nodeId).CreateViewStream(offset, 5);
+                                var realPacketType = (NodePacketType)accessor.ReadByte();
+                                var length = accessor.ReadByte();
+                                length += accessor.ReadByte() << 8;
+                                length += accessor.ReadByte() << 16;
+                                length += accessor.ReadByte() << 24;
+                                accessor = getOrOpenFile(nodeId).CreateViewStream(offset + 5, length - 5);
+
+                                _packetFactory.DeserializeAndRoutePacket(0, realPacketType, BinaryTranslator.GetReadTranslator(accessor, _sharedReadBuffer));
+                                accessor.Dispose();
                             }
-                            catch (Exception e)
+                            else
                             {
-                                // Error while deserializing or handling packet.  Abort.
-                                CommunicationsUtilities.Trace("Exception while deserializing packet {0}: {1}", packetType, e);
-                                ExceptionHandling.DumpExceptionToFile(e);
-                                ChangeLinkStatus(LinkStatus.Failed);
-                                exitLoop = true;
-                                break;
+#endif
+                                try
+                                {
+                                    _packetFactory.DeserializeAndRoutePacket(0, packetType, BinaryTranslator.GetReadTranslator(localReadPipe, _sharedReadBuffer));
+                                }
+                                catch (Exception e)
+                                {
+                                    // Error while deserializing or handling packet.  Abort.
+                                    CommunicationsUtilities.Trace("Exception while deserializing packet {0}: {1}", packetType, e);
+                                    ExceptionHandling.DumpExceptionToFile(e);
+                                    ChangeLinkStatus(LinkStatus.Failed);
+                                    exitLoop = true;
+                                    break;
+                                }
+#if NET472_OR_GREATER
                             }
+#endif
 
 #if NET451_OR_GREATER
                             readTask = localReadPipe.ReadAsync(headerByte, 0, headerByte.Length, CancellationToken.None);

--- a/src/Shared/NodeEndpointOutOfProcBase.cs
+++ b/src/Shared/NodeEndpointOutOfProcBase.cs
@@ -523,6 +523,7 @@ namespace Microsoft.Build.BackEnd
                 // We don't really care if Disconnect somehow fails, but it gives us a chance to do the right thing.
             }
         }
+
 #if NET472_OR_GREATER
         private Dictionary<int, MemoryMappedFile> _sideChannels = new Dictionary<int, MemoryMappedFile>();
         private Dictionary<int, MemoryMappedFile> _sideChannelsWrite = new Dictionary<int, MemoryMappedFile>();


### PR DESCRIPTION
Part of  #11160 

### Context
One of our bottlenecks for MSBuild parallelization is IPC, e.g. node-to-node communication.
One of the pain points is serialization/deserialization - which isn't addressed here, but it could be a step in this direction.
The other point is that the IPC workflow is as follows:
 - Node serializes packet into buffer,
 - Then adds five control bytes (node type + packet length) at the beginning of the message
 - Then writes the buffer into a pipe
 - The receiving end reads the data from the pipe into a buffer
 - then handles it as needed.
Even if we look away from the serialization, there are several more data moves then necessary. This is an attempt to eliminate them and potentially lay groundwork for further improvements:
 - I open a sufficiently large memory mapped file for every node in every direction 
   - this has some memory overhead, discussion about size of the file is welcome
   - for now there is no file overflow protection if the produces pushes data too fast, catching up with the not-yet-read part (hence the size of the files), some sort of push-back mechanism might be needed, especially if we decide we need to shrink the MMFs. currently I'm using 10MB file for every direction, e.g. 360MB overhead for 20 node build. Though I'm not sure when exactly is the memory used, it might be less since I'm using smaller view accessors.

The workflow now looks like this:
 - node serializes packet directly into the memory mapped file.
 - it then pushes 9 bytes into the pipe, with a new packet type that signalizes "this one goes through the MMF, special handling needed"
 - the receiving end then deserializes the data directly from the memory mapped file.
This saves two full moves of the data and also lessens the pressure on the IPC since the data is passed directly through the RAM.

Initial performance profiling suggests improvement from average of 39.38 to 38.13 e.g. some ~3% of wallclock time(so I would say 2-4%, since there is large variance)
Note that this could be less due to having to implement some further checking mechanisms or more, since this is just a first crude implementation and some cleanup/optimization could help.

### Changes Made
Introduced memory mapped file for both directions of the node-to-node communication on .net472 framework. (should be reasonably extensible to net9, but there was some issue with importing that I will look at later, if we decide to move forward with this one)

### Testing
Manual testing on OrchardCore. The build succeeds, data flows normally.

### Notes
Caveat:
TaskHost doesn't support Memory mapped files so keeping the old implementation is unfortunately necessary, unless we figure out a better way to split the code. Maybe It's time to force TaskHost into isolation at the cost of some code duplication? (this isn't the first time I've run into an issue with refactoring due to the TaskHost)

Profiling on OrchardCore, with binlogs enabled:
| my change: | main (current one, old profiling was against a different branch but it should be close enough): |
|--------------| -------------|
| 47.6336016 | 53.8131099 |
| 49.8221584 | 54.8453553  |
| 49.9176297 | 53.0443207 |
| 49.3054388 | 55.7054659 |
| 49.5569108 | 52.5317888 |
| 78.3659469 | 51.8770221 |
| 52.6296225 | 53.0219047 |
| 52.2793575 | 54.2732421 |
| 52.5254928 | 52.656414 |
| 51.5814135 | 52.374719 |
| 50.187404 | 55.6009437 |
| 49.388237 | 53.7160303 |
| 51.041493 | 51.4574196 |
| 51.5348809 | |
| 50.2932251 | |
| 49.8235173 | |
| 51.3037764 | |
| Average | |
| 52.1 | 53.6 |  
| Median: | |
| 50.2 |  53.38 |










