### PR TITLE
Do not fall back to legacy dependency resolution logic if `deps.json` file exists.

### DIFF
--- a/documentation/wiki/ChangeWaves.md
+++ b/documentation/wiki/ChangeWaves.md
@@ -24,6 +24,9 @@ A wave of features is set to "rotate out" (i.e. become standard functionality) t
 
 ## Current Rotation of Change Waves
 
+### 18.0
+- [Do not fall back to legacy dependency resolution logic if `.deps.json` file exists.](https://github.com/dotnet/msbuild/pull/12496)
+
 ### 17.14
 - ~[.SLNX support - use the new parser for .sln and .slnx](https://github.com/dotnet/msbuild/pull/10836)~ reverted after compat problems discovered
 - ~~[Support custom culture in RAR](https://github.com/dotnet/msbuild/pull/11000)~~ - see [11607](https://github.com/dotnet/msbuild/pull/11607) for details

--- a/src/Framework/ChangeWaves.cs
+++ b/src/Framework/ChangeWaves.cs
@@ -30,7 +30,8 @@ namespace Microsoft.Build.Framework
         internal static readonly Version Wave17_10 = new Version(17, 10);
         internal static readonly Version Wave17_12 = new Version(17, 12);
         internal static readonly Version Wave17_14 = new Version(17, 14);
-        internal static readonly Version[] AllWaves = { Wave17_10, Wave17_12, Wave17_14 };
+        internal static readonly Version Wave18_0 = new Version(18, 0);
+        internal static readonly Version[] AllWaves = { Wave17_10, Wave17_12, Wave17_14, Wave18_0 };
 
         /// <summary>
         /// Special value indicating that all features behind all Change Waves should be enabled.

--- a/src/Shared/MSBuildLoadContext.cs
+++ b/src/Shared/MSBuildLoadContext.cs
@@ -55,10 +55,14 @@ namespace Microsoft.Build.Shared
             }
 
             // respect plugin.dll.json with the AssemblyDependencyResolver
-            string? assemblyPath = _resolver?.ResolveAssemblyToPath(assemblyName);
-            if (assemblyPath != null)
-            {
-                return LoadFromAssemblyPath(assemblyPath);
+            if (_resolver is not null)
+            { 
+                string? assemblyPath = _resolver.ResolveAssemblyToPath(assemblyName);
+                if (assemblyPath != null)
+                {
+                    return LoadFromAssemblyPath(assemblyPath);
+                }
+                return null;
             }
 
             // Fall back to the older MSBuild-on-Core behavior to continue to support

--- a/src/Shared/MSBuildLoadContext.cs
+++ b/src/Shared/MSBuildLoadContext.cs
@@ -6,6 +6,7 @@ using System.Collections.Immutable;
 using System.IO;
 using System.Reflection;
 using System.Runtime.Loader;
+using Microsoft.Build.Framework;
 using Microsoft.Build.Shared.FileSystem;
 
 namespace Microsoft.Build.Shared
@@ -63,7 +64,10 @@ namespace Microsoft.Build.Shared
                     return LoadFromAssemblyPath(assemblyPath);
                 }
 
-                return null;
+                if (ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave18_0))
+                {
+                    return null;
+                }
             }
 
             // Fall back to the older MSBuild-on-Core behavior to continue to support

--- a/src/Shared/MSBuildLoadContext.cs
+++ b/src/Shared/MSBuildLoadContext.cs
@@ -56,12 +56,13 @@ namespace Microsoft.Build.Shared
 
             // respect plugin.dll.json with the AssemblyDependencyResolver
             if (_resolver is not null)
-            { 
+            {
                 string? assemblyPath = _resolver.ResolveAssemblyToPath(assemblyName);
                 if (assemblyPath != null)
                 {
                     return LoadFromAssemblyPath(assemblyPath);
                 }
+
                 return null;
             }
 


### PR DESCRIPTION
Fixes #12495.