### PR TITLE
Track FileWritesShareable that occur underneath the project directory

### DIFF
--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -5787,8 +5787,9 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <FilesToTrackFromOutputDirectories Include="@(FileWritesShareable)" Condition=" $(TrackFileWritesShareableOutsideOfProjectDirectory) == true "/>
     </ItemGroup>
     
+    <!-- Even if we don't allow cleaning filewrites from outside of the project bubble, we should still include FileWritesShareable that are inside the bubble -->
     <FindUnderPath Condition="!$(TrackFileWritesShareableOutsideOfProjectDirectory)" Path="$(MSBuildProjectDirectory)" Files="@(FileWritesShareable)" UpdateToAbsolutePaths="true">
-      <Output TaskParameter="InPath" ItemName="FileWrites"/>
+      <Output TaskParameter="InPath" ItemName="FilesToTrackFromOutputDirectories"/>
     </FindUnderPath>
 
     <!-- Find all files in the final output directory. -->


### PR DESCRIPTION
There are tests in the SDK that verify clean works in various scenarios:

```csharp
       [Fact]
        public void It_cleans_the_project_successfully_with_static_graph_and_isolation()
        {
            var (testAsset, outputDirectories) = BuildAppWithTransitiveDependenciesAndTransitiveCompileReference(new[] { "/graph", "/bl:build-{}.binlog" });

            var cleanCommand = new DotnetCommand(
                Log,
                "msbuild",
                Path.Combine(testAsset.TestRoot, "1", "1.csproj"),
                "/t:clean",
                "/graph",
                "/bl:clean-{}.binlog");

            cleanCommand
                .Execute()
                .Should()
                .Pass();

            foreach (var outputDirectory in outputDirectories)
            {
                outputDirectory.Value.GetFileSystemInfos()
                    .Should()
                    .BeEmpty();
            }
        }
```

This one and several others started failing when VMR codeflow with https://github.com/dotnet/msbuild/pull/12096 in it flowed to SDK.

The root of the problem is that in the case where we aren't allowing FileWritesShareable to be deleted from outside the project bubble, we should still add FileWritesShared from within the bubble to the list of files to be cleaned.

In the broken scenario, we can see the inside-bubble FileWritesShared items being added to FileWrites, but because FileWrites is no longer directly being used this assignment does nothing:
<img width="777" height="740" alt="image" src="https://github.com/user-attachments/assets/6d94d8ea-41f0-45b1-9e05-d1ab4745e77c" />

In the corrected scenario, we can see the inside-bubble FileWritesShared items being added to FilesToTrackFromOutputDirectories, and from there flowing to the _CleanCurrentFileWrites as expected:
<img width="859" height="848" alt="image" src="https://github.com/user-attachments/assets/d4f5a62f-5a78-4f4a-8f3c-9ebcd73eda90" />

As a result, the Clean target works again.
