### PR TITLE
Move post-build to main ymls

### DIFF
--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -22,6 +22,10 @@ parameters:
   displayName: Require Default Channels
   type: boolean
   default: true
+- name: enableSigningValidation
+  displayName: Enable Signing Validation
+  type: boolean
+  default: true
 
 variables:
   # if OptProfDrop is not set, string '$(OptProfDrop)' will be passed to the build script.
@@ -134,4 +138,4 @@ extends:
         enableSourceLinkValidation: false
         enableNugetValidation: false
         requireDefaultChannels: ${{ parameters.requireDefaultChannelsEnabled }}
-        enableSigningValidation: true
+        enableSigningValidation: ${{ parameters.enableSigningValidation }}

--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -45,9 +45,8 @@ variables:
   - ${{ if eq(parameters.EnableOptProf, false) }}:
     - name: SkipApplyOptimizationData
       value: true
-  - ${{ if and(not(startsWith(variables['Build.SourceBranch'], 'refs/heads/exp/')), not(startsWith(variables['Build.SourceBranch'], 'refs/heads/perf/'))) }}:
-    - name: requireDefaultChannels
-      value: ${{ parameters.requireDefaultChannelsEnabled }}
+  - name: requireDefaultChannels
+    value: ${{ parameters.requireDefaultChannelsEnabled }}
   - name: EnableReleaseOneLocBuild
     value: true # Enable loc for vs17.14
   - name: Codeql.Enabled
@@ -127,4 +126,12 @@ extends:
         parameters:
           isExperimental: false
           enableComponentGovernance: true
-          enableSigningValidation: true
+
+    - template: /eng/common/templates-official/post-build/post-build.yml@self
+      parameters:
+        publishingInfraVersion: 3
+        enableSymbolValidation: true
+        enableSourceLinkValidation: false
+        enableNugetValidation: false
+        requireDefaultChannels: ${{ parameters.requireDefaultChannelsEnabled }}
+        enableSigningValidation: true

--- a/azure-pipelines/.vsts-dotnet-build-jobs.yml
+++ b/azure-pipelines/.vsts-dotnet-build-jobs.yml
@@ -1,245 +1,239 @@
 # Template for the main Windows_NT build job
-parameters:
-- name: isExperimental
-  type: boolean
-  default: false
-- name: enableComponentGovernance
-  type: boolean
-  default: false
-- name: enableSigningValidation
-  type: boolean
-  default: false
-
-jobs:
-- job: Windows_NT
-  pool:
-    name: VSEngSS-MicroBuild2022-1ES
-    demands:
-    - agent.os -equals Windows_NT
-
-  timeoutInMinutes: 180
-
-  variables:
-  - group: Publish-Build-Assets
-  - name: TeamName
-    value: MSBuild
-  - name: VisualStudio.MajorVersion
-    value: 18
-  - name: VisualStudio.ChannelName
-    value: 'int.main'
-  - name: VisualStudio.DropName
-    value: Products/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildNumber)
-
-  steps:
-  - task: NuGetToolInstaller@1
-    displayName: 'Install NuGet.exe'
-  - pwsh: Get-MpComputerStatus
-
-  - pwsh: Set-MpPreference -DisableRealtimeMonitoring $true
-
-  - task: PowerShell@2
-    displayName: Setup Private Feeds Credentials
-    inputs:
-      filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.ps1
-      arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $Env:Token
-    env:
-      Token: $(dn-bot-dnceng-artifact-feeds-rw)
-
-  - task: NuGetCommand@2
-    displayName: Restore internal tools
-    inputs:
-      command: restore
-      feedsToUse: config
-      restoreSolution: 'eng\common\internal\Tools.csproj'
-      nugetConfigPath: 'eng\common\internal\NuGet.config'
-      restoreDirectory: '$(Build.SourcesDirectory)\.packages'
-  
-  - task: MicroBuildSigningPlugin@4
-    displayName: Install MicroBuild plugin
-    inputs:
-      signType: $(SignType)
-      zipSources: false
-      feedSource: https://devdiv.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
-      ${{ if and(eq(variables['SignType'], 'real'), eq(variables['System.TeamProject'], 'DevDiv')) }}:
-        ConnectedPMEServiceName: 6cc74545-d7b9-4050-9dfa-ebefcc8961ea
-    env:
-      SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-    condition: and(succeeded(), in(variables['SignType'], 'test', 'real'))
-
-  - task: MicroBuildOptProfPlugin@6
-    inputs:
-      ProfilingInputsDropName: '$(VisualStudio.DropName)'
-      ShouldSkipOptimize: true
-      AccessToken: '$(System.AccessToken)'
-      feedSource: 'https://devdiv.pkgs.visualstudio.com/DefaultCollection/_packaging/MicroBuildToolset/nuget/v3/index.json'
-    displayName: 'Install OptProf Plugin'
-
-  # Required by MicroBuildBuildVSBootstrapper
-  - task: MicroBuildSwixPlugin@4
-    inputs:
-      dropName: $(VisualStudio.DropName)
-
-  - script: eng/CIBuild.cmd
-              -configuration $(BuildConfiguration)
-              -officialBuildId $(Build.BuildNumber)
-              -officialSkipApplyOptimizationData $(SkipApplyOptimizationData)
-              /p:RepositoryName=$(Build.Repository.Name)
-              /p:VisualStudioIbcSourceBranchName=$(SourceBranch)
-              /p:VisualStudioDropAccessToken=$(System.AccessToken)
-              /p:VisualStudioDropName=$(VisualStudio.DropName)
-              /p:DotNetSignType=$(SignType)
-              /p:TeamName=MSBuild
-              /p:DotNetPublishUsingPipelines=true
-              /p:VisualStudioIbcDrop=$(OptProfDrop)
-              /p:GenerateSbom=true
-              /p:SuppressFinalPackageVersion=${{ parameters.isExperimental }}
-    displayName: Build
-    condition: succeeded()
-
-  # Required by Microsoft policy
-  - template: /eng/common/templates-official/steps/generate-sbom.yml@self
-
-  # Publish OptProf configuration files
-  - task: 1ES.PublishArtifactsDrop@1
-    inputs:
-      dropServiceURI: 'https://devdiv.artifacts.visualstudio.com'
-      buildNumber: 'ProfilingInputs/DevDiv/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildNumber)'
-      sourcePath: '$(Build.SourcesDirectory)\artifacts\OptProf\$(BuildConfiguration)\Data'
-      toLowerCase: false
-      usePat: true
-    displayName: 'OptProf - Publish to Artifact Services - ProfilingInputs'
-    condition: succeeded()
-
-  # Build VS bootstrapper
-  # Generates $(Build.StagingDirectory)\MicroBuild\Output\BootstrapperInfo.json
-  - task: MicroBuildBuildVSBootstrapper@3
-    inputs:
-      vsMajorVersion: $(VisualStudio.MajorVersion)
-      channelName: $(VisualStudio.ChannelName)
-      manifests: $(VisualStudio.SetupManifestList)
-      outputFolder: '$(Build.SourcesDirectory)\artifacts\VSSetup\$(BuildConfiguration)\Insertion'
-    displayName: 'OptProf - Build VS bootstrapper'
-    condition: succeeded()
-
-  # Publish run settings
-  - task: PowerShell@2
-    inputs:
-      filePath: eng\common\sdk-task.ps1
-      arguments: -configuration $(BuildConfiguration)
-                -task VisualStudio.BuildIbcTrainingSettings
-                /p:VisualStudioDropName=$(VisualStudio.DropName)
-                /p:BootstrapperInfoPath=$(Build.StagingDirectory)\MicroBuild\Output\BootstrapperInfo.json
-                /p:VisualStudioIbcTrainingSettingsPath=$(Build.SourcesDirectory)\eng\config\OptProf.runsettings
-    displayName: 'OptProf - Build IBC training settings'
-    condition: succeeded()
-
-  # Publish bootstrapper info
-  - task: 1ES.PublishBuildArtifacts@1
-    inputs:
-      PathtoPublish: $(Build.StagingDirectory)\MicroBuild\Output
-      ArtifactName: MicroBuildOutputs
-      ArtifactType: Container
-    displayName: 'OptProf - Publish Artifact: MicroBuildOutputs'
-    condition: succeeded()
-
-  - task: 1ES.PublishBuildArtifacts@1
-    displayName: 'Publish Artifact: logs'
-    inputs:
-      PathtoPublish: 'artifacts\log\$(BuildConfiguration)'
-      ArtifactName: logs
-    condition: succeededOrFailed()
-
-  # Publishes setup VSIXes to a drop.
-  # Note: The insertion tool looks for the display name of this task in the logs.
-  - task: 1ES.MicroBuildVstsDrop@1
-    displayName: Upload VSTS Drop
-    inputs:
-      dropName: $(VisualStudio.DropName)
-      dropFolder: 'artifacts\VSSetup\$(BuildConfiguration)\Insertion'
-      dropRetentionDays: '30' # extended by insertion + VS release
-      accessToken: '$(System.AccessToken)'
-      dropServiceUri: 'https://devdiv.artifacts.visualstudio.com'
-      vsDropServiceUri: 'https://vsdrop.corp.microsoft.com/file/v1'
-    condition: succeeded()
-
-  # Publish an artifact that the RoslynInsertionTool is able to find by its name.
-  - task: 1ES.PublishBuildArtifacts@1
-    displayName: 'Publish Artifact: VSSetup'
-    inputs:
-      PathtoPublish: 'artifacts\VSSetup\$(BuildConfiguration)'
-      ArtifactName: VSSetup
-    condition: succeeded()
-
-  # Archive NuGet packages to DevOps.
-  # Publish our NuPkgs as an artifact. The name of this artifact must be PackageArtifacts as the
-  # arcade templates depend on the name.
-  - task: 1ES.PublishBuildArtifacts@1
-    displayName: 'Publish Artifact: packages'
-    inputs:
-      PathtoPublish: 'artifacts\packages\$(BuildConfiguration)'
-      ArtifactName: PackageArtifacts
-    condition: succeeded()
-
-  # Publish "IntelliSense" XSD files to their own artifact
-  # so it can be consumed by the insertion-to-VS job
-  - task: 1ES.PublishPipelineArtifact@1
-    displayName: 'Publish Artifact: xsd'
-    inputs:
-      path: 'artifacts\xsd'
-      artifactName: xsd
-    condition: succeeded()
-
-  # Publish Asset Manifests for Build Asset Registry job
-  - task: 1ES.PublishBuildArtifacts@1
-    displayName: Publish Asset Manifests
-    inputs:
-      PathtoPublish: '$(Build.SourcesDirectory)/artifacts/log/$(BuildConfiguration)/AssetManifest'
-      ArtifactName: AssetManifests
-    condition: succeeded()
-
-  # Tag the build at the very end when we know it's been successful.
-  - task: colinsalmcorner.colinsalmcorner-buildtasks.tag-build-task.tagBuildOrRelease@0
-    displayName: Tag build as ready for optimization training
-    inputs:
-      tags: 'ready-for-training'
-    condition: succeeded()
-
-  - task: ms-vseng.MicroBuildTasks.521a94ea-9e68-468a-8167-6dcf361ea776.MicroBuildCleanup@1
-    displayName: Execute cleanup tasks
-    condition: succeededOrFailed()
-
-  # Conditional component governance
-  - ${{ if parameters.enableComponentGovernance }}:
-    - template: /eng/common/templates-official/steps/component-governance.yml@self
-      parameters:
-        disableComponentGovernance: false
-
-- template: /eng/common/templates-official/jobs/source-build.yml@self
+extends:
+  template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:
-    platforms:
-      - name: Managed
+  - name: isExperimental
+    type: boolean
+    default: false
+  - name: enableComponentGovernance
+    type: boolean
+    default: false
+
+    stages:
+    - stage: build
+      displayName: Build
+
+      jobs:
+      - job: Windows_NT
         pool:
-          name: AzurePipelines-EO
-          image: 1ESPT-Ubuntu22.04
-          os: linux
+          name: VSEngSS-MicroBuild2022-1ES
+          demands:
+          - agent.os -equals Windows_NT
 
-- template: /eng/common/templates-official/job/publish-build-assets.yml@self
-  parameters:
-    enablePublishBuildArtifacts: true
-    publishUsingPipelines: true
-    dependsOn:
-      - Windows_NT
-      - Source_Build_Managed
-    pool:
-      name: $(DncEngInternalBuildPool)
-      image: $(WindowsImage)
-      os: windows
+        timeoutInMinutes: 180
 
-- template: /eng/common/templates-official/post-build/post-build.yml@self
-  parameters:
-    publishingInfraVersion: 3
-    enableSymbolValidation: true
-    enableSourceLinkValidation: false
-    enableNugetValidation: false
-    requireDefaultChannels: ${{ variables.requireDefaultChannels }}
-    enableSigningValidation: ${{ variables.enableSigningValidation }}
+        variables:
+        - group: Publish-Build-Assets
+        - name: TeamName
+          value: MSBuild
+        - name: VisualStudio.MajorVersion
+          value: 18
+        - name: VisualStudio.ChannelName
+          value: 'int.main'
+        - name: VisualStudio.DropName
+          value: Products/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildNumber)
+
+        steps:
+        - task: NuGetToolInstaller@1
+          displayName: 'Install NuGet.exe'
+        - pwsh: Get-MpComputerStatus
+
+        - pwsh: Set-MpPreference -DisableRealtimeMonitoring $true
+
+        - task: PowerShell@2
+          displayName: Setup Private Feeds Credentials
+          inputs:
+            filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.ps1
+            arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $Env:Token
+          env:
+            Token: $(dn-bot-dnceng-artifact-feeds-rw)
+
+        - task: NuGetCommand@2
+          displayName: Restore internal tools
+          inputs:
+            command: restore
+            feedsToUse: config
+            restoreSolution: 'eng\common\internal\Tools.csproj'
+            nugetConfigPath: 'eng\common\internal\NuGet.config'
+            restoreDirectory: '$(Build.SourcesDirectory)\.packages'
+
+        - task: MicroBuildSigningPlugin@4
+          displayName: Install MicroBuild plugin
+          inputs:
+            signType: $(SignType)
+            zipSources: false
+            feedSource: https://devdiv.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
+            ${{ if and(eq(variables['SignType'], 'real'), eq(variables['System.TeamProject'], 'DevDiv')) }}:
+              ConnectedPMEServiceName: 6cc74545-d7b9-4050-9dfa-ebefcc8961ea
+          env:
+            SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+          condition: and(succeeded(), in(variables['SignType'], 'test', 'real'))
+
+        - task: MicroBuildOptProfPlugin@6
+          inputs:
+            ProfilingInputsDropName: '$(VisualStudio.DropName)'
+            ShouldSkipOptimize: true
+            AccessToken: '$(System.AccessToken)'
+            feedSource: 'https://devdiv.pkgs.visualstudio.com/DefaultCollection/_packaging/MicroBuildToolset/nuget/v3/index.json'
+          displayName: 'Install OptProf Plugin'
+
+        # Required by MicroBuildBuildVSBootstrapper
+        - task: MicroBuildSwixPlugin@4
+          inputs:
+            dropName: $(VisualStudio.DropName)
+
+        - script: eng/CIBuild.cmd
+                    -configuration $(BuildConfiguration)
+                    -officialBuildId $(Build.BuildNumber)
+                    -officialSkipApplyOptimizationData $(SkipApplyOptimizationData)
+                    /p:RepositoryName=$(Build.Repository.Name)
+                    /p:VisualStudioIbcSourceBranchName=$(SourceBranch)
+                    /p:VisualStudioDropAccessToken=$(System.AccessToken)
+                    /p:VisualStudioDropName=$(VisualStudio.DropName)
+                    /p:DotNetSignType=$(SignType)
+                    /p:TeamName=MSBuild
+                    /p:DotNetPublishUsingPipelines=true
+                    /p:VisualStudioIbcDrop=$(OptProfDrop)
+                    /p:GenerateSbom=true
+                    /p:SuppressFinalPackageVersion=${{ parameters.isExperimental }}
+          displayName: Build
+          condition: succeeded()
+
+        # Required by Microsoft policy
+        - template: /eng/common/templates-official/steps/generate-sbom.yml@self
+
+        # Publish OptProf configuration files
+        - task: 1ES.PublishArtifactsDrop@1
+          inputs:
+            dropServiceURI: 'https://devdiv.artifacts.visualstudio.com'
+            buildNumber: 'ProfilingInputs/DevDiv/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildNumber)'
+            sourcePath: '$(Build.SourcesDirectory)\artifacts\OptProf\$(BuildConfiguration)\Data'
+            toLowerCase: false
+            usePat: true
+          displayName: 'OptProf - Publish to Artifact Services - ProfilingInputs'
+          condition: succeeded()
+
+        # Build VS bootstrapper
+        # Generates $(Build.StagingDirectory)\MicroBuild\Output\BootstrapperInfo.json
+        - task: MicroBuildBuildVSBootstrapper@3
+          inputs:
+            vsMajorVersion: $(VisualStudio.MajorVersion)
+            channelName: $(VisualStudio.ChannelName)
+            manifests: $(VisualStudio.SetupManifestList)
+            outputFolder: '$(Build.SourcesDirectory)\artifacts\VSSetup\$(BuildConfiguration)\Insertion'
+          displayName: 'OptProf - Build VS bootstrapper'
+          condition: succeeded()
+
+        # Publish run settings
+        - task: PowerShell@2
+          inputs:
+            filePath: eng\common\sdk-task.ps1
+            arguments: -configuration $(BuildConfiguration)
+                      -task VisualStudio.BuildIbcTrainingSettings
+                      /p:VisualStudioDropName=$(VisualStudio.DropName)
+                      /p:BootstrapperInfoPath=$(Build.StagingDirectory)\MicroBuild\Output\BootstrapperInfo.json
+                      /p:VisualStudioIbcTrainingSettingsPath=$(Build.SourcesDirectory)\eng\config\OptProf.runsettings
+          displayName: 'OptProf - Build IBC training settings'
+          condition: succeeded()
+
+        # Publish bootstrapper info
+        - task: 1ES.PublishBuildArtifacts@1
+          inputs:
+            PathtoPublish: $(Build.StagingDirectory)\MicroBuild\Output
+            ArtifactName: MicroBuildOutputs
+            ArtifactType: Container
+          displayName: 'OptProf - Publish Artifact: MicroBuildOutputs'
+          condition: succeeded()
+
+        - task: 1ES.PublishBuildArtifacts@1
+          displayName: 'Publish Artifact: logs'
+          inputs:
+            PathtoPublish: 'artifacts\log\$(BuildConfiguration)'
+            ArtifactName: logs
+          condition: succeededOrFailed()
+
+        # Publishes setup VSIXes to a drop.
+        # Note: The insertion tool looks for the display name of this task in the logs.
+        - task: 1ES.MicroBuildVstsDrop@1
+          displayName: Upload VSTS Drop
+          inputs:
+            dropName: $(VisualStudio.DropName)
+            dropFolder: 'artifacts\VSSetup\$(BuildConfiguration)\Insertion'
+            dropRetentionDays: '30' # extended by insertion + VS release
+            accessToken: '$(System.AccessToken)'
+            dropServiceUri: 'https://devdiv.artifacts.visualstudio.com'
+            vsDropServiceUri: 'https://vsdrop.corp.microsoft.com/file/v1'
+          condition: succeeded()
+
+        # Publish an artifact that the RoslynInsertionTool is able to find by its name.
+        - task: 1ES.PublishBuildArtifacts@1
+          displayName: 'Publish Artifact: VSSetup'
+          inputs:
+            PathtoPublish: 'artifacts\VSSetup\$(BuildConfiguration)'
+            ArtifactName: VSSetup
+          condition: succeeded()
+
+        # Archive NuGet packages to DevOps.
+        # Publish our NuPkgs as an artifact. The name of this artifact must be PackageArtifacts as the
+        # arcade templates depend on the name.
+        - task: 1ES.PublishBuildArtifacts@1
+          displayName: 'Publish Artifact: packages'
+          inputs:
+            PathtoPublish: 'artifacts\packages\$(BuildConfiguration)'
+            ArtifactName: PackageArtifacts
+          condition: succeeded()
+
+        # Publish "IntelliSense" XSD files to their own artifact
+        # so it can be consumed by the insertion-to-VS job
+        - task: 1ES.PublishPipelineArtifact@1
+          displayName: 'Publish Artifact: xsd'
+          inputs:
+            path: 'artifacts\xsd'
+            artifactName: xsd
+          condition: succeeded()
+
+        # Publish Asset Manifests for Build Asset Registry job
+        - task: 1ES.PublishBuildArtifacts@1
+          displayName: Publish Asset Manifests
+          inputs:
+            PathtoPublish: '$(Build.SourcesDirectory)/artifacts/log/$(BuildConfiguration)/AssetManifest'
+            ArtifactName: AssetManifests
+          condition: succeeded()
+
+        # Tag the build at the very end when we know it's been successful.
+        - task: colinsalmcorner.colinsalmcorner-buildtasks.tag-build-task.tagBuildOrRelease@0
+          displayName: Tag build as ready for optimization training
+          inputs:
+            tags: 'ready-for-training'
+          condition: succeeded()
+
+        - task: ms-vseng.MicroBuildTasks.521a94ea-9e68-468a-8167-6dcf361ea776.MicroBuildCleanup@1
+          displayName: Execute cleanup tasks
+          condition: succeededOrFailed()
+
+        # Conditional component governance
+        - ${{ if parameters.enableComponentGovernance }}:
+          - template: /eng/common/templates-official/steps/component-governance.yml@self
+            parameters:
+              disableComponentGovernance: false
+
+      - template: /eng/common/templates-official/jobs/source-build.yml@self
+        parameters:
+          platforms:
+            - name: Managed
+              pool:
+                name: AzurePipelines-EO
+                image: 1ESPT-Ubuntu22.04
+                os: linux
+
+      - template: /eng/common/templates-official/job/publish-build-assets.yml@self
+        parameters:
+          enablePublishBuildArtifacts: true
+          publishUsingPipelines: true
+          dependsOn:
+            - Windows_NT
+            - Source_Build_Managed
+          pool:
+            name: $(DncEngInternalBuildPool)
+            image: $(WindowsImage)
+            os: windows

--- a/azure-pipelines/.vsts-dotnet-build-jobs.yml
+++ b/azure-pipelines/.vsts-dotnet-build-jobs.yml
@@ -1,239 +1,233 @@
 # Template for the main Windows_NT build job
-extends:
-  template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
+parameters:
+- name: isExperimental
+  type: boolean
+  default: false
+- name: enableComponentGovernance
+  type: boolean
+  default: false
+
+jobs:
+- job: Windows_NT
+  pool:
+    name: VSEngSS-MicroBuild2022-1ES
+    demands:
+    - agent.os -equals Windows_NT
+
+  timeoutInMinutes: 180
+
+  variables:
+  - group: Publish-Build-Assets
+  - name: TeamName
+    value: MSBuild
+  - name: VisualStudio.MajorVersion
+    value: 18
+  - name: VisualStudio.ChannelName
+    value: 'int.main'
+  - name: VisualStudio.DropName
+    value: Products/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildNumber)
+
+  steps:
+  - task: NuGetToolInstaller@1
+    displayName: 'Install NuGet.exe'
+  - pwsh: Get-MpComputerStatus
+
+  - pwsh: Set-MpPreference -DisableRealtimeMonitoring $true
+
+  - task: PowerShell@2
+    displayName: Setup Private Feeds Credentials
+    inputs:
+      filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.ps1
+      arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $Env:Token
+    env:
+      Token: $(dn-bot-dnceng-artifact-feeds-rw)
+
+  - task: NuGetCommand@2
+    displayName: Restore internal tools
+    inputs:
+      command: restore
+      feedsToUse: config
+      restoreSolution: 'eng\common\internal\Tools.csproj'
+      nugetConfigPath: 'eng\common\internal\NuGet.config'
+      restoreDirectory: '$(Build.SourcesDirectory)\.packages'
+
+  - task: MicroBuildSigningPlugin@4
+    displayName: Install MicroBuild plugin
+    inputs:
+      signType: $(SignType)
+      zipSources: false
+      feedSource: https://devdiv.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
+      ${{ if and(eq(variables['SignType'], 'real'), eq(variables['System.TeamProject'], 'DevDiv')) }}:
+        ConnectedPMEServiceName: 6cc74545-d7b9-4050-9dfa-ebefcc8961ea
+    env:
+      SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+    condition: and(succeeded(), in(variables['SignType'], 'test', 'real'))
+
+  - task: MicroBuildOptProfPlugin@6
+    inputs:
+      ProfilingInputsDropName: '$(VisualStudio.DropName)'
+      ShouldSkipOptimize: true
+      AccessToken: '$(System.AccessToken)'
+      feedSource: 'https://devdiv.pkgs.visualstudio.com/DefaultCollection/_packaging/MicroBuildToolset/nuget/v3/index.json'
+    displayName: 'Install OptProf Plugin'
+
+  # Required by MicroBuildBuildVSBootstrapper
+  - task: MicroBuildSwixPlugin@4
+    inputs:
+      dropName: $(VisualStudio.DropName)
+
+  - script: eng/CIBuild.cmd
+              -configuration $(BuildConfiguration)
+              -officialBuildId $(Build.BuildNumber)
+              -officialSkipApplyOptimizationData $(SkipApplyOptimizationData)
+              /p:RepositoryName=$(Build.Repository.Name)
+              /p:VisualStudioIbcSourceBranchName=$(SourceBranch)
+              /p:VisualStudioDropAccessToken=$(System.AccessToken)
+              /p:VisualStudioDropName=$(VisualStudio.DropName)
+              /p:DotNetSignType=$(SignType)
+              /p:TeamName=MSBuild
+              /p:DotNetPublishUsingPipelines=true
+              /p:VisualStudioIbcDrop=$(OptProfDrop)
+              /p:GenerateSbom=true
+              /p:SuppressFinalPackageVersion=${{ parameters.isExperimental }}
+    displayName: Build
+    condition: succeeded()
+
+  # Required by Microsoft policy
+  - template: /eng/common/templates-official/steps/generate-sbom.yml@self
+
+  # Publish OptProf configuration files
+  - task: 1ES.PublishArtifactsDrop@1
+    inputs:
+      dropServiceURI: 'https://devdiv.artifacts.visualstudio.com'
+      buildNumber: 'ProfilingInputs/DevDiv/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildNumber)'
+      sourcePath: '$(Build.SourcesDirectory)\artifacts\OptProf\$(BuildConfiguration)\Data'
+      toLowerCase: false
+      usePat: true
+    displayName: 'OptProf - Publish to Artifact Services - ProfilingInputs'
+    condition: succeeded()
+
+  # Build VS bootstrapper
+  # Generates $(Build.StagingDirectory)\MicroBuild\Output\BootstrapperInfo.json
+  - task: MicroBuildBuildVSBootstrapper@3
+    inputs:
+      vsMajorVersion: $(VisualStudio.MajorVersion)
+      channelName: $(VisualStudio.ChannelName)
+      manifests: $(VisualStudio.SetupManifestList)
+      outputFolder: '$(Build.SourcesDirectory)\artifacts\VSSetup\$(BuildConfiguration)\Insertion'
+    displayName: 'OptProf - Build VS bootstrapper'
+    condition: succeeded()
+
+  # Publish run settings
+  - task: PowerShell@2
+    inputs:
+      filePath: eng\common\sdk-task.ps1
+      arguments: -configuration $(BuildConfiguration)
+                -task VisualStudio.BuildIbcTrainingSettings
+                /p:VisualStudioDropName=$(VisualStudio.DropName)
+                /p:BootstrapperInfoPath=$(Build.StagingDirectory)\MicroBuild\Output\BootstrapperInfo.json
+                /p:VisualStudioIbcTrainingSettingsPath=$(Build.SourcesDirectory)\eng\config\OptProf.runsettings
+    displayName: 'OptProf - Build IBC training settings'
+    condition: succeeded()
+
+  # Publish bootstrapper info
+  - task: 1ES.PublishBuildArtifacts@1
+    inputs:
+      PathtoPublish: $(Build.StagingDirectory)\MicroBuild\Output
+      ArtifactName: MicroBuildOutputs
+      ArtifactType: Container
+    displayName: 'OptProf - Publish Artifact: MicroBuildOutputs'
+    condition: succeeded()
+
+  - task: 1ES.PublishBuildArtifacts@1
+    displayName: 'Publish Artifact: logs'
+    inputs:
+      PathtoPublish: 'artifacts\log\$(BuildConfiguration)'
+      ArtifactName: logs
+    condition: succeededOrFailed()
+
+  # Publishes setup VSIXes to a drop.
+  # Note: The insertion tool looks for the display name of this task in the logs.
+  - task: 1ES.MicroBuildVstsDrop@1
+    displayName: Upload VSTS Drop
+    inputs:
+      dropName: $(VisualStudio.DropName)
+      dropFolder: 'artifacts\VSSetup\$(BuildConfiguration)\Insertion'
+      dropRetentionDays: '30' # extended by insertion + VS release
+      accessToken: '$(System.AccessToken)'
+      dropServiceUri: 'https://devdiv.artifacts.visualstudio.com'
+      vsDropServiceUri: 'https://vsdrop.corp.microsoft.com/file/v1'
+    condition: succeeded()
+
+  # Publish an artifact that the RoslynInsertionTool is able to find by its name.
+  - task: 1ES.PublishBuildArtifacts@1
+    displayName: 'Publish Artifact: VSSetup'
+    inputs:
+      PathtoPublish: 'artifacts\VSSetup\$(BuildConfiguration)'
+      ArtifactName: VSSetup
+    condition: succeeded()
+
+  # Archive NuGet packages to DevOps.
+  # Publish our NuPkgs as an artifact. The name of this artifact must be PackageArtifacts as the
+  # arcade templates depend on the name.
+  - task: 1ES.PublishBuildArtifacts@1
+    displayName: 'Publish Artifact: packages'
+    inputs:
+      PathtoPublish: 'artifacts\packages\$(BuildConfiguration)'
+      ArtifactName: PackageArtifacts
+    condition: succeeded()
+
+  # Publish "IntelliSense" XSD files to their own artifact
+  # so it can be consumed by the insertion-to-VS job
+  - task: 1ES.PublishPipelineArtifact@1
+    displayName: 'Publish Artifact: xsd'
+    inputs:
+      path: 'artifacts\xsd'
+      artifactName: xsd
+    condition: succeeded()
+
+  # Publish Asset Manifests for Build Asset Registry job
+  - task: 1ES.PublishBuildArtifacts@1
+    displayName: Publish Asset Manifests
+    inputs:
+      PathtoPublish: '$(Build.SourcesDirectory)/artifacts/log/$(BuildConfiguration)/AssetManifest'
+      ArtifactName: AssetManifests
+    condition: succeeded()
+
+  # Tag the build at the very end when we know it's been successful.
+  - task: colinsalmcorner.colinsalmcorner-buildtasks.tag-build-task.tagBuildOrRelease@0
+    displayName: Tag build as ready for optimization training
+    inputs:
+      tags: 'ready-for-training'
+    condition: succeeded()
+
+  - task: ms-vseng.MicroBuildTasks.521a94ea-9e68-468a-8167-6dcf361ea776.MicroBuildCleanup@1
+    displayName: Execute cleanup tasks
+    condition: succeededOrFailed()
+
+  # Conditional component governance
+  - ${{ if parameters.enableComponentGovernance }}:
+    - template: /eng/common/templates-official/steps/component-governance.yml@self
+      parameters:
+        disableComponentGovernance: false
+
+- template: /eng/common/templates-official/jobs/source-build.yml@self
   parameters:
-  - name: isExperimental
-    type: boolean
-    default: false
-  - name: enableComponentGovernance
-    type: boolean
-    default: false
-
-    stages:
-    - stage: build
-      displayName: Build
-
-      jobs:
-      - job: Windows_NT
+    platforms:
+      - name: Managed
         pool:
-          name: VSEngSS-MicroBuild2022-1ES
-          demands:
-          - agent.os -equals Windows_NT
+          name: AzurePipelines-EO
+          image: 1ESPT-Ubuntu22.04
+          os: linux
 
-        timeoutInMinutes: 180
-
-        variables:
-        - group: Publish-Build-Assets
-        - name: TeamName
-          value: MSBuild
-        - name: VisualStudio.MajorVersion
-          value: 18
-        - name: VisualStudio.ChannelName
-          value: 'int.main'
-        - name: VisualStudio.DropName
-          value: Products/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildNumber)
-
-        steps:
-        - task: NuGetToolInstaller@1
-          displayName: 'Install NuGet.exe'
-        - pwsh: Get-MpComputerStatus
-
-        - pwsh: Set-MpPreference -DisableRealtimeMonitoring $true
-
-        - task: PowerShell@2
-          displayName: Setup Private Feeds Credentials
-          inputs:
-            filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.ps1
-            arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $Env:Token
-          env:
-            Token: $(dn-bot-dnceng-artifact-feeds-rw)
-
-        - task: NuGetCommand@2
-          displayName: Restore internal tools
-          inputs:
-            command: restore
-            feedsToUse: config
-            restoreSolution: 'eng\common\internal\Tools.csproj'
-            nugetConfigPath: 'eng\common\internal\NuGet.config'
-            restoreDirectory: '$(Build.SourcesDirectory)\.packages'
-
-        - task: MicroBuildSigningPlugin@4
-          displayName: Install MicroBuild plugin
-          inputs:
-            signType: $(SignType)
-            zipSources: false
-            feedSource: https://devdiv.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
-            ${{ if and(eq(variables['SignType'], 'real'), eq(variables['System.TeamProject'], 'DevDiv')) }}:
-              ConnectedPMEServiceName: 6cc74545-d7b9-4050-9dfa-ebefcc8961ea
-          env:
-            SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-          condition: and(succeeded(), in(variables['SignType'], 'test', 'real'))
-
-        - task: MicroBuildOptProfPlugin@6
-          inputs:
-            ProfilingInputsDropName: '$(VisualStudio.DropName)'
-            ShouldSkipOptimize: true
-            AccessToken: '$(System.AccessToken)'
-            feedSource: 'https://devdiv.pkgs.visualstudio.com/DefaultCollection/_packaging/MicroBuildToolset/nuget/v3/index.json'
-          displayName: 'Install OptProf Plugin'
-
-        # Required by MicroBuildBuildVSBootstrapper
-        - task: MicroBuildSwixPlugin@4
-          inputs:
-            dropName: $(VisualStudio.DropName)
-
-        - script: eng/CIBuild.cmd
-                    -configuration $(BuildConfiguration)
-                    -officialBuildId $(Build.BuildNumber)
-                    -officialSkipApplyOptimizationData $(SkipApplyOptimizationData)
-                    /p:RepositoryName=$(Build.Repository.Name)
-                    /p:VisualStudioIbcSourceBranchName=$(SourceBranch)
-                    /p:VisualStudioDropAccessToken=$(System.AccessToken)
-                    /p:VisualStudioDropName=$(VisualStudio.DropName)
-                    /p:DotNetSignType=$(SignType)
-                    /p:TeamName=MSBuild
-                    /p:DotNetPublishUsingPipelines=true
-                    /p:VisualStudioIbcDrop=$(OptProfDrop)
-                    /p:GenerateSbom=true
-                    /p:SuppressFinalPackageVersion=${{ parameters.isExperimental }}
-          displayName: Build
-          condition: succeeded()
-
-        # Required by Microsoft policy
-        - template: /eng/common/templates-official/steps/generate-sbom.yml@self
-
-        # Publish OptProf configuration files
-        - task: 1ES.PublishArtifactsDrop@1
-          inputs:
-            dropServiceURI: 'https://devdiv.artifacts.visualstudio.com'
-            buildNumber: 'ProfilingInputs/DevDiv/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildNumber)'
-            sourcePath: '$(Build.SourcesDirectory)\artifacts\OptProf\$(BuildConfiguration)\Data'
-            toLowerCase: false
-            usePat: true
-          displayName: 'OptProf - Publish to Artifact Services - ProfilingInputs'
-          condition: succeeded()
-
-        # Build VS bootstrapper
-        # Generates $(Build.StagingDirectory)\MicroBuild\Output\BootstrapperInfo.json
-        - task: MicroBuildBuildVSBootstrapper@3
-          inputs:
-            vsMajorVersion: $(VisualStudio.MajorVersion)
-            channelName: $(VisualStudio.ChannelName)
-            manifests: $(VisualStudio.SetupManifestList)
-            outputFolder: '$(Build.SourcesDirectory)\artifacts\VSSetup\$(BuildConfiguration)\Insertion'
-          displayName: 'OptProf - Build VS bootstrapper'
-          condition: succeeded()
-
-        # Publish run settings
-        - task: PowerShell@2
-          inputs:
-            filePath: eng\common\sdk-task.ps1
-            arguments: -configuration $(BuildConfiguration)
-                      -task VisualStudio.BuildIbcTrainingSettings
-                      /p:VisualStudioDropName=$(VisualStudio.DropName)
-                      /p:BootstrapperInfoPath=$(Build.StagingDirectory)\MicroBuild\Output\BootstrapperInfo.json
-                      /p:VisualStudioIbcTrainingSettingsPath=$(Build.SourcesDirectory)\eng\config\OptProf.runsettings
-          displayName: 'OptProf - Build IBC training settings'
-          condition: succeeded()
-
-        # Publish bootstrapper info
-        - task: 1ES.PublishBuildArtifacts@1
-          inputs:
-            PathtoPublish: $(Build.StagingDirectory)\MicroBuild\Output
-            ArtifactName: MicroBuildOutputs
-            ArtifactType: Container
-          displayName: 'OptProf - Publish Artifact: MicroBuildOutputs'
-          condition: succeeded()
-
-        - task: 1ES.PublishBuildArtifacts@1
-          displayName: 'Publish Artifact: logs'
-          inputs:
-            PathtoPublish: 'artifacts\log\$(BuildConfiguration)'
-            ArtifactName: logs
-          condition: succeededOrFailed()
-
-        # Publishes setup VSIXes to a drop.
-        # Note: The insertion tool looks for the display name of this task in the logs.
-        - task: 1ES.MicroBuildVstsDrop@1
-          displayName: Upload VSTS Drop
-          inputs:
-            dropName: $(VisualStudio.DropName)
-            dropFolder: 'artifacts\VSSetup\$(BuildConfiguration)\Insertion'
-            dropRetentionDays: '30' # extended by insertion + VS release
-            accessToken: '$(System.AccessToken)'
-            dropServiceUri: 'https://devdiv.artifacts.visualstudio.com'
-            vsDropServiceUri: 'https://vsdrop.corp.microsoft.com/file/v1'
-          condition: succeeded()
-
-        # Publish an artifact that the RoslynInsertionTool is able to find by its name.
-        - task: 1ES.PublishBuildArtifacts@1
-          displayName: 'Publish Artifact: VSSetup'
-          inputs:
-            PathtoPublish: 'artifacts\VSSetup\$(BuildConfiguration)'
-            ArtifactName: VSSetup
-          condition: succeeded()
-
-        # Archive NuGet packages to DevOps.
-        # Publish our NuPkgs as an artifact. The name of this artifact must be PackageArtifacts as the
-        # arcade templates depend on the name.
-        - task: 1ES.PublishBuildArtifacts@1
-          displayName: 'Publish Artifact: packages'
-          inputs:
-            PathtoPublish: 'artifacts\packages\$(BuildConfiguration)'
-            ArtifactName: PackageArtifacts
-          condition: succeeded()
-
-        # Publish "IntelliSense" XSD files to their own artifact
-        # so it can be consumed by the insertion-to-VS job
-        - task: 1ES.PublishPipelineArtifact@1
-          displayName: 'Publish Artifact: xsd'
-          inputs:
-            path: 'artifacts\xsd'
-            artifactName: xsd
-          condition: succeeded()
-
-        # Publish Asset Manifests for Build Asset Registry job
-        - task: 1ES.PublishBuildArtifacts@1
-          displayName: Publish Asset Manifests
-          inputs:
-            PathtoPublish: '$(Build.SourcesDirectory)/artifacts/log/$(BuildConfiguration)/AssetManifest'
-            ArtifactName: AssetManifests
-          condition: succeeded()
-
-        # Tag the build at the very end when we know it's been successful.
-        - task: colinsalmcorner.colinsalmcorner-buildtasks.tag-build-task.tagBuildOrRelease@0
-          displayName: Tag build as ready for optimization training
-          inputs:
-            tags: 'ready-for-training'
-          condition: succeeded()
-
-        - task: ms-vseng.MicroBuildTasks.521a94ea-9e68-468a-8167-6dcf361ea776.MicroBuildCleanup@1
-          displayName: Execute cleanup tasks
-          condition: succeededOrFailed()
-
-        # Conditional component governance
-        - ${{ if parameters.enableComponentGovernance }}:
-          - template: /eng/common/templates-official/steps/component-governance.yml@self
-            parameters:
-              disableComponentGovernance: false
-
-      - template: /eng/common/templates-official/jobs/source-build.yml@self
-        parameters:
-          platforms:
-            - name: Managed
-              pool:
-                name: AzurePipelines-EO
-                image: 1ESPT-Ubuntu22.04
-                os: linux
-
-      - template: /eng/common/templates-official/job/publish-build-assets.yml@self
-        parameters:
-          enablePublishBuildArtifacts: true
-          publishUsingPipelines: true
-          dependsOn:
-            - Windows_NT
-            - Source_Build_Managed
-          pool:
-            name: $(DncEngInternalBuildPool)
-            image: $(WindowsImage)
-            os: windows
+- template: /eng/common/templates-official/job/publish-build-assets.yml@self
+  parameters:
+    enablePublishBuildArtifacts: true
+    publishUsingPipelines: true
+    dependsOn:
+      - Windows_NT
+      - Source_Build_Managed
+    pool:
+      name: $(DncEngInternalBuildPool)
+      image: $(WindowsImage)
+      os: windows

--- a/azure-pipelines/.vsts-dotnet-exp-perf.yml
+++ b/azure-pipelines/.vsts-dotnet-exp-perf.yml
@@ -18,6 +18,10 @@ parameters:
   displayName: Require Default Channels
   type: boolean
   default: true
+- name: enableSigningValidation
+  displayName: Enable Signing Validation
+  type: boolean
+  default: false
 
 variables:
   # if OptProfDrop is not set, string '$(OptProfDrop)' will be passed to the build script.
@@ -93,4 +97,4 @@ extends:
         enableSourceLinkValidation: false
         enableNugetValidation: false
         requireDefaultChannels: ${{ parameters.requireDefaultChannelsEnabled }}
-        enableSigningValidation: false
+        enableSigningValidation: ${{ parameters.enableSigningValidation }}

--- a/azure-pipelines/.vsts-dotnet-exp-perf.yml
+++ b/azure-pipelines/.vsts-dotnet-exp-perf.yml
@@ -85,4 +85,12 @@ extends:
         parameters:
           isExperimental: true
           enableComponentGovernance: false
-          enableSigningValidation: false
+
+    - template: /eng/common/templates-official/post-build/post-build.yml@self
+      parameters:
+        publishingInfraVersion: 3
+        enableSymbolValidation: true
+        enableSourceLinkValidation: false
+        enableNugetValidation: false
+        requireDefaultChannels: ${{ parameters.requireDefaultChannelsEnabled }}
+        enableSigningValidation: false


### PR DESCRIPTION
### Fixes:

- Changed the templates from having stages: at the top level to jobs:. This is because it's being included as a job template, not a stage template.
- Post-build Template Location: Moved the post-build template from inside the job template (where it doesn't belong) to the main pipelines at the stage level where it should be.