### PR TITLE
Specify initial size in HashSet constructor

### DIFF
--- a/src/Build/BackEnd/Components/Scheduler/Scheduler.cs
+++ b/src/Build/BackEnd/Components/Scheduler/Scheduler.cs
@@ -698,7 +698,7 @@ namespace Microsoft.Build.BackEnd
 
             // Resume any work available which has already been assigned to specific nodes.
             ResumeRequiredWork(responses);
-            HashSet<int> idleNodes = new HashSet<int>();
+            HashSet<int> idleNodes = new HashSet<int>(_availableNodes.Count);
             foreach (int availableNodeId in _availableNodes.Keys)
             {
                 if (!_schedulingData.IsNodeWorking(availableNodeId))


### PR DESCRIPTION
Sets the initial size of the HashSet base on the likely size of elements we could expect.


### Changes Made


### Testing


### Notes
