### PR TITLE
Remove closures from ExpandItemIntoItems

### DIFF
--- a/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupIntrinsicTask.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupIntrinsicTask.cs
@@ -474,6 +474,9 @@ namespace Microsoft.Build.BackEnd
             {
                 // Calculate all Exclude
                 var excludesUnescapedForComparison = EvaluateExcludePaths(excludes, originalItem.ExcludeLocation);
+
+                // Perf: removing Linq to avoid closures.
+                // Note: this may not be optimal but decided to initialize the list with the same size as items to avoid resizing it later.
                 var filteredProjectItems = new List<ProjectItemInstance>(items.Count);
                 foreach (ProjectItemInstance item in items)
                 {

--- a/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupIntrinsicTask.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupIntrinsicTask.cs
@@ -474,7 +474,7 @@ namespace Microsoft.Build.BackEnd
             {
                 // Calculate all Exclude
                 var excludesUnescapedForComparison = EvaluateExcludePaths(excludes, originalItem.ExcludeLocation);
-                var filteredProjectItems = new List<ProjectItemInstance>();
+                var filteredProjectItems = new List<ProjectItemInstance>(items.Count);
                 foreach (ProjectItemInstance item in items)
                 {
                     if (!excludesUnescapedForComparison.Contains(((IItem)item).EvaluatedInclude.NormalizeForPathComparison()))

--- a/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupIntrinsicTask.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupIntrinsicTask.cs
@@ -474,11 +474,16 @@ namespace Microsoft.Build.BackEnd
             {
                 // Calculate all Exclude
                 var excludesUnescapedForComparison = EvaluateExcludePaths(excludes, originalItem.ExcludeLocation);
+                var filteredProjectItems = new List<ProjectItemInstance>();
+                foreach (ProjectItemInstance item in items)
+                {
+                    if (!excludesUnescapedForComparison.Contains(((IItem)item).EvaluatedInclude.NormalizeForPathComparison()))
+                    {
+                        filteredProjectItems.Add(item);
+                    }
+                }
 
-                // Subtract any Exclude
-                items = items
-                    .Where(i => !excludesUnescapedForComparison.Contains(((IItem)i).EvaluatedInclude.NormalizeForPathComparison()))
-                    .ToList();
+                items = filteredProjectItems;
             }
 
             // Filter the metadata as appropriate


### PR DESCRIPTION
Fixes #

### Context
Based on some traces there were some closures from a linq call without the right context. This caused extra allocations and this addresses it.

### Changes Made
Instead of using linq to filter ites, just used a for loop to create a filtered list

### Testing
Compared with ILSpy that there were less closures and allocations (DisplayName)
Before
![image](https://github.com/user-attachments/assets/7971ebe3-bf1f-4eb8-9b1f-ebfc46a09077)


After
![image](https://github.com/user-attachments/assets/901dae33-c694-4e96-9460-d964584cbf49)


### Notes
