### PR TITLE
Revert "Handle the case for updated binding redirects"

### DIFF
--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -2585,24 +2585,6 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <AppConfig Condition="$(_NewGenerateBindingRedirectsIntermediateAppConfig) == 'true'">$(_GenerateBindingRedirectsIntermediateAppConfig)</AppConfig>
     </PropertyGroup>
 
-    <PropertyGroup>
-      <ConfigFileExists Condition="Exists('@(AppConfigWithTargetPath->'$(OutDir)%(TargetPath)')')">true</ConfigFileExists>
-      <HasNoBindingRedirects Condition="'@(SuggestedBindingRedirects)' == ''">true</HasNoBindingRedirects>
-    </PropertyGroup>
-
-    <!-- Overwrites .config file with a App.config content if RAR returned empty @(SuggestedBindingRedirects). -->
-    <Copy
-      SourceFiles="@(AppConfigWithTargetPath->'%(FullPath)')"
-      DestinationFiles="$(_GenerateBindingRedirectsIntermediateAppConfig)"
-      SkipUnchangedFiles="true"
-      Condition="'$(ConfigFileExists)' == 'true' and '$(HasNoBindingRedirects)' == 'true' and '$(DesignTimeBuild)' != 'true'">
-      <Output TaskParameter="CopiedFiles" ItemName="FileWrites"/>
-    </Copy>
-    <Touch
-      Files="$(_GenerateBindingRedirectsIntermediateAppConfig)"
-      AlwaysCreate="true"
-      Condition="'$(ConfigFileExists)' == 'true' and '$(HasNoBindingRedirects)' == 'true' and '$(DesignTimeBuild)' != 'true'"/>
-
     <ItemGroup Condition="$(_NewGenerateBindingRedirectsIntermediateAppConfig) == 'true'">
       <AppConfigWithTargetPath Remove="@(AppConfigWithTargetPath)" />
       <AppConfigWithTargetPath Include="$(AppConfig)">


### PR DESCRIPTION
Reverts dotnet/msbuild#11411 since Visual Studio 2022  overwrites *.exe.config file with every run
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2477543
