### PR TITLE
check telemetry should be collected before collecting mem info

### DIFF
--- a/src/Build/BackEnd/Components/RequestBuilder/TaskBuilder.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TaskBuilder.cs
@@ -428,8 +428,10 @@ namespace Microsoft.Build.BackEnd
                     {
                         TaskLoggingContext taskLoggingContext = _targetLoggingContext.LogTaskBatchStarted(_projectFullPath, _targetChildInstance, taskAssemblyLocation);
                         MSBuildEventSource.Log.ExecuteTaskStart(_taskNode?.Name, taskLoggingContext.BuildEventContext.TaskId);
-                        // Can be condition with _componentHost.BuildParameters.IsTelemetryEnabled) - but it's a cheap call
-                        taskFactoryWrapper?.Statistics?.ExecutionStarted();
+                        if (_componentHost?.BuildParameters?.IsTelemetryEnabled)
+                        {
+                            taskFactoryWrapper?.Statistics?.ExecutionStarted();
+                        }
 
                         _buildRequestEntry.Request.CurrentTaskContext = taskLoggingContext.BuildEventContext;
 
@@ -479,7 +481,10 @@ namespace Microsoft.Build.BackEnd
 
                             // Flag the completion of the task.
                             taskLoggingContext.LogTaskBatchFinished(_projectFullPath, taskResult.ResultCode == WorkUnitResultCode.Success || taskResult.ResultCode == WorkUnitResultCode.Skipped);
-                            taskFactoryWrapper?.Statistics?.ExecutionStopped();
+                            if (_componentHost?.BuildParameters?.IsTelemetryEnabled)
+                            {
+                                taskFactoryWrapper?.Statistics?.ExecutionStopped();
+                            }
 
                             if (taskResult.ResultCode == WorkUnitResultCode.Failed && _continueOnError == ContinueOnError.WarnAndContinue)
                             {

--- a/src/Build/BackEnd/Components/RequestBuilder/TaskBuilder.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TaskBuilder.cs
@@ -428,7 +428,7 @@ namespace Microsoft.Build.BackEnd
                     {
                         TaskLoggingContext taskLoggingContext = _targetLoggingContext.LogTaskBatchStarted(_projectFullPath, _targetChildInstance, taskAssemblyLocation);
                         MSBuildEventSource.Log.ExecuteTaskStart(_taskNode?.Name, taskLoggingContext.BuildEventContext.TaskId);
-                        if (_componentHost?.BuildParameters?.IsTelemetryEnabled)
+                        if (_componentHost.BuildParameters.IsTelemetryEnabled)
                         {
                             taskFactoryWrapper?.Statistics?.ExecutionStarted();
                         }
@@ -481,7 +481,7 @@ namespace Microsoft.Build.BackEnd
 
                             // Flag the completion of the task.
                             taskLoggingContext.LogTaskBatchFinished(_projectFullPath, taskResult.ResultCode == WorkUnitResultCode.Success || taskResult.ResultCode == WorkUnitResultCode.Skipped);
-                            if (_componentHost?.BuildParameters?.IsTelemetryEnabled)
+                            if (_componentHost.BuildParameters.IsTelemetryEnabled)
                             {
                                 taskFactoryWrapper?.Statistics?.ExecutionStopped();
                             }


### PR DESCRIPTION
Fixes https://github.com/dotnet/msbuild/issues/11791

### Context
https://github.com/dotnet/runtime/issues/114389#issuecomment-2851189615

### Changes Made
wrap with check that we're using telemetry

### Testing
existing tests

### Notes
