### PR TITLE
Allow null SdkResult from SdkResolver.Resolve

### DIFF
--- a/src/Framework/Sdk/SdkResolver.cs
+++ b/src/Framework/Sdk/SdkResolver.cs
@@ -31,10 +31,9 @@ namespace Microsoft.Build.Framework
         /// applicable for a particular <see cref="SdkReference"/>.
         /// </returns>
         /// <remarks>
-        ///  Note: You must use <see cref="SdkResultFactory"/> to return a result.
-        ///  </remarks>
-        ///
-        public abstract SdkResult Resolve(SdkReference sdkReference,
+        /// Note: You must use <see cref="SdkResultFactory"/> to return a result.
+        /// </remarks>
+        public abstract SdkResult? Resolve(SdkReference sdkReference,
                                           SdkResolverContext resolverContext,
                                           SdkResultFactory factory);
     }


### PR DESCRIPTION
The doc comment explicitly mentions returning null and the SDK can do
so, which caused a break in dotnet/dotnet#4579:

    src\sdk\src\Resolvers\Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver\WorkloadSdkResolver.cs(35,36): error CS8764: Nullability of return type doesn't match overridden member (possibly because of nullability attributes).

Follow up to #13157.