### PR TITLE
Skip HandleBuildResultAsync when ProjectInstance is not loaded on in-proc node

### DIFF
--- a/src/Build/BackEnd/Components/ProjectCache/ProjectCacheService.cs
+++ b/src/Build/BackEnd/Components/ProjectCache/ProjectCacheService.cs
@@ -24,7 +24,6 @@ using Microsoft.Build.Framework;
 using Microsoft.Build.Graph;
 using Microsoft.Build.Internal;
 using Microsoft.Build.Shared;
-using Microsoft.Build.Framework.Telemetry;
 using ExceptionHandling = Microsoft.Build.Framework.ExceptionHandling;
 
 #pragma warning disable CS0618 // Type or member is obsolete, this class is adapting to both Experimental and new plugin APIs
@@ -811,37 +810,38 @@ namespace Microsoft.Build.ProjectCache
                 return;
             }
 
-            // We need to retrieve the configuration if it's already loaded in order to access the Project property below.
+            // The ProjectInstance may not be loaded on the in-proc node when the project was built on an
+            // out-of-proc worker. VS submits builds by project path (without a ProjectInstance), so the
+            // configuration is added to the in-proc cache with _project=null. The worker node loads and
+            // evaluates the project locally, but the ProjectInstance is never transferred back — it's too
+            // large to serialize across the named pipe (only the BuildResult with target outcomes is returned).
+            //
+            // This method is reached because ShouldUseCache is shared by two call sites:
+            //   1. Pre-build (BuildManager.ExecuteSubmission): decides whether to issue a cache request.
+            //      The project isn't evaluated yet, so ShouldUseCache must return true in VS/global-plugin
+            //      scenarios without requiring IsLoaded. The cache request path (PostCacheRequest) handles
+            //      loading the project itself via EvaluateProjectIfNecessary.
+            //   2. Post-build (BuildManager.HandleResult): decides whether to notify cache plugins about
+            //      the build result. Here the in-proc config may still have no ProjectInstance if the
+            //      project was built on an out-of-proc node.
+            //
+            // We check IsLoaded rather than Project==null because the Project getter asserts !IsCached
+            // and would throw if the configuration happens to be in cached-to-disk state. IsLoaded is
+            // a safe read-only check (_project?.IsLoaded == true) with no side effects.
+            //
+            // Skipping is safe: the build already completed successfully and the cache plugin's
+            // HandleProjectFinishedAsync needs a loaded ProjectInstance to determine which plugins
+            // apply (via GetProjectCacheDescriptors) and to provide project context to the plugin.
+            if (!requestConfiguration.IsLoaded)
+            {
+                return;
+            }
+
+            // If the ProjectInstance was evicted to disk to save memory, restore it before accessing
+            // the Project property below (whose getter asserts !IsCached).
             if (requestConfiguration.IsCached)
             {
                 requestConfiguration.RetrieveFromCache();
-            }
-
-            // The Project property may be null if the configuration was created from a remote node
-            // request or the project was never loaded locally (e.g., in VS scenario where ShouldUseCache
-            // returns true before checking IsLoaded). Skip cache result handling in this case.
-            if (requestConfiguration.Project is null)
-            {
-                string projectCacheState = string.Join(":",
-                    requestConfiguration.ConfigurationId,
-                    Path.GetFileName(requestConfiguration.ProjectFullPath),
-                    requestConfiguration.IsLoaded,
-                    requestConfiguration.IsCached,
-                    requestConfiguration.WasGeneratedByNode,
-                    _isVsScenario,
-                    _globalProjectCacheDescriptor is not null);
-
-                CrashTelemetryRecorder.EmitEndBuildHangDiagnostics(new CrashTelemetry
-                {
-                    ExitType = CrashExitType.ProjectCacheFailure,
-                    ExceptionMessage = "Project unexpectedly null in HandleBuildResultAsync",
-                    BuildEngineVersion = Evaluation.ProjectCollection.Version?.ToString(),
-                    BuildEngineFrameworkName = NativeMethodsShared.FrameworkName,
-                    BuildEngineHost = BuildEnvironmentState.GetHostName(),
-                    IsStandaloneExecution = false,
-                    ProjectCacheState = projectCacheState,
-                });
-                return;
             }
 
             // Filter to plugins which apply to the project, if any


### PR DESCRIPTION
## Summary

Related to https://github.com/dotnet/msbuild/pull/13332/changes
`HandleBuildResultAsync` in `ProjectCacheService` crashes with `InternalErrorException("Project unexpectedly null")` when a build result arrives for a configuration whose `ProjectInstance` was never loaded on the in-proc node.

## Root Cause

In VS (and global plugin) scenarios, `ShouldUseCache` returns `true` without checking `IsLoaded`. This is by design - it's needed for the **pre-build** cache request path (`BuildManager.ExecuteSubmission`), where the project hasn't been evaluated yet and `PostCacheRequest` loads it via `EvaluateProjectIfNecessary`.

However, `ShouldUseCache` is also called from the **post-build** path (`BuildManager.HandleResult`) to decide whether to notify cache plugins about the result. When a project was built on an out-of-proc worker node, the in-proc config cache entry never gets a `ProjectInstance` assigned - `ProjectInstance` is intentionally not transferred back from worker nodes because it's too large to serialize across the named pipe (only `BuildResult` with target outcomes is returned).

This means `HandleBuildResultAsync` is called with a configuration where `IsLoaded` is false and accessing `.Project` would crash.

## Fix
Replace the `VerifyThrowInternalNull(requestConfiguration.Project)` assert with an `!requestConfiguration.IsLoaded` early return.

**Why `IsLoaded` instead of `Project == null`**: The `Project` getter has an internal assert (`!IsCached`) that throws if the configuration happens to be in cached-to-disk state. `IsLoaded` is a safe read-only check (`_project?.IsLoaded == true`) with no side effects or asserts. It also correctly handles the edge case of a partially-initialized `ProjectInstance` (deserialized but not yet `LateInitialize`'d).

Skipping is safe because:
- The build has already completed successfully at this point
- The cache plugin's `HandleProjectFinishedAsync` requires a loaded `ProjectInstance` to determine applicable plugins and provide project context
- No build correctness is affected — only the cache plugin notification is skipped for this configuration

## Validation

Diagnostic telemetry (`ProjectCacheState`) deployed in a prior iteration confirmed the root cause across multiple VS repo users:
- `IsLoaded=False`, `IsCached=False`, `WasGeneratedByNode=False`, `IsVsScenario=True`
- Configuration created from `BuildRequestData` without `ProjectInstance` (VS submits by path)
- Project built on out-of-proc worker node, `ProjectInstance` never transferred back
