### PR TITLE
Resolves the test failure in CanShutdownServerProcess when setting capacity for the _nodeContexts dictionary

### DIFF
--- a/src/Build/BackEnd/Components/Communications/NodeProviderInProc.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderInProc.cs
@@ -122,7 +122,19 @@ namespace Microsoft.Build.BackEnd
         public void InitializeComponent(IBuildComponentHost host)
         {
             _componentHost = host;
-            _nodeContexts = new ConcurrentDictionary<int, NodeContext>();
+
+            // Initialize with proper capacity for performance optimization
+            // Use Environment.ProcessorCount for concurrencyLevel to handle multi-threaded scenarios
+            if (host.BuildParameters?.MaxNodeCount > 0)
+            {
+                _nodeContexts = new ConcurrentDictionary<int, NodeContext>(
+                    concurrencyLevel: Environment.ProcessorCount,
+                    capacity: host.BuildParameters.MaxNodeCount);
+            }
+            else
+            {
+                _nodeContexts = new ConcurrentDictionary<int, NodeContext>();
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Resolves the test failure in CanShutdownServerProcess when setting capacity for the _nodeContexts dictionary https://github.com/dotnet/msbuild/issues/12187

Fixes #12187

### Context

When attempting to set capacity for `_nodeContexts` dictionary to improve performance, the test `MSBuildServer_Tests.CanShutdownServerProcess(byBuildManager: True)` failed due to `NullReferenceException` when accessing `host.BuildParameters.MaxNodeCount` without null-checking.

### Changes Made

- Added null-safe check for `host.BuildParameters` before accessing `MaxNodeCount`
- Validate `MaxNodeCount > 0` to avoid invalid capacity values
- Use `Environment.ProcessorCount` for `concurrencyLevel` to optimize multi-threaded scenarios
- Provide fallback initialization when `BuildParameters` is null or invalid

### Testing

- Verified `MSBuildServer_Tests.CanShutdownServerProcess` passes with both `byBuildManager: True` and `False`
- Confirmed the fix enables capacity optimization while maintaining thread-safety

### Notes

This change allows performance optimization through pre-allocated dictionary capacity while ensuring test stability and proper null handling.
