### PR TITLE
Disable opt prof

### DIFF
--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -41,6 +41,11 @@ variables:
     value: .NETCore
   - name: _DotNetValidationArtifactsCategory
     value: .NETCoreValidation
+  # For now skipping apply optimization data for vs16.11, because the run with real signed bits requires being fully automated
+  # while there is no available optimization data for vs16.11.
+  - ${{ if startsWith(variables['Build.SourceBranch'], 'refs/heads/vs16.11') }}:
+    - name: SkipApplyOptimizationData
+      value: true
 
 resources:
   repositories:

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,7 +2,7 @@
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the MIT license. See License.txt in the project root for full license information. -->
 <Project>
   <PropertyGroup>
-    <VersionPrefix>16.11.11</VersionPrefix>
+    <VersionPrefix>16.11.12</VersionPrefix>
     <DotNetFinalVersionKind>release</DotNetFinalVersionKind>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>


### PR DESCRIPTION
For now skip applying optimization data for vs16.11, because the run with real signed bits requires being fully automated
while there is no available optimization data for vs16.11.