### PR TITLE
[vs17.14] Fix SdkResult Evalution when ProjectRootElement is null

### DIFF
--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -1928,7 +1928,7 @@ namespace Microsoft.Build.Evaluation
 
             // Generate a unique filename for the generated project for each unique set of properties and items that ends like ".SdkResolver.{propertiesAndItemsHash}.proj".
             // _projectRootElement.FullPath can be null. This can be in the case when Project is created from XmlReader. For that case we generate filename like "{Guid}.SdkResolver.{propertiesAndItemsHash}.proj in the current directory.
-            // Oterwise the project is in the same directory as _projectRootElement and has a name of the saem project and ends like ".SdkResolver.{propertiesAndItemsHash}.proj".
+            // Otherwise the project is in the same directory as _projectRootElement and has a name of the saem project and ends like ".SdkResolver.{propertiesAndItemsHash}.proj".
             string projectNameEnding = $".SdkResolver.{propertiesAndItemsHash}.proj";
             string projectPath = _projectRootElement.FullPath != null ?
              _projectRootElement.FullPath + projectNameEnding :

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -1928,7 +1928,7 @@ namespace Microsoft.Build.Evaluation
 
             // Generate a unique filename for the generated project for each unique set of properties and items that ends like ".SdkResolver.{propertiesAndItemsHash}.proj".
             // _projectRootElement.FullPath can be null. This can be in the case when Project is created from XmlReader. For that case we generate filename like "{Guid}.SdkResolver.{propertiesAndItemsHash}.proj in the current directory.
-            // Otherwise the project is in the same directory as _projectRootElement and has a name of the saem project and ends like ".SdkResolver.{propertiesAndItemsHash}.proj".
+            // Otherwise the project is in the same directory as _projectRootElement and has a name of the same project and ends like ".SdkResolver.{propertiesAndItemsHash}.proj".
             string projectNameEnding = $".SdkResolver.{propertiesAndItemsHash}.proj";
             string projectPath = _projectRootElement.FullPath != null ?
              _projectRootElement.FullPath + projectNameEnding :

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -1926,8 +1926,13 @@ namespace Microsoft.Build.Evaluation
             propertiesAndItemsHash = hash.ToHashCode();
 #endif
 
-            // Generate a unique filename for the generated project for each unique set of properties and items.
-            string projectPath = _projectRootElement.FullPath + ".SdkResolver." + propertiesAndItemsHash + ".proj";
+            // Generate a unique filename for the generated project for each unique set of properties and items that ends like ".SdkResolver.{propertiesAndItemsHash}.proj".
+            // _projectRootElement.FullPath can be null. This can be in the case when Project is created from XmlReader. For that case we generate filename like "{Guid}.SdkResolver.{propertiesAndItemsHash}.proj in the current directory.
+            // Oterwise the project is in the same directory as _projectRootElement and has a name of the saem project and ends like ".SdkResolver.{propertiesAndItemsHash}.proj".
+            string projectNameEnding = $".SdkResolver.{propertiesAndItemsHash}.proj";
+            string projectPath = _projectRootElement.FullPath != null ?
+             _projectRootElement.FullPath + projectNameEnding :
+             FileUtilities.NormalizePath(Guid.NewGuid() + projectNameEnding);
 
             ProjectRootElement InnerCreate(string _, ProjectRootElementCacheBase __)
             {


### PR DESCRIPTION
Fixes #11550

### Context
This is a regression caused by changes in `MSBuildSdkResolver` that were introduced in https://github.com/dotnet/sdk/pull/45364. Specifically by adding 2 new properties. 
This results in hitting the path that was not hit before - handling properties and items of `SdkResult`:
https://github.com/dotnet/msbuild/blob/6aeb262fe5570316ede42dc69788908b548972c5/src/Build/Evaluation/Evaluator.cs#L1867-L1875

When `Project` is created from `XmlReader` and not from `ProjectRootElement`, it results in null `ProjectRootElement` during Evaluation. Which results in internal exception like ` InternalErrorException: MSB0001: Internal MSBuild Error: .SdkResolver.1981936763.proj unexpectedly not a rooted path` here:
https://github.com/dotnet/msbuild/blob/6aeb262fe5570316ede42dc69788908b548972c5/src/Build/Evaluation/Evaluator.cs#L1928
Above created project path is just `.SdkResolver.1981936763.proj` with no directory. Later exception is thrown here because of it:
https://github.com/dotnet/msbuild/blob/9e51a07c6f1b23cb28b958d63c1dff1de704108d/src/Build/Evaluation/ProjectRootElementCache.cs#L262
or here if you use `SimpleProjectRootElementCache`:
https://github.com/dotnet/msbuild/blob/9e51a07c6f1b23cb28b958d63c1dff1de704108d/src/Build/Evaluation/SimpleProjectRootElementCache.cs#L43


### Changes Made
Changed the projet path that is created for `SdkResult` properties and items - if there is no `ProjectRootElement` then generate name like `{Guid}.SdkResolver.{propertiesAndItemsHash}.proj` in the current directory.

### Testing
Added test. Tested manually as well

### Notes
