### PR TITLE
Add real sign condition for PME enforcement

### DIFF
--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -173,9 +173,9 @@ extends:
             signType: $(SignType)
             zipSources: false
             feedSource: https://devdiv.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
-            ${{ if eq(variables['System.TeamProject'], 'DevDiv') }}:
+            ${{ if and(eq(variables['SignType'], 'real'), eq(variables['System.TeamProject'], 'DevDiv')) }}:
               ConnectedPMEServiceName: 6cc74545-d7b9-4050-9dfa-ebefcc8961ea
-            ${{ else }}:
+            ${{ if and(eq(variables['SignType'], 'real'), ne(variables['System.TeamProject'], 'DevDiv')) }}:
               ConnectedPMEServiceName: 248d384a-b39b-46e3-8ad5-c2c210d5e7ca
           env:
             SYSTEM_ACCESSTOKEN: $(System.AccessToken)


### PR DESCRIPTION
The PME connection isn't needed for test-signed bits.
