### PR TITLE
Fix the build after moving to UnscheduledRequestsWhichCanBeScheduled

### DIFF
--- a/src/Build/BackEnd/Components/Scheduler/Scheduler.cs
+++ b/src/Build/BackEnd/Components/Scheduler/Scheduler.cs
@@ -1037,11 +1037,12 @@ namespace Microsoft.Build.BackEnd
             if (idleNodes.Contains(InProcNodeId))
             {
                 SchedulableRequest[] unscheduledRequests = _requestBufferPool.Rent(_schedulingData.UnscheduledRequestsCount);
-         
-                var numRead = 0;
-                while (numRead < unscheduledRequests.Length && _schedulingData.UnscheduledRequestsWhichCanBeScheduled.MoveNext())
+
+                int numRead = 0;
+                SchedulingData.UnscheduledRequestsWhichCanBeScheduledEnumerator unscheduledRequestsRead = _schedulingData.UnscheduledRequestsWhichCanBeScheduled.GetEnumerator();
+                while (numRead < unscheduledRequests.Length && unscheduledRequestsRead.MoveNext())
                 {
-                    unscheduledRequests[numRead] = _schedulingData.UnscheduledRequestsWhichCanBeScheduled.Current;
+                    unscheduledRequests[numRead] = unscheduledRequestsRead.Current;
                     numRead++;
                 }
 

--- a/src/Build/BackEnd/Components/Scheduler/Scheduler.cs
+++ b/src/Build/BackEnd/Components/Scheduler/Scheduler.cs
@@ -11,8 +11,8 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Build.Execution;
-using Microsoft.Build.ProjectCache;
 using Microsoft.Build.Framework;
+using Microsoft.Build.ProjectCache;
 using Microsoft.Build.Shared;
 using Microsoft.Build.Shared.Debugging;
 using BuildAbortedException = Microsoft.Build.Exceptions.BuildAbortedException;
@@ -1036,8 +1036,15 @@ namespace Microsoft.Build.BackEnd
         {
             if (idleNodes.Contains(InProcNodeId))
             {
-                SchedulableRequest[] unscheduledRequests = RentPooledBuffer(
-                    _schedulingData.UnscheduledRequestsWhichCanBeScheduled, _schedulingData.UnscheduledRequestsCount, out int numRead);
+                SchedulableRequest[] unscheduledRequests = _requestBufferPool.Rent(_schedulingData.UnscheduledRequestsCount);
+         
+                var numRead = 0;
+                while (numRead < unscheduledRequests.Length && _schedulingData.UnscheduledRequestsWhichCanBeScheduled.MoveNext())
+                {
+                    unscheduledRequests[numRead] = _schedulingData.UnscheduledRequestsWhichCanBeScheduled.Current;
+                    numRead++;
+                }
+
                 foreach (SchedulableRequest request in new ReadOnlySpan<SchedulableRequest>(unscheduledRequests, 0, numRead))
                 {
                     if (CanScheduleRequestToNode(request, InProcNodeId) && shouldBeScheduled(request))


### PR DESCRIPTION
Related to: https://github.com/dotnet/msbuild/pull/12179

The return type has changed because it conflicts with RentPooledBuffer method signature.