### PR TITLE
Refactor SolutionProjectGenerator and add public API for buildability of projects

### DIFF
--- a/src/Build/Construction/Solution/SolutionFile.cs
+++ b/src/Build/Construction/Solution/SolutionFile.cs
@@ -281,17 +281,24 @@ namespace Microsoft.Build.Construction
             return _solutionFilter?.Contains(FileUtilities.FixFilePath(projectFile)) != false;
         }
 
+        public bool IsProjectBuildable(ProjectInSolution projectInSolution)
+            => IsProjectBuildable(projectInSolution, $"{GetDefaultConfigurationName()}|{GetDefaultPlatformName()}");
+
         internal bool IsProjectBuildable(ProjectInSolution projectInSolution, string selectedSolutionConfiguration)
         {
             _ = projectInSolution.ProjectConfigurations.TryGetValue(selectedSolutionConfiguration, out ProjectConfigurationInSolution projectConfiguration);
+            return IsProjectBuildable(projectInSolution, selectedSolutionConfiguration, projectConfiguration);
+        }
 
+        internal bool IsProjectBuildable(ProjectInSolution projectInSolution, string selectedSolutionConfiguration, ProjectConfigurationInSolution projectConfigurationInSolution)
+        {
             // If the solution filter does not contain this project, do not build it.
             if (!ProjectShouldBuild(projectInSolution.RelativePath))
             {
                 return false;
             }
 
-            if (projectConfiguration == null)
+            if (projectConfigurationInSolution == null)
             {
                 if (projectInSolution.ProjectType == SolutionProjectType.WebProject)
                 {
@@ -310,7 +317,7 @@ namespace Microsoft.Build.Construction
                 return false;
             }
 
-            if (!projectConfiguration.IncludeInBuild)
+            if (!projectConfigurationInSolution.IncludeInBuild)
             {
                 // Not included in the build.
                 return false;

--- a/src/Build/Construction/Solution/SolutionProjectGenerator.cs
+++ b/src/Build/Construction/Solution/SolutionProjectGenerator.cs
@@ -650,6 +650,9 @@ namespace Microsoft.Build.Construction
         internal static bool WouldProjectBuild(SolutionFile solutionFile, string selectedSolutionConfiguration, ProjectInSolution project)
             => solutionFile.IsProjectBuildable(project, selectedSolutionConfiguration);
 
+        internal static bool WouldProjectBuild(SolutionFile solutionFile, string selectedSolutionConfiguration, ProjectInSolution project, ProjectConfigurationInSolution projectConfigurationInSolution)
+            => solutionFile.IsProjectBuildable(project, selectedSolutionConfiguration, projectConfigurationInSolution);
+
         /// <summary>
         /// Private method: generates an MSBuild wrapper project for the solution passed in; the MSBuild wrapper
         /// project to be generated is the private variable "msbuildProject" and the SolutionFile containing information


### PR DESCRIPTION
@rainersigwald Does this sound reasonable? I think this public API is going to be useful in `dotnet test` implementation in SDK.