### PR TITLE
Migrates unit tests to use RoslynCodeTaskFactory to enable running tests under .NET Core

### DIFF
--- a/src/Build.UnitTests/BackEnd/TaskBuilder_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/TaskBuilder_Tests.cs
@@ -690,16 +690,15 @@ namespace Microsoft.Build.UnitTests.BackEnd
 #endif
 
 
-#if FEATURE_CODETASKFACTORY
         /// <summary>
-        /// If an item being output from a task has null metadata, we shouldn't crash.
+        /// If an item being output from an inline task has null metadata, we shouldn't crash.
         /// </summary>
         [Fact]
         public void NullMetadataOnOutputItems_InlineTask()
         {
             string projectContents = @"
-                    <Project xmlns='msbuildnamespace' ToolsVersion='msbuilddefaulttoolsversion'>
-                        <UsingTask TaskName=`NullMetadataTask_v12` TaskFactory=`CodeTaskFactory` AssemblyFile=`$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll`>
+                    <Project>
+                        <UsingTask TaskName=`NullMetadataTask_Roslyn` TaskFactory=`RoslynCodeTaskFactory` AssemblyFile=`$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll`>
                             <ParameterGroup>
                                <OutputItems ParameterType=`Microsoft.Build.Framework.ITaskItem[]` Output=`true` />
                             </ParameterGroup>
@@ -719,9 +718,9 @@ namespace Microsoft.Build.UnitTests.BackEnd
                             </Task>
                         </UsingTask>
                       <Target Name=`Build`>
-                        <NullMetadataTask_v12>
+                        <NullMetadataTask_Roslyn>
                           <Output TaskParameter=`OutputItems` ItemName=`Outputs` />
-                        </NullMetadataTask_v12>
+                        </NullMetadataTask_Roslyn>
 
                         <Message Text=`[%(Outputs.Identity): %(Outputs.a)]` Importance=`High` />
                       </Target>
@@ -730,88 +729,6 @@ namespace Microsoft.Build.UnitTests.BackEnd
             MockLogger logger = ObjectModelHelpers.BuildProjectExpectSuccess(projectContents, _testOutput, LoggerVerbosity.Diagnostic);
             logger.AssertLogContains("[foo: ]");
         }
-
-        /// <summary>
-        /// If an item being output from a task has null metadata, we shouldn't crash.
-        /// </summary>
-        [Fact(Skip = "This test fails when diagnostic logging is available, as deprecated EscapingUtilities.UnescapeAll method cannot handle null value. This is not relevant to non-deprecated version of this method.")]
-        public void NullMetadataOnLegacyOutputItems_InlineTask()
-        {
-            string projectContents = @"
-                    <Project xmlns='msbuildnamespace' ToolsVersion='msbuilddefaulttoolsversion'>
-                        <UsingTask TaskName=`NullMetadataTask_v4` TaskFactory=`CodeTaskFactory` AssemblyFile=`$(MSBuildFrameworkToolsPath)\Microsoft.Build.Tasks.v4.0.dll`>
-                            <ParameterGroup>
-                               <OutputItems ParameterType=`Microsoft.Build.Framework.ITaskItem[]` Output=`true` />
-                            </ParameterGroup>
-                            <Task>
-                                <Code>
-                                <![CDATA[
-                                    OutputItems = new ITaskItem[1];
-
-                                    IDictionary<string, string> metadata = new Dictionary<string, string>();
-                                    metadata.Add(`a`, null);
-
-                                    OutputItems[0] = new TaskItem(`foo`, (IDictionary)metadata);
-
-                                    return true;
-                                ]]>
-                                </Code>
-                            </Task>
-                        </UsingTask>
-                      <Target Name=`Build`>
-                        <NullMetadataTask_v4>
-                          <Output TaskParameter=`OutputItems` ItemName=`Outputs` />
-                        </NullMetadataTask_v4>
-
-                        <Message Text=`[%(Outputs.Identity): %(Outputs.a)]` Importance=`High` />
-                      </Target>
-                    </Project>";
-
-            MockLogger logger = ObjectModelHelpers.BuildProjectExpectSuccess(projectContents, _testOutput);
-            logger.AssertLogContains("[foo: ]");
-        }
-
-        /// <summary>
-        /// If an item being output from a task has null metadata, we shouldn't crash.
-        /// </summary>
-        [Fact(Skip = "This test fails when diagnostic logging is available, as deprecated EscapingUtilities.UnescapeAll method cannot handle null value. This is not relevant to non-deprecated version of this method.")]
-        [Trait("Category", "non-mono-tests")]
-        public void NullMetadataOnLegacyOutputItems_InlineTask_Diagnostic()
-        {
-            string projectContents = @"
-                    <Project xmlns='msbuildnamespace' ToolsVersion='msbuilddefaulttoolsversion'>
-                        <UsingTask TaskName=`NullMetadataTask_v4` TaskFactory=`CodeTaskFactory` AssemblyFile=`$(MSBuildFrameworkToolsPath)\Microsoft.Build.Tasks.v4.0.dll`>
-                            <ParameterGroup>
-                               <OutputItems ParameterType=`Microsoft.Build.Framework.ITaskItem[]` Output=`true` />
-                            </ParameterGroup>
-                            <Task>
-                                <Code>
-                                <![CDATA[
-                                    OutputItems = new ITaskItem[1];
-
-                                    IDictionary<string, string> metadata = new Dictionary<string, string>();
-                                    metadata.Add(`a`, null);
-
-                                    OutputItems[0] = new TaskItem(`foo`, (IDictionary)metadata);
-
-                                    return true;
-                                ]]>
-                                </Code>
-                            </Task>
-                        </UsingTask>
-                      <Target Name=`Build`>
-                        <NullMetadataTask_v4>
-                          <Output TaskParameter=`OutputItems` ItemName=`Outputs` />
-                        </NullMetadataTask_v4>
-
-                        <Message Text=`[%(Outputs.Identity): %(Outputs.a)]` Importance=`High` />
-                      </Target>
-                    </Project>";
-
-            MockLogger logger = ObjectModelHelpers.BuildProjectExpectSuccess(projectContents, _testOutput, loggerVerbosity: LoggerVerbosity.Diagnostic);
-            logger.AssertLogContains("[foo: ]");
-        }
-#endif
 
         /// <summary>
         /// Validates that the defining project metadata is set (or not set) as expected in

--- a/src/Build.UnitTests/BackEnd/TaskHost_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/TaskHost_Tests.cs
@@ -546,37 +546,35 @@ namespace Microsoft.Build.UnitTests.BackEnd
             Assert.True(_taskHost.IsRunningMultipleNodes); // "Expect IsRunningMultipleNodes to be true with 4 nodes"
         }
 
-#if FEATURE_CODETASKFACTORY
         /// <summary>
         /// Task logging after it's done should not crash us.
         /// </summary>
         [Fact]
         public void LogCustomAfterTaskIsDone()
         {
-            string projectFileContents = @"
-                    <Project ToolsVersion='msbuilddefaulttoolsversion'>
-                        <UsingTask TaskName='test' TaskFactory='CodeTaskFactory' AssemblyFile='$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll' >
-                            <Task>
-                              <Using Namespace='System' />
-                              <Using Namespace='System.Threading' />
-                              <Code Type='Fragment' Language='cs'>
+            string projectFileContents = """
+                <Project>
+                    <UsingTask TaskName='test' TaskFactory='RoslynCodeTaskFactory' AssemblyFile='$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll'>
+                        <Task>
+                            <Using Namespace='System.Threading' />
+                            <Code Type='Fragment' Language='cs'>
                                 <![CDATA[
-                                  Log.LogWarning(""[1]"");
-                                  ThreadPool.QueueUserWorkItem(state=>
-                                  {
-                                          Thread.Sleep(100);
-                                          Log.LogExternalProjectStarted(""a"", ""b"", ""c"", ""d""); // this logs a custom event
-                                  });
-
+                                Log.LogWarning("[1]");
+                                ThreadPool.QueueUserWorkItem(state =>
+                                {
+                                    Thread.Sleep(100);
+                                    Log.LogExternalProjectStarted("a", "b", "c", "d");
+                                });
                                 ]]>
-                              </Code>
-                            </Task>
-                        </UsingTask>
-                        <Target Name='Build'>
-                            <test/>
-                            <Warning Text=""[3]""/>
-                        </Target>
-                    </Project>";
+                            </Code>
+                        </Task>
+                    </UsingTask>
+                    <Target Name='Build'>
+                        <test/>
+                        <Warning Text="[3]"/>
+                    </Target>
+                </Project>
+                """;
 
             MockLogger mockLogger = Helpers.BuildProjectWithNewOMExpectSuccess(projectFileContents);
             mockLogger.AssertLogContains("[1]");
@@ -589,30 +587,29 @@ namespace Microsoft.Build.UnitTests.BackEnd
         [Fact]
         public void LogCommentAfterTaskIsDone()
         {
-            string projectFileContents = @"
-                    <Project ToolsVersion='msbuilddefaulttoolsversion'>
-                        <UsingTask TaskName='test' TaskFactory='CodeTaskFactory' AssemblyFile='$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll' >
-                            <Task>
-                              <Using Namespace='System' />
-                              <Using Namespace='System.Threading' />
-                              <Code Type='Fragment' Language='cs'>
+            string projectFileContents = """
+                <Project>
+                    <UsingTask TaskName='test' TaskFactory='RoslynCodeTaskFactory' AssemblyFile='$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll'>
+                        <Task>
+                            <Using Namespace='System.Threading' />
+                            <Code Type='Fragment' Language='cs'>
                                 <![CDATA[
-                                  Log.LogMessage(""[1]"");
-                                  ThreadPool.QueueUserWorkItem(state=>
-                                  {
-                                          Thread.Sleep(100);
-                                          Log.LogMessage(""[2]"");
-                                  });
-
+                                Log.LogMessage("[1]");
+                                ThreadPool.QueueUserWorkItem(state =>
+                                {
+                                    Thread.Sleep(100);
+                                    Log.LogMessage("[2]");
+                                });
                                 ]]>
-                              </Code>
-                            </Task>
-                        </UsingTask>
-                        <Target Name='Build'>
-                            <test/>
-                            <Message Text=""[3]""/>
-                        </Target>
-                    </Project>";
+                            </Code>
+                        </Task>
+                    </UsingTask>
+                    <Target Name='Build'>
+                        <test/>
+                        <Message Text="[3]"/>
+                    </Target>
+                </Project>
+                """;
 
             MockLogger mockLogger = Helpers.BuildProjectWithNewOMExpectSuccess(projectFileContents);
             mockLogger.AssertLogContains("[1]");
@@ -620,35 +617,34 @@ namespace Microsoft.Build.UnitTests.BackEnd
         }
 
         /// <summary>
-        /// Task logging after it's done should not crash us.
+        /// Task logging a warning after it's done should not crash us.
         /// </summary>
         [Fact]
         public void LogWarningAfterTaskIsDone()
         {
-            string projectFileContents = @"
-                    <Project ToolsVersion='msbuilddefaulttoolsversion'>
-                        <UsingTask TaskName='test' TaskFactory='CodeTaskFactory' AssemblyFile='$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll' >
-                            <Task>
-                              <Using Namespace='System' />
-                              <Using Namespace='System.Threading' />
-                              <Code Type='Fragment' Language='cs'>
+            string projectFileContents = """
+                <Project>
+                    <UsingTask TaskName='test' TaskFactory='RoslynCodeTaskFactory' AssemblyFile='$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll'>
+                        <Task>
+                            <Using Namespace='System.Threading' />
+                            <Code Type='Fragment' Language='cs'>
                                 <![CDATA[
-                                  Log.LogWarning(""[1]"");
-                                  ThreadPool.QueueUserWorkItem(state=>
-                                  {
-                                          Thread.Sleep(100);
-                                          Log.LogWarning(""[2]"");
-                                  });
-
+                                Log.LogWarning("[1]");
+                                ThreadPool.QueueUserWorkItem(state =>
+                                {
+                                    Thread.Sleep(100);
+                                    Log.LogWarning("[2]");
+                                });
                                 ]]>
-                              </Code>
-                            </Task>
-                        </UsingTask>
-                        <Target Name='Build'>
-                            <test/>
-                            <Warning Text=""[3]""/>
-                        </Target>
-                    </Project>";
+                            </Code>
+                        </Task>
+                    </UsingTask>
+                    <Target Name='Build'>
+                        <test/>
+                        <Warning Text="[3]"/>
+                    </Target>
+                </Project>
+                """;
 
             MockLogger mockLogger = Helpers.BuildProjectWithNewOMExpectSuccess(projectFileContents);
             mockLogger.AssertLogContains("[1]");
@@ -656,41 +652,39 @@ namespace Microsoft.Build.UnitTests.BackEnd
         }
 
         /// <summary>
-        /// Task logging after it's done should not crash us.
+        /// Task logging an error after it's done should not crash us.
         /// </summary>
         [Fact]
         public void LogErrorAfterTaskIsDone()
         {
-            string projectFileContents = @"
-                    <Project ToolsVersion='msbuilddefaulttoolsversion'>
-                        <UsingTask TaskName='test' TaskFactory='CodeTaskFactory' AssemblyFile='$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll' >
-                            <Task>
-                              <Using Namespace='System' />
-                              <Using Namespace='System.Threading' />
-                              <Code Type='Fragment' Language='cs'>
+            string projectFileContents = """
+                <Project>
+                    <UsingTask TaskName='test' TaskFactory='RoslynCodeTaskFactory' AssemblyFile='$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll'>
+                        <Task>
+                            <Using Namespace='System.Threading' />
+                            <Code Type='Fragment' Language='cs'>
                                 <![CDATA[
-                                  Log.LogError(""[1]"");
-                                  ThreadPool.QueueUserWorkItem(state=>
-                                  {
-                                          Thread.Sleep(100);
-                                          Log.LogError(""[2]"");
-                                  });
-
+                                Log.LogError("[1]");
+                                ThreadPool.QueueUserWorkItem(state =>
+                                {
+                                    Thread.Sleep(100);
+                                    Log.LogError("[2]");
+                                });
                                 ]]>
-                              </Code>
-                            </Task>
-                        </UsingTask>
-                        <Target Name='Build'>
-                            <test ContinueOnError=""true""/>
-                            <Warning Text=""[3]""/>
-                        </Target>
-                    </Project>";
+                            </Code>
+                        </Task>
+                    </UsingTask>
+                    <Target Name='Build'>
+                        <test ContinueOnError="true"/>
+                        <Warning Text="[3]"/>
+                    </Target>
+                </Project>
+                """;
 
             MockLogger mockLogger = Helpers.BuildProjectWithNewOMExpectSuccess(projectFileContents);
             mockLogger.AssertLogContains("[1]");
             mockLogger.AssertLogContains("[3]"); // [2] may or may not appear.
         }
-#endif
 
         /// <summary>
         /// Verifies that tasks can get global properties.


### PR DESCRIPTION
Fixes #248 

### Context

I'm trying to migrate the tests so we can run them on .NET Core as indicated in the task.
Doing a small first batch first to catch any concerns and understand repo mechanics, will do a bigger volume in a follow-up PR.

### Changes Made

- Rewrite to using RoslynCodeTaskFactory for tests where the SUT is **not** CodeTaskFactory but the factory is part of the test setup.
- Minor stylistic changes
- Removing ignored tests (see comment to discuss)

### Testing

Tests should be passing for both Framework and Core flavors.

### Notes
