### PR TITLE
issue-12415 increase stack size

### DIFF
--- a/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
@@ -681,7 +681,7 @@ namespace Microsoft.Build.BackEnd
                 _packetQueueDrainDelayCancellation = new CancellationTokenSource();
 
                 // specify the smallest stack size - 64kb
-                _drainPacketQueueThread = new Thread(DrainPacketQueue, 64 * 1024);
+                _drainPacketQueueThread = new Thread(DrainPacketQueue, 0x30000);
                 _drainPacketQueueThread.IsBackground = true;
                 _drainPacketQueueThread.Start(this);
             }

--- a/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
@@ -680,7 +680,8 @@ namespace Microsoft.Build.BackEnd
                 _packetEnqueued = new AutoResetEvent(false);
                 _packetQueueDrainDelayCancellation = new CancellationTokenSource();
 
-                // specify the smallest stack size - 64kb
+                // We select a thread size empirically - for debug builds the minimum possible stack size was too small.
+                // The current size is reported to not have the issue.
                 _drainPacketQueueThread = new Thread(DrainPacketQueue, 0x30000);
                 _drainPacketQueueThread.IsBackground = true;
                 _drainPacketQueueThread.Start(this);


### PR DESCRIPTION
Fixes #12415

### Context
During one of our recent optimization runs we reduced stack size of the DrainPacketQueue times.
While this is fine in a normal scenario, it sometimes results in a StackOverflow during debugging or performance runs.

### Changes Made
Increased the stack size.

### Testing


### Notes
@Erarndt is planning to refactor this away in the near future so I hope this is a sufficient hotfix for the interim.
This doesn't affect production, only custom builds.