### PR TITLE
Avoid redefining AutoInsertTargetBranch

### DIFF
--- a/azure-pipelines/vs-insertion.yml
+++ b/azure-pipelines/vs-insertion.yml
@@ -68,7 +68,7 @@ variables:
   - name: AutoInsertTargetBranch
     ${{ if eq(variables['Build.SourceBranchName'], 'vs18.0') }}:
       value: 'rel/d18.0'
-    ${{ if eq(variables['Build.SourceBranchName'], 'vs17.14') }}:
+    ${{ elseif eq(variables['Build.SourceBranchName'], 'vs17.14') }}:
       value: 'rel/d17.14'
     ${{ elseif eq(variables['Build.SourceBranchName'], 'vs17.13') }}:
       value: 'rel/d17.13'


### PR DESCRIPTION
Fixes an error

    /azure-pipelines/vs-insertion.yml (Line: 94, Col: 7): 'value' is already defined

That arose because we needed an elseif after the new clause.
