### PR TITLE
Use SDK from .dotnet with new resolvers

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,8 @@
 {
   "sdk": {
-    "allowPrerelease": true
+    "allowPrerelease": true,
+    "paths": [ ".dotnet", "$host$" ],
+    "errorMessage": "The .NET SDK could not be found, please run a command-line build with ./build.cmd."
   },
   "tools": {
     "dotnet": "9.0.106",


### PR DESCRIPTION
Uses [SDK hint paths][] to tell modern SDK resolvers (.NET CLI in 10 previews, and unreleased VS versions at present) to use the SDK from the `.dotnet` folder that Arcade restores, instead of the default behavior.

Should be silently ignored by older resolvers, so shouldn't change CI behavior.

[SDK hint paths]: https://github.com/dotnet/designs/blob/238ca0202ea5df96d378a06c01960fc289aba166/accepted/2025/local-sdk-global-json.md
