### PR TITLE
Pin samples/ProjectCachePlugin to released MSBuild

### DIFF
--- a/src/Samples/ProjectCachePlugin/ProjectCachePlugin.csproj
+++ b/src/Samples/ProjectCachePlugin/ProjectCachePlugin.csproj
@@ -8,8 +8,7 @@
     <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(FullFrameworkTFM);$(LatestDotNetCoreForMSBuild)</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\Build\Microsoft.Build.csproj" />
-    <ProjectReference Include="..\..\Framework\Microsoft.Build.Framework.csproj" />
+    <PackageReference Include="Microsoft.Build" Version="16.11.0" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Shouldly" Version="4.2.1" />

--- a/src/Samples/ProjectCachePlugin/ProjectCachePlugin.csproj
+++ b/src/Samples/ProjectCachePlugin/ProjectCachePlugin.csproj
@@ -8,7 +8,13 @@
     <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(FullFrameworkTFM);$(LatestDotNetCoreForMSBuild)</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build" Version="16.11.0" />
+    <PackageReference Include="Microsoft.Build" Version="16.11.0" PrivateAssets="all" />
+
+    <!-- Bump versions of transitive dependencies to vulnerable packages,
+         but don't reference them so the plugin doesn't carry higher references
+         than its targeted MSBuild. NOT NECESSARY for public plugins; use higher MSBuild. -->
+    <PackageReference Include="System.Drawing.Common" Version="4.7.2" ExcludeAssets="all" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="4.7.2" ExcludeAssets="all" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Shouldly" Version="4.2.1" />


### PR DESCRIPTION
This will ensure that we're testing compatibility, and avoid requiring updating the dependencies of the ProjectCachePlugin.

It's needed for #11038.