### PR TITLE
Fix the job "Sync Microsoft.Build version in analyzer template with Version.props"

### DIFF
--- a/.github/workflows/SyncAnalyzerTemplateMSBuildVersion.yml
+++ b/.github/workflows/SyncAnalyzerTemplateMSBuildVersion.yml
@@ -3,8 +3,13 @@ on:
   push:
     branches:
       - main
+      - jennyTest
     paths:
       - 'eng/Versions.props'
+
+permissions:
+  contents: write
+  pull-requests: write
 
 jobs:
   Sync-version:

--- a/.github/workflows/SyncAnalyzerTemplateMSBuildVersion.yml
+++ b/.github/workflows/SyncAnalyzerTemplateMSBuildVersion.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - vs1**
     paths:
       - 'eng/Versions.props'
 

--- a/.github/workflows/SyncAnalyzerTemplateMSBuildVersion.yml
+++ b/.github/workflows/SyncAnalyzerTemplateMSBuildVersion.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - main
-      - jennyTest
+      - vs1**
     paths:
       - 'eng/Versions.props'
 


### PR DESCRIPTION
The job "Sync Microsoft.Build version in analyzer template with Version.props" https://github.com/dotnet/msbuild/actions/runs/13499671367/job/37714757956 failed to push commit since the permissions. Add permissions settings