### PR TITLE
Clarify conditions for ToolingPackage metadata

### DIFF
--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -1,8 +1,9 @@
 <Project>
 
   <!-- Update Artifacts with Kind=Package to have additional metadata item Category="ToolingPackage".
-       Depending on channel configuration, this means that these assets could be pushed to a different feed. -->
-  <ItemGroup>
+       Depending on channel configuration, this means that these assets could be pushed to a different feed. 
+       Only apply this when building from the standalone MSBuild repo, not from the VMR (dotnet/dotnet). -->
+  <ItemGroup Condition="'$(DotNetBuildFromVMR)' != 'true'">
     <Artifact Update="@(Artifact->WithMetadataValue('Kind', 'Package'))" Category="ToolingPackage" />
   </ItemGroup>
 


### PR DESCRIPTION
Updated condition for applying metadata that define when MSBuild packages are published to https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json

