### PR TITLE
Revert "Update assembly versions to latest for packages that recently shipped"

### DIFF
--- a/eng/Packages.props
+++ b/eng/Packages.props
@@ -34,7 +34,6 @@
     <PackageVersion Include="System.Text.Json" Version="$(SystemTextJsonVersion)" />
     <PackageVersion Include="System.Threading.Channels" Version="$(SystemThreadingChannelsVersion)" />
     <PackageVersion Include="System.Threading.Tasks.Dataflow" Version="$(SystemThreadingTasksDataflowVersion)" />
-    <PackageVersion Include="System.Threading.Tasks.Extensions" Version="$(SystemThreadingTasksExtensionsVersion)" />
     <PackageVersion Include="xunit.console" Version="$(XUnitVersion)" />
     <PackageVersion Include="Microsoft.VisualStudio.OpenTelemetry.Collector" Version="$(MicrosoftVisualStudioOpenTelemetryVersion)" />
     <PackageVersion Include="Microsoft.VisualStudio.OpenTelemetry.ClientExtensions" Version="$(MicrosoftVisualStudioOpenTelemetryVersion)" />

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -20,18 +20,28 @@
     <UsingToolVSSDK>true</UsingToolVSSDK>
   </PropertyGroup>
   <!-- Production Dependencies -->
-  <PropertyGroup>
-    <!-- manually maintained versions -->
+  <!-- Condition consumption of maintenance-packages dependencies based on source build.
+       This is to prevent "package downgrade" errors coming from other packages that are
+       already consuming the newest version of these same dependencies. -->
+  <PropertyGroup Condition="'$(DotNetBuildSourceOnly)' == 'true'">
+    <!-- Use newest package versions. -->
+    <SystemMemoryVersion>4.6.0</SystemMemoryVersion>
+    <SystemRuntimeCompilerServicesUnsafeVersion>6.1.0</SystemRuntimeCompilerServicesUnsafeVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(DotNetBuildSourceOnly)' != 'true'">
+    <!-- Keep using older versions. Upgrade carefully. -->
     <!--
         Modifying the version of System.Memory is very high impact and causes downstream breaks in third-party tooling that uses the MSBuild API.
         When updating the version of System.Memory file a breaking change here: https://github.com/dotnet/docs/issues/new?assignees=gewarren&labels=breaking-change%2CPri1%2Cdoc-idea&template=breaking-change.yml&title=%5BBreaking+change%5D%3A+
         and follow the guidelines written here (internal-link): https://dev.azure.com/devdiv/DevDiv/_wiki/wikis/DevDiv.wiki/1796/How-to-add-a-Known-Issue
     -->
-    <SystemMemoryVersion>4.6.0</SystemMemoryVersion>
-    <SystemThreadingTasksExtensionsVersion>4.6.0</SystemThreadingTasksExtensionsVersion>
-    <MicrosoftIORedistVersion>6.1.0</MicrosoftIORedistVersion>
+    <SystemMemoryVersion>4.5.5</SystemMemoryVersion>
+    <SystemRuntimeCompilerServicesUnsafeVersion>6.0.0</SystemRuntimeCompilerServicesUnsafeVersion>
+  </PropertyGroup>
+  <PropertyGroup>
+    <!-- manually maintained versions -->
+    <MicrosoftIORedistVersion>6.0.1</MicrosoftIORedistVersion>
     <MicrosoftVisualStudioOpenTelemetryVersion>0.2.104-beta</MicrosoftVisualStudioOpenTelemetryVersion>
-    <SystemRuntimeCompilerServicesUnsafeVersion>6.1.0</SystemRuntimeCompilerServicesUnsafeVersion>
     <SystemSecurityPrincipalWindowsVersion>5.0.0</SystemSecurityPrincipalWindowsVersion>
   </PropertyGroup>
   <PropertyGroup>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,7 +2,7 @@
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the MIT license. See License.txt in the project root for full license information. -->
 <Project>
   <PropertyGroup>
-    <VersionPrefix>17.14.0</VersionPrefix><DotNetFinalVersionKind>release</DotNetFinalVersionKind>
+    <VersionPrefix>17.14.1</VersionPrefix><DotNetFinalVersionKind>release</DotNetFinalVersionKind>
     <PackageValidationBaselineVersion>17.13.9</PackageValidationBaselineVersion>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>

--- a/src/MSBuild/app.amd64.config
+++ b/src/MSBuild/app.amd64.config
@@ -39,8 +39,8 @@
 
         <dependentAssembly>
           <assemblyIdentity name="Microsoft.IO.Redist" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-          <bindingRedirect oldVersion="0.0.0.0-6.1.0.0" newVersion="6.1.0.0" />
-          <codeBase version="6.1.0.0" href="..\Microsoft.IO.Redist.dll"/>
+          <bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="6.0.0.1" />
+          <codeBase version="6.0.0.1" href="..\Microsoft.IO.Redist.dll"/>
         </dependentAssembly>
 
         <!-- Redirects for assemblies redistributed by MSBuild (in the .vsix). -->
@@ -94,8 +94,8 @@
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-          <bindingRedirect oldVersion="0.0.0.0-4.0.4.0" newVersion="4.0.4.0" />
-          <codeBase version="4.0.4.0" href="..\System.Buffers.dll"/>
+          <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
+          <codeBase version="4.0.3.0" href="..\System.Buffers.dll"/>
         </dependentAssembly>
 
         <!-- Pull plugins that reference SCI up to our version in case they depended on our copy of the older version -->
@@ -190,13 +190,13 @@
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-          <bindingRedirect oldVersion="0.0.0.0-4.0.1.2" newVersion="4.0.2.0" />
-          <codeBase version="4.0.2.0" href="..\System.Memory.dll"/>
+          <bindingRedirect oldVersion="0.0.0.0-4.0.1.2" newVersion="4.0.1.2" />
+          <codeBase version="4.0.1.2" href="..\System.Memory.dll"/>
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="System.Numerics.Vectors" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-          <bindingRedirect oldVersion="0.0.0.0-4.1.5.0" newVersion="4.1.5.0" />
-          <codeBase version="4.1.5.0" href="..\System.Numerics.Vectors.dll"/>
+          <bindingRedirect oldVersion="0.0.0.0-4.1.4.0" newVersion="4.1.4.0" />
+          <codeBase version="4.1.4.0" href="..\System.Numerics.Vectors.dll"/>
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
@@ -215,8 +215,8 @@
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-          <bindingRedirect oldVersion="0.0.0.0-6.0.1.0" newVersion="6.0.1.0" />
-          <codeBase version="6.0.1.0" href="..\System.Runtime.CompilerServices.Unsafe.dll"/>
+          <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+          <codeBase version="6.0.0.0" href="..\System.Runtime.CompilerServices.Unsafe.dll"/>
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="System.Text.Encodings.Web" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
@@ -240,8 +240,8 @@
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-          <bindingRedirect oldVersion="0.0.0.0-4.2.1.0" newVersion="4.2.1.0" />
-          <codeBase version="4.2.1.0" href="..\System.Threading.Tasks.Extensions.dll"/>
+          <bindingRedirect oldVersion="0.0.0.0-4.2.0.1" newVersion="4.2.0.1" />
+          <codeBase version="4.2.0.1" href="..\System.Threading.Tasks.Extensions.dll"/>
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="System.ValueTuple" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />

--- a/src/MSBuild/app.config
+++ b/src/MSBuild/app.config
@@ -45,7 +45,7 @@
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="Microsoft.IO.Redist" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-          <bindingRedirect oldVersion="0.0.0.0-6.1.0.0" newVersion="6.1.0.0" />
+          <bindingRedirect oldVersion="0.0.0.0-6.0.0.1" newVersion="6.0.0.1" />
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="Microsoft.NET.StringTools" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
@@ -57,7 +57,7 @@
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-          <bindingRedirect oldVersion="0.0.0.0-4.0.4.0" newVersion="4.0.4.0" />
+          <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
         </dependentAssembly>
         <!-- Pull plugins that reference SCI up to our version in case they depended on our copy of the older version -->
         <dependentAssembly>
@@ -78,11 +78,11 @@
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-          <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0" />
+          <bindingRedirect oldVersion="0.0.0.0-4.0.1.2" newVersion="4.0.1.2" />
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="System.Numerics.Vectors" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-          <bindingRedirect oldVersion="0.0.0.0-4.1.5.0" newVersion="4.1.5.0" />
+          <bindingRedirect oldVersion="0.0.0.0-4.1.4.0" newVersion="4.1.4.0" />
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
@@ -98,7 +98,7 @@
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-          <bindingRedirect oldVersion="0.0.0.0-6.0.1.0" newVersion="6.0.1.0" />
+          <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="System.Text.Encodings.Web" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
@@ -114,7 +114,7 @@
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-          <bindingRedirect oldVersion="0.0.0.0-4.2.1.0" newVersion="4.2.1.0" />
+          <bindingRedirect oldVersion="0.0.0.0-4.2.0.1" newVersion="4.2.0.1" />
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="System.ValueTuple" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />


### PR DESCRIPTION
Reverts dotnet/msbuild#11038

It causes versioning issues. 