### PR TITLE
Allow using more input types in task parameters and task outputs

### DIFF
--- a/documentation/wiki/Tasks.md
+++ b/documentation/wiki/Tasks.md
@@ -14,8 +14,8 @@ A task is a class implementing [`ITask`](https://github.com/dotnet/msbuild/blob/
     - **Numeric value types**: `int`, `long`, `short`, `byte`, `uint`, `ulong`, `ushort`, `sbyte`, `double`, `float`, `decimal`, and their array equivalents
     - **Other value types**: `char`, `DateTime`, and their array equivalents
     - **Item types**: `ITaskItem` (representation of a file system object with metadata), `ITaskItem[]`
-    - **Strongly-typed items**: `ITaskItem<T>` where `T` is a value type (e.g., `ITaskItem<int>`), and their array equivalents
-    - **Path types**: `AbsolutePath`, `AbsolutePath[]`
+    - **Strongly-typed items**: `ITaskItem<T>` where `T` is a value type, `FileInfo`, or `DirectoryInfo` (e.g., `ITaskItem<int>`, `ITaskItem<FileInfo>`), and their array equivalents
+    - **Path types**: `AbsolutePath`, `AbsolutePath[]`, `FileInfo`, `FileInfo[]`, `DirectoryInfo`, `DirectoryInfo[]`
     - **Custom value types**: Any struct implementing `IConvertible` (for output parameters only)
   - The properties can have attributes `[Required]` which causes the engine to check that it has a value when the task is run and `[Output]` which exposes the property to be used again in XML
 

--- a/documentation/wiki/Tasks.md
+++ b/documentation/wiki/Tasks.md
@@ -8,8 +8,16 @@ A task is a class implementing [`ITask`](https://github.com/dotnet/msbuild/blob/
 
 - The notable method of this interface is `bool Execute()`. Code in it will get executed when the task is run.
 - A Task can have public properties that can be set by the user in the project file.
-  - These properties can be `string`, `bool`, `ITaskItem` (representation of a file system object), `string[]`, `bool[]`, `ITaskItem[]`
-  - the properties can have attributes `[Required]` which causes the engine to check that it has a value when the task is run and `[Output]` which exposes the property to be used again in XML
+  - These properties can be:
+    - **String types**: `string`, `string[]`
+    - **Boolean types**: `bool`, `bool[]`
+    - **Numeric value types**: `int`, `long`, `short`, `byte`, `uint`, `ulong`, `ushort`, `sbyte`, `double`, `float`, `decimal`, and their array equivalents
+    - **Other value types**: `char`, `DateTime`, and their array equivalents
+    - **Item types**: `ITaskItem` (representation of a file system object with metadata), `ITaskItem[]`
+    - **Strongly-typed items**: `ITaskItem<T>` where `T` is a value type (e.g., `ITaskItem<int>`), and their array equivalents
+    - **Path types**: `AbsolutePath`, `AbsolutePath[]`
+    - **Custom value types**: Any struct implementing `IConvertible` (for output parameters only)
+  - The properties can have attributes `[Required]` which causes the engine to check that it has a value when the task is run and `[Output]` which exposes the property to be used again in XML
 
 - Tasks have the `Log` property set by the engine to log messages/errors/warnings.
 

--- a/src/Build.UnitTests/BackEnd/TaskBuilderTestTask.cs
+++ b/src/Build.UnitTests/BackEnd/TaskBuilderTestTask.cs
@@ -237,6 +237,16 @@ namespace Microsoft.Build.UnitTests.BackEnd
         private ITaskItem[] _itemArrayOutput;
 
         /// <summary>
+        /// The value for the AbsolutePathOutput.
+        /// </summary>
+        private AbsolutePath _absolutePathOutput;
+
+        /// <summary>
+        /// The value for the AbsolutePathArrayOutput.
+        /// </summary>
+        private AbsolutePath[] _absolutePathArrayOutput;
+
+        /// <summary>
         /// Property determining if Execute() should throw or not.
         /// </summary>
         public bool ThrowOnExecute
@@ -626,6 +636,30 @@ namespace Microsoft.Build.UnitTests.BackEnd
             {
                 _itemArrayOutput = value;
                 _testTaskHost?.ParameterSet("ItemArrayParam", value);
+            }
+        }
+
+        /// <summary>
+        /// An AbsolutePath parameter.
+        /// </summary>
+        public AbsolutePath AbsolutePathParam
+        {
+            set
+            {
+                _absolutePathOutput = value;
+                _testTaskHost?.ParameterSet("AbsolutePathParam", value);
+            }
+        }
+
+        /// <summary>
+        /// An AbsolutePath array parameter.
+        /// </summary>
+        public AbsolutePath[] AbsolutePathArrayParam
+        {
+            set
+            {
+                _absolutePathArrayOutput = value;
+                _testTaskHost?.ParameterSet("AbsolutePathArrayParam", value);
             }
         }
 
@@ -1172,6 +1206,32 @@ namespace Microsoft.Build.UnitTests.BackEnd
             {
                 _testTaskHost?.OutputRead("ItemArrayNullOutput", _itemArrayOutput);
                 return null;
+            }
+        }
+
+        /// <summary>
+        /// An AbsolutePath output.
+        /// </summary>
+        [Output]
+        public AbsolutePath AbsolutePathOutput
+        {
+            get
+            {
+                _testTaskHost?.OutputRead("AbsolutePathOutput", _absolutePathOutput);
+                return _absolutePathOutput;
+            }
+        }
+
+        /// <summary>
+        /// An AbsolutePath array output.
+        /// </summary>
+        [Output]
+        public AbsolutePath[] AbsolutePathArrayOutput
+        {
+            get
+            {
+                _testTaskHost?.OutputRead("AbsolutePathArrayOutput", _absolutePathArrayOutput);
+                return _absolutePathArrayOutput;
             }
         }
 

--- a/src/Build.UnitTests/BackEnd/TaskBuilderTestTask.cs
+++ b/src/Build.UnitTests/BackEnd/TaskBuilderTestTask.cs
@@ -257,6 +257,46 @@ namespace Microsoft.Build.UnitTests.BackEnd
         private ITaskItem<int>[] _taskItemIntArrayOutput;
 
         /// <summary>
+        /// The value for the FileInfoOutput.
+        /// </summary>
+        private System.IO.FileInfo _fileInfoOutput;
+
+        /// <summary>
+        /// The value for the FileInfoArrayOutput.
+        /// </summary>
+        private System.IO.FileInfo[] _fileInfoArrayOutput;
+
+        /// <summary>
+        /// The value for the DirectoryInfoOutput.
+        /// </summary>
+        private System.IO.DirectoryInfo _directoryInfoOutput;
+
+        /// <summary>
+        /// The value for the DirectoryInfoArrayOutput.
+        /// </summary>
+        private System.IO.DirectoryInfo[] _directoryInfoArrayOutput;
+
+        /// <summary>
+        /// The value for the TaskItemFileInfoOutput.
+        /// </summary>
+        private ITaskItem<System.IO.FileInfo> _taskItemFileInfoOutput;
+
+        /// <summary>
+        /// The value for the TaskItemFileInfoArrayOutput.
+        /// </summary>
+        private ITaskItem<System.IO.FileInfo>[] _taskItemFileInfoArrayOutput;
+
+        /// <summary>
+        /// The value for the TaskItemDirectoryInfoOutput.
+        /// </summary>
+        private ITaskItem<System.IO.DirectoryInfo> _taskItemDirectoryInfoOutput;
+
+        /// <summary>
+        /// The value for the TaskItemDirectoryInfoArrayOutput.
+        /// </summary>
+        private ITaskItem<System.IO.DirectoryInfo>[] _taskItemDirectoryInfoArrayOutput;
+
+        /// <summary>
         /// Property determining if Execute() should throw or not.
         /// </summary>
         public bool ThrowOnExecute
@@ -694,6 +734,102 @@ namespace Microsoft.Build.UnitTests.BackEnd
             {
                 _taskItemIntArrayOutput = value;
                 _testTaskHost?.ParameterSet("TaskItemIntArrayParam", value);
+            }
+        }
+
+        /// <summary>
+        /// A FileInfo parameter.
+        /// </summary>
+        public System.IO.FileInfo FileInfoParam
+        {
+            set
+            {
+                _fileInfoOutput = value;
+                _testTaskHost?.ParameterSet("FileInfoParam", value);
+            }
+        }
+
+        /// <summary>
+        /// A FileInfo array parameter.
+        /// </summary>
+        public System.IO.FileInfo[] FileInfoArrayParam
+        {
+            set
+            {
+                _fileInfoArrayOutput = value;
+                _testTaskHost?.ParameterSet("FileInfoArrayParam", value);
+            }
+        }
+
+        /// <summary>
+        /// A DirectoryInfo parameter.
+        /// </summary>
+        public System.IO.DirectoryInfo DirectoryInfoParam
+        {
+            set
+            {
+                _directoryInfoOutput = value;
+                _testTaskHost?.ParameterSet("DirectoryInfoParam", value);
+            }
+        }
+
+        /// <summary>
+        /// A DirectoryInfo array parameter.
+        /// </summary>
+        public System.IO.DirectoryInfo[] DirectoryInfoArrayParam
+        {
+            set
+            {
+                _directoryInfoArrayOutput = value;
+                _testTaskHost?.ParameterSet("DirectoryInfoArrayParam", value);
+            }
+        }
+
+        /// <summary>
+        /// An ITaskItem&lt;FileInfo&gt; parameter.
+        /// </summary>
+        public ITaskItem<System.IO.FileInfo> TaskItemFileInfoParam
+        {
+            set
+            {
+                _taskItemFileInfoOutput = value;
+                _testTaskHost?.ParameterSet("TaskItemFileInfoParam", value);
+            }
+        }
+
+        /// <summary>
+        /// An ITaskItem&lt;FileInfo&gt; array parameter.
+        /// </summary>
+        public ITaskItem<System.IO.FileInfo>[] TaskItemFileInfoArrayParam
+        {
+            set
+            {
+                _taskItemFileInfoArrayOutput = value;
+                _testTaskHost?.ParameterSet("TaskItemFileInfoArrayParam", value);
+            }
+        }
+
+        /// <summary>
+        /// An ITaskItem&lt;DirectoryInfo&gt; parameter.
+        /// </summary>
+        public ITaskItem<System.IO.DirectoryInfo> TaskItemDirectoryInfoParam
+        {
+            set
+            {
+                _taskItemDirectoryInfoOutput = value;
+                _testTaskHost?.ParameterSet("TaskItemDirectoryInfoParam", value);
+            }
+        }
+
+        /// <summary>
+        /// An ITaskItem&lt;DirectoryInfo&gt; array parameter.
+        /// </summary>
+        public ITaskItem<System.IO.DirectoryInfo>[] TaskItemDirectoryInfoArrayParam
+        {
+            set
+            {
+                _taskItemDirectoryInfoArrayOutput = value;
+                _testTaskHost?.ParameterSet("TaskItemDirectoryInfoArrayParam", value);
             }
         }
 
@@ -1292,6 +1428,110 @@ namespace Microsoft.Build.UnitTests.BackEnd
             {
                 _testTaskHost?.OutputRead("TaskItemIntArrayOutput", _taskItemIntArrayOutput);
                 return _taskItemIntArrayOutput;
+            }
+        }
+
+        /// <summary>
+        /// A FileInfo output.
+        /// </summary>
+        [Output]
+        public System.IO.FileInfo FileInfoOutput
+        {
+            get
+            {
+                _testTaskHost?.OutputRead("FileInfoOutput", _fileInfoOutput);
+                return _fileInfoOutput;
+            }
+        }
+
+        /// <summary>
+        /// A FileInfo array output.
+        /// </summary>
+        [Output]
+        public System.IO.FileInfo[] FileInfoArrayOutput
+        {
+            get
+            {
+                _testTaskHost?.OutputRead("FileInfoArrayOutput", _fileInfoArrayOutput);
+                return _fileInfoArrayOutput;
+            }
+        }
+
+        /// <summary>
+        /// A DirectoryInfo output.
+        /// </summary>
+        [Output]
+        public System.IO.DirectoryInfo DirectoryInfoOutput
+        {
+            get
+            {
+                _testTaskHost?.OutputRead("DirectoryInfoOutput", _directoryInfoOutput);
+                return _directoryInfoOutput;
+            }
+        }
+
+        /// <summary>
+        /// A DirectoryInfo array output.
+        /// </summary>
+        [Output]
+        public System.IO.DirectoryInfo[] DirectoryInfoArrayOutput
+        {
+            get
+            {
+                _testTaskHost?.OutputRead("DirectoryInfoArrayOutput", _directoryInfoArrayOutput);
+                return _directoryInfoArrayOutput;
+            }
+        }
+
+        /// <summary>
+        /// An ITaskItem&lt;FileInfo&gt; output.
+        /// </summary>
+        [Output]
+        public ITaskItem<System.IO.FileInfo> TaskItemFileInfoOutput
+        {
+            get
+            {
+                _testTaskHost?.OutputRead("TaskItemFileInfoOutput", _taskItemFileInfoOutput);
+                return _taskItemFileInfoOutput;
+            }
+        }
+
+        /// <summary>
+        /// An ITaskItem&lt;FileInfo&gt; array output.
+        /// </summary>
+        [Output]
+        public ITaskItem<System.IO.FileInfo>[] TaskItemFileInfoArrayOutput
+        {
+            get
+            {
+                _testTaskHost?.OutputRead("TaskItemFileInfoArrayOutput", _taskItemFileInfoArrayOutput);
+                return _taskItemFileInfoArrayOutput;
+            }
+        }
+
+        /// <summary>
+        /// An ITaskItem&lt;DirectoryInfo&gt; output.
+        /// </summary>
+        [Output]
+        public ITaskItem<System.IO.DirectoryInfo> TaskItemDirectoryInfoOutput
+        {
+            get
+            {
+                _testTaskHost?.OutputRead("TaskItemDirectoryInfoOutput", _taskItemDirectoryInfoOutput);
+                return _taskItemDirectoryInfoOutput;
+            }
+        }
+
+        /// <summary>
+        /// An ITaskItem&lt;DirectoryInfo&gt; array output.
+        /// </summary>
+        [Output]
+        public ITaskItem<System.IO.DirectoryInfo>[] TaskItemDirectoryInfoArrayOutput
+        {
+            get
+            {
+                _testTaskHost?.OutputRead("TaskItemDirectoryInfoArrayOutput", _taskItemDirectoryInfoArrayOutput);
+                return _taskItemDirectoryInfoArrayOutput;
             }
         }
 

--- a/src/Build.UnitTests/BackEnd/TaskBuilderTestTask.cs
+++ b/src/Build.UnitTests/BackEnd/TaskBuilderTestTask.cs
@@ -247,6 +247,16 @@ namespace Microsoft.Build.UnitTests.BackEnd
         private AbsolutePath[] _absolutePathArrayOutput;
 
         /// <summary>
+        /// The value for the TaskItemIntOutput.
+        /// </summary>
+        private ITaskItem<int> _taskItemIntOutput;
+
+        /// <summary>
+        /// The value for the TaskItemIntArrayOutput.
+        /// </summary>
+        private ITaskItem<int>[] _taskItemIntArrayOutput;
+
+        /// <summary>
         /// Property determining if Execute() should throw or not.
         /// </summary>
         public bool ThrowOnExecute
@@ -660,6 +670,30 @@ namespace Microsoft.Build.UnitTests.BackEnd
             {
                 _absolutePathArrayOutput = value;
                 _testTaskHost?.ParameterSet("AbsolutePathArrayParam", value);
+            }
+        }
+
+        /// <summary>
+        /// A TaskItem&lt;int&gt; parameter.
+        /// </summary>
+        public ITaskItem<int> TaskItemIntParam
+        {
+            set
+            {
+                _taskItemIntOutput = value;
+                _testTaskHost?.ParameterSet("TaskItemIntParam", value);
+            }
+        }
+
+        /// <summary>
+        /// A TaskItem&lt;int&gt; array parameter.
+        /// </summary>
+        public ITaskItem<int>[] TaskItemIntArrayParam
+        {
+            set
+            {
+                _taskItemIntArrayOutput = value;
+                _testTaskHost?.ParameterSet("TaskItemIntArrayParam", value);
             }
         }
 
@@ -1232,6 +1266,32 @@ namespace Microsoft.Build.UnitTests.BackEnd
             {
                 _testTaskHost?.OutputRead("AbsolutePathArrayOutput", _absolutePathArrayOutput);
                 return _absolutePathArrayOutput;
+            }
+        }
+
+        /// <summary>
+        /// A TaskItem&lt;int&gt; output.
+        /// </summary>
+        [Output]
+        public ITaskItem<int> TaskItemIntOutput
+        {
+            get
+            {
+                _testTaskHost?.OutputRead("TaskItemIntOutput", _taskItemIntOutput);
+                return _taskItemIntOutput;
+            }
+        }
+
+        /// <summary>
+        /// A TaskItem&lt;int&gt; array output.
+        /// </summary>
+        [Output]
+        public ITaskItem<int>[] TaskItemIntArrayOutput
+        {
+            get
+            {
+                _testTaskHost?.OutputRead("TaskItemIntArrayOutput", _taskItemIntArrayOutput);
+                return _taskItemIntArrayOutput;
             }
         }
 

--- a/src/Build.UnitTests/BackEnd/TaskExecutionHost_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/TaskExecutionHost_Tests.cs
@@ -20,6 +20,7 @@ using Microsoft.Build.Execution;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
 using Microsoft.Build.Shared.Debugging;
+using Microsoft.Build.Utilities;
 using Shouldly;
 using Xunit;
 using InvalidProjectFileException = Microsoft.Build.Exceptions.InvalidProjectFileException;
@@ -564,6 +565,99 @@ namespace Microsoft.Build.UnitTests.BackEnd
 
         #endregion
 
+        #region TaskItem<T> Params
+
+        /// <summary>
+        /// Validate that setting a TaskItem&lt;int&gt; parameter with a valid integer works.
+        /// </summary>
+        [Fact]
+        public void TestSetTaskItemIntParam()
+        {
+            ValidateTaskParameter("TaskItemIntParam", "42", new Microsoft.Build.Utilities.TaskItem<int>(42));
+        }
+
+        /// <summary>
+        /// Validate that setting the parameter with an empty value does not cause it to be set.
+        /// </summary>
+        [Fact]
+        public void TestSetTaskItemIntParamEmptyAttribute()
+        {
+            ValidateTaskParameterNotSet("TaskItemIntParam", "");
+        }
+
+        /// <summary>
+        /// Validate that setting the parameter with a property which evaluates to an empty value does not cause it to be set.
+        /// </summary>
+        [Fact]
+        public void TestSetTaskItemIntParamEmptyProperty()
+        {
+            ValidateTaskParameterNotSet("TaskItemIntParam", "$(NonExistentProperty)");
+        }
+
+        /// <summary>
+        /// Validate that setting the parameter with an item which evaluates to an empty value does not cause it to be set.
+        /// </summary>
+        [Fact]
+        public void TestSetTaskItemIntParamEmptyItem()
+        {
+            ValidateTaskParameterNotSet("TaskItemIntParam", "@(NonExistentItem)");
+        }
+
+        #endregion
+
+        #region TaskItem<T> Array Params
+
+        /// <summary>
+        /// Validate that setting a TaskItem&lt;int&gt; array with a single value sets the correct value.
+        /// </summary>
+        [Fact]
+        public void TestSetTaskItemIntArrayParam()
+        {
+            ValidateTaskParameterArray("TaskItemIntArrayParam", "42", new Microsoft.Build.Utilities.TaskItem<int>[] { new Microsoft.Build.Utilities.TaskItem<int>(42) });
+        }
+
+        /// <summary>
+        /// Validate that setting a TaskItem&lt;int&gt; array with multiple values sets the correct values.
+        /// </summary>
+        [Fact]
+        public void TestSetTaskItemIntArrayParamMultiple()
+        {
+            ValidateTaskParameterArray("TaskItemIntArrayParam", "10;20;30", new Microsoft.Build.Utilities.TaskItem<int>[] {
+                new Microsoft.Build.Utilities.TaskItem<int>(10),
+                new Microsoft.Build.Utilities.TaskItem<int>(20),
+                new Microsoft.Build.Utilities.TaskItem<int>(30)
+            });
+        }
+
+        /// <summary>
+        /// Validate that setting the parameter with an empty value does not cause it to be set.
+        /// </summary>
+        [Fact]
+        public void TestSetTaskItemIntArrayParamEmptyAttribute()
+        {
+            ValidateTaskParameterNotSet("TaskItemIntArrayParam", "");
+        }
+
+        /// <summary>
+        /// Validate that setting the parameter with a property which evaluates to an empty value does not cause it to be set.
+        /// </summary>
+        [Fact]
+        public void TestSetTaskItemIntArrayParamEmptyProperty()
+        {
+            ValidateTaskParameterNotSet("TaskItemIntArrayParam", "$(NonExistentProperty)");
+        }
+
+        /// <summary>
+        /// Validate that setting the parameter with an item which evaluates to an empty value does not cause it to be set.
+        /// </summary>
+        [Fact]
+        public void TestSetTaskItemIntArrayParamEmptyItem()
+        {
+            ValidateTaskParameterNotSet("TaskItemIntArrayParam", "@(NonExistentItem)");
+        }
+
+        #endregion
+
         #region ITaskItem Params
 
         /// <summary>
@@ -977,6 +1071,50 @@ namespace Microsoft.Build.UnitTests.BackEnd
         {
             SetTaskParameter("ItemArrayParam", "@(ItemListContainingTwoItems)");
             ValidateOutputProperty("ItemArrayOutput", String.Concat(_twoItems[0].ItemSpec, ";", _twoItems[1].ItemSpec));
+        }
+
+        #endregion
+
+        #region TaskItem<T> Outputs
+
+        /// <summary>
+        /// Validate that a TaskItem&lt;int&gt; output to an item produces the correct evaluated include.
+        /// </summary>
+        [Fact]
+        public void TestOutputTaskItemIntToItem()
+        {
+            SetTaskParameter("TaskItemIntParam", "42");
+            ValidateOutputItem("TaskItemIntOutput", "42");
+        }
+
+        /// <summary>
+        /// Validate that a TaskItem&lt;int&gt; output to a property produces the correct evaluated value.
+        /// </summary>
+        [Fact]
+        public void TestOutputTaskItemIntToProperty()
+        {
+            SetTaskParameter("TaskItemIntParam", "42");
+            ValidateOutputProperty("TaskItemIntOutput", "42");
+        }
+
+        /// <summary>
+        /// Validate that a TaskItem&lt;int&gt; array output to items produces the correct evaluated includes.
+        /// </summary>
+        [Fact]
+        public void TestOutputTaskItemIntArrayToItems()
+        {
+            SetTaskParameter("TaskItemIntArrayParam", "42;99");
+            ValidateOutputItems("TaskItemIntArrayOutput", new string[] { "42", "99" });
+        }
+
+        /// <summary>
+        /// Validate that a TaskItem&lt;int&gt; array output to a property produces the correct semi-colon-delimited evaluated value.
+        /// </summary>
+        [Fact]
+        public void TestOutputTaskItemIntArrayToProperty()
+        {
+            SetTaskParameter("TaskItemIntArrayParam", "42;99");
+            ValidateOutputProperty("TaskItemIntArrayOutput", "42;99");
         }
 
         #endregion

--- a/src/Build.UnitTests/BackEnd/TaskExecutionHost_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/TaskExecutionHost_Tests.cs
@@ -577,6 +577,18 @@ namespace Microsoft.Build.UnitTests.BackEnd
         }
 
         /// <summary>
+        /// Validate that parse failures from TaskItem&lt;T&gt; scalar binding are reported as invalid task parameter values.
+        /// </summary>
+        [Fact]
+        public void TestSetTaskItemIntParamInvalidValue()
+        {
+            var parameters = GetStandardParametersDictionary(true);
+            parameters["TaskItemIntParam"] = ("not-an-int", ElementLocation.Create("foo.proj"));
+
+            Should.Throw<InvalidProjectFileException>(() => _host.SetTaskParameters(parameters));
+        }
+
+        /// <summary>
         /// Validate that setting the parameter with an empty value does not cause it to be set.
         /// </summary>
         [Fact]
@@ -627,6 +639,18 @@ namespace Microsoft.Build.UnitTests.BackEnd
                 new Microsoft.Build.Utilities.TaskItem<int>(20),
                 new Microsoft.Build.Utilities.TaskItem<int>(30)
             });
+        }
+
+        /// <summary>
+        /// Validate that parse failures from TaskItem&lt;T&gt; array binding are reported as invalid task parameter values.
+        /// </summary>
+        [Fact]
+        public void TestSetTaskItemIntArrayParamInvalidValue()
+        {
+            var parameters = GetStandardParametersDictionary(true);
+            parameters["TaskItemIntArrayParam"] = ("10;not-an-int", ElementLocation.Create("foo.proj"));
+
+            Should.Throw<InvalidProjectFileException>(() => _host.SetTaskParameters(parameters));
         }
 
         /// <summary>

--- a/src/Build.UnitTests/BackEnd/TaskExecutionHost_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/TaskExecutionHost_Tests.cs
@@ -658,6 +658,384 @@ namespace Microsoft.Build.UnitTests.BackEnd
 
         #endregion
 
+        #region FileInfo Params
+
+        /// <summary>
+        /// Validate that setting a FileInfo parameter with a valid file path works.
+        /// </summary>
+        [Fact]
+        public void TestSetFileInfoParam()
+        {
+            string filePath = NativeMethodsShared.IsWindows ? @"C:\temp\file.txt" : "/tmp/file.txt";
+            ValidateTaskParameter("FileInfoParam", filePath, new FileInfo(filePath));
+        }
+
+        /// <summary>
+        /// Validate that setting the parameter with an empty value does not cause it to be set.
+        /// </summary>
+        [Fact]
+        public void TestSetFileInfoParamEmptyAttribute()
+        {
+            ValidateTaskParameterNotSet("FileInfoParam", "");
+        }
+
+        /// <summary>
+        /// Validate that setting the parameter with a property which evaluates to an empty value does not cause it to be set.
+        /// </summary>
+        [Fact]
+        public void TestSetFileInfoParamEmptyProperty()
+        {
+            ValidateTaskParameterNotSet("FileInfoParam", "$(NonExistentProperty)");
+        }
+
+        /// <summary>
+        /// Validate that setting the parameter with an item which evaluates to an empty value does not cause it to be set.
+        /// </summary>
+        [Fact]
+        public void TestSetFileInfoParamEmptyItem()
+        {
+            ValidateTaskParameterNotSet("FileInfoParam", "@(NonExistentItem)");
+        }
+
+        #endregion
+
+        #region FileInfo Array Params
+
+        /// <summary>
+        /// Validate that setting a FileInfo array with a single value sets the correct value.
+        /// </summary>
+        [Fact]
+        public void TestSetFileInfoArrayParam()
+        {
+            string filePath = NativeMethodsShared.IsWindows ? @"C:\temp\file.txt" : "/tmp/file.txt";
+            ValidateTaskParameterArray("FileInfoArrayParam", filePath, new FileInfo[] { new FileInfo(filePath) });
+        }
+
+        /// <summary>
+        /// Validate that setting a FileInfo array with multiple values sets the correct values.
+        /// </summary>
+        [Fact]
+        public void TestSetFileInfoArrayParamMultiple()
+        {
+            string path1 = NativeMethodsShared.IsWindows ? @"C:\temp\file1.txt" : "/tmp/file1.txt";
+            string path2 = NativeMethodsShared.IsWindows ? @"C:\temp\file2.txt" : "/tmp/file2.txt";
+            ValidateTaskParameterArray("FileInfoArrayParam", path1 + ";" + path2, new FileInfo[] { new FileInfo(path1), new FileInfo(path2) });
+        }
+
+        /// <summary>
+        /// Validate that setting the parameter with an empty value does not cause it to be set.
+        /// </summary>
+        [Fact]
+        public void TestSetFileInfoArrayParamEmptyAttribute()
+        {
+            ValidateTaskParameterNotSet("FileInfoArrayParam", "");
+        }
+
+        /// <summary>
+        /// Validate that setting the parameter with a property which evaluates to an empty value does not cause it to be set.
+        /// </summary>
+        [Fact]
+        public void TestSetFileInfoArrayParamEmptyProperty()
+        {
+            ValidateTaskParameterNotSet("FileInfoArrayParam", "$(NonExistentProperty)");
+        }
+
+        /// <summary>
+        /// Validate that setting the parameter with an item which evaluates to an empty value does not cause it to be set.
+        /// </summary>
+        [Fact]
+        public void TestSetFileInfoArrayParamEmptyItem()
+        {
+            ValidateTaskParameterNotSet("FileInfoArrayParam", "@(NonExistentItem)");
+        }
+
+        #endregion
+
+        #region DirectoryInfo Params
+
+        /// <summary>
+        /// Validate that setting a DirectoryInfo parameter with a valid directory path works.
+        /// </summary>
+        [Fact]
+        public void TestSetDirectoryInfoParam()
+        {
+            string dirPath = NativeMethodsShared.IsWindows ? @"C:\temp" : "/tmp";
+            ValidateTaskParameter("DirectoryInfoParam", dirPath, new DirectoryInfo(dirPath));
+        }
+
+        /// <summary>
+        /// Validate that setting the parameter with an empty value does not cause it to be set.
+        /// </summary>
+        [Fact]
+        public void TestSetDirectoryInfoParamEmptyAttribute()
+        {
+            ValidateTaskParameterNotSet("DirectoryInfoParam", "");
+        }
+
+        /// <summary>
+        /// Validate that setting the parameter with a property which evaluates to an empty value does not cause it to be set.
+        /// </summary>
+        [Fact]
+        public void TestSetDirectoryInfoParamEmptyProperty()
+        {
+            ValidateTaskParameterNotSet("DirectoryInfoParam", "$(NonExistentProperty)");
+        }
+
+        /// <summary>
+        /// Validate that setting the parameter with an item which evaluates to an empty value does not cause it to be set.
+        /// </summary>
+        [Fact]
+        public void TestSetDirectoryInfoParamEmptyItem()
+        {
+            ValidateTaskParameterNotSet("DirectoryInfoParam", "@(NonExistentItem)");
+        }
+
+        #endregion
+
+        #region DirectoryInfo Array Params
+
+        /// <summary>
+        /// Validate that setting a DirectoryInfo array with a single value sets the correct value.
+        /// </summary>
+        [Fact]
+        public void TestSetDirectoryInfoArrayParam()
+        {
+            string dirPath = NativeMethodsShared.IsWindows ? @"C:\temp" : "/tmp";
+            ValidateTaskParameterArray("DirectoryInfoArrayParam", dirPath, new DirectoryInfo[] { new DirectoryInfo(dirPath) });
+        }
+
+        /// <summary>
+        /// Validate that setting a DirectoryInfo array with multiple values sets the correct values.
+        /// </summary>
+        [Fact]
+        public void TestSetDirectoryInfoArrayParamMultiple()
+        {
+            string path1 = NativeMethodsShared.IsWindows ? @"C:\temp" : "/tmp";
+            string path2 = NativeMethodsShared.IsWindows ? @"C:\Windows" : "/usr";
+            ValidateTaskParameterArray("DirectoryInfoArrayParam", path1 + ";" + path2, new DirectoryInfo[] { new DirectoryInfo(path1), new DirectoryInfo(path2) });
+        }
+
+        /// <summary>
+        /// Validate that setting the parameter with an empty value does not cause it to be set.
+        /// </summary>
+        [Fact]
+        public void TestSetDirectoryInfoArrayParamEmptyAttribute()
+        {
+            ValidateTaskParameterNotSet("DirectoryInfoArrayParam", "");
+        }
+
+        /// <summary>
+        /// Validate that setting the parameter with a property which evaluates to an empty value does not cause it to be set.
+        /// </summary>
+        [Fact]
+        public void TestSetDirectoryInfoArrayParamEmptyProperty()
+        {
+            ValidateTaskParameterNotSet("DirectoryInfoArrayParam", "$(NonExistentProperty)");
+        }
+
+        /// <summary>
+        /// Validate that setting the parameter with an item which evaluates to an empty value does not cause it to be set.
+        /// </summary>
+        [Fact]
+        public void TestSetDirectoryInfoArrayParamEmptyItem()
+        {
+            ValidateTaskParameterNotSet("DirectoryInfoArrayParam", "@(NonExistentItem)");
+        }
+
+        #endregion
+
+        #region TaskItem<FileInfo> Params
+
+        /// <summary>
+        /// Validate that setting a TaskItem&lt;FileInfo&gt; parameter with a valid file path works.
+        /// </summary>
+        [Fact]
+        public void TestSetTaskItemFileInfoParam()
+        {
+            string filePath = NativeMethodsShared.IsWindows ? @"C:\temp\file.txt" : "/tmp/file.txt";
+            ValidateTaskParameter("TaskItemFileInfoParam", filePath, new Microsoft.Build.Utilities.TaskItem<FileInfo>(new FileInfo(filePath)));
+        }
+
+        /// <summary>
+        /// Validate that setting the parameter with an empty value does not cause it to be set.
+        /// </summary>
+        [Fact]
+        public void TestSetTaskItemFileInfoParamEmptyAttribute()
+        {
+            ValidateTaskParameterNotSet("TaskItemFileInfoParam", "");
+        }
+
+        /// <summary>
+        /// Validate that setting the parameter with a property which evaluates to an empty value does not cause it to be set.
+        /// </summary>
+        [Fact]
+        public void TestSetTaskItemFileInfoParamEmptyProperty()
+        {
+            ValidateTaskParameterNotSet("TaskItemFileInfoParam", "$(NonExistentProperty)");
+        }
+
+        /// <summary>
+        /// Validate that setting the parameter with an item which evaluates to an empty value does not cause it to be set.
+        /// </summary>
+        [Fact]
+        public void TestSetTaskItemFileInfoParamEmptyItem()
+        {
+            ValidateTaskParameterNotSet("TaskItemFileInfoParam", "@(NonExistentItem)");
+        }
+
+        #endregion
+
+        #region TaskItem<FileInfo> Array Params
+
+        /// <summary>
+        /// Validate that setting a TaskItem&lt;FileInfo&gt; array with a single value sets the correct value.
+        /// </summary>
+        [Fact]
+        public void TestSetTaskItemFileInfoArrayParam()
+        {
+            string filePath = NativeMethodsShared.IsWindows ? @"C:\temp\file.txt" : "/tmp/file.txt";
+            ValidateTaskParameterArray("TaskItemFileInfoArrayParam", filePath, new Microsoft.Build.Utilities.TaskItem<FileInfo>[] { new Microsoft.Build.Utilities.TaskItem<FileInfo>(new FileInfo(filePath)) });
+        }
+
+        /// <summary>
+        /// Validate that setting a TaskItem&lt;FileInfo&gt; array with multiple values sets the correct values.
+        /// </summary>
+        [Fact]
+        public void TestSetTaskItemFileInfoArrayParamMultiple()
+        {
+            string path1 = NativeMethodsShared.IsWindows ? @"C:\temp\file1.txt" : "/tmp/file1.txt";
+            string path2 = NativeMethodsShared.IsWindows ? @"C:\temp\file2.txt" : "/tmp/file2.txt";
+            ValidateTaskParameterArray("TaskItemFileInfoArrayParam", path1 + ";" + path2, new Microsoft.Build.Utilities.TaskItem<FileInfo>[] {
+                new Microsoft.Build.Utilities.TaskItem<FileInfo>(new FileInfo(path1)),
+                new Microsoft.Build.Utilities.TaskItem<FileInfo>(new FileInfo(path2))
+            });
+        }
+
+        /// <summary>
+        /// Validate that setting the parameter with an empty value does not cause it to be set.
+        /// </summary>
+        [Fact]
+        public void TestSetTaskItemFileInfoArrayParamEmptyAttribute()
+        {
+            ValidateTaskParameterNotSet("TaskItemFileInfoArrayParam", "");
+        }
+
+        /// <summary>
+        /// Validate that setting the parameter with a property which evaluates to an empty value does not cause it to be set.
+        /// </summary>
+        [Fact]
+        public void TestSetTaskItemFileInfoArrayParamEmptyProperty()
+        {
+            ValidateTaskParameterNotSet("TaskItemFileInfoArrayParam", "$(NonExistentProperty)");
+        }
+
+        /// <summary>
+        /// Validate that setting the parameter with an item which evaluates to an empty value does not cause it to be set.
+        /// </summary>
+        [Fact]
+        public void TestSetTaskItemFileInfoArrayParamEmptyItem()
+        {
+            ValidateTaskParameterNotSet("TaskItemFileInfoArrayParam", "@(NonExistentItem)");
+        }
+
+        #endregion
+
+        #region TaskItem<DirectoryInfo> Params
+
+        /// <summary>
+        /// Validate that setting a TaskItem&lt;DirectoryInfo&gt; parameter with a valid directory path works.
+        /// </summary>
+        [Fact]
+        public void TestSetTaskItemDirectoryInfoParam()
+        {
+            string dirPath = NativeMethodsShared.IsWindows ? @"C:\temp" : "/tmp";
+            ValidateTaskParameter("TaskItemDirectoryInfoParam", dirPath, new Microsoft.Build.Utilities.TaskItem<DirectoryInfo>(new DirectoryInfo(dirPath)));
+        }
+
+        /// <summary>
+        /// Validate that setting the parameter with an empty value does not cause it to be set.
+        /// </summary>
+        [Fact]
+        public void TestSetTaskItemDirectoryInfoParamEmptyAttribute()
+        {
+            ValidateTaskParameterNotSet("TaskItemDirectoryInfoParam", "");
+        }
+
+        /// <summary>
+        /// Validate that setting the parameter with a property which evaluates to an empty value does not cause it to be set.
+        /// </summary>
+        [Fact]
+        public void TestSetTaskItemDirectoryInfoParamEmptyProperty()
+        {
+            ValidateTaskParameterNotSet("TaskItemDirectoryInfoParam", "$(NonExistentProperty)");
+        }
+
+        /// <summary>
+        /// Validate that setting the parameter with an item which evaluates to an empty value does not cause it to be set.
+        /// </summary>
+        [Fact]
+        public void TestSetTaskItemDirectoryInfoParamEmptyItem()
+        {
+            ValidateTaskParameterNotSet("TaskItemDirectoryInfoParam", "@(NonExistentItem)");
+        }
+
+        #endregion
+
+        #region TaskItem<DirectoryInfo> Array Params
+
+        /// <summary>
+        /// Validate that setting a TaskItem&lt;DirectoryInfo&gt; array with a single value sets the correct value.
+        /// </summary>
+        [Fact]
+        public void TestSetTaskItemDirectoryInfoArrayParam()
+        {
+            string dirPath = NativeMethodsShared.IsWindows ? @"C:\temp" : "/tmp";
+            ValidateTaskParameterArray("TaskItemDirectoryInfoArrayParam", dirPath, new Microsoft.Build.Utilities.TaskItem<DirectoryInfo>[] { new Microsoft.Build.Utilities.TaskItem<DirectoryInfo>(new DirectoryInfo(dirPath)) });
+        }
+
+        /// <summary>
+        /// Validate that setting a TaskItem&lt;DirectoryInfo&gt; array with multiple values sets the correct values.
+        /// </summary>
+        [Fact]
+        public void TestSetTaskItemDirectoryInfoArrayParamMultiple()
+        {
+            string path1 = NativeMethodsShared.IsWindows ? @"C:\temp" : "/tmp";
+            string path2 = NativeMethodsShared.IsWindows ? @"C:\Windows" : "/usr";
+            ValidateTaskParameterArray("TaskItemDirectoryInfoArrayParam", path1 + ";" + path2, new Microsoft.Build.Utilities.TaskItem<DirectoryInfo>[] {
+                new Microsoft.Build.Utilities.TaskItem<DirectoryInfo>(new DirectoryInfo(path1)),
+                new Microsoft.Build.Utilities.TaskItem<DirectoryInfo>(new DirectoryInfo(path2))
+            });
+        }
+
+        /// <summary>
+        /// Validate that setting the parameter with an empty value does not cause it to be set.
+        /// </summary>
+        [Fact]
+        public void TestSetTaskItemDirectoryInfoArrayParamEmptyAttribute()
+        {
+            ValidateTaskParameterNotSet("TaskItemDirectoryInfoArrayParam", "");
+        }
+
+        /// <summary>
+        /// Validate that setting the parameter with a property which evaluates to an empty value does not cause it to be set.
+        /// </summary>
+        [Fact]
+        public void TestSetTaskItemDirectoryInfoArrayParamEmptyProperty()
+        {
+            ValidateTaskParameterNotSet("TaskItemDirectoryInfoArrayParam", "$(NonExistentProperty)");
+        }
+
+        /// <summary>
+        /// Validate that setting the parameter with an item which evaluates to an empty value does not cause it to be set.
+        /// </summary>
+        [Fact]
+        public void TestSetTaskItemDirectoryInfoArrayParamEmptyItem()
+        {
+            ValidateTaskParameterNotSet("TaskItemDirectoryInfoArrayParam", "@(NonExistentItem)");
+        }
+
+        #endregion
+
         #region ITaskItem Params
 
         /// <summary>
@@ -1592,7 +1970,31 @@ namespace Microsoft.Build.UnitTests.BackEnd
             SetTaskParameter(parameterName, value);
 
             Assert.True(_parametersSetOnTask.ContainsKey(parameterName));
-            Assert.Equal(expectedValue, _parametersSetOnTask[parameterName]);
+
+            object actualValue = _parametersSetOnTask[parameterName];
+
+            // Special handling for FileInfo and DirectoryInfo - compare FullName instead of object equality
+            if (expectedValue is FileInfo expectedFileInfo && actualValue is FileInfo actualFileInfo)
+            {
+                Assert.Equal(expectedFileInfo.FullName, actualFileInfo.FullName);
+            }
+            else if (expectedValue is DirectoryInfo expectedDirInfo && actualValue is DirectoryInfo actualDirInfo)
+            {
+                Assert.Equal(expectedDirInfo.FullName, actualDirInfo.FullName);
+            }
+            // Special handling for TaskItem<FileInfo> and TaskItem<DirectoryInfo> - compare FullName through ItemSpec
+            else if (expectedValue is ITaskItem<FileInfo> expectedTaskItemFileInfo && actualValue is ITaskItem<FileInfo> actualTaskItemFileInfo)
+            {
+                Assert.Equal(expectedTaskItemFileInfo.Value.FullName, actualTaskItemFileInfo.Value.FullName);
+            }
+            else if (expectedValue is ITaskItem<DirectoryInfo> expectedTaskItemDirInfo && actualValue is ITaskItem<DirectoryInfo> actualTaskItemDirInfo)
+            {
+                Assert.Equal(expectedTaskItemDirInfo.Value.FullName, actualTaskItemDirInfo.Value.FullName);
+            }
+            else
+            {
+                Assert.Equal(expectedValue, actualValue);
+            }
         }
 
         /// <summary>
@@ -1687,7 +2089,31 @@ namespace Microsoft.Build.UnitTests.BackEnd
             Assert.Equal(expectedArray.Length, actualArray.Length);
             for (int i = 0; i < expectedArray.Length; i++)
             {
-                Assert.Equal(expectedArray.GetValue(i), actualArray.GetValue(i));
+                object expected = expectedArray.GetValue(i);
+                object actual = actualArray.GetValue(i);
+
+                // Special handling for FileInfo and DirectoryInfo - compare FullName instead of object equality
+                if (expected is FileInfo expectedFileInfo && actual is FileInfo actualFileInfo)
+                {
+                    Assert.Equal(expectedFileInfo.FullName, actualFileInfo.FullName);
+                }
+                else if (expected is DirectoryInfo expectedDirInfo && actual is DirectoryInfo actualDirInfo)
+                {
+                    Assert.Equal(expectedDirInfo.FullName, actualDirInfo.FullName);
+                }
+                // Special handling for TaskItem<FileInfo> and TaskItem<DirectoryInfo> - compare FullName through ItemSpec
+                else if (expected is ITaskItem<FileInfo> expectedTaskItemFileInfo && actual is ITaskItem<FileInfo> actualTaskItemFileInfo)
+                {
+                    Assert.Equal(expectedTaskItemFileInfo.Value.FullName, actualTaskItemFileInfo.Value.FullName);
+                }
+                else if (expected is ITaskItem<DirectoryInfo> expectedTaskItemDirInfo && actual is ITaskItem<DirectoryInfo> actualTaskItemDirInfo)
+                {
+                    Assert.Equal(expectedTaskItemDirInfo.Value.FullName, actualTaskItemDirInfo.Value.FullName);
+                }
+                else
+                {
+                    Assert.Equal(expected, actual);
+                }
             }
         }
 

--- a/src/Build.UnitTests/BackEnd/TaskExecutionHost_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/TaskExecutionHost_Tests.cs
@@ -471,6 +471,99 @@ namespace Microsoft.Build.UnitTests.BackEnd
 
         #endregion
 
+        #region AbsolutePath Params
+
+        /// <summary>
+        /// Validate that setting an AbsolutePath parameter with a valid absolute path works.
+        /// </summary>
+        [Fact]
+        public void TestSetAbsolutePathParam()
+        {
+            string absolutePath = NativeMethodsShared.IsWindows ? @"C:\temp\file.txt" : "/tmp/file.txt";
+            ValidateTaskParameter("AbsolutePathParam", absolutePath, new AbsolutePath(absolutePath));
+        }
+
+        /// <summary>
+        /// Validate that setting the parameter with an empty value does not cause it to be set.
+        /// </summary>
+        [Fact]
+        public void TestSetAbsolutePathParamEmptyAttribute()
+        {
+            ValidateTaskParameterNotSet("AbsolutePathParam", "");
+        }
+
+        /// <summary>
+        /// Validate that setting the parameter with a property which evaluates to an empty value does not cause it to be set.
+        /// </summary>
+        [Fact]
+        public void TestSetAbsolutePathParamEmptyProperty()
+        {
+            ValidateTaskParameterNotSet("AbsolutePathParam", "$(NonExistentProperty)");
+        }
+
+        /// <summary>
+        /// Validate that setting the parameter with an item which evaluates to an empty value does not cause it to be set.
+        /// </summary>
+        [Fact]
+        public void TestSetAbsolutePathParamEmptyItem()
+        {
+            ValidateTaskParameterNotSet("AbsolutePathParam", "@(NonExistentItem)");
+        }
+
+        #endregion
+
+        #region AbsolutePath Array Params
+
+        /// <summary>
+        /// Validate that setting an AbsolutePath array with a single value sets the correct value.
+        /// </summary>
+        [Fact]
+        public void TestSetAbsolutePathArrayParam()
+        {
+            string absolutePath = NativeMethodsShared.IsWindows ? @"C:\temp\file.txt" : "/tmp/file.txt";
+            ValidateTaskParameterArray("AbsolutePathArrayParam", absolutePath, new AbsolutePath[] { new AbsolutePath(absolutePath) });
+        }
+
+        /// <summary>
+        /// Validate that setting an AbsolutePath array with multiple values sets the correct values.
+        /// </summary>
+        [Fact]
+        public void TestSetAbsolutePathArrayParamMultiple()
+        {
+            string path1 = NativeMethodsShared.IsWindows ? @"C:\temp\file1.txt" : "/tmp/file1.txt";
+            string path2 = NativeMethodsShared.IsWindows ? @"C:\temp\file2.txt" : "/tmp/file2.txt";
+            ValidateTaskParameterArray("AbsolutePathArrayParam", path1 + ";" + path2, new AbsolutePath[] { new AbsolutePath(path1), new AbsolutePath(path2) });
+        }
+
+        /// <summary>
+        /// Validate that setting the parameter with an empty value does not cause it to be set.
+        /// </summary>
+        [Fact]
+        public void TestSetAbsolutePathArrayParamEmptyAttribute()
+        {
+            ValidateTaskParameterNotSet("AbsolutePathArrayParam", "");
+        }
+
+        /// <summary>
+        /// Validate that setting the parameter with a property which evaluates to an empty value does not cause it to be set.
+        /// </summary>
+        [Fact]
+        public void TestSetAbsolutePathArrayParamEmptyProperty()
+        {
+            ValidateTaskParameterNotSet("AbsolutePathArrayParam", "$(NonExistentProperty)");
+        }
+
+        /// <summary>
+        /// Validate that setting the parameter with an item which evaluates to an empty value does not cause it to be set.
+        /// </summary>
+        [Fact]
+        public void TestSetAbsolutePathArrayParamEmptyItem()
+        {
+            ValidateTaskParameterNotSet("AbsolutePathArrayParam", "@(NonExistentItem)");
+        }
+
+        #endregion
+
         #region ITaskItem Params
 
         /// <summary>

--- a/src/Build.UnitTests/BackEnd/TaskParameterTypeVerifier_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/TaskParameterTypeVerifier_Tests.cs
@@ -1,0 +1,326 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using Microsoft.Build.BackEnd;
+using Microsoft.Build.Framework;
+using Xunit;
+
+#nullable disable
+
+namespace Microsoft.Build.UnitTests.BackEnd
+{
+    /// <summary>
+    /// Tests for TaskParameterTypeVerifier class
+    /// </summary>
+    public class TaskParameterTypeVerifier_Tests
+    {
+        #region IsValidScalarInputParameter Tests
+
+        [Fact]
+        public void IsValidScalarInputParameter_String_ReturnsTrue()
+        {
+            Assert.True(TaskParameterTypeVerifier.IsValidScalarInputParameter(typeof(string)));
+        }
+
+        [Fact]
+        public void IsValidScalarInputParameter_ITaskItem_ReturnsTrue()
+        {
+            Assert.True(TaskParameterTypeVerifier.IsValidScalarInputParameter(typeof(ITaskItem)));
+        }
+
+        [Fact]
+        public void IsValidScalarInputParameter_Bool_ReturnsTrue()
+        {
+            Assert.True(TaskParameterTypeVerifier.IsValidScalarInputParameter(typeof(bool)));
+        }
+
+        [Fact]
+        public void IsValidScalarInputParameter_Int_ReturnsTrue()
+        {
+            Assert.True(TaskParameterTypeVerifier.IsValidScalarInputParameter(typeof(int)));
+        }
+
+        [Fact]
+        public void IsValidScalarInputParameter_Double_ReturnsTrue()
+        {
+            Assert.True(TaskParameterTypeVerifier.IsValidScalarInputParameter(typeof(double)));
+        }
+
+        [Fact]
+        public void IsValidScalarInputParameter_DateTime_ReturnsTrue()
+        {
+            Assert.True(TaskParameterTypeVerifier.IsValidScalarInputParameter(typeof(DateTime)));
+        }
+
+        [Fact]
+        public void IsValidScalarInputParameter_AbsolutePath_ReturnsTrue()
+        {
+            Assert.True(TaskParameterTypeVerifier.IsValidScalarInputParameter(typeof(AbsolutePath)));
+        }
+
+        [Fact]
+        public void IsValidScalarInputParameter_Object_ReturnsFalse()
+        {
+            Assert.False(TaskParameterTypeVerifier.IsValidScalarInputParameter(typeof(object)));
+        }
+
+        [Fact]
+        public void IsValidScalarInputParameter_StringArray_ReturnsFalse()
+        {
+            Assert.False(TaskParameterTypeVerifier.IsValidScalarInputParameter(typeof(string[])));
+        }
+
+        #endregion
+
+        #region IsValidVectorInputParameter Tests
+
+        [Fact]
+        public void IsValidVectorInputParameter_StringArray_ReturnsTrue()
+        {
+            Assert.True(TaskParameterTypeVerifier.IsValidVectorInputParameter(typeof(string[])));
+        }
+
+        [Fact]
+        public void IsValidVectorInputParameter_ITaskItemArray_ReturnsTrue()
+        {
+            Assert.True(TaskParameterTypeVerifier.IsValidVectorInputParameter(typeof(ITaskItem[])));
+        }
+
+        [Fact]
+        public void IsValidVectorInputParameter_BoolArray_ReturnsTrue()
+        {
+            Assert.True(TaskParameterTypeVerifier.IsValidVectorInputParameter(typeof(bool[])));
+        }
+
+        [Fact]
+        public void IsValidVectorInputParameter_IntArray_ReturnsTrue()
+        {
+            Assert.True(TaskParameterTypeVerifier.IsValidVectorInputParameter(typeof(int[])));
+        }
+
+        [Fact]
+        public void IsValidVectorInputParameter_DoubleArray_ReturnsTrue()
+        {
+            Assert.True(TaskParameterTypeVerifier.IsValidVectorInputParameter(typeof(double[])));
+        }
+
+        [Fact]
+        public void IsValidVectorInputParameter_DateTimeArray_ReturnsTrue()
+        {
+            Assert.True(TaskParameterTypeVerifier.IsValidVectorInputParameter(typeof(DateTime[])));
+        }
+
+        [Fact]
+        public void IsValidVectorInputParameter_AbsolutePathArray_ReturnsTrue()
+        {
+            Assert.True(TaskParameterTypeVerifier.IsValidVectorInputParameter(typeof(AbsolutePath[])));
+        }
+
+        [Fact]
+        public void IsValidVectorInputParameter_String_ReturnsFalse()
+        {
+            Assert.False(TaskParameterTypeVerifier.IsValidVectorInputParameter(typeof(string)));
+        }
+
+        [Fact]
+        public void IsValidVectorInputParameter_ObjectArray_ReturnsFalse()
+        {
+            Assert.False(TaskParameterTypeVerifier.IsValidVectorInputParameter(typeof(object[])));
+        }
+
+        #endregion
+
+        #region IsValueTypeOutputParameter Tests
+
+        [Fact]
+        public void IsValueTypeOutputParameter_String_ReturnsTrue()
+        {
+            Assert.True(TaskParameterTypeVerifier.IsValueTypeOutputParameter(typeof(string)));
+        }
+
+        [Fact]
+        public void IsValueTypeOutputParameter_Bool_ReturnsTrue()
+        {
+            Assert.True(TaskParameterTypeVerifier.IsValueTypeOutputParameter(typeof(bool)));
+        }
+
+        [Fact]
+        public void IsValueTypeOutputParameter_Int_ReturnsTrue()
+        {
+            Assert.True(TaskParameterTypeVerifier.IsValueTypeOutputParameter(typeof(int)));
+        }
+
+        [Fact]
+        public void IsValueTypeOutputParameter_AbsolutePath_ReturnsTrue()
+        {
+            Assert.True(TaskParameterTypeVerifier.IsValueTypeOutputParameter(typeof(AbsolutePath)));
+        }
+
+        [Fact]
+        public void IsValueTypeOutputParameter_StringArray_ReturnsTrue()
+        {
+            Assert.True(TaskParameterTypeVerifier.IsValueTypeOutputParameter(typeof(string[])));
+        }
+
+        [Fact]
+        public void IsValueTypeOutputParameter_BoolArray_ReturnsTrue()
+        {
+            Assert.True(TaskParameterTypeVerifier.IsValueTypeOutputParameter(typeof(bool[])));
+        }
+
+        [Fact]
+        public void IsValueTypeOutputParameter_IntArray_ReturnsTrue()
+        {
+            Assert.True(TaskParameterTypeVerifier.IsValueTypeOutputParameter(typeof(int[])));
+        }
+
+        [Fact]
+        public void IsValueTypeOutputParameter_AbsolutePathArray_ReturnsTrue()
+        {
+            Assert.True(TaskParameterTypeVerifier.IsValueTypeOutputParameter(typeof(AbsolutePath[])));
+        }
+
+        [Fact]
+        public void IsValueTypeOutputParameter_ITaskItem_ReturnsFalse()
+        {
+            Assert.False(TaskParameterTypeVerifier.IsValueTypeOutputParameter(typeof(ITaskItem)));
+        }
+
+        [Fact]
+        public void IsValueTypeOutputParameter_Object_ReturnsFalse()
+        {
+            Assert.False(TaskParameterTypeVerifier.IsValueTypeOutputParameter(typeof(object)));
+        }
+
+        #endregion
+
+        #region IsValidInputParameter Tests
+
+        [Fact]
+        public void IsValidInputParameter_String_ReturnsTrue()
+        {
+            Assert.True(TaskParameterTypeVerifier.IsValidInputParameter(typeof(string)));
+        }
+
+        [Fact]
+        public void IsValidInputParameter_ITaskItem_ReturnsTrue()
+        {
+            Assert.True(TaskParameterTypeVerifier.IsValidInputParameter(typeof(ITaskItem)));
+        }
+
+        [Fact]
+        public void IsValidInputParameter_Bool_ReturnsTrue()
+        {
+            Assert.True(TaskParameterTypeVerifier.IsValidInputParameter(typeof(bool)));
+        }
+
+        [Fact]
+        public void IsValidInputParameter_AbsolutePath_ReturnsTrue()
+        {
+            Assert.True(TaskParameterTypeVerifier.IsValidInputParameter(typeof(AbsolutePath)));
+        }
+
+        [Fact]
+        public void IsValidInputParameter_StringArray_ReturnsTrue()
+        {
+            Assert.True(TaskParameterTypeVerifier.IsValidInputParameter(typeof(string[])));
+        }
+
+        [Fact]
+        public void IsValidInputParameter_ITaskItemArray_ReturnsTrue()
+        {
+            Assert.True(TaskParameterTypeVerifier.IsValidInputParameter(typeof(ITaskItem[])));
+        }
+
+        [Fact]
+        public void IsValidInputParameter_BoolArray_ReturnsTrue()
+        {
+            Assert.True(TaskParameterTypeVerifier.IsValidInputParameter(typeof(bool[])));
+        }
+
+        [Fact]
+        public void IsValidInputParameter_AbsolutePathArray_ReturnsTrue()
+        {
+            Assert.True(TaskParameterTypeVerifier.IsValidInputParameter(typeof(AbsolutePath[])));
+        }
+
+        [Fact]
+        public void IsValidInputParameter_Object_ReturnsFalse()
+        {
+            Assert.False(TaskParameterTypeVerifier.IsValidInputParameter(typeof(object)));
+        }
+
+        [Fact]
+        public void IsValidInputParameter_ObjectArray_ReturnsFalse()
+        {
+            Assert.False(TaskParameterTypeVerifier.IsValidInputParameter(typeof(object[])));
+        }
+
+        #endregion
+
+        #region IsValidOutputParameter Tests
+
+        [Fact]
+        public void IsValidOutputParameter_String_ReturnsTrue()
+        {
+            Assert.True(TaskParameterTypeVerifier.IsValidOutputParameter(typeof(string)));
+        }
+
+        [Fact]
+        public void IsValidOutputParameter_ITaskItem_ReturnsTrue()
+        {
+            Assert.True(TaskParameterTypeVerifier.IsValidOutputParameter(typeof(ITaskItem)));
+        }
+
+        [Fact]
+        public void IsValidOutputParameter_Bool_ReturnsTrue()
+        {
+            Assert.True(TaskParameterTypeVerifier.IsValidOutputParameter(typeof(bool)));
+        }
+
+        [Fact]
+        public void IsValidOutputParameter_AbsolutePath_ReturnsTrue()
+        {
+            Assert.True(TaskParameterTypeVerifier.IsValidOutputParameter(typeof(AbsolutePath)));
+        }
+
+        [Fact]
+        public void IsValidOutputParameter_StringArray_ReturnsTrue()
+        {
+            Assert.True(TaskParameterTypeVerifier.IsValidOutputParameter(typeof(string[])));
+        }
+
+        [Fact]
+        public void IsValidOutputParameter_ITaskItemArray_ReturnsTrue()
+        {
+            Assert.True(TaskParameterTypeVerifier.IsValidOutputParameter(typeof(ITaskItem[])));
+        }
+
+        [Fact]
+        public void IsValidOutputParameter_BoolArray_ReturnsTrue()
+        {
+            Assert.True(TaskParameterTypeVerifier.IsValidOutputParameter(typeof(bool[])));
+        }
+
+        [Fact]
+        public void IsValidOutputParameter_AbsolutePathArray_ReturnsTrue()
+        {
+            Assert.True(TaskParameterTypeVerifier.IsValidOutputParameter(typeof(AbsolutePath[])));
+        }
+
+        [Fact]
+        public void IsValidOutputParameter_Object_ReturnsFalse()
+        {
+            Assert.False(TaskParameterTypeVerifier.IsValidOutputParameter(typeof(object)));
+        }
+
+        [Fact]
+        public void IsValidOutputParameter_ObjectArray_ReturnsFalse()
+        {
+            Assert.False(TaskParameterTypeVerifier.IsValidOutputParameter(typeof(object[])));
+        }
+
+        #endregion
+    }
+}

--- a/src/Build.UnitTests/BackEnd/TaskParameterTypeVerifier_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/TaskParameterTypeVerifier_Tests.cs
@@ -321,6 +321,44 @@ namespace Microsoft.Build.UnitTests.BackEnd
             Assert.False(TaskParameterTypeVerifier.IsValidOutputParameter(typeof(object[])));
         }
 
+        // ─── ITaskItem<T> and ITaskItem<T>[] coverage ───────────────────────────
+
+        [Fact]
+        public void IsValidScalarInputParameter_ITaskItemOfT_ReturnsTrue()
+        {
+            Assert.True(TaskParameterTypeVerifier.IsValidScalarInputParameter(typeof(ITaskItem<int>)));
+        }
+
+        [Fact]
+        public void IsValidVectorInputParameter_ITaskItemOfTArray_ReturnsTrue()
+        {
+            Assert.True(TaskParameterTypeVerifier.IsValidVectorInputParameter(typeof(ITaskItem<int>[])));
+        }
+
+        [Fact]
+        public void IsAssignableToITaskItem_ITaskItemOfT_ReturnsTrue()
+        {
+            Assert.True(TaskParameterTypeVerifier.IsAssignableToITaskItem(typeof(ITaskItem<int>)));
+        }
+
+        [Fact]
+        public void IsAssignableToITaskItem_ITaskItemOfTArray_ReturnsTrue()
+        {
+            Assert.True(TaskParameterTypeVerifier.IsAssignableToITaskItem(typeof(ITaskItem<int>[])));
+        }
+
+        [Fact]
+        public void IsValidOutputParameter_ITaskItemOfT_ReturnsTrue()
+        {
+            Assert.True(TaskParameterTypeVerifier.IsValidOutputParameter(typeof(ITaskItem<int>)));
+        }
+
+        [Fact]
+        public void IsValidOutputParameter_ITaskItemOfTArray_ReturnsTrue()
+        {
+            Assert.True(TaskParameterTypeVerifier.IsValidOutputParameter(typeof(ITaskItem<int>[])));
+        }
+
         #endregion
     }
 }

--- a/src/Build.UnitTests/BackEnd/TaskParameterTypeVerifier_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/TaskParameterTypeVerifier_Tests.cs
@@ -4,6 +4,8 @@
 using System;
 using Microsoft.Build.BackEnd;
 using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Shouldly;
 using Xunit;
 
 #nullable disable
@@ -357,6 +359,19 @@ namespace Microsoft.Build.UnitTests.BackEnd
         public void IsValidOutputParameter_ITaskItemOfTArray_ReturnsTrue()
         {
             Assert.True(TaskParameterTypeVerifier.IsValidOutputParameter(typeof(ITaskItem<int>[])));
+        }
+
+        [Fact]
+        public void IsAssignableToITaskItem_TaskItemOfTArray_ReturnsTrue()
+        {
+            typeof(ITaskItem[]).IsAssignableFrom(typeof(TaskItem<int>[])).ShouldBeFalse();
+            TaskParameterTypeVerifier.IsAssignableToITaskItem(typeof(TaskItem<int>[])).ShouldBeTrue();
+        }
+
+        [Fact]
+        public void IsValidOutputParameter_TaskItemOfTArray_ReturnsTrue()
+        {
+            TaskParameterTypeVerifier.IsValidOutputParameter(typeof(TaskItem<int>[])).ShouldBeTrue();
         }
 
         #endregion

--- a/src/Build/BackEnd/TaskExecutionHost/TaskExecutionHost.cs
+++ b/src/Build/BackEnd/TaskExecutionHost/TaskExecutionHost.cs
@@ -6,6 +6,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 #if FEATURE_APPDOMAIN
@@ -756,7 +757,7 @@ namespace Microsoft.Build.BackEnd
         #region Local Methods
 
         /// <summary>
-        /// Checks if a type is TaskItem&lt;T&gt; where T is a value type.
+        /// Checks if a type is TaskItem&lt;T&gt; where T is a value type, FileInfo, or DirectoryInfo.
         /// </summary>
         private static bool IsTaskItemOfT(Type parameterType)
         {
@@ -772,7 +773,13 @@ namespace Microsoft.Build.BackEnd
             }
 
             Type[] genericArguments = parameterType.GetGenericArguments();
-            return genericArguments.Length == 1 && genericArguments[0].GetTypeInfo().IsValueType;
+            if (genericArguments.Length != 1)
+            {
+                return false;
+            }
+
+            Type typeArg = genericArguments[0];
+            return typeArg.GetTypeInfo().IsValueType || typeArg == typeof(FileInfo) || typeArg == typeof(DirectoryInfo);
         }
 
         /// <summary>
@@ -810,6 +817,20 @@ namespace Microsoft.Build.BackEnd
                 return InternalSetTaskParameter(parameter, TaskEnvironment.GetAbsolutePath(expandedParameterValue));
             }
 
+            // Special handling for FileInfo - validate path through AbsolutePath first
+            if (parameterType == typeof(FileInfo))
+            {
+                AbsolutePath absolutePath = TaskEnvironment.GetAbsolutePath(expandedParameterValue);
+                return InternalSetTaskParameter(parameter, new FileInfo(absolutePath.Value));
+            }
+
+            // Special handling for DirectoryInfo - validate path through AbsolutePath first
+            if (parameterType == typeof(DirectoryInfo))
+            {
+                AbsolutePath absolutePath = TaskEnvironment.GetAbsolutePath(expandedParameterValue);
+                return InternalSetTaskParameter(parameter, new DirectoryInfo(absolutePath.Value));
+            }
+
             // Use the unified ValueTypeParser for all other types
             object parsedValue = ValueTypeParser.Parse(expandedParameterValue, parameterType);
             return InternalSetTaskParameter(parameter, parsedValue);
@@ -845,6 +866,16 @@ namespace Microsoft.Build.BackEnd
                         else if (parameterType == typeof(AbsolutePath[]))
                         {
                             finalTaskInputs.Add(TaskEnvironment.GetAbsolutePath(item.ItemSpec));
+                        }
+                        else if (parameterType == typeof(FileInfo[]))
+                        {
+                            AbsolutePath absolutePath = TaskEnvironment.GetAbsolutePath(item.ItemSpec);
+                            finalTaskInputs.Add(new FileInfo(absolutePath.Value));
+                        }
+                        else if (parameterType == typeof(DirectoryInfo[]))
+                        {
+                            AbsolutePath absolutePath = TaskEnvironment.GetAbsolutePath(item.ItemSpec);
+                            finalTaskInputs.Add(new DirectoryInfo(absolutePath.Value));
                         }
                         else
                         {

--- a/src/Build/BackEnd/TaskExecutionHost/TaskExecutionHost.cs
+++ b/src/Build/BackEnd/TaskExecutionHost/TaskExecutionHost.cs
@@ -775,6 +775,10 @@ namespace Microsoft.Build.BackEnd
             {
                 return InternalSetTaskParameter(parameter, expandedParameterValue);
             }
+            else if (parameterType == typeof(AbsolutePath))
+            {
+                return InternalSetTaskParameter(parameter, TaskEnvironment.GetAbsolutePath(expandedParameterValue));
+            }
             else
             {
                 return InternalSetTaskParameter(parameter, Convert.ChangeType(expandedParameterValue, parameterType, CultureInfo.InvariantCulture));
@@ -805,6 +809,10 @@ namespace Microsoft.Build.BackEnd
                         else if (parameterType == typeof(bool[]))
                         {
                             finalTaskInputs.Add(ConversionUtilities.ConvertStringToBool(item.ItemSpec));
+                        }
+                        else if (parameterType == typeof(AbsolutePath[]))
+                        {
+                            finalTaskInputs.Add(TaskEnvironment.GetAbsolutePath(item.ItemSpec));
                         }
                         else
                         {
@@ -892,7 +900,15 @@ namespace Microsoft.Build.BackEnd
                 object output = convertibleOutputs.GetValue(i);
                 if (output != null)
                 {
-                    stringOutputs[i] = (string)Convert.ChangeType(output, typeof(string), CultureInfo.InvariantCulture);
+                    // AbsolutePath needs special handling because Convert.ChangeType doesn't work with implicit operators
+                    if (output is AbsolutePath absolutePath)
+                    {
+                        stringOutputs[i] = absolutePath.Value;
+                    }
+                    else
+                    {
+                        stringOutputs[i] = (string)Convert.ChangeType(output, typeof(string), CultureInfo.InvariantCulture);
+                    }
                 }
             }
 

--- a/src/Build/BackEnd/TaskExecutionHost/TaskExecutionHost.cs
+++ b/src/Build/BackEnd/TaskExecutionHost/TaskExecutionHost.cs
@@ -795,7 +795,15 @@ namespace Microsoft.Build.BackEnd
             Type constructedType = typeof(TaskItem<>).MakeGenericType(valueType);
             ConstructorInfo constructor = constructedType.GetConstructor(new[] { typeof(ITaskItem) });
 
-            return constructor.Invoke(new object[] { item });
+            try
+            {
+                return constructor.Invoke(new object[] { item });
+            }
+            catch (TargetInvocationException e) when (e.InnerException is not null)
+            {
+                System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(e.InnerException).Throw();
+                throw;
+            }
         }
 
         /// <summary>

--- a/src/Build/BackEnd/TaskExecutionHost/TaskExecutionHost.cs
+++ b/src/Build/BackEnd/TaskExecutionHost/TaskExecutionHost.cs
@@ -15,16 +15,17 @@ using System.Text;
 using System.Threading;
 
 using Microsoft.Build.BackEnd.Logging;
+using Microsoft.Build.Collections;
 using Microsoft.Build.Construction;
 using Microsoft.Build.Evaluation;
 using Microsoft.Build.Exceptions;
 using Microsoft.Build.Execution;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
+using Microsoft.Build.Utilities;
 
 using TaskItem = Microsoft.Build.Execution.ProjectItemInstance.TaskItem;
 using Task = System.Threading.Tasks.Task;
-using Microsoft.Build.Collections;
 
 #nullable disable
 
@@ -753,6 +754,43 @@ namespace Microsoft.Build.BackEnd
         }
 
         #region Local Methods
+
+        /// <summary>
+        /// Checks if a type is TaskItem&lt;T&gt; where T is a value type.
+        /// </summary>
+        private static bool IsTaskItemOfT(Type parameterType)
+        {
+            if (!parameterType.GetTypeInfo().IsGenericType)
+            {
+                return false;
+            }
+
+            Type genericTypeDefinition = parameterType.GetGenericTypeDefinition();
+            if (genericTypeDefinition != typeof(ITaskItem<>) && genericTypeDefinition != typeof(TaskItem<>))
+            {
+                return false;
+            }
+
+            Type[] genericArguments = parameterType.GetGenericArguments();
+            return genericArguments.Length == 1 && genericArguments[0].GetTypeInfo().IsValueType;
+        }
+
+        /// <summary>
+        /// Creates an instance of TaskItem&lt;T&gt; from an ITaskItem.
+        /// </summary>
+        private static object CreateTaskItemOfT(Type taskItemType, ITaskItem item)
+        {
+            // Get the T from TaskItem<T>
+            Type[] genericArguments = taskItemType.GetGenericArguments();
+            Type valueType = genericArguments[0];
+
+            // Create TaskItem<T> using the constructor that takes ITaskItem
+            Type constructedType = typeof(TaskItem<>).MakeGenericType(valueType);
+            ConstructorInfo constructor = constructedType.GetConstructor(new[] { typeof(ITaskItem) });
+
+            return constructor.Invoke(new object[] { item });
+        }
+
         /// <summary>
         /// Called on the local side.
         /// </summary>
@@ -766,23 +804,15 @@ namespace Microsoft.Build.BackEnd
         /// </summary>
         private bool SetValueParameter(TaskPropertyInfo parameter, Type parameterType, string expandedParameterValue)
         {
-            if (parameterType == typeof(bool))
-            {
-                // Convert the string to the appropriate datatype, and set the task's parameter.
-                return InternalSetTaskParameter(parameter, ConversionUtilities.ConvertStringToBool(expandedParameterValue));
-            }
-            else if (parameterType == typeof(string))
-            {
-                return InternalSetTaskParameter(parameter, expandedParameterValue);
-            }
-            else if (parameterType == typeof(AbsolutePath))
+            // Special handling for AbsolutePath to use TaskEnvironment for proper path resolution
+            if (parameterType == typeof(AbsolutePath))
             {
                 return InternalSetTaskParameter(parameter, TaskEnvironment.GetAbsolutePath(expandedParameterValue));
             }
-            else
-            {
-                return InternalSetTaskParameter(parameter, Convert.ChangeType(expandedParameterValue, parameterType, CultureInfo.InvariantCulture));
-            }
+
+            // Use the unified ValueTypeParser for all other types
+            object parsedValue = ValueTypeParser.Parse(expandedParameterValue, parameterType);
+            return InternalSetTaskParameter(parameter, parsedValue);
         }
 
         /// <summary>
@@ -797,7 +827,9 @@ namespace Microsoft.Build.BackEnd
                 // Loop through all the TaskItems in our arraylist, and convert them.
                 ArrayList finalTaskInputs = new ArrayList(taskItems.Count);
 
-                if (parameterType != typeof(ITaskItem[]))
+                Type elementType = parameterType.GetElementType();
+
+                if (parameterType != typeof(ITaskItem[]) && !IsTaskItemOfT(elementType))
                 {
                     foreach (TaskItem item in taskItems)
                     {
@@ -816,12 +848,24 @@ namespace Microsoft.Build.BackEnd
                         }
                         else
                         {
-                            finalTaskInputs.Add(Convert.ChangeType(item.ItemSpec, parameterType.GetElementType(), CultureInfo.InvariantCulture));
+                            finalTaskInputs.Add(Convert.ChangeType(item.ItemSpec, elementType, CultureInfo.InvariantCulture));
                         }
+                    }
+                }
+                else if (IsTaskItemOfT(elementType))
+                {
+                    // Handle TaskItem<T>[]
+                    foreach (TaskItem item in taskItems)
+                    {
+                        currentItem = item;
+                        RecordItemForDisconnectIfNecessary(item);
+                        object taskItemOfT = CreateTaskItemOfT(elementType, item);
+                        finalTaskInputs.Add(taskItemOfT);
                     }
                 }
                 else
                 {
+                    // Handle ITaskItem[]
                     foreach (TaskItem item in taskItems)
                     {
                         // if we've been asked to remote these items then
@@ -874,7 +918,38 @@ namespace Microsoft.Build.BackEnd
 
             if (!(outputs is ITaskItem[] taskItemOutputs))
             {
-                taskItemOutputs = [(ITaskItem)outputs];
+                if (outputs == null)
+                {
+                    taskItemOutputs = null;
+                }
+                else
+                {
+                    // Check if it's a TaskItem<T> or TaskItem<T>[]
+                    Type outputType = outputs.GetType();
+                    if (outputType.IsArray)
+                    {
+                        Type elementType = outputType.GetElementType();
+                        if (IsTaskItemOfT(elementType))
+                        {
+                            // Convert TaskItem<T>[] to ITaskItem[]
+                            Array taskItemArray = (Array)outputs;
+                            taskItemOutputs = new ITaskItem[taskItemArray.Length];
+                            for (int i = 0; i < taskItemArray.Length; i++)
+                            {
+                                taskItemOutputs[i] = (ITaskItem)taskItemArray.GetValue(i);
+                            }
+                        }
+                        else
+                        {
+                            taskItemOutputs = [(ITaskItem)outputs];
+                        }
+                    }
+                    else
+                    {
+                        // Scalar value (including TaskItem<T>)
+                        taskItemOutputs = [(ITaskItem)outputs];
+                    }
+                }
             }
 
             return taskItemOutputs;
@@ -900,15 +975,8 @@ namespace Microsoft.Build.BackEnd
                 object output = convertibleOutputs.GetValue(i);
                 if (output != null)
                 {
-                    // AbsolutePath needs special handling because Convert.ChangeType doesn't work with implicit operators
-                    if (output is AbsolutePath absolutePath)
-                    {
-                        stringOutputs[i] = absolutePath.Value;
-                    }
-                    else
-                    {
-                        stringOutputs[i] = (string)Convert.ChangeType(output, typeof(string), CultureInfo.InvariantCulture);
-                    }
+                    // Use the unified ValueTypeParser for consistent formatting
+                    stringOutputs[i] = ValueTypeParser.ToString(output);
                 }
             }
 
@@ -1255,7 +1323,7 @@ namespace Microsoft.Build.BackEnd
 
             try
             {
-                if (parameterType == typeof(ITaskItem))
+                if (parameterType == typeof(ITaskItem) || IsTaskItemOfT(parameterType))
                 {
                     // We don't know how many items we're going to end up with, but we'll
                     // keep adding them to this arraylist as we find them.
@@ -1269,7 +1337,7 @@ namespace Microsoft.Build.BackEnd
                     {
                         if (finalTaskItems.Count != 1)
                         {
-                            // We only allow a single item to be passed into a parameter of ITaskItem.
+                            // We only allow a single item to be passed into a parameter of ITaskItem or TaskItem<T>.
 
                             // Some of the computation (expansion) here is expensive, so don't switch to VerifyThrowInvalidProject.
                             ProjectErrorUtilities.ThrowInvalidProject(
@@ -1283,7 +1351,16 @@ namespace Microsoft.Build.BackEnd
 
                         RecordItemForDisconnectIfNecessary(finalTaskItems[0]);
 
-                        success = SetTaskItemParameter(parameter, finalTaskItems[0]);
+                        if (IsTaskItemOfT(parameterType))
+                        {
+                            // Create TaskItem<T> from ITaskItem
+                            object taskItemOfT = CreateTaskItemOfT(parameterType, finalTaskItems[0]);
+                            success = InternalSetTaskParameter(parameter, taskItemOfT);
+                        }
+                        else
+                        {
+                            success = SetTaskItemParameter(parameter, finalTaskItems[0]);
+                        }
 
                         taskParameterSet = true;
                     }

--- a/src/Build/Microsoft.Build.csproj
+++ b/src/Build/Microsoft.Build.csproj
@@ -29,6 +29,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Framework\Microsoft.Build.Framework.csproj" />
+    <ProjectReference Include="..\Utilities\Microsoft.Build.Utilities.csproj" />
     <PackageReference Include="Microsoft.VisualStudio.SolutionPersistence" PrivateAssets="all" />
     <PackageReference Include="System.Configuration.ConfigurationManager" />
 

--- a/src/BuildCheck.UnitTests/EndToEndTests.cs
+++ b/src/BuildCheck.UnitTests/EndToEndTests.cs
@@ -945,7 +945,7 @@ public class EndToEndTests : IDisposable
         var nugetTemplateName = "nugetTemplate.config";
         var nugetTemplatePath = Path.Combine(TestAssetsRootPath, "CheckCandidate", nugetTemplateName);
         File.Copy(nugetTemplatePath, Path.Combine(workFolder.Path, nugetTemplateName));
-        AddCustomDataSourceToNugetConfig(workFolder.Path);
+        AddCustomDataSourceToNugetConfig(workFolder.Path, isolateGlobalPackages: false);
 
         var ExecuteDotnetCommand = (string parameters) =>
         {
@@ -966,7 +966,7 @@ public class EndToEndTests : IDisposable
     }
 #endif
 
-    private void AddCustomDataSourceToNugetConfig(string checkCandidatePath)
+    private void AddCustomDataSourceToNugetConfig(string checkCandidatePath, bool isolateGlobalPackages = true)
     {
         var nugetTemplatePath = Path.Combine(checkCandidatePath, "nugetTemplate.config");
 
@@ -980,6 +980,7 @@ public class EndToEndTests : IDisposable
         if (doc.DocumentElement != null)
         {
             XmlNode? packageSourcesNode = doc.SelectSingleNode("//packageSources");
+            XmlNode? configNode = doc.SelectSingleNode("//configuration/config");
 
             // The test packages are generated during the test project build and saved in CustomChecks folder.
             string checksPackagesPath = Path.Combine(Directory.GetParent(AssemblyLocation)?.Parent?.FullName ?? string.Empty, "CustomChecks");
@@ -987,6 +988,14 @@ public class EndToEndTests : IDisposable
 
             // MSBuild packages are placed in a separate folder, so we need to add it as a package source.
             AddPackageSource(doc, packageSourcesNode, "MSBuildTestPackagesSource", RunnerUtilities.ArtifactsLocationAttribute.ArtifactsLocation);
+
+            if (isolateGlobalPackages)
+            {
+                // Use a test-local package cache to avoid stale global cache collisions for fixed-version custom test packages.
+                string localPackagesPath = Path.Combine(checkCandidatePath, ".packages");
+                Directory.CreateDirectory(localPackagesPath);
+                AddConfigSetting(doc, configNode, "globalPackagesFolder", localPackagesPath);
+            }
 
             // PackageSourceMapping is enabled at the repository level. For the test packages we need to add the PackageSourceMapping as well.
             XmlNode? packageSourceMapping = doc.CreateElement("packageSourceMapping");
@@ -997,6 +1006,16 @@ public class EndToEndTests : IDisposable
 
             doc.Save(Path.Combine(checkCandidatePath, "nuget.config"));
         }
+    }
+
+    private void AddConfigSetting(XmlDocument doc, XmlNode? configNode, string key, string value)
+    {
+        configNode ??= doc.DocumentElement?.AppendChild(doc.CreateElement("config"));
+
+        XmlElement addNode = doc.CreateElement("add");
+        PopulateXmlAttribute(doc, addNode, "key", key);
+        PopulateXmlAttribute(doc, addNode, "value", value);
+        configNode!.AppendChild(addNode);
     }
 
     private void AddPackageSourceMapping(XmlDocument doc, XmlNode? packageSourceMapping, string key, string[] packagePatterns)

--- a/src/BuildCheck.UnitTests/EndToEndTests.cs
+++ b/src/BuildCheck.UnitTests/EndToEndTests.cs
@@ -1014,11 +1014,16 @@ public class EndToEndTests : IDisposable
 
     private string ExecBootstrapedMSBuildWithTestAttachments(string workingDirectory, string msbuildParameters, out bool success, int timeoutMilliseconds)
     {
-        string logDirectory = Path.Combine(workingDirectory, ".buildcheck-testlogs");
+        string logDirectory = Path.Combine(
+            BuildCheckUnitTestsConstants.RepoRoot,
+            "artifacts",
+            "TestResults",
+            "BuildCheckAttachments");
         Directory.CreateDirectory(logDirectory);
 
         string timestamp = DateTime.UtcNow.ToString("yyyyMMddHHmmssfff");
-        string logPrefix = $"BuildCheck_{timestamp}_{Guid.NewGuid():N}";
+        string workingDirectoryName = Path.GetFileName(workingDirectory.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
+        string logPrefix = $"BuildCheck_{workingDirectoryName}_{timestamp}_{Guid.NewGuid():N}";
         string binlogPath = Path.Combine(logDirectory, $"{logPrefix}.binlog");
         string fullLogPath = Path.Combine(logDirectory, $"{logPrefix}.full.log");
         string errorLogPath = Path.Combine(logDirectory, $"{logPrefix}.errors.log");

--- a/src/BuildCheck.UnitTests/EndToEndTests.cs
+++ b/src/BuildCheck.UnitTests/EndToEndTests.cs
@@ -670,7 +670,8 @@ public class EndToEndTests : IDisposable
                 },
                 checkCandidatePath));
 
-            string projectCheckBuildLog = RunnerUtilities.ExecBootstrapedMSBuild(
+            string projectCheckBuildLog = ExecBootstrapedMSBuildWithTestAttachments(
+                checkCandidatePath,
                 $"{Path.Combine(checkCandidatePath, $"CheckCandidate.csproj")} /m:1 -nr:False -restore -check -verbosity:n", out bool success, timeoutMilliseconds: 1200_0000);
             success.ShouldBeTrue();
 
@@ -838,7 +839,8 @@ public class EndToEndTests : IDisposable
             var checkCandidatePath = Path.Combine(TestAssetsRootPath, checkCandidate);
             AddCustomDataSourceToNugetConfig(checkCandidatePath);
 
-            string projectCheckBuildLog = RunnerUtilities.ExecBootstrapedMSBuild(
+            string projectCheckBuildLog = ExecBootstrapedMSBuildWithTestAttachments(
+                checkCandidatePath,
                 $"{Path.Combine(checkCandidatePath, $"{checkCandidate}.csproj")} /m:1 -nr:False -restore -check -verbosity:n",
                 out bool successBuild, timeoutMilliseconds: timeoutInMilliseconds);
 
@@ -878,7 +880,8 @@ public class EndToEndTests : IDisposable
                 ruleToCustomConfig: null,
                 checkCandidatePath));
 
-            string projectCheckBuildLog = RunnerUtilities.ExecBootstrapedMSBuild(
+            string projectCheckBuildLog = ExecBootstrapedMSBuildWithTestAttachments(
+                checkCandidatePath,
                 $"{Path.Combine(checkCandidatePath, $"{checkCandidate}.csproj")} /m:1 -nr:False -restore -check -verbosity:n", out bool _, timeoutMilliseconds: timeoutInMilliseconds);
 
             projectCheckBuildLog.ShouldContain(expectedMessage);
@@ -907,7 +910,8 @@ public class EndToEndTests : IDisposable
                 ruleToCustomConfig: null,
                 checkCandidatePath));
 
-            string projectCheckBuildLog = RunnerUtilities.ExecBootstrapedMSBuild(
+            string projectCheckBuildLog = ExecBootstrapedMSBuildWithTestAttachments(
+                checkCandidatePath,
                 $"{Path.Combine(checkCandidatePath, $"{checkCandidate}.csproj")} /m:1 -nr:False -restore -check -verbosity:n", out bool success, timeoutMilliseconds: timeoutInMilliseconds);
 
             success.ShouldBeTrue();
@@ -1005,6 +1009,42 @@ public class EndToEndTests : IDisposable
             doc.DocumentElement.AppendChild(packageSourceMapping);
 
             doc.Save(Path.Combine(checkCandidatePath, "nuget.config"));
+        }
+    }
+
+    private string ExecBootstrapedMSBuildWithTestAttachments(string workingDirectory, string msbuildParameters, out bool success, int timeoutMilliseconds)
+    {
+        string logDirectory = Path.Combine(workingDirectory, ".buildcheck-testlogs");
+        Directory.CreateDirectory(logDirectory);
+
+        string timestamp = DateTime.UtcNow.ToString("yyyyMMddHHmmssfff");
+        string logPrefix = $"BuildCheck_{timestamp}_{Guid.NewGuid():N}";
+        string binlogPath = Path.Combine(logDirectory, $"{logPrefix}.binlog");
+        string fullLogPath = Path.Combine(logDirectory, $"{logPrefix}.full.log");
+        string errorLogPath = Path.Combine(logDirectory, $"{logPrefix}.errors.log");
+
+        string commandLine = $"{msbuildParameters}" +
+            $" /bl:\"{binlogPath}\"" +
+            $" -flp:\"LogFile={fullLogPath};Verbosity=diagnostic;Encoding=UTF-8\"" +
+            $" -flp1:\"LogFile={errorLogPath};Verbosity=normal;ErrorsOnly\"";
+
+        string output = RunnerUtilities.ExecBootstrapedMSBuild(commandLine, out success, timeoutMilliseconds: timeoutMilliseconds);
+
+        AttachFileToCurrentTest(binlogPath);
+        AttachFileToCurrentTest(fullLogPath);
+        AttachFileToCurrentTest(errorLogPath);
+
+        _env.Output.WriteLine($"Attached diagnostic logs:{Environment.NewLine}{binlogPath}{Environment.NewLine}{fullLogPath}{Environment.NewLine}{errorLogPath}");
+
+        return output;
+    }
+
+    private static void AttachFileToCurrentTest(string filePath)
+    {
+        if (File.Exists(filePath))
+        {
+            string mediaType = filePath.EndsWith(".binlog", StringComparison.OrdinalIgnoreCase) ? "application/octet-stream" : "text/plain";
+            Xunit.TestContext.Current.AddAttachment(Path.GetFileName(filePath), File.ReadAllBytes(filePath), mediaType);
         }
     }
 

--- a/src/Framework/ITaskItem_T.cs
+++ b/src/Framework/ITaskItem_T.cs
@@ -1,0 +1,25 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+namespace Microsoft.Build.Framework
+{
+    /// <summary>
+    /// A strongly-typed task item interface that wraps a value of type <typeparamref name="T"/>
+    /// and provides access to it along with standard task item functionality.
+    /// </summary>
+    /// <typeparam name="T">The type of the value. Must be a value type.</typeparam>
+    /// <remarks>
+    /// This interface allows tasks to receive strongly-typed parameters while still working with MSBuild's item system.
+    /// The value is parsed from the item's identity (ItemSpec) using MSBuild's standard parsing conventions.
+    /// </remarks>
+    public interface ITaskItem<T> : ITaskItem2
+        where T : struct
+    {
+        /// <summary>
+        /// Gets the strongly-typed value parsed from the item's identity.
+        /// </summary>
+        T Value { get; }
+    }
+}

--- a/src/Framework/ITaskItem_T.cs
+++ b/src/Framework/ITaskItem_T.cs
@@ -9,13 +9,13 @@ namespace Microsoft.Build.Framework
     /// A strongly-typed task item interface that wraps a value of type <typeparamref name="T"/>
     /// and provides access to it along with standard task item functionality.
     /// </summary>
-    /// <typeparam name="T">The type of the value. Must be a value type.</typeparam>
+    /// <typeparam name="T">The type of the value. Can be a value type, FileInfo, or DirectoryInfo.</typeparam>
     /// <remarks>
     /// This interface allows tasks to receive strongly-typed parameters while still working with MSBuild's item system.
     /// The value is parsed from the item's identity (ItemSpec) using MSBuild's standard parsing conventions.
+    /// Supported types include primitive value types (int, bool, etc.), AbsolutePath, FileInfo, and DirectoryInfo.
     /// </remarks>
     public interface ITaskItem<T> : ITaskItem2
-        where T : struct
     {
         /// <summary>
         /// Gets the strongly-typed value parsed from the item's identity.

--- a/src/Framework/Microsoft.Build.Framework.csproj
+++ b/src/Framework/Microsoft.Build.Framework.csproj
@@ -63,6 +63,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="..\Shared\ValueTypeParser.cs">
+      <Link>Shared\ValueTypeParser.cs</Link>
+    </Compile>
     <Compile Include="..\GlobalUsings.cs" Link="GlobalUsings.cs" />
   </ItemGroup>
 

--- a/src/Shared/TaskParameter.cs
+++ b/src/Shared/TaskParameter.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 using Microsoft.Build.Collections;
@@ -41,12 +42,14 @@ namespace Microsoft.Build.BackEnd
         PrimitiveTypeArray,
 
         /// <summary>
-        /// Parameter is a value type.  Note:  Must be <see cref="IConvertible"/>.
+        /// Parameter is a non-primitive value serialized as a string (for example a value type
+        /// such as <see cref="AbsolutePath"/>, or <see cref="FileInfo"/>/<see cref="DirectoryInfo"/>).
         /// </summary>
         ValueType,
 
         /// <summary>
-        /// Parameter is an array of value types.  Note:  Must be <see cref="IConvertible"/>.
+        /// Parameter is an array of non-primitive values serialized as strings (for example an array
+        /// of value types, or <see cref="FileInfo"/>[]/<see cref="DirectoryInfo"/>[]).
         /// </summary>
         ValueTypeArray,
 
@@ -141,8 +144,11 @@ namespace Microsoft.Build.BackEnd
 
                     _wrappedParameter = taskItemArrayParameter;
                 }
-                else if (wrappedParameterType.GetElementType().GetTypeInfo().IsValueType)
+                else if (wrappedParameterType.GetElementType().GetTypeInfo().IsValueType
+                    || wrappedParameterType.GetElementType() == typeof(FileInfo)
+                    || wrappedParameterType.GetElementType() == typeof(DirectoryInfo))
                 {
+                    // Value-type arrays as well as FileInfo[]/DirectoryInfo[] are serialized as strings.
                     _parameterType = TaskParameterType.ValueTypeArray;
                     _wrappedParameter = wrappedParameter;
                 }
@@ -176,8 +182,11 @@ namespace Microsoft.Build.BackEnd
                     _parameterType = TaskParameterType.ITaskItem;
                     _wrappedParameter = new TaskParameterTaskItem((ITaskItem)wrappedParameter);
                 }
-                else if (wrappedParameterType.GetTypeInfo().IsValueType)
+                else if (wrappedParameterType.GetTypeInfo().IsValueType
+                    || wrappedParameterType == typeof(FileInfo)
+                    || wrappedParameterType == typeof(DirectoryInfo))
                 {
+                    // Value types as well as FileInfo/DirectoryInfo are serialized as strings.
                     _parameterType = TaskParameterType.ValueType;
                     _wrappedParameter = wrappedParameter;
                 }
@@ -465,37 +474,39 @@ namespace Microsoft.Build.BackEnd
         }
 
         /// <summary>
-        /// Serializes or deserializes the value type instance wrapped by this <see cref="TaskParameter"/>.
+        /// Serializes or deserializes the value instance wrapped by this <see cref="TaskParameter"/>.
         /// </summary>
         /// <remarks>
-        /// The value type is converted to/from string using the <see cref="Convert"/> class. Note that we require
-        /// task parameter types to be <see cref="IConvertible"/> so this conversion is guaranteed to work for parameters
-        /// that have made it this far.
+        /// The value is converted to a string on the write side using <see cref="ValueTypeParser.ToString"/>,
+        /// the same canonical conversion the in-process engine uses when gathering task outputs
+        /// (see TaskExecutionHost.GetValueOutputs). This guarantees identical string output across the
+        /// in-process and out-of-process task host paths. The value is not converted back to its original
+        /// type on the read side: this is fine because output task parameters are anyway converted to strings
+        /// by the engine and input task parameters of custom value types are not supported.
         /// </remarks>
         private void TranslateValueType(ITranslator translator)
         {
             string valueString = null;
             if (translator.Mode == TranslationDirection.WriteToStream)
             {
-                valueString = (string)Convert.ChangeType(_wrappedParameter, typeof(string), CultureInfo.InvariantCulture);
+                valueString = ValueTypeParser.ToString(_wrappedParameter);
             }
 
             translator.Translate(ref valueString);
 
             if (translator.Mode == TranslationDirection.ReadFromStream)
             {
-                // We don't know how to convert the string back to the original value type. This is fine because output
-                // task parameters are anyway converted to strings by the engine (see TaskExecutionHost.GetValueOutputs)
-                // and input task parameters of custom value types are not supported.
                 _wrappedParameter = valueString;
             }
         }
 
         /// <summary>
-        /// Serializes or deserializes the value type array instance wrapped by this <see cref="TaskParameter"/>.
+        /// Serializes or deserializes the array instance wrapped by this <see cref="TaskParameter"/>.
         /// </summary>
         /// <remarks>
-        /// The array is assumed to be non-null.
+        /// The array is assumed to be non-null. Each element is converted to a string on the write side
+        /// using <see cref="ValueTypeParser.ToString"/>, the same canonical conversion the in-process engine
+        /// uses when gathering task outputs.
         /// </remarks>
         private void TranslateValueTypeArray(ITranslator translator)
         {
@@ -508,7 +519,7 @@ namespace Microsoft.Build.BackEnd
 
                 for (int i = 0; i < length; i++)
                 {
-                    string valueString = Convert.ToString(array.GetValue(i), CultureInfo.InvariantCulture);
+                    string valueString = ValueTypeParser.ToString(array.GetValue(i));
                     translator.Translate(ref valueString);
                 }
             }

--- a/src/Shared/TaskParameterTypeVerifier.cs
+++ b/src/Shared/TaskParameterTypeVerifier.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Build.BackEnd
         /// Is the parameter type a valid scalar input value
         /// </summary>
         internal static bool IsValidScalarInputParameter(Type parameterType) =>
-            parameterType.GetTypeInfo().IsValueType || parameterType == typeof(string) || parameterType == typeof(ITaskItem);
+            parameterType.GetTypeInfo().IsValueType || parameterType == typeof(string) || parameterType == typeof(ITaskItem) || parameterType == typeof(AbsolutePath);
 
         /// <summary>
         /// Is the passed in parameterType a valid vector input parameter
@@ -27,14 +27,15 @@ namespace Microsoft.Build.BackEnd
         {
             bool result = (parameterType.IsArray && parameterType.GetElementType().GetTypeInfo().IsValueType) ||
                         parameterType == typeof(string[]) ||
-                        parameterType == typeof(ITaskItem[]);
+                        parameterType == typeof(ITaskItem[]) ||
+                        parameterType == typeof(AbsolutePath[]);
             return result;
         }
 
         /// <summary>
-        /// Is the passed in value type assignable to an ITask or Itask[] object
+        /// Is the passed in value type assignable to an ITaskItem or ITaskItem[] object
         /// </summary>
-        internal static bool IsAssignableToITask(Type parameterType)
+        internal static bool IsAssignableToITaskItem(Type parameterType)
         {
             bool result = typeof(ITaskItem[]).GetTypeInfo().IsAssignableFrom(parameterType.GetTypeInfo()) ||    /* ITaskItem array or derived type, or */
                           typeof(ITaskItem).IsAssignableFrom(parameterType);                                    /* ITaskItem or derived type */
@@ -48,8 +49,10 @@ namespace Microsoft.Build.BackEnd
         {
             bool result = (parameterType.IsArray && parameterType.GetElementType().GetTypeInfo().IsValueType) ||    /* array of value types, or */
                           parameterType == typeof(string[]) ||                                                      /* string array, or */
+                          parameterType == typeof(AbsolutePath[]) ||                                                /* AbsolutePath array, or */
                           parameterType.GetTypeInfo().IsValueType ||                                                /* value type, or */
-                          parameterType == typeof(string);                                                          /* string */
+                          parameterType == typeof(string) ||                                                        /* string, or */
+                          parameterType == typeof(AbsolutePath);                                                    /* AbsolutePath */
             return result;
         }
 
@@ -66,7 +69,7 @@ namespace Microsoft.Build.BackEnd
         /// </summary>
         internal static bool IsValidOutputParameter(Type parameterType)
         {
-            return IsValueTypeOutputParameter(parameterType) || IsAssignableToITask(parameterType);
+            return IsValueTypeOutputParameter(parameterType) || IsAssignableToITaskItem(parameterType);
         }
     }
 }

--- a/src/Shared/TaskParameterTypeVerifier.cs
+++ b/src/Shared/TaskParameterTypeVerifier.cs
@@ -82,6 +82,11 @@ namespace Microsoft.Build.BackEnd
         /// </summary>
         internal static bool IsAssignableToITaskItem(Type parameterType)
         {
+            if (parameterType.IsArray && typeof(ITaskItem).IsAssignableFrom(parameterType.GetElementType()))
+            {
+                return true;
+            }
+
             // Check if it's directly assignable
             bool result = typeof(ITaskItem[]).GetTypeInfo().IsAssignableFrom(parameterType.GetTypeInfo()) ||    /* ITaskItem array or derived type, or */
                           typeof(ITaskItem).IsAssignableFrom(parameterType);                                    /* ITaskItem or derived type */

--- a/src/Shared/TaskParameterTypeVerifier.cs
+++ b/src/Shared/TaskParameterTypeVerifier.cs
@@ -15,7 +15,6 @@ namespace Microsoft.Build.BackEnd
     /// </summary>
     internal static class TaskParameterTypeVerifier
     {
-#if !TASKHOST
         /// <summary>
         /// Checks if a type is ITaskItem&lt;T&gt; where T is a value type.
         /// </summary>
@@ -41,7 +40,6 @@ namespace Microsoft.Build.BackEnd
             Type typeArg = genericArguments[0];
             return typeArg.GetTypeInfo().IsValueType || typeArg == typeof(FileInfo) || typeArg == typeof(DirectoryInfo);
         }
-#endif
 
         /// <summary>
         /// Is the parameter type a valid scalar input value
@@ -50,12 +48,10 @@ namespace Microsoft.Build.BackEnd
             parameterType.GetTypeInfo().IsValueType ||
             parameterType == typeof(string) ||
             parameterType == typeof(ITaskItem)
-#if !TASKHOST
             || parameterType == typeof(AbsolutePath)
             || parameterType == typeof(FileInfo)
             || parameterType == typeof(DirectoryInfo)
             || IsTaskItemOfT(parameterType)
-#endif
             ;
 
         /// <summary>
@@ -73,12 +69,10 @@ namespace Microsoft.Build.BackEnd
             bool result = elementType.GetTypeInfo().IsValueType ||
                         parameterType == typeof(string[]) ||
                         parameterType == typeof(ITaskItem[])
-#if !TASKHOST
                         || parameterType == typeof(AbsolutePath[])
                         || parameterType == typeof(FileInfo[])
                         || parameterType == typeof(DirectoryInfo[])
                         || IsTaskItemOfT(elementType)
-#endif
                         ;
             return result;
         }
@@ -92,7 +86,6 @@ namespace Microsoft.Build.BackEnd
             bool result = typeof(ITaskItem[]).GetTypeInfo().IsAssignableFrom(parameterType.GetTypeInfo()) ||    /* ITaskItem array or derived type, or */
                           typeof(ITaskItem).IsAssignableFrom(parameterType);                                    /* ITaskItem or derived type */
 
-#if !TASKHOST
             // Also check for TaskItem<T> or TaskItem<T>[]
             if (!result)
             {
@@ -105,7 +98,6 @@ namespace Microsoft.Build.BackEnd
                     result = IsTaskItemOfT(parameterType);
                 }
             }
-#endif
 
             return result;
         }
@@ -117,18 +109,14 @@ namespace Microsoft.Build.BackEnd
         {
             bool result = (parameterType.IsArray && parameterType.GetElementType().GetTypeInfo().IsValueType) ||    /* array of value types, or */
                           parameterType == typeof(string[]) ||                                                      /* string array, or */
-#if !TASKHOST
                           parameterType == typeof(AbsolutePath[]) ||                                                /* AbsolutePath array, or */
                           parameterType == typeof(FileInfo[]) ||                                                    /* FileInfo array, or */
                           parameterType == typeof(DirectoryInfo[]) ||                                               /* DirectoryInfo array, or */
-#endif
                           parameterType.GetTypeInfo().IsValueType ||                                                /* value type, or */
                           parameterType == typeof(string)                                                           /* string, or */
-#if !TASKHOST
                           || parameterType == typeof(AbsolutePath)                                                  /* AbsolutePath, or */
                           || parameterType == typeof(FileInfo)                                                      /* FileInfo, or */
                           || parameterType == typeof(DirectoryInfo)                                                 /* DirectoryInfo */
-#endif
                           ;
             return result;
         }

--- a/src/Shared/TaskParameterTypeVerifier.cs
+++ b/src/Shared/TaskParameterTypeVerifier.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.IO;
 using System.Reflection;
 using Microsoft.Build.Framework;
 
@@ -32,7 +33,13 @@ namespace Microsoft.Build.BackEnd
             }
 
             Type[] genericArguments = parameterType.GetGenericArguments();
-            return genericArguments.Length == 1 && genericArguments[0].GetTypeInfo().IsValueType;
+            if (genericArguments.Length != 1)
+            {
+                return false;
+            }
+
+            Type typeArg = genericArguments[0];
+            return typeArg.GetTypeInfo().IsValueType || typeArg == typeof(FileInfo) || typeArg == typeof(DirectoryInfo);
         }
 #endif
 
@@ -45,6 +52,8 @@ namespace Microsoft.Build.BackEnd
             parameterType == typeof(ITaskItem)
 #if !TASKHOST
             || parameterType == typeof(AbsolutePath)
+            || parameterType == typeof(FileInfo)
+            || parameterType == typeof(DirectoryInfo)
             || IsTaskItemOfT(parameterType)
 #endif
             ;
@@ -66,6 +75,8 @@ namespace Microsoft.Build.BackEnd
                         parameterType == typeof(ITaskItem[])
 #if !TASKHOST
                         || parameterType == typeof(AbsolutePath[])
+                        || parameterType == typeof(FileInfo[])
+                        || parameterType == typeof(DirectoryInfo[])
                         || IsTaskItemOfT(elementType)
 #endif
                         ;
@@ -108,11 +119,15 @@ namespace Microsoft.Build.BackEnd
                           parameterType == typeof(string[]) ||                                                      /* string array, or */
 #if !TASKHOST
                           parameterType == typeof(AbsolutePath[]) ||                                                /* AbsolutePath array, or */
+                          parameterType == typeof(FileInfo[]) ||                                                    /* FileInfo array, or */
+                          parameterType == typeof(DirectoryInfo[]) ||                                               /* DirectoryInfo array, or */
 #endif
                           parameterType.GetTypeInfo().IsValueType ||                                                /* value type, or */
                           parameterType == typeof(string)                                                           /* string, or */
 #if !TASKHOST
-                          || parameterType == typeof(AbsolutePath)                                                  /* AbsolutePath */
+                          || parameterType == typeof(AbsolutePath)                                                  /* AbsolutePath, or */
+                          || parameterType == typeof(FileInfo)                                                      /* FileInfo, or */
+                          || parameterType == typeof(DirectoryInfo)                                                 /* DirectoryInfo */
 #endif
                           ;
             return result;

--- a/src/Shared/TaskParameterTypeVerifier.cs
+++ b/src/Shared/TaskParameterTypeVerifier.cs
@@ -14,21 +14,61 @@ namespace Microsoft.Build.BackEnd
     /// </summary>
     internal static class TaskParameterTypeVerifier
     {
+#if !TASKHOST
+        /// <summary>
+        /// Checks if a type is ITaskItem&lt;T&gt; where T is a value type.
+        /// </summary>
+        private static bool IsTaskItemOfT(Type parameterType)
+        {
+            if (!parameterType.GetTypeInfo().IsGenericType)
+            {
+                return false;
+            }
+
+            Type genericTypeDefinition = parameterType.GetGenericTypeDefinition();
+            if (genericTypeDefinition != typeof(ITaskItem<>))
+            {
+                return false;
+            }
+
+            Type[] genericArguments = parameterType.GetGenericArguments();
+            return genericArguments.Length == 1 && genericArguments[0].GetTypeInfo().IsValueType;
+        }
+#endif
+
         /// <summary>
         /// Is the parameter type a valid scalar input value
         /// </summary>
         internal static bool IsValidScalarInputParameter(Type parameterType) =>
-            parameterType.GetTypeInfo().IsValueType || parameterType == typeof(string) || parameterType == typeof(ITaskItem) || parameterType == typeof(AbsolutePath);
+            parameterType.GetTypeInfo().IsValueType ||
+            parameterType == typeof(string) ||
+            parameterType == typeof(ITaskItem)
+#if !TASKHOST
+            || parameterType == typeof(AbsolutePath)
+            || IsTaskItemOfT(parameterType)
+#endif
+            ;
 
         /// <summary>
         /// Is the passed in parameterType a valid vector input parameter
         /// </summary>
         internal static bool IsValidVectorInputParameter(Type parameterType)
         {
-            bool result = (parameterType.IsArray && parameterType.GetElementType().GetTypeInfo().IsValueType) ||
+            if (!parameterType.IsArray)
+            {
+                return false;
+            }
+
+            Type elementType = parameterType.GetElementType();
+
+            bool result = elementType.GetTypeInfo().IsValueType ||
                         parameterType == typeof(string[]) ||
-                        parameterType == typeof(ITaskItem[]) ||
-                        parameterType == typeof(AbsolutePath[]);
+                        parameterType == typeof(ITaskItem[])
+#if !TASKHOST
+                        || parameterType == typeof(AbsolutePath[])
+                        || IsTaskItemOfT(elementType)
+#endif
+                        ;
             return result;
         }
 
@@ -37,8 +77,25 @@ namespace Microsoft.Build.BackEnd
         /// </summary>
         internal static bool IsAssignableToITaskItem(Type parameterType)
         {
+            // Check if it's directly assignable
             bool result = typeof(ITaskItem[]).GetTypeInfo().IsAssignableFrom(parameterType.GetTypeInfo()) ||    /* ITaskItem array or derived type, or */
                           typeof(ITaskItem).IsAssignableFrom(parameterType);                                    /* ITaskItem or derived type */
+
+#if !TASKHOST
+            // Also check for TaskItem<T> or TaskItem<T>[]
+            if (!result)
+            {
+                if (parameterType.IsArray)
+                {
+                    result = IsTaskItemOfT(parameterType.GetElementType());
+                }
+                else
+                {
+                    result = IsTaskItemOfT(parameterType);
+                }
+            }
+#endif
+
             return result;
         }
 
@@ -49,10 +106,15 @@ namespace Microsoft.Build.BackEnd
         {
             bool result = (parameterType.IsArray && parameterType.GetElementType().GetTypeInfo().IsValueType) ||    /* array of value types, or */
                           parameterType == typeof(string[]) ||                                                      /* string array, or */
+#if !TASKHOST
                           parameterType == typeof(AbsolutePath[]) ||                                                /* AbsolutePath array, or */
+#endif
                           parameterType.GetTypeInfo().IsValueType ||                                                /* value type, or */
-                          parameterType == typeof(string) ||                                                        /* string, or */
-                          parameterType == typeof(AbsolutePath);                                                    /* AbsolutePath */
+                          parameterType == typeof(string)                                                           /* string, or */
+#if !TASKHOST
+                          || parameterType == typeof(AbsolutePath)                                                  /* AbsolutePath */
+#endif
+                          ;
             return result;
         }
 

--- a/src/Shared/UnitTests/TaskParameter_Tests.cs
+++ b/src/Shared/UnitTests/TaskParameter_Tests.cs
@@ -165,6 +165,135 @@ namespace Microsoft.Build.UnitTests
             Assert.Equal(value[1].ToString(CultureInfo.InvariantCulture), stringArray[1]);
         }
 
+        /// <summary>
+        /// A default <see cref="AbsolutePath"/> (null Value) must serialize cleanly. This is the
+        /// scenario that crashed the out-of-proc task host: a struct-typed output is never null, so
+        /// it always gets serialized, and the old code threw InvalidCastException because AbsolutePath
+        /// is not IConvertible. See https://github.com/dotnet/msbuild/pull/13016.
+        /// </summary>
+        [Fact]
+        public void DefaultAbsolutePathParameter()
+        {
+            TaskParameter t = new TaskParameter(default(AbsolutePath));
+
+            Assert.Equal(TaskParameterType.ValueType, t.ParameterType);
+
+            ((ITranslatable)t).Translate(TranslationHelpers.GetWriteTranslator());
+            TaskParameter t2 = TaskParameter.FactoryForDeserialization(TranslationHelpers.GetReadTranslator());
+
+            // A default AbsolutePath has a null Value and serializes to the empty string.
+            Assert.Equal(string.Empty, t2.WrappedParameter);
+            Assert.Equal(TaskParameterType.ValueType, t2.ParameterType);
+        }
+
+        [Fact]
+        public void AbsolutePathParameter()
+        {
+            string path = Path.Combine(Path.GetTempPath(), "TaskParameterTests_file.txt");
+            AbsolutePath value = new AbsolutePath(path);
+            TaskParameter t = new TaskParameter(value);
+
+            Assert.Equal(TaskParameterType.ValueType, t.ParameterType);
+
+            ((ITranslatable)t).Translate(TranslationHelpers.GetWriteTranslator());
+            TaskParameter t2 = TaskParameter.FactoryForDeserialization(TranslationHelpers.GetReadTranslator());
+
+            // Path types are serialized using the same canonical conversion as the in-process engine.
+            Assert.Equal(value.Value, t2.WrappedParameter);
+            Assert.Equal(TaskParameterType.ValueType, t2.ParameterType);
+        }
+
+        [Fact]
+        public void AbsolutePathArrayParameter()
+        {
+            AbsolutePath[] value = new AbsolutePath[]
+            {
+                new AbsolutePath(Path.Combine(Path.GetTempPath(), "a.txt")),
+                new AbsolutePath(Path.Combine(Path.GetTempPath(), "b.txt")),
+            };
+            TaskParameter t = new TaskParameter(value);
+
+            Assert.Equal(TaskParameterType.ValueTypeArray, t.ParameterType);
+
+            ((ITranslatable)t).Translate(TranslationHelpers.GetWriteTranslator());
+            TaskParameter t2 = TaskParameter.FactoryForDeserialization(TranslationHelpers.GetReadTranslator());
+
+            string[] stringArray = Assert.IsType<string[]>(t2.WrappedParameter);
+            Assert.Equal(value[0].Value, stringArray[0]);
+            Assert.Equal(value[1].Value, stringArray[1]);
+        }
+
+        [Fact]
+        public void FileInfoParameter()
+        {
+            FileInfo value = new FileInfo(Path.Combine(Path.GetTempPath(), "TaskParameterTests_file.txt"));
+            TaskParameter t = new TaskParameter(value);
+
+            Assert.Equal(TaskParameterType.ValueType, t.ParameterType);
+
+            ((ITranslatable)t).Translate(TranslationHelpers.GetWriteTranslator());
+            TaskParameter t2 = TaskParameter.FactoryForDeserialization(TranslationHelpers.GetReadTranslator());
+
+            // FileInfo is serialized as its full path, matching ValueTypeParser/the in-process engine.
+            Assert.Equal(value.FullName, t2.WrappedParameter);
+            Assert.Equal(TaskParameterType.ValueType, t2.ParameterType);
+        }
+
+        [Fact]
+        public void DirectoryInfoParameter()
+        {
+            DirectoryInfo value = new DirectoryInfo(Path.Combine(Path.GetTempPath(), "TaskParameterTests_dir"));
+            TaskParameter t = new TaskParameter(value);
+
+            Assert.Equal(TaskParameterType.ValueType, t.ParameterType);
+
+            ((ITranslatable)t).Translate(TranslationHelpers.GetWriteTranslator());
+            TaskParameter t2 = TaskParameter.FactoryForDeserialization(TranslationHelpers.GetReadTranslator());
+
+            Assert.Equal(value.FullName, t2.WrappedParameter);
+            Assert.Equal(TaskParameterType.ValueType, t2.ParameterType);
+        }
+
+        [Fact]
+        public void FileInfoArrayParameter()
+        {
+            FileInfo[] value = new FileInfo[]
+            {
+                new FileInfo(Path.Combine(Path.GetTempPath(), "a.txt")),
+                new FileInfo(Path.Combine(Path.GetTempPath(), "b.txt")),
+            };
+            TaskParameter t = new TaskParameter(value);
+
+            Assert.Equal(TaskParameterType.ValueTypeArray, t.ParameterType);
+
+            ((ITranslatable)t).Translate(TranslationHelpers.GetWriteTranslator());
+            TaskParameter t2 = TaskParameter.FactoryForDeserialization(TranslationHelpers.GetReadTranslator());
+
+            string[] stringArray = Assert.IsType<string[]>(t2.WrappedParameter);
+            Assert.Equal(value[0].FullName, stringArray[0]);
+            Assert.Equal(value[1].FullName, stringArray[1]);
+        }
+
+        [Fact]
+        public void DirectoryInfoArrayParameter()
+        {
+            DirectoryInfo[] value = new DirectoryInfo[]
+            {
+                new DirectoryInfo(Path.Combine(Path.GetTempPath(), "dirA")),
+                new DirectoryInfo(Path.Combine(Path.GetTempPath(), "dirB")),
+            };
+            TaskParameter t = new TaskParameter(value);
+
+            Assert.Equal(TaskParameterType.ValueTypeArray, t.ParameterType);
+
+            ((ITranslatable)t).Translate(TranslationHelpers.GetWriteTranslator());
+            TaskParameter t2 = TaskParameter.FactoryForDeserialization(TranslationHelpers.GetReadTranslator());
+
+            string[] stringArray = Assert.IsType<string[]>(t2.WrappedParameter);
+            Assert.Equal(value[0].FullName, stringArray[0]);
+            Assert.Equal(value[1].FullName, stringArray[1]);
+        }
+
         private enum TestEnumForParameter
         {
             Something,

--- a/src/Shared/ValueTypeParser.cs
+++ b/src/Shared/ValueTypeParser.cs
@@ -1,0 +1,139 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Globalization;
+using Microsoft.Build.Framework;
+
+#nullable enable
+
+namespace Microsoft.Build.Shared
+{
+    /// <summary>
+    /// Provides unified parsing and formatting logic for value types used in MSBuild task parameters.
+    /// This ensures consistent behavior between TaskItem&lt;T&gt; parsing and TaskExecutionHost parameter binding.
+    /// </summary>
+    internal static class ValueTypeParser
+    {
+        /// <summary>
+        /// Parses a boolean value using MSBuild's boolean conventions.
+        /// Supports: true/on/yes/!false/!off/!no for true, false/off/no/!true/!on/!yes for false.
+        /// </summary>
+        private static bool ParseBool(string value)
+        {
+            // MSBuild boolean true values
+            if (string.Equals(value, "true", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(value, "on", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(value, "yes", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(value, "!false", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(value, "!off", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(value, "!no", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            // MSBuild boolean false values
+            if (string.Equals(value, "false", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(value, "off", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(value, "no", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(value, "!true", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(value, "!on", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(value, "!yes", StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            throw new ArgumentException($"Cannot parse '{value}' as a boolean value.");
+        }
+
+        /// <summary>
+        /// Parses a string value as the specified type.
+        /// </summary>
+        /// <param name="value">The string value to parse.</param>
+        /// <param name="targetType">The type to parse the value as.</param>
+        /// <returns>The parsed value as an object.</returns>
+        /// <exception cref="ArgumentException">Thrown if the value cannot be parsed as the target type.</exception>
+        public static object Parse(string value, Type targetType)
+        {
+            try
+            {
+                // Special handling for AbsolutePath
+                if (targetType == typeof(AbsolutePath))
+                {
+                    return new AbsolutePath(value);
+                }
+
+                // Special handling for bool - MSBuild supports various boolean representations
+                if (targetType == typeof(bool))
+                {
+                    return ParseBool(value);
+                }
+
+                // Special handling for string (no parsing needed)
+                if (targetType == typeof(string))
+                {
+                    return value;
+                }
+
+                // Use TypeCode-based parsing for built-in types
+                TypeCode typeCode = Type.GetTypeCode(targetType);
+                switch (typeCode)
+                {
+                    case TypeCode.Int32:
+                        return int.Parse(value, CultureInfo.InvariantCulture);
+                    case TypeCode.Int64:
+                        return long.Parse(value, CultureInfo.InvariantCulture);
+                    case TypeCode.Double:
+                        return double.Parse(value, CultureInfo.InvariantCulture);
+                    case TypeCode.Single:
+                        return float.Parse(value, CultureInfo.InvariantCulture);
+                    case TypeCode.Decimal:
+                        return decimal.Parse(value, CultureInfo.InvariantCulture);
+                    case TypeCode.Byte:
+                        return byte.Parse(value, CultureInfo.InvariantCulture);
+                    case TypeCode.SByte:
+                        return sbyte.Parse(value, CultureInfo.InvariantCulture);
+                    case TypeCode.Int16:
+                        return short.Parse(value, CultureInfo.InvariantCulture);
+                    case TypeCode.UInt16:
+                        return ushort.Parse(value, CultureInfo.InvariantCulture);
+                    case TypeCode.UInt32:
+                        return uint.Parse(value, CultureInfo.InvariantCulture);
+                    case TypeCode.UInt64:
+                        return ulong.Parse(value, CultureInfo.InvariantCulture);
+                    case TypeCode.Char:
+                        return char.Parse(value);
+                    default:
+                        // Fallback to Convert.ChangeType for other types
+                        return Convert.ChangeType(value, targetType, CultureInfo.InvariantCulture);
+                }
+            }
+            catch (Exception ex) when (ex is FormatException || ex is InvalidCastException || ex is OverflowException || ex is ArgumentException || ex is NotSupportedException)
+            {
+                throw new ArgumentException($"Cannot parse '{value}' as type {targetType.Name}.", nameof(value), ex);
+            }
+        }
+
+        /// <summary>
+        /// Converts a value to its string representation for use in MSBuild.
+        /// </summary>
+        /// <param name="value">The value to convert.</param>
+        /// <returns>The string representation of the value.</returns>
+        public static string ToString(object? value)
+        {
+            if (value == null)
+            {
+                return string.Empty;
+            }
+
+            // AbsolutePath needs special handling because Convert.ChangeType doesn't work with implicit operators
+            if (value is AbsolutePath absolutePath)
+            {
+                return absolutePath.Value;
+            }
+
+            // Use InvariantCulture for consistent formatting
+            return Convert.ToString(value, CultureInfo.InvariantCulture) ?? string.Empty;
+        }
+    }
+}

--- a/src/Shared/ValueTypeParser.cs
+++ b/src/Shared/ValueTypeParser.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Globalization;
+using System.IO;
 using Microsoft.Build.Framework;
 
 #nullable enable
@@ -61,6 +62,18 @@ namespace Microsoft.Build.Shared
                 if (targetType == typeof(AbsolutePath))
                 {
                     return new AbsolutePath(value);
+                }
+
+                // Special handling for FileInfo
+                if (targetType == typeof(FileInfo))
+                {
+                    return new FileInfo(value);
+                }
+
+                // Special handling for DirectoryInfo
+                if (targetType == typeof(DirectoryInfo))
+                {
+                    return new DirectoryInfo(value);
                 }
 
                 // Special handling for bool - MSBuild supports various boolean representations
@@ -130,6 +143,17 @@ namespace Microsoft.Build.Shared
             if (value is AbsolutePath absolutePath)
             {
                 return absolutePath.Value;
+            }
+
+            // FileInfo and DirectoryInfo need special handling to return their path
+            if (value is FileInfo fileInfo)
+            {
+                return fileInfo.FullName;
+            }
+
+            if (value is DirectoryInfo directoryInfo)
+            {
+                return directoryInfo.FullName;
             }
 
             // Use InvariantCulture for consistent formatting

--- a/src/Shared/ValueTypeParser.cs
+++ b/src/Shared/ValueTypeParser.cs
@@ -142,7 +142,7 @@ namespace Microsoft.Build.Shared
             // AbsolutePath needs special handling because Convert.ChangeType doesn't work with implicit operators
             if (value is AbsolutePath absolutePath)
             {
-                return absolutePath.Value;
+                return absolutePath.Value ?? string.Empty;
             }
 
             // FileInfo and DirectoryInfo need special handling to return their path

--- a/src/TaskAnalyzer.Tests/PreferTypedParameterAnalyzerTests.cs
+++ b/src/TaskAnalyzer.Tests/PreferTypedParameterAnalyzerTests.cs
@@ -543,6 +543,34 @@ public class PreferTypedParameterAnalyzerTests
     }
 
     [Fact]
+    public async Task ArrayProperty_SuggestsArrayType()
+    {
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+            using Microsoft.Build.Framework;
+            [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
+            public class MyTask : Microsoft.Build.Utilities.Task, Microsoft.Build.Framework.IMultiThreadableTask
+            {
+                public TaskEnvironment TaskEnvironment { get; set; } = new();
+                public ITaskItem[] Directories { get; set; } = null!;
+                public override bool Execute()
+                {
+                    foreach (ITaskItem item in Directories)
+                    {
+                        AbsolutePath abs = TaskEnvironment.GetAbsolutePath(item.ItemSpec);
+                    }
+                    return true;
+                }
+            }
+            """);
+
+        var task7 = diags.Where(d => d.Id == DiagnosticIds.PreferTypedTaskItem).ToArray();
+        task7.Length.ShouldBeGreaterThanOrEqualTo(1);
+        // Should suggest array type, not singular
+        task7.ShouldContain(d => d.GetMessage().Contains("AbsolutePath[]"));
+        task7.ShouldNotContain(d => d.GetMessage().Contains("'AbsolutePath'") && !d.GetMessage().Contains("[]"));
+    }
+
+    [Fact]
     public async Task NewDirectoryInfo_FromAbsolutePathLocal_SuggestsDirectoryInfo()
     {
         var diags = await GetTypedParameterDiagnosticsAsync("""

--- a/src/TaskAnalyzer.Tests/PreferTypedParameterAnalyzerTests.cs
+++ b/src/TaskAnalyzer.Tests/PreferTypedParameterAnalyzerTests.cs
@@ -128,6 +128,52 @@ public class PreferTypedParameterAnalyzerTests
         diags.ShouldContain(d => d.Id == DiagnosticIds.PreferTypedPathParameter);
     }
 
+    [Fact]
+    public async Task PathCombine_WithStringProp_ProducesDiagnostic()
+    {
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+            using System.IO;
+            using Microsoft.Build.Framework;
+            [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                public string BasePath { get; set; } = "";
+                public override bool Execute()
+                {
+                    var combined = Path.Combine(BasePath, "sub", "file.txt");
+                    return true;
+                }
+            }
+            """);
+
+        diags.ShouldContain(d => d.Id == DiagnosticIds.PreferTypedPathParameter);
+        diags.Length.ShouldBe(1);
+        diags[0].GetMessage().ShouldContain("BasePath");
+    }
+
+    [Fact]
+    public async Task HelperMethodWrapping_StringProp_ProducesDiagnostic()
+    {
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+            using Microsoft.Build.Framework;
+            [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                public string InputPath { get; set; } = "";
+                public override bool Execute()
+                {
+                    var abs = new AbsolutePath(FixPath(InputPath));
+                    return true;
+                }
+                private static string FixPath(string p) => p.Replace('/', '\\');
+            }
+            """);
+
+        diags.ShouldContain(d => d.Id == DiagnosticIds.PreferTypedPathParameter);
+        diags.Length.ShouldBe(1);
+        diags[0].GetMessage().ShouldContain("InputPath");
+    }
+
     // ── Negative cases for MSBuildTask0006 ──
 
     [Fact]
@@ -448,6 +494,52 @@ public class PreferTypedParameterAnalyzerTests
             """);
 
         diags.ShouldContain(d => d.Id == DiagnosticIds.PreferTypedTaskItem);
+    }
+
+    [Fact]
+    public async Task PathCombine_WithItemSpec_ProducesDiagnostic()
+    {
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+            using System.IO;
+            using Microsoft.Build.Framework;
+            [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                public ITaskItem OutputDir { get; set; } = null!;
+                public ITaskItem OutputFile { get; set; } = null!;
+                public override bool Execute()
+                {
+                    var combined = Path.Combine(OutputDir.ItemSpec, OutputFile.ItemSpec);
+                    return true;
+                }
+            }
+            """);
+
+        diags.Where(d => d.Id == DiagnosticIds.PreferTypedTaskItem).Count().ShouldBeGreaterThanOrEqualTo(1);
+    }
+
+    [Fact]
+    public async Task HelperMethodWrapping_ItemSpec_ProducesDiagnostic()
+    {
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+            using Microsoft.Build.Framework;
+            [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
+            public class MyTask : Microsoft.Build.Utilities.Task, Microsoft.Build.Framework.IMultiThreadableTask
+            {
+                public TaskEnvironment TaskEnvironment { get; set; } = new();
+                public ITaskItem FileItem { get; set; } = null!;
+                public override bool Execute()
+                {
+                    var abs = TaskEnvironment.GetAbsolutePath(FixPath(FileItem.ItemSpec));
+                    return true;
+                }
+                private static string FixPath(string p) => p.Replace('/', '\\');
+            }
+            """);
+
+        diags.ShouldContain(d => d.Id == DiagnosticIds.PreferTypedTaskItem);
+        diags.Length.ShouldBe(1);
+        diags[0].GetMessage().ShouldContain("FileItem");
     }
 
     // ── Negative cases for MSBuildTask0007 ──

--- a/src/TaskAnalyzer.Tests/PreferTypedParameterAnalyzerTests.cs
+++ b/src/TaskAnalyzer.Tests/PreferTypedParameterAnalyzerTests.cs
@@ -23,6 +23,7 @@ public class PreferTypedParameterAnalyzerTests
     {
         var diags = await GetTypedParameterDiagnosticsAsync("""
             using Microsoft.Build.Framework;
+            [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
             public class MyTask : Microsoft.Build.Utilities.Task
             {
                 public string InputPath { get; set; } = "";
@@ -45,6 +46,7 @@ public class PreferTypedParameterAnalyzerTests
     {
         var diags = await GetTypedParameterDiagnosticsAsync("""
             using System.IO;
+            [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
             public class MyTask : Microsoft.Build.Utilities.Task
             {
                 public string FilePath { get; set; } = "";
@@ -66,6 +68,7 @@ public class PreferTypedParameterAnalyzerTests
     {
         var diags = await GetTypedParameterDiagnosticsAsync("""
             using System.IO;
+            [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
             public class MyTask : Microsoft.Build.Utilities.Task
             {
                 public string DirPath { get; set; } = "";
@@ -109,6 +112,7 @@ public class PreferTypedParameterAnalyzerTests
     {
         var diags = await GetTypedParameterDiagnosticsAsync("""
             using Microsoft.Build.Framework;
+            [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
             public class MyTask : Microsoft.Build.Utilities.Task
             {
                 public string InputPath { get; set; } = "";
@@ -131,6 +135,7 @@ public class PreferTypedParameterAnalyzerTests
     {
         var diags = await GetTypedParameterDiagnosticsAsync("""
             using Microsoft.Build.Framework;
+            [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
             public class MyTask : Microsoft.Build.Utilities.Task
             {
                 public override bool Execute()
@@ -149,6 +154,7 @@ public class PreferTypedParameterAnalyzerTests
     {
         var diags = await GetTypedParameterDiagnosticsAsync("""
             using Microsoft.Build.Framework;
+            [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
             public class MyTask : Microsoft.Build.Utilities.Task
             {
                 public string InputPath { get; set; } = "";
@@ -170,6 +176,7 @@ public class PreferTypedParameterAnalyzerTests
     {
         var diags = await GetTypedParameterDiagnosticsAsync("""
             using Microsoft.Build.Framework;
+            [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
             public class MyTask : Microsoft.Build.Utilities.Task
             {
                 [Output]
@@ -190,6 +197,7 @@ public class PreferTypedParameterAnalyzerTests
     {
         var diags = await GetTypedParameterDiagnosticsAsync("""
             using Microsoft.Build.Framework;
+            [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
             public class MyTask : Microsoft.Build.Utilities.Task
             {
                 private string InternalPath { get; set; } = "";
@@ -209,6 +217,7 @@ public class PreferTypedParameterAnalyzerTests
     {
         var diags = await GetTypedParameterDiagnosticsAsync("""
             using Microsoft.Build.Framework;
+            [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
             public class MyTask : Microsoft.Build.Utilities.Task
             {
                 public string ComputedPath { get; } = "/fixed";
@@ -250,6 +259,7 @@ public class PreferTypedParameterAnalyzerTests
     {
         var diags = await GetTypedParameterDiagnosticsAsync("""
             using Microsoft.Build.Framework;
+            [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
             public class MyTask : Microsoft.Build.Utilities.Task
             {
                 public ITaskItem Item { get; set; } = null!;
@@ -272,6 +282,7 @@ public class PreferTypedParameterAnalyzerTests
     {
         var diags = await GetTypedParameterDiagnosticsAsync("""
             using Microsoft.Build.Framework;
+            [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
             public class MyTask : Microsoft.Build.Utilities.Task
             {
                 public ITaskItem Flag { get; set; } = null!;
@@ -293,6 +304,7 @@ public class PreferTypedParameterAnalyzerTests
         var diags = await GetTypedParameterDiagnosticsAsync("""
             using System;
             using Microsoft.Build.Framework;
+            [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
             public class MyTask : Microsoft.Build.Utilities.Task
             {
                 public ITaskItem Count { get; set; } = null!;
@@ -313,6 +325,7 @@ public class PreferTypedParameterAnalyzerTests
     {
         var diags = await GetTypedParameterDiagnosticsAsync("""
             using Microsoft.Build.Framework;
+            [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
             public class MyTask : Microsoft.Build.Utilities.Task
             {
                 public ITaskItem PathItem { get; set; } = null!;
@@ -334,6 +347,7 @@ public class PreferTypedParameterAnalyzerTests
         var diags = await GetTypedParameterDiagnosticsAsync("""
             using System.IO;
             using Microsoft.Build.Framework;
+            [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
             public class MyTask : Microsoft.Build.Utilities.Task
             {
                 public ITaskItem FileItem { get; set; } = null!;
@@ -376,6 +390,7 @@ public class PreferTypedParameterAnalyzerTests
     {
         var diags = await GetTypedParameterDiagnosticsAsync("""
             using Microsoft.Build.Framework;
+            [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
             public class MyTask : Microsoft.Build.Utilities.Task
             {
                 public ITaskItem Item { get; set; } = null!;
@@ -396,6 +411,7 @@ public class PreferTypedParameterAnalyzerTests
     {
         var diags = await GetTypedParameterDiagnosticsAsync("""
             using Microsoft.Build.Framework;
+            [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
             public class MyTask : Microsoft.Build.Utilities.Task
             {
                 public ITaskItem[] Items { get; set; } = null!;
@@ -419,6 +435,7 @@ public class PreferTypedParameterAnalyzerTests
     {
         var diags = await GetTypedParameterDiagnosticsAsync("""
             using Microsoft.Build.Framework;
+            [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
             public class MyTask : Microsoft.Build.Utilities.Task
             {
                 public ITaskItem[] Items { get; set; } = null!;
@@ -440,6 +457,7 @@ public class PreferTypedParameterAnalyzerTests
     {
         var diags = await GetTypedParameterDiagnosticsAsync("""
             using Microsoft.Build.Framework;
+            [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
             public class MyTask : Microsoft.Build.Utilities.Task
             {
                 public ITaskItem Item { get; set; } = null!;
@@ -459,6 +477,7 @@ public class PreferTypedParameterAnalyzerTests
     {
         var diags = await GetTypedParameterDiagnosticsAsync("""
             using Microsoft.Build.Framework;
+            [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
             public class MyTask : Microsoft.Build.Utilities.Task
             {
                 public string CountStr { get; set; } = "0";
@@ -479,6 +498,7 @@ public class PreferTypedParameterAnalyzerTests
     {
         var diags = await GetTypedParameterDiagnosticsAsync("""
             using Microsoft.Build.Framework;
+            [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
             public class MyTask : Microsoft.Build.Utilities.Task
             {
                 [Output]
@@ -505,6 +525,48 @@ public class PreferTypedParameterAnalyzerTests
                 public void DoWork()
                 {
                     int value = int.Parse(Item.ItemSpec);
+                }
+            }
+            """);
+
+        diags.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task NonMultiThreadableTask_NoDiagnostic()
+    {
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+            using Microsoft.Build.Framework;
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                public string InputPath { get; set; } = "";
+                public ITaskItem FileItem { get; set; } = null!;
+                public override bool Execute()
+                {
+                    var abs = new AbsolutePath(InputPath);
+                    int value = int.Parse(FileItem.ItemSpec);
+                    return true;
+                }
+            }
+            """);
+
+        diags.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task MultiThreadableAttribute_ButNotITask_NoDiagnostic()
+    {
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+            using Microsoft.Build.Framework;
+            [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
+            public class NotATask
+            {
+                public string InputPath { get; set; } = "";
+                public ITaskItem FileItem { get; set; } = null!;
+                public void DoWork()
+                {
+                    var abs = new AbsolutePath(InputPath);
+                    int value = int.Parse(FileItem.ItemSpec);
                 }
             }
             """);

--- a/src/TaskAnalyzer.Tests/PreferTypedParameterAnalyzerTests.cs
+++ b/src/TaskAnalyzer.Tests/PreferTypedParameterAnalyzerTests.cs
@@ -931,4 +931,73 @@ public class PreferTypedParameterAnalyzerTests
         task7[0].GetMessage().ShouldNotContain("FileInfo");
         task7[0].GetMessage().ShouldNotContain("DirectoryInfo");
     }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Fix #5: Restrict to ValueTypeParser-supported types only
+    // ═══════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task GuidParse_FromItemSpec_NoDiagnostic()
+    {
+        // Guid is not supported by ValueTypeParser, so no diagnostic should be emitted.
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+            using System;
+            using Microsoft.Build.Framework;
+            [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
+            public class MyTask : Microsoft.Build.Utilities.Task, Microsoft.Build.Framework.IMultiThreadableTask
+            {
+                public ITaskItem Item { get; set; } = null!;
+                public override bool Execute()
+                {
+                    var id = Guid.Parse(Item.ItemSpec);
+                    return true;
+                }
+            }
+            """);
+
+        diags.ShouldNotContain(d => d.Id == DiagnosticIds.PreferTypedTaskItem);
+    }
+
+    [Fact]
+    public async Task TimeSpanParse_FromItemSpec_NoDiagnostic()
+    {
+        // TimeSpan is not supported by ValueTypeParser, so no diagnostic should be emitted.
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+            using System;
+            using Microsoft.Build.Framework;
+            [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
+            public class MyTask : Microsoft.Build.Utilities.Task, Microsoft.Build.Framework.IMultiThreadableTask
+            {
+                public ITaskItem Item { get; set; } = null!;
+                public override bool Execute()
+                {
+                    var ts = TimeSpan.Parse(Item.ItemSpec);
+                    return true;
+                }
+            }
+            """);
+
+        diags.ShouldNotContain(d => d.Id == DiagnosticIds.PreferTypedTaskItem);
+    }
+
+    [Fact]
+    public async Task IntParse_FromItemSpec_StillProducesDiagnostic()
+    {
+        // int is supported by ValueTypeParser, so the diagnostic should still fire.
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+            using Microsoft.Build.Framework;
+            [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
+            public class MyTask : Microsoft.Build.Utilities.Task, Microsoft.Build.Framework.IMultiThreadableTask
+            {
+                public ITaskItem Item { get; set; } = null!;
+                public override bool Execute()
+                {
+                    var n = int.Parse(Item.ItemSpec);
+                    return true;
+                }
+            }
+            """);
+
+        diags.ShouldContain(d => d.Id == DiagnosticIds.PreferTypedTaskItem);
+    }
 }

--- a/src/TaskAnalyzer.Tests/PreferTypedParameterAnalyzerTests.cs
+++ b/src/TaskAnalyzer.Tests/PreferTypedParameterAnalyzerTests.cs
@@ -542,6 +542,58 @@ public class PreferTypedParameterAnalyzerTests
         diags[0].GetMessage().ShouldContain("FileItem");
     }
 
+    [Fact]
+    public async Task NewDirectoryInfo_FromAbsolutePathLocal_SuggestsDirectoryInfo()
+    {
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+            using System.IO;
+            using Microsoft.Build.Framework;
+            [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
+            public class MyTask : Microsoft.Build.Utilities.Task, Microsoft.Build.Framework.IMultiThreadableTask
+            {
+                public TaskEnvironment TaskEnvironment { get; set; } = new();
+                public ITaskItem SourceDir { get; set; } = null!;
+                public override bool Execute()
+                {
+                    AbsolutePath abs = TaskEnvironment.GetAbsolutePath(SourceDir.ItemSpec);
+                    var dir = new DirectoryInfo(abs);
+                    return true;
+                }
+            }
+            """);
+
+        // Should get MSBuildTask0007 for GetAbsolutePath(item.ItemSpec) AND for new DirectoryInfo(abs)
+        var task7 = diags.Where(d => d.Id == DiagnosticIds.PreferTypedTaskItem).ToArray();
+        task7.Length.ShouldBeGreaterThanOrEqualTo(1);
+        // At least one diagnostic should suggest DirectoryInfo
+        task7.ShouldContain(d => d.GetMessage().Contains("DirectoryInfo"));
+    }
+
+    [Fact]
+    public async Task NewFileInfo_FromAbsolutePathLocal_SuggestsFileInfo()
+    {
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+            using System.IO;
+            using Microsoft.Build.Framework;
+            [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
+            public class MyTask : Microsoft.Build.Utilities.Task, Microsoft.Build.Framework.IMultiThreadableTask
+            {
+                public TaskEnvironment TaskEnvironment { get; set; } = new();
+                public ITaskItem DestFile { get; set; } = null!;
+                public override bool Execute()
+                {
+                    AbsolutePath abs = TaskEnvironment.GetAbsolutePath(DestFile.ItemSpec);
+                    var fi = new FileInfo(abs);
+                    return true;
+                }
+            }
+            """);
+
+        var task7 = diags.Where(d => d.Id == DiagnosticIds.PreferTypedTaskItem).ToArray();
+        task7.Length.ShouldBeGreaterThanOrEqualTo(1);
+        task7.ShouldContain(d => d.GetMessage().Contains("FileInfo"));
+    }
+
     // ── Negative cases for MSBuildTask0007 ──
 
     [Fact]

--- a/src/TaskAnalyzer.Tests/PreferTypedParameterAnalyzerTests.cs
+++ b/src/TaskAnalyzer.Tests/PreferTypedParameterAnalyzerTests.cs
@@ -1,0 +1,492 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Linq;
+using System.Threading.Tasks;
+using Shouldly;
+using Xunit;
+using static Microsoft.Build.TaskAuthoring.Analyzer.Tests.TestHelpers;
+
+namespace Microsoft.Build.TaskAuthoring.Analyzer.Tests;
+
+/// <summary>
+/// Tests for <see cref="PreferTypedParameterAnalyzer"/> covering MSBuildTask0006 and MSBuildTask0007.
+/// </summary>
+public class PreferTypedParameterAnalyzerTests
+{
+    // ═══════════════════════════════════════════════════════════════════════
+    // MSBuildTask0006: Prefer typed path parameters
+    // ═══════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task NewAbsolutePath_FromStringProp_ProducesDiagnostic()
+    {
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+            using Microsoft.Build.Framework;
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                public string InputPath { get; set; } = "";
+                public override bool Execute()
+                {
+                    var abs = new AbsolutePath(InputPath);
+                    return true;
+                }
+            }
+            """);
+
+        diags.ShouldContain(d => d.Id == DiagnosticIds.PreferTypedPathParameter);
+        diags.Length.ShouldBe(1);
+        diags[0].GetMessage().ShouldContain("InputPath");
+        diags[0].GetMessage().ShouldContain("AbsolutePath");
+    }
+
+    [Fact]
+    public async Task NewFileInfo_FromStringProp_ProducesDiagnostic()
+    {
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+            using System.IO;
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                public string FilePath { get; set; } = "";
+                public override bool Execute()
+                {
+                    var fi = new FileInfo(FilePath);
+                    return true;
+                }
+            }
+            """);
+
+        diags.ShouldContain(d => d.Id == DiagnosticIds.PreferTypedPathParameter);
+        diags.Length.ShouldBe(1);
+        diags[0].GetMessage().ShouldContain("FileInfo");
+    }
+
+    [Fact]
+    public async Task NewDirectoryInfo_FromStringProp_ProducesDiagnostic()
+    {
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+            using System.IO;
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                public string DirPath { get; set; } = "";
+                public override bool Execute()
+                {
+                    var di = new DirectoryInfo(DirPath);
+                    return true;
+                }
+            }
+            """);
+
+        diags.ShouldContain(d => d.Id == DiagnosticIds.PreferTypedPathParameter);
+        diags[0].GetMessage().ShouldContain("DirectoryInfo");
+    }
+
+    [Fact]
+    public async Task TaskEnvironmentGetAbsolutePath_FromStringProp_ProducesDiagnostic()
+    {
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+            using Microsoft.Build.Framework;
+            public class MyTask : Microsoft.Build.Framework.IMultiThreadableTask
+            {
+                public IBuildEngine BuildEngine { get; set; } = null!;
+                public TaskEnvironment TaskEnvironment { get; set; } = null!;
+                public string InputPath { get; set; } = "";
+                public bool Execute()
+                {
+                    var abs = TaskEnvironment.GetAbsolutePath(InputPath);
+                    return true;
+                }
+            }
+            """);
+
+        diags.ShouldContain(d => d.Id == DiagnosticIds.PreferTypedPathParameter);
+        diags.Length.ShouldBe(1);
+        diags[0].GetMessage().ShouldContain("InputPath");
+    }
+
+    [Fact]
+    public async Task NewAbsolutePath_WithLocalIndirection_ProducesDiagnostic()
+    {
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+            using Microsoft.Build.Framework;
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                public string InputPath { get; set; } = "";
+                public override bool Execute()
+                {
+                    var path = InputPath;
+                    var abs = new AbsolutePath(path);
+                    return true;
+                }
+            }
+            """);
+
+        diags.ShouldContain(d => d.Id == DiagnosticIds.PreferTypedPathParameter);
+    }
+
+    // ── Negative cases for MSBuildTask0006 ──
+
+    [Fact]
+    public async Task NewAbsolutePath_FromLiteral_NoDiagnostic()
+    {
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+            using Microsoft.Build.Framework;
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                public override bool Execute()
+                {
+                    var abs = new AbsolutePath("/some/path");
+                    return true;
+                }
+            }
+            """);
+
+        diags.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task NewAbsolutePath_FromNonTaskProperty_NoDiagnostic()
+    {
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+            using Microsoft.Build.Framework;
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                public string InputPath { get; set; } = "";
+                public override bool Execute()
+                {
+                    string localPath = ComputePath();
+                    var abs = new AbsolutePath(localPath);
+                    return true;
+                }
+                private string ComputePath() => "/computed";
+            }
+            """);
+
+        diags.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task OutputProperty_Excluded_NoDiagnostic()
+    {
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+            using Microsoft.Build.Framework;
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                [Output]
+                public string OutputPath { get; set; } = "";
+                public override bool Execute()
+                {
+                    var abs = new AbsolutePath(OutputPath);
+                    return true;
+                }
+            }
+            """);
+
+        diags.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task PrivateProperty_Excluded_NoDiagnostic()
+    {
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+            using Microsoft.Build.Framework;
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                private string InternalPath { get; set; } = "";
+                public override bool Execute()
+                {
+                    var abs = new AbsolutePath(InternalPath);
+                    return true;
+                }
+            }
+            """);
+
+        diags.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task ReadOnlyProperty_Excluded_NoDiagnostic()
+    {
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+            using Microsoft.Build.Framework;
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                public string ComputedPath { get; } = "/fixed";
+                public override bool Execute()
+                {
+                    var abs = new AbsolutePath(ComputedPath);
+                    return true;
+                }
+            }
+            """);
+
+        diags.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task NonTaskClass_NoDiagnostic()
+    {
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+            using Microsoft.Build.Framework;
+            public class NotATask
+            {
+                public string InputPath { get; set; } = "";
+                public void DoWork()
+                {
+                    var abs = new AbsolutePath(InputPath);
+                }
+            }
+            """);
+
+        diags.ShouldBeEmpty();
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // MSBuildTask0007: Prefer ITaskItem<T> over manual ItemSpec parsing
+    // ═══════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task IntParse_FromItemSpec_ProducesDiagnostic()
+    {
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+            using Microsoft.Build.Framework;
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                public ITaskItem Item { get; set; } = null!;
+                public override bool Execute()
+                {
+                    int value = int.Parse(Item.ItemSpec);
+                    return true;
+                }
+            }
+            """);
+
+        diags.ShouldContain(d => d.Id == DiagnosticIds.PreferTypedTaskItem);
+        diags.Length.ShouldBe(1);
+        diags[0].GetMessage().ShouldContain("int");
+        diags[0].GetMessage().ShouldContain("Item");
+    }
+
+    [Fact]
+    public async Task BoolParse_FromItemSpec_ProducesDiagnostic()
+    {
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+            using Microsoft.Build.Framework;
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                public ITaskItem Flag { get; set; } = null!;
+                public override bool Execute()
+                {
+                    bool value = bool.Parse(Flag.ItemSpec);
+                    return true;
+                }
+            }
+            """);
+
+        diags.ShouldContain(d => d.Id == DiagnosticIds.PreferTypedTaskItem);
+        diags[0].GetMessage().ShouldContain("bool");
+    }
+
+    [Fact]
+    public async Task ConvertToInt32_FromItemSpec_ProducesDiagnostic()
+    {
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+            using System;
+            using Microsoft.Build.Framework;
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                public ITaskItem Count { get; set; } = null!;
+                public override bool Execute()
+                {
+                    int value = Convert.ToInt32(Count.ItemSpec);
+                    return true;
+                }
+            }
+            """);
+
+        diags.ShouldContain(d => d.Id == DiagnosticIds.PreferTypedTaskItem);
+        diags[0].GetMessage().ShouldContain("int");
+    }
+
+    [Fact]
+    public async Task NewAbsolutePath_FromItemSpec_ProducesDiagnostic()
+    {
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+            using Microsoft.Build.Framework;
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                public ITaskItem PathItem { get; set; } = null!;
+                public override bool Execute()
+                {
+                    var abs = new AbsolutePath(PathItem.ItemSpec);
+                    return true;
+                }
+            }
+            """);
+
+        diags.ShouldContain(d => d.Id == DiagnosticIds.PreferTypedTaskItem);
+        diags[0].GetMessage().ShouldContain("AbsolutePath");
+    }
+
+    [Fact]
+    public async Task NewFileInfo_FromItemSpec_ProducesDiagnostic()
+    {
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+            using System.IO;
+            using Microsoft.Build.Framework;
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                public ITaskItem FileItem { get; set; } = null!;
+                public override bool Execute()
+                {
+                    var fi = new FileInfo(FileItem.ItemSpec);
+                    return true;
+                }
+            }
+            """);
+
+        diags.ShouldContain(d => d.Id == DiagnosticIds.PreferTypedTaskItem);
+        diags[0].GetMessage().ShouldContain("FileInfo");
+    }
+
+    [Fact]
+    public async Task IntParse_FromItemSpec_WithLocalIndirection_ProducesDiagnostic()
+    {
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+            using Microsoft.Build.Framework;
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                public ITaskItem Item { get; set; } = null!;
+                public override bool Execute()
+                {
+                    var spec = Item.ItemSpec;
+                    int value = int.Parse(spec);
+                    return true;
+                }
+            }
+            """);
+
+        diags.ShouldContain(d => d.Id == DiagnosticIds.PreferTypedTaskItem);
+    }
+
+    [Fact]
+    public async Task IntParse_FromArrayItemSpec_InForeach_ProducesDiagnostic()
+    {
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+            using Microsoft.Build.Framework;
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                public ITaskItem[] Items { get; set; } = null!;
+                public override bool Execute()
+                {
+                    foreach (var item in Items)
+                    {
+                        int value = int.Parse(item.ItemSpec);
+                    }
+                    return true;
+                }
+            }
+            """);
+
+        diags.ShouldContain(d => d.Id == DiagnosticIds.PreferTypedTaskItem);
+        diags[0].GetMessage().ShouldContain("ITaskItem[]");
+    }
+
+    [Fact]
+    public async Task IntParse_FromArrayElementItemSpec_ProducesDiagnostic()
+    {
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+            using Microsoft.Build.Framework;
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                public ITaskItem[] Items { get; set; } = null!;
+                public override bool Execute()
+                {
+                    int value = int.Parse(Items[0].ItemSpec);
+                    return true;
+                }
+            }
+            """);
+
+        diags.ShouldContain(d => d.Id == DiagnosticIds.PreferTypedTaskItem);
+    }
+
+    // ── Negative cases for MSBuildTask0007 ──
+
+    [Fact]
+    public async Task IntParse_FromNonItemSpec_NoDiagnostic()
+    {
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+            using Microsoft.Build.Framework;
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                public ITaskItem Item { get; set; } = null!;
+                public override bool Execute()
+                {
+                    int value = int.Parse(Item.GetMetadata("Count"));
+                    return true;
+                }
+            }
+            """);
+
+        diags.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task IntParse_FromStringProp_NoDiagnostic()
+    {
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+            using Microsoft.Build.Framework;
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                public string CountStr { get; set; } = "0";
+                public override bool Execute()
+                {
+                    int value = int.Parse(CountStr);
+                    return true;
+                }
+            }
+            """);
+
+        // MSBuildTask0007 should not fire; 0006 wouldn't either since int is not a path type
+        diags.Where(d => d.Id == DiagnosticIds.PreferTypedTaskItem).ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task OutputItemProperty_Excluded_NoDiagnostic()
+    {
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+            using Microsoft.Build.Framework;
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                [Output]
+                public ITaskItem ResultItem { get; set; } = null!;
+                public override bool Execute()
+                {
+                    int value = int.Parse(ResultItem.ItemSpec);
+                    return true;
+                }
+            }
+            """);
+
+        diags.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task NonTaskClass_ItemSpec_NoDiagnostic()
+    {
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+            using Microsoft.Build.Framework;
+            public class NotATask
+            {
+                public ITaskItem Item { get; set; } = null!;
+                public void DoWork()
+                {
+                    int value = int.Parse(Item.ItemSpec);
+                }
+            }
+            """);
+
+        diags.ShouldBeEmpty();
+    }
+}

--- a/src/TaskAnalyzer.Tests/PreferTypedParameterAnalyzerTests.cs
+++ b/src/TaskAnalyzer.Tests/PreferTypedParameterAnalyzerTests.cs
@@ -565,9 +565,8 @@ public class PreferTypedParameterAnalyzerTests
 
         var task7 = diags.Where(d => d.Id == DiagnosticIds.PreferTypedTaskItem).ToArray();
         task7.Length.ShouldBeGreaterThanOrEqualTo(1);
-        // Should suggest array type, not singular
-        task7.ShouldContain(d => d.GetMessage().Contains("AbsolutePath[]"));
-        task7.ShouldNotContain(d => d.GetMessage().Contains("'AbsolutePath'") && !d.GetMessage().Contains("[]"));
+        // Should suggest ITaskItem<AbsolutePath>[] — brackets outside the angle brackets
+        task7.ShouldContain(d => d.GetMessage().Contains("ITaskItem<AbsolutePath>[]"));
     }
 
     [Fact]

--- a/src/TaskAnalyzer.Tests/PreferTypedParameterAnalyzerTests.cs
+++ b/src/TaskAnalyzer.Tests/PreferTypedParameterAnalyzerTests.cs
@@ -350,6 +350,28 @@ public class PreferTypedParameterAnalyzerTests
     }
 
     [Fact]
+    public async Task GetAbsolutePath_FromItemSpec_ProducesDiagnostic()
+    {
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+            using Microsoft.Build.Framework;
+            public class MyTask : Microsoft.Build.Framework.IMultiThreadableTask
+            {
+                public IBuildEngine BuildEngine { get; set; } = null!;
+                public TaskEnvironment TaskEnvironment { get; set; } = null!;
+                public ITaskItem PathItem { get; set; } = null!;
+                public bool Execute()
+                {
+                    var abs = TaskEnvironment.GetAbsolutePath(PathItem.ItemSpec);
+                    return true;
+                }
+            }
+            """);
+
+        diags.ShouldContain(d => d.Id == DiagnosticIds.PreferTypedTaskItem);
+        diags[0].GetMessage().ShouldContain("AbsolutePath");
+    }
+
+    [Fact]
     public async Task IntParse_FromItemSpec_WithLocalIndirection_ProducesDiagnostic()
     {
         var diags = await GetTypedParameterDiagnosticsAsync("""

--- a/src/TaskAnalyzer.Tests/PreferTypedParameterAnalyzerTests.cs
+++ b/src/TaskAnalyzer.Tests/PreferTypedParameterAnalyzerTests.cs
@@ -515,7 +515,11 @@ public class PreferTypedParameterAnalyzerTests
             }
             """);
 
-        diags.Where(d => d.Id == DiagnosticIds.PreferTypedTaskItem).Count().ShouldBeGreaterThanOrEqualTo(1);
+        // Every argument that flows from a task input is flagged, not just the first.
+        var task7 = diags.Where(d => d.Id == DiagnosticIds.PreferTypedTaskItem).ToArray();
+        task7.Length.ShouldBe(2);
+        task7.ShouldContain(d => d.GetMessage().Contains("OutputDir"));
+        task7.ShouldContain(d => d.GetMessage().Contains("OutputFile"));
     }
 
     [Fact]
@@ -744,5 +748,187 @@ public class PreferTypedParameterAnalyzerTests
             """);
 
         diags.ShouldBeEmpty();
+    }
+
+    // ── System.IO consumption-site inference (File.* => FileInfo, Directory.* => DirectoryInfo) ──
+
+    [Fact]
+    public async Task FileDelete_OnItemSpec_SuggestsFileInfo()
+    {
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+        using System.IO;
+        using Microsoft.Build.Framework;
+        [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
+        public class MyTask : Microsoft.Build.Utilities.Task, Microsoft.Build.Framework.IMultiThreadableTask
+        {
+            public TaskEnvironment TaskEnvironment { get; set; } = new();
+            public ITaskItem Target { get; set; } = null!;
+            public override bool Execute()
+            {
+                File.Delete(Target.ItemSpec);
+                return true;
+            }
+        }
+        """);
+
+        var task7 = diags.Where(d => d.Id == DiagnosticIds.PreferTypedTaskItem).ToArray();
+        task7.Length.ShouldBe(1);
+        task7[0].GetMessage().ShouldContain("FileInfo");
+    }
+
+    [Fact]
+    public async Task DirectoryCreate_OnItemSpec_SuggestsDirectoryInfo()
+    {
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+        using System.IO;
+        using Microsoft.Build.Framework;
+        [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
+        public class MyTask : Microsoft.Build.Utilities.Task, Microsoft.Build.Framework.IMultiThreadableTask
+        {
+            public TaskEnvironment TaskEnvironment { get; set; } = new();
+            public ITaskItem DestinationFolder { get; set; } = null!;
+            public override bool Execute()
+            {
+                Directory.CreateDirectory(DestinationFolder.ItemSpec);
+                return true;
+            }
+        }
+        """);
+
+        var task7 = diags.Where(d => d.Id == DiagnosticIds.PreferTypedTaskItem).ToArray();
+        task7.Length.ShouldBe(1);
+        task7[0].GetMessage().ShouldContain("DirectoryInfo");
+    }
+
+    [Fact]
+    public async Task FileReadAllLines_ThroughAbsolutePath_SuggestsFileInfoAndSuppressesAbsolutePath()
+    {
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+        using System.IO;
+        using Microsoft.Build.Framework;
+        [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
+        public class MyTask : Microsoft.Build.Utilities.Task, Microsoft.Build.Framework.IMultiThreadableTask
+        {
+            public TaskEnvironment TaskEnvironment { get; set; } = new();
+            public ITaskItem Input { get; set; } = null!;
+            public override bool Execute()
+            {
+                var lines = File.ReadAllLines(TaskEnvironment.GetAbsolutePath(Input.ItemSpec));
+                return true;
+            }
+        }
+        """);
+
+        var task7 = diags.Where(d => d.Id == DiagnosticIds.PreferTypedTaskItem).ToArray();
+        task7.Length.ShouldBe(1);
+        task7[0].GetMessage().ShouldContain("FileInfo");
+        task7[0].GetMessage().ShouldNotContain("AbsolutePath");
+    }
+
+    [Fact]
+    public async Task NewFileStream_OnItemSpec_SuggestsFileInfo()
+    {
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+        using System.IO;
+        using Microsoft.Build.Framework;
+        [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
+        public class MyTask : Microsoft.Build.Utilities.Task, Microsoft.Build.Framework.IMultiThreadableTask
+        {
+            public TaskEnvironment TaskEnvironment { get; set; } = new();
+            public ITaskItem XmlInputPath { get; set; } = null!;
+            public override bool Execute()
+            {
+                using var stream = new FileStream(XmlInputPath.ItemSpec, FileMode.Open);
+                return true;
+            }
+        }
+        """);
+
+        var task7 = diags.Where(d => d.Id == DiagnosticIds.PreferTypedTaskItem).ToArray();
+        task7.Length.ShouldBe(1);
+        task7[0].GetMessage().ShouldContain("FileInfo");
+    }
+
+    [Fact]
+    public async Task FileWriteAllText_DoesNotFlagNonPathContentsArgument()
+    {
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+        using System.IO;
+        using Microsoft.Build.Framework;
+        [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
+        public class MyTask : Microsoft.Build.Utilities.Task, Microsoft.Build.Framework.IMultiThreadableTask
+        {
+            public TaskEnvironment TaskEnvironment { get; set; } = new();
+            public ITaskItem OutputFile { get; set; } = null!;
+            public ITaskItem Contents { get; set; } = null!;
+            public override bool Execute()
+            {
+                File.WriteAllText(OutputFile.ItemSpec, Contents.ItemSpec);
+                return true;
+            }
+        }
+        """);
+
+        var task7 = diags.Where(d => d.Id == DiagnosticIds.PreferTypedTaskItem).ToArray();
+        task7.Length.ShouldBe(1);
+        task7[0].GetMessage().ShouldContain("OutputFile");
+        task7[0].GetMessage().ShouldContain("FileInfo");
+    }
+
+    [Fact]
+    public async Task DirectoryCreate_OnReassignedNullableLocal_SuggestsDirectoryInfo()
+    {
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+            using System.IO;
+            using Microsoft.Build.Framework;
+            [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
+            public class MyTask : Microsoft.Build.Utilities.Task, Microsoft.Build.Framework.IMultiThreadableTask
+            {
+                public TaskEnvironment TaskEnvironment { get; set; } = new();
+                public ITaskItem Directories { get; set; } = null!;
+                public override bool Execute()
+                {
+                    AbsolutePath? absolutePath = null;
+                    absolutePath = TaskEnvironment.GetAbsolutePath(Directories.ItemSpec);
+                    Directory.CreateDirectory(absolutePath);
+                    return true;
+                }
+            }
+            """);
+
+        // The local is declared `= null` then assigned once; the consumption site still resolves to DirectoryInfo.
+        var task7 = diags.Where(d => d.Id == DiagnosticIds.PreferTypedTaskItem).ToArray();
+        task7.Length.ShouldBe(1);
+        task7[0].GetMessage().ShouldContain("DirectoryInfo");
+        task7[0].GetMessage().ShouldNotContain("AbsolutePath");
+    }
+
+    [Fact]
+    public async Task FileAndDirectoryConflict_FallsBackToAbsolutePath()
+    {
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+        using System.IO;
+        using Microsoft.Build.Framework;
+        [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
+        public class MyTask : Microsoft.Build.Utilities.Task, Microsoft.Build.Framework.IMultiThreadableTask
+        {
+            public TaskEnvironment TaskEnvironment { get; set; } = new();
+            public ITaskItem Ambiguous { get; set; } = null!;
+            public override bool Execute()
+            {
+                AbsolutePath abs = TaskEnvironment.GetAbsolutePath(Ambiguous.ItemSpec);
+                File.Delete(abs);
+                Directory.CreateDirectory(abs);
+                return true;
+            }
+        }
+        """);
+
+        // Contradictory file/dir inference for one property: keep the AbsolutePath fallback, drop the specifics.
+        var task7 = diags.Where(d => d.Id == DiagnosticIds.PreferTypedTaskItem).ToArray();
+        task7.Length.ShouldBe(1);
+        task7[0].GetMessage().ShouldContain("AbsolutePath");
+        task7[0].GetMessage().ShouldNotContain("FileInfo");
+        task7[0].GetMessage().ShouldNotContain("DirectoryInfo");
     }
 }

--- a/src/TaskAnalyzer.Tests/PreferTypedParameterAnalyzerTests.cs
+++ b/src/TaskAnalyzer.Tests/PreferTypedParameterAnalyzerTests.cs
@@ -589,11 +589,11 @@ public class PreferTypedParameterAnalyzerTests
             }
             """);
 
-        // Should get MSBuildTask0007 for GetAbsolutePath(item.ItemSpec) AND for new DirectoryInfo(abs)
+        // The AbsolutePath suggestion should be suppressed in favor of DirectoryInfo
         var task7 = diags.Where(d => d.Id == DiagnosticIds.PreferTypedTaskItem).ToArray();
-        task7.Length.ShouldBeGreaterThanOrEqualTo(1);
-        // At least one diagnostic should suggest DirectoryInfo
-        task7.ShouldContain(d => d.GetMessage().Contains("DirectoryInfo"));
+        task7.Length.ShouldBe(1);
+        task7[0].GetMessage().ShouldContain("DirectoryInfo");
+        task7[0].GetMessage().ShouldNotContain("AbsolutePath");
     }
 
     [Fact]
@@ -617,8 +617,9 @@ public class PreferTypedParameterAnalyzerTests
             """);
 
         var task7 = diags.Where(d => d.Id == DiagnosticIds.PreferTypedTaskItem).ToArray();
-        task7.Length.ShouldBeGreaterThanOrEqualTo(1);
-        task7.ShouldContain(d => d.GetMessage().Contains("FileInfo"));
+        task7.Length.ShouldBe(1);
+        task7[0].GetMessage().ShouldContain("FileInfo");
+        task7[0].GetMessage().ShouldNotContain("AbsolutePath");
     }
 
     // ── Negative cases for MSBuildTask0007 ──

--- a/src/TaskAnalyzer.Tests/PreferTypedParameterCodeFixProviderTests.cs
+++ b/src/TaskAnalyzer.Tests/PreferTypedParameterCodeFixProviderTests.cs
@@ -1,0 +1,220 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using Xunit;
+using static Microsoft.Build.TaskAuthoring.Analyzer.Tests.TestHelpers;
+
+namespace Microsoft.Build.TaskAuthoring.Analyzer.Tests;
+
+public class PreferTypedParameterCodeFixProviderTests
+{
+    private static CSharpCodeFixTest<PreferTypedParameterAnalyzer, PreferTypedParameterCodeFixProvider, DefaultVerifier> CreateFixTest(
+        string testCode, string fixedCode, params DiagnosticResult[] expected)
+    {
+        var test = new CSharpCodeFixTest<PreferTypedParameterAnalyzer, PreferTypedParameterCodeFixProvider, DefaultVerifier>
+        {
+            TestCode = testCode,
+            FixedCode = fixedCode,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        };
+        test.TestState.Sources.Add(("Stubs.cs", FrameworkStubs));
+        test.FixedState.Sources.Add(("Stubs.cs", FrameworkStubs));
+        test.ExpectedDiagnostics.AddRange(expected);
+        return test;
+    }
+
+    private static DiagnosticResult Diag(string id) => id switch
+    {
+        DiagnosticIds.PreferTypedPathParameter => new DiagnosticResult(DiagnosticDescriptors.PreferTypedPathParameter),
+        DiagnosticIds.PreferTypedTaskItem => new DiagnosticResult(DiagnosticDescriptors.PreferTypedTaskItem),
+        _ => new DiagnosticResult(id, DiagnosticSeverity.Info),
+    };
+
+    [Fact]
+    public async Task Fix_0006_NewAbsolutePath_RetypesPropertyAndRemovesConversion()
+    {
+        await CreateFixTest(
+            testCode: """
+                using Microsoft.Build.Framework;
+                [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
+                public class MyTask : Microsoft.Build.Utilities.Task
+                {
+                    public string InputPath { get; set; } = "";
+                    public override bool Execute()
+                    {
+                        var abs = {|#0:new AbsolutePath(InputPath)|};
+                        return true;
+                    }
+                }
+                """,
+            fixedCode: """
+                using Microsoft.Build.Framework;
+                [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
+                public class MyTask : Microsoft.Build.Utilities.Task
+                {
+                    public AbsolutePath InputPath { get; set; } = default;
+                    public override bool Execute()
+                    {
+                        var abs = InputPath;
+                        return true;
+                    }
+                }
+                """,
+            Diag(DiagnosticIds.PreferTypedPathParameter).WithLocation(0)
+                .WithArguments("InputPath", "string", "AbsolutePath")).RunAsync();
+    }
+
+    [Fact]
+    public async Task Fix_0006_NewFileInfo_RetypesPropertyAndUsesTypedValue()
+    {
+        await CreateFixTest(
+            testCode: """
+                using System.IO;
+                using Microsoft.Build.Framework;
+                [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
+                public class MyTask : Microsoft.Build.Utilities.Task
+                {
+                    public string FilePath { get; set; } = "";
+                    public override bool Execute()
+                    {
+                        var fi = {|#0:new FileInfo(FilePath)|};
+                        return true;
+                    }
+                }
+                """,
+            fixedCode: """
+                using System.IO;
+                using Microsoft.Build.Framework;
+                [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
+                public class MyTask : Microsoft.Build.Utilities.Task
+                {
+                    public FileInfo FilePath { get; set; } = null!;
+                    public override bool Execute()
+                    {
+                        var fi = FilePath;
+                        return true;
+                    }
+                }
+                """,
+            Diag(DiagnosticIds.PreferTypedPathParameter).WithLocation(0)
+                .WithArguments("FilePath", "string", "FileInfo")).RunAsync();
+    }
+
+    [Fact]
+    public async Task Fix_0007_IntParse_RetypesTaskItemAndUsesValue()
+    {
+        await CreateFixTest(
+            testCode: """
+                using Microsoft.Build.Framework;
+                [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
+                public class MyTask : Microsoft.Build.Utilities.Task
+                {
+                    public ITaskItem Item { get; set; } = null!;
+                    public override bool Execute()
+                    {
+                        int value = {|#0:int.Parse(Item.ItemSpec)|};
+                        return true;
+                    }
+                }
+                """,
+            fixedCode: """
+                using Microsoft.Build.Framework;
+                [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
+                public class MyTask : Microsoft.Build.Utilities.Task
+                {
+                    public ITaskItem<int> Item { get; set; } = null!;
+                    public override bool Execute()
+                    {
+                        int value = Item.Value;
+                        return true;
+                    }
+                }
+                """,
+            Diag(DiagnosticIds.PreferTypedTaskItem).WithLocation(0)
+                .WithArguments("Item", "ITaskItem", "int", "")).RunAsync();
+    }
+
+    [Fact]
+    public async Task Fix_0007_ArrayForeach_RetypesArrayAndUsesValue()
+    {
+        await CreateFixTest(
+            testCode: """
+                using System.IO;
+                using Microsoft.Build.Framework;
+                [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
+                public class MyTask : Microsoft.Build.Utilities.Task
+                {
+                    public ITaskItem[] Items { get; set; } = null!;
+                    public override bool Execute()
+                    {
+                        foreach (var item in Items)
+                        {
+                            var fi = {|#0:new FileInfo(item.ItemSpec)|};
+                        }
+                        return true;
+                    }
+                }
+                """,
+            fixedCode: """
+                using System.IO;
+                using Microsoft.Build.Framework;
+                [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
+                public class MyTask : Microsoft.Build.Utilities.Task
+                {
+                    public ITaskItem<FileInfo>[] Items { get; set; } = null!;
+                    public override bool Execute()
+                    {
+                        foreach (var item in Items)
+                        {
+                            var fi = item.Value;
+                        }
+                        return true;
+                    }
+                }
+                """,
+            Diag(DiagnosticIds.PreferTypedTaskItem).WithLocation(0)
+                .WithArguments("Items", "ITaskItem[]", "FileInfo", "[]")).RunAsync();
+    }
+
+    [Fact]
+    public async Task Fix_0006_RewritesAllSitesForProperty()
+    {
+        await CreateFixTest(
+            testCode: """
+                using Microsoft.Build.Framework;
+                [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
+                public class MyTask : Microsoft.Build.Utilities.Task
+                {
+                    public string InputPath { get; set; } = "";
+                    public override bool Execute()
+                    {
+                        var first = {|#0:new AbsolutePath(InputPath)|};
+                        var second = {|#1:new AbsolutePath(InputPath)|};
+                        return true;
+                    }
+                }
+                """,
+            fixedCode: """
+                using Microsoft.Build.Framework;
+                [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
+                public class MyTask : Microsoft.Build.Utilities.Task
+                {
+                    public AbsolutePath InputPath { get; set; } = default;
+                    public override bool Execute()
+                    {
+                        var first = InputPath;
+                        var second = InputPath;
+                        return true;
+                    }
+                }
+                """,
+            Diag(DiagnosticIds.PreferTypedPathParameter).WithLocation(0)
+                .WithArguments("InputPath", "string", "AbsolutePath"),
+            Diag(DiagnosticIds.PreferTypedPathParameter).WithLocation(1)
+                .WithArguments("InputPath", "string", "AbsolutePath")).RunAsync();
+    }
+}

--- a/src/TaskAnalyzer.Tests/TestHelpers.cs
+++ b/src/TaskAnalyzer.Tests/TestHelpers.cs
@@ -190,6 +190,21 @@ internal static class TestHelpers
     }
 
     /// <summary>
+    /// Runs the UnsupportedTaskItemTypeAnalyzer on the given source code and returns analyzer diagnostics.
+    /// Source is combined with framework stubs automatically.
+    /// </summary>
+    public static async System.Threading.Tasks.Task<ImmutableArray<Diagnostic>> GetUnsupportedTaskItemTypeDiagnosticsAsync(string source)
+    {
+        var compilation = CreateCompilation(source);
+        var analyzer = new UnsupportedTaskItemTypeAnalyzer();
+        var compilationWithAnalyzers = compilation.WithAnalyzers(
+            ImmutableArray.Create<DiagnosticAnalyzer>(analyzer));
+
+        var allDiags = await compilationWithAnalyzers.GetAnalyzerDiagnosticsAsync();
+        return allDiags;
+    }
+
+    /// <summary>
     /// Creates a compilation with the given source code and framework stubs.
     /// </summary>
     public static CSharpCompilation CreateCompilation(string source)

--- a/src/TaskAnalyzer.Tests/TestHelpers.cs
+++ b/src/TaskAnalyzer.Tests/TestHelpers.cs
@@ -50,6 +50,7 @@ internal static class TestHelpers
 
             public struct AbsolutePath
             {
+                public AbsolutePath(string path) { Value = path; OriginalValue = path; }
                 public string Value { get; }
                 public string OriginalValue { get; }
                 public static implicit operator string(AbsolutePath p) => p.Value;
@@ -61,12 +62,24 @@ internal static class TestHelpers
                 string GetMetadata(string metadataName);
             }
 
+            public interface ITaskItem2 : ITaskItem
+            {
+            }
+
+            public interface ITaskItem<T> : ITaskItem2
+            {
+                T Value { get; }
+            }
+
             public class TaskItem : ITaskItem
             {
                 public string ItemSpec { get; set; } = string.Empty;
                 public string GetMetadata(string metadataName) => string.Empty;
                 public string GetMetadataValue(string metadataName) => string.Empty;
             }
+
+            [System.AttributeUsage(System.AttributeTargets.Property)]
+            public sealed class OutputAttribute : System.Attribute { }
 
             [System.AttributeUsage(System.AttributeTargets.Class)]
             public class MSBuildMultiThreadableTaskAnalyzedAttribute : System.Attribute { }
@@ -159,6 +172,21 @@ internal static class TestHelpers
         return allDiagnostics
             .Where(d => d.Location.SourceTree?.FilePath == "Test.cs")
             .ToImmutableArray();
+    }
+
+    /// <summary>
+    /// Runs the PreferTypedParameterAnalyzer on the given source code and returns analyzer diagnostics.
+    /// Source is combined with framework stubs automatically.
+    /// </summary>
+    public static async System.Threading.Tasks.Task<ImmutableArray<Diagnostic>> GetTypedParameterDiagnosticsAsync(string source)
+    {
+        var compilation = CreateCompilation(source);
+        var analyzer = new PreferTypedParameterAnalyzer();
+        var compilationWithAnalyzers = compilation.WithAnalyzers(
+            ImmutableArray.Create<DiagnosticAnalyzer>(analyzer));
+
+        var allDiags = await compilationWithAnalyzers.GetAnalyzerDiagnosticsAsync();
+        return allDiags;
     }
 
     /// <summary>

--- a/src/TaskAnalyzer.Tests/UnsupportedTaskItemTypeAnalyzerTests.cs
+++ b/src/TaskAnalyzer.Tests/UnsupportedTaskItemTypeAnalyzerTests.cs
@@ -1,0 +1,191 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Threading.Tasks;
+using Shouldly;
+using Xunit;
+using static Microsoft.Build.TaskAuthoring.Analyzer.Tests.TestHelpers;
+
+namespace Microsoft.Build.TaskAuthoring.Analyzer.Tests;
+
+/// <summary>
+/// Tests for <see cref="UnsupportedTaskItemTypeAnalyzer"/> covering MSBuildTask0008.
+/// </summary>
+public class UnsupportedTaskItemTypeAnalyzerTests
+{
+    // ═══════════════════════════════════════════════════════════════════════
+    // Supported types — no diagnostic expected
+    // ═══════════════════════════════════════════════════════════════════════
+
+    [Theory]
+    [InlineData("int")]
+    [InlineData("bool")]
+    [InlineData("long")]
+    [InlineData("double")]
+    [InlineData("float")]
+    [InlineData("decimal")]
+    [InlineData("byte")]
+    [InlineData("sbyte")]
+    [InlineData("short")]
+    [InlineData("ushort")]
+    [InlineData("uint")]
+    [InlineData("ulong")]
+    [InlineData("char")]
+    [InlineData("string")]
+    public async Task SupportedValueType_NoDiagnostic(string typeName)
+    {
+        var diags = await GetUnsupportedTaskItemTypeDiagnosticsAsync($$"""
+            using Microsoft.Build.Framework;
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                public ITaskItem<{{typeName}}> Item { get; set; } = null!;
+                public override bool Execute() => true;
+            }
+            """);
+
+        diags.ShouldNotContain(d => d.Id == DiagnosticIds.UnsupportedTaskItemType);
+    }
+
+    [Fact]
+    public async Task AbsolutePath_NoDiagnostic()
+    {
+        var diags = await GetUnsupportedTaskItemTypeDiagnosticsAsync("""
+            using Microsoft.Build.Framework;
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                public ITaskItem<AbsolutePath> Item { get; set; } = null!;
+                public override bool Execute() => true;
+            }
+            """);
+
+        diags.ShouldNotContain(d => d.Id == DiagnosticIds.UnsupportedTaskItemType);
+    }
+
+    [Fact]
+    public async Task FileInfo_NoDiagnostic()
+    {
+        var diags = await GetUnsupportedTaskItemTypeDiagnosticsAsync("""
+            using System.IO;
+            using Microsoft.Build.Framework;
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                public ITaskItem<FileInfo> Item { get; set; } = null!;
+                public override bool Execute() => true;
+            }
+            """);
+
+        diags.ShouldNotContain(d => d.Id == DiagnosticIds.UnsupportedTaskItemType);
+    }
+
+    [Fact]
+    public async Task DirectoryInfo_NoDiagnostic()
+    {
+        var diags = await GetUnsupportedTaskItemTypeDiagnosticsAsync("""
+            using System.IO;
+            using Microsoft.Build.Framework;
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                public ITaskItem<DirectoryInfo> Item { get; set; } = null!;
+                public override bool Execute() => true;
+            }
+            """);
+
+        diags.ShouldNotContain(d => d.Id == DiagnosticIds.UnsupportedTaskItemType);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Array variants of supported types — no diagnostic expected
+    // ═══════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task SupportedTypeArray_NoDiagnostic()
+    {
+        var diags = await GetUnsupportedTaskItemTypeDiagnosticsAsync("""
+            using Microsoft.Build.Framework;
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                public ITaskItem<int>[] Items { get; set; } = null!;
+                public override bool Execute() => true;
+            }
+            """);
+
+        diags.ShouldNotContain(d => d.Id == DiagnosticIds.UnsupportedTaskItemType);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Unsupported types — diagnostic expected
+    // ═══════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task Guid_ProducesDiagnostic()
+    {
+        var diags = await GetUnsupportedTaskItemTypeDiagnosticsAsync("""
+            using System;
+            using Microsoft.Build.Framework;
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                public ITaskItem<Guid> Item { get; set; } = null!;
+                public override bool Execute() => true;
+            }
+            """);
+
+        diags.ShouldContain(d => d.Id == DiagnosticIds.UnsupportedTaskItemType);
+        diags[0].GetMessage().ShouldContain("Item");
+        diags[0].GetMessage().ShouldContain("Guid");
+    }
+
+    [Fact]
+    public async Task TimeSpan_ProducesDiagnostic()
+    {
+        var diags = await GetUnsupportedTaskItemTypeDiagnosticsAsync("""
+            using System;
+            using Microsoft.Build.Framework;
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                public ITaskItem<TimeSpan> Duration { get; set; } = null!;
+                public override bool Execute() => true;
+            }
+            """);
+
+        diags.ShouldContain(d => d.Id == DiagnosticIds.UnsupportedTaskItemType);
+        diags[0].GetMessage().ShouldContain("Duration");
+        diags[0].GetMessage().ShouldContain("TimeSpan");
+    }
+
+    [Fact]
+    public async Task UnsupportedTypeArray_ProducesDiagnostic()
+    {
+        var diags = await GetUnsupportedTaskItemTypeDiagnosticsAsync("""
+            using System;
+            using Microsoft.Build.Framework;
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                public ITaskItem<Guid>[] Items { get; set; } = null!;
+                public override bool Execute() => true;
+            }
+            """);
+
+        diags.ShouldContain(d => d.Id == DiagnosticIds.UnsupportedTaskItemType);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Non-task classes — no diagnostic expected
+    // ═══════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task NonTaskClass_NoDiagnostic()
+    {
+        // A class that does not implement ITask should not trigger the diagnostic,
+        // even if it has an ITaskItem<Guid> property.
+        var diags = await GetUnsupportedTaskItemTypeDiagnosticsAsync("""
+            using System;
+            using Microsoft.Build.Framework;
+            public class NotATask
+            {
+                public ITaskItem<Guid> Item { get; set; } = null!;
+            }
+            """);
+
+        diags.ShouldNotContain(d => d.Id == DiagnosticIds.UnsupportedTaskItemType);
+    }
+}

--- a/src/TaskAnalyzer/AnalyzerReleases.Unshipped.md
+++ b/src/TaskAnalyzer/AnalyzerReleases.Unshipped.md
@@ -7,3 +7,5 @@ MSBuildTask0002 | MSBuild.TaskAuthoring | Warning | APIs that should use TaskEnv
 MSBuildTask0003 | MSBuild.TaskAuthoring | Warning | File APIs that need absolute paths
 MSBuildTask0004 | MSBuild.TaskAuthoring | Warning | APIs that may cause issues in multithreaded task execution
 MSBuildTask0005 | MSBuild.TaskAuthoring | Warning | Transitive unsafe API usage detected in task call chain
+MSBuildTask0006 | MSBuild.TaskAuthoring | Info | Prefer typed path parameter (AbsolutePath/FileInfo/DirectoryInfo) over string
+MSBuildTask0007 | MSBuild.TaskAuthoring | Info | Prefer ITaskItem<T> over manual ItemSpec parsing

--- a/src/TaskAnalyzer/AnalyzerReleases.Unshipped.md
+++ b/src/TaskAnalyzer/AnalyzerReleases.Unshipped.md
@@ -7,5 +7,5 @@ MSBuildTask0002 | MSBuild.TaskAuthoring | Warning | APIs that should use TaskEnv
 MSBuildTask0003 | MSBuild.TaskAuthoring | Warning | File APIs that need absolute paths
 MSBuildTask0004 | MSBuild.TaskAuthoring | Warning | APIs that may cause issues in multithreaded task execution
 MSBuildTask0005 | MSBuild.TaskAuthoring | Warning | Transitive unsafe API usage detected in task call chain
-MSBuildTask0006 | MSBuild.TaskAuthoring | Info | Prefer typed path parameter (AbsolutePath/FileInfo/DirectoryInfo) over string
-MSBuildTask0007 | MSBuild.TaskAuthoring | Info | Prefer ITaskItem<T> over manual ItemSpec parsing
+MSBuildTask0006 | MSBuild.TaskAuthoring | Info | Prefer typed path parameter (AbsolutePath/FileInfo/DirectoryInfo) over string (code fix available)
+MSBuildTask0007 | MSBuild.TaskAuthoring | Info | Prefer ITaskItem<T> over manual ItemSpec parsing (code fix available)

--- a/src/TaskAnalyzer/AnalyzerReleases.Unshipped.md
+++ b/src/TaskAnalyzer/AnalyzerReleases.Unshipped.md
@@ -9,3 +9,4 @@ MSBuildTask0004 | MSBuild.TaskAuthoring | Warning | APIs that may cause issues i
 MSBuildTask0005 | MSBuild.TaskAuthoring | Warning | Transitive unsafe API usage detected in task call chain
 MSBuildTask0006 | MSBuild.TaskAuthoring | Info | Prefer typed path parameter (AbsolutePath/FileInfo/DirectoryInfo) over string (code fix available)
 MSBuildTask0007 | MSBuild.TaskAuthoring | Info | Prefer ITaskItem<T> over manual ItemSpec parsing (code fix available)
+MSBuildTask0008 | MSBuild.TaskAuthoring | Warning | ITaskItem<T> used with a type argument T that ValueTypeParser cannot parse at runtime

--- a/src/TaskAnalyzer/DiagnosticDescriptors.cs
+++ b/src/TaskAnalyzer/DiagnosticDescriptors.cs
@@ -58,11 +58,31 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
             description: "A method called from this task transitively uses an API that is unsafe in multithreaded task execution. Review the call chain and migrate the callee.",
             customTags: WellKnownDiagnosticTags.CompilationEnd);
 
+        public static readonly DiagnosticDescriptor PreferTypedPathParameter = new(
+            id: DiagnosticIds.PreferTypedPathParameter,
+            title: "Prefer typed path parameter over manual path construction",
+            messageFormat: "Consider changing task property '{0}' from '{1}' to '{2}' instead of converting inside the task body",
+            category: "MSBuild.TaskAuthoring",
+            defaultSeverity: DiagnosticSeverity.Info,
+            isEnabledByDefault: true,
+            description: "MSBuild can bind AbsolutePath, FileInfo, and DirectoryInfo task parameters automatically. Using these types avoids manual path construction in the task body.");
+
+        public static readonly DiagnosticDescriptor PreferTypedTaskItem = new(
+            id: DiagnosticIds.PreferTypedTaskItem,
+            title: "Prefer ITaskItem<T> over manual ItemSpec parsing",
+            messageFormat: "Consider changing task property '{0}' from '{1}' to 'ITaskItem<{2}>' instead of parsing ItemSpec manually",
+            category: "MSBuild.TaskAuthoring",
+            defaultSeverity: DiagnosticSeverity.Info,
+            isEnabledByDefault: true,
+            description: "MSBuild can bind ITaskItem<T> task parameters that provide a strongly-typed Value property parsed from ItemSpec. Using ITaskItem<T> avoids manual parsing in the task body.");
+
         public static ImmutableArray<DiagnosticDescriptor> All { get; } = ImmutableArray.Create(
             CriticalError,
             TaskEnvironmentRequired,
             FilePathRequiresAbsolute,
             PotentialIssue,
-            TransitiveUnsafeCall);
+            TransitiveUnsafeCall,
+            PreferTypedPathParameter,
+            PreferTypedTaskItem);
     }
 }

--- a/src/TaskAnalyzer/DiagnosticDescriptors.cs
+++ b/src/TaskAnalyzer/DiagnosticDescriptors.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
         public static readonly DiagnosticDescriptor PreferTypedTaskItem = new(
             id: DiagnosticIds.PreferTypedTaskItem,
             title: "Prefer ITaskItem<T> over manual ItemSpec parsing",
-            messageFormat: "Consider changing task property '{0}' from '{1}' to 'ITaskItem<{2}>' instead of parsing ItemSpec manually",
+            messageFormat: "Consider changing task property '{0}' from '{1}' to 'ITaskItem<{2}>{3}' instead of parsing ItemSpec manually",
             category: "MSBuild.TaskAuthoring",
             defaultSeverity: DiagnosticSeverity.Info,
             isEnabledByDefault: true,

--- a/src/TaskAnalyzer/DiagnosticDescriptors.cs
+++ b/src/TaskAnalyzer/DiagnosticDescriptors.cs
@@ -76,6 +76,15 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
             isEnabledByDefault: true,
             description: "MSBuild can bind ITaskItem<T> task parameters that provide a strongly-typed Value property parsed from ItemSpec for tasks that opt into multithreaded support. Using ITaskItem<T> avoids manual parsing in the task body.");
 
+        public static readonly DiagnosticDescriptor UnsupportedTaskItemType = new(
+            id: DiagnosticIds.UnsupportedTaskItemType,
+            title: "ITaskItem<T> used with unsupported type argument",
+            messageFormat: "Task property '{0}' uses ITaskItem<{1}> but '{1}' is not supported by MSBuild's ValueTypeParser. Supported types are: bool, char, byte, sbyte, short, ushort, int, uint, long, ulong, float, double, decimal, string, AbsolutePath, FileInfo, DirectoryInfo.",
+            category: "MSBuild.TaskAuthoring",
+            defaultSeverity: DiagnosticSeverity.Warning,
+            isEnabledByDefault: true,
+            description: "MSBuild can only parse ITaskItem<T> properties when T is a type supported by ValueTypeParser. Using an unsupported type will cause a runtime failure when MSBuild tries to bind the parameter.");
+
         public static ImmutableArray<DiagnosticDescriptor> All { get; } = ImmutableArray.Create(
             CriticalError,
             TaskEnvironmentRequired,
@@ -83,6 +92,7 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
             PotentialIssue,
             TransitiveUnsafeCall,
             PreferTypedPathParameter,
-            PreferTypedTaskItem);
+            PreferTypedTaskItem,
+            UnsupportedTaskItemType);
     }
 }

--- a/src/TaskAnalyzer/DiagnosticDescriptors.cs
+++ b/src/TaskAnalyzer/DiagnosticDescriptors.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
             category: "MSBuild.TaskAuthoring",
             defaultSeverity: DiagnosticSeverity.Info,
             isEnabledByDefault: true,
-            description: "MSBuild can bind AbsolutePath, FileInfo, and DirectoryInfo task parameters automatically. Using these types avoids manual path construction in the task body.");
+            description: "MSBuild can bind AbsolutePath, FileInfo, and DirectoryInfo task parameters automatically for tasks that opt into multithreaded support. Using these types avoids manual path construction in the task body.");
 
         public static readonly DiagnosticDescriptor PreferTypedTaskItem = new(
             id: DiagnosticIds.PreferTypedTaskItem,
@@ -74,7 +74,7 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
             category: "MSBuild.TaskAuthoring",
             defaultSeverity: DiagnosticSeverity.Info,
             isEnabledByDefault: true,
-            description: "MSBuild can bind ITaskItem<T> task parameters that provide a strongly-typed Value property parsed from ItemSpec. Using ITaskItem<T> avoids manual parsing in the task body.");
+            description: "MSBuild can bind ITaskItem<T> task parameters that provide a strongly-typed Value property parsed from ItemSpec for tasks that opt into multithreaded support. Using ITaskItem<T> avoids manual parsing in the task body.");
 
         public static ImmutableArray<DiagnosticDescriptor> All { get; } = ImmutableArray.Create(
             CriticalError,

--- a/src/TaskAnalyzer/DiagnosticIds.cs
+++ b/src/TaskAnalyzer/DiagnosticIds.cs
@@ -23,5 +23,11 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
 
         /// <summary>Transitive unsafe API usage detected in task call chain.</summary>
         public const string TransitiveUnsafeCall = "MSBuildTask0005";
+
+        /// <summary>Task input property should use AbsolutePath, FileInfo, or DirectoryInfo instead of string.</summary>
+        public const string PreferTypedPathParameter = "MSBuildTask0006";
+
+        /// <summary>Task input property should use ITaskItem&lt;T&gt; instead of ITaskItem with manual ItemSpec parsing.</summary>
+        public const string PreferTypedTaskItem = "MSBuildTask0007";
     }
 }

--- a/src/TaskAnalyzer/DiagnosticIds.cs
+++ b/src/TaskAnalyzer/DiagnosticIds.cs
@@ -29,5 +29,8 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
 
         /// <summary>Task input property should use ITaskItem&lt;T&gt; instead of ITaskItem with manual ItemSpec parsing.</summary>
         public const string PreferTypedTaskItem = "MSBuildTask0007";
+
+        /// <summary>Task property uses ITaskItem&lt;T&gt; with a type argument not supported by ValueTypeParser.</summary>
+        public const string UnsupportedTaskItemType = "MSBuildTask0008";
     }
 }

--- a/src/TaskAnalyzer/PreferTypedParameterAnalyzer.cs
+++ b/src/TaskAnalyzer/PreferTypedParameterAnalyzer.cs
@@ -36,8 +36,17 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
 
         private static void OnCompilationStart(CompilationStartAnalysisContext compilationContext)
         {
+            // The class must implement ITask to be considered a task at all
             var iTaskType = compilationContext.Compilation.GetTypeByMetadataName(WellKnownTypeNames.ITaskFullName);
             if (iTaskType is null)
+            {
+                return;
+            }
+
+            // Additionally, the task must opt into multithreaded support
+            var iMultiThreadableTaskType = compilationContext.Compilation.GetTypeByMetadataName(WellKnownTypeNames.IMultiThreadableTaskFullName);
+            var multiThreadableTaskAttributeType = compilationContext.Compilation.GetTypeByMetadataName(WellKnownTypeNames.MultiThreadableTaskAttributeFullName);
+            if (iMultiThreadableTaskType is null && multiThreadableTaskAttributeType is null)
             {
                 return;
             }
@@ -52,7 +61,20 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
             compilationContext.RegisterSymbolStartAction(symbolStartContext =>
             {
                 var namedType = (INamedTypeSymbol)symbolStartContext.Symbol;
+
+                // Gate 1: Must be an ITask implementation
                 if (!ImplementsInterface(namedType, iTaskType))
+                {
+                    return;
+                }
+
+                // Gate 2: Must have opted into multithreaded support
+                bool isMultiThreadable =
+                    (iMultiThreadableTaskType is not null && ImplementsInterface(namedType, iMultiThreadableTaskType)) ||
+                    (multiThreadableTaskAttributeType is not null && namedType.GetAttributes().Any(
+                        attr => SymbolEqualityComparer.Default.Equals(attr.AttributeClass, multiThreadableTaskAttributeType)));
+
+                if (!isMultiThreadable)
                 {
                     return;
                 }

--- a/src/TaskAnalyzer/PreferTypedParameterAnalyzer.cs
+++ b/src/TaskAnalyzer/PreferTypedParameterAnalyzer.cs
@@ -534,16 +534,19 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
         /// <summary>
         /// Determines the parsed target type from a Parse/TryParse/Convert method call.
         /// Returns the simple type name suitable for ITaskItem&lt;T&gt; suggestion, or null if not a recognized parse call.
+        /// Only returns suggestions for types supported by ValueTypeParser.
         /// </summary>
         private static string? GetParsedTypeFromMethod(IMethodSymbol method)
         {
             // Static Parse/TryParse on value types: int.Parse, bool.Parse, etc.
+            // Restrict to types supported by ValueTypeParser to avoid suggesting unsupported types like Guid.
             if ((method.Name == "Parse" || method.Name == "TryParse") &&
                 method.IsStatic &&
                 method.ContainingType is not null &&
                 method.ContainingType.IsValueType)
             {
-                return method.ContainingType.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
+                string typeName = method.ContainingType.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
+                return s_supportedValueTypeNames.Contains(typeName) ? typeName : null;
             }
 
             // Convert.ToXxx methods
@@ -571,6 +574,28 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
 
             return null;
         }
+
+        /// <summary>
+        /// Value type names (as minimal C# names) that ValueTypeParser supports.
+        /// Only these types should be suggested by the analyzer.
+        /// </summary>
+        private static readonly System.Collections.Generic.HashSet<string> s_supportedValueTypeNames =
+            new(System.StringComparer.Ordinal)
+            {
+                "bool",
+                "char",
+                "byte",
+                "sbyte",
+                "short",
+                "ushort",
+                "int",
+                "uint",
+                "long",
+                "ulong",
+                "float",
+                "double",
+                "decimal",
+            };
 
         /// <summary>
         /// Checks if the given operation traces back (with at most one level of local indirection)

--- a/src/TaskAnalyzer/PreferTypedParameterAnalyzer.cs
+++ b/src/TaskAnalyzer/PreferTypedParameterAnalyzer.cs
@@ -151,7 +151,7 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
             {
                 case IObjectCreationOperation creation:
                     AnalyzeObjectCreation(context, creation, stringInputProps, taskItemInputProps,
-                        absolutePathType, iTaskItemType, fileInfoType, directoryInfoType);
+                        absolutePathType, taskEnvironmentType, iTaskItemType, fileInfoType, directoryInfoType);
                     break;
 
                 case IInvocationOperation invocation:
@@ -168,6 +168,7 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
             HashSet<IPropertySymbol> stringInputProps,
             HashSet<IPropertySymbol> taskItemInputProps,
             INamedTypeSymbol? absolutePathType,
+            INamedTypeSymbol? taskEnvironmentType,
             INamedTypeSymbol? iTaskItemType,
             INamedTypeSymbol? fileInfoType,
             INamedTypeSymbol? directoryInfoType)
@@ -228,6 +229,7 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
 
                 if (suggestedTypeArg is not null)
                 {
+                    // Direct: new FileInfo(item.ItemSpec) or new AbsolutePath(item.ItemSpec)
                     var (sourceProp, _) = FindItemSpecSource(creation.Arguments[0].Value, taskItemInputProps, iTaskItemType);
                     if (sourceProp is not null)
                     {
@@ -236,6 +238,22 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                             DiagnosticDescriptors.PreferTypedTaskItem,
                             creation.Syntax.GetLocation(),
                             sourceProp.Name, currentType, suggestedTypeArg));
+                        return;
+                    }
+
+                    // Indirect via AbsolutePath: new FileInfo(absLocal) where absLocal = GetAbsolutePath(item.ItemSpec)
+                    if (suggestedTypeArg != "AbsolutePath" && taskEnvironmentType is not null)
+                    {
+                        var itemProp = FindItemSpecSourceThroughAbsolutePath(
+                            creation.Arguments[0].Value, taskItemInputProps, iTaskItemType, taskEnvironmentType);
+                        if (itemProp is not null)
+                        {
+                            string currentType = itemProp.Type is IArrayTypeSymbol ? "ITaskItem[]" : "ITaskItem";
+                            context.ReportDiagnostic(Diagnostic.Create(
+                                DiagnosticDescriptors.PreferTypedTaskItem,
+                                creation.Syntax.GetLocation(),
+                                itemProp.Name, currentType, suggestedTypeArg));
+                        }
                     }
                 }
             }
@@ -616,6 +634,58 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
             }
 
             return (null, false);
+        }
+
+        /// <summary>
+        /// Traces through an AbsolutePath intermediary to find the original ITaskItem source.
+        /// Handles patterns like:
+        ///   AbsolutePath abs = TaskEnvironment.GetAbsolutePath(item.ItemSpec);
+        ///   new FileInfo(abs);  // abs traces back to item.ItemSpec
+        /// </summary>
+        private static IPropertySymbol? FindItemSpecSourceThroughAbsolutePath(
+            IOperation operation,
+            HashSet<IPropertySymbol> taskItemInputProps,
+            INamedTypeSymbol iTaskItemType,
+            INamedTypeSymbol taskEnvironmentType)
+        {
+            // Unwrap conversions
+            while (operation is IConversionOperation conversion)
+            {
+                operation = conversion.Operand;
+            }
+
+            // Direct: new FileInfo(TaskEnvironment.GetAbsolutePath(item.ItemSpec))
+            if (operation is IInvocationOperation invocation &&
+                invocation.TargetMethod.Name == "GetAbsolutePath" &&
+                SymbolEqualityComparer.Default.Equals(invocation.TargetMethod.ContainingType, taskEnvironmentType) &&
+                invocation.Arguments.Length > 0)
+            {
+                var (sourceProp, _) = FindItemSpecSource(invocation.Arguments[0].Value, taskItemInputProps, iTaskItemType);
+                return sourceProp;
+            }
+
+            // Local indirection: var abs = TaskEnvironment.GetAbsolutePath(item.ItemSpec); new FileInfo(abs);
+            if (operation is ILocalReferenceOperation localRef)
+            {
+                var local = localRef.Local;
+                if (local.DeclaringSyntaxReferences.Length == 1)
+                {
+                    var syntax = local.DeclaringSyntaxReferences[0].GetSyntax();
+                    var semanticModel = operation.SemanticModel;
+                    if (semanticModel is not null)
+                    {
+                        var declOp = semanticModel.GetOperation(syntax);
+                        if (declOp is IVariableDeclaratorOperation declarator &&
+                            declarator.Initializer?.Value is IOperation initValue)
+                        {
+                            return FindItemSpecSourceThroughAbsolutePath(
+                                initValue, taskItemInputProps, iTaskItemType, taskEnvironmentType);
+                        }
+                    }
+                }
+            }
+
+            return null;
         }
     }
 }

--- a/src/TaskAnalyzer/PreferTypedParameterAnalyzer.cs
+++ b/src/TaskAnalyzer/PreferTypedParameterAnalyzer.cs
@@ -300,6 +300,44 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                     }
                 }
             }
+
+            // Path.Combine(...) with any argument tracing to a task input property
+            if (method.ContainingType?.ToDisplayString() == "System.IO.Path" &&
+                method.Name == "Combine" &&
+                invocation.Arguments.Length >= 2)
+            {
+                foreach (var arg in invocation.Arguments)
+                {
+                    // MSBuildTask0006: Path.Combine(stringProp, ...) or Path.Combine(..., stringProp)
+                    if (stringInputProps.Count > 0)
+                    {
+                        var sourceProp = FindSourceProperty(arg.Value, stringInputProps);
+                        if (sourceProp is not null)
+                        {
+                            context.ReportDiagnostic(Diagnostic.Create(
+                                DiagnosticDescriptors.PreferTypedPathParameter,
+                                invocation.Syntax.GetLocation(),
+                                sourceProp.Name, "string", "AbsolutePath"));
+                            break;
+                        }
+                    }
+
+                    // MSBuildTask0007: Path.Combine(item.ItemSpec, ...) or Path.Combine(..., item.ItemSpec)
+                    if (taskItemInputProps.Count > 0 && iTaskItemType is not null)
+                    {
+                        var (itemProp, _) = FindItemSpecSource(arg.Value, taskItemInputProps, iTaskItemType);
+                        if (itemProp is not null)
+                        {
+                            string currentType = itemProp.Type is IArrayTypeSymbol ? "ITaskItem[]" : "ITaskItem";
+                            context.ReportDiagnostic(Diagnostic.Create(
+                                DiagnosticDescriptors.PreferTypedTaskItem,
+                                invocation.Syntax.GetLocation(),
+                                itemProp.Name, currentType, "AbsolutePath"));
+                            break;
+                        }
+                    }
+                }
+            }
         }
 
         /// <summary>
@@ -384,6 +422,20 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                 }
             }
 
+            // One level of method call wrapping: SomeMethod(stringProp)
+            // e.g., FileUtilities.FixFilePath(stringProp)
+            if (operation is IInvocationOperation wrappingCall && wrappingCall.Arguments.Length > 0)
+            {
+                foreach (var arg in wrappingCall.Arguments)
+                {
+                    var result = FindSourcePropertyDirect(arg.Value, candidateProps);
+                    if (result is not null)
+                    {
+                        return result;
+                    }
+                }
+            }
+
             return null;
         }
 
@@ -412,6 +464,7 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
         /// Checks if the given operation is an access to .ItemSpec on an ITaskItem
         /// that traces back to one of the collected task input properties.
         /// Returns the source property and whether it came from an array element.
+        /// Also traces through one level of method call wrapping (e.g., FixFilePath(item.ItemSpec)).
         /// </summary>
         private static (IPropertySymbol? sourceProp, bool fromArray) FindItemSpecSource(
             IOperation operation,
@@ -445,6 +498,20 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                 }
 
                 return (null, false);
+            }
+
+            // One level of method call wrapping: SomeMethod(item.ItemSpec)
+            // e.g., FileUtilities.FixFilePath(item.ItemSpec)
+            if (operation is IInvocationOperation wrappingCall && wrappingCall.Arguments.Length > 0)
+            {
+                foreach (var arg in wrappingCall.Arguments)
+                {
+                    var result = FindItemSpecSourceDirect(arg.Value, taskItemInputProps, iTaskItemType);
+                    if (result.sourceProp is not null)
+                    {
+                        return result;
+                    }
+                }
             }
 
             return FindItemSpecSourceDirect(operation, taskItemInputProps, iTaskItemType);

--- a/src/TaskAnalyzer/PreferTypedParameterAnalyzer.cs
+++ b/src/TaskAnalyzer/PreferTypedParameterAnalyzer.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -126,19 +127,77 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                     return;
                 }
 
+                // Collect diagnostics during operation analysis, then deduplicate in SymbolEndAction.
+                // This allows suppressing AbsolutePath suggestions when a more specific
+                // FileInfo/DirectoryInfo suggestion exists for the same property.
+                var pendingDiagnostics = new ConcurrentBag<Diagnostic>();
+
                 symbolStartContext.RegisterOperationAction(ctx =>
                 {
-                    AnalyzeOperation(ctx, stringInputProps, taskItemInputProps,
+                    AnalyzeOperation(ctx, pendingDiagnostics, stringInputProps, taskItemInputProps,
                         absolutePathType, taskEnvironmentType, iTaskItemType,
                         fileInfoType, directoryInfoType);
                 },
                 OperationKind.ObjectCreation,
                 OperationKind.Invocation);
+
+                symbolStartContext.RegisterSymbolEndAction(endCtx =>
+                {
+                    // Group diagnostics by property name + rule ID, then suppress AbsolutePath
+                    // suggestions when a FileInfo/DirectoryInfo suggestion exists for the same property.
+                    var diagnosticsList = pendingDiagnostics.ToList();
+
+                    // Find properties that have FileInfo or DirectoryInfo suggestions
+                    var propsWithSpecificType = new HashSet<string>();
+                    foreach (var diag in diagnosticsList)
+                    {
+                        string message = diag.GetMessage();
+                        if (message.Contains("FileInfo") || message.Contains("DirectoryInfo"))
+                        {
+                            // Extract property name from message format: "... property '{0}' from ..."
+                            int startIdx = message.IndexOf('\'');
+                            if (startIdx >= 0)
+                            {
+                                int endIdx = message.IndexOf('\'', startIdx + 1);
+                                if (endIdx > startIdx)
+                                {
+                                    string propName = message.Substring(startIdx + 1, endIdx - startIdx - 1);
+                                    propsWithSpecificType.Add(diag.Id + "|" + propName);
+                                }
+                            }
+                        }
+                    }
+
+                    foreach (var diag in diagnosticsList)
+                    {
+                        string message = diag.GetMessage();
+                        // Suppress AbsolutePath suggestions when FileInfo/DirectoryInfo exists for same property
+                        if (message.Contains("AbsolutePath") && propsWithSpecificType.Count > 0)
+                        {
+                            int startIdx = message.IndexOf('\'');
+                            if (startIdx >= 0)
+                            {
+                                int endIdx = message.IndexOf('\'', startIdx + 1);
+                                if (endIdx > startIdx)
+                                {
+                                    string propName = message.Substring(startIdx + 1, endIdx - startIdx - 1);
+                                    if (propsWithSpecificType.Contains(diag.Id + "|" + propName))
+                                    {
+                                        continue; // Suppress — more specific type available
+                                    }
+                                }
+                            }
+                        }
+
+                        endCtx.ReportDiagnostic(diag);
+                    }
+                });
             }, SymbolKind.NamedType);
         }
 
         private static void AnalyzeOperation(
             OperationAnalysisContext context,
+            ConcurrentBag<Diagnostic> pendingDiagnostics,
             HashSet<IPropertySymbol> stringInputProps,
             HashSet<IPropertySymbol> taskItemInputProps,
             INamedTypeSymbol? absolutePathType,
@@ -150,12 +209,12 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
             switch (context.Operation)
             {
                 case IObjectCreationOperation creation:
-                    AnalyzeObjectCreation(context, creation, stringInputProps, taskItemInputProps,
+                    AnalyzeObjectCreation(pendingDiagnostics, creation, stringInputProps, taskItemInputProps,
                         absolutePathType, taskEnvironmentType, iTaskItemType, fileInfoType, directoryInfoType);
                     break;
 
                 case IInvocationOperation invocation:
-                    AnalyzeInvocation(context, invocation, stringInputProps, taskItemInputProps,
+                    AnalyzeInvocation(pendingDiagnostics, invocation, stringInputProps, taskItemInputProps,
                         absolutePathType, taskEnvironmentType, iTaskItemType,
                         fileInfoType, directoryInfoType);
                     break;
@@ -163,7 +222,7 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
         }
 
         private static void AnalyzeObjectCreation(
-            OperationAnalysisContext context,
+            ConcurrentBag<Diagnostic> pendingDiagnostics,
             IObjectCreationOperation creation,
             HashSet<IPropertySymbol> stringInputProps,
             HashSet<IPropertySymbol> taskItemInputProps,
@@ -201,7 +260,7 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                     var sourceProp = FindSourceProperty(creation.Arguments[0].Value, stringInputProps);
                     if (sourceProp is not null)
                     {
-                        context.ReportDiagnostic(Diagnostic.Create(
+                        pendingDiagnostics.Add(Diagnostic.Create(
                             DiagnosticDescriptors.PreferTypedPathParameter,
                             creation.Syntax.GetLocation(),
                             sourceProp.Name, "string", suggestedType));
@@ -235,7 +294,7 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                     {
                         bool isArray = sourceProp.Type is IArrayTypeSymbol;
                         string currentType = isArray ? "ITaskItem[]" : "ITaskItem";
-                        context.ReportDiagnostic(Diagnostic.Create(
+                        pendingDiagnostics.Add(Diagnostic.Create(
                             DiagnosticDescriptors.PreferTypedTaskItem,
                             creation.Syntax.GetLocation(),
                             sourceProp.Name, currentType, suggestedTypeArg, isArray ? "[]" : ""));
@@ -251,7 +310,7 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                         {
                             bool isArray = itemProp.Type is IArrayTypeSymbol;
                             string currentType = isArray ? "ITaskItem[]" : "ITaskItem";
-                            context.ReportDiagnostic(Diagnostic.Create(
+                            pendingDiagnostics.Add(Diagnostic.Create(
                                 DiagnosticDescriptors.PreferTypedTaskItem,
                                 creation.Syntax.GetLocation(),
                                 itemProp.Name, currentType, suggestedTypeArg, isArray ? "[]" : ""));
@@ -262,7 +321,7 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
         }
 
         private static void AnalyzeInvocation(
-            OperationAnalysisContext context,
+            ConcurrentBag<Diagnostic> pendingDiagnostics,
             IInvocationOperation invocation,
             HashSet<IPropertySymbol> stringInputProps,
             HashSet<IPropertySymbol> taskItemInputProps,
@@ -284,7 +343,7 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                 var sourceProp = FindSourceProperty(invocation.Arguments[0].Value, stringInputProps);
                 if (sourceProp is not null)
                 {
-                    context.ReportDiagnostic(Diagnostic.Create(
+                    pendingDiagnostics.Add(Diagnostic.Create(
                         DiagnosticDescriptors.PreferTypedPathParameter,
                         invocation.Syntax.GetLocation(),
                         sourceProp.Name, "string", "AbsolutePath"));
@@ -314,7 +373,7 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                     {
                         bool isArray = sourceProp.Type is IArrayTypeSymbol;
                         string currentType = isArray ? "ITaskItem[]" : "ITaskItem";
-                        context.ReportDiagnostic(Diagnostic.Create(
+                        pendingDiagnostics.Add(Diagnostic.Create(
                             DiagnosticDescriptors.PreferTypedTaskItem,
                             invocation.Syntax.GetLocation(),
                             sourceProp.Name, currentType, suggestedTypeArg, isArray ? "[]" : ""));
@@ -335,7 +394,7 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                         var sourceProp = FindSourceProperty(arg.Value, stringInputProps);
                         if (sourceProp is not null)
                         {
-                            context.ReportDiagnostic(Diagnostic.Create(
+                            pendingDiagnostics.Add(Diagnostic.Create(
                                 DiagnosticDescriptors.PreferTypedPathParameter,
                                 invocation.Syntax.GetLocation(),
                                 sourceProp.Name, "string", "AbsolutePath"));
@@ -351,7 +410,7 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                         {
                             bool isArray = itemProp.Type is IArrayTypeSymbol;
                             string currentType = isArray ? "ITaskItem[]" : "ITaskItem";
-                            context.ReportDiagnostic(Diagnostic.Create(
+                            pendingDiagnostics.Add(Diagnostic.Create(
                                 DiagnosticDescriptors.PreferTypedTaskItem,
                                 invocation.Syntax.GetLocation(),
                                 itemProp.Name, currentType, "AbsolutePath", isArray ? "[]" : ""));

--- a/src/TaskAnalyzer/PreferTypedParameterAnalyzer.cs
+++ b/src/TaskAnalyzer/PreferTypedParameterAnalyzer.cs
@@ -1,0 +1,522 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+using static Microsoft.Build.TaskAuthoring.Analyzer.SharedAnalyzerHelpers;
+
+namespace Microsoft.Build.TaskAuthoring.Analyzer
+{
+    /// <summary>
+    /// Roslyn analyzer that suggests using strongly-typed task parameters instead of
+    /// manual path construction or ItemSpec parsing inside task bodies.
+    ///
+    /// MSBuildTask0006: Prefer AbsolutePath/FileInfo/DirectoryInfo parameters over converting from string.
+    /// MSBuildTask0007: Prefer ITaskItem&lt;T&gt; parameters over parsing ItemSpec manually.
+    /// </summary>
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class PreferTypedParameterAnalyzer : DiagnosticAnalyzer
+    {
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
+            ImmutableArray.Create(
+                DiagnosticDescriptors.PreferTypedPathParameter,
+                DiagnosticDescriptors.PreferTypedTaskItem);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.EnableConcurrentExecution();
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.RegisterCompilationStartAction(OnCompilationStart);
+        }
+
+        private static void OnCompilationStart(CompilationStartAnalysisContext compilationContext)
+        {
+            var iTaskType = compilationContext.Compilation.GetTypeByMetadataName(WellKnownTypeNames.ITaskFullName);
+            if (iTaskType is null)
+            {
+                return;
+            }
+
+            var absolutePathType = compilationContext.Compilation.GetTypeByMetadataName(WellKnownTypeNames.AbsolutePathFullName);
+            var taskEnvironmentType = compilationContext.Compilation.GetTypeByMetadataName(WellKnownTypeNames.TaskEnvironmentFullName);
+            var iTaskItemType = compilationContext.Compilation.GetTypeByMetadataName(WellKnownTypeNames.ITaskItemFullName);
+            var outputAttributeType = compilationContext.Compilation.GetTypeByMetadataName(WellKnownTypeNames.OutputAttributeFullName);
+            var fileInfoType = compilationContext.Compilation.GetTypeByMetadataName("System.IO.FileInfo");
+            var directoryInfoType = compilationContext.Compilation.GetTypeByMetadataName("System.IO.DirectoryInfo");
+
+            compilationContext.RegisterSymbolStartAction(symbolStartContext =>
+            {
+                var namedType = (INamedTypeSymbol)symbolStartContext.Symbol;
+                if (!ImplementsInterface(namedType, iTaskType))
+                {
+                    return;
+                }
+
+                // Collect string-typed task input properties (candidates for MSBuildTask0006)
+                var stringInputProps = new HashSet<IPropertySymbol>(SymbolEqualityComparer.Default);
+                // Collect ITaskItem/ITaskItem[]-typed task input properties (candidates for MSBuildTask0007)
+                var taskItemInputProps = new HashSet<IPropertySymbol>(SymbolEqualityComparer.Default);
+
+                foreach (var member in namedType.GetMembers().OfType<IPropertySymbol>())
+                {
+                    if (member.DeclaredAccessibility != Accessibility.Public)
+                    {
+                        continue;
+                    }
+
+                    if (member.SetMethod is null || member.SetMethod.DeclaredAccessibility != Accessibility.Public)
+                    {
+                        continue;
+                    }
+
+                    // Exclude [Output] properties — they are set by the task, not MSBuild
+                    if (outputAttributeType is not null && member.GetAttributes().Any(
+                        a => SymbolEqualityComparer.Default.Equals(a.AttributeClass, outputAttributeType)))
+                    {
+                        continue;
+                    }
+
+                    if (member.Type.SpecialType == SpecialType.System_String)
+                    {
+                        stringInputProps.Add(member);
+                    }
+                    else if (iTaskItemType is not null)
+                    {
+                        if (SymbolEqualityComparer.Default.Equals(member.Type, iTaskItemType))
+                        {
+                            taskItemInputProps.Add(member);
+                        }
+                        else if (member.Type is IArrayTypeSymbol arrayType &&
+                                 SymbolEqualityComparer.Default.Equals(arrayType.ElementType, iTaskItemType))
+                        {
+                            taskItemInputProps.Add(member);
+                        }
+                    }
+                }
+
+                if (stringInputProps.Count == 0 && taskItemInputProps.Count == 0)
+                {
+                    return;
+                }
+
+                symbolStartContext.RegisterOperationAction(ctx =>
+                {
+                    AnalyzeOperation(ctx, stringInputProps, taskItemInputProps,
+                        absolutePathType, taskEnvironmentType, iTaskItemType,
+                        fileInfoType, directoryInfoType);
+                },
+                OperationKind.ObjectCreation,
+                OperationKind.Invocation);
+            }, SymbolKind.NamedType);
+        }
+
+        private static void AnalyzeOperation(
+            OperationAnalysisContext context,
+            HashSet<IPropertySymbol> stringInputProps,
+            HashSet<IPropertySymbol> taskItemInputProps,
+            INamedTypeSymbol? absolutePathType,
+            INamedTypeSymbol? taskEnvironmentType,
+            INamedTypeSymbol? iTaskItemType,
+            INamedTypeSymbol? fileInfoType,
+            INamedTypeSymbol? directoryInfoType)
+        {
+            switch (context.Operation)
+            {
+                case IObjectCreationOperation creation:
+                    AnalyzeObjectCreation(context, creation, stringInputProps, taskItemInputProps,
+                        absolutePathType, iTaskItemType, fileInfoType, directoryInfoType);
+                    break;
+
+                case IInvocationOperation invocation:
+                    AnalyzeInvocation(context, invocation, stringInputProps, taskItemInputProps,
+                        absolutePathType, taskEnvironmentType, iTaskItemType,
+                        fileInfoType, directoryInfoType);
+                    break;
+            }
+        }
+
+        private static void AnalyzeObjectCreation(
+            OperationAnalysisContext context,
+            IObjectCreationOperation creation,
+            HashSet<IPropertySymbol> stringInputProps,
+            HashSet<IPropertySymbol> taskItemInputProps,
+            INamedTypeSymbol? absolutePathType,
+            INamedTypeSymbol? iTaskItemType,
+            INamedTypeSymbol? fileInfoType,
+            INamedTypeSymbol? directoryInfoType)
+        {
+            var createdType = creation.Type;
+            if (createdType is null || creation.Arguments.Length == 0)
+            {
+                return;
+            }
+
+            // MSBuildTask0006: new AbsolutePath(stringProp), new FileInfo(stringProp), new DirectoryInfo(stringProp)
+            if (stringInputProps.Count > 0)
+            {
+                string? suggestedType = null;
+                if (absolutePathType is not null && SymbolEqualityComparer.Default.Equals(createdType, absolutePathType))
+                {
+                    suggestedType = "AbsolutePath";
+                }
+                else if (fileInfoType is not null && SymbolEqualityComparer.Default.Equals(createdType, fileInfoType))
+                {
+                    suggestedType = "FileInfo";
+                }
+                else if (directoryInfoType is not null && SymbolEqualityComparer.Default.Equals(createdType, directoryInfoType))
+                {
+                    suggestedType = "DirectoryInfo";
+                }
+
+                if (suggestedType is not null)
+                {
+                    var sourceProp = FindSourceProperty(creation.Arguments[0].Value, stringInputProps);
+                    if (sourceProp is not null)
+                    {
+                        context.ReportDiagnostic(Diagnostic.Create(
+                            DiagnosticDescriptors.PreferTypedPathParameter,
+                            creation.Syntax.GetLocation(),
+                            sourceProp.Name, "string", suggestedType));
+                        return;
+                    }
+                }
+            }
+
+            // MSBuildTask0007: new AbsolutePath(item.ItemSpec), new FileInfo(item.ItemSpec), new DirectoryInfo(item.ItemSpec)
+            if (taskItemInputProps.Count > 0 && iTaskItemType is not null)
+            {
+                string? suggestedTypeArg = null;
+                if (absolutePathType is not null && SymbolEqualityComparer.Default.Equals(createdType, absolutePathType))
+                {
+                    suggestedTypeArg = "AbsolutePath";
+                }
+                else if (fileInfoType is not null && SymbolEqualityComparer.Default.Equals(createdType, fileInfoType))
+                {
+                    suggestedTypeArg = "FileInfo";
+                }
+                else if (directoryInfoType is not null && SymbolEqualityComparer.Default.Equals(createdType, directoryInfoType))
+                {
+                    suggestedTypeArg = "DirectoryInfo";
+                }
+
+                if (suggestedTypeArg is not null)
+                {
+                    var (sourceProp, _) = FindItemSpecSource(creation.Arguments[0].Value, taskItemInputProps, iTaskItemType);
+                    if (sourceProp is not null)
+                    {
+                        string currentType = sourceProp.Type is IArrayTypeSymbol ? "ITaskItem[]" : "ITaskItem";
+                        context.ReportDiagnostic(Diagnostic.Create(
+                            DiagnosticDescriptors.PreferTypedTaskItem,
+                            creation.Syntax.GetLocation(),
+                            sourceProp.Name, currentType, suggestedTypeArg));
+                    }
+                }
+            }
+        }
+
+        private static void AnalyzeInvocation(
+            OperationAnalysisContext context,
+            IInvocationOperation invocation,
+            HashSet<IPropertySymbol> stringInputProps,
+            HashSet<IPropertySymbol> taskItemInputProps,
+            INamedTypeSymbol? absolutePathType,
+            INamedTypeSymbol? taskEnvironmentType,
+            INamedTypeSymbol? iTaskItemType,
+            INamedTypeSymbol? fileInfoType,
+            INamedTypeSymbol? directoryInfoType)
+        {
+            var method = invocation.TargetMethod;
+
+            // MSBuildTask0006: TaskEnvironment.GetAbsolutePath(stringProp)
+            if (stringInputProps.Count > 0 &&
+                taskEnvironmentType is not null &&
+                method.Name == "GetAbsolutePath" &&
+                SymbolEqualityComparer.Default.Equals(method.ContainingType, taskEnvironmentType) &&
+                invocation.Arguments.Length > 0)
+            {
+                var sourceProp = FindSourceProperty(invocation.Arguments[0].Value, stringInputProps);
+                if (sourceProp is not null)
+                {
+                    context.ReportDiagnostic(Diagnostic.Create(
+                        DiagnosticDescriptors.PreferTypedPathParameter,
+                        invocation.Syntax.GetLocation(),
+                        sourceProp.Name, "string", "AbsolutePath"));
+                    return;
+                }
+            }
+
+            // MSBuildTask0007: Parse methods on ItemSpec
+            if (taskItemInputProps.Count > 0 && iTaskItemType is not null && invocation.Arguments.Length > 0)
+            {
+                // Check for Type.Parse(item.ItemSpec) and Convert.ToType(item.ItemSpec)
+                string? suggestedTypeArg = GetParsedTypeFromMethod(method);
+                if (suggestedTypeArg is not null)
+                {
+                    var (sourceProp, _) = FindItemSpecSource(invocation.Arguments[0].Value, taskItemInputProps, iTaskItemType);
+                    if (sourceProp is not null)
+                    {
+                        string currentType = sourceProp.Type is IArrayTypeSymbol ? "ITaskItem[]" : "ITaskItem";
+                        context.ReportDiagnostic(Diagnostic.Create(
+                            DiagnosticDescriptors.PreferTypedTaskItem,
+                            invocation.Syntax.GetLocation(),
+                            sourceProp.Name, currentType, suggestedTypeArg));
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Determines the parsed target type from a Parse/TryParse/Convert method call.
+        /// Returns the simple type name suitable for ITaskItem&lt;T&gt; suggestion, or null if not a recognized parse call.
+        /// </summary>
+        private static string? GetParsedTypeFromMethod(IMethodSymbol method)
+        {
+            // Static Parse/TryParse on value types: int.Parse, bool.Parse, etc.
+            if ((method.Name == "Parse" || method.Name == "TryParse") &&
+                method.IsStatic &&
+                method.ContainingType is not null &&
+                method.ContainingType.IsValueType)
+            {
+                return method.ContainingType.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
+            }
+
+            // Convert.ToXxx methods
+            if (method.IsStatic &&
+                method.ContainingType?.ToDisplayString() == "System.Convert" &&
+                method.Name.StartsWith("To", System.StringComparison.Ordinal))
+            {
+                switch (method.Name)
+                {
+                    case "ToInt32": return "int";
+                    case "ToInt64": return "long";
+                    case "ToBoolean": return "bool";
+                    case "ToDouble": return "double";
+                    case "ToSingle": return "float";
+                    case "ToDecimal": return "decimal";
+                    case "ToByte": return "byte";
+                    case "ToSByte": return "sbyte";
+                    case "ToInt16": return "short";
+                    case "ToUInt16": return "ushort";
+                    case "ToUInt32": return "uint";
+                    case "ToUInt64": return "ulong";
+                    case "ToChar": return "char";
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Checks if the given operation traces back (with at most one level of local indirection)
+        /// to one of the collected string task input properties.
+        /// </summary>
+        private static IPropertySymbol? FindSourceProperty(
+            IOperation operation,
+            HashSet<IPropertySymbol> candidateProps)
+        {
+            // Unwrap conversions
+            while (operation is IConversionOperation conversion)
+            {
+                operation = conversion.Operand;
+            }
+
+            // Direct property reference: this.MyProp or MyProp
+            if (operation is IPropertyReferenceOperation propRef &&
+                candidateProps.Contains(propRef.Property))
+            {
+                return propRef.Property;
+            }
+
+            // One level of local indirection: var x = this.MyProp; ... use x ...
+            if (operation is ILocalReferenceOperation localRef)
+            {
+                var local = localRef.Local;
+                if (local.DeclaringSyntaxReferences.Length == 1)
+                {
+                    var syntax = local.DeclaringSyntaxReferences[0].GetSyntax();
+                    var semanticModel = operation.SemanticModel;
+                    if (semanticModel is not null)
+                    {
+                        var declOp = semanticModel.GetOperation(syntax);
+                        if (declOp is IVariableDeclaratorOperation declarator &&
+                            declarator.Initializer?.Value is IOperation initValue)
+                        {
+                            return FindSourcePropertyDirect(initValue, candidateProps);
+                        }
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Direct property reference check without local indirection (prevents infinite recursion).
+        /// </summary>
+        private static IPropertySymbol? FindSourcePropertyDirect(
+            IOperation operation,
+            HashSet<IPropertySymbol> candidateProps)
+        {
+            while (operation is IConversionOperation conversion)
+            {
+                operation = conversion.Operand;
+            }
+
+            if (operation is IPropertyReferenceOperation propRef &&
+                candidateProps.Contains(propRef.Property))
+            {
+                return propRef.Property;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Checks if the given operation is an access to .ItemSpec on an ITaskItem
+        /// that traces back to one of the collected task input properties.
+        /// Returns the source property and whether it came from an array element.
+        /// </summary>
+        private static (IPropertySymbol? sourceProp, bool fromArray) FindItemSpecSource(
+            IOperation operation,
+            HashSet<IPropertySymbol> taskItemInputProps,
+            INamedTypeSymbol iTaskItemType)
+        {
+            // Unwrap conversions
+            while (operation is IConversionOperation conversion)
+            {
+                operation = conversion.Operand;
+            }
+
+            // One level of local indirection for the ItemSpec value:
+            // var spec = item.ItemSpec; int.Parse(spec);
+            if (operation is ILocalReferenceOperation specLocal)
+            {
+                var local = specLocal.Local;
+                if (local.DeclaringSyntaxReferences.Length == 1)
+                {
+                    var syntax = local.DeclaringSyntaxReferences[0].GetSyntax();
+                    var semanticModel = operation.SemanticModel;
+                    if (semanticModel is not null)
+                    {
+                        var declOp = semanticModel.GetOperation(syntax);
+                        if (declOp is IVariableDeclaratorOperation declarator &&
+                            declarator.Initializer?.Value is IOperation initValue)
+                        {
+                            return FindItemSpecSourceDirect(initValue, taskItemInputProps, iTaskItemType);
+                        }
+                    }
+                }
+
+                return (null, false);
+            }
+
+            return FindItemSpecSourceDirect(operation, taskItemInputProps, iTaskItemType);
+        }
+
+        /// <summary>
+        /// Direct check: is this operation item.ItemSpec where item traces to a task property?
+        /// </summary>
+        private static (IPropertySymbol? sourceProp, bool fromArray) FindItemSpecSourceDirect(
+            IOperation operation,
+            HashSet<IPropertySymbol> taskItemInputProps,
+            INamedTypeSymbol iTaskItemType)
+        {
+            while (operation is IConversionOperation conversion)
+            {
+                operation = conversion.Operand;
+            }
+
+            // Check for .ItemSpec property access
+            if (operation is IPropertyReferenceOperation itemSpecRef &&
+                itemSpecRef.Property.Name == "ItemSpec")
+            {
+                var receiverType = itemSpecRef.Property.ContainingType;
+                if (receiverType is not null &&
+                    (SymbolEqualityComparer.Default.Equals(receiverType, iTaskItemType) ||
+                     ImplementsInterface(receiverType, iTaskItemType)))
+                {
+                    // Check if the receiver traces to a task input property
+                    var receiver = itemSpecRef.Instance;
+                    if (receiver is not null)
+                    {
+                        return FindTaskItemPropertySource(receiver, taskItemInputProps);
+                    }
+                }
+            }
+
+            return (null, false);
+        }
+
+        /// <summary>
+        /// Traces an ITaskItem receiver back to a task input property,
+        /// including through foreach iteration variables and array indexing.
+        /// </summary>
+        private static (IPropertySymbol? sourceProp, bool fromArray) FindTaskItemPropertySource(
+            IOperation operation,
+            HashSet<IPropertySymbol> taskItemInputProps)
+        {
+            while (operation is IConversionOperation conversion)
+            {
+                operation = conversion.Operand;
+            }
+
+            // Direct property reference: this.MyItemProp.ItemSpec
+            if (operation is IPropertyReferenceOperation propRef &&
+                taskItemInputProps.Contains(propRef.Property))
+            {
+                return (propRef.Property, false);
+            }
+
+            // Local variable tracing (foreach variable or simple assignment)
+            if (operation is ILocalReferenceOperation localRef)
+            {
+                var local = localRef.Local;
+                var syntaxRef = local.DeclaringSyntaxReferences.FirstOrDefault();
+                if (syntaxRef is not null)
+                {
+                    var syntax = syntaxRef.GetSyntax();
+                    var semanticModel = operation.SemanticModel;
+                    if (semanticModel is not null)
+                    {
+                        var declOp = semanticModel.GetOperation(syntax);
+
+                        // Simple local assignment: var item = this.MyItemProp;
+                        if (declOp is IVariableDeclaratorOperation declarator &&
+                            declarator.Initializer?.Value is IOperation initValue)
+                        {
+                            return FindTaskItemPropertySource(initValue, taskItemInputProps);
+                        }
+
+                        // Foreach iteration variable: walk up syntax to find the foreach statement
+                        // The variable's declaring syntax may be the identifier token or designation
+                        // within a ForEachStatementSyntax
+                        var current = syntax;
+                        while (current is not null)
+                        {
+                            var op = semanticModel.GetOperation(current);
+                            if (op is IForEachLoopOperation foreachOp)
+                            {
+                                return FindTaskItemPropertySource(foreachOp.Collection, taskItemInputProps);
+                            }
+
+                            current = current.Parent;
+                        }
+                    }
+                }
+            }
+
+            // Array element access: this.MyItems[i].ItemSpec
+            if (operation is IArrayElementReferenceOperation arrayRef)
+            {
+                return FindTaskItemPropertySource(arrayRef.ArrayReference, taskItemInputProps);
+            }
+
+            return (null, false);
+        }
+    }
+}

--- a/src/TaskAnalyzer/PreferTypedParameterAnalyzer.cs
+++ b/src/TaskAnalyzer/PreferTypedParameterAnalyzer.cs
@@ -233,11 +233,13 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                     var (sourceProp, _) = FindItemSpecSource(creation.Arguments[0].Value, taskItemInputProps, iTaskItemType);
                     if (sourceProp is not null)
                     {
-                        string currentType = sourceProp.Type is IArrayTypeSymbol ? "ITaskItem[]" : "ITaskItem";
+                        bool isArray = sourceProp.Type is IArrayTypeSymbol;
+                        string currentType = isArray ? "ITaskItem[]" : "ITaskItem";
+                        string suggested = isArray ? suggestedTypeArg + "[]" : suggestedTypeArg;
                         context.ReportDiagnostic(Diagnostic.Create(
                             DiagnosticDescriptors.PreferTypedTaskItem,
                             creation.Syntax.GetLocation(),
-                            sourceProp.Name, currentType, suggestedTypeArg));
+                            sourceProp.Name, currentType, suggested));
                         return;
                     }
 
@@ -248,11 +250,13 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                             creation.Arguments[0].Value, taskItemInputProps, iTaskItemType, taskEnvironmentType);
                         if (itemProp is not null)
                         {
-                            string currentType = itemProp.Type is IArrayTypeSymbol ? "ITaskItem[]" : "ITaskItem";
+                            bool isArray = itemProp.Type is IArrayTypeSymbol;
+                            string currentType = isArray ? "ITaskItem[]" : "ITaskItem";
+                            string suggested = isArray ? suggestedTypeArg + "[]" : suggestedTypeArg;
                             context.ReportDiagnostic(Diagnostic.Create(
                                 DiagnosticDescriptors.PreferTypedTaskItem,
                                 creation.Syntax.GetLocation(),
-                                itemProp.Name, currentType, suggestedTypeArg));
+                                itemProp.Name, currentType, suggested));
                         }
                     }
                 }
@@ -310,11 +314,13 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                     var (sourceProp, _) = FindItemSpecSource(invocation.Arguments[0].Value, taskItemInputProps, iTaskItemType);
                     if (sourceProp is not null)
                     {
-                        string currentType = sourceProp.Type is IArrayTypeSymbol ? "ITaskItem[]" : "ITaskItem";
+                        bool isArray = sourceProp.Type is IArrayTypeSymbol;
+                        string currentType = isArray ? "ITaskItem[]" : "ITaskItem";
+                        string suggested = isArray ? suggestedTypeArg + "[]" : suggestedTypeArg;
                         context.ReportDiagnostic(Diagnostic.Create(
                             DiagnosticDescriptors.PreferTypedTaskItem,
                             invocation.Syntax.GetLocation(),
-                            sourceProp.Name, currentType, suggestedTypeArg));
+                            sourceProp.Name, currentType, suggested));
                     }
                 }
             }
@@ -346,11 +352,13 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                         var (itemProp, _) = FindItemSpecSource(arg.Value, taskItemInputProps, iTaskItemType);
                         if (itemProp is not null)
                         {
-                            string currentType = itemProp.Type is IArrayTypeSymbol ? "ITaskItem[]" : "ITaskItem";
+                            bool isArray = itemProp.Type is IArrayTypeSymbol;
+                            string currentType = isArray ? "ITaskItem[]" : "ITaskItem";
+                            string suggested = isArray ? "AbsolutePath[]" : "AbsolutePath";
                             context.ReportDiagnostic(Diagnostic.Create(
                                 DiagnosticDescriptors.PreferTypedTaskItem,
                                 invocation.Syntax.GetLocation(),
-                                itemProp.Name, currentType, "AbsolutePath"));
+                                itemProp.Name, currentType, suggested));
                             break;
                         }
                     }

--- a/src/TaskAnalyzer/PreferTypedParameterAnalyzer.cs
+++ b/src/TaskAnalyzer/PreferTypedParameterAnalyzer.cs
@@ -255,6 +255,16 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
             {
                 // Check for Type.Parse(item.ItemSpec) and Convert.ToType(item.ItemSpec)
                 string? suggestedTypeArg = GetParsedTypeFromMethod(method);
+
+                // Check for TaskEnvironment.GetAbsolutePath(item.ItemSpec)
+                if (suggestedTypeArg is null &&
+                    taskEnvironmentType is not null &&
+                    method.Name == "GetAbsolutePath" &&
+                    SymbolEqualityComparer.Default.Equals(method.ContainingType, taskEnvironmentType))
+                {
+                    suggestedTypeArg = "AbsolutePath";
+                }
+
                 if (suggestedTypeArg is not null)
                 {
                     var (sourceProp, _) = FindItemSpecSource(invocation.Arguments[0].Value, taskItemInputProps, iTaskItemType);

--- a/src/TaskAnalyzer/PreferTypedParameterAnalyzer.cs
+++ b/src/TaskAnalyzer/PreferTypedParameterAnalyzer.cs
@@ -28,6 +28,11 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                 DiagnosticDescriptors.PreferTypedPathParameter,
                 DiagnosticDescriptors.PreferTypedTaskItem);
 
+        // Structured metadata carried on each diagnostic so deduplication can reason over the
+        // inferred property and suggested type without parsing the human-readable message.
+        private const string PropertyNameKey = "PropertyName";
+        private const string SuggestedTypeKey = "SuggestedType";
+
         public override void Initialize(AnalysisContext context)
         {
             context.EnableConcurrentExecution();
@@ -143,49 +148,48 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
 
                 symbolStartContext.RegisterSymbolEndAction(endCtx =>
                 {
-                    // Group diagnostics by property name + rule ID, then suppress AbsolutePath
-                    // suggestions when a FileInfo/DirectoryInfo suggestion exists for the same property.
+                    // Group diagnostics by property name + rule ID using structured metadata,
+                    // then resolve AbsolutePath vs FileInfo/DirectoryInfo overlaps:
+                    //   - exactly one specific type inferred  => suppress AbsolutePath, keep the specific type
+                    //   - both FileInfo AND DirectoryInfo     => suppress the specifics, fall back to AbsolutePath
                     var diagnosticsList = pendingDiagnostics.ToList();
 
-                    // Find properties that have FileInfo or DirectoryInfo suggestions
-                    var propsWithSpecificType = new HashSet<string>();
+                    var suggestedTypesByProp = new Dictionary<string, HashSet<string>>(System.StringComparer.Ordinal);
                     foreach (var diag in diagnosticsList)
                     {
-                        string message = diag.GetMessage();
-                        if (message.Contains("FileInfo") || message.Contains("DirectoryInfo"))
+                        if (TryGetDiagnosticKey(diag, out string key, out string suggestedType))
                         {
-                            // Extract property name from message format: "... property '{0}' from ..."
-                            int startIdx = message.IndexOf('\'');
-                            if (startIdx >= 0)
+                            if (!suggestedTypesByProp.TryGetValue(key, out var set))
                             {
-                                int endIdx = message.IndexOf('\'', startIdx + 1);
-                                if (endIdx > startIdx)
-                                {
-                                    string propName = message.Substring(startIdx + 1, endIdx - startIdx - 1);
-                                    propsWithSpecificType.Add(diag.Id + "|" + propName);
-                                }
+                                set = new HashSet<string>(System.StringComparer.Ordinal);
+                                suggestedTypesByProp[key] = set;
                             }
+
+                            set.Add(suggestedType);
                         }
                     }
 
-                    foreach (var diag in diagnosticsList)
+                    foreach (var diag in diagnosticsList.OrderBy(d => d.Location.SourceSpan.Start))
                     {
-                        string message = diag.GetMessage();
-                        // Suppress AbsolutePath suggestions when FileInfo/DirectoryInfo exists for same property
-                        if (message.Contains("AbsolutePath") && propsWithSpecificType.Count > 0)
+                        if (TryGetDiagnosticKey(diag, out string key, out string suggestedType) &&
+                            suggestedTypesByProp.TryGetValue(key, out var set))
                         {
-                            int startIdx = message.IndexOf('\'');
-                            if (startIdx >= 0)
+                            bool hasFile = set.Contains("FileInfo");
+                            bool hasDir = set.Contains("DirectoryInfo");
+
+                            if (suggestedType == "AbsolutePath")
                             {
-                                int endIdx = message.IndexOf('\'', startIdx + 1);
-                                if (endIdx > startIdx)
+                                // Suppress when exactly one specific type was inferred (no file/dir conflict).
+                                if (hasFile ^ hasDir)
                                 {
-                                    string propName = message.Substring(startIdx + 1, endIdx - startIdx - 1);
-                                    if (propsWithSpecificType.Contains(diag.Id + "|" + propName))
-                                    {
-                                        continue; // Suppress — more specific type available
-                                    }
+                                    continue;
                                 }
+                            }
+                            else if ((suggestedType == "FileInfo" || suggestedType == "DirectoryInfo") &&
+                                     hasFile && hasDir && set.Contains("AbsolutePath"))
+                            {
+                                // Conflicting file/dir inference: prefer the AbsolutePath fallback.
+                                continue;
                             }
                         }
 
@@ -219,6 +223,103 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                         fileInfoType, directoryInfoType);
                     break;
             }
+        }
+
+        private static bool TryGetDiagnosticKey(Diagnostic diagnostic, out string key, out string suggestedType)
+        {
+            if (diagnostic.Properties.TryGetValue(PropertyNameKey, out var propName) && propName is not null &&
+                diagnostic.Properties.TryGetValue(SuggestedTypeKey, out var type) && type is not null)
+            {
+                key = diagnostic.Id + "|" + propName;
+                suggestedType = type;
+                return true;
+            }
+
+            key = string.Empty;
+            suggestedType = string.Empty;
+            return false;
+        }
+
+        private static Diagnostic CreatePathDiagnostic(Location location, string propertyName, string suggestedType)
+        {
+            var properties = ImmutableDictionary<string, string?>.Empty
+                .Add(PropertyNameKey, propertyName)
+                .Add(SuggestedTypeKey, suggestedType);
+
+            return Diagnostic.Create(
+                DiagnosticDescriptors.PreferTypedPathParameter,
+                location,
+                properties,
+                propertyName, "string", suggestedType);
+        }
+
+        private static Diagnostic CreateItemDiagnostic(Location location, string propertyName, bool isArray, string suggestedType)
+        {
+            var properties = ImmutableDictionary<string, string?>.Empty
+                .Add(PropertyNameKey, propertyName)
+                .Add(SuggestedTypeKey, suggestedType);
+
+            string currentType = isArray ? "ITaskItem[]" : "ITaskItem";
+            return Diagnostic.Create(
+                DiagnosticDescriptors.PreferTypedTaskItem,
+                location,
+                properties,
+                propertyName, currentType, suggestedType, isArray ? "[]" : "");
+        }
+
+        /// <summary>
+        /// Reports an <c>ITaskItem&lt;T&gt;</c> suggestion for every distinct task input property whose
+        /// ItemSpec (directly, or through an AbsolutePath intermediary) flows into a path-like argument of a
+        /// System.IO consumption site (e.g. <c>File.ReadAllLines(...)</c>, <c>Directory.CreateDirectory(...)</c>).
+        /// </summary>
+        private static void ReportPathConsumers(
+            ConcurrentBag<Diagnostic> pendingDiagnostics,
+            ImmutableArray<IArgumentOperation> arguments,
+            Location location,
+            string suggestedType,
+            HashSet<IPropertySymbol> taskItemInputProps,
+            INamedTypeSymbol iTaskItemType,
+            INamedTypeSymbol? taskEnvironmentType)
+        {
+            var flagged = new HashSet<IPropertySymbol>(SymbolEqualityComparer.Default);
+            foreach (var arg in arguments)
+            {
+                if (arg.Parameter is null || !IsPathParameterName(arg.Parameter.Name))
+                {
+                    continue;
+                }
+
+                var itemProp = FindPathConsumerSource(arg.Value, taskItemInputProps, iTaskItemType, taskEnvironmentType);
+                if (itemProp is not null && flagged.Add(itemProp))
+                {
+                    pendingDiagnostics.Add(CreateItemDiagnostic(
+                        location, itemProp.Name, itemProp.Type is IArrayTypeSymbol, suggestedType));
+                }
+            }
+        }
+
+        /// <summary>
+        /// Traces a path argument back to a source ITaskItem property, either directly via
+        /// <c>item.ItemSpec</c> or through an AbsolutePath intermediary.
+        /// </summary>
+        private static IPropertySymbol? FindPathConsumerSource(
+            IOperation argument,
+            HashSet<IPropertySymbol> taskItemInputProps,
+            INamedTypeSymbol iTaskItemType,
+            INamedTypeSymbol? taskEnvironmentType)
+        {
+            var (direct, _) = FindItemSpecSource(argument, taskItemInputProps, iTaskItemType);
+            if (direct is not null)
+            {
+                return direct;
+            }
+
+            if (taskEnvironmentType is not null)
+            {
+                return FindItemSpecSourceThroughAbsolutePath(argument, taskItemInputProps, iTaskItemType, taskEnvironmentType);
+            }
+
+            return null;
         }
 
         private static void AnalyzeObjectCreation(
@@ -260,10 +361,8 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                     var sourceProp = FindSourceProperty(creation.Arguments[0].Value, stringInputProps);
                     if (sourceProp is not null)
                     {
-                        pendingDiagnostics.Add(Diagnostic.Create(
-                            DiagnosticDescriptors.PreferTypedPathParameter,
-                            creation.Syntax.GetLocation(),
-                            sourceProp.Name, "string", suggestedType));
+                        pendingDiagnostics.Add(CreatePathDiagnostic(
+                            creation.Syntax.GetLocation(), sourceProp.Name, suggestedType));
                         return;
                     }
                 }
@@ -292,12 +391,8 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                     var (sourceProp, _) = FindItemSpecSource(creation.Arguments[0].Value, taskItemInputProps, iTaskItemType);
                     if (sourceProp is not null)
                     {
-                        bool isArray = sourceProp.Type is IArrayTypeSymbol;
-                        string currentType = isArray ? "ITaskItem[]" : "ITaskItem";
-                        pendingDiagnostics.Add(Diagnostic.Create(
-                            DiagnosticDescriptors.PreferTypedTaskItem,
-                            creation.Syntax.GetLocation(),
-                            sourceProp.Name, currentType, suggestedTypeArg, isArray ? "[]" : ""));
+                        pendingDiagnostics.Add(CreateItemDiagnostic(
+                            creation.Syntax.GetLocation(), sourceProp.Name, sourceProp.Type is IArrayTypeSymbol, suggestedTypeArg));
                         return;
                     }
 
@@ -308,14 +403,21 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                             creation.Arguments[0].Value, taskItemInputProps, iTaskItemType, taskEnvironmentType);
                         if (itemProp is not null)
                         {
-                            bool isArray = itemProp.Type is IArrayTypeSymbol;
-                            string currentType = isArray ? "ITaskItem[]" : "ITaskItem";
-                            pendingDiagnostics.Add(Diagnostic.Create(
-                                DiagnosticDescriptors.PreferTypedTaskItem,
-                                creation.Syntax.GetLocation(),
-                                itemProp.Name, currentType, suggestedTypeArg, isArray ? "[]" : ""));
+                            pendingDiagnostics.Add(CreateItemDiagnostic(
+                                creation.Syntax.GetLocation(), itemProp.Name, itemProp.Type is IArrayTypeSymbol, suggestedTypeArg));
                         }
                     }
+                }
+            }
+
+            // MSBuildTask0007: new FileStream/StreamReader/StreamWriter(item.ItemSpec) consuming an ItemSpec => FileInfo
+            if (taskItemInputProps.Count > 0 && iTaskItemType is not null)
+            {
+                string createdTypeName = createdType.ToDisplayString();
+                if (createdTypeName is "System.IO.FileStream" or "System.IO.StreamReader" or "System.IO.StreamWriter")
+                {
+                    ReportPathConsumers(pendingDiagnostics, creation.Arguments, creation.Syntax.GetLocation(),
+                        "FileInfo", taskItemInputProps, iTaskItemType, taskEnvironmentType);
                 }
             }
         }
@@ -343,10 +445,8 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                 var sourceProp = FindSourceProperty(invocation.Arguments[0].Value, stringInputProps);
                 if (sourceProp is not null)
                 {
-                    pendingDiagnostics.Add(Diagnostic.Create(
-                        DiagnosticDescriptors.PreferTypedPathParameter,
-                        invocation.Syntax.GetLocation(),
-                        sourceProp.Name, "string", "AbsolutePath"));
+                    pendingDiagnostics.Add(CreatePathDiagnostic(
+                        invocation.Syntax.GetLocation(), sourceProp.Name, "AbsolutePath"));
                     return;
                 }
             }
@@ -371,50 +471,60 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                     var (sourceProp, _) = FindItemSpecSource(invocation.Arguments[0].Value, taskItemInputProps, iTaskItemType);
                     if (sourceProp is not null)
                     {
-                        bool isArray = sourceProp.Type is IArrayTypeSymbol;
-                        string currentType = isArray ? "ITaskItem[]" : "ITaskItem";
-                        pendingDiagnostics.Add(Diagnostic.Create(
-                            DiagnosticDescriptors.PreferTypedTaskItem,
-                            invocation.Syntax.GetLocation(),
-                            sourceProp.Name, currentType, suggestedTypeArg, isArray ? "[]" : ""));
+                        pendingDiagnostics.Add(CreateItemDiagnostic(
+                            invocation.Syntax.GetLocation(), sourceProp.Name, sourceProp.Type is IArrayTypeSymbol, suggestedTypeArg));
                     }
                 }
             }
 
-            // Path.Combine(...) with any argument tracing to a task input property
+            // MSBuildTask0007: File.X(path)/Directory.X(path) consuming an ItemSpec => FileInfo/DirectoryInfo
+            if (taskItemInputProps.Count > 0 && iTaskItemType is not null && invocation.Arguments.Length > 0)
+            {
+                string? consumerType = method.ContainingType?.ToDisplayString() switch
+                {
+                    "System.IO.File" => "FileInfo",
+                    "System.IO.Directory" => "DirectoryInfo",
+                    _ => null
+                };
+
+                if (consumerType is not null)
+                {
+                    ReportPathConsumers(pendingDiagnostics, invocation.Arguments, invocation.Syntax.GetLocation(),
+                        consumerType, taskItemInputProps, iTaskItemType, taskEnvironmentType);
+                }
+            }
+
+            // Path.Combine(...) — any argument tracing to a task input property indicates that
+            // property is used to build an absolute path, regardless of its position in the call.
             if (method.ContainingType?.ToDisplayString() == "System.IO.Path" &&
                 method.Name == "Combine" &&
                 invocation.Arguments.Length >= 2)
             {
+                var flaggedStringProps = new HashSet<IPropertySymbol>(SymbolEqualityComparer.Default);
+                var flaggedItemProps = new HashSet<IPropertySymbol>(SymbolEqualityComparer.Default);
+
                 foreach (var arg in invocation.Arguments)
                 {
-                    // MSBuildTask0006: Path.Combine(stringProp, ...) or Path.Combine(..., stringProp)
+                    // MSBuildTask0006: Path.Combine(..., stringProp, ...)
                     if (stringInputProps.Count > 0)
                     {
                         var sourceProp = FindSourceProperty(arg.Value, stringInputProps);
-                        if (sourceProp is not null)
+                        if (sourceProp is not null && flaggedStringProps.Add(sourceProp))
                         {
-                            pendingDiagnostics.Add(Diagnostic.Create(
-                                DiagnosticDescriptors.PreferTypedPathParameter,
-                                invocation.Syntax.GetLocation(),
-                                sourceProp.Name, "string", "AbsolutePath"));
-                            break;
+                            pendingDiagnostics.Add(CreatePathDiagnostic(
+                                invocation.Syntax.GetLocation(), sourceProp.Name, "AbsolutePath"));
+                            continue;
                         }
                     }
 
-                    // MSBuildTask0007: Path.Combine(item.ItemSpec, ...) or Path.Combine(..., item.ItemSpec)
+                    // MSBuildTask0007: Path.Combine(..., item.ItemSpec, ...)
                     if (taskItemInputProps.Count > 0 && iTaskItemType is not null)
                     {
                         var (itemProp, _) = FindItemSpecSource(arg.Value, taskItemInputProps, iTaskItemType);
-                        if (itemProp is not null)
+                        if (itemProp is not null && flaggedItemProps.Add(itemProp))
                         {
-                            bool isArray = itemProp.Type is IArrayTypeSymbol;
-                            string currentType = isArray ? "ITaskItem[]" : "ITaskItem";
-                            pendingDiagnostics.Add(Diagnostic.Create(
-                                DiagnosticDescriptors.PreferTypedTaskItem,
-                                invocation.Syntax.GetLocation(),
-                                itemProp.Name, currentType, "AbsolutePath", isArray ? "[]" : ""));
-                            break;
+                            pendingDiagnostics.Add(CreateItemDiagnostic(
+                                invocation.Syntax.GetLocation(), itemProp.Name, itemProp.Type is IArrayTypeSymbol, "AbsolutePath"));
                         }
                     }
                 }
@@ -710,6 +820,14 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
             HashSet<IPropertySymbol> taskItemInputProps,
             INamedTypeSymbol iTaskItemType,
             INamedTypeSymbol taskEnvironmentType)
+            => FindItemSpecSourceThroughAbsolutePath(operation, taskItemInputProps, iTaskItemType, taskEnvironmentType, visitedLocals: null);
+
+        private static IPropertySymbol? FindItemSpecSourceThroughAbsolutePath(
+            IOperation operation,
+            HashSet<IPropertySymbol> taskItemInputProps,
+            INamedTypeSymbol iTaskItemType,
+            INamedTypeSymbol taskEnvironmentType,
+            HashSet<ILocalSymbol>? visitedLocals)
         {
             // Unwrap conversions
             while (operation is IConversionOperation conversion)
@@ -727,28 +845,94 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                 return sourceProp;
             }
 
-            // Local indirection: var abs = TaskEnvironment.GetAbsolutePath(item.ItemSpec); new FileInfo(abs);
+            // Local indirection. Handles both:
+            //   AbsolutePath abs = TaskEnvironment.GetAbsolutePath(item.ItemSpec); ... use abs ...
+            //   AbsolutePath? abs = null; try { abs = TaskEnvironment.GetAbsolutePath(item.ItemSpec); } ... use abs ...
             if (operation is ILocalReferenceOperation localRef)
             {
                 var local = localRef.Local;
-                if (local.DeclaringSyntaxReferences.Length == 1)
+
+                // Guard against cycles (e.g. self-referencing assignments).
+                visitedLocals ??= new HashSet<ILocalSymbol>(SymbolEqualityComparer.Default);
+                if (!visitedLocals.Add(local))
+                {
+                    return null;
+                }
+
+                // (a) Declaration initializer: AbsolutePath abs = GetAbsolutePath(item.ItemSpec);
+                if (local.DeclaringSyntaxReferences.Length == 1 && operation.SemanticModel is SemanticModel declModel)
                 {
                     var syntax = local.DeclaringSyntaxReferences[0].GetSyntax();
-                    var semanticModel = operation.SemanticModel;
-                    if (semanticModel is not null)
+                    if (declModel.GetOperation(syntax) is IVariableDeclaratorOperation declarator &&
+                        declarator.Initializer?.Value is IOperation initValue)
                     {
-                        var declOp = semanticModel.GetOperation(syntax);
-                        if (declOp is IVariableDeclaratorOperation declarator &&
-                            declarator.Initializer?.Value is IOperation initValue)
+                        var fromInitializer = FindItemSpecSourceThroughAbsolutePath(
+                            initValue, taskItemInputProps, iTaskItemType, taskEnvironmentType, visitedLocals);
+                        if (fromInitializer is not null)
                         {
-                            return FindItemSpecSourceThroughAbsolutePath(
-                                initValue, taskItemInputProps, iTaskItemType, taskEnvironmentType);
+                            return fromInitializer;
                         }
+                    }
+                }
+
+                // (b) A single unconditional assignment elsewhere in the method body.
+                return FindLocalAssignmentSource(localRef, local, taskItemInputProps, iTaskItemType, taskEnvironmentType, visitedLocals);
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Finds the ITaskItem source for a local that is assigned (rather than initialized) via
+        /// <c>local = TaskEnvironment.GetAbsolutePath(item.ItemSpec)</c>. Returns the source property only
+        /// when every resolvable assignment to the local maps to the same property; otherwise returns null
+        /// to stay conservative in the face of ambiguous data flow.
+        /// </summary>
+        private static IPropertySymbol? FindLocalAssignmentSource(
+            ILocalReferenceOperation localRef,
+            ILocalSymbol local,
+            HashSet<IPropertySymbol> taskItemInputProps,
+            INamedTypeSymbol iTaskItemType,
+            INamedTypeSymbol taskEnvironmentType,
+            HashSet<ILocalSymbol> visitedLocals)
+        {
+            if (localRef.SemanticModel is not SemanticModel semanticModel ||
+                local.ContainingSymbol is not IMethodSymbol method ||
+                method.DeclaringSyntaxReferences.Length != 1)
+            {
+                return null;
+            }
+
+            var methodSyntax = method.DeclaringSyntaxReferences[0].GetSyntax();
+            var methodOperation = semanticModel.GetOperation(methodSyntax);
+            if (methodOperation is null)
+            {
+                return null;
+            }
+
+            IPropertySymbol? found = null;
+            foreach (var descendant in methodOperation.Descendants())
+            {
+                if (descendant is ISimpleAssignmentOperation assignment &&
+                    assignment.Target is ILocalReferenceOperation targetRef &&
+                    SymbolEqualityComparer.Default.Equals(targetRef.Local, local))
+                {
+                    var prop = FindItemSpecSourceThroughAbsolutePath(
+                        assignment.Value, taskItemInputProps, iTaskItemType, taskEnvironmentType, visitedLocals);
+                    if (prop is not null)
+                    {
+                        if (found is not null && !SymbolEqualityComparer.Default.Equals(found, prop))
+                        {
+                            // The local is assigned from more than one distinct property — ambiguous.
+                            return null;
+                        }
+
+                        found = prop;
                     }
                 }
             }
 
-            return null;
+            return found;
         }
     }
 }

--- a/src/TaskAnalyzer/PreferTypedParameterAnalyzer.cs
+++ b/src/TaskAnalyzer/PreferTypedParameterAnalyzer.cs
@@ -235,11 +235,10 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                     {
                         bool isArray = sourceProp.Type is IArrayTypeSymbol;
                         string currentType = isArray ? "ITaskItem[]" : "ITaskItem";
-                        string suggested = isArray ? suggestedTypeArg + "[]" : suggestedTypeArg;
                         context.ReportDiagnostic(Diagnostic.Create(
                             DiagnosticDescriptors.PreferTypedTaskItem,
                             creation.Syntax.GetLocation(),
-                            sourceProp.Name, currentType, suggested));
+                            sourceProp.Name, currentType, suggestedTypeArg, isArray ? "[]" : ""));
                         return;
                     }
 
@@ -252,11 +251,10 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                         {
                             bool isArray = itemProp.Type is IArrayTypeSymbol;
                             string currentType = isArray ? "ITaskItem[]" : "ITaskItem";
-                            string suggested = isArray ? suggestedTypeArg + "[]" : suggestedTypeArg;
                             context.ReportDiagnostic(Diagnostic.Create(
                                 DiagnosticDescriptors.PreferTypedTaskItem,
                                 creation.Syntax.GetLocation(),
-                                itemProp.Name, currentType, suggested));
+                                itemProp.Name, currentType, suggestedTypeArg, isArray ? "[]" : ""));
                         }
                     }
                 }
@@ -316,11 +314,10 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                     {
                         bool isArray = sourceProp.Type is IArrayTypeSymbol;
                         string currentType = isArray ? "ITaskItem[]" : "ITaskItem";
-                        string suggested = isArray ? suggestedTypeArg + "[]" : suggestedTypeArg;
                         context.ReportDiagnostic(Diagnostic.Create(
                             DiagnosticDescriptors.PreferTypedTaskItem,
                             invocation.Syntax.GetLocation(),
-                            sourceProp.Name, currentType, suggested));
+                            sourceProp.Name, currentType, suggestedTypeArg, isArray ? "[]" : ""));
                     }
                 }
             }
@@ -354,11 +351,10 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                         {
                             bool isArray = itemProp.Type is IArrayTypeSymbol;
                             string currentType = isArray ? "ITaskItem[]" : "ITaskItem";
-                            string suggested = isArray ? "AbsolutePath[]" : "AbsolutePath";
                             context.ReportDiagnostic(Diagnostic.Create(
                                 DiagnosticDescriptors.PreferTypedTaskItem,
                                 invocation.Syntax.GetLocation(),
-                                itemProp.Name, currentType, suggested));
+                                itemProp.Name, currentType, "AbsolutePath", isArray ? "[]" : ""));
                             break;
                         }
                     }

--- a/src/TaskAnalyzer/PreferTypedParameterCodeFixProvider.cs
+++ b/src/TaskAnalyzer/PreferTypedParameterCodeFixProvider.cs
@@ -1,0 +1,547 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Editing;
+using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.CodeAnalysis.Simplification;
+
+namespace Microsoft.Build.TaskAuthoring.Analyzer
+{
+    /// <summary>
+    /// Code fixer for the strongly-typed task parameter analyzer.
+    /// Fixes:
+    /// - MSBuildTask0006: Retypes a string task property to AbsolutePath/FileInfo/DirectoryInfo and
+    ///   removes the now-redundant conversion at every use site.
+    /// - MSBuildTask0007: Retypes an ITaskItem/ITaskItem[] task property to ITaskItem&lt;T&gt;/ITaskItem&lt;T&gt;[]
+    ///   and replaces the manual ItemSpec parsing with the strongly-typed Value at every use site.
+    /// </summary>
+    /// <remarks>
+    /// The fix is intentionally conservative: changing a property's type affects every reference to it, so a
+    /// fix is only offered when EVERY reference to the property is a conversion the analyzer knows how to
+    /// rewrite. Otherwise a leftover string-typed use (for example <c>File.Exists(InputPath)</c>) would no
+    /// longer compile once the property is retyped. This guarantees the produced code compiles.
+    /// </remarks>
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(PreferTypedParameterCodeFixProvider))]
+    [Shared]
+    public sealed class PreferTypedParameterCodeFixProvider : CodeFixProvider
+    {
+        private const string EquivalenceKey = "PreferTypedParameter";
+
+        public override ImmutableArray<string> FixableDiagnosticIds =>
+            ImmutableArray.Create(DiagnosticIds.PreferTypedPathParameter, DiagnosticIds.PreferTypedTaskItem);
+
+        public override FixAllProvider GetFixAllProvider() => new PreferTypedParameterFixAllProvider();
+
+        public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+            var semanticModel = await context.Document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
+            if (root is null || semanticModel is null)
+            {
+                return;
+            }
+
+            foreach (var diagnostic in context.Diagnostics)
+            {
+                var plan = TryBuildPlan(semanticModel, root, diagnostic, context.CancellationToken);
+                if (plan is null)
+                {
+                    continue;
+                }
+
+                context.RegisterCodeFix(
+                    CodeAction.Create(
+                        title: $"Change '{plan.Property.Name}' to '{plan.NewTypeDisplay}'",
+                        createChangedDocument: ct => ApplyPlansAsync(context.Document, new[] { diagnostic }, ct),
+                        equivalenceKey: EquivalenceKey),
+                    diagnostic);
+            }
+        }
+
+        /// <summary>
+        /// Applies fixes for the supplied diagnostics, grouping them by target property so that a property whose
+        /// type changes is retyped exactly once even when it has multiple conversion sites.
+        /// </summary>
+        internal static async Task<Document> ApplyPlansAsync(Document document, IReadOnlyList<Diagnostic> diagnostics, CancellationToken cancellationToken)
+        {
+            var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+            var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+            if (root is null || semanticModel is null)
+            {
+                return document;
+            }
+
+            var plans = new List<PropertyFixPlan>();
+            var seenProperties = new List<IPropertySymbol>();
+            foreach (var diagnostic in diagnostics)
+            {
+                var plan = TryBuildPlan(semanticModel, root, diagnostic, cancellationToken);
+                if (plan is null)
+                {
+                    continue;
+                }
+
+                // Each plan already rewrites every site for its property; dedupe so we don't process a property twice.
+                if (seenProperties.Any(p => SymbolEqualityComparer.Default.Equals(p, plan.Property)))
+                {
+                    continue;
+                }
+
+                seenProperties.Add(plan.Property);
+                plans.Add(plan);
+            }
+
+            if (plans.Count == 0)
+            {
+                return document;
+            }
+
+            var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
+            foreach (var plan in plans)
+            {
+                editor.ReplaceNode(plan.PropertyDeclaration, BuildRetypedProperty(plan));
+                foreach (var (oldNode, newNode) in plan.SiteEdits)
+                {
+                    editor.ReplaceNode(oldNode, newNode);
+                }
+            }
+
+            return editor.GetChangedDocument();
+        }
+
+        /// <summary>
+        /// Validates that the diagnostic's target property can be safely retyped (every reference is a
+        /// rewritable conversion) and, if so, produces the set of edits to apply.
+        /// </summary>
+        private static PropertyFixPlan? TryBuildPlan(SemanticModel semanticModel, SyntaxNode root, Diagnostic diagnostic, CancellationToken cancellationToken)
+        {
+            if (!diagnostic.Properties.TryGetValue("PropertyName", out var propertyName) || propertyName is null ||
+                !diagnostic.Properties.TryGetValue("SuggestedType", out var suggestedType) || suggestedType is null)
+            {
+                return null;
+            }
+
+            var conversionNode = root.FindNode(diagnostic.Location.SourceSpan);
+            var typeDeclaration = conversionNode.AncestorsAndSelf().OfType<TypeDeclarationSyntax>().FirstOrDefault();
+            if (typeDeclaration is null)
+            {
+                return null;
+            }
+
+            if (semanticModel.GetDeclaredSymbol(typeDeclaration, cancellationToken) is not INamedTypeSymbol taskType)
+            {
+                return null;
+            }
+
+            var property = taskType.GetMembers(propertyName).OfType<IPropertySymbol>().FirstOrDefault();
+            if (property is null)
+            {
+                return null;
+            }
+
+            // The property must be declared exactly once, in this syntax tree, as a property declaration we can edit.
+            if (property.DeclaringSyntaxReferences.Length != 1 ||
+                property.DeclaringSyntaxReferences[0].GetSyntax(cancellationToken) is not PropertyDeclarationSyntax propertyDeclaration ||
+                propertyDeclaration.SyntaxTree != root.SyntaxTree)
+            {
+                return null;
+            }
+
+            bool isItemRule = diagnostic.Id == DiagnosticIds.PreferTypedTaskItem;
+            bool isArray = propertyDeclaration.Type is ArrayTypeSyntax;
+
+            // The strong type the rewritten conversions must produce (used to guard against losing semantics).
+            ITypeSymbol? expectedResultType = ResolvePathTypeSymbol(semanticModel.Compilation, suggestedType);
+
+            var siteEdits = new List<(SyntaxNode, SyntaxNode)>();
+            if (!TryCollectSiteEdits(semanticModel, typeDeclaration, property, suggestedType, expectedResultType, isItemRule, isArray, siteEdits, cancellationToken))
+            {
+                return null;
+            }
+
+            if (siteEdits.Count == 0)
+            {
+                return null;
+            }
+
+            string newTypeName = BuildNewTypeName(suggestedType, isItemRule, isArray);
+            string newTypeDisplay = BuildDisplayTypeName(suggestedType, isItemRule, isArray);
+            bool newTypeIsValueType = !isItemRule && suggestedType == "AbsolutePath";
+
+            return new PropertyFixPlan(property, propertyDeclaration, newTypeName, newTypeDisplay, newTypeIsValueType, siteEdits);
+        }
+
+        /// <summary>
+        /// Visits every reference to <paramref name="property"/> within the task type and verifies each one is a
+        /// conversion that can be rewritten. Populates <paramref name="siteEdits"/>; returns false if any reference
+        /// cannot be safely rewritten (in which case no fix should be offered).
+        /// </summary>
+        private static bool TryCollectSiteEdits(
+            SemanticModel semanticModel,
+            TypeDeclarationSyntax typeDeclaration,
+            IPropertySymbol property,
+            string suggestedType,
+            ITypeSymbol? expectedResultType,
+            bool isItemRule,
+            bool isArray,
+            List<(SyntaxNode, SyntaxNode)> siteEdits,
+            CancellationToken cancellationToken)
+        {
+            foreach (var identifier in typeDeclaration.DescendantNodes().OfType<IdentifierNameSyntax>())
+            {
+                if (identifier.Identifier.Text != property.Name)
+                {
+                    continue;
+                }
+
+                if (!SymbolEqualityComparer.Default.Equals(semanticModel.GetSymbolInfo(identifier, cancellationToken).Symbol, property))
+                {
+                    continue;
+                }
+
+                ExpressionSyntax propertyAccess = GetPropertyAccessExpression(identifier);
+
+                if (isItemRule && isArray)
+                {
+                    if (!TryRewriteForEachArray(semanticModel, propertyAccess, suggestedType, expectedResultType, siteEdits, cancellationToken))
+                    {
+                        return false;
+                    }
+                }
+                else if (isItemRule)
+                {
+                    if (!TryRewriteItemSpecConversion(semanticModel, propertyAccess, propertyAccess, suggestedType, expectedResultType, siteEdits, cancellationToken))
+                    {
+                        return false;
+                    }
+                }
+                else
+                {
+                    if (!TryRewritePathConversion(semanticModel, propertyAccess, suggestedType, expectedResultType, siteEdits, cancellationToken))
+                    {
+                        return false;
+                    }
+                }
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// MSBuildTask0006: rewrites <c>new T(prop)</c> or <c>TaskEnvironment.GetAbsolutePath(prop)</c> to just
+        /// <c>prop</c> after the property is retyped to <paramref name="suggestedType"/>.
+        /// </summary>
+        private static bool TryRewritePathConversion(
+            SemanticModel semanticModel,
+            ExpressionSyntax propertyAccess,
+            string suggestedType,
+            ITypeSymbol? expectedResultType,
+            List<(SyntaxNode, SyntaxNode)> siteEdits,
+            CancellationToken cancellationToken)
+        {
+            var conversion = GetSingleArgumentConversion(propertyAccess);
+            if (conversion is null || !IsExpectedConversion(semanticModel, conversion, suggestedType, expectedResultType, isItemRule: false, cancellationToken))
+            {
+                return false;
+            }
+
+            var replacement = propertyAccess
+                .WithoutTrivia()
+                .WithTriviaFrom(conversion)
+                .WithAdditionalAnnotations(Formatter.Annotation);
+
+            siteEdits.Add((conversion, replacement));
+            return true;
+        }
+
+        /// <summary>
+        /// MSBuildTask0007 (scalar): rewrites <c>new T(item.ItemSpec)</c> or <c>int.Parse(item.ItemSpec)</c> to
+        /// <c>item.Value</c> after the property is retyped to <c>ITaskItem&lt;T&gt;</c>.
+        /// </summary>
+        private static bool TryRewriteItemSpecConversion(
+            SemanticModel semanticModel,
+            ExpressionSyntax itemAccess,
+            ExpressionSyntax valueReceiver,
+            string suggestedType,
+            ITypeSymbol? expectedResultType,
+            List<(SyntaxNode, SyntaxNode)> siteEdits,
+            CancellationToken cancellationToken)
+        {
+            // itemAccess must be the receiver of an `.ItemSpec` member access.
+            if (itemAccess.Parent is not MemberAccessExpressionSyntax itemSpecAccess ||
+                itemSpecAccess.Expression != itemAccess ||
+                itemSpecAccess.Name.Identifier.Text != "ItemSpec")
+            {
+                return false;
+            }
+
+            var conversion = GetSingleArgumentConversion(itemSpecAccess);
+            if (conversion is null || !IsExpectedConversion(semanticModel, conversion, suggestedType, expectedResultType, isItemRule: true, cancellationToken))
+            {
+                return false;
+            }
+
+            var valueAccess = SyntaxFactory.MemberAccessExpression(
+                    SyntaxKind.SimpleMemberAccessExpression,
+                    valueReceiver.WithoutTrivia(),
+                    SyntaxFactory.IdentifierName("Value"))
+                .WithTriviaFrom(conversion)
+                .WithAdditionalAnnotations(Formatter.Annotation);
+
+            siteEdits.Add((conversion, valueAccess));
+            return true;
+        }
+
+        /// <summary>
+        /// MSBuildTask0007 (array): the property is the source of a <c>foreach (var x in Prop)</c> whose loop
+        /// variable's every use is an <c>x.ItemSpec</c> conversion. Rewrites each conversion to <c>x.Value</c>.
+        /// Only <c>var</c> loop variables are handled so the element re-infers to <c>ITaskItem&lt;T&gt;</c>.
+        /// </summary>
+        private static bool TryRewriteForEachArray(
+            SemanticModel semanticModel,
+            ExpressionSyntax propertyAccess,
+            string suggestedType,
+            ITypeSymbol? expectedResultType,
+            List<(SyntaxNode, SyntaxNode)> siteEdits,
+            CancellationToken cancellationToken)
+        {
+            if (propertyAccess.Parent is not ForEachStatementSyntax forEach ||
+                forEach.Expression != propertyAccess ||
+                !forEach.Type.IsVar)
+            {
+                return false;
+            }
+
+            if (semanticModel.GetDeclaredSymbol(forEach, cancellationToken) is not ILocalSymbol loopVariable)
+            {
+                return false;
+            }
+
+            bool sawConversion = false;
+            foreach (var identifier in forEach.Statement.DescendantNodes().OfType<IdentifierNameSyntax>())
+            {
+                if (identifier.Identifier.Text != loopVariable.Name ||
+                    !SymbolEqualityComparer.Default.Equals(semanticModel.GetSymbolInfo(identifier, cancellationToken).Symbol, loopVariable))
+                {
+                    continue;
+                }
+
+                var loopVariableReference = SyntaxFactory.IdentifierName(loopVariable.Name);
+                if (!TryRewriteItemSpecConversion(semanticModel, identifier, loopVariableReference, suggestedType, expectedResultType, siteEdits, cancellationToken))
+                {
+                    return false;
+                }
+
+                sawConversion = true;
+            }
+
+            return sawConversion;
+        }
+
+        /// <summary>
+        /// Returns the conversion expression (object creation or <c>Type.Parse</c> invocation) when
+        /// <paramref name="argument"/> is its single argument; otherwise null.
+        /// </summary>
+        private static ExpressionSyntax? GetSingleArgumentConversion(ExpressionSyntax argument)
+        {
+            if (argument.Parent is not ArgumentSyntax arg ||
+                arg.Parent is not ArgumentListSyntax argumentList ||
+                argumentList.Arguments.Count != 1)
+            {
+                return null;
+            }
+
+            return argumentList.Parent switch
+            {
+                ObjectCreationExpressionSyntax creation => creation,
+                InvocationExpressionSyntax invocation => invocation,
+                _ => null,
+            };
+        }
+
+        /// <summary>
+        /// Verifies the conversion produces exactly the suggested strong type, so replacing it does not change
+        /// the static type observed by surrounding code (e.g. <c>var x = ...;</c>).
+        /// </summary>
+        private static bool IsExpectedConversion(
+            SemanticModel semanticModel,
+            ExpressionSyntax conversion,
+            string suggestedType,
+            ITypeSymbol? expectedResultType,
+            bool isItemRule,
+            CancellationToken cancellationToken)
+        {
+            switch (conversion)
+            {
+                case ObjectCreationExpressionSyntax:
+                    break;
+
+                case InvocationExpressionSyntax invocation when invocation.Expression is MemberAccessExpressionSyntax memberAccess:
+                    // For the path rule only TaskEnvironment.GetAbsolutePath qualifies; for the item rule, a Parse call.
+                    string methodName = memberAccess.Name.Identifier.Text;
+                    if (!isItemRule && methodName != "GetAbsolutePath")
+                    {
+                        return false;
+                    }
+
+                    if (isItemRule && methodName != "Parse")
+                    {
+                        return false;
+                    }
+
+                    break;
+
+                default:
+                    return false;
+            }
+
+            var resultType = semanticModel.GetTypeInfo(conversion, cancellationToken).Type;
+            if (resultType is null)
+            {
+                return false;
+            }
+
+            return expectedResultType is not null
+                ? SymbolEqualityComparer.Default.Equals(resultType, expectedResultType)
+                : resultType.ToDisplayString() == suggestedType;
+        }
+
+        /// <summary>
+        /// Returns the expression that yields the property value: the identifier itself, or the enclosing
+        /// <c>this.Prop</c> member access when the identifier is the member name.
+        /// </summary>
+        private static ExpressionSyntax GetPropertyAccessExpression(IdentifierNameSyntax identifier)
+        {
+            if (identifier.Parent is MemberAccessExpressionSyntax memberAccess && memberAccess.Name == identifier)
+            {
+                return memberAccess;
+            }
+
+            return identifier;
+        }
+
+        private static PropertyDeclarationSyntax BuildRetypedProperty(PropertyFixPlan plan)
+        {
+            var newType = SyntaxFactory.ParseTypeName(plan.NewTypeName)
+                .WithTriviaFrom(plan.PropertyDeclaration.Type)
+                .WithAdditionalAnnotations(Simplifier.Annotation);
+
+            var newProperty = plan.PropertyDeclaration.WithType(newType);
+
+            // A string initializer (e.g. = "") is invalid once the type changes; replace it with a compatible default.
+            if (plan.PropertyDeclaration.Initializer is not null)
+            {
+                ExpressionSyntax defaultValue = plan.NewTypeIsValueType
+                    ? SyntaxFactory.LiteralExpression(SyntaxKind.DefaultLiteralExpression, SyntaxFactory.Token(SyntaxKind.DefaultKeyword))
+                    : SyntaxFactory.PostfixUnaryExpression(
+                        SyntaxKind.SuppressNullableWarningExpression,
+                        SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression));
+
+                newProperty = newProperty.WithInitializer(
+                    plan.PropertyDeclaration.Initializer.WithValue(defaultValue));
+            }
+
+            return newProperty.WithAdditionalAnnotations(Formatter.Annotation);
+        }
+
+        private static ITypeSymbol? ResolvePathTypeSymbol(Compilation compilation, string suggestedType) => suggestedType switch
+        {
+            "AbsolutePath" => compilation.GetTypeByMetadataName(WellKnownTypeNames.AbsolutePathFullName),
+            "FileInfo" => compilation.GetTypeByMetadataName("System.IO.FileInfo"),
+            "DirectoryInfo" => compilation.GetTypeByMetadataName("System.IO.DirectoryInfo"),
+            _ => null,
+        };
+
+        private static string FullyQualify(string typeName) => typeName switch
+        {
+            "AbsolutePath" => "global::" + WellKnownTypeNames.AbsolutePathFullName,
+            "FileInfo" => "global::System.IO.FileInfo",
+            "DirectoryInfo" => "global::System.IO.DirectoryInfo",
+            _ => typeName,
+        };
+
+        private static string BuildNewTypeName(string suggestedType, bool isItemRule, bool isArray)
+        {
+            if (!isItemRule)
+            {
+                return FullyQualify(suggestedType);
+            }
+
+            string itemType = $"global::{WellKnownTypeNames.ITaskItemFullName}<{FullyQualify(suggestedType)}>";
+            return isArray ? itemType + "[]" : itemType;
+        }
+
+        private static string BuildDisplayTypeName(string suggestedType, bool isItemRule, bool isArray)
+        {
+            if (!isItemRule)
+            {
+                return suggestedType;
+            }
+
+            string itemType = $"ITaskItem<{suggestedType}>";
+            return isArray ? itemType + "[]" : itemType;
+        }
+
+        /// <summary>
+        /// The set of edits required to retype one property and rewrite all of its conversion sites.
+        /// </summary>
+        private sealed class PropertyFixPlan
+        {
+            public PropertyFixPlan(
+                IPropertySymbol property,
+                PropertyDeclarationSyntax propertyDeclaration,
+                string newTypeName,
+                string newTypeDisplay,
+                bool newTypeIsValueType,
+                List<(SyntaxNode, SyntaxNode)> siteEdits)
+            {
+                Property = property;
+                PropertyDeclaration = propertyDeclaration;
+                NewTypeName = newTypeName;
+                NewTypeDisplay = newTypeDisplay;
+                NewTypeIsValueType = newTypeIsValueType;
+                SiteEdits = siteEdits;
+            }
+
+            public IPropertySymbol Property { get; }
+
+            public PropertyDeclarationSyntax PropertyDeclaration { get; }
+
+            public string NewTypeName { get; }
+
+            public string NewTypeDisplay { get; }
+
+            public bool NewTypeIsValueType { get; }
+
+            public List<(SyntaxNode OldNode, SyntaxNode NewNode)> SiteEdits { get; }
+        }
+
+        /// <summary>
+        /// Applies the property-scoped fix across all diagnostics in a document, grouping by property so each
+        /// property is retyped once even when reported at multiple conversion sites.
+        /// </summary>
+        private sealed class PreferTypedParameterFixAllProvider : DocumentBasedFixAllProvider
+        {
+            protected override async Task<Document?> FixAllAsync(FixAllContext fixAllContext, Document document, ImmutableArray<Diagnostic> diagnostics)
+            {
+                if (diagnostics.IsDefaultOrEmpty)
+                {
+                    return document;
+                }
+
+                return await ApplyPlansAsync(document, diagnostics, fixAllContext.CancellationToken).ConfigureAwait(false);
+            }
+        }
+    }
+}

--- a/src/TaskAnalyzer/README.md
+++ b/src/TaskAnalyzer/README.md
@@ -153,10 +153,21 @@ public class MyTask : Task
         var fi = new FileInfo(absPath);                   // flagged (suggests ITaskItem<FileInfo>)
         var di = new DirectoryInfo(absPath);              // flagged (suggests ITaskItem<DirectoryInfo>)
 
+        // System.IO consumption sites infer the most specific type:
+        File.Delete(TaskEnvironment.GetAbsolutePath(Item.ItemSpec));   // flagged (suggests ITaskItem<FileInfo>)
+        Directory.CreateDirectory(absPath);                            // flagged (suggests ITaskItem<DirectoryInfo>)
+        using var s = new FileStream(Item.ItemSpec, FileMode.Open);    // flagged (suggests ITaskItem<FileInfo>)
+
+        var combined = Path.Combine(Item.ItemSpec, "sub");             // flagged (suggests ITaskItem<AbsolutePath>)
+
         return true;
     }
 }
 ```
+
+**Biasing toward `FileInfo`/`DirectoryInfo`:** When a rooted path flows into a `System.IO.File.*` call or a `FileStream`/`StreamReader`/`StreamWriter` constructor, the analyzer suggests `ITaskItem<FileInfo>`; when it flows into a `System.IO.Directory.*` call, it suggests `ITaskItem<DirectoryInfo>`. These more specific suggestions replace the generic `ITaskItem<AbsolutePath>` for the same property. Tracing follows both a direct `item.ItemSpec` and an `AbsolutePath` intermediary, including a local that is declared and then assigned once (the common `AbsolutePath? p = null; try { p = GetAbsolutePath(...); }` pattern). If one property is used as both a file and a directory, the analyzer falls back to `ITaskItem<AbsolutePath>`.
+
+**`Path.Combine`:** A task input flowing into *any* argument position of `Path.Combine` is flagged (each distinct property is reported once per call), since the value is being used to build an absolute path.
 
 **Array properties:** When the source property is `ITaskItem[]`, the suggestion correctly formats as `ITaskItem<T>[]` (brackets outside the angle brackets), e.g., `ITaskItem<AbsolutePath>[]`.
 
@@ -307,7 +318,7 @@ dotnet test
 | `SharedAnalyzerHelpers.cs` | Shared path safety analysis, banned API resolution, and interface checking helpers |
 | `DiagnosticDescriptors.cs` | Seven diagnostic descriptors in category `MSBuild.TaskAuthoring` |
 | `DiagnosticIds.cs` | Public constants: `MSBuildTask0001`–`MSBuildTask0007` |
-| `PreferTypedParameterAnalyzer.cs` | Analyzer for MSBuildTask0006 and MSBuildTask0007 — detects manual path construction, ItemSpec parsing, Path.Combine usage, helper method wrapping, and FileInfo/DirectoryInfo construction through AbsolutePath intermediaries |
+| `PreferTypedParameterAnalyzer.cs` | Analyzer for MSBuildTask0006 and MSBuildTask0007 — detects manual path construction, ItemSpec parsing, Path.Combine usage (any argument position), helper method wrapping, FileInfo/DirectoryInfo construction through AbsolutePath intermediaries, and System.IO consumption sites (`File.*`/`Directory.*`/`FileStream`/`StreamReader`/`StreamWriter`) that bias suggestions toward `FileInfo`/`DirectoryInfo` |
 
 ### Performance
 

--- a/src/TaskAnalyzer/README.md
+++ b/src/TaskAnalyzer/README.md
@@ -19,6 +19,8 @@ This analyzer catches unsafe API usage at compile time and offers code fixes to 
 | **MSBuildTask0003** | Warning | All `ITask` implementations | File system API requires absolute path |
 | **MSBuildTask0004** | Warning | All `ITask` implementations | API may cause issues in multithreaded tasks |
 | **MSBuildTask0005** | Warning | All `ITask` implementations | Transitive unsafe API usage in task call chain |
+| **MSBuildTask0006** | Info | All `ITask` implementations | Prefer typed path parameter over string |
+| **MSBuildTask0007** | Info | All `ITask` implementations | Prefer `ITaskItem<T>` over manual ItemSpec parsing |
 
 ### MSBuildTask0001 — Critical: No Safe Alternative
 
@@ -97,16 +99,71 @@ These APIs may cause version conflicts or other issues in a shared task host.
 | `Activator.CreateInstanceFrom` | May cause version conflicts |
 | `AppDomain.Load`, `CreateInstance`, `CreateInstanceFrom` | May cause version conflicts |
 
+### MSBuildTask0006 — Prefer Typed Path Parameters
+
+When a task has a `string` input property and converts it to `AbsolutePath`, `FileInfo`, or `DirectoryInfo` inside the task body, the analyzer suggests changing the property type directly. MSBuild can bind these types automatically.
+
+**Detected patterns:**
+
+```csharp
+// ⚠️ MSBuildTask0006: Consider changing 'InputPath' from 'string' to 'AbsolutePath'
+public class MyTask : Task
+{
+    public string InputPath { get; set; }
+
+    public override bool Execute()
+    {
+        var abs = new AbsolutePath(InputPath);           // flagged
+        var abs2 = TaskEnvironment.GetAbsolutePath(InputPath); // flagged
+        var fi = new FileInfo(InputPath);                 // flagged (suggests FileInfo)
+        var di = new DirectoryInfo(InputPath);            // flagged (suggests DirectoryInfo)
+        return true;
+    }
+}
+```
+
+**Not flagged:** `[Output]` properties, non-public properties, read-only properties, values from method calls or literals.
+
+### MSBuildTask0007 — Prefer `ITaskItem<T>` Over ItemSpec Parsing
+
+When a task has an `ITaskItem` or `ITaskItem[]` input property and parses `ItemSpec` to a value type or path type, the analyzer suggests using `ITaskItem<T>` instead.
+
+**Detected patterns:**
+
+```csharp
+// ⚠️ MSBuildTask0007: Consider changing 'Item' from 'ITaskItem' to 'ITaskItem<int>'
+public class MyTask : Task
+{
+    public ITaskItem Item { get; set; }
+    public ITaskItem[] Items { get; set; }
+
+    public override bool Execute()
+    {
+        int value = int.Parse(Item.ItemSpec);             // flagged
+        bool flag = Convert.ToBoolean(Item.ItemSpec);     // flagged
+        var abs = new AbsolutePath(Item.ItemSpec);        // flagged (suggests ITaskItem<AbsolutePath>)
+
+        foreach (var item in Items)
+        {
+            int v = int.Parse(item.ItemSpec);             // flagged (suggests ITaskItem<int>[])
+        }
+        return true;
+    }
+}
+```
+
+**Not flagged:** Metadata access (`item.GetMetadata(...)`), `[Output]` properties, non-task classes.
+
 ## Analysis Scope
 
 The analyzer determines what to check based on the type declaration:
 
 | Type | Rules Applied |
 |---|---|
-| Any class implementing `ITask` | MSBuildTask0001–MSBuildTask0005 |
-| Class implementing `IMultiThreadableTask` | All five rules |
-| Class with `[MSBuildMultiThreadableTask]` attribute | All five rules |
-| Helper class with `[MSBuildMultiThreadableTaskAnalyzed]` attribute | All five rules |
+| Any class implementing `ITask` | MSBuildTask0001–MSBuildTask0007 |
+| Class implementing `IMultiThreadableTask` | All seven rules |
+| Class with `[MSBuildMultiThreadableTask]` attribute | All seven rules |
+| Helper class with `[MSBuildMultiThreadableTaskAnalyzed]` attribute | MSBuildTask0001–MSBuildTask0005 |
 | Regular class (no task interface or attribute) | Not analyzed |
 
 The `[MSBuildMultiThreadableTaskAnalyzed]` attribute allows opting helper classes into **direct** analysis by the `MultiThreadableTaskAnalyzer` (MSBuildTask0001–0004). Without it, only classes implementing `ITask` receive per-line diagnostics and code fixes for those rules. The **transitive** analyzer (MSBuildTask0005) already discovers helpers via call graph analysis, but it reports only at the task entry point. Adding this attribute to a helper class gives you inline diagnostics and code fixes directly in the helper's source.
@@ -117,6 +174,7 @@ The `[MSBuildMultiThreadableTaskAnalyzed]` attribute allows opting helper classe
 
 - **MSBuildTask0001** is always **Error** — these APIs are never safe in any MSBuild task.
 - **MSBuildTask0002–MSBuildTask0005** report as **Warning** for all task types.
+- **MSBuildTask0006–MSBuildTask0007** report as **Info** — these are modernization suggestions, not correctness issues.
 
 ## Code Fixes
 
@@ -223,7 +281,7 @@ public class CopyFiles : Task, IMultiThreadableTask
 
 ## Tests
 
-111 tests covering all rules, safe patterns, edge cases, code fixes, and compiler diagnostic suppression:
+135 tests covering all rules, safe patterns, edge cases, code fixes, and compiler diagnostic suppression:
 
 ```
 cd src/TaskAnalyzer.Tests
@@ -238,8 +296,9 @@ dotnet test
 | `MultiThreadableTaskCodeFixProvider.cs` | Code fixes for MSBuildTask0002 and MSBuildTask0003 |
 | `BannedApiDefinitions.cs` | ~50 banned API entries resolved via `DocumentationCommentId` for O(1) symbol lookup |
 | `SharedAnalyzerHelpers.cs` | Shared path safety analysis, banned API resolution, and interface checking helpers |
-| `DiagnosticDescriptors.cs` | Five diagnostic descriptors in category `MSBuild.TaskAuthoring` |
-| `DiagnosticIds.cs` | Public constants: `MSBuildTask0001`–`MSBuildTask0005` |
+| `DiagnosticDescriptors.cs` | Seven diagnostic descriptors in category `MSBuild.TaskAuthoring` |
+| `DiagnosticIds.cs` | Public constants: `MSBuildTask0001`–`MSBuildTask0007` |
+| `PreferTypedParameterAnalyzer.cs` | Analyzer for MSBuildTask0006 and MSBuildTask0007 — detects manual path construction and ItemSpec parsing |
 
 ### Performance
 

--- a/src/TaskAnalyzer/README.md
+++ b/src/TaskAnalyzer/README.md
@@ -147,10 +147,18 @@ public class MyTask : Task
         {
             int v = int.Parse(item.ItemSpec);             // flagged (suggests ITaskItem<int>[])
         }
+
+        // FileInfo/DirectoryInfo through AbsolutePath intermediary:
+        AbsolutePath absPath = TaskEnvironment.GetAbsolutePath(Item.ItemSpec);
+        var fi = new FileInfo(absPath);                   // flagged (suggests ITaskItem<FileInfo>)
+        var di = new DirectoryInfo(absPath);              // flagged (suggests ITaskItem<DirectoryInfo>)
+
         return true;
     }
 }
 ```
+
+**Array properties:** When the source property is `ITaskItem[]`, the suggestion correctly formats as `ITaskItem<T>[]` (brackets outside the angle brackets), e.g., `ITaskItem<AbsolutePath>[]`.
 
 **Not flagged:** Metadata access (`item.GetMetadata(...)`), `[Output]` properties, non-task classes.
 
@@ -299,7 +307,7 @@ dotnet test
 | `SharedAnalyzerHelpers.cs` | Shared path safety analysis, banned API resolution, and interface checking helpers |
 | `DiagnosticDescriptors.cs` | Seven diagnostic descriptors in category `MSBuild.TaskAuthoring` |
 | `DiagnosticIds.cs` | Public constants: `MSBuildTask0001`–`MSBuildTask0007` |
-| `PreferTypedParameterAnalyzer.cs` | Analyzer for MSBuildTask0006 and MSBuildTask0007 — detects manual path construction and ItemSpec parsing |
+| `PreferTypedParameterAnalyzer.cs` | Analyzer for MSBuildTask0006 and MSBuildTask0007 — detects manual path construction, ItemSpec parsing, Path.Combine usage, helper method wrapping, and FileInfo/DirectoryInfo construction through AbsolutePath intermediaries |
 
 ### Performance
 

--- a/src/TaskAnalyzer/README.md
+++ b/src/TaskAnalyzer/README.md
@@ -19,8 +19,8 @@ This analyzer catches unsafe API usage at compile time and offers code fixes to 
 | **MSBuildTask0003** | Warning | All `ITask` implementations | File system API requires absolute path |
 | **MSBuildTask0004** | Warning | All `ITask` implementations | API may cause issues in multithreaded tasks |
 | **MSBuildTask0005** | Warning | All `ITask` implementations | Transitive unsafe API usage in task call chain |
-| **MSBuildTask0006** | Info | All `ITask` implementations | Prefer typed path parameter over string |
-| **MSBuildTask0007** | Info | All `ITask` implementations | Prefer `ITaskItem<T>` over manual ItemSpec parsing |
+| **MSBuildTask0006** | Info | Multithreaded tasks (`IMultiThreadableTask` or `[MSBuildMultiThreadableTask]`) | Prefer typed path parameter over string |
+| **MSBuildTask0007** | Info | Multithreaded tasks (`IMultiThreadableTask` or `[MSBuildMultiThreadableTask]`) | Prefer `ITaskItem<T>` over manual ItemSpec parsing |
 
 ### MSBuildTask0001 — Critical: No Safe Alternative
 
@@ -160,7 +160,8 @@ The analyzer determines what to check based on the type declaration:
 
 | Type | Rules Applied |
 |---|---|
-| Any class implementing `ITask` | MSBuildTask0001–MSBuildTask0007 |
+| Any class implementing `ITask` | MSBuildTask0001–MSBuildTask0005 |
+| Multithreaded tasks (`IMultiThreadableTask` or `[MSBuildMultiThreadableTask]`) | MSBuildTask0006–MSBuildTask0007 |
 | Class implementing `IMultiThreadableTask` | All seven rules |
 | Class with `[MSBuildMultiThreadableTask]` attribute | All seven rules |
 | Helper class with `[MSBuildMultiThreadableTaskAnalyzed]` attribute | MSBuildTask0001–MSBuildTask0005 |

--- a/src/TaskAnalyzer/README.md
+++ b/src/TaskAnalyzer/README.md
@@ -21,6 +21,7 @@ This analyzer catches unsafe API usage at compile time and offers code fixes to 
 | **MSBuildTask0005** | Warning | All `ITask` implementations | Transitive unsafe API usage in task call chain |
 | **MSBuildTask0006** | Info | Multithreaded tasks (`IMultiThreadableTask` or `[MSBuildMultiThreadableTask]`) | Prefer typed path parameter over string |
 | **MSBuildTask0007** | Info | Multithreaded tasks (`IMultiThreadableTask` or `[MSBuildMultiThreadableTask]`) | Prefer `ITaskItem<T>` over manual ItemSpec parsing |
+| **MSBuildTask0008** | Warning | All `ITask` implementations | `ITaskItem<T>` used with unsupported type argument |
 
 ### MSBuildTask0001 — Critical: No Safe Alternative
 
@@ -173,16 +174,36 @@ public class MyTask : Task
 
 **Not flagged:** Metadata access (`item.GetMetadata(...)`), `[Output]` properties, non-task classes.
 
+### MSBuildTask0008 — Unsupported `ITaskItem<T>` Type Argument
+
+When a task property is typed as `ITaskItem<T>` or `ITaskItem<T>[]` but `T` is not a type that MSBuild's `ValueTypeParser` can parse at runtime, a **Warning** is emitted. Using an unsupported type will cause a runtime failure when MSBuild tries to bind the parameter.
+
+**Supported type arguments:** `bool`, `char`, `byte`, `sbyte`, `short`, `ushort`, `int`, `uint`, `long`, `ulong`, `float`, `double`, `decimal`, `string`, `AbsolutePath`, `FileInfo`, `DirectoryInfo`.
+
+```csharp
+// ⚠️ MSBuildTask0008: Task property 'Id' uses ITaskItem<Guid> but 'Guid' is not supported
+public class MyTask : Task
+{
+    public ITaskItem<System.Guid> Id { get; set; }       // warning
+    public ITaskItem<System.TimeSpan>[] Durations { get; set; }  // warning
+    public ITaskItem<int> Count { get; set; }             // OK
+}
+```
+
+No code fix is offered for MSBuildTask0008 — the resolution depends on the intended semantics (e.g., switching to `string` and parsing manually, or choosing a different supported type).
+
+**Scope:** All `ITask` implementations (not just multithreaded tasks), since using an unsupported T is always a runtime correctness problem.
+
 ## Analysis Scope
 
 The analyzer determines what to check based on the type declaration:
 
 | Type | Rules Applied |
 |---|---|
-| Any class implementing `ITask` | MSBuildTask0001–MSBuildTask0005 |
+| Any class implementing `ITask` | MSBuildTask0001–MSBuildTask0005, MSBuildTask0008 |
 | Multithreaded tasks (`IMultiThreadableTask` or `[MSBuildMultiThreadableTask]`) | MSBuildTask0006–MSBuildTask0007 |
-| Class implementing `IMultiThreadableTask` | All seven rules |
-| Class with `[MSBuildMultiThreadableTask]` attribute | All seven rules |
+| Class implementing `IMultiThreadableTask` | All eight rules |
+| Class with `[MSBuildMultiThreadableTask]` attribute | All eight rules |
 | Helper class with `[MSBuildMultiThreadableTaskAnalyzed]` attribute | MSBuildTask0001–MSBuildTask0005 |
 | Regular class (no task interface or attribute) | Not analyzed |
 
@@ -193,7 +214,7 @@ The `[MSBuildMultiThreadableTaskAnalyzed]` attribute allows opting helper classe
 ### Severity Levels
 
 - **MSBuildTask0001** is always **Error** — these APIs are never safe in any MSBuild task.
-- **MSBuildTask0002–MSBuildTask0005** report as **Warning** for all task types.
+- **MSBuildTask0002–MSBuildTask0005, MSBuildTask0008** report as **Warning** for all task types.
 - **MSBuildTask0006–MSBuildTask0007** report as **Info** — these are modernization suggestions, not correctness issues.
 
 ## Code Fixes

--- a/src/TaskAnalyzer/README.md
+++ b/src/TaskAnalyzer/README.md
@@ -209,8 +209,14 @@ The analyzer ships with a code fix provider that offers automatic replacements:
 | MSBuildTask0002: `Environment.CurrentDirectory` | → `TaskEnvironment.ProjectDirectory` |
 | MSBuildTask0002: `Directory.GetCurrentDirectory()` | → `TaskEnvironment.ProjectDirectory` |
 | MSBuildTask0003: `File.Exists(relativePath)` | → `File.Exists(TaskEnvironment.GetAbsolutePath(relativePath))` |
+| MSBuildTask0006: `new AbsolutePath(InputPath)` | → Retype `InputPath` to `AbsolutePath` and replace conversion with direct property usage |
+| MSBuildTask0006: `new FileInfo(FilePath)` / `new DirectoryInfo(DirPath)` | → Retype property to `FileInfo`/`DirectoryInfo` and replace conversion with direct property usage |
+| MSBuildTask0007: `int.Parse(Item.ItemSpec)` | → Retype `Item` to ``ITaskItem<int>`` and replace parse with `Item.Value` |
+| MSBuildTask0007: `new FileInfo(item.ItemSpec)` in `foreach` over `ITaskItem[]` | → Retype source property to ``ITaskItem<FileInfo>[]`` and replace with `item.Value` |
 
 The MSBuildTask0003 fixer intelligently finds the first **unwrapped** path argument rather than blindly wrapping the first argument — so for `File.Copy(safePath, unsafePath)` it correctly wraps the second argument.
+
+The MSBuildTask0006/MSBuildTask0007 fixer is conservative by design: it only offers a fix when every reference to the property can be safely rewritten as part of the same change, so the resulting code keeps compiling after the property type is updated.
 
 ## Compiler Diagnostic Suppressions
 

--- a/src/TaskAnalyzer/UnsupportedTaskItemTypeAnalyzer.cs
+++ b/src/TaskAnalyzer/UnsupportedTaskItemTypeAnalyzer.cs
@@ -1,0 +1,154 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using static Microsoft.Build.TaskAuthoring.Analyzer.SharedAnalyzerHelpers;
+
+namespace Microsoft.Build.TaskAuthoring.Analyzer
+{
+    /// <summary>
+    /// Roslyn analyzer that warns when a task property is typed as <c>ITaskItem&lt;T&gt;</c> or
+    /// <c>ITaskItem&lt;T&gt;[]</c> where <c>T</c> is not in the set of types that MSBuild's
+    /// <c>ValueTypeParser</c> can parse at runtime.
+    ///
+    /// MSBuildTask0008: ITaskItem&lt;T&gt; used with unsupported type argument.
+    /// </summary>
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class UnsupportedTaskItemTypeAnalyzer : DiagnosticAnalyzer
+    {
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
+            ImmutableArray.Create(DiagnosticDescriptors.UnsupportedTaskItemType);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.EnableConcurrentExecution();
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.RegisterCompilationStartAction(OnCompilationStart);
+        }
+
+        private static void OnCompilationStart(CompilationStartAnalysisContext compilationContext)
+        {
+            var iTaskType = compilationContext.Compilation.GetTypeByMetadataName(WellKnownTypeNames.ITaskFullName);
+            if (iTaskType is null)
+            {
+                return;
+            }
+
+            var iTaskItemOfTType = compilationContext.Compilation.GetTypeByMetadataName(WellKnownTypeNames.ITaskItemOfTFullName);
+            if (iTaskItemOfTType is null)
+            {
+                return;
+            }
+
+            // Collect fully-qualified metadata names for supported T types (mirrors ValueTypeParser)
+            var absolutePathType = compilationContext.Compilation.GetTypeByMetadataName(WellKnownTypeNames.AbsolutePathFullName);
+            var fileInfoType = compilationContext.Compilation.GetTypeByMetadataName("System.IO.FileInfo");
+            var directoryInfoType = compilationContext.Compilation.GetTypeByMetadataName("System.IO.DirectoryInfo");
+
+            var supportedSpecialTypes = new HashSet<SpecialType>
+            {
+                SpecialType.System_Boolean,
+                SpecialType.System_Char,
+                SpecialType.System_Byte,
+                SpecialType.System_SByte,
+                SpecialType.System_Int16,
+                SpecialType.System_UInt16,
+                SpecialType.System_Int32,
+                SpecialType.System_UInt32,
+                SpecialType.System_Int64,
+                SpecialType.System_UInt64,
+                SpecialType.System_Single,
+                SpecialType.System_Double,
+                SpecialType.System_Decimal,
+                SpecialType.System_String,
+            };
+
+            compilationContext.RegisterSymbolAction(symbolContext =>
+            {
+                var namedType = (INamedTypeSymbol)symbolContext.Symbol;
+
+                // Only check ITask implementations
+                if (!ImplementsInterface(namedType, iTaskType))
+                {
+                    return;
+                }
+
+                foreach (var member in namedType.GetMembers())
+                {
+                    if (member is not IPropertySymbol property)
+                    {
+                        continue;
+                    }
+
+                    if (property.DeclaredAccessibility != Accessibility.Public || property.SetMethod is null)
+                    {
+                        continue;
+                    }
+
+                    // Unwrap array: ITaskItem<T>[] → ITaskItem<T>
+                    ITypeSymbol propertyType = property.Type;
+                    if (propertyType is IArrayTypeSymbol arrayType)
+                    {
+                        propertyType = arrayType.ElementType;
+                    }
+
+                    // Check if the property type is ITaskItem<T>
+                    if (propertyType is not INamedTypeSymbol namedPropertyType ||
+                        !namedPropertyType.IsGenericType ||
+                        !SymbolEqualityComparer.Default.Equals(namedPropertyType.OriginalDefinition, iTaskItemOfTType))
+                    {
+                        continue;
+                    }
+
+                    ITypeSymbol typeArg = namedPropertyType.TypeArguments[0];
+
+                    // Check if T is in the supported set
+                    if (IsSupportedTypeArgument(typeArg, supportedSpecialTypes, absolutePathType, fileInfoType, directoryInfoType))
+                    {
+                        continue;
+                    }
+
+                    symbolContext.ReportDiagnostic(Diagnostic.Create(
+                        DiagnosticDescriptors.UnsupportedTaskItemType,
+                        property.Locations[0],
+                        property.Name,
+                        typeArg.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat)));
+                }
+            }, SymbolKind.NamedType);
+        }
+
+        private static bool IsSupportedTypeArgument(
+            ITypeSymbol typeArg,
+            HashSet<SpecialType> supportedSpecialTypes,
+            INamedTypeSymbol? absolutePathType,
+            INamedTypeSymbol? fileInfoType,
+            INamedTypeSymbol? directoryInfoType)
+        {
+            if (typeArg.SpecialType != SpecialType.None && supportedSpecialTypes.Contains(typeArg.SpecialType))
+            {
+                return true;
+            }
+
+            if (absolutePathType is not null && SymbolEqualityComparer.Default.Equals(typeArg, absolutePathType))
+            {
+                return true;
+            }
+
+            if (fileInfoType is not null && SymbolEqualityComparer.Default.Equals(typeArg, fileInfoType))
+            {
+                return true;
+            }
+
+            if (directoryInfoType is not null && SymbolEqualityComparer.Default.Equals(typeArg, directoryInfoType))
+            {
+                return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/TaskAnalyzer/WellKnownTypeNames.cs
+++ b/src/TaskAnalyzer/WellKnownTypeNames.cs
@@ -13,6 +13,9 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
         internal const string TaskEnvironmentFullName = "Microsoft.Build.Framework.TaskEnvironment";
         internal const string AbsolutePathFullName = "Microsoft.Build.Framework.AbsolutePath";
         internal const string ITaskItemFullName = "Microsoft.Build.Framework.ITaskItem";
+        internal const string ITaskItem2FullName = "Microsoft.Build.Framework.ITaskItem2";
+        internal const string ITaskItemOfTFullName = "Microsoft.Build.Framework.ITaskItem`1";
+        internal const string OutputAttributeFullName = "Microsoft.Build.Framework.OutputAttribute";
         internal const string RequiredAttributeFullName = "Microsoft.Build.Framework.RequiredAttribute";
         internal const string AnalyzedAttributeFullName = "Microsoft.Build.Framework.MSBuildMultiThreadableTaskAnalyzedAttribute";
         internal const string MultiThreadableTaskAttributeFullName = "Microsoft.Build.Framework.MSBuildMultiThreadableTaskAttribute";

--- a/src/Tasks/Microsoft.Build.Tasks.csproj
+++ b/src/Tasks/Microsoft.Build.Tasks.csproj
@@ -46,8 +46,6 @@
     <Compile Include="..\Shared\NodeShutdown.cs" />
     <Compile Include="..\Shared\TaskParameter.cs" />
     <Compile Include="..\Shared\TaskParameterTypeVerifier.cs" />
-  </ItemGroup>
-  <ItemGroup>
     <!-- Source Files -->
     <Compile Include="..\Shared\AssemblyFolders\AssemblyFoldersEx.cs">
       <Link>AssemblyDependency\AssemblyFoldersEx.cs</Link>

--- a/src/Utilities.UnitTests/TaskItem_Tests.cs
+++ b/src/Utilities.UnitTests/TaskItem_Tests.cs
@@ -439,4 +439,38 @@ namespace Microsoft.Build.UnitTests
         }
 #endif
     }
+
+    /// <summary>
+    /// Tests for the generic <see cref="TaskItem{T}"/> struct.
+    /// </summary>
+    public class TaskItemOfTTests
+    {
+        [Fact]
+        public void SetMetadata_DoesNotThrow()
+        {
+            var item = new TaskItem<int>(42);
+            // Should not throw - backing is a mutable TaskItem, not TaskItemData
+            item.SetMetadata("key", "value");
+            item.GetMetadata("key").ShouldBe("value");
+        }
+
+        [Fact]
+        public void RemoveMetadata_DoesNotThrow()
+        {
+            var item = new TaskItem<int>(42);
+            item.SetMetadata("key", "value");
+            item.RemoveMetadata("key");
+            item.GetMetadata("key").ShouldBeNullOrEmpty();
+        }
+
+        [Fact]
+        public void CopyMetadataTo_DoesNotThrow()
+        {
+            var source = new TaskItem<int>(42);
+            source.SetMetadata("key", "value");
+            var dest = new TaskItem("dest");
+            source.CopyMetadataTo(dest);
+            dest.GetMetadata("key").ShouldBe("value");
+        }
+    }
 }

--- a/src/Utilities.UnitTests/TaskItem_Tests.cs
+++ b/src/Utilities.UnitTests/TaskItem_Tests.cs
@@ -472,5 +472,26 @@ namespace Microsoft.Build.UnitTests
             source.CopyMetadataTo(dest);
             dest.GetMetadata("key").ShouldBe("value");
         }
+
+        [Fact]
+        public void FromITaskItem_PathLikeType_UsesFullPathMetadata()
+        {
+            // FullPath is a reserved metadata computed by the MSBuild item system as the absolute path.
+            // TaskItem<FileInfo> should use FullPath so relative ItemSpecs resolve to absolute paths.
+            var backingItem = new TaskItem("relative\\path.txt");
+            string expectedAbsolutePath = backingItem.GetMetadata("FullPath");
+            expectedAbsolutePath.ShouldNotBeNullOrEmpty();
+
+            var item = new TaskItem<System.IO.FileInfo>(backingItem);
+            item.Value.FullName.ShouldBe(expectedAbsolutePath);
+        }
+
+        [Fact]
+        public void FromITaskItem_NonPathType_UsesItemSpec()
+        {
+            var backingItem = new TaskItem("42");
+            var item = new TaskItem<int>(backingItem);
+            item.Value.ShouldBe(42);
+        }
     }
 }

--- a/src/Utilities.UnitTests/TaskItem_Tests.cs
+++ b/src/Utilities.UnitTests/TaskItem_Tests.cs
@@ -493,5 +493,47 @@ namespace Microsoft.Build.UnitTests
             var item = new TaskItem<int>(backingItem);
             item.Value.ShouldBe(42);
         }
+
+        [Fact]
+        public void Equals_SameValue_ReturnsTrue()
+        {
+            var a = new TaskItem<int>(42);
+            var b = new TaskItem<int>(42);
+            a.Equals(b).ShouldBeTrue();
+            (a == b).ShouldBeTrue();
+        }
+
+        [Fact]
+        public void Equals_DifferentValue_ReturnsFalse()
+        {
+            var a = new TaskItem<int>(1);
+            var b = new TaskItem<int>(2);
+            a.Equals(b).ShouldBeFalse();
+            (a != b).ShouldBeTrue();
+        }
+
+        [Fact]
+        public void Equals_NullStringValue_HandledCorrectly()
+        {
+            // EqualityComparer<string>.Default handles null without boxing or NullReferenceException
+            var a = new TaskItem<string>((string)null!);
+            var b = new TaskItem<string>((string)null!);
+            a.Equals(b).ShouldBeTrue();
+        }
+
+        [Fact]
+        public void GetHashCode_NullValue_ReturnsZero()
+        {
+            var item = new TaskItem<string>((string)null!);
+            item.GetHashCode().ShouldBe(0);
+        }
+
+        [Fact]
+        public void GetHashCode_ConsistentWithEquality()
+        {
+            var a = new TaskItem<int>(42);
+            var b = new TaskItem<int>(42);
+            a.GetHashCode().ShouldBe(b.GetHashCode());
+        }
     }
 }

--- a/src/Utilities/TaskItem_T.cs
+++ b/src/Utilities/TaskItem_T.cs
@@ -12,14 +12,13 @@ namespace Microsoft.Build.Utilities
     /// A strongly-typed wrapper around <see cref="ITaskItem"/> that parses the item's identity
     /// as a value of type <typeparamref name="T"/>.
     /// </summary>
-    /// <typeparam name="T">The type to parse the item identity as. Must be a value type.</typeparam>
+    /// <typeparam name="T">The type to parse the item identity as. Can be a value type, FileInfo, or DirectoryInfo.</typeparam>
     /// <remarks>
     /// This allows tasks to receive strongly-typed parameters while still working with MSBuild's item system.
-    /// The identity (ItemSpec) is parsed using <see cref="Convert.ChangeType(object?, Type)"/> or special handling for
-    /// types like <see cref="AbsolutePath"/>.
+    /// The identity (ItemSpec) is parsed using <see cref="ValueTypeParser"/> which handles value types,
+    /// AbsolutePath, FileInfo, and DirectoryInfo.
     /// </remarks>
     public readonly struct TaskItem<T> : ITaskItem<T>, IEquatable<TaskItem<T>>
-        where T : struct
     {
         private readonly ITaskItem _backingItem;
 
@@ -155,13 +154,14 @@ namespace Microsoft.Build.Utilities
         #region Equality and Conversion
 
         /// <inheritdoc/>
-        public bool Equals(TaskItem<T> other) => Value.Equals(other.Value);
+        public bool Equals(TaskItem<T> other) =>
+            Value?.Equals(other.Value) ?? (other.Value == null);
 
         /// <inheritdoc/>
         public override bool Equals(object? obj) => obj is TaskItem<T> other && Equals(other);
 
         /// <inheritdoc/>
-        public override int GetHashCode() => Value.GetHashCode();
+        public override int GetHashCode() => Value?.GetHashCode() ?? 0;
 
         /// <summary>
         /// Determines whether two <see cref="TaskItem{T}"/> instances are equal.

--- a/src/Utilities/TaskItem_T.cs
+++ b/src/Utilities/TaskItem_T.cs
@@ -1,0 +1,191 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Shared;
+
+namespace Microsoft.Build.Utilities
+{
+    /// <summary>
+    /// A strongly-typed wrapper around <see cref="ITaskItem"/> that parses the item's identity
+    /// as a value of type <typeparamref name="T"/>.
+    /// </summary>
+    /// <typeparam name="T">The type to parse the item identity as. Must be a value type.</typeparam>
+    /// <remarks>
+    /// This allows tasks to receive strongly-typed parameters while still working with MSBuild's item system.
+    /// The identity (ItemSpec) is parsed using <see cref="Convert.ChangeType(object?, Type)"/> or special handling for
+    /// types like <see cref="AbsolutePath"/>.
+    /// </remarks>
+    public readonly struct TaskItem<T> : ITaskItem<T>, IEquatable<TaskItem<T>>
+        where T : struct
+    {
+        private readonly ITaskItem _backingItem;
+
+        /// <summary>
+        /// Gets the strongly-typed value parsed from the item's identity.
+        /// </summary>
+        public T Value { get; }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="TaskItem{T}"/> from a strongly-typed value.
+        /// </summary>
+        /// <param name="value">The value to wrap.</param>
+        public TaskItem(T value)
+        {
+            Value = value;
+
+            // Create a backing item with the stringified value as ItemSpec
+            string itemSpec = ValueTypeParser.ToString(value);
+            _backingItem = new TaskItemData(itemSpec, null);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="TaskItem{T}"/> from an <see cref="ITaskItem"/>.
+        /// </summary>
+        /// <param name="item">The task item to parse.</param>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="item"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown if the item's identity cannot be parsed as type <typeparamref name="T"/>.</exception>
+        public TaskItem(ITaskItem item)
+        {
+            if (item == null)
+            {
+                throw new ArgumentNullException(nameof(item));
+            }
+
+            _backingItem = item;
+
+            string itemSpec = item.ItemSpec;
+            if (string.IsNullOrEmpty(itemSpec))
+            {
+                throw new ArgumentException($"Cannot create TaskItem<{typeof(T).Name}> from an item with empty identity.", nameof(item));
+            }
+
+            // Parse the value from ItemSpec
+            Value = ParseValue(itemSpec);
+        }
+
+        /// <summary>
+        /// Parses a string value as type <typeparamref name="T"/>.
+        /// Uses the unified ValueTypeParser for consistent parsing behavior across MSBuild.
+        /// </summary>
+        private static T ParseValue(string value) => (T)ValueTypeParser.Parse(value, typeof(T));
+
+        /// <summary>
+        /// Converts the strongly-typed value to its string representation for use as ItemSpec.
+        /// Uses the unified ValueTypeParser for consistent formatting behavior across MSBuild.
+        /// </summary>
+        private string ValueToString() => ValueTypeParser.ToString(Value);
+
+        #region ITaskItem Implementation
+
+        /// <inheritdoc/>
+        public string ItemSpec
+        {
+            get => _backingItem.ItemSpec;
+            set => throw new NotSupportedException("TaskItem<T> ItemSpec is read-only. Create a new instance to change the value.");
+        }
+
+        /// <inheritdoc/>
+        public ICollection MetadataNames => _backingItem.MetadataNames;
+
+        /// <inheritdoc/>
+        public int MetadataCount => _backingItem.MetadataCount;
+
+        /// <inheritdoc/>
+        public string GetMetadata(string metadataName) => _backingItem.GetMetadata(metadataName);
+
+        /// <inheritdoc/>
+        public void SetMetadata(string metadataName, string metadataValue) =>
+            _backingItem.SetMetadata(metadataName, metadataValue);
+
+        /// <inheritdoc/>
+        public void RemoveMetadata(string metadataName) =>
+            _backingItem.RemoveMetadata(metadataName);
+
+        /// <inheritdoc/>
+        public void CopyMetadataTo(ITaskItem destinationItem) =>
+            _backingItem.CopyMetadataTo(destinationItem);
+
+        /// <inheritdoc/>
+        public IDictionary CloneCustomMetadata() => _backingItem.CloneCustomMetadata();
+
+        #endregion
+
+        #region ITaskItem2 Implementation
+
+        /// <inheritdoc/>
+        public string EvaluatedIncludeEscaped
+        {
+            get => (_backingItem as ITaskItem2)?.EvaluatedIncludeEscaped ?? ItemSpec;
+            set => throw new NotSupportedException("TaskItem<T> EvaluatedIncludeEscaped is read-only. Create a new instance to change the value.");
+        }
+
+        /// <inheritdoc/>
+        public string GetMetadataValueEscaped(string metadataName)
+        {
+            return (_backingItem as ITaskItem2)?.GetMetadataValueEscaped(metadataName) ?? string.Empty;
+        }
+
+        /// <inheritdoc/>
+        public void SetMetadataValueLiteral(string metadataName, string metadataValue)
+        {
+            if (_backingItem is ITaskItem2 taskItem2)
+            {
+                taskItem2.SetMetadataValueLiteral(metadataName, metadataValue);
+            }
+            else
+            {
+                // For ITaskItem (non-ITaskItem2), we need to escape the value manually
+                // Since we don't have access to EscapingUtilities in Framework, we'll just set it directly
+                // This is acceptable because TaskItem<T> is primarily used with ITaskItem2 implementations
+                _backingItem.SetMetadata(metadataName, metadataValue);
+            }
+        }
+
+        /// <inheritdoc/>
+        public IDictionary CloneCustomMetadataEscaped()
+        {
+            return (_backingItem as ITaskItem2)?.CloneCustomMetadataEscaped() ?? new Hashtable();
+        }
+
+        #endregion
+
+        #region Equality and Conversion
+
+        /// <inheritdoc/>
+        public bool Equals(TaskItem<T> other) => Value.Equals(other.Value);
+
+        /// <inheritdoc/>
+        public override bool Equals(object? obj) => obj is TaskItem<T> other && Equals(other);
+
+        /// <inheritdoc/>
+        public override int GetHashCode() => Value.GetHashCode();
+
+        /// <summary>
+        /// Determines whether two <see cref="TaskItem{T}"/> instances are equal.
+        /// </summary>
+        public static bool operator ==(TaskItem<T> left, TaskItem<T> right) => left.Equals(right);
+
+        /// <summary>
+        /// Determines whether two <see cref="TaskItem{T}"/> instances are not equal.
+        /// </summary>
+        public static bool operator !=(TaskItem<T> left, TaskItem<T> right) => !left.Equals(right);
+
+        /// <summary>
+        /// Implicitly converts a <see cref="TaskItem{T}"/> to its strongly-typed value.
+        /// </summary>
+        public static implicit operator T(TaskItem<T> taskItem) => taskItem.Value;
+
+        /// <summary>
+        /// Implicitly converts a strongly-typed value to a <see cref="TaskItem{T}"/>.
+        /// </summary>
+        public static implicit operator TaskItem<T>(T value) => new TaskItem<T>(value);
+
+        #endregion
+
+        /// <inheritdoc/>
+        public override string ToString() => ValueToString();
+    }
+}

--- a/src/Utilities/TaskItem_T.cs
+++ b/src/Utilities/TaskItem_T.cs
@@ -65,8 +65,26 @@ namespace Microsoft.Build.Utilities
                 throw new ArgumentException($"Cannot create TaskItem<{typeof(T).Name}> from an item with empty identity.", nameof(item));
             }
 
-            // Parse the value from ItemSpec
-            Value = ParseValue(itemSpec);
+            // For path-like types, prefer the FullPath metadata (which is always absolute)
+            // over ItemSpec which may be relative.
+            string parseFrom = IsPathLikeType() ? GetFullPathOrItemSpec(item, itemSpec) : itemSpec;
+            Value = ParseValue(parseFrom);
+        }
+
+        /// <summary>Returns true if T is a path-like type that benefits from absolute path resolution.</summary>
+        private static bool IsPathLikeType()
+        {
+            Type t = typeof(T);
+            return t == typeof(System.IO.FileInfo) ||
+                   t == typeof(System.IO.DirectoryInfo) ||
+                   t == typeof(AbsolutePath);
+        }
+
+        /// <summary>Returns the FullPath metadata value if non-empty, otherwise falls back to itemSpec.</summary>
+        private static string GetFullPathOrItemSpec(ITaskItem item, string itemSpec)
+        {
+            string fullPath = item.GetMetadata("FullPath");
+            return !string.IsNullOrEmpty(fullPath) ? fullPath : itemSpec;
         }
 
         /// <summary>

--- a/src/Utilities/TaskItem_T.cs
+++ b/src/Utilities/TaskItem_T.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
 
@@ -177,13 +178,13 @@ namespace Microsoft.Build.Utilities
 
         /// <inheritdoc/>
         public bool Equals(TaskItem<T> other) =>
-            Value?.Equals(other.Value) ?? (other.Value == null);
+            EqualityComparer<T>.Default.Equals(Value, other.Value);
 
         /// <inheritdoc/>
         public override bool Equals(object? obj) => obj is TaskItem<T> other && Equals(other);
 
         /// <inheritdoc/>
-        public override int GetHashCode() => Value?.GetHashCode() ?? 0;
+        public override int GetHashCode() => Value is null ? 0 : EqualityComparer<T>.Default.GetHashCode(Value);
 
         /// <summary>
         /// Determines whether two <see cref="TaskItem{T}"/> instances are equal.

--- a/src/Utilities/TaskItem_T.cs
+++ b/src/Utilities/TaskItem_T.cs
@@ -6,6 +6,10 @@ using System.Collections;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
 
+// Alias to avoid ambiguity: within TaskItem<T>, "TaskItem" refers to this generic struct;
+// use TaskItemImpl to refer to the non-generic Utilities.TaskItem class.
+using TaskItemImpl = Microsoft.Build.Utilities.TaskItem;
+
 namespace Microsoft.Build.Utilities
 {
     /// <summary>
@@ -35,9 +39,9 @@ namespace Microsoft.Build.Utilities
         {
             Value = value;
 
-            // Create a backing item with the stringified value as ItemSpec
+            // Use a mutable TaskItem as backing so metadata mutations are supported
             string itemSpec = ValueTypeParser.ToString(value);
-            _backingItem = new TaskItemData(itemSpec, null);
+            _backingItem = new TaskItemImpl(itemSpec);
         }
 
         /// <summary>


### PR DESCRIPTION
A lot of the migration of Tasks to MT mode is figuring out what to do with strings. Today we typically make them an AbsolutePath, and then use that AbsolutePath to use File/Directory APIs in some way.

We can make this _much_ more ergonomic _and_ less error prone by allowing users to declare those types directly for their Inputs and Outputs and letting the engine do the correct thing automatically!

### Context

# MSBuild Task Parameter Type Enhancements

This branch adds three major enhancements to MSBuild's task parameter system, enabling tasks to use strongly-typed parameters with rich .NET types and metadata access.

## Summary of Enhancements

### 1. AbsolutePath Parameter Support
Tasks can now use `AbsolutePath` and `AbsolutePath[]` as parameter types for validated absolute paths.

### 2. Generic `ITaskItem<T>` Interface
A new `ITaskItem<T>` interface allows tasks to receive primitive types (int, bool, DateTime, etc.) wrapped as items with full metadata access. The `T` will be coerced from the input EvaluatedIdentity via a unified value type converter mechanism that allows for sharing the logic across the many locations in the codebase that coercion is done.

### 3. FileInfo and DirectoryInfo Support
Tasks can now use `System.IO.FileInfo` and `System.IO.DirectoryInfo` types for file system operations. They are created by rooting the path via the AbsolutePath type, and then constructing the instance via that path. The File/Directory does not need to exist in order to be bound.

---

<details>
<summary><h2>Feature 1: AbsolutePath Parameters</h2></summary>

### Overview
The `AbsolutePath` type provides validated absolute paths with proper resolution and error checking.

### Supported Types
- `AbsolutePath` - Single validated absolute path
- `AbsolutePath[]` - Array of validated absolute paths

### Example

```xml
<Project>
  <UsingTask TaskName="MyPathTask" AssemblyFile="MyTasks.dll" />

  <Target Name="ProcessPaths">
    <MyPathTask
      ConfigPath="config.json"
      OutputPath="bin\output" />
  </Target>
</Project>
```

```csharp
using Microsoft.Build.Framework;
using Microsoft.Build.Utilities;

public class MyPathTask : Task
{
    [Required]
    public AbsolutePath ConfigPath { get; set; }

    [Required]
    public AbsolutePath OutputPath { get; set; }

    public override bool Execute()
    {
        // Paths are automatically resolved to absolute paths
        Log.LogMessage($"Config: {ConfigPath.Value}");
        Log.LogMessage($"Output: {OutputPath.Value}");

        // AbsolutePath ensures the path is valid and absolute
        if (File.Exists(ConfigPath.Value))
        {
            string config = File.ReadAllText(ConfigPath.Value);
            // Process config...
        }

        return true;
    }
}
```

### Benefits
- **Automatic validation**: Paths are validated when the task is invoked
- **Relative path resolution**: Relative paths are automatically resolved relative to the project directory
- **Type safety**: Compile-time checking that paths are being used correctly
- **Error prevention**: Invalid paths are caught early in the build process

</details>

---

<details>
<summary><h2>Feature 2: ITaskItem&lt;T&gt; Generic Interface</h2></summary>

### Overview
The new `ITaskItem<T>` interface allows task parameters to be strongly-typed while retaining full access to MSBuild item metadata. This bridges the gap between primitive types and MSBuild's item system.

### Supported Types
- **Value types**: `int`, `long`, `short`, `byte`, `uint`, `ulong`, `ushort`, `sbyte`, `double`, `float`, `decimal`
- **Other types**: `char`, `bool`, `DateTime`
- **Path types**: `AbsolutePath`, `FileInfo`, `DirectoryInfo`
- **Arrays**: All of the above as array types (e.g., `ITaskItem<int>[]`)

### Key Components

#### ITaskItem&lt;T&gt; Interface
```csharp
namespace Microsoft.Build.Framework
{
    public interface ITaskItem<T> : ITaskItem2
    {
        T Value { get; }
    }
}
```

#### TaskItem&lt;T&gt; Implementation
```csharp
namespace Microsoft.Build.Utilities
{
    public readonly struct TaskItem<T> : ITaskItem<T>
    {
        public T Value { get; }
        // ... implements all ITaskItem/ITaskItem2 members
    }
}
```

### Example: Integer Items with Metadata

```xml
<Project>
  <ItemGroup>
    <Port Include="8080">
      <Service>WebAPI</Service>
      <Protocol>HTTP</Protocol>
    </Port>
    <Port Include="8443">
      <Service>WebAPI</Service>
      <Protocol>HTTPS</Protocol>
    </Port>
    <Port Include="5432">
      <Service>Database</Service>
      <Protocol>PostgreSQL</Protocol>
    </Port>
  </ItemGroup>

  <Target Name="ConfigurePorts">
    <MyPortTask Ports="@(Port)" />
  </Target>
</Project>
```

```csharp
using Microsoft.Build.Framework;
using Microsoft.Build.Utilities;

public class MyPortTask : Task
{
    [Required]
    public ITaskItem<int>[] Ports { get; set; }

    public override bool Execute()
    {
        foreach (var portItem in Ports)
        {
            // Access the strongly-typed value
            int port = portItem.Value;

            // Access MSBuild metadata
            string service = portItem.GetMetadata("Service");
            string protocol = portItem.GetMetadata("Protocol");

            Log.LogMessage($"Configuring {service} on port {port} ({protocol})");

            // Use the port number in type-safe operations
            if (port < 1024)
            {
                Log.LogWarning($"Port {port} is in the privileged range");
            }
        }

        return true;
    }
}
```

### Benefits of ITaskItem&lt;T&gt;

1. **Type Safety**: Compile-time checking of value types
   ```csharp
   // Before: String parsing, runtime errors
   public ITaskItem[] Ports { get; set; }
   int port = int.Parse(Ports[0].ItemSpec);  // Can throw at runtime

   // After: Type-safe, no parsing needed
   public ITaskItem<int>[] Ports { get; set; }
   int port = Ports[0].Value;  // Direct access, no exceptions
   ```

2. **Metadata Access**: Full MSBuild item capabilities
   ```csharp
   var item = Ports[0];
   int value = item.Value;                        // Type-safe value
   string metadata = item.GetMetadata("Service"); // Metadata access
   item.SetMetadata("Status", "Configured");      // Metadata mutation
   ```

3. **Automatic Conversion**: MSBuild handles all conversions
</details>

---

<details>
<summary><h2>Feature 3: FileInfo and DirectoryInfo Parameters</h2></summary>

### Overview
Tasks can now use `System.IO.FileInfo` and `System.IO.DirectoryInfo` types, providing rich file system APIs and automatic path validation.

### Supported Types
- `FileInfo` - Single file parameter
- `FileInfo[]` - Array of file parameters
- `DirectoryInfo` - Single directory parameter
- `DirectoryInfo[]` - Array of directory parameters
- `ITaskItem<FileInfo>` - File with metadata
- `ITaskItem<FileInfo>[]` - Array of files with metadata
- `ITaskItem<DirectoryInfo>` - Directory with metadata
- `ITaskItem<DirectoryInfo>[]` - Array of directories with metadata

### Example: File Processing

```xml
<Target Name="ProcessFiles">
  <ItemGroup>
    <SourceFiles Include="src\**\*.cs" />
  </ItemGroup>

  <MyFileTask Files="@(SourceFiles)" />
</Target>
```

```csharp
public class MyFileTask : Task
{
    [Required]
    public FileInfo[] Files { get; set; }

    public override bool Execute()
    {
        Log.LogMessage($"Processing {Files.Length} files...");

        long totalSize = 0;
        DateTime latestModified = DateTime.MinValue;

        foreach (FileInfo file in Files)
        {
            if (file.Exists)
            {
                // Rich FileInfo API
                totalSize += file.Length;
                if (file.LastWriteTime > latestModified)
                {
                    latestModified = file.LastWriteTime;
                }

                Log.LogMessage($"  {file.Name}:");
                Log.LogMessage($"    Size: {file.Length:N0} bytes");
                Log.LogMessage($"    Modified: {file.LastWriteTime:yyyy-MM-dd HH:mm:ss}");
                Log.LogMessage($"    Read-only: {file.IsReadOnly}");
            }
        }

        Log.LogMessage($"Total: {totalSize:N0} bytes");
        Log.LogMessage($"Latest modification: {latestModified:yyyy-MM-dd HH:mm:ss}");

        return true;
    }
}
```

### Example: Directory Operations

```xml
<Target Name="CleanDirectories">
  <MyCleanTask
    SourceDir="src"
    BuildDirs="bin;obj;packages" />
</Target>
```

```csharp
public class MyCleanTask : Task
{
    [Required]
    public DirectoryInfo SourceDir { get; set; }

    [Required]
    public DirectoryInfo[] BuildDirs { get; set; }

    public override bool Execute()
    {
        // Search for build artifacts
        foreach (DirectoryInfo buildDir in BuildDirs)
        {
            var matches = SourceDir.GetDirectories(buildDir.Name, SearchOption.AllDirectories);

            Log.LogMessage($"Found {matches.Length} '{buildDir.Name}' directories");

            foreach (var dir in matches)
            {
                try
                {
                    Log.LogMessage($"  Deleting: {dir.FullName}");
                    dir.Delete(recursive: true);
                }
                catch (Exception ex)
                {
                    Log.LogWarning($"  Could not delete {dir.FullName}: {ex.Message}");
                }
            }
        }

        return true;
    }
}
```

### Example: Files with Metadata

```xml
<ItemGroup>
  <InputFile Include="data\users.csv">
    <Format>CSV</Format>
    <HasHeader>true</HasHeader>
    <Encoding>UTF-8</Encoding>
  </InputFile>
  <InputFile Include="data\products.json">
    <Format>JSON</Format>
    <Schema>v2</Schema>
  </InputFile>
</ItemGroup>

<Target Name="ImportData">
  <MyImportTask Files="@(InputFile)" />
</Target>
```

```csharp
public class MyImportTask : Task
{
    [Required]
    public ITaskItem<FileInfo>[] Files { get; set; }

    public override bool Execute()
    {
        foreach (var fileItem in Files)
        {
            // Access FileInfo
            FileInfo file = fileItem.Value;

            // Access metadata
            string format = fileItem.GetMetadata("Format");
            string encoding = fileItem.GetMetadata("Encoding");

            Log.LogMessage($"Importing {file.Name}");
            Log.LogMessage($"  Format: {format}");
            Log.LogMessage($"  Size: {file.Length:N0} bytes");

            if (!file.Exists)
            {
                Log.LogError($"File not found: {file.FullName}");
                continue;
            }

            // Process based on format
            switch (format.ToUpperInvariant())
            {
                case "CSV":
                    bool hasHeader = bool.Parse(fileItem.GetMetadata("HasHeader") ?? "false");
                    ImportCsv(file, hasHeader, encoding);
                    break;

                case "JSON":
                    string schema = fileItem.GetMetadata("Schema");
                    ImportJson(file, schema);
                    break;
            }
        }

        return true;
    }

    private void ImportCsv(FileInfo file, bool hasHeader, string encoding) { /* ... */ }
    private void ImportJson(FileInfo file, string schema) { /* ... */ }
}
```

### Path Validation

All file and directory paths are validated through MSBuild's `AbsolutePath` infrastructure so that they behave correctly
in both multithreaded and multi-process builds:

```csharp
// In TaskExecutionHost
if (parameterType == typeof(FileInfo))
{
    AbsolutePath absolutePath = TaskEnvironment.GetAbsolutePath(expandedParameterValue);
    return InternalSetTaskParameter(parameter, new FileInfo(absolutePath.Value));
}
```

This ensures:
- Paths are properly rooted and resolved
- Relative paths are expanded relative to the project directory
- Invalid path characters are detected early
- Consistent behavior with other MSBuild path types

</details>

---

## Technical Implementation

### ValueTypeParser
A new unified parsing utility handles conversion between strings and value types:

```csharp
namespace Microsoft.Build.Shared
{
    internal static class ValueTypeParser
    {
        public static object Parse(string value, Type targetType);
        public static string ToString(object value);
    }
}
```

This provides consistent behavior for:
- Numeric conversions with `InvariantCulture`
- Boolean parsing (supports MSBuild conventions: `true`, `on`, `yes`, `!false`, etc.)
- DateTime parsing
- AbsolutePath, FileInfo, DirectoryInfo construction

### TaskParameterTypeVerifier
Enhanced to recognize new parameter types:

```csharp
internal static bool IsValidScalarInputParameter(Type parameterType) =>
    parameterType.GetTypeInfo().IsValueType ||
    parameterType == typeof(string) ||
    parameterType == typeof(ITaskItem) ||
    parameterType == typeof(AbsolutePath) ||
    parameterType == typeof(FileInfo) ||
    parameterType == typeof(DirectoryInfo) ||
    IsTaskItemOfT(parameterType);
```

### TaskExecutionHost
Updated parameter binding logic to handle:
- Direct type conversion for scalars
- Array element processing
- ITaskItem&lt;T&gt; wrapper creation
- Path validation through AbsolutePath

---

## Migration Guide

### Before: String-Based Parameters
```csharp
public class OldTask : Task
{
    public string Port { get; set; }
    public string[] Files { get; set; }

    public override bool Execute()
    {
        int port = int.Parse(Port);  // Runtime parsing
        foreach (string filePath in Files)
        {
            var file = new FileInfo(filePath);  // Manual construction
            // ...
        }
        return true;
    }
}
```

### After: Strongly-Typed Parameters
```csharp
public class NewTask : Task
{
    public ITaskItem<int> Port { get; set; }
    public FileInfo[] Files { get; set; }

    public override bool Execute()
    {
        int port = Port.Value;  // Direct access
        string service = Port.GetMetadata("Service");  // Metadata available

        foreach (FileInfo file in Files)
        {
            // FileInfo ready to use, no construction needed
            long size = file.Length;
            // ...
        }
        return true;
    }
}
```

---

## Compatibility

All enhancements are **fully backward compatible**:
- Existing tasks using `string` or `ITaskItem` continue to work unchanged
- No changes required to existing project files
- New types are opt-in for new task development - though using them does require using recent versions of MSBuild

---

## Test Coverage

Comprehensive test suite includes:
- **AbsolutePath**: 12 tests covering scalars, arrays, and edge cases
- **ITaskItem&lt;T&gt;**: 24 tests covering all value types and arrays
- **FileInfo/DirectoryInfo**: 36 tests covering all scenarios
- **Total**: 72+ new tests, all passing on .NET Framework and .NET Core

---

## Documentation Updates

- [Tasks.md](documentation/wiki/Tasks.md) - Updated with all new parameter types
- API documentation for new interfaces and classes
- Inline code documentation for all public APIs

---

## Roslyn Analyzers for Typed Parameters

Two new Roslyn analyzers guide task authors toward using the new typed parameters. These analyzers only fire on tasks that have opted into multithreaded support (implement `IMultiThreadableTask` or are decorated with `[MSBuildMultiThreadableTask]`), since the new typed parameter features are designed for the multithreaded task execution path.

### MSBuildTask0006 — Prefer Typed Path Parameters (Info)

Fires when a multithreaded task converts a `string` input property to `AbsolutePath`, `FileInfo`, or `DirectoryInfo` inside the task body. Suggests changing the property type directly so MSBuild handles the binding.

**Detected patterns:** `new AbsolutePath(stringProp)`, `TaskEnvironment.GetAbsolutePath(stringProp)`, `new FileInfo(stringProp)`, `new DirectoryInfo(stringProp)`

### MSBuildTask0007 — Prefer `ITaskItem<T>` (Info)

Fires when a multithreaded task parses `ItemSpec` from an `ITaskItem` or `ITaskItem[]` property to a value type or path type. Suggests using `ITaskItem<T>` for automatic binding.

**Detected patterns:** `int.Parse(item.ItemSpec)`, `Convert.ToBoolean(item.ItemSpec)`, `new AbsolutePath(item.ItemSpec)`, `TaskEnvironment.GetAbsolutePath(item.ItemSpec)`, etc.

**Biasing toward `FileInfo`/`DirectoryInfo`:** When a task input's rooted path flows into a `System.IO.File.*` call or a `FileStream`/`StreamReader`/`StreamWriter` constructor, the analyzer suggests `ITaskItem<FileInfo>`; when it flows into a `System.IO.Directory.*` call, it suggests `ITaskItem<DirectoryInfo>` — instead of the generic `ITaskItem<AbsolutePath>`. Tracing follows the direct `ItemSpec`, an `AbsolutePath` intermediary, and locals that are declared then assigned once. When one property is used as both a file and a directory, it falls back to `AbsolutePath`.

**`Path.Combine`:** A task input flowing into *any* argument position of `Path.Combine` is flagged (each distinct property once per call).

Both analyzers:
- **Only fire on multithreaded tasks** (`IMultiThreadableTask` or `[MSBuildMultiThreadableTask]`) that also implement `ITask`
- Trace through local variable indirection (including single-assignment locals), `foreach` iteration, array indexing, and one level of helper-method wrapping
- Exclude `[Output]` properties, non-public properties, and read-only properties
- Use **Info** severity — these are migration suggestions, not correctness issues

Running the analyzers across `Microsoft.Build.Tasks` surfaces **63 unique locations** (19 MSBuildTask0006 + 44 MSBuildTask0007), of which 10 properties are now biased to `FileInfo`/`DirectoryInfo` based on their System.IO usage. See the [analysis comment](https://github.com/dotnet/msbuild/pull/13016#issuecomment-4624655241) for the full breakdown.

### Other Changes

- Removed dead `#if !TASKHOST` preprocessor guards from `TaskParameterTypeVerifier.cs` — the `TASKHOST` define is no longer set by any project in the main codebase since the .NET 3.5 taskhost was separated.






### Analyzer fixer support
- Added Roslyn code fixers for MSBuildTask0006 and MSBuildTask0007.
- Fixes retype task properties (for example, to typed path parameters / ITaskItem<T> shapes) and rewrite the flagged conversion sites to direct typed usage.

