### PR TITLE
Users/tevinstanley/allocatelistsizecorrectly

### DIFF
--- a/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupIntrinsicTask.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupIntrinsicTask.cs
@@ -353,11 +353,11 @@ namespace Microsoft.Build.BackEnd
         /// </summary>
         /// <param name="parameterValues">The list of batchable values</param>
         /// <param name="child">The item from which to find batchable values</param>
-        private void  GetBatchableValuesFromBuildItemGroupChild(List<string> parameterValues, ProjectItemGroupTaskItemInstance child)
+        private void GetBatchableValuesFromBuildItemGroupChild(List<string> parameterValues, ProjectItemGroupTaskItemInstance child)
         {
-            if (parameterValues.Capacity < child.Metadata.Count + 5)
+            if (parameterValues.Capacity < child.Metadata.Count + 4)
             {
-                parameterValues.Capacity = child.Metadata.Count + 5;
+                parameterValues.Capacity = child.Metadata.Count + 4;
             }
 
             AddIfNotEmptyString(parameterValues, child.Include);

--- a/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupIntrinsicTask.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupIntrinsicTask.cs
@@ -51,13 +51,14 @@ namespace Microsoft.Build.BackEnd
         /// <param name="lookup">The lookup used for evaluation and as a destination for these items.</param>
         internal override void ExecuteTask(Lookup lookup)
         {
+            List<string> parameterValues = null;
             foreach (ProjectItemGroupTaskItemInstance child in _taskInstance.Items)
             {
                 List<ItemBucket> buckets = null;
 
                 try
                 {
-                    List<string> parameterValues = new List<string>();
+                    parameterValues ??= new List<string>();
                     GetBatchableValuesFromBuildItemGroupChild(parameterValues, child);
                     buckets = BatchingEngine.PrepareBatchingBuckets(parameterValues, lookup, child.ItemType, _taskInstance.Location, LoggingContext);
 
@@ -139,6 +140,7 @@ namespace Microsoft.Build.BackEnd
                             bucket.LeaveScope();
                         }
                     }
+                    parameterValues.Clear();
                 }
             }
         }
@@ -351,8 +353,13 @@ namespace Microsoft.Build.BackEnd
         /// </summary>
         /// <param name="parameterValues">The list of batchable values</param>
         /// <param name="child">The item from which to find batchable values</param>
-        private void GetBatchableValuesFromBuildItemGroupChild(List<string> parameterValues, ProjectItemGroupTaskItemInstance child)
+        private void  GetBatchableValuesFromBuildItemGroupChild(List<string> parameterValues, ProjectItemGroupTaskItemInstance child)
         {
+            if (parameterValues.Capacity < child.Metadata.Count + 5)
+            {
+                parameterValues.Capacity = child.Metadata.Count + 5;
+            }
+
             AddIfNotEmptyString(parameterValues, child.Include);
             AddIfNotEmptyString(parameterValues, child.Exclude);
             AddIfNotEmptyString(parameterValues, child.Remove);


### PR DESCRIPTION
Fixes #

### Context
On traces we could see about  & mb of allocations due to add nonempty strings. When taking it look at the code we could see alot of adding to a list which was constantly resizing. 
![image](https://github.com/user-attachments/assets/5ee67e97-09d0-4d87-9605-8f7ed11955e3)


### Changes Made
Instead of defaulting a list of default size we use context to initialize the size to be something closer to what we would like. So that the capacity only needs to be set once.
### Testing


### Notes
