### PR TITLE
Fix nullref exception in TaskReistry.CanTaskBeCreatedByFactory

### DIFF
--- a/src/Build/Instance/TaskRegistry.cs
+++ b/src/Build/Instance/TaskRegistry.cs
@@ -1099,7 +1099,7 @@ namespace Microsoft.Build.Execution
             /// <summary>
             /// Lock for the taskFactoryTypeLoader
             /// </summary>
-            private static readonly Object s_taskFactoryTypeLoaderLock = new Object();
+            private static readonly LockType s_taskFactoryTypeLoaderLock = new ();
 
 #if DEBUG
             /// <summary>
@@ -1154,7 +1154,7 @@ namespace Microsoft.Build.Execution
             /// When ever a taskName is checked against the factory we cache the result so we do not have to
             /// make possibly expensive calls over and over again.
             /// </summary>
-            private volatile ConcurrentDictionary<RegisteredTaskIdentity, object> _taskNamesCreatableByFactory;
+            private ConcurrentDictionary<RegisteredTaskIdentity, object> _taskNamesCreatableByFactory;
 
             /// <summary>
             /// Set of parameters that can be used by the task factory specifically.


### PR DESCRIPTION
Fixes #12285 

### Context
The bug caused by:
https://github.com/dotnet/msbuild/pull/12251/files

<img width="3283" height="1455" alt="Image" src="https://github.com/user-attachments/assets/63d1235a-09f8-445e-a815-2dc72255acbe" />

it happens, when RegisteredTaskRecord is created via deserialization (DTB case)

```
            internal static RegisteredTaskRecord FactoryForDeserialization(ITranslator translator)
            {
                var instance = new RegisteredTaskRecord();
                instance.Translate(translator);

                return instance;
            }
```

<img width="3727" height="1749" alt="Image" src="https://github.com/user-attachments/assets/1e882f8c-664b-4ac3-ba10-d29a5d18d85a" />

and leaves `_taskNamesCreatableByFactory `uninitialized. (see the taskName on the screenshots)
I am preparing the fix.

### Changes Made
Return initialization to `CanTaskBeCreatedByFactory` method to avoid handling `_taskNamesCreatableByFactory` initialization in different `RegisteredTaskRecord` ctors.

### Testing
Manual due to the stable repro presence. 
