### PR TITLE
Tweak build and test instructions in AGENTS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,8 @@ Instructions for GitHub Copilot and other AI coding agents working with the MSBu
 
 ## Code Review Instructions
 
+Official builds treat all warnings as errors, so do not introduce new warnings.
+
 ### Performance Considerations
 
 When reviewing pull requests:
@@ -120,7 +122,7 @@ Build individual projects with `dotnet msbuild {path/to/project.csproj} -v:q`.
 
 ### Bootstrap Environment Setup
 
-After building the whole repo, to use the just-built MSBuild to build things use the bootstrap environment (described in `skills/use-bootstrap-msbuild`).
+After building the whole repo, to use the just-built MSBuild to build things use the bootstrap environment (described in [`skills/use-bootstrap-msbuild](.github/skills/use-bootstrap-msbuild/SKILL.md)).
 
 ### Build Troubleshooting
 
@@ -233,9 +235,6 @@ When reviewing PRs, always consider whether the behavior change could be experie
 2. Run the full build (WAIT for completion - takes 2-3 minutes):
    - Windows: `.\build.cmd -v quiet`
    - macOS/Linux: `./build.sh -v quiet`
-3. Set up environment:
-   - Windows: `artifacts\msbuild-build-env.bat`
-   - macOS/Linux: `source artifacts/sdk-build-env.sh`
 4. Test your changes end-to-end using the bootstrap output: `dotnet build src/Samples/Dependency/Dependency.csproj`
 5. Run relevant individual tests, not the full test suite
 6. Commit your changes

--- a/documentation/wiki/Building-Testing-and-Debugging-on-.Net-Core-MSBuild.md
+++ b/documentation/wiki/Building-Testing-and-Debugging-on-.Net-Core-MSBuild.md
@@ -30,7 +30,7 @@ If you encounter errors, see [Something's wrong in my build](Something's-wrong-i
 
 ## Tests
 
-`./build.sh --test`
+`./build.sh --test` runs all tests in the repo.
 
 # Getting .Net Core MSBuild binaries without building the code
 
@@ -53,7 +53,6 @@ For example, set `MSBUILDDEBUGONSTART` to `2`, then attach a debugger to the pro
 
 ```shell
 build.cmd # to have a full build first
-.\artifacts\msbuild-build-env.bat
 cd test\YOURTEST.Tests # cd to the test folder that contains the test csproj file
 dotnet test --filter "FullyQualifiedName~TESTNAME" # run individual test
 ```
@@ -64,7 +63,6 @@ Use developer command prompt for Visual Studio or put devenv on you PATH
 
 ```shell
 build.cmd # to have a full build first
-.\artifacts\msbuild-build-env.bat
 devenv MSBuild.slnx
 ```
 


### PR DESCRIPTION
Some of the instructions were stale; some things seem to be base model problems like not understanding how to use file loggers.
