### PR TITLE
Perf: Don't cache ItemData.EnumerateMetadata pointer

### DIFF
--- a/src/Framework/IItemData.cs
+++ b/src/Framework/IItemData.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Collections.Generic;
 
 namespace Microsoft.Build.Framework;
@@ -41,11 +40,8 @@ public readonly record struct PropertyData(string Name, string Value);
 /// </remarks>
 public readonly struct ItemData
 {
-    private readonly Func<IEnumerable<KeyValuePair<string, string>>> _enumerateMetadata;
-
     public ItemData(string type, object value)
     {
-
         Type = type;
         Value = value;
 
@@ -56,17 +52,14 @@ public readonly struct ItemData
         if (value is IItemData dt)
         {
             EvaluatedInclude = dt.EvaluatedInclude;
-            _enumerateMetadata = dt.EnumerateMetadata;
         }
         else if (value is ITaskItem ti)
         {
             EvaluatedInclude = ti.ItemSpec;
-            _enumerateMetadata = ti.EnumerateMetadata;
         }
         else
         {
             EvaluatedInclude = value.ToString() ?? string.Empty;
-            _enumerateMetadata = () => [];
         }
     }
 
@@ -91,5 +84,16 @@ public readonly struct ItemData
     /// The item metadata
     /// </summary>
     public IEnumerable<KeyValuePair<string, string>> EnumerateMetadata()
-        => _enumerateMetadata();
+    {
+        if (Value is IItemData dt)
+        {
+            return dt.EnumerateMetadata();
+        }
+        else if (Value is ITaskItem ti)
+        {
+            return ti.EnumerateMetadata();
+        }
+
+        return [];
+    }
 }


### PR DESCRIPTION
### Fixes

Many allocations due to implicit object creation to capture function pointer + instance.

### Context

Here's 72MB / 1.19M `Func<IEnumerable<KeyValuePair<string, string>>` objects being supposedly allocated by `Utilities.CastItemsOnByOne`:

![image](https://github.com/user-attachments/assets/e6323e88-3fbd-4404-8e1f-228a0041559f)

In reality, the allocation is actually happening in the `ItemData` constructor:
```cs
public readonly struct ItemData
{
    private readonly Func<IEnumerable<KeyValuePair<string, string>>> _enumerateMetadata;

    public ItemData(string type, object value)
    {

        Type = type;
        Value = value;

        if (value is IItemData dt)
        {
            EvaluatedInclude = dt.EvaluatedInclude;
            _enumerateMetadata = dt.EnumerateMetadata;
        }
        else if (value is ITaskItem ti)
        {
            EvaluatedInclude = ti.ItemSpec;
            _enumerateMetadata = ti.EnumerateMetadata;
        }
        else
        {
            EvaluatedInclude = value.ToString() ?? string.Empty;
            _enumerateMetadata = () => [];
        }
    }
}
```

Referencing an instance method implicitly has to create an object since you need to store both a pointer to the target method that lives with the class definition + a pointer to the source instance to pass the method at runtime.

You can see this is exactly what the IL shows as well:

![image](https://github.com/user-attachments/assets/5e672341-b292-43ca-86f2-87023699046c)


### Changes Made

Since the struct already has a reference to the target in `Value`, we can directly call the function on-demand when needed without the allocation.