### PR TITLE
Align TL creation API with msbuild.exe forcing behavior

### DIFF
--- a/src/Build.UnitTests/TerminalLogger_Tests.cs
+++ b/src/Build.UnitTests/TerminalLogger_Tests.cs
@@ -86,6 +86,14 @@ namespace Microsoft.Build.UnitTests
         [InlineData(null, false, false, "true", typeof(TerminalLogger))] // Force when env var set to "true"
         [InlineData(null, true, false, "on", typeof(TerminalLogger))] // Force when env var set to "on"
         [InlineData(null, false, true, "true", typeof(TerminalLogger))] // Force when env var set to "true"
+        [InlineData("-tl:auto", false, false, "", typeof(ConsoleLogger))] // Auto respects system capabilities (no ANSI, no screen)
+        [InlineData("-tl:auto", true, false, "", typeof(ConsoleLogger))] // Auto respects system capabilities (ANSI but no screen)
+        [InlineData("-tl:auto", false, true, "", typeof(ConsoleLogger))] // Auto respects system capabilities (screen but no ANSI)
+        [InlineData("-tl:auto", true, true, "", typeof(TerminalLogger))] // Auto respects system capabilities (both ANSI and screen)
+        [InlineData("-tl:auto", true, true, "off", typeof(TerminalLogger))] // Auto ignores env var when explicitly set
+        [InlineData("-tl:auto", false, false, "on", typeof(ConsoleLogger))] // Auto ignores env var and respects system capabilities
+        [InlineData(null, false, false, "auto", typeof(ConsoleLogger))] // Auto via env var respects system capabilities
+        [InlineData(null, true, true, "auto", typeof(TerminalLogger))] // Auto via env var respects system capabilities
         public void CreateTerminalOrConsoleLogger_CreatesCorrectLoggerInstance(string? argsString, bool supportsAnsi, bool outputIsScreen, string evnVariableValue, Type expectedType)
         {
             using TestEnvironment testEnvironment = TestEnvironment.Create();

--- a/src/Build.UnitTests/TerminalLogger_Tests.cs
+++ b/src/Build.UnitTests/TerminalLogger_Tests.cs
@@ -72,8 +72,20 @@ namespace Microsoft.Build.UnitTests
         [InlineData(null, true, true, "off", typeof(ConsoleLogger))]
         [InlineData(null, true, true, "false", typeof(ConsoleLogger))]
         [InlineData("--tl:off", true, true, "", typeof(ConsoleLogger))]
+        [InlineData("--tl:false", true, true, "", typeof(ConsoleLogger))]
         [InlineData(null, true, true, "", typeof(TerminalLogger))]
-        [InlineData("-tl:on", true, true, "off", typeof(TerminalLogger))]
+        [InlineData("-tl:on", true, true, "off", typeof(TerminalLogger))] // arg overrides env
+        [InlineData("-tl:true", true, true, "off", typeof(TerminalLogger))] // arg overrides env
+        [InlineData("-tl:off", true, true, "on", typeof(ConsoleLogger))] // arg overrides env (disable)
+        [InlineData("-tl:false", true, true, "true", typeof(ConsoleLogger))] // arg overrides env (disable)
+        [InlineData("-tl:on", false, false, "", typeof(TerminalLogger))] // Force when explicitly set to "on"
+        [InlineData("-tl:true", false, false, "", typeof(TerminalLogger))] // Force when explicitly set to "true"
+        [InlineData("-tl:on", true, false, "", typeof(TerminalLogger))] // Force when explicitly set to "on"
+        [InlineData("-tl:true", false, true, "", typeof(TerminalLogger))] // Force when explicitly set to "true"
+        [InlineData(null, false, false, "on", typeof(TerminalLogger))] // Force when env var set to "on"
+        [InlineData(null, false, false, "true", typeof(TerminalLogger))] // Force when env var set to "true"
+        [InlineData(null, true, false, "on", typeof(TerminalLogger))] // Force when env var set to "on"
+        [InlineData(null, false, true, "true", typeof(TerminalLogger))] // Force when env var set to "true"
         public void CreateTerminalOrConsoleLogger_CreatesCorrectLoggerInstance(string? argsString, bool supportsAnsi, bool outputIsScreen, string evnVariableValue, Type expectedType)
         {
             using TestEnvironment testEnvironment = TestEnvironment.Create();

--- a/src/Build/Logging/TerminalLogger/TerminalLogger.cs
+++ b/src/Build/Logging/TerminalLogger/TerminalLogger.cs
@@ -250,7 +250,7 @@ public sealed partial class TerminalLogger : INodeLogger
         {
             string argsString = string.Join(" ", args);
 
-            MatchCollection tlMatches = Regex.Matches(argsString, @"(?:/|-|--)(?:tl|terminallogger):(?'value'on|off|true|false)", RegexOptions.IgnoreCase);
+            MatchCollection tlMatches = Regex.Matches(argsString, @"(?:/|-|--)(?:tl|terminallogger):(?'value'on|off|true|false|auto)", RegexOptions.IgnoreCase);
             tlArg = tlMatches.OfType<Match>().LastOrDefault()?.Groups["value"].Value ?? string.Empty;
 
             MatchCollection verbosityMatches = Regex.Matches(argsString, @"(?:/|-|--)(?:v|verbosity):(?'value'\w+)", RegexOptions.IgnoreCase);
@@ -273,7 +273,7 @@ public sealed partial class TerminalLogger : INodeLogger
         }
 
         // Command line arguments take precedence over environment variables
-        string effectiveValue = !string.IsNullOrEmpty(tlArg) ? tlArg : tlEnvVariable;
+        string effectiveValue = !string.IsNullOrEmpty(tlArg) ? tlArg : !string.IsNullOrEmpty(tlEnvVariable) ? tlEnvVariable : "auto";
 
         bool isForced = IsTerminalLoggerEnabled(effectiveValue);
         bool isDisabled = IsTerminalLoggerDisabled(effectiveValue);
@@ -292,7 +292,7 @@ public sealed partial class TerminalLogger : INodeLogger
         }
 
         // If not forced and system doesn't support terminal features, fall back to console logger
-        if (supportsAnsi && outputIsScreen)
+        if (effectiveValue == "auto" && supportsAnsi && outputIsScreen)
         {
             return new TerminalLogger(verbosity, originalConsoleMode);
         }

--- a/src/Build/Logging/TerminalLogger/TerminalLogger.cs
+++ b/src/Build/Logging/TerminalLogger/TerminalLogger.cs
@@ -309,24 +309,20 @@ public sealed partial class TerminalLogger : INodeLogger
     /// </summary>
     /// <param name="value">The value to check (from command line or environment variable)</param>
     /// <returns>True if the value indicates TerminalLogger should be enabled</returns>
-    private static bool IsTerminalLoggerEnabled(string? value)
-    {
-        return !string.IsNullOrEmpty(value) &&
-               (value.Equals("on", StringComparison.InvariantCultureIgnoreCase) ||
-                value.Equals("true", StringComparison.InvariantCultureIgnoreCase));
-    }
+    private static bool IsTerminalLoggerEnabled(string? value) =>
+        value is { Length: > 0 } &&
+            (value.Equals("on", StringComparison.InvariantCultureIgnoreCase) ||
+             value.Equals("true", StringComparison.InvariantCultureIgnoreCase));
 
     /// <summary>
     /// Checks if the given value indicates TerminalLogger should be disabled.
     /// </summary>
     /// <param name="value">The value to check (from command line or environment variable)</param>
     /// <returns>True if the value indicates TerminalLogger should be disabled</returns>
-    private static bool IsTerminalLoggerDisabled(string? value)
-    {
-        return !string.IsNullOrEmpty(value) &&
-               (value.Equals("off", StringComparison.InvariantCultureIgnoreCase) ||
-                value.Equals("false", StringComparison.InvariantCultureIgnoreCase));
-    }
+    private static bool IsTerminalLoggerDisabled(string? value) =>
+        value is { Length: > 0 } &&
+            (value.Equals("off", StringComparison.InvariantCultureIgnoreCase) ||
+             value.Equals("false", StringComparison.InvariantCultureIgnoreCase));
 
     #region INodeLogger implementation
 


### PR DESCRIPTION
Fixes #12237 

### Context

The API for making terminallogger or consolelogger instances didn't apply the same precedence ordering as msbuild.exe itself did - making it hard to test in API-based consumers of terminallogger.

### Changes Made

* Added a forced-enablement semantic to the API to align with MSBuild.exe
* ensures that CLI flags passed to the API supersede env var flags with the same behavior as MSBuild.exe

### Testing

Automated testing to assert that expected logger types are created in the various newly-enforced scenarios

## Notes

Thanks to copilot chat for doing this for me :)