### PR TITLE
use GxHash in net10

### DIFF
--- a/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
@@ -7,10 +7,6 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
-#if NET10_0_OR_GREATER
-using ArmAes = System.Runtime.Intrinsics.Arm.Aes;
-using X86Aes = System.Runtime.Intrinsics.X86.Aes;
-#endif
 using Microsoft.Build.BackEnd.Logging;
 using Microsoft.Build.Collections;
 using Microsoft.Build.Evaluation;
@@ -1350,17 +1346,14 @@ namespace Microsoft.Build.Logging
                 {
 #if NET9_0_OR_GREATER
                     // Perf: This should get jitted away in the case where neither is supported
-                    if (ArmAes.IsSupported || X86Aes.IsSupported)
+                    if (GxHash.GxHash.IsSupported)
                     {
                         value = GxHash.GxHash.Hash64(System.Runtime.InteropServices.MemoryMarshal.Cast<char, byte>(text.AsSpan()));
+                        return;
                     }
-                    else
-                    {
-                        value = FowlerNollVo1aHash.ComputeHash64Fast(text);
-                    }
-#else
-                    value = FowlerNollVo1aHash.ComputeHash64Fast(text);
 #endif
+
+                    value = FowlerNollVo1aHash.ComputeHash64Fast(text);
                 }
             }
 

--- a/src/StringTools/GxHash.cs
+++ b/src/StringTools/GxHash.cs
@@ -40,6 +40,9 @@ namespace GxHash;
 public class GxHash
 {
 #if NET10_0_OR_GREATER
+
+    public static bool IsSupported = ArmAes.IsSupported || X86Aes.IsSupported;
+
     // Internal usage only because T cannot be checked at compile time via generic type constrains
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static T Hash<T>(ReadOnlySpan<byte> bytes, UInt128 seed)


### PR DESCRIPTION
### Context
The [ogxd/gxhash-csharp](https://github.com/ogxd/gxhash-csharp) is a blazing fast hash implementation that outperforms our current hash (Fnv1a64Fast) by a factor of ~three. 

### Changes Made
replaced the Fnv1a64Fast invocation by the GxHash in net10, where it is supported.

### Testing
If nothing breaks, this should be good to go. It is a change that only affects the binlog.

### Notes
I'm not saying we have to merge this - I take it as a more of a discussion opener. With that I mind, the hash is amazing.
Is it worth it?

|      Method |       Mean |    Error |   StdDev |
|------------ |-----------:|---------:|---------:|
|    xxHash64 |   822.9 ns |  4.26 ns |  3.78 ns |
| Fnv1a64Fast | 1,019.7 ns |  5.74 ns |  5.09 ns |
|     Fnv1a64 | 1,054.4 ns | 11.37 ns | 10.64 ns |
|    Marvin32 | 2,059.3 ns |  9.77 ns |  8.66 ns |
|          Gx |   311.7 ns |  6.02 ns |  5.91 ns |
|  CityHash64 | 4,017.1 ns | 76.58 ns | 81.94 ns |
|        MH64 | 1,597.3 ns | 26.66 ns | 24.93 ns |
|        djb2 | 1,075.7 ns |  4.20 ns |  3.92 ns |
| Murmur3_128 | 1,511.9 ns |  3.77 ns |  3.15 ns |

```
String set: roslynStrings Strings: 243,650
  GxHash          Collisions: 0               Elapsed: 00:00:00.1087355
  Murmur3-128     Collisions: 0               Elapsed: 00:00:00.1377711
  xxHash64        Collisions: 0               Elapsed: 00:00:00.1486599
  Fnv1a64Fast     Collisions: 0               Elapsed: 00:00:00.2294724
  CityHash        Collisions: 0               Elapsed: 00:00:00.2434761
  Sha256-64       Collisions: 0               Elapsed: 00:00:00.2982072
  Fnv1a64         Collisions: 0               Elapsed: 00:00:00.2997860
  Default         Collisions: 3               Elapsed: 00:00:00.0816374
  GetHashCode     Collisions: 3               Elapsed: 00:00:00.1402600
  xxHash32        Collisions: 8               Elapsed: 00:00:00.1768018
  Murmur3-32      Collisions: 6               Elapsed: 00:00:00.2037003
  Marvin          Collisions: 9               Elapsed: 00:00:00.2281257
  Sha256-32       Collisions: 5               Elapsed: 00:00:00.2286937
  Fnv1a32         Collisions: 2               Elapsed: 00:00:00.2788992
  djb2            Collisions: 6               Elapsed: 00:00:00.2837722
  Fnv1a32Fast     Collisions: 12              Elapsed: 00:00:00.2873694
```

The time spent hashing on OrchardCore is reduced from ~3% cpu to ~1.6% cpu