### PR TITLE
Perf: Directly use ImmutableDictionary for TaskItem metadata

### DIFF
--- a/src/Build.UnitTests/Instance/TaskItem_Tests.cs
+++ b/src/Build.UnitTests/Instance/TaskItem_Tests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.Build.BackEnd;
 using Microsoft.Build.Collections;
@@ -191,11 +192,12 @@ namespace Microsoft.Build.UnitTests.OM.Instance
             item.MetadataNames.Cast<string>().ShouldBeSetEquivalentTo(new[] { "a", "b" }.Concat(s_builtInMetadataNames));
             item.MetadataCount.ShouldBe(s_builtInMetadataNames.Length + 2);
             item.DirectMetadataCount.ShouldBe(1);
+            item.HasCustomMetadata.ShouldBeTrue();
 
-            ICopyOnWritePropertyDictionary<ProjectMetadataInstance> metadata = item.MetadataCollection;
+            ImmutableDictionary<string, string> metadata = item.MetadataCollection;
             metadata.Count.ShouldBe(2);
-            metadata["a"].EvaluatedValue.ShouldBe("override");
-            metadata["b"].EvaluatedValue.ShouldBe("base");
+            metadata["a"].ShouldBe("override");
+            metadata["b"].ShouldBe("base");
 
             item.EnumerateMetadata().ShouldBeSetEquivalentTo(new KeyValuePair<string, string>[] { new("a", "override"), new("b", "base") });
 
@@ -219,12 +221,12 @@ namespace Microsoft.Build.UnitTests.OM.Instance
                     }
                 }
 
-                CopyOnWritePropertyDictionary<ProjectMetadataInstance> directMetadata = new();
+                ImmutableDictionary<string, string> directMetadata = ImmutableDictionaryExtensions.EmptyMetadata;
                 if (metadata is not null)
                 {
                     foreach ((string name, string value) in metadata)
                     {
-                        directMetadata.Set(new(name, value));
+                        directMetadata = directMetadata.SetItem(name, value);
                     }
                 }
 

--- a/src/Build/BackEnd/TaskExecutionHost/TaskExecutionHost.cs
+++ b/src/Build/BackEnd/TaskExecutionHost/TaskExecutionHost.cs
@@ -1412,8 +1412,19 @@ namespace Microsoft.Build.BackEnd
                                     // Probably a Microsoft.Build.Utilities.TaskItem.  Not quite as good, but we can still preserve escaping.
                                     newItem = new ProjectItemInstance(_projectInstance, outputTargetName, outputAsITaskItem2.EvaluatedIncludeEscaped, parameterLocationEscaped);
 
-                                    // It would be nice to be copy-on-write here, but Utilities.TaskItem doesn't know about CopyOnWritePropertyDictionary.
-                                    newItem.SetMetadataOnTaskOutput(outputAsITaskItem2.CloneCustomMetadataEscaped().Cast<KeyValuePair<string, string>>());
+                                    // If found, directly pass the backing copy-on-write dictionary.
+                                    // Otherwise, retrieve a cloned dictionary from the task item.
+                                    IMetadataContainer outputAsMetadataContainer = output as IMetadataContainer;
+                                    SerializableMetadata backingMetadata = outputAsMetadataContainer?.BackingMetadata ?? default;
+
+                                    if (backingMetadata.HasValue)
+                                    {
+                                        newItem.SetMetadataOnTaskOutput(backingMetadata.Dictionary);
+                                    }
+                                    else
+                                    {
+                                        newItem.SetMetadataOnTaskOutput(outputAsITaskItem2.CloneCustomMetadataEscaped().Cast<KeyValuePair<string, string>>());
+                                    }
                                 }
                                 else
                                 {

--- a/src/Build/Instance/ProjectInstance.cs
+++ b/src/Build/Instance/ProjectInstance.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
@@ -1004,33 +1005,18 @@ namespace Microsoft.Build.Execution
                 result = instanceProvider.ImmutableInstance;
                 if (result == null)
                 {
-                    IDictionary<string, ProjectMetadataInstance> metadata = null;
+                    ImmutableDictionary<string, string> metadata = null;
                     if (projectItemDefinition.Metadata is IDictionary<string, ProjectMetadata> linkedMetadataDict)
                     {
-                        metadata = new ImmutableElementCollectionConverter<ProjectMetadata, ProjectMetadataInstance>(
-                                        linkedMetadataDict,
-                                        constrainedProjectElements: null,
-                                        ConvertCachedProjectMetadataToInstance);
+                        IEnumerable<KeyValuePair<string, string>> projectMetadataInstances = linkedMetadataDict.Select(directMetadatum
+                            => new KeyValuePair<string, string>(directMetadatum.Key, directMetadatum.Value.EvaluatedValueEscaped));
+
+                        metadata = ImmutableDictionaryExtensions.EmptyMetadata
+                            .SetItems(projectMetadataInstances, ProjectMetadataInstance.VerifyThrowReservedName);
                     }
 
                     result = instanceProvider.GetOrSetImmutableInstance(
                         new ProjectItemDefinitionInstance(projectItemDefinition.ItemType, metadata));
-                }
-            }
-
-            return result;
-        }
-
-        private static ProjectMetadataInstance ConvertCachedProjectMetadataToInstance(ProjectMetadata projectMetadata)
-        {
-            ProjectMetadataInstance result = null;
-
-            if (projectMetadata is IImmutableInstanceProvider<ProjectMetadataInstance> instanceProvider)
-            {
-                result = instanceProvider.ImmutableInstance;
-                if (result == null)
-                {
-                    result = instanceProvider.GetOrSetImmutableInstance(new ProjectMetadataInstance(projectMetadata));
                 }
             }
 
@@ -3424,13 +3410,14 @@ namespace Microsoft.Build.Execution
                 }
             }
 
-            CopyOnWritePropertyDictionary<ProjectMetadataInstance> directMetadata = null;
+            ImmutableDictionary<string, string> directMetadata = null;
             if (item.DirectMetadata != null)
             {
-                directMetadata = new CopyOnWritePropertyDictionary<ProjectMetadataInstance>();
+                IEnumerable<KeyValuePair<string, string>> projectMetadataInstances = item.DirectMetadata.Select(directMetadatum
+                    => new KeyValuePair<string, string>(directMetadatum.Name, directMetadatum.EvaluatedValueEscaped));
 
-                IEnumerable<ProjectMetadataInstance> projectMetadataInstances = item.DirectMetadata.Select(directMetadatum => new ProjectMetadataInstance(directMetadatum));
-                directMetadata.ImportProperties(projectMetadataInstances);
+                directMetadata = ImmutableDictionaryExtensions.EmptyMetadata
+                    .SetItems(projectMetadataInstances, ProjectMetadataInstance.VerifyThrowReservedName);
             }
 
             GetEvaluatedIncludesFromProjectItem(
@@ -3476,20 +3463,14 @@ namespace Microsoft.Build.Execution
                     itemTypeDefinition,
                     ConvertCachedItemDefinitionToInstance);
 
-            ICopyOnWritePropertyDictionary<ProjectMetadataInstance> directMetadata = null;
+            ImmutableDictionary<string, string> directMetadata = null;
             if (item.DirectMetadata is not null)
             {
-                if (item.DirectMetadata is IDictionary<string, ProjectMetadata> metadataDict)
-                {
-                    directMetadata = new ImmutablePropertyCollectionConverter<ProjectMetadata, ProjectMetadataInstance>(metadataDict, ConvertCachedProjectMetadataToInstance);
-                }
-                else
-                {
-                    directMetadata = new CopyOnWritePropertyDictionary<ProjectMetadataInstance>();
+                IEnumerable<KeyValuePair<string, string>> projectMetadataInstances = item.DirectMetadata.Select(directMetadatum
+                    => new KeyValuePair<string, string>(directMetadatum.Name, directMetadatum.EvaluatedValueEscaped));
 
-                    IEnumerable<ProjectMetadataInstance> projectMetadataInstances = item.DirectMetadata.Select(directMetadatum => new ProjectMetadataInstance(directMetadatum));
-                    directMetadata.ImportProperties(projectMetadataInstances);
-                }
+                directMetadata = ImmutableDictionaryExtensions.EmptyMetadata
+                    .SetItems(projectMetadataInstances, ProjectMetadataInstance.VerifyThrowReservedName);
             }
 
             GetEvaluatedIncludesFromProjectItem(

--- a/src/Build/Instance/ProjectItemDefinitionInstance.cs
+++ b/src/Build/Instance/ProjectItemDefinitionInstance.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
@@ -10,6 +11,7 @@ using Microsoft.Build.BackEnd;
 using Microsoft.Build.Collections;
 using Microsoft.Build.Construction;
 using Microsoft.Build.Evaluation;
+using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
 
 #nullable disable
@@ -32,7 +34,7 @@ namespace Microsoft.Build.Execution
         /// Collection of metadata that link the XML metadata and instance metadata
         /// Since evaluation has occurred, this is an unordered collection.
         /// </summary>
-        private IDictionary<string, ProjectMetadataInstance> _metadata;
+        private ImmutableDictionary<string, string> _metadata;
 
         /// <summary>
         /// Constructs an empty project item definition instance.
@@ -57,11 +59,10 @@ namespace Microsoft.Build.Execution
         {
             if (itemDefinition.MetadataCount > 0)
             {
-                var copyOnWriteMetadataDictionary = new CopyOnWritePropertyDictionary<ProjectMetadataInstance>();
-                IEnumerable<ProjectMetadataInstance> projectMetadataInstances = itemDefinition.Metadata.Select(originalMetadata => new ProjectMetadataInstance(originalMetadata));
-                copyOnWriteMetadataDictionary.ImportProperties(projectMetadataInstances);
-
-                _metadata = copyOnWriteMetadataDictionary;
+                IEnumerable<KeyValuePair<string, string>> projectMetadataInstances = itemDefinition.Metadata.Select(originalMetadata
+                        => new KeyValuePair<string, string>(originalMetadata.Name, originalMetadata.EvaluatedValueEscaped));
+                _metadata = ImmutableDictionaryExtensions.EmptyMetadata
+                    .SetItems(projectMetadataInstances, ProjectMetadataInstance.VerifyThrowReservedName);
             }
         }
 
@@ -70,7 +71,7 @@ namespace Microsoft.Build.Execution
         /// </summary>
         /// <param name="itemType">The type of item this definition object represents.</param>
         /// <param name="metadata">A (possibly null) collection of the metadata associated with this item definition.</param>
-        internal ProjectItemDefinitionInstance(string itemType, IDictionary<string, ProjectMetadataInstance> metadata)
+        internal ProjectItemDefinitionInstance(string itemType, ImmutableDictionary<string, string> metadata)
             : this(itemType)
         {
             _metadata = metadata;
@@ -106,7 +107,8 @@ namespace Microsoft.Build.Execution
                     return ReadOnlyEmptyCollection<ProjectMetadataInstance>.Instance;
                 }
 
-                return new ReadOnlyCollection<ProjectMetadataInstance>(_metadata.Values);
+                IEnumerable<ProjectMetadataInstance> metadata = _metadata.Select(kvp => new ProjectMetadataInstance(kvp.Key, kvp.Value, allowItemSpecModifiers: true));
+                return new ReadOnlyCollection<ProjectMetadataInstance>(metadata);
             }
         }
 
@@ -134,13 +136,20 @@ namespace Microsoft.Build.Execution
         }
 
         /// <summary>
+        /// The backing metadata dictionary for copy-on-write cloning.
+        /// </summary>
+        internal ImmutableDictionary<string, string> BackingMetadata => _metadata ?? ImmutableDictionaryExtensions.EmptyMetadata;
+
+        /// <summary>
         /// Get any metadata in the item that has the specified name,
         /// otherwise returns null
         /// </summary>
         [DebuggerStepThrough]
         public ProjectMetadataInstance GetMetadata(string name)
         {
-            return _metadata?[name];
+            return _metadata?.TryGetValue(name, out string value) ?? false
+                ? new ProjectMetadataInstance(name, value, allowItemSpecModifiers: true)
+                : null;
         }
 
         #region IMetadataTable Members
@@ -195,10 +204,10 @@ namespace Microsoft.Build.Execution
         ProjectMetadataInstance IItemDefinition<ProjectMetadataInstance>.SetMetadata(ProjectMetadataElement xml, string evaluatedValue, ProjectMetadataInstance predecessor)
         {
             // No mutability check as this is used during creation (evaluation)
-            _metadata ??= new CopyOnWritePropertyDictionary<ProjectMetadataInstance>();
+            _metadata ??= ImmutableDictionaryExtensions.EmptyMetadata;
 
             ProjectMetadataInstance metadatum = new ProjectMetadataInstance(xml.Name, evaluatedValue);
-            _metadata[xml.Name] = metadatum;
+            _metadata = _metadata.SetItem(xml.Name, metadatum.EvaluatedValueEscaped);
 
             return metadatum;
         }
@@ -212,8 +221,7 @@ namespace Microsoft.Build.Execution
             parent.AppendChild(element);
             foreach (var kvp in _metadata)
             {
-                ProjectMetadataInstance metadataInstance = kvp.Value;
-                element.AddMetadata(metadataInstance.Name, metadataInstance.EvaluatedValue);
+                element.AddMetadata(kvp.Key, EscapingUtilities.UnescapeAll(kvp.Value));
             }
 
             return element;
@@ -222,7 +230,7 @@ namespace Microsoft.Build.Execution
         void ITranslatable.Translate(ITranslator translator)
         {
             translator.Translate(ref _itemType);
-            translator.TranslateDictionary(ref _metadata, ProjectMetadataInstance.FactoryForDeserialization, CreateMetadataCollection);
+            translator.TranslateDictionary(ref _metadata, MSBuildNameIgnoreCaseComparer.Default);
         }
 
         internal static ProjectItemDefinitionInstance FactoryForDeserialization(ITranslator translator)
@@ -234,10 +242,5 @@ namespace Microsoft.Build.Execution
         }
 
         string IItemTypeDefinition.ItemType => _itemType;
-
-        private static IDictionary<string, ProjectMetadataInstance> CreateMetadataCollection(int capacity)
-        {
-            return new CopyOnWritePropertyDictionary<ProjectMetadataInstance>();
-        }
     }
 }

--- a/src/Build/Instance/ProjectItemInstance.cs
+++ b/src/Build/Instance/ProjectItemInstance.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
@@ -100,7 +101,7 @@ namespace Microsoft.Build.Execution
             string itemType,
             string includeEscaped,
             string includeBeforeWildcardExpansionEscaped,
-            ICopyOnWritePropertyDictionary<ProjectMetadataInstance> directMetadata,
+            ImmutableDictionary<string, string> directMetadata,
             IList<ProjectItemDefinitionInstance> itemDefinitions,
             string definingFileEscaped,
             bool useItemDefinitionsWithoutModification)
@@ -121,13 +122,12 @@ namespace Microsoft.Build.Execution
         /// </remarks>
         internal ProjectItemInstance(ProjectInstance project, string itemType, string includeEscaped, IEnumerable<KeyValuePair<string, string>> directMetadata, string definingFileEscaped)
         {
-            CopyOnWritePropertyDictionary<ProjectMetadataInstance> metadata = null;
+            ImmutableDictionary<string, string> metadata = null;
 
             if (directMetadata?.GetEnumerator().MoveNext() == true)
             {
-                metadata = new CopyOnWritePropertyDictionary<ProjectMetadataInstance>();
-                IEnumerable<ProjectMetadataInstance> directMetadataInstances = directMetadata.Select(metadatum => new ProjectMetadataInstance(metadatum.Key, metadatum.Value));
-                metadata.ImportProperties(directMetadataInstances);
+                metadata = ImmutableDictionaryExtensions.EmptyMetadata
+                    .SetItems(directMetadata, ProjectMetadataInstance.VerifyThrowReservedName);
             }
 
             CommonConstructor(project, itemType, includeEscaped, includeEscaped, metadata, null /* need to add item definition metadata */, definingFileEscaped, useItemDefinitionsWithoutModification: false);
@@ -252,7 +252,7 @@ namespace Microsoft.Build.Execution
         [SuppressMessage("Microsoft.Naming", "CA1721:PropertyNamesShouldNotMatchGetMethods", Justification = "This is a reasonable choice. API review approved")]
         public IEnumerable<ProjectMetadataInstance> Metadata
         {
-            get { return _taskItem.MetadataCollection; }
+            get { return ((IItem<ProjectMetadataInstance>)_taskItem).Metadata; }
         }
 
         /// <summary>
@@ -262,6 +262,11 @@ namespace Microsoft.Build.Execution
         {
             get { return _taskItem.DirectMetadataCount; }
         }
+
+        /// <summary>
+        /// Gets a value indicating whether indicates whether the item has any custom metadata.
+        /// </summary>
+        public bool HasCustomMetadata => _taskItem.HasCustomMetadata;
 
         /// <summary>
         /// Implementation of IKeyed exposing the item type
@@ -357,6 +362,11 @@ namespace Microsoft.Build.Execution
         {
             get { return _project.FullPath; }
         }
+
+        /// <summary>
+        /// Gets the backing metadata dictionary in a serializable wrapper.
+        /// </summary>
+        SerializableMetadata IMetadataContainer.BackingMetadata => _taskItem.BackingMetadata;
 
         /// <summary>
         /// Get any metadata in the item that has the specified name,
@@ -491,7 +501,9 @@ namespace Microsoft.Build.Execution
         /// </comments>
         void ITaskItem.SetMetadata(string metadataName, string metadataValue)
         {
-            SetMetadata(metadataName, metadataValue);
+            _project.VerifyThrowNotImmutable();
+
+            _taskItem.SetMetadata(metadataName, metadataValue, allowItemSpecModifiers: false);
         }
 
         /// <summary>
@@ -605,14 +617,15 @@ namespace Microsoft.Build.Execution
         internal static void SetMetadata(IEnumerable<KeyValuePair<string, string>> metadataList, IEnumerable<ProjectItemInstance> items)
         {
             // Set up a single dictionary that can be applied to all the items
-            CopyOnWritePropertyDictionary<ProjectMetadataInstance> metadata = new();
+            ImmutableDictionary<string, string> metadata = ImmutableDictionaryExtensions.EmptyMetadata
+                .SetItems(metadataList, ProjectMetadataInstance.VerifyThrowReservedName);
 
-            IEnumerable<ProjectMetadataInstance> projectMetadataInstances = metadataList.Select(metadatum => new ProjectMetadataInstance(metadatum.Key, metadatum.Value));
-            metadata.ImportProperties(projectMetadataInstances);
-
-            foreach (ProjectItemInstance item in items)
+            if (metadata.Count > 0)
             {
-                item._taskItem.SetMetadata(metadata); // Potential copy on write
+                foreach (ProjectItemInstance item in items)
+                {
+                    item._taskItem.SetMetadata(metadata); // Potential copy on write
+                }
             }
         }
 
@@ -630,7 +643,7 @@ namespace Microsoft.Build.Execution
         /// Add a metadata with the specified names and values.
         /// Overwrites any metadata with the same name already in the collection.
         /// </summary>
-        internal void SetMetadata(ICopyOnWritePropertyDictionary<ProjectMetadataInstance> metadataDictionary)
+        internal void SetMetadata(ImmutableDictionary<string, string> metadataDictionary)
         {
             _project.VerifyThrowNotImmutable();
 
@@ -647,6 +660,17 @@ namespace Microsoft.Build.Execution
         /// We don't copy them too because tasks shouldn't set them (they might become inconsistent)
         /// </summary>
         internal void SetMetadataOnTaskOutput(IEnumerable<KeyValuePair<string, string>> items)
+        {
+            _project.VerifyThrowNotImmutable();
+
+            _taskItem.SetMetadataOnTaskOutput(items);
+        }
+
+        /// <summary>
+        /// Special case of <see cref="SetMetadataOnTaskOutput(IEnumerable{KeyValuePair{string, string}})"/> for when
+        /// we are importing from a known internal metadata source.
+        /// </summary>
+        internal void SetMetadataOnTaskOutput(ImmutableDictionary<string, string> items)
         {
             _project.VerifyThrowNotImmutable();
 
@@ -702,7 +726,7 @@ namespace Microsoft.Build.Execution
             string itemTypeToUse,
             string includeEscaped,
             string includeBeforeWildcardExpansionEscaped,
-            ICopyOnWritePropertyDictionary<ProjectMetadataInstance> directMetadata,
+            ImmutableDictionary<string, string> directMetadata,
             IList<ProjectItemDefinitionInstance> itemDefinitions,
             string definingFileEscaped,
             bool useItemDefinitionsWithoutModification)
@@ -739,7 +763,7 @@ namespace Microsoft.Build.Execution
             _taskItem = new TaskItem(
                             includeEscaped,
                             includeBeforeWildcardExpansionEscaped,
-                            directMetadata?.DeepClone(), // copy on write!
+                            directMetadata, // copy on write!
                             inheritedItemDefinitions,
                             _project.Directory,
                             _project.IsImmutable,
@@ -786,7 +810,7 @@ namespace Microsoft.Build.Execution
             /// Lazily created, as there are huge numbers of items generated in
             /// a build that have no metadata at all.
             /// </remarks>
-            private ICopyOnWritePropertyDictionary<ProjectMetadataInstance> _directMetadata;
+            private ImmutableDictionary<string, string> _directMetadata;
 
             /// <summary>
             /// Cached value of the fullpath metadata. All other metadata are computed on demand.
@@ -829,7 +853,7 @@ namespace Microsoft.Build.Execution
             internal TaskItem(
                               string includeEscaped,
                               string includeBeforeWildcardExpansionEscaped,
-                              ICopyOnWritePropertyDictionary<ProjectMetadataInstance> directMetadata,
+                              ImmutableDictionary<string, string> directMetadata,
                               IList<ProjectItemDefinitionInstance> itemDefinitions,
                               string projectDirectory,
                               bool immutable,
@@ -944,13 +968,13 @@ namespace Microsoft.Build.Execution
             {
                 get
                 {
-                    ICopyOnWritePropertyDictionary<ProjectMetadataInstance> metadataCollection = MetadataCollection;
+                    ImmutableDictionary<string, string> metadataCollection = MetadataCollection;
 
                     List<string> names = new List<string>(capacity: metadataCollection.Count + FileUtilities.ItemSpecModifiers.All.Length);
 
-                    foreach (ProjectMetadataInstance metadatum in (IEnumerable<ProjectMetadataInstance>)metadataCollection)
+                    foreach (KeyValuePair<string, string> metadatum in metadataCollection)
                     {
-                        names.Add(metadatum.Name);
+                        names.Add(metadatum.Key);
                     }
 
                     names.AddRange(FileUtilities.ItemSpecModifiers.All);
@@ -1048,6 +1072,11 @@ namespace Microsoft.Build.Execution
             }
 
             /// <summary>
+            /// Gets a value indicating whether indicates whether the item has any custom metadata.
+            /// </summary>
+            public bool HasCustomMetadata => _directMetadata?.Count > 0 || _itemDefinitions?.Count > 0;
+
+            /// <summary>
             /// Efficient way to retrieve metadata used by packet serialization
             /// and binary logger.
             /// </summary>
@@ -1081,12 +1110,41 @@ namespace Microsoft.Build.Execution
             /// Equivalent to calling <see cref="SetMetadata(string,string)"/> for each item in <paramref name="metadata"/>.
             /// </summary>
             /// <param name="metadata">The metadata to set.</param>
-            public void ImportMetadata(IEnumerable<KeyValuePair<string, string>> metadata)
+            public void ImportMetadata(IEnumerable<KeyValuePair<string, string>> metadata) =>
+                ImportMetadata(metadata, validateKeys: true);
+
+            /// <summary>
+            /// Sets the given metadata.
+            /// </summary>
+            /// <param name="metadata">The metadata to set.</param>
+            /// <param name="validateKeys">If true, all imported metadata keys will be validated for reserved names.</param>
+            /// <remarks>
+            /// If importing from another ProjectItemInstance.TaskItem instance, the caller should not set validateKeys
+            /// since all incoming metadata will already have been validated.
+            /// </remarks>
+            private void ImportMetadata(IEnumerable<KeyValuePair<string, string>> metadata, bool validateKeys)
             {
                 ProjectInstance.VerifyThrowNotImmutable(_isImmutable);
 
-                _directMetadata ??= new CopyOnWritePropertyDictionary<ProjectMetadataInstance>();
-                _directMetadata.ImportProperties(metadata.Select(kvp => new ProjectMetadataInstance(kvp.Key, kvp.Value, allowItemSpecModifiers: true)));
+                if (DirectMetadataCount == 0 && metadata.GetType() == typeof(ImmutableDictionary<string, string>))
+                {
+                    _directMetadata = (ImmutableDictionary<string, string>)metadata;
+
+                    if (validateKeys)
+                    {
+                        foreach (KeyValuePair<string, string> metadatum in _directMetadata)
+                        {
+                            ProjectMetadataInstance.VerifyThrowReservedNameAllowItemSpecModifiers(metadatum.Key);
+                        }
+                    }
+                }
+                else
+                {
+                    _directMetadata ??= ImmutableDictionaryExtensions.EmptyMetadata;
+                    _directMetadata = validateKeys
+                        ? _directMetadata.SetItems(metadata, ProjectMetadataInstance.VerifyThrowReservedNameAllowItemSpecModifiers)
+                        : _directMetadata.SetItems(metadata);
+                }
             }
 
 #if FEATURE_APPDOMAIN
@@ -1096,16 +1154,13 @@ namespace Microsoft.Build.Execution
             /// </summary>
             /// <param name="list">The source list to return metadata from.</param>
             /// <returns>An array of string key-value pairs representing metadata.</returns>
-            private IEnumerable<KeyValuePair<string, string>> EnumerateMetadataEager(ICopyOnWritePropertyDictionary<ProjectMetadataInstance> list)
+            private IEnumerable<KeyValuePair<string, string>> EnumerateMetadataEager(ImmutableDictionary<string, string> list)
             {
                 var result = new List<KeyValuePair<string, string>>(list.Count);
 
-                foreach (var projectMetadataInstance in list.Values)
+                foreach (KeyValuePair<string, string> projectMetadataInstance in list)
                 {
-                    if (projectMetadataInstance != null)
-                    {
-                        result.Add(new KeyValuePair<string, string>(projectMetadataInstance.Name, projectMetadataInstance.EvaluatedValue));
-                    }
+                    result.Add(new KeyValuePair<string, string>(projectMetadataInstance.Key, EscapingUtilities.UnescapeAll(projectMetadataInstance.Value)));
                 }
 
                 // Probably better to send the raw array across the wire even if it's another allocation.
@@ -1113,14 +1168,11 @@ namespace Microsoft.Build.Execution
             }
 #endif
 
-            private IEnumerable<KeyValuePair<string, string>> EnumerateMetadata(ICopyOnWritePropertyDictionary<ProjectMetadataInstance> list)
+            private IEnumerable<KeyValuePair<string, string>> EnumerateMetadata(ImmutableDictionary<string, string> list)
             {
-                foreach (var projectMetadataInstance in list.Values)
+                foreach (KeyValuePair<string, string> projectMetadataInstance in list)
                 {
-                    if (projectMetadataInstance != null)
-                    {
-                        yield return new KeyValuePair<string, string>(projectMetadataInstance.Name, projectMetadataInstance.EvaluatedValue);
-                    }
+                    yield return new KeyValuePair<string, string>(projectMetadataInstance.Key, EscapingUtilities.UnescapeAll(projectMetadataInstance.Value));
                 }
             }
 
@@ -1132,7 +1184,7 @@ namespace Microsoft.Build.Execution
             /// This is a read-only collection. To modify the metadata, use <see cref="SetMetadata(string, string)"/>.
             /// Computed, not necessarily fast.
             /// </summary>
-            internal ICopyOnWritePropertyDictionary<ProjectMetadataInstance> MetadataCollection
+            internal ImmutableDictionary<string, string> MetadataCollection
             {
                 get
                 {
@@ -1143,56 +1195,51 @@ namespace Microsoft.Build.Execution
                     // (1) any directly defined metadata on the source item
                     // (2) any item definition metadata the item had accumulated, in order of accumulation
                     //  (last of which is any item definition metadata associated with the destination item's item type)
-                    if (_itemDefinitions == null)
+                    if (_itemDefinitions == null || _itemDefinitions.Count == 0)
                     {
-                        return (_directMetadata == null) ? new CopyOnWritePropertyDictionary<ProjectMetadataInstance>() : _directMetadata.DeepClone(); // copy on write!
+                        return _directMetadata ?? ImmutableDictionaryExtensions.EmptyMetadata; // copy on write!
                     }
 
-                    CopyOnWritePropertyDictionary<ProjectMetadataInstance> allMetadata = new CopyOnWritePropertyDictionary<ProjectMetadataInstance>();
+                    ImmutableDictionary<string, string> lastItemDefinition = _itemDefinitions[_itemDefinitions.Count - 1].BackingMetadata;
 
-                    allMetadata.ImportProperties(metaData());
-
-                    return allMetadata;
-
-                    IEnumerable<ProjectMetadataInstance> metaData()
+                    // If we only have a single item definition and/or direct metadata, directly return.
+                    if (_itemDefinitions.Count == 1)
                     {
-                        // Next, any inherited item definitions. Front of the list is highest priority,
-                        // so walk backwards.
-                        for (int i = _itemDefinitions.Count - 1; i >= 0; i--)
-                        {
-                            foreach (ProjectMetadataInstance metadatum in _itemDefinitions[i].Metadata)
-                            {
-                                if (metadatum != null)
-                                {
-                                    yield return metadatum;
-                                }
-                                else
-                                {
-                                    Debug.Fail($"metadatum from {_itemDefinitions[i]} is null, see https://github.com/dotnet/msbuild/issues/5267");
-                                }
-                            }
-                        }
+                        return _directMetadata == null ? lastItemDefinition : lastItemDefinition.SetItems(_directMetadata);
+                    }
 
-                        // Finally any direct metadata win.
-                        if (_directMetadata != null)
-                        {
-                            foreach (ProjectMetadataInstance metadatum in (IEnumerable<ProjectMetadataInstance>)_directMetadata)
-                            {
-                                if (metadatum != null)
-                                {
-                                    yield return metadatum;
-                                }
-                                else
-                                {
-                                    Debug.Fail("metadatum in _directMetadata is null, see https://github.com/dotnet/msbuild/issues/5267");
-                                }
-                            }
-                        }
+                    // Otherwise, merge remaining inherited item definitions. Front of the list is highest priority,
+                    // so walk backwards. Skip the last entry since we've already used it as the base.
+                    for (int i = _itemDefinitions.Count - 2; i >= 0; i--)
+                    {
+                        lastItemDefinition = lastItemDefinition.SetItems(_itemDefinitions[i].BackingMetadata);
+                    }
+
+                    // Finally any direct metadata win.
+                    if (_directMetadata != null)
+                    {
+                        lastItemDefinition = lastItemDefinition.SetItems(_directMetadata);
+                    }
+
+                    return lastItemDefinition;
+                }
+            }
+
+            IEnumerable<ProjectMetadataInstance> IItem<ProjectMetadataInstance>.Metadata
+            {
+                get
+                {
+                    foreach (KeyValuePair<string, string> metadatum in MetadataCollection)
+                    {
+                        yield return new ProjectMetadataInstance(metadatum.Key, metadatum.Value, allowItemSpecModifiers: true);
                     }
                 }
             }
 
-            IEnumerable<ProjectMetadataInstance> IItem<ProjectMetadataInstance>.Metadata => MetadataCollection;
+            /// <summary>
+            /// Gets the backing metadata dictionary in a serializable wrapper.
+            /// </summary>
+            public SerializableMetadata BackingMetadata => new(MetadataCollection);
 
             #region Operators
 
@@ -1326,13 +1373,9 @@ namespace Microsoft.Build.Execution
                     ErrorUtilities.VerifyThrowArgumentLength(metadataName);
                 }
 
-                if (_directMetadata != null)
+                if (_directMetadata?.TryGetValue(metadataName, out string escapedValue) == true && escapedValue != null)
                 {
-                    string escapedValue = _directMetadata.GetEscapedValue(metadataName);
-                    if (escapedValue != null)
-                    {
-                        return escapedValue;
-                    }
+                    return escapedValue;
                 }
 
                 ProjectMetadataInstance metadatum;
@@ -1365,7 +1408,7 @@ namespace Microsoft.Build.Execution
             {
                 ProjectInstance.VerifyThrowNotImmutable(_isImmutable);
 
-                SetMetadataObject(metadataName, metadataValueEscaped, true /* built-in metadata allowed */);
+                SetMetadata(metadataName, metadataValueEscaped, allowItemSpecModifiers: true);
             }
 
             /// <summary>
@@ -1387,7 +1430,7 @@ namespace Microsoft.Build.Execution
             {
                 ProjectInstance.VerifyThrowNotImmutable(_isImmutable);
 
-                _directMetadata?.Remove(metadataName);
+                _directMetadata = _directMetadata?.Remove(metadataName);
             }
 
             /// <summary>
@@ -1428,12 +1471,13 @@ namespace Microsoft.Build.Execution
                     originalItemSpec = destinationItem.GetMetadata("OriginalItemSpec");
                 }
 
-                if (destinationItem is TaskItem destinationAsTaskItem && destinationAsTaskItem._directMetadata == null)
+                TaskItem destinationAsTaskItem = destinationItem as TaskItem;
+                if (destinationAsTaskItem != null && destinationAsTaskItem._directMetadata == null)
                 {
                     ProjectInstance.VerifyThrowNotImmutable(destinationAsTaskItem._isImmutable);
 
                     // This optimized path is hit most often
-                    destinationAsTaskItem._directMetadata = _directMetadata?.DeepClone(); // copy on write!
+                    destinationAsTaskItem._directMetadata = _directMetadata; // copy on write!
 
                     // If the destination item already has item definitions then we want to maintain them
                     // But ours will be of less precedence than those already on the item
@@ -1449,22 +1493,22 @@ namespace Microsoft.Build.Execution
                         }
                     }
                 }
-                else if (destinationItem is IMetadataContainer destinationItemAsMetadataContainer)
+                else if (destinationItem is ITaskItem2 destinationItemAsTaskItem2 and IMetadataContainer destinationItemAsMetadataContainer)
                 {
+                    // OK, most likely the destination item was a Microsoft.Build.Utilities.TaskItem.
                     // The destination implements IMetadataContainer so we can use the ImportMetadata bulk-set operation.
-                    BulkImportMetadata(destinationItem, destinationItemAsMetadataContainer);
+                    BulkImportMetadata(destinationItemAsTaskItem2, destinationItemAsMetadataContainer, destinationAsTaskItem);
                 }
                 else
                 {
-                    // OK, most likely the destination item was a Microsoft.Build.Utilities.TaskItem.
-                    foreach (ProjectMetadataInstance metadatum in (IEnumerable<ProjectMetadataInstance>)MetadataCollection)
+                    foreach (KeyValuePair<string, string> metadatum in MetadataCollection)
                     {
                         // When copying metadata, we do NOT overwrite metadata already on the destination item.
-                        string destinationValue = destinationItem.GetMetadata(metadatum.Name);
+                        string destinationValue = destinationItem.GetMetadata(metadatum.Key);
                         if (String.IsNullOrEmpty(destinationValue))
                         {
                             // Utilities.TaskItem's don't know about item definition metadata. So merge that into the values.
-                            destinationItem.SetMetadata(metadatum.Name, GetMetadataEscaped(metadatum.Name));
+                            destinationItem.SetMetadata(metadatum.Key, GetMetadataEscaped(metadatum.Key));
                         }
                     }
                 }
@@ -1480,22 +1524,49 @@ namespace Microsoft.Build.Execution
             }
 
             // PERF: Keep this method extracted to avoid unconditionally allocating a closure object
-            private void BulkImportMetadata(ITaskItem destinationItem, IMetadataContainer destinationItemAsMetadataContainer)
+            private void BulkImportMetadata(ITaskItem2 destinationItem, IMetadataContainer destinationItemAsMetadataContainer, TaskItem destinationAsTaskItem)
             {
-                IEnumerable<ProjectMetadataInstance> metadataEnumerable = MetadataCollection;
-                IEnumerable<KeyValuePair<string, string>> metadataToImport = metadataEnumerable
-                    .Where(metadatum => string.IsNullOrEmpty(destinationItem.GetMetadata(metadatum.Name)))
-                    .Select(metadatum => new KeyValuePair<string, string>(metadatum.Name, GetMetadataEscaped(metadatum.Name)));
-
-#if FEATURE_APPDOMAIN
-                if (RemotingServices.IsTransparentProxy(destinationItem))
+                if (!HasCustomMetadata)
                 {
-                    // Linq is not serializable so materialize the collection before making the call.
-                    metadataToImport = metadataToImport.ToList();
+                    return;
                 }
+
+                // Defer any LINQ queries. If the destination supports copy-on-write cloning, we may be able to pass
+                // a direct reference to the metadata.
+                IEnumerable<KeyValuePair<string, string>> metadataToImport = MetadataCollection;
+
+                // If the destination already has existing metadata, only import values which are not already set.
+                if (destinationItemAsMetadataContainer.HasCustomMetadata)
+                {
+                    metadataToImport = metadataToImport
+                        .Where(metadatum => string.IsNullOrEmpty(destinationItem.GetMetadataValueEscaped(metadatum.Key)));
+                }
+
+                // If we have item definitions with potential expandable expressions, fully evaluate all entries.
+                if (HasAnyExpandableExpressions())
+                {
+                    metadataToImport = metadataToImport
+                        .Select(metadatum => new KeyValuePair<string, string>(metadatum.Key, GetMetadataEscaped(metadatum.Key)));
+                }
+
+                // Special case TaskItem since we can skip repeating any key validations.
+                if (destinationAsTaskItem != null)
+                {
+                    // No need to check for AppDomains the source and destination only exist in the Engine side.
+                    destinationAsTaskItem.ImportMetadata(metadataToImport, validateKeys: false);
+                }
+                else
+                {
+#if FEATURE_APPDOMAIN
+                    if (RemotingServices.IsTransparentProxy(destinationItem))
+                    {
+                        // Linq is not serializable so materialize the collection before making the call.
+                        metadataToImport = metadataToImport.ToList();
+                    }
 #endif
 
-                destinationItemAsMetadataContainer.ImportMetadata(metadataToImport);
+                    destinationItemAsMetadataContainer.ImportMetadata(metadataToImport);
+                }
             }
 
             /// <summary>
@@ -1508,9 +1579,9 @@ namespace Microsoft.Build.Execution
                 var metadata = MetadataCollection;
                 Dictionary<string, string> clonedMetadata = new Dictionary<string, string>(metadata.Count, MSBuildNameIgnoreCaseComparer.Default);
 
-                foreach (ProjectMetadataInstance metadatum in (IEnumerable<ProjectMetadataInstance>)metadata)
+                foreach (KeyValuePair<string, string> metadatum in metadata)
                 {
-                    clonedMetadata[metadatum.Name] = metadatum.EvaluatedValue;
+                    clonedMetadata[metadatum.Key] = EscapingUtilities.UnescapeAll(metadatum.Value);
                 }
 
                 return clonedMetadata;
@@ -1525,9 +1596,9 @@ namespace Microsoft.Build.Execution
             {
                 Dictionary<string, string> clonedMetadata = new Dictionary<string, string>(MSBuildNameIgnoreCaseComparer.Default);
 
-                foreach (ProjectMetadataInstance metadatum in (IEnumerable<ProjectMetadataInstance>)MetadataCollection)
+                foreach (KeyValuePair<string, string> metadatum in MetadataCollection)
                 {
-                    clonedMetadata[metadatum.Name] = metadatum.EvaluatedValueEscaped;
+                    clonedMetadata[metadatum.Key] = metadatum.Value;
                 }
 
                 return clonedMetadata;
@@ -1558,8 +1629,7 @@ namespace Microsoft.Build.Execution
                 TranslatorHelpers.TranslateDictionary(
                     translator,
                     ref _directMetadata,
-                    ProjectMetadataInstance.FactoryForDeserialization,
-                    (capacity) => new CopyOnWritePropertyDictionary<ProjectMetadataInstance>());
+                    MSBuildNameIgnoreCaseComparer.Default);
 
                 if (_itemDefinitions?.Count == 0)
                 {
@@ -1650,22 +1720,22 @@ namespace Microsoft.Build.Execution
 
                 if (_directMetadata is not null)
                 {
-                    foreach (ProjectMetadataInstance metadatum in (IEnumerable<ProjectMetadataInstance>)_directMetadata)
+                    foreach (KeyValuePair<string, string> metadatum in _directMetadata)
                     {
-                        thisNames.Add(metadatum.Name);
+                        thisNames.Add(metadatum.Key);
                     }
                 }
 
-                ICopyOnWritePropertyDictionary<ProjectMetadataInstance> otherMetadata = other.MetadataCollection;
+                ImmutableDictionary<string, string> otherMetadata = other.MetadataCollection;
 
                 if (otherMetadata.Count != thisNames.Count)
                 {
                     return false;
                 }
 
-                foreach (ProjectMetadataInstance metadatum in (IEnumerable<ProjectMetadataInstance>)otherMetadata)
+                foreach (KeyValuePair<string, string> metadatum in otherMetadata)
                 {
-                    string name = metadatum.Name;
+                    string name = metadatum.Key;
 
                     if (!thisNames.Remove(name))
                     {
@@ -1700,7 +1770,7 @@ namespace Microsoft.Build.Execution
             /// </remarks>
             public bool HasMetadata(string name)
             {
-                if ((_directMetadata?.Contains(name) == true) ||
+                if ((_directMetadata?.ContainsKey(name) == true) ||
                      FileUtilities.ItemSpecModifiers.IsItemSpecModifier(name) ||
                     GetItemDefinitionMetadata(name) != null)
                 {
@@ -1773,17 +1843,17 @@ namespace Microsoft.Build.Execution
                     WriteInternString(translator, interner, ref _includeBeforeWildcardExpansionEscaped);
                     WriteInternString(translator, interner, ref _definingFileEscaped);
 
-                    ICopyOnWritePropertyDictionary<ProjectMetadataInstance> temp = MetadataCollection;
+                    ImmutableDictionary<string, string> temp = MetadataCollection;
 
                     // Intern the metadata
                     if (translator.TranslateNullable(temp))
                     {
                         int count = temp.Count;
                         translator.Writer.Write(count);
-                        foreach (ProjectMetadataInstance metadatum in (IEnumerable<ProjectMetadataInstance>)temp)
+                        foreach (KeyValuePair<string, string> metadatum in temp)
                         {
-                            int key = interner.Intern(metadatum.Name);
-                            int value = interner.Intern(metadatum.EvaluatedValueEscaped);
+                            int key = interner.Intern(metadatum.Key);
+                            int value = interner.Intern(metadatum.Value);
                             translator.Writer.Write(key);
                             translator.Writer.Write(value);
                         }
@@ -1798,15 +1868,14 @@ namespace Microsoft.Build.Execution
                         int count = translator.Reader.ReadInt32();
                         if (count > 0)
                         {
-                            IEnumerable<ProjectMetadataInstance> metaData =
+                            IEnumerable<KeyValuePair<string, string>> metaData =
                                 Enumerable.Range(0, count).Select(_ =>
                                 {
                                     int key = translator.Reader.ReadInt32();
                                     int value = translator.Reader.ReadInt32();
-                                    return new ProjectMetadataInstance(interner.GetString(key), interner.GetString(value), allowItemSpecModifiers: true);
+                                    return new KeyValuePair<string, string>(interner.GetString(key), interner.GetString(value));
                                 });
-                            _directMetadata = new CopyOnWritePropertyDictionary<ProjectMetadataInstance>();
-                            _directMetadata.ImportProperties(metaData);
+                            _directMetadata = ImmutableDictionaryExtensions.EmptyMetadata.SetItems(metaData);
                         }
                         else
                         {
@@ -1824,9 +1893,9 @@ namespace Microsoft.Build.Execution
             {
                 ProjectMetadataInstance value = null;
 
-                if (_directMetadata != null)
+                if (_directMetadata != null && _directMetadata.TryGetValue(name, out string escapedValue))
                 {
-                    value = _directMetadata[name];
+                    value = new ProjectMetadataInstance(name, escapedValue, allowItemSpecModifiers: true);
                 }
 
                 if (value == null)
@@ -1841,7 +1910,7 @@ namespace Microsoft.Build.Execution
             /// Add a metadata with the specified name and value.
             /// Overwrites any metadata with the same name already in the collection.
             /// </summary>
-            internal void SetMetadata(ICopyOnWritePropertyDictionary<ProjectMetadataInstance> metadata)
+            internal void SetMetadata(ImmutableDictionary<string, string> metadata)
             {
                 ProjectInstance.VerifyThrowNotImmutable(_isImmutable);
 
@@ -1850,14 +1919,29 @@ namespace Microsoft.Build.Execution
                     return;
                 }
 
-                if (_directMetadata == null)
+                _directMetadata = DirectMetadataCount == 0 ? metadata : _directMetadata.SetItems(metadata);
+            }
+
+            /// <summary>
+            /// Add a metadata with the specified name and value.
+            /// Overwrites any metadata with the same name already in the collection.
+            /// Does not allow built-in metadata unless allowItemSpecModifiers is set.
+            /// </summary>
+            internal void SetMetadata(string name, string metadataValueEscaped, bool allowItemSpecModifiers)
+            {
+                ProjectInstance.VerifyThrowNotImmutable(_isImmutable);
+
+                if (allowItemSpecModifiers)
                 {
-                    _directMetadata = metadata.DeepClone(); // Copy on write !
+                    ProjectMetadataInstance.VerifyThrowReservedNameAllowItemSpecModifiers(name);
                 }
                 else
                 {
-                    _directMetadata.ImportProperties(metadata);
+                    ProjectMetadataInstance.VerifyThrowReservedName(name);
                 }
+
+                _directMetadata ??= ImmutableDictionaryExtensions.EmptyMetadata;
+                _directMetadata = _directMetadata.SetItem(name, metadataValueEscaped ?? string.Empty);
             }
 
             /// <summary>
@@ -1869,9 +1953,9 @@ namespace Microsoft.Build.Execution
             {
                 ProjectInstance.VerifyThrowNotImmutable(_isImmutable);
 
-                _directMetadata ??= new CopyOnWritePropertyDictionary<ProjectMetadataInstance>();
+                _directMetadata ??= ImmutableDictionaryExtensions.EmptyMetadata;
                 ProjectMetadataInstance metadatum = new ProjectMetadataInstance(name, metadataValueEscaped, allowItemSpecModifiers /* may not be built-in metadata name */);
-                _directMetadata.Set(metadatum);
+                _directMetadata = _directMetadata.SetItem(name, metadatum.EvaluatedValueEscaped);
 
                 return metadatum;
             }
@@ -1891,22 +1975,45 @@ namespace Microsoft.Build.Execution
 
                 if (!FileUtilities.ItemSpecModifiers.IsDerivableItemSpecModifier(name))
                 {
-                    _directMetadata ??= new CopyOnWritePropertyDictionary<ProjectMetadataInstance>();
-                    ProjectMetadataInstance metadatum = new ProjectMetadataInstance(name, evaluatedValueEscaped, true /* may be built-in metadata name */);
-                    _directMetadata.Set(metadatum);
+                    _directMetadata ??= ImmutableDictionaryExtensions.EmptyMetadata;
+                    ProjectMetadataInstance.VerifyThrowReservedNameAllowItemSpecModifiers(name);
+                    _directMetadata = _directMetadata.SetItem(name, evaluatedValueEscaped ?? string.Empty);
                 }
             }
 
             internal void SetMetadataOnTaskOutput(IEnumerable<KeyValuePair<string, string>> items)
             {
                 ProjectInstance.VerifyThrowNotImmutable(_isImmutable);
-                _directMetadata ??= new CopyOnWritePropertyDictionary<ProjectMetadataInstance>();
+                _directMetadata ??= ImmutableDictionaryExtensions.EmptyMetadata;
 
                 var metadata = items
-                    .Where(item => !FileUtilities.ItemSpecModifiers.IsDerivableItemSpecModifier(item.Key))
-                    .Select(item => new ProjectMetadataInstance(item.Key, item.Value, true /* may be built-in metadata name */));
+                    .Where(item => !FileUtilities.ItemSpecModifiers.IsDerivableItemSpecModifier(item.Key));
 
-                _directMetadata.ImportProperties(metadata);
+                _directMetadata = _directMetadata.SetItems(metadata, ProjectMetadataInstance.VerifyThrowReservedNameAllowItemSpecModifiers);
+            }
+
+            /// <summary>
+            /// Special case of <see cref="SetMetadataOnTaskOutput(IEnumerable{KeyValuePair{string, string}})"/> for when
+            /// we are importing from a known internal metadata source.
+            /// </summary>
+            internal void SetMetadataOnTaskOutput(ImmutableDictionary<string, string> items)
+            {
+                ProjectInstance.VerifyThrowNotImmutable(_isImmutable);
+
+                if (items.IsEmpty)
+                {
+                    return;
+                }
+
+                // Validate reserved names since Utilities.TaskItem allows them.
+                // Performing this separately from SetItems as we most likely have an empty dictionary and can no-op.
+                foreach (KeyValuePair<string, string> item in items)
+                {
+                    ProjectMetadataInstance.VerifyThrowReservedNameAllowItemSpecModifiers(item.Key);
+                }
+
+                // Don't bother checking for item-spec modifiers since Utilities.TaskItem already validates them.
+                _directMetadata = DirectMetadataCount == 0 ? items : _directMetadata.SetItems(items);
             }
 
             /// <summary>
@@ -1971,6 +2078,35 @@ namespace Microsoft.Build.Execution
                 return null;
             }
 
+            /// <summary>
+            /// Checks if any of the item definitions may have expandable expressions.
+            /// </summary>
+            /// <remarks>
+            /// Normally when we copy metadata to an external TaskItem, we need to call GetMetadataEscaped for each
+            /// value since item definitions may have lazily expanded expressions.
+            /// If no expressions exist, we can directly pass our backing dictionary and avoid allocations.
+            /// </remarks>
+            private bool HasAnyExpandableExpressions()
+            {
+                if (_itemDefinitions == null || _itemDefinitions.Count == 0)
+                {
+                    return false;
+                }
+
+                foreach (ProjectItemDefinitionInstance item in _itemDefinitions)
+                {
+                    foreach (KeyValuePair<string, string> kvp in item.BackingMetadata)
+                    {
+                        if (Expander<ProjectProperty, ProjectItem>.ExpressionMayContainExpandableExpressions(kvp.Value))
+                        {
+                            return true;
+                        }
+                    }
+                }
+
+                return false;
+            }
+
             internal readonly struct MetadataNamesEnumerable
             {
                 private readonly TaskItem _item;
@@ -1982,13 +2118,13 @@ namespace Microsoft.Build.Execution
 
             internal struct MetadataNamesEnumerator
             {
-                private readonly IEnumerator<ProjectMetadataInstance> _metadataCollectionEnumerator;
+                private readonly IEnumerator<KeyValuePair<string, string>> _metadataCollectionEnumerator;
                 private bool _metadataNamesEnumerated;
                 private int _itemSpecModifiersIndex;
 
-                internal MetadataNamesEnumerator(ICopyOnWritePropertyDictionary<ProjectMetadataInstance> metadataCollection)
+                internal MetadataNamesEnumerator(ImmutableDictionary<string, string> metadataCollection)
                 {
-                    _metadataCollectionEnumerator = ((IEnumerable<ProjectMetadataInstance>)metadataCollection).GetEnumerator();
+                    _metadataCollectionEnumerator = metadataCollection.GetEnumerator();
                     _metadataNamesEnumerated = false;
                     _itemSpecModifiersIndex = 0;
                 }
@@ -2001,7 +2137,7 @@ namespace Microsoft.Build.Execution
                     {
                         if (_metadataCollectionEnumerator.MoveNext())
                         {
-                            Current = _metadataCollectionEnumerator.Current.Name;
+                            Current = _metadataCollectionEnumerator.Current.Key;
 
                             return true;
                         }
@@ -2123,13 +2259,16 @@ namespace Microsoft.Build.Execution
                 public void SetMetadata(IEnumerable<KeyValuePair<ProjectMetadataElement, string>> metadataList, IEnumerable<ProjectItemInstance> destinationItems)
                 {
                     // Set up a single dictionary that can be applied to all the items
-                    CopyOnWritePropertyDictionary<ProjectMetadataInstance> metadata = new CopyOnWritePropertyDictionary<ProjectMetadataInstance>();
-                    IEnumerable<ProjectMetadataInstance> projectMetadataInstances = metadataList.Select(metadatum => new ProjectMetadataInstance(metadatum.Key.Name, metadatum.Value));
-                    metadata.ImportProperties(projectMetadataInstances);
+                    ImmutableDictionary<string, string> metadata = ImmutableDictionaryExtensions.EmptyMetadata;
+                    IEnumerable<KeyValuePair<string, string>> projectMetadataInstances = metadataList.Select(metadatum => new KeyValuePair<string, string>(metadatum.Key.Name, metadatum.Value));
+                    metadata = metadata.SetItems(projectMetadataInstances, ProjectMetadataInstance.VerifyThrowReservedName);
 
-                    foreach (ProjectItemInstance item in destinationItems)
+                    if (metadata.Count > 0)
                     {
-                        item._taskItem.SetMetadata(metadata);
+                        foreach (ProjectItemInstance item in destinationItems)
+                        {
+                            item._taskItem.SetMetadata(metadata);
+                        }
                     }
                 }
 

--- a/src/Build/Instance/ProjectItemInstance.cs
+++ b/src/Build/Instance/ProjectItemInstance.cs
@@ -1126,9 +1126,9 @@ namespace Microsoft.Build.Execution
             {
                 ProjectInstance.VerifyThrowNotImmutable(_isImmutable);
 
-                if (DirectMetadataCount == 0 && metadata.GetType() == typeof(ImmutableDictionary<string, string>))
+                if (DirectMetadataCount == 0 && metadata is ImmutableDictionary<string, string> immutableMetadata)
                 {
-                    _directMetadata = (ImmutableDictionary<string, string>)metadata;
+                    _directMetadata = immutableMetadata;
 
                     if (validateKeys)
                     {

--- a/src/Build/Instance/ProjectMetadataInstance.cs
+++ b/src/Build/Instance/ProjectMetadataInstance.cs
@@ -242,7 +242,7 @@ namespace Microsoft.Build.Execution
             VerifyThrowReservedNameAllowItemSpecModifiers(name);
             foreach (string itemSpecModifier in FileUtilities.ItemSpecModifiers.All)
             {
-                if (itemSpecModifier.Length == name.Length && itemSpecModifier[0] == name[0])
+                if (itemSpecModifier.Length == name.Length && itemSpecModifier[0] == char.ToUpperInvariant(name[0]))
                 {
                     ErrorUtilities.VerifyThrowArgument(!MSBuildNameIgnoreCaseComparer.Default.Equals(itemSpecModifier, name), "OM_ReservedName", name);
                 }
@@ -262,7 +262,7 @@ namespace Microsoft.Build.Execution
             {
                 if (reservedName.Length == name.Length && reservedName[0] == name[0])
                 {
-                    ErrorUtilities.VerifyThrowArgument(!MSBuildNameIgnoreCaseComparer.Default.Equals(reservedName, name), "OM_ReservedName", name);
+                    ErrorUtilities.VerifyThrowArgument(!StringComparer.Ordinal.Equals(reservedName, name), "OM_ReservedName", name);
                 }
             }
         }

--- a/src/Build/Instance/ProjectMetadataInstance.cs
+++ b/src/Build/Instance/ProjectMetadataInstance.cs
@@ -65,11 +65,11 @@ namespace Microsoft.Build.Execution
 
             if (allowItemSpecModifiers)
             {
-                ErrorUtilities.VerifyThrowArgument(!XMakeElements.ReservedItemNames.Contains(name), "OM_ReservedName", name);
+                VerifyThrowReservedNameAllowItemSpecModifiers(name);
             }
             else
             {
-                ErrorUtilities.VerifyThrowArgument(!XMakeElements.ReservedItemNames.Contains(name) && !FileUtilities.ItemSpecModifiers.IsItemSpecModifier(name), "OM_ReservedName", name);
+                VerifyThrowReservedName(name);
             }
 
             _name = name;
@@ -227,6 +227,44 @@ namespace Microsoft.Build.Execution
         internal static ProjectMetadataInstance FactoryForDeserialization(ITranslator translator)
         {
             return new ProjectMetadataInstance(translator);
+        }
+
+        /// <summary>
+        /// Verifies that the name is not a reserved name.
+        /// </summary>
+        /// <remarks>
+        /// Exposed so project items can validate metadata names without allocating ProjectMetadataInstance.
+        /// </remarks>
+        internal static void VerifyThrowReservedName(string name)
+        {
+            // PERF: This sequence of checks is faster than a full HashSet lookup since finding a match is an error case.
+            // Otherwise, many keys would still match to a bucket and begin a string comparison.
+            VerifyThrowReservedNameAllowItemSpecModifiers(name);
+            foreach (string itemSpecModifier in FileUtilities.ItemSpecModifiers.All)
+            {
+                if (itemSpecModifier.Length == name.Length && itemSpecModifier[0] == name[0])
+                {
+                    ErrorUtilities.VerifyThrowArgument(!MSBuildNameIgnoreCaseComparer.Default.Equals(itemSpecModifier, name), "OM_ReservedName", name);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Verifies that the name is not a reserved name, while allowing item spec modifiers.
+        /// </summary>
+        /// <remarks>
+        /// Exposed so project items can validate metadata names without allocating ProjectMetadataInstance.
+        /// </remarks>
+        internal static void VerifyThrowReservedNameAllowItemSpecModifiers(string name)
+        {
+            ErrorUtilities.VerifyThrowArgumentLength(name);
+            foreach (string reservedName in XMakeElements.ReservedItemNames)
+            {
+                if (reservedName.Length == name.Length && reservedName[0] == name[0])
+                {
+                    ErrorUtilities.VerifyThrowArgument(!MSBuildNameIgnoreCaseComparer.Default.Equals(reservedName, name), "OM_ReservedName", name);
+                }
+            }
         }
     }
 }

--- a/src/Build/Microsoft.Build.csproj
+++ b/src/Build/Microsoft.Build.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="..\Shared\FileSystemSources.proj" />
   <Import Project="..\Shared\DebuggingSources.proj" />
@@ -79,9 +79,6 @@
     </Compile>
     <Compile Include="..\Shared\CanonicalError.cs">
       <Link>BackEnd\Components\RequestBuilder\IntrinsicTasks\CanonicalError.cs</Link>
-    </Compile>
-    <Compile Include="..\Shared\IConstrainedEqualityComparer.cs">
-      <Link>IConstrainedEqualityComparer.cs</Link>
     </Compile>
     <Compile Include="..\Shared\PropertyParser.cs">
       <Link>BackEnd\Components\RequestBuilder\IntrinsicTasks\PropertyParser.cs</Link>
@@ -381,7 +378,6 @@
       <Link>Collections\CopyOnWriteDictionary.cs</Link>
     </Compile>
     <Compile Include="Collections\CopyOnWritePropertyDictionary.cs" />
-    <Compile Include="..\Shared\MSBuildNameIgnoreCaseComparer.cs" />
     <Compile Include="Collections\HashTableUtility.cs" />
     <Compile Include="Collections\IConstrainableDictionary.cs" />
     <Compile Include="Collections\ICopyOnWritePropertyDictionary.cs" />

--- a/src/Framework/IConstrainedEqualityComparer.cs
+++ b/src/Framework/IConstrainedEqualityComparer.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
@@ -11,7 +11,11 @@ namespace Microsoft.Build.Collections
     ///     Defines methods to support the comparison of objects for
     ///     equality over constrained inputs.
     /// </summary>
+#if TASKHOST
+    internal interface IConstrainedEqualityComparer<T> : IEqualityComparer<T>
+#else
     internal interface IConstrainedEqualityComparer<in T> : IEqualityComparer<T>
+#endif
     {
         /// <summary>
         /// Determines whether the specified objects are equal, factoring in the specified bounds when comparing <paramref name="y"/>.

--- a/src/Framework/IMetadataContainer.cs
+++ b/src/Framework/IMetadataContainer.cs
@@ -13,6 +13,25 @@ namespace Microsoft.Build.Framework
     internal interface IMetadataContainer
     {
         /// <summary>
+        /// Gets the backing metadata dictionary in a serializable wrapper.
+        /// </summary>
+        /// <remarks>
+        /// If the implementation's backing dictionary does not support copy-on-write, it should return the default struct,
+        /// allowing the caller to decide whether to take the reference.
+        /// This can safely be used across AppDomain boundaries.
+        /// </remarks>
+        SerializableMetadata BackingMetadata { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether indicates whether the item has any custom metadata.
+        /// </summary>
+        /// <remarks>
+        /// Used to skip unnecessary enumerations when copying metadata between items, allowing copy-on-write cloning.
+        /// This is independent of a Count property as items may have multiple backing collections that need to be deduped.
+        /// </remarks>
+        bool HasCustomMetadata { get; }
+
+        /// <summary>
         /// Returns a list of metadata names and unescaped values, including
         /// metadata from item definition groups, but not including built-in
         /// metadata. Implementations should be low-overhead as the method

--- a/src/Framework/ImmutableDictionaryExtensions.cs
+++ b/src/Framework/ImmutableDictionaryExtensions.cs
@@ -1,0 +1,51 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using Microsoft.Build.Collections;
+
+namespace Microsoft.Build.Framework
+{
+    internal static class ImmutableDictionaryExtensions
+    {
+        /// <summary>
+        /// An empty dictionary pre-configured with a comparer for metadata dictionaries.
+        /// </summary>
+        public static readonly ImmutableDictionary<string, string> EmptyMetadata =
+            ImmutableDictionary<string, string>.Empty.WithComparers(MSBuildNameIgnoreCaseComparer.Default);
+
+        /// <summary>
+        /// Sets the given items while running a validation function on each key.
+        /// </summary>
+        /// <remarks>
+        /// ProjectItemInstance.TaskItem exposes dictionary values as ProjectMetadataInstance. For perf reasons,
+        /// we don't want to internally store ProjectMetadataInstance since it prevents us from sharing immutable
+        /// dictionaries with Utilities.TaskItem, and it results in more than 2x memory allocated per-entry.
+        /// </remarks>
+        public static ImmutableDictionary<string, string> SetItems(
+            this ImmutableDictionary<string, string> dictionary,
+            IEnumerable<KeyValuePair<string, string>> items,
+            Action<string> verifyThrowKey)
+        {
+            return dictionary.SetItems(ValidateItems(items, verifyThrowKey));
+
+            // PERF: This extra allocation is still faster than enumerating ImmutableDictionary after modification.
+            static IEnumerable<KeyValuePair<string, string>> ValidateItems(
+                IEnumerable<KeyValuePair<string, string>> items,
+                Action<string> verifyThrowKey)
+            {
+                foreach (KeyValuePair<string, string> item in items)
+                {
+                    verifyThrowKey.Invoke(item.Key);
+
+                    // Set null as empty string to match behavior with ProjectMetadataInstance.
+                    yield return item.Value == null
+                        ? new KeyValuePair<string, string>(item.Key, string.Empty)
+                        : item;
+                }
+            }
+        }
+    }
+}

--- a/src/Framework/ImmutableDictionaryExtensions.cs
+++ b/src/Framework/ImmutableDictionaryExtensions.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Build.Framework
             {
                 foreach (KeyValuePair<string, string> item in items)
                 {
-                    verifyThrowKey.Invoke(item.Key);
+                    verifyThrowKey(item.Key);
 
                     // Set null as empty string to match behavior with ProjectMetadataInstance.
                     yield return item.Value == null

--- a/src/Framework/MSBuildNameIgnoreCaseComparer.cs
+++ b/src/Framework/MSBuildNameIgnoreCaseComparer.cs
@@ -1,9 +1,9 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;
-using Microsoft.Build.Shared;
+using Microsoft.Build.Framework;
 
 #nullable disable
 
@@ -22,7 +22,7 @@ namespace Microsoft.Build.Collections
         /// <summary>
         /// The processor architecture on which we are running, but default it will be x86
         /// </summary>
-        private static readonly NativeMethodsShared.ProcessorArchitectures s_runningProcessorArchitecture = NativeMethodsShared.ProcessorArchitecture;
+        private static readonly NativeMethods.ProcessorArchitectures s_runningProcessorArchitecture = NativeMethods.ProcessorArchitecture;
 
         /// <summary>
         /// The default immutable comparer instance.
@@ -46,12 +46,12 @@ namespace Microsoft.Build.Collections
         {
             if (lengthToCompare < 0)
             {
-                ErrorUtilities.ThrowInternalError("Invalid lengthToCompare '{0}' {1} {2}", constrainedString, start, lengthToCompare);
+                EscapeHatches.ThrowInternalError("Invalid lengthToCompare '{0}' {1} {2}", constrainedString, start, lengthToCompare);
             }
 
             if (start < 0 || start > (constrainedString?.Length ?? 0) - lengthToCompare)
             {
-                ErrorUtilities.ThrowInternalError("Invalid start '{0}' {1} {2}", constrainedString, start, lengthToCompare);
+                EscapeHatches.ThrowInternalError("Invalid start '{0}' {1} {2}", constrainedString, start, lengthToCompare);
             }
 
             if (ReferenceEquals(compareToString, constrainedString))
@@ -72,8 +72,8 @@ namespace Microsoft.Build.Collections
                 return false;
             }
 
-            if ((s_runningProcessorArchitecture != NativeMethodsShared.ProcessorArchitectures.IA64)
-                && (s_runningProcessorArchitecture != NativeMethodsShared.ProcessorArchitectures.ARM))
+            if ((s_runningProcessorArchitecture != NativeMethods.ProcessorArchitectures.IA64)
+                && (s_runningProcessorArchitecture != NativeMethods.ProcessorArchitectures.ARM))
             {
                 // The use of unsafe here is quite a bit faster than the regular
                 // mechanism in the BCL. This is because we can make assumptions
@@ -120,8 +120,8 @@ namespace Microsoft.Build.Collections
                 return 0; // per BCL convention
             }
 
-            if ((s_runningProcessorArchitecture != NativeMethodsShared.ProcessorArchitectures.IA64)
-                && (s_runningProcessorArchitecture != NativeMethodsShared.ProcessorArchitectures.ARM))
+            if ((s_runningProcessorArchitecture != NativeMethods.ProcessorArchitectures.IA64)
+                && (s_runningProcessorArchitecture != NativeMethods.ProcessorArchitectures.ARM))
             {
                 unsafe
                 {

--- a/src/Framework/SerializableMetadata.cs
+++ b/src/Framework/SerializableMetadata.cs
@@ -1,0 +1,62 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Runtime.Serialization;
+
+namespace Microsoft.Build.Framework
+{
+    /// <summary>
+    /// Serializable wrapper for immutable metadata dictionaries.
+    /// Safe to use across AppDomains.
+    /// </summary>
+    [Serializable]
+    internal readonly struct SerializableMetadata : ISerializable
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SerializableMetadata"/> struct.
+        /// </summary>
+        /// <param name="dictionary">The metadata dictionary to set.</param>
+        /// <remarks>
+        /// Calling this constructor implies that the instance value is usable. As such, a null input will be converted
+        /// to an empty instance.
+        /// </remarks>
+        public SerializableMetadata(ImmutableDictionary<string, string> dictionary) =>
+            Dictionary = dictionary ?? ImmutableDictionaryExtensions.EmptyMetadata;
+
+        public SerializableMetadata(SerializationInfo info, StreamingContext context)
+        {
+            bool hasValue = info.GetBoolean("hasValue");
+            if (hasValue)
+            {
+                object entries = info.GetValue("value", typeof(KeyValuePair<string, string>[]))!;
+                Dictionary = ImmutableDictionaryExtensions.EmptyMetadata.AddRange((KeyValuePair<string, string>[])entries);
+            }
+        }
+
+        /// <summary>
+        /// Gets the backing metadata dictionary.
+        /// </summary>
+        internal ImmutableDictionary<string, string>? Dictionary { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the wrapped dictionary represents a usable instance.
+        /// </summary>
+        /// <remarks>
+        /// Since SerializableMetadata is a struct, this allows the default value to represent an unusable instance.
+        /// </remarks>
+        internal bool HasValue => Dictionary != null;
+
+        public void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            info.AddValue("hasValue", HasValue);
+            if (HasValue)
+            {
+                info.AddValue("value", Dictionary!.ToArray());
+            }
+        }
+    }
+}

--- a/src/Framework/TaskItemData.cs
+++ b/src/Framework/TaskItemData.cs
@@ -47,6 +47,10 @@ namespace Microsoft.Build.Framework
             Metadata = dictionary;
         }
 
+        SerializableMetadata IMetadataContainer.BackingMetadata => default;
+
+        bool IMetadataContainer.HasCustomMetadata => Metadata.Count > 0;
+
         IEnumerable<KeyValuePair<string, string>> IMetadataContainer.EnumerateMetadata() => Metadata;
 
         void IMetadataContainer.ImportMetadata(IEnumerable<KeyValuePair<string, string>> metadata)

--- a/src/MSBuild/MSBuild.csproj
+++ b/src/MSBuild/MSBuild.csproj
@@ -76,9 +76,6 @@
     <Compile Include="..\Shared\FileUtilitiesRegex.cs">
       <Link>FileUtilitiesRegex.cs</Link>
     </Compile>
-    <Compile Include="..\Shared\IConstrainedEqualityComparer.cs">
-      <Link>IConstrainedEqualityComparer.cs</Link>
-    </Compile>
     <Compile Include="..\Shared\QuotingUtilities.cs" />
     <Compile Include="..\Shared\RegisteredTaskObjectCacheBase.cs">
       <Link>RegisteredTaskObjectCacheBase.cs</Link>
@@ -91,7 +88,6 @@
     <Compile Include="..\Shared\BufferedReadStream.cs" />
     <Compile Include="..\Shared\CopyOnWriteDictionary.cs" />
     <Compile Include="..\Shared\IKeyed.cs" />
-    <Compile Include="..\Shared\MSBuildNameIgnoreCaseComparer.cs" />
     <Compile Include="..\Shared\NamedPipeUtil.cs" />
     <Compile Include="..\Shared\ReadOnlyEmptyCollection.cs" />
     <Compile Include="..\Shared\ReadOnlyEmptyDictionary.cs" />

--- a/src/MSBuildTaskHost/MSBuildTaskHost.csproj
+++ b/src/MSBuildTaskHost/MSBuildTaskHost.csproj
@@ -225,6 +225,11 @@
     <Compile Include="..\Framework\InterningWriteTranslator.cs" />
     <Compile Include="..\Framework\InternPathIds.cs" />
 
+    <Compile Include="..\Framework\IConstrainedEqualityComparer.cs" />
+    <Compile Include="..\Framework\ImmutableDictionaryExtensions.cs" />
+    <Compile Include="..\Framework\MSBuildNameIgnoreCaseComparer.cs" />
+    <Compile Include="..\Framework\SerializableMetadata.cs" />
+
     <Compile Include="..\Shared\FileSystem\IFileSystem.cs" />
     <Compile Include="..\Shared\FileSystem\FileSystems.cs" />
     <Compile Include="FileSystem\MSBuildTaskHostFileSystem.cs" />

--- a/src/Shared/CopyOnWriteDictionary.cs
+++ b/src/Shared/CopyOnWriteDictionary.cs
@@ -105,7 +105,9 @@ namespace Microsoft.Build.Collections
 
         public CopyOnWriteDictionary(IDictionary<string, V> dictionary)
         {
-            _backing = dictionary.ToImmutableDictionary();
+            _backing = dictionary.GetType() == typeof(ImmutableDictionary<string, V>)
+                ? (ImmutableDictionary<string, V>)dictionary
+                : dictionary.ToImmutableDictionary();
         }
 
         /// <summary>
@@ -171,6 +173,11 @@ namespace Microsoft.Build.Collections
             get => _backing.KeyComparer;
             private set => _backing = _backing.WithComparers(keyComparer: value);
         }
+
+        /// <summary>
+        /// The backing copy-on-write dictionary, safe to reuse.
+        /// </summary>
+        internal ImmutableDictionary<string, V> BackingDictionary => _backing;
 
         /// <summary>
         /// Accesses the value for the specified key.

--- a/src/Shared/TaskParameter.cs
+++ b/src/Shared/TaskParameter.cs
@@ -825,6 +825,10 @@ namespace Microsoft.Build.BackEnd
                 }
             }
 
+            public SerializableMetadata BackingMetadata => default;
+
+            public bool HasCustomMetadata => _customEscapedMetadata?.Count > 0;
+
             /// <summary>
             /// Allows the values of metadata on the item to be queried.
             /// </summary>

--- a/src/Shared/XMakeElements.cs
+++ b/src/Shared/XMakeElements.cs
@@ -1,10 +1,10 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 #if NET
 using System.Buffers;
 #endif
+using System;
 using System.Collections.Frozen;
-using Microsoft.Build.Collections;
 
 #nullable disable
 
@@ -46,7 +46,7 @@ namespace Microsoft.Build.Shared
             ['$', '@', '(', ')', '%', '*', '?', '.']);
 
         // Names that cannot be used as property or item names because they are reserved
-        internal static readonly FrozenSet<string> ReservedItemNames = FrozenSet.Create(MSBuildNameIgnoreCaseComparer.Default,
+        internal static readonly FrozenSet<string> ReservedItemNames = FrozenSet.Create(StringComparer.Ordinal,
         [
             // project, "Project" is not reserved, because unfortunately ProjectReference items already use it as metadata name.
             visualStudioProject,

--- a/src/Shared/XMakeElements.cs
+++ b/src/Shared/XMakeElements.cs
@@ -3,7 +3,8 @@
 #if NET
 using System.Buffers;
 #endif
-using System.Collections.Generic;
+using System.Collections.Frozen;
+using Microsoft.Build.Collections;
 
 #nullable disable
 
@@ -45,7 +46,7 @@ namespace Microsoft.Build.Shared
             ['$', '@', '(', ')', '%', '*', '?', '.']);
 
         // Names that cannot be used as property or item names because they are reserved
-        internal static readonly HashSet<string> ReservedItemNames =
+        internal static readonly FrozenSet<string> ReservedItemNames = FrozenSet.Create(MSBuildNameIgnoreCaseComparer.Default,
         [
             // project, "Project" is not reserved, because unfortunately ProjectReference items already use it as metadata name.
             visualStudioProject,
@@ -61,6 +62,6 @@ namespace Microsoft.Build.Shared
             choose,
             when,
             otherwise,
-        ];
+        ]);
     }
 }

--- a/src/Tasks/Microsoft.Build.Tasks.csproj
+++ b/src/Tasks/Microsoft.Build.Tasks.csproj
@@ -87,7 +87,6 @@
     <Compile Include="..\Shared\FileDelegates.cs">
       <Link>FileDelegates.cs</Link>
     </Compile>
-    <Compile Include="..\Shared\IConstrainedEqualityComparer.cs" />
     <Compile Include="..\Shared\PropertyParser.cs">
       <Link>PropertyParser.cs</Link>
     </Compile>
@@ -132,7 +131,6 @@
     <Compile Include="..\Shared\Modifiers.cs">
       <Link>Modifiers.cs</Link>
     </Compile>
-    <Compile Include="..\Shared\MSBuildNameIgnoreCaseComparer.cs" />
     <Compile Include="..\Shared\ReadOnlyCollection.cs" />
     <Compile Include="..\Shared\ReadOnlyEmptyDictionary.cs" />
     <Compile Include="..\Shared\Tracing.cs" />

--- a/src/Utilities/Microsoft.Build.Utilities.csproj
+++ b/src/Utilities/Microsoft.Build.Utilities.csproj
@@ -87,14 +87,8 @@
     <Compile Include="..\Shared\FrameworkLocationHelper.cs">
       <Link>Shared\FrameworkLocationHelper.cs</Link>
     </Compile>
-    <Compile Include="..\Shared\IConstrainedEqualityComparer.cs">
-      <Link>Shared\IConstrainedEqualityComparer.cs</Link>
-    </Compile>
     <Compile Include="..\Shared\IKeyed.cs">
       <Link>Shared\IKeyed.cs</Link>
-    </Compile>
-    <Compile Include="..\Shared\MSBuildNameIgnoreCaseComparer.cs">
-      <Link>Shared\MSBuildNameIgnoreCaseComparer.cs</Link>
     </Compile>
     <Compile Include="..\Shared\Modifiers.cs">
       <Link>Shared\Modifiers.cs</Link>

--- a/src/Utilities/TaskItem.cs
+++ b/src/Utilities/TaskItem.cs
@@ -124,7 +124,7 @@ namespace Microsoft.Build.Utilities
 
             if (itemMetadata.Count > 0)
             {
-                _metadata = ImmutableDictionaryExtensions.EmptyMetadata;
+                ImmutableDictionary<string, string>.Builder builder = ImmutableDictionaryExtensions.EmptyMetadata.ToBuilder();
 
                 foreach (DictionaryEntry singleMetadata in itemMetadata)
                 {
@@ -132,9 +132,11 @@ namespace Microsoft.Build.Utilities
                     string key = (string)singleMetadata.Key;
                     if (!FileUtilities.ItemSpecModifiers.IsDerivableItemSpecModifier(key))
                     {
-                        _metadata = _metadata.SetItem(key, (string)singleMetadata.Value ?? string.Empty);
+                        builder[key] = (string)singleMetadata.Value ?? string.Empty;
                     }
                 }
+
+                _metadata = builder.ToImmutable();
             }
         }
 

--- a/src/Utilities/TaskItem.cs
+++ b/src/Utilities/TaskItem.cs
@@ -541,9 +541,9 @@ namespace Microsoft.Build.Utilities
 
         void IMetadataContainer.ImportMetadata(IEnumerable<KeyValuePair<string, string>> metadata)
         {
-            if ((_metadata == null || _metadata.IsEmpty) && metadata.GetType() == typeof(ImmutableDictionary<string, string>))
+            if ((_metadata == null || _metadata.IsEmpty) && metadata is ImmutableDictionary<string, string> immutableMetadata)
             {
-                _metadata = (ImmutableDictionary<string, string>)metadata;
+                _metadata = immutableMetadata;
                 return;
             }
 

--- a/src/Utilities/TaskItem.cs
+++ b/src/Utilities/TaskItem.cs
@@ -6,6 +6,9 @@ using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
+#if FEATURE_APPDOMAIN
+using System.Runtime.Remoting;
+#endif
 #if FEATURE_SECURITY_PERMISSIONS
 using System.Security;
 #endif
@@ -13,6 +16,7 @@ using System.Security;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
 using Microsoft.Build.Collections;
+using System.Collections.Immutable;
 
 #nullable disable
 
@@ -45,7 +49,7 @@ namespace Microsoft.Build.Utilities
         // project file via XML child elements of the item element.  These have
         // no meaning to MSBuild, but tasks may use them.
         // Values are stored in escaped form.
-        private CopyOnWriteDictionary<string> _metadata;
+        private ImmutableDictionary<string, string> _metadata;
 
         // cache of the fullpath value
         private string _fullPath;
@@ -120,7 +124,7 @@ namespace Microsoft.Build.Utilities
 
             if (itemMetadata.Count > 0)
             {
-                _metadata = new CopyOnWriteDictionary<string>(MSBuildNameIgnoreCaseComparer.Default);
+                _metadata = ImmutableDictionaryExtensions.EmptyMetadata;
 
                 foreach (DictionaryEntry singleMetadata in itemMetadata)
                 {
@@ -128,7 +132,7 @@ namespace Microsoft.Build.Utilities
                     string key = (string)singleMetadata.Key;
                     if (!FileUtilities.ItemSpecModifiers.IsDerivableItemSpecModifier(key))
                     {
-                        _metadata[key] = (string)singleMetadata.Value ?? string.Empty;
+                        _metadata = _metadata.SetItem(key, (string)singleMetadata.Value ?? string.Empty);
                     }
                 }
             }
@@ -233,21 +237,25 @@ namespace Microsoft.Build.Utilities
         public int MetadataCount => (_metadata?.Count ?? 0) + FileUtilities.ItemSpecModifiers.All.Length;
 
         /// <summary>
+        /// Gets the backing metadata dictionary in a serializable wrapper.
+        /// </summary>
+        SerializableMetadata IMetadataContainer.BackingMetadata => Metadata;
+
+        /// <summary>
+        /// Gets a value indicating whether indicates whether the item has any custom metadata.
+        /// </summary>
+        bool IMetadataContainer.HasCustomMetadata => _metadata?.Count > 0;
+
+        /// <summary>
         /// Gets the metadata dictionary
         /// Property is required so that we can access the metadata dictionary in an item from
         /// another appdomain, as the CLR has implemented remoting policies that disallow accessing
         /// private fields in remoted items.
         /// </summary>
-        private CopyOnWriteDictionary<string> Metadata
+        private SerializableMetadata Metadata
         {
-            get
-            {
-                return _metadata;
-            }
-            set
-            {
-                _metadata = value;
-            }
+            get => new(_metadata);
+            set => _metadata = value.Dictionary;
         }
 
         #endregion
@@ -264,7 +272,7 @@ namespace Microsoft.Build.Utilities
             ErrorUtilities.VerifyThrowArgument(!FileUtilities.ItemSpecModifiers.IsItemSpecModifier(metadataName),
                 "Shared.CannotChangeItemSpecModifiers", metadataName);
 
-            _metadata?.Remove(metadataName);
+            _metadata = _metadata?.Remove(metadataName);
         }
 
         /// <summary>
@@ -286,9 +294,9 @@ namespace Microsoft.Build.Utilities
             ErrorUtilities.VerifyThrowArgument(!FileUtilities.ItemSpecModifiers.IsDerivableItemSpecModifier(metadataName),
                 "Shared.CannotChangeItemSpecModifiers", metadataName);
 
-            _metadata ??= new CopyOnWriteDictionary<string>(MSBuildNameIgnoreCaseComparer.Default);
+            _metadata ??= ImmutableDictionaryExtensions.EmptyMetadata;
 
-            _metadata[metadataName] = metadataValue ?? string.Empty;
+            _metadata = _metadata.SetItem(metadataName, metadataValue ?? string.Empty);
         }
 
         /// <summary>
@@ -319,28 +327,55 @@ namespace Microsoft.Build.Utilities
             // between items, and need to know the source item where the metadata came from
             string originalItemSpec = destinationItem.GetMetadata("OriginalItemSpec");
             ITaskItem2 destinationAsITaskItem2 = destinationItem as ITaskItem2;
+            IMetadataContainer destinationAsMetadataContainer = destinationItem as IMetadataContainer;
 
             if (_metadata != null)
             {
                 if (destinationItem is TaskItem destinationAsTaskItem)
                 {
-                    CopyOnWriteDictionary<string> copiedMetadata;
+                    ImmutableDictionary<string, string> copiedMetadata;
+                    ImmutableDictionary<string, string> destinationMetadata = destinationAsTaskItem.Metadata.Dictionary;
+
                     // Avoid a copy if we can, and if not, minimize the number of items we have to set.
-                    if (destinationAsTaskItem.Metadata == null)
+                    if (!destinationAsMetadataContainer.HasCustomMetadata)
                     {
-                        copiedMetadata = _metadata.Clone(); // Copy on write!
+                        copiedMetadata = _metadata;
                     }
-                    else if (destinationAsTaskItem.Metadata.Count < _metadata.Count)
+                    else if (destinationMetadata.Count < _metadata.Count)
                     {
-                        copiedMetadata = _metadata.Clone(); // Copy on write!
-                        copiedMetadata.SetItems(destinationAsTaskItem.Metadata.Where(entry => !String.IsNullOrEmpty(entry.Value)));
+                        copiedMetadata = _metadata.SetItems(destinationMetadata.Where(entry => !String.IsNullOrEmpty(entry.Value)));
                     }
                     else
                     {
-                        copiedMetadata = destinationAsTaskItem.Metadata.Clone();
-                        copiedMetadata.SetItems(_metadata.Where(entry => !destinationAsTaskItem.Metadata.TryGetValue(entry.Key, out string val) || String.IsNullOrEmpty(val)));
+                        copiedMetadata = destinationMetadata.SetItems(_metadata.Where(entry => !destinationMetadata.TryGetValue(entry.Key, out string val) || String.IsNullOrEmpty(val)));
                     }
-                    destinationAsTaskItem.Metadata = copiedMetadata;
+
+                    // Wrap in SerializableMetadata since ImmutableDictionary is not serializable.
+                    destinationAsTaskItem.Metadata = new SerializableMetadata(copiedMetadata);
+                }
+                else if (destinationAsITaskItem2 != null && destinationAsMetadataContainer != null)
+                {
+                    // Most likely the destination item is a ProjectItemInstance.TaskItem.
+                    // Defer any LINQ queries. If the destination supports copy-on-write cloning, we may be able to pass
+                    // a direct reference to the metadata.
+                    IEnumerable<KeyValuePair<string, string>> metadataToImport = _metadata;
+
+                    // If the destination already has existing metadata, only import values which are not already set.
+                    if (destinationAsMetadataContainer.HasCustomMetadata)
+                    {
+                        metadataToImport = metadataToImport
+                            .Where(metadatum => string.IsNullOrEmpty(destinationAsITaskItem2.GetMetadataValueEscaped(metadatum.Key)));
+                    }
+
+#if FEATURE_APPDOMAIN
+                    if (RemotingServices.IsTransparentProxy(destinationItem))
+                    {
+                        // Linq is not serializable so materialize the collection before making the call.
+                        metadataToImport = metadataToImport.ToList();
+                    }
+#endif
+
+                    destinationAsMetadataContainer.ImportMetadata(metadataToImport);
                 }
                 else
                 {
@@ -482,7 +517,7 @@ namespace Microsoft.Build.Utilities
         /// <returns>The cloned metadata.</returns>
         IDictionary ITaskItem2.CloneCustomMetadataEscaped() => _metadata == null
             ? new CopyOnWriteDictionary<string>(MSBuildNameIgnoreCaseComparer.Default)
-            : _metadata.Clone();
+            : new CopyOnWriteDictionary<string>(_metadata);
 
         #endregion
 
@@ -504,8 +539,14 @@ namespace Microsoft.Build.Utilities
 
         void IMetadataContainer.ImportMetadata(IEnumerable<KeyValuePair<string, string>> metadata)
         {
-            _metadata ??= new CopyOnWriteDictionary<string>(MSBuildNameIgnoreCaseComparer.Default);
-            _metadata.SetItems(metadata.Select(kvp => new KeyValuePair<string, string>(kvp.Key, kvp.Value ?? string.Empty)));
+            if ((_metadata == null || _metadata.IsEmpty) && metadata.GetType() == typeof(ImmutableDictionary<string, string>))
+            {
+                _metadata = (ImmutableDictionary<string, string>)metadata;
+                return;
+            }
+
+            _metadata ??= ImmutableDictionaryExtensions.EmptyMetadata;
+            _metadata = _metadata.SetItems(metadata.Select(kvp => new KeyValuePair<string, string>(kvp.Key, kvp.Value ?? string.Empty)));
         }
 
 #if FEATURE_APPDOMAIN


### PR DESCRIPTION
### Fixes

Fairly complex refactor to replace `TaskItem` metadata wrapper classes with direct use of `ImmutableDictionary<string, string>`. This eliminates multiple categories of allocations and significantly reduces known hot paths such as `GatherTaskItemOutputs` and `CopyMetadataTo`.

On OrchardCore, this change alone cuts RAR by ~40% + many other tasks, reduces allocations by ~1.4GB, and has a noticeable impact on E2E build time.

Also fixes #11895

**GatherTaskItemOutputs - Before**
<img width="727" height="212" alt="image" src="https://github.com/user-attachments/assets/94b58e27-eca5-4950-90b9-4eacf89d3a84" />

**GatherTaskItemOutputs - After**
<img width="863" height="230" alt="image" src="https://github.com/user-attachments/assets/98335118-41f7-4c90-9033-b50e1c640f10" />

**/m:1 Total Allocations - Before**
<img width="287" height="185" alt="image" src="https://github.com/user-attachments/assets/b4c4f674-9f5a-4bb7-8979-68d124c9fde0" />

**/m:1 Total Allocations - After**
<img width="292" height="199" alt="image" src="https://github.com/user-attachments/assets/c692e8dd-be5a-4c8a-ab8f-9290c4185ce8" />

**/m:1 Working Set - Before**
<img width="330" height="230" alt="image" src="https://github.com/user-attachments/assets/409d79ec-bdd5-448c-9511-952d6bebba41" />

**/m:1 Working Set - After**
<img width="352" height="241" alt="image" src="https://github.com/user-attachments/assets/45e5714d-9edc-4415-a77b-a5dd325fe2dd" />

**/m cold incremental build (no nodes) - Before**
```
...
     2771 ms  ResolvePackageAssets                     436 calls
     3057 ms  ProcessFrameworkReferences               436 calls
     5804 ms  ResolvePackageFileConflicts              436 calls
     6904 ms  Copy                                     7037 calls
    25061 ms  ResolveAssemblyReference                 436 calls
    144029 ms  CallTarget                               872 calls
    7396229 ms  MSBuild                                  2388 calls

Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:42.91
```

**/m cold incremental build (no nodes) - After**
```
...
     1861 ms  ResolvePackageAssets                     436 calls
     2107 ms  AssignProjectConfiguration               436 calls
     2224 ms  ProcessFrameworkReferences               436 calls
     5492 ms  ResolvePackageFileConflicts              436 calls
     5770 ms  Copy                                     7037 calls
    16408 ms  ResolveAssemblyReference                 436 calls
    163157 ms  CallTarget                               872 calls
    5339115 ms  MSBuild                                  2388 calls

Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:34.41
```

**/m hot incremental build (existing nodes) - Before**
```
...
     1311 ms  ResolvePackageAssets                     436 calls
     1611 ms  ResolveTargetingPackAssets               436 calls
     5295 ms  ResolvePackageFileConflicts              436 calls
     5965 ms  Copy                                     7037 calls
    21149 ms  ResolveAssemblyReference                 436 calls
    76149 ms  CallTarget                               872 calls
    3354848 ms  MSBuild                                  2388 calls

Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:27.71
```

**/m hot incremental build (existing nodes) - After**

```
...
      782 ms  ProcessFrameworkReferences               436 calls
      897 ms  AssignProjectConfiguration               436 calls
      954 ms  Microsoft.Build.Tasks.Git.GetUntrackedFiles 420 calls
      955 ms  ResolvePackageAssets                     436 calls
     4440 ms  Copy                                     7037 calls
     4434 ms  ResolvePackageFileConflicts              436 calls
    12249 ms  ResolveAssemblyReference                 436 calls
    100407 ms  CallTarget                               872 calls
    3321973 ms  MSBuild                                  2388 calls

Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:23.32

```

### Context

`ProjectItemInstance.TaskItem` (engine side) and `Utilities.TaskItem` (task side) currently use a various wrapping collections to implement their backing dictionaries:

*ProjectItemInstance.TaskItem*
- `ProjectMetadataInstance` to wrap key/value pairs and validate keys
- `CopyOnWritePropertyDictionary<ProjectMetadataInstance>` to provide a COW API that automatically converts and enumerates over `ProjectMetadataInstance`

*Utilities.TaskItem*
- `CopyOnWriteDictionary<string, string>` to provide a COW API

There are a few main issues here:

- Given that these are the most allocated objects in MSBuild, even these basic wrapping instances are responsible for a large number of allocations.
- Because the types between `ImmutableDictionary` implementations don't match, "cloning" to another type always results in fully rebuilding the dictionary instance.
- `ProjectMetadataInstance` is just the key + evaluated value, and everything else is derived - so we're essentially doubling the required memory per-entry.

### Changes Made

The overall gist of this change is replacing the above objects with direct use of `ImmutableDictionary<string, string>`, and adding a number of fast-paths that take advantage of this.

- To replicate the reserved name + itemspec modifier validation in `ProjectMetadataInstance`, `ImmutableDictionaryExtensions.SetItems()` is used throughout the Engine side. Otherwise, these are really only used now in the public API which can't be changed.
- `ImmutableDictionaryExtensions.EmptyMetadata` provides a singleton with `MSBuildNameIgnoreCaseComparer` already configured.
- To handle cross-AppDomain calls via `IMetadataContainer`, `SerializableMetadata` replaces `CopyOnWriteDictionary` as a simple struct wrapper that handles serialization.
- Use of `ICopyOnWritePropertyDictionary` is removed from `ProjectItemInstance` and `ItemDefinitionInstance` since this would add a fair amount of complexity to extracting and type checking backing dictionaries.

### Testing Notes

One area that isn't well tested is the immutable instance caching that was added for the CPS evaluation cache (which I believe is used by C# Dev Kit and VS?). Since this change removes use of interfaces for backing dictionaries, this bypasses the converters and instance caches (see `ProjectInstance.cs`).

I **suspect** that the massive savings in allocations and CPU here would offset any gains made by the immutable instance caching for `ICopyOnWritePropertyDictionary` and `ProjectMetadataInstance`. Plus the higher-level classes such as `ProjectItemInstance` are still cached, so I'm not even sure if it makes sense to still apply caching to the backing fields.

Either way though, the main issue is that there doesn't seem to be any unit testing around that functionality.

There's also a decent amount of dead code now in the replaced classes and room for merging some APIs given we have a single concrete-type, but this PR is already big enough as-is 😅

### Other Motivation

I also have a prototype of an array-based immutable dictionary that cuts off even **more** time here, and additionally Translator serialization of TaskItems since the slowest area is serializing `ImmutableDictionary`. That would cut down a large chunk of overhead off of the TaskHost and RAR out-of-proc, and after this change, it would be essentially a drop-in replacement.

### Bonus allocation / perf data

**ImmutableDictionary + related - Before**
<img width="948" height="505" alt="image" src="https://github.com/user-attachments/assets/c3f638bf-b6f4-4965-b1e7-db5089d47185" />

**ImmutableDictionary + related - After**
<img width="875" height="526" alt="image" src="https://github.com/user-attachments/assets/46034d00-b913-4950-a1fd-e3990b0f1e5c" />

**CopyOnWriteDictionary - Before**
<img width="951" height="405" alt="image" src="https://github.com/user-attachments/assets/c6f26435-0cea-43fe-8cbb-dc3c2ecafc5b" />

**CopyOnWriteDictionary - After**
<img width="875" height="413" alt="image" src="https://github.com/user-attachments/assets/cfcc5df9-543a-4ea4-a892-606bcc0e39b1" />

**ProjectMetadataInstance - Before**
<img width="958" height="509" alt="image" src="https://github.com/user-attachments/assets/94fced0c-3302-4f7f-9909-a526a6484128" />

**ProjectMetadataInstance - After**
<img width="890" height="361" alt="image" src="https://github.com/user-attachments/assets/bf2bb957-73bf-4592-9d75-d8af7d5c2c92" />

