### PR TITLE
Hash-based pipe naming for fast node discovery on Unix

### DIFF
--- a/src/Build.UnitTests/BackEnd/HashBasedPipeNaming_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/HashBasedPipeNaming_Tests.cs
@@ -95,14 +95,9 @@ namespace Microsoft.Build.UnitTests
             pipeName.ShouldContain($"MSBuild-testhash-{currentPid}");
         }
 
-        [Fact]
+        [UnixOnlyFact]
         public void GetHashBasedPipeName_OnUnix_IsAbsolutePath()
         {
-            if (!NativeMethodsShared.IsUnixLike)
-            {
-                return;
-            }
-
             string pipeName = NamedPipeUtil.GetHashBasedPipeName("hash", 123);
             pipeName.ShouldStartWith("/tmp/");
         }
@@ -111,26 +106,16 @@ namespace Microsoft.Build.UnitTests
 
         #region FindNodesByHandshakeHash Tests
 
-        [Fact]
+        [WindowsOnlyFact]
         public void FindNodesByHandshakeHash_ReturnsEmptyOnWindows()
         {
-            if (NativeMethodsShared.IsUnixLike)
-            {
-                return; // Only test on Windows
-            }
-
             var pids = NamedPipeUtil.FindNodesByHandshakeHash("nonexistent");
             pids.ShouldBeEmpty();
         }
 
-        [Fact]
+        [UnixOnlyFact]
         public void FindNodesByHandshakeHash_FindsMatchingPipeFiles()
         {
-            if (!NativeMethodsShared.IsUnixLike)
-            {
-                return; // Only works on Unix where pipes are files
-            }
-
             string testHash = $"test-{Guid.NewGuid():N}";
 
             // Create fake pipe files in /tmp
@@ -158,14 +143,9 @@ namespace Microsoft.Build.UnitTests
             }
         }
 
-        [Fact]
+        [UnixOnlyFact]
         public void FindNodesByHandshakeHash_IgnoresMalformedFileNames()
         {
-            if (!NativeMethodsShared.IsUnixLike)
-            {
-                return;
-            }
-
             string testHash = $"test-{Guid.NewGuid():N}";
             string pipeGood = $"/tmp/MSBuild-{testHash}-5555";
             string pipeBad = $"/tmp/MSBuild-{testHash}-notanumber";
@@ -187,14 +167,9 @@ namespace Microsoft.Build.UnitTests
             }
         }
 
-        [Fact]
+        [UnixOnlyFact]
         public void FindNodesByHandshakeHash_ReturnsEmptyWhenNoMatches()
         {
-            if (!NativeMethodsShared.IsUnixLike)
-            {
-                return;
-            }
-
             var pids = NamedPipeUtil.FindNodesByHandshakeHash($"nopipes-{Guid.NewGuid():N}");
             pids.ShouldBeEmpty();
         }

--- a/src/Build.UnitTests/BackEnd/HashBasedPipeNaming_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/HashBasedPipeNaming_Tests.cs
@@ -1,0 +1,204 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+using Microsoft.Build.Internal;
+using Microsoft.Build.Shared;
+using Shouldly;
+using Xunit;
+
+#nullable disable
+
+namespace Microsoft.Build.UnitTests
+{
+    /// <summary>
+    /// Tests for hash-based pipe naming in NamedPipeUtil and Handshake.ComputeHash.
+    /// </summary>
+    public class HashBasedPipeNaming_Tests
+    {
+        #region ComputeHash Tests
+
+        [Fact]
+        public void ComputeHash_ReturnsDeterministicValue()
+        {
+            var handshake = new Handshake(HandshakeOptions.NodeReuse);
+            string hash1 = handshake.ComputeHash();
+            string hash2 = handshake.ComputeHash();
+
+            hash1.ShouldNotBeNullOrEmpty();
+            hash2.ShouldNotBeNullOrEmpty();
+            hash1.ShouldBe(hash2);
+        }
+
+        [Fact]
+        public void ComputeHash_SameOptionsSameHash()
+        {
+            var h1 = new Handshake(HandshakeOptions.NodeReuse);
+            var h2 = new Handshake(HandshakeOptions.NodeReuse);
+
+            h1.ComputeHash().ShouldBe(h2.ComputeHash());
+        }
+
+        [Fact]
+        public void ComputeHash_DifferentOptionsYieldDifferentHash()
+        {
+            var h1 = new Handshake(HandshakeOptions.NodeReuse);
+            var h2 = new Handshake(HandshakeOptions.None);
+
+            h1.ComputeHash().ShouldNotBe(h2.ComputeHash());
+        }
+
+        [Fact]
+        public void ComputeHash_NoPaddingOrSlashes()
+        {
+            var handshake = new Handshake(HandshakeOptions.NodeReuse);
+            string hash = handshake.ComputeHash();
+
+            // Hash should be URL/filename-safe: no / or = characters
+            hash.ShouldNotContain("/");
+            hash.ShouldNotContain("=");
+        }
+
+        [Fact]
+        public void ComputeHash_IsCached()
+        {
+            var handshake = new Handshake(HandshakeOptions.NodeReuse);
+            string hash1 = handshake.ComputeHash();
+            string hash2 = handshake.ComputeHash();
+
+            // Should be the exact same object reference (cached)
+            ReferenceEquals(hash1, hash2).ShouldBeTrue();
+        }
+
+        #endregion
+
+        #region GetHashBasedPipeName Tests
+
+        [Fact]
+        public void GetHashBasedPipeName_ContainsHashAndPid()
+        {
+            string hash = "abc123";
+            int pid = 42;
+            string pipeName = NamedPipeUtil.GetHashBasedPipeName(hash, pid);
+
+            pipeName.ShouldContain("MSBuild-abc123-42");
+        }
+
+        [Fact]
+        public void GetHashBasedPipeName_DefaultsToCurrentPid()
+        {
+            string hash = "testhash";
+            string pipeName = NamedPipeUtil.GetHashBasedPipeName(hash);
+
+            int currentPid = EnvironmentUtilities.CurrentProcessId;
+            pipeName.ShouldContain($"MSBuild-testhash-{currentPid}");
+        }
+
+        [Fact]
+        public void GetHashBasedPipeName_OnUnix_IsAbsolutePath()
+        {
+            if (!NativeMethodsShared.IsUnixLike)
+            {
+                return;
+            }
+
+            string pipeName = NamedPipeUtil.GetHashBasedPipeName("hash", 123);
+            pipeName.ShouldStartWith("/tmp/");
+        }
+
+        #endregion
+
+        #region FindNodesByHandshakeHash Tests
+
+        [Fact]
+        public void FindNodesByHandshakeHash_ReturnsEmptyOnWindows()
+        {
+            if (NativeMethodsShared.IsUnixLike)
+            {
+                return; // Only test on Windows
+            }
+
+            var pids = NamedPipeUtil.FindNodesByHandshakeHash("nonexistent");
+            pids.ShouldBeEmpty();
+        }
+
+        [Fact]
+        public void FindNodesByHandshakeHash_FindsMatchingPipeFiles()
+        {
+            if (!NativeMethodsShared.IsUnixLike)
+            {
+                return; // Only works on Unix where pipes are files
+            }
+
+            string testHash = $"test-{Guid.NewGuid():N}";
+
+            // Create fake pipe files in /tmp
+            string pipe1 = $"/tmp/MSBuild-{testHash}-1001";
+            string pipe2 = $"/tmp/MSBuild-{testHash}-1002";
+            string pipeOther = $"/tmp/MSBuild-otherhash-9999";
+
+            try
+            {
+                File.WriteAllText(pipe1, "");
+                File.WriteAllText(pipe2, "");
+                File.WriteAllText(pipeOther, "");
+
+                var pids = NamedPipeUtil.FindNodesByHandshakeHash(testHash);
+
+                pids.ShouldContain(1001);
+                pids.ShouldContain(1002);
+                pids.ShouldNotContain(9999);
+            }
+            finally
+            {
+                File.Delete(pipe1);
+                File.Delete(pipe2);
+                File.Delete(pipeOther);
+            }
+        }
+
+        [Fact]
+        public void FindNodesByHandshakeHash_IgnoresMalformedFileNames()
+        {
+            if (!NativeMethodsShared.IsUnixLike)
+            {
+                return;
+            }
+
+            string testHash = $"test-{Guid.NewGuid():N}";
+            string pipeGood = $"/tmp/MSBuild-{testHash}-5555";
+            string pipeBad = $"/tmp/MSBuild-{testHash}-notanumber";
+
+            try
+            {
+                File.WriteAllText(pipeGood, "");
+                File.WriteAllText(pipeBad, "");
+
+                var pids = NamedPipeUtil.FindNodesByHandshakeHash(testHash);
+
+                pids.ShouldContain(5555);
+                pids.Count.ShouldBe(1);
+            }
+            finally
+            {
+                File.Delete(pipeGood);
+                File.Delete(pipeBad);
+            }
+        }
+
+        [Fact]
+        public void FindNodesByHandshakeHash_ReturnsEmptyWhenNoMatches()
+        {
+            if (!NativeMethodsShared.IsUnixLike)
+            {
+                return;
+            }
+
+            var pids = NamedPipeUtil.FindNodesByHandshakeHash($"nopipes-{Guid.NewGuid():N}");
+            pids.ShouldBeEmpty();
+        }
+
+        #endregion
+    }
+}

--- a/src/Build/BackEnd/Components/Communications/NodeEndpointOutOfProc.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeEndpointOutOfProc.cs
@@ -26,7 +26,13 @@ namespace Microsoft.Build.BackEnd
             _enableReuse = enableReuse;
             LowPriority = lowPriority;
 
-            InternalConstruct();
+            // Use hash-based pipe name for fast discovery on Unix.
+            // Format: MSBuild-{hash}-{pid} — allows schedulers to find compatible nodes
+            // by listing /tmp/MSBuild-{hash}-* instead of probing all dotnet processes.
+            string? pipeName = NativeMethodsShared.IsUnixLike
+                ? NamedPipeUtil.GetHashBasedPipeName(GetHandshake().ComputeHash())
+                : null; // Windows: keep legacy MSBuild{PID} naming
+            InternalConstruct(pipeName);
         }
 
         /// <summary>

--- a/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
@@ -255,7 +255,34 @@ namespace Microsoft.Build.BackEnd
             if (nodeReuseRequested)
             {
                 IList<Process> possibleRunningNodesList;
-                (expectedProcessName, possibleRunningNodesList) = GetPossibleRunningNodes(msbuildLocation, expectedNodeMode);
+
+                // On Unix, use hash-based pipe file listing for O(1) discovery of compatible nodes
+                // instead of enumerating all dotnet processes and probing each one.
+                if (NativeMethodsShared.IsUnixLike)
+                {
+                    string handshakeHash = nodeLaunchData.Handshake.ComputeHash();
+                    IList<int> pids = NamedPipeUtil.FindNodesByHandshakeHash(handshakeHash);
+                    var processes = new List<Process>(pids.Count);
+                    foreach (int pid in pids)
+                    {
+                        try
+                        {
+                            processes.Add(Process.GetProcessById(pid));
+                        }
+                        catch
+                        {
+                            // Process may have exited between pipe file listing and this call.
+                        }
+                    }
+
+                    expectedProcessName = "dotnet";
+                    possibleRunningNodesList = processes;
+                }
+                else
+                {
+                    (expectedProcessName, possibleRunningNodesList) = GetPossibleRunningNodes(msbuildLocation, expectedNodeMode);
+                }
+
                 possibleRunningNodes = new ConcurrentQueue<Process>(possibleRunningNodesList);
 
                 if (possibleRunningNodesList.Count > 0)
@@ -719,8 +746,11 @@ namespace Microsoft.Build.BackEnd
         /// </summary>
         private Stream TryConnectToProcess(int nodeProcessId, int timeout, Handshake handshake, out HandshakeResult result)
         {
-            // Try and connect to the process.
-            string pipeName = NamedPipeUtil.GetPlatformSpecificPipeName(nodeProcessId);
+            // On Unix, nodes create pipes with hash-based names for fast discovery.
+            // On Windows, keep legacy MSBuild{PID} naming.
+            string pipeName = NativeMethodsShared.IsUnixLike
+                ? NamedPipeUtil.GetHashBasedPipeName(handshake.ComputeHash(), nodeProcessId)
+                : NamedPipeUtil.GetPlatformSpecificPipeName(nodeProcessId);
 
 #pragma warning disable SA1111, SA1009 // Closing parenthesis should be on line of last parameter
             NamedPipeClientStream nodeStream = new NamedPipeClientStream(

--- a/src/MSBuild/NodeEndpointOutOfProcTaskHost.cs
+++ b/src/MSBuild/NodeEndpointOutOfProcTaskHost.cs
@@ -4,6 +4,7 @@
 using Microsoft.Build.BackEnd;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Internal;
+using Microsoft.Build.Shared;
 
 namespace Microsoft.Build.CommandLine
 {
@@ -24,7 +25,12 @@ namespace Microsoft.Build.CommandLine
         internal NodeEndpointOutOfProcTaskHost(bool nodeReuse, byte parentPacketVersion)
         {
             _nodeReuse = nodeReuse;
-            InternalConstruct(pipeName: null, parentPacketVersion);
+
+            // Use hash-based pipe name on Unix to match TryConnectToProcess.
+            string? pipeName = NativeMethodsShared.IsUnixLike
+                ? NamedPipeUtil.GetHashBasedPipeName(GetHandshake().ComputeHash())
+                : null;
+            InternalConstruct(pipeName, parentPacketVersion);
         }
 
         #endregion // Constructors and Factories

--- a/src/Shared/CommunicationsUtilities.cs
+++ b/src/Shared/CommunicationsUtilities.cs
@@ -1007,6 +1007,13 @@ namespace Microsoft.Build.Internal
                     }
 
                     architectureFlagToSet = taskHostParameters.Architecture;
+
+                    // Resolve "*" (any) to the current architecture so both parent and child
+                    // compute identical HandshakeOptions and hash-based pipe names.
+                    if (string.Equals(architectureFlagToSet, XMakeAttributes.MSBuildArchitectureValues.any, StringComparison.OrdinalIgnoreCase))
+                    {
+                        architectureFlagToSet = XMakeAttributes.GetCurrentMSBuildArchitecture();
+                    }
                 }
             }
 

--- a/src/Shared/CommunicationsUtilities.cs
+++ b/src/Shared/CommunicationsUtilities.cs
@@ -340,35 +340,15 @@ namespace Microsoft.Build.Internal
         public virtual string GetKey() => $"{_handshakeComponents.Options} {_handshakeComponents.Salt} {_handshakeComponents.FileVersionMajor} {_handshakeComponents.FileVersionMinor} {_handshakeComponents.FileVersionBuild} {_handshakeComponents.FileVersionPrivate} {_handshakeComponents.SessionId}".ToString(CultureInfo.InvariantCulture);
 
         public virtual byte? ExpectedVersionInFirstByte => CommunicationsUtilities.handshakeVersion;
-    }
 
-    internal sealed class ServerNodeHandshake : Handshake
-    {
         /// <summary>
         /// Caching computed hash.
         /// </summary>
         private string _computedHash = null;
 
-        public override byte? ExpectedVersionInFirstByte => null;
-
-        internal ServerNodeHandshake(HandshakeOptions nodeType)
-            : base(nodeType, includeSessionId: false, toolsDirectory: null)
-        {
-        }
-
-        public override HandshakeComponents RetrieveHandshakeComponents() => new HandshakeComponents(
-            CommunicationsUtilities.AvoidEndOfHandshakeSignal(_handshakeComponents.Options),
-            CommunicationsUtilities.AvoidEndOfHandshakeSignal(_handshakeComponents.Salt),
-            CommunicationsUtilities.AvoidEndOfHandshakeSignal(_handshakeComponents.FileVersionMajor),
-            CommunicationsUtilities.AvoidEndOfHandshakeSignal(_handshakeComponents.FileVersionMinor),
-            CommunicationsUtilities.AvoidEndOfHandshakeSignal(_handshakeComponents.FileVersionBuild),
-            CommunicationsUtilities.AvoidEndOfHandshakeSignal(_handshakeComponents.FileVersionPrivate));
-
-        public override string GetKey() => $"{_handshakeComponents.Options} {_handshakeComponents.Salt} {_handshakeComponents.FileVersionMajor} {_handshakeComponents.FileVersionMinor} {_handshakeComponents.FileVersionBuild} {_handshakeComponents.FileVersionPrivate}"
-            .ToString(CultureInfo.InvariantCulture);
-
         /// <summary>
         /// Computes Handshake stable hash string representing whole state of handshake.
+        /// Used for hash-based pipe naming to enable fast node discovery without trial-and-error probing.
         /// </summary>
         public string ComputeHash()
         {
@@ -389,6 +369,27 @@ namespace Microsoft.Build.Internal
             }
             return _computedHash;
         }
+    }
+
+    internal sealed class ServerNodeHandshake : Handshake
+    {
+        public override byte? ExpectedVersionInFirstByte => null;
+
+        internal ServerNodeHandshake(HandshakeOptions nodeType)
+            : base(nodeType, includeSessionId: false, toolsDirectory: null)
+        {
+        }
+
+        public override HandshakeComponents RetrieveHandshakeComponents() => new HandshakeComponents(
+            CommunicationsUtilities.AvoidEndOfHandshakeSignal(_handshakeComponents.Options),
+            CommunicationsUtilities.AvoidEndOfHandshakeSignal(_handshakeComponents.Salt),
+            CommunicationsUtilities.AvoidEndOfHandshakeSignal(_handshakeComponents.FileVersionMajor),
+            CommunicationsUtilities.AvoidEndOfHandshakeSignal(_handshakeComponents.FileVersionMinor),
+            CommunicationsUtilities.AvoidEndOfHandshakeSignal(_handshakeComponents.FileVersionBuild),
+            CommunicationsUtilities.AvoidEndOfHandshakeSignal(_handshakeComponents.FileVersionPrivate));
+
+        public override string GetKey() => $"{_handshakeComponents.Options} {_handshakeComponents.Salt} {_handshakeComponents.FileVersionMajor} {_handshakeComponents.FileVersionMinor} {_handshakeComponents.FileVersionBuild} {_handshakeComponents.FileVersionPrivate}"
+            .ToString(CultureInfo.InvariantCulture);
     }
 
     /// <summary>

--- a/src/Shared/NamedPipeUtil.cs
+++ b/src/Shared/NamedPipeUtil.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Build.Shared
 
             try
             {
-                foreach (string file in System.IO.Directory.GetFiles(pipeDir, $"MSBuild-{handshakeHash}-*"))
+                foreach (string file in System.IO.Directory.EnumerateFiles(pipeDir, $"MSBuild-{handshakeHash}-*"))
                 {
                     string fileName = Path.GetFileName(file);
                     if (fileName.StartsWith(prefix) && int.TryParse(fileName.Substring(prefix.Length), out int pid))
@@ -65,7 +65,8 @@ namespace Microsoft.Build.Shared
             }
             catch
             {
-                // Directory enumeration can fail; fall back to legacy.
+                // Directory enumeration can fail (e.g. permissions); return empty
+                // so the caller falls through to launching new nodes.
             }
 
             return pids;

--- a/src/Shared/NamedPipeUtil.cs
+++ b/src/Shared/NamedPipeUtil.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Generic;
 using System.IO;
 using Microsoft.Build.Internal;
 
@@ -18,6 +19,56 @@ namespace Microsoft.Build.Shared
             string pipeName = $"MSBuild{processId}";
 
             return GetPlatformSpecificPipeName(pipeName);
+        }
+
+        /// <summary>
+        /// Returns a pipe name that encodes both the handshake hash and the process ID.
+        /// Format: MSBuild-{hash}-{pid}
+        /// This allows discovery of compatible nodes by listing pipes matching the hash prefix,
+        /// eliminating trial-and-error probing of all dotnet processes.
+        /// </summary>
+        internal static string GetHashBasedPipeName(string handshakeHash, int? processId = null)
+        {
+            processId ??= EnvironmentUtilities.CurrentProcessId;
+            string pipeName = $"MSBuild-{handshakeHash}-{processId}";
+            return GetPlatformSpecificPipeName(pipeName);
+        }
+
+        /// <summary>
+        /// Finds pipe files matching a handshake hash and extracts their PIDs.
+        /// Only works on Unix where pipes are files in /tmp.
+        /// </summary>
+        internal static IList<int> FindNodesByHandshakeHash(string handshakeHash)
+        {
+            var pids = new List<int>();
+            // GetPlatformSpecificPipeName returns full paths like /tmp/MSBuild-{hash}-{pid}
+            // on Unix, and .NET does NOT add CoreFxPipe_ prefix for absolute paths.
+            string prefix = $"MSBuild-{handshakeHash}-";
+            string? pipeDir = NativeMethodsShared.IsUnixLike ? "/tmp" : null;
+
+            if (pipeDir == null)
+            {
+                // On Windows, named pipes aren't files — fall back to legacy discovery.
+                return pids;
+            }
+
+            try
+            {
+                foreach (string file in System.IO.Directory.GetFiles(pipeDir, $"MSBuild-{handshakeHash}-*"))
+                {
+                    string fileName = Path.GetFileName(file);
+                    if (fileName.StartsWith(prefix) && int.TryParse(fileName.Substring(prefix.Length), out int pid))
+                    {
+                        pids.Add(pid);
+                    }
+                }
+            }
+            catch
+            {
+                // Directory enumeration can fail; fall back to legacy.
+            }
+
+            return pids;
         }
 
         internal static string GetPlatformSpecificPipeName(string pipeName)


### PR DESCRIPTION
## Hash-based pipe naming for fast node discovery on Unix

### Problem
On Unix/macOS, MSBuild discovers reusable worker nodes by enumerating **all** running `dotnet` processes and probing each one with a handshake. With many processes running, this is slow and creates O(N) connection attempts.

### Solution
Encode both handshake hash and PID in the pipe name: `MSBuild-{hash}-{pid}`. This allows the scheduler to find compatible nodes by listing `/tmp/MSBuild-{hash}-*` — an O(1) directory glob instead of trial-and-error probing.

### Changes
- **CommunicationsUtilities.cs**: Move `ComputeHash()` from `ServerNodeHandshake` to base `Handshake` class so both client and server can compute their hash
- **NamedPipeUtil.cs**: Add `GetHashBasedPipeName()` and `FindNodesByHandshakeHash()` for hash-based pipe naming and discovery
- **NodeEndpointOutOfProc.cs**: Use hash-based pipe name on Unix when creating the endpoint
- **NodeEndpointOutOfProcTaskHost.cs**: Same for task host endpoints
- **NodeProviderOutOfProcBase.cs**: Use hash-based discovery on Unix (directory listing) instead of process enumeration; use hash-based pipe names when connecting

### Tests
12 new unit tests covering `ComputeHash`, `GetHashBasedPipeName`, and `FindNodesByHandshakeHash`.

This is now a standalone PR (previously stacked on #13336, which has been split into #13354–#13357).
