### PR TITLE
remove some closures as well as boxing from enumerator

### DIFF
--- a/src/Build/BackEnd/Components/RequestBuilder/Lookup.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/Lookup.cs
@@ -860,10 +860,9 @@ namespace Microsoft.Build.BackEnd
             {
 
                 // Perf: Avoid boxing when possible by getting the underlying struct enumerator if available.
-                List<string> metadataToRemove;
+                List<string> metadataToRemove = new List<string>(); ;
                 if (itemToModify.Metadata is CopyOnWritePropertyDictionary<ProjectMetadataInstance> copyOnWritePropertyMetadata)
                 {
-                    metadataToRemove = new List<string>(copyOnWritePropertyMetadata.Count);
                     foreach (var m in copyOnWritePropertyMetadata)
                     {
                         string name = m.Value.Name;
@@ -875,7 +874,6 @@ namespace Microsoft.Build.BackEnd
                 }
                 else
                 {
-                    metadataToRemove = new List<string>();
                     foreach (var m in itemToModify.Metadata)
                     {
                         if (modificationsToApply[m.Name].Remove)

--- a/src/Build/BackEnd/Components/RequestBuilder/Lookup.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/Lookup.cs
@@ -859,7 +859,7 @@ namespace Microsoft.Build.BackEnd
             if (modificationsToApply.KeepOnlySpecified)
             {
 
-                // Perf: Avoid boxing when possible by getting the underlying struct enumertor if available.
+                // Perf: Avoid boxing when possible by getting the underlying struct enumerator if available.
                 List<string> metadataToRemove;
                 if (itemToModify.Metadata is CopyOnWritePropertyDictionary<ProjectMetadataInstance> copyOnWritePropertyMetadata)
                 {

--- a/src/Build/BackEnd/Components/RequestBuilder/Lookup.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/Lookup.cs
@@ -858,7 +858,33 @@ namespace Microsoft.Build.BackEnd
             // or if keepOnlySpecified == true and there is no entry for that name.
             if (modificationsToApply.KeepOnlySpecified)
             {
-                List<string> metadataToRemove = new List<string>(itemToModify.Metadata.Where(m => modificationsToApply[m.Name].Remove).Select(m => m.Name));
+
+                // Perf: Avoid boxing when possible by getting the underlying struct enumertor if available.
+                List<string> metadataToRemove;
+                if (itemToModify.Metadata is CopyOnWritePropertyDictionary<ProjectMetadataInstance> copyOnWritePropertyMetadata)
+                {
+                    metadataToRemove = new List<string>(copyOnWritePropertyMetadata.Count);
+                    foreach (var m in copyOnWritePropertyMetadata)
+                    {
+                        string name = m.Value.Name;
+                        if (modificationsToApply[name].Remove)
+                        {
+                            metadataToRemove.Add(name);
+                        }
+                    }
+                }
+                else
+                {
+                    metadataToRemove = new List<string>();
+                    foreach (var m in itemToModify.Metadata)
+                    {
+                        if (modificationsToApply[m.Name].Remove)
+                        {
+                            metadataToRemove.Add(m.Name);
+                        }
+                    }
+                }
+
                 foreach (var metadataName in metadataToRemove)
                 {
                     itemToModify.RemoveMetadata(metadataName);


### PR DESCRIPTION
Fixes # Captures that lead to allocations.

### Context
Based on a trace was able to see that allocations from captures that were from using linq without the correct context.

### Changes Made
Manually created a list instead of using the where clause to create one.
Also moved over to grabbing the underlying struct enumerator when possible to avoid boxing.

### Testing

Looked at the dll in ILSPY to verify change in closures.

Before. (Display Class shows a capture)
![image](https://github.com/user-attachments/assets/272679f2-ea1a-4d56-990e-1f9fdb9776bd)

After (no more DisplayClass)
![image](https://github.com/user-attachments/assets/905775a6-4de9-4550-b281-55812ab2d1f8)

### Notes
