### PR TITLE
Allow FileWritesShared to be tracked and cleaned with an opt-in flag

### DIFF
--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -5761,28 +5761,43 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <ItemGroup>
       <_CleanPriorFileWrites Include="@(_CleanUnfilteredPriorFileWrites)" Exclude="@(_ResolveAssemblyReferenceResolvedFilesAbsolute)"/>
     </ItemGroup>
+    
+    <PropertyGroup>
+      <!-- 
+        If set, FileWritesShareable will be located under the OutDir and IntermediateOutputPath.
+        If not set, FileWritesShareable will be located only under the MSBuildProjectDirectory.
 
-    <!--
-        Of shareable files, keep only those that are in the project's directory.
-        We never clean shareable files outside of the project directory because
-        the build may be to a common output directory and other projects may need
-        them.
+        The default layout of projects is that everything particular to the project is
+        located under the MSBuildProjectDirectory, so it's considered safe to track/delete those.
+        The assumption was that anything outside the project's directory is shared between multiple projects
+        and should not be deleted by the Clean target.
 
-        Only subtract the outputs from ResolveAssemblyReferences target because that's the
-        only "Resolve" target that tries to resolve assemblies directly from the output
-        directory.
-        -->
-    <FindUnderPath Path="$(MSBuildProjectDirectory)" Files="@(FileWritesShareable)" UpdateToAbsolutePaths="true">
+        However, this is not always the case. The .NET SDK has a feature called Artifacts Layout
+        where project outputs are tracked in _project-specific_ locations under a root that is
+        outside of the project directory. In such cases, we need to be able to track FileWritesShareable
+        even from those locations.
+      -->
+      <TrackFileWritesShareableOutsideOfProjectDirectory Condition=" '$(TrackFileWritesShareableOutsideOfProjectDirectory)' == '' ">false</TrackFileWritesShareableOutsideOfProjectDirectory>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <!-- Always track the FileWrites from the project-specific output directories -->
+      <FilesToTrackFromOutputDirectories Include="@(FileWrites)" />
+      <!-- Track the FileWritesShareable too if requested -->
+      <FilesToTrackFromOutputDirectories Include="@(FileWritesShareable)" Condition=" $(TrackFileWritesShareableOutsideOfProjectDirectory) == true "/>
+    </ItemGroup>
+    
+    <FindUnderPath Condition="!$(TrackFileWritesShareableOutsideOfProjectDirectory)" Path="$(MSBuildProjectDirectory)" Files="@(FileWritesShareable)" UpdateToAbsolutePaths="true">
       <Output TaskParameter="InPath" ItemName="FileWrites"/>
     </FindUnderPath>
 
     <!-- Find all files in the final output directory. -->
-    <FindUnderPath Path="$(OutDir)" Files="@(FileWrites)" UpdateToAbsolutePaths="true">
+    <FindUnderPath Path="$(OutDir)" Files="@(FilesToTrackFromOutputDirectories)" UpdateToAbsolutePaths="true">
       <Output TaskParameter="InPath" ItemName="_CleanCurrentFileWritesInOutput"/>
     </FindUnderPath>
 
     <!-- Find all files in the intermediate output directory. -->
-    <FindUnderPath Path="$(IntermediateOutputPath)" Files="@(FileWrites)" UpdateToAbsolutePaths="true">
+    <FindUnderPath Path="$(IntermediateOutputPath)" Files="@(FilesToTrackFromOutputDirectories)" UpdateToAbsolutePaths="true">
       <Output TaskParameter="InPath" ItemName="_CleanCurrentFileWritesInIntermediate"/>
     </FindUnderPath>
 


### PR DESCRIPTION
This allows features like the .NET SDK's Artifacts Layout to correctly track and clean outputs that aren't under the project directory, but _are_ in project-isolated bubbles.

Part of https://github.com/dotnet/sdk/issues/49582.

### Context

The core problem is that during the Publish, one of the things that happens is that we call the `_CleanGetCurrentAndPriorFileWrites` target from `Microsoft.Common.CurrentVersion.targets`. The purpose of this Target is to identify all of the files that were written and that are deleteable from the current build. These files are then tracked in a file that future builds use as an input to their own cleanup operations. The `dotnet build -c Release` command _does_ read this file to delete files as necessary, but in this circumstance the file simply lacks all of the content that the self-contained build dumps into the `artifacts/bin/myproj/release` directory.

I'll inline the Target so we can discuss it:

https://github.com/dotnet/msbuild/blob/25d1e4c409f9efd81c345fb41fbee6d2af83bed6/src/Tasks/Microsoft.Common.CurrentVersion.targets#L5733-L5806

The specific part of this Target that is failing is the part that[ tries to locate](https://github.com/dotnet/msbuild/blob/25d1e4c409f9efd81c345fb41fbee6d2af83bed6/src/Tasks/Microsoft.Common.CurrentVersion.targets#L5765-L5777) any `FileWritesShareable` MSBuild Items that live under the `MSBuildProjectDirectory` (meaning, the directory of the project file currently being built. `FileWritesShareable` are automatically tracked by the build, and for the publish do contain all of the runtime files that need to be cleaned. However, when the `BaseOutputPath` is directed into someplace that isn't under `MSBuildProjectDirectory` (as is the case with the artifacts layout), none of these `FileWritesShareable` will be found (because they are all in some location not under `MSBuildProjectDirectory`).

### Changes Made

Adds an opt-in flag that consumers like the .NET SDK can set so that potentially-shared files outside of the directory bubble are tracked for cleanup.

### Testing

Manual testing by passing the property in and verifying FileListAbsolute.txt content.

### Notes
