### PR TITLE
Reduce pipe read allocations due to async state and context capturing

### DIFF
--- a/src/Build/BackEnd/Client/MSBuildClientPacketPump.cs
+++ b/src/Build/BackEnd/Client/MSBuildClientPacketPump.cs
@@ -207,25 +207,26 @@ namespace Microsoft.Build.BackEnd.Client
 #if FEATURE_APM
                 IAsyncResult result = localStream.BeginRead(headerByte, 0, headerByte.Length, null, null);
 #else
-                Task<int> readTask = CommunicationsUtilities.ReadAsync(localStream, headerByte, headerByte.Length).AsTask();
+                Task<int> readTask = localStream.ReadAsync(headerByte.AsMemory(), CancellationToken.None).AsTask();
 #endif
+
+                // Ordering of the wait handles is important. The first signalled wait handle in the array
+                // will be returned by WaitAny if multiple wait handles are signalled. We prefer to have the
+                // terminate event triggered so that we cannot get into a situation where packets are being
+                // spammed to the client and it never gets an opportunity to shutdown.
+                WaitHandle[] handles =
+                [
+                    localPacketPumpShutdownEvent,
+#if FEATURE_APM
+                    result.AsyncWaitHandle
+#else
+                    ((IAsyncResult)readTask).AsyncWaitHandle
+#endif
+                ];
 
                 bool continueReading = true;
                 do
                 {
-                    // Ordering of the wait handles is important. The first signalled wait handle in the array
-                    // will be returned by WaitAny if multiple wait handles are signalled. We prefer to have the
-                    // terminate event triggered so that we cannot get into a situation where packets are being
-                    // spammed to the client and it never gets an opportunity to shutdown.
-                    WaitHandle[] handles =
-                    [
-                        localPacketPumpShutdownEvent,
-#if FEATURE_APM
-                        result.AsyncWaitHandle
-#else
-                        ((IAsyncResult)readTask).AsyncWaitHandle
-#endif
-                    ];
                     int waitId = WaitHandle.WaitAny(handles);
                     switch (waitId)
                     {
@@ -242,7 +243,7 @@ namespace Microsoft.Build.BackEnd.Client
 #if FEATURE_APM
                                 headerBytesRead = localStream.EndRead(result);
 #else
-                                headerBytesRead = readTask.Result;
+                                headerBytesRead = readTask.ConfigureAwait(false).GetAwaiter().GetResult();
 #endif
 
                                 if ((headerBytesRead != headerByte.Length) && !localPacketPumpShutdownEvent.WaitOne(0))
@@ -275,7 +276,12 @@ namespace Microsoft.Build.BackEnd.Client
 
                                 while (packetBytesRead < packetLength)
                                 {
+#if FEATURE_APM
                                     int bytesRead = localStream.Read(packetData, packetBytesRead, packetLength - packetBytesRead);
+#else
+                                    ValueTask<int> bytesReadTask = localStream.ReadAsync(packetData.AsMemory(packetBytesRead, packetLength - packetBytesRead));
+                                    int bytesRead = bytesReadTask.IsCompleted ? bytesReadTask.Result : bytesReadTask.AsTask().ConfigureAwait(false).GetAwaiter().GetResult();;
+#endif
                                     if (bytesRead == 0)
                                     {
                                         // Incomplete read.  Abort.
@@ -305,8 +311,10 @@ namespace Microsoft.Build.BackEnd.Client
                                     // Start reading the next package header.
 #if FEATURE_APM
                                     result = localStream.BeginRead(headerByte, 0, headerByte.Length, null, null);
+                                    handles[1] = result.AsyncWaitHandle;
 #else
-                                    readTask = CommunicationsUtilities.ReadAsync(localStream, headerByte, headerByte.Length).AsTask();
+                                    readTask = localStream.ReadAsync(headerByte.AsMemory(), CancellationToken.None).AsTask();
+                                    handles[1] = ((IAsyncResult)readTask).AsyncWaitHandle;
 #endif
                                 }
                             }

--- a/src/Shared/NodeEndpointOutOfProcBase.cs
+++ b/src/Shared/NodeEndpointOutOfProcBase.cs
@@ -524,7 +524,7 @@ namespace Microsoft.Build.BackEnd
 #if NET451_OR_GREATER
             Task<int> readTask = localReadPipe.ReadAsync(headerByte, 0, headerByte.Length, CancellationToken.None);
 #elif NETCOREAPP
-            Task<int> readTask = CommunicationsUtilities.ReadAsync(localReadPipe, headerByte, headerByte.Length).AsTask();
+            Task<int> readTask = localReadPipe.ReadAsync(headerByte.AsMemory(), CancellationToken.None).AsTask();
 #else
             IAsyncResult result = localReadPipe.BeginRead(headerByte, 0, headerByte.Length, null, null);
 #endif
@@ -554,7 +554,7 @@ namespace Microsoft.Build.BackEnd
                             try
                             {
 #if NET451_OR_GREATER || NETCOREAPP
-                                bytesRead = readTask.Result;
+                                bytesRead = readTask.ConfigureAwait(false).GetAwaiter().GetResult();
 #else
                                 bytesRead = localReadPipe.EndRead(result);
 #endif


### PR DESCRIPTION
### Changes

- Unroll looped uses of `CommunicationsUtils.ReadAsync` to avoid redundant state machine allocations.
- Add missing `ConfigureAwait(false)` to awaited reads to reduce allocations due to context capturing.
- Avoid creating a `Task` when `ReadAsync()` completes synchronously and returns a `ValueTask`.

### Context

Currently the pipe read loops on .NET Core go through a helper in `CommunicationsUtilities` that looks like this:

```cs
internal static async ValueTask<int> ReadAsync(Stream stream, byte[] buffer, int bytesToRead)
{
	int totalBytesRead = 0;
	while (totalBytesRead < bytesToRead)
	{
		int bytesRead = await stream.ReadAsync(buffer.AsMemory(totalBytesRead, bytesToRead - totalBytesRead), CancellationToken.None);
		if (bytesRead == 0)
		{
			return totalBytesRead;
		}
		totalBytesRead += bytesRead;
	}
	return totalBytesRead;
}
```

Unfortunately when used within an outer loop, this leads to a ton of extra allocations due to having to create a new `AsyncStateMachineBox` for every iteration.

Here's an example:
```
System.Runtime.CompilerServices.AsyncTaskMethodBuilder+AsyncStateMachineBox<Int32, CommunicationsUtilities+<ReadAsync>d__17>
  Objects : 552567
  Bytes   : 75149112

 100%  GetStateMachineBox • 71.67 MB / 71.67 MB • System.Runtime.CompilerServices.AsyncTaskMethodBuilder<TResult>.GetStateMachineBox<TStateMachine>(TStateMachine, Task<TResult>)
  ►  96.8%  MoveNext • 69.40 MB / - • Microsoft.Build.Internal.CommunicationsUtilities+<ReadAsync>d__17.MoveNext()
  ►  3.16%  AwaitUnsafeOnCompleted • 2.27 MB / - • System.Runtime.CompilerServices.AsyncTaskMethodBuilder<TResult>.AwaitUnsafeOnCompleted<TAwaiter, TStateMachine>(TAwaiter, TStateMachine, Task<TResult>)
```

Using `NodeProviderOutOfProcBase.ReadPacketLoopAsync()` as an example - after this change, we only see the single state machine allocations for the outer loop as it's reused, even when the async method schedules a continuation:
```
System.Runtime.CompilerServices.AsyncTaskMethodBuilder+AsyncStateMachineBox<VoidTaskResult, NodeProviderOutOfProcBase+NodeContext+<RunPacketReadLoopAsync>d__20>
  Objects : 15
  Bytes   : 1920

 100%  GetStateMachineBox • 1.9 KB / 1.9 KB • System.Runtime.CompilerServices.AsyncTaskMethodBuilder<TResult>.GetStateMachineBox<TStateMachine>(TStateMachine, Task<TResult>)
 ...
```
Here's two profiles comparing total before / after on a .NET Core build (see objects allocated, total allocations, ect.)

![Pasted image 20250530154531](https://github.com/user-attachments/assets/35d7b0ec-2aa3-46e4-b5ab-5fe442b0d992)

![Pasted image 20250530154433](https://github.com/user-attachments/assets/b0e96c4b-c671-4575-b492-561d6000989b)
