### PR TITLE
Revert #13076 "Adds validation to throw MSB4259 when property references contain leading or trailing whitespace outside of conditions.

### DIFF
--- a/documentation/wiki/ChangeWaves.md
+++ b/documentation/wiki/ChangeWaves.md
@@ -24,9 +24,6 @@ A wave of features is set to "rotate out" (i.e. become standard functionality) t
 
 ## Current Rotation of Change Waves
 
-### 18.5
-- [Throw MSB4281 error for property references and property function calls with leading or trailing whitespace (e.g., `$( Foo )`, `$( Foo.StartsWith('Bar') )`).](https://github.com/dotnet/msbuild/pull/13076)
-
 ### 18.4
 - [Start throwing on null or empty paths in MultiProcess and MultiThreaded Task Environment Drivers.](https://github.com/dotnet/msbuild/pull/12914)
 

--- a/src/Build.UnitTests/Evaluation/Expander_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/Expander_Tests.cs
@@ -3854,71 +3854,14 @@ namespace Microsoft.Build.UnitTests.Evaluation
         [Fact]
         public void PropertySimpleSpaced()
         {
-            using (TestEnvironment env = TestEnvironment.Create())
-            {
-                env.SetEnvironmentVariable("MSBUILDDISABLEFEATURESFROMVERSION", ChangeWaves.Wave18_4.ToString());
+            PropertyDictionary<ProjectPropertyInstance> pg = new PropertyDictionary<ProjectPropertyInstance>();
+            pg.Set(ProjectPropertyInstance.Create("SomeStuff", "This IS SOME STUff"));
 
-                PropertyDictionary<ProjectPropertyInstance> pg = new PropertyDictionary<ProjectPropertyInstance>();
-                pg.Set(ProjectPropertyInstance.Create("SomeStuff", "This IS SOME STUff"));
+            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
 
-                Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
+            string result = expander.ExpandIntoStringLeaveEscaped(@"$( SomeStuff )", ExpanderOptions.ExpandProperties, MockElementLocation.Instance);
 
-                string result = expander.ExpandIntoStringLeaveEscaped(@"$( SomeStuff )", ExpanderOptions.ExpandProperties, MockElementLocation.Instance);
-
-                Assert.Equal(String.Empty, result);
-            }
-        }
-
-        /// <summary>
-        /// Expand a property reference that has whitespace around the property name should throw error MSB4281
-        /// when ChangeWave 18.5 is enabled
-        /// </summary>
-        [Theory]
-        [InlineData("$( SomeStuff )")]   // Leading and trailing space
-        [InlineData("$( SomeStuff)")]    // Leading space only
-        [InlineData("$(SomeStuff )")]    // Trailing space only
-        public void PropertyWithWhitespace_ShouldThrowError_WhenChangeWaveEnabled(string expression)
-        {
-            using (TestEnvironment env = TestEnvironment.Create())
-            {
-                env.SetEnvironmentVariable("MSBUILDDISABLEFEATURESFROMVERSION", "");
-
-                PropertyDictionary<ProjectPropertyInstance> pg = new PropertyDictionary<ProjectPropertyInstance>();
-                pg.Set(ProjectPropertyInstance.Create("SomeStuff", "This IS SOME STUff"));
-
-                Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
-
-                InvalidProjectFileException ex = Assert.Throws<InvalidProjectFileException>(
-                    () => expander.ExpandIntoStringLeaveEscaped(expression, ExpanderOptions.ExpandProperties, MockElementLocation.Instance));
-
-                Assert.Equal("MSB4281", ex.ErrorCode);
-            }
-        }
-
-        /// <summary>
-        /// Expand a property function call that has whitespace around the property name should throw error MSB4281
-        /// when ChangeWave 18.5 is enabled
-        /// </summary>
-        [Theory]
-        [InlineData("$( SomeStuff.StartsWith('This'))")]   // Leading space only
-        [InlineData("$(SomeStuff.StartsWith('This') )")]   // Trailing space only
-        [InlineData("$( SomeStuff.StartsWith('This') )")]  // Leading and trailing space
-        public void PropertyFunctionWithWhitespace_ShouldThrowError_WhenChangeWaveEnabled(string expression)
-        {
-            using (TestEnvironment env = TestEnvironment.Create())
-            {
-                env.SetEnvironmentVariable("MSBUILDDISABLEFEATURESFROMVERSION", "");
-
-                PropertyDictionary<ProjectPropertyInstance> pg = new PropertyDictionary<ProjectPropertyInstance>();
-                pg.Set(ProjectPropertyInstance.Create("SomeStuff", "This IS SOME STUff"));
-
-                Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
-
-                InvalidProjectFileException ex = Assert.Throws<InvalidProjectFileException>(
-                    () => expander.ExpandIntoStringLeaveEscaped(expression, ExpanderOptions.ExpandProperties, MockElementLocation.Instance));
-
-                Assert.Equal("MSB4281", ex.ErrorCode);
-            }
+            Assert.Equal(String.Empty, result);
         }
 
         [WindowsOnlyFact]

--- a/src/Build/Evaluation/Expander.cs
+++ b/src/Build/Evaluation/Expander.cs
@@ -1385,30 +1385,7 @@ namespace Microsoft.Build.Evaluation
                         }
                         else // This is a regular property
                         {
-                            int propertyNameStart = propertyStartIndex + 2;
-                            int propertyNameEnd = propertyEndIndex - 1;
-
-                            // Check for whitespace in property name - this is likely a typo
-                            // Gated behind ChangeWave 18.5 as this is a breaking change
-                            if (ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave18_5))
-                            {
-                                // Check if there's leading or trailing whitespace
-                                if (Char.IsWhiteSpace(expression[propertyNameStart]) || Char.IsWhiteSpace(expression[propertyNameEnd]))
-                                {
-                                    // Find the position of the whitespace for error message
-                                    int whitespacePosition = Char.IsWhiteSpace(expression[propertyNameStart])
-                                        ? propertyNameStart
-                                        : propertyNameEnd;
-
-                                    ProjectErrorUtilities.ThrowInvalidProject(
-                                        elementLocation,
-                                        "IllFormedPropertySpaceInPropertyReference",
-                                        expression.Substring(propertyStartIndex, propertyEndIndex - propertyStartIndex + 1),
-                                        whitespacePosition - propertyStartIndex + 1);
-                                }
-                            }
-
-                            propertyValue = LookupProperty(properties, expression, propertyNameStart, propertyNameEnd, elementLocation, propertiesUseTracker);
+                            propertyValue = LookupProperty(properties, expression, propertyStartIndex + 2, propertyEndIndex - 1, elementLocation, propertiesUseTracker);
                         }
 
                         if (propertyValue != null)
@@ -1457,27 +1434,7 @@ namespace Microsoft.Build.Evaluation
                 Function<T> function = null;
                 string propertyName = propertyBody;
 
-                // Check for whitespace in property body - this is likely a typo
-                // Gated behind ChangeWave 18.5 as this is a breaking change
-                if (ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave18_5))
-                {
-                    if (Char.IsWhiteSpace(propertyBody[0]) || Char.IsWhiteSpace(propertyBody[propertyBody.Length - 1]))
-                    {
-                        // Calculate the position of the whitespace for error message
-                        // Position is 1-based, relative to the full property reference $({propertyBody})
-                        int whitespacePosition = Char.IsWhiteSpace(propertyBody[0])
-                            ? 3  // Position after "$("
-                            : propertyBody.Length + 2;  // Position before ")"
-
-                        ProjectErrorUtilities.ThrowInvalidProject(
-                            elementLocation,
-                            "IllFormedPropertySpaceInPropertyReference",
-                            $"$({propertyBody})",
-                            whitespacePosition);
-                    }
-                }
-
-                // Trim the body for compatibility reasons (when ChangeWave is disabled):
+                // Trim the body for compatibility reasons:
                 // Spaces are not valid property name chars, but $( Foo ) is allowed, and should always expand to BLANK.
                 // Do a very fast check for leading and trailing whitespace, and trim them from the property body if we have any.
                 // But we will do a property name lookup on the propertyName that we held onto.

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -529,10 +529,6 @@
     <value>MSB4259: Unexpected space at position "{1}" of condition "{0}". Did you forget to remove a space?</value>
     <comment>{StrBegin="MSB4259: "}</comment>
   </data>
-  <data name="IllFormedPropertySpaceInPropertyReference" xml:space="preserve">
-    <value>MSB4281: Unexpected space at position "{1}" of property reference "{0}". Did you forget to remove a space?</value>
-    <comment>{StrBegin="MSB4281: "}</comment>
-  </data>
   <data name="IllFormedQuotedStringInCondition" xml:space="preserve">
     <value>MSB4101: Expected a closing quote after position {1} in condition "{0}".</value>
     <comment>{StrBegin="MSB4101: "}</comment>
@@ -2466,7 +2462,7 @@ Utilization:          {0} Average Utilization: {1:###.0}</value>
   <!--
         The Build message bucket is: MSB4000 - MSB4999
 
-        Next message code should be MSB4282
+        Next message code should be MSB4281
 
         Don't forget to update this comment after using a new code.
   -->

--- a/src/Build/Resources/xlf/Strings.cs.xlf
+++ b/src/Build/Resources/xlf/Strings.cs.xlf
@@ -540,16 +540,6 @@
         <target state="translated">MSB4259: Na pozici {1} podmínky {0} je neočekávaná mezera. Nezapomněli jste ji odebrat?</target>
         <note>{StrBegin="MSB4259: "}</note>
       </trans-unit>
-      <trans-unit id="IllFormedPropertySpaceInPropertyReference">
-        <source>MSB4281: Unexpected space at position "{1}" of property reference "{0}". Did you forget to remove a space?</source>
-        <target state="translated">MSB4281: Neočekávaná mezera na pozici {1} odkazu na vlastnost {0}. Nezapomněli jste ji odebrat?</target>
-        <note>{StrBegin="MSB4281: "}</note>
-      </trans-unit>
-      <trans-unit id="IllFormedQuotedStringInCondition">
-        <source>MSB4101: Expected a closing quote after position {1} in condition "{0}".</source>
-        <target state="translated">MSB4101: Na pozici {1} v podmínce {0} byla očekávána pravá uvozovka.</target>
-        <note>{StrBegin="MSB4101: "}</note>
-      </trans-unit>
       <trans-unit id="IllegalCharactersInFileOrDirectory">
         <source>There are illegal characters in '{0}' in the {1} item.</source>
         <target state="translated">V položce {1} jsou v „{0}“ neplatné znaky.</target>
@@ -1535,6 +1525,11 @@ Chyby: {3}</target>
         <source>MSB4110: Expected a property at position {1} in condition "{0}". Did you forget the opening parenthesis after the '$'? To use a literal '$', use '%24' instead.</source>
         <target state="translated">MSB4110: Na pozici {1} v podmínce {0} byla očekávána vlastnost. Nezapomněli jste zadat levou závorku za znak $? Chcete-li použít literál $, použijte místo toho znak %24.</target>
         <note>{StrBegin="MSB4110: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedQuotedStringInCondition">
+        <source>MSB4101: Expected a closing quote after position {1} in condition "{0}".</source>
+        <target state="translated">MSB4101: Na pozici {1} v podmínce {0} byla očekávána pravá uvozovka.</target>
+        <note>{StrBegin="MSB4101: "}</note>
       </trans-unit>
       <trans-unit id="ImportedProjectNotFound">
         <source>MSB4019: The imported project "{0}" was not found. Confirm that the expression in the Import declaration "{1}", which evaluated to "{2}", is correct, and that the file exists on disk.</source>

--- a/src/Build/Resources/xlf/Strings.de.xlf
+++ b/src/Build/Resources/xlf/Strings.de.xlf
@@ -540,16 +540,6 @@
         <target state="translated">MSB4259: Unerwartetes Leerzeichen an Position "{1}" der Bedingung "{0}". Haben Sie vergessen, ein Leerzeichen zu entfernen?</target>
         <note>{StrBegin="MSB4259: "}</note>
       </trans-unit>
-      <trans-unit id="IllFormedPropertySpaceInPropertyReference">
-        <source>MSB4281: Unexpected space at position "{1}" of property reference "{0}". Did you forget to remove a space?</source>
-        <target state="translated">MSB4281: Unerwartetes Leerzeichen an Position „{1}“ der Eigenschaftsreferenz „{0}“. Haben Sie vergessen, ein Leerzeichen zu entfernen?</target>
-        <note>{StrBegin="MSB4281: "}</note>
-      </trans-unit>
-      <trans-unit id="IllFormedQuotedStringInCondition">
-        <source>MSB4101: Expected a closing quote after position {1} in condition "{0}".</source>
-        <target state="translated">MSB4101: Es wurde ein schließendes Anführungszeichen hinter Position {1} in Bedingung {0} erwartet.</target>
-        <note>{StrBegin="MSB4101: "}</note>
-      </trans-unit>
       <trans-unit id="IllegalCharactersInFileOrDirectory">
         <source>There are illegal characters in '{0}' in the {1} item.</source>
         <target state="translated">Unzulässige Zeichen in „{0}“ im {1}-Element.</target>
@@ -1535,6 +1525,11 @@ Fehler: {3}</target>
         <source>MSB4110: Expected a property at position {1} in condition "{0}". Did you forget the opening parenthesis after the '$'? To use a literal '$', use '%24' instead.</source>
         <target state="translated">MSB4110: Eine Eigenschaft wurde an Position {1} in Bedingung "{0}" erwartet. Haben Sie die öffnende Klammer hinter dem '$' vergessen? Wenn Sie ein literales '$' verwenden möchten, geben Sie stattdessen '%24' ein.</target>
         <note>{StrBegin="MSB4110: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedQuotedStringInCondition">
+        <source>MSB4101: Expected a closing quote after position {1} in condition "{0}".</source>
+        <target state="translated">MSB4101: Es wurde ein schließendes Anführungszeichen hinter Position {1} in Bedingung {0} erwartet.</target>
+        <note>{StrBegin="MSB4101: "}</note>
       </trans-unit>
       <trans-unit id="ImportedProjectNotFound">
         <source>MSB4019: The imported project "{0}" was not found. Confirm that the expression in the Import declaration "{1}", which evaluated to "{2}", is correct, and that the file exists on disk.</source>

--- a/src/Build/Resources/xlf/Strings.es.xlf
+++ b/src/Build/Resources/xlf/Strings.es.xlf
@@ -540,16 +540,6 @@
         <target state="translated">MSB4259: Espacio inesperado en la posición "{1}" de la condición "{0}". ¿Olvidó quitar un espacio?</target>
         <note>{StrBegin="MSB4259: "}</note>
       </trans-unit>
-      <trans-unit id="IllFormedPropertySpaceInPropertyReference">
-        <source>MSB4281: Unexpected space at position "{1}" of property reference "{0}". Did you forget to remove a space?</source>
-        <target state="translated">MSB4281: espacio inesperado en la posición "{1}" de la referencia de propiedad "{0}". ¿Olvidó quitar un espacio?</target>
-        <note>{StrBegin="MSB4281: "}</note>
-      </trans-unit>
-      <trans-unit id="IllFormedQuotedStringInCondition">
-        <source>MSB4101: Expected a closing quote after position {1} in condition "{0}".</source>
-        <target state="translated">MSB4101: Se esperaban unas comillas de cierre después de la posición {1} en la condición "{0}".</target>
-        <note>{StrBegin="MSB4101: "}</note>
-      </trans-unit>
       <trans-unit id="IllegalCharactersInFileOrDirectory">
         <source>There are illegal characters in '{0}' in the {1} item.</source>
         <target state="translated">Hay caracteres no válidos en '{0}' en el elemento {1}.</target>
@@ -1535,6 +1525,11 @@ Errores: {3}</target>
         <source>MSB4110: Expected a property at position {1} in condition "{0}". Did you forget the opening parenthesis after the '$'? To use a literal '$', use '%24' instead.</source>
         <target state="translated">MSB4110: Se esperaba una propiedad en la posición {1} en la condición "{0}". ¿Olvidó el paréntesis de apertura después de '$'? Para usar '$' literal, use '%24' en su lugar.</target>
         <note>{StrBegin="MSB4110: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedQuotedStringInCondition">
+        <source>MSB4101: Expected a closing quote after position {1} in condition "{0}".</source>
+        <target state="translated">MSB4101: Se esperaban unas comillas de cierre después de la posición {1} en la condición "{0}".</target>
+        <note>{StrBegin="MSB4101: "}</note>
       </trans-unit>
       <trans-unit id="ImportedProjectNotFound">
         <source>MSB4019: The imported project "{0}" was not found. Confirm that the expression in the Import declaration "{1}", which evaluated to "{2}", is correct, and that the file exists on disk.</source>

--- a/src/Build/Resources/xlf/Strings.fr.xlf
+++ b/src/Build/Resources/xlf/Strings.fr.xlf
@@ -540,16 +540,6 @@
         <target state="translated">MSB4259: espace inattendu à la position "{1}" de la condition "{0}". Avez-vous oublié de supprimer un espace ?</target>
         <note>{StrBegin="MSB4259: "}</note>
       </trans-unit>
-      <trans-unit id="IllFormedPropertySpaceInPropertyReference">
-        <source>MSB4281: Unexpected space at position "{1}" of property reference "{0}". Did you forget to remove a space?</source>
-        <target state="translated">MSB4281: espace inattendu à la position « {1} » de la référence de propriété « {0} ». Avez-vous oublié de supprimer un espace ?</target>
-        <note>{StrBegin="MSB4281: "}</note>
-      </trans-unit>
-      <trans-unit id="IllFormedQuotedStringInCondition">
-        <source>MSB4101: Expected a closing quote after position {1} in condition "{0}".</source>
-        <target state="translated">MSB4101: Guillemet fermant attendu après la position {1} dans la condition "{0}".</target>
-        <note>{StrBegin="MSB4101: "}</note>
-      </trans-unit>
       <trans-unit id="IllegalCharactersInFileOrDirectory">
         <source>There are illegal characters in '{0}' in the {1} item.</source>
         <target state="translated">Il existe des caractères non conformes dans « {0} » dans l’élément {1}.</target>
@@ -1535,6 +1525,11 @@ Erreurs : {3}</target>
         <source>MSB4110: Expected a property at position {1} in condition "{0}". Did you forget the opening parenthesis after the '$'? To use a literal '$', use '%24' instead.</source>
         <target state="translated">MSB4110: Propriété attendue à la position {1} dans la condition "{0}". Avez-vous oublié la parenthèse ouvrante après '$' ? Pour utiliser un '$' littéral, utilisez plutôt '%24'.</target>
         <note>{StrBegin="MSB4110: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedQuotedStringInCondition">
+        <source>MSB4101: Expected a closing quote after position {1} in condition "{0}".</source>
+        <target state="translated">MSB4101: Guillemet fermant attendu après la position {1} dans la condition "{0}".</target>
+        <note>{StrBegin="MSB4101: "}</note>
       </trans-unit>
       <trans-unit id="ImportedProjectNotFound">
         <source>MSB4019: The imported project "{0}" was not found. Confirm that the expression in the Import declaration "{1}", which evaluated to "{2}", is correct, and that the file exists on disk.</source>

--- a/src/Build/Resources/xlf/Strings.it.xlf
+++ b/src/Build/Resources/xlf/Strings.it.xlf
@@ -540,16 +540,6 @@
         <target state="translated">MSB4259: spazio imprevisto alla posizione "{1}" della condizione "{0}". Si è dimenticato di rimuovere uno spazio?</target>
         <note>{StrBegin="MSB4259: "}</note>
       </trans-unit>
-      <trans-unit id="IllFormedPropertySpaceInPropertyReference">
-        <source>MSB4281: Unexpected space at position "{1}" of property reference "{0}". Did you forget to remove a space?</source>
-        <target state="translated">MSB4281: spazio imprevisto alla posizione "{1}" del riferimento alla proprietà "{0}". Si è dimenticato di rimuovere uno spazio?</target>
-        <note>{StrBegin="MSB4281: "}</note>
-      </trans-unit>
-      <trans-unit id="IllFormedQuotedStringInCondition">
-        <source>MSB4101: Expected a closing quote after position {1} in condition "{0}".</source>
-        <target state="translated">MSB4101: è prevista una virgoletta di chiusura dopo la posizione {1} nella condizione "{0}".</target>
-        <note>{StrBegin="MSB4101: "}</note>
-      </trans-unit>
       <trans-unit id="IllegalCharactersInFileOrDirectory">
         <source>There are illegal characters in '{0}' in the {1} item.</source>
         <target state="translated">Sono presenti caratteri non validi in '{0}' nell'elemento {1}.</target>
@@ -1535,6 +1525,11 @@ Errori: {3}</target>
         <source>MSB4110: Expected a property at position {1} in condition "{0}". Did you forget the opening parenthesis after the '$'? To use a literal '$', use '%24' instead.</source>
         <target state="translated">MSB4110: è prevista una proprietà nella posizione {1} nella condizione "{0}". Si è omessa la parentesi di apertura dopo il simbolo '$'? Per usare un valore letterale '$', specificare '%24'.</target>
         <note>{StrBegin="MSB4110: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedQuotedStringInCondition">
+        <source>MSB4101: Expected a closing quote after position {1} in condition "{0}".</source>
+        <target state="translated">MSB4101: è prevista una virgoletta di chiusura dopo la posizione {1} nella condizione "{0}".</target>
+        <note>{StrBegin="MSB4101: "}</note>
       </trans-unit>
       <trans-unit id="ImportedProjectNotFound">
         <source>MSB4019: The imported project "{0}" was not found. Confirm that the expression in the Import declaration "{1}", which evaluated to "{2}", is correct, and that the file exists on disk.</source>

--- a/src/Build/Resources/xlf/Strings.ja.xlf
+++ b/src/Build/Resources/xlf/Strings.ja.xlf
@@ -540,16 +540,6 @@
         <target state="translated">MSB4259: 条件 "{0}" の位置 "{1}" に予期しないスペースがあります。スペースを削除したか確認してください。</target>
         <note>{StrBegin="MSB4259: "}</note>
       </trans-unit>
-      <trans-unit id="IllFormedPropertySpaceInPropertyReference">
-        <source>MSB4281: Unexpected space at position "{1}" of property reference "{0}". Did you forget to remove a space?</source>
-        <target state="translated">MSB4281: プロパティ参照 "{0}" の位置 "{1}" に予期しないスペースがあります。スペースを削除したか確認してください。</target>
-        <note>{StrBegin="MSB4281: "}</note>
-      </trans-unit>
-      <trans-unit id="IllFormedQuotedStringInCondition">
-        <source>MSB4101: Expected a closing quote after position {1} in condition "{0}".</source>
-        <target state="translated">MSB4101: 条件 "{0}" の場所 {1} の後に終わり引用符が必要です。</target>
-        <note>{StrBegin="MSB4101: "}</note>
-      </trans-unit>
       <trans-unit id="IllegalCharactersInFileOrDirectory">
         <source>There are illegal characters in '{0}' in the {1} item.</source>
         <target state="translated">{1} 項目内の '{0}' に不正な文字があります。</target>
@@ -1535,6 +1525,11 @@ Errors: {3}</source>
         <source>MSB4110: Expected a property at position {1} in condition "{0}". Did you forget the opening parenthesis after the '$'? To use a literal '$', use '%24' instead.</source>
         <target state="translated">MSB4110: 条件 "{0}" の場所 {1} にプロパティが必要です。始めかっこが '$' の後に入力されていることを確認してください。リテラル '$' を使用するには、'%24' を代わりに使用してください。</target>
         <note>{StrBegin="MSB4110: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedQuotedStringInCondition">
+        <source>MSB4101: Expected a closing quote after position {1} in condition "{0}".</source>
+        <target state="translated">MSB4101: 条件 "{0}" の場所 {1} の後に終わり引用符が必要です。</target>
+        <note>{StrBegin="MSB4101: "}</note>
       </trans-unit>
       <trans-unit id="ImportedProjectNotFound">
         <source>MSB4019: The imported project "{0}" was not found. Confirm that the expression in the Import declaration "{1}", which evaluated to "{2}", is correct, and that the file exists on disk.</source>

--- a/src/Build/Resources/xlf/Strings.ko.xlf
+++ b/src/Build/Resources/xlf/Strings.ko.xlf
@@ -540,16 +540,6 @@
         <target state="translated">MSB4259: "{0}" 조건의 "{1}" 위치에 예기치 않은 공백이 있습니다. 공백을 제거했는지 확인하세요.</target>
         <note>{StrBegin="MSB4259: "}</note>
       </trans-unit>
-      <trans-unit id="IllFormedPropertySpaceInPropertyReference">
-        <source>MSB4281: Unexpected space at position "{1}" of property reference "{0}". Did you forget to remove a space?</source>
-        <target state="translated">MSB4281: "{0}" 속성 참조의 "{1}" 위치에 예기치 않은 공백이 있습니다. 공백을 제거했는지 확인하세요.</target>
-        <note>{StrBegin="MSB4281: "}</note>
-      </trans-unit>
-      <trans-unit id="IllFormedQuotedStringInCondition">
-        <source>MSB4101: Expected a closing quote after position {1} in condition "{0}".</source>
-        <target state="translated">MSB4101: "{0}" 조건의 {1} 위치 뒤에 닫는 따옴표가 필요합니다.</target>
-        <note>{StrBegin="MSB4101: "}</note>
-      </trans-unit>
       <trans-unit id="IllegalCharactersInFileOrDirectory">
         <source>There are illegal characters in '{0}' in the {1} item.</source>
         <target state="translated">{1} 항목의 '{0}'에 허용되지 않는 문자가 있습니다.</target>
@@ -1535,6 +1525,11 @@ Errors: {3}</source>
         <source>MSB4110: Expected a property at position {1} in condition "{0}". Did you forget the opening parenthesis after the '$'? To use a literal '$', use '%24' instead.</source>
         <target state="translated">MSB4110: "{0}" 조건의 {1} 위치에 속성이 필요합니다. '$' 뒤에 여는 괄호가 없습니다. '$' 리터럴을 사용하려면 '%24'를 대신 사용하세요.</target>
         <note>{StrBegin="MSB4110: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedQuotedStringInCondition">
+        <source>MSB4101: Expected a closing quote after position {1} in condition "{0}".</source>
+        <target state="translated">MSB4101: "{0}" 조건의 {1} 위치 뒤에 닫는 따옴표가 필요합니다.</target>
+        <note>{StrBegin="MSB4101: "}</note>
       </trans-unit>
       <trans-unit id="ImportedProjectNotFound">
         <source>MSB4019: The imported project "{0}" was not found. Confirm that the expression in the Import declaration "{1}", which evaluated to "{2}", is correct, and that the file exists on disk.</source>

--- a/src/Build/Resources/xlf/Strings.pl.xlf
+++ b/src/Build/Resources/xlf/Strings.pl.xlf
@@ -540,16 +540,6 @@
         <target state="translated">MSB4259: Nieoczekiwana spacja na pozycji „{1}” warunku „{0}”. Czy zapomniano o usunięciu spacji?</target>
         <note>{StrBegin="MSB4259: "}</note>
       </trans-unit>
-      <trans-unit id="IllFormedPropertySpaceInPropertyReference">
-        <source>MSB4281: Unexpected space at position "{1}" of property reference "{0}". Did you forget to remove a space?</source>
-        <target state="translated">MSB4281: Nieoczekiwana spacja na pozycji „{1}” odwołania do właściwości „{0}”. Czy zapomniano o usunięciu spacji?</target>
-        <note>{StrBegin="MSB4281: "}</note>
-      </trans-unit>
-      <trans-unit id="IllFormedQuotedStringInCondition">
-        <source>MSB4101: Expected a closing quote after position {1} in condition "{0}".</source>
-        <target state="translated">MSB4101: Oczekiwano cudzysłowu zamykającego po położeniu {1} w warunku „{0}”.</target>
-        <note>{StrBegin="MSB4101: "}</note>
-      </trans-unit>
       <trans-unit id="IllegalCharactersInFileOrDirectory">
         <source>There are illegal characters in '{0}' in the {1} item.</source>
         <target state="translated">Element {0} zawiera niedozwolone znaki w „{1}”.</target>
@@ -1535,6 +1525,11 @@ Błędy: {3}</target>
         <source>MSB4110: Expected a property at position {1} in condition "{0}". Did you forget the opening parenthesis after the '$'? To use a literal '$', use '%24' instead.</source>
         <target state="translated">MSB4110: Oczekiwano właściwości w położeniu {1} w warunku „{0}”. Czy nie brakuje nawiasu zamykającego po znaku „$”? Aby użyć literału „$”, użyj zamiast niego zapisu „%24”.</target>
         <note>{StrBegin="MSB4110: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedQuotedStringInCondition">
+        <source>MSB4101: Expected a closing quote after position {1} in condition "{0}".</source>
+        <target state="translated">MSB4101: Oczekiwano cudzysłowu zamykającego po położeniu {1} w warunku „{0}”.</target>
+        <note>{StrBegin="MSB4101: "}</note>
       </trans-unit>
       <trans-unit id="ImportedProjectNotFound">
         <source>MSB4019: The imported project "{0}" was not found. Confirm that the expression in the Import declaration "{1}", which evaluated to "{2}", is correct, and that the file exists on disk.</source>

--- a/src/Build/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Build/Resources/xlf/Strings.pt-BR.xlf
@@ -540,16 +540,6 @@
         <target state="translated">MSB4259: espaço inesperado na posição "{1}" da condição "{0}". Você esqueceu de remover um espaço?</target>
         <note>{StrBegin="MSB4259: "}</note>
       </trans-unit>
-      <trans-unit id="IllFormedPropertySpaceInPropertyReference">
-        <source>MSB4281: Unexpected space at position "{1}" of property reference "{0}". Did you forget to remove a space?</source>
-        <target state="translated">MSB4281: espaço inesperado na posição "{1}" da referência de propriedade "{0}". Você esqueceu de remover um espaço?</target>
-        <note>{StrBegin="MSB4281: "}</note>
-      </trans-unit>
-      <trans-unit id="IllFormedQuotedStringInCondition">
-        <source>MSB4101: Expected a closing quote after position {1} in condition "{0}".</source>
-        <target state="translated">MSB4101: Aspas de fechamento esperadas depois da posição {1} da condição "{0}".</target>
-        <note>{StrBegin="MSB4101: "}</note>
-      </trans-unit>
       <trans-unit id="IllegalCharactersInFileOrDirectory">
         <source>There are illegal characters in '{0}' in the {1} item.</source>
         <target state="translated">Há caracteres inválidos em "{0}" no item {1}.</target>
@@ -1535,6 +1525,11 @@ Erros: {3}</target>
         <source>MSB4110: Expected a property at position {1} in condition "{0}". Did you forget the opening parenthesis after the '$'? To use a literal '$', use '%24' instead.</source>
         <target state="translated">MSB4110: Propriedade esperada na posição {1} da condição "{0}". Você se esqueceu de inserir o parêntese de abertura depois do caractere "$"? Para usar um "$" literal, use "%24".</target>
         <note>{StrBegin="MSB4110: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedQuotedStringInCondition">
+        <source>MSB4101: Expected a closing quote after position {1} in condition "{0}".</source>
+        <target state="translated">MSB4101: Aspas de fechamento esperadas depois da posição {1} da condição "{0}".</target>
+        <note>{StrBegin="MSB4101: "}</note>
       </trans-unit>
       <trans-unit id="ImportedProjectNotFound">
         <source>MSB4019: The imported project "{0}" was not found. Confirm that the expression in the Import declaration "{1}", which evaluated to "{2}", is correct, and that the file exists on disk.</source>

--- a/src/Build/Resources/xlf/Strings.ru.xlf
+++ b/src/Build/Resources/xlf/Strings.ru.xlf
@@ -540,16 +540,6 @@
         <target state="translated">MSB4259: неожиданный пробел в позиции "{1}" условия "{0}". Вы забыли удалить пробел?</target>
         <note>{StrBegin="MSB4259: "}</note>
       </trans-unit>
-      <trans-unit id="IllFormedPropertySpaceInPropertyReference">
-        <source>MSB4281: Unexpected space at position "{1}" of property reference "{0}". Did you forget to remove a space?</source>
-        <target state="translated">MSB4281: неожиданный пробел в позиции "{1}" ссылки на свойство "{0}". Вы забыли удалить пробел?</target>
-        <note>{StrBegin="MSB4281: "}</note>
-      </trans-unit>
-      <trans-unit id="IllFormedQuotedStringInCondition">
-        <source>MSB4101: Expected a closing quote after position {1} in condition "{0}".</source>
-        <target state="translated">MSB4101: после позиции {1} в условии "{0}" должна быть закрывающая кавычка.</target>
-        <note>{StrBegin="MSB4101: "}</note>
-      </trans-unit>
       <trans-unit id="IllegalCharactersInFileOrDirectory">
         <source>There are illegal characters in '{0}' in the {1} item.</source>
         <target state="translated">В "{0}" в элементе {1} есть запрещенные символы.</target>
@@ -1535,6 +1525,11 @@ Errors: {3}</source>
         <source>MSB4110: Expected a property at position {1} in condition "{0}". Did you forget the opening parenthesis after the '$'? To use a literal '$', use '%24' instead.</source>
         <target state="translated">MSB4110: в позиции {1} условия "{0}" ожидалось свойство. Возможно, отсутствует открывающая круглая скобка после "$". Если требуется литерал "$", используйте "%24".</target>
         <note>{StrBegin="MSB4110: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedQuotedStringInCondition">
+        <source>MSB4101: Expected a closing quote after position {1} in condition "{0}".</source>
+        <target state="translated">MSB4101: после позиции {1} в условии "{0}" должна быть закрывающая кавычка.</target>
+        <note>{StrBegin="MSB4101: "}</note>
       </trans-unit>
       <trans-unit id="ImportedProjectNotFound">
         <source>MSB4019: The imported project "{0}" was not found. Confirm that the expression in the Import declaration "{1}", which evaluated to "{2}", is correct, and that the file exists on disk.</source>

--- a/src/Build/Resources/xlf/Strings.tr.xlf
+++ b/src/Build/Resources/xlf/Strings.tr.xlf
@@ -540,16 +540,6 @@
         <target state="translated">MSB4259: "{0}" koşulunun "{1}" konumunda beklenmeyen boşluk var. Boşluğu kaldırmayı unutmuş olabilirsiniz.</target>
         <note>{StrBegin="MSB4259: "}</note>
       </trans-unit>
-      <trans-unit id="IllFormedPropertySpaceInPropertyReference">
-        <source>MSB4281: Unexpected space at position "{1}" of property reference "{0}". Did you forget to remove a space?</source>
-        <target state="translated">MSB4281: "{0}" özellik başvurusunun "{1}" konumunda beklenmeyen boşluk var. Boşluğu kaldırmayı unutmuş olabilirsiniz.</target>
-        <note>{StrBegin="MSB4281: "}</note>
-      </trans-unit>
-      <trans-unit id="IllFormedQuotedStringInCondition">
-        <source>MSB4101: Expected a closing quote after position {1} in condition "{0}".</source>
-        <target state="translated">MSB4101: "{0}" koşulunda {1} konumundan sonra bir kapatma tırnağı bekleniyor.</target>
-        <note>{StrBegin="MSB4101: "}</note>
-      </trans-unit>
       <trans-unit id="IllegalCharactersInFileOrDirectory">
         <source>There are illegal characters in '{0}' in the {1} item.</source>
         <target state="translated">{1} maddesindeki '{0}'da yasadışı karakterler var.</target>
@@ -1535,6 +1525,11 @@ Hatalar: {3}</target>
         <source>MSB4110: Expected a property at position {1} in condition "{0}". Did you forget the opening parenthesis after the '$'? To use a literal '$', use '%24' instead.</source>
         <target state="translated">MSB4110: "{0}" koşulunda, {1} konumunda bir özellik bekleniyordu. '$' sonrasında parantez açmayı mı unuttunuz? '$' sabit değerini kullanmak için '%24' kullanın.</target>
         <note>{StrBegin="MSB4110: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedQuotedStringInCondition">
+        <source>MSB4101: Expected a closing quote after position {1} in condition "{0}".</source>
+        <target state="translated">MSB4101: "{0}" koşulunda {1} konumundan sonra bir kapatma tırnağı bekleniyor.</target>
+        <note>{StrBegin="MSB4101: "}</note>
       </trans-unit>
       <trans-unit id="ImportedProjectNotFound">
         <source>MSB4019: The imported project "{0}" was not found. Confirm that the expression in the Import declaration "{1}", which evaluated to "{2}", is correct, and that the file exists on disk.</source>

--- a/src/Build/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hans.xlf
@@ -540,16 +540,6 @@
         <target state="translated">MSB4259: 在条件“{0}”的位置“{1}”处出现意外空格。是否忘记了删除空格?</target>
         <note>{StrBegin="MSB4259: "}</note>
       </trans-unit>
-      <trans-unit id="IllFormedPropertySpaceInPropertyReference">
-        <source>MSB4281: Unexpected space at position "{1}" of property reference "{0}". Did you forget to remove a space?</source>
-        <target state="translated">MSB4281: 在属性引用“{0}”的位置“{1}”处出现意外空格。是否忘记了删除空格?</target>
-        <note>{StrBegin="MSB4281: "}</note>
-      </trans-unit>
-      <trans-unit id="IllFormedQuotedStringInCondition">
-        <source>MSB4101: Expected a closing quote after position {1} in condition "{0}".</source>
-        <target state="translated">MSB4101: 条件“{0}”中的位置 {1} 后面应为右引号。</target>
-        <note>{StrBegin="MSB4101: "}</note>
-      </trans-unit>
       <trans-unit id="IllegalCharactersInFileOrDirectory">
         <source>There are illegal characters in '{0}' in the {1} item.</source>
         <target state="translated">{1} 项中的“{0}”中存在非法字符。</target>
@@ -1535,6 +1525,11 @@ Errors: {3}</source>
         <source>MSB4110: Expected a property at position {1} in condition "{0}". Did you forget the opening parenthesis after the '$'? To use a literal '$', use '%24' instead.</source>
         <target state="translated">MSB4110: 条件“{0}”中的位置 {1} 处应为属性。是否忘记了“$”后面的左括号?若要使用“$”，请改用“%24”。</target>
         <note>{StrBegin="MSB4110: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedQuotedStringInCondition">
+        <source>MSB4101: Expected a closing quote after position {1} in condition "{0}".</source>
+        <target state="translated">MSB4101: 条件“{0}”中的位置 {1} 后面应为右引号。</target>
+        <note>{StrBegin="MSB4101: "}</note>
       </trans-unit>
       <trans-unit id="ImportedProjectNotFound">
         <source>MSB4019: The imported project "{0}" was not found. Confirm that the expression in the Import declaration "{1}", which evaluated to "{2}", is correct, and that the file exists on disk.</source>

--- a/src/Build/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hant.xlf
@@ -540,16 +540,6 @@
         <target state="translated">MSB4259: 條件 "{0}" 的位置 "{1}" 出現非預期的空格。忘記移除空格了嗎?</target>
         <note>{StrBegin="MSB4259: "}</note>
       </trans-unit>
-      <trans-unit id="IllFormedPropertySpaceInPropertyReference">
-        <source>MSB4281: Unexpected space at position "{1}" of property reference "{0}". Did you forget to remove a space?</source>
-        <target state="translated">MSB4281: 屬性參考 "{0}" 的位置 "{1}" 有非預期的空格。忘記移除空格了嗎?</target>
-        <note>{StrBegin="MSB4281: "}</note>
-      </trans-unit>
-      <trans-unit id="IllFormedQuotedStringInCondition">
-        <source>MSB4101: Expected a closing quote after position {1} in condition "{0}".</source>
-        <target state="translated">MSB4101: 條件 "{0}" 的位置 {1} 後面必須是結束引號。</target>
-        <note>{StrBegin="MSB4101: "}</note>
-      </trans-unit>
       <trans-unit id="IllegalCharactersInFileOrDirectory">
         <source>There are illegal characters in '{0}' in the {1} item.</source>
         <target state="translated">{1} 項目中的 '{0}' 有不合法的字元。</target>
@@ -1535,6 +1525,11 @@ Errors: {3}</source>
         <source>MSB4110: Expected a property at position {1} in condition "{0}". Did you forget the opening parenthesis after the '$'? To use a literal '$', use '%24' instead.</source>
         <target state="translated">MSB4110: 條件 "{0}" 的位置 {1} 中必須是屬性。是否忘記 '$' 後面的左括弧?若要使用常值 '$'，請改用 '%24'。</target>
         <note>{StrBegin="MSB4110: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedQuotedStringInCondition">
+        <source>MSB4101: Expected a closing quote after position {1} in condition "{0}".</source>
+        <target state="translated">MSB4101: 條件 "{0}" 的位置 {1} 後面必須是結束引號。</target>
+        <note>{StrBegin="MSB4101: "}</note>
       </trans-unit>
       <trans-unit id="ImportedProjectNotFound">
         <source>MSB4019: The imported project "{0}" was not found. Confirm that the expression in the Import declaration "{1}", which evaluated to "{2}", is correct, and that the file exists on disk.</source>

--- a/src/Framework/ChangeWaves.cs
+++ b/src/Framework/ChangeWaves.cs
@@ -32,8 +32,7 @@ namespace Microsoft.Build.Framework
         internal static readonly Version Wave17_14 = new Version(17, 14);
         internal static readonly Version Wave18_3 = new Version(18, 3);
         internal static readonly Version Wave18_4 = new Version(18, 4);
-        internal static readonly Version Wave18_5 = new Version(18, 5);
-        internal static readonly Version[] AllWaves = [Wave17_10, Wave17_12, Wave17_14, Wave18_3, Wave18_4, Wave18_5];
+        internal static readonly Version[] AllWaves = [Wave17_10, Wave17_12, Wave17_14, Wave18_3, Wave18_4];
 
         /// <summary>
         /// Special value indicating that all features behind all Change Waves should be enabled.


### PR DESCRIPTION
This reverts commit fa4162351a81f0e27f8b0c675447b28b1aa68e43.

Fixes #
internally reported regression

### Context


### Changes Made


### Testing


### Notes
@huulinhnguyen-dev 
error is too heavy handed, in the property function case it's a regression and in the property case it should be either a warning or buildcheck