### PR TITLE
Fix package validation telemetry assembly resolution warnings

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -16,7 +16,7 @@
        Microsoft.VisualStudio.Telemetry is referenced with PrivateAssets="all" in Framework,
        so package validation can't resolve it when validating dependent packages. -->
   <PropertyGroup Condition="'$(EnablePackageValidation)' == 'true'">
-    <ApiCompatAdditionalSearchPaths>$(ApiCompatAdditionalSearchPaths);$(NuGetPackageRoot)microsoft.visualstudio.telemetry\$(MicrosoftVisualStudioTelemetryVersion)\lib\net472</ApiCompatAdditionalSearchPaths>
+    <ApiCompatAdditionalSearchPaths>$(ApiCompatAdditionalSearchPaths);$(NuGetPackageRoot)microsoft.visualstudio.telemetry\$(MicrosoftVisualStudioTelemetryVersion)\lib\$(FullFrameworkTFM)</ApiCompatAdditionalSearchPaths>
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(IsPackable)' == 'true' ">


### PR DESCRIPTION
## Summary

During build, package validation emits warnings about being unable to resolve `Microsoft.VisualStudio.Telemetry.dll`:

```
Could not resolve reference 'Microsoft.VisualStudio.Telemetry.dll' directly or transitively referenced by 'ref/net472/Microsoft.Build.dll' (...) in any of the provided search directories.
```

This occurs because `Microsoft.Build.Framework` references `Microsoft.VisualStudio.Telemetry` with `PrivateAssets="all"` for net472 (to enable telemetry in Visual Studio scenarios). When package validation runs on packages like `Microsoft.Build` that depend on Framework, it cannot resolve this private reference.

## Fix

Add the telemetry package path to `ApiCompatAdditionalSearchPaths` in `Directory.Build.targets`, allowing the package validation to locate the assembly.

## Testing

- Built locally with `.\build.cmd -v quiet` - warnings no longer appear
- Build succeeds with 0 errors
