### PR TITLE
Stop UsingToolMicrosoftNetCompilers

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -20,7 +20,6 @@
   <PropertyGroup>
     <UsingToolIbcOptimization>true</UsingToolIbcOptimization>
     <UsingToolVisualStudioIbcTraining>true</UsingToolVisualStudioIbcTraining>
-    <UsingToolMicrosoftNetCompilers>true</UsingToolMicrosoftNetCompilers>
     <UsingToolSymbolUploader>true</UsingToolSymbolUploader>
     <UsingToolVSSDK>true</UsingToolVSSDK>
   </PropertyGroup>


### PR DESCRIPTION
We shouldn't need to strictly control compiler version and floating makes things much easier.
