### PR TITLE
Temporarily disable localization for vs 18.* main

### DIFF
--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -49,7 +49,7 @@ variables:
     - name: SkipApplyOptimizationData
       value: true
   - name: EnableReleaseOneLocBuild
-    value: true # Enable loc for vs18.1
+    value: false # Temp DISABLE to localize vs 17.14
   - name: Codeql.Enabled
     value: true
   - group: DotNet-MSBuild-SDLValidation-Params


### PR DESCRIPTION
Fixes #
We need to disable localization of main to get the translated strings in vs17.14
See https://ceapex.visualstudio.com/CEINTL/_workitems/edit/1115227 for more details 
