### PR TITLE
Override SkipApplyOptimizationData to true when disabling OptProf data collection

### DIFF
--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -37,6 +37,10 @@ variables:
       value: ${{parameters.OptProfDropName}}
     - name: SourceBranch
       value: ''
+  # Override SkipApplyOptimizationData to true when disabling OptProf data collection
+  - ${{ if eq(parameters.EnableOptProf, false) }}:
+    - name: SkipApplyOptimizationData
+      value: true
   - name: EnableReleaseOneLocBuild
     value: false # disable loc for vs17.11
   - name: Codeql.Enabled

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,7 +2,7 @@
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the MIT license. See License.txt in the project root for full license information. -->
 <Project>
   <PropertyGroup>
-    <VersionPrefix>17.11.37</VersionPrefix>
+    <VersionPrefix>17.11.38</VersionPrefix>
     <DotNetFinalVersionKind>release</DotNetFinalVersionKind>
     <PackageValidationBaselineVersion>17.10.4</PackageValidationBaselineVersion>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>


### PR DESCRIPTION
When disabling OptProf data collection, build should skip apply optimization data.