### PR TITLE
Fix comparison in TaskHostParameters 

### DIFF
--- a/src/Build/Instance/TaskRegistry.cs
+++ b/src/Build/Instance/TaskRegistry.cs
@@ -950,18 +950,16 @@ namespace Microsoft.Build.Execution
                             return false;
                         }
 
-                        // For exact match, all properties must be equal (case-insensitive)
+                        // For exact match, only identity properties must be equal
+                        // Paths are NOT part of identity - they're just resolved locations
                         return string.Equals(x.Runtime, y.Runtime, StringComparison.OrdinalIgnoreCase) &&
                                string.Equals(x.Architecture, y.Architecture, StringComparison.OrdinalIgnoreCase) &&
-                               string.Equals(x.DotnetHostPath, y.DotnetHostPath, StringComparison.OrdinalIgnoreCase) &&
-                               string.Equals(x.MSBuildAssemblyPath, y.MSBuildAssemblyPath, StringComparison.OrdinalIgnoreCase) &&
                                x.TaskHostFactoryExplicitlyRequested == y.TaskHostFactoryExplicitlyRequested;
                     }
                     else
                     {
                         // Fuzzy match: null is treated as "don't care"
                         // Only check runtime and architecture for fuzzy matching
-
                         string runtimeX = x.Runtime;
                         string runtimeY = y.Runtime;
                         string architectureX = x.Architecture;

--- a/src/Framework/TaskHostParameters.cs
+++ b/src/Framework/TaskHostParameters.cs
@@ -73,17 +73,12 @@ namespace Microsoft.Build.Framework
         /// </summary>
         public bool? TaskHostFactoryExplicitlyRequested => _taskHostFactoryExplicitlyRequested;
 
-        public override bool Equals(object? obj)
-      => obj is TaskHostParameters other && Equals(other);
+        public override bool Equals(object? obj) => obj is TaskHostParameters other && Equals(other);
 
-        public bool Equals(TaskHostParameters other)
-        {
-            // ONLY compare the fields that matter for process identity
-            return StringComparer.OrdinalIgnoreCase.Equals(Runtime ?? "", other.Runtime ?? "") &&
-                   StringComparer.OrdinalIgnoreCase.Equals(Architecture ?? "", other.Architecture ?? "") &&
-                   TaskHostFactoryExplicitlyRequested == other.TaskHostFactoryExplicitlyRequested;
-            // Do NOT compare DotnetHostPath and MSBuildAssemblyPath!
-        }
+        public bool Equals(TaskHostParameters other) =>
+            StringComparer.OrdinalIgnoreCase.Equals(Runtime ?? string.Empty, other.Runtime ?? string.Empty)
+            && StringComparer.OrdinalIgnoreCase.Equals(Architecture ?? string.Empty, other.Architecture ?? string.Empty)
+            && TaskHostFactoryExplicitlyRequested == other.TaskHostFactoryExplicitlyRequested;
 
         public override int GetHashCode()
         {
@@ -93,9 +88,10 @@ namespace Microsoft.Build.Framework
             unchecked
             {
                 int hash = 17;
-                hash = hash * 31 + comparer.GetHashCode(Runtime ?? "");
-                hash = hash * 31 + comparer.GetHashCode(Architecture ?? "");
+                hash = hash * 31 + comparer.GetHashCode(Runtime ?? string.Empty);
+                hash = hash * 31 + comparer.GetHashCode(Architecture ?? string.Empty);
                 hash = hash * 31 + (TaskHostFactoryExplicitlyRequested?.GetHashCode() ?? 0);
+
                 return hash;
             }
         }


### PR DESCRIPTION
This change introduces a new read only struct that is used in Dictionary for caching in TaskRegistry
https://github.com/dotnet/msbuild/pull/12620


Without a proper equality check it spawns a new process due to mismatch.

Experimental insertion without extra allocation reported: https://devdiv.visualstudio.com/DevDiv/_git/VS/pullrequest/686770
