### PR TITLE
update to stop closures from lazy functions and linq

### DIFF
--- a/src/Build/Evaluation/LazyItemEvaluator.IncludeOperation.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.IncludeOperation.cs
@@ -39,7 +39,6 @@ namespace Microsoft.Build.Evaluation
             {
                 ImmutableArray<I>.Builder? itemsToAdd = null;
 
-                Func<string, bool>? excludeTester = null;
                 ImmutableList<string>.Builder excludePatterns = ImmutableList.CreateBuilder<string>();
                 if (_excludes != null)
                 {
@@ -53,14 +52,10 @@ namespace Microsoft.Build.Evaluation
                 }
 
                 ISet<string>? excludePatternsForGlobs = null;
+                Func<string, bool>? excludeTester = excludePatterns.Count > 0 ? EngineFileUtilities.GetFileSpecMatchTester(excludePatterns, _rootDirectory) : null;
 
                 foreach (var fragment in _itemSpec.Fragments)
                 {
-                    if (excludeTester is null && excludePatterns.Count > 0)
-                    {
-                        excludeTester = EngineFileUtilities.GetFileSpecMatchTester(excludePatterns, _rootDirectory);
-                    }
-
                     if (fragment is ItemSpec<P, I>.ItemExpressionFragment itemReferenceFragment)
                     {
                         // STEP 3: If expression is "@(x)" copy specified list with its metadata, otherwise just treat as string
@@ -94,7 +89,7 @@ namespace Microsoft.Build.Evaluation
                     {
                         string value = valueFragment.TextFragment;
 
-                        if (excludeTester is not null && !excludeTester(EscapingUtilities.UnescapeAll(value)))
+                        if (excludeTester is null || !excludeTester(EscapingUtilities.UnescapeAll(value)))
                         {
                             itemsToAdd ??= ImmutableArray.CreateBuilder<I>();
                             itemsToAdd.Add(_itemFactory.CreateItem(value, value, _itemElement.ContainingProject.FullPath));

--- a/src/Build/Evaluation/LazyItemEvaluator.IncludeOperation.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.IncludeOperation.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Build.Evaluation
             {
                 ImmutableArray<I>.Builder? itemsToAdd = null;
 
-                Lazy<Func<string, bool>>? excludeTester = null;
+                Func<string, bool>? excludeTester = null;
                 ImmutableList<string>.Builder excludePatterns = ImmutableList.CreateBuilder<string>();
                 if (_excludes != null)
                 {
@@ -50,17 +50,17 @@ namespace Microsoft.Build.Evaluation
                         var excludeSplits = ExpressionShredder.SplitSemiColonSeparatedList(excludeExpanded);
                         excludePatterns.AddRange(excludeSplits);
                     }
-
-                    if (excludePatterns.Count > 0)
-                    {
-                        excludeTester = new Lazy<Func<string, bool>>(() => EngineFileUtilities.GetFileSpecMatchTester(excludePatterns, _rootDirectory));
-                    }
                 }
 
                 ISet<string>? excludePatternsForGlobs = null;
 
                 foreach (var fragment in _itemSpec.Fragments)
                 {
+                    if (excludeTester is null && excludePatterns.Count > 0)
+                    {
+                        excludeTester = EngineFileUtilities.GetFileSpecMatchTester(excludePatterns, _rootDirectory);
+                    }
+
                     if (fragment is ItemSpec<P, I>.ItemExpressionFragment itemReferenceFragment)
                     {
                         // STEP 3: If expression is "@(x)" copy specified list with its metadata, otherwise just treat as string
@@ -74,16 +74,27 @@ namespace Microsoft.Build.Evaluation
                             elementLocation: _itemElement.IncludeLocation);
 
                         itemsToAdd ??= ImmutableArray.CreateBuilder<I>();
-                        itemsToAdd.AddRange(
-                            excludeTester != null
-                                ? itemsFromExpression.Where(item => !excludeTester.Value(item.EvaluatedInclude))
-                                : itemsFromExpression);
+
+                        if (excludeTester is not null)
+                        {
+                            foreach (var item in itemsFromExpression)
+                            {
+                                if (!excludeTester(item.EvaluatedInclude))
+                                {
+                                    itemsToAdd.Add(item);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            itemsToAdd.AddRange(itemsFromExpression);
+                        }
                     }
                     else if (fragment is ValueFragment valueFragment)
                     {
                         string value = valueFragment.TextFragment;
 
-                        if (excludeTester?.Value(EscapingUtilities.UnescapeAll(value)) != true)
+                        if (excludeTester is not null && !excludeTester(EscapingUtilities.UnescapeAll(value)))
                         {
                             itemsToAdd ??= ImmutableArray.CreateBuilder<I>();
                             itemsToAdd.Add(_itemFactory.CreateItem(value, value, _itemElement.ContainingProject.FullPath));


### PR DESCRIPTION
Fixes : Allocation issue.

### Context
Looking at a trace of allocations. It was shown that some of the allocations were coming from closures. This pr addresses the closures found.

### Changes Made
* Removed lazy from exclude tester function since it was not needed since lifetime of lazy object was within the method itself.
* switched from linq clause for add range to manually adding items, because the linq version caused a closure from a method it did not have context with.

### Testing
Used ILSpy to verify that the closures disappeared. (DisplayClass represents a closure)
Before
![image](https://github.com/user-attachments/assets/123f3b9f-4d2e-4f1d-bcba-2dcbe9144741)

Afterwards
![image](https://github.com/user-attachments/assets/9a7b9f91-1466-4de9-a0ff-579e0d5407bc)



### Notes
