### PR TITLE
Unset InsertPackagePropsValues when irrelevant

### DIFF
--- a/azure-pipelines/vs-insertion.yml
+++ b/azure-pipelines/vs-insertion.yml
@@ -237,12 +237,17 @@ extends:
               }
               $propsValue = $props -join ";"
 
-              # As of 18.0, don't update PackageReferences so that VS packages like VSSDK
+              # For 18.0+, don't update PackageReferences so that VS packages like VSSDK
               # can choose their own versioning and don't always depend on a super fresh MSBuild
               if ("$(InsertTargetBranch)" -in @("rel/d17.10", "rel/d17.12", "rel/d17.14"))
               {
                   Write-Host "Setting InsertPackagePropsValues to '$propsValue'"
                   Write-Host "##vso[task.setvariable variable=InsertPackagePropsValues]$($propsValue)"
+              }
+              else
+              {
+                  Write-Host "Unsetting InsertPackagePropsValues"
+                  Write-Host "##vso[task.setvariable variable=InsertPackagePropsValues]"
               }
 
               # autocomplete main


### PR DESCRIPTION
When the insertion is not updating .props files, explicitly unset `InsertPackagePropsValues` to empty, to avoid errors parsing the literal string `$(InsertPackagePropsValues)` like

    ##[error]Cannot insert payload: $(InsertPackagePropsValues) does not match the pattern 'packageId=version[,...]'.

Test insertion: https://dev.azure.com/devdiv/DevDiv/_build/results?buildId=12819912