### PR TITLE
Fix issue 11820 Add DirectoryExists() and FileExists() function

### DIFF
--- a/src/Build.UnitTests/Evaluation/IntrinsicFunctionOverload_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/IntrinsicFunctionOverload_Tests.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.IO;
 using Microsoft.Build.Evaluation;
 using Microsoft.Build.Framework;
 using Microsoft.Build.UnitTests;
@@ -119,6 +120,88 @@ namespace Microsoft.Build.Engine.UnitTests.Evaluation
             Project project = projectFromString.Project;
             ProjectProperty? actualProperty = project.GetProperty("Actual");
             actualProperty.EvaluatedValue.ShouldBe(expected);
+        }
+
+        [Fact]
+        public void FileExists_WhenFileExists_ReturnsTrue()
+        {          
+            using TestEnvironment env = TestEnvironment.Create();
+
+            string testFilePath = Path.Combine(env.DefaultTestDirectory.Path, "TestFile.txt");
+            File.WriteAllText(testFilePath, "Test content");
+
+            string projectContent = $@"
+                <Project>
+                    <PropertyGroup>
+                        <TestFilePath>{testFilePath.Replace(@"\", @"\\")}</TestFilePath>
+                        <FileExists>$([MSBuild]::FileExists($(TestFilePath)))</FileExists>
+                    </PropertyGroup>
+                </Project>";
+
+            using ProjectFromString projectFromString = new(projectContent.Cleanup());
+            Project project = projectFromString.Project;
+
+            ProjectProperty actualProperty = project.GetProperty("FileExists");
+            actualProperty.EvaluatedValue.ShouldBe("True");
+        }
+
+        [Fact]
+        public void FileExists_WhenFileDoesNotExist_ReturnsFalse()
+        {
+            const string projectContent = @"
+            <Project>
+                <PropertyGroup>
+                    <TestFilePath>NonExistentFile.txt</TestFilePath>
+                    <FileExists>$([MSBuild]::FileExists($(TestFilePath)))</FileExists>
+                </PropertyGroup>
+            </Project>";
+
+            using ProjectFromString projectFromString = new(projectContent.Cleanup());
+            Project project = projectFromString.Project;
+
+            ProjectProperty actualProperty = project.GetProperty("FileExists");
+            actualProperty.EvaluatedValue.ShouldBe("False");
+        }
+
+        [Fact]
+        public void DirectoryExists_WhenDirectoryExists_ReturnsTrue()
+        {
+            using TestEnvironment env = TestEnvironment.Create();
+            string testDirPath = Path.Combine(env.DefaultTestDirectory.Path, "TestDir");
+
+            Directory.CreateDirectory(testDirPath);
+
+            string projectContent = $@"
+            <Project>
+                <PropertyGroup>
+                    <TestDirPath>{testDirPath.Replace(@"\", @"\\")}</TestDirPath>
+                    <DirExists>$([MSBuild]::DirectoryExists($(TestDirPath)))</DirExists>
+                </PropertyGroup>
+            </Project>";
+
+            using ProjectFromString projectFromString = new(projectContent.Cleanup());
+            Project project = projectFromString.Project;
+
+            ProjectProperty actualProperty = project.GetProperty("DirExists");
+            actualProperty.EvaluatedValue.ShouldBe("True");
+        }
+
+        [Fact]
+        public void DirectoryExists_WhenDirectoryDoesNotExists_ReturnsFalse()
+        {
+            const string projectContent = @"
+            <Project>
+                <PropertyGroup>
+                    <TestDirPath>TestDir</TestDirPath>
+                    <DirExists>$([MSBuild]::DirectoryExists($(TestDirPath)))</DirExists>
+                </PropertyGroup>
+            </Project>";
+
+            using ProjectFromString projectFromString = new(projectContent.Cleanup());
+            Project project = projectFromString.Project;
+
+            ProjectProperty actualProperty = project.GetProperty("DirExists");
+            actualProperty.EvaluatedValue.ShouldBe("False");
         }
 
         [Fact]

--- a/src/Build.UnitTests/Evaluation/IntrinsicFunctionOverload_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/IntrinsicFunctionOverload_Tests.cs
@@ -164,6 +164,47 @@ namespace Microsoft.Build.Engine.UnitTests.Evaluation
         }
 
         [Fact]
+        public void SystemIODirectoryExists_WhenDirectoryExists_ReturnsTrue()
+        {
+            using TestEnvironment env = TestEnvironment.Create();
+            string testDirPath = Path.Combine(env.DefaultTestDirectory.Path, "TestDir");
+
+            Directory.CreateDirectory(testDirPath);
+
+            string projectContent = $@"
+                <Project>
+                    <PropertyGroup>
+                        <TestDirPath>{testDirPath.Replace(@"\", @"\\")}</TestDirPath>
+                        <DirExists>$([System.IO.Directory]::Exists($(TestDirPath)))</DirExists>
+                    </PropertyGroup>
+                </Project>";
+
+            using ProjectFromString projectFromString = new(projectContent.Cleanup());
+            Project project = projectFromString.Project;
+
+            ProjectProperty actualProperty = project.GetProperty("DirExists");
+            actualProperty.EvaluatedValue.ShouldBe("True");
+        }
+
+        [Fact]
+        public void SystemIODirectoryExists_WhenDirectoryDoesNotExist_ReturnsFalse()
+        {
+            const string projectContent = @"
+            <Project>
+                <PropertyGroup>
+                    <TestDirPath>TestDir</TestDirPath>
+                    <DirExists>$([System.IO.Directory]::Exists($(TestDirPath)))</DirExists>
+                </PropertyGroup>
+            </Project>";
+
+            using ProjectFromString projectFromString = new(projectContent.Cleanup());
+            Project project = projectFromString.Project;
+
+            ProjectProperty actualProperty = project.GetProperty("DirExists");
+            actualProperty.EvaluatedValue.ShouldBe("False");
+        }
+
+        [Fact]
         public void DirectoryExists_WhenDirectoryExists_ReturnsTrue()
         {
             using TestEnvironment env = TestEnvironment.Create();

--- a/src/Build/Evaluation/Expander/WellKnownFunctions.cs
+++ b/src/Build/Evaluation/Expander/WellKnownFunctions.cs
@@ -744,6 +744,22 @@ namespace Microsoft.Build.Evaluation.Expander
                     return true;
                 }
             }
+            else if (string.Equals(methodName, nameof(IntrinsicFunctions.FileExists), StringComparison.OrdinalIgnoreCase))
+            {
+                if (ParseArgs.TryGetArg(args, out string? arg0))
+                {
+                    returnVal = IntrinsicFunctions.FileExists(arg0);
+                    return true;
+                }
+            }
+            else if (string.Equals(methodName, nameof(IntrinsicFunctions.DirectoryExists), StringComparison.OrdinalIgnoreCase))
+            {
+                if (ParseArgs.TryGetArg(args, out string? arg0))
+                {
+                    returnVal = IntrinsicFunctions.DirectoryExists(arg0);
+                    return true;
+                }
+            }
             return false;
         }
 

--- a/src/Build/Evaluation/IntrinsicFunctions.cs
+++ b/src/Build/Evaluation/IntrinsicFunctions.cs
@@ -540,6 +540,26 @@ namespace Microsoft.Build.Evaluation
         }
 
         /// <summary>
+        /// Returns if the file exists
+        /// </summary>
+        /// <param name="path">The path to check</param>
+        /// <returns></returns>
+        internal static bool FileExists(string path)
+        {
+            return FileUtilities.FileExistsNoThrow(path);
+        }
+
+        /// <summary>
+        /// Returns if the directory exists
+        /// </summary>
+        /// <param name="path">The path to check</param>
+        /// <returns></returns>
+        internal static bool DirectoryExists(string path)
+        {
+            return FileUtilities.DirectoryExistsNoThrow(path);
+        }
+
+        /// <summary>
         /// Gets the canonicalized full path of the provided path and ensures it contains the correct directory separator characters for the current operating system.
         /// </summary>
         /// <param name="path">One or more paths to combine and normalize.</param>

--- a/src/Build/Resources/Constants.cs
+++ b/src/Build/Resources/Constants.cs
@@ -325,6 +325,7 @@ namespace Microsoft.Build.Internal
                         availableStaticMethods.TryAdd("System.IO.Directory::GetLastWriteTime", directoryType);
                         availableStaticMethods.TryAdd("System.IO.Directory::GetParent", directoryType);
                         availableStaticMethods.TryAdd("System.IO.Directory::Exists", directoryType);
+
                         availableStaticMethods.TryAdd("System.IO.File::Exists", fileType);
                         availableStaticMethods.TryAdd("System.IO.File::GetCreationTime", fileType);
                         availableStaticMethods.TryAdd("System.IO.File::GetAttributes", fileType);

--- a/src/Build/Resources/Constants.cs
+++ b/src/Build/Resources/Constants.cs
@@ -324,6 +324,7 @@ namespace Microsoft.Build.Internal
                         availableStaticMethods.TryAdd("System.IO.Directory::GetLastAccessTime", directoryType);
                         availableStaticMethods.TryAdd("System.IO.Directory::GetLastWriteTime", directoryType);
                         availableStaticMethods.TryAdd("System.IO.Directory::GetParent", directoryType);
+                        availableStaticMethods.TryAdd("System.IO.Directory::Exists", directoryType);
                         availableStaticMethods.TryAdd("System.IO.File::Exists", fileType);
                         availableStaticMethods.TryAdd("System.IO.File::GetCreationTime", fileType);
                         availableStaticMethods.TryAdd("System.IO.File::GetAttributes", fileType);

--- a/src/Build/Resources/Constants.cs
+++ b/src/Build/Resources/Constants.cs
@@ -319,12 +319,12 @@ namespace Microsoft.Build.Internal
                         availableStaticMethods.TryAdd("System.Environment::Version", environmentType);
                         availableStaticMethods.TryAdd("System.Environment::WorkingSet", environmentType);
 
+                        availableStaticMethods.TryAdd("System.IO.Directory::Exists", directoryType);
                         availableStaticMethods.TryAdd("System.IO.Directory::GetDirectories", directoryType);
                         availableStaticMethods.TryAdd("System.IO.Directory::GetFiles", directoryType);
                         availableStaticMethods.TryAdd("System.IO.Directory::GetLastAccessTime", directoryType);
                         availableStaticMethods.TryAdd("System.IO.Directory::GetLastWriteTime", directoryType);
-                        availableStaticMethods.TryAdd("System.IO.Directory::GetParent", directoryType);
-                        availableStaticMethods.TryAdd("System.IO.Directory::Exists", directoryType);
+                        availableStaticMethods.TryAdd("System.IO.Directory::GetParent", directoryType);                      
 
                         availableStaticMethods.TryAdd("System.IO.File::Exists", fileType);
                         availableStaticMethods.TryAdd("System.IO.File::GetCreationTime", fileType);


### PR DESCRIPTION
Fixes #
Fix the issue 11820, add two function DirectoryExists() and FileExists() https://github.com/dotnet/msbuild/issues/11820

### Context
Currently, doesn't have any goodway to check the File or the Directory is exist or not, and the [System.IO.Directory]::Exists() is not allowed.
### Changes Made
Add two function DirectoryExists() and FileExists() in the msbuild, now we can use [MSBuild]::FileExist() or [MSBuild]::DirectoryExists() in the project files

### Testing
I have performed testing for various exception to validate the changes. Tested two case FileExists and DirectoryExist

### Notes
