### PR TITLE
Fix non-determinstic resources section in some deps.json files

### DIFF
--- a/src/Tasks/AssemblyDependency/ResolveAssemblyReference.cs
+++ b/src/Tasks/AssemblyDependency/ResolveAssemblyReference.cs
@@ -3293,7 +3293,9 @@ namespace Microsoft.Build.Tasks
             return Execute(
                 p => FileUtilities.FileExistsNoThrow(p),
                 p => FileUtilities.DirectoryExistsNoThrow(p),
-                (p, searchPattern) => FileSystems.Default.EnumerateDirectories(p, searchPattern).ToArray(),
+                (p, searchPattern) => FileSystems.Default.EnumerateDirectories(p, searchPattern)
+                                        .OrderBy(path => path, StringComparer.Ordinal) // sort to ensure deterministic order
+                                        .ToArray(),
                 p => AssemblyNameExtension.GetAssemblyNameEx(p),
                 (string path, ConcurrentDictionary<string, AssemblyMetadata> assemblyMetadataCache, out AssemblyNameExtension[] dependencies, out string[] scatterFiles, out FrameworkNameVersioning frameworkName)
                     => AssemblyInformation.GetAssemblyMetadata(path, assemblyMetadataCache, out dependencies, out scatterFiles, out frameworkName),


### PR DESCRIPTION
Fixes: https://github.com/dotnet/msbuild/issues/12818

### Context

This is part of an effort to make the .NET build end to end deterministic and reproducible (dotnet/source-build#4963).

When I build and rebuild the entire VMR (commit
e8070609f60e288d2efe730cacbe0f3e48dc14ac) in source-build mode, 3 deps.json files contain resources entries that are in an unstable order. The 3 files all seem to be roslyn:

    dotnet/sdk/10.0.100-dev/Roslyn/bincore/VBCSCompiler.deps.json
    dotnet/sdk/10.0.100-dev/Roslyn/bincore/csc.deps.json
    dotnet/sdk/10.0.100-dev/Roslyn/bincore/vbc.deps.json

(There are other differences in many other .deps.json files, but they seem to be related to sha512 identifies of binary packages/dependencies)

The differences are all in the ordering of the language-specific resource assemblies, like:

- cs/Microsoft.CodeAnalysis.resources.dll
- de/Microsoft.CodeAnalysis.resources.dll
- fr/Microsoft.CodeAnalysis.resources.dll
- ru/Microsoft.CodeAnalysis.resources.dll

The differences in ordering seem to be down to file-system enumration of the sattelite files discovered by the ResolveAssemblyReferences task. At least on Linux, the order of returned entries by readdir(3) is not defined.

### Changes Made

Sort the files in some (any) well-defined/reproducible order. 

### Testing

I built the VMR with this change, then used that to build itself multiple times and the non-deterministicness in VBCSCompiler.deps.json, csc.deps.json and vbc.deps.json went away.

### Notes
