### PR TITLE
Add try/catch to prevent ArgumentOutOfRangeException in BuildEventArgsWriter.WriteArguments

### DIFF
--- a/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
@@ -777,7 +777,7 @@ namespace Microsoft.Build.Logging
                     // - We can't control the threading behavior of the objects passed to us
                     // - The corruption typically happens before objects reach this method
                     // - Defensive exception handling is more efficient than preemptive locking
-                    argument = arguments[i]?.GetType().Name ?? "<null>";
+                    argument = arguments[i]?.GetType()?.Name ?? "<null>";
                 }
 
                 WriteDeduplicatedString(argument);

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
@@ -777,7 +777,7 @@ namespace Microsoft.Build.Logging
                     // - We can't control the threading behavior of the objects passed to us
                     // - The corruption typically happens before objects reach this method
                     // - Defensive exception handling is more efficient than preemptive locking
-                    argument = arguments[i]?.GetType()?.Name ?? "<null>";
+                    argument = $"Exception encountered writing an object of type {arguments[i]?.GetType()?.Name ?? "<null>"}";
                 }
 
                 WriteDeduplicatedString(argument);

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
@@ -756,7 +756,30 @@ namespace Microsoft.Build.Logging
             Write(count);
             for (int i = 0; i < count; i++)
             {
-                string argument = Convert.ToString(arguments[i], CultureInfo.CurrentCulture);
+                string argument;
+                try
+                {
+                    argument = Convert.ToString(arguments[i], CultureInfo.CurrentCulture);
+                }
+                catch (Exception ex) when (ex is ArgumentOutOfRangeException or InvalidOperationException)
+                {
+                    // Handle cases where the object's ToString() method fails due to internal state corruption.
+                    // This commonly occurs with StringBuilder when:
+                    // 1. Race conditions: Multiple threads modify StringBuilder without synchronization, causing
+                    //    internal fields (m_ChunkLength, m_ChunkOffset) to become inconsistent with the actual
+                    //    character array, leading to range exceptions in ToString()
+                    // 2. Memory corruption: Unsafe code or interop operations corrupt StringBuilder's internal state
+                    // 3. Reflection abuse: Direct modification of private fields creates invalid object state
+                    // 4. Serialization issues: Deserialized objects with inconsistent internal field values
+                    //
+                    // Adding synchronization would be prohibitively expensive here since:
+                    // - This is called frequently during build logging (performance critical path)
+                    // - We can't control the threading behavior of the objects passed to us
+                    // - The corruption typically happens before objects reach this method
+                    // - Defensive exception handling is more efficient than preemptive locking
+                    argument = arguments[i]?.GetType().Name ?? "<null>";
+                }
+
                 WriteDeduplicatedString(argument);
             }
         }


### PR DESCRIPTION
## Fixes
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2421790/?view=edit

## Context
The Retail Build Validation (DartLab) CI pipeline has been experiencing intermittent MSB4017 logger failures with ArgumentOutOfRangeException: Index was out of range. Must be non-negative and less than the size of the collection in BuildEventArgsWriter.WriteArguments(). The error occurs when Convert.ToString() is called on objects with corrupted internal state, particularly StringBuilder instances with inconsistent internal fields (m_ChunkLength, m_ChunkOffset) due to race conditions, memory corruption, or unsafe code in build tasks.

## Changes Made
Added defensive exception handling in WriteArguments() method to catch ArgumentOutOfRangeException and InvalidOperationException when converting arguments to strings. When corruption is detected, the method now logs the object type name instead of failing the entire build. 

This approach was chosen over synchronization because this is a performance-critical logging path called frequently during builds