### PR TITLE
Remove unactionable info from reviewer agent

### DIFF
--- a/.github/agents/expert-reviewer.agent.md
+++ b/.github/agents/expert-reviewer.agent.md
@@ -656,6 +656,8 @@ Use this to prioritize dimensions based on changed files.
 
    **Omit all LGTM dimensions from the table** — only list dimensions that have findings. This keeps the review concise and actionable. Show the count of clean dimensions as a single summary line instead.
 
+   When there **are** findings:
+
    ```markdown
    | # | Dimension | Verdict |
    |---|-----------|---------|
@@ -666,6 +668,12 @@ Use this to prioritize dimensions based on changed files.
 
    - [ ] Concurrency — shared state race
    - [ ] Correctness — null input edge case
+   ```
+
+   When **all dimensions are clean**, omit the table entirely:
+
+   ```markdown
+   ✅ 24/24 dimensions clean — no findings.
    ```
 
    `[ ]` = dimensions with findings. Any BLOCKING → event: **REQUEST_CHANGES**. Otherwise (including all-clear) → event: **COMMENT**.

--- a/.github/agents/expert-reviewer.agent.md
+++ b/.github/agents/expert-reviewer.agent.md
@@ -646,24 +646,29 @@ Use this to prioritize dimensions based on changed files.
 
    **Important**: Use `create_pull_request_review_comment` (inline on diff), NOT `add_comment` (general PR comment). Only findings tied to a specific changed line should use this tool.
 
+   **Every inline comment must be actionable.** Do NOT post comments that only praise existing code, acknowledge good patterns, or say "looks good". If a dimension is clean, record it as LGTM in the summary table — do not leave an inline comment for it. Comments like "This is well-written 👍" or "Good use of X pattern" add noise without giving the author anything to act on.
+
 6. Post design-level concerns (not tied to a specific diff line) as a single PR comment via the `add_comment` safe-output tool — one bullet each.
 
 ### Wave 4: Summary
 
-7. Submit the final review verdict via the `submit_pull_request_review` safe-output tool. Include the summary table in the review `body` and set the `event` field:
+7. Submit the final review verdict via the `submit_pull_request_review` safe-output tool. Include the summary table in the review `body` and set the `event` field.
+
+   **Omit all LGTM dimensions from the table** — only list dimensions that have findings. This keeps the review concise and actionable. Show the count of clean dimensions as a single summary line instead.
 
    ```markdown
    | # | Dimension | Verdict |
    |---|-----------|---------|
-   | 1 | Backwards Compatibility | ✅ LGTM |
    | 13 | Concurrency | 🔴 2 MAJOR |
+   | 22 | Correctness | 🟡 1 MODERATE |
 
-   - [x] Backwards Compat
+   ✅ 22/24 dimensions clean.
+
    - [ ] Concurrency — shared state race
+   - [ ] Correctness — null input edge case
    ```
 
-   `[x]` = LGTM or NITs only. `[ ]` = BLOCKING.
-   Any BLOCKING → event: **REQUEST_CHANGES**. Otherwise (including all-clear) → event: **COMMENT**.
+   `[ ]` = dimensions with findings. Any BLOCKING → event: **REQUEST_CHANGES**. Otherwise (including all-clear) → event: **COMMENT**.
    **Never use APPROVE** — the agent must not count as a PR approval.
 
    All inline comments from step 5 are automatically bundled into this review submission.

--- a/.github/agents/expert-reviewer.agent.md
+++ b/.github/agents/expert-reviewer.agent.md
@@ -646,7 +646,7 @@ Use this to prioritize dimensions based on changed files.
 
    **Important**: Use `create_pull_request_review_comment` (inline on diff), NOT `add_comment` (general PR comment). Only findings tied to a specific changed line should use this tool.
 
-   **Every inline comment must be actionable.** Do NOT post comments that only praise existing code, acknowledge good patterns, or say "looks good". If a dimension is clean, record it as LGTM in the summary table — do not leave an inline comment for it. Comments like "This is well-written 👍" or "Good use of X pattern" add noise without giving the author anything to act on.
+   **Every inline comment must be actionable.** Do NOT post comments that only praise existing code, acknowledge good patterns, or say "looks good". If a dimension is clean, do not leave an inline comment for it and do not add it as an LGTM row in the summary table; instead, count it only in the aggregate clean-dimensions summary line described in step 7. Comments like "This is well-written 👍" or "Good use of X pattern" add noise without giving the author anything to act on.
 
 6. Post design-level concerns (not tied to a specific diff line) as a single PR comment via the `add_comment` safe-output tool — one bullet each.
 


### PR DESCRIPTION
### Context
@jankratochvilcz was pointing two friction points with pr-reviewer:
 - Non actionable comments - e.g. https://github.com/dotnet/msbuild/pull/13573#discussion_r3106952838
 - The overviw table containing numerous 'LGTM' rows - which reduces 'signal-to-noise' ratio

### Changes
Guiding to reduce nonactionable outputs

cc @jankratochvilcz 