### PR TITLE
Updated common types XSD to remove errors from redefining `Include` attributes

### DIFF
--- a/src/MSBuild/MSBuild/Microsoft.Build.CommonTypes.xsd
+++ b/src/MSBuild/MSBuild/Microsoft.Build.CommonTypes.xsd
@@ -6,6 +6,16 @@ elementFormDefault="qualified">
     <xs:include schemaLocation="Microsoft.Build.Core.xsd"/>
 
     <!-- ======================== ITEMS =====================================-->
+    <!-- Redefine SimpleItemType to allow the "Include" property to be redefine inside our this file as much as we want without errors -->
+    <xs:redefine schemaLocation="./Microsoft.Build.Core.xsd">
+        <xs:complexType name="SimpleItemType">
+            <xs:complexContent>
+                <xs:restriction base="msb:SimpleItemType">
+                    <xs:attribute name="Include" type="xs:string" use="prohibited" />
+                </xs:restriction>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:redefine>
     <!-- Possible Types include SimpleItemType (no meta-data subelements), GenericItemType (any meta-data), or something more specific.-->
     <xs:element name="Reference" substitutionGroup="msb:Item">
         <xs:annotation>


### PR DESCRIPTION
### Context

Some XML LSPs (like Lemmix, the engine that powers the [redhat-developer/vscode-xml](https://github.com/redhat-developer/vscode-xml) VSCode extension) struggle with the GitHub XSDs because they redefine the `Include` attribute inside the XSDs in order to redefine the documentation comments per element type.

This PR addresses that by prohibiting the use of the attribute inside the common types XSD, thus allowing this redefinition to occur.

### Changes Made

* Added a XSD `redefine` block to `src/MSBuild/MSBuild/Microsoft.Build.CommonTypes.xsd` to ensure `Include` blocks are not marked as already defined from outside the file.

### Testing

1. Load the XSD into a validation engine.
2. See that no errors are produced as a result of `Include` blocks being redefined.
