### PR TITLE
Embed .editorconfig in binary log

### DIFF
--- a/src/Build/BuildCheck/Infrastructure/EditorConfig/EditorConfigParser.cs
+++ b/src/Build/BuildCheck/Infrastructure/EditorConfig/EditorConfigParser.cs
@@ -12,6 +12,10 @@ namespace Microsoft.Build.Experimental.BuildCheck.Infrastructure.EditorConfig;
 
 internal sealed class EditorConfigParser
 {
+    // Define a static property to hold the editorConfigFilePath
+    private static ConcurrentBag<string> editorConfigFilePaths = new ConcurrentBag<string>();
+    public static IEnumerable<string> EditorConfigFilePaths => editorConfigFilePaths;
+
     private const string EditorconfigFile = ".editorconfig";
 
     /// <summary>
@@ -34,16 +38,15 @@ internal sealed class EditorConfigParser
         var editorConfigDataFromFilesList = new List<EditorConfigFile>();
 
         var directoryOfTheProject = Path.GetDirectoryName(filePath);
-        // The method will look for the file in parent directory if not found in current until found or the directory is root. 
+        // The method will look for the file in parent directory if not found in current until found or the directory is root.
         var editorConfigFilePath = FileUtilities.GetPathOfFileAbove(EditorconfigFile, directoryOfTheProject);
-
         while (editorConfigFilePath != string.Empty)
         {
             var editorConfig = _editorConfigFileCache.GetOrAdd(editorConfigFilePath, (key) =>
             {
                 return EditorConfigFile.Parse(File.ReadAllText(editorConfigFilePath));
             });
-
+            editorConfigFilePaths.Add(editorConfigFilePath);
             editorConfigDataFromFilesList.Add(editorConfig);
 
             if (editorConfig.IsRoot)
@@ -61,7 +64,7 @@ internal sealed class EditorConfigParser
     }
 
     /// <summary>
-    /// Retrieves the config dictionary from the sections that matched the filePath. 
+    /// Retrieves the config dictionary from the sections that matched the filePath.
     /// </summary>
     /// <param name="editorConfigFiles"></param>
     /// <param name="filePath"></param>

--- a/src/Build/BuildCheck/Infrastructure/EditorConfig/EditorConfigParser.cs
+++ b/src/Build/BuildCheck/Infrastructure/EditorConfig/EditorConfigParser.cs
@@ -30,6 +30,13 @@ internal sealed class EditorConfigParser
     }
 
     /// <summary>
+    /// Clears the editorConfigFilePaths collection after embedding in the binlog.
+    /// </summary>
+    public static void ClearEditorConfigFilePaths()
+    {
+        editorConfigFilePaths = new ConcurrentBag<string>();
+    }
+    /// <summary>
     /// Fetches the list of EditorconfigFile ordered from the nearest to the filePath.
     /// </summary>
     /// <param name="filePath"></param>

--- a/src/Build/BuildCheck/Infrastructure/EditorConfig/EditorConfigParser.cs
+++ b/src/Build/BuildCheck/Infrastructure/EditorConfig/EditorConfigParser.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Build.Experimental.BuildCheck.Infrastructure.EditorConfig;
 
 internal sealed class EditorConfigParser
 {
-    // Define a static property to hold the editorConfigFilePath
+    // static property for embedding resolved `.editorconfig`s in binlog
     private static ConcurrentBag<string> editorConfigFilePaths = new ConcurrentBag<string>();
     public static IEnumerable<string> EditorConfigFilePaths => editorConfigFilePaths;
 

--- a/src/Build/Logging/BinaryLogger/BinaryLogger.cs
+++ b/src/Build/Logging/BinaryLogger/BinaryLogger.cs
@@ -4,7 +4,6 @@
 using System;
 using System.IO;
 using System.IO.Compression;
-using System.Linq;
 using Microsoft.Build.Experimental.BuildCheck.Infrastructure.EditorConfig;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Framework.Telemetry;
@@ -324,12 +323,9 @@ namespace Microsoft.Build.Logging
             if (projectImportsCollector != null)
             {
                 // Write the build check editorconfig file paths to the log
-                if (EditorConfigParser.EditorConfigFilePaths.Any())
+                foreach (var filePath in EditorConfigParser.EditorConfigFilePaths)
                 {
-                    foreach (var filePath in EditorConfigParser.EditorConfigFilePaths)
-                    {
-                        projectImportsCollector.AddFile(filePath);
-                    }
+                    projectImportsCollector.AddFile(filePath);
                 }
                 projectImportsCollector.Close();
 

--- a/src/Build/Logging/BinaryLogger/BinaryLogger.cs
+++ b/src/Build/Logging/BinaryLogger/BinaryLogger.cs
@@ -327,6 +327,7 @@ namespace Microsoft.Build.Logging
                 {
                     projectImportsCollector.AddFile(filePath);
                 }
+                EditorConfigParser.ClearEditorConfigFilePaths();
                 projectImportsCollector.Close();
 
                 if (CollectProjectImports == ProjectImportsCollectionMode.Embed)

--- a/src/Build/Logging/BinaryLogger/BinaryLogger.cs
+++ b/src/Build/Logging/BinaryLogger/BinaryLogger.cs
@@ -4,6 +4,8 @@
 using System;
 using System.IO;
 using System.IO.Compression;
+using System.Linq;
+using Microsoft.Build.Experimental.BuildCheck.Infrastructure.EditorConfig;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Framework.Telemetry;
 using Microsoft.Build.Shared;
@@ -334,6 +336,15 @@ namespace Microsoft.Build.Logging
 
                 projectImportsCollector.FileIOExceptionEvent -= EventSource_AnyEventRaised;
                 projectImportsCollector = null;
+            }
+
+            // Write the build check editorconfig file paths to the log
+            if (EditorConfigParser.EditorConfigFilePaths.Any())
+            {
+                foreach (var filePath in EditorConfigParser.EditorConfigFilePaths)
+                {
+                    projectImportsCollector.AddFile(filePath);
+                }
             }
 
             if (stream != null)

--- a/src/Build/Logging/BinaryLogger/BinaryLogger.cs
+++ b/src/Build/Logging/BinaryLogger/BinaryLogger.cs
@@ -323,6 +323,14 @@ namespace Microsoft.Build.Logging
 
             if (projectImportsCollector != null)
             {
+                // Write the build check editorconfig file paths to the log
+                if (EditorConfigParser.EditorConfigFilePaths.Any())
+                {
+                    foreach (var filePath in EditorConfigParser.EditorConfigFilePaths)
+                    {
+                        projectImportsCollector.AddFile(filePath);
+                    }
+                }
                 projectImportsCollector.Close();
 
                 if (CollectProjectImports == ProjectImportsCollectionMode.Embed)
@@ -338,14 +346,6 @@ namespace Microsoft.Build.Logging
                 projectImportsCollector = null;
             }
 
-            // Write the build check editorconfig file paths to the log
-            if (EditorConfigParser.EditorConfigFilePaths.Any())
-            {
-                foreach (var filePath in EditorConfigParser.EditorConfigFilePaths)
-                {
-                    projectImportsCollector.AddFile(filePath);
-                }
-            }
 
             if (stream != null)
             {


### PR DESCRIPTION
Fixes [#10866](https://github.com/dotnet/msbuild/issues/10866)

### Context
Binary log (.binlog file) contains embedded files. For improved diagnostics, we should also embed BuildCheck .editorconfig file to the binary log.

### Changes Made
Use the static property to store all the .editorconfig file and call that in the BinaryLogger.cs Shutdown method.

### Testing
![image](https://github.com/user-attachments/assets/e1356f69-fe44-42e0-a1a0-9b15d9d65164)