### PR TITLE
Avoid boxing with enumerators in TaskBuilder.cs -> CreateListOfParameterValues

### DIFF
--- a/src/Build/BackEnd/Components/RequestBuilder/TaskBuilder.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TaskBuilder.cs
@@ -254,23 +254,24 @@ namespace Microsoft.Build.BackEnd
             // Add parameters on any output tags
             for (int i = 0; i < _taskNode.Outputs.Count; i++)
             {
-                ProjectTaskOutputItemInstance outputItemInstance = _taskNode.Outputs[i] as ProjectTaskOutputItemInstance;
+                var projectTaskInstanceChild = _taskNode.Outputs[i];
+                ProjectTaskOutputItemInstance outputItemInstance = projectTaskInstanceChild as ProjectTaskOutputItemInstance;
                 if (outputItemInstance != null)
                 {
                     taskParameters.Add(outputItemInstance.TaskParameter);
                     taskParameters.Add(outputItemInstance.ItemType);
                 }
 
-                ProjectTaskOutputPropertyInstance outputPropertyInstance = _taskNode.Outputs[i] as ProjectTaskOutputPropertyInstance;
+                ProjectTaskOutputPropertyInstance outputPropertyInstance = projectTaskInstanceChild as ProjectTaskOutputPropertyInstance;
                 if (outputPropertyInstance != null)
                 {
                     taskParameters.Add(outputPropertyInstance.TaskParameter);
                     taskParameters.Add(outputPropertyInstance.PropertyName);
                 }
 
-                if (!String.IsNullOrEmpty(_taskNode.Outputs[i].Condition))
+                if (!String.IsNullOrEmpty(projectTaskInstanceChild.Condition))
                 {
-                    taskParameters.Add(_taskNode.Outputs[i].Condition);
+                    taskParameters.Add(projectTaskInstanceChild.Condition);
                 }
             }
 

--- a/src/Build/BackEnd/Components/RequestBuilder/TaskBuilder.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TaskBuilder.cs
@@ -246,13 +246,13 @@ namespace Microsoft.Build.BackEnd
 
             List<string> taskParameters = new List<string>(_taskNode.ParametersForBuild.Count + _taskNode.Outputs.Count);
 
-            foreach (KeyValuePair<string, (string, ElementLocation)> taskParameter in _taskNode.ParametersForBuild)
+            foreach (KeyValuePair<string, (string, ElementLocation)> taskParameter in (CopyOnWriteDictionary<(string, ElementLocation)>)_taskNode.ParametersForBuild)
             {
                 taskParameters.Add(taskParameter.Value.Item1);
             }
 
             // Add parameters on any output tags
-            foreach (ProjectTaskInstanceChild taskOutputSpecification in _taskNode.Outputs)
+            foreach (ProjectTaskInstanceChild taskOutputSpecification in (List<ProjectTaskInstanceChild>)_taskNode.Outputs)
             {
                 ProjectTaskOutputItemInstance outputItemInstance = taskOutputSpecification as ProjectTaskOutputItemInstance;
                 if (outputItemInstance != null)
@@ -273,6 +273,7 @@ namespace Microsoft.Build.BackEnd
                     taskParameters.Add(taskOutputSpecification.Condition);
                 }
             }
+
 
             if (!String.IsNullOrEmpty(_taskNode.Condition))
             {

--- a/src/Build/BackEnd/Components/RequestBuilder/TaskBuilder.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TaskBuilder.cs
@@ -246,31 +246,31 @@ namespace Microsoft.Build.BackEnd
 
             List<string> taskParameters = new List<string>(_taskNode.ParametersForBuild.Count + _taskNode.Outputs.Count);
 
-            foreach (KeyValuePair<string, (string, ElementLocation)> taskParameter in (CopyOnWriteDictionary<(string, ElementLocation)>)_taskNode.ParametersForBuild)
+            foreach (KeyValuePair<string, (string, ElementLocation)> taskParameter in _taskNode.ParametersForBuild)
             {
                 taskParameters.Add(taskParameter.Value.Item1);
             }
 
             // Add parameters on any output tags
-            foreach (ProjectTaskInstanceChild taskOutputSpecification in (List<ProjectTaskInstanceChild>)_taskNode.Outputs)
+            for (int i = 0; i < _taskNode.Outputs.Count; i++)
             {
-                ProjectTaskOutputItemInstance outputItemInstance = taskOutputSpecification as ProjectTaskOutputItemInstance;
+                ProjectTaskOutputItemInstance outputItemInstance = _taskNode.Outputs[i] as ProjectTaskOutputItemInstance;
                 if (outputItemInstance != null)
                 {
                     taskParameters.Add(outputItemInstance.TaskParameter);
                     taskParameters.Add(outputItemInstance.ItemType);
                 }
 
-                ProjectTaskOutputPropertyInstance outputPropertyInstance = taskOutputSpecification as ProjectTaskOutputPropertyInstance;
+                ProjectTaskOutputPropertyInstance outputPropertyInstance = _taskNode.Outputs[i] as ProjectTaskOutputPropertyInstance;
                 if (outputPropertyInstance != null)
                 {
                     taskParameters.Add(outputPropertyInstance.TaskParameter);
                     taskParameters.Add(outputPropertyInstance.PropertyName);
                 }
 
-                if (!String.IsNullOrEmpty(taskOutputSpecification.Condition))
+                if (!String.IsNullOrEmpty(_taskNode.Outputs[i].Condition))
                 {
-                    taskParameters.Add(taskOutputSpecification.Condition);
+                    taskParameters.Add(_taskNode.Outputs[i].Condition);
                 }
             }
 

--- a/src/Build/BackEnd/Components/RequestBuilder/TaskBuilder.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TaskBuilder.cs
@@ -252,6 +252,7 @@ namespace Microsoft.Build.BackEnd
             }
 
             // Add parameters on any output tags
+            // Perf: Moved to indexed based for loop to avoid boxing of the enumerator for IList.
             for (int i = 0; i < _taskNode.Outputs.Count; i++)
             {
                 var projectTaskInstanceChild = _taskNode.Outputs[i];
@@ -274,7 +275,6 @@ namespace Microsoft.Build.BackEnd
                     taskParameters.Add(projectTaskInstanceChild.Condition);
                 }
             }
-
 
             if (!String.IsNullOrEmpty(_taskNode.Condition))
             {

--- a/src/Build/BackEnd/Components/RequestBuilder/TaskBuilder.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TaskBuilder.cs
@@ -255,24 +255,22 @@ namespace Microsoft.Build.BackEnd
             // Perf: Moved to indexed based for loop to avoid boxing of the enumerator for IList.
             for (int i = 0; i < _taskNode.Outputs.Count; i++)
             {
-                var projectTaskInstanceChild = _taskNode.Outputs[i];
-                ProjectTaskOutputItemInstance outputItemInstance = projectTaskInstanceChild as ProjectTaskOutputItemInstance;
-                if (outputItemInstance != null)
+                ProjectTaskInstanceChild taskOutputSpecification = _taskNode.Outputs[i];
+                if (taskOutputSpecification is ProjectTaskOutputItemInstance outputItemInstance)
                 {
                     taskParameters.Add(outputItemInstance.TaskParameter);
                     taskParameters.Add(outputItemInstance.ItemType);
                 }
 
-                ProjectTaskOutputPropertyInstance outputPropertyInstance = projectTaskInstanceChild as ProjectTaskOutputPropertyInstance;
-                if (outputPropertyInstance != null)
+                if (taskOutputSpecification is ProjectTaskOutputPropertyInstance outputPropertyInstance)
                 {
                     taskParameters.Add(outputPropertyInstance.TaskParameter);
                     taskParameters.Add(outputPropertyInstance.PropertyName);
                 }
 
-                if (!String.IsNullOrEmpty(projectTaskInstanceChild.Condition))
+                if (!String.IsNullOrEmpty(taskOutputSpecification.Condition))
                 {
-                    taskParameters.Add(projectTaskInstanceChild.Condition);
+                    taskParameters.Add(taskOutputSpecification.Condition);
                 }
             }
 

--- a/src/Build/Instance/ProjectTaskInstance.cs
+++ b/src/Build/Instance/ProjectTaskInstance.cs
@@ -299,7 +299,7 @@ namespace Microsoft.Build.Execution
         /// <summary>
         /// Retrieves the parameters dictionary as used during the build.
         /// </summary>
-        internal IDictionary<string, (string, ElementLocation)> ParametersForBuild
+        internal CopyOnWriteDictionary<(string, ElementLocation)> ParametersForBuild
         {
             get { return _parameters; }
         }


### PR DESCRIPTION
Fixes #
Allocations due to boxing of enumerators in TaskBuilder
### Context
On some traces we're seeing some allocations due to boxing of enumerators in TaskBuilder.cs
![image](https://github.com/user-attachments/assets/d82e8d0f-f395-48ae-a412-915524fae287)

If possible we want to avoid that.
### Changes Made
* Changed an internal getter to return the actual type instead of the interface since it was used only once and would allow for using the underlying struct enumerator vs being boxed from the interface during a foreach loop.
* Saw another foreach loop that would end up being boxed from using IList. So changed it to use the indexed for loop to avoid using the enumerator all together.

### Testing


### Notes
