### PR TITLE
Update issue-labeler workflows to reflect disabling prediction for pulls. Add comments/doc.

### DIFF
--- a/.github/workflows/labeler-cache-retention.yml
+++ b/.github/workflows/labeler-cache-retention.yml
@@ -1,3 +1,8 @@
+# Workflow template imported and updated from:
+# https://github.com/dotnet/issue-labeler/wiki/Onboarding
+#
+# See labeler.md for more information
+#
 # Regularly restore the prediction models from cache to prevent cache eviction
 name: "Labeler: Cache Retention"
 
@@ -26,7 +31,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        type: ["issues", "pulls"]
+        type: ["issues"] # Pulls are disabled in this repository, so "pulls" is removed from the matrix
     steps:
       - uses: dotnet/issue-labeler/restore@46125e85e6a568dc712f358c39f35317366f5eed # v2.0.0
         with:

--- a/.github/workflows/labeler-predict-issues.yml
+++ b/.github/workflows/labeler-predict-issues.yml
@@ -1,3 +1,8 @@
+# Workflow template imported and updated from:
+# https://github.com/dotnet/issue-labeler/wiki/Onboarding
+#
+# See labeler.md for more information
+#
 # Predict labels for Issues using a trained model
 name: "Labeler: Predict (Issues)"
 

--- a/.github/workflows/labeler-predict-pulls.yml
+++ b/.github/workflows/labeler-predict-pulls.yml
@@ -1,3 +1,8 @@
+# Workflow template imported and updated from:
+# https://github.com/dotnet/issue-labeler/wiki/Onboarding
+#
+# See labeler.md for more information
+#
 # Predict labels for Pull Requests using a trained model
 name: "Labeler: Predict (Pulls)"
 

--- a/.github/workflows/labeler-promote.yml
+++ b/.github/workflows/labeler-promote.yml
@@ -1,3 +1,8 @@
+# Workflow template imported and updated from:
+# https://github.com/dotnet/issue-labeler/wiki/Onboarding
+#
+# See labeler.md for more information
+#
 # Promote a model from staging to 'ACTIVE', backing up the currently 'ACTIVE' model
 name: "Labeler: Promotion"
 

--- a/.github/workflows/labeler-train.yml
+++ b/.github/workflows/labeler-train.yml
@@ -1,3 +1,8 @@
+# Workflow template imported and updated from:
+# https://github.com/dotnet/issue-labeler/wiki/Onboarding
+#
+# See labeler.md for more information
+#
 # Train the Issues and Pull Requests models for label prediction
 name: "Labeler: Training"
 
@@ -8,7 +13,7 @@ on:
         description: "Issues or Pull Requests"
         type: choice
         required: true
-        default: "Both"
+        default: "Issues" # Pulls are disabled in this repository, so default to "Issues" only
         options:
           - "Both"
           - "Issues"

--- a/.github/workflows/labeler.md
+++ b/.github/workflows/labeler.md
@@ -1,0 +1,36 @@
+# Issue-Labeler Workflows
+
+This repository uses actions from [dotnet/issue-labeler](https://github.com/dotnet/issue-labeler) to predict area labels for issues and pull requests.
+
+The following workflow templates were imported and updated from [dotnet/issue-labeler/wiki/Onboarding](https://github.com/dotnet/issue-labeler/wiki/Onboarding):
+
+1. `labeler-cache-retention.yml`
+2. `labeler-predict-issues.yml`
+3. `labeler-predict-pulls.yml`
+4. `labeler-promote.yml`
+5. `labeler-train.yml`
+
+## Repository Configuration
+
+Across these workflows, the following changes were made to configure the issue labeler for this repository:
+
+1. Set `LABEL_PREFIX` to `"Area: "`:
+    - `labeler-predict-issues.yml`
+    - `labeler-predict-pulls.yml`
+    - `labeler-train.yml`
+2. Remove `DEFAULT_LABEL` to value as we do not apply a default label when a prediction is not made:
+    - `labeler-predict-issues.yml`
+    - `labeler-predict-pulls.yml`
+3. Remove the `EXCLUDED_AUTHORS` value as we do not bypass labeling for any authors' issues/pulls in this repository:
+    - `labeler-predict-issues.yml`
+    - `labeler-predict-pulls.yml`
+4. Update the pull request labeling branches to include `main` and `vs*`:
+    - `labeler-predict-pulls.yml`
+5. Remove the `repository` input for training the models against another repository:
+    - `labeler-train.yml`
+6. Update the cache retention cron schedule to an arbitrary time of day:
+    - `labeler-cache-retention.yml`
+7. Disable pull request training, cache retention, and predition
+    - `labeler-train.yml` - Change the default from "Both" to "Issues"
+    - `labeler-cache-retention.yml` - Remove "pulls" from the job matrix (leaving a comment)
+    - `labeler-predict-pulls.yml` - Workflow marked as Disabled via GitHub UI


### PR DESCRIPTION
Follow up to #11781.

This updates the workflows to reflect that this repository has the labeler disabled for pull requests. By removing "pulls" from the cache-retention job, that job will not try to restore the pulls model (and fail). The job should be green daily to show the issues model was successfilly restored (and therefore prediction can succeed).

This also adds comments to the workflows and a markdown file documenting the configuration of the issue-labeler, based on feedback received in another repo.