### PR TITLE
Revert "Allow FileWritesShared to be tracked and cleaned with an opt-in flag"

### DIFF
--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -5761,43 +5761,28 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <ItemGroup>
       <_CleanPriorFileWrites Include="@(_CleanUnfilteredPriorFileWrites)" Exclude="@(_ResolveAssemblyReferenceResolvedFilesAbsolute)"/>
     </ItemGroup>
-    
-    <PropertyGroup>
-      <!-- 
-        If set, FileWritesShareable will be located under the OutDir and IntermediateOutputPath.
-        If not set, FileWritesShareable will be located only under the MSBuildProjectDirectory.
 
-        The default layout of projects is that everything particular to the project is
-        located under the MSBuildProjectDirectory, so it's considered safe to track/delete those.
-        The assumption was that anything outside the project's directory is shared between multiple projects
-        and should not be deleted by the Clean target.
+    <!--
+        Of shareable files, keep only those that are in the project's directory.
+        We never clean shareable files outside of the project directory because
+        the build may be to a common output directory and other projects may need
+        them.
 
-        However, this is not always the case. The .NET SDK has a feature called Artifacts Layout
-        where project outputs are tracked in _project-specific_ locations under a root that is
-        outside of the project directory. In such cases, we need to be able to track FileWritesShareable
-        even from those locations.
-      -->
-      <TrackFileWritesShareableOutsideOfProjectDirectory Condition=" '$(TrackFileWritesShareableOutsideOfProjectDirectory)' == '' ">false</TrackFileWritesShareableOutsideOfProjectDirectory>
-    </PropertyGroup>
-
-    <ItemGroup>
-      <!-- Always track the FileWrites from the project-specific output directories -->
-      <FilesToTrackFromOutputDirectories Include="@(FileWrites)" />
-      <!-- Track the FileWritesShareable too if requested -->
-      <FilesToTrackFromOutputDirectories Include="@(FileWritesShareable)" Condition=" $(TrackFileWritesShareableOutsideOfProjectDirectory) == true "/>
-    </ItemGroup>
-    
-    <FindUnderPath Condition="!$(TrackFileWritesShareableOutsideOfProjectDirectory)" Path="$(MSBuildProjectDirectory)" Files="@(FileWritesShareable)" UpdateToAbsolutePaths="true">
+        Only subtract the outputs from ResolveAssemblyReferences target because that's the
+        only "Resolve" target that tries to resolve assemblies directly from the output
+        directory.
+        -->
+    <FindUnderPath Path="$(MSBuildProjectDirectory)" Files="@(FileWritesShareable)" UpdateToAbsolutePaths="true">
       <Output TaskParameter="InPath" ItemName="FileWrites"/>
     </FindUnderPath>
 
     <!-- Find all files in the final output directory. -->
-    <FindUnderPath Path="$(OutDir)" Files="@(FilesToTrackFromOutputDirectories)" UpdateToAbsolutePaths="true">
+    <FindUnderPath Path="$(OutDir)" Files="@(FileWrites)" UpdateToAbsolutePaths="true">
       <Output TaskParameter="InPath" ItemName="_CleanCurrentFileWritesInOutput"/>
     </FindUnderPath>
 
     <!-- Find all files in the intermediate output directory. -->
-    <FindUnderPath Path="$(IntermediateOutputPath)" Files="@(FilesToTrackFromOutputDirectories)" UpdateToAbsolutePaths="true">
+    <FindUnderPath Path="$(IntermediateOutputPath)" Files="@(FileWrites)" UpdateToAbsolutePaths="true">
       <Output TaskParameter="InPath" ItemName="_CleanCurrentFileWritesInIntermediate"/>
     </FindUnderPath>
 


### PR DESCRIPTION
Reverts dotnet/msbuild#12096

The rootcause is tracked internally: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2533238/
