### PR TITLE
Fix race condition in TaskRegistry for multi-threaded MSBuild

### DIFF
--- a/src/Build/Instance/TaskRegistry.cs
+++ b/src/Build/Instance/TaskRegistry.cs
@@ -1149,7 +1149,12 @@ namespace Microsoft.Build.Execution
             /// When ever a taskName is checked against the factory we cache the result so we do not have to
             /// make possibly expensive calls over and over again.
             /// </summary>
-            private Dictionary<RegisteredTaskIdentity, object> _taskNamesCreatableByFactory;
+            private ConcurrentDictionary<RegisteredTaskIdentity, object> _taskNamesCreatableByFactory;
+
+            /// <summary>
+            /// Lock object for initializing the cache
+            /// </summary>
+            private readonly object _taskNamesCreatableByFactoryLock = new object();
 
             /// <summary>
             /// Set of parameters that can be used by the task factory specifically.
@@ -1357,10 +1362,14 @@ namespace Microsoft.Build.Execution
             /// <returns>true if the task can be created by the factory, false if it cannot be created</returns>
             internal bool CanTaskBeCreatedByFactory(string taskName, string taskProjectFile, IDictionary<string, string> taskIdentityParameters, TargetLoggingContext targetLoggingContext, ElementLocation elementLocation)
             {
-                // Keep a cache of task identities which have been checked against the factory, this is useful because we ask this question everytime we get a registered task record or a taskFactory wrapper.
+                // Double-checked locking pattern for thread-safe lazy initialization
                 if (_taskNamesCreatableByFactory == null)
                 {
-                    _taskNamesCreatableByFactory = new Dictionary<RegisteredTaskIdentity, object>(RegisteredTaskIdentity.RegisteredTaskIdentityComparer.Exact);
+                    lock (_taskNamesCreatableByFactoryLock)
+                    {
+                        // Keep a cache of task identities which have been checked against the factory, this is useful because we ask this question everytime we get a registered task record or a taskFactory wrapper.
+                        _taskNamesCreatableByFactory ??= new ConcurrentDictionary<RegisteredTaskIdentity, object>(RegisteredTaskIdentity.RegisteredTaskIdentityComparer.Exact);
+                    }
                 }
 
                 RegisteredTaskIdentity taskIdentity = new RegisteredTaskIdentity(taskName, taskIdentityParameters);

--- a/src/Build/Instance/TaskRegistry.cs
+++ b/src/Build/Instance/TaskRegistry.cs
@@ -1149,12 +1149,7 @@ namespace Microsoft.Build.Execution
             /// When ever a taskName is checked against the factory we cache the result so we do not have to
             /// make possibly expensive calls over and over again.
             /// </summary>
-            private ConcurrentDictionary<RegisteredTaskIdentity, object> _taskNamesCreatableByFactory;
-
-            /// <summary>
-            /// Lock object for initializing the cache
-            /// </summary>
-            private readonly object _taskNamesCreatableByFactoryLock = new object();
+            private readonly ConcurrentDictionary<RegisteredTaskIdentity, object> _taskNamesCreatableByFactory;
 
             /// <summary>
             /// Set of parameters that can be used by the task factory specifically.
@@ -1240,6 +1235,7 @@ namespace Microsoft.Build.Execution
                 _taskIdentity = new RegisteredTaskIdentity(registeredName, taskFactoryParameters);
                 _parameterGroupAndTaskBody = inlineTask;
                 _registrationOrderId = registrationOrderId;
+                _taskNamesCreatableByFactory = new ConcurrentDictionary<RegisteredTaskIdentity, object>(RegisteredTaskIdentity.RegisteredTaskIdentityComparer.Exact);
 
                 if (String.IsNullOrEmpty(taskFactory))
                 {
@@ -1362,19 +1358,6 @@ namespace Microsoft.Build.Execution
             /// <returns>true if the task can be created by the factory, false if it cannot be created</returns>
             internal bool CanTaskBeCreatedByFactory(string taskName, string taskProjectFile, IDictionary<string, string> taskIdentityParameters, TargetLoggingContext targetLoggingContext, ElementLocation elementLocation)
             {
-                // Double-checked locking pattern for thread-safe lazy initialization
-                if (_taskNamesCreatableByFactory == null)
-                {
-                    lock (_taskNamesCreatableByFactoryLock)
-                    {
-                        // Keep a cache of task identities which have been checked against the factory, this is useful because we ask this question everytime we get a registered task record or a taskFactory wrapper.
-                        if (_taskNamesCreatableByFactory == null)
-                        {
-                            _taskNamesCreatableByFactory = new ConcurrentDictionary<RegisteredTaskIdentity, object>(RegisteredTaskIdentity.RegisteredTaskIdentityComparer.Exact);
-                        }
-                    }
-                }
-
                 RegisteredTaskIdentity taskIdentity = new RegisteredTaskIdentity(taskName, taskIdentityParameters);
 
                 // See if the task name as already been checked against the factory, return the value if it has

--- a/src/Build/Instance/TaskRegistry.cs
+++ b/src/Build/Instance/TaskRegistry.cs
@@ -1368,7 +1368,10 @@ namespace Microsoft.Build.Execution
                     lock (_taskNamesCreatableByFactoryLock)
                     {
                         // Keep a cache of task identities which have been checked against the factory, this is useful because we ask this question everytime we get a registered task record or a taskFactory wrapper.
-                        _taskNamesCreatableByFactory ??= new ConcurrentDictionary<RegisteredTaskIdentity, object>(RegisteredTaskIdentity.RegisteredTaskIdentityComparer.Exact);
+                        if (_taskNamesCreatableByFactory == null)
+                        {
+                            _taskNamesCreatableByFactory = new ConcurrentDictionary<RegisteredTaskIdentity, object>(RegisteredTaskIdentity.RegisteredTaskIdentityComparer.Exact);
+                        }
                     }
                 }
 


### PR DESCRIPTION
Fixes #12123

### Context
Currently when using the new `-mt` switch to enable multi-threaded behavior, we sometimes get this concurrency error:
```
dotnet build SimpleMultiProcTest.sln -mt
Restore complete (0,8s)
    info NETSDK1057: You are using a preview version of .NET. See: https://aka.ms/dotnet-support-policy
  ProjectC failed with 1 error(s) (0,3s)
    MSBUILD : error : 
      This is an unhandled exception in MSBuild -- PLEASE UPVOTE AN EXISTING ISS
      UE OR FILE A NEW ONE AT https://aka.ms/msbuild/unhandled
          System.InvalidOperationException: Operations that change non-concurren
      t collections must have exclusive access. A concurrent update was performe
      d on this collection and corrupted its state. The collection's state is no
       longer correct.
         at System.Collections.Generic.Dictionary`2.TryInsert(TKey key, TValue v
      alue, InsertionBehavior behavior)
         at System.Collections.Generic.Dictionary`2.set_Item(TKey key, TValue va
      lue)
         at Microsoft.Build.Execution.TaskRegistry.RegisteredTaskRecord.CanTaskB
      eCreatedByFactory(String taskName, String taskProjectFile, IDictionary`2 t
      askIdentityParameters, TargetLoggingContext targetLoggingContext, ElementL
      ocation elementLocation) in /Users/surayyahuseynzada/msbuild/src/Build/Ins
      tance/TaskRegistry.cs:line 1437
         at Microsoft.Build.Execution.TaskRegistry.RegisteredTaskRecord.CanTaskB
      eCreatedByFactory(String taskName, String taskProjectFile, IDictionary`2 t
      askIdentityParameters, TargetLoggingContext targetLoggingContext, ElementL
      ocation elementLocation) in /Users/surayyahuseynzada/msbuild/src/Build/Ins
      tance/TaskRegistry.cs:line 1359
         at Microsoft.Build.Execution.TaskRegistry.<>c__DisplayClass41_0.<GetMat
      chingRegistration>b__0(RegisteredTaskRecord r) in /Users/surayyahuseynzada
      /msbuild/src/Build/Instance/TaskRegistry.cs:line 779
         at System.Linq.Enumerable.TryGetFirst[TSource](IEnumerable`1 source, Fu
      nc`2 predicate, Boolean& found)
         at System.Linq.Enumerable.FirstOrDefault[TSource](IEnumerable`1 source,
       Func`2 predicate)
         at Microsoft.Build.Execution.TaskRegistry.GetMatchingRegistration(Strin
      g taskName, IEnumerable`1 taskRecords, String taskProjectFile, IDictionary
      `2 taskIdentityParameters, TargetLoggingContext targetLoggingContext, Elem
      entLocation elementLocation) in /Users/surayyahuseynzada/msbuild/src/Build
      /Instance/TaskRegistry.cs:line 778
         at Microsoft.Build.Execution.TaskRegistry.GetTaskRegistrationRecord(Str
      ing taskName, String taskProjectFile, IDictionary`2 taskIdentityParameters
      , Boolean exactMatchRequired, TargetLoggingContext targetLoggingContext, E
      lementLocation elementLocation, Boolean& retrievedFromCache) in /Users/sur
      ayyahuseynzada/msbuild/src/Build/Instance/TaskRegistry.cs:line 607
         at Microsoft.Build.Execution.TaskRegistry.GetTaskRegistrationRecord(Str
      ing taskName, String taskProjectFile, IDictionary`2 taskIdentityParameters
      , Boolean exactMatchRequired, TargetLoggingContext targetLoggingContext, E
      lementLocation elementLocation, Boolean& retrievedFromCache) in /Users/sur
      ayyahuseynzada/msbuild/src/Build/Instance/TaskRegistry.cs:line 614
         at Microsoft.Build.Execution.TaskRegistry.GetRegisteredTask(String task
      Name, String taskProjectFile, IDictionary`2 taskIdentityParameters, Boolea
      n exactMatchRequired, TargetLoggingContext targetLoggingContext, ElementLo
      cation elementLocation) in /Users/surayyahuseynzada/msbuild/src/Build/Inst
      ance/TaskRegistry.cs:line 479
         at Microsoft.Build.BackEnd.TaskExecutionHost.FindTaskInRegistry(IDictio
      nary`2 taskIdentityParameters) in /Users/surayyahuseynzada/msbuild/src/Bui
      ld/BackEnd/TaskExecutionHost/TaskExecutionHost.cs:line 871
         at Microsoft.Build.BackEnd.TaskExecutionHost.FindTask(IDictionary`2 tas
      kIdentityParameters) in /Users/surayyahuseynzada/msbuild/src/Build/BackEnd
      /TaskExecutionHost/TaskExecutionHost.cs:line 276
         at Microsoft.Build.BackEnd.TaskBuilder.ExecuteBucket(TaskHost taskHost,
       ItemBucket bucket, TaskExecutionMode howToExecuteTask, Dictionary`2 looku
      pHash) in /Users/surayyahuseynzada/msbuild/src/Build/BackEnd/Components/Re
      questBuilder/TaskBuilder.cs:line 424
         at Microsoft.Build.BackEnd.TaskBuilder.ExecuteTask(TaskExecutionMode mo
      de, Lookup lookup) in /Users/surayyahuseynzada/msbuild/src/Build/BackEnd/C
      omponents/RequestBuilder/TaskBuilder.cs:line 332
         at Microsoft.Build.BackEnd.TaskBuilder.ExecuteTask(TargetLoggingContext
       loggingContext, BuildRequestEntry requestEntry, ITargetBuilderCallback ta
      rgetBuilderCallback, ProjectTargetInstanceChild taskInstance, TaskExecutio
      nMode mode, Lookup inferLookup, Lookup executeLookup, CancellationToken ca
      ncellationToken) in /Users/surayyahuseynzada/msbuild/src/Build/BackEnd/Com
      ponents/RequestBuilder/TaskBuilder.cs:line 186
         at Microsoft.Build.BackEnd.TargetEntry.ProcessBucket(ITaskBuilder taskB
      uilder, TargetLoggingContext targetLoggingContext, TaskExecutionMode mode,
       Lookup lookupForInference, Lookup lookupForExecution) in /Users/surayyahu
      seynzada/msbuild/src/Build/BackEnd/Components/RequestBuilder/TargetEntry.c
      s:line 822
         at Microsoft.Build.BackEnd.TargetEntry.ExecuteTarget(ITaskBuilder taskB
      uilder, BuildRequestEntry requestEntry, ProjectLoggingContext projectLoggi
      ngContext, CancellationToken cancellationToken) in /Users/surayyahuseynzad
      a/msbuild/src/Build/BackEnd/Components/RequestBuilder/TargetEntry.cs:line 
      520
         at Microsoft.Build.BackEnd.TargetBuilder.ProcessTargetStack(ITaskBuilde
      r taskBuilder) in /Users/surayyahuseynzada/msbuild/src/Build/BackEnd/Compo
      nents/RequestBuilder/TargetBuilder.cs:line 492
         at Microsoft.Build.BackEnd.TargetBuilder.BuildTargets(ProjectLoggingCon
      text loggingContext, BuildRequestEntry entry, IRequestBuilderCallback call
      back, ValueTuple`2[] targetNames, Lookup baseLookup, CancellationToken can
      cellationToken) in /Users/surayyahuseynzada/msbuild/src/Build/BackEnd/Comp
      onents/RequestBuilder/TargetBuilder.cs:line 173
         at Microsoft.Build.BackEnd.RequestBuilder.BuildProject() in /Users/sura
      yyahuseynzada/msbuild/src/Build/BackEnd/Components/RequestBuilder/RequestB
      uilder.cs:line 1213
         at Microsoft.Build.BackEnd.RequestBuilder.RequestThreadProc(Boolean set
      ThreadParameters) in /Users/surayyahuseynzada/msbuild/src/Build/BackEnd/Co
      mponents/RequestBuilder/RequestBuilder.cs:line 784
  ProjectB succeeded (0,3s) → bin/Debug/net9.0/ProjectB.dll
  ProjectD succeeded (0,3s) → bin/Debug/net9.0/ProjectD.dll
```

Race condition occurs when trying to access cache `RegisteredTaskRecord._taskNamesCreatableByFactory`

### Changes Made
Replaced `_taskNamesCreatableByFactory` `Dictionary` with `ConcurrentDictionary`.

### Testing
Manually tested by running build with `mt` switch a few times - the error no longer appears.


### Notes
Checked with the prototype https://github.com/dotnet/msbuild/compare/main...dev/AR-May/multi-threaded-msbuild-3
It seems that in `TaskRegistry` every method that was in my stack trace was changed by adding `[MethodImpl(MethodImplOptions.Synchronized)]` to remove the problem fast. But changing only `CanTaskBeCreatedByFactory` fixes everything. 
In the prototype `RegisterTasksFromUsingTaskElement` is changed too. It isn't in my stack trace above but it has appeared before. Later it was fixed by changes in `Toolset`