### PR TITLE
[vs17.14] Binlog not produced for C++ project on Visual Studio Load Fix

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,7 +2,7 @@
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the MIT license. See License.txt in the project root for full license information. -->
 <Project>
   <PropertyGroup>
-    <VersionPrefix>17.14.5</VersionPrefix><DotNetFinalVersionKind>release</DotNetFinalVersionKind>
+    <VersionPrefix>17.14.7</VersionPrefix><DotNetFinalVersionKind>release</DotNetFinalVersionKind>
     <PackageValidationBaselineVersion>17.13.9</PackageValidationBaselineVersion>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,7 +2,7 @@
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the MIT license. See License.txt in the project root for full license information. -->
 <Project>
   <PropertyGroup>
-    <VersionPrefix>17.14.4</VersionPrefix><DotNetFinalVersionKind>release</DotNetFinalVersionKind>
+    <VersionPrefix>17.14.5</VersionPrefix><DotNetFinalVersionKind>release</DotNetFinalVersionKind>
     <PackageValidationBaselineVersion>17.13.9</PackageValidationBaselineVersion>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>

--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -677,7 +677,7 @@ namespace Microsoft.Build.Execution
 
                 var logger = new BinaryLogger { Parameters = binlogPath };
 
-                return (loggers ?? [logger]);
+                return (loggers ?? []).Concat([logger]);
             }
 
             void InitializeCaches()

--- a/src/Tasks/GenerateResource.cs
+++ b/src/Tasks/GenerateResource.cs
@@ -1705,7 +1705,7 @@ namespace Microsoft.Build.Tasks
 
             // Check the timestamp of each of the passed-in references to find the newest;
             // and then the additional inputs
-            ITaskItem[] inputs = this.References ?? [.. (this.AdditionalInputs ?? [])];
+            var inputs = (this.References ?? []).Concat(this.AdditionalInputs ?? []);
 
             foreach (ITaskItem input in inputs)
             {


### PR DESCRIPTION
Fixes #11678

Work item (Internal use): 

### Summary
Regression in Visual Studio 17.13 (worked in 17.12). 
Binlog is not created for C++ project on Visual Studio load.

### Customer Impact

Harder to diagnose build failures/perf issues for vcxproj in VS.

### Regression?

Yes, from 17.12 to 17.13.

### Testing

Manual testing:
1. Get any C++ projec. I got it from the feedback ticket
2. In the terminal set `MSBUILDDEBUGENGINE` and `MSBUILDDEBUGPATH`
3. in the same terminal open the C++ project with devenv
4. Check the `MSBUILDDEBUGPATH` for the binlogs

For using the correct msbuild
1. Use `build.cmd` script 
2. Use `~\msbuild\artifacts\bin\bootstrap\net472\MSBuild\Current` instead of `{Visual Studio path }\MSBuild\Current`

### Risk

Low--spot fixes of refactorings.

### Details

The bug is on this line:

https://github.com/dotnet/msbuild/blob/7ad4e1c76585d0ed6e438da2d4f9394326934399/src/Build/BackEnd/BuildManager/BuildManager.cs#L671

The PR that changed this line:
https://github.com/dotnet/msbuild/pull/10758/files#diff-2b0716a511d8f4ee690ebd5c3a59dec1e3f9a5eab4ab2a80a1018820a658accbL671

The code before and after
```diff
- return (loggers ?? Enumerable.Empty<ILogger>()).Concat(new[] { logger });
+ return (loggers ?? [logger]);
```

Before `logger` (BinaryLogger here) was always included.

### Changes Made
Made sure to include the BinaryLogger.


### Notes
There is also a same mistake with misplaced brackets here:
https://github.com/dotnet/msbuild/pull/10758/files#diff-9ee98aebd9b1aea9900e0b2859bdcbe6b6bdda285f4b5771d9bdeb8b2f480b8dL1708

```diff
- var inputs = (this.References ?? Enumerable.Empty<ITaskItem>()).Concat(this.AdditionalInputs ?? Enumerable.Empty<ITaskItem>());
+ ITaskItem[] inputs = this.References ?? [..(this.AdditionalInputs ?? [])];
```
Also fixed this mistake in this PR.
