### PR TITLE
Reduce default node idle timeout from 15 minutes to 30 seconds

### DIFF
--- a/src/Shared/CommunicationsUtilities.cs
+++ b/src/Shared/CommunicationsUtilities.cs
@@ -409,7 +409,7 @@ namespace Microsoft.Build.Internal
         /// <summary>
         /// The timeout to connect to a node.
         /// </summary>
-        private const int DefaultNodeConnectionTimeout = 900 * 1000; // 15 minutes; enough time that a dev will typically do another build in this time
+        private const int DefaultNodeConnectionTimeout = 30 * 1000; // 30 seconds; how long idle nodes wait for a new host connection before exiting
 
         /// <summary>
         /// Whether to trace communications


### PR DESCRIPTION
## Problem
Idle MSBuild worker nodes linger for 15 minutes (`DefaultNodeConnectionTimeout`), consuming memory and PIDs. On macOS with 12 cores, a single solution build can leave 10+ idle nodes resident for 15 minutes. With 5-10 concurrent builds this compounds to 50-100+ idle nodes.

## Change
Reduce `DefaultNodeConnectionTimeout` from 15 minutes to 30 seconds.

30 seconds is long enough to keep nodes warm for incremental rebuilds (the common dev loop) while reclaiming resources much sooner.

**Note:** `src/MSBuildTaskHost/CommunicationsUtilities.cs` has a separate copy of this timeout — it still defaults to 15 minutes. The TaskHost only runs on .NET Framework/Windows where the impact is different.

This is a behavioral change split out from #13336 for separate discussion per @baronfel's request.
