### PR TITLE
Change the channel from int.main to int.d17.14

### DIFF
--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -119,7 +119,7 @@ extends:
         - name: VisualStudio.MajorVersion
           value: 17
         - name: VisualStudio.ChannelName
-          value: 'int.main'
+          value: 'int.d17.14'
         - name: VisualStudio.DropName
           value: Products/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildNumber)
 


### PR DESCRIPTION
Fixes #

Internal build on main failed the channel manifest using the channel int.main was not found.

### Changes Made
Change the channel from int.main to int.d17.14. And verified with experimental branch and the build https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=11564894&view=results passed.
