### PR TITLE
Fix race conditions in task host path resolution

### DIFF
--- a/src/Build/BackEnd/Components/Communications/CurrentHost.cs
+++ b/src/Build/BackEnd/Components/Communications/CurrentHost.cs
@@ -25,14 +25,15 @@ internal static class CurrentHost
     public static string? GetCurrentHost()
     {
 #if RUNTIME_TYPE_NETCORE
-        if (s_currentHost == null)
+        string? host = s_currentHost;
+        if (host is null)
         {
             string dotnetExe = Path.Combine(
                 FileUtilities.GetFolderAbove(BuildEnvironmentHelper.Instance.CurrentMSBuildToolsDirectory, 2),
                 Constants.DotnetProcessName);
             if (FileSystems.Default.FileExists(dotnetExe))
             {
-                s_currentHost = dotnetExe;
+                host = dotnetExe;
             }
             else
             {
@@ -40,7 +41,7 @@ internal static class CurrentHost
                     && Path.GetFileName(processPath) == Constants.DotnetProcessName)
                 {
                     // If the current process is already running in a general-purpose host, use its path.
-                    s_currentHost = processPath;
+                    host = processPath;
                 }
                 else
                 {
@@ -52,7 +53,7 @@ internal static class CurrentHost
                         Constants.DotnetProcessName);
                     if (FileSystems.Default.FileExists(dotnetExe))
                     {
-                        s_currentHost = dotnetExe;
+                        host = dotnetExe;
                     }
                     else
                     {
@@ -60,9 +61,11 @@ internal static class CurrentHost
                     }
                 }
             }
+
+            s_currentHost = host;
         }
 
-        return s_currentHost;
+        return host;
 #else
         return null;
 #endif

--- a/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcTaskHost.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcTaskHost.cs
@@ -161,17 +161,14 @@ namespace Microsoft.Build.BackEnd
         {
             get
             {
-                if (s_msbuildTaskHostName == null)
+                string name = s_msbuildTaskHostName;
+                if (name is null)
                 {
-                    s_msbuildTaskHostName = Environment.GetEnvironmentVariable("MSBUILDTASKHOST_EXE_NAME");
-
-                    if (s_msbuildTaskHostName == null)
-                    {
-                        s_msbuildTaskHostName = "MSBuildTaskHost.exe";
-                    }
+                    name = Environment.GetEnvironmentVariable("MSBUILDTASKHOST_EXE_NAME") ?? "MSBuildTaskHost.exe";
+                    s_msbuildTaskHostName = name;
                 }
 
-                return s_msbuildTaskHostName;
+                return name;
             }
         }
 
@@ -378,7 +375,9 @@ namespace Microsoft.Build.BackEnd
 
         /// <summary>
         /// Clears out our cached values for the various task host names and paths.
-        /// FOR UNIT TESTING ONLY
+        /// FOR UNIT TESTING ONLY. Must not be called concurrently with methods that
+        /// read or populate these statics (e.g. GetMSBuildExecutablePathForNonNETRuntimes),
+        /// otherwise cleared fields may be partially reinstated by an in-flight caller.
         /// </summary>
         internal static void ClearCachedTaskHostPaths()
         {
@@ -405,19 +404,20 @@ namespace Microsoft.Build.BackEnd
                 return TaskHostNameForClr2TaskHost;
             }
 
-            if (string.IsNullOrEmpty(s_msbuildName))
+            string name = s_msbuildName;
+            if (string.IsNullOrEmpty(name))
             {
-                s_msbuildName = Environment.GetEnvironmentVariable("MSBUILD_EXE_NAME");
-                if (!string.IsNullOrEmpty(s_msbuildName))
+                name = Environment.GetEnvironmentVariable("MSBUILD_EXE_NAME");
+                if (string.IsNullOrEmpty(name))
                 {
-                    return s_msbuildName;
+                    // Default based on whether it's .NET or Framework
+                    name = Constants.MSBuildExecutableName;
                 }
 
-                // Default based on whether it's .NET or Framework
-                s_msbuildName = Constants.MSBuildExecutableName;
+                s_msbuildName = name;
             }
 
-            return s_msbuildName;
+            return name;
         }
 
         /// <summary>
@@ -433,9 +433,30 @@ namespace Microsoft.Build.BackEnd
             ErrorUtilities.VerifyThrowInternalErrorUnreachable(Handshake.IsHandshakeOptionEnabled(hostContext, HandshakeOptions.TaskHost));
 
             var toolName = GetTaskHostNameFromHostContext(hostContext);
-            s_baseTaskHostPath = BuildEnvironmentHelper.Instance.MSBuildToolsDirectory32;
-            s_baseTaskHostPath64 = BuildEnvironmentHelper.Instance.MSBuildToolsDirectory64;
-            s_baseTaskHostPathArm64 = BuildEnvironmentHelper.Instance.MSBuildToolsDirectoryArm64;
+
+            // Snapshot to locals so concurrent callers never read a null static
+            // that another thread hasn't written yet. Redundant computation is
+            // harmless — BuildEnvironmentHelper properties are deterministic.
+            string basePath = s_baseTaskHostPath;
+            if (basePath is null)
+            {
+                basePath = BuildEnvironmentHelper.Instance.MSBuildToolsDirectory32;
+                s_baseTaskHostPath = basePath;
+            }
+
+            string basePath64 = s_baseTaskHostPath64;
+            if (basePath64 is null)
+            {
+                basePath64 = BuildEnvironmentHelper.Instance.MSBuildToolsDirectory64;
+                s_baseTaskHostPath64 = basePath64;
+            }
+
+            string basePathArm64 = s_baseTaskHostPathArm64;
+            if (basePathArm64 is null)
+            {
+                basePathArm64 = BuildEnvironmentHelper.Instance.MSBuildToolsDirectoryArm64;
+                s_baseTaskHostPathArm64 = basePathArm64;
+            }
 
             bool isX64 = Handshake.IsHandshakeOptionEnabled(hostContext, HandshakeOptions.X64);
             bool isArm64 = Handshake.IsHandshakeOptionEnabled(hostContext, HandshakeOptions.Arm64);
@@ -449,21 +470,21 @@ namespace Microsoft.Build.BackEnd
                 }
 
                 return isX64
-                    ? Path.Combine(GetOrInitializeX64Clr2Path(toolName), toolName)
-                    : Path.Combine(GetOrInitializeX32Clr2Path(toolName), toolName);
+                    ? Path.Combine(GetOrInitializeX64Clr2Path(toolName, basePath64), toolName)
+                    : Path.Combine(GetOrInitializeX32Clr2Path(toolName, basePath), toolName);
             }
 
             if (isX64)
             {
-                return Path.Combine(s_pathToX64Clr4 ??= s_baseTaskHostPath64, toolName);
+                return Path.Combine(s_pathToX64Clr4 ??= basePath64, toolName);
             }
 
             if (isArm64)
             {
-                return Path.Combine(s_pathToArm64Clr4 ??= s_baseTaskHostPathArm64, toolName);
+                return Path.Combine(s_pathToArm64Clr4 ??= basePathArm64, toolName);
             }
 
-            return Path.Combine(s_pathToX32Clr4 ??= s_baseTaskHostPath, toolName);
+            return Path.Combine(s_pathToX32Clr4 ??= basePath, toolName);
         }
 
         /// <summary>
@@ -559,18 +580,14 @@ namespace Microsoft.Build.BackEnd
                 : null;
         }
 
-        private static string GetOrInitializeX64Clr2Path(string toolName)
+        private static string GetOrInitializeX64Clr2Path(string toolName, string basePath64)
         {
-            s_pathToX64Clr2 ??= GetPathFromEnvironmentOrDefault("MSBUILDTASKHOSTLOCATION64", s_baseTaskHostPath64, toolName);
-
-            return s_pathToX64Clr2;
+            return s_pathToX64Clr2 ??= GetPathFromEnvironmentOrDefault("MSBUILDTASKHOSTLOCATION64", basePath64, toolName);
         }
 
-        private static string GetOrInitializeX32Clr2Path(string toolName)
+        private static string GetOrInitializeX32Clr2Path(string toolName, string basePath)
         {
-            s_pathToX32Clr2 ??= GetPathFromEnvironmentOrDefault("MSBUILDTASKHOSTLOCATION", s_baseTaskHostPath, toolName);
-
-            return s_pathToX32Clr2;
+            return s_pathToX32Clr2 ??= GetPathFromEnvironmentOrDefault("MSBUILDTASKHOSTLOCATION", basePath, toolName);
         }
 
         private static string GetPathFromEnvironmentOrDefault(string environmentVariable, string defaultPath, string toolName)


### PR DESCRIPTION
# Fixes #13484

### Context
Multithreaded (`/mt`) builds that launch out-of-process task hosts crash with `ArgumentNullException: Value cannot be null. Parameter name: path2` in `Path.Combine` when multiple `RequestBuilder` threads simultaneously resolve the task host executable name.

### Root cause

`GetTaskHostNameFromHostContext` in `NodeProviderOutOfProcTaskHost.cs` has an unsafe read-modify-write sequence on the static field `s_msbuildName`:

```csharp
if (string.IsNullOrEmpty(s_msbuildName))            // (1) check
{
    s_msbuildName = Environment.GetEnvironmentVariable("MSBUILD_EXE_NAME"); // (2) write — may be null
    if (!string.IsNullOrEmpty(s_msbuildName))
    {
        return s_msbuildName;
    }
    s_msbuildName = Constants.MSBuildExecutableName;  // (3) write — always non-null
}
return s_msbuildName;                                // (4) read
```

When `MSBUILD_EXE_NAME` is not set, step (2) writes `null` into `s_msbuildName`. Between steps (2) and (3), another thread can read `s_msbuildName` at step (4)** and get `null`.

The returned `null` is passed as `toolName` into `Path.Combine(basePath, toolName)`, which throws `ArgumentNullException` on .NET Framework (where `Path.Combine` does not accept null arguments).

### Changes Made
 Since all computations are deterministic (environment variables + constants), we use the local-variable snapshot pattern
  — read the static into a local, compute if null, write back, return the local. This is lock-free and safe because reference writes are atomic in .NET. Applied the same fix to similar patterns in nearby code in NodeProviderOutOfProcTaskHost.cs and CurrentHost.cs

### Testing
No extra testing. There is no stable local repro.