### PR TITLE
Add null check when iterating through TargetOutputs in terminal logger

### DIFF
--- a/src/Build/Logging/TerminalLogger/TerminalLogger.cs
+++ b/src/Build/Logging/TerminalLogger/TerminalLogger.cs
@@ -808,15 +808,17 @@ public sealed partial class TerminalLogger : INodeLogger
         // For cache plugin projects which result in a cache hit, ensure the output path is set
         // to the item spec corresponding to the GetTargetPath target upon completion.
         var buildEventContext = e.BuildEventContext;
+        var targetOutputs = e.TargetOutputs;
         if (_restoreContext is null
             && buildEventContext is not null
+            && targetOutputs is not null
             && _hasUsedCache
             && e.TargetName == "GetTargetPath"
             && _projects.TryGetValue(new ProjectContext(buildEventContext), out TerminalProjectInfo? project))
         {
-            if (project.IsCachePluginProject)
+            if (project is not null && project.IsCachePluginProject)
             {
-                foreach (ITaskItem output in e.TargetOutputs)
+                foreach (ITaskItem output in targetOutputs)
                 {
                     project.OutputPath = output.ItemSpec.AsMemory();
                     break;


### PR DESCRIPTION
Fixes #11605

### Context
Internal logger exception is thrown when executing `msbuild /tl` or `dotnet build` with the cache plugin enabled. This is because the `TargetOutputs` is null for cache plugin projects which result in a cache hit. 

### Changes Made
It is unclear why `TargetOutputs` is null for cache plugin projects and whether a change from #11318 introduced this issue, but this change simply performs a null check to ensure the build can continue with the cache plugin and terminal logger enabled.

### Testing
Sample output from local test with cache plugin enabled:
```
Restore complete (1.3s)
MSBUILD : warning : Project cache plugin initialization failed. There will be no cache hits. See QuickBuild.log for more details.
X succeeded (15.3s) → c:\src\<path>\X.exe

Build succeeded with 1 warning(s) in 26.2s
```
