### PR TITLE
WriteLinesToFile improvements

### DIFF
--- a/src/Tasks/FileIO/WriteLinesToFile.cs
+++ b/src/Tasks/FileIO/WriteLinesToFile.cs
@@ -60,101 +60,99 @@ namespace Microsoft.Build.Tasks
         [Obsolete]
         public bool CanBeIncremental => WriteOnlyWhenDifferent;
 
-        /// <summary>
-        /// Execute the task.
-        /// </summary>
-        /// <returns></returns>
+        /// <inheritdoc cref="ITask.Execute" />
         public override bool Execute()
         {
             bool success = true;
 
-            if (File != null)
+            if (File == null)
             {
-                string filePath = FileUtilities.NormalizePath(File.ItemSpec);
+                return success;
+            }
 
-                // do not return if Lines is null, because we may
-                // want to delete the file in that case
-                StringBuilder buffer = new StringBuilder();
-                if (Lines != null)
+            string filePath = FileUtilities.NormalizePath(File.ItemSpec);
+
+            string contentsAsString = string.Empty;
+
+            if (Lines != null && Lines.Length > 0)
+            {
+                StringBuilder buffer = new StringBuilder(capacity: Lines.Length * 64);
+
+                foreach (ITaskItem line in Lines)
                 {
-                    foreach (ITaskItem line in Lines)
-                    {
-                        buffer.AppendLine(line.ItemSpec);
-                    }
+                    buffer.AppendLine(line.ItemSpec);
                 }
 
-                Encoding encoding = s_defaultEncoding;
-                if (Encoding != null)
-                {
-                    try
-                    {
-                        encoding = System.Text.Encoding.GetEncoding(Encoding);
-                    }
-                    catch (ArgumentException)
-                    {
-                        Log.LogErrorWithCodeFromResources("General.InvalidValue", "Encoding", "WriteLinesToFile");
-                        return false;
-                    }
-                }
+                contentsAsString = buffer.ToString();
+            }
 
+            Encoding encoding = s_defaultEncoding;
+            if (Encoding != null)
+            {
                 try
                 {
-                    Directory.CreateDirectory(Path.GetDirectoryName(filePath));
+                    encoding = System.Text.Encoding.GetEncoding(Encoding);
+                }
+                catch (ArgumentException)
+                {
+                    Log.LogErrorWithCodeFromResources("General.InvalidValue", "Encoding", "WriteLinesToFile");
+                    return false;
+                }
+            }
 
-                    if (Overwrite)
+            try
+            {
+                Directory.CreateDirectory(Path.GetDirectoryName(filePath));
+
+                if (Overwrite)
+                {
+                    // When WriteOnlyWhenDifferent is set, read the file and if they're the same return.
+                    if (WriteOnlyWhenDifferent)
                     {
-                        string contentsAsString = buffer.ToString();
-
-                        // When WriteOnlyWhenDifferent is set, read the file and if they're the same return.
-                        if (WriteOnlyWhenDifferent)
+                        MSBuildEventSource.Log.WriteLinesToFileUpToDateStart();
+                        try
                         {
-                            MSBuildEventSource.Log.WriteLinesToFileUpToDateStart();
-                            try
+                            if (FileUtilities.FileExistsNoThrow(filePath))
                             {
-                                if (FileUtilities.FileExistsNoThrow(filePath))
+                                string existingContents = FileSystems.Default.ReadFileAllText(filePath);
+
+                                if (existingContents.Equals(contentsAsString))
                                 {
-                                    string existingContents = FileSystems.Default.ReadFileAllText(filePath);
-                                    if (existingContents.Length == buffer.Length)
-                                    {
-                                        if (existingContents.Equals(contentsAsString))
-                                        {
-                                            Log.LogMessageFromResources(MessageImportance.Low, "WriteLinesToFile.SkippingUnchangedFile", filePath);
-                                            MSBuildEventSource.Log.WriteLinesToFileUpToDateStop(filePath, true);
-                                            return true;
-                                        }
-                                        else if (FailIfNotIncremental)
-                                        {
-                                            Log.LogErrorWithCodeFromResources("WriteLinesToFile.ErrorReadingFile", filePath);
-                                            return false;
-                                        }
-                                    }
+                                    Log.LogMessageFromResources(MessageImportance.Low, "WriteLinesToFile.SkippingUnchangedFile", filePath);
+                                    MSBuildEventSource.Log.WriteLinesToFileUpToDateStop(filePath, true);
+                                    return true;
+                                }
+                                else if (FailIfNotIncremental)
+                                {
+                                    Log.LogErrorWithCodeFromResources("WriteLinesToFile.ErrorReadingFile", filePath);
+                                    return false;
                                 }
                             }
-                            catch (IOException)
-                            {
-                                Log.LogMessageFromResources(MessageImportance.Low, "WriteLinesToFile.ErrorReadingFile", filePath);
-                            }
-                            MSBuildEventSource.Log.WriteLinesToFileUpToDateStop(filePath, false);
                         }
-
-                        System.IO.File.WriteAllText(filePath, contentsAsString, encoding);
-                    }
-                    else
-                    {
-                        if (WriteOnlyWhenDifferent)
+                        catch (IOException)
                         {
-                            Log.LogMessageFromResources(MessageImportance.Normal, "WriteLinesToFile.UnusedWriteOnlyWhenDifferent", filePath);
+                            Log.LogMessageFromResources(MessageImportance.Low, "WriteLinesToFile.ErrorReadingFile", filePath);
                         }
-                        
-                        System.IO.File.AppendAllText(filePath, buffer.ToString(), encoding);
+                        MSBuildEventSource.Log.WriteLinesToFileUpToDateStop(filePath, false);
                     }
+
+                    System.IO.File.WriteAllText(filePath, contentsAsString, encoding);
                 }
-                catch (Exception e) when (ExceptionHandling.IsIoRelatedException(e))
+                else
                 {
-                    string lockedFileMessage = LockCheck.GetLockedFileMessage(filePath);
-                    Log.LogErrorWithCodeFromResources("WriteLinesToFile.ErrorOrWarning", filePath, e.Message, lockedFileMessage);
-                    success = false;
+                    if (WriteOnlyWhenDifferent)
+                    {
+                        Log.LogMessageFromResources(MessageImportance.Normal, "WriteLinesToFile.UnusedWriteOnlyWhenDifferent", filePath);
+                    }
+
+                    System.IO.File.AppendAllText(filePath, contentsAsString, encoding);
                 }
+            }
+            catch (Exception e) when (ExceptionHandling.IsIoRelatedException(e))
+            {
+                string lockedFileMessage = LockCheck.GetLockedFileMessage(filePath);
+                Log.LogErrorWithCodeFromResources("WriteLinesToFile.ErrorOrWarning", filePath, e.Message, lockedFileMessage);
+                success = false;
             }
 
             return success;


### PR DESCRIPTION
Fixes #

### Context
I was working on something else entirely and saw some easy improvements to make in `WriteLinesToFile`.

### Changes Made
1. `File.ItemSpec` is being accessed 14 times.  I think the implementation will [make a new string](https://github.com/jeffkl/msbuild/blob/f4e7bc9c01e75873d00a36b6f6a9e3dabb771c21/src/Build/Instance/ProjectItemInstance.cs?plain=1#L927C1-L928C1) each time.
2. It has two code paths, overwrite vs not and both code paths were creating the directory
3. The contents of the file to write are stored in a `StringBuilder` with no initial capacity.  I took a wild guess and set to `lines * 64`
4. If no lines are specified, a `StringBuilder` is no longer created and instead it uses `string.Empty`
5. Since the contents are now stored in a string on all code paths, the comparison of the current vs new is simplified since `string.Equals()` will check the length
6. Reduced nesting by inverting the `if (File != null)` statement

### Testing
From what I can tell, the existing tests are good.

### Notes
