### PR TITLE
Official build: Run loc and build concurrently

### DIFF
--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -122,6 +122,7 @@ extends:
 
     - stage: build
       displayName: Build
+      dependsOn: [] # empty dependency list to enable parallelization with localization stage
       jobs:
       - template: /azure-pipelines/.vsts-dotnet-build-jobs.yml@self
         parameters:


### PR DESCRIPTION
This should reduce our official build time by ~9 minutes by moving the Localization step off the critical path.

Before:
<img width="2148" height="779" alt="image" src="https://github.com/user-attachments/assets/7e4428f5-6acf-4505-b78a-bee5c874d6ba" />


https://dev.azure.com/devdiv/DevDiv/\_build/results?buildId=12889574 shows it working (though it required some additional tweaks to get the loc stuff to run at all on a branch that's not main or vs\*):

<img width="1585" height="940" alt="image" src="https://github.com/user-attachments/assets/0bbbc98f-110f-4754-85fa-a5183aaae42c" />
