### PR TITLE
experimental suffix in exp perf build

### DIFF
--- a/azure-pipelines/.vsts-dotnet-build-jobs.yml
+++ b/azure-pipelines/.vsts-dotnet-build-jobs.yml
@@ -90,6 +90,7 @@ jobs:
               /p:VisualStudioIbcDrop=$(OptProfDrop)
               /p:GenerateSbom=true
               /p:SuppressFinalPackageVersion=${{ parameters.isExperimental }}
+              /p:IsExperimental=${{ parameters.isExperimental }}
     displayName: Build
     condition: succeeded()
 

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -8,7 +8,7 @@
     <AssemblyVersion>15.1.0.0</AssemblyVersion>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
     <!-- differentiate experimental insertions to avoid package id conflicts -->
-    <PreReleaseVersionLabel Condition="'$(IsExperimental)' != ''">experimental</PreReleaseVersionLabel>
+    <PreReleaseVersionLabel Condition="'$(IsExperimental)' == 'true'">experimental</PreReleaseVersionLabel>
     <!--
       Don't use shipping versions when building in the VMR unless the VMR directs the build to use shipping versions.
       This can cause issues when building downstream repos in the orchestrated build if the time MSBuild


### PR DESCRIPTION
### Context
collision between package names in official build and exp perf build after  split in https://github.com/dotnet/msbuild/pull/12397 causes package duplicate names 

### Changes Made
change package suffix for experimental

### Testing
https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=12283803&view=results
### Notes
I'm not sure if it's a problem for netcore infra that the official build ids can be duplicate with exp-perf builds, but this is improvement over current state for our VS use case.
We cant edit build ids freely, they have to have the default format of date+revision.