### PR TITLE
Update VS insertions for 17.14

### DIFF
--- a/.vsts-dotnet-ci.yml
+++ b/.vsts-dotnet-ci.yml
@@ -14,40 +14,40 @@ variables:
   value: none
 
 jobs:
-- job: CheckVersionBumpOnReleaseBranches
-  displayName: "Check Version Bump On Release Branches"
-  steps:
-  - powershell: |
-      $versionsFile = "eng/Versions.props"
-      $changedFiles = git diff --name-only HEAD HEAD~1
-      $changedVersionsFile = $changedFiles | Where-Object { $_ -eq $versionsFile }
-      $isInitialCommit = $false
-      $isVersionBumped = $false
-      if ($changedVersionsFile -ne $null) {
-        $difference = git diff HEAD~1 $versionsFile
-        $changedContent = $difference -join "%"
-        # 'DotNetFinalVersionKind' is expected to be added only during the initial setup of the release branch
-        $initialCommitPattern = '-\s*<VersionPrefix>\d+\.\d+\.\d+<\/VersionPrefix>%.*\+\s*<VersionPrefix>\d+\.\d+\.\d+<\/VersionPrefix><DotNetFinalVersionKind>release<\/DotNetFinalVersionKind>'
-        $isInitialCommit = $changedContent -match $initialCommitPattern
-        $pattern = '-\s*<VersionPrefix>\d+\.\d+\.(?<previous>\d+)<\/VersionPrefix>.*%\+\s*<VersionPrefix>\d+\.\d+\.(?<current>\d+)<\/VersionPrefix>'
-        if (!($isInitialCommit) -and ($changedContent -match $pattern)) {
-          try {
-            $previousPatch = [Convert]::ToInt32($Matches.previous)
-            $currentPatch = [Convert]::ToInt32($Matches.current)
-            if ($currentPatch -gt $previousPatch) {
-              $isVersionBumped = $true
-            }
-          } catch {
-            Write-Host "An error occurred during conversion: $_"
-          }
-        }
-      }
+# - job: CheckVersionBumpOnReleaseBranches
+#   displayName: "Check Version Bump On Release Branches"
+#   steps:
+#   - powershell: |
+#       $versionsFile = "eng/Versions.props"
+#       $changedFiles = git diff --name-only HEAD HEAD~1
+#       $changedVersionsFile = $changedFiles | Where-Object { $_ -eq $versionsFile }
+#       $isInitialCommit = $false
+#       $isVersionBumped = $false
+#       if ($changedVersionsFile -ne $null) {
+#         $difference = git diff HEAD~1 $versionsFile
+#         $changedContent = $difference -join "%"
+#         # 'DotNetFinalVersionKind' is expected to be added only during the initial setup of the release branch
+#         $initialCommitPattern = '-\s*<VersionPrefix>\d+\.\d+\.\d+<\/VersionPrefix>%.*\+\s*<VersionPrefix>\d+\.\d+\.\d+<\/VersionPrefix><DotNetFinalVersionKind>release<\/DotNetFinalVersionKind>'
+#         $isInitialCommit = $changedContent -match $initialCommitPattern
+#         $pattern = '-\s*<VersionPrefix>\d+\.\d+\.(?<previous>\d+)<\/VersionPrefix>.*%\+\s*<VersionPrefix>\d+\.\d+\.(?<current>\d+)<\/VersionPrefix>'
+#         if (!($isInitialCommit) -and ($changedContent -match $pattern)) {
+#           try {
+#             $previousPatch = [Convert]::ToInt32($Matches.previous)
+#             $currentPatch = [Convert]::ToInt32($Matches.current)
+#             if ($currentPatch -gt $previousPatch) {
+#               $isVersionBumped = $true
+#             }
+#           } catch {
+#             Write-Host "An error occurred during conversion: $_"
+#           }
+#         }
+#       }
 
-      if (!($isInitialCommit -or $isVersionBumped)) {
-        throw "Hello! I noticed that you're targeting one of our servicing branches. You need to increase the revision version number (the last part) of 'VersionPrefix' in eng/Versions.props."
-      }
-    condition: startsWith(variables['System.PullRequest.TargetBranch'], 'vs')
-    displayName: "Check if patch version is bumped up"
+#       if (!($isInitialCommit -or $isVersionBumped)) {
+#         throw "Hello! I noticed that you're targeting one of our servicing branches. You need to increase the revision version number (the last part) of 'VersionPrefix' in eng/Versions.props."
+#       }
+#     condition: startsWith(variables['System.PullRequest.TargetBranch'], 'vs')
+#     displayName: "Check if patch version is bumped up"
 
 - job: IfOnlyDocumentionChanged
   displayName: "Check whether Test Results need to be executed"

--- a/azure-pipelines/vs-insertion-experimental.yml
+++ b/azure-pipelines/vs-insertion-experimental.yml
@@ -2,6 +2,16 @@
 trigger: none
 name: $(Date:yyyyMMdd).$(Rev:r)
 
+# Since our release branch is the one flowing into main
+# we will keep our main experimental insertions to make sure everything is alright
+schedules:
+  - cron: '0 3 * * 1,3,5' # Runs every Monday, Wednesday and Friday at 3AM UTC
+    displayName: Experimental VS insertion main
+    branches:
+      include:
+        - main
+    always: false # Don't run if there are no code changes
+    
 resources:
   pipelines:
   - pipeline: 'MSBuild'

--- a/azure-pipelines/vs-insertion.yml
+++ b/azure-pipelines/vs-insertion.yml
@@ -12,13 +12,13 @@ trigger: none
 pr: none
 name: $(Date:yyyyMMdd).$(Rev:r)
 
-schedules:
-  - cron: '0 3 * * 1-5' # Runs every weekday at 3AM UTC
-    displayName: Daily VS insertion main
-    branches:
-      include:
-        - main
-    always: false # Don't run if there are no code changes
+# schedules:
+#   - cron: '0 3 * * 1-5' # Runs every weekday at 3AM UTC
+#     displayName: Daily VS insertion main
+#     branches:
+#       include:
+#         - main
+#     always: false # Don't run if there are no code changes
 
 resources:
   pipelines:
@@ -66,7 +66,7 @@ variables:
   # `auto` should work every time and selecting a branch in parameters is likely to fail due to incompatible versions in MSBuild and VS
   - name: AutoInsertTargetBranch
     ${{ if eq(variables['Build.SourceBranchName'], 'vs17.14') }}:
-      value: 'rel/d17.14'
+      value: 'main'
     ${{ elseif eq(variables['Build.SourceBranchName'], 'vs17.13') }}:
       value: 'rel/d17.13'
     ${{ elseif eq(variables['Build.SourceBranchName'], 'vs17.12') }}:


### PR DESCRIPTION
Our branch versioning currently differs from VS's. This will adjust so our 17.14 insertions go to main, but keeping main branch with experimental insertions scheduled so we do not have one big PR when versions align again.