### PR TITLE
Fix insertion target branches and schedule

### DIFF
--- a/azure-pipelines/vs-insertion-experimental.yml
+++ b/azure-pipelines/vs-insertion-experimental.yml
@@ -2,16 +2,6 @@
 trigger: none
 name: $(Date:yyyyMMdd).$(Rev:r)
 
-# Since our release branch is the one flowing into main
-# we will keep our main experimental insertions to make sure everything is alright
-schedules:
-  - cron: '0 3 * * 1,3,5' # Runs every Monday, Wednesday and Friday at 3AM UTC
-    displayName: Experimental VS insertion main
-    branches:
-      include:
-        - main
-    always: false # Don't run if there are no code changes
-    
 resources:
   pipelines:
   - pipeline: 'MSBuild'

--- a/azure-pipelines/vs-insertion.yml
+++ b/azure-pipelines/vs-insertion.yml
@@ -12,13 +12,13 @@ trigger: none
 pr: none
 name: $(Date:yyyyMMdd).$(Rev:r)
 
-# schedules:
-#   - cron: '0 3 * * 1-5' # Runs every weekday at 3AM UTC
-#     displayName: Daily VS insertion main
-#     branches:
-#       include:
-#         - main
-#     always: false # Don't run if there are no code changes
+schedules:
+  - cron: '0 3 * * 1-5' # Runs every weekday at 3AM UTC
+    displayName: Daily VS insertion main
+    branches:
+      include:
+        - main
+    always: false # Don't run if there are no code changes
 
 resources:
   pipelines:
@@ -66,7 +66,7 @@ variables:
   # `auto` should work every time and selecting a branch in parameters is likely to fail due to incompatible versions in MSBuild and VS
   - name: AutoInsertTargetBranch
     ${{ if eq(variables['Build.SourceBranchName'], 'vs17.14') }}:
-      value: 'main'
+      value: 'rel/d17.14'
     ${{ elseif eq(variables['Build.SourceBranchName'], 'vs17.13') }}:
       value: 'rel/d17.13'
     ${{ elseif eq(variables['Build.SourceBranchName'], 'vs17.12') }}:
@@ -227,7 +227,7 @@ extends:
               $propsValue = $props -join ";"
               Write-Host "Setting InsertPackagePropsValues to '$propsValue'"
               Write-Host "##vso[task.setvariable variable=InsertPackagePropsValues]$($propsValue)"
-              
+
               # autocomplete main
               $autocomplete = "false"
               if ("$(InsertTargetBranch)" -eq "main")

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,7 +2,7 @@
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the MIT license. See License.txt in the project root for full license information. -->
 <Project>
   <PropertyGroup>
-    <VersionPrefix>17.14.10</VersionPrefix><DotNetFinalVersionKind>release</DotNetFinalVersionKind>
+    <VersionPrefix>17.14.11</VersionPrefix><DotNetFinalVersionKind>release</DotNetFinalVersionKind>
     <PackageValidationBaselineVersion>17.13.9</PackageValidationBaselineVersion>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>
     <PreReleaseVersionLabel>servicing</PreReleaseVersionLabel>


### PR DESCRIPTION
### Context
we should be inserting 17.14 to 17.14 & the schedule should be set for main normal insertion not the experimental one

### Changes Made
Pseudo-reverts https://github.com/dotnet/msbuild/pull/11558/

### Notes
should be merged forward to main