### PR TITLE
Don't invoke Regex.Replace(...) incorrectly in property function

### DIFF
--- a/src/Build.UnitTests/Evaluation/Expander_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/Expander_Tests.cs
@@ -4827,6 +4827,25 @@ $(
             TestPropertyFunction(expression, "dummy", "", expected);
         }
 
+        [Fact]
+        public void PropertyFunction_ReplaceDoesNotCallRegexReplace()
+        {
+            // Regression test for https://github.com/dotnet/msbuild/issues/12923
+
+            var properties = new PropertyDictionary<ProjectProperty>();
+            var expander = new Expander<ProjectProperty, ProjectItem>(properties, FileSystems.Default);
+
+            Should.Throw<InvalidProjectFileException>(() =>
+            {
+                string result = expander.ExpandIntoStringLeaveEscaped(
+                    "$([System.TimeSpan]::Replace('abc_123_ghi', '\\d+', 'def'))",
+                    ExpanderOptions.ExpandProperties,
+                    MockElementLocation.Instance);
+
+                result.ShouldNotBe("abc_def_ghi");
+            });
+        }
+
         private void TestPropertyFunction(string expression, string propertyName, string propertyValue, string expected)
         {
             var properties = new PropertyDictionary<ProjectPropertyInstance>();

--- a/src/Build/Evaluation/Expander/WellKnownFunctions.cs
+++ b/src/Build/Evaluation/Expander/WellKnownFunctions.cs
@@ -885,7 +885,7 @@ namespace Microsoft.Build.Evaluation.Expander
                     if (string.Equals(methodName, nameof(char.IsDigit), StringComparison.OrdinalIgnoreCase))
                     {
                         bool? result = null;
-                        
+
                         if (ParseArgs.TryGetArg(args, out string? arg0) && arg0?.Length == 1)
                         {
                             char c = arg0[0];
@@ -895,7 +895,7 @@ namespace Microsoft.Build.Evaluation.Expander
                         {
                             result = char.IsDigit(str, index);
                         }
-                        
+
                         if (result.HasValue)
                         {
                             returnVal = result.Value;
@@ -903,12 +903,15 @@ namespace Microsoft.Build.Evaluation.Expander
                         }
                     }
                 }
-                else if (string.Equals(methodName, nameof(Regex.Replace), StringComparison.OrdinalIgnoreCase) && args.Length == 3)
+                else if (receiverType == typeof(Regex))
                 {
-                    if (ParseArgs.TryGetArgs(args, out string? arg1, out string? arg2, out string? arg3) && arg1 != null && arg2 != null && arg3 != null)
+                    if (string.Equals(methodName, nameof(Regex.Replace), StringComparison.OrdinalIgnoreCase) && args.Length == 3)
                     {
-                        returnVal = Regex.Replace(arg1, arg2, arg3);
-                        return true;
+                        if (ParseArgs.TryGetArgs(args, out string? arg1, out string? arg2, out string? arg3) && arg1 != null && arg2 != null && arg3 != null)
+                        {
+                            returnVal = Regex.Replace(arg1, arg2, arg3);
+                            return true;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Fixes #12923

There is a small bug in `WellKnownFunctions` where a `receiverType == typeof(Regex)` was missed, allowing `Regex.Replace(...)` to be called for different receiver types in certain cases.