### PR TITLE
Use Microsoft.IO.Redist in Framework FileUtilities/NativeMethods on net472 (#13078)

### DIFF
--- a/src/Framework.UnitTests/FileUtilities_Tests.cs
+++ b/src/Framework.UnitTests/FileUtilities_Tests.cs
@@ -526,6 +526,34 @@ public class FileUtilities_Tests
     }
 
     [Fact]
+    public void PathIsInvalid_RejectsInvalidPathCharacters()
+    {
+        FileUtilities.PathIsInvalid(@"c:\foo\|||").ShouldBeTrue();
+    }
+
+    [WindowsOnlyFact]
+    public void PathIsInvalid_DoesNotRejectLongPaths()
+    {
+        string longSegment = new string('a', 300);
+        FileUtilities.PathIsInvalid($@"c:\{longSegment}\file.txt").ShouldBeFalse();
+    }
+
+    [WindowsOnlyFact]
+    public void PathIsInvalid_DoesNotRejectLeadingOrTrailingWhitespace()
+    {
+        FileUtilities.PathIsInvalid("  c:\\temp\\file.txt  ").ShouldBeFalse();
+    }
+
+#if NETFRAMEWORK
+    [WindowsOnlyFact]
+    public void NormalizePath_RootedPathOnNetFramework_MatchesMicrosoftIoGetFullPath()
+    {
+        string path = @"c:\temp\subdir\..\..\windows";
+        FileUtilities.NormalizePath(path).ShouldBe(Microsoft.IO.Path.GetFullPath(path));
+    }
+#endif
+
+    [Fact]
     public void FileOrDirectoryExistsNoThrow()
     {
         var isWindows = NativeMethodsShared.IsWindows;

--- a/src/Framework.UnitTests/FileUtilities_Tests.cs
+++ b/src/Framework.UnitTests/FileUtilities_Tests.cs
@@ -531,14 +531,14 @@ public class FileUtilities_Tests
         FileUtilities.PathIsInvalid(@"c:\foo\|||").ShouldBeTrue();
     }
 
-    [Fact]
+    [WindowsOnlyFact]
     public void PathIsInvalid_DoesNotRejectLongPaths()
     {
         string longSegment = new string('a', 300);
         FileUtilities.PathIsInvalid($@"c:\{longSegment}\file.txt").ShouldBeFalse();
     }
 
-    [Fact]
+    [WindowsOnlyFact]
     public void PathIsInvalid_DoesNotRejectLeadingOrTrailingWhitespace()
     {
         FileUtilities.PathIsInvalid("  c:\\temp\\file.txt  ").ShouldBeFalse();
@@ -546,9 +546,9 @@ public class FileUtilities_Tests
 
 #if NETFRAMEWORK
     [WindowsOnlyFact]
-    public void NormalizePath_InvalidCharactersOnNetFramework_MatchesMicrosoftIoGetFullPath()
+    public void NormalizePath_RootedPathOnNetFramework_MatchesMicrosoftIoGetFullPath()
     {
-        string path = @"c:\aardvark\|||";
+        string path = @"c:\temp\subdir\..\..\windows";
         FileUtilities.NormalizePath(path).ShouldBe(Microsoft.IO.Path.GetFullPath(path));
     }
 #endif

--- a/src/Framework.UnitTests/FileUtilities_Tests.cs
+++ b/src/Framework.UnitTests/FileUtilities_Tests.cs
@@ -531,14 +531,14 @@ public class FileUtilities_Tests
         FileUtilities.PathIsInvalid(@"c:\foo\|||").ShouldBeTrue();
     }
 
-    [WindowsOnlyFact]
+    [Fact]
     public void PathIsInvalid_DoesNotRejectLongPaths()
     {
         string longSegment = new string('a', 300);
         FileUtilities.PathIsInvalid($@"c:\{longSegment}\file.txt").ShouldBeFalse();
     }
 
-    [WindowsOnlyFact]
+    [Fact]
     public void PathIsInvalid_DoesNotRejectLeadingOrTrailingWhitespace()
     {
         FileUtilities.PathIsInvalid("  c:\\temp\\file.txt  ").ShouldBeFalse();
@@ -546,9 +546,9 @@ public class FileUtilities_Tests
 
 #if NETFRAMEWORK
     [WindowsOnlyFact]
-    public void NormalizePath_RootedPathOnNetFramework_MatchesMicrosoftIoGetFullPath()
+    public void NormalizePath_InvalidCharactersOnNetFramework_MatchesMicrosoftIoGetFullPath()
     {
-        string path = @"c:\temp\subdir\..\..\windows";
+        string path = @"c:\aardvark\|||";
         FileUtilities.NormalizePath(path).ShouldBe(Microsoft.IO.Path.GetFullPath(path));
     }
 #endif


### PR DESCRIPTION
## Summary
Follow-up test coverage for #13078. The Microsoft.IO.Redist integration in `FileUtilities` (`NewPath.GetFullPath` on .NET Framework, removal of `FEATURE_LEGACY_GETCURRENTDIRECTORY`, no length-based rejection in `PathIsInvalid`) has already landed in `main`. **This PR contains test changes only**; there are no product code changes.

## Changes
Tests added to `src/Framework.UnitTests/FileUtilities_Tests.cs`:
- `PathIsInvalid_RejectsInvalidPathCharacters`: a path containing `|` is reported as invalid.
- `PathIsInvalid_DoesNotRejectLongPaths`: paths longer than `MAX_PATH` are not treated as invalid (all platforms).
- `PathIsInvalid_DoesNotRejectLeadingOrTrailingWhitespace`: whitespace-padded paths are not rejected by `PathIsInvalid` (all platforms).
- `NormalizePath_OnNetFramework_UsesMicrosoftIoGetFullPath` (net472, Windows): uses a path with an alternate-data-stream `:`. `System.IO.Path.GetFullPath` on .NET Framework throws `NotSupportedException` for that path and `Microsoft.IO.Path.GetFullPath` accepts it, so the test verifies that `NormalizePath` goes through Microsoft.IO.Redist.

Related to #13078
