### PR TITLE
Add multithreaded mode indication to telemetry documentation

### DIFF
--- a/documentation/wiki/CollectedTelemetry.md
+++ b/documentation/wiki/CollectedTelemetry.md
@@ -91,4 +91,4 @@ Expressed and collected via [BuildTelemetry type](https://github.com/dotnet/msbu
 | All          | Version of MSBuild. |
 | >= 9.0.100   | Indication of enablement of BuildCheck feature. |
 | >= 9.0.100   | Indication of Smart App Control being in evaluation mode on machine executing the build. |
-| >= 10.0.100  | If the build was run in multithreaded mode or not |
+| >= 10.0.100  | Indication if the build was run in multithreaded mode. |

--- a/documentation/wiki/CollectedTelemetry.md
+++ b/documentation/wiki/CollectedTelemetry.md
@@ -91,3 +91,4 @@ Expressed and collected via [BuildTelemetry type](https://github.com/dotnet/msbu
 | All          | Version of MSBuild. |
 | >= 9.0.100   | Indication of enablement of BuildCheck feature. |
 | >= 9.0.100   | Indication of Smart App Control being in evaluation mode on machine executing the build. |
+| >= 10.0.100  | If the build was run in multithreaded mode or not |


### PR DESCRIPTION
Just a quick change to sync this now that https://github.com/dotnet/msbuild/pull/12508 is merged.