### PR TITLE
Use .exe.config when loading "as full Framework"

### DIFF
--- a/src/Shared/BuildEnvironmentHelper.cs
+++ b/src/Shared/BuildEnvironmentHelper.cs
@@ -568,12 +568,14 @@ namespace Microsoft.Build.Shared
                 currentToolsDirectory = currentMSBuildExeFile.Directory;
 
                 CurrentMSBuildToolsDirectory = currentMSBuildExeFile.DirectoryName;
-                const string configFileExtension =
+                string configFileExtension =
 #if NET
-                    ".dll.config"; // Compat with what we looked for before 18.5
-#else
-                    ".exe.config";
+                    // Prior to 18.6, we looked at MSBuild.dll.config for core scenarios
+                    // EXCEPT in the force-full-framework case when we loaded the
+                    // full-framework copy of MSBuild.exe.config.
+                    !Traits.Instance.ForceEvaluateAsFullFramework ? ".dll.config" :
 #endif
+                    ".exe.config";
                 CurrentMSBuildConfigurationFile = Path.ChangeExtension(currentMSBuildExePath, configFileExtension);
                 MSBuildToolsDirectory32 = CurrentMSBuildToolsDirectory;
                 MSBuildToolsDirectory64 = CurrentMSBuildToolsDirectory;


### PR DESCRIPTION
c8011cb0 broke the internal `quickbuild.exe` parse step, because it
started looking for `MSBuild.dll.config` from the Visual Studio
install folder, instead of the `MSBuild.exe.config` that is actually
present there.

Fix confirmed by private patch of the quickbuild repo.
