### PR TITLE
Enable secure source coding hashing

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,7 +2,7 @@
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the MIT license. See License.txt in the project root for full license information. -->
 <Project>
   <PropertyGroup>
-    <VersionPrefix>17.8.30</VersionPrefix>
+    <VersionPrefix>17.8.31</VersionPrefix>
     <DotNetFinalVersionKind>release</DotNetFinalVersionKind>
     <PackageValidationBaselineVersion>17.7.0</PackageValidationBaselineVersion>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>

--- a/src/Deprecated/Conversion/Microsoft.Build.Conversion.csproj
+++ b/src/Deprecated/Conversion/Microsoft.Build.Conversion.csproj
@@ -10,6 +10,7 @@
     <NoWarn>$(NoWarn);1570;1572;1573;1587</NoWarn>
     <Nullable>disable</Nullable>
     <EnablePackageValidation>true</EnablePackageValidation>
+    <ChecksumAlgorithm>SHA256</ChecksumAlgorithm>
   </PropertyGroup>
   <ItemGroup>
     <!-- Source Files -->

--- a/src/Deprecated/Engine/Microsoft.Build.Engine.csproj
+++ b/src/Deprecated/Engine/Microsoft.Build.Engine.csproj
@@ -15,6 +15,7 @@
     <NoWarn>$(NoWarn);1570;1572;1573;1587</NoWarn>
     <Nullable>disable</Nullable>
     <EnablePackageValidation>true</EnablePackageValidation>
+    <ChecksumAlgorithm>SHA256</ChecksumAlgorithm>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes 
binskim warning BA2004: EnableSecureSourceCodeHashing on 
- Microsoft.Build.Engine.dll
- Microsoft.Build.Conversion.Core.dll

### Context
The assembly is a managed binary compiled with an insecure (SHA-1) source code hashing algorithm. SHA-1 is subject to collision attacks and its use can compromise supply chain integrity.

### Changes Made
Add <ChecksumAlgorithm> property with 'SHA256' to enable secure source code hashing.

And the change needs to be flowed into higher branches vs17.9, vs17.10, vs17.11, vs17.12.

### Testing
N/A

### Notes
