### PR TITLE
Respect MSBUILDPRESERVETOOLTEMPFILES in ProcessExit cleanup

### DIFF
--- a/src/Framework/FileUtilities_TempFiles.cs
+++ b/src/Framework/FileUtilities_TempFiles.cs
@@ -35,10 +35,10 @@ internal static partial class FileUtilities
     {
         AppDomain.CurrentDomain.ProcessExit += (_, _) =>
         {
-            // ToolTask creates response files (.rsp) and batch files (.cmd/.sh) inside
-            // this directory via GetTemporaryFileName. MSBUILDPRESERVETOOLTEMPFILES=1 tells
-            // ToolTask.DeleteTempFile() to keep them for post-build inspection, but that is
-            // ineffective if we delete the entire directory here on exit.
+            // ToolTask creates response files (.rsp) in this directory via GetTemporaryFileName
+            // and batch files (.cmd/.sh) via FileUtilities.GetTemporaryFile(".cmd"/".sh").
+            // MSBUILDPRESERVETOOLTEMPFILES=1 tells ToolTask.DeleteTempFile() to keep them for
+            // post-build inspection, but that is ineffective if we delete the entire directory here on exit.
             if (string.Equals(Environment.GetEnvironmentVariable("MSBUILDPRESERVETOOLTEMPFILES"), "1", StringComparison.Ordinal))
             {
                 return;


### PR DESCRIPTION
 When MSBUILDPRESERVETOOLTEMPFILES=1 is set, ToolTask.DeleteTempFile() correctly skips deleting .rsp and .cmd/.sh files so they can be inspected after the build.
  However, RegisterCleanupOnExit() in FileUtilities_TempFiles.cs unconditionally deletes the entire MSBuildTemp{guid} directory on process exit, destroying the
  preserved files.

  This was not an issue historically because temp files were created directly in %TEMP%. After the security-motivated refactor (PR #12688) that moved temp files into
  a MSBuildTemp{guid} subdirectory with automatic cleanup, the preserve flag became effectively broken.

  Fix: Check MSBUILDPRESERVETOOLTEMPFILES in the ProcessExit handler and skip directory cleanup when the flag is set