### PR TITLE
Use correct separator character when parsing buildplan file

### DIFF
--- a/src/Build/BackEnd/Components/Scheduler/SchedulingPlan.cs
+++ b/src/Build/BackEnd/Components/Scheduler/SchedulingPlan.cs
@@ -400,7 +400,7 @@ namespace Microsoft.Build.BackEnd
                     return;
                 }
 
-                string[] values = line.Split(MSBuildConstants.SemicolonChar);
+                string[] values = line.Split(MSBuildConstants.SpaceChar);
                 if (values.Length < 3)
                 {
                     throw new InvalidDataException("Too few values in build plan.");


### PR DESCRIPTION
Fixes #11705

### Context
buildplan file written to disk by setting MSBUILDENABLEBUILDPLAN can't be read on the next build because the written file seperates datw with spaces while the reading expected semicolons

### Changes Made
Fixes bug introduced here: https://github.com/dotnet/msbuild/pull/4079/files#diff-8d669fb4d66fce73a89f3e6d364202f6095860780cacce11fa3561a6ab79a9fbR507
Space character was replaced with semicolon by accident.

### Testing


### Notes
