### PR TITLE
Final branding for 18.6 release

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -1,10 +1,10 @@
-<Project>
+﻿<Project>
 
   <Import Project="Version.Details.props" />
 
   <PropertyGroup>
-    <VersionPrefix>18.6.0</VersionPrefix>
-    <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
+    <VersionPrefix>18.6.0</VersionPrefix><DotNetFinalVersionKind>release</DotNetFinalVersionKind><!-- Keep next to VersionPrefix to create a conflict in forward-flow -->
+    <PreReleaseVersionLabel>servicing</PreReleaseVersionLabel>
     <PackageValidationBaselineVersion>18.5.0-preview-26126-01</PackageValidationBaselineVersion>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>
 


### PR DESCRIPTION
## Release 18.6 — Phase 4: Final Branding

Tracking issue: https://github.com/dotnet/msbuild/issues/13468

### Changes
- Add \<DotNetFinalVersionKind>release</DotNetFinalVersionKind>\ on the \VersionPrefix\ line (creates merge conflict for forward-flow)
- Change \PreReleaseVersionLabel\ from \preview\ to \servicing\

Generated by \scripts/Stabilize-Release.ps1\.

### Next steps after merge
- Bootstrap OptProf for \s18.6\
- Babysit VS insertion PR into VS \main\ before insiders snap (Apr 3)