### PR TITLE
Bump to NuGet 5.11.6

### DIFF
--- a/eng/Packages.props
+++ b/eng/Packages.props
@@ -7,7 +7,7 @@
     <PackageReference Update="BenchmarkDotNet" Version="0.12.1" />
     <PackageReference Update="jnm2.ReferenceAssemblies.net35" Version="1.0.1" />
     <PackageReference Update="LargeAddressAware" Version="1.0.5" />
-    <PackageReference Update="Microsoft.Build.NuGetSdkResolver" Version="$(NuGetBuildTasksVersion)" />
+    <PackageReference Update="Microsoft.Build.NuGetSdkResolver" Version="5.11.2-rc.2" /><!-- Pinning to latest on the feed to allow NuGetBuildTasksVersion to update to newer -->
     <PackageReference Update="Microsoft.CodeAnalysis.Build.Tasks" Version="$(MicrosoftNetCompilersToolsetVersion)" />
     <PackageReference Update="Microsoft.DotNet.GenAPI" Version="2.1.0-prerelease-02404-02" />
     <PackageReference Update="Microsoft.Extensions.DependencyModel" Version="2.1.0" />

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -32,7 +32,7 @@
          Otherwise, this version of dotnet will not be installed and the build will error out. -->
     <DotNetCliVersion>5.0.408</DotNetCliVersion>
     <MicrosoftNetCompilersToolsetVersion>3.9.0-2.20574.26</MicrosoftNetCompilersToolsetVersion>
-    <NuGetBuildTasksVersion>5.11.1-rc.5</NuGetBuildTasksVersion>
+    <NuGetBuildTasksVersion>5.11.6</NuGetBuildTasksVersion>
   </PropertyGroup>
   <Target Name="OverrideArcadeFileVersion" AfterTargets="_InitializeAssemblyVersion">
     <!-- See https://github.com/dotnet/arcade/issues/3386


### PR DESCRIPTION
This is the latest GA version for this release and should resolve some CG alerts.
