### PR TITLE
OutPut the PathTooLong when when longpath is disabled

### DIFF
--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -345,6 +345,11 @@ namespace Microsoft.Build.Evaluation
             {
                 evaluator.Evaluate();
             }
+            catch (Exception ex)
+            {
+                evaluator._evaluationLoggingContext.LogErrorFromText(null, null, null, new BuildEventFileInfo(root.ProjectFileLocation.File),
+                    ex.Message);
+            }
             finally
             {
                 IEnumerable globalProperties = null;

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -345,7 +345,7 @@ namespace Microsoft.Build.Evaluation
             {
                 evaluator.Evaluate();
             }
-            catch (Exception ex)
+            catch (PathTooLongException ex)
             {
                 evaluator._evaluationLoggingContext.LogErrorFromText(null, null, null, new BuildEventFileInfo(root.ProjectFileLocation.File),
                     ex.Message);

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -1045,6 +1045,13 @@ namespace Microsoft.Build.CommandLine
 
                 exitType = ExitType.Unexpected;
             }
+            catch (PathTooLongException e)
+            {
+                Console.WriteLine(
+                    $"{e.Message}{(e.InnerException != null ? $" {e.InnerException.Message}" : string.Empty)}");
+
+                exitType = ExitType.Unexpected;
+            }
             // handle fatal errors
             catch (Exception e)
             {

--- a/src/Shared/FileSystem/WindowsFileSystem.cs
+++ b/src/Shared/FileSystem/WindowsFileSystem.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Build.Shared.FileSystem
 
         public override bool DirectoryExists(string path)
         {
-            if (FileUtilities.IsPathTooLong(path))
+            if (!string.IsNullOrEmpty(path) && FileUtilities.IsPathTooLong(path))
             {
                 // If the path is too long, we can't check if it exists on windows
                 string message = ResourceUtilities.FormatString(AssemblyResources.GetString("Shared.PathTooLong"), path, NativeMethodsShared.MaxPath);

--- a/src/Shared/FileSystem/WindowsFileSystem.cs
+++ b/src/Shared/FileSystem/WindowsFileSystem.cs
@@ -55,6 +55,12 @@ namespace Microsoft.Build.Shared.FileSystem
 
         public override bool DirectoryExists(string path)
         {
+            if (FileUtilities.IsPathTooLong(path))
+            {
+                // If the path is too long, we can't check if it exists on windows
+                string message = ResourceUtilities.FormatString(AssemblyResources.GetString("Shared.PathTooLong"), path, NativeMethodsShared.MaxPath);
+                throw new PathTooLongException(message);
+            }
             return NativeMethodsShared.DirectoryExistsWindows(path);
         }
 

--- a/src/Shared/FileUtilities.cs
+++ b/src/Shared/FileUtilities.cs
@@ -1239,7 +1239,7 @@ namespace Microsoft.Build.Shared
             return FixFilePath(path);
         }
 
-        private static bool IsPathTooLong(string path)
+        public static bool IsPathTooLong(string path)
         {
             // >= not > because MAX_PATH assumes a trailing null
             return path.Length >= NativeMethodsShared.MaxPath;


### PR DESCRIPTION
Fixes [#10201](https://github.com/dotnet/msbuild/issues/10201)

### Context
When build with  dotnet sdk 9.0, during evaluation, it can't find the file Program.cs with main function
![image](https://github.com/user-attachments/assets/e4c133c2-ffd3-48e6-8927-ca7cdb4a35a4)

When build with MSBuild.exe, it has the following error
![image](https://github.com/user-attachments/assets/e8e57a06-3b9e-43a5-b7de-a8ddc7860c09)

### Changes Made
Throw the PathTooLongException exception in windows when the file path exceeds the maximum length
Catch the exception when evaluation and processing the msbuild.exe command.
### Testing
![image](https://github.com/user-attachments/assets/cbdad345-ede5-4b7a-bc83-e612269b79e6)

![image](https://github.com/user-attachments/assets/1f001ad0-0620-42e3-9348-316ffdd861a9)

### Notes
