### PR TITLE
Add platform-specific build infrastructure (TargetOS, TARGET_WINDOWS…)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,29 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
+
+  <PropertyGroup Label="CalculateArch">
+    <BuildArchitecture Condition="'$(BuildArchitecture)' == ''">$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture.ToString().ToLowerInvariant())</BuildArchitecture>
+    <TargetArchitecture Condition="'$(TargetArchitecture)' == '' AND ('$(BuildArchitecture)' == 'arm64' OR '$(BuildArchitecture)' == 's390x' OR '$(BuildArchitecture)' == 'ppc64le' OR '$(BuildArchitecture)' == 'loongarch64')">$(BuildArchitecture)</TargetArchitecture>
+    <TargetArchitecture Condition="'$(TargetArchitecture)' == ''">x64</TargetArchitecture>
+  </PropertyGroup>
+
+  <!-- Host and target OS detection.
+       Uses full OS names (windows, linux, osx, freebsd, etc.) matching the VMR convention.
+       See https://github.com/dotnet/dotnet/blob/main/docs/VMR-Controls.md#output-controls -->
+  <PropertyGroup Label="CalculateTargetOS">
+    <HostOS Condition="'$(HostOS)' == '' AND $([MSBuild]::IsOSPlatform('WINDOWS'))">windows</HostOS>
+    <HostOS Condition="'$(HostOS)' == '' AND $([MSBuild]::IsOSPlatform('OSX'))">osx</HostOS>
+    <HostOS Condition="'$(HostOS)' == '' AND $([MSBuild]::IsOSPlatform('FREEBSD'))">freebsd</HostOS>
+    <HostOS Condition="'$(HostOS)' == '' AND $([MSBuild]::IsOSPlatform('OPENBSD'))">openbsd</HostOS>
+    <HostOS Condition="'$(HostOS)' == '' AND $([MSBuild]::IsOSPlatform('ILLUMOS'))">illumos</HostOS>
+    <HostOS Condition="'$(HostOS)' == '' AND $([MSBuild]::IsOSPlatform('SOLARIS'))">solaris</HostOS>
+    <HostOS Condition="'$(HostOS)' == '' AND $([MSBuild]::IsOSPlatform('HAIKU'))">haiku</HostOS>
+    <HostOS Condition="'$(HostOS)' == '' AND $([MSBuild]::IsOSPlatform('LINUX'))">linux</HostOS>
+
+    <!-- TargetOS defaults to HostOS; overridable via /p:TargetOS from build scripts or VMR. -->
+    <TargetOS Condition="'$(TargetOS)' == ''">$(HostOS)</TargetOS>
+  </PropertyGroup>
+
   <Import Project="Sdk.props" Sdk="Microsoft.DotNet.Arcade.Sdk" />
 
   <PropertyGroup Condition="'$(CopyrightNetFoundation)' != ''">
@@ -67,6 +91,8 @@ ates https://learn.microsoft.com/en-gb/dotnet/fundamentals/syslib-diagnostics/sy
          version numbers. This is ok in that context, since VMR-produced MSBuild packages won't
          be published. -->
     <NoWarn Condition="'$(DotNetBuild)' == 'true'">$(NoWarn);NU5104;</NoWarn>
+
+    <DefineConstants Condition="'$(TargetOS)' == 'windows'">$(DefineConstants);TARGET_WINDOWS</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -58,4 +58,14 @@
                Condition="Exists('$(_PackageFolderInGlobalPackages)')" />
   </Target>
 
+  <!-- Diagnostic target for verifying platform property resolution -->
+  <Target Name="ShowPlatformProperties"
+          BeforeTargets="Build"
+          Condition="'$(ShowPlatformProperties)' == 'true'">
+    <Message Importance="high" Text="HostOS              = $(HostOS)" />
+    <Message Importance="high" Text="TargetOS            = $(TargetOS)" />
+    <Message Importance="high" Text="BuildArchitecture   = $(BuildArchitecture)" />
+    <Message Importance="high" Text="TargetArchitecture  = $(TargetArchitecture)" />
+  </Target>
+
 </Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -36,7 +36,7 @@
 
     <!-- Target frameworks for Exe and unit test projects (ie projects with runtime output) -->
     <RuntimeOutputTargetFrameworks>$(LatestDotNetCoreForMSBuild)</RuntimeOutputTargetFrameworks>
-    <RuntimeOutputTargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(FullFrameworkTFM);$(RuntimeOutputTargetFrameworks)</RuntimeOutputTargetFrameworks>
+    <RuntimeOutputTargetFrameworks Condition="'$(TargetOS)' == 'windows'">$(FullFrameworkTFM);$(RuntimeOutputTargetFrameworks)</RuntimeOutputTargetFrameworks>
 
     <!-- Don't automatically append target framework to output path, since we want to put the Platform Target beforehand, if it's not AnyCPU -->
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>


### PR DESCRIPTION
This will facilitate conditionalizing OS specific code to reduce assembly size and make VMR integration easier. In particular, shifting to direct interop on Windows with CsWin32 will improve startup time and allow more code to run in AOT scenarios (notably in parts of the CLI).

Introduce centralized OS/architecture detection and platform-specific
C# preprocessor defines, following the patterns in the SDK repo.