### PR TITLE
Update remote-host-object.md with SDK .tlb shipping and IDispatch example

### DIFF
--- a/documentation/specs/remote-host-object.md
+++ b/documentation/specs/remote-host-object.md
@@ -39,7 +39,7 @@ With the `.tlb` included in the SDK, the MSBuild apphost gains full support for:
 
 - **Remote host objects via the Running Object Table (ROT)** — IDE hosts (such as Visual Studio) can register host objects that out-of-proc MSBuild worker nodes retrieve through `IRunningObjectTable::GetObject`. This is the mechanism that allows build tasks running in separate processes to access unsaved file changes from the IDE.
 - **Registration-free COM for `ITaskHost`** — the apphost's manifest (`MSBuild.exe.manifest`) references the `.tlb` to enable COM proxy/stub generation without requiring any machine-wide registry entries. This makes the SDK's MSBuild fully portable and xcopy-deployable.
-- **Parity with Visual Studio's MSBuild** — the SDK-shipped MSBuild apphost now has the same COM interop capabilities as the VS-shipped `msbuild.exe`, ensuring consistent behavior regardless of how MSBuild is invoked.
+- **Parity with Visual Studio's MSBuild** — the SDK-shipped MSBuild apphost now has the same COM interop capabilities as the VS-shipped `msbuild.exe`, ensuring consistent behavior regardless of how MSBuild tasks are executed.
 
 ### SDK layout
 


### PR DESCRIPTION
Update `remote-host-object.md` with documentation for the MSBuild apphost changes.

### What's added

1. **Shipping `Microsoft.Build.Framework.tlb` with the .NET SDK** - documents that the `.tlb` ships starting from 10.0.3xx, explains why it's needed (COM marshaling for `ITaskHost` across process boundaries), what capabilities it enables (ROT host objects, registration-free COM, parity with VS), and shows the SDK layout.

2. **Practical `IDispatch` example** - end-to-end example showing how a VS host object (WebTools) serializes task items to JSON via `QueryAllTaskItems`, and how the SDK Container task ([dotnet/sdk#52856](https://github.com/dotnet/sdk/pull/52856)) calls it via `IDispatch` (reflection `InvokeMember`) with a fallback to the legacy in-proc path.

Related PRs:
- dotnet/msbuild#13175 (Add App Host Support for MSBuild)
- dotnet/sdk#52856 (Refactor VSHostObject for COM compatibility)
- [WebTools PR 701336](https://dev.azure.com/devdiv/DevDiv/_git/WebTools/pullrequest/701336)