### PR TITLE
Revert assembly-scan change

### DIFF
--- a/src/MSBuild/MSBuild.csproj
+++ b/src/MSBuild/MSBuild.csproj
@@ -59,9 +59,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="..\Shared\FrameworkLocationHelper.cs">
-      <Link>Shared\FrameworkLocationHelper.cs</Link>
-    </Compile>
     <Compile Include="..\Shared\BuildEnvironmentHelper.cs">
       <Link>BuildEnvironmentHelper.cs</Link>
     </Compile>


### PR DESCRIPTION
It's not totally clear how, but this appears to have caused perf DDRIT failures on insertion to VS. Reverting to investigate later.



* Revert "Make runtimeAssembliesCLR35\_20 lazy (#12928)"
* Revert " Fix assembly resolution for .exe files and legacy .NET Framework tasks (CLR35 and CLR2) (#12823)"
