### PR TITLE
Perf: Avoid hidden closures in Scheduler request loop

### DIFF
--- a/src/Build/BackEnd/Components/Scheduler/Scheduler.cs
+++ b/src/Build/BackEnd/Components/Scheduler/Scheduler.cs
@@ -1711,10 +1711,8 @@ namespace Microsoft.Build.BackEnd
                         abortRequestBatch = true;
                     }
                 }
-                else if (CheckIfCacheMissOnReferencedProjectIsAllowedAndErrorIfNot(nodeForResults, request, responses, out var emitNonErrorLogs))
+                else if (CheckIfCacheMissOnReferencedProjectIsAllowedAndErrorIfNot(nodeForResults, request, responses, emitNonErrorLogs: true))
                 {
-                    emitNonErrorLogs(_componentHost.LoggingService);
-
                     // Ensure there is no affinity mismatch between this request and a previous request of the same configuration.
                     NodeAffinity requestAffinity = GetNodeAffinityForRequest(request);
                     NodeAffinity existingRequestAffinity = NodeAffinity.Any;
@@ -1875,7 +1873,7 @@ namespace Microsoft.Build.BackEnd
             }
             else
             {
-                CheckIfCacheMissOnReferencedProjectIsAllowedAndErrorIfNot(nodeForResults, request.BuildRequest, responses, out _);
+                CheckIfCacheMissOnReferencedProjectIsAllowedAndErrorIfNot(nodeForResults, request.BuildRequest, responses, emitNonErrorLogs: false);
             }
         }
 
@@ -1954,35 +1952,40 @@ namespace Microsoft.Build.BackEnd
         }
 
         /// <returns>True if caches misses are allowed, false otherwise</returns>
-        private bool CheckIfCacheMissOnReferencedProjectIsAllowedAndErrorIfNot(int nodeForResults, BuildRequest request, List<ScheduleResponse> responses, out Action<ILoggingService> emitNonErrorLogs)
+        private bool CheckIfCacheMissOnReferencedProjectIsAllowedAndErrorIfNot(int nodeForResults, BuildRequest request, List<ScheduleResponse> responses, bool emitNonErrorLogs)
         {
-            emitNonErrorLogs = _ => { };
-
             ProjectIsolationMode isolateProjects = _componentHost.BuildParameters.ProjectIsolationMode;
-            var configCache = (IConfigCache)_componentHost.GetComponent(BuildComponentType.ConfigCache);
 
             // do not check root requests as nothing depends on them
             if (isolateProjects == ProjectIsolationMode.False || request.IsRootRequest || request.SkipStaticGraphIsolationConstraints
-                || SkipNonexistentTargetsIfExistentTargetsHaveResults(request))
+                || SkipNonexistentTargetsIfExistentTargetsHaveResults(request, _configCache, _resultsCache))
             {
-                bool logComment = ((isolateProjects == ProjectIsolationMode.True || isolateProjects == ProjectIsolationMode.MessageUponIsolationViolation) && request.SkipStaticGraphIsolationConstraints);
-                if (logComment)
+                if (emitNonErrorLogs
+                    && (isolateProjects == ProjectIsolationMode.True || isolateProjects == ProjectIsolationMode.MessageUponIsolationViolation)
+                    && request.SkipStaticGraphIsolationConstraints)
                 {
                     // retrieving the configs is not quite free, so avoid computing them eagerly
-                    var configs = GetConfigurations();
-
-                    emitNonErrorLogs = ls => ls.LogComment(
-                            NewBuildEventContext(),
+                    string projectFullPath = _configCache[request.ConfigurationId].ProjectFullPath;
+                    string parentProjectFullPath = GetParentConfigurationId(request, _configCache, _schedulingData).ProjectFullPath;
+                    _componentHost.LoggingService.LogComment(
+                            new BuildEventContext(
+                                request.SubmissionId,
+                                1,
+                                BuildEventContext.InvalidProjectInstanceId,
+                                BuildEventContext.InvalidProjectContextId,
+                                BuildEventContext.InvalidTargetId,
+                                BuildEventContext.InvalidTaskId),
                             MessageImportance.Normal,
                             "SkippedConstraintsOnRequest",
-                            configs.ParentConfig.ProjectFullPath,
-                            configs.RequestConfig.ProjectFullPath);
+                            parentProjectFullPath,
+                            projectFullPath);
                 }
 
                 return true;
             }
 
-            (BuildRequestConfiguration requestConfig, BuildRequestConfiguration parentConfig) = GetConfigurations();
+            BuildRequestConfiguration requestConfig = _configCache[request.ConfigurationId];
+            BuildRequestConfiguration parentConfig = GetParentConfigurationId(request, _configCache, _schedulingData);
 
             // allow self references (project calling the msbuild task on itself, potentially with different global properties)
             if (parentConfig.ProjectFullPath.Equals(requestConfig.ProjectFullPath, StringComparison.OrdinalIgnoreCase))
@@ -2010,40 +2013,43 @@ namespace Microsoft.Build.BackEnd
 
             return false;
 
-            BuildEventContext NewBuildEventContext()
+            static BuildRequestConfiguration GetParentConfigurationId(BuildRequest request, IConfigCache configCache, SchedulingData schedulingData)
             {
-                return new BuildEventContext(
-                    request.SubmissionId,
-                    1,
-                    BuildEventContext.InvalidProjectInstanceId,
-                    BuildEventContext.InvalidProjectContextId,
-                    BuildEventContext.InvalidTargetId,
-                    BuildEventContext.InvalidTaskId);
-            }
-
-            (BuildRequestConfiguration RequestConfig, BuildRequestConfiguration ParentConfig) GetConfigurations()
-            {
-                BuildRequestConfiguration buildRequestConfiguration = configCache[request.ConfigurationId];
+                int configurationId = BuildRequestConfiguration.InvalidConfigurationId;
 
                 // Need the parent request. It might be blocked or executing; check both.
-                SchedulableRequest parentRequest = _schedulingData.BlockedRequests.FirstOrDefault(r => r.BuildRequest.GlobalRequestId == request.ParentGlobalRequestId)
-                    ?? _schedulingData.ExecutingRequests.FirstOrDefault(r => r.BuildRequest.GlobalRequestId == request.ParentGlobalRequestId);
+                foreach (SchedulableRequest blockedRequest in schedulingData.BlockedRequests)
+                {
+                    if (blockedRequest.BuildRequest.GlobalRequestId == request.ParentGlobalRequestId)
+                    {
+                        configurationId = blockedRequest.BuildRequest.ConfigurationId;
+                        break;
+                    }
+                }
 
-                ErrorUtilities.VerifyThrowInternalNull(parentRequest);
+                if (configurationId == BuildRequestConfiguration.InvalidConfigurationId)
+                {
+                    foreach (SchedulableRequest executingRequest in schedulingData.ExecutingRequests)
+                    {
+                        if (executingRequest.BuildRequest.GlobalRequestId == request.ParentGlobalRequestId)
+                        {
+                            configurationId = executingRequest.BuildRequest.ConfigurationId;
+                            break;
+                        }
+                    }
+                }
+
                 ErrorUtilities.VerifyThrow(
-                    configCache.HasConfiguration(parentRequest.BuildRequest.ConfigurationId),
+                    configCache.HasConfiguration(configurationId),
                     "All non root requests should have a parent with a loaded configuration");
 
-                BuildRequestConfiguration parentConfiguration = configCache[parentRequest.BuildRequest.ConfigurationId];
-                return (buildRequestConfiguration, parentConfiguration);
+                return configCache[configurationId];
             }
 
-            string ConcatenateGlobalProperties(BuildRequestConfiguration configuration)
-            {
-                return string.Join("; ", configuration.GlobalProperties.Select<ProjectPropertyInstance, string>(p => $"{p.Name}={p.EvaluatedValue}"));
-            }
+            static string ConcatenateGlobalProperties(BuildRequestConfiguration configuration)
+                => string.Join("; ", configuration.GlobalProperties.Select<ProjectPropertyInstance, string>(p => $"{p.Name}={p.EvaluatedValue}"));
 
-            bool SkipNonexistentTargetsIfExistentTargetsHaveResults(BuildRequest buildRequest)
+            static bool SkipNonexistentTargetsIfExistentTargetsHaveResults(BuildRequest buildRequest, IConfigCache configCache, IResultsCache resultsCache)
             {
                 // Return early if the top-level target(s) of this build request weren't requested to be skipped if nonexistent.
                 if ((buildRequest.BuildRequestDataFlags & BuildRequestDataFlags.SkipNonexistentTargets) != BuildRequestDataFlags.SkipNonexistentTargets)
@@ -2051,7 +2057,7 @@ namespace Microsoft.Build.BackEnd
                     return false;
                 }
 
-                BuildResult requestResults = _resultsCache.GetResultsForConfiguration(buildRequest.ConfigurationId);
+                BuildResult requestResults = resultsCache.GetResultsForConfiguration(buildRequest.ConfigurationId);
 
                 // On a self-referenced build, cache misses are allowed.
                 if (requestResults == null)
@@ -2061,9 +2067,9 @@ namespace Microsoft.Build.BackEnd
 
                 // A cache miss on at least one existing target without results is disallowed,
                 // as it violates isolation constraints.
-                foreach (string target in request.Targets)
+                foreach (string target in buildRequest.Targets)
                 {
-                    if (_configCache[buildRequest.ConfigurationId]
+                    if (configCache[buildRequest.ConfigurationId]
                         .ProjectTargets
                         .Contains(target) &&
                         !requestResults.HasResultsForTarget(target))


### PR DESCRIPTION
### Fixes

Millions of hidden delegate allocations in hot Scheduler loop.

### Context

If you check out a memory profile, you may see a generated class in `Scheduler` as the top allocated type. Here at 315MB, it's taking up a whopping 12% of total allocations:

![image](https://github.com/user-attachments/assets/4913a2ae-fa3d-4871-919b-9b967040cbee)

Supposedly, this is created *in* `ResumeRequiredWork`:
```
Microsoft.Build.BackEnd.Scheduler+<>c__DisplayClass78_0
  Objects : 8258657
  Bytes   : 330346280

►  98.3%  ResumeRequiredWork • 309.74 MB / 309.74 MB • Microsoft.Build.BackEnd.Scheduler.ResumeRequiredWork(List<T>)
```

But if you look at `ResumeRequiredWork` or even try to source map over in dottrace, it brings you here:

```cs
foreach (SchedulableRequest request in unscheduledRequests)
{
    ResolveRequestFromCacheAndResumeIfPossible(request, responses);
}
```

Probably some JIT inlining going on, but  if you inspect the IL you'll find the real source:

![image](https://github.com/user-attachments/assets/2d33fb9b-cd23-450f-8b7c-36b6387127e1)


Basically, the compiler is trying to do a favor by creating a single type and allocation for all closures that capture the same or similar sets of variables. But in order to do this, it decides to create the allocation at the very start of the function - regardless of whether any of the functions actually need to run.

This means in order to get rid of the allocation, *every* anonymous and local function here needs to be rewritten to avoid capturing any local or instance state.
 
### Changes Made


### Testing


### Notes
