### PR TITLE
Add escape hatch for not sharing assemblies from tools directory

### DIFF
--- a/src/Framework/Traits.cs
+++ b/src/Framework/Traits.cs
@@ -403,6 +403,13 @@ namespace Microsoft.Build.Framework
         public readonly bool UseSingleLoadContext = Environment.GetEnvironmentVariable("MSBUILDSINGLELOADCONTEXT") == "1";
 
         /// <summary>
+        /// Use custom AssemblyLoadContext for loading dependencies found in the MSBuild tools directory.
+        /// When enabled, assemblies found in the MSBuild tools directory are loaded into the plugin's isolated context
+        /// instead of the shared default context, preventing potential version conflicts with the host application.
+        /// </summary>
+        public readonly bool UseCustomLoadContextForDependenciesInToolsDirectory = Environment.GetEnvironmentVariable("MSBUILDUSECUSTOMLOADCONTEXTFORDEPENDENCIESINTOOLSDIRECTORY") == "1";
+
+        /// <summary>
         /// Enables the user of autorun functionality in CMD.exe on Windows which is disabled by default in MSBuild.
         /// </summary>
         public readonly bool UseAutoRunWhenLaunchingProcessUnderCmd = Environment.GetEnvironmentVariable("MSBUILDUSERAUTORUNINCMD") == "1";

--- a/src/Shared/MSBuildLoadContext.cs
+++ b/src/Shared/MSBuildLoadContext.cs
@@ -94,13 +94,15 @@ namespace Microsoft.Build.Shared
             // If the Assembly is provided via a file path, the following rules are used to load the assembly:
             // - the assembly from the user specified path is loaded, if it exists, into the custom ALC, or
             // - if the simple name of the assembly exists in the same folder as msbuild.exe, then that assembly gets loaded
-            //   into the default ALC (so it's shared with other uses).
+            //   into the default ALC (so it's shared with other uses), or into the custom ALC if the custom load context escape hatch
+            //   is enabled (to isolate MSBuild assemblies from the app's dependencies).
             var assemblyNameInExecutableDirectory = Path.Combine(BuildEnvironmentHelper.Instance.CurrentMSBuildToolsDirectory,
                 $"{assemblyName.Name}.dll");
 
             if (FileSystems.Default.FileExists(assemblyNameInExecutableDirectory))
             {
-                return AssemblyLoadContext.Default.LoadFromAssemblyPath(assemblyNameInExecutableDirectory);
+                AssemblyLoadContext targetAlc = Framework.Traits.Instance.EscapeHatches.UseCustomLoadContextForDependenciesInToolsDirectory ? this : AssemblyLoadContext.Default;
+                return targetAlc.LoadFromAssemblyPath(assemblyNameInExecutableDirectory);
             }
 
             return null;


### PR DESCRIPTION
Fixes #13286

### Context

When MSBuild resolves dependencies for a task, if it cannot find the dependent assembly in the task assembly's directory, it tries finding it in MSBuild's tools directory. In that case, the dependency is loaded to `AssemblyLoadContext.Default` instead of the task's own ALC, in order to share it across tasks and avoid loading it multiple times.

However, loading it to the default ALC does not reliably work if MSBuild is running on an arbitrary host app (such as by being loaded by `MSBuildLocator`), because it will cause failures if the host app has itself a dependency on an older assembly version than the task's dependency. This is what caused the linked issue.


### Changes Made
Added escape hatch that customers can set up to work around this problem.

### Testing
manual, tested on the provided repro project
