### PR TITLE
Fix the addxml  when add node after comment xml node

### DIFF
--- a/src/Build.OM.UnitTests/Construction/ProjectItemGroupElement_tests.cs
+++ b/src/Build.OM.UnitTests/Construction/ProjectItemGroupElement_tests.cs
@@ -146,7 +146,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
             var items = group.Items.ToList();
             var newItem = project.CreateItemElement("PackageReference");
             newItem.Include = "Inserted";
-            group.InsertBeforeChild(newItem, items[1]);
+            group.InsertAfterChild(newItem, items[0]);
             newItem.AddMetadata("Version", "1.5.0", true);
 
             Helpers.VerifyAssertLineByLine(expectedContent, project.RawXml);
@@ -190,7 +190,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
             """
             <Project>
               <ItemGroup>
-                <PackageReference Include="A" Version="1.0.0" />
+                <PackageReference Include="A" Version="1.0.0" />    <!-- comment A -->
                 <!-- comment before B -->
                 <PackageReference Include="B" Version="2.0.0" />
               </ItemGroup>
@@ -200,7 +200,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
             """
             <Project>
               <ItemGroup>
-                <PackageReference Include="A" Version="1.0.0" />
+                <PackageReference Include="A" Version="1.0.0" />    <!-- comment A -->
                 <PackageReference Include="Inserted" Version="1.5.0" />
                 <!-- comment before B -->
                 <PackageReference Include="B" Version="2.0.0" />
@@ -208,6 +208,32 @@ namespace Microsoft.Build.UnitTests.OM.Construction
             </Project>
             """;
             AddItem_PreservesComments_Helper(content2, expectedContent2);
+
+            // Adjacent multiple line Comment after item
+            string content3 =
+            """
+            <Project>
+              <ItemGroup>
+                <PackageReference Include="A" Version="1.0.0" /><!--
+                    This is a multi-line
+                    comment across lines
+                    -->
+              </ItemGroup>
+            </Project>
+            """;
+            string expectedContent3 =
+            """
+            <Project>
+              <ItemGroup>
+                <PackageReference Include="A" Version="1.0.0" /><!--
+                    This is a multi-line
+                    comment across lines
+                    -->
+                <PackageReference Include="Inserted" Version="1.5.0" />
+              </ItemGroup>
+            </Project>
+            """;
+            AddItem_PreservesComments_Helper(content3, expectedContent3);
         }
     }
 }

--- a/src/Build.OM.UnitTests/Construction/ProjectItemGroupElement_tests.cs
+++ b/src/Build.OM.UnitTests/Construction/ProjectItemGroupElement_tests.cs
@@ -152,12 +152,8 @@ namespace Microsoft.Build.UnitTests.OM.Construction
             Helpers.VerifyAssertLineByLine(expectedContent, project.RawXml);
         }
 
-        [Fact]
-        public void AddItem_PreservesComments_VariousCases()
-        {
-            // Multi-line comment scenario
-            string content1 =
-            """
+        [Theory]
+        [InlineData("""
             <Project>
                <ItemGroup>
                     <PackageReference Include="A" Version="1.0.0" />
@@ -168,9 +164,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
                     <PackageReference Include="B" Version="2.0.0" />
                 </ItemGroup>
             </Project>
-            """;
-            string expectedContent1 =
-            """
+            """, """
             <Project>
                <ItemGroup>
                     <PackageReference Include="A" Version="1.0.0" />
@@ -182,12 +176,8 @@ namespace Microsoft.Build.UnitTests.OM.Construction
                     <PackageReference Include="B" Version="2.0.0" />
                 </ItemGroup>
             </Project>
-            """;
-            AddItem_PreservesComments_Helper(content1, expectedContent1);
-
-            // Single-line comment scenario
-            string content2 =
-            """
+            """)]
+        [InlineData("""
             <Project>
               <ItemGroup>
                 <PackageReference Include="A" Version="1.0.0" />    <!-- comment A -->
@@ -195,9 +185,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
                 <PackageReference Include="B" Version="2.0.0" />
               </ItemGroup>
             </Project>
-            """;
-            string expectedContent2 =
-            """
+            """, """
             <Project>
               <ItemGroup>
                 <PackageReference Include="A" Version="1.0.0" />    <!-- comment A -->
@@ -206,12 +194,8 @@ namespace Microsoft.Build.UnitTests.OM.Construction
                 <PackageReference Include="B" Version="2.0.0" />
               </ItemGroup>
             </Project>
-            """;
-            AddItem_PreservesComments_Helper(content2, expectedContent2);
-
-            // Adjacent multiple line Comment after item
-            string content3 =
-            """
+            """)]
+        [InlineData("""
             <Project>
               <ItemGroup>
                 <PackageReference Include="A" Version="1.0.0" /><!--
@@ -220,9 +204,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
                     -->
               </ItemGroup>
             </Project>
-            """;
-            string expectedContent3 =
-            """
+            """, """
             <Project>
               <ItemGroup>
                 <PackageReference Include="A" Version="1.0.0" /><!--
@@ -232,8 +214,10 @@ namespace Microsoft.Build.UnitTests.OM.Construction
                 <PackageReference Include="Inserted" Version="1.5.0" />
               </ItemGroup>
             </Project>
-            """;
-            AddItem_PreservesComments_Helper(content3, expectedContent3);
+            """)]
+        public void AddItem_PreservesComments_VariousCases(string content, string expectedContent)
+        {
+            AddItem_PreservesComments_Helper(content, expectedContent);
         }
     }
 }

--- a/src/Build/Construction/ProjectElementContainer.cs
+++ b/src/Build/Construction/ProjectElementContainer.cs
@@ -528,8 +528,7 @@ namespace Microsoft.Build.Construction
                     XmlNode next = insertAfter.NextSibling;
                     while (next != null &&
                         (next.NodeType == XmlNodeType.Whitespace ||
-                         next.NodeType == XmlNodeType.Comment ||
-                         next.NodeType == XmlNodeType.ProcessingInstruction)
+                         next.NodeType == XmlNodeType.Comment)
                          && (next.Value == null || (!next.Value.Contains("\n") && !next.Value.Contains("\r"))))
                     {
                         insertAfter = next;

--- a/src/Build/Construction/ProjectElementContainer.cs
+++ b/src/Build/Construction/ProjectElementContainer.cs
@@ -521,16 +521,13 @@ namespace Microsoft.Build.Construction
 
                 if (TrySearchLeftSiblings(child.PreviousSibling, SiblingIsExplicitElement, out ProjectElement referenceSibling))
                 {
-                    // Heuristic: If the reference element is immediately followed by a series of XML nodes, each of which
-                    // does not contain any line breaks and is whitespace, a comment, or a processing instruction,
-                    // then insert the new element after those nodes.
                     XmlNode insertAfter = referenceSibling.XmlElement;
                     XmlNode next = insertAfter.NextSibling;
                     while (next != null &&
-                        (next.NodeType == XmlNodeType.Whitespace ||
-                         next.NodeType == XmlNodeType.Comment)
-                         && (next.Value == null || (!next.Value.Contains("\n") && !next.Value.Contains("\r"))))
+                    (next.NodeType == XmlNodeType.Comment||
+                    (next.NodeType == XmlNodeType.Whitespace && !next.Value.Contains("\n") && !next.Value.Contains("\r"))))
                     {
+                        // If the next node is a comment or whitespace that does not contain newlines, then insert after it
                         insertAfter = next;
                         next = insertAfter.NextSibling;
                     }


### PR DESCRIPTION
Fixes [#11933 ](https://github.com/dotnet/msbuild/issues/11933)

### Context
```
<ItemGroup>
    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" /><!-- some comment -->
  </ItemGroup>
```
**dotnet add package Serilog --version 4.3.0
The trailing comment on the Newtonsoft.Json line is moved to the newly added package.**

```
<ItemGroup>
  <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
  <PackageReference Include="Serilog" Version="4.3.0" /><!-- some comment -->
</ItemGroup>
```

### Changes Made
If the reference element is immediately followed by a series of XML nodes, each of which does not contain any line breaks and is whitespace, a comment, or a processing instruction, then insert the new element after those nodes.

### Testing
AddPackageReference_PreservesTrailingCommentOnSameLine

### Notes
