### PR TITLE
Replace WMI with NtQueryInformationProcess for process command line retrieval

### DIFF
--- a/src/Framework/Utilities/ProcessExtensions.cs
+++ b/src/Framework/Utilities/ProcessExtensions.cs
@@ -11,6 +11,7 @@ using System.IO;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using System.Text;
+using Microsoft.Win32.SafeHandles;
 #endif
 
 namespace Microsoft.Build.Shared
@@ -166,478 +167,90 @@ namespace Microsoft.Build.Shared
 
 #if NET
         /// <summary>
-        /// Windows-specific command line retrieval via WMI COM interfaces.
-        /// Queries Win32_Process for the CommandLine property using IWbemLocator/IWbemServices.
+        /// Windows-specific command line retrieval via NtQueryInformationProcess
+        /// with ProcessCommandLineInformation (info class 60).
         /// </summary>
         [SupportedOSPlatform("windows")]
         private static class Windows
         {
-            // WMI COM interface GUIDs
-            private static readonly Guid CLSID_WbemLocator = new Guid("4590F811-1D3A-11D0-891F-00AA004B2E24");
-            private static readonly Guid IID_IWbemLocator = new Guid("DC12A687-737F-11CF-884D-00AA004B2E24");
+            private const int ProcessCommandLineInformation = 60;
+            private const int PROCESS_QUERY_LIMITED_INFORMATION = 0x1000;
+            private const int STATUS_SUCCESS = 0;
+            private const int STATUS_INFO_LENGTH_MISMATCH = unchecked((int)0xC0000004);
+            private const int STATUS_BUFFER_TOO_SMALL = unchecked((int)0xC0000023);
+            private const int STATUS_BUFFER_OVERFLOW = unchecked((int)0x80000005);
 
-            // WBEM status codes
-            private const int WBEM_S_NO_ERROR = 0;
-            private const int WBEM_S_FALSE = 1; // No more objects in enumeration
-            private const int WBEM_FLAG_FORWARD_ONLY = 0x00000020;
-            private const int WBEM_FLAG_RETURN_IMMEDIATELY = 0x00000010;
-            private const int WBEM_INFINITE = -1;
-
-
-            // RPC authentication/impersonation constants (used by CoInitializeSecurity and CoSetProxyBlanket)
-            private const int RPC_C_AUTHN_LEVEL_DEFAULT = 0;
-            private const int RPC_C_AUTHN_LEVEL_CALL = 3;
-            private const int RPC_C_IMP_LEVEL_IMPERSONATE = 3;
-            private const int RPC_C_AUTHN_WINNT = 10;
-            private const int RPC_C_AUTHZ_NONE = 0;
-            private const int EOAC_NONE = 0;
-
-            // CoCreateInstance: in-process server
-            private const int CLSCTX_INPROC_SERVER = 1;
-
-            // HRESULTs for conditions that are not fatal failures
-            private const int RPC_E_TOO_LATE = unchecked((int)0x80010119);     // CoInitializeSecurity already called
-
-            [DllImport("ole32.dll")]
-            private static extern int CoInitializeEx(IntPtr pvReserved, int dwCoInit);
-
-            [DllImport("ole32.dll")]
-            private static extern int CoInitializeSecurity(
-                IntPtr pSecDesc,
-                int cAuthSvc,
-                IntPtr asAuthSvc,
-                IntPtr pReserved,
-                int dwAuthnLevel,
-                int dwImpLevel,
-                IntPtr pAuthList,
-                int dwCapabilities,
-                IntPtr pReserved3);
-
-            [DllImport("ole32.dll")]
-            private static extern int CoCreateInstance(
-                ref Guid rclsid,
-                IntPtr pUnkOuter,
-                int dwClsContext,
-                ref Guid riid,
-                [MarshalAs(UnmanagedType.Interface)] out IWbemLocator ppv);
-
-            [DllImport("ole32.dll")]
-            private static extern int CoSetProxyBlanket(
-                [MarshalAs(UnmanagedType.IUnknown)] object pProxy,
-                int dwAuthnSvc,
-                int dwAuthzSvc,
-                IntPtr pServerPrincName,
-                int dwAuthnLevel,
-                int dwImpLevel,
-                IntPtr pAuthInfo,
-                int dwCapabilities);
-
-            [ComImport]
-            [Guid("DC12A687-737F-11CF-884D-00AA004B2E24")]
-            [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-            private interface IWbemLocator
+            [StructLayout(LayoutKind.Sequential)]
+            private struct UNICODE_STRING
             {
-                [PreserveSig]
-                int ConnectServer(
-                    [MarshalAs(UnmanagedType.BStr)] string strNetworkResource,
-                    [MarshalAs(UnmanagedType.BStr)] string? strUser,
-                    [MarshalAs(UnmanagedType.BStr)] string? strPassword,
-                    [MarshalAs(UnmanagedType.BStr)] string? strLocale,
-                    int lSecurityFlags,
-                    [MarshalAs(UnmanagedType.BStr)] string? strAuthority,
-                    IntPtr pCtx,
-                    [MarshalAs(UnmanagedType.Interface)] out IWbemServices ppNamespace);
+                public ushort Length;
+                public ushort MaximumLength;
+                public IntPtr Buffer;
             }
 
-            [Guid("44ACA674-E8FC-11D0-A07C-00C04FB68820")]
-            [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-            [ComImport]
-            internal interface IWbemContext
-            {
-                [PreserveSig]
-                int Clone([MarshalAs(UnmanagedType.Interface)] out IWbemContext ppNewCopy);
+            [DllImport("kernel32.dll", SetLastError = true)]
+            private static extern SafeProcessHandle OpenProcess(int dwDesiredAccess, [MarshalAs(UnmanagedType.Bool)] bool bInheritHandle, int dwProcessId);
 
-                [PreserveSig]
-                int GetNames(int lFlags, IntPtr pNames);
-
-                [PreserveSig]
-                int BeginEnumeration(int lFlags);
-
-                [PreserveSig]
-                int Next(int lFlags, [MarshalAs(UnmanagedType.BStr)] out string pstrName, IntPtr pValue);
-
-                [PreserveSig]
-                int EndEnumeration();
-
-                [PreserveSig]
-                int SetValue([MarshalAs(UnmanagedType.LPWStr)] string wszName, int lFlags, IntPtr pValue);
-
-                [PreserveSig]
-                int GetValue([MarshalAs(UnmanagedType.LPWStr)] string wszName, int lFlags, IntPtr pValue);
-
-                [PreserveSig]
-                int DeleteValue([MarshalAs(UnmanagedType.LPWStr)] string wszName, int lFlags);
-
-                [PreserveSig]
-                int DeleteAll();
-            }
-
-            [ComImport]
-            [Guid("9556DC99-828C-11CF-A37E-00AA003240C7")]
-            [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-            private interface IWbemServices
-            {
-                [PreserveSig]
-                int OpenNamespace(
-                    [MarshalAs(UnmanagedType.BStr)] string strNamespace,
-                    int lFlags,
-                    IntPtr pCtx,
-                    IntPtr ppWorkingNamespace,
-                    IntPtr ppResult);
-
-                [PreserveSig]
-                int CancelAsyncCall(IntPtr pSink);
-
-                [PreserveSig]
-                int QueryObjectSink(int lFlags, IntPtr ppResponseHandler);
-
-                [PreserveSig]
-                int GetObject(
-                    [MarshalAs(UnmanagedType.BStr)] string strObjectPath,
-                    int lFlags,
-                    IntPtr pCtx,
-                    IntPtr ppObject,
-                    IntPtr ppCallResult);
-
-                [PreserveSig]
-                int GetObjectAsync(
-                    [MarshalAs(UnmanagedType.BStr)] string strObjectPath,
-                    int lFlags,
-                    IntPtr pCtx,
-                    IntPtr pResponseHandler);
-
-                [PreserveSig]
-                int PutClass(IntPtr pObject, int lFlags, IntPtr pCtx, IntPtr ppCallResult);
-
-                [PreserveSig]
-                int PutClassAsync(IntPtr pObject, int lFlags, IntPtr pCtx, IntPtr pResponseHandler);
-
-                [PreserveSig]
-                int DeleteClass(
-                    [MarshalAs(UnmanagedType.BStr)] string strClass,
-                    int lFlags,
-                    IntPtr pCtx,
-                    IntPtr ppCallResult);
-
-                [PreserveSig]
-                int DeleteClassAsync(
-                    [MarshalAs(UnmanagedType.BStr)] string strClass,
-                    int lFlags,
-                    IntPtr pCtx,
-                    IntPtr pResponseHandler);
-
-                [PreserveSig]
-                int CreateClassEnum(
-                    [MarshalAs(UnmanagedType.BStr)] string strSuperclass,
-                    int lFlags,
-                    IntPtr pCtx,
-                    [MarshalAs(UnmanagedType.Interface)] out IEnumWbemClassObject ppEnum);
-
-                [PreserveSig]
-                int CreateClassEnumAsync(
-                    [MarshalAs(UnmanagedType.BStr)] string strSuperclass,
-                    int lFlags,
-                    IntPtr pCtx,
-                    IntPtr pResponseHandler);
-
-                [PreserveSig]
-                int PutInstance(IntPtr pInst, int lFlags, IntPtr pCtx, IntPtr ppCallResult);
-
-                [PreserveSig]
-                int PutInstanceAsync(IntPtr pInst, int lFlags, IntPtr pCtx, IntPtr pResponseHandler);
-
-                [PreserveSig]
-                int DeleteInstance(
-                    [MarshalAs(UnmanagedType.BStr)] string strObjectPath,
-                    int lFlags,
-                    IntPtr pCtx,
-                    IntPtr ppCallResult);
-
-                [PreserveSig]
-                int DeleteInstanceAsync(
-                    [MarshalAs(UnmanagedType.BStr)] string strObjectPath,
-                    int lFlags,
-                    IntPtr pCtx,
-                    IntPtr pResponseHandler);
-
-                [PreserveSig]
-                int CreateInstanceEnum(
-                    [MarshalAs(UnmanagedType.BStr)] string strFilter,
-                    int lFlags,
-                    IntPtr pCtx,
-                    [MarshalAs(UnmanagedType.Interface)] out IEnumWbemClassObject ppEnum);
-
-                [PreserveSig]
-                int CreateInstanceEnumAsync(
-                    [MarshalAs(UnmanagedType.BStr)] string strFilter,
-                    int lFlags,
-                    IntPtr pCtx,
-                    IntPtr pResponseHandler);
-
-                [PreserveSig]
-                int ExecQuery(
-                    [In][MarshalAs(UnmanagedType.BStr)] string strQueryLanguage,
-                    [In][MarshalAs(UnmanagedType.BStr)] string strQuery,
-                    [In] int lFlags,
-                    [In] IWbemContext? pCtx,
-                    [MarshalAs(UnmanagedType.Interface)] out IEnumWbemClassObject ppEnum);
-
-                [PreserveSig]
-                int ExecQueryAsync(
-                    [MarshalAs(UnmanagedType.BStr)] string strQueryLanguage,
-                    [MarshalAs(UnmanagedType.BStr)] string strQuery,
-                    int lFlags,
-                    IntPtr pCtx,
-                    IntPtr pResponseHandler);
-
-                [PreserveSig]
-                int ExecNotificationQuery(
-                    [MarshalAs(UnmanagedType.BStr)] string strQueryLanguage,
-                    [MarshalAs(UnmanagedType.BStr)] string strQuery,
-                    int lFlags,
-                    IntPtr pCtx,
-                    IntPtr ppEnum);
-
-                [PreserveSig]
-                int ExecNotificationQueryAsync(
-                    [MarshalAs(UnmanagedType.BStr)] string strQueryLanguage,
-                    [MarshalAs(UnmanagedType.BStr)] string strQuery,
-                    int lFlags,
-                    IntPtr pCtx,
-                    IntPtr pResponseHandler);
-
-                [PreserveSig]
-                int ExecMethod(
-                    [MarshalAs(UnmanagedType.BStr)] string strObjectPath,
-                    [MarshalAs(UnmanagedType.BStr)] string strMethodName,
-                    int lFlags,
-                    IntPtr pCtx,
-                    IntPtr pInParams,
-                    IntPtr ppOutParams,
-                    IntPtr ppCallResult);
-
-                [PreserveSig]
-                int ExecMethodAsync(
-                    [MarshalAs(UnmanagedType.BStr)] string strObjectPath,
-                    [MarshalAs(UnmanagedType.BStr)] string strMethodName,
-                    int lFlags,
-                    IntPtr pCtx,
-                    IntPtr pInParams,
-                    IntPtr pResponseHandler);
-            }
-
-            [ComImport]
-            [Guid("027947E1-D731-11CE-A357-000000000001")]
-            [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-            private interface IEnumWbemClassObject
-            {
-                [PreserveSig]
-                int Reset();
-
-                [PreserveSig]
-                int Next(
-                    int lTimeout,
-                    uint uCount,
-                    [MarshalAs(UnmanagedType.Interface)] out IWbemClassObject apObjects,
-                    out uint puReturned);
-
-                [PreserveSig]
-                int NextAsync(uint uCount, IntPtr pSink);
-
-                [PreserveSig]
-                int Clone([MarshalAs(UnmanagedType.Interface)] out IEnumWbemClassObject ppEnum);
-
-                [PreserveSig]
-                int Skip(int lTimeout, uint nCount);
-            }
-
-            [ComImport]
-            [Guid("DC12A681-737F-11CF-884D-00AA004B2E24")]
-            [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-            private interface IWbemClassObject
-            {
-                [PreserveSig]
-                int GetQualifierSet(IntPtr ppQualSet);
-
-                [PreserveSig]
-                int Get(
-                    [MarshalAs(UnmanagedType.LPWStr)] string wszName,
-                    int lFlags,
-                    ref object pVal,
-                    IntPtr pType,
-                    IntPtr plFlavor);
-
-                [PreserveSig]
-                int Put([MarshalAs(UnmanagedType.LPWStr)] string wszName, int lFlags, ref object pVal, int type);
-
-                [PreserveSig]
-                int Delete([MarshalAs(UnmanagedType.LPWStr)] string wszName);
-
-                [PreserveSig]
-                int GetNames([MarshalAs(UnmanagedType.LPWStr)] string wszQualifierName, int lFlags, ref object pQualifierVal, IntPtr pNames);
-
-                [PreserveSig]
-                int BeginEnumeration(int lEnumFlags);
-
-                [PreserveSig]
-                int Next(int lFlags, [MarshalAs(UnmanagedType.BStr)] out string strName, ref object pVal, IntPtr pType, IntPtr plFlavor);
-
-                [PreserveSig]
-                int EndEnumeration();
-
-                [PreserveSig]
-                int GetPropertyQualifierSet([MarshalAs(UnmanagedType.LPWStr)] string wszProperty, IntPtr ppQualSet);
-
-                [PreserveSig]
-                int Clone([MarshalAs(UnmanagedType.Interface)] out IWbemClassObject ppCopy);
-
-                [PreserveSig]
-                int GetObjectText(int lFlags, [MarshalAs(UnmanagedType.BStr)] out string pstrObjectText);
-
-                [PreserveSig]
-                int SpawnDerivedClass(int lFlags, IntPtr ppNewClass);
-
-                [PreserveSig]
-                int SpawnInstance(int lFlags, IntPtr ppNewInstance);
-
-                [PreserveSig]
-                int CompareTo(int lFlags, IntPtr pCompareTo);
-
-                [PreserveSig]
-                int GetPropertyOrigin([MarshalAs(UnmanagedType.LPWStr)] string wszName, [MarshalAs(UnmanagedType.BStr)] out string pstrClassName);
-
-                [PreserveSig]
-                int InheritsFrom([MarshalAs(UnmanagedType.LPWStr)] string strAncestor);
-
-                [PreserveSig]
-                int GetMethod([MarshalAs(UnmanagedType.LPWStr)] string wszName, int lFlags, IntPtr ppInSignature, IntPtr ppOutSignature);
-
-                [PreserveSig]
-                int PutMethod([MarshalAs(UnmanagedType.LPWStr)] string wszName, int lFlags, IntPtr pInSignature, IntPtr pOutSignature);
-
-                [PreserveSig]
-                int DeleteMethod([MarshalAs(UnmanagedType.LPWStr)] string wszName);
-
-                [PreserveSig]
-                int BeginMethodEnumeration(int lEnumFlags);
-
-                [PreserveSig]
-                int NextMethod(int lFlags, [MarshalAs(UnmanagedType.BStr)] out string pstrName, IntPtr ppInSignature, IntPtr ppOutSignature);
-
-                [PreserveSig]
-                int EndMethodEnumeration();
-
-                [PreserveSig]
-                int GetMethodQualifierSet([MarshalAs(UnmanagedType.LPWStr)] string wszMethod, IntPtr ppQualSet);
-
-                [PreserveSig]
-                int GetMethodOrigin([MarshalAs(UnmanagedType.LPWStr)] string wszMethodName, [MarshalAs(UnmanagedType.BStr)] out string pstrClassName);
-            }
-
+            [DllImport("ntdll.dll")]
+            private static extern int NtQueryInformationProcess(
+                SafeProcessHandle processHandle,
+                int processInformationClass,
+                IntPtr processInformation,
+                int processInformationLength,
+                out int returnLength);
 
             /// <summary>
-            /// Retrieves the command line for a process by querying WMI Win32_Process via COM.
-            /// Runs: SELECT CommandLine FROM Win32_Process WHERE ProcessId='<paramref name="processId"/>'
+            /// Retrieves the command line for a process via NtQueryInformationProcess.
+            /// Returns null if the process cannot be opened or the query fails.
             /// </summary>
             internal static string? GetCommandLine(int processId)
             {
-                int hr = CoInitializeSecurity(
-                    IntPtr.Zero,
-                    -1,
-                    IntPtr.Zero,
-                    IntPtr.Zero,
-                    RPC_C_AUTHN_LEVEL_DEFAULT,
-                    RPC_C_IMP_LEVEL_IMPERSONATE,
-                    IntPtr.Zero,
-                    EOAC_NONE,
-                    IntPtr.Zero);
-                // RPC_E_TOO_LATE (0x80010119) means another call already set security — not fatal.
-                if (hr != WBEM_S_NO_ERROR && hr != RPC_E_TOO_LATE)
+                using SafeProcessHandle hProcess = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, processId);
+                if (hProcess.IsInvalid)
                 {
-                    throw new InvalidOperationException(
-                        $"WMI CoInitializeSecurity failed for PID {processId}. HRESULT: 0x{hr:X8}");
-                }
-
-                Guid clsid = CLSID_WbemLocator;
-                Guid iid = IID_IWbemLocator;
-                hr = CoCreateInstance(ref clsid, IntPtr.Zero, CLSCTX_INPROC_SERVER, ref iid, out IWbemLocator locator);
-                if (hr != WBEM_S_NO_ERROR)
-                {
-                    throw new InvalidOperationException(
-                        $"WMI CoCreateInstance failed for PID {processId}. HRESULT: 0x{hr:X8}");
-                }
-
-                hr = locator.ConnectServer(
-                    @"ROOT\CIMV2",
-                    strUser: null, strPassword: null, strLocale: null,
-                    lSecurityFlags: 0, strAuthority: null,
-                    pCtx: IntPtr.Zero,
-                    out IWbemServices services);
-                if (hr != WBEM_S_NO_ERROR)
-                {
-                    throw new InvalidOperationException(
-                        $"WMI ConnectServer failed for PID {processId}. HRESULT: 0x{hr:X8}");
-                }
-
-                hr = CoSetProxyBlanket(
-                    services,
-                    RPC_C_AUTHN_WINNT,
-                    RPC_C_AUTHZ_NONE,
-                    IntPtr.Zero,
-                    RPC_C_AUTHN_LEVEL_CALL,
-                    RPC_C_IMP_LEVEL_IMPERSONATE,
-                    IntPtr.Zero,
-                    EOAC_NONE);
-                if (hr != WBEM_S_NO_ERROR)
-                {
-                    throw new InvalidOperationException(
-                        $"WMI CoSetProxyBlanket failed for PID {processId}. HRESULT: 0x{hr:X8}");
-                }
-
-                string query = $"SELECT CommandLine FROM Win32_Process WHERE ProcessId='{processId}'";
-                hr = services.ExecQuery(
-                    "WQL",
-                    query,
-                    WBEM_FLAG_FORWARD_ONLY | WBEM_FLAG_RETURN_IMMEDIATELY,
-                    null,
-                    out IEnumWbemClassObject enumerator);
-                if (hr != WBEM_S_NO_ERROR)
-                {
-                    throw new InvalidOperationException(
-                        $"WMI ExecQuery failed for PID {processId}. HRESULT: 0x{hr:X8}");
-                }
-
-                hr = enumerator.Next(WBEM_INFINITE, 1, out IWbemClassObject obj, out uint returned);
-                if (hr == WBEM_S_FALSE || returned == 0)
-                {
-                    // No matching process found.
                     return null;
                 }
-                if (hr != WBEM_S_NO_ERROR)
-                {
-                    throw new InvalidOperationException(
-                        $"WMI IEnumWbemClassObject.Next failed for PID {processId}. HRESULT: 0x{hr:X8}");
-                }
 
-                object val = null!;
-                hr = obj.Get("CommandLine", 0, ref val, IntPtr.Zero, IntPtr.Zero);
-                if (hr != WBEM_S_NO_ERROR)
+                int bufferSize = 1024;
+                IntPtr buffer = Marshal.AllocHGlobal(bufferSize);
+                try
                 {
-                    throw new InvalidOperationException(
-                        $"WMI IWbemClassObject.Get(\"CommandLine\") failed for PID {processId}. HRESULT: 0x{hr:X8}");
-                }
+                    int status = NtQueryInformationProcess(hProcess, ProcessCommandLineInformation, buffer, bufferSize, out int returnLength);
 
-                return val as string;
+                    if (status == STATUS_INFO_LENGTH_MISMATCH || status == STATUS_BUFFER_TOO_SMALL || status == STATUS_BUFFER_OVERFLOW)
+                    {
+                        if (returnLength <= 0)
+                        {
+                            return null;
+                        }
+
+                        Marshal.FreeHGlobal(buffer);
+                        buffer = IntPtr.Zero;
+                        bufferSize = returnLength;
+                        buffer = Marshal.AllocHGlobal(bufferSize);
+                        status = NtQueryInformationProcess(hProcess, ProcessCommandLineInformation, buffer, bufferSize, out _);
+                    }
+
+                    if (status != STATUS_SUCCESS)
+                    {
+                        return null;
+                    }
+
+                    // The buffer contains a UNICODE_STRING structure whose Buffer field
+                    // points to the string data within this same allocation.
+                    UNICODE_STRING unicodeString = Marshal.PtrToStructure<UNICODE_STRING>(buffer);
+
+                    if (unicodeString.Length == 0 || unicodeString.Buffer == IntPtr.Zero)
+                    {
+                        return null;
+                    }
+
+                    return Marshal.PtrToStringUni(unicodeString.Buffer, unicodeString.Length / sizeof(char));
+                }
+                finally
+                {
+                    Marshal.FreeHGlobal(buffer);
+                }
             }
         }
 #endif


### PR DESCRIPTION
## Summary

Replace the Windows implementation of `TryGetCommandLine` in `ProcessExtensions.cs` to use `NtQueryInformationProcess` with `ProcessCommandLineInformation` (info class 60) instead of WMI COM queries.

Fixes #13522

## Problem

The previous implementation queried WMI (`Win32_Process`) via COM with `WBEM_INFINITE` timeout to retrieve process command lines during node reuse scanning. When the WMI service was unresponsive, corrupted, or overloaded (common with third-party endpoint protection/monitoring software), this caused an **indefinite hang** on the calling thread, freezing the entire build.

The hang was observed in a dump with the main thread blocked at `ZwAlpcSendWaitReceivePort` waiting for the WMI RPC response that never came.

## Fix

Use `NtQueryInformationProcess` with `ProcessCommandLineInformation` — a direct kernel query with no service dependency. This matches the pattern already used by the Linux (`/proc/pid/cmdline`) and macOS (`sysctl KERN_PROCARGS2`) implementations in the same file.

## Benefits

- **Eliminates infinite hang risk** — no WMI service dependency
- **Faster** — single syscall vs cross-process RPC to WMI service
- **Lower privilege** — `PROCESS_QUERY_LIMITED_INFORMATION` vs WMI impersonation
- **Removes ~450 lines** of COM interface definitions
- **Consistent** — all three platforms now use direct OS queries

## Testing

- Existing `TryGetCommandLine_RunningProcess_ContainsExpectedExecutable` — passes
- Existing `TryGetCommandLine_RunningProcess_ContainsArguments` — passes
- Framework project builds with 0 warnings, 0 errors

## Context

The WMI-based code path is gated behind ChangeWave 18.5 (node mode filtering). Users hitting the hang can work around it by setting `MSBUILDDISABLEFEATURESFROMVERSION=18.5`, but this fix eliminates the root cause.