### PR TITLE
Fix parallelism in test case EndToEndMinimumMessageImportance

### DIFF
--- a/src/MSBuild.UnitTests/XMake_Tests.cs
+++ b/src/MSBuild.UnitTests/XMake_Tests.cs
@@ -10,6 +10,7 @@ using System.IO.Compression;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Xml.Linq;
 using Microsoft.Build.CommandLine;
@@ -2712,9 +2713,12 @@ EndGlobal
             TransientTestProjectWithFiles testProject = testEnvironment.CreateTestProjectWithFiles(projectContents);
 
             // If /bl is specified, set a path for the binlog that is defined by the test environment
-            if (arguments.Contains("/bl"))
+            string pattern = @"/v:(\w+)\s/b"; ;
+            Regex.Match(arguments, pattern);
+            Match match = Regex.Match(arguments, pattern);
+            if (match.Success)
             {
-                string binlogPath = Path.Combine(testProject.TestRoot, "output.binlog");
+                string binlogPath = Path.Combine(testProject.TestRoot, match.Groups[1] + ".binlog");
                 arguments = arguments.Replace("/bl", $"/bl:{binlogPath}");
             }
 

--- a/src/MSBuild.UnitTests/XMake_Tests.cs
+++ b/src/MSBuild.UnitTests/XMake_Tests.cs
@@ -2711,6 +2711,13 @@ EndGlobal
 
             TransientTestProjectWithFiles testProject = testEnvironment.CreateTestProjectWithFiles(projectContents);
 
+            // If /bl is specified, set a path for the binlog that is defined by the test environment
+            if (arguments.Contains("/bl"))
+            {
+                string binlogPath = Path.Combine(testProject.TestRoot, "output.binlog");
+                arguments = arguments.Replace("/bl", $"/bl:{binlogPath}");
+            }
+
             // Build in-proc.
             RunnerUtilities.ExecMSBuild($"{arguments} \"{testProject.ProjectFile}\"", out bool success, _output);
             success.ShouldBeTrue();


### PR DESCRIPTION
Fixes [#11579](https://github.com/dotnet/msbuild/issues/11576)

### Context
MSBUILD : Logger error MSB4104: Failed to write to log file "S:\work\msb2\artifacts\bin\Microsoft.Build.CommandLine.UnitTests\Debug\net9.0\msbuild.binlog". The process cannot access the file 'S:\work\msb2\artifacts\bin\Microsoft.Build.CommandLine.UnitTests\Debug\net9.0\msbuild.binlog' because it is being used by another process.

### Changes Made
Specify a path for the binlog that is defined by the test environment, so it doesn't conflict.
