### PR TITLE
Changewave doc updates

### DIFF
--- a/.github/skills/changewaves/SKILL.md
+++ b/.github/skills/changewaves/SKILL.md
@@ -40,11 +40,11 @@ Look up the current MSBuild version. If a wave already exists for that version i
 
 C# and MSBuild examples are in [ChangeWaves-Dev.md](../../../documentation/wiki/ChangeWaves-Dev.md). Prefer to put checks inline rather than abstracting out a method to host the check.
 
-## Step 4: Write Tests
+## Step 3: Write Tests
 
 Write normal tests for the new behavior. Then add at least one test that verifies the old behavior is **preserved** when the wave is opted out.
 
-## Step 5: Document the Feature
+## Step 4: Document the Feature
 
 Add an entry to the **Current Rotation of Change Waves** section in [ChangeWaves.md](../../../documentation/wiki/ChangeWaves.md).
 

--- a/documentation/wiki/ChangeWaves-Dev.md
+++ b/documentation/wiki/ChangeWaves-Dev.md
@@ -10,7 +10,7 @@ Opt-out is a better approach for us because we'd likely get limited feedback whe
 The opt-out comes in the form of setting the environment variable `MSBUILDDISABLEFEATURESFROMVERSION` to the Change Wave (or version) that contains the feature you want **disabled**. This version happens to be the version of MSBuild that the features were developed for. See the mapping of change waves to features below.
 
 ## Choosing a Change Wave for a New Feature
-Use the changewave for the currently-in-development version of MSBuild, as specified in `eng\Versions.props`. This version corresponds to the latest version of Visual Studio. Create a new change wave if there isn't one for this version of MSBuild yet. For example, if you're developing a feature for MSBuild 18.6, you should use `Wave18_6` or create it if it doesn't exist.
+Use the change wave for the currently-in-development version of MSBuild, as specified in `eng/Versions.props`. This version corresponds to the latest version of Visual Studio. Create a new change wave if there isn't one for this version of MSBuild yet. For example, if you're developing a feature for MSBuild 18.6, you should use `Wave18_6` or create it if it doesn't exist.
 
 # Developing With Change Waves in Mind
 For the purpose of providing an example, the rest of this document assumes we're developing a feature for MSBuild version **17.3**.

--- a/documentation/wiki/ChangeWaves.md
+++ b/documentation/wiki/ChangeWaves.md
@@ -14,7 +14,7 @@ The opt-out should be just a *temporary* workaround for a problem - as the featu
 
 A wave of features is eligible to "rotate out" (i.e. become standard functionality) six months after its release. For example, wave 16.8 stayed opt-out through wave 16.10, becoming standard functionality when wave 17.0 is introduced.
 
-Changewave checks around features will be removed in the release that accompanies a new major version of .NET (for example, .NET 11, .NET 12).
+Change wave checks around features will be removed in the release that accompanies a new major version of .NET (for example, .NET 11, .NET 12).
 
 ## MSBUILDDISABLEFEATURESFROMVERSION Values & Outcomes
 | `MSBUILDDISABLEFEATURESFROMVERSION` Value                         | Result        | Receive Warning? |


### PR DESCRIPTION
Per some team discussion, the old changewave pace doesn't make a ton of
sense if we're releasing monthly. Let's

* Be more willing to create new changewaves
* Always match them to the current development version

And we also decided last year that we would wait until the release
corresponding to a .NET SDK major version to actually remove waves.
Writing that down!

Also added an agent skill to refer to these docs to help, so you can

    /changewaves Wrap this call in a changewave

And it will (if all goes well) handle it for you.
