### PR TITLE
asking terminal for dimensions during every frame is expensive

### DIFF
--- a/src/Build/Logging/TerminalLogger/TerminalLogger.cs
+++ b/src/Build/Logging/TerminalLogger/TerminalLogger.cs
@@ -1064,6 +1064,7 @@ public sealed partial class TerminalLogger : INodeLogger
             count++;
             lock (_lock)
             {
+                // Querying the terminal for it's dimensions is expensive, so we only do it every 30 frames e.g. once a second.
                 if (count >= 30)
                 {
                     count = 0;

--- a/src/Build/Logging/TerminalLogger/TerminalLogger.cs
+++ b/src/Build/Logging/TerminalLogger/TerminalLogger.cs
@@ -1058,11 +1058,21 @@ public sealed partial class TerminalLogger : INodeLogger
     private void ThreadProc()
     {
         // 1_000 / 30 is a poor approx of 30Hz
+        var count = 0;
         while (!_cts.Token.WaitHandle.WaitOne(1_000 / 30))
         {
+            count++;
             lock (_lock)
             {
-                DisplayNodes();
+                if (count > 30)
+                {
+                    count = 0;
+                    DisplayNodes(true);
+                }
+                else
+                {
+                    DisplayNodes();
+                }
             }
         }
 
@@ -1073,9 +1083,11 @@ public sealed partial class TerminalLogger : INodeLogger
     /// Render Nodes section.
     /// It shows what all build nodes do.
     /// </summary>
-    internal void DisplayNodes()
+    internal void DisplayNodes(bool updateSize = false)
     {
-        TerminalNodesFrame newFrame = new TerminalNodesFrame(_nodes, width: Terminal.Width, height: Terminal.Height);
+        var width = updateSize ? Terminal.Width : _currentFrame.Width;
+        var height = updateSize ? Terminal.Height : _currentFrame.Height;
+        TerminalNodesFrame newFrame = new TerminalNodesFrame(_nodes, width: width, height: height);
 
         // Do not render delta but clear everything if Terminal width or height have changed.
         if (newFrame.Width != _currentFrame.Width || newFrame.Height != _currentFrame.Height)

--- a/src/Build/Logging/TerminalLogger/TerminalLogger.cs
+++ b/src/Build/Logging/TerminalLogger/TerminalLogger.cs
@@ -1064,14 +1064,14 @@ public sealed partial class TerminalLogger : INodeLogger
             count++;
             lock (_lock)
             {
-                if (count > 30)
+                if (count >= 30)
                 {
                     count = 0;
-                    DisplayNodes(true);
+                    DisplayNodes();
                 }
                 else
                 {
-                    DisplayNodes();
+                    DisplayNodes(false);
                 }
             }
         }
@@ -1083,7 +1083,7 @@ public sealed partial class TerminalLogger : INodeLogger
     /// Render Nodes section.
     /// It shows what all build nodes do.
     /// </summary>
-    internal void DisplayNodes(bool updateSize = false)
+    internal void DisplayNodes(bool updateSize = true)
     {
         var width = updateSize ? Terminal.Width : _currentFrame.Width;
         var height = updateSize ? Terminal.Height : _currentFrame.Height;


### PR DESCRIPTION
Part of #11160

### Context
While profiling some of Eric's PRs and one of my experiments, I've noticed following:
<img width="953" alt="terminall_loger_get_width_height_cost" src="https://github.com/user-attachments/assets/bb3478c3-e669-4911-b6b0-0c834e38305e" />
Terminal width/height are behind a lock and repeated access is quite expensive.

### Changes Made
I've set it so that the update is happening only once every ~second or so. This makes the cost negligible.
Note that this appears to be ~1.5% CPU time saved on the main node, which is the one under heaviest load due to IPC with all the other nodes.

### Testing
None, this should be non-disruptive change.

### Notes
Refresh frequency is up to discussion. Making it twice a second should be fine as well.
