### PR TITLE
Fix importance check for target-skipped messages

### DIFF
--- a/inline.proj
+++ b/inline.proj
@@ -1,0 +1,56 @@
+<Project DefaultTargets="Build" ToolsVersion="Current">
+  <PropertyGroup>
+    <NugetPackageRoot>Q:\.tools\.nuget\packages\</NugetPackageRoot>
+    <NoWarn></NoWarn> 
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+
+  <UsingTask TaskName="CustomRoslynTask" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
+    <Task>
+      <!-- <Reference Include="$(NugetPackageRoot)\microsoft.bcl.asyncinterfaces\9.0.4\lib\netstandard2.0\Microsoft.Bcl.AsyncInterfaces.dll" /> -->
+      <Reference Include="$(NugetPackageRoot)\system.memory\4.6.3\lib\netstandard2.0\System.Memory.dll" />
+      <Reference Include="$(NugetPackageRoot)\system.text.encodings.web\9.0.4\lib\netstandard2.0\System.Text.Encodings.Web.dll" />
+      <Reference Include="$(NugetPackageRoot)\system.text.json\9.0.4\lib\netstandard2.0\System.Text.Json.dll" />
+      <Code Type="Class" Language="cs"><![CDATA[
+        using System;
+        using System.Text.Json;
+        using System.Buffers;
+        using Microsoft.Build.Framework;
+        using Microsoft.Build.Utilities;
+
+        public class CustomRoslynTask : Task
+        {
+            public override bool Execute()
+            {
+                try
+                {
+                    // Use System.Text.Json to trigger binding
+                    var json = JsonSerializer.Serialize(new { Name = "Test" });
+                    Log.LogMessage(MessageImportance.High, "JSON: {0}", json);
+
+                    // Use Memory<T> from System.Memory.dll to ensure reference
+                    Memory<byte> memory = new byte[10];
+                    Log.LogMessage(MessageImportance.High, "Memory Length: {0}", memory.Length);
+
+                    // Use Span<T> for additional binding check
+                    Span<byte> span = memory.Span;
+                    Log.LogMessage(MessageImportance.High, "Span Length: {0}", span.Length);
+
+                    return true;
+                }
+                catch (Exception ex)
+                {
+                    Log.LogError("Task failed: {0}", ex.Message);
+                    return false;
+                }
+            }
+        }
+      ]]></Code>
+    </Task>
+  </UsingTask>
+
+  <Target Name="Build">
+    <CustomRoslynTask />
+  </Target>
+</Project>

--- a/src/Build/BackEnd/Components/RequestBuilder/TargetEntry.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TargetEntry.cs
@@ -367,7 +367,7 @@ namespace Microsoft.Build.BackEnd
                     projectLoggingContext.BuildEventContext);
                 _state = TargetEntryState.Completed;
 
-                if (projectLoggingContext.LoggingService.MinimumRequiredMessageImportance > MessageImportance.Low &&
+                if (projectLoggingContext.LoggingService.MinimumRequiredMessageImportance.IsAtLeast(MessageImportance.Low) &&
                     !projectLoggingContext.LoggingService.OnlyLogCriticalEvents)
                 {
                     // Expand the expression for the Log.  Since we know the condition evaluated to false, leave unexpandable properties in the condition so as not to cause an error

--- a/src/Framework/BuildMessageEventArgs.cs
+++ b/src/Framework/BuildMessageEventArgs.cs
@@ -14,28 +14,6 @@ using Microsoft.Build.Shared;
 namespace Microsoft.Build.Framework
 {
     /// <summary>
-    /// This enumeration provides three levels of importance for messages.
-    /// </summary>
-    [Serializable]
-    public enum MessageImportance
-    {
-        /// <summary>
-        /// High importance, appears in less verbose logs
-        /// </summary>
-        High,
-
-        /// <summary>
-        /// Normal importance
-        /// </summary>
-        Normal,
-
-        /// <summary>
-        /// Low importance, appears in more verbose logs
-        /// </summary>
-        Low
-    }
-
-    /// <summary>
     /// Arguments for message events
     /// </summary>
     // WARNING: marking a type [Serializable] without implementing

--- a/src/Framework/MessageImportance.cs
+++ b/src/Framework/MessageImportance.cs
@@ -1,0 +1,28 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+namespace Microsoft.Build.Framework;
+
+/// <summary>
+/// This enumeration provides three levels of importance for messages.
+/// </summary>
+[Serializable]
+public enum MessageImportance
+{
+    /// <summary>
+    /// High importance, appears in less verbose logs
+    /// </summary>
+    High,
+
+    /// <summary>
+    /// Normal importance
+    /// </summary>
+    Normal,
+
+    /// <summary>
+    /// Low importance, appears in more verbose logs
+    /// </summary>
+    Low
+}

--- a/src/Framework/MessageImportanceExtensions.cs
+++ b/src/Framework/MessageImportanceExtensions.cs
@@ -1,0 +1,26 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Build.Framework;
+
+/// <summary>
+/// Extension methods for <see cref="MessageImportance"/>.
+/// </summary>
+internal static class MessageImportanceExtensions
+{
+    /// <summary>
+    /// Returns true if the message importance is at least the required importance.
+    /// High &gt;= Normal &gt;= Low.
+    /// For example, High.IsAtLeast(MessageImportance.Normal) returns true, while
+    /// Normal.IsAtLeast(MessageImportance.High) returns false.
+    /// </summary>
+    /// <param name="importance">The importance to evaluate.</param>
+    /// <param name="requiredImportance">The minimum required importance.</param>
+    /// <returns><see langword="true"/> if <paramref name="importance"/> is at least <paramref name="requiredImportance"/>; otherwise <see langword="false"/>.</returns>
+    public static bool IsAtLeast(this MessageImportance importance, MessageImportance requiredImportance)
+    {
+        // Enum underlying values: High = 0, Normal = 1, Low = 2.
+        // Smaller numeric value indicates higher importance.
+        return importance <= requiredImportance;
+    }
+}


### PR DESCRIPTION
https://github.com/dotnet/msbuild/pull/12226 introduced a bug: `MessageImportance.Low` is (numerically) the highest value, so nothing is ever greater than it is. This caused the problems observed in https://github.com/microsoft/testfx/pull/6426 (thanks @Youssef1313 for diagnosing this!).



Reverse the comparison and extract a method to avoid this confusion in the future.

