### PR TITLE
Fix MSBuildTask0002 analyzer warnings in already-migrated tasks

### DIFF
--- a/src/Tasks.UnitTests/Copy_Tests.cs
+++ b/src/Tasks.UnitTests/Copy_Tests.cs
@@ -108,8 +108,6 @@ namespace Microsoft.Build.UnitTests
 
             Environment.SetEnvironmentVariable(Copy.AlwaysOverwriteReadOnlyFilesEnvVar, null);
             Environment.SetEnvironmentVariable(Copy.AlwaysRetryEnvVar, null);
-
-            Copy.RefreshInternalEnvironmentValues();
         }
 
         /// <summary>
@@ -119,8 +117,6 @@ namespace Microsoft.Build.UnitTests
         {
             Environment.SetEnvironmentVariable(Copy.AlwaysOverwriteReadOnlyFilesEnvVar, _alwaysOverwriteReadOnlyFiles);
             Environment.SetEnvironmentVariable(Copy.AlwaysRetryEnvVar, _alwaysRetry);
-
-            Copy.RefreshInternalEnvironmentValues();
         }
 
         [Fact]
@@ -848,7 +844,6 @@ namespace Microsoft.Build.UnitTests
             try
             {
                 Environment.SetEnvironmentVariable(Copy.AlwaysRetryEnvVar, "1   ");
-                Copy.RefreshInternalEnvironmentValues();
 
                 using (StreamWriter sw = FileUtilities.OpenWrite(source, true))
                 {
@@ -896,7 +891,6 @@ namespace Microsoft.Build.UnitTests
             finally
             {
                 Environment.SetEnvironmentVariable(Copy.AlwaysRetryEnvVar, oldAlwaysRetryValue);
-                Copy.RefreshInternalEnvironmentValues();
 
                 File.SetAttributes(destination, FileAttributes.Normal);
 

--- a/src/Tasks/AssignTargetPath.cs
+++ b/src/Tasks/AssignTargetPath.cs
@@ -82,7 +82,9 @@ namespace Microsoft.Build.Tasks
                     // Ensure trailing slash otherwise c:\bin appears to match part of c:\bin2\foo
                     // Also ensure that relative segments in the path are resolved and throw on illegal characters in Path.GetFullPath to preserve pre-existing behavior.
                     fullRootPathString = 
+#pragma warning disable MSBuildTask0002 // Path is already absolute from TaskEnvironment.GetAbsolutePath; GetFullPath only canonicalizes. Guarded by ChangeWave.
                         Path.GetFullPath(TaskEnvironment.GetAbsolutePath(FileUtilities.EnsureTrailingSlash(RootFolder)));
+#pragma warning restore MSBuildTask0002
 
                     // Ensure trailing slash for comparison. Current directory is already canonical, so we don't need to call GetCanonicalForm on it.
                     AbsolutePath currentDirectory = FileUtilities.EnsureTrailingSlash(TaskEnvironment.ProjectDirectory);
@@ -143,7 +145,9 @@ namespace Microsoft.Build.Tasks
                             else 
                             {
                                 string itemSpecFullFileNamePath = 
+#pragma warning disable MSBuildTask0002 // Path is already absolute from TaskEnvironment.GetAbsolutePath; GetFullPath only canonicalizes. Guarded by ChangeWave.
                                     Path.GetFullPath(TaskEnvironment.GetAbsolutePath(Files[i].ItemSpec));
+#pragma warning restore MSBuildTask0002
 
                                 if (String.Compare(fullRootPathString, 0, itemSpecFullFileNamePath, 0, fullRootPathString.Length, StringComparison.CurrentCultureIgnoreCase) == 0)
                                 {

--- a/src/Tasks/Copy.cs
+++ b/src/Tasks/Copy.cs
@@ -24,8 +24,6 @@ namespace Microsoft.Build.Tasks
     [MSBuildMultiThreadableTask]
     public class Copy : TaskExtension, IIncrementalTask, ICancelableTask, IMultiThreadableTask
     {
-        internal const string AlwaysRetryEnvVar = "MSBUILDALWAYSRETRY";
-        internal const string AlwaysOverwriteReadOnlyFilesEnvVar = "MSBUILDALWAYSOVERWRITEREADONLYFILES";
 
         // Default parallelism determined empirically - times below are in seconds spent in the Copy task building this repo
         // with "build -skiptests -rebuild -configuration Release /ds" (with hack to build.ps1 to disable creating selfhost
@@ -110,17 +108,16 @@ namespace Microsoft.Build.Tasks
         // Bool is just a placeholder, we're mainly interested in a threadsafe key set.
         private readonly ConcurrentDictionary<string, bool> _directoriesKnownToExist = new ConcurrentDictionary<string, bool>(DefaultCopyParallelism, DefaultCopyParallelism, FileUtilities.PathComparer);
 
+        internal const string AlwaysRetryEnvVar = "MSBUILDALWAYSRETRY";
+        internal const string AlwaysOverwriteReadOnlyFilesEnvVar = "MSBUILDALWAYSOVERWRITEREADONLYFILES";
+
         /// <summary>
         /// Force the copy to retry even when it hits ERROR_ACCESS_DENIED -- normally we wouldn't retry in this case since
         /// normally there's no point, but occasionally things get into a bad state temporarily, and retrying does actually
         /// succeed.  So keeping around a secret environment variable to allow forcing that behavior if necessary.
+        /// Initialized from TaskEnvironment in Execute() for MT-safety.
         /// </summary>
-        private static bool s_alwaysRetryCopy = Environment.GetEnvironmentVariable(AlwaysRetryEnvVar) != null;
-
-        /// <summary>
-        /// Global flag to force on UseSymboliclinksIfPossible since Microsoft.Common.targets doesn't expose the functionality.
-        /// </summary>
-        private static readonly bool s_forceSymlinks = Environment.GetEnvironmentVariable("MSBuildUseSymboliclinksIfPossible") != null;
+        private bool _alwaysRetryCopy;
 
         private static readonly bool s_copyInParallel = GetParallelismFromEnvironment();
 
@@ -156,8 +153,20 @@ namespace Microsoft.Build.Tasks
         /// <summary>
         /// Gets or sets a value that indicates whether to create symbolic links for the copied files
         /// rather than copy the files, if it's possible to do so.
+        /// The MSBuildUseSymboliclinksIfPossible env var sets the default; explicit task parameter overrides it.
         /// </summary>
-        public bool UseSymboliclinksIfPossible { get; set; } = s_forceSymlinks;
+        public bool UseSymboliclinksIfPossible
+        {
+            get => _useSymboliclinksIfPossible ?? false;
+            set
+            {
+                _useSymboliclinksIfPossible = value;
+                _useSymboliclinksIfPossibleExplicitlySet = true;
+            }
+        }
+
+        private bool? _useSymboliclinksIfPossible;
+        private bool _useSymboliclinksIfPossibleExplicitlySet;
 
         /// <summary>
         /// Fail if unable to create a symbolic or hard link instead of falling back to copy
@@ -230,24 +239,12 @@ namespace Microsoft.Build.Tasks
         }
 
         /// <summary>
-        /// INTERNAL FOR UNIT-TESTING ONLY
-        ///
-        /// We've got several environment variables that we read into statics since we don't expect them to ever
-        /// reasonably change, but we need some way of refreshing their values so that we can modify them for
-        /// unit testing purposes.
-        /// </summary>
-        internal static void RefreshInternalEnvironmentValues()
-        {
-            s_alwaysRetryCopy = Environment.GetEnvironmentVariable(AlwaysRetryEnvVar) != null;
-        }
-
-        /// <summary>
         /// If MSBUILDALWAYSRETRY is set, also log useful diagnostic information -- as
         /// a warning, so it's easily visible.
         /// </summary>
         private void LogAlwaysRetryDiagnosticFromResources(string messageResourceName, params object[] messageArgs)
         {
-            if (s_alwaysRetryCopy)
+            if (_alwaysRetryCopy)
             {
                 Log.LogWarningWithCodeFromResources(messageResourceName, messageArgs);
             }
@@ -454,6 +451,15 @@ namespace Microsoft.Build.Tasks
             if (TaskEnvironment.GetEnvironmentVariable(AlwaysOverwriteReadOnlyFilesEnvVar) != null)
             {
                 OverwriteReadOnlyFiles = true;
+            }
+
+            _alwaysRetryCopy = TaskEnvironment.GetEnvironmentVariable(AlwaysRetryEnvVar) != null;
+
+            // Env var sets the default for UseSymboliclinksIfPossible, but explicit task parameter wins.
+            if (!_useSymboliclinksIfPossibleExplicitlySet
+                && TaskEnvironment.GetEnvironmentVariable("MSBuildUseSymboliclinksIfPossible") != null)
+            {
+                _useSymboliclinksIfPossible = true;
             }
 
             // Track successfully copied subset.
@@ -1033,7 +1039,7 @@ namespace Microsoft.Build.Tasks
                                 // to a failure to reset the readonly bit properly, in which case retrying will succeed.  This seems to be
                                 // a pretty edge scenario, but since some of our internal builds appear to be hitting it, provide a secret
                                 // environment variable to allow overriding the default behavior and forcing retries in this circumstance as well.
-                                if (!s_alwaysRetryCopy)
+                                if (!_alwaysRetryCopy)
                                 {
                                     throw;
                                 }

--- a/src/Tasks/FileIO/GetFileHash.cs
+++ b/src/Tasks/FileIO/GetFileHash.cs
@@ -143,7 +143,7 @@ namespace Microsoft.Build.Tasks
         internal static bool TryParseHashEncoding(string value, out HashEncoding encoding)
             => Enum.TryParse<HashEncoding>(value, /*ignoreCase:*/ true, out encoding);
 
-        internal static byte[] ComputeHash(Func<HashAlgorithm> algorithmFactory, string filePath, CancellationToken ct)
+        internal static byte[] ComputeHash(Func<HashAlgorithm> algorithmFactory, AbsolutePath filePath, CancellationToken ct)
         {
             using (var stream = File.OpenRead(filePath))
             using (var algorithm = algorithmFactory())

--- a/src/Tasks/ListOperators/FindUnderPath.cs
+++ b/src/Tasks/ListOperators/FindUnderPath.cs
@@ -73,7 +73,9 @@ namespace Microsoft.Build.Tasks
                 {
                     conePath =
                         Strings.WeakIntern(
+#pragma warning disable MSBuildTask0002 // Path is already absolute from TaskEnvironment.GetAbsolutePath; GetFullPath only canonicalizes. Guarded by ChangeWave.
                             System.IO.Path.GetFullPath(TaskEnvironment.GetAbsolutePath(FileUtilities.FixFilePath(Path.ItemSpec))));
+#pragma warning restore MSBuildTask0002
                 }
 
                 conePath = FileUtilities.EnsureTrailingSlash(conePath);
@@ -104,7 +106,9 @@ namespace Microsoft.Build.Tasks
                     {
                         fullPath =
                             Strings.WeakIntern(
+#pragma warning disable MSBuildTask0002 // Path is already absolute from TaskEnvironment.GetAbsolutePath; GetFullPath only canonicalizes. Guarded by ChangeWave.
                                 System.IO.Path.GetFullPath(TaskEnvironment.GetAbsolutePath(FileUtilities.FixFilePath(item.ItemSpec))));
+#pragma warning restore MSBuildTask0002
                     }
                 }
                 catch (Exception e) when (ExceptionHandling.IsIoRelatedException(e))

--- a/src/Tasks/NativeMethods.cs
+++ b/src/Tasks/NativeMethods.cs
@@ -4,6 +4,7 @@
 using System;
 using System.IO;
 using System.Runtime.InteropServices;
+using Microsoft.Build.Framework;
 using Microsoft.Build.Shared.FileSystem;
 
 using System.Text;
@@ -835,7 +836,7 @@ namespace Microsoft.Build.Tasks
         /// <param name="newFileName"></param>
         /// <param name="flags"></param>
         /// <returns></returns>
-        internal static bool MoveFileEx(string existingFileName, string newFileName, MoveFileFlags flags)
+        internal static bool MoveFileEx(AbsolutePath existingFileName, AbsolutePath newFileName, MoveFileFlags flags)
         {
             if (NativeMethodsShared.IsWindows)
             {
@@ -860,7 +861,7 @@ namespace Microsoft.Build.Tasks
                 throw new IOException("Moving target is read-only");
             }
 
-            if (string.Equals(existingFileName, newFileName, StringComparison.Ordinal))
+            if (existingFileName == newFileName)
             {
                 return true;
             }

--- a/src/Tasks/Unzip.cs
+++ b/src/Tasks/Unzip.cs
@@ -176,7 +176,7 @@ namespace Microsoft.Build.Tasks
         /// <param name="destinationDirectory">The <see cref="DirectoryInfo"/> to extract files to.</param>
         private void Extract(ZipArchive sourceArchive, DirectoryInfo destinationDirectory)
         {
-            string fullDestinationDirectoryPath = Path.GetFullPath(FileUtilities.EnsureTrailingSlash(destinationDirectory.FullName));
+            AbsolutePath fullDestinationDirectoryPath = TaskEnvironment.GetAbsolutePath(FileUtilities.EnsureTrailingSlash(destinationDirectory.FullName)).GetCanonicalForm();
 
             foreach (ZipArchiveEntry zipArchiveEntry in sourceArchive.Entries.TakeWhile(i => !_cancellationToken.IsCancellationRequested))
             {
@@ -186,8 +186,8 @@ namespace Microsoft.Build.Tasks
                     continue;
                 }
 
-                string fullDestinationPath = Path.GetFullPath(Path.Combine(destinationDirectory.FullName, zipArchiveEntry.FullName));
-                ErrorUtilities.VerifyThrowInvalidOperation(fullDestinationPath.StartsWith(fullDestinationDirectoryPath, FileUtilities.PathComparison), "Unzip.ZipSlipExploit", fullDestinationPath);
+                AbsolutePath fullDestinationPath = TaskEnvironment.GetAbsolutePath(Path.Combine(destinationDirectory.FullName, zipArchiveEntry.FullName)).GetCanonicalForm();
+                ErrorUtilities.VerifyThrowInvalidOperation(fullDestinationPath.Value.StartsWith(fullDestinationDirectoryPath, FileUtilities.PathComparison), "Unzip.ZipSlipExploit", fullDestinationPath);
 
                 FileInfo destinationPath = new(fullDestinationPath);
 


### PR DESCRIPTION
Replace direct Environment.GetEnvironmentVariable and Path.GetFullPath calls in tasks that already implement IMultiThreadableTask, addressing analyzer warnings in the 'Linux Core Multithreaded Mode' CI leg.

Changes:
- Copy.cs: Convert static env var reads to instance fields initialized from TaskEnvironment.GetEnvironmentVariable() at the start of Execute(). This is MT-safe since each task instance gets its own TaskEnvironment. Constants remain on Copy for test access. RefreshInternalEnvironmentValues() is now a no-op (env vars are read fresh per Execute call).
- GetFileHash.cs: Change ComputeHash parameter from string to AbsolutePath to preserve type safety through to File.OpenRead call.
- Unzip.cs: Replace Path.GetFullPath with TaskEnvironment.GetAbsolutePath().GetCanonicalForm() using AbsolutePath type. GetCanonicalForm resolves '..' for zip slip protection.
- FindUnderPath.cs: Pragma-suppress MSBuildTask0002 in pre-ChangeWave branches where Path.GetFullPath is called on already-absolute paths from TaskEnvironment.GetAbsolutePath (only canonicalizes, CWD not consulted).
- AssignTargetPath.cs: Same pragma-suppress pattern as FindUnderPath.
