### PR TITLE
Remove warning CS1701 and CS1702 when using RoslynCodeTaskFactory

### DIFF
--- a/src/Tasks.UnitTests/RoslynCodeTaskFactory_Tests.cs
+++ b/src/Tasks.UnitTests/RoslynCodeTaskFactory_Tests.cs
@@ -227,7 +227,7 @@ Log.LogError(Class1.ToPrint());
         }
 
         [Fact]
-        public void InlineTaskWithoutCS1702Warning()
+        public void RoslynCodeTaskFactoryWithoutCS1702Warning()
         {
             using (TestEnvironment env = TestEnvironment.Create())
             {

--- a/src/Tasks/RoslynCodeTaskFactory/RoslynCodeTaskFactory.cs
+++ b/src/Tasks/RoslynCodeTaskFactory/RoslynCodeTaskFactory.cs
@@ -738,7 +738,7 @@ namespace Microsoft.Build.Tasks
                     managedCompiler.OutputAssembly = new TaskItem(assemblyPath);
                     managedCompiler.References = references;
                     managedCompiler.Sources = [new TaskItem(sourceCodePath)];
-                    managedCompiler.NoWarnCodes = "1702";
+                    managedCompiler.NoWarn = "1701;1702";
                     managedCompiler.TargetType = "Library";
                     managedCompiler.UseSharedCompilation = false;
 

--- a/src/Tasks/RoslynCodeTaskFactory/RoslynCodeTaskFactory.cs
+++ b/src/Tasks/RoslynCodeTaskFactory/RoslynCodeTaskFactory.cs
@@ -738,6 +738,7 @@ namespace Microsoft.Build.Tasks
                     managedCompiler.OutputAssembly = new TaskItem(assemblyPath);
                     managedCompiler.References = references;
                     managedCompiler.Sources = [new TaskItem(sourceCodePath)];
+                    managedCompiler.NoWarnCodes = "1702";
                     managedCompiler.TargetType = "Library";
                     managedCompiler.UseSharedCompilation = false;
 

--- a/src/Tasks/RoslynCodeTaskFactory/RoslynCodeTaskFactoryCompilers.cs
+++ b/src/Tasks/RoslynCodeTaskFactory/RoslynCodeTaskFactoryCompilers.cs
@@ -81,6 +81,8 @@ namespace Microsoft.Build.Tasks
 
         public ITaskItem OutputAssembly { get; set; }
 
+        public string NoWarnCodes { get; set; }
+
         public ITaskItem[] References { get; set; }
 
         public ITaskItem[] Sources { get; set; }
@@ -110,6 +112,7 @@ namespace Microsoft.Build.Tasks
             commandLine.AppendPlusOrMinusSwitch("/deterministic", Deterministic);
             commandLine.AppendSwitchIfTrue("/nologo", NoLogo);
             commandLine.AppendPlusOrMinusSwitch("/optimize", Optimize);
+            commandLine.AppendSwitchIfNotNull("/nowarn:", NoWarnCodes);
             commandLine.AppendSwitchIfNotNull("/target:", TargetType);
             commandLine.AppendSwitchIfNotNull("/out:", OutputAssembly);
             commandLine.AppendFileNamesIfNotNull(Sources, " ");

--- a/src/Tasks/RoslynCodeTaskFactory/RoslynCodeTaskFactoryCompilers.cs
+++ b/src/Tasks/RoslynCodeTaskFactory/RoslynCodeTaskFactoryCompilers.cs
@@ -81,7 +81,7 @@ namespace Microsoft.Build.Tasks
 
         public ITaskItem OutputAssembly { get; set; }
 
-        public string NoWarnCodes { get; set; }
+        public string NoWarn { get; set; }
 
         public ITaskItem[] References { get; set; }
 
@@ -112,7 +112,7 @@ namespace Microsoft.Build.Tasks
             commandLine.AppendPlusOrMinusSwitch("/deterministic", Deterministic);
             commandLine.AppendSwitchIfTrue("/nologo", NoLogo);
             commandLine.AppendPlusOrMinusSwitch("/optimize", Optimize);
-            commandLine.AppendSwitchIfNotNull("/nowarn:", NoWarnCodes);
+            commandLine.AppendSwitchIfNotNull("/nowarn:", NoWarn);
             commandLine.AppendSwitchIfNotNull("/target:", TargetType);
             commandLine.AppendSwitchIfNotNull("/out:", OutputAssembly);
             commandLine.AppendFileNamesIfNotNull(Sources, " ");


### PR DESCRIPTION
Fixes #
Fix the issue: Suppress CS1701 and CS1702 warnings by default in `RoslynCodeTaskFactory `to align with .NET SDK https://github.com/dotnet/msbuild/issues/12101
### Context
When using `RoslynCodeTaskFactory`, MSBuild emits CS1701 and CS1702 assembly binding warnings for version mismatches (e.g., between `System.Memory` and `System.Text.Json`). These warnings are not actionable in modern .NET scenarios and are already suppressed by default in the .NET SDK and Roslyn. This issue causes unnecessary warning noise and confusion in custom task or non-SDK builds.

### Changes Made
Added a new property in the task factory configuration to include `NoWarn="1701;1702"` for all tasks generated by `RoslynCodeTaskFactory`

### Testing
Added a new unit test `RoslynCodeTaskFactoryWithoutCS1702Warning` in the MSBuild test suite to verify that no CS1702 warnings are emitted when using `RoslynCodeTaskFactory` with references to `System.Memory` (v4.6.3) and `System.Text.Json` (v9.0.7).

Create a project file base on example of user for test https://github.com/dotnet/roslyn/issues/19640#issuecomment-3143786333
### Notes
