### PR TITLE
Fix thread-unsafe Dictionary in telemetry (#12867)

### DIFF
--- a/src/Build/BackEnd/Components/Logging/ProjectTelemetry.cs
+++ b/src/Build/BackEnd/Components/Logging/ProjectTelemetry.cs
@@ -40,6 +40,7 @@ namespace Microsoft.Build.BackEnd.Logging
         // Telemetry for non-sealed subclasses of Microsoft-owned MSBuild tasks
         // Maps Microsoft task names to counts of their non-sealed usage
         private readonly Dictionary<string, int> _msbuildTaskSubclassUsage = new();
+        private readonly object _subclassUsageLock = new();
 
         /// <summary>
         /// Adds a task execution to the telemetry data.
@@ -107,8 +108,11 @@ namespace Microsoft.Build.BackEnd.Logging
                     // Track it only if it's NOT itself Microsoft-owned (i.e., user-authored subclass)
                     if (!isMicrosoftOwned)
                     {
-                        _msbuildTaskSubclassUsage.TryGetValue(baseTypeName, out int count);
-                        _msbuildTaskSubclassUsage[baseTypeName] = count + 1;
+                        lock (_subclassUsageLock)
+                        {
+                            _msbuildTaskSubclassUsage.TryGetValue(baseTypeName, out int count);
+                            _msbuildTaskSubclassUsage[baseTypeName] = count + 1;
+                        }
                     }
                     // Stop at the first Microsoft-owned base class we find
                     break;
@@ -171,7 +175,10 @@ namespace Microsoft.Build.BackEnd.Logging
 
             _taskHostTasksExecutedCount = 0;
 
-            _msbuildTaskSubclassUsage.Clear();
+            lock (_subclassUsageLock)
+            {
+                _msbuildTaskSubclassUsage.Clear();
+            }
         }
 
         private static void AddCountIfNonZero(Dictionary<string, string> properties, string propertyName, int count)
@@ -217,12 +224,15 @@ namespace Microsoft.Build.BackEnd.Logging
         {
             Dictionary<string, string> properties = new();
 
-            // Add each Microsoft task name with its non-sealed subclass usage count
-            foreach (var kvp in _msbuildTaskSubclassUsage)
+            lock (_subclassUsageLock)
             {
-                // Use a sanitized property name (replace dots with underscores for telemetry)
-                string propertyName = kvp.Key.Replace(".", "_");
-                properties[propertyName] = kvp.Value.ToString(CultureInfo.InvariantCulture);
+                // Add each Microsoft task name with its non-sealed subclass usage count
+                foreach (var kvp in _msbuildTaskSubclassUsage)
+                {
+                    // Use a sanitized property name (replace dots with underscores for telemetry)
+                    string propertyName = kvp.Key.Replace(".", "_");
+                    properties[propertyName] = kvp.Value.ToString(CultureInfo.InvariantCulture);
+                }
             }
 
             return properties;

--- a/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
@@ -19,6 +19,7 @@ using Microsoft.Build.Execution;
 using Microsoft.Build.Experimental.BuildCheck;
 using Microsoft.Build.Experimental.BuildCheck.Infrastructure;
 using Microsoft.Build.Framework;
+using Microsoft.Build.Framework.Telemetry;
 using Microsoft.Build.Internal;
 using Microsoft.Build.Shared;
 using Microsoft.Build.TelemetryInfra;
@@ -1284,6 +1285,10 @@ namespace Microsoft.Build.BackEnd
                 return;
             }
 
+            // Accumulate telemetry into a local instance (no contention — single-owner).
+            // This mirrors the OOP node pattern: each node accumulates locally, then merges once.
+            var localTelemetry = new WorkerNodeTelemetryData();
+
             foreach (var projectTargetInstance in _requestEntry.RequestConfiguration.Project.Targets)
             {
                 bool wasExecuted =
@@ -1314,15 +1319,8 @@ namespace Microsoft.Build.BackEnd
                                (isFromNuget && FileClassifier.Shared.IsMicrosoftPackageInNugetCache(projectTargetInstance.Value.FullPath));
                 }
 
-                telemetryForwarder.AddTarget(
-                    projectTargetInstance.Key,
-                    // would we want to distinguish targets that were executed only during this execution - we'd need
-                    //  to remember target names from ResultsByTarget from before execution
-                    wasExecuted,
-                    isCustom,
-                    isMetaprojTarget,
-                    isFromNuget,
-                    skipReason);
+                var key = new TaskOrTargetTelemetryKey(projectTargetInstance.Key, isCustom, isFromNuget, isMetaprojTarget);
+                localTelemetry.AddTarget(key, wasExecuted, skipReason);
             }
 
             TaskRegistry taskReg = _requestEntry.RequestConfiguration.Project.TaskRegistry;
@@ -1337,13 +1335,17 @@ namespace Microsoft.Build.BackEnd
 
                 foreach (TaskRegistry.RegisteredTaskRecord registeredTaskRecord in taskRegistry.TaskRegistrations.Values.SelectMany(record => record))
                 {
-                    telemetryForwarder.AddTask(
+                    var key = new TaskOrTargetTelemetryKey(
                         registeredTaskRecord.TaskIdentity.Name,
+                        registeredTaskRecord.ComputeIfCustom(),
+                        registeredTaskRecord.IsFromNugetCache,
+                        isFromMetaProject: false);
+
+                    localTelemetry.AddTask(
+                        key,
                         registeredTaskRecord.Statistics.ExecutedTime,
                         registeredTaskRecord.Statistics.ExecutedCount,
                         registeredTaskRecord.Statistics.TotalMemoryConsumption,
-                        registeredTaskRecord.ComputeIfCustom(),
-                        registeredTaskRecord.IsFromNugetCache,
                         registeredTaskRecord.TaskFactoryAttributeName,
                         registeredTaskRecord.TaskFactoryParameters.Runtime);
 
@@ -1352,6 +1354,9 @@ namespace Microsoft.Build.BackEnd
 
                 taskRegistry.Toolset?.InspectInternalTaskRegistry(CollectTasksStats);
             }
+
+            // Single lock acquisition to merge local data into the shared node-level telemetry.
+            telemetryForwarder.MergeWorkerData(localTelemetry);
         }
 
         private static bool IsMetaprojTargetPath(string targetPath) => targetPath.EndsWith(".metaproj", StringComparison.OrdinalIgnoreCase);

--- a/src/Build/TelemetryInfra/ITelemetryForwarder.cs
+++ b/src/Build/TelemetryInfra/ITelemetryForwarder.cs
@@ -4,6 +4,7 @@
 using System;
 using Microsoft.Build.BackEnd.Logging;
 using Microsoft.Build.Framework;
+using Microsoft.Build.Framework.Telemetry;
 
 namespace Microsoft.Build.TelemetryInfra;
 
@@ -35,6 +36,13 @@ internal interface ITelemetryForwarder
     /// <param name="isFromNugetCache">Whether the target is from a NuGet package.</param>
     /// <param name="skipReason">The reason the target was skipped, if applicable.</param>
     void AddTarget(string name, bool wasExecuted, bool isCustom, bool isMetaproj, bool isFromNugetCache, TargetSkipReason skipReason = TargetSkipReason.None);
+
+    /// <summary>
+    /// Merges pre-accumulated per-project telemetry data into the shared node-level telemetry.
+    /// This is the preferred path — accumulate locally (no contention),
+    /// then merge once under a single lock acquisition, mirroring how OOP nodes merge into the main node.
+    /// </summary>
+    void MergeWorkerData(IWorkerNodeTelemetryData data);
 
     void FinalizeProcessing(LoggingContext loggingContext);
 }

--- a/src/Build/TelemetryInfra/TelemetryForwarderProvider.cs
+++ b/src/Build/TelemetryInfra/TelemetryForwarderProvider.cs
@@ -78,6 +78,11 @@ internal class TelemetryForwarderProvider : IBuildComponent
             { BuildEventContext = loggingContext.BuildEventContext };
             loggingContext.LogBuildEvent(telemetryArgs);
         }
+
+        public void MergeWorkerData(IWorkerNodeTelemetryData data)
+        {
+            _workerNodeTelemetryData.Add(data);
+        }
     }
 
     public class NullTelemetryForwarder : ITelemetryForwarder
@@ -87,6 +92,8 @@ internal class TelemetryForwarderProvider : IBuildComponent
         public void AddTask(string name, TimeSpan cumulativeExecutionTime, short executionsCount, long totalMemoryConsumed, bool isCustom, bool isFromNugetCache, string? taskFactoryName, string? taskHostRuntime) { }
 
         public void AddTarget(string name, bool wasExecuted, bool isCustom, bool isMetaproj, bool isFromNugetCache, TargetSkipReason skipReason = TargetSkipReason.None) { }
+
+        public void MergeWorkerData(IWorkerNodeTelemetryData data) { }
 
         public void FinalizeProcessing(LoggingContext loggingContext) { }
     }

--- a/src/Framework.UnitTests/WorkerNodeTelemetryData_Tests.cs
+++ b/src/Framework.UnitTests/WorkerNodeTelemetryData_Tests.cs
@@ -1,0 +1,162 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Build.Framework.Telemetry;
+using Shouldly;
+using Xunit;
+
+namespace Microsoft.Build.Framework.UnitTests;
+
+public class WorkerNodeTelemetryData_Tests
+{
+    /// <summary>
+    /// Tests that concurrent AddTask calls on the same WorkerNodeTelemetryData instance
+    /// do not corrupt the internal dictionary (regression test for #12867).
+    /// </summary>
+    [Fact]
+    public void AddTask_ConcurrentAccess_DoesNotCorrupt()
+    {
+        var telemetryData = new WorkerNodeTelemetryData();
+        const int threadCount = 20;
+        const int iterationsPerThread = 200;
+
+        // Use a barrier to maximize contention by starting all threads simultaneously
+        using var barrier = new Barrier(threadCount);
+
+        var tasks = new Task[threadCount];
+
+        for (int t = 0; t < threadCount; t++)
+        {
+            int threadId = t;
+            tasks[t] = Task.Run(() =>
+            {
+                barrier.SignalAndWait();
+                for (int i = 0; i < iterationsPerThread; i++)
+                {
+                    // Shared key to exercise same-key contention
+                    var sharedKey = new TaskOrTargetTelemetryKey($"SharedTask_{i % 10}", isCustom: false, isFromNugetCache: false, isFromMetaProject: false);
+                    telemetryData.AddTask(sharedKey, TimeSpan.FromMilliseconds(1), executionsCount: 1, totalMemoryConsumption: 100, factoryName: null, taskHostRuntime: null);
+
+                    // Unique key to trigger dictionary resizing
+                    if (i % 5 == 0)
+                    {
+                        var uniqueKey = new TaskOrTargetTelemetryKey($"UniqueTask_{threadId}_{i}", isCustom: false, isFromNugetCache: false, isFromMetaProject: false);
+                        telemetryData.AddTask(uniqueKey, TimeSpan.FromMilliseconds(1), executionsCount: 1, totalMemoryConsumption: 100, factoryName: null, taskHostRuntime: null);
+                    }
+                }
+            });
+        }
+
+        // Should not throw (previously crashed with ArgumentException in Dictionary.Resize)
+        Task.WaitAll(tasks);
+
+        // Verify data integrity: shared tasks should have accumulated counts
+        for (int i = 0; i < 10; i++)
+        {
+            var key = new TaskOrTargetTelemetryKey($"SharedTask_{i}", isCustom: false, isFromNugetCache: false, isFromMetaProject: false);
+            telemetryData.TasksExecutionData.ShouldContainKey(key);
+            telemetryData.TasksExecutionData[key].ExecutionsCount.ShouldBeGreaterThan(0);
+        }
+    }
+
+    /// <summary>
+    /// Tests that concurrent AddTarget calls on the same WorkerNodeTelemetryData instance
+    /// do not corrupt the internal dictionary (regression test for #12867).
+    /// </summary>
+    [Fact]
+    public void AddTarget_ConcurrentAccess_DoesNotCorrupt()
+    {
+        var telemetryData = new WorkerNodeTelemetryData();
+        const int threadCount = 20;
+        const int iterationsPerThread = 200;
+
+        using var barrier = new Barrier(threadCount);
+
+        var tasks = new Task[threadCount];
+
+        for (int t = 0; t < threadCount; t++)
+        {
+            int threadId = t;
+            tasks[t] = Task.Run(() =>
+            {
+                barrier.SignalAndWait();
+                for (int i = 0; i < iterationsPerThread; i++)
+                {
+                    // Shared key to exercise same-key contention
+                    var sharedKey = new TaskOrTargetTelemetryKey($"SharedTarget_{i % 10}", isCustom: false, isFromNugetCache: false, isFromMetaProject: false);
+                    telemetryData.AddTarget(sharedKey, wasExecuted: i % 2 == 0, skipReason: TargetSkipReason.None);
+
+                    // Unique key to trigger dictionary resizing
+                    if (i % 5 == 0)
+                    {
+                        var uniqueKey = new TaskOrTargetTelemetryKey($"UniqueTarget_{threadId}_{i}", isCustom: false, isFromNugetCache: false, isFromMetaProject: false);
+                        telemetryData.AddTarget(uniqueKey, wasExecuted: true, skipReason: TargetSkipReason.None);
+                    }
+                }
+            });
+        }
+
+        // Should not throw
+        Task.WaitAll(tasks);
+
+        // Verify data integrity
+        for (int i = 0; i < 10; i++)
+        {
+            var key = new TaskOrTargetTelemetryKey($"SharedTarget_{i}", isCustom: false, isFromNugetCache: false, isFromMetaProject: false);
+            telemetryData.TargetsExecutionData.ShouldContainKey(key);
+        }
+    }
+
+    /// <summary>
+    /// Tests that concurrent Add (merge) calls on the same WorkerNodeTelemetryData instance
+    /// do not corrupt the internal dictionaries (regression test for #12867).
+    /// </summary>
+    [Fact]
+    public void Add_ConcurrentMerge_DoesNotCorrupt()
+    {
+        var telemetryData = new WorkerNodeTelemetryData();
+        const int threadCount = 20;
+
+        using var barrier = new Barrier(threadCount);
+
+        var tasks = new Task[threadCount];
+
+        for (int t = 0; t < threadCount; t++)
+        {
+            int threadId = t;
+            tasks[t] = Task.Run(() =>
+            {
+                // Each thread creates its own data and merges it
+                var localData = new WorkerNodeTelemetryData();
+                for (int i = 0; i < 50; i++)
+                {
+                    var key = new TaskOrTargetTelemetryKey($"Task_{i}", isCustom: false, isFromNugetCache: false, isFromMetaProject: false);
+                    localData.AddTask(key, TimeSpan.FromMilliseconds(1), executionsCount: 1, totalMemoryConsumption: 100, factoryName: null, taskHostRuntime: null);
+
+                    var targetKey = new TaskOrTargetTelemetryKey($"Target_{i}", isCustom: false, isFromNugetCache: false, isFromMetaProject: false);
+                    localData.AddTarget(targetKey, wasExecuted: true);
+                }
+
+                barrier.SignalAndWait();
+                // All threads merge into the shared instance at the same time
+                telemetryData.Add(localData);
+            });
+        }
+
+        // Should not throw
+        Task.WaitAll(tasks);
+
+        // Verify all tasks and targets are present
+        for (int i = 0; i < 50; i++)
+        {
+            var key = new TaskOrTargetTelemetryKey($"Task_{i}", isCustom: false, isFromNugetCache: false, isFromMetaProject: false);
+            telemetryData.TasksExecutionData.ShouldContainKey(key);
+            // Each of 20 threads contributed 1 execution
+            telemetryData.TasksExecutionData[key].ExecutionsCount.ShouldBe(threadCount);
+        }
+    }
+}

--- a/src/Framework/Telemetry/WorkerNodeTelemetryData.cs
+++ b/src/Framework/Telemetry/WorkerNodeTelemetryData.cs
@@ -8,6 +8,8 @@ namespace Microsoft.Build.Framework.Telemetry;
 
 internal class WorkerNodeTelemetryData : IWorkerNodeTelemetryData
 {
+    private readonly object _lock = new();
+
     public WorkerNodeTelemetryData(Dictionary<TaskOrTargetTelemetryKey, TaskExecutionStats> tasksExecutionData, Dictionary<TaskOrTargetTelemetryKey, TargetExecutionStats> targetsExecutionData)
     {
         TasksExecutionData = tasksExecutionData;
@@ -16,21 +18,39 @@ internal class WorkerNodeTelemetryData : IWorkerNodeTelemetryData
 
     public void Add(IWorkerNodeTelemetryData other)
     {
-        foreach (var task in other.TasksExecutionData)
+        lock (_lock)
         {
-            AddTask(task.Key, task.Value.CumulativeExecutionTime, task.Value.ExecutionsCount, task.Value.TotalMemoryBytes, task.Value.TaskFactoryName, task.Value.TaskHostRuntime);
-        }
+            foreach (var task in other.TasksExecutionData)
+            {
+                AddTaskUnsafe(task.Key, task.Value.CumulativeExecutionTime, task.Value.ExecutionsCount, task.Value.TotalMemoryBytes, task.Value.TaskFactoryName, task.Value.TaskHostRuntime);
+            }
 
-        foreach (var target in other.TargetsExecutionData)
-        {
-            AddTarget(target.Key, target.Value.WasExecuted, target.Value.SkipReason);
+            foreach (var target in other.TargetsExecutionData)
+            {
+                AddTargetUnsafe(target.Key, target.Value.WasExecuted, target.Value.SkipReason);
+            }
         }
     }
 
     public void AddTask(TaskOrTargetTelemetryKey task, TimeSpan cumulativeExecutionTime, int executionsCount, long totalMemoryConsumption, string? factoryName, string? taskHostRuntime)
     {
-        TaskExecutionStats? taskExecutionStats;
-        if (!TasksExecutionData.TryGetValue(task, out taskExecutionStats))
+        lock (_lock)
+        {
+            AddTaskUnsafe(task, cumulativeExecutionTime, executionsCount, totalMemoryConsumption, factoryName, taskHostRuntime);
+        }
+    }
+
+    public void AddTarget(TaskOrTargetTelemetryKey target, bool wasExecuted, TargetSkipReason skipReason = TargetSkipReason.None)
+    {
+        lock (_lock)
+        {
+            AddTargetUnsafe(target, wasExecuted, skipReason);
+        }
+    }
+
+    private void AddTaskUnsafe(TaskOrTargetTelemetryKey task, TimeSpan cumulativeExecutionTime, int executionsCount, long totalMemoryConsumption, string? factoryName, string? taskHostRuntime)
+    {
+        if (!TasksExecutionData.TryGetValue(task, out TaskExecutionStats? taskExecutionStats))
         {
             taskExecutionStats = new(cumulativeExecutionTime, executionsCount, totalMemoryConsumption, factoryName, taskHostRuntime);
             TasksExecutionData[task] = taskExecutionStats;
@@ -45,7 +65,7 @@ internal class WorkerNodeTelemetryData : IWorkerNodeTelemetryData
         }
     }
 
-    public void AddTarget(TaskOrTargetTelemetryKey target, bool wasExecuted, TargetSkipReason skipReason = TargetSkipReason.None)
+    private void AddTargetUnsafe(TaskOrTargetTelemetryKey target, bool wasExecuted, TargetSkipReason skipReason = TargetSkipReason.None)
     {
         if (TargetsExecutionData.TryGetValue(target, out var existingStats))
         {


### PR DESCRIPTION
## Summary

Fixes #12867 — `Dictionary` corruption crash in telemetry when building with `/m /mt`.

## Problem

In **out-of-proc mode** (`/m` only), each worker node runs in a separate process with its own `TelemetryForwarderProvider` singleton, so its `WorkerNodeTelemetryData` dictionaries are only accessed by one thread. At end-of-build, each node sends a single `WorkerNodeTelemetryEventArgs` message and the main node merges them one at a time. No contention, no problem.

In **in-proc multithreaded mode** (`/m /mt`), all in-proc nodes share a single process and therefore a single `TelemetryForwarderProvider` singleton. Multiple `RequestBuilder` instances run on dedicated threads (`DedicatedThreadsTaskScheduler`) and call `AddTask`/`AddTarget` concurrently on the **same** `Dictionary<>` fields. This causes `Dictionary.Resize` corruption — an `ArgumentException` or silent data loss on every build with enough parallelism.

**Reproduction:** 20 non-SDK .NET Framework library projects + 1 exe referencing all of them, built with `MSBuild.exe Repro.sln /m /mt`. Crashed 12/12 times before this fix.

## Approach

Rather than switching to `ConcurrentDictionary` (which has per-operation stripe-lock overhead and requires `AddOrUpdate` with lambda allocations for the check-then-act pattern), this PR makes the `/mt` path match the OOP architecture:

**Before:** `RequestBuilder.UpdateStatisticsPostBuild` called `telemetryForwarder.AddTask()`/`AddTarget()` once per target and once per task — each call individually hitting the shared singleton dictionary. For a project with 300 targets and 15 tasks, that was 315 lock-needing mutations on the shared state per project.

**After:** `UpdateStatisticsPostBuild` creates a **local** `WorkerNodeTelemetryData`, accumulates all targets and tasks into it (zero contention — single owner, no lock needed), then calls `telemetryForwarder.MergeWorkerData(localData)` once. This does a single `Add()` to merge into the shared singleton under one lock acquisition. For 32 projects, that is 32 lock acquisitions total.

Additionally, `WorkerNodeTelemetryData.AddTask`/`AddTarget`/`Add` are now protected by `lock` to guard the merge path and any remaining direct callers. `ProjectTelemetry._msbuildTaskSubclassUsage` gets the same treatment.

## Changes

| File | Change |
|------|--------|
| `WorkerNodeTelemetryData.cs` | Added `lock` around `AddTask`/`AddTarget`/`Add`; extracted private `Unsafe` variants to avoid nested locking |
| `ProjectTelemetry.cs` | Added `lock` around `_msbuildTaskSubclassUsage` dictionary access |
| `ITelemetryForwarder.cs` | Added `MergeWorkerData(IWorkerNodeTelemetryData)` to interface |
| `TelemetryForwarderProvider.cs` | Implemented `MergeWorkerData` in `TelemetryForwarder` and `NullTelemetryForwarder` |
| `RequestBuilder.cs` | Refactored `UpdateStatisticsPostBuild` to local-accumulate + single merge; constructs `TaskOrTargetTelemetryKey` directly |
| `WorkerNodeTelemetryData_Tests.cs` | 3 new concurrency regression tests (AddTask, AddTarget, Add merge) using 20 threads + Barrier |

## Verification

| Scenario | Before | After |
|----------|--------|-------|
| E2E: 20-project `/m /mt` incremental build × 20 runs | 12/12 crashes | **20/20 pass** |
| Unit tests: concurrent AddTask/AddTarget/Add | N/A | **3/3 pass** |
