### PR TITLE
Fix bootstrap issue

### DIFF
--- a/eng/BootStrapMsBuild.targets
+++ b/eng/BootStrapMsBuild.targets
@@ -251,6 +251,18 @@
     <Copy SourceFiles="@(FreshlyBuiltNetBinaries)"
           DestinationFiles="@(FreshlyBuiltNetBinaries->'$(InstallDir)sdk\$(BootstrapSdkVersion)\%(RecursiveDir)%(Filename)%(Extension)')" />
 
+    <!-- global.json in the repo root defines path to .dotnet folder with the highest priority. It ruins the core bootstrap configuration.
+         To workaround it, here we copy the root global.json to bootstrap folder and remove a problematic part from it. -->
+    <Copy SourceFiles="$(RepoRoot)\global.json" DestinationFiles="$(InstallDir)\global.json" />
+    <PropertyGroup>
+        <GlobalJsonContent>$([System.IO.File]::ReadAllText('$(InstallDir)\global.json'))</GlobalJsonContent>
+        <ModifiedContent>$([System.Text.RegularExpressions.Regex]::Replace($(GlobalJsonContent), ',?\s*"paths":\s*\[[^\]]*\]', ''))</ModifiedContent>
+    </PropertyGroup>
+
+    <WriteLinesToFile File="$(InstallDir)\global.json"
+                      Lines="$(ModifiedContent)"
+                      Overwrite="true" />
+
   </Target>
 
 </Project>


### PR DESCRIPTION
### Context
Moving to arcade10 brough a problematic change for our bootstrap logic 
https://github.com/dotnet/runtime/pull/113512

global.json contains a search path that defines content of .dotnet as a highest priority source
```
    "paths": [
      ".dotnet",
      "$host$"
    ],
```

For all the core-dependent e2e tests and runs of bootstrapped dotnet.exe, bits from local MSBuild are ignored.

### Fix

global.json has a priority logic well defined -the closest to the executable has the highest prio.
As a step in bootstrap, I take global.json from root, copy it to bootstrap/core and remove a problematic part.

Validated the change locally by running E2e test and checking what assembly was used.
The binlog with validation is attached to PR.
[test_bootstrapFix.zip](https://github.com/user-attachments/files/21126592/test_bootstrapFix.zip)
