### PR TITLE
Enlighten RequiresFramework35SP1Assembly task for multithreaded mode

### DIFF
--- a/src/Tasks.UnitTests/RequiresFramework35SP1Assembly_Tests.cs
+++ b/src/Tasks.UnitTests/RequiresFramework35SP1Assembly_Tests.cs
@@ -8,8 +8,6 @@ using Microsoft.Build.Utilities;
 using Shouldly;
 using Xunit;
 
-#nullable disable
-
 namespace Microsoft.Build.UnitTests
 {
     public sealed class RequiresFramework35SP1Assembly_Tests
@@ -21,21 +19,28 @@ namespace Microsoft.Build.UnitTests
             _output = output;
         }
 
-        private RequiresFramework35SP1Assembly CreateTask()
-        {
-            return new RequiresFramework35SP1Assembly
+        private RequiresFramework35SP1Assembly CreateTask() =>
+            new()
             {
                 BuildEngine = new MockEngine(_output),
-                // SigningManifests defaults to false, which UncheckedSigning() treats as a "requires SP1" signal.
-                // Default to true so per-predicate tests are not contaminated by it.
-                SigningManifests = true,
             };
+
+        [Fact]
+        public void Defaults_UncheckedSigningTriggers()
+        {
+            // The task's default SigningManifests=false is itself an "unchecked signing" trigger,
+            // so the all-defaults case reports RequiresMinimumFramework35SP1=true.
+            RequiresFramework35SP1Assembly task = CreateTask();
+
+            task.Execute().ShouldBeTrue();
+            task.RequiresMinimumFramework35SP1.ShouldBeTrue();
         }
 
         [Fact]
-        public void Defaults_NoSignalsTriggered()
+        public void SigningEnabled_NoOtherSignals_DoesNotTrigger()
         {
             RequiresFramework35SP1Assembly task = CreateTask();
+            task.SigningManifests = true;
 
             task.Execute().ShouldBeTrue();
             task.RequiresMinimumFramework35SP1.ShouldBeFalse();
@@ -45,6 +50,7 @@ namespace Microsoft.Build.UnitTests
         public void ErrorReportUrl_Triggers()
         {
             RequiresFramework35SP1Assembly task = CreateTask();
+            task.SigningManifests = true;
             task.ErrorReportUrl = "https://example.com/errors";
 
             task.Execute().ShouldBeTrue();
@@ -55,18 +61,9 @@ namespace Microsoft.Build.UnitTests
         public void CreateDesktopShortcut_OnNet35_Triggers()
         {
             RequiresFramework35SP1Assembly task = CreateTask();
+            task.SigningManifests = true;
             task.TargetFrameworkVersion = "v3.5";
             task.CreateDesktopShortcut = true;
-
-            task.Execute().ShouldBeTrue();
-            task.RequiresMinimumFramework35SP1.ShouldBeTrue();
-        }
-
-        [Fact]
-        public void UncheckedSigning_Triggers()
-        {
-            RequiresFramework35SP1Assembly task = CreateTask();
-            task.SigningManifests = false;
 
             task.Execute().ShouldBeTrue();
             task.RequiresMinimumFramework35SP1.ShouldBeTrue();
@@ -76,6 +73,7 @@ namespace Microsoft.Build.UnitTests
         public void SuiteName_Triggers()
         {
             RequiresFramework35SP1Assembly task = CreateTask();
+            task.SigningManifests = true;
             task.SuiteName = "MyAppSuite";
 
             task.Execute().ShouldBeTrue();
@@ -91,7 +89,8 @@ namespace Microsoft.Build.UnitTests
         public void IncludeHashFalse_OnAnyItemInput_Triggers(string inputName)
         {
             RequiresFramework35SP1Assembly task = CreateTask();
-            ITaskItem item = new TaskItem("some.dll", new Dictionary<string, string> { { "IncludeHash", "false" } });
+            task.SigningManifests = true;
+            ITaskItem item = new TaskItem("some.dll", new Dictionary<string, string?> { { "IncludeHash", "false" } });
             AssignItemInput(task, inputName, item);
 
             task.Execute().ShouldBeTrue();
@@ -102,6 +101,7 @@ namespace Microsoft.Build.UnitTests
         public void CreateDesktopShortcut_OnNet20_DoesNotTrigger()
         {
             RequiresFramework35SP1Assembly task = CreateTask();
+            task.SigningManifests = true;
             task.TargetFrameworkVersion = "v2.0";
             task.CreateDesktopShortcut = true;
 
@@ -113,6 +113,7 @@ namespace Microsoft.Build.UnitTests
         public void CreateDesktopShortcut_BareVersionString_Works()
         {
             RequiresFramework35SP1Assembly task = CreateTask();
+            task.SigningManifests = true;
             task.TargetFrameworkVersion = "3.5";
             task.CreateDesktopShortcut = true;
 
@@ -124,6 +125,7 @@ namespace Microsoft.Build.UnitTests
         public void Sp1AssemblyIdentity_TriggersWithoutIncludeHash()
         {
             RequiresFramework35SP1Assembly task = CreateTask();
+            task.SigningManifests = true;
             task.Files = [new TaskItem("System.Data.Entity")];
 
             task.Execute().ShouldBeTrue();
@@ -134,6 +136,7 @@ namespace Microsoft.Build.UnitTests
         public void Net35ClientSentinelIdentity_Triggers()
         {
             RequiresFramework35SP1Assembly task = CreateTask();
+            task.SigningManifests = true;
             task.Assemblies = [new TaskItem("Sentinel.v3.5Client")];
 
             task.Execute().ShouldBeTrue();

--- a/src/Tasks.UnitTests/RequiresFramework35SP1Assembly_Tests.cs
+++ b/src/Tasks.UnitTests/RequiresFramework35SP1Assembly_Tests.cs
@@ -1,0 +1,167 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Tasks;
+using Microsoft.Build.Utilities;
+using Shouldly;
+using Xunit;
+
+#nullable disable
+
+namespace Microsoft.Build.UnitTests
+{
+    public sealed class RequiresFramework35SP1Assembly_Tests
+    {
+        private readonly ITestOutputHelper _output;
+
+        public RequiresFramework35SP1Assembly_Tests(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        private RequiresFramework35SP1Assembly CreateTask()
+        {
+            return new RequiresFramework35SP1Assembly
+            {
+                BuildEngine = new MockEngine(_output),
+                // SigningManifests defaults to false, which UncheckedSigning() treats as a "requires SP1" signal.
+                // Default to true so per-predicate tests are not contaminated by it.
+                SigningManifests = true,
+            };
+        }
+
+        [Fact]
+        public void Defaults_NoSignalsTriggered()
+        {
+            RequiresFramework35SP1Assembly task = CreateTask();
+
+            task.Execute().ShouldBeTrue();
+            task.RequiresMinimumFramework35SP1.ShouldBeFalse();
+        }
+
+        [Fact]
+        public void ErrorReportUrl_Triggers()
+        {
+            RequiresFramework35SP1Assembly task = CreateTask();
+            task.ErrorReportUrl = "https://example.com/errors";
+
+            task.Execute().ShouldBeTrue();
+            task.RequiresMinimumFramework35SP1.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void CreateDesktopShortcut_OnNet35_Triggers()
+        {
+            RequiresFramework35SP1Assembly task = CreateTask();
+            task.TargetFrameworkVersion = "v3.5";
+            task.CreateDesktopShortcut = true;
+
+            task.Execute().ShouldBeTrue();
+            task.RequiresMinimumFramework35SP1.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void UncheckedSigning_Triggers()
+        {
+            RequiresFramework35SP1Assembly task = CreateTask();
+            task.SigningManifests = false;
+
+            task.Execute().ShouldBeTrue();
+            task.RequiresMinimumFramework35SP1.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void SuiteName_Triggers()
+        {
+            RequiresFramework35SP1Assembly task = CreateTask();
+            task.SuiteName = "MyAppSuite";
+
+            task.Execute().ShouldBeTrue();
+            task.RequiresMinimumFramework35SP1.ShouldBeTrue();
+        }
+
+        [Theory]
+        [InlineData("ReferencedAssemblies")]
+        [InlineData("Assemblies")]
+        [InlineData("Files")]
+        [InlineData("DeploymentManifestEntryPoint")]
+        [InlineData("EntryPoint")]
+        public void IncludeHashFalse_OnAnyItemInput_Triggers(string inputName)
+        {
+            RequiresFramework35SP1Assembly task = CreateTask();
+            ITaskItem item = new TaskItem("some.dll", new Dictionary<string, string> { { "IncludeHash", "false" } });
+            AssignItemInput(task, inputName, item);
+
+            task.Execute().ShouldBeTrue();
+            task.RequiresMinimumFramework35SP1.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void CreateDesktopShortcut_OnNet20_DoesNotTrigger()
+        {
+            RequiresFramework35SP1Assembly task = CreateTask();
+            task.TargetFrameworkVersion = "v2.0";
+            task.CreateDesktopShortcut = true;
+
+            task.Execute().ShouldBeTrue();
+            task.RequiresMinimumFramework35SP1.ShouldBeFalse();
+        }
+
+        [Fact]
+        public void CreateDesktopShortcut_BareVersionString_Works()
+        {
+            RequiresFramework35SP1Assembly task = CreateTask();
+            task.TargetFrameworkVersion = "3.5";
+            task.CreateDesktopShortcut = true;
+
+            task.Execute().ShouldBeTrue();
+            task.RequiresMinimumFramework35SP1.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void Sp1AssemblyIdentity_TriggersWithoutIncludeHash()
+        {
+            RequiresFramework35SP1Assembly task = CreateTask();
+            task.Files = [new TaskItem("System.Data.Entity")];
+
+            task.Execute().ShouldBeTrue();
+            task.RequiresMinimumFramework35SP1.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void Net35ClientSentinelIdentity_Triggers()
+        {
+            RequiresFramework35SP1Assembly task = CreateTask();
+            task.Assemblies = [new TaskItem("Sentinel.v3.5Client")];
+
+            task.Execute().ShouldBeTrue();
+            task.RequiresMinimumFramework35SP1.ShouldBeTrue();
+        }
+
+        private static void AssignItemInput(RequiresFramework35SP1Assembly task, string inputName, ITaskItem item)
+        {
+            switch (inputName)
+            {
+                case "ReferencedAssemblies":
+                    task.ReferencedAssemblies = [item];
+                    break;
+                case "Assemblies":
+                    task.Assemblies = [item];
+                    break;
+                case "Files":
+                    task.Files = [item];
+                    break;
+                case "DeploymentManifestEntryPoint":
+                    task.DeploymentManifestEntryPoint = item;
+                    break;
+                case "EntryPoint":
+                    task.EntryPoint = item;
+                    break;
+                default:
+                    throw new System.ArgumentOutOfRangeException(nameof(inputName));
+            }
+        }
+    }
+}

--- a/src/Tasks.UnitTests/RequiresFramework35SP1Assembly_Tests.cs
+++ b/src/Tasks.UnitTests/RequiresFramework35SP1Assembly_Tests.cs
@@ -137,7 +137,7 @@ namespace Microsoft.Build.UnitTests
         {
             RequiresFramework35SP1Assembly task = CreateTask();
             task.SigningManifests = true;
-            task.Assemblies = [new TaskItem("Sentinel.v3.5Client")];
+            AssignItemInput(task, "Assemblies", new TaskItem("Sentinel.v3.5Client"));
 
             task.Execute().ShouldBeTrue();
             task.RequiresMinimumFramework35SP1.ShouldBeTrue();

--- a/src/Tasks.UnitTests/RequiresFramework35SP1Assembly_Tests.cs
+++ b/src/Tasks.UnitTests/RequiresFramework35SP1Assembly_Tests.cs
@@ -126,7 +126,7 @@ namespace Microsoft.Build.UnitTests
         {
             RequiresFramework35SP1Assembly task = CreateTask();
             task.SigningManifests = true;
-            task.Files = [new TaskItem("System.Data.Entity")];
+            AssignItemInput(task, "Files", new TaskItem("System.Data.Entity"));
 
             task.Execute().ShouldBeTrue();
             task.RequiresMinimumFramework35SP1.ShouldBeTrue();

--- a/src/Tasks/RequiresFramework35SP1Assembly.cs
+++ b/src/Tasks/RequiresFramework35SP1Assembly.cs
@@ -12,6 +12,7 @@ namespace Microsoft.Build.Tasks
     /// <summary>
     /// This task determines if this project requires VS2008 SP1 assembly.
     /// </summary>
+    [MSBuildMultiThreadableTask]
     public sealed class RequiresFramework35SP1Assembly : TaskExtension
     {
         #region Fields


### PR DESCRIPTION
`RequiresFramework35SP1Assembly` is purely in-memory (string compares, `Version` parse/compare, `ITaskItem` metadata reads) — no filesystem, env vars, process start, or shared static state. Per the `multithreaded-task-migration` skill Step 1b, the `[MSBuildMultiThreadableTask]` attribute alone is sufficient; `IMultiThreadableTask` is not needed. No code changes to `Execute` or helpers, no targets change, no ChangeWave.

The task previously had no direct unit coverage. Added 14 test cases locking in the contract: defaults, each `Execute` predicate triggering independently, the `CreateDesktopShortcut` TFV ≥ v3.5 gate (both `v`-prefixed and bare version strings), and the SP1/Net35Client sentinel identity short-circuit. Passing on `net10.0` and `net472`.

Fixes #13572