### PR TITLE
Move DotNetBuild properties into the repo

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -7,6 +7,11 @@
     <Description Condition="'$(Description)' == ''">$(TargetFileName)</Description>
   </PropertyGroup>
 
+  <!-- Disable package validation as source build filters out target frameworks. -->
+  <PropertyGroup Condition="'$(DotNetBuildSourceOnly)' == 'true'">
+    <EnablePackageValidation>false</EnablePackageValidation>
+  </PropertyGroup>
+
   <ItemGroup Condition=" '$(IsPackable)' == 'true' ">
     <None Include="$(ThirdPartyNotice)" Pack="true" PackagePath="notices" Visible="false" />
     <None Include="README.md" Pack="true" PackagePath="\" />

--- a/eng/Build.props
+++ b/eng/Build.props
@@ -6,11 +6,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-	<!-- Remove all sln files globbed by arcade so far and add only MSBuild.sln to the build.
-	Without this, arcade tries to build all three MSBuild solution at once, which leads to
-	locked file errors. -->
+    <!-- Remove all sln files globbed by arcade so far and add only MSBuild.sln to the build.
+         Without this, arcade tries to build all three MSBuild solution at once, which leads to
+         locked file errors. -->
     <ProjectToBuild Remove="@(ProjectToBuild)" />
-    <ProjectToBuild Include="$(RepoRoot)MSBuild.sln" />
+    <ProjectToBuild Include="$(RepoRoot)MSBuild.sln" Condition="'$(DotNetBuildSourceOnly)' != 'true'" />
+    <ProjectToBuild Include="$(RepoRoot)MSBuild.SourceBuild.slnf" Condition="'$(DotNetBuildSourceOnly)' == 'true'" />
   </ItemGroup>
 
 </Project>

--- a/eng/DotNetBuild.props
+++ b/eng/DotNetBuild.props
@@ -1,21 +1,9 @@
 <!-- When altering this file, include @dotnet/product-construction as a reviewer. -->
-
 <Project>
 
   <PropertyGroup>
     <GitHubRepositoryName>msbuild</GitHubRepositoryName>
     <SourceBuildManagedOnly>true</SourceBuildManagedOnly>
   </PropertyGroup>
-
-  <Target Name="ConfigureInnerBuildArgs" BeforeTargets="GetSourceBuildCommandConfiguration"
-          Condition="'$(DotNetBuildSourceOnly)' == 'true'">
-    <PropertyGroup>
-      <!-- Filter down projects aggressively in source-only modes. -->
-      <InnerBuildArgs>$(InnerBuildArgs) /p:Projects="$(InnerSourceBuildRepoRoot)MSBuild.SourceBuild.slnf"</InnerBuildArgs>
-
-      <!-- Disable package validation as source build filters out target frameworks. -->
-      <InnerBuildArgs>$(InnerBuildArgs) /p:EnablePackageValidation=false</InnerBuildArgs>
-    </PropertyGroup>
-  </Target>
 
 </Project>


### PR DESCRIPTION
This minimizes the differences between a DotNetBuild and repo build. This will eventually allow to converge the entry point paths.

Fixes #

### Context


### Changes Made


### Testing


### Notes
