### PR TITLE
Add multithreaded mode information to build telemetry

### DIFF
--- a/src/Build.UnitTests/BackEnd/KnownTelemetry_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/KnownTelemetry_Tests.cs
@@ -48,6 +48,9 @@ public class KnownTelemetry_Tests
         buildTelemetry.BuildSuccess.ShouldBeNull();
         buildTelemetry.BuildTarget.ShouldBeNull();
         buildTelemetry.BuildEngineVersion.ShouldBeNull();
+        buildTelemetry.BuildCheckEnabled.ShouldBeNull();
+        buildTelemetry.MultiThreadedModeEnabled.ShouldBeNull();
+        buildTelemetry.SACEnabled.ShouldBeNull();
 
         buildTelemetry.GetProperties().ShouldBeEmpty();
     }
@@ -73,10 +76,13 @@ public class KnownTelemetry_Tests
         buildTelemetry.BuildSuccess = true;
         buildTelemetry.BuildTarget = "clean";
         buildTelemetry.BuildEngineVersion = new Version(1, 2, 3, 4);
+        buildTelemetry.BuildCheckEnabled = true;
+        buildTelemetry.MultiThreadedModeEnabled = false;
+        buildTelemetry.SACEnabled = true;
 
         var properties = buildTelemetry.GetProperties();
 
-        properties.Count.ShouldBe(11);
+        properties.Count.ShouldBe(14);
 
         properties["BuildEngineDisplayVersion"].ShouldBe("Some Display Version");
         properties["BuildEngineFrameworkName"].ShouldBe("new .NET");
@@ -87,6 +93,9 @@ public class KnownTelemetry_Tests
         properties["BuildSuccess"].ShouldBe("True");
         properties["BuildTarget"].ShouldBe("clean");
         properties["BuildEngineVersion"].ShouldBe("1.2.3.4");
+        properties["BuildCheckEnabled"].ShouldBe("True");
+        properties["MultiThreadedModeEnabled"].ShouldBe("False");
+        properties["SACEnabled"].ShouldBe("True");
 
         // verify computed
         properties["BuildDurationInMilliseconds"] = (finishedAt - startAt).TotalMilliseconds.ToString(CultureInfo.InvariantCulture);

--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -1120,6 +1120,7 @@ namespace Microsoft.Build.Execution
                             _buildTelemetry.BuildEngineHost = host;
 
                             _buildTelemetry.BuildCheckEnabled = _buildParameters!.IsBuildCheckEnabled;
+                            _buildTelemetry.MultiThreadedModeEnabled = _buildParameters!.MultiThreaded;
                             var sacState = NativeMethodsShared.GetSACState();
                             // The Enforcement would lead to build crash - but let's have the check for completeness sake.
                             _buildTelemetry.SACEnabled = sacState == NativeMethodsShared.SAC_State.Evaluation || sacState == NativeMethodsShared.SAC_State.Enforcement;

--- a/src/Framework/Telemetry/BuildTelemetry.cs
+++ b/src/Framework/Telemetry/BuildTelemetry.cs
@@ -80,6 +80,11 @@ namespace Microsoft.Build.Framework.Telemetry
         public bool? BuildCheckEnabled { get; set; }
 
         /// <summary>
+        /// True if multithreaded mode was enabled.
+        /// </summary>
+        public bool? MultiThreadedModeEnabled { get; set; }
+
+        /// <summary>
         /// True if Smart Application Control was enabled.
         /// </summary>
         public bool? SACEnabled { get; set; }
@@ -160,6 +165,11 @@ namespace Microsoft.Build.Framework.Telemetry
                 properties[nameof(BuildCheckEnabled)] = BuildCheckEnabled.Value.ToString(CultureInfo.InvariantCulture);
             }
 
+            if (MultiThreadedModeEnabled != null)
+            {
+                properties[nameof(MultiThreadedModeEnabled)] = MultiThreadedModeEnabled.Value.ToString(CultureInfo.InvariantCulture);
+            }
+
             if (SACEnabled != null)
             {
                 properties[nameof(SACEnabled)] = SACEnabled.Value.ToString(CultureInfo.InvariantCulture);
@@ -209,6 +219,11 @@ namespace Microsoft.Build.Framework.Telemetry
             if (BuildCheckEnabled != null)
             {
                 telemetryItems.Add(new TelemetryItem(nameof(BuildCheckEnabled), BuildCheckEnabled, false));
+            }
+
+            if (MultiThreadedModeEnabled != null)
+            {
+                telemetryItems.Add(new TelemetryItem(nameof(MultiThreadedModeEnabled), MultiThreadedModeEnabled, false));
             }
 
             if (SACEnabled != null)


### PR DESCRIPTION
Partially fixes #12507

Adding basic telemetry for multithreaded MSBuild: 
- emit information whether the multithreading is enabled or not. 