### PR TITLE
Reduce node handshake read timeout from 60s to 5s

### DIFF
--- a/src/Shared/NodeEndpointOutOfProcBase.cs
+++ b/src/Shared/NodeEndpointOutOfProcBase.cs
@@ -43,9 +43,13 @@ namespace Microsoft.Build.BackEnd
 
 #if NETCOREAPP2_1_OR_GREATER
         /// <summary>
-        /// The amount of time to wait for the client to connect to the host.
+        /// Timeout for reading each handshake component from a connected client.
+        /// Kept short so that failed or stalled handshakes don't block idle nodes
+        /// from reaching their connection timeout check and exiting.
+        /// Note: on Windows, TryReadIntForHandshake uses a blocking read so this
+        /// timeout only takes effect on Unix (where ReadAsync + Wait is used).
         /// </summary>
-        private const int ClientConnectTimeout = 60000;
+        private const int HandshakeReadTimeout = 5000;
 #endif // NETCOREAPP2_1
 
         /// <summary>
@@ -425,7 +429,7 @@ namespace Microsoft.Build.BackEnd
                             if (!_pipeServer.TryReadIntForHandshake(
                                 byteToAccept: index == 0 ? (byte?)CommunicationsUtilities.handshakeVersion : null, /* this will disconnect a < 16.8 host; it expects leading 00 or F5 or 06. 0x00 is a wildcard */
 #if NETCOREAPP2_1_OR_GREATER
-                             ClientConnectTimeout, /* wait a long time for the handshake from this side */
+                             HandshakeReadTimeout, /* timeout for handshake read */
 #endif
                               out HandshakeResult result))
                             {
@@ -453,7 +457,7 @@ namespace Microsoft.Build.BackEnd
 
                             if (
 #if NETCOREAPP2_1_OR_GREATER
-                            _pipeServer.TryReadEndOfHandshakeSignal(false, ClientConnectTimeout, out HandshakeResult _)) /* wait a long time for the handshake from this side */
+                            _pipeServer.TryReadEndOfHandshakeSignal(false, HandshakeReadTimeout, out HandshakeResult _)) /* timeout for end-of-handshake signal */
 #else
                             _pipeServer.TryReadEndOfHandshakeSignal(false, out HandshakeResult _))
 #endif


### PR DESCRIPTION
## Problem
Idle nodes block in `WaitForConnection`, then read the handshake with a 60s timeout (`ClientConnectTimeout`). If a reuse probe connects but the handshake fails or stalls, the node is blocked for up to 60s before it can loop back and check the idle timeout. This means nodes can linger much longer than the configured idle timeout.

## Fix
Reduce `ClientConnectTimeout` from 60s to 5s. A failed handshake now only blocks the node briefly, allowing it to promptly re-check whether it should exit.

Also updates stale "wait a long time" comments to match the new timeout value.

Split from #13336 per reviewer request. @baronfel asked @rainersigwald about this change — the message processing pump is single-threaded, so a long block here prevents the node from servicing other work.
