### PR TITLE
Move core ProjectReferenceTargets from Managed-only to Common targets

### DIFF
--- a/documentation/ProjectReference-Protocol.md
+++ b/documentation/ProjectReference-Protocol.md
@@ -1,6 +1,6 @@
 # The `ProjectReference` Protocol
 
-The MSBuild engine doesn't have a notion of a “project reference”—it only provides the [`MSBuild` task](https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-task) to allow cross-project communication.
+The MSBuild engine doesn't have a notion of a “project reference”—it only provides the [`MSBuild` task](https://learn.microsoft.com/visualstudio/msbuild/msbuild-task) to allow cross-project communication.
 
 That's a powerful tool, but no one would want to have to specify how to build every single reference in every single project. The common targets introduce an item, `ProjectReference`, and a default process for building references declared via that item.
 

--- a/documentation/ProjectReference-Protocol.md
+++ b/documentation/ProjectReference-Protocol.md
@@ -1,12 +1,12 @@
 # The `ProjectReference` Protocol
 
-The MSBuild engine doesn't have a notion of a “project reference”—it only provides the [`MSBuild` task](https://docs.microsoft.com/en-us/visualstudio/msbuild/msbuild-task) to allow cross-project communication.
+The MSBuild engine doesn't have a notion of a “project reference”—it only provides the [`MSBuild` task](https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-task) to allow cross-project communication.
 
 That's a powerful tool, but no one would want to have to specify how to build every single reference in every single project. The common targets introduce an item, `ProjectReference`, and a default process for building references declared via that item.
 
 Default protocol implementation:
-- https://github.com/dotnet/msbuild/blob/main/src/Tasks/Microsoft.Common.CurrentVersion.targets
-- https://github.com/dotnet/msbuild/blob/main/src/Tasks/Microsoft.Common.CrossTargeting.targets
+- [Microsoft.Common.CurrentVersion.targets](../src/Tasks/Microsoft.Common.CurrentVersion.targets)
+- [Microsoft.Common.CrossTargeting.targets](../src/Tasks/Microsoft.Common.CrossTargeting.targets)
 
 ## Projects that have references
 
@@ -74,7 +74,7 @@ If implementing a project with an “outer” (determine what properties to pass
 * `GetTargetPath` should return the path of the project's output, but _not_ build that output.
   * **Conditions**: this is used for builds inside Visual Studio, but not on the command line.
   * It's also used when the property `BuildProjectReferences` is `false`, manually indicating that all `ProjectReferences` are up to date and shouldn't be (re)built.
-  * This should return a single item that is the primary output of the project, with metadata describing that output. See [`TargetPathWithTargetPlatformMoniker`](https://github.com/dotnet/msbuild/blob/080ef976a428f6ff7bf53ca5dd4ee637b3fe949c/src/Tasks/Microsoft.Common.CurrentVersion.targets#L1834-L1842) for the default metadata.
+  * This should return a single item that is the primary output of the project, with metadata describing that output. See `TargetPathWithTargetPlatformMoniker` in the `GetTargetPath` target of [Microsoft.Common.CurrentVersion.targets](../src/Tasks/Microsoft.Common.CurrentVersion.targets) for the default metadata.
 * **Default** targets should do the full build and return an assembly to be referenced.
   * **Conditions**: this is _not_ called when building inside Visual Studio. Instead, Visual Studio builds each project in isolation but in order, so the path returned from `GetTargetPath` can be assumed to exist at consumption time.
   * If the `ProjectReference` defines the `Targets` metadata, it is used. If not, no target is passed, and the default target of the reference (usually `Build`) is built.
@@ -87,7 +87,7 @@ If implementing a project with an “outer” (determine what properties to pass
   * It is not called during a normal build, only during "Clean" and "Rebuild".
 
 ### Targets Marked With `SkipNonexistentTargets='true'` Metadatum
-`GetTargetFrameworks` and `GetTargetFrameworksWithPlatformForSingleTargetFramework` are skippable if nonexistent since some project types (for example, `wixproj` projects) may not define them. See [this comment](https://github.com/dotnet/msbuild/blob/cc55017f88688cbe3f9aa810cdf44273adea76ea/src/Tasks/Microsoft.Managed.After.targets#L74-L77) for more details.
+`GetTargetFrameworks` and `GetTargetFrameworksWithPlatformForSingleTargetFramework` are skippable if nonexistent since some project types (for example, `wixproj` projects) may not define them. See [this comment](../src/Tasks/Microsoft.Common.CurrentVersion.targets) in the `ProjectReferenceTargets for Static Graph` section for more details.
 
 ## Other protocol requirements
 

--- a/src/Build.UnitTests/Graph/ProjectReferenceTargetsProtocol_Tests.cs
+++ b/src/Build.UnitTests/Graph/ProjectReferenceTargetsProtocol_Tests.cs
@@ -10,7 +10,6 @@ using Microsoft.Build.Shared;
 using Microsoft.Build.UnitTests;
 using Shouldly;
 using Xunit;
-using Xunit.Abstractions;
 using static Microsoft.Build.Graph.UnitTests.GraphTestingUtilities;
 
 #nullable disable

--- a/src/Build.UnitTests/Graph/ProjectReferenceTargetsProtocol_Tests.cs
+++ b/src/Build.UnitTests/Graph/ProjectReferenceTargetsProtocol_Tests.cs
@@ -1,0 +1,555 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.Build.Execution;
+using Microsoft.Build.Shared;
+using Microsoft.Build.UnitTests;
+using Shouldly;
+using Xunit;
+using Xunit.Abstractions;
+using static Microsoft.Build.Graph.UnitTests.GraphTestingUtilities;
+
+#nullable disable
+
+namespace Microsoft.Build.Graph.UnitTests
+{
+    /// <summary>
+    /// Tests verifying that the ProjectReferenceTargets protocol defined in
+    /// Microsoft.Common.CurrentVersion.targets, Microsoft.Common.CrossTargeting.targets,
+    /// and Microsoft.Managed.After.targets correctly propagates targets through the graph.
+    ///
+    /// These tests use synthetic project XML that mirrors the real targets files to ensure
+    /// the protocol is correct regardless of which project types import the targets.
+    /// </summary>
+    public class ProjectReferenceTargetsProtocolTests : IDisposable
+    {
+        private TestEnvironment _env;
+
+        public ProjectReferenceTargetsProtocolTests(ITestOutputHelper output)
+        {
+            _env = TestEnvironment.Create(output);
+        }
+
+        /// <summary>
+        /// The core ProjectReferenceTargets protocol as defined in Microsoft.Common.CurrentVersion.targets
+        /// (the "ProjectReferenceTargets for Static Graph" section, around line 5183).
+        /// Keep in sync with the real file — if the protocol changes there, update this constant.
+        /// This applies to all project types that import the Common targets.
+        /// </summary>
+        private const string CommonCurrentVersionTargetsProtocol = """
+            <PropertyGroup>
+              <_RecursiveTargetForContentCopying>GetCopyToOutputDirectoryItems</_RecursiveTargetForContentCopying>
+            </PropertyGroup>
+
+            <PropertyGroup Condition="'$(IsGraphBuild)' == 'true' and '$(IsCrossTargetingBuild)' != 'true'">
+              <_MainReferenceTargetForBuild Condition="'$(BuildProjectReferences)' == '' or '$(BuildProjectReferences)' == 'true'">.projectReferenceTargetsOrDefaultTargets</_MainReferenceTargetForBuild>
+              <_MainReferenceTargetForBuild Condition="'$(_MainReferenceTargetForBuild)' == ''">GetTargetPath</_MainReferenceTargetForBuild>
+
+              <ProjectReferenceTargetsForBuild>$(_MainReferenceTargetForBuild);GetNativeManifest;$(_RecursiveTargetForContentCopying);$(ProjectReferenceTargetsForBuild)</ProjectReferenceTargetsForBuild>
+            </PropertyGroup>
+            <PropertyGroup Condition="'$(IsGraphBuild)' == 'true'">
+              <ProjectReferenceTargetsForClean>Clean;$(ProjectReferenceTargetsForClean)</ProjectReferenceTargetsForClean>
+              <ProjectReferenceTargetsForRebuild>$(ProjectReferenceTargetsForClean);$(ProjectReferenceTargetsForBuild);$(ProjectReferenceTargetsForRebuild)</ProjectReferenceTargetsForRebuild>
+            </PropertyGroup>
+
+            <ItemGroup Condition="'$(IsGraphBuild)' == 'true'">
+              <ProjectReferenceTargets Include="Build" Targets="$(ProjectReferenceTargetsForBuildInOuterBuild)" Condition=" '$(ProjectReferenceTargetsForBuildInOuterBuild)' != '' " OuterBuild="true" />
+              <ProjectReferenceTargets Include="Build" Targets="GetTargetFrameworks" OuterBuild="true" SkipNonexistentTargets="true" Condition="'$(IsCrossTargetingBuild)' != 'true'" />
+              <ProjectReferenceTargets Include="Build" Targets="$(ProjectReferenceTargetsForBuild)" Condition=" '$(ProjectReferenceTargetsForBuild)' != '' " />
+
+              <ProjectReferenceTargets Include="Clean" Targets="$(ProjectReferenceTargetsForCleanInOuterBuild)" Condition=" '$(ProjectReferenceTargetsForCleanInOuterBuild)' != '' " OuterBuild="true" />
+              <ProjectReferenceTargets Include="Clean" Targets="GetTargetFrameworks" OuterBuild="true" SkipNonexistentTargets="true" Condition="'$(IsCrossTargetingBuild)' != 'true'" />
+              <ProjectReferenceTargets Include="Clean" Targets="$(ProjectReferenceTargetsForClean)" Condition=" '$(ProjectReferenceTargetsForClean)' != '' " />
+
+              <ProjectReferenceTargets Include="Build" Targets="GetTargetFrameworksWithPlatformForSingleTargetFramework" SkipNonexistentTargets="true" Condition="'$(IsCrossTargetingBuild)' != 'true'" />
+              <ProjectReferenceTargets Include="Clean" Targets="GetTargetFrameworksWithPlatformForSingleTargetFramework" SkipNonexistentTargets="true" Condition="'$(IsCrossTargetingBuild)' != 'true'" />
+              <ProjectReferenceTargets Include="Rebuild" Targets="GetTargetFrameworksWithPlatformForSingleTargetFramework" SkipNonexistentTargets="true" Condition="'$(IsCrossTargetingBuild)' != 'true'" />
+
+              <ProjectReferenceTargets Include="Rebuild" Targets="$(ProjectReferenceTargetsForRebuild)" Condition=" '$(ProjectReferenceTargetsForRebuild)' != '' " />
+            </ItemGroup>
+            """;
+
+        /// <summary>
+        /// The cross-targeting protocol as defined in Microsoft.Common.CrossTargeting.targets
+        /// (the "ProjectReferenceTargets for Static Graph (Cross-Targeting)" section).
+        /// Keep in sync with the real file.
+        /// </summary>
+        private const string CrossTargetingProtocol = """
+            <PropertyGroup Condition="'$(IsGraphBuild)' == 'true'">
+              <ProjectReferenceTargetsForBuild>.default;$(ProjectReferenceTargetsForBuild)</ProjectReferenceTargetsForBuild>
+              <ProjectReferenceTargetsForClean>Clean;$(ProjectReferenceTargetsForClean)</ProjectReferenceTargetsForClean>
+              <ProjectReferenceTargetsForRebuild>$(ProjectReferenceTargetsForClean);$(ProjectReferenceTargetsForBuild);$(ProjectReferenceTargetsForRebuild)</ProjectReferenceTargetsForRebuild>
+            </PropertyGroup>
+            <ItemGroup Condition="'$(IsGraphBuild)' == 'true'">
+              <ProjectReferenceTargets Include="Build" Targets="$(ProjectReferenceTargetsForBuild)" Condition=" '$(ProjectReferenceTargetsForBuild)' != '' " />
+              <ProjectReferenceTargets Include="Clean" Targets="$(ProjectReferenceTargetsForClean)" Condition=" '$(ProjectReferenceTargetsForClean)' != '' " />
+              <ProjectReferenceTargets Include="Rebuild" Targets="$(ProjectReferenceTargetsForRebuild)" Condition=" '$(ProjectReferenceTargetsForRebuild)' != '' " />
+            </ItemGroup>
+            """;
+
+        /// <summary>
+        /// The managed-specific extensions from Microsoft.Managed.After.targets for Publish and DeployOnBuild.
+        /// Keep in sync with the real file.
+        /// </summary>
+        private const string ManagedAfterTargetsProtocol = """
+            <PropertyGroup Condition="'$(IsGraphBuild)' == 'true' and '$(IsCrossTargetingBuild)' != 'true'">
+              <_MainReferenceTargetForPublish Condition="'$(NoBuild)' == 'true'">GetTargetPath</_MainReferenceTargetForPublish>
+              <_MainReferenceTargetForPublish Condition="'$(NoBuild)' != 'true'">$(_MainReferenceTargetForBuild)</_MainReferenceTargetForPublish>
+              <ProjectReferenceTargetsForPublish>GetTargetFrameworks;$(_MainReferenceTargetForPublish);GetNativeManifest;GetCopyToPublishDirectoryItems;$(ProjectReferenceTargetsForPublish)</ProjectReferenceTargetsForPublish>
+
+              <ProjectReferenceTargetsForGetCopyToPublishDirectoryItems>GetCopyToPublishDirectoryItems;$(ProjectReferenceTargetsForGetCopyToPublishDirectoryItems)</ProjectReferenceTargetsForGetCopyToPublishDirectoryItems>
+            </PropertyGroup>
+
+            <ItemGroup Condition="'$(IsGraphBuild)' == 'true'">
+              <ProjectReferenceTargets Include="Build" Targets="$(ProjectReferenceTargetsForPublish)" Condition="'$(DeployOnBuild)' == 'true' and '$(IsCrossTargetingBuild)' != 'true' and '$(ProjectReferenceTargetsForPublish)' != ''" />
+              <ProjectReferenceTargets Include="Rebuild" Targets="$(ProjectReferenceTargetsForPublish)" Condition="'$(DeployOnBuild)' == 'true' and '$(IsCrossTargetingBuild)' != 'true' and '$(ProjectReferenceTargetsForPublish)' != ''" />
+
+              <ProjectReferenceTargets Include="Publish" Targets="$(ProjectReferenceTargetsForPublish)" Condition=" '$(ProjectReferenceTargetsForPublish)' != '' " />
+
+              <ProjectReferenceTargets Include="GetCopyToPublishDirectoryItems" Targets="$(ProjectReferenceTargetsForGetCopyToPublishDirectoryItems)" Condition=" '$(ProjectReferenceTargetsForGetCopyToPublishDirectoryItems)' != '' " />
+            </ItemGroup>
+            """;
+
+        /// <summary>
+        /// Multitargeting specification using TargetFramework / TargetFrameworks, as in real managed projects.
+        /// </summary>
+        private const string MultitargetingSpec = """
+            <PropertyGroup>
+              <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+            </PropertyGroup>
+            <PropertyGroup Condition="'$(TargetFrameworks)' != '' and '$(TargetFramework)' == ''">
+              <IsCrossTargetingBuild>true</IsCrossTargetingBuild>
+            </PropertyGroup>
+            <PropertyGroup>
+              <InnerBuildProperty>TargetFramework</InnerBuildProperty>
+              <InnerBuildPropertyValues>TargetFrameworks</InnerBuildPropertyValues>
+            </PropertyGroup>
+            """;
+
+        private string AllDummyTargets => """
+            <Target Name="Build" />
+            <Target Name="Clean" />
+            <Target Name="Rebuild" />
+            <Target Name="Publish" />
+            <Target Name="GetTargetPath" />
+            <Target Name="GetNativeManifest" />
+            <Target Name="GetCopyToOutputDirectoryItems" />
+            <Target Name="GetCopyToPublishDirectoryItems" />
+            <Target Name="GetTargetFrameworks" />
+            <Target Name="GetTargetFrameworksWithPlatformForSingleTargetFramework" />
+            """;
+
+        /// <summary>
+        /// A non-managed project type (importing Common targets only, not Managed.After.targets) should
+        /// get the core Build/Clean/Rebuild ProjectReferenceTargets in a graph build.
+        /// </summary>
+        [Fact]
+        public void NonManagedProject_GetsCoreBuildCleanRebuild_InGraphBuild()
+        {
+            // Project 1 → Project 2, both only importing the Common protocol
+            string commonProtocol = CommonCurrentVersionTargetsProtocol + AllDummyTargets;
+
+            ProjectGraph graph = Helpers.CreateProjectGraph(
+                env: _env,
+                dependencyEdges: new Dictionary<int, int[]>
+                {
+                    { 1, new[] { 2 } },
+                },
+                extraContentForAllNodes: commonProtocol);
+
+            graph.ProjectNodes.Count.ShouldBe(2);
+
+            // Build propagation: entry target Build → reference gets the full Build protocol
+            IReadOnlyDictionary<ProjectGraphNode, ImmutableList<string>> buildTargets =
+                graph.GetTargetLists(new[] { "Build" });
+
+            buildTargets[GetFirstNodeWithProjectNumber(graph, 1)].ShouldBe(new[] { "Build" });
+
+            ImmutableList<string> refBuildTargets = buildTargets[GetFirstNodeWithProjectNumber(graph, 2)];
+            // Should include the core Build targets from Common.CurrentVersion.targets
+            refBuildTargets.ShouldContain("GetTargetFrameworks");
+            refBuildTargets.ShouldContain("GetNativeManifest");
+            refBuildTargets.ShouldContain("GetCopyToOutputDirectoryItems");
+            refBuildTargets.ShouldContain("GetTargetFrameworksWithPlatformForSingleTargetFramework");
+
+            // Clean propagation
+            IReadOnlyDictionary<ProjectGraphNode, ImmutableList<string>> cleanTargets =
+                graph.GetTargetLists(new[] { "Clean" });
+
+            ImmutableList<string> refCleanTargets = cleanTargets[GetFirstNodeWithProjectNumber(graph, 2)];
+            refCleanTargets.ShouldContain("Clean");
+            refCleanTargets.ShouldContain("GetTargetFrameworks");
+            refCleanTargets.ShouldContain("GetTargetFrameworksWithPlatformForSingleTargetFramework");
+
+            // Rebuild propagation
+            IReadOnlyDictionary<ProjectGraphNode, ImmutableList<string>> rebuildTargets =
+                graph.GetTargetLists(new[] { "Rebuild" });
+
+            ImmutableList<string> refRebuildTargets = rebuildTargets[GetFirstNodeWithProjectNumber(graph, 2)];
+            refRebuildTargets.ShouldContain("Clean");
+            refRebuildTargets.ShouldContain("GetNativeManifest");
+            refRebuildTargets.ShouldContain("GetCopyToOutputDirectoryItems");
+            refRebuildTargets.ShouldContain("GetTargetFrameworksWithPlatformForSingleTargetFramework");
+        }
+
+        /// <summary>
+        /// A managed project (importing both Common and Managed.After targets) should get
+        /// the same core Build/Clean/Rebuild targets as before the move, plus Publish support.
+        /// </summary>
+        [Fact]
+        public void ManagedProject_GraphBuildTargets_MatchExpectedProtocol()
+        {
+            // Managed project: Common protocol + Managed extensions
+            string managedProtocol = CommonCurrentVersionTargetsProtocol + ManagedAfterTargetsProtocol + AllDummyTargets;
+
+            ProjectGraph graph = Helpers.CreateProjectGraph(
+                env: _env,
+                dependencyEdges: new Dictionary<int, int[]>
+                {
+                    { 1, new[] { 2 } },
+                },
+                extraContentForAllNodes: managedProtocol);
+
+            graph.ProjectNodes.Count.ShouldBe(2);
+
+            // Build targets should include the core protocol
+            IReadOnlyDictionary<ProjectGraphNode, ImmutableList<string>> buildTargets =
+                graph.GetTargetLists(new[] { "Build" });
+
+            ImmutableList<string> refBuildTargets = buildTargets[GetFirstNodeWithProjectNumber(graph, 2)];
+            refBuildTargets.ShouldContain("GetTargetFrameworks");
+            refBuildTargets.ShouldContain("GetNativeManifest");
+            refBuildTargets.ShouldContain("GetCopyToOutputDirectoryItems");
+            refBuildTargets.ShouldContain("GetTargetFrameworksWithPlatformForSingleTargetFramework");
+
+            // Publish targets should include managed-specific targets
+            IReadOnlyDictionary<ProjectGraphNode, ImmutableList<string>> publishTargets =
+                graph.GetTargetLists(new[] { "Publish" });
+
+            ImmutableList<string> refPublishTargets = publishTargets[GetFirstNodeWithProjectNumber(graph, 2)];
+            refPublishTargets.ShouldContain("GetTargetFrameworks");
+            refPublishTargets.ShouldContain("GetNativeManifest");
+            refPublishTargets.ShouldContain("GetCopyToPublishDirectoryItems");
+        }
+
+        /// <summary>
+        /// When DeployOnBuild=true, the Build entry target should include the Publish protocol targets
+        /// in addition to the standard Build targets. This verifies the property-to-item migration
+        /// where DeployOnBuild handling was refactored from appending to the ProjectReferenceTargetsForBuild
+        /// property to adding separate ProjectReferenceTargets items.
+        /// </summary>
+        [Fact]
+        public void DeployOnBuild_GraphBuild_IncludesPublishTargetsForBuildAndRebuild()
+        {
+            string managedProtocol = CommonCurrentVersionTargetsProtocol + ManagedAfterTargetsProtocol + AllDummyTargets;
+
+            ProjectGraph graph = Helpers.CreateProjectGraph(
+                env: _env,
+                dependencyEdges: new Dictionary<int, int[]>
+                {
+                    { 1, new[] { 2 } },
+                },
+                globalProperties: new Dictionary<string, string> { { "DeployOnBuild", "true" } },
+                extraContentForAllNodes: managedProtocol);
+
+            graph.ProjectNodes.Count.ShouldBe(2);
+
+            // Build should include both core Build targets AND Publish targets
+            IReadOnlyDictionary<ProjectGraphNode, ImmutableList<string>> buildTargets =
+                graph.GetTargetLists(new[] { "Build" });
+
+            ImmutableList<string> refBuildTargets = buildTargets[GetFirstNodeWithProjectNumber(graph, 2)];
+            // Core build protocol
+            refBuildTargets.ShouldContain("GetNativeManifest");
+            refBuildTargets.ShouldContain("GetCopyToOutputDirectoryItems");
+            // Publish targets added via DeployOnBuild
+            refBuildTargets.ShouldContain("GetCopyToPublishDirectoryItems");
+
+            // Rebuild should also include Publish targets when DeployOnBuild=true
+            IReadOnlyDictionary<ProjectGraphNode, ImmutableList<string>> rebuildTargets =
+                graph.GetTargetLists(new[] { "Rebuild" });
+
+            ImmutableList<string> refRebuildTargets = rebuildTargets[GetFirstNodeWithProjectNumber(graph, 2)];
+            refRebuildTargets.ShouldContain("Clean");
+            refRebuildTargets.ShouldContain("GetNativeManifest");
+            refRebuildTargets.ShouldContain("GetCopyToPublishDirectoryItems");
+        }
+
+        /// <summary>
+        /// When BuildProjectReferences=false, the Build protocol should use GetTargetPath instead of
+        /// .projectReferenceTargetsOrDefaultTargets, both for Build and Publish.
+        /// </summary>
+        [Fact]
+        public void BuildProjectReferencesFalse_UsesGetTargetPath()
+        {
+            string managedProtocol = CommonCurrentVersionTargetsProtocol + ManagedAfterTargetsProtocol + AllDummyTargets;
+
+            ProjectGraph graph = Helpers.CreateProjectGraph(
+                env: _env,
+                dependencyEdges: new Dictionary<int, int[]>
+                {
+                    { 1, new[] { 2 } },
+                },
+                globalProperties: new Dictionary<string, string> { { "BuildProjectReferences", "false" } },
+                extraContentForAllNodes: managedProtocol);
+
+            IReadOnlyDictionary<ProjectGraphNode, ImmutableList<string>> buildTargets =
+                graph.GetTargetLists(new[] { "Build" });
+
+            ImmutableList<string> refBuildTargets = buildTargets[GetFirstNodeWithProjectNumber(graph, 2)];
+            // Should use GetTargetPath instead of default targets
+            refBuildTargets.ShouldContain("GetTargetPath");
+            refBuildTargets.ShouldContain("GetNativeManifest");
+            refBuildTargets.ShouldContain("GetCopyToOutputDirectoryItems");
+        }
+
+        /// <summary>
+        /// A multitargeting project using the cross-targeting protocol should dispatch
+        /// via .default and properly handle outer/inner build target assignment.
+        /// </summary>
+        [Fact]
+        public void CrossTargetingProject_UsesDefaultTargetDispatch()
+        {
+            // Project 1 is multitargeting (outer build dispatches to inner builds)
+            // Project 2 is a single-targeting reference
+            string innerBuildContent = CommonCurrentVersionTargetsProtocol + AllDummyTargets;
+
+            // The outer build uses CrossTargeting protocol
+            string outerBuildContent = MultitargetingSpec + CrossTargetingProtocol + CommonCurrentVersionTargetsProtocol + AllDummyTargets;
+
+            ProjectGraph graph = Helpers.CreateProjectGraph(
+                env: _env,
+                dependencyEdges: new Dictionary<int, int[]>
+                {
+                    { 1, new[] { 2 } },
+                },
+                extraContentPerProjectNumber: new Dictionary<int, string>
+                {
+                    { 1, outerBuildContent },
+                    { 2, innerBuildContent },
+                });
+
+            // Should have: 1 outer build + 2 inner builds (net8.0, net9.0) for project 1, + project 2
+            // Inner builds of project 1 should reference project 2
+            ProjectGraphNode outerBuild1 = GetOuterBuild(graph, 1);
+            outerBuild1.ShouldNotBeNull();
+
+            IReadOnlyCollection<ProjectGraphNode> innerBuilds1 = GetInnerBuilds(graph, 1);
+            innerBuilds1.Count.ShouldBe(2);
+
+            // Outer build dispatches to inner builds with .default
+            IReadOnlyDictionary<ProjectGraphNode, ImmutableList<string>> buildTargets =
+                graph.GetTargetLists(new[] { "Build" });
+
+            // The outer build should get Build
+            buildTargets[outerBuild1].ShouldBe(new[] { "Build" });
+
+            // Inner builds should get Build (propagated)
+            foreach (ProjectGraphNode inner in innerBuilds1)
+            {
+                buildTargets[inner].ShouldBe(new[] { "Build" });
+            }
+
+            // Project 2 (referenced by inner builds) should get the full inner build protocol
+            ImmutableList<string> refTargets = buildTargets[GetFirstNodeWithProjectNumber(graph, 2)];
+            refTargets.ShouldContain("GetTargetFrameworks");
+            refTargets.ShouldContain("GetNativeManifest");
+            refTargets.ShouldContain("GetCopyToOutputDirectoryItems");
+        }
+
+        /// <summary>
+        /// Multitargeting project with BuildProjectReferences=false should use GetTargetPath
+        /// for inner builds while outer builds still dispatch via .default.
+        /// </summary>
+        [Fact]
+        public void CrossTargetingProject_BuildProjectReferencesFalse_UsesGetTargetPath()
+        {
+            string innerBuildContent = CommonCurrentVersionTargetsProtocol + AllDummyTargets;
+            string outerBuildContent = MultitargetingSpec + CrossTargetingProtocol + CommonCurrentVersionTargetsProtocol + AllDummyTargets;
+
+            ProjectGraph graph = Helpers.CreateProjectGraph(
+                env: _env,
+                dependencyEdges: new Dictionary<int, int[]>
+                {
+                    { 1, new[] { 2 } },
+                },
+                globalProperties: new Dictionary<string, string> { { "BuildProjectReferences", "false" } },
+                extraContentPerProjectNumber: new Dictionary<int, string>
+                {
+                    { 1, outerBuildContent },
+                    { 2, innerBuildContent },
+                });
+
+            IReadOnlyDictionary<ProjectGraphNode, ImmutableList<string>> buildTargets =
+                graph.GetTargetLists(new[] { "Build" });
+
+            // Project 2 should get GetTargetPath (not default targets) since BuildProjectReferences=false
+            ImmutableList<string> refTargets = buildTargets[GetFirstNodeWithProjectNumber(graph, 2)];
+            refTargets.ShouldContain("GetTargetPath");
+            refTargets.ShouldContain("GetNativeManifest");
+        }
+
+        /// <summary>
+        /// Clean on a cross-targeting project should propagate Clean to inner builds
+        /// and to referenced projects.
+        /// </summary>
+        [Fact]
+        public void CrossTargetingProject_CleanPropagatesCorrectly()
+        {
+            string innerBuildContent = CommonCurrentVersionTargetsProtocol + AllDummyTargets;
+            string outerBuildContent = MultitargetingSpec + CrossTargetingProtocol + CommonCurrentVersionTargetsProtocol + AllDummyTargets;
+
+            ProjectGraph graph = Helpers.CreateProjectGraph(
+                env: _env,
+                dependencyEdges: new Dictionary<int, int[]>
+                {
+                    { 1, new[] { 2 } },
+                },
+                extraContentPerProjectNumber: new Dictionary<int, string>
+                {
+                    { 1, outerBuildContent },
+                    { 2, innerBuildContent },
+                });
+
+            IReadOnlyDictionary<ProjectGraphNode, ImmutableList<string>> cleanTargets =
+                graph.GetTargetLists(new[] { "Clean" });
+
+            // Outer build should get Clean
+            cleanTargets[GetOuterBuild(graph, 1)].ShouldBe(new[] { "Clean" });
+
+            // Inner builds should get Clean
+            foreach (ProjectGraphNode inner in GetInnerBuilds(graph, 1))
+            {
+                cleanTargets[inner].ShouldBe(new[] { "Clean" });
+            }
+
+            // Referenced project should get Clean
+            ImmutableList<string> refCleanTargets = cleanTargets[GetFirstNodeWithProjectNumber(graph, 2)];
+            refCleanTargets.ShouldContain("Clean");
+            refCleanTargets.ShouldContain("GetTargetFrameworks");
+            refCleanTargets.ShouldContain("GetTargetFrameworksWithPlatformForSingleTargetFramework");
+        }
+
+        /// <summary>
+        /// When DeployOnBuild is NOT set, Build should NOT include Publish targets.
+        /// This confirms the DeployOnBuild condition is properly gating the Publish items.
+        /// </summary>
+        [Fact]
+        public void NoDeployOnBuild_BuildDoesNotIncludePublishTargets()
+        {
+            string managedProtocol = CommonCurrentVersionTargetsProtocol + ManagedAfterTargetsProtocol + AllDummyTargets;
+
+            ProjectGraph graph = Helpers.CreateProjectGraph(
+                env: _env,
+                dependencyEdges: new Dictionary<int, int[]>
+                {
+                    { 1, new[] { 2 } },
+                },
+                extraContentForAllNodes: managedProtocol);
+
+            IReadOnlyDictionary<ProjectGraphNode, ImmutableList<string>> buildTargets =
+                graph.GetTargetLists(new[] { "Build" });
+
+            ImmutableList<string> refBuildTargets = buildTargets[GetFirstNodeWithProjectNumber(graph, 2)];
+            refBuildTargets.ShouldNotContain("GetCopyToPublishDirectoryItems");
+        }
+
+        /// <summary>
+        /// Managed project with Publish entry target should call the correct Publish protocol
+        /// on referenced projects regardless of DeployOnBuild setting.
+        /// </summary>
+        [Fact]
+        public void ManagedProject_PublishTarget_CallsPublishProtocol()
+        {
+            string managedProtocol = CommonCurrentVersionTargetsProtocol + ManagedAfterTargetsProtocol + AllDummyTargets;
+
+            ProjectGraph graph = Helpers.CreateProjectGraph(
+                env: _env,
+                dependencyEdges: new Dictionary<int, int[]>
+                {
+                    { 1, new[] { 2 } },
+                },
+                extraContentForAllNodes: managedProtocol);
+
+            IReadOnlyDictionary<ProjectGraphNode, ImmutableList<string>> publishTargets =
+                graph.GetTargetLists(new[] { "Publish" });
+
+            ImmutableList<string> refPublishTargets = publishTargets[GetFirstNodeWithProjectNumber(graph, 2)];
+            refPublishTargets.ShouldContain("GetTargetFrameworks");
+            refPublishTargets.ShouldContain("GetNativeManifest");
+            refPublishTargets.ShouldContain("GetCopyToPublishDirectoryItems");
+        }
+
+        /// <summary>
+        /// The core protocol should work for a chain of 3 projects, verifying
+        /// that targets propagate transitively through the graph.
+        /// </summary>
+        [Fact]
+        public void NonManagedProjectChain_PropagatesTargetsThroughGraph()
+        {
+            string commonProtocol = CommonCurrentVersionTargetsProtocol + AllDummyTargets;
+
+            // 1 → 2 → 3
+            ProjectGraph graph = Helpers.CreateProjectGraph(
+                env: _env,
+                dependencyEdges: new Dictionary<int, int[]>
+                {
+                    { 1, new[] { 2 } },
+                    { 2, new[] { 3 } },
+                },
+                extraContentForAllNodes: commonProtocol);
+
+            graph.ProjectNodes.Count.ShouldBe(3);
+
+            IReadOnlyDictionary<ProjectGraphNode, ImmutableList<string>> buildTargets =
+                graph.GetTargetLists(new[] { "Build" });
+
+            // Project 2 gets targets from project 1's protocol
+            ImmutableList<string> proj2Targets = buildTargets[GetFirstNodeWithProjectNumber(graph, 2)];
+            proj2Targets.ShouldContain("GetNativeManifest");
+            proj2Targets.ShouldContain("GetCopyToOutputDirectoryItems");
+
+            // Project 3 gets targets from project 2's protocol
+            ImmutableList<string> proj3Targets = buildTargets[GetFirstNodeWithProjectNumber(graph, 3)];
+            proj3Targets.ShouldContain("GetNativeManifest");
+            proj3Targets.ShouldContain("GetCopyToOutputDirectoryItems");
+        }
+
+        /// <summary>
+        /// When NoBuild=true, the Publish protocol should use GetTargetPath
+        /// instead of .projectReferenceTargetsOrDefaultTargets for the main reference target.
+        /// </summary>
+        [Fact]
+        public void NoBuild_PublishUsesGetTargetPath()
+        {
+            string managedProtocol = CommonCurrentVersionTargetsProtocol + ManagedAfterTargetsProtocol + AllDummyTargets;
+
+            ProjectGraph graph = Helpers.CreateProjectGraph(
+                env: _env,
+                dependencyEdges: new Dictionary<int, int[]>
+                {
+                    { 1, new[] { 2 } },
+                },
+                globalProperties: new Dictionary<string, string> { { "NoBuild", "true" } },
+                extraContentForAllNodes: managedProtocol);
+
+            IReadOnlyDictionary<ProjectGraphNode, ImmutableList<string>> publishTargets =
+                graph.GetTargetLists(new[] { "Publish" });
+
+            ImmutableList<string> refPublishTargets = publishTargets[GetFirstNodeWithProjectNumber(graph, 2)];
+            // With NoBuild=true, Publish should use GetTargetPath instead of building
+            refPublishTargets.ShouldContain("GetTargetPath");
+            refPublishTargets.ShouldContain("GetTargetFrameworks");
+            refPublishTargets.ShouldContain("GetCopyToPublishDirectoryItems");
+        }
+
+        public void Dispose()
+        {
+            _env.Dispose();
+        }
+    }
+}

--- a/src/Build.UnitTests/Graph/ProjectReferenceTargetsProtocol_Tests.cs
+++ b/src/Build.UnitTests/Graph/ProjectReferenceTargetsProtocol_Tests.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Build.Graph.UnitTests
     /// </summary>
     public class ProjectReferenceTargetsProtocolTests : IDisposable
     {
-        private TestEnvironment _env;
+        private readonly TestEnvironment _env;
 
         public ProjectReferenceTargetsProtocolTests(ITestOutputHelper output)
         {
@@ -318,7 +318,9 @@ namespace Microsoft.Build.Graph.UnitTests
             // Project 2 is a single-targeting reference
             string innerBuildContent = CommonCurrentVersionTargetsProtocol + AllDummyTargets;
 
-            // The outer build uses CrossTargeting protocol
+            // The outer build uses CrossTargeting protocol + CommonCurrentVersion protocol.
+            // Both are needed because the same project file serves as outer and inner builds;
+            // IsCrossTargetingBuild conditions determine which protocol items activate.
             string outerBuildContent = MultitargetingSpec + CrossTargetingProtocol + CommonCurrentVersionTargetsProtocol + AllDummyTargets;
 
             ProjectGraph graph = Helpers.CreateProjectGraph(

--- a/src/Build.UnitTests/Graph/ProjectReferenceTargetsProtocol_Tests.cs
+++ b/src/Build.UnitTests/Graph/ProjectReferenceTargetsProtocol_Tests.cs
@@ -21,125 +21,79 @@ namespace Microsoft.Build.Graph.UnitTests
     /// Microsoft.Common.CurrentVersion.targets, Microsoft.Common.CrossTargeting.targets,
     /// and Microsoft.Managed.After.targets correctly propagates targets through the graph.
     ///
-    /// These tests use synthetic project XML that mirrors the real targets files to ensure
-    /// the protocol is correct regardless of which project types import the targets.
+    /// These tests import the real targets files via $(MSBuildToolsPath) so the assertions
+    /// run against the production protocol, not a copy-pasted snapshot. Changes to the
+    /// real ProjectReferenceTargets sections in those files will exercise these tests directly.
     /// </summary>
     public class ProjectReferenceTargetsProtocolTests : IDisposable
     {
         private readonly TestEnvironment _env;
 
+        /// <summary>
+        /// Microsoft.Common.CrossTargeting.targets unconditionally imports $(NuGetRestoreTargets),
+        /// which defaults to $(MSBuildToolsPath)\NuGet.targets — a file not present in the
+        /// unit-test bin directory. The cross-targeting tests override the property to point at
+        /// this empty stub so the import resolves to a no-op. (Microsoft.Common.CurrentVersion.targets
+        /// guards its NuGet import with Exists(), so the non-cross-targeting tests don't need this.)
+        /// </summary>
+        private readonly TransientTestFile _emptyNuGetTargets;
+
         public ProjectReferenceTargetsProtocolTests(ITestOutputHelper output)
         {
             _env = TestEnvironment.Create(output);
+            _emptyNuGetTargets = _env.CreateFile("NuGet.targets", "<Project/>");
         }
 
         /// <summary>
-        /// The core ProjectReferenceTargets protocol as defined in Microsoft.Common.CurrentVersion.targets
-        /// (the "ProjectReferenceTargets for Static Graph" section, around line 5183).
-        /// Keep in sync with the real file — if the protocol changes there, update this constant.
-        /// This applies to all project types that import the Common targets.
+        /// Synthetic project content for a non-managed, non-cross-targeting project that imports
+        /// Microsoft.Common.targets (which in turn imports Microsoft.Common.CurrentVersion.targets).
+        /// This gives the test the real core Build/Clean/Rebuild ProjectReferenceTargets protocol.
         /// </summary>
-        private const string CommonCurrentVersionTargetsProtocol = """
+        private const string CommonImports = """
             <PropertyGroup>
-              <_RecursiveTargetForContentCopying>GetCopyToOutputDirectoryItems</_RecursiveTargetForContentCopying>
+              <Configuration>Debug</Configuration>
+              <Platform>AnyCPU</Platform>
+              <OutputPath>bin\Debug\</OutputPath>
             </PropertyGroup>
-
-            <PropertyGroup Condition="'$(IsGraphBuild)' == 'true' and '$(IsCrossTargetingBuild)' != 'true'">
-              <_MainReferenceTargetForBuild Condition="'$(BuildProjectReferences)' == '' or '$(BuildProjectReferences)' == 'true'">.projectReferenceTargetsOrDefaultTargets</_MainReferenceTargetForBuild>
-              <_MainReferenceTargetForBuild Condition="'$(_MainReferenceTargetForBuild)' == ''">GetTargetPath</_MainReferenceTargetForBuild>
-
-              <ProjectReferenceTargetsForBuild>$(_MainReferenceTargetForBuild);GetNativeManifest;$(_RecursiveTargetForContentCopying);$(ProjectReferenceTargetsForBuild)</ProjectReferenceTargetsForBuild>
-            </PropertyGroup>
-            <PropertyGroup Condition="'$(IsGraphBuild)' == 'true'">
-              <ProjectReferenceTargetsForClean>Clean;$(ProjectReferenceTargetsForClean)</ProjectReferenceTargetsForClean>
-              <ProjectReferenceTargetsForRebuild>$(ProjectReferenceTargetsForClean);$(ProjectReferenceTargetsForBuild);$(ProjectReferenceTargetsForRebuild)</ProjectReferenceTargetsForRebuild>
-            </PropertyGroup>
-
-            <ItemGroup Condition="'$(IsGraphBuild)' == 'true'">
-              <ProjectReferenceTargets Include="Build" Targets="$(ProjectReferenceTargetsForBuildInOuterBuild)" Condition=" '$(ProjectReferenceTargetsForBuildInOuterBuild)' != '' " OuterBuild="true" />
-              <ProjectReferenceTargets Include="Build" Targets="GetTargetFrameworks" OuterBuild="true" SkipNonexistentTargets="true" Condition="'$(IsCrossTargetingBuild)' != 'true'" />
-              <ProjectReferenceTargets Include="Build" Targets="$(ProjectReferenceTargetsForBuild)" Condition=" '$(ProjectReferenceTargetsForBuild)' != '' " />
-
-              <ProjectReferenceTargets Include="Clean" Targets="$(ProjectReferenceTargetsForCleanInOuterBuild)" Condition=" '$(ProjectReferenceTargetsForCleanInOuterBuild)' != '' " OuterBuild="true" />
-              <ProjectReferenceTargets Include="Clean" Targets="GetTargetFrameworks" OuterBuild="true" SkipNonexistentTargets="true" Condition="'$(IsCrossTargetingBuild)' != 'true'" />
-              <ProjectReferenceTargets Include="Clean" Targets="$(ProjectReferenceTargetsForClean)" Condition=" '$(ProjectReferenceTargetsForClean)' != '' " />
-
-              <ProjectReferenceTargets Include="Build" Targets="GetTargetFrameworksWithPlatformForSingleTargetFramework" SkipNonexistentTargets="true" Condition="'$(IsCrossTargetingBuild)' != 'true'" />
-              <ProjectReferenceTargets Include="Clean" Targets="GetTargetFrameworksWithPlatformForSingleTargetFramework" SkipNonexistentTargets="true" Condition="'$(IsCrossTargetingBuild)' != 'true'" />
-              <ProjectReferenceTargets Include="Rebuild" Targets="GetTargetFrameworksWithPlatformForSingleTargetFramework" SkipNonexistentTargets="true" Condition="'$(IsCrossTargetingBuild)' != 'true'" />
-
-              <ProjectReferenceTargets Include="Rebuild" Targets="$(ProjectReferenceTargetsForRebuild)" Condition=" '$(ProjectReferenceTargetsForRebuild)' != '' " />
-            </ItemGroup>
+            <Import Project="$(MSBuildToolsPath)\Microsoft.Common.targets" />
             """;
 
         /// <summary>
-        /// The cross-targeting protocol as defined in Microsoft.Common.CrossTargeting.targets
-        /// (the "ProjectReferenceTargets for Static Graph (Cross-Targeting)" section).
-        /// Keep in sync with the real file.
+        /// Synthetic project content for a managed project. Imports Microsoft.Common.targets plus
+        /// Microsoft.Managed.After.targets (which adds the managed-specific Publish / DeployOnBuild
+        /// extensions). Mirrors the shape of a real C#/VB project's import chain for the purpose
+        /// of these protocol tests, without pulling in the language-specific compile targets.
         /// </summary>
-        private const string CrossTargetingProtocol = """
-            <PropertyGroup Condition="'$(IsGraphBuild)' == 'true'">
-              <ProjectReferenceTargetsForBuild>.default;$(ProjectReferenceTargetsForBuild)</ProjectReferenceTargetsForBuild>
-              <ProjectReferenceTargetsForClean>Clean;$(ProjectReferenceTargetsForClean)</ProjectReferenceTargetsForClean>
-              <ProjectReferenceTargetsForRebuild>$(ProjectReferenceTargetsForClean);$(ProjectReferenceTargetsForBuild);$(ProjectReferenceTargetsForRebuild)</ProjectReferenceTargetsForRebuild>
+        private const string ManagedImports = """
+            <PropertyGroup>
+              <Configuration>Debug</Configuration>
+              <Platform>AnyCPU</Platform>
+              <OutputPath>bin\Debug\</OutputPath>
             </PropertyGroup>
-            <ItemGroup Condition="'$(IsGraphBuild)' == 'true'">
-              <ProjectReferenceTargets Include="Build" Targets="$(ProjectReferenceTargetsForBuild)" Condition=" '$(ProjectReferenceTargetsForBuild)' != '' " />
-              <ProjectReferenceTargets Include="Clean" Targets="$(ProjectReferenceTargetsForClean)" Condition=" '$(ProjectReferenceTargetsForClean)' != '' " />
-              <ProjectReferenceTargets Include="Rebuild" Targets="$(ProjectReferenceTargetsForRebuild)" Condition=" '$(ProjectReferenceTargetsForRebuild)' != '' " />
-            </ItemGroup>
+            <Import Project="$(MSBuildToolsPath)\Microsoft.Common.targets" />
+            <Import Project="$(MSBuildToolsPath)\Microsoft.Managed.After.targets" />
             """;
 
         /// <summary>
-        /// The managed-specific extensions from Microsoft.Managed.After.targets for Publish and DeployOnBuild.
-        /// Keep in sync with the real file.
+        /// Synthetic content for a multitargeting (cross-targeting) managed project. The same XML
+        /// is evaluated multiple times by ProjectGraph: once for the outer build (no TargetFramework
+        /// global property, IsCrossTargetingBuild=true) and once per inner build (TargetFramework
+        /// set, IsCrossTargetingBuild=false). The conditional imports route each evaluation to
+        /// the right targets file, matching the production SDK pattern.
         /// </summary>
-        private const string ManagedAfterTargetsProtocol = """
-            <PropertyGroup Condition="'$(IsGraphBuild)' == 'true' and '$(IsCrossTargetingBuild)' != 'true'">
-              <_MainReferenceTargetForPublish Condition="'$(NoBuild)' == 'true'">GetTargetPath</_MainReferenceTargetForPublish>
-              <_MainReferenceTargetForPublish Condition="'$(NoBuild)' != 'true'">$(_MainReferenceTargetForBuild)</_MainReferenceTargetForPublish>
-              <ProjectReferenceTargetsForPublish>GetTargetFrameworks;$(_MainReferenceTargetForPublish);GetNativeManifest;GetCopyToPublishDirectoryItems;$(ProjectReferenceTargetsForPublish)</ProjectReferenceTargetsForPublish>
-
-              <ProjectReferenceTargetsForGetCopyToPublishDirectoryItems>GetCopyToPublishDirectoryItems;$(ProjectReferenceTargetsForGetCopyToPublishDirectoryItems)</ProjectReferenceTargetsForGetCopyToPublishDirectoryItems>
-            </PropertyGroup>
-
-            <ItemGroup Condition="'$(IsGraphBuild)' == 'true'">
-              <ProjectReferenceTargets Include="Build" Targets="$(ProjectReferenceTargetsForPublish)" Condition="'$(DeployOnBuild)' == 'true' and '$(IsCrossTargetingBuild)' != 'true' and '$(ProjectReferenceTargetsForPublish)' != ''" />
-              <ProjectReferenceTargets Include="Rebuild" Targets="$(ProjectReferenceTargetsForPublish)" Condition="'$(DeployOnBuild)' == 'true' and '$(IsCrossTargetingBuild)' != 'true' and '$(ProjectReferenceTargetsForPublish)' != ''" />
-
-              <ProjectReferenceTargets Include="Publish" Targets="$(ProjectReferenceTargetsForPublish)" Condition=" '$(ProjectReferenceTargetsForPublish)' != '' " />
-
-              <ProjectReferenceTargets Include="GetCopyToPublishDirectoryItems" Targets="$(ProjectReferenceTargetsForGetCopyToPublishDirectoryItems)" Condition=" '$(ProjectReferenceTargetsForGetCopyToPublishDirectoryItems)' != '' " />
-            </ItemGroup>
-            """;
-
-        /// <summary>
-        /// Multitargeting specification using TargetFramework / TargetFrameworks, as in real managed projects.
-        /// </summary>
-        private const string MultitargetingSpec = """
+        private const string MultitargetingManagedImports = """
             <PropertyGroup>
               <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
-            </PropertyGroup>
-            <PropertyGroup Condition="'$(TargetFrameworks)' != '' and '$(TargetFramework)' == ''">
-              <IsCrossTargetingBuild>true</IsCrossTargetingBuild>
-            </PropertyGroup>
-            <PropertyGroup>
               <InnerBuildProperty>TargetFramework</InnerBuildProperty>
               <InnerBuildPropertyValues>TargetFrameworks</InnerBuildPropertyValues>
+              <Configuration>Debug</Configuration>
+              <Platform>AnyCPU</Platform>
+              <OutputPath>bin\Debug\</OutputPath>
+              <IsCrossTargetingBuild Condition="'$(TargetFrameworks)' != '' and '$(TargetFramework)' == ''">true</IsCrossTargetingBuild>
             </PropertyGroup>
-            """;
-
-        private string AllDummyTargets => """
-            <Target Name="Build" />
-            <Target Name="Clean" />
-            <Target Name="Rebuild" />
-            <Target Name="Publish" />
-            <Target Name="GetTargetPath" />
-            <Target Name="GetNativeManifest" />
-            <Target Name="GetCopyToOutputDirectoryItems" />
-            <Target Name="GetCopyToPublishDirectoryItems" />
-            <Target Name="GetTargetFrameworks" />
-            <Target Name="GetTargetFrameworksWithPlatformForSingleTargetFramework" />
+            <Import Project="$(MSBuildToolsPath)\Microsoft.Common.CrossTargeting.targets" Condition="'$(IsCrossTargetingBuild)' == 'true'" />
+            <Import Project="$(MSBuildToolsPath)\Microsoft.Common.targets" Condition="'$(IsCrossTargetingBuild)' != 'true'" />
+            <Import Project="$(MSBuildToolsPath)\Microsoft.Managed.After.targets" />
             """;
 
         /// <summary>
@@ -149,16 +103,14 @@ namespace Microsoft.Build.Graph.UnitTests
         [Fact]
         public void NonManagedProject_GetsCoreBuildCleanRebuild_InGraphBuild()
         {
-            // Project 1 → Project 2, both only importing the Common protocol
-            string commonProtocol = CommonCurrentVersionTargetsProtocol + AllDummyTargets;
-
+            // Project 1 → Project 2, both only importing the Common targets
             ProjectGraph graph = Helpers.CreateProjectGraph(
                 env: _env,
                 dependencyEdges: new Dictionary<int, int[]>
                 {
                     { 1, new[] { 2 } },
                 },
-                extraContentForAllNodes: commonProtocol);
+                extraContentForAllNodes: CommonImports);
 
             graph.ProjectNodes.Count.ShouldBe(2);
 
@@ -202,16 +154,13 @@ namespace Microsoft.Build.Graph.UnitTests
         [Fact]
         public void ManagedProject_GraphBuildTargets_MatchExpectedProtocol()
         {
-            // Managed project: Common protocol + Managed extensions
-            string managedProtocol = CommonCurrentVersionTargetsProtocol + ManagedAfterTargetsProtocol + AllDummyTargets;
-
             ProjectGraph graph = Helpers.CreateProjectGraph(
                 env: _env,
                 dependencyEdges: new Dictionary<int, int[]>
                 {
                     { 1, new[] { 2 } },
                 },
-                extraContentForAllNodes: managedProtocol);
+                extraContentForAllNodes: ManagedImports);
 
             graph.ProjectNodes.Count.ShouldBe(2);
 
@@ -244,8 +193,6 @@ namespace Microsoft.Build.Graph.UnitTests
         [Fact]
         public void DeployOnBuild_GraphBuild_IncludesPublishTargetsForBuildAndRebuild()
         {
-            string managedProtocol = CommonCurrentVersionTargetsProtocol + ManagedAfterTargetsProtocol + AllDummyTargets;
-
             ProjectGraph graph = Helpers.CreateProjectGraph(
                 env: _env,
                 dependencyEdges: new Dictionary<int, int[]>
@@ -253,7 +200,7 @@ namespace Microsoft.Build.Graph.UnitTests
                     { 1, new[] { 2 } },
                 },
                 globalProperties: new Dictionary<string, string> { { "DeployOnBuild", "true" } },
-                extraContentForAllNodes: managedProtocol);
+                extraContentForAllNodes: ManagedImports);
 
             graph.ProjectNodes.Count.ShouldBe(2);
 
@@ -285,8 +232,6 @@ namespace Microsoft.Build.Graph.UnitTests
         [Fact]
         public void BuildProjectReferencesFalse_UsesGetTargetPath()
         {
-            string managedProtocol = CommonCurrentVersionTargetsProtocol + ManagedAfterTargetsProtocol + AllDummyTargets;
-
             ProjectGraph graph = Helpers.CreateProjectGraph(
                 env: _env,
                 dependencyEdges: new Dictionary<int, int[]>
@@ -294,7 +239,7 @@ namespace Microsoft.Build.Graph.UnitTests
                     { 1, new[] { 2 } },
                 },
                 globalProperties: new Dictionary<string, string> { { "BuildProjectReferences", "false" } },
-                extraContentForAllNodes: managedProtocol);
+                extraContentForAllNodes: ManagedImports);
 
             IReadOnlyDictionary<ProjectGraphNode, ImmutableList<string>> buildTargets =
                 graph.GetTargetLists(new[] { "Build" });
@@ -313,25 +258,19 @@ namespace Microsoft.Build.Graph.UnitTests
         [Fact]
         public void CrossTargetingProject_UsesDefaultTargetDispatch()
         {
-            // Project 1 is multitargeting (outer build dispatches to inner builds)
-            // Project 2 is a single-targeting reference
-            string innerBuildContent = CommonCurrentVersionTargetsProtocol + AllDummyTargets;
-
-            // The outer build uses CrossTargeting protocol + CommonCurrentVersion protocol.
-            // Both are needed because the same project file serves as outer and inner builds;
-            // IsCrossTargetingBuild conditions determine which protocol items activate.
-            string outerBuildContent = MultitargetingSpec + CrossTargetingProtocol + CommonCurrentVersionTargetsProtocol + AllDummyTargets;
-
+            // Project 1 is multitargeting (outer build dispatches to inner builds via cross-targeting imports).
+            // Project 2 is a single-targeting reference using the Common imports.
             ProjectGraph graph = Helpers.CreateProjectGraph(
                 env: _env,
                 dependencyEdges: new Dictionary<int, int[]>
                 {
                     { 1, new[] { 2 } },
                 },
+                globalProperties: new Dictionary<string, string> { { "NuGetRestoreTargets", _emptyNuGetTargets.Path } },
                 extraContentPerProjectNumber: new Dictionary<int, string>
                 {
-                    { 1, outerBuildContent },
-                    { 2, innerBuildContent },
+                    { 1, MultitargetingManagedImports },
+                    { 2, CommonImports },
                 });
 
             // Should have: 1 outer build + 2 inner builds (net8.0, net9.0) for project 1, + project 2
@@ -369,20 +308,21 @@ namespace Microsoft.Build.Graph.UnitTests
         [Fact]
         public void CrossTargetingProject_BuildProjectReferencesFalse_UsesGetTargetPath()
         {
-            string innerBuildContent = CommonCurrentVersionTargetsProtocol + AllDummyTargets;
-            string outerBuildContent = MultitargetingSpec + CrossTargetingProtocol + CommonCurrentVersionTargetsProtocol + AllDummyTargets;
-
             ProjectGraph graph = Helpers.CreateProjectGraph(
                 env: _env,
                 dependencyEdges: new Dictionary<int, int[]>
                 {
                     { 1, new[] { 2 } },
                 },
-                globalProperties: new Dictionary<string, string> { { "BuildProjectReferences", "false" } },
+                globalProperties: new Dictionary<string, string>
+                {
+                    { "BuildProjectReferences", "false" },
+                    { "NuGetRestoreTargets", _emptyNuGetTargets.Path },
+                },
                 extraContentPerProjectNumber: new Dictionary<int, string>
                 {
-                    { 1, outerBuildContent },
-                    { 2, innerBuildContent },
+                    { 1, MultitargetingManagedImports },
+                    { 2, CommonImports },
                 });
 
             IReadOnlyDictionary<ProjectGraphNode, ImmutableList<string>> buildTargets =
@@ -401,19 +341,17 @@ namespace Microsoft.Build.Graph.UnitTests
         [Fact]
         public void CrossTargetingProject_CleanPropagatesCorrectly()
         {
-            string innerBuildContent = CommonCurrentVersionTargetsProtocol + AllDummyTargets;
-            string outerBuildContent = MultitargetingSpec + CrossTargetingProtocol + CommonCurrentVersionTargetsProtocol + AllDummyTargets;
-
             ProjectGraph graph = Helpers.CreateProjectGraph(
                 env: _env,
                 dependencyEdges: new Dictionary<int, int[]>
                 {
                     { 1, new[] { 2 } },
                 },
+                globalProperties: new Dictionary<string, string> { { "NuGetRestoreTargets", _emptyNuGetTargets.Path } },
                 extraContentPerProjectNumber: new Dictionary<int, string>
                 {
-                    { 1, outerBuildContent },
-                    { 2, innerBuildContent },
+                    { 1, MultitargetingManagedImports },
+                    { 2, CommonImports },
                 });
 
             IReadOnlyDictionary<ProjectGraphNode, ImmutableList<string>> cleanTargets =
@@ -442,15 +380,13 @@ namespace Microsoft.Build.Graph.UnitTests
         [Fact]
         public void NoDeployOnBuild_BuildDoesNotIncludePublishTargets()
         {
-            string managedProtocol = CommonCurrentVersionTargetsProtocol + ManagedAfterTargetsProtocol + AllDummyTargets;
-
             ProjectGraph graph = Helpers.CreateProjectGraph(
                 env: _env,
                 dependencyEdges: new Dictionary<int, int[]>
                 {
                     { 1, new[] { 2 } },
                 },
-                extraContentForAllNodes: managedProtocol);
+                extraContentForAllNodes: ManagedImports);
 
             IReadOnlyDictionary<ProjectGraphNode, ImmutableList<string>> buildTargets =
                 graph.GetTargetLists(new[] { "Build" });
@@ -466,15 +402,13 @@ namespace Microsoft.Build.Graph.UnitTests
         [Fact]
         public void ManagedProject_PublishTarget_CallsPublishProtocol()
         {
-            string managedProtocol = CommonCurrentVersionTargetsProtocol + ManagedAfterTargetsProtocol + AllDummyTargets;
-
             ProjectGraph graph = Helpers.CreateProjectGraph(
                 env: _env,
                 dependencyEdges: new Dictionary<int, int[]>
                 {
                     { 1, new[] { 2 } },
                 },
-                extraContentForAllNodes: managedProtocol);
+                extraContentForAllNodes: ManagedImports);
 
             IReadOnlyDictionary<ProjectGraphNode, ImmutableList<string>> publishTargets =
                 graph.GetTargetLists(new[] { "Publish" });
@@ -492,8 +426,6 @@ namespace Microsoft.Build.Graph.UnitTests
         [Fact]
         public void NonManagedProjectChain_PropagatesTargetsThroughGraph()
         {
-            string commonProtocol = CommonCurrentVersionTargetsProtocol + AllDummyTargets;
-
             // 1 → 2 → 3
             ProjectGraph graph = Helpers.CreateProjectGraph(
                 env: _env,
@@ -502,7 +434,7 @@ namespace Microsoft.Build.Graph.UnitTests
                     { 1, new[] { 2 } },
                     { 2, new[] { 3 } },
                 },
-                extraContentForAllNodes: commonProtocol);
+                extraContentForAllNodes: CommonImports);
 
             graph.ProjectNodes.Count.ShouldBe(3);
 
@@ -527,8 +459,6 @@ namespace Microsoft.Build.Graph.UnitTests
         [Fact]
         public void NoBuild_PublishUsesGetTargetPath()
         {
-            string managedProtocol = CommonCurrentVersionTargetsProtocol + ManagedAfterTargetsProtocol + AllDummyTargets;
-
             ProjectGraph graph = Helpers.CreateProjectGraph(
                 env: _env,
                 dependencyEdges: new Dictionary<int, int[]>
@@ -536,7 +466,7 @@ namespace Microsoft.Build.Graph.UnitTests
                     { 1, new[] { 2 } },
                 },
                 globalProperties: new Dictionary<string, string> { { "NoBuild", "true" } },
-                extraContentForAllNodes: managedProtocol);
+                extraContentForAllNodes: ManagedImports);
 
             IReadOnlyDictionary<ProjectGraphNode, ImmutableList<string>> publishTargets =
                 graph.GetTargetLists(new[] { "Publish" });

--- a/src/Tasks/Microsoft.Common.CrossTargeting.targets
+++ b/src/Tasks/Microsoft.Common.CrossTargeting.targets
@@ -193,6 +193,32 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <Target Name="Rebuild" DependsOnTargets="Clean;Build" />
 
   <!--
+    ============================================================
+                                        ProjectReferenceTargets for Static Graph (Cross-Targeting)
+
+    Define the project-to-project calling patterns for graph builds
+    in the cross-targeting (outer build) context.
+
+    The outer build dispatches to inner builds:
+      - Build (via DispatchToInnerBuilds) calls the default targets on inner builds
+      - Clean calls Clean on inner builds
+      - Rebuild calls Clean + Build
+
+    The inner build protocol is defined in Microsoft.Common.CurrentVersion.targets.
+    ============================================================
+  -->
+  <PropertyGroup Condition="'$(IsGraphBuild)' == 'true'">
+    <ProjectReferenceTargetsForBuild>.default;$(ProjectReferenceTargetsForBuild)</ProjectReferenceTargetsForBuild>
+    <ProjectReferenceTargetsForClean>Clean;$(ProjectReferenceTargetsForClean)</ProjectReferenceTargetsForClean>
+    <ProjectReferenceTargetsForRebuild>$(ProjectReferenceTargetsForClean);$(ProjectReferenceTargetsForBuild);$(ProjectReferenceTargetsForRebuild)</ProjectReferenceTargetsForRebuild>
+  </PropertyGroup>
+  <ItemGroup Condition="'$(IsGraphBuild)' == 'true'">
+    <ProjectReferenceTargets Include="Build" Targets="$(ProjectReferenceTargetsForBuild)" Condition=" '$(ProjectReferenceTargetsForBuild)' != '' " />
+    <ProjectReferenceTargets Include="Clean" Targets="$(ProjectReferenceTargetsForClean)" Condition=" '$(ProjectReferenceTargetsForClean)' != '' " />
+    <ProjectReferenceTargets Include="Rebuild" Targets="$(ProjectReferenceTargetsForRebuild)" Condition=" '$(ProjectReferenceTargetsForRebuild)' != '' " />
+  </ItemGroup>
+
+  <!--
     This will import NuGet restore targets. We need restore to work before any package assets are available.
   -->
   <PropertyGroup>

--- a/src/Tasks/Microsoft.Common.CrossTargeting.targets
+++ b/src/Tasks/Microsoft.Common.CrossTargeting.targets
@@ -213,8 +213,12 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <ProjectReferenceTargetsForRebuild>$(ProjectReferenceTargetsForClean);$(ProjectReferenceTargetsForBuild);$(ProjectReferenceTargetsForRebuild)</ProjectReferenceTargetsForRebuild>
   </PropertyGroup>
   <ItemGroup Condition="'$(IsGraphBuild)' == 'true'">
+    <ProjectReferenceTargets Include="Build" Targets="$(ProjectReferenceTargetsForBuildInOuterBuild)" Condition=" '$(ProjectReferenceTargetsForBuildInOuterBuild)' != '' " OuterBuild="true" />
     <ProjectReferenceTargets Include="Build" Targets="$(ProjectReferenceTargetsForBuild)" Condition=" '$(ProjectReferenceTargetsForBuild)' != '' " />
+
+    <ProjectReferenceTargets Include="Clean" Targets="$(ProjectReferenceTargetsForCleanInOuterBuild)" Condition=" '$(ProjectReferenceTargetsForCleanInOuterBuild)' != '' " OuterBuild="true" />
     <ProjectReferenceTargets Include="Clean" Targets="$(ProjectReferenceTargetsForClean)" Condition=" '$(ProjectReferenceTargetsForClean)' != '' " />
+
     <ProjectReferenceTargets Include="Rebuild" Targets="$(ProjectReferenceTargetsForRebuild)" Condition=" '$(ProjectReferenceTargetsForRebuild)' != '' " />
   </ItemGroup>
 

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -5183,6 +5183,63 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <_RecursiveTargetForContentCopying Condition=" '$(MSBuildCopyContentTransitively)' == 'false' ">_GetCopyToOutputDirectoryItemsFromThisProject</_RecursiveTargetForContentCopying>
   </PropertyGroup>
 
+  <!--
+    ============================================================
+                                        ProjectReferenceTargets for Static Graph
+
+    Define the project-to-project calling patterns for graph builds.
+    These items tell the static graph which targets a project calls
+    on its referenced projects for Build, Clean, and Rebuild.
+
+    These must accurately describe the MSBuild task calls in:
+      - ResolveProjectReferences (Build / GetTargetPath + GetNativeManifest)
+      - GetCopyToOutputDirectoryItems (_RecursiveTargetForContentCopying)
+      - CleanReferencedProjects (Clean)
+      - Rebuild (Clean + Build)
+
+    SDKs can extend these by appending to the ProjectReferenceTargetsFor*
+    properties before this evaluation, or by adding additional
+    ProjectReferenceTargets items after import.
+    ============================================================
+  -->
+  <!--
+      Properties for extension of ProjectReferenceTargets.
+      Append any current value which may have been provided in a Directory.Build.props since the intent was likely to append, not prepend.
+  -->
+  <PropertyGroup Condition="'$(IsGraphBuild)' == 'true' and '$(IsCrossTargetingBuild)' != 'true'">
+    <!-- Empty case is for builds which do not import the target files that set BuildProjectReferences -->
+    <_MainReferenceTargetForBuild Condition="'$(BuildProjectReferences)' == '' or '$(BuildProjectReferences)' == 'true'">.projectReferenceTargetsOrDefaultTargets</_MainReferenceTargetForBuild>
+    <_MainReferenceTargetForBuild Condition="'$(_MainReferenceTargetForBuild)' == ''">GetTargetPath</_MainReferenceTargetForBuild>
+
+    <ProjectReferenceTargetsForBuild>$(_MainReferenceTargetForBuild);GetNativeManifest;$(_RecursiveTargetForContentCopying);$(ProjectReferenceTargetsForBuild)</ProjectReferenceTargetsForBuild>
+  </PropertyGroup>
+  <!-- Cross-targeting outer builds define their protocol in Microsoft.Common.CrossTargeting.targets -->
+  <PropertyGroup Condition="'$(IsGraphBuild)' == 'true'">
+    <ProjectReferenceTargetsForClean>Clean;$(ProjectReferenceTargetsForClean)</ProjectReferenceTargetsForClean>
+    <ProjectReferenceTargetsForRebuild>$(ProjectReferenceTargetsForClean);$(ProjectReferenceTargetsForBuild);$(ProjectReferenceTargetsForRebuild)</ProjectReferenceTargetsForRebuild>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(IsGraphBuild)' == 'true'">
+    <ProjectReferenceTargets Include="Build" Targets="$(ProjectReferenceTargetsForBuildInOuterBuild)" Condition=" '$(ProjectReferenceTargetsForBuildInOuterBuild)' != '' " OuterBuild="true" />
+    <ProjectReferenceTargets Include="Build" Targets="GetTargetFrameworks" OuterBuild="true" SkipNonexistentTargets="true" Condition="'$(IsCrossTargetingBuild)' != 'true'" />
+    <ProjectReferenceTargets Include="Build" Targets="$(ProjectReferenceTargetsForBuild)" Condition=" '$(ProjectReferenceTargetsForBuild)' != '' " />
+
+    <ProjectReferenceTargets Include="Clean" Targets="$(ProjectReferenceTargetsForCleanInOuterBuild)" Condition=" '$(ProjectReferenceTargetsForCleanInOuterBuild)' != '' " OuterBuild="true" />
+    <ProjectReferenceTargets Include="Clean" Targets="GetTargetFrameworks" OuterBuild="true" SkipNonexistentTargets="true" Condition="'$(IsCrossTargetingBuild)' != 'true'" />
+    <ProjectReferenceTargets Include="Clean" Targets="$(ProjectReferenceTargetsForClean)" Condition=" '$(ProjectReferenceTargetsForClean)' != '' " />
+
+    <!--
+     Note: SkipNonexistentTargets="true" on the following three items means that an outer build node's call to its existent
+     GetTargetFrameworks target will fail if its inner build nodes don't define GetTargetFrameworksWithPlatformForSingleTargetFramework.
+     This is necessary since the P2P protocol cannot express the targets called from the outer build to the inner build.
+     -->
+    <ProjectReferenceTargets Include="Build" Targets="GetTargetFrameworksWithPlatformForSingleTargetFramework" SkipNonexistentTargets="true" Condition="'$(IsCrossTargetingBuild)' != 'true'" />
+    <ProjectReferenceTargets Include="Clean" Targets="GetTargetFrameworksWithPlatformForSingleTargetFramework" SkipNonexistentTargets="true" Condition="'$(IsCrossTargetingBuild)' != 'true'" />
+    <ProjectReferenceTargets Include="Rebuild" Targets="GetTargetFrameworksWithPlatformForSingleTargetFramework" SkipNonexistentTargets="true" Condition="'$(IsCrossTargetingBuild)' != 'true'" />
+
+    <ProjectReferenceTargets Include="Rebuild" Targets="$(ProjectReferenceTargetsForRebuild)" Condition=" '$(ProjectReferenceTargetsForRebuild)' != '' " />
+  </ItemGroup>
+
   <Target Name="_PopulateCommonStateForGetCopyToOutputDirectoryItems">
     <!-- In the general case, clients need very little of the metadata which is generated by invoking this target on this project and its children.  For those
          cases, we can immediately discard the unwanted metadata, reducing memory usage, particularly in very large and interconnected systems of projects.

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -5182,6 +5182,63 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <_RecursiveTargetForContentCopying Condition=" '$(MSBuildCopyContentTransitively)' == 'false' ">_GetCopyToOutputDirectoryItemsFromThisProject</_RecursiveTargetForContentCopying>
   </PropertyGroup>
 
+  <!--
+    ============================================================
+                                        ProjectReferenceTargets for Static Graph
+
+    Define the project-to-project calling patterns for graph builds.
+    These items tell the static graph which targets a project calls
+    on its referenced projects for Build, Clean, and Rebuild.
+
+    These must accurately describe the MSBuild task calls in:
+      - ResolveProjectReferences (Build / GetTargetPath + GetNativeManifest)
+      - GetCopyToOutputDirectoryItems (_RecursiveTargetForContentCopying)
+      - CleanReferencedProjects (Clean)
+      - Rebuild (Clean + Build)
+
+    SDKs can extend these by appending to the ProjectReferenceTargetsFor*
+    properties before this evaluation, or by adding additional
+    ProjectReferenceTargets items after import.
+    ============================================================
+  -->
+  <!--
+      Properties for extension of ProjectReferenceTargets.
+      Append any current value which may have been provided in a Directory.Build.props since the intent was likely to append, not prepend.
+  -->
+  <PropertyGroup Condition="'$(IsGraphBuild)' == 'true' and '$(IsCrossTargetingBuild)' != 'true'">
+    <!-- Empty case is for builds which do not import the target files that set BuildProjectReferences -->
+    <_MainReferenceTargetForBuild Condition="'$(BuildProjectReferences)' == '' or '$(BuildProjectReferences)' == 'true'">.projectReferenceTargetsOrDefaultTargets</_MainReferenceTargetForBuild>
+    <_MainReferenceTargetForBuild Condition="'$(_MainReferenceTargetForBuild)' == ''">GetTargetPath</_MainReferenceTargetForBuild>
+
+    <ProjectReferenceTargetsForBuild>$(_MainReferenceTargetForBuild);GetNativeManifest;$(_RecursiveTargetForContentCopying);$(ProjectReferenceTargetsForBuild)</ProjectReferenceTargetsForBuild>
+  </PropertyGroup>
+  <!-- Cross-targeting outer builds define their protocol in Microsoft.Common.CrossTargeting.targets -->
+  <PropertyGroup Condition="'$(IsGraphBuild)' == 'true'">
+    <ProjectReferenceTargetsForClean>Clean;$(ProjectReferenceTargetsForClean)</ProjectReferenceTargetsForClean>
+    <ProjectReferenceTargetsForRebuild>$(ProjectReferenceTargetsForClean);$(ProjectReferenceTargetsForBuild);$(ProjectReferenceTargetsForRebuild)</ProjectReferenceTargetsForRebuild>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(IsGraphBuild)' == 'true'">
+    <ProjectReferenceTargets Include="Build" Targets="$(ProjectReferenceTargetsForBuildInOuterBuild)" Condition=" '$(ProjectReferenceTargetsForBuildInOuterBuild)' != '' " OuterBuild="true" />
+    <ProjectReferenceTargets Include="Build" Targets="GetTargetFrameworks" OuterBuild="true" SkipNonexistentTargets="true" Condition="'$(IsCrossTargetingBuild)' != 'true'" />
+    <ProjectReferenceTargets Include="Build" Targets="$(ProjectReferenceTargetsForBuild)" Condition=" '$(ProjectReferenceTargetsForBuild)' != '' " />
+
+    <ProjectReferenceTargets Include="Clean" Targets="$(ProjectReferenceTargetsForCleanInOuterBuild)" Condition=" '$(ProjectReferenceTargetsForCleanInOuterBuild)' != '' " OuterBuild="true" />
+    <ProjectReferenceTargets Include="Clean" Targets="GetTargetFrameworks" OuterBuild="true" SkipNonexistentTargets="true" Condition="'$(IsCrossTargetingBuild)' != 'true'" />
+    <ProjectReferenceTargets Include="Clean" Targets="$(ProjectReferenceTargetsForClean)" Condition=" '$(ProjectReferenceTargetsForClean)' != '' " />
+
+    <!--
+     Note: SkipNonexistentTargets="true" on the following three items means that an outer build node's call to its existent
+     GetTargetFrameworks target will fail if its inner build nodes don't define GetTargetFrameworksWithPlatformForSingleTargetFramework.
+     This is necessary since the P2P protocol cannot express the targets called from the outer build to the inner build.
+     -->
+    <ProjectReferenceTargets Include="Build" Targets="GetTargetFrameworksWithPlatformForSingleTargetFramework" SkipNonexistentTargets="true" Condition="'$(IsCrossTargetingBuild)' != 'true'" />
+    <ProjectReferenceTargets Include="Clean" Targets="GetTargetFrameworksWithPlatformForSingleTargetFramework" SkipNonexistentTargets="true" Condition="'$(IsCrossTargetingBuild)' != 'true'" />
+    <ProjectReferenceTargets Include="Rebuild" Targets="GetTargetFrameworksWithPlatformForSingleTargetFramework" SkipNonexistentTargets="true" Condition="'$(IsCrossTargetingBuild)' != 'true'" />
+
+    <ProjectReferenceTargets Include="Rebuild" Targets="$(ProjectReferenceTargetsForRebuild)" Condition=" '$(ProjectReferenceTargetsForRebuild)' != '' " />
+  </ItemGroup>
+
   <Target Name="_PopulateCommonStateForGetCopyToOutputDirectoryItems">
     <!-- In the general case, clients need very little of the metadata which is generated by invoking this target on this project and its children.  For those
          cases, we can immediately discard the unwanted metadata, reducing memory usage, particularly in very large and interconnected systems of projects.

--- a/src/Tasks/Microsoft.Managed.After.targets
+++ b/src/Tasks/Microsoft.Managed.After.targets
@@ -7,6 +7,10 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
 This file defines common build logic for all managed languaged: C#, VisualBasic, F#
 It is imported after the common targets have been imported.
 
+The core ProjectReferenceTargets for Build, Clean, and Rebuild are defined in
+Microsoft.Common.CurrentVersion.targets so they apply to all project types.
+This file adds managed-specific extensions (Publish, DeployOnBuild, WPF, etc.).
+
 Copyright (C) Microsoft Corporation. All rights reserved.
 ***********************************************************************************************
 -->
@@ -33,53 +37,22 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   </ItemGroup>
 
   <!--
-      Properties for extension of ProjectReferenceTargets.
-      Append any current value which may have been provided in a Directory.Build.props since the intent was likely to append, not prepend.
+      Managed-specific extensions to ProjectReferenceTargets for Publish and DeployOnBuild.
+      The core Build/Clean/Rebuild protocol is defined in Microsoft.Common.CurrentVersion.targets.
   -->
   <PropertyGroup Condition="'$(IsGraphBuild)' == 'true' and '$(IsCrossTargetingBuild)' != 'true'">
-    <!-- Empty case is for builds which do not import the target files that set BuildProjectReferences -->
-    <_MainReferenceTargetForBuild Condition="'$(BuildProjectReferences)' == '' or '$(BuildProjectReferences)' == 'true'">.projectReferenceTargetsOrDefaultTargets</_MainReferenceTargetForBuild>
-    <_MainReferenceTargetForBuild Condition="'$(_MainReferenceTargetForBuild)' == ''">GetTargetPath</_MainReferenceTargetForBuild>
-
-    <ProjectReferenceTargetsForBuild>$(_MainReferenceTargetForBuild);GetNativeManifest;$(_RecursiveTargetForContentCopying);$(ProjectReferenceTargetsForBuild)</ProjectReferenceTargetsForBuild>
-
     <!-- Publish has the same logic as Build for the main reference target except it also takes $(NoBuild) into account. -->
     <_MainReferenceTargetForPublish Condition="'$(NoBuild)' == 'true'">GetTargetPath</_MainReferenceTargetForPublish>
     <_MainReferenceTargetForPublish Condition="'$(NoBuild)' != 'true'">$(_MainReferenceTargetForBuild)</_MainReferenceTargetForPublish>
     <ProjectReferenceTargetsForPublish>GetTargetFrameworks;$(_MainReferenceTargetForPublish);GetNativeManifest;GetCopyToPublishDirectoryItems;$(ProjectReferenceTargetsForPublish)</ProjectReferenceTargetsForPublish>
 
-    <!-- When DeployOnBuild=true, the Publish target is hooked to the Build target -->
-    <ProjectReferenceTargetsForBuild Condition="'$(DeployOnBuild)' == 'true'">$(ProjectReferenceTargetsForBuild);$(ProjectReferenceTargetsForPublish)</ProjectReferenceTargetsForBuild>
-    <ProjectReferenceTargetsForRebuild Condition="'$(DeployOnBuild)' == 'true'">$(ProjectReferenceTargetsForRebuild);$(ProjectReferenceTargetsForPublish)</ProjectReferenceTargetsForRebuild>
-
     <ProjectReferenceTargetsForGetCopyToPublishDirectoryItems>GetCopyToPublishDirectoryItems;$(ProjectReferenceTargetsForGetCopyToPublishDirectoryItems)</ProjectReferenceTargetsForGetCopyToPublishDirectoryItems>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(IsGraphBuild)' == 'true' and '$(IsCrossTargetingBuild)' == 'true'">
-    <ProjectReferenceTargetsForBuild>.default;$(ProjectReferenceTargetsForBuild)</ProjectReferenceTargetsForBuild>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(IsGraphBuild)' == 'true'">
-    <ProjectReferenceTargetsForClean>Clean;$(ProjectReferenceTargetsForClean)</ProjectReferenceTargetsForClean>
-    <ProjectReferenceTargetsForRebuild>$(ProjectReferenceTargetsForClean);$(ProjectReferenceTargetsForBuild);$(ProjectReferenceTargetsForRebuild)</ProjectReferenceTargetsForRebuild>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(IsGraphBuild)' == 'true'">
-    <ProjectReferenceTargets Include="Build" Targets="$(ProjectReferenceTargetsForBuildInOuterBuild)" Condition=" '$(ProjectReferenceTargetsForBuildInOuterBuild)' != '' " OuterBuild="true" />
-    <ProjectReferenceTargets Include="Build" Targets="GetTargetFrameworks" OuterBuild="true" SkipNonexistentTargets="true" Condition="'$(IsCrossTargetingBuild)' != 'true'" />
-    <ProjectReferenceTargets Include="Build" Targets="$(ProjectReferenceTargetsForBuild)" Condition=" '$(ProjectReferenceTargetsForBuild)' != '' " />
-
-    <ProjectReferenceTargets Include="Clean" Targets="$(ProjectReferenceTargetsForCleanInOuterBuild)" Condition=" '$(ProjectReferenceTargetsForCleanInOuterBuild)' != '' " OuterBuild="true" />
-    <ProjectReferenceTargets Include="Clean" Targets="GetTargetFrameworks" OuterBuild="true" SkipNonexistentTargets="true" Condition="'$(IsCrossTargetingBuild)' != 'true'" />
-    <ProjectReferenceTargets Include="Clean" Targets="$(ProjectReferenceTargetsForClean)" Condition=" '$(ProjectReferenceTargetsForClean)' != '' " />
-
-    <!--
-     Note: SkipNonexistentTargets="true" on the following three items means that an outer build node's call to its existent GetTargetFrameworks target will fail if its inner build nodes don't define GetTargetFrameworksWithPlatformForSingleTargetFrameworks.
-     This is necessary since the P2P protocol cannot express the targets called from the outer build to the inner build.
-     -->
-    <ProjectReferenceTargets Include="Build" Targets="GetTargetFrameworksWithPlatformForSingleTargetFramework" SkipNonexistentTargets="true" Condition="'$(IsCrossTargetingBuild)' != 'true'" />
-    <ProjectReferenceTargets Include="Clean" Targets="GetTargetFrameworksWithPlatformForSingleTargetFramework" SkipNonexistentTargets="true" Condition="'$(IsCrossTargetingBuild)' != 'true'" />
-    <ProjectReferenceTargets Include="Rebuild" Targets="GetTargetFrameworksWithPlatformForSingleTargetFramework" SkipNonexistentTargets="true" Condition="'$(IsCrossTargetingBuild)' != 'true'" />
-
-    <ProjectReferenceTargets Include="Rebuild" Targets="$(ProjectReferenceTargetsForRebuild)" Condition=" '$(ProjectReferenceTargetsForRebuild)' != '' " />
+    <!-- When DeployOnBuild=true, the Publish target is hooked to the Build target -->
+    <ProjectReferenceTargets Include="Build" Targets="$(ProjectReferenceTargetsForPublish)" Condition="'$(DeployOnBuild)' == 'true' and '$(IsCrossTargetingBuild)' != 'true' and '$(ProjectReferenceTargetsForPublish)' != ''" />
+    <ProjectReferenceTargets Include="Rebuild" Targets="$(ProjectReferenceTargetsForPublish)" Condition="'$(DeployOnBuild)' == 'true' and '$(IsCrossTargetingBuild)' != 'true' and '$(ProjectReferenceTargetsForPublish)' != ''" />
 
     <ProjectReferenceTargets Include="Publish" Targets="$(ProjectReferenceTargetsForPublish)" Condition=" '$(ProjectReferenceTargetsForPublish)' != '' " />
 

--- a/src/Tasks/Microsoft.Managed.After.targets
+++ b/src/Tasks/Microsoft.Managed.After.targets
@@ -4,7 +4,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
           created a backup copy.  Incorrect changes to this file will make it
           impossible to load or build your projects from the command-line or the IDE.
 
-This file defines common build logic for all managed languaged: C#, VisualBasic, F#
+This file defines common build logic for all managed languages: C#, VisualBasic, F#
 It is imported after the common targets have been imported.
 
 The core ProjectReferenceTargets for Build, Clean, and Rebuild are defined in


### PR DESCRIPTION
## Summary

Move the core Build/Clean/Rebuild `ProjectReferenceTargets` protocol from `Microsoft.Managed.After.targets` into `Microsoft.Common.CurrentVersion.targets` so it applies to **all project types** that import the common targets, not just managed languages (C#, VB, F#). This aligns with the [static graph spec](https://github.com/dotnet/msbuild/blob/main/documentation/specs/static-graph.md) which prescribes that common protocols be defined in the common targets.

## What changed

### Targets files
- **`Microsoft.Common.CurrentVersion.targets`**: Now contains the core `ProjectReferenceTargets` for Build, Clean, and Rebuild, including `OuterBuild` items, `SkipNonexistentTargets` items, and the extensibility properties (`ProjectReferenceTargetsForBuild`, etc.)
- **`Microsoft.Common.CrossTargeting.targets`**: Now contains the cross-targeting outer build protocol (`.default` dispatch) that was previously inlined in `Managed.After.targets`
- **`Microsoft.Managed.After.targets`**: Retains only managed-specific extensions: Publish, DeployOnBuild, `GetCopyToPublishDirectoryItems`, WPF graph isolation, and `InnerBuildProperty`/`InnerBuildPropertyValues`

### DeployOnBuild refactor
DeployOnBuild handling changed from property-level composition (appending Publish targets to `$(ProjectReferenceTargetsForBuild)`) to item-level composition (separate `ProjectReferenceTargets` items). This is functionally equivalent since the static graph engine merges all items with the same `Include` value, and eliminates a subtle duplication in the old code where `ProjectReferenceTargetsForRebuild` included publish targets twice.

### Documentation
- Updated stale `docs.microsoft.com` → `learn.microsoft.com` URL
- Converted absolute GitHub links to relative paths
- Added prose hints for deep-link references into large targets files
- Fixed typo in SkipNonexistentTargets comment

## Testing

### Unit tests (11 new, all passing)
New file `src/Build.UnitTests/Graph/ProjectReferenceTargetsProtocol_Tests.cs` covering:
- Non-managed project gets core Build/Clean/Rebuild protocol
- Managed project protocol unchanged after move
- DeployOnBuild property→item migration
- Cross-targeting `.default` dispatch
- `BuildProjectReferences=false` and `NoBuild=true` fallbacks
- Clean/Rebuild propagation through multi-project chains

### Manual validation
Tested with old (VS 18 Canary) vs new (bootstrap) MSBuild:
- **Key result**: Non-managed `.proj` with `/graph /isolate` — old MSBuild produces `MSB4252` isolation violation ("target not specified in ProjectReferenceTargets"), new MSBuild resolves the graph correctly
- `-getItem:ProjectReferenceTargets /p:IsGraphBuild=true` on non-managed `.proj`: old returns empty, new returns full Build/Clean/Rebuild protocol from `Microsoft.Common.CurrentVersion.targets`
- C++ graph build binlogs produced for manual inspection
