### PR TITLE
Remove '.dotnet' from SDK paths in global.json

### DIFF
--- a/global.json
+++ b/global.json
@@ -2,7 +2,6 @@
   "sdk": {
     "allowPrerelease": true,
     "paths": [
-      ".dotnet",
       "$host$"
     ],
     "errorMessage": "The .NET SDK could not be found, please run a command-line build with ./build.cmd."


### PR DESCRIPTION
### Context
with this the core bootstrap does not work as intended and it confuses copilot agents
<img width="920" height="111" alt="image" src="https://github.com/user-attachments/assets/82792aa9-4137-4e54-a60b-85378ebf16cc" />


when you run the bootstrap in main with `artifacts/bin/bootstrap/core/dotnet build` it takes Microsoft.Build.dll from the sdk folder instead of the bootstrap folder and we're solving that by locally deleting this line. So let's delete in the repo

### Testing
local validation it fixes the loading issue

### Notes
