### PR TITLE
Make link in BuildCheck help clickable by adding https://

### DIFF
--- a/src/MSBuild/Resources/Strings.resx
+++ b/src/MSBuild/Resources/Strings.resx
@@ -1037,7 +1037,7 @@
     <value>  -check
                      Enables BuildChecks during the build.
                      BuildCheck enables evaluating rules to ensure properties
-                     of the build. For more info see aka.ms/buildcheck
+                     of the build. For more info see https://aka.ms/buildcheck
 	</value>
 	<comment>
     {Locked="-check"}{Locked="BuildChecks"}{Locked="BuildCheck"}

--- a/src/MSBuild/Resources/xlf/Strings.cs.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.cs.xlf
@@ -282,9 +282,9 @@
         <source>  -check
                      Enables BuildChecks during the build.
                      BuildCheck enables evaluating rules to ensure properties
-                     of the build. For more info see aka.ms/buildcheck
+                     of the build. For more info see https://aka.ms/buildcheck
 	</source>
-        <target state="translated">  -check
+        <target state="needs-review-translation">  -check
                      Povolí během sestavování BuildChecks.
                      BuildCheck umožňuje vyhodnocovat pravidla, aby se zajistily vlastnosti
                      sestavení. Další informace viz aka.ms/buildcheck

--- a/src/MSBuild/Resources/xlf/Strings.de.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.de.xlf
@@ -282,9 +282,9 @@
         <source>  -check
                      Enables BuildChecks during the build.
                      BuildCheck enables evaluating rules to ensure properties
-                     of the build. For more info see aka.ms/buildcheck
+                     of the build. For more info see https://aka.ms/buildcheck
 	</source>
-        <target state="translated">  -check
+        <target state="needs-review-translation">  -check
                      Aktiviert BuildChecks während des Builds.
                      BuildCheck ermöglicht die Regelauswertung, um Eigenschaften 
                      des Builds sicherzustellen. Weitere Infos: aka.ms/buildcheck

--- a/src/MSBuild/Resources/xlf/Strings.es.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.es.xlf
@@ -281,9 +281,9 @@ Esta marca es experimental y puede que no funcione según lo previsto.
         <source>  -check
                      Enables BuildChecks during the build.
                      BuildCheck enables evaluating rules to ensure properties
-                     of the build. For more info see aka.ms/buildcheck
+                     of the build. For more info see https://aka.ms/buildcheck
 	</source>
-        <target state="translated">  -check
+        <target state="needs-review-translation">  -check
                      Habilita BuildChecks durante la compilación.
                      BuildCheck permite evaluar reglas para garantizar que las propiedades
                      de la compilación. Para obtener más información, consulta aka.ms/buildcheck

--- a/src/MSBuild/Resources/xlf/Strings.fr.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.fr.xlf
@@ -282,9 +282,9 @@ futures
         <source>  -check
                      Enables BuildChecks during the build.
                      BuildCheck enables evaluating rules to ensure properties
-                     of the build. For more info see aka.ms/buildcheck
+                     of the build. For more info see https://aka.ms/buildcheck
 	</source>
-        <target state="translated">  -check
+        <target state="needs-review-translation">  -check
                      Active BuildChecks pendant la construction.
                      BuildCheck permet d'évaluer les règles pour garantir les propriétés
                      de la build. Pour plus d'informations, consultez aka.ms/buildcheck

--- a/src/MSBuild/Resources/xlf/Strings.it.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.it.xlf
@@ -282,9 +282,9 @@ Questo flag è sperimentale e potrebbe non funzionare come previsto.
         <source>  -check
                      Enables BuildChecks during the build.
                      BuildCheck enables evaluating rules to ensure properties
-                     of the build. For more info see aka.ms/buildcheck
+                     of the build. For more info see https://aka.ms/buildcheck
 	</source>
-        <target state="translated">  -check
+        <target state="needs-review-translation">  -check
                      Abilita BuildChecks durante la compilazione.
                      BuildCheck consente di valutare le regole per garantire le proprietà 
                      della compilazione. Per altre informazioni, vedere aka.ms/buildcheck

--- a/src/MSBuild/Resources/xlf/Strings.ja.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.ja.xlf
@@ -282,9 +282,9 @@
         <source>  -check
                      Enables BuildChecks during the build.
                      BuildCheck enables evaluating rules to ensure properties
-                     of the build. For more info see aka.ms/buildcheck
+                     of the build. For more info see https://aka.ms/buildcheck
 	</source>
-        <target state="translated">  -check
+        <target state="needs-review-translation">  -check
                      ビルド中に BuildChecks を有効にします。
                      BuildCheck を使用すると、ビルドのプロパティを保証するための
                      評価ルールが有効になります。詳細については、aka.ms/buildcheck を参照してください

--- a/src/MSBuild/Resources/xlf/Strings.ko.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.ko.xlf
@@ -283,9 +283,9 @@
         <source>  -check
                      Enables BuildChecks during the build.
                      BuildCheck enables evaluating rules to ensure properties
-                     of the build. For more info see aka.ms/buildcheck
+                     of the build. For more info see https://aka.ms/buildcheck
 	</source>
-        <target state="translated">  -check
+        <target state="needs-review-translation">  -check
                      빌드하는 동안 BuildChecks를 사용하도록 설정합니다.
                      BuildCheck는 속성을 확실히 하기 위해 규칙 평가를 사용 설정합니다
                      빌드의 자세한 내용은 aka.ms/buildcheck를 참조하세요.

--- a/src/MSBuild/Resources/xlf/Strings.pl.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.pl.xlf
@@ -281,9 +281,9 @@ Ta flaga jest eksperymentalna i może nie działać zgodnie z oczekiwaniami.
         <source>  -check
                      Enables BuildChecks during the build.
                      BuildCheck enables evaluating rules to ensure properties
-                     of the build. For more info see aka.ms/buildcheck
+                     of the build. For more info see https://aka.ms/buildcheck
 	</source>
-        <target state="translated">  -check
+        <target state="needs-review-translation">  -check
                      Włącza funkcję BuildChecks podczas kompilacji.
                      Funkcja BuildCheck umożliwia ocenę reguł w celu zapewnienia właściwości
                      kompilacji. Aby uzyskać więcej informacji, zobacz aka.ms/buildcheck

--- a/src/MSBuild/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.pt-BR.xlf
@@ -281,9 +281,9 @@
         <source>  -check
                      Enables BuildChecks during the build.
                      BuildCheck enables evaluating rules to ensure properties
-                     of the build. For more info see aka.ms/buildcheck
+                     of the build. For more info see https://aka.ms/buildcheck
 	</source>
-        <target state="translated">  -check
+        <target state="needs-review-translation">  -check
                      Habilita BuildChecks durante o build.
                      BuildCheck habilita a avaliação de regras para garantir as propriedades
                      do build. Para obter mais informações, confira aka.ms/buildcheck

--- a/src/MSBuild/Resources/xlf/Strings.ru.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.ru.xlf
@@ -281,9 +281,9 @@
         <source>  -check
                      Enables BuildChecks during the build.
                      BuildCheck enables evaluating rules to ensure properties
-                     of the build. For more info see aka.ms/buildcheck
+                     of the build. For more info see https://aka.ms/buildcheck
 	</source>
-        <target state="translated">  -check
+        <target state="needs-review-translation">  -check
                      Включает BuildChecks во время сборки.
                      BuildCheck позволяет оценивать правила для проверки свойств
                      сборки. Дополнительные сведения см. на странице aka.ms/buildcheck

--- a/src/MSBuild/Resources/xlf/Strings.tr.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.tr.xlf
@@ -281,9 +281,9 @@
         <source>  -check
                      Enables BuildChecks during the build.
                      BuildCheck enables evaluating rules to ensure properties
-                     of the build. For more info see aka.ms/buildcheck
+                     of the build. For more info see https://aka.ms/buildcheck
 	</source>
-        <target state="translated">  -check
+        <target state="needs-review-translation">  -check
                      Derleme sırasında BuildChecks'i sağlar.
                      BuildCheck, özelliklerin güvenliğini sağlamak için kuralların değerlendirilmesini sağlar
                      kuralların değerlendirilmesini sağlar. Daha fazla bilgi için bkz. aka.ms/buildcheck

--- a/src/MSBuild/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.zh-Hans.xlf
@@ -281,9 +281,9 @@
         <source>  -check
                      Enables BuildChecks during the build.
                      BuildCheck enables evaluating rules to ensure properties
-                     of the build. For more info see aka.ms/buildcheck
+                     of the build. For more info see https://aka.ms/buildcheck
 	</source>
-        <target state="translated">  -check
+        <target state="needs-review-translation">  -check
                      在生成中启用 BuildChecks。
                      BuildCheck 允许评估规则以确保生成的
                      属性。有关详细信息，请参阅 aka.ms/buildcheck

--- a/src/MSBuild/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.zh-Hant.xlf
@@ -282,9 +282,9 @@
         <source>  -check
                      Enables BuildChecks during the build.
                      BuildCheck enables evaluating rules to ensure properties
-                     of the build. For more info see aka.ms/buildcheck
+                     of the build. For more info see https://aka.ms/buildcheck
 	</source>
-        <target state="translated">  -check
+        <target state="needs-review-translation">  -check
                      在建置期間啟用 BuildChecks。
                      BuildCheck 會啟用評估規則以確保組建的 
                      屬性。如需詳細資訊，請參閱 aka.ms/buildcheck


### PR DESCRIPTION
BuildCheck help shows:

```
  -check
                     Enables BuildChecks during the build.
                     BuildCheck enables evaluating rules to ensure properties
                     of the build. For more info see aka.ms/buildcheck
```

This change makes the link shown here clickable in many terminals or log viewers.