### PR TITLE
Fix telemetry allocation regression: per-engine collector ownership

### DIFF
--- a/src/Build.UnitTests/BackEnd/MockHost.cs
+++ b/src/Build.UnitTests/BackEnd/MockHost.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;

--- a/src/Build.UnitTests/BackEnd/MockHost.cs
+++ b/src/Build.UnitTests/BackEnd/MockHost.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -65,7 +65,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
 
         private IBuildCheckManagerProvider _buildCheckManagerProvider;
 
-        private TelemetryForwarderProvider _telemetryForwarder;
+        private TelemetryCollectorProvider _telemetryCollector;
 
         #region SystemParameterFields
 
@@ -136,8 +136,8 @@ namespace Microsoft.Build.UnitTests.BackEnd
             _buildCheckManagerProvider = new NullBuildCheckManagerProvider();
             ((IBuildComponent)_buildCheckManagerProvider).InitializeComponent(this);
 
-            _telemetryForwarder = new TelemetryForwarderProvider();
-            ((IBuildComponent)_telemetryForwarder).InitializeComponent(this);
+            _telemetryCollector = new TelemetryCollectorProvider();
+            ((IBuildComponent)_telemetryCollector).InitializeComponent(this);
         }
 
         /// <summary>
@@ -207,7 +207,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
                 BuildComponentType.RequestBuilder => (IBuildComponent)_requestBuilder,
                 BuildComponentType.SdkResolverService => (IBuildComponent)_sdkResolverService,
                 BuildComponentType.BuildCheckManagerProvider => (IBuildComponent)_buildCheckManagerProvider,
-                BuildComponentType.TelemetryForwarder => (IBuildComponent)_telemetryForwarder,
+                BuildComponentType.TelemetryCollector => (IBuildComponent)_telemetryCollector,
                 _ => throw new ArgumentException("Unexpected type " + type),
             };
         }

--- a/src/Build.UnitTests/Telemetry/Telemetry_Tests.cs
+++ b/src/Build.UnitTests/Telemetry/Telemetry_Tests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -486,16 +486,16 @@ namespace Microsoft.Build.Engine.UnitTests
         }
 
         [Fact]
-        public void TelemetryForwarder_AccumulatesAndSendsOnFinalize()
+        public void TelemetryCollector_AccumulatesAndSendsOnFinalize()
         {
-            var forwarder = new TelemetryForwarderProvider.TelemetryForwarder();
+            var forwarder = new TelemetryCollectorProvider.telemetryCollector();
             var loggingService = new EventRecordingLoggingService();
 
             var loggingContext = new MockLoggingContext(
                 loggingService,
                 new BuildEventContext(1, 2, BuildEventContext.InvalidProjectContextId, 4));
 
-            // Add data via the forwarder API.
+            // Add data via the collector API.
             var key = new TaskOrTargetTelemetryKey("TestTarget", isCustom: true, isFromNugetCache: false, isFromMetaProject: false);
             forwarder.AddTarget(key, wasExecuted: true);
 
@@ -505,11 +505,11 @@ namespace Microsoft.Build.Engine.UnitTests
             telemetryEvents.Count.ShouldBe(1);
             telemetryEvents[0].WorkerNodeTelemetryData.TargetsExecutionData.ShouldContainKey(key);
 
-            // Second FinalizeProcessing on an empty forwarder should be a no-op (state was reset).
+            // Second FinalizeProcessing on an empty collector should be a no-op (state was reset).
             forwarder.FinalizeProcessing(loggingContext);
             loggingService.RecordedEvents.OfType<WorkerNodeTelemetryEventArgs>().Count().ShouldBe(1, "No new event should be emitted after reset");
 
-            // Add new data after reset — forwarder should still work.
+            // Add new data after reset — collector should still work.
             var key2 = new TaskOrTargetTelemetryKey("TestTarget2", isCustom: false, isFromNugetCache: false, isFromMetaProject: false);
             forwarder.AddTarget(key2, wasExecuted: false, skipReason: TargetSkipReason.ConditionWasFalse);
 

--- a/src/Build.UnitTests/Telemetry/Telemetry_Tests.cs
+++ b/src/Build.UnitTests/Telemetry/Telemetry_Tests.cs
@@ -486,7 +486,7 @@ namespace Microsoft.Build.Engine.UnitTests
         }
 
         [Fact]
-        public void FinalizeProcessing_AfterMerge_ResetsState()
+        public void TelemetryForwarder_AccumulatesAndSendsOnFinalize()
         {
             var forwarder = new TelemetryForwarderProvider.TelemetryForwarder();
             var loggingService = new EventRecordingLoggingService();
@@ -495,11 +495,9 @@ namespace Microsoft.Build.Engine.UnitTests
                 loggingService,
                 new BuildEventContext(1, 2, BuildEventContext.InvalidProjectContextId, 4));
 
-            // Merge some data.
-            var localData = new WorkerNodeTelemetryData();
+            // Add data via the forwarder API.
             var key = new TaskOrTargetTelemetryKey("TestTarget", isCustom: true, isFromNugetCache: false, isFromMetaProject: false);
-            localData.AddTarget(key, wasExecuted: true);
-            forwarder.MergeWorkerData(localData);
+            forwarder.AddTarget(key, wasExecuted: true);
 
             // First FinalizeProcessing should emit a telemetry event.
             forwarder.FinalizeProcessing(loggingContext);
@@ -511,11 +509,9 @@ namespace Microsoft.Build.Engine.UnitTests
             forwarder.FinalizeProcessing(loggingContext);
             loggingService.RecordedEvents.OfType<WorkerNodeTelemetryEventArgs>().Count().ShouldBe(1, "No new event should be emitted after reset");
 
-            // Merge new data after reset — forwarder should still work.
-            var localData2 = new WorkerNodeTelemetryData();
+            // Add new data after reset — forwarder should still work.
             var key2 = new TaskOrTargetTelemetryKey("TestTarget2", isCustom: false, isFromNugetCache: false, isFromMetaProject: false);
-            localData2.AddTarget(key2, wasExecuted: false, skipReason: TargetSkipReason.ConditionWasFalse);
-            forwarder.MergeWorkerData(localData2);
+            forwarder.AddTarget(key2, wasExecuted: false, skipReason: TargetSkipReason.ConditionWasFalse);
 
             // Third FinalizeProcessing should emit only the new data.
             forwarder.FinalizeProcessing(loggingContext);

--- a/src/Build.UnitTests/Telemetry/Telemetry_Tests.cs
+++ b/src/Build.UnitTests/Telemetry/Telemetry_Tests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -488,7 +488,7 @@ namespace Microsoft.Build.Engine.UnitTests
         [Fact]
         public void TelemetryCollector_AccumulatesAndSendsOnFinalize()
         {
-            var forwarder = new TelemetryCollectorProvider.telemetryCollector();
+            var collector = new TelemetryCollectorProvider.TelemetryCollector();
             var loggingService = new EventRecordingLoggingService();
 
             var loggingContext = new MockLoggingContext(
@@ -497,24 +497,24 @@ namespace Microsoft.Build.Engine.UnitTests
 
             // Add data via the collector API.
             var key = new TaskOrTargetTelemetryKey("TestTarget", isCustom: true, isFromNugetCache: false, isFromMetaProject: false);
-            forwarder.AddTarget(key, wasExecuted: true);
+            collector.AddTarget(key, wasExecuted: true);
 
             // First FinalizeProcessing should emit a telemetry event.
-            forwarder.FinalizeProcessing(loggingContext);
+            collector.FinalizeProcessing(loggingContext);
             var telemetryEvents = loggingService.RecordedEvents.OfType<WorkerNodeTelemetryEventArgs>().ToList();
             telemetryEvents.Count.ShouldBe(1);
             telemetryEvents[0].WorkerNodeTelemetryData.TargetsExecutionData.ShouldContainKey(key);
 
             // Second FinalizeProcessing on an empty collector should be a no-op (state was reset).
-            forwarder.FinalizeProcessing(loggingContext);
+            collector.FinalizeProcessing(loggingContext);
             loggingService.RecordedEvents.OfType<WorkerNodeTelemetryEventArgs>().Count().ShouldBe(1, "No new event should be emitted after reset");
 
             // Add new data after reset — collector should still work.
             var key2 = new TaskOrTargetTelemetryKey("TestTarget2", isCustom: false, isFromNugetCache: false, isFromMetaProject: false);
-            forwarder.AddTarget(key2, wasExecuted: false, skipReason: TargetSkipReason.ConditionWasFalse);
+            collector.AddTarget(key2, wasExecuted: false, skipReason: TargetSkipReason.ConditionWasFalse);
 
             // Third FinalizeProcessing should emit only the new data.
-            forwarder.FinalizeProcessing(loggingContext);
+            collector.FinalizeProcessing(loggingContext);
             var allTelemetryEvents = loggingService.RecordedEvents.OfType<WorkerNodeTelemetryEventArgs>().ToList();
             allTelemetryEvents.Count.ShouldBe(2);
             allTelemetryEvents[1].WorkerNodeTelemetryData.TargetsExecutionData.ShouldContainKey(key2);

--- a/src/Build/BackEnd/Components/BuildComponentFactoryCollection.cs
+++ b/src/Build/BackEnd/Components/BuildComponentFactoryCollection.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;

--- a/src/Build/BackEnd/Components/BuildComponentFactoryCollection.cs
+++ b/src/Build/BackEnd/Components/BuildComponentFactoryCollection.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
@@ -82,7 +82,7 @@ namespace Microsoft.Build.BackEnd
             _componentEntriesByType[BuildComponentType.RequestBuilder] = new BuildComponentEntry(BuildComponentType.RequestBuilder, RequestBuilder.CreateComponent, CreationPattern.CreateAlways);
             // Following two conditionally registers real or no-op implementation based on BuildParameters
             _componentEntriesByType[BuildComponentType.BuildCheckManagerProvider] = new BuildComponentEntry(BuildComponentType.BuildCheckManagerProvider, BuildCheckManagerProvider.CreateComponent, CreationPattern.Singleton);
-            _componentEntriesByType[BuildComponentType.TelemetryForwarder] = new BuildComponentEntry(BuildComponentType.TelemetryForwarder, TelemetryForwarderProvider.CreateComponent, CreationPattern.Singleton);
+            _componentEntriesByType[BuildComponentType.TelemetryCollector] = new BuildComponentEntry(BuildComponentType.TelemetryCollector, TelemetryCollectorProvider.CreateComponent, CreationPattern.Singleton);
             _componentEntriesByType[BuildComponentType.TargetBuilder] = new BuildComponentEntry(BuildComponentType.TargetBuilder, TargetBuilder.CreateComponent, CreationPattern.CreateAlways);
             _componentEntriesByType[BuildComponentType.TaskBuilder] = new BuildComponentEntry(BuildComponentType.TaskBuilder, TaskBuilder.CreateComponent, CreationPattern.CreateAlways);
             _componentEntriesByType[BuildComponentType.RegisteredTaskObjectCache] = new BuildComponentEntry(BuildComponentType.RegisteredTaskObjectCache, RegisteredTaskObjectCache.CreateComponent, CreationPattern.Singleton);

--- a/src/Build/BackEnd/Components/BuildRequestEngine/BuildRequestEngine.cs
+++ b/src/Build/BackEnd/Components/BuildRequestEngine/BuildRequestEngine.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;

--- a/src/Build/BackEnd/Components/BuildRequestEngine/BuildRequestEngine.cs
+++ b/src/Build/BackEnd/Components/BuildRequestEngine/BuildRequestEngine.cs
@@ -208,6 +208,11 @@ namespace Microsoft.Build.BackEnd
 
             _nodeLoggingContext = loggingContext;
 
+            // Create a per-engine telemetry forwarder via the provider.
+            // Each engine owns its forwarder — no cross-engine sharing, no singleton contention.
+            var telemetryProvider = (TelemetryForwarderProvider)_componentHost.GetComponent(BuildComponentType.TelemetryForwarder);
+            _nodeLoggingContext.TelemetryForwarder = telemetryProvider.CreateForwarder();
+
             // Create a work queue that will take an action and invoke it.  The generic parameter is the type which ActionBlock.Post() will
             // take (an Action in this case) and the parameter to this constructor is a function which takes that parameter of type Action
             // (which we have named action) and does something with it (in this case calls invoke on it.)
@@ -302,9 +307,8 @@ namespace Microsoft.Build.BackEnd
                     IBuildCheckManagerProvider buildCheckProvider = (_componentHost.GetComponent(BuildComponentType.BuildCheckManagerProvider) as IBuildCheckManagerProvider);
                     var buildCheckManager = buildCheckProvider!.Instance;
                     buildCheckManager.FinalizeProcessing(_nodeLoggingContext);
-                    // Flush and send the final telemetry data if they are being collected
-                    ITelemetryForwarder telemetryForwarder = (_componentHost.GetComponent(BuildComponentType.TelemetryForwarder) as TelemetryForwarderProvider)!.Instance;
-                    telemetryForwarder.FinalizeProcessing(_nodeLoggingContext);
+                    // Flush and send the per-engine telemetry data if any was collected.
+                    _nodeLoggingContext.TelemetryForwarder?.FinalizeProcessing(_nodeLoggingContext);
                     // Clears the instance so that next call (on node reuse) to 'GetComponent' leads to reinitialization.
                     buildCheckProvider.ShutdownComponent();
                 },

--- a/src/Build/BackEnd/Components/BuildRequestEngine/BuildRequestEngine.cs
+++ b/src/Build/BackEnd/Components/BuildRequestEngine/BuildRequestEngine.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -208,10 +208,10 @@ namespace Microsoft.Build.BackEnd
 
             _nodeLoggingContext = loggingContext;
 
-            // Create a per-engine telemetry forwarder via the provider.
+            // Create a per-engine telemetry collector via the provider.
             // Each engine owns its forwarder — no cross-engine sharing, no singleton contention.
-            var telemetryProvider = (TelemetryForwarderProvider)_componentHost.GetComponent(BuildComponentType.TelemetryForwarder);
-            _nodeLoggingContext.TelemetryForwarder = telemetryProvider.CreateForwarder();
+            var telemetryProvider = (TelemetryCollectorProvider)_componentHost.GetComponent(BuildComponentType.TelemetryCollector);
+            _nodeLoggingContext.TelemetryCollector = telemetryProvider.CreateCollector();
 
             // Create a work queue that will take an action and invoke it.  The generic parameter is the type which ActionBlock.Post() will
             // take (an Action in this case) and the parameter to this constructor is a function which takes that parameter of type Action
@@ -308,7 +308,7 @@ namespace Microsoft.Build.BackEnd
                     var buildCheckManager = buildCheckProvider!.Instance;
                     buildCheckManager.FinalizeProcessing(_nodeLoggingContext);
                     // Flush and send the per-engine telemetry data if any was collected.
-                    _nodeLoggingContext.TelemetryForwarder?.FinalizeProcessing(_nodeLoggingContext);
+                    _nodeLoggingContext.TelemetryCollector?.FinalizeProcessing(_nodeLoggingContext);
                     // Clears the instance so that next call (on node reuse) to 'GetComponent' leads to reinitialization.
                     buildCheckProvider.ShutdownComponent();
                 },

--- a/src/Build/BackEnd/Components/BuildRequestEngine/BuildRequestEngine.cs
+++ b/src/Build/BackEnd/Components/BuildRequestEngine/BuildRequestEngine.cs
@@ -208,8 +208,8 @@ namespace Microsoft.Build.BackEnd
 
             _nodeLoggingContext = loggingContext;
 
-            // Create a per-engine telemetry collector via the provider.
-            // Each engine owns its forwarder — no cross-engine sharing, no singleton contention.
+            // Create a per-BuildRequestEngine telemetry collector via the provider.
+            // Each BuildRequestEngine owns its collector — no cross-engine sharing, no singleton contention.
             var telemetryProvider = (TelemetryCollectorProvider)_componentHost.GetComponent(BuildComponentType.TelemetryCollector);
             _nodeLoggingContext.TelemetryCollector = telemetryProvider.CreateCollector();
 
@@ -307,7 +307,7 @@ namespace Microsoft.Build.BackEnd
                     IBuildCheckManagerProvider buildCheckProvider = (_componentHost.GetComponent(BuildComponentType.BuildCheckManagerProvider) as IBuildCheckManagerProvider);
                     var buildCheckManager = buildCheckProvider!.Instance;
                     buildCheckManager.FinalizeProcessing(_nodeLoggingContext);
-                    // Flush and send the per-engine telemetry data if any was collected.
+                    // Flush and send the per-BuildRequestEngine telemetry data if any was collected.
                     _nodeLoggingContext.TelemetryCollector?.FinalizeProcessing(_nodeLoggingContext);
                     // Clears the instance so that next call (on node reuse) to 'GetComponent' leads to reinitialization.
                     buildCheckProvider.ShutdownComponent();

--- a/src/Build/BackEnd/Components/IBuildComponentHost.cs
+++ b/src/Build/BackEnd/Components/IBuildComponentHost.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using BuildParameters = Microsoft.Build.Execution.BuildParameters;

--- a/src/Build/BackEnd/Components/IBuildComponentHost.cs
+++ b/src/Build/BackEnd/Components/IBuildComponentHost.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using BuildParameters = Microsoft.Build.Execution.BuildParameters;
@@ -151,7 +151,7 @@ namespace Microsoft.Build.BackEnd
         /// <summary>
         /// The component which collects telemetry data in worker node and forwards it to the main node.
         /// </summary>
-        TelemetryForwarder,
+        TelemetryCollector,
     }
 
     /// <summary>

--- a/src/Build/BackEnd/Components/Logging/NodeLoggingContext.cs
+++ b/src/Build/BackEnd/Components/Logging/NodeLoggingContext.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Build.Execution;
@@ -36,10 +36,10 @@ namespace Microsoft.Build.BackEnd.Logging
         }
 
         /// <summary>
-        /// Per-engine telemetry forwarder created by the build request engine.
+        /// Per-engine telemetry collector created by the build request engine.
         /// Null when telemetry collection is disabled.
         /// </summary>
-        internal ITelemetryForwarder TelemetryForwarder { get; set; }
+        internal ITelemetryCollector TelemetryCollector { get; set; }
 
         /// <summary>
         /// Log the completion of a build

--- a/src/Build/BackEnd/Components/Logging/NodeLoggingContext.cs
+++ b/src/Build/BackEnd/Components/Logging/NodeLoggingContext.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Build.BackEnd.Logging
         }
 
         /// <summary>
-        /// Per-engine telemetry collector created by the build request engine.
+        /// Per-<see cref="BuildRequestEngine"/> telemetry collector.
         /// Null when telemetry collection is disabled.
         /// </summary>
         internal ITelemetryCollector TelemetryCollector { get; set; }

--- a/src/Build/BackEnd/Components/Logging/NodeLoggingContext.cs
+++ b/src/Build/BackEnd/Components/Logging/NodeLoggingContext.cs
@@ -4,6 +4,7 @@
 using Microsoft.Build.Execution;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
+using Microsoft.Build.TelemetryInfra;
 
 #nullable disable
 
@@ -33,6 +34,12 @@ namespace Microsoft.Build.BackEnd.Logging
 
             this.IsValid = true;
         }
+
+        /// <summary>
+        /// Per-engine telemetry forwarder created by the build request engine.
+        /// Null when telemetry collection is disabled.
+        /// </summary>
+        internal ITelemetryForwarder TelemetryForwarder { get; set; }
 
         /// <summary>
         /// Log the completion of a build

--- a/src/Build/BackEnd/Components/Logging/NodeLoggingContext.cs
+++ b/src/Build/BackEnd/Components/Logging/NodeLoggingContext.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Build.Execution;

--- a/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;

--- a/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -1297,9 +1297,9 @@ namespace Microsoft.Build.BackEnd
 
         private void UpdateStatisticsPostBuild()
         {
-            ITelemetryForwarder telemetryForwarder = _nodeLoggingContext?.TelemetryForwarder;
+            ITelemetryCollector telemetryCollector = _nodeLoggingContext?.TelemetryCollector;
 
-            if (telemetryForwarder is null || !telemetryForwarder.IsTelemetryCollected)
+            if (telemetryCollector is null || !telemetryCollector.IsTelemetryCollected)
             {
                 return;
             }
@@ -1346,7 +1346,7 @@ namespace Microsoft.Build.BackEnd
 
                 var key = new TaskOrTargetTelemetryKey(
                     projectTargetInstance.Key, isCustom, isFromNuget, isMetaprojTarget);
-                telemetryForwarder.AddTarget(key, wasExecuted, skipReason);
+                telemetryCollector.AddTarget(key, wasExecuted, skipReason);
             }
 
             TaskRegistry taskReg = _requestEntry.RequestConfiguration.Project.TaskRegistry;
@@ -1366,7 +1366,7 @@ namespace Microsoft.Build.BackEnd
                         registeredTaskRecord.ComputeIfCustom(),
                         registeredTaskRecord.IsFromNugetCache,
                         isFromMetaProject: false);
-                    telemetryForwarder.AddTask(
+                    telemetryCollector.AddTask(
                         key,
                         registeredTaskRecord.Statistics.ExecutedTime,
                         registeredTaskRecord.Statistics.ExecutedCount,

--- a/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
@@ -1297,11 +1297,9 @@ namespace Microsoft.Build.BackEnd
 
         private void UpdateStatisticsPostBuild()
         {
-            ITelemetryForwarder telemetryForwarder =
-                ((TelemetryForwarderProvider)_componentHost.GetComponent(BuildComponentType.TelemetryForwarder))
-                ?.Instance;
+            ITelemetryForwarder telemetryForwarder = _nodeLoggingContext?.TelemetryForwarder;
 
-            if (telemetryForwarder == null || !telemetryForwarder.IsTelemetryCollected)
+            if (telemetryForwarder is null || !telemetryForwarder.IsTelemetryCollected)
             {
                 return;
             }
@@ -1315,9 +1313,6 @@ namespace Microsoft.Build.BackEnd
             {
                 return;
             }
-
-            // Accumulate all telemetry into a local instance, then merge into the shared singleton once.
-            WorkerNodeTelemetryData telemetryData = new();
 
             foreach (var projectTargetInstance in _requestEntry.RequestConfiguration.Project.Targets)
             {
@@ -1351,13 +1346,11 @@ namespace Microsoft.Build.BackEnd
 
                 var key = new TaskOrTargetTelemetryKey(
                     projectTargetInstance.Key, isCustom, isFromNuget, isMetaprojTarget);
-                telemetryData.AddTarget(key, wasExecuted, skipReason);
+                telemetryForwarder.AddTarget(key, wasExecuted, skipReason);
             }
 
             TaskRegistry taskReg = _requestEntry.RequestConfiguration.Project.TaskRegistry;
             CollectTasksStats(taskReg);
-
-            telemetryForwarder.MergeWorkerData(telemetryData);
 
             void CollectTasksStats(TaskRegistry taskRegistry)
             {
@@ -1373,7 +1366,7 @@ namespace Microsoft.Build.BackEnd
                         registeredTaskRecord.ComputeIfCustom(),
                         registeredTaskRecord.IsFromNugetCache,
                         isFromMetaProject: false);
-                    telemetryData.AddTask(
+                    telemetryForwarder.AddTask(
                         key,
                         registeredTaskRecord.Statistics.ExecutedTime,
                         registeredTaskRecord.Statistics.ExecutedCount,

--- a/src/Build/Microsoft.Build.csproj
+++ b/src/Build/Microsoft.Build.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="..\Shared\DebuggingSources.proj" />
 

--- a/src/Build/Microsoft.Build.csproj
+++ b/src/Build/Microsoft.Build.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="..\Shared\DebuggingSources.proj" />
 
@@ -181,8 +181,8 @@
     <Compile Include="Logging\TerminalLogger\**\*.cs" />
     <Compile Include="Logging\ReusableLogger.cs" />
     <Compile Include="TelemetryInfra\InternalTelemetryConsumingLogger.cs" />
-    <Compile Include="TelemetryInfra\ITelemetryForwarder.cs" />
-    <Compile Include="TelemetryInfra\TelemetryForwarderProvider.cs" />
+    <Compile Include="TelemetryInfra\ITelemetryCollector.cs" />
+    <Compile Include="TelemetryInfra\TelemetryCollectorProvider.cs" />
     <Compile Include="Utilities\AwaitExtensions.cs" />
     <Compile Include="Utilities\EncodingStringWriter.cs" />
     <Compile Include="Utilities\ProjectWriter.cs" />

--- a/src/Build/TelemetryInfra/ITelemetryCollector.cs
+++ b/src/Build/TelemetryInfra/ITelemetryCollector.cs
@@ -9,10 +9,11 @@ using Microsoft.Build.Framework.Telemetry;
 namespace Microsoft.Build.TelemetryInfra;
 
 /// <summary>
-/// Collects task and target telemetry for a single build engine's lifetime.
-/// Not thread-safe: the engine's one-active-builder-at-a-time invariant
-/// guarantees single-threaded access to <see cref="AddTarget"/> and <see cref="AddTask"/>.
-/// Created per engine by <see cref="TelemetryCollectorProvider.CreateCollector"/>.
+/// Collects task and target telemetry for a single <see cref="BuildRequestEngine"/>'s lifetime.
+/// Not thread-safe: only one <see cref="RequestBuilder"/> is active at a time per
+/// <see cref="BuildRequestEngine"/>, so <see cref="AddTarget"/> and <see cref="AddTask"/>
+/// are always called from a single thread.
+/// Created per <see cref="BuildRequestEngine"/> by <see cref="TelemetryCollectorProvider.CreateCollector"/>.
 /// </summary>
 internal interface ITelemetryCollector
 {

--- a/src/Build/TelemetryInfra/ITelemetryCollector.cs
+++ b/src/Build/TelemetryInfra/ITelemetryCollector.cs
@@ -9,11 +9,11 @@ using Microsoft.Build.Framework.Telemetry;
 namespace Microsoft.Build.TelemetryInfra;
 
 /// <summary>
-/// Collects task and target telemetry for a single <see cref="BuildRequestEngine"/>'s lifetime.
-/// Not thread-safe: only one <see cref="RequestBuilder"/> is active at a time per
-/// <see cref="BuildRequestEngine"/>, so <see cref="AddTarget"/> and <see cref="AddTask"/>
+/// Collects task and target telemetry for a single BuildRequestEngine's lifetime.
+/// Not thread-safe: only one RequestBuilder is active at a time per
+/// BuildRequestEngine, so <see cref="AddTarget"/> and <see cref="AddTask"/>
 /// are always called from a single thread.
-/// Created per <see cref="BuildRequestEngine"/> by <see cref="TelemetryCollectorProvider.CreateCollector"/>.
+/// Created per BuildRequestEngine by <see cref="TelemetryCollectorProvider.CreateCollector"/>.
 /// </summary>
 internal interface ITelemetryCollector
 {

--- a/src/Build/TelemetryInfra/ITelemetryCollector.cs
+++ b/src/Build/TelemetryInfra/ITelemetryCollector.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -12,9 +12,9 @@ namespace Microsoft.Build.TelemetryInfra;
 /// Collects task and target telemetry for a single build engine's lifetime.
 /// Not thread-safe: the engine's one-active-builder-at-a-time invariant
 /// guarantees single-threaded access to <see cref="AddTarget"/> and <see cref="AddTask"/>.
-/// Created per engine by <see cref="TelemetryForwarderProvider.CreateForwarder"/>.
+/// Created per engine by <see cref="TelemetryCollectorProvider.CreateCollector"/>.
 /// </summary>
-internal interface ITelemetryForwarder
+internal interface ITelemetryCollector
 {
     bool IsTelemetryCollected { get; }
 

--- a/src/Build/TelemetryInfra/ITelemetryForwarder.cs
+++ b/src/Build/TelemetryInfra/ITelemetryForwarder.cs
@@ -1,26 +1,35 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using Microsoft.Build.BackEnd.Logging;
+using Microsoft.Build.Framework;
 using Microsoft.Build.Framework.Telemetry;
 
 namespace Microsoft.Build.TelemetryInfra;
 
 /// <summary>
-/// A build component responsible for accumulating telemetry data from worker node and then sending it to main node
-/// at the end of the build.
+/// Collects task and target telemetry for a single build engine's lifetime.
+/// Not thread-safe: the engine's one-active-builder-at-a-time invariant
+/// guarantees single-threaded access to <see cref="AddTarget"/> and <see cref="AddTask"/>.
+/// Created per engine by <see cref="TelemetryForwarderProvider.CreateForwarder"/>.
 /// </summary>
 internal interface ITelemetryForwarder
 {
     bool IsTelemetryCollected { get; }
 
-    /// <summary>
-    /// Merges a batch of telemetry data into this forwarder's accumulated state.
-    /// </summary>
-    void MergeWorkerData(IWorkerNodeTelemetryData data);
+    void AddTarget(TaskOrTargetTelemetryKey key, bool wasExecuted, TargetSkipReason skipReason = TargetSkipReason.None);
+
+    void AddTask(
+        TaskOrTargetTelemetryKey key,
+        TimeSpan cumulativeExecutionTime,
+        int executionsCount,
+        long totalMemoryConsumed,
+        string? taskFactoryName,
+        string? taskHostRuntime);
 
     /// <summary>
-    /// Sends accumulated telemetry and resets internal state.
+    /// Sends accumulated telemetry as a <see cref="WorkerNodeTelemetryEventArgs"/> and resets for the next build.
     /// </summary>
     void FinalizeProcessing(LoggingContext loggingContext);
 }

--- a/src/Build/TelemetryInfra/TelemetryCollectorProvider.cs
+++ b/src/Build/TelemetryInfra/TelemetryCollectorProvider.cs
@@ -11,9 +11,9 @@ using Microsoft.Build.Shared;
 namespace Microsoft.Build.TelemetryInfra;
 
 /// <summary>
-/// Build component that creates per-<see cref="BuildRequestEngine"/> <see cref="ITelemetryCollector"/> instances.
-/// Registered as a singleton, but holds no mutable state — each <see cref="BuildRequestEngine"/> gets its own
-/// forwarder via <see cref="CreateCollector"/>.
+/// Build component that creates per-BuildRequestEngine <see cref="ITelemetryCollector"/> instances.
+/// Registered as a singleton, but holds no mutable state — each BuildRequestEngine gets its own
+/// collector via <see cref="CreateCollector"/>.
 /// </summary>
 internal class TelemetryCollectorProvider : IBuildComponent
 {
@@ -24,7 +24,7 @@ internal class TelemetryCollectorProvider : IBuildComponent
     /// Returns a no-op collector when telemetry is disabled.
     /// </summary>
     internal ITelemetryCollector CreateCollector()
-        => _telemetryEnabled ? new telemetryCollector() : NullTelemetryCollector.Instance;
+        => _telemetryEnabled ? new TelemetryCollector() : NullTelemetryCollector.Instance;
 
     internal static IBuildComponent CreateComponent(BuildComponentType type)
     {
@@ -43,10 +43,10 @@ internal class TelemetryCollectorProvider : IBuildComponent
     }
 
     /// <summary>
-    /// Collects task/target telemetry for one <see cref="BuildRequestEngine"/>. Not thread-safe —
-    /// only one <see cref="RequestBuilder"/> is active at a time per <see cref="BuildRequestEngine"/>.
+    /// Collects task/target telemetry for one BuildRequestEngine. Not thread-safe —
+    /// only one RequestBuilder is active at a time per BuildRequestEngine.
     /// </summary>
-    internal class telemetryCollector : ITelemetryCollector
+    internal class TelemetryCollector : ITelemetryCollector
     {
         private WorkerNodeTelemetryData _data = new();
 

--- a/src/Build/TelemetryInfra/TelemetryCollectorProvider.cs
+++ b/src/Build/TelemetryInfra/TelemetryCollectorProvider.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -11,25 +11,25 @@ using Microsoft.Build.Shared;
 namespace Microsoft.Build.TelemetryInfra;
 
 /// <summary>
-/// Build component that creates per-engine <see cref="ITelemetryForwarder"/> instances.
+/// Build component that creates per-engine <see cref="ITelemetryCollector"/> instances.
 /// Registered as a singleton, but holds no mutable state — each engine gets its own
-/// forwarder via <see cref="CreateForwarder"/>.
+/// forwarder via <see cref="CreateCollector"/>.
 /// </summary>
-internal class TelemetryForwarderProvider : IBuildComponent
+internal class TelemetryCollectorProvider : IBuildComponent
 {
     private bool _telemetryEnabled;
 
     /// <summary>
-    /// Creates a new <see cref="ITelemetryForwarder"/> scoped to one engine's build lifetime.
-    /// Returns a no-op forwarder when telemetry is disabled.
+    /// Creates a new <see cref="ITelemetryCollector"/> scoped to one engine's build lifetime.
+    /// Returns a no-op collector when telemetry is disabled.
     /// </summary>
-    internal ITelemetryForwarder CreateForwarder()
-        => _telemetryEnabled ? new TelemetryForwarder() : NullTelemetryForwarder.Instance;
+    internal ITelemetryCollector CreateCollector()
+        => _telemetryEnabled ? new telemetryCollector() : NullTelemetryCollector.Instance;
 
     internal static IBuildComponent CreateComponent(BuildComponentType type)
     {
-        ErrorUtilities.VerifyThrow(type == BuildComponentType.TelemetryForwarder, "Cannot create components of type {0}", type);
-        return new TelemetryForwarderProvider();
+        ErrorUtilities.VerifyThrow(type == BuildComponentType.TelemetryCollector, "Cannot create components of type {0}", type);
+        return new TelemetryCollectorProvider();
     }
 
     public void InitializeComponent(IBuildComponentHost host)
@@ -48,7 +48,7 @@ internal class TelemetryForwarderProvider : IBuildComponent
     /// See <see href="https://github.com/dotnet/msbuild/issues/13531"/> for hardening
     /// the yield/reacquire protocol that this invariant depends on.
     /// </summary>
-    internal class TelemetryForwarder : ITelemetryForwarder
+    internal class telemetryCollector : ITelemetryCollector
     {
         private WorkerNodeTelemetryData _data = new();
 
@@ -80,9 +80,9 @@ internal class TelemetryForwarderProvider : IBuildComponent
         }
     }
 
-    internal class NullTelemetryForwarder : ITelemetryForwarder
+    internal class NullTelemetryCollector : ITelemetryCollector
     {
-        internal static readonly NullTelemetryForwarder Instance = new();
+        internal static readonly NullTelemetryCollector Instance = new();
 
         public bool IsTelemetryCollected => false;
 

--- a/src/Build/TelemetryInfra/TelemetryCollectorProvider.cs
+++ b/src/Build/TelemetryInfra/TelemetryCollectorProvider.cs
@@ -11,8 +11,8 @@ using Microsoft.Build.Shared;
 namespace Microsoft.Build.TelemetryInfra;
 
 /// <summary>
-/// Build component that creates per-engine <see cref="ITelemetryCollector"/> instances.
-/// Registered as a singleton, but holds no mutable state — each engine gets its own
+/// Build component that creates per-<see cref="BuildRequestEngine"/> <see cref="ITelemetryCollector"/> instances.
+/// Registered as a singleton, but holds no mutable state — each <see cref="BuildRequestEngine"/> gets its own
 /// forwarder via <see cref="CreateCollector"/>.
 /// </summary>
 internal class TelemetryCollectorProvider : IBuildComponent
@@ -20,7 +20,7 @@ internal class TelemetryCollectorProvider : IBuildComponent
     private bool _telemetryEnabled;
 
     /// <summary>
-    /// Creates a new <see cref="ITelemetryCollector"/> scoped to one engine's build lifetime.
+    /// Creates a new <see cref="ITelemetryCollector"/> scoped to one <see cref="BuildRequestEngine"/>'s build lifetime.
     /// Returns a no-op collector when telemetry is disabled.
     /// </summary>
     internal ITelemetryCollector CreateCollector()
@@ -43,10 +43,8 @@ internal class TelemetryCollectorProvider : IBuildComponent
     }
 
     /// <summary>
-    /// Collects task/target telemetry for one engine. Not thread-safe — the engine's
-    /// one-active-builder-at-a-time invariant guarantees single-threaded access.
-    /// See <see href="https://github.com/dotnet/msbuild/issues/13531"/> for hardening
-    /// the yield/reacquire protocol that this invariant depends on.
+    /// Collects task/target telemetry for one <see cref="BuildRequestEngine"/>. Not thread-safe —
+    /// only one <see cref="RequestBuilder"/> is active at a time per <see cref="BuildRequestEngine"/>.
     /// </summary>
     internal class telemetryCollector : ITelemetryCollector
     {

--- a/src/Build/TelemetryInfra/TelemetryForwarderProvider.cs
+++ b/src/Build/TelemetryInfra/TelemetryForwarderProvider.cs
@@ -1,22 +1,30 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using Microsoft.Build.BackEnd;
 using Microsoft.Build.BackEnd.Logging;
+using Microsoft.Build.Framework;
 using Microsoft.Build.Framework.Telemetry;
 using Microsoft.Build.Shared;
 
 namespace Microsoft.Build.TelemetryInfra;
 
 /// <summary>
-/// A build component responsible for accumulating telemetry data from worker node and then sending it to main node
-/// at the end of the build.
+/// Build component that creates per-engine <see cref="ITelemetryForwarder"/> instances.
+/// Registered as a singleton, but holds no mutable state — each engine gets its own
+/// forwarder via <see cref="CreateForwarder"/>.
 /// </summary>
 internal class TelemetryForwarderProvider : IBuildComponent
 {
-    private ITelemetryForwarder? _instance;
+    private bool _telemetryEnabled;
 
-    public ITelemetryForwarder Instance => _instance ?? new NullTelemetryForwarder();
+    /// <summary>
+    /// Creates a new <see cref="ITelemetryForwarder"/> scoped to one engine's build lifetime.
+    /// Returns a no-op forwarder when telemetry is disabled.
+    /// </summary>
+    internal ITelemetryForwarder CreateForwarder()
+        => _telemetryEnabled ? new TelemetryForwarder() : NullTelemetryForwarder.Instance;
 
     internal static IBuildComponent CreateComponent(BuildComponentType type)
     {
@@ -27,66 +35,44 @@ internal class TelemetryForwarderProvider : IBuildComponent
     public void InitializeComponent(IBuildComponentHost host)
     {
         ErrorUtilities.VerifyThrow(host != null, "BuildComponentHost was null");
-
-        if (_instance == null)
-        {
-            if (host!.BuildParameters.IsTelemetryEnabled)
-            {
-                _instance = new TelemetryForwarder();
-            }
-            else
-            {
-                _instance = new NullTelemetryForwarder();
-            }
-        }
+        _telemetryEnabled = host!.BuildParameters.IsTelemetryEnabled;
     }
 
     public void ShutdownComponent()
     {
-        /* Too late here for any communication to the main node or for logging anything. Just cleanup. */
-        _instance = null;
     }
 
     /// <summary>
-    /// Active telemetry forwarder that accumulates worker node telemetry.
+    /// Collects task/target telemetry for one engine. Not thread-safe — the engine's
+    /// one-active-builder-at-a-time invariant guarantees single-threaded access.
+    /// See <see href="https://github.com/dotnet/msbuild/issues/13531"/> for hardening
+    /// the yield/reacquire protocol that this invariant depends on.
     /// </summary>
-    /// <remarks>
-    /// Thread-safe: in /m /mt mode, multiple <see cref="BuildRequestEngine"/> instances share a single
-    /// <see cref="TelemetryForwarderProvider"/> singleton, so <see cref="MergeWorkerData"/> and
-    /// <see cref="FinalizeProcessing"/> may be called concurrently from different node threads.
-    /// </remarks>
-    public class TelemetryForwarder : ITelemetryForwarder
+    internal class TelemetryForwarder : ITelemetryForwarder
     {
-        private WorkerNodeTelemetryData _workerNodeTelemetryData = new();
-        private readonly LockType _lock = new();
+        private WorkerNodeTelemetryData _data = new();
 
-        // in future, this might be per event type
         public bool IsTelemetryCollected => true;
 
-        public void MergeWorkerData(IWorkerNodeTelemetryData data)
+        public void AddTarget(TaskOrTargetTelemetryKey key, bool wasExecuted, TargetSkipReason skipReason = TargetSkipReason.None)
         {
-            lock (_lock)
-            {
-                _workerNodeTelemetryData.Add(data);
-            }
+            _data.AddTarget(key, wasExecuted, skipReason);
         }
 
+        public void AddTask(TaskOrTargetTelemetryKey key, TimeSpan cumulativeExecutionTime, int executionsCount, long totalMemoryConsumed, string? taskFactoryName, string? taskHostRuntime)
+        {
+            _data.AddTask(key, cumulativeExecutionTime, executionsCount, totalMemoryConsumed, taskFactoryName, taskHostRuntime);
+        }
 
         public void FinalizeProcessing(LoggingContext loggingContext)
         {
-            WorkerNodeTelemetryData snapshot;
-
-            lock (_lock)
+            if (_data.IsEmpty)
             {
-                // Nothing accumulated since the last call — skip sending.
-                if (_workerNodeTelemetryData.IsEmpty)
-                {
-                    return;
-                }
-
-                snapshot = _workerNodeTelemetryData;
-                _workerNodeTelemetryData = new();
+                return;
             }
+
+            WorkerNodeTelemetryData snapshot = _data;
+            _data = new();
 
             WorkerNodeTelemetryEventArgs telemetryArgs = new(snapshot)
             { BuildEventContext = loggingContext.BuildEventContext };
@@ -94,11 +80,15 @@ internal class TelemetryForwarderProvider : IBuildComponent
         }
     }
 
-    public class NullTelemetryForwarder : ITelemetryForwarder
+    internal class NullTelemetryForwarder : ITelemetryForwarder
     {
+        internal static readonly NullTelemetryForwarder Instance = new();
+
         public bool IsTelemetryCollected => false;
 
-        public void MergeWorkerData(IWorkerNodeTelemetryData data) { }
+        public void AddTarget(TaskOrTargetTelemetryKey key, bool wasExecuted, TargetSkipReason skipReason = TargetSkipReason.None) { }
+
+        public void AddTask(TaskOrTargetTelemetryKey key, TimeSpan cumulativeExecutionTime, int executionsCount, long totalMemoryConsumed, string? taskFactoryName, string? taskHostRuntime) { }
 
         public void FinalizeProcessing(LoggingContext loggingContext) { }
     }


### PR DESCRIPTION
### Context

PR #13413 fixed thread-safety in telemetry by creating a **local `WorkerNodeTelemetryData`** (with 2 `Dictionary<>` instances) per build request, populating it with all targets/tasks, then merging under a lock into a shared singleton. This introduced a ~200MB allocation regression on large solutions, affecting **both MT and non-MT modes** (the pattern was applied unconditionally).

### Architecture: before, after #13413, and now

**Before #13413** (broken in MT mode):
```
TelemetryForwarderProvider  [Singleton, shared across all engines]
  +-- TelemetryForwarder
        +-- WorkerNodeTelemetryData  [one shared dict, NO locking]

RequestBuilder1 --AddTarget/AddTask--> shared dict  <-- RACE
RequestBuilder2 --AddTarget/AddTask--> shared dict  <-- RACE

Engine1.FinalizeProcessing() -> sends ALL data
Engine2.FinalizeProcessing() -> sends ALL data again  <-- Nx DUPLICATION
```

**After #13413** (correct but 200MB regression):
```
TelemetryForwarderProvider  [Singleton, shared across all engines]
  +-- TelemetryForwarder
        +-- WorkerNodeTelemetryData  [shared dict, with lock]
        +-- FinalizeProcessing: swap-and-send (fixes duplication)

RequestBuilder (per request):
  new WorkerNodeTelemetryData()  <-- 2 fresh Dictionary<> per request
  populate with ~200 targets, ~60 tasks (6-7 resize steps each)
  forwarder.MergeWorkerData(localData)  <-- merge under lock, discard local

  ~30KB alloc churn x ~1000 requests/node x N nodes = ~200MB
```

**This PR** (correct, zero per-request allocations):
```
TelemetryForwarderProvider  [Singleton, but just a factory now]
  +-- CreateForwarder() -> new TelemetryForwarder per engine

BuildRequestEngine1                    BuildRequestEngine2
  +-- TelemetryForwarder1               +-- TelemetryForwarder2
        +-- data (no lock needed)             +-- data (no lock needed)

RequestBuilder --AddTarget/AddTask--> own engine forwarder
                                      NO local dicts, NO singleton contention

Engine1.FinalizeProcessing() -> sends only Engine1 data
Engine2.FinalizeProcessing() -> sends only Engine2 data
InternalTelemetryConsumingLogger merges all events (unchanged)
```

No locking is needed because the engine one-active-builder-at-a-time invariant guarantees single-threaded access (see #13531 for hardening the yield/reacquire protocol this depends on).

### Measured regression (OrchardCore, 233 projects)

| Metric | Value |
|--------|-------|
| Avg targets/project | ~199 (range 112-593) |
| Build requests/node | ~1000 (inner builds, metaprojects) |
| Per-request alloc overhead | ~30 KB (Entry[], Int32[], TaskExecutionStats) |
| Per-node regression | ~30 MB |
| x multiple nodes | **~200 MB total** |

### Commit structure

1. **Functional change** - move telemetry ownership to per-engine (keeps old Forwarder names)
2. **Pure rename** - TelemetryForwarder -> TelemetryCollector (no behavioral changes)

### Testing
- All 32 telemetry unit tests pass
- Full build succeeds with 0 warnings, 0 errors
- Red-teamed from 5 perspectives (thread safety, data completeness, duplication, node lifecycle, consumer compatibility)