### PR TITLE
Add dotnet/skills marketplace and enable plugins

### DIFF
--- a/.github/copilot/settings.json
+++ b/.github/copilot/settings.json
@@ -1,0 +1,23 @@
+{
+  "extraKnownMarketplaces": {
+    "dotnet-arcade-skills": {
+      "source": {
+        "source": "github",
+        "repo": "dotnet/arcade-skills"
+      }
+    },
+    "dotnet-skills": {
+      "source": {
+        "source": "github",
+        "repo": "dotnet/skills"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "dotnet-dnceng@dotnet-arcade-skills": true,
+    "dotnet@dotnet-skills": true,
+    "dotnet-msbuild@dotnet-skills": true,
+    "dotnet-nuget@dotnet-skills": true,
+    "dotnet-test@dotnet-skills": true
+  }
+}

--- a/.github/copilot/settings.json
+++ b/.github/copilot/settings.json
@@ -12,12 +12,5 @@
         "repo": "dotnet/skills"
       }
     }
-  },
-  "enabledPlugins": {
-    "dotnet-dnceng@dotnet-arcade-skills": true,
-    "dotnet@dotnet-skills": true,
-    "dotnet-msbuild@dotnet-skills": true,
-    "dotnet-nuget@dotnet-skills": true,
-    "dotnet-test@dotnet-skills": true
   }
 }


### PR DESCRIPTION
Add `.github/copilot/settings.json` to configure Copilot agent plugin marketplaces and enable dotnet plugins:

- `dotnet/arcade-skills` marketplace with `dotnet-dnceng` plugin
- `dotnet/skills` marketplace with `dotnet`, `dotnet-msbuild`, `dotnet-nuget`, and `dotnet-test` plugins

Relates to (and should replace a big part of) #13574