### PR TITLE
Ad-hoc re-sign bootstrap dotnet on macOS to prevent SIGKILL

### DIFF
--- a/eng/BootStrapMsBuild.targets
+++ b/eng/BootStrapMsBuild.targets
@@ -258,6 +258,11 @@
     <Copy SourceFiles="@(FreshlyBuiltNetBinaries)"
           DestinationFiles="@(FreshlyBuiltNetBinaries->'$(InstallDir)sdk\$(BootstrapSdkVersion)\%(RecursiveDir)%(Filename)%(Extension)')" />
 
+    <!-- macOS Gatekeeper kills copied dotnet apphosts that lack a valid local signature.
+         Ad-hoc re-sign to prevent SIGKILL (exit code 137) when tests invoke the bootstrap dotnet. -->
+    <Exec Command="codesign --force --sign - &quot;$(InstallDir)dotnet&quot;"
+          Condition="$([MSBuild]::IsOSPlatform('osx'))" />
+
   </Target>
 
 </Project>


### PR DESCRIPTION
## Problem

I found this because on my Mac some unit tests are failing, namely RoslynCodeTaskFactory_Tests. 

On macOS, the bootstrap `dotnet` binary at `artifacts/bin/bootstrap/core/dotnet` is frequently killed by Gatekeeper with **SIGKILL (exit code 137)** immediately upon execution. This happens because the `dotnet-install.sh` script downloads and copies the apphost binary into the bootstrap directory, and macOS code-signing enforcement rejects it in its new location.

This causes any test that invokes the bootstrap `dotnet` to fail — most visibly tests using `RoslynCodeTaskFactory`, which shells out to `dotnet csc.dll` to compile inline tasks. The failure manifests as:

- `MSB6006: "csc.exe" exited with code 137`
- `Killed: 9` when running the bootstrap dotnet directly

The error is confusing because exit code 137 typically suggests OOM, but the real cause is macOS security policy.

## Solution

Add an `Exec` step at the end of the `BootstrapNetCore` target in `eng/BootStrapMsBuild.targets` that ad-hoc re-signs the bootstrap `dotnet` binary on macOS:

```xml
<Exec Command="codesign --force --sign - \&quot;$(InstallDir)dotnet\&quot;"
      Condition="$([MSBuild]::IsOSPlatform('osx'))" />
```

This runs automatically as part of every bootstrap build, so macOS developers never need to manually troubleshoot this issue. The `--force --sign -` flags replace the existing signature with an ad-hoc local signature that macOS accepts. The condition ensures this only runs on macOS — Windows and Linux are unaffected.

## Testing

1. Cleaned the repo (`rm -rf artifacts/`)
2. Ran `./build.sh -v quiet` — build succeeded, codesign step ran automatically
3. Verified `artifacts/bin/bootstrap/core/dotnet --version` works (previously: `Killed: 9`)
4. Ran `dotnet test src/Tasks.UnitTests/ --filter BothForceAndMultiThreadedWork` — passed ✅