### PR TITLE
Support string interning / deduplication within packets

### DIFF
--- a/src/Build.UnitTests/BackEnd/BinaryTranslator_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/BinaryTranslator_Tests.cs
@@ -581,7 +581,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
 
             // The path components should be reconstructed using the first encountered value.
             Assert.Equal(fullPath, deserializedFullPath);
-            Assert.Equal(fullPath, Path.Combine(deserializedDirectory, deserializedFullPath));
+            Assert.Equal(fullPath, Path.Combine(deserializedDirectory, deserializedFileName));
         }
 
         /// <summary>

--- a/src/Build.UnitTests/BackEnd/BinaryTranslator_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/BinaryTranslator_Tests.cs
@@ -425,6 +425,417 @@ namespace Microsoft.Build.UnitTests.BackEnd
         }
 
         /// <summary>
+        /// Tests interning strings within an intern scope.
+        /// </summary>
+        /// <remarks>
+        /// Most of the string intern tests use casing differences to assert whether interning was successful, rather
+        /// than asserting the underlying buffer contents. Although the intended use is to deduplicate many strings of the
+        /// same casing, this is harder to validate this high level, so we focus on testing behavior here.
+        /// </remarks>
+        [Theory]
+        [InlineData("foo", true)]
+        [InlineData("", true)]
+        [InlineData(null, true)]
+        [InlineData("foo", false)]
+        [InlineData("", false)]
+        public void TestInternWithInterning(string value, bool nullable)
+        {
+            // Create a case mismatch to test if the string is deduplicated.
+            string valueUpperCase = value?.ToUpperInvariant();
+            TranslationHelpers.GetWriteTranslator().WithInterning(StringComparer.OrdinalIgnoreCase, initialCapacity: 1, translator =>
+            {
+                translator.Intern(ref value, nullable);
+                translator.Intern(ref valueUpperCase, nullable);
+            });
+
+            string deserializedValue = null;
+            string deserializedValueUpperCase = null;
+            TranslationHelpers.GetReadTranslator().WithInterning(StringComparer.OrdinalIgnoreCase, initialCapacity: 1, translator =>
+            {
+                translator.Intern(ref deserializedValue, nullable);
+                translator.Intern(ref deserializedValueUpperCase, nullable);
+            });
+
+            // All occurrences should deserialize to the first encountered value.
+            Assert.Equal(value, deserializedValue);
+            Assert.Equal(value, deserializedValueUpperCase);
+        }
+
+        /// <summary>
+        /// Tests interning strings outside of an intern scope.
+        /// All calls should be forwarded to the regular translate method.
+        /// </summary>
+        [Theory]
+        [InlineData("foo", true)]
+        [InlineData("", true)]
+        [InlineData(null, true)]
+        [InlineData("foo", false)]
+        [InlineData("", false)]
+        [InlineData(null, false)]
+        public void TestInternNoInterning(string value, bool nullable)
+        {
+            TranslationHelpers.GetWriteTranslator().Intern(ref value, nullable);
+
+            string deserializedValue = null;
+            TranslationHelpers.GetReadTranslator().Intern(ref deserializedValue, nullable);
+
+            // If we haven't blown up so far, assume we've skipped interning.
+            Assert.Equal(value, deserializedValue);
+        }
+
+        /// <summary>
+        /// Tests interning path-like strings within an intern scope.
+        /// </summary>
+        [Theory]
+        [InlineData(@"C:\src\msbuild\artifacts\bin\SomeProject.Namespace\Debug\net472\SomeProject.NameSpace.dll", true)]
+        [InlineData("foo", true)]
+        [InlineData("", true)]
+        [InlineData(null, true)]
+        [InlineData(@"C:\src\msbuild\artifacts\bin\SomeProject.Namespace\Debug\net472\SomeProject.NameSpace.dll", false)]
+        [InlineData("foo", false)]
+        [InlineData("", false)]
+        public void TestInternPathWithInterning(string value, bool nullable)
+        {
+            // Create a case mismatch to test if the path parts are deduplicated.
+            string valueUpperCase = value?.ToUpperInvariant();
+            TranslationHelpers.GetWriteTranslator().WithInterning(StringComparer.OrdinalIgnoreCase, initialCapacity: 1, translator =>
+            {
+                translator.InternPath(ref value, nullable);
+                translator.InternPath(ref valueUpperCase, nullable);
+            });
+
+            string deserializedValue = null;
+            string deserializedValueUpperCase = null;
+            TranslationHelpers.GetReadTranslator().WithInterning(StringComparer.OrdinalIgnoreCase, initialCapacity: 1, translator =>
+            {
+                translator.InternPath(ref deserializedValue, nullable);
+                translator.InternPath(ref deserializedValueUpperCase, nullable);
+            });
+
+            // All occurrences should deserialize to the first encountered value.
+            Assert.Equal(value, deserializedValue);
+            Assert.Equal(value, deserializedValueUpperCase);
+        }
+
+        /// <summary>
+        /// Tests interning components in path-like strings.
+        /// </summary>
+        [Fact]
+        public void TestInternPathWithComponentsFirst()
+        {
+            // Create a case mismatch to test if the path parts are deduplicated.
+            string directory = @"C:\SRC\MSBUILD\ARTIFACTS\BIN\SOMEPROJECT.NAMESPACE\DEBUG\NET472\";
+            string fileName = @"SOMEPROJECT.NAMESPACE.DLL";
+            string fullPath = @"C:\src\msbuild\artifacts\bin\SomeProject.Namespace\Debug\net472\SomeProject.NameSpace.dll";
+
+            TranslationHelpers.GetWriteTranslator().WithInterning(StringComparer.OrdinalIgnoreCase, initialCapacity: 2, translator =>
+            {
+                translator.InternPath(ref directory);
+                translator.InternPath(ref fileName);
+                translator.InternPath(ref fullPath);
+            });
+
+            string deserializedDirectory = null;
+            string deserializedFileName = null;
+            string deserializedFullPath = null;
+            TranslationHelpers.GetReadTranslator().WithInterning(StringComparer.OrdinalIgnoreCase, initialCapacity: 2, translator =>
+            {
+                translator.InternPath(ref deserializedDirectory);
+                translator.InternPath(ref deserializedFileName);
+                translator.InternPath(ref deserializedFullPath);
+            });
+
+            // The path components should be reconstructed using the first encountered value.
+            Assert.Equal(directory, deserializedDirectory);
+            Assert.Equal(fileName, deserializedFileName);
+            Assert.Equal(Path.Combine(directory, fileName), deserializedFullPath);
+        }
+
+        /// <summary>
+        /// Tests interning components in path-like strings.
+        /// </summary>
+        [Fact]
+        public void TestInternPathWithFullPathFirst()
+        {
+            // Create a case mismatch to test if the path parts are deduplicated.
+            string fullPath = @"c:\src\msbuild\artifacts\bin\someproject.namespace\debug\net472\someproject.namespace.dll";
+            string directory = @"C:\SRC\MSBUILD\ARTIFACTS\BIN\SOMEPROJECT.NAMESPACE\DEBUG\NET472\";
+            string fileName = @"SOMEPROJECT.NAMESPACE.DLL";
+
+            TranslationHelpers.GetWriteTranslator().WithInterning(StringComparer.OrdinalIgnoreCase, initialCapacity: 2, translator =>
+            {
+                translator.InternPath(ref fullPath);
+                translator.InternPath(ref directory);
+                translator.InternPath(ref fileName);
+            });
+
+            string deserializedFullPath = null;
+            string deserializedDirectory = null;
+            string deserializedFileName = null;
+            TranslationHelpers.GetReadTranslator().WithInterning(StringComparer.OrdinalIgnoreCase, initialCapacity: 2, translator =>
+            {
+                translator.InternPath(ref deserializedFullPath);
+                translator.InternPath(ref deserializedDirectory);
+                translator.InternPath(ref deserializedFileName);
+            });
+
+            // The path components should be reconstructed using the first encountered value.
+            Assert.Equal(fullPath, deserializedFullPath);
+            Assert.Equal(fullPath, Path.Combine(deserializedDirectory, deserializedFullPath));
+        }
+
+        /// <summary>
+        /// Tests serializing string arrays within an intern scope.
+        /// </summary>
+        [Fact]
+        public void TestInternStringArrayWithInterning()
+        {
+            // Create a case mismatch to test if the string is deduplicated.
+            string[] value1 = ["foo", "FOO"];
+            string[] value2 = ["Foo", "fOO"];
+
+            TranslationHelpers.GetWriteTranslator().WithInterning(StringComparer.OrdinalIgnoreCase, initialCapacity: 1, translator =>
+            {
+                translator.Intern(ref value1);
+                translator.Intern(ref value2);
+            });
+
+            string[] deserializedValue1 = null;
+            string[] deserializedValue2 = null;
+            TranslationHelpers.GetReadTranslator().WithInterning(StringComparer.OrdinalIgnoreCase, initialCapacity: 1, translator =>
+            {
+                translator.Intern(ref deserializedValue1);
+                translator.Intern(ref deserializedValue2);
+            });
+
+            // All occurrences should deserialize to the first encountered value.
+            string[] expectedValue = ["foo", "foo"];
+            Assert.True(TranslationHelpers.CompareCollections(expectedValue, deserializedValue1, StringComparer.Ordinal));
+            Assert.True(TranslationHelpers.CompareCollections(expectedValue, deserializedValue2, StringComparer.Ordinal));
+        }
+
+        /// <summary>
+        /// Tests serializing string arrays outside of an intern scope.
+        /// All calls should be forwarded to the regular translate method.
+        /// </summary>
+        [Fact]
+        public void TestInternStringArrayNoInterning()
+        {
+            string[] value1 = ["foo", "FOO"];
+            string[] value2 = ["Foo", "fOO"];
+
+            ITranslator translator = TranslationHelpers.GetWriteTranslator();
+            translator.Intern(ref value1);
+            translator.Intern(ref value2);
+
+            string[] deserializedValue1 = null;
+            string[] deserializedValue2 = null;
+            translator = TranslationHelpers.GetReadTranslator();
+            translator.Intern(ref deserializedValue1);
+            translator.Intern(ref deserializedValue2);
+
+            Assert.True(TranslationHelpers.CompareCollections(value1, deserializedValue1, StringComparer.Ordinal));
+            Assert.True(TranslationHelpers.CompareCollections(value2, deserializedValue2, StringComparer.Ordinal));
+        }
+
+        /// <summary>
+        /// End-to-end test using a mixture of interned and non-interned operations to ensure that we don't hit
+        /// invalid states, as this will be the most common use case.
+        /// </summary>
+        [Fact]
+        public void TestWithInterningMixedUsage()
+        {
+            string value1 = "Foobar";
+            string value2 = "foobar";
+            string valueToIntern = "FooBar";
+            int value3 = 10;
+            string value4 = "fooBar";
+
+            // Create a case mismatch to test if the string is deduplicated.
+            string valueToInternUpperCase = valueToIntern?.ToUpperInvariant();
+            string value5 = "Foo_Bar";
+
+            ITranslator translator = TranslationHelpers.GetWriteTranslator();
+
+            // Interleave interned and non-interned operations.
+            translator.Translate(ref value1);
+            translator.WithInterning(StringComparer.OrdinalIgnoreCase, initialCapacity: 1, translator =>
+            {
+                translator.Translate(ref value2);
+                translator.Intern(ref valueToIntern);
+                translator.Translate(ref value3);
+                translator.Intern(ref valueToInternUpperCase);
+                translator.Translate(ref value4);
+            });
+            translator.Translate(ref value5);
+
+            string deserializedValue1 = null;
+            string deserializedValue2 = null;
+            string deserializedInternedValue = null;
+            int deserializedValue3 = -1;
+            string deserializedValue4 = null;
+            string deserializedInternedValueUpperCase = null;
+            string deserializedValue5 = null;
+
+            translator = TranslationHelpers.GetReadTranslator();
+
+            // This will only succeed if both translators are correctly sequenced:
+            // packet body -> intern header -> intern body -> packet body.
+            translator.Translate(ref deserializedValue1);
+            translator.WithInterning(StringComparer.OrdinalIgnoreCase, initialCapacity: 1, translator =>
+            {
+                translator.Translate(ref deserializedValue2);
+                translator.Intern(ref deserializedInternedValue);
+                translator.Translate(ref deserializedValue3);
+                translator.Intern(ref deserializedInternedValueUpperCase);
+                translator.Translate(ref deserializedValue4);
+            });
+            translator.Translate(ref deserializedValue5);
+
+            // All non-interned values should maintain their original casing.
+            Assert.Equal(value1, deserializedValue1);
+            Assert.Equal(value2, deserializedValue2);
+            Assert.Equal(value3, deserializedValue3);
+            Assert.Equal(value4, deserializedValue4);
+            Assert.Equal(value5, deserializedValue5);
+
+            // All interned values should deserialize to the first encountered value.
+            Assert.Equal(valueToIntern, deserializedInternedValue);
+            Assert.Equal(valueToIntern, deserializedInternedValueUpperCase);
+        }
+
+        /// <summary>
+        /// Tests interning path-like strings outside of an intern scope.
+        /// All calls should be forwarded to the regular translate method.
+        /// </summary>
+        [Theory]
+        [InlineData(@"C:\src\msbuild\artifacts\bin\SomeProject.Namespace\Debug\net472\SomeProject.NameSpace.dll", true)]
+        [InlineData("foo", true)]
+        [InlineData("", true)]
+        [InlineData(null, true)]
+        [InlineData("foo", false)]
+        [InlineData(@"C:\src\msbuild\artifacts\bin\SomeProject.Namespace\Debug\net472\SomeProject.NameSpace.dll", false)]
+        [InlineData("", false)]
+        [InlineData(null, false)]
+        public void TestInternPathNoInterning(string value, bool nullable)
+        {
+            TranslationHelpers.GetWriteTranslator().InternPath(ref value, nullable);
+
+            string deserializedValue = null;
+            TranslationHelpers.GetReadTranslator().InternPath(ref deserializedValue, nullable);
+
+            // If we haven't blown up so far, assume we've skipped interning.
+            Assert.Equal(value, deserializedValue);
+        }
+
+        /// <summary>
+        /// Tests no-op when nothing is written to the interner. E.g. a packet opens an intern scope, but none of its
+        /// translatable child objects write anything.
+        /// </summary>
+        [Fact]
+        public void TestWithInterningNoWritesDoesNotThrow()
+        {
+            TranslationHelpers.GetWriteTranslator().WithInterning(StringComparer.OrdinalIgnoreCase, initialCapacity: 128, translator =>
+            {
+            });
+            TranslationHelpers.GetReadTranslator().WithInterning(StringComparer.OrdinalIgnoreCase, initialCapacity: 128, translator =>
+            {
+            });
+        }
+
+        /// <summary>
+        /// Tests reusing a translator with different interning comparers.
+        /// This is important if the translator is reused for multiple packet types with different case sensitivity.
+        /// </summary>
+        [Fact]
+        public void TestWithInterningResetsComparerBetweenScopes()
+        {
+            string mixedCaseValue = "StringWithSomeCasing";
+            string lowerCaseValue = "stringwithsomecasing";
+
+            MemoryStream serializationStream = new();
+            ITranslator writeTranslator = BinaryTranslator.GetWriteTranslator(serializationStream);
+            ITranslator readTranslator = BinaryTranslator.GetReadTranslator(serializationStream, InterningBinaryReader.PoolingBuffer);
+
+            writeTranslator.WithInterning(StringComparer.OrdinalIgnoreCase, initialCapacity: 1, translator =>
+            {
+                translator.Intern(ref mixedCaseValue);
+                translator.Intern(ref lowerCaseValue);
+            });
+
+            serializationStream.Position = 0;
+
+            string deserializedMixedCaseValue = null;
+            string deserializedLowerCaseValue = null;
+
+            readTranslator.WithInterning(StringComparer.OrdinalIgnoreCase, initialCapacity: 1, translator =>
+            {
+                translator.Intern(ref deserializedMixedCaseValue);
+                translator.Intern(ref deserializedLowerCaseValue);
+            });
+
+            // Only the first casing should be interned.
+            Assert.Equal(mixedCaseValue, deserializedMixedCaseValue);
+            Assert.Equal(mixedCaseValue, deserializedLowerCaseValue);
+
+            // Simulate translator reuse by resetting the underlying stream.
+            serializationStream.Position = 0;
+            serializationStream.SetLength(0);
+
+            writeTranslator.WithInterning(StringComparer.Ordinal, initialCapacity: 2, translator =>
+            {
+                translator.Intern(ref mixedCaseValue);
+                translator.Intern(ref lowerCaseValue);
+            });
+
+            serializationStream.Position = 0;
+
+            readTranslator.WithInterning(StringComparer.Ordinal, initialCapacity: 2, translator =>
+            {
+                translator.Intern(ref deserializedMixedCaseValue);
+                translator.Intern(ref deserializedLowerCaseValue);
+            });
+
+            // Both casings should be interned if the comparer was correctly reset.
+            Assert.Equal(mixedCaseValue, deserializedMixedCaseValue);
+            Assert.Equal(lowerCaseValue, deserializedLowerCaseValue);
+        }
+
+        /// <summary>
+        /// Tests throwing an exception on nested intern scopes, which is unsupported.
+        /// </summary>
+        [Fact]
+        public void TestWithInterningThrowsOnNestedScopes()
+        {
+            _ = Assert.Throws<InvalidOperationException>(() =>
+            {
+                ITranslator translator = TranslationHelpers.GetWriteTranslator();
+                translator.WithInterning(StringComparer.OrdinalIgnoreCase, initialCapacity: 1, translator =>
+                {
+                    translator.WithInterning(StringComparer.OrdinalIgnoreCase, initialCapacity: 1, translator =>
+                    {
+                    });
+                });
+            });
+
+            TranslationHelpers.GetWriteTranslator().WithInterning(StringComparer.OrdinalIgnoreCase, initialCapacity: 1, translator =>
+            {
+                // Reset the stream, since the broken write will result in an IO exception when read.
+            });
+
+            _ = Assert.Throws<InvalidOperationException>(() =>
+            {
+                ITranslator translator = TranslationHelpers.GetReadTranslator();
+                translator.WithInterning(StringComparer.OrdinalIgnoreCase, initialCapacity: 1, translator =>
+                {
+                    translator.WithInterning(StringComparer.OrdinalIgnoreCase, initialCapacity: 1, translator =>
+                    {
+                    });
+                });
+            });
+        }
+
+        /// <summary>
         /// Tests serializing a dictionary of { string, string }
         /// </summary>
         [Fact]
@@ -538,6 +949,178 @@ namespace Microsoft.Build.UnitTests.BackEnd
 
             Assert.Equal(value, deserializedValue);
         }
+
+        /// <summary>
+        /// Tests interning dictionaries of { string, string } within an intern scope.
+        /// </summary>
+        [Fact]
+        public void TestInternDictionaryStringString()
+        {
+            Dictionary<string, string> value = new(StringComparer.OrdinalIgnoreCase)
+            {
+                ["foo"] = "bar",
+                ["alpha"] = "omega",
+            };
+            Dictionary<string, string> valueUpperCase = new(StringComparer.OrdinalIgnoreCase)
+            {
+                ["FOO"] = "BAR",
+                ["ALPHA"] = "OMEGA",
+            };
+
+            TranslationHelpers.GetWriteTranslator().WithInterning(StringComparer.OrdinalIgnoreCase, initialCapacity: 4, translator =>
+            {
+                translator.InternDictionary(ref value, StringComparer.OrdinalIgnoreCase);
+                translator.InternDictionary(ref valueUpperCase, StringComparer.OrdinalIgnoreCase);
+            });
+
+            Dictionary<string, string> deserializedValue = null;
+            Dictionary<string, string> deserializedValueUpperCase = null;
+            TranslationHelpers.GetReadTranslator().WithInterning(StringComparer.OrdinalIgnoreCase, initialCapacity: 4, translator =>
+            {
+                translator.InternDictionary(ref deserializedValue, StringComparer.OrdinalIgnoreCase);
+                translator.InternDictionary(ref deserializedValueUpperCase, StringComparer.OrdinalIgnoreCase);
+            });
+
+            Assert.Equal(value.Count, deserializedValue.Count);
+            Assert.Equal(value["foo"], deserializedValue["foo"]);
+            Assert.Equal(value["alpha"], deserializedValue["alpha"]);
+
+            // All occurrences should deserialize to the first encountered value.
+            // We don't test the keys since the dictionary already uses an ignore case comparer, and
+            // we also want to test that the dictionary comparer matches on both sides.
+            Assert.Equal(valueUpperCase.Count, deserializedValueUpperCase.Count);
+            Assert.Equal(value["foo"], deserializedValueUpperCase["foo"]);
+            Assert.Equal(value["alpha"], deserializedValueUpperCase["alpha"]);
+        }
+
+        /// <summary>
+        /// Tests interning a dictionary of { string, T } within an intern scope.
+        /// </summary>
+        [Fact]
+        public void TestInternDictionaryStringT()
+        {
+            // Since we don't have string values, mismatch the key comparer to verify that interning works.
+            Dictionary<string, BaseClass> value = new(StringComparer.Ordinal)
+            {
+                ["foo"] = new BaseClass(1),
+                ["alpha"] = new BaseClass(2),
+            };
+            Dictionary<string, BaseClass> valueUpperCase = new(StringComparer.Ordinal)
+            {
+                ["FOO"] = new BaseClass(1),
+                ["ALPHA"] = new BaseClass(2),
+            };
+
+            TranslationHelpers.GetWriteTranslator().WithInterning(StringComparer.OrdinalIgnoreCase, initialCapacity: 2, translator =>
+            {
+                translator.InternDictionary(ref value, StringComparer.OrdinalIgnoreCase, BaseClass.FactoryForDeserialization);
+                translator.InternDictionary(ref valueUpperCase, StringComparer.OrdinalIgnoreCase, BaseClass.FactoryForDeserialization);
+            });
+
+            Dictionary<string, BaseClass> deserializedValue = null;
+            Dictionary<string, BaseClass> deserializedValueUpperCase = null;
+            TranslationHelpers.GetReadTranslator().WithInterning(StringComparer.OrdinalIgnoreCase, initialCapacity: 2, translator =>
+            {
+                translator.InternDictionary(ref deserializedValue, StringComparer.OrdinalIgnoreCase, BaseClass.FactoryForDeserialization);
+                translator.InternDictionary(ref deserializedValueUpperCase, StringComparer.OrdinalIgnoreCase, BaseClass.FactoryForDeserialization);
+            });
+
+            Assert.Equal(value.Count, deserializedValue.Count);
+            Assert.Equal(0, BaseClass.Comparer.Compare(value["foo"], deserializedValue["foo"]));
+            Assert.Equal(0, BaseClass.Comparer.Compare(value["alpha"], deserializedValue["alpha"]));
+
+            // All occurrences should deserialize to the first encountered key.
+            Assert.Equal(0, BaseClass.Comparer.Compare(valueUpperCase["FOO"], deserializedValueUpperCase["foo"]));
+            Assert.Equal(0, BaseClass.Comparer.Compare(valueUpperCase["ALPHA"], deserializedValueUpperCase["alpha"]));
+        }
+
+        /// <summary>
+        /// Tests interning dictionaries of { string, string } with path-like values within an intern scope.
+        /// </summary>
+        [Fact]
+        public void TestInternPathDictionaryStringString()
+        {
+            Dictionary<string, string> value = new(StringComparer.OrdinalIgnoreCase)
+            {
+                ["foo"] = @"C:\src\msbuild\artifacts\bin\ProjectA.Namespace\Debug\net472\ProjectA.NameSpace.dll",
+                ["alpha"] = @"C:\src\msbuild\artifacts\bin\ProjectB.Namespace\Debug\net472\ProjectB.NameSpace.dll",
+            };
+            Dictionary<string, string> valueUpperCase = new(StringComparer.OrdinalIgnoreCase)
+            {
+                ["FOO"] = @"C:\SRC\MSBUILD\ARTIFACTS\BIN\PROJECTA.NAMESPACE\DEBUG\NET472\PROJECTA.NAMESPACE.DLL",
+                ["ALPHA"] = @"C:\SRC\MSBUILD\ARTIFACTS\BIN\PROJECTB.NAMESPACE\DEBUG\NET472\PROJECTB.NAMESPACE.DLL",
+            };
+
+            TranslationHelpers.GetWriteTranslator().WithInterning(StringComparer.OrdinalIgnoreCase, initialCapacity: 4, translator =>
+            {
+                translator.InternDictionary(ref value, StringComparer.OrdinalIgnoreCase);
+                translator.InternDictionary(ref valueUpperCase, StringComparer.OrdinalIgnoreCase);
+            });
+
+            Dictionary<string, string> deserializedValue = null;
+            Dictionary<string, string> deserializedValueUpperCase = null;
+            TranslationHelpers.GetReadTranslator().WithInterning(StringComparer.OrdinalIgnoreCase, initialCapacity: 4, translator =>
+            {
+                translator.InternDictionary(ref deserializedValue, StringComparer.OrdinalIgnoreCase);
+                translator.InternDictionary(ref deserializedValueUpperCase, StringComparer.OrdinalIgnoreCase);
+            });
+
+            Assert.Equal(value.Count, deserializedValue.Count);
+            Assert.Equal(value["foo"], deserializedValue["foo"]);
+            Assert.Equal(value["alpha"], deserializedValue["alpha"]);
+
+            // All occurrences should deserialize to the first encountered value.
+            // We don't test the keys since the dictionary already uses an ignore case comparer, and
+            // we also want to test that the dictionary comparer matches on both sides.
+            Assert.Equal(valueUpperCase.Count, deserializedValueUpperCase.Count);
+            Assert.Equal(value["foo"], deserializedValueUpperCase["foo"]);
+            Assert.Equal(value["alpha"], deserializedValueUpperCase["alpha"]);
+        }
+
+        /// <summary>
+        /// Tests interning a dictionary of { string, T } with path-like keys within an intern scope.
+        /// </summary>
+        [Fact]
+        public void TestInternPathDictionaryStringT()
+        {
+            const string PathA = @"C:\src\msbuild\artifacts\bin\ProjectA.Namespace\Debug\net472\ProjectA.NameSpace.dll";
+            const string PathB = @"C:\src\msbuild\artifacts\bin\ProjectB.Namespace\Debug\net472\ProjectB.NameSpace.dll";
+
+            // Since we don't have string values, mismatch the key comparer to verify that interning works.
+            Dictionary<string, BaseClass> value = new(StringComparer.Ordinal)
+            {
+                [PathA] = new BaseClass(1),
+                [PathB] = new BaseClass(2),
+            };
+            Dictionary<string, BaseClass> valueUpperCase = new(StringComparer.Ordinal)
+            {
+                [PathA.ToUpperInvariant()] = new BaseClass(1),
+                [PathB.ToUpperInvariant()] = new BaseClass(2),
+            };
+
+            TranslationHelpers.GetWriteTranslator().WithInterning(StringComparer.OrdinalIgnoreCase, initialCapacity: 2, translator =>
+            {
+                translator.InternDictionary(ref value, StringComparer.OrdinalIgnoreCase, BaseClass.FactoryForDeserialization);
+                translator.InternDictionary(ref valueUpperCase, StringComparer.OrdinalIgnoreCase, BaseClass.FactoryForDeserialization);
+            });
+
+            Dictionary<string, BaseClass> deserializedValue = null;
+            Dictionary<string, BaseClass> deserializedValueUpperCase = null;
+            TranslationHelpers.GetReadTranslator().WithInterning(StringComparer.OrdinalIgnoreCase, initialCapacity: 2, translator =>
+            {
+                translator.InternDictionary(ref deserializedValue, StringComparer.OrdinalIgnoreCase, BaseClass.FactoryForDeserialization);
+                translator.InternDictionary(ref deserializedValueUpperCase, StringComparer.OrdinalIgnoreCase, BaseClass.FactoryForDeserialization);
+            });
+
+            Assert.Equal(value.Count, deserializedValue.Count);
+            Assert.Equal(0, BaseClass.Comparer.Compare(value[PathA], deserializedValue[PathA]));
+            Assert.Equal(0, BaseClass.Comparer.Compare(value[PathB], deserializedValue[PathB]));
+
+            // All occurrences should deserialize to the first encountered key.
+            Assert.Equal(0, BaseClass.Comparer.Compare(valueUpperCase[PathA.ToUpperInvariant()], deserializedValueUpperCase[PathA]));
+            Assert.Equal(0, BaseClass.Comparer.Compare(valueUpperCase[PathB.ToUpperInvariant()], deserializedValueUpperCase[PathB]));
+        }
+
 
         [Theory]
         [InlineData("en")]

--- a/src/Build.UnitTests/BackEnd/BinaryTranslator_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/BinaryTranslator_Tests.cs
@@ -487,11 +487,11 @@ namespace Microsoft.Build.UnitTests.BackEnd
         /// Tests interning path-like strings within an intern scope.
         /// </summary>
         [Theory]
-        [InlineData(@"C:\src\msbuild\artifacts\bin\SomeProject.Namespace\Debug\net472\SomeProject.NameSpace.dll", true)]
+        [InlineData(@"C:/src/msbuild/artifacts/bin/SomeProject.Namespace/Debug/net472/SomeProject.NameSpace.dll", true)]
         [InlineData("foo", true)]
         [InlineData("", true)]
         [InlineData(null, true)]
-        [InlineData(@"C:\src\msbuild\artifacts\bin\SomeProject.Namespace\Debug\net472\SomeProject.NameSpace.dll", false)]
+        [InlineData(@"C:/src/msbuild/artifacts/bin/SomeProject.Namespace/Debug/net472/SomeProject.NameSpace.dll", false)]
         [InlineData("foo", false)]
         [InlineData("", false)]
         public void TestInternPathWithInterning(string value, bool nullable)
@@ -524,9 +524,9 @@ namespace Microsoft.Build.UnitTests.BackEnd
         public void TestInternPathWithComponentsFirst()
         {
             // Create a case mismatch to test if the path parts are deduplicated.
-            string directory = @"C:\SRC\MSBUILD\ARTIFACTS\BIN\SOMEPROJECT.NAMESPACE\DEBUG\NET472\";
+            string directory = @"C:/SRC/MSBUILD/ARTIFACTS/BIN/SOMEPROJECT.NAMESPACE/DEBUG/NET472/";
             string fileName = @"SOMEPROJECT.NAMESPACE.DLL";
-            string fullPath = @"C:\src\msbuild\artifacts\bin\SomeProject.Namespace\Debug\net472\SomeProject.NameSpace.dll";
+            string fullPath = @"C:/src/msbuild/artifacts/bin/SomeProject.Namespace/Debug/net472/SomeProject.NameSpace.dll";
 
             TranslationHelpers.GetWriteTranslator().WithInterning(StringComparer.OrdinalIgnoreCase, initialCapacity: 2, translator =>
             {
@@ -558,8 +558,8 @@ namespace Microsoft.Build.UnitTests.BackEnd
         public void TestInternPathWithFullPathFirst()
         {
             // Create a case mismatch to test if the path parts are deduplicated.
-            string fullPath = @"c:\src\msbuild\artifacts\bin\someproject.namespace\debug\net472\someproject.namespace.dll";
-            string directory = @"C:\SRC\MSBUILD\ARTIFACTS\BIN\SOMEPROJECT.NAMESPACE\DEBUG\NET472\";
+            string fullPath = @"c:/src/msbuild/artifacts/bin/someproject.namespace/debug/net472/someproject.namespace.dll";
+            string directory = @"C:/SRC/MSBUILD/ARTIFACTS/BIN/SOMEPROJECT.NAMESPACE/DEBUG/NET472/";
             string fileName = @"SOMEPROJECT.NAMESPACE.DLL";
 
             TranslationHelpers.GetWriteTranslator().WithInterning(StringComparer.OrdinalIgnoreCase, initialCapacity: 2, translator =>
@@ -709,12 +709,12 @@ namespace Microsoft.Build.UnitTests.BackEnd
         /// All calls should be forwarded to the regular translate method.
         /// </summary>
         [Theory]
-        [InlineData(@"C:\src\msbuild\artifacts\bin\SomeProject.Namespace\Debug\net472\SomeProject.NameSpace.dll", true)]
+        [InlineData(@"C:/src/msbuild/artifacts/bin/SomeProject.Namespace/Debug/net472/SomeProject.NameSpace.dll", true)]
         [InlineData("foo", true)]
         [InlineData("", true)]
         [InlineData(null, true)]
         [InlineData("foo", false)]
-        [InlineData(@"C:\src\msbuild\artifacts\bin\SomeProject.Namespace\Debug\net472\SomeProject.NameSpace.dll", false)]
+        [InlineData(@"C:/src/msbuild/artifacts/bin/SomeProject.Namespace/Debug/net472/SomeProject.NameSpace.dll", false)]
         [InlineData("", false)]
         [InlineData(null, false)]
         public void TestInternPathNoInterning(string value, bool nullable)
@@ -1042,13 +1042,13 @@ namespace Microsoft.Build.UnitTests.BackEnd
         {
             Dictionary<string, string> value = new(StringComparer.OrdinalIgnoreCase)
             {
-                ["foo"] = @"C:\src\msbuild\artifacts\bin\ProjectA.Namespace\Debug\net472\ProjectA.NameSpace.dll",
-                ["alpha"] = @"C:\src\msbuild\artifacts\bin\ProjectB.Namespace\Debug\net472\ProjectB.NameSpace.dll",
+                ["foo"] = @"C:/src/msbuild/artifacts/bin/ProjectA.Namespace/Debug/net472/ProjectA.NameSpace.dll",
+                ["alpha"] = @"C:/src/msbuild/artifacts/bin/ProjectB.Namespace/Debug/net472/ProjectB.NameSpace.dll",
             };
             Dictionary<string, string> valueUpperCase = new(StringComparer.OrdinalIgnoreCase)
             {
-                ["FOO"] = @"C:\SRC\MSBUILD\ARTIFACTS\BIN\PROJECTA.NAMESPACE\DEBUG\NET472\PROJECTA.NAMESPACE.DLL",
-                ["ALPHA"] = @"C:\SRC\MSBUILD\ARTIFACTS\BIN\PROJECTB.NAMESPACE\DEBUG\NET472\PROJECTB.NAMESPACE.DLL",
+                ["FOO"] = @"C:/SRC/MSBUILD/ARTIFACTS/BIN/PROJECTA.NAMESPACE/DEBUG/NET472/PROJECTA.NAMESPACE.DLL",
+                ["ALPHA"] = @"C:/SRC/MSBUILD/ARTIFACTS/BIN/PROJECTB.NAMESPACE/DEBUG/NET472/PROJECTB.NAMESPACE.DLL",
             };
 
             TranslationHelpers.GetWriteTranslator().WithInterning(StringComparer.OrdinalIgnoreCase, initialCapacity: 4, translator =>
@@ -1083,8 +1083,8 @@ namespace Microsoft.Build.UnitTests.BackEnd
         [Fact]
         public void TestInternPathDictionaryStringT()
         {
-            const string PathA = @"C:\src\msbuild\artifacts\bin\ProjectA.Namespace\Debug\net472\ProjectA.NameSpace.dll";
-            const string PathB = @"C:\src\msbuild\artifacts\bin\ProjectB.Namespace\Debug\net472\ProjectB.NameSpace.dll";
+            const string PathA = @"C:/src/msbuild/artifacts/bin/ProjectA.Namespace/Debug/net472/ProjectA.NameSpace.dll";
+            const string PathB = @"C:/src/msbuild/artifacts/bin/ProjectB.Namespace/Debug/net472/ProjectB.NameSpace.dll";
 
             // Since we don't have string values, mismatch the key comparer to verify that interning works.
             Dictionary<string, BaseClass> value = new(StringComparer.Ordinal)

--- a/src/Framework/ITranslator.cs
+++ b/src/Framework/ITranslator.cs
@@ -7,6 +7,8 @@ using System.Globalization;
 using System.IO;
 using Microsoft.Build.Framework;
 
+#nullable disable
+
 namespace Microsoft.Build.BackEnd
 {
     /// <summary>

--- a/src/Framework/ITranslator.cs
+++ b/src/Framework/ITranslator.cs
@@ -371,7 +371,7 @@ namespace Microsoft.Build.BackEnd
         /// Creates a scope which activates string interning / deduplication for any Intern_xx method.
         /// This should generally be called from the root level packet.
         /// </summary>
-        /// <param name="comparer">The strseaparating comparer to use when populating the intern cache.</param>
+        /// <param name="comparer">The string comparer to use when populating the intern cache.</param>
         /// <param name="initialCapacity">The initial capacity of the intern cache.</param>
         /// <param name="internBlock">A delegate providing a translator, in which all Intern_xx calls will go through the intern cache.</param>
         /// <remarks>

--- a/src/Framework/ITranslator.cs
+++ b/src/Framework/ITranslator.cs
@@ -98,6 +98,8 @@ namespace Microsoft.Build.BackEnd
             get;
         }
 
+        bool IsInterning { get; }
+
         /// <summary>
         /// Translates a boolean.
         /// </summary>
@@ -366,5 +368,14 @@ namespace Microsoft.Build.BackEnd
         /// <typeparam name="T">The type of object to test.</typeparam>
         /// <returns>True if the object should be written, false otherwise.</returns>
         bool TranslateNullable<T>(T value);
+
+        void Intern(ref string str, bool nullable = false);
+
+        void Intern(ref string[] array);
+
+
+        void InternPath(ref string str, bool nullable = false);
+
+        void WithInterning(IEqualityComparer<string> comparer, int initialCapacity, Action<ITranslator> internBlock);
     }
 }

--- a/src/Framework/ITranslator.cs
+++ b/src/Framework/ITranslator.cs
@@ -7,8 +7,6 @@ using System.Globalization;
 using System.IO;
 using Microsoft.Build.Framework;
 
-#nullable disable
-
 namespace Microsoft.Build.BackEnd
 {
     /// <summary>
@@ -97,8 +95,6 @@ namespace Microsoft.Build.BackEnd
         {
             get;
         }
-
-        bool IsInterning { get; }
 
         /// <summary>
         /// Translates a boolean.
@@ -369,13 +365,58 @@ namespace Microsoft.Build.BackEnd
         /// <returns>True if the object should be written, false otherwise.</returns>
         bool TranslateNullable<T>(T value);
 
-        void Intern(ref string str, bool nullable = false);
+        /// <summary>
+        /// Creates a scope which activates string interning / deduplication for any Intern_xx method.
+        /// This should generally be called from the root level packet.
+        /// </summary>
+        /// <param name="comparer">The strseaparating comparer to use when populating the intern cache.</param>
+        /// <param name="initialCapacity">The initial capacity of the intern cache.</param>
+        /// <param name="internBlock">A delegate providing a translator, in which all Intern_xx calls will go through the intern cache.</param>
+        /// <remarks>
+        /// Packet interning is implemented via a header with an array of all interned strings, followed by the body in
+        /// which any interned / duplicated strings are replaced by their ID.
+        /// <see cref="TranslationDirection"/> modes have different ordering requirements, so it would not be
+        /// possible to implement direction-agnostic serialization via the Intern_xx methods alone:
+        /// - Write: Because we don't know the full list of strings ahead of time, we need to create a temporary buffer
+        ///   for the packet body, which we can later offset when flushing to the real stream.
+        /// - Read: The intern header needs to be deserialized before the packet body, otherwise we won't know what
+        ///   string each ID maps to.
+        /// This method abstracts these requirements to the caller, such that the underlying translator will
+        /// automatically handle the appropriate IO ordering when entering / exiting the delegate scope.
+        /// </remarks>
+        void WithInterning(IEqualityComparer<string> comparer, int initialCapacity, Action<ITranslator> internBlock);
 
+        /// <summary>
+        /// Interns the string if the translator is currently within an intern block.
+        /// Otherwise, this forwards to the regular Translate method.
+        /// </summary>
+        /// <param name="str">The value to be translated.</param>
+        /// <param name="nullable">
+        /// Whether to null check and translate the nullable marker.
+        /// Setting this to false can reduce packet sizes when interning large numbers of strings
+        /// which are validated to always be non-null, such as dictionary keys.
+        /// </param>
+        void Intern(ref string str, bool nullable = true);
+
+        /// <summary>
+        /// Interns each string in the array if the translator is currently within an intern block.
+        /// Otherwise, this forwards to the regular Translate method. To match behavior, all strings
+        /// assumed to be non-null.
+        /// </summary>
+        /// <param name="array">The array to be translated.</param>
         void Intern(ref string[] array);
 
-
-        void InternPath(ref string str, bool nullable = false);
-
-        void WithInterning(IEqualityComparer<string> comparer, int initialCapacity, Action<ITranslator> internBlock);
+        /// <summary>
+        /// Interns the string if the translator is currently within an intern block.
+        /// Otherwise, this forwards to the regular Translate method.
+        /// If the string is determined to be path-like, the path components will be interned separately.
+        /// </summary>
+        /// <param name="str">The value to be translated.</param>
+        /// <param name="nullable">
+        /// Whether to null check and translate the nullable marker.
+        /// Setting this to false can reduce packet sizes when interning large numbers of strings
+        /// which are validated to always be non-null, such as dictionary keys.
+        /// </param>
+        void InternPath(ref string str, bool nullable = true);
     }
 }

--- a/src/Framework/InternPathIds.cs
+++ b/src/Framework/InternPathIds.cs
@@ -1,0 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Build.BackEnd
+{
+    internal readonly record struct InternPathIds(int DirectoryId, int FileNameId);
+}

--- a/src/Framework/InterningReadTranslator.cs
+++ b/src/Framework/InterningReadTranslator.cs
@@ -1,0 +1,94 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.Build.BackEnd;
+
+namespace Microsoft.Build.BackEnd
+{
+    internal sealed class InterningReadTranslator : ITranslatable
+    {
+        private List<string> _strings = [];
+
+        private Dictionary<PathIds, string> _pathIdsToString = [];
+
+        private readonly ITranslator _translator;
+
+        internal InterningReadTranslator(ITranslator translator)
+        {
+            _translator = translator;
+        }
+
+        internal string? ReadNullable()
+        {
+            if (!_translator.TranslateNullable(string.Empty))
+            {
+                return null;
+            }
+
+            return Read();
+        }
+
+        internal string Read()
+        {
+            int key = -1;
+            _translator.Translate(ref key);
+            return _strings[key];
+        }
+
+        internal string? ReadNullablePath()
+        {
+            if (!_translator.TranslateNullable(string.Empty))
+            {
+                return null;
+            }
+
+            return ReadPath();
+        }
+
+        internal string ReadPath()
+        {
+            if (!_translator.TranslateNullable(string.Empty))
+            {
+                return Read();
+            }
+
+            int directoryKey = -1;
+            int fileNameKey = -1;
+            _translator.Translate(ref directoryKey);
+            _translator.Translate(ref fileNameKey);
+
+            PathIds pathIds = new(directoryKey, fileNameKey);
+
+            if (_pathIdsToString.TryGetValue(pathIds, out string? path))
+            {
+                return path;
+            }
+
+            string directory = _strings[pathIds.DirectoryId];
+            string fileName = _strings[pathIds.FileNameId];
+            string str = string.Concat(directory, fileName);
+            _pathIdsToString.Add(pathIds, str);
+
+            return str;
+        }
+
+        public void Translate(ITranslator translator)
+        {
+            _translator.Translate(ref _strings);
+            foreach (string str in _strings)
+            {
+                Console.WriteLine(str);
+            }
+#if NET
+            _pathIdsToString.EnsureCapacity(_strings.Count);
+#else
+            _pathIdsToString = new(_strings.Count);
+#endif
+        }
+
+        private readonly record struct PathIds(int DirectoryId, int FileNameId);
+    }
+}

--- a/src/Framework/InterningReadTranslator.cs
+++ b/src/Framework/InterningReadTranslator.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
 
 namespace Microsoft.Build.BackEnd
 {

--- a/src/Framework/InterningWriteTranslator.cs
+++ b/src/Framework/InterningWriteTranslator.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Build.BackEnd
     /// 1. Serialize the list of unique strings to an array, where the ID is the index.
     /// 2. Serialize the temporary buffer (aka the packet body) with all interned strings replaced by their ID.
     /// This ordering is important since the reader will need the string lookup table before parsing the body.
-    /// As such, two rules need to be follwed when using this class:
+    /// As such, two rules need to be followed when using this class:
     /// 1. Any interleaved non-interned writes should be written using the exposed BinaryWriter to keep the overall
     /// packet in sync.
     /// 2. Translate should *only* be called after all internable writes have been processed.

--- a/src/Framework/InterningWriteTranslator.cs
+++ b/src/Framework/InterningWriteTranslator.cs
@@ -4,54 +4,104 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using Microsoft.Build.BackEnd;
 
 namespace Microsoft.Build.BackEnd
 {
+    /// <summary>
+    /// Writes strings into a translator with interning / deduplication.
+    /// </summary>
+    /// <remarks>
+    /// This maintains a reusable temporary buffer and lookup table for deduplicating strings within a translatable packet.
+    /// All unique strings (as determined by the comparer) will be assigned an incrementing ID and stored into a dictionary.
+    /// This ID will be written to a private buffer in place of the string and any repeat occurrences.
+    /// When serialized into another translator, the interner will:
+    /// 1. Serialize the list of unique strings to an array, where the ID is the index.
+    /// 2. Serialize the temporary buffer (aka the packet body) with all interned strings replaced by their ID.
+    /// This ordering is important since the reader will need the string lookup table before parsing the body.
+    /// As such, two rules need to be follwed when using this class:
+    /// 1. Any interleaved non-interned writes should be written using the exposed BinaryWriter to keep the overall
+    /// packet in sync.
+    /// 2. Translate should *only* be called after all internable writes have been processed.
+    /// </remarks>
     internal sealed class InterningWriteTranslator : ITranslatable
     {
+        private static readonly char[] DirectorySeparatorChars = [Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar];
+
+        private static readonly string IsPathMarker = string.Empty;
+
+        private static readonly string? NotPathMarker = null;
+
+        private readonly ITranslator _translator;
+
+        private readonly MemoryStream _packetStream;
+
         private List<string> _strings = [];
 
         private Dictionary<string, int> _stringToIds = [];
 
-        private Dictionary<string, PathIds> _stringToPathIds = [];
+        private Dictionary<string, InternPathIds> _stringToPathIds = [];
 
-        private MemoryStream _packetStream = new();
-
-#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.
-        // Recursive loop
-        internal ITranslator Translator { get; private set; }
-#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.
-
-        internal void InitCapacity(IEqualityComparer<string> comparer, int count)
+        internal InterningWriteTranslator()
         {
-            if (Translator == null)
-            {
-                Translator = BinaryTranslator.GetWriteTranslator(_packetStream, this);
-            }
+            _packetStream = new MemoryStream();
+            _translator = BinaryTranslator.GetWriteTranslator(_packetStream);
 
-            int capacity = count * 8;
-            int bufferCapacity = capacity * 128;
-            _stringToIds = new Dictionary<string, int>(count * 8, comparer);
-            _stringToPathIds = new Dictionary<string, PathIds>(count * 8, comparer);
-            _strings.Clear();
-            _strings.Capacity = capacity;
+            // Avoid directly exposing the buffered translator - any accidental Intern_xx method calls could go into a
+            // recursive loop.
+            Writer = _translator.Writer;
+        }
+
+        /// <summary>
+        /// The writer for the underlying buffer.
+        /// Use to forward any non-interning writes into this translator.
+        /// </summary>
+        internal BinaryWriter Writer { get; }
+
+        /// <summary>
+        /// Setup the intern cache and underlying buffer. This allows the interner to be reused.
+        /// </summary>
+        /// <param name="comparer">The string comparer to use for string deduplication.</param>
+        /// <param name="initialCapacity">An estimate of the number of unique strings to be interned.</param>
+        internal void Setup(IEqualityComparer<string> comparer, int initialCapacity)
+        {
+#if NET
+            if (_stringToIds.Comparer == comparer)
+            {
+                // Clear before setting capacity, since dictionaries will rehash every entry.
+                _strings.Clear();
+                _stringToIds.Clear();
+                _stringToPathIds.Clear();
+                _strings.EnsureCapacity(initialCapacity);
+                _stringToIds.EnsureCapacity(initialCapacity);
+                _stringToPathIds.EnsureCapacity(initialCapacity);
+            }
+            else
+            {
+#endif
+                // If the interner is in a reused translator, the comparer might not match between packets.
+                // Just throw away the old collections in this case.
+                _strings.Clear();
+                _strings.Capacity = initialCapacity;
+                _stringToIds = new Dictionary<string, int>(initialCapacity, comparer);
+                _stringToPathIds = new Dictionary<string, InternPathIds>(initialCapacity, comparer);
+#if NET
+            }
+#endif
             _packetStream.Position = 0;
             _packetStream.SetLength(0);
-            _packetStream.Capacity = bufferCapacity;
+
+            // This is a rough estimate since the final size will depend on the length of each string and the total number
+            // of intern cache hits. Assume a mixture of short strings (e.g. item metadata pairs, RAR assembly metadata)
+            // and file paths (e.g. item include paths, RAR statefile entries).
+            const int CharactersPerString = 32;
+            const int BytesPerCharacter = 2;
+            const int BytesPerInternedString = 5;
+            int internHeaderSize = initialCapacity * CharactersPerString * BytesPerCharacter;
+            int packetPayloadSize = initialCapacity * BytesPerInternedString;
+            _packetStream.Capacity = internHeaderSize + packetPayloadSize;
         }
 
-        internal void Intern(string str) => InternString(str);
-
-        internal void InternNullable(string str)
-        {
-            if (!Translator.TranslateNullable(str))
-            {
-                return;
-            }
-
-            InternString(str);
-        }
+        internal void Intern(string str) => _ = InternString(str);
 
         private int InternString(string str)
         {
@@ -62,70 +112,62 @@ namespace Microsoft.Build.BackEnd
                 _strings.Add(str);
             }
 
-            Translator.Translate(ref index);
+            _translator.Translate(ref index);
             return index;
-        }
-
-        internal void InternNullablePath(string str)
-        {
-            if (!Translator.TranslateNullable(str))
-            {
-                return;
-            }
-
-            InternPath(str);
         }
 
         internal void InternPath(string str)
         {
-            if (_stringToPathIds.TryGetValue(str, out PathIds pathIds))
+            // If we've seen a string already and know it's path-like, we just need the index pair.
+            if (_stringToPathIds.TryGetValue(str, out InternPathIds pathIds))
             {
-                _ = Translator.TranslateNullable(string.Empty);
+                _ = _translator.TranslateNullable(IsPathMarker);
                 int directoryId = pathIds.DirectoryId;
                 int fileNameId = pathIds.FileNameId;
-                Translator.Translate(ref directoryId);
-                Translator.Translate(ref fileNameId);
+                _translator.Translate(ref directoryId);
+                _translator.Translate(ref fileNameId);
                 return;
             }
 
-            int splitId = str.LastIndexOf(Path.DirectorySeparatorChar);
-
-            if (splitId == -1)
-            {
-                splitId = str.LastIndexOf(Path.AltDirectorySeparatorChar);
-            }
-
+            // Quick and basic heuristic to check if we have a path-like string.
+            int splitId = str.LastIndexOfAny(DirectorySeparatorChars);
             bool hasDirectorySeparator = splitId > -1
                 && splitId < str.Length - 1
                 && str.IndexOf('%') == -1;
 
             if (!hasDirectorySeparator)
             {
-                string? dummy = null;
-                _ = Translator.TranslateNullable(dummy);
+                // Set a marker to signal the reader to parse this as a single string.
+                _ = _translator.TranslateNullable(NotPathMarker);
                 _ = InternString(str);
                 return;
             }
 
-            // If we've seen a string already and know it's pathlike, we just need the index duo
             string directory = str.Substring(0, splitId + 1);
             string fileName = str.Substring(splitId + 1);
 
-            _ = Translator.TranslateNullable(string.Empty);
+            _ = _translator.TranslateNullable(IsPathMarker);
             int directoryIndex = InternString(directory);
             int fileNameIndex = InternString(fileName);
 
-            _stringToPathIds.Add(str, new PathIds(directoryIndex, fileNameIndex));
+            _stringToPathIds.Add(str, new InternPathIds(directoryIndex, fileNameIndex));
         }
 
         public void Translate(ITranslator translator)
         {
+            if (translator.Mode != TranslationDirection.WriteToStream)
+            {
+                throw new InvalidOperationException(
+                    $"{nameof(InterningWriteTranslator)} can only be used with {nameof(TranslationDirection.WriteToStream)}.");
+            }
+
+            // Write the set of unique strings as the packet header.
             translator.Translate(ref _strings);
+
+            // Write the temporary buffer as the packet body.
             byte[] buffer = _packetStream.GetBuffer();
             int bufferSize = (int)_packetStream.Length;
             translator.Writer.Write(buffer, 0, bufferSize);
         }
-
-        private readonly record struct PathIds(int DirectoryId, int FileNameId);
     }
 }

--- a/src/Framework/InterningWriteTranslator.cs
+++ b/src/Framework/InterningWriteTranslator.cs
@@ -1,0 +1,131 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.Build.BackEnd;
+
+namespace Microsoft.Build.BackEnd
+{
+    internal sealed class InterningWriteTranslator : ITranslatable
+    {
+        private List<string> _strings = [];
+
+        private Dictionary<string, int> _stringToIds = [];
+
+        private Dictionary<string, PathIds> _stringToPathIds = [];
+
+        private MemoryStream _packetStream = new();
+
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.
+        // Recursive loop
+        internal ITranslator Translator { get; private set; }
+#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.
+
+        internal void InitCapacity(IEqualityComparer<string> comparer, int count)
+        {
+            if (Translator == null)
+            {
+                Translator = BinaryTranslator.GetWriteTranslator(_packetStream, this);
+            }
+
+            int capacity = count * 8;
+            int bufferCapacity = capacity * 128;
+            _stringToIds = new Dictionary<string, int>(count * 8, comparer);
+            _stringToPathIds = new Dictionary<string, PathIds>(count * 8, comparer);
+            _strings.Clear();
+            _strings.Capacity = capacity;
+            _packetStream.Position = 0;
+            _packetStream.SetLength(0);
+            _packetStream.Capacity = bufferCapacity;
+        }
+
+        internal void Intern(string str) => InternString(str);
+
+        internal void InternNullable(string str)
+        {
+            if (!Translator.TranslateNullable(str))
+            {
+                return;
+            }
+
+            InternString(str);
+        }
+
+        private int InternString(string str)
+        {
+            if (!_stringToIds.TryGetValue(str, out int index))
+            {
+                index = _strings.Count;
+                _stringToIds.Add(str, index);
+                _strings.Add(str);
+            }
+
+            Translator.Translate(ref index);
+            return index;
+        }
+
+        internal void InternNullablePath(string str)
+        {
+            if (!Translator.TranslateNullable(str))
+            {
+                return;
+            }
+
+            InternPath(str);
+        }
+
+        internal void InternPath(string str)
+        {
+            if (_stringToPathIds.TryGetValue(str, out PathIds pathIds))
+            {
+                _ = Translator.TranslateNullable(string.Empty);
+                int directoryId = pathIds.DirectoryId;
+                int fileNameId = pathIds.FileNameId;
+                Translator.Translate(ref directoryId);
+                Translator.Translate(ref fileNameId);
+                return;
+            }
+
+            int splitId = str.LastIndexOf(Path.DirectorySeparatorChar);
+
+            if (splitId == -1)
+            {
+                splitId = str.LastIndexOf(Path.AltDirectorySeparatorChar);
+            }
+
+            bool hasDirectorySeparator = splitId > -1
+                && splitId < str.Length - 1
+                && str.IndexOf('%') == -1;
+
+            if (!hasDirectorySeparator)
+            {
+                string? dummy = null;
+                _ = Translator.TranslateNullable(dummy);
+                _ = InternString(str);
+                return;
+            }
+
+            // If we've seen a string already and know it's pathlike, we just need the index duo
+            string directory = str.Substring(0, splitId + 1);
+            string fileName = str.Substring(splitId + 1);
+
+            _ = Translator.TranslateNullable(string.Empty);
+            int directoryIndex = InternString(directory);
+            int fileNameIndex = InternString(fileName);
+
+            _stringToPathIds.Add(str, new PathIds(directoryIndex, fileNameIndex));
+        }
+
+        public void Translate(ITranslator translator)
+        {
+            translator.Translate(ref _strings);
+            byte[] buffer = _packetStream.GetBuffer();
+            int bufferSize = (int)_packetStream.Length;
+            translator.Writer.Write(buffer, 0, bufferSize);
+        }
+
+        private readonly record struct PathIds(int DirectoryId, int FileNameId);
+    }
+}

--- a/src/MSBuildTaskHost/MSBuildTaskHost.csproj
+++ b/src/MSBuildTaskHost/MSBuildTaskHost.csproj
@@ -221,6 +221,9 @@
     <Compile Include="..\Shared\TaskParameter.cs" />
     <Compile Include="..\Shared\AssemblyNameExtension.cs" />
 
+    <Compile Include="..\Framework\InterningReadTranslator.cs" />
+    <Compile Include="..\Framework\InterningWriteTranslator.cs" />
+
     <Compile Include="..\Shared\FileSystem\IFileSystem.cs" />
     <Compile Include="..\Shared\FileSystem\FileSystems.cs" />
     <Compile Include="FileSystem\MSBuildTaskHostFileSystem.cs" />

--- a/src/MSBuildTaskHost/MSBuildTaskHost.csproj
+++ b/src/MSBuildTaskHost/MSBuildTaskHost.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <!-- The .NET Core version of MSBuild doesn't support targeting .NET Framework 3.5.  So in that case, we import
        a .props file that prevents building the project from doing much of anything. -->
@@ -223,6 +223,7 @@
 
     <Compile Include="..\Framework\InterningReadTranslator.cs" />
     <Compile Include="..\Framework\InterningWriteTranslator.cs" />
+    <Compile Include="..\Framework\InternPathIds.cs" />
 
     <Compile Include="..\Shared\FileSystem\IFileSystem.cs" />
     <Compile Include="..\Shared\FileSystem\FileSystems.cs" />

--- a/src/Shared/TranslatorHelpers.cs
+++ b/src/Shared/TranslatorHelpers.cs
@@ -89,7 +89,10 @@ namespace Microsoft.Build.BackEnd
             translator.TranslateDictionary(ref dictionary, comparer, AdaptFactory(valueFactory));
         }
 
-        public static void InternDictionary(this ITranslator translator, ref Dictionary<string, string> dictionary, IEqualityComparer<string> comparer)
+        public static void InternDictionary(
+            this ITranslator translator,
+            ref Dictionary<string, string> dictionary,
+            IEqualityComparer<string> comparer)
         {
             IDictionary<string, string> localDict = dictionary;
             translator.TranslateDictionary(
@@ -100,7 +103,11 @@ namespace Microsoft.Build.BackEnd
             dictionary = (Dictionary<string, string>)localDict;
         }
 
-        public static void InternDictionary<T>(this ITranslator translator, ref Dictionary<string, T> dictionary, IEqualityComparer<string> stringComparer, NodePacketValueFactory<T> valueFactory)
+        public static void InternDictionary<T>(
+            this ITranslator translator,
+            ref Dictionary<string, T> dictionary,
+            IEqualityComparer<string> stringComparer,
+            NodePacketValueFactory<T> valueFactory)
             where T : ITranslatable
         {
             IDictionary<string, T> localDict = dictionary;
@@ -112,9 +119,14 @@ namespace Microsoft.Build.BackEnd
             dictionary = (Dictionary<string, T>)localDict;
         }
 
-        public static void InternPathDictionary(this ITranslator translator, ref Dictionary<string, string> dictionary, IEqualityComparer<string> comparer)
+        public static void InternPathDictionary(
+            this ITranslator translator,
+            ref Dictionary<string, string> dictionary,
+            IEqualityComparer<string> comparer)
         {
             IDictionary<string, string> localDict = dictionary;
+
+            // For now, assume only the value contains path-like strings (e.g. TaskItem metadata).
             translator.TranslateDictionary(
                 ref localDict,
                 (ITranslator translator, ref string key) => translator.Intern(ref key),
@@ -123,7 +135,11 @@ namespace Microsoft.Build.BackEnd
             dictionary = (Dictionary<string, string>)localDict;
         }
 
-        public static void InternPathDictionary<T>(this ITranslator translator, ref Dictionary<string, T> dictionary, IEqualityComparer<string> stringComparer, NodePacketValueFactory<T> valueFactory)
+        public static void InternPathDictionary<T>(
+            this ITranslator translator,
+            ref Dictionary<string, T> dictionary,
+            IEqualityComparer<string> stringComparer,
+            NodePacketValueFactory<T> valueFactory)
             where T : ITranslatable
         {
             IDictionary<string, T> localDict = dictionary;
@@ -293,14 +309,14 @@ namespace Microsoft.Build.BackEnd
                 publicKeyToken = assemblyName.GetPublicKeyToken();
             }
 
-            translator.InternPath(ref name, nullable: true);
+            translator.Translate(ref name);
             translator.Translate(ref version);
             translator.TranslateEnum(ref flags, (int)flags);
             translator.TranslateEnum(ref processorArchitecture, (int)processorArchitecture);
             translator.Translate(ref cultureInfo);
             translator.TranslateEnum(ref hashAlgorithm, (int)hashAlgorithm);
             translator.TranslateEnum(ref versionCompatibility, (int)versionCompatibility);
-            translator.Intern(ref codeBase, nullable: true);
+            translator.Translate(ref codeBase);
 
             translator.Translate(ref publicKey);
             translator.Translate(ref publicKeyToken);

--- a/src/Tasks/SystemState.cs
+++ b/src/Tasks/SystemState.cs
@@ -265,13 +265,10 @@ namespace Microsoft.Build.Tasks
                 throw new NullReferenceException(nameof(instanceLocalFileStateCache));
             }
 
-            translator.WithInterning(StringComparer.Ordinal, 100, translator =>
-            {
-                translator.InternPathDictionary(
-                    ref (translator.Mode == TranslationDirection.WriteToStream) ? ref instanceLocalOutgoingFileStateCache : ref instanceLocalFileStateCache,
-                    StringComparer.OrdinalIgnoreCase,
-                    t => new FileState(t));
-            });
+            translator.TranslateDictionary(
+                ref (translator.Mode == TranslationDirection.WriteToStream) ? ref instanceLocalOutgoingFileStateCache : ref instanceLocalFileStateCache,
+                StringComparer.OrdinalIgnoreCase,
+                (ITranslator t) => new FileState(t));
 
             // IsDirty should be false for either direction. Either this cache was brought
             // up-to-date with the on-disk cache or vice versa. Either way, they agree.

--- a/src/Tasks/SystemState.cs
+++ b/src/Tasks/SystemState.cs
@@ -265,10 +265,13 @@ namespace Microsoft.Build.Tasks
                 throw new NullReferenceException(nameof(instanceLocalFileStateCache));
             }
 
-            translator.TranslateDictionary(
-                ref (translator.Mode == TranslationDirection.WriteToStream) ? ref instanceLocalOutgoingFileStateCache : ref instanceLocalFileStateCache,
-                StringComparer.OrdinalIgnoreCase,
-                (ITranslator t) => new FileState(t));
+            translator.WithInterning(StringComparer.Ordinal, 100, translator =>
+            {
+                translator.InternPathDictionary(
+                    ref (translator.Mode == TranslationDirection.WriteToStream) ? ref instanceLocalOutgoingFileStateCache : ref instanceLocalFileStateCache,
+                    StringComparer.OrdinalIgnoreCase,
+                    t => new FileState(t));
+            });
 
             // IsDirty should be false for either direction. Either this cache was brought
             // up-to-date with the on-disk cache or vice versa. Either way, they agree.


### PR DESCRIPTION
### Context

When looking at serialization overhead for the RAR node, I found that most of the serialization overhead comes down to reading strings from the payload.

Many strings are shared between task items, such as common metadata values, file names, parent directories.

With the existing translator system, you *can* manually do this - you effectively need to create a temporary buffer, ID mapping, and offset the lookup depending on the direction. But it's difficult to set up, all child objects would need separate constructors, and it breaks the idea of having `ITranslator` be unidirectional since the write patterns have different ordering requirements - which makes it incredibly easy to accidentally break.

### Changes Made

This bakes in an opt-in string interning API directly into the `ITranslator` framework. By defining a block like:
```cs
translator.WithInterning(StringComparer.Ordinal, translator =>
{
   translator.Translate(ref  _someItem);
   translator.Intern(ref _someString);
   translator.InternDictionary(ref _someDictionary, StringComparer.OrdinalIgnoreCase, translator => new SomeITranslator(translator));
});
```
...all steps are automatically handled. `BinaryWriteTranslator` swaps its writer with a translator provided by `InterningWriteTranslator`. When the block is completed, the offset + flush automatically happens. On the read side, `BinaryReadTranslator` just reads directly from the stream, using `InterningReadTranslator` to decode any interned strings.

A parent translator can enter multiple intern blocks across its lifetime as the buffers are just reset and reused. This makes it possible to use with the existing node pipe implementations, since they are reused across packets.

The `ITranslatable` implementation can selectively choose which strings to intern, and which strings are unlikely to be duplicated.

If `_.Intern()` methods are called outside of an enclosing delegate, they simply behave as a non-interned operation. 

This makes it extremely easy to add string interning / deduplication support for any arbitrary `INodePacket`. See the included example of enabling this for the RAR statefile.

### Testing

Implementation seen here effectively cuts packet size for RAR request / response packets by ~50-60%.

RAR statefile can hit a ~20% size reduction, but only with additional changes to intern on substrings rather than a path separator (e.g. you run into strings like `file///somepath/foo.dll` where the full path isn't deduplicated due to the prefix). Given this, substring / path API needs more thought as it would be very useful to split on multiple known separators. Currently it's closer to ~10% (tested on cloudbuild and orchard core repos).

Basic powershell command to count the diff:
```powershell
ls -r *AssemblyReference.cache | select -ExpandProperty Length | Measure-Object -Sum | foreach {$_.Sum / 100000}
```