### PR TITLE
Redo filewritessharable change with hopefully higher performance

### DIFF
--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -5779,26 +5779,26 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       -->
       <TrackFileWritesShareableOutsideOfProjectDirectory Condition=" '$(TrackFileWritesShareableOutsideOfProjectDirectory)' == '' ">false</TrackFileWritesShareableOutsideOfProjectDirectory>
     </PropertyGroup>
-
-    <ItemGroup>
-      <!-- Always track the FileWrites from the project-specific output directories -->
-      <FilesToTrackFromOutputDirectories Include="@(FileWrites)" />
-      <!-- Track the FileWritesShareable too if requested -->
-      <FilesToTrackFromOutputDirectories Include="@(FileWritesShareable)" Condition=" $(TrackFileWritesShareableOutsideOfProjectDirectory) == true "/>
-    </ItemGroup>
     
     <!-- Even if we don't allow cleaning filewrites from outside of the project bubble, we should still include FileWritesShareable that are inside the bubble -->
     <FindUnderPath Condition="!$(TrackFileWritesShareableOutsideOfProjectDirectory)" Path="$(MSBuildProjectDirectory)" Files="@(FileWritesShareable)" UpdateToAbsolutePaths="true">
-      <Output TaskParameter="InPath" ItemName="FilesToTrackFromOutputDirectories"/>
+      <Output TaskParameter="InPath" ItemName="FileWrites"/>
     </FindUnderPath>
 
-    <!-- Find all files in the final output directory. -->
-    <FindUnderPath Path="$(OutDir)" Files="@(FilesToTrackFromOutputDirectories)" UpdateToAbsolutePaths="true">
+    <!-- Find all files in the final output directory. Use separate item includes for Files based on condition so we don't create a whole new
+         item list unnecessarily -->
+    <FindUnderPath Path="$(OutDir)" Files="@(FileWrites)" UpdateToAbsolutePaths="true" Condition="!$(TrackFileWritesShareableOutsideOfProjectDirectory)">
+      <Output TaskParameter="InPath" ItemName="_CleanCurrentFileWritesInOutput"/>
+    </FindUnderPath>
+    <FindUnderPath Path="$(OutDir)" Files="@(FileWrites);@(FileWritesShareable)" UpdateToAbsolutePaths="true" Condition="$(TrackFileWritesShareableOutsideOfProjectDirectory)">
       <Output TaskParameter="InPath" ItemName="_CleanCurrentFileWritesInOutput"/>
     </FindUnderPath>
 
-    <!-- Find all files in the intermediate output directory. -->
-    <FindUnderPath Path="$(IntermediateOutputPath)" Files="@(FilesToTrackFromOutputDirectories)" UpdateToAbsolutePaths="true">
+    <!-- Find all files in the intermediate output directory. Same as above, use Conditions to prevent new item list writes -->
+    <FindUnderPath Path="$(IntermediateOutputPath)" Files="@(FileWrites)" UpdateToAbsolutePaths="true" Condition="!$(TrackFileWritesShareableOutsideOfProjectDirectory)">
+      <Output TaskParameter="InPath" ItemName="_CleanCurrentFileWritesInIntermediate"/>
+    </FindUnderPath>
+    <FindUnderPath Path="$(IntermediateOutputPath)" Files="@(FileWrites);@(FileWritesShareable)" UpdateToAbsolutePaths="true" Condition="$(TrackFileWritesShareableOutsideOfProjectDirectory)">
       <Output TaskParameter="InPath" ItemName="_CleanCurrentFileWritesInIntermediate"/>
     </FindUnderPath>
 

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -5787,8 +5787,9 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <FilesToTrackFromOutputDirectories Include="@(FileWritesShareable)" Condition=" $(TrackFileWritesShareableOutsideOfProjectDirectory) == true "/>
     </ItemGroup>
     
+    <!-- Even if we don't allow cleaning filewrites from outside of the project bubble, we should still include FileWritesShareable that are inside the bubble -->
     <FindUnderPath Condition="!$(TrackFileWritesShareableOutsideOfProjectDirectory)" Path="$(MSBuildProjectDirectory)" Files="@(FileWritesShareable)" UpdateToAbsolutePaths="true">
-      <Output TaskParameter="InPath" ItemName="FileWrites"/>
+      <Output TaskParameter="InPath" ItemName="FilesToTrackFromOutputDirectories"/>
     </FindUnderPath>
 
     <!-- Find all files in the final output directory. -->


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk/issues/49582
Reverts the original revert of #12192 in #12233

### Context

The previous version of this change created a new itemlist made from FileWrites and FileWritesShareable and used that in subsequent operations. This version doesn't create a new item list.

### Changes Made

Use conditions to determine which set of items should be considered for cleaning - only FileWrites, or FileWrites + FileWritesShareable

### Testing

Currently doing manual testing

### Notes
