### PR TITLE
switch from newing up a ICollection ot a IReadOnlyCollection

### DIFF
--- a/src/Build.UnitTests/BackEnd/IntrinsicTask_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/IntrinsicTask_Tests.cs
@@ -246,8 +246,8 @@ namespace Microsoft.Build.UnitTests.BackEnd
             Lookup lookup = LookupHelpers.CreateEmptyLookup();
             ExecuteTask(task, lookup);
 
-            ICollection<ProjectItemInstance> i1Group = lookup.GetItems("i1");
-            ICollection<ProjectItemInstance> i2Group = lookup.GetItems("i2");
+            IReadOnlyCollection<ProjectItemInstance> i1Group = lookup.GetItems("i1");
+            IReadOnlyCollection<ProjectItemInstance> i2Group = lookup.GetItems("i2");
             Assert.Equal("a1", i1Group.First().EvaluatedInclude);
             Assert.Equal("b1", i2Group.First().EvaluatedInclude);
         }
@@ -698,7 +698,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             Lookup lookup = LookupHelpers.CreateEmptyLookup();
             ExecuteTask(task, lookup);
 
-            ICollection<ProjectItemInstance> i1Group = lookup.GetItems("i1");
+            IReadOnlyCollection<ProjectItemInstance> i1Group = lookup.GetItems("i1");
             Assert.Empty(i1Group);
         }
 
@@ -721,7 +721,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             Lookup lookup = LookupHelpers.CreateEmptyLookup();
             ExecuteTask(task, lookup);
 
-            ICollection<ProjectItemInstance> i1Group = lookup.GetItems("i1");
+            IReadOnlyCollection<ProjectItemInstance> i1Group = lookup.GetItems("i1");
             Assert.Equal("a1", i1Group.First().EvaluatedInclude);
             Assert.Equal("m1", i1Group.First().GetMetadataValue("m"));
         }
@@ -747,7 +747,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             Lookup lookup = LookupHelpers.CreateLookup(properties);
             ExecuteTask(task, lookup);
 
-            ICollection<ProjectItemInstance> i1Group = lookup.GetItems("i1");
+            IReadOnlyCollection<ProjectItemInstance> i1Group = lookup.GetItems("i1");
             Assert.Equal("v0", i1Group.First().EvaluatedInclude);
         }
 
@@ -818,8 +818,8 @@ namespace Microsoft.Build.UnitTests.BackEnd
             Lookup lookup = LookupHelpers.CreateEmptyLookup();
             ExecuteTask(task, lookup);
 
-            ICollection<ProjectItemInstance> i1Group = lookup.GetItems("i1");
-            ICollection<ProjectItemInstance> i2Group = lookup.GetItems("i2");
+            IReadOnlyCollection<ProjectItemInstance> i1Group = lookup.GetItems("i1");
+            IReadOnlyCollection<ProjectItemInstance> i2Group = lookup.GetItems("i2");
             Assert.Equal("a.cpp", i1Group.First().EvaluatedInclude);
             Assert.Equal("a.obj", i2Group.First().EvaluatedInclude);
         }
@@ -842,7 +842,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             Lookup lookup = LookupHelpers.CreateEmptyLookup();
             ExecuteTask(task, lookup);
 
-            ICollection<ProjectItemInstance> i2Group = lookup.GetItems("i2");
+            IReadOnlyCollection<ProjectItemInstance> i2Group = lookup.GetItems("i2");
             Assert.Equal("a.cpp", i2Group.First().EvaluatedInclude);
             Assert.Equal("a.obj", i2Group.First().GetMetadataValue("m"));
         }
@@ -863,8 +863,8 @@ namespace Microsoft.Build.UnitTests.BackEnd
             Lookup lookup = LookupHelpers.CreateEmptyLookup();
             ExecuteTask(task, lookup);
 
-            ICollection<ProjectItemInstance> i1Group = lookup.GetItems("i1");
-            ICollection<ProjectItemInstance> i2Group = lookup.GetItems("i2");
+            IReadOnlyCollection<ProjectItemInstance> i1Group = lookup.GetItems("i1");
+            IReadOnlyCollection<ProjectItemInstance> i2Group = lookup.GetItems("i2");
             Assert.Equal("a1", i1Group.First().EvaluatedInclude);
             Assert.Equal("b2", i2Group.First().EvaluatedInclude);
         }
@@ -887,8 +887,8 @@ namespace Microsoft.Build.UnitTests.BackEnd
             Lookup lookup = LookupHelpers.CreateEmptyLookup();
             ExecuteTask(task, lookup);
 
-            ICollection<ProjectItemInstance> i1Group = lookup.GetItems("i1");
-            ICollection<ProjectItemInstance> i2Group = lookup.GetItems("i2");
+            IReadOnlyCollection<ProjectItemInstance> i1Group = lookup.GetItems("i1");
+            IReadOnlyCollection<ProjectItemInstance> i2Group = lookup.GetItems("i2");
             Assert.Single(i1Group);
             Assert.Single(i2Group);
             Assert.Equal("a1", i1Group.First().EvaluatedInclude);
@@ -998,8 +998,8 @@ namespace Microsoft.Build.UnitTests.BackEnd
             Lookup lookup = LookupHelpers.CreateLookup(properties);
             ExecuteTask(task, lookup);
 
-            ICollection<ProjectItemInstance> i1Group = lookup.GetItems("i1");
-            ICollection<ProjectItemInstance> i2Group = lookup.GetItems("i2");
+            IReadOnlyCollection<ProjectItemInstance> i1Group = lookup.GetItems("i1");
+            IReadOnlyCollection<ProjectItemInstance> i2Group = lookup.GetItems("i2");
             Assert.Equal("v0", i1Group.First().EvaluatedInclude);
             Assert.Equal("a2", i2Group.First().EvaluatedInclude);
         }
@@ -1025,8 +1025,8 @@ namespace Microsoft.Build.UnitTests.BackEnd
             Lookup lookup = LookupHelpers.CreateEmptyLookup();
             ExecuteTask(task, lookup);
 
-            ICollection<ProjectItemInstance> i1Group = lookup.GetItems("i1");
-            ICollection<ProjectItemInstance> i2Group = lookup.GetItems("i2");
+            IReadOnlyCollection<ProjectItemInstance> i1Group = lookup.GetItems("i1");
+            IReadOnlyCollection<ProjectItemInstance> i2Group = lookup.GetItems("i2");
 
             Assert.Equal("a1", i1Group.First().EvaluatedInclude);
             Assert.Equal("a2", i1Group.ElementAt(1).EvaluatedInclude);
@@ -1059,7 +1059,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             Lookup lookup = LookupHelpers.CreateEmptyLookup();
             ExecuteTask(task, lookup);
 
-            ICollection<ProjectItemInstance> i2Group = lookup.GetItems("i2");
+            IReadOnlyCollection<ProjectItemInstance> i2Group = lookup.GetItems("i2");
 
             Assert.Equal(2, i2Group.Count);
             Assert.Equal("a1", i2Group.First().EvaluatedInclude);
@@ -1116,8 +1116,8 @@ namespace Microsoft.Build.UnitTests.BackEnd
             Lookup lookup = GenerateLookup(task.Project);
             ExecuteTask(task, lookup);
 
-            ICollection<ProjectItemInstance> i1Group = lookup.GetItems("i1");
-            ICollection<ProjectItemInstance> i2Group = lookup.GetItems("i2");
+            IReadOnlyCollection<ProjectItemInstance> i1Group = lookup.GetItems("i1");
+            IReadOnlyCollection<ProjectItemInstance> i2Group = lookup.GetItems("i2");
 
             Assert.Equal("b1", i1Group.First().EvaluatedInclude);
             Assert.Equal("b1", i1Group.ElementAt(1).EvaluatedInclude);
@@ -2049,7 +2049,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             IntrinsicTask task = CreateIntrinsicTask(content);
             Lookup lookup = LookupHelpers.CreateEmptyLookup();
             ExecuteTask(task, lookup);
-            ICollection<ProjectItemInstance> items = lookup.GetItems("I2");
+            IReadOnlyCollection<ProjectItemInstance> items = lookup.GetItems("I2");
             items.Count.ShouldBe(3);
             items.ElementAt(0).EvaluatedInclude.ShouldBe("a2");
             items.ElementAt(1).EvaluatedInclude.ShouldBe("c2");
@@ -2084,7 +2084,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             IntrinsicTask task = CreateIntrinsicTask(content);
             Lookup lookup = LookupHelpers.CreateEmptyLookup();
             ExecuteTask(task, lookup);
-            ICollection<ProjectItemInstance> items = lookup.GetItems("I3");
+            IReadOnlyCollection<ProjectItemInstance> items = lookup.GetItems("I3");
             items.ShouldBeEmpty();
         }
 
@@ -2143,7 +2143,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
 
             task.ExecuteTask(lookup);
 
-            ICollection<ProjectItemInstance> i0Group = lookup.GetItems("i0");
+            IReadOnlyCollection<ProjectItemInstance> i0Group = lookup.GetItems("i0");
 
             Assert.Equal(3, i0Group.Count);
             Assert.Equal("a1", i0Group.First().EvaluatedInclude);
@@ -2224,7 +2224,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
 
             task.ExecuteTask(lookup);
 
-            ICollection<ProjectItemInstance> i1Group = lookup.GetItems("i1");
+            IReadOnlyCollection<ProjectItemInstance> i1Group = lookup.GetItems("i1");
 
             Assert.Single(i1Group);
             Assert.Equal("x", i1Group.First().EvaluatedInclude);
@@ -2267,7 +2267,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
 
             task.ExecuteTask(lookup);
 
-            ICollection<ProjectItemInstance> linkGroup = lookup.GetItems("link");
+            IReadOnlyCollection<ProjectItemInstance> linkGroup = lookup.GetItems("link");
 
             Assert.Equal(4, linkGroup.Count);
             Assert.Equal("A_PCH", linkGroup.First().EvaluatedInclude);
@@ -3111,7 +3111,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
 
             task.ExecuteTask(lookup);
 
-            ICollection<ProjectItemInstance> i0Group = lookup.GetItems("i0");
+            IReadOnlyCollection<ProjectItemInstance> i0Group = lookup.GetItems("i0");
 
             Assert.Equal(4, i0Group.Count);
             foreach (ProjectItemInstance item in i0Group)

--- a/src/Build.UnitTests/BackEnd/Lookup_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/Lookup_Tests.cs
@@ -412,7 +412,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
 
             // Get rid of all of the metadata.
             Lookup.MetadataModifications newMetadata = new Lookup.MetadataModifications(keepOnlySpecified: true);
-            ICollection<ProjectItemInstance> group = lookup.GetItems(item1.ItemType);
+            IReadOnlyCollection<ProjectItemInstance> group = lookup.GetItems(item1.ItemType);
             lookup.ModifyItems(item1.ItemType, group, newMetadata);
 
             group = lookup.GetItems("i1");
@@ -477,7 +477,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             // Add m3 metadata
             Lookup.MetadataModifications newMetadata = new Lookup.MetadataModifications(keepOnlySpecified: false);
             newMetadata.Add("m3", "m3");
-            ICollection<ProjectItemInstance> group = lookup.GetItems(item1.ItemType);
+            IReadOnlyCollection<ProjectItemInstance> group = lookup.GetItems(item1.ItemType);
             lookup.ModifyItems(item1.ItemType, group, newMetadata);
 
             group = lookup.GetItems("i1");
@@ -537,7 +537,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             // Get rid of all of the metadata, then add m3
             Lookup.MetadataModifications newMetadata = new Lookup.MetadataModifications(keepOnlySpecified: true);
             newMetadata.Add("m3", "m3");
-            ICollection<ProjectItemInstance> group = lookup.GetItems(item1.ItemType);
+            IReadOnlyCollection<ProjectItemInstance> group = lookup.GetItems(item1.ItemType);
             lookup.ModifyItems(item1.ItemType, group, newMetadata);
 
             group = lookup.GetItems("i1");
@@ -608,7 +608,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             // Get rid of all of the metadata, then add m3
             Lookup.MetadataModifications newMetadata = new Lookup.MetadataModifications(keepOnlySpecified: true);
             newMetadata.Add("m3", "m3");
-            ICollection<ProjectItemInstance> group = lookup.GetItems(item1.ItemType);
+            IReadOnlyCollection<ProjectItemInstance> group = lookup.GetItems(item1.ItemType);
             lookup.ModifyItems(item1.ItemType, group, newMetadata);
 
             group = lookup.GetItems("i1");
@@ -675,7 +675,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             // Test keeping only specified metadata
             Lookup.MetadataModifications newMetadata = new Lookup.MetadataModifications(keepOnlySpecified: true);
             newMetadata["m1"] = Lookup.MetadataModification.CreateFromNoChange();
-            ICollection<ProjectItemInstance> group = lookup.GetItems(item1.ItemType);
+            IReadOnlyCollection<ProjectItemInstance> group = lookup.GetItems(item1.ItemType);
             lookup.ModifyItems(item1.ItemType, group, newMetadata);
 
             group = lookup.GetItems("i1");
@@ -729,7 +729,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
 
             // Test keeping only specified metadata
             Lookup.MetadataModifications newMetadata = new Lookup.MetadataModifications(keepOnlySpecified: true);
-            ICollection<ProjectItemInstance> group = lookup.GetItems(item1.ItemType);
+            IReadOnlyCollection<ProjectItemInstance> group = lookup.GetItems(item1.ItemType);
             lookup.ModifyItems(item1.ItemType, group, newMetadata);
 
             group = lookup.GetItems("i1");
@@ -777,8 +777,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             // Change the item to be m=m2
             Lookup.MetadataModifications newMetadata = new Lookup.MetadataModifications(keepOnlySpecified: false);
             newMetadata.Add("m", "m2");
-            ICollection<ProjectItemInstance> group = new List<ProjectItemInstance>();
-            group.Add(item1);
+            IReadOnlyCollection<ProjectItemInstance> group = new List<ProjectItemInstance> { item1 };
             lookup.ModifyItems(item1.ItemType, group, newMetadata);
 
             // Now it has m=m2
@@ -832,8 +831,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             Lookup.MetadataModifications newMetadata = new Lookup.MetadataModifications(keepOnlySpecified: false);
             newMetadata.Add("m", "m2");
             newMetadata.Add("n", "n2");
-            ICollection<ProjectItemInstance> group = new List<ProjectItemInstance>();
-            group.Add(item1);
+            IReadOnlyCollection<ProjectItemInstance> group = new List<ProjectItemInstance> { item1 };
             lookup.ModifyItems(item1.ItemType, group, newMetadata);
 
             lookup.EnterScope("x");
@@ -872,8 +870,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             // Make a modification to the item to be m=m2
             Lookup.MetadataModifications newMetadata = new Lookup.MetadataModifications(keepOnlySpecified: false);
             newMetadata.Add("m", "m2");
-            ICollection<ProjectItemInstance> group = new List<ProjectItemInstance>();
-            group.Add(item1);
+            IReadOnlyCollection<ProjectItemInstance> group = new List<ProjectItemInstance> { item1 };
             lookup.ModifyItems(item1.ItemType, group, newMetadata);
 
             // Make an unrelated modification to the item
@@ -907,7 +904,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             Lookup.Scope enteredScope = lookup.EnterScope("x");
 
             // It's still m=m1, n=n1, o=o1
-            ICollection<ProjectItemInstance> group = lookup.GetItems("i1");
+            IReadOnlyCollection<ProjectItemInstance> group = lookup.GetItems("i1");
             Assert.Single(group);
             Assert.Equal("m1", group.First().GetMetadataValue("m"));
             Assert.Equal("n1", group.First().GetMetadataValue("n"));
@@ -917,12 +914,11 @@ namespace Microsoft.Build.UnitTests.BackEnd
             Lookup.MetadataModifications newMetadata = new Lookup.MetadataModifications(keepOnlySpecified: false);
             newMetadata.Add("m", "m2");
             newMetadata.Add("n", "n2");
-            group = new List<ProjectItemInstance>();
-            group.Add(item1);
+            group = new List<ProjectItemInstance> { item1 };
             lookup.ModifyItems("i1", group, newMetadata);
 
             // It's now m=m2, n=n2, o=o1
-            ICollection<ProjectItemInstance> foundGroup = lookup.GetItems("i1");
+            IReadOnlyCollection<ProjectItemInstance> foundGroup = lookup.GetItems("i1");
             Assert.Single(foundGroup);
             Assert.Equal("m2", foundGroup.First().GetMetadataValue("m"));
             Assert.Equal("n2", foundGroup.First().GetMetadataValue("n"));
@@ -978,8 +974,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             // Change the item to be m=m2
             Lookup.MetadataModifications newMetadata = new Lookup.MetadataModifications(keepOnlySpecified: false);
             newMetadata.Add("m", "m2");
-            ICollection<ProjectItemInstance> group = new List<ProjectItemInstance>();
-            group.Add(item1);
+            IReadOnlyCollection<ProjectItemInstance> group = new List<ProjectItemInstance> { item1 };
             lookup.ModifyItems(item1.ItemType, group, newMetadata);
 
             // Now it has m=m2
@@ -1035,24 +1030,22 @@ namespace Microsoft.Build.UnitTests.BackEnd
             // Make a modification to the item to be m=m2
             Lookup.MetadataModifications newMetadata = new Lookup.MetadataModifications(keepOnlySpecified: false);
             newMetadata.Add("m", "m2");
-            ICollection<ProjectItemInstance> group = new List<ProjectItemInstance>();
-            group.Add(item1);
+            IReadOnlyCollection<ProjectItemInstance> group = new List<ProjectItemInstance> { item1 };
             lookup.ModifyItems(item1.ItemType, group, newMetadata);
 
             // Get the item (under the covers, it cloned it in order to apply the modification)
-            ICollection<ProjectItemInstance> group2 = lookup.GetItems(item1.ItemType);
+            IReadOnlyCollection<ProjectItemInstance> group2 = lookup.GetItems(item1.ItemType);
             Assert.Single(group2);
             ProjectItemInstance item1b = group2.First();
 
             // Modify to m=m3
             Lookup.MetadataModifications newMetadata2 = new Lookup.MetadataModifications(keepOnlySpecified: false);
             newMetadata2.Add("m", "m3");
-            ICollection<ProjectItemInstance> group3 = new List<ProjectItemInstance>();
-            group3.Add(item1b);
+            IReadOnlyCollection<ProjectItemInstance> group3 = new List<ProjectItemInstance> { item1b };
             lookup.ModifyItems(item1b.ItemType, group3, newMetadata2);
 
             // Modifications are visible
-            ICollection<ProjectItemInstance> group4 = lookup.GetItems(item1b.ItemType);
+            IReadOnlyCollection<ProjectItemInstance> group4 = lookup.GetItems(item1b.ItemType);
             Assert.Single(group4);
             Assert.Equal("m3", group4.First().GetMetadataValue("m"));
 
@@ -1060,7 +1053,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             enteredScope.LeaveScope();
 
             // Still visible
-            ICollection<ProjectItemInstance> group5 = lookup.GetItems(item1b.ItemType);
+            IReadOnlyCollection<ProjectItemInstance> group5 = lookup.GetItems(item1b.ItemType);
             Assert.Single(group5);
             Assert.Equal("m3", group5.First().GetMetadataValue("m"));
         }
@@ -1091,7 +1084,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             lookup.ModifyItems(item1.ItemType, group, newMetadata);
 
             // Get the item (under the covers, it cloned it in order to apply the modification)
-            ICollection<ProjectItemInstance> group2 = lookup.GetItems(item1.ItemType);
+            IReadOnlyCollection<ProjectItemInstance> group2 = lookup.GetItems(item1.ItemType);
             Assert.Single(group2);
             ProjectItemInstance item1b = group2.First();
 
@@ -1103,7 +1096,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             lookup.ModifyItems(item1b.ItemType, group3, newMetadata2);
 
             // Modifications are visible
-            ICollection<ProjectItemInstance> group4 = lookup.GetItems(item1b.ItemType);
+            IReadOnlyCollection<ProjectItemInstance> group4 = lookup.GetItems(item1b.ItemType);
             Assert.Single(group4);
             Assert.Equal("m3", group4.First().GetMetadataValue("m"));
 
@@ -1111,7 +1104,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             enteredScope.LeaveScope();
 
             // Still visible
-            ICollection<ProjectItemInstance> group5 = lookup.GetItems(item1b.ItemType);
+            IReadOnlyCollection<ProjectItemInstance> group5 = lookup.GetItems(item1b.ItemType);
             Assert.Single(group5);
             Assert.Equal("m3", group5.First().GetMetadataValue("m"));
 
@@ -1144,7 +1137,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             lookup.ModifyItems(item1.ItemType, group, newMetadata);
 
             // Get the item (under the covers, it cloned it in order to apply the modification)
-            ICollection<ProjectItemInstance> group2 = lookup.GetItems(item1.ItemType);
+            IReadOnlyCollection<ProjectItemInstance> group2 = lookup.GetItems(item1.ItemType);
             Assert.Single(group2);
             ProjectItemInstance item1b = group2.First();
 
@@ -1152,7 +1145,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             lookup.RemoveItem(item1b);
 
             // There's now no items at all
-            ICollection<ProjectItemInstance> group3 = lookup.GetItems(item1.ItemType);
+            IReadOnlyCollection<ProjectItemInstance> group3 = lookup.GetItems(item1.ItemType);
             Assert.Empty(group3);
         }
 
@@ -1181,7 +1174,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             lookup.ModifyItems(item1.ItemType, group, newMetadata);
 
             // Get the item (under the covers, it cloned it in order to apply the modification)
-            ICollection<ProjectItemInstance> group2 = lookup.GetItems(item1.ItemType);
+            IReadOnlyCollection<ProjectItemInstance> group2 = lookup.GetItems(item1.ItemType);
             Assert.Single(group2);
             ProjectItemInstance item1b = group2.First();
 
@@ -1189,7 +1182,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             lookup.RemoveItem(item1b);
 
             // There's now no items at all
-            ICollection<ProjectItemInstance> group3 = lookup.GetItems(item1.ItemType);
+            IReadOnlyCollection<ProjectItemInstance> group3 = lookup.GetItems(item1.ItemType);
             Assert.Empty(group3);
 
             // Leave scope

--- a/src/Build.UnitTests/BackEnd/TaskExecutionHost_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/TaskExecutionHost_Tests.cs
@@ -1282,7 +1282,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             itemsByName.Add(item2);
             _twoItems = new ITaskItem[] { new TaskItem(item), new TaskItem(item2) };
 
-            _bucket = new ItemBucket(new Dictionary<string, ICollection<ProjectItemInstance>>().Keys, new Dictionary<string, string>(), new Lookup(itemsByName, new PropertyDictionary<ProjectPropertyInstance>()), 0);
+            _bucket = new ItemBucket(new Dictionary<string, IReadOnlyCollection<ProjectItemInstance>>().Keys, new Dictionary<string, string>(), new Lookup(itemsByName, new PropertyDictionary<ProjectPropertyInstance>()), 0);
             _bucket.Initialize(null);
             _host.FindTask(null);
             _host.InitializeForBatch(talc, _bucket, null);

--- a/src/Build.UnitTests/Collections/OMcollections_tests.cs
+++ b/src/Build.UnitTests/Collections/OMcollections_tests.cs
@@ -129,7 +129,7 @@ namespace Microsoft.Build.UnitTests.OM.Collections
             Assert.Empty(list);
 
             // Cause an empty list for type 'x' to be added
-            ICollection<ProjectItemInstance> itemList = items["x"];
+            IReadOnlyCollection<ProjectItemInstance> itemList = items["x"];
 
             // Enumerate empty collection, with an empty list in it
             foreach (ProjectItemInstance item in items)

--- a/src/Build/BackEnd/Components/RequestBuilder/BatchingEngine.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/BatchingEngine.cs
@@ -144,7 +144,7 @@ namespace Microsoft.Build.BackEnd
                 // that weren't represented in "consumedItemReferences"... this would happen if there
                 // were qualified metadata references in the consumedMetadataReferences table, such as
                 // %(EmbeddedResource.Culture).
-                Dictionary<string, ICollection<ProjectItemInstance>> itemListsToBeBatched = GetItemListsToBeBatched(consumedMetadataReferences, consumedItemReferences, lookup, elementLocation);
+                Dictionary<string, IReadOnlyCollection<ProjectItemInstance>> itemListsToBeBatched = GetItemListsToBeBatched(consumedMetadataReferences, consumedItemReferences, lookup, elementLocation);
 
                 // At this point, if there were any metadata references in the tag, but no item
                 // references to batch on, we've got a problem because we can't figure out which
@@ -203,7 +203,7 @@ namespace Microsoft.Build.BackEnd
         /// the entire list of items will be returned in the Value.  Otherwise, the Value will be empty, indicating only the
         /// qualified item set (in the Key) should be batched.
         /// </returns>
-        private static Dictionary<string, ICollection<ProjectItemInstance>> GetItemListsToBeBatched(
+        private static Dictionary<string, IReadOnlyCollection<ProjectItemInstance>> GetItemListsToBeBatched(
             Dictionary<string, MetadataReference> consumedMetadataReferences,   // Key is [string] potentially qualified metadata name
                                                                                 // Value is [struct MetadataReference]
             HashSet<string> consumedItemReferenceNames,
@@ -212,7 +212,7 @@ namespace Microsoft.Build.BackEnd
         {
             // The keys in this hashtable are the names of the items that we will batch on.
             // The values are always String.Empty (not used).
-            var itemListsToBeBatched = new Dictionary<string, ICollection<ProjectItemInstance>>(MSBuildNameIgnoreCaseComparer.Default);
+            var itemListsToBeBatched = new Dictionary<string, IReadOnlyCollection<ProjectItemInstance>>(MSBuildNameIgnoreCaseComparer.Default);
 
             // Loop through all the metadata references and find the ones that are qualified
             // with an item name.
@@ -254,7 +254,7 @@ namespace Microsoft.Build.BackEnd
                         foreach (string consumedItemName in consumedItemReferenceNames)
                         {
                             // Loop through all the items in the item list.
-                            ICollection<ProjectItemInstance> items = lookup.GetItems(consumedItemName);
+                            IReadOnlyCollection<ProjectItemInstance> items = lookup.GetItems(consumedItemName);
 
                             if (items != null)
                             {
@@ -299,7 +299,7 @@ namespace Microsoft.Build.BackEnd
         /// <returns>List containing ItemBucket objects (can be empty), each one representing an execution batch.</returns>
         private static List<ItemBucket> BucketConsumedItems(
             Lookup lookup,
-            Dictionary<string, ICollection<ProjectItemInstance>> itemListsToBeBatched,
+            Dictionary<string, IReadOnlyCollection<ProjectItemInstance>> itemListsToBeBatched,
             Dictionary<string, MetadataReference> consumedMetadataReferences,
             ElementLocation elementLocation,
             LoggingContext loggingContext)
@@ -310,12 +310,12 @@ namespace Microsoft.Build.BackEnd
             var buckets = new List<ItemBucket>();
 
             // Get and iterate through the list of item names that we're supposed to batch on.
-            foreach (KeyValuePair<string, ICollection<ProjectItemInstance>> entry in itemListsToBeBatched)
+            foreach (KeyValuePair<string, IReadOnlyCollection<ProjectItemInstance>> entry in itemListsToBeBatched)
             {
                 string itemName = entry.Key;
 
                 // Use the previously-fetched items, if possible
-                ICollection<ProjectItemInstance> items = entry.Value ?? lookup.GetItems(itemName);
+                IReadOnlyCollection<ProjectItemInstance> items = entry.Value ?? lookup.GetItems(itemName);
 
                 if (items != null)
                 {

--- a/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupIntrinsicTask.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupIntrinsicTask.cs
@@ -249,7 +249,7 @@ namespace Microsoft.Build.BackEnd
         /// <param name="matchingOptions">Options matching.</param>
         private void ExecuteRemove(ProjectItemGroupTaskItemInstance child, ItemBucket bucket, HashSet<string> matchOnMetadata, MatchOnMetadataOptions matchingOptions)
         {
-            ICollection<ProjectItemInstance> group = bucket.Lookup.GetItems(child.ItemType);
+            IReadOnlyCollection<ProjectItemInstance> group = bucket.Lookup.GetItems(child.ItemType);
             if (group == null)
             {
                 // No items of this type to remove
@@ -296,7 +296,7 @@ namespace Microsoft.Build.BackEnd
         /// <param name="loggingContext">Context for this operation.</param>
         private void ExecuteModify(ProjectItemGroupTaskItemInstance child, ItemBucket bucket, ISet<string> keepMetadata, ISet<string> removeMetadata, LoggingContext loggingContext = null)
         {
-            ICollection<ProjectItemInstance> group = bucket.Lookup.GetItems(child.ItemType);
+            IReadOnlyCollection<ProjectItemInstance> group = bucket.Lookup.GetItems(child.ItemType);
             if (group == null || group.Count == 0)
             {
                 // No items of this type to modify
@@ -342,7 +342,7 @@ namespace Microsoft.Build.BackEnd
             }
 
             // Now apply the changes.  This must be done after filtering, since explicitly set metadata overrides filters.
-            bucket.Lookup.ModifyItems(child.ItemType, group, metadataToSet);
+            bucket.Lookup.ModifyItems(child.ItemType, [..group], metadataToSet);
         }
 
         /// <summary>
@@ -585,7 +585,7 @@ namespace Microsoft.Build.BackEnd
         /// <param name="expander">The expander to use</param>
         /// <returns>A list of matching items</returns>
         private List<ProjectItemInstance> FindItemsMatchingSpecification(
-            ICollection<ProjectItemInstance> items,
+            IReadOnlyCollection<ProjectItemInstance> items,
             string specification,
             ElementLocation specificationLocation,
             Expander<ProjectPropertyInstance, ProjectItemInstance> expander)
@@ -653,7 +653,7 @@ namespace Microsoft.Build.BackEnd
         }
 
         private List<ProjectItemInstance> FindItemsMatchingMetadataSpecification(
-            ICollection<ProjectItemInstance> group,
+            IReadOnlyCollection<ProjectItemInstance> group,
             ProjectItemGroupTaskItemInstance child,
             Expander<ProjectPropertyInstance, ProjectItemInstance> expander,
             HashSet<string> matchOnMetadata,

--- a/src/Build/BackEnd/Components/RequestBuilder/ItemBucket.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/ItemBucket.cs
@@ -74,7 +74,7 @@ namespace Microsoft.Build.BackEnd
         /// <param name="lookup">The <see cref="Lookup"/> to use for the items in the bucket.</param>
         /// <param name="bucketSequenceNumber">A sequence number indication what order the buckets were created in.</param>
         internal ItemBucket(
-            Dictionary<string, ICollection<ProjectItemInstance>>.KeyCollection itemNames, // PERF: directly use the KeyCollection to avoid boxing the enumerator.
+            Dictionary<string, IReadOnlyCollection<ProjectItemInstance>>.KeyCollection itemNames, // PERF: directly use the KeyCollection to avoid boxing the enumerator.
             Dictionary<string, string> metadata,
             Lookup lookup,
             int bucketSequenceNumber)

--- a/src/Build/BackEnd/Components/RequestBuilder/Lookup.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/Lookup.cs
@@ -461,7 +461,7 @@ namespace Microsoft.Build.BackEnd
         /// If no match is found, returns an empty list.
         /// Caller must not modify the group returned.
         /// </summary>
-        public ICollection<ProjectItemInstance> GetItems(string itemType)
+        public IReadOnlyCollection<ProjectItemInstance> GetItems(string itemType)
         {
             // The visible items consist of the adds (accumulated as we go down)
             // plus the first set of regular items we encounter
@@ -470,14 +470,14 @@ namespace Microsoft.Build.BackEnd
             List<ProjectItemInstance> allAdds = null;
             List<ProjectItemInstance> allRemoves = null;
             Dictionary<ProjectItemInstance, MetadataModifications> allModifies = null;
-            ICollection<ProjectItemInstance> groupFound = null;
+            IReadOnlyCollection<ProjectItemInstance> groupFound = null;
 
             foreach (Scope scope in _lookupScopes)
             {
                 // Accumulate adds while we look downwards
                 if (scope.Adds != null)
                 {
-                    ICollection<ProjectItemInstance> adds = scope.Adds[itemType];
+                    IReadOnlyCollection<ProjectItemInstance> adds = scope.Adds[itemType];
                     if (adds.Count != 0)
                     {
                         if (allAdds == null)
@@ -495,7 +495,7 @@ namespace Microsoft.Build.BackEnd
                 // Accumulate removes while we look downwards
                 if (scope.Removes != null)
                 {
-                    ICollection<ProjectItemInstance> removes = scope.Removes[itemType];
+                    IReadOnlyCollection<ProjectItemInstance> removes = scope.Removes[itemType];
                     if (removes.Count != 0)
                     {
                         if (allRemoves == null)
@@ -607,10 +607,10 @@ namespace Microsoft.Build.BackEnd
         /// Should be used only by batching buckets, and if no items are passed,
         /// explicitly stores a marker for this item type indicating this.
         /// </summary>
-        internal void PopulateWithItems(string itemType, ICollection<ProjectItemInstance> group)
+        internal void PopulateWithItems(string itemType, IReadOnlyCollection<ProjectItemInstance> group)
         {
             PrimaryTable ??= new ItemDictionary<ProjectItemInstance>();
-            ICollection<ProjectItemInstance> existing = PrimaryTable[itemType];
+            IReadOnlyCollection<ProjectItemInstance> existing = PrimaryTable[itemType];
             ErrorUtilities.VerifyThrow(existing.Count == 0, "Cannot add an itemgroup of this type.");
 
             if (group.Count > 0)
@@ -756,7 +756,7 @@ namespace Microsoft.Build.BackEnd
         /// Modifies items in this scope with the same set of metadata modifications.
         /// Assumes all the items in the group have the same, provided, type.
         /// </summary>
-        internal void ModifyItems(string itemType, ICollection<ProjectItemInstance> group, MetadataModifications metadataChanges)
+        internal void ModifyItems(string itemType, IReadOnlyCollection<ProjectItemInstance> group, MetadataModifications metadataChanges)
         {
             // Modifying in outer scope could be easily implemented, but our code does not do it at present
             MustNotBeOuterScope();
@@ -927,7 +927,7 @@ namespace Microsoft.Build.BackEnd
         /// </summary>
         private void ApplyModificationsToTable(IItemDictionary<ProjectItemInstance> table, string itemType, ItemsMetadataUpdateDictionary modify)
         {
-            ICollection<ProjectItemInstance> existing = table[itemType];
+            IReadOnlyCollection<ProjectItemInstance> existing = table[itemType];
             if (existing != null)
             {
                 foreach (var kvPair in modify)
@@ -990,7 +990,7 @@ namespace Microsoft.Build.BackEnd
         {
             if (table?.ItemTypes.Contains(item.ItemType) == true)
             {
-                ICollection<ProjectItemInstance> tableOfItemsOfSameType = table[item.ItemType];
+                IReadOnlyCollection<ProjectItemInstance> tableOfItemsOfSameType = table[item.ItemType];
                 if (tableOfItemsOfSameType != null)
                 {
                     ErrorUtilities.VerifyThrow(!tableOfItemsOfSameType.Contains(item), "Item should not be in table");

--- a/src/Build/Collections/IItemDictionary.cs
+++ b/src/Build/Collections/IItemDictionary.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Build.Collections
         /// Use AddItem or RemoveItem to modify items in this project.
         /// Using the return value from this in a multithreaded situation is unsafe.
         /// </summary>
-        ICollection<T> this[string itemType] { get; }
+        IReadOnlyCollection<T> this[string itemType] { get; }
 
         /// <summary>
         /// Empty the collection.

--- a/src/Build/Collections/ItemDictionary.cs
+++ b/src/Build/Collections/ItemDictionary.cs
@@ -111,7 +111,7 @@ namespace Microsoft.Build.Collections
         /// Use AddItem or RemoveItem to modify items in this project.
         /// Using the return value from this in a multithreaded situation is unsafe.
         /// </summary>
-        public ICollection<T> this[string itemtype]
+        public IReadOnlyCollection<T> this[string itemtype]
         {
             get
             {
@@ -124,7 +124,7 @@ namespace Microsoft.Build.Collections
                     }
                 }
 
-                return new ReadOnlyCollection<T>(list);
+                return list;
             }
         }
 
@@ -213,11 +213,16 @@ namespace Microsoft.Build.Collections
         /// </summary>
         /// <param name="itemType">The item type to return</param>
         /// <returns>The list of matching items.</returns>
-        public ICollection<T> GetItems(string itemType)
+        public IReadOnlyCollection<T> GetItems(string itemType)
         {
-            ICollection<T> result = this[itemType];
+            IReadOnlyCollection<T> result = this[itemType];
 
             return result ?? Array.Empty<T>();
+        }
+
+        IReadOnlyCollection<T> IItemProvider<T>.GetItems(string itemType)
+        {
+            return this[itemType];
         }
 
         #endregion

--- a/src/Build/Definition/Project.cs
+++ b/src/Build/Definition/Project.cs
@@ -3111,7 +3111,8 @@ namespace Microsoft.Build.Evaluation
             /// </comments>
             public override ICollection<ProjectItem> GetItems(string itemType)
             {
-                ICollection<ProjectItem> items = _data.GetItems(itemType);
+                ICollection<ProjectItem> items = new ReadOnlyCollection<ProjectItem>(_data.GetItems(itemType));
+                
                 return items;
             }
 
@@ -3125,7 +3126,7 @@ namespace Microsoft.Build.Evaluation
             /// </comments>
             public override ICollection<ProjectItem> GetItemsIgnoringCondition(string itemType)
             {
-                ICollection<ProjectItem> items = _data.ItemsIgnoringCondition[itemType];
+                ICollection<ProjectItem> items = new ReadOnlyCollection<ProjectItem>(_data.ItemsIgnoringCondition[itemType]);
                 return items;
             }
 
@@ -4551,7 +4552,7 @@ namespace Microsoft.Build.Evaluation
             /// </comments>
             /// <param name="itemType">The type of items to return.</param>
             /// <returns>A list of matching items.</returns>
-            public ICollection<ProjectItem> GetItems(string itemType)
+            public IReadOnlyCollection<ProjectItem> GetItems(string itemType)
             {
                 return Items[itemType];
             }

--- a/src/Build/Evaluation/IItemProvider.cs
+++ b/src/Build/Evaluation/IItemProvider.cs
@@ -20,6 +20,6 @@ namespace Microsoft.Build.Evaluation
         /// </summary>
         /// <param name="itemType">The item type of items to return.</param>
         /// <returns>A list of matching items.</returns>
-        ICollection<T> GetItems(string itemType);
+        IReadOnlyCollection<T> GetItems(string itemType);
     }
 }

--- a/src/Build/Evaluation/LazyItemEvaluator.EvaluatorData.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.EvaluatorData.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Build.Evaluation
                 }
             }
 
-            public ICollection<I> GetItems(string itemType)
+            public IReadOnlyCollection<I> GetItems(string itemType)
             {
                 return _itemsByType.TryGetValue(itemType, out LazyItemList items)
                     ? items.GetMatchedItems(globsToIgnore: ImmutableHashSet<string>.Empty)

--- a/src/Build/Evaluation/PropertyTrackingEvaluatorDataWrapper.cs
+++ b/src/Build/Evaluation/PropertyTrackingEvaluatorDataWrapper.cs
@@ -134,7 +134,7 @@ namespace Microsoft.Build.Evaluation
         #endregion
 
         #region IEvaluatorData<> members that are forwarded directly to wrapped object.
-        public ICollection<I> GetItems(string itemType) => _wrapped.GetItems(itemType);
+        public IReadOnlyCollection<I> GetItems(string itemType) => _wrapped.GetItems(itemType);
         public int EvaluationId { get => _wrapped.EvaluationId; set => _wrapped.EvaluationId = value; }
         public string Directory => _wrapped.Directory;
         public TaskRegistry TaskRegistry { get => _wrapped.TaskRegistry; set => _wrapped.TaskRegistry = value; }

--- a/src/Build/Instance/ImmutableProjectCollections/ImmutableItemDictionary.cs
+++ b/src/Build/Instance/ImmutableProjectCollections/ImmutableItemDictionary.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Build.Instance
         }
 
         /// <inheritdoc />
-        public ICollection<T> this[string itemType]
+        public IReadOnlyCollection<T> this[string itemType]
         {
             get
             {
@@ -86,7 +86,7 @@ namespace Microsoft.Build.Instance
                 return false;
             }
 
-            ICollection<T> items = GetItems(itemType);
+            IReadOnlyCollection<T> items = GetItems(itemType);
             return items.Contains(projectItem);
         }
 
@@ -145,7 +145,7 @@ namespace Microsoft.Build.Instance
         }
 
         /// <inheritdoc />
-        public ICollection<T> GetItems(string itemType)
+        public IReadOnlyCollection<T> GetItems(string itemType)
         {
             if (_itemsByType.TryGetValue(itemType, out ICollection<TCached>? items))
             {
@@ -173,7 +173,7 @@ namespace Microsoft.Build.Instance
         /// <inheritdoc />
         public void Replace(T existingItem, T newItem) => throw new NotSupportedException();
 
-        private sealed class ListConverter : ICollection<T>
+        private sealed class ListConverter : IReadOnlyCollection<T>
         {
             private readonly ICollection<TCached> _list;
             private readonly Func<TCached, T?> _getInstance;

--- a/src/Build/Instance/ProjectInstance.cs
+++ b/src/Build/Instance/ProjectInstance.cs
@@ -1673,7 +1673,7 @@ namespace Microsoft.Build.Execution
         /// <comments>
         /// Already a readonly collection
         /// </comments>
-        ICollection<ProjectItemInstance> IItemProvider<ProjectItemInstance>.GetItems(string itemType)
+        IReadOnlyCollection<ProjectItemInstance> IItemProvider<ProjectItemInstance>.GetItems(string itemType)
         {
             return _items[itemType];
         }
@@ -1987,7 +1987,7 @@ namespace Microsoft.Build.Execution
         public ICollection<ProjectItemInstance> GetItems(string itemType)
         {
             // GetItems already returns a readonly collection
-            return ((IItemProvider<ProjectItemInstance>)this).GetItems(itemType);
+            return new ReadOnlyCollection<ProjectItemInstance>(((IItemProvider<ProjectItemInstance>)this).GetItems(itemType));
         }
 
         /// <summary>
@@ -2508,7 +2508,7 @@ namespace Microsoft.Build.Execution
 
                 foreach (string itemType in _items.ItemTypes)
                 {
-                    ICollection<ProjectItemInstance> itemList = _items[itemType];
+                    IReadOnlyCollection<ProjectItemInstance> itemList = _items[itemType];
                     int itemCount = itemList.Count;
                     translator.Translate(ref itemCount);
                     foreach (ProjectItemInstance item in itemList)


### PR DESCRIPTION
### Context
There were lots of allocations due to newing up a ReadOnlyCollection just to fufill a ICollection contract even if it was internal.
![image](https://github.com/user-attachments/assets/f7acc193-c952-4b4b-85cf-182d594365b8)


### Changes Made
* For internal usage I moved over to returning IReadOnlyCollection instead of creating a new ReadOnlyCollection that can be used with ICollection.
* For public api's that couldn't change I waited till the actual return time to create a ReadOnlyCollection

### Testing

Took traces of build before my changes and after my changes.
Before (ReadOnlyCollection 33 Megs of allocations)
![image](https://github.com/user-attachments/assets/8fe4d43d-2b45-42a7-8ea6-8a689ccb1036)

After (ReadOnlyCollection 5 Megs of allocations)
![image](https://github.com/user-attachments/assets/1244a8e4-7cae-4577-8c47-cfd1dd107726)


### Notes
