### PR TITLE
Clean up several allocations in SetItems

### DIFF
--- a/src/Build/Utilities/EngineFileUtilities.cs
+++ b/src/Build/Utilities/EngineFileUtilities.cs
@@ -594,23 +594,6 @@ namespace Microsoft.Build.Internal
             return _regexMatchCache.Value.GetOrAdd(fileSpec, file => s_lazyWildCardExpansionRegexes.Any(regex => regex.IsMatch(fileSpec)));
         }
 
-        /// <summary>
-        /// Returns a Func that will return true IFF its argument matches any of the specified filespecs.
-        /// Assumes filespec may be escaped, so it unescapes it.
-        /// The returned function makes no escaping assumptions or escaping operations. Its callers should control escaping.
-        /// </summary>
-        /// <param name="filespecsEscaped"></param>
-        /// <param name="currentDirectory"></param>
-        /// <returns>A Func that will return true IFF its argument matches any of the specified filespecs.</returns>
-        internal static Func<string, bool> GetFileSpecMatchTester(IList<string> filespecsEscaped, string? currentDirectory)
-        {
-            var matchers = filespecsEscaped
-                .Select(fs => new Lazy<FileSpecMatcherTester>(() => FileSpecMatcherTester.Parse(currentDirectory, fs)))
-                .ToList();
-
-            return file => matchers.Any(m => m.Value.IsMatch(file));
-        }
-
         internal sealed class IOCache
         {
             private readonly Lazy<ConcurrentDictionary<string, bool>> existenceCache = new Lazy<ConcurrentDictionary<string, bool>>(() => new ConcurrentDictionary<string, bool>(), true);


### PR DESCRIPTION
Fixes #

### Context

The current implementation of `SetItems` causes several allocations from a mix of different things such as closures and delegates. We can reduce or eliminate these allocations with some small tweaks.

I see roughly 40MB of allocations saved when building Roslyn

<img width="901" height="844" alt="image" src="https://github.com/user-attachments/assets/8fedd59b-83aa-4d6e-b9fe-4252d393a4bb" />

The allocations inside of `GetFileSpecMatchTester()` were removed and these are the new allocations since I swapped over to a vanilla array

<img width="1197" height="728" alt="image" src="https://github.com/user-attachments/assets/83581378-51c8-4636-b0c4-b85e0bc3ea7b" />


### Changes Made


### Testing


### Notes
