### PR TITLE
Enlighten more tasks that require no change

### DIFF
--- a/src/Tasks/CombineTargetFrameworkInfoProperties.cs
+++ b/src/Tasks/CombineTargetFrameworkInfoProperties.cs
@@ -12,6 +12,7 @@ namespace Microsoft.Build.Tasks
     /// <summary>
     /// Combines items that represent properties and values into an XML representation.
     /// </summary>
+    [MSBuildMultiThreadableTask]
     public class CombineTargetFrameworkInfoProperties : TaskExtension
     {
         /// <summary>

--- a/src/Tasks/CombineXmlElements.cs
+++ b/src/Tasks/CombineXmlElements.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Build.Tasks
     /// <summary>
     /// Combines multiple XML elements
     /// </summary>
+    [MSBuildMultiThreadableTask]
     public class CombineXmlElements : TaskExtension
     {
         /// <summary>

--- a/src/Tasks/ErrorFromResources.cs
+++ b/src/Tasks/ErrorFromResources.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Build.Tasks
     /// Task that emits an error given a resource string. Engine will add project file path and line/column
     /// information.
     /// </summary>
+    [MSBuildMultiThreadableTask]
     public sealed class ErrorFromResources : TaskExtension
     {
         /// <summary>

--- a/src/Tasks/FindAppConfigFile.cs
+++ b/src/Tasks/FindAppConfigFile.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Build.Tasks
     /// For compat reasons, it has to follow a particular arbitrary algorithm.
     /// It also adds the TargetPath metadata.
     /// </summary>
+    [MSBuildMultiThreadableTask]
     public class FindAppConfigFile : TaskExtension
     {
         // The list to search through

--- a/src/Tasks/FindInvalidProjectReferences.cs
+++ b/src/Tasks/FindInvalidProjectReferences.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Build.Tasks
     /// <summary>
     /// Returns the reference assembly paths to the various frameworks
     /// </summary>
+    [MSBuildMultiThreadableTask]
     public partial class FindInvalidProjectReferences : TaskExtension
     {
         #region Fields

--- a/src/Tasks/GetCompatiblePlatform.cs
+++ b/src/Tasks/GetCompatiblePlatform.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Build.Tasks
     ///
     /// See ProjectReference-Protocol.md for details.
     /// </summary>
+    [MSBuildMultiThreadableTask]
     public class GetCompatiblePlatform : TaskExtension
     {
         /// <summary>


### PR DESCRIPTION
### Context
This PR marks several simple tasks as multithreadable.

### Changes Made
Marks several simple tasks as multithreadable by adding the MSBuildMultiThreadableTask attribute. 

These tasks are safe for concurrent execution because they:
CombineTargetFrameworkInfoProperties, CombineXmlElements - Pure XML/string manipulation 
ErrorFromResources - only logs messages
FindAppConfigFile, FindInvalidProjectReferences, GetCompatiblePlatform - Only reads metadata from ITaskItem objects; no file I/O

### Testing
manual