### PR TITLE
Load `before/after.{solutionName}.sln.targets` for .`slnx`

### DIFF
--- a/src/Build.UnitTests/Construction/SolutionFile_NewParser_Tests.cs
+++ b/src/Build.UnitTests/Construction/SolutionFile_NewParser_Tests.cs
@@ -145,7 +145,7 @@ namespace Microsoft.Build.UnitTests.Construction
             }
         }
 
-        private static string ConvertToSlnx(string slnPath)
+        internal static string ConvertToSlnx(string slnPath)
         {
             string slnxPath = slnPath + "x";
             ISolutionSerializer serializer = SolutionSerializers.GetSerializerByMoniker(slnPath).ShouldNotBeNull();

--- a/src/Build.UnitTests/Construction/SolutionProjectGenerator_Tests.cs
+++ b/src/Build.UnitTests/Construction/SolutionProjectGenerator_Tests.cs
@@ -57,23 +57,59 @@ namespace Microsoft.Build.UnitTests.Construction
         /// Test that if a before.{sln}>.targets or after.{sln}.targets file has one of the default targets (Build, Clean, etc.) that it includes only the user-defined target.
         /// </summary>
         [Theory]
-        [InlineData("before.MySln.sln.targets")]
-        [InlineData("after.MySln.sln.targets")]
-        [InlineData("name.that.does.Not.Affect.The.Build.targets")]
-        public void SolutionProjectIgnoresDuplicateDefaultTargets(string name)
+        [InlineData("before.MySln.sln.targets", false)]
+        [InlineData("before.MySln.sln.targets", true)]
+        [InlineData("after.MySln.sln.targets", false)]
+        [InlineData("after.MySln.sln.targets", true)]
+        [InlineData("name.that.does.Not.Affect.The.Build.targets", false)]
+        [InlineData("name.that.does.Not.Affect.The.Build.targets", true)]
+        public void SolutionProjectIgnoresDuplicateDefaultTargets(string name, bool convertToSlnx)
         {
             using (TestEnvironment testEnvironment = TestEnvironment.Create())
             {
                 TransientTestFolder folder = testEnvironment.CreateFolder(createFolder: true);
-                TransientTestFile sln = testEnvironment.CreateFile(folder, "MySln.sln", @"Microsoft Visual Studio Solution File, Format Version 16.00");
-                TransientTestFile targetsFile = testEnvironment.CreateFile(folder, name,
-                    @"<Project>
-                        <Target Name=""Build"" AfterTargets=""NonsenseTarget"">
-                        </Target>
-                      </Project>");
-                ProjectInstance[] instances = SolutionProjectGenerator.Generate(SolutionFile.Parse(sln.Path), null, null, _buildEventContext, CreateMockLoggingService());
+                string solutionFileContents = "Microsoft Visual Studio Solution File, Format Version 12.00";
+                TransientTestFile sln = testEnvironment.CreateFile(folder, "MySln.sln", solutionFileContents);
+                string solutionPath = convertToSlnx ? SolutionFile_NewParser_Tests.ConvertToSlnx(sln.Path) : sln.Path;
+                testEnvironment.CreateFile(folder, name,
+                      """
+                      <Project>
+                          <Target Name="TestTarget" />
+                      </Project>
+                      """);
+                ProjectInstance[] instances = SolutionProjectGenerator.Generate(SolutionFile.Parse(solutionPath), null, null, _buildEventContext, CreateMockLoggingService());
                 instances.ShouldHaveSingleItem();
                 instances[0].Targets["Build"].AfterTargets.ShouldBe(string.Empty);
+                MockLogger logger = new MockLogger(output);
+                instances[0].Build(targets: null, new List<ILogger> { logger }).ShouldBeTrue();
+            }
+        }
+
+        /// <summary>
+        /// Test that targets in before.{sln}.targets and after.{sln}.targets files are included in the project.
+        /// </summary>
+        [Theory]
+        [InlineData("before.MySln.sln.targets", false)]
+        [InlineData("before.MySln.sln.targets", true)]
+        [InlineData("after.MySln.sln.targets", false)]
+        [InlineData("after.MySln.sln.targets", true)]
+        public void SolutionProjectIncludesBeforeAndAfterTargets(string name, bool convertToSlnx)
+        {
+            using (TestEnvironment testEnvironment = TestEnvironment.Create())
+            {
+                TransientTestFolder folder = testEnvironment.CreateFolder(createFolder: true);
+                string solutionFileContents = "Microsoft Visual Studio Solution File, Format Version 12.00";
+                TransientTestFile sln = testEnvironment.CreateFile(folder, "MySln.sln", solutionFileContents);
+                string solutionPath = convertToSlnx ? SolutionFile_NewParser_Tests.ConvertToSlnx(sln.Path) : sln.Path;
+                testEnvironment.CreateFile(folder, name,
+                      """
+                      <Project>
+                          <Target Name="TestTarget" />
+                      </Project>
+                      """);
+                ProjectInstance[] instances = SolutionProjectGenerator.Generate(SolutionFile.Parse(solutionPath), null, null, _buildEventContext, CreateMockLoggingService());
+                instances.ShouldHaveSingleItem();
+                instances[0].Targets.ShouldContainKey("TestTarget");
                 MockLogger logger = new MockLogger(output);
                 instances[0].Build(targets: null, new List<ILogger> { logger }).ShouldBeTrue();
             }


### PR DESCRIPTION
Fixes #11288

### Context
see the issue description #11288

### Changes Made
1. Load `before/after.{solutionName}.sln.targets` for .`slnx`
2. Added test checking that targets from these files are included in the project for `.sln` and `.slnx`

### Testing
Added tests, tested manually

### Notes
