### PR TITLE
Fix a gap in the file-matching of the gitops tool

### DIFF
--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -159,6 +159,11 @@ configuration:
             action: Opened
         - isAction:
             action: Reopened
+      # empty PRs will match the swr pattern below (because the implementation doesn't consider the 'empty files list' case)
+      # so we force _any_ file to exist before continuing the condition checks
+      - filesMatchPattern:
+          pattern: ".*"
+          matchAny: true
       - or:
         - filesMatchPattern:
             pattern: ^.+\.swr$


### PR DESCRIPTION
### Context
[This kind of comment](https://github.com/dotnet/msbuild/pull/12656#issuecomment-3412856561) is really annoying. This should fix it.

### Changes Made

Force there to be any files at all in a PR before performing the swr-modification checks.