### PR TITLE
Avoid eagerly allocating in GetReferencedItemNamesAndMetadata

### DIFF
--- a/src/Build/Evaluation/ExpressionShredder.cs
+++ b/src/Build/Evaluation/ExpressionShredder.cs
@@ -300,9 +300,9 @@ namespace Microsoft.Build.Evaluation
                         i--;
                     }
 
-                    // Grab the name, but continue to verify it's a well-formed expression
+                    // Grab the name boundaries, but continue to verify it's a well-formed expression
                     // before we store it.
-                    string name = expression.Substring(startOfName, i - startOfName);
+                    int nameLength = i - startOfName;
 
                     SinkWhitespace(expression, ref i);
 
@@ -378,7 +378,7 @@ namespace Microsoft.Build.Evaluation
                     if ((whatToShredFor & ShredderOptions.ItemTypes) != 0)
                     {
                         pair.Items ??= new HashSet<string>(MSBuildNameIgnoreCaseComparer.Default);
-                        pair.Items.Add(name);
+                        pair.Items.Add(expression.Substring(startOfName, nameLength));
                     }
 
                     i--;


### PR DESCRIPTION
Slightly reduce allocations in GetReferencedItemNamesAndMetadata

### Context

We can avoid eagerly creating a substring in this method to reduce allocations. The resulting "name" string is conditionally used in one place

                    // If we've got this far, we know the item expression was
                    // well formed, so make sure the name's in the table
                    if ((whatToShredFor & ShredderOptions.ItemTypes) != 0)
                    {
                        pair.Items ??= new HashSet<string>(MSBuildNameIgnoreCaseComparer.Default);
                        pair.Items.Add(name);
                    }

We can capture the boundaries of the desired substring and only create it when we actually need it.


Before:
![image](https://github.com/user-attachments/assets/3f3cec51-cd02-42f8-a029-9bd0f727fd5c)

After:
![image](https://github.com/user-attachments/assets/46071f0f-43c7-4a6d-996c-e642e188c2b8)

Not a dramatic difference, but the change is small.
### Changes Made


### Testing


### Notes
