### PR TITLE
Do not share assemblies of task dependencies if not running on `MSBuild.exe`.

### DIFF
--- a/src/Shared/MSBuildLoadContext.cs
+++ b/src/Shared/MSBuildLoadContext.cs
@@ -29,8 +29,6 @@ namespace Microsoft.Build.Shared
             "Microsoft.Build.Utilities.Core",
         ];
 
-        private static readonly bool IsRunningOnMsBuildExecutable = Assembly.GetEntryAssembly()?.GetName().Name is "MSBuild";
-
         public MSBuildLoadContext(string assemblyPath)
             : base($"MSBuild plugin {assemblyPath}")
         {
@@ -105,8 +103,8 @@ namespace Microsoft.Build.Shared
                 // If we are not running on MSBuild.exe (e.g. on an app using MSBuildLocator), we cannot load
                 // the assembly in the default ALC, because it might interfere with the app's own dependencies.
                 // In that case, load it in the plugin's isolated ALC.
-                AssemblyLoadContext alcToLoadSharedDependency = IsRunningOnMsBuildExecutable ? Default : this;
-                return alcToLoadSharedDependency.LoadFromAssemblyPath(assemblyNameInExecutableDirectory);
+                AssemblyLoadContext targetAlc = BuildEnvironmentHelper.Instance.RunningInMSBuildExe ? Default : this;
+                return targetAlc.LoadFromAssemblyPath(assemblyNameInExecutableDirectory);
             }
 
             return null;

--- a/src/Shared/MSBuildLoadContext.cs
+++ b/src/Shared/MSBuildLoadContext.cs
@@ -94,15 +94,13 @@ namespace Microsoft.Build.Shared
             // If the Assembly is provided via a file path, the following rules are used to load the assembly:
             // - the assembly from the user specified path is loaded, if it exists, into the custom ALC, or
             // - if the simple name of the assembly exists in the same folder as msbuild.exe, then that assembly gets loaded
-            //   into the default ALC (so it's shared with other uses).
+            //   into the default ALC (so it's shared with other uses), or into the custom ALC if we are not running on
+            //   MSBuild.exe (because it might interfere with the app's own dependencies).
             var assemblyNameInExecutableDirectory = Path.Combine(BuildEnvironmentHelper.Instance.CurrentMSBuildToolsDirectory,
                 $"{assemblyName.Name}.dll");
 
             if (FileSystems.Default.FileExists(assemblyNameInExecutableDirectory))
             {
-                // If we are not running on MSBuild.exe (e.g. on an app using MSBuildLocator), we cannot load
-                // the assembly in the default ALC, because it might interfere with the app's own dependencies.
-                // In that case, load it in the plugin's isolated ALC.
                 AssemblyLoadContext targetAlc = BuildEnvironmentHelper.Instance.RunningInMSBuildExe ? Default : this;
                 return targetAlc.LoadFromAssemblyPath(assemblyNameInExecutableDirectory);
             }


### PR DESCRIPTION
Fixes microsoft/MSBuildLocator#336
Fixes #13286

### Context

When MSBuild resolves dependencies for a task, if it cannot find the dependent assembly in the task assembly's directory, it tries finding it in MSBuild's tools directory. In that case, the dependency is loaded to `AssemblyLoadContext.Default` instead of the task's own ALC, in order to share it across tasks and avoid loading it multiple times.

However, loading it to the default ALC does not reliably work if MSBuild is running on an arbitrary host app (such as by being loaded by `MSBuildLocator`), because it will cause failures if the host app has itself a dependency on an older assembly version than the task's dependency. This is what caused the linked issue.

### Changes Made

Updated `MSBuildLoadContext.Load` to load dependencies found in the tools directory, into itself, instead of in `AssemblyLoadContext.Default`. To avoid regressing performance in the majority of cases, the existing behavior is maintained if MSBuild is running as part of `MSBuild.exe` (detected by checking the entry assembly's name, once in static initialization).

### Testing

Validated that the test failures in the linked issue no longer reproduce. I did this by using a custom copy of .NET SDK 8.0.418, with a patched `Microsoft.Build.dll`.

### Notes
