### PR TITLE
RoslynCodeTaskFactory: Log MSB3753 when task class does not implement ITask

### DIFF
--- a/src/Tasks.UnitTests/RoslynCodeTaskFactory_Tests.cs
+++ b/src/Tasks.UnitTests/RoslynCodeTaskFactory_Tests.cs
@@ -784,6 +784,49 @@ namespace InlineTask
             }
         }
 
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void ClassDoesNotInheritFromITask(bool forceOutOfProc)
+        {
+            const string taskName = "ClassDoesNotInheritFromITask";
+            string unformattedMessage = ResourceUtilities.GetResourceString("CodeTaskFactory.NeedsITaskInterface");
+
+            string projectContent = $$"""
+                <Project>
+                  <UsingTask TaskName="{{taskName}}" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
+                    <Task>
+                      <Code Type="Class">
+                namespace InlineTask
+                {
+                    public class {{taskName}}
+                    {
+                        public bool Execute()
+                        {
+                            return true;
+                        }
+                    }
+                }
+                      </Code>
+                    </Task>
+                  </UsingTask>
+                  <Target Name="Build">
+                    <{{taskName}} />
+                  </Target>
+                </Project>
+                """;
+
+            using TestEnvironment env = TestEnvironment.Create();
+            if (forceOutOfProc)
+            {
+                env.SetEnvironmentVariable("MSBUILDFORCEINLINETASKFACTORIESOUTOFPROC", "1");
+            }
+
+            TransientTestProjectWithFiles proj = env.CreateTestProjectWithFiles(projectContent);
+            MockLogger logger = proj.BuildProjectExpectFailure();
+            logger.AssertLogContains(unformattedMessage);
+        }
+
         [Fact]
         public void EmbedsGeneratedFromSourceFileInBinlog()
         {
@@ -908,6 +951,46 @@ namespace InlineTask
             logLines.Where(l => l.Contains(dotnetPath)).Count().ShouldBe(1, log);
         }
 #endif
+
+        [Fact]
+        public void BuildRoslynCodeTaskFactoryTempDirectoryDoesntExist()
+        {
+            string text = """
+                <Project>
+                  <UsingTask TaskName="MyTempDirTask" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
+                    <ParameterGroup>
+                      <Text />
+                    </ParameterGroup>
+                    <Task>
+                      <Code Type="Fragment" Language="cs">
+                        Log.LogMessage(MessageImportance.High, Text);
+                      </Code>
+                    </Task>
+                  </UsingTask>
+                  <Target Name="Build">
+                    <MyTempDirTask Text="Hello, World!" />
+                  </Target>
+                </Project>
+                """;
+
+            var newTempPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+
+            using var env = TestEnvironment.Create();
+
+            Directory.Exists(newTempPath).ShouldBeFalse();
+            env.SetEnvironmentVariable("TMP", newTempPath);
+            env.SetEnvironmentVariable("TMPDIR", newTempPath);
+
+            try
+            {
+                MockLogger logger = Helpers.BuildProjectWithNewOMExpectSuccess(text);
+                logger.AssertLogContains("Hello, World!");
+            }
+            finally
+            {
+                FileUtilities.DeleteDirectoryNoThrow(newTempPath, true);
+            }
+        }
 
         private void TryLoadTaskBodyAndExpectFailure(string taskBody, string expectedErrorMessage)
         {

--- a/src/Tasks.UnitTests/RoslynCodeTaskFactory_Tests.cs
+++ b/src/Tasks.UnitTests/RoslynCodeTaskFactory_Tests.cs
@@ -18,6 +18,7 @@ using Shouldly;
 using VerifyTests;
 using VerifyXunit;
 using Xunit;
+using Xunit.Abstractions;
 
 using static VerifyXunit.Verifier;
 
@@ -32,8 +33,11 @@ namespace Microsoft.Build.Tasks.UnitTests
 
         private readonly VerifySettings _verifySettings;
 
-        public RoslynCodeTaskFactory_Tests()
+        private readonly ITestOutputHelper _testOutput;
+
+        public RoslynCodeTaskFactory_Tests(ITestOutputHelper testOutput)
         {
+            _testOutput = testOutput;
             UseProjectRelativeDirectory("TaskFactorySource");
 
             _verifySettings = new();
@@ -816,7 +820,7 @@ namespace InlineTask
                 </Project>
                 """;
 
-            using TestEnvironment env = TestEnvironment.Create();
+            using TestEnvironment env = TestEnvironment.Create(_testOutput);
             if (forceOutOfProc)
             {
                 env.SetEnvironmentVariable("MSBUILDFORCEINLINETASKFACTORIESOUTOFPROC", "1");

--- a/src/Tasks.UnitTests/RoslynCodeTaskFactory_Tests.cs
+++ b/src/Tasks.UnitTests/RoslynCodeTaskFactory_Tests.cs
@@ -952,46 +952,6 @@ namespace InlineTask
         }
 #endif
 
-        [Fact]
-        public void BuildRoslynCodeTaskFactoryTempDirectoryDoesntExist()
-        {
-            string text = """
-                <Project>
-                  <UsingTask TaskName="MyTempDirTask" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
-                    <ParameterGroup>
-                      <Text />
-                    </ParameterGroup>
-                    <Task>
-                      <Code Type="Fragment" Language="cs">
-                        Log.LogMessage(MessageImportance.High, Text);
-                      </Code>
-                    </Task>
-                  </UsingTask>
-                  <Target Name="Build">
-                    <MyTempDirTask Text="Hello, World!" />
-                  </Target>
-                </Project>
-                """;
-
-            var newTempPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
-
-            using var env = TestEnvironment.Create();
-
-            Directory.Exists(newTempPath).ShouldBeFalse();
-            env.SetEnvironmentVariable("TMP", newTempPath);
-            env.SetEnvironmentVariable("TMPDIR", newTempPath);
-
-            try
-            {
-                MockLogger logger = Helpers.BuildProjectWithNewOMExpectSuccess(text);
-                logger.AssertLogContains("Hello, World!");
-            }
-            finally
-            {
-                FileUtilities.DeleteDirectoryNoThrow(newTempPath, true);
-            }
-        }
-
         private void TryLoadTaskBodyAndExpectFailure(string taskBody, string expectedErrorMessage)
         {
             if (expectedErrorMessage == null)

--- a/src/Tasks/RoslynCodeTaskFactory/RoslynCodeTaskFactory.cs
+++ b/src/Tasks/RoslynCodeTaskFactory/RoslynCodeTaskFactory.cs
@@ -141,7 +141,13 @@ namespace Microsoft.Build.Tasks
         {
             // The type of the task has already been determined and the assembly is already loaded after compilation so
             // just create an instance of the type and return it.
-            return Activator.CreateInstance(TaskType) as ITask;
+            ITask taskInstance = Activator.CreateInstance(TaskType) as ITask;
+            if (taskInstance is null)
+            {
+                _log.LogErrorWithCodeFromResources("CodeTaskFactory.NeedsITaskInterface", _taskName);
+            }
+
+            return taskInstance;
         }
 
         /// <inheritdoc cref="ITaskFactory.GetTaskParameters"/>

--- a/src/Tasks/RoslynCodeTaskFactory/RoslynCodeTaskFactory.cs
+++ b/src/Tasks/RoslynCodeTaskFactory/RoslynCodeTaskFactory.cs
@@ -144,7 +144,8 @@ namespace Microsoft.Build.Tasks
             ITask taskInstance = Activator.CreateInstance(TaskType) as ITask;
             if (taskInstance is null)
             {
-                _log.LogErrorWithCodeFromResources("CodeTaskFactory.NeedsITaskInterface", _taskName);
+                TaskLoggingHelper taskInvocationLog = new TaskLoggingHelper(taskFactoryLoggingHost, _taskName);
+                taskInvocationLog.LogErrorWithCodeFromResources("CodeTaskFactory.NeedsITaskInterface", _taskName);
             }
 
             return taskInstance;

--- a/src/Tasks/RoslynCodeTaskFactory/RoslynCodeTaskFactory.cs
+++ b/src/Tasks/RoslynCodeTaskFactory/RoslynCodeTaskFactory.cs
@@ -144,7 +144,11 @@ namespace Microsoft.Build.Tasks
             ITask taskInstance = Activator.CreateInstance(TaskType) as ITask;
             if (taskInstance is null)
             {
-                TaskLoggingHelper taskInvocationLog = new TaskLoggingHelper(taskFactoryLoggingHost, _taskName);
+                TaskLoggingHelper taskInvocationLog = new TaskLoggingHelper(taskFactoryLoggingHost, _taskName)
+                {
+                    TaskResources = AssemblyResources.PrimaryResources,
+                    HelpKeywordPrefix = "MSBuild."
+                };
                 taskInvocationLog.LogErrorWithCodeFromResources("CodeTaskFactory.NeedsITaskInterface", _taskName);
             }
 


### PR DESCRIPTION
## Summary

`RoslynCodeTaskFactory.CreateTask()` silently returned `null` when the inline task class did not implement `ITask`, causing the engine to emit the generic MSB4060 error. `CodeTaskFactory` already checks for this and emits the more specific MSB3753 (`CodeTaskFactory.NeedsITaskInterface`).

## Changes

- **`RoslynCodeTaskFactory.cs`**: Added null check after `Activator.CreateInstance(TaskType) as ITask` — logs MSB3753 via the existing `_log` instance (set during `Initialize`), matching `CodeTaskFactory` behavior.
- **`RoslynCodeTaskFactory_Tests.cs`**: Added `ClassDoesNotInheritFromITask` test covering both in-proc and out-of-proc (`MSBUILDFORCEINLINETASKFACTORIESOUTOFPROC`) paths.

## Context

I noticed this when trying to migrate usage of CodeTaskFactory to RoslynCodeTaskFactory and checking for coverage parity between these two factories as part of that.

The `CodeTaskFactory` equivalent test (`CodeTaskFactoryTests.cs`) already validates this behavior. This was an oversight in `RoslynCodeTaskFactory` — the two factories should produce the same diagnostic for this user error.