### PR TITLE
Perf: Frozen environment variable caching

### DIFF
--- a/src/Build/BackEnd/BuildManager/BuildParameters.cs
+++ b/src/Build/BackEnd/BuildManager/BuildParameters.cs
@@ -282,7 +282,7 @@ namespace Microsoft.Build.Execution
             _enableRarNode = other._enableRarNode;
             _buildProcessEnvironment = resetEnvironment
                 ? CommunicationsUtilities.GetEnvironmentVariables()
-                : other._buildProcessEnvironment ?? null;
+                : other._buildProcessEnvironment;
             _environmentProperties = other._environmentProperties != null ? new PropertyDictionary<ProjectPropertyInstance>(other._environmentProperties) : null;
             _forwardingLoggers = other._forwardingLoggers != null ? new List<ForwardingLoggerRecord>(other._forwardingLoggers) : null;
             _globalProperties = other._globalProperties != null ? new PropertyDictionary<ProjectPropertyInstance>(other._globalProperties) : null;

--- a/src/Build/BackEnd/BuildManager/BuildParameters.cs
+++ b/src/Build/BackEnd/BuildManager/BuildParameters.cs
@@ -1,9 +1,9 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections.Frozen;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Threading;
@@ -129,7 +129,7 @@ namespace Microsoft.Build.Execution
         /// <summary>
         /// The original process environment.
         /// </summary>
-        private Dictionary<string, string> _buildProcessEnvironment;
+        private FrozenDictionary<string, string> _buildProcessEnvironment;
 
         /// <summary>
         /// The environment properties for the build.
@@ -282,9 +282,7 @@ namespace Microsoft.Build.Execution
             _enableRarNode = other._enableRarNode;
             _buildProcessEnvironment = resetEnvironment
                 ? CommunicationsUtilities.GetEnvironmentVariables()
-                : other._buildProcessEnvironment != null
-                    ? new Dictionary<string, string>(other._buildProcessEnvironment)
-                    : null;
+                : other._buildProcessEnvironment ?? null;
             _environmentProperties = other._environmentProperties != null ? new PropertyDictionary<ProjectPropertyInstance>(other._environmentProperties) : null;
             _forwardingLoggers = other._forwardingLoggers != null ? new List<ForwardingLoggerRecord>(other._forwardingLoggers) : null;
             _globalProperties = other._globalProperties != null ? new PropertyDictionary<ProjectPropertyInstance>(other._globalProperties) : null;
@@ -356,8 +354,7 @@ namespace Microsoft.Build.Execution
         /// <summary>
         /// Gets the environment variables which were set when this build was created.
         /// </summary>
-        public IDictionary<string, string> BuildProcessEnvironment => new ReadOnlyDictionary<string, string>(
-            _buildProcessEnvironment ?? new Dictionary<string, string>(0));
+        public IDictionary<string, string> BuildProcessEnvironment => BuildProcessEnvironmentInternal;
 
         /// <summary>
         /// The name of the culture to use during the build.
@@ -719,6 +716,8 @@ namespace Microsoft.Build.Execution
             get => _buildId;
             set => _buildId = value;
         }
+
+        internal FrozenDictionary<string, string> BuildProcessEnvironmentInternal => _buildProcessEnvironment ?? new Dictionary<string, string>(0).ToFrozenDictionary();
 
         /// <summary>
         /// Gets or sets the environment properties.

--- a/src/Build/BackEnd/BuildManager/BuildParameters.cs
+++ b/src/Build/BackEnd/BuildManager/BuildParameters.cs
@@ -717,7 +717,7 @@ namespace Microsoft.Build.Execution
             set => _buildId = value;
         }
 
-        internal FrozenDictionary<string, string> BuildProcessEnvironmentInternal => _buildProcessEnvironment ?? new Dictionary<string, string>(0).ToFrozenDictionary();
+        internal FrozenDictionary<string, string> BuildProcessEnvironmentInternal => _buildProcessEnvironment ?? FrozenDictionary<string, string>.Empty;
 
         /// <summary>
         /// Gets or sets the environment properties.

--- a/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -1378,7 +1379,7 @@ namespace Microsoft.Build.BackEnd
             else
             {
                 // Restore the original build environment variables.
-                SetEnvironmentVariableBlock(_componentHost.BuildParameters.BuildProcessEnvironment);
+                SetEnvironmentVariableBlock(_componentHost.BuildParameters.BuildProcessEnvironmentInternal);
             }
         }
 
@@ -1401,9 +1402,9 @@ namespace Microsoft.Build.BackEnd
         /// <summary>
         /// Sets the environment block to the set of saved variables.
         /// </summary>
-        private void SetEnvironmentVariableBlock(IDictionary<string, string> savedEnvironment)
+        private void SetEnvironmentVariableBlock(FrozenDictionary<string, string> savedEnvironment)
         {
-            IDictionary<string, string> currentEnvironment = CommunicationsUtilities.GetEnvironmentVariables();
+            FrozenDictionary<string, string> currentEnvironment = CommunicationsUtilities.GetEnvironmentVariables();
             ClearVariablesNotInEnvironment(savedEnvironment, currentEnvironment);
             UpdateEnvironmentVariables(savedEnvironment, currentEnvironment);
         }
@@ -1411,7 +1412,7 @@ namespace Microsoft.Build.BackEnd
         /// <summary>
         /// Clears from the current environment any variables which do not exist in the saved environment
         /// </summary>
-        private void ClearVariablesNotInEnvironment(IDictionary<string, string> savedEnvironment, IDictionary<string, string> currentEnvironment)
+        private void ClearVariablesNotInEnvironment(FrozenDictionary<string, string> savedEnvironment, FrozenDictionary<string, string> currentEnvironment)
         {
             foreach (KeyValuePair<string, string> entry in currentEnvironment)
             {
@@ -1425,7 +1426,7 @@ namespace Microsoft.Build.BackEnd
         /// <summary>
         /// Updates the current environment with values in the saved environment which differ or are not yet set.
         /// </summary>
-        private void UpdateEnvironmentVariables(IDictionary<string, string> savedEnvironment, IDictionary<string, string> currentEnvironment)
+        private void UpdateEnvironmentVariables(FrozenDictionary<string, string> savedEnvironment, FrozenDictionary<string, string> currentEnvironment)
         {
             foreach (KeyValuePair<string, string> entry in savedEnvironment)
             {

--- a/src/Build/BackEnd/Node/InProcNode.cs
+++ b/src/Build/BackEnd/Node/InProcNode.cs
@@ -1,9 +1,9 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
+using System.Collections.Frozen;
 using System.Globalization;
 using System.Threading;
 using Microsoft.Build.BackEnd.Components.Caching;
@@ -31,7 +31,7 @@ namespace Microsoft.Build.BackEnd
         /// <summary>
         /// The environment at the time the build is started.
         /// </summary>
-        private IDictionary<string, string> _savedEnvironment;
+        private FrozenDictionary<string, string> _savedEnvironment;
 
         /// <summary>
         /// The current directory at the time the build is started.

--- a/src/Build/BackEnd/Node/OutOfProcNode.cs
+++ b/src/Build/BackEnd/Node/OutOfProcNode.cs
@@ -1,8 +1,9 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
@@ -50,7 +51,7 @@ namespace Microsoft.Build.Execution
         /// <summary>
         /// The saved environment for the process.
         /// </summary>
-        private IDictionary<string, string> _savedEnvironment;
+        private FrozenDictionary<string, string> _savedEnvironment;
 
         /// <summary>
         /// The component factories.

--- a/src/Build/BackEnd/Shared/BuildRequestConfiguration.cs
+++ b/src/Build/BackEnd/Shared/BuildRequestConfiguration.cs
@@ -1,7 +1,8 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
@@ -131,7 +132,7 @@ namespace Microsoft.Build.BackEnd
         /// <summary>
         /// Holds a snapshot of the environment at the time we blocked.
         /// </summary>
-        private Dictionary<string, string> _savedEnvironmentVariables;
+        private FrozenDictionary<string, string> _savedEnvironmentVariables;
 
         /// <summary>
         /// Holds a snapshot of the current working directory at the time we blocked.
@@ -611,7 +612,7 @@ namespace Microsoft.Build.BackEnd
         /// <summary>
         /// Holds a snapshot of the environment at the time we blocked.
         /// </summary>
-        public Dictionary<string, string> SavedEnvironmentVariables
+        public FrozenDictionary<string, string> SavedEnvironmentVariables
         {
             get => _savedEnvironmentVariables;
 

--- a/src/Build/BackEnd/Shared/IBuildResults.cs
+++ b/src/Build/BackEnd/Shared/IBuildResults.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using Microsoft.Build.Execution;
 
@@ -32,7 +33,7 @@ namespace Microsoft.Build.BackEnd
         /// <summary>
         /// Set of environment variables for the configuration this result came from
         /// </summary>
-        Dictionary<string, string> SavedEnvironmentVariables { get; set; }
+        FrozenDictionary<string, string> SavedEnvironmentVariables { get; set; }
 
         /// <summary>
         /// The current directory for the configuration this result came from

--- a/src/Framework/BinaryTranslator.cs
+++ b/src/Framework/BinaryTranslator.cs
@@ -601,7 +601,7 @@ namespace Microsoft.Build.BackEnd
             /// This overload is needed for a workaround concerning serializing BuildResult with a version.
             /// It deserializes additional entries together with the main dictionary.
             /// </remarks>
-            public void TranslateDictionary(ref Dictionary<string, string> dictionary, IEqualityComparer<string> comparer, ref Dictionary<string, string> additionalEntries, HashSet<string> additionalEntriesKeys)
+            public void TranslateDictionary(ref IDictionary<string, string> dictionary, IEqualityComparer<string> comparer, ref Dictionary<string, string> additionalEntries, HashSet<string> additionalEntriesKeys)
             {
                 if (!TranslateNullable(dictionary))
                 {
@@ -1383,7 +1383,7 @@ namespace Microsoft.Build.BackEnd
             /// This overload is needed for a workaround concerning serializing BuildResult with a version.
             /// It serializes additional entries together with the main dictionary.
             /// </remarks>
-            public void TranslateDictionary(ref Dictionary<string, string> dictionary, IEqualityComparer<string> comparer, ref Dictionary<string, string> additionalEntries, HashSet<string> additionalEntriesKeys)
+            public void TranslateDictionary(ref IDictionary<string, string> dictionary, IEqualityComparer<string> comparer, ref Dictionary<string, string> additionalEntries, HashSet<string> additionalEntriesKeys)
             {
                 // Translate whether object is null
                 if ((dictionary is null) && ((additionalEntries is null) || (additionalEntries.Count == 0)))

--- a/src/Framework/ITranslator.cs
+++ b/src/Framework/ITranslator.cs
@@ -318,7 +318,7 @@ namespace Microsoft.Build.BackEnd
         /// This overload is needed for a workaround concerning serializing BuildResult with a version.
         /// It serializes/deserializes additional entries together with the main dictionary.
         /// </remarks>
-        void TranslateDictionary(ref Dictionary<string, string> dictionary, IEqualityComparer<string> comparer, ref Dictionary<string, string> additionalEntries, HashSet<string> additionalEntriesKeys);
+        void TranslateDictionary(ref IDictionary<string, string> dictionary, IEqualityComparer<string> comparer, ref Dictionary<string, string> additionalEntries, HashSet<string> additionalEntriesKeys);
 
         void TranslateDictionary(ref IDictionary<string, string> dictionary, NodePacketCollectionCreator<IDictionary<string, string>> collectionCreator);
 

--- a/src/Shared/CommunicationsUtilities.cs
+++ b/src/Shared/CommunicationsUtilities.cs
@@ -7,9 +7,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.IO.Pipes;
-#if NETFRAMEWORK
 using System.Runtime.InteropServices;
-#endif
 #if FEATURE_SECURITY_PRINCIPAL_WINDOWS
 using System.Security.Principal;
 #endif
@@ -23,6 +21,9 @@ using System.Text;
 
 #if !CLR2COMPATIBILITY
 using Microsoft.Build.Shared.Debugging;
+using System.Collections;
+using System.Collections.Frozen;
+using Microsoft.NET.StringTools;
 #endif
 #if !FEATURE_APM
 using System.Threading.Tasks;
@@ -246,6 +247,14 @@ namespace Microsoft.Build.Internal
         /// </summary>
         private static long s_lastLoggedTicks = DateTime.UtcNow.Ticks;
 
+#if !CLR2COMPATIBILITY
+        /// <summary>
+        /// A set of environment variables cached from the last time we called GetEnvironmentVariables.
+        /// Used to avoid allocations if the environment has not changed.
+        /// </summary>
+        private static EnvironmentState s_environmentState;
+#endif
+
         /// <summary>
         /// Delegate to debug the communication utilities.
         /// </summary>
@@ -259,7 +268,6 @@ namespace Microsoft.Build.Internal
             get { return GetIntegerVariableOrDefault("MSBUILDNODECONNECTIONTIMEOUT", DefaultNodeConnectionTimeout); }
         }
 
-#if NETFRAMEWORK
         /// <summary>
         /// Get environment block.
         /// </summary>
@@ -272,6 +280,7 @@ namespace Microsoft.Build.Internal
         [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
         internal static extern unsafe bool FreeEnvironmentStrings(char* pStrings);
 
+#if NETFRAMEWORK
         /// <summary>
         /// Set environment variable P/Invoke.
         /// </summary>
@@ -293,6 +302,16 @@ namespace Microsoft.Build.Internal
                 throw Marshal.GetExceptionForHR(Marshal.GetHRForLastWin32Error());
             }
         }
+#endif
+
+#if !CLR2COMPATIBILITY
+        /// <summary>
+        /// A container to atomically swap a cached set of environment variables and the block string used to create it.
+        /// The environment block property will only be set on Windows, since on Unix we need to directly call
+        /// Environment.GetEnvironmentVariables().
+        /// </summary>
+        private sealed record class EnvironmentState(FrozenDictionary<string, string> EnvironmentVariables, string EnvironmentBlock = null);
+#endif
 
         /// <summary>
         /// Returns key value pairs of environment variables in a new dictionary
@@ -301,16 +320,17 @@ namespace Microsoft.Build.Internal
         /// <remarks>
         /// Copied from the BCL implementation to eliminate some expensive security asserts on .NET Framework.
         /// </remarks>
+#if CLR2COMPATIBILITY
         internal static Dictionary<string, string> GetEnvironmentVariables()
         {
-#if !CLR2COMPATIBILITY
+#else
+        private static FrozenDictionary<string, string> GetEnvironmentVariablesWindows()
+        {
             // The DebugUtils static constructor can set the MSBUILDDEBUGPATH environment variable to propagate the debug path to out of proc nodes.
             // Need to ensure that constructor is called before this method returns in order to capture its env var write.
             // Otherwise the env var is not captured and thus gets deleted when RequiestBuilder resets the environment based on the cached results of this method.
             ErrorUtilities.VerifyThrowInternalNull(DebugUtils.ProcessInfoString, nameof(DebugUtils.DebugPath));
 #endif
-
-            Dictionary<string, string> table = new Dictionary<string, string>(200, StringComparer.OrdinalIgnoreCase); // Razzle has 150 environment variables
 
             unsafe
             {
@@ -331,6 +351,19 @@ namespace Microsoft.Build.Internal
                         pEnvironmentBlockEnd++;
                     }
                     long stringBlockLength = pEnvironmentBlockEnd - pEnvironmentBlock;
+
+#if !CLR2COMPATIBILITY
+                    // Avoid allocating any objects if the environment still matches the last state.
+                    // We speed this up by comparing the full block instead of individual key-value pairs.
+                    ReadOnlySpan<char> stringBlock = new(pEnvironmentBlock, (int)stringBlockLength);
+                    EnvironmentState lastState = s_environmentState;
+                    if (lastState?.EnvironmentBlock.AsSpan().SequenceEqual(stringBlock) == true)
+                    {
+                        return lastState.EnvironmentVariables;
+                    }
+#endif
+
+                    Dictionary<string, string> table = new(200, StringComparer.OrdinalIgnoreCase); // Razzle has 150 environment variables
 
                     // Copy strings out, parsing into pairs and inserting into the table.
                     // The first few environment variable entries start with an '='!
@@ -373,7 +406,12 @@ namespace Microsoft.Build.Internal
                             continue;
                         }
 
+#if !CLR2COMPATIBILITY
+                        string key = Strings.WeakIntern(new ReadOnlySpan<char>(pEnvironmentBlock + startKey, i - startKey));
+#else
                         string key = new string(pEnvironmentBlock, startKey, i - startKey);
+#endif
+
                         i++;
 
                         // skip over '='
@@ -385,11 +423,25 @@ namespace Microsoft.Build.Internal
                             i++;
                         }
 
+#if !CLR2COMPATIBILITY
+                        string value = Strings.WeakIntern(new ReadOnlySpan<char>(pEnvironmentBlock + startValue, i - startValue));
+#else
                         string value = new string(pEnvironmentBlock, startValue, i - startValue);
+#endif
 
                         // skip over 0 handled by for loop's i++
                         table[key] = value;
                     }
+
+#if !CLR2COMPATIBILITY
+                    // Update with the current state.
+                    EnvironmentState currentState =
+                        new(table.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase), stringBlock.ToString());
+                    s_environmentState = currentState;
+                    return currentState.EnvironmentVariables;
+#else
+                    return table;
+#endif
                 }
                 finally
                 {
@@ -399,34 +451,78 @@ namespace Microsoft.Build.Internal
                     }
                 }
             }
-
-            return table;
         }
 
-#else // NETFRAMEWORK
-
+#if NET
         /// <summary>
         /// Sets an environment variable using <see cref="Environment.SetEnvironmentVariable(string,string)" />.
         /// </summary>
         internal static void SetEnvironmentVariable(string name, string value)
             => Environment.SetEnvironmentVariable(name, value);
+#endif
 
+#if !CLR2COMPATIBILITY
         /// <summary>
-        /// Returns key value pairs of environment variables in a new dictionary
+        /// Returns key value pairs of environment variables in a read-only dictionary
         /// with a case-insensitive key comparer.
+        ///
+        /// If the environment variables have not changed since the last time
+        /// this method was called, the same dictionary instance will be returned.
         /// </summary>
-        internal static Dictionary<string, string> GetEnvironmentVariables()
+        internal static FrozenDictionary<string, string> GetEnvironmentVariables()
         {
-            var vars = Environment.GetEnvironmentVariables();
-
-            Dictionary<string, string> table = new Dictionary<string, string>(vars.Count, StringComparer.OrdinalIgnoreCase);
-            foreach (var key in vars.Keys)
+            // Always call the native method on Windows, as we'll be able to avoid the internal
+            // string and Hashtable allocations caused by Environment.GetEnvironmentVariables().
+            if (NativeMethodsShared.IsWindows)
             {
-                table[(string)key] = (string)vars[key];
+                return GetEnvironmentVariablesWindows();
             }
-            return table;
+
+            IDictionary vars = Environment.GetEnvironmentVariables();
+
+            // Directly use the enumerator since Current will box DictionaryEntry.
+            IDictionaryEnumerator enumerator = vars.GetEnumerator();
+
+            // If every key-value pair matches the last state, return a cached dictionary.
+            FrozenDictionary<string, string> lastEnvironmentVariables = s_environmentState?.EnvironmentVariables;
+            if (vars.Count == lastEnvironmentVariables?.Count)
+            {
+                bool sameState = true;
+
+                while (enumerator.MoveNext() && sameState)
+                {
+                    DictionaryEntry entry = enumerator.Entry;
+                    if (!lastEnvironmentVariables.TryGetValue((string)entry.Key, out string value)
+                        || !string.Equals((string)entry.Value, value, StringComparison.OrdinalIgnoreCase))
+                    {
+                        sameState = false;
+                    }
+                }
+
+                if (sameState)
+                {
+                    return lastEnvironmentVariables;
+                }
+            }
+
+            // Otherwise, allocate and update with the current state.
+            Dictionary<string, string> table = new(vars.Count, StringComparer.OrdinalIgnoreCase);
+
+            enumerator.Reset();
+            while (enumerator.MoveNext())
+            {
+                DictionaryEntry entry = enumerator.Entry;
+                string key = Strings.WeakIntern((string)entry.Key);
+                string value = Strings.WeakIntern((string)entry.Value);
+                table[key] = value;
+            }
+
+            EnvironmentState newState = new(table.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase));
+            s_environmentState = newState;
+
+            return newState.EnvironmentVariables;
         }
-#endif // NETFRAMEWORK
+#endif
 
         /// <summary>
         /// Updates the environment to match the provided dictionary.
@@ -436,7 +532,7 @@ namespace Microsoft.Build.Internal
             if (newEnvironment != null)
             {
                 // First, delete all no longer set variables
-                Dictionary<string, string> currentEnvironment = GetEnvironmentVariables();
+                IDictionary<string, string> currentEnvironment = GetEnvironmentVariables();
                 foreach (KeyValuePair<string, string> entry in currentEnvironment)
                 {
                     if (!newEnvironment.ContainsKey(entry.Key))

--- a/src/Shared/CommunicationsUtilities.cs
+++ b/src/Shared/CommunicationsUtilities.cs
@@ -310,7 +310,7 @@ namespace Microsoft.Build.Internal
         /// The environment block property will only be set on Windows, since on Unix we need to directly call
         /// Environment.GetEnvironmentVariables().
         /// </summary>
-        private sealed record class EnvironmentState(FrozenDictionary<string, string> EnvironmentVariables, string EnvironmentBlock = null);
+        private sealed record class EnvironmentState(FrozenDictionary<string, string> EnvironmentVariables, ReadOnlyMemory<char> EnvironmentBlock = default);
 #endif
 
         /// <summary>
@@ -358,7 +358,7 @@ namespace Microsoft.Build.Internal
                     // We speed this up by comparing the full block instead of individual key-value pairs.
                     ReadOnlySpan<char> stringBlock = new(pEnvironmentBlock, (int)stringBlockLength);
                     EnvironmentState lastState = s_environmentState;
-                    if (lastState?.EnvironmentBlock.AsSpan().SequenceEqual(stringBlock) == true)
+                    if (lastState?.EnvironmentBlock.Span.SequenceEqual(stringBlock) == true)
                     {
                         return lastState.EnvironmentVariables;
                     }
@@ -437,7 +437,7 @@ namespace Microsoft.Build.Internal
 #if !CLR2COMPATIBILITY
                     // Update with the current state.
                     EnvironmentState currentState =
-                        new(table.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase), stringBlock.ToString());
+                        new(table.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase), stringBlock.ToArray());
                     s_environmentState = currentState;
                     return currentState.EnvironmentVariables;
 #else

--- a/src/Shared/CommunicationsUtilities.cs
+++ b/src/Shared/CommunicationsUtilities.cs
@@ -272,12 +272,14 @@ namespace Microsoft.Build.Internal
         /// Get environment block.
         /// </summary>
         [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        [System.Runtime.Versioning.SupportedOSPlatform("windows")]
         internal static extern unsafe char* GetEnvironmentStrings();
 
         /// <summary>
         /// Free environment block.
         /// </summary>
         [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        [System.Runtime.Versioning.SupportedOSPlatform("windows")]
         internal static extern unsafe bool FreeEnvironmentStrings(char* pStrings);
 
 #if NETFRAMEWORK

--- a/src/Shared/CommunicationsUtilities.cs
+++ b/src/Shared/CommunicationsUtilities.cs
@@ -324,6 +324,7 @@ namespace Microsoft.Build.Internal
         internal static Dictionary<string, string> GetEnvironmentVariables()
         {
 #else
+        [System.Runtime.Versioning.SupportedOSPlatform("windows")]
         private static FrozenDictionary<string, string> GetEnvironmentVariablesWindows()
         {
             // The DebugUtils static constructor can set the MSBUILDDEBUGPATH environment variable to propagate the debug path to out of proc nodes.

--- a/src/Shared/CommunicationsUtilities.cs
+++ b/src/Shared/CommunicationsUtilities.cs
@@ -494,7 +494,7 @@ namespace Microsoft.Build.Internal
                 {
                     DictionaryEntry entry = enumerator.Entry;
                     if (!lastEnvironmentVariables.TryGetValue((string)entry.Key, out string value)
-                        || !string.Equals((string)entry.Value, value, StringComparison.OrdinalIgnoreCase))
+                        || !string.Equals((string)entry.Value, value, StringComparison.Ordinal))
                     {
                         sameState = false;
                     }

--- a/src/Shared/TranslatorHelpers.cs
+++ b/src/Shared/TranslatorHelpers.cs
@@ -2,6 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+#if !TASKHOST
+using System.Collections.Frozen;
+#endif
 using System.Collections.Generic;
 using System.Configuration.Assemblies;
 using System.Globalization;
@@ -171,6 +174,22 @@ namespace Microsoft.Build.BackEnd
         {
             translator.TranslateDictionary(ref dictionary, AdaptFactory(valueFactory), collectionCreator);
         }
+
+#if !TASKHOST
+        public static void TranslateDictionary(
+            this ITranslator translator,
+            ref FrozenDictionary<string, string> dictionary,
+            IEqualityComparer<string> comparer)
+        {
+            IDictionary<string, string> localDict = dictionary;
+            translator.TranslateDictionary(ref localDict, capacity => new Dictionary<string, string>(capacity, comparer));
+
+            if (translator.Mode == TranslationDirection.ReadFromStream)
+            {
+                dictionary = localDict?.ToFrozenDictionary(comparer);
+            }
+        }
+#endif
 
         public static void TranslateHashSet<T>(
             this ITranslator translator,


### PR DESCRIPTION
### Fixes

CPU + allocations + memory usage by repeated construction of environment variables by returning a cached `FrozenDictionary` instance when no changes exist.

These are also currently held onto by `ConfigCache -> BuildRequestConfiguration`, so these will actually stay in the working set for the entire build if not de-duped.

*Before:*

![image](https://github.com/user-attachments/assets/97746318-bd80-4ec7-8690-c691fcef6bf1)

![image](https://github.com/user-attachments/assets/737248f0-ae89-4873-86bc-53c2765c7e7e)

*After:*

![image](https://github.com/user-attachments/assets/c5ab9a01-b8d9-4e95-b792-a5cc60b498d1)

![image](https://github.com/user-attachments/assets/416015cf-3922-43ad-8d64-ab7e47586010)



### Context

On .NET Core, `Environment.GetEnvironmentVariables()` internally creates a new Hashtable instance and string allocations for each key-value pair. Since the rest of MSBuild expects a typed `Dictionary<string, string>` instance, we need to allocate yet another dictionary and copy all the results.

```cs
IDictionary vars = Environment.GetEnvironmentVariables();
Dictionary<string, string> table = new Dictionary<string, string>(vars.Count, StringComparer.OrdinalIgnoreCase);
foreach (var key in vars.Keys)
{
    // copy
}
```

On .NET Framework, we use the native Win32 APIs so we directly parse into a `Dictionary` instance, but we still end up allocating a new instance on every call and a bunch of additional strings.

```cs
Dictionary<string, string> table = new(200, StringComparer.OrdinalIgnoreCase);
for (int i = 0; i < stringBlockLength; i++)
{
    string key = new string(pEnvironmentBlock, startKey, i - startKey);
    string value = new string(pEnvironmentBlock, startValue, i - startValue);
}
```

The environment set only changes a handful of times throughout a build, so in reality we're just creating the same set over and over again.

Given that these are then handed to long lived objects, we also just end up with a ton of duplicated strings in memory. Here's a time slice of `OrchardCode` taken at the same point of the build graph, where ~100k strings less are being held on to in memory after this:

![image](https://github.com/user-attachments/assets/18622d92-6288-49af-8344-feb6ef1c7877)

![image](https://github.com/user-attachments/assets/c06783cf-9b61-4f6a-bf0a-92b35cefbf47))

### Changes Made

This introduces a container for caching the previous environment state. If we read the environment variables and the count, keys, and values are an exact match, we skip the allocation altogether and return a `FrozenDictionary` instance.

```cs
private static EnvironmentState s_environmentState;

private sealed record class EnvironmentState(FrozenDictionary<string, string> EnvironmentVariables, string EnvironmentBlock = null);
```

This also changes .NET Core on Windows to use the native codepath. In this case, we can use the entire environment block string as our cache comparison, and utilize `StringTools` to avoid unnecessary extra string allocations if we need to build a new set.

```cs
ReadOnlySpan<char> stringBlock = new(pEnvironmentBlock, (int)stringBlockLength);
EnvironmentState lastState = s_environmentState;
if (lastState?.EnvironmentBlock.AsSpan().SequenceEqual(stringBlock) == true)
{
    return lastState.EnvironmentVariables;
}
```

```cs
string key = Strings.WeakIntern(new ReadOnlySpan<char>(pEnvironmentBlock + startKey, i - startKey));
string value = Strings.WeakIntern(new ReadOnlySpan<char>(pEnvironmentBlock + startValue, i - startValue));
```

On Unix, we still need to call `Environment.GetEnvironmentVariables()`, but we can still avoid the extra dictionary allocation and duplicated memory by doing a set comparison.

The `TaskHost` path is ifdef-ed to behave as before, due to the absence of `System.Collections.Frozen`.

### Notes

My one main concern was whether the dictionary is exposed in some public API that expects a mutable dictionary. As far as I can tell, that isn't the case since the only place we expose it (in `BuildParameters.BuildProcessEnvironment`) already returns a `ReadOnlyDictionary`, and the rest of our uses are internal and already don't mutate