### PR TITLE
Set sha from VMRs main in the Source tag

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
-  <Source Uri="https://github.com/dotnet/dotnet" Mapping="msbuild" Sha="d499f9cdfd5b7b7bb291f95a3c14417d5edc969f" BarId="287756" />
+  <Source Uri="https://github.com/dotnet/dotnet" Mapping="msbuild" Sha="cdc420f453860b662a76fcc72672ed2a65243146" BarId="288940" />
   <ProductDependencies>
     <!-- Necessary for source-build. This allows the live version of the package to be used by source-build. -->
     <Dependency Name="System.CodeDom" Version="9.0.9">


### PR DESCRIPTION
Currently msbuild link has a 10.0.1xx VMR build.
This is wrong as it should come from main.
This PR changes the Source tag to a main build, after which we'll need to do a forward flow, and only then a backflow