### PR TITLE
[ClickOnce] Add support for SHA384 and SHA512 signing for ClickOnce apps

### DIFF
--- a/src/Tasks/ManifestUtil/RSAPKCS1SHA384SignatureDescription.cs
+++ b/src/Tasks/ManifestUtil/RSAPKCS1SHA384SignatureDescription.cs
@@ -1,0 +1,51 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Security.Cryptography;
+
+#nullable disable
+
+namespace System.Deployment.Internal.CodeSigning
+{
+    [SuppressMessage("Microsoft.Naming", "CA1709:IdentifiersShouldBeCasedCorrectly", MessageId = "RSAPKCS", Justification = "This casing is to match the existing RSAPKCS1SHA256SignatureDescription type")]
+    [SuppressMessage("Microsoft.Naming", "CA1709:IdentifiersShouldBeCasedCorrectly", MessageId = "SHA", Justification = "This casing is to match the use of SHA throughout the framework")]
+    public sealed class RSAPKCS1SHA384SignatureDescription : SignatureDescription
+    {
+        public RSAPKCS1SHA384SignatureDescription()
+        {
+            KeyAlgorithm = typeof(RSACryptoServiceProvider).FullName;
+#if RUNTIME_TYPE_NETCORE
+            DigestAlgorithm = typeof(SHA384).FullName;
+#else
+            DigestAlgorithm = typeof(SHA384Cng).FullName;
+#endif
+            FormatterAlgorithm = typeof(RSAPKCS1SignatureFormatter).FullName;
+            DeformatterAlgorithm = typeof(RSAPKCS1SignatureDeformatter).FullName;
+        }
+
+        public override AsymmetricSignatureDeformatter CreateDeformatter(AsymmetricAlgorithm key)
+        {
+            if (key == null)
+            {
+                throw new ArgumentNullException(nameof(key));
+            }
+
+            RSAPKCS1SignatureDeformatter deformatter = new RSAPKCS1SignatureDeformatter(key);
+            deformatter.SetHashAlgorithm("SHA384");
+            return deformatter;
+        }
+
+        public override AsymmetricSignatureFormatter CreateFormatter(AsymmetricAlgorithm key)
+        {
+            if (key == null)
+            {
+                throw new ArgumentNullException(nameof(key));
+            }
+
+            RSAPKCS1SignatureFormatter formatter = new RSAPKCS1SignatureFormatter(key);
+            formatter.SetHashAlgorithm("SHA384");
+            return formatter;
+        }
+    }
+}

--- a/src/Tasks/ManifestUtil/RSAPKCS1SHA512SignatureDescription.cs
+++ b/src/Tasks/ManifestUtil/RSAPKCS1SHA512SignatureDescription.cs
@@ -1,0 +1,51 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Security.Cryptography;
+
+#nullable disable
+
+namespace System.Deployment.Internal.CodeSigning
+{
+    [SuppressMessage("Microsoft.Naming", "CA1709:IdentifiersShouldBeCasedCorrectly", MessageId = "RSAPKCS", Justification = "This casing is to match the existing RSAPKCS1SHA1SignatureDescription type")]
+    [SuppressMessage("Microsoft.Naming", "CA1709:IdentifiersShouldBeCasedCorrectly", MessageId = "SHA", Justification = "This casing is to match the use of SHA throughout the framework")]
+    public sealed class RSAPKCS1SHA512SignatureDescription : SignatureDescription
+    {
+        public RSAPKCS1SHA512SignatureDescription()
+        {
+            KeyAlgorithm = typeof(RSACryptoServiceProvider).FullName;
+#if RUNTIME_TYPE_NETCORE
+            DigestAlgorithm = typeof(SHA512).FullName;
+#else
+            DigestAlgorithm = typeof(SHA512Cng).FullName;
+#endif
+            FormatterAlgorithm = typeof(RSAPKCS1SignatureFormatter).FullName;
+            DeformatterAlgorithm = typeof(RSAPKCS1SignatureDeformatter).FullName;
+        }
+
+        public override AsymmetricSignatureDeformatter CreateDeformatter(AsymmetricAlgorithm key)
+        {
+            if (key == null)
+            {
+                throw new ArgumentNullException(nameof(key));
+            }
+
+            RSAPKCS1SignatureDeformatter deformatter = new RSAPKCS1SignatureDeformatter(key);
+            deformatter.SetHashAlgorithm("SHA512");
+            return deformatter;
+        }
+
+        public override AsymmetricSignatureFormatter CreateFormatter(AsymmetricAlgorithm key)
+        {
+            if (key == null)
+            {
+                throw new ArgumentNullException(nameof(key));
+            }
+
+            RSAPKCS1SignatureFormatter formatter = new RSAPKCS1SignatureFormatter(key);
+            formatter.SetHashAlgorithm("SHA512");
+            return formatter;
+        }
+    }
+}


### PR DESCRIPTION
Fixes #

### Context
ClickOnce does not support signing it payload with SHA384 and SHA512 certs.

### Changes Made
Added support for signing with SHA384 and SHA512 cert instead of defaulting to SHA256 for .NET 4.X apps.

### Testing
Ongoing

### Notes
