### PR TITLE
Eliminate XmlChildNodes allocations in GetXmlNodeInnerContents

### DIFF
--- a/src/Build/Utilities/Utilities.cs
+++ b/src/Build/Utilities/Utilities.cs
@@ -197,12 +197,12 @@ namespace Microsoft.Build.Internal
             // Avoid accessing node.ChildNodes -- it allocates a new XmlChildNodes wrapper on every call.
             // Use FirstChild/NextSibling linked-list traversal instead (allocation-free).
             XmlNode firstChild = node.FirstChild;
-            if (firstChild == null)
+            if (firstChild is null)
             {
                 return String.Empty;
             }
 
-            bool isSingleChild = firstChild.NextSibling == null;
+            bool isSingleChild = firstChild.NextSibling is null;
             if (isSingleChild && firstChild.NodeType == XmlNodeType.Whitespace)
             {
                 return String.Empty;

--- a/src/Build/Utilities/Utilities.cs
+++ b/src/Build/Utilities/Utilities.cs
@@ -194,12 +194,21 @@ namespace Microsoft.Build.Internal
 
             // XmlNode.InnerXml is much more expensive than InnerText. Don't use it for trivial cases.
             // (single child node with a trivial value or no child nodes)
-            if (!node.HasChildNodes || (node.ChildNodes.Count == 1 && node.FirstChild.NodeType == XmlNodeType.Whitespace))
+            // Avoid accessing node.ChildNodes -- it allocates a new XmlChildNodes wrapper on every call.
+            // Use FirstChild/NextSibling linked-list traversal instead (allocation-free).
+            XmlNode firstChild = node.FirstChild;
+            if (firstChild == null)
             {
                 return String.Empty;
             }
 
-            if (node.ChildNodes.Count == 1 && (node.FirstChild.NodeType == XmlNodeType.Text || node.FirstChild.NodeType == XmlNodeType.CDATA))
+            bool isSingleChild = firstChild.NextSibling == null;
+            if (isSingleChild && firstChild.NodeType == XmlNodeType.Whitespace)
+            {
+                return String.Empty;
+            }
+
+            if (isSingleChild && (firstChild.NodeType == XmlNodeType.Text || firstChild.NodeType == XmlNodeType.CDATA))
             {
                 return node.InnerText;
             }


### PR DESCRIPTION
**&#129302; AI-Generated Pull Request &#129302;**

This pull request was generated by the **VS Perf Rel AI Agent**. Please review this AI-generated PR with extra care! For more information, visit our [wiki](https://devdiv.visualstudio.com/DevDiv/_wiki/wikis/DevDiv.wiki/49206/PerfRel-Agent). Please share feedback with [TIP Insights](mailto:tipinsights@microsoft.com)

---

- **Issue**:
`Utilities.GetXmlNodeInnerContents` accesses `node.ChildNodes` twice to check `Count == 1`.
In .NET Framework, `XmlNode.ChildNodes` calls `new XmlChildNodes(this)` on every access — it never caches — so each call produces 2 throwaway heap allocations.
This method is called for every property and metadata element during evaluation, making it a significant source of GC pressure during solution load.

  **Allocation sites** (`TypeAllocated!System.Xml.XmlChildNodes`, ~86% of sampled allocations):
  ```
  GetXmlNodeInnerContents
   → XmlNode.get_ChildNodes        ← allocates new XmlChildNodes(this) every call
     → XmlChildNodes.get_Count     ← iterates all children, result used once
       → compared to == 1, wrapper discarded
  ```
  **Callers on hot path as per Perfwatson traces:**
  ```
  EvaluatePropertyElement → GetXmlNodeInnerContents        (~21%)
  ProcessMetadataElements → GetXmlNodeInnerContents      (~25%)
  DecorateItemsWithMetadata → GetXmlNodeInnerContents    (~40%)
  ```

- **Issue type**: Avoid allocating wrapper objects when allocation-free alternatives exist on the same API surface.

- **Proposed fix**: Replace `node.ChildNodes.Count == 1` with `node.FirstChild.NextSibling == null` — a simple pointer check that answers the same question ("is there exactly one child?") with zero allocations. Cache `FirstChild` in a local and split the compound `if` into clear separate checks. This is a direct semantic equivalence (`FirstChild == null` ↔ `!HasChildNodes`, `NextSibling == null` ↔ `Count == 1`), internal-only, and produces identical results for all edge cases.


[Best practices wiki](https://dev.azure.com/devdiv/DevDiv/_wiki/wikis/DevDiv.wiki/24181/Garbage-collection-(GC))
[See related failure in PRISM](https://prism.vsdata.io/failure/?eventType=allocation&failureType=dualdirection&failureHash=37150888-6400-2b4a-28d6-4912c88650ac)
[ADO work item](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2906084)