### PR TITLE
Avoid allocating closures in translator calls.

### DIFF
--- a/src/Framework/BinaryTranslator.cs
+++ b/src/Framework/BinaryTranslator.cs
@@ -347,6 +347,14 @@ namespace Microsoft.Build.BackEnd
                 list = (List<T>)listAsInterface;
             }
 
+            /// <inheritdoc/>
+            public void Translate<T>(ref List<T> list, ObjectTranslatorWithValueFactory<T> objectTranslator, NodePacketValueFactory<T> valueFactory)
+            {
+                IList<T> listAsInterface = list;
+                Translate(ref listAsInterface, objectTranslator, valueFactory, count => new List<T>(count));
+                list = (List<T>)listAsInterface;
+            }
+
             public void Translate<T, L>(ref IList<T> list, ObjectTranslator<T> objectTranslator, NodePacketCollectionCreator<L> collectionFactory) where L : IList<T>
             {
                 if (!TranslateNullable(list))
@@ -362,6 +370,25 @@ namespace Microsoft.Build.BackEnd
                     T value = default(T);
 
                     objectTranslator(this, ref value);
+                    list.Add(value);
+                }
+            }
+
+            public void Translate<T, L>(ref IList<T> list, ObjectTranslatorWithValueFactory<T> objectTranslator, NodePacketValueFactory<T> valueFactory, NodePacketCollectionCreator<L> collectionFactory) where L : IList<T>
+            {
+                if (!TranslateNullable(list))
+                {
+                    return;
+                }
+
+                int count = _reader.ReadInt32();
+                list = collectionFactory(count);
+
+                for (int i = 0; i < count; i++)
+                {
+                    T value = default(T);
+
+                    objectTranslator(this, valueFactory, ref value);
                     list.Add(value);
                 }
             }
@@ -551,13 +578,8 @@ namespace Microsoft.Build.BackEnd
                 }
             }
 
-            /// <summary>
-            /// Translates an array of objects using an <see cref="ObjectTranslator{T}"/>
-            /// </summary>
-            /// <typeparam name="T">The reference type.</typeparam>
-            /// <param name="array">The array to be translated.</param>
-            /// <param name="objectTranslator">The translator to use for the elements in the array</param>
-            public void TranslateArray<T>(ref T[] array, ObjectTranslator<T> objectTranslator)
+            /// <inheritdoc/>
+            public void TranslateArray<T>(ref T[] array, ObjectTranslatorWithValueFactory<T> objectTranslator, NodePacketValueFactory<T> valueFactory)
             {
                 if (!TranslateNullable(array))
                 {
@@ -569,7 +591,7 @@ namespace Microsoft.Build.BackEnd
 
                 for (int i = 0; i < count; i++)
                 {
-                    objectTranslator(this, ref array[i]);
+                    objectTranslator(this, valueFactory, ref array[i]);
                 }
             }
 
@@ -680,14 +702,34 @@ namespace Microsoft.Build.BackEnd
                 }
             }
 
-            /// <summary>
-            /// Translates a dictionary of { string, T }.
-            /// </summary>
-            /// <typeparam name="T">The reference type for the values</typeparam>
-            /// <param name="dictionary">The dictionary to be translated.</param>
-            /// <param name="comparer">The comparer used to instantiate the dictionary.</param>
-            /// <param name="objectTranslator">The translator to use for the values in the dictionary</param>
-            public void TranslateDictionary<T>(ref Dictionary<string, T> dictionary, IEqualityComparer<string> comparer, ObjectTranslator<T> objectTranslator)
+            /// <inheritdoc/>
+            public void TranslateDictionary<K, V>(
+                ref IDictionary<K, V> dictionary,
+                ObjectTranslator<K> keyTranslator,
+                ObjectTranslatorWithValueFactory<V> valueTranslator,
+                NodePacketValueFactory<V> valueFactory,
+                NodePacketCollectionCreator<IDictionary<K, V>> dictionaryCreator)
+            {
+                if (!TranslateNullable(dictionary))
+                {
+                    return;
+                }
+
+                int count = _reader.ReadInt32();
+                dictionary = dictionaryCreator(count);
+
+                for (int i = 0; i < count; i++)
+                {
+                    K key = default(K);
+                    keyTranslator(this, ref key);
+                    V value = default(V);
+                    valueTranslator(this, valueFactory, ref value);
+                    dictionary[key] = value;
+                }
+            }
+
+            /// <inheritdoc/>
+            public void TranslateDictionary<T>(ref Dictionary<string, T> dictionary, IEqualityComparer<string> comparer, ObjectTranslatorWithValueFactory<T> objectTranslator, NodePacketValueFactory<T> valueFactory)
                 where T : class
             {
                 if (!TranslateNullable(dictionary))
@@ -703,19 +745,13 @@ namespace Microsoft.Build.BackEnd
                     string key = null;
                     Translate(ref key);
                     T value = null;
-                    objectTranslator(this, ref value);
+                    objectTranslator(this, valueFactory, ref value);
                     dictionary[key] = value;
                 }
             }
 
-            /// <summary>
-            /// Translates a dictionary of { string, T } for dictionaries with public parameterless constructors.
-            /// </summary>
-            /// <typeparam name="D">The reference type for the dictionary.</typeparam>
-            /// <typeparam name="T">The reference type for values in the dictionary.</typeparam>
-            /// <param name="dictionary">The dictionary to be translated.</param>
-            /// <param name="objectTranslator">The translator to use for the values in the dictionary</param>
-            public void TranslateDictionary<D, T>(ref D dictionary, ObjectTranslator<T> objectTranslator)
+            /// <inheritdoc/>
+            public void TranslateDictionary<D, T>(ref D dictionary, ObjectTranslatorWithValueFactory<T> objectTranslator, NodePacketValueFactory<T> valueFactory)
                 where D : IDictionary<string, T>, new()
                 where T : class
             {
@@ -732,20 +768,13 @@ namespace Microsoft.Build.BackEnd
                     string key = null;
                     Translate(ref key);
                     T value = null;
-                    objectTranslator(this, ref value);
+                    objectTranslator(this, valueFactory, ref value);
                     dictionary[key] = value;
                 }
             }
 
-            /// <summary>
-            /// Translates a dictionary of { string, T } for dictionaries with public parameterless constructors.
-            /// </summary>
-            /// <typeparam name="D">The reference type for the dictionary.</typeparam>
-            /// <typeparam name="T">The reference type for values in the dictionary.</typeparam>
-            /// <param name="dictionary">The dictionary to be translated.</param>
-            /// <param name="objectTranslator">The translator to use for the values in the dictionary</param>
-            /// <param name="dictionaryCreator">The delegate used to instantiate the dictionary.</param>
-            public void TranslateDictionary<D, T>(ref D dictionary, ObjectTranslator<T> objectTranslator, NodePacketCollectionCreator<D> dictionaryCreator)
+            /// <inheritdoc/>
+            public void TranslateDictionary<D, T>(ref D dictionary, ObjectTranslatorWithValueFactory<T> objectTranslator, NodePacketValueFactory<T> valueFactory, NodePacketCollectionCreator<D> dictionaryCreator)
                 where D : IDictionary<string, T>
                 where T : class
             {
@@ -762,7 +791,7 @@ namespace Microsoft.Build.BackEnd
                     string key = null;
                     Translate(ref key);
                     T value = null;
-                    objectTranslator(this, ref value);
+                    objectTranslator(this, valueFactory, ref value);
                     dictionary[key] = value;
                 }
             }
@@ -1142,6 +1171,24 @@ namespace Microsoft.Build.BackEnd
                 }
             }
 
+            /// <inheritdoc/>
+            public void Translate<T>(ref List<T> list, ObjectTranslatorWithValueFactory<T> objectTranslator, NodePacketValueFactory<T> valueFactory)
+            {
+                if (!TranslateNullable(list))
+                {
+                    return;
+                }
+
+                int count = list.Count;
+                _writer.Write(count);
+
+                for (int i = 0; i < count; i++)
+                {
+                    T value = list[i];
+                    objectTranslator(this, valueFactory, ref value);
+                }
+            }
+
             /// <summary>
             /// Translates a list of T using an <see cref="ObjectTranslator{T}"/>
             /// </summary>
@@ -1164,6 +1211,24 @@ namespace Microsoft.Build.BackEnd
                 {
                     T value = list[i];
                     objectTranslator(this, ref value);
+                }
+            }
+
+            /// <inheritdoc/>
+            public void Translate<T, L>(ref IList<T> list, ObjectTranslatorWithValueFactory<T> objectTranslator, NodePacketValueFactory<T> valueFactory, NodePacketCollectionCreator<L> collectionFactory) where L : IList<T>
+            {
+                if (!TranslateNullable(list))
+                {
+                    return;
+                }
+
+                int count = list.Count;
+                _writer.Write(count);
+
+                for (int i = 0; i < count; i++)
+                {
+                    T value = list[i];
+                    objectTranslator(this, valueFactory, ref value);
                 }
             }
 
@@ -1339,13 +1404,8 @@ namespace Microsoft.Build.BackEnd
                 }
             }
 
-            /// <summary>
-            /// Translates an array of objects using an <see cref="ObjectTranslator{T}"/>
-            /// </summary>
-            /// <typeparam name="T">The reference type.</typeparam>
-            /// <param name="array">The array to be translated.</param>
-            /// <param name="objectTranslator">The translator to use for the elements in the array</param>
-            public void TranslateArray<T>(ref T[] array, ObjectTranslator<T> objectTranslator)
+            /// <inheritdoc/>
+            public void TranslateArray<T>(ref T[] array, ObjectTranslatorWithValueFactory<T> objectTranslator, NodePacketValueFactory<T> valueFactory)
             {
                 if (!TranslateNullable(array))
                 {
@@ -1357,7 +1417,7 @@ namespace Microsoft.Build.BackEnd
 
                 for (int i = 0; i < count; i++)
                 {
-                    objectTranslator(this, ref array[i]);
+                    objectTranslator(this, valueFactory, ref array[i]);
                 }
             }
 
@@ -1480,14 +1540,33 @@ namespace Microsoft.Build.BackEnd
                 }
             }
 
-            /// <summary>
-            /// Translates a dictionary of { string, T }.
-            /// </summary>
-            /// <typeparam name="T">The reference type for the values, which implements INodePacketTranslatable.</typeparam>
-            /// <param name="dictionary">The dictionary to be translated.</param>
-            /// <param name="comparer">The comparer used to instantiate the dictionary.</param>
-            /// <param name="objectTranslator">The translator to use for the values in the dictionary</param>
-            public void TranslateDictionary<T>(ref Dictionary<string, T> dictionary, IEqualityComparer<string> comparer, ObjectTranslator<T> objectTranslator)
+            /// <inheritdoc/>
+            public void TranslateDictionary<K, V>(
+                ref IDictionary<K, V> dictionary,
+                ObjectTranslator<K> keyTranslator,
+                ObjectTranslatorWithValueFactory<V> valueTranslator,
+                NodePacketValueFactory<V> valueFactory,
+                NodePacketCollectionCreator<IDictionary<K, V>> collectionCreator)
+            {
+                if (!TranslateNullable(dictionary))
+                {
+                    return;
+                }
+
+                int count = dictionary.Count;
+                _writer.Write(count);
+
+                foreach (KeyValuePair<K, V> pair in dictionary)
+                {
+                    K key = pair.Key;
+                    keyTranslator(this, ref key);
+                    V value = pair.Value;
+                    valueTranslator(this, valueFactory, ref value);
+                }
+            }
+
+            /// <inheritdoc/>
+            public void TranslateDictionary<T>(ref Dictionary<string, T> dictionary, IEqualityComparer<string> comparer, ObjectTranslatorWithValueFactory<T> objectTranslator, NodePacketValueFactory<T> valueFactory)
                 where T : class
             {
                 if (!TranslateNullable(dictionary))
@@ -1503,18 +1582,12 @@ namespace Microsoft.Build.BackEnd
                     string key = pair.Key;
                     Translate(ref key);
                     T value = pair.Value;
-                    objectTranslator(this, ref value);
+                    objectTranslator(this, valueFactory, ref value);
                 }
             }
 
-            /// <summary>
-            /// Translates a dictionary of { string, T } for dictionaries with public parameterless constructors.
-            /// </summary>
-            /// <typeparam name="D">The reference type for the dictionary.</typeparam>
-            /// <typeparam name="T">The reference type for values in the dictionary.</typeparam>
-            /// <param name="dictionary">The dictionary to be translated.</param>
-            /// <param name="objectTranslator">The translator to use for the values in the dictionary</param>
-            public void TranslateDictionary<D, T>(ref D dictionary, ObjectTranslator<T> objectTranslator)
+            /// <inheritdoc/>
+            public void TranslateDictionary<D, T>(ref D dictionary, ObjectTranslatorWithValueFactory<T> objectTranslator, NodePacketValueFactory<T> valueFactory)
                 where D : IDictionary<string, T>, new()
                 where T : class
             {
@@ -1531,19 +1604,12 @@ namespace Microsoft.Build.BackEnd
                     string key = pair.Key;
                     Translate(ref key);
                     T value = pair.Value;
-                    objectTranslator(this, ref value);
+                    objectTranslator(this, valueFactory, ref value);
                 }
             }
 
-            /// <summary>
-            /// Translates a dictionary of { string, T } for dictionaries with public parameterless constructors.
-            /// </summary>
-            /// <typeparam name="D">The reference type for the dictionary.</typeparam>
-            /// <typeparam name="T">The reference type for values in the dictionary.</typeparam>
-            /// <param name="dictionary">The dictionary to be translated.</param>
-            /// <param name="objectTranslator">The translator to use for the values in the dictionary</param>
-            /// <param name="dictionaryCreator">The delegate used to instantiate the dictionary.</param>
-            public void TranslateDictionary<D, T>(ref D dictionary, ObjectTranslator<T> objectTranslator, NodePacketCollectionCreator<D> dictionaryCreator)
+            /// <inheritdoc/>
+            public void TranslateDictionary<D, T>(ref D dictionary, ObjectTranslatorWithValueFactory<T> objectTranslator, NodePacketValueFactory<T> valueFactory, NodePacketCollectionCreator<D> dictionaryCreator)
                 where D : IDictionary<string, T>
                 where T : class
             {
@@ -1560,7 +1626,7 @@ namespace Microsoft.Build.BackEnd
                     string key = pair.Key;
                     Translate(ref key);
                     T value = pair.Value;
-                    objectTranslator(this, ref value);
+                    objectTranslator(this, valueFactory, ref value);
                 }
             }
 

--- a/src/Framework/ITranslator.cs
+++ b/src/Framework/ITranslator.cs
@@ -26,6 +26,14 @@ namespace Microsoft.Build.BackEnd
     internal delegate void ObjectTranslator<T>(ITranslator translator, ref T objectToTranslate);
 
     /// <summary>
+    /// Delegate for users that want to translate an arbitrary structure that doesn't implement <see cref="ITranslatable"/> (e.g. translating a complex collection)
+    /// </summary>
+    /// <param name="translator">the translator</param>
+    /// <param name="valueFactory">The factory to use to create the value.</param>
+    /// <param name="objectToTranslate">the object to translate</param>
+    internal delegate void ObjectTranslatorWithValueFactory<T>(ITranslator translator, NodePacketValueFactory<T> valueFactory, ref T objectToTranslate);
+
+    /// <summary>
     /// This delegate is used to create arbitrary collection types for serialization.
     /// </summary>
     /// <typeparam name="T">The type of dictionary to be created.</typeparam>
@@ -191,6 +199,15 @@ namespace Microsoft.Build.BackEnd
         void Translate<T>(ref List<T> list, ObjectTranslator<T> objectTranslator);
 
         /// <summary>
+        /// Translates a list of T using an <see cref="ObjectTranslator{T}"/>
+        /// </summary>
+        /// <param name="list">The list to be translated.</param>
+        /// <param name="objectTranslator">The translator to use for the items in the list</param>
+        /// <param name="valueFactory">The factory to use to create the value.</param>
+        /// <typeparam name="T">A TaskItemType</typeparam>
+        void Translate<T>(ref List<T> list, ObjectTranslatorWithValueFactory<T> objectTranslator, NodePacketValueFactory<T> valueFactory);
+
+        /// <summary>
         /// Translates a list of T using an <see cref="ObjectTranslator{T}"/> anda collection factory
         /// </summary>
         /// <param name="list">The list to be translated.</param>
@@ -199,6 +216,17 @@ namespace Microsoft.Build.BackEnd
         /// <typeparam name="L">An IList subtype</typeparam>
         /// <param name="collectionFactory">factory to create a collection</param>
         void Translate<T, L>(ref IList<T> list, ObjectTranslator<T> objectTranslator, NodePacketCollectionCreator<L> collectionFactory) where L : IList<T>;
+
+        /// <summary>
+        /// Translates a list of T using an <see cref="ObjectTranslator{T}"/> anda collection factory
+        /// </summary>
+        /// <param name="list">The list to be translated.</param>
+        /// <param name="objectTranslator">The translator to use for the items in the list</param>
+        /// <param name="valueFactory">The factory to use to create the value.</param>
+        /// <typeparam name="T">An ITranslatable subtype</typeparam>
+        /// <typeparam name="L">An IList subtype</typeparam>
+        /// <param name="collectionFactory">factory to create a collection</param>
+        void Translate<T, L>(ref IList<T> list, ObjectTranslatorWithValueFactory<T> objectTranslator, NodePacketValueFactory<T> valueFactory, NodePacketCollectionCreator<L> collectionFactory) where L : IList<T>;
 
         /// <summary>
         /// Translates a collection of T into the specified type using an <see cref="ObjectTranslator{T}"/> and <see cref="NodePacketCollectionCreator{L}"/>
@@ -298,7 +326,8 @@ namespace Microsoft.Build.BackEnd
         /// <typeparam name="T">The reference type.</typeparam>
         /// <param name="array">The array to be translated.</param>
         /// <param name="objectTranslator">The translator to use for the elements in the array.</param>
-        void TranslateArray<T>(ref T[] array, ObjectTranslator<T> objectTranslator);
+        /// <param name="valueFactory">The factory to use to create the value.</param>
+        void TranslateArray<T>(ref T[] array, ObjectTranslatorWithValueFactory<T> objectTranslator, NodePacketValueFactory<T> valueFactory);
 
         /// <summary>
         /// Translates a dictionary of { string, string }.
@@ -326,6 +355,8 @@ namespace Microsoft.Build.BackEnd
 
         void TranslateDictionary<K, V>(ref IDictionary<K, V> dictionary, ObjectTranslator<K> keyTranslator, ObjectTranslator<V> valueTranslator, NodePacketCollectionCreator<IDictionary<K, V>> dictionaryCreator);
 
+        void TranslateDictionary<K, V>(ref IDictionary<K, V> dictionary, ObjectTranslator<K> keyTranslator, ObjectTranslatorWithValueFactory<V> valueTranslator, NodePacketValueFactory<V> valueFactory, NodePacketCollectionCreator<IDictionary<K, V>> dictionaryCreator);
+
         /// <summary>
         /// Translates a dictionary of { string, T }.
         /// </summary>
@@ -333,7 +364,8 @@ namespace Microsoft.Build.BackEnd
         /// <param name="dictionary">The dictionary to be translated.</param>
         /// <param name="comparer">The comparer used to instantiate the dictionary.</param>
         /// <param name="objectTranslator">The translator to use for the values in the dictionary</param>
-        void TranslateDictionary<T>(ref Dictionary<string, T> dictionary, IEqualityComparer<string> comparer, ObjectTranslator<T> objectTranslator)
+        /// /// <param name="valueFactory">The factory to use to create the value.</param>
+        void TranslateDictionary<T>(ref Dictionary<string, T> dictionary, IEqualityComparer<string> comparer, ObjectTranslatorWithValueFactory<T> objectTranslator, NodePacketValueFactory<T> valueFactory)
             where T : class;
 
         /// <summary>
@@ -343,7 +375,8 @@ namespace Microsoft.Build.BackEnd
         /// <typeparam name="T">The reference type for values in the dictionary.</typeparam>
         /// <param name="dictionary">The dictionary to be translated.</param>
         /// <param name="objectTranslator">The translator to use for the values in the dictionary.</param>
-        void TranslateDictionary<D, T>(ref D dictionary, ObjectTranslator<T> objectTranslator)
+        /// <param name="valueFactory">The factory to use to create the value.</param>
+        void TranslateDictionary<D, T>(ref D dictionary, ObjectTranslatorWithValueFactory<T> objectTranslator, NodePacketValueFactory<T> valueFactory)
             where D : IDictionary<string, T>, new()
             where T : class;
 
@@ -354,8 +387,9 @@ namespace Microsoft.Build.BackEnd
         /// <typeparam name="T">The reference type for values in the dictionary.</typeparam>
         /// <param name="dictionary">The dictionary to be translated.</param>
         /// <param name="objectTranslator">The translator to use for the values in the dictionary</param>
+        /// /// <param name="valueFactory">The factory to use to create the value.</param>
         /// <param name="collectionCreator">A factory used to create the dictionary.</param>
-        void TranslateDictionary<D, T>(ref D dictionary, ObjectTranslator<T> objectTranslator, NodePacketCollectionCreator<D> collectionCreator)
+        void TranslateDictionary<D, T>(ref D dictionary, ObjectTranslatorWithValueFactory<T> objectTranslator, NodePacketValueFactory<T> valueFactory, NodePacketCollectionCreator<D> collectionCreator)
             where D : IDictionary<string, T>
             where T : class;
 

--- a/src/Shared/TranslatorHelpers.cs
+++ b/src/Shared/TranslatorHelpers.cs
@@ -48,9 +48,9 @@ namespace Microsoft.Build.BackEnd
             }
         }
 
-        private static ObjectTranslator<T> AdaptFactory<T>(NodePacketValueFactory<T> valueFactory) where T : ITranslatable
+        private static ObjectTranslatorWithValueFactory<T> AdaptFactory<T>(NodePacketValueFactory<T> valueFactory) where T : ITranslatable
         {
-            void TranslateUsingValueFactory(ITranslator translator, ref T objectToTranslate)
+            static void TranslateUsingValueFactory(ITranslator translator, NodePacketValueFactory<T> valueFactory, ref T objectToTranslate)
             {
                 translator.Translate(ref objectToTranslate, valueFactory);
             }
@@ -63,7 +63,7 @@ namespace Microsoft.Build.BackEnd
             ref List<T> list,
             NodePacketValueFactory<T> valueFactory) where T : class, ITranslatable
         {
-            translator.Translate(ref list, AdaptFactory(valueFactory));
+            translator.Translate(ref list, AdaptFactory(valueFactory), valueFactory);
         }
 
         public static void Translate<T, L>(
@@ -72,7 +72,7 @@ namespace Microsoft.Build.BackEnd
             NodePacketValueFactory<T> valueFactory,
             NodePacketCollectionCreator<L> collectionFactory) where L : IList<T> where T : ITranslatable
         {
-            translator.Translate(ref list, AdaptFactory(valueFactory), collectionFactory);
+            translator.Translate(ref list, AdaptFactory(valueFactory), valueFactory, collectionFactory);
         }
 
         public static void TranslateArray<T>(
@@ -80,7 +80,7 @@ namespace Microsoft.Build.BackEnd
             ref T[] array,
             NodePacketValueFactory<T> valueFactory) where T : class, ITranslatable
         {
-            translator.TranslateArray(ref array, AdaptFactory(valueFactory));
+            translator.TranslateArray(ref array, AdaptFactory(valueFactory), valueFactory);
         }
 
         public static void TranslateDictionary<T>(
@@ -89,7 +89,7 @@ namespace Microsoft.Build.BackEnd
             IEqualityComparer<string> comparer,
             NodePacketValueFactory<T> valueFactory) where T : class, ITranslatable
         {
-            translator.TranslateDictionary(ref dictionary, comparer, AdaptFactory(valueFactory));
+            translator.TranslateDictionary(ref dictionary, comparer, AdaptFactory(valueFactory), valueFactory);
         }
 
         public static void InternDictionary(
@@ -118,6 +118,7 @@ namespace Microsoft.Build.BackEnd
                 ref localDict,
                 (ITranslator translator, ref string key) => translator.Intern(ref key),
                 AdaptFactory(valueFactory),
+                valueFactory,
                 capacity => new Dictionary<string, T>(capacity, stringComparer));
             dictionary = (Dictionary<string, T>)localDict;
         }
@@ -150,6 +151,7 @@ namespace Microsoft.Build.BackEnd
                 ref localDict,
                 (ITranslator translator, ref string key) => translator.InternPath(ref key),
                 AdaptFactory(valueFactory),
+                valueFactory,
                 capacity => new Dictionary<string, T>(capacity, stringComparer));
             dictionary = (Dictionary<string, T>)localDict;
         }
@@ -161,7 +163,7 @@ namespace Microsoft.Build.BackEnd
             where D : IDictionary<string, T>, new()
             where T : class, ITranslatable
         {
-            translator.TranslateDictionary(ref dictionary, AdaptFactory(valueFactory));
+            translator.TranslateDictionary(ref dictionary, AdaptFactory(valueFactory), valueFactory);
         }
 
         public static void TranslateDictionary<D, T>(
@@ -172,7 +174,7 @@ namespace Microsoft.Build.BackEnd
             where D : IDictionary<string, T>
             where T : class, ITranslatable
         {
-            translator.TranslateDictionary(ref dictionary, AdaptFactory(valueFactory), collectionCreator);
+            translator.TranslateDictionary(ref dictionary, AdaptFactory(valueFactory), valueFactory, collectionCreator);
         }
 
 #if !TASKHOST


### PR DESCRIPTION
Fixes #

### Context

there are a non-trivial amount of allocations caused by the creation of a closure object in Translate paths

<img width="1139" height="271" alt="image" src="https://github.com/user-attachments/assets/2d038af7-7757-4d01-b827-e9e200b63e11" />

Rather than closing over the value factory, the delegate and consumers can be updated to take the value factory as a parameter.

Before:
<img width="1149" height="388" alt="image" src="https://github.com/user-attachments/assets/03650f5b-1d1a-4409-9972-0d46583d03a4" />

After:
<img width="1253" height="312" alt="image" src="https://github.com/user-attachments/assets/b6cf7a98-a30f-4778-a912-a980a76a90a7" />


### Changes Made


### Testing


### Notes
