### PR TITLE
Update pipelines for VS insertions

### DIFF
--- a/.config/git-merge-flow-config.jsonc
+++ b/.config/git-merge-flow-config.jsonc
@@ -30,8 +30,12 @@
         "vs17.12": {
             "MergeToBranch": "vs17.13"
         },
-        // MSBuild latest release to main
+        // Automate opening PRs to merge msbuild's vs17.13 (SDK 9.0.2xx) into vs17.14 (SDK 9.0.3xx)
         "vs17.13": {
+            "MergeToBranch": "vs17.14"
+        },
+        // MSBuild latest release to main
+        "vs17.14": {
             "MergeToBranch": "main"
         }
     }

--- a/azure-pipelines/vs-insertion-experimental.yml
+++ b/azure-pipelines/vs-insertion-experimental.yml
@@ -2,6 +2,16 @@
 trigger: none
 name: $(Date:yyyyMMdd).$(Rev:r)
 
+# Since our release branch is the one flowing into main
+# we will keep our main experimental insertions to make sure everything is alright
+schedules:
+  - cron: '0 3 * * 1,3,5' # Runs every Monday, Wednesday and Friday at 3AM UTC
+    displayName: Experimental VS insertion main
+    branches:
+      include:
+        - main
+    always: false # Don't run if there are no code changes
+
 resources:
   pipelines:
   - pipeline: 'MSBuild'

--- a/azure-pipelines/vs-insertion.yml
+++ b/azure-pipelines/vs-insertion.yml
@@ -17,7 +17,7 @@ schedules:
     displayName: Daily VS insertion main
     branches:
       include:
-        - main
+        - vs17.14
     always: false # Don't run if there are no code changes
 
 resources:


### PR DESCRIPTION
Our branch versioning currently differs from VS's. This will adjust so our 17.14 insertions go to main, but keeping main branch with experimental insertions scheduled so we do not have one big PR when versions align again.

It also updates merge flows between repo branches.

