### PR TITLE
Revert "Refactor Microsoft.IO usage"

### DIFF
--- a/src/Build/BackEnd/Shared/BuildRequestConfiguration.cs
+++ b/src/Build/BackEnd/Shared/BuildRequestConfiguration.cs
@@ -301,7 +301,7 @@ namespace Microsoft.Build.BackEnd
             {
                 if (!_isTraversalProject.HasValue)
                 {
-#if FEATURE_MSIOREDIST
+#if NET471_OR_GREATER
                     if (MemoryExtensions.Equals(Microsoft.IO.Path.GetFileName(ProjectFullPath.AsSpan()), "dirs.proj".AsSpan(), StringComparison.OrdinalIgnoreCase))
 #else
                     if (MemoryExtensions.Equals(Path.GetFileName(ProjectFullPath.AsSpan()), "dirs.proj", StringComparison.OrdinalIgnoreCase))

--- a/src/Build/BuildCheck/Checks/DoubleWritesCheck.cs
+++ b/src/Build/BuildCheck/Checks/DoubleWritesCheck.cs
@@ -3,14 +3,15 @@
 
 using System;
 using System.Collections.Generic;
+#if !FEATURE_MSIOREDIST
+using System.IO;
+#endif
 using System.Linq;
 using Microsoft.Build.Shared;
 using static Microsoft.Build.Experimental.BuildCheck.TaskInvocationCheckData;
 
 #if FEATURE_MSIOREDIST
 using Path = Microsoft.IO.Path;
-#else
-using System.IO;
 #endif
 
 namespace Microsoft.Build.Experimental.BuildCheck.Checks;

--- a/src/Build/BuildCheck/Checks/ExecCliBuildCheck.cs
+++ b/src/Build/BuildCheck/Checks/ExecCliBuildCheck.cs
@@ -3,12 +3,13 @@
 
 using System;
 using System.Collections.Generic;
+#if !FEATURE_MSIOREDIST
+using System.IO;
+#endif
 using Microsoft.Build.Shared;
 
 #if FEATURE_MSIOREDIST
 using Path = Microsoft.IO.Path;
-#else
-using System.IO;
 #endif
 
 namespace Microsoft.Build.Experimental.BuildCheck.Checks;

--- a/src/Build/Evaluation/Expander.cs
+++ b/src/Build/Evaluation/Expander.cs
@@ -7,7 +7,11 @@ using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
+#if NET
 using System.IO;
+#else
+using Microsoft.IO;
+#endif
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
@@ -29,11 +33,6 @@ using ParseArgs = Microsoft.Build.Evaluation.Expander.ArgumentParser;
 using ReservedPropertyNames = Microsoft.Build.Internal.ReservedPropertyNames;
 using TaskItem = Microsoft.Build.Execution.ProjectItemInstance.TaskItem;
 using TaskItemFactory = Microsoft.Build.Execution.ProjectItemInstance.TaskItem.TaskItemFactory;
-
-#if FEATURE_MSIOREDIST
-using Directory = Microsoft.IO.Directory;
-using Path = Microsoft.IO.Path;
-#endif
 
 #nullable disable
 

--- a/src/Build/Evaluation/Expander/ArgumentParser.cs
+++ b/src/Build/Evaluation/Expander/ArgumentParser.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Globalization;
 
-#if FEATURE_MSIOREDIST
+#if NETFRAMEWORK
 using Microsoft.IO;
 #endif
 

--- a/src/Build/Instance/TaskFactories/AssemblyTaskFactory.cs
+++ b/src/Build/Instance/TaskFactories/AssemblyTaskFactory.cs
@@ -11,9 +11,8 @@ using System.Threading.Tasks;
 using Microsoft.Build.BackEnd.Components.RequestBuilder;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
-
-#if FEATURE_MSIOREDIST
-using Path = Microsoft.IO.Path;
+#if NETFRAMEWORK
+using Microsoft.IO;
 #else
 using System.IO;
 #endif

--- a/src/Build/Logging/TerminalLogger/TerminalLogger.cs
+++ b/src/Build/Logging/TerminalLogger/TerminalLogger.cs
@@ -16,8 +16,8 @@ using Microsoft.Build.Shared;
 using System.Buffers;
 #endif
 
-#if FEATURE_MSIOREDIST
-using Path = Microsoft.IO.Path;
+#if NETFRAMEWORK
+using Microsoft.IO;
 #else
 using System.IO;
 #endif

--- a/src/Build/Utilities/Utilities.cs
+++ b/src/Build/Utilities/Utilities.cs
@@ -5,6 +5,11 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
+#if NET
+using System.IO;
+#else
+using Microsoft.IO;
+#endif
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -16,12 +21,6 @@ using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
 using Toolset = Microsoft.Build.Evaluation.Toolset;
 using XmlElementWithLocation = Microsoft.Build.Construction.XmlElementWithLocation;
-
-#if FEATURE_MSIOREDIST
-using Path = Microsoft.IO.Path;
-#else
-using System.IO;
-#endif
 
 #nullable disable
 

--- a/src/Framework/PathHelpers/AbsolutePath.cs
+++ b/src/Framework/PathHelpers/AbsolutePath.cs
@@ -2,9 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-
-#if FEATURE_MSIOREDIST
-using Path = Microsoft.IO.Path;
+#if NETFRAMEWORK
+using Microsoft.IO;
 #else
 using System.IO;
 #endif

--- a/src/MSBuild.UnitTests/MSBuildServer_Tests.cs
+++ b/src/MSBuild.UnitTests/MSBuildServer_Tests.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Diagnostics;
-using System.IO;
 using System.Reflection;
 using System.Text.RegularExpressions;
 using System.Threading;
@@ -14,9 +13,15 @@ using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
 using Microsoft.Build.UnitTests;
 using Microsoft.Build.UnitTests.Shared;
+#if NETFRAMEWORK
+using Microsoft.IO;
+#else
+using System.IO;
+#endif
 using Shouldly;
 using Xunit;
 using Xunit.Abstractions;
+using Path = System.IO.Path;
 
 namespace Microsoft.Build.Engine.UnitTests
 {

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -45,10 +45,11 @@ using LoggerDescription = Microsoft.Build.Logging.LoggerDescription;
 using SimpleErrorLogger = Microsoft.Build.Logging.SimpleErrorLogger.SimpleErrorLogger;
 using TerminalLogger = Microsoft.Build.Logging.TerminalLogger;
 
-#if FEATURE_MSIOREDIST
+#if NETFRAMEWORK
 // Use I/O operations from Microsoft.IO.Redist which is generally higher perf
 // and also works around https://github.com/dotnet/msbuild/issues/10540.
 // Unnecessary on .NET 6+ because the perf improvements are in-box there.
+using Microsoft.IO;
 using Directory = Microsoft.IO.Directory;
 using File = Microsoft.IO.File;
 using FileInfo = Microsoft.IO.FileInfo;

--- a/src/Shared/FileMatcher.cs
+++ b/src/Shared/FileMatcher.cs
@@ -6,13 +6,12 @@ using System.Buffers;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
-
-#if FEATURE_MSIOREDIST
-using Path = Microsoft.IO.Path;
-#else
+#if !NETFRAMEWORK
 using System.IO;
+#else
+using Microsoft.IO;
 #endif
+using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;

--- a/src/Shared/FileSystem/WindowsFileSystem.cs
+++ b/src/Shared/FileSystem/WindowsFileSystem.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Build.Shared.FileSystem
 
         public override bool FileExists(string path)
         {
-#if FEATURE_MSIOREDIST
+#if NETFRAMEWORK
             return Microsoft.IO.File.Exists(path);
 #else
             return File.Exists(path);

--- a/src/Shared/TaskFactoryUtilities.cs
+++ b/src/Shared/TaskFactoryUtilities.cs
@@ -6,10 +6,8 @@ using System.Collections.Generic;
 using System.Reflection;
 using Microsoft.Build.Shared.FileSystem;
 using Microsoft.Build.Framework;
-
-#if FEATURE_MSIOREDIST
-using File = Microsoft.IO.File;
-using Path = Microsoft.IO.Path;
+#if NETFRAMEWORK
+using Microsoft.IO;
 #else
 using System.IO;
 #endif

--- a/src/Tasks.UnitTests/RoslynCodeTaskFactory_Tests.cs
+++ b/src/Tasks.UnitTests/RoslynCodeTaskFactory_Tests.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Reflection;
 using Microsoft.Build.Framework;
@@ -11,6 +10,10 @@ using Microsoft.Build.Shared;
 using Microsoft.Build.UnitTests;
 using Microsoft.Build.UnitTests.Shared;
 using Microsoft.Build.Utilities;
+using System.IO;
+#if NETFRAMEWORK
+using MicrosoftIO = Microsoft.IO;
+#endif
 using Shouldly;
 using VerifyTests;
 using VerifyXunit;

--- a/src/Tasks/XamlTaskFactory/CommandLineGenerator.cs
+++ b/src/Tasks/XamlTaskFactory/CommandLineGenerator.cs
@@ -7,6 +7,10 @@ using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 
+#if NETFRAMEWORK
+using Microsoft.IO;
+#endif
+
 using Microsoft.Build.Framework;
 using Microsoft.Build.Framework.XamlTypes;
 using Microsoft.Build.Shared;


### PR DESCRIPTION
Reverts dotnet/msbuild#13062

It causes regression in VS, see https://dev.azure.com/devdiv/DevDiv/_workitems/edit/2695509 for details.
CC: @AR-May 