### PR TITLE
Bugfix/fix asp websites failing to resolve projects that depend on netstandard

### DIFF
--- a/src/Build/Construction/Solution/SolutionProjectGenerator.cs
+++ b/src/Build/Construction/Solution/SolutionProjectGenerator.cs
@@ -451,8 +451,8 @@ namespace Microsoft.Build.Construction
             rarTask.SetParameter("FindSerializationAssemblies", "true");
             rarTask.SetParameter("FindRelatedFiles", "true");
             rarTask.SetParameter("TargetFrameworkMoniker", project.TargetFrameworkMoniker);
-            rarTask.SetParameter("TargetFrameworkVersion", "v" + new FrameworkName(project.TargetFrameworkMoniker).Version.ToString());
-            rarTask.AddOutputItem("CopyLocalFiles", copyLocalFilesItemName, null);  
+            rarTask.SetParameter("TargetFrameworkVersion", $"v{new FrameworkName(project.TargetFrameworkMoniker).Version}");
+            rarTask.AddOutputItem("CopyLocalFiles", copyLocalFilesItemName, null);
 
             // Copy all the copy-local files (reported by RAR) to the web project's "bin"
             // directory.


### PR DESCRIPTION
Fixes #12933

### Context
Currently we don't provide a target framework version when generating metaprojects for asp websites, which leads reference table to assume that the framework version is 4.6.0, which apparently does not contain a reference for netstandard2.0.

### Changes Made
Add a TargetFrameworkVersion based on the provided target framework moniker