### PR TITLE
Add support for schema validation in `dotnet msbuild`.

### DIFF
--- a/src/Directory.BeforeCommon.targets
+++ b/src/Directory.BeforeCommon.targets
@@ -66,7 +66,6 @@
     <DefineConstants>$(DefineConstants);FEATURE_XAML_TYPES</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_XAMLTASKFACTORY</DefineConstants>
     <FeatureXamlTypes>true</FeatureXamlTypes>
-    <DefineConstants>$(DefineConstants);FEATURE_XML_SCHEMA_VALIDATION</DefineConstants>
     <DefineConstants Condition="'$(MachineIndependentBuild)' != 'true'">$(DefineConstants);FEATURE_WIN32_REGISTRY</DefineConstants>
     <DefineConstants Condition="'$(MachineIndependentBuild)' != 'true' and '$(TargetFrameworkVersion)' != 'v3.5' and '$(DotNetBuildSourceOnly)' != 'true'">$(DefineConstants);FEATURE_VISUALSTUDIOSETUP</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_MSCOREE</DefineConstants>

--- a/src/MSBuild.UnitTests/CommandLineSwitches_Tests.cs
+++ b/src/MSBuild.UnitTests/CommandLineSwitches_Tests.cs
@@ -474,7 +474,6 @@ namespace Microsoft.Build.UnitTests
             unquoteParameters.ShouldBeTrue();
         }
 
-#if FEATURE_XML_SCHEMA_VALIDATION
         [Theory]
         [InlineData("validate")]
         [InlineData("VALIDATE")]
@@ -498,7 +497,6 @@ namespace Microsoft.Build.UnitTests
             missingParametersErrorMessage.ShouldBeNull();
             unquoteParameters.ShouldBeTrue();
         }
-#endif
 
         [Theory]
         [InlineData("preprocess")]
@@ -1185,10 +1183,8 @@ namespace Microsoft.Build.UnitTests
                                         Array.Empty<ILogger>(),
                                         LoggerVerbosity.Normal,
                                         Array.Empty<DistributedLoggerRecord>(),
-#if FEATURE_XML_SCHEMA_VALIDATION
                                         false,
                                         null,
-#endif
                                         1,
                                         false,
                                         true,

--- a/src/MSBuild.UnitTests/ProjectSchemaValidationHandler_Tests.cs
+++ b/src/MSBuild.UnitTests/ProjectSchemaValidationHandler_Tests.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#if FEATURE_XML_SCHEMA_VALIDATION
 using System;
 using System.IO;
 using System.Reflection;
@@ -397,4 +396,3 @@ namespace Microsoft.Build.UnitTests
 #pragma warning restore format
     }
 }
-#endif

--- a/src/MSBuild/CommandLineSwitches.cs
+++ b/src/MSBuild/CommandLineSwitches.cs
@@ -72,9 +72,7 @@ namespace Microsoft.Build.CommandLine
             Logger,
             DistributedLogger,
             Verbosity,
-#if FEATURE_XML_SCHEMA_VALIDATION
             Validate,
-#endif
             ConsoleLoggerParameters,
             NodeMode,
             MaxCPUCount,
@@ -247,9 +245,7 @@ namespace Microsoft.Build.CommandLine
             new ParameterizedSwitchInfo(  ["logger", "l"],                      ParameterizedSwitch.Logger,                     null,                           false,          "MissingLoggerError",                  false,  false,   "HelpMessage_11_LoggerSwitch"),
             new ParameterizedSwitchInfo(  ["distributedlogger", "dl"],          ParameterizedSwitch.DistributedLogger,          null,                           false,          "MissingLoggerError",                  false,  false,   "HelpMessage_18_DistributedLoggerSwitch"),
             new ParameterizedSwitchInfo(  ["verbosity", "v"],                   ParameterizedSwitch.Verbosity,                  null,                           false,          "MissingVerbosityError",               true,   false,   "HelpMessage_12_VerbositySwitch"),
-#if FEATURE_XML_SCHEMA_VALIDATION
             new ParameterizedSwitchInfo(  ["validate", "val"],                  ParameterizedSwitch.Validate,                   null,                           false,          null,                                  true,   false,   "HelpMessage_15_ValidateSwitch"),
-#endif
             new ParameterizedSwitchInfo(  ["consoleloggerparameters", "clp"],   ParameterizedSwitch.ConsoleLoggerParameters,    null,                           false,          "MissingConsoleLoggerParameterError",  true,   false,   "HelpMessage_13_ConsoleLoggerParametersSwitch"),
             new ParameterizedSwitchInfo(  ["nodemode", "nmode"],                ParameterizedSwitch.NodeMode,                   null,                           false,          null,                                  false,  false,   null),
             new ParameterizedSwitchInfo(  ["maxcpucount", "m"],                 ParameterizedSwitch.MaxCPUCount,                null,                           false,          "MissingMaxCPUCountError",             true,   false,   "HelpMessage_17_MaximumCPUSwitch"),

--- a/src/MSBuild/ProjectSchemaValidationHandler.cs
+++ b/src/MSBuild/ProjectSchemaValidationHandler.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#if FEATURE_XML_SCHEMA_VALIDATION
 using System;
 using System.IO;
 using System.Xml;
@@ -276,4 +275,3 @@ namespace Microsoft.Build.CommandLine
 #pragma warning restore format
     }
 }
-#endif

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -710,10 +710,8 @@ namespace Microsoft.Build.CommandLine
                 LoggerVerbosity verbosity = LoggerVerbosity.Normal;
                 LoggerVerbosity originalVerbosity = LoggerVerbosity.Normal;
                 List<DistributedLoggerRecord> distributedLoggerRecords = null;
-#if FEATURE_XML_SCHEMA_VALIDATION
                 bool needToValidateProject = false;
                 string schemaFile = null;
-#endif
                 int cpuCount = 1;
                 bool multiThreaded = false;
 #if FEATURE_NODE_REUSE
@@ -757,10 +755,8 @@ namespace Microsoft.Build.CommandLine
                                             ref verbosity,
                                             ref originalVerbosity,
                                             ref distributedLoggerRecords,
-#if FEATURE_XML_SCHEMA_VALIDATION
                                             ref needToValidateProject,
                                             ref schemaFile,
-#endif
                                             ref cpuCount,
                                             ref multiThreaded,
                                             ref enableNodeReuse,
@@ -881,35 +877,34 @@ namespace Microsoft.Build.CommandLine
                                 loggers,
                                 verbosity,
                                 distributedLoggerRecords.ToArray(),
-#if FEATURE_XML_SCHEMA_VALIDATION
-                                needToValidateProject, schemaFile,
-#endif
-                                    cpuCount,
-                                    multiThreaded,
-                                    enableNodeReuse,
-                                    preprocessWriter,
-                                    targetsWriter,
-                                    detailedSummary,
-                                    warningsAsErrors,
-                                    warningsNotAsErrors,
-                                    warningsAsMessages,
-                                    enableRestore,
-                                    profilerLogger,
-                                    enableProfiler,
-                                    interactive,
-                                    isolateProjects,
-                                    graphBuildOptions,
-                                    lowPriority,
-                                    question,
-                                    isBuildCheckEnabled,
-                                    inputResultsCaches,
-                                    outputResultsCache,
-                                    saveProjectResult: outputPropertiesItemsOrTargetResults,
-                                    ref result,
+                                needToValidateProject,
+                                schemaFile,
+                                cpuCount,
+                                multiThreaded,
+                                enableNodeReuse,
+                                preprocessWriter,
+                                targetsWriter,
+                                detailedSummary,
+                                warningsAsErrors,
+                                warningsNotAsErrors,
+                                warningsAsMessages,
+                                enableRestore,
+                                profilerLogger,
+                                enableProfiler,
+                                interactive,
+                                isolateProjects,
+                                graphBuildOptions,
+                                lowPriority,
+                                question,
+                                isBuildCheckEnabled,
+                                inputResultsCaches,
+                                outputResultsCache,
+                                saveProjectResult: outputPropertiesItemsOrTargetResults,
+                                ref result,
 #if FEATURE_REPORTFILEACCESSES
-                                    reportFileAccesses,
+                                reportFileAccesses,
 #endif
-                                    commandLine))
+                                commandLine))
                         {
                             exitType = ExitType.BuildError;
                         }
@@ -1293,10 +1288,8 @@ namespace Microsoft.Build.CommandLine
             ILogger[] loggers,
             LoggerVerbosity verbosity,
             DistributedLoggerRecord[] distributedLoggerRecords,
-#if FEATURE_XML_SCHEMA_VALIDATION
             bool needToValidateProject,
             string schemaFile,
-#endif
             int cpuCount,
             bool multiThreaded,
             bool enableNodeReuse,
@@ -1430,7 +1423,6 @@ namespace Microsoft.Build.CommandLine
 
                 bool isSolution = FileUtilities.IsSolutionFilename(projectFile);
 
-#if FEATURE_XML_SCHEMA_VALIDATION
                 // If the user has requested that the schema be validated, do that here.
                 if (needToValidateProject && !isSolution)
                 {
@@ -1448,7 +1440,6 @@ namespace Microsoft.Build.CommandLine
                     // we can safely assume that the project successfully validated.
                     projectCollection.UnloadProject(project);
                 }
-#endif
 
                 if (isPreprocess)
                 {
@@ -2518,10 +2509,8 @@ namespace Microsoft.Build.CommandLine
             ref LoggerVerbosity verbosity,
             ref LoggerVerbosity originalVerbosity,
             ref List<DistributedLoggerRecord> distributedLoggerRecords,
-#if FEATURE_XML_SCHEMA_VALIDATION
             ref bool needToValidateProject,
             ref string schemaFile,
-#endif
             ref int cpuCount,
             ref bool multiThreaded,
             ref bool enableNodeReuse,
@@ -2658,10 +2647,8 @@ namespace Microsoft.Build.CommandLine
                                                            ref verbosity,
                                                            ref originalVerbosity,
                                                            ref distributedLoggerRecords,
-#if FEATURE_XML_SCHEMA_VALIDATION
                                                            ref needToValidateProject,
                                                            ref schemaFile,
-#endif
                                                            ref cpuCount,
                                                            ref multiThreaded,
                                                            ref enableNodeReuse,
@@ -2807,11 +2794,9 @@ namespace Microsoft.Build.CommandLine
                         Console.WriteLine($"{Path.Combine(s_exePath, s_exeName)} {equivalentCommandLine} {projectFile}");
                     }
 
-#if FEATURE_XML_SCHEMA_VALIDATION
                     // figure out if the project needs to be validated against a schema
                     needToValidateProject = commandLineSwitches.IsParameterizedSwitchSet(CommandLineSwitches.ParameterizedSwitch.Validate);
                     schemaFile = ProcessValidateSwitch(commandLineSwitches[CommandLineSwitches.ParameterizedSwitch.Validate]);
-#endif
                     invokeBuild = true;
 
                     if (commandLineSwitches.IsParameterizedSwitchSet(CommandLineSwitches.ParameterizedSwitch.WarningsNotAsErrors) &&
@@ -4616,7 +4601,6 @@ namespace Microsoft.Build.CommandLine
             }
         }
 
-#if FEATURE_XML_SCHEMA_VALIDATION
         /// <summary>
         /// Figures out if the project needs to be validated against a schema.
         /// </summary>
@@ -4637,7 +4621,6 @@ namespace Microsoft.Build.CommandLine
 
             return schemaFile;
         }
-#endif
 
         /// <summary>
         /// Given an invalid ToolsVersion string and the collection of valid toolsets,


### PR DESCRIPTION
Fixes #12229

### Context
The `-validate` CLI option was restricted to .NET Framework editions of MSBuild, but the underlying APIs are available on all currently supported frameworks. This PR stops excluding the code in question to only .NET Framework, which adds this CLI options to `dotnet msbuild`.

### Changes Made
The `FEATURE_XML_SCHEMA_VALIDATION` directive was removed, and the code it was guarding is now compiled on all frameworks.

### Testing
Existing tests enabled to run on all frameworks.

### Notes
