### PR TITLE
Add the switch running OptProf tasks

### DIFF
--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -17,7 +17,7 @@ parameters:
   type: string
   default: 'default'
 - name: EnableOptProf
-  displayName: Enable OptProf tasks
+  displayName: Enable OptProf data collection for this build
   type: boolean
   default: true
 

--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -16,6 +16,10 @@ parameters:
   displayName: Optional OptProfDrop Override
   type: string
   default: 'default'
+- name: EnableOptProf
+  displayName: Enable OptProf tasks
+  type: boolean
+  default: true
 
 variables:
   # if OptProfDrop is not set, string '$(OptProfDrop)' will be passed to the build script.
@@ -153,6 +157,7 @@ extends:
             AccessToken: '$(System.AccessToken)'
             feedSource: 'https://devdiv.pkgs.visualstudio.com/DefaultCollection/_packaging/MicroBuildToolset/nuget/v3/index.json'
           displayName: 'Install OptProf Plugin'
+          condition: and(succeeded(), ${{ parameters.EnableOptProf }})
 
         # Required by MicroBuildBuildVSBootstrapper
         - task: MicroBuildSwixPlugin@4
@@ -188,7 +193,7 @@ extends:
             toLowerCase: false
             usePat: true
           displayName: 'OptProf - Publish to Artifact Services - ProfilingInputs'
-          condition: succeeded()
+          condition: and(succeeded(), ${{ parameters.EnableOptProf }})
 
         # Build VS bootstrapper
         # Generates $(Build.StagingDirectory)\MicroBuild\Output\BootstrapperInfo.json
@@ -200,7 +205,7 @@ extends:
             outputFolder: '$(Build.SourcesDirectory)\artifacts\VSSetup\$(BuildConfiguration)\Insertion'
             bootstrapperCoreVersion:
           displayName: 'OptProf - Build VS bootstrapper'
-          condition: succeeded()
+          condition: and(succeeded(), ${{ parameters.EnableOptProf }})
 
         # Publish run settings
         - task: PowerShell@2
@@ -212,7 +217,7 @@ extends:
                       /p:BootstrapperInfoPath=$(Build.StagingDirectory)\MicroBuild\Output\BootstrapperInfo.json
                       /p:VisualStudioIbcTrainingSettingsPath=$(Build.SourcesDirectory)\eng\config\OptProf.runsettings
           displayName: 'OptProf - Build IBC training settings'
-          condition: succeeded()
+          condition: and(succeeded(), ${{ parameters.EnableOptProf }})
 
         # Publish bootstrapper info
         - task: 1ES.PublishBuildArtifacts@1
@@ -221,7 +226,7 @@ extends:
             ArtifactName: MicroBuildOutputs
             ArtifactType: Container
           displayName: 'OptProf - Publish Artifact: MicroBuildOutputs'
-          condition: succeeded()
+          condition: and(succeeded(), ${{ parameters.EnableOptProf }})
 
         - task: 1ES.PublishBuildArtifacts@1
           displayName: 'Publish Artifact: logs'
@@ -290,7 +295,7 @@ extends:
           displayName: Tag build as ready for optimization training
           inputs:
             tags: 'ready-for-training'
-          condition: succeeded()
+          condition: and(succeeded(), ${{ parameters.EnableOptProf }})
 
         - task: ms-vseng.MicroBuildTasks.521a94ea-9e68-468a-8167-6dcf361ea776.MicroBuildCleanup@1
           displayName: Execute cleanup tasks

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,7 +2,7 @@
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the MIT license. See License.txt in the project root for full license information. -->
 <Project>
   <PropertyGroup>
-    <VersionPrefix>17.11.35</VersionPrefix>
+    <VersionPrefix>17.11.36</VersionPrefix>
     <DotNetFinalVersionKind>release</DotNetFinalVersionKind>
     <PackageValidationBaselineVersion>17.10.4</PackageValidationBaselineVersion>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>


### PR DESCRIPTION
In the case there isn't available VS manifest files from VSDrop, internal build is blocked by OptProf tasks. This needs another  mode that opts out of all OptProf tasks. Then add the switch running OptProf tasks or not.