### PR TITLE
Improve testing old nuget

### DIFF
--- a/eng/BootStrapMsBuild.targets
+++ b/eng/BootStrapMsBuild.targets
@@ -118,6 +118,7 @@
       <FreshlyBuiltBinariesx64 Include="$(X64BinPath)**\*.exe.config" />
       <FreshlyBuiltBinariesx64 Include="$(MSBuildTaskHostX64BinPath)**\*.exe.config" />
       <FreshlyBuiltBinariesx64 Include="$(X64BinPath)**\*.dll.config" />
+      <FreshlyBuiltBinariesx64 Remove="$(X64BinPath)**\Microsoft.VisualStudio.SolutionPersistence.dll" />
 
       <FreshlyBuiltBinariesArm64 Include="$(X64BinPath)\Microsoft.Build.Tasks.Core.dll" />
       <FreshlyBuiltBinariesArm64 Include="$(X64BinPath)\Microsoft.Build.dll" />

--- a/src/Build.OM.UnitTests/NugetRestoreTests.cs
+++ b/src/Build.OM.UnitTests/NugetRestoreTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.IO;
+using System.Reflection;
 using Microsoft.Build.UnitTests;
 using Microsoft.Build.UnitTests.Shared;
 using Shouldly;
@@ -22,7 +23,8 @@ namespace Microsoft.Build.Engine.OM.UnitTests
         [WindowsFullFrameworkOnlyFact]
         public void TestOldNuget()
         {
-            string msbuildExePath = Path.GetDirectoryName(RunnerUtilities.PathToCurrentlyRunningMsBuildExe)!;
+            string currentAssemblyDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!;
+            string bootstrapMsBuildBinaryDir = RunnerUtilities.BootstrapMsBuildBinaryLocation;
             using TestEnvironment testEnvironment = TestEnvironment.Create();
             TransientTestFolder folder = testEnvironment.CreateFolder(createFolder: true);
             // The content of the solution isn't known to matter, but having a custom solution makes it easier to add requirements should they become evident.
@@ -46,7 +48,7 @@ GlobalSection(SolutionProperties) = preSolution
 EndGlobalSection
 EndGlobal
 ");
-            RunnerUtilities.RunProcessAndGetOutput(Path.Combine(msbuildExePath, "nuget", "NuGet.exe"), "restore " + sln.Path + " -MSBuildPath \"" + msbuildExePath + "\"", out bool success, outputHelper: _output);
+            RunnerUtilities.RunProcessAndGetOutput(Path.Combine(currentAssemblyDir, "nuget", "NuGet.exe"), "restore " + sln.Path + " -MSBuildPath \"" + bootstrapMsBuildBinaryDir + "\"", out bool success, outputHelper: _output);
             success.ShouldBeTrue();
         }
     }

--- a/src/UnitTests.Shared/RunnerUtilities.cs
+++ b/src/UnitTests.Shared/RunnerUtilities.cs
@@ -19,6 +19,10 @@ namespace Microsoft.Build.UnitTests.Shared
 
         public static ArtifactsLocationAttribute ArtifactsLocationAttribute = Assembly.GetExecutingAssembly().GetCustomAttribute<ArtifactsLocationAttribute>()
                                                    ?? throw new InvalidOperationException("This test assembly does not have the ArtifactsLocationAttribute");
+
+        internal static BootstrapLocationAttribute BootstrapLocationAttribute = Assembly.GetExecutingAssembly().GetCustomAttribute<BootstrapLocationAttribute>()
+                                                   ?? throw new InvalidOperationException("This test assembly does not have the BootstrapLocationAttribute");
+        public static string BootstrapMsBuildBinaryLocation => BootstrapLocationAttribute.BootstrapMsBuildBinaryLocation;
 #if !FEATURE_RUN_EXE_IN_TESTS
         private static readonly string s_dotnetExePath = EnvironmentProvider.GetDotnetExePath();
 
@@ -62,15 +66,11 @@ namespace Microsoft.Build.UnitTests.Shared
             bool attachProcessId = true,
             int timeoutMilliseconds = 30_000)
         {
-            BootstrapLocationAttribute attribute = Assembly.GetExecutingAssembly().GetCustomAttribute<BootstrapLocationAttribute>()
-                                                   ?? throw new InvalidOperationException("This test assembly does not have the BootstrapLocationAttribute");
-
-            string binaryFolder = attribute.BootstrapMsBuildBinaryLocation;
 #if NET
-            string pathToExecutable = EnvironmentProvider.GetDotnetExePathFromFolder(binaryFolder);
-            msbuildParameters = Path.Combine(binaryFolder, "sdk", attribute.BootstrapSdkVersion, "MSBuild.dll") + " " + msbuildParameters;
+            string pathToExecutable = EnvironmentProvider.GetDotnetExePathFromFolder(BootstrapMsBuildBinaryLocation);
+            msbuildParameters = Path.Combine(BootstrapMsBuildBinaryLocation, "sdk", BootstrapLocationAttribute.BootstrapSdkVersion, "MSBuild.dll") + " " + msbuildParameters;
 #else
-            string pathToExecutable = Path.Combine(binaryFolder, "MSBuild.exe");
+            string pathToExecutable = Path.Combine(BootstrapMsBuildBinaryLocation, "MSBuild.exe");
 #endif
             return RunProcessAndGetOutput(pathToExecutable, msbuildParameters, out successfulExit, shellExecute, outputHelper, attachProcessId, timeoutMilliseconds);
         }


### PR DESCRIPTION
Fixes #11516

### Context
Existing test could not catch the regression mentioned in the issue. The binaries used in the test are different from msbuild binaries in VS installation. https://github.com/dotnet/msbuild/blob/36b265d7dec4d4e5934507551c16ff7b2a99b549/src/Build.OM.UnitTests/NugetRestoreTests.cs#L24-L52

### Changes Made
Remove Microsoft.VisualStudio.SolutionPersistence.dll from 64-bit msbuild in the boostrap. And improve the test using bootstrap msbuild.

### Testing
Existing test

### Notes
