### PR TITLE
Revert "Reduce allocations due to resizing dictionaries"

### DIFF
--- a/src/Build/BackEnd/Components/RequestBuilder/BatchingEngine.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/BatchingEngine.cs
@@ -360,8 +360,6 @@ namespace Microsoft.Build.BackEnd
                             buckets.Insert(~matchingBucketIndex, matchingBucket);
                         }
 
-                        matchingBucket.Lookup.EnsureCapacity(items.Count);
-
                         // We already have a bucket for this type of item, so add this item to
                         // the bucket.
                         matchingBucket.AddItem(item);

--- a/src/Build/BackEnd/Components/RequestBuilder/Lookup.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/Lookup.cs
@@ -376,7 +376,7 @@ namespace Microsoft.Build.BackEnd
             // adds to the world
             if (PrimaryAddTable != null)
             {
-                SecondaryTable ??= new ItemDictionary<ProjectItemInstance>(PrimaryAddTable.ItemTypesCount);
+                SecondaryTable ??= new ItemDictionary<ProjectItemInstance>();
                 SecondaryTable.ImportItems(PrimaryAddTable);
             }
 
@@ -707,24 +707,6 @@ namespace Microsoft.Build.BackEnd
         }
 
         /// <summary>
-        /// Attempts to set the initial capacity of the primary add table.
-        /// </summary>
-        /// <param name="capacity"></param>
-        internal void EnsureCapacity(int capacity)
-        {
-            if (PrimaryAddTable is null)
-            {
-                PrimaryAddTable = new ItemDictionary<ProjectItemInstance>(capacity);
-            }
-#if NET
-            else
-            {
-                PrimaryAddTable.EnsureCapacity(capacity);
-            }
-#endif
-        }
-
-        /// <summary>
         /// Implements a true add, an item that has been created in a batch.
         /// </summary>
         internal void AddNewItem(ProjectItemInstance item)
@@ -830,7 +812,7 @@ namespace Microsoft.Build.BackEnd
             }
         }
 
-#endregion
+        #endregion
 
         #region Private Methods
 

--- a/src/Build/BackEnd/TaskExecutionHost/TaskExecutionHost.cs
+++ b/src/Build/BackEnd/TaskExecutionHost/TaskExecutionHost.cs
@@ -1384,7 +1384,6 @@ namespace Microsoft.Build.BackEnd
                 {
                     // Only count non-null elements. We sometimes have a single-element array where the element is null
                     bool hasElements = false;
-                    _batchBucket.Lookup.EnsureCapacity(outputs.Length);
 
                     foreach (ITaskItem output in outputs)
                     {
@@ -1549,8 +1548,6 @@ namespace Microsoft.Build.BackEnd
             {
                 if (outputTargetIsItem)
                 {
-                    _batchBucket.Lookup.EnsureCapacity(outputs.Length);
-
                     // to store the outputs as items, use the string representations of the outputs as item-specs
                     foreach (string output in outputs)
                     {

--- a/src/Build/Collections/ItemDictionary.cs
+++ b/src/Build/Collections/ItemDictionary.cs
@@ -82,27 +82,7 @@ namespace Microsoft.Build.Collections
         /// <summary>
         /// Number of items in total, for debugging purposes.
         /// </summary>
-        public int Count
-        {
-            get
-            {
-                lock (_itemLists)
-                {
-                    return _nodes.Count;
-                }
-            }
-        }
-
-        public int ItemTypesCount
-        {
-            get
-            {
-                lock (_itemLists)
-                {
-                    return _itemLists.Count;
-                }
-            }
-        }
+        public int Count => _nodes.Count;
 
         /// <summary>
         /// Get the item types that have at least one item in this collection
@@ -149,16 +129,6 @@ namespace Microsoft.Build.Collections
                 return new ReadOnlyCollection<T>(list);
             }
         }
-
-#if NET
-        public void EnsureCapacity(int desiredCapacity)
-        {
-            lock (_itemLists)
-            {
-                _itemLists.EnsureCapacity(desiredCapacity);
-            }
-        }
-#endif
 
         /// <summary>
         /// Empty the collection


### PR DESCRIPTION
Reverts dotnet/msbuild#12159

Confirmed with @Erarndt , it causes extra allocations in VS.