### PR TITLE
Add VcxprojReader.exe to ngenApplications

### DIFF
--- a/src/Package/MSBuild.VSSetup/files.swr
+++ b/src/Package/MSBuild.VSSetup/files.swr
@@ -26,7 +26,7 @@ folder InstallDir:\MSBuild\Current
 
 folder InstallDir:\MSBuild\Current\Bin
   file source=$(X86BinPath)Microsoft.Build.dll vs.file.ngenApplications="[installDir]\Common7\IDE\vsn.exe" vs.file.ngenApplications="[installDir]\MSBuild\Current\Bin\MSBuild.exe" vs.file.ngenArchitecture=all vs.file.ngenPriority=2
-  file source=$(X86BinPath)Microsoft.Build.Framework.dll vs.file.ngenApplications="[installDir]\Common7\IDE\vsn.exe" vs.file.ngenApplications="[installDir]\MSBuild\Current\Bin\MSBuild.exe" vs.file.ngenArchitecture=all
+  file source=$(X86BinPath)Microsoft.Build.Framework.dll vs.file.ngenApplications="[installDir]\Common7\IDE\vsn.exe" vs.file.ngenApplications="[installDir]\MSBuild\Current\Bin\MSBuild.exe" vs.file.ngenApplications="[installDir]\Common7\IDE\VcxprojReader.exe" vs.file.ngenArchitecture=all
   file source=$(X86BinPath)Microsoft.Build.Framework.tlb
   file source=$(X86BinPath)Microsoft.Build.Tasks.Core.dll vs.file.ngenApplications="[installDir]\Common7\IDE\vsn.exe" vs.file.ngenApplications="[installDir]\MSBuild\Current\Bin\MSBuild.exe" vs.file.ngenArchitecture=all vs.file.ngenPriority=2
   file source=$(X86BinPath)Microsoft.Build.Utilities.Core.dll vs.file.ngenApplications="[installDir]\Common7\IDE\vsn.exe" vs.file.ngenApplications="[installDir]\MSBuild\Current\Bin\MSBuild.exe" vs.file.ngenArchitecture=all vs.file.ngenPriority=2


### PR DESCRIPTION
During perf tests investigations I noticed that VcxprojReader doesn't use NGENed image of Microsoft.Build.Framework.dll, resulting in ~485.0 extra JIT'd methods.
This PR fixes it by adding VcxprojReader.exe to ngenApplications.

<img width="2438" height="1484" alt="{8A95DAD1-92AD-41B4-9194-AACE60EC9510}" src="https://github.com/user-attachments/assets/41b175fe-d538-4c9a-9df6-1e5cd6d0dfe5" />

This PR fixes it.