### PR TITLE
Version bump check fix

### DIFF
--- a/.vsts-dotnet-ci.yml
+++ b/.vsts-dotnet-ci.yml
@@ -22,7 +22,13 @@ jobs:
       $versionsFile = "eng/Versions.props"
 
       [xml]$xml = Get-Content $versionsFile
-      $finalVersionKind = $xml.SelectSingleNode('//DotNetFinalVersionKind').'#text'
+      $finalVersionNode = $xml.SelectSingleNode('//DotNetFinalVersionKind')
+      if ($null -eq $finalVersionNode -or [string]::IsNullOrWhiteSpace($finalVersionNode.InnerText)) {
+        Write-Host "##vso[task.logissue type=error;sourcepath=eng/Versions.props;linenumber=1;]DotNetFinalVersionKind element is missing or empty in eng/Versions.props."
+        exit 1
+      }
+
+      $finalVersionKind = $finalVersionNode.InnerText.Trim()
       if ($finalVersionKind -ne 'release') {
         Write-Host "Since it is not released, skip the version bump check.";
         return


### PR DESCRIPTION
Fixes #13451

### Context
Version bump check didn't work. This change should fix that.

### Changes Made
Node selection logic was changed.

### Testing
Change tested in release branch: https://dev.azure.com/dnceng-public/public/_build/results?buildId=1355155&view=logs&j=6fe8bf02-8a7a-56a7-e3fd-913e2045a877&t=e87b56af-cb98-594d-acd9-14509c9c5689

### Notes
