### PR TITLE
ZipDirectory task supports CompressionLevel

### DIFF
--- a/src/MSBuild/MSBuild/Microsoft.Build.CommonTypes.xsd
+++ b/src/MSBuild/MSBuild/Microsoft.Build.CommonTypes.xsd
@@ -6304,7 +6304,7 @@ elementFormDefault="qualified">
                     </xs:attribute>
                     <xs:attribute name="DestinationFile" use="required" />
                     <xs:attribute name="Overwrite" type="msb:boolean" />
-                    <xs:attribute name="SourceDirectory" type="msb:boolean" />
+                    <xs:attribute name="SourceDirectory" use="required" />
                 </xs:extension>
             </xs:complexContent>
         </xs:complexType>

--- a/src/MSBuild/MSBuild/Microsoft.Build.CommonTypes.xsd
+++ b/src/MSBuild/MSBuild/Microsoft.Build.CommonTypes.xsd
@@ -6287,6 +6287,21 @@ elementFormDefault="qualified">
         <xs:complexType>
             <xs:complexContent>
                 <xs:extension base="msb:TaskType">
+                    <xs:attribute name="CompressionLevel">
+                        <xs:annotation>
+                            <xs:documentation>
+                                <!-- _locID_text="CompressionLevel" _locComment="" -->Specify the compression level to apply. Possible values are Optimal, Fastest, NoCompression and SmallestSize. In the .NET Framework version of MSBuild, the SmallestSize option is unavailable. Using it will on .NET Framework will log warning MSB3945 and use the default compression level instead.
+                            </xs:documentation>
+                        </xs:annotation>
+                        <xs:simpleType>
+                            <xs:restriction base="xs:string">
+                                <xs:enumeration value="Optimal" />
+                                <xs:enumeration value="Fastest" />
+                                <xs:enumeration value="NoCompression" />
+                                <xs:enumeration value="SmallestSize" />
+                            </xs:restriction>
+                        </xs:simpleType>
+                    </xs:attribute>
                     <xs:attribute name="DestinationFile" use="required" />
                     <xs:attribute name="Overwrite" type="msb:boolean" />
                     <xs:attribute name="SourceDirectory" type="msb:boolean" />

--- a/src/Tasks.UnitTests/ZipDirectory_Tests.cs
+++ b/src/Tasks.UnitTests/ZipDirectory_Tests.cs
@@ -11,16 +11,21 @@ using Microsoft.Build.Utilities;
 using Shouldly;
 using Xunit;
 
-#nullable disable
-
 namespace Microsoft.Build.Tasks.UnitTests
 {
     public class ZipDirectory_Tests
     {
         private readonly MockEngine _mockEngine = new MockEngine();
 
-        [Fact]
-        public void CanZipDirectory()
+        [Theory]
+        [InlineData(null)]
+        [InlineData(CompressionLevel.Optimal)]
+        [InlineData(CompressionLevel.Fastest)]
+        [InlineData(CompressionLevel.NoCompression)]
+#if NET
+        [InlineData(CompressionLevel.SmallestSize)]
+#endif
+        public void CanZipDirectory(CompressionLevel? compressionLevel)
         {
             using (TestEnvironment testEnvironment = TestEnvironment.Create())
             {
@@ -34,8 +39,9 @@ namespace Microsoft.Build.Tasks.UnitTests
                 ZipDirectory zipDirectory = new ZipDirectory
                 {
                     BuildEngine = _mockEngine,
+                    CompressionLevel = compressionLevel,
                     DestinationFile = new TaskItem(zipFilePath),
-                    SourceDirectory = new TaskItem(sourceFolder.Path)
+                    SourceDirectory = new TaskItem(sourceFolder.Path),
                 };
 
                 zipDirectory.Execute().ShouldBeTrue(_mockEngine.Log);
@@ -61,7 +67,7 @@ namespace Microsoft.Build.Tasks.UnitTests
         }
 
         [Fact]
-        public void CanOvewriteExistingFile()
+        public void CanOverwriteExistingFile()
         {
             using (TestEnvironment testEnvironment = TestEnvironment.Create())
             {

--- a/src/Tasks/Resources/Strings.resx
+++ b/src/Tasks/Resources/Strings.resx
@@ -2923,6 +2923,14 @@
     <value>MSB3943: Failed to zip directory "{0}" to file "{1}".  {2} {3}</value>
     <comment>{StrBegin="MSB3943: "}</comment>
   </data>
+  <data name="ZipDirectory.ErrorInvalidCompressionLevel">
+    <value>MSB3944: Unsupported compression level '{0}'. Using default compression level instead.</value>
+    <comment>{StrBegin="MSB3944: "}</comment>
+  </data>
+  <data name="ZipDirectory.WarningCompressionLevelUnsupportedOnFramework">
+    <value>MSB3945: Compression level '{0}' is not supported on the .NET Framework version of MSBuild. Using default compression level instead.</value>
+    <comment>{StrBegin="MSB3945: "}</comment>
+  </data>
   <data name="ZipDirectory.Comment">
     <value>Zipping directory "{0}" to "{1}".</value>
   </data>

--- a/src/Tasks/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Resources/xlf/Strings.cs.xlf
@@ -3582,6 +3582,16 @@
         <target state="translated">MSB3942: Zazipovaný soubor {0} se nepodařilo vytvořit, protože už existuje. Odstraňte nebo přejmenujte prosím tento soubor a zkuste to znovu.</target>
         <note>{StrBegin="MSB3942: "}</note>
       </trans-unit>
+      <trans-unit id="ZipDirectory.ErrorInvalidCompressionLevel">
+        <source>MSB3944: Unsupported compression level '{0}'. Using default compression level instead.</source>
+        <target state="new">MSB3944: Unsupported compression level '{0}'. Using default compression level instead.</target>
+        <note>{StrBegin="MSB3944: "}</note>
+      </trans-unit>
+      <trans-unit id="ZipDirectory.WarningCompressionLevelUnsupportedOnFramework">
+        <source>MSB3945: Compression level '{0}' is not supported on the .NET Framework version of MSBuild. Using default compression level instead.</source>
+        <target state="new">MSB3945: Compression level '{0}' is not supported on the .NET Framework version of MSBuild. Using default compression level instead.</target>
+        <note>{StrBegin="MSB3945: "}</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Resources/xlf/Strings.de.xlf
@@ -3582,6 +3582,16 @@
         <target state="translated">MSB3942: Fehler beim Erstellen der ZIP-Datei "{0}", weil sie bereits vorhanden ist. Löschen Sie die Datei, oder benennen Sie sie um, und versuchen Sie es dann noch mal.</target>
         <note>{StrBegin="MSB3942: "}</note>
       </trans-unit>
+      <trans-unit id="ZipDirectory.ErrorInvalidCompressionLevel">
+        <source>MSB3944: Unsupported compression level '{0}'. Using default compression level instead.</source>
+        <target state="new">MSB3944: Unsupported compression level '{0}'. Using default compression level instead.</target>
+        <note>{StrBegin="MSB3944: "}</note>
+      </trans-unit>
+      <trans-unit id="ZipDirectory.WarningCompressionLevelUnsupportedOnFramework">
+        <source>MSB3945: Compression level '{0}' is not supported on the .NET Framework version of MSBuild. Using default compression level instead.</source>
+        <target state="new">MSB3945: Compression level '{0}' is not supported on the .NET Framework version of MSBuild. Using default compression level instead.</target>
+        <note>{StrBegin="MSB3945: "}</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Resources/xlf/Strings.es.xlf
@@ -3582,6 +3582,16 @@
         <target state="translated">MSB3942: No se pudo crear el archivo comprimido "{0}" porque ya existe. Elimine el archivo, o cámbiele el nombre, e inténtelo de nuevo.</target>
         <note>{StrBegin="MSB3942: "}</note>
       </trans-unit>
+      <trans-unit id="ZipDirectory.ErrorInvalidCompressionLevel">
+        <source>MSB3944: Unsupported compression level '{0}'. Using default compression level instead.</source>
+        <target state="new">MSB3944: Unsupported compression level '{0}'. Using default compression level instead.</target>
+        <note>{StrBegin="MSB3944: "}</note>
+      </trans-unit>
+      <trans-unit id="ZipDirectory.WarningCompressionLevelUnsupportedOnFramework">
+        <source>MSB3945: Compression level '{0}' is not supported on the .NET Framework version of MSBuild. Using default compression level instead.</source>
+        <target state="new">MSB3945: Compression level '{0}' is not supported on the .NET Framework version of MSBuild. Using default compression level instead.</target>
+        <note>{StrBegin="MSB3945: "}</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Resources/xlf/Strings.fr.xlf
@@ -3582,6 +3582,16 @@
         <target state="translated">MSB3942: Échec de la compression du fichier zip "{0}", car il existe déjà. Supprimez ou renommez le fichier, puis réessayez.</target>
         <note>{StrBegin="MSB3942: "}</note>
       </trans-unit>
+      <trans-unit id="ZipDirectory.ErrorInvalidCompressionLevel">
+        <source>MSB3944: Unsupported compression level '{0}'. Using default compression level instead.</source>
+        <target state="new">MSB3944: Unsupported compression level '{0}'. Using default compression level instead.</target>
+        <note>{StrBegin="MSB3944: "}</note>
+      </trans-unit>
+      <trans-unit id="ZipDirectory.WarningCompressionLevelUnsupportedOnFramework">
+        <source>MSB3945: Compression level '{0}' is not supported on the .NET Framework version of MSBuild. Using default compression level instead.</source>
+        <target state="new">MSB3945: Compression level '{0}' is not supported on the .NET Framework version of MSBuild. Using default compression level instead.</target>
+        <note>{StrBegin="MSB3945: "}</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Resources/xlf/Strings.it.xlf
@@ -3582,6 +3582,16 @@
         <target state="translated">MSB3942: non è stato possibile creare il file ZIP "{0}" perché esiste già. Eliminare o rinominare il file e riprovare.</target>
         <note>{StrBegin="MSB3942: "}</note>
       </trans-unit>
+      <trans-unit id="ZipDirectory.ErrorInvalidCompressionLevel">
+        <source>MSB3944: Unsupported compression level '{0}'. Using default compression level instead.</source>
+        <target state="new">MSB3944: Unsupported compression level '{0}'. Using default compression level instead.</target>
+        <note>{StrBegin="MSB3944: "}</note>
+      </trans-unit>
+      <trans-unit id="ZipDirectory.WarningCompressionLevelUnsupportedOnFramework">
+        <source>MSB3945: Compression level '{0}' is not supported on the .NET Framework version of MSBuild. Using default compression level instead.</source>
+        <target state="new">MSB3945: Compression level '{0}' is not supported on the .NET Framework version of MSBuild. Using default compression level instead.</target>
+        <note>{StrBegin="MSB3945: "}</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ja.xlf
@@ -3582,6 +3582,16 @@
         <target state="translated">MSB3942: 既に存在するため、zip ファイル "{0}" を作成できませんでした。そのファイルを削除するか、名前を変更して、もう一度お試しください。</target>
         <note>{StrBegin="MSB3942: "}</note>
       </trans-unit>
+      <trans-unit id="ZipDirectory.ErrorInvalidCompressionLevel">
+        <source>MSB3944: Unsupported compression level '{0}'. Using default compression level instead.</source>
+        <target state="new">MSB3944: Unsupported compression level '{0}'. Using default compression level instead.</target>
+        <note>{StrBegin="MSB3944: "}</note>
+      </trans-unit>
+      <trans-unit id="ZipDirectory.WarningCompressionLevelUnsupportedOnFramework">
+        <source>MSB3945: Compression level '{0}' is not supported on the .NET Framework version of MSBuild. Using default compression level instead.</source>
+        <target state="new">MSB3945: Compression level '{0}' is not supported on the .NET Framework version of MSBuild. Using default compression level instead.</target>
+        <note>{StrBegin="MSB3945: "}</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ko.xlf
@@ -3582,6 +3582,16 @@
         <target state="translated">MSB3942: 파일이 이미 존재하기 때문에 Zip 파일 "{0}"을(를) 만들지 못했습니다. 파일을 삭제하거나 이름을 바꾸고 다시 시도하세요.</target>
         <note>{StrBegin="MSB3942: "}</note>
       </trans-unit>
+      <trans-unit id="ZipDirectory.ErrorInvalidCompressionLevel">
+        <source>MSB3944: Unsupported compression level '{0}'. Using default compression level instead.</source>
+        <target state="new">MSB3944: Unsupported compression level '{0}'. Using default compression level instead.</target>
+        <note>{StrBegin="MSB3944: "}</note>
+      </trans-unit>
+      <trans-unit id="ZipDirectory.WarningCompressionLevelUnsupportedOnFramework">
+        <source>MSB3945: Compression level '{0}' is not supported on the .NET Framework version of MSBuild. Using default compression level instead.</source>
+        <target state="new">MSB3945: Compression level '{0}' is not supported on the .NET Framework version of MSBuild. Using default compression level instead.</target>
+        <note>{StrBegin="MSB3945: "}</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Resources/xlf/Strings.pl.xlf
@@ -3582,6 +3582,16 @@
         <target state="translated">MSB3942: Nie można utworzyć pliku zip „{0}”, ponieważ już istnieje. Usuń plik lub zmień jego nazwę i spróbuj ponownie.</target>
         <note>{StrBegin="MSB3942: "}</note>
       </trans-unit>
+      <trans-unit id="ZipDirectory.ErrorInvalidCompressionLevel">
+        <source>MSB3944: Unsupported compression level '{0}'. Using default compression level instead.</source>
+        <target state="new">MSB3944: Unsupported compression level '{0}'. Using default compression level instead.</target>
+        <note>{StrBegin="MSB3944: "}</note>
+      </trans-unit>
+      <trans-unit id="ZipDirectory.WarningCompressionLevelUnsupportedOnFramework">
+        <source>MSB3945: Compression level '{0}' is not supported on the .NET Framework version of MSBuild. Using default compression level instead.</source>
+        <target state="new">MSB3945: Compression level '{0}' is not supported on the .NET Framework version of MSBuild. Using default compression level instead.</target>
+        <note>{StrBegin="MSB3945: "}</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Resources/xlf/Strings.pt-BR.xlf
@@ -3582,6 +3582,16 @@
         <target state="translated">MSB3942: Falha ao criar o arquivo zipado "{0}" porque ele já existe. Exclua ou renomeie o arquivo e tente novamente.</target>
         <note>{StrBegin="MSB3942: "}</note>
       </trans-unit>
+      <trans-unit id="ZipDirectory.ErrorInvalidCompressionLevel">
+        <source>MSB3944: Unsupported compression level '{0}'. Using default compression level instead.</source>
+        <target state="new">MSB3944: Unsupported compression level '{0}'. Using default compression level instead.</target>
+        <note>{StrBegin="MSB3944: "}</note>
+      </trans-unit>
+      <trans-unit id="ZipDirectory.WarningCompressionLevelUnsupportedOnFramework">
+        <source>MSB3945: Compression level '{0}' is not supported on the .NET Framework version of MSBuild. Using default compression level instead.</source>
+        <target state="new">MSB3945: Compression level '{0}' is not supported on the .NET Framework version of MSBuild. Using default compression level instead.</target>
+        <note>{StrBegin="MSB3945: "}</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ru.xlf
@@ -3582,6 +3582,16 @@
         <target state="translated">MSB3942: не удалось создать ZIP-файл "{0}", так как он уже существует. Удалите или переименуйте файл и повторите попытку.</target>
         <note>{StrBegin="MSB3942: "}</note>
       </trans-unit>
+      <trans-unit id="ZipDirectory.ErrorInvalidCompressionLevel">
+        <source>MSB3944: Unsupported compression level '{0}'. Using default compression level instead.</source>
+        <target state="new">MSB3944: Unsupported compression level '{0}'. Using default compression level instead.</target>
+        <note>{StrBegin="MSB3944: "}</note>
+      </trans-unit>
+      <trans-unit id="ZipDirectory.WarningCompressionLevelUnsupportedOnFramework">
+        <source>MSB3945: Compression level '{0}' is not supported on the .NET Framework version of MSBuild. Using default compression level instead.</source>
+        <target state="new">MSB3945: Compression level '{0}' is not supported on the .NET Framework version of MSBuild. Using default compression level instead.</target>
+        <note>{StrBegin="MSB3945: "}</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Resources/xlf/Strings.tr.xlf
@@ -3582,6 +3582,16 @@
         <target state="translated">MSB3942: "{0}" zip dosyası zaten mevcut olduğundan sıkıştırılamadı. Lütfen dosyayı silin veya yeniden adlandırın ve tekrar deneyin.</target>
         <note>{StrBegin="MSB3942: "}</note>
       </trans-unit>
+      <trans-unit id="ZipDirectory.ErrorInvalidCompressionLevel">
+        <source>MSB3944: Unsupported compression level '{0}'. Using default compression level instead.</source>
+        <target state="new">MSB3944: Unsupported compression level '{0}'. Using default compression level instead.</target>
+        <note>{StrBegin="MSB3944: "}</note>
+      </trans-unit>
+      <trans-unit id="ZipDirectory.WarningCompressionLevelUnsupportedOnFramework">
+        <source>MSB3945: Compression level '{0}' is not supported on the .NET Framework version of MSBuild. Using default compression level instead.</source>
+        <target state="new">MSB3945: Compression level '{0}' is not supported on the .NET Framework version of MSBuild. Using default compression level instead.</target>
+        <note>{StrBegin="MSB3945: "}</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Resources/xlf/Strings.zh-Hans.xlf
@@ -3582,6 +3582,16 @@
         <target state="translated">MSB3942: 未能创建压缩文件“{0}”，因为它已经存在。请删除或重命名文件，然后重试。</target>
         <note>{StrBegin="MSB3942: "}</note>
       </trans-unit>
+      <trans-unit id="ZipDirectory.ErrorInvalidCompressionLevel">
+        <source>MSB3944: Unsupported compression level '{0}'. Using default compression level instead.</source>
+        <target state="new">MSB3944: Unsupported compression level '{0}'. Using default compression level instead.</target>
+        <note>{StrBegin="MSB3944: "}</note>
+      </trans-unit>
+      <trans-unit id="ZipDirectory.WarningCompressionLevelUnsupportedOnFramework">
+        <source>MSB3945: Compression level '{0}' is not supported on the .NET Framework version of MSBuild. Using default compression level instead.</source>
+        <target state="new">MSB3945: Compression level '{0}' is not supported on the .NET Framework version of MSBuild. Using default compression level instead.</target>
+        <note>{StrBegin="MSB3945: "}</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Tasks/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Resources/xlf/Strings.zh-Hant.xlf
@@ -3582,6 +3582,16 @@
         <target state="translated">MSB3942: 因為壓縮檔 "{0}" 已存在，所以無法建立。請刪除或重新命名該檔案，然後再試一次。</target>
         <note>{StrBegin="MSB3942: "}</note>
       </trans-unit>
+      <trans-unit id="ZipDirectory.ErrorInvalidCompressionLevel">
+        <source>MSB3944: Unsupported compression level '{0}'. Using default compression level instead.</source>
+        <target state="new">MSB3944: Unsupported compression level '{0}'. Using default compression level instead.</target>
+        <note>{StrBegin="MSB3944: "}</note>
+      </trans-unit>
+      <trans-unit id="ZipDirectory.WarningCompressionLevelUnsupportedOnFramework">
+        <source>MSB3945: Compression level '{0}' is not supported on the .NET Framework version of MSBuild. Using default compression level instead.</source>
+        <target state="new">MSB3945: Compression level '{0}' is not supported on the .NET Framework version of MSBuild. Using default compression level instead.</target>
+        <note>{StrBegin="MSB3945: "}</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>


### PR DESCRIPTION
Fixes #11963

### Context

Compression can be parameterized by "level", which allows trading off time for compression ratio. This option was not available on the `ZipDirectory` task

### Changes Made

Add a `CompressionLevel` parameter to the `ZipDirectory` task.

Also enabled null annotations in the task and its test.

### Testing

Extend unit test.

### Notes

A potential issue here is different `CompressionLevel` enum options between .NET Framework and .NET. A user could write a build script that uses `SmallestSize` and have their build work in one environment, then fail in another. I suspect this might cause issues in Visual Studio, for example.

I doubt this is a new issue for MSBuild tasks, so let me know what the standard way of handling this is. It would be a shame to disallow the `SmallestSize` value, as it's my original motivation for adding this.

One option would be to translate `SmallestSize` into some other value (`Optimal`?) on .NET Framework. Not ideal, but better than completely neutering the ability.