### PR TITLE
mark Tasks requiring no change as multithreadable

### DIFF
--- a/src/Tasks/AssignCulture.cs
+++ b/src/Tasks/AssignCulture.cs
@@ -32,6 +32,7 @@ namespace Microsoft.Build.Tasks
     /// There are plenty of corner cases with this task. See the unit test for
     /// more details.
     /// </summary>
+    [MSBuildMultiThreadableTask]
     public class AssignCulture : TaskExtension
     {
         #region Properties

--- a/src/Tasks/AssignLinkMetadata.cs
+++ b/src/Tasks/AssignLinkMetadata.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Build.Tasks
     /// <summary>
     /// Task to assign a reasonable "Link" metadata to the provided items.
     /// </summary>
+    [MSBuildMultiThreadableTask]
     public class AssignLinkMetadata : TaskExtension
     {
         /// <summary>

--- a/src/Tasks/CombinePath.cs
+++ b/src/Tasks/CombinePath.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Build.Tasks
     /// <summary>
     /// Task to call Path.Combine.
     /// </summary>
+    [MSBuildMultiThreadableTask]
     public class CombinePath : TaskExtension
     {
         private ITaskItem[] _paths;

--- a/src/Tasks/ConvertToAbsolutePath.cs
+++ b/src/Tasks/ConvertToAbsolutePath.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Build.Tasks
     /// <summary>
     /// Task to call Path.GetFullPath
     /// </summary>
+    [MSBuildMultiThreadableTask]
     public class ConvertToAbsolutePath : TaskExtension
     {
         private ITaskItem[] _paths;

--- a/src/Tasks/CreateProperty.cs
+++ b/src/Tasks/CreateProperty.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Build.Tasks
     /// <summary>
     /// Just a straight pass-through of the inputs through to the outputs.
     /// </summary>
+    [MSBuildMultiThreadableTask]
     public class CreateProperty : TaskExtension
     {
         /// <summary>

--- a/src/Tasks/Error.cs
+++ b/src/Tasks/Error.cs
@@ -6,6 +6,7 @@
 #if NET
 using System.Diagnostics.CodeAnalysis;
 #endif
+using Microsoft.Build.Framework;
 
 namespace Microsoft.Build.Tasks
 {
@@ -13,6 +14,7 @@ namespace Microsoft.Build.Tasks
     /// Task that simply emits an error. Engine will add project file path and line/column
     /// information.
     /// </summary>
+    [MSBuildMultiThreadableTask]
     public sealed class Error : TaskExtension
     {
         /// <summary>

--- a/src/Tasks/FindInList.cs
+++ b/src/Tasks/FindInList.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Build.Tasks
     /// A task that finds an item with the specified itemspec, if present,
     /// in the provided list.
     /// </summary>
+    [MSBuildMultiThreadableTask]
     public class FindInList : TaskExtension
     {
         private ITaskItem[] _list;

--- a/src/Tasks/FormatVersion.cs
+++ b/src/Tasks/FormatVersion.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Build.Tasks
     ///  Case #2: Input: Version="1.0.0.*"    Revision="5"            Output: OutputVersion="1.0.0.5"
     ///  Case #3: Input: Version="1.0.0.0"    Revision=&lt;don't care&gt;   Output: OutputVersion="1.0.0.0"
     /// </comment>
+    [MSBuildMultiThreadableTask]
     public sealed class FormatVersion : TaskExtension
     {
         private enum _FormatType

--- a/src/Tasks/Hash.cs
+++ b/src/Tasks/Hash.cs
@@ -22,6 +22,7 @@ namespace Microsoft.Build.Tasks
     /// Would this need to be revised - XxHash64 from System.Io.Hashing could be used instead for better performance.
     /// (That however currently requires load of additional binary into VS process which has it's own costs)
     /// </remarks>
+    [MSBuildMultiThreadableTask]
     public class Hash : TaskExtension
     {
         private const char ItemSeparatorCharacter = '\u2028';

--- a/src/Tasks/ListOperators/RemoveDuplicates.cs
+++ b/src/Tasks/ListOperators/RemoveDuplicates.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Build.Tasks
     /// <summary>
     /// Given a list of items, remove duplicate items. Attributes are not considered. Case insensitive.
     /// </summary>
+    [MSBuildMultiThreadableTask]
     public class RemoveDuplicates : TaskExtension
     {
         /// <summary>

--- a/src/Tasks/MSBuildInternalMessage.cs
+++ b/src/Tasks/MSBuildInternalMessage.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Build.Tasks
     /// Represents a task that produces localized messages based on the specified resource name.
     /// This task is intended to be called from internal targets only.
     /// </summary>
+    [MSBuildMultiThreadableTask]
     public sealed class MSBuildInternalMessage : TaskExtension
     {
         private enum BuildMessageSeverity

--- a/src/Tasks/Message.cs
+++ b/src/Tasks/Message.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Build.Tasks
     /// <summary>
     /// Task that simply emits a message. Importance defaults to high if not specified.
     /// </summary>
+    [MSBuildMultiThreadableTask]
     public sealed class Message : TaskExtension
     {
         /// <summary>

--- a/src/Tasks/SetRidAgnosticValueForProjects.cs
+++ b/src/Tasks/SetRidAgnosticValueForProjects.cs
@@ -9,6 +9,7 @@ using Microsoft.Build.Utilities;
 
 namespace Microsoft.Build.Tasks
 {
+    [MSBuildMultiThreadableTask]
     public sealed class SetRidAgnosticValueForProjects : TaskExtension
     {
         public ITaskItem[] Projects { get; set; } = Array.Empty<ITaskItem>();

--- a/src/Tasks/Telemetry.cs
+++ b/src/Tasks/Telemetry.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Build.Tasks
     /// <summary>
     /// Task that logs telemetry.
     /// </summary>
+    [MSBuildMultiThreadableTask]
     public sealed class Telemetry : TaskExtension
     {
         /// <summary>

--- a/src/Tasks/Warning.cs
+++ b/src/Tasks/Warning.cs
@@ -6,6 +6,7 @@
 #if NET
 using System.Diagnostics.CodeAnalysis;
 #endif
+using Microsoft.Build.Framework;
 
 namespace Microsoft.Build.Tasks
 {
@@ -13,6 +14,7 @@ namespace Microsoft.Build.Tasks
     /// Task that simply emits a warning. Engine will add the project path because
     /// we do not specify a filename.
     /// </summary>
+    [MSBuildMultiThreadableTask]
     public sealed class Warning : TaskExtension
     {
         /// <summary>


### PR DESCRIPTION
Fixes #

### Context
These tasks don't rely on process state (CWD etc.)

### Changes Made
Add attribute marking them as multithreadable

### Testing


### Notes
