### PR TITLE
Don't populate ProjectInstance.EvaluatedItemElements in CPS-specific constructors

### DIFF
--- a/src/Build/Instance/ProjectInstance.cs
+++ b/src/Build/Instance/ProjectInstance.cs
@@ -407,11 +407,7 @@ namespace Microsoft.Build.Execution
 
             this.ProjectRootElementCache = project.ProjectCollection.ProjectRootElementCache;
 
-            this.EvaluatedItemElements = new List<ProjectItemElement>(project.Items.Count);
-            foreach (var item in project.Items)
-            {
-                this.EvaluatedItemElements.Add(item.Xml);
-            }
+            this.EvaluatedItemElements = new List<ProjectItemElement>();
 
             _usingDifferentToolsVersionFromProjectFile = false;
             _originalProjectToolsVersion = project.ToolsVersion;
@@ -483,11 +479,7 @@ namespace Microsoft.Build.Execution
 
             ProjectRootElementCache = linkedProject.ProjectCollection.ProjectRootElementCache;
 
-            EvaluatedItemElements = new List<ProjectItemElement>(linkedProject.Items.Count);
-            foreach (var item in linkedProject.Items)
-            {
-                EvaluatedItemElements.Add(item.Xml);
-            }
+            EvaluatedItemElements = new List<ProjectItemElement>();
 
             _usingDifferentToolsVersionFromProjectFile = false;
             _originalProjectToolsVersion = linkedProject.ToolsVersion;


### PR DESCRIPTION
Fixes #
AzDO 2534627

### Context
CPS has a CPS-specific constructor for building a ProjectInstance from its evaluation cache data. This constructor populates EvaluatedItemElements, which uses a not insignificant amount of memory.

### Changes Made
This PR modifies the CPS-specific constructors such that the contents of EvaluatedItemElements are no longer populated.

### Testing
Manual verification of CPS scenarios.

### Notes
