### PR TITLE
Stage 3: Forward BuildProjectFile* callbacks from OOP TaskHost to worker node

### DIFF
--- a/documentation/specs/multithreading/taskhost-threading.md
+++ b/documentation/specs/multithreading/taskhost-threading.md
@@ -12,10 +12,10 @@ The main thread runs `OutOfProcTaskHostNode.Run()`, a `WaitHandle.WaitAny` loop 
 
 | Index | Event | Handler |
 |-------|-------|---------|
-| 0 | `_shutdownEvent` | `HandleShutdown()` — joins the task thread, cleans up, exits |
-| 1 | `_packetReceivedEvent` | `HandlePacket()` — dispatches incoming IPC packets |
-| 2 | `_taskCompleteEvent` | `CompleteTask()` — sends `TaskHostTaskComplete` to owning worker node |
-| 3 | `_taskCancelledEvent` | `CancelTask()` — calls `ICancelableTask.Cancel()` on the task |
+| 0 | `_shutdownEvent` | `HandleShutdown()` -- joins the task thread, cleans up, exits |
+| 1 | `_packetReceivedEvent` | `HandlePacket()` -- dispatches incoming IPC packets |
+| 2 | `_taskCompleteEvent` | `CompleteTask()` -- sends `TaskHostTaskComplete` to owning worker node |
+| 3 | `_taskCancelledEvent` | `CancelTask()` -- calls `ICancelableTask.Cancel()` on the task |
 
 This thread is responsible for all IPC: receiving packets from the owning worker node (task configuration, cancellation, callback responses) and sending packets back (log messages, task completion, callback requests).
 
@@ -26,7 +26,7 @@ When the main thread receives a `TaskHostConfiguration` packet, it spawns the ta
 1. Sets up the environment (working directory, env vars, culture)
 2. Loads the task assembly and instantiates the task
 3. Sets task parameters via reflection
-4. Calls `task.Execute()` — for tasks implementing `IMultiThreadableTask`, the default `TaskEnvironment` (backed by `MultiProcessTaskEnvironmentDriver`) is available, providing safe access to the task host process's working directory and environment variables
+4. Calls `task.Execute()` -- for tasks implementing `IMultiThreadableTask`, the default `TaskEnvironment` (backed by `MultiProcessTaskEnvironmentDriver`) is available, providing safe access to the task host process's working directory and environment variables
 5. Collects output parameters
 6. Packages the result into `TaskHostTaskComplete` and signals `_taskCompleteEvent`
 
@@ -34,9 +34,9 @@ The task runner thread is where user task code runs. Any `IBuildEngine` calls fr
 
 ## IBuildEngine Callback Flow (added in Stage 1)
 
-Before callback support, the two threads had a simple lifecycle: the main thread spawned the task thread, waited for completion, and sent the result. Communication was one-directional (worker node → TaskHost for configuration/cancellation, TaskHost → worker node for logs/completion).
+Before callback support, the two threads had a simple lifecycle: the main thread spawned the task thread, waited for completion, and sent the result. Communication was one-directional (worker node -> TaskHost for configuration/cancellation, TaskHost -> worker node for logs/completion).
 
-With callback support, the task can query the owning worker node for information it doesn't have locally (e.g., `IsRunningMultipleNodes`, and in future stages: `RequestCores`, `BuildProjectFile`). This introduces **bidirectional IPC** between the threads:
+With callback support, the task can query the owning worker node for information it doesn't have locally (e.g., `IsRunningMultipleNodes`, `RequestCores`, `BuildProjectFile`). This introduces **bidirectional IPC** between the threads:
 
 ```mermaid
 sequenceDiagram
@@ -77,7 +77,7 @@ The callback wait intentionally does **not** check `_taskCancelledEvent`. This a
 
 Cancellation is handled cooperatively: after the callback returns, the task checks its cancellation state (set by `ICancelableTask.Cancel()`) and exits.
 
-> **Future opportunity:** Unlike in-process mode where callbacks are direct method calls that cannot be interrupted, the IPC-based callback mechanism *could* support cancellation-aware callbacks — for example, by failing the pending `TaskCompletionSource` when `_taskCancelledEvent` is signaled. This would let long-running callbacks like `BuildProjectFile` abort immediately on cancellation rather than waiting for the worker node to process and respond. This is not implemented today for consistency with in-process behavior, but the mechanism is in place if needed.
+> **Future opportunity:** Unlike in-process mode where callbacks are direct method calls that cannot be interrupted, the IPC-based callback mechanism *could* support cancellation-aware callbacks -- for example, by failing the pending `TaskCompletionSource` when `_taskCancelledEvent` is signaled. This would let long-running callbacks like `BuildProjectFile` abort immediately on cancellation rather than waiting for the worker node to process and respond. This is not implemented today for consistency with in-process behavior, but the mechanism is in place if needed.
 
 The only exception path is connection loss (owning worker node killed), detected by `OnLinkStatusChanged` which fails all pending `TaskCompletionSource` entries with `InvalidOperationException`. This unblocks task threads immediately.
 
@@ -87,17 +87,73 @@ There is a causal dependency chain that prevents deadlock:
 
 ```
 Worker node sends callback response
-  → TaskHost callback returns
-    → task finishes Execute()
-      → TaskHost sends TaskHostTaskComplete
-        → worker node exits packet loop
+  -> TaskHost callback returns
+    -> task finishes Execute()
+      -> TaskHost sends TaskHostTaskComplete
+        -> worker node exits packet loop
 ```
 
 The worker node cannot exit its packet loop without first receiving `TaskHostTaskComplete`. But `TaskHostTaskComplete` cannot be sent until the task finishes. And the task cannot finish while it is blocked waiting for a callback response. Therefore, the worker node **must** process the callback request and send the response before it can ever stop.
 
+## BuildProjectFile Callback Flow (added in Stage 3)
+
+Tasks running in the TaskHost can call `BuildProjectFile` to build other projects. All four overloads normalize to the canonical 6-param form and send a `TaskHostBuildRequest` packet to the owning worker node, which forwards the call to the in-process `IBuildEngine3.BuildProjectFilesInParallel`.
+
+### Block-for-Callback Pattern
+
+When a task calls `BuildProjectFile`, the TaskHost blocks so the scheduler can reuse the process for nested tasks:
+
+```mermaid
+sequenceDiagram
+    participant TR as Task Runner Thread
+    participant MT as Main Thread
+    participant PP as Owning Worker Node
+    participant SC as Scheduler
+
+    TR->>TR: BlockForCallback()<br/>(blocked++, active--)
+    TR->>MT: TaskHostBuildRequest<br/>(blocks on TCS)
+    activate TR
+
+    MT->>PP: TaskHostBuildRequest packet
+    PP->>SC: BuildProjectFilesInParallel()
+
+    Note over SC: Child project needs same TaskHost runtime
+    SC->>PP: Schedule nested task to same TaskHost
+    PP->>MT: TaskHostConfiguration (nested)
+    MT->>MT: HandleTaskHostConfiguration()<br/>(starts Thread-B)
+
+    Note over MT: Thread-B executes nested task
+    MT-->>PP: TaskHostTaskComplete (nested)
+    PP-->>SC: Nested task done
+
+    SC-->>PP: BuildProjectFile result
+    PP-->>MT: TaskHostBuildResponse
+    MT->>MT: HandleCallbackResponse()<br/>(sets TCS result)
+    MT-->>TR: TCS unblocks
+    deactivate TR
+    TR->>TR: ResumeAfterCallback()<br/>(active++, blocked--)
+```
+
+### Counter Management
+
+Two counters track the TaskHost's availability:
+
+- `_activeTaskCount`: Number of tasks actively executing. A non-zero count prevents new tasks from being scheduled.
+- `_blockedTaskCount`: Number of tasks blocked on a callback. A blocked task does NOT prevent new tasks from being scheduled.
+
+**Transition ordering**: When blocking, increment `_blockedTaskCount` BEFORE decrementing `_activeTaskCount`. When resuming, the reverse. This ensures the sum is never zero during transition.
+
+### Handler Stack (Process Reuse)
+
+`NodeProviderOutOfProcTaskHost` uses a `Stack<INodePacketHandler>` to manage multiple `TaskHostTask` handlers on the same node. Push on nested task dispatch, peek for packet routing, pop on nested task completion.
+
+### Per-Task Isolation (TaskExecutionContext)
+
+Each task gets a `TaskExecutionContext` stored in `_taskContexts` (ConcurrentDictionary) and accessed via `_currentTaskContext` (AsyncLocal). The context holds configuration, saved environment (CWD, env vars, warning settings), pending callback requests, and execution state. `EffectiveConfiguration` reads from the per-task context first, falling back to `_currentConfiguration`.
+
 ## TaskHost Lifecycle
 
-The TaskHost process can execute multiple tasks sequentially. After finishing one task, it returns to an idle state and waits for either a new task or a shutdown signal.
+The TaskHost process can execute multiple tasks, both sequentially and concurrently. After finishing one task, it returns to an idle state and waits for either a new task or a shutdown signal. When a task calls `BuildProjectFile`, the TaskHost blocks (incrementing `_blockedTaskCount`, then decrementing `_activeTaskCount`), allowing the scheduler to dispatch a nested task to the same process while the outer task is blocked waiting for the callback response.
 
 ### Event Loop Cycle
 
@@ -112,21 +168,21 @@ stateDiagram-v2
 ```
 
 1. **Idle**: `WaitAny()` blocks on the four wait handles. No task thread exists. `_currentConfiguration` is null.
-2. **TaskHostConfiguration arrives**: `HandleTaskHostConfiguration()` stores the config and spawns `_taskRunnerThread` to call `RunTask()`. The main thread immediately returns to `WaitAny()`.
-3. **Task executes**: `RunTask()` sets up the environment, loads the task assembly, calls `task.Execute()`, collects output parameters, and packages the result into `_taskCompletePacket`. On completion (success or failure), it signals `_taskCompleteEvent`.
-4. **CompleteTask()**: The main thread wakes on index 2, sends `_taskCompletePacket` to the owning worker node, and sets `_currentConfiguration = null`. The node is now idle again.
+2. **TaskHostConfiguration arrives**: `HandleTaskHostConfiguration()` stores the config and spawns a task runner thread (stored in `TaskExecutionContext.ExecutingThread`) to call `RunTask()`. The main thread immediately returns to `WaitAny()`.
+3. **Task executes**: `RunTask()` sets up the environment, loads the task assembly, calls `task.Execute()`, collects output parameters, and stores the result in `_taskCompletePacket`. On completion (success or failure), it signals `_taskCompleteEvent`.
+4. **CompleteTask()**: The main thread wakes on index 2, sends `_taskCompletePacket` as a `TaskHostTaskComplete` packet to the owning worker node. When no tasks remain active or blocked, it clears `_currentConfiguration`. The node is now idle again.
 5. **Back to step 1**: The main thread loops back to `WaitAny()`, ready for another `TaskHostConfiguration` or a `NodeBuildComplete`.
 
 ### State Between Tasks
 
 Each new `TaskHostConfiguration` carries a full environment snapshot, task parameters, and warning settings. The task runner thread resets per-task state at the start of `RunTask()`:
 
-**Reset per task:** `_isTaskExecuting`, `_currentConfiguration`, `_debugCommunications`, `_updateEnvironment`, `WarningsAsErrors`/`WarningsNotAsErrors`/`WarningsAsMessages`, `_fileAccessData`
+**Reset per task:** `_currentConfiguration`, `_debugCommunications`, `_updateEnvironment`, `_warningsAsErrors`/`_warningsNotAsErrors`/`_warningsAsMessages`, `_fileAccessData`, per-task `TaskExecutionContext`
 
 **Persists across tasks (within a single build):**
-- `s_mismatchedEnvironmentValues` (static) — environment variable fixups for bitness differences, computed once per process
-- `_registeredTaskObjectCache` — task object cache with `Build` lifetime scope, disposed at end of each build (in `HandleShutdown()`), recreated fresh on the next `Run()` call
-- `_pendingCallbackRequests` / `_nextCallbackRequestId` — callback tracking (should be empty between tasks)
+- `s_mismatchedEnvironmentValues` (static) -- environment variable fixups for bitness differences, computed once per process
+- `_registeredTaskObjectCache` -- task object cache with `Build` lifetime scope, disposed at end of each build (in `HandleShutdown()`), recreated fresh on the next `Run()` call
+- `_pendingCallbackRequests` / `_nextCallbackRequestId` -- callback tracking (should be empty between tasks)
 
 ### Shutdown vs. Reuse
 
@@ -135,4 +191,4 @@ When the owning worker node sends `NodeBuildComplete`, `HandleNodeBuildComplete(
 - **Sidecar TaskHost** (`_nodeReuse = true`): Always sets `BuildCompleteReuse`. The sidecar process persists across builds, re-entering the `Run()` outer loop to accept new connections.
 - **Regular TaskHost** (`_nodeReuse = false`): Sets `BuildCompleteReuse` only if `buildComplete.PrepareForReuse` is true **and** `Traits.Instance.EscapeHatches.ReuseTaskHostNodes` is enabled. Otherwise sets `BuildComplete` and the process exits. This avoids holding assembly locks on custom task DLLs between builds.
 
-There is **no idle timeout**. The `WaitAny()` call has no timeout parameter — the TaskHost waits indefinitely until it receives a shutdown signal or the connection drops.
+There is **no idle timeout**. The `WaitAny()` call has no timeout parameter -- the TaskHost waits indefinitely until it receives a shutdown signal or the connection drops.

--- a/src/Build.UnitTests/BackEnd/BuildProjectFileAndReportPidTask.cs
+++ b/src/Build.UnitTests/BackEnd/BuildProjectFileAndReportPidTask.cs
@@ -1,0 +1,73 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections;
+using System.Diagnostics;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace Microsoft.Build.UnitTests.BackEnd
+{
+    /// <summary>
+    /// A test task that reports its process ID and optionally calls BuildProjectFile
+    /// on a child project. Used by TaskHost reuse E2E tests to verify that a parent
+    /// task and a nested child task run in the same OOP TaskHost process.
+    /// </summary>
+    public class BuildProjectFileAndReportPidTask : Task
+    {
+        /// <summary>
+        /// Path to the project file to build. If empty, just reports PID without building.
+        /// </summary>
+        public string ProjectFile { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Semicolon-separated list of Property=Value pairs to pass as global properties.
+        /// </summary>
+        public string Properties { get; set; } = string.Empty;
+
+        /// <summary>
+        /// The process ID of the TaskHost running this task.
+        /// </summary>
+        [Output]
+        public int ProcessId { get; set; }
+
+        /// <summary>
+        /// Whether the child build succeeded (only meaningful when ProjectFile is set).
+        /// </summary>
+        [Output]
+        public bool BuildSucceeded { get; set; }
+
+        public override bool Execute()
+        {
+            ProcessId = Process.GetCurrentProcess().Id;
+            Log.LogMessage(MessageImportance.High, $"TASKHOST_PID={ProcessId}");
+
+            if (!string.IsNullOrEmpty(ProjectFile))
+            {
+                Hashtable? globalProperties = null;
+                if (!string.IsNullOrEmpty(Properties))
+                {
+                    globalProperties = new Hashtable();
+                    foreach (string pair in Properties.Split(';'))
+                    {
+                        string[] parts = pair.Split(new[] { '=' }, 2);
+                        if (parts.Length == 2)
+                        {
+                            globalProperties[parts[0].Trim()] = parts[1].Trim();
+                        }
+                    }
+                }
+
+                Hashtable targetOutputs = new();
+                BuildSucceeded = BuildEngine.BuildProjectFile(ProjectFile, null, globalProperties, targetOutputs);
+                Log.LogMessage(MessageImportance.High, $"BuildProjectFile({ProjectFile}) = {BuildSucceeded}");
+            }
+            else
+            {
+                BuildSucceeded = true;
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/Build.UnitTests/BackEnd/BuildProjectFileTask.cs
+++ b/src/Build.UnitTests/BackEnd/BuildProjectFileTask.cs
@@ -1,0 +1,91 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections;
+using System.Collections.Generic;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace Microsoft.Build.UnitTests.BackEnd
+{
+    /// <summary>
+    /// A test task that calls IBuildEngine.BuildProjectFile to build another project.
+    /// Used by TaskHostCallback_Tests (in-process) and NetTaskHost_E2E_Tests (cross-runtime).
+    /// The E2E project includes this file via linked compile to avoid duplication.
+    /// </summary>
+    public class BuildProjectFileTask : Task
+    {
+        /// <summary>
+        /// Path to the project file to build.
+        /// </summary>
+        [Required]
+        public string ProjectFile { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Semicolon-separated list of targets to build. If empty, builds default targets.
+        /// </summary>
+        public string Targets { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Semicolon-separated list of Property=Value pairs to pass as global properties.
+        /// </summary>
+        public string Properties { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Whether the child build succeeded.
+        /// </summary>
+        [Output]
+        public bool BuildSucceeded { get; set; }
+
+        /// <summary>
+        /// Target output items from the child build (if any).
+        /// </summary>
+        [Output]
+        public ITaskItem[] OutputItems { get; set; } = [];
+
+        public override bool Execute()
+        {
+            string[]? targetNames = null;
+            if (!string.IsNullOrEmpty(Targets))
+            {
+                targetNames = Targets.Split(';');
+            }
+
+            Hashtable? globalProperties = null;
+            if (!string.IsNullOrEmpty(Properties))
+            {
+                globalProperties = new Hashtable();
+                foreach (string pair in Properties.Split(';'))
+                {
+                    string[] parts = pair.Split('=');
+                    if (parts.Length == 2)
+                    {
+                        globalProperties[parts[0].Trim()] = parts[1].Trim();
+                    }
+                }
+            }
+
+            Hashtable targetOutputs = new();
+
+            BuildSucceeded = BuildEngine.BuildProjectFile(ProjectFile, targetNames, globalProperties, targetOutputs);
+
+            // Collect all targets' outputs as ITaskItem[] if available.
+            if (BuildSucceeded && targetOutputs.Count > 0)
+            {
+                var items = new List<ITaskItem>();
+                foreach (DictionaryEntry entry in targetOutputs)
+                {
+                    if (entry.Value is ITaskItem[] taskItems)
+                    {
+                        items.AddRange(taskItems);
+                    }
+                }
+
+                OutputItems = items.ToArray();
+            }
+
+            Log.LogMessage(MessageImportance.High, $"BuildProjectFile({ProjectFile}) = {BuildSucceeded}, OutputItems={OutputItems.Length}");
+            return true;
+        }
+    }
+}

--- a/src/Build.UnitTests/BackEnd/TaskHostCallbackPacket_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/TaskHostCallbackPacket_Tests.cs
@@ -1,7 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
+using System.Collections.Generic;
 using Microsoft.Build.BackEnd;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Execution;
 using Shouldly;
 using Xunit;
 
@@ -9,7 +13,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
 {
     /// <summary>
     /// Pure unit tests for TaskHost callback packet serialization.
-    /// No I/O or BuildManager — just round-trip translation.
+    /// No I/O or BuildManager -- just round-trip translation.
     /// </summary>
     public class TaskHostCallbackPacket_Tests
     {
@@ -83,6 +87,116 @@ namespace Microsoft.Build.UnitTests.BackEnd
             deserialized.RequestId.ShouldBe(99);
             deserialized.GrantedCores.ShouldBe(grantedCores);
             deserialized.Type.ShouldBe(NodePacketType.TaskHostCoresResponse);
+        }
+
+        [Fact]
+        public void TaskHostBuildRequest_RoundTrip_Serialization()
+        {
+            Dictionary<string, string>?[] globalProps = [new(StringComparer.OrdinalIgnoreCase) { ["Configuration"] = "Release" }, null];
+            List<string>?[] removeProps = [new() { "Platform" }, null];
+            string?[] toolsVersions = ["17.0", null];
+            var request = new TaskHostBuildRequest(
+                ["proj1.csproj", "proj2.csproj"],
+                ["Build", "Test"],
+                globalProps,
+                removeProps,
+                toolsVersions!,
+                returnTargetOutputs: true);
+            request.RequestId = 55;
+
+            ITranslator writeTranslator = TranslationHelpers.GetWriteTranslator();
+            request.Translate(writeTranslator);
+
+            ITranslator readTranslator = TranslationHelpers.GetReadTranslator();
+            var deserialized = (TaskHostBuildRequest)TaskHostBuildRequest.FactoryForDeserialization(readTranslator);
+
+            deserialized.RequestId.ShouldBe(55);
+            deserialized.Type.ShouldBe(NodePacketType.TaskHostBuildRequest);
+            deserialized.ProjectFileNames.ShouldBe(["proj1.csproj", "proj2.csproj"]);
+            deserialized.TargetNames.ShouldBe(["Build", "Test"]);
+            deserialized.ToolsVersions.ShouldBe(toolsVersions!);
+            deserialized.ReturnTargetOutputs.ShouldBeTrue();
+            deserialized.GlobalProperties!.Length.ShouldBe(2);
+            deserialized.GlobalProperties![0]!["Configuration"].ShouldBe("Release");
+            deserialized.GlobalProperties[1].ShouldBeNull();
+            deserialized.RemoveGlobalProperties!.Length.ShouldBe(2);
+            deserialized.RemoveGlobalProperties![0].ShouldBe(["Platform"]);
+            deserialized.RemoveGlobalProperties[1].ShouldBeNull();
+        }
+
+        [Fact]
+        public void TaskHostBuildRequest_NullArrays_RoundTrip_Serialization()
+        {
+            var request = new TaskHostBuildRequest(
+                null, null, null, null, null, returnTargetOutputs: false);
+            request.RequestId = 10;
+
+            ITranslator writeTranslator = TranslationHelpers.GetWriteTranslator();
+            request.Translate(writeTranslator);
+
+            ITranslator readTranslator = TranslationHelpers.GetReadTranslator();
+            var deserialized = (TaskHostBuildRequest)TaskHostBuildRequest.FactoryForDeserialization(readTranslator);
+
+            deserialized.RequestId.ShouldBe(10);
+            deserialized.ProjectFileNames.ShouldBeNull();
+            deserialized.TargetNames.ShouldBeNull();
+            deserialized.GlobalProperties.ShouldBeNull();
+            deserialized.RemoveGlobalProperties.ShouldBeNull();
+            deserialized.ToolsVersions.ShouldBeNull();
+            deserialized.ReturnTargetOutputs.ShouldBeFalse();
+        }
+
+        [Fact]
+        public void TaskHostBuildResponse_Success_WithOutputs_RoundTrip_Serialization()
+        {
+            var outputs = new List<Dictionary<string, TaskParameter>>
+            {
+                new(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["Build"] = new TaskParameter(new ITaskItem[] { new Utilities.TaskItem("item1.dll") }),
+                    ["Test"] = new TaskParameter(new ITaskItem[] { new Utilities.TaskItem("result.trx") })
+                }
+            };
+
+            var response = new TaskHostBuildResponse(88, true, outputs);
+
+            ITranslator writeTranslator = TranslationHelpers.GetWriteTranslator();
+            response.Translate(writeTranslator);
+
+            ITranslator readTranslator = TranslationHelpers.GetReadTranslator();
+            var deserialized = (TaskHostBuildResponse)TaskHostBuildResponse.FactoryForDeserialization(readTranslator);
+
+            deserialized.RequestId.ShouldBe(88);
+            deserialized.Success.ShouldBeTrue();
+            deserialized.Type.ShouldBe(NodePacketType.TaskHostBuildResponse);
+            deserialized.TargetOutputsPerProject.ShouldNotBeNull();
+            deserialized.TargetOutputsPerProject.Count.ShouldBe(1);
+            deserialized.TargetOutputsPerProject[0].ContainsKey("Build").ShouldBeTrue();
+
+            var buildEngineResult = deserialized.ToBuildEngineResult();
+            buildEngineResult.Result.ShouldBeTrue();
+            buildEngineResult.TargetOutputsPerProject.Count.ShouldBe(1);
+            buildEngineResult.TargetOutputsPerProject[0]["Build"].Length.ShouldBe(1);
+            buildEngineResult.TargetOutputsPerProject[0]["Build"][0].ItemSpec.ShouldBe("item1.dll");
+        }
+
+        [Fact]
+        public void TaskHostBuildResponse_Failure_NoOutputs_RoundTrip_Serialization()
+        {
+            var response = new TaskHostBuildResponse(33, false, null);
+
+            ITranslator writeTranslator = TranslationHelpers.GetWriteTranslator();
+            response.Translate(writeTranslator);
+
+            ITranslator readTranslator = TranslationHelpers.GetReadTranslator();
+            var deserialized = (TaskHostBuildResponse)TaskHostBuildResponse.FactoryForDeserialization(readTranslator);
+
+            deserialized.RequestId.ShouldBe(33);
+            deserialized.Success.ShouldBeFalse();
+            deserialized.TargetOutputsPerProject.ShouldBeNull();
+
+            var buildEngineResult = deserialized.ToBuildEngineResult();
+            buildEngineResult.Result.ShouldBeFalse();
         }
     }
 }

--- a/src/Build.UnitTests/BackEnd/TaskHostCallback_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/TaskHostCallback_Tests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
@@ -6,6 +6,7 @@ using System.IO;
 using Microsoft.Build.BackEnd;
 using Microsoft.Build.Execution;
 using Microsoft.Build.Framework;
+using Microsoft.Build.Shared;
 using Microsoft.Build.UnitTests.Shared;
 using Shouldly;
 using Xunit;
@@ -32,8 +33,8 @@ namespace Microsoft.Build.UnitTests.BackEnd
         /// See TaskHost.IsRunningMultipleNodes: returns _host.BuildParameters.MaxNodeCount > 1 || _disableInprocNode.
         /// </summary>
         [Theory]
-        [InlineData(1, false)]  // MaxNodeCount=1 → IsRunningMultipleNodes=false
-        [InlineData(4, true)]   // MaxNodeCount=4 → IsRunningMultipleNodes=true (even with one project)
+        [InlineData(1, false)]  // MaxNodeCount=1 -> IsRunningMultipleNodes=false
+        [InlineData(4, true)]   // MaxNodeCount=4 -> IsRunningMultipleNodes=true (even with one project)
         public void IsRunningMultipleNodes_WorksWithExplicitTaskHostFactory(int maxNodeCount, bool expectedResult)
         {
             using TestEnvironment env = TestEnvironment.Create(_output);
@@ -117,7 +118,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
         {
             using TestEnvironment env = TestEnvironment.Create(_output);
 
-            // Explicitly do NOT set MSBUILDENABLETASKHOSTCALLBACKS — callbacks should be disabled
+            // Explicitly do NOT set MSBUILDENABLETASKHOSTCALLBACKS -- callbacks should be disabled
             string projectContents = $@"
 <Project>
     <UsingTask TaskName=""{nameof(IsRunningMultipleNodesTask)}"" AssemblyFile=""{typeof(IsRunningMultipleNodesTask).Assembly.Location}"" TaskFactory=""TaskHostFactory"" />
@@ -136,7 +137,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
                 new BuildParameters { MaxNodeCount = 4, EnableNodeReuse = false, Loggers = [logger] },
                 new BuildRequestData(projectInstance, targetsToBuild: ["Test"]));
 
-            // MSB5022 error should be logged — the callback was not forwarded
+            // MSB5022 error should be logged -- the callback was not forwarded
             logger.ErrorCount.ShouldBeGreaterThan(0);
             logger.FullLog.ShouldContain("MSB5022");
         }
@@ -370,7 +371,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
         {
             using TestEnvironment env = TestEnvironment.Create(_output);
 
-            // Explicitly do NOT set MSBUILDENABLETASKHOSTCALLBACKS — callbacks should be disabled.
+            // Explicitly do NOT set MSBUILDENABLETASKHOSTCALLBACKS -- callbacks should be disabled.
             // Use RequestCoresWithFallbackTask which catches NotImplementedException like real callers do.
             string projectContents = $@"
 <Project>
@@ -391,10 +392,10 @@ namespace Microsoft.Build.UnitTests.BackEnd
                 new BuildParameters { MaxNodeCount = 4, EnableNodeReuse = false, Loggers = [logger] },
                 new BuildRequestData(projectInstance, targetsToBuild: ["Test"]));
 
-            // Build must succeed — the task catches NotImplementedException and falls back.
+            // Build must succeed -- the task catches NotImplementedException and falls back.
             buildResult.OverallResult.ShouldBe(BuildResultCode.Success);
 
-            // No errors should be logged — NotImplementedException is caught by the task, not by MSBuild.
+            // No errors should be logged -- NotImplementedException is caught by the task, not by MSBuild.
             logger.ErrorCount.ShouldBe(0);
 
             // The task should have used its fallback path (NotImplementedException was thrown).
@@ -418,7 +419,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
         {
             using TestEnvironment env = TestEnvironment.Create(_output);
 
-            // Explicitly do NOT set MSBUILDENABLETASKHOSTCALLBACKS — callbacks should be disabled
+            // Explicitly do NOT set MSBUILDENABLETASKHOSTCALLBACKS -- callbacks should be disabled
             string projectContents = $@"
 <Project>
     <UsingTask TaskName=""{nameof(RequestCoresWithFallbackTask)}"" AssemblyFile=""{typeof(RequestCoresWithFallbackTask).Assembly.Location}"" TaskFactory=""TaskHostFactory"" />
@@ -442,9 +443,267 @@ namespace Microsoft.Build.UnitTests.BackEnd
             buildResult.OverallResult.ShouldBe(BuildResultCode.Success);
             logger.ErrorCount.ShouldBe(0);
 
-            // Fallback fired — ReleaseCores should have been skipped (be9 nulled in catch).
+            // Fallback fired -- ReleaseCores should have been skipped (nulled in catch).
             logger.FullLog.ShouldContain("RequestCores threw NotImplementedException, using fallback");
             logger.FullLog.ShouldNotContain("ReleaseCores(");
+        }
+
+        /// <summary>
+        /// Verifies BuildProjectFile callback works when task is explicitly run in TaskHost via TaskHostFactory.
+        /// The child project should build and the task should return success.
+        /// </summary>
+        [Fact]
+        public void BuildProjectFile_WorksWithExplicitTaskHostFactory()
+        {
+            using TestEnvironment env = TestEnvironment.Create(_output);
+            env.SetEnvironmentVariable("MSBUILDENABLETASKHOSTCALLBACKS", "1");
+
+            string childProject = env.CreateFile("Child.proj", """
+                <Project>
+                    <Target Name="Build">
+                        <Message Text="ChildProjectBuilt" Importance="high" />
+                    </Target>
+                </Project>
+                """).Path;
+
+            string projectContents = $@"
+<Project>
+    <UsingTask TaskName=""{nameof(BuildProjectFileTask)}"" AssemblyFile=""{typeof(BuildProjectFileTask).Assembly.Location}"" TaskFactory=""TaskHostFactory"" />
+    <Target Name=""Test"">
+        <{nameof(BuildProjectFileTask)} ProjectFile=""{childProject}"" Targets=""Build"">
+            <Output PropertyName=""Result"" TaskParameter=""BuildSucceeded"" />
+        </{nameof(BuildProjectFileTask)}>
+    </Target>
+</Project>";
+
+            TransientTestProjectWithFiles project = env.CreateTestProjectWithFiles(projectContents);
+            ProjectInstance projectInstance = new(project.ProjectFile);
+
+            var logger = new MockLogger(_output);
+            BuildResult buildResult = BuildManager.DefaultBuildManager.Build(
+                new BuildParameters { MaxNodeCount = 4, EnableNodeReuse = false, Loggers = [logger] },
+                new BuildRequestData(projectInstance, targetsToBuild: ["Test"]));
+
+            buildResult.OverallResult.ShouldBe(BuildResultCode.Success);
+            bool.Parse(projectInstance.GetPropertyValue("Result")).ShouldBeTrue();
+            logger.FullLog.ShouldContain("ChildProjectBuilt");
+        }
+
+        /// <summary>
+        /// Verifies BuildProjectFile forwards global properties to the child build.
+        /// </summary>
+        [Fact]
+        public void BuildProjectFile_ForwardsGlobalProperties()
+        {
+            using TestEnvironment env = TestEnvironment.Create(_output);
+            env.SetEnvironmentVariable("MSBUILDENABLETASKHOSTCALLBACKS", "1");
+
+            string childProject = env.CreateFile("Child.proj", """
+                <Project>
+                    <Target Name="Build">
+                        <Message Text="Config=$(Configuration)" Importance="high" />
+                    </Target>
+                </Project>
+                """).Path;
+
+            string projectContents = $@"
+<Project>
+    <UsingTask TaskName=""{nameof(BuildProjectFileTask)}"" AssemblyFile=""{typeof(BuildProjectFileTask).Assembly.Location}"" TaskFactory=""TaskHostFactory"" />
+    <Target Name=""Test"">
+        <{nameof(BuildProjectFileTask)} ProjectFile=""{childProject}"" Targets=""Build"" Properties=""Configuration=Release"">
+            <Output PropertyName=""Result"" TaskParameter=""BuildSucceeded"" />
+        </{nameof(BuildProjectFileTask)}>
+    </Target>
+</Project>";
+
+            TransientTestProjectWithFiles project = env.CreateTestProjectWithFiles(projectContents);
+            ProjectInstance projectInstance = new(project.ProjectFile);
+
+            var logger = new MockLogger(_output);
+            BuildResult buildResult = BuildManager.DefaultBuildManager.Build(
+                new BuildParameters { MaxNodeCount = 4, EnableNodeReuse = false, Loggers = [logger] },
+                new BuildRequestData(projectInstance, targetsToBuild: ["Test"]));
+
+            buildResult.OverallResult.ShouldBe(BuildResultCode.Success);
+            logger.FullLog.ShouldContain("Config=Release");
+        }
+
+        /// <summary>
+        /// Verifies BuildProjectFile returns ITaskItem[] target outputs through the TaskHost callback.
+        /// </summary>
+        [Fact]
+        public void BuildProjectFile_ReturnsTargetOutputs()
+        {
+            using TestEnvironment env = TestEnvironment.Create(_output);
+            env.SetEnvironmentVariable("MSBUILDENABLETASKHOSTCALLBACKS", "1");
+
+            string childProject = env.CreateFile("Child.proj", """
+                <Project>
+                    <ItemGroup>
+                        <OutputItem Include="Output1.dll">
+                            <CustomMeta>Value1</CustomMeta>
+                        </OutputItem>
+                        <OutputItem Include="Output2.dll" />
+                    </ItemGroup>
+                    <Target Name="GetOutputs" Returns="@(OutputItem)">
+                        <Message Text="GetOutputs executed" Importance="high" />
+                    </Target>
+                </Project>
+                """).Path;
+
+            string projectContents = $@"
+<Project>
+    <UsingTask TaskName=""{nameof(BuildProjectFileTask)}"" AssemblyFile=""{typeof(BuildProjectFileTask).Assembly.Location}"" TaskFactory=""TaskHostFactory"" />
+    <Target Name=""Test"">
+        <{nameof(BuildProjectFileTask)} ProjectFile=""{childProject}"" Targets=""GetOutputs"">
+            <Output PropertyName=""Result"" TaskParameter=""BuildSucceeded"" />
+            <Output ItemName=""Items"" TaskParameter=""OutputItems"" />
+        </{nameof(BuildProjectFileTask)}>
+        <Message Text=""OutputItemCount=@(Items->Count())"" Importance=""high"" />
+    </Target>
+</Project>";
+
+            TransientTestProjectWithFiles project = env.CreateTestProjectWithFiles(projectContents);
+            ProjectInstance projectInstance = new(project.ProjectFile);
+
+            var logger = new MockLogger(_output);
+            BuildResult buildResult = BuildManager.DefaultBuildManager.Build(
+                new BuildParameters { MaxNodeCount = 4, EnableNodeReuse = false, Loggers = [logger] },
+                new BuildRequestData(projectInstance, targetsToBuild: ["Test"]));
+
+            buildResult.OverallResult.ShouldBe(BuildResultCode.Success);
+            bool.Parse(projectInstance.GetPropertyValue("Result")).ShouldBeTrue();
+            logger.FullLog.ShouldContain("OutputItemCount=2");
+        }
+
+        /// <summary>
+        /// Verifies BuildProjectFile returns false when the child project fails.
+        /// </summary>
+        [Fact]
+        public void BuildProjectFile_ChildFailure_ReturnsFalse()
+        {
+            using TestEnvironment env = TestEnvironment.Create(_output);
+            env.SetEnvironmentVariable("MSBUILDENABLETASKHOSTCALLBACKS", "1");
+
+            string childProject = env.CreateFile("Child.proj", """
+                <Project>
+                    <Target Name="Build">
+                        <Error Text="Intentional failure" />
+                    </Target>
+                </Project>
+                """).Path;
+
+            string projectContents = $@"
+<Project>
+    <UsingTask TaskName=""{nameof(BuildProjectFileTask)}"" AssemblyFile=""{typeof(BuildProjectFileTask).Assembly.Location}"" TaskFactory=""TaskHostFactory"" />
+    <Target Name=""Test"">
+        <{nameof(BuildProjectFileTask)} ProjectFile=""{childProject}"" Targets=""Build"">
+            <Output PropertyName=""Result"" TaskParameter=""BuildSucceeded"" />
+        </{nameof(BuildProjectFileTask)}>
+        <Message Text=""ChildResult=$(Result)"" Importance=""high"" />
+    </Target>
+</Project>";
+
+            TransientTestProjectWithFiles project = env.CreateTestProjectWithFiles(projectContents);
+            ProjectInstance projectInstance = new(project.ProjectFile);
+
+            var logger = new MockLogger(_output);
+            BuildResult buildResult = BuildManager.DefaultBuildManager.Build(
+                new BuildParameters { MaxNodeCount = 4, EnableNodeReuse = false, Loggers = [logger] },
+                new BuildRequestData(projectInstance, targetsToBuild: ["Test"]));
+
+            buildResult.OverallResult.ShouldBe(BuildResultCode.Success);
+            logger.FullLog.ShouldContain("ChildResult=False");
+        }
+
+        /// <summary>
+        /// Verifies BuildProjectFile auto-ejection works in multithreaded mode.
+        /// </summary>
+        [Fact]
+        public void BuildProjectFile_WorksWhenAutoEjectedInMultiThreadedMode()
+        {
+            using TestEnvironment env = TestEnvironment.Create(_output);
+            env.SetEnvironmentVariable("MSBUILDENABLETASKHOSTCALLBACKS", "1");
+            string testDir = env.CreateFolder().Path;
+
+            string childProject = Path.Combine(testDir, "Child.proj");
+            File.WriteAllText(childProject, """
+                <Project>
+                    <Target Name="Build">
+                        <Message Text="ChildBuiltInMT" Importance="high" />
+                    </Target>
+                </Project>
+                """);
+
+            string projectContents = $@"
+<Project>
+    <UsingTask TaskName=""{nameof(BuildProjectFileTask)}"" AssemblyFile=""{typeof(BuildProjectFileTask).Assembly.Location}"" />
+    <Target Name=""Test"">
+        <{nameof(BuildProjectFileTask)} ProjectFile=""{childProject}"" Targets=""Build"">
+            <Output PropertyName=""Result"" TaskParameter=""BuildSucceeded"" />
+        </{nameof(BuildProjectFileTask)}>
+    </Target>
+</Project>";
+
+            string projectFile = Path.Combine(testDir, "Test.proj");
+            File.WriteAllText(projectFile, projectContents);
+
+            var logger = new MockLogger(_output);
+            BuildResult buildResult = BuildManager.DefaultBuildManager.Build(
+                new BuildParameters
+                {
+                    MultiThreaded = true,
+                    MaxNodeCount = 4,
+                    Loggers = [logger],
+                    EnableNodeReuse = false
+                },
+                new BuildRequestData(projectFile, new Dictionary<string, string?>(), null, ["Test"], null));
+
+            buildResult.OverallResult.ShouldBe(BuildResultCode.Success);
+            logger.FullLog.ShouldContain("external task host");
+            logger.FullLog.ShouldContain("ChildBuiltInMT");
+        }
+
+        /// <summary>
+        /// Verifies that BuildProjectFile when callbacks are disabled logs error MSB5022.
+        /// </summary>
+        [Fact]
+        public void BuildProjectFile_LogsErrorWhenCallbacksNotSupported()
+        {
+            using TestEnvironment env = TestEnvironment.Create(_output);
+
+            string childProject = env.CreateFile("Child.proj", """
+                <Project>
+                    <Target Name="Build">
+                        <Message Text="ShouldNotRun" Importance="high" />
+                    </Target>
+                </Project>
+                """).Path;
+
+            // Explicitly do NOT set MSBUILDENABLETASKHOSTCALLBACKS
+            string projectContents = $@"
+<Project>
+    <UsingTask TaskName=""{nameof(BuildProjectFileTask)}"" AssemblyFile=""{typeof(BuildProjectFileTask).Assembly.Location}"" TaskFactory=""TaskHostFactory"" />
+    <Target Name=""Test"">
+        <{nameof(BuildProjectFileTask)} ProjectFile=""{childProject}"" Targets=""Build"">
+            <Output PropertyName=""Result"" TaskParameter=""BuildSucceeded"" />
+        </{nameof(BuildProjectFileTask)}>
+    </Target>
+</Project>";
+
+            TransientTestProjectWithFiles project = env.CreateTestProjectWithFiles(projectContents);
+            ProjectInstance projectInstance = new(project.ProjectFile);
+
+            var logger = new MockLogger(_output);
+            BuildResult buildResult = BuildManager.DefaultBuildManager.Build(
+                new BuildParameters { MaxNodeCount = 4, EnableNodeReuse = false, Loggers = [logger] },
+                new BuildRequestData(projectInstance, targetsToBuild: ["Test"]));
+
+            // MSB5022 error should be logged
+            logger.ErrorCount.ShouldBeGreaterThan(0);
+            logger.FullLog.ShouldContain("MSB5022");
+            // Child should not have been built
+            logger.FullLog.ShouldNotContain("ShouldNotRun");
         }
     }
 }

--- a/src/Build.UnitTests/NetTaskHost_E2E_Tests.cs
+++ b/src/Build.UnitTests/NetTaskHost_E2E_Tests.cs
@@ -316,10 +316,6 @@ namespace Microsoft.Build.Engine.UnitTests
             successTestTask.ShouldBeTrue();
 
             // Both the parent task and child task should report TASKHOST_PID
-            testTaskOutput.ShouldContain("TASKHOST_PID=");
-            testTaskOutput.ShouldContain("PARENT_TASKHOST_PID=");
-            testTaskOutput.ShouldContain("CHILD_TASKHOST_PID=");
-
             // Extract PIDs from output and verify they match (same process reused)
             var parentPidMatch = System.Text.RegularExpressions.Regex.Match(testTaskOutput, @"PARENT_TASKHOST_PID=(\d+)");
             var childPidMatch = System.Text.RegularExpressions.Regex.Match(testTaskOutput, @"CHILD_TASKHOST_PID=(\d+)");

--- a/src/Build.UnitTests/NetTaskHost_E2E_Tests.cs
+++ b/src/Build.UnitTests/NetTaskHost_E2E_Tests.cs
@@ -169,7 +169,7 @@ namespace Microsoft.Build.Engine.UnitTests
             using TestEnvironment env = TestEnvironment.Create(_output);
 
             string testProjectPath = Path.Combine(TestAssetsRootPath, "ExampleNetTask", "TestMSBuildTaskInNet", "TestMSBuildTaskInNet.csproj");
-            string testTaskOutput = RunnerUtilities.ExecBootstrapedMSBuild($"{testProjectPath} -restore  -v:n -p:LatestDotNetCoreForMSBuild={RunnerUtilities.LatestDotNetCoreForMSBuild}", out bool successTestTask);
+            string testTaskOutput = RunnerUtilities.ExecBootstrapedMSBuild($"{testProjectPath} -restore -v:n -p:LatestDotNetCoreForMSBuild={RunnerUtilities.LatestDotNetCoreForMSBuild}", out bool successTestTask);
 
             if (!successTestTask)
             {
@@ -227,6 +227,29 @@ namespace Microsoft.Build.Engine.UnitTests
             testTaskOutput.ShouldContain("CallbackResult: RequestCores(2) =");
         }
 
+        [WindowsFullFrameworkOnlyFact]
+        public void NetTaskHost_CallbackBuildProjectFileTest()
+        {
+            using TestEnvironment env = TestEnvironment.Create(_output);
+            env.SetEnvironmentVariable("MSBUILDENABLETASKHOSTCALLBACKS", "1");
+
+            var coreDirectory = Path.Combine(RunnerUtilities.BootstrapRootPath, "core");
+            env.SetEnvironmentVariable("DOTNET_MSBUILD_SDK_RESOLVER_CLI_DIR", coreDirectory);
+
+            string testProjectPath = Path.Combine(TestAssetsRootPath, "ExampleNetTask", "TestNetTaskBuildCallback", "TestNetTaskBuildCallback.csproj");
+
+            string testTaskOutput = RunnerUtilities.ExecBootstrapedMSBuild($"{testProjectPath} -v:n -p:LatestDotNetCoreForMSBuild={RunnerUtilities.LatestDotNetCoreForMSBuild} -t:TestTask", out bool successTestTask);
+
+            if (!successTestTask)
+            {
+                _output.WriteLine(testTaskOutput);
+            }
+
+            successTestTask.ShouldBeTrue();
+            testTaskOutput.ShouldContain("CallbackResult: BuildProjectFile = True");
+            testTaskOutput.ShouldContain("ChildProject: GetOutputs target executed");
+        }
+
         [WindowsFullFrameworkOnlyFact] // This test verifies the fallback behavior with implicit host parameters.
         public void NetTaskWithImplicitHostParamsTest_FallbackToDotnet()
         {
@@ -235,7 +258,7 @@ namespace Microsoft.Build.Engine.UnitTests
 
             string testProjectPath = Path.Combine(TestAssetsRootPath, "ExampleNetTask", "TestNetTaskWithImplicitParams", "TestNetTaskWithImplicitParams.csproj");
 
-            string testTaskOutput = RunnerUtilities.ExecBootstrapedMSBuild($"{testProjectPath} -restore  -v:n -p:LatestDotNetCoreForMSBuild={RunnerUtilities.LatestDotNetCoreForMSBuild}", out bool successTestTask);
+            string testTaskOutput = RunnerUtilities.ExecBootstrapedMSBuild($"{testProjectPath} -restore -v:n -p:LatestDotNetCoreForMSBuild={RunnerUtilities.LatestDotNetCoreForMSBuild}", out bool successTestTask);
 
             if (!successTestTask)
             {
@@ -275,6 +298,41 @@ namespace Microsoft.Build.Engine.UnitTests
             testTaskOutput.ShouldContain("/nodereuse:True");
         }
 
+        [WindowsFullFrameworkOnlyFact]
+        public void NetTaskHost_TaskHostProcessReuse_SameProcessForNestedBuild()
+        {
+            using TestEnvironment env = TestEnvironment.Create(_output);
+            env.SetEnvironmentVariable("MSBUILDENABLETASKHOSTCALLBACKS", "1");
+
+            var coreDirectory = Path.Combine(RunnerUtilities.BootstrapRootPath, "core");
+            env.SetEnvironmentVariable("DOTNET_MSBUILD_SDK_RESOLVER_CLI_DIR", coreDirectory);
+
+            string testProjectPath = Path.Combine(TestAssetsRootPath, "ExampleNetTask", "TestNetTaskHostReuse", "TestNetTaskHostReuse.csproj");
+
+            string testTaskOutput = RunnerUtilities.ExecBootstrapedMSBuild($"{testProjectPath} -v:n -p:LatestDotNetCoreForMSBuild={RunnerUtilities.LatestDotNetCoreForMSBuild} -t:TestTaskHostReuse", out bool successTestTask);
+
+            _output.WriteLine(testTaskOutput);
+
+            successTestTask.ShouldBeTrue();
+
+            // Both the parent task and child task should report TASKHOST_PID
+            testTaskOutput.ShouldContain("TASKHOST_PID=");
+            testTaskOutput.ShouldContain("PARENT_TASKHOST_PID=");
+            testTaskOutput.ShouldContain("CHILD_TASKHOST_PID=");
+
+            // Extract PIDs from output and verify they match (same process reused)
+            var parentPidMatch = System.Text.RegularExpressions.Regex.Match(testTaskOutput, @"PARENT_TASKHOST_PID=(\d+)");
+            var childPidMatch = System.Text.RegularExpressions.Regex.Match(testTaskOutput, @"CHILD_TASKHOST_PID=(\d+)");
+
+            parentPidMatch.Success.ShouldBeTrue("Should find PARENT_TASKHOST_PID in output");
+            childPidMatch.Success.ShouldBeTrue("Should find CHILD_TASKHOST_PID in output");
+
+            string parentPid = parentPidMatch.Groups[1].Value;
+            string childPid = childPidMatch.Groups[1].Value;
+
+            parentPid.ShouldBe(childPid, $"Parent PID ({parentPid}) and child PID ({childPid}) should match -- same TaskHost process should be reused for nested build");
+        }
+
 #if NET
         /// <summary>
         /// Regression test: proves that launching the MSBuild task host through a symlinked
@@ -283,8 +341,8 @@ namespace Microsoft.Build.Engine.UnitTests
         /// On macOS, /tmp is a symlink to /private/tmp. When the SDK is under /tmp, the
         /// MSBuild property $(NetCoreSdkRoot) = $(MSBuildThisFileDirectory) preserves the
         /// unresolved /tmp form. But the child task host's AppContext.BaseDirectory resolves
-        /// to /private/tmp. The parent and child compute different handshake hashes → different
-        /// pipe names → MSB4216.
+        /// to /private/tmp. The parent and child compute different handshake hashes -> different
+        /// pipe names -> MSB4216.
         ///
         /// This test recreates the scenario by symlinking the bootstrap SDK directory and
         /// running MSBuild through the symlink.
@@ -295,7 +353,7 @@ namespace Microsoft.Build.Engine.UnitTests
             using TestEnvironment env = TestEnvironment.Create(_output);
 
             // Create a symlink pointing to the bootstrap SDK binary location.
-            // This simulates the macOS /tmp → /private/tmp scenario.
+            // This simulates the macOS /tmp -> /private/tmp scenario.
             string realSdkPath = RunnerUtilities.BootstrapMsBuildBinaryLocation;
             string symlinkPath = Path.Combine(Path.GetTempPath(), $"msbuild_symlink_test_{Guid.NewGuid():N}");
 

--- a/src/Build.UnitTests/TestAssets/ExampleNetTask/ExampleTask/ExampleTask.csproj
+++ b/src/Build.UnitTests/TestAssets/ExampleNetTask/ExampleTask/ExampleTask.csproj
@@ -17,6 +17,8 @@
   <ItemGroup>
     <Compile Include="..\..\..\BackEnd\IsRunningMultipleNodesTask.cs" Link="IsRunningMultipleNodesTask.cs" />
     <Compile Include="..\..\..\BackEnd\RequestCoresTask.cs" Link="RequestCoresTask.cs" />
+    <Compile Include="..\..\..\BackEnd\BuildProjectFileTask.cs" Link="BuildProjectFileTask.cs" />
+    <Compile Include="..\..\..\BackEnd\BuildProjectFileAndReportPidTask.cs" Link="BuildProjectFileAndReportPidTask.cs" />
   </ItemGroup>
 
 </Project>

--- a/src/Build.UnitTests/TestAssets/ExampleNetTask/TestNetTaskBuildCallback/ChildProject.proj
+++ b/src/Build.UnitTests/TestAssets/ExampleNetTask/TestNetTaskBuildCallback/ChildProject.proj
@@ -1,0 +1,11 @@
+<Project>
+  <ItemGroup>
+    <OutputItem Include="ItemFromChildProject">
+      <CustomMetadata>MetadataValue</CustomMetadata>
+    </OutputItem>
+  </ItemGroup>
+
+  <Target Name="GetOutputs" Returns="@(OutputItem)">
+    <Message Text="ChildProject: GetOutputs target executed" Importance="high" />
+  </Target>
+</Project>

--- a/src/Build.UnitTests/TestAssets/ExampleNetTask/TestNetTaskBuildCallback/TestNetTaskBuildCallback.csproj
+++ b/src/Build.UnitTests/TestAssets/ExampleNetTask/TestNetTaskBuildCallback/TestNetTaskBuildCallback.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(LatestDotNetCoreForMSBuild)</TargetFramework>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <TestProjectFolder>$([System.IO.Path]::GetFullPath('$([System.IO.Path]::Combine('$(MSBuildThisFileDirectory)', '..', '..', '..', '..'))'))</TestProjectFolder>
+    <ExampleTaskPath>$([System.IO.Path]::Combine('$(TestProjectFolder)', '$(TargetFramework)', 'ExampleTask.dll'))</ExampleTaskPath>
+    <ChildProjectPath>$([System.IO.Path]::Combine('$(MSBuildThisFileDirectory)', 'ChildProject.proj'))</ChildProjectPath>
+  </PropertyGroup>
+
+  <UsingTask
+      TaskName="Microsoft.Build.UnitTests.BackEnd.BuildProjectFileTask"
+      AssemblyFile="$(ExampleTaskPath)"
+      TaskFactory="TaskHostFactory"
+      Runtime="NET"/>
+
+  <Target Name="TestTask" BeforeTargets="Build">
+    <Microsoft.Build.UnitTests.BackEnd.BuildProjectFileTask
+        ProjectFile="$(ChildProjectPath)"
+        Targets="GetOutputs">
+      <Output PropertyName="ChildBuildResult" TaskParameter="BuildSucceeded" />
+      <Output ItemName="ChildOutputItems" TaskParameter="OutputItems" />
+    </Microsoft.Build.UnitTests.BackEnd.BuildProjectFileTask>
+    <Message Text="CallbackResult: BuildProjectFile = $(ChildBuildResult)" Importance="high" />
+    <Message Text="CallbackResult: OutputItem = %(ChildOutputItems.Identity)" Importance="high" Condition="'@(ChildOutputItems)' != ''" />
+  </Target>
+
+</Project>

--- a/src/Build.UnitTests/TestAssets/ExampleNetTask/TestNetTaskBuildCallback/global.json
+++ b/src/Build.UnitTests/TestAssets/ExampleNetTask/TestNetTaskBuildCallback/global.json
@@ -1,0 +1,9 @@
+{
+    "sdk": {
+        // This global.json is needed to prevent builds running in tests using the bootstrap layout from walking
+        // up the repo tree and resolving our sdk.paths, instead of the bootstrap layout's SDK.
+        // See https://github.com/dotnet/runtime/issues/118488 for details.
+        "allowPrerelease": true,
+        "rollForward": "latestMajor"
+    }
+}

--- a/src/Build.UnitTests/TestAssets/ExampleNetTask/TestNetTaskHostReuse/ChildProject.proj
+++ b/src/Build.UnitTests/TestAssets/ExampleNetTask/TestNetTaskHostReuse/ChildProject.proj
@@ -1,0 +1,15 @@
+<Project>
+  <!-- ExampleTaskPath is passed as a global property from the parent -->
+  <UsingTask
+      TaskName="Microsoft.Build.UnitTests.BackEnd.BuildProjectFileAndReportPidTask"
+      AssemblyFile="$(ExampleTaskPath)"
+      TaskFactory="TaskHostFactory"
+      Runtime="NET"/>
+
+  <Target Name="ReportPid">
+    <Microsoft.Build.UnitTests.BackEnd.BuildProjectFileAndReportPidTask>
+      <Output PropertyName="ChildPid" TaskParameter="ProcessId" />
+    </Microsoft.Build.UnitTests.BackEnd.BuildProjectFileAndReportPidTask>
+    <Message Text="CHILD_TASKHOST_PID=$(ChildPid)" Importance="high" />
+  </Target>
+</Project>

--- a/src/Build.UnitTests/TestAssets/ExampleNetTask/TestNetTaskHostReuse/TestNetTaskHostReuse.csproj
+++ b/src/Build.UnitTests/TestAssets/ExampleNetTask/TestNetTaskHostReuse/TestNetTaskHostReuse.csproj
@@ -1,0 +1,34 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(LatestDotNetCoreForMSBuild)</TargetFramework>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <TestProjectFolder>$([System.IO.Path]::GetFullPath('$([System.IO.Path]::Combine('$(MSBuildThisFileDirectory)', '..', '..', '..', '..'))'))</TestProjectFolder>
+    <ExampleTaskPath>$([System.IO.Path]::Combine('$(TestProjectFolder)', '$(TargetFramework)', 'ExampleTask.dll'))</ExampleTaskPath>
+    <ChildProjectPath>$([System.IO.Path]::Combine('$(MSBuildThisFileDirectory)', 'ChildProject.proj'))</ChildProjectPath>
+  </PropertyGroup>
+
+  <!-- Parent task: reports its PID and calls BuildProjectFile on child project -->
+  <UsingTask
+      TaskName="Microsoft.Build.UnitTests.BackEnd.BuildProjectFileAndReportPidTask"
+      AssemblyFile="$(ExampleTaskPath)"
+      TaskFactory="TaskHostFactory"
+      Runtime="NET"/>
+
+  <Target Name="TestTaskHostReuse" BeforeTargets="Build">
+    <!-- This task runs in an OOP TaskHost, reports its PID, and calls BuildProjectFile on ChildProject.
+         The child project also uses a task via TaskHostFactory with the same runtime, so the same
+         OOP TaskHost process should be reused (while the parent task is blocked on BuildProjectFile callback). -->
+    <Microsoft.Build.UnitTests.BackEnd.BuildProjectFileAndReportPidTask
+        ProjectFile="$(ChildProjectPath)"
+        Properties="ExampleTaskPath=$(ExampleTaskPath)">
+      <Output PropertyName="ParentPid" TaskParameter="ProcessId" />
+      <Output PropertyName="ParentBuildResult" TaskParameter="BuildSucceeded" />
+    </Microsoft.Build.UnitTests.BackEnd.BuildProjectFileAndReportPidTask>
+    <Message Text="PARENT_TASKHOST_PID=$(ParentPid)" Importance="high" />
+    <Message Text="ParentBuildResult=$(ParentBuildResult)" Importance="high" />
+  </Target>
+
+</Project>

--- a/src/Build.UnitTests/TestAssets/ExampleNetTask/TestNetTaskHostReuse/global.json
+++ b/src/Build.UnitTests/TestAssets/ExampleNetTask/TestNetTaskHostReuse/global.json
@@ -1,0 +1,9 @@
+{
+    "sdk": {
+        // This global.json is needed to prevent builds running in tests using the bootstrap layout from walking
+        // up the repo tree and resolving our sdk.paths, instead of the bootstrap layout's SDK.
+        // See https://github.com/dotnet/runtime/issues/118488 for details.
+        "allowPrerelease": true,
+        "rollForward": "latestMajor"
+    }
+}

--- a/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcTaskHost.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcTaskHost.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -93,20 +93,15 @@ namespace Microsoft.Build.BackEnd
         private ConcurrentDictionary<int, TaskHostNodeKey> _nodeIdToNodeKey;
 
         /// <summary>
-        /// A mapping of all of the INodePacketFactories wrapped by this provider.
-        /// Keyed by the communication node ID (NodeContext.NodeId) for O(1) packet routing.
-        /// Thread-safe to support parallel taskhost creation in /mt mode where multiple thread nodes
-        /// can simultaneously create their own taskhosts.
+        /// Per-node handler stacks for routing packets from OOP TaskHost processes.
+        /// Keyed by communication node ID (one per OOP process). Each node can have
+        /// multiple OOP processes for different architectures (x86, x64, ARM64).
+        /// The stack supports nested BuildProjectFile callbacks: when Task A calls
+        /// BuildProjectFile and blocks, Task B is dispatched to the same process --
+        /// handler B is pushed on top. Packets always route to Peek() (the active task).
+        /// When Task B finishes, handler B is popped and Task A's handler is restored.
         /// </summary>
-        private ConcurrentDictionary<int, INodePacketFactory> _nodeIdToPacketFactory;
-
-        /// <summary>
-        /// A mapping of all of the INodePacketHandlers wrapped by this provider.
-        /// Keyed by the communication node ID (NodeContext.NodeId) for O(1) packet routing.
-        /// Thread-safe to support parallel taskhost creation in /mt mode where multiple thread nodes
-        /// can simultaneously create their own taskhosts.
-        /// </summary>
-        private ConcurrentDictionary<int, INodePacketHandler> _nodeIdToPacketHandler;
+        private ConcurrentDictionary<int, Stack<INodePacketHandler>> _nodeIdToPacketHandlerStack;
 
         /// <summary>
         /// Keeps track of the set of node IDs for which we have not yet received shutdown notification.
@@ -237,8 +232,7 @@ namespace Microsoft.Build.BackEnd
             ComponentHost = host;
             _nodeContexts = new ConcurrentDictionary<TaskHostNodeKey, NodeContext>();
             _nodeIdToNodeKey = new ConcurrentDictionary<int, TaskHostNodeKey>();
-            _nodeIdToPacketFactory = new ConcurrentDictionary<int, INodePacketFactory>();
-            _nodeIdToPacketHandler = new ConcurrentDictionary<int, INodePacketHandler>();
+            _nodeIdToPacketHandlerStack = new ConcurrentDictionary<int, Stack<INodePacketHandler>>();
             _activeNodes = [];
             _nextNodeId = 0;
 
@@ -248,6 +242,13 @@ namespace Microsoft.Build.BackEnd
             (this as INodePacketFactory).RegisterPacketHandler(NodePacketType.LogMessage, LogMessagePacket.FactoryForDeserialization, this);
             (this as INodePacketFactory).RegisterPacketHandler(NodePacketType.TaskHostTaskComplete, TaskHostTaskComplete.FactoryForDeserialization, this);
             (this as INodePacketFactory).RegisterPacketHandler(NodePacketType.NodeShutdown, NodeShutdown.FactoryForDeserialization, this);
+
+            // Register callback request packet types so we can deserialize them when
+            // they arrive from TaskHost processes. These are forwarded to the current
+            // TaskHostTask handler via the handler stack.
+            (this as INodePacketFactory).RegisterPacketHandler(NodePacketType.TaskHostIsRunningMultipleNodesRequest, TaskHostIsRunningMultipleNodesRequest.FactoryForDeserialization, this);
+            (this as INodePacketFactory).RegisterPacketHandler(NodePacketType.TaskHostCoresRequest, TaskHostCoresRequest.FactoryForDeserialization, this);
+            (this as INodePacketFactory).RegisterPacketHandler(NodePacketType.TaskHostBuildRequest, TaskHostBuildRequest.FactoryForDeserialization, this);
         }
 
         /// <summary>
@@ -283,20 +284,17 @@ namespace Microsoft.Build.BackEnd
 
         /// <summary>
         /// Takes a serializer, deserializes the packet and routes it to the appropriate handler.
+        /// Always uses the local packet factory for deserialization, which routes through
+        /// our PacketReceived method (using the handler stack).
         /// </summary>
         /// <param name="nodeId">The node from which the packet was received.</param>
         /// <param name="packetType">The packet type.</param>
         /// <param name="translator">The translator containing the data from which the packet should be reconstructed.</param>
         public void DeserializeAndRoutePacket(int nodeId, NodePacketType packetType, ITranslator translator)
         {
-            if (_nodeIdToPacketFactory.TryGetValue(nodeId, out INodePacketFactory nodePacketFactory))
-            {
-                nodePacketFactory.DeserializeAndRoutePacket(nodeId, packetType, translator);
-            }
-            else
-            {
-                _localPacketFactory.DeserializeAndRoutePacket(nodeId, packetType, translator);
-            }
+            // Always route through our local factory which handles deserialization
+            // and routes to our PacketReceived, which uses the handler stack.
+            _localPacketFactory.DeserializeAndRoutePacket(nodeId, packetType, translator);
         }
 
         /// <summary>
@@ -310,20 +308,13 @@ namespace Microsoft.Build.BackEnd
         }
 
         /// <summary>
-        /// Routes the specified packet
+        /// Routes the specified packet through our PacketReceived method (handler stack).
         /// </summary>
         /// <param name="nodeId">The node from which the packet was received.</param>
         /// <param name="packet">The packet to route.</param>
         public void RoutePacket(int nodeId, INodePacket packet)
         {
-            if (_nodeIdToPacketFactory.TryGetValue(nodeId, out INodePacketFactory nodePacketFactory))
-            {
-                nodePacketFactory.RoutePacket(nodeId, packet);
-            }
-            else
-            {
-                _localPacketFactory.RoutePacket(nodeId, packet);
-            }
+            _localPacketFactory.RoutePacket(nodeId, packet);
         }
 
         #endregion
@@ -338,27 +329,40 @@ namespace Microsoft.Build.BackEnd
         /// <param name="packet">The packet.</param>
         public void PacketReceived(int node, INodePacket packet)
         {
-            if (_nodeIdToPacketHandler.TryGetValue(node, out INodePacketHandler packetHandler))
+            if (_nodeIdToPacketHandlerStack.TryGetValue(node, out Stack<INodePacketHandler> handlerStack))
             {
-                packetHandler.PacketReceived(node, packet);
-            }
-            else
-            {
-                ErrorUtilities.VerifyThrow(packet.Type == NodePacketType.NodeShutdown, "We should only ever handle packets of type NodeShutdown -- everything else should only come in when there's an active task");
-
-                // May also be removed by unnatural termination, so don't assume it's there
-                lock (_activeNodes)
+                lock (handlerStack)
                 {
-                    if (_activeNodes.Contains(node))
+                    if (handlerStack.Count > 0)
                     {
-                        _activeNodes.Remove(node);
-                    }
-
-                    if (_activeNodes.Count == 0)
-                    {
-                        _noNodesActiveEvent.Set();
+                        INodePacketHandler packetHandler = handlerStack.Peek();
+                        packetHandler.PacketReceived(node, packet);
+                        return;
                     }
                 }
+            }
+
+            // No handler. Handle node-level events directly.
+            switch (packet.Type)
+            {
+                case NodePacketType.NodeShutdown:
+                    lock (_activeNodes)
+                    {
+                        if (_activeNodes.Contains(node))
+                        {
+                            _activeNodes.Remove(node);
+                        }
+
+                        if (_activeNodes.Count == 0)
+                        {
+                            _noNodesActiveEvent.Set();
+                        }
+                    }
+
+                    break;
+                default:
+                    CommunicationsUtilities.Trace("PacketReceived: no handler for node {0}, dropping packet type {1}", node, packet.Type);
+                    break;
             }
         }
 
@@ -630,9 +634,12 @@ namespace Microsoft.Build.BackEnd
             if (nodeCreationSucceeded)
             {
                 NodeContext context = _nodeContexts[nodeKey];
-                // Map the transport ID directly to the handlers for O(1) packet routing
-                _nodeIdToPacketFactory[context.NodeId] = factory;
-                _nodeIdToPacketHandler[context.NodeId] = handler;
+
+                Stack<INodePacketHandler> handlerStack = _nodeIdToPacketHandlerStack.GetOrAdd(context.NodeId, _ => new Stack<INodePacketHandler>());
+                lock (handlerStack)
+                {
+                    handlerStack.Push(handler);
+                }
 
                 // Configure the node.
                 context.SendData(configuration);
@@ -647,21 +654,29 @@ namespace Microsoft.Build.BackEnd
         /// </summary>
         internal void DisconnectFromHost(TaskHostNodeKey nodeKey)
         {
-            // The node context might already have been removed by NodeContextTerminated if the task host
-            // process terminated before we got here. This is a valid race condition - just return early.
-            // Note: NodeContextTerminated does NOT remove handlers, so they'll be orphaned in this case,
-            // but that's acceptable since the task host is dead and the handlers will be cleaned up
-            // when the provider is shut down.
             if (!_nodeContexts.TryGetValue(nodeKey, out NodeContext context))
             {
                 CommunicationsUtilities.Trace("DisconnectFromHost: Node context already removed for key: {0}", nodeKey);
                 return;
             }
 
-            bool successRemoveFactory = _nodeIdToPacketFactory.TryRemove(context.NodeId, out _);
-            bool successRemoveHandler = _nodeIdToPacketHandler.TryRemove(context.NodeId, out _);
+            int nodeId = context.NodeId;
 
-            ErrorUtilities.VerifyThrow(successRemoveFactory && successRemoveHandler, "Why are we trying to disconnect from a context that we already disconnected from?  Did we call DisconnectFromHost twice?");
+            if (_nodeIdToPacketHandlerStack.TryGetValue(nodeId, out Stack<INodePacketHandler> handlerStack))
+            {
+                lock (handlerStack)
+                {
+                    if (handlerStack.Count > 0)
+                    {
+                        handlerStack.Pop();
+                    }
+
+                    if (handlerStack.Count == 0)
+                    {
+                        _nodeIdToPacketHandlerStack.TryRemove(nodeId, out _);
+                    }
+                }
+            }
         }
 
         /// <summary>
@@ -760,7 +775,7 @@ namespace Microsoft.Build.BackEnd
             //
             // On .NET Core, parent and child are always from the same SDK directory. Passing
             // msbuildAssemblyPath from $(NetCoreSdkRoot) can cause a handshake mismatch on
-            // macOS where /tmp → /private/tmp symlink means the property value differs from
+            // macOS where /tmp -> /private/tmp symlink means the property value differs from
             // AppContext.BaseDirectory. By omitting toolsDirectory, both sides default to
             // BuildEnvironmentHelper which resolves symlinks consistently.
 #if RUNTIME_TYPE_NETCORE

--- a/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcTaskHost.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcTaskHost.cs
@@ -361,7 +361,7 @@ namespace Microsoft.Build.BackEnd
 
                     break;
                 default:
-                    CommunicationsUtilities.Trace("PacketReceived: no handler for node {0}, dropping packet type {1}", node, packet.Type);
+                    ErrorUtilities.ThrowInternalError("PacketReceived: no handler for node {0}, unexpected packet type {1}", node, packet.Type);
                     break;
             }
         }

--- a/src/Build/Instance/TaskFactories/TaskHostTask.cs
+++ b/src/Build/Instance/TaskFactories/TaskHostTask.cs
@@ -201,7 +201,7 @@ namespace Microsoft.Build.BackEnd
             (this as INodePacketFactory).RegisterPacketHandler(NodePacketType.NodeShutdown, NodeShutdown.FactoryForDeserialization, this);
             (this as INodePacketFactory).RegisterPacketHandler(NodePacketType.TaskHostIsRunningMultipleNodesRequest, TaskHostIsRunningMultipleNodesRequest.FactoryForDeserialization, this);
             (this as INodePacketFactory).RegisterPacketHandler(NodePacketType.TaskHostCoresRequest, TaskHostCoresRequest.FactoryForDeserialization, this);
-
+            (this as INodePacketFactory).RegisterPacketHandler(NodePacketType.TaskHostBuildRequest, TaskHostBuildRequest.FactoryForDeserialization, this);
             _packetReceivedEvent = new AutoResetEvent(false);
             _receivedPackets = new ConcurrentQueue<INodePacket>();
             _taskHostLock = new();
@@ -535,6 +535,9 @@ namespace Microsoft.Build.BackEnd
                 case NodePacketType.TaskHostCoresRequest:
                     HandleCoresRequest(packet as TaskHostCoresRequest);
                     break;
+                case NodePacketType.TaskHostBuildRequest:
+                    HandleBuildRequest(packet as TaskHostBuildRequest);
+                    break;
                 default:
                     ErrorUtilities.ThrowInternalErrorUnreachable();
                     break;
@@ -691,7 +694,7 @@ namespace Microsoft.Build.BackEnd
         /// </summary>
         private void HandleCoresRequest(TaskHostCoresRequest request)
         {
-            // Default to 1 for RequestCores (not 0) to satisfy the API contract (return ∈ [1, requested]).
+            // Default to 1 for RequestCores (not 0) to satisfy the API contract (return in [1, requested]).
             // For ReleaseCores, 0 is correct as it's just an acknowledgment.
             int grantedCores = request.IsRelease ? 0 : 1;
 
@@ -711,6 +714,69 @@ namespace Microsoft.Build.BackEnd
             }
 
             var response = new TaskHostCoresResponse(request.RequestId, grantedCores);
+            _taskHostProvider.SendData(_taskHostNodeKey, response);
+        }
+
+        /// <summary>
+        /// Handle BuildProjectFile* request from the TaskHost.
+        /// Forwards the call to the in-process IBuildEngine3.BuildProjectFilesInParallel,
+        /// which handles project resolution, scheduler interaction, and target execution.
+        /// </summary>
+        private void HandleBuildRequest(TaskHostBuildRequest request)
+        {
+            TaskHostBuildResponse response;
+            try
+            {
+                if (_buildEngine is not IBuildEngine3 engine3)
+                {
+                    ErrorUtilities.ThrowInternalError("HandleBuildRequest requires IBuildEngine3 but _buildEngine is {0}",
+                        _buildEngine?.GetType().Name ?? "null");
+                    return; // unreachable, but satisfies flow analysis
+                }
+
+                // Reconstruct IDictionary[] from the serialized Dictionary<string, string>[]
+                System.Collections.IDictionary[] globalProperties = null;
+                if (request.GlobalProperties is not null)
+                {
+                    globalProperties = new System.Collections.IDictionary[request.GlobalProperties.Length];
+                    for (int i = 0; i < request.GlobalProperties.Length; i++)
+                    {
+                        globalProperties[i] = request.GlobalProperties[i];
+                    }
+                }
+
+                // Reconstruct IList<string>[] from List<string>[]
+                IList<string>[] removeGlobalProperties = null;
+                if (request.RemoveGlobalProperties is not null)
+                {
+                    removeGlobalProperties = new IList<string>[request.RemoveGlobalProperties.Length];
+                    for (int i = 0; i < request.RemoveGlobalProperties.Length; i++)
+                    {
+                        removeGlobalProperties[i] = request.RemoveGlobalProperties[i];
+                    }
+                }
+
+                BuildEngineResult result = engine3.BuildProjectFilesInParallel(
+                    request.ProjectFileNames,
+                    request.TargetNames,
+                    globalProperties,
+                    removeGlobalProperties,
+                    request.ToolsVersions,
+                    request.ReturnTargetOutputs);
+
+                response = TaskHostBuildResponse.FromBuildEngineResult(request.RequestId, result);
+            }
+            catch (Exception ex) when (!ExceptionHandling.IsCriticalException(ex))
+            {
+                // Engine error state: the BuildProjectFilesInParallel call on the worker side threw.
+                // The task will see Success=false in the response and can react accordingly.
+                // Trace instead of warning to avoid surfacing engine internals to users.
+                CommunicationsUtilities.Trace("TaskHost BuildProjectFile callback failed: {0}", ex);
+
+                // Always send a response to prevent the OOP task from hanging.
+                response = new TaskHostBuildResponse(request.RequestId, false, null);
+            }
+
             _taskHostProvider.SendData(_taskHostNodeKey, response);
         }
 

--- a/src/Build/Instance/TaskFactories/TaskHostTask.cs
+++ b/src/Build/Instance/TaskFactories/TaskHostTask.cs
@@ -724,7 +724,7 @@ namespace Microsoft.Build.BackEnd
         /// </summary>
         private void HandleBuildRequest(TaskHostBuildRequest request)
         {
-            TaskHostBuildResponse response;
+            TaskHostBuildResponse response = null;
             try
             {
                 if (_buildEngine is not IBuildEngine3 engine3)
@@ -766,18 +766,15 @@ namespace Microsoft.Build.BackEnd
 
                 response = TaskHostBuildResponse.FromBuildEngineResult(request.RequestId, result);
             }
-            catch (Exception ex) when (!ExceptionHandling.IsCriticalException(ex))
+            finally
             {
-                // Engine error state: the BuildProjectFilesInParallel call on the worker side threw.
-                // The task will see Success=false in the response and can react accordingly.
-                // Trace instead of warning to avoid surfacing engine internals to users.
-                CommunicationsUtilities.Trace("TaskHost BuildProjectFile callback failed: {0}", ex);
-
                 // Always send a response to prevent the OOP task from hanging.
-                response = new TaskHostBuildResponse(request.RequestId, false, null);
+                // On success, sends the real result; on exception, sends failure.
+                // Exceptions propagate to TaskBuilder which handles them identically
+                // to the in-proc TaskHost path (CircularDependencyException, etc.).
+                response ??= new TaskHostBuildResponse(request.RequestId, false, null);
+                _taskHostProvider.SendData(_taskHostNodeKey, response);
             }
-
-            _taskHostProvider.SendData(_taskHostNodeKey, response);
         }
 
         /// <summary>

--- a/src/Build/Microsoft.Build.csproj
+++ b/src/Build/Microsoft.Build.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="..\Shared\DebuggingSources.proj" />
 
@@ -102,6 +102,9 @@
     <Compile Include="..\Shared\TaskHostIsRunningMultipleNodesResponse.cs" />
     <Compile Include="..\Shared\TaskHostCoresRequest.cs" />
     <Compile Include="..\Shared\TaskHostCoresResponse.cs" />
+    <Compile Include="..\Shared\TaskHostBuildRequest.cs" />
+    <Compile Include="..\Shared\TaskHostBuildResponse.cs" />
+
     <Compile Include="..\Shared\OutOfProcTaskHostTaskResult.cs" />
     <Compile Include="..\Shared\TaskLoader.cs" />
     <Compile Include="..\Shared\NodeEngineShutdownReason.cs" />

--- a/src/Framework/MSBuildEventSource.cs
+++ b/src/Framework/MSBuildEventSource.cs
@@ -758,5 +758,27 @@ namespace Microsoft.Build.Eventing
             WriteEvent(106, nodeId, processId, succeeded);
         }
         #endregion
+
+        #region TaskHost Callback Events
+
+        /// <summary>
+        /// Raised when a TaskHost begins a BuildProjectFile callback.
+        /// </summary>
+        [Event(107, Keywords = Keywords.All)]
+        public void TaskHostBuildProjectFileStart(string projectFiles, string targetNames)
+        {
+            WriteEvent(107, projectFiles, targetNames);
+        }
+
+        /// <summary>
+        /// Raised when a TaskHost BuildProjectFile callback completes.
+        /// </summary>
+        [Event(108, Keywords = Keywords.All)]
+        public void TaskHostBuildProjectFileStop(string projectFiles, bool success)
+        {
+            WriteEvent(108, projectFiles, success);
+        }
+
+        #endregion
     }
 }

--- a/src/MSBuild/MSBuild.csproj
+++ b/src/MSBuild/MSBuild.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="..\Shared\DebuggingSources.proj" />
 
@@ -81,6 +81,9 @@
     <Compile Include="..\Shared\TaskHostIsRunningMultipleNodesResponse.cs" />
     <Compile Include="..\Shared\TaskHostCoresRequest.cs" />
     <Compile Include="..\Shared\TaskHostCoresResponse.cs" />
+    <Compile Include="..\Shared\TaskHostBuildRequest.cs" />
+    <Compile Include="..\Shared\TaskHostBuildResponse.cs" />
+
     <Compile Include="..\Shared\TaskLoader.cs" />
     <Compile Include="..\Shared\TypeLoader.cs" />
     <Compile Include="..\Shared\NodeBuildComplete.cs" />
@@ -102,6 +105,7 @@
     <Compile Include="NodeEndpointOutOfProcTaskHost.cs" />
     <Compile Include="ProjectSchemaValidationHandler.cs" />
     <Compile Include="OutOfProcTaskHostNode.cs" />
+    <Compile Include="TaskExecutionContext.cs" />
     <Compile Include="OutOfProcTaskAppDomainWrapperBase.cs" />
     <Compile Include="OutOfProcTaskAppDomainWrapper.cs" />
     <Compile Include="PerformanceLogEventListener.cs" />

--- a/src/MSBuild/OutOfProcTaskHostNode.cs
+++ b/src/MSBuild/OutOfProcTaskHostNode.cs
@@ -11,6 +11,7 @@ using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Build.BackEnd;
+using Microsoft.Build.Eventing;
 using Microsoft.Build.Execution;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Experimental.FileAccess;
@@ -100,9 +101,17 @@ namespace Microsoft.Build.CommandLine
         private NodeEngineShutdownReason _shutdownReason;
 
         /// <summary>
-        /// We set this flag to track a currently executing task
+        /// Count of tasks that are actively executing (not blocked on a callback).
+        /// When a task blocks on BuildProjectFile, this decrements. When it resumes, this increments.
+        /// Used to determine if we can accept new TaskHostConfiguration packets.
         /// </summary>
-        private bool _isTaskExecuting;
+        private int _activeTaskCount;
+
+        /// <summary>
+        /// Number of tasks currently blocked on a BuildProjectFile callback.
+        /// A blocked task does NOT prevent new tasks from being scheduled to this TaskHost.
+        /// </summary>
+        private int _blockedTaskCount;
 
         /// <summary>
         /// The event which is set when a task has completed.
@@ -110,27 +119,17 @@ namespace Microsoft.Build.CommandLine
         private AutoResetEvent _taskCompleteEvent;
 
         /// <summary>
-        /// Packet containing all the information relating to the
-        /// completed state of the task.
+        /// The completed task packet waiting to be sent by the main thread.
+        /// Only one task can be completing at a time (blocked tasks can't complete
+        /// until they resume, and the resumed task is the only active one).
         /// </summary>
         private TaskHostTaskComplete _taskCompletePacket;
-
-        /// <summary>
-        /// Object used to synchronize access to taskCompletePacket
-        /// </summary>
-        private LockType _taskCompleteLock = new();
 
         /// <summary>
         /// The event which is set when a task is cancelled
         /// </summary>
         private ManualResetEvent _taskCancelledEvent;
 
-        /// <summary>
-        /// The thread currently executing user task in the TaskRunner
-        /// </summary>
-        private Thread _taskRunnerThread;
-
-        /// <summary>
         /// This is the wrapper for the user task to be executed.
         /// We are providing a wrapper to create a possibility of executing the task in a separate AppDomain
         /// </summary>
@@ -183,6 +182,27 @@ namespace Microsoft.Build.CommandLine
         private readonly ConcurrentDictionary<int, TaskCompletionSource<INodePacket>> _pendingCallbackRequests = new();
 
         /// <summary>
+        /// All active task execution contexts, keyed by task ID.
+        /// Supports nested task execution when tasks block on BuildProjectFile callbacks.
+        /// </summary>
+        private readonly ConcurrentDictionary<int, TaskExecutionContext> _taskContexts
+            = new ConcurrentDictionary<int, TaskExecutionContext>();
+
+        /// <summary>
+        /// The task context for the calling thread. Each task runs on its own thread
+        /// (spawned in HandleTaskHostConfiguration). When Task A blocks on BuildProjectFile,
+        /// Task B starts on a new thread. AsyncLocal ensures each thread sees its own context
+        /// for logging, pending callbacks, and environment state.
+        /// </summary>
+        private readonly AsyncLocal<TaskExecutionContext> _currentTaskContext
+            = new AsyncLocal<TaskExecutionContext>();
+
+        /// <summary>
+        /// Counter for generating task IDs when configuration doesn't provide one.
+        /// </summary>
+        private int _nextLocalTaskId;
+
+        /// <summary>
         /// The packet version negotiated with the owning worker node.
         /// Used to determine if the worker node supports callback packets.
         /// </summary>
@@ -199,6 +219,12 @@ namespace Microsoft.Build.CommandLine
         /// True if the worker node's packet version is high enough, or if the feature is force-enabled via env var.
         /// </summary>
         private bool CallbacksSupported => _parentPacketVersion >= CallbacksMinPacketVersion || Traits.Instance.EnableTaskHostCallbacks;
+
+        /// <summary>
+        /// Gets the effective configuration for the current task thread.
+        /// Uses the per-task context first, falling back to <see cref="_currentConfiguration"/>.
+        /// </summary>
+        private TaskHostConfiguration EffectiveConfiguration => GetCurrentConfiguration();
 
         /// <summary>
         /// Constructor.
@@ -227,7 +253,7 @@ namespace Microsoft.Build.CommandLine
             thisINodePacketFactory.RegisterPacketHandler(NodePacketType.NodeBuildComplete, NodeBuildComplete.FactoryForDeserialization, this);
             thisINodePacketFactory.RegisterPacketHandler(NodePacketType.TaskHostIsRunningMultipleNodesResponse, TaskHostIsRunningMultipleNodesResponse.FactoryForDeserialization, this);
             thisINodePacketFactory.RegisterPacketHandler(NodePacketType.TaskHostCoresResponse, TaskHostCoresResponse.FactoryForDeserialization, this);
-
+            thisINodePacketFactory.RegisterPacketHandler(NodePacketType.TaskHostBuildResponse, TaskHostBuildResponse.FactoryForDeserialization, this);
             EngineServices = new EngineServicesImpl(this);
         }
 
@@ -240,8 +266,8 @@ namespace Microsoft.Build.CommandLine
         {
             get
             {
-                ErrorUtilities.VerifyThrow(_currentConfiguration != null, "We should never have a null configuration during a BuildEngine callback!");
-                return _currentConfiguration.ContinueOnError;
+                ErrorUtilities.VerifyThrow(EffectiveConfiguration != null, "We should never have a null configuration during a BuildEngine callback!");
+                return EffectiveConfiguration.ContinueOnError;
             }
         }
 
@@ -252,8 +278,8 @@ namespace Microsoft.Build.CommandLine
         {
             get
             {
-                ErrorUtilities.VerifyThrow(_currentConfiguration != null, "We should never have a null configuration during a BuildEngine callback!");
-                return _currentConfiguration.LineNumberOfTask;
+                ErrorUtilities.VerifyThrow(EffectiveConfiguration != null, "We should never have a null configuration during a BuildEngine callback!");
+                return EffectiveConfiguration.LineNumberOfTask;
             }
         }
 
@@ -264,8 +290,8 @@ namespace Microsoft.Build.CommandLine
         {
             get
             {
-                ErrorUtilities.VerifyThrow(_currentConfiguration != null, "We should never have a null configuration during a BuildEngine callback!");
-                return _currentConfiguration.ColumnNumberOfTask;
+                ErrorUtilities.VerifyThrow(EffectiveConfiguration != null, "We should never have a null configuration during a BuildEngine callback!");
+                return EffectiveConfiguration.ColumnNumberOfTask;
             }
         }
 
@@ -276,8 +302,8 @@ namespace Microsoft.Build.CommandLine
         {
             get
             {
-                ErrorUtilities.VerifyThrow(_currentConfiguration != null, "We should never have a null configuration during a BuildEngine callback!");
-                return _currentConfiguration.ProjectFileOfTask;
+                ErrorUtilities.VerifyThrow(EffectiveConfiguration != null, "We should never have a null configuration during a BuildEngine callback!");
+                return EffectiveConfiguration.ProjectFileOfTask;
             }
         }
 
@@ -320,17 +346,56 @@ namespace Microsoft.Build.CommandLine
         /// <summary>
         /// Contains all warnings that should be logged as errors.
         /// Non-null empty set when all warnings should be treated as errors.
+        /// Fallback for code paths without a TaskExecutionContext (e.g., main thread).
+        /// Task threads use EffectiveWarningsAs* which reads per-task context first.
         /// </summary>
-        private ICollection<string> WarningsAsErrors { get; set; }
+        private ICollection<string> _warningsAsErrors;
 
-        private ICollection<string> WarningsNotAsErrors { get; set; }
+        /// <summary>Fallback for WarningsNotAsErrors. See <see cref="_warningsAsErrors"/>.</summary>
+        private ICollection<string> _warningsNotAsErrors;
 
-        private ICollection<string> WarningsAsMessages { get; set; }
+        /// <summary>Fallback for WarningsAsMessages. See <see cref="_warningsAsErrors"/>.</summary>
+        private ICollection<string> _warningsAsMessages;
+
+        /// <summary>
+        /// Gets the effective WarningsAsErrors for the current task context.
+        /// Uses per-task saved values when available (during concurrent execution),
+        /// falling back to the shared field.
+        /// </summary>
+        private ICollection<string> EffectiveWarningsAsErrors
+        {
+            get
+            {
+                var context = GetCurrentTaskContext();
+                return context?.WarningsAsErrors ?? _warningsAsErrors;
+            }
+        }
+
+        private ICollection<string> EffectiveWarningsNotAsErrors
+        {
+            get
+            {
+                var context = GetCurrentTaskContext();
+                return context?.WarningsNotAsErrors ?? _warningsNotAsErrors;
+            }
+        }
+
+        private ICollection<string> EffectiveWarningsAsMessages
+        {
+            get
+            {
+                var context = GetCurrentTaskContext();
+                return context?.WarningsAsMessages ?? _warningsAsMessages;
+            }
+        }
 
         public bool ShouldTreatWarningAsError(string warningCode)
         {
+            var warningsAsErrors = EffectiveWarningsAsErrors;
+            var warningsAsMessages = EffectiveWarningsAsMessages;
+
             // Warnings as messages overrides warnings as errors.
-            if (WarningsAsErrors == null || WarningsAsMessages?.Contains(warningCode) == true)
+            if (warningsAsErrors is null || warningsAsMessages?.Contains(warningCode) == true)
             {
                 return false;
             }
@@ -338,16 +403,16 @@ namespace Microsoft.Build.CommandLine
             if (ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave18_6))
             {
                 // An empty set means all warnings are errors.
-                return (WarningsAsErrors.Count == 0 && WarningAsErrorNotOverriden(warningCode)) || WarningsAsErrors.Contains(warningCode);
+                return (warningsAsErrors.Count == 0 && WarningAsErrorNotOverriden(warningCode)) || warningsAsErrors.Contains(warningCode);
             }
 
             // Pre-18.6 behavior preserved for backward compatibility: incorrectly checks WarningsAsMessages instead of WarningsAsErrors.
-            return (WarningsAsErrors.Count == 0 && WarningAsErrorNotOverriden(warningCode)) || WarningsAsMessages.Contains(warningCode);
+            return (warningsAsErrors.Count == 0 && WarningAsErrorNotOverriden(warningCode)) || warningsAsMessages.Contains(warningCode);
         }
 
         private bool WarningAsErrorNotOverriden(string warningCode)
         {
-            return WarningsNotAsErrors?.Contains(warningCode) != true;
+            return EffectiveWarningsNotAsErrors?.Contains(warningCode) != true;
         }
         #endregion
 
@@ -394,13 +459,17 @@ namespace Microsoft.Build.CommandLine
         }
 
         /// <summary>
-        /// Stub implementation of IBuildEngine.BuildProjectFile.  The task host does not support IBuildEngine
-        /// callbacks for the purposes of building projects, so error.
+        /// Implementation of IBuildEngine.BuildProjectFile. Delegates to the 5-param overload.
         /// </summary>
         public bool BuildProjectFile(string projectFileName, string[] targetNames, IDictionary globalProperties, IDictionary targetOutputs)
         {
-            LogErrorFromResource("BuildEngineCallbacksInTaskHostUnsupported");
-            return false;
+            if (!CallbacksSupported)
+            {
+                LogErrorFromResource("BuildEngineCallbacksInTaskHostUnsupported");
+                return false;
+            }
+
+            return BuildProjectFile(projectFileName, targetNames, globalProperties, targetOutputs, null);
         }
 
         #endregion // IBuildEngine Implementation (Methods)
@@ -408,23 +477,67 @@ namespace Microsoft.Build.CommandLine
         #region IBuildEngine2 Implementation (Methods)
 
         /// <summary>
-        /// Stub implementation of IBuildEngine2.BuildProjectFile.  The task host does not support IBuildEngine
-        /// callbacks for the purposes of building projects, so error.
+        /// Implementation of IBuildEngine2.BuildProjectFile. Delegates to the 7-param BuildProjectFilesInParallel.
         /// </summary>
         public bool BuildProjectFile(string projectFileName, string[] targetNames, IDictionary globalProperties, IDictionary targetOutputs, string toolsVersion)
         {
-            LogErrorFromResource("BuildEngineCallbacksInTaskHostUnsupported");
-            return false;
+            if (!CallbacksSupported)
+            {
+                LogErrorFromResource("BuildEngineCallbacksInTaskHostUnsupported");
+                return false;
+            }
+
+            return BuildProjectFilesInParallel(
+                [projectFileName],
+                targetNames,
+                [globalProperties],
+                [targetOutputs],
+                [toolsVersion],
+                true,
+                false);
         }
 
         /// <summary>
-        /// Stub implementation of IBuildEngine2.BuildProjectFilesInParallel.  The task host does not support IBuildEngine
-        /// callbacks for the purposes of building projects, so error.
+        /// Implementation of IBuildEngine2.BuildProjectFilesInParallel. Delegates to the 6-param IBuildEngine3 overload.
         /// </summary>
         public bool BuildProjectFilesInParallel(string[] projectFileNames, string[] targetNames, IDictionary[] globalProperties, IDictionary[] targetOutputsPerProject, string[] toolsVersion, bool useResultsCache, bool unloadProjectsOnCompletion)
         {
-            LogErrorFromResource("BuildEngineCallbacksInTaskHostUnsupported");
-            return false;
+            if (!CallbacksSupported)
+            {
+                LogErrorFromResource("BuildEngineCallbacksInTaskHostUnsupported");
+                return false;
+            }
+
+            if (projectFileNames is null)
+            {
+                return false;
+            }
+
+            ErrorUtilities.VerifyThrow(
+                targetOutputsPerProject is null || projectFileNames.Length == targetOutputsPerProject.Length,
+                "projectFileNames has {0} entries but targetOutputsPerProject has {1} -- lengths must match.",
+                projectFileNames.Length,
+                targetOutputsPerProject?.Length ?? 0);
+
+            bool includeTargetOutputs = targetOutputsPerProject is not null;
+
+            BuildEngineResult result = BuildProjectFilesInParallel(projectFileNames, targetNames, globalProperties, new List<string>[projectFileNames.Length], toolsVersion, includeTargetOutputs);
+
+            if (includeTargetOutputs && result.TargetOutputsPerProject is not null)
+            {
+                for (int i = 0; i < targetOutputsPerProject.Length && i < result.TargetOutputsPerProject.Count; i++)
+                {
+                    if (targetOutputsPerProject[i] is not null)
+                    {
+                        foreach (KeyValuePair<string, ITaskItem[]> output in result.TargetOutputsPerProject[i])
+                        {
+                            targetOutputsPerProject[i].Add(output.Key, output.Value);
+                        }
+                    }
+                }
+            }
+
+            return result.Result;
         }
 
         #endregion // IBuildEngine2 Implementation (Methods)
@@ -432,31 +545,67 @@ namespace Microsoft.Build.CommandLine
         #region IBuildEngine3 Implementation
 
         /// <summary>
-        /// Stub implementation of IBuildEngine3.BuildProjectFilesInParallel.  The task host does not support IBuildEngine
-        /// callbacks for the purposes of building projects, so error.
+        /// Implementation of IBuildEngine3.BuildProjectFilesInParallel. This is the canonical form that
+        /// sends the request to the owning worker node and waits for the response.
         /// </summary>
         public BuildEngineResult BuildProjectFilesInParallel(string[] projectFileNames, string[] targetNames, IDictionary[] globalProperties, IList<string>[] removeGlobalProperties, string[] toolsVersion, bool returnTargetOutputs)
         {
-            LogErrorFromResource("BuildEngineCallbacksInTaskHostUnsupported");
-            return new BuildEngineResult(false, null);
+            if (!CallbacksSupported)
+            {
+                LogErrorFromResource("BuildEngineCallbacksInTaskHostUnsupported");
+                return new BuildEngineResult(false, null);
+            }
+
+            string projectFilesJoined = string.Join(";", projectFileNames ?? []);
+            string targetNamesJoined = string.Join(";", targetNames ?? []);
+
+            if (MSBuildEventSource.Log.IsEnabled())
+            {
+                MSBuildEventSource.Log.TaskHostBuildProjectFileStart(projectFilesJoined, targetNamesJoined);
+            }
+
+            var request = new TaskHostBuildRequest(
+                projectFileNames,
+                targetNames,
+                TaskHostBuildRequest.ConvertGlobalProperties(globalProperties),
+                TaskHostBuildRequest.ConvertRemoveGlobalProperties(removeGlobalProperties),
+                toolsVersion,
+                returnTargetOutputs);
+
+            // Block while the callback is processed so the node can accept nested tasks.
+            BlockForCallback();
+            bool success = false;
+            try
+            {
+                var response = SendCallbackRequestAndWaitForResponse<TaskHostBuildResponse>(request);
+                var result = response.ToBuildEngineResult();
+                success = result.Result;
+                return result;
+            }
+            finally
+            {
+                if (MSBuildEventSource.Log.IsEnabled())
+                {
+                    MSBuildEventSource.Log.TaskHostBuildProjectFileStop(projectFilesJoined, success);
+                }
+
+                ResumeAfterCallback();
+            }
         }
 
         /// <summary>
-        /// Stub implementation of IBuildEngine3.Yield.  The task host does not support yielding, so just go ahead and silently
-        /// return, letting the task continue.
+        /// No-op. Explicit yield is not supported in the OOP TaskHost.
+        /// Nested task dispatch uses BuildProjectFile callback blocking instead.
         /// </summary>
         public void Yield()
         {
-            return;
         }
 
         /// <summary>
-        /// Stub implementation of IBuildEngine3.Reacquire. The task host does not support yielding, so just go ahead and silently
-        /// return, letting the task continue.
+        /// No-op. See <see cref="Yield"/>.
         /// </summary>
         public void Reacquire()
         {
-            return;
         }
 
         #endregion // IBuildEngine3 Implementation
@@ -533,7 +682,7 @@ namespace Microsoft.Build.CommandLine
         /// <returns>An <see cref="IReadOnlyDictionary{String, String}" /> containing the global properties of the current project.</returns>
         public IReadOnlyDictionary<string, string> GetGlobalProperties()
         {
-            return new Dictionary<string, string>(_currentConfiguration.GlobalProperties);
+            return new Dictionary<string, string>(EffectiveConfiguration.GlobalProperties);
         }
 
         #endregion
@@ -593,8 +742,8 @@ namespace Microsoft.Build.CommandLine
             {
                 get
                 {
-                    ErrorUtilities.VerifyThrow(_taskHost._currentConfiguration != null, "We should never have a null configuration during a BuildEngine callback!");
-                    return _taskHost._currentConfiguration.IsTaskInputLoggingEnabled;
+                    ErrorUtilities.VerifyThrow(_taskHost.EffectiveConfiguration != null, "We should never have a null configuration during a BuildEngine callback!");
+                    return _taskHost.EffectiveConfiguration.IsTaskInputLoggingEnabled;
                 }
             }
 
@@ -780,6 +929,7 @@ namespace Microsoft.Build.CommandLine
                 // Callback response packets - route to pending request
                 case NodePacketType.TaskHostIsRunningMultipleNodesResponse:
                 case NodePacketType.TaskHostCoresResponse:
+                case NodePacketType.TaskHostBuildResponse:
                     HandleCallbackResponse(packet);
                     break;
             }
@@ -797,12 +947,26 @@ namespace Microsoft.Build.CommandLine
                 return;
             }
 
-            // Request ID not found is expected if the connection was lost and the task thread
-            // already cleaned up via the finally block in SendCallbackRequestAndWaitForResponse.
+            // Try per-task context pending requests first, then fall back to global
+            foreach (var kvp in _taskContexts)
+            {
+                if (kvp.Value.PendingCallbackRequests.TryRemove(callbackPacket.RequestId, out TaskCompletionSource<INodePacket> tcsFromContext))
+                {
+                    tcsFromContext.TrySetResult(packet);
+                    return;
+                }
+            }
+
             if (_pendingCallbackRequests.TryRemove(callbackPacket.RequestId, out TaskCompletionSource<INodePacket> tcs))
             {
                 tcs.TrySetResult(packet);
+                return;
             }
+
+            // No pending request matched -- trace for diagnostic visibility.
+            // This is an engine error state (protocol bug or race), not a user scenario.
+            CommunicationsUtilities.Trace("TaskHost received callback response with no pending request. RequestId={0}, Type={1}",
+                callbackPacket.RequestId, packet.Type);
         }
 
         /// <summary>
@@ -834,19 +998,24 @@ namespace Microsoft.Build.CommandLine
         private TResponse SendCallbackRequestAndWaitForResponse<TResponse>(ITaskHostCallbackPacket request)
             where TResponse : class, INodePacket
         {
+            // Get context - use per-task pending requests if available
+            var context = GetCurrentTaskContext();
+            var pendingRequests = context?.PendingCallbackRequests ?? _pendingCallbackRequests;
+
+            // IMPORTANT: Request IDs must be globally unique across all task contexts
             int requestId = Interlocked.Increment(ref _nextCallbackRequestId);
             request.RequestId = requestId;
 
             var tcs = new TaskCompletionSource<INodePacket>(TaskCreationOptions.RunContinuationsAsynchronously);
-            _pendingCallbackRequests[requestId] = tcs;
+            pendingRequests[requestId] = tcs;
 
             try
             {
                 // Send the request packet to the owning worker node
                 _nodeEndpoint.SendData(request);
 
-                // Block until the response arrives (via HandleCallbackResponse → TCS.SetResult)
-                // or the connection is lost (via OnLinkStatusChanged → TCS.TrySetException).
+                // Block until the response arrives (via HandleCallbackResponse -> TCS.SetResult)
+                // or the connection is lost (via OnLinkStatusChanged -> TCS.TrySetException).
                 // No timeout - callbacks like BuildProjectFile can legitimately take hours.
                 INodePacket response = tcs.Task.GetAwaiter().GetResult();
 
@@ -860,8 +1029,136 @@ namespace Microsoft.Build.CommandLine
             }
             finally
             {
-                _pendingCallbackRequests.TryRemove(requestId, out _);
+                pendingRequests.TryRemove(requestId, out _);
             }
+        }
+
+        /// <summary>
+        /// Marks this task as blocked on a callback so the node can accept nested tasks.
+        /// Saves the current operating environment before blocking.
+        /// </summary>
+        private void BlockForCallback()
+        {
+            var context = GetCurrentTaskContext();
+            if (context is not null)
+            {
+                SaveOperatingEnvironment(context);
+                context.State = TaskExecutionState.BlockedOnCallback;
+            }
+
+            // Transition from "active" to "blocked" state.
+            Interlocked.Increment(ref _blockedTaskCount);
+            Interlocked.Decrement(ref _activeTaskCount);
+        }
+
+        /// <summary>
+        /// Marks this task as active again after a callback completes.
+        /// Restores the previously saved operating environment.
+        /// </summary>
+        private void ResumeAfterCallback()
+        {
+            // Transition from "blocked" back to "active" state.
+            Interlocked.Increment(ref _activeTaskCount);
+            Interlocked.Decrement(ref _blockedTaskCount);
+
+            // Restore environment state after resuming
+            var context = GetCurrentTaskContext();
+            if (context is not null)
+            {
+                RestoreOperatingEnvironment(context);
+                context.State = TaskExecutionState.Executing;
+            }
+        }
+
+        /// <summary>
+        /// Gets the task execution context for the current thread.
+        /// </summary>
+        private TaskExecutionContext GetCurrentTaskContext()
+        {
+            return _currentTaskContext.Value;
+        }
+
+        /// <summary>
+        /// Gets the configuration for the currently executing task on this thread.
+        /// Uses the thread-local task context if available, falling back to the global configuration.
+        /// </summary>
+        private TaskHostConfiguration GetCurrentConfiguration()
+        {
+            var context = GetCurrentTaskContext();
+            return context?.Configuration ?? _currentConfiguration;
+        }
+
+        /// <summary>
+        /// Creates a new task execution context for the given configuration.
+        /// </summary>
+        private TaskExecutionContext CreateTaskContext(TaskHostConfiguration configuration)
+        {
+            int taskId = Interlocked.Increment(ref _nextLocalTaskId);
+
+            var context = new TaskExecutionContext(taskId, configuration);
+
+            if (!_taskContexts.TryAdd(taskId, context))
+            {
+                context.Dispose();
+                throw new InvalidOperationException(
+                    $"Task ID {taskId} already exists in TaskHost.");
+            }
+
+            return context;
+        }
+
+        /// <summary>
+        /// Removes and disposes a task execution context.
+        /// </summary>
+        private void RemoveTaskContext(int taskId)
+        {
+            if (_taskContexts.TryRemove(taskId, out var context))
+            {
+                context.Dispose();
+            }
+        }
+
+        /// <summary>
+        /// Saves the current operating environment to the task context.
+        /// Called before blocking on a callback that allows other tasks to run.
+        /// </summary>
+        private void SaveOperatingEnvironment(TaskExecutionContext context)
+        {
+            ErrorUtilities.VerifyThrowArgumentNull(context, nameof(context));
+
+            context.SavedCurrentDirectory = NativeMethodsShared.GetCurrentDirectory();
+            context.SavedEnvironment = new Dictionary<string, string>(
+                FrameworkCommunicationsUtilities.GetEnvironmentVariables(),
+                StringComparer.OrdinalIgnoreCase);
+
+            // Save debug/environment flags that are overwritten per-task in RunTask
+            context.SavedDebugCommunications = _debugCommunications;
+            context.SavedUpdateEnvironment = _updateEnvironment;
+            context.SavedUpdateEnvironmentAndLog = _updateEnvironmentAndLog;
+        }
+
+        /// <summary>
+        /// Restores the previously saved operating environment from the task context.
+        /// </summary>
+        private void RestoreOperatingEnvironment(TaskExecutionContext context)
+        {
+            ErrorUtilities.VerifyThrowArgumentNull(context, nameof(context));
+
+            if (context.SavedCurrentDirectory is null || context.SavedEnvironment is null)
+            {
+                return;
+            }
+
+            FrameworkCommunicationsUtilities.SetEnvironment(context.SavedEnvironment);
+            NativeMethodsShared.SetCurrentDirectory(context.SavedCurrentDirectory);
+
+            // Restore debug/environment flags
+            _debugCommunications = context.SavedDebugCommunications;
+            _updateEnvironment = context.SavedUpdateEnvironment;
+            _updateEnvironmentAndLog = context.SavedUpdateEnvironmentAndLog;
+
+            context.SavedCurrentDirectory = null;
+            context.SavedEnvironment = null;
         }
 
         /// <summary>
@@ -870,13 +1167,29 @@ namespace Microsoft.Build.CommandLine
         /// </summary>
         private void HandleTaskHostConfiguration(TaskHostConfiguration taskHostConfiguration)
         {
-            ErrorUtilities.VerifyThrow(!_isTaskExecuting, "Why are we getting a TaskHostConfiguration packet while we're still executing a task?");
+            // Allow new configuration when no task is actively executing.
+            // A task blocked on a BuildProjectFile callback does NOT prevent
+            // a new task from starting - this enables nested build scenarios.
+            ErrorUtilities.VerifyThrow(_activeTaskCount == 0,
+                "Why are we getting a TaskHostConfiguration packet while a task is actively executing? activeTaskCount={0}",
+                _activeTaskCount);
+
+            if (_blockedTaskCount > 0)
+            {
+                CommunicationsUtilities.Trace("Nested task {0} dispatched while {1} tasks are blocked on callbacks.", taskHostConfiguration.TaskName, _blockedTaskCount);
+            }
+
             _currentConfiguration = taskHostConfiguration;
+            // Create task execution context for this task
+            var context = CreateTaskContext(taskHostConfiguration);
+            context.State = TaskExecutionState.Executing;
 
             // Kick off the task running thread.
-            _taskRunnerThread = new Thread(new ParameterizedThreadStart(RunTask));
-            _taskRunnerThread.Name = "Task runner for task " + taskHostConfiguration.TaskName;
-            _taskRunnerThread.Start(taskHostConfiguration);
+            var taskThread = new Thread(new ParameterizedThreadStart(RunTask));
+            taskThread.Name = "Task runner for task " + taskHostConfiguration.TaskName;
+            context.ExecutingThread = taskThread;
+
+            taskThread.Start(context);
         }
 
         /// <summary>
@@ -884,22 +1197,20 @@ namespace Microsoft.Build.CommandLine
         /// </summary>
         private void CompleteTask()
         {
-            ErrorUtilities.VerifyThrow(!_isTaskExecuting, "The task should be done executing before CompleteTask.");
-            if (_nodeEndpoint.LinkStatus == LinkStatus.Active)
+            // Only the active (topmost) task can complete. Blocked tasks are waiting
+            // on a callback response and can't finish until they resume.
+            if (_nodeEndpoint.LinkStatus == LinkStatus.Active && _taskCompletePacket is not null)
             {
-                TaskHostTaskComplete taskCompletePacketToSend;
-
-                lock (_taskCompleteLock)
-                {
-                    ErrorUtilities.VerifyThrowInternalNull(_taskCompletePacket, "taskCompletePacket");
-                    taskCompletePacketToSend = _taskCompletePacket;
-                    _taskCompletePacket = null;
-                }
-
-                _nodeEndpoint.SendData(taskCompletePacketToSend);
+                _nodeEndpoint.SendData(_taskCompletePacket);
+                _taskCompletePacket = null;
             }
 
-            _currentConfiguration = null;
+            // Only clear _currentConfiguration when no tasks remain (active or blocked).
+            // A blocked task still needs the config for logging via EffectiveConfiguration.
+            if (_activeTaskCount == 0 && _blockedTaskCount == 0)
+            {
+                _currentConfiguration = null;
+            }
 
             // If the task has been canceled, the event will still be set.
             // If so, now that we've completed the task, we want to shut down
@@ -917,26 +1228,32 @@ namespace Microsoft.Build.CommandLine
         /// </summary>
         private void CancelTask()
         {
-            // If the task is an ICancellable task in CLR4 we will call it here and wait for it to complete
-            // Otherwise it's a classic ITask.
-
-            // Store in a local to avoid a race
-            var wrapper = _taskWrapper;
-            if (wrapper?.CancelTask() == false)
+            // Cancel all task wrappers -- with nested builds via BuildProjectFile callbacks,
+            // multiple tasks may be active on the same TaskHost process.
+            foreach (var kvp in _taskContexts)
             {
-                // Create a possibility for the task to be aborted if the user really wants it dropped dead asap
-                if (Environment.GetEnvironmentVariable("MSBUILDTASKHOSTABORTTASKONCANCEL") == "1")
+                var ctxWrapper = kvp.Value.TaskWrapper;
+                ctxWrapper?.CancelTask();
+            }
+
+            // Also cancel via the shared field for the case where no context exists yet
+            var wrapper = _taskWrapper;
+            wrapper?.CancelTask();
+
+            if (Environment.GetEnvironmentVariable("MSBUILDTASKHOSTABORTTASKONCANCEL") == "1")
+            {
+                if (_activeTaskCount > 0)
                 {
-                    // Don't bother aborting the task if it has passed the actual user task Execute()
-                    // It means we're already in the process of shutting down - Wait for the taskCompleteEvent to be set instead.
-                    if (_isTaskExecuting)
-                    {
 #if FEATURE_THREAD_ABORT
-                        // The thread will be terminated crudely so our environment may be trashed but it's ok since we are
-                        // shutting down ASAP.
-                        _taskRunnerThread.Abort();
-#endif
+                    foreach (var kvp in _taskContexts)
+                    {
+                        Thread t = kvp.Value.ExecutingThread;
+                        if (t is not null && t.IsAlive)
+                        {
+                            t.Abort();
+                        }
                     }
+#endif
                 }
             }
         }
@@ -946,7 +1263,7 @@ namespace Microsoft.Build.CommandLine
         /// </summary>
         private void HandleNodeBuildComplete(NodeBuildComplete buildComplete)
         {
-            ErrorUtilities.VerifyThrow(!_isTaskExecuting, "We should never have a task in the process of executing when we receive NodeBuildComplete.");
+            ErrorUtilities.VerifyThrow(_activeTaskCount == 0, "We should never have a task in the process of executing when we receive NodeBuildComplete.");
 
             // Sidecar TaskHost will persist after the build is done.
             if (_nodeReuse)
@@ -966,8 +1283,15 @@ namespace Microsoft.Build.CommandLine
         /// </summary>
         private NodeEngineShutdownReason HandleShutdown()
         {
-            // Wait for the RunTask task runner thread before shutting down so that we can cleanly dispose all WaitHandles.
-            _taskRunnerThread?.Join();
+            // FIRST: Fail all pending callback requests so blocked task threads can unblock.
+            // This must happen BEFORE joining threads to prevent deadlock.
+            FailAllPendingCallbackRequests("TaskHost shutting down.");
+
+            // Wait for all task threads before shutting down so that we can cleanly dispose all WaitHandles.
+            foreach (var kvp in _taskContexts)
+            {
+                kvp.Value.ExecutingThread?.Join();
+            }
 
             using StreamWriter debugWriter = _debugCommunications
                     ? File.CreateText(string.Format(CultureInfo.CurrentCulture, Path.Combine(FileUtilities.TempFileDirectory, @"MSBuild_NodeShutdown_{0}.txt"), EnvironmentUtilities.CurrentProcessId))
@@ -1025,14 +1349,7 @@ namespace Microsoft.Build.CommandLine
 
                     // Fail all pending callback requests so task threads unblock immediately
                     // instead of waiting indefinitely for responses that will never arrive.
-                    foreach (var kvp in _pendingCallbackRequests)
-                    {
-                        if (_pendingCallbackRequests.TryRemove(kvp.Key, out TaskCompletionSource<INodePacket> tcs))
-                        {
-                            tcs.TrySetException(new InvalidOperationException(
-                                "TaskHost lost connection to owning worker node during callback."));
-                        }
-                    }
+                    FailAllPendingCallbackRequests("TaskHost lost connection to owning worker node during callback.");
 
                     _shutdownEvent.Set();
                     break;
@@ -1046,13 +1363,46 @@ namespace Microsoft.Build.CommandLine
         }
 
         /// <summary>
+        /// Fails all pending callback requests (both global and per-task) with an InvalidOperationException.
+        /// Used during shutdown and connection loss to unblock task threads waiting on callback responses.
+        /// </summary>
+        private void FailAllPendingCallbackRequests(string errorMessage)
+        {
+            foreach (var kvp in _pendingCallbackRequests)
+            {
+                if (_pendingCallbackRequests.TryRemove(kvp.Key, out TaskCompletionSource<INodePacket> tcs))
+                {
+                    tcs.TrySetException(new InvalidOperationException(errorMessage));
+                }
+            }
+
+            foreach (var contextKvp in _taskContexts)
+            {
+                foreach (var reqKvp in contextKvp.Value.PendingCallbackRequests)
+                {
+                    if (contextKvp.Value.PendingCallbackRequests.TryRemove(reqKvp.Key, out TaskCompletionSource<INodePacket> ctxTcs))
+                    {
+                        ctxTcs.TrySetException(new InvalidOperationException(errorMessage));
+                    }
+                }
+            }
+        }
+
+        /// <summary>
         /// Task runner method
         /// </summary>
         private void RunTask(object state)
         {
-            _isTaskExecuting = true;
+            Interlocked.Increment(ref _activeTaskCount);
             OutOfProcTaskHostTaskResult taskResult = null;
-            TaskHostConfiguration taskConfiguration = state as TaskHostConfiguration;
+            TaskExecutionContext taskContext = state as TaskExecutionContext;
+            TaskHostConfiguration taskConfiguration = taskContext?.Configuration ?? state as TaskHostConfiguration;
+
+            if (taskContext is not null)
+            {
+                _currentTaskContext.Value = taskContext;
+            }
+
             IDictionary<string, TaskParameter> taskParams = taskConfiguration.TaskParameters;
 
             // We only really know the values of these variables for sure once we see what we received from the owning worker node
@@ -1061,9 +1411,19 @@ namespace Microsoft.Build.CommandLine
             _debugCommunications = taskConfiguration.BuildProcessEnvironment.ContainsValueAndIsEqual("MSBUILDDEBUGCOMM", "1", StringComparison.OrdinalIgnoreCase);
             _updateEnvironment = !taskConfiguration.BuildProcessEnvironment.ContainsValueAndIsEqual("MSBuildTaskHostDoNotUpdateEnvironment", "1", StringComparison.OrdinalIgnoreCase);
             _updateEnvironmentAndLog = taskConfiguration.BuildProcessEnvironment.ContainsValueAndIsEqual("MSBuildTaskHostUpdateEnvironmentAndLog", "1", StringComparison.OrdinalIgnoreCase);
-            WarningsAsErrors = taskConfiguration.WarningsAsErrors;
-            WarningsNotAsErrors = taskConfiguration.WarningsNotAsErrors;
-            WarningsAsMessages = taskConfiguration.WarningsAsMessages;
+            _warningsAsErrors = taskConfiguration.WarningsAsErrors;
+            _warningsNotAsErrors = taskConfiguration.WarningsNotAsErrors;
+            _warningsAsMessages = taskConfiguration.WarningsAsMessages;
+
+            // Store warning settings in per-task context so EffectiveWarningsAs* accessors
+            // return the correct values when multiple tasks run concurrently.
+            if (taskContext is not null)
+            {
+                taskContext.WarningsAsErrors = taskConfiguration.WarningsAsErrors;
+                taskContext.WarningsNotAsErrors = taskConfiguration.WarningsNotAsErrors;
+                taskContext.WarningsAsMessages = taskConfiguration.WarningsAsMessages;
+            }
+            OutOfProcTaskAppDomainWrapper taskWrapper = null;
             try
             {
                 // Change to the startup directory
@@ -1089,9 +1449,17 @@ namespace Microsoft.Build.CommandLine
 
                 // We will not create an appdomain now because of a bug
                 // As a fix, we will create the class directly without wrapping it in a domain
-                _taskWrapper = new OutOfProcTaskAppDomainWrapper();
+                taskWrapper = new OutOfProcTaskAppDomainWrapper();
+                _taskWrapper = taskWrapper;
 
-                taskResult = _taskWrapper.ExecuteTask(
+                // Store in per-task context so CancelTask() can find the correct wrapper
+                // when multiple tasks are active (nested builds via BuildProjectFile callbacks).
+                if (taskContext is not null)
+                {
+                    taskContext.TaskWrapper = taskWrapper;
+                }
+
+                taskResult = taskWrapper.ExecuteTask(
                     this as IBuildEngine,
                     taskName,
                     taskLocation,
@@ -1119,22 +1487,29 @@ namespace Microsoft.Build.CommandLine
             {
                 try
                 {
-                    _isTaskExecuting = false;
+                    // Reconcile counters: if the task is still blocked on a callback
+                    // (shouldn't happen -- BlockForCallback/ResumeAfterCallback are paired),
+                    // fix up the counters defensively.
+                    if (taskContext is not null && taskContext.State == TaskExecutionState.BlockedOnCallback)
+                    {
+                        Interlocked.Decrement(ref _blockedTaskCount);
+                        // Don't decrement _activeTaskCount -- it was already decremented by BlockForCallback
+                    }
+                    else
+                    {
+                        Interlocked.Decrement(ref _activeTaskCount);
+                    }
 
                     IDictionary<string, string> currentEnvironment = FrameworkCommunicationsUtilities.GetEnvironmentVariables();
                     currentEnvironment = UpdateEnvironmentForMainNode(currentEnvironment);
 
                     taskResult ??= new OutOfProcTaskHostTaskResult(TaskCompleteType.Failure);
-
-                    lock (_taskCompleteLock)
-                    {
-                        _taskCompletePacket = new TaskHostTaskComplete(
-                            taskResult,
+                    _taskCompletePacket = new TaskHostTaskComplete(
+                        taskResult,
 #if FEATURE_REPORTFILEACCESSES
-                            _fileAccessData,
+                        _fileAccessData,
 #endif
-                            currentEnvironment);
-                    }
+                        currentEnvironment);
 
 #if FEATURE_APPDOMAIN
                     foreach (TaskParameter param in taskParams.Values)
@@ -1149,16 +1524,13 @@ namespace Microsoft.Build.CommandLine
                 }
                 catch (Exception e)
                 {
-                    lock (_taskCompleteLock)
-                    {
-                        // Create a minimal taskCompletePacket to carry the exception so that the TaskHostTask does not hang while waiting
-                        _taskCompletePacket = new TaskHostTaskComplete(
-                            new OutOfProcTaskHostTaskResult(TaskCompleteType.CrashedAfterExecution, e),
+                    // Create a minimal taskCompletePacket to carry the exception so that the TaskHostTask does not hang while waiting
+                    _taskCompletePacket = new TaskHostTaskComplete(
+                        new OutOfProcTaskHostTaskResult(TaskCompleteType.CrashedAfterExecution, e),
 #if FEATURE_REPORTFILEACCESSES
-                            _fileAccessData,
+                        _fileAccessData,
 #endif
-                            null);
-                    }
+                        null);
                 }
                 finally
                 {
@@ -1167,10 +1539,27 @@ namespace Microsoft.Build.CommandLine
 #endif
 
                     // Call CleanupTask to unload any domains and other necessary cleanup in the taskWrapper
-                    _taskWrapper.CleanupTask();
+                    // Use local variable -- _taskWrapper may have been overwritten by a nested task.
+                    taskWrapper?.CleanupTask();
+                    // Mark context as completed and clean up
+                    if (taskContext is not null)
+                    {
+                        taskContext.State = TaskExecutionState.Completed;
+                        _currentTaskContext.Value = null;
+                        RemoveTaskContext(taskContext.TaskId);
+                    }
 
-                    // The task has now fully completed executing
-                    _taskCompleteEvent.Set();
+                    // The task has now fully completed executing.
+                    // Guard against ObjectDisposedException if HandleShutdown already disposed
+                    // the event (can happen if thread.Join timed out during shutdown).
+                    try
+                    {
+                        _taskCompleteEvent.Set();
+                    }
+                    catch (ObjectDisposedException)
+                    {
+                        // Shutdown already disposed the event -- nothing to signal.
+                    }
                 }
             }
         }
@@ -1363,7 +1752,7 @@ namespace Microsoft.Build.CommandLine
                     return;
                 }
 
-                LogMessagePacketBase logMessage = new(new KeyValuePair<int, BuildEventArgs>(_currentConfiguration.NodeId, e));
+                LogMessagePacketBase logMessage = new(new KeyValuePair<int, BuildEventArgs>(EffectiveConfiguration.NodeId, e));
                 _nodeEndpoint.SendData(logMessage);
             }
         }
@@ -1373,13 +1762,13 @@ namespace Microsoft.Build.CommandLine
         /// </summary>
         private void LogMessageFromResource(MessageImportance importance, string messageResource, params object[] messageArgs)
         {
-            ErrorUtilities.VerifyThrow(_currentConfiguration != null, "We should never have a null configuration when we're trying to log messages!");
+            ErrorUtilities.VerifyThrow(EffectiveConfiguration != null, "We should never have a null configuration when we're trying to log messages!");
 
             // Using the CLR 2 build event because this class is shared between MSBuildTaskHost.exe (CLR2) and MSBuild.exe (CLR4+)
             BuildMessageEventArgs message = new BuildMessageEventArgs(
                                                     ResourceUtilities.FormatString(AssemblyResources.GetString(messageResource), messageArgs),
                                                     null,
-                                                    _currentConfiguration.TaskName,
+                                                    EffectiveConfiguration.TaskName,
                                                     importance);
 
             LogMessageEvent(message);
@@ -1390,7 +1779,7 @@ namespace Microsoft.Build.CommandLine
         /// </summary>
         private void LogWarningFromResource(string messageResource, params object[] messageArgs)
         {
-            ErrorUtilities.VerifyThrow(_currentConfiguration != null, "We should never have a null configuration when we're trying to log warnings!");
+            ErrorUtilities.VerifyThrow(EffectiveConfiguration != null, "We should never have a null configuration when we're trying to log warnings!");
 
             // Using the CLR 2 build event because this class is shared between MSBuildTaskHost.exe (CLR2) and MSBuild.exe (CLR4+)
             BuildWarningEventArgs warning = new BuildWarningEventArgs(
@@ -1403,7 +1792,7 @@ namespace Microsoft.Build.CommandLine
                                                     0,
                                                     ResourceUtilities.FormatString(AssemblyResources.GetString(messageResource), messageArgs),
                                                     null,
-                                                    _currentConfiguration.TaskName);
+                                                    EffectiveConfiguration.TaskName);
 
             LogWarningEvent(warning);
         }
@@ -1413,7 +1802,7 @@ namespace Microsoft.Build.CommandLine
         /// </summary>
         private void LogErrorFromResource(string messageResource)
         {
-            ErrorUtilities.VerifyThrow(_currentConfiguration != null, "We should never have a null configuration when we're trying to log errors!");
+            ErrorUtilities.VerifyThrow(EffectiveConfiguration != null, "We should never have a null configuration when we're trying to log errors!");
 
             // Using the CLR 2 build event because this class is shared between MSBuildTaskHost.exe (CLR2) and MSBuild.exe (CLR4+)
             BuildErrorEventArgs error = new BuildErrorEventArgs(
@@ -1426,7 +1815,7 @@ namespace Microsoft.Build.CommandLine
                                                     0,
                                                     AssemblyResources.GetString(messageResource),
                                                     null,
-                                                    _currentConfiguration.TaskName);
+                                                    EffectiveConfiguration.TaskName);
 
             LogErrorEvent(error);
         }

--- a/src/MSBuild/OutOfProcTaskHostNode.cs
+++ b/src/MSBuild/OutOfProcTaskHostNode.cs
@@ -1003,7 +1003,8 @@ namespace Microsoft.Build.CommandLine
             var context = GetCurrentTaskContext();
             var pendingRequests = context?.PendingCallbackRequests ?? _pendingCallbackRequests;
 
-            // IMPORTANT: Request IDs must be globally unique across all task contexts
+            // Request IDs are unique across all task contexts for the process lifetime
+            // (monotonic counter, never resets) to prevent cross-task or stale response misdelivery.
             int requestId = Interlocked.Increment(ref _nextCallbackRequestId);
             request.RequestId = requestId;
 

--- a/src/MSBuild/OutOfProcTaskHostNode.cs
+++ b/src/MSBuild/OutOfProcTaskHostNode.cs
@@ -1170,9 +1170,8 @@ namespace Microsoft.Build.CommandLine
         /// </summary>
         private void HandleTaskHostConfiguration(TaskHostConfiguration taskHostConfiguration)
         {
-            // Allow new configuration when no task is actively executing.
-            // A task blocked on a BuildProjectFile callback does NOT prevent
-            // a new task from starting - this enables nested build scenarios.
+            // Only _activeTaskCount must be zero — blocked tasks (waiting on BuildProjectFile
+            // callbacks) don't prevent accepting a new nested task configuration.
             ErrorUtilities.VerifyThrow(_activeTaskCount == 0,
                 "Why are we getting a TaskHostConfiguration packet while a task is actively executing? activeTaskCount={0}",
                 _activeTaskCount);
@@ -1200,8 +1199,6 @@ namespace Microsoft.Build.CommandLine
         /// </summary>
         private void CompleteTask()
         {
-            // Only the active (topmost) task can complete. Blocked tasks are waiting
-            // on a callback response and can't finish until they resume.
             if (_nodeEndpoint.LinkStatus == LinkStatus.Active && _taskCompletePacket is not null)
             {
                 _nodeEndpoint.SendData(_taskCompletePacket);
@@ -1490,18 +1487,13 @@ namespace Microsoft.Build.CommandLine
             {
                 try
                 {
-                    // Reconcile counters: if the task is still blocked on a callback
-                    // (shouldn't happen -- BlockForCallback/ResumeAfterCallback are paired),
-                    // fix up the counters defensively.
-                    if (taskContext is not null && taskContext.State == TaskExecutionState.BlockedOnCallback)
-                    {
-                        Interlocked.Decrement(ref _blockedTaskCount);
-                        // Don't decrement _activeTaskCount -- it was already decremented by BlockForCallback
-                    }
-                    else
-                    {
-                        Interlocked.Decrement(ref _activeTaskCount);
-                    }
+                    // BlockForCallback/ResumeAfterCallback are always paired, so a task
+                    // should never be in BlockedOnCallback state when it completes.
+                    ErrorUtilities.VerifyThrow(
+                        taskContext is null || taskContext.State != TaskExecutionState.BlockedOnCallback,
+                        "Task completed while still in BlockedOnCallback state.");
+
+                    Interlocked.Decrement(ref _activeTaskCount);
 
                     IDictionary<string, string> currentEnvironment = FrameworkCommunicationsUtilities.GetEnvironmentVariables();
                     currentEnvironment = UpdateEnvironmentForMainNode(currentEnvironment);

--- a/src/MSBuild/OutOfProcTaskHostNode.cs
+++ b/src/MSBuild/OutOfProcTaskHostNode.cs
@@ -1747,7 +1747,7 @@ namespace Microsoft.Build.CommandLine
                     return;
                 }
 
-                LogMessagePacketBase logMessage = new(new KeyValuePair<int, BuildEventArgs>(EffectiveConfiguration.NodeId, e));
+                LogMessagePacketBase logMessage = new(new KeyValuePair<int, BuildEventArgs>(_currentConfiguration.NodeId, e));
                 _nodeEndpoint.SendData(logMessage);
             }
         }

--- a/src/MSBuild/OutOfProcTaskHostNode.cs
+++ b/src/MSBuild/OutOfProcTaskHostNode.cs
@@ -1082,7 +1082,9 @@ namespace Microsoft.Build.CommandLine
 
         /// <summary>
         /// Gets the configuration for the currently executing task on this thread.
-        /// Uses the thread-local task context if available, falling back to the global configuration.
+        /// On task threads, returns the per-task context configuration.
+        /// On the main communication thread (e.g., infrastructure logging), the context
+        /// is null so this falls back to the global <see cref="_currentConfiguration"/>.
         /// </summary>
         private TaskHostConfiguration GetCurrentConfiguration()
         {

--- a/src/MSBuild/OutOfProcTaskHostNode.cs
+++ b/src/MSBuild/OutOfProcTaskHostNode.cs
@@ -964,9 +964,9 @@ namespace Microsoft.Build.CommandLine
                 return;
             }
 
-            // No pending request matched -- trace for diagnostic visibility.
-            // This is an engine error state (protocol bug or race), not a user scenario.
-            CommunicationsUtilities.Trace("TaskHost received callback response with no pending request. RequestId={0}, Type={1}",
+            // No pending request matched -- this is a protocol bug (duplicate response,
+            // corrupted request ID, or race with shutdown). Crash to surface the issue.
+            ErrorUtilities.ThrowInternalError("TaskHost received callback response with no pending request. RequestId={0}, Type={1}",
                 callbackPacket.RequestId, packet.Type);
         }
 

--- a/src/MSBuild/OutOfProcTaskHostNode.cs
+++ b/src/MSBuild/OutOfProcTaskHostNode.cs
@@ -556,11 +556,12 @@ namespace Microsoft.Build.CommandLine
                 return new BuildEngineResult(false, null);
             }
 
-            string projectFilesJoined = string.Join(";", projectFileNames ?? []);
-            string targetNamesJoined = string.Join(";", targetNames ?? []);
+            string projectFilesJoined = null;
 
             if (MSBuildEventSource.Log.IsEnabled())
             {
+                projectFilesJoined = string.Join(";", projectFileNames ?? []);
+                string targetNamesJoined = string.Join(";", targetNames ?? []);
                 MSBuildEventSource.Log.TaskHostBuildProjectFileStart(projectFilesJoined, targetNamesJoined);
             }
 
@@ -586,7 +587,7 @@ namespace Microsoft.Build.CommandLine
             {
                 if (MSBuildEventSource.Log.IsEnabled())
                 {
-                    MSBuildEventSource.Log.TaskHostBuildProjectFileStop(projectFilesJoined, success);
+                    MSBuildEventSource.Log.TaskHostBuildProjectFileStop(projectFilesJoined!, success);
                 }
 
                 ResumeAfterCallback();

--- a/src/MSBuild/OutOfProcTaskHostNode.cs
+++ b/src/MSBuild/OutOfProcTaskHostNode.cs
@@ -1104,8 +1104,7 @@ namespace Microsoft.Build.CommandLine
             if (!_taskContexts.TryAdd(taskId, context))
             {
                 context.Dispose();
-                throw new InvalidOperationException(
-                    $"Task ID {taskId} already exists in TaskHost.");
+                ErrorUtilities.ThrowInternalError("Task ID {0} already exists in TaskHost.", taskId);
             }
 
             return context;

--- a/src/MSBuild/TaskExecutionContext.cs
+++ b/src/MSBuild/TaskExecutionContext.cs
@@ -1,0 +1,128 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Build.BackEnd;
+
+namespace Microsoft.Build.CommandLine
+{
+    /// <summary>
+    /// Represents the execution context for a single task running in the TaskHost.
+    /// Multiple contexts may exist when a task blocks on a BuildProjectFile callback
+    /// and a nested task is dispatched to the same process.
+    /// </summary>
+    /// <remarks>
+    /// When Task A calls BuildProjectFile and blocks, Task B may be dispatched
+    /// to the same TaskHost process. Each task needs its own:
+    /// - Configuration and parameters
+    /// - Pending callback requests (for request/response correlation)
+    /// - Saved environment (for context switching on callback blocking)
+    /// </remarks>
+    internal sealed class TaskExecutionContext : IDisposable
+    {
+        /// <summary>
+        /// Unique identifier for this task execution.
+        /// </summary>
+        public int TaskId { get; }
+
+        /// <summary>
+        /// The configuration packet that initiated this task execution.
+        /// </summary>
+        public TaskHostConfiguration Configuration { get; }
+
+        /// <summary>
+        /// The thread executing this task, or null if not yet started.
+        /// </summary>
+        public Thread? ExecutingThread { get; set; }
+
+        /// <summary>
+        /// Current execution state of this task.
+        /// </summary>
+        public TaskExecutionState State { get; set; }
+
+        /// <summary>
+        /// Saved current directory when task blocks on a BuildProjectFile callback.
+        /// </summary>
+        public string? SavedCurrentDirectory { get; set; }
+
+        /// <summary>
+        /// Saved environment variables when task blocks on a BuildProjectFile callback.
+        /// </summary>
+        public IDictionary<string, string>? SavedEnvironment { get; set; }
+
+        /// <summary>
+        /// Per-task warning settings from the task's configuration. Read via EffectiveWarningsAs* properties.
+        /// </summary>
+        public ICollection<string>? WarningsAsErrors { get; set; }
+
+        /// <summary>Per-task WarningsNotAsErrors from the task's configuration.</summary>
+        public ICollection<string>? WarningsNotAsErrors { get; set; }
+
+        /// <summary>Per-task WarningsAsMessages from the task's configuration.</summary>
+        public ICollection<string>? WarningsAsMessages { get; set; }
+
+        /// <summary>
+        /// The task wrapper for this execution, used for cancellation.
+        /// Stored per-task to prevent stale references when nested tasks overwrite the shared field.
+        /// </summary>
+        public OutOfProcTaskAppDomainWrapper? TaskWrapper { get; set; }
+
+        /// <summary>
+        /// Saved _debugCommunications setting for this task.
+        /// </summary>
+        public bool SavedDebugCommunications { get; set; }
+
+        /// <summary>
+        /// Saved _updateEnvironment setting for this task.
+        /// </summary>
+        public bool SavedUpdateEnvironment { get; set; }
+
+        /// <summary>
+        /// Saved _updateEnvironmentAndLog setting for this task.
+        /// </summary>
+        public bool SavedUpdateEnvironmentAndLog { get; set; }
+
+        /// <summary>
+        /// Pending callback requests for THIS task, keyed by request ID.
+        /// Each task has isolated pending requests to prevent cross-contamination
+        /// when multiple tasks are blocked on callbacks simultaneously.
+        /// </summary>
+        public ConcurrentDictionary<int, TaskCompletionSource<INodePacket>> PendingCallbackRequests { get; } = new();
+
+        /// <summary>
+        /// Creates a new task execution context.
+        /// </summary>
+        public TaskExecutionContext(int taskId, TaskHostConfiguration configuration)
+        {
+            TaskId = taskId;
+            Configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+            State = TaskExecutionState.Pending;
+        }
+
+        /// <summary>
+        /// Disposes resources held by this context.
+        /// </summary>
+        public void Dispose()
+        {
+        }
+    }
+
+    /// <summary>
+    /// Execution states for a task running in the TaskHost.
+    /// </summary>
+    internal enum TaskExecutionState
+    {
+        /// <summary>Task context created but not yet started.</summary>
+        Pending,
+        /// <summary>Task is actively executing on its thread.</summary>
+        Executing,
+        /// <summary>Task is blocked waiting for a callback response (e.g., BuildProjectFile).</summary>
+        BlockedOnCallback,
+        /// <summary>Task has finished execution.</summary>
+        Completed,
+    }
+}

--- a/src/Shared/INodePacket.cs
+++ b/src/Shared/INodePacket.cs
@@ -269,15 +269,7 @@ namespace Microsoft.Build.BackEnd
         /// </summary>
         TaskHostIsRunningMultipleNodesResponse = 0x25,
 
-        /// <summary>
-        /// Request from TaskHost to parent for Yield/Reacquire operations.
-        /// </summary>
-        TaskHostYieldRequest = 0x26,
-
-        /// <summary>
-        /// Response from parent to TaskHost acknowledging yield/reacquire.
-        /// </summary>
-        TaskHostYieldResponse = 0x27,
+        // 0x26-0x27 reserved for future TaskHost callback packet types
 
         #endregion
 

--- a/src/Shared/TaskHostBuildRequest.cs
+++ b/src/Shared/TaskHostBuildRequest.cs
@@ -1,0 +1,215 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Microsoft.Build.BackEnd
+{
+    /// <summary>
+    /// Packet sent from TaskHost to owning worker node to execute a BuildProjectFile* callback.
+    /// All four BuildProjectFile/BuildProjectFilesInParallel overloads normalize to the
+    /// IBuildEngine3 6-param canonical form carried by this packet.
+    /// </summary>
+    internal class TaskHostBuildRequest : INodePacket, ITaskHostCallbackPacket
+    {
+        private int _requestId;
+        private string[]? _projectFileNames;
+        private string[]? _targetNames;
+        private Dictionary<string, string>?[]? _globalProperties;
+        private List<string>?[]? _removeGlobalProperties;
+        private string[]? _toolsVersions;
+        private bool _returnTargetOutputs;
+
+        public TaskHostBuildRequest()
+        {
+        }
+
+        public TaskHostBuildRequest(
+            string[]? projectFileNames,
+            string[]? targetNames,
+            Dictionary<string, string>?[]? globalProperties,
+            List<string>?[]? removeGlobalProperties,
+            string[]? toolsVersions,
+            bool returnTargetOutputs)
+        {
+            _projectFileNames = projectFileNames;
+            _targetNames = targetNames;
+            _globalProperties = globalProperties;
+            _removeGlobalProperties = removeGlobalProperties;
+            _toolsVersions = toolsVersions;
+            _returnTargetOutputs = returnTargetOutputs;
+        }
+
+        public NodePacketType Type => NodePacketType.TaskHostBuildRequest;
+
+        public int RequestId
+        {
+            get => _requestId;
+            set => _requestId = value;
+        }
+
+        /// <summary>Array of project file paths to build.</summary>
+        public string[]? ProjectFileNames => _projectFileNames;
+
+        /// <summary>Array of target names to build in each project.</summary>
+        public string[]? TargetNames => _targetNames;
+
+        /// <summary>Per-project global properties to pass to the build.</summary>
+        public Dictionary<string, string>?[]? GlobalProperties => _globalProperties;
+
+        /// <summary>Per-project global properties to remove before building.</summary>
+        public List<string>?[]? RemoveGlobalProperties => _removeGlobalProperties;
+
+        /// <summary>Per-project tools versions to use.</summary>
+        public string[]? ToolsVersions => _toolsVersions;
+
+        /// <summary>Whether to include target outputs in the response.</summary>
+        public bool ReturnTargetOutputs => _returnTargetOutputs;
+
+        /// <summary>
+        /// Converts non-generic IDictionary[] (as used by IBuildEngine interfaces) to
+        /// Dictionary&lt;string, string&gt;[] for serialization.
+        /// </summary>
+        internal static Dictionary<string, string>?[]? ConvertGlobalProperties(IDictionary[]? globalProperties)
+        {
+            if (globalProperties is null)
+            {
+                return null;
+            }
+
+            var result = new Dictionary<string, string>?[globalProperties.Length];
+            for (int i = 0; i < globalProperties.Length; i++)
+            {
+                if (globalProperties[i] is not null)
+                {
+                    result[i] = new Dictionary<string, string>(globalProperties[i].Count, StringComparer.OrdinalIgnoreCase);
+                    foreach (DictionaryEntry entry in globalProperties[i])
+                    {
+                        result[i]![(string)entry.Key] = entry.Value?.ToString() ?? string.Empty;
+                    }
+                }
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Converts IList&lt;string&gt;[] to List&lt;string&gt;[] for serialization.
+        /// </summary>
+        internal static List<string>?[]? ConvertRemoveGlobalProperties(IList<string>[]? removeGlobalProperties)
+        {
+            if (removeGlobalProperties is null)
+            {
+                return null;
+            }
+
+            return Array.ConvertAll(removeGlobalProperties,
+                list => list is not null ? new List<string>(list) : null);
+        }
+
+        public void Translate(ITranslator translator)
+        {
+            translator.Translate(ref _requestId);
+            TranslateNullableStringArray(translator, ref _projectFileNames);
+            TranslateNullableStringArray(translator, ref _targetNames);
+            translator.Translate(ref _returnTargetOutputs);
+            TranslateNullableStringArray(translator, ref _toolsVersions);
+            TranslateGlobalPropertiesArray(translator);
+            TranslateRemoveGlobalPropertiesArray(translator);
+        }
+
+        /// <summary>
+        /// Serializes a string array where individual elements may be null.
+        /// The standard translator.Translate(ref string[]) doesn't handle null elements.
+        /// </summary>
+        private static void TranslateNullableStringArray(ITranslator translator, ref string[]? array)
+        {
+            bool hasArray = array is not null;
+            translator.Translate(ref hasArray);
+
+            if (!hasArray)
+            {
+                array = null;
+                return;
+            }
+
+            int length = array?.Length ?? 0;
+            translator.Translate(ref length);
+
+            if (translator.Mode == TranslationDirection.ReadFromStream)
+            {
+                array = new string[length];
+            }
+
+            for (int i = 0; i < length; i++)
+            {
+                string? element = array![i];
+                translator.Translate(ref element);
+                array[i] = element!;
+            }
+        }
+
+        private void TranslateGlobalPropertiesArray(ITranslator translator)
+        {
+            bool hasArray = _globalProperties is not null;
+            translator.Translate(ref hasArray);
+
+            if (!hasArray)
+            {
+                _globalProperties = null;
+                return;
+            }
+
+            int length = _globalProperties?.Length ?? 0;
+            translator.Translate(ref length);
+
+            if (translator.Mode == TranslationDirection.ReadFromStream)
+            {
+                _globalProperties = new Dictionary<string, string>?[length];
+            }
+
+            for (int i = 0; i < length; i++)
+            {
+                Dictionary<string, string>? dict = _globalProperties![i];
+                translator.TranslateDictionary(ref dict, StringComparer.OrdinalIgnoreCase);
+                _globalProperties[i] = dict;
+            }
+        }
+
+        private void TranslateRemoveGlobalPropertiesArray(ITranslator translator)
+        {
+            bool hasArray = _removeGlobalProperties is not null;
+            translator.Translate(ref hasArray);
+
+            if (!hasArray)
+            {
+                _removeGlobalProperties = null;
+                return;
+            }
+
+            int length = _removeGlobalProperties?.Length ?? 0;
+            translator.Translate(ref length);
+
+            if (translator.Mode == TranslationDirection.ReadFromStream)
+            {
+                _removeGlobalProperties = new List<string>?[length];
+            }
+
+            for (int i = 0; i < length; i++)
+            {
+                List<string>? list = _removeGlobalProperties![i];
+                translator.Translate(ref list);
+                _removeGlobalProperties[i] = list;
+            }
+        }
+
+        internal static INodePacket FactoryForDeserialization(ITranslator translator)
+        {
+            var packet = new TaskHostBuildRequest();
+            packet.Translate(translator);
+            return packet;
+        }
+    }
+}

--- a/src/Shared/TaskHostBuildResponse.cs
+++ b/src/Shared/TaskHostBuildResponse.cs
@@ -1,0 +1,160 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Build.Framework;
+
+namespace Microsoft.Build.BackEnd
+{
+    /// <summary>
+    /// Response packet from owning worker node to TaskHost with BuildProjectFile* results.
+    /// Carries the build success/failure and target outputs per project.
+    /// </summary>
+    internal class TaskHostBuildResponse : INodePacket, ITaskHostCallbackPacket
+    {
+        private int _requestId;
+        private bool _success;
+
+        /// <summary>
+        /// Target outputs per project. Each entry is a dictionary mapping target names to TaskParameter
+        /// wrapping ITaskItem[] outputs. Uses the same TaskParameter serialization as TaskHostTaskComplete.
+        /// </summary>
+        private List<Dictionary<string, TaskParameter>>? _targetOutputsPerProject;
+
+        public TaskHostBuildResponse()
+        {
+        }
+
+        public TaskHostBuildResponse(int requestId, bool success, List<Dictionary<string, TaskParameter>>? targetOutputsPerProject)
+        {
+            _requestId = requestId;
+            _success = success;
+            _targetOutputsPerProject = targetOutputsPerProject;
+        }
+
+        public NodePacketType Type => NodePacketType.TaskHostBuildResponse;
+
+        public int RequestId
+        {
+            get => _requestId;
+            set => _requestId = value;
+        }
+
+        /// <summary>Whether the build succeeded.</summary>
+        public bool Success => _success;
+
+        /// <summary>Per-project target outputs, or null if outputs were not requested.</summary>
+        public List<Dictionary<string, TaskParameter>>? TargetOutputsPerProject => _targetOutputsPerProject;
+
+        /// <summary>
+        /// Reconstructs a <see cref="BuildEngineResult"/> from this response packet.
+        /// Converts <see cref="TaskParameter"/> values back to <see cref="ITaskItem"/>[] arrays.
+        /// </summary>
+        public BuildEngineResult ToBuildEngineResult()
+        {
+            List<IDictionary<string, ITaskItem[]>>? result = null;
+
+            if (_targetOutputsPerProject is not null)
+            {
+                result = new List<IDictionary<string, ITaskItem[]>>(_targetOutputsPerProject.Count);
+
+                foreach (Dictionary<string, TaskParameter> projectOutputs in _targetOutputsPerProject)
+                {
+                    var dict = new Dictionary<string, ITaskItem[]>(projectOutputs.Count, StringComparer.OrdinalIgnoreCase);
+
+                    if (projectOutputs is not null)
+                    {
+                        foreach (KeyValuePair<string, TaskParameter> entry in projectOutputs)
+                        {
+                            dict[entry.Key] = (ITaskItem[]?)entry.Value?.WrappedParameter ?? [];
+                        }
+                    }
+
+                    result.Add(dict);
+                }
+            }
+
+            return new BuildEngineResult(_success, result ?? []);
+        }
+
+        /// <summary>
+        /// Creates a response from a <see cref="BuildEngineResult"/>.
+        /// Wraps <see cref="ITaskItem"/>[] arrays in <see cref="TaskParameter"/> for serialization.
+        /// </summary>
+        internal static TaskHostBuildResponse FromBuildEngineResult(int requestId, BuildEngineResult engineResult)
+        {
+            List<Dictionary<string, TaskParameter>>? outputs = null;
+
+            if (engineResult.TargetOutputsPerProject is not null && engineResult.TargetOutputsPerProject.Count > 0)
+            {
+                outputs = new List<Dictionary<string, TaskParameter>>(engineResult.TargetOutputsPerProject.Count);
+
+                foreach (IDictionary<string, ITaskItem[]> projectOutputs in engineResult.TargetOutputsPerProject)
+                {
+                    var dict = new Dictionary<string, TaskParameter>(projectOutputs?.Count ?? 0, StringComparer.OrdinalIgnoreCase);
+
+                    if (projectOutputs is not null)
+                    {
+                        foreach (KeyValuePair<string, ITaskItem[]> entry in projectOutputs)
+                        {
+                            dict[entry.Key] = new TaskParameter(entry.Value);
+                        }
+                    }
+
+                    outputs.Add(dict);
+                }
+            }
+
+            return new TaskHostBuildResponse(requestId, engineResult.Result, outputs);
+        }
+
+        public void Translate(ITranslator translator)
+        {
+            translator.Translate(ref _requestId);
+            translator.Translate(ref _success);
+            TranslateTargetOutputs(translator);
+        }
+
+        private void TranslateTargetOutputs(ITranslator translator)
+        {
+            bool hasOutputs = _targetOutputsPerProject is not null;
+            translator.Translate(ref hasOutputs);
+
+            if (!hasOutputs)
+            {
+                _targetOutputsPerProject = null;
+                return;
+            }
+
+            int count = _targetOutputsPerProject?.Count ?? 0;
+            translator.Translate(ref count);
+
+            if (translator.Mode == TranslationDirection.ReadFromStream)
+            {
+                _targetOutputsPerProject = new List<Dictionary<string, TaskParameter>>(count);
+                for (int i = 0; i < count; i++)
+                {
+                    Dictionary<string, TaskParameter>? dict = null;
+                    translator.TranslateDictionary(ref dict, StringComparer.OrdinalIgnoreCase, TaskParameter.FactoryForDeserialization);
+                    _targetOutputsPerProject.Add(dict!);
+                }
+            }
+            else
+            {
+                for (int i = 0; i < count; i++)
+                {
+                    Dictionary<string, TaskParameter>? dict = _targetOutputsPerProject![i];
+                    translator.TranslateDictionary(ref dict, StringComparer.OrdinalIgnoreCase, TaskParameter.FactoryForDeserialization);
+                }
+            }
+        }
+
+        internal static INodePacket FactoryForDeserialization(ITranslator translator)
+        {
+            var packet = new TaskHostBuildResponse();
+            packet.Translate(translator);
+            return packet;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Stage 3 of IBuildEngine callback support for out-of-process TaskHost. Implements forwarding of `BuildProjectFile*` from OOP TaskHost to the owning worker node, enabling tasks ejected to TaskHost (via `-mt` or explicit `TaskHostFactory`) to build other projects.

**Real-world impact:** WPF XAML compilation uses `GenerateTemporaryTargetAssembly` which calls `BuildProjectFile` from TaskHost. Without this change, building any WPF project with `-mt` fails with MSB5022.

## Design

### Packet pair
- `TaskHostBuildRequest` (0x20) / `TaskHostBuildResponse` (0x21): All 4 `BuildProjectFile*` overloads normalize to the 6-param `BuildProjectFilesInParallel` canonical form.

### Callback flow (no Yield/Reacquire)

Unlike the original design, we do **not** use `Yield`/`Reacquire` for `BuildProjectFile` callbacks. Instead:

1. Task thread calls `BuildProjectFile` → gates on `CallbacksSupported`
2. `BlockForCallback()` transitions the task from _active_ to _blocked_ (`_activeTaskCount--`, `_blockedTaskCount++`)
3. `SendCallbackRequestAndWaitForResponse<T>` serializes the request and blocks on `TaskCompletionSource`
4. Worker's `TaskHostTask.HandleBuildRequest` calls `IBuildEngine3.BuildProjectFilesInParallel` — exceptions propagate to `TaskBuilder` naturally (matching in-proc behavior), `finally` sends the response
5. Response arrives → TCS completes → `ResumeAfterCallback()` restores counters and environment

A blocked task does _not_ prevent the node from accepting new work — `HandleTaskHostConfiguration` checks `_activeTaskCount == 0` (not blocked count), so nested task dispatch works.

`Yield`/`Reacquire` remain  no-ops in the OOP TaskHost.
### Per-task isolation
`TaskExecutionContext` stores per-task state via `ConcurrentDictionary<int, TaskExecutionContext>` + `AsyncLocal`: configuration, task wrapper, saved environment, debug flags, warning settings, pending callback requests. `GetCurrentConfiguration()` and `EffectiveWarningsAs*` read from per-task context on task threads, falling back to `_currentConfiguration` on the main communication thread.

### Handler routing (process reuse)
`NodeProviderOutOfProcTaskHost` routes packets by `TaskHostNodeKey`, supporting nested task dispatch when an outer task is blocked on a callback and a new task arrives on the same TaskHost process.

### Version gating
Gated behind `CallbacksSupported` (`_parentPacketVersion >= 4` OR `MSBUILDENABLETASKHOSTCALLBACKS=1`). Each `BuildProjectFile` overload explicitly checks. Follow-up PR bumps `PacketVersion` to 4 and removes the env var.

## Tests
- **Serialization tests** — packet round-trip for `TaskHostBuildRequest`/`Response` with null/empty/populated properties
- **Integration tests** — `BuildProjectFile` via `TaskHostFactory`, global property forwarding, target output retrieval, callbacks-not-supported error path (MSB5022)
- **E2E tests** — cross-runtime `BuildProjectFile` callback, TaskHost process reuse (same PID verification)
- **MT mode test** — `BuildProjectFile` during `-mt` build

## Context
- Spec: #12868
- Stage 1: #13149 (merged) — `IsRunningMultipleNodes`
- Stage 2: #13306 (merged) — `RequestCores`/`ReleaseCores`
- WPF repro: #12863
