### PR TITLE
Restore stub package for Dependabot

### DIFF
--- a/eng/dependabot/dependabot.csproj
+++ b/eng/dependabot/dependabot.csproj
@@ -1,0 +1,4 @@
+<!-- This isn't a real project, but Dependabot requires a project. If one
+     exists, it'll update stuff in Directory.Packages.props as well, which is
+     all we really want here. -->
+<Project />


### PR DESCRIPTION
This partially reverts #12898.

Dependabot does now support `Directory.Packages.props`, but still seems
to require a project file to be present:

```
updater | 2026/02/09 01:52:58 INFO Discovering build files in workspace [/home/dependabot/dependabot-updater/repo/eng/dependabot].
updater | 2026/02/09 01:52:58 INFO   No dotnet-tools.json file found.
updater | 2026/02/09 01:52:58 INFO   Discovered [global.json] file.
updater | 2026/02/09 01:52:58 INFO   Discovering projects beneath [eng/dependabot].
updater | 2026/02/09 01:52:58 INFO   No project files found.
updater | 2026/02/09 01:52:58 INFO Discovery complete.
```

From https://github.com/dotnet/msbuild/actions/runs/21809650562/job/62919159519#step:3:174