### PR TITLE
Migrate  GetInstalledSDKLocations to Task Environment API

### DIFF
--- a/src/Framework.UnitTests/AbsolutePath_Tests.cs
+++ b/src/Framework.UnitTests/AbsolutePath_Tests.cs
@@ -236,13 +236,11 @@ namespace Microsoft.Build.UnitTests
         }
 
         [Fact]
-        public void GetCanonicalForm_NullPath_ShouldReturnSameInstance()
+        public void GetCanonicalForm_NullPath_ShouldThrow()
         {
             var absolutePath = new AbsolutePath(null!, null!, ignoreRootedCheck: true);
-            var result = absolutePath.GetCanonicalForm();
 
-            // Should return the same struct values when no normalization is needed
-            result.ShouldBe(absolutePath);
+            Should.Throw<ArgumentNullException>(() => absolutePath.GetCanonicalForm());
         }
 
 
@@ -281,6 +279,26 @@ namespace Microsoft.Build.UnitTests
 
             // Should preserve original value
             result.OriginalValue.ShouldBe(absolutePath.OriginalValue);
+        }
+
+        [Fact]
+        public void GetCanonicalForm_InvalidPathCharacters_ShouldThrowSameAsPathGetFullPath()
+        {
+            // A path containing a null character is invalid on all platforms.
+            // Path.GetFullPath throws for this input; GetCanonicalForm should too.
+            // Construct the path string directly to avoid Path.Combine throwing on .NET Framework.
+            string invalidPath = Path.GetTempPath() + "foo\0bar";
+            var absolutePath = new AbsolutePath(invalidPath, ignoreRootedCheck: true);
+
+            // Capture the exception that Path.GetFullPath would throw
+            Exception? getFullPathException = Record.Exception(() => Path.GetFullPath(invalidPath));
+
+            getFullPathException.ShouldNotBeNull("Path.GetFullPath should throw for a path with null character");
+
+            // GetCanonicalForm should throw the same exception type
+            Should.Throw(
+                () => absolutePath.GetCanonicalForm(),
+                getFullPathException.GetType());
         }
 
         [WindowsOnlyFact]

--- a/src/Framework/PathHelpers/AbsolutePath.cs
+++ b/src/Framework/PathHelpers/AbsolutePath.cs
@@ -135,58 +135,11 @@ namespace Microsoft.Build.Framework
         /// </list>
         /// </para>
         /// <para>
-        /// If the path is already in canonical form, returns the current instance to avoid unnecessary allocations.
         /// Preserves the OriginalValue of the current instance.
         /// </para>
         /// </remarks>
         internal AbsolutePath GetCanonicalForm()
         {
-            if (string.IsNullOrEmpty(Value))
-            {
-                return this;
-            }
-
-            if (ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave18_6))
-            {
-                // Note: this is a quick check to avoid calling Path.GetFullPath when it's not necessary, since it can be expensive. 
-                // It should cover the most common cases and avoid the overhead of Path.GetFullPath in those cases.
-
-                // Check for relative path segments "." and ".."
-                // In absolute path those segments can not appear in the beginning of the path, only after a path separator.
-                // This is not a precise full detection of relative segments. There is no false negatives as this might affect correctenes, but it may have false positives:
-                // like when there is a hidden file or directory starting with a dot, or on linux the backslash and dot can be part of the file name.
-                // In case of false positives we would call Path.GetFullPath and the result would still be correct.
-
-                bool hasRelativeSegment = Value.Contains("/.") || Value.Contains("\\.");
-
-                // Check if directory separator normalization is required (only on Windows: "/" to "\")
-                // On unix "\" is not a valid path separator, but is a part of the file/directory name, so no normalization is needed. 
-                bool needsSeparatorNormalization = NativeMethods.IsWindows && Value.IndexOf(Path.AltDirectorySeparatorChar) >= 0;
-
-                // Check for consecutive directory separators (e.g., "\\") which Path.GetFullPath would collapse.
-                // On Windows, consecutive backslashes in the middle of a path (not at the start for UNC) should be collapsed.
-                // On Unix, consecutive forward slashes should be collapsed.
-                bool hasConsecutiveSeparators;
-                if (NativeMethods.IsWindows)
-                {
-                    // On Windows, search from offset 1 to skip position 0 where UNC paths legitimately start with "\\".
-                    // This still catches cases like "C:\\foo" (positions 2-3) or "D:\foo\\bar".
-                    // Length > 3 guard: searching for 2-char match from offset 1 needs at least 4 chars.
-                    hasConsecutiveSeparators = Value.Length > 3 && Value.IndexOf("\\\\", 1, StringComparison.Ordinal) >= 0;
-                }
-                else
-                {
-                    hasConsecutiveSeparators = Value.Contains("//");
-                }
-
-                if (!hasRelativeSegment && !needsSeparatorNormalization && !hasConsecutiveSeparators)
-                {
-                    return this;
-                }
-            }
-
-            // Use Path.GetFullPath to resolve relative segments and normalize separators.
-            // Skip validation since Path.GetFullPath already ensures the result is absolute.
             return new AbsolutePath(Path.GetFullPath(Value), OriginalValue, ignoreRootedCheck: true);
         }
 

--- a/src/Tasks.UnitTests/GetInstalledSDKLocations_Tests.cs
+++ b/src/Tasks.UnitTests/GetInstalledSDKLocations_Tests.cs
@@ -4,7 +4,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using Microsoft.Build.Framework;

--- a/src/Tasks.UnitTests/GetInstalledSDKLocations_Tests.cs
+++ b/src/Tasks.UnitTests/GetInstalledSDKLocations_Tests.cs
@@ -473,14 +473,12 @@ namespace Microsoft.Build.UnitTests.GetInstalledSDKLocation_Tests
         private readonly ITestOutputHelper _output;
         private readonly TestEnvironment _env;
         private readonly string _fakeSDKStructureRoot;
-        private readonly string _fakeSDKStructureRoot2;
 
         public GetInstalledSDKLocationsMultiThreadTests(FakeSDKStructure fakeSDKStructure, ITestOutputHelper output)
         {
             _output = output;
             _env = TestEnvironment.Create(output);
             _fakeSDKStructureRoot = fakeSDKStructure.FakeSdkStructureRoot;
-            _fakeSDKStructureRoot2 = fakeSDKStructure.FakeSdkStructureRoot2;
         }
 
         public void Dispose() => _env.Dispose();

--- a/src/Tasks.UnitTests/GetInstalledSDKLocations_Tests.cs
+++ b/src/Tasks.UnitTests/GetInstalledSDKLocations_Tests.cs
@@ -4,12 +4,16 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
 using Microsoft.Build.Tasks;
+using Microsoft.Build.UnitTests;
+using Shouldly;
 using Xunit;
+using Xunit.Abstractions;
 
 #nullable disable
 
@@ -457,5 +461,104 @@ namespace Microsoft.Build.UnitTests.GetInstalledSDKLocation_Tests
         }
 
         #endregion
+    }
+
+    /// <summary>
+    /// Tests for GetInstalledSDKLocations multithreaded task migration.
+    /// Verifies interface compliance, path absolutization via TaskEnvironment,
+    /// concurrent execution safety, and behavioral equivalence across environments.
+    /// </summary>
+    public sealed class GetInstalledSDKLocationsMultiThreadTests : IClassFixture<FakeSDKStructure>, IDisposable
+    {
+        private readonly ITestOutputHelper _output;
+        private readonly TestEnvironment _env;
+        private readonly string _fakeSDKStructureRoot;
+        private readonly string _fakeSDKStructureRoot2;
+
+        public GetInstalledSDKLocationsMultiThreadTests(FakeSDKStructure fakeSDKStructure, ITestOutputHelper output)
+        {
+            _output = output;
+            _env = TestEnvironment.Create(output);
+            _fakeSDKStructureRoot = fakeSDKStructure.FakeSdkStructureRoot;
+            _fakeSDKStructureRoot2 = fakeSDKStructure.FakeSdkStructureRoot2;
+        }
+
+        public void Dispose() => _env.Dispose();
+
+
+        /// <summary>
+        /// Verifies that relative SDKDirectoryRoots are resolved via TaskEnvironment's project
+        /// directory, NOT via the process working directory. Uses two TaskEnvironments pointing
+        /// at different project directories with the same relative root name — one finds SDKs
+        /// (correct parent) and the other finds none (wrong parent), proving absolutization
+        /// goes through TaskEnvironment.
+        /// </summary>
+        [WindowsOnlyFact]
+        public void Execute_WithRelativeDirectoryRoots_AbsolutizesViaTaskEnvironment()
+        {
+            string parentDir = Path.GetDirectoryName(_fakeSDKStructureRoot);
+            string relativeName = Path.GetFileName(_fakeSDKStructureRoot);
+
+            // Set CWD to an unrelated directory so relative paths can't accidentally
+            // resolve via process CWD.
+            _env.SetCurrentDirectory(Path.GetTempPath());
+
+            // TaskEnvironment pointing at the CORRECT parent — relative root should resolve
+            // to the real fake SDK structure.
+            var correctEnv = TaskEnvironment.CreateWithProjectDirectoryAndEnvironment(
+                parentDir,
+                new Dictionary<string, string>
+                {
+                    ["MSBUILDDISABLEREGISTRYFORSDKLOOKUP"] = "true",
+                });
+
+            var engineCorrect = new MockEngine(_output);
+            var taskCorrect = new GetInstalledSDKLocations
+            {
+                TargetPlatformIdentifier = "Windows",
+                TargetPlatformVersion = new Version(int.MaxValue, int.MaxValue, int.MaxValue, int.MaxValue).ToString(),
+                SDKDirectoryRoots = new[] { relativeName },
+                SDKRegistryRoot = String.Empty,
+                BuildEngine = engineCorrect,
+                TaskEnvironment = correctEnv,
+            };
+            bool successCorrect = taskCorrect.Execute();
+
+            successCorrect.ShouldBeTrue();
+            taskCorrect.InstalledSDKs.ShouldNotBeNull();
+            taskCorrect.InstalledSDKs.Length.ShouldBe(3, "Correct project directory should resolve the relative root to the real SDK structure");
+
+            // Output metadata must preserve the original relative value (Sin 1 check).
+            foreach (ITaskItem item in taskCorrect.InstalledSDKs)
+            {
+                item.GetMetadata("DirectoryRoots").ShouldBe(relativeName);
+            }
+
+            // TaskEnvironment pointing at the WRONG parent — same relative name resolves
+            // to a non-existent directory, proving resolution goes through TaskEnvironment.
+            string wrongParent = _env.CreateFolder().Path;
+            var wrongEnv = TaskEnvironment.CreateWithProjectDirectoryAndEnvironment(
+                wrongParent,
+                new Dictionary<string, string>
+                {
+                    ["MSBUILDDISABLEREGISTRYFORSDKLOOKUP"] = "true",
+                });
+
+            var engineWrong = new MockEngine(_output);
+            var taskWrong = new GetInstalledSDKLocations
+            {
+                TargetPlatformIdentifier = "Windows",
+                TargetPlatformVersion = new Version(int.MaxValue, int.MaxValue, int.MaxValue, int.MaxValue).ToString(),
+                SDKDirectoryRoots = new[] { relativeName },
+                SDKRegistryRoot = String.Empty,
+                BuildEngine = engineWrong,
+                TaskEnvironment = wrongEnv,
+            };
+            bool successWrong = taskWrong.Execute();
+
+            successWrong.ShouldBeTrue();
+            taskWrong.InstalledSDKs.ShouldNotBeNull();
+            taskWrong.InstalledSDKs.Length.ShouldBe(0, "Wrong project directory should not find any SDKs");
+        }
     }
 }

--- a/src/Tasks/GetInstalledSDKLocations.cs
+++ b/src/Tasks/GetInstalledSDKLocations.cs
@@ -18,7 +18,8 @@ namespace Microsoft.Build.Tasks
     ///  so they can be used during SDK reference resolution and RAR for single files.
     /// </summary>
 #pragma warning disable RS0022 // Constructor make noninheritable base class inheritable: Longstanding API design that we shouldn't change now
-    public class GetInstalledSDKLocations : TaskExtension
+    [MSBuildMultiThreadableTask]
+    public class GetInstalledSDKLocations : TaskExtension, IMultiThreadableTask
 #pragma warning restore RS0022 // Constructor make noninheritable base class inheritable
     {
         /// <summary>
@@ -45,6 +46,9 @@ namespace Microsoft.Build.Tasks
         /// Key into our build cache
         /// </summary>
         private const string StaticSDKCacheKey = "StaticToolLocationHelperSDKCacheDisposer";
+
+        /// <inheritdoc />
+        public TaskEnvironment TaskEnvironment { get; set; } = TaskEnvironment.Fallback;
 
         #region Properties
 
@@ -140,12 +144,15 @@ namespace Microsoft.Build.Tasks
             // Dictionary of ESDKs. Each entry is a (location, platform version) tuple
             IDictionary<string, Tuple<string, string>> installedSDKs = null;
 
+            string[] absoluteDirectoryRoots = AbsolutizePaths(SDKDirectoryRoots);
+            string[] absoluteExtensionRoots = AbsolutizePaths(SDKExtensionDirectoryRoots);
+
             try
             {
                 Log.LogMessageFromResources("GetInstalledSDKs.SearchingForSDKs", _targetPlatformIdentifier, _targetPlatformVersion);
 
                 Version platformVersion = Version.Parse(TargetPlatformVersion);
-                installedSDKs = ToolLocationHelper.GetPlatformExtensionSDKLocationsAndVersions(SDKDirectoryRoots, SDKExtensionDirectoryRoots, SDKRegistryRoot, TargetPlatformIdentifier, platformVersion);
+                installedSDKs = ToolLocationHelper.GetPlatformExtensionSDKLocationsAndVersions(absoluteDirectoryRoots, absoluteExtensionRoots, SDKRegistryRoot, TargetPlatformIdentifier, platformVersion);
             }
             catch (Exception e) when (!ExceptionHandling.IsCriticalException(e))
             {
@@ -205,5 +212,26 @@ namespace Microsoft.Build.Tasks
         }
 
         #endregion
+
+        /// <summary>
+        /// Absolutizes an array of path strings using TaskEnvironment, returning null if the input is null.
+        /// </summary>
+        private string[] AbsolutizePaths(string[] paths)
+        {
+            if (paths == null)
+            {
+                return null;
+            }
+
+            var result = new string[paths.Length];
+            for (int i = 0; i < paths.Length; i++)
+            {
+                result[i] = String.IsNullOrEmpty(paths[i])
+                    ? paths[i]
+                    : TaskEnvironment.GetAbsolutePath(paths[i]).Value;
+            }
+
+            return result;
+        }
     }
 }

--- a/src/Tasks/GetInstalledSDKLocations.cs
+++ b/src/Tasks/GetInstalledSDKLocations.cs
@@ -144,15 +144,18 @@ namespace Microsoft.Build.Tasks
             // Dictionary of ESDKs. Each entry is a (location, platform version) tuple
             IDictionary<string, Tuple<string, string>> installedSDKs = null;
 
-            string[] absoluteDirectoryRoots = TaskEnvironment.GetAbsolutePathsOrNull(SDKDirectoryRoots);
-            string[] absoluteExtensionRoots = TaskEnvironment.GetAbsolutePathsOrNull(SDKExtensionDirectoryRoots);
+            AbsolutePath[] absoluteDirectoryRoots = TaskEnvironment.GetAbsolutePathsOrNull(SDKDirectoryRoots);
+            AbsolutePath[] absoluteExtensionRoots = TaskEnvironment.GetAbsolutePathsOrNull(SDKExtensionDirectoryRoots);
 
             try
             {
                 Log.LogMessageFromResources("GetInstalledSDKs.SearchingForSDKs", _targetPlatformIdentifier, _targetPlatformVersion);
 
                 Version platformVersion = Version.Parse(TargetPlatformVersion);
-                installedSDKs = ToolLocationHelper.GetPlatformExtensionSDKLocationsAndVersions(absoluteDirectoryRoots, absoluteExtensionRoots, SDKRegistryRoot, TargetPlatformIdentifier, platformVersion);
+                installedSDKs = ToolLocationHelper.GetPlatformExtensionSDKLocationsAndVersions(
+                    absoluteDirectoryRoots.ToStringArray(),
+                    absoluteExtensionRoots.ToStringArray(),
+                    SDKRegistryRoot, TargetPlatformIdentifier, platformVersion);
             }
             catch (Exception e) when (!ExceptionHandling.IsCriticalException(e))
             {

--- a/src/Tasks/TaskEnvironmentExtensions.cs
+++ b/src/Tasks/TaskEnvironmentExtensions.cs
@@ -6,7 +6,7 @@ using Microsoft.Build.Framework;
 namespace Microsoft.Build.Tasks
 {
     /// <summary>
-    /// Extension methods for <see cref="TaskEnvironment"/> used by built-in tasks.
+    /// Extension methods for <see cref="TaskEnvironment"/> and <see cref="AbsolutePath"/> used by built-in tasks.
     /// </summary>
     internal static class TaskEnvironmentExtensions
     {
@@ -15,9 +15,31 @@ namespace Microsoft.Build.Tasks
         /// Returns <see langword="null"/> if <paramref name="paths"/> is <see langword="null"/>.
         /// Empty or null entries are passed through unchanged.
         /// </summary>
-        internal static string[]? GetAbsolutePathsOrNull(this TaskEnvironment taskEnvironment, string[]? paths)
+        internal static AbsolutePath[]? GetAbsolutePathsOrNull(this TaskEnvironment taskEnvironment, string[]? paths)
         {
-            if (paths == null)
+            if (paths is null)
+            {
+                return null;
+            }
+
+            var result = new AbsolutePath[paths.Length];
+            for (int i = 0; i < paths.Length; i++)
+            {
+                result[i] = string.IsNullOrEmpty(paths[i])
+                    ? new AbsolutePath(paths[i], ignoreRootedCheck: true)
+                    : taskEnvironment.GetAbsolutePath(paths[i]);
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Converts an array of <see cref="AbsolutePath"/> to a string array.
+        /// Returns <see langword="null"/> if <paramref name="paths"/> is <see langword="null"/>.
+        /// </summary>
+        internal static string[]? ToStringArray(this AbsolutePath[]? paths)
+        {
+            if (paths is null)
             {
                 return null;
             }
@@ -25,9 +47,7 @@ namespace Microsoft.Build.Tasks
             var result = new string[paths.Length];
             for (int i = 0; i < paths.Length; i++)
             {
-                result[i] = string.IsNullOrEmpty(paths[i])
-                    ? paths[i]
-                    : taskEnvironment.GetAbsolutePath(paths[i]).Value;
+                result[i] = paths[i].Value;
             }
 
             return result;


### PR DESCRIPTION
Fixes #13562

### Context
The  GetInstalledSDKLocationstask was made thread-safe.

### Changes Made
Routed path resolution through TaskEnvironment.GetAbsolutePath().

### Testing
Unit tests in GetInstalledSDKLocations_Tests.cs