### PR TITLE
Add traces and timeout for node shutdown 

### DIFF
--- a/src/Framework/MSBuildEventSource.cs
+++ b/src/Framework/MSBuildEventSource.cs
@@ -679,6 +679,19 @@ namespace Microsoft.Build.Eventing
         {
             WriteEvent(93);
         }
+
+        [Event(94, Keywords = Keywords.All)]
+        public void NodeShutdownFailure(string additionalInformation)
+        {
+            WriteEvent(94, additionalInformation);
+        }
+
+        [Event(95, Keywords = Keywords.All)]
+        public void NodeShutdownSuccess(string additionalInformation)
+        {
+            WriteEvent(95, additionalInformation);
+        }
+
         #endregion
     }
 }


### PR DESCRIPTION
This PR helps with diagnosing and potentially working around a problem where nodes don't signal completion due to crash reason: https://developercommunity.visualstudio.com/t/Canceling-build-failed-no-path-to-conti/10933619

The selected timeout is 5 seconds, but we can extend/cut it.