### PR TITLE
[vs17.15] redirects for workflow editor tools in VS (#12372)

### DIFF
--- a/azure-pipelines/vs-insertion.yml
+++ b/azure-pipelines/vs-insertion.yml
@@ -85,6 +85,8 @@ variables:
       value: 'rel/d17.0'
     ${{ elseif eq(variables['Build.SourceBranchName'], 'main') }}:
       value: 'main'
+    ${{ elseif eq(variables['Build.SourceBranchName'], 'vs17.15') }}:
+      value: 'main'
     ${{ else }}:
       value: ''
   - name: InsertTargetBranch

--- a/src/MSBuild/app.amd64.config
+++ b/src/MSBuild/app.amd64.config
@@ -255,11 +255,11 @@
         <!-- Redirects for components dropped by Visual Studio -->
         <dependentAssembly>
           <assemblyIdentity name="Microsoft.Activities.Build" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-          <bindingRedirect oldVersion="4.0.0.0" newVersion="17.0.0.0" />
+          <bindingRedirect oldVersion="4.0.0.0" newVersion="18.0.0.0" />
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="XamlBuildTask" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-          <bindingRedirect oldVersion="4.0.0.0-17.0.0.0" newVersion="17.0.0.0" />
+          <bindingRedirect oldVersion="4.0.0.0-18.0.0.0" newVersion="18.0.0.0" />
         </dependentAssembly>
 
         <!-- Workaround for crash in C++ CodeAnalysis scenarios due to https://github.com/dotnet/msbuild/issues/1675 -->

--- a/src/MSBuild/app.config
+++ b/src/MSBuild/app.config
@@ -127,13 +127,13 @@
         <!-- Redirects for components dropped by Visual Studio -->
         <dependentAssembly>
           <assemblyIdentity name="Microsoft.Activities.Build" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-          <bindingRedirect oldVersion="4.0.0.0" newVersion="17.0.0.0" />
-          <codeBase version="17.0.0.0" href=".\amd64\Microsoft.Activities.Build.dll" />
+          <bindingRedirect oldVersion="4.0.0.0" newVersion="18.0.0.0" />
+          <codeBase version="18.0.0.0" href=".\amd64\Microsoft.Activities.Build.dll" />
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="XamlBuildTask" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-          <bindingRedirect oldVersion="4.0.0.0-17.0.0.0" newVersion="17.0.0.0" />
-          <codeBase version="17.0.0.0" href=".\amd64\XamlBuildTask.dll" />
+          <bindingRedirect oldVersion="4.0.0.0-18.0.0.0" newVersion="18.0.0.0" />
+          <codeBase version="18.0.0.0" href=".\amd64\XamlBuildTask.dll" />
         </dependentAssembly>
 
         <!-- Workaround for crash in C++ CodeAnalysis scenarios due to https://github.com/dotnet/msbuild/issues/1675 -->


### PR DESCRIPTION
### Summary

Updating binding redirects for workflow editor tools in VS. This allows
building of workflow projects in VS.

### Customer Impact

Workflow editor is non-functional.

### Regression?

Yes, from 17.14.

### Testing

Applied fix locally and verified WF projects could build.

### Risk

Low--assembly binding redirect is isolated to this scenario.

### note
add change to insert to main