### PR TITLE
Expose operational counters

### DIFF
--- a/src/Build/BackEnd/Components/BuildRequestEngine/BuildRequestEngine.cs
+++ b/src/Build/BackEnd/Components/BuildRequestEngine/BuildRequestEngine.cs
@@ -4,8 +4,10 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.Metrics;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks.Dataflow;
 using Microsoft.Build.BackEnd.Logging;
@@ -42,6 +44,8 @@ namespace Microsoft.Build.BackEnd
         /// </summary>
         private static readonly object s_traceLock = new();
 
+        private static Meter s_meter = new Meter("Microsoft.Build", "1.0.0");
+
         /// <summary>
         /// The starting unresolved configuration id assigned by the engine.
         /// </summary>
@@ -76,6 +80,12 @@ namespace Microsoft.Build.BackEnd
         /// Mapping of global request ids to the request entries.
         /// </summary>
         private readonly Dictionary<int, BuildRequestEntry> _requestsByGlobalRequestId;
+
+#pragma warning disable IDE0052 // Remove unread private members
+        private ObservableGauge<int> _requestsGauge;
+        private ObservableGauge<int> _workQueueGauge;
+        private ObservableGauge<int> _engineStatusGauge;
+#pragma warning restore IDE0052 // Remove unread private members
 
         /// <summary>
         /// The list of requests currently waiting to be submitted from RequestBuilders.
@@ -213,11 +223,28 @@ namespace Microsoft.Build.BackEnd
             var telemetryProvider = (TelemetryCollectorProvider)_componentHost.GetComponent(BuildComponentType.TelemetryCollector);
             _nodeLoggingContext.TelemetryCollector = telemetryProvider.CreateCollector();
 
+            _requestsGauge = s_meter.CreateObservableGauge("build_request_engine_requests", CollectRequestStatus, "requests", "Number of active build requests in the BuildRequestEngine", tags: [new("nodeId", _nodeLoggingContext.BuildEventContext.NodeId)]);
+            _workQueueGauge = s_meter.CreateObservableGauge("build_request_engine_work_queue_length", () => _workQueue.InputCount, "items", "Number of items in the BuildRequestEngine work queue", tags: [new("nodeId", _nodeLoggingContext.BuildEventContext.NodeId)]);
+            _engineStatusGauge = s_meter.CreateObservableGauge("build_request_engine_status", () => (int)_status, "status", "Current status of the BuildRequestEngine", tags: [new("nodeId", _nodeLoggingContext.BuildEventContext.NodeId)]);
+
             // Create a work queue that will take an action and invoke it.  The generic parameter is the type which ActionBlock.Post() will
             // take (an Action in this case) and the parameter to this constructor is a function which takes that parameter of type Action
             // (which we have named action) and does something with it (in this case calls invoke on it.)
             _workQueue = new ActionBlock<Action>(action => action.Invoke());
             ChangeStatus(BuildRequestEngineStatus.Idle);
+        }
+
+        private IEnumerable<Measurement<int>> CollectRequestStatus()
+        {
+#if NET
+            var requestsByState = _requests.CountBy(r => r.State);
+#else
+            var requestsByState = _requests.GroupBy(r => r.State).ToDictionary(g => g.Key, g => g.Count());
+#endif
+            foreach (var kvp in requestsByState)
+            {
+                yield return new Measurement<int>(kvp.Value, new KeyValuePair<string, object>("state", kvp.Key.ToString()));
+            }
         }
 
         /// <summary>

--- a/src/Build/BackEnd/Components/BuildRequestEngine/BuildRequestEngine.cs
+++ b/src/Build/BackEnd/Components/BuildRequestEngine/BuildRequestEngine.cs
@@ -87,7 +87,8 @@ namespace Microsoft.Build.BackEnd
         private ObservableGauge<int> _workQueueGauge;
         private ObservableGauge<int> _engineStatusGauge;
         private Histogram<double> _configurationResolutionHistogram;
-        private readonly ObservableCounter<long> _stateTransitionsCounter;
+        private ObservableCounter<long> _stateTransitionsCounter;
+        private Histogram<double> _requestWaitTimeHistogram;
 #pragma warning restore IDE0052 // Remove unread private members
 
         /// <summary>
@@ -140,6 +141,11 @@ namespace Microsoft.Build.BackEnd
         private readonly Dictionary<int, BuildRequestEntryState> _previousStates;
 
         /// <summary>
+        /// Tracks when requests started waiting and the reason for waiting. Key is GlobalRequestId, value is (timestamp, reason).
+        /// </summary>
+        private readonly Dictionary<int, (long timestamp, string reason)> _requestWaitStartTimes;
+
+        /// <summary>
         /// The logging context for the node
         /// </summary>
         private NodeLoggingContext _nodeLoggingContext;
@@ -181,6 +187,7 @@ namespace Microsoft.Build.BackEnd
             _requestsByGlobalRequestId = new Dictionary<int, BuildRequestEntry>();
             _stateTransitionCounts = new ConcurrentDictionary<string, long>();
             _previousStates = new Dictionary<int, BuildRequestEntryState>();
+            _requestWaitStartTimes = new Dictionary<int, (long timestamp, string reason)>();
         }
 
         #region IBuildRequestEngine Members
@@ -252,6 +259,7 @@ namespace Microsoft.Build.BackEnd
                 CollectStateTransitionCounts,
                 unit: "transitions",
                 description: "Count of build request state transitions");
+            _requestWaitTimeHistogram = s_meter.CreateHistogram<double>("msbuild_request_wait_time", unit: "ms", description: "Time requests spend waiting, categorized by blocking reason");
 
             // Create a work queue that will take an action and invoke it.  The generic parameter is the type which ActionBlock.Post() will
             // take (an Action in this case) and the parameter to this constructor is a function which takes that parameter of type Action
@@ -277,7 +285,7 @@ namespace Microsoft.Build.BackEnd
         {
             foreach (var kvp in _stateTransitionCounts)
             {
-                yield return new Measurement<long>(kvp.Value, new KeyValuePair<string, object?>("transition", kvp.Key));
+                yield return new Measurement<long>(kvp.Value, new KeyValuePair<string, object>("transition", kvp.Key));
             }
         }
 
@@ -620,8 +628,8 @@ namespace Microsoft.Build.BackEnd
                     // Record configuration resolution duration
                     if (_configurationRequestTimestamps.TryGetValue(response.NodeConfigurationId, out long startTimestamp))
                     {
-                        long endTimestamp = Stopwatch.GetTimestamp();
-                        double durationMs = (endTimestamp - startTimestamp) * 1000.0 / Stopwatch.Frequency;
+                        long endTimestamp = System.Diagnostics.Stopwatch.GetTimestamp();
+                        double durationMs = (endTimestamp - startTimestamp) * 1000.0 / System.Diagnostics.Stopwatch.Frequency;
                         _configurationResolutionHistogram.Record(durationMs);
                         _configurationRequestTimestamps.Remove(response.NodeConfigurationId);
                     }
@@ -752,15 +760,34 @@ namespace Microsoft.Build.BackEnd
         /// <param name="newState">The event's new state.</param>
         private void BuildRequestEntry_StateChanged(BuildRequestEntry entry, BuildRequestEntryState newState)
         {
+            int globalRequestId = entry.Request.GlobalRequestId;
+
             // Track the state transition for metrics
-            if (_previousStates.TryGetValue(entry.Request.GlobalRequestId, out BuildRequestEntryState oldState))
+            if (_previousStates.TryGetValue(globalRequestId, out BuildRequestEntryState oldState))
             {
                 string transition = $"{oldState}->{newState}";
                 _stateTransitionCounts.AddOrUpdate(transition, 1, (key, oldValue) => oldValue + 1);
+
+                // Track wait time when transitioning out of Waiting state
+                if (oldState == BuildRequestEntryState.Waiting &&
+                    _requestWaitStartTimes.TryGetValue(globalRequestId, out var waitInfo))
+                {
+                    long endTimestamp = System.Diagnostics.Stopwatch.GetTimestamp();
+                    double durationMs = (endTimestamp - waitInfo.timestamp) * 1000.0 / System.Diagnostics.Stopwatch.Frequency;
+                    _requestWaitTimeHistogram.Record(durationMs, new KeyValuePair<string, object>("reason", waitInfo.reason));
+                    _requestWaitStartTimes.Remove(globalRequestId);
+                }
+
+                // Record wait start time when transitioning to Waiting state
+                if (newState == BuildRequestEntryState.Waiting)
+                {
+                    string reason = entry.WaitReason ?? "unknown";
+                    _requestWaitStartTimes[globalRequestId] = (System.Diagnostics.Stopwatch.GetTimestamp(), reason);
+                }
             }
 
             // Update the previous state for next transition
-            _previousStates[entry.Request.GlobalRequestId] = newState;
+            _previousStates[globalRequestId] = newState;
 
             QueueAction(() => { EvaluateRequestStates(); }, isLastTask: false);
         }
@@ -898,6 +925,7 @@ namespace Microsoft.Build.BackEnd
                 _requests.Remove(completedEntry);
                 _requestsByGlobalRequestId.Remove(completedEntry.Request.GlobalRequestId);
                 _previousStates.Remove(completedEntry.Request.GlobalRequestId);
+                _requestWaitStartTimes.Remove(completedEntry.Request.GlobalRequestId);
             }
 
             // If we completed a request, that means we may be able to unload the configuration if there is memory pressure.  Further we
@@ -1285,7 +1313,7 @@ namespace Microsoft.Build.BackEnd
                             request.Config.ConfigurationId = GetNextUnresolvedConfigurationId();
                             _unresolvedConfigurationsById.Add(request.Config.ConfigurationId, request.Config);
                             _unresolvedConfigurationsByMetadata.Add(configMetadata, request.Config);
-                            _configurationRequestTimestamps[request.Config.ConfigurationId] = Stopwatch.GetTimestamp();
+                            _configurationRequestTimestamps[request.Config.ConfigurationId] = System.Diagnostics.Stopwatch.GetTimestamp();
                             unresolvedConfigurationsAdded ??= new HashSet<int>();
                             unresolvedConfigurationsAdded.Add(request.Config.ConfigurationId);
                         }

--- a/src/Build/BackEnd/Components/BuildRequestEngine/BuildRequestEngine.cs
+++ b/src/Build/BackEnd/Components/BuildRequestEngine/BuildRequestEngine.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Metrics;
@@ -85,6 +86,8 @@ namespace Microsoft.Build.BackEnd
         private ObservableGauge<int> _requestsGauge;
         private ObservableGauge<int> _workQueueGauge;
         private ObservableGauge<int> _engineStatusGauge;
+        private Histogram<double> _configurationResolutionHistogram;
+        private readonly ObservableCounter<long> _stateTransitionsCounter;
 #pragma warning restore IDE0052 // Remove unread private members
 
         /// <summary>
@@ -120,6 +123,21 @@ namespace Microsoft.Build.BackEnd
         /// The list of unresolved configurations by metadata.
         /// </summary>
         private Dictionary<ConfigurationMetadata, BuildRequestConfiguration> _unresolvedConfigurationsByMetadata;
+
+        /// <summary>
+        /// Tracks when configuration resolution requests were initiated, for timing metrics. Entries are removed when resolution is finished.
+        /// </summary>
+        private Dictionary<int, long> _configurationRequestTimestamps;
+
+        /// <summary>
+        /// Tracks counts of build request state transitions for metrics. Keys are a particular kind of state transition, e.g. "Waiting->Active".
+        /// </summary>
+        private readonly ConcurrentDictionary<string, long> _stateTransitionCounts;
+
+        /// <summary>
+        /// Tracks the previous state of each build request entry for transition tracking. Entries are removed when the request is completed.
+        /// </summary>
+        private readonly Dictionary<int, BuildRequestEntryState> _previousStates;
 
         /// <summary>
         /// The logging context for the node
@@ -161,6 +179,8 @@ namespace Microsoft.Build.BackEnd
             _requests = new List<BuildRequestEntry>();
             _unsubmittedRequests = new Queue<PendingUnsubmittedBuildRequests>();
             _requestsByGlobalRequestId = new Dictionary<int, BuildRequestEntry>();
+            _stateTransitionCounts = new ConcurrentDictionary<string, long>();
+            _previousStates = new Dictionary<int, BuildRequestEntryState>();
         }
 
         #region IBuildRequestEngine Members
@@ -226,6 +246,12 @@ namespace Microsoft.Build.BackEnd
             _requestsGauge = s_meter.CreateObservableGauge("build_request_engine_requests", CollectRequestStatus, "requests", "Number of active build requests in the BuildRequestEngine", tags: [new("nodeId", _nodeLoggingContext.BuildEventContext.NodeId)]);
             _workQueueGauge = s_meter.CreateObservableGauge("build_request_engine_work_queue_length", () => _workQueue.InputCount, "items", "Number of items in the BuildRequestEngine work queue", tags: [new("nodeId", _nodeLoggingContext.BuildEventContext.NodeId)]);
             _engineStatusGauge = s_meter.CreateObservableGauge("build_request_engine_status", () => (int)_status, "status", "Current status of the BuildRequestEngine", tags: [new("nodeId", _nodeLoggingContext.BuildEventContext.NodeId)]);
+            _configurationResolutionHistogram = s_meter.CreateHistogram<double>("msbuild_configuration_resolution_duration", unit: "ms", description: "Time taken to resolve build configurations");
+            _stateTransitionsCounter = s_meter.CreateObservableCounter(
+                "msbuild_build_request_state_transitions",
+                CollectStateTransitionCounts,
+                unit: "transitions",
+                description: "Count of build request state transitions");
 
             // Create a work queue that will take an action and invoke it.  The generic parameter is the type which ActionBlock.Post() will
             // take (an Action in this case) and the parameter to this constructor is a function which takes that parameter of type Action
@@ -244,6 +270,14 @@ namespace Microsoft.Build.BackEnd
             foreach (var kvp in requestsByState)
             {
                 yield return new Measurement<int>(kvp.Value, new KeyValuePair<string, object>("state", kvp.Key.ToString()));
+            }
+        }
+
+        private IEnumerable<Measurement<long>> CollectStateTransitionCounts()
+        {
+            foreach (var kvp in _stateTransitionCounts)
+            {
+                yield return new Measurement<long>(kvp.Value, new KeyValuePair<string, object?>("transition", kvp.Key));
             }
         }
 
@@ -442,6 +476,9 @@ namespace Microsoft.Build.BackEnd
 
                         entry.OnStateChanged += BuildRequestEntry_StateChanged;
 
+                        // Initialize the previous state for transition tracking
+                        _previousStates[request.GlobalRequestId] = entry.State;
+
                         _requests.Add(entry);
                         _requestsByGlobalRequestId[request.GlobalRequestId] = entry;
                         ActivateBuildRequest(entry);
@@ -580,6 +617,15 @@ namespace Microsoft.Build.BackEnd
                     _ = _unresolvedConfigurationsById.Remove(response.NodeConfigurationId);
                     _ = _unresolvedConfigurationsByMetadata.Remove(new ConfigurationMetadata(config));
 
+                    // Record configuration resolution duration
+                    if (_configurationRequestTimestamps.TryGetValue(response.NodeConfigurationId, out long startTimestamp))
+                    {
+                        long endTimestamp = Stopwatch.GetTimestamp();
+                        double durationMs = (endTimestamp - startTimestamp) * 1000.0 / Stopwatch.Frequency;
+                        _configurationResolutionHistogram.Record(durationMs);
+                        _configurationRequestTimestamps.Remove(response.NodeConfigurationId);
+                    }
+
                     // Add the configuration to the resolved cache unless it already exists there.  This will be
                     // the case in single-proc mode as we share the global cache with the Build Manager.
                     IConfigCache globalConfigurations = (IConfigCache)_componentHost.GetComponent(BuildComponentType.ConfigCache);
@@ -674,6 +720,7 @@ namespace Microsoft.Build.BackEnd
             // NOTE: Because we don't get this from the component host, we cannot override it.
             _unresolvedConfigurationsById = new Dictionary<int, BuildRequestConfiguration>();
             _unresolvedConfigurationsByMetadata = new Dictionary<ConfigurationMetadata, BuildRequestConfiguration>();
+            _configurationRequestTimestamps = new Dictionary<int, long>();
         }
 
         /// <summary>
@@ -705,6 +752,16 @@ namespace Microsoft.Build.BackEnd
         /// <param name="newState">The event's new state.</param>
         private void BuildRequestEntry_StateChanged(BuildRequestEntry entry, BuildRequestEntryState newState)
         {
+            // Track the state transition for metrics
+            if (_previousStates.TryGetValue(entry.Request.GlobalRequestId, out BuildRequestEntryState oldState))
+            {
+                string transition = $"{oldState}->{newState}";
+                _stateTransitionCounts.AddOrUpdate(transition, 1, (key, oldValue) => oldValue + 1);
+            }
+
+            // Update the previous state for next transition
+            _previousStates[entry.Request.GlobalRequestId] = newState;
+
             QueueAction(() => { EvaluateRequestStates(); }, isLastTask: false);
         }
 
@@ -840,6 +897,7 @@ namespace Microsoft.Build.BackEnd
                 TraceEngine("ERS: Request {0}({1}) (nr {2}) is being removed from the requests list.", completedEntry.Request.GlobalRequestId, completedEntry.Request.ConfigurationId, completedEntry.Request.NodeRequestId);
                 _requests.Remove(completedEntry);
                 _requestsByGlobalRequestId.Remove(completedEntry.Request.GlobalRequestId);
+                _previousStates.Remove(completedEntry.Request.GlobalRequestId);
             }
 
             // If we completed a request, that means we may be able to unload the configuration if there is memory pressure.  Further we
@@ -1227,6 +1285,7 @@ namespace Microsoft.Build.BackEnd
                             request.Config.ConfigurationId = GetNextUnresolvedConfigurationId();
                             _unresolvedConfigurationsById.Add(request.Config.ConfigurationId, request.Config);
                             _unresolvedConfigurationsByMetadata.Add(configMetadata, request.Config);
+                            _configurationRequestTimestamps[request.Config.ConfigurationId] = Stopwatch.GetTimestamp();
                             unresolvedConfigurationsAdded ??= new HashSet<int>();
                             unresolvedConfigurationsAdded.Add(request.Config.ConfigurationId);
                         }

--- a/src/Build/BackEnd/Components/Caching/ConfigCache.cs
+++ b/src/Build/BackEnd/Components/Caching/ConfigCache.cs
@@ -350,6 +350,10 @@ namespace Microsoft.Build.BackEnd
         /// </summary>
         private record class Configurations : ITranslatable
         {
+            private static Meter s_configurationMetrics = new("Microsoft.Build");
+#pragma warning disable IDE0052 // Remove unread private members
+            private readonly ObservableGauge<int> _configurationsPerProjectGauge;
+#pragma warning restore IDE0052 // Remove unread private members
             private ConcurrentDictionary<int, BuildRequestConfiguration> _byId;
             private ConcurrentDictionary<ConfigurationMetadata, BuildRequestConfiguration> _byMetadata;
 
@@ -357,22 +361,12 @@ namespace Microsoft.Build.BackEnd
             {
                 _byId = new ConcurrentDictionary<int, BuildRequestConfiguration>();
                 _byMetadata = new ConcurrentDictionary<ConfigurationMetadata, BuildRequestConfiguration>();
-                _configurationMetrics.CreateObservableGauge(
-                "msbuild_configurations_per_project",
-                () => GetConfigurationsPerProjectMeasurements(),
-                description: "The count of configurations per project file during the build",
-                unit: "configurations");
+                _configurationsPerProjectGauge = s_configurationMetrics.CreateObservableGauge(
+                    "msbuild_configurations_per_project",
+                    GetConfigurationsPerProjectMeasurements,
+                    description: "The count of configurations per project file during the build",
+                    unit: "configurations");
             }
-            
-            private static Meter _configurationMetrics = new("Microsoft.Build");
-
-#pragma warning disable CA1823 // Avoid unused private fields
-#pragma warning disable IDE0051 // Remove unused private members
-#pragma warning disable CS0169 // Remove unused private members
-            private readonly ObservableGauge<int> _configurationsPerProjectGauge;
-#pragma warning restore CS0169 // Remove unused private members
-#pragma warning restore IDE0051 // Remove unused private members
-#pragma warning restore CA1823 // Avoid unused private fields
 
             private IEnumerable<Measurement<int>> GetConfigurationsPerProjectMeasurements()
             {

--- a/src/Build/BackEnd/Components/Communications/NodeLauncher.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeLauncher.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Build.BackEnd
 {
     internal sealed class NodeLauncher : INodeLauncher, IBuildComponent
     {
-        private static const string DotnetEnableDiagnosticsEnvVarName = "DOTNET_EnableDiagnostics";
+        private const string DotnetEnableDiagnosticsEnvVarName = "DOTNET_EnableDiagnostics";
 
         public static IBuildComponent CreateComponent(BuildComponentType type)
         {
@@ -137,7 +137,8 @@ namespace Microsoft.Build.BackEnd
                 RedirectStandardError = redirectStreams,
                 CreateNoWindow = redirectStreams && (creationFlags & BackendNativeMethods.CREATENOWINDOW) != 0,
             };
-            if (!processStartInfo.Environment.TryAdd(DotnetEnableDiagnosticsEnvVarName, "0"))
+
+            if (!processStartInfo.Environment.ContainsKey(DotnetEnableDiagnosticsEnvVarName))
             {
                 processStartInfo.Environment[DotnetEnableDiagnosticsEnvVarName] = "0";
             }
@@ -281,7 +282,8 @@ namespace Microsoft.Build.BackEnd
             {
                 environment[(string)entry.Key] = (string)entry.Value;
             }
-            if (!environment.TryAdd(DotnetEnableDiagnosticsEnvVarName, "0"))
+
+            if (environment.ContainsKey(DotnetEnableDiagnosticsEnvVarName))
             {
                 environment[DotnetEnableDiagnosticsEnvVarName] = "0";
             }

--- a/src/Build/BackEnd/Components/Communications/NodeLauncher.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeLauncher.cs
@@ -26,6 +26,8 @@ namespace Microsoft.Build.BackEnd
 {
     internal sealed class NodeLauncher : INodeLauncher, IBuildComponent
     {
+        private static const string DotnetEnableDiagnosticsEnvVarName = "DOTNET_EnableDiagnostics";
+
         public static IBuildComponent CreateComponent(BuildComponentType type)
         {
             ErrorUtilities.VerifyThrowArgumentOutOfRange(type == BuildComponentType.NodeLauncher, nameof(type));
@@ -135,7 +137,10 @@ namespace Microsoft.Build.BackEnd
                 RedirectStandardError = redirectStreams,
                 CreateNoWindow = redirectStreams && (creationFlags & BackendNativeMethods.CREATENOWINDOW) != 0,
             };
-
+            if (!processStartInfo.Environment.TryAdd(DotnetEnableDiagnosticsEnvVarName, "0"))
+            {
+                processStartInfo.Environment[DotnetEnableDiagnosticsEnvVarName] = "0";
+            }
             DotnetHostEnvironmentHelper.ApplyEnvironmentOverrides(processStartInfo.Environment, nodeLaunchData.EnvironmentOverrides);
 
             try
@@ -276,7 +281,10 @@ namespace Microsoft.Build.BackEnd
             {
                 environment[(string)entry.Key] = (string)entry.Value;
             }
-
+            if (!environment.TryAdd(DotnetEnableDiagnosticsEnvVarName, "0"))
+            {
+                environment[DotnetEnableDiagnosticsEnvVarName] = "0";
+            }
             DotnetHostEnvironmentHelper.ApplyEnvironmentOverrides(environment, environmentOverrides);
 
             // Build the environment block: "key=value\0key=value\0\0"

--- a/src/Build/BackEnd/Components/Communications/NodeManager.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeManager.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Build.BackEnd
     /// </summary>
     internal class NodeManager : INodeManager
     {
-        private static System.Diagnostics.Metrics.Meter _nodeMetrics = new("Microsoft.Build.Nodes");
+        private static Meter _nodeMetrics = new("Microsoft.Build");
 
         /// <summary>
         /// The node provider for the in-proc node.
@@ -356,7 +356,7 @@ namespace Microsoft.Build.BackEnd
                 _nodeIdToProvider.Add(node.NodeId, nodeProvider);
             }
             
-            int matchingNodeCount = _nodeIdToProvider.Values.Count(provider => provider == nodeProvider);
+            int matchingNodeCount = _nodeIdToProvider.Count(kvp => kvp.Value == nodeProvider);
             _nodeCountMetric.Record(matchingNodeCount, new KeyValuePair<string, object?>("node.type", nodeProvider == _inProcNodeProvider ? "inproc" : "outofproc"));
 
             return nodes;

--- a/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcTaskHost.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcTaskHost.cs
@@ -766,7 +766,7 @@ namespace Microsoft.Build.BackEnd
 #if RUNTIME_TYPE_NETCORE
             Handshake handshake = new Handshake(hostContext);
 #else
-            Handshake handshake = new Handshake(hostContext, toolsDirectory: msbuildAssemblyPath);
+            Handshake handshake = new Handshake(hostContext, predefinedToolsDirectory: msbuildAssemblyPath);
 #endif
 
             if (FileSystems.Default.FileExists(appHostPath))

--- a/src/Build/BackEnd/Components/Logging/LoggingService.cs
+++ b/src/Build/BackEnd/Components/Logging/LoggingService.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics.Metrics;
 using System.Globalization;
 using System.Linq;
 using System.Reflection;
@@ -105,6 +106,11 @@ namespace Microsoft.Build.BackEnd.Logging
         /// it is only discoverable with Reflection using the Public flag (go figure!)
         /// </remarks>
         private static readonly Lazy<PropertyInfo> s_projectStartedEventArgsToolsVersion = new Lazy<PropertyInfo>(() => typeof(ProjectStartedEventArgs).GetProperty("ToolsVersion", BindingFlags.Public | BindingFlags.Instance), LazyThreadSafetyMode.PublicationOnly);
+
+        /// <summary>
+        /// Meter for logging service metrics.
+        /// </summary>
+        private static readonly Meter s_meter = new Meter("Microsoft.Build");
 
         #region Data
 
@@ -247,6 +253,19 @@ namespace Microsoft.Build.BackEnd.Logging
         /// Null means that the optimization is disabled or no relevant logger has been registered.
         /// </summary>
         private MessageImportance? _minimumRequiredMessageImportance;
+
+        /// <summary>
+        /// Counter tracking the total number of log messages forwarded from worker nodes to the central node, by source node.
+        /// </summary>
+        private ConcurrentDictionary<int, long> _forwardedLogMessageCountByNode;
+
+        /// <summary>
+        /// Observable counter for forwarded log messages metric.
+        /// Must be kept alive for the observable counter to continue reporting.
+        /// </summary>
+#pragma warning disable IDE0052 // Remove unread private members
+        private ObservableCounter<long> _forwardedLogMessagesCounter;
+#pragma warning restore IDE0052 // Remove unread private members
 
         #region LoggingThread Data
 
@@ -881,6 +900,21 @@ namespace Microsoft.Build.BackEnd.Logging
         }
 
         /// <summary>
+        /// Callback method to collect forwarded log message counts by source node.
+        /// </summary>
+        /// <returns>Measurements for each source node that has forwarded messages.</returns>
+        private IEnumerable<Measurement<long>> CollectForwardedLogMessageCounts()
+        {
+            if (_forwardedLogMessageCountByNode != null)
+            {
+                foreach (var kvp in _forwardedLogMessageCountByNode)
+                {
+                    yield return new(kvp.Value, new KeyValuePair<string, object>("node.id", kvp.Key));
+                }
+            }
+        }
+
+        /// <summary>
         /// NotThreadSafe, this method should only be called from the component host thread
         /// Called by the build component host when a component is first initialized.
         /// </summary>
@@ -912,6 +946,17 @@ namespace Microsoft.Build.BackEnd.Logging
                 _buildEngineDataRouter = (buildComponentHost.GetComponent(BuildComponentType.BuildCheckManagerProvider) as IBuildCheckManagerProvider)?.BuildEngineDataRouter;
 
                 _buildCheckEnabled = buildComponentHost.BuildParameters.IsBuildCheckEnabled;
+
+                // Only create the forwarded log messages counter on the central (scheduler) node
+                if (_nodeId == Scheduler.VirtualNode)
+                {
+                    _forwardedLogMessageCountByNode = new ConcurrentDictionary<int, long>();
+                    _forwardedLogMessagesCounter = s_meter.CreateObservableCounter(
+                        "msbuild_forwarded_log_messages",
+                        CollectForwardedLogMessageCounts,
+                        unit: "messages",
+                        description: "Total number of log messages forwarded from worker nodes to the central node");
+                }
             }
         }
 
@@ -1013,6 +1058,12 @@ namespace Microsoft.Build.BackEnd.Logging
             InjectNonSerializedData(loggingPacket);
 
             ErrorUtilities.VerifyThrow(loggingPacket.EventType != LoggingEventType.CustomEvent, "Custom event types are no longer supported. Does the sending node have a different version?");
+
+            // Increment the forwarded log message counter by source node (only on central node where the counter is created)
+            if (_nodeId == Scheduler.VirtualNode && _forwardedLogMessageCountByNode != null)
+            {
+                _forwardedLogMessageCountByNode.AddOrUpdate(node, 1, (key, oldValue) => oldValue + 1);
+            }
 
             ProcessLoggingEvent(loggingPacket.NodeBuildEvent);
         }

--- a/src/Build/BackEnd/Components/Scheduler/SchedulableRequest.cs
+++ b/src/Build/BackEnd/Components/Scheduler/SchedulableRequest.cs
@@ -6,8 +6,6 @@ using System.Collections.Generic;
 using Microsoft.Build.Execution;
 using Microsoft.Build.Shared;
 
-#nullable disable
-
 namespace Microsoft.Build.BackEnd
 {
     /// <summary>
@@ -83,12 +81,12 @@ namespace Microsoft.Build.BackEnd
         /// <summary>
         /// The schedulable request which issued this request.
         /// </summary>
-        private SchedulableRequest _parent;
+        private SchedulableRequest? _parent;
 
         /// <summary>
         /// The list of targets which were actively building at the time we were blocked.
         /// </summary>
-        private string[] _activeTargetsWhenBlocked;
+        private string[]? _activeTargetsWhenBlocked;
 
         /// <summary>
         /// The requests which must complete before we can continue executing.  Indexed by global request id and node request id.
@@ -124,7 +122,7 @@ namespace Microsoft.Build.BackEnd
         /// <summary>
         /// Constructor.
         /// </summary>
-        public SchedulableRequest(SchedulingData collection, BuildRequest request, SchedulableRequest parent)
+        public SchedulableRequest(SchedulingData collection, BuildRequest request, SchedulableRequest? parent)
         {
             ErrorUtilities.VerifyThrowArgumentNull(collection);
             ErrorUtilities.VerifyThrowArgumentNull(request);
@@ -167,7 +165,7 @@ namespace Microsoft.Build.BackEnd
         /// <summary>
         /// The request which issued this request.
         /// </summary>
-        public SchedulableRequest Parent
+        public SchedulableRequest? Parent
         {
             get { return _parent; }
         }
@@ -188,14 +186,14 @@ namespace Microsoft.Build.BackEnd
             get
             {
                 VerifyOneOfStates([SchedulableRequestState.Yielding, SchedulableRequestState.Blocked, SchedulableRequestState.Executing]);
-                return _activeTargetsWhenBlocked;
+                return _activeTargetsWhenBlocked!;
             }
         }
 
         /// <summary>
         /// The target we are blocked on
         /// </summary>
-        public string BlockingTarget { get; private set; }
+        public string? BlockingTarget { get; private set; }
 
         /// <summary>
         /// Gets a count of the requests we are blocked by.
@@ -332,7 +330,7 @@ namespace Microsoft.Build.BackEnd
         /// <param name="blockingRequest">The request which is blocking this one.</param>
         /// <param name="activeTargets">The list of targets this request was currently building at the time it became blocked.</param>
         /// <param name="blockingTarget">Target that we are blocked on which is being built by <paramref name="blockingRequest"/></param>
-        public void BlockByRequest(SchedulableRequest blockingRequest, string[] activeTargets, string blockingTarget = null)
+        public void BlockByRequest(SchedulableRequest blockingRequest, string[] activeTargets, string? blockingTarget = null)
         {
             VerifyOneOfStates([SchedulableRequestState.Blocked, SchedulableRequestState.Executing]);
             ErrorUtilities.VerifyThrowArgumentNull(blockingRequest);
@@ -516,7 +514,7 @@ namespace Microsoft.Build.BackEnd
         {
             // If there is already a blocked request which has the same configuration id as the blocking request and that blocked request is (recursively)
             // waiting on this request, then that is an indirect circular dependency.
-            SchedulableRequest alternateRequest = _schedulingData.GetBlockedRequestIfAny(blockingRequest.BuildRequest.GlobalRequestId);
+            SchedulableRequest? alternateRequest = _schedulingData.GetBlockedRequestIfAny(blockingRequest.BuildRequest.GlobalRequestId);
             if (alternateRequest == null)
             {
                 return;
@@ -528,10 +526,10 @@ namespace Microsoft.Build.BackEnd
 
             while (requestsToEvaluate.Count > 0)
             {
-                SchedulableRequest requestToEvaluate = requestsToEvaluate.Pop();
+                SchedulableRequest? requestToEvaluate = requestsToEvaluate.Pop();
 
                 // If we make it to a child which is us, then it's a circular dependency.
-                if (requestToEvaluate.BuildRequest.GlobalRequestId == this.BuildRequest.GlobalRequestId)
+                if (requestToEvaluate.BuildRequest.GlobalRequestId == BuildRequest.GlobalRequestId)
                 {
                     ThrowIndirectCircularDependency(blockingRequest, requestToEvaluate);
                 }
@@ -588,7 +586,7 @@ namespace Microsoft.Build.BackEnd
             // A circular dependency occurs when this project (or any of its ancestors) has the same global request id as the
             // blocking request.
             List<SchedulableRequest> ancestors = new List<SchedulableRequest>(16);
-            SchedulableRequest currentRequest = this;
+            SchedulableRequest? currentRequest = this;
             do
             {
                 ancestors.Add(currentRequest);
@@ -638,7 +636,7 @@ namespace Microsoft.Build.BackEnd
         /// </summary>
         internal void DisconnectRequestWeAreBlockedBy(BlockingRequestKey blockingRequestKey)
         {
-            ErrorUtilities.VerifyThrow(_requestsWeAreBlockedBy.TryGetValue(blockingRequestKey, out SchedulableRequest unblockingRequest), "We are not blocked by the specified request.");
+            ErrorUtilities.VerifyThrow(_requestsWeAreBlockedBy.TryGetValue(blockingRequestKey, out SchedulableRequest? unblockingRequest), "We are not blocked by the specified request.");
             ErrorUtilities.VerifyThrow(unblockingRequest._requestsWeAreBlocking.Contains(this), "The request unblocking us doesn't think it is blocking us.");
 
             _requestsWeAreBlockedBy.Remove(blockingRequestKey);
@@ -693,11 +691,11 @@ namespace Microsoft.Build.BackEnd
             /// <summary>
             /// Equals override.
             /// </summary>
-            public override bool Equals(object obj)
+            public override bool Equals(object? obj)
             {
                 if (obj != null)
                 {
-                    BlockingRequestKey other = obj as BlockingRequestKey;
+                    BlockingRequestKey? other = obj as BlockingRequestKey;
                     if (other != null)
                     {
                         return (other._globalRequestId == _globalRequestId) && (other._nodeRequestId == _nodeRequestId);

--- a/src/Build/BackEnd/Components/Scheduler/Scheduler.cs
+++ b/src/Build/BackEnd/Components/Scheduler/Scheduler.cs
@@ -117,6 +117,7 @@ namespace Microsoft.Build.BackEnd
 #pragma warning disable IDE0052 // Remove unread private members
         private readonly ObservableGauge<int> _outOfProcNodeCountGauge;
         private readonly ObservableGauge<int> _inProcNodeCountGauge;
+        private readonly ObservableGauge<int> _schedulerRequestCountGauge;
 #pragma warning restore IDE0052 // Remove unread private members
 
         /// <summary>
@@ -277,6 +278,12 @@ namespace Microsoft.Build.BackEnd
                 description: "The current count of nodes in the scheduler",
                 unit: "nodes",
                 tags: [new("node.type", "inproc")]);
+
+            _schedulerRequestCountGauge = _schedulerMetrics.CreateObservableGauge(
+                "msbuild_scheduler_request_count",
+                () => _nextGlobalRequestId,
+                description: "The total count of requests in the scheduler",
+                unit: "requests");
 
             Reset();
         }

--- a/src/Build/BackEnd/Components/Scheduler/Scheduler.cs
+++ b/src/Build/BackEnd/Components/Scheduler/Scheduler.cs
@@ -20,8 +20,6 @@ using BuildAbortedException = Microsoft.Build.Exceptions.BuildAbortedException;
 using ILoggingService = Microsoft.Build.BackEnd.Logging.ILoggingService;
 using NodeLoggingContext = Microsoft.Build.BackEnd.Logging.NodeLoggingContext;
 
-#nullable disable
-
 namespace Microsoft.Build.BackEnd
 {
     /// <summary>
@@ -73,7 +71,7 @@ namespace Microsoft.Build.BackEnd
         /// <summary>
         /// Content of the environment variable  MSBUILDSCHEDULINGUNLIMITED
         /// </summary>
-        private string _schedulingUnlimitedVariable;
+        private string? _schedulingUnlimitedVariable;
 
         /// <summary>
         /// If MSBUILDSCHEDULINGUNLIMITED is set, this flag will make AtSchedulingLimit() always return false
@@ -115,9 +113,7 @@ namespace Microsoft.Build.BackEnd
         private int _currentOutOfProcNodeCount = 0;
 
 #pragma warning disable IDE0052 // Remove unread private members
-        private readonly ObservableGauge<int> _outOfProcNodeCountGauge;
-        private readonly ObservableGauge<int> _inProcNodeCountGauge;
-        private readonly ObservableGauge<int> _schedulerRequestCountGauge;
+        private readonly ObservableGauge<int> _schedulerNodeCountGauge;
 #pragma warning restore IDE0052 // Remove unread private members
 
         /// <summary>
@@ -180,12 +176,12 @@ namespace Microsoft.Build.BackEnd
         /// <summary>
         /// The plan.
         /// </summary>
-        private SchedulingPlan _schedulingPlan;
+        private SchedulingPlan? _schedulingPlan;
 
         /// <summary>
         /// If MSBUILDCUSTOMSCHEDULER is set, contains the requested scheduling algorithm
         /// </summary>
-        private AssignUnscheduledRequestsDelegate _customRequestSchedulingAlgorithm;
+        private AssignUnscheduledRequestsDelegate? _customRequestSchedulingAlgorithm;
 
         private NodeLoggingContext _inprocNodeContext;
 
@@ -216,7 +212,9 @@ namespace Microsoft.Build.BackEnd
         /// <summary>
         /// Constructor.
         /// </summary>
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable. Ignored because of Reset call.
         public Scheduler()
+#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.
         {
             // Be careful moving these to Traits, changing the timing of reading environment variables has a breaking potential.
             _debugDumpState = Traits.Instance.DebugScheduler;
@@ -232,7 +230,7 @@ namespace Microsoft.Build.BackEnd
             {
                 _schedulingUnlimited = false;
 
-                string strNodeLimitOffset = Environment.GetEnvironmentVariable("MSBUILDNODELIMITOFFSET");
+                string? strNodeLimitOffset = Environment.GetEnvironmentVariable("MSBUILDNODELIMITOFFSET");
                 if (!String.IsNullOrEmpty(strNodeLimitOffset))
                 {
                     _nodeLimitOffset = Int16.Parse(strNodeLimitOffset, CultureInfo.InvariantCulture);
@@ -266,26 +264,20 @@ namespace Microsoft.Build.BackEnd
                 _debugDumpPath = FileUtilities.TempFileDirectory;
             }
 
-            _outOfProcNodeCountGauge = _schedulerMetrics.CreateObservableGauge(
+            _schedulerNodeCountGauge = _schedulerMetrics.CreateObservableGauge(
                 "msbuild_scheduler_node_count",
-                () => _currentOutOfProcNodeCount,
+                ComputeNodeCounts,
                 description: "The current count of nodes in the scheduler",
                 unit: "nodes",
                 tags: [new("node.type", "outofproc")]);
-            _inProcNodeCountGauge = _schedulerMetrics.CreateObservableGauge(
-                "msbuild_scheduler_node_count",
-                () => _currentInProcNodeCount,
-                description: "The current count of nodes in the scheduler",
-                unit: "nodes",
-                tags: [new("node.type", "inproc")]);
-
-            _schedulerRequestCountGauge = _schedulerMetrics.CreateObservableGauge(
-                "msbuild_scheduler_request_count",
-                () => _nextGlobalRequestId,
-                description: "The total count of requests in the scheduler",
-                unit: "requests");
 
             Reset();
+        }
+
+        private IEnumerable<Measurement<int>> ComputeNodeCounts()
+        {
+            yield return new Measurement<int>(_currentOutOfProcNodeCount, new KeyValuePair<string, object?>("node.type", "outofproc"));
+            yield return new Measurement<int>(_currentInProcNodeCount, new KeyValuePair<string, object?>("node.type", "inproc"));
         }
 
         #region Delegates
@@ -344,15 +336,15 @@ namespace Microsoft.Build.BackEnd
         /// <summary>
         /// Retrieves the request executing on a node.
         /// </summary>
-        public BuildRequest GetExecutingRequestByNode(int nodeId)
+        public BuildRequest? GetExecutingRequestByNode(int nodeId)
         {
             if (!_schedulingData.IsNodeWorking(nodeId))
             {
                 return null;
             }
 
-            SchedulableRequest request = _schedulingData.GetExecutingRequestByNode(nodeId);
-            return request.BuildRequest;
+            SchedulableRequest? request = _schedulingData.GetExecutingRequestByNode(nodeId);
+            return request?.BuildRequest;
         }
 
         /// <summary>
@@ -364,7 +356,7 @@ namespace Microsoft.Build.BackEnd
             List<ScheduleResponse> responses = new List<ScheduleResponse>();
 
             // Get the parent, if any
-            SchedulableRequest parentRequest = null;
+            SchedulableRequest parentRequest = null!;
             if (blocker.BlockedRequestId != BuildRequest.InvalidGlobalRequestId)
             {
                 if (blocker.YieldAction == YieldAction.Reacquire)
@@ -465,7 +457,7 @@ namespace Microsoft.Build.BackEnd
 
                     // Note: In this case we do not need to log that we got the results from the cache because we are only using the cache
                     // for filtering the targets for the result instead rather than using the cache as the location where this result came from.
-                    ScheduleResponse response = TrySatisfyRequestFromCache(request.Parent.AssignedNode, request.BuildRequest, skippedResultsDoNotCauseCacheMiss: _componentHost.BuildParameters.SkippedResultsDoNotCauseCacheMiss());
+                    ScheduleResponse? response = TrySatisfyRequestFromCache(request.Parent.AssignedNode, request.BuildRequest, skippedResultsDoNotCauseCacheMiss: _componentHost.BuildParameters.SkippedResultsDoNotCauseCacheMiss());
 
                     // response may be null if the result was never added to the cache. This can happen if the result has an exception in it
                     // or the results could not be satisfied because the initial or default targets have been skipped. If that is the case
@@ -509,7 +501,7 @@ namespace Microsoft.Build.BackEnd
                         // its configuration and set of targets are identical -- from MSBuild's perspective, it's the same.  So since
                         // we're not going to attempt to re-execute it, if there are skipped targets in the result, that's fine. We just
                         // need to know what the target results are so that we can log them.
-                        ScheduleResponse response = TrySatisfyRequestFromCache(parentNode, unscheduledRequest.BuildRequest, skippedResultsDoNotCauseCacheMiss: true);
+                        ScheduleResponse? response = TrySatisfyRequestFromCache(parentNode, unscheduledRequest.BuildRequest, skippedResultsDoNotCauseCacheMiss: true);
 
                         // If we have a response we need to tell the loggers that we satisfied that request from the cache.
                         if (response != null)
@@ -925,7 +917,7 @@ namespace Microsoft.Build.BackEnd
 
             if (_customRequestSchedulingAlgorithm == null)
             {
-                string customScheduler = Environment.GetEnvironmentVariable("MSBUILDCUSTOMSCHEDULER");
+                string? customScheduler = Environment.GetEnvironmentVariable("MSBUILDCUSTOMSCHEDULER");
 
                 if (!String.IsNullOrEmpty(customScheduler))
                 {
@@ -970,7 +962,7 @@ namespace Microsoft.Build.BackEnd
                     {
                         _customRequestSchedulingAlgorithm = AssignUnscheduledRequestsUsingCustomSchedulerForSQL;
 
-                        string multiplier = Environment.GetEnvironmentVariable("MSBUILDCUSTOMSCHEDULERFORSQLCONFIGURATIONLIMITMULTIPLIER");
+                        string? multiplier = Environment.GetEnvironmentVariable("MSBUILDCUSTOMSCHEDULERFORSQLCONFIGURATIONLIMITMULTIPLIER");
                         double convertedMultiplier = 0;
                         if (!Double.TryParse(multiplier, NumberStyles.AllowDecimalPoint | NumberStyles.AllowLeadingSign, CultureInfo.InvariantCulture.NumberFormat, out convertedMultiplier) || convertedMultiplier < 1)
                         {
@@ -1007,15 +999,15 @@ namespace Microsoft.Build.BackEnd
         {
             foreach (int idleNodeId in idleNodes)
             {
-                SchedulingPlan.PlanConfigData bestConfig = null;
-                SchedulableRequest bestRequest = null;
+                SchedulingPlan.PlanConfigData? bestConfig = null;
+                SchedulableRequest? bestRequest = null;
 
                 // Find the most expensive request in the plan to schedule from among the ones available.
                 foreach (SchedulableRequest request in _schedulingData.UnscheduledRequestsWhichCanBeScheduled)
                 {
                     if (CanScheduleRequestToNode(request, idleNodeId))
                     {
-                        SchedulingPlan.PlanConfigData configToConsider = _schedulingPlan.GetConfiguration(request.BuildRequest.ConfigurationId);
+                        SchedulingPlan.PlanConfigData? configToConsider = _schedulingPlan?.GetConfiguration(request.BuildRequest.ConfigurationId);
                         if (configToConsider is null)
                         {
                             if (bestConfig is null)
@@ -1143,7 +1135,7 @@ namespace Microsoft.Build.BackEnd
             // Assign requests with the largest file sizes.
             while (idleNodes.Count > 0 && _schedulingData.UnscheduledRequestsCount > 0)
             {
-                SchedulableRequest requestWithSmallestSourceFile = null;
+                SchedulableRequest? requestWithSmallestSourceFile = null;
                 int requestRequiredNodeId = InvalidNodeId;
                 long sizeOfSmallestSourceFile = long.MaxValue;
 
@@ -1153,7 +1145,7 @@ namespace Microsoft.Build.BackEnd
                     if (requiredNodeId == InvalidNodeId || idleNodes.Contains(requiredNodeId))
                     {
                         // Look for a request with the smallest source file
-                        System.IO.FileInfo f = new FileInfo(_configCache[unscheduledRequest.BuildRequest.ConfigurationId].ProjectFullPath);
+                        FileInfo f = new FileInfo(_configCache[unscheduledRequest.BuildRequest.ConfigurationId].ProjectFullPath);
                         if (f.Length < sizeOfSmallestSourceFile)
                         {
                             sizeOfSmallestSourceFile = f.Length;
@@ -1185,7 +1177,7 @@ namespace Microsoft.Build.BackEnd
             // Assign requests with the largest file sizes.
             while (idleNodes.Count > 0 && _schedulingData.UnscheduledRequestsCount > 0)
             {
-                SchedulableRequest requestWithLargestSourceFile = null;
+                SchedulableRequest? requestWithLargestSourceFile = null;
                 int requestRequiredNodeId = InvalidNodeId;
                 long sizeOfLargestSourceFile = 0;
 
@@ -1195,7 +1187,7 @@ namespace Microsoft.Build.BackEnd
                     if (requiredNodeId == InvalidNodeId || idleNodes.Contains(requiredNodeId))
                     {
                         // Look for a request with the largest source file
-                        System.IO.FileInfo f = new FileInfo(_configCache[unscheduledRequest.BuildRequest.ConfigurationId].ProjectFullPath);
+                        FileInfo f = new(_configCache[unscheduledRequest.BuildRequest.ConfigurationId].ProjectFullPath);
                         if (f.Length > sizeOfLargestSourceFile)
                         {
                             sizeOfLargestSourceFile = f.Length;
@@ -1228,9 +1220,9 @@ namespace Microsoft.Build.BackEnd
             foreach (int nodeId in idleNodes)
             {
                 int maxWaitingRequests = 0;
-                SchedulableRequest requestToSchedule = null;
-                SchedulableRequest requestToScheduleNoAffinity = null;
-                SchedulableRequest requestToScheduleWithAffinity = null;
+                SchedulableRequest? requestToSchedule = null;
+                SchedulableRequest? requestToScheduleNoAffinity = null;
+                SchedulableRequest? requestToScheduleWithAffinity = null;
                 foreach (SchedulableRequest currentSchedulableRequest in _schedulingData.UnscheduledRequestsWhichCanBeScheduled)
                 {
                     BuildRequest currentRequest = currentSchedulableRequest.BuildRequest;
@@ -1305,7 +1297,7 @@ namespace Microsoft.Build.BackEnd
             foreach (int nodeId in idleNodes)
             {
                 // Find the request with the most waiting requests
-                SchedulableRequest mostWaitingRequests = null;
+                SchedulableRequest? mostWaitingRequests = null;
                 foreach (SchedulableRequest unscheduledRequest in _schedulingData.UnscheduledRequestsWhichCanBeScheduled)
                 {
                     if (CanScheduleRequestToNode(unscheduledRequest, nodeId))
@@ -1573,10 +1565,12 @@ namespace Microsoft.Build.BackEnd
                 // Although this request has not been scheduled, this configuration may previously have been
                 // scheduled to an existing node.  If so, we shouldn't count it in our checks for new node
                 // creation, because it'll only eventually get assigned to its existing node anyway.
+#pragma warning disable IDE0002 // Simplify Member Access
                 if (assignedNodeForConfiguration != Scheduler.InvalidNodeId)
                 {
                     continue;
                 }
+#pragma warning restore IDE0002 // Simplify Member Access
 
                 NodeAffinity affinityRequired = GetNodeAffinityForRequest(request.BuildRequest);
 
@@ -1725,7 +1719,7 @@ namespace Microsoft.Build.BackEnd
                 blockingRequest.RequestsWeAreBlockedBy.Contains(blockedRequest))
             {
                 // if the blocking request is waiting on a target we have partial results for, preemptively break its dependency
-                if (blocker.PartialBuildResult.HasResultsForTarget(blockingRequest.BlockingTarget))
+                if (blockingRequest.BlockingTarget is not null && blocker.PartialBuildResult.HasResultsForTarget(blockingRequest.BlockingTarget))
                 {
                     blockingRequest.UnblockWithPartialResultForBlockingTarget(blocker.PartialBuildResult);
                 }
@@ -1765,7 +1759,7 @@ namespace Microsoft.Build.BackEnd
         /// <summary>
         /// Marks the request as being blocked by new requests whose results we must get before we can proceed.
         /// </summary>
-        private void HandleRequestBlockedByNewRequests(SchedulableRequest parentRequest, BuildRequestBlocker blocker, List<ScheduleResponse> responses)
+        private void HandleRequestBlockedByNewRequests(SchedulableRequest? parentRequest, BuildRequestBlocker blocker, List<ScheduleResponse> responses)
         {
             ErrorUtilities.VerifyThrowArgumentNull(blocker);
             ErrorUtilities.VerifyThrowArgumentNull(responses);
@@ -1787,7 +1781,7 @@ namespace Microsoft.Build.BackEnd
                 // First, determine if we have already built this request and have results for it.  If we do, we prepare the responses for it
                 // directly here.  We COULD simply report these as blocking the parent request and let the scheduler pick them up later when the parent
                 // comes back up as schedulable, but we prefer to send the results back immediately so this request can (potentially) continue uninterrupted.
-                ScheduleResponse response = TrySatisfyRequestFromCache(nodeForResults, request, skippedResultsDoNotCauseCacheMiss: _componentHost.BuildParameters.SkippedResultsDoNotCauseCacheMiss());
+                ScheduleResponse? response = TrySatisfyRequestFromCache(nodeForResults, request, skippedResultsDoNotCauseCacheMiss: _componentHost.BuildParameters.SkippedResultsDoNotCauseCacheMiss());
                 if (response != null)
                 {
                     TraceScheduler("Request {0} (node request {1}) satisfied from the cache.", request.GlobalRequestId, request.NodeRequestId);
@@ -1813,7 +1807,7 @@ namespace Microsoft.Build.BackEnd
                     {
                         bool affinityMismatch = false;
                         int assignedNodeId = _schedulingData.GetAssignedNodeForRequestConfiguration(request.ConfigurationId);
-                        if (assignedNodeId != Scheduler.InvalidNodeId)
+                        if (assignedNodeId != InvalidNodeId)
                         {
                             if (!_availableNodes[assignedNodeId].CanServiceRequestWithAffinity(GetNodeAffinityForRequest(request)))
                             {
@@ -1931,7 +1925,7 @@ namespace Microsoft.Build.BackEnd
             int nodeForResults = (request.Parent != null) ? request.Parent.AssignedNode : InvalidNodeId;
 
             // Do we already have results?  If so, just return them.
-            ScheduleResponse response = TrySatisfyRequestFromCache(nodeForResults, request.BuildRequest, skippedResultsDoNotCauseCacheMiss: _componentHost.BuildParameters.SkippedResultsDoNotCauseCacheMiss());
+            ScheduleResponse? response = TrySatisfyRequestFromCache(nodeForResults, request.BuildRequest, skippedResultsDoNotCauseCacheMiss: _componentHost.BuildParameters.SkippedResultsDoNotCauseCacheMiss());
             if (response != null)
             {
                 if (response.Action == ScheduleActionType.SubmissionComplete)
@@ -2034,7 +2028,7 @@ namespace Microsoft.Build.BackEnd
         /// <summary>
         /// Attempts to get a result from the cache to satisfy the request, and returns the appropriate response if possible.
         /// </summary>
-        private ScheduleResponse TrySatisfyRequestFromCache(int nodeForResults, BuildRequest request, bool skippedResultsDoNotCauseCacheMiss)
+        private ScheduleResponse? TrySatisfyRequestFromCache(int nodeForResults, BuildRequest request, bool skippedResultsDoNotCauseCacheMiss)
         {
             BuildRequestConfiguration config = _configCache[request.ConfigurationId];
             ResultsCacheResponse resultsResponse = _resultsCache.SatisfyRequest(request, config.ProjectInitialTargets, config.ProjectDefaultTargets, skippedResultsDoNotCauseCacheMiss);
@@ -2416,7 +2410,7 @@ namespace Microsoft.Build.BackEnd
             // save on some instructions.
             for (int i = 0; i < numRead; i++)
             {
-                buffer[i] = null;
+                buffer[i] = null!;
             }
 
             _requestBufferPool.Return(buffer, clearArray: false);
@@ -2656,6 +2650,7 @@ namespace Microsoft.Build.BackEnd
                 }
             }
 
+#pragma warning disable JSON002 // Probable JSON string detected
             loggingService.LogComment(
                 context,
                 MessageImportance.Normal,
@@ -2667,6 +2662,7 @@ namespace Microsoft.Build.BackEnd
                 String.Format(CultureInfo.InvariantCulture, "{0:0.000}", request.GetTimeSpentInState(SchedulableRequestState.Executing).TotalSeconds + request.GetTimeSpentInState(SchedulableRequestState.Blocked).TotalSeconds + request.GetTimeSpentInState(SchedulableRequestState.Ready).TotalSeconds),
                 _configCache[request.BuildRequest.ConfigurationId].ProjectFullPath,
                 String.Join(", ", request.BuildRequest.Targets));
+#pragma warning restore JSON002 // Probable JSON string detected
 
             List<SchedulableRequest> childRequests = new List<SchedulableRequest>(_schedulingData.GetRequestsByHierarchy(request));
             childRequests.Sort(delegate (SchedulableRequest left, SchedulableRequest right)
@@ -2758,8 +2754,7 @@ namespace Microsoft.Build.BackEnd
                                     ? string.Format(
                                         CultureInfo.InvariantCulture,
                                         "Active ({0} executing)",
-                                        _schedulingData.GetExecutingRequestByNode(nodeId)
-                                            .BuildRequest.GlobalRequestId)
+                                        _schedulingData.GetExecutingRequestByNode(nodeId)?.BuildRequest.GlobalRequestId ?? 0)
                                     : "Idle",
                                 _schedulingData.GetScheduledRequestsCountByNode(nodeId),
                                 _schedulingData.GetConfigurationsCountByNode(nodeId, false, null));
@@ -2917,7 +2912,7 @@ namespace Microsoft.Build.BackEnd
         /// <summary>
         /// Dumps the hierarchy of requests.
         /// </summary>
-        private void DumpRequestHierarchy(StreamWriter file, SchedulableRequest root, int indent)
+        private void DumpRequestHierarchy(StreamWriter file, SchedulableRequest? root, int indent)
         {
             foreach (SchedulableRequest child in _schedulingData.GetRequestsByHierarchy(root))
             {
@@ -2952,7 +2947,7 @@ namespace Microsoft.Build.BackEnd
         /// <summary>
         /// Dumps detailed information about a request.
         /// </summary>
-        private void DumpRequestSpec(StreamWriter file, SchedulableRequest request, int indent, string prefix)
+        private void DumpRequestSpec(StreamWriter file, SchedulableRequest request, int indent, string? prefix)
         {
             var buildRequest = request.BuildRequest;
 

--- a/src/Build/BackEnd/Components/Scheduler/Scheduler.cs
+++ b/src/Build/BackEnd/Components/Scheduler/Scheduler.cs
@@ -280,8 +280,8 @@ namespace Microsoft.Build.BackEnd
             }
 
             // Initialize metric tracking dictionaries
-            _requestBlockerCounts = new ConcurrentDictionary<string, long>(4);
-            _circularDependencyCounts = new ConcurrentDictionary<string, long>(2);
+            _requestBlockerCounts = new ConcurrentDictionary<string, long>(Environment.ProcessorCount, 4);
+            _circularDependencyCounts = new ConcurrentDictionary<string, long>(Environment.ProcessorCount, 2);
 
             // Initialize metrics
             _schedulerNodeCountGauge = _schedulerMetrics.CreateObservableGauge(

--- a/src/Build/BackEnd/Components/Scheduler/Scheduler.cs
+++ b/src/Build/BackEnd/Components/Scheduler/Scheduler.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Buffers;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics.Metrics;
 using System.Globalization;
@@ -114,7 +115,21 @@ namespace Microsoft.Build.BackEnd
 
 #pragma warning disable IDE0052 // Remove unread private members
         private readonly ObservableGauge<int> _schedulerNodeCountGauge;
+        private readonly ObservableCounter<long> _requestBlockerCounter;
+        private readonly ObservableCounter<long> _circularDependencyCounter;
+        private readonly ObservableGauge<int> _coresInUseGauge;
+        private readonly ObservableGauge<int> _pendingCoreRequestsGauge;
 #pragma warning restore IDE0052 // Remove unread private members
+
+        /// <summary>
+        /// Tracks counts of request blocking events by blocker type.
+        /// </summary>
+        private readonly ConcurrentDictionary<string, long> _requestBlockerCounts;
+
+        /// <summary>
+        /// Tracks counts of circular dependency detections by type.
+        /// </summary>
+        private readonly ConcurrentDictionary<string, long> _circularDependencyCounts;
 
         /// <summary>
         /// The collection of all requests currently known to the system.
@@ -264,12 +279,41 @@ namespace Microsoft.Build.BackEnd
                 _debugDumpPath = FileUtilities.TempFileDirectory;
             }
 
+            // Initialize metric tracking dictionaries
+            _requestBlockerCounts = new ConcurrentDictionary<string, long>(4);
+            _circularDependencyCounts = new ConcurrentDictionary<string, long>(2);
+
+            // Initialize metrics
             _schedulerNodeCountGauge = _schedulerMetrics.CreateObservableGauge(
                 "msbuild_scheduler_node_count",
                 ComputeNodeCounts,
                 description: "The current count of nodes in the scheduler",
                 unit: "nodes",
                 tags: [new("node.type", "outofproc")]);
+
+            _requestBlockerCounter = _schedulerMetrics.CreateObservableCounter(
+                "msbuild_request_blocked_events",
+                CollectRequestBlockerCounts,
+                unit: "events",
+                description: "Count of request blocking events by blocker type");
+
+            _circularDependencyCounter = _schedulerMetrics.CreateObservableCounter(
+                "msbuild_circular_dependency_errors",
+                CollectCircularDependencyCounts,
+                unit: "errors",
+                description: "Count of circular dependency detections");
+
+            _coresInUseGauge = _schedulerMetrics.CreateObservableGauge(
+                "msbuild_cores_in_use",
+                () => _schedulingData?.ExplicitlyGrantedCores ?? 0,
+                unit: "cores",
+                description: "Number of cores currently allocated to requests");
+
+            _pendingCoreRequestsGauge = _schedulerMetrics.CreateObservableGauge(
+                "msbuild_pending_core_requests",
+                () => _pendingRequestCoresCallbacks?.Count ?? 0,
+                unit: "requests",
+                description: "Number of requests waiting for core allocation");
 
             Reset();
         }
@@ -278,6 +322,22 @@ namespace Microsoft.Build.BackEnd
         {
             yield return new Measurement<int>(_currentOutOfProcNodeCount, new KeyValuePair<string, object?>("node.type", "outofproc"));
             yield return new Measurement<int>(_currentInProcNodeCount, new KeyValuePair<string, object?>("node.type", "inproc"));
+        }
+
+        private IEnumerable<Measurement<long>> CollectRequestBlockerCounts()
+        {
+            foreach (var kvp in _requestBlockerCounts)
+            {
+                yield return new Measurement<long>(kvp.Value, new KeyValuePair<string, object?>("blocker_type", kvp.Key));
+            }
+        }
+
+        private IEnumerable<Measurement<long>> CollectCircularDependencyCounts()
+        {
+            foreach (var kvp in _circularDependencyCounts)
+            {
+                yield return new Measurement<long>(kvp.Value, new KeyValuePair<string, object?>("error_type", kvp.Key));
+            }
         }
 
         #region Delegates
@@ -377,12 +437,14 @@ namespace Microsoft.Build.BackEnd
                 {
                     TraceScheduler("Request {0} on node {1} is performing yield action {2}.", blocker.BlockedRequestId, nodeId, blocker.YieldAction);
                     ErrorUtilities.VerifyThrow(string.IsNullOrEmpty(blocker.BlockingTarget), "Blocking target should be null because this is not a request blocking on a target");
+                    _requestBlockerCounts.AddOrUpdate("yield", 1, (key, oldValue) => oldValue + 1);
                     HandleYieldAction(parentRequest, blocker);
                 }
                 else if ((blocker.BlockingRequestId == blocker.BlockedRequestId) && blocker.BlockingRequestId != BuildRequest.InvalidGlobalRequestId)
                 {
                     ErrorUtilities.VerifyThrow(string.IsNullOrEmpty(blocker.BlockingTarget), "Blocking target should be null because this is not a request blocking on a target");
                     // We are blocked waiting for a transfer of results.
+                    _requestBlockerCounts.AddOrUpdate("results_transfer", 1, (key, oldValue) => oldValue + 1);
                     HandleRequestBlockedOnResultsTransfer(parentRequest, responses);
                 }
                 else if (blocker.BlockingRequestId != BuildRequest.InvalidGlobalRequestId)
@@ -392,11 +454,13 @@ namespace Microsoft.Build.BackEnd
                     {
                         ErrorUtilities.VerifyThrow(!string.IsNullOrEmpty(blocker.BlockingTarget), "Blocking target should exist");
 
+                        _requestBlockerCounts.AddOrUpdate("in_progress_target", 1, (key, oldValue) => oldValue + 1);
                         HandleRequestBlockedOnInProgressTarget(parentRequest, blocker);
                     }
                     catch (SchedulerCircularDependencyException ex)
                     {
                         TraceScheduler("Circular dependency caused by request {0}({1}) (nr {2}), parent {3}({4}) (nr {5})", ex.Request.GlobalRequestId, ex.Request.ConfigurationId, ex.Request.NodeRequestId, parentRequest.BuildRequest.GlobalRequestId, parentRequest.BuildRequest.ConfigurationId, parentRequest.BuildRequest.NodeRequestId);
+                        _circularDependencyCounts.AddOrUpdate("in_progress_target", 1, (key, oldValue) => oldValue + 1);
                         responses.Add(ScheduleResponse.CreateCircularDependencyResponse(nodeId, parentRequest.BuildRequest, ex.Request));
                     }
                 }
@@ -404,12 +468,14 @@ namespace Microsoft.Build.BackEnd
                 {
                     ErrorUtilities.VerifyThrow(string.IsNullOrEmpty(blocker.BlockingTarget), "Blocking target should be null because this is not a request blocking on a target");
                     // We are blocked by new requests, either top-level or MSBuild task.
+                    _requestBlockerCounts.AddOrUpdate("new_requests", 1, (key, oldValue) => oldValue + 1);
                     HandleRequestBlockedByNewRequests(parentRequest, blocker, responses);
                 }
             }
             catch (SchedulerCircularDependencyException ex)
             {
                 TraceScheduler("Circular dependency caused by request {0}({1}) (nr {2}), parent {3}({4}) (nr {5})", ex.Request.GlobalRequestId, ex.Request.ConfigurationId, ex.Request.NodeRequestId, parentRequest.BuildRequest.GlobalRequestId, parentRequest.BuildRequest.ConfigurationId, parentRequest.BuildRequest.NodeRequestId);
+                _circularDependencyCounts.AddOrUpdate("new_requests", 1, (key, oldValue) => oldValue + 1);
                 responses.Add(ScheduleResponse.CreateCircularDependencyResponse(nodeId, parentRequest.BuildRequest, ex.Request));
             }
 

--- a/src/Build/BackEnd/Components/Scheduler/Scheduler.cs
+++ b/src/Build/BackEnd/Components/Scheduler/Scheduler.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Buffers;
 using System.Collections.Generic;
+using System.Diagnostics.Metrics;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -28,6 +29,8 @@ namespace Microsoft.Build.BackEnd
     /// </summary>
     internal class Scheduler : IScheduler
     {
+        private static Meter _schedulerMetrics = new("Microsoft.Build");
+
         /// <summary>
         /// The invalid node id
         /// </summary>
@@ -110,6 +113,11 @@ namespace Microsoft.Build.BackEnd
         /// node limit.
         /// </summary>
         private int _currentOutOfProcNodeCount = 0;
+
+#pragma warning disable IDE0052 // Remove unread private members
+        private readonly ObservableGauge<int> _outOfProcNodeCountGauge;
+        private readonly ObservableGauge<int> _inProcNodeCountGauge;
+#pragma warning restore IDE0052 // Remove unread private members
 
         /// <summary>
         /// The collection of all requests currently known to the system.
@@ -256,6 +264,19 @@ namespace Microsoft.Build.BackEnd
             {
                 _debugDumpPath = FileUtilities.TempFileDirectory;
             }
+
+            _outOfProcNodeCountGauge = _schedulerMetrics.CreateObservableGauge(
+                "msbuild_scheduler_node_count",
+                () => _currentOutOfProcNodeCount,
+                description: "The current count of nodes in the scheduler",
+                unit: "nodes",
+                tags: [new("node.type", "outofproc")]);
+            _inProcNodeCountGauge = _schedulerMetrics.CreateObservableGauge(
+                "msbuild_scheduler_node_count",
+                () => _currentInProcNodeCount,
+                description: "The current count of nodes in the scheduler",
+                unit: "nodes",
+                tags: [new("node.type", "inproc")]);
 
             Reset();
         }
@@ -581,7 +602,7 @@ namespace Microsoft.Build.BackEnd
             DumpConfigurations();
             DumpRequests();
             _schedulingPlan = null;
-            _schedulingData = new SchedulingData();
+            _schedulingData = new SchedulingData(_schedulerMetrics);
             _availableNodes = new Dictionary<int, NodeInfo>(8);
             _pendingRequestCoresCallbacks = new Queue<TaskCompletionSource<int>>();
             _requestBufferPool = ArrayPool<SchedulableRequest>.Create();

--- a/src/Framework/CommunicationsUtilities.cs
+++ b/src/Framework/CommunicationsUtilities.cs
@@ -184,7 +184,11 @@ namespace Microsoft.Build.Framework
                     }
 
                     // ensure that taskhost nodes don't try to hook into diagnostics
-                    table[Strings.WeakIntern("DOTNET_EnableDiagnostics")] = Strings.WeakIntern("0");
+#if !CLR2COMPATIBILITY
+                    table[Strings.WeakIntern(DotnetDiagnosticsEnvironmentVariableName)] = Strings.WeakIntern("0");
+#else
+                    table[DotnetDiagnosticsEnvironmentVariableName] = "0";
+#endif
 
                     // Update with the current state.
                     EnvironmentState currentState =

--- a/src/Framework/CommunicationsUtilities.cs
+++ b/src/Framework/CommunicationsUtilities.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Build.Framework
     internal static class FrameworkCommunicationsUtilities
     {
 
-        internal static const string DotnetDiagnosticsEnvironmentVariableName = "DOTNET_EnableDiagnostics";
+        internal const string DotnetDiagnosticsEnvironmentVariableName = "DOTNET_EnableDiagnostics";
 
         /// <summary>
         /// Case-insensitive string comparer for environment variable names.

--- a/src/Framework/CommunicationsUtilities.cs
+++ b/src/Framework/CommunicationsUtilities.cs
@@ -18,6 +18,9 @@ namespace Microsoft.Build.Framework
     /// </summary>
     internal static class FrameworkCommunicationsUtilities
     {
+
+        internal static const string DotnetDiagnosticsEnvironmentVariableName = "DOTNET_EnableDiagnostics";
+
         /// <summary>
         /// Case-insensitive string comparer for environment variable names.
         /// </summary>
@@ -180,6 +183,9 @@ namespace Microsoft.Build.Framework
                         table[key] = value;
                     }
 
+                    // ensure that taskhost nodes don't try to hook into diagnostics
+                    table[Strings.WeakIntern("DOTNET_EnableDiagnostics")] = Strings.WeakIntern("0");
+
                     // Update with the current state.
                     EnvironmentState currentState =
                         new(table.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase), stringBlock.ToArray());
@@ -248,7 +254,7 @@ namespace Microsoft.Build.Framework
             }
 
             // Otherwise, allocate and update with the current state.
-            Dictionary<string, string> table = new(vars.Count, EnvironmentVariableComparer);
+            Dictionary<string, string> table = new(vars.Count + 1, EnvironmentVariableComparer);
 
             enumerator.Reset();
             while (enumerator.MoveNext())
@@ -258,7 +264,8 @@ namespace Microsoft.Build.Framework
                 string value = Strings.WeakIntern((string)entry.Value);
                 table[key] = value;
             }
-
+            // ensure that taskhost nodes don't try to hook into diagnostics
+            table[DotnetDiagnosticsEnvironmentVariableName] = "0";
             EnvironmentState newState = new(table.ToFrozenDictionary(EnvironmentVariableComparer));
             s_environmentState = newState;
 

--- a/src/Framework/Microsoft.Build.Framework.csproj
+++ b/src/Framework/Microsoft.Build.Framework.csproj
@@ -50,11 +50,12 @@
   <!-- Framework and standard don't have these. -->
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' OR '$(TargetFrameworkIdentifier)' == '.NETStandard'">
     <PackageReference Include="System.Collections.Immutable" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" />
   </ItemGroup>
 
   <!-- When targeting NS2.0, make private all references not exposed in the public API. -->
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard'">
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" PrivateAssets="all" />
+    <PackageReference Update="System.Diagnostics.DiagnosticSource" PrivateAssets="all" />
     <PackageReference Update="System.Collections.Immutable" PrivateAssets="all" />
   </ItemGroup>
 

--- a/src/Shared/CommunicationsUtilities.cs
+++ b/src/Shared/CommunicationsUtilities.cs
@@ -225,13 +225,6 @@ namespace Microsoft.Build.Internal
         /// <param name="nodeType">
         ///  The <see cref="HandshakeOptions"/> that specifies the type of node and configuration options for the handshake operation.
         /// </param>
-        /// <param name="predefinedToolsDirectory">
-        /// An optional directory path used for .NET TaskHost handshake salt calculation (only on .NET Framework).
-        /// When specified for .NET TaskHost nodes, this directory path is included in the handshake salt
-        /// to ensure the child dotnet process connects with the expected tools directory context.
-        /// For non-.NET TaskHost nodes or on .NET Core, the MSBuildToolsDirectoryRoot is used instead.
-        /// This parameter is ignored when not running .NET TaskHost on .NET Framework.
-        /// </param>
         public Handshake(HandshakeOptions nodeType)
             : this(nodeType, includeSessionId: true, toolsDirectory: null)
         {
@@ -244,12 +237,15 @@ namespace Microsoft.Build.Internal
         /// <param name="nodeType">
         ///  The <see cref="HandshakeOptions"/> that specifies the type of node and configuration options for the handshake operation.
         /// </param>
-        /// <param name="toolsDirectory">
-        ///  The directory path to use for handshake salt calculation. For some task hosts, notably the .NET TaskHost (on .NET Framework)
-        ///  and the CLR2 TaskHost, this is needed to ensure the child process connects with the expected tools directory context.
+        /// <param name="predefinedToolsDirectory">
+        /// An optional directory path used for .NET TaskHost handshake salt calculation (only on .NET Framework).
+        /// When specified for .NET TaskHost nodes, this directory path is included in the handshake salt
+        /// to ensure the child dotnet process connects with the expected tools directory context.
+        /// For non-.NET TaskHost nodes or on .NET Core, the MSBuildToolsDirectoryRoot is used instead.
+        /// This parameter is ignored when not running .NET TaskHost on .NET Framework.
         /// </param>
-        public Handshake(HandshakeOptions nodeType, string toolsDirectory)
-            : this(nodeType, includeSessionId: true, toolsDirectory)
+        public Handshake(HandshakeOptions nodeType, string predefinedToolsDirectory)
+            : this(nodeType, includeSessionId: true, predefinedToolsDirectory)
         {
         }
 

--- a/src/Shared/CommunicationsUtilities.cs
+++ b/src/Shared/CommunicationsUtilities.cs
@@ -150,7 +150,7 @@ namespace Microsoft.Build.Internal
     /// <summary>
     /// An aggregate class for passing around results of a handshake and adjacent information.
     /// ErrorMessage is to propagate error messages where necessary
-    /// </summary> 
+    /// </summary>
     internal class HandshakeResult
     {
         /// <summary>
@@ -224,6 +224,13 @@ namespace Microsoft.Build.Internal
         /// </summary>
         /// <param name="nodeType">
         ///  The <see cref="HandshakeOptions"/> that specifies the type of node and configuration options for the handshake operation.
+        /// </param>
+        /// <param name="predefinedToolsDirectory">
+        /// An optional directory path used for .NET TaskHost handshake salt calculation (only on .NET Framework).
+        /// When specified for .NET TaskHost nodes, this directory path is included in the handshake salt
+        /// to ensure the child dotnet process connects with the expected tools directory context.
+        /// For non-.NET TaskHost nodes or on .NET Core, the MSBuildToolsDirectoryRoot is used instead.
+        /// This parameter is ignored when not running .NET TaskHost on .NET Framework.
         /// </param>
         public Handshake(HandshakeOptions nodeType)
             : this(nodeType, includeSessionId: true, toolsDirectory: null)


### PR DESCRIPTION
This is a draft PR to explore exporting some System.Diagnostics.Metrics.Meter-based counters for the operational metrics of the build. The aim would be to make it easy to collect operational data cross-platform for comparisons when trying things like scheduling algorithm changes, or to quickly in real-world scenarios how the scheduler is assigning configurations to nodes, etc.

To use:
* ./build.sh|cmd
* copy the built Microsoft.Build and Microsoft.Build.Framework dlls to a global SDK 10+ location
  * yes, I know this is horrible - this is actually important because we'll be using `dotnet-counters` to view the counters and like all framework-dependent tools it gets confused when using bootstrap/local SDK installs
* install dotnet-counters - `dotnet tool install -g dotnet-counters`
* run a build of something using your hacked SDK install, instrumenting it with the counters: `dotnet-counters monitor --refresh-interval 1 --counters Microsoft.Build -- dotnet build rest_of_args`

You'll get output like this:
<img width="1900" height="1150" alt="image" src="https://github.com/user-attachments/assets/603778a5-7661-44fb-8a96-3fdff09580eb" />

This method makes use of the dotnet diagnostics pipe - so when spawning processes we need to make sure that _other_ dotnet processes don't inherit the diagnostics behaviors. For this reason I injected the "disable diagnostics" env var into node creation and TaskHost environments. Without this any process spawning will hang.


### Alternative usage

Instead of needing to hack a global SDK install you can spawn a bootstrapped `dotnet build` invocation with the `DOTNET_DiagnosticPorts=my_diag_port1` and `DOTNET_EnableDiagnostics=1` env vars, and then run `dotnet counters` with the `--diagnostic-port` option pointing to that same port name.


# Counter documentation

## Metrics Overview

All metrics use the `System.Diagnostics.Metrics` API and are exposed under the `Microsoft.Build` meter name. They can be collected using standard tools like `dotnet-counters`, OpenTelemetry, or Prometheus exporters.

---

## Logging Metrics

### `msbuild_forwarded_log_messages`

**Type:** ObservableCounter (monotonically increasing)
**Unit:** messages
**Description:** Total number of log messages forwarded from worker nodes to the central node during distributed builds.

**Tags:**
- `source_node` (int): The node ID that sent the log message

**Use Cases:**
- Detect uneven logging distribution across nodes
- Identify nodes generating excessive log traffic
- Diagnose communication bottlenecks in distributed builds
- Monitor logging overhead per node

---

## Scheduler Metrics

### `msbuild_scheduler_node_count`

**Type:** ObservableGauge
**Unit:** nodes
**Description:** Current count of active nodes in the scheduler.

**Tags:**
- `node.type`: Node provider type
  - `"outofproc"` - Out-of-process worker nodes
  - `"inproc"` - In-process node

**Use Cases:**
- Monitor node availability during builds
- Verify expected parallelism level
- Detect node provisioning issues
- Track node lifecycle events

### `msbuild_request_blocked_events`

**Type:** ObservableCounter (monotonically increasing)
**Unit:** events
**Description:** Count of request blocking events, categorized by the type of blocker that caused the wait.

**Tags:**
- `blocker_type`: The reason a request was blocked
  - `"yield"` - Request explicitly yielded execution
  - `"results_transfer"` - Blocked waiting for result transfer
  - `"in_progress_target"` - Blocked waiting for an in-progress target
  - `"new_requests"` - Blocked by new child requests

**Use Cases:**
- Identify most common blocking patterns
- Detect excessive yielding behavior
- Find synchronization bottlenecks
- Analyze build parallelism effectiveness

### `msbuild_circular_dependency_errors`

**Type:** ObservableCounter (monotonically increasing)
**Unit:** errors
**Description:** Count of circular dependency detections during scheduling.

**Tags:**
- `error_type`: The context where the circular dependency was detected
  - `"in_progress_target"` - Circular dependency involving in-progress targets
  - `"new_requests"` - Circular dependency in new request chain

**Use Cases:**
- Detect project dependency graph issues
- Track frequency of circular dependency errors
- Identify problematic project configurations
- Monitor build health

### `msbuild_cores_in_use`

**Type:** ObservableGauge
**Unit:** cores
**Description:** Number of CPU cores currently allocated to build requests via `IBuildEngine9.RequestCores`.

**Tags:** None

**Use Cases:**
- Monitor CPU resource utilization
- Verify core allocation is working as expected
- Detect core allocation leaks or inefficiencies
- Analyze parallelism opportunities

### `msbuild_pending_core_requests`

**Type:** ObservableGauge
**Unit:** requests
**Description:** Number of build requests currently waiting for core allocation.

**Tags:** None

**Use Cases:**
- Identify CPU resource contention
- Detect over-subscription of cores
- Find tasks waiting for parallelism resources
- Tune core allocation strategies

---

## Scheduling Data Metrics

### `msbuild_scheduler_request_count`

**Type:** ObservableGauge
**Unit:** requests
**Description:** Current count of requests in the scheduler by state.

**Tags:**
- `request.type`: The state of the requests being counted
  - `"executing"` - Currently executing requests
  - `"ready"` - Requests ready to execute
  - `"blocked"` - Requests blocked on dependencies
  - `"yielding"` - Requests that have yielded
  - `"unscheduled"` - Requests not yet scheduled to nodes

**Use Cases:**
- Monitor request queue depths
- Identify scheduling bottlenecks
- Detect stuck or stalled requests
- Analyze scheduler efficiency

### `msbuild_scheduler_node_configuration_count`

**Type:** ObservableGauge
**Unit:** configurations
**Description:** Current count of build configurations assigned to each node.

**Tags:**
- `node.id` (int): The node ID

**Use Cases:**
- Monitor configuration distribution across nodes
- Detect uneven work distribution
- Identify configuration affinity issues
- Optimize node assignment strategies

### `msbuild_scheduler_build_event_count`

**Type:** ObservableGauge
**Unit:** events
**Description:** Total count of build events that have occurred during the current build.

**Tags:** None

**Use Cases:**
- Track build activity level
- Monitor event processing throughput
- Detect event processing issues
- General build progress indicator

### `msbuild_node_idle_time`

**Type:** ObservableCounter (monotonically increasing)
**Unit:** ms (milliseconds)
**Description:** Total time each node has spent idle (not executing requests).

**Tags:**
- `node_id` (int): The node ID

**Use Cases:**
- Identify underutilized nodes
- Detect load balancing issues
- Calculate node efficiency ratios
- Optimize node count and work distribution

---

## Build Request Engine Metrics

### `build_request_engine_requests`

**Type:** ObservableGauge
**Unit:** requests
**Description:** Number of active build requests in the BuildRequestEngine by state.

**Tags:**
- `nodeId` (int): The node ID where the engine is running
- `state`: The state of the request (determined by callback implementation)

**Use Cases:**
- Monitor per-node request queue depth
- Track request lifecycle on each node
- Identify nodes with processing issues
- Analyze per-node workload

### `build_request_engine_work_queue_length`

**Type:** ObservableGauge
**Unit:** items
**Description:** Number of work items pending in the BuildRequestEngine's work queue.

**Tags:**
- `nodeId` (int): The node ID where the engine is running

**Use Cases:**
- Detect work queue backlog
- Identify processing bottlenecks
- Monitor engine responsiveness
- Track per-node processing capacity

### `build_request_engine_status`

**Type:** ObservableGauge
**Unit:** status
**Description:** Current status of the BuildRequestEngine as an integer enum value.

**Tags:**
- `nodeId` (int): The node ID where the engine is running

**Use Cases:**
- Monitor engine lifecycle states
- Detect stuck or failed engines
- Track engine state transitions
- Debug engine behavior

### `msbuild_configuration_resolution_duration`

**Type:** Histogram
**Unit:** ms (milliseconds)
**Description:** Time taken to resolve build configurations (round-trip from configuration request to response).

**Tags:** None

**Use Cases:**
- Identify slow configuration resolution
- Detect configuration caching issues
- Optimize configuration creation
- Find configuration bottlenecks

### `msbuild_build_request_state_transitions`

**Type:** ObservableCounter (monotonically increasing)
**Unit:** transitions
**Description:** Count of build request state transitions.

**Tags:**
- `transition`: The state transition in format "FromState->ToState"
  - Examples: `"Active->Waiting"`, `"Waiting->Ready"`, `"Ready->Active"`, `"Active->Complete"`

**Use Cases:**
- Analyze request lifecycle patterns
- Detect abnormal state transitions
- Track how requests flow through states
- Identify requests getting stuck in specific states

### `msbuild_request_wait_time`

**Type:** Histogram
**Unit:** ms (milliseconds)
**Description:** Time requests spend in the Waiting state, categorized by the reason for blocking.

**Tags:**
- `reason`: The reason the request was waiting
  - `"blocking_target"` - Waiting for another target to complete
  - `"unresolved_configuration"` - Waiting for configuration resolution
  - `"child_requests"` - Waiting for child build requests

**Use Cases:**
- Identify most time-consuming blocking scenarios
- Detect synchronization bottlenecks
- Find opportunities to improve parallelism
- Diagnose slow build phases

---

## Metric Collection Examples

### Using dotnet-counters

```bash
# Monitor all MSBuild metrics in real-time
dotnet-counters monitor --process-id <pid> --counters Microsoft.Build

# Monitor specific metrics
dotnet-counters monitor --process-id <pid> --counters Microsoft.Build[msbuild_node_idle_time,msbuild_request_wait_time]
```

### Using OpenTelemetry

Configure OpenTelemetry to collect metrics from the `Microsoft.Build` meter:

```csharp
services.AddOpenTelemetry()
    .WithMetrics(builder => builder
        .AddMeter("Microsoft.Build")
        .AddPrometheusExporter());
```

---

## Common Analysis Scenarios

### Identifying Parallelism Issues

1. Check `msbuild_node_idle_time` - High idle time suggests poor work distribution
2. Review `msbuild_request_blocked_events` - Excessive blocking reduces parallelism
3. Analyze `msbuild_request_wait_time` histogram - Shows where requests spend time waiting
4. Monitor `msbuild_scheduler_request_count` with `request.type=blocked` - Track blocked request count

### Detecting Resource Contention

1. Watch `msbuild_pending_core_requests` - Non-zero indicates CPU contention
2. Check `msbuild_cores_in_use` vs available cores - Shows resource utilization
3. Review `build_request_engine_work_queue_length` - Backlog indicates processing bottleneck

### Analyzing Build Performance

1. Examine `msbuild_configuration_resolution_duration` percentiles - Identify slow configs
2. Track `msbuild_request_wait_time` by reason - Find most impactful wait causes
3. Monitor `msbuild_build_request_state_transitions` - Understand request flow patterns
4. Check `msbuild_forwarded_log_messages` - Excessive logging can slow builds

### Troubleshooting Build Issues

1. Look for `msbuild_circular_dependency_errors` - Indicates dependency graph problems
2. Review `msbuild_build_request_state_transitions` - Find abnormal state patterns
3. Check `build_request_engine_status` per node - Detect failed or stuck engines
4. Monitor `msbuild_scheduler_node_configuration_count` distribution - Uneven suggests issues

---

## Implementation Notes

- All counters are monotonically increasing and track cumulative values
- Gauges represent current point-in-time snapshots
- Histograms automatically calculate percentiles when collected by tools like Prometheus
- Metrics are only collected when an observer is listening (no overhead when unused)
- Tags/dimensions allow filtering and grouping for detailed analysis
