### PR TITLE
chore: Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/SyncAnalyzerTemplateMSBuildVersion.yml
+++ b/.github/workflows/SyncAnalyzerTemplateMSBuildVersion.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 #v3
 
     - name: Set baseBranch variable
       id: vars
@@ -88,7 +88,7 @@ jobs:
 
     - name: Create Pull Request
       if: env.updateNeeded == 'true'
-      uses: actions/github-script@v7
+      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b #v7
       with:
         script: |
           const baseBranch = process.env.baseBranch;

--- a/.github/workflows/perfstar-branch.yml
+++ b/.github/workflows/perfstar-branch.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
### Fixes n/a

### Changes Made
- Pinned `actions/checkout` from `v3` to `f43a0e5` in `.github/workflows/SyncAnalyzerTemplateMSBuildVersion.yml`
- Pinned `actions/github-script` from `v7` to `f28e40c` in `.github/workflows/SyncAnalyzerTemplateMSBuildVersion.yml`
- Pinned `actions/checkout` from `v4` to `34e1148` in `.github/workflows/perfstar-branch.yml`

### Testing
The changes will be tested in the CI pipeline of the pull request.

### Notes
None