### PR TITLE
Suppress CodeQL warning dangerous deserialization that only happens in debug build

### DIFF
--- a/src/Build/Collections/RetrievableEntryHashSet/RetrievableEntryHashSet.cs
+++ b/src/Build/Collections/RetrievableEntryHashSet/RetrievableEntryHashSet.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Build.Collections
 #if FEATURE_SECURITY_PERMISSIONS
     [System.Security.Permissions.HostProtection(MayLeakOnAbort = true)]
 #endif
-    internal class RetrievableEntryHashSet<T> : IRetrievableEntryHashSet<T>
+    internal class RetrievableEntryHashSet<T> : IRetrievableEntryHashSet<T> // CodeQL [SM02227] The dangerous method is called only in debug build. It's safe for release build.
         where T : class, IKeyed
     {
         // store lower 31 bits of hash code

--- a/src/Build/Errors/InvalidToolsetDefinitionException.cs
+++ b/src/Build/Errors/InvalidToolsetDefinitionException.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Build.Exceptions
     /// Exception subclass that ToolsetReaders should throw.
     /// </summary>
     [Serializable]
-    public class InvalidToolsetDefinitionException : BuildExceptionBase
+    public class InvalidToolsetDefinitionException : BuildExceptionBase // CodeQL [SM02227] The dangerous method is called only in debug build. It's safe for release build.
     {
         /// <summary>
         /// The MSBuild error code corresponding with this exception.

--- a/src/MSBuild/CommandLineSwitchException.cs
+++ b/src/MSBuild/CommandLineSwitchException.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Build.CommandLine
     /// This exception is used to flag (syntax) errors in command line switches passed to the application.
     /// </summary>
     [Serializable]
-    internal sealed class CommandLineSwitchException : Exception
+    internal sealed class CommandLineSwitchException : Exception // CodeQL [SM02227] The dangerous method is called only in debug build. It's safe for release build.
     {
         /// <summary>
         /// This constructor initializes the exception message.

--- a/src/MSBuild/InitializationException.cs
+++ b/src/MSBuild/InitializationException.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Build.CommandLine
     /// Unlike the CommandLineSwitchException, this exception is NOT thrown for syntax errors in switches.
     /// </remarks>
     [Serializable]
-    internal sealed class InitializationException : Exception
+    internal sealed class InitializationException : Exception // CodeQL [SM02227] The dangerous method is called only in debug build. It's safe for release build.
     {
         /// <summary>
         /// This constructor initializes the exception message.


### PR DESCRIPTION
Fixes - CodeQL isssue dangerous deserialization

### Context
CodeQL issue dangerous deserialization below only happens in debug build by checking the code flows. It's safe for release build. 
[src/MSBuild/CommandLineSwitchException.cs : 20](https://codeql.microsoft.com/issues/65c9b22f-93ab-42b1-9e95-4542cc643038?Context=sdl)
[src/MSBuild/InitializationException.cs : 25](https://codeql.microsoft.com/issues/679d318f-89cf-4261-9171-db10ec4ab3bf?Context=sdl)
[src/Build/Collections/RetrievableEntryHashSet/RetrievableEntryHashSet.cs : 85](https://codeql.microsoft.com/issues/6debd16f-8bc8-42ef-82b6-9b65fb379850?Context=sdl)
[src/Build/Errors/InvalidToolsetDefinitionException.cs : 21](https://codeql.microsoft.com/issues/d634837c-340f-4981-a54c-325722834832?Context=sdl)

### Changes Made
Add the comment to suppress the warning.

