### PR TITLE
Skill to test changes using just-built MSBuild

### DIFF
--- a/.github/skills/use-bootstrap-msbuild/SKILL.md
+++ b/.github/skills/use-bootstrap-msbuild/SKILL.md
@@ -25,7 +25,7 @@ Build MSBuild to create the bootstrap directory:
 
 This creates the bootstrap at `artifacts\bin\bootstrap\` with your changes.
 
-Rerun this after making any code change. If run in the default mode, there may be 
+Rerun this after making any code change. If run in the default mode, there may be some errors on subsequent builds about locked files (due to MSBuild worker node processes lingering). If so, run `./artifacts/bin/bootstrap/core/dotnet build-server shutdown`.
 
 ## Step 2: Run Your Repro Project
 
@@ -43,7 +43,7 @@ artifacts\bin\bootstrap\core\dotnet.exe build <path-to-repro.csproj>
 ./artifacts/bin/bootstrap/core/dotnet build <path-to-repro.csproj>
 ```
 
-All of the usual command line arguments should work, incluing `-bl` to create binlogs.
+All of the usual command line arguments should work, including `-bl` to create binlogs.
 
 ### .NET Framework Projects
 


### PR DESCRIPTION
A standard part of the inner developer loop in this repo is to build MSBuild with a change, then run it against a repro project or projects to validate that MSBuild is generally working and the change affects the behavior you expect.

Adding a skill to (hopefully!) make that crystal clear to agents.
