### PR TITLE
Significantly reduce allocations in ExpandMetadataLeaveEscaped

### DIFF
--- a/src/Build/Evaluation/Expander.cs
+++ b/src/Build/Evaluation/Expander.cs
@@ -971,6 +971,7 @@ namespace Microsoft.Build.Evaluation
 
                         int start = 0;
                         MetadataMatchEvaluator matchEvaluator = new MetadataMatchEvaluator(metadata, options, elementLocation, loggingContext);
+                        MatchEvaluator matchEvaluatorDelegate = new MatchEvaluator(matchEvaluator.ExpandSingleMetadata);
 
                         if (itemVectorExpressions != null)
                         {
@@ -983,7 +984,7 @@ namespace Microsoft.Build.Evaluation
                                 // Extract the part of the expression that appears before the item vector expression
                                 // e.g. the ABC in ABC@(foo->'%(FullPath)')
                                 string subExpressionToReplaceIn = expression.Substring(start, itemVectorExpressions[n].Index - start);
-                                string replacementResult = RegularExpressions.NonTransformItemMetadataRegex.Replace(subExpressionToReplaceIn, new MatchEvaluator(matchEvaluator.ExpandSingleMetadata));
+                                string replacementResult = RegularExpressions.NonTransformItemMetadataRegex.Replace(subExpressionToReplaceIn, matchEvaluatorDelegate);
 
                                 // Append the metadata replacement
                                 finalResultBuilder.Append(replacementResult);
@@ -991,7 +992,7 @@ namespace Microsoft.Build.Evaluation
                                 // Expand any metadata that appears in the item vector expression's separator
                                 if (itemVectorExpressions[n].Separator != null)
                                 {
-                                    vectorExpression = RegularExpressions.NonTransformItemMetadataRegex.Replace(itemVectorExpressions[n].Value, new MatchEvaluator(matchEvaluator.ExpandSingleMetadata), -1, itemVectorExpressions[n].SeparatorStart);
+                                    vectorExpression = RegularExpressions.NonTransformItemMetadataRegex.Replace(itemVectorExpressions[n].Value, matchEvaluatorDelegate, -1, itemVectorExpressions[n].SeparatorStart);
                                 }
 
                                 // Append the item vector expression as is
@@ -1008,7 +1009,7 @@ namespace Microsoft.Build.Evaluation
                         if (start < expression.Length)
                         {
                             string subExpressionToReplaceIn = expression.Substring(start);
-                            string replacementResult = RegularExpressions.NonTransformItemMetadataRegex.Replace(subExpressionToReplaceIn, new MatchEvaluator(matchEvaluator.ExpandSingleMetadata));
+                            string replacementResult = RegularExpressions.NonTransformItemMetadataRegex.Replace(subExpressionToReplaceIn, matchEvaluatorDelegate);
 
                             finalResultBuilder.Append(replacementResult);
                         }

--- a/src/StringTools/SpanBasedStringBuilder.cs
+++ b/src/StringTools/SpanBasedStringBuilder.cs
@@ -120,6 +120,32 @@ namespace Microsoft.NET.StringTools
         /// </summary>
         public int Capacity => _spans.Capacity;
 
+        public bool Equals(ReadOnlySpan<char> other)
+        {
+            if (_spans.Count == 0 && other.IsEmpty)
+            {
+                return true;
+            }
+
+            if (_spans.Count == 0 || other.IsEmpty || Length != other.Length)
+            {
+                return false;
+            }
+
+            int otherIndex = 0;
+            foreach (ReadOnlyMemory<char> internalSpan in _spans)
+            {
+                if (!MemoryExtensions.Equals(other.Slice(otherIndex, internalSpan.Length), internalSpan.Span, StringComparison.Ordinal))
+                {
+                    return false;
+                }
+
+                otherIndex += internalSpan.Length;
+            }
+
+            return true;
+        }
+
         /// <summary>
         /// Creates a new enumerator for enumerating characters in this string. Does not allocate.
         /// </summary>


### PR DESCRIPTION
### Context

The current implementation of `ExpandMetadataLeaveEscaped()` heavily leverages Regex methods, and doing so allocates a considerable amount. I measure around 3.8GB of allocations in this path while building Roslyn. Many of these allocations come from a combination of internal Regex implementation and the existing patterns of consuming them. Take this code for example:

                        using SpanBasedStringBuilder finalResultBuilder = Strings.GetSpanBasedStringBuilder();

                        int start = 0;
                        MetadataMatchEvaluator matchEvaluator = new MetadataMatchEvaluator(metadata, options, elementLocation, loggingContext);

                        if (itemVectorExpressions != null)
                        {
                            // Move over the expression, skipping those that have been recognized as an item vector expression
                            // Anything other than an item vector expression we want to expand bare metadata in.
                            for (int n = 0; n < itemVectorExpressions.Count; n++)
                            {
                                string vectorExpression = itemVectorExpressions[n].Value;

                                // Extract the part of the expression that appears before the item vector expression
                                // e.g. the ABC in ABC@(foo->'%(FullPath)')
                                string subExpressionToReplaceIn = expression.Substring(start, itemVectorExpressions[n].Index - start);
                                string replacementResult = RegularExpressions.NonTransformItemMetadataRegex.Replace(subExpressionToReplaceIn, new MatchEvaluator(matchEvaluator.ExpandSingleMetadata));

                                // Append the metadata replacement
                                finalResultBuilder.Append(replacementResult);

                                // Expand any metadata that appears in the item vector expression's separator
                                if (itemVectorExpressions[n].Separator != null)
                                {
                                    vectorExpression = RegularExpressions.NonTransformItemMetadataRegex.Replace(itemVectorExpressions[n].Value, new MatchEvaluator(matchEvaluator.ExpandSingleMetadata), -1, itemVectorExpressions[n].SeparatorStart);
                                }

                                // Append the item vector expression as is
                                // e.g. the @(foo->'%(FullPath)') in ABC@(foo->'%(FullPath)')
                                finalResultBuilder.Append(vectorExpression);

                                // Move onto the next part of the expression that isn't an item vector expression
                                start = (itemVectorExpressions[n].Index + itemVectorExpressions[n].Length);
                            }
                        }


Here there are several calls to `Regex.Replace()` that each return a new string that gets appended to the `SpanBasedStringBuilder`. If you dig into the implementation of `Regex.Replace()` you can start to see where the inefficiencies really add up

            stringBuilder = new StringBuilder();
            int num = 0;
            do
            {
                if (match.Index != num)
                {
                    stringBuilder.Append(input, num, match.Index - num);
                }

                num = match.Index + match.Length;
                stringBuilder.Append(evaluator(match));
                if (--count == 0)
                {
                    break;
                }

                match = match.NextMatch();
            }
            while (match.Success);
            if (num < input.Length)
            {
                stringBuilder.Append(input, num, input.Length - num);
            }

So, for *each* call to `Regex.Replace()` we're, we're creating a new `StringBuilder` and appending to it, causing it to expand it's internal data structures, as we evaluate the matches. Finally, we return the resulting string and add it to the span based builder. By modifying this implementation to directly use the `SpanBasedStringBuilder`, we can eliminate a considerable amount of duplication. We can do some additional cleanup in this code to avoid some additional allocations as well.

Before:

![image](https://github.com/user-attachments/assets/e8c8d024-7694-46ba-827d-0b687b5ee9ea)

After:

![image](https://github.com/user-attachments/assets/75dbe605-efdd-4177-9274-b8f8d889188a)


Many types that were previously allocated are either entirely eliminated or significantly reduced. Before there are ~3.8GB of allocations here and only 2.7GB here after.

### Changes Made


### Testing


### Notes
