### PR TITLE
Fix insertion auto-queuing perf tests

### DIFF
--- a/azure-pipelines/vs-insertion-experimental.yml
+++ b/azure-pipelines/vs-insertion-experimental.yml
@@ -179,7 +179,7 @@ extends:
             DefaultConfigValues: $(InsertConfigValues)
             InsertionReviewers: MSBuild
             CustomScriptExecutionCommand: $(InsertCustomScriptExecutionCommand)
-            InsertionBuildPolicy: 'Request Perf DDRITs'
+            InsertionBuildPolicies: 'Request Perf DDRITs'
             ConnectedVSDropServiceName: 'VSEng-VSDrop-MI'
           env:
             SYSTEM_ACCESSTOKEN: $(System.AccessToken)

--- a/azure-pipelines/vs-insertion.yml
+++ b/azure-pipelines/vs-insertion.yml
@@ -293,7 +293,7 @@ extends:
             CustomScriptExecutionCommand: $(InsertCustomScriptExecutionCommand)
             AutoCompletePR: $(AutoCompleteEnabled)
             AutoCompleteMergeStrategy: Squash
-            InsertionBuildPolicy: 'Request Perf DDRITs'
+            InsertionBuildPolicies: 'Request Perf DDRITs'
             ConnectedVSDropServiceName: 'VSEng-VSDrop-MI'
           env:
             SYSTEM_ACCESSTOKEN: $(System.AccessToken)


### PR DESCRIPTION

### Context
https://github.com/dotnet/msbuild/commit/9f564193fd81558c41ee2be0010a8d079364f396
updated the InsertVSPayload task, and the parameter name for queuing build policies changed
