### PR TITLE
Remove RichCodeNavIndexer from .vsts-dotnet-ci.yml

### DIFF
--- a/.vsts-dotnet-ci.yml
+++ b/.vsts-dotnet-ci.yml
@@ -276,23 +276,6 @@ jobs:
     continueOnError: true
     condition: eq(variables.onlyDocChanged, 0)
 
-# Unavailable in dnceng-public as of 9/1/2022; should be restored soon.
-# - job: RichCodeNavIndex
-#   displayName: "Windows Code Indexing"
-#   pool:
-#     vmImage: 'windows-2022'
-#   steps:
-#   - task: BatchScript@1
-#     displayName: build.cmd
-#     inputs:
-#       filename: 'build.cmd'
-#   - task: RichCodeNavIndexer@0
-#     displayName: RichCodeNav Upload
-#     inputs:
-#       languages: 'csharp'
-#     continueOnError: true
-#     condition: succeeded()
-
 - job: CoreBootstrappedOnLinux
   displayName: "Linux Core"
   dependsOn: IfOnlyDocumentionChanged


### PR DESCRIPTION
The service is not coming back, remove the commented out code.
