### PR TITLE
Revert "Include resources in command line arguments produced by csc in design-time build (take 2)"

### DIFF
--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -3189,8 +3189,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       AssignTargetPaths;
       SplitResourcesByCulture;
       CreateManifestResourceNames;
-      CreateCustomManifestResourceNames;
-      AssignEmbeddedResourceOutputPaths;
+      CreateCustomManifestResourceNames
     </PrepareResourceNamesDependsOn>
   </PropertyGroup>
 
@@ -3246,17 +3245,6 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <Output TaskParameter="AssignedFiles" ItemName="_DeploymentBaseManifestWithTargetPath" />
     </AssignTargetPath>
 
-  </Target>
-
-  <!--
-    Sets OutputResource metadata on EmbeddedResource items. This metadata is used in design time build without running ResGen target.
-  -->
-  <Target Name="AssignEmbeddedResourceOutputPaths">
-    <ItemGroup>
-      <EmbeddedResource Condition="'%(EmbeddedResource.OutputResource)' == ''">
-        <OutputResource>$(IntermediateOutputPath)%(EmbeddedResource.ManifestResourceName).resources</OutputResource>
-      </EmbeddedResource>
-    </ItemGroup>
   </Target>
 
   <!--
@@ -3675,7 +3663,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     Create the _CoreCompileResourceInputs list of inputs to the CoreCompile target.
     ============================================================
     -->
-  <Target Name="_GenerateCompileInputs" DependsOnTargets="PrepareResourceNames">
+  <Target Name="_GenerateCompileInputs">
 
     <MSBuildInternalMessage
       Condition="'@(ManifestResourceWithNoCulture)'!='' and '%(ManifestResourceWithNoCulture.EmittedForCompatibilityOnly)'==''"


### PR DESCRIPTION
Reverts dotnet/msbuild#11949

it causes perf regressions, need to discuss the change separately. 
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2528565