### PR TITLE
Combine official-build artifact uploads for perf

### DIFF
--- a/azure-pipelines/.vsts-dotnet-build-jobs.yml
+++ b/azure-pipelines/.vsts-dotnet-build-jobs.yml
@@ -30,6 +30,7 @@ jobs:
       sourcePath: '$(Build.SourcesDirectory)\artifacts\official\OptProf\$(BuildConfiguration)\Data'
       dropServiceURI: 'https://devdiv.artifacts.visualstudio.com'
       dropMetadataContainerName: 'ProfilingInputs/DevDiv/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildNumber)'
+      condition: and(succeeded(), ${{ parameters.enableOptProf }})
 
     # Publish bootstrapper info for OptProf data collection run to consume
     - output: buildArtifacts
@@ -46,6 +47,7 @@ jobs:
     - output: buildArtifacts
       PathtoPublish: '$(Build.SourcesDirectory)\artifacts\official\VSSetup\$(BuildConfiguration)'
       ArtifactName: VSSetup
+      condition: and(succeeded(), ${{ parameters.enableOptProf }})
 
     # Archive NuGet packages to DevOps.
     # Publish our NuPkgs as an artifact. The name of this artifact must be PackageArtifacts as the
@@ -197,12 +199,15 @@ jobs:
 
       $paths = @(
         "log/$(BuildConfiguration)",
-        "OptProf/$(BuildConfiguration)/Data",
         "$(Build.StagingDirectory)/MicroBuild/Output",
-        "VSSetup/$(BuildConfiguration)",
         "packages/$(BuildConfiguration)",
         "xsd"
       )
+
+      if ("${{ parameters.enableOptProf }}" -eq "true") {  
+        $paths += "OptProf/$(BuildConfiguration)/Data"  
+        $paths += "VSSetup/$(BuildConfiguration)"  
+      }
 
       $allpresent = $true
 


### PR DESCRIPTION
Scans injected by policy have dramatically increased our official build time. I consulted with some folks internally, the highest-impact approach we identified was to reduce the number of invocations of the artifact-upload tasks, since each one in the normal flow of the job incurs a scan cost.

To do this we had to:

1. Convert all of the `1ES.PublishBuildArtifacts` task calls to declarative template `outputs:`
2. define an `outputParentDirectory` that can be scanned exactly once (for all uploaded artifacts) instead of per-upload
3. Restrict that `outputParentDirectory` to contain only things that will be uploaded (`artifacts/` was too broad and caused the scan to find some false positives).

Example successful official build: https://dev.azure.com/devdiv/DevDiv/_build/results?buildId=12895565
<img width="503" height="346" alt="image" src="https://github.com/user-attachments/assets/b79838d2-bba1-43e0-bd15-00584c4ca858" />

(compare that 1h 21m to 2h 34m from a recent `main` branch official build)

Example exp build showing log upload on (artificially injected) failure: https://dev.azure.com/devdiv/DevDiv/_build/results?buildId=12941708
