### PR TITLE
Fix Unix SessionId in handshake to enable cross-terminal node reuse

### DIFF
--- a/src/Build.UnitTests/BackEnd/UnixNodeReuseFixes_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/UnixNodeReuseFixes_Tests.cs
@@ -1,0 +1,44 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#if NET
+
+using Microsoft.Build.Internal;
+using Microsoft.Build.Shared;
+using Shouldly;
+using Xunit;
+
+namespace Microsoft.Build.UnitTests
+{
+    /// <summary>
+    /// Tests for Unix node reuse bug fixes:
+    /// - SessionId = 0 on Unix (cross-terminal node reuse)
+    /// </summary>
+    public class UnixNodeReuseFixes_Tests
+    {
+        [UnixOnlyFact]
+        public void Handshake_OnUnix_SessionIdIsZero()
+        {
+            var handshake = new Handshake(HandshakeOptions.NodeReuse);
+
+            // Use the structured accessor rather than parsing the key string
+            handshake.RetrieveHandshakeComponents().SessionId.ShouldBe(0,
+                "Unix handshake SessionId should be 0 to enable cross-terminal node reuse");
+        }
+
+        [UnixOnlyFact]
+        public void Handshake_OnUnix_KeyIsDeterministic()
+        {
+            // Two handshakes with same options produce identical keys on Unix
+            // because SessionId is always 0 (not terminal-specific).
+            // Note: this runs in a single process, so it validates determinism
+            // rather than cross-terminal behavior (which requires integration testing).
+            var h1 = new Handshake(HandshakeOptions.NodeReuse);
+            var h2 = new Handshake(HandshakeOptions.NodeReuse);
+
+            h1.GetKey().ShouldBe(h2.GetKey());
+        }
+    }
+}
+
+#endif

--- a/src/Shared/CommunicationsUtilities.cs
+++ b/src/Shared/CommunicationsUtilities.cs
@@ -287,8 +287,12 @@ namespace Microsoft.Build.Internal
 
             // Get session ID if needed (expensive call)
             int sessionId = 0;
-            if (includeSessionId)
+            if (includeSessionId && NativeMethodsShared.IsWindows)
             {
+                // On Windows, SessionId differentiates RDP sessions.
+                // On Unix, getsid() returns the session leader PID which differs per terminal,
+                // preventing cross-terminal node reuse. Use 0 since Unix doesn't need
+                // RDP-style session isolation.
                 using var currentProcess = Process.GetCurrentProcess();
                 sessionId = currentProcess.SessionId;
             }


### PR DESCRIPTION
## Problem
On Unix, `Process.SessionId` returns the session leader PID (from `getsid()`), which differs per terminal. This prevents MSBuild nodes launched from one terminal from being reused by builds in another terminal — each terminal effectively gets its own set of idle nodes.

## Fix
Use `SessionId=0` on non-Windows platforms. Unix doesn't need RDP-style session isolation, so 0 is safe and enables cross-terminal node reuse.

## Tests
- `Handshake_OnUnix_SessionIdIsZero` — asserts the SessionId component is 0 in the key
- `Handshake_OnUnix_MatchesAcrossInstances` — asserts matching keys across instances

Both use `[UnixOnlyFact]` per review feedback (no silent pass on Windows).

**Note:** The MSBuildTaskHost copy (`src/MSBuildTaskHost/`) uses `Process.SessionId` directly but only runs on .NET Framework/Windows, so it's unaffected.

Split from #13336 per reviewer request.
