### PR TITLE
Attach MockLogger in WriteLinesToFile test and update test instructions

### DIFF
--- a/.github/instructions/tests.instructions.md
+++ b/.github/instructions/tests.instructions.md
@@ -31,7 +31,7 @@ Do not specify `xmlns` in test XML snippets unless it is important to the functi
 
 ## Build and Task Testing Helpers
 
-Use `MockLogger` (`Microsoft.Build.UnitTests.MockLogger`) to capture and assert build output. It provides `AssertLogContains`, `AssertLogDoesntContain`, `AssertNoErrors`, `AssertNoWarnings`, and typed event collections (`Errors`, `Warnings`, `TargetStartedEvents`, etc.). Do not assume the test locale will be English--assert on invariant substrings or explicit localized resources, not full English strings.
+Use `MockLogger` (`Microsoft.Build.UnitTests.MockLogger`) to capture and assert build output. It provides `AssertLogContains`, `AssertLogDoesntContain`, `AssertNoErrors`, `AssertNoWarnings`, and typed event collections (`Errors`, `Warnings`, `TargetStartedEvents`, etc.). Do not assume the test locale will be English--assert on invariant substrings or explicit localized resources, not full English strings. Tests that invoke builds via `ProjectCollection` or `BuildManager` must always attach a `MockLogger(_output)` so that build errors and warnings appear in the .trx test output for CI diagnostics.
 
 Use `MockEngine` (`Microsoft.Build.UnitTests.MockEngine`) as an `IBuildEngine` implementation for testing individual tasks in isolation without a full build.
 

--- a/src/Tasks.UnitTests/WriteLinesToFile_Tests.cs
+++ b/src/Tasks.UnitTests/WriteLinesToFile_Tests.cs
@@ -488,9 +488,10 @@ namespace Microsoft.Build.Tasks.UnitTests
                 }
 
                 // Build using ProjectCollection as recommended by Change Waves documentation
+                var logger = new MockLogger(_output);
                 using (var collection = new ProjectCollection(
                     globalProperties: null,
-                    loggers: null,
+                    loggers: [logger],
                     remoteLoggers: null,
                     toolsetDefinitionLocations: ToolsetDefinitionLocations.Default,
                     maxNodeCount: Environment.ProcessorCount,


### PR DESCRIPTION
Add `MockLogger(_output)` to `TransactionalModePreservesAllData` so build diagnostics
appear in test output. Update `tests.instructions.md` to require
MockLogger for tests that build via ProjectCollection or BuildManager.

(this test failed, seemingly flakily, in an unrelated PR, so let's get better info out of it)