### PR TITLE
Move version label next to version prefix

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -4,9 +4,9 @@
   <Import Project="Version.Details.props" Condition="Exists('Version.Details.props')" />
   <PropertyGroup>
     <VersionPrefix>18.1.0</VersionPrefix>
+    <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
     <PackageValidationBaselineVersion>18.0.0-preview-25480-115</PackageValidationBaselineVersion>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>
-    <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
 
     <!-- differentiate experimental insertions to avoid package id conflicts, 
      it has to be alphabetically after "preview" to avoid downgrade errors in VS -->


### PR DESCRIPTION
Moving version label near to version prefix hoping that we will introduce merge conflicts on version label when merging release branch to main. 

See https://github.com/dotnet/msbuild/pull/12592#discussion_r2406653561 
