### PR TITLE
Avoid creation of enumerator state machines

### DIFF
--- a/src/Build/Collections/CopyOnWritePropertyDictionary.cs
+++ b/src/Build/Collections/CopyOnWritePropertyDictionary.cs
@@ -354,12 +354,13 @@ namespace Microsoft.Build.Collections
         /// <param name="other">An enumerator over the properties to add.</param>
         public void ImportProperties(IEnumerable<T> other)
         {
-            ImmutableDictionary<string, T>.Builder builder = _backing.ToBuilder();
+            ImmutableDictionary<string, T>.Builder builder = null;
 
             if (other is CopyOnWritePropertyDictionary<T> copyOnWriteDictionary)
             {
                 foreach (KeyValuePair<string, T> kvp in copyOnWriteDictionary)
                 {
+                    builder ??= _backing.ToBuilder();
                     builder[kvp.Value.Key] = kvp.Value;
                 }
             }
@@ -367,11 +368,15 @@ namespace Microsoft.Build.Collections
             {
                 foreach (T property in other)
                 {
+                    builder ??= _backing.ToBuilder();
                     builder[property.Key] = property;
                 }
             }
 
-            _backing = builder.ToImmutable();
+            if (builder is not null)
+            {
+                _backing = builder.ToImmutable();
+            }
         }
 
         /// <summary>

--- a/src/Build/Collections/CopyOnWritePropertyDictionary.cs
+++ b/src/Build/Collections/CopyOnWritePropertyDictionary.cs
@@ -354,30 +354,24 @@ namespace Microsoft.Build.Collections
         /// <param name="other">An enumerator over the properties to add.</param>
         public void ImportProperties(IEnumerable<T> other)
         {
-            if (other is CopyOnWritePropertyDictionary<T> copyOnWriteDictionary)
-            {
-                _backing = _backing.SetItems(DictionaryItems(copyOnWriteDictionary));
-            }
-            else
-            {
-                _backing = _backing.SetItems(Items(other));
-            }
+            ImmutableDictionary<string, T>.Builder builder = _backing.ToBuilder();
 
-            static IEnumerable<KeyValuePair<string, T>> DictionaryItems(CopyOnWritePropertyDictionary<T> copyOnWriteDictionary)
+            if (other is CopyOnWritePropertyDictionary<T> copyOnWriteDictionary)
             {
                 foreach (KeyValuePair<string, T> kvp in copyOnWriteDictionary)
                 {
-                    yield return new(kvp.Value.Key, kvp.Value);
+                    builder[kvp.Value.Key] = kvp.Value;
                 }
             }
-
-            static IEnumerable<KeyValuePair<string, T>> Items(IEnumerable<T> other)
+            else
             {
                 foreach (T property in other)
                 {
-                    yield return new(property.Key, property);
+                    builder[property.Key] = property;
                 }
             }
+
+            _backing = builder.ToImmutable();
         }
 
         /// <summary>


### PR DESCRIPTION
### Context

Usage of `yield return` causes the compiler to create a state machine to handle the enumeration. For `ImportProperties()`, this amounts to ~130MB of allocations of the state machine.

![image](https://github.com/user-attachments/assets/0be5884f-3a73-4235-ac74-9462325d8603)

We used this state machine to transform the incoming `IEnumerable<T>` to a KVP to be consumed by `ImmutableDictionary<TKey, TValue>.SetItems()`.  We can avoid this by using an `ImmutableDictionary<TKey, TValue>.Builder` to avoid the need for a state machine.

After:

![image](https://github.com/user-attachments/assets/75a2923d-f314-434e-9980-9deea86334f1)


Using a builder rather than repeatedly calling `Add()` has two main advantages. `SetItems()` overwrites values if the key already exists while `Add()` will throw, and using a builder is more efficient.

### Changes Made


### Testing


### Notes
