### PR TITLE
Make node contexts managed by NodeProviderInProc concurrent

### DIFF
--- a/src/Build/BackEnd/Components/Communications/NodeProviderInProc.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderInProc.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;
@@ -60,7 +61,7 @@ namespace Microsoft.Build.BackEnd
         /// <summary>
         /// A mapping of all the nodes managed by this provider.
         /// </summary>
-        private Dictionary<int, NodeContext> _nodeContexts;
+        private ConcurrentDictionary<int, NodeContext> _nodeContexts;
 
         /// <summary>
         /// Flag indicating we have disposed.
@@ -121,7 +122,7 @@ namespace Microsoft.Build.BackEnd
         public void InitializeComponent(IBuildComponentHost host)
         {
             _componentHost = host;
-            _nodeContexts = new Dictionary<int, NodeContext>();
+            _nodeContexts = new ConcurrentDictionary<int, NodeContext>();
         }
 
         /// <summary>
@@ -303,7 +304,7 @@ namespace Microsoft.Build.BackEnd
             // will report that the in-proc node is still in use when it has actually shut down.
             if (packet.Type == NodePacketType.NodeShutdown)
             {
-                _nodeContexts.Remove(nodeId);
+                _nodeContexts.TryRemove(nodeId, out _);
 
                 // Release the operating environment semaphore if we were holding it.
                 if ((_componentHost.BuildParameters.SaveOperatingEnvironment) &&


### PR DESCRIPTION
### Context
There is a concurrency issue with `NodeProviderInProc._nodeContexts`. It should be `ConcurrentDictionary`

https://dev.azure.com/dnceng-public/public/_build/results?buildId=1098853&view=ms.vss-test-web.build-test-results-tab&runId=30052564&resultId=101712&paneView=debug

```
at System.ThrowHelper.ThrowInvalidOperationException(ExceptionResource resource)
   at System.Collections.Generic.Dictionary`2.ValueCollection.Enumerator.MoveNext()
   at Microsoft.Build.BackEnd.NodeProviderInProc.ShutdownConnectedNodes(Boolean enableReuse) in /_/src/Build/BackEnd/Components/Communications/NodeProviderInProc.cs:line 160
   at Microsoft.Build.BackEnd.NodeManager.ShutdownConnectedNodes(Boolean enableReuse) in /_/src/Build/BackEnd/Components/Communications/NodeManager.cs:line 148
   at Microsoft.Build.Execution.BuildManager.ShutdownConnectedNodes(Boolean abort) in /_/src/Build/BackEnd/BuildManager/BuildManager.cs:line 2161
   at Microsoft.Build.Execution.BuildManager.EndBuild() in /_/src/Build/BackEnd/BuildManager/BuildManager.cs:line 1080
   at Microsoft.Build.Execution.BuildManager.Build[TRequestData,TResultData](BuildParameters parameters, TRequestData requestData) in /_/src/Build/BackEnd/BuildManager/BuildManager.cs:line 1210
   at Microsoft.Build.Execution.BuildManager.Build(BuildParameters parameters, BuildRequestData requestData) in /_/src/Build/BackEnd/BuildManager/BuildManager.cs:line 1221
   at Microsoft.Build.Execution.ProjectInstance.Build(String[] targets, IEnumerable`1 loggers, IEnumerable`1 remoteLoggers, ILoggingService loggingService, Int32 maxNodeCount, IDictionary`2& targetOutputs) in /_/src/Build/Instance/ProjectInstance.cs:line 2808
   at Microsoft.Build.Evaluation.Project.ProjectImpl.Build(String[] targets, IEnumerable`1 loggers, IEnumerable`1 remoteLoggers, EvaluationContext evaluationContext) in /_/src/Build/Definition/Project.cs:line 3354
   at Microsoft.Build.Evaluation.Project.Build(String[] targets, IEnumerable`1 loggers, IEnumerable`1 remoteLoggers, EvaluationContext evaluationContext) in /_/src/Build/Definition/Project.cs:line 1645
   at Microsoft.Build.Evaluation.Project.Build(String[] targets, IEnumerable`1 loggers, IEnumerable`1 remoteLoggers) in /_/src/Build/Definition/Project.cs:line 1632
   at Microsoft.Build.Evaluation.Project.Build(String[] targets) in /_/src/Build/Definition/Project.cs:line 1599
   at Microsoft.Build.Evaluation.Project.Build() in /_/src/Build/Definition/Project.cs:line 1493
   at Microsoft.Build.Engine.UnitTests.ChangeWaves_Tests.buildSimpleProjectAndValidateChangeWave(TestEnvironment testEnvironment, Version versionToCheckAgainstCurrentChangeWave, Version currentChangeWaveShouldUltimatelyResolveTo, String[] warningCodesLogShouldContain) in D:\a\1\s\src\Build.UnitTests\ChangeWaves_Tests.cs:line 65
   at Microsoft.Build.Engine.UnitTests.ChangeWaves_Tests.CorrectlyDetermineDisabledFeatures() in D:\a\1\s\src\Build.UnitTests\ChangeWaves_Tests.cs:line 227
```

### Changes made
Used `ConcurrentDictionary` instead of `Dictionary` for node contexts managed by `NodeProviderInProc`
