### PR TITLE
Fix working directory of taskhosts launched in -mt mode

### DIFF
--- a/src/Build.UnitTests/BackEnd/AssemblyTaskFactory_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/AssemblyTaskFactory_Tests.cs
@@ -244,7 +244,8 @@ namespace Microsoft.Build.UnitTests.BackEnd
 #endif
                     false,
                     scheduledNodeId: 1,
-                    (string propName) => ProjectPropertyInstance.Create("test", "test"));
+                    (string propName) => ProjectPropertyInstance.Create("test", "test"),
+                    string.Empty);
                 createdTask.ShouldNotBeNull();
                 createdTask.ShouldNotBeOfType<TaskHostTask>();
             }
@@ -275,7 +276,8 @@ namespace Microsoft.Build.UnitTests.BackEnd
 #endif
                     false,
                     scheduledNodeId: 1,
-                    (string propName) => ProjectPropertyInstance.Create("test", "test"));
+                    (string propName) => ProjectPropertyInstance.Create("test", "test"),
+                    string.Empty);
                 Assert.NotNull(createdTask);
                 Assert.False(createdTask is TaskHostTask);
             }
@@ -306,7 +308,8 @@ namespace Microsoft.Build.UnitTests.BackEnd
 #endif
                     false,
                     scheduledNodeId: 1,
-                    (string propName) => ProjectPropertyInstance.Create("test", "test"));
+                    (string propName) => ProjectPropertyInstance.Create("test", "test"),
+                    string.Empty);
                 Assert.NotNull(createdTask);
                 Assert.False(createdTask is TaskHostTask);
             }
@@ -339,7 +342,8 @@ namespace Microsoft.Build.UnitTests.BackEnd
 #endif
                     false,
                     scheduledNodeId: 1,
-                    (string propName) => ProjectPropertyInstance.Create("test", "test"));
+                    (string propName) => ProjectPropertyInstance.Create("test", "test"),
+                    string.Empty);
                 Assert.NotNull(createdTask);
                 Assert.False(createdTask is TaskHostTask);
             }
@@ -372,7 +376,8 @@ namespace Microsoft.Build.UnitTests.BackEnd
 #endif
                     false,
                     scheduledNodeId: 1,
-                    (string propName) => ProjectPropertyInstance.Create("test", "test"));
+                    (string propName) => ProjectPropertyInstance.Create("test", "test"),
+                    string.Empty);
                 Assert.NotNull(createdTask);
                 Assert.False(createdTask is TaskHostTask);
             }
@@ -407,7 +412,8 @@ namespace Microsoft.Build.UnitTests.BackEnd
 #endif
                     false,
                     scheduledNodeId: 1,
-                    (string propName) => ProjectPropertyInstance.Create("test", "test"));
+                    (string propName) => ProjectPropertyInstance.Create("test", "test"),
+                    string.Empty);
                 Assert.NotNull(createdTask);
                 Assert.False(createdTask is TaskHostTask);
             }
@@ -440,7 +446,8 @@ namespace Microsoft.Build.UnitTests.BackEnd
 #endif
                     false,
                     scheduledNodeId: 1,
-                    (string propName) => ProjectPropertyInstance.Create("test", "test"));
+                    (string propName) => ProjectPropertyInstance.Create("test", "test"),
+                    string.Empty);
                 Assert.NotNull(createdTask);
                 Assert.IsType<TaskHostTask>(createdTask);
             }
@@ -471,7 +478,8 @@ namespace Microsoft.Build.UnitTests.BackEnd
 #endif
                     false,
                     scheduledNodeId: 1,
-                    (string propName) => ProjectPropertyInstance.Create("test", "test"));
+                    (string propName) => ProjectPropertyInstance.Create("test", "test"),
+                    string.Empty);
                 Assert.NotNull(createdTask);
                 Assert.IsType<TaskHostTask>(createdTask);
             }
@@ -506,7 +514,8 @@ namespace Microsoft.Build.UnitTests.BackEnd
 #endif
                     false,
                     scheduledNodeId: 1,
-                    (string propName) => ProjectPropertyInstance.Create("test", "test"));
+                    (string propName) => ProjectPropertyInstance.Create("test", "test"),
+                    string.Empty);
                 Assert.NotNull(createdTask);
                 Assert.IsType<TaskHostTask>(createdTask);
             }
@@ -537,7 +546,8 @@ namespace Microsoft.Build.UnitTests.BackEnd
 #endif
                     false,
                     scheduledNodeId: 1,
-                    (string propName) => ProjectPropertyInstance.Create("test", "test"));
+                    (string propName) => ProjectPropertyInstance.Create("test", "test"),
+                    string.Empty);
                 Assert.NotNull(createdTask);
                 Assert.IsType<TaskHostTask>(createdTask);
             }
@@ -570,7 +580,8 @@ namespace Microsoft.Build.UnitTests.BackEnd
 #endif
                     false,
                     scheduledNodeId: 1,
-                    (string propName) => ProjectPropertyInstance.Create("test", "test"));
+                    (string propName) => ProjectPropertyInstance.Create("test", "test"),
+                    string.Empty);
                 Assert.NotNull(createdTask);
                 Assert.IsType<TaskHostTask>(createdTask);
             }
@@ -603,7 +614,8 @@ namespace Microsoft.Build.UnitTests.BackEnd
 #endif
                     false,
                     scheduledNodeId: 1,
-                    (string propName) => ProjectPropertyInstance.Create("test", "test"));
+                    (string propName) => ProjectPropertyInstance.Create("test", "test"),
+                    string.Empty);
                 Assert.NotNull(createdTask);
                 Assert.IsType<TaskHostTask>(createdTask);
             }
@@ -637,7 +649,8 @@ namespace Microsoft.Build.UnitTests.BackEnd
 #endif
                     false,
                     scheduledNodeId: 1,
-                    (string propName) => ProjectPropertyInstance.Create("test", "test"));
+                    (string propName) => ProjectPropertyInstance.Create("test", "test"),
+                    string.Empty);
                 Assert.NotNull(createdTask);
                 Assert.IsNotType<TaskHostTask>(createdTask);
             }
@@ -660,7 +673,8 @@ namespace Microsoft.Build.UnitTests.BackEnd
 #endif
                     false,
                     scheduledNodeId: 1,
-                    (string propName) => ProjectPropertyInstance.Create("test", "test"));
+                    (string propName) => ProjectPropertyInstance.Create("test", "test"),
+                    string.Empty);
                 Assert.NotNull(createdTask);
                 Assert.IsType<TaskHostTask>(createdTask);
             }

--- a/src/Build.UnitTests/BackEnd/TaskHostTask_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/TaskHostTask_Tests.cs
@@ -1,0 +1,57 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+using Microsoft.Build.BackEnd;
+using Microsoft.Build.Shared;
+using Shouldly;
+using Xunit;
+
+namespace Microsoft.Build.UnitTests.BackEnd
+{
+    public class TaskHostTask_Tests
+    {
+        [Fact]
+        public void GetStartupDirectory_ReturnsProjectDirectory_WhenMultiThreadedAndProjectFileExists()
+        {
+            string projectFile = Path.Combine("C:", "MyProject", "Project.csproj");
+            string expectedDirectory = Path.GetDirectoryName(projectFile)!;
+            
+            string result = TaskHostTask.GetStartupDirectory(projectFile, true);
+            
+            result.ShouldBe(expectedDirectory);
+        }
+
+        [Fact]
+        public void GetStartupDirectory_ReturnsCurrentDirectory_WhenNotMultiThreaded()
+        {
+            string projectFile = Path.Combine("C:", "MyProject", "Project.csproj");
+            string currentDirectory = NativeMethodsShared.GetCurrentDirectory();
+            
+            string result = TaskHostTask.GetStartupDirectory(projectFile, false);
+            
+            result.ShouldBe(currentDirectory);
+        }
+
+        [Fact]
+        public void GetStartupDirectory_ReturnsCurrentDirectory_WhenMultiThreadedButProjectFileIsNull()
+        {
+            string currentDirectory = NativeMethodsShared.GetCurrentDirectory();
+            
+            string result = TaskHostTask.GetStartupDirectory(null, true);
+            
+            result.ShouldBe(currentDirectory);
+        }
+
+        [Fact]
+        public void GetStartupDirectory_ReturnsCurrentDirectory_WhenMultiThreadedButProjectFileIsEmpty()
+        {
+            string currentDirectory = NativeMethodsShared.GetCurrentDirectory();
+            
+            string result = TaskHostTask.GetStartupDirectory(string.Empty, true);
+            
+            result.ShouldBe(currentDirectory);
+        }
+    }
+}

--- a/src/Build/BackEnd/TaskExecutionHost/TaskExecutionHost.cs
+++ b/src/Build/BackEnd/TaskExecutionHost/TaskExecutionHost.cs
@@ -964,7 +964,8 @@ namespace Microsoft.Build.BackEnd
 #endif
                         IsOutOfProc,
                         scheduledNodeId,
-                        ProjectInstance.GetProperty);
+                        ProjectInstance.GetProperty,
+                        _projectInstance.FullPath);
                 }
                 else
                 {
@@ -1804,7 +1805,8 @@ namespace Microsoft.Build.BackEnd
 #if FEATURE_APPDOMAIN
                 AppDomainSetup,
 #endif
-                scheduledNodeId);
+                scheduledNodeId,
+                _projectInstance.FullPath);
         }
     }
 }

--- a/src/Build/Instance/TaskFactories/AssemblyTaskFactory.cs
+++ b/src/Build/Instance/TaskFactories/AssemblyTaskFactory.cs
@@ -322,7 +322,8 @@ namespace Microsoft.Build.BackEnd
 #endif
             bool isOutOfProc,
             int scheduledNodeId,
-            Func<string, ProjectPropertyInstance> getProperty)
+            Func<string, ProjectPropertyInstance> getProperty,
+            string projectFileOfTaskNode)
         {
             // If the type was loaded via MetadataLoadContext, we MUST use TaskFactory since it didn't load any task assemblies in memory.
             bool useTaskFactory = _loadedType.LoadedViaMetadataLoadContext;
@@ -374,7 +375,8 @@ namespace Microsoft.Build.BackEnd
 #if FEATURE_APPDOMAIN
                     appDomainSetup,
 #endif
-                    scheduledNodeId);
+                    scheduledNodeId,
+                    projectFileOfTaskNode);
                 return task;
             }
             else


### PR DESCRIPTION
Fixes #12802 

### Context
in -mt mode taskhosts are spawned with currentworkingdirectory, which may not mirror behavior in multiprocess build - a node has cwd = directory where the project file being built is, leading to task failures for tasks which rely on cwd being set correctly

### Changes Made
propagate information which project are building to TaskHostTask

### Testing
updated unit tests,
manually validated it fixes the repro project

### Notes
alternative design: once taskenvironemtn apis are merged
https://github.com/dotnet/msbuild/commit/567e44bf49b0a5e7c6b37f53af0f28f8b81db3da