### PR TITLE
Fix invalid substitutionGroup in Microsoft.Build.CommonTypes

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,7 +2,7 @@
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the MIT license. See License.txt in the project root for full license information. -->
 <Project>
   <PropertyGroup>
-    <VersionPrefix>17.14.8</VersionPrefix><DotNetFinalVersionKind>release</DotNetFinalVersionKind>
+    <VersionPrefix>17.14.9</VersionPrefix><DotNetFinalVersionKind>release</DotNetFinalVersionKind>
     <PackageValidationBaselineVersion>17.13.9</PackageValidationBaselineVersion>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>
     <PreReleaseVersionLabel>servicing</PreReleaseVersionLabel>

--- a/src/MSBuild/MSBuild/Microsoft.Build.CommonTypes.xsd
+++ b/src/MSBuild/MSBuild/Microsoft.Build.CommonTypes.xsd
@@ -1893,7 +1893,7 @@ elementFormDefault="qualified">
     <xs:element name="LinkIncremental" type="msb:boolean" substitutionGroup="msb:Property"/>
     <xs:element name="ManifestCertificateThumbprint" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
     <xs:element name="ManifestKeyFile" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="EnableCustomCulture" type="msb:boolean" substitutionGroup="msb:EnableCustomCulture"/>
+    <xs:element name="EnableCustomCulture" type="msb:boolean" substitutionGroup="msb:Property"/>
     <xs:element name="MapFileExtensions" type="msb:boolean" substitutionGroup="msb:Property">
         <xs:annotation>
             <xs:documentation><!-- _locID_text="MapFileExtensions" _locComment="" -->boolean</xs:documentation>


### PR DESCRIPTION
### Context
The typo in substitutionGroup in Microsoft.Build.CommonTypes causes VS issues. 

### Changes Made
Fix the invalid element in Microsoft.Build.CommonTypes.

### Testing
Manual.
