### PR TITLE
Avoid closure object allocations in TaskItem.CopyMetadataTo

### DIFF
--- a/src/Build/Instance/ProjectItemInstance.cs
+++ b/src/Build/Instance/ProjectItemInstance.cs
@@ -1452,20 +1452,7 @@ namespace Microsoft.Build.Execution
                 else if (destinationItem is IMetadataContainer destinationItemAsMetadataContainer)
                 {
                     // The destination implements IMetadataContainer so we can use the ImportMetadata bulk-set operation.
-                    IEnumerable<ProjectMetadataInstance> metadataEnumerable = MetadataCollection;
-                    IEnumerable<KeyValuePair<string, string>> metadataToImport = metadataEnumerable
-                        .Where(metadatum => string.IsNullOrEmpty(destinationItem.GetMetadata(metadatum.Name)))
-                        .Select(metadatum => new KeyValuePair<string, string>(metadatum.Name, GetMetadataEscaped(metadatum.Name)));
-
-#if FEATURE_APPDOMAIN
-                    if (RemotingServices.IsTransparentProxy(destinationItem))
-                    {
-                        // Linq is not serializable so materialize the collection before making the call.
-                        metadataToImport = metadataToImport.ToList();
-                    }
-#endif
-
-                    destinationItemAsMetadataContainer.ImportMetadata(metadataToImport);
+                    BulkImportMetadata(destinationItem, destinationItemAsMetadataContainer);
                 }
                 else
                 {
@@ -1490,6 +1477,24 @@ namespace Microsoft.Build.Execution
                         destinationItem.SetMetadata("OriginalItemSpec", _includeEscaped);
                     }
                 }
+            }
+
+            private void BulkImportMetadata(ITaskItem destinationItem, IMetadataContainer destinationItemAsMetadataContainer)
+            {
+                IEnumerable<ProjectMetadataInstance> metadataEnumerable = MetadataCollection;
+                IEnumerable<KeyValuePair<string, string>> metadataToImport = metadataEnumerable
+                    .Where(metadatum => string.IsNullOrEmpty(destinationItem.GetMetadata(metadatum.Name)))
+                    .Select(metadatum => new KeyValuePair<string, string>(metadatum.Name, GetMetadataEscaped(metadatum.Name)));
+
+#if FEATURE_APPDOMAIN
+                if (RemotingServices.IsTransparentProxy(destinationItem))
+                {
+                    // Linq is not serializable so materialize the collection before making the call.
+                    metadataToImport = metadataToImport.ToList();
+                }
+#endif
+
+                destinationItemAsMetadataContainer.ImportMetadata(metadataToImport);
             }
 
             /// <summary>

--- a/src/Build/Instance/ProjectItemInstance.cs
+++ b/src/Build/Instance/ProjectItemInstance.cs
@@ -1479,6 +1479,7 @@ namespace Microsoft.Build.Execution
                 }
             }
 
+            // PERF: Keep this method extracted to avoid unconditionally allocating a closure object
             private void BulkImportMetadata(ITaskItem destinationItem, IMetadataContainer destinationItemAsMetadataContainer)
             {
                 IEnumerable<ProjectMetadataInstance> metadataEnumerable = MetadataCollection;


### PR DESCRIPTION
Fixes #

We can avoid some closure object creations by extracting a portion of the existing code.


### Context

There are a non-trivial amount of allocations coming from this path, and we can reduce them by creating another method that is only called when we need the closure

![image](https://github.com/user-attachments/assets/a8399901-0caf-4902-b07f-00141f18ec9f)


### Changes Made


### Testing


### Notes
