### PR TITLE
Clarify DefaultNodeConnectionTimeout

### DIFF
--- a/src/Shared/CommunicationsUtilities.cs
+++ b/src/Shared/CommunicationsUtilities.cs
@@ -391,8 +391,11 @@ namespace Microsoft.Build.Internal
         internal const byte handshakeVersion = 0x01;
 
         /// <summary>
-        /// The timeout to connect to a node.
+        /// Wait time between when a node goes idle and its self-termination.
         /// </summary>
+        /// <remarks>
+        /// A longer timeout increases node reuse success but also machine resource use.
+        /// </remarks>
         private const int DefaultNodeConnectionTimeout = 900 * 1000; // 15 minutes; enough time that a dev will typically do another build in this time
 
         /// <summary>


### PR DESCRIPTION
@baronfel and I both looked around this and were confused by the description of this variable, which is actually just the post-build node idle timeout.