### PR TITLE
TL forwarding take 2

### DIFF
--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -2851,7 +2851,8 @@ namespace Microsoft.Build.Execution
                     loggingService.IncludeEvaluationProfile,
                     loggingService.IncludeEvaluationPropertiesAndItemsInProjectStartedEvent,
                     loggingService.IncludeEvaluationPropertiesAndItemsInEvaluationFinishedEvent,
-                    loggingService.IncludeTaskInputs));
+                    loggingService.IncludeTaskInputs,
+                    loggingService.EnableTargetOutputLogging));
             }
 
             return _nodeConfiguration;
@@ -3039,6 +3040,12 @@ namespace Microsoft.Build.Execution
 
                 forwardingLoggers = forwardingLoggers?.Concat(forwardingLogger) ?? forwardingLogger;
             }
+
+            if (_buildParameters.EnableTargetOutputLogging)
+            {
+                loggingService.EnableTargetOutputLogging = true;
+            }
+
 
             try
             {

--- a/src/Build/BackEnd/BuildManager/BuildParameters.cs
+++ b/src/Build/BackEnd/BuildManager/BuildParameters.cs
@@ -176,6 +176,8 @@ namespace Microsoft.Build.Execution
         /// </summary>
         private bool _onlyLogCriticalEvents;
 
+        private bool _enableTargetOutputLogging;
+
         /// <summary>
         /// The UI culture.
         /// </summary>
@@ -253,6 +255,7 @@ namespace Microsoft.Build.Execution
 
             _maxNodeCount = projectCollection.MaxNodeCount;
             _onlyLogCriticalEvents = projectCollection.OnlyLogCriticalEvents;
+            _enableTargetOutputLogging = projectCollection.EnableTargetOutputLogging;
             ToolsetDefinitionLocations = projectCollection.ToolsetLocations;
             _defaultToolsVersion = projectCollection.DefaultToolsVersion;
 
@@ -324,6 +327,7 @@ namespace Microsoft.Build.Execution
             IsBuildCheckEnabled = other.IsBuildCheckEnabled;
             IsTelemetryEnabled = other.IsTelemetryEnabled;
             ProjectCacheDescriptor = other.ProjectCacheDescriptor;
+            _enableTargetOutputLogging = other.EnableTargetOutputLogging;
         }
 
         /// <summary>
@@ -569,6 +573,15 @@ namespace Microsoft.Build.Execution
         {
             get => _onlyLogCriticalEvents;
             set => _onlyLogCriticalEvents = value;
+        }
+
+        /// <summary>
+        /// When true, target outputs (and returns) are logged as well.
+        /// </summary>
+        public bool EnableTargetOutputLogging
+        {
+            get => _enableTargetOutputLogging;
+            set => _enableTargetOutputLogging = value;
         }
 
         /// <summary>

--- a/src/Build/BackEnd/Components/Logging/ILoggingService.cs
+++ b/src/Build/BackEnd/Components/Logging/ILoggingService.cs
@@ -88,6 +88,15 @@ namespace Microsoft.Build.BackEnd.Logging
         }
 
         /// <summary>
+        /// When true, target outputs (and returns) are logged as well.
+        /// </summary>
+        bool EnableTargetOutputLogging
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
         /// Number of nodes in the system when it was initially started
         /// </summary>
         int MaxCPUCount

--- a/src/Build/BackEnd/Components/Logging/LoggingService.cs
+++ b/src/Build/BackEnd/Components/Logging/LoggingService.cs
@@ -255,7 +255,7 @@ namespace Microsoft.Build.BackEnd.Logging
         private AutoResetEvent _dequeueEvent;
 
         /// <summary>
-        /// Event set when queue become empty. 
+        /// Event set when queue become empty.
         /// </summary>
         private ManualResetEvent _emptyQueueEvent;
 
@@ -463,6 +463,15 @@ namespace Microsoft.Build.BackEnd.Logging
             get => _onlyLogCriticalEvents;
 
             set => _onlyLogCriticalEvents = value;
+        }
+
+        /// <summary>
+        /// When true, target outputs (and returns) are logged as well.
+        /// </summary>
+        public bool EnableTargetOutputLogging
+        {
+            get;
+            set;
         }
 
         /// <summary>
@@ -874,6 +883,7 @@ namespace Microsoft.Build.BackEnd.Logging
                 // Ask the component host if onlyLogCriticalEvents is true or false. If the host does
                 // not have this information default to false.
                 _onlyLogCriticalEvents = buildComponentHost.BuildParameters.OnlyLogCriticalEvents;
+                EnableTargetOutputLogging = buildComponentHost.BuildParameters.EnableTargetOutputLogging;
 
                 _serviceState = LoggingServiceState.Initialized;
 

--- a/src/Build/BackEnd/Components/Logging/TargetLoggingContext.cs
+++ b/src/Build/BackEnd/Components/Logging/TargetLoggingContext.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Collections;
 using System.Collections.Generic;
 using Microsoft.Build.Execution;
@@ -17,10 +16,6 @@ namespace Microsoft.Build.BackEnd.Logging
     /// </summary>
     internal class TargetLoggingContext : BuildLoggingContext
     {
-        /// <summary>
-        /// Should target outputs be logged also.
-        /// </summary>
-        private static bool s_enableTargetOutputLogging = !String.IsNullOrEmpty(Environment.GetEnvironmentVariable("MSBUILDTARGETOUTPUTLOGGING"));
 
         /// <summary>
         /// The project to which this target is attached.
@@ -40,7 +35,7 @@ namespace Microsoft.Build.BackEnd.Logging
         {
             _projectLoggingContext = projectLoggingContext;
             _target = target;
-
+            EnableTargetOutputLogging = projectLoggingContext.LoggingService.EnableTargetOutputLogging;
             this.IsValid = true;
         }
 
@@ -61,6 +56,7 @@ namespace Microsoft.Build.BackEnd.Logging
         internal TargetLoggingContext(ILoggingService loggingService, BuildEventContext outOfProcContext)
             : base(loggingService, outOfProcContext, true)
         {
+            EnableTargetOutputLogging = loggingService.EnableTargetOutputLogging;
             this.IsValid = true;
         }
 
@@ -69,8 +65,8 @@ namespace Microsoft.Build.BackEnd.Logging
         /// </summary>
         internal static bool EnableTargetOutputLogging
         {
-            get { return s_enableTargetOutputLogging; }
-            set { s_enableTargetOutputLogging = value; }
+            get;
+            set;
         }
 
         /// <summary>
@@ -105,7 +101,7 @@ namespace Microsoft.Build.BackEnd.Logging
             TargetOutputItemsInstanceEnumeratorProxy targetOutputWrapper = null;
 
             // Only log target outputs if we are going to log a target finished event and the environment variable is set and the target outputs are not null
-            if (!LoggingService.OnlyLogCriticalEvents && s_enableTargetOutputLogging && targetOutputs != null)
+            if (!LoggingService.OnlyLogCriticalEvents && EnableTargetOutputLogging && targetOutputs != null)
             {
                 targetOutputWrapper = new TargetOutputItemsInstanceEnumeratorProxy(targetOutputs);
             }

--- a/src/Build/BackEnd/Node/LoggingNodeConfiguration.cs
+++ b/src/Build/BackEnd/Node/LoggingNodeConfiguration.cs
@@ -12,12 +12,14 @@ namespace Microsoft.Build.BackEnd
         private bool _includeEvaluationPropertiesAndItemsInProjectStartedEvent;
         private bool _includeEvaluationPropertiesAndItemsInEvaluationFinishedEvent;
         private bool _includeTaskInputs;
+        private bool _includeTargetOutputs;
 
         public bool IncludeEvaluationMetaprojects => _includeEvaluationMetaprojects;
         public bool IncludeEvaluationProfiles => _includeEvaluationProfiles;
         public bool IncludeEvaluationPropertiesAndItemsInProjectStartedEvent => _includeEvaluationPropertiesAndItemsInProjectStartedEvent;
         public bool IncludeEvaluationPropertiesAndItemsInEvaluationFinishedEvent => _includeEvaluationPropertiesAndItemsInEvaluationFinishedEvent;
         public bool IncludeTaskInputs => _includeTaskInputs;
+        public bool IncludeTargetOutputs => _includeTargetOutputs;
 
         public LoggingNodeConfiguration()
         {
@@ -28,13 +30,15 @@ namespace Microsoft.Build.BackEnd
             bool includeEvaluationProfiles,
             bool includeEvaluationPropertiesAndItemsInProjectStartedEvent,
             bool includeEvaluationPropertiesAndItemsInEvaluationFinishedEvent,
-            bool includeTaskInputs)
+            bool includeTaskInputs,
+            bool includeTargetOutputs)
         {
             _includeEvaluationMetaprojects = includeEvaluationMetaprojects;
             _includeEvaluationProfiles = includeEvaluationProfiles;
             _includeEvaluationPropertiesAndItemsInProjectStartedEvent = includeEvaluationPropertiesAndItemsInProjectStartedEvent;
             _includeEvaluationPropertiesAndItemsInEvaluationFinishedEvent = includeEvaluationPropertiesAndItemsInEvaluationFinishedEvent;
             _includeTaskInputs = includeTaskInputs;
+            _includeTargetOutputs = includeTargetOutputs;
         }
 
         void ITranslatable.Translate(ITranslator translator)
@@ -44,6 +48,7 @@ namespace Microsoft.Build.BackEnd
             translator.Translate(ref _includeEvaluationPropertiesAndItemsInProjectStartedEvent);
             translator.Translate(ref _includeEvaluationPropertiesAndItemsInEvaluationFinishedEvent);
             translator.Translate(ref _includeTaskInputs);
+            translator.Translate(ref _includeTargetOutputs);
         }
     }
 }

--- a/src/Build/BackEnd/Node/OutOfProcNode.cs
+++ b/src/Build/BackEnd/Node/OutOfProcNode.cs
@@ -794,6 +794,10 @@ namespace Microsoft.Build.Execution
                     configuration.LoggingNodeConfiguration
                         .IncludeEvaluationPropertiesAndItemsInEvaluationFinishedEvent);
             }
+            if (configuration.LoggingNodeConfiguration.IncludeTargetOutputs)
+            {
+                _loggingService.EnableTargetOutputLogging = true;
+            }
 
             try
             {

--- a/src/Build/Definition/ProjectCollection.cs
+++ b/src/Build/Definition/ProjectCollection.cs
@@ -176,6 +176,8 @@ namespace Microsoft.Build.Evaluation
         /// </summary>
         private bool _onlyLogCriticalEvents;
 
+        private bool _enableTargetOutputLogging;
+
         /// <summary>
         /// Whether reevaluation is temporarily disabled on projects in this collection.
         /// This is useful when the host expects to make a number of reads and writes
@@ -279,7 +281,7 @@ namespace Microsoft.Build.Evaluation
         /// <param name="onlyLogCriticalEvents">If set to true, only critical events will be logged.</param>
         /// <param name="loadProjectsReadOnly">If set to true, load all projects as read-only.</param>
         public ProjectCollection(IDictionary<string, string> globalProperties, IEnumerable<ILogger> loggers, IEnumerable<ForwardingLoggerRecord> remoteLoggers, ToolsetDefinitionLocations toolsetDefinitionLocations, int maxNodeCount, bool onlyLogCriticalEvents, bool loadProjectsReadOnly)
-            : this(globalProperties, loggers, remoteLoggers, toolsetDefinitionLocations, maxNodeCount, onlyLogCriticalEvents, loadProjectsReadOnly, useAsynchronousLogging: false, reuseProjectRootElementCache: false)
+            : this(globalProperties, loggers, remoteLoggers, toolsetDefinitionLocations, maxNodeCount, onlyLogCriticalEvents, loadProjectsReadOnly, useAsynchronousLogging: false, reuseProjectRootElementCache: false, enableTargetOutputLogging: false)
         {
         }
 
@@ -298,9 +300,10 @@ namespace Microsoft.Build.Evaluation
         /// <param name="maxNodeCount">The maximum number of nodes to use for building.</param>
         /// <param name="onlyLogCriticalEvents">If set to true, only critical events will be logged.</param>
         /// <param name="loadProjectsReadOnly">If set to true, load all projects as read-only.</param>
-        /// <param name="useAsynchronousLogging">If set to true, asynchronous logging will be used. <see cref="ProjectCollection.Dispose()"/> has to called to clear resources used by async logging.</param>
+        /// <param name="useAsynchronousLogging">If set to true, asynchronous logging will be used. <see cref="Dispose()"/> has to called to clear resources used by async logging.</param>
         /// <param name="reuseProjectRootElementCache">If set to true, it will try to reuse <see cref="ProjectRootElementCacheBase"/> singleton.</param>
-        public ProjectCollection(IDictionary<string, string> globalProperties, IEnumerable<ILogger> loggers, IEnumerable<ForwardingLoggerRecord> remoteLoggers, ToolsetDefinitionLocations toolsetDefinitionLocations, int maxNodeCount, bool onlyLogCriticalEvents, bool loadProjectsReadOnly, bool useAsynchronousLogging, bool reuseProjectRootElementCache)
+        /// <param name="enableTargetOutputLogging">If set to true, loggers will collect and send Target outputs when targets are finished executing.</param>
+        public ProjectCollection(IDictionary<string, string> globalProperties, IEnumerable<ILogger> loggers, IEnumerable<ForwardingLoggerRecord> remoteLoggers, ToolsetDefinitionLocations toolsetDefinitionLocations, int maxNodeCount, bool onlyLogCriticalEvents, bool loadProjectsReadOnly, bool useAsynchronousLogging, bool reuseProjectRootElementCache, bool enableTargetOutputLogging)
         {
             _loadedProjects = new LoadedProjectCollection();
             ToolsetLocations = toolsetDefinitionLocations;
@@ -328,11 +331,12 @@ namespace Microsoft.Build.Evaluation
             }
 
             OnlyLogCriticalEvents = onlyLogCriticalEvents;
+            EnableTargetOutputLogging = enableTargetOutputLogging;
 
             try
             {
                 _loggerMode = useAsynchronousLogging ? LoggerMode.Asynchronous : LoggerMode.Synchronous;
-                CreateLoggingService(maxNodeCount, onlyLogCriticalEvents);
+                CreateLoggingService(maxNodeCount, onlyLogCriticalEvents, enableTargetOutputLogging);
 
                 RegisterLoggers(loggers);
                 RegisterForwardingLoggers(remoteLoggers);
@@ -432,7 +436,7 @@ namespace Microsoft.Build.Evaluation
                     // Take care to ensure that there is never more than one value observed
                     // from this property even in the case of race conditions while lazily initializing.
                     var local = new ProjectCollection(null, null, null, ToolsetDefinitionLocations.Default,
-                        maxNodeCount: 1, onlyLogCriticalEvents: false, loadProjectsReadOnly: false, useAsynchronousLogging: true, reuseProjectRootElementCache: false);
+                        maxNodeCount: 1, onlyLogCriticalEvents: false, loadProjectsReadOnly: false, useAsynchronousLogging: true, reuseProjectRootElementCache: false, enableTargetOutputLogging: false);
 
                     if (Interlocked.CompareExchange(ref s_globalProjectCollection, local, null) != null)
                     {
@@ -711,6 +715,35 @@ namespace Microsoft.Build.Evaluation
                 {
                     OnProjectCollectionChanged(
                         new ProjectCollectionChangedEventArgs(ProjectCollectionChangedState.OnlyLogCriticalEvents));
+                }
+            }
+        }
+
+        public bool EnableTargetOutputLogging
+        {
+            get
+            {
+                using (_locker.EnterDisposableReadLock())
+                {
+                    return _enableTargetOutputLogging;
+                }
+            }
+            set
+            {
+                bool sendEvent = false;
+                using (_locker.EnterDisposableWriteLock())
+                {
+                    if (_enableTargetOutputLogging != value)
+                    {
+                        _enableTargetOutputLogging = value;
+                        sendEvent = true;
+                    }
+                }
+
+                if (sendEvent)
+                {
+                    OnProjectCollectionChanged(
+                        new ProjectCollectionChangedEventArgs(ProjectCollectionChangedState.EnableTargetOutputLogging));
                 }
             }
         }
@@ -1331,7 +1364,7 @@ namespace Microsoft.Build.Evaluation
 
                 // UNDONE: Logging service should not shut down when all loggers are unregistered.
                 // VS unregisters all loggers on the same project collection often. To workaround this, we have to create it again now!
-                CreateLoggingService(MaxNodeCount, OnlyLogCriticalEvents);
+                CreateLoggingService(MaxNodeCount, OnlyLogCriticalEvents, EnableTargetOutputLogging);
             }
 
             OnProjectCollectionChanged(new ProjectCollectionChangedEventArgs(ProjectCollectionChangedState.Loggers));
@@ -1765,11 +1798,12 @@ namespace Microsoft.Build.Evaluation
         /// <summary>
         /// Create a new logging service
         /// </summary>
-        private void CreateLoggingService(int maxCPUCount, bool onlyLogCriticalEvents)
+        private void CreateLoggingService(int maxCPUCount, bool onlyLogCriticalEvents, bool enableTargetOutputLogging)
         {
             _loggingService = BackEnd.Logging.LoggingService.CreateLoggingService(_loggerMode, 0 /*Evaluation can be done as if it was on node "0"*/);
             _loggingService.MaxCPUCount = maxCPUCount;
             _loggingService.OnlyLogCriticalEvents = onlyLogCriticalEvents;
+            _loggingService.EnableTargetOutputLogging = enableTargetOutputLogging;
         }
 
         /// <summary>

--- a/src/Build/Definition/ProjectCollectionChangedEventArgs.cs
+++ b/src/Build/Definition/ProjectCollectionChangedEventArgs.cs
@@ -56,6 +56,7 @@ namespace Microsoft.Build.Evaluation
         /// The <see cref="ProjectCollection.SkipEvaluation"/> property changed.
         /// </summary>
         SkipEvaluation,
+        EnableTargetOutputLogging
     }
 
     /// <summary>

--- a/src/Build/Logging/BaseConsoleLogger.cs
+++ b/src/Build/Logging/BaseConsoleLogger.cs
@@ -906,7 +906,7 @@ namespace Microsoft.Build.BackEnd.Logging
 
             ParseParameters();
 
-            showTargetOutputs = !String.IsNullOrEmpty(Environment.GetEnvironmentVariable("MSBUILDTARGETOUTPUTLOGGING"));
+            showTargetOutputs = Traits.Instance.EnableTargetOutputLogging;
 
             if (showOnlyWarnings || showOnlyErrors)
             {

--- a/src/Build/Logging/TerminalLogger/ForwardingTerminalLogger.cs
+++ b/src/Build/Logging/TerminalLogger/ForwardingTerminalLogger.cs
@@ -1,0 +1,103 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Build.Framework;
+
+namespace Microsoft.Build.Logging;
+
+/// <summary>
+/// A forwarding logger that forwards events relevant to implementing the TerminalLogger from build nodes to the central nodes.
+/// This logger
+/// </summary>
+public sealed partial class ForwardingTerminalLogger : IForwardingLogger
+{
+    /// <inheritdoc />
+    public IEventRedirector? BuildEventRedirector { get; set; }
+    /// <inheritdoc />
+    public int NodeId { get; set; }
+
+    public LoggerVerbosity Verbosity { get; set; } = LoggerVerbosity.Diagnostic;
+    /// <inheritdoc />
+    public string? Parameters { get; set; }
+
+    /// <inheritdoc />
+    public void Initialize(IEventSource eventSource, int nodeCount)
+    {
+        NodeId = nodeCount;
+        Initialize(eventSource);
+    }
+
+    /// <inheritdoc />
+    public void Initialize(IEventSource eventSource)
+    {
+        eventSource.BuildStarted += ForwardEventUnconditionally;
+        eventSource.BuildFinished += ForwardEventUnconditionally;
+        eventSource.ProjectStarted += ForwardEventUnconditionally;
+        eventSource.ProjectFinished += ForwardEventUnconditionally;
+        eventSource.TargetStarted += ForwardEventUnconditionally;
+        eventSource.TargetFinished += ForwardEventUnconditionally;
+        eventSource.TaskStarted += TaskStarted;
+
+        eventSource.MessageRaised += MessageRaised;
+        eventSource.WarningRaised += ForwardEventUnconditionally;
+        eventSource.ErrorRaised += ForwardEventUnconditionally;
+        eventSource.StatusEventRaised += ForwardEvaluationEvents;
+
+        if (eventSource is IEventSource3 eventSource3)
+        {
+            eventSource3.IncludeTaskInputs();
+        }
+
+        if (eventSource is IEventSource4 eventSource4)
+        {
+            eventSource4.IncludeEvaluationPropertiesAndItems();
+        }
+    }
+
+    private void ForwardEvaluationEvents(object sender, BuildStatusEventArgs e)
+    {
+        if (e is ProjectEvaluationStartedEventArgs ||
+            e is ProjectEvaluationFinishedEventArgs)
+        {
+            // Forward evaluation events unconditionally
+            BuildEventRedirector?.ForwardEvent(e);
+        }
+    }
+
+    public void ForwardEventUnconditionally(object sender, BuildEventArgs e)
+    {
+        BuildEventRedirector?.ForwardEvent(e);
+    }
+
+    public void TaskStarted(object sender, TaskStartedEventArgs e)
+    {
+        // The central node updates the 'in-flight' node status on the terminal
+        // when a node starts the MSBuild task, so we need to forward these along so that behavior still works.
+        if (e.BuildEventContext is not null && e.TaskName == "MSBuild")
+        {
+            BuildEventRedirector?.ForwardEvent(e);
+        }
+    }
+
+    public void MessageRaised(object sender, BuildMessageEventArgs e)
+    {
+        if (e.BuildEventContext is null)
+        {
+            return;
+        }
+
+        if (e.Message is not null &&
+            // Never forward messages if the verbosity is quiet
+            Verbosity != LoggerVerbosity.Quiet &&
+            // High-priority messages are always collected by the central node
+            (e.Importance == MessageImportance.High
+            // Normmal-priority messages are only collected if the verbosity is more verbose than normal
+            || (e.Importance == MessageImportance.Normal && Verbosity > LoggerVerbosity.Normal)))
+        {
+            BuildEventRedirector?.ForwardEvent(e);
+        }
+    }
+
+    /// <inheritdoc />
+    public void Shutdown() {}
+}

--- a/src/Build/Logging/TerminalLogger/ForwardingTerminalLogger.cs
+++ b/src/Build/Logging/TerminalLogger/ForwardingTerminalLogger.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using Microsoft.Build.Framework;
 
 namespace Microsoft.Build.Logging;
@@ -84,6 +85,18 @@ public sealed partial class ForwardingTerminalLogger : IForwardingLogger
         if (e.BuildEventContext is null)
         {
             return;
+        }
+
+        if (e is TaskParameterEventArgs taskArgs)
+        {
+            if (taskArgs.Kind == TaskParameterMessageKind.AddItem)
+            {
+                if (taskArgs.ItemType.Equals("SourceRoot", StringComparison.OrdinalIgnoreCase))
+                {
+                    BuildEventRedirector?.ForwardEvent(taskArgs);
+                    return;
+                }
+            }
         }
 
         if (e.Message is not null &&

--- a/src/Build/Logging/TerminalLogger/ForwardingTerminalLogger.cs
+++ b/src/Build/Logging/TerminalLogger/ForwardingTerminalLogger.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using Microsoft.Build.Framework;
 
 namespace Microsoft.Build.Logging;
@@ -85,18 +84,6 @@ public sealed partial class ForwardingTerminalLogger : IForwardingLogger
         if (e.BuildEventContext is null)
         {
             return;
-        }
-
-        if (e is TaskParameterEventArgs taskArgs)
-        {
-            if (taskArgs.Kind == TaskParameterMessageKind.AddItem)
-            {
-                if (taskArgs.ItemType.Equals("SourceRoot", StringComparison.OrdinalIgnoreCase))
-                {
-                    BuildEventRedirector?.ForwardEvent(taskArgs);
-                    return;
-                }
-            }
         }
 
         if (e.Message is not null &&

--- a/src/Build/Logging/TerminalLogger/TerminalLogger.cs
+++ b/src/Build/Logging/TerminalLogger/TerminalLogger.cs
@@ -321,6 +321,11 @@ public sealed partial class TerminalLogger : INodeLogger
         eventSource.WarningRaised += WarningRaised;
         eventSource.ErrorRaised += ErrorRaised;
 
+        if (eventSource is IEventSource3 eventSource3)
+        {
+            eventSource3.IncludeTaskInputs();
+        }
+
         if (eventSource is IEventSource4 eventSource4)
         {
             eventSource4.IncludeEvaluationPropertiesAndItems();
@@ -855,6 +860,17 @@ public sealed partial class TerminalLogger : INodeLogger
         }
 
         string? message = e.Message;
+
+        if (e is TaskParameterEventArgs taskArgs)
+        {
+            if (taskArgs.Kind == TaskParameterMessageKind.AddItem)
+            {
+                if (taskArgs.ItemType.Equals("SourceRoot", StringComparison.OrdinalIgnoreCase))
+                {
+                    TryReadSourceControlInformationForProject(taskArgs.BuildEventContext, taskArgs.Items as IList<Execution.ProjectItemInstance>);
+                }
+            }
+        }
         if (message is not null && e.Importance == MessageImportance.High)
         {
             var hasProject = _projects.TryGetValue(new ProjectContext(buildEventContext), out TerminalProjectInfo? project);
@@ -1001,6 +1017,33 @@ public sealed partial class TerminalLogger : INodeLogger
             // It is necessary to display warning messages reported by MSBuild, even if it's not tracked in _projects collection or the verbosity is Quiet.
             RenderImmediateMessage(FormatWarningMessage(e, Indentation));
             _buildWarningsCount++;
+        }
+    }
+
+
+    private void TryReadSourceControlInformationForProject(BuildEventContext? context, IEnumerable<ITaskItem>? sourceRoots)
+    {
+        if (context is null || sourceRoots is null)
+        {
+            return;
+        }
+
+        var projectContext = new ProjectContext(context);
+        if (_projects.TryGetValue(projectContext, out TerminalProjectInfo? project))
+        {
+            if (project.SourceRoot is not null)
+            {
+                return;
+            }
+            var sourceControlSourceRoot = sourceRoots.FirstOrDefault(root => !string.IsNullOrEmpty(root.GetMetadata("SourceControl")));
+            if (sourceControlSourceRoot is not null)
+            {
+                // This takes the first root from source control the first time it's added to the build.
+                // This seems to be the Target InitializeSourceControlInformationFromSourceControlManager.
+                // So far this has been acceptable, but if a SourceRoot would be modified by a task later on
+                // (e.g. TranslateGitHubUrlsInSourceControlInformation) we would lose that modification.
+                project.SourceRoot = sourceControlSourceRoot.ItemSpec.AsMemory();
+            }
         }
     }
 

--- a/src/Build/Logging/TerminalLogger/TerminalLogger.cs
+++ b/src/Build/Logging/TerminalLogger/TerminalLogger.cs
@@ -689,19 +689,43 @@ public sealed partial class TerminalLogger : INodeLogger
                                 urlString = uri.ToString();
                             }
 
-                            // If the output path is under the initial working directory, make the console output relative to that to save space.
-                            if (outputPathSpan.StartsWith(_initialWorkingDirectory.AsSpan(), FileUtilities.PathComparison))
+                            // now we compute the path to show the user for this project.
+                            // some options:
+                            // * the raw, full output path from the MSBuild logic (OutputPath property)
+                            // * the output path relative to the initial working directory, if it is under it
+                            // * the output path relative to the source root, if it is under it
+
+                            // full path fallback
+                            var projectDisplayPathSpan = outputPathSpan;
+                            var workingDirectorySpan = _initialWorkingDirectory.AsSpan();
+                            // under working dir case
+                            if (outputPathSpan.StartsWith(workingDirectorySpan, FileUtilities.PathComparison))
                             {
-                                if (outputPathSpan.Length > _initialWorkingDirectory.Length
-                                    && (outputPathSpan[_initialWorkingDirectory.Length] == Path.DirectorySeparatorChar
-                                        || outputPathSpan[_initialWorkingDirectory.Length] == Path.AltDirectorySeparatorChar))
+                                if (outputPathSpan.Length > workingDirectorySpan.Length
+                                    && (outputPathSpan[workingDirectorySpan.Length] == Path.DirectorySeparatorChar
+                                        || outputPathSpan[workingDirectorySpan.Length] == Path.AltDirectorySeparatorChar))
                                 {
-                                    outputPathSpan = outputPathSpan.Slice(_initialWorkingDirectory.Length + 1);
+                                    projectDisplayPathSpan = outputPathSpan.Slice(workingDirectorySpan.Length + 1);
+                                }
+                            }
+                            // under source root case
+                            else if (project.SourceRoot is { Span: var sourceRootSpan } )
+                            {
+                                var relativePathFromWorkingDirToSourceRoot = Path.GetRelativePath(workingDirectorySpan.ToString(), sourceRootSpan.ToString()).AsSpan();
+                                if (outputPathSpan.StartsWith(sourceRootSpan, FileUtilities.PathComparison))
+                                {
+                                    if (outputPathSpan.Length > sourceRootSpan.Length
+                                        // offsets are -1 here compared to above for ***reasons***
+                                        && (outputPathSpan[sourceRootSpan.Length - 1] == Path.DirectorySeparatorChar
+                                            || outputPathSpan[sourceRootSpan.Length - 1] == Path.AltDirectorySeparatorChar))
+                                    {
+                                        projectDisplayPathSpan = Path.Combine(relativePathFromWorkingDirToSourceRoot.ToString(), outputPathSpan.Slice(sourceRootSpan.Length).ToString()).AsSpan();
+                                    }
                                 }
                             }
 
                             Terminal.WriteLine(ResourceUtilities.FormatResourceStringIgnoreCodeAndKeyword("ProjectFinished_OutputPath",
-                                $"{AnsiCodes.LinkPrefix}{urlString}{AnsiCodes.LinkInfix}{outputPathSpan.ToString()}{AnsiCodes.LinkSuffix}"));
+                                $"{AnsiCodes.LinkPrefix}{urlString}{AnsiCodes.LinkInfix}{projectDisplayPathSpan.ToString()}{AnsiCodes.LinkSuffix}"));
                         }
                         else
                         {
@@ -812,12 +836,15 @@ public sealed partial class TerminalLogger : INodeLogger
         // to the item spec corresponding to the GetTargetPath target upon completion.
         var buildEventContext = e.BuildEventContext;
         var targetOutputs = e.TargetOutputs;
-        if (_restoreContext is null
-            && buildEventContext is not null
-            && targetOutputs is not null
-            && _hasUsedCache
-            && e.TargetName == "GetTargetPath"
-            && _projects.TryGetValue(new ProjectContext(buildEventContext), out TerminalProjectInfo? project))
+        if (_restoreContext is not null || buildEventContext is null)
+        {
+            return;
+        }
+
+        if (targetOutputs is not null
+                && _hasUsedCache
+                && e.TargetName == "GetTargetPath"
+                && _projects.TryGetValue(new ProjectContext(buildEventContext), out TerminalProjectInfo? project))
         {
             if (project is not null && project.IsCachePluginProject)
             {
@@ -827,6 +854,16 @@ public sealed partial class TerminalLogger : INodeLogger
                     break;
                 }
             }
+        }
+        else if (targetOutputs is not null
+            && e.TargetName == "InitializeSourceRootMappedPaths"
+            && _projects.TryGetValue(new ProjectContext(buildEventContext), out project)
+            && project.SourceRoot is null)
+        {
+            project.SourceRoot =
+                (targetOutputs as IEnumerable<ITaskItem>)?
+                .FirstOrDefault(root => !string.IsNullOrEmpty(root.GetMetadata("SourceControl")))
+                ?.ItemSpec.AsMemory();
         }
     }
 
@@ -861,16 +898,6 @@ public sealed partial class TerminalLogger : INodeLogger
 
         string? message = e.Message;
 
-        if (e is TaskParameterEventArgs taskArgs)
-        {
-            if (taskArgs.Kind == TaskParameterMessageKind.AddItem)
-            {
-                if (taskArgs.ItemType.Equals("SourceRoot", StringComparison.OrdinalIgnoreCase))
-                {
-                    TryReadSourceControlInformationForProject(taskArgs.BuildEventContext, taskArgs.Items as IList<Execution.ProjectItemInstance>);
-                }
-            }
-        }
         if (message is not null && e.Importance == MessageImportance.High)
         {
             var hasProject = _projects.TryGetValue(new ProjectContext(buildEventContext), out TerminalProjectInfo? project);
@@ -1017,33 +1044,6 @@ public sealed partial class TerminalLogger : INodeLogger
             // It is necessary to display warning messages reported by MSBuild, even if it's not tracked in _projects collection or the verbosity is Quiet.
             RenderImmediateMessage(FormatWarningMessage(e, Indentation));
             _buildWarningsCount++;
-        }
-    }
-
-
-    private void TryReadSourceControlInformationForProject(BuildEventContext? context, IEnumerable<ITaskItem>? sourceRoots)
-    {
-        if (context is null || sourceRoots is null)
-        {
-            return;
-        }
-
-        var projectContext = new ProjectContext(context);
-        if (_projects.TryGetValue(projectContext, out TerminalProjectInfo? project))
-        {
-            if (project.SourceRoot is not null)
-            {
-                return;
-            }
-            var sourceControlSourceRoot = sourceRoots.FirstOrDefault(root => !string.IsNullOrEmpty(root.GetMetadata("SourceControl")));
-            if (sourceControlSourceRoot is not null)
-            {
-                // This takes the first root from source control the first time it's added to the build.
-                // This seems to be the Target InitializeSourceControlInformationFromSourceControlManager.
-                // So far this has been acceptable, but if a SourceRoot would be modified by a task later on
-                // (e.g. TranslateGitHubUrlsInSourceControlInformation) we would lose that modification.
-                project.SourceRoot = sourceControlSourceRoot.ItemSpec.AsMemory();
-            }
         }
     }
 

--- a/src/Build/Logging/TerminalLogger/TerminalProjectInfo.cs
+++ b/src/Build/Logging/TerminalLogger/TerminalProjectInfo.cs
@@ -49,6 +49,11 @@ internal sealed class TerminalProjectInfo
     public ReadOnlyMemory<char>? OutputPath { get; set; }
 
     /// <summary>
+    /// Full path to the 'root' of this project's source control repository, if known.
+    /// </summary>
+    public ReadOnlyMemory<char>? SourceRoot { get; set; }
+
+    /// <summary>
     /// The target framework of the project or null if not multi-targeting.
     /// </summary>
     public string? TargetFramework { get; }

--- a/src/Framework/Traits.cs
+++ b/src/Framework/Traits.cs
@@ -150,6 +150,8 @@ namespace Microsoft.Build.Framework
         public bool ExcludeTasksDetailsFromTelemetry = IsEnvVarOneOrTrue("MSBUILDTELEMETRYEXCLUDETASKSDETAILS");
         public bool FlushNodesTelemetryIntoConsole = IsEnvVarOneOrTrue("MSBUILDFLUSHNODESTELEMETRYINTOCONSOLE");
 
+        public bool EnableTargetOutputLogging = IsEnvVarOneOrTrue("MSBUILDTARGETOUTPUTLOGGING");
+
         // for VS17.14
         public readonly bool TelemetryOptIn = IsEnvVarOneOrTrue("MSBUILD_TELEMETRY_OPTIN");
         public readonly bool SlnParsingWithSolutionPersistenceOptIn = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("MSBUILD_PARSE_SLN_WITH_SOLUTIONPERSISTENCE"));

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -734,6 +734,7 @@ namespace Microsoft.Build.CommandLine
                 string[] inputResultsCaches = null;
                 string outputResultsCache = null;
                 bool question = false;
+                bool isTaskInputLoggingRequired = false;
                 bool isBuildCheckEnabled = false;
                 string[] getProperty = [];
                 string[] getItem = [];
@@ -782,6 +783,7 @@ namespace Microsoft.Build.CommandLine
 #endif
                                             ref lowPriority,
                                             ref question,
+                                            ref isTaskInputLoggingRequired,
                                             ref isBuildCheckEnabled,
                                             ref getProperty,
                                             ref getItem,
@@ -898,6 +900,7 @@ namespace Microsoft.Build.CommandLine
                                     graphBuildOptions,
                                     lowPriority,
                                     question,
+                                    isTaskInputLoggingRequired,
                                     isBuildCheckEnabled,
                                     inputResultsCaches,
                                     outputResultsCache,
@@ -1304,6 +1307,7 @@ namespace Microsoft.Build.CommandLine
             GraphBuildOptions graphBuildOptions,
             bool lowPriority,
             bool question,
+            bool isTaskInputLoggingRequired,
             bool isBuildCheckEnabled,
             string[] inputResultsCaches,
             string outputResultsCache,
@@ -1364,7 +1368,7 @@ namespace Microsoft.Build.CommandLine
                 // This is a hack for now to make sure the perf hit only happens
                 // on diagnostic. This should be changed to pipe it through properly,
                 // perhaps as part of a fuller tracing feature.
-                bool logTaskInputs = verbosity == LoggerVerbosity.Diagnostic || isBuildCheckEnabled;
+                bool logTaskInputs = verbosity == LoggerVerbosity.Diagnostic || isTaskInputLoggingRequired;
 
                 if (!logTaskInputs)
                 {
@@ -2533,6 +2537,7 @@ namespace Microsoft.Build.CommandLine
 #endif
             ref bool lowPriority,
             ref bool question,
+            ref bool isTaskInputLoggingRequired,
             ref bool isBuildCheckEnabled,
             ref string[] getProperty,
             ref string[] getItem,
@@ -2562,10 +2567,11 @@ namespace Microsoft.Build.CommandLine
 #endif
 
             bool useTerminalLogger = ProcessTerminalLoggerConfiguration(commandLineSwitches, out string aggregatedTerminalLoggerParameters);
+            isTaskInputLoggingRequired = useTerminalLogger;
 
             // This is temporary until we can remove the need for the environment variable.
-            // DO NOT use this environment variable for any new features as it will be removed without further notice.
-            Environment.SetEnvironmentVariable("_MSBUILDTLENABLED", useTerminalLogger ? "1" : "0");
+                // DO NOT use this environment variable for any new features as it will be removed without further notice.
+                Environment.SetEnvironmentVariable("_MSBUILDTLENABLED", useTerminalLogger ? "1" : "0");
 
             DisplayVersionMessageIfNeeded(recursing, useTerminalLogger, commandLineSwitches);
 
@@ -2672,6 +2678,7 @@ namespace Microsoft.Build.CommandLine
 #endif
                                                            ref lowPriority,
                                                            ref question,
+                                                           ref isTaskInputLoggingRequired,
                                                            ref isBuildCheckEnabled,
                                                            ref getProperty,
                                                            ref getItem,
@@ -2757,8 +2764,8 @@ namespace Microsoft.Build.CommandLine
                     }
 
                     question = commandLineSwitches.IsParameterizedSwitchSet(CommandLineSwitches.ParameterizedSwitch.Question);
-
                     isBuildCheckEnabled = IsBuildCheckEnabled(commandLineSwitches);
+                    isTaskInputLoggingRequired = isTaskInputLoggingRequired || isBuildCheckEnabled;
 
                     inputResultsCaches = ProcessInputResultsCaches(commandLineSwitches);
 

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -3038,7 +3038,7 @@ namespace Microsoft.Build.CommandLine
             }
 
             // Check for environment variables that indicate automated environments
-            string[] automatedEnvironmentVariables = 
+            string[] automatedEnvironmentVariables =
             {
                 "COPILOT_API_URL",    // GitHub Copilot
                 "BUILD_ID",           // Jenkins, Google Cloud Build
@@ -4111,25 +4111,24 @@ namespace Microsoft.Build.CommandLine
                     /// node using an instance of <see cref="ConfigurableForwardingLogger"/> with the following parameters.
                     /// Important: Note that TerminalLogger is special-cased in <see cref="BackEnd.Logging.LoggingService.UpdateMinimumMessageImportance"/>
                     /// so changing this list may impact the minimum message importance logging optimization.
-                    string[] configurableForwardingLoggerParameters =
-                    [
-                        "BUILDSTARTEDEVENT",
-                        "BUILDFINISHEDEVENT",
-                        "PROJECTSTARTEDEVENT",
-                        "PROJECTFINISHEDEVENT",
-                        "TARGETSTARTEDEVENT",
-                        "TARGETFINISHEDEVENT",
-                        "TASKSTARTEDEVENT",
-                        "HIGHMESSAGEEVENT",
-                        "WARNINGEVENT",
-                        "ERROREVENT"
-                    ];
-
                     // For performance, register this logger using the forwarding logger mechanism.
-                    DistributedLoggerRecord forwardingLoggerRecord = CreateForwardingLoggerRecord(logger, string.Join(";", configurableForwardingLoggerParameters), LoggerVerbosity.Quiet);
-                    distributedLoggerRecords.Add(forwardingLoggerRecord);
+                    distributedLoggerRecords.Add(CreateTerminalLoggerForwardingLoggerRecord(logger, aggregatedLoggerParameters, verbosity));
                 }
             }
+        }
+
+        private static DistributedLoggerRecord CreateTerminalLoggerForwardingLoggerRecord(TerminalLogger centralLogger, string loggerParameters, LoggerVerbosity inputVerbosity)
+        {
+            string verbosityParameter = ExtractAnyLoggerParameter(loggerParameters, "verbosity", "v");
+            string verbosityValue = ExtractAnyParameterValue(verbosityParameter);
+            LoggerVerbosity effectiveVerbosity = inputVerbosity;
+            if (!string.IsNullOrEmpty(verbosityValue))
+            {
+                effectiveVerbosity = ProcessVerbositySwitch(verbosityValue);
+            }
+            var tlForwardingType = typeof(ForwardingTerminalLogger);
+            LoggerDescription forwardingLoggerDescription = new LoggerDescription(tlForwardingType.FullName, tlForwardingType.Assembly.FullName, null, loggerParameters, effectiveVerbosity);
+            return new DistributedLoggerRecord(centralLogger, forwardingLoggerDescription);
         }
 
         /// <summary>

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -1307,7 +1307,7 @@ namespace Microsoft.Build.CommandLine
             GraphBuildOptions graphBuildOptions,
             bool lowPriority,
             bool question,
-            bool isTaskInputLoggingRequired,
+            bool isTaskAndTargetItemLoggingRequired,
             bool isBuildCheckEnabled,
             string[] inputResultsCaches,
             string outputResultsCache,
@@ -1368,7 +1368,7 @@ namespace Microsoft.Build.CommandLine
                 // This is a hack for now to make sure the perf hit only happens
                 // on diagnostic. This should be changed to pipe it through properly,
                 // perhaps as part of a fuller tracing feature.
-                bool logTaskInputs = verbosity == LoggerVerbosity.Diagnostic || isTaskInputLoggingRequired;
+                bool logTaskInputs = verbosity == LoggerVerbosity.Diagnostic || isTaskAndTargetItemLoggingRequired;
 
                 if (!logTaskInputs)
                 {
@@ -1410,6 +1410,7 @@ namespace Microsoft.Build.CommandLine
                     toolsetDefinitionLocations,
                     cpuCount,
                     onlyLogCriticalEvents,
+                    enableTargetOutputLogging: isTaskAndTargetItemLoggingRequired,
                     loadProjectsReadOnly: !isPreprocess,
                     useAsynchronousLogging: true,
                     reuseProjectRootElementCache: s_isServerNode);
@@ -1517,6 +1518,7 @@ namespace Microsoft.Build.CommandLine
 #if FEATURE_REPORTFILEACCESSES
                     parameters.ReportFileAccesses = reportFileAccesses;
 #endif
+                    parameters.EnableTargetOutputLogging = isTaskAndTargetItemLoggingRequired;
 
                     // Propagate the profiler flag into the project load settings so the evaluator
                     // can pick it up


### PR DESCRIPTION
Fixes https://github.com/dotnet/msbuild/issues/9806

### Context

This is another take on making TL a forwarding logger. I've gotten it much better this time - it's working in multi-node setups consistently on my machine, and I was able to get the Target Outputs for targets that I care about after a bit of work. We can make this more efficient be filtering down the Target Outputs _at the forwarding level maybe_?

### Changes Made


### Testing


### Notes
