### PR TITLE
Fix CodeSign.MissingSigningCert for xsd/Update-MSBuildXsds.ps1

### DIFF
--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -4,7 +4,7 @@
          and thus this file is not populated to VisualStudioSetupInsertionPath -->
     <ItemsToSign Include="$(VisualStudioSetupInsertionPath)Microsoft.Build.UnGAC.exe" Condition="'$(MSBuildRuntimeType)' != 'Core'" />
 
-    <ItemsToSign Include="$(ArtifactsDir)\xsd\Update-MSBuildXsds.ps1" Condition="Exists('$(ArtifactsDir)\xsd\Update-MSBuildXsds.ps1')" />
+    <ItemsToSign Include="$(ArtifactsDir)\xsd\Update-MSBuildXsds.ps1" />
 
     <!-- Do not include if it is test signing due to arcade issue with validation. -->
     <ItemsToSign Remove="$(VisualStudioSetupInsertionPath)Microsoft.Build.Arm64.vsix" Condition="'$(SignType)' == 'test'"/>


### PR DESCRIPTION
## Summary

PR #13175 accidentally replaced the `ItemsToSign Include` for `Update-MSBuildXsds.ps1` with a conditional `Remove`, meaning the file was never added to signing. CodeSignValidation then flagged it as unsigned (`CodeSign.MissingSigningCert`).

## Change

Restore the original unconditional `Include` in `eng/Signing.props`. The broken `Remove` (which was removing an item that was never added) is deleted.

## Why this is safe

- **MSBuild official build** (Windows): The `CopyXsds` target produces the file in `artifacts\xsd`. The `Include` ensures it gets signed. This is consumed by VS insertion via `CustomScriptExecutionCommand` in `vs-insertion.yml`.
- **Source-build** (Linux, `dotnet/dotnet`): Signing is test/disabled, so the `Include` is harmless.
- **dotnet official build** (Windows): Does not run CodeSignValidation on component-level artifacts.

Fixes AB#2787495
