### PR TITLE
Use unbounded SemaphoreSlim

### DIFF
--- a/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
@@ -788,7 +788,10 @@ namespace Microsoft.Build.BackEnd
                     _exitPacketState = ExitPacketState.ExitPacketQueued;
                 }
 
+                Thread.MemoryBarrier();
                 _packetWriteQueue.Enqueue(packet);
+
+                Thread.MemoryBarrier();
                 _packetEnqueued.Release();
             }
 

--- a/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
@@ -161,22 +161,29 @@ namespace Microsoft.Build.BackEnd
                 int timeout = 30;
 
                 // Attempt to connect to the process with the handshake without low priority.
-                Stream nodeStream = TryConnectToProcess(nodeProcess.Id, timeout, NodeProviderOutOfProc.GetHandshake(nodeReuse, false));
-
-                if (nodeStream == null)
-                {
-                    // If we couldn't connect attempt to connect to the process with the handshake including low priority.
-                    nodeStream = TryConnectToProcess(nodeProcess.Id, timeout, NodeProviderOutOfProc.GetHandshake(nodeReuse, true));
-                }
-
+                using Stream nodeStream = TryConnectToProcess(nodeProcess.Id, timeout, NodeProviderOutOfProc.GetHandshake(nodeReuse, false));
                 if (nodeStream != null)
                 {
-                    // If we're able to connect to such a process, send a packet requesting its termination
-                    CommunicationsUtilities.Trace("Shutting down node with pid = {0}", nodeProcess.Id);
-                    NodeContext nodeContext = new NodeContext(0, nodeProcess, nodeStream, factory, terminateNode);
-                    nodeContext.SendData(new NodeBuildComplete(false /* no node reuse */));
-                    nodeStream.Dispose();
+                    ShutdownNode(terminateNode, factory, nodeProcess, nodeStream);
                 }
+                else
+                {
+                    // If we couldn't connect attempt to connect to the process with the handshake including low priority.
+                    using Stream lowPriorityConnection = TryConnectToProcess(nodeProcess.Id, timeout, NodeProviderOutOfProc.GetHandshake(nodeReuse, true));
+
+                    if (lowPriorityConnection != null)
+                    {
+                        ShutdownNode(terminateNode, factory, nodeProcess, lowPriorityConnection);
+                    }
+                }
+            }
+
+            static void ShutdownNode(NodeContextTerminateDelegate terminateNode, INodePacketFactory factory, Process nodeProcess, Stream nodeStream)
+            {
+                // If we're able to connect to such a process, send a packet requesting its termination
+                CommunicationsUtilities.Trace("Shutting down node with pid = {0}", nodeProcess.Id);
+                NodeContext nodeContext = new NodeContext(0, nodeProcess, nodeStream, factory, terminateNode);
+                nodeContext.SendData(new NodeBuildComplete(false /* no node reuse */));
             }
         }
 
@@ -624,19 +631,14 @@ namespace Microsoft.Build.BackEnd
             private readonly NodeContextTerminateDelegate _terminateDelegate;
 
             /// <summary>
-            /// A dedicated thread to consume enqueued packets.
+            /// A task representing the work to consume enqueued packets.
             /// </summary>
-            private readonly Thread _drainPacketQueueThread;
+            private readonly Task _packetWriteDrainTask;
 
             /// <summary>
-            /// Used to signal the consuming thread that a packet has been enqueued;
+            /// Used to signal the consuming task that a packet has been enqueued.
             /// </summary>
-            private readonly AutoResetEvent _packetEnqueued;
-
-            /// <summary>
-            /// Used to signal that the exit packet has been sent and we no longer need to wait for the queue to drain.
-            /// </summary>
-            private readonly CancellationTokenSource _packetQueueDrainDelayCancellation;
+            private readonly SemaphoreSlim _packetEnqueued;
 
             /// <summary>
             /// Tracks the state of the packet sent to terminate the node.
@@ -677,13 +679,9 @@ namespace Microsoft.Build.BackEnd
 #endif
 
                 _packetWriteQueue = new ConcurrentQueue<INodePacket>();
-                _packetEnqueued = new AutoResetEvent(false);
-                _packetQueueDrainDelayCancellation = new CancellationTokenSource();
+                _packetEnqueued = new SemaphoreSlim(0);
 
-                // specify the smallest stack size - 64kb
-                _drainPacketQueueThread = new Thread(DrainPacketQueue, 64 * 1024);
-                _drainPacketQueueThread.IsBackground = true;
-                _drainPacketQueueThread.Start(this);
+                _packetWriteDrainTask = DrainPacketQueue();
             }
 
             /// <summary>
@@ -789,30 +787,30 @@ namespace Microsoft.Build.BackEnd
                 {
                     _exitPacketState = ExitPacketState.ExitPacketQueued;
                 }
+
                 _packetWriteQueue.Enqueue(packet);
-                _packetEnqueued.Set();
+                _packetEnqueued.Release();
             }
 
             /// <summary>
-            /// We use a dedicated thread to avoid blocking a threadpool thread.
+            /// Use a threadpool thread to drain the queue and be careful not to block it where possible.
             /// </summary>
             /// <remarks>Usually there'll be a single packet in the queue, but sometimes
             /// a burst of SendData comes in, with 10-20 packets scheduled.</remarks>
-            private void DrainPacketQueue(object state)
+            private async Task DrainPacketQueue()
             {
-                NodeContext context = (NodeContext)state;
-                MemoryStream writeStream = context._writeBufferMemoryStream;
-                Stream serverToClientStream = context._pipeStream;
+                MemoryStream writeStream = _writeBufferMemoryStream;
+                Stream serverToClientStream = _pipeStream;
+                ITranslator writeTranslator = _writeTranslator;
 
                 while (true)
                 {
-                    context._packetEnqueued.WaitOne();
-                    while (context._packetWriteQueue.TryDequeue(out INodePacket packet))
+                    await _packetEnqueued.WaitAsync();
+                    while (_packetWriteQueue.TryDequeue(out INodePacket packet))
                     {
                         // clear the buffer but keep the underlying capacity to avoid reallocations
                         writeStream.SetLength(0);
 
-                        ITranslator writeTranslator = context._writeTranslator;
                         try
                         {
                             NodePacketType packetType = packet.Type;
@@ -845,22 +843,29 @@ namespace Microsoft.Build.BackEnd
                             for (int i = 0; i < writeStreamLength; i += MaxPacketWriteSize)
                             {
                                 int lengthToWrite = Math.Min(writeStreamLength - i, MaxPacketWriteSize);
-
-                                serverToClientStream.Write(writeStreamBuffer, i, lengthToWrite);
+#if NET
+                                await serverToClientStream.WriteAsync(writeStreamBuffer.AsMemory(i, lengthToWrite));
+#else
+                                await serverToClientStream.WriteAsync(writeStreamBuffer, i, lengthToWrite);
+#endif
                             }
 
                             if (IsExitPacket(packet))
                             {
-                                context._exitPacketState = ExitPacketState.ExitPacketSent;
-                                context._packetQueueDrainDelayCancellation.Cancel();
+                                _exitPacketState = ExitPacketState.ExitPacketSent;
 
+                                return;
+                            }
+
+                            if (packet is NodeBuildComplete)
+                            {
                                 return;
                             }
                         }
                         catch (IOException e)
                         {
                             // Do nothing here because any exception will be caught by the async read handler
-                            CommunicationsUtilities.Trace(context._nodeId, "EXCEPTION in SendData: {0}", e);
+                            CommunicationsUtilities.Trace(_nodeId, "EXCEPTION in SendData: {0}", e);
                         }
                         catch (ObjectDisposedException) // This happens if a child dies unexpectedly
                         {
@@ -892,6 +897,7 @@ namespace Microsoft.Build.BackEnd
             private void Close()
             {
                 _pipeStream.Dispose();
+                _packetEnqueued.Dispose();
                 _terminateDelegate(_nodeId);
             }
 
@@ -905,13 +911,15 @@ namespace Microsoft.Build.BackEnd
                     // Wait up to 100ms until all remaining packets are sent.
                     // We don't need to wait long, just long enough for the Task to start running on the ThreadPool.
 #if NET
-                    await Task.Delay(100, _packetQueueDrainDelayCancellation.Token).ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing);
+                    await _packetWriteDrainTask.WaitAsync(TimeSpan.FromMilliseconds(100)).ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing);
 #else
-                    await Task.WhenAny(Task.Delay(100, _packetQueueDrainDelayCancellation.Token));
+                    using (var cts = new CancellationTokenSource(100))
+                    {
+                        await Task.WhenAny(_packetWriteDrainTask, Task.Delay(100, cts.Token));
+                        cts.Cancel();
+                    }
 #endif
                 }
-
-                _packetQueueDrainDelayCancellation?.Dispose();
 
                 if (_exitPacketState == ExitPacketState.ExitPacketSent)
                 {


### PR DESCRIPTION
Fixes #

### Context

This is a modification of https://github.com/dotnet/msbuild/pull/12113 that uses a `SemaphoreSlim` without a cap on the number of times it can be released. The previous code checked the count property to see if `Release()` needed to be called since calling it when there is a maximum specified can throw an exception if we're already at the max.

However, this pattern has a potential race condition if more than one thread tries to enqueue a packet at once. Multiple threads read `0` from `CurrentCount` and try to call `Release()` which causes an exception to be thrown. Additionally, the ARM64 architecture has a weaker memory model than x86/64 which can lead to unintended behavior. The .NET runtime maintains its own memory model rules that ensure correctness across platforms. Of note in this case is this section about [order of memory operations](https://github.com/dotnet/runtime/blob/main/docs/design/specs/Memory-model.md#order-of-memory-operations).

_"The effects of ordinary reads and writes can be reordered as long as that preserves single-thread consistency."_

Since the runtime only needs to guarantee single-thread consistency, the read of something like `CurrentCount` could be read before the packet is enqueued, and this could lead to `DrainPacketQueue` never being signaled.


### Changes Made


### Testing


### Notes
