### PR TITLE
Perf: Reimplement Lookup.Scope tables without ItemDictionary

### DIFF
--- a/src/Build.UnitTests/BackEnd/Lookup_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/Lookup_Tests.cs
@@ -264,14 +264,14 @@ namespace Microsoft.Build.UnitTests.BackEnd
             lookup.AddNewItem(item2);
 
             // Remove one item
-            lookup.RemoveItem(item1);
+            lookup.RemoveItems("i1", [item1]);
 
             // We see one item
             Assert.Single(lookup.GetItems("i1"));
             Assert.Equal("a2", lookup.GetItems("i1").First().EvaluatedInclude);
 
             // Remove the other item
-            lookup.RemoveItem(item2);
+            lookup.RemoveItems("i1", [item2]);
 
             // We see no items
             Assert.Empty(lookup.GetItems("i1"));
@@ -326,7 +326,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             Assert.Single(lookup.GetItems("i1"));
 
             // Remove that item
-            lookup.RemoveItem(item1);
+            lookup.RemoveItems("i1", [item1]);
 
             // We see no items
             Assert.Empty(lookup.GetItems("i1"));
@@ -372,7 +372,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             Assert.Single(lookup.GetItems("i1"));
 
             // Remove that item
-            lookup.RemoveItem(item1);
+            lookup.RemoveItems("i1", [item1]);
 
             // We see no items
             Assert.Empty(lookup.GetItems("i1"));
@@ -824,7 +824,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             // Add an item with m=m1 and n=n1
             ProjectItemInstance item1 = new ProjectItemInstance(project, "i1", "a2", project.FullPath);
             item1.SetMetadata("m", "m1");
-            lookup.PopulateWithItem(item1);
+            table1.Add(item1);
 
             lookup.EnterScope("x");
 
@@ -865,7 +865,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             // Add an item with m=m1 and n=n1
             ProjectItemInstance item1 = new ProjectItemInstance(project, "i1", "a2", project.FullPath);
             item1.SetMetadata("m", "m1");
-            lookup.PopulateWithItem(item1);
+            table1.Add(item1);
 
             lookup.EnterScope("x");
 
@@ -902,7 +902,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             item1.SetMetadata("m", "m1");
             item1.SetMetadata("n", "n1");
             item1.SetMetadata("o", "o1");
-            lookup.PopulateWithItem(item1);
+            table1.Add(item1);
 
             Lookup.Scope enteredScope = lookup.EnterScope("x");
 
@@ -1028,7 +1028,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             // Add an item with m=m1 and n=n1
             ProjectItemInstance item1 = new ProjectItemInstance(project, "i1", "a2", project.FullPath);
             item1.SetMetadata("m", "m1");
-            lookup.PopulateWithItem(item1);
+            table1.Add(item1);
 
             Lookup.Scope enteredScope = lookup.EnterScope("x");
 
@@ -1132,7 +1132,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             // Add an item with m=m1 and n=n1
             ProjectItemInstance item1 = new ProjectItemInstance(project, "i1", "a2", project.FullPath);
             item1.SetMetadata("m", "m1");
-            lookup.PopulateWithItem(item1);
+            table1.Add(item1);
 
             lookup.EnterScope("x");
 
@@ -1149,7 +1149,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             ProjectItemInstance item1b = group2.First();
 
             // Remove the item
-            lookup.RemoveItem(item1b);
+            lookup.RemoveItems(item1.ItemType, [item1b]);
 
             // There's now no items at all
             ICollection<ProjectItemInstance> group3 = lookup.GetItems(item1.ItemType);
@@ -1186,7 +1186,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             ProjectItemInstance item1b = group2.First();
 
             // Remove the item
-            lookup.RemoveItem(item1b);
+            lookup.RemoveItems(item1.ItemType, [item1b]);
 
             // There's now no items at all
             ICollection<ProjectItemInstance> group3 = lookup.GetItems(item1.ItemType);

--- a/src/Build.UnitTests/BackEnd/TargetUpToDateChecker_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/TargetUpToDateChecker_Tests.cs
@@ -291,7 +291,8 @@ namespace Microsoft.Build.UnitTests.BackEnd
 
             // Even though they were all up to date, we still expect to see an empty marker
             // so that lookups can correctly *not* find items of that type
-            Assert.True(changedTargetInputs.HasEmptyMarker("MoreItems"));
+            Assert.True(changedTargetInputs.ItemTypes.Contains("MoreItems"));
+            Assert.Empty(changedTargetInputs["MoreItems"]);
         }
 
         [Fact]

--- a/src/Build.UnitTests/BackEnd/TaskExecutionHost_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/TaskExecutionHost_Tests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections;
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -1282,7 +1283,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             itemsByName.Add(item2);
             _twoItems = new ITaskItem[] { new TaskItem(item), new TaskItem(item2) };
 
-            _bucket = new ItemBucket(new Dictionary<string, ICollection<ProjectItemInstance>>().Keys, new Dictionary<string, string>(), new Lookup(itemsByName, new PropertyDictionary<ProjectPropertyInstance>()), 0);
+            _bucket = new ItemBucket(FrozenSet<string>.Empty, new Dictionary<string, string>(), new Lookup(itemsByName, new PropertyDictionary<ProjectPropertyInstance>()), 0);
             _bucket.Initialize(null);
             _host.FindTask(null);
             _host.InitializeForBatch(talc, _bucket, null);

--- a/src/Build/BackEnd/Components/RequestBuilder/BatchingEngine.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/BatchingEngine.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using Microsoft.Build.BackEnd.Logging;
 using Microsoft.Build.Collections;
@@ -311,6 +312,7 @@ namespace Microsoft.Build.BackEnd
             ErrorUtilities.VerifyThrow(consumedMetadataReferences.Count > 0, "Need item metadata consumed by the batchable object.");
 
             var buckets = new List<ItemBucket>();
+            FrozenSet<string> itemNames = itemListsToBeBatched.Keys.ToFrozenSet(MSBuildNameIgnoreCaseComparer.Default);
 
             // Get and iterate through the list of item names that we're supposed to batch on.
             foreach (KeyValuePair<string, ICollection<ProjectItemInstance>> entry in itemListsToBeBatched)
@@ -346,7 +348,7 @@ namespace Microsoft.Build.BackEnd
                         }
                         else
                         {
-                            matchingBucket = new ItemBucket(itemListsToBeBatched.Keys, itemMetadataValues, lookup, buckets.Count);
+                            matchingBucket = new ItemBucket(itemNames, itemMetadataValues, lookup, buckets.Count);
                             if (loggingContext != null)
                             {
                                 matchingBucket.Initialize(loggingContext);

--- a/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupIntrinsicTask.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupIntrinsicTask.cs
@@ -281,7 +281,7 @@ namespace Microsoft.Build.BackEnd
                         child.Location);
                 }
 
-                bucket.Lookup.RemoveItems(itemsToRemove);
+                bucket.Lookup.RemoveItems(child.ItemType, itemsToRemove);
             }
         }
 

--- a/src/Build/BackEnd/Components/RequestBuilder/Lookup.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/Lookup.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections;
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Build.Collections;
@@ -59,6 +60,15 @@ namespace Microsoft.Build.BackEnd
         #region Fields
 
         /// <summary>
+        /// The first set of items used to create the lookup.
+        /// </summary>
+        /// <remarks>
+        /// This represents the primary table for the outer Scope. This is tracked separately as we don't have control
+        /// over the incoming implementation dictionary, while Scope uses a simplified item dictionary for perf.
+        /// </remarks>
+        private readonly IItemDictionary<ProjectItemInstance> _baseItems;
+
+        /// <summary>
         /// Ordered stack of scopes used for lookup, where each scope references its parent.
         /// Each scope contains multiple tables:
         ///  - the main item table (populated with subsets of lists, in order to create batches)
@@ -94,7 +104,8 @@ namespace Microsoft.Build.BackEnd
             ErrorUtilities.VerifyThrowInternalNull(projectItems);
             ErrorUtilities.VerifyThrowInternalNull(properties);
 
-            _lookupScopes = new Lookup.Scope(this, "Lookup()", projectItems, properties);
+            _baseItems = projectItems;
+            _lookupScopes = new Lookup.Scope(this, "Lookup()", properties);
         }
 
         /// <summary>
@@ -103,6 +114,7 @@ namespace Microsoft.Build.BackEnd
         private Lookup(Lookup that)
         {
             // Add the same tables from the original.
+            _baseItems = that._baseItems;
             _lookupScopes = that._lookupScopes;
 
             // Clones need to share an (item)clone table; the batching engine asks for items from the lookup,
@@ -117,19 +129,19 @@ namespace Microsoft.Build.BackEnd
         // Convenience private properties
         // "Primary" is the "top" or "innermost" scope
         // "Secondary" is the next from the top.
-        private IItemDictionary<ProjectItemInstance> PrimaryTable
+        private ItemDictionarySlim PrimaryTable
         {
             get { return _lookupScopes.Items; }
             set { _lookupScopes.Items = value; }
         }
 
-        private ItemDictionary<ProjectItemInstance> PrimaryAddTable
+        private ItemDictionarySlim PrimaryAddTable
         {
             get { return _lookupScopes.Adds; }
             set { _lookupScopes.Adds = value; }
         }
 
-        private ItemDictionary<ProjectItemInstance> PrimaryRemoveTable
+        private ItemDictionarySlim PrimaryRemoveTable
         {
             get { return _lookupScopes.Removes; }
             set { _lookupScopes.Removes = value; }
@@ -147,19 +159,13 @@ namespace Microsoft.Build.BackEnd
             set { _lookupScopes.PropertySets = value; }
         }
 
-        private IItemDictionary<ProjectItemInstance> SecondaryTable
-        {
-            get { return _lookupScopes.Parent.Items; }
-            set { _lookupScopes.Parent.Items = value; }
-        }
-
-        private ItemDictionary<ProjectItemInstance> SecondaryAddTable
+        private ItemDictionarySlim SecondaryAddTable
         {
             get { return _lookupScopes.Parent.Adds; }
             set { _lookupScopes.Parent.Adds = value; }
         }
 
-        private ItemDictionary<ProjectItemInstance> SecondaryRemoveTable
+        private ItemDictionarySlim SecondaryRemoveTable
         {
             get { return _lookupScopes.Parent.Removes; }
             set { _lookupScopes.Parent.Removes = value; }
@@ -243,7 +249,7 @@ namespace Microsoft.Build.BackEnd
         internal Lookup.Scope EnterScope(string description)
         {
             // We don't create the tables unless we need them
-            Scope scope = new Scope(this, description, null, null);
+            Scope scope = new Scope(this, description, null);
             _lookupScopes = scope;
             return scope;
         }
@@ -311,16 +317,11 @@ namespace Microsoft.Build.BackEnd
                 }
                 else
                 {
-                    // When merging remove lists from two or more batches both tables (primary and secondary) may contain identical items. The reason is when removing the items we get the original items rather than a clone
-                    // so the same item may have already been added to the secondary table. If we then try and add the same item from the primary table we will get a duplicate key exception from the
-                    // dictionary. Therefore we must not merge in an item if it already is in the secondary remove table.
-                    foreach (ProjectItemInstance item in PrimaryRemoveTable)
-                    {
-                        if (!SecondaryRemoveTable.Contains(item))
-                        {
-                            SecondaryRemoveTable.Add(item);
-                        }
-                    }
+                    // When merging remove lists from two or more batches both tables (primary and secondary) may contain
+                    // identical items. The reason is when removing the items we get the original items rather than a clone,
+                    // so the same item may have already been added to the secondary table.
+                    // For perf, we concatenate these lists without checking for duplicates, deferring until used.
+                    SecondaryRemoveTable.ImportItems(PrimaryRemoveTable);
                 }
             }
 
@@ -376,22 +377,25 @@ namespace Microsoft.Build.BackEnd
             // adds to the world
             if (PrimaryAddTable != null)
             {
-                SecondaryTable ??= new ItemDictionary<ProjectItemInstance>();
-                SecondaryTable.ImportItems(PrimaryAddTable);
+                foreach (KeyValuePair<string, List<ProjectItemInstance>> kvp in PrimaryAddTable)
+                {
+                    _baseItems.ImportItemsOfType(kvp.Key, kvp.Value);
+                }
             }
 
             if (PrimaryRemoveTable != null)
             {
-                SecondaryTable ??= new ItemDictionary<ProjectItemInstance>();
-                SecondaryTable.RemoveItems(PrimaryRemoveTable);
+                foreach (KeyValuePair<string, List<ProjectItemInstance>> kvp in PrimaryRemoveTable)
+                {
+                    _baseItems.RemoveItems(kvp.Value);
+                }
             }
 
             if (PrimaryModifyTable != null)
             {
                 foreach (KeyValuePair<string, Dictionary<ProjectItemInstance, MetadataModifications>> entry in PrimaryModifyTable)
                 {
-                    SecondaryTable ??= new ItemDictionary<ProjectItemInstance>();
-                    ApplyModificationsToTable(SecondaryTable, entry.Key, entry.Value);
+                    ApplyModificationsToTable(_baseItems, entry.Key, entry.Value);
                 }
             }
 
@@ -433,11 +437,6 @@ namespace Microsoft.Build.BackEnd
                     }
                 }
 
-                if (scope.TruncateLookupsAtThisScope)
-                {
-                    break;
-                }
-
                 scope = scope.Parent;
             }
 
@@ -467,46 +466,36 @@ namespace Microsoft.Build.BackEnd
             // plus the first set of regular items we encounter
             // minus any removes
 
-            List<ProjectItemInstance> allAdds = null;
-            List<ProjectItemInstance> allRemoves = null;
+            List<List<ProjectItemInstance>> allAdds = null;
+            List<List<ProjectItemInstance>> allRemoves = null;
             Dictionary<ProjectItemInstance, MetadataModifications> allModifies = null;
             ICollection<ProjectItemInstance> groupFound = null;
 
+            // Iterate through all scopes *except* the outer scope.
+            // The outer scope will always be empty and is currently only used for tracking base properties.
+            // We use the base items only when no other item group is found.
             Scope scope = _lookupScopes;
-            while (scope != null)
+            while (scope.Parent != null)
             {
                 // Accumulate adds while we look downwards
                 if (scope.Adds != null)
                 {
-                    ICollection<ProjectItemInstance> adds = scope.Adds[itemType];
-                    if (adds.Count != 0)
+                    List<ProjectItemInstance> adds = scope.Adds[itemType];
+                    if (adds != null)
                     {
-                        if (allAdds == null)
-                        {
-                            // Use the List<T>(IEnumerable<T>) constructor to avoid an intermediate array allocation.
-                            allAdds = new List<ProjectItemInstance>(adds);
-                        }
-                        else
-                        {
-                            allAdds.AddRange(adds);
-                        }
+                        allAdds ??= [];
+                        allAdds.Add(adds);
                     }
                 }
 
                 // Accumulate removes while we look downwards
                 if (scope.Removes != null)
                 {
-                    ICollection<ProjectItemInstance> removes = scope.Removes[itemType];
-                    if (removes.Count != 0)
+                    List<ProjectItemInstance> removes = scope.Removes[itemType];
+                    if (removes != null)
                     {
-                        if (allRemoves == null)
-                        {
-                            allRemoves = new List<ProjectItemInstance>(removes);
-                        }
-                        else
-                        {
-                            allRemoves.AddRange(removes);
-                        }
+                        allRemoves ??= [];
+                        allRemoves.Add(removes);
                     }
                 }
 
@@ -534,19 +523,20 @@ namespace Microsoft.Build.BackEnd
                 if (scope.Items != null)
                 {
                     groupFound = scope.Items[itemType];
-                    if (groupFound.Count != 0 || scope.Items.HasEmptyMarker(itemType))
+                    if (groupFound?.Count > 0 || scope.ItemTypesToTruncateAtThisScope.Contains(itemType))
                     {
                         // Found a group: we go no further
                         break;
                     }
                 }
 
-                if (scope.TruncateLookupsAtThisScope)
-                {
-                    break;
-                }
-
                 scope = scope.Parent;
+            }
+
+            // If we've made it to the root scope, use the original items.
+            if (groupFound == null && scope.Parent == null)
+            {
+                groupFound = _baseItems[itemType];
             }
 
             if ((allAdds == null) &&
@@ -561,7 +551,6 @@ namespace Microsoft.Build.BackEnd
             }
 
             // Set the initial sizes to avoid resizing during import
-            int itemsTypesCount = 1;    // We're only ever importing a single item type
             int itemsCount = groupFound?.Count ?? 0;    // Start with initial set
             itemsCount += allAdds?.Count ?? 0;          // Add all the additions
             itemsCount -= allRemoves?.Count ?? 0;       // Remove the removals
@@ -574,11 +563,26 @@ namespace Microsoft.Build.BackEnd
             // We can't modify the group, because that might
             // be visible to other batches; we have to create
             // a new one.
-            ItemDictionary<ProjectItemInstance> result = new ItemDictionary<ProjectItemInstance>(itemsTypesCount, itemsCount);
+            List<ProjectItemInstance> result = new(itemsCount);
 
-            if (groupFound != null)
+            if (groupFound?.Count > 0)
             {
-                result.ImportItemsOfType(itemType, groupFound);
+                if (allRemoves == null)
+                {
+                    // No removes, so use fast path for ICollection<T>.
+                    result.AddRange(groupFound);
+                }
+                else
+                {
+                    // Otherwise, need to filter any items marked for removal.
+                    foreach (ProjectItemInstance item in groupFound)
+                    {
+                        if (!ShouldRemoveItem(item, allRemoves))
+                        {
+                            result.Add(item);
+                        }
+                    }
+                }
             }
             // Removes are processed after adds; this means when we remove there's no need to concern ourselves
             // with the case where the item being removed is in an add table somewhere. The converse case is not possible
@@ -586,12 +590,25 @@ namespace Microsoft.Build.BackEnd
             // a unique new item.
             if (allAdds != null)
             {
-                result.ImportItemsOfType(itemType, allAdds);
-            }
-
-            if (allRemoves != null)
-            {
-                result.RemoveItems(allRemoves);
+                foreach (List<ProjectItemInstance> adds in allAdds)
+                {
+                    if (allRemoves == null)
+                    {
+                        // No removes, so use fast path for ICollection<T>.
+                        result.AddRange(adds);
+                    }
+                    else
+                    {
+                        // Otherwise, need to filter any items marked for removal.
+                        foreach (ProjectItemInstance item in adds)
+                        {
+                            if (!ShouldRemoveItem(item, allRemoves))
+                            {
+                                result.Add(item);
+                            }
+                        }
+                    }
+                }
             }
 
             // Modifies can be processed last; if a modified item was removed, the modify will be ignored
@@ -600,40 +617,88 @@ namespace Microsoft.Build.BackEnd
                 ApplyModifies(result, allModifies);
             }
 
-            return result[itemType];
+            return result;
+
+            // Helper to perform a linear search across the removes.
+            // PERF: This linear search is still cheaper than combining all removes into hashsets and performing a lookup
+            // due to allocation and hashcode costs, provided that we can quickly filter out false matches.
+            static bool ShouldRemoveItem(ProjectItemInstance item, List<List<ProjectItemInstance>> allRemoves)
+            {
+                ITaskItem2 itemAsTaskItem = item;
+                string evaluatedInclude = itemAsTaskItem.EvaluatedIncludeEscaped;
+
+                foreach (List<ProjectItemInstance> removes in allRemoves)
+                {
+                    foreach (ProjectItemInstance remove in removes)
+                    {
+                        // Get access to allocation-free item spec property.
+                        ITaskItem2 removeAsTaskItem = remove;
+
+                        // Start with the item spec length as a fast filter for false matches.
+                        if (evaluatedInclude.Length == removeAsTaskItem.EvaluatedIncludeEscaped.Length
+                            && StringComparer.Ordinal.Equals(evaluatedInclude, removeAsTaskItem.EvaluatedIncludeEscaped)
+                            && itemAsTaskItem == removeAsTaskItem)
+                        {
+                            return true;
+                        }
+                    }
+                }
+
+                return false;
+            }
         }
 
         /// <summary>
         /// Populates with an item group. This is done before the item lookup is used in this scope.
         /// Assumes all the items in the group have the same, provided, type.
         /// Assumes there is no item group of this type in the primary table already.
-        /// Should be used only by batching buckets, and if no items are passed,
-        /// explicitly stores a marker for this item type indicating this.
+        /// Should be used only by batching buckets.
         /// </summary>
         internal void PopulateWithItems(string itemType, ICollection<ProjectItemInstance> group)
         {
-            PrimaryTable ??= new ItemDictionary<ProjectItemInstance>();
-            ICollection<ProjectItemInstance> existing = PrimaryTable[itemType];
-            ErrorUtilities.VerifyThrow(existing.Count == 0, "Cannot add an itemgroup of this type.");
+            // The outer scope should never have primary table populated.
+            MustNotBeOuterScope();
 
-            if (group.Count > 0)
+            if (group.Count == 0)
             {
-                PrimaryTable.ImportItemsOfType(itemType, group);
+                return;
             }
-            else
-            {
-                PrimaryTable.AddEmptyMarker(itemType);
-            }
+
+            PrimaryTable ??= new ItemDictionarySlim();
+            ICollection<ProjectItemInstance> existing = PrimaryTable[itemType];
+            ErrorUtilities.VerifyThrow(existing == null, "Cannot add an itemgroup of this type.");
+
+            PrimaryTable.ImportItemsOfType(itemType, group);
         }
 
         /// <summary>
         /// Populates with an item. This is done before the item lookup is used in this scope.
         /// There may or may not already be a group for it.
+        /// Should be used only by batching buckets.
         /// </summary>
         internal void PopulateWithItem(ProjectItemInstance item)
         {
-            PrimaryTable ??= new ItemDictionary<ProjectItemInstance>();
+            // The outer scope should never have primary table populated.
+            MustNotBeOuterScope();
+
+            PrimaryTable ??= new ItemDictionarySlim();
             PrimaryTable.Add(item);
+        }
+
+        /// <summary>
+        /// Sets the item types to truncate at the current scope.
+        /// </summary>
+        /// <remarks>
+        /// This can only be setup once per-scope, as the truncate set will be frozen for perf.
+        /// </remarks>
+        internal void TruncateLookupsForItemTypes(ICollection<string> itemTypes)
+        {
+            ErrorUtilities.VerifyThrow(_lookupScopes.ItemTypesToTruncateAtThisScope == null, "Cannot add an itemgroup of this type.");
+
+            // Add the item types to truncate at this scope
+            _lookupScopes.ItemTypesToTruncateAtThisScope =
+                itemTypes?.ToFrozenSet(MSBuildNameIgnoreCaseComparer.Default)
+                ?? FrozenSet<string>.Empty;
         }
 
         /// <summary>
@@ -670,7 +735,7 @@ namespace Microsoft.Build.BackEnd
             }
 
             // Put them in the add table
-            PrimaryAddTable ??= new ItemDictionary<ProjectItemInstance>();
+            PrimaryAddTable ??= new ItemDictionarySlim();
             IEnumerable<ProjectItemInstance> itemsToAdd = group;
             if (doNotAddDuplicates)
             {
@@ -721,36 +786,30 @@ namespace Microsoft.Build.BackEnd
 #endif
 
             // Put in the add table
-            PrimaryAddTable ??= new ItemDictionary<ProjectItemInstance>();
+            PrimaryAddTable ??= new ItemDictionarySlim();
             PrimaryAddTable.Add(item);
         }
 
         /// <summary>
         /// Remove a bunch of items from this scope
         /// </summary>
-        internal void RemoveItems(IEnumerable<ProjectItemInstance> items)
-        {
-            foreach (ProjectItemInstance item in items)
-            {
-                RemoveItem(item);
-            }
-        }
-
-        /// <summary>
-        /// Remove an item from this scope
-        /// </summary>
-        internal void RemoveItem(ProjectItemInstance item)
+        internal void RemoveItems(string itemType, ICollection<ProjectItemInstance> items)
         {
             // Removing from outer scope could be easily implemented, but our code does not do it at present
             MustNotBeOuterScope();
 
-            item = RetrieveOriginalFromCloneTable(item);
+            if (items.Count == 0)
+            {
+                return;
+            }
 
-            // Put in the remove table
-            PrimaryRemoveTable ??= new ItemDictionary<ProjectItemInstance>();
-            PrimaryRemoveTable.Add(item);
+            PrimaryRemoveTable ??= new ItemDictionarySlim();
+            PrimaryRemoveTable.EnsureCapacityForItemType(itemType, items.Count);
 
-            // No need to remove this item from the primary add table if it's
+            IEnumerable<ProjectItemInstance> itemsToRemove = items.Select(RetrieveOriginalFromCloneTable);
+            PrimaryRemoveTable.ImportItemsOfType(itemType, itemsToRemove);
+
+            // No need to remove these items from the primary add table if it's
             // already there -- we always apply removes after adds, so that add
             // will be reversed anyway.
         }
@@ -820,7 +879,7 @@ namespace Microsoft.Build.BackEnd
         /// Apply modifies to a temporary result group.
         /// Items to be modified are virtual-cloned so the original isn't changed.
         /// </summary>
-        private void ApplyModifies(ItemDictionary<ProjectItemInstance> result, Dictionary<ProjectItemInstance, MetadataModifications> allModifies)
+        private void ApplyModifies(List<ProjectItemInstance> result, Dictionary<ProjectItemInstance, MetadataModifications> allModifies)
         {
             // Clone, because we're modifying actual items, and this would otherwise be visible to other batches,
             // and would be "published" even if a target fails.
@@ -829,20 +888,18 @@ namespace Microsoft.Build.BackEnd
             // Store the clone, in case we're asked to modify or remove it later (we will record it against the real item)
             _cloneTable ??= new Dictionary<ProjectItemInstance, ProjectItemInstance>();
 
-            foreach (var modify in allModifies)
+            // Iterate through the result group while replacing any items that have pending modifications.
+            for (int i = 0; i < result.Count; i++)
             {
-                ProjectItemInstance originalItem = modify.Key;
-
-                if (result.Contains(originalItem))
+                ProjectItemInstance originalItem = result[i];
+                if (allModifies.TryGetValue(originalItem, out MetadataModifications modificationsToApply))
                 {
-                    var modificationsToApply = modify.Value;
-
                     // Modify the cloned item and replace the original with it.
-                    ProjectItemInstance cloneItem = modify.Key.DeepClone();
+                    ProjectItemInstance cloneItem = originalItem.DeepClone();
 
                     ApplyMetadataModificationsToItem(modificationsToApply, cloneItem);
 
-                    result.Replace(originalItem, cloneItem);
+                    result[i] = cloneItem;
 
                     // This will be null if the item wasn't in the result group, ie, it had been removed after being modified
                     ErrorUtilities.VerifyThrow(!_cloneTable.ContainsKey(cloneItem), "Should be new, not already in table!");
@@ -972,11 +1029,11 @@ namespace Microsoft.Build.BackEnd
         /// <summary>
         /// Verify item is not in the table
         /// </summary>
-        private void MustNotBeInTable(ItemDictionary<ProjectItemInstance> table, ProjectItemInstance item)
+        private void MustNotBeInTable(ItemDictionarySlim table, ProjectItemInstance item)
         {
-            if (table?.ItemTypes.Contains(item.ItemType) == true)
+            if (table?.ContainsKey(item.ItemType) == true)
             {
-                ICollection<ProjectItemInstance> tableOfItemsOfSameType = table[item.ItemType];
+                List<ProjectItemInstance> tableOfItemsOfSameType = table[item.ItemType];
                 if (tableOfItemsOfSameType != null)
                 {
                     ErrorUtilities.VerifyThrow(!tableOfItemsOfSameType.Contains(item), "Item should not be in table");
@@ -1025,7 +1082,7 @@ namespace Microsoft.Build.BackEnd
         /// </summary>
         private void MustNotBeOuterScope()
         {
-            ErrorUtilities.VerifyThrow(_lookupScopes.Count > 1, "Operation in outer scope not supported");
+            ErrorUtilities.VerifyThrow(_lookupScopes.Parent != null, "Operation in outer scope not supported");
         }
 
         #endregion
@@ -1335,17 +1392,17 @@ namespace Microsoft.Build.BackEnd
             /// <summary>
             /// Contains all of the original items at this level in the Lookup
             /// </summary>
-            private IItemDictionary<ProjectItemInstance> _items;
+            private ItemDictionarySlim _items;
 
             /// <summary>
             /// Contains all of the items which have been added at this level in the Lookup
             /// </summary>
-            private ItemDictionary<ProjectItemInstance> _adds;
+            private ItemDictionarySlim _adds;
 
             /// <summary>
             /// Contails all of the items which have been removed at this level in the Lookup
             /// </summary>
-            private ItemDictionary<ProjectItemInstance> _removes;
+            private ItemDictionarySlim _removes;
 
             /// <summary>
             /// Contains all of the metadata which has been changed for items at this level in the Lookup.
@@ -1364,11 +1421,6 @@ namespace Microsoft.Build.BackEnd
             private PropertyDictionary<ProjectPropertyInstance> _propertySets;
 
             /// <summary>
-            /// The managed thread id which entered this scope.
-            /// </summary>
-            private int _threadIdThatEnteredScope;
-
-            /// <summary>
             /// A description of this scope, for error checking
             /// </summary>
             private string _description;
@@ -1380,22 +1432,21 @@ namespace Microsoft.Build.BackEnd
 
             /// <summary>
             /// Indicates whether or not further levels in the Lookup should be consulted beyond this one
-            /// to find the actual value for the desired item or property.
+            /// to find the actual value for the desired item type.
             /// </summary>
-            private bool _truncateLookupsAtThisScope;
+            private FrozenSet<string> _itemTypesToTruncateAtThisScope;
 
-            internal Scope(Lookup lookup, string description, IItemDictionary<ProjectItemInstance> items, PropertyDictionary<ProjectPropertyInstance> properties)
+            internal Scope(Lookup lookup, string description, PropertyDictionary<ProjectPropertyInstance> properties)
             {
                 _owningLookup = lookup;
                 _description = description;
-                _items = items;
+                _items = null;
                 _adds = null;
                 _removes = null;
                 _modifies = null;
                 _properties = properties;
                 _propertySets = null;
-                _threadIdThatEnteredScope = Environment.CurrentManagedThreadId;
-                _truncateLookupsAtThisScope = false;
+                _itemTypesToTruncateAtThisScope = null;
                 Parent = lookup._lookupScopes;
             }
 
@@ -1429,7 +1480,7 @@ namespace Microsoft.Build.BackEnd
             /// include adds or removes unless it's the table in
             /// the outermost scope.
             /// </summary>
-            internal IItemDictionary<ProjectItemInstance> Items
+            internal ItemDictionarySlim Items
             {
                 get { return _items; }
                 set { _items = value; }
@@ -1437,7 +1488,7 @@ namespace Microsoft.Build.BackEnd
             /// <summary>
             /// Adds made in this scope or above.
             /// </summary>
-            internal ItemDictionary<ProjectItemInstance> Adds
+            internal ItemDictionarySlim Adds
             {
                 get { return _adds; }
                 set { _adds = value; }
@@ -1445,7 +1496,7 @@ namespace Microsoft.Build.BackEnd
             /// <summary>
             /// Removes made in this scope or above.
             /// </summary>
-            internal ItemDictionary<ProjectItemInstance> Removes
+            internal ItemDictionarySlim Removes
             {
                 get { return _removes; }
                 set { _removes = value; }
@@ -1476,19 +1527,14 @@ namespace Microsoft.Build.BackEnd
                 get { return _propertySets; }
                 set { _propertySets = value; }
             }
+
             /// <summary>
-            /// ID of thread owning this scope
+            /// Whether to stop lookups going beyond this scope downwards for item types in the set.
             /// </summary>
-            internal int ThreadIdThatEnteredScope
+            internal FrozenSet<string> ItemTypesToTruncateAtThisScope
             {
-                get { return _threadIdThatEnteredScope; }
-            }
-            /// <summary>
-            /// Whether to stop lookups going beyond this scope downwards
-            /// </summary>
-            internal bool TruncateLookupsAtThisScope
-            {
-                get { return _truncateLookupsAtThisScope; }
+                get { return _itemTypesToTruncateAtThisScope; }
+                set { _itemTypesToTruncateAtThisScope = value; }
             }
 
             /// <summary>
@@ -1506,6 +1552,110 @@ namespace Microsoft.Build.BackEnd
             {
                 _owningLookup.LeaveScope(this);
             }
+        }
+
+        /// <summary>
+        /// A simple implementation of ItemDictionary intended for populating Scope tables and merging adds/removes,
+        /// without the overhead of locking and additional lookups.
+        /// </summary>
+        internal class ItemDictionarySlim : IEnumerable<KeyValuePair<string, List<ProjectItemInstance>>>
+        {
+            private readonly Dictionary<string, List<ProjectItemInstance>> _itemLists;
+
+            public ItemDictionarySlim() =>
+                _itemLists = new Dictionary<string, List<ProjectItemInstance>>(MSBuildNameIgnoreCaseComparer.Default);
+
+            /// <summary>
+            /// Gets all items of the given type, or null if there are none.
+            /// </summary>
+            public List<ProjectItemInstance> this[string itemType] =>
+                _itemLists.TryGetValue(itemType, out List<ProjectItemInstance> itemsOfType) ? itemsOfType : null;
+
+            /// <summary>
+            /// Returns true if there are any items of the given type.
+            /// </summary>
+            public bool ContainsKey(string itemType) => _itemLists.ContainsKey(itemType);
+
+            /// <summary>
+            /// Adds a single item to the matching list for its type.
+            /// </summary>
+            public void Add(ProjectItemInstance projectItem)
+            {
+                if (!_itemLists.TryGetValue(projectItem.ItemType, out List<ProjectItemInstance> list))
+                {
+                    list = [];
+                    _itemLists[projectItem.ItemType] = list;
+                }
+
+                list.Add(projectItem);
+            }
+
+            /// <summary>
+            /// Imports and merges all items from an existing item dictionary, appending to any existing list.
+            /// </summary>
+            /// <remarks>
+            /// This should only be called when merging between scopes, as it may take list references from the other dictionary.
+            /// This is safe since we create these internal lists, and the owning Scope will always be discarded after a merge.
+            /// </remarks>
+            public void ImportItems(ItemDictionarySlim other)
+            {
+                foreach (KeyValuePair<string, List<ProjectItemInstance>> kvp in other._itemLists)
+                {
+                    string itemType = kvp.Key;
+                    List<ProjectItemInstance> itemsToAdd = kvp.Value;
+
+                    if (_itemLists.TryGetValue(itemType, out List<ProjectItemInstance> list))
+                    {
+                        // There are already items of this type, so append to the existing list
+                        list.AddRange(itemsToAdd);
+                    }
+                    else
+                    {
+                        // Otherwise, steal the reference instead of copying items out.
+                        _itemLists[itemType] = itemsToAdd;
+                    }
+                }
+            }
+
+            /// <summary>
+            /// Imports and merges all items of the given type, appending to any existing list.
+            /// </summary>
+            public void ImportItemsOfType(string itemType, IEnumerable<ProjectItemInstance> items)
+            {
+                if (!_itemLists.TryGetValue(itemType, out List<ProjectItemInstance> list))
+                {
+                    list = [];
+                    _itemLists[itemType] = list;
+                }
+
+                list.AddRange(items);
+            }
+
+            /// <summary>
+            /// Sets the capacity for the item list matching the given type.
+            /// </summary>
+            /// <remarks>
+            /// Useful for dealing with IEnumerable if we know the upper bound or estimate of items to be added.
+            /// </remarks>
+            internal void EnsureCapacityForItemType(string itemType, int capacity)
+            {
+                if (!_itemLists.TryGetValue(itemType, out List<ProjectItemInstance> list))
+                {
+                    list = new List<ProjectItemInstance>(capacity);
+                    _itemLists[itemType] = list;
+                }
+                else if (capacity > list.Capacity)
+                {
+                    // Conditional since List.Capacity will throw if set less than its current value.
+                    list.Capacity = capacity;
+                }
+            }
+
+            public Dictionary<string, List<ProjectItemInstance>>.Enumerator GetEnumerator() => _itemLists.GetEnumerator();
+
+            IEnumerator<KeyValuePair<string, List<ProjectItemInstance>>> IEnumerable<KeyValuePair<string, List<ProjectItemInstance>>>.GetEnumerator() => GetEnumerator();
+
+            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
         }
     }
 }

--- a/src/Build/BackEnd/Components/RequestBuilder/TargetEntry.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TargetEntry.cs
@@ -504,6 +504,10 @@ namespace Microsoft.Build.BackEnd
                                 // as a result we need separate sets of item and property collections to track changes
                                 if (dependencyResult == DependencyAnalysisResult.IncrementalBuild)
                                 {
+                                    // Ensure that these lookups stop at the current scope, regardless of whether items were added.
+                                    lookupForInference.TruncateLookupsForItemTypes(upToDateTargetInputs.ItemTypes);
+                                    lookupForExecution.TruncateLookupsForItemTypes(changedTargetInputs.ItemTypes);
+
                                     // subset the relevant items to those that are up-to-date
                                     foreach (string itemType in upToDateTargetInputs.ItemTypes)
                                     {

--- a/src/Build/BackEnd/Components/RequestBuilder/TargetUpToDateChecker.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TargetUpToDateChecker.cs
@@ -698,14 +698,14 @@ namespace Microsoft.Build.BackEnd
                         // them.
                         if (!changedTargetInputs.ItemTypes.Contains(inputItems[0].ItemType))
                         {
-                            changedTargetInputs.AddEmptyMarker(inputItems[0].ItemType);
+                            changedTargetInputs.ImportItemsOfType(inputItems[0].ItemType, Array.Empty<ProjectItemInstance>());
                         }
 
                         // We need to perform the same operation on the up-to-date side
                         // too.
                         if (!upToDateTargetInputs.ItemTypes.Contains(inputItems[0].ItemType))
                         {
-                            upToDateTargetInputs.AddEmptyMarker(inputItems[0].ItemType);
+                            upToDateTargetInputs.ImportItemsOfType(inputItems[0].ItemType, Array.Empty<ProjectItemInstance>());
                         }
                     }
                 }

--- a/src/Build/Collections/IItemDictionary.cs
+++ b/src/Build/Collections/IItemDictionary.cs
@@ -66,29 +66,14 @@ namespace Microsoft.Build.Collections
         void Add(T projectItem);
 
         /// <summary>
-        /// Adds each new item to the collection, at the
-        /// end of the list of other items with the same key.
-        /// </summary>
-        void AddRange(IEnumerable<T> projectItems);
-
-        /// <summary>
         /// Removes an item, if it is in the collection.
         /// Returns true if it was found, otherwise false.
         /// </summary>
         /// <remarks>
         /// If a list is emptied, removes the list from the enclosing collection
         /// so it can be garbage collected.
-        /// </remarks>        
+        /// </remarks>
         bool Remove(T projectItem);
-
-        /// <summary>
-        /// Replaces an existing item with a new item.  This is necessary to preserve the original ordering semantics of Lookup.GetItems
-        /// when items with metadata modifications are being returned.  See Dev10 bug 480737.
-        /// If the item is not found, does nothing.
-        /// </summary>
-        /// <param name="existingItem">The item to be replaced.</param>
-        /// <param name="newItem">The replacement item.</param>
-        void Replace(T existingItem, T newItem);
 
         /// <summary>
         /// Add the set of items specified to this dictionary.
@@ -109,21 +94,5 @@ namespace Microsoft.Build.Collections
         /// </summary>
         /// <param name="other">An enumerator over the items to remove.</param>
         void RemoveItems(IEnumerable<T> other);
-
-        /// <summary>
-        /// Special method used for batching buckets.
-        /// Adds an explicit marker indicating there are no items for the specified item type.
-        /// In the general case, this is redundant, but batching buckets use this to indicate that they are
-        /// batching over the item type, but their bucket does not contain items of that type.
-        /// See <see cref="HasEmptyMarker">HasEmptyMarker</see>.
-        /// </summary>
-        void AddEmptyMarker(string itemType);
-
-        /// <summary>
-        /// Special method used for batching buckets.
-        /// Lookup can call this to see whether there was an explicit marker placed indicating that
-        /// there are no items of this type. See comment on <see cref="AddEmptyMarker">AddEmptyMarker</see>.
-        /// </summary>
-        bool HasEmptyMarker(string itemType);
     }
 }

--- a/src/Build/Collections/ItemDictionary.cs
+++ b/src/Build/Collections/ItemDictionary.cs
@@ -6,7 +6,9 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using Microsoft.Build.Evaluation;
+#if DEBUG
 using Microsoft.Build.Shared;
+#endif
 
 #nullable disable
 
@@ -34,8 +36,6 @@ namespace Microsoft.Build.Collections
     {
         /// <summary>
         /// Dictionary of item lists used as a backing store.
-        /// An empty list should never be stored in here unless it is an empty marker.
-        /// See <see cref="AddEmptyMarker">AddEmptyMarker</see>.
         /// This collection provides quick access to the ordered set of items of a particular type.
         /// </summary>
         private readonly Dictionary<string, LinkedList<T>> _itemLists;
@@ -245,17 +245,6 @@ namespace Microsoft.Build.Collections
             }
         }
 
-        public void AddRange(IEnumerable<T> projectItems)
-        {
-            lock (_itemLists)
-            {
-                foreach (var projectItem in projectItems)
-                {
-                    AddProjectItem(projectItem);
-                }
-            }
-        }
-
         /// <summary>
         /// Removes an item, if it is in the collection.
         /// Returns true if it was found, otherwise false.
@@ -288,33 +277,18 @@ namespace Microsoft.Build.Collections
         }
 
         /// <summary>
-        /// Replaces an exsting item with a new item.  This is necessary to preserve the original ordering semantics of Lookup.GetItems
-        /// when items with metadata modifications are being returned.  See Dev10 bug 480737.
-        /// If the item is not found, does nothing.
-        /// </summary>
-        /// <param name="existingItem">The item to be replaced.</param>
-        /// <param name="newItem">The replacement item.</param>
-        public void Replace(T existingItem, T newItem)
-        {
-            ErrorUtilities.VerifyThrow(existingItem.Key == newItem.Key, "Cannot replace an item {0} with an item {1} with a different name.", existingItem.Key, newItem.Key);
-            lock (_itemLists)
-            {
-                if (_nodes.TryGetValue(existingItem, out LinkedListNode<T> node))
-                {
-                    node.Value = newItem;
-                    _nodes.Remove(existingItem);
-                    _nodes.Add(newItem, node);
-                }
-            }
-        }
-
-        /// <summary>
         /// Add the set of items specified to this dictionary
         /// </summary>
         /// <param name="other">An enumerator over the items to remove.</param>
         public void ImportItems(IEnumerable<T> other)
         {
-            AddRange(other);
+            lock (_itemLists)
+            {
+                foreach (var projectItem in other)
+                {
+                    AddProjectItem(projectItem);
+                }
+            }
         }
 
         /// <summary>
@@ -354,40 +328,6 @@ namespace Microsoft.Build.Collections
             foreach (T item in other)
             {
                 Remove(item);
-            }
-        }
-
-        /// <summary>
-        /// Special method used for batching buckets.
-        /// Adds an explicit marker indicating there are no items for the specified item type.
-        /// In the general case, this is redundant, but batching buckets use this to indicate that they are
-        /// batching over the item type, but their bucket does not contain items of that type.
-        /// See <see cref="HasEmptyMarker">HasEmptyMarker</see>.
-        /// </summary>
-        public void AddEmptyMarker(string itemType)
-        {
-            lock (_itemLists)
-            {
-                ErrorUtilities.VerifyThrow(!_itemLists.ContainsKey(itemType), "Should be none");
-                _itemLists.Add(itemType, new LinkedList<T>());
-            }
-        }
-
-        /// <summary>
-        /// Special method used for batching buckets.
-        /// Lookup can call this to see whether there was an explicit marker placed indicating that
-        /// there are no items of this type. See comment on <see cref="AddEmptyMarker">AddEmptyMarker</see>.
-        /// </summary>
-        public bool HasEmptyMarker(string itemType)
-        {
-            lock (_itemLists)
-            {
-                if (_itemLists.TryGetValue(itemType, out LinkedList<T> list) && list.Count == 0)
-                {
-                    return true;
-                }
-
-                return false;
             }
         }
 

--- a/src/Build/Instance/ImmutableProjectCollections/ImmutableItemDictionary.cs
+++ b/src/Build/Instance/ImmutableProjectCollections/ImmutableItemDictionary.cs
@@ -64,12 +64,6 @@ namespace Microsoft.Build.Instance
         public void Add(T projectItem) => throw new NotSupportedException();
 
         /// <inheritdoc />
-        public void AddEmptyMarker(string itemType) => throw new NotSupportedException();
-
-        /// <inheritdoc />
-        public void AddRange(IEnumerable<T> projectItems) => throw new NotSupportedException();
-
-        /// <inheritdoc />
         public void Clear() => throw new NotSupportedException();
 
         /// <inheritdoc />
@@ -156,9 +150,6 @@ namespace Microsoft.Build.Instance
         }
 
         /// <inheritdoc />
-        public bool HasEmptyMarker(string itemType) => _itemsByType.Values.Any(list => list.Count == 0);
-
-        /// <inheritdoc />
         public void ImportItems(IEnumerable<T> other) => throw new NotSupportedException();
 
         /// <inheritdoc />
@@ -169,9 +160,6 @@ namespace Microsoft.Build.Instance
 
         /// <inheritdoc />
         public void RemoveItems(IEnumerable<T> other) => throw new NotSupportedException();
-
-        /// <inheritdoc />
-        public void Replace(T existingItem, T newItem) => throw new NotSupportedException();
 
         private sealed class ListConverter : ICollection<T>
         {


### PR DESCRIPTION
### Fixes

Reduces a significant amount of CPU and allocations in `Lookup` related to `ItemDictionary` overhead.

Before:
<img width="1456" height="346" alt="image" src="https://github.com/user-attachments/assets/5ac39119-a151-47c5-b3d7-fc9bcf5e8cd7" />

After (-2.8s of CPU - most of the remaining time is related to metadata `Modifies` and `PropertyDictionary`)
<img width="1455" height="345" alt="image" src="https://github.com/user-attachments/assets/7534dab8-5b1f-4591-99a4-405c60ba50dd" />

Allocations are harder to 1:1 here, but you can see on the left a total ~870MB reduction.

Before:
<img width="1156" height="412" alt="image" src="https://github.com/user-attachments/assets/2a247dd9-6f17-43c4-b7bf-527e1b570faa" />

After:
<img width="1151" height="410" alt="image" src="https://github.com/user-attachments/assets/9395a174-94ed-49ab-8546-cba48e9824b4" />


### Context

`Lookup` uses a stack of `Scope` objects which each track multiple optional tables of `ProjectItemInstance` (implemented via `ItemDictionary`).

```cs
internal class Scope
{
      internal ItemDictionary<ProjectItemInstance> Items { get; set; }
      internal ItemDictionary<ProjectItemInstance> Adds { get; set; }
      internal ItemDictionary<ProjectItemInstance> Removes { get; set; }

      // More properties not relevant to this PR
}
```

For the context of the PR, here's a quick overview of how this currently works:

- When a scope is "popped", each table *except* for `Items` is merged into the next scope. After this point, the popped scope is effectively discarded  (see `MergeScopeIntoNotLastScope()`).
- When the outer scope is reached, the set of item adds/removes + any metadata modifications are applied to the base scope's `Items`  (see `MergeScopeIntoLastScope()`). Unlike other scopes, this base table is externally provided at the construction of the first `Lookup`.
  - The outer scope only exists to track the base collections passed into the first scope - as such, its adds/removes/modification tables are always empty.
- `GetItems()` returns a non-destructive merge down the scope stack, stopping if either the outer scope is reached, or a scope is found with its `Items` table set.
  - Note that this currently creates an additional `ItemDictionary`, even though we only return a single item type list.
  - Intermediate `Items` tables generally only contain *one* item type with items, with others containing "empty markers". These are used to mask the base item dictionary, primarily in `ItemBucket` where each bucket (and therefore scope) holds a single type.

Currently, each of these intermediate tables are implemented via `ItemDictionary`, which internally uses a `Dictionary<string, LinkedList>` to represent item lists and a `Dictionary<ProjectItemInstance, LinkedList>` to provide O(1) access to indices. Empty markers are implemented by creating empty entries. Every method also takes a lock, since `ItemDictionary` is designed for use in other areas of MSBuild - whereas `Lookup` is only used in single-threaded contexts.

```cs
internal sealed class ItemDictionary<T> : IItemDictionary<T>
    where T : class, IKeyed, IItem
{
    private readonly Dictionary<string, LinkedList<T>> _itemLists;
    private readonly Dictionary<T, LinkedListNode<T>> _nodes;
}
```

This all adds overhead that can be avoided by replacing `ItemDicitonary` with basic collections for all inner scopes.

### Changes Made

- Introduce a lighter-weight `ItemDictionarySlim` to replace `ItemDictionary` inside of `Lookup`, while still providing similar helper methods.

```cs
internal class ItemDictionarySlim : IEnumerable<KeyValuePair<string, List<ProjectItemInstance>>>
{
    private readonly Dictionary<string, List<ProjectItemInstance>> _itemLists;

   // helper methods...
}
```

- Implement empty markers as a reuseable frozen set - `ItemTypesToTruncateAtThisScope`

```cs
internal class Scope
{
      internal FrozenSet<string> ItemTypesToTruncateAtThisScope { get; set; }

      // Other properties...
}
```

- Track removes as a simple list concatenation, instead of deduplicating at each scope
- Avoid a host of intermediate allocations during `GetItems`
