### PR TITLE
Don't leak SDK-resolver environment to global env

### DIFF
--- a/src/Build/Instance/ProjectInstance.cs
+++ b/src/Build/Instance/ProjectInstance.cs
@@ -1380,9 +1380,6 @@ namespace Microsoft.Build.Execution
 
             _sdkResolvedEnvironmentVariableProperties.Set(property);
 
-            // Also set the property in the EnvironmentVariablePropertiesDictionary so that it can be used in regular evaluation
-            _environmentVariableProperties.Set(property);
-
             // Only set the local property if it does not already exist, prioritizing regular properties defined in XML.
             if (GetProperty(name) is null)
             {


### PR DESCRIPTION
Work item (Internal use): devdiv2542861 (web), devdiv2522896 (MAUI)

### Summary

Fix an issue that caused `DOTNET_HOST_PATH` to not be set as expected for .NET SDK tasks in some build situations, including VS Publish and build-with-restore-from-`MSBuild.exe`.

### Customer Impact

Publish for web projects and ILMerge failed with unfixable and hard-to-diagnose errors.

### Regression?

Yes, introduced with #12077 (enabling setting `DOTNET_HOST_PATH` in .NET Framework-driven builds like through VS).

### Testing

Automated testing, scenario testing for Web Publish through VS and on the command line.

### Risk

Medium: changes a codepath that is important for .NET SDK projects where test coverage (finding this issue and getting it to us) is suboptimal. Change is scoped to .NET SDK projects but affects all of them.

### Fix details

In many of the constructor codepaths that create ProjectInstances,
`_environmentVariableProperties` will be an object that is shared among
several logical projects/instances, so mutating it can have bad effects.
