### PR TITLE
Dev/erarndt/project root element

### DIFF
--- a/src/Build/Construction/ProjectRootElement.cs
+++ b/src/Build/Construction/ProjectRootElement.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
@@ -136,11 +135,6 @@ namespace Microsoft.Build.Construction
         /// by an external means.
         /// </summary>
         private DateTime _lastWriteTimeWhenReadUtc;
-
-        /// <summary>
-        /// Reason it was last marked dirty; unlocalized, for debugging
-        /// </summary>
-        private string _dirtyReason = "first created project {0}";
 
         internal ProjectRootElementLink RootLink => (ProjectRootElementLink)Link;
 
@@ -691,13 +685,6 @@ namespace Microsoft.Build.Construction
         /// </remarks>
         internal ProjectExtensionsElement ProjectExtensions
             => GetChildrenReversedOfType<ProjectExtensionsElement>().FirstOrDefault();
-
-        /// <summary>
-        /// Returns an unlocalized indication of how this file was last dirtied.
-        /// This is for debugging purposes only.
-        /// String formatting only occurs when retrieved.
-        /// </summary>
-        internal string LastDirtyReason => _dirtyReason;
 
         /// <summary>
         /// Initialize an in-memory empty ProjectRootElement instance that CANNOT be saved later.
@@ -1828,8 +1815,6 @@ namespace Microsoft.Build.Construction
             }
 
             IncrementVersion();
-
-            _dirtyReason = reason is not null && Project.s_debugEvaluation ? String.Format(CultureInfo.InvariantCulture, reason, param) : null;
 
             _timeLastChangedUtc = DateTime.UtcNow;
 

--- a/src/Build/Construction/ProjectTargetElement.cs
+++ b/src/Build/Construction/ProjectTargetElement.cs
@@ -273,16 +273,6 @@ namespace Microsoft.Build.Construction
                         value,
                         true); /* only remove the element if the value is null -- setting to empty string is OK */
 
-                // if this target's Returns attribute is non-null, then there is at least one target in the
-                // parent project that has the returns attribute.
-                // NOTE: As things are currently, if a project is created that has targets with Returns, but then
-                // all of those targets are set to not have Returns anymore, the PRE will still claim that it
-                // contains targets with the Returns attribute.  Do we care?
-                if (returnsAttribute != null)
-                {
-                    ((ProjectRootElement)Parent).ContainsTargetsWithReturnsAttribute = true;
-                }
-
                 MarkDirty("Set target Returns {0}", value);
             }
         }

--- a/src/Build/Definition/Project.cs
+++ b/src/Build/Definition/Project.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Build.Evaluation
         /// <summary>
         /// Whether to write information about why we evaluate to debug output.
         /// </summary>
-        private static readonly bool s_debugEvaluation = (Environment.GetEnvironmentVariable("MSBUILDDEBUGEVALUATION") != null);
+        internal static readonly bool s_debugEvaluation = (Environment.GetEnvironmentVariable("MSBUILDDEBUGEVALUATION") != null);
 
         /// <summary>
         /// * and ? are invalid file name characters, but they occur in globs as wild cards.
@@ -1819,7 +1819,7 @@ namespace Microsoft.Build.Evaluation
         /// Internal project evaluation implementation.
         /// </summary>
         [DebuggerDisplay("#GlobalProperties={_data.GlobalPropertiesDictionary.Count} #Properties={_data.Properties.Count} #ItemTypes={_data.ItemTypes.Count} #ItemDefinitions={_data.ItemDefinitions.Count} #Items={_data.Items.Count} #Targets={_data.Targets.Count}")]
-        private class ProjectImpl : ProjectLink, IProjectLinkInternal
+        internal class ProjectImpl : ProjectLink, IProjectLinkInternal
         {
             /// <summary>
             /// Backing data; stored in a nested class so it can be passed to the Evaluator to fill
@@ -2263,7 +2263,7 @@ namespace Microsoft.Build.Evaluation
 
                     foreach (ResolvedImport import in _data.ImportClosure)
                     {
-                        if (import.ImportingElement != null && !import.ImportedProject.IsEphemeral) // Exclude outer project itself and SDK-resolver synthesized imports
+                        if (import.ImportingElement != null && import.ImportedProject is not EphemeralProjectRootElement) // Exclude outer project itself and SDK-resolver synthesized imports
                         {
                             imports.Add(import);
                         }
@@ -2286,7 +2286,7 @@ namespace Microsoft.Build.Evaluation
 
                     foreach (var import in _data.ImportClosureWithDuplicates)
                     {
-                        if (import.ImportingElement != null && !import.ImportedProject.IsEphemeral) // Exclude outer project itself and SDK-resolver synthesized imports
+                        if (import.ImportingElement != null && import.ImportedProject is not EphemeralProjectRootElement) // Exclude outer project itself and SDK-resolver synthesized imports
                         {
                             imports.Add(import);
                         }

--- a/src/Build/Definition/Project.cs
+++ b/src/Build/Definition/Project.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Build.Evaluation
         /// <summary>
         /// Whether to write information about why we evaluate to debug output.
         /// </summary>
-        internal static readonly bool s_debugEvaluation = (Environment.GetEnvironmentVariable("MSBUILDDEBUGEVALUATION") != null);
+        private static readonly bool s_debugEvaluation = (Environment.GetEnvironmentVariable("MSBUILDDEBUGEVALUATION") != null);
 
         /// <summary>
         /// * and ? are invalid file name characters, but they occur in globs as wild cards.
@@ -2065,7 +2065,7 @@ namespace Microsoft.Build.Evaluation
                         {
                             if (Xml.Count > 0) // don't log empty projects, evaluation is not interesting
                             {
-                                Trace.WriteLine(String.Format(CultureInfo.InvariantCulture, "MSBUILD: Is dirty because {0} [{1}] [PC Hash {2}]", Xml.LastDirtyReason, FullPath, ProjectCollection.GetHashCode()));
+                                Trace.WriteLine(String.Format(CultureInfo.InvariantCulture, "MSBUILD: Is dirty because of version mismatch [{0}] [PC Hash {1}]", FullPath, ProjectCollection.GetHashCode()));
                             }
                         }
 
@@ -2088,12 +2088,7 @@ namespace Microsoft.Build.Evaluation
                         {
                             if (s_debugEvaluation)
                             {
-                                string reason = import.ImportedProject.LastDirtyReason;
-
-                                if (reason != null)
-                                {
-                                    Trace.WriteLine(String.Format(CultureInfo.InvariantCulture, "MSBUILD: Is dirty because {0} [{1} - {2}] [PC Hash {3}]", reason, FullPath, import.ImportedProject.FullPath == FullPath ? String.Empty : import.ImportedProject.FullPath, ProjectCollection.GetHashCode()));
-                                }
+                                Trace.WriteLine(String.Format(CultureInfo.InvariantCulture, "MSBUILD: Is dirty because version numbers are mismatched [{0} - {1}] [PC Hash {2}]", FullPath, import.ImportedProject.FullPath == FullPath ? String.Empty : import.ImportedProject.FullPath, ProjectCollection.GetHashCode()));
                             }
 
                             return true;


### PR DESCRIPTION
Fixes #

### Context
To combat expensive individual garbage collections, it's important to minimize the amount of memory that gets promoted. One way to help is to shrink the size of the objects. This PR trims `ProjectRootElement`. This is a heap snapshot when building OrchardCore.

<img width="1073" height="286" alt="image" src="https://github.com/user-attachments/assets/0969fd57-b3f5-42d6-a343-cc5d908fa1c8" />

There are roughly 13.7MB of these items on the heap (~66k at 206B per object).

The `_escapedFullPath` is intended to cache the result for the `EscapedFullPath` property. However, this is called very infrequently (I saw once per build), so the field provides little value.

There are two fields, `_dirtyReason` and `_dirtyParameter` that are only used when the `MSBUILDDEBUGEVALUATION` environment variable is set. I believe we can remove these fields and still provide useful information by updating the trace messages.

The `IsEphemeral` property is rarely used, and it can be covered by having another class that includes this field (`EphemeralProjectRootElement`) and used in places where an ephemeral version is needed.

Finally, `ContainsTargetsWithReturnsAttribute` was only ever written to, so it can be removed.

### Changes Made


### Testing


### Notes
