### PR TITLE
Fix the head parameter when search the created PRs

### DIFF
--- a/.github/workflows/SyncAnalyzerTemplateMSBuildVersion.yml
+++ b/.github/workflows/SyncAnalyzerTemplateMSBuildVersion.yml
@@ -142,14 +142,19 @@ jobs:
             const { data: pullRequests } = await github.rest.pulls.list({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              head: newBranch,
+              head: `${context.repo.owner}:${newBranch}`,
               base: baseBranch,
               state: 'open',
             });
 
             if (pullRequests.length === 0) {
+               console.log(`No open pull requests found for branch ${newBranch} against ${baseBranch}.`);
               return true;
             } else {
+              // Log pull request details
+              pullRequests.forEach(pr => {
+                console.log(`Pull request #${pr.number}: ${pr.title} (created by ${pr.user.login})`);
+              });
               return false;
             }
           }


### PR DESCRIPTION
Fix the issue https://github.com/dotnet/msbuild/actions/runs/13778304840/job/38531781822 that failed to create the PR since the head parameter doesn't include the owner


