### PR TITLE
Fix cross-AppDomain TaskItem modifier cache regression

### DIFF
--- a/src/Framework/ItemSpecModifiers.cs
+++ b/src/Framework/ItemSpecModifiers.cs
@@ -52,6 +52,12 @@ internal static class ItemSpecModifiers
         DefiningProjectExtension
     ];
 
+    /// <summary>
+    ///  Per-item cache for the FullPath modifier. Other derivable modifiers (RootDir,
+    ///  Filename, Extension, RelativeDir, Directory) are intentionally NOT cached here
+    ///  because TaskItem is a MarshalByRefObject on .NET Framework, and copying a
+    ///  multi-field struct cross-AppDomain causes allocation regression in VS.
+    /// </summary>
     internal struct Cache
     {
         public string? FullPath;


### PR DESCRIPTION
The ItemSpecModifiers.Cache struct I introduced with #13386 caused a surprising ~200 MB allocation regression in Visual Studio scenarios on .NET Framework. Essentially, when TaskItem (a MarshalByRefObject) cached modifiers in an embedded struct, there's a huge cost to copy that struct cross-AppDomain.

To fix the problem, reduce the Cache struct to just a single field to store the full path. This should effectively bring memory allocations back in line.