### PR TITLE
Fix CI: replace decommissioned vs2022preview pool image [vs17.12]

### DIFF
--- a/.vsts-dotnet-ci.yml
+++ b/.vsts-dotnet-ci.yml
@@ -215,7 +215,7 @@ jobs:
   pool:
     ${{ if eq(variables['System.TeamProject'], 'public') }}:
       name: NetCore-Public
-      demands: ImageOverride -equals windows.vs2022preview.amd64.open
+      demands: ImageOverride -equals windows.vs2022.amd64.open
     ${{ if ne(variables['System.TeamProject'], 'public') }}:
       name: VSEngSS-MicroBuild2022-1ES
       demands: agent.os -equals Windows_NT

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,7 +2,7 @@
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the MIT license. See License.txt in the project root for full license information. -->
 <Project>
   <PropertyGroup>
-    <VersionPrefix>17.12.58</VersionPrefix>
+    <VersionPrefix>17.12.59</VersionPrefix>
     <DotNetFinalVersionKind>release</DotNetFinalVersionKind>
     <PackageValidationBaselineVersion>17.11.4</PackageValidationBaselineVersion>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>


### PR DESCRIPTION
## Problem

The `FullReleaseOnWindows` CI job uses the `windows.vs2022preview.amd64.open` image on the `NetCore-Public` pool. This image has been decommissioned by the dnceng infrastructure team (see [dotnet/dnceng#6396](https://github.com/dotnet/dnceng/issues/6396)), causing the job to hang waiting for an agent and eventually time out after 3 hours.

This has been broken since approximately Feb-Mar 2026 (last known working PR: Jan 26, first known broken: Apr 6).

## Fix

Replace `windows.vs2022preview.amd64.open` with `windows.vs2022.amd64.open` (the stable VS 2022 image that is actively maintained). This is the same image used by the vs17.8 servicing branch which continues to work.

The `main` branch uses `windows.vs2026preview.scout.amd64.open` but that targets a newer VS version not appropriate for 17.x servicing branches.

## Changes

- `.vsts-dotnet-ci.yml`: Update pool image demand for `FullReleaseOnWindows` job
- `eng/Versions.props`: Bump patch version (required for servicing branch PRs)