### PR TITLE
Remove duplicate function in FileUtilities.cs

### DIFF
--- a/src/Framework/FileUtilities.cs
+++ b/src/Framework/FileUtilities.cs
@@ -215,27 +215,6 @@ namespace Microsoft.Build.Framework
         }
 
         /// <summary>
-        /// Resolves relative segments like "." and "..". Fixes directory separators on Windows like Path.GetFullPath does.
-        /// ASSUMES INPUT IS ALREADY UNESCAPED.
-        /// </summary>
-        internal static AbsolutePath RemoveRelativeSegments(AbsolutePath path)
-        {
-            if (string.IsNullOrEmpty(path.Value))
-            {
-                return path;
-            }
-
-            if (!MayHaveRelativeSegment(path.Value) && !HasUnixDirectorySeparatorOnWindows(path.Value))
-            {
-                return path;
-            }
-
-            return new AbsolutePath(Path.GetFullPath(path.Value),
-                original: path.OriginalValue,
-                ignoreRootedCheck: true);
-        }
-
-        /// <summary>
         /// Fixes file path separators for the current platform.
         /// </summary>
         internal static AbsolutePath FixFilePath(AbsolutePath path)

--- a/src/Tasks/Copy.cs
+++ b/src/Tasks/Copy.cs
@@ -1133,14 +1133,14 @@ namespace Microsoft.Build.Tasks
         /// canonicalization problem, so we just compare strings on the full paths.
         /// </summary>
         /// <remarks>
-        /// This method has a side effect of removing relative segments from the paths before comparison to avoid
+        /// This method has a side effect of canonicalizing the paths before comparison to avoid
         /// false negatives due to different path representations. This operation may throw in certain cases (e.g. invalid paths on Windows).
         /// TODO: refactor this task not to rely on this side effect for correct exception handling and caching
         /// </remarks>
         private static bool PathsAreIdentical(FileState source, FileState destination)
         {
-            source.Path = FrameworkFileUtilities.RemoveRelativeSegments(source.Path);
-            destination.Path = FrameworkFileUtilities.RemoveRelativeSegments(destination.Path);
+            source.Path = source.Path.GetCanonicalForm();
+            destination.Path = destination.Path.GetCanonicalForm();
             return source.Path == destination.Path;
         }
 


### PR DESCRIPTION
### Context
`RemoveRelativeSegments` does the same as `AbsolutePath.GetCanonicalForm()`. There is no need for code duplication.

### Testing
Unit tests
