### PR TITLE
Split internal pipeline on exp and prod

### DIFF
--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -100,11 +100,4 @@ extends:
           isExperimental: false
           enableLocalization: true
           enableComponentGovernance: true
-
-    - template: /eng/common/templates-official/post-build/post-build.yml@self
-      parameters:
-        publishingInfraVersion: 3
-        enableSymbolValidation: true
-        enableSourceLinkValidation: false
-        enableNugetValidation: false
-        requireDefaultChannels: ${{ variables.requireDefaultChannels }}
+          enableSigningValidation: true

--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -38,7 +38,7 @@ variables:
   # if OptProfDropName is set as a parameter, set OptProfDrop to the parameter and unset SourceBranch
   - ${{ if ne(parameters.OptProfDropName, 'default') }}:
     - name: OptProfDrop
-      value: ${{parameters.OptProfDropName}}
+      value: ${{ parameters.OptProfDropName }}
     - name: SourceBranch
       value: ''
   # Override SkipApplyOptimizationData to true when disabling OptProf data collection
@@ -92,12 +92,39 @@ extends:
         suppressionsFile: $(Build.SourcesDirectory)/eng/CredScanSuppressions.json
 
     stages:
+    - ${{ if or(startsWith(variables['Build.SourceBranch'], 'refs/heads/vs'), eq(variables['Build.SourceBranch'], 'refs/heads/main')) }}:
+      - stage: localization
+        displayName: Localization
+        jobs:
+        # The localization setup for release/ branches. Note difference in LclPackageId. main branch is handled separately below.
+        # Used for vs17.2, vs17.4, vs17.6 etc. branches only.
+        # When the branch is setup for localization (the localization ticket needs to be created - https://aka.ms/ceChangeLocConfig, requesting change from one release branch to another),
+        #  set 'EnableReleaseOneLocBuild' to true.
+        - ${{ if startsWith(variables['Build.SourceBranch'], 'refs/heads/vs') }}:
+          - template: /eng/common/templates-official/job/onelocbuild.yml@self
+            parameters:
+              MirrorRepo: 'msbuild'
+              LclSource: lclFilesfromPackage
+              LclPackageId: 'LCL-JUNO-PROD-MSBUILDREL'
+              MirrorBranch: ${{ replace(variables['Build.SourceBranch'], 'refs/heads/', '') }}
+              JobNameSuffix: '_release'
+              condition: ${{ variables.EnableReleaseOneLocBuild }}
+        # The localization setup for main branch. Note difference in package ID. Should not be used with release/ branches.
+        - ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/main') }}:
+          - template: /eng/common/templates-official/job/onelocbuild.yml@self
+            parameters:
+              MirrorRepo: 'msbuild'
+              LclSource: lclFilesfromPackage
+              LclPackageId: 'LCL-JUNO-PROD-MSBUILD'
+              MirrorBranch: 'main'
+              JobNameSuffix: '_main'
+              condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')
+
     - stage: build
       displayName: Build
       jobs:
       - template: /azure-pipelines/.vsts-dotnet-build-jobs.yml@self
         parameters:
           isExperimental: false
-          enableLocalization: true
           enableComponentGovernance: true
           enableSigningValidation: true

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -31,6 +31,14 @@
 
   <Import Project="Sdk.targets" Sdk="Microsoft.DotNet.Arcade.Sdk" />
 
+  <!-- Put it after Sdk.targets imports to override values from StrongName.targets. It's needed to avoid NGEN validation issues on VS exp insertions.  -->
+  <PropertyGroup Condition="'$(SignType)' == 'test'">
+    <!-- Remove open source signing -->
+    <PublicSign>false</PublicSign>
+    <SignAssembly>true</SignAssembly>
+    <DelaySign>true</DelaySign>
+  </PropertyGroup>
+
   <Target Name="DeleteDevPackage" AfterTargets="GenerateNuspec">
     <!-- If package just built was already in global packages folder, delete it.  This helps support a local dev cycle where you are consuming
          a package from another repo without having to update the package version each time. -->

--- a/azure-pipelines/.vsts-dotnet-build-jobs.yml
+++ b/azure-pipelines/.vsts-dotnet-build-jobs.yml
@@ -1,0 +1,260 @@
+# Template for the main Windows_NT build job
+parameters:
+- name: isExperimental
+  type: boolean
+  default: false
+- name: enableLocalization
+  type: boolean
+  default: false
+- name: enableComponentGovernance
+  type: boolean
+  default: false
+
+jobs:
+# The localization setup for release/ branches. Note difference in LclPackageId. main branch is handled separately below.
+# Used for vs17.2, vs17.4, vs17.6 etc. branches only.
+# When the branch is setup for localization (the localization ticket needs to be created - https://aka.ms/ceChangeLocConfig, requesting change from one release branch to another),
+#  set 'EnableReleaseOneLocBuild' to true.
+- ${{ if and(parameters.enableLocalization, startsWith(variables['Build.SourceBranch'], 'refs/heads/vs')) }}:
+  - template: /eng/common/templates-official/job/onelocbuild.yml@self
+    parameters:
+      MirrorRepo: 'msbuild'
+      LclSource: lclFilesfromPackage
+      LclPackageId: 'LCL-JUNO-PROD-MSBUILDREL'
+      MirrorBranch: ${{ replace(variables['Build.SourceBranch'], 'refs/heads/', '') }}
+      JobNameSuffix: '_release'
+      condition: ${{ variables.EnableReleaseOneLocBuild }}
+# The localization setup for main branch. Note difference in package ID. Should not be used with release/ branches.
+- ${{ if and(parameters.enableLocalization, eq(variables['Build.SourceBranch'], 'refs/heads/main')) }}:
+  - template: /eng/common/templates-official/job/onelocbuild.yml@self
+    parameters:
+      MirrorRepo: 'msbuild'
+      LclSource: lclFilesfromPackage
+      LclPackageId: 'LCL-JUNO-PROD-MSBUILD'
+      MirrorBranch: 'main'
+      JobNameSuffix: '_main'
+      condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')
+
+- job: Windows_NT
+  pool:
+    name: VSEngSS-MicroBuild2022-1ES
+    demands:
+    - agent.os -equals Windows_NT
+
+  timeoutInMinutes: 180
+
+  variables:
+  - group: Publish-Build-Assets
+  - name: TeamName
+    value: MSBuild
+  - name: VisualStudio.MajorVersion
+    value: 18
+  - name: VisualStudio.ChannelName
+    value: 'int.main'
+  - name: VisualStudio.DropName
+    value: Products/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildNumber)
+
+  steps:
+  - task: NuGetToolInstaller@1
+    displayName: 'Install NuGet.exe'
+  - pwsh: Get-MpComputerStatus
+
+  - pwsh: Set-MpPreference -DisableRealtimeMonitoring $true
+
+  - task: PowerShell@2
+    displayName: Setup Private Feeds Credentials
+    inputs:
+      filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.ps1
+      arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $Env:Token
+    env:
+      Token: $(dn-bot-dnceng-artifact-feeds-rw)
+
+  - task: NuGetCommand@2
+    displayName: Restore internal tools
+    inputs:
+      command: restore
+      feedsToUse: config
+      restoreSolution: 'eng\common\internal\Tools.csproj'
+      nugetConfigPath: 'eng\common\internal\NuGet.config'
+      restoreDirectory: '$(Build.SourcesDirectory)\.packages'
+  
+  - task: MicroBuildSigningPlugin@4
+    displayName: Install MicroBuild plugin
+    inputs:
+      signType: $(SignType)
+      zipSources: false
+      feedSource: https://devdiv.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
+      ${{ if and(eq(variables['SignType'], 'real'), eq(variables['System.TeamProject'], 'DevDiv')) }}:
+        ConnectedPMEServiceName: 6cc74545-d7b9-4050-9dfa-ebefcc8961ea
+    env:
+      SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+    condition: and(succeeded(), in(variables['SignType'], 'test', 'real'))
+
+  - task: MicroBuildOptProfPlugin@6
+    inputs:
+      ProfilingInputsDropName: '$(VisualStudio.DropName)'
+      ShouldSkipOptimize: true
+      AccessToken: '$(System.AccessToken)'
+      feedSource: 'https://devdiv.pkgs.visualstudio.com/DefaultCollection/_packaging/MicroBuildToolset/nuget/v3/index.json'
+    displayName: 'Install OptProf Plugin'
+
+  # Required by MicroBuildBuildVSBootstrapper
+  - task: MicroBuildSwixPlugin@4
+    inputs:
+      dropName: $(VisualStudio.DropName)
+
+  - script: eng/CIBuild.cmd
+              -configuration $(BuildConfiguration)
+              -officialBuildId $(Build.BuildNumber)
+              -officialSkipApplyOptimizationData $(SkipApplyOptimizationData)
+              /p:RepositoryName=$(Build.Repository.Name)
+              /p:VisualStudioIbcSourceBranchName=$(SourceBranch)
+              /p:VisualStudioDropAccessToken=$(System.AccessToken)
+              /p:VisualStudioDropName=$(VisualStudio.DropName)
+              /p:DotNetSignType=$(SignType)
+              /p:TeamName=MSBuild
+              /p:DotNetPublishUsingPipelines=true
+              /p:VisualStudioIbcDrop=$(OptProfDrop)
+              /p:GenerateSbom=true
+              /p:SuppressFinalPackageVersion=${{ parameters.isExperimental }}
+    displayName: Build
+    condition: succeeded()
+
+  # Required by Microsoft policy
+  - template: /eng/common/templates-official/steps/generate-sbom.yml@self
+
+  # Publish OptProf configuration files
+  - task: 1ES.PublishArtifactsDrop@1
+    inputs:
+      dropServiceURI: 'https://devdiv.artifacts.visualstudio.com'
+      buildNumber: 'ProfilingInputs/DevDiv/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildNumber)'
+      sourcePath: '$(Build.SourcesDirectory)\artifacts\OptProf\$(BuildConfiguration)\Data'
+      toLowerCase: false
+      usePat: true
+    displayName: 'OptProf - Publish to Artifact Services - ProfilingInputs'
+    condition: succeeded()
+
+  # Build VS bootstrapper
+  # Generates $(Build.StagingDirectory)\MicroBuild\Output\BootstrapperInfo.json
+  - task: MicroBuildBuildVSBootstrapper@3
+    inputs:
+      vsMajorVersion: $(VisualStudio.MajorVersion)
+      channelName: $(VisualStudio.ChannelName)
+      manifests: $(VisualStudio.SetupManifestList)
+      outputFolder: '$(Build.SourcesDirectory)\artifacts\VSSetup\$(BuildConfiguration)\Insertion'
+    displayName: 'OptProf - Build VS bootstrapper'
+    condition: succeeded()
+
+  # Publish run settings
+  - task: PowerShell@2
+    inputs:
+      filePath: eng\common\sdk-task.ps1
+      arguments: -configuration $(BuildConfiguration)
+                -task VisualStudio.BuildIbcTrainingSettings
+                /p:VisualStudioDropName=$(VisualStudio.DropName)
+                /p:BootstrapperInfoPath=$(Build.StagingDirectory)\MicroBuild\Output\BootstrapperInfo.json
+                /p:VisualStudioIbcTrainingSettingsPath=$(Build.SourcesDirectory)\eng\config\OptProf.runsettings
+    displayName: 'OptProf - Build IBC training settings'
+    condition: succeeded()
+
+  # Publish bootstrapper info
+  - task: 1ES.PublishBuildArtifacts@1
+    inputs:
+      PathtoPublish: $(Build.StagingDirectory)\MicroBuild\Output
+      ArtifactName: MicroBuildOutputs
+      ArtifactType: Container
+    displayName: 'OptProf - Publish Artifact: MicroBuildOutputs'
+    condition: succeeded()
+
+  - task: 1ES.PublishBuildArtifacts@1
+    displayName: 'Publish Artifact: logs'
+    inputs:
+      PathtoPublish: 'artifacts\log\$(BuildConfiguration)'
+      ArtifactName: logs
+    condition: succeededOrFailed()
+
+  # Publishes setup VSIXes to a drop.
+  # Note: The insertion tool looks for the display name of this task in the logs.
+  - task: 1ES.MicroBuildVstsDrop@1
+    displayName: Upload VSTS Drop
+    inputs:
+      dropName: $(VisualStudio.DropName)
+      dropFolder: 'artifacts\VSSetup\$(BuildConfiguration)\Insertion'
+      dropRetentionDays: '30' # extended by insertion + VS release
+      accessToken: '$(System.AccessToken)'
+      dropServiceUri: 'https://devdiv.artifacts.visualstudio.com'
+      vsDropServiceUri: 'https://vsdrop.corp.microsoft.com/file/v1'
+    condition: succeeded()
+
+  # Publish an artifact that the RoslynInsertionTool is able to find by its name.
+  - task: 1ES.PublishBuildArtifacts@1
+    displayName: 'Publish Artifact: VSSetup'
+    inputs:
+      PathtoPublish: 'artifacts\VSSetup\$(BuildConfiguration)'
+      ArtifactName: VSSetup
+    condition: succeeded()
+
+  # Archive NuGet packages to DevOps.
+  # Publish our NuPkgs as an artifact. The name of this artifact must be PackageArtifacts as the
+  # arcade templates depend on the name.
+  - task: 1ES.PublishBuildArtifacts@1
+    displayName: 'Publish Artifact: packages'
+    inputs:
+      PathtoPublish: 'artifacts\packages\$(BuildConfiguration)'
+      ArtifactName: PackageArtifacts
+    condition: succeeded()
+
+  # Publish "IntelliSense" XSD files to their own artifact
+  # so it can be consumed by the insertion-to-VS job
+  - task: 1ES.PublishPipelineArtifact@1
+    displayName: 'Publish Artifact: xsd'
+    inputs:
+      path: 'artifacts\xsd'
+      artifactName: xsd
+    condition: succeeded()
+
+  # Publish Asset Manifests for Build Asset Registry job
+  - task: 1ES.PublishBuildArtifacts@1
+    displayName: Publish Asset Manifests
+    inputs:
+      PathtoPublish: '$(Build.SourcesDirectory)/artifacts/log/$(BuildConfiguration)/AssetManifest'
+      ArtifactName: AssetManifests
+    condition: succeeded()
+
+  # Tag the build at the very end when we know it's been successful.
+  - task: colinsalmcorner.colinsalmcorner-buildtasks.tag-build-task.tagBuildOrRelease@0
+    displayName: Tag build as ready for optimization training
+    inputs:
+      tags: 'ready-for-training'
+    condition: succeeded()
+
+  - task: ms-vseng.MicroBuildTasks.521a94ea-9e68-468a-8167-6dcf361ea776.MicroBuildCleanup@1
+    displayName: Execute cleanup tasks
+    condition: succeededOrFailed()
+
+  # Conditional component governance
+  - ${{ if parameters.enableComponentGovernance }}:
+    - template: /eng/common/templates-official/steps/component-governance.yml@self
+      parameters:
+        disableComponentGovernance: false
+
+- template: /eng/common/templates-official/jobs/source-build.yml@self
+  parameters:
+    platforms:
+      - name: Managed
+        pool:
+          name: AzurePipelines-EO
+          image: 1ESPT-Ubuntu22.04
+          os: linux
+
+- template: /eng/common/templates-official/job/publish-build-assets.yml@self
+  parameters:
+    enablePublishBuildArtifacts: true
+    publishUsingPipelines: true
+    dependsOn:
+      - Windows_NT
+      - Source_Build_Managed
+    pool:
+      name: $(DncEngInternalBuildPool)
+      image: $(WindowsImage)
+      os: windows

--- a/azure-pipelines/.vsts-dotnet-build-jobs.yml
+++ b/azure-pipelines/.vsts-dotnet-build-jobs.yml
@@ -3,9 +3,6 @@ parameters:
 - name: isExperimental
   type: boolean
   default: false
-- name: enableLocalization
-  type: boolean
-  default: false
 - name: enableComponentGovernance
   type: boolean
   default: false
@@ -14,30 +11,6 @@ parameters:
   default: false
 
 jobs:
-# The localization setup for release/ branches. Note difference in LclPackageId. main branch is handled separately below.
-# Used for vs17.2, vs17.4, vs17.6 etc. branches only.
-# When the branch is setup for localization (the localization ticket needs to be created - https://aka.ms/ceChangeLocConfig, requesting change from one release branch to another),
-#  set 'EnableReleaseOneLocBuild' to true.
-- ${{ if and(parameters.enableLocalization, startsWith(variables['Build.SourceBranch'], 'refs/heads/vs')) }}:
-  - template: /eng/common/templates-official/job/onelocbuild.yml@self
-    parameters:
-      MirrorRepo: 'msbuild'
-      LclSource: lclFilesfromPackage
-      LclPackageId: 'LCL-JUNO-PROD-MSBUILDREL'
-      MirrorBranch: ${{ replace(variables['Build.SourceBranch'], 'refs/heads/', '') }}
-      JobNameSuffix: '_release'
-      condition: ${{ variables.EnableReleaseOneLocBuild }}
-# The localization setup for main branch. Note difference in package ID. Should not be used with release/ branches.
-- ${{ if and(parameters.enableLocalization, eq(variables['Build.SourceBranch'], 'refs/heads/main')) }}:
-  - template: /eng/common/templates-official/job/onelocbuild.yml@self
-    parameters:
-      MirrorRepo: 'msbuild'
-      LclSource: lclFilesfromPackage
-      LclPackageId: 'LCL-JUNO-PROD-MSBUILD'
-      MirrorBranch: 'main'
-      JobNameSuffix: '_main'
-      condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')
-
 - job: Windows_NT
   pool:
     name: VSEngSS-MicroBuild2022-1ES

--- a/azure-pipelines/.vsts-dotnet-build-jobs.yml
+++ b/azure-pipelines/.vsts-dotnet-build-jobs.yml
@@ -9,6 +9,9 @@ parameters:
 - name: enableComponentGovernance
   type: boolean
   default: false
+- name: enableSigningValidation
+  type: boolean
+  default: false
 
 jobs:
 # The localization setup for release/ branches. Note difference in LclPackageId. main branch is handled separately below.
@@ -258,3 +261,12 @@ jobs:
       name: $(DncEngInternalBuildPool)
       image: $(WindowsImage)
       os: windows
+
+- template: /eng/common/templates-official/post-build/post-build.yml@self
+  parameters:
+    publishingInfraVersion: 3
+    enableSymbolValidation: true
+    enableSourceLinkValidation: false
+    enableNugetValidation: false
+    requireDefaultChannels: ${{ variables.requireDefaultChannels }}
+    enableSigningValidation: ${{ variables.enableSigningValidation }}

--- a/azure-pipelines/.vsts-dotnet-exp-perf.yml
+++ b/azure-pipelines/.vsts-dotnet-exp-perf.yml
@@ -27,7 +27,7 @@ variables:
     value: false
   - name: SourceBranch
     value: $(IbcSourceBranchName)
-  # Use main as our optprof collection branch by default.
+  # Use main as our optprof collection branch by default in exp branches.
   - ${{ if not(startsWith(variables['Build.SourceBranch'], 'refs/heads/vs')) }}:
     - name: SourceBranch
       value: main
@@ -86,12 +86,4 @@ extends:
           isExperimental: true
           enableLocalization: false
           enableComponentGovernance: false
-
-    - template: /eng/common/templates-official/post-build/post-build.yml@self
-      parameters:
-        publishingInfraVersion: 3
-        enableSymbolValidation: true
-        enableSourceLinkValidation: false
-        enableNugetValidation: false
-        requireDefaultChannels: ${{ variables.requireDefaultChannels }}
-        enableSigningValidation: false
+          enableSigningValidation: false

--- a/azure-pipelines/.vsts-dotnet-exp-perf.yml
+++ b/azure-pipelines/.vsts-dotnet-exp-perf.yml
@@ -84,6 +84,5 @@ extends:
       - template: /azure-pipelines/.vsts-dotnet-build-jobs.yml@self
         parameters:
           isExperimental: true
-          enableLocalization: false
           enableComponentGovernance: false
           enableSigningValidation: false

--- a/azure-pipelines/.vsts-dotnet-exp-perf.yml
+++ b/azure-pipelines/.vsts-dotnet-exp-perf.yml
@@ -1,12 +1,12 @@
 trigger:
-- main
-- vs*
+- exp/*
+- perf/*
 
 # If defined here, these values are not overrideable
 # Once they exist, we should define these as "runtime parameters"
 # https://github.com/Microsoft/azure-pipelines-yaml/pull/129
 # variables:
-#   SignType: real
+#   SignType: test
 #   SkipApplyOptimizationData: false
 
 parameters:
@@ -14,10 +14,6 @@ parameters:
   displayName: Optional OptProfDrop Override
   type: string
   default: 'default'
-- name: EnableOptProf
-  displayName: Enable OptProf data collection for this build
-  type: boolean
-  default: true
 - name: requireDefaultChannelsEnabled
   displayName: Require Default Channels
   type: boolean
@@ -31,7 +27,7 @@ variables:
     value: false
   - name: SourceBranch
     value: $(IbcSourceBranchName)
-  # If we're not on a vs* branch, use main as our optprof collection branch
+  # Use main as our optprof collection branch by default.
   - ${{ if not(startsWith(variables['Build.SourceBranch'], 'refs/heads/vs')) }}:
     - name: SourceBranch
       value: main
@@ -41,17 +37,8 @@ variables:
       value: ${{parameters.OptProfDropName}}
     - name: SourceBranch
       value: ''
-  # Override SkipApplyOptimizationData to true when disabling OptProf data collection
-  - ${{ if eq(parameters.EnableOptProf, false) }}:
-    - name: SkipApplyOptimizationData
-      value: true
-  - ${{ if and(not(startsWith(variables['Build.SourceBranch'], 'refs/heads/exp/')), not(startsWith(variables['Build.SourceBranch'], 'refs/heads/perf/'))) }}:
-    - name: requireDefaultChannels
-      value: ${{ parameters.requireDefaultChannelsEnabled }}
-  - name: EnableReleaseOneLocBuild
-    value: true # Enable loc for vs17.14
   - name: Codeql.Enabled
-    value: true
+    value: false
   - group: DotNet-MSBuild-SDLValidation-Params
   - group: AzureDevOps-Artifact-Feeds-Pats
   - name: cfsNugetWarnLevel
@@ -85,8 +72,7 @@ extends:
       sbom:
         enabled: false
       codeSignValidation:
-        enabled: true
-        break: true
+        enabled: false
         additionalTargetsGlobPattern: -|**\bootstrapper\**\vs_enterprise.exe
       credscan:
         suppressionsFile: $(Build.SourcesDirectory)/eng/CredScanSuppressions.json
@@ -97,9 +83,9 @@ extends:
       jobs:
       - template: /azure-pipelines/.vsts-dotnet-build-jobs.yml@self
         parameters:
-          isExperimental: false
-          enableLocalization: true
-          enableComponentGovernance: true
+          isExperimental: true
+          enableLocalization: false
+          enableComponentGovernance: false
 
     - template: /eng/common/templates-official/post-build/post-build.yml@self
       parameters:
@@ -108,3 +94,4 @@ extends:
         enableSourceLinkValidation: false
         enableNugetValidation: false
         requireDefaultChannels: ${{ variables.requireDefaultChannels }}
+        enableSigningValidation: false

--- a/azure-pipelines/vs-insertion-experimental.yml
+++ b/azure-pipelines/vs-insertion-experimental.yml
@@ -4,9 +4,9 @@ name: $(Date:yyyyMMdd).$(Rev:r)
 
 resources:
   pipelines:
-  - pipeline: 'MSBuild'
+  - pipeline: 'MSBuildExpPerf'
     project: 'DevDiv'
-    source: 'MSBuild'
+    source: 'MSBuild/MSBuild-ExpPerf'
     trigger:
       branches:
         include:
@@ -40,9 +40,9 @@ variables:
   - name: TeamEmail
     value: msbtm@microsoft.com
   - name: MSBuild_CI_BuildNumber
-    value: $(resources.pipeline.MSBuild.runName)
+    value: $(resources.pipeline.MSBuildExpPerf.runName)
   - name: MSBuild_CI_SourceVersion
-    value: $(resources.pipeline.MSBuild.sourceCommit)
+    value: $(resources.pipeline.MSBuildExpPerf.sourceCommit)
   - name: ArtifactPackagesPath
     value: $(Build.ArtifactStagingDirectory)/PackageArtifacts
 
@@ -80,11 +80,11 @@ extends:
         templateContext:
           inputs:
           - input: pipelineArtifact
-            pipeline: 'MSBuild'
+            pipeline: 'MSBuildExpPerf'
             artifactName: 'xsd'
             targetPath: '$(Pipeline.Workspace)/xsd'
           - input: pipelineArtifact
-            pipeline: 'MSBuild'
+            pipeline: 'MSBuildExpPerf'
             artifactName: 'PackageArtifacts'
             targetPath: '$(Build.ArtifactStagingDirectory)/PackageArtifacts'
             # the CI build creates a sourcebuild intermediate package that is not signed, remove it to avoid warning from Guardian
@@ -99,7 +99,7 @@ extends:
             targetType: inline
             script: |
               # Extract the last section after the last '/'
-              $fullBranch = "$(resources.pipeline.MSBuild.sourceBranch)"
+              $fullBranch = "$(resources.pipeline.MSBuildExpPerf.sourceBranch)"
               $branchSegments = $fullBranch -split '/'
               $branch = $branchSegments[-1]
               Write-Host "Setting drops branch to '$branch'"
@@ -112,7 +112,7 @@ extends:
             targetType: inline
             script: |
               # Extract VS version from branch name if it follows exp/vsXX.Y-somename pattern
-              $fullBranch = "$(resources.pipeline.MSBuild.sourceBranch)"
+              $fullBranch = "$(resources.pipeline.MSBuildExpPerf.sourceBranch)"
               $parameterTargetBranch = "${{ parameters.TargetBranch }}"
               $detectedTarget = "main" # Default target branch
 


### PR DESCRIPTION
Attempt 2 for https://github.com/dotnet/msbuild/pull/12126

The previous one was reverted due to problems with exp pipelines.
Now it got resolved with some tweaks around package validation in VS tests.

validated in scope of https://devdiv.visualstudio.com/DevDiv/_git/VS/pullrequest/663724