### PR TITLE
Respect NetCoreSdkRoot property for TaskHostParameters

### DIFF
--- a/src/Build/Resources/Constants.cs
+++ b/src/Build/Resources/Constants.cs
@@ -121,6 +121,11 @@ namespace Microsoft.Build.Internal
         internal const string RuntimeIdentifierGraphPath = nameof(RuntimeIdentifierGraphPath);
 
         /// <summary>
+        /// The project property name used to get the root of the .NET Core SDK.
+        /// </summary>
+        internal const string NetCoreSdkRoot = nameof(NetCoreSdkRoot);
+
+        /// <summary>
         /// Defines the name of dotnet process based on the operating system.
         /// </summary>
         internal static readonly string DotnetProcessName = NativeMethodsShared.IsWindows ? "dotnet.exe" : "dotnet";


### PR DESCRIPTION
The property got added with https://github.com/dotnet/sdk/commit/e0c4dda2e07d99203f83254b7ff5d117fb8e2220

The `RuntimeIdentifierGraphPath` property isn't guaranteed to point to a file inside a directory that contains the msbuild assemblies as customers sometimes set that to a custom .json file (i.e. new RID).