### PR TITLE
Temporarily support preview6 resolver setting DOTNET_HOST_PATH

### DIFF
--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -1887,6 +1887,22 @@ namespace Microsoft.Build.Evaluation
                     }
                 }
 
+                // TEMPORARY COMPAT SHIM: .NET SDK 10.0.100-preview.6 shipped with a resolver that didn't
+                // return environment variables. Take the _property_ it does set and promote it.
+                // REMOVE BY net10 RC.
+                if (sdkResult.PropertiesToAdd?.ContainsKey("DOTNET_EXPERIMENTAL_HOST_PATH") == true)
+                {
+                    // "S:\sdk\.dotnet\sdk\10.0.100-preview.6.25315.102\Sdks\Microsoft.NET.Sdk\Sdk"
+                    //                  ^5              ^4               ^3          ^2        ^1
+                    string dotnetExe = Path.Combine(FileUtilities.GetFolderAbove(sdkResult.Path, 5),
+                        "dotnet.exe");
+                    if (File.Exists(dotnetExe))
+                    {
+
+                        _data.AddSdkResolvedEnvironmentVariable("DOTNET_HOST_PATH", dotnetExe);
+                    }
+                }
+
                 projects = projectList;
             }
             else


### PR DESCRIPTION
Because of the timing of release of .NET SDK 10.0.100-preview.6, its SDK resolver didn't define the `DOTNET_HOST_PATH` environment variable that is needed to support running Roslyn (https://github.com/dotnet/roslyn/issues/78939).

However the SDK resolver does set a _property_ that we can use to trigger the desired behavior end-to-end. Let's do that so int preview VS users can test the new codepath ASAP.

