### PR TITLE
Add separate DeserializePacket() to INodePacketFactory

### DIFF
--- a/eng/SourceBuildPrebuiltBaseline.xml
+++ b/eng/SourceBuildPrebuiltBaseline.xml
@@ -24,6 +24,8 @@
     <UsagePattern IdentityGlob="System.Diagnostics.EventLog/*9.0.0*" />
     <!-- dependency of System.Resources.Extensions -->
     <UsagePattern IdentityGlob="System.Formats.Nrbf/*9.0.0*" />
+    <!-- dependency of System.System.Threading.Channels -->
+    <UsagePattern IdentityGlob="Microsoft.Bcl.AsyncInterfaces/*9.0.0*" />
     <!-- dependency of System.Security.Cryptography.Pkcs -->
     <UsagePattern IdentityGlob="Microsoft.Bcl.Cryptography/*9.0.0*" />
   </IgnorePatterns>

--- a/src/Build.UnitTests/BackEnd/NodeEndpointInProc_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/NodeEndpointInProc_Tests.cs
@@ -105,6 +105,11 @@ namespace Microsoft.Build.UnitTests.BackEnd
                 throw new NotImplementedException();
             }
 
+            public INodePacket DeserializePacket(NodePacketType packetType, ITranslator translator)
+            {
+                throw new NotImplementedException();
+            }
+
             public void RoutePacket(int nodeId, INodePacket packet)
             {
                 _dataReceivedContext = new DataReceivedContext(Thread.CurrentThread, packet);

--- a/src/Build/BackEnd/Client/MSBuildClientPacketPump.cs
+++ b/src/Build/BackEnd/Client/MSBuildClientPacketPump.cs
@@ -126,6 +126,16 @@ namespace Microsoft.Build.BackEnd.Client
         }
 
         /// <summary>
+        /// Deserializes a packet.
+        /// </summary>
+        /// <param name="packetType">The packet type.</param>
+        /// <param name="translator">The translator to use as a source for packet data.</param>
+        public INodePacket DeserializePacket(NodePacketType packetType, ITranslator translator)
+        {
+            return _packetFactory.DeserializePacket(packetType, translator);
+        }
+
+        /// <summary>
         /// Routes a packet to the appropriate handler.
         /// </summary>
         /// <param name="nodeId">The node id from which the packet was received.</param>

--- a/src/Build/BackEnd/Components/Communications/NodeManager.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeManager.cs
@@ -256,6 +256,16 @@ namespace Microsoft.Build.BackEnd
         }
 
         /// <summary>
+        /// Takes a serializer and deserializes the packet.
+        /// </summary>
+        /// <param name="packetType">The packet type.</param>
+        /// <param name="translator">The translator containing the data from which the packet should be reconstructed.</param>
+        public INodePacket DeserializePacket(NodePacketType packetType, ITranslator translator)
+        {
+            return _packetFactory.DeserializePacket(packetType, translator);
+        }
+
+        /// <summary>
         /// Routes the specified packet. This is called by the Inproc node directly since it does not have to do any deserialization
         /// </summary>
         /// <param name="nodeId">The node from which the packet was received.</param>

--- a/src/Build/BackEnd/Components/Communications/NodeProviderInProc.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderInProc.cs
@@ -293,6 +293,16 @@ namespace Microsoft.Build.BackEnd
         }
 
         /// <summary>
+        /// Deserializes and routes a packet.  Not used in the in-proc node.
+        /// </summary>
+        public INodePacket DeserializePacket(NodePacketType packetType, ITranslator translator)
+        {
+            // Not used
+            ErrorUtilities.ThrowInternalErrorUnreachable();
+            return null;
+        }
+
+        /// <summary>
         /// Routes a packet.
         /// </summary>
         /// <param name="nodeId">The id of the node from which the packet is being routed.</param>

--- a/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcTaskHost.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcTaskHost.cs
@@ -288,6 +288,16 @@ namespace Microsoft.Build.BackEnd
         }
 
         /// <summary>
+        /// Takes a serializer and deserializes the packet.
+        /// </summary>
+        /// <param name="packetType">The packet type.</param>
+        /// <param name="translator">The translator containing the data from which the packet should be reconstructed.</param>
+        public INodePacket DeserializePacket(NodePacketType packetType, ITranslator translator)
+        {
+            return _localPacketFactory.DeserializePacket(packetType, translator);
+        }
+
+        /// <summary>
         /// Routes the specified packet
         /// </summary>
         /// <param name="nodeId">The node from which the packet was received.</param>

--- a/src/Build/BackEnd/Components/Communications/TaskHostNodeManager.cs
+++ b/src/Build/BackEnd/Components/Communications/TaskHostNodeManager.cs
@@ -150,6 +150,16 @@ namespace Microsoft.Build.BackEnd
         }
 
         /// <summary>
+        /// Takes a serializer, deserializes the packet and routes it to the appropriate handler.
+        /// </summary>
+        /// <param name="packetType">The packet type.</param>
+        /// <param name="translator">The translator containing the data from which the packet should be reconstructed.</param>
+        public INodePacket DeserializePacket(NodePacketType packetType, ITranslator translator)
+        {
+            throw new NotSupportedException("not used");
+        }
+
+        /// <summary>
         /// Routes the specified packet. This is called by the Inproc node directly since it does not have to do any deserialization
         /// </summary>
         /// <param name="nodeId">The node from which the packet was received.</param>

--- a/src/Build/BackEnd/Node/InProcNode.cs
+++ b/src/Build/BackEnd/Node/InProcNode.cs
@@ -223,6 +223,16 @@ namespace Microsoft.Build.BackEnd
         }
 
         /// <summary>
+        /// Not necessary for in-proc node - we don't serialize.
+        /// </summary>
+        public INodePacket DeserializePacket(NodePacketType packetType, ITranslator translator)
+        {
+            // The in-proc endpoint shouldn't be serializing, just routing.
+            ErrorUtilities.ThrowInternalError("Unexpected call to DeserializePacket on the in-proc node.");
+            return null;
+        }
+
+        /// <summary>
         /// Routes the packet to the appropriate handler.
         /// </summary>
         /// <param name="nodeId">The node id.</param>

--- a/src/Build/BackEnd/Node/OutOfProcNode.cs
+++ b/src/Build/BackEnd/Node/OutOfProcNode.cs
@@ -344,6 +344,16 @@ namespace Microsoft.Build.Execution
         }
 
         /// <summary>
+        /// Deserializes a packet.
+        /// </summary>
+        /// <param name="packetType">The packet type.</param>
+        /// <param name="translator">The translator to use as a source for packet data.</param>
+        INodePacket INodePacketFactory.DeserializePacket(NodePacketType packetType, ITranslator translator)
+        {
+            return _packetFactory.DeserializePacket(packetType, translator);
+        }
+
+        /// <summary>
         /// Routes a packet to the appropriate handler.
         /// </summary>
         /// <param name="nodeId">The node id from which the packet was received.</param>

--- a/src/Build/BackEnd/Node/OutOfProcServerNode.cs
+++ b/src/Build/BackEnd/Node/OutOfProcServerNode.cs
@@ -211,6 +211,16 @@ namespace Microsoft.Build.Experimental
         }
 
         /// <summary>
+        /// Deserializes a packet.
+        /// </summary>
+        /// <param name="packetType">The packet type.</param>
+        /// <param name="translator">The translator to use as a source for packet data.</param>
+        INodePacket INodePacketFactory.DeserializePacket(NodePacketType packetType, ITranslator translator)
+        {
+            return _packetFactory.DeserializePacket(packetType, translator);
+        }
+
+        /// <summary>
         /// Routes a packet to the appropriate handler.
         /// </summary>
         /// <param name="nodeId">The node id from which the packet was received.</param>

--- a/src/Build/Instance/TaskFactories/TaskHostTask.cs
+++ b/src/Build/Instance/TaskFactories/TaskHostTask.cs
@@ -375,6 +375,16 @@ namespace Microsoft.Build.BackEnd
         }
 
         /// <summary>
+        /// Takes a serializer and deserializes the packet.
+        /// </summary>
+        /// <param name="packetType">The packet type.</param>
+        /// <param name="translator">The translator containing the data from which the packet should be reconstructed.</param>
+        public INodePacket DeserializePacket(NodePacketType packetType, ITranslator translator)
+        {
+            return _packetFactory.DeserializePacket(packetType, translator);
+        }
+
+        /// <summary>
         /// Routes the specified packet
         /// </summary>
         /// <param name="nodeId">The node from which the packet was received.</param>

--- a/src/MSBuild/OutOfProcTaskHostNode.cs
+++ b/src/MSBuild/OutOfProcTaskHostNode.cs
@@ -592,6 +592,16 @@ namespace Microsoft.Build.CommandLine
         }
 
         /// <summary>
+        /// Takes a serializer and deserializes the packet.
+        /// </summary>
+        /// <param name="packetType">The packet type.</param>
+        /// <param name="translator">The translator containing the data from which the packet should be reconstructed.</param>
+        public INodePacket DeserializePacket(NodePacketType packetType, ITranslator translator)
+        {
+            return _packetFactory.DeserializePacket(packetType, translator);
+        }
+
+        /// <summary>
         /// Routes the specified packet
         /// </summary>
         /// <param name="nodeId">The node from which the packet was received.</param>

--- a/src/Shared/INodePacketFactory.cs
+++ b/src/Shared/INodePacketFactory.cs
@@ -43,7 +43,14 @@ namespace Microsoft.Build.BackEnd
         void DeserializeAndRoutePacket(int nodeId, NodePacketType packetType, ITranslator translator);
 
         /// <summary>
-        /// Routes the specified packet
+        /// Takes a serializer and deserializes the packet.
+        /// </summary>
+        /// <param name="packetType">The packet type.</param>
+        /// <param name="translator">The translator containing the data from which the packet should be reconstructed.</param>
+        INodePacket DeserializePacket(NodePacketType packetType, ITranslator translator);
+
+        /// <summary>
+        /// Routes the specified packet.
         /// </summary>
         /// <param name="nodeId">The node from which the packet was received.</param>
         /// <param name="packet">The packet to route.</param>

--- a/src/Shared/NodePipeBase.cs
+++ b/src/Shared/NodePipeBase.cs
@@ -226,7 +226,7 @@ namespace Microsoft.Build.Internal
         }
 
 #if !TASKHOST
-        private async Task<int> ReadAsync(byte[] buffer, int bytesToRead, CancellationToken cancellationToken)
+        private async ValueTask<int> ReadAsync(byte[] buffer, int bytesToRead, CancellationToken cancellationToken)
         {
             int totalBytesRead = 0;
             while (totalBytesRead < bytesToRead)

--- a/src/Shared/NodePipeBase.cs
+++ b/src/Shared/NodePipeBase.cs
@@ -226,7 +226,7 @@ namespace Microsoft.Build.Internal
         }
 
 #if !TASKHOST
-        private async ValueTask<int> ReadAsync(byte[] buffer, int bytesToRead, CancellationToken cancellationToken)
+        private async Task<int> ReadAsync(byte[] buffer, int bytesToRead, CancellationToken cancellationToken)
         {
             int totalBytesRead = 0;
             while (totalBytesRead < bytesToRead)

--- a/src/Shared/NodePipeClient.cs
+++ b/src/Shared/NodePipeClient.cs
@@ -84,7 +84,11 @@ namespace Microsoft.Build.Internal
             _pipeClient.WriteEndOfHandshakeSignal();
 
             CommunicationsUtilities.Trace("Reading handshake from pipe {0}", PipeName);
+#if NET
             _pipeClient.ReadEndOfHandshakeSignal(true, timeout);
+#else
+            _pipeClient.ReadEndOfHandshakeSignal(true);
+#endif
         }
     }
 }


### PR DESCRIPTION
### Context

Minimum change to get shared IPC added in #11546 recompiling again for #11383 (since the original PR was reverted).

### Changes Made

- Splits up `DeserializeAndRoutePacket()` in `PacketFactoryRecord` (private class)
- Adds `DeserializePacket()` to `INodePacketFactory` and all implementations. Does not remove old method.
- Adds ifdef's to shared pipe classes for compilation purposes

No behavior changes to MSBuild.

