### PR TITLE
[vs17.14] Add check for node shut down event and reorder the sequence of shutdown in OutOfProcNode

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,7 +2,7 @@
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the MIT license. See License.txt in the project root for full license information. -->
 <Project>
   <PropertyGroup>
-    <VersionPrefix>17.14.18</VersionPrefix><DotNetFinalVersionKind>release</DotNetFinalVersionKind>
+    <VersionPrefix>17.14.19</VersionPrefix><DotNetFinalVersionKind>release</DotNetFinalVersionKind>
     <PackageValidationBaselineVersion>17.13.9</PackageValidationBaselineVersion>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>
     <PreReleaseVersionLabel>servicing</PreReleaseVersionLabel>

--- a/src/Build.UnitTests/BackEnd/MockSdkResolverService.cs
+++ b/src/Build.UnitTests/BackEnd/MockSdkResolverService.cs
@@ -16,6 +16,8 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
     {
         public Action<INodePacket> SendPacket { get; }
 
+        public bool IsNodeShutDown { get; set; }
+
         public void ClearCache(int submissionId)
         {
         }
@@ -33,8 +35,6 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
         {
         }
 
-        public void ShutdownComponent()
-        {
-        }
+        public void ShutdownComponent() => IsNodeShutDown = true;
     }
 }

--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -779,6 +779,7 @@ namespace Microsoft.Build.Execution
         /// </summary>
         public void CancelAllSubmissions()
         {
+            MSBuildEventSource.Log.CancelSubmissionsStart();
             CancelAllSubmissions(true);
         }
 

--- a/src/Build/BackEnd/Components/Communications/SerializationContractInitializer.cs
+++ b/src/Build/BackEnd/Components/Communications/SerializationContractInitializer.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Build.BackEnd
             BuildExceptionSerializationHelper.InitializeSerializationContract(
                 new(typeof(GenericBuildTransferredException), (msg, inner) => new GenericBuildTransferredException(msg, inner)),
                 new(typeof(SdkResolverException), (msg, inner) => new SdkResolverException(msg, inner)),
+                new(typeof(SdkResolverServiceException), (msg, inner) => new SdkResolverServiceException(msg, inner)),
                 new(typeof(BuildAbortedException), BuildAbortedException.CreateFromRemote),
                 new(typeof(CircularDependencyException), (msg, inner) => new CircularDependencyException(msg, inner)),
                 new(typeof(InternalLoggerException), (msg, inner) => new InternalLoggerException(msg, inner)),

--- a/src/Build/BackEnd/Components/SdkResolution/HostedSdkResolverServiceBase.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/HostedSdkResolverServiceBase.cs
@@ -5,6 +5,7 @@ using System;
 using System.Threading;
 using Microsoft.Build.BackEnd.Logging;
 using Microsoft.Build.Construction;
+using Microsoft.Build.Eventing;
 using Microsoft.Build.Framework;
 
 #nullable disable
@@ -28,6 +29,9 @@ namespace Microsoft.Build.BackEnd.SdkResolution
 
         /// <inheritdoc cref="ISdkResolverService.SendPacket"/>
         public Action<INodePacket> SendPacket { get; set; }
+
+        /// <inheritdoc cref="ISdkResolverService.IsNodeShutDown"/>
+        public bool IsNodeShutDown { get; set; }
 
         /// <inheritdoc cref="ISdkResolverService.ClearCache"/>
         public virtual void ClearCache(int submissionId)
@@ -55,6 +59,8 @@ namespace Microsoft.Build.BackEnd.SdkResolution
         public virtual void ShutdownComponent()
         {
             ShutdownEvent.Set();
+            IsNodeShutDown = true;
+            MSBuildEventSource.Log.SdkResolverServiceNodeShutDownSet();
         }
     }
 }

--- a/src/Build/BackEnd/Components/SdkResolution/ISdkResolverService.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/ISdkResolverService.cs
@@ -21,6 +21,11 @@ namespace Microsoft.Build.BackEnd.SdkResolution
         Action<INodePacket> SendPacket { get; }
 
         /// <summary>
+        /// Gets or sets if shutdown event was already triggered.
+        /// </summary>
+        bool IsNodeShutDown { get; set; }
+
+        /// <summary>
         /// Clears the cache for the specified build submission ID.
         /// </summary>
         /// <param name="submissionId">The build submission ID to clear from the cache.</param>

--- a/src/Build/BackEnd/Components/SdkResolution/OutOfProcNodeSdkResolverService.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/OutOfProcNodeSdkResolverService.cs
@@ -66,6 +66,11 @@ namespace Microsoft.Build.BackEnd.SdkResolution
         /// <inheritdoc cref="ISdkResolverService.ResolveSdk"/>
         public override SdkResult ResolveSdk(int submissionId, SdkReference sdk, LoggingContext loggingContext, ElementLocation sdkReferenceLocation, string solutionPath, string projectPath, bool interactive, bool isRunningInVisualStudio, bool failOnUnresolvedSdk)
         {
+            if (IsNodeShutDown)
+            {
+                throw new SdkResolverServiceException("SDK could not be resolved by the SDK resolver because the worker node was shut down.");
+            }
+
             bool wasResultCached = true;
 
             MSBuildEventSource.Log.OutOfProcSdkResolverServiceRequestSdkPathFromMainNodeStart(submissionId, sdk.Name, solutionPath, projectPath);
@@ -127,6 +132,11 @@ namespace Microsoft.Build.BackEnd.SdkResolution
 
             // Wait for either the response or a shutdown event.  Either event means this thread should return
             WaitHandle.WaitAny([_responseReceivedEvent, ShutdownEvent]);
+
+            if (_lastResponse == null)
+            {
+                throw new SdkResolverServiceException("SDK could not be resolved by the SDK resolver.");
+            }
 
             // Keep track of the element location of the reference
             _lastResponse.ElementLocation = sdkReferenceLocation;

--- a/src/Build/BackEnd/Components/SdkResolution/SdkResolverService.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/SdkResolverService.cs
@@ -78,6 +78,9 @@ namespace Microsoft.Build.BackEnd.SdkResolution
         /// <inheritdoc cref="ISdkResolverService.SendPacket"/>
         public Action<INodePacket> SendPacket { get; }
 
+        /// <inheritdoc cref="ISdkResolverService.IsNodeShutDown"/>
+        public bool IsNodeShutDown { get; set; }
+
         /// <summary>
         /// Determines if the <see cref="SdkReference"/> is the same as the specified version.  If the <paramref name="sdk"/> object has <code>null</code> for the version,
         /// this method will always return true since <code>null</code> can match any version.

--- a/src/Build/BackEnd/Components/SdkResolution/SdkResolverServiceException.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/SdkResolverServiceException.cs
@@ -1,0 +1,26 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using Microsoft.Build.Framework.BuildException;
+
+#nullable disable
+
+namespace Microsoft.Build.BackEnd.SdkResolution
+{
+    /// <summary>
+    /// Represents an exception that occurs when an SdkResolverService throws an unhandled exception.
+    /// </summary>
+    public class SdkResolverServiceException : BuildExceptionBase
+    {
+        public SdkResolverServiceException(string message, params string[] args)
+            : base(string.Format(message, args))
+        {
+        }
+
+        // Do not remove - used by BuildExceptionSerializationHelper
+        internal SdkResolverServiceException(string message, Exception inner)
+            : base(message, inner)
+        { }
+    }
+}

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -1802,10 +1802,17 @@ namespace Microsoft.Build.Evaluation
                 {
                     using var assemblyLoadsTracker = AssemblyLoadsTracker.StartTracking(_evaluationLoggingContext, AssemblyLoadingContext.SdkResolution, _sdkResolverService.GetType());
 
-                    sdkResult = _sdkResolverService.ResolveSdk(_submissionId, sdkReference, _evaluationLoggingContext, importElement.Location, solutionPath, projectPath, _interactive, _isRunningInVisualStudio,
+                    sdkResult = _sdkResolverService.ResolveSdk(
+                        _submissionId,
+                        sdkReference,
+                        _evaluationLoggingContext,
+                        importElement.Location,
+                        solutionPath, projectPath,
+                        _interactive,
+                        _isRunningInVisualStudio,
                         failOnUnresolvedSdk: !_loadSettings.HasFlag(ProjectLoadSettings.IgnoreMissingImports) || _loadSettings.HasFlag(ProjectLoadSettings.FailOnUnresolvedSdk));
                 }
-                catch (SdkResolverException e)
+                catch (Exception e) when (e is SdkResolverException or SdkResolverServiceException)
                 {
                     // We throw using e.Message because e.Message already contains the stack trace
                     // https://github.com/dotnet/msbuild/pull/6763

--- a/src/Build/Microsoft.Build.csproj
+++ b/src/Build/Microsoft.Build.csproj
@@ -31,7 +31,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Framework\Microsoft.Build.Framework.csproj" />
     <ProjectReference Include="..\StringTools\StringTools.csproj" />
-    <PackageReference Include="Microsoft.VisualStudio.SolutionPersistence" PrivateAssets="all"/>
+    <PackageReference Include="Microsoft.VisualStudio.SolutionPersistence" PrivateAssets="all" />
     <PackageReference Include="System.Configuration.ConfigurationManager" />
 
     <PackageReference Include="System.Reflection.MetadataLoadContext" />
@@ -159,6 +159,7 @@
     <Compile Include="BackEnd\Components\FileAccesses\FileAccessReport.cs" />
     <Compile Include="BackEnd\Components\FileAccesses\OutOfProcNodeFileAccessManager.cs" />
     <Compile Include="BackEnd\Components\FileAccesses\ProcessReport.cs" />
+    <Compile Include="BackEnd\Components\SdkResolution\SdkResolverServiceException.cs" />
     <Compile Include="BackEnd\Shared\EventsCreatorHelper.cs" />
     <Compile Include="BackEnd\Components\RequestBuilder\AssemblyLoadsTracker.cs" />
     <Compile Include="BackEnd\Components\SdkResolution\SdkResolverException.cs" />

--- a/src/Framework/MSBuildEventSource.cs
+++ b/src/Framework/MSBuildEventSource.cs
@@ -672,6 +672,30 @@ namespace Microsoft.Build.Eventing
         {
             WriteEvent(92, pluginTypeName, projectPath, targets);
         }
+
+        [Event(93, Keywords = Keywords.All)]
+        public void CancelSubmissionsStart()
+        {
+            WriteEvent(93);
+        }
+
+        [Event(94, Keywords = Keywords.All)]
+        public void SdkResolverServiceNodeShutDownSet()
+        {
+            WriteEvent(94);
+        }
+
+        [Event(95, Keywords = Keywords.All)]
+        public void OutOfProcNodeShutDownStart()
+        {
+            WriteEvent(95);
+        }
+
+        [Event(96, Keywords = Keywords.All)]
+        public void OutOfProcNodeShutDownStop(string shutdownReason)
+        {
+            WriteEvent(96, shutdownReason);
+        }
         #endregion
     }
 }


### PR DESCRIPTION
Backports https://github.com/dotnet/msbuild/pull/12194 in vs17.14

## Summary
In VS it's a long standing issue when a customer opens a large solution and attempts to close VS instance in the middle of DTB (design time build) or build process it can hang.
The rootcause is the race condition between 
Undergoing shutdown operation in OutOfProc node and parallel invocation of SdkResolver from Evaluation
<img width="2007" height="925" alt="image" src="https://github.com/user-attachments/assets/d5382ddc-3962-403c-bfc6-7a171d655af4" />

## Fix
The issue was fixed for 2 potential scenarios:
1) When SDK resolution requested AFTER Cancellation happens ;
 - Setup a guard flag `IsNodeShutDown` and checking it's value on request;
2) Cancellation happens AFTER  SDK resolution requested but BEFORE the response was received 
- Trigger `ShutdownComponent()` from SdkResolutionService BEFORE cleaning up engine caches (the prevent the deadlock in the screenshot above)

## Customer Impact
VS hang observed from telemetry and feedback tickets, there is no workaround.

## Regression?
No

## Testing
It was validated in scope of the internal ticket by testers
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2528482

## Risk
Low, the change is minimal and tested. 