### PR TITLE
Use newer maintenance-packages at runtime

### DIFF
--- a/eng/Packages.props
+++ b/eng/Packages.props
@@ -34,6 +34,7 @@
     <PackageVersion Include="System.Text.Json" Version="$(SystemTextJsonVersion)" />
     <PackageVersion Include="System.Threading.Channels" Version="$(SystemThreadingChannelsVersion)" />
     <PackageVersion Include="System.Threading.Tasks.Dataflow" Version="$(SystemThreadingTasksDataflowVersion)" />
+    <PackageVersion Include="System.Threading.Tasks.Extensions" Version="$(SystemThreadingTasksExtensionsVersion)" />
     <PackageVersion Include="xunit.console" Version="$(XUnitVersion)" />
     <PackageVersion Include="Microsoft.VisualStudio.OpenTelemetry.Collector" Version="$(MicrosoftVisualStudioOpenTelemetryVersion)" />
     <PackageVersion Include="Microsoft.VisualStudio.OpenTelemetry.ClientExtensions" Version="$(MicrosoftVisualStudioOpenTelemetryVersion)" />

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -24,8 +24,9 @@
     <!-- manually maintained versions -->
     <!--
         Modifying the version of System.Memory is very high impact and causes downstream breaks in third-party tooling that uses the MSBuild API.
-        When updating the version of System.Memory file a breaking change here: https://github.com/dotnet/docs/issues/new?assignees=gewarren&labels=breaking-change%2CPri1%2Cdoc-idea&template=breaking-change.yml&title=%5BBreaking+change%5D%3A+
-        and follow the guidelines written here (internal-link): https://dev.azure.com/devdiv/DevDiv/_wiki/wikis/DevDiv.wiki/1796/How-to-add-a-Known-Issue
+        As a result, we CONTINUE TO REFERENCE the old versions at build time, so those are the versions that get embedded into MSBuild assemblies.
+        However, we can update, binding-redirect to, and distribute the newest version (that matches the VS-referenced versions) in order to get the benefits of updating.
+        See uses of $(UseFrozenMaintenancePackageVersions) for details.
     -->
     <SystemMemoryVersion>4.6.0</SystemMemoryVersion>
     <SystemThreadingTasksExtensionsVersion>4.6.0</SystemThreadingTasksExtensionsVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,7 +2,7 @@
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the MIT license. See License.txt in the project root for full license information. -->
 <Project>
   <PropertyGroup>
-    <VersionPrefix>17.14.2</VersionPrefix><DotNetFinalVersionKind>release</DotNetFinalVersionKind>
+    <VersionPrefix>17.14.3</VersionPrefix><DotNetFinalVersionKind>release</DotNetFinalVersionKind>
     <PackageValidationBaselineVersion>17.13.9</PackageValidationBaselineVersion>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
@@ -20,28 +20,18 @@
     <UsingToolVSSDK>true</UsingToolVSSDK>
   </PropertyGroup>
   <!-- Production Dependencies -->
-  <!-- Condition consumption of maintenance-packages dependencies based on source build.
-       This is to prevent "package downgrade" errors coming from other packages that are
-       already consuming the newest version of these same dependencies. -->
-  <PropertyGroup Condition="'$(DotNetBuildSourceOnly)' == 'true'">
-    <!-- Use newest package versions. -->
-    <SystemMemoryVersion>4.6.0</SystemMemoryVersion>
-    <SystemRuntimeCompilerServicesUnsafeVersion>6.1.0</SystemRuntimeCompilerServicesUnsafeVersion>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(DotNetBuildSourceOnly)' != 'true'">
-    <!-- Keep using older versions. Upgrade carefully. -->
+  <PropertyGroup>
+    <!-- manually maintained versions -->
     <!--
         Modifying the version of System.Memory is very high impact and causes downstream breaks in third-party tooling that uses the MSBuild API.
         When updating the version of System.Memory file a breaking change here: https://github.com/dotnet/docs/issues/new?assignees=gewarren&labels=breaking-change%2CPri1%2Cdoc-idea&template=breaking-change.yml&title=%5BBreaking+change%5D%3A+
         and follow the guidelines written here (internal-link): https://dev.azure.com/devdiv/DevDiv/_wiki/wikis/DevDiv.wiki/1796/How-to-add-a-Known-Issue
     -->
-    <SystemMemoryVersion>4.5.5</SystemMemoryVersion>
-    <SystemRuntimeCompilerServicesUnsafeVersion>6.0.0</SystemRuntimeCompilerServicesUnsafeVersion>
-  </PropertyGroup>
-  <PropertyGroup>
-    <!-- manually maintained versions -->
-    <MicrosoftIORedistVersion>6.0.1</MicrosoftIORedistVersion>
+    <SystemMemoryVersion>4.6.0</SystemMemoryVersion>
+    <SystemThreadingTasksExtensionsVersion>4.6.0</SystemThreadingTasksExtensionsVersion>
+    <MicrosoftIORedistVersion>6.1.0</MicrosoftIORedistVersion>
     <MicrosoftVisualStudioOpenTelemetryVersion>0.2.104-beta</MicrosoftVisualStudioOpenTelemetryVersion>
+    <SystemRuntimeCompilerServicesUnsafeVersion>6.1.0</SystemRuntimeCompilerServicesUnsafeVersion>
     <SystemSecurityPrincipalWindowsVersion>5.0.0</SystemSecurityPrincipalWindowsVersion>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -139,7 +139,7 @@
   <Import Project="$(BUILD_STAGINGDIRECTORY)\MicroBuild\Plugins\MicroBuild.Plugins.IBCMerge.*\**\build\MicroBuild.Plugins.*.targets" Condition="'$(BUILD_STAGINGDIRECTORY)' != '' and $(TargetFramework.StartsWith('net4')) and '$(MicroBuild_EnablePGO)' != 'false'" />
 
   <PropertyGroup>
-    <UseFrozenMaintenancePackageVersions Condition="'$(UseFrozenMaintenancePackageVersions)' == '' AND $([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net472')) AND '$(OutputType)' != 'exe'">true</UseFrozenMaintenancePackageVersions>
+    <UseFrozenMaintenancePackageVersions Condition="'$(UseFrozenMaintenancePackageVersions)' == '' AND '$(IsUnitTestProject)' != 'true' AND $([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net472')) AND '$(OutputType)' != 'exe'">true</UseFrozenMaintenancePackageVersions>
 
     <FrozenMicrosoftIORedistVersion>6.0.1</FrozenMicrosoftIORedistVersion>
     <FrozenSystemMemoryVersion>4.5.5</FrozenSystemMemoryVersion>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -138,6 +138,52 @@
 
   <Import Project="$(BUILD_STAGINGDIRECTORY)\MicroBuild\Plugins\MicroBuild.Plugins.IBCMerge.*\**\build\MicroBuild.Plugins.*.targets" Condition="'$(BUILD_STAGINGDIRECTORY)' != '' and $(TargetFramework.StartsWith('net4')) and '$(MicroBuild_EnablePGO)' != 'false'" />
 
+  <PropertyGroup>
+    <UseFrozenMaintenancePackageVersions Condition="'$(UseFrozenMaintenancePackageVersions)' == '' AND $([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net472')) AND '$(OutputType)' != 'exe'">true</UseFrozenMaintenancePackageVersions>
+
+    <FrozenMicrosoftIORedistVersion>6.0.1</FrozenMicrosoftIORedistVersion>
+    <FrozenSystemMemoryVersion>4.5.5</FrozenSystemMemoryVersion>
+    <FrozenSystemRuntimeCompilerServicesUnsafeVersion>6.0.0</FrozenSystemRuntimeCompilerServicesUnsafeVersion>
+    <FrozenSystemThreadingTasksExtensionsVersion>4.5.4</FrozenSystemThreadingTasksExtensionsVersion>
+    <FrozenSystemBuffersVersion>4.5.1</FrozenSystemBuffersVersion>
+    <FrozenSystemNumericsVectorsVersion>4.5.0</FrozenSystemNumericsVectorsVersion>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(UseFrozenMaintenancePackageVersions)' == 'true'">
+    <PackageDownload Include="Microsoft.IO.Redist" Version="[$(FrozenMicrosoftIORedistVersion)]" />
+    <PackageDownload Include="System.Memory" Version="[$(FrozenSystemMemoryVersion)]" />
+    <PackageDownload Include="System.Runtime.CompilerServices.Unsafe" Version="[$(FrozenSystemRuntimeCompilerServicesUnsafeVersion)]" />
+    <PackageDownload Include="System.Threading.Tasks.Extensions" Version="[$(FrozenSystemThreadingTasksExtensionsVersion)]" />
+    <PackageDownload Include="System.Buffers" Version="[$(FrozenSystemBuffersVersion)]" />
+    <PackageDownload Include="System.Numerics.Vectors" Version="[$(FrozenSystemNumericsVectorsVersion)]" />
+  </ItemGroup>
+
+  <!-- Work around maintenance-packages updates breaking stuff -->
+  <Target Name="ReplaceCompileReferencesWithOlderMaintenancePackagesVersions"
+          BeforeTargets="ResolveAssemblyReferences"
+          Condition="$(UseFrozenMaintenancePackageVersions) == 'true'">
+
+    <ItemGroup>
+      <Reference Remove="@(Reference)" Condition="'%(Reference.NuGetPackageId)' == 'Microsoft.IO.Redist' and $([MSBuild]::VersionGreaterThan(%(Reference.NuGetPackageVersion), '$(FrozenMicrosoftIORedistVersion)'))" />
+      <Reference Include="$(NuGetPackageRoot)microsoft.io.redist\$(FrozenMicrosoftIORedistVersion)\lib\net472\Microsoft.IO.Redist.dll" />
+
+      <Reference Remove="@(Reference)" Condition="'%(Reference.NuGetPackageId)' == 'System.Buffers' and $([MSBuild]::VersionGreaterThan(%(Reference.NuGetPackageVersion), '$(FrozenSystemBuffersVersion)'))" />
+      <Reference Include="$(NuGetPackageRoot)system.buffers\$(FrozenSystemBuffersVersion)\lib\net461\System.Buffers.dll" />
+
+      <Reference Remove="@(Reference)" Condition="'%(Reference.NuGetPackageId)' == 'System.Memory' and $([MSBuild]::VersionGreaterThan(%(Reference.NuGetPackageVersion), '$(FrozenSystemMemoryVersion)'))" />
+      <Reference Include="$(NuGetPackageRoot)system.memory\$(FrozenSystemMemoryVersion)\lib\net461\System.Memory.dll" />
+
+      <Reference Remove="@(Reference)" Condition="'%(Reference.NuGetPackageId)' == 'System.Numerics.Vectors' and $([MSBuild]::VersionGreaterThan(%(Reference.NuGetPackageVersion), '$(FrozenSystemNumericsVectorsVersion)'))" />
+      <Reference Include="$(NuGetPackageRoot)system.numerics.vectors\$(FrozenSystemNumericsVectorsVersion)\lib\net46\System.Numerics.Vectors.dll" />
+
+      <Reference Remove="@(Reference)" Condition="'%(Reference.NuGetPackageId)' == 'System.Runtime.CompilerServices.Unsafe' and $([MSBuild]::VersionGreaterThan(%(Reference.NuGetPackageVersion), '$(FrozenSystemRuntimeCompilerServicesUnsafeVersion)'))" />
+      <Reference Include="$(NuGetPackageRoot)system.runtime.compilerservices.unsafe\$(FrozenSystemRuntimeCompilerServicesUnsafeVersion)\lib\net461\System.Runtime.CompilerServices.Unsafe.dll" />
+
+      <Reference Remove="@(Reference)" Condition="'%(Reference.NuGetPackageId)' == 'System.Threading.Tasks.Extensions' and $([MSBuild]::VersionGreaterThan(%(Reference.NuGetPackageVersion), '$(FrozenSystemThreadingTasksExtensionsVersion)'))" />
+      <Reference Include="$(NuGetPackageRoot)system.threading.tasks.extensions\$(FrozenSystemThreadingTasksExtensionsVersion)\lib\net461\System.Threading.Tasks.Extensions.dll" />
+    </ItemGroup>
+  </Target>
+
   <!-- Import parent targets -->
   <Import Project="..\Directory.Build.targets"/>
 

--- a/src/MSBuild.Bootstrap/MSBuild.Bootstrap.csproj
+++ b/src/MSBuild.Bootstrap/MSBuild.Bootstrap.csproj
@@ -9,6 +9,9 @@
     <ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>None</ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>
 
     <DeterministicSourcePaths>false</DeterministicSourcePaths>
+
+    <!-- The output of this project is sort of an "executable" so it can get the latest versions of everything. -->
+    <UseFrozenMaintenancePackageVersions>false</UseFrozenMaintenancePackageVersions>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/MSBuild/app.amd64.config
+++ b/src/MSBuild/app.amd64.config
@@ -39,8 +39,8 @@
 
         <dependentAssembly>
           <assemblyIdentity name="Microsoft.IO.Redist" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-          <bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="6.0.0.1" />
-          <codeBase version="6.0.0.1" href="..\Microsoft.IO.Redist.dll"/>
+          <bindingRedirect oldVersion="0.0.0.0-6.1.0.0" newVersion="6.1.0.0" />
+          <codeBase version="6.1.0.0" href="..\Microsoft.IO.Redist.dll"/>
         </dependentAssembly>
 
         <!-- Redirects for assemblies redistributed by MSBuild (in the .vsix). -->
@@ -94,8 +94,8 @@
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-          <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
-          <codeBase version="4.0.3.0" href="..\System.Buffers.dll"/>
+          <bindingRedirect oldVersion="0.0.0.0-4.0.4.0" newVersion="4.0.4.0" />
+          <codeBase version="4.0.4.0" href="..\System.Buffers.dll"/>
         </dependentAssembly>
 
         <!-- Pull plugins that reference SCI up to our version in case they depended on our copy of the older version -->
@@ -190,13 +190,13 @@
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-          <bindingRedirect oldVersion="0.0.0.0-4.0.1.2" newVersion="4.0.1.2" />
-          <codeBase version="4.0.1.2" href="..\System.Memory.dll"/>
+          <bindingRedirect oldVersion="0.0.0.0-4.0.1.2" newVersion="4.0.2.0" />
+          <codeBase version="4.0.2.0" href="..\System.Memory.dll"/>
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="System.Numerics.Vectors" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-          <bindingRedirect oldVersion="0.0.0.0-4.1.4.0" newVersion="4.1.4.0" />
-          <codeBase version="4.1.4.0" href="..\System.Numerics.Vectors.dll"/>
+          <bindingRedirect oldVersion="0.0.0.0-4.1.5.0" newVersion="4.1.5.0" />
+          <codeBase version="4.1.5.0" href="..\System.Numerics.Vectors.dll"/>
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
@@ -215,8 +215,8 @@
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-          <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
-          <codeBase version="6.0.0.0" href="..\System.Runtime.CompilerServices.Unsafe.dll"/>
+          <bindingRedirect oldVersion="0.0.0.0-6.0.1.0" newVersion="6.0.1.0" />
+          <codeBase version="6.0.1.0" href="..\System.Runtime.CompilerServices.Unsafe.dll"/>
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="System.Text.Encodings.Web" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
@@ -240,8 +240,8 @@
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-          <bindingRedirect oldVersion="0.0.0.0-4.2.0.1" newVersion="4.2.0.1" />
-          <codeBase version="4.2.0.1" href="..\System.Threading.Tasks.Extensions.dll"/>
+          <bindingRedirect oldVersion="0.0.0.0-4.2.1.0" newVersion="4.2.1.0" />
+          <codeBase version="4.2.1.0" href="..\System.Threading.Tasks.Extensions.dll"/>
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="System.ValueTuple" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />

--- a/src/MSBuild/app.amd64.config
+++ b/src/MSBuild/app.amd64.config
@@ -190,7 +190,7 @@
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-          <bindingRedirect oldVersion="0.0.0.0-4.0.1.2" newVersion="4.0.2.0" />
+          <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0" />
           <codeBase version="4.0.2.0" href="..\System.Memory.dll"/>
         </dependentAssembly>
         <dependentAssembly>

--- a/src/MSBuild/app.config
+++ b/src/MSBuild/app.config
@@ -45,7 +45,7 @@
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="Microsoft.IO.Redist" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-          <bindingRedirect oldVersion="0.0.0.0-6.0.0.1" newVersion="6.0.0.1" />
+          <bindingRedirect oldVersion="0.0.0.0-6.1.0.0" newVersion="6.1.0.0" />
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="Microsoft.NET.StringTools" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
@@ -57,7 +57,7 @@
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-          <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
+          <bindingRedirect oldVersion="0.0.0.0-4.0.4.0" newVersion="4.0.4.0" />
         </dependentAssembly>
         <!-- Pull plugins that reference SCI up to our version in case they depended on our copy of the older version -->
         <dependentAssembly>
@@ -78,11 +78,11 @@
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-          <bindingRedirect oldVersion="0.0.0.0-4.0.1.2" newVersion="4.0.1.2" />
+          <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0" />
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="System.Numerics.Vectors" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-          <bindingRedirect oldVersion="0.0.0.0-4.1.4.0" newVersion="4.1.4.0" />
+          <bindingRedirect oldVersion="0.0.0.0-4.1.5.0" newVersion="4.1.5.0" />
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
@@ -98,7 +98,7 @@
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-          <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+          <bindingRedirect oldVersion="0.0.0.0-6.0.1.0" newVersion="6.0.1.0" />
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="System.Text.Encodings.Web" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
@@ -114,7 +114,7 @@
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-          <bindingRedirect oldVersion="0.0.0.0-4.2.0.1" newVersion="4.2.0.1" />
+          <bindingRedirect oldVersion="0.0.0.0-4.2.1.0" newVersion="4.2.1.0" />
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="System.ValueTuple" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />

--- a/src/Package/DevDivPackage/DevDivPackage.csproj
+++ b/src/Package/DevDivPackage/DevDivPackage.csproj
@@ -2,6 +2,7 @@
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
   <PropertyGroup>
     <TargetFramework>$(FullFrameworkTFM)</TargetFramework>
+    <UseFrozenMaintenancePackageVersions>false</UseFrozenMaintenancePackageVersions>
     <NuspecFile>VS.ExternalAPIs.MSBuild.nuspec</NuspecFile>
     <IsShipping>false</IsShipping>
     <PlatformTarget>x86</PlatformTarget>

--- a/src/Samples/Directory.Build.props
+++ b/src/Samples/Directory.Build.props
@@ -16,6 +16,8 @@
 
     <IsShipping>false</IsShipping>
     <ExcludeFromSourceOnlyBuild>true</ExcludeFromSourceOnlyBuild>
+
+    <UseFrozenMaintenancePackageVersions>false</UseFrozenMaintenancePackageVersions>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
Visual Studio 17.14 updated to newer versions of the assemblies built in https://github.com/dotnet/maintenance-packages, which caused some performance regressions related to the mismatch between MSBuild.exe and devenv.exe dependencies (AB#2359731).

We hoped to fix this by taking the same update (#11038), but that caused functional problems: applications that use MSBuildLocator to build or manipulate projects using the MSBuild API are broken by updates to some dependencies (`System.Memory`, as in https://github.com/dotnet/msbuild/issues/7873#issuecomment-1227332842, and now `System.Threading.Task.Extensions`). This means that a straightforward update to those packages breaks all API consumers _including_ users of Roslyn's `MSBuildWorkspace`, since the `Microsoft.CodeAnalysis.Workspaces.MSBuild.BuildHost.exe` shipped in current versions of Roslyn uses `System.Threading.Tasks.Extensions` 4.2.0.1. We backed that out in #11659 to avoid the break.

After consulting with a great group of experts (thanks @ericstj, @ViktorHofer, @AArnott!), we arrived at this design:

* Continue building MSBuild assemblies against the same versions of the references that we did in 17.13.
* Ship and binding-redirect to the new (matched to VS) versions of the references.

This means that

1. an application that worked against 17.13 and is unchanged will continue working, since the assembly-level metadata that the .NET Framework assembly loader looks at is unchanged.
1. VS and `MSBuild.exe` dependency versions match at runtime.
1. VS and `MSBuild.exe` dependency versions are updated.
2. An application may choose to update and binding-redirect to newer versions, which is fine because the new assemblies are what we use in VS and `MSBuild.exe`.

An [experimental insertion](https://dev.azure.com/devdiv/DevDiv/_git/VS/pullrequest/624738) (Microsoft-internal link) validates that this fixes the `MethodsJitted` regression caused when VS updated, causing the mismatch.