### PR TITLE
Default to enumerating "MSBuild" processes

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -3,7 +3,7 @@
   <Import Project="Version.Details.props" />
 
   <PropertyGroup>
-    <VersionPrefix>18.6.0</VersionPrefix><DotNetFinalVersionKind>release</DotNetFinalVersionKind><!-- Keep next to VersionPrefix to create a conflict in forward-flow -->
+    <VersionPrefix>18.6.1</VersionPrefix><DotNetFinalVersionKind>release</DotNetFinalVersionKind><!-- Keep next to VersionPrefix to create a conflict in forward-flow -->
     <PreReleaseVersionLabel>servicing</PreReleaseVersionLabel>
     <PackageValidationBaselineVersion>18.5.0-preview-26126-01</PackageValidationBaselineVersion>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>

--- a/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
@@ -475,6 +475,12 @@ namespace Microsoft.Build.BackEnd
             bool isNativeHost = msbuildLocation != null && Path.GetFileName(msbuildLocation).Equals(Constants.MSBuildExecutableName, StringComparison.OrdinalIgnoreCase);
             string expectedProcessName = Path.GetFileNameWithoutExtension(isNativeHost ? msbuildLocation : (CurrentHost.GetCurrentHost() ?? msbuildLocation));
 
+#if NETFRAMEWORK
+            // Fall back to the standard executable name for most nodes
+            // on .NET Framework, to function in `ShutdownAllNodes()`
+            expectedProcessName ??= Constants.MSBuildAppName;
+#endif
+
             Process[] processes;
             try
             {


### PR DESCRIPTION
Fixes devdiv2860587

### Summary

Fixes the `BuildManager.ShutdownAllNodes()` API used to close MSBuild at VS shutdown.

### Customer Impact

VS didn't clean up after itself and left `MSBuild.exe` processes idle after shutdown.

### Regression?

Yes, worked in 18.5. 

### Testing

Manual validation of fix.

### Risk

Low. This API is used when acquiring (existing) nodes, but that codepath always passed in enough information to avoid the bug.