### PR TITLE
using virtual fuction instead of reflection

### DIFF
--- a/src/Framework/BuildEventArgs.cs
+++ b/src/Framework/BuildEventArgs.cs
@@ -202,16 +202,6 @@ namespace Microsoft.Build.Framework
 
 
         /// <summary>
-        /// Convenience access point for CreateFromStream method to avoid making everything public.
-        /// </summary>
-        /// <param name="reader"></param>
-        /// <param name="version"></param>
-        public void PublicCreateFromStream(BinaryReader reader, int version)
-        {
-            CreateFromStream(reader, version);
-        }
-
-        /// <summary>
         /// Deserializes from a stream through a binary reader
         /// </summary>
         /// <param name="reader">Binary reader which is attached to the stream the event will be deserialized from</param>

--- a/src/Framework/BuildEventArgs.cs
+++ b/src/Framework/BuildEventArgs.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -199,7 +199,6 @@ namespace Microsoft.Build.Framework
         {
             WriteToStreamWithExplicitMessage(writer, RawMessage);
         }
-
 
         /// <summary>
         /// Deserializes from a stream through a binary reader

--- a/src/Framework/BuildEventArgs.cs
+++ b/src/Framework/BuildEventArgs.cs
@@ -200,6 +200,17 @@ namespace Microsoft.Build.Framework
             WriteToStreamWithExplicitMessage(writer, RawMessage);
         }
 
+
+        /// <summary>
+        /// Convenience access point for CreateFromStream method to avoid making everything public.
+        /// </summary>
+        /// <param name="reader"></param>
+        /// <param name="version"></param>
+        public void PublicCreateFromStream(BinaryReader reader, int version)
+        {
+            CreateFromStream(reader, version);
+        }
+
         /// <summary>
         /// Deserializes from a stream through a binary reader
         /// </summary>

--- a/src/Shared/LogMessagePacketBase.cs
+++ b/src/Shared/LogMessagePacketBase.cs
@@ -500,7 +500,6 @@ namespace Microsoft.Build.Shared
                 _buildEvent.CreateFromStream(translator.Reader, packetVersion);
 #endif
 
-                
                 if (_eventType == LoggingEventType.TargetFinishedEvent && _targetFinishedTranslator != null)
                 {
                     _targetFinishedTranslator(translator, (TargetFinishedEventArgs)_buildEvent);

--- a/src/Shared/LogMessagePacketBase.cs
+++ b/src/Shared/LogMessagePacketBase.cs
@@ -469,7 +469,6 @@ namespace Microsoft.Build.Shared
 
             _buildEvent = GetBuildEventArgFromId();
 
-
             // The other side is telling us whether the event knows how to log itself, or whether we're going to have
             // to do it manually
             int packetVersion = s_defaultPacketVersion;

--- a/src/Shared/LogMessagePacketBase.cs
+++ b/src/Shared/LogMessagePacketBase.cs
@@ -473,6 +473,7 @@ namespace Microsoft.Build.Shared
             // to do it manually
             int packetVersion = s_defaultPacketVersion;
             translator.Translate(ref packetVersion);
+
             bool eventCanSerializeItself = true;
             translator.Translate(ref eventCanSerializeItself);
 
@@ -490,6 +491,7 @@ namespace Microsoft.Build.Shared
                         s_readMethodCache.Add(_eventType, methodInfo);
                     }
                 }
+
                 ArgsReaderDelegate readerMethod = (ArgsReaderDelegate)CreateDelegateRobust(typeof(ArgsReaderDelegate), _buildEvent, methodInfo);
 
                 readerMethod(translator.Reader, packetVersion);

--- a/src/Shared/LogMessagePacketBase.cs
+++ b/src/Shared/LogMessagePacketBase.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -18,8 +18,6 @@ using Microsoft.Build.Collections;
 using Microsoft.Build.Framework.Profiler;
 using System.Collections;
 using System.Linq;
-using System.Diagnostics;
-
 #endif
 
 #if FEATURE_APPDOMAIN

--- a/src/Shared/LogMessagePacketBase.cs
+++ b/src/Shared/LogMessagePacketBase.cs
@@ -496,7 +496,7 @@ namespace Microsoft.Build.Shared
                 readerMethod(translator.Reader, packetVersion);
 
 #else
-                _buildEvent.PublicCreateFromStream(translator.Reader, packetVersion);
+                _buildEvent.CreateFromStream(translator.Reader, packetVersion);
 #endif
 
                 


### PR DESCRIPTION
###Part of #11160
Building on top of Eric's IPC pr - his work allowed for other bottlenecks to reveal themselves.

### Context
![read_from_stream_reflection](https://github.com/user-attachments/assets/aa0bd4b9-cb39-4351-9c51-e4bbbfa01c37)
![read_from_stream_virtual](https://github.com/user-attachments/assets/7fe81c55-1aaf-4e79-97a5-648c6a68cfe5)
Currently, the ReadFromStream function uses 
```
ArgsReaderDelegate readerMethod = (ArgsReaderDelegate)CreateDelegateRobust(typeof(ArgsReaderDelegate), _buildEvent, methodInfo);
```
for a large portion of it's packet deserialization. This is large enough to be seen in the performance profiler as shown above more than 3% of CPU an it's on a critical path.
When I checked, the function was already virtual so the change is minimal. Unfortunately I had to make an allowance to the task host since it wasn't compatible.

### Changes Made
Exposed a convenience public endpoint for the CreateFromStream function, that calls the virtual method Create from stream.
Used this endpoint instead of delegate creation.

### Testing
As long as nothing breaks, I consider that a win.
I did local profiling.


