### PR TITLE
Make task host node creation retry count and timeout configurable

### DIFF
--- a/src/Build.UnitTests/BackEnd/NodeProviderOutOfProc_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/NodeProviderOutOfProc_Tests.cs
@@ -3,7 +3,9 @@
 
 using System;
 using Microsoft.Build.BackEnd;
+using Microsoft.Build.Internal;
 using Microsoft.Build.Shared;
+using Microsoft.Build.UnitTests;
 using Shouldly;
 using Xunit;
 
@@ -145,6 +147,58 @@ namespace Microsoft.Build.UnitTests.BackEnd
             
             result.Length.ShouldBe(1);
             result[0].ShouldBeFalse();
+        }
+
+        [Fact]
+        public void NodeCreationRetries_Default_IsTen()
+        {
+            // Ensure default is 10 when env var is not set.
+            using TestEnvironment env = TestEnvironment.Create();
+            env.SetEnvironmentVariable("MSBUILDNODECREATIONRETRIES", null);
+
+            int retries = CommunicationsUtilities.GetIntegerVariableOrDefault("MSBUILDNODECREATIONRETRIES", 10);
+            retries.ShouldBe(10);
+        }
+
+        [Fact]
+        public void NodeCreationRetries_CanBeOverriddenViaEnvironmentVariable()
+        {
+            using TestEnvironment env = TestEnvironment.Create();
+            env.SetEnvironmentVariable("MSBUILDNODECREATIONRETRIES", "25");
+
+            int retries = CommunicationsUtilities.GetIntegerVariableOrDefault("MSBUILDNODECREATIONRETRIES", 10);
+            retries.ShouldBe(25);
+        }
+
+        [Fact]
+        public void NodeCreationTimeout_Default_Is30000()
+        {
+            // Ensure default is 30000 ms when env var is not set.
+            using TestEnvironment env = TestEnvironment.Create();
+            env.SetEnvironmentVariable("MSBUILDNODECREATIONTIMEOUT", null);
+
+            int timeout = CommunicationsUtilities.GetIntegerVariableOrDefault("MSBUILDNODECREATIONTIMEOUT", 30000);
+            timeout.ShouldBe(30000);
+        }
+
+        [Fact]
+        public void NodeCreationTimeout_CanBeOverriddenViaEnvironmentVariable()
+        {
+            using TestEnvironment env = TestEnvironment.Create();
+            env.SetEnvironmentVariable("MSBUILDNODECREATIONTIMEOUT", "60000");
+
+            int timeout = CommunicationsUtilities.GetIntegerVariableOrDefault("MSBUILDNODECREATIONTIMEOUT", 30000);
+            timeout.ShouldBe(60000);
+        }
+
+        [Fact]
+        public void NodeCreationRetries_InvalidValue_ReturnsDefault()
+        {
+            using TestEnvironment env = TestEnvironment.Create();
+            env.SetEnvironmentVariable("MSBUILDNODECREATIONRETRIES", "not_a_number");
+
+            int retries = CommunicationsUtilities.GetIntegerVariableOrDefault("MSBUILDNODECREATIONRETRIES", 10);
+            retries.ShouldBe(10);
         }
     }
 }

--- a/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
@@ -40,19 +40,43 @@ namespace Microsoft.Build.BackEnd
         private const int MaxPacketWriteSize = 1048576;
 
         /// <summary>
-        /// The number of times to retry creating an out-of-proc node.
+        /// The default number of times to retry creating an out-of-proc node.
+        /// Can be overridden via the MSBUILDNODECREATIONRETRIES environment variable.
         /// </summary>
-        private const int NodeCreationRetries = 10;
+        private const int DefaultNodeCreationRetries = 10;
 
         /// <summary>
-        /// The amount of time to wait for an out-of-proc node to spool up before we give up.
+        /// The default amount of time (ms) to wait for an out-of-proc node to spool up before we give up.
+        /// Can be overridden via the MSBUILDNODECREATIONTIMEOUT environment variable.
         /// </summary>
-        private const int TimeoutForNewNodeCreation = 30000;
+        private const int DefaultTimeoutForNewNodeCreation = 30000;
+
+        /// <summary>
+        /// The minimum backoff delay (ms) between node creation retry attempts.
+        /// </summary>
+        private const int MinBackoffDelayMs = 100;
+
+        /// <summary>
+        /// The maximum backoff delay (ms) between node creation retry attempts.
+        /// </summary>
+        private const int MaxBackoffDelayMs = 5000;
 
         /// <summary>
         /// The amount of time to wait for an out-of-proc node to exit.
         /// </summary>
         private const int TimeoutForWaitForExit = 30000;
+
+        /// <summary>
+        /// Gets the number of times to retry creating an out-of-proc node.
+        /// Configurable via the MSBUILDNODECREATIONRETRIES environment variable.
+        /// </summary>
+        private static int NodeCreationRetries => CommunicationsUtilities.GetIntegerVariableOrDefault("MSBUILDNODECREATIONRETRIES", DefaultNodeCreationRetries);
+
+        /// <summary>
+        /// Gets the amount of time (ms) to wait for an out-of-proc node to spool up before we give up.
+        /// Configurable via the MSBUILDNODECREATIONTIMEOUT environment variable.
+        /// </summary>
+        private static int TimeoutForNewNodeCreation => CommunicationsUtilities.GetIntegerVariableOrDefault("MSBUILDNODECREATIONTIMEOUT", DefaultTimeoutForNewNodeCreation);
 
 #if !FEATURE_PIPEOPTIONS_CURRENTUSERONLY
         private static readonly WindowsIdentity s_currentWindowsIdentity = WindowsIdentity.GetCurrent();
@@ -340,14 +364,20 @@ namespace Microsoft.Build.BackEnd
             // Create a new node process.
             bool StartNewNode(int nodeId)
             {
-                CommunicationsUtilities.Trace("Could not connect to existing process, now creating a process...");
+                int maxRetries = NodeCreationRetries;
+                int timeout = TimeoutForNewNodeCreation;
+
+                CommunicationsUtilities.Trace("Could not connect to existing process, now creating a process (retries: {0}, timeout: {1} ms)...", maxRetries, timeout);
 
                 // We try this in a loop because it is possible that there is another MSBuild multiproc
                 // host process running somewhere which is also trying to create nodes right now. It might
                 // find our newly created node and connect to it before we get a chance.
-                int retries = NodeCreationRetries;
+                int retries = maxRetries;
                 while (retries-- > 0)
                 {
+                    int attemptNumber = maxRetries - retries;
+                    CommunicationsUtilities.Trace("Node creation attempt {0} of {1} for node {2}...", attemptNumber, maxRetries, nodeId);
+
 #if FEATURE_NET35_TASKHOST
                     // We will also check to see if .NET 3.5 is installed in the case where we need to launch a CLR2 OOP TaskHost.
                     // Failure to detect this has been known to stall builds when Windows pops up a related dialog.
@@ -380,11 +410,11 @@ namespace Microsoft.Build.BackEnd
                     // to the debugger process. Instead, use MSBUILDDEBUGONSTART=1
 
                     // Now try to connect to it.
-                    Stream nodeStream = TryConnectToProcess(msbuildProcess.Id, TimeoutForNewNodeCreation, nodeLaunchData.Handshake, out HandshakeResult result);
+                    Stream nodeStream = TryConnectToProcess(msbuildProcess.Id, timeout, nodeLaunchData.Handshake, out HandshakeResult result);
                     if (nodeStream != null)
                     {
                         // Connection successful, use this node.
-                        CommunicationsUtilities.Trace("Successfully connected to created node {0} which is PID {1}", nodeId, msbuildProcess.Id);
+                        CommunicationsUtilities.Trace("Successfully connected to created node {0} which is PID {1} on attempt {2}", nodeId, msbuildProcess.Id, attemptNumber);
 
                         CreateNodeContext(nodeId, msbuildProcess, nodeStream, result.NegotiatedPacketVersion);
                         return true;
@@ -396,19 +426,27 @@ namespace Microsoft.Build.BackEnd
                         {
                             try
                             {
-                                CommunicationsUtilities.Trace("Could not connect to node with PID {0}; it has exited with exit code {1}. This can indicate a crash at startup", msbuildProcess.Id, msbuildProcess.ExitCode);
+                                CommunicationsUtilities.Trace("Could not connect to node with PID {0}; it has exited with exit code {1}. This can indicate a crash at startup (attempt {2} of {3})", msbuildProcess.Id, msbuildProcess.ExitCode, attemptNumber, maxRetries);
                             }
                             catch (InvalidOperationException)
                             {
                                 // This case is common on Windows where we called CreateProcess and the Process object
                                 // can't get the exit code.
-                                CommunicationsUtilities.Trace("Could not connect to node with PID {0}; it has exited with unknown exit code. This can indicate a crash at startup", msbuildProcess.Id);
+                                CommunicationsUtilities.Trace("Could not connect to node with PID {0}; it has exited with unknown exit code. This can indicate a crash at startup (attempt {1} of {2})", msbuildProcess.Id, attemptNumber, maxRetries);
                             }
                         }
                     }
                     else
                     {
-                        CommunicationsUtilities.Trace("Could not connect to node with PID {0}; it is still running. This can occur when two multiprocess builds run in parallel and the other one 'stole' this node", msbuildProcess.Id);
+                        CommunicationsUtilities.Trace("Could not connect to node with PID {0}; it is still running. This can occur when two multiprocess builds run in parallel and the other one 'stole' this node (attempt {1} of {2})", msbuildProcess.Id, attemptNumber, maxRetries);
+                    }
+
+                    // Apply backoff before retrying to reduce contention under load.
+                    if (retries > 0)
+                    {
+                        int backoffMs = Math.Min(MinBackoffDelayMs * (1 << (attemptNumber - 1)), MaxBackoffDelayMs);
+                        CommunicationsUtilities.Trace("Waiting {0} ms before node creation retry attempt {1} of {2}", backoffMs, attemptNumber + 1, maxRetries);
+                        Thread.Sleep(backoffMs);
                     }
                 }
 

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -1224,7 +1224,7 @@
     <value>"{0}" is an invalid value for the task host parameter "{1}". Valid values are: "{2}", "{3}", "{4}", and "{5}"; not specifying a value is also valid.</value>
   </data>
   <data name="TaskHostAcquireFailed" xml:space="preserve">
-    <value>MSB4216: Could not run the "{0}" task because MSBuild could not create or connect to a task host with runtime "{1}" and architecture "{2}".  Please ensure that (1) the requested runtime and/or architecture are available on the machine, and (2) that the required executable "{3}" exists and can be run.</value>
+    <value>MSB4216: Could not run the "{0}" task because MSBuild could not create or connect to a task host with runtime "{1}" and architecture "{2}".  Please ensure that (1) the requested runtime and/or architecture are available on the machine, and (2) that the required executable "{3}" exists and can be run. If this is a transient failure (e.g. under heavy system load), you can increase retry attempts via the MSBUILDNODECREATIONRETRIES environment variable (default: 10) and the per-attempt timeout via MSBUILDNODECREATIONTIMEOUT (default: 30000 ms).</value>
     <comment>{StrBegin="MSB4216: "}</comment>
   </data>
   <data name="TaskHostNodeFailedToLaunch" xml:space="preserve">

--- a/src/Build/Resources/xlf/Strings.cs.xlf
+++ b/src/Build/Resources/xlf/Strings.cs.xlf
@@ -2403,7 +2403,7 @@ Chyby: {3}</target>
         <note />
       </trans-unit>
       <trans-unit id="TaskHostAcquireFailed">
-        <source>MSB4216: Could not run the "{0}" task because MSBuild could not create or connect to a task host with runtime "{1}" and architecture "{2}".  Please ensure that (1) the requested runtime and/or architecture are available on the machine, and (2) that the required executable "{3}" exists and can be run.</source>
+        <source>MSB4216: Could not run the "{0}" task because MSBuild could not create or connect to a task host with runtime "{1}" and architecture "{2}".  Please ensure that (1) the requested runtime and/or architecture are available on the machine, and (2) that the required executable "{3}" exists and can be run. If this is a transient failure (e.g. under heavy system load), you can increase retry attempts via the MSBUILDNODECREATIONRETRIES environment variable (default: 10) and the per-attempt timeout via MSBUILDNODECREATIONTIMEOUT (default: 30000 ms).</source>
         <target state="translated">MSB4216: Nelze spustit úlohu {0}, protože nástroj MSBuild nemohl vytvořit hostitele úlohy, jehož modul runtime je {1} a architektura je {2}, nebo se k němu nemohl připojit.  Ověřte, (1) zda požadovaný modul runtime a architektura jsou v počítači k dispozici a (2) zda existuje požadovaný spustitelný soubor {3} a je možné jej spustit.</target>
         <note>{StrBegin="MSB4216: "}</note>
       </trans-unit>

--- a/src/Build/Resources/xlf/Strings.de.xlf
+++ b/src/Build/Resources/xlf/Strings.de.xlf
@@ -2403,7 +2403,7 @@ Fehler: {3}</target>
         <note />
       </trans-unit>
       <trans-unit id="TaskHostAcquireFailed">
-        <source>MSB4216: Could not run the "{0}" task because MSBuild could not create or connect to a task host with runtime "{1}" and architecture "{2}".  Please ensure that (1) the requested runtime and/or architecture are available on the machine, and (2) that the required executable "{3}" exists and can be run.</source>
+        <source>MSB4216: Could not run the "{0}" task because MSBuild could not create or connect to a task host with runtime "{1}" and architecture "{2}".  Please ensure that (1) the requested runtime and/or architecture are available on the machine, and (2) that the required executable "{3}" exists and can be run. If this is a transient failure (e.g. under heavy system load), you can increase retry attempts via the MSBUILDNODECREATIONRETRIES environment variable (default: 10) and the per-attempt timeout via MSBUILDNODECREATIONTIMEOUT (default: 30000 ms).</source>
         <target state="translated">MSB4216: Die "{0}"-Aufgabe konnte nicht ausgeführt werden, da MSBuild keinen Aufgabenhost erstellen oder keine Verbindung zu einem Aufgabenhost mit Laufzeit "{1}" und Architektur "{2}" herstellen konnte.  Stellen Sie sicher, dass (1) die angeforderte Laufzeit und/oder Architektur auf dem Computer verfügbar ist und (2) die erforderliche ausführbare Datei "{3}" vorhanden ist und ausgeführt werden kann.</target>
         <note>{StrBegin="MSB4216: "}</note>
       </trans-unit>

--- a/src/Build/Resources/xlf/Strings.en.xlf
+++ b/src/Build/Resources/xlf/Strings.en.xlf
@@ -1680,8 +1680,8 @@
         <note />
       </trans-unit>
       <trans-unit id="TaskHostAcquireFailed">
-        <source>MSB4216: Could not run the "{0}" task because MSBuild could not create or connect to a task host with runtime "{1}" and architecture "{2}".  Please ensure that (1) the requested runtime and/or architecture are available on the machine, and (2) that the required executable "{3}" exists and can be run.</source>
-        <target state="new">MSB4216: Could not run the "{0}" task because MSBuild could not create or connect to a task host with runtime "{1}" and architecture "{2}".  Please ensure that (1) the requested runtime and/or architecture are available on the machine, and (2) that the required executable "{3}" exists and can be run.</target>
+        <source>MSB4216: Could not run the "{0}" task because MSBuild could not create or connect to a task host with runtime "{1}" and architecture "{2}".  Please ensure that (1) the requested runtime and/or architecture are available on the machine, and (2) that the required executable "{3}" exists and can be run. If this is a transient failure (e.g. under heavy system load), you can increase retry attempts via the MSBUILDNODECREATIONRETRIES environment variable (default: 10) and the per-attempt timeout via MSBUILDNODECREATIONTIMEOUT (default: 30000 ms).</source>
+        <target state="new">MSB4216: Could not run the "{0}" task because MSBuild could not create or connect to a task host with runtime "{1}" and architecture "{2}".  Please ensure that (1) the requested runtime and/or architecture are available on the machine, and (2) that the required executable "{3}" exists and can be run. If this is a transient failure (e.g. under heavy system load), you can increase retry attempts via the MSBUILDNODECREATIONRETRIES environment variable (default: 10) and the per-attempt timeout via MSBUILDNODECREATIONTIMEOUT (default: 30000 ms).</target>
         <note>{StrBegin="MSB4216: "}</note>
       </trans-unit>
       <trans-unit id="TaskHostNodeFailedToLaunch">

--- a/src/Build/Resources/xlf/Strings.es.xlf
+++ b/src/Build/Resources/xlf/Strings.es.xlf
@@ -2403,7 +2403,7 @@ Errores: {3}</target>
         <note />
       </trans-unit>
       <trans-unit id="TaskHostAcquireFailed">
-        <source>MSB4216: Could not run the "{0}" task because MSBuild could not create or connect to a task host with runtime "{1}" and architecture "{2}".  Please ensure that (1) the requested runtime and/or architecture are available on the machine, and (2) that the required executable "{3}" exists and can be run.</source>
+        <source>MSB4216: Could not run the "{0}" task because MSBuild could not create or connect to a task host with runtime "{1}" and architecture "{2}".  Please ensure that (1) the requested runtime and/or architecture are available on the machine, and (2) that the required executable "{3}" exists and can be run. If this is a transient failure (e.g. under heavy system load), you can increase retry attempts via the MSBUILDNODECREATIONRETRIES environment variable (default: 10) and the per-attempt timeout via MSBUILDNODECREATIONTIMEOUT (default: 30000 ms).</source>
         <target state="translated">MSB4216: No se pudo ejecutar la tarea "{0}" porque MSBuild no pudo crear o conectarse a un host de tareas con runtime "{1}" y arquitectura "{2}".  Asegúrese de que (1) el runtime y/o la arquitectura solicitados estén disponibles en el equipo y de que (2) el archivo ejecutable "{3}" requerido existe y se puede ejecutar.</target>
         <note>{StrBegin="MSB4216: "}</note>
       </trans-unit>

--- a/src/Build/Resources/xlf/Strings.fr.xlf
+++ b/src/Build/Resources/xlf/Strings.fr.xlf
@@ -2403,7 +2403,7 @@ Erreurs : {3}</target>
         <note />
       </trans-unit>
       <trans-unit id="TaskHostAcquireFailed">
-        <source>MSB4216: Could not run the "{0}" task because MSBuild could not create or connect to a task host with runtime "{1}" and architecture "{2}".  Please ensure that (1) the requested runtime and/or architecture are available on the machine, and (2) that the required executable "{3}" exists and can be run.</source>
+        <source>MSB4216: Could not run the "{0}" task because MSBuild could not create or connect to a task host with runtime "{1}" and architecture "{2}".  Please ensure that (1) the requested runtime and/or architecture are available on the machine, and (2) that the required executable "{3}" exists and can be run. If this is a transient failure (e.g. under heavy system load), you can increase retry attempts via the MSBUILDNODECREATIONRETRIES environment variable (default: 10) and the per-attempt timeout via MSBUILDNODECREATIONTIMEOUT (default: 30000 ms).</source>
         <target state="translated">MSB4216: Impossible d'exécuter la tâche "{0}", car MSBuild n'a pas pu créer ou se connecter à un hôte de tâche avec le runtime "{1}" et l'architecture "{2}".  Vérifiez que (1) le runtime et/ou l'architecture nécessaire sont disponibles sur la machine, et que (2) le fichier exécutable "{3}" obligatoire existe et peut être exécuté.</target>
         <note>{StrBegin="MSB4216: "}</note>
       </trans-unit>

--- a/src/Build/Resources/xlf/Strings.it.xlf
+++ b/src/Build/Resources/xlf/Strings.it.xlf
@@ -2403,7 +2403,7 @@ Errori: {3}</target>
         <note />
       </trans-unit>
       <trans-unit id="TaskHostAcquireFailed">
-        <source>MSB4216: Could not run the "{0}" task because MSBuild could not create or connect to a task host with runtime "{1}" and architecture "{2}".  Please ensure that (1) the requested runtime and/or architecture are available on the machine, and (2) that the required executable "{3}" exists and can be run.</source>
+        <source>MSB4216: Could not run the "{0}" task because MSBuild could not create or connect to a task host with runtime "{1}" and architecture "{2}".  Please ensure that (1) the requested runtime and/or architecture are available on the machine, and (2) that the required executable "{3}" exists and can be run. If this is a transient failure (e.g. under heavy system load), you can increase retry attempts via the MSBUILDNODECREATIONRETRIES environment variable (default: 10) and the per-attempt timeout via MSBUILDNODECREATIONTIMEOUT (default: 30000 ms).</source>
         <target state="translated">MSB4216: non è stato possibile eseguire l'attività "{0}" perché MSBuild non è riuscito a creare o connettersi a un host attività con runtime "{1}" e architettura "{2}". Assicurarsi che (1) il runtime e/o l'architettura richiesti siano disponibili nel computer e (2) che l'eseguibile richiesto "{3}" esista e possa essere eseguito.</target>
         <note>{StrBegin="MSB4216: "}</note>
       </trans-unit>

--- a/src/Build/Resources/xlf/Strings.ja.xlf
+++ b/src/Build/Resources/xlf/Strings.ja.xlf
@@ -2403,7 +2403,7 @@ Errors: {3}</source>
         <note />
       </trans-unit>
       <trans-unit id="TaskHostAcquireFailed">
-        <source>MSB4216: Could not run the "{0}" task because MSBuild could not create or connect to a task host with runtime "{1}" and architecture "{2}".  Please ensure that (1) the requested runtime and/or architecture are available on the machine, and (2) that the required executable "{3}" exists and can be run.</source>
+        <source>MSB4216: Could not run the "{0}" task because MSBuild could not create or connect to a task host with runtime "{1}" and architecture "{2}".  Please ensure that (1) the requested runtime and/or architecture are available on the machine, and (2) that the required executable "{3}" exists and can be run. If this is a transient failure (e.g. under heavy system load), you can increase retry attempts via the MSBUILDNODECREATIONRETRIES environment variable (default: 10) and the per-attempt timeout via MSBUILDNODECREATIONTIMEOUT (default: 30000 ms).</source>
         <target state="translated">MSB4216: MSBuild がランタイム "{1}" とアーキテクチャ "{2}" を持つタスク ホストを作成できなかった、またはこのホストに接続できなかったため、"{0}" タスクを実行できませんでした。次のことを確認してください。(1) 要求されたランタイムとアーキテクチャの両方またはいずれかがコンピューター上にあること。(2) 必要な実行可能ファイル "{3}" が存在し、実行可能であること。</target>
         <note>{StrBegin="MSB4216: "}</note>
       </trans-unit>

--- a/src/Build/Resources/xlf/Strings.ko.xlf
+++ b/src/Build/Resources/xlf/Strings.ko.xlf
@@ -2403,7 +2403,7 @@ Errors: {3}</source>
         <note />
       </trans-unit>
       <trans-unit id="TaskHostAcquireFailed">
-        <source>MSB4216: Could not run the "{0}" task because MSBuild could not create or connect to a task host with runtime "{1}" and architecture "{2}".  Please ensure that (1) the requested runtime and/or architecture are available on the machine, and (2) that the required executable "{3}" exists and can be run.</source>
+        <source>MSB4216: Could not run the "{0}" task because MSBuild could not create or connect to a task host with runtime "{1}" and architecture "{2}".  Please ensure that (1) the requested runtime and/or architecture are available on the machine, and (2) that the required executable "{3}" exists and can be run. If this is a transient failure (e.g. under heavy system load), you can increase retry attempts via the MSBUILDNODECREATIONRETRIES environment variable (default: 10) and the per-attempt timeout via MSBUILDNODECREATIONTIMEOUT (default: 30000 ms).</source>
         <target state="translated">MSB4216: MSBuild에서 런타임이 "{1}"이고 아키텍처가 "{2}"인 작업 호스트를 만들거나 연결할 수 없기 때문에 "{0}" 작업을 실행할 수 없습니다.  (1) 요청한 런타임 및/또는 아키텍처를 컴퓨터에서 사용할 수 있는지, (2) 필요한 실행 파일 "{3}"이(가) 있고 실행될 수 있는지 확인하세요.</target>
         <note>{StrBegin="MSB4216: "}</note>
       </trans-unit>

--- a/src/Build/Resources/xlf/Strings.pl.xlf
+++ b/src/Build/Resources/xlf/Strings.pl.xlf
@@ -2403,7 +2403,7 @@ Błędy: {3}</target>
         <note />
       </trans-unit>
       <trans-unit id="TaskHostAcquireFailed">
-        <source>MSB4216: Could not run the "{0}" task because MSBuild could not create or connect to a task host with runtime "{1}" and architecture "{2}".  Please ensure that (1) the requested runtime and/or architecture are available on the machine, and (2) that the required executable "{3}" exists and can be run.</source>
+        <source>MSB4216: Could not run the "{0}" task because MSBuild could not create or connect to a task host with runtime "{1}" and architecture "{2}".  Please ensure that (1) the requested runtime and/or architecture are available on the machine, and (2) that the required executable "{3}" exists and can be run. If this is a transient failure (e.g. under heavy system load), you can increase retry attempts via the MSBUILDNODECREATIONRETRIES environment variable (default: 10) and the per-attempt timeout via MSBUILDNODECREATIONTIMEOUT (default: 30000 ms).</source>
         <target state="translated">MSB4216: Nie można uruchomić zadania „{0}”, ponieważ program MSBuild nie może utworzyć albo nawiązać połączenia z hostem zadań o środowisku uruchomieniowym „{1}” i architekturze „{2}”.  Upewnij się, że (1) wymagane środowisko uruchomieniowe i/lub architektura są dostępne na maszynie oraz (2) wymagany plik wykonywalny „{3}” istnieje i można go uruchomić.</target>
         <note>{StrBegin="MSB4216: "}</note>
       </trans-unit>

--- a/src/Build/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Build/Resources/xlf/Strings.pt-BR.xlf
@@ -2403,7 +2403,7 @@ Erros: {3}</target>
         <note />
       </trans-unit>
       <trans-unit id="TaskHostAcquireFailed">
-        <source>MSB4216: Could not run the "{0}" task because MSBuild could not create or connect to a task host with runtime "{1}" and architecture "{2}".  Please ensure that (1) the requested runtime and/or architecture are available on the machine, and (2) that the required executable "{3}" exists and can be run.</source>
+        <source>MSB4216: Could not run the "{0}" task because MSBuild could not create or connect to a task host with runtime "{1}" and architecture "{2}".  Please ensure that (1) the requested runtime and/or architecture are available on the machine, and (2) that the required executable "{3}" exists and can be run. If this is a transient failure (e.g. under heavy system load), you can increase retry attempts via the MSBUILDNODECREATIONRETRIES environment variable (default: 10) and the per-attempt timeout via MSBUILDNODECREATIONTIMEOUT (default: 30000 ms).</source>
         <target state="translated">MSB4216: Não foi possível executar a tarefa "{0}" porque o MSBuild não pôde criar ou se conectar a um host de tarefas com runtime "{1}" e arquitetura "{2}".  Verifique se (1) o runtime e/ou a arquitetura solicitados estão disponíveis no computador e se (2) o executável necessário "{3}" existe e pode ser executado.</target>
         <note>{StrBegin="MSB4216: "}</note>
       </trans-unit>

--- a/src/Build/Resources/xlf/Strings.ru.xlf
+++ b/src/Build/Resources/xlf/Strings.ru.xlf
@@ -2403,7 +2403,7 @@ Errors: {3}</source>
         <note />
       </trans-unit>
       <trans-unit id="TaskHostAcquireFailed">
-        <source>MSB4216: Could not run the "{0}" task because MSBuild could not create or connect to a task host with runtime "{1}" and architecture "{2}".  Please ensure that (1) the requested runtime and/or architecture are available on the machine, and (2) that the required executable "{3}" exists and can be run.</source>
+        <source>MSB4216: Could not run the "{0}" task because MSBuild could not create or connect to a task host with runtime "{1}" and architecture "{2}".  Please ensure that (1) the requested runtime and/or architecture are available on the machine, and (2) that the required executable "{3}" exists and can be run. If this is a transient failure (e.g. under heavy system load), you can increase retry attempts via the MSBUILDNODECREATIONRETRIES environment variable (default: 10) and the per-attempt timeout via MSBUILDNODECREATIONTIMEOUT (default: 30000 ms).</source>
         <target state="translated">MSB4216: не удалось выполнить задачу "{0}", поскольку MSBuild не удалось создать сервер задач со средой выполнения "{1}" и архитектурой "{2}" или подключиться к нему.  Убедитесь, что (1) запрошенные среда выполнения и архитектура существуют на компьютере и (2) необходимый исполняемый файл "{3}" существует и может быть запущен.</target>
         <note>{StrBegin="MSB4216: "}</note>
       </trans-unit>

--- a/src/Build/Resources/xlf/Strings.tr.xlf
+++ b/src/Build/Resources/xlf/Strings.tr.xlf
@@ -2403,7 +2403,7 @@ Hatalar: {3}</target>
         <note />
       </trans-unit>
       <trans-unit id="TaskHostAcquireFailed">
-        <source>MSB4216: Could not run the "{0}" task because MSBuild could not create or connect to a task host with runtime "{1}" and architecture "{2}".  Please ensure that (1) the requested runtime and/or architecture are available on the machine, and (2) that the required executable "{3}" exists and can be run.</source>
+        <source>MSB4216: Could not run the "{0}" task because MSBuild could not create or connect to a task host with runtime "{1}" and architecture "{2}".  Please ensure that (1) the requested runtime and/or architecture are available on the machine, and (2) that the required executable "{3}" exists and can be run. If this is a transient failure (e.g. under heavy system load), you can increase retry attempts via the MSBUILDNODECREATIONRETRIES environment variable (default: 10) and the per-attempt timeout via MSBUILDNODECREATIONTIMEOUT (default: 30000 ms).</source>
         <target state="translated">MSB4216: MSBuild "{1}" çalışma zamanı ve "{2}" mimarisi ile bir görev oluşturmadığından veya görev konağına bağlanamadığından "{0}" görevi çalıştırılamadı.  Lütfen (1) istenen çalışma zamanı ve/veya mimarinin makinede kullanılabildiğinden ve (2) gerekli yürütülebilir "{3}" öğesinin mevcut ve çalıştırılabilir olduğundan emin olun.</target>
         <note>{StrBegin="MSB4216: "}</note>
       </trans-unit>

--- a/src/Build/Resources/xlf/Strings.xlf
+++ b/src/Build/Resources/xlf/Strings.xlf
@@ -1080,7 +1080,7 @@
         <note />
       </trans-unit>
       <trans-unit id="TaskHostAcquireFailed">
-        <source>MSB4216: Could not run the "{0}" task because MSBuild could not create or connect to a task host with runtime "{1}" and architecture "{2}".  Please ensure that (1) the requested runtime and/or architecture are available on the machine, and (2) that the required executable "{3}" exists and can be run.</source>
+        <source>MSB4216: Could not run the "{0}" task because MSBuild could not create or connect to a task host with runtime "{1}" and architecture "{2}".  Please ensure that (1) the requested runtime and/or architecture are available on the machine, and (2) that the required executable "{3}" exists and can be run. If this is a transient failure (e.g. under heavy system load), you can increase retry attempts via the MSBUILDNODECREATIONRETRIES environment variable (default: 10) and the per-attempt timeout via MSBUILDNODECREATIONTIMEOUT (default: 30000 ms).</source>
         <note>{StrBegin="MSB4216: "}</note>
       </trans-unit>
       <trans-unit id="TaskHostNodeFailedToLaunch">

--- a/src/Build/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hans.xlf
@@ -2403,7 +2403,7 @@ Errors: {3}</source>
         <note />
       </trans-unit>
       <trans-unit id="TaskHostAcquireFailed">
-        <source>MSB4216: Could not run the "{0}" task because MSBuild could not create or connect to a task host with runtime "{1}" and architecture "{2}".  Please ensure that (1) the requested runtime and/or architecture are available on the machine, and (2) that the required executable "{3}" exists and can be run.</source>
+        <source>MSB4216: Could not run the "{0}" task because MSBuild could not create or connect to a task host with runtime "{1}" and architecture "{2}".  Please ensure that (1) the requested runtime and/or architecture are available on the machine, and (2) that the required executable "{3}" exists and can be run. If this is a transient failure (e.g. under heavy system load), you can increase retry attempts via the MSBUILDNODECREATIONRETRIES environment variable (default: 10) and the per-attempt timeout via MSBUILDNODECREATIONTIMEOUT (default: 30000 ms).</source>
         <target state="translated">MSB4216: 无法运行“{0}”任务，因为 MSBuild 无法创建或连接到运行时为“{1}”、体系结构为“{2}”的任务宿主。请确保 (1) 请求的运行时和/或体系结构在计算机上可用，以及 (2) 所需的可执行文件“{3}”存在，且可以运行。</target>
         <note>{StrBegin="MSB4216: "}</note>
       </trans-unit>

--- a/src/Build/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hant.xlf
@@ -2403,7 +2403,7 @@ Errors: {3}</source>
         <note />
       </trans-unit>
       <trans-unit id="TaskHostAcquireFailed">
-        <source>MSB4216: Could not run the "{0}" task because MSBuild could not create or connect to a task host with runtime "{1}" and architecture "{2}".  Please ensure that (1) the requested runtime and/or architecture are available on the machine, and (2) that the required executable "{3}" exists and can be run.</source>
+        <source>MSB4216: Could not run the "{0}" task because MSBuild could not create or connect to a task host with runtime "{1}" and architecture "{2}".  Please ensure that (1) the requested runtime and/or architecture are available on the machine, and (2) that the required executable "{3}" exists and can be run. If this is a transient failure (e.g. under heavy system load), you can increase retry attempts via the MSBUILDNODECREATIONRETRIES environment variable (default: 10) and the per-attempt timeout via MSBUILDNODECREATIONTIMEOUT (default: 30000 ms).</source>
         <target state="translated">MSB4216: 因為 MSBuild 無法建立或連接到執行階段為 "{1}" 且結構為 "{2}" 的工作主機，所以無法執行 "{0}" 工作。請確定 (1) 要求的執行階段及 (或) 結構可在電腦上提供使用，以及 (2) 必要的可執行檔 "{3}" 存在且可以執行。</target>
         <note>{StrBegin="MSB4216: "}</note>
       </trans-unit>


### PR DESCRIPTION
## Summary
**probably a bad idea** just for discussion


Adds `MSBUILDNODECREATIONRETRIES` and `MSBUILDNODECREATIONTIMEOUT` environment variables to allow tuning out-of-process task host node creation under load. Also adds exponential backoff between retry attempts and improved diagnostics.

## Motivation

With the recent introduction of `Runtime="NET"` on UsingTask declarations ([dotnet/arcade#16413](https://github.com/dotnet/arcade/pull/16413)), desktop MSBuild builds that invoke .NET tasks now spawn many more out-of-process task host processes via named pipes. Under CI load with `nodeReuse=false`, transient named pipe connection failures can exhaust all retry attempts and produce MSB4216 errors.

See [dotnet/dotnet#5482](https://github.com/dotnet/dotnet/issues/5482) for the full root cause analysis.

The specific failure chain:
1. aspnetcore Windows builds use desktop MSBuild (`-msbuildEngine vs`)
2. Installer tasks are registered with `Runtime="NET"` (post-arcade#16413)
3. Each task invocation spawns a fresh out-of-process .NET task host (nodeReuse=false in CI)
4. ~15-25 process launches per build, each requiring a named pipe connection
5. Under resource pressure, pipe connections can time out
6. After 10 rapid retries with no backoff, MSB4216 is logged

## Changes

### Configurable retry constants
Convert hardcoded `NodeCreationRetries` (10) and `TimeoutForNewNodeCreation` (30000 ms) to properties backed by environment variables, using the existing `GetIntegerVariableOrDefault` pattern (matching `MSBUILDNODECONNECTIONTIMEOUT`, `MSBUILDTHREADSTACKSIZE`, `MSBUILDENDPOINTSHUTDOWNTIMEOUT`, etc.).

`
MSBUILDNODECREATIONRETRIES  - default: 10
MSBUILDNODECREATIONTIMEOUT  - default: 30000 (ms)
`

### Exponential backoff
Add backoff delay between retry attempts (100ms doubling to 5s cap) to reduce contention storms when multiple builds spawn nodes concurrently.

### Improved diagnostics
- Retry attempt numbers (N of M) in all trace messages
- Retry count and timeout logged at start of node creation
- Backoff delay logged before each wait

### Updated MSB4216 error message
The `TaskHostAcquireFailed` error message now mentions the tunable environment variables so users hitting this in CI can self-serve.

## Backward compatibility

**Defaults are unchanged.** This is fully backward compatible - the env vars are opt-in. The only behavioral difference for users who don't set env vars is the new backoff delay between retries (100ms, 200ms, 400ms, ..., up to 5s), which slightly increases the total retry window under failure conditions but does not affect successful connections.

## Test

- Unit tests verify default values and environment variable override behavior
- E2E testing requires full MSBuild bootstrap (CI will validate)

/cc @dotnet/msbuild