### PR TITLE
Add environment variable support to SDK resolvers

### DIFF
--- a/src/Build.UnitTests/BackEnd/SdkResolverService_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/SdkResolverService_Tests.cs
@@ -1007,7 +1007,6 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
             }
         }
 
-
         private sealed class MockSdkResolverThrows : SdkResolver
         {
             public override string Name => nameof(MockSdkResolverThrows);

--- a/src/Build.UnitTests/BackEnd/SdkResolverService_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/SdkResolverService_Tests.cs
@@ -723,6 +723,37 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
             isRunningInVisualStudio.ShouldBeTrue();
         }
 
+        [Fact]
+        public void AssertResolversCanReturnEnvVariables()
+        {
+            var service = new CachingSdkResolverService();
+
+            service.InitializeForTests(
+                resolvers: new List<SdkResolver>
+                {
+                    new SdkUtilities.ConfigurableMockSdkResolver((sdkReference, resolverContext, factory) =>
+                    {
+                        // Simulate returning environment variables
+                        return factory.IndicateSuccess("envresolver", "1.0.0", null, null, environmentVariablesToAdd: new Dictionary<string, string>
+                        {
+                            { "EnvVar1", "Value1" }
+                        });
+                    })
+                });
+            var result = service.ResolveSdk(
+                BuildEventContext.InvalidSubmissionId,
+                new SdkReference("envresolver", "1.0.0", null),
+                _loggingContext,
+                new MockElementLocation("file"),
+                "sln",
+                "projectPath",
+                interactive: false,
+                isRunningInVisualStudio: false,
+                failOnUnresolvedSdk: true);
+
+            result.EnvironmentVariablesToAdd.Count.ShouldBe(1);
+        }
+
         internal sealed class SdkResolverServiceTextExtension : SdkResolverService
         {
 
@@ -770,7 +801,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
             public bool ResolversHaveBeenLoaded { get; private set; } = false;
             public bool ManifestsHaveBeenLoaded { get; private set; } = false;
 
-            public MockLoaderStrategy(bool includeErrorResolver = false, bool includeResolversWithPatterns = false, bool includeDefaultResolver = false , bool includeSingleResolverOnly = false) : this()
+            public MockLoaderStrategy(bool includeErrorResolver = false, bool includeResolversWithPatterns = false, bool includeDefaultResolver = false, bool includeSingleResolverOnly = false) : this()
             {
                 if (includeSingleResolverOnly)
                 {
@@ -975,6 +1006,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
                 return factory.IndicateSuccess("resolverpath", "1.0");
             }
         }
+
 
         private sealed class MockSdkResolverThrows : SdkResolver
         {

--- a/src/Build.UnitTests/Evaluation/SdkResultEvaluation_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/SdkResultEvaluation_Tests.cs
@@ -535,8 +535,8 @@ namespace Microsoft.Build.UnitTests.Evaluation
             _logger.AssertNoErrors();
             _logger.AssertNoWarnings();
 
-            instance.GetItems("ThingsAsEnvironment").ShouldHaveSingleItem().EvaluatedInclude.ShouldBe("TestEnvVarValue");
             instance.GetItems("ThingsAsProperty").ShouldHaveSingleItem().EvaluatedInclude.ShouldBe("TestEnvVarValue");
+            instance.GetItems("ThingsAsEnvironment").ShouldHaveSingleItem($"Should have a ThingsAsEnvironment. Log: {_logger.FullLog}").EvaluatedInclude.ShouldBe("TestEnvVarValue");
         }
         public void Dispose()
         {

--- a/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
@@ -1404,6 +1404,14 @@ namespace Microsoft.Build.BackEnd
         private void SetEnvironmentVariableBlock(IDictionary<string, string> savedEnvironment)
         {
             IDictionary<string, string> currentEnvironment = CommunicationsUtilities.GetEnvironmentVariables();
+            var sdkResolvedVars = (_requestEntry.RequestConfiguration.Project as IEvaluatorData<ProjectPropertyInstance, ProjectItemInstance, ProjectMetadataInstance, ProjectItemDefinitionInstance>).SdkResolvedEnvironmentVariablePropertiesDictionary;
+            if (sdkResolvedVars is var dict)
+            {
+                foreach (var entry in dict)
+                {
+                    currentEnvironment.Add(entry.Name, entry.EvaluatedValue);
+                }
+            }
             ClearVariablesNotInEnvironment(savedEnvironment, currentEnvironment);
             UpdateEnvironmentVariables(savedEnvironment, currentEnvironment);
         }

--- a/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
@@ -1124,16 +1124,17 @@ namespace Microsoft.Build.BackEnd
                 }
 
                 // Set SDK-resolved environment variables if they haven't been set yet for this configuration
-                if (!_requestEntry.RequestConfiguration.SdkResolvedEnvironmentVariablesSet && _requestEntry.RequestConfiguration.Project != null)
+                if (!_requestEntry.RequestConfiguration.SdkResolvedEnvironmentVariablesSet &&
+                     _requestEntry.RequestConfiguration.Project is IEvaluatorData<ProjectPropertyInstance, ProjectItemInstance, ProjectMetadataInstance, ProjectItemDefinitionInstance> project)
                 {
-                    if (((IEvaluatorData<ProjectPropertyInstance, ProjectItemInstance, ProjectMetadataInstance, ProjectItemDefinitionInstance>)_requestEntry.RequestConfiguration.Project)
-                        .SdkResolvedEnvironmentVariablePropertiesDictionary is PropertyDictionary<ProjectPropertyInstance> environmentProperties)
+                    if (project.SdkResolvedEnvironmentVariablePropertiesDictionary is PropertyDictionary<ProjectPropertyInstance> environmentProperties)
                     {
-                        foreach (var propertyInstance in environmentProperties)
+                        foreach (ProjectPropertyInstance environmentProperty in environmentProperties)
                         {
-                            Environment.SetEnvironmentVariable(propertyInstance.Name, propertyInstance.EvaluatedValue, EnvironmentVariableTarget.Process);
+                            Environment.SetEnvironmentVariable(environmentProperty.Name, environmentProperty.EvaluatedValue, EnvironmentVariableTarget.Process);
                         }
                     }
+
                     _requestEntry.RequestConfiguration.SdkResolvedEnvironmentVariablesSet = true;
                 }
             }

--- a/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
@@ -1121,7 +1121,11 @@ namespace Microsoft.Build.BackEnd
                         RequestEntry.Request.BuildRequestDataFlags,
                         RequestEntry.Request.SubmissionId,
                         _nodeLoggingContext.BuildEventContext.NodeId);
+                }
 
+                // Set SDK-resolved environment variables if they haven't been set yet for this configuration
+                if (!_requestEntry.RequestConfiguration.SdkResolvedEnvironmentVariablesSet && _requestEntry.RequestConfiguration.Project != null)
+                {
                     if (((IEvaluatorData<ProjectPropertyInstance, ProjectItemInstance, ProjectMetadataInstance, ProjectItemDefinitionInstance>)_requestEntry.RequestConfiguration.Project)
                         .SdkResolvedEnvironmentVariablePropertiesDictionary is PropertyDictionary<ProjectPropertyInstance> environmentProperties)
                     {
@@ -1130,6 +1134,7 @@ namespace Microsoft.Build.BackEnd
                             Environment.SetEnvironmentVariable(propertyInstance.Name, propertyInstance.EvaluatedValue, EnvironmentVariableTarget.Process);
                         }
                     }
+                    _requestEntry.RequestConfiguration.SdkResolvedEnvironmentVariablesSet = true;
                 }
             }
             catch

--- a/src/Build/BackEnd/Components/SdkResolution/SdkResult.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/SdkResult.cs
@@ -13,7 +13,7 @@ using SdkResultBase = Microsoft.Build.Framework.SdkResult;
 namespace Microsoft.Build.BackEnd.SdkResolution
 {
     /// <summary>
-    /// An internal implementation of <see cref="Microsoft.Build.Framework.SdkResult"/>.
+    /// An internal implementation of <see cref="Framework.SdkResult"/>.
     /// </summary>
     internal sealed class SdkResult : SdkResultBase, INodePacket
     {
@@ -31,7 +31,7 @@ namespace Microsoft.Build.BackEnd.SdkResolution
         }
 
         public SdkResult(SdkReference sdkReference, string path, string version, IEnumerable<string> warnings,
-            IDictionary<string, string> propertiesToAdd = null, IDictionary<string, SdkResultItem> itemsToAdd = null)
+            IDictionary<string, string> propertiesToAdd = null, IDictionary<string, SdkResultItem> itemsToAdd = null, IDictionary<string, string> environmentVariablesToAdd = null)
         {
             Success = true;
             SdkReference = sdkReference;
@@ -40,6 +40,7 @@ namespace Microsoft.Build.BackEnd.SdkResolution
             Warnings = warnings;
             PropertiesToAdd = propertiesToAdd;
             ItemsToAdd = itemsToAdd;
+            EnvironmentVariablesToAdd = environmentVariablesToAdd;
         }
 
         public SdkResult()
@@ -47,7 +48,7 @@ namespace Microsoft.Build.BackEnd.SdkResolution
         }
 
         public SdkResult(SdkReference sdkReference, IEnumerable<string> paths, string version, IDictionary<string, string> propertiesToAdd,
-                         IDictionary<string, SdkResultItem> itemsToAdd, IEnumerable<string> warnings)
+                         IDictionary<string, SdkResultItem> itemsToAdd, IEnumerable<string> warnings, IDictionary<string, string> environmentVariablesToAdd = null)
         {
             Success = true;
             SdkReference = sdkReference;
@@ -69,6 +70,7 @@ namespace Microsoft.Build.BackEnd.SdkResolution
             // Note: these dictionaries should use StringComparison.OrdinalIgnoreCase
             PropertiesToAdd = propertiesToAdd;
             ItemsToAdd = itemsToAdd;
+            EnvironmentVariablesToAdd = environmentVariablesToAdd;
 
             Warnings = warnings;
         }

--- a/src/Build/BackEnd/Components/SdkResolution/SdkResultFactory.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/SdkResultFactory.cs
@@ -12,7 +12,7 @@ using SdkResultFactoryBase = Microsoft.Build.Framework.SdkResultFactory;
 namespace Microsoft.Build.BackEnd.SdkResolution
 {
     /// <summary>
-    /// An internal implementation of <see cref="Microsoft.Build.Framework.SdkResultFactory"/>.
+    /// An internal implementation of <see cref="Framework.SdkResultFactory"/>.
     /// </summary>
     internal class SdkResultFactory : SdkResultFactoryBase
     {
@@ -49,6 +49,26 @@ namespace Microsoft.Build.BackEnd.SdkResolution
                                                       IEnumerable<string> warnings = null)
         {
             return new SdkResult(_sdkReference, paths, version, propertiesToAdd, itemsToAdd, warnings);
+        }
+
+        public override SdkResultBase IndicateSuccess(string path,
+                                                      string version,
+                                                      IDictionary<string, string> propertiesToAdd,
+                                                      IDictionary<string, SdkResultItem> itemsToAdd,
+                                                      IEnumerable<string> warnings = null,
+                                                      IDictionary<string, string> environmentVariablesToAdd = null)
+        {
+            return new SdkResult(_sdkReference, path, version, warnings, propertiesToAdd, itemsToAdd, environmentVariablesToAdd);
+        }
+
+        public override SdkResultBase IndicateSuccess(IEnumerable<string> paths,
+                                                      string version,
+                                                      IDictionary<string, string> propertiesToAdd = null,
+                                                      IDictionary<string, SdkResultItem> itemsToAdd = null,
+                                                      IEnumerable<string> warnings = null,
+                                                      IDictionary<string, string> environmentVariablesToAdd = null)
+        {
+            return new SdkResult(_sdkReference, paths, version, propertiesToAdd, itemsToAdd, warnings, environmentVariablesToAdd);
         }
     }
 }

--- a/src/Build/BackEnd/Shared/BuildRequestConfiguration.cs
+++ b/src/Build/BackEnd/Shared/BuildRequestConfiguration.cs
@@ -330,6 +330,11 @@ namespace Microsoft.Build.BackEnd
         }
 
         /// <summary>
+        /// Flag indicating whether SDK-resolved environment variables have been set for this configuration.
+        /// </summary>
+        internal bool SdkResolvedEnvironmentVariablesSet { get; set; }
+
+        /// <summary>
         /// Returns true if this configuration was generated on a node and has not yet been resolved.
         /// </summary>
         public bool WasGeneratedByNode => _configId < InvalidConfigurationId;

--- a/src/Build/Definition/Project.cs
+++ b/src/Build/Definition/Project.cs
@@ -4265,6 +4265,9 @@ namespace Microsoft.Build.Evaluation
             /// </summary>
             internal MultiDictionary<string, ProjectItem> ItemsByEvaluatedIncludeCache { get; private set; }
 
+
+            public PropertyDictionary<ProjectPropertyInstance> ResolvedEnvironmentVariablesDictionary { get; private set; }
+
             /// <summary>
             /// Prepares the data object for evaluation.
             /// </summary>
@@ -4285,6 +4288,7 @@ namespace Microsoft.Build.Evaluation
                 AllEvaluatedItemDefinitionMetadata = new List<ProjectMetadata>();
                 AllEvaluatedItems = new List<ProjectItem>();
                 EvaluatedItemElements = new List<ProjectItemElement>();
+                ResolvedEnvironmentVariablesDictionary = new PropertyDictionary<ProjectPropertyInstance>();
                 EvaluationId = BuildEventContext.InvalidEvaluationId;
 
                 _globalPropertiesToTreatAsLocal?.Clear();
@@ -4498,6 +4502,13 @@ namespace Microsoft.Build.Evaluation
             public void RecordImport(ProjectImportElement importElement, ProjectRootElement import, int versionEvaluated, SdkResult sdkResult)
             {
                 ImportClosure.Add(new ResolvedImport(Project, importElement, import, versionEvaluated, sdkResult));
+                if (sdkResult.EnvironmentVariablesToAdd is var sdkEnvironmentVariablesToAdd && sdkEnvironmentVariablesToAdd.Count > 0)
+                {
+                    foreach (var environmentVariable in sdkEnvironmentVariablesToAdd)
+                    {
+                        ResolvedEnvironmentVariablesDictionary.Set(new SdkResolvedEnvironmentVariablePropertyInstance(environmentVariable.Key, environmentVariable.Value));
+                    }
+                }
                 RecordImportWithDuplicates(importElement, import, versionEvaluated);
             }
 

--- a/src/Build/Definition/Project.cs
+++ b/src/Build/Definition/Project.cs
@@ -4266,7 +4266,7 @@ namespace Microsoft.Build.Evaluation
             internal MultiDictionary<string, ProjectItem> ItemsByEvaluatedIncludeCache { get; private set; }
 
 
-            public PropertyDictionary<ProjectPropertyInstance> ResolvedEnvironmentVariablesDictionary { get; private set; }
+            public PropertyDictionary<ProjectPropertyInstance> SdkResolvedEnvironmentVariablePropertiesDictionary { get; private set; }
 
             /// <summary>
             /// Prepares the data object for evaluation.
@@ -4288,7 +4288,7 @@ namespace Microsoft.Build.Evaluation
                 AllEvaluatedItemDefinitionMetadata = new List<ProjectMetadata>();
                 AllEvaluatedItems = new List<ProjectItem>();
                 EvaluatedItemElements = new List<ProjectItemElement>();
-                ResolvedEnvironmentVariablesDictionary = new PropertyDictionary<ProjectPropertyInstance>();
+                SdkResolvedEnvironmentVariablePropertiesDictionary = new PropertyDictionary<ProjectPropertyInstance>();
                 EvaluationId = BuildEventContext.InvalidEvaluationId;
 
                 _globalPropertiesToTreatAsLocal?.Clear();
@@ -4506,7 +4506,7 @@ namespace Microsoft.Build.Evaluation
                 {
                     foreach (var environmentVariable in sdkEnvironmentVariablesToAdd)
                     {
-                        ResolvedEnvironmentVariablesDictionary.Set(new SdkResolvedEnvironmentVariablePropertyInstance(environmentVariable.Key, environmentVariable.Value));
+                        SdkResolvedEnvironmentVariablePropertiesDictionary.Set(new ProjectPropertyInstance.SdkResolvedEnvironmentVariablePropertyInstance(environmentVariable.Key, environmentVariable.Value));
                     }
                 }
                 RecordImportWithDuplicates(importElement, import, versionEvaluated);

--- a/src/Build/Definition/Project.cs
+++ b/src/Build/Definition/Project.cs
@@ -4445,6 +4445,14 @@ namespace Microsoft.Build.Evaluation
                 return itemDefinition;
             }
 
+            public void AddProjectSpecificEnvironmentVariable(string name, string value)
+            {
+                SdkResolvedEnvironmentVariablePropertiesDictionary ??= new();
+                SdkResolvedEnvironmentVariablePropertiesDictionary.Set(new ProjectPropertyInstance.SdkResolvedEnvironmentVariablePropertyInstance(name, value));
+
+                throw new NotImplementedException();
+            }
+
             /// <summary>
             /// Sets a property which is not derived from Xml.
             /// </summary>

--- a/src/Build/Definition/Project.cs
+++ b/src/Build/Definition/Project.cs
@@ -4446,10 +4446,10 @@ namespace Microsoft.Build.Evaluation
             }
 
             /// <summary>
-            ///
+            /// Add an environment variable (and property) based on the result of an SDK resolver.
             /// </summary>
-            /// <param name="name"></param>
-            /// <param name="value"></param>
+            /// <param name="name">Environment variable name.</param>
+            /// <param name="value">Environment variable value.</param>
             public void AddSdkResolvedEnvironmentVariable(string name, string value)
             {
                 // If the property has already been set as an environment variable or by another SDK, we do not overwrite it.

--- a/src/Build/Definition/Project.cs
+++ b/src/Build/Definition/Project.cs
@@ -4445,12 +4445,26 @@ namespace Microsoft.Build.Evaluation
                 return itemDefinition;
             }
 
+            /// <summary>
+            ///
+            /// </summary>
+            /// <param name="name"></param>
+            /// <param name="value"></param>
             public void AddProjectSpecificEnvironmentVariable(string name, string value)
             {
-                SdkResolvedEnvironmentVariablePropertiesDictionary ??= new();
-                SdkResolvedEnvironmentVariablePropertiesDictionary.Set(new ProjectPropertyInstance.SdkResolvedEnvironmentVariablePropertyInstance(name, value));
+                // If the property has already been set as an environment variable or by another SDK, we do not overwrite it.
+                if (EnvironmentVariablePropertiesDictionary?.Contains(name) == true
+                    || SdkResolvedEnvironmentVariablePropertiesDictionary?.Contains(name) == true)
+                {
+                    return;
+                }
 
-                throw new NotImplementedException();
+                ProjectPropertyInstance.SdkResolvedEnvironmentVariablePropertyInstance property = new(name, value);
+
+                SdkResolvedEnvironmentVariablePropertiesDictionary ??= new();
+                SdkResolvedEnvironmentVariablePropertiesDictionary.Set(property);
+
+                SetProperty(name, value, isGlobalProperty: false, mayBeReserved: false, loggingContext: null);
             }
 
             /// <summary>

--- a/src/Build/Definition/Project.cs
+++ b/src/Build/Definition/Project.cs
@@ -4502,13 +4502,6 @@ namespace Microsoft.Build.Evaluation
             public void RecordImport(ProjectImportElement importElement, ProjectRootElement import, int versionEvaluated, SdkResult sdkResult)
             {
                 ImportClosure.Add(new ResolvedImport(Project, importElement, import, versionEvaluated, sdkResult));
-                if (sdkResult?.EnvironmentVariablesToAdd is IDictionary<string, string> sdkEnvironmentVariablesToAdd && sdkEnvironmentVariablesToAdd.Count > 0)
-                {
-                    foreach (var environmentVariable in sdkEnvironmentVariablesToAdd)
-                    {
-                        SdkResolvedEnvironmentVariablePropertiesDictionary.Set(new ProjectPropertyInstance.SdkResolvedEnvironmentVariablePropertyInstance(environmentVariable.Key, environmentVariable.Value));
-                    }
-                }
                 RecordImportWithDuplicates(importElement, import, versionEvaluated);
             }
 

--- a/src/Build/Definition/Project.cs
+++ b/src/Build/Definition/Project.cs
@@ -4450,7 +4450,7 @@ namespace Microsoft.Build.Evaluation
             /// </summary>
             /// <param name="name"></param>
             /// <param name="value"></param>
-            public void AddProjectSpecificEnvironmentVariable(string name, string value)
+            public void AddSdkResolvedEnvironmentVariable(string name, string value)
             {
                 // If the property has already been set as an environment variable or by another SDK, we do not overwrite it.
                 if (EnvironmentVariablePropertiesDictionary?.Contains(name) == true

--- a/src/Build/Definition/Project.cs
+++ b/src/Build/Definition/Project.cs
@@ -4502,7 +4502,7 @@ namespace Microsoft.Build.Evaluation
             public void RecordImport(ProjectImportElement importElement, ProjectRootElement import, int versionEvaluated, SdkResult sdkResult)
             {
                 ImportClosure.Add(new ResolvedImport(Project, importElement, import, versionEvaluated, sdkResult));
-                if (sdkResult.EnvironmentVariablesToAdd is var sdkEnvironmentVariablesToAdd && sdkEnvironmentVariablesToAdd.Count > 0)
+                if (sdkResult?.EnvironmentVariablesToAdd is IDictionary<string, string> sdkEnvironmentVariablesToAdd && sdkEnvironmentVariablesToAdd.Count > 0)
                 {
                     foreach (var environmentVariable in sdkEnvironmentVariablesToAdd)
                     {

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -1883,7 +1883,7 @@ namespace Microsoft.Build.Evaluation
                 {
                     foreach (var environmentVariable in sdkEnvironmentVariablesToAdd)
                     {
-                        _data.AddProjectSpecificEnvironmentVariable(environmentVariable.Key, environmentVariable.Value);
+                        _data.AddSdkResolvedEnvironmentVariable(environmentVariable.Key, environmentVariable.Value);
                     }
                 }
 

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -1898,33 +1898,35 @@ namespace Microsoft.Build.Evaluation
 
         private void SetSdkResolvedEnvironmentVariable(string name, string value)
         {
-            // If the property has already been set as an environment variable, we do not overwrite it.
-            if (_data.EnvironmentVariablePropertiesDictionary.Contains(name))
-            {
-                // TODO: Log a warning that the environment variable is already set?
-                // _evaluationLoggingContext.LogWarning("SdkEnvironmentVariableAlreadySet", name, value);
-                return;
-            }
-            // If another SDK already set it, we do not overwrite it.
-            else if (_data.SdkResolvedEnvironmentVariablePropertiesDictionary.Contains(name))
-            {
-                // TODO: Log a warning that the environment variable is already set?
-                // _evaluationLoggingContext.LogWarning("SdkEnvironmentVariableAlreadySet", name, value);
-                return;
-            }
+            _data.AddProjectSpecificEnvironmentVariable(name, value);
 
-            SdkResolvedEnvironmentVariablePropertyInstance property = new(name, value);
+            // // If the property has already been set as an environment variable, we do not overwrite it.
+            // if (_data.EnvironmentVariablePropertiesDictionary.Contains(name))
+            // {
+            //     // TODO: Log a warning that the environment variable is already set?
+            //     // _evaluationLoggingContext.LogWarning("SdkEnvironmentVariableAlreadySet", name, value);
+            //     return;
+            // }
+            // // If another SDK already set it, we do not overwrite it.
+            // else if (_data.SdkResolvedEnvironmentVariablePropertiesDictionary.Contains(name))
+            // {
+            //     // TODO: Log a warning that the environment variable is already set?
+            //     // _evaluationLoggingContext.LogWarning("SdkEnvironmentVariableAlreadySet", name, value);
+            //     return;
+            // }
 
-            _data.SdkResolvedEnvironmentVariablePropertiesDictionary.Set(property);
+            // SdkResolvedEnvironmentVariablePropertyInstance property = new(name, value);
 
-            // Also set the property in the EnvironmentVariablePropertiesDictionary so that it can be used in regular evaluation
-            _data.EnvironmentVariablePropertiesDictionary.Set(property);
+            // _data.SdkResolvedEnvironmentVariablePropertiesDictionary.Set(property);
 
-            // Only set the local property if it does not already exist, prioritizing regular properties defined in XML.
-            if (_data.GetProperty(name) is null)
-            {
-                _data.SetProperty(name, value, isGlobalProperty: false, mayBeReserved: false, loggingContext: _evaluationLoggingContext, isEnvironmentVariable: true);
-            }
+            // // Also set the property in the EnvironmentVariablePropertiesDictionary so that it can be used in regular evaluation
+            // _data.EnvironmentVariablePropertiesDictionary.Set(property);
+
+            // // Only set the local property if it does not already exist, prioritizing regular properties defined in XML.
+            // if (_data.GetProperty(name) is null)
+            // {
+            //     _data.SetProperty(name, value, isGlobalProperty: false, mayBeReserved: false, loggingContext: _evaluationLoggingContext, isEnvironmentVariable: true);
+            // }
         }
 
         // Creates a project to set the properties and include the items from an SdkResult

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -1883,7 +1883,7 @@ namespace Microsoft.Build.Evaluation
                 {
                     foreach (var environmentVariable in sdkEnvironmentVariablesToAdd)
                     {
-                        SetSdkResolvedEnvironmentVariable(environmentVariable.Key, environmentVariable.Value);
+                        _data.AddProjectSpecificEnvironmentVariable(environmentVariable.Key, environmentVariable.Value);
                     }
                 }
 
@@ -1894,39 +1894,6 @@ namespace Microsoft.Build.Evaluation
                 ExpandAndLoadImportsFromUnescapedImportExpression(directoryOfImportingFile, importElement, project,
                     throwOnFileNotExistsError: true, out projects);
             }
-        }
-
-        private void SetSdkResolvedEnvironmentVariable(string name, string value)
-        {
-            _data.AddProjectSpecificEnvironmentVariable(name, value);
-
-            // // If the property has already been set as an environment variable, we do not overwrite it.
-            // if (_data.EnvironmentVariablePropertiesDictionary.Contains(name))
-            // {
-            //     // TODO: Log a warning that the environment variable is already set?
-            //     // _evaluationLoggingContext.LogWarning("SdkEnvironmentVariableAlreadySet", name, value);
-            //     return;
-            // }
-            // // If another SDK already set it, we do not overwrite it.
-            // else if (_data.SdkResolvedEnvironmentVariablePropertiesDictionary.Contains(name))
-            // {
-            //     // TODO: Log a warning that the environment variable is already set?
-            //     // _evaluationLoggingContext.LogWarning("SdkEnvironmentVariableAlreadySet", name, value);
-            //     return;
-            // }
-
-            // SdkResolvedEnvironmentVariablePropertyInstance property = new(name, value);
-
-            // _data.SdkResolvedEnvironmentVariablePropertiesDictionary.Set(property);
-
-            // // Also set the property in the EnvironmentVariablePropertiesDictionary so that it can be used in regular evaluation
-            // _data.EnvironmentVariablePropertiesDictionary.Set(property);
-
-            // // Only set the local property if it does not already exist, prioritizing regular properties defined in XML.
-            // if (_data.GetProperty(name) is null)
-            // {
-            //     _data.SetProperty(name, value, isGlobalProperty: false, mayBeReserved: false, loggingContext: _evaluationLoggingContext, isEnvironmentVariable: true);
-            // }
         }
 
         // Creates a project to set the properties and include the items from an SdkResult

--- a/src/Build/Evaluation/IEvaluatorData.cs
+++ b/src/Build/Evaluation/IEvaluatorData.cs
@@ -215,7 +215,7 @@ namespace Microsoft.Build.Evaluation
         /// </summary>
         PropertyDictionary<ProjectPropertyInstance> SdkResolvedEnvironmentVariablePropertiesDictionary { get; }
 
-        void AddProjectSpecificEnvironmentVariable(string name, string value);
+        void AddSdkResolvedEnvironmentVariable(string name, string value);
 
         /// <summary>
         /// Prepares the data block for a new evaluation pass

--- a/src/Build/Evaluation/IEvaluatorData.cs
+++ b/src/Build/Evaluation/IEvaluatorData.cs
@@ -211,6 +211,11 @@ namespace Microsoft.Build.Evaluation
         PropertyDictionary<ProjectPropertyInstance> EnvironmentVariablePropertiesDictionary { get; }
 
         /// <summary>
+        /// A dictionary of all discovered environment variables during Sdk Resolutions that occurred during evaluation.
+        /// </summary>
+        PropertyDictionary<ProjectPropertyInstance> ResolvedEnvironmentVariablesDictionary { get; }
+
+        /// <summary>
         /// Prepares the data block for a new evaluation pass
         /// </summary>
         void InitializeForEvaluation(IToolsetProvider toolsetProvider, EvaluationContext evaluationContext, LoggingContext loggingContext);

--- a/src/Build/Evaluation/IEvaluatorData.cs
+++ b/src/Build/Evaluation/IEvaluatorData.cs
@@ -213,7 +213,7 @@ namespace Microsoft.Build.Evaluation
         /// <summary>
         /// A dictionary of all discovered environment variables during Sdk Resolutions that occurred during evaluation.
         /// </summary>
-        PropertyDictionary<ProjectPropertyInstance> ResolvedEnvironmentVariablesDictionary { get; }
+        PropertyDictionary<ProjectPropertyInstance> SdkResolvedEnvironmentVariablePropertiesDictionary { get; }
 
         /// <summary>
         /// Prepares the data block for a new evaluation pass

--- a/src/Build/Evaluation/IEvaluatorData.cs
+++ b/src/Build/Evaluation/IEvaluatorData.cs
@@ -215,6 +215,8 @@ namespace Microsoft.Build.Evaluation
         /// </summary>
         PropertyDictionary<ProjectPropertyInstance> SdkResolvedEnvironmentVariablePropertiesDictionary { get; }
 
+        void AddProjectSpecificEnvironmentVariable(string name, string value);
+
         /// <summary>
         /// Prepares the data block for a new evaluation pass
         /// </summary>

--- a/src/Build/Evaluation/IEvaluatorData.cs
+++ b/src/Build/Evaluation/IEvaluatorData.cs
@@ -215,6 +215,11 @@ namespace Microsoft.Build.Evaluation
         /// </summary>
         PropertyDictionary<ProjectPropertyInstance> SdkResolvedEnvironmentVariablePropertiesDictionary { get; }
 
+        /// <summary>
+        /// Add an environment variable (and property) based on the result of an SDK resolver.
+        /// </summary>
+        /// <param name="name">Environment variable name.</param>
+        /// <param name="value">Environment variable value.</param>
         void AddSdkResolvedEnvironmentVariable(string name, string value);
 
         /// <summary>

--- a/src/Build/Evaluation/LazyItemEvaluator.EvaluatorData.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.EvaluatorData.cs
@@ -30,21 +30,9 @@ namespace Microsoft.Build.Evaluation
                 _itemsByType = itemsByType;
             }
 
-            public IItemDictionary<I> Items
-            {
-                get
-                {
-                    throw new NotImplementedException();
-                }
-            }
+            public IItemDictionary<I> Items => throw new NotImplementedException();
 
-            public List<ProjectItemElement> EvaluatedItemElements
-            {
-                get
-                {
-                    throw new NotImplementedException();
-                }
-            }
+            public List<ProjectItemElement> EvaluatedItemElements => throw new NotImplementedException();
 
             public ICollection<I> GetItems(string itemType)
             {
@@ -79,13 +67,7 @@ namespace Microsoft.Build.Evaluation
                 }
             }
 
-            public Dictionary<string, List<string>> ConditionedProperties
-            {
-                get
-                {
-                    return _wrappedData.ConditionedProperties;
-                }
-            }
+            public Dictionary<string, List<string>> ConditionedProperties => _wrappedData.ConditionedProperties;
 
             public List<string> DefaultTargets
             {
@@ -106,45 +88,15 @@ namespace Microsoft.Build.Evaluation
                 set { _wrappedData.EvaluationId = value; }
             }
 
-            public string Directory
-            {
-                get
-                {
-                    return _wrappedData.Directory;
-                }
-            }
+            public string Directory => _wrappedData.Directory;
 
-            public string ExplicitToolsVersion
-            {
-                get
-                {
-                    return _wrappedData.ExplicitToolsVersion;
-                }
-            }
+            public string ExplicitToolsVersion => _wrappedData.ExplicitToolsVersion;
 
-            public PropertyDictionary<ProjectPropertyInstance> GlobalPropertiesDictionary
-            {
-                get
-                {
-                    return _wrappedData.GlobalPropertiesDictionary;
-                }
-            }
+            public PropertyDictionary<ProjectPropertyInstance> GlobalPropertiesDictionary => _wrappedData.GlobalPropertiesDictionary;
 
-            public PropertyDictionary<ProjectPropertyInstance> EnvironmentVariablePropertiesDictionary
-            {
-                get
-                {
-                    return _wrappedData.EnvironmentVariablePropertiesDictionary;
-                }
-            }
+            public PropertyDictionary<ProjectPropertyInstance> EnvironmentVariablePropertiesDictionary => _wrappedData.EnvironmentVariablePropertiesDictionary;
 
-            public ISet<string> GlobalPropertiesToTreatAsLocal
-            {
-                get
-                {
-                    return _wrappedData.GlobalPropertiesToTreatAsLocal;
-                }
-            }
+            public ISet<string> GlobalPropertiesToTreatAsLocal => _wrappedData.GlobalPropertiesToTreatAsLocal;
 
             public List<string> InitialTargets
             {
@@ -159,46 +111,16 @@ namespace Microsoft.Build.Evaluation
                 }
             }
 
-            public IEnumerable<D> ItemDefinitionsEnumerable
-            {
-                get
-                {
-                    return _wrappedData.ItemDefinitionsEnumerable;
-                }
-            }
+            public IEnumerable<D> ItemDefinitionsEnumerable => _wrappedData.ItemDefinitionsEnumerable;
 
 
-            public bool CanEvaluateElementsWithFalseConditions
-            {
-                get
-                {
-                    return _wrappedData.CanEvaluateElementsWithFalseConditions;
-                }
-            }
+            public bool CanEvaluateElementsWithFalseConditions => _wrappedData.CanEvaluateElementsWithFalseConditions;
 
-            public PropertyDictionary<P> Properties
-            {
-                get
-                {
-                    return _wrappedData.Properties;
-                }
-            }
+            public PropertyDictionary<P> Properties => _wrappedData.Properties;
 
-            public bool ShouldEvaluateForDesignTime
-            {
-                get
-                {
-                    return _wrappedData.ShouldEvaluateForDesignTime;
-                }
-            }
+            public bool ShouldEvaluateForDesignTime => _wrappedData.ShouldEvaluateForDesignTime;
 
-            public string SubToolsetVersion
-            {
-                get
-                {
-                    return _wrappedData.SubToolsetVersion;
-                }
-            }
+            public string SubToolsetVersion => _wrappedData.SubToolsetVersion;
 
             public TaskRegistry TaskRegistry
             {
@@ -213,13 +135,9 @@ namespace Microsoft.Build.Evaluation
                 }
             }
 
-            public Toolset Toolset
-            {
-                get
-                {
-                    return _wrappedData.Toolset;
-                }
-            }
+            public Toolset Toolset => _wrappedData.Toolset;
+
+            public PropertyDictionary<ProjectPropertyInstance> SdkResolvedEnvironmentVariablePropertiesDictionary => _wrappedData.SdkResolvedEnvironmentVariablePropertiesDictionary;
 
             public void AddItem(I item)
             {

--- a/src/Build/Evaluation/LazyItemEvaluator.EvaluatorData.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.EvaluatorData.cs
@@ -139,6 +139,8 @@ namespace Microsoft.Build.Evaluation
 
             public PropertyDictionary<ProjectPropertyInstance> SdkResolvedEnvironmentVariablePropertiesDictionary => _wrappedData.SdkResolvedEnvironmentVariablePropertiesDictionary;
 
+            public void AddProjectSpecificEnvironmentVariable(string name, string value) => throw new NotSupportedException();
+
             public void AddItem(I item)
             {
                 throw new NotSupportedException();

--- a/src/Build/Evaluation/LazyItemEvaluator.EvaluatorData.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.EvaluatorData.cs
@@ -139,7 +139,7 @@ namespace Microsoft.Build.Evaluation
 
             public PropertyDictionary<ProjectPropertyInstance> SdkResolvedEnvironmentVariablePropertiesDictionary => _wrappedData.SdkResolvedEnvironmentVariablePropertiesDictionary;
 
-            public void AddProjectSpecificEnvironmentVariable(string name, string value) => throw new NotSupportedException();
+            public void AddSdkResolvedEnvironmentVariable(string name, string value) => throw new NotSupportedException();
 
             public void AddItem(I item)
             {

--- a/src/Build/Evaluation/PropertyTrackingEvaluatorDataWrapper.cs
+++ b/src/Build/Evaluation/PropertyTrackingEvaluatorDataWrapper.cs
@@ -157,14 +157,14 @@ namespace Microsoft.Build.Evaluation
         public PropertyDictionary<ProjectPropertyInstance> EnvironmentVariablePropertiesDictionary => _wrapped.EnvironmentVariablePropertiesDictionary;
         public PropertyDictionary<ProjectPropertyInstance> SdkResolvedEnvironmentVariablePropertiesDictionary => _wrapped.SdkResolvedEnvironmentVariablePropertiesDictionary;
 
-        public void AddProjectSpecificEnvironmentVariable(string name, string value)
+        public void AddSdkResolvedEnvironmentVariable(string name, string value)
         {
             if (_wrapped.EnvironmentVariablePropertiesDictionary.Contains(name))
             {
                 TrackEnvironmentVariableRead(name);
             }
 
-            _wrapped.AddProjectSpecificEnvironmentVariable(name, value);
+            _wrapped.AddSdkResolvedEnvironmentVariable(name, value);
         }
 
         public void InitializeForEvaluation(IToolsetProvider toolsetProvider, EvaluationContext evaluationContext, LoggingContext loggingContext) => _wrapped.InitializeForEvaluation(toolsetProvider, evaluationContext, loggingContext);

--- a/src/Build/Evaluation/PropertyTrackingEvaluatorDataWrapper.cs
+++ b/src/Build/Evaluation/PropertyTrackingEvaluatorDataWrapper.cs
@@ -159,8 +159,12 @@ namespace Microsoft.Build.Evaluation
 
         public void AddProjectSpecificEnvironmentVariable(string name, string value)
         {
+            if (_wrapped.EnvironmentVariablePropertiesDictionary.Contains(name))
+            {
+                TrackEnvironmentVariableRead(name);
+            }
+
             _wrapped.AddProjectSpecificEnvironmentVariable(name, value);
-            throw new NotImplementedException();
         }
 
         public void InitializeForEvaluation(IToolsetProvider toolsetProvider, EvaluationContext evaluationContext, LoggingContext loggingContext) => _wrapped.InitializeForEvaluation(toolsetProvider, evaluationContext, loggingContext);

--- a/src/Build/Evaluation/PropertyTrackingEvaluatorDataWrapper.cs
+++ b/src/Build/Evaluation/PropertyTrackingEvaluatorDataWrapper.cs
@@ -156,6 +156,13 @@ namespace Microsoft.Build.Evaluation
         public List<ProjectItemElement> EvaluatedItemElements => _wrapped.EvaluatedItemElements;
         public PropertyDictionary<ProjectPropertyInstance> EnvironmentVariablePropertiesDictionary => _wrapped.EnvironmentVariablePropertiesDictionary;
         public PropertyDictionary<ProjectPropertyInstance> SdkResolvedEnvironmentVariablePropertiesDictionary => _wrapped.SdkResolvedEnvironmentVariablePropertiesDictionary;
+
+        public void AddProjectSpecificEnvironmentVariable(string name, string value)
+        {
+            _wrapped.AddProjectSpecificEnvironmentVariable(name, value);
+            throw new NotImplementedException();
+        }
+
         public void InitializeForEvaluation(IToolsetProvider toolsetProvider, EvaluationContext evaluationContext, LoggingContext loggingContext) => _wrapped.InitializeForEvaluation(toolsetProvider, evaluationContext, loggingContext);
         public void FinishEvaluation() => _wrapped.FinishEvaluation();
         public void AddItem(I item) => _wrapped.AddItem(item);

--- a/src/Build/Evaluation/PropertyTrackingEvaluatorDataWrapper.cs
+++ b/src/Build/Evaluation/PropertyTrackingEvaluatorDataWrapper.cs
@@ -155,6 +155,7 @@ namespace Microsoft.Build.Evaluation
         public IItemDictionary<I> Items => _wrapped.Items;
         public List<ProjectItemElement> EvaluatedItemElements => _wrapped.EvaluatedItemElements;
         public PropertyDictionary<ProjectPropertyInstance> EnvironmentVariablePropertiesDictionary => _wrapped.EnvironmentVariablePropertiesDictionary;
+        public PropertyDictionary<ProjectPropertyInstance> SdkResolvedEnvironmentVariablePropertiesDictionary => _wrapped.SdkResolvedEnvironmentVariablePropertiesDictionary;
         public void InitializeForEvaluation(IToolsetProvider toolsetProvider, EvaluationContext evaluationContext, LoggingContext loggingContext) => _wrapped.InitializeForEvaluation(toolsetProvider, evaluationContext, loggingContext);
         public void FinishEvaluation() => _wrapped.FinishEvaluation();
         public void AddItem(I item) => _wrapped.AddItem(item);
@@ -459,7 +460,8 @@ namespace Microsoft.Build.Evaluation
                         location.File,
                         location.Line,
                         location.Column,
-                        message: null) { BuildEventContext = loggingContext.BuildEventContext };
+                        message: null)
+                    { BuildEventContext = loggingContext.BuildEventContext };
 
                     loggingContext.LogBuildEvent(args);
                 }
@@ -478,7 +480,8 @@ namespace Microsoft.Build.Evaluation
                             location.File,
                             location.Line,
                             location.Column,
-                            message: null) { BuildEventContext = loggingContext.BuildEventContext, };
+                            message: null)
+                        { BuildEventContext = loggingContext.BuildEventContext, };
 
                         loggingContext.LogBuildEvent(args);
                     }

--- a/src/Build/Instance/ProjectInstance.cs
+++ b/src/Build/Instance/ProjectInstance.cs
@@ -1386,14 +1386,12 @@ namespace Microsoft.Build.Execution
             // If the property has already been set as an environment variable, we do not overwrite it.
             if (_environmentVariableProperties.Contains(name))
             {
-                // TODO: Log a warning that the environment variable is already set?
                 _loggingContext.LogWarning("SdkEnvironmentVariableAlreadySet", name, value);
                 return;
             }
             // If another SDK already set it, we do not overwrite it.
             else if (_sdkResolvedEnvironmentVariableProperties?.Contains(name) == true)
             {
-                // TODO: Log a warning that the environment variable is already set?
                 _loggingContext.LogWarning("SdkEnvironmentVariableAlreadySet", name, value);
                 return;
             }

--- a/src/Build/Instance/ProjectInstance.cs
+++ b/src/Build/Instance/ProjectInstance.cs
@@ -754,12 +754,14 @@ namespace Microsoft.Build.Execution
                     _environmentVariableProperties.Set(environmentProperty.DeepClone(_isImmutable));
                 }
 
-                _sdkResolvedEnvironmentVariableProperties =
-                    new PropertyDictionary<ProjectPropertyInstance>(that._sdkResolvedEnvironmentVariableProperties.Count);
-
-                foreach (ProjectPropertyInstance sdkResolvedEnvironmentVariable in that._sdkResolvedEnvironmentVariableProperties)
+                if (that._sdkResolvedEnvironmentVariableProperties is PropertyDictionary<ProjectPropertyInstance> thatEnvProps)
                 {
-                    _sdkResolvedEnvironmentVariableProperties.Set(sdkResolvedEnvironmentVariable.DeepClone(_isImmutable));
+                    _sdkResolvedEnvironmentVariableProperties = new(thatEnvProps.Count);
+
+                    foreach (ProjectPropertyInstance sdkResolvedEnvironmentVariable in thatEnvProps)
+                    {
+                        _sdkResolvedEnvironmentVariableProperties.Set(sdkResolvedEnvironmentVariable.DeepClone(_isImmutable));
+                    }
                 }
 
                 this.DefaultTargets = new List<string>(that.DefaultTargets);

--- a/src/Build/Instance/ProjectInstance.cs
+++ b/src/Build/Instance/ProjectInstance.cs
@@ -823,7 +823,7 @@ namespace Microsoft.Build.Execution
                         {
                             _environmentVariableProperties.Set(environmentProperty.DeepClone(isImmutable: true));
                         }
-                        var sdkResolvedEnvironmentProperty = that._sdkResolvedEnvironmentVariableProperties.GetProperty(desiredProperty);
+                        var sdkResolvedEnvironmentProperty = that._sdkResolvedEnvironmentVariableProperties?.GetProperty(desiredProperty);
                         if (sdkResolvedEnvironmentProperty != null)
                         {
                             _sdkResolvedEnvironmentVariableProperties.Set(sdkResolvedEnvironmentProperty.DeepClone(isImmutable: true));

--- a/src/Build/Instance/ProjectInstance.cs
+++ b/src/Build/Instance/ProjectInstance.cs
@@ -2351,6 +2351,7 @@ namespace Microsoft.Build.Execution
                     if (!_globalProperties.Contains(property.Name) || !String.Equals(_globalProperties[property.Name].EvaluatedValue, property.EvaluatedValue, StringComparison.OrdinalIgnoreCase))
                     {
                         if ((!_environmentVariableProperties.Contains(property.Name) || !String.Equals(_environmentVariableProperties[property.Name].EvaluatedValue, property.EvaluatedValue, StringComparison.OrdinalIgnoreCase))
+                            && _sdkResolvedEnvironmentVariableProperties is not null
                             && (!_sdkResolvedEnvironmentVariableProperties.Contains(property.Name) || !String.Equals(_sdkResolvedEnvironmentVariableProperties[property.Name].EvaluatedValue, property.EvaluatedValue, StringComparison.OrdinalIgnoreCase)))
                         {
                             property.ToProjectPropertyElement(propertyGroupElement);

--- a/src/Build/Instance/ProjectInstance.cs
+++ b/src/Build/Instance/ProjectInstance.cs
@@ -1381,6 +1381,8 @@ namespace Microsoft.Build.Execution
             get => _sdkResolvedEnvironmentVariableProperties;
         }
 
+        public void AddProjectSpecificEnvironmentVariable(string name, string value) => throw new NotSupportedException();
+
         /// <summary>
         /// List of names of the properties that, while global, are still treated as overridable
         /// </summary>

--- a/src/Build/Instance/ProjectInstance.cs
+++ b/src/Build/Instance/ProjectInstance.cs
@@ -667,6 +667,7 @@ namespace Microsoft.Build.Execution
             this.CreateEvaluatedIncludeSnapshotIfRequested(keepEvaluationCache, new ReadOnlyCollection<ProjectItem>(data.Items), projectItemToInstanceMap);
             this.CreateGlobalPropertiesSnapshot(data.GlobalPropertiesDictionary);
             this.CreateEnvironmentVariablePropertiesSnapshot(environmentVariableProperties);
+            this.CreateSdkResolvedEnvironmentVariablePropertiesSnapshot(data.SdkResolvedEnvironmentVariablePropertiesDictionary);
             this.CreateTargetsSnapshot(data.Targets, data.DefaultTargets, data.InitialTargets, data.BeforeTargets, data.AfterTargets);
             this.CreateImportsSnapshot(data.ImportClosure, data.ImportClosureWithDuplicates);
 
@@ -685,6 +686,16 @@ namespace Microsoft.Build.Execution
             _explicitToolsVersionSpecified = data.ExplicitToolsVersion != null;
 
             _isImmutable = immutable;
+        }
+
+        private void CreateSdkResolvedEnvironmentVariablePropertiesSnapshot(PropertyDictionary<ProjectPropertyInstance> sdkResolvedEnvironmentVariablePropertiesDictionary)
+        {
+            _sdkResolvedEnvironmentVariableProperties = new PropertyDictionary<ProjectPropertyInstance>(sdkResolvedEnvironmentVariablePropertiesDictionary.Count);
+
+            foreach (ProjectPropertyInstance environmentProperty in sdkResolvedEnvironmentVariablePropertiesDictionary)
+            {
+                _sdkResolvedEnvironmentVariableProperties.Set(environmentProperty.DeepClone());
+            }
         }
 
         /// <summary>
@@ -1869,7 +1880,7 @@ namespace Microsoft.Build.Execution
             SdkResult sdkResult)
         {
             _importPaths.Add(import.FullPath);
-            if (sdkResult.EnvironmentVariablesToAdd is var sdkEnvironmentVariablesToAdd && sdkEnvironmentVariablesToAdd.Count > 0)
+            if (sdkResult?.EnvironmentVariablesToAdd is IDictionary<string, string> sdkEnvironmentVariablesToAdd && sdkEnvironmentVariablesToAdd.Count > 0)
             {
                 foreach (var environmentVariable in sdkEnvironmentVariablesToAdd)
                 {

--- a/src/Build/Instance/ProjectInstance.cs
+++ b/src/Build/Instance/ProjectInstance.cs
@@ -1386,13 +1386,13 @@ namespace Microsoft.Build.Execution
             // If the property has already been set as an environment variable, we do not overwrite it.
             if (_environmentVariableProperties.Contains(name))
             {
-                _loggingContext.LogWarning("SdkEnvironmentVariableAlreadySet", name, value);
+                _loggingContext.LogComment(MessageImportance.Low, "SdkEnvironmentVariableAlreadySet", name, value);
                 return;
             }
             // If another SDK already set it, we do not overwrite it.
             else if (_sdkResolvedEnvironmentVariableProperties?.Contains(name) == true)
             {
-                _loggingContext.LogWarning("SdkEnvironmentVariableAlreadySet", name, value);
+                _loggingContext.LogComment(MessageImportance.Low, "SdkEnvironmentVariableAlreadySetBySdk", name, value);
                 return;
             }
 
@@ -1411,6 +1411,8 @@ namespace Microsoft.Build.Execution
                 ((IEvaluatorData<ProjectPropertyInstance, ProjectItemInstance, ProjectMetadataInstance, ProjectItemDefinitionInstance>)this)
                    .SetProperty(name, value, isGlobalProperty: false, mayBeReserved: false, loggingContext: _loggingContext, isEnvironmentVariable: true, isCommandLineProperty: false);
             }
+
+            _loggingContext.LogComment(MessageImportance.Low, "SdkEnvironmentVariableSet", name, value);
         }
 
         /// <summary>

--- a/src/Build/Instance/ProjectInstance.cs
+++ b/src/Build/Instance/ProjectInstance.cs
@@ -1381,7 +1381,7 @@ namespace Microsoft.Build.Execution
             get => _sdkResolvedEnvironmentVariableProperties;
         }
 
-        public void AddProjectSpecificEnvironmentVariable(string name, string value)
+        public void AddSdkResolvedEnvironmentVariable(string name, string value)
         {
             // If the property has already been set as an environment variable, we do not overwrite it.
             if (_environmentVariableProperties.Contains(name))

--- a/src/Build/Instance/ProjectPropertyInstance.cs
+++ b/src/Build/Instance/ProjectPropertyInstance.cs
@@ -389,5 +389,18 @@ namespace Microsoft.Build.Execution
 
             internal LoggingContext loggingContext;
         }
+
+
+        internal class SdkResolvedEnvironmentVariablePropertyInstance(string name, string escapedValue) : ProjectPropertyInstance(name, escapedValue)
+        {
+            /// <summary>
+            /// Whether this object can be changed. An immutable object cannot be made mutable.
+            /// </summary>
+            /// <remarks>
+            /// The environment is captured at the start of the build, so environment-derived
+            /// properties can't change.
+            /// </remarks>
+            public override bool IsImmutable => true;
+        }
     }
 }

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -1383,6 +1383,15 @@ Errors: {3}</value>
     <value>MSB4238: The name "{0}" is not a valid SDK name.</value>
     <comment>{StrBegin="MSB4238: "}</comment>
   </data>
+  <data name="SdkEnvironmentVariableAlreadySet" xml:space="preserve">
+    <value>An SDK attempted to set the environment variable "{0}" to "{1}" but it was already set as an environment variable.</value>
+  </data>
+  <data name="SdkEnvironmentVariableAlreadySetBySdk" xml:space="preserve">
+    <value>An SDK attempted to set the environment variable "{0}" to "{1}" but it was already set by another SDK.</value>
+  </data>
+  <data name="SdkEnvironmentVariableSet" xml:space="preserve">
+    <value>An SDK attempted set the environment variable "{0}" to "{1}".</value>
+  </data>
   <data name="UnrecognizedParentElement" xml:space="preserve">
     <value>MSB4189: &lt;{1}&gt; is not a valid child of the &lt;{0}&gt; element.</value>
     <comment>{StrBegin="MSB4189: "}</comment>

--- a/src/Build/Resources/xlf/Strings.cs.xlf
+++ b/src/Build/Resources/xlf/Strings.cs.xlf
@@ -860,6 +860,21 @@ Chyby: {3}</target>
         <target state="translated">Překladač sady SDK „{0}“ vrátil hodnotu null.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SdkEnvironmentVariableAlreadySet">
+        <source>An SDK attempted to set the environment variable "{0}" to "{1}" but it was already set as an environment variable.</source>
+        <target state="new">An SDK attempted to set the environment variable "{0}" to "{1}" but it was already set as an environment variable.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkEnvironmentVariableAlreadySetBySdk">
+        <source>An SDK attempted to set the environment variable "{0}" to "{1}" but it was already set by another SDK.</source>
+        <target state="new">An SDK attempted to set the environment variable "{0}" to "{1}" but it was already set by another SDK.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkEnvironmentVariableSet">
+        <source>An SDK attempted set the environment variable "{0}" to "{1}".</source>
+        <target state="new">An SDK attempted set the environment variable "{0}" to "{1}".</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SingleResolverFailedToResolveSDK">
         <source>SDK '{0}' could not be resolved by the SDK resolver '{1}'. {2}</source>
         <target state="translated">Sadu SDK {0} se nepodařilo vyřešit pomocí překladače sady SDK {1}. {2}</target>

--- a/src/Build/Resources/xlf/Strings.de.xlf
+++ b/src/Build/Resources/xlf/Strings.de.xlf
@@ -860,6 +860,21 @@ Fehler: {3}</target>
         <target state="translated">Der SDK-Resolver "{0}" hat NULL zurückgegeben.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SdkEnvironmentVariableAlreadySet">
+        <source>An SDK attempted to set the environment variable "{0}" to "{1}" but it was already set as an environment variable.</source>
+        <target state="new">An SDK attempted to set the environment variable "{0}" to "{1}" but it was already set as an environment variable.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkEnvironmentVariableAlreadySetBySdk">
+        <source>An SDK attempted to set the environment variable "{0}" to "{1}" but it was already set by another SDK.</source>
+        <target state="new">An SDK attempted to set the environment variable "{0}" to "{1}" but it was already set by another SDK.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkEnvironmentVariableSet">
+        <source>An SDK attempted set the environment variable "{0}" to "{1}".</source>
+        <target state="new">An SDK attempted set the environment variable "{0}" to "{1}".</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SingleResolverFailedToResolveSDK">
         <source>SDK '{0}' could not be resolved by the SDK resolver '{1}'. {2}</source>
         <target state="translated">SDK „{0}“ konnte vom SDK-Resolver „{1}“ nicht aufgelöst werden. {2}</target>

--- a/src/Build/Resources/xlf/Strings.es.xlf
+++ b/src/Build/Resources/xlf/Strings.es.xlf
@@ -860,6 +860,21 @@ Errores: {3}</target>
         <target state="translated">La resolución del SDK "{0}" devolvió null.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SdkEnvironmentVariableAlreadySet">
+        <source>An SDK attempted to set the environment variable "{0}" to "{1}" but it was already set as an environment variable.</source>
+        <target state="new">An SDK attempted to set the environment variable "{0}" to "{1}" but it was already set as an environment variable.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkEnvironmentVariableAlreadySetBySdk">
+        <source>An SDK attempted to set the environment variable "{0}" to "{1}" but it was already set by another SDK.</source>
+        <target state="new">An SDK attempted to set the environment variable "{0}" to "{1}" but it was already set by another SDK.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkEnvironmentVariableSet">
+        <source>An SDK attempted set the environment variable "{0}" to "{1}".</source>
+        <target state="new">An SDK attempted set the environment variable "{0}" to "{1}".</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SingleResolverFailedToResolveSDK">
         <source>SDK '{0}' could not be resolved by the SDK resolver '{1}'. {2}</source>
         <target state="translated">El SDK '{0}' no se pudo resolver mediante la resolución de SDK '{1}'. {2}</target>

--- a/src/Build/Resources/xlf/Strings.fr.xlf
+++ b/src/Build/Resources/xlf/Strings.fr.xlf
@@ -860,6 +860,21 @@ Erreurs : {3}</target>
         <target state="translated">Le programme de résolution du Kit de développement logiciel (SDK) «{0}» a retourné null.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SdkEnvironmentVariableAlreadySet">
+        <source>An SDK attempted to set the environment variable "{0}" to "{1}" but it was already set as an environment variable.</source>
+        <target state="new">An SDK attempted to set the environment variable "{0}" to "{1}" but it was already set as an environment variable.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkEnvironmentVariableAlreadySetBySdk">
+        <source>An SDK attempted to set the environment variable "{0}" to "{1}" but it was already set by another SDK.</source>
+        <target state="new">An SDK attempted to set the environment variable "{0}" to "{1}" but it was already set by another SDK.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkEnvironmentVariableSet">
+        <source>An SDK attempted set the environment variable "{0}" to "{1}".</source>
+        <target state="new">An SDK attempted set the environment variable "{0}" to "{1}".</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SingleResolverFailedToResolveSDK">
         <source>SDK '{0}' could not be resolved by the SDK resolver '{1}'. {2}</source>
         <target state="translated">Le Kit de développement logiciel (SDK) « {0} » n’a pas pu être résolu par le résolveur de SDK « {1} ». {2}</target>

--- a/src/Build/Resources/xlf/Strings.it.xlf
+++ b/src/Build/Resources/xlf/Strings.it.xlf
@@ -860,6 +860,21 @@ Errori: {3}</target>
         <target state="translated">Il resolver SDK "{0}" ha restituito null.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SdkEnvironmentVariableAlreadySet">
+        <source>An SDK attempted to set the environment variable "{0}" to "{1}" but it was already set as an environment variable.</source>
+        <target state="new">An SDK attempted to set the environment variable "{0}" to "{1}" but it was already set as an environment variable.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkEnvironmentVariableAlreadySetBySdk">
+        <source>An SDK attempted to set the environment variable "{0}" to "{1}" but it was already set by another SDK.</source>
+        <target state="new">An SDK attempted to set the environment variable "{0}" to "{1}" but it was already set by another SDK.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkEnvironmentVariableSet">
+        <source>An SDK attempted set the environment variable "{0}" to "{1}".</source>
+        <target state="new">An SDK attempted set the environment variable "{0}" to "{1}".</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SingleResolverFailedToResolveSDK">
         <source>SDK '{0}' could not be resolved by the SDK resolver '{1}'. {2}</source>
         <target state="translated">Il resolver SDK '{0}' non è riuscito a risolvere l'SDK '{1}'. {2}</target>

--- a/src/Build/Resources/xlf/Strings.ja.xlf
+++ b/src/Build/Resources/xlf/Strings.ja.xlf
@@ -860,6 +860,21 @@ Errors: {3}</source>
         <target state="translated">SDK リゾルバー "{0}" が null を返しました。</target>
         <note />
       </trans-unit>
+      <trans-unit id="SdkEnvironmentVariableAlreadySet">
+        <source>An SDK attempted to set the environment variable "{0}" to "{1}" but it was already set as an environment variable.</source>
+        <target state="new">An SDK attempted to set the environment variable "{0}" to "{1}" but it was already set as an environment variable.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkEnvironmentVariableAlreadySetBySdk">
+        <source>An SDK attempted to set the environment variable "{0}" to "{1}" but it was already set by another SDK.</source>
+        <target state="new">An SDK attempted to set the environment variable "{0}" to "{1}" but it was already set by another SDK.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkEnvironmentVariableSet">
+        <source>An SDK attempted set the environment variable "{0}" to "{1}".</source>
+        <target state="new">An SDK attempted set the environment variable "{0}" to "{1}".</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SingleResolverFailedToResolveSDK">
         <source>SDK '{0}' could not be resolved by the SDK resolver '{1}'. {2}</source>
         <target state="translated">SDK '{0}' を SDK リゾルバー '{1}' で解決できませんでした。{2}</target>

--- a/src/Build/Resources/xlf/Strings.ko.xlf
+++ b/src/Build/Resources/xlf/Strings.ko.xlf
@@ -860,6 +860,21 @@ Errors: {3}</source>
         <target state="translated">SDK 확인자 "{0}"이(가) null을 반환했습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SdkEnvironmentVariableAlreadySet">
+        <source>An SDK attempted to set the environment variable "{0}" to "{1}" but it was already set as an environment variable.</source>
+        <target state="new">An SDK attempted to set the environment variable "{0}" to "{1}" but it was already set as an environment variable.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkEnvironmentVariableAlreadySetBySdk">
+        <source>An SDK attempted to set the environment variable "{0}" to "{1}" but it was already set by another SDK.</source>
+        <target state="new">An SDK attempted to set the environment variable "{0}" to "{1}" but it was already set by another SDK.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkEnvironmentVariableSet">
+        <source>An SDK attempted set the environment variable "{0}" to "{1}".</source>
+        <target state="new">An SDK attempted set the environment variable "{0}" to "{1}".</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SingleResolverFailedToResolveSDK">
         <source>SDK '{0}' could not be resolved by the SDK resolver '{1}'. {2}</source>
         <target state="translated">SDK 확인자 '{1}'에서 SDK '{0}'을(를) 확인할 수 없습니다. {2}</target>

--- a/src/Build/Resources/xlf/Strings.pl.xlf
+++ b/src/Build/Resources/xlf/Strings.pl.xlf
@@ -860,6 +860,21 @@ Błędy: {3}</target>
         <target state="translated">Narzędzie Resolver zestawu SDK „{0}” zwróciło wartość null.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SdkEnvironmentVariableAlreadySet">
+        <source>An SDK attempted to set the environment variable "{0}" to "{1}" but it was already set as an environment variable.</source>
+        <target state="new">An SDK attempted to set the environment variable "{0}" to "{1}" but it was already set as an environment variable.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkEnvironmentVariableAlreadySetBySdk">
+        <source>An SDK attempted to set the environment variable "{0}" to "{1}" but it was already set by another SDK.</source>
+        <target state="new">An SDK attempted to set the environment variable "{0}" to "{1}" but it was already set by another SDK.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkEnvironmentVariableSet">
+        <source>An SDK attempted set the environment variable "{0}" to "{1}".</source>
+        <target state="new">An SDK attempted set the environment variable "{0}" to "{1}".</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SingleResolverFailedToResolveSDK">
         <source>SDK '{0}' could not be resolved by the SDK resolver '{1}'. {2}</source>
         <target state="translated">Nie można rozpoznać zestawu SDK „{0}” przez program rozpoznawania nazw zestawu SDK „{1}”. {2}</target>

--- a/src/Build/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Build/Resources/xlf/Strings.pt-BR.xlf
@@ -860,6 +860,21 @@ Erros: {3}</target>
         <target state="translated">O resolvedor do SDK "{0}" retornou nulo.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SdkEnvironmentVariableAlreadySet">
+        <source>An SDK attempted to set the environment variable "{0}" to "{1}" but it was already set as an environment variable.</source>
+        <target state="new">An SDK attempted to set the environment variable "{0}" to "{1}" but it was already set as an environment variable.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkEnvironmentVariableAlreadySetBySdk">
+        <source>An SDK attempted to set the environment variable "{0}" to "{1}" but it was already set by another SDK.</source>
+        <target state="new">An SDK attempted to set the environment variable "{0}" to "{1}" but it was already set by another SDK.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkEnvironmentVariableSet">
+        <source>An SDK attempted set the environment variable "{0}" to "{1}".</source>
+        <target state="new">An SDK attempted set the environment variable "{0}" to "{1}".</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SingleResolverFailedToResolveSDK">
         <source>SDK '{0}' could not be resolved by the SDK resolver '{1}'. {2}</source>
         <target state="translated">O SDK '{0}' não pôde ser resolvido pelo resolvedor de SDK '{1}'. {2}</target>

--- a/src/Build/Resources/xlf/Strings.ru.xlf
+++ b/src/Build/Resources/xlf/Strings.ru.xlf
@@ -860,6 +860,21 @@ Errors: {3}</source>
         <target state="translated">Сопоставитель пакетов SDK "{0}" вернул значение null.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SdkEnvironmentVariableAlreadySet">
+        <source>An SDK attempted to set the environment variable "{0}" to "{1}" but it was already set as an environment variable.</source>
+        <target state="new">An SDK attempted to set the environment variable "{0}" to "{1}" but it was already set as an environment variable.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkEnvironmentVariableAlreadySetBySdk">
+        <source>An SDK attempted to set the environment variable "{0}" to "{1}" but it was already set by another SDK.</source>
+        <target state="new">An SDK attempted to set the environment variable "{0}" to "{1}" but it was already set by another SDK.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkEnvironmentVariableSet">
+        <source>An SDK attempted set the environment variable "{0}" to "{1}".</source>
+        <target state="new">An SDK attempted set the environment variable "{0}" to "{1}".</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SingleResolverFailedToResolveSDK">
         <source>SDK '{0}' could not be resolved by the SDK resolver '{1}'. {2}</source>
         <target state="translated">Не удалось разрешить SDK "{0}" с помощью сопоставителя SDK "{1}". {2}</target>

--- a/src/Build/Resources/xlf/Strings.tr.xlf
+++ b/src/Build/Resources/xlf/Strings.tr.xlf
@@ -860,6 +860,21 @@ Hatalar: {3}</target>
         <target state="translated">SDK çözümleyici "{0}" null döndürdü.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SdkEnvironmentVariableAlreadySet">
+        <source>An SDK attempted to set the environment variable "{0}" to "{1}" but it was already set as an environment variable.</source>
+        <target state="new">An SDK attempted to set the environment variable "{0}" to "{1}" but it was already set as an environment variable.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkEnvironmentVariableAlreadySetBySdk">
+        <source>An SDK attempted to set the environment variable "{0}" to "{1}" but it was already set by another SDK.</source>
+        <target state="new">An SDK attempted to set the environment variable "{0}" to "{1}" but it was already set by another SDK.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkEnvironmentVariableSet">
+        <source>An SDK attempted set the environment variable "{0}" to "{1}".</source>
+        <target state="new">An SDK attempted set the environment variable "{0}" to "{1}".</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SingleResolverFailedToResolveSDK">
         <source>SDK '{0}' could not be resolved by the SDK resolver '{1}'. {2}</source>
         <target state="translated">SDK '{0}', SDK çözümleyici '{1}' tarafından çözümlenemedi. {2}</target>

--- a/src/Build/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hans.xlf
@@ -860,6 +860,21 @@ Errors: {3}</source>
         <target state="translated">SDK 解析程序“{0}”返回 null。</target>
         <note />
       </trans-unit>
+      <trans-unit id="SdkEnvironmentVariableAlreadySet">
+        <source>An SDK attempted to set the environment variable "{0}" to "{1}" but it was already set as an environment variable.</source>
+        <target state="new">An SDK attempted to set the environment variable "{0}" to "{1}" but it was already set as an environment variable.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkEnvironmentVariableAlreadySetBySdk">
+        <source>An SDK attempted to set the environment variable "{0}" to "{1}" but it was already set by another SDK.</source>
+        <target state="new">An SDK attempted to set the environment variable "{0}" to "{1}" but it was already set by another SDK.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkEnvironmentVariableSet">
+        <source>An SDK attempted set the environment variable "{0}" to "{1}".</source>
+        <target state="new">An SDK attempted set the environment variable "{0}" to "{1}".</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SingleResolverFailedToResolveSDK">
         <source>SDK '{0}' could not be resolved by the SDK resolver '{1}'. {2}</source>
         <target state="translated">SDK 解析程序“{1}”无法解析 SDK“{0}”。{2}</target>

--- a/src/Build/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hant.xlf
@@ -860,6 +860,21 @@ Errors: {3}</source>
         <target state="translated">SDK 解析程式 "{0}" 傳回 Null。</target>
         <note />
       </trans-unit>
+      <trans-unit id="SdkEnvironmentVariableAlreadySet">
+        <source>An SDK attempted to set the environment variable "{0}" to "{1}" but it was already set as an environment variable.</source>
+        <target state="new">An SDK attempted to set the environment variable "{0}" to "{1}" but it was already set as an environment variable.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkEnvironmentVariableAlreadySetBySdk">
+        <source>An SDK attempted to set the environment variable "{0}" to "{1}" but it was already set by another SDK.</source>
+        <target state="new">An SDK attempted to set the environment variable "{0}" to "{1}" but it was already set by another SDK.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SdkEnvironmentVariableSet">
+        <source>An SDK attempted set the environment variable "{0}" to "{1}".</source>
+        <target state="new">An SDK attempted set the environment variable "{0}" to "{1}".</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SingleResolverFailedToResolveSDK">
         <source>SDK '{0}' could not be resolved by the SDK resolver '{1}'. {2}</source>
         <target state="translated">SDK 解析程式 '{1}' 無法解析 SDK '{0}'。{2}</target>

--- a/src/Framework/Sdk/SdkResult.cs
+++ b/src/Framework/Sdk/SdkResult.cs
@@ -26,6 +26,7 @@ namespace Microsoft.Build.Framework
         private protected IList<string> _additionalPaths;
         private protected IDictionary<string, string> _propertiesToAdd;
         private protected IDictionary<string, SdkResultItem> _itemsToAdd;
+        private protected IDictionary<string, string> _environmentVariablesToAdd;
         private protected SdkReference _sdkReference;
 
         /// <summary>
@@ -65,6 +66,11 @@ namespace Microsoft.Build.Framework
         /// Items that should be added to the evaluation.  This allows an SDK resolver to provide information to the build
         /// </summary>
         public virtual IDictionary<string, SdkResultItem> ItemsToAdd { get => _itemsToAdd; protected set => _itemsToAdd = value; }
+
+        /// <summary>
+        /// Environment variables that should be added to the evaluation.  This allows an SDK resolver to provide information to the build
+        /// </summary>
+        public virtual IDictionary<string, string> EnvironmentVariablesToAdd { get => _environmentVariablesToAdd; protected set => _environmentVariablesToAdd = value; }
 
         /// <summary>
         ///     The Sdk reference

--- a/src/Framework/Sdk/SdkResultFactory.cs
+++ b/src/Framework/Sdk/SdkResultFactory.cs
@@ -79,7 +79,11 @@ namespace Microsoft.Build.Framework
         /// <param name="propertiesToAdd">Properties to set in the evaluation</param>
         /// <param name="itemsToAdd">Items to add to the evaluation</param>
         /// <param name="warnings">Optional warnings to display during resolution.</param>
-        /// <param name="environmentVariablesToAdd">Environment variables to add to the evaluation process state</param>
+        /// <param name="environmentVariablesToAdd">
+        /// Environment variables to add to the project.
+        /// Environment variables set in this way are available as properties during evaluation, and
+        /// additionally set as environment variables during execution, including to tasks and launched processes.
+        /// </param>
         /// <returns></returns>
         public virtual SdkResult IndicateSuccess(string path,
             string version,
@@ -105,7 +109,11 @@ namespace Microsoft.Build.Framework
         /// <param name="propertiesToAdd">Properties to set in the evaluation</param>
         /// <param name="itemsToAdd">Items to add to the evaluation</param>
         /// <param name="warnings">Optional warnings to display during resolution.</param>
-        /// <param name="environmentVariablesToAdd">Environment variables to add to the evaluation process state</param>
+        /// <param name="environmentVariablesToAdd">
+        /// Environment variables to add to the project.
+        /// Environment variables set in this way are available as properties during evaluation, and
+        /// additionally set as environment variables during execution, including to tasks and launched processes.
+        /// </param>
         /// <returns></returns>
         public virtual SdkResult IndicateSuccess(IEnumerable<string> paths,
             string version,

--- a/src/Framework/Sdk/SdkResultFactory.cs
+++ b/src/Framework/Sdk/SdkResultFactory.cs
@@ -66,6 +66,58 @@ namespace Microsoft.Build.Framework
         }
 
         /// <summary>
+        ///     Create an <see cref="SdkResolver" /> object indicating success.
+        /// </summary>
+        /// <remarks>
+        /// This overload allows any number (zero, one, or many) of SDK paths to be returned.  This means a "successful" result
+        /// may not resolve to any SDKs.  The resolver can also supply properties or items to communicate information to the build.  This
+        /// can allow resolvers to report SDKs that could not be resolved without hard-failing the evaluation, which can allow other
+        /// components to take more appropriate action (for example installing optional workloads or downloading NuGet SDKs).
+        /// </remarks>
+        /// <param name="path">Path to the SDK.</param>
+        /// <param name="version">SDK version which should be imported</param>
+        /// <param name="propertiesToAdd">Properties to set in the evaluation</param>
+        /// <param name="itemsToAdd">Items to add to the evaluation</param>
+        /// <param name="warnings">Optional warnings to display during resolution.</param>
+        /// <param name="environmentVariablesToAdd">Environment variables to add to the evaluation process state</param>
+        /// <returns></returns>
+        public virtual SdkResult IndicateSuccess(string path,
+            string version,
+            IDictionary<string, string> propertiesToAdd,
+            IDictionary<string, SdkResultItem> itemsToAdd,
+            IEnumerable<string> warnings = null,
+            IDictionary<string, string> environmentVariablesToAdd = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        ///     Create an <see cref="SdkResolver" /> object indicating success.
+        /// </summary>
+        /// <remarks>
+        /// This overload allows any number (zero, one, or many) of SDK paths to be returned.  This means a "successful" result
+        /// may not resolve to any SDKs.  The resolver can also supply properties or items to communicate information to the build.  This
+        /// can allow resolvers to report SDKs that could not be resolved without hard-failing the evaluation, which can allow other
+        /// components to take more appropriate action (for example installing optional workloads or downloading NuGet SDKs).
+        /// </remarks>
+        /// <param name="paths">SDK paths which should be imported</param>
+        /// <param name="version">SDK version which should be imported</param>
+        /// <param name="propertiesToAdd">Properties to set in the evaluation</param>
+        /// <param name="itemsToAdd">Items to add to the evaluation</param>
+        /// <param name="warnings">Optional warnings to display during resolution.</param>
+        /// <param name="environmentVariablesToAdd">Environment variables to add to the evaluation process state</param>
+        /// <returns></returns>
+        public virtual SdkResult IndicateSuccess(IEnumerable<string> paths,
+            string version,
+            IDictionary<string, string> propertiesToAdd = null,
+            IDictionary<string, SdkResultItem> itemsToAdd = null,
+            IEnumerable<string> warnings = null,
+            IDictionary<string, string> environmentVariablesToAdd = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
         ///     Create an <see cref="SdkResolver" /> object indicating failure resolving the SDK.
         /// </summary>
         /// <param name="errors">

--- a/src/Tasks.UnitTests/ResolveAssemblyReference_CustomCultureTests.cs
+++ b/src/Tasks.UnitTests/ResolveAssemblyReference_CustomCultureTests.cs
@@ -7,7 +7,6 @@ using Microsoft.Build.UnitTests;
 using Microsoft.Build.UnitTests.Shared;
 using Shouldly;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Microsoft.Build.Tasks.UnitTests
 {
@@ -16,13 +15,6 @@ namespace Microsoft.Build.Tasks.UnitTests
     /// </summary>
     public class ResolveAssemblyReference_CustomCultureTests
     {
-        private readonly ITestOutputHelper _output;
-
-        public ResolveAssemblyReference_CustomCultureTests(ITestOutputHelper output)
-        {
-            _output = output;
-        }
-
         private static string TestAssetsRootPath { get; } = Path.Combine(
             Path.GetDirectoryName(typeof(AddToWin32Manifest_Tests).Assembly.Location) ?? AppContext.BaseDirectory,
             "TestResources",
@@ -38,7 +30,7 @@ namespace Microsoft.Build.Tasks.UnitTests
         [InlineData(true, "euy;yue")]
         public void E2EScenarioTests(bool enableCustomCulture, string customCultureExclusions = "", bool isYueCultureExpected = false, bool isEuyCultureExpected = false)
         {
-            using (TestEnvironment env = TestEnvironment.Create(_output))
+            using (TestEnvironment env = TestEnvironment.Create())
             {
                 // Set up project paths
                 var testAssetsPath = TestAssetsRootPath;
@@ -65,12 +57,7 @@ namespace Microsoft.Build.Tasks.UnitTests
                 env.SetCurrentDirectory(projectBFolder);
                 var output = RunnerUtilities.ExecBootstrapedMSBuild("-restore", out bool buildSucceeded);
 
-                if (!buildSucceeded)
-                {
-                    _output.WriteLine(output);
-                }
-
-                buildSucceeded.ShouldBeTrue("MSBuild should complete successfully.");
+                buildSucceeded.ShouldBeTrue($"MSBuild should complete successfully. Build output: {output}");
 
                 var yueCultureResourceDll = Path.Combine(projBOutputPath, "yue", "ProjectA.resources.dll");
                 AssertCustomCulture(isYueCultureExpected, "yue", yueCultureResourceDll);


### PR DESCRIPTION
Enable https://github.com/dotnet/roslyn/issues/78939 by adding the ability for SDK resolvers to return environment variables.

The environment variables are set during _execution_, because they cannot be reliably set during evaluation, which may be happening concurrently within a process. The value is also set as a regular property for ease of access during evaluation time.