### PR TITLE
Change IDictionary<string, string> to TaskHostParameters

### DIFF
--- a/src/Build.UnitTests/BackEnd/AssemblyTaskFactory_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/AssemblyTaskFactory_Tests.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
         /// </summary>
         public AssemblyTaskFactory_Tests()
         {
-            SetupTaskFactory(null, false);
+            SetupTaskFactory(TaskHostParameters.Empty, false);
         }
 
         #region AssemblyTaskFactory
@@ -57,7 +57,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             Assert.Throws<ArgumentNullException>(() =>
             {
                 AssemblyTaskFactory taskFactory = new AssemblyTaskFactory();
-                taskFactory.InitializeFactory(null, "TaskToTestFactories", new Dictionary<string, TaskPropertyInfo>(), string.Empty, null, false, null, ElementLocation.Create("NONE"), String.Empty);
+                taskFactory.InitializeFactory(null, "TaskToTestFactories", new Dictionary<string, TaskPropertyInfo>(), string.Empty, TaskHostParameters.Empty, false, null, ElementLocation.Create("NONE"), String.Empty);
             });
         }
         /// <summary>
@@ -69,7 +69,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             Assert.Throws<InvalidProjectFileException>(() =>
             {
                 AssemblyTaskFactory taskFactory = new AssemblyTaskFactory();
-                taskFactory.InitializeFactory(_loadInfo, null, new Dictionary<string, TaskPropertyInfo>(), string.Empty, null, false, null, ElementLocation.Create("NONE"), String.Empty);
+                taskFactory.InitializeFactory(_loadInfo, null, new Dictionary<string, TaskPropertyInfo>(), string.Empty, TaskHostParameters.Empty, false, null, ElementLocation.Create("NONE"), String.Empty);
             });
         }
         /// <summary>
@@ -81,7 +81,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             Assert.Throws<InvalidProjectFileException>(() =>
             {
                 AssemblyTaskFactory taskFactory = new AssemblyTaskFactory();
-                taskFactory.InitializeFactory(_loadInfo, String.Empty, new Dictionary<string, TaskPropertyInfo>(), string.Empty, null, false, null, ElementLocation.Create("NONE"), String.Empty);
+                taskFactory.InitializeFactory(_loadInfo, String.Empty, new Dictionary<string, TaskPropertyInfo>(), string.Empty, TaskHostParameters.Empty, false, null, ElementLocation.Create("NONE"), String.Empty);
             });
         }
         /// <summary>
@@ -93,7 +93,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             Assert.Throws<InvalidProjectFileException>(() =>
             {
                 AssemblyTaskFactory taskFactory = new AssemblyTaskFactory();
-                taskFactory.InitializeFactory(_loadInfo, "RandomTask", new Dictionary<string, TaskPropertyInfo>(), string.Empty, null, false, null, ElementLocation.Create("NONE"), String.Empty);
+                taskFactory.InitializeFactory(_loadInfo, "RandomTask", new Dictionary<string, TaskPropertyInfo>(), string.Empty, TaskHostParameters.Empty, false, null, ElementLocation.Create("NONE"), String.Empty);
             });
         }
         /// <summary>
@@ -110,6 +110,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
                 taskFactory.Initialize(String.Empty, new Dictionary<string, TaskPropertyInfo>(), String.Empty, null);
             });
         }
+
         /// <summary>
         /// Make sure we get an internal error when we call the ITaskFactory2 version of initialize factory.
         /// This is done because we cannot properly initialize the task factory using the public interface and keep
@@ -121,7 +122,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             Assert.Throws<InternalErrorException>(() =>
             {
                 AssemblyTaskFactory taskFactory = new AssemblyTaskFactory();
-                taskFactory.Initialize(String.Empty, null, new Dictionary<string, TaskPropertyInfo>(), String.Empty, null);
+                taskFactory.Initialize(String.Empty, TaskHostParameters.Empty, new Dictionary<string, TaskPropertyInfo>(), String.Empty, null);
             });
         }
         #endregion
@@ -132,7 +133,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
         [Fact]
         public void CreatableByTaskFactoryGoodName()
         {
-            Assert.True(_taskFactory.TaskNameCreatableByFactory("TaskToTestFactories", null, String.Empty, null, ElementLocation.Create(".", 1, 1)));
+            Assert.True(_taskFactory.TaskNameCreatableByFactory("TaskToTestFactories", TaskHostParameters.Empty, String.Empty, null, ElementLocation.Create(".", 1, 1)));
         }
 
         /// <summary>
@@ -141,7 +142,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
         [Fact]
         public void CreatableByTaskFactoryNotInAssembly()
         {
-            Assert.False(_taskFactory.TaskNameCreatableByFactory("NotInAssembly", null, String.Empty, null, ElementLocation.Create(".", 1, 1)));
+            Assert.False(_taskFactory.TaskNameCreatableByFactory("NotInAssembly", TaskHostParameters.Empty, String.Empty, null, ElementLocation.Create(".", 1, 1)));
         }
 
         /// <summary>
@@ -152,7 +153,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
         {
             Assert.Throws<InvalidProjectFileException>(() =>
             {
-                Assert.False(_taskFactory.TaskNameCreatableByFactory(String.Empty, null, String.Empty, null, ElementLocation.Create(".", 1, 1)));
+                Assert.False(_taskFactory.TaskNameCreatableByFactory(String.Empty, TaskHostParameters.Empty, String.Empty, null, ElementLocation.Create(".", 1, 1)));
             });
         }
         /// <summary>
@@ -163,7 +164,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
         {
             Assert.Throws<InvalidProjectFileException>(() =>
             {
-                Assert.False(_taskFactory.TaskNameCreatableByFactory(null, null, String.Empty, null, ElementLocation.Create(".", 1, 1)));
+                Assert.False(_taskFactory.TaskNameCreatableByFactory(null, TaskHostParameters.Empty, String.Empty, null, ElementLocation.Create(".", 1, 1)));
             });
         }
         /// <summary>
@@ -173,15 +174,10 @@ namespace Microsoft.Build.UnitTests.BackEnd
         [Fact]
         public void CreatableByTaskFactoryMatchingIdentity()
         {
-            IDictionary<string, string> factoryIdentityParameters = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-            factoryIdentityParameters.Add(XMakeAttributes.runtime, XMakeAttributes.MSBuildRuntimeValues.currentRuntime);
-            factoryIdentityParameters.Add(XMakeAttributes.architecture, XMakeAttributes.MSBuildArchitectureValues.currentArchitecture);
-
+            TaskHostParameters factoryIdentityParameters = new (XMakeAttributes.MSBuildRuntimeValues.currentRuntime, XMakeAttributes.MSBuildArchitectureValues.currentArchitecture);
             SetupTaskFactory(factoryIdentityParameters, false /* don't want task host */);
 
-            IDictionary<string, string> taskIdentityParameters = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-            taskIdentityParameters.Add(XMakeAttributes.runtime, XMakeAttributes.GetCurrentMSBuildRuntime());
-            taskIdentityParameters.Add(XMakeAttributes.architecture, XMakeAttributes.GetCurrentMSBuildArchitecture());
+            TaskHostParameters taskIdentityParameters = new(XMakeAttributes.GetCurrentMSBuildRuntime(), XMakeAttributes.GetCurrentMSBuildArchitecture());
 
             Assert.True(_taskFactory.TaskNameCreatableByFactory("TaskToTestFactories", taskIdentityParameters, String.Empty, null, ElementLocation.Create(".", 1, 1)));
         }
@@ -193,15 +189,11 @@ namespace Microsoft.Build.UnitTests.BackEnd
         [Fact]
         public void CreatableByTaskFactoryMismatchedIdentity()
         {
-            IDictionary<string, string> factoryIdentityParameters = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-            factoryIdentityParameters.Add(XMakeAttributes.runtime, XMakeAttributes.MSBuildRuntimeValues.clr2);
-            factoryIdentityParameters.Add(XMakeAttributes.architecture, XMakeAttributes.MSBuildArchitectureValues.currentArchitecture);
+            TaskHostParameters factoryIdentityParameters = new (XMakeAttributes.MSBuildRuntimeValues.clr2, XMakeAttributes.MSBuildArchitectureValues.currentArchitecture);
 
             SetupTaskFactory(factoryIdentityParameters, false /* don't want task host */);
 
-            IDictionary<string, string> taskIdentityParameters = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-            taskIdentityParameters.Add(XMakeAttributes.runtime, XMakeAttributes.MSBuildRuntimeValues.clr4);
-            taskIdentityParameters.Add(XMakeAttributes.architecture, XMakeAttributes.MSBuildArchitectureValues.currentArchitecture);
+            TaskHostParameters taskIdentityParameters = new(XMakeAttributes.MSBuildRuntimeValues.clr4, XMakeAttributes.MSBuildArchitectureValues.currentArchitecture);
 
             Assert.False(_taskFactory.TaskNameCreatableByFactory("TaskToTestFactories", taskIdentityParameters, String.Empty, null, ElementLocation.Create(".", 1, 1)));
         }
@@ -246,7 +238,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             ITask createdTask = null;
             try
             {
-                createdTask = _taskFactory.CreateTaskInstance(ElementLocation.Create("MSBUILD"), null, new MockHost(), null,
+                createdTask = _taskFactory.CreateTaskInstance(ElementLocation.Create("MSBUILD"), null, new MockHost(), TaskHostParameters.Empty,
 #if FEATURE_APPDOMAIN
                     new AppDomainSetup(),
 #endif
@@ -275,9 +267,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             ITask createdTask = null;
             try
             {
-                IDictionary<string, string> taskParameters = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-                taskParameters.Add(XMakeAttributes.runtime, XMakeAttributes.MSBuildRuntimeValues.any);
-                taskParameters.Add(XMakeAttributes.architecture, XMakeAttributes.MSBuildArchitectureValues.any);
+                TaskHostParameters taskParameters = new (XMakeAttributes.MSBuildRuntimeValues.any, XMakeAttributes.MSBuildArchitectureValues.any);
 
                 createdTask = _taskFactory.CreateTaskInstance(ElementLocation.Create("MSBUILD"), null, new MockHost(), taskParameters,
 #if FEATURE_APPDOMAIN
@@ -308,9 +298,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             ITask createdTask = null;
             try
             {
-                IDictionary<string, string> taskParameters = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-                taskParameters.Add(XMakeAttributes.runtime, XMakeAttributes.GetCurrentMSBuildRuntime());
-                taskParameters.Add(XMakeAttributes.architecture, XMakeAttributes.GetCurrentMSBuildArchitecture());
+                TaskHostParameters taskParameters = new (XMakeAttributes.GetCurrentMSBuildRuntime(), XMakeAttributes.GetCurrentMSBuildArchitecture());
 
                 createdTask = _taskFactory.CreateTaskInstance(ElementLocation.Create("MSBUILD"), null, new MockHost(), taskParameters,
 #if FEATURE_APPDOMAIN
@@ -341,13 +329,11 @@ namespace Microsoft.Build.UnitTests.BackEnd
             ITask createdTask = null;
             try
             {
-                IDictionary<string, string> taskParameters = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-                taskParameters.Add(XMakeAttributes.runtime, XMakeAttributes.MSBuildRuntimeValues.any);
-                taskParameters.Add(XMakeAttributes.architecture, XMakeAttributes.MSBuildArchitectureValues.any);
+                TaskHostParameters taskParameters = new (XMakeAttributes.MSBuildRuntimeValues.any, XMakeAttributes.MSBuildArchitectureValues.any);
 
                 SetupTaskFactory(taskParameters, false /* don't want task host */);
 
-                createdTask = _taskFactory.CreateTaskInstance(ElementLocation.Create("MSBUILD"), null, new MockHost(), null,
+                createdTask = _taskFactory.CreateTaskInstance(ElementLocation.Create("MSBUILD"), null, new MockHost(), TaskHostParameters.Empty,
 #if FEATURE_APPDOMAIN
                     new AppDomainSetup(),
 #endif
@@ -376,13 +362,11 @@ namespace Microsoft.Build.UnitTests.BackEnd
             ITask createdTask = null;
             try
             {
-                IDictionary<string, string> taskParameters = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-                taskParameters.Add(XMakeAttributes.runtime, XMakeAttributes.MSBuildRuntimeValues.any);
-                taskParameters.Add(XMakeAttributes.architecture, XMakeAttributes.GetCurrentMSBuildArchitecture());
+                TaskHostParameters taskParameters = new (XMakeAttributes.MSBuildRuntimeValues.any, XMakeAttributes.GetCurrentMSBuildArchitecture());
 
                 SetupTaskFactory(taskParameters, false /* don't want task host */);
 
-                createdTask = _taskFactory.CreateTaskInstance(ElementLocation.Create("MSBUILD"), null, new MockHost(), null,
+                createdTask = _taskFactory.CreateTaskInstance(ElementLocation.Create("MSBUILD"), null, new MockHost(), TaskHostParameters.Empty,
 #if FEATURE_APPDOMAIN
                     new AppDomainSetup(),
 #endif
@@ -411,13 +395,11 @@ namespace Microsoft.Build.UnitTests.BackEnd
             ITask createdTask = null;
             try
             {
-                IDictionary<string, string> factoryParameters = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-                factoryParameters.Add(XMakeAttributes.runtime, XMakeAttributes.GetCurrentMSBuildRuntime());
+                TaskHostParameters factoryParameters = new (XMakeAttributes.GetCurrentMSBuildRuntime());
 
                 SetupTaskFactory(factoryParameters, false /* don't want task host */);
 
-                IDictionary<string, string> taskParameters = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-                taskParameters.Add(XMakeAttributes.architecture, XMakeAttributes.MSBuildArchitectureValues.currentArchitecture);
+                TaskHostParameters taskParameters = new (architecture: XMakeAttributes.MSBuildArchitectureValues.currentArchitecture);
 
                 createdTask = _taskFactory.CreateTaskInstance(ElementLocation.Create("MSBUILD"), null, new MockHost(), taskParameters,
 #if FEATURE_APPDOMAIN
@@ -448,13 +430,11 @@ namespace Microsoft.Build.UnitTests.BackEnd
             ITask createdTask = null;
             try
             {
-                IDictionary<string, string> taskParameters = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-                taskParameters.Add(XMakeAttributes.runtime, XMakeAttributes.MSBuildRuntimeValues.clr2);
-                taskParameters.Add(XMakeAttributes.architecture, XMakeAttributes.MSBuildArchitectureValues.any);
+                TaskHostParameters taskParameters = new (XMakeAttributes.MSBuildRuntimeValues.clr2, XMakeAttributes.MSBuildArchitectureValues.any);
 
                 SetupTaskFactory(taskParameters, false /* don't want task host */);
 
-                createdTask = _taskFactory.CreateTaskInstance(ElementLocation.Create("MSBUILD"), null, new MockHost(), null,
+                createdTask = _taskFactory.CreateTaskInstance(ElementLocation.Create("MSBUILD"), null, new MockHost(), TaskHostParameters.Empty,
 #if FEATURE_APPDOMAIN
                     new AppDomainSetup(),
 #endif
@@ -483,9 +463,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             ITask createdTask = null;
             try
             {
-                IDictionary<string, string> taskParameters = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-                taskParameters.Add(XMakeAttributes.runtime, XMakeAttributes.MSBuildRuntimeValues.clr2);
-                taskParameters.Add(XMakeAttributes.architecture, XMakeAttributes.MSBuildArchitectureValues.any);
+                TaskHostParameters taskParameters = new(XMakeAttributes.MSBuildRuntimeValues.clr2, XMakeAttributes.MSBuildArchitectureValues.any);
 
                 createdTask = _taskFactory.CreateTaskInstance(ElementLocation.Create("MSBUILD"), null, new MockHost(), taskParameters,
 #if FEATURE_APPDOMAIN
@@ -516,13 +494,11 @@ namespace Microsoft.Build.UnitTests.BackEnd
             ITask createdTask = null;
             try
             {
-                IDictionary<string, string> factoryParameters = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-                factoryParameters.Add(XMakeAttributes.runtime, XMakeAttributes.MSBuildRuntimeValues.clr2);
+                TaskHostParameters factoryParameters = new (XMakeAttributes.MSBuildRuntimeValues.clr2);
 
                 SetupTaskFactory(factoryParameters, false /* don't want task host */);
 
-                IDictionary<string, string> taskParameters = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-                taskParameters.Add(XMakeAttributes.architecture, XMakeAttributes.MSBuildArchitectureValues.any);
+                TaskHostParameters taskParameters = new(architecture: XMakeAttributes.MSBuildArchitectureValues.any);
 
                 createdTask = _taskFactory.CreateTaskInstance(ElementLocation.Create("MSBUILD"), null, new MockHost(), taskParameters,
 #if FEATURE_APPDOMAIN
@@ -553,9 +529,9 @@ namespace Microsoft.Build.UnitTests.BackEnd
             ITask createdTask = null;
             try
             {
-                SetupTaskFactory(null, true /* want task host */, true);
+                SetupTaskFactory(TaskHostParameters.Empty, true /* want task host */, true);
 
-                createdTask = _taskFactory.CreateTaskInstance(ElementLocation.Create("MSBUILD"), null, new MockHost(), null,
+                createdTask = _taskFactory.CreateTaskInstance(ElementLocation.Create("MSBUILD"), null, new MockHost(), TaskHostParameters.Empty,
 #if FEATURE_APPDOMAIN
                     new AppDomainSetup(),
 #endif
@@ -584,13 +560,11 @@ namespace Microsoft.Build.UnitTests.BackEnd
             ITask createdTask = null;
             try
             {
-                IDictionary<string, string> taskParameters = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-                taskParameters.Add(XMakeAttributes.runtime, XMakeAttributes.MSBuildRuntimeValues.any);
-                taskParameters.Add(XMakeAttributes.architecture, XMakeAttributes.MSBuildArchitectureValues.any);
+                TaskHostParameters taskParameters = new (XMakeAttributes.MSBuildRuntimeValues.any, XMakeAttributes.MSBuildArchitectureValues.any);
 
                 SetupTaskFactory(taskParameters, true /* want task host */, isTaskHostFactory: true);
 
-                createdTask = _taskFactory.CreateTaskInstance(ElementLocation.Create("MSBUILD"), null, new MockHost(), null,
+                createdTask = _taskFactory.CreateTaskInstance(ElementLocation.Create("MSBUILD"), null, new MockHost(), TaskHostParameters.Empty,
 #if FEATURE_APPDOMAIN
                     new AppDomainSetup(),
 #endif
@@ -619,11 +593,9 @@ namespace Microsoft.Build.UnitTests.BackEnd
             ITask createdTask = null;
             try
             {
-                SetupTaskFactory(null, true /* want task host */, true);
+                SetupTaskFactory(TaskHostParameters.Empty, true /* want task host */, true);
 
-                IDictionary<string, string> taskParameters = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-                taskParameters.Add(XMakeAttributes.runtime, XMakeAttributes.MSBuildRuntimeValues.any);
-                taskParameters.Add(XMakeAttributes.architecture, XMakeAttributes.MSBuildArchitectureValues.any);
+                TaskHostParameters taskParameters = new (XMakeAttributes.MSBuildRuntimeValues.any, XMakeAttributes.MSBuildArchitectureValues.any);
 
                 createdTask = _taskFactory.CreateTaskInstance(ElementLocation.Create("MSBUILD"), null, new MockHost(), taskParameters,
 #if FEATURE_APPDOMAIN
@@ -652,16 +624,14 @@ namespace Microsoft.Build.UnitTests.BackEnd
         public void VerifySameFactoryCanGenerateDifferentTaskInstances()
         {
             ITask createdTask = null;
-            IDictionary<string, string> factoryParameters = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-            factoryParameters.Add(XMakeAttributes.runtime, XMakeAttributes.MSBuildRuntimeValues.any);
-            factoryParameters.Add(XMakeAttributes.architecture, XMakeAttributes.MSBuildArchitectureValues.any);
+            TaskHostParameters factoryParameters = new TaskHostParameters(XMakeAttributes.MSBuildRuntimeValues.any, XMakeAttributes.MSBuildArchitectureValues.any);
 
             SetupTaskFactory(factoryParameters, explicitlyLaunchTaskHost: false, isTaskHostFactory: false);
 
             try
             {
                 // #1: don't launch task host
-                createdTask = _taskFactory.CreateTaskInstance(ElementLocation.Create("MSBUILD"), null, new MockHost(), null,
+                createdTask = _taskFactory.CreateTaskInstance(ElementLocation.Create("MSBUILD"), null, new MockHost(), TaskHostParameters.Empty,
 #if FEATURE_APPDOMAIN
                     new AppDomainSetup(),
 #endif
@@ -682,9 +652,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             try
             {
                 // #2: launch task host
-                var taskParameters = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-                taskParameters.Add(XMakeAttributes.runtime, XMakeAttributes.MSBuildRuntimeValues.clr2);
-                taskParameters.Add(XMakeAttributes.architecture, XMakeAttributes.MSBuildArchitectureValues.currentArchitecture);
+                TaskHostParameters taskParameters = new(XMakeAttributes.MSBuildRuntimeValues.clr2, XMakeAttributes.MSBuildArchitectureValues.currentArchitecture);
 
                 createdTask = _taskFactory.CreateTaskInstance(ElementLocation.Create("MSBUILD"), null, new MockHost(), taskParameters,
 #if FEATURE_APPDOMAIN
@@ -709,7 +677,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
         /// Abstract out the creation of the new AssemblyTaskFactory with default task, and
         /// with some basic validation.
         /// </summary>
-        private void SetupTaskFactory(IDictionary<string, string> factoryParameters, bool explicitlyLaunchTaskHost = false, bool isTaskHostFactory = false)
+        private void SetupTaskFactory(TaskHostParameters factoryParameters, bool explicitlyLaunchTaskHost = false, bool isTaskHostFactory = false)
         {
             _taskFactory = new AssemblyTaskFactory();
 #if FEATURE_ASSEMBLY_LOCATION
@@ -719,9 +687,9 @@ namespace Microsoft.Build.UnitTests.BackEnd
 #endif
             if (explicitlyLaunchTaskHost)
             {
-                factoryParameters ??= new Dictionary<string, string>();
-                factoryParameters.Add(Internal.Constants.TaskHostExplicitlyRequested, "true");
+                factoryParameters = TaskHostParameters.MergeTaskHostParameters(factoryParameters, new TaskHostParameters(isTaskHostFactory: true));
             }
+
             _loadedType = _taskFactory.InitializeFactory(_loadInfo, "TaskToTestFactories", new Dictionary<string, TaskPropertyInfo>(), string.Empty, factoryParameters, explicitlyLaunchTaskHost, null, ElementLocation.Create("NONE"), String.Empty);
             Assert.True(_loadedType.Assembly.Equals(_loadInfo)); // "Expected the AssemblyLoadInfo to be equal"
         }

--- a/src/Build.UnitTests/BackEnd/TaskExecutionHost_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/TaskExecutionHost_Tests.cs
@@ -997,8 +997,8 @@ namespace Microsoft.Build.UnitTests.BackEnd
 #endif
                     false,
                     CancellationToken.None);
-                _host.FindTask(null);
-                _host.InitializeForBatch(new TaskLoggingContext(_loggingService, tlc.BuildEventContext), _bucket, null, scheduledNodeId: 1);
+                _host.FindTask(TaskHostParameters.Empty);
+                _host.InitializeForBatch(new TaskLoggingContext(_loggingService, tlc.BuildEventContext), _bucket, TaskHostParameters.Empty, scheduledNodeId: 1);
             });
         }
         /// <summary>
@@ -1026,8 +1026,8 @@ namespace Microsoft.Build.UnitTests.BackEnd
                 false,
                 CancellationToken.None);
 
-            _host.FindTask(null);
-            _host.InitializeForBatch(new TaskLoggingContext(_loggingService, tlc.BuildEventContext), _bucket, null, scheduledNodeId: 1);
+            _host.FindTask(TaskHostParameters.Empty);
+            _host.InitializeForBatch(new TaskLoggingContext(_loggingService, tlc.BuildEventContext), _bucket, TaskHostParameters.Empty, scheduledNodeId: 1);
             _logger.AssertLogContains("MSB4036");
         }
 
@@ -1254,7 +1254,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             TaskBuilderTestTask.TaskBuilderTestTaskFactory taskFactory = new TaskBuilderTestTask.TaskBuilderTestTaskFactory();
             taskFactory.ThrowOnExecute = throwOnExecute;
             string taskName = "TaskBuilderTestTask";
-            (_host as TaskExecutionHost)._UNITTESTONLY_TaskFactoryWrapper = new TaskFactoryWrapper(taskFactory, loadedType, taskName, null);
+            (_host as TaskExecutionHost)._UNITTESTONLY_TaskFactoryWrapper = new TaskFactoryWrapper(taskFactory, loadedType, taskName, TaskHostParameters.Empty);
             _host.InitializeForTask(
                 this,
                 tlc,
@@ -1289,8 +1289,8 @@ namespace Microsoft.Build.UnitTests.BackEnd
 
             _bucket = new ItemBucket(FrozenSet<string>.Empty, new Dictionary<string, string>(), new Lookup(itemsByName, new PropertyDictionary<ProjectPropertyInstance>()), 0);
             _bucket.Initialize(null);
-            _host.FindTask(null);
-            _host.InitializeForBatch(talc, _bucket, null, scheduledNodeId: 1);
+            _host.FindTask(TaskHostParameters.Empty);
+            _host.InitializeForBatch(talc, _bucket, TaskHostParameters.Empty, scheduledNodeId: 1);
             _parametersSetOnTask = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
             _outputsReadFromTask = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
         }

--- a/src/Build.UnitTests/BackEnd/TaskRegistry_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/TaskRegistry_Tests.cs
@@ -114,7 +114,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
 
             foreach (ProjectUsingTaskElement taskElement in elementList)
             {
-                List<TaskRegistry.RegisteredTaskRecord> registrationRecords = registry.TaskRegistrations[new TaskRegistry.RegisteredTaskIdentity(taskElement.TaskName, null)];
+                List<TaskRegistry.RegisteredTaskRecord> registrationRecords = registry.TaskRegistrations[new TaskRegistry.RegisteredTaskIdentity(taskElement.TaskName, TaskHostParameters.Empty)];
                 Assert.NotNull(registrationRecords); // "Task registrationrecord not found in TaskRegistry.TaskRegistrations!"
                 Assert.Single(registrationRecords); // "Expected only one record registered under this TaskName!"
 
@@ -154,7 +154,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
 
             foreach (ProjectUsingTaskElement taskElement in elementList)
             {
-                List<TaskRegistry.RegisteredTaskRecord> registrationRecords = registry.TaskRegistrations[new TaskRegistry.RegisteredTaskIdentity(taskElement.TaskName, null)];
+                List<TaskRegistry.RegisteredTaskRecord> registrationRecords = registry.TaskRegistrations[new TaskRegistry.RegisteredTaskIdentity(taskElement.TaskName, TaskHostParameters.Empty)];
                 Assert.NotNull(registrationRecords); // "Task registrationrecord not found in TaskRegistry.TaskRegistrations!"
                 Assert.Single(registrationRecords); // "Expected only one record registered under this TaskName!"
 
@@ -198,7 +198,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             Assert.Equal(2, registry.TaskRegistrations.Count); // "Expected only two buckets since two of three tasks have the same name!"
 
             // Now let's look at the bucket with only one task
-            List<TaskRegistry.RegisteredTaskRecord> singletonBucket = registry.TaskRegistrations[new TaskRegistry.RegisteredTaskIdentity(elementList[1].TaskName, null)];
+            List<TaskRegistry.RegisteredTaskRecord> singletonBucket = registry.TaskRegistrations[new TaskRegistry.RegisteredTaskIdentity(elementList[1].TaskName, TaskHostParameters.Empty)];
             Assert.NotNull(singletonBucket); // "Record not found in TaskRegistry.TaskRegistrations!"
             Assert.Single(singletonBucket); // "Expected only Record registered under this TaskName!"
             AssemblyLoadInfo singletonAssemblyLoadInfo = singletonBucket[0].TaskFactoryAssemblyLoadInfo;
@@ -207,7 +207,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             Assert.Equal(singletonAssemblyLoadInfo, AssemblyLoadInfo.Create(assemblyName, assemblyFile)); // "Task record was not properly registered by TaskRegistry.RegisterTask!"
 
             // Now let's look at the bucket with two tasks
-            List<TaskRegistry.RegisteredTaskRecord> duplicateBucket = registry.TaskRegistrations[new TaskRegistry.RegisteredTaskIdentity(elementList[0].TaskName, null)];
+            List<TaskRegistry.RegisteredTaskRecord> duplicateBucket = registry.TaskRegistrations[new TaskRegistry.RegisteredTaskIdentity(elementList[0].TaskName, TaskHostParameters.Empty)];
             Assert.NotNull(duplicateBucket); // "Records not found in TaskRegistry.TaskRegistrations!"
             Assert.Equal(2, duplicateBucket.Count); // "Expected two Records registered under this TaskName!"
 
@@ -261,7 +261,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
 
             foreach (ProjectUsingTaskElement taskElement in elementList)
             {
-                List<TaskRegistry.RegisteredTaskRecord> registrationRecords = registry.TaskRegistrations[new TaskRegistry.RegisteredTaskIdentity(taskElement.TaskName, null)];
+                List<TaskRegistry.RegisteredTaskRecord> registrationRecords = registry.TaskRegistrations[new TaskRegistry.RegisteredTaskIdentity(taskElement.TaskName, TaskHostParameters.Empty)];
                 Assert.NotNull(registrationRecords); // "Task registrationrecord not found in TaskRegistry.TaskRegistrations!"
                 Assert.Single(registrationRecords); // "Expected only one record registered under this TaskName!"
 
@@ -551,51 +551,6 @@ namespace Microsoft.Build.UnitTests.BackEnd
                     runtime: XMakeAttributes.MSBuildRuntimeValues.clr4,
                     architecture: XMakeAttributes.MSBuildArchitectureValues.x86,
                     shouldBeRetrieved: true,
-                    shouldBeRetrievedFromCache: true);
-        }
-
-        /// <summary>
-        /// Validate task retrieval and exact cache retrieval when attempting to load
-        /// a task with parameters beyond just runtime and architecture.  Hint: it shouldn't
-        /// ever work, since we don't currently have a way to create a using task with
-        /// parameters other than those two.
-        /// </summary>
-        [Fact]
-        public void RetrieveFromCacheMatchingExactParameters_AdditionalParameters()
-        {
-            Assert.NotNull(_testTaskLocation); // "Need a test task to run this test"
-
-            List<ProjectUsingTaskElement> elementList = new List<ProjectUsingTaskElement>();
-            ProjectRootElement project = ProjectRootElement.Create();
-
-            ProjectUsingTaskElement element = project.AddUsingTask(TestTaskName, _testTaskLocation, null);
-            element.Runtime = "CLR4";
-            element.Architecture = "x86";
-            elementList.Add(element);
-
-            TaskRegistry registry = CreateTaskRegistryAndRegisterTasks(elementList);
-
-            // Runtime and architecture match the using task exactly, but since there is an additional parameter, it still
-            // doesn't match when doing exact matching.
-            Dictionary<string, string> taskParameters = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-            taskParameters.Add(XMakeAttributes.runtime, XMakeAttributes.MSBuildRuntimeValues.clr4);
-            taskParameters.Add(XMakeAttributes.architecture, XMakeAttributes.MSBuildArchitectureValues.x86);
-            taskParameters.Add("Foo", "Bar");
-
-            RetrieveAndValidateRegisteredTaskRecord(
-                    registry,
-                    true /* exact match */,
-                    taskParameters,
-                    shouldBeRetrieved: false,
-                    shouldBeRetrievedFromCache: false);
-
-            // However, it should still match itself -- so if we try again, we should get the "no match"
-            // back from the cache this time.
-            RetrieveAndValidateRegisteredTaskRecord(
-                    registry,
-                    true /* exact match */,
-                    taskParameters,
-                    shouldBeRetrieved: false,
                     shouldBeRetrievedFromCache: true);
         }
 
@@ -1032,70 +987,6 @@ namespace Microsoft.Build.UnitTests.BackEnd
                     shouldBeRetrievedFromCache: true);
         }
 
-        /// <summary>
-        /// Validate task retrieval and exact cache retrieval when attempting to load
-        /// a task with parameters beyond just runtime and architecture.  Hint: it shouldn't
-        /// ever work, since we don't currently have a way to create a using task with
-        /// parameters other than those two.
-        /// </summary>
-        [Fact]
-        public void RetrieveFromCacheFuzzyMatchingParameters_AdditionalParameters()
-        {
-            Assert.NotNull(_testTaskLocation); // "Need a test task to run this test"
-
-            List<ProjectUsingTaskElement> elementList = new List<ProjectUsingTaskElement>();
-            ProjectRootElement project = ProjectRootElement.Create();
-
-            ProjectUsingTaskElement element = project.AddUsingTask(TestTaskName, _testTaskLocation, null);
-            element.Runtime = "CLR4";
-            element.Architecture = "x86";
-            elementList.Add(element);
-
-            TaskRegistry registry = CreateTaskRegistryAndRegisterTasks(elementList);
-
-            // Runtime and architecture match, so even though we have the extra parameter, it should still match
-            Dictionary<string, string> taskParameters = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-            taskParameters.Add(XMakeAttributes.runtime, XMakeAttributes.MSBuildRuntimeValues.clr4);
-            taskParameters.Add(XMakeAttributes.architecture, XMakeAttributes.MSBuildArchitectureValues.x86);
-            taskParameters.Add("Foo", "Bar");
-
-            RetrieveAndValidateRegisteredTaskRecord(
-                    registry,
-                    false /* fuzzy match */,
-                    taskParameters,
-                    shouldBeRetrieved: true,
-                    shouldBeRetrievedFromCache: false,
-                    expectedRuntime: XMakeAttributes.MSBuildRuntimeValues.clr4,
-                    expectedArchitecture: XMakeAttributes.MSBuildArchitectureValues.x86);
-
-            // And if we try again, we should get it from the cache this time.
-            RetrieveAndValidateRegisteredTaskRecord(
-                    registry,
-                    false /* fuzzy match */,
-                    taskParameters,
-                    shouldBeRetrieved: true,
-                    shouldBeRetrievedFromCache: true,
-                    expectedRuntime: XMakeAttributes.MSBuildRuntimeValues.clr4,
-                    expectedArchitecture: XMakeAttributes.MSBuildArchitectureValues.x86);
-
-            taskParameters = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-            taskParameters.Add(XMakeAttributes.runtime, XMakeAttributes.MSBuildRuntimeValues.clr4);
-            taskParameters.Add(XMakeAttributes.architecture, XMakeAttributes.MSBuildArchitectureValues.x86);
-            taskParameters.Add("Baz", "Qux");
-
-            // Even with a different value to the additional parameter, because it's a fuzzy equals and because all
-            // our equivalence check looks for is runtime and architecture, it still successfully retrieves the
-            // existing record from the cache.
-            RetrieveAndValidateRegisteredTaskRecord(
-                    registry,
-                    false /* fuzzy match */,
-                    taskParameters,
-                    shouldBeRetrieved: true,
-                    shouldBeRetrievedFromCache: true,
-                    expectedRuntime: XMakeAttributes.MSBuildRuntimeValues.clr4,
-                    expectedArchitecture: XMakeAttributes.MSBuildArchitectureValues.x86);
-        }
-
         #endregion
 
         /// <summary>
@@ -1140,7 +1031,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
                 expandedAssemblyFile = String.IsNullOrEmpty(expandedAssemblyFile) ? null : expandedAssemblyFile;
                 expandedTaskFactory = String.IsNullOrEmpty(expandedTaskFactory) ? "AssemblyTaskFactory" : expandedTaskFactory;
 
-                List<TaskRegistry.RegisteredTaskRecord> registeredTaskRecords = registry.TaskRegistrations[new TaskRegistry.RegisteredTaskIdentity(expandedtaskName, null)];
+                List<TaskRegistry.RegisteredTaskRecord> registeredTaskRecords = registry.TaskRegistrations[new TaskRegistry.RegisteredTaskIdentity(expandedtaskName, TaskHostParameters.Empty)];
                 Assert.NotNull(registeredTaskRecords); // "Task to be found in TaskRegistry.TaskRegistrations!"
                 Assert.Single(registeredTaskRecords); // "Expected only one task registered under this TaskName!"
 
@@ -1195,7 +1086,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
                 expandedAssemblyName = String.IsNullOrEmpty(expandedAssemblyName) ? null : expandedAssemblyName;
                 expandedAssemblyFile = String.IsNullOrEmpty(expandedAssemblyFile) ? null : expandedAssemblyFile;
 
-                List<TaskRegistry.RegisteredTaskRecord> registeredTaskRecords = registry.TaskRegistrations[new TaskRegistry.RegisteredTaskIdentity(expandedtaskName, null)];
+                List<TaskRegistry.RegisteredTaskRecord> registeredTaskRecords = registry.TaskRegistrations[new TaskRegistry.RegisteredTaskIdentity(expandedtaskName, TaskHostParameters.Empty)];
                 Assert.NotNull(registeredTaskRecords); // "Task to be found in TaskRegistry.TaskRegistrations!"
                 Assert.Single(registeredTaskRecords); // "Expected only one task registered under this TaskName!"
 
@@ -1224,7 +1115,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             IDictionary<TaskRegistry.RegisteredTaskIdentity, List<TaskRegistry.RegisteredTaskRecord>> registeredTasks = registry.TaskRegistrations;
 
             ProjectUsingTaskElement taskElement = elementList[0];
-            List<TaskRegistry.RegisteredTaskRecord> registeredTaskRecords = registry.TaskRegistrations[new TaskRegistry.RegisteredTaskIdentity("Hello", null)];
+            List<TaskRegistry.RegisteredTaskRecord> registeredTaskRecords = registry.TaskRegistrations[new TaskRegistry.RegisteredTaskIdentity("Hello", TaskHostParameters.Empty)];
             Assert.NotNull(registeredTaskRecords); // "Task to be found in TaskRegistry.TaskRegistrations!"
             Assert.Single(registeredTaskRecords); // "Expected only one task registered under this TaskName!"
             Assert.Empty(registeredTaskRecords[0].ParameterGroupAndTaskBody.UsingTaskParameters);
@@ -1244,7 +1135,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
 
             TaskRegistry registry = CreateTaskRegistryAndRegisterTasks(elementList);
 
-            InvalidProjectFileException exception = Should.Throw<InvalidProjectFileException>(() => registry.GetRegisteredTask("Task1", "none", null, false, new TargetLoggingContext(_loggingService, new BuildEventContext(1, 1, BuildEventContext.InvalidProjectContextId, 1)), ElementLocation.Create("none", 1, 2)));
+            InvalidProjectFileException exception = Should.Throw<InvalidProjectFileException>(() => registry.GetRegisteredTask("Task1", "none", TaskHostParameters.Empty, false, new TargetLoggingContext(_loggingService, new BuildEventContext(1, 1, BuildEventContext.InvalidProjectContextId, 1)), ElementLocation.Create("none", 1, 2)));
 
             exception.ErrorCode.ShouldBe("MSB4175");
 
@@ -1276,7 +1167,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             IDictionary<TaskRegistry.RegisteredTaskIdentity, List<TaskRegistry.RegisteredTaskRecord>> registeredTasks = registry.TaskRegistrations;
 
             ProjectUsingTaskElement taskElement = elementList[0];
-            List<TaskRegistry.RegisteredTaskRecord> registeredTaskRecords = registry.TaskRegistrations[new TaskRegistry.RegisteredTaskIdentity("Name", null)];
+            List<TaskRegistry.RegisteredTaskRecord> registeredTaskRecords = registry.TaskRegistrations[new TaskRegistry.RegisteredTaskIdentity("Name", TaskHostParameters.Empty)];
             Assert.NotNull(registeredTaskRecords); // "Task to be found in TaskRegistry.TaskRegistrations!"
             Assert.Single(registeredTaskRecords); // "Expected only one task registered under this TaskName!"
             TaskRegistry.RegisteredTaskRecord.ParameterGroupAndTaskElementRecord inlineTaskRecord = registeredTaskRecords[0].ParameterGroupAndTaskBody;
@@ -1312,7 +1203,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             IDictionary<TaskRegistry.RegisteredTaskIdentity, List<TaskRegistry.RegisteredTaskRecord>> registeredTasks = registry.TaskRegistrations;
 
             ProjectUsingTaskElement taskElement = elementList[0];
-            List<TaskRegistry.RegisteredTaskRecord> registeredTaskRecords = registry.TaskRegistrations[new TaskRegistry.RegisteredTaskIdentity("Name", null)];
+            List<TaskRegistry.RegisteredTaskRecord> registeredTaskRecords = registry.TaskRegistrations[new TaskRegistry.RegisteredTaskIdentity("Name", TaskHostParameters.Empty)];
             Assert.NotNull(registeredTaskRecords); // "Task to be found in TaskRegistry.TaskRegistrations!"
             Assert.Single(registeredTaskRecords); // "Expected only one task registered under this TaskName!"
 
@@ -1348,7 +1239,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
 
             List<ProjectUsingTaskElement> elementList = CreateParameterElementWithAttributes(output, required, type);
             TaskRegistry registry = CreateTaskRegistryAndRegisterTasks(elementList);
-            Assert.True(registry.TaskRegistrations[new TaskRegistry.RegisteredTaskIdentity("Name", null)][0].ParameterGroupAndTaskBody.UsingTaskParameters["ParameterWithAllAttributesHardCoded"].PropertyType.Equals(typeof(String)));
+            Assert.True(registry.TaskRegistrations[new TaskRegistry.RegisteredTaskIdentity("Name", TaskHostParameters.Empty)][0].ParameterGroupAndTaskBody.UsingTaskParameters["ParameterWithAllAttributesHardCoded"].PropertyType.Equals(typeof(String)));
         }
 
         /// <summary>
@@ -1363,7 +1254,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
 
             List<ProjectUsingTaskElement> elementList = CreateParameterElementWithAttributes(output, required, type);
             TaskRegistry registry = CreateTaskRegistryAndRegisterTasks(elementList);
-            Assert.True(registry.TaskRegistrations[new TaskRegistry.RegisteredTaskIdentity("Name", null)][0].ParameterGroupAndTaskBody.UsingTaskParameters["ParameterWithAllAttributesHardCoded"].PropertyType.Equals(typeof(String)));
+            Assert.True(registry.TaskRegistrations[new TaskRegistry.RegisteredTaskIdentity("Name", TaskHostParameters.Empty)][0].ParameterGroupAndTaskBody.UsingTaskParameters["ParameterWithAllAttributesHardCoded"].PropertyType.Equals(typeof(String)));
         }
 
         /// <summary>
@@ -1573,7 +1464,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
 
             List<ProjectUsingTaskElement> elementList = CreateParameterElementWithAttributes(output, required, type);
             TaskRegistry registry = CreateTaskRegistryAndRegisterTasks(elementList);
-            Assert.False(((TaskPropertyInfo)registry.TaskRegistrations[new TaskRegistry.RegisteredTaskIdentity("Name", null)][0].ParameterGroupAndTaskBody.UsingTaskParameters["ParameterWithAllAttributesHardCoded"]).Output);
+            Assert.False(((TaskPropertyInfo)registry.TaskRegistrations[new TaskRegistry.RegisteredTaskIdentity("Name", TaskHostParameters.Empty)][0].ParameterGroupAndTaskBody.UsingTaskParameters["ParameterWithAllAttributesHardCoded"]).Output);
         }
 
         /// <summary>
@@ -1588,7 +1479,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
 
             List<ProjectUsingTaskElement> elementList = CreateParameterElementWithAttributes(output, required, type);
             TaskRegistry registry = CreateTaskRegistryAndRegisterTasks(elementList);
-            Assert.False(((TaskPropertyInfo)registry.TaskRegistrations[new TaskRegistry.RegisteredTaskIdentity("Name", null)][0].ParameterGroupAndTaskBody.UsingTaskParameters["ParameterWithAllAttributesHardCoded"]).Output);
+            Assert.False(((TaskPropertyInfo)registry.TaskRegistrations[new TaskRegistry.RegisteredTaskIdentity("Name", TaskHostParameters.Empty)][0].ParameterGroupAndTaskBody.UsingTaskParameters["ParameterWithAllAttributesHardCoded"]).Output);
         }
 
         /// <summary>
@@ -1620,7 +1511,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
 
             List<ProjectUsingTaskElement> elementList = CreateParameterElementWithAttributes(output, required, type);
             TaskRegistry registry = CreateTaskRegistryAndRegisterTasks(elementList);
-            Assert.False(((TaskPropertyInfo)registry.TaskRegistrations[new TaskRegistry.RegisteredTaskIdentity("Name", null)][0].ParameterGroupAndTaskBody.UsingTaskParameters["ParameterWithAllAttributesHardCoded"]).Required);
+            Assert.False(((TaskPropertyInfo)registry.TaskRegistrations[new TaskRegistry.RegisteredTaskIdentity("Name", TaskHostParameters.Empty)][0].ParameterGroupAndTaskBody.UsingTaskParameters["ParameterWithAllAttributesHardCoded"]).Required);
         }
 
         /// <summary>
@@ -1635,7 +1526,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
 
             List<ProjectUsingTaskElement> elementList = CreateParameterElementWithAttributes(output, required, type);
             TaskRegistry registry = CreateTaskRegistryAndRegisterTasks(elementList);
-            Assert.False(((TaskPropertyInfo)registry.TaskRegistrations[new TaskRegistry.RegisteredTaskIdentity("Name", null)][0].ParameterGroupAndTaskBody.UsingTaskParameters["ParameterWithAllAttributesHardCoded"]).Required);
+            Assert.False(((TaskPropertyInfo)registry.TaskRegistrations[new TaskRegistry.RegisteredTaskIdentity("Name", TaskHostParameters.Empty)][0].ParameterGroupAndTaskBody.UsingTaskParameters["ParameterWithAllAttributesHardCoded"]).Required);
         }
 
         /// <summary>
@@ -1685,7 +1576,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             IDictionary<TaskRegistry.RegisteredTaskIdentity, List<TaskRegistry.RegisteredTaskRecord>> registeredTasks = registry.TaskRegistrations;
 
             ProjectUsingTaskElement taskElement = elementList[0];
-            List<TaskRegistry.RegisteredTaskRecord> registeredTaskRecords = registry.TaskRegistrations[new TaskRegistry.RegisteredTaskIdentity("Name", null)];
+            List<TaskRegistry.RegisteredTaskRecord> registeredTaskRecords = registry.TaskRegistrations[new TaskRegistry.RegisteredTaskIdentity("Name", TaskHostParameters.Empty)];
             Assert.NotNull(registeredTaskRecords); // "Task to be found in TaskRegistry.TaskRegistrations!"
             Assert.Single(registeredTaskRecords); // "Expected only one task registered under this TaskName!"
 
@@ -1734,7 +1625,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
 
             TaskRegistry registry = CreateTaskRegistryAndRegisterTasks(elementList);
 
-            List<TaskRegistry.RegisteredTaskRecord> registeredTaskRecords = registry.TaskRegistrations[new TaskRegistry.RegisteredTaskIdentity("Name", null)];
+            List<TaskRegistry.RegisteredTaskRecord> registeredTaskRecords = registry.TaskRegistrations[new TaskRegistry.RegisteredTaskIdentity("Name", TaskHostParameters.Empty)];
             Assert.Single(registeredTaskRecords); // "Expected only one task registered under this TaskName!"
 
             TaskRegistry.RegisteredTaskRecord.ParameterGroupAndTaskElementRecord inlineTaskRecord = registeredTaskRecords[0].ParameterGroupAndTaskBody;
@@ -1758,7 +1649,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
 
             TaskRegistry registry = CreateTaskRegistryAndRegisterTasks(elementList);
 
-            List<TaskRegistry.RegisteredTaskRecord> registeredTaskRecords = registry.TaskRegistrations[new TaskRegistry.RegisteredTaskIdentity("Name", null)];
+            List<TaskRegistry.RegisteredTaskRecord> registeredTaskRecords = registry.TaskRegistrations[new TaskRegistry.RegisteredTaskIdentity("Name", TaskHostParameters.Empty)];
             Assert.Single(registeredTaskRecords); // "Expected only one task registered under this TaskName!"
 
             TaskRegistry.RegisteredTaskRecord.ParameterGroupAndTaskElementRecord inlineTaskRecord = registeredTaskRecords[0].ParameterGroupAndTaskBody;
@@ -1777,7 +1668,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             TaskRegistry registry = CreateTaskRegistryAndRegisterTasks(elementList);
 
             // Make sure when evaluate is false the string passed in is not expanded
-            Assert.False(registry.TaskRegistrations[new TaskRegistry.RegisteredTaskIdentity("Name", null)][0].ParameterGroupAndTaskBody.TaskBodyEvaluated.Equals(body));
+            Assert.False(registry.TaskRegistrations[new TaskRegistry.RegisteredTaskIdentity("Name", TaskHostParameters.Empty)][0].ParameterGroupAndTaskBody.TaskBodyEvaluated.Equals(body));
         }
 
         /// <summary>
@@ -1795,7 +1686,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             TaskRegistry registry = CreateTaskRegistryAndRegisterTasks(elementList);
 
             // Make sure when evaluate is false the string passed in is not expanded
-            Assert.False(registry.TaskRegistrations[new TaskRegistry.RegisteredTaskIdentity("Name", null)][0].ParameterGroupAndTaskBody.TaskBodyEvaluated.Equals(expandedBody));
+            Assert.False(registry.TaskRegistrations[new TaskRegistry.RegisteredTaskIdentity("Name", TaskHostParameters.Empty)][0].ParameterGroupAndTaskBody.TaskBodyEvaluated.Equals(expandedBody));
         }
 
         /// <summary>
@@ -1821,7 +1712,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             string evaluate = bool.FalseString;
             List<ProjectUsingTaskElement> elementList = CreateTaskBodyElementWithAttributes(evaluate, "");
             TaskRegistry registry = CreateTaskRegistryAndRegisterTasks(elementList);
-            Assert.False(registry.TaskRegistrations[new TaskRegistry.RegisteredTaskIdentity("Name", null)][0].ParameterGroupAndTaskBody.TaskBodyEvaluated);
+            Assert.False(registry.TaskRegistrations[new TaskRegistry.RegisteredTaskIdentity("Name", TaskHostParameters.Empty)][0].ParameterGroupAndTaskBody.TaskBodyEvaluated);
         }
 
         /// <summary>
@@ -1833,7 +1724,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             string evaluate = "";
             List<ProjectUsingTaskElement> elementList = CreateTaskBodyElementWithAttributes(evaluate, "");
             TaskRegistry registry = CreateTaskRegistryAndRegisterTasks(elementList);
-            Assert.True(registry.TaskRegistrations[new TaskRegistry.RegisteredTaskIdentity("Name", null)][0].ParameterGroupAndTaskBody.TaskBodyEvaluated);
+            Assert.True(registry.TaskRegistrations[new TaskRegistry.RegisteredTaskIdentity("Name", TaskHostParameters.Empty)][0].ParameterGroupAndTaskBody.TaskBodyEvaluated);
         }
 
         /// <summary>
@@ -1845,7 +1736,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             string evaluate = null;
             List<ProjectUsingTaskElement> elementList = CreateTaskBodyElementWithAttributes(evaluate, "");
             TaskRegistry registry = CreateTaskRegistryAndRegisterTasks(elementList);
-            Assert.True(registry.TaskRegistrations[new TaskRegistry.RegisteredTaskIdentity("Name", null)][0].ParameterGroupAndTaskBody.TaskBodyEvaluated);
+            Assert.True(registry.TaskRegistrations[new TaskRegistry.RegisteredTaskIdentity("Name", TaskHostParameters.Empty)][0].ParameterGroupAndTaskBody.TaskBodyEvaluated);
         }
         #endregion
 
@@ -2001,7 +1892,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
         private void RetrieveAndValidateRegisteredTaskRecord(
                                                             TaskRegistry registry,
                                                             bool exactMatchRequired,
-                                                            Dictionary<string, string> taskParameters,
+                                                            TaskHostParameters taskParameters,
                                                             bool shouldBeRetrieved,
                                                             bool shouldBeRetrievedFromCache,
                                                             string expectedRuntime,
@@ -2016,12 +1907,12 @@ namespace Microsoft.Build.UnitTests.BackEnd
 
                 if (expectedRuntime != null)
                 {
-                    Assert.Equal(expectedRuntime, record.TaskFactoryParameters[XMakeAttributes.runtime]);
+                    Assert.Equal(expectedRuntime, record.TaskFactoryParameters.Runtime);
                 }
 
                 if (expectedArchitecture != null)
                 {
-                    Assert.Equal(expectedArchitecture, record.TaskFactoryParameters[XMakeAttributes.architecture]);
+                    Assert.Equal(expectedArchitecture, record.TaskFactoryParameters.Architecture);
                 }
             }
             else
@@ -2041,48 +1932,22 @@ namespace Microsoft.Build.UnitTests.BackEnd
         ///   values as its factory parameters.
         /// </summary>
         private void RetrieveAndValidateRegisteredTaskRecord(
-                                                            TaskRegistry registry,
-                                                            bool exactMatchRequired,
-                                                            string runtime,
-                                                            string architecture,
-                                                            bool shouldBeRetrieved,
-                                                            bool shouldBeRetrievedFromCache,
-                                                            string expectedRuntime,
-                                                            string expectedArchitecture)
+            TaskRegistry registry,
+            bool exactMatchRequired,
+            string runtime,
+            string architecture,
+            bool shouldBeRetrieved,
+            bool shouldBeRetrievedFromCache,
+            string expectedRuntime,
+            string expectedArchitecture)
         {
-            Dictionary<string, string> parameters = null;
+            TaskHostParameters parameters = TaskHostParameters.Empty;
             if (runtime != null || architecture != null)
             {
-                parameters = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
-                {
-                    {XMakeAttributes.runtime, runtime ?? XMakeAttributes.MSBuildRuntimeValues.any},
-                    {XMakeAttributes.architecture, architecture ?? XMakeAttributes.MSBuildArchitectureValues.any}
-                };
+                parameters = new(runtime ?? XMakeAttributes.MSBuildRuntimeValues.any, architecture ?? XMakeAttributes.MSBuildArchitectureValues.any);
             }
 
             RetrieveAndValidateRegisteredTaskRecord(registry, exactMatchRequired, parameters, shouldBeRetrieved, shouldBeRetrievedFromCache, expectedRuntime, expectedArchitecture);
-        }
-
-        /// <summary>
-        /// With the given task registry, retrieve a copy of the test task with the given runtime and
-        /// architecture and verify:
-        /// - that it was retrieved (or not) as expected
-        /// - that it was retrieved from the cache (or not) as expected
-        /// </summary>
-        private void RetrieveAndValidateRegisteredTaskRecord(TaskRegistry registry, bool exactMatchRequired, Dictionary<string, string> taskParameters, bool shouldBeRetrieved, bool shouldBeRetrievedFromCache)
-        {
-            // if we're requiring an exact match, we can cheat and figure out what the expected runtime / architecture should be.
-            // if not, then if the user didn't pass us an expected runtime, we can't really check it, so just pass
-            // null (which will be treated as "don't validate").
-            string expectedRuntime = null;
-            string expectedArchitecture = null;
-            if (exactMatchRequired)
-            {
-                taskParameters.TryGetValue(XMakeAttributes.runtime, out expectedRuntime);
-                taskParameters.TryGetValue(XMakeAttributes.architecture, out expectedArchitecture);
-            }
-
-            RetrieveAndValidateRegisteredTaskRecord(registry, exactMatchRequired, taskParameters, shouldBeRetrieved, shouldBeRetrievedFromCache, expectedRuntime, expectedArchitecture);
         }
 
         /// <summary>
@@ -2125,7 +1990,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
                     true /* case-insensitive */);
             }
 
-            Assert.True(registry.TaskRegistrations[new TaskRegistry.RegisteredTaskIdentity("Name", null)][0].ParameterGroupAndTaskBody.UsingTaskParameters["ParameterWithAllAttributesHardCoded"].PropertyType.Equals(paramType));
+            Assert.True(registry.TaskRegistrations[new TaskRegistry.RegisteredTaskIdentity("Name", TaskHostParameters.Empty)][0].ParameterGroupAndTaskBody.UsingTaskParameters["ParameterWithAllAttributesHardCoded"].PropertyType.Equals(paramType));
         }
 
         /// <summary>

--- a/src/Build.UnitTests/Definition/ToolsVersion_Tests.cs
+++ b/src/Build.UnitTests/Definition/ToolsVersion_Tests.cs
@@ -47,25 +47,25 @@ namespace Microsoft.Build.UnitTests.Definition
 
             foreach (string expectedRegisteredTask in expectedRegisteredTasks)
             {
-                Assert.True(taskRegistry.TaskRegistrations.ContainsKey(new TaskRegistry.RegisteredTaskIdentity(expectedRegisteredTask, null)),
+                Assert.True(taskRegistry.TaskRegistrations.ContainsKey(new TaskRegistry.RegisteredTaskIdentity(expectedRegisteredTask, TaskHostParameters.Empty)),
                               String.Format("Expected task '{0}' registered!", expectedRegisteredTask));
             }
 
             foreach (string expectedRegisteredTask in expectedOverrideTasks)
             {
-                Assert.True(taskoverrideRegistry.TaskRegistrations.ContainsKey(new TaskRegistry.RegisteredTaskIdentity(expectedRegisteredTask, null)),
+                Assert.True(taskoverrideRegistry.TaskRegistrations.ContainsKey(new TaskRegistry.RegisteredTaskIdentity(expectedRegisteredTask, TaskHostParameters.Empty)),
                               String.Format("Expected task '{0}' registered!", expectedRegisteredTask));
             }
 
             foreach (string unexpectedRegisteredTask in unexpectedRegisteredTasks)
             {
-                Assert.False(taskRegistry.TaskRegistrations.ContainsKey(new TaskRegistry.RegisteredTaskIdentity(unexpectedRegisteredTask, null)),
+                Assert.False(taskRegistry.TaskRegistrations.ContainsKey(new TaskRegistry.RegisteredTaskIdentity(unexpectedRegisteredTask, TaskHostParameters.Empty)),
                               String.Format("Unexpected task '{0}' registered!", unexpectedRegisteredTask));
             }
 
             foreach (string unexpectedRegisteredTask in unexpectedOverrideRegisteredTasks)
             {
-                Assert.False(taskoverrideRegistry.TaskRegistrations.ContainsKey(new TaskRegistry.RegisteredTaskIdentity(unexpectedRegisteredTask, null)),
+                Assert.False(taskoverrideRegistry.TaskRegistrations.ContainsKey(new TaskRegistry.RegisteredTaskIdentity(unexpectedRegisteredTask, TaskHostParameters.Empty)),
                               String.Format("Unexpected task '{0}' registered!", unexpectedRegisteredTask));
             }
         }
@@ -172,12 +172,12 @@ namespace Microsoft.Build.UnitTests.Definition
 
             foreach (string expectedRegisteredTask in expectedRegisteredTasks)
             {
-                Assert.True(taskRegistry.TaskRegistrations.ContainsKey(new TaskRegistry.RegisteredTaskIdentity(expectedRegisteredTask, null)),
+                Assert.True(taskRegistry.TaskRegistrations.ContainsKey(new TaskRegistry.RegisteredTaskIdentity(expectedRegisteredTask, TaskHostParameters.Empty)),
                               String.Format("Expected task '{0}' registered!", expectedRegisteredTask));
             }
             foreach (string unexpectedRegisteredTask in unexpectedRegisteredTasks)
             {
-                Assert.False(taskRegistry.TaskRegistrations.ContainsKey(new TaskRegistry.RegisteredTaskIdentity(unexpectedRegisteredTask, null)),
+                Assert.False(taskRegistry.TaskRegistrations.ContainsKey(new TaskRegistry.RegisteredTaskIdentity(unexpectedRegisteredTask, TaskHostParameters.Empty)),
                               String.Format("Unexpected task '{0}' registered!", unexpectedRegisteredTask));
             }
         }
@@ -202,7 +202,7 @@ namespace Microsoft.Build.UnitTests.Definition
             Assert.Equal(1, mockLogger.WarningCount); // "Expected 1 warning logged!"
             foreach (string unexpectedRegisteredTask in unexpectedRegisteredTasks)
             {
-                Assert.False(taskRegistry.TaskRegistrations.ContainsKey(new TaskRegistry.RegisteredTaskIdentity(unexpectedRegisteredTask, null)),
+                Assert.False(taskRegistry.TaskRegistrations.ContainsKey(new TaskRegistry.RegisteredTaskIdentity(unexpectedRegisteredTask, TaskHostParameters.Empty)),
                                String.Format("Unexpected task '{0}' registered!", unexpectedRegisteredTask));
             }
         }

--- a/src/Build.UnitTests/Instance/ProjectInstance_Internal_Tests.cs
+++ b/src/Build.UnitTests/Instance/ProjectInstance_Internal_Tests.cs
@@ -70,10 +70,10 @@ namespace Microsoft.Build.UnitTests.OM.Instance
                 ProjectInstance project = new Project(projectRootElementFromString.Project).CreateProjectInstance();
 
                 project.TaskRegistry.TaskRegistrations.Count.ShouldBe(3);
-                project.TaskRegistry.TaskRegistrations[new TaskRegistry.RegisteredTaskIdentity("t0", null)][0].TaskFactoryAssemblyLoadInfo.AssemblyFile.ShouldBe(Path.Combine(Directory.GetCurrentDirectory(), "af0"));
-                project.TaskRegistry.TaskRegistrations[new TaskRegistry.RegisteredTaskIdentity("t1", null)][0].TaskFactoryAssemblyLoadInfo.AssemblyFile.ShouldBe(Path.Combine(Directory.GetCurrentDirectory(), "af1a"));
-                project.TaskRegistry.TaskRegistrations[new TaskRegistry.RegisteredTaskIdentity("t1", null)][1].TaskFactoryAssemblyLoadInfo.AssemblyName.ShouldBe("an1");
-                project.TaskRegistry.TaskRegistrations[new TaskRegistry.RegisteredTaskIdentity("t2", null)][0].TaskFactoryAssemblyLoadInfo.AssemblyName.ShouldBe("an2");
+                project.TaskRegistry.TaskRegistrations[new TaskRegistry.RegisteredTaskIdentity("t0", TaskHostParameters.Empty)][0].TaskFactoryAssemblyLoadInfo.AssemblyFile.ShouldBe(Path.Combine(Directory.GetCurrentDirectory(), "af0"));
+                project.TaskRegistry.TaskRegistrations[new TaskRegistry.RegisteredTaskIdentity("t1", TaskHostParameters.Empty)][0].TaskFactoryAssemblyLoadInfo.AssemblyFile.ShouldBe(Path.Combine(Directory.GetCurrentDirectory(), "af1a"));
+                project.TaskRegistry.TaskRegistrations[new TaskRegistry.RegisteredTaskIdentity("t1", TaskHostParameters.Empty)][1].TaskFactoryAssemblyLoadInfo.AssemblyName.ShouldBe("an1");
+                project.TaskRegistry.TaskRegistrations[new TaskRegistry.RegisteredTaskIdentity("t2", TaskHostParameters.Empty)][0].TaskFactoryAssemblyLoadInfo.AssemblyName.ShouldBe("an2");
             }
             finally
             {

--- a/src/Build.UnitTests/TestComparers/TaskRegistryComparers.cs
+++ b/src/Build.UnitTests/TestComparers/TaskRegistryComparers.cs
@@ -50,14 +50,14 @@ namespace Microsoft.Build.Engine.UnitTests.TestComparers
                 Assert.Equal(x.TaskFactoryAttributeName, y.TaskFactoryAttributeName);
                 Assert.Equal(x.ParameterGroupAndTaskBody, y.ParameterGroupAndTaskBody, new ParamterGroupAndTaskBodyComparer());
 
-                Helpers.AssertDictionariesEqual(
-                    x.TaskFactoryParameters,
-                    y.TaskFactoryParameters,
-                    (xp, yp) =>
-                    {
-                        Assert.Equal(xp.Key, yp.Key);
-                        Assert.Equal(xp.Value, yp.Value);
-                    });
+                // Assert TaskFactoryParameters equality
+                var xParams = x.TaskFactoryParameters;
+                var yParams = y.TaskFactoryParameters;
+                Assert.Equal(xParams.Runtime, yParams.Runtime);
+                Assert.Equal(xParams.Architecture, yParams.Architecture);
+                Assert.Equal(xParams.DotnetHostPath, yParams.DotnetHostPath);
+                Assert.Equal(xParams.MSBuildAssemblyPath, yParams.MSBuildAssemblyPath);
+                Assert.Equal(xParams.IsTaskHostFactory, yParams.IsTaskHostFactory);
 
                 return true;
             }

--- a/src/Build/BackEnd/Client/MSBuildClient.cs
+++ b/src/Build/BackEnd/Client/MSBuildClient.cs
@@ -534,10 +534,10 @@ namespace Microsoft.Build.Experimental
                         partialBuildTelemetry);
         }
 
-        private ServerNodeHandshake GetHandshake()
-        {
-            return new ServerNodeHandshake(CommunicationsUtilities.GetHandshakeOptions(taskHost: false, architectureFlagToSet: XMakeAttributes.GetCurrentMSBuildArchitecture()));
-        }
+        private ServerNodeHandshake GetHandshake() => new(CommunicationsUtilities.GetHandshakeOptions(
+            taskHost: false,
+            taskHostParameters: TaskHostParameters.Empty,
+            architectureFlagToSet: XMakeAttributes.GetCurrentMSBuildArchitecture()));
 
         /// <summary>
         /// Handle cancellation.

--- a/src/Build/BackEnd/Components/Communications/NodeEndpointOutOfProc.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeEndpointOutOfProc.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.Build.Framework;
 using Microsoft.Build.Internal;
 using Microsoft.Build.Shared;
 
@@ -35,6 +36,7 @@ namespace Microsoft.Build.BackEnd
         {
             HandshakeOptions handshakeOptions = CommunicationsUtilities.GetHandshakeOptions(
                 taskHost: false,
+                taskHostParameters: TaskHostParameters.Empty,
                 architectureFlagToSet: XMakeAttributes.GetCurrentMSBuildArchitecture(),
                 nodeReuse: _enableReuse,
                 lowPriority: LowPriority);

--- a/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProc.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProc.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Build.BackEnd
         internal static Handshake GetHandshake(bool enableNodeReuse, bool enableLowPriority)
         {
             CommunicationsUtilities.Trace("MSBUILDNODEHANDSHAKESALT=\"{0}\", msbuildDirectory=\"{1}\", enableNodeReuse={2}, enableLowPriority={3}", Traits.MSBuildNodeHandshakeSalt, BuildEnvironmentHelper.Instance.MSBuildToolsDirectory32, enableNodeReuse, enableLowPriority);
-            return new Handshake(CommunicationsUtilities.GetHandshakeOptions(taskHost: false, architectureFlagToSet: XMakeAttributes.GetCurrentMSBuildArchitecture(), nodeReuse: enableNodeReuse, lowPriority: enableLowPriority));
+            return new Handshake(CommunicationsUtilities.GetHandshakeOptions(taskHost: false, taskHostParameters: TaskHostParameters.Empty, architectureFlagToSet: XMakeAttributes.GetCurrentMSBuildArchitecture(), nodeReuse: enableNodeReuse, lowPriority: enableLowPriority));
         }
 
         /// <summary>
@@ -98,7 +98,7 @@ namespace Microsoft.Build.BackEnd
 
             CommunicationsUtilities.Trace("Starting to acquire {1} new or existing node(s) to establish nodes from ID {0} to {2}...", nextNodeId, numberOfNodesToCreate, nextNodeId + numberOfNodesToCreate - 1);
 
-            Handshake hostHandshake = new(CommunicationsUtilities.GetHandshakeOptions(taskHost: false, architectureFlagToSet: XMakeAttributes.GetCurrentMSBuildArchitecture(), nodeReuse: ComponentHost.BuildParameters.EnableNodeReuse, lowPriority: ComponentHost.BuildParameters.LowPriority));
+            Handshake hostHandshake = new(CommunicationsUtilities.GetHandshakeOptions(taskHost: false, taskHostParameters: TaskHostParameters.Empty, architectureFlagToSet: XMakeAttributes.GetCurrentMSBuildArchitecture(), nodeReuse: ComponentHost.BuildParameters.EnableNodeReuse, lowPriority: ComponentHost.BuildParameters.LowPriority));
             IList<NodeContext> nodeContexts = GetNodes(null, commandLineArgs, nextNodeId, factory, hostHandshake, NodeContextCreated, NodeContextTerminated, numberOfNodesToCreate);
 
             if (nodeContexts.Count > 0)

--- a/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcTaskHost.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcTaskHost.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using Microsoft.Build.Exceptions;
+using Microsoft.Build.Framework;
 using Microsoft.Build.Internal;
 using Microsoft.Build.Shared;
 using Microsoft.Build.Shared.FileSystem;
@@ -450,23 +451,20 @@ namespace Microsoft.Build.BackEnd
         /// - RuntimeHostPath: The path to the dotnet executable that will host the .NET runtime
         /// - MSBuildAssemblyPath: The full path to MSBuild.dll that will be loaded by the dotnet host.
         /// </returns>
-        internal static (string RuntimeHostPath, string MSBuildAssemblyPath) GetMSBuildLocationForNETRuntime(HandshakeOptions hostContext, Dictionary<string, string> taskHostParameters)
+        internal static (string RuntimeHostPath, string MSBuildAssemblyPath) GetMSBuildLocationForNETRuntime(HandshakeOptions hostContext, TaskHostParameters taskHostParameters)
         {
             ErrorUtilities.VerifyThrowInternalErrorUnreachable(Handshake.IsHandshakeOptionEnabled(hostContext, HandshakeOptions.TaskHost));
 
-            taskHostParameters.TryGetValue(Constants.DotnetHostPath, out string runtimeHostPath);
-            var msbuildAssemblyPath = GetMSBuildAssemblyPath(taskHostParameters);
-
-            return (runtimeHostPath, msbuildAssemblyPath);
+            return (taskHostParameters.DotnetHostPath, GetMSBuildAssemblyPath(taskHostParameters));
         }
 
-        private static string GetMSBuildAssemblyPath(Dictionary<string, string> taskHostParameters)
+        private static string GetMSBuildAssemblyPath(TaskHostParameters taskHostParameters)
         {
-            if (taskHostParameters.TryGetValue(Constants.MSBuildAssemblyPath, out string msbuildAssemblyPath))
+            if (taskHostParameters.MSBuildAssemblyPath != null)
             {
-                ValidateNetHostSdkVersion(msbuildAssemblyPath);
+                ValidateNetHostSdkVersion(taskHostParameters.MSBuildAssemblyPath);
 
-                return msbuildAssemblyPath;
+                return taskHostParameters.MSBuildAssemblyPath;
             }
 
             throw new InvalidProjectFileException(ResourceUtilities.GetResourceString("NETHostTaskLoad_Failed"));
@@ -572,7 +570,7 @@ namespace Microsoft.Build.BackEnd
             INodePacketFactory factory,
             INodePacketHandler handler,
             TaskHostConfiguration configuration,
-            Dictionary<string, string> taskHostParameters)
+            TaskHostParameters taskHostParameters)
         {
             bool nodeCreationSucceeded;
             if (!_nodeContexts.ContainsKey(taskHostNodeId))
@@ -613,7 +611,7 @@ namespace Microsoft.Build.BackEnd
         /// <summary>
         /// Instantiates a new MSBuild or MSBuildTaskHost process acting as a child node.
         /// </summary>
-        internal bool CreateNode(HandshakeOptions hostContext, int taskHostNodeId, INodePacketFactory factory, INodePacketHandler handler, TaskHostConfiguration configuration, Dictionary<string, string> taskHostParameters)
+        internal bool CreateNode(HandshakeOptions hostContext, int taskHostNodeId, INodePacketFactory factory, INodePacketHandler handler, TaskHostConfiguration configuration, TaskHostParameters taskHostParameters)
         {
             ErrorUtilities.VerifyThrowArgumentNull(factory);
             ErrorUtilities.VerifyThrow(!_nodeIdToPacketFactory.ContainsKey(taskHostNodeId), "We should not already have a factory for this context!  Did we forget to call DisconnectFromHost somewhere?");

--- a/src/Build/BackEnd/Components/RequestBuilder/TaskBuilder.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TaskBuilder.cs
@@ -421,7 +421,7 @@ namespace Microsoft.Build.BackEnd
                 if (howToExecuteTask == TaskExecutionMode.ExecuteTaskAndGatherOutputs)
                 {
                     // We need to find the task before logging the task started event so that the using task statement comes before the task started event
-                    IDictionary<string, string> taskIdentityParameters = GatherTaskIdentityParameters(bucket.Expander);
+                    TaskHostParameters taskIdentityParameters = GatherTaskIdentityParameters(bucket.Expander);
                     (TaskRequirements? requirements, TaskFactoryWrapper taskFactoryWrapper) = _taskExecutionHost.FindTask(taskIdentityParameters);
                     string taskAssemblyLocation = taskFactoryWrapper?.TaskFactoryLoadedType?.Path;
 
@@ -527,29 +527,24 @@ namespace Microsoft.Build.BackEnd
         /// <summary>
         /// Returns the set of parameters that can contribute to a task's identity, and their values for this particular task.
         /// </summary>
-        private IDictionary<string, string> GatherTaskIdentityParameters(Expander<ProjectPropertyInstance, ProjectItemInstance> expander)
+        private TaskHostParameters GatherTaskIdentityParameters(Expander<ProjectPropertyInstance, ProjectItemInstance> expander)
         {
             ErrorUtilities.VerifyThrowInternalNull(_taskNode, "taskNode"); // taskNode should never be null when we're calling this method.
 
             string msbuildArchitecture = expander.ExpandIntoStringAndUnescape(_taskNode.MSBuildArchitecture ?? String.Empty, ExpanderOptions.ExpandAll, _taskNode.MSBuildArchitectureLocation ?? ElementLocation.EmptyLocation);
             string msbuildRuntime = expander.ExpandIntoStringAndUnescape(_taskNode.MSBuildRuntime ?? String.Empty, ExpanderOptions.ExpandAll, _taskNode.MSBuildRuntimeLocation ?? ElementLocation.EmptyLocation);
 
-            IDictionary<string, string> taskIdentityParameters = null;
-
             // only bother to create a task identity parameter set if we're putting anything in there -- otherwise,
             // a null set will be treated as equivalent to all parameters being "don't care".
             if (msbuildRuntime != string.Empty || msbuildArchitecture != string.Empty)
             {
-                taskIdentityParameters = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-
                 msbuildArchitecture = msbuildArchitecture == string.Empty ? XMakeAttributes.MSBuildArchitectureValues.any : msbuildArchitecture.Trim();
                 msbuildRuntime = msbuildRuntime == string.Empty ? XMakeAttributes.MSBuildRuntimeValues.any : msbuildRuntime.Trim();
 
-                taskIdentityParameters.Add(XMakeAttributes.runtime, msbuildRuntime);
-                taskIdentityParameters.Add(XMakeAttributes.architecture, msbuildArchitecture);
+                return new TaskHostParameters(msbuildRuntime, msbuildArchitecture);
             }
 
-            return taskIdentityParameters;
+            return TaskHostParameters.Empty;
         }
 
 #if FEATURE_APARTMENT_STATE
@@ -561,7 +556,7 @@ namespace Microsoft.Build.BackEnd
         /// Any bug fixes made to this code, please ensure that you also fix that code.
         /// </comment>
         [SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes", Justification = "Exception is caught and rethrown in the correct thread.")]
-        private WorkUnitResult ExecuteTaskInSTAThread(ItemBucket bucket, TaskLoggingContext taskLoggingContext, IDictionary<string, string> taskIdentityParameters, TaskHost taskHost, TaskExecutionMode howToExecuteTask)
+        private WorkUnitResult ExecuteTaskInSTAThread(ItemBucket bucket, TaskLoggingContext taskLoggingContext, TaskHostParameters taskIdentityParameters, TaskHost taskHost, TaskExecutionMode howToExecuteTask)
         {
             WorkUnitResult taskResult = new WorkUnitResult(WorkUnitResultCode.Failed, WorkUnitActionCode.Stop, null);
             Thread staThread = null;
@@ -656,7 +651,7 @@ namespace Microsoft.Build.BackEnd
         /// <summary>
         /// Initializes and executes the task.
         /// </summary>
-        private async Task<WorkUnitResult> InitializeAndExecuteTask(TaskLoggingContext taskLoggingContext, ItemBucket bucket, IDictionary<string, string> taskIdentityParameters, TaskHost taskHost, TaskExecutionMode howToExecuteTask)
+        private async Task<WorkUnitResult> InitializeAndExecuteTask(TaskLoggingContext taskLoggingContext, ItemBucket bucket, TaskHostParameters taskIdentityParameters, TaskHost taskHost, TaskExecutionMode howToExecuteTask)
         {
             if (!_taskExecutionHost.InitializeForBatch(taskLoggingContext, bucket, taskIdentityParameters, _buildRequestEntry.Request.ScheduledNodeId))
             {

--- a/src/Build/BackEnd/Node/OutOfProcServerNode.cs
+++ b/src/Build/BackEnd/Node/OutOfProcServerNode.cs
@@ -99,7 +99,7 @@ namespace Microsoft.Build.Experimental
         public NodeEngineShutdownReason Run(out Exception? shutdownException)
         {
             ServerNodeHandshake handshake = new(
-                CommunicationsUtilities.GetHandshakeOptions(taskHost: false, architectureFlagToSet: XMakeAttributes.GetCurrentMSBuildArchitecture()));
+                CommunicationsUtilities.GetHandshakeOptions(taskHost: false, taskHostParameters: TaskHostParameters.Empty, architectureFlagToSet: XMakeAttributes.GetCurrentMSBuildArchitecture()));
 
             _serverBusyMutexName = GetBusyServerMutexName(handshake);
 

--- a/src/Build/Evaluation/IntrinsicFunctions.cs
+++ b/src/Build/Evaluation/IntrinsicFunctions.cs
@@ -502,11 +502,7 @@ namespace Microsoft.Build.Evaluation
             runtime = XMakeAttributes.GetExplicitMSBuildRuntime(runtime);
             architecture = XMakeAttributes.GetExplicitMSBuildArchitecture(architecture);
 
-            Dictionary<string, string> parameters = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
-            {
-                { XMakeAttributes.runtime, runtime },
-                { XMakeAttributes.architecture, architecture },
-            };
+            TaskHostParameters parameters = new(runtime, architecture);
 
             HandshakeOptions desiredContext = CommunicationsUtilities.GetHandshakeOptions(taskHost: true, taskHostParameters: parameters);
 

--- a/src/Build/Instance/TaskFactories/TaskHostTask.cs
+++ b/src/Build/Instance/TaskFactories/TaskHostTask.cs
@@ -78,7 +78,7 @@ namespace Microsoft.Build.BackEnd
         /// <summary>
         /// The set of parameters used to decide which host to launch.
         /// </summary>
-        private Dictionary<string, string> _taskHostParameters;
+        private TaskHostParameters _taskHostParameters;
 
         /// <summary>
         /// The type of the task that we are wrapping.
@@ -153,7 +153,7 @@ namespace Microsoft.Build.BackEnd
             IElementLocation taskLocation,
             TaskLoggingContext taskLoggingContext,
             IBuildComponentHost buildComponentHost,
-            Dictionary<string, string> taskHostParameters,
+            TaskHostParameters taskHostParameters,
             LoadedType taskType,
             bool taskHostFactoryExplicitlyRequested,
 #if FEATURE_APPDOMAIN
@@ -280,11 +280,13 @@ namespace Microsoft.Build.BackEnd
         /// </summary>
         public bool Execute()
         {
-            // log that we are about to spawn the task host
-            string runtime = _taskHostParameters[XMakeAttributes.runtime];
-            string architecture = _taskHostParameters[XMakeAttributes.architecture];
-        
-            _taskLoggingContext.LogComment(MessageImportance.Low, "ExecutingTaskInTaskHost", _taskType.Type.Name, _taskType.Assembly.AssemblyLocation, runtime, architecture);
+            _taskLoggingContext.LogComment(
+                MessageImportance.Low,
+                "ExecutingTaskInTaskHost",
+                _taskType.Type.Name,
+                _taskType.Assembly.AssemblyLocation,
+                _taskHostParameters.Runtime,
+                _taskHostParameters.Architecture);
 
             // set up the node
             lock (_taskHostLock)
@@ -372,16 +374,16 @@ namespace Microsoft.Build.BackEnd
                 }
                 else
                 {
-                    LogErrorUnableToCreateTaskHost(_requiredContext, runtime, architecture, null);
+                    LogErrorUnableToCreateTaskHost(_requiredContext, _taskHostParameters.Runtime, _taskHostParameters.Architecture, null);
                 }
             }
             catch (BuildAbortedException)
             {
-                LogErrorUnableToCreateTaskHost(_requiredContext, runtime, architecture, null);
+                LogErrorUnableToCreateTaskHost(_requiredContext, _taskHostParameters.Runtime, _taskHostParameters.Architecture, null);
             }
             catch (NodeFailedToLaunchException e)
             {
-                LogErrorUnableToCreateTaskHost(_requiredContext, runtime, architecture, e);
+                LogErrorUnableToCreateTaskHost(_requiredContext, _taskHostParameters.Runtime, _taskHostParameters.Architecture, e);
             }
 
             return _taskExecutionSucceeded;

--- a/src/Build/Instance/TaskFactoryWrapper.cs
+++ b/src/Build/Instance/TaskFactoryWrapper.cs
@@ -68,10 +68,9 @@ namespace Microsoft.Build.Execution
         private string _taskName;
 
         /// <summary>
-        /// The set of special parameters that, along with the name, contribute to the identity of
-        /// this factory.
+        /// The set of special parameters that, along with the name, contribute to the identity of this factory.
         /// </summary>
-        private IDictionary<string, string> _factoryIdentityParameters;
+        private TaskHostParameters _factoryIdentityParameters;
 
         /// <summary>
         /// An execution statistics holder.
@@ -89,7 +88,7 @@ namespace Microsoft.Build.Execution
             ITaskFactory taskFactory,
             LoadedType taskFactoryLoadInfo,
             string taskName,
-            IDictionary<string, string> factoryIdentityParameters,
+            TaskHostParameters factoryIdentityParameters,
             TaskRegistry.RegisteredTaskRecord.Stats? statistics = null)
         {
             ErrorUtilities.VerifyThrowArgumentNull(taskFactory);
@@ -167,13 +166,7 @@ namespace Microsoft.Build.Execution
         /// The set of task identity parameters that were set on
         /// this particular factory's UsingTask statement.
         /// </summary>
-        public IDictionary<string, string> FactoryIdentityParameters
-        {
-            get
-            {
-                return _factoryIdentityParameters;
-            }
-        }
+        public TaskHostParameters FactoryIdentityParameters => _factoryIdentityParameters;
 
         #endregion
 

--- a/src/Build/Instance/TaskRegistry.cs
+++ b/src/Build/Instance/TaskRegistry.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -16,7 +15,6 @@ using Microsoft.Build.Collections;
 using Microsoft.Build.Construction;
 using Microsoft.Build.Evaluation;
 using Microsoft.Build.Framework;
-using Microsoft.Build.Internal;
 using Microsoft.Build.Shared;
 using Microsoft.Build.Shared.FileSystem;
 using Microsoft.NET.StringTools;
@@ -420,17 +418,16 @@ namespace Microsoft.Build.Execution
                 parameterGroupAndTaskElementRecord.ExpandUsingTask<P, I>(projectUsingTaskXml, expander, expanderOptions);
             }
 
-            Dictionary<string, string> taskFactoryParameters = null;
+            TaskHostParameters taskFactoryParameters = TaskHostParameters.Empty;
             string runtime = expander.ExpandIntoStringLeaveEscaped(projectUsingTaskXml.Runtime, expanderOptions, projectUsingTaskXml.RuntimeLocation);
             string architecture = expander.ExpandIntoStringLeaveEscaped(projectUsingTaskXml.Architecture, expanderOptions, projectUsingTaskXml.ArchitectureLocation);
             string overrideUsingTask = expander.ExpandIntoStringLeaveEscaped(projectUsingTaskXml.Override, expanderOptions, projectUsingTaskXml.OverrideLocation);
 
-            if ((runtime != String.Empty) || (architecture != String.Empty))
+            if ((runtime != string.Empty) || (architecture != string.Empty))
             {
-                taskFactoryParameters = CreateTaskFactoryParametersDictionary();
-
-                taskFactoryParameters.Add(XMakeAttributes.runtime, runtime == String.Empty ? XMakeAttributes.MSBuildRuntimeValues.any : runtime);
-                taskFactoryParameters.Add(XMakeAttributes.architecture, architecture == String.Empty ? XMakeAttributes.MSBuildArchitectureValues.any : architecture);
+                taskFactoryParameters = new TaskHostParameters(
+                    runtime == string.Empty ? XMakeAttributes.MSBuildRuntimeValues.any : runtime,
+                    architecture == string.Empty ? XMakeAttributes.MSBuildArchitectureValues.any : architecture);
             }
 
             taskRegistry.RegisterTask(
@@ -444,13 +441,6 @@ namespace Microsoft.Build.Execution
                 ConversionUtilities.ValidBooleanTrue(overrideUsingTask));
         }
 
-        private static Dictionary<string, string> CreateTaskFactoryParametersDictionary(int? initialCount = null)
-        {
-            return initialCount == null
-                ? new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
-                : new Dictionary<string, string>(initialCount.Value, StringComparer.OrdinalIgnoreCase);
-        }
-
         /// <summary>
         /// Given a task name, this method retrieves the task class. If the task has been requested before, it will be found in
         /// the class cache; otherwise, &lt;UsingTask&gt; declarations will be used to search the appropriate assemblies.
@@ -458,7 +448,7 @@ namespace Microsoft.Build.Execution
         internal TaskFactoryWrapper GetRegisteredTask(
             string taskName,
             string taskProjectFile,
-            IDictionary<string, string> taskIdentityParameters,
+            TaskHostParameters taskIdentityParameters,
             bool exactMatchRequired,
             TargetLoggingContext targetLoggingContext,
             ElementLocation elementLocation)
@@ -514,7 +504,7 @@ namespace Microsoft.Build.Execution
         internal RegisteredTaskRecord GetTaskRegistrationRecord(
             string taskName,
             string taskProjectFile,
-            IDictionary<string, string> taskIdentityParameters,
+            TaskHostParameters taskIdentityParameters,
             bool exactMatchRequired,
             TargetLoggingContext targetLoggingContext,
             ElementLocation elementLocation,
@@ -522,7 +512,7 @@ namespace Microsoft.Build.Execution
         {
             RegisteredTaskRecord taskRecord = null;
             retrievedFromCache = false;
-            RegisteredTaskIdentity taskIdentity = new RegisteredTaskIdentity(taskName, taskIdentityParameters);
+            RegisteredTaskIdentity taskIdentity = new(taskName, taskIdentityParameters);
 
             // Project-level override tasks are keyed by task name (unqualified).
             // Because Foo.Bar and Baz.Bar are both valid, they are stored
@@ -682,7 +672,7 @@ namespace Microsoft.Build.Execution
             string taskName,
             AssemblyLoadInfo assemblyLoadInfo,
             string taskFactory,
-            Dictionary<string, string> taskFactoryParameters,
+            TaskHostParameters taskFactoryParameters,
             RegisteredTaskRecord.ParameterGroupAndTaskElementRecord inlineTaskRecord,
             LoggingContext loggingContext,
             ProjectUsingTaskElement projectUsingTaskInXml,
@@ -764,7 +754,7 @@ namespace Microsoft.Build.Execution
             string taskName,
             IEnumerable<RegisteredTaskRecord> taskRecords,
             string taskProjectFile,
-            IDictionary<string, string> taskIdentityParameters,
+            TaskHostParameters taskIdentityParameters,
             TargetLoggingContext targetLoggingContext,
             ElementLocation elementLocation)
             =>
@@ -786,34 +776,15 @@ namespace Microsoft.Build.Execution
         internal class RegisteredTaskIdentity : ITranslatable
         {
             private string _name;
-            private IDictionary<string, string> _taskIdentityParameters;
+            private TaskHostParameters _taskIdentityParameters;
 
             /// <summary>
-            /// Constructor
+            /// Constructor.
             /// </summary>
-            internal RegisteredTaskIdentity(string name, IDictionary<string, string> taskIdentityParameters)
+            internal RegisteredTaskIdentity(string name, TaskHostParameters taskIdentityParameters)
             {
                 _name = name;
-
-                // The ReadOnlyDictionary is a *wrapper*, the Dictionary is the copy.
-                _taskIdentityParameters = taskIdentityParameters == null ? null : new ReadOnlyDictionary<string, string>(CreateTaskIdentityParametersDictionary(taskIdentityParameters));
-            }
-
-            private static IDictionary<string, string> CreateTaskIdentityParametersDictionary(IDictionary<string, string> initialState = null, int? initialCount = null)
-            {
-                ErrorUtilities.VerifyThrow(initialState == null || initialCount == null, "at most one can be non-null");
-
-                if (initialState != null)
-                {
-                    return new Dictionary<string, string>(initialState, StringComparer.OrdinalIgnoreCase);
-                }
-
-                if (initialCount != null)
-                {
-                    return new Dictionary<string, string>(initialCount.Value, StringComparer.OrdinalIgnoreCase);
-                }
-
-                return new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+                _taskIdentityParameters = taskIdentityParameters.IsEmpty ? TaskHostParameters.Empty : taskIdentityParameters;
             }
 
             public RegisteredTaskIdentity()
@@ -829,12 +800,9 @@ namespace Microsoft.Build.Execution
             }
 
             /// <summary>
-            /// The identity parameters
+            /// The identity parameters.
             /// </summary>
-            public IDictionary<string, string> TaskIdentityParameters
-            {
-                get { return _taskIdentityParameters; }
-            }
+            public TaskHostParameters TaskIdentityParameters => _taskIdentityParameters;
 
             /// <summary>
             /// Comparer used to figure out whether two RegisteredTaskIdentities are equal or not.
@@ -888,14 +856,9 @@ namespace Microsoft.Build.Execution
                 /// </summary>
                 public static bool IsPartialMatch(RegisteredTaskIdentity x, RegisteredTaskIdentity y)
                 {
-                    if (TypeLoader.IsPartialTypeNameMatch(x.Name, y.Name))
-                    {
-                        return IdentityParametersMatch(x.TaskIdentityParameters, y.TaskIdentityParameters, false /* fuzzy match */);
-                    }
-                    else
-                    {
-                        return false;
-                    }
+                    return TypeLoader.IsPartialTypeNameMatch(x.Name, y.Name)
+                        ? IdentityParametersMatch(x.TaskIdentityParameters, y.TaskIdentityParameters, false /* fuzzy match */)
+                        : false;
                 }
 
                 /// <summary>
@@ -939,20 +902,11 @@ namespace Microsoft.Build.Execution
                     // Since equality for the exact comparer depends on the exact values of the parameters,
                     // we need our hash code to depend on them as well. However, for fuzzy matches, we just
                     // need the ultimate meaning of the parameters to be the same.
-                    string runtime = null;
-                    string architecture = null;
-
-                    if (obj.TaskIdentityParameters != null)
-                    {
-                        obj.TaskIdentityParameters.TryGetValue(XMakeAttributes.runtime, out runtime);
-                        obj.TaskIdentityParameters.TryGetValue(XMakeAttributes.architecture, out architecture);
-                    }
-
                     int paramHash;
                     if (_exactMatchRequired)
                     {
-                        int runtimeHash = runtime == null ? 0 : StringComparer.OrdinalIgnoreCase.GetHashCode(runtime);
-                        int architectureHash = architecture == null ? 0 : StringComparer.OrdinalIgnoreCase.GetHashCode(architecture);
+                        int runtimeHash = obj.TaskIdentityParameters.Runtime == null ? 0 : StringComparer.OrdinalIgnoreCase.GetHashCode(obj.TaskIdentityParameters.Runtime);
+                        int architectureHash = obj.TaskIdentityParameters.Architecture == null ? 0 : StringComparer.OrdinalIgnoreCase.GetHashCode(obj.TaskIdentityParameters.Architecture);
 
                         paramHash = runtimeHash ^ architectureHash;
                     }
@@ -971,65 +925,42 @@ namespace Microsoft.Build.Execution
                 }
 
                 /// <summary>
-                /// Returns true if the two dictionaries representing sets of task identity parameters match; false otherwise.
+                /// Returns true if the two TaskHostParameters match; false otherwise.
                 /// Internal so that RegisteredTaskRecord can use this function in its determination of whether the task factory
                 /// supports a certain task identity.
                 /// </summary>
-                private static bool IdentityParametersMatch(IDictionary<string, string> x, IDictionary<string, string> y, bool exactMatchRequired)
+                private static bool IdentityParametersMatch(TaskHostParameters x, TaskHostParameters y, bool exactMatchRequired)
                 {
-                    if (x == null && y == null)
+                    // Both empty - match
+                    if (x.IsEmpty && y.IsEmpty)
                     {
                         return true;
                     }
 
                     if (exactMatchRequired)
                     {
-                        if (x == null || y == null)
+                        // For exact match, one empty means no match
+                        if (x.IsEmpty || y.IsEmpty)
                         {
                             return false;
                         }
 
-                        if (x.Count != y.Count)
-                        {
-                            return false;
-                        }
-
-                        // make sure that each parameter value matches as well
-                        foreach (KeyValuePair<string, string> param in x)
-                        {
-                            string value;
-                            if (y.TryGetValue(param.Key, out value))
-                            {
-                                if (!String.Equals(param.Value, value, StringComparison.OrdinalIgnoreCase))
-                                {
-                                    return false;
-                                }
-                            }
-                            else
-                            {
-                                return false;
-                            }
-                        }
+                        // For exact match, all properties must be equal (case-insensitive)
+                        return string.Equals(x.Runtime, y.Runtime, StringComparison.OrdinalIgnoreCase) &&
+                               string.Equals(x.Architecture, y.Architecture, StringComparison.OrdinalIgnoreCase) &&
+                               string.Equals(x.DotnetHostPath, y.DotnetHostPath, StringComparison.OrdinalIgnoreCase) &&
+                               string.Equals(x.MSBuildAssemblyPath, y.MSBuildAssemblyPath, StringComparison.OrdinalIgnoreCase) &&
+                               x.IsTaskHostFactory == y.IsTaskHostFactory;
                     }
                     else
                     {
-                        // we need to fuzzy-match the parameters as well
-                        string runtimeX = null;
-                        string runtimeY = null;
-                        string architectureX = null;
-                        string architectureY = null;
+                        // Fuzzy match: null is treated as "don't care"
+                        // Only check runtime and architecture for fuzzy matching
 
-                        if (x != null)
-                        {
-                            x.TryGetValue(XMakeAttributes.runtime, out runtimeX);
-                            x.TryGetValue(XMakeAttributes.architecture, out architectureX);
-                        }
-
-                        if (y != null)
-                        {
-                            y.TryGetValue(XMakeAttributes.runtime, out runtimeY);
-                            y.TryGetValue(XMakeAttributes.architecture, out architectureY);
-                        }
+                        string runtimeX = x.Runtime;
+                        string runtimeY = y.Runtime;
+                        string architectureX = x.Architecture;
+                        string architectureY = y.Architecture;
 
                         // null is OK -- it's treated as a "don't care"
                         if (!XMakeAttributes.RuntimeValuesMatch(runtimeX, runtimeY))
@@ -1043,7 +974,7 @@ namespace Microsoft.Build.Execution
                         }
                     }
 
-                    // if we didn't return before now, all parameters were found and matched.
+                    // if we didn't return before now, all parameters matched
                     return true;
                 }
             }
@@ -1051,14 +982,7 @@ namespace Microsoft.Build.Execution
             public void Translate(ITranslator translator)
             {
                 translator.Translate(ref _name);
-
-                IDictionary<string, string> taskIdentityParameters = _taskIdentityParameters;
-                translator.TranslateDictionary(ref taskIdentityParameters, count => CreateTaskIdentityParametersDictionary(null, count));
-
-                if (translator.Mode == TranslationDirection.ReadFromStream && taskIdentityParameters != null)
-                {
-                    _taskIdentityParameters = new ReadOnlyDictionary<string, string>(taskIdentityParameters);
-                }
+                translator.Translate(ref _taskIdentityParameters);
             }
         }
 
@@ -1152,9 +1076,9 @@ namespace Microsoft.Build.Execution
             private Dictionary<RegisteredTaskIdentity, object> _taskNamesCreatableByFactory;
 
             /// <summary>
-            /// Set of parameters that can be used by the task factory specifically.
+            /// Parameters that can be used by the task factory specifically.
             /// </summary>
-            private Dictionary<string, string> _taskFactoryParameters;
+            private TaskHostParameters _taskFactoryParameters;
 
             /// <summary>
             /// Encapsulates the parameters and the body of the task element for the inline task.
@@ -1181,7 +1105,7 @@ namespace Microsoft.Build.Execution
             {
                 public short ExecutedCount { get; private set; } = 0;
                 public long TotalMemoryConsumption { get; private set; } = 0;
-                private readonly Stopwatch _executedSw  = new Stopwatch();
+                private readonly Stopwatch _executedSw = new Stopwatch();
                 private long _memoryConsumptionOnStart;
 
                 public TimeSpan ExecutedTime => _executedSw.Elapsed;
@@ -1223,7 +1147,7 @@ namespace Microsoft.Build.Execution
                 string registeredName,
                 AssemblyLoadInfo assemblyLoadInfo,
                 string taskFactory,
-                Dictionary<string, string> taskFactoryParameters,
+                TaskHostParameters taskFactoryParameters,
                 ParameterGroupAndTaskElementRecord inlineTask,
                 int registrationOrderId,
                 string containingFileFullPath)
@@ -1236,11 +1160,13 @@ namespace Microsoft.Build.Execution
                 _parameterGroupAndTaskBody = inlineTask;
                 _registrationOrderId = registrationOrderId;
 
-                if (String.IsNullOrEmpty(taskFactory))
+                if (string.IsNullOrEmpty(taskFactory))
                 {
-                    if (taskFactoryParameters != null)
+                    if (!taskFactoryParameters.IsEmpty)
                     {
-                        ErrorUtilities.VerifyThrow(taskFactoryParameters.Count == 2, "if the parameter dictionary is non-null, it should contain both parameters when we get here!");
+                        ErrorUtilities.VerifyThrow(
+                            taskFactoryParameters.Runtime != null && taskFactoryParameters.Architecture != null,
+                            "if the parameters are non-null, it should contain both Runtime and Architecture when we get here!");
                     }
 
                     _taskFactory = AssemblyTaskFactory;
@@ -1319,13 +1245,12 @@ namespace Microsoft.Build.Execution
             }
 
             /// <summary>
-            /// Gets the set of parameters for the task factory
+            /// Gets the set of parameters for the task factory.
             /// </summary>
-            internal IDictionary<string, string> TaskFactoryParameters
+            internal TaskHostParameters TaskFactoryParameters
             {
                 [DebuggerStepThrough]
-                get
-                { return _taskFactoryParameters; }
+                get => _taskFactoryParameters;
             }
 
             /// <summary>
@@ -1355,7 +1280,7 @@ namespace Microsoft.Build.Execution
             /// loads an external file and uses that to generate the tasks.
             /// </summary>
             /// <returns>true if the task can be created by the factory, false if it cannot be created</returns>
-            internal bool CanTaskBeCreatedByFactory(string taskName, string taskProjectFile, IDictionary<string, string> taskIdentityParameters, TargetLoggingContext targetLoggingContext, ElementLocation elementLocation)
+            internal bool CanTaskBeCreatedByFactory(string taskName, string taskProjectFile, TaskHostParameters taskIdentityParameters, TargetLoggingContext targetLoggingContext, ElementLocation elementLocation)
             {
                 // First check (fast path - no locking)
                 if (_taskNamesCreatableByFactory == null)
@@ -1463,7 +1388,7 @@ namespace Microsoft.Build.Execution
             /// Given a Registered task record and a task name. Check create an instance of the task factory using the record.
             /// If the factory is a assembly task factory see if the assemblyFile has the correct task inside of it.
             /// </summary>
-            internal TaskFactoryWrapper GetTaskFactoryFromRegistrationRecord(string taskName, string taskProjectFile, IDictionary<string, string> taskIdentityParameters, TargetLoggingContext targetLoggingContext, ElementLocation elementLocation)
+            internal TaskFactoryWrapper GetTaskFactoryFromRegistrationRecord(string taskName, string taskProjectFile, TaskHostParameters taskIdentityParameters, TargetLoggingContext targetLoggingContext, ElementLocation elementLocation)
             {
                 if (CanTaskBeCreatedByFactory(taskName, taskProjectFile, taskIdentityParameters, targetLoggingContext, elementLocation))
                 {
@@ -1489,8 +1414,10 @@ namespace Microsoft.Build.Execution
 
                     bool isAssemblyTaskFactory = String.Equals(TaskFactoryAttributeName, AssemblyTaskFactory, StringComparison.OrdinalIgnoreCase);
                     bool isTaskHostFactory = String.Equals(TaskFactoryAttributeName, TaskHostFactory, StringComparison.OrdinalIgnoreCase);
-                    _taskFactoryParameters ??= new();
-                    TaskFactoryParameters.Add(Constants.TaskHostExplicitlyRequested, isTaskHostFactory.ToString());
+
+                    _taskFactoryParameters = TaskHostParameters.MergeTaskHostParameters(
+                      _taskFactoryParameters,
+                      new TaskHostParameters(isTaskHostFactory: isTaskHostFactory));
 
                     if (isAssemblyTaskFactory || isTaskHostFactory)
                     {
@@ -1593,8 +1520,8 @@ namespace Microsoft.Build.Execution
 
                                         // TaskFactoryParameters will always be null unless specifically created to have runtime and architecture parameters.
                                         // In case TaskHostFactory is explicitly requested, we will now have a parameter for that.
-                                        bool containsArchOrRuntimeParam = TaskFactoryParameters?.TryGetValue(XMakeAttributes.runtime, out _) == true
-                                                                          || TaskFactoryParameters?.TryGetValue(XMakeAttributes.architecture, out _) == true;
+                                        bool containsArchOrRuntimeParam = TaskFactoryParameters.Runtime != null
+                                                                          || TaskFactoryParameters.Architecture != null;
 
                                         if (initialized && containsArchOrRuntimeParam)
                                         {
@@ -1937,14 +1864,7 @@ namespace Microsoft.Build.Execution
                 translator.Translate(ref _parameterGroupAndTaskBody);
                 translator.Translate(ref _registrationOrderId);
                 translator.Translate(ref _definingFileFullPath);
-
-                IDictionary<string, string> localParameters = _taskFactoryParameters;
-                translator.TranslateDictionary(ref localParameters, count => CreateTaskFactoryParametersDictionary(count));
-
-                if (translator.Mode == TranslationDirection.ReadFromStream && localParameters != null)
-                {
-                    _taskFactoryParameters = (Dictionary<string, string>)localParameters;
-                }
+                translator.Translate(ref _taskFactoryParameters);
             }
 
             internal static RegisteredTaskRecord FactoryForDeserialization(ITranslator translator)

--- a/src/Framework/BinaryTranslator.cs
+++ b/src/Framework/BinaryTranslator.cs
@@ -193,6 +193,37 @@ namespace Microsoft.Build.BackEnd
             public void Translate(ref uint unsignedInteger) => unsignedInteger = _reader.ReadUInt32();
 
             /// <summary>
+            /// Translates a TaskHostParameters.
+            /// </summary>
+            /// <param name="value">The TaskHostParameters to be translated.</param>
+            public void Translate(ref TaskHostParameters value)
+            {
+                string runtime = null;
+                string architecture = null;
+                string dotnetHostPath = null;
+                string msBuildAssemblyPath = null;
+                bool? isTaskHostFactory = null;
+
+                Translate(ref runtime);
+                Translate(ref architecture);
+                Translate(ref dotnetHostPath);
+                Translate(ref msBuildAssemblyPath);
+
+                bool hasTaskHostFactory = _reader.ReadBoolean();
+                if (hasTaskHostFactory)
+                {
+                    isTaskHostFactory = _reader.ReadBoolean();
+                }
+
+                value = new TaskHostParameters(
+                    runtime: runtime,
+                    architecture: architecture,
+                    dotnetHostPath: dotnetHostPath,
+                    msBuildAssemblyPath: msBuildAssemblyPath,
+                    isTaskHostFactory: isTaskHostFactory);
+            }
+
+            /// <summary>
             /// Translates an <see langword="int"/> array.
             /// </summary>
             /// <param name="array">The array to be translated.</param>
@@ -1087,6 +1118,30 @@ namespace Microsoft.Build.BackEnd
             public void Translate(ref double value)
             {
                 _writer.Write(value);
+            }
+
+            /// <summary>
+            /// Translates a TaskHostParameters.
+            /// </summary>
+            /// <param name="value">The TaskHostParameters to be translated.</param>
+            public void Translate(ref TaskHostParameters value)
+            {
+                string runtime = value.Runtime;
+                string architecture = value.Architecture;
+                string dotnetHostPath = value.DotnetHostPath;
+                string msBuildAssemblyPath = value.MSBuildAssemblyPath;
+
+                Translate(ref runtime);
+                Translate(ref architecture);
+                Translate(ref dotnetHostPath);
+                Translate(ref msBuildAssemblyPath);
+
+                bool hasTaskHostFactory = value.IsTaskHostFactory.HasValue;
+                _writer.Write(hasTaskHostFactory);
+                if (hasTaskHostFactory)
+                {
+                    _writer.Write(value.IsTaskHostFactory.Value);
+                }
             }
 
             /// <summary>

--- a/src/Framework/CompatibilitySuppressions.xml
+++ b/src/Framework/CompatibilitySuppressions.xml
@@ -2,6 +2,76 @@
 <!-- https://learn.microsoft.com/dotnet/fundamentals/package-validation/diagnostic-ids -->
 <Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <Suppression>
+    <DiagnosticId>CP0006</DiagnosticId>
+    <Target>M:Microsoft.Build.Framework.ITaskFactory2.CreateTask(Microsoft.Build.Framework.IBuildEngine,Microsoft.Build.Framework.TaskHostParameters)</Target>
+    <Left>lib/net10.0/Microsoft.Build.Framework.dll</Left>
+    <Right>lib/net10.0/Microsoft.Build.Framework.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0006</DiagnosticId>
+    <Target>M:Microsoft.Build.Framework.ITaskFactory2.Initialize(System.String,Microsoft.Build.Framework.TaskHostParameters,System.Collections.Generic.IDictionary{System.String,Microsoft.Build.Framework.TaskPropertyInfo},System.String,Microsoft.Build.Framework.IBuildEngine)</Target>
+    <Left>lib/net10.0/Microsoft.Build.Framework.dll</Left>
+    <Right>lib/net10.0/Microsoft.Build.Framework.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0006</DiagnosticId>
+    <Target>M:Microsoft.Build.Framework.ITaskFactory2.CreateTask(Microsoft.Build.Framework.IBuildEngine,Microsoft.Build.Framework.TaskHostParameters)</Target>
+    <Left>lib/net472/Microsoft.Build.Framework.dll</Left>
+    <Right>lib/net472/Microsoft.Build.Framework.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0006</DiagnosticId>
+    <Target>M:Microsoft.Build.Framework.ITaskFactory2.Initialize(System.String,Microsoft.Build.Framework.TaskHostParameters,System.Collections.Generic.IDictionary{System.String,Microsoft.Build.Framework.TaskPropertyInfo},System.String,Microsoft.Build.Framework.IBuildEngine)</Target>
+    <Left>lib/net472/Microsoft.Build.Framework.dll</Left>
+    <Right>lib/net472/Microsoft.Build.Framework.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0006</DiagnosticId>
+    <Target>M:Microsoft.Build.Framework.ITaskFactory2.CreateTask(Microsoft.Build.Framework.IBuildEngine,Microsoft.Build.Framework.TaskHostParameters)</Target>
+    <Left>ref/net10.0/Microsoft.Build.Framework.dll</Left>
+    <Right>ref/net10.0/Microsoft.Build.Framework.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0006</DiagnosticId>
+    <Target>M:Microsoft.Build.Framework.ITaskFactory2.Initialize(System.String,Microsoft.Build.Framework.TaskHostParameters,System.Collections.Generic.IDictionary{System.String,Microsoft.Build.Framework.TaskPropertyInfo},System.String,Microsoft.Build.Framework.IBuildEngine)</Target>
+    <Left>ref/net10.0/Microsoft.Build.Framework.dll</Left>
+    <Right>ref/net10.0/Microsoft.Build.Framework.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0006</DiagnosticId>
+    <Target>M:Microsoft.Build.Framework.ITaskFactory2.CreateTask(Microsoft.Build.Framework.IBuildEngine,Microsoft.Build.Framework.TaskHostParameters)</Target>
+    <Left>ref/net472/Microsoft.Build.Framework.dll</Left>
+    <Right>ref/net472/Microsoft.Build.Framework.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0006</DiagnosticId>
+    <Target>M:Microsoft.Build.Framework.ITaskFactory2.Initialize(System.String,Microsoft.Build.Framework.TaskHostParameters,System.Collections.Generic.IDictionary{System.String,Microsoft.Build.Framework.TaskPropertyInfo},System.String,Microsoft.Build.Framework.IBuildEngine)</Target>
+    <Left>ref/net472/Microsoft.Build.Framework.dll</Left>
+    <Right>ref/net472/Microsoft.Build.Framework.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0006</DiagnosticId>
+    <Target>M:Microsoft.Build.Framework.ITaskFactory2.CreateTask(Microsoft.Build.Framework.IBuildEngine,Microsoft.Build.Framework.TaskHostParameters)</Target>
+    <Left>ref/netstandard2.0/Microsoft.Build.Framework.dll</Left>
+    <Right>ref/netstandard2.0/Microsoft.Build.Framework.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0006</DiagnosticId>
+    <Target>M:Microsoft.Build.Framework.ITaskFactory2.Initialize(System.String,Microsoft.Build.Framework.TaskHostParameters,System.Collections.Generic.IDictionary{System.String,Microsoft.Build.Framework.TaskPropertyInfo},System.String,Microsoft.Build.Framework.IBuildEngine)</Target>
+    <Left>ref/netstandard2.0/Microsoft.Build.Framework.dll</Left>
+    <Right>ref/netstandard2.0/Microsoft.Build.Framework.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
     <DiagnosticId>PKV004</DiagnosticId>
     <Target>.NETCoreApp,Version=v2.0</Target>
   </Suppression>

--- a/src/Framework/ITaskFactory2.cs
+++ b/src/Framework/ITaskFactory2.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Collections.Generic;
 
 #nullable disable
@@ -35,7 +36,32 @@ namespace Microsoft.Build.Framework
         /// The taskFactoryLoggingHost will log messages in the context of the target where the task is first used.
         /// </para>
         /// </remarks>
+        [Obsolete("Use Initialize with TaskHostParameters instead.")]
         bool Initialize(string taskName, IDictionary<string, string> factoryIdentityParameters, IDictionary<string, TaskPropertyInfo> parameterGroup, string taskBody, IBuildEngine taskFactoryLoggingHost);
+
+        /// <summary>
+        /// Initializes this factory for instantiating tasks with a particular inline task block and a set of UsingTask parameters.  MSBuild
+        /// provides an implementation of this interface, TaskHostFactory, that uses "Runtime", with values "CLR2", "CLR4", "CurrentRuntime",
+        /// and "*" (Any); and "Architecture", with values "x86", "x64", "CurrentArchitecture", and "*" (Any).  An implementer of ITaskFactory2
+        /// can choose to use these pre-defined Runtime and Architecture values, or can specify new values for these parameters.
+        /// </summary>
+        /// <param name="taskName">Name of the task.</param>
+        /// <param name="factoryIdentityParameters">Special parameters that the task factory can use to modify how it executes tasks,
+        /// such as Runtime and Architecture.  The key is the name of the parameter and the value is the parameter's value. This
+        /// is the set of parameters that was set on the UsingTask using e.g. the UsingTask Runtime and Architecture parameters.</param>
+        /// <param name="parameterGroup">The parameter group.</param>
+        /// <param name="taskBody">The task body.</param>
+        /// <param name="taskFactoryLoggingHost">The task factory logging host.</param>
+        /// <returns>A value indicating whether initialization was successful.</returns>
+        /// <remarks>
+        /// <para>MSBuild engine will call this to initialize the factory. This should initialize the factory enough so that the
+        /// factory can be asked whether or not task names can be created by the factory.  If a task factory implements ITaskFactory2,
+        /// this Initialize method will be called in place of ITaskFactory.Initialize.</para>
+        /// <para>
+        /// The taskFactoryLoggingHost will log messages in the context of the target where the task is first used.
+        /// </para>
+        /// </remarks>
+        bool Initialize(string taskName, TaskHostParameters factoryIdentityParameters, IDictionary<string, TaskPropertyInfo> parameterGroup, string taskBody, IBuildEngine taskFactoryLoggingHost);
 
         /// <summary>
         /// Create an instance of the task to be used, with an optional set of "special" parameters set on the individual task invocation using
@@ -58,6 +84,30 @@ namespace Microsoft.Build.Framework
         /// <returns>
         /// The generated task, or <c>null</c> if the task failed to be created.
         /// </returns>
+        [Obsolete]
         ITask CreateTask(IBuildEngine taskFactoryLoggingHost, IDictionary<string, string> taskIdentityParameters);
+
+        /// <summary>
+        /// Create an instance of the task to be used, with an optional set of "special" parameters set on the individual task invocation using
+        /// the MSBuildRuntime and MSBuildArchitecture default task parameters.  MSBuild provides an implementation of this interface,
+        /// TaskHostFactory, that uses "MSBuildRuntime", with values "CLR2", "CLR4", "CurrentRuntime", and "*" (Any); and "MSBuildArchitecture",
+        /// with values "x86", "x64", "CurrentArchitecture", and "*" (Any).  An implementer of ITaskFactory2 can choose to use these pre-defined
+        /// MSBuildRuntime and MSBuildArchitecture values, or can specify new values for these parameters.
+        /// </summary>
+        /// <param name="taskFactoryLoggingHost">
+        /// The task factory logging host will log messages in the context of the task.
+        /// </param>
+        /// <param name="taskIdentityParameters">
+        /// Special parameters that the task factory can use to modify how it executes tasks, such as Runtime and Architecture.
+        /// The key is the name of the parameter and the value is the parameter's value.  This is the set of parameters that was
+        /// set to the task invocation itself, via e.g. the special MSBuildRuntime and MSBuildArchitecture parameters.
+        /// </param>
+        /// <remarks>
+        /// If a task factory implements ITaskFactory2, MSBuild will call this method instead of ITaskFactory.CreateTask.
+        /// </remarks>
+        /// <returns>
+        /// The generated task, or <c>null</c> if the task failed to be created.
+        /// </returns>
+        ITask CreateTask(IBuildEngine taskFactoryLoggingHost, TaskHostParameters taskIdentityParameters);
     }
 }

--- a/src/Framework/ITranslator.cs
+++ b/src/Framework/ITranslator.cs
@@ -344,6 +344,12 @@ namespace Microsoft.Build.BackEnd
         void TranslateDictionary(ref Dictionary<string, string> dictionary, IEqualityComparer<string> comparer);
 
         /// <summary>
+        /// Translates a TaskHostParameters.
+        /// </summary>
+        /// <param name="value">The TaskHostParameters to translate.</param>
+        void Translate(ref TaskHostParameters value);
+
+        /// <summary>
         /// Translates a dictionary of { string, string } adding additional entries.
         /// </summary>
         /// <param name="dictionary">The dictionary to be translated.</param>

--- a/src/Framework/TaskHostParameters.cs
+++ b/src/Framework/TaskHostParameters.cs
@@ -1,0 +1,118 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Build.Framework
+{
+    /// <summary>
+    /// A readonly struct that represents task host parameters used to determine which host process to launch.
+    /// </summary>
+    public readonly struct TaskHostParameters
+    {
+        private readonly string? _runtime;
+        private readonly string? _architecture;
+        private readonly string? _dotnetHostPath;
+        private readonly string? _msBuildAssemblyPath;
+        private readonly bool? _isTaskHostFactory;
+
+        /// <summary>
+        /// A static empty instance to avoid allocations when default parameters are needed.
+        /// </summary>
+        public static readonly TaskHostParameters Empty = new();
+
+        /// <summary>
+        /// Initializes a new instance of the TaskHostParameters struct with the specified parameters.
+        /// </summary>
+        /// <param name="runtime">The target runtime identifier (e.g., "net8.0", "net472").</param>
+        /// <param name="architecture">The target architecture (e.g., "x64", "x86", "arm64").</param>
+        /// <param name="dotnetHostPath">The path to the dotnet host executable.</param>
+        /// <param name="msBuildAssemblyPath">The path to the MSBuild assembly.</param>
+        /// <param name="isTaskHostFactory">Defines if Task Host Factory was explicitly requested.</param>
+        internal TaskHostParameters(
+            string? runtime = null,
+            string? architecture = null,
+            string? dotnetHostPath = null,
+            string? msBuildAssemblyPath = null,
+            bool? isTaskHostFactory = null)
+        {
+            _runtime = runtime;
+            _architecture = architecture;
+            _dotnetHostPath = dotnetHostPath;
+            _msBuildAssemblyPath = msBuildAssemblyPath;
+            _isTaskHostFactory = isTaskHostFactory;
+        }
+
+        /// <summary>
+        /// Gets the target runtime identifier (e.g., "net8.0", "net472").
+        /// </summary>
+        /// <value>The runtime identifier, or an empty string if not specified.</value>
+        public string? Runtime => _runtime;
+
+        /// <summary>
+        /// Gets the target architecture (e.g., "x64", "x86", "arm64").
+        /// </summary>
+        /// <value>The architecture identifier, or an empty string if not specified.</value>
+        public string? Architecture => _architecture;
+
+        /// <summary>
+        /// Gets the path to the dotnet host executable.
+        /// </summary>
+        /// <value>The dotnet host path, or an empty string if not specified.</value>
+        public string? DotnetHostPath => _dotnetHostPath;
+
+        /// <summary>
+        /// Gets the path to the MSBuild assembly.
+        /// </summary>
+        /// <value>The MSBuild assembly path, or an empty string if not specified.</value>
+        public string? MSBuildAssemblyPath => _msBuildAssemblyPath;
+
+        /// <summary>
+        /// Gets if Task Host Factory was requested explicitly.
+        /// </summary>
+        public bool? IsTaskHostFactory => _isTaskHostFactory;
+
+        /// <summary>
+        /// Returns true if all parameters are unset (null or false).
+        /// </summary>
+        internal bool IsEmpty =>
+            _runtime == null &&
+            _architecture == null &&
+            _dotnetHostPath == null &&
+            _msBuildAssemblyPath == null &&
+            _isTaskHostFactory == null;
+
+        /// <summary>
+        /// Merges two TaskHostParameters instances, with the second parameter values taking precedence when both are specified.
+        /// </summary>
+        /// <param name="baseParameters">The base parameters.</param>
+        /// <param name="overrideParameters">The override parameters that take precedence.</param>
+        /// <returns>A new TaskHostParameters with merged values.</returns>
+        internal static TaskHostParameters MergeTaskHostParameters(TaskHostParameters baseParameters, TaskHostParameters overrideParameters)
+        {
+            // If both are empty, return empty
+            if (baseParameters.IsEmpty && overrideParameters.IsEmpty)
+            {
+                return Empty;
+            }
+
+            // If override is empty, return base
+            if (overrideParameters.IsEmpty)
+            {
+                return baseParameters;
+            }
+
+            // If base is empty, return override
+            if (baseParameters.IsEmpty)
+            {
+                return overrideParameters;
+            }
+
+            // Merge: override values take precedence, fall back to base values
+            return new TaskHostParameters(
+                runtime: overrideParameters.Runtime ?? baseParameters.Runtime,
+                architecture: overrideParameters.Architecture ?? baseParameters.Architecture,
+                dotnetHostPath: overrideParameters.DotnetHostPath ?? baseParameters.DotnetHostPath,
+                msBuildAssemblyPath: overrideParameters.MSBuildAssemblyPath ?? baseParameters.MSBuildAssemblyPath,
+                isTaskHostFactory: overrideParameters.IsTaskHostFactory ?? baseParameters.IsTaskHostFactory);
+        }
+    }
+}

--- a/src/MSBuild/NodeEndpointOutOfProcTaskHost.cs
+++ b/src/MSBuild/NodeEndpointOutOfProcTaskHost.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Build.BackEnd;
+using Microsoft.Build.Framework;
 using Microsoft.Build.Internal;
 
 #nullable disable
@@ -31,9 +32,7 @@ namespace Microsoft.Build.CommandLine
         /// <summary>
         /// Returns the host handshake for this node endpoint
         /// </summary>
-        protected override Handshake GetHandshake()
-        {
-            return new Handshake(CommunicationsUtilities.GetHandshakeOptions(taskHost: true, nodeReuse: _nodeReuse));
-        }
+        protected override Handshake GetHandshake() =>
+            new(CommunicationsUtilities.GetHandshakeOptions(taskHost: true, taskHostParameters: TaskHostParameters.Empty, nodeReuse: _nodeReuse));
     }
 }

--- a/src/MSBuildTaskHost/MSBuildTaskHost.csproj
+++ b/src/MSBuildTaskHost/MSBuildTaskHost.csproj
@@ -229,6 +229,7 @@
     <Compile Include="..\Framework\InterningReadTranslator.cs" />
     <Compile Include="..\Framework\InterningWriteTranslator.cs" />
     <Compile Include="..\Framework\InternPathIds.cs" />
+    <Compile Include="..\Framework\TaskHostParameters.cs" />
 
     <Compile Include="..\Framework\IConstrainedEqualityComparer.cs" />
     <Compile Include="..\Framework\ImmutableDictionaryExtensions.cs" />

--- a/src/Shared/CommunicationsUtilities.cs
+++ b/src/Shared/CommunicationsUtilities.cs
@@ -846,10 +846,10 @@ namespace Microsoft.Build.Internal
         /// </summary>
         internal static HandshakeOptions GetHandshakeOptions(
             bool taskHost,
+            TaskHostParameters taskHostParameters,
             string architectureFlagToSet = null,
             bool nodeReuse = false,
-            bool lowPriority = false,
-            IDictionary<string, string> taskHostParameters = null)
+            bool lowPriority = false)
         {
             HandshakeOptions context = taskHost ? HandshakeOptions.TaskHost : HandshakeOptions.None;
 
@@ -859,25 +859,25 @@ namespace Microsoft.Build.Internal
             if (taskHost)
             {
                 // No parameters given, default to current
-                if (taskHostParameters == null)
+                if (taskHostParameters.IsEmpty)
                 {
                     clrVersion = typeof(bool).GetTypeInfo().Assembly.GetName().Version.Major;
                     architectureFlagToSet = XMakeAttributes.GetCurrentMSBuildArchitecture();
                 }
                 else // Figure out flags based on parameters given
                 {
-                    ErrorUtilities.VerifyThrow(taskHostParameters.TryGetValue(XMakeAttributes.runtime, out string runtimeVersion), "Should always have an explicit runtime when we call this method.");
-                    ErrorUtilities.VerifyThrow(taskHostParameters.TryGetValue(XMakeAttributes.architecture, out string architecture), "Should always have an explicit architecture when we call this method.");
+                    ErrorUtilities.VerifyThrow(taskHostParameters.Runtime != null, "Should always have an explicit runtime when we call this method.");
+                    ErrorUtilities.VerifyThrow(taskHostParameters.Architecture != null, "Should always have an explicit architecture when we call this method.");
 
-                    if (runtimeVersion.Equals(XMakeAttributes.MSBuildRuntimeValues.clr2, StringComparison.OrdinalIgnoreCase))
+                    if (taskHostParameters.Runtime.Equals(XMakeAttributes.MSBuildRuntimeValues.clr2, StringComparison.OrdinalIgnoreCase))
                     {
                         clrVersion = 2;
                     }
-                    else if (runtimeVersion.Equals(XMakeAttributes.MSBuildRuntimeValues.clr4, StringComparison.OrdinalIgnoreCase))
+                    else if (taskHostParameters.Runtime.Equals(XMakeAttributes.MSBuildRuntimeValues.clr4, StringComparison.OrdinalIgnoreCase))
                     {
                         clrVersion = 4;
                     }
-                    else if (runtimeVersion.Equals(XMakeAttributes.MSBuildRuntimeValues.net, StringComparison.OrdinalIgnoreCase))
+                    else if (taskHostParameters.Runtime.Equals(XMakeAttributes.MSBuildRuntimeValues.net, StringComparison.OrdinalIgnoreCase))
                     {
                         clrVersion = 5;
                     }
@@ -886,7 +886,7 @@ namespace Microsoft.Build.Internal
                         ErrorUtilities.ThrowInternalErrorUnreachable();
                     }
 
-                    architectureFlagToSet = architecture;
+                    architectureFlagToSet = taskHostParameters.Architecture;
                 }
             }
 

--- a/src/Shared/XMakeAttributes.cs
+++ b/src/Shared/XMakeAttributes.cs
@@ -149,18 +149,12 @@ namespace Microsoft.Build.Shared
         /// <summary>
         /// Returns true if the given string is a valid member of the MSBuildRuntimeValues set
         /// </summary>
-        internal static bool IsValidMSBuildRuntimeValue(string runtime)
-        {
-            return runtime == null || ValidMSBuildRuntimeValues.Contains(runtime);
-        }
+        internal static bool IsValidMSBuildRuntimeValue(string runtime) => runtime == null || ValidMSBuildRuntimeValues.Contains(runtime);
 
         /// <summary>
         /// Returns true if the given string is a valid member of the MSBuildArchitectureValues set
         /// </summary>
-        internal static bool IsValidMSBuildArchitectureValue(string architecture)
-        {
-            return architecture == null || ValidMSBuildArchitectureValues.Contains(architecture);
-        }
+        internal static bool IsValidMSBuildArchitectureValue(string architecture) => architecture == null || ValidMSBuildArchitectureValues.Contains(architecture);
 
         /// <summary>
         /// Compares two members of MSBuildRuntimeValues, returning true if they count as a match, and false otherwise.


### PR DESCRIPTION
Fixes https://github.com/dotnet/msbuild/issues/12287

### Context 
The previous implementation used IDictionary<string, string> to pass task identity parameters throughout the system. This approach had several drawbacks:
1.	Lack of Type Safety: Dictionary keys were string literals, prone to typos and requiring runtime validation
2.	Poor Discoverability: Developers had to search through code or documentation to understand what parameters were available
3.	Runtime Errors: Invalid parameter names or values were only caught at runtime
4.	Performance Overhead: Dictionary allocations and lookups added unnecessary overhead for a fixed set of parameters
5.	Unclear Intent: Dictionary usage didn't clearly communicate the specific parameters being used

### What Changed
New TaskHostParameters readonly struct was added.

Main Changes:
1.	src/Framework/TaskHostParameters.cs - New struct definition
2.	src/Framework/ITaskFactory2.cs - Updated interface
3.	src/Build/Instance/TaskRegistry.cs - Identity comparison logic changes
4.	src/Framework/BinaryTranslator.cs - Serialization support