### PR TITLE
Prevent tasks from modifying immutable environment variables in MT mode

### DIFF
--- a/documentation/specs/multithreading/msbuild-task-enlightenment.md
+++ b/documentation/specs/multithreading/msbuild-task-enlightenment.md
@@ -1,0 +1,26 @@
+# MSBuild Repository Task Enlightenment Guidelines
+
+This document provides specific guidance for enlightening tasks within the MSBuild repository.
+
+## Acceptable Changes in Task Behavior During Enlightenment
+
+**The fundamental principle is to preserve task behavior and outputs for all input options.**
+
+### Permissible Changes
+Modifications to error messaging or failure location are acceptable when a task fails with a different but reasonable error at an alternative execution point, provided that **no significant side effects** (such as disk modifications or output changes) occur between the original and new failure points.
+
+### Changes Requiring Change Waves
+Modifications that alter the success or failure outcome of a task for given inputs require careful evaluation. Such changes are permissible only when implemented behind a **change wave** and when the affected scenarios represent **obscure or edge use cases**.
+
+## Immutable Environment Variables in MSBuild
+
+Certain MSBuild tasks (such as `GetFrameworkPath`) use internal infrastructure that depends on environment variables for resolution. These results are cached in-process for reuse by both tasks and internal MSBuild components. MSBuild assumes that these variables remain constant throughout the build process. 
+
+While multiprocess mode cannot prevent tasks from modifying these variables, multithreaded mode enables MSBuild to enforce protection of environment variables that must remain immutable. Attempts to modify these protected variables will result in an `InvalidOperationException`.
+
+With this protection in place, we will allow MSBuild tasks to continue using internal infrastructure directly without requiring the TaskEnvironment API.
+
+MSBuild protects environment variables in these categories:
+
+1. **Variables with MSBuild-specific prefixes** (e.g. ones used in Traits)
+2. **Framework and SDK location variables** (e.g., `COMPLUS_INSTALL_ROOT`, `COMPLUS_VERSION`, `ReferenceAssemblyRoot`, `ProgramW6432`, etc)

--- a/src/Build.UnitTests/BackEnd/BuildManager_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/BuildManager_Tests.cs
@@ -3491,7 +3491,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
         [Fact]
         public void DotnetHostPathDirectoryWarning()
         {
-            _env.SetEnvironmentVariable(Constants.DotnetHostPathEnvVarName, Path.GetTempPath());
+            _env.SetEnvironmentVariable(EnvironmentVariablesNames.DotnetHostPath, Path.GetTempPath());
 
             BuildRequestData data = GetBuildRequestData(CleanupFileContents(@"<Project xmlns='msbuildnamespace' ToolsVersion='msbuilddefaulttoolsversion'><Target Name='test'/></Project>"));
             _buildManager.Build(_parameters, data);
@@ -3506,7 +3506,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
         public void DotnetHostPathFileNoWarning()
         {
             TransientTestFile tempFile = _env.CreateFile("dotnet.exe", "");
-            _env.SetEnvironmentVariable(Constants.DotnetHostPathEnvVarName, tempFile.Path);
+            _env.SetEnvironmentVariable(EnvironmentVariablesNames.DotnetHostPath, tempFile.Path);
 
             BuildRequestData data = GetBuildRequestData(CleanupFileContents(@"<Project xmlns='msbuildnamespace' ToolsVersion='msbuilddefaulttoolsversion'><Target Name='test'/></Project>"));
             _buildManager.Build(_parameters, data);
@@ -3520,7 +3520,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
         [Fact]
         public void DotnetHostPathNotSetNoWarning()
         {
-            _env.SetEnvironmentVariable(Constants.DotnetHostPathEnvVarName, null);
+            _env.SetEnvironmentVariable(EnvironmentVariablesNames.DotnetHostPath, null);
 
             BuildRequestData data = GetBuildRequestData(CleanupFileContents(@"<Project xmlns='msbuildnamespace' ToolsVersion='msbuilddefaulttoolsversion'><Target Name='test'/></Project>"));
             _buildManager.Build(_parameters, data);

--- a/src/Build.UnitTests/BackEnd/TaskEnvironment_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/TaskEnvironment_Tests.cs
@@ -86,7 +86,7 @@ namespace Microsoft.Build.UnitTests
         public void TaskEnvironment_SetAndGetEnvironmentVariable_ShouldWork(string environmentType)
         {
             var taskEnvironment = CreateTaskEnvironment(environmentType);
-            string testVarName = $"MSBUILD_TEST_VAR_{environmentType}_{Guid.NewGuid():N}";
+            string testVarName = $"TEST_ENV_VAR_{environmentType}_{Guid.NewGuid():N}";
             string testVarValue = $"test_value_{environmentType}";
 
             try
@@ -112,7 +112,7 @@ namespace Microsoft.Build.UnitTests
         public void TaskEnvironment_SetEnvironmentVariableToNull_ShouldRemoveVariable(string environmentType)
         {
             var taskEnvironment = CreateTaskEnvironment(environmentType);
-            string testVarName = $"MSBUILD_REMOVE_TEST_{environmentType}_{Guid.NewGuid():N}";
+            string testVarName = $"TEST_ENV_VAR_REMOVE_{environmentType}_{Guid.NewGuid():N}";
             string testVarValue = "value_to_remove";
 
             try
@@ -138,7 +138,7 @@ namespace Microsoft.Build.UnitTests
         public void TaskEnvironment_SetEnvironment_ShouldReplaceAllVariables(string environmentType)
         {
             var taskEnvironment = CreateTaskEnvironment(environmentType);
-            string prefix = $"MSBUILD_SET_ENV_TEST_{environmentType}_{Guid.NewGuid():N}";
+            string prefix = $"TEST_ENV_VAR_SET_{environmentType}_{Guid.NewGuid():N}";
             string var1Name = $"{prefix}_VAR1";
             string var2Name = $"{prefix}_VAR2";
             string var3Name = $"{prefix}_VAR3";
@@ -265,7 +265,7 @@ namespace Microsoft.Build.UnitTests
         {
             var taskEnvironment = CreateTaskEnvironment(environmentType);
             string testDirectory = GetResolvedTempPath();
-            string testVarName = $"MSBUILD_PROCESS_TEST_{environmentType}_{Guid.NewGuid():N}";
+            string testVarName = $"TEST_ENV_VAR_PROCESS_{environmentType}_{Guid.NewGuid():N}";
             string testVarValue = "process_test_value";
             string originalDirectory = Directory.GetCurrentDirectory();
 
@@ -303,7 +303,7 @@ namespace Microsoft.Build.UnitTests
         [Fact]
         public void TaskEnvironment_StubEnvironment_ShouldAffectSystemEnvironment()
         {
-            string testVarName = $"MSBUILD_STUB_ISOLATION_TEST_{Guid.NewGuid():N}";
+            string testVarName = $"TEST_ENV_VAR_STUB_ISOLATION_{Guid.NewGuid():N}";
             string testVarValue = "stub_test_value";
 
             var stubEnvironment = TaskEnvironmentHelper.CreateForTest();
@@ -333,7 +333,7 @@ namespace Microsoft.Build.UnitTests
         [Fact]
         public void TaskEnvironment_MultithreadedEnvironment_ShouldBeIsolatedFromSystem()
         {
-            string testVarName = $"MSBUILD_MULTITHREADED_ISOLATION_TEST_{Guid.NewGuid():N}";
+            string testVarName = $"TEST_ENV_VAR_MULTITHREADED_ISOLATION_{Guid.NewGuid():N}";
             string testVarValue = "multithreaded_test_value";
 
             using var driver = new MultiThreadedTaskEnvironmentDriver(

--- a/src/Build.UnitTests/BackEnd/TaskEnvironment_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/TaskEnvironment_Tests.cs
@@ -32,7 +32,13 @@ namespace Microsoft.Build.UnitTests
             return environmentType switch
             {
                 StubEnvironmentName => TaskEnvironmentHelper.CreateForTest(),
-                MultithreadedEnvironmentName => new TaskEnvironment(new MultiThreadedTaskEnvironmentDriver(GetResolvedTempPath())),
+                MultithreadedEnvironmentName => new TaskEnvironment(new MultiThreadedTaskEnvironmentDriver(
+                    GetResolvedTempPath(),
+                    new Dictionary<string, string>
+                    {
+                        ["env_var_1"] = "env_var_1_value",
+                        ["env_var_2"] = "env_var_2_value"
+                    })),
                 _ => throw new ArgumentException($"Unknown environment type: {environmentType}")
             };
         }

--- a/src/Build.UnitTests/Evaluation/Evaluator_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/Evaluator_Tests.cs
@@ -2626,7 +2626,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             if (!String.IsNullOrEmpty(programFiles32))
             {
                 // only set in 32-bit windows on 64-bit machines
-                expected = Environment.GetEnvironmentVariable("ProgramW6432");
+                expected = Environment.GetEnvironmentVariable(EnvironmentVariablesNames.ProgramW6432);
 
                 if (string.IsNullOrEmpty(expected))
                 {

--- a/src/Build/BackEnd/BuildManager/EnvironmentVariableValidator.cs
+++ b/src/Build/BackEnd/BuildManager/EnvironmentVariableValidator.cs
@@ -6,7 +6,6 @@ using Microsoft.Build.BackEnd.Logging;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
 using Microsoft.Build.Shared.FileSystem;
-using Constants = Microsoft.Build.Framework.Constants;
 
 namespace Microsoft.Build.Execution
 {
@@ -32,7 +31,7 @@ namespace Microsoft.Build.Execution
         /// </summary>
         private static void ValidateDotnetHostPath(ILoggingService loggingService)
         {
-            string? dotnetHostPath = Environment.GetEnvironmentVariable(Constants.DotnetHostPathEnvVarName);
+            string? dotnetHostPath = Environment.GetEnvironmentVariable(EnvironmentVariablesNames.DotnetHostPath);
             if (string.IsNullOrEmpty(dotnetHostPath))
             {
                 return;

--- a/src/Build/BackEnd/TaskExecutionHost/MultiThreadedTaskEnvironmentDriver.cs
+++ b/src/Build/BackEnd/TaskExecutionHost/MultiThreadedTaskEnvironmentDriver.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Build.BackEnd
         /// <exception cref="ArgumentException">Thrown when attempting to modify an immutable environment variable.</exception>
         private void EnsureVariableCanBeModified(string name)
         {
-            if (EnvironmentVariableClassifier.IsImmutable(name))
+            if (EnvironmentVariableClassifier.Instance.IsImmutable(name))
             {
                 throw new ArgumentException(
                     $"Task cannot modify environment variable '{name}' because MSBuild assumes it should remain constant.",

--- a/src/Build/BackEnd/TaskExecutionHost/MultiThreadedTaskEnvironmentDriver.cs
+++ b/src/Build/BackEnd/TaskExecutionHost/MultiThreadedTaskEnvironmentDriver.cs
@@ -106,7 +106,7 @@ namespace Microsoft.Build.BackEnd
         {
             // Only validate if we're actually changing the value
             _environmentVariables.TryGetValue(name, out string? currentValue);
-            if (!CommunicationsUtilities.EnvironmentVariableComparer.Equals(currentValue, value))
+            if (!string.Equals(currentValue, value, StringComparison.Ordinal))
             {
                 EnsureVariableCanBeModified(name);
             }
@@ -139,7 +139,7 @@ namespace Microsoft.Build.BackEnd
                 _environmentVariables.TryGetValue(entry.Key, out string? currentValue);
                 
                 // Only validate if we're actually changing the value
-                if (!CommunicationsUtilities.EnvironmentVariableComparer.Equals(currentValue, entry.Value))
+                if (!string.Equals(currentValue, entry.Value, StringComparison.Ordinal))
                 {
                     EnsureVariableCanBeModified(entry.Key);
                 }

--- a/src/Build/BackEnd/TaskExecutionHost/MultiThreadedTaskEnvironmentDriver.cs
+++ b/src/Build/BackEnd/TaskExecutionHost/MultiThreadedTaskEnvironmentDriver.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Internal;
+using Microsoft.Build.Shared;
 
 namespace Microsoft.Build.BackEnd
 {
@@ -42,14 +43,13 @@ namespace Microsoft.Build.BackEnd
         /// Throws if the variable is one that MSBuild assumes should remain constant.
         /// </summary>
         /// <param name="name">The name of the environment variable to check.</param>
-        /// <exception cref="ArgumentException">Thrown when attempting to modify an immutable environment variable.</exception>
+        /// <exception cref="InvalidOperationException">Thrown when attempting to modify an immutable environment variable.</exception>
         private void EnsureVariableCanBeModified(string name)
         {
             if (EnvironmentVariableClassifier.Instance.IsImmutable(name))
             {
-                throw new ArgumentException(
-                    $"Task cannot modify environment variable '{name}' because MSBuild assumes it should remain constant.",
-                    nameof(name));
+                throw new InvalidOperationException(
+                    ResourceUtilities.FormatResourceStringStripCodeAndKeyword("TaskCannotModifyImmutableEnvironmentVariable", name));
             }
         }
 

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -1904,7 +1904,7 @@ namespace Microsoft.Build.Evaluation
                     string dotnetExe = Path.Combine(FileUtilities.GetFolderAbove(sdkResult.Path, 5), Constants.DotnetProcessName);
                     if (FileSystems.Default.FileExists(dotnetExe))
                     {
-                        _data.AddSdkResolvedEnvironmentVariable(Constants.DotnetHostPathEnvVarName, dotnetExe);
+                        _data.AddSdkResolvedEnvironmentVariable(EnvironmentVariablesNames.DotnetHostPath, dotnetExe);
                     }
                 }
 

--- a/src/Build/Instance/TaskFactories/AssemblyTaskFactory.cs
+++ b/src/Build/Instance/TaskFactories/AssemblyTaskFactory.cs
@@ -654,7 +654,7 @@ namespace Microsoft.Build.BackEnd
                 return currentParams;
             }
 
-            string dotnetHostPath = getProperty(Constants.DotnetHostPathEnvVarName)?.EvaluatedValue;
+            string dotnetHostPath = getProperty(EnvironmentVariablesNames.DotnetHostPath)?.EvaluatedValue;
             string netCoreSdkRoot = getProperty(Constants.NetCoreSdkRoot)?.EvaluatedValue?.TrimEnd('/', '\\');
 
             // The NetCoreSdkRoot property got added with .NET 11, so for earlier SDKs we fall back to the RID graph path

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -145,6 +145,9 @@
   <data name="WaitingForEndOfBuild" xml:space="preserve">
     <value>The operation cannot be completed because EndBuild has already been called but existing submissions have not yet completed.</value>
   </data>
+  <data name="TaskCannotModifyImmutableEnvironmentVariable" xml:space="preserve">
+    <value>Cannot modify environment variable '{0}': variable is immutable and must remain constant during the build.</value>
+  </data>
   <data name="EnvironmentDerivedPropertyRead">
     <value>Property '{0}' with value '{1}' expanded from the environment.</value>
   </data>

--- a/src/Build/Resources/xlf/Strings.cs.xlf
+++ b/src/Build/Resources/xlf/Strings.cs.xlf
@@ -1002,6 +1002,11 @@ Chyby: {3}</target>
         <target state="translated">Sestavení úlohy bylo načteno z{0}, ale požadované umístění bylo{1}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="TaskCannotModifyImmutableEnvironmentVariable">
+        <source>Cannot modify environment variable '{0}': variable is immutable and must remain constant during the build.</source>
+        <target state="new">Cannot modify environment variable '{0}': variable is immutable and must remain constant during the build.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TaskReleasedCores">
         <source>Task "{0}" released {1} cores and now holds {2} cores total.</source>
         <target state="translated">Úloha {0} uvolnila tento počet jader: {1}. Teď používá celkem tento počet jader: {2}</target>

--- a/src/Build/Resources/xlf/Strings.de.xlf
+++ b/src/Build/Resources/xlf/Strings.de.xlf
@@ -1002,6 +1002,11 @@ Fehler: {3}</target>
         <target state="translated">Die Aufgabenassembly wurde aus „{0}“ geladen, während der gewünschte Speicherort „{1}“ war.</target>
         <note />
       </trans-unit>
+      <trans-unit id="TaskCannotModifyImmutableEnvironmentVariable">
+        <source>Cannot modify environment variable '{0}': variable is immutable and must remain constant during the build.</source>
+        <target state="new">Cannot modify environment variable '{0}': variable is immutable and must remain constant during the build.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TaskReleasedCores">
         <source>Task "{0}" released {1} cores and now holds {2} cores total.</source>
         <target state="translated">Die Aufgabe "{0}" hat {1} Kerne freigegeben und belegt jetzt insgesamt {2} Kerne.</target>

--- a/src/Build/Resources/xlf/Strings.es.xlf
+++ b/src/Build/Resources/xlf/Strings.es.xlf
@@ -1002,6 +1002,11 @@ Errores: {3}</target>
         <target state="translated">El ensamblado de tarea se cargó desde "{0}" mientras que la ubicación deseada era "{1}".</target>
         <note />
       </trans-unit>
+      <trans-unit id="TaskCannotModifyImmutableEnvironmentVariable">
+        <source>Cannot modify environment variable '{0}': variable is immutable and must remain constant during the build.</source>
+        <target state="new">Cannot modify environment variable '{0}': variable is immutable and must remain constant during the build.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TaskReleasedCores">
         <source>Task "{0}" released {1} cores and now holds {2} cores total.</source>
         <target state="translated">La tarea "{0}" liberó {1} núcleos y ahora retiene un total de {2} núcleos.</target>

--- a/src/Build/Resources/xlf/Strings.fr.xlf
+++ b/src/Build/Resources/xlf/Strings.fr.xlf
@@ -1002,6 +1002,11 @@ Erreurs : {3}</target>
         <target state="translated">L’assembly de tâche a été chargé à partir de « {0} » alors que l’emplacement souhaité était « {1} ».</target>
         <note />
       </trans-unit>
+      <trans-unit id="TaskCannotModifyImmutableEnvironmentVariable">
+        <source>Cannot modify environment variable '{0}': variable is immutable and must remain constant during the build.</source>
+        <target state="new">Cannot modify environment variable '{0}': variable is immutable and must remain constant during the build.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TaskReleasedCores">
         <source>Task "{0}" released {1} cores and now holds {2} cores total.</source>
         <target state="translated">La tâche "{0}" a libéré {1} cœur. Elle détient désormais {2} cœurs au total.</target>

--- a/src/Build/Resources/xlf/Strings.it.xlf
+++ b/src/Build/Resources/xlf/Strings.it.xlf
@@ -1002,6 +1002,11 @@ Errori: {3}</target>
         <target state="translated">L'assembly attività è stato caricato da "{0}" mentre era "{1}" il percorso desiderato.</target>
         <note />
       </trans-unit>
+      <trans-unit id="TaskCannotModifyImmutableEnvironmentVariable">
+        <source>Cannot modify environment variable '{0}': variable is immutable and must remain constant during the build.</source>
+        <target state="new">Cannot modify environment variable '{0}': variable is immutable and must remain constant during the build.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TaskReleasedCores">
         <source>Task "{0}" released {1} cores and now holds {2} cores total.</source>
         <target state="translated">L'attività "{0}" ha rilasciato {1} core e ora contiene {2} core in totale.</target>

--- a/src/Build/Resources/xlf/Strings.ja.xlf
+++ b/src/Build/Resources/xlf/Strings.ja.xlf
@@ -1002,6 +1002,11 @@ Errors: {3}</source>
         <target state="translated">タスク アセンブリは '{0}' から読み込まれましたが、必要な場所は '{1}' でした。</target>
         <note />
       </trans-unit>
+      <trans-unit id="TaskCannotModifyImmutableEnvironmentVariable">
+        <source>Cannot modify environment variable '{0}': variable is immutable and must remain constant during the build.</source>
+        <target state="new">Cannot modify environment variable '{0}': variable is immutable and must remain constant during the build.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TaskReleasedCores">
         <source>Task "{0}" released {1} cores and now holds {2} cores total.</source>
         <target state="translated">タスク "{0}" では、{1} 個のコアを解放したため、現在合計 {2} 個のコアを保持しています。</target>

--- a/src/Build/Resources/xlf/Strings.ko.xlf
+++ b/src/Build/Resources/xlf/Strings.ko.xlf
@@ -1002,6 +1002,11 @@ Errors: {3}</source>
         <target state="translated">원하는 위치가 '{1}'인 동안 '{0}'에서 작업 어셈블리를 로드했습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="TaskCannotModifyImmutableEnvironmentVariable">
+        <source>Cannot modify environment variable '{0}': variable is immutable and must remain constant during the build.</source>
+        <target state="new">Cannot modify environment variable '{0}': variable is immutable and must remain constant during the build.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TaskReleasedCores">
         <source>Task "{0}" released {1} cores and now holds {2} cores total.</source>
         <target state="translated">"{0}" 작업에서 코어 {1}개를 해제했고 지금 총 {2}개의 코어를 보유하고 있습니다.</target>

--- a/src/Build/Resources/xlf/Strings.pl.xlf
+++ b/src/Build/Resources/xlf/Strings.pl.xlf
@@ -1002,6 +1002,11 @@ Błędy: {3}</target>
         <target state="translated">Zestaw zadania został załadowany z lokalizacji „{0}”, gdy żądana lokalizacja to „{1}”.</target>
         <note />
       </trans-unit>
+      <trans-unit id="TaskCannotModifyImmutableEnvironmentVariable">
+        <source>Cannot modify environment variable '{0}': variable is immutable and must remain constant during the build.</source>
+        <target state="new">Cannot modify environment variable '{0}': variable is immutable and must remain constant during the build.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TaskReleasedCores">
         <source>Task "{0}" released {1} cores and now holds {2} cores total.</source>
         <target state="translated">Zadanie „{0}” zwolniło rdzenie ({1}) i teraz jego łączna liczba rdzeni to {2}.</target>

--- a/src/Build/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Build/Resources/xlf/Strings.pt-BR.xlf
@@ -1002,6 +1002,11 @@ Erros: {3}</target>
         <target state="translated">O assembly da tarefa foi carregado de "{0}" enquanto o local desejado era "{1}".</target>
         <note />
       </trans-unit>
+      <trans-unit id="TaskCannotModifyImmutableEnvironmentVariable">
+        <source>Cannot modify environment variable '{0}': variable is immutable and must remain constant during the build.</source>
+        <target state="new">Cannot modify environment variable '{0}': variable is immutable and must remain constant during the build.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TaskReleasedCores">
         <source>Task "{0}" released {1} cores and now holds {2} cores total.</source>
         <target state="translated">A tarefa "{0}" liberou {1} núcleos e agora contém {2} núcleos no total.</target>

--- a/src/Build/Resources/xlf/Strings.ru.xlf
+++ b/src/Build/Resources/xlf/Strings.ru.xlf
@@ -1002,6 +1002,11 @@ Errors: {3}</source>
         <target state="translated">Сборка задачи была загружена из "{0}", а нужное расположение — "{1}".</target>
         <note />
       </trans-unit>
+      <trans-unit id="TaskCannotModifyImmutableEnvironmentVariable">
+        <source>Cannot modify environment variable '{0}': variable is immutable and must remain constant during the build.</source>
+        <target state="new">Cannot modify environment variable '{0}': variable is immutable and must remain constant during the build.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TaskReleasedCores">
         <source>Task "{0}" released {1} cores and now holds {2} cores total.</source>
         <target state="translated">Задача "{0}" освободила указанное число ядер ({1}). Теперь общее число ядер, которыми располагает задача, равно {2}.</target>

--- a/src/Build/Resources/xlf/Strings.tr.xlf
+++ b/src/Build/Resources/xlf/Strings.tr.xlf
@@ -1002,6 +1002,11 @@ Hatalar: {3}</target>
         <target state="translated">İstenilen konum '{1}' iken görev derlemesi '{0}'dan yüklendi.</target>
         <note />
       </trans-unit>
+      <trans-unit id="TaskCannotModifyImmutableEnvironmentVariable">
+        <source>Cannot modify environment variable '{0}': variable is immutable and must remain constant during the build.</source>
+        <target state="new">Cannot modify environment variable '{0}': variable is immutable and must remain constant during the build.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TaskReleasedCores">
         <source>Task "{0}" released {1} cores and now holds {2} cores total.</source>
         <target state="translated">"{0}" görevi {1} çekirdeği serbest bıraktı. Şu anda toplam {2} çekirdek tutuyor.</target>

--- a/src/Build/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hans.xlf
@@ -1002,6 +1002,11 @@ Errors: {3}</source>
         <target state="translated">已从“{0}”加载任务程序集，但所需位置为“{1}”。</target>
         <note />
       </trans-unit>
+      <trans-unit id="TaskCannotModifyImmutableEnvironmentVariable">
+        <source>Cannot modify environment variable '{0}': variable is immutable and must remain constant during the build.</source>
+        <target state="new">Cannot modify environment variable '{0}': variable is immutable and must remain constant during the build.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TaskReleasedCores">
         <source>Task "{0}" released {1} cores and now holds {2} cores total.</source>
         <target state="translated">任务“{0}”发布了 {1} 个核心，现总共包含 {2} 个核心。</target>

--- a/src/Build/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hant.xlf
@@ -1002,6 +1002,11 @@ Errors: {3}</source>
         <target state="translated">工作組件已從 '{0}' 載入，但 '{1}' 才是所需的位置。</target>
         <note />
       </trans-unit>
+      <trans-unit id="TaskCannotModifyImmutableEnvironmentVariable">
+        <source>Cannot modify environment variable '{0}': variable is immutable and must remain constant during the build.</source>
+        <target state="new">Cannot modify environment variable '{0}': variable is immutable and must remain constant during the build.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TaskReleasedCores">
         <source>Task "{0}" released {1} cores and now holds {2} cores total.</source>
         <target state="translated">工作 "{0}" 已發行 {1} 個核心，現在共保留 {2} 個核心。</target>

--- a/src/Framework.UnitTests/EnvironmentVariableClassifier_Tests.cs
+++ b/src/Framework.UnitTests/EnvironmentVariableClassifier_Tests.cs
@@ -1,0 +1,95 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Build.Shared;
+using Shouldly;
+using Xunit;
+
+#nullable disable
+
+namespace Microsoft.Build.Framework.UnitTests
+{
+    public class EnvironmentVariableClassifier_Tests
+    {
+        [Fact]
+        public void IsImmutable_CustomImmutableVariables_ExactMatchWorks()
+        {
+            var classifier = new EnvironmentVariableClassifier([
+                "test_env_var_1",
+                "test_env_var_2"
+            ], null);
+
+            classifier.IsImmutable("test_env_var_1").ShouldBeTrue();
+            classifier.IsImmutable("test_env_var_2").ShouldBeTrue();
+            classifier.IsImmutable("test_env_var_3").ShouldBeFalse();
+            classifier.IsImmutable("non_immutable_var_1").ShouldBeFalse();
+        }
+
+        [Fact]
+        public void IsImmutable_CustomPrefixes_WorksCorrectly()
+        {
+            var classifier = new EnvironmentVariableClassifier([], ["prefix_1", "prefix_2"]);
+
+            // Custom prefixes should work
+            classifier.IsImmutable("prefix_1").ShouldBeTrue();
+            classifier.IsImmutable("prefix_1_var").ShouldBeTrue();
+            classifier.IsImmutable("prefix_2_var").ShouldBeTrue();
+
+            // Non-matching prefixes should not work
+            classifier.IsImmutable("test_prefix_1_var").ShouldBeFalse();
+            classifier.IsImmutable("non_immutable_var_1").ShouldBeFalse();
+        }
+
+        [Fact]
+        public void IsImmutable_EmptyOrNullNames_ReturnsFalse()
+        {
+            var classifier = new EnvironmentVariableClassifier([
+                "test_env_var_1"
+            ], null);
+
+            classifier.IsImmutable(null).ShouldBeFalse();
+            classifier.IsImmutable("").ShouldBeFalse();
+            classifier.IsImmutable(string.Empty).ShouldBeFalse();
+        }
+
+        [WindowsOnlyFact]
+        public void IsImmutable_CaseSensitivityBehavior_Windows()
+        {
+            var classifier = new EnvironmentVariableClassifier([
+                "test_env_var_1",
+            ], ["prefix_1"]);
+
+            // On Windows, environment variables should be case-insensitive
+            classifier.IsImmutable("test_env_var_1").ShouldBeTrue();
+            classifier.IsImmutable("TEST_ENV_VAR_1").ShouldBeTrue();
+            classifier.IsImmutable("Test_Env_Var_1").ShouldBeTrue();
+
+            // Custom prefixes should also be case-insensitive
+            classifier.IsImmutable("prefix_1").ShouldBeTrue();
+            classifier.IsImmutable("PREFIX_1").ShouldBeTrue();
+            classifier.IsImmutable("prefix_1_var").ShouldBeTrue();
+            classifier.IsImmutable("PREFIX_1_VAR").ShouldBeTrue();
+            classifier.IsImmutable("Prefix_1_Var").ShouldBeTrue();
+        }
+
+        [UnixOnlyFact]
+        public void IsImmutable_CaseSensitivityBehavior_Unix()
+        {
+            var classifier = new EnvironmentVariableClassifier([
+                "test_env_var_1",
+            ], ["prefix_1"]);
+
+            // On Unix, environment variables should be case-sensitive
+            classifier.IsImmutable("test_env_var_1").ShouldBeTrue();
+            classifier.IsImmutable("TEST_ENV_VAR_1").ShouldBeFalse();
+            classifier.IsImmutable("Test_Env_Var_1").ShouldBeFalse();
+
+            // Custom prefixes should also be case-sensitive
+            classifier.IsImmutable("prefix_1").ShouldBeTrue();
+            classifier.IsImmutable("prefix_1_var").ShouldBeTrue();
+            classifier.IsImmutable("PREFIX_1").ShouldBeFalse();
+            classifier.IsImmutable("PREFIX_1_VAR").ShouldBeFalse();
+            classifier.IsImmutable("Prefix_1_Var").ShouldBeFalse();
+        }
+    }
+}

--- a/src/Framework/Constants.cs
+++ b/src/Framework/Constants.cs
@@ -11,11 +11,6 @@ namespace Microsoft.Build.Framework
     internal static class Constants
     {
         /// <summary>
-        /// Defines the name of dotnet host path environment variable (e.g  DOTNET_HOST_PATH = C:\msbuild\.dotnet\dotnet.exe).
-        /// </summary>
-        internal const string DotnetHostPathEnvVarName = "DOTNET_HOST_PATH";
-
-        /// <summary>
         /// The project property name used to get the path to the MSBuild assembly.
         /// </summary>
         internal const string RuntimeIdentifierGraphPath = nameof(RuntimeIdentifierGraphPath);
@@ -93,5 +88,52 @@ namespace Microsoft.Build.Framework
         internal const string MSBuildAllProjectsPropertyName = "MSBuildAllProjects";
 
         internal const string TaskHostExplicitlyRequested = "TaskHostExplicitlyRequested";
+    }
+
+    /// <summary>
+    /// Environment variable names used by MSBuild for immutable variable classification.
+    /// These constants are excluded from TASKHOST context to avoid validation overhead.
+    /// </summary>
+    internal static class EnvironmentVariablesNames
+    {
+        /// <summary>
+        /// Name of the environment variable that points to 64-bit program files directory.
+        /// </summary>
+        internal const string ProgramW6432 = "ProgramW6432";
+
+        /// <summary>
+        /// Name of the environment variable that points to program files directory.
+        /// </summary>
+        internal const string ProgramFiles = "ProgramFiles";
+
+        /// <summary>
+        /// Name of the environment variable for .NET Framework installation root.
+        /// </summary>
+        internal const string ComplusInstallRoot = "COMPLUS_INSTALLROOT";
+
+        /// <summary>
+        /// Name of the environment variable for .NET Framework version override.
+        /// </summary>
+        internal const string ComplusVersion = "COMPLUS_VERSION";
+
+        /// <summary>
+        /// Name of the environment variable for reference assembly root path.
+        /// </summary>
+        internal const string ReferenceAssemblyRoot = "ReferenceAssemblyRoot";
+
+        /// <summary>
+        /// Name of the environment variable for .NET Framework installation root (alternate casing).
+        /// </summary>
+        internal const string ComplusInstallRootAlt = "COMPLUS_InstallRoot";
+
+        /// <summary>
+        /// Name of the environment variable for .NET Framework version (alternate casing).
+        /// </summary>
+        internal const string ComplusVersionAlt = "COMPLUS_Version";
+
+        /// <summary>
+        /// Defines the name of dotnet host path environment variable.
+        /// </summary>
+        internal const string DotnetHostPath = "DOTNET_HOST_PATH";
     }
 }

--- a/src/Framework/EnvironmentVariableClassifier.cs
+++ b/src/Framework/EnvironmentVariableClassifier.cs
@@ -35,9 +35,9 @@ namespace Microsoft.Build.Framework
         private readonly FrozenSet<string> _immutableVariables;
 
         /// <summary>
-        /// Array of prefixes that identify immutable environment variables.
+        /// List of prefixes that identify immutable environment variables.
         /// </summary>
-        private readonly string[] _immutablePrefixes;
+        private readonly IReadOnlyList<string> _immutablePrefixes;
 
         /// <summary>
         /// Initializse a new instance with the default set of immutable environment variables and prefixes.
@@ -52,7 +52,9 @@ namespace Microsoft.Build.Framework
                 EnvironmentVariablesNames.ProgramW6432
             ], FrameworkFileUtilities.EnvironmentVariableComparer);
             
-            _immutablePrefixes = ["MSBUILD"];
+            // On case-sensitive systems, both "MSBUILD" and "MSBuild" prefixes are used
+            var prefixSet = new HashSet<string>(FrameworkFileUtilities.EnvironmentVariableComparer) { "MSBUILD", "MSBuild" };
+            _immutablePrefixes = new List<string>(prefixSet);
         }
 
         /// <summary>

--- a/src/Framework/EnvironmentVariableClassifier.cs
+++ b/src/Framework/EnvironmentVariableClassifier.cs
@@ -1,0 +1,54 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Frozen;
+
+namespace Microsoft.Build.Framework
+{
+    /// <summary>
+    /// Classifies environment variables to prevent modification of those that MSBuild assumes remain constant.
+    /// These variables should not be modified during the build process,
+    /// particularly in multi-threaded build scenarios.
+    /// </summary>
+    internal static class EnvironmentVariableClassifier
+    {
+
+        /// <summary>
+        /// Set of specific environment variable names that MSBuild assumes should not be modified.
+        /// </summary>
+        private static readonly Lazy<FrozenSet<string>> s_immutableVariables = new Lazy<FrozenSet<string>>(() =>
+            FrozenSet.ToFrozenSet([
+                // .NET Framework path resolution - used by FrameworkLocationHelper
+                EnvironmentVariablesNames.ComplusInstallRoot,
+                EnvironmentVariablesNames.ComplusVersion,
+                
+                // Reference assembly root path - used by FrameworkLocationHelper
+                EnvironmentVariablesNames.ReferenceAssemblyRoot,
+                
+                // Program Files directories - used by ToolLocationHelper for SDK/tool discovery
+                EnvironmentVariablesNames.ProgramW6432,
+                EnvironmentVariablesNames.ProgramFiles,
+                
+                // .NET host path - used by ToolLocationHelper for .NET Core/.NET 5+ discovery
+                EnvironmentVariablesNames.DotnetHostPath
+            ], FrameworkFileUtilities.EnvironmentVariableComparer));
+
+        /// <summary>
+        /// Gets whether the specified environment variable is one that MSBuild assumes should not be modified.
+        /// </summary>
+        /// <param name="name">The environment variable name to check.</param>
+        /// <returns>True if the variable is immutable, false otherwise.</returns>
+        internal static bool IsImmutable(string name)
+        {
+            // Check specific variables that MSBuild assumes are constant
+            if (s_immutableVariables.Value.Contains(name))
+            {
+                return true;
+            }
+
+            // All variables that start with "MSBUILD" are assumed to be immutable
+            return name.StartsWith("MSBUILD", FrameworkFileUtilities.EnvironmentVariableComparison);
+        }
+    }
+}

--- a/src/Framework/EnvironmentVariableClassifier.cs
+++ b/src/Framework/EnvironmentVariableClassifier.cs
@@ -3,52 +3,98 @@
 
 using System;
 using System.Collections.Frozen;
+using System.Collections.Generic;
 
 namespace Microsoft.Build.Framework
 {
     /// <summary>
     /// Classifies environment variables to prevent modification of those that MSBuild assumes remain constant.
-    /// These variables should not be modified during the build process,
-    /// particularly in multi-threaded build scenarios.
+    /// These variables should not be modified during the build process.
     /// </summary>
-    internal static class EnvironmentVariableClassifier
+    /// <remarks>
+    /// Used in multithreaded build scenarios to prevent tasks from modifying environment variables that could affect other concurrently building projects. 
+    /// </remarks>
+    internal sealed class EnvironmentVariableClassifier
     {
+        /// <summary>
+        /// Shared instance used by MSBuild for environment variable classification.
+        /// </summary>
+        /// <remarks>
+        /// Deferred creation avoids overhead in multiprocess builds where this is not to be used.
+        /// </remarks>
+        private static readonly Lazy<EnvironmentVariableClassifier> s_instance = new(() => new EnvironmentVariableClassifier());
+
+        /// <summary>
+        /// Shared instance used by MSBuild for production environment variable classification.
+        /// </summary>
+        internal static EnvironmentVariableClassifier Instance => s_instance.Value;
 
         /// <summary>
         /// Set of specific environment variable names that MSBuild assumes should not be modified.
         /// </summary>
-        private static readonly Lazy<FrozenSet<string>> s_immutableVariables = new Lazy<FrozenSet<string>>(() =>
-            FrozenSet.ToFrozenSet([
-                // .NET Framework path resolution - used by FrameworkLocationHelper
+        private readonly FrozenSet<string> _immutableVariables;
+
+        /// <summary>
+        /// Array of prefixes that identify immutable environment variables.
+        /// </summary>
+        private readonly string[] _immutablePrefixes;
+
+        /// <summary>
+        /// Initializse a new instance with the default set of immutable environment variables and prefixes.
+        /// </summary>
+        private EnvironmentVariableClassifier()
+        {
+            _immutableVariables = FrozenSet.ToFrozenSet([
+                // Environment variables used by FrameworkLocationHelper and ToolLocationHelper for framework/SDK discovery.
                 EnvironmentVariablesNames.ComplusInstallRoot,
                 EnvironmentVariablesNames.ComplusVersion,
-                
-                // Reference assembly root path - used by FrameworkLocationHelper
                 EnvironmentVariablesNames.ReferenceAssemblyRoot,
-                
-                // Program Files directories - used by ToolLocationHelper for SDK/tool discovery
-                EnvironmentVariablesNames.ProgramW6432,
-                EnvironmentVariablesNames.ProgramFiles,
-                
-                // .NET host path - used by ToolLocationHelper for .NET Core/.NET 5+ discovery
-                EnvironmentVariablesNames.DotnetHostPath
-            ], FrameworkFileUtilities.EnvironmentVariableComparer));
+                EnvironmentVariablesNames.ProgramW6432
+            ], FrameworkFileUtilities.EnvironmentVariableComparer);
+            
+            _immutablePrefixes = ["MSBUILD"];
+        }
+
+        /// <summary>
+        /// Initializes a new instance with a custom set of immutable environment variables and prefixes.
+        /// Used primarily for testing scenarios.
+        /// </summary>
+        /// <param name="immutableVariables">Custom set of environment variable names to treat as immutable.</param>
+        /// <param name="immutablePrefixes">Array of prefixes that identify immutable environment variables. If null or empty, no prefix matching is performed.</param>
+        internal EnvironmentVariableClassifier(IEnumerable<string> immutableVariables, string[] immutablePrefixes)
+        {
+            _immutableVariables = FrozenSet.ToFrozenSet(immutableVariables, FrameworkFileUtilities.EnvironmentVariableComparer);
+            _immutablePrefixes = immutablePrefixes ?? [];
+        }
 
         /// <summary>
         /// Gets whether the specified environment variable is one that MSBuild assumes should not be modified.
         /// </summary>
         /// <param name="name">The environment variable name to check.</param>
         /// <returns>True if the variable is immutable, false otherwise.</returns>
-        internal static bool IsImmutable(string name)
+        internal bool IsImmutable(string name)
         {
-            // Check specific variables that MSBuild assumes are constant
-            if (s_immutableVariables.Value.Contains(name))
+            if (string.IsNullOrEmpty(name))
+            {
+                return false;
+            }
+
+            // Check specific variables that are configured as constant
+            if (_immutableVariables.Contains(name))
             {
                 return true;
             }
 
-            // All variables that start with "MSBUILD" are assumed to be immutable
-            return name.StartsWith("MSBUILD", FrameworkFileUtilities.EnvironmentVariableComparison);
+            // Check if variable starts with any of the configured immutable prefixes
+            foreach (string prefix in _immutablePrefixes)
+            {
+                if (name.StartsWith(prefix, FrameworkFileUtilities.EnvironmentVariableComparison))
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
     }
 }

--- a/src/Framework/FileUtilities.cs
+++ b/src/Framework/FileUtilities.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
+
 #if !TASKHOST
 using System.Threading;
 #endif
@@ -26,6 +28,18 @@ namespace Microsoft.Build.Framework
         private const char WindowsDirectorySeparator = '\\';
 
         internal static readonly char[] Slashes = [UnixDirectorySeparator, WindowsDirectorySeparator];
+
+        /// <summary>
+        /// The string comparison to use for environment variable name comparisons, based on OS environment variable handling.
+        /// Windows: case-insensitive, Unix/Linux: case-sensitive.
+        /// </summary>
+        internal static readonly StringComparison EnvironmentVariableComparison = NativeMethods.IsWindows ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+
+        /// <summary>
+        /// The string comparer to use for environment variable name comparisons, based on OS environment variable handling.
+        /// Windows: case-insensitive, Unix/Linux: case-sensitive.
+        /// </summary>
+        internal static readonly StringComparer EnvironmentVariableComparer = NativeMethods.IsWindows ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
 
 #if !TASKHOST
         /// <summary>

--- a/src/Framework/Traits.cs
+++ b/src/Framework/Traits.cs
@@ -259,6 +259,13 @@ namespace Microsoft.Build.Framework
         public readonly bool AlwaysDoImmutableFilesUpToDateCheck = Environment.GetEnvironmentVariable("MSBUILDDONOTCACHEMODIFICATIONTIME") == "1";
 
         /// <summary>
+        /// Disables the check that prevents tasks from modifying immutable environment variables (e.g., MSBUILD* variables)
+        /// in multithreaded build mode. This escape hatch should only be used for compatibility with tasks that need to
+        /// modify these variables and understand the risks of doing so in a concurrent build environment.
+        /// </summary>
+        public readonly bool DisableImmutableEnvironmentVariableCheck = Environment.GetEnvironmentVariable("MSBUILDDISABLEIMMUTABLEENVIRONMENTVARIABLECHECK") == "1";
+
+        /// <summary>
         /// When copying over an existing file, copy directly into the existing file rather than deleting and recreating.
         /// </summary>
         public readonly bool CopyWithoutDelete = Environment.GetEnvironmentVariable("MSBUILDCOPYWITHOUTDELETE") == "1";

--- a/src/MSBuild.UnitTests/MSBuildMultithreaded_Tests.cs
+++ b/src/MSBuild.UnitTests/MSBuildMultithreaded_Tests.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Build.Engine.UnitTests
         private bool TestEnvironmentIsolation()
         {
             string mode = IsMultithreadedMode ? "MultiThreaded" : "MultiProcess";
-            string envVarName = $"MSBUILD_MULTITHREADED_TEST_VAR_{Guid.NewGuid():N}";
+            string envVarName = $"TEST_ENV_VAR_MULTITHREADED_{Guid.NewGuid():N}";
             string envVarValue = "TestValue";
 
             // Set environment variable using TaskEnvironment

--- a/src/Shared/FrameworkLocationHelper.cs
+++ b/src/Shared/FrameworkLocationHelper.cs
@@ -766,8 +766,8 @@ namespace Microsoft.Build.Shared
         private static bool CheckForFrameworkInstallation(string registryEntryToCheckInstall, string registryValueToCheckInstall)
         {
             // Get the complus install root and version
-            string complusInstallRoot = Environment.GetEnvironmentVariable("COMPLUS_INSTALLROOT");
-            string complusVersion = Environment.GetEnvironmentVariable("COMPLUS_VERSION");
+            string complusInstallRoot = Environment.GetEnvironmentVariable(EnvironmentVariablesNames.ComplusInstallRoot);
+            string complusVersion = Environment.GetEnvironmentVariable(EnvironmentVariablesNames.ComplusVersion);
 
             // Complus is not set we need to make sure the framework we are targeting is installed. Check the registry key before trying to find the directory.
             // If complus is set then we will return that directory as the framework directory, there is no need to check the registry value for the framework and it may not even be installed.
@@ -818,8 +818,8 @@ namespace Microsoft.Build.Shared
             }
 
             // If the COMPLUS variables are set, they override everything -- that's the directory we want.
-            string complusInstallRoot = Environment.GetEnvironmentVariable("COMPLUS_INSTALLROOT");
-            string complusVersion = Environment.GetEnvironmentVariable("COMPLUS_VERSION");
+            string complusInstallRoot = Environment.GetEnvironmentVariable(EnvironmentVariablesNames.ComplusInstallRoot);
+            string complusVersion = Environment.GetEnvironmentVariable(EnvironmentVariablesNames.ComplusVersion);
 
             if (!String.IsNullOrEmpty(complusInstallRoot) && !String.IsNullOrEmpty(complusVersion))
             {
@@ -935,7 +935,7 @@ namespace Microsoft.Build.Shared
                 // either we're in a 32-bit window, or we're on a 32-bit machine.
                 // if we're on a 32-bit machine, ProgramW6432 won't exist
                 // if we're on a 64-bit machine, ProgramW6432 will point to the correct Program Files.
-                programFilesX64 = Environment.GetEnvironmentVariable("ProgramW6432");
+                programFilesX64 = Environment.GetEnvironmentVariable(EnvironmentVariablesNames.ProgramW6432);
             }
             else
             {
@@ -953,7 +953,7 @@ namespace Microsoft.Build.Shared
         /// </summary>
         internal static string GenerateProgramFilesReferenceAssemblyRoot()
         {
-            string combinedPath = Environment.GetEnvironmentVariable("ReferenceAssemblyRoot");
+            string combinedPath = Environment.GetEnvironmentVariable(EnvironmentVariablesNames.ReferenceAssemblyRoot);
             if (!String.IsNullOrEmpty(combinedPath))
             {
                 combinedPath = Path.GetFullPath(combinedPath);

--- a/src/Tasks.UnitTests/RoslynCodeTaskFactory_Tests.cs
+++ b/src/Tasks.UnitTests/RoslynCodeTaskFactory_Tests.cs
@@ -899,7 +899,7 @@ namespace InlineTask
             }
 
             RunnerUtilities.ApplyDotnetHostPathEnvironmentVariable(env);
-            var dotnetPath = Environment.GetEnvironmentVariable("DOTNET_HOST_PATH");
+            var dotnetPath = Environment.GetEnvironmentVariable(EnvironmentVariablesNames.DotnetHostPath);
 
             var project = env.CreateTestProjectWithFiles("p1.proj", text);
             var logger = project.BuildProjectExpectSuccess();

--- a/src/Tasks/Al.cs
+++ b/src/Tasks/Al.cs
@@ -305,7 +305,7 @@ namespace Microsoft.Build.Tasks
 
             // If COMPLUS_InstallRoot\COMPLUS_Version are set (the dogfood world), we want to find it there, instead of
             // the SDK, which may or may not be installed. The following will look there.
-            if (!String.IsNullOrEmpty(Environment.GetEnvironmentVariable("COMPLUS_InstallRoot")) || !String.IsNullOrEmpty(Environment.GetEnvironmentVariable("COMPLUS_Version")))
+            if (!String.IsNullOrEmpty(Environment.GetEnvironmentVariable(EnvironmentVariablesNames.ComplusInstallRootAlt)) || !String.IsNullOrEmpty(Environment.GetEnvironmentVariable(EnvironmentVariablesNames.ComplusVersionAlt)))
             {
                 pathToTool = ToolLocationHelper.GetPathToDotNetFrameworkFile(ToolExe, TargetDotNetFrameworkVersion.Latest);
             }

--- a/src/Tasks/RoslynCodeTaskFactory/RoslynCodeTaskFactoryCompilers.cs
+++ b/src/Tasks/RoslynCodeTaskFactory/RoslynCodeTaskFactoryCompilers.cs
@@ -10,7 +10,6 @@ using Microsoft.Build.Utilities;
 #if RUNTIME_TYPE_NETCORE
 using System.Runtime.InteropServices;
 using Microsoft.Build.Shared;
-using Constants = Microsoft.Build.Framework.Constants;
 #endif
 
 #nullable disable
@@ -53,7 +52,7 @@ namespace Microsoft.Build.Tasks
 #if RUNTIME_TYPE_NETCORE
             // Tools and MSBuild Tasks within the SDK that invoke binaries via the dotnet host are expected
             // to honor the environment variable DOTNET_HOST_PATH to ensure a consistent experience.
-            _dotnetCliPath = Environment.GetEnvironmentVariable(Constants.DotnetHostPathEnvVarName);
+            _dotnetCliPath = Environment.GetEnvironmentVariable(EnvironmentVariablesNames.DotnetHostPath);
             if (string.IsNullOrEmpty(_dotnetCliPath))
             {
                 // Fallback to get dotnet path from current process which might be dotnet executable.

--- a/src/Tasks/SGen.cs
+++ b/src/Tasks/SGen.cs
@@ -307,7 +307,7 @@ namespace Microsoft.Build.Tasks
 
             // If COMPLUS_InstallRoot\COMPLUS_Version are set (the dogfood world), we want to find it there, instead of
             // the SDK, which may or may not be installed. The following will look there.
-            if (!String.IsNullOrEmpty(Environment.GetEnvironmentVariable("COMPLUS_InstallRoot")) || !String.IsNullOrEmpty(Environment.GetEnvironmentVariable("COMPLUS_Version")))
+            if (!String.IsNullOrEmpty(Environment.GetEnvironmentVariable(EnvironmentVariablesNames.ComplusInstallRootAlt)) || !String.IsNullOrEmpty(Environment.GetEnvironmentVariable(EnvironmentVariablesNames.ComplusVersionAlt)))
             {
                 pathToTool = ToolLocationHelper.GetPathToDotNetFrameworkFile(ToolExe, TargetDotNetFrameworkVersion.Latest);
             }

--- a/src/UnitTests.Shared/RunnerUtilities.cs
+++ b/src/UnitTests.Shared/RunnerUtilities.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Build.UnitTests.Shared
         public static void ApplyDotnetHostPathEnvironmentVariable(TestEnvironment testEnvironment)
         {
             // Built msbuild.dll executed by dotnet.exe needs this environment variable for msbuild tasks such as RoslynCodeTaskFactory.
-            testEnvironment.SetEnvironmentVariable(Constants.DotnetHostPathEnvVarName, s_dotnetExePath);
+            testEnvironment.SetEnvironmentVariable(EnvironmentVariablesNames.DotnetHostPath, s_dotnetExePath);
         }
 #endif
 


### PR DESCRIPTION
### Context
Some MSBuild tasks implicitly rely on environment variables remaining immutable across multiple projects builds and cache this state in-process. We would like to disallow to modify certain set of environment variables in the tasks. We can easily check that in the multithreaded mode through task environment. This will help use easier enlighten msbuild tasks that depend on immutable state and cache this state in process. These checks would work only in multithreaded mode.

### Changes Made
- In multithreaded mode, validate environment variable assignments and disallow modifications to variables marked as immutable
- Centralize and refactor environment variable constants to avoid code duplication
- added escape hatch to opt-out from the behavior.

### Testing
unit tests + manual tests (in process)