### PR TITLE
[vs16.11] Recover bootstrap and corresponding disabled tests

### DIFF
--- a/.vsts-dotnet-ci.yml
+++ b/.vsts-dotnet-ci.yml
@@ -13,6 +13,8 @@ jobs:
     displayName: cibuild_bootstrapped_msbuild.cmd
     inputs:
       filename: 'eng/cibuild_bootstrapped_msbuild.cmd'
+    env:
+      ForceUseXCopyMSBuild: 1
   - task: PublishTestResults@2
     displayName: Publish .NET Framework Test Results
     inputs:

--- a/.vsts-dotnet-ci.yml
+++ b/.vsts-dotnet-ci.yml
@@ -7,14 +7,12 @@ jobs:
 - job: BootstrapMSBuildOnFullFrameworkWindows
   displayName: "Windows Full"
   pool:
-    vmImage: 'windows-2022'
+    vmImage: 'windows.server.amd64.vs2019'
   steps:
   - task: BatchScript@1
     displayName: cibuild_bootstrapped_msbuild.cmd
     inputs:
       filename: 'eng/cibuild_bootstrapped_msbuild.cmd'
-    env:
-      ForceUseXCopyMSBuild: 1
   - task: PublishTestResults@2
     displayName: Publish .NET Framework Test Results
     inputs:

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,7 +2,7 @@
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the MIT license. See License.txt in the project root for full license information. -->
 <Project>
   <PropertyGroup>
-    <VersionPrefix>16.11.8</VersionPrefix>
+    <VersionPrefix>16.11.9</VersionPrefix>
     <DotNetFinalVersionKind>release</DotNetFinalVersionKind>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>

--- a/eng/cibuild_bootstrapped_msbuild.ps1
+++ b/eng/cibuild_bootstrapped_msbuild.ps1
@@ -71,8 +71,67 @@ try {
 
   if ($buildStage1)
   {
-    & $PSScriptRoot\Common\Build.ps1 -restore -build -test -ci -msbuildEngine $msbuildEngine /p:CreateBootstrap=true @properties
+    & $PSScriptRoot\Common\Build.ps1 -restore -build -ci -msbuildEngine $msbuildEngine /p:CreateBootstrap=true @properties
   }
+
+  $bootstrapRoot = Join-Path $Stage1BinDir "bootstrap"
+
+  # we need to do this to guarantee we have/know where dotnet.exe is installed
+  $dotnetToolPath = InitializeDotNetCli $true
+  $dotnetExePath = Join-Path $dotnetToolPath "dotnet.exe"
+
+  if ($msbuildEngine -eq 'vs')
+  {
+    $buildToolPath = Join-Path $bootstrapRoot "net472\MSBuild\Current\Bin\MSBuild.exe"
+    $buildToolCommand = "";
+    $buildToolFramework = "net472"
+
+    if ($configuration -eq "Debug-MONO" -or $configuration -eq "Release-MONO")
+    {
+      # Copy MSBuild.dll to MSBuild.exe so we can run it without a host
+      $sourceDll = Join-Path $bootstrapRoot "net472\MSBuild\Current\Bin\MSBuild.dll"
+      Copy-Item -Path $sourceDll -Destination $msbuildToUse
+    }
+  }
+  else
+  {
+    $buildToolPath = $dotnetExePath
+    $buildToolCommand = Join-Path $bootstrapRoot "net5.0\MSBuild\MSBuild.dll"
+    $buildToolFramework = "netcoreapp2.1"
+  }
+
+  # Use separate artifacts folder for stage 2
+  # $env:ArtifactsDir = Join-Path $ArtifactsDir "2\"
+
+  & $dotnetExePath build-server shutdown
+
+  if ($buildStage1)
+  {
+    if (Test-Path $Stage1Dir)
+    {
+      Remove-Item -Force -Recurse $Stage1Dir
+    }
+
+    Move-Item -Path $ArtifactsDir -Destination $Stage1Dir -Force
+  }
+
+  $buildTool = @{ Path = $buildToolPath; Command = $buildToolCommand; Tool = $msbuildEngine; Framework = $buildToolFramework }
+  $global:_BuildTool = $buildTool
+
+  # turn vbcscompiler back on to save on time. It speeds up the build considerably
+  $env:UseSharedCompilation="true"
+
+  # Ensure that debug bits fail fast, rather than hanging waiting for a debugger attach.
+  $env:MSBUILDDONOTLAUNCHDEBUGGER="true"
+
+  # Opt into performance logging. https://github.com/dotnet/msbuild/issues/5900
+  $env:DOTNET_PERFLOG_DIR=$PerfLogDir
+
+  # When using bootstrapped MSBuild:
+  # - Turn off node reuse (so that bootstrapped MSBuild processes don't stay running and lock files)
+  # - Do run tests
+  # - Don't try to create a bootstrap deployment
+  & $PSScriptRoot\Common\Build.ps1 -restore -build -test -ci /p:CreateBootstrap=false /nr:false @properties
 
   exit $lastExitCode
 }

--- a/src/Build.UnitTests/BackEnd/MSBuild_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/MSBuild_Tests.cs
@@ -361,7 +361,7 @@ namespace Microsoft.Build.UnitTests
         /// However, it's a situation where the project author doesn't have control over the
         /// property value and so he can't escape it himself.
         /// </summary>
-        [Fact(Skip = "skipped for failing tests when reviving pipeline")]
+        [Fact]
         public void PropertyOverridesContainSemicolon()
         {
             ObjectModelHelpers.DeleteTempProjectDirectory();

--- a/src/Build.UnitTests/EscapingInProjects_Tests.cs
+++ b/src/Build.UnitTests/EscapingInProjects_Tests.cs
@@ -946,7 +946,7 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
         /// <summary>
         ///     ESCAPING: Escaping in conditionals is broken.
         /// </summary>
-        [Fact(Skip = "skipped for failing tests when reviving pipeline")]
+        [Fact]
         public void SemicolonInConfiguration()
         {
             ObjectModelHelpers.DeleteTempProjectDirectory();
@@ -1006,7 +1006,7 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
         /// <summary>
         ///     ESCAPING: Escaping in conditionals is broken.
         /// </summary>
-        [Fact(Skip = "skipped for failing tests when reviving pipeline")]
+        [Fact]
         public void SemicolonInConfiguration_UsingTaskHost()
         {
             string originalOverrideTaskHostVariable = Environment.GetEnvironmentVariable("MSBUILDFORCEALLTASKSOUTOFPROC");
@@ -1076,7 +1076,7 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
         /// <summary>
         ///     ESCAPING: CopyBuildTarget target fails if the output assembly name contains a semicolon or single-quote
         /// </summary>
-        [Fact(Skip = "skipped for failing tests when reviving pipeline")]
+        [Fact]
         public void SemicolonInAssemblyName()
         {
             ObjectModelHelpers.DeleteTempProjectDirectory();
@@ -1131,7 +1131,7 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
         /// <summary>
         ///     ESCAPING: CopyBuildTarget target fails if the output assembly name contains a semicolon or single-quote
         /// </summary>
-        [Fact(Skip = "skipped for failing tests when reviving pipeline")]
+        [Fact]
         public void SemicolonInAssemblyName_UsingTaskHost()
         {
             string originalOverrideTaskHostVariable = Environment.GetEnvironmentVariable("MSBUILDFORCEALLTASKSOUTOFPROC");
@@ -1196,7 +1196,7 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
         /// <summary>
         ///     ESCAPING: Conversion Issue: Properties with $(xxx) as literals are not being converted correctly
         /// </summary>
-        [Fact(Skip = "skipped for failing tests when reviving pipeline")]
+        [Fact]
         public void DollarSignInAssemblyName()
         {
             ObjectModelHelpers.DeleteTempProjectDirectory();
@@ -1251,7 +1251,7 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
         /// <summary>
         ///     ESCAPING: Conversion Issue: Properties with $(xxx) as literals are not being converted correctly
         /// </summary>
-        [Fact(Skip = "skipped for failing tests when reviving pipeline")]
+        [Fact]
         public void DollarSignInAssemblyName_UsingTaskHost()
         {
             string originalOverrideTaskHostVariable = Environment.GetEnvironmentVariable("MSBUILDFORCEALLTASKSOUTOFPROC");
@@ -1316,7 +1316,7 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
         /// <summary>
         /// This is the case when one of the source code files in the project has a filename containing a semicolon.
         /// </summary>
-        [Fact(Skip = "skipped for failing tests when reviving pipeline")]
+        [Fact]
         public void SemicolonInSourceCodeFilename()
         {
             ObjectModelHelpers.DeleteTempProjectDirectory();
@@ -1371,7 +1371,7 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
         /// <summary>
         /// This is the case when one of the source code files in the project has a filename containing a semicolon.
         /// </summary>
-        [Fact(Skip = "skipped for failing tests when reviving pipeline")]
+        [Fact]
         public void SemicolonInSourceCodeFilename_UsingTaskHost()
         {
             string originalOverrideTaskHostVariable = Environment.GetEnvironmentVariable("MSBUILDFORCEALLTASKSOUTOFPROC");

--- a/src/Build.UnitTests/Evaluation/Expander_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/Expander_Tests.cs
@@ -1940,7 +1940,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             log.AssertLogDoesntContain("%29");
         }
 
-        [Fact(Skip = "skipped for failing tests when reviving pipeline")]
+        [Fact]
         [Trait("Category", "mono-osx-failing")]
         public void TestGetPathToReferenceAssembliesAsFunction()
         {

--- a/src/Build.UnitTests/TargetsFile_Test.cs
+++ b/src/Build.UnitTests/TargetsFile_Test.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Build.UnitTests
         /// <summary>
         /// Check that the ARM flag is passed to the compiler when targeting ARM.
         /// </summary>
-        [Fact(Skip = "skipped for failing tests when reviving pipeline")]
+        [Fact]
         public void TargetARM()
         {
             string file = null;
@@ -121,7 +121,7 @@ namespace Microsoft.Build.UnitTests
         /// Check that with an explicit platform of anycpu, library type assemblies do not 
         /// get forced to anycpu32bitpreferred by default. 
         /// </summary>
-        [Fact(Skip = "skipped for failing tests when reviving pipeline")]
+        [Fact]
         public void ExplicitAnyCPULibraryProjectIsNot32BitPreferred()
         {
             string file = null;
@@ -228,7 +228,7 @@ namespace Microsoft.Build.UnitTests
         /// Check that with an explicit platformtarget of anycpu, winmdobj type assemblies do not 
         /// get forced to anycpu32bitpreferred by default. 
         /// </summary>
-        [Fact(Skip = "skipped for failing tests when reviving pipeline")]
+        [Fact]
         public void ExplicitAnyCPUWinMDObjProjectIsNot32BitPreferred()
         {
             string file = null;
@@ -285,7 +285,7 @@ namespace Microsoft.Build.UnitTests
         /// Check that with an empty platformtarget (equivalent to anycpu), exe type assemblies 
         /// get forced to anycpu32bitpreferred by default. 
         /// </summary>
-        [Fact(Skip = "skipped for failing tests when reviving pipeline")]
+        [Fact]
         public void AnyCPUExeProjectIs32BitPreferred()
         {
             string file = null;
@@ -335,7 +335,7 @@ namespace Microsoft.Build.UnitTests
         /// Check that with an explicit platformtarget of anycpu, exe type assemblies 
         /// get forced to anycpu32bitpreferred by default. 
         /// </summary>
-        [Fact(Skip = "skipped for failing tests when reviving pipeline")]
+        [Fact]
         public void ExplicitAnyCPUExeProjectIs32BitPreferred()
         {
             string file = null;
@@ -436,7 +436,7 @@ namespace Microsoft.Build.UnitTests
         /// Check that with an explicit platformtarget of anycpu, exe type assemblies that are 
         /// targeting .NET 4.0 do not get forced to anycpu32bitpreferred by default. 
         /// </summary>
-        [Fact(Skip = "skipped for failing tests when reviving pipeline")]
+        [Fact]
         public void ExplicitAnyCPU40ExeProjectIsNot32BitPreferred()
         {
             string file = null;
@@ -487,7 +487,7 @@ namespace Microsoft.Build.UnitTests
         /// Check that with an empty platformtarget (equivalent to anycpu), appcontainerexe type assemblies 
         /// get forced to anycpu32bitpreferred by default. 
         /// </summary>
-        [Fact(Skip = "skipped for failing tests when reviving pipeline")]
+        [Fact]
         public void AnyCPUAppContainerExeProjectIs32BitPreferred()
         {
             string file = null;
@@ -543,7 +543,7 @@ namespace Microsoft.Build.UnitTests
         /// Check that with an explicit platformtarget of anycpu, appcontainerexe type assemblies 
         /// get forced to anycpu32bitpreferred by default. 
         /// </summary>
-        [Fact(Skip = "skipped for failing tests when reviving pipeline")]
+        [Fact]
         public void ExplicitAnyCPUAppContainerExeProjectIs32BitPreferred()
         {
             string file = null;
@@ -600,7 +600,7 @@ namespace Microsoft.Build.UnitTests
         /// Although AnyCPU library projects should not default to AnyCPU32BitPreferred, because that platform is 
         /// not supported for library projects, if Prefer32Bit is explicitly set, we should still respect that. 
         /// </summary>
-        [Fact(Skip = "skipped for failing tests when reviving pipeline")]
+        [Fact]
         public void AnyCPULibraryProjectIs32BitPreferredIfPrefer32BitSet()
         {
             string file = null;
@@ -652,7 +652,7 @@ namespace Microsoft.Build.UnitTests
         /// A project with no explicit OutputType will end up defaulting its OutputType to exe, 
         /// so it should also default to Prefer32Bit = true. 
         /// </summary>
-        [Fact(Skip = "skipped for failing tests when reviving pipeline")]
+        [Fact]
         public void AnyCPUProjectWithNoExplicitOutputTypeIs32BitPreferred()
         {
             string file = null;
@@ -702,7 +702,7 @@ namespace Microsoft.Build.UnitTests
         /// A project with no explicit OutputType will end up defaulting its OutputType to exe, 
         /// so it should also default to Prefer32Bit = true. 
         /// </summary>
-        [Fact(Skip = "skipped for failing tests when reviving pipeline")]
+        [Fact]
         public void AnyCPUJupiterProjectWithNoExplicitOutputTypeIs32BitPreferred()
         {
             string file = null;
@@ -854,7 +854,7 @@ namespace Microsoft.Build.UnitTests
         /// <summary>
         /// Doesn't synthesize Link metadata if the items are defined in the project  
         /// </summary>
-        [Fact(Skip = "skipped for failing tests when reviving pipeline")]
+        [Fact]
         public void NoLinkMetadataSynthesisWhenDefinedInProject()
         {
             string[] files = null;
@@ -916,7 +916,7 @@ namespace Microsoft.Build.UnitTests
         /// <summary>
         /// Synthesizes Link metadata if the items are defined in an import and are on the whitelist
         /// </summary>
-        [Fact(Skip = "skipped for failing tests when reviving pipeline")]
+        [Fact]
         public void SynthesizeLinkMetadataForItemsOnWhitelist()
         {
             string outputPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
@@ -994,7 +994,7 @@ namespace Microsoft.Build.UnitTests
         /// <summary>
         /// Don't synthesize link metadata if the SynthesizeLinkMetadata property is false
         /// </summary>
-        [Fact(Skip = "skipped for failing tests when reviving pipeline")]
+        [Fact]
         public void DontSynthesizeLinkMetadataIfPropertyNotSet()
         {
             string outputPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));

--- a/src/Tasks.UnitTests/GetReferencePaths_Tests.cs
+++ b/src/Tasks.UnitTests/GetReferencePaths_Tests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Build.UnitTests
         /// <summary>
         /// Test the case where there is a good target framework moniker passed in.
         /// </summary>
-        [Fact(Skip = "skipped for failing tests when reviving pipeline")]
+        [Fact]
         public void TestGeneralFrameworkMonikerGood()
         {
             string targetFrameworkMoniker = ".NetFramework, Version=v4.5";

--- a/src/Tasks.UnitTests/RegressionTests.cs
+++ b/src/Tasks.UnitTests/RegressionTests.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Build.Tasks.UnitTests
         /// Tests fix for https://github.com/microsoft/msbuild/issues/1479.
         /// </summary>
         //[ConditionalFact(typeof(NativeMethodsShared), nameof(NativeMethodsShared.IsWindows))]
-        [Fact(Skip = "skipped for failing tests when reviving pipeline")]
+        [Fact]
         public void AssemblyAttributesLocation()
         {
             var expectedCompileItems = "a.cs;" + Path.Combine("obj", "Debug", ".NETFramework,Version=v4.0.AssemblyAttributes.cs");

--- a/src/Tasks.UnitTests/ResourceHandling/GenerateResourceOutOfProc_Tests.cs
+++ b/src/Tasks.UnitTests/ResourceHandling/GenerateResourceOutOfProc_Tests.cs
@@ -2352,7 +2352,7 @@ namespace Microsoft.Build.UnitTests.GenerateResource_Tests.OutOfProc
             _output = output;
         }
 
-        [Fact(Skip = "skipped for failing tests when reviving pipeline")]
+        [Fact]
         //FIXME: mono: looks for csc.exe
         // https://github.com/Microsoft/msbuild/issues/677
         [Trait("Category", "mono-osx-failing")]
@@ -2529,7 +2529,7 @@ namespace Microsoft.Build.UnitTests.GenerateResource_Tests.OutOfProc
         /// Assembly.LoadFile on that relative path, which fails (LoadFile requires an
         /// absolute path).  The fix was to use Assembly.LoadFrom instead.
         /// </summary>
-        [Fact(Skip = "skipped for failing tests when reviving pipeline")]
+        [Fact]
         //FIXME: mono: looks for csc.exe
         // https://github.com/Microsoft/msbuild/issues/677
         [Trait("Category", "mono-osx-failing")]

--- a/src/Tasks.UnitTests/ResourceHandling/GenerateResource_Tests.cs
+++ b/src/Tasks.UnitTests/ResourceHandling/GenerateResource_Tests.cs
@@ -2714,7 +2714,7 @@ namespace Microsoft.Build.UnitTests.GenerateResource_Tests.InProc
             _output = output;
         }
 
-        [Fact(Skip = "skipped for failing tests when reviving pipeline")]
+        [Fact]
         [SkipOnTargetFramework(TargetFrameworkMonikers.Netcoreapp, "Linked resources not supported on Core: https://github.com/microsoft/msbuild/issues/4094")]
         [SkipOnTargetFramework(TargetFrameworkMonikers.Mono, "https://github.com/Microsoft/msbuild/issues/677")]
         public void DontLockP2PReferenceWhenResolvingSystemTypes()
@@ -2892,7 +2892,7 @@ namespace Microsoft.Build.UnitTests.GenerateResource_Tests.InProc
         /// which fails (LoadFile requires an absolute path).  The fix was to use
         /// Assembly.LoadFrom instead.
         /// </summary>
-        [Fact(Skip = "skipped for failing tests when reviving pipeline")]
+        [Fact]
         [SkipOnTargetFramework(TargetFrameworkMonikers.Netcoreapp, "Linked resources not supported on Core: https://github.com/microsoft/msbuild/issues/4094")]
         [SkipOnTargetFramework(TargetFrameworkMonikers.Mono, "https://github.com/Microsoft/msbuild/issues/677")]
         public void ReferencedAssemblySpecifiedUsingRelativePath()

--- a/src/Utilities.UnitTests/ToolLocationHelper_Tests.cs
+++ b/src/Utilities.UnitTests/ToolLocationHelper_Tests.cs
@@ -1955,7 +1955,7 @@ namespace Microsoft.Build.UnitTests
         /// its corresponding reference assemblies are installed.
         /// If they are not installed, the test should be ignored.
         /// </summary>
-        [Fact(Skip = "skipped for failing tests when reviving pipeline")]
+        [Fact]
         [Trait("Category", "mono-osx-failing")]
         public void GetPathToReferenceAssembliesDefaultLocation45()
         {


### PR DESCRIPTION
partially fix #11888

### Context
Previously before disabling bootstrap build on Windows Full in CI pipeline failed with mismatched dependency version. It's caused by that for bootstrap the additional assemblies copied from VS 17.14 in the image windows-2022 has higher version than this release branch.

### Changes Made
Force to use XCopyMsbuild for bootstrap on Windows Full in CI pipeline to avoid additional assemblies copied from VS installation which may mismatch the version.

### Testing
N/A

### Notes
