### PR TITLE
Enlighten public versions of intrinsic tasks.

### DIFF
--- a/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/MSBuild.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/MSBuild.cs
@@ -316,8 +316,9 @@ namespace Microsoft.Build.BackEnd
             {
                 ITaskItem project = Projects[i];
 
-                AbsolutePath projectPath = TaskEnvironment.GetAbsolutePath(FileUtilities.AttemptToShortenPath(project.ItemSpec));
-
+                AbsolutePath projectPath = FrameworkFileUtilities.FixFilePath(
+                    TaskEnvironment.GetAbsolutePath(project.ItemSpec).GetCanonicalForm());
+                    
                 if (StopOnFirstFailure && !success)
                 {
                     // Inform the user that we skipped the remaining projects because StopOnFirstFailure=true.

--- a/src/Tasks.UnitTests/MSBuild_Tests.cs
+++ b/src/Tasks.UnitTests/MSBuild_Tests.cs
@@ -75,6 +75,7 @@ namespace Microsoft.Build.UnitTests
                 {
                     MSBuild msbuildTask = new MSBuild
                     {
+                        TaskEnvironment = TaskEnvironmentHelper.CreateForTest(),
                         BuildEngine = new MockEngine(_testOutput),
 
                         Projects = new ITaskItem[] { new TaskItem(projectFile1) }
@@ -123,6 +124,7 @@ namespace Microsoft.Build.UnitTests
             try
             {
                 MSBuild msbuildTask = new MSBuild();
+                msbuildTask.TaskEnvironment = TaskEnvironmentHelper.CreateForTest();
                 msbuildTask.BuildEngine = new MockEngine();
 
                 msbuildTask.Projects = new ITaskItem[] { new TaskItem(projectFile1), new TaskItem(projectFile2) };
@@ -519,6 +521,7 @@ namespace Microsoft.Build.UnitTests
                 projects[3].SetMetadata("Properties", "MyProp=1");
 
                 MSBuild msbuildTask = new MSBuild();
+                msbuildTask.TaskEnvironment = TaskEnvironmentHelper.CreateForTest();
                 msbuildTask.BuildEngine = new MockEngine();
                 msbuildTask.Projects = projects;
                 msbuildTask.Properties = new string[] { "MyProp=0" };
@@ -577,6 +580,7 @@ namespace Microsoft.Build.UnitTests
                 projects[3].SetMetadata("Properties", "MyProp=1");
 
                 MSBuild msbuildTask = new MSBuild();
+                msbuildTask.TaskEnvironment = TaskEnvironmentHelper.CreateForTest();
                 msbuildTask.BuildEngine = new MockEngine();
 
                 msbuildTask.Projects = projects;
@@ -633,6 +637,7 @@ namespace Microsoft.Build.UnitTests
                 projects[3].SetMetadata("Properties", "MyProp=1");
 
                 MSBuild msbuildTask = new MSBuild();
+                msbuildTask.TaskEnvironment = TaskEnvironmentHelper.CreateForTest();
                 msbuildTask.BuildEngine = new MockEngine();
 
                 msbuildTask.Projects = projects;
@@ -688,6 +693,7 @@ namespace Microsoft.Build.UnitTests
                 projects[3].SetMetadata("Properties", "=;1");
 
                 MSBuild msbuildTask = new MSBuild();
+                msbuildTask.TaskEnvironment = TaskEnvironmentHelper.CreateForTest();
                 msbuildTask.BuildEngine = new MockEngine();
 
                 msbuildTask.Projects = projects;
@@ -735,6 +741,7 @@ namespace Microsoft.Build.UnitTests
                 projects[1].SetMetadata("AdditionalProperties", "MyPropA=0");
 
                 MSBuild msbuildTask = new MSBuild();
+                msbuildTask.TaskEnvironment = TaskEnvironmentHelper.CreateForTest();
                 msbuildTask.BuildEngine = new MockEngine();
                 msbuildTask.Properties = new string[] { "MyPropG=1" };
                 msbuildTask.Projects = projects;
@@ -794,6 +801,7 @@ namespace Microsoft.Build.UnitTests
                 projects[1].SetMetadata("Properties", "MyPropG=0");
 
                 MSBuild msbuildTask = new MSBuild();
+                msbuildTask.TaskEnvironment = TaskEnvironmentHelper.CreateForTest();
                 msbuildTask.BuildEngine = new MockEngine();
                 msbuildTask.Projects = projects;
 
@@ -849,6 +857,7 @@ namespace Microsoft.Build.UnitTests
                 projects[1].SetMetadata("AdditionalProperties", "MyPropA=1");
 
                 MSBuild msbuildTask = new MSBuild();
+                msbuildTask.TaskEnvironment = TaskEnvironmentHelper.CreateForTest();
                 msbuildTask.BuildEngine = new MockEngine();
                 msbuildTask.Projects = projects;
 
@@ -907,6 +916,7 @@ namespace Microsoft.Build.UnitTests
                 };
 
                 MSBuild msbuildTask = new MSBuild();
+                msbuildTask.TaskEnvironment = TaskEnvironmentHelper.CreateForTest();
                 msbuildTask.BuildEngine = new MockEngine();
                 msbuildTask.Projects = projects;
 
@@ -957,6 +967,7 @@ namespace Microsoft.Build.UnitTests
                 for (int i = 0; i < 4; i++)
                 {
                     MSBuild msbuildTask = new MSBuild();
+                    msbuildTask.TaskEnvironment = TaskEnvironmentHelper.CreateForTest();
                     // By default IsMultipleNodesIs false
                     MockEngine mockEngine = new MockEngine();
                     mockEngine.IsRunningMultipleNodes = false;
@@ -1059,6 +1070,7 @@ namespace Microsoft.Build.UnitTests
                 for (int i = 0; i < 4; i++)
                 {
                     MSBuild msbuildTask = new MSBuild();
+                    msbuildTask.TaskEnvironment = TaskEnvironmentHelper.CreateForTest();
                     MockEngine mockEngine = new MockEngine();
                     mockEngine.IsRunningMultipleNodes = true;
                     msbuildTask.BuildEngine = mockEngine;
@@ -1157,6 +1169,7 @@ namespace Microsoft.Build.UnitTests
                 };
 
                 MSBuild msbuildTask = new MSBuild();
+                msbuildTask.TaskEnvironment = TaskEnvironmentHelper.CreateForTest();
                 MockEngine mockEngine = new MockEngine();
                 mockEngine.IsRunningMultipleNodes = true;
                 msbuildTask.BuildEngine = mockEngine;
@@ -1174,6 +1187,7 @@ namespace Microsoft.Build.UnitTests
                 };
 
                 msbuildTask = new MSBuild();
+                msbuildTask.TaskEnvironment = TaskEnvironmentHelper.CreateForTest();
                 mockEngine = new MockEngine();
                 mockEngine.IsRunningMultipleNodes = true;
                 msbuildTask.BuildEngine = mockEngine;
@@ -1221,6 +1235,7 @@ namespace Microsoft.Build.UnitTests
                 {
                     // Test the case where the error is in the last target
                     MSBuild msbuildTask = new MSBuild();
+                    msbuildTask.TaskEnvironment = TaskEnvironmentHelper.CreateForTest();
                     MockEngine mockEngine = new MockEngine();
                     msbuildTask.BuildEngine = mockEngine;
                     msbuildTask.Projects = projects;
@@ -1338,6 +1353,7 @@ namespace Microsoft.Build.UnitTests
                 };
 
                 MSBuild msbuildTask = new MSBuild();
+                msbuildTask.TaskEnvironment = TaskEnvironmentHelper.CreateForTest();
                 msbuildTask.BuildEngine = new MockEngine();
                 msbuildTask.Projects = projects;
 

--- a/src/Tasks/CallTarget.cs
+++ b/src/Tasks/CallTarget.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Build.Tasks
     /// id validation checks to fail.
     /// </remarks>
     [RunInMTA]
+    [MSBuildMultiThreadableTask]
     public class CallTarget : TaskExtension
     {
         #region Properties

--- a/src/Tasks/MSBuild.cs
+++ b/src/Tasks/MSBuild.cs
@@ -280,7 +280,8 @@ namespace Microsoft.Build.Tasks
             {
                 ITaskItem project = Projects[i];
 
-                AbsolutePath projectPath = TaskEnvironment.GetAbsolutePath(FileUtilities.AttemptToShortenPath(project.ItemSpec));
+                AbsolutePath projectPath = FrameworkFileUtilities.FixFilePath(
+                    TaskEnvironment.GetAbsolutePath(project.ItemSpec).GetCanonicalForm());
 
                 if (StopOnFirstFailure && !success)
                 {

--- a/src/Tasks/MSBuild.cs
+++ b/src/Tasks/MSBuild.cs
@@ -19,7 +19,8 @@ namespace Microsoft.Build.Tasks
     /// RequestBuilder which spawned them.
     /// </remarks>
     [RunInMTA]
-    public class MSBuild : TaskExtension
+    [MSBuildMultiThreadableTask]
+    public class MSBuild : TaskExtension, IMultiThreadableTask
     {
         /// <summary>
         /// Enum describing the behavior when a project doesn't exist on disk.
@@ -187,6 +188,9 @@ namespace Microsoft.Build.Tasks
         /// </summary>
         public string[] TargetAndPropertyListSeparators { get; set; }
 
+        /// <inheritdoc />
+        public TaskEnvironment TaskEnvironment { get; set; }
+
         #endregion
 
         #region ITask Members
@@ -276,7 +280,7 @@ namespace Microsoft.Build.Tasks
             {
                 ITaskItem project = Projects[i];
 
-                string projectPath = FileUtilities.AttemptToShortenPath(project.ItemSpec);
+                AbsolutePath projectPath = TaskEnvironment.GetAbsolutePath(FileUtilities.AttemptToShortenPath(project.ItemSpec));
 
                 if (StopOnFirstFailure && !success)
                 {


### PR DESCRIPTION
### Context
We have enlightened the internal versions of CallTarget and MSbuild tasks, but not the public ones.

### Changes Made
Enlighten the public versions of intrinsic tasks.

### Testing
Unit tests
