### PR TITLE
Undo COM support in out of proc task host CLR4

### DIFF
--- a/src/Shared/INodePacket.cs
+++ b/src/Shared/INodePacket.cs
@@ -329,7 +329,7 @@ namespace Microsoft.Build.BackEnd
         /// <returns>True if extended header flag was set, false otherwise.</returns>
         public static bool TryCreateExtendedHeaderType(HandshakeOptions handshakeOptions, NodePacketType type, out byte extendedheader)
         {
-            if (Handshake.IsHandshakeOptionEnabled(handshakeOptions, HandshakeOptions.TaskHost))
+            if (Handshake.IsHandshakeOptionEnabled(handshakeOptions, HandshakeOptions.TaskHost) && Handshake.IsHandshakeOptionEnabled(handshakeOptions, HandshakeOptions.NET))
             {
                 extendedheader = (byte)((byte)type | ExtendedHeaderFlag);
                 return true;


### PR DESCRIPTION
Revert https://github.com/dotnet/msbuild/pull/13033 since it causes issues with DTB in C++.
I will investigate it more
