### PR TITLE
#10788 - docs: mention that patched .NET SDK is now an output of the bootstrap…

### DIFF
--- a/documentation/Deploy-MSBuild.md
+++ b/documentation/Deploy-MSBuild.md
@@ -26,3 +26,14 @@ Deploy-MSBuild can also patch a .NET (Core) SDK installation. Pass the `-runtime
 ### Linux
 
 There isn’t a shell script for deploying MSBuild. Instead, you’ll need to [install the PowerShell tool](https://learn.microsoft.com/powershell/scripting/install/installing-powershell-on-linux) and execute `Deploy-MSBuild.ps1` using the tool on Unix platforms with the command: `pwsh scripts\Deploy-MSBuild.ps1`.
+
+## Automatically-Patched SDK from Bootstrap
+
+As of [recent changes to the bootstrap process](https://github.com/dotnet/msbuild/blob/9c89563239bd60739920991211649d899b32ecb4/documentation/wiki/Bootstrap.md), building MSBuild now automatically creates a patched .NET SDK as part of the normal build output. This patched SDK is located in the bootstrap folder and contains the fresh MSBuild bits integrated with a compatible .NET SDK version.
+The bootstrap SDK is primarily used for:
+
+- End-to-end testing
+- CI runs
+- Development and testing scenarios where you need MSBuild changes integrated with the .NET SDK
+
+For most development and testing scenarios, you can use this automatically generated bootstrap SDK instead of manually patching an existing SDK installation.


### PR DESCRIPTION
# Context

The bootstrap process was updated to automatically create a patched .NET SDK during the build process, but this wasn't documented in the Deploy-MSBuild.md file. Users needed to know that having a patched .NET SDK is now a normal output of the build.

# Changes Made

- Added a new "Bootstrap SDK" section to Deploy-MSBuild.md
- Documented that the build process now automatically creates a patched .NET SDK in the bootstrap folder
- Explained the purpose and usage of the bootstrap SDK for testing and development
- Noted that developers can use the bootstrap SDK instead of manually patching SDK installations

# Testing

Verified the documentation accurately reflects the current bootstrap behavior
Confirmed the new section provides clear guidance for developers

# Notes

This is a documentation-only change that addresses the gap between the current bootstrap implementation and the documentation available to users.