### PR TITLE
Further aspnet website build improvements

### DIFF
--- a/src/Build/Construction/Solution/SolutionProjectGenerator.cs
+++ b/src/Build/Construction/Solution/SolutionProjectGenerator.cs
@@ -451,7 +451,8 @@ namespace Microsoft.Build.Construction
             rarTask.SetParameter("FindSerializationAssemblies", "true");
             rarTask.SetParameter("FindRelatedFiles", "true");
             rarTask.SetParameter("TargetFrameworkMoniker", project.TargetFrameworkMoniker);
-            rarTask.AddOutputItem("CopyLocalFiles", copyLocalFilesItemName, null);
+            rarTask.SetParameter("TargetFrameworkVersion", "v" + new FrameworkName(project.TargetFrameworkMoniker).Version.ToString());
+            rarTask.AddOutputItem("CopyLocalFiles", copyLocalFilesItemName, null);  
 
             // Copy all the copy-local files (reported by RAR) to the web project's "bin"
             // directory.

--- a/src/Build/Construction/Solution/SolutionProjectGenerator.cs
+++ b/src/Build/Construction/Solution/SolutionProjectGenerator.cs
@@ -444,6 +444,7 @@ namespace Microsoft.Build.Construction
             // files need to be copy-localed.
             ProjectTaskInstance rarTask = target.AddTask("ResolveAssemblyReference", String.Format(CultureInfo.InvariantCulture, "Exists('%({0}.Identity)')", referenceItemName), null);
             rarTask.SetParameter("Assemblies", "@(" + referenceItemName + "->'%(FullPath)')");
+            rarTask.SetParameter("AppConfigFile", "$(WebConfigFileName)");
             rarTask.SetParameter("TargetFrameworkDirectories", "$(" + targetFrameworkDirectoriesName + ")");
             rarTask.SetParameter("FullFrameworkFolders", "$(" + fullFrameworkRefAssyPathName + ")");
             rarTask.SetParameter("SearchPaths", "{RawFileName};{TargetFrameworkDirectory};{GAC}");
@@ -462,6 +463,7 @@ namespace Microsoft.Build.Construction
             // directory.
             ProjectTaskInstance copyTask = target.AddTask("Copy", conditionDescribingValidConfigurations, null);
             copyTask.SetParameter("SourceFiles", "@(" + copyLocalFilesItemName + ")");
+            copyTask.SetParameter("SkipUnchangedFiles", "true");
             copyTask.SetParameter(
                 "DestinationFiles",
                 String.Format(CultureInfo.InvariantCulture, @"@({0}->'{1}%(DestinationSubDirectory)%(Filename)%(Extension)')", copyLocalFilesItemName, destinationFolder));
@@ -1256,6 +1258,16 @@ namespace Microsoft.Build.Construction
                     "AspNetCompiler.UnsupportedMSBuildVersion",
                     project.ProjectName);
 #else
+
+                if (File.Exists(Path.Combine(project.AbsolutePath, "web.config")))
+                {
+                    metaprojectInstance.SetProperty("WebConfigFileName", Path.Combine(project.AbsolutePath, "web.config"));
+                }
+                else if (File.Exists(Path.Combine(project.AbsolutePath, "Web.config")))
+                {
+                    metaprojectInstance.SetProperty("WebConfigFileName", Path.Combine(project.AbsolutePath, "Web.config"));
+                }
+
                 AddMetaprojectTargetForWebProject(traversalProject, metaprojectInstance, project, null);
                 AddMetaprojectTargetForWebProject(traversalProject, metaprojectInstance, project, "Clean");
                 AddMetaprojectTargetForWebProject(traversalProject, metaprojectInstance, project, "Rebuild");
@@ -1551,6 +1563,7 @@ namespace Microsoft.Build.Construction
             newTask.SetParameter("TargetPath", "$(" + GenerateSafePropertyName(project, "AspNetTargetPath") + ")");
             newTask.SetParameter("Force", "$(" + GenerateSafePropertyName(project, "AspNetForce") + ")");
             newTask.SetParameter("Updateable", "$(" + GenerateSafePropertyName(project, "AspNetUpdateable") + ")");
+            newTask.SetParameter("Clean", "true");
             newTask.SetParameter("Debug", "$(" + GenerateSafePropertyName(project, "AspNetDebug") + ")");
             newTask.SetParameter("KeyFile", "$(" + GenerateSafePropertyName(project, "AspNetKeyFile") + ")");
             newTask.SetParameter("KeyContainer", "$(" + GenerateSafePropertyName(project, "AspNetKeyContainer") + ")");

--- a/src/Build/Construction/Solution/SolutionProjectGenerator.cs
+++ b/src/Build/Construction/Solution/SolutionProjectGenerator.cs
@@ -451,8 +451,8 @@ namespace Microsoft.Build.Construction
             rarTask.SetParameter("FindSerializationAssemblies", "true");
             rarTask.SetParameter("FindRelatedFiles", "true");
             rarTask.SetParameter("TargetFrameworkMoniker", project.TargetFrameworkMoniker);
-            rarTask.SetParameter("TargetFrameworkVersion", "v" + new FrameworkName(project.TargetFrameworkMoniker).Version.ToString());
-            rarTask.AddOutputItem("CopyLocalFiles", copyLocalFilesItemName, null);  
+            rarTask.SetParameter("TargetFrameworkVersion", $"v{new FrameworkName(project.TargetFrameworkMoniker).Version}");
+            rarTask.AddOutputItem("CopyLocalFiles", copyLocalFilesItemName, null);
 
             // Copy all the copy-local files (reported by RAR) to the web project's "bin"
             // directory.

--- a/src/Build/Instance/ProjectInstance.cs
+++ b/src/Build/Instance/ProjectInstance.cs
@@ -2398,8 +2398,10 @@ namespace Microsoft.Build.Execution
                     if (!_globalProperties.Contains(property.Name) || !String.Equals(_globalProperties[property.Name].EvaluatedValue, property.EvaluatedValue, StringComparison.OrdinalIgnoreCase))
                     {
                         if ((!_environmentVariableProperties.Contains(property.Name) || !String.Equals(_environmentVariableProperties[property.Name].EvaluatedValue, property.EvaluatedValue, StringComparison.OrdinalIgnoreCase))
-                            && _sdkResolvedEnvironmentVariableProperties is not null
-                            && (!_sdkResolvedEnvironmentVariableProperties.Contains(property.Name) || !String.Equals(_sdkResolvedEnvironmentVariableProperties[property.Name].EvaluatedValue, property.EvaluatedValue, StringComparison.OrdinalIgnoreCase)))
+                            && (!Toolset.Properties.ContainsKey(property.Name) || !String.Equals(Toolset.Properties[property.Name].EvaluatedValue, property.EvaluatedValue, StringComparison.OrdinalIgnoreCase))
+                            && (_sdkResolvedEnvironmentVariableProperties is null
+                                || !_sdkResolvedEnvironmentVariableProperties.Contains(property.Name)
+                                || !String.Equals(_sdkResolvedEnvironmentVariableProperties[property.Name].EvaluatedValue, property.EvaluatedValue, StringComparison.OrdinalIgnoreCase)))
                         {
                             property.ToProjectPropertyElement(propertyGroupElement);
                         }

--- a/src/Tasks/AspNetCompiler.cs
+++ b/src/Tasks/AspNetCompiler.cs
@@ -246,6 +246,7 @@ namespace Microsoft.Build.Tasks
         /// <param name="commandLine">command line builder class to add arguments to</param>
         protected internal override void AddCommandLineCommands(CommandLineBuilderExtension commandLine)
         {
+            commandLine.AppendSwitch("-errorstack");
             commandLine.AppendSwitchIfNotNull("-m ", MetabasePath);
             commandLine.AppendSwitchIfNotNull("-v ", VirtualPath);
             commandLine.AppendSwitchIfNotNull("-p ", PhysicalPath);


### PR DESCRIPTION
Builds off https://github.com/dotnet/msbuild/pull/13058 and https://github.com/dotnet/msbuild/pull/12980 resolving https://github.com/dotnet/msbuild/pull/12980, by addressing other issues I encountered when trying to build a clean version of my solution. The biggest of these is that the RAR tasks in website metaprojects don't currently detect the web.config file and by extension the assembly redirects. Also the AspNetCompiler task's doesn't report error stack traces at the moment, which I believe is an easy when to add in. I am also skipping unchanged files when copying dependencies to the Bin folder to reduce double writes. I also have changed the generated metaproject to include properties that have been set using SetProperty on the metaproject instance. I know my filtering here is not complete and my tests will fail so leaving in draft until I have that resolved. The AspNetCompiler task generated in website metaprojects also doesn't provide the clean flag at the moment. I haven't found an elegant solution to pass this in at the moment, so I have hard coded it to be true. Welcome to feedback here but I needed it to be enabled in order to avoid a cheeky null reference error. Leaving in draft for now as I await the other PR's being merged and test resolution
