### PR TITLE
Return PrivateAssets="all" to System.Threading.Channels

### DIFF
--- a/src/Tasks/Microsoft.Build.Tasks.csproj
+++ b/src/Tasks/Microsoft.Build.Tasks.csproj
@@ -688,7 +688,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'">
-    <PackageReference Include="System.Threading.Channels" />
+    <PackageReference Include="System.Threading.Channels" PrivateAssets="all" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" />
     <PackageReference Include="System.Collections.Immutable" />
   </ItemGroup>


### PR DESCRIPTION
Fixes #
Regression in VS perf tests

### Context
In scope of this commit https://github.com/dotnet/msbuild/commit/f62465c9fc103af252f9522614bab7492f27e319#diff-bbcd69b169631ba90e590372d9064ceda7093fe5a52e5a626352366c639091a9 
System.Threading.Channels reference was moved to the different section without "PrivateAssets="all" attribute. It caused the excessive reference loading in some of VS scenarious.

### Changes Made
Return  PrivateAssets="all" to the reference.

### Testing
Experimental insertion looks good: https://dev.azure.com/devdiv/DevDiv/_git/VS/pullrequest/691054 (the loading of System.Threading.Channels went away for test ManagedLangsVS64.Debugging.0600.Stop Debugging.VM_AdjustedImagesInMemory_Total_devenv)

<img width="2400" height="177" alt="{73BEA632-1FBE-430A-A631-77FAD57A36E2}" src="https://github.com/user-attachments/assets/b48ceedc-9e5a-4833-b953-afa2eb2b01b7" />
