### PR TITLE
Fix bug with not passing scheduled node id to the task host task

### DIFF
--- a/src/Build/BackEnd/TaskExecutionHost/TaskExecutionHost.cs
+++ b/src/Build/BackEnd/TaskExecutionHost/TaskExecutionHost.cs
@@ -1003,7 +1003,7 @@ namespace Microsoft.Build.BackEnd
                                 return null;
                             }
 
-                            task = CreateTaskHostTaskForOutOfProcFactory(taskIdentityParameters, taskFactoryEngineContext, outOfProcTaskFactory);
+                            task = CreateTaskHostTaskForOutOfProcFactory(taskIdentityParameters, taskFactoryEngineContext, outOfProcTaskFactory, scheduledNodeId);
                             isTaskHost = true;
                         }
                         else
@@ -1740,8 +1740,13 @@ namespace Microsoft.Build.BackEnd
         /// <param name="taskIdentityParameters">Task identity parameters.</param>
         /// <param name="taskFactoryEngineContext">The engine context to use for the task.</param>
         /// <param name="outOfProcTaskFactory">The out-of-process task factory instance.</param>
+        /// <param name="scheduledNodeId">Node for which the task host should be called</param>
         /// <returns>A TaskHostTask that will execute the inner task out of process, or <code>null</code> if task creation fails.</returns>
-        private ITask CreateTaskHostTaskForOutOfProcFactory(IDictionary<string, string> taskIdentityParameters, TaskFactoryEngineContext taskFactoryEngineContext, IOutOfProcTaskFactory outOfProcTaskFactory)
+        private ITask CreateTaskHostTaskForOutOfProcFactory(
+            IDictionary<string, string> taskIdentityParameters,
+            TaskFactoryEngineContext taskFactoryEngineContext,
+            IOutOfProcTaskFactory outOfProcTaskFactory,
+            int scheduledNodeId)
         {
             ITask innerTask;
 
@@ -1791,19 +1796,17 @@ namespace Microsoft.Build.BackEnd
             // Clean up the original task since we're going to wrap it
             _taskFactoryWrapper.TaskFactory.CleanupTask(innerTask);
 
-#pragma warning disable SA1111, SA1009 // Closing parenthesis should be on line of last parameter
             return new TaskHostTask(
                 _taskLocation,
                 _taskLoggingContext,
                 _buildComponentHost,
                 taskHostParameters,
                 taskLoadedType,
-                true
+                true,
 #if FEATURE_APPDOMAIN
-                , AppDomainSetup
+                AppDomainSetup,
 #endif
-                );
-#pragma warning restore SA1111, SA1009 // Closing parenthesis should be on line of last parameter
+                scheduledNodeId);
         }
     }
 }

--- a/src/Build/Instance/TaskFactories/AssemblyTaskFactory.cs
+++ b/src/Build/Instance/TaskFactories/AssemblyTaskFactory.cs
@@ -389,7 +389,6 @@ namespace Microsoft.Build.BackEnd
                     AddNetHostParams(ref mergedParameters, getProperty);
                 }
 
-#pragma warning disable SA1111, SA1009 // Closing parenthesis should be on line of last parameter
                 TaskHostTask task = new TaskHostTask(
                     taskLocation,
                     taskLoggingContext,

--- a/src/Build/Instance/TaskFactories/TaskHostTask.cs
+++ b/src/Build/Instance/TaskFactories/TaskHostTask.cs
@@ -159,7 +159,7 @@ namespace Microsoft.Build.BackEnd
 #if FEATURE_APPDOMAIN
             AppDomainSetup appDomainSetup,
 #endif
-            int scheduledNodeId = -1)
+            int scheduledNodeId)
         {
             ErrorUtilities.VerifyThrowInternalNull(taskType);
 


### PR DESCRIPTION
### Context
There seem to be a merge bug introduced in #12577. 
The scheduled node id should be passed to the `TaskHostTask` in both instances of the task creation.

### Changes Made
1. Passed scheduled node id to the task host task constructor
2. Removed the default value in constructor to avoid such errors in future.

### Testing
None
