### PR TITLE
use correct output reporting

### DIFF
--- a/src/Build/Logging/TerminalLogger/TerminalLogger.cs
+++ b/src/Build/Logging/TerminalLogger/TerminalLogger.cs
@@ -762,7 +762,7 @@ public sealed partial class TerminalLogger : INodeLogger
                                 }
                             }
 
-                            Terminal.WriteLine(ResourceUtilities.FormatResourceStringIgnoreCodeAndKeyword("ProjectFinished_OutputPath", CreateLink(uri, outputPathSpan.ToString())));
+                            Terminal.WriteLine(ResourceUtilities.FormatResourceStringIgnoreCodeAndKeyword("ProjectFinished_OutputPath", CreateLink(uri, projectDisplayPathSpan.ToString())));
                         }
                         else
                         {


### PR DESCRIPTION
Fixes a slight rebase error on the recently-merged Terminal Logger Forwarding Logger PR. We want to use the computed display path we just derived, not the full output path.