### PR TITLE
Handle null ProjectFile in InvalidProjectFileException

### DIFF
--- a/src/Build/Errors/InvalidProjectFileException.cs
+++ b/src/Build/Errors/InvalidProjectFileException.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Build.Exceptions
         /// The assumption is that all the metadata for the outer exception comes from the inner exception, eg., they have the same error code.
         /// </summary>
         internal InvalidProjectFileException(string message, InvalidProjectFileException innerException)
-            : this(innerException.ProjectFile, innerException.LineNumber, innerException.ColumnNumber, innerException.EndLineNumber, innerException.EndColumnNumber, message, innerException.ErrorSubcategory, innerException.ErrorCode, innerException.HelpKeyword)
+            : this(innerException.ProjectFile ?? "MSBUILD", innerException.LineNumber, innerException.ColumnNumber, innerException.EndLineNumber, innerException.EndColumnNumber, message, innerException.ErrorSubcategory, innerException.ErrorCode, innerException.HelpKeyword)
         {
         }
 


### PR DESCRIPTION
The internal InvalidProctFileException constructor accepts an existing InvalidProjectFileException object as a parameter. It passes the ProjectFile property from that passed in object to another constructor that then verifies that projectFile is not null.

Whenever an InvalidProjectFileException object is passed in that has a null projectFile (which is possible via the public ctors), an ArgumentNullException gets thrown and hides real errors.

The object gets passed to the internal ctor here: https://github.com/dotnet/msbuild/blob/8bd4d54903169f7e515f8a32e20190b340a295c9/src/Build/BackEnd/Components/RequestBuilder/TaskBuilder.cs#L923

Fix this by passing "MSBUILD" as a string in whenever projectFile is null.

Fixes  https://github.com/dotnet/msbuild/issues/13150