### PR TITLE
Prefer dotnet MSBuild.dll for out-of-proc worker nodes in CLI scenarios

### DIFF
--- a/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
@@ -22,7 +22,6 @@ using System.Security.Principal;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Internal;
 using Microsoft.Build.Shared;
-using Microsoft.Build.Shared.FileSystem;
 using Constants = Microsoft.Build.Framework.Constants;
 
 #nullable disable
@@ -235,9 +234,9 @@ namespace Microsoft.Build.BackEnd
 #if RUNTIME_TYPE_NETCORE
             // When MSBuild is hosted by dotnet.exe (e.g. `dotnet build`), NodeExeLocation may resolve
             // to the AppHost (MSBuild.exe on Windows, MSBuild on Unix) because BuildEnvironmentHelper
-            // prefers the AppHost over MSBuild.dll. Launching worker nodes as AppHost processes incurs
-            // significant native bootstrap overhead. Prefer MSBuild.dll so worker nodes are launched
-            // via dotnet.exe, matching the parent process.
+            // prefers the AppHost over MSBuild.dll. Launching worker nodes as MSBuild.exe AppHost
+            // processes is measurably slower than using dotnet MSBuild.dll. Prefer MSBuild.dll so
+            // worker nodes are launched via dotnet.exe, matching the parent process.
             // This only applies to regular out-of-proc worker nodes (nodemode:1), not task host nodes
             // (nodemode:2) which may need the AppHost for COM host object support.
             if (expectedNodeMode == NodeMode.OutOfProcNode
@@ -248,7 +247,7 @@ namespace Microsoft.Build.BackEnd
                 if (currentProcessName?.Equals(Constants.DotnetProcessName, StringComparison.OrdinalIgnoreCase) == true)
                 {
                     string dllPath = Path.Combine(Path.GetDirectoryName(msbuildLocation), Constants.MSBuildAssemblyName);
-                    if (FileSystems.Default.FileExists(dllPath))
+                    if (File.Exists(dllPath))
                     {
                         msbuildLocation = dllPath;
                     }


### PR DESCRIPTION
## Summary

When MSBuild is launched via `dotnet.exe` (e.g. `dotnet build`, `dotnet msbuild`), `BuildEnvironmentHelper` resolves `CurrentMSBuildExePath` to `MSBuild.exe` (the AppHost) because it prefers the AppHost over `MSBuild.dll`. This causes all out-of-proc worker nodes to launch as `MSBuild.exe` processes instead of `dotnet MSBuild.dll`.

## Problem

PR #13175 introduced the MSBuild AppHost (`MSBuild.exe`). After this change, `dotnet build` spawns worker nodes as `MSBuild.exe` processes. ETL trace analysis of OrchardCore NuGet restore shows a **~16% regression** (61s -> 72s):

- **RestoreTask**: 29,619ms -> 37,718ms (+27%)
- **ExecuteTask total**: 207,854ms -> 232,996ms (+12%)
- Same number of worker nodes (7), same build work (~1.03M build events)
- JIT method counts are similar (116,545 vs 112,952) but CPU samples in JIT are ~17% higher per worker
- The regression is spread across the entire process lifetime, not concentrated in startup

The root cause of the performance difference between `MSBuild.exe` and `dotnet MSBuild.dll` hosting is not fully understood from available ETL data. Reverting worker nodes to `dotnet MSBuild.dll` in CLI scenarios restores baseline performance.