### PR TITLE
change experimental insertion suffix to `test`

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -7,8 +7,10 @@
     <PackageValidationBaselineVersion>17.14.8</PackageValidationBaselineVersion>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
-    <!-- differentiate experimental insertions to avoid package id conflicts -->
-    <PreReleaseVersionLabel Condition="'$(IsExperimental)' == 'true'">experimental</PreReleaseVersionLabel>
+
+    <!-- differentiate experimental insertions to avoid package id conflicts, 
+     it has to be alphabetically after "preview" to avoid downgrade errors in VS -->
+    <PreReleaseVersionLabel Condition="'$(IsExperimental)' == 'true'">test</PreReleaseVersionLabel>
     <!--
       Don't use shipping versions when building in the VMR unless the VMR directs the build to use shipping versions.
       This can cause issues when building downstream repos in the orchestrated build if the time MSBuild


### PR DESCRIPTION
after https://github.com/dotnet/msbuild/pull/12444 VS rejects the exp package because it's a version downgrade because alphabetically `experimental` < `preview`


### Changes Made
change suffix to `test`

### Testing


### Notes
