### PR TITLE
Revert "Include resources in command line arguments produced by csc in design-time build"

### DIFF
--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -3190,8 +3190,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       AssignTargetPaths;
       SplitResourcesByCulture;
       CreateManifestResourceNames;
-      CreateCustomManifestResourceNames;
-      AssignEmbeddedResourceOutputPaths;
+      CreateCustomManifestResourceNames
     </PrepareResourceNamesDependsOn>
   </PropertyGroup>
 
@@ -3247,17 +3246,6 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <Output TaskParameter="AssignedFiles" ItemName="_DeploymentBaseManifestWithTargetPath" />
     </AssignTargetPath>
 
-  </Target>
-
-  <!--
-    Sets OutputResource metadata on EmbeddedResource items. This metadata is used in design time build without running ResGen target.
-  -->
-  <Target Name="AssignEmbeddedResourceOutputPaths">
-    <ItemGroup>
-      <EmbeddedResource>
-        <OutputResource>$(IntermediateOutputPath)%(EmbeddedResource.ManifestResourceName).resources</OutputResource>
-      </EmbeddedResource>
-    </ItemGroup>
   </Target>
 
   <!--
@@ -3466,7 +3454,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         StronglyTypedNamespace="%(EmbeddedResource.StronglyTypedNamespace)"
         StronglyTypedManifestPrefix="%(EmbeddedResource.StronglyTypedManifestPrefix)"
         PublicClass="%(EmbeddedResource.PublicClass)"
-        OutputResources="@(EmbeddedResource->'%(OutputResource)')"
+        OutputResources="@(EmbeddedResource->'$(IntermediateOutputPath)%(ManifestResourceName).resources')"
         Condition="'%(EmbeddedResource.Type)' == 'Resx' and '%(EmbeddedResource.GenerateResource)' != 'false' and '$(GenerateResourceMSBuildRuntime)' != 'CLR2'"
         SdkToolsPath="$(ResgenToolPath)"
         ExecuteAsTool="$(ResGenExecuteAsTool)"
@@ -3676,7 +3664,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     Create the _CoreCompileResourceInputs list of inputs to the CoreCompile target.
     ============================================================
     -->
-  <Target Name="_GenerateCompileInputs" DependsOnTargets="PrepareResourceNames">
+  <Target Name="_GenerateCompileInputs">
 
     <MSBuildInternalMessage
       Condition="'@(ManifestResourceWithNoCulture)'!='' and '%(ManifestResourceWithNoCulture.EmittedForCompatibilityOnly)'==''"


### PR DESCRIPTION
Reverts dotnet/msbuild#11893 because it causes issues in VMR https://github.com/dotnet/dotnet/pull/918#issuecomment-2934835328