### PR TITLE
Discourage review agent from approving PRs

### DIFF
--- a/.github/agents/expert-reviewer.md
+++ b/.github/agents/expert-reviewer.md
@@ -663,6 +663,7 @@ Use this to prioritize dimensions based on changed files.
    ```
 
    `[x]` = LGTM or NITs only. `[ ]` = MAJOR or BLOCKING.
-   All `[x]` → event: **APPROVE**. Any BLOCKING → event: **REQUEST_CHANGES**. Otherwise → event: **COMMENT**.
+   Any BLOCKING → event: **REQUEST_CHANGES**. Otherwise (including all-clear) → event: **COMMENT**.
+   **Never use APPROVE** — the agent must not count as a PR approval.
 
    All inline comments from step 5 are automatically bundled into this review submission.

--- a/.github/agents/expert-reviewer.md
+++ b/.github/agents/expert-reviewer.md
@@ -662,7 +662,7 @@ Use this to prioritize dimensions based on changed files.
    - [ ] Concurrency — shared state race
    ```
 
-   `[x]` = LGTM or NITs only. `[ ]` = MAJOR or BLOCKING.
+   `[x]` = LGTM or NITs only. `[ ]` = BLOCKING.
    Any BLOCKING → event: **REQUEST_CHANGES**. Otherwise (including all-clear) → event: **COMMENT**.
    **Never use APPROVE** — the agent must not count as a PR approval.
 

--- a/.github/workflows/shared/review-shared.md
+++ b/.github/workflows/shared/review-shared.md
@@ -38,5 +38,6 @@ Review pull request #${{ github.event.pull_request.number || github.event.issue.
 3. Do **not** post comments yourself. The subagent will post its own comments using the available safe-output tools:
    - **Inline review comments** on specific diff lines via `create_pull_request_review_comment`
    - **Design-level concerns** (not tied to a line) via `add_comment`
-   - **Final review verdict** (APPROVE / COMMENT / REQUEST_CHANGES) via `submit_pull_request_review`
-4. If the subagent does not post anything (e.g. no issues found), post a brief approval comment.
+   - **Final review verdict** (COMMENT or REQUEST_CHANGES) via `submit_pull_request_review`
+   - **Never use APPROVE** — the agent must not count as a PR approval. Use COMMENT for clean reviews.
+4. If the subagent does not post anything (e.g. no issues found), post a brief COMMENT (not APPROVE).

--- a/.github/workflows/shared/review-shared.md
+++ b/.github/workflows/shared/review-shared.md
@@ -35,9 +35,9 @@ Review pull request #${{ github.event.pull_request.number || github.event.issue.
 
 1. Fetch the full diff for the pull request.
 2. Call the `expert-reviewer` agent. Make sure to call it as subagent (`task` tool, `agent_type: "general-purpose"`, `model: "claude-opus-4.6"`). And make sure to follow the guidance on subagent calls from within the `expert-reviewer` agent. We expect 2+ levels of agents to be called.
-3. Do **not** post comments yourself. The subagent will post its own comments using the available safe-output tools:
+3. Do **not** post comments or reviews yourself, except for the fallback in step 4 if the subagent posts nothing. The subagent will post its own comments using the available safe-output tools:
    - **Inline review comments** on specific diff lines via `create_pull_request_review_comment`
    - **Design-level concerns** (not tied to a line) via `add_comment`
    - **Final review verdict** (COMMENT or REQUEST_CHANGES) via `submit_pull_request_review`
    - **Never use APPROVE** — the agent must not count as a PR approval. Use COMMENT for clean reviews.
-4. If the subagent does not post anything (e.g. no issues found), post a brief COMMENT (not APPROVE).
+4. If the subagent does not post anything (e.g. no issues found), this is the only exception to step 3: post a brief fallback review using `submit_pull_request_review` with event `COMMENT` (not `APPROVE`). Do not use `add_comment` for this fallback.


### PR DESCRIPTION
### Context
Thanks @JanProvaznik for pointing that the expert-reviewer could approve the PR.

### Notes
To completely prevent the reviewing workflow from approving we'd need to remove the `submit-pull-request-review` from `safe-outputs`:

https://github.com/dotnet/msbuild/blob/9b5c9daa4c58a5afea5748333eeb994881e9dec8/.github/workflows/shared/review-shared.md?plain=1#L24

(untill https://github.com/github/gh-aw/issues/25439 is fixed and deployed)

But even better - we should tune the repo ruleset for PR approvals to either accept it only from CODEOWNERS (though we'd nee to maintain that), or to exclude 'github-actions'