### PR TITLE
Configure automerge for vs18.3

### DIFF
--- a/.config/git-merge-flow-config.jsonc
+++ b/.config/git-merge-flow-config.jsonc
@@ -26,7 +26,7 @@
         "vs17.14": {
             "MergeToBranch": "vs18.0"
         },
-        // Automate opening PRs to merge msbuild's vs18.0 (SDK 10.0.2xx) into vs18.3 (SDK 10.0.2xx, VS) 
+        // Automate opening PRs to merge msbuild's vs18.0 (SDK 10.0.1xx) into vs18.3 (SDK 10.0.2xx, VS)
         "vs18.0": {
             "MergeToBranch": "main" // update to flow through vs18.3 after we fork for release
         },


### PR DESCRIPTION
Note that since we're still doing active development in `main` for 18.3 I opted to keep `vs18.0`->`main` going for now.
