### PR TITLE
Add comment for updating MicrosoftCodeAnalysisCollectionsVersion

### DIFF
--- a/eng/Packages.props
+++ b/eng/Packages.props
@@ -10,8 +10,8 @@
   <ItemGroup>
     <PackageVersion Include="Microsoft.Build.NuGetSdkResolver" Version="$(NuGetBuildTasksVersion)" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Collections" Version="$(MicrosoftCodeAnalysisCollectionsVersion)" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.Contracts" Version="$(MicrosoftCodeAnalysisCollectionsVersion)" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.PooledObjects" Version="$(MicrosoftCodeAnalysisCollectionsVersion)" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Contracts" Version="$(MicrosoftCodeAnalysisContractsVersion)" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.PooledObjects" Version="$(MicrosoftCodeAnalysisPooledObjectsVersion)" />
     <PackageVersion Include="Microsoft.DotNet.XUnitExtensions" Version="$(MicrosoftDotNetXUnitExtensionsVersion)" />
     <PackageVersion Include="Microsoft.IO.Redist" Version="$(MicrosoftIORedistVersion)" />
     <PackageVersion Include="Microsoft.Net.Compilers.Toolset" Version="$(MicrosoftNetCompilersToolsetVersion)" Condition="'$(UsingToolMicrosoftNetCompilers)' != 'true'" />

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -85,7 +85,7 @@
   </PropertyGroup>
   <PropertyGroup>
   <!-- These are manually updated since they are text-only source packages and can't be
-       overriden in source-build, see https://github.com/dotnet/msbuild/issues/6960.
+       overridden in source-build, see https://github.com/dotnet/msbuild/issues/6960.
        When updating the version make sure to add the new version to source-build-reference-packages first. -->
     <MicrosoftCodeAnalysisCollectionsVersion>5.0.0-1.25277.114</MicrosoftCodeAnalysisCollectionsVersion>
     <MicrosoftCodeAnalysisContractsVersion>5.0.0-1.25277.114</MicrosoftCodeAnalysisContractsVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -79,10 +79,17 @@
     <!-- DotNetCliVersion MUST match the dotnet version in global.json.
          Otherwise, this version of dotnet will not be installed and the build will error out. -->
     <DotNetCliVersion>$([System.Text.RegularExpressions.Regex]::Match($([System.IO.File]::ReadAllText('$(MSBuildThisFileDirectory)..\global.json')), '"dotnet": "([^"]*)"').Groups.get_Item(1))</DotNetCliVersion>
-    <MicrosoftCodeAnalysisCollectionsVersion>5.0.0-1.25277.114</MicrosoftCodeAnalysisCollectionsVersion>
     <MicrosoftDotNetXUnitExtensionsVersion>10.0.0-beta.25358.3</MicrosoftDotNetXUnitExtensionsVersion>
     <NuGetBuildTasksVersion>6.15.0-preview.1.86</NuGetBuildTasksVersion>
     <MicrosoftNetCompilersToolsetVersion>5.0.0-1.25361.3</MicrosoftNetCompilersToolsetVersion>
+  </PropertyGroup>
+  <PropertyGroup>
+  <!-- These are manually updated since they are text-only source packages and can't be
+       overriden in source-build, see https://github.com/dotnet/msbuild/issues/6960.
+       When updating the version make sure to add the new version to source-build-reference-packages first. -->
+    <MicrosoftCodeAnalysisCollectionsVersion>5.0.0-1.25277.114</MicrosoftCodeAnalysisCollectionsVersion>
+    <MicrosoftCodeAnalysisContractsVersion>5.0.0-1.25277.114</MicrosoftCodeAnalysisContractsVersion>
+    <MicrosoftCodeAnalysisPooledObjectsVersion>5.0.0-1.25277.114</MicrosoftCodeAnalysisPooledObjectsVersion>
   </PropertyGroup>
   <PropertyGroup>
     <BootstrapSdkVersion>10.0.100-preview.6.25315.102</BootstrapSdkVersion>


### PR DESCRIPTION
https://github.com/dotnet/msbuild/pull/12161 broke in the VMR dependency flow PR https://github.com/dotnet/dotnet/pull/1490 because this version isn't in source-build-reference-packages.

Add a comment so this is clearer when updating next time.