### PR TITLE
Avoid boxing allocations for creation of error message in non-error cases

### DIFF
--- a/src/Build/BackEnd/Components/BuildRequestEngine/BuildRequestEntry.cs
+++ b/src/Build/BackEnd/Components/BuildRequestEngine/BuildRequestEntry.cs
@@ -305,7 +305,7 @@ namespace Microsoft.Build.BackEnd
                 ErrorUtilities.VerifyThrowArgumentNull(result);
 
                 // PERF: Check the condition and then throw rather than using VerifyThrow to avoid the allocations that happen when boxing the message arguments.
-                if (State == BuildRequestEntryState.Waiting || _outstandingRequests == null)
+                if (!(State == BuildRequestEntryState.Waiting || _outstandingRequests == null))
                 {
                     ErrorUtilities.ThrowInternalError("Entry must be in the Waiting state to report results, or we must have flushed our requests due to an error. Config: {0} State: {1} Requests: {2}", RequestConfiguration.ConfigurationId, State, _outstandingRequests != null);
                 }

--- a/src/Build/BackEnd/Components/BuildRequestEngine/BuildRequestEntry.cs
+++ b/src/Build/BackEnd/Components/BuildRequestEngine/BuildRequestEntry.cs
@@ -303,7 +303,12 @@ namespace Microsoft.Build.BackEnd
             lock (GlobalLock)
             {
                 ErrorUtilities.VerifyThrowArgumentNull(result);
-                ErrorUtilities.VerifyThrow(State == BuildRequestEntryState.Waiting || _outstandingRequests == null, "Entry must be in the Waiting state to report results, or we must have flushed our requests due to an error. Config: {0} State: {1} Requests: {2}", RequestConfiguration.ConfigurationId, State, _outstandingRequests != null);
+
+                // PERF: Check the condition and then throw rather than using VerifyThrow to avoid the allocations that happen when boxing the message arguments.
+                if (State == BuildRequestEntryState.Waiting || _outstandingRequests == null)
+                {
+                    ErrorUtilities.ThrowInternalError("Entry must be in the Waiting state to report results, or we must have flushed our requests due to an error. Config: {0} State: {1} Requests: {2}", RequestConfiguration.ConfigurationId, State, _outstandingRequests != null);
+                }
 
                 // If the matching request is in the issue list, remove it so we don't try to ask for it to be built.
                 if (_requestsToIssue != null)


### PR DESCRIPTION


Fixes #

### Context

With the current way the code is constructed, the parameters for the error message in `ReportResult()` end up getting boxed even if they never end up getting used. By expanding this a little and guarding the call based on the error condition, we only pay the allocation cost in the error state.

There are ~11MB of allocations due to the types being boxed.
<img width="1256" height="457" alt="image" src="https://github.com/user-attachments/assets/80fe3271-5198-4c52-9f2a-43dfb88ad58d" />


### Changes Made


### Testing


### Notes
