### PR TITLE
Avoid enumerator boxing for ItemBucket

### DIFF
--- a/src/Build.UnitTests/BackEnd/TaskExecutionHost_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/TaskExecutionHost_Tests.cs
@@ -1282,7 +1282,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             itemsByName.Add(item2);
             _twoItems = new ITaskItem[] { new TaskItem(item), new TaskItem(item2) };
 
-            _bucket = new ItemBucket(Array.Empty<string>(), new Dictionary<string, string>(), new Lookup(itemsByName, new PropertyDictionary<ProjectPropertyInstance>()), 0);
+            _bucket = new ItemBucket(new Dictionary<string, ICollection<ProjectItemInstance>>().Keys, new Dictionary<string, string>(), new Lookup(itemsByName, new PropertyDictionary<ProjectPropertyInstance>()), 0);
             _bucket.Initialize(null);
             _host.FindTask(null);
             _host.InitializeForBatch(talc, _bucket, null);

--- a/src/Build/BackEnd/Components/RequestBuilder/ItemBucket.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/ItemBucket.cs
@@ -74,7 +74,7 @@ namespace Microsoft.Build.BackEnd
         /// <param name="lookup">The <see cref="Lookup"/> to use for the items in the bucket.</param>
         /// <param name="bucketSequenceNumber">A sequence number indication what order the buckets were created in.</param>
         internal ItemBucket(
-            ICollection<string> itemNames,
+            Dictionary<string, ICollection<ProjectItemInstance>>.KeyCollection itemNames, // PERF: directly use the KeyCollection to avoid boxing the enumerator.
             Dictionary<string, string> metadata,
             Lookup lookup,
             int bucketSequenceNumber)


### PR DESCRIPTION
Fixes #

The ItemBucket constructor enumerates some dictionary keys through the ICollection<T> interface that causes allocations by boxing an enumerator.

### Context
 The only type that's passed to the constructor is a dictionary and we pass the associated KeyCollection which ends up getting boxed. We can just pass the concrete type to avoid this.

![image](https://github.com/user-attachments/assets/99ad2076-782f-4544-b174-d3aee5675784)


### Changes Made


### Testing


### Notes
