### PR TITLE
Look for apphost when considering node reuse

### DIFF
--- a/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
@@ -635,7 +635,7 @@ namespace Microsoft.Build.BackEnd
 
         private static (string expectedProcessName, IList<Process> nodeProcesses) GetPossibleRunningNodes(NodeMode? expectedNodeMode)
         {
-            var expectedProcessName = Constants.MSBuildExecutableName;
+            var expectedProcessName = Constants.MSBuildAppName;
 
             Process[] processes;
             try


### PR DESCRIPTION
There was a collision between #13220 (at end of build, look for other
running MSBuild processes and decide whether node reuse is likely to be
worthwhile) and #13175 (use an apphost on core). This broke the
overprovisioning detection, which was looking for `dotnet` instead
of the new `MSBuild`.

Always search for `MSBuild` instead, and remove the now-unnecesary
"try to filter `dotnet.exe` processes to those running `MSBuild.dll`
code too.
