### PR TITLE
Make some of the node-level communication logging more clear to readers

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -73,7 +73,7 @@
     <MicrosoftCodeAnalysisPooledObjectsVersion>5.0.0-1.25277.114</MicrosoftCodeAnalysisPooledObjectsVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <BootstrapSdkVersion>10.0.100-rc.1.25451.107</BootstrapSdkVersion>
+    <BootstrapSdkVersion>10.0.100-rc.2.25466.101</BootstrapSdkVersion>
   </PropertyGroup>
   <Target Name="OverrideArcadeFileVersion" AfterTargets="_InitializeAssemblyVersion">
     <!-- See https://github.com/dotnet/arcade/issues/3386

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -659,7 +659,7 @@ namespace Microsoft.Build.CommandLine
 
                 GatherAllSwitches(commandLine, out var switchesFromAutoResponseFile, out var switchesNotFromAutoResponseFile, out _);
 
-                CommunicationsUtilities.Trace($"Command line parameters: {commandLine}");
+                CommunicationsUtilities.Trace($"Command line parameters: \"{string.Join(' ', commandLine)}\"");
 
                 bool buildCanBeInvoked = ProcessCommandLineSwitches(
                                             switchesFromAutoResponseFile,


### PR DESCRIPTION
### Context

Some of the node commmunication data is hard to unpack, e.g. arrays are stringified as `System.String[]` instead of useful content.

Here's a sample:

```
 (TID 1) 638975452648927540 +     6.825ms: Command line parameters: System.String[]
.NET TP Worker (TID 4) 638975452664083250 +  1477.307ms: Starting to acquire 1 new or existing node(s) to establish nodes from ID 2 to 2...
.NET TP Worker (TID 4) 638975452664605130 +    52.188ms: Building handshake for node type NodeReuse, Arm64, (version 1): options 16777352.
.NET TP Worker (TID 4) 638975452664643740 +     3.861ms: Handshake salt is 
```

On this sample log,

* the parameters are the array type name
* the handshake node options are encoded
* the salt is empty but it's unclear if that's _intentional_

### Changes Made
This small change correctly renders the command lines args for the node that's tracking communication, as well as the handshake options for easier reading.

Here's the 'after':

```
 (TID 1) 638977828182753790 +    49.029ms: Command line parameters: "/Users/chethusk/code/msbuild/artifacts/bin/bootstrap/core/sdk/10.0.100-rc.2.25466.101/MSBuild.dll /noautoresponse /nologo /nodemode:1 /nodeReuse:true /low:false"
OutOfProc Endpoint Packet Pump (TID 5) 638977828209647270 +     2.657ms: Waiting for connection 900000 ms...
OutOfProc Endpoint Packet Pump (TID 5) 638977828209678460 +     3.119ms: Parent started connecting. Reading handshake from parent
OutOfProc Endpoint Packet Pump (TID 5) 638977828209936360 +     25.79ms: Building handshake for node type NodeReuse, Arm64, (version 1): options NodeReuse,Arm64.
OutOfProc Endpoint Packet Pump (TID 5) 638977828210022560 +      8.62ms: Handshake salt is <not specified>
```

### Testing


### Notes
