### PR TITLE
Smaller thread stack size for copy threads

### DIFF
--- a/src/Tasks/Copy.cs
+++ b/src/Tasks/Copy.cs
@@ -61,7 +61,9 @@ namespace Microsoft.Build.Tasks
                     {
                         AutoResetEvent autoResetEvent = new AutoResetEvent(false);
                         copyThreadSignals[i] = autoResetEvent;
-                        Thread newThread = new Thread(ParallelCopyTask);
+
+                        // specify the smallest stack size - 64kb
+                        Thread newThread = new Thread(ParallelCopyTask, 64 * 1024);
                         newThread.IsBackground = true;
                         newThread.Name = "Parallel Copy Thread";
                         newThread.Start(autoResetEvent);


### PR DESCRIPTION
### Context

We spawn a handful of threads to handle synchronous copying. These threads don't need the default stack size, and we can specify a smaller one to save some space for resource constrained machines.

### Changes Made


### Testing


### Notes
