### PR TITLE
Bump bootstrap

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -73,7 +73,7 @@
     <MicrosoftCodeAnalysisPooledObjectsVersion>5.0.0-1.25277.114</MicrosoftCodeAnalysisPooledObjectsVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <BootstrapSdkVersion>10.0.100-rc.1.25411.109</BootstrapSdkVersion>
+    <BootstrapSdkVersion>10.0.100-rc.2.25420.109</BootstrapSdkVersion>
   </PropertyGroup>
   <Target Name="OverrideArcadeFileVersion" AfterTargets="_InitializeAssemblyVersion">
     <!-- See https://github.com/dotnet/arcade/issues/3386

--- a/src/Build.UnitTests/ProjectCache/ProjectCacheTests.cs
+++ b/src/Build.UnitTests/ProjectCache/ProjectCacheTests.cs
@@ -1725,6 +1725,8 @@ namespace Microsoft.Build.Engine.UnitTests.ProjectCache
             }
             """);
 
+            directory.CreateFile("global.json", GetGlobalJsonContent());
+
             // Create EmbeddedResources file
             var file1 = directory.CreateFile("File1.txt", "A=1");
             var file2 = directory.CreateFile("File2.txt", "B=1");
@@ -1749,5 +1751,16 @@ namespace Microsoft.Build.Engine.UnitTests.ProjectCache
             output.ShouldNotContain("A=1");
             output.ShouldContain("B=1");
         }
+
+        private static string GetGlobalJsonContent() =>
+            /*lang=json*/ @"{
+                // This global.json is needed to prevent builds running in tests using the bootstrap layout from walking
+                // up the repo tree and resolving our sdk.paths, instead of the bootstrap layout's SDK.
+                // See https://github.com/dotnet/runtime/issues/118488 for details.
+                ""sdk"": {
+                    ""allowPrerelease"": true,
+                    ""rollForward"": ""latestMajor""
+                }
+            }";
     }
 }


### PR DESCRIPTION
### Fixes

Bootstrap run:
`System.TypeInitializationException: The type initializer for 'Microsoft.DotNet.Cli.Parser' threw an exception.
 ---> System.TypeInitializationException: The type initializer for 'Microsoft.DotNet.Cli.Commands.NuGet.NuGetCommandParser' threw an exception.
 ---> System.IO.FileNotFoundException: Could not load file or assembly 'NuGet.Common, Version=7.0.0.609, Culture=neutral, PublicKeyToken=31bf3856ad364e35'. The system cannot find the file specified.
File name: 'NuGet.Common, Version=7.0.0.609, Culture=neutral, PublicKeyToken=31bf3856ad364e35'`
