### PR TITLE
Exit DrainPacketQueue thread when build completes.

### DIFF
--- a/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
@@ -851,16 +851,14 @@ namespace Microsoft.Build.BackEnd
                                 serverToClientStream.Write(writeStreamBuffer, i, lengthToWrite);
                             }
 
-                            if (IsExitPacket(packet))
-                            {
-                                context._exitPacketState = ExitPacketState.ExitPacketSent;
-                                context._packetQueueDrainDelayCancellation.Cancel();
-
-                                return;
-                            }
-
                             if (packet is NodeBuildComplete)
                             {
+                                if (IsExitPacket(packet))
+                                {
+                                    context._exitPacketState = ExitPacketState.ExitPacketSent;
+                                    context._packetQueueDrainDelayCancellation.Cancel();
+                                }
+
                                 return;
                             }
                         }


### PR DESCRIPTION
Fixes #

### Context

Currently, the dedicated thread that handles processing the packet queue doesn't exit properly when build finishes. The threads are idle, but repeated builds create a new thread each time and they accumulate during the session:

<img width="1058" height="185" alt="image" src="https://github.com/user-attachments/assets/a93a2d90-c1e3-4146-994b-9d6172ff6e4e" />

The check for `IsExitPacket()` is slightly misleading since it checks for more than just the completion of the build

            private static bool IsExitPacket(INodePacket packet)
            {
                return packet is NodeBuildComplete buildCompletePacket && !buildCompletePacket.PrepareForReuse;
            }

By explicitly checking for the `NodeBuildComplete` packet, we can exit the processing loop and let the thread get cleaned up. Additionally, I named the dedicated thread to help identify issues like this in the future.

### Changes Made


### Testing


### Notes
