### PR TITLE
Avoid closure allocation in CastItemsOneByOne

### DIFF
--- a/src/Build/Utilities/Utilities.cs
+++ b/src/Build/Utilities/Utilities.cs
@@ -881,7 +881,7 @@ namespace Microsoft.Build.Internal
                 }
 
                 // if itemTypeNameToFetch was not set - then return all items
-                if (itemValue != null && (itemTypeNamesToFetch == null || itemTypeNamesToFetch.Any(tp => MSBuildNameIgnoreCaseComparer.Default.Equals(itemType, tp))))
+                if (itemValue != null && (itemTypeNamesToFetch == null || MatchesAnyItemTypeToFetch(itemTypeNamesToFetch, itemType)))
                 {
                     // The ProjectEvaluationFinishedEventArgs.Items are currently assigned only in Evaluator.Evaluate()
                     //  where the only types that can be assigned are ProjectItem or ProjectItemInstance
@@ -889,6 +889,20 @@ namespace Microsoft.Build.Internal
                     //  (see xml comments of TaskItemData for details)
                     yield return new ItemData(itemType!, itemValue);
                 }
+            }
+
+            // PERF: This replaces a previous call to Any() that was causing an allocation due to a closure.
+            static bool MatchesAnyItemTypeToFetch(string[] itemTypeNamesToFetch, string itemType)
+            {
+                foreach (string tp in itemTypeNamesToFetch)
+                {
+                    if (MSBuildNameIgnoreCaseComparer.Default.Equals(itemType, tp))
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
             }
         }
     }


### PR DESCRIPTION
Fixes #

### Context

The `Any()` call here requires capturing `itemType` which leads to a meaningful number of allocations here. In OrchardCore, this is ~55MB.

<img width="884" height="288" alt="image" src="https://github.com/user-attachments/assets/3d762b02-5bcf-4ebb-8443-34ec063eb18e" />


### Changes Made

Introducing a static local method lets us avoid the allocation by passing in the required state rather than creating a capture.

### Testing


### Notes
