### PR TITLE
TotalMemoryConsumption: include GC'd memory.

### DIFF
--- a/src/Build/Instance/TaskRegistry.cs
+++ b/src/Build/Instance/TaskRegistry.cs
@@ -1182,17 +1182,13 @@ namespace Microsoft.Build.Execution
                 public short ExecutedCount { get; private set; } = 0;
                 public long TotalMemoryConsumption { get; private set; } = 0;
                 private readonly Stopwatch _executedSw  = new Stopwatch();
-#if NET
                 private long _memoryConsumptionOnStart;
-#endif
 
                 public TimeSpan ExecutedTime => _executedSw.Elapsed;
 
                 public void ExecutionStarted()
                 {
-#if NET
-                    _memoryConsumptionOnStart = GC.GetTotalAllocatedBytes(false);
-#endif
+                    _memoryConsumptionOnStart = GetMemoryAllocated();
                     _executedSw.Start();
                     ExecutedCount++;
                 }
@@ -1200,8 +1196,15 @@ namespace Microsoft.Build.Execution
                 public void ExecutionStopped()
                 {
                     _executedSw.Stop();
+                    TotalMemoryConsumption += GetMemoryAllocated() - _memoryConsumptionOnStart;
+                }
+
+                private static long GetMemoryAllocated()
+                {
 #if NET
-                    TotalMemoryConsumption += GC.GetTotalAllocatedBytes(false) - _memoryConsumptionOnStart;
+                    return GC.GetTotalAllocatedBytes(false);
+#else
+                    return GC.GetTotalMemory(false);
 #endif
                 }
 

--- a/src/Build/Instance/TaskRegistry.cs
+++ b/src/Build/Instance/TaskRegistry.cs
@@ -1182,13 +1182,17 @@ namespace Microsoft.Build.Execution
                 public short ExecutedCount { get; private set; } = 0;
                 public long TotalMemoryConsumption { get; private set; } = 0;
                 private readonly Stopwatch _executedSw  = new Stopwatch();
+#if NET
                 private long _memoryConsumptionOnStart;
+#endif
 
                 public TimeSpan ExecutedTime => _executedSw.Elapsed;
 
                 public void ExecutionStarted()
                 {
-                    _memoryConsumptionOnStart = GC.GetTotalMemory(false);
+#if NET
+                    _memoryConsumptionOnStart = GC.GetTotalAllocatedBytes(false);
+#endif
                     _executedSw.Start();
                     ExecutedCount++;
                 }
@@ -1196,7 +1200,9 @@ namespace Microsoft.Build.Execution
                 public void ExecutionStopped()
                 {
                     _executedSw.Stop();
-                    TotalMemoryConsumption += GC.GetTotalMemory(false) - _memoryConsumptionOnStart;
+#if NET
+                    TotalMemoryConsumption += GC.GetTotalAllocatedBytes(false) - _memoryConsumptionOnStart;
+#endif
                 }
 
                 public void Reset()


### PR DESCRIPTION
Use GetTotalAllocatedBytes instead of GetTotalMemory.

This causes objects that were allocated to the heap but have since been collected to be accounted as well.

@JanKrivanek @rainersigwald ptal