### PR TITLE
Update xcopy-msbuild to latest available version

### DIFF
--- a/global.json
+++ b/global.json
@@ -7,7 +7,7 @@
     "vs": {
       "version": "17.12.0"
     },
-    "xcopy-msbuild": "17.12.0"
+    "xcopy-msbuild": "17.13.0"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "9.0.0-beta.25111.5"


### PR DESCRIPTION
Updated `xcopy-msbuild` in `global.json` to the latest available version on dotnet-eng

I am raising this as I made the change in [aspnetcore](https://github.com/dotnet/aspnetcore) via https://github.com/dotnet/aspnetcore/pull/60666 and spotted this repository was using the previous version also
