### PR TITLE
skipping the flaky tests for now

### DIFF
--- a/src/Build.UnitTests/BackEnd/TaskHostFactory_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/TaskHostFactory_Tests.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
             _output = testOutputHelper;
         }
 
-        [Theory]
+        [Theory(Skip = "Failing on CI due to Env var issues.")]
         [InlineData(true, false)]
         [InlineData(false, true)]
         [InlineData(true, true)]
@@ -82,7 +82,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
             }
         }
 
-        [Fact]
+        [Fact(Skip = "Failing on CI due to Env var issues.")]
         public void TransiendAndSidecarNodeCanCoexist()
         {
             using (TestEnvironment env = TestEnvironment.Create())


### PR DESCRIPTION
### Context
Some of the recently introduced TaskHost tests depend on Environment variables that don't behave properly in the CI.


### Changes Made
Skipping the offending tests until we can figure out how to fix the Env var behavior.

