### PR TITLE
[vs18.3] Stabilize package versions

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -3,7 +3,7 @@
   <Import Project="Version.Details.props" />
 
   <PropertyGroup>
-    <VersionPrefix>18.3.2</VersionPrefix><DotNetFinalVersionKind>release</DotNetFinalVersionKind> <!-- Keep next to VersionPrefix to create a conflict in forward-flow -->
+    <VersionPrefix>18.3.3</VersionPrefix><DotNetFinalVersionKind>release</DotNetFinalVersionKind> <!-- Keep next to VersionPrefix to create a conflict in forward-flow -->
     <PreReleaseVersionLabel>servicing</PreReleaseVersionLabel>
     <PackageValidationBaselineVersion>18.0.2</PackageValidationBaselineVersion>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>


### PR DESCRIPTION
CI packages from vs18.3 are being produced with a `-release.{commitid}` pre-release suffix because `DotNetFinalVersionKind` was never set when the branch was stabilized.

This adds `<DotNetFinalVersionKind>release</DotNetFinalVersionKind>` to `eng/Versions.props`, matching the pattern used in vs17.14 and other servicing branches, so that packages are produced as stable `18.3.2` versions.