### PR TITLE
Fix SdkResultFactory conflicting parameters

### DIFF
--- a/src/Build/BackEnd/Components/SdkResolution/SdkResultFactory.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/SdkResultFactory.cs
@@ -52,11 +52,11 @@ namespace Microsoft.Build.BackEnd.SdkResolution
         }
 
         public override SdkResultBase IndicateSuccess(string path,
-                                              string version,
-                                              IDictionary<string, string> propertiesToAdd,
-                                              IDictionary<string, SdkResultItem> itemsToAdd,
-                                              IEnumerable<string> warnings = null,
-                                              IDictionary<string, string> environmentVariablesToAdd = null)
+                                                      string version,
+                                                      IDictionary<string, string> propertiesToAdd,
+                                                      IDictionary<string, SdkResultItem> itemsToAdd,
+                                                      IEnumerable<string> warnings = null,
+                                                      IDictionary<string, string> environmentVariablesToAdd = null)
         {
             return new SdkResult(_sdkReference, path, version, warnings, propertiesToAdd, itemsToAdd, environmentVariablesToAdd);
         }

--- a/src/Build/BackEnd/Components/SdkResolution/SdkResultFactory.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/SdkResultFactory.cs
@@ -44,19 +44,19 @@ namespace Microsoft.Build.BackEnd.SdkResolution
 
         public override SdkResultBase IndicateSuccess(IEnumerable<string> paths,
                                                       string version,
-                                                      IDictionary<string, string> propertiesToAdd = null,
-                                                      IDictionary<string, SdkResultItem> itemsToAdd = null,
-                                                      IEnumerable<string> warnings = null)
+                                                      IDictionary<string, string> propertiesToAdd,
+                                                      IDictionary<string, SdkResultItem> itemsToAdd,
+                                                      IEnumerable<string> warnings)
         {
             return new SdkResult(_sdkReference, paths, version, propertiesToAdd, itemsToAdd, warnings);
         }
 
         public override SdkResultBase IndicateSuccess(string path,
-                                                      string version,
-                                                      IDictionary<string, string> propertiesToAdd,
-                                                      IDictionary<string, SdkResultItem> itemsToAdd,
-                                                      IEnumerable<string> warnings = null,
-                                                      IDictionary<string, string> environmentVariablesToAdd = null)
+                                              string version,
+                                              IDictionary<string, string> propertiesToAdd,
+                                              IDictionary<string, SdkResultItem> itemsToAdd,
+                                              IEnumerable<string> warnings = null,
+                                              IDictionary<string, string> environmentVariablesToAdd = null)
         {
             return new SdkResult(_sdkReference, path, version, warnings, propertiesToAdd, itemsToAdd, environmentVariablesToAdd);
         }

--- a/src/Framework/Sdk/SdkResultFactory.cs
+++ b/src/Framework/Sdk/SdkResultFactory.cs
@@ -54,13 +54,13 @@ namespace Microsoft.Build.Framework
         /// <param name="version">SDK version which should be imported</param>
         /// <param name="propertiesToAdd">Properties to set in the evaluation</param>
         /// <param name="itemsToAdd">Items to add to the evaluation</param>
-        /// <param name="warnings">Optional warnings to display during resolution.</param>
+        /// <param name="warnings">Warnings to display during resolution.</param>
         /// <returns></returns>
         public virtual SdkResult IndicateSuccess(IEnumerable<string> paths,
             string version,
-            IDictionary<string, string> propertiesToAdd = null,
-            IDictionary<string, SdkResultItem> itemsToAdd = null,
-            IEnumerable<string> warnings = null)
+            IDictionary<string, string> propertiesToAdd,
+            IDictionary<string, SdkResultItem> itemsToAdd,
+            IEnumerable<string> warnings)
         {
             throw new NotImplementedException();
         }


### PR DESCRIPTION
The recent change causes issues in VMR
https://dev.azure.com/dnceng-public/public/_build/results?buildId=1084638&view=results

`Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver/CachingWorkloadResolver.cs(89,40): error CS0121: (NETCORE_ENGINEERING_TELEMETRY=Build) The call is ambiguous between the following methods or properties: 'SdkResultFactory.IndicateSuccess(IEnumerable<string>, string, IDictionary<string, string>, IDictionary<string, SdkResultItem>, IEnumerable<string>)' and
 'SdkResultFactory.IndicateSuccess(IEnumerable<string>, string, IDictionary<string, string>, IDictionary<string, SdkResultItem>, IEnumerable<string>, IDictionary<string, string>)'`

this proves to resolve the issue
https://github.com/dotnet/dotnet/pull/1389/checks?check_run_id=45276701182