### PR TITLE
Avoid allocating intermediate string.

### DIFF
--- a/src/Build/BackEnd/TaskExecutionHost/TaskExecutionHost.cs
+++ b/src/Build/BackEnd/TaskExecutionHost/TaskExecutionHost.cs
@@ -1226,8 +1226,9 @@ namespace Microsoft.Build.BackEnd
 
             parameter.Initialized = true;
 
-            string taskAndParameterName = _taskName + "_" + parameter.Name;
-            string key = "DisableLogTaskParameter_" + taskAndParameterName;
+            // PERF: Be careful to avoid unnecessary string allocations. Appending '_taskName + "_" + parameter.Name' happens in both paths,
+            // but we don't want to allocate the string if we don't need to.
+            string key = "DisableLogTaskParameter_" + _taskName + "_" + parameter.Name;
 
             if (string.Equals(lookup.GetProperty(key)?.EvaluatedValue, "true", StringComparison.OrdinalIgnoreCase))
             {
@@ -1235,7 +1236,7 @@ namespace Microsoft.Build.BackEnd
             }
             else
             {
-                string metadataKey = "DisableLogTaskParameterItemMetadata_" + taskAndParameterName;
+                string metadataKey = "DisableLogTaskParameterItemMetadata_" + _taskName + "_" + parameter.Name;
                 if (string.Equals(lookup.GetProperty(metadataKey)?.EvaluatedValue, "true", StringComparison.OrdinalIgnoreCase))
                 {
                     parameter.LogItemMetadata = false;


### PR DESCRIPTION
### Context

We can avoid allocating an intermediate string inside of EnsureParameterInitialized()

Before:

![image](https://github.com/user-attachments/assets/4f28c6e8-691b-49ac-90ef-3fabfd435506)

After:
![image](https://github.com/user-attachments/assets/c6802d4b-6f01-41e0-a2a0-e0f12444de93)


### Changes Made


### Testing


### Notes
