### PR TITLE
[CodeQL][SM03800] Remove unapproved usage of DSACryptoServiceProvider

### DIFF
--- a/src/Tasks/ManifestUtil/CngLightup.cs
+++ b/src/Tasks/ManifestUtil/CngLightup.cs
@@ -26,7 +26,6 @@ namespace System.Security.Cryptography
 {
     internal static partial class CngLightup
     {
-        private const string DsaOid = "1.2.840.10040.4.1";
         private const string RsaOid = "1.2.840.113549.1.1.1";
 
         private const string HashAlgorithmNameTypeName = "System.Security.Cryptography.HashAlgorithmName";
@@ -56,9 +55,6 @@ namespace System.Security.Cryptography
             s_rsaEncryptionPaddingType?.GetProperty("OaepSHA1", BindingFlags.Static | BindingFlags.Public).GetValue(null);
 
         private static readonly Lazy<bool> s_preferRsaCng = new Lazy<bool>(DetectRsaCngSupport);
-
-        private static volatile Func<X509Certificate2, DSA> s_getDsaPublicKey;
-        private static volatile Func<X509Certificate2, DSA> s_getDsaPrivateKey;
 
         private static volatile Func<X509Certificate2, RSA> s_getRsaPublicKey;
         private static volatile Func<X509Certificate2, RSA> s_getRsaPrivateKey;
@@ -110,30 +106,6 @@ namespace System.Security.Cryptography
             }
 
             return s_getRsaPrivateKey(cert);
-        }
-
-        internal static DSA GetDSAPublicKey(X509Certificate2 cert)
-        {
-            if (s_getDsaPublicKey == null)
-            {
-                s_getDsaPublicKey =
-                    BindCoreDelegate<DSA>("DSA", isPublic: true) ??
-                    BindGetCapiPublicKey<DSA, DSACryptoServiceProvider>(DsaOid);
-            }
-
-            return s_getDsaPublicKey(cert);
-        }
-
-        internal static DSA GetDSAPrivateKey(X509Certificate2 cert)
-        {
-            if (s_getDsaPrivateKey == null)
-            {
-                s_getDsaPrivateKey =
-                    BindCoreDelegate<DSA>("DSA", isPublic: false) ??
-                    BindGetCapiPrivateKey<DSA>(DsaOid, csp => new DSACryptoServiceProvider(csp));
-            }
-
-            return s_getDsaPrivateKey(cert);
         }
 
 #if !CNG_LIGHTUP_NO_SYSTEM_CORE
@@ -526,7 +498,6 @@ namespace System.Security.Cryptography
             // Load System.Core.dll and load the appropriate extension class
             // (one of
             //    System.Security.Cryptography.X509Certificates.RSACertificateExtensions
-            //    System.Security.Cryptography.X509Certificates.DSACertificateExtensions
             //    System.Security.Cryptography.X509Certificates.ECDsaCertificateExtensions
             // )
             string typeName = "System.Security.Cryptography.X509Certificates." + algorithmName + "CertificateExtensions";
@@ -547,8 +518,6 @@ namespace System.Security.Cryptography
             // (one of
             //     GetRSAPublicKey(this X509Certificate2 c)
             //     GetRSAPrivateKey(this X509Certificate2 c)
-            //     GetDSAPublicKey(this X509Certificate2 c)
-            //     GetDSAPrivateKey(this X509Certificate2 c)
             //     GetECDsaPublicKey(this X509Certificate2 c)
             //     GetECDsaPrivateKey(this X509Certificate2 c)
             // )


### PR DESCRIPTION
Fixes #
CodeQL SM03800 issue

### Context
CodeQL is flagging unapproved usage of DSACryptoServiceProvider

### Changes Made
The flagged code is not required in ClickOnce so deleting it.

### Testing
ClickOnce signing scenarios validated from .NET Fx 3.5 through .NET 9.

### Notes
