### PR TITLE
The skills/agents check filters-in only touched files

### DIFF
--- a/.github/workflows/skill-validation.yml
+++ b/.github/workflows/skill-validation.yml
@@ -36,6 +36,80 @@ jobs:
             .github/agents
           persist-credentials: false
 
+      # ── Determine changed skills/agents (PRs only) ───────────────
+      - name: Determine changed skills and agents
+        id: changed
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          changed_files=$(gh pr view ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --json files --jq '.files[].path')
+
+          changed_skill_files=$(echo "$changed_files" | grep '^\.github/skills/' || true)
+          changed_agent_files=$(echo "$changed_files" | grep '^\.github/agents/' || true)
+
+          if [ -z "$changed_skill_files" ] && [ -z "$changed_agent_files" ]; then
+            echo "No skill/agent files changed in this PR"
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "has_changes=true" >> "$GITHUB_OUTPUT"
+
+          # Extract unique skill directory names
+          if [ -n "$changed_skill_files" ]; then
+            echo "$changed_skill_files" | sed 's|\.github/skills/\([^/]*\)/.*|\1|' | sort -u > changed-skill-dirs.txt
+            echo "has_skills=true" >> "$GITHUB_OUTPUT"
+            echo "Changed skill directories:"
+            cat changed-skill-dirs.txt
+          else
+            echo "has_skills=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          if [ -n "$changed_agent_files" ]; then
+            echo "$changed_agent_files" > changed-agent-files.txt
+            echo "has_agents=true" >> "$GITHUB_OUTPUT"
+            echo "Changed agent files:"
+            cat changed-agent-files.txt
+          else
+            echo "has_agents=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      # ── Filter to only changed skills/agents (PRs only) ──────────
+      - name: Filter to changed skills and agents
+        if: github.event_name == 'pull_request' && steps.changed.outputs.has_changes == 'true'
+        shell: bash
+        run: |
+          # Remove unchanged skill directories
+          if [ "${{ steps.changed.outputs.has_skills }}" = "true" ] && [ -f changed-skill-dirs.txt ]; then
+            for dir in .github/skills/*/; do
+              dirname=$(basename "$dir")
+              if ! grep -qx "$dirname" changed-skill-dirs.txt; then
+                rm -rf "$dir"
+              fi
+            done
+          elif [ -d .github/skills ]; then
+            rm -rf .github/skills
+          fi
+
+          # Remove unchanged agent files
+          if [ "${{ steps.changed.outputs.has_agents }}" = "true" ] && [ -f changed-agent-files.txt ]; then
+            for f in .github/agents/*; do
+              if ! grep -qx "$f" changed-agent-files.txt; then
+                rm -f "$f"
+              fi
+            done
+          elif [ -d .github/agents ]; then
+            rm -rf .github/agents
+          fi
+
+          # Log what remains
+          echo "Skills to validate:"
+          find .github/skills -mindepth 1 -maxdepth 1 -type d 2>/dev/null || echo "  (none)"
+          echo "Agents to validate:"
+          find .github/agents -name '*.agent.md' 2>/dev/null || echo "  (none)"
+
       # ── Download & cache skill-validator ──────────────────────────
       - name: Get cache key date
         id: cache-date
@@ -74,6 +148,7 @@ jobs:
       # ── Run skill-validator check ─────────────────────────────────
       - name: Run skill-validator check
         id: check
+        if: github.event_name != 'pull_request' || steps.changed.outputs.has_changes == 'true'
         shell: bash
         run: |
           rc=0
@@ -132,6 +207,13 @@ jobs:
         if: always()
         run: |
           mkdir -p sv-results
+
+          # If check step was skipped (PR with no skill/agent changes), emit zeros
+          exit_code="${{ steps.check.outputs.exit_code }}"
+          if [ -z "$exit_code" ]; then
+            exit_code=0
+          fi
+
           skill_count=$(find .github/skills -mindepth 1 -maxdepth 1 -type d 2>/dev/null | wc -l)
           agent_count=$(find .github/agents -name '*.agent.md' 2>/dev/null | wc -l)
           total=$((skill_count + agent_count))
@@ -139,7 +221,7 @@ jobs:
           echo "$skill_count" > sv-results/skill-count.txt
           echo "$agent_count" > sv-results/agent-count.txt
           echo "$total" > sv-results/total.txt
-          echo "${{ steps.check.outputs.exit_code }}" > sv-results/exit-code.txt
+          echo "$exit_code" > sv-results/exit-code.txt
           if [ -f sv-output.txt ]; then
             cp sv-output.txt sv-results/sv-output.txt
           fi

--- a/.github/workflows/skill-validation.yml
+++ b/.github/workflows/skill-validation.yml
@@ -22,6 +22,7 @@ concurrency:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   validate:
@@ -85,7 +86,7 @@ jobs:
           if [ "${{ steps.changed.outputs.has_skills }}" = "true" ] && [ -f changed-skill-dirs.txt ]; then
             for dir in .github/skills/*/; do
               dirname=$(basename "$dir")
-              if ! grep -qx "$dirname" changed-skill-dirs.txt; then
+              if ! grep -Fxq "$dirname" changed-skill-dirs.txt; then
                 rm -rf "$dir"
               fi
             done
@@ -96,7 +97,7 @@ jobs:
           # Remove unchanged agent files
           if [ "${{ steps.changed.outputs.has_agents }}" = "true" ] && [ -f changed-agent-files.txt ]; then
             for f in .github/agents/*; do
-              if ! grep -qx "$f" changed-agent-files.txt; then
+              if ! grep -Fxq "$f" changed-agent-files.txt; then
                 rm -f "$f"
               fi
             done
@@ -210,13 +211,16 @@ jobs:
 
           # If check step was skipped (PR with no skill/agent changes), emit zeros
           exit_code="${{ steps.check.outputs.exit_code }}"
+          skill_count=0
+          agent_count=0
+          total=0
           if [ -z "$exit_code" ]; then
             exit_code=0
+          else
+            skill_count=$(find .github/skills -mindepth 1 -maxdepth 1 -type d 2>/dev/null | wc -l)
+            agent_count=$(find .github/agents -name '*.agent.md' 2>/dev/null | wc -l)
+            total=$((skill_count + agent_count))
           fi
-
-          skill_count=$(find .github/skills -mindepth 1 -maxdepth 1 -type d 2>/dev/null | wc -l)
-          agent_count=$(find .github/agents -name '*.agent.md' 2>/dev/null | wc -l)
-          total=$((skill_count + agent_count))
           echo "${{ github.event.pull_request.number }}" > sv-results/pr-number.txt
           echo "$skill_count" > sv-results/skill-count.txt
           echo "$agent_count" > sv-results/agent-count.txt


### PR DESCRIPTION
https://github.com/dotnet/msbuild/pull/13537 followup

### Context
The PR above introduced skills/agents files checking within PRs touching skills/agents
But it checked all the files - possibly repeating same and unactionable findings

### Changes Made
We now filter only for the touched skills and agent files
