### PR TITLE
Add VMR codeflow health check to pipelines skill

### DIFF
--- a/.github/skills/pipelines-health-check/SKILL.md
+++ b/.github/skills/pipelines-health-check/SKILL.md
@@ -65,7 +65,7 @@ WorkIQ is not required for the core health check. If unavailable, the skill will
 
 ### Step 1: Run all data collection scripts
 
-Run these three scripts from the repository root. They output JSON to stdout.
+Run these three scripts from the repository root **in parallel**. They output JSON to stdout. Each script may take 1–3 minutes depending on the number of PRs and pipeline runs to fetch, so use an `initial_wait` of **120 seconds** or higher.
 
 ```powershell
 # Pipeline health (checks both MSBuild and MSBuild-OptProf)
@@ -78,7 +78,9 @@ $prJson = & .\.github\skills\pipelines-health-check\check-vs-pr-status.ps1
 $vmrJson = & .\.github\skills\pipelines-health-check\check-vmr-codeflow.ps1
 ```
 
-The pipeline and VS PR scripts rely on the `az` CLI for authentication. The VMR codeflow script uses `gh` CLI for authenticated GitHub API access and unauthenticated Azure DevOps REST API for the public dnceng-public org.
+All scripts write progress messages to stderr (`Write-Host`) and the JSON result to stdout.
+
+The scripts sanitize error messages (stripping control characters, truncating to 500 chars) so the JSON output can be parsed directly with `ConvertFrom-Json` without additional cleanup.
 
 ### Step 2: Present the overview table IMMEDIATELY
 
@@ -379,3 +381,8 @@ WorkIQ queries Microsoft 365 data (Outlook, Teams, SharePoint). Results depend o
 - The dotnet-unified-build pipeline runs in `dnceng-public/public`, which is publicly accessible
 - If no runs appear, the pipeline may not have been triggered yet for that PR
 - Codeflow PRs may take a few minutes after creation before CI triggers
+
+### JSON output too large or contains unexpected characters
+- Error messages from Azure DevOps timelines can contain Windows paths, control characters, and multi-KB stack traces
+- The scripts sanitize and truncate these to 500 characters — if you still see issues, check that you're running the latest version of the scripts
+- Use `ConvertFrom-Json` in PowerShell or `json.loads()` in Python to parse the output; avoid manual string manipulation

--- a/.github/skills/pipelines-health-check/check-pipeline-health.ps1
+++ b/.github/skills/pipelines-health-check/check-pipeline-health.ps1
@@ -87,6 +87,31 @@ function Get-LastSuccessfulRun {
     return $runs[0]
 }
 
+function Sanitize-ErrorString {
+    <#
+    .SYNOPSIS
+        Cleans an error string for safe JSON serialization: strips control
+        characters and truncates to a reasonable length.
+    #>
+    param(
+        [string]$Text,
+        [int]$MaxLength = 500
+    )
+
+    if ([string]::IsNullOrEmpty($Text)) { return "" }
+
+    # Strip control characters (0x00-0x1F) except common whitespace (\n \r \t)
+    $cleaned = $Text -replace '[\x00-\x08\x0B\x0C\x0E-\x1F]', ''
+    # Collapse runs of whitespace (newlines, tabs, spaces) into a single space
+    $cleaned = $cleaned -replace '\s+', ' '
+    $cleaned = $cleaned.Trim()
+
+    if ($cleaned.Length -gt $MaxLength) {
+        $cleaned = $cleaned.Substring(0, $MaxLength) + "..."
+    }
+    return $cleaned
+}
+
 function Get-FailedTasksFromTimeline {
     param([int]$BuildId)
     $url = "$Organization/$Project/_apis/build/builds/$BuildId/timeline?api-version=7.1"
@@ -103,7 +128,9 @@ function Get-FailedTasksFromTimeline {
     foreach ($task in $failedTasks) {
         $errors = @()
         if ($task.issues) {
-            $errors = @($task.issues | Where-Object { $_.type -eq "error" } | ForEach-Object { $_.message })
+            $errors = @($task.issues | Where-Object { $_.type -eq "error" } | ForEach-Object {
+                Sanitize-ErrorString -Text $_.message
+            })
         }
         $results += [PSCustomObject]@{
             name   = $task.name

--- a/.github/skills/pipelines-health-check/check-vmr-codeflow.ps1
+++ b/.github/skills/pipelines-health-check/check-vmr-codeflow.ps1
@@ -227,7 +227,9 @@ function Get-FailedJobsFromTimeline {
         foreach ($task in $failedTasks) {
             $errors = @()
             if ($task.issues) {
-                $errors = @($task.issues | Where-Object { $_.type -eq "error" } | ForEach-Object { $_.message })
+                $errors = @($task.issues | Where-Object { $_.type -eq "error" } | ForEach-Object {
+                    Sanitize-ErrorString -Text $_.message
+                })
             }
             $taskDetails += [ordered]@{
                 name   = $task.name
@@ -246,28 +248,43 @@ function Get-FailedJobsFromTimeline {
         }
     }
 
-    # Also collect all stages and their results for the overview
-    $stages = @($timeline.records | Where-Object { $_.type -eq "Stage" } | ForEach-Object {
-        [ordered]@{
-            name   = $_.name
-            state  = $_.state
-            result = $_.result
-        }
-    })
-
-    $allJobs = @($timeline.records | Where-Object { $_.type -eq "Job" } | ForEach-Object {
-        [ordered]@{
-            name   = $_.name
-            state  = $_.state
-            result = $_.result
-        }
-    })
+    # Compact job summary: count by result instead of listing every job
+    $jobSummary = [ordered]@{
+        total     = @($timeline.records | Where-Object { $_.type -eq "Job" }).Count
+        succeeded = @($timeline.records | Where-Object { $_.type -eq "Job" -and $_.result -eq "succeeded" }).Count
+        failed    = @($timeline.records | Where-Object { $_.type -eq "Job" -and $_.result -eq "failed" }).Count
+        skipped   = @($timeline.records | Where-Object { $_.type -eq "Job" -and ($_.result -eq "skipped" -or $_.result -eq "canceled") }).Count
+    }
 
     return [ordered]@{
         failedJobs = $failedJobs
-        stages     = $stages
-        allJobs    = $allJobs
+        jobSummary = $jobSummary
     }
+}
+
+function Sanitize-ErrorString {
+    <#
+    .SYNOPSIS
+        Cleans an error string for safe JSON serialization: strips control
+        characters and truncates to a reasonable length.
+    #>
+    param(
+        [string]$Text,
+        [int]$MaxLength = 500
+    )
+
+    if ([string]::IsNullOrEmpty($Text)) { return "" }
+
+    # Strip control characters (0x00-0x1F) except common whitespace (\n \r \t)
+    $cleaned = $Text -replace '[\x00-\x08\x0B\x0C\x0E-\x1F]', ''
+    # Collapse runs of whitespace (newlines, tabs, spaces) into a single space
+    $cleaned = $cleaned -replace '\s+', ' '
+    $cleaned = $cleaned.Trim()
+
+    if ($cleaned.Length -gt $MaxLength) {
+        $cleaned = $cleaned.Substring(0, $MaxLength) + "..."
+    }
+    return $cleaned
 }
 
 function Get-FailureCategory {
@@ -307,7 +324,7 @@ if ($codeflowPRs.Count -eq 0) {
         codeflowPRs   = @()
         summary       = "No open codeflow PRs found from $SourceRepo."
     }
-    $output | ConvertTo-Json -Depth 8
+    $output | ConvertTo-Json -Depth 10
     return
 }
 
@@ -319,7 +336,18 @@ foreach ($pr in $codeflowPRs) {
     # Get upstream PRs included in this codeflow
     $upstreamPRNumbers = Get-IncludedUpstreamPRs -PullNumber $pr.number
     $upstreamPRDetails = @()
-    foreach ($num in $upstreamPRNumbers) {
+
+    # Fetch details for up to 30 upstream PRs to keep output manageable.
+    # For larger batches, only the first 30 get full details; the rest are
+    # listed as numbers so the agent knows they exist.
+    $maxDetailedPRs = 30
+    $detailedNumbers = $upstreamPRNumbers | Select-Object -First $maxDetailedPRs
+    $remainingNumbers = @()
+    if ($upstreamPRNumbers.Count -gt $maxDetailedPRs) {
+        $remainingNumbers = @($upstreamPRNumbers | Select-Object -Skip $maxDetailedPRs)
+        Write-Host "  Found $($upstreamPRNumbers.Count) upstream PRs; fetching details for $maxDetailedPRs, listing rest as numbers." -ForegroundColor Yellow
+    }
+    foreach ($num in $detailedNumbers) {
         $upstreamPRDetails += Get-UpstreamPRDetails -PullNumber $num
     }
 
@@ -342,8 +370,7 @@ foreach ($pr in $codeflowPRs) {
         # Get timeline details for completed builds
         if ($run.status -eq "completed") {
             $timelineInfo = Get-FailedJobsFromTimeline -BuildId $run.id
-            $runObj.stages = $timelineInfo.stages
-            $runObj.allJobs = $timelineInfo.allJobs
+            $runObj.jobSummary = $timelineInfo.jobSummary
             $runObj.failedJobs = $timelineInfo.failedJobs
 
             # Categorize failures
@@ -358,8 +385,7 @@ foreach ($pr in $codeflowPRs) {
         elseif ($run.status -eq "inProgress") {
             # Get current state of in-progress build
             $timelineInfo = Get-FailedJobsFromTimeline -BuildId $run.id
-            $runObj.stages = $timelineInfo.stages
-            $runObj.allJobs = $timelineInfo.allJobs
+            $runObj.jobSummary = $timelineInfo.jobSummary
             $runObj.failedJobs = $timelineInfo.failedJobs
         }
 
@@ -452,6 +478,8 @@ foreach ($pr in $codeflowPRs) {
         createdAt       = $pr.created_at
         updatedAt       = $pr.updated_at
         upstreamPRs     = @($upstreamPRDetails)
+        upstreamPRCount = $upstreamPRNumbers.Count
+        additionalUpstreamPRNumbers = @($remainingNumbers)
         pipelineRuns    = @($runResults)
         healthSummary   = $healthSummary
         failureCorrelation = @($failureCorrelation)
@@ -479,4 +507,4 @@ $output = [PSCustomObject][ordered]@{
     summary       = ($summaryParts -join ". ") + "."
 }
 
-$output | ConvertTo-Json -Depth 8
+$output | ConvertTo-Json -Depth 10


### PR DESCRIPTION
## Summary

Extends the pipelines-health-check skill to monitor VMR (dotnet/dotnet) codeflow PRs and the \dotnet-unified-build\ pipeline.

### Changes

**New: \check-vmr-codeflow.ps1\**
- Finds open codeflow PRs from dotnet/msbuild → dotnet/dotnet via GitHub API
- Gets \dotnet-unified-build\ pipeline runs from \dnceng-public/public\ via Azure DevOps REST API
- Extracts failed jobs/tasks with error messages from build timelines
- Categorizes failures (TASK_HOST, COMPILATION, BUILD_COMMAND, SIGNING, NUGET_AUTH, etc.)
- Parses PR comments to extract included upstream msbuild PR numbers
- **Correlates failures with upstream PRs** by matching error categories to PR title keywords
- Outputs structured JSON with health summary per codeflow PR

**Updated: \SKILL.md\**
- Added VMR triggers in 'When to Use' and frontmatter description
- Added \dotnet-unified-build\ pipeline reference and key URLs
- Added \\\ data collection step
- Added VMR Codeflow PRs table rendering with failure details and upstream PR listing
- Added VMR codeflow failure/stale as new problem types
- Added subagent prompt template for VMR codeflow failure investigation with change correlation
- Added VMR-specific troubleshooting entries

### Motivation

When MSBuild source changes are codeflowed into the VMR, the \dotnet-unified-build\ pipeline validates them. Failures there (like the recent MSB4216 task host errors from the app host changes) weren't covered by the existing skill. This addition lets the agent automatically detect VMR failures and correlate them back to the specific msbuild PRs that likely caused them.

### Testing

Tested locally — script successfully found 2 open codeflow PRs (#5183, #5204), identified TASK_HOST failures, and correlated them with upstream PRs.