### PR TITLE
Avoid boxing DictionaryEntry through IEnumerator.

### DIFF
--- a/src/Build/Utilities/Utilities.cs
+++ b/src/Build/Utilities/Utilities.cs
@@ -853,41 +853,65 @@ namespace Microsoft.Build.Internal
         /// <returns></returns>
         private static IEnumerable<ItemData> CastItemsOneByOne(IEnumerable items, string[] itemTypeNamesToFetch)
         {
-            foreach (var item in items)
+            IEnumerator enumerator = items.GetEnumerator();
+            if (enumerator is List<DictionaryEntry>.Enumerator listEnumerator)
             {
-                string itemType = default;
-                object itemValue = null;
+                while (listEnumerator.MoveNext())
+                {
+                    DictionaryEntry dictionaryEntry = listEnumerator.Current;
+                    string itemType = dictionaryEntry.Key as string;
+                    object itemValue = dictionaryEntry.Value;
 
-                if (item is IItem iitem)
-                {
-                    itemType = iitem.Key;
-                    itemValue = iitem;
-                }
-                else if (item is DictionaryEntry dictionaryEntry)
-                {
-                    itemType = dictionaryEntry.Key as string;
-                    itemValue = dictionaryEntry.Value;
-                }
-                else
-                {
-                    if (item == null)
+                    // if itemTypeNameToFetch was not set - then return all items
+                    if (itemValue != null && (itemTypeNamesToFetch == null || itemTypeNamesToFetch.Any(tp => MSBuildNameIgnoreCaseComparer.Default.Equals(itemType, tp))))
                     {
-                        Debug.Fail($"In {nameof(EnumerateItems)}(): Unexpected: {nameof(item)} is null");
+                        // The ProjectEvaluationFinishedEventArgs.Items are currently assigned only in Evaluator.Evaluate()
+                        //  where the only types that can be assigned are ProjectItem or ProjectItemInstance
+                        // However! NodePacketTranslator and BuildEventArgsReader might deserialize those as TaskItemData
+                        //  (see xml comments of TaskItemData for details)
+                        yield return new ItemData(itemType!, itemValue);
+                    }
+                }
+            }
+            else
+            {
+                while (enumerator.MoveNext())
+                {
+                    object item = enumerator.Current;
+                    string itemType = default;
+                    object itemValue = null;
+
+                    if (item is IItem iitem)
+                    {
+                        itemType = iitem.Key;
+                        itemValue = iitem;
+                    }
+                    else if (item is DictionaryEntry dictionaryEntry)
+                    {
+                        itemType = dictionaryEntry.Key as string;
+                        itemValue = dictionaryEntry.Value;
                     }
                     else
                     {
-                        Debug.Fail($"In {nameof(EnumerateItems)}(): Unexpected {nameof(item)} {item} of type {item?.GetType().ToString()}");
+                        if (item == null)
+                        {
+                            Debug.Fail($"In {nameof(EnumerateItems)}(): Unexpected: {nameof(item)} is null");
+                        }
+                        else
+                        {
+                            Debug.Fail($"In {nameof(EnumerateItems)}(): Unexpected {nameof(item)} {item} of type {item?.GetType().ToString()}");
+                        }
                     }
-                }
 
-                // if itemTypeNameToFetch was not set - then return all items
-                if (itemValue != null && (itemTypeNamesToFetch == null || itemTypeNamesToFetch.Any(tp => MSBuildNameIgnoreCaseComparer.Default.Equals(itemType, tp))))
-                {
-                    // The ProjectEvaluationFinishedEventArgs.Items are currently assigned only in Evaluator.Evaluate()
-                    //  where the only types that can be assigned are ProjectItem or ProjectItemInstance
-                    // However! NodePacketTranslator and BuildEventArgsReader might deserialize those as TaskItemData
-                    //  (see xml comments of TaskItemData for details)
-                    yield return new ItemData(itemType!, itemValue);
+                    // if itemTypeNameToFetch was not set - then return all items
+                    if (itemValue != null && (itemTypeNamesToFetch == null || itemTypeNamesToFetch.Any(tp => MSBuildNameIgnoreCaseComparer.Default.Equals(itemType, tp))))
+                    {
+                        // The ProjectEvaluationFinishedEventArgs.Items are currently assigned only in Evaluator.Evaluate()
+                        //  where the only types that can be assigned are ProjectItem or ProjectItemInstance
+                        // However! NodePacketTranslator and BuildEventArgsReader might deserialize those as TaskItemData
+                        //  (see xml comments of TaskItemData for details)
+                        yield return new ItemData(itemType!, itemValue);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Fixes #

### Context

By processing items in `CastItemsOneByOne()` through the non-generic `IEnumerable` interface, underlying value types can be boxed since the `Current` property is of type `object`. This results in ~70MB of allocations when building OrchardCore

<img width="1553" height="251" alt="image" src="https://github.com/user-attachments/assets/3df54f7a-1d19-46c2-a570-d08bd70d582d" />

What adds a bit of awkwardness to the fix is that the `List` enumerator is exposed via the `CopyOnReadEnumerable.GetEnumerator()` call.

        public IEnumerator<TResult> GetEnumerator()
        {
            List<TResult> list;

    #if NET
            if (_backingEnumerable.TryGetNonEnumeratedCount(out int count))
            {
    #else
            if (_backingEnumerable is ICollection backingCollection)
            {
                int count = backingCollection.Count;
    #endif
                list = new List<TResult>(count);
            }
            else if (_backingEnumerable is IReadOnlyCollection<TSource> readOnlyCollection)
            {
                list = new List<TResult>(readOnlyCollection.Count);
            }
            else
            {
                list = new List<TResult>();
            }

            lock (_syncRoot)
            {
                list.AddRange(_backingEnumerable.Select(_selector));
            }

            return list.GetEnumerator();
        }


`CopyOnReadEnumerable` has two generic type parameters. This means that directly casting the input `IEnumerable` to `CopyOnReadEnumerable` is a bit more brittle since both type parameters need to match to cast successfully, so I opted to check the type of the enumerator to cover more scenarios. From some brief investigation, it looks like the type parameters used are limited, but I wasn't able to guarantee this.



### Changes Made


### Testing


### Notes
