### PR TITLE
Fix race conditions in AssemblyTaskFactory class.

### DIFF
--- a/src/Build/Instance/TaskFactories/AssemblyTaskFactory.cs
+++ b/src/Build/Instance/TaskFactories/AssemblyTaskFactory.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Reflection;
 #if FEATURE_APPDOMAIN
+using System.Collections.Concurrent;
 using System.Threading.Tasks;
 #endif
 
@@ -54,7 +55,7 @@ namespace Microsoft.Build.BackEnd
         /// <summary>
         /// A cache of tasks and the AppDomains they are loaded in.
         /// </summary>
-        private Dictionary<ITask, AppDomain> _tasksAndAppDomains = new Dictionary<ITask, AppDomain>();
+        private readonly ConcurrentDictionary<ITask, AppDomain> _tasksAndAppDomains = new ConcurrentDictionary<ITask, AppDomain>();
 #endif
 
         /// <summary>
@@ -199,10 +200,8 @@ namespace Microsoft.Build.BackEnd
         {
             ErrorUtilities.VerifyThrowArgumentNull(task);
 #if FEATURE_APPDOMAIN
-            AppDomain appDomain;
-            if (_tasksAndAppDomains.TryGetValue(task, out appDomain))
+            if (_tasksAndAppDomains.TryRemove(task, out AppDomain appDomain))
             {
-                _tasksAndAppDomains.Remove(task);
 
                 if (appDomain != null)
                 {


### PR DESCRIPTION
Fixes #12867

### Context
Building large repos (e.g., Roslyn) in multi-threaded mode crashes intermittently:

error MSB4061: The "CombineTargetFrameworkInfoProperties" task could not be instantiated...
Operations that change non-concurrent collections must have exclusive access. A concurrent update was performed on this collection and corrupted its state.

Root Cause
`AssemblyTaskFactory` instances are shared across thread nodes — they're cached in `TaskRegistry._taskFactoryWrapperInstance`. `TaskRegistry` itself is shared across thread nodes by design. In mt builds, multiple projects call `CreateTaskInstance()` on the same `AssemblyTaskFactory` instance concurrently from different threads. This exposed two thread-safety issues:

 1. `_taskLoggingContext` field race (crash-causing)

Race condition example: When Thread A (Project A) and Thread B (Project B) concurrently call `CreateTaskInstance()`:
   1. Thread A sets `_taskLoggingContext = contextA`
   2. Thread B overwrites `_taskLoggingContext = contextB`
   3. Thread A reads `_taskLoggingContext` for `TrackTaskSubclassing` → gets `contextB` → writes to Project B's ProjectTelemetry
   4. Thread B also writes to Project B's ProjectTelemetry
   5. Two threads mutate the same Dictionary<string, int> → crash

The `ProjectTelemetry` in turn is not supposed to be accessed from multiple threads - only one thread node should build a project. It does not need to be thread-safe.

`_taskLoggingContext` field existed so that `ErrorLoggingDelegate` (a named method passed as a callback to `TaskLoader.CreateTask()`) could access the logging context, but it is not really required. For mt mode support, there should not be mutable fields in `AssemblyTaskFactory` that relate to a specific task.

  2. `_tasksAndAppDomains` dictionary (in .NET Framework)

`Dictionary<ITask, AppDomain>` is not safe for concurrent structural mutations. While each thread operates on different keys (unique ITask instances), concurrent add/remove on different keys still corrupts a plain Dictionary.

### Changes Made
- Removed `_taskLoggingContext` field entirely. 
- Changed `_tasksAndAppDomains` from `Dictionary<ITask, AppDomain>` to `ConcurrentDictionary<ITask, AppDomain>`
Note that lock contention should be negligible, as each thread would add and clean-up its own set of keys.

### Testing
Existing unit tests