### PR TITLE
Don't emit duplicate src files to binlog in CodeTaskFactory

### DIFF
--- a/src/Tasks.UnitTests/CodeTaskFactoryTests.cs
+++ b/src/Tasks.UnitTests/CodeTaskFactoryTests.cs
@@ -1214,7 +1214,7 @@ namespace Microsoft.Build.UnitTests
                 <Project>
                   <UsingTask
                     TaskName=""CustomTask""
-                    TaskFactory=""{0}""
+                    TaskFactory=""CodeTaskFactory""
                     AssemblyFile=""$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll"">
                     <ParameterGroup>
                       <InputParameter ParameterType=""System.String"" />
@@ -1232,9 +1232,6 @@ namespace Microsoft.Build.UnitTests
                   </UsingTask>
                 </Project>";
 
-            // Inject factoryType into taskXml
-            taskXml = string.Format(taskXml, FactoryType.CodeTaskFactory);
-
             TransientTestFile importTargetsFile = env.CreateFile("Import.targets", taskXml);
 
             // Define Another.proj content
@@ -1248,13 +1245,13 @@ namespace Microsoft.Build.UnitTests
                 </Target>
             </Project>";
 
-            TransientTestFile customTaskProjFile = env.CreateFile("Another.proj", anotherContent);
+            TransientTestFile anotherProjFile = env.CreateFile("Another.proj", anotherContent);
 
             // Define main.csproj content
             string projectFileContent = $@"<Project>
                 <Import Project=""{importTargetsFile.Path.Replace("\\", "/")}"" />
                 <Target Name=""Build"">
-                    <MSBuild Projects=""{customTaskProjFile.Path.Replace("\\", "/")}"" Targets=""AnotherTarget"" />
+                    <MSBuild Projects=""{anotherProjFile.Path.Replace("\\", "/")}"" Targets=""AnotherTarget"" />
                     <CustomTask InputParameter=""Bar"" />
                 </Target>
             </Project>";

--- a/src/Tasks.UnitTests/CodeTaskFactoryTests.cs
+++ b/src/Tasks.UnitTests/CodeTaskFactoryTests.cs
@@ -1236,7 +1236,7 @@ namespace Microsoft.Build.UnitTests
 
             // Define Another.proj content
             string anotherContent = $@"<Project>
-                <Import Project=""{importTargetsFile.Path.Replace("\\", "/")}"" />
+                <Import Project=""{importTargetsFile.Path}"" />
                 <Target Name=""AnotherTarget"">
                     <CustomTask InputParameter=""Foo"">
                         <Output PropertyName=""TaskOutput"" TaskParameter=""OutputParameter"" />
@@ -1249,9 +1249,9 @@ namespace Microsoft.Build.UnitTests
 
             // Define main.csproj content
             string projectFileContent = $@"<Project>
-                <Import Project=""{importTargetsFile.Path.Replace("\\", "/")}"" />
+                <Import Project=""{importTargetsFile.Path}"" />
                 <Target Name=""Build"">
-                    <MSBuild Projects=""{anotherProjFile.Path.Replace("\\", "/")}"" Targets=""AnotherTarget"" />
+                    <MSBuild Projects=""{anotherProjFile.Path}"" Targets=""AnotherTarget"" />
                     <CustomTask InputParameter=""Bar"" />
                 </Target>
             </Project>";
@@ -1271,10 +1271,6 @@ namespace Microsoft.Build.UnitTests
             string projectImportsZipPath = Path.ChangeExtension(binlog.Path, ".ProjectImports.zip");
             using var fileStream = new FileStream(projectImportsZipPath, FileMode.Open);
             using var zipArchive = new ZipArchive(fileStream, ZipArchiveMode.Read);
-
-            // A path like "C:\path" in ZipArchive is saved as "C\path"
-            // For unix-based systems path uses '/'
-            projectDirectory = NativeMethodsShared.IsWindows ? projectDirectory.Replace(":\\", "\\") : projectDirectory.Replace("/", "\\");
 
             // check to make sure that only 1 tmp file is created
             var tmpFiles = zipArchive.Entries.Where(zE => zE.Name.EndsWith("CustomTask-compilation-file.tmp")).ToList();

--- a/src/Tasks.UnitTests/CodeTaskFactoryTests.cs
+++ b/src/Tasks.UnitTests/CodeTaskFactoryTests.cs
@@ -1237,8 +1237,8 @@ namespace Microsoft.Build.UnitTests
 
             TransientTestFile importTargetsFile = env.CreateFile("Import.targets", taskXml);
 
-            // Define CustomTask.proj content
-            string customTaskContent = $@"<Project>
+            // Define Another.proj content
+            string anotherContent = $@"<Project>
                 <Import Project=""{importTargetsFile.Path.Replace("\\", "/")}"" />
                 <Target Name=""AnotherTarget"">
                     <CustomTask InputParameter=""Foo"">
@@ -1248,7 +1248,7 @@ namespace Microsoft.Build.UnitTests
                 </Target>
             </Project>";
 
-            TransientTestFile customTaskProjFile = env.CreateFile("Another.proj", customTaskContent);
+            TransientTestFile customTaskProjFile = env.CreateFile("Another.proj", anotherContent);
 
             // Define main.csproj content
             string projectFileContent = $@"<Project>

--- a/src/Tasks/CodeTaskFactory.cs
+++ b/src/Tasks/CodeTaskFactory.cs
@@ -791,15 +791,15 @@ namespace Microsoft.Build.Tasks
                 // Our code generation is complete, grab the source from the builder ready for compilation
                 string fullCode = codeBuilder.ToString();
 
-                // Embed generated file in the binlog
-                string fileNameInBinlog = $"{Guid.NewGuid()}-{_nameOfTask}-compilation-file.tmp";
-                _log.LogIncludeGeneratedFile(fileNameInBinlog, fullCode);
-
                 var fullSpec = new FullTaskSpecification(finalReferencedAssemblies, fullCode);
                 if (!s_compiledTaskCache.TryGetValue(fullSpec, out Assembly existingAssembly))
                 {
                     // Invokes compilation.
                     CompilerResults compilerResults = provider.CompileAssemblyFromSource(compilerParameters, fullCode);
+
+                    // Embed generated file in the binlog
+                    string fileNameInBinlog = $"{Guid.NewGuid()}-{_nameOfTask}-compilation-file.tmp";
+                    _log.LogIncludeGeneratedFile(fileNameInBinlog, fullCode);
 
                     string outputPath = null;
                     if (compilerResults.Errors.Count > 0 || Environment.GetEnvironmentVariable("MSBUILDLOGCODETASKFACTORYOUTPUT") != null)


### PR DESCRIPTION
Fixes #
Fix the issue: Don't emit duplicate generated files into the binlog https://github.com/dotnet/msbuild/issues/11884

### Context
The CodeTaskFactory was generating multiple .tmp files in the binlog for each invocation of a task, even when the task used the same source code. The goal is to emit only one .tmp file per unique task source code after its first successful compilation.

### Changes Made
Added a HashSet<FullTaskSpecification> _loggedCodeFiles to track task specifications already logged to the binlog.

Updated the logic to check _loggedCodeFiles before emitting a .tmp file, ensuring only one file is logged per unique FullTaskSpecification

### Testing
Created a test project that invokes CustomTask multiple times with  parameters (InputParameter="Foo" and InputParameter="Bar") via Another.proj and directly.

Verified that only one .tmp file is generated in the binlog for tasks sharing the same source code (from Import.targets), confirming duplicate suppression.

Created an additional project (Another1.proj) with a different source code (Import1.targets) to confirm two .tmp files are generated when source codes differ, validating that unique FullTaskSpecification instances produce separate files.

### Notes
