### PR TITLE
Fix hardcoded path separators in output paths

### DIFF
--- a/src/Tasks.UnitTests/OutputPathTests.cs
+++ b/src/Tasks.UnitTests/OutputPathTests.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Build.Tasks.UnitTests
             project.Build(new MockLogger(_output)).ShouldBeFalse();
 
             // Assert
-            project.GetPropertyValue("BaseOutputPath").ShouldBe(baseOutputPath + '\\');
+            project.GetPropertyValue("BaseOutputPath").ShouldBe(baseOutputPath.WithTrailingSlash());
             project.GetPropertyValue("BaseOutputPathWasSpecified").ShouldBe(string.Empty);
             project.GetPropertyValue("_OutputPathWasMissing").ShouldBe("true");
         }

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -149,17 +149,17 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
     <ConfigurationName Condition="'$(ConfigurationName)' == ''">$(Configuration)</ConfigurationName>
 
-    <BaseOutputPath Condition="'$(BaseOutputPath)' == ''">bin\</BaseOutputPath>
-    <BaseOutputPath Condition="!HasTrailingSlash('$(BaseOutputPath)')">$(BaseOutputPath)\</BaseOutputPath>
-    <OutputPath Condition="'$(OutputPath)' == '' and '$(PlatformName)' == 'AnyCPU'">$(BaseOutputPath)$(Configuration)\</OutputPath>
-    <OutputPath Condition="'$(OutputPath)' == '' and '$(PlatformName)' != 'AnyCPU'">$(BaseOutputPath)$(PlatformName)\$(Configuration)\</OutputPath>
-    <OutputPath Condition="!HasTrailingSlash('$(OutputPath)')">$(OutputPath)\</OutputPath>
+    <BaseOutputPath Condition="'$(BaseOutputPath)' == ''">bin$([System.IO.Path]::DirectorySeparatorChar)</BaseOutputPath>
+    <BaseOutputPath Condition="!HasTrailingSlash('$(BaseOutputPath)')">$(BaseOutputPath)$([System.IO.Path]::DirectorySeparatorChar)</BaseOutputPath>
+    <OutputPath Condition="'$(OutputPath)' == '' and '$(PlatformName)' == 'AnyCPU'">$(BaseOutputPath)$(Configuration)$([System.IO.Path]::DirectorySeparatorChar)</OutputPath>
+    <OutputPath Condition="'$(OutputPath)' == '' and '$(PlatformName)' != 'AnyCPU'">$(BaseOutputPath)$(PlatformName)$([System.IO.Path]::DirectorySeparatorChar)$(Configuration)$([System.IO.Path]::DirectorySeparatorChar)</OutputPath>
+    <OutputPath Condition="!HasTrailingSlash('$(OutputPath)')">$(OutputPath)$([System.IO.Path]::DirectorySeparatorChar)</OutputPath>
 
-    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)' == ''">obj\</BaseIntermediateOutputPath>
-    <BaseIntermediateOutputPath Condition="!HasTrailingSlash('$(BaseIntermediateOutputPath)')">$(BaseIntermediateOutputPath)\</BaseIntermediateOutputPath>
-    <IntermediateOutputPath Condition="'$(IntermediateOutputPath)' == '' and '$(PlatformName)' == 'AnyCPU'">$(BaseIntermediateOutputPath)$(Configuration)\</IntermediateOutputPath>
-    <IntermediateOutputPath Condition="'$(IntermediateOutputPath)' == '' and '$(PlatformName)' != 'AnyCPU'">$(BaseIntermediateOutputPath)$(PlatformName)\$(Configuration)\</IntermediateOutputPath>
-    <IntermediateOutputPath Condition="!HasTrailingSlash('$(IntermediateOutputPath)')">$(IntermediateOutputPath)\</IntermediateOutputPath>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)' == ''">obj$([System.IO.Path]::DirectorySeparatorChar)</BaseIntermediateOutputPath>
+    <BaseIntermediateOutputPath Condition="!HasTrailingSlash('$(BaseIntermediateOutputPath)')">$(BaseIntermediateOutputPath)$([System.IO.Path]::DirectorySeparatorChar)</BaseIntermediateOutputPath>
+    <IntermediateOutputPath Condition="'$(IntermediateOutputPath)' == '' and '$(PlatformName)' == 'AnyCPU'">$(BaseIntermediateOutputPath)$(Configuration)$([System.IO.Path]::DirectorySeparatorChar)</IntermediateOutputPath>
+    <IntermediateOutputPath Condition="'$(IntermediateOutputPath)' == '' and '$(PlatformName)' != 'AnyCPU'">$(BaseIntermediateOutputPath)$(PlatformName)$([System.IO.Path]::DirectorySeparatorChar)$(Configuration)$([System.IO.Path]::DirectorySeparatorChar)</IntermediateOutputPath>
+    <IntermediateOutputPath Condition="!HasTrailingSlash('$(IntermediateOutputPath)')">$(IntermediateOutputPath)$([System.IO.Path]::DirectorySeparatorChar)</IntermediateOutputPath>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/UnitTests.Shared/ObjectModelHelpers.cs
+++ b/src/UnitTests.Shared/ObjectModelHelpers.cs
@@ -6,6 +6,7 @@ using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
@@ -588,7 +589,7 @@ namespace Microsoft.Build.UnitTests
         /// <returns></returns>
         public static string CleanupFileContents([StringSyntax(StringSyntaxAttribute.Xml)] string projectFileContents)
         {
-            StringBuilder temp = new (projectFileContents);
+            StringBuilder temp = new(projectFileContents);
 
             // Replace reverse-single-quotes with double-quotes.
             temp.Replace('`', '"');
@@ -2005,11 +2006,14 @@ namespace Microsoft.Build.UnitTests
         /// <param name="timeSpan">A <see cref="TimeSpan"/> representing the amount of time to sleep.</param>
         public static string GetSleepCommand(TimeSpan timeSpan)
         {
+            string sleepArgument = NativeMethodsShared.IsWindows
+                ? timeSpan.TotalMilliseconds.ToString(CultureInfo.InvariantCulture)
+                : timeSpan.TotalSeconds.ToString(CultureInfo.InvariantCulture);
+
             return string.Format(
+                CultureInfo.InvariantCulture,
                 GetSleepCommandTemplate(),
-                NativeMethodsShared.IsWindows
-                    ? timeSpan.TotalMilliseconds // powershell can't handle floating point seconds, so give it milliseconds
-                    : timeSpan.TotalSeconds);
+                sleepArgument);
         }
 
         /// <summary>

--- a/src/Utilities.UnitTests/ToolTask_Tests.cs
+++ b/src/Utilities.UnitTests/ToolTask_Tests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Resources;
 using System.Text.RegularExpressions;
@@ -1064,8 +1065,8 @@ namespace Microsoft.Build.UnitTests
             /// </summary>
             protected override string GenerateCommandLineCommands() =>
                 NativeMethodsShared.IsUnixLike ?
-                string.Format(_unixSleep, RepeatCount < 2 ? InitialDelay / 1000.0 : FollowupDelay / 1000.0) :
-                string.Format(_windowsSleep, RepeatCount < 2 ? InitialDelay / 1000.0 : FollowupDelay / 1000.0);
+                string.Format(CultureInfo.InvariantCulture, _unixSleep, RepeatCount < 2 ? InitialDelay / 1000.0 : FollowupDelay / 1000.0) :
+                string.Format(CultureInfo.InvariantCulture, _windowsSleep, RepeatCount < 2 ? InitialDelay / 1000.0 : FollowupDelay / 1000.0);
 
             /// <summary>
             /// Ensures that test parameters make sense.


### PR DESCRIPTION
`Microsoft.Common.CurrentVersion.targets` hardcodes Windows path separators (`\`) when computing `BaseOutputPath`, `OutputPath`, `BaseIntermediateOutputPath`, and `IntermediateOutputPath`.

On Unix-based systems, `\` is a valid filename character, not a path separator. This causes MSBuild to create literal directories such as `bin\Debug`, which are not ignored by standard `.gitignore` rules and can later break MSBuild path enumeration, globbing, and builds.

This issue is especially visible during design-time builds (e.g. `dotnet ef migrations add`) but can affect any build on non-Windows platforms.

- Fixes locale-dependent sleep command formatting in unit tests on Unix.
- Normalizes parallel logger output in binlog roundtrip tests by removing non-deterministic lines and target output items.
- Updates OutputPath tests to use platform-appropriate trailing slashes.