### PR TITLE
perfstar branch creation gh action

### DIFF
--- a/.github/workflows/perfstar-branch.yml
+++ b/.github/workflows/perfstar-branch.yml
@@ -1,0 +1,47 @@
+name: Create Perf Branch on /perfstar comment
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  create_perf_branch:
+    if: |
+      github.event.issue.pull_request &&
+      github.event.comment.body == '/perfstar' &&
+      contains(fromJSON('["COLLABORATOR", "MEMBER", "OWNER"]'), github.event.comment.author_association)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get PR information
+        id: pr_info
+        run: |
+          PR_DATA=$(gh pr view ${{ github.event.issue.number }} --json headRefName,headRefOid)
+          echo "pr_head_branch=$(echo $PR_DATA | jq -r '.headRefName')" >> $GITHUB_OUTPUT
+          echo "pr_head_sha=$(echo $PR_DATA | jq -r '.headRefOid')" >> $GITHUB_OUTPUT
+          echo "new_branch_name=perf/$(echo $PR_DATA | jq -r '.headRefName')" >> $GITHUB_OUTPUT
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create and push perf branch
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          
+          # Create branch from PR head
+          git checkout -b ${{ steps.pr_info.outputs.new_branch_name }} ${{ steps.pr_info.outputs.pr_head_sha }}
+          
+          # Merge main branch
+          git fetch origin main
+          git merge origin/main --no-ff --no-edit -m "Merge main into ${{ steps.pr_info.outputs.new_branch_name }} for perf testing"
+          
+          # Push branch
+          git push origin ${{ steps.pr_info.outputs.new_branch_name }}

--- a/.github/workflows/perfstar-branch.yml
+++ b/.github/workflows/perfstar-branch.yml
@@ -24,10 +24,15 @@ jobs:
       - name: Get PR information
         id: pr_info
         run: |
-          PR_DATA=$(gh pr view ${{ github.event.issue.number }} --json headRefName,headRefOid)
-          echo "pr_head_branch=$(echo $PR_DATA | jq -r '.headRefName')" >> $GITHUB_OUTPUT
-          echo "pr_head_sha=$(echo $PR_DATA | jq -r '.headRefOid')" >> $GITHUB_OUTPUT
-          echo "new_branch_name=perf/$(echo $PR_DATA | jq -r '.headRefName')" >> $GITHUB_OUTPUT
+          PR_DATA=$(gh pr view ${{ github.event.issue.number }} --json headRefName,headRefOid,headRepository)
+          HEAD_REF=$(echo $PR_DATA | jq -r '.headRefName')
+          HEAD_SHA=$(echo $PR_DATA | jq -r '.headRefOid')
+          HEAD_REPO=$(echo $PR_DATA | jq -r '.headRepository.nameWithOwner')
+          
+          echo "pr_head_branch=${HEAD_REF}" >> $GITHUB_OUTPUT
+          echo "pr_head_sha=${HEAD_SHA}" >> $GITHUB_OUTPUT
+          echo "pr_head_repo=${HEAD_REPO}" >> $GITHUB_OUTPUT
+          echo "new_branch_name=perf/${HEAD_REF}" >> $GITHUB_OUTPUT
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -35,6 +40,9 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          
+          # Ensure we can access the PR's commits (especially important for forks)
+          git fetch origin pull/${{ github.event.issue.number }}/head:pr-${{ github.event.issue.number }}-head
           
           # Create branch from PR head
           git checkout -b ${{ steps.pr_info.outputs.new_branch_name }} ${{ steps.pr_info.outputs.pr_head_sha }}


### PR DESCRIPTION
workflow to speed up running perfstar on a PR, creates a new perf/ prefixed branch on comment by insiders. which has the PRs changes + merged main into it.

### Testing
https://github.com/JanProvaznik/actiontesting - this workflow successfully creates a new perf prefixed branch on /perfstar comment


### Usage
1. Someone  (external/internal) creates a PR
2. member of the dotnet org or collaborator [see gh docs](https://docs.github.com/en/graphql/reference/enums#commentauthorassociation) on this repo can comment `/perfstar` on the PR
3. the action runs, creates a branch in the repo `perf/original-pr-branch-name`
4. on this new branch prefixed with perf, the internal perfstar infrastructure runs and members of the team can look at the report