### PR TITLE
Reuse static delegate rather than create a new one each call

### DIFF
--- a/src/Build/BackEnd/Components/Communications/LogMessagePacket.cs
+++ b/src/Build/BackEnd/Components/Communications/LogMessagePacket.cs
@@ -19,11 +19,13 @@ namespace Microsoft.Build.BackEnd
     /// </summary>
     internal class LogMessagePacket : LogMessagePacketBase
     {
+        private static readonly TargetFinishedTranslator targetFinishedTranslator = new TargetFinishedTranslator(TranslateTargetFinishedEvent);
+
         /// <summary>
         /// Encapsulates the buildEventArg in this packet.
         /// </summary>
         internal LogMessagePacket(KeyValuePair<int, BuildEventArgs>? nodeBuildEvent)
-            : base(nodeBuildEvent, new TargetFinishedTranslator(TranslateTargetFinishedEvent))
+            : base(nodeBuildEvent, targetFinishedTranslator)
         {
         }
 
@@ -31,7 +33,7 @@ namespace Microsoft.Build.BackEnd
         /// Constructor for deserialization
         /// </summary>
         private LogMessagePacket(ITranslator translator)
-            : base(translator, new TargetFinishedTranslator(TranslateTargetFinishedEvent))
+            : base(translator, targetFinishedTranslator)
         {
         }
 


### PR DESCRIPTION
Fixes #

### Context

The constructors for `LogMessagePacket` allocate a new `TargetFinishedTranslator` delegate for each call. The delegate function is static already, so this can be cached to avoid the repeated allocations. There are ~22MB of allocations total from two separate paths.

<img width="1120" height="322" alt="image" src="https://github.com/user-attachments/assets/896ae734-5aba-40a7-895e-9472c0556c68" />


### Changes Made


### Testing


### Notes
