### PR TITLE
Migrate GetAssemblyIdentity to multithreaded execution model

### DIFF
--- a/src/Tasks.UnitTests/GetAssemblyIdentity_Tests.cs
+++ b/src/Tasks.UnitTests/GetAssemblyIdentity_Tests.cs
@@ -35,8 +35,11 @@ namespace Microsoft.Build.UnitTests
         public void AbsolutePathToExistingAssembly_ProducesCorrectIdentity()
         {
             // Use this test assembly as the input — it's guaranteed to exist.
+            // Use the compile-time assembly name as the baseline rather than
+            // AssemblyName.GetAssemblyName(path), to avoid asserting against the same
+            // reflection API the production code uses internally.
             string assemblyPath = typeof(GetAssemblyIdentity_Tests).Assembly.Location;
-            AssemblyName expectedName = AssemblyName.GetAssemblyName(assemblyPath);
+            AssemblyName expectedName = typeof(GetAssemblyIdentity_Tests).Assembly.GetName();
 
             GetAssemblyIdentity task = CreateTaskUnderTest();
             task.AssemblyFiles = [new TaskItem(assemblyPath)];
@@ -84,7 +87,7 @@ namespace Microsoft.Build.UnitTests
             TransientTestFile textFile = env.CreateFile("bad.txt", "not an assembly");
 
             string goodAssemblyPath = typeof(GetAssemblyIdentity_Tests).Assembly.Location;
-            AssemblyName expectedName = AssemblyName.GetAssemblyName(goodAssemblyPath);
+            AssemblyName expectedName = typeof(GetAssemblyIdentity_Tests).Assembly.GetName();
 
             var engine = new MockEngine(_output);
             GetAssemblyIdentity task = CreateTaskUnderTest(engine);
@@ -132,7 +135,7 @@ namespace Microsoft.Build.UnitTests
             TransientTestFolder projectDir = env.CreateFolder();
 
             string sourceAssembly = typeof(GetAssemblyIdentity_Tests).Assembly.Location;
-            AssemblyName expectedName = AssemblyName.GetAssemblyName(sourceAssembly);
+            AssemblyName expectedName = typeof(GetAssemblyIdentity_Tests).Assembly.GetName();
 
             string relativeFileName = "TestAssembly.dll";
             File.Copy(sourceAssembly, Path.Combine(projectDir.Path, relativeFileName));
@@ -152,7 +155,7 @@ namespace Microsoft.Build.UnitTests
         public void OutputItem_DoesNotContainAbsolutizedPaths()
         {
             string assemblyPath = typeof(GetAssemblyIdentity_Tests).Assembly.Location;
-            AssemblyName expectedName = AssemblyName.GetAssemblyName(assemblyPath);
+            AssemblyName expectedName = typeof(GetAssemblyIdentity_Tests).Assembly.GetName();
 
             GetAssemblyIdentity task = CreateTaskUnderTest();
             task.AssemblyFiles = [new TaskItem(assemblyPath)];
@@ -178,8 +181,8 @@ namespace Microsoft.Build.UnitTests
 
             task.Execute().ShouldBeTrue();
 
-            task.Assemblies.Length.ShouldBe(1);
-            task.Assemblies[0].GetMetadata("CustomMeta").ShouldBe("CustomValue");
+            task.Assemblies.ShouldHaveSingleItem()
+                .GetMetadata("CustomMeta").ShouldBe("CustomValue");
         }
 
         private void AssertCouldNotGetAssemblyName(MockEngine engine)

--- a/src/Tasks.UnitTests/GetAssemblyIdentity_Tests.cs
+++ b/src/Tasks.UnitTests/GetAssemblyIdentity_Tests.cs
@@ -112,7 +112,9 @@ namespace Microsoft.Build.UnitTests
             GetAssemblyIdentity task = CreateTaskUnderTest(engine);
             task.AssemblyFiles = [new TaskItem("")];
 
-            Assert.Throws<ArgumentException>(() => task.Execute());
+            task.Execute().ShouldBeFalse();
+
+            AssertCouldNotGetAssemblyName(engine);
         }
 
         [Fact]

--- a/src/Tasks.UnitTests/GetAssemblyIdentity_Tests.cs
+++ b/src/Tasks.UnitTests/GetAssemblyIdentity_Tests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.IO;
 using System.Reflection;
 using Microsoft.Build.Framework;
@@ -109,11 +110,17 @@ namespace Microsoft.Build.UnitTests
         {
             var engine = new MockEngine(_output);
             GetAssemblyIdentity task = CreateTaskUnderTest(engine);
-            task.AssemblyFiles = [new TaskItem(string.Empty)];
+            task.AssemblyFiles = [new TaskItem("")];
 
-            task.Execute().ShouldBeFalse();
+            Assert.Throws<ArgumentException>(() => task.Execute());
+        }
 
-            AssertCouldNotGetAssemblyName(engine);
+        [Fact]
+        public void NullItemSpec_LogsErrorAndReturnsFalse()
+        {
+            var engine = new MockEngine(_output);
+            GetAssemblyIdentity task = CreateTaskUnderTest(engine);
+            Assert.Throws<ArgumentNullException>(() => task.AssemblyFiles = [new TaskItem((ITaskItem)null)]);
         }
 
         [Fact]

--- a/src/Tasks.UnitTests/GetAssemblyIdentity_Tests.cs
+++ b/src/Tasks.UnitTests/GetAssemblyIdentity_Tests.cs
@@ -1,0 +1,182 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.IO;
+using System.Reflection;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Tasks;
+using Microsoft.Build.Utilities;
+using Shouldly;
+using Xunit;
+
+#nullable disable
+
+namespace Microsoft.Build.UnitTests
+{
+    public sealed class GetAssemblyIdentity_Tests
+    {
+        private readonly ITestOutputHelper _output;
+
+        public GetAssemblyIdentity_Tests(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        private GetAssemblyIdentity CreateTaskUnderTest(MockEngine engine = null)
+        {
+            return new GetAssemblyIdentity
+            {
+                BuildEngine = engine ?? new MockEngine(_output),
+            };
+        }
+
+        [Fact]
+        public void AbsolutePathToExistingAssembly_ProducesCorrectIdentity()
+        {
+            // Use this test assembly as the input — it's guaranteed to exist.
+            string assemblyPath = typeof(GetAssemblyIdentity_Tests).Assembly.Location;
+            AssemblyName expectedName = AssemblyName.GetAssemblyName(assemblyPath);
+
+            GetAssemblyIdentity task = CreateTaskUnderTest();
+            task.AssemblyFiles = [new TaskItem(assemblyPath)];
+
+            task.Execute().ShouldBeTrue();
+
+            task.Assemblies.Length.ShouldBe(1);
+            task.Assemblies[0].ItemSpec.ShouldBe(expectedName.FullName);
+            task.Assemblies[0].GetMetadata("Name").ShouldBe(expectedName.Name);
+            task.Assemblies[0].GetMetadata("Version").ShouldBe(expectedName.Version.ToString());
+        }
+
+        [Fact]
+        public void NonExistentFile_LogsErrorAndReturnsFalse()
+        {
+            var engine = new MockEngine(_output);
+            GetAssemblyIdentity task = CreateTaskUnderTest(engine);
+            task.AssemblyFiles = [new TaskItem("does-not-exist.dll")];
+
+            task.Execute().ShouldBeFalse();
+
+            AssertCouldNotGetAssemblyName(engine);
+            engine.Log.ShouldContain("does-not-exist.dll");
+        }
+
+        [Fact]
+        public void NonAssemblyFile_LogsErrorAndReturnsFalse()
+        {
+            using TestEnvironment env = TestEnvironment.Create(_output);
+            TransientTestFile textFile = env.CreateFile("notanassembly.txt", "This is not an assembly.");
+
+            var engine = new MockEngine(_output);
+            GetAssemblyIdentity task = CreateTaskUnderTest(engine);
+            task.AssemblyFiles = [new TaskItem(textFile.Path)];
+
+            task.Execute().ShouldBeFalse();
+
+            AssertCouldNotGetAssemblyName(engine);
+        }
+
+        [Fact]
+        public void MixedBatch_GoodAndBadItems()
+        {
+            using TestEnvironment env = TestEnvironment.Create(_output);
+            TransientTestFile textFile = env.CreateFile("bad.txt", "not an assembly");
+
+            string goodAssemblyPath = typeof(GetAssemblyIdentity_Tests).Assembly.Location;
+            AssemblyName expectedName = AssemblyName.GetAssemblyName(goodAssemblyPath);
+
+            var engine = new MockEngine(_output);
+            GetAssemblyIdentity task = CreateTaskUnderTest(engine);
+            task.AssemblyFiles =
+            [
+                new TaskItem(goodAssemblyPath),
+                new TaskItem(textFile.Path),
+            ];
+
+            // Execute returns false because one item failed.
+            task.Execute().ShouldBeFalse();
+
+            // The good item should still appear in the output.
+            task.Assemblies.Length.ShouldBe(1);
+            task.Assemblies[0].ItemSpec.ShouldBe(expectedName.FullName);
+
+            // The bad item should have produced an error.
+            engine.Errors.ShouldBe(1);
+        }
+
+        [Fact]
+        public void EmptyItemSpec_LogsErrorAndReturnsFalse()
+        {
+            var engine = new MockEngine(_output);
+            GetAssemblyIdentity task = CreateTaskUnderTest(engine);
+            task.AssemblyFiles = [new TaskItem(string.Empty)];
+
+            task.Execute().ShouldBeFalse();
+
+            AssertCouldNotGetAssemblyName(engine);
+        }
+
+        [Fact]
+        public void RelativePath_ResolvesAgainstProjectDirectory()
+        {
+            using TestEnvironment env = TestEnvironment.Create(_output);
+            TransientTestFolder projectDir = env.CreateFolder();
+
+            string sourceAssembly = typeof(GetAssemblyIdentity_Tests).Assembly.Location;
+            AssemblyName expectedName = AssemblyName.GetAssemblyName(sourceAssembly);
+
+            string relativeFileName = "TestAssembly.dll";
+            File.Copy(sourceAssembly, Path.Combine(projectDir.Path, relativeFileName));
+
+            var engine = new MockEngine(_output);
+            GetAssemblyIdentity task = CreateTaskUnderTest(engine);
+            task.TaskEnvironment = TaskEnvironment.CreateWithProjectDirectoryAndEnvironment(projectDir.Path);
+            task.AssemblyFiles = [new TaskItem(relativeFileName)];
+
+            task.Execute().ShouldBeTrue();
+
+            task.Assemblies.Length.ShouldBe(1);
+            task.Assemblies[0].ItemSpec.ShouldBe(expectedName.FullName);
+        }
+
+        [Fact]
+        public void OutputItem_DoesNotContainAbsolutizedPaths()
+        {
+            string assemblyPath = typeof(GetAssemblyIdentity_Tests).Assembly.Location;
+            AssemblyName expectedName = AssemblyName.GetAssemblyName(assemblyPath);
+
+            GetAssemblyIdentity task = CreateTaskUnderTest();
+            task.AssemblyFiles = [new TaskItem(assemblyPath)];
+
+            task.Execute().ShouldBeTrue();
+
+            task.Assemblies.Length.ShouldBe(1);
+
+            // ItemSpec should be the assembly identity string, not a path.
+            task.Assemblies[0].ItemSpec.ShouldBe(expectedName.FullName);
+        }
+
+        [Fact]
+        public void OutputItem_CopiesInputMetadataVerbatim()
+        {
+            string assemblyPath = typeof(GetAssemblyIdentity_Tests).Assembly.Location;
+
+            var inputItem = new TaskItem(assemblyPath);
+            inputItem.SetMetadata("CustomMeta", "CustomValue");
+
+            GetAssemblyIdentity task = CreateTaskUnderTest();
+            task.AssemblyFiles = [inputItem];
+
+            task.Execute().ShouldBeTrue();
+
+            task.Assemblies.Length.ShouldBe(1);
+            task.Assemblies[0].GetMetadata("CustomMeta").ShouldBe("CustomValue");
+        }
+
+        private void AssertCouldNotGetAssemblyName(MockEngine engine)
+        {
+            engine.Errors.ShouldBe(1);
+            engine.Log.ShouldContain("MSB3441");
+        }
+    }
+}

--- a/src/Tasks/GetAssemblyIdentity.cs
+++ b/src/Tasks/GetAssemblyIdentity.cs
@@ -26,9 +26,7 @@ namespace Microsoft.Build.Tasks
     [MSBuildMultiThreadableTask]
     public class GetAssemblyIdentity : TaskExtension, IMultiThreadableTask
     {
-        /// <summary>
-        /// Gets or sets the task execution environment for thread-safe path resolution.
-        /// </summary>
+        /// <inheritdoc />
         public TaskEnvironment TaskEnvironment { get; set; } = TaskEnvironment.Fallback;
 
         private ITaskItem[] _assemblyFiles;

--- a/src/Tasks/GetAssemblyIdentity.cs
+++ b/src/Tasks/GetAssemblyIdentity.cs
@@ -71,16 +71,9 @@ namespace Microsoft.Build.Tasks
             var list = new List<ITaskItem>();
             foreach (ITaskItem item in AssemblyFiles)
             {
-                AbsolutePath assemblyPath;
-                try
-                {
-                    assemblyPath = TaskEnvironment.GetAbsolutePath(item.ItemSpec);
-                }
-                catch (ArgumentException e)
-                {
-                    Log.LogErrorWithCodeFromResources("GetAssemblyIdentity.CouldNotGetAssemblyName", item.ItemSpec, e.Message);
-                    continue;
-                }
+                ArgumentNullException.ThrowIfNullOrEmpty(item.ItemSpec, nameof(item.ItemSpec));
+
+                AbsolutePath assemblyPath = assemblyPath = TaskEnvironment.GetAbsolutePath(item.ItemSpec);
 
                 AssemblyName an;
                 try

--- a/src/Tasks/GetAssemblyIdentity.cs
+++ b/src/Tasks/GetAssemblyIdentity.cs
@@ -71,9 +71,9 @@ namespace Microsoft.Build.Tasks
             var list = new List<ITaskItem>();
             foreach (ITaskItem item in AssemblyFiles)
             {
-                ArgumentNullException.ThrowIfNullOrEmpty(item.ItemSpec, nameof(item.ItemSpec));
-
-                AbsolutePath assemblyPath = assemblyPath = TaskEnvironment.GetAbsolutePath(item.ItemSpec);
+                string assemblyPath = !string.IsNullOrEmpty(item.ItemSpec)
+                    ? TaskEnvironment.GetAbsolutePath(item.ItemSpec)
+                    : item.ItemSpec;
 
                 AssemblyName an;
                 try

--- a/src/Tasks/GetAssemblyIdentity.cs
+++ b/src/Tasks/GetAssemblyIdentity.cs
@@ -23,8 +23,14 @@ namespace Microsoft.Build.Tasks
     ///  Input:  Assembly Include="foo.exe"
     ///  Output: Identity Include="Foo, Version=1.0.0.0", Name="Foo, Version="1.0.0.0"
     /// </comment>
-    public class GetAssemblyIdentity : TaskExtension
+    [MSBuildMultiThreadableTask]
+    public class GetAssemblyIdentity : TaskExtension, IMultiThreadableTask
     {
+        /// <summary>
+        /// Gets or sets the task execution environment for thread-safe path resolution.
+        /// </summary>
+        public TaskEnvironment TaskEnvironment { get; set; } = TaskEnvironment.Fallback;
+
         private ITaskItem[] _assemblyFiles;
 
         [Required]
@@ -65,10 +71,21 @@ namespace Microsoft.Build.Tasks
             var list = new List<ITaskItem>();
             foreach (ITaskItem item in AssemblyFiles)
             {
+                AbsolutePath assemblyPath;
+                try
+                {
+                    assemblyPath = TaskEnvironment.GetAbsolutePath(item.ItemSpec);
+                }
+                catch (ArgumentException e)
+                {
+                    Log.LogErrorWithCodeFromResources("GetAssemblyIdentity.CouldNotGetAssemblyName", item.ItemSpec, e.Message);
+                    continue;
+                }
+
                 AssemblyName an;
                 try
                 {
-                    an = AssemblyName.GetAssemblyName(item.ItemSpec);
+                    an = AssemblyName.GetAssemblyName(assemblyPath);
                 }
                 catch (BadImageFormatException e)
                 {
@@ -100,6 +117,7 @@ namespace Microsoft.Build.Tasks
                 item.CopyMetadataTo(newItem);
                 list.Add(newItem);
             }
+
             Assemblies = list.ToArray();
             return !Log.HasLoggedErrors;
         }


### PR DESCRIPTION
Migrates the `GetAssemblyIdentity` task to MSBuild's multithreaded execution model, applying the absolutize-at-boundary pattern.

Fixes #13571.

## What changed

Relative `AssemblyFiles` paths are now resolved via `TaskEnvironment.GetAbsolutePath()` instead of relying on `Environment.CurrentDirectory`. This makes the task safe for concurrent execution across projects with different working directories.

## Validation

- `GetAssemblyIdentity_Tests` — 8 tests covering baseline behavior, project-relative resolution, output integrity (Sin 1), and metadata copying.
- Full `Tasks.UnitTests` build passes with 0 warnings.