### PR TITLE
Include resources in command line arguments produced by csc in design-time build

### DIFF
--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -3203,7 +3203,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       AssignTargetPaths;
       SplitResourcesByCulture;
       CreateManifestResourceNames;
-      CreateCustomManifestResourceNames
+      CreateCustomManifestResourceNames;
+      AssignEmbeddedResourceOutputPaths;
     </PrepareResourceNamesDependsOn>
   </PropertyGroup>
 
@@ -3259,6 +3260,17 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <Output TaskParameter="AssignedFiles" ItemName="_DeploymentBaseManifestWithTargetPath" />
     </AssignTargetPath>
 
+  </Target>
+
+  <!--
+    Sets OutputResource metadata on EmbeddedResource items. This metadata is used in design time build without running ResGen target.
+  -->
+  <Target Name="AssignEmbeddedResourceOutputPaths">
+    <ItemGroup>
+      <EmbeddedResource Update="@(EmbeddedResource)">
+        <OutputResource>$(IntermediateOutputPath)%(EmbeddedResource.ManifestResourceName).resources</OutputResource>
+      </EmbeddedResource>
+    </ItemGroup>
   </Target>
 
   <!--
@@ -3467,7 +3479,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         StronglyTypedNamespace="%(EmbeddedResource.StronglyTypedNamespace)"
         StronglyTypedManifestPrefix="%(EmbeddedResource.StronglyTypedManifestPrefix)"
         PublicClass="%(EmbeddedResource.PublicClass)"
-        OutputResources="@(EmbeddedResource->'$(IntermediateOutputPath)%(ManifestResourceName).resources')"
+        OutputResources="@(EmbeddedResource->'%(OutputResource)')"
         Condition="'%(EmbeddedResource.Type)' == 'Resx' and '%(EmbeddedResource.GenerateResource)' != 'false' and '$(GenerateResourceMSBuildRuntime)' != 'CLR2'"
         SdkToolsPath="$(ResgenToolPath)"
         ExecuteAsTool="$(ResGenExecuteAsTool)"
@@ -3677,7 +3689,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     Create the _CoreCompileResourceInputs list of inputs to the CoreCompile target.
     ============================================================
     -->
-  <Target Name="_GenerateCompileInputs">
+  <Target Name="_GenerateCompileInputs" DependsOnTargets="PrepareResourceNames">
 
     <MSBuildInternalMessage
       Condition="'@(ManifestResourceWithNoCulture)'!='' and '%(ManifestResourceWithNoCulture.EmittedForCompatibilityOnly)'==''"

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -3267,7 +3267,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   -->
   <Target Name="AssignEmbeddedResourceOutputPaths">
     <ItemGroup>
-      <EmbeddedResource Update="@(EmbeddedResource)">
+      <EmbeddedResource>
         <OutputResource>$(IntermediateOutputPath)%(EmbeddedResource.ManifestResourceName).resources</OutputResource>
       </EmbeddedResource>
     </ItemGroup>


### PR DESCRIPTION
### Context

`csc` task in design-time build does not currently get the list of embedded resources as an input and thus does not include them in the generated command line.

Target `_GenerateCompileInputs` that generates the inputs needs `EmbeddedResource` to have metadata `WithCulture`, `Type` and `OutputResource` set. The former two are set in `SplitResourcesByCulture` target, which is a dependency of `PrepareResourceNames` target. The `OutputResource` is currently set by `GenerateResource` task.

To support updating resources during Hot Reload Roslyn needs to track resource files. To do that `/resource` command line arguments need to be produced by `csc` task at design-time.

### Changes Made

This change moves setting of `OutputResource` metadata to a new target `AssignEmbeddedResourceOutputPaths` that is a dependency of `PrepareResourceNames`.

The change also includes `PrepareResourceNames` in the dependencies of `_GenerateCompileInputs` target, so that it is run during design-time build.

### Testing

Manual testing of DTB with this change.

### Notes
