### PR TITLE
Enhance error handling in RunningObjectTable

### DIFF
--- a/src/Build/Instance/RunningObjectTable.cs
+++ b/src/Build/Instance/RunningObjectTable.cs
@@ -21,12 +21,14 @@ namespace Microsoft.Build.Execution
     internal class RunningObjectTable : IRunningObjectTableWrapper
     {
         private readonly Task<IRunningObjectTable> _rotTask;
+
         public RunningObjectTable()
         {
             if (!NativeMethodsShared.IsWindows)
             {
                 return;
             }
+
             if (Thread.CurrentThread.GetApartmentState() == ApartmentState.MTA)
             {
                 Ole32.GetRunningObjectTable(0, out var rot);
@@ -46,6 +48,7 @@ namespace Microsoft.Build.Execution
                 });
             }
         }
+
         /// <summary>
         /// Attempts to retrieve an item from the ROT.
         /// </summary>

--- a/src/MSBuild/CommandLine/CommandLineParser.cs
+++ b/src/MSBuild/CommandLine/CommandLineParser.cs
@@ -10,6 +10,7 @@ using System.Security;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using Microsoft.Build.Internal;
 using Microsoft.Build.Shared;
 using Microsoft.Build.Shared.FileSystem;
 
@@ -62,6 +63,8 @@ namespace Microsoft.Build.CommandLine
         {
             // split the command line on (unquoted) whitespace
             List<string> commandLineArgs = QuotingUtilities.SplitUnquoted(commandLine);
+
+            CommunicationsUtilities.Trace($"Command line parameters: {string.Join(" ", commandLineArgs)}");
 
             exeName = FileUtilities.FixFilePath(QuotingUtilities.Unquote(commandLineArgs[0]));
 

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -669,8 +669,6 @@ namespace Microsoft.Build.CommandLine
 
                 commandLineParser.GatherAllSwitches(commandLine, out var switchesFromAutoResponseFile, out var switchesNotFromAutoResponseFile, out _, out s_exeName);
 
-                CommunicationsUtilities.Trace($"Command line parameters: {commandLine}");
-
                 bool buildCanBeInvoked = ProcessCommandLineSwitches(
                                             switchesFromAutoResponseFile,
                                             switchesNotFromAutoResponseFile,


### PR DESCRIPTION
Refactor error handling in GetObject method to provide detailed COM error information when retrieval fails.

