### PR TITLE
separate the tracking parts of TL into a reusable base, so that TL becomes a 'renderer'

### DIFF
--- a/src/Build/Logging/ProjectTrackingLoggerBase.cs
+++ b/src/Build/Logging/ProjectTrackingLoggerBase.cs
@@ -1,0 +1,430 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Build.Framework;
+
+namespace Microsoft.Build.Logging;
+
+/// <summary>
+/// A wrapper over the project context ID passed to us in <see cref="IEventSource"/> logger events.
+/// </summary>
+internal record struct ProjectContext(int Id)
+{
+    public ProjectContext(BuildEventContext context)
+        : this(context.ProjectContextId)
+    {
+    }
+}
+
+/// <summary>
+/// A wrapper over the evaluation context ID passed to us in <see cref="IEventSource"/> logger events.
+/// </summary>
+internal record struct EvalContext(int Id)
+{
+    public EvalContext(BuildEventContext context)
+        : this(context.EvaluationId)
+    {
+    }
+}
+
+/// <summary>
+/// Base class that tracks build state (evaluation data, node status, completed project data, and whole-build data) during builds.
+/// Subclasses can specialize the type of data tracked for each area and implement rendering logic.
+/// </summary>
+/// <typeparam name="TEvalData">Data gathered/projected for each evaluation context</typeparam>
+/// <typeparam name="TNodeData">Data stored for each live, actively running build worker node</typeparam>
+/// <typeparam name="TProjectData">Data stored for each completed project context instance</typeparam>
+/// <typeparam name="TBuildData">Data that is aggregated across the entire build session</typeparam>
+public abstract class ProjectTrackingLoggerBase<TEvalData, TNodeData, TProjectData, TBuildData> : INodeLogger
+{
+
+    /// <summary>
+    /// Tracks the evaluation data for all evaluations seen so far.
+    /// </summary>
+    /// <remarks>
+    /// Keyed by an ID that gets passed to logger callbacks, this allows us to quickly look up the corresponding evaluation.
+    /// </remarks>
+    private readonly Dictionary<EvalContext, TEvalData> _evaluationDataByEvalId = new();
+
+    /// <summary>
+    /// Tracks the status of all relevant projects seen so far.
+    /// </summary>
+    /// <remarks>
+    /// Keyed by an ID that gets passed to logger callbacks, this allows us to quickly look up the corresponding project.
+    /// </remarks>
+    private readonly Dictionary<ProjectContext, TProjectData> _projectDataByProjectContextId = new();
+
+    /// <summary>
+    /// Tracks build-level data for the entire build session.
+    /// </summary>
+    private TBuildData? _buildData;
+
+    #region INodeLogger implementation
+
+    /// <inheritdoc/>
+    public abstract LoggerVerbosity Verbosity { get; set; }
+
+    /// <inheritdoc/>
+    public abstract string? Parameters { get; set; }
+
+    /// <summary>
+    /// The number of nodes in the build. Handles the case where MSBUILDNOINPROCNODE is set by reserving an extra slot.
+    /// </summary>
+    protected int NodeCount { get; private set; }
+
+    /// <inheritdoc/>
+    public virtual void Initialize(IEventSource eventSource, int nodeCount)
+    {
+        // When MSBUILDNOINPROCNODE enabled, NodeId's reported by build start with 2. We need to reserve an extra spot for this case.
+        NodeCount = nodeCount + 1;
+
+        Initialize(eventSource);
+    }
+
+    /// <inheritdoc/>
+    public virtual void Initialize(IEventSource eventSource)
+    {
+        eventSource.BuildStarted += BuildStartedHandler;
+        eventSource.BuildFinished += BuildFinishedHandler;
+        eventSource.ProjectStarted += ProjectStartedHandler;
+        eventSource.ProjectFinished += ProjectFinishedHandler;
+        eventSource.TargetStarted += TargetStartedHandler;
+        eventSource.TargetFinished += TargetFinishedHandler;
+        eventSource.TaskStarted += TaskStartedHandler;
+        eventSource.StatusEventRaised += StatusEventRaisedHandler;
+        eventSource.MessageRaised += MessageRaisedHandler;
+        eventSource.WarningRaised += WarningRaisedHandler;
+        eventSource.ErrorRaised += ErrorRaisedHandler;
+
+        if (eventSource is IEventSource3 eventSource3)
+        {
+            eventSource3.IncludeTaskInputs();
+        }
+
+        if (eventSource is IEventSource4 eventSource4)
+        {
+            eventSource4.IncludeEvaluationPropertiesAndItems();
+        }
+    }
+
+    /// <inheritdoc/>
+    public abstract void Shutdown();
+
+    #endregion
+
+    #region Logger callbacks
+
+    /// <summary>
+    /// The <see cref="IEventSource.BuildStarted"/> callback.
+    /// </summary>
+    private void BuildStartedHandler(object sender, BuildStartedEventArgs e)
+    {
+        _buildData = CreateBuildData(e);
+        OnBuildStarted(e, _buildData);
+    }
+
+    /// <summary>
+    /// The <see cref="IEventSource.BuildFinished"/> callback.
+    /// </summary>
+    private void BuildFinishedHandler(object sender, BuildFinishedEventArgs e)
+    {
+        OnBuildFinished(e, _projectDataByProjectContextId.Values.ToArray(), _buildData!);
+
+        // Clear tracking data
+        _projectDataByProjectContextId.Clear();
+        _evaluationDataByEvalId.Clear();
+        _buildData = default;
+    }
+
+    /// <summary>
+    /// The <see cref="IEventSource.StatusEventRaised"/> callback.
+    /// </summary>
+    private void StatusEventRaisedHandler(object sender, BuildStatusEventArgs e)
+    {
+        switch (e)
+        {
+            case BuildCanceledEventArgs cancelEvent:
+                OnBuildCanceled(cancelEvent);
+                break;
+            case ProjectEvaluationStartedEventArgs:
+                break;
+            case ProjectEvaluationFinishedEventArgs evalFinish:
+                CaptureEvalContext(evalFinish);
+                break;
+        }
+    }
+
+    /// <summary>
+    /// The <see cref="IEventSource.ProjectStarted"/> callback.
+    /// </summary>
+    private void ProjectStartedHandler(object sender, ProjectStartedEventArgs e)
+    {
+        if (e.BuildEventContext is null)
+        {
+            return;
+        }
+
+        ProjectContext projectContext = new(e.BuildEventContext);
+        EvalContext evalContext = new(e.BuildEventContext);
+
+        // Get eval data for this project
+        if (_evaluationDataByEvalId.TryGetValue(evalContext, out TEvalData? evalData))
+        {
+            // Create project data using the eval data
+            TProjectData? projectData = CreateProjectData(evalData, e);
+            if (projectData != null)
+            {
+                _projectDataByProjectContextId[projectContext] = projectData;
+                OnProjectStarted(e, evalData, projectData!, _buildData!);
+            }
+        }
+    }
+
+    /// <summary>
+    /// The <see cref="IEventSource.ProjectFinished"/> callback.
+    /// </summary>
+    private void ProjectFinishedHandler(object sender, ProjectFinishedEventArgs e)
+    {
+        var buildEventContext = e.BuildEventContext;
+        if (buildEventContext is null)
+        {
+            return;
+        }
+
+        ProjectContext projectContext = new(buildEventContext);
+
+        // Get project data
+        if (_projectDataByProjectContextId.TryGetValue(projectContext, out var projectData))
+        {
+            OnProjectFinished(e, projectData, _buildData!);
+        }
+    }
+
+    /// <summary>
+    /// The <see cref="IEventSource.TargetStarted"/> callback.
+    /// </summary>
+    private void TargetStartedHandler(object sender, TargetStartedEventArgs e)
+    {
+        var buildEventContext = e.BuildEventContext;
+        if (buildEventContext is not null)
+        {
+            ProjectContext projectContext = new(buildEventContext);
+            if (_projectDataByProjectContextId.TryGetValue(projectContext, out TProjectData? projectData))
+            {
+                OnTargetStarted(e, projectData, _buildData!);
+            }
+        }
+    }
+
+    /// <summary>
+    /// The <see cref="IEventSource.TargetFinished"/> callback.
+    /// </summary>
+    private void TargetFinishedHandler(object sender, TargetFinishedEventArgs e)
+    {
+        var buildEventContext = e.BuildEventContext;
+        if (buildEventContext is null)
+        {
+            return;
+        }
+
+        ProjectContext projectContext = new(buildEventContext);
+        if (_projectDataByProjectContextId.TryGetValue(projectContext, out var projectData))
+        {
+            OnTargetFinished(e, projectData, _buildData!);
+        }
+    }
+
+    /// <summary>
+    /// The <see cref="IEventSource.TaskStarted"/> callback.
+    /// </summary>
+    private void TaskStartedHandler(object sender, TaskStartedEventArgs e)
+    {
+        var buildEventContext = e.BuildEventContext;
+        if (buildEventContext is not null)
+        {
+            ProjectContext projectContext = new(buildEventContext);
+            if (_projectDataByProjectContextId.TryGetValue(projectContext, out var projectData))
+            {
+                OnTaskStarted(e, projectData, _buildData!);
+            }
+        }
+    }
+
+    /// <summary>
+    /// The <see cref="IEventSource.MessageRaised"/> callback.
+    /// </summary>
+    private void MessageRaisedHandler(object sender, BuildMessageEventArgs e)
+    {
+        var buildEventContext = e.BuildEventContext;
+        if (buildEventContext is null)
+        {
+            return;
+        }
+
+        ProjectContext projectContext = new(buildEventContext);
+        TProjectData? projectData = default;
+        _projectDataByProjectContextId.TryGetValue(projectContext, out projectData);
+        OnMessageRaised(e, projectData, _buildData!);
+    }
+
+    /// <summary>
+    /// The <see cref="IEventSource.WarningRaised"/> callback.
+    /// </summary>
+    private void WarningRaisedHandler(object sender, BuildWarningEventArgs e)
+    {
+        BuildEventContext? buildEventContext = e.BuildEventContext;
+        if (buildEventContext is null)
+        {
+            OnWarningRaised(e, default, _buildData!);
+            return;
+        }
+
+        ProjectContext projectContext = new(buildEventContext);
+        TProjectData? projectData = default;
+        _projectDataByProjectContextId.TryGetValue(projectContext, out projectData);
+        OnWarningRaised(e, projectData, _buildData!);
+    }
+
+    /// <summary>
+    /// The <see cref="IEventSource.ErrorRaised"/> callback.
+    /// </summary>
+    private void ErrorRaisedHandler(object sender, BuildErrorEventArgs e)
+    {
+        BuildEventContext? buildEventContext = e.BuildEventContext;
+        if (buildEventContext is null)
+        {
+            OnErrorRaised(e, default, _buildData!);
+            return;
+        }
+
+        ProjectContext projectContext = new(buildEventContext);
+        TProjectData? projectData = default;
+        _projectDataByProjectContextId.TryGetValue(projectContext, out projectData);
+        OnErrorRaised(e, projectData, _buildData!);
+    }
+
+    #endregion
+
+    #region Protected helpers
+
+    protected int? GetNodeIdForEvent(BuildEventArgs args) => args?.BuildEventContext is null ? null : NodeIndexForContext(args.BuildEventContext);
+
+    #endregion
+
+    #region Private helpers
+
+    private int NodeIndexForContext(BuildEventContext context)
+    {
+        // Node IDs reported by the build are 1-based.
+        return context.NodeId - 1;
+    }
+
+    /// <summary>
+    /// Captures evaluation context data from the evaluation finished event.
+    /// </summary>
+    private void CaptureEvalContext(ProjectEvaluationFinishedEventArgs evalFinish)
+    {
+        var buildEventContext = evalFinish.BuildEventContext;
+        if (buildEventContext is null)
+        {
+            return;
+        }
+
+        EvalContext evalContext = new(buildEventContext);
+
+        if (!_evaluationDataByEvalId.ContainsKey(evalContext))
+        {
+            TEvalData evalData = CreateEvalData(evalFinish);
+            _evaluationDataByEvalId[evalContext] = evalData;
+        }
+    }
+
+    #endregion
+
+    #region Abstract methods - must be implemented by subclasses
+
+    /// <summary>
+    /// Creates evaluation data from the evaluation finished event.
+    /// </summary>
+    /// <param name="e">The evaluation finished event args.</param>
+    /// <returns>The evaluation data to store, or null to not track this evaluation.</returns>
+    protected abstract TEvalData CreateEvalData(ProjectEvaluationFinishedEventArgs e);
+
+    /// <summary>
+    /// Creates project data from the project started event and evaluation data.
+    /// </summary>
+    /// <param name="evalData">The evaluation data for this project.</param>
+    /// <param name="e">The project started event args.</param>
+    /// <returns>The project data to store, or null to not track this project.</returns>
+    protected abstract TProjectData? CreateProjectData(TEvalData evalData, ProjectStartedEventArgs e);
+
+    /// <summary>
+    /// Creates build data when the build starts.
+    /// </summary>
+    /// <param name="e">The build started event args.</param>
+    /// <returns>The build data to track for this build session.</returns>
+    protected abstract TBuildData CreateBuildData(BuildStartedEventArgs e);
+
+    #endregion
+
+    #region Virtual methods - can be overridden by subclasses
+
+    /// <summary>
+    /// Called when the build starts.
+    /// </summary>
+    protected virtual void OnBuildStarted(BuildStartedEventArgs e, TBuildData buildData) { }
+
+    /// <summary>
+    /// Called when the build finishes.
+    /// </summary>
+    protected virtual void OnBuildFinished(BuildFinishedEventArgs e, TProjectData[] projectData, TBuildData buildData) { }
+
+    /// <summary>
+    /// Called when the build is canceled.
+    /// </summary>
+    protected virtual void OnBuildCanceled(BuildCanceledEventArgs e) { }
+
+    /// <summary>
+    /// Called when a project starts.
+    /// </summary>
+    protected virtual void OnProjectStarted(ProjectStartedEventArgs e, TEvalData evalData, TProjectData projectData, TBuildData buildData) { }
+
+    /// <summary>
+    /// Called when a project finishes.
+    /// </summary>
+    protected virtual void OnProjectFinished(ProjectFinishedEventArgs e, TProjectData projectData, TBuildData buildData) { }
+
+    /// <summary>
+    /// Called when a target starts.
+    /// </summary>
+    protected virtual void OnTargetStarted(TargetStartedEventArgs e, TProjectData projectData, TBuildData buildData) { }
+
+    /// <summary>
+    /// Called when a target finishes.
+    /// </summary>
+    protected virtual void OnTargetFinished(TargetFinishedEventArgs e, TProjectData projectData, TBuildData buildData) { }
+
+    /// <summary>
+    /// Called when a task starts.
+    /// </summary>
+    protected virtual void OnTaskStarted(TaskStartedEventArgs e, TProjectData projectData, TBuildData buildData) { }
+
+    /// <summary>
+    /// Called when a message is raised.
+    /// </summary>
+    protected virtual void OnMessageRaised(BuildMessageEventArgs e, TProjectData? projectData, TBuildData buildData) { }
+
+    /// <summary>
+    /// Called when a warning is raised.
+    /// </summary>
+    protected virtual void OnWarningRaised(BuildWarningEventArgs e, TProjectData? projectData, TBuildData buildData) { }
+
+    /// <summary>
+    /// Called when an error is raised.
+    /// </summary>
+    protected virtual void OnErrorRaised(BuildErrorEventArgs e, TProjectData? projectData, TBuildData buildData) { }
+
+    #endregion
+}

--- a/src/Build/Logging/TerminalLogger/StopwatchAbstraction.cs
+++ b/src/Build/Logging/TerminalLogger/StopwatchAbstraction.cs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.Build.Logging;
 
-internal abstract class StopwatchAbstraction
+public abstract class StopwatchAbstraction
 {
     public abstract void Start();
     public abstract void Stop();

--- a/src/Build/Logging/TerminalLogger/TerminalBuildData.cs
+++ b/src/Build/Logging/TerminalLogger/TerminalBuildData.cs
@@ -1,0 +1,51 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+namespace Microsoft.Build.Logging;
+
+/// <summary>
+/// Tracks build-level data for the TerminalLogger across an entire build session.
+/// </summary>
+public sealed class TerminalBuildData
+{
+    /// <summary>
+    /// The timestamp of the build start event.
+    /// </summary>
+    public DateTime BuildStartTime { get; set; }
+
+    /// <summary>
+    /// Number of build errors encountered during the build.
+    /// </summary>
+    public int BuildErrorsCount { get; set; }
+
+    /// <summary>
+    /// Number of build warnings encountered during the build.
+    /// </summary>
+    public int BuildWarningsCount { get; set; }
+
+    /// <summary>
+    /// The project build context corresponding to the Restore initial target, or null if the build is currently not restoring.
+    /// </summary>
+    public int? RestoreContext { get; set; }
+
+    /// <summary>
+    /// True if restore failed and this failure has already been reported.
+    /// </summary>
+    public bool RestoreFailed { get; set; }
+
+    /// <summary>
+    /// True if restore happened and finished.
+    /// </summary>
+    public bool RestoreFinished { get; set; }
+
+    /// <summary>
+    /// Initializes a new instance of TerminalBuildData.
+    /// </summary>
+    /// <param name="buildStartTime">The timestamp when the build started.</param>
+    public TerminalBuildData(DateTime buildStartTime)
+    {
+        BuildStartTime = buildStartTime;
+    }
+}

--- a/src/Build/Logging/TerminalLogger/TerminalBuildMessage.cs
+++ b/src/Build/Logging/TerminalLogger/TerminalBuildMessage.cs
@@ -6,5 +6,5 @@ namespace Microsoft.Build.Logging;
 /// <summary>
 /// Represents a piece of diagnostic output (message/warning/error).
 /// </summary>
-internal record struct TerminalBuildMessage(TerminalMessageSeverity Severity, string Message)
+public record struct TerminalBuildMessage(TerminalMessageSeverity Severity, string Message)
 { }

--- a/src/Build/Logging/TerminalLogger/TerminalMessageSeverity.cs
+++ b/src/Build/Logging/TerminalLogger/TerminalMessageSeverity.cs
@@ -6,4 +6,4 @@ namespace Microsoft.Build.Logging;
 /// <summary>
 /// Enumerates the supported message severities.
 /// </summary>
-internal enum TerminalMessageSeverity { Message, Warning, Error }
+public enum TerminalMessageSeverity { Message, Warning, Error }

--- a/src/Build/Logging/TerminalLogger/TerminalNodeStatus.cs
+++ b/src/Build/Logging/TerminalLogger/TerminalNodeStatus.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Build.Logging;
 /// <summary>
 /// Encapsulates the per-node data shown in live node output.
 /// </summary>
-internal class TerminalNodeStatus
+public class TerminalNodeStatus
 {
     public string Project { get; }
     public string? TargetFramework { get; }

--- a/src/Build/Logging/TerminalLogger/TerminalProjectInfo.cs
+++ b/src/Build/Logging/TerminalLogger/TerminalProjectInfo.cs
@@ -10,32 +10,25 @@ namespace Microsoft.Build.Logging;
 /// <summary>
 /// A struct containing relevant evaluation-time data that may not be knowable just from ProjectStart events.
 /// </summary>
-/// <param name="context"></param>
-/// <param name="ProjectFile"></param>
-/// <param name="TargetFramework"></param>
-/// <param name="RuntimeIdentifier"></param>
-internal record struct EvalProjectInfo(TerminalLogger.EvalContext context, string? ProjectFile, string? TargetFramework, string? RuntimeIdentifier)
+public record struct EvalProjectInfo(string? ProjectFile, string? TargetFramework, string? RuntimeIdentifier)
 {
-    public readonly int Id => context.Id;
 }
 
 /// <summary>
 /// Represents a project being built.
 /// </summary>
-internal sealed class TerminalProjectInfo
+public sealed class TerminalProjectInfo
 {
     private List<TerminalBuildMessage>? _buildMessages;
 
     /// <summary>
     /// Initialized a new <see cref="TerminalProjectInfo"/> with the given <paramref name="evalInfo"/> .
     /// </summary>
-    /// <param name="context">The ProjectContext of this project execution.</param>
     /// <param name="evalInfo">A subset of the interesting eval-time data for this running project</param>
     /// <param name="stopwatch">A stopwatch to time the build of the project.</param>
-    public TerminalProjectInfo(TerminalLogger.ProjectContext context, EvalProjectInfo evalInfo, StopwatchAbstraction? stopwatch)
+    public TerminalProjectInfo(EvalProjectInfo evalInfo, StopwatchAbstraction? stopwatch)
     {
         _evalInfo = evalInfo;
-        _context = context;
 
         if (stopwatch is not null)
         {
@@ -47,11 +40,6 @@ internal sealed class TerminalProjectInfo
             Stopwatch = SystemStopwatch.StartNew();
         }
     }
-
-    /// <summary>
-    /// The int value of the ProjectContext id of this project execution.
-    /// </summary>
-    public int Id => _context.Id;
 
     /// <summary>
     /// The full path to the project file.
@@ -82,7 +70,6 @@ internal sealed class TerminalProjectInfo
     /// The runtime identifier of the project or null if platform-agnostic.
     /// </summary>
     public string? RuntimeIdentifier => _evalInfo.RuntimeIdentifier;
-    private readonly TerminalLogger.ProjectContext _context;
     private readonly EvalProjectInfo _evalInfo;
 
     /// <summary>

--- a/src/Build/Microsoft.Build.csproj
+++ b/src/Build/Microsoft.Build.csproj
@@ -178,6 +178,7 @@
     <Compile Include="FileAccess\RequestedAccess.cs" />
     <Compile Include="Instance\IPropertyElementWithLocation.cs" />
     <Compile Include="Logging\BuildEventArgsExtensions.cs" />
+    <Compile Include="Logging\ProjectTrackingLoggerBase.cs" />
     <Compile Include="Logging\TerminalLogger\**\*.cs" />
     <Compile Include="Logging\ReusableLogger.cs" />
     <Compile Include="TelemetryInfra\InternalTelemetryConsumingLogger.cs" />

--- a/src/Framework/Logging/TerminalColor.cs
+++ b/src/Framework/Logging/TerminalColor.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Build.Framework.Logging;
 /// <summary>
 /// Enumerates the text colors supported by VT100 terminal.
 /// </summary>
-internal enum TerminalColor
+public enum TerminalColor
 {
     Black = 30,
     Red = 31,


### PR DESCRIPTION
This makes it easier to implement other Loggers - you just need to pick out what kinds of data you need from evaluation/projects, and then render warnings, errors, etc however you want during certain lifecycle events.  The thought is that all of the data required to track/associate/trigger the lifecycle warnings is kept by the 'tracker', so your use-case-specific logger can mostly ignore that.

This is low-priority ATM, but something that may be useful for us as we think about how Loggers might need to change to more easily react to LLMs and other tools. For example, @richlander has a prototype logger that emits markdown - I'm pretty sure that logger doesn't understand the relationship between 'outer' builds and 'inner' like TL does. If it built on this base and then it could more easily get that understanding for free.

I kind of think of this interface as a step towards a more user-friendly Logger programming model - for loggers that care about rendering the 'intent' of the build and reshaping/papering over MSBuild specifics in favor of a more user-centric model this base can hide a lot of the guts.