### PR TITLE
Add more info to ETL traces

### DIFF
--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -779,7 +779,6 @@ namespace Microsoft.Build.Execution
         /// </summary>
         public void CancelAllSubmissions()
         {
-            // Log the cancellation started event to ETL traces
             MSBuildEventSource.Log.CancelSubmissionsStart();
             CancelAllSubmissions(true);
         }

--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -779,6 +779,8 @@ namespace Microsoft.Build.Execution
         /// </summary>
         public void CancelAllSubmissions()
         {
+            // Log the cancellation started event to ETL traces
+            MSBuildEventSource.Log.CancelSubmissionsStart();
             CancelAllSubmissions(true);
         }
 

--- a/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
@@ -1106,8 +1106,6 @@ namespace Microsoft.Build.BackEnd
             // logged with the node logging context
             _projectLoggingContext = null;
 
-            MSBuildEventSource.Log.BuildProjectStart(_requestEntry.RequestConfiguration.ProjectFullPath);
-
             try
             {
                 // Load the project
@@ -1145,6 +1143,13 @@ namespace Microsoft.Build.BackEnd
 
             try
             {
+                // Determine the set of targets we need to build
+                (string name, TargetBuiltReason reason)[] allTargets = _requestEntry.RequestConfiguration
+   .GetTargetsUsedToBuildRequest(_requestEntry.Request).ToArray();
+                if (MSBuildEventSource.Log.IsEnabled())
+                {
+                    MSBuildEventSource.Log.BuildProjectStart(_requestEntry.RequestConfiguration.ProjectFullPath, string.Join(", ", allTargets));
+                }
                 HandleProjectStarted(buildCheckManager);
 
                 // Make sure to extract known immutable folders from properties and register them for fast up-to-date check
@@ -1162,9 +1167,6 @@ namespace Microsoft.Build.BackEnd
 
                 _requestEntry.Request.BuildEventContext = _projectLoggingContext.BuildEventContext;
 
-                // Determine the set of targets we need to build
-                (string name, TargetBuiltReason reason)[] allTargets = _requestEntry.RequestConfiguration
-                    .GetTargetsUsedToBuildRequest(_requestEntry.Request).ToArray();
 
                 ProjectErrorUtilities.VerifyThrowInvalidProject(allTargets.Length > 0,
                     _requestEntry.RequestConfiguration.Project.ProjectFileLocation, "NoTargetSpecified");

--- a/src/Framework/MSBuildEventSource.cs
+++ b/src/Framework/MSBuildEventSource.cs
@@ -79,11 +79,12 @@ namespace Microsoft.Build.Eventing
         /// <summary>
         /// Call this method to notify listeners of information of how a project file built.
         /// <param name="projectPath">Filename of the project being built.</param>
+        /// <param name="targets">Names of the targets that built.</param>
         /// </summary>
-        [Event(5, Keywords = Keywords.All | Keywords.PerformanceLog)]
-        public void BuildProjectStart(string projectPath)
+        [Event(5, Keywords = Keywords.All | Keywords.PerformanceLog, Version = 1)]
+        public void BuildProjectStart(string projectPath, string targets)
         {
-            WriteEvent(5, projectPath);
+            WriteEvent(5, projectPath, targets);
         }
 
         /// <param name="projectPath">Filename of the project being built.</param>
@@ -671,6 +672,12 @@ namespace Microsoft.Build.Eventing
         public void ProjectCacheHandleBuildResultStop(string pluginTypeName, string projectPath, string targets)
         {
             WriteEvent(92, pluginTypeName, projectPath, targets);
+        }
+
+        [Event(93, Keywords = Keywords.All)]
+        public void CancelSubmissionsStart()
+        {
+            WriteEvent(93);
         }
         #endregion
     }


### PR DESCRIPTION
Add these info to etl traces:

- Add a cancellation started event to better track the timeline of cancellation (when a customer attempts to cancel a build)
- Add Target List to build project start event ((now it's only on build stop event)

![image](https://github.com/user-attachments/assets/07dc689d-3a76-4a8a-95f4-170b83821822)
![image](https://github.com/user-attachments/assets/1cbfab74-1eea-48d8-b181-81a36322f138)
![image](https://github.com/user-attachments/assets/45ab15a4-13fd-4da7-b3d6-1d30dc7818e2)

**Note :** [note: this PR changes the order of
_requestEntry.RequestConfiguration.RetrieveFromCache();
(string name, TargetBuiltReason reason)[] allTargets = _requestEntry.RequestConfiguration .GetTargetsUsedToBuildRequest(_requestEntry.Request).ToArray();
from looking at the code I'm pretty sure these don't interact in any way, but logging this if we eventually run into some side effect downstream of this](https://github.com/dotnet/msbuild/pull/11743/files#r2053726738)