### PR TITLE
Optimize for single capture case

### DIFF
--- a/src/Build/Evaluation/ExpressionShredder.cs
+++ b/src/Build/Evaluation/ExpressionShredder.cs
@@ -179,7 +179,8 @@ namespace Microsoft.Build.Evaluation
                             int endQuoted = currentIndex - 1;
                             if (transformExpressions == null)
                             {
-                                transformExpressions = new List<ItemExpressionCapture>();
+                                // PERF: Almost all expressions have only one capture, so optimize for that case
+                                transformExpressions = new List<ItemExpressionCapture>(1);
                             }
 
                             transformExpressions.Add(new ItemExpressionCapture(startQuoted, endQuoted - startQuoted, expression.Substring(startQuoted, endQuoted - startQuoted)));
@@ -192,7 +193,8 @@ namespace Microsoft.Build.Evaluation
                         {
                             if (transformExpressions == null)
                             {
-                                transformExpressions = new List<ItemExpressionCapture>();
+                                // PERF: Almost all expressions have only one capture, so optimize for that case
+                                transformExpressions = new List<ItemExpressionCapture>(1);
                             }
 
                             transformExpressions.Add(functionCapture.Value);


### PR DESCRIPTION
Fixes #

### Context

In most cases, an expression will only have one capture. We can optimize for that case and avoid allocating a size 4 array (list default) just to hold one element.

Before:
<img width="1066" height="356" alt="image" src="https://github.com/user-attachments/assets/1c3b0737-ae05-495f-b587-27c2baeb6d71" />


After:
<img width="972" height="342" alt="image" src="https://github.com/user-attachments/assets/edc42036-2bf5-4f13-9b57-09efac0bd46a" />

This saves ~150MB

### Changes Made


### Testing


### Notes
