### PR TITLE
Stop updating VS PackageReferences on insertion

### DIFF
--- a/azure-pipelines/vs-insertion-experimental.yml
+++ b/azure-pipelines/vs-insertion-experimental.yml
@@ -143,22 +143,6 @@ extends:
 
               Write-Host "##vso[task.setvariable variable=FinalTargetBranch]$finalTargetBranch"
 
-        - task: Powershell@2
-          name: PwshMungeExternalAPIsPkgVersion
-          displayName: Munge ExternalAPIs package version
-          inputs:
-            targetType: inline
-            script: |
-              $folder = "$(Build.ArtifactStagingDirectory)/PackageArtifacts/VS.ExternalAPIs.*.nupkg"
-              $packageFile = Get-ChildItem -Path $folder -Filter VS.ExternalAPIs.*.nupkg | Select-Object -First 1
-              $packageVersion = $packageFile.BaseName.TrimStart("VS.ExternalAPIs.MSBuild")
-              Write-Host "Setting MSBuild_ExtApisPackageVersion to '$packageVersion'"
-              Write-Host "##vso[task.setvariable variable=MSBuild_ExtApisPackageVersion]$($packageVersion)"
-              $folder = "$(Build.ArtifactStagingDirectory)/PackageArtifacts/Microsoft.NET.StringTools*.nupkg"
-              $packageFile = Get-ChildItem -Path $folder -Filter Microsoft.NET.StringTools*.nupkg | Select-Object -First 1
-              $packageVersion = $packageFile.BaseName.TrimStart("Microsoft.NET.StringTools")
-              Write-Host "Setting MicrosoftNETStringToolsPackageVersion to '$packageVersion'"
-              Write-Host "##vso[task.setvariable variable=MicrosoftNETStringToolsPackageVersion]$($packageVersion)"
         - task: 1ES.PublishNuGet@1
           displayName: 'Push MSBuild CoreXT packages'
           inputs:
@@ -176,7 +160,6 @@ extends:
             TeamEmail: $(TeamEmail)
             TargetBranch: $(FinalTargetBranch)
             InsertionPayloadName: $(InsertPayloadName)
-            PackagePropsValues: VS.ExternalAPIs.MSBuild=$(MSBuild_ExtApisPackageVersion);Microsoft.Build=$(MicrosoftNETStringToolsPackageVersion);Microsoft.Build.Framework=$(MicrosoftNETStringToolsPackageVersion);Microsoft.Build.Tasks.Core=$(MicrosoftNETStringToolsPackageVersion);Microsoft.Build.Utilities.Core=$(MicrosoftNETStringToolsPackageVersion);Microsoft.NET.StringTools=$(MicrosoftNETStringToolsPackageVersion)
             InsertionDescription: $(InsertDescription)
             ComponentJsonValues: $(InsertJsonValues)
             DefaultConfigValues: $(InsertConfigValues)

--- a/azure-pipelines/vs-insertion.yml
+++ b/azure-pipelines/vs-insertion.yml
@@ -233,8 +233,14 @@ extends:
                   )
               }
               $propsValue = $props -join ";"
-              Write-Host "Setting InsertPackagePropsValues to '$propsValue'"
-              Write-Host "##vso[task.setvariable variable=InsertPackagePropsValues]$($propsValue)"
+
+              # As of 18.0, don't update PackageReferences so that VS packages like VSSDK
+              # can choose their own versioning and don't always depend on a super fresh MSBuild
+              if ("$(InsertTargetBranch)" -in @("rel/d17.10", "rel/d17.12", "rel/d17.14"))
+              {
+                  Write-Host "Setting InsertPackagePropsValues to '$propsValue'"
+                  Write-Host "##vso[task.setvariable variable=InsertPackagePropsValues]$($propsValue)"
+              }
 
               # autocomplete main
               $autocomplete = "false"


### PR DESCRIPTION
VSSDK packages have recently exposed a "live" dependency on MSBuild,
which has caused several complications in the VS/MSBuild/VSSDK release
process. In consultation with the VSSDK team, the plan for now is to pin
to MSBuild's 18.0 package, so there's a known stable version to use.

VSSDK consumers will have the option to locally reference a higher
MSBuild but we suspect they are unlikely to need to do so.

This can't be a full and final solution because eventually we'll
introduce new API for VS to use and need to reference it in VS. At that
time we'll need to disentangle the "public" and "internal" MSBuild
references in VS.

Related internal PR: https://dev.azure.com/devdiv/DevDiv/_git/VS/pullrequest/680433