### PR TITLE
Resolve ide0040, ide0051, ide0052, ide0350 warnings

### DIFF
--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -2405,7 +2405,7 @@ namespace Microsoft.Build.Execution
             {
                 // Resource request requires a response and may be blocking. Our continuation is effectively a callback
                 // to be called once at least one core becomes available.
-                _scheduler!.RequestCores(request.GlobalRequestId, request.NumCores, request.IsBlocking).ContinueWith((Task<int> task) =>
+                _scheduler!.RequestCores(request.GlobalRequestId, request.NumCores, request.IsBlocking).ContinueWith((task) =>
                 {
                     var response = new ResourceResponse(request.GlobalRequestId, task.Result);
                     _nodeManager!.SendData(node, response);

--- a/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
@@ -881,23 +881,6 @@ namespace Microsoft.Build.BackEnd
                 _process.KillTree(timeoutMilliseconds: 5000);
             }
 
-#if FEATURE_APM
-            /// <summary>
-            /// Completes the asynchronous packet write to the node.
-            /// </summary>
-            private void PacketWriteComplete(IAsyncResult result)
-            {
-                try
-                {
-                    _serverToClientStream.EndWrite(result);
-                }
-                catch (IOException)
-                {
-                    // Do nothing here because any exception will be caught by the async read handler
-                }
-            }
-#endif
-
             private bool ProcessHeaderBytesRead(int bytesRead)
             {
                 if (bytesRead != _headerByte.Length)

--- a/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
@@ -497,7 +497,7 @@ namespace Microsoft.Build.BackEnd
             // a queue of pending requests.
             ResourceResponse responseObject = null;
             using AutoResetEvent responseEvent = new AutoResetEvent(false);
-            _pendingResourceRequests.Enqueue((ResourceResponse response) =>
+            _pendingResourceRequests.Enqueue((response) =>
             {
                 responseObject = response;
                 responseEvent.Set();

--- a/src/Build/BackEnd/Components/RequestBuilder/TargetEntry.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TargetEntry.cs
@@ -149,11 +149,6 @@ namespace Microsoft.Build.BackEnd
         private bool _isExecuting;
 
         /// <summary>
-        /// The current task builder.
-        /// </summary>
-        private ITaskBuilder _currentTaskBuilder;
-
-        /// <summary>
         /// The constructor.
         /// </summary>
         /// <param name="requestEntry">The build request entry for the target.</param>
@@ -816,46 +811,36 @@ namespace Microsoft.Build.BackEnd
             WorkUnitActionCode finalActionCode = WorkUnitActionCode.Continue;
             WorkUnitResult lastResult = new WorkUnitResult(WorkUnitResultCode.Success, WorkUnitActionCode.Continue, null);
 
-            try
+            int currentTask = 0;
+
+            // Walk through all of the tasks and execute them in order.
+            for (; (currentTask < _target.Children.Count) && !_cancellationToken.IsCancellationRequested; ++currentTask)
             {
-                // Grab the task builder so if cancel is called it will have something to operate on.
-                _currentTaskBuilder = taskBuilder;
+                ProjectTargetInstanceChild targetChildInstance = _target.Children[currentTask];
 
-                int currentTask = 0;
+                // Execute the task.
+                lastResult = await taskBuilder.ExecuteTask(targetLoggingContext, _requestEntry, _targetBuilderCallback, targetChildInstance, mode, lookupForInference, lookupForExecution, _cancellationToken);
 
-                // Walk through all of the tasks and execute them in order.
-                for (; (currentTask < _target.Children.Count) && !_cancellationToken.IsCancellationRequested; ++currentTask)
+                if (lastResult.ResultCode == WorkUnitResultCode.Failed)
                 {
-                    ProjectTargetInstanceChild targetChildInstance = _target.Children[currentTask];
-
-                    // Execute the task.
-                    lastResult = await taskBuilder.ExecuteTask(targetLoggingContext, _requestEntry, _targetBuilderCallback, targetChildInstance, mode, lookupForInference, lookupForExecution, _cancellationToken);
-
-                    if (lastResult.ResultCode == WorkUnitResultCode.Failed)
-                    {
-                        aggregatedTaskResult = WorkUnitResultCode.Failed;
-                    }
-                    else if (lastResult.ResultCode == WorkUnitResultCode.Success && aggregatedTaskResult != WorkUnitResultCode.Failed)
-                    {
-                        aggregatedTaskResult = WorkUnitResultCode.Success;
-                    }
-
-                    if (lastResult.ActionCode == WorkUnitActionCode.Stop)
-                    {
-                        finalActionCode = WorkUnitActionCode.Stop;
-                        break;
-                    }
+                    aggregatedTaskResult = WorkUnitResultCode.Failed;
+                }
+                else if (lastResult.ResultCode == WorkUnitResultCode.Success && aggregatedTaskResult != WorkUnitResultCode.Failed)
+                {
+                    aggregatedTaskResult = WorkUnitResultCode.Success;
                 }
 
-                if (_cancellationToken.IsCancellationRequested)
+                if (lastResult.ActionCode == WorkUnitActionCode.Stop)
                 {
-                    aggregatedTaskResult = WorkUnitResultCode.Canceled;
                     finalActionCode = WorkUnitActionCode.Stop;
+                    break;
                 }
             }
-            finally
+
+            if (_cancellationToken.IsCancellationRequested)
             {
-                _currentTaskBuilder = null;
+                aggregatedTaskResult = WorkUnitResultCode.Canceled;
+                finalActionCode = WorkUnitActionCode.Stop;
             }
 
             return new WorkUnitResult(aggregatedTaskResult, finalActionCode, lastResult.Exception);

--- a/src/Build/BackEnd/Components/Scheduler/Scheduler.cs
+++ b/src/Build/BackEnd/Components/Scheduler/Scheduler.cs
@@ -579,7 +579,7 @@ namespace Microsoft.Build.BackEnd
                 return Task.FromResult(0);
             }
 
-            Func<int, int> grantCores = (int availableCores) =>
+            Func<int, int> grantCores = (availableCores) =>
             {
                 int grantedCores = Math.Min(requestedCores, availableCores);
                 if (grantedCores > 0)
@@ -599,7 +599,7 @@ namespace Microsoft.Build.BackEnd
                 // We have no cores to grant at the moment, queue up the request.
                 TaskCompletionSource<int> completionSource = new TaskCompletionSource<int>();
                 _pendingRequestCoresCallbacks.Enqueue(completionSource);
-                return completionSource.Task.ContinueWith((Task<int> task) => grantCores(task.Result), TaskContinuationOptions.ExecuteSynchronously);
+                return completionSource.Task.ContinueWith((task) => grantCores(task.Result), TaskContinuationOptions.ExecuteSynchronously);
             }
         }
 

--- a/src/Build/BackEnd/Components/Scheduler/SchedulingPlan.cs
+++ b/src/Build/BackEnd/Components/Scheduler/SchedulingPlan.cs
@@ -111,7 +111,7 @@ namespace Microsoft.Build.BackEnd
                     RecursiveAccumulateConfigurationTimes(rootRequest, accumulatedTimeByConfiguration);
 
                     List<KeyValuePair<int, double>> configurationsInOrder = new(accumulatedTimeByConfiguration);
-                    configurationsInOrder.Sort((KeyValuePair<int, double> l, KeyValuePair<int, double> r) => Comparer<int>.Default.Compare(l.Key, r.Key));
+                    configurationsInOrder.Sort((l, r) => Comparer<int>.Default.Compare(l.Key, r.Key));
                     foreach (KeyValuePair<int, double> configuration in configurationsInOrder)
                     {
                         file.WriteLine(String.Format(CultureInfo.InvariantCulture, "{0} {1} {2}", configuration.Key, configuration.Value, _configCache[configuration.Key].ProjectFullPath));

--- a/src/Build/BuildCheck/Infrastructure/BuildCheckBuildEventHandler.cs
+++ b/src/Build/BuildCheck/Infrastructure/BuildCheckBuildEventHandler.cs
@@ -28,25 +28,25 @@ internal class BuildCheckBuildEventHandler
 
         _eventHandlersFull = new()
         {
-            { typeof(BuildSubmissionStartedEventArgs), (BuildEventArgs e) => HandleBuildSubmissionStartedEvent((BuildSubmissionStartedEventArgs)e) },
-            { typeof(ProjectEvaluationFinishedEventArgs), (BuildEventArgs e) => HandleProjectEvaluationFinishedEvent((ProjectEvaluationFinishedEventArgs)e) },
-            { typeof(ProjectEvaluationStartedEventArgs), (BuildEventArgs e) => HandleProjectEvaluationStartedEvent((ProjectEvaluationStartedEventArgs)e) },
-            { typeof(EnvironmentVariableReadEventArgs), (BuildEventArgs e) => HandleEnvironmentVariableReadEvent((EnvironmentVariableReadEventArgs)e) },
-            { typeof(ProjectStartedEventArgs), (BuildEventArgs e) => HandleProjectStartedRequest((ProjectStartedEventArgs)e) },
-            { typeof(ProjectFinishedEventArgs), (BuildEventArgs e) => HandleProjectFinishedRequest((ProjectFinishedEventArgs)e) },
-            { typeof(BuildCheckTracingEventArgs), (BuildEventArgs e) => HandleBuildCheckTracingEvent((BuildCheckTracingEventArgs)e) },
-            { typeof(BuildCheckAcquisitionEventArgs), (BuildEventArgs e) => HandleBuildCheckAcquisitionEvent((BuildCheckAcquisitionEventArgs)e) },
-            { typeof(TaskStartedEventArgs), (BuildEventArgs e) => HandleTaskStartedEvent((TaskStartedEventArgs)e) },
-            { typeof(TaskFinishedEventArgs), (BuildEventArgs e) => HandleTaskFinishedEvent((TaskFinishedEventArgs)e) },
-            { typeof(TaskParameterEventArgs), (BuildEventArgs e) => HandleTaskParameterEvent((TaskParameterEventArgs)e) },
-            { typeof(BuildFinishedEventArgs), (BuildEventArgs e) => HandleBuildFinishedEvent((BuildFinishedEventArgs)e) },
-            { typeof(ProjectImportedEventArgs), (BuildEventArgs e) => HandleProjectImportedEvent((ProjectImportedEventArgs)e) },
+            { typeof(BuildSubmissionStartedEventArgs), (e) => HandleBuildSubmissionStartedEvent((BuildSubmissionStartedEventArgs)e) },
+            { typeof(ProjectEvaluationFinishedEventArgs), (e) => HandleProjectEvaluationFinishedEvent((ProjectEvaluationFinishedEventArgs)e) },
+            { typeof(ProjectEvaluationStartedEventArgs), (e) => HandleProjectEvaluationStartedEvent((ProjectEvaluationStartedEventArgs)e) },
+            { typeof(EnvironmentVariableReadEventArgs), (e) => HandleEnvironmentVariableReadEvent((EnvironmentVariableReadEventArgs)e) },
+            { typeof(ProjectStartedEventArgs), (e) => HandleProjectStartedRequest((ProjectStartedEventArgs)e) },
+            { typeof(ProjectFinishedEventArgs), (e) => HandleProjectFinishedRequest((ProjectFinishedEventArgs)e) },
+            { typeof(BuildCheckTracingEventArgs), (e) => HandleBuildCheckTracingEvent((BuildCheckTracingEventArgs)e) },
+            { typeof(BuildCheckAcquisitionEventArgs), (e) => HandleBuildCheckAcquisitionEvent((BuildCheckAcquisitionEventArgs)e) },
+            { typeof(TaskStartedEventArgs), (e) => HandleTaskStartedEvent((TaskStartedEventArgs)e) },
+            { typeof(TaskFinishedEventArgs), (e) => HandleTaskFinishedEvent((TaskFinishedEventArgs)e) },
+            { typeof(TaskParameterEventArgs), (e) => HandleTaskParameterEvent((TaskParameterEventArgs)e) },
+            { typeof(BuildFinishedEventArgs), (e) => HandleBuildFinishedEvent((BuildFinishedEventArgs)e) },
+            { typeof(ProjectImportedEventArgs), (e) => HandleProjectImportedEvent((ProjectImportedEventArgs)e) },
         };
 
         // During restore we'll wait only for restore to be done.
         _eventHandlersRestore = new()
         {
-            { typeof(BuildSubmissionStartedEventArgs), (BuildEventArgs e) => HandleBuildSubmissionStartedEvent((BuildSubmissionStartedEventArgs)e) },
+            { typeof(BuildSubmissionStartedEventArgs), (e) => HandleBuildSubmissionStartedEvent((BuildSubmissionStartedEventArgs)e) },
         };
 
         _eventHandlers = _eventHandlersFull;

--- a/src/Build/BuildCheck/Infrastructure/BuildCheckConnectorLogger.cs
+++ b/src/Build/BuildCheck/Infrastructure/BuildCheckConnectorLogger.cs
@@ -16,15 +16,11 @@ namespace Microsoft.Build.Experimental.BuildCheck.Infrastructure;
 internal sealed class BuildCheckConnectorLogger : ILogger
 {
     private readonly BuildCheckBuildEventHandler _eventHandler;
-    private readonly IBuildCheckManager _buildCheckManager;
-    private readonly ICheckContextFactory _checkContextFactory;
 
     internal BuildCheckConnectorLogger(
         ICheckContextFactory checkContextFactory,
         IBuildCheckManager buildCheckManager)
     {
-        _buildCheckManager = buildCheckManager;
-        _checkContextFactory = checkContextFactory;
         _eventHandler = new BuildCheckBuildEventHandler(checkContextFactory, buildCheckManager);
     }
 

--- a/src/Build/BuildCheck/OM/BuildCheckDataContext.cs
+++ b/src/Build/BuildCheck/OM/BuildCheckDataContext.cs
@@ -16,9 +16,9 @@ public abstract class CheckData(string projectFilePath, int? projectConfiguratio
 {
     private string? _projectFileDirectory;
     // The id is going to be used in future revision
-#pragma warning disable CA1823
+#pragma warning disable CA1823, IDE0052
     private int? _projectConfigurationId = projectConfigurationId;
-#pragma warning restore CA1823
+#pragma warning restore CA1823, IDE0052
 
     /// <summary>
     /// Full path to the project file being built.

--- a/src/Build/Definition/Project.cs
+++ b/src/Build/Definition/Project.cs
@@ -3815,7 +3815,7 @@ namespace Microsoft.Build.Evaluation
 
                 // Cause the project to be actually loaded into the collection, and register for
                 // rename notifications so we can subsequently update the collection.
-                _renameHandler = (string oldFullPath) => ProjectCollection.OnAfterRenameLoadedProject(oldFullPath, Owner);
+                _renameHandler = (oldFullPath) => ProjectCollection.OnAfterRenameLoadedProject(oldFullPath, Owner);
 
                 Xml.OnAfterProjectRename += _renameHandler;
                 Xml.OnProjectXmlChanged += ProjectRootElement_ProjectXmlChangedHandler;

--- a/src/Build/Definition/ToolsetReader.cs
+++ b/src/Build/Definition/ToolsetReader.cs
@@ -28,11 +28,6 @@ namespace Microsoft.Build.Evaluation
     internal abstract class ToolsetReader
     {
         /// <summary>
-        /// The global properties used to read the toolset.
-        /// </summary>
-        private PropertyDictionary<ProjectPropertyInstance> _globalProperties;
-
-        /// <summary>
         /// The environment properties used to read the toolset.
         /// </summary>
         private readonly PropertyDictionary<ProjectPropertyInstance> _environmentProperties;
@@ -45,7 +40,6 @@ namespace Microsoft.Build.Evaluation
             PropertyDictionary<ProjectPropertyInstance> globalProperties)
         {
             _environmentProperties = environmentProperties;
-            _globalProperties = globalProperties;
         }
 
         /// <summary>

--- a/src/Build/Evaluation/LazyItemEvaluator.OrderedItemDataCollection.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.OrderedItemDataCollection.cs
@@ -41,7 +41,6 @@ namespace Microsoft.Build.Evaluation
 
                 #region IEnumerable implementation
 
-                private ImmutableList<ItemData>.Enumerator GetEnumerator() => _listBuilder.GetEnumerator();
                 IEnumerator<ItemData> IEnumerable<ItemData>.GetEnumerator() => _listBuilder.GetEnumerator();
 
                 System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => _listBuilder.GetEnumerator();

--- a/src/Build/Graph/GraphBuilder.cs
+++ b/src/Build/Graph/GraphBuilder.cs
@@ -662,8 +662,10 @@ namespace Microsoft.Build.Graph
             {
                 ReferenceItems.AddOrUpdate(
                     key,
+#pragma warning disable IDE0350
                     addValueFactory: static ((ProjectGraphNode node, ProjectGraphNode reference) key, ProjectItemInstance referenceItem) => referenceItem,
                     updateValueFactory: static ((ProjectGraphNode node, ProjectGraphNode reference) key, ProjectItemInstance existingItem, ProjectItemInstance newItem) =>
+#pragma warning restore IDE0350
                     {
                         string existingTargetsMetadata = existingItem.GetMetadataValue(ItemMetadataNames.ProjectReferenceTargetsMetadataName);
                         string newTargetsMetadata = newItem.GetMetadataValue(ItemMetadataNames.ProjectReferenceTargetsMetadataName);

--- a/src/Build/Instance/ImmutableProjectCollections/ImmutableItemDictionary.cs
+++ b/src/Build/Instance/ImmutableProjectCollections/ImmutableItemDictionary.cs
@@ -175,13 +175,11 @@ namespace Microsoft.Build.Instance
 
         private sealed class ListConverter : ICollection<T>
         {
-            private readonly string _itemType;
             private readonly ICollection<TCached> _list;
             private readonly Func<TCached, T?> _getInstance;
 
             public ListConverter(string itemType, ICollection<TCached> list, Func<TCached, T?> getInstance)
             {
-                _itemType = itemType;
                 _list = list;
                 _getInstance = getInstance;
             }

--- a/src/Build/Instance/ProjectItemInstance.cs
+++ b/src/Build/Instance/ProjectItemInstance.cs
@@ -1085,6 +1085,7 @@ namespace Microsoft.Build.Execution
                 _directMetadata.ImportProperties(metadata.Select(kvp => new ProjectMetadataInstance(kvp.Key, kvp.Value, allowItemSpecModifiers: true)));
             }
 
+#if FEATURE_APPDOMAIN
             /// <summary>
             /// Used to return metadata from another AppDomain. Can't use yield return because the
             /// generated state machine is not marked as [Serializable], so we need to allocate.
@@ -1106,6 +1107,7 @@ namespace Microsoft.Build.Execution
                 // Probably better to send the raw array across the wire even if it's another allocation.
                 return result.ToArray();
             }
+#endif
 
             private IEnumerable<KeyValuePair<string, string>> EnumerateMetadata(ICopyOnWritePropertyDictionary<ProjectMetadataInstance> list)
             {

--- a/src/Build/Logging/ParallelLogger/ParallelConsoleLogger.cs
+++ b/src/Build/Logging/ParallelLogger/ParallelConsoleLogger.cs
@@ -1402,22 +1402,6 @@ namespace Microsoft.Build.BackEnd.Logging
         }
 
         /// <summary>
-        /// Write message taking into account whether or not the prefix (timestamp and key) have already been written on the line
-        /// </summary>
-        private void WriteBasedOnPrefix(string nonNullMessage, bool prefixAlreadyWritten, int adjustedPrefixWidth)
-        {
-            if (prefixAlreadyWritten)
-            {
-                WriteHandler(nonNullMessage + Environment.NewLine);
-            }
-            else
-            {
-                // No prefix info has been written, indent the line to the proper location
-                WriteHandler(IndentString(nonNullMessage, adjustedPrefixWidth));
-            }
-        }
-
-        /// <summary>
         /// Will display the target started event which was deferred until the first visible message for the target is ready to be displayed
         /// </summary>
         private void DisplayDeferredTargetStartedEvent(BuildEventContext e)

--- a/src/MSBuild/MSBuildClientApp.cs
+++ b/src/MSBuild/MSBuildClientApp.cs
@@ -97,28 +97,5 @@ namespace Microsoft.Build.CommandLine
 
             return MSBuildApp.ExitType.MSBuildClientFailure;
         }
-
-        // Copied from NodeProviderOutOfProcBase.cs
-#if RUNTIME_TYPE_NETCORE
-        private static string? CurrentHost;
-        private static string GetCurrentHost()
-        {
-            if (CurrentHost == null)
-            {
-                string dotnetExe = Path.Combine(FileUtilities.GetFolderAbove(BuildEnvironmentHelper.Instance.CurrentMSBuildToolsDirectory, 2),
-                    NativeMethodsShared.IsWindows ? "dotnet.exe" : "dotnet");
-                if (File.Exists(dotnetExe))
-                {
-                    CurrentHost = dotnetExe;
-                }
-                else
-                {
-                    CurrentHost = EnvironmentUtilities.ProcessPath ?? throw new InvalidOperationException("Failed to retrieve process executable.");
-                }
-            }
-
-            return CurrentHost;
-        }
-#endif
     }
 }

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -4526,6 +4526,7 @@ namespace Microsoft.Build.CommandLine
             }
         }
 
+#if FEATURE_XML_SCHEMA_VALIDATION
         /// <summary>
         /// Figures out if the project needs to be validated against a schema.
         /// </summary>
@@ -4546,6 +4547,7 @@ namespace Microsoft.Build.CommandLine
 
             return schemaFile;
         }
+#endif
 
         /// <summary>
         /// Given an invalid ToolsVersion string and the collection of valid toolsets,

--- a/src/Shared/AssemblyNameExtension.cs
+++ b/src/Shared/AssemblyNameExtension.cs
@@ -989,8 +989,8 @@ namespace Microsoft.Build.Shared
 
             // TODO: consider some kind of protection against infinite loop during serialization, hint: pre serialize check for cycle in graph
             translator.TranslateHashSet(ref remappedFrom,
-                (ITranslator t) => new AssemblyNameExtension(t),
-                (int capacity) => CreateRemappedFrom());
+                (t) => new AssemblyNameExtension(t),
+                (capacity) => CreateRemappedFrom());
         }
     }
 }

--- a/src/Shared/Debugging/PrintLineDebugger.cs
+++ b/src/Shared/Debugging/PrintLineDebugger.cs
@@ -3,6 +3,9 @@
 
 using System;
 using System.Collections.Generic;
+#if DEBUG
+using System.IO;
+#endif
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using Microsoft.Build.Framework;

--- a/src/Shared/Debugging/PrintLineDebugger.cs
+++ b/src/Shared/Debugging/PrintLineDebugger.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using Microsoft.Build.Framework;
@@ -38,13 +37,17 @@ namespace Microsoft.Build.Shared.Debugging
         public static Lazy<PrintLineDebugger> DefaultWithProcessInfo =
             new Lazy<PrintLineDebugger>(() => Create(null, null, true));
 
+#if DEBUG
         private readonly string _id;
+#endif
 
         private readonly CommonWriterType _writerSetByThisInstance;
 
         public PrintLineDebugger(string id, CommonWriterType writer)
         {
+#if DEBUG
             _id = id ?? string.Empty;
+#endif
 
             if (writer != null)
             {
@@ -145,10 +148,12 @@ namespace Microsoft.Build.Shared.Debugging
 #endif
         }
 
+#if DEBUG
         private static string CallsiteString(string sourceFilePath, string memberName, int sourceLineNumber)
         {
             return $"@{Path.GetFileNameWithoutExtension(sourceFilePath)}.{memberName}({sourceLineNumber})";
         }
+#endif
 
         private void ReleaseUnmanagedResources()
         {

--- a/src/Shared/FileSystem/IFileSystem.cs
+++ b/src/Shared/FileSystem/IFileSystem.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Build.Shared.FileSystem
 
         FileAttributes GetAttributes(string path);
 
-        public DateTime GetLastWriteTimeUtc(string path);
+        DateTime GetLastWriteTimeUtc(string path);
 
         bool DirectoryExists(string path);
 

--- a/src/Shared/FileSystem/ManagedFileSystem.cs
+++ b/src/Shared/FileSystem/ManagedFileSystem.cs
@@ -18,6 +18,7 @@ namespace Microsoft.Build.Shared.FileSystem
 
         public static ManagedFileSystem Singleton() => ManagedFileSystem.Instance;
 
+#if FEATURE_MSIOREDIST
         private static bool ShouldUseMicrosoftIO
         {
             get
@@ -31,6 +32,7 @@ namespace Microsoft.Build.Shared.FileSystem
 #endif
             }
         }
+#endif
 
         protected ManagedFileSystem() { }
 

--- a/src/Shared/FrameworkLocationHelper.cs
+++ b/src/Shared/FrameworkLocationHelper.cs
@@ -1262,24 +1262,9 @@ namespace Microsoft.Build.Shared
             private const string MicrosoftSDKsRegistryKey = @"SOFTWARE\Microsoft\Microsoft SDKs";
 
             /// <summary>
-            /// The registry key of this .net framework, i.e. "SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Full" for .net v4.5.
-            /// </summary>
-            private readonly string _dotNetFrameworkRegistryKey;
-
-            /// <summary>
-            /// The name in registry to indicate that this .net framework is installed, i.e. "Install" for .net v4.5.
-            /// </summary>
-            private readonly string _dotNetFrameworkSetupRegistryInstalledName;
-
-            /// <summary>
             /// The key in registry to indicate the sdk tools folder, i.e. "WinSDK-NetFx40Tools-x86" for .net v4.5.
             /// </summary>
             private readonly string _dotNetFrameworkSdkRegistryToolsKey;
-
-            /// <summary>
-            /// The version of visual studio that shipped with this .net framework.
-            /// </summary>
-            private readonly Version _visualStudioVersion;
 
             /// <summary>
             /// Does this .net framework include MSBuild?
@@ -1298,9 +1283,24 @@ namespace Microsoft.Build.Shared
 
 #if FEATURE_WIN32_REGISTRY
             /// <summary>
-            /// Cached path of the corresponding windows sdk.
+            /// The registry key of this .net framework, i.e. "SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Full" for .net v4.5.
+            /// </summary>
+            private readonly string _dotNetFrameworkRegistryKey;
+
+            /// <summary>
+            /// The name in registry to indicate that this .net framework is installed, i.e. "Install" for .net v4.5.
+            /// </summary>
+            private readonly string _dotNetFrameworkSetupRegistryInstalledName;
+
+            /// <summary>
+            /// /// Cached path of the corresponding windows sdk.
             /// </summary>
             private string _pathToWindowsSdk;
+
+            /// <summary>
+            /// The version of visual studio that shipped with this .net framework.
+            /// </summary>
+            private readonly Version _visualStudioVersion;
 #endif
 
             /// <summary>
@@ -1319,15 +1319,18 @@ namespace Microsoft.Build.Shared
                 Version visualStudioVersion = null)
             {
                 this.Version = version;
-                this._visualStudioVersion = visualStudioVersion;
-                this._dotNetFrameworkRegistryKey = dotNetFrameworkRegistryKey;
-                this._dotNetFrameworkSetupRegistryInstalledName = dotNetFrameworkSetupRegistryInstalledName;
                 this.DotNetFrameworkFolderPrefix = dotNetFrameworkVersionFolderPrefix;
                 this._dotNetFrameworkSdkRegistryToolsKey = dotNetFrameworkSdkRegistryToolsKey;
                 this.DotNetFrameworkSdkRegistryInstallationFolderName = dotNetFrameworkSdkRegistryInstallationFolderName;
                 this._hasMsBuild = hasMSBuild;
                 this._pathsToDotNetFramework = new ConcurrentDictionary<DotNetFrameworkArchitecture, string>();
                 this._pathsToDotNetFrameworkSdkTools = new ConcurrentDictionary<Version, string>();
+
+#if FEATURE_WIN32_REGISTRY
+                this._dotNetFrameworkRegistryKey = dotNetFrameworkRegistryKey;
+                this._dotNetFrameworkSetupRegistryInstalledName = dotNetFrameworkSetupRegistryInstalledName;
+                this._visualStudioVersion = visualStudioVersion;
+#endif
             }
 
             /// <summary>

--- a/src/Shared/TaskParameter.cs
+++ b/src/Shared/TaskParameter.cs
@@ -997,6 +997,7 @@ namespace Microsoft.Build.BackEnd
                 return EnumerateMetadataLazy();
             }
 
+#if FEATURE_APPDOMAIN
             private IEnumerable<KeyValuePair<string, string>> EnumerateMetadataEager()
             {
                 if (_customEscapedMetadata == null || _customEscapedMetadata.Count == 0)
@@ -1014,6 +1015,7 @@ namespace Microsoft.Build.BackEnd
 
                 return result;
             }
+#endif
 
             private IEnumerable<KeyValuePair<string, string>> EnumerateMetadataLazy()
             {

--- a/src/Tasks/AssemblyDependency/ReferenceTable.cs
+++ b/src/Tasks/AssemblyDependency/ReferenceTable.cs
@@ -92,10 +92,6 @@ namespace Microsoft.Build.Tasks
         private readonly GetAssemblyMetadata _getAssemblyMetadata;
         /// <summary>Delegate used to get the image runtime version of a file</summary>
         private readonly GetAssemblyRuntimeVersion _getRuntimeVersion;
-#if FEATURE_WIN32_REGISTRY
-        /// <summary> Delegate to get the base registry key for AssemblyFoldersEx</summary>
-        private OpenBaseKey _openBaseKey;
-#endif
         /// <summary>Version of the runtime we are targeting</summary>
         private readonly Version _targetedRuntimeVersion;
 
@@ -320,9 +316,6 @@ namespace Microsoft.Build.Tasks
             _getRuntimeVersion = getRuntimeVersion;
             _projectTargetFramework = projectTargetFramework;
             _targetedRuntimeVersion = targetedRuntimeVersion;
-#if FEATURE_WIN32_REGISTRY
-            _openBaseKey = openBaseKey;
-#endif
             _targetFrameworkMoniker = targetFrameworkMoniker;
             _latestTargetFrameworkDirectories = latestTargetFrameworkDirectories;
             _copyLocalDependenciesWhenParentReferenceInGac = copyLocalDependenciesWhenParentReferenceInGac;

--- a/src/Tasks/CultureInfoCache.cs
+++ b/src/Tasks/CultureInfoCache.cs
@@ -2,12 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Collections.Generic;
 using System.Globalization;
 #if NET
 using System.Linq;
-#endif
+#else
+using System.Collections.Generic;
 using Microsoft.Build.Shared;
+#endif
 
 #nullable disable
 
@@ -32,6 +33,7 @@ namespace Microsoft.Build.Tasks
         // installed cultures, even if the registry keys are set. Therefore, add them to the list manually.
         private static readonly string[] pseudoLocales = ["qps-ploc", "qps-ploca", "qps-plocm", "qps-Latn-x-sh"];
 
+#if !NET
         private static HashSet<string> InitializeValidCultureNames()
         {
 #if !FEATURE_CULTUREINFO_GETCULTURES
@@ -54,6 +56,7 @@ namespace Microsoft.Build.Tasks
 
             return validCultureNames;
         }
+#endif
 
         /// <summary>
         /// Determine if a culture string represents a valid <see cref="CultureInfo"/> instance.
@@ -79,7 +82,7 @@ namespace Microsoft.Build.Tasks
 #endif
         }
 
-#if !FEATURE_CULTUREINFO_GETCULTURES
+#if !NET && !FEATURE_CULTUREINFO_GETCULTURES
         // Copied from https://github.com/aspnet/Localization/blob/5e1fb16071affd15f15b9c732833f3ae2ac46e10/src/Microsoft.Framework.Globalization.CultureInfoCache/CultureInfoList.cs
         // Regenerated using the tool (removed by https://github.com/aspnet/Localization/pull/130)
         //   * Removed the empty string from the list

--- a/src/Tasks/GenerateResource.cs
+++ b/src/Tasks/GenerateResource.cs
@@ -2015,7 +2015,6 @@ namespace Microsoft.Build.Tasks
                 return result != null;
             }
         }
-#endif
 
         /// <summary>
         /// Turns the nicely justified block of base64 found in a resx into a byte array.
@@ -2046,6 +2045,7 @@ namespace Microsoft.Build.Tasks
                 return Convert.FromBase64String(text);
             }
         }
+#endif
 
         /// <summary>
         /// Make sure that OutputResources has 1 file name for each name in Sources.
@@ -2295,10 +2295,12 @@ namespace Microsoft.Build.Tasks
         /// </summary>
         private List<ITaskItem> _inFiles;
 
+#if !FEATURE_ASSEMBLYLOADCONTEXT
         /// <summary>
         /// List of satellite input files to process.
         /// </summary>
         private List<ITaskItem> _satelliteInFiles;
+#endif
 
         /// <summary>
         /// List of output files to process.
@@ -2309,11 +2311,6 @@ namespace Microsoft.Build.Tasks
         /// Whether we are extracting ResW files from an assembly, instead of creating .resources files.
         /// </summary>
         private bool _extractResWFiles;
-
-        /// <summary>
-        /// Where to write extracted ResW files.
-        /// </summary>
-        private string _resWOutputDirectory;
 
         private bool _usePreserializedResources;
 
@@ -2402,7 +2399,9 @@ namespace Microsoft.Build.Tasks
             _logger = log;
             _assemblyFiles = assemblyFilesList;
             _inFiles = inputs;
+#if !FEATURE_ASSEMBLYLOADCONTEXT
             _satelliteInFiles = satelliteInputs;
+#endif
             _outFiles = outputs;
             _useSourcePath = sourcePath;
             _stronglyTypedLanguage = language;
@@ -2413,7 +2412,6 @@ namespace Microsoft.Build.Tasks
             _stronglyTypedClassIsPublic = publicClass;
             _readers = new List<ReaderInfo>();
             _extractResWFiles = extractingResWFiles;
-            _resWOutputDirectory = resWOutputDirectory;
             _portableLibraryCacheInfo = new List<ResGenDependencies.PortableLibraryFile>();
             _usePreserializedResources = usePreserializedResources;
             _logWarningForBinaryFormatter = logWarningForBinaryFormatter;

--- a/src/Tasks/ResolveKeySource.cs
+++ b/src/Tasks/ResolveKeySource.cs
@@ -62,6 +62,7 @@ namespace Microsoft.Build.Tasks
             return ResolveAssemblyKey() && ResolveManifestKey();
         }
 
+#if FEATURE_PFX_SIGNING
         // We we use hash the contens of .pfx file so we can establish relationship file <-> container name, whithout
         // need to prompt for password. Note this is not used for any security reasons. With the departure from standard MD5 algoritm
         // we need as simple hash function for replacement. The data blobs we use (.pfx files)  are
@@ -87,6 +88,7 @@ namespace Microsoft.Build.Tasks
             result |= dw2;
             return result;
         }
+#endif
 
         private bool ResolveAssemblyKey()
         {

--- a/src/Tasks/SystemState.cs
+++ b/src/Tasks/SystemState.cs
@@ -171,10 +171,8 @@ namespace Microsoft.Build.Tasks
                 ErrorUtilities.VerifyThrowArgumentNull(translator);
 
                 translator.Translate(ref lastModified);
-                translator.Translate(ref assemblyName,
-                    (ITranslator t) => new AssemblyNameExtension(t));
-                translator.TranslateArray(ref dependencies,
-                    (ITranslator t) => new AssemblyNameExtension(t));
+                translator.Translate(ref assemblyName, (t) => new AssemblyNameExtension(t));
+                translator.TranslateArray(ref dependencies, (t) => new AssemblyNameExtension(t));
                 translator.Translate(ref scatterFiles);
                 translator.Translate(ref runtimeVersion);
                 translator.Translate(ref frameworkName);
@@ -268,7 +266,7 @@ namespace Microsoft.Build.Tasks
             translator.TranslateDictionary(
                 ref (translator.Mode == TranslationDirection.WriteToStream) ? ref instanceLocalOutgoingFileStateCache : ref instanceLocalFileStateCache,
                 StringComparer.OrdinalIgnoreCase,
-                (ITranslator t) => new FileState(t));
+                (t) => new FileState(t));
 
             // IsDirty should be false for either direction. Either this cache was brought
             // up-to-date with the on-disk cache or vice versa. Either way, they agree.

--- a/src/Tasks/TaskRequiresFramework.cs
+++ b/src/Tasks/TaskRequiresFramework.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#pragma warning disable IDE0052
+
 #if NETFRAMEWORK
 using System;
 #endif

--- a/src/Tasks/XslTransformation.cs
+++ b/src/Tasks/XslTransformation.cs
@@ -2,15 +2,18 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Reflection;
 using System.Xml;
 using System.Xml.XPath;
 using System.Xml.Xsl;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
 using Microsoft.Build.Utilities;
+
+#if FEATURE_COMPILED_XSL
+using System.Collections.Generic;
+using System.Reflection;
+#endif
 
 #nullable disable
 
@@ -495,6 +498,7 @@ namespace Microsoft.Build.Tasks
                 return xslct;
             }
 
+#if FEATURE_COMPILED_XSL
             /// <summary>
             /// Find the type from an assembly and loads it.
             /// </summary>
@@ -528,6 +532,7 @@ namespace Microsoft.Build.Tasks
                     throw new ArgumentException(ResourceUtilities.FormatResourceStringStripCodeAndKeyword("XslTransform.MustSpecifyType", assemblyPath));
                 }
             }
+#endif
         }
         #endregion
     }

--- a/src/UnitTests.Shared/EngineTestEnvironment.cs
+++ b/src/UnitTests.Shared/EngineTestEnvironment.cs
@@ -25,9 +25,9 @@ namespace Microsoft.Build.UnitTests
     public partial class TestEnvironment
     {
         // reset the default build manager and the state it might have accumulated from other tests
-#pragma warning disable CA1823 // Avoid unused private fields
+#pragma warning disable CA1823, IDE0052 // Avoid unused private fields
         private object _resetBuildManager = new ResetDefaultBuildManager();
-#pragma warning restore CA1823 // Avoid unused private fields
+#pragma warning restore CA1823, IDE0052 // Avoid unused private fields
 
         private sealed class ResetDefaultBuildManager
         {

--- a/src/UnitTests.Shared/TestEnvironment.cs
+++ b/src/UnitTests.Shared/TestEnvironment.cs
@@ -677,19 +677,16 @@ namespace Microsoft.Build.UnitTests
 
     public class TransientTestFile : TransientTestState
     {
-        private readonly bool _createFile;
         private readonly bool _expectedAsOutput;
 
         public TransientTestFile(string extension, bool createFile, bool expectedAsOutput)
         {
-            _createFile = createFile;
             _expectedAsOutput = expectedAsOutput;
             Path = FileUtilities.GetTemporaryFile(null, null, extension, createFile);
         }
 
         public TransientTestFile(string rootPath, string extension, bool createFile, bool expectedAsOutput)
         {
-            _createFile = createFile;
             _expectedAsOutput = expectedAsOutput;
             Path = FileUtilities.GetTemporaryFile(rootPath, null, extension, createFile);
         }

--- a/src/Utilities/TaskItem.cs
+++ b/src/Utilities/TaskItem.cs
@@ -508,6 +508,7 @@ namespace Microsoft.Build.Utilities
             _metadata.SetItems(metadata.Select(kvp => new KeyValuePair<string, string>(kvp.Key, kvp.Value ?? string.Empty)));
         }
 
+#if FEATURE_APPDOMAIN
         private IEnumerable<KeyValuePair<string, string>> EnumerateMetadataEager()
         {
             if (_metadata == null)
@@ -526,6 +527,7 @@ namespace Microsoft.Build.Utilities
 
             return result;
         }
+#endif
 
         private IEnumerable<KeyValuePair<string, string>> EnumerateMetadataLazy()
         {


### PR DESCRIPTION
These are showing up when building with a recent .NET 10 SDK. This allows us to remove the warnAsError=false flag in the VMR when building msbuild

Review with hide whitespaces toggled one:

![image](https://github.com/user-attachments/assets/d198a397-c1b0-4728-873c-1ff3b982d1a9)


Fixes #

### Context


### Changes Made


### Testing


### Notes
