### PR TITLE
Separate the data-tracking parts of Terminal Logger into a reusable base

### DIFF
--- a/src/Build/Logging/ProjectTrackingLoggerBase.cs
+++ b/src/Build/Logging/ProjectTrackingLoggerBase.cs
@@ -1,8 +1,10 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Collections.Generic;
-using System.Linq;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using Microsoft.Build.Framework;
 
 namespace Microsoft.Build.Logging;
@@ -57,9 +59,28 @@ public abstract class ProjectTrackingLoggerBase<TEvalData, TNodeData, TProjectDa
     private readonly Dictionary<ProjectContext, TProjectData> _projectDataByProjectContextId = new();
 
     /// <summary>
+    /// Protects access to state shared between the logger callbacks and the rendering thread.
+    /// </summary>
+    private readonly LockType _stateUpdateLock = new();
+
+    /// <summary>
     /// Tracks build-level data for the entire build session.
     /// </summary>
     private TBuildData? _buildData;
+
+    /// <summary>
+    /// Tracks the work currently being done by build nodes. Null means the node is not doing any work worth reporting.
+    /// </summary>
+    /// <remarks>
+    /// There is no locking around access to this data structure despite it being accessed concurrently by multiple threads.
+    /// However, reads and writes to locations in an array is atomic, so locking is not required.
+    /// </remarks>
+    private TNodeData?[] _nodeDataByNodeId = [];
+
+    /// <summary>
+    /// True if we're replaying a binary log. In this mode, we may encounter NodeIds higher than the initial node count.
+    /// </summary>
+    private bool _isReplayMode = false;
 
     #region INodeLogger implementation
 
@@ -74,6 +95,15 @@ public abstract class ProjectTrackingLoggerBase<TEvalData, TNodeData, TProjectDa
     /// </summary>
     protected int NodeCount { get; private set; }
 
+    public virtual bool NeedsTaskInputs => false;
+
+    public virtual bool NeedsEvaluationPropertiesAndItems => false;
+
+    /// <summary>
+    /// Opts this base into tracking per-node data structures.
+    /// </summary>
+    public virtual bool UsesPerNodeData => false;
+
     /// <inheritdoc/>
     public virtual void Initialize(IEventSource eventSource, int nodeCount)
     {
@@ -81,11 +111,18 @@ public abstract class ProjectTrackingLoggerBase<TEvalData, TNodeData, TProjectDa
         NodeCount = nodeCount + 1;
 
         Initialize(eventSource);
+
+        _nodeDataByNodeId = UsesPerNodeData ? new TNodeData?[NodeCount] : [];
     }
 
     /// <inheritdoc/>
     public virtual void Initialize(IEventSource eventSource)
     {
+        if (eventSource is BinaryLogReplayEventSource)
+        {
+            _isReplayMode = true;
+        }
+
         eventSource.BuildStarted += BuildStartedHandler;
         eventSource.BuildFinished += BuildFinishedHandler;
         eventSource.ProjectStarted += ProjectStartedHandler;
@@ -99,12 +136,12 @@ public abstract class ProjectTrackingLoggerBase<TEvalData, TNodeData, TProjectDa
         eventSource.WarningRaised += WarningRaisedHandler;
         eventSource.ErrorRaised += ErrorRaisedHandler;
 
-        if (eventSource is IEventSource3 eventSource3)
+        if (eventSource is IEventSource3 eventSource3 && NeedsTaskInputs)
         {
             eventSource3.IncludeTaskInputs();
         }
 
-        if (eventSource is IEventSource4 eventSource4)
+        if (eventSource is IEventSource4 eventSource4 && NeedsEvaluationPropertiesAndItems)
         {
             eventSource4.IncludeEvaluationPropertiesAndItems();
         }
@@ -131,7 +168,7 @@ public abstract class ProjectTrackingLoggerBase<TEvalData, TNodeData, TProjectDa
     /// </summary>
     private void BuildFinishedHandler(object sender, BuildFinishedEventArgs e)
     {
-        OnBuildFinished(e, _projectDataByProjectContextId.Values.ToArray(), _buildData!);
+        OnBuildFinished(e, _projectDataByProjectContextId.Values, _buildData!);
 
         // Clear tracking data
         _projectDataByProjectContextId.Clear();
@@ -192,9 +229,9 @@ public abstract class ProjectTrackingLoggerBase<TEvalData, TNodeData, TProjectDa
         else if (FileUtilities.IsMetaprojectFilename(e.ProjectFile))
         {
             // create synthetic evaluation data for metaprojects
-                TEvalData syntheticEvalData = CreateSyntheticEvalDataForMetaproject(e);
-                _evaluationDataByEvalId[evalContext] = syntheticEvalData;
-                return syntheticEvalData;
+            TEvalData syntheticEvalData = CreateSyntheticEvalDataForMetaproject(e);
+            _evaluationDataByEvalId[evalContext] = syntheticEvalData;
+            return syntheticEvalData;
         }
         return default;
     }
@@ -350,6 +387,66 @@ public abstract class ProjectTrackingLoggerBase<TEvalData, TNodeData, TProjectDa
             BuildEventContext context => NodeIdForContext(context),
         };
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void EnsurePerNodeDataEnabled()
+    {
+        Debug.Assert(UsesPerNodeData, "Node data is not being tracked because UsesPerNodeData is false. Opt this logger into tracking per-node data by overriding UsesPerNodeData to return true.");
+    }
+
+    /// <summary>
+    /// Retrieves the node data associated with the given build event, based on the node ID in the event's <see cref="BuildEventContext"/>, or <see langword="null"/> if no data is found.
+    /// </summary>
+    protected TNodeData? GetNodeDataForEvent(BuildEventArgs e)
+    {
+        EnsurePerNodeDataEnabled();
+        int? node = GetNodeArrayIndexForEvent(e);
+        if (node is int nodeId)
+        {
+            EnsureNodeCapacity(nodeId);
+            if (_nodeDataByNodeId[nodeId] is TNodeData status)
+            {
+                return status;
+            }
+        }
+
+        return default;
+    }
+
+    /// <summary>
+    /// Updates the node data associated with the given build event in the internal tracking.
+    /// </summary>
+    protected void SetActiveNodeStatus(BuildEventArgs e, TNodeData status)
+    {
+        EnsurePerNodeDataEnabled();
+        if (GetNodeArrayIndexForEvent(e) is int nodeId)
+        {
+            EnsureNodeCapacity(nodeId);
+            _nodeDataByNodeId[nodeId] = status;
+        }
+    }
+
+    /// <summary>
+    /// Marks the node associated with the given build event as no longer active.
+    /// </summary>
+    protected void YieldNode(BuildEventArgs e)
+    {
+        EnsurePerNodeDataEnabled();
+        if (GetNodeArrayIndexForEvent(e) is int nodeId)
+        {
+            EnsureNodeCapacity(nodeId);
+            _nodeDataByNodeId[nodeId] = default;
+        }
+    }
+
+    /// <summary>
+    /// Gets a read-only view of the per-node data.
+    /// </summary>
+    protected ReadOnlySpan<TNodeData?> GetAllNodeData()
+    {
+        EnsurePerNodeDataEnabled();
+        return _nodeDataByNodeId;
+    }
+
     #endregion
 
     #region Private helpers
@@ -386,6 +483,27 @@ public abstract class ProjectTrackingLoggerBase<TEvalData, TNodeData, TProjectDa
         }
     }
 
+    /// <summary>
+    /// Ensures that the <see cref="_nodeDataByNodeId"/> array has enough capacity to accommodate the given index.
+    /// This is necessary for binary log replay scenarios where the replay may use fewer nodes than the original build.
+    /// </summary>
+    private void EnsureNodeCapacity(int nodeIndex)
+    {
+        // Only resize in replay mode - during normal builds, the node count is fixed
+        if (_isReplayMode && nodeIndex >= _nodeDataByNodeId.Length)
+        {
+            // Resize to accommodate the new index plus some extra capacity
+            lock (_stateUpdateLock)
+            {
+                if (nodeIndex >= _nodeDataByNodeId.Length)
+                {
+                    int newSize = Math.Max(nodeIndex + 1, _nodeDataByNodeId.Length * 2);
+                    Array.Resize(ref _nodeDataByNodeId, newSize);
+                }
+            }
+        }
+    }
+
     #endregion
 
     #region Abstract methods - must be implemented by subclasses
@@ -410,7 +528,6 @@ public abstract class ProjectTrackingLoggerBase<TEvalData, TNodeData, TProjectDa
     /// <param name="e">The project started event args.</param>
     /// <returns>The project data to store, or null to not track this project.</returns>
     protected abstract TProjectData? CreateProjectData(TEvalData? evalData, TBuildData buildData, ProjectStartedEventArgs e);
-    
 
     /// <summary>
     /// Creates build data when the build starts.
@@ -431,7 +548,7 @@ public abstract class ProjectTrackingLoggerBase<TEvalData, TNodeData, TProjectDa
     /// <summary>
     /// Called when the build finishes.
     /// </summary>
-    protected virtual void OnBuildFinished(BuildFinishedEventArgs e, TProjectData[] projectData, TBuildData buildData) { }
+    protected virtual void OnBuildFinished(BuildFinishedEventArgs e, IEnumerable<TProjectData> projectData, TBuildData buildData) { }
 
     /// <summary>
     /// Called when the build is canceled.

--- a/src/Build/Logging/ProjectTrackingLoggerBase.cs
+++ b/src/Build/Logging/ProjectTrackingLoggerBase.cs
@@ -378,14 +378,7 @@ public abstract class ProjectTrackingLoggerBase<TEvalData, TNodeData, TProjectDa
     #endregion
 
     #region Protected helpers
-    
-    /// <inheritdoc cref="NodeIdForContext(BuildEventContext)"/>
-    protected int? GetNodeArrayIndexForEvent(BuildEventArgs args) => 
-        args?.BuildEventContext switch
-        {
-            null => null,
-            BuildEventContext context => NodeIdForContext(context),
-        };
+
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     private void EnsurePerNodeDataEnabled()
@@ -399,7 +392,7 @@ public abstract class ProjectTrackingLoggerBase<TEvalData, TNodeData, TProjectDa
     protected TNodeData? GetNodeDataForEvent(BuildEventArgs e)
     {
         EnsurePerNodeDataEnabled();
-        int? node = GetNodeArrayIndexForEvent(e);
+        int? node = NodeIdForContext(e.BuildEventContext);
         if (node is int nodeId)
         {
             EnsureNodeCapacity(nodeId);
@@ -418,7 +411,7 @@ public abstract class ProjectTrackingLoggerBase<TEvalData, TNodeData, TProjectDa
     protected void SetActiveNodeStatus(BuildEventArgs e, TNodeData status)
     {
         EnsurePerNodeDataEnabled();
-        if (GetNodeArrayIndexForEvent(e) is int nodeId)
+        if (NodeIdForContext(e.BuildEventContext) is int nodeId)
         {
             EnsureNodeCapacity(nodeId);
             _nodeDataByNodeId[nodeId] = status;
@@ -431,7 +424,7 @@ public abstract class ProjectTrackingLoggerBase<TEvalData, TNodeData, TProjectDa
     protected void YieldNode(BuildEventArgs e)
     {
         EnsurePerNodeDataEnabled();
-        if (GetNodeArrayIndexForEvent(e) is int nodeId)
+        if (NodeIdForContext(e.BuildEventContext) is int nodeId)
         {
             EnsureNodeCapacity(nodeId);
             _nodeDataByNodeId[nodeId] = default;
@@ -457,10 +450,13 @@ public abstract class ProjectTrackingLoggerBase<TEvalData, TNodeData, TProjectDa
     /// <remarks>
     /// Engine Node IDs are 1-based, so we subtract 1 to get a zero-based array index.
     /// </remarks>
-    private int NodeIdForContext(BuildEventContext context)
+    private int? NodeIdForContext(BuildEventContext? context)
     {
-        // Node IDs reported by the build are 1-based.
-        return context.NodeId - 1;
+        return context switch
+        {
+            null => null,
+            _ => context.NodeId - 1,// Node IDs reported by the build are 1-based.
+        };
     }
 
     /// <summary>

--- a/src/Build/Logging/ProjectTrackingLoggerBase.cs
+++ b/src/Build/Logging/ProjectTrackingLoggerBase.cs
@@ -173,7 +173,7 @@ public abstract class ProjectTrackingLoggerBase<TEvalData, TNodeData, TProjectDa
         if (TryGetEvalDataForProject(e) is TEvalData evalData)
         {
             // Create project data using the eval data
-            TProjectData? projectData = CreateProjectData(evalData, e);
+            TProjectData? projectData = CreateProjectData(evalData, _buildData, e);
             if (projectData != null)
             {
                 _projectDataByProjectContextId[projectContext] = projectData;
@@ -341,14 +341,26 @@ public abstract class ProjectTrackingLoggerBase<TEvalData, TNodeData, TProjectDa
     #endregion
 
     #region Protected helpers
-
-    protected int? GetNodeIdForEvent(BuildEventArgs args) => args?.BuildEventContext is null ? null : NodeIndexForContext(args.BuildEventContext);
+    
+    /// <inheritdoc cref="NodeIdForContext(BuildEventContext)"/>
+    protected int? GetNodeArrayIndexForEvent(BuildEventArgs args) => 
+        args?.BuildEventContext switch
+        {
+            null => null,
+            BuildEventContext context => NodeIdForContext(context),
+        };
 
     #endregion
 
     #region Private helpers
 
-    private int NodeIndexForContext(BuildEventContext context)
+    /// <summary>
+    /// Computes the zero-based node array index for the given build event context.
+    /// </summary>
+    /// <remarks>
+    /// Engine Node IDs are 1-based, so we subtract 1 to get a zero-based array index.
+    /// </remarks>
+    private int NodeIdForContext(BuildEventContext context)
     {
         // Node IDs reported by the build are 1-based.
         return context.NodeId - 1;
@@ -394,9 +406,10 @@ public abstract class ProjectTrackingLoggerBase<TEvalData, TNodeData, TProjectDa
     /// Creates project data from the project started event and evaluation data.
     /// </summary>
     /// <param name="evalData">The evaluation data for this project.</param>
+    /// <param name="buildData">The build data for this build session - can be used to decide if the project should be tracked.</param>
     /// <param name="e">The project started event args.</param>
     /// <returns>The project data to store, or null to not track this project.</returns>
-    protected abstract TProjectData? CreateProjectData(TEvalData? evalData, ProjectStartedEventArgs e);
+    protected abstract TProjectData? CreateProjectData(TEvalData? evalData, TBuildData buildData, ProjectStartedEventArgs e);
     
 
     /// <summary>

--- a/src/Build/Logging/ProjectTrackingLoggerBase.cs
+++ b/src/Build/Logging/ProjectTrackingLoggerBase.cs
@@ -173,7 +173,7 @@ public abstract class ProjectTrackingLoggerBase<TEvalData, TNodeData, TProjectDa
         if (TryGetEvalDataForProject(e) is TEvalData evalData)
         {
             // Create project data using the eval data
-            TProjectData? projectData = CreateProjectData(evalData, _buildData, e);
+            TProjectData? projectData = CreateProjectData(evalData, _buildData!, e);
             if (projectData != null)
             {
                 _projectDataByProjectContextId[projectContext] = projectData;

--- a/src/Build/Logging/ProjectTrackingLoggerBase.cs
+++ b/src/Build/Logging/ProjectTrackingLoggerBase.cs
@@ -1,0 +1,474 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Build.Framework;
+
+namespace Microsoft.Build.Logging;
+
+/// <summary>
+/// A wrapper over the project context ID passed to us in <see cref="IEventSource"/> logger events.
+/// </summary>
+internal record struct ProjectContext(int Id)
+{
+    public ProjectContext(BuildEventContext context)
+        : this(context.ProjectContextId)
+    {
+    }
+}
+
+/// <summary>
+/// A wrapper over the evaluation context ID passed to us in <see cref="IEventSource"/> logger events.
+/// </summary>
+internal record struct EvalContext(int Id)
+{
+    public EvalContext(BuildEventContext context)
+        : this(context.EvaluationId)
+    {
+    }
+}
+
+/// <summary>
+/// Base class that tracks build state (evaluation data, node status, completed project data, and whole-build data) during builds.
+/// Subclasses can specialize the type of data tracked for each area and implement rendering logic.
+/// </summary>
+/// <typeparam name="TEvalData">Data gathered/projected for each evaluation context</typeparam>
+/// <typeparam name="TNodeData">Data stored for each live, actively running build worker node</typeparam>
+/// <typeparam name="TProjectData">Data stored for each completed project context instance</typeparam>
+/// <typeparam name="TBuildData">Data that is aggregated across the entire build session</typeparam>
+public abstract class ProjectTrackingLoggerBase<TEvalData, TNodeData, TProjectData, TBuildData> : INodeLogger
+{
+
+    /// <summary>
+    /// Tracks the evaluation data for all evaluations seen so far.
+    /// </summary>
+    /// <remarks>
+    /// Keyed by an ID that gets passed to logger callbacks, this allows us to quickly look up the corresponding evaluation.
+    /// </remarks>
+    private readonly Dictionary<EvalContext, TEvalData> _evaluationDataByEvalId = new();
+
+    /// <summary>
+    /// Tracks the status of all relevant projects seen so far.
+    /// </summary>
+    /// <remarks>
+    /// Keyed by an ID that gets passed to logger callbacks, this allows us to quickly look up the corresponding project.
+    /// </remarks>
+    private readonly Dictionary<ProjectContext, TProjectData> _projectDataByProjectContextId = new();
+
+    /// <summary>
+    /// Tracks build-level data for the entire build session.
+    /// </summary>
+    private TBuildData? _buildData;
+
+    #region INodeLogger implementation
+
+    /// <inheritdoc/>
+    public abstract LoggerVerbosity Verbosity { get; set; }
+
+    /// <inheritdoc/>
+    public abstract string? Parameters { get; set; }
+
+    /// <summary>
+    /// The number of nodes in the build. Handles the case where MSBUILDNOINPROCNODE is set by reserving an extra slot.
+    /// </summary>
+    protected int NodeCount { get; private set; }
+
+    /// <inheritdoc/>
+    public virtual void Initialize(IEventSource eventSource, int nodeCount)
+    {
+        // When MSBUILDNOINPROCNODE enabled, NodeId's reported by build start with 2. We need to reserve an extra spot for this case.
+        NodeCount = nodeCount + 1;
+
+        Initialize(eventSource);
+    }
+
+    /// <inheritdoc/>
+    public virtual void Initialize(IEventSource eventSource)
+    {
+        eventSource.BuildStarted += BuildStartedHandler;
+        eventSource.BuildFinished += BuildFinishedHandler;
+        eventSource.ProjectStarted += ProjectStartedHandler;
+        eventSource.ProjectFinished += ProjectFinishedHandler;
+        eventSource.TargetStarted += TargetStartedHandler;
+        eventSource.TargetFinished += TargetFinishedHandler;
+        eventSource.TaskStarted += TaskStartedHandler;
+        eventSource.TaskFinished += TaskFinishedHandler;
+        eventSource.StatusEventRaised += StatusEventRaisedHandler;
+        eventSource.MessageRaised += MessageRaisedHandler;
+        eventSource.WarningRaised += WarningRaisedHandler;
+        eventSource.ErrorRaised += ErrorRaisedHandler;
+
+        if (eventSource is IEventSource3 eventSource3)
+        {
+            eventSource3.IncludeTaskInputs();
+        }
+
+        if (eventSource is IEventSource4 eventSource4)
+        {
+            eventSource4.IncludeEvaluationPropertiesAndItems();
+        }
+    }
+
+    /// <inheritdoc/>
+    public abstract void Shutdown();
+
+    #endregion
+
+    #region Logger callbacks
+
+    /// <summary>
+    /// The <see cref="IEventSource.BuildStarted"/> callback.
+    /// </summary>
+    private void BuildStartedHandler(object sender, BuildStartedEventArgs e)
+    {
+        _buildData = CreateBuildData(e);
+        OnBuildStarted(e, _buildData);
+    }
+
+    /// <summary>
+    /// The <see cref="IEventSource.BuildFinished"/> callback.
+    /// </summary>
+    private void BuildFinishedHandler(object sender, BuildFinishedEventArgs e)
+    {
+        OnBuildFinished(e, _projectDataByProjectContextId.Values.ToArray(), _buildData!);
+
+        // Clear tracking data
+        _projectDataByProjectContextId.Clear();
+        _evaluationDataByEvalId.Clear();
+        _buildData = default;
+    }
+
+    /// <summary>
+    /// The <see cref="IEventSource.StatusEventRaised"/> callback.
+    /// </summary>
+    private void StatusEventRaisedHandler(object sender, BuildStatusEventArgs e)
+    {
+        switch (e)
+        {
+            case BuildCanceledEventArgs cancelEvent:
+                OnBuildCanceled(cancelEvent);
+                break;
+            case ProjectEvaluationStartedEventArgs:
+                break;
+            case ProjectEvaluationFinishedEventArgs evalFinish:
+                CaptureEvalContext(evalFinish);
+                break;
+        }
+    }
+
+    /// <summary>
+    /// The <see cref="IEventSource.ProjectStarted"/> callback.
+    /// </summary>
+    private void ProjectStartedHandler(object sender, ProjectStartedEventArgs e)
+    {
+        if (e.BuildEventContext is null)
+        {
+            return;
+        }
+
+        ProjectContext projectContext = new(e.BuildEventContext);
+
+        // Get eval data for this project. 
+        if (TryGetEvalDataForProject(e) is TEvalData evalData)
+        {
+            // Create project data using the eval data
+            TProjectData? projectData = CreateProjectData(evalData, e);
+            if (projectData != null)
+            {
+                _projectDataByProjectContextId[projectContext] = projectData;
+                OnProjectStarted(e, evalData, projectData!, _buildData!);
+            }
+        }
+    }
+
+    private TEvalData? TryGetEvalDataForProject(ProjectStartedEventArgs e)
+    {
+        EvalContext evalContext = new(e.BuildEventContext!);
+        if (_evaluationDataByEvalId.TryGetValue(evalContext, out TEvalData? evalData))
+        {
+            return evalData;
+        }
+        else if (FileUtilities.IsMetaprojectFilename(e.ProjectFile))
+        {
+            // create synthetic evaluation data for metaprojects
+                TEvalData syntheticEvalData = CreateSyntheticEvalDataForMetaproject(e);
+                _evaluationDataByEvalId[evalContext] = syntheticEvalData;
+                return syntheticEvalData;
+        }
+        return default;
+    }
+
+    /// <summary>
+    /// The <see cref="IEventSource.ProjectFinished"/> callback.
+    /// </summary>
+    private void ProjectFinishedHandler(object sender, ProjectFinishedEventArgs e)
+    {
+        var buildEventContext = e.BuildEventContext;
+        if (buildEventContext is null)
+        {
+            return;
+        }
+
+        ProjectContext projectContext = new(buildEventContext);
+
+        // Get project data
+        if (_projectDataByProjectContextId.TryGetValue(projectContext, out var projectData))
+        {
+            OnProjectFinished(e, projectData, _buildData!);
+        }
+    }
+
+    /// <summary>
+    /// The <see cref="IEventSource.TargetStarted"/> callback.
+    /// </summary>
+    private void TargetStartedHandler(object sender, TargetStartedEventArgs e)
+    {
+        var buildEventContext = e.BuildEventContext;
+        if (buildEventContext is not null)
+        {
+            ProjectContext projectContext = new(buildEventContext);
+            if (_projectDataByProjectContextId.TryGetValue(projectContext, out TProjectData? projectData))
+            {
+                OnTargetStarted(e, projectData, _buildData!);
+            }
+        }
+    }
+
+    /// <summary>
+    /// The <see cref="IEventSource.TargetFinished"/> callback.
+    /// </summary>
+    private void TargetFinishedHandler(object sender, TargetFinishedEventArgs e)
+    {
+        var buildEventContext = e.BuildEventContext;
+        if (buildEventContext is null)
+        {
+            return;
+        }
+
+        ProjectContext projectContext = new(buildEventContext);
+        if (_projectDataByProjectContextId.TryGetValue(projectContext, out var projectData))
+        {
+            OnTargetFinished(e, projectData, _buildData!);
+        }
+    }
+
+    /// <summary>
+    /// The <see cref="IEventSource.TaskStarted"/> callback.
+    /// </summary>
+    private void TaskStartedHandler(object sender, TaskStartedEventArgs e)
+    {
+        var buildEventContext = e.BuildEventContext;
+        if (buildEventContext is not null)
+        {
+            ProjectContext projectContext = new(buildEventContext);
+            if (_projectDataByProjectContextId.TryGetValue(projectContext, out var projectData))
+            {
+                OnTaskStarted(e, projectData, _buildData!);
+            }
+        }
+    }
+
+    /// <summary>
+    /// The <see cref="IEventSource.TaskFinished"/> callback.
+    /// </summary>
+    private void TaskFinishedHandler(object sender, TaskFinishedEventArgs e)
+    {
+        var buildEventContext = e.BuildEventContext;
+        if (buildEventContext is not null)
+        {
+            ProjectContext projectContext = new(buildEventContext);
+            if (_projectDataByProjectContextId.TryGetValue(projectContext, out var projectData))
+            {
+                OnTaskFinished(e, projectData, _buildData!);
+            }
+        }
+    }
+
+    /// <summary>
+    /// The <see cref="IEventSource.MessageRaised"/> callback.
+    /// </summary>
+    private void MessageRaisedHandler(object sender, BuildMessageEventArgs e)
+    {
+        var buildEventContext = e.BuildEventContext;
+        if (buildEventContext is null)
+        {
+            return;
+        }
+
+        ProjectContext projectContext = new(buildEventContext);
+        TProjectData? projectData = default;
+        _projectDataByProjectContextId.TryGetValue(projectContext, out projectData);
+        OnMessageRaised(e, projectData, _buildData!);
+    }
+
+    /// <summary>
+    /// The <see cref="IEventSource.WarningRaised"/> callback.
+    /// </summary>
+    private void WarningRaisedHandler(object sender, BuildWarningEventArgs e)
+    {
+        BuildEventContext? buildEventContext = e.BuildEventContext;
+        if (buildEventContext is null)
+        {
+            OnWarningRaised(e, default, _buildData!);
+            return;
+        }
+
+        ProjectContext projectContext = new(buildEventContext);
+        TProjectData? projectData = default;
+        _projectDataByProjectContextId.TryGetValue(projectContext, out projectData);
+        OnWarningRaised(e, projectData, _buildData!);
+    }
+
+    /// <summary>
+    /// The <see cref="IEventSource.ErrorRaised"/> callback.
+    /// </summary>
+    private void ErrorRaisedHandler(object sender, BuildErrorEventArgs e)
+    {
+        BuildEventContext? buildEventContext = e.BuildEventContext;
+        if (buildEventContext is null)
+        {
+            OnErrorRaised(e, default, _buildData!);
+            return;
+        }
+
+        ProjectContext projectContext = new(buildEventContext);
+        TProjectData? projectData = default;
+        _projectDataByProjectContextId.TryGetValue(projectContext, out projectData);
+        OnErrorRaised(e, projectData, _buildData!);
+    }
+
+    #endregion
+
+    #region Protected helpers
+
+    protected int? GetNodeIdForEvent(BuildEventArgs args) => args?.BuildEventContext is null ? null : NodeIndexForContext(args.BuildEventContext);
+
+    #endregion
+
+    #region Private helpers
+
+    private int NodeIndexForContext(BuildEventContext context)
+    {
+        // Node IDs reported by the build are 1-based.
+        return context.NodeId - 1;
+    }
+
+    /// <summary>
+    /// Captures evaluation context data from the evaluation finished event.
+    /// </summary>
+    private void CaptureEvalContext(ProjectEvaluationFinishedEventArgs evalFinish)
+    {
+        var buildEventContext = evalFinish.BuildEventContext;
+        if (buildEventContext is null)
+        {
+            return;
+        }
+
+        EvalContext evalContext = new(buildEventContext);
+
+        if (!_evaluationDataByEvalId.ContainsKey(evalContext))
+        {
+            TEvalData evalData = CreateEvalData(evalFinish);
+            _evaluationDataByEvalId[evalContext] = evalData;
+        }
+    }
+
+    #endregion
+
+    #region Abstract methods - must be implemented by subclasses
+
+    /// <summary>
+    /// Creates evaluation data from the evaluation finished event.
+    /// </summary>
+    /// <param name="e">The evaluation finished event args.</param>
+    /// <returns>The evaluation data to store, or null to not track this evaluation.</returns>
+    protected abstract TEvalData CreateEvalData(ProjectEvaluationFinishedEventArgs e);
+
+    /// <summary>
+    /// Creates synthetic evaluation data for a metaproject from the project started event.
+    /// </summary>
+    protected abstract TEvalData CreateSyntheticEvalDataForMetaproject(ProjectStartedEventArgs e);
+
+    /// <summary>
+    /// Creates project data from the project started event and evaluation data.
+    /// </summary>
+    /// <param name="evalData">The evaluation data for this project.</param>
+    /// <param name="e">The project started event args.</param>
+    /// <returns>The project data to store, or null to not track this project.</returns>
+    protected abstract TProjectData? CreateProjectData(TEvalData? evalData, ProjectStartedEventArgs e);
+    
+
+    /// <summary>
+    /// Creates build data when the build starts.
+    /// </summary>
+    /// <param name="e">The build started event args.</param>
+    /// <returns>The build data to track for this build session.</returns>
+    protected abstract TBuildData CreateBuildData(BuildStartedEventArgs e);
+
+    #endregion
+
+    #region Virtual methods - can be overridden by subclasses
+
+    /// <summary>
+    /// Called when the build starts.
+    /// </summary>
+    protected virtual void OnBuildStarted(BuildStartedEventArgs e, TBuildData buildData) { }
+
+    /// <summary>
+    /// Called when the build finishes.
+    /// </summary>
+    protected virtual void OnBuildFinished(BuildFinishedEventArgs e, TProjectData[] projectData, TBuildData buildData) { }
+
+    /// <summary>
+    /// Called when the build is canceled.
+    /// </summary>
+    protected virtual void OnBuildCanceled(BuildCanceledEventArgs e) { }
+
+    /// <summary>
+    /// Called when a project starts.
+    /// </summary>
+    protected virtual void OnProjectStarted(ProjectStartedEventArgs e, TEvalData evalData, TProjectData projectData, TBuildData buildData) { }
+
+    /// <summary>
+    /// Called when a project finishes.
+    /// </summary>
+    protected virtual void OnProjectFinished(ProjectFinishedEventArgs e, TProjectData projectData, TBuildData buildData) { }
+
+    /// <summary>
+    /// Called when a target starts.
+    /// </summary>
+    protected virtual void OnTargetStarted(TargetStartedEventArgs e, TProjectData projectData, TBuildData buildData) { }
+
+    /// <summary>
+    /// Called when a target finishes.
+    /// </summary>
+    protected virtual void OnTargetFinished(TargetFinishedEventArgs e, TProjectData projectData, TBuildData buildData) { }
+
+    /// <summary>
+    /// Called when a task starts.
+    /// </summary>
+    protected virtual void OnTaskStarted(TaskStartedEventArgs e, TProjectData projectData, TBuildData buildData) { }
+
+    /// <summary>
+    /// Called when a task finishes.
+    /// </summary>
+    protected virtual void OnTaskFinished(TaskFinishedEventArgs e, TProjectData projectData, TBuildData buildData) { }
+
+    /// <summary>
+    /// Called when a message is raised.
+    /// </summary>
+    protected virtual void OnMessageRaised(BuildMessageEventArgs e, TProjectData? projectData, TBuildData buildData) { }
+
+    /// <summary>
+    /// Called when a warning is raised.
+    /// </summary>
+    protected virtual void OnWarningRaised(BuildWarningEventArgs e, TProjectData? projectData, TBuildData buildData) { }
+
+    /// <summary>
+    /// Called when an error is raised.
+    /// </summary>
+    protected virtual void OnErrorRaised(BuildErrorEventArgs e, TProjectData? projectData, TBuildData buildData) { }
+
+    #endregion
+}

--- a/src/Build/Logging/TerminalLogger/StopwatchAbstraction.cs
+++ b/src/Build/Logging/TerminalLogger/StopwatchAbstraction.cs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.Build.Logging;
 
-internal abstract class StopwatchAbstraction
+public abstract class StopwatchAbstraction
 {
     public abstract void Start();
     public abstract void Stop();

--- a/src/Build/Logging/TerminalLogger/TerminalBuildData.cs
+++ b/src/Build/Logging/TerminalLogger/TerminalBuildData.cs
@@ -1,0 +1,51 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+namespace Microsoft.Build.Logging;
+
+/// <summary>
+/// Tracks build-level data for the TerminalLogger across an entire build session.
+/// </summary>
+public sealed class TerminalBuildData
+{
+    /// <summary>
+    /// The timestamp of the build start event.
+    /// </summary>
+    public DateTime BuildStartTime { get; set; }
+
+    /// <summary>
+    /// Number of build errors encountered during the build.
+    /// </summary>
+    public int BuildErrorsCount { get; set; }
+
+    /// <summary>
+    /// Number of build warnings encountered during the build.
+    /// </summary>
+    public int BuildWarningsCount { get; set; }
+
+    /// <summary>
+    /// The project build context corresponding to the Restore initial target, or null if the build is currently not restoring.
+    /// </summary>
+    public int? RestoreContext { get; set; }
+
+    /// <summary>
+    /// True if restore failed and this failure has already been reported.
+    /// </summary>
+    public bool RestoreFailed { get; set; }
+
+    /// <summary>
+    /// True if restore happened and finished.
+    /// </summary>
+    public bool RestoreFinished { get; set; }
+
+    /// <summary>
+    /// Initializes a new instance of TerminalBuildData.
+    /// </summary>
+    /// <param name="buildStartTime">The timestamp when the build started.</param>
+    public TerminalBuildData(DateTime buildStartTime)
+    {
+        BuildStartTime = buildStartTime;
+    }
+}

--- a/src/Build/Logging/TerminalLogger/TerminalBuildData.cs
+++ b/src/Build/Logging/TerminalLogger/TerminalBuildData.cs
@@ -31,6 +31,11 @@ public sealed class TerminalBuildData
     public int? RestoreContext { get; set; }
 
     /// <summary>
+    /// True if the build is currently performing a restore operation.
+    /// </summary>
+    public bool IsRestoring => RestoreContext is not null;
+
+    /// <summary>
     /// True if restore failed and this failure has already been reported.
     /// </summary>
     public bool RestoreFailed { get; set; }

--- a/src/Build/Logging/TerminalLogger/TerminalBuildMessage.cs
+++ b/src/Build/Logging/TerminalLogger/TerminalBuildMessage.cs
@@ -6,5 +6,5 @@ namespace Microsoft.Build.Logging;
 /// <summary>
 /// Represents a piece of diagnostic output (message/warning/error).
 /// </summary>
-internal record struct TerminalBuildMessage(TerminalMessageSeverity Severity, string Message)
+public record struct TerminalBuildMessage(TerminalMessageSeverity Severity, string Message)
 { }

--- a/src/Build/Logging/TerminalLogger/TerminalLogger.cs
+++ b/src/Build/Logging/TerminalLogger/TerminalLogger.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Build.Logging;
 /// <remarks>
 /// Uses ANSI/VT100 control codes to erase and overwrite lines as the build is progressing.
 /// </remarks>
-public sealed partial class TerminalLogger : INodeLogger
+public sealed partial class TerminalLogger : ProjectTrackingLoggerBase<EvalProjectInfo, TerminalNodeStatus, TerminalProjectInfo, TerminalBuildData>
 {
     private const string FilePathPattern = " -> ";
     private const string MSBuildTaskName = "MSBuild";
@@ -43,27 +43,7 @@ public sealed partial class TerminalLogger : INodeLogger
 
     private static readonly string[] newLineStrings = { "\r\n", "\n" };
 
-    /// <summary>
-    /// A wrapper over the project context ID passed to us in <see cref="IEventSource"/> logger events.
-    /// </summary>
-    internal record struct ProjectContext(int Id)
-    {
-        public ProjectContext(BuildEventContext context)
-            : this(context.ProjectContextId)
-        {
-        }
-    }
-
-    /// <summary>
-    /// A wrapper over the evaluation context ID passed to us in <see cref="IEventSource"/> logger events.
-    /// </summary>
-    internal record struct EvalContext(int Id)
-    {
-        public EvalContext(BuildEventContext context)
-            : this(context.EvaluationId)
-        {
-        }
-    }
+    // ProjectContext and EvalContext are now inherited from BuildTrackerLogger
 
     private readonly record struct TestSummary(int Total, int Passed, int Skipped, int Failed);
 
@@ -82,6 +62,15 @@ public sealed partial class TerminalLogger : INodeLogger
     internal Func<StopwatchAbstraction>? _createStopwatch = null;
 
     /// <summary>
+    /// Tracks the work currently being done by build nodes. Null means the node is not doing any work worth reporting.
+    /// </summary>
+    /// <remarks>
+    /// There is no locking around access to this data structure despite it being accessed concurrently by multiple threads.
+    /// However, reads and writes to locations in an array is atomic, so locking is not required.
+    /// </remarks>
+    private TerminalNodeStatus?[] _nodes = [];
+
+    /// <summary>
     /// Name of target that identifies the project cache plugin run has just started.
     /// </summary>
     private const string CachePluginStartTarget = "_CachePluginRunStart";
@@ -96,60 +85,12 @@ public sealed partial class TerminalLogger : INodeLogger
     /// </summary>
     private readonly CancellationTokenSource _cts = new();
 
-    /// <summary>
-    /// Tracks the status of all relevant projects seen so far.
-    /// </summary>
-    /// <remarks>
-    /// Keyed by an ID that gets passed to logger callbacks, this allows us to quickly look up the corresponding project.
-    /// </remarks>
-    private readonly Dictionary<ProjectContext, TerminalProjectInfo> _projects = [];
-
-    private readonly Dictionary<EvalContext, EvalProjectInfo> _projectEvaluations = [];
-
-    /// <summary>
-    /// Tracks the work currently being done by build nodes. Null means the node is not doing any work worth reporting.
-    /// </summary>
-    /// <remarks>
-    /// There is no locking around access to this data structure despite it being accessed concurrently by multiple threads.
-    /// However, reads and writes to locations in an array is atomic, so locking is not required.
-    /// </remarks>
-    private TerminalNodeStatus?[] _nodes = Array.Empty<TerminalNodeStatus>();
-
-    /// <summary>
-    /// The timestamp of the <see cref="IEventSource.BuildStarted"/> event.
-    /// </summary>
-    private DateTime _buildStartTime;
 
     /// <summary>
     /// The working directory when the build starts, to trim relative output paths.
     /// </summary>
     private readonly string _initialWorkingDirectory = Environment.CurrentDirectory;
 
-    /// <summary>
-    /// Number of build errors.
-    /// </summary>
-    private int _buildErrorsCount;
-
-    /// <summary>
-    /// Number of build warnings.
-    /// </summary>
-    private int _buildWarningsCount;
-
-    /// <summary>
-    /// True if restore failed and this failure has already been reported.
-    /// </summary>
-    private bool _restoreFailed;
-
-    /// <summary>
-    /// True if restore happened and finished.
-    /// </summary>
-    private bool _restoreFinished = false;
-
-    /// <summary>
-    /// The project build context corresponding to the <c>Restore</c> initial target, or null if the build is currently
-    /// not restoring.
-    /// </summary>
-    private ProjectContext? _restoreContext;
 
     /// <summary>
     /// True if we're replaying a binary log. In this mode, we may encounter NodeIds higher than the initial node count.
@@ -418,50 +359,19 @@ public sealed partial class TerminalLogger : INodeLogger
     #region INodeLogger implementation
 
     /// <inheritdoc/>
-    public LoggerVerbosity Verbosity { get; set; } = LoggerVerbosity.Minimal;
+    public override LoggerVerbosity Verbosity { get; set; } = LoggerVerbosity.Minimal;
 
     /// <inheritdoc/>
-    public string? Parameters { get; set; } = null;
+    public override string? Parameters { get; set; } = null;
 
     /// <inheritdoc/>
-    public void Initialize(IEventSource eventSource, int nodeCount)
-    {
-        // When MSBUILDNOINPROCNODE enabled, NodeId's reported by build start with 2. We need to reserve an extra spot for this case.
-        _nodes = new TerminalNodeStatus[nodeCount + 1];
-
-        Initialize(eventSource);
-    }
-
-    /// <inheritdoc/>
-    public void Initialize(IEventSource eventSource)
+    public override void Initialize(IEventSource eventSource)
     {
         ParseParameters();
-
         // Detect if we're in replay mode
         _isReplayMode = eventSource is IBinaryLogReplaySource;
-
-        eventSource.BuildStarted += BuildStarted;
-        eventSource.BuildFinished += BuildFinished;
-        eventSource.ProjectStarted += ProjectStarted;
-        eventSource.ProjectFinished += ProjectFinished;
-        eventSource.TargetStarted += TargetStarted;
-        eventSource.TargetFinished += TargetFinished;
-        eventSource.TaskStarted += TaskStarted;
-        eventSource.TaskFinished += TaskFinished;
-        eventSource.StatusEventRaised += StatusEventRaised;
-        eventSource.MessageRaised += MessageRaised;
-        eventSource.WarningRaised += WarningRaised;
-        eventSource.ErrorRaised += ErrorRaised;
-
-        if (eventSource is IEventSource3 eventSource3)
-        {
-            eventSource3.IncludeTaskInputs();
-        }
-
-        if (eventSource is IEventSource4 eventSource4)
-        {
-            eventSource4.IncludeEvaluationPropertiesAndItems();
-        }
+        base.Initialize(eventSource);
+        _nodes = new TerminalNodeStatus[NodeCount];
     }
 
 
@@ -542,7 +452,7 @@ public sealed partial class TerminalLogger : INodeLogger
     }
 
     /// <inheritdoc/>
-    public void Shutdown()
+    public override void Shutdown()
     {
         NativeMethodsShared.RestoreConsoleMode(_originalConsoleMode);
 
@@ -564,12 +474,94 @@ public sealed partial class TerminalLogger : INodeLogger
 
     #endregion
 
-    #region Logger callbacks
+    #region BuildTrackerLogger implementation
 
-    /// <summary>
-    /// The <see cref="IEventSource.BuildStarted"/> callback.
-    /// </summary>
-    private void BuildStarted(object sender, BuildStartedEventArgs e)
+    /// <inheritdoc/>
+    protected override TerminalBuildData CreateBuildData(BuildStartedEventArgs e)
+    {
+        return new TerminalBuildData(e.Timestamp);
+    }
+
+    /// <inheritdoc/>
+    protected override EvalProjectInfo CreateEvalData(ProjectEvaluationFinishedEventArgs e)
+    {
+        (string? tfm, string? rid) = EnumerateEvalProperties(e.EnumerateProperties());
+        return new EvalProjectInfo(e.ProjectFile!, tfm, rid);
+    }
+
+    /// <inheritdoc/>
+    protected override EvalProjectInfo CreateSyntheticEvalDataForMetaproject(ProjectStartedEventArgs e)
+    {
+        (string? tfm, string? rid) = EnumerateEvalProperties(e.EnumerateProperties());
+        return new EvalProjectInfo(e.ProjectFile!, tfm, rid);
+    }
+
+    private (string? tfm, string? rid) EnumerateEvalProperties(IEnumerable<PropertyData> properties)
+    {
+        string? tfm = null;
+        string? rid = null;
+
+        foreach (PropertyData property in properties)
+        {
+            if (tfm is not null && rid is not null)
+            {
+                // We already have both properties, no need to continue.
+                break;
+            }
+
+            switch (property.Name)
+            {
+                case "TargetFramework":
+                    tfm = property.Value;
+                    break;
+                case "RuntimeIdentifier":
+                    rid = property.Value;
+                    break;
+            }
+        }
+
+        return (tfm, rid);
+    }
+
+    /// <inheritdoc/>
+    protected override TerminalProjectInfo? CreateProjectData(EvalProjectInfo evalData, ProjectStartedEventArgs e)
+    {
+        return new TerminalProjectInfo(evalData, _createStopwatch?.Invoke());
+    }
+
+    private TerminalNodeStatus? CreateNodeData(TargetStartedEventArgs e, TerminalProjectInfo projectData)
+    {
+        projectData.Stopwatch.Start();
+        string projectFile = Path.GetFileNameWithoutExtension(e.ProjectFile);
+        string targetName = e.TargetName;
+        projectData.CurrentTarget = targetName;
+
+        if (targetName == CachePluginStartTarget)
+        {
+            projectData.IsCachePluginProject = true;
+            _hasUsedCache = true;
+        }
+
+        if (targetName == _testStartTarget)
+        {
+            targetName = "Testing";
+            _testStartTime = _testStartTime == null
+                ? e.Timestamp
+                : e.Timestamp < _testStartTime
+                    ? e.Timestamp : _testStartTime;
+            projectData.IsTestProject = true;
+        }
+
+        return new TerminalNodeStatus(projectFile, projectData.TargetFramework, projectData.RuntimeIdentifier, targetName, projectData.Stopwatch);
+    }
+
+
+    #endregion
+
+    #region Logger event overrides
+
+    /// <inheritdoc/>
+    protected override void OnBuildStarted(BuildStartedEventArgs e, TerminalBuildData buildData)
     {
         if (!_manualRefresh && _showNodesDisplay)
         {
@@ -578,18 +570,14 @@ public sealed partial class TerminalLogger : INodeLogger
             _refresher.Start();
         }
 
-        _buildStartTime = e.Timestamp;
-
         if (Terminal.SupportsProgressReporting && Verbosity != LoggerVerbosity.Quiet)
         {
             Terminal.Write(AnsiCodes.SetProgressIndeterminate);
         }
     }
 
-    /// <summary>
-    /// The <see cref="IEventSource.BuildFinished"/> callback.
-    /// </summary>
-    private void BuildFinished(object sender, BuildFinishedEventArgs e)
+    /// <inheritdoc/>
+    protected override void OnBuildFinished(BuildFinishedEventArgs e, TerminalProjectInfo[] projectInfos, TerminalBuildData buildData)
     {
         _cts.Cancel();
         _refresher?.Join();
@@ -599,8 +587,8 @@ public sealed partial class TerminalLogger : INodeLogger
         {
             if (Verbosity > LoggerVerbosity.Quiet)
             {
-                string duration = (e.Timestamp - _buildStartTime).TotalSeconds.ToString("F1");
-                string buildResult = GetBuildResultString(e.Succeeded, _buildErrorsCount, _buildWarningsCount);
+                string duration = (e.Timestamp - buildData.BuildStartTime).TotalSeconds.ToString("F1");
+                string buildResult = GetBuildResultString(e.Succeeded, buildData.BuildErrorsCount, buildData.BuildWarningsCount);
 
                 Terminal.WriteLine("");
                 if (_testRunSummaries.Any())
@@ -612,8 +600,8 @@ public sealed partial class TerminalLogger : INodeLogger
                     string testDuration = (_testStartTime != null && _testEndTime != null ? (_testEndTime - _testStartTime).Value.TotalSeconds : 0).ToString("F1");
 
                     bool colorizeFailed = failed > 0;
-                    bool colorizePassed = passed > 0 && _buildErrorsCount == 0 && failed == 0;
-                    bool colorizeSkipped = skipped > 0 && skipped == total && _buildErrorsCount == 0 && failed == 0;
+                    bool colorizePassed = passed > 0 && buildData.BuildErrorsCount == 0 && failed == 0;
+                    bool colorizeSkipped = skipped > 0 && skipped == total && buildData.BuildErrorsCount == 0 && failed == 0;
 
                     string summaryAndTotalText = ResourceUtilities.FormatResourceStringIgnoreCodeAndKeyword("TestSummary_BannerAndTotal", total);
                     string failedText = ResourceUtilities.FormatResourceStringIgnoreCodeAndKeyword("TestSummary_Failed", failed);
@@ -630,10 +618,10 @@ public sealed partial class TerminalLogger : INodeLogger
 
                 if (_showSummary == true)
                 {
-                    RenderBuildSummary();
+                    RenderBuildSummary(buildData, projectInfos);
                 }
 
-                if (_restoreFailed)
+                if (buildData?.RestoreFailed == true)
                 {
                     Terminal.WriteLine(ResourceUtilities.FormatResourceStringIgnoreCodeAndKeyword("RestoreCompleteWithMessage",
                         buildResult,
@@ -657,18 +645,14 @@ public sealed partial class TerminalLogger : INodeLogger
             Terminal.EndUpdate();
         }
 
-        _projects.Clear();
         _testRunSummaries.Clear();
-        _buildErrorsCount = 0;
-        _buildWarningsCount = 0;
-        _restoreFailed = false;
         _testStartTime = null;
         _testEndTime = null;
     }
 
-    private void RenderBuildSummary()
+    private void RenderBuildSummary(TerminalBuildData buildData, TerminalProjectInfo[] projectInfos)
     {
-        if (_buildErrorsCount == 0 && _buildWarningsCount == 0)
+        if (buildData.BuildErrorsCount == 0 && buildData.BuildWarningsCount == 0)
         {
             // No errors/warnings to display.
             return;
@@ -676,7 +660,7 @@ public sealed partial class TerminalLogger : INodeLogger
 
         Terminal.WriteLine(ResourceUtilities.GetResourceString("BuildSummary"));
 
-        foreach (TerminalProjectInfo project in _projects.Values.Where(p => p.HasErrorsOrWarnings))
+        foreach (TerminalProjectInfo project in projectInfos.Where(p => p.HasErrorsOrWarnings))
         {
             string duration = project.Stopwatch.ElapsedSeconds.ToString("F1");
             string buildResult = GetBuildResultString(project.Succeeded, project.ErrorCount, project.WarningCount);
@@ -693,69 +677,25 @@ public sealed partial class TerminalLogger : INodeLogger
         Terminal.WriteLine(string.Empty);
     }
 
-    private void StatusEventRaised(object sender, BuildStatusEventArgs e)
+    /// <inheritdoc/>
+    protected override void OnBuildCanceled(BuildCanceledEventArgs e)
     {
-        switch (e)
+        RenderImmediateMessage(e.Message!);
+    }
+
+    /// <inheritdoc/>
+    protected override void OnProjectStarted(ProjectStartedEventArgs e, EvalProjectInfo evalData, TerminalProjectInfo projectData, TerminalBuildData buildData)
+    {
+        // Handle restore case
+        if (buildData.RestoreContext is null && e.TargetNames == "Restore" && !buildData.RestoreFinished && e.BuildEventContext is not null)
         {
-            case BuildCanceledEventArgs cancelEvent:
-                RenderImmediateMessage(cancelEvent.Message!);
-                break;
-            case ProjectEvaluationStartedEventArgs _evalStart:
-                break;
-            case ProjectEvaluationFinishedEventArgs evalFinish:
-                CaptureEvalContext(evalFinish);
-                break;
+            buildData.RestoreContext = e.BuildEventContext.ProjectContextId;
+            StartNode(e, new TerminalNodeStatus(e.ProjectFile!, evalData.TargetFramework, evalData.RuntimeIdentifier, "Restore", projectData.Stopwatch));
         }
     }
 
-    /// <summary>
-    /// The <see cref="IEventSource.ProjectStarted"/> callback.
-    /// </summary>
-    private void ProjectStarted(object sender, ProjectStartedEventArgs e)
-    {
-        if (e.BuildEventContext is null)
-        {
-            return;
-        }
-
-        ProjectContext c = new(e.BuildEventContext);
-
-        if (_restoreContext is null)
-        {
-            EvalContext evalContext = new(e.BuildEventContext);
-            string? targetFramework = null;
-            string? runtimeIdentifier = null;
-            
-            if (_projectEvaluations.TryGetValue(evalContext, out EvalProjectInfo evalInfo))
-            {
-                targetFramework = evalInfo.TargetFramework;
-                runtimeIdentifier = evalInfo.RuntimeIdentifier;
-            }
-
-            // Per-project metaproj files (e.g. MyProject.csproj.metaproj) are constructed
-            // directly without evaluation, so they won't have a matching ProjectEvaluationFinished event.
-            System.Diagnostics.Debug.Assert(
-                evalInfo != default || FileUtilities.IsMetaprojectFilename(e.ProjectFile),
-                "EvalProjectInfo should have been captured before ProjectStarted");
-
-            TerminalProjectInfo projectInfo = new(c, evalInfo, _createStopwatch?.Invoke());
-            _projects[c] = projectInfo;
-
-            // First ever restore in the build is starting.
-            if (e.TargetNames == "Restore" && !_restoreFinished)
-            {
-                _restoreContext = c;
-                int nodeIndex = NodeIndexForContext(e.BuildEventContext);
-                EnsureNodeCapacity(nodeIndex);
-                _nodes[nodeIndex] = new TerminalNodeStatus(e.ProjectFile!, targetFramework, runtimeIdentifier, "Restore", _projects[c].Stopwatch);
-            }
-        }
-    }
-
-    /// <summary>
-    /// The <see cref="IEventSource.ProjectFinished"/> callback.
-    /// </summary>
-    private void ProjectFinished(object sender, ProjectFinishedEventArgs e)
+    /// <inheritdoc/>
+    protected override void OnProjectFinished(ProjectFinishedEventArgs e, TerminalProjectInfo? projectData, TerminalBuildData buildData)
     {
         var buildEventContext = e.BuildEventContext;
         if (buildEventContext is null)
@@ -764,26 +704,29 @@ public sealed partial class TerminalLogger : INodeLogger
         }
 
         // Mark node idle until something uses it again
-        if (_restoreContext is null)
+        if (buildData.RestoreContext is null)
         {
-            UpdateNodeStatus(buildEventContext, null);
+            YieldNode(e);
         }
 
-        ProjectContext c = new(buildEventContext);
-
-        if (_projects.TryGetValue(c, out TerminalProjectInfo? project))
+        // Continue execution and add project summary to the static part of the Console only if verbosity is higher than Quiet.
+        if (Verbosity <= LoggerVerbosity.Quiet)
         {
-            project.Succeeded = e.Succeeded;
-            project.Stopwatch.Stop();
+            return;
+        }
 
-            // In quiet mode, only show projects with errors or warnings.
-            // In higher verbosity modes, show projects based on other criteria.
-            if (Verbosity == LoggerVerbosity.Quiet && !project.HasErrorsOrWarnings)
+        if (projectData != null)
+        {
+            projectData.Succeeded = e.Succeeded;
+            projectData.Stopwatch.Stop();
+
+            // Handle restore completion
+            if (buildEventContext.ProjectContextId == buildData.RestoreContext)
             {
-                // Still need to update counts even if not displaying
-                _buildErrorsCount += project.ErrorCount;
-                _buildWarningsCount += project.WarningCount;
-                return;
+                buildData.RestoreContext = null;
+                buildData.RestoreFinished = true;
+                buildData.RestoreFailed = !e.Succeeded;
+                OnRestoreFinished(e, projectData, buildData);
             }
 
             lock (_lock)
@@ -793,53 +736,27 @@ public sealed partial class TerminalLogger : INodeLogger
                 {
                     EraseNodes();
 
-                    string duration = project.Stopwatch.ElapsedSeconds.ToString("F1");
-                    ReadOnlyMemory<char>? outputPath = project.OutputPath;
+                    string duration = projectData.Stopwatch.ElapsedSeconds.ToString("F1");
+                    ReadOnlyMemory<char>? outputPath = projectData.OutputPath;
 
                     // Build result. One of 'failed', 'succeeded with warnings', or 'succeeded' depending on the build result and diagnostic messages
                     // reported during build.
-                    string buildResult = GetBuildResultString(project.Succeeded, project.ErrorCount, project.WarningCount);
+                    string buildResult = GetBuildResultString(projectData.Succeeded, projectData.ErrorCount, projectData.WarningCount);
 
-                    // Check if we're done restoring.
-                    if (c == _restoreContext)
-                    {
-                        if (e.Succeeded)
-                        {
-                            if (project.HasErrorsOrWarnings)
-                            {
-                                Terminal.WriteLine(ResourceUtilities.FormatResourceStringIgnoreCodeAndKeyword("RestoreCompleteWithMessage",
-                                    buildResult,
-                                    duration));
-                            }
-                            else
-                            {
-                                Terminal.WriteLine(ResourceUtilities.FormatResourceStringIgnoreCodeAndKeyword("RestoreComplete",
-                                    duration));
-                            }
-                        }
-                        else
-                        {
-                            // It will be reported after build finishes.
-                            _restoreFailed = true;
-                        }
-
-                        _restoreContext = null;
-                        _restoreFinished = true;
-                    }
                     // If this was a notable project build, we print it as completed only if it's produced an output or warnings/error.
                     // If this is a test project, print it always, so user can see either a success or failure, otherwise success is hidden
                     // and it is hard to see if project finished, or did not run at all.
                     // In quiet mode, we show the project header if there are errors/warnings (already checked above).
-                    else if (project.OutputPath is not null || project.BuildMessages is not null || project.IsTestProject)
+                    if (projectData.OutputPath is not null || projectData.BuildMessages is not null || projectData.IsTestProject)
                     {
                         // Show project build complete and its output
-                        string projectFinishedHeader = GetProjectFinishedHeader(project, buildResult, duration);
+                        string projectFinishedHeader = GetProjectFinishedHeader(projectData, buildResult, duration);
                         Terminal.Write(projectFinishedHeader);
 
                         // Print the output path as a link if we have it.
                         if (outputPath is { } outputPathSpan)
                         {
-                            (string? projectDisplayPath, var urlLink) = DetermineOutputPathToRender(outputPathSpan, _initialWorkingDirectory.AsMemory(), project.SourceRoot);
+                            (string projectDisplayPath, Uri? urlLink) = DetermineOutputPathToRender(outputPathSpan, _initialWorkingDirectory.AsMemory(), projectData.SourceRoot);
                             Terminal.WriteLine(ResourceUtilities.FormatResourceStringIgnoreCodeAndKeyword("ProjectFinished_OutputPath", CreateLink(urlLink, projectDisplayPath.ToString())));
                         }
                         else
@@ -849,16 +766,20 @@ public sealed partial class TerminalLogger : INodeLogger
                     }
 
                     // Print diagnostic output under the Project -> Output line.
-                    if (project.BuildMessages is not null)
+                    if (projectData.BuildMessages is not null)
                     {
-                        foreach (TerminalBuildMessage buildMessage in project.BuildMessages)
+                        foreach (TerminalBuildMessage buildMessage in projectData.BuildMessages)
                         {
                             Terminal.WriteLine($"{DoubleIndentation}{buildMessage.Message}");
                         }
                     }
 
-                    _buildErrorsCount += project.ErrorCount;
-                    _buildWarningsCount += project.WarningCount;
+                    // Track errors and warnings in build data
+                    if (buildData != null)
+                    {
+                        buildData.BuildErrorsCount += projectData.ErrorCount;
+                        buildData.BuildWarningsCount += projectData.WarningCount;
+                    }
 
                     if (_showNodesDisplay && Verbosity > LoggerVerbosity.Quiet)
                     {
@@ -873,39 +794,27 @@ public sealed partial class TerminalLogger : INodeLogger
         }
     }
 
-    private void CaptureEvalContext(ProjectEvaluationFinishedEventArgs evalFinish)
+    private void OnRestoreFinished(ProjectFinishedEventArgs e, TerminalProjectInfo? projectData, TerminalBuildData buildData)
     {
-        var buildEventContext = evalFinish.BuildEventContext;
-        if (buildEventContext is null)
+        if (Verbosity > LoggerVerbosity.Quiet && projectData != null)
         {
-            return;
-        }
+            string duration = projectData.Stopwatch.ElapsedSeconds.ToString("F1");
+            string buildResult = GetBuildResultString(projectData.Succeeded, projectData.ErrorCount, projectData.WarningCount);
 
-        EvalContext c = new(buildEventContext);
-
-        if (!_projectEvaluations.TryGetValue(c, out EvalProjectInfo _))
-        {
-            string? tfm = null;
-            string? rid = null;
-            foreach (var property in evalFinish.EnumerateProperties())
+            if (e.Succeeded)
             {
-                if (tfm is not null && rid is not null)
+                if (projectData.HasErrorsOrWarnings)
                 {
-                    // We already have both properties, no need to continue.
-                    break;
+                    Terminal.WriteLine(ResourceUtilities.FormatResourceStringIgnoreCodeAndKeyword("RestoreCompleteWithMessage",
+                        buildResult,
+                        duration));
                 }
-                switch (property.Name)
+                else
                 {
-                    case "TargetFramework":
-                        tfm = property.Value;
-                        break;
-                    case "RuntimeIdentifier":
-                        rid = property.Value;
-                        break;
+                    Terminal.WriteLine(ResourceUtilities.FormatResourceStringIgnoreCodeAndKeyword("RestoreComplete",
+                        duration));
                 }
             }
-            var evalInfo = new EvalProjectInfo(c, evalFinish.ProjectFile, tfm, rid);
-            _projectEvaluations[c] = evalInfo;
         }
     }
 
@@ -927,8 +836,9 @@ public sealed partial class TerminalLogger : INodeLogger
         // * the output path relative to the source root, if it is under it
 
         // full path fallback
-        var projectDisplayPathSpan = outputPathSpan;
-        var workingDirectorySpan = workingDir.Span;
+        ReadOnlySpan<char> projectDisplayPathSpan = outputPathSpan;
+        ReadOnlySpan<char> workingDirectorySpan = workingDir.Span;
+        
         // under working dir case
         if (outputPathSpan.StartsWith(workingDirectorySpan, FileUtilities.PathComparison))
         {
@@ -939,10 +849,11 @@ public sealed partial class TerminalLogger : INodeLogger
                 projectDisplayPathSpan = outputPathSpan.Slice(workingDirectorySpan.Length + 1);
             }
         }
+
         // under source root case
         else if (sourceRoot is { Span: var sourceRootSpan })
         {
-            var relativePathFromWorkingDirToSourceRoot = Path.GetRelativePath(workingDirectorySpan.ToString(), sourceRootSpan.ToString()).AsSpan();
+            ReadOnlySpan<char> relativePathFromWorkingDirToSourceRoot = Path.GetRelativePath(workingDirectorySpan.ToString(), sourceRootSpan.ToString()).AsSpan();
             if (outputPathSpan.StartsWith(sourceRootSpan, FileUtilities.PathComparison))
             {
                 if (outputPathSpan.Length > sourceRootSpan.Length
@@ -1029,47 +940,14 @@ public sealed partial class TerminalLogger : INodeLogger
         };
     }
 
-    /// <summary>
-    /// The <see cref="IEventSource.TargetStarted"/> callback.
-    /// </summary>
-    private void TargetStarted(object sender, TargetStartedEventArgs e)
+    /// <inheritdoc/>
+    protected override void OnTargetStarted(TargetStartedEventArgs e, TerminalProjectInfo projectData, TerminalBuildData buildData)
     {
-        var buildEventContext = e.BuildEventContext;
-        if (_restoreContext is null && buildEventContext is not null && _projects.TryGetValue(new ProjectContext(buildEventContext), out TerminalProjectInfo? project))
+        TerminalNodeStatus? nodeData = CreateNodeData(e, projectData);
+        if (nodeData != null)
         {
-            project.Stopwatch.Start();
-
-            string projectFile = Path.GetFileNameWithoutExtension(e.ProjectFile);
-
-            string targetName = e.TargetName;
-            project.CurrentTarget = targetName;
-            if (targetName == CachePluginStartTarget)
-            {
-                project.IsCachePluginProject = true;
-                _hasUsedCache = true;
-            }
-
-            if (targetName == _testStartTarget)
-            {
-                // Use the minimal start time, so if we run tests in parallel, we can calculate duration
-                // as this start time, minus time when tests finished.
-                _testStartTime = _testStartTime == null
-                    ? e.Timestamp
-                    : e.Timestamp < _testStartTime
-                        ? e.Timestamp : _testStartTime;
-                project.IsTestProject = true;
-            }
-
-            TerminalNodeStatus nodeStatus = new(projectFile, project.TargetFramework, project.RuntimeIdentifier, GetDisplayTargetName(targetName), project.Stopwatch);
-            UpdateNodeStatus(buildEventContext, nodeStatus);
+            StartNode(e, nodeData);
         }
-    }
-
-    private void UpdateNodeStatus(BuildEventContext buildEventContext, TerminalNodeStatus? nodeStatus)
-    {
-        int nodeIndex = NodeIndexForContext(buildEventContext);
-        EnsureNodeCapacity(nodeIndex);
-        _nodes[nodeIndex] = nodeStatus;
     }
 
     /// <summary>
@@ -1093,99 +971,69 @@ public sealed partial class TerminalLogger : INodeLogger
         }
     }
 
-    /// <summary>
-    /// The <see cref="IEventSource.TargetFinished"/> callback. Unused.
-    /// </summary>
-    private void TargetFinished(object sender, TargetFinishedEventArgs e)
+    /// <inheritdoc/>
+    protected override void OnTargetFinished(TargetFinishedEventArgs e, TerminalProjectInfo? projectData, TerminalBuildData buildData)
     {
         // For cache plugin projects which result in a cache hit, ensure the output path is set
         // to the item spec corresponding to the GetTargetPath target upon completion.
-        var buildEventContext = e.BuildEventContext;
         var targetOutputs = e.TargetOutputs;
-        if (_restoreContext is not null || buildEventContext is null)
+        if (projectData is null || targetOutputs is null)
         {
             return;
         }
 
-        if (targetOutputs is not null
-                && _hasUsedCache
-                && e.TargetName == "GetTargetPath"
-                && _projects.TryGetValue(new ProjectContext(buildEventContext), out TerminalProjectInfo? project))
+        if (_hasUsedCache && e.TargetName == "GetTargetPath" && projectData.IsCachePluginProject)
         {
-            if (project is not null && project.IsCachePluginProject)
+            foreach (ITaskItem output in targetOutputs)
             {
-                foreach (ITaskItem output in targetOutputs)
-                {
-                    project.OutputPath = output.ItemSpec.AsMemory();
-                    break;
-                }
+                projectData.OutputPath = output.ItemSpec.AsMemory();
+                break;
             }
         }
-        else if (targetOutputs is not null
-            && e.TargetName == "InitializeSourceRootMappedPaths"
-            && _projects.TryGetValue(new ProjectContext(buildEventContext), out project)
-            && project.SourceRoot is null)
+        else if (e.TargetName == "InitializeSourceRootMappedPaths" && projectData.SourceRoot is null)
         {
-            project.SourceRoot =
+            projectData.SourceRoot =
                 (targetOutputs as IEnumerable<ITaskItem>)?
                 .FirstOrDefault(root => !string.IsNullOrEmpty(root.GetMetadata("SourceControl")))
                 ?.ItemSpec.AsMemory();
         }
     }
 
-    /// <summary>
-    /// The <see cref="IEventSource.TaskStarted"/> callback.
-    /// </summary>
-    private void TaskStarted(object sender, TaskStartedEventArgs e)
+    /// <inheritdoc/>
+    protected override void OnTaskStarted(TaskStartedEventArgs e, TerminalProjectInfo projectData, TerminalBuildData buildData)
     {
-        var buildEventContext = e.BuildEventContext;
-        if (_restoreContext is null && buildEventContext is not null && e.TaskName == MSBuildTaskName)
+        if (buildData.RestoreContext is null && e.BuildEventContext is not null && e.TaskName == MSBuildTaskName)
         {
             // This will yield the node, so preemptively mark it idle
-            UpdateNodeStatus(buildEventContext, null);
+            YieldNode(e);
 
-            if (_projects.TryGetValue(new ProjectContext(buildEventContext), out TerminalProjectInfo? project))
-            {
-                project.Stopwatch.Stop();
-            }
+            projectData.Stopwatch.Stop();
         }
     }
 
-    /// <summary>
-    /// The <see cref="IEventSource.TaskFinished"/> callback.
-    /// </summary>
-    private void TaskFinished(object sender, TaskFinishedEventArgs e)
+    /// <inheritdoc/>
+    protected override void OnTaskFinished(TaskFinishedEventArgs e, TerminalProjectInfo projectData, TerminalBuildData buildData)
     {
         var buildEventContext = e.BuildEventContext;
-        if (_restoreContext is null && buildEventContext is not null && e.TaskName == MSBuildTaskName
-            && _projects.TryGetValue(new ProjectContext(buildEventContext), out TerminalProjectInfo? project))
+        if (buildData.RestoreContext is null && buildEventContext is not null && e.TaskName == MSBuildTaskName)
         {
-            project.Stopwatch.Start();
+            projectData.Stopwatch.Start();
 
             string projectFile = Path.GetFileNameWithoutExtension(e.ProjectFile);
-            string targetName = project.CurrentTarget ?? "";
-
-            TerminalNodeStatus nodeStatus = new(projectFile, project.TargetFramework, project.RuntimeIdentifier, GetDisplayTargetName(targetName), project.Stopwatch);
-            UpdateNodeStatus(buildEventContext, nodeStatus);
+            string targetName = projectData.CurrentTarget ?? "";
+            TerminalNodeStatus nodeStatus = new(projectFile, projectData.TargetFramework, projectData.RuntimeIdentifier, GetDisplayTargetName(targetName), projectData.Stopwatch);
+            StartNode(e, nodeStatus);
         }
     }
 
-    /// <summary>
-    /// The <see cref="IEventSource.MessageRaised"/> callback.
-    /// </summary>
-    private void MessageRaised(object sender, BuildMessageEventArgs e)
+    /// <inheritdoc/>
+    protected override void OnMessageRaised(BuildMessageEventArgs e, TerminalProjectInfo? projectData, TerminalBuildData buildData)
     {
-        var buildEventContext = e.BuildEventContext;
-        if (buildEventContext is null)
-        {
-            return;
-        }
-
         string? message = e.Message;
 
         if (message is not null && e.Importance == MessageImportance.High)
         {
-            bool hasProject = _projects.TryGetValue(new ProjectContext(buildEventContext), out TerminalProjectInfo? project);
+            var hasProject = projectData != null;
 
             // Detect project output path by matching high-importance messages against the "$(MSBuildProjectName) -> ..."
             // pattern used by the CopyFilesToOutputDirectory target.
@@ -1194,10 +1042,10 @@ public sealed partial class TerminalLogger : INodeLogger
             {
                 var projectFileName = Path.GetFileName(e.ProjectFile.AsSpan());
                 if (!projectFileName.IsEmpty &&
-                    message.AsSpan().StartsWith(Path.GetFileNameWithoutExtension(projectFileName)) && hasProject)
+                    message.AsSpan().StartsWith(Path.GetFileNameWithoutExtension(projectFileName)) && hasProject && projectData != null)
                 {
                     ReadOnlyMemory<char> outputPath = e.Message.AsMemory().Slice(index + 4);
-                    project!.OutputPath = outputPath;
+                    projectData.OutputPath = outputPath;
                     return;
                 }
             }
@@ -1226,12 +1074,9 @@ public sealed partial class TerminalLogger : INodeLogger
                 }
             }
 
-            if (hasProject && project!.IsTestProject)
+            if (hasProject && projectData != null && projectData.IsTestProject)
             {
-                int nodeIndex = NodeIndexForContext(buildEventContext);
-                EnsureNodeCapacity(nodeIndex);
-                TerminalNodeStatus? node = _nodes[nodeIndex];
-
+                var node = GetNodeForEvent(e);
                 // Consumes test update messages produced by VSTest and MSTest runner.
                 if (e is IExtendedBuildEventArgs extendedMessage)
                 {
@@ -1244,9 +1089,13 @@ public sealed partial class TerminalLogger : INodeLogger
                                     string indicator = extendedMessage.ExtendedMetadata!["localizedResult"]!;
                                     string displayName = extendedMessage.ExtendedMetadata!["displayName"]!;
 
-                                    var status = new TerminalNodeStatus(node.Project, node.TargetFramework, node.RuntimeIdentifier, TerminalColor.Green, indicator, displayName, project.Stopwatch);
-                                    UpdateNodeStatus(buildEventContext, status);
+                                    TerminalNodeStatus? status = new TerminalNodeStatus(node.Project, node.TargetFramework, node.RuntimeIdentifier, TerminalColor.Green, indicator, displayName, projectData.Stopwatch);
+                                    if (e.BuildEventContext != null)
+                                    {
+                                        StartNode(e, status);
+                                    }
                                 }
+
                                 break;
                             }
 
@@ -1256,9 +1105,11 @@ public sealed partial class TerminalLogger : INodeLogger
                                 {
                                     string indicator = extendedMessage.ExtendedMetadata!["localizedResult"]!;
                                     string displayName = extendedMessage.ExtendedMetadata!["displayName"]!;
-
-                                    var status = new TerminalNodeStatus(node.Project, node.TargetFramework, node.RuntimeIdentifier, TerminalColor.Yellow, indicator, displayName, project.Stopwatch);
-                                    UpdateNodeStatus(buildEventContext, status);
+                                    TerminalNodeStatus? status = new TerminalNodeStatus(node.Project, node.TargetFramework, node.RuntimeIdentifier, TerminalColor.Yellow, indicator, displayName, projectData.Stopwatch);
+                                    if (e.BuildEventContext != null)
+                                    {
+                                        StartNode(e, status);
+                                    }
                                 }
                                 break;
                             }
@@ -1304,9 +1155,9 @@ public sealed partial class TerminalLogger : INodeLogger
                     return;
                 }
 
-                if (hasProject)
+                if (hasProject && projectData != null)
                 {
-                    project!.AddBuildMessage(TerminalMessageSeverity.Message, FormatInformationalMessage(e));
+                    projectData.AddBuildMessage(TerminalMessageSeverity.Message, FormatInformationalMessage(e));
                 }
                 else
                 {
@@ -1330,13 +1181,9 @@ public sealed partial class TerminalLogger : INodeLogger
         }
     }
 
-    /// <summary>
-    /// The <see cref="IEventSource.WarningRaised"/> callback.
-    /// </summary>
-    private void WarningRaised(object sender, BuildWarningEventArgs e)
+    /// <inheritdoc/>
+    protected override void OnWarningRaised(BuildWarningEventArgs e, TerminalProjectInfo? projectData, TerminalBuildData buildData)
     {
-        BuildEventContext? buildEventContext = e.BuildEventContext;
-
         // auth provider messages are 'global' in nature and should be a) immediate reported, and b) not re-reported in the summary.
         if (IsAuthProviderMessage(e.Message))
         {
@@ -1344,8 +1191,9 @@ public sealed partial class TerminalLogger : INodeLogger
             return;
         }
 
-        if (buildEventContext is not null
-            && _projects.TryGetValue(new ProjectContext(buildEventContext), out TerminalProjectInfo? project))
+        if (e.BuildEventContext is not null
+            && projectData != null
+            && Verbosity > LoggerVerbosity.Quiet)
         {
             // If the warning is not a 'global' auth provider message, but is immediate, we render it immediately
             // but we don't early return so that the project also tracks it.
@@ -1357,14 +1205,17 @@ public sealed partial class TerminalLogger : INodeLogger
             // This is the general case - _most_ warnings are not immediate, so we add them to the project summary
             // and display them in the per-project and final summary.
             // In quiet mode, we still accumulate so they can be shown in project-grouped form later.
-            project.AddBuildMessage(TerminalMessageSeverity.Warning, FormatWarningMessage(e, TripleIndentation));
+            projectData.AddBuildMessage(TerminalMessageSeverity.Warning, FormatWarningMessage(e, TripleIndentation));
         }
         else
         {
             // It is necessary to display warning messages reported by MSBuild,
-            // even if it's not tracked in _projects collection.
+            // even if it's not tracked in projects collection or the verbosity is Quiet.
+            // The idea here (similar to the implementation in ErrorRaised) is that
+            // even in Quiet scenarios we need to show warnings/errors, even if not in
+            // full project-tree view
             RenderImmediateMessage(FormatWarningMessage(e, Indentation));
-            _buildWarningsCount++;
+            buildData.BuildWarningsCount++;
         }
     }
 
@@ -1419,27 +1270,22 @@ public sealed partial class TerminalLogger : INodeLogger
         }
     }
 
-    /// <summary>
-    /// The <see cref="IEventSource.ErrorRaised"/> callback.
-    /// </summary>
-    private void ErrorRaised(object sender, BuildErrorEventArgs e)
+    /// <inheritdoc/>
+    protected override void OnErrorRaised(BuildErrorEventArgs e, TerminalProjectInfo? projectData, TerminalBuildData buildData)
     {
-        BuildEventContext? buildEventContext = e.BuildEventContext;
-
-        if (buildEventContext is not null
-            && _projects.TryGetValue(new ProjectContext(buildEventContext), out TerminalProjectInfo? project))
+        if (projectData != null && Verbosity > LoggerVerbosity.Quiet)
         {
             // Always accumulate errors in the project, even in quiet mode, so they can be shown
             // in project-grouped form later.
-            project.AddBuildMessage(TerminalMessageSeverity.Error, FormatErrorMessage(e, TripleIndentation));
+            projectData.AddBuildMessage(TerminalMessageSeverity.Error, FormatErrorMessage(e, TripleIndentation));
         }
         else
         {
-            // It is necessary to display error messages reported by MSBuild, even if it's not tracked in _projects collection.
+            // It is necessary to display error messages reported by MSBuild, even if it's not tracked in projects collection or the verbosity is Quiet.
             // For nicer formatting, any messages from the engine we strip the file portion from.
             bool hasMSBuildPlaceholderLocation = e.File.Equals("MSBUILD", StringComparison.Ordinal);
             RenderImmediateMessage(FormatErrorMessage(e, Indentation, requireFileAndLinePortion: !hasMSBuildPlaceholderLocation));
-            _buildErrorsCount++;
+            buildData.BuildErrorsCount++;
         }
     }
 
@@ -1536,6 +1382,41 @@ public sealed partial class TerminalLogger : INodeLogger
         return targetName == _testStartTarget ? "Testing" : targetName;
     }
 
+    private TerminalNodeStatus? GetNodeForEvent(BuildEventArgs e)
+    {
+        int? node = GetNodeIdForEvent(e);
+        if (node is int nodeId)
+        {
+            EnsureNodeCapacity(nodeId);
+            if (_nodes[nodeId] is TerminalNodeStatus status)
+            {
+                return status;
+            }
+        }
+
+        return null;
+    }
+
+    private void StartNode(BuildEventArgs e, TerminalNodeStatus status)
+    {
+        int? node = GetNodeIdForEvent(e);
+        if (node is int nodeId)
+        {
+            EnsureNodeCapacity(nodeId);
+            _nodes[nodeId] = status;
+        }
+    }
+
+    public void YieldNode(BuildEventArgs e)
+    {
+        var node = GetNodeIdForEvent(e);
+        if (node is int nodeId)
+        {
+            EnsureNodeCapacity(nodeId);
+            _nodes[nodeId] = null;
+        }
+    }
+
     /// <summary>
     /// Construct a build result summary string.
     /// </summary>
@@ -1582,14 +1463,7 @@ public sealed partial class TerminalLogger : INodeLogger
         }
     }
 
-    /// <summary>
-    /// Returns the <see cref="_nodes"/> index corresponding to the given <see cref="BuildEventContext"/>.
-    /// </summary>
-    private int NodeIndexForContext(BuildEventContext context)
-    {
-        // Node IDs reported by the build are 1-based.
-        return context.NodeId - 1;
-    }
+    // NodeIndexForContext is now inherited from base class
 
     /// <summary>
     /// Colorizes the filename part of the given path.
@@ -1793,7 +1667,7 @@ public sealed partial class TerminalLogger : INodeLogger
         }
     }
     #endregion
-    
+
     #region Regex Patterns
     // Regex patterns for command line argument parsing
     private const string s_terminalLoggerArgPattern = @"(?:/|-|--)(?:tl|terminallogger):(?'value'on|off|true|false|auto)";

--- a/src/Build/Logging/TerminalLogger/TerminalLogger.cs
+++ b/src/Build/Logging/TerminalLogger/TerminalLogger.cs
@@ -43,6 +43,11 @@ public sealed partial class TerminalLogger : ProjectTrackingLoggerBase<EvalProje
 
     private static readonly string[] newLineStrings = { "\r\n", "\n" };
 
+    /// <summary>
+    /// Protects access to the stdout - ensures that only one thread writes to the console at a time.
+    /// </summary>
+    private readonly LockType _renderLock = new();
+
     private readonly record struct TestSummary(int Total, int Passed, int Skipped, int Failed);
 
     /// <summary>
@@ -60,40 +65,19 @@ public sealed partial class TerminalLogger : ProjectTrackingLoggerBase<EvalProje
     internal Func<StopwatchAbstraction>? _createStopwatch = null;
 
     /// <summary>
-    /// Tracks the work currently being done by build nodes. Null means the node is not doing any work worth reporting.
-    /// </summary>
-    /// <remarks>
-    /// There is no locking around access to this data structure despite it being accessed concurrently by multiple threads.
-    /// However, reads and writes to locations in an array is atomic, so locking is not required.
-    /// </remarks>
-    private TerminalNodeStatus?[] _nodes = [];
-
-    /// <summary>
     /// Name of target that identifies the project cache plugin run has just started.
     /// </summary>
     private const string CachePluginStartTarget = "_CachePluginRunStart";
-
-    /// <summary>
-    /// Protects access to state shared between the logger callbacks and the rendering thread.
-    /// </summary>
-    private readonly LockType _lock = new();
 
     /// <summary>
     /// A cancellation token to signal the rendering thread that it should exit.
     /// </summary>
     private readonly CancellationTokenSource _cts = new();
 
-
     /// <summary>
     /// The working directory when the build starts, to trim relative output paths.
     /// </summary>
     private readonly string _initialWorkingDirectory = Environment.CurrentDirectory;
-
-
-    /// <summary>
-    /// True if we're replaying a binary log. In this mode, we may encounter NodeIds higher than the initial node count.
-    /// </summary>
-    private bool _isReplayMode = false;
 
     /// <summary>
     /// The thread that performs periodic refresh of the console output.
@@ -366,10 +350,7 @@ public sealed partial class TerminalLogger : ProjectTrackingLoggerBase<EvalProje
     public override void Initialize(IEventSource eventSource)
     {
         ParseParameters();
-        // Detect if we're in replay mode
-        _isReplayMode = eventSource is IBinaryLogReplaySource;
         base.Initialize(eventSource);
-        _nodes = new TerminalNodeStatus[NodeCount];
     }
 
 
@@ -473,6 +454,12 @@ public sealed partial class TerminalLogger : ProjectTrackingLoggerBase<EvalProje
     #endregion
 
     #region ProjectTrackingLoggerBase implementation
+    
+    public override bool NeedsTaskInputs => true;
+
+    public override bool NeedsEvaluationPropertiesAndItems => true;
+
+    public override bool UsesPerNodeData => true;
 
     /// <inheritdoc/>
     protected override TerminalBuildData CreateBuildData(BuildStartedEventArgs e)
@@ -581,7 +568,7 @@ public sealed partial class TerminalLogger : ProjectTrackingLoggerBase<EvalProje
     }
 
     /// <inheritdoc/>
-    protected override void OnBuildFinished(BuildFinishedEventArgs e, TerminalProjectInfo[] projectInfos, TerminalBuildData buildData)
+    protected override void OnBuildFinished(BuildFinishedEventArgs e, IEnumerable<TerminalProjectInfo> projectInfos, TerminalBuildData buildData)
     {
         _cts.Cancel();
         _refresher?.Join();
@@ -654,7 +641,7 @@ public sealed partial class TerminalLogger : ProjectTrackingLoggerBase<EvalProje
         _testEndTime = null;
     }
 
-    private void RenderBuildSummary(TerminalBuildData buildData, TerminalProjectInfo[] projectInfos)
+    private void RenderBuildSummary(TerminalBuildData buildData, IEnumerable<TerminalProjectInfo> projectInfos)
     {
         if (buildData.BuildErrorsCount == 0 && buildData.BuildWarningsCount == 0)
         {
@@ -694,7 +681,7 @@ public sealed partial class TerminalLogger : ProjectTrackingLoggerBase<EvalProje
         if (!buildData.IsRestoring && e.TargetNames == "Restore" && !buildData.RestoreFinished && e.BuildEventContext is not null)
         {
             buildData.RestoreContext = e.BuildEventContext.ProjectContextId;
-            StartNode(e, new TerminalNodeStatus(e.ProjectFile!, evalData.TargetFramework, evalData.RuntimeIdentifier, "Restore", projectData.Stopwatch));
+            SetActiveNodeStatus(e, new TerminalNodeStatus(e.ProjectFile!, evalData.TargetFramework, evalData.RuntimeIdentifier, "Restore", projectData.Stopwatch));
         }
     }
 
@@ -734,12 +721,12 @@ public sealed partial class TerminalLogger : ProjectTrackingLoggerBase<EvalProje
                 return;
             }
 
-            lock (_lock)
+            lock (_renderLock)
             {
                 Terminal.BeginUpdate();
                 try
                 {
-                    EraseNodes();
+                    EraseNodesDisplay();
 
                     string duration = projectData.Stopwatch.ElapsedSeconds.ToString("F1");
                     ReadOnlyMemory<char>? outputPath = projectData.OutputPath;
@@ -953,28 +940,7 @@ public sealed partial class TerminalLogger : ProjectTrackingLoggerBase<EvalProje
             TerminalNodeStatus? nodeData = CreateNodeData(e, projectData);
             if (nodeData != null)
             {
-                StartNode(e, nodeData);
-            }
-        }
-    }
-
-    /// <summary>
-    /// Ensures that the <see cref="_nodes"/> array has enough capacity to accommodate the given index.
-    /// This is necessary for binary log replay scenarios where the replay may use fewer nodes than the original build.
-    /// </summary>
-    private void EnsureNodeCapacity(int nodeIndex)
-    {
-        // Only resize in replay mode - during normal builds, the node count is fixed
-        if (_isReplayMode && nodeIndex >= _nodes.Length)
-        {
-            // Resize to accommodate the new index plus some extra capacity
-            lock (_lock)
-            {
-                if (nodeIndex >= _nodes.Length)
-                {
-                    int newSize = Math.Max(nodeIndex + 1, _nodes.Length * 2);
-                    Array.Resize(ref _nodes, newSize);
-                }
+                SetActiveNodeStatus(e, nodeData);
             }
         }
     }
@@ -1030,7 +996,7 @@ public sealed partial class TerminalLogger : ProjectTrackingLoggerBase<EvalProje
             string projectFile = Path.GetFileNameWithoutExtension(e.ProjectFile);
             string targetName = projectData.CurrentTarget ?? "";
             TerminalNodeStatus nodeStatus = new(projectFile, projectData.TargetFramework, projectData.RuntimeIdentifier, GetDisplayTargetName(targetName), projectData.Stopwatch);
-            StartNode(e, nodeStatus);
+            SetActiveNodeStatus(e, nodeStatus);
         }
     }
 
@@ -1084,7 +1050,7 @@ public sealed partial class TerminalLogger : ProjectTrackingLoggerBase<EvalProje
 
             if (hasProject && projectData != null && projectData.IsTestProject)
             {
-                var node = GetNodeForEvent(e);
+                var node = GetNodeDataForEvent(e);
                 // Consumes test update messages produced by VSTest and MSTest runner.
                 if (e is IExtendedBuildEventArgs extendedMessage)
                 {
@@ -1092,7 +1058,7 @@ public sealed partial class TerminalLogger : ProjectTrackingLoggerBase<EvalProje
                     {
                         case "TLTESTPASSED":
                             {
-                                if (node != null)
+                                if (node != default)
                                 {
                                     string indicator = extendedMessage.ExtendedMetadata!["localizedResult"]!;
                                     string displayName = extendedMessage.ExtendedMetadata!["displayName"]!;
@@ -1100,7 +1066,7 @@ public sealed partial class TerminalLogger : ProjectTrackingLoggerBase<EvalProje
                                     TerminalNodeStatus? status = new TerminalNodeStatus(node.Project, node.TargetFramework, node.RuntimeIdentifier, TerminalColor.Green, indicator, displayName, projectData.Stopwatch);
                                     if (e.BuildEventContext != null)
                                     {
-                                        StartNode(e, status);
+                                        SetActiveNodeStatus(e, status);
                                     }
                                 }
 
@@ -1109,14 +1075,14 @@ public sealed partial class TerminalLogger : ProjectTrackingLoggerBase<EvalProje
 
                         case "TLTESTSKIPPED":
                             {
-                                if (node != null)
+                                if (node != default)
                                 {
                                     string indicator = extendedMessage.ExtendedMetadata!["localizedResult"]!;
                                     string displayName = extendedMessage.ExtendedMetadata!["displayName"]!;
                                     TerminalNodeStatus? status = new TerminalNodeStatus(node.Project, node.TargetFramework, node.RuntimeIdentifier, TerminalColor.Yellow, indicator, displayName, projectData.Stopwatch);
                                     if (e.BuildEventContext != null)
                                     {
-                                        StartNode(e, status);
+                                        SetActiveNodeStatus(e, status);
                                     }
                                 }
                                 break;
@@ -1310,7 +1276,7 @@ public sealed partial class TerminalLogger : ProjectTrackingLoggerBase<EvalProje
         while (!_cts.Token.WaitHandle.WaitOne(1_000 / 30))
         {
             count++;
-            lock (_lock)
+            lock (_renderLock)
             {
                 // Querying the terminal for it's dimensions is expensive, so we only do it every 30 frames e.g. once a second.
                 if (count >= 30)
@@ -1325,7 +1291,7 @@ public sealed partial class TerminalLogger : ProjectTrackingLoggerBase<EvalProje
             }
         }
 
-        EraseNodes();
+        EraseNodesDisplay();
     }
 
     /// <summary>
@@ -1336,12 +1302,12 @@ public sealed partial class TerminalLogger : ProjectTrackingLoggerBase<EvalProje
     {
         int width = updateSize ? Terminal.Width : _currentFrame.Width;
         int height = updateSize ? Terminal.Height : _currentFrame.Height;
-        TerminalNodesFrame newFrame = new TerminalNodesFrame(_nodes, width: width, height: height);
+        TerminalNodesFrame newFrame = new TerminalNodesFrame(GetAllNodeData(), width: width, height: height);
 
         // Do not render delta but clear everything if Terminal width or height have changed.
         if (newFrame.Width != _currentFrame.Width || newFrame.Height != _currentFrame.Height)
         {
-            EraseNodes();
+            EraseNodesDisplay();
         }
 
         string rendered = newFrame.Render(_currentFrame);
@@ -1363,7 +1329,7 @@ public sealed partial class TerminalLogger : ProjectTrackingLoggerBase<EvalProje
     /// <summary>
     /// Erases the previously printed live node output.
     /// </summary>
-    private void EraseNodes()
+    private void EraseNodesDisplay()
     {
         if (_currentFrame.NodesCount == 0)
         {
@@ -1387,39 +1353,6 @@ public sealed partial class TerminalLogger : ProjectTrackingLoggerBase<EvalProje
     private static string GetDisplayTargetName(string targetName)
     {
         return targetName == _testStartTarget ? "Testing" : targetName;
-    }
-
-    private TerminalNodeStatus? GetNodeForEvent(BuildEventArgs e)
-    {
-        int? node = GetNodeArrayIndexForEvent(e);
-        if (node is int nodeId)
-        {
-            EnsureNodeCapacity(nodeId);
-            if (_nodes[nodeId] is TerminalNodeStatus status)
-            {
-                return status;
-            }
-        }
-
-        return null;
-    }
-
-    private void StartNode(BuildEventArgs e, TerminalNodeStatus status)
-    {
-        if (GetNodeArrayIndexForEvent(e) is int nodeId)
-        {
-            EnsureNodeCapacity(nodeId);
-            _nodes[nodeId] = status;
-        }
-    }
-
-    private void YieldNode(BuildEventArgs e)
-    {
-        if (GetNodeArrayIndexForEvent(e) is int nodeId)
-        {
-            EnsureNodeCapacity(nodeId);
-            _nodes[nodeId] = null;
-        }
     }
 
     /// <summary>
@@ -1459,11 +1392,11 @@ public sealed partial class TerminalLogger : ProjectTrackingLoggerBase<EvalProje
     /// <param name="message">Build message needed to be shown immediately.</param>
     private void RenderImmediateMessage(string message)
     {
-        lock (_lock)
+        lock (_renderLock)
         {
             // Calling erase helps to clear the screen before printing the message
             // The immediate output will not overlap with node status reporting
-            EraseNodes();
+            EraseNodesDisplay();
             Terminal.WriteLine(message);
         }
     }

--- a/src/Build/Logging/TerminalLogger/TerminalLogger.cs
+++ b/src/Build/Logging/TerminalLogger/TerminalLogger.cs
@@ -728,6 +728,12 @@ public sealed partial class TerminalLogger : ProjectTrackingLoggerBase<EvalProje
                 OnRestoreFinished(e, projectData, buildData);
             }
 
+            // In quiet mode, only show projects with errors or warnings.
+            if (Verbosity == LoggerVerbosity.Quiet && !projectData.HasErrorsOrWarnings)
+            {
+                return;
+            }
+
             lock (_lock)
             {
                 Terminal.BeginUpdate();
@@ -1017,7 +1023,7 @@ public sealed partial class TerminalLogger : ProjectTrackingLoggerBase<EvalProje
     protected override void OnTaskFinished(TaskFinishedEventArgs e, TerminalProjectInfo projectData, TerminalBuildData buildData)
     {
         var buildEventContext = e.BuildEventContext;
-        if (buildData.IsRestoring && buildEventContext is not null && e.TaskName == MSBuildTaskName)
+        if (!buildData.IsRestoring && buildEventContext is not null && e.TaskName == MSBuildTaskName)
         {
             projectData.Stopwatch.Start();
 

--- a/src/Build/Logging/TerminalLogger/TerminalLogger.cs
+++ b/src/Build/Logging/TerminalLogger/TerminalLogger.cs
@@ -43,8 +43,6 @@ public sealed partial class TerminalLogger : ProjectTrackingLoggerBase<EvalProje
 
     private static readonly string[] newLineStrings = { "\r\n", "\n" };
 
-    // ProjectContext and EvalContext are now inherited from BuildTrackerLogger
-
     private readonly record struct TestSummary(int Total, int Passed, int Skipped, int Failed);
 
     /// <summary>
@@ -474,7 +472,7 @@ public sealed partial class TerminalLogger : ProjectTrackingLoggerBase<EvalProje
 
     #endregion
 
-    #region BuildTrackerLogger implementation
+    #region ProjectTrackingLoggerBase implementation
 
     /// <inheritdoc/>
     protected override TerminalBuildData CreateBuildData(BuildStartedEventArgs e)
@@ -524,8 +522,14 @@ public sealed partial class TerminalLogger : ProjectTrackingLoggerBase<EvalProje
     }
 
     /// <inheritdoc/>
-    protected override TerminalProjectInfo? CreateProjectData(EvalProjectInfo evalData, ProjectStartedEventArgs e)
+    protected override TerminalProjectInfo? CreateProjectData(EvalProjectInfo evalData, TerminalBuildData buildData, ProjectStartedEventArgs e)
     {
+        // TL doesn't want to track projects that are part of a restore
+        if (buildData.IsRestoring)
+        {
+            return null;
+        }
+
         return new TerminalProjectInfo(evalData, _createStopwatch?.Invoke());
     }
 
@@ -687,7 +691,7 @@ public sealed partial class TerminalLogger : ProjectTrackingLoggerBase<EvalProje
     protected override void OnProjectStarted(ProjectStartedEventArgs e, EvalProjectInfo evalData, TerminalProjectInfo projectData, TerminalBuildData buildData)
     {
         // Handle restore case
-        if (buildData.RestoreContext is null && e.TargetNames == "Restore" && !buildData.RestoreFinished && e.BuildEventContext is not null)
+        if (!buildData.IsRestoring && e.TargetNames == "Restore" && !buildData.RestoreFinished && e.BuildEventContext is not null)
         {
             buildData.RestoreContext = e.BuildEventContext.ProjectContextId;
             StartNode(e, new TerminalNodeStatus(e.ProjectFile!, evalData.TargetFramework, evalData.RuntimeIdentifier, "Restore", projectData.Stopwatch));
@@ -704,16 +708,11 @@ public sealed partial class TerminalLogger : ProjectTrackingLoggerBase<EvalProje
         }
 
         // Mark node idle until something uses it again
-        if (buildData.RestoreContext is null)
+        if (!buildData.IsRestoring)
         {
             YieldNode(e);
         }
 
-        // Continue execution and add project summary to the static part of the Console only if verbosity is higher than Quiet.
-        if (Verbosity <= LoggerVerbosity.Quiet)
-        {
-            return;
-        }
 
         if (projectData != null)
         {
@@ -943,10 +942,13 @@ public sealed partial class TerminalLogger : ProjectTrackingLoggerBase<EvalProje
     /// <inheritdoc/>
     protected override void OnTargetStarted(TargetStartedEventArgs e, TerminalProjectInfo projectData, TerminalBuildData buildData)
     {
-        TerminalNodeStatus? nodeData = CreateNodeData(e, projectData);
-        if (nodeData != null)
+        if (!buildData.IsRestoring)
         {
-            StartNode(e, nodeData);
+            TerminalNodeStatus? nodeData = CreateNodeData(e, projectData);
+            if (nodeData != null)
+            {
+                StartNode(e, nodeData);
+            }
         }
     }
 
@@ -1002,7 +1004,7 @@ public sealed partial class TerminalLogger : ProjectTrackingLoggerBase<EvalProje
     /// <inheritdoc/>
     protected override void OnTaskStarted(TaskStartedEventArgs e, TerminalProjectInfo projectData, TerminalBuildData buildData)
     {
-        if (buildData.RestoreContext is null && e.BuildEventContext is not null && e.TaskName == MSBuildTaskName)
+        if (!buildData.IsRestoring && e.BuildEventContext is not null && e.TaskName == MSBuildTaskName)
         {
             // This will yield the node, so preemptively mark it idle
             YieldNode(e);
@@ -1015,7 +1017,7 @@ public sealed partial class TerminalLogger : ProjectTrackingLoggerBase<EvalProje
     protected override void OnTaskFinished(TaskFinishedEventArgs e, TerminalProjectInfo projectData, TerminalBuildData buildData)
     {
         var buildEventContext = e.BuildEventContext;
-        if (buildData.RestoreContext is null && buildEventContext is not null && e.TaskName == MSBuildTaskName)
+        if (buildData.IsRestoring && buildEventContext is not null && e.TaskName == MSBuildTaskName)
         {
             projectData.Stopwatch.Start();
 
@@ -1192,8 +1194,7 @@ public sealed partial class TerminalLogger : ProjectTrackingLoggerBase<EvalProje
         }
 
         if (e.BuildEventContext is not null
-            && projectData != null
-            && Verbosity > LoggerVerbosity.Quiet)
+            && projectData != null)
         {
             // If the warning is not a 'global' auth provider message, but is immediate, we render it immediately
             // but we don't early return so that the project also tracks it.
@@ -1273,7 +1274,7 @@ public sealed partial class TerminalLogger : ProjectTrackingLoggerBase<EvalProje
     /// <inheritdoc/>
     protected override void OnErrorRaised(BuildErrorEventArgs e, TerminalProjectInfo? projectData, TerminalBuildData buildData)
     {
-        if (projectData != null && Verbosity > LoggerVerbosity.Quiet)
+        if (projectData != null)
         {
             // Always accumulate errors in the project, even in quiet mode, so they can be shown
             // in project-grouped form later.
@@ -1384,7 +1385,7 @@ public sealed partial class TerminalLogger : ProjectTrackingLoggerBase<EvalProje
 
     private TerminalNodeStatus? GetNodeForEvent(BuildEventArgs e)
     {
-        int? node = GetNodeIdForEvent(e);
+        int? node = GetNodeArrayIndexForEvent(e);
         if (node is int nodeId)
         {
             EnsureNodeCapacity(nodeId);
@@ -1399,18 +1400,16 @@ public sealed partial class TerminalLogger : ProjectTrackingLoggerBase<EvalProje
 
     private void StartNode(BuildEventArgs e, TerminalNodeStatus status)
     {
-        int? node = GetNodeIdForEvent(e);
-        if (node is int nodeId)
+        if (GetNodeArrayIndexForEvent(e) is int nodeId)
         {
             EnsureNodeCapacity(nodeId);
             _nodes[nodeId] = status;
         }
     }
 
-    public void YieldNode(BuildEventArgs e)
+    private void YieldNode(BuildEventArgs e)
     {
-        var node = GetNodeIdForEvent(e);
-        if (node is int nodeId)
+        if (GetNodeArrayIndexForEvent(e) is int nodeId)
         {
             EnsureNodeCapacity(nodeId);
             _nodes[nodeId] = null;

--- a/src/Build/Logging/TerminalLogger/TerminalMessageSeverity.cs
+++ b/src/Build/Logging/TerminalLogger/TerminalMessageSeverity.cs
@@ -6,4 +6,4 @@ namespace Microsoft.Build.Logging;
 /// <summary>
 /// Enumerates the supported message severities.
 /// </summary>
-internal enum TerminalMessageSeverity { Message, Warning, Error }
+public enum TerminalMessageSeverity { Message, Warning, Error }

--- a/src/Build/Logging/TerminalLogger/TerminalNodeStatus.cs
+++ b/src/Build/Logging/TerminalLogger/TerminalNodeStatus.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Build.Logging;
 /// <summary>
 /// Encapsulates the per-node data shown in live node output.
 /// </summary>
-internal class TerminalNodeStatus
+public class TerminalNodeStatus
 {
     public string Project { get; }
     public string? TargetFramework { get; }

--- a/src/Build/Logging/TerminalLogger/TerminalNodeStatus.cs
+++ b/src/Build/Logging/TerminalLogger/TerminalNodeStatus.cs
@@ -84,6 +84,17 @@ public class TerminalNodeStatus
 
     public override int GetHashCode()
     {
-        throw new System.NotImplementedException();
+#if NETCOREAPP
+        return HashCode.Combine(Project, TargetFramework, RuntimeIdentifier, Target, TargetPrefixColor, TargetPrefix);
+#else
+        int hash = 17;
+        hash = hash * 31 + (Project?.GetHashCode() ?? 0);
+        hash = hash * 31 + (TargetFramework?.GetHashCode() ?? 0);
+        hash = hash * 31 + (RuntimeIdentifier?.GetHashCode() ?? 0);
+        hash = hash * 31 + (Target?.GetHashCode() ?? 0);
+        hash = hash * 31 + TargetPrefixColor.GetHashCode();
+        hash = hash * 31 + (TargetPrefix?.GetHashCode() ?? 0);
+        return hash;
+#endif
     }
 }

--- a/src/Build/Logging/TerminalLogger/TerminalNodeStatus.cs
+++ b/src/Build/Logging/TerminalLogger/TerminalNodeStatus.cs
@@ -1,9 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#if DEBUG
-using System;
-#endif
 using Microsoft.Build.Framework.Logging;
 
 namespace Microsoft.Build.Logging;
@@ -34,7 +31,7 @@ public class TerminalNodeStatus
 #if DEBUG
         if (target.Contains("\x1B"))
         {
-            throw new ArgumentException("Target should not contain any escape codes, if you want to colorize target use the other constructor.");
+            throw new System.ArgumentException("Target should not contain any escape codes, if you want to colorize target use the other constructor.");
         }
 #endif
         Project = project;
@@ -85,7 +82,7 @@ public class TerminalNodeStatus
     public override int GetHashCode()
     {
 #if NETCOREAPP
-        return HashCode.Combine(Project, TargetFramework, RuntimeIdentifier, Target, TargetPrefixColor, TargetPrefix);
+        return System.HashCode.Combine(Project, TargetFramework, RuntimeIdentifier, Target, TargetPrefixColor, TargetPrefix);
 #else
         int hash = 17;
         hash = hash * 31 + (Project?.GetHashCode() ?? 0);

--- a/src/Build/Logging/TerminalLogger/TerminalNodesFrame.cs
+++ b/src/Build/Logging/TerminalLogger/TerminalNodesFrame.cs
@@ -24,7 +24,7 @@ internal sealed class TerminalNodesFrame
     public int Height { get; }
     public int NodesCount { get; private set; }
 
-    public TerminalNodesFrame(TerminalNodeStatus?[] nodes, int width, int height)
+    public TerminalNodesFrame(ReadOnlySpan<TerminalNodeStatus?> nodes, int width, int height)
     {
         Width = Math.Min(width, MaxColumn);
         Height = height;

--- a/src/Build/Logging/TerminalLogger/TerminalProjectInfo.cs
+++ b/src/Build/Logging/TerminalLogger/TerminalProjectInfo.cs
@@ -10,32 +10,25 @@ namespace Microsoft.Build.Logging;
 /// <summary>
 /// A struct containing relevant evaluation-time data that may not be knowable just from ProjectStart events.
 /// </summary>
-/// <param name="context"></param>
-/// <param name="ProjectFile"></param>
-/// <param name="TargetFramework"></param>
-/// <param name="RuntimeIdentifier"></param>
-internal record struct EvalProjectInfo(TerminalLogger.EvalContext context, string? ProjectFile, string? TargetFramework, string? RuntimeIdentifier)
+public record struct EvalProjectInfo(string? ProjectFile, string? TargetFramework, string? RuntimeIdentifier)
 {
-    public readonly int Id => context.Id;
 }
 
 /// <summary>
 /// Represents a project being built.
 /// </summary>
-internal sealed class TerminalProjectInfo
+public sealed class TerminalProjectInfo
 {
     private List<TerminalBuildMessage>? _buildMessages;
 
     /// <summary>
     /// Initialized a new <see cref="TerminalProjectInfo"/> with the given <paramref name="evalInfo"/> .
     /// </summary>
-    /// <param name="context">The ProjectContext of this project execution.</param>
     /// <param name="evalInfo">A subset of the interesting eval-time data for this running project</param>
     /// <param name="stopwatch">A stopwatch to time the build of the project.</param>
-    public TerminalProjectInfo(TerminalLogger.ProjectContext context, EvalProjectInfo evalInfo, StopwatchAbstraction? stopwatch)
+    public TerminalProjectInfo(EvalProjectInfo evalInfo, StopwatchAbstraction? stopwatch)
     {
         _evalInfo = evalInfo;
-        _context = context;
 
         if (stopwatch is not null)
         {
@@ -47,11 +40,6 @@ internal sealed class TerminalProjectInfo
             Stopwatch = SystemStopwatch.StartNew();
         }
     }
-
-    /// <summary>
-    /// The int value of the ProjectContext id of this project execution.
-    /// </summary>
-    public int Id => _context.Id;
 
     /// <summary>
     /// The full path to the project file.
@@ -82,7 +70,6 @@ internal sealed class TerminalProjectInfo
     /// The runtime identifier of the project or null if platform-agnostic.
     /// </summary>
     public string? RuntimeIdentifier => _evalInfo.RuntimeIdentifier;
-    private readonly TerminalLogger.ProjectContext _context;
     private readonly EvalProjectInfo _evalInfo;
 
     /// <summary>

--- a/src/Build/Microsoft.Build.csproj
+++ b/src/Build/Microsoft.Build.csproj
@@ -181,6 +181,7 @@
     <Compile Include="IElementLocation.cs" />
     <Compile Include="Instance\IPropertyElementWithLocation.cs" />
     <Compile Include="Logging\BuildEventArgsExtensions.cs" />
+    <Compile Include="Logging\ProjectTrackingLoggerBase.cs" />
     <Compile Include="Logging\TerminalLogger\**\*.cs" />
     <Compile Include="Logging\ReusableLogger.cs" />
     <Compile Include="TelemetryInfra\InternalTelemetryConsumingLogger.cs" />

--- a/src/Framework/Logging/TerminalColor.cs
+++ b/src/Framework/Logging/TerminalColor.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Build.Framework.Logging;
 /// <summary>
 /// Enumerates the text colors supported by VT100 terminal.
 /// </summary>
-internal enum TerminalColor
+public enum TerminalColor
 {
     Black = 30,
     Red = 31,


### PR DESCRIPTION
This makes it easier to implement other Loggers - you just need to pick out what kinds of data you need from evaluation/projects, and then render warnings, errors, etc however you want during certain lifecycle events. The thought is that all of the data required to track/associate/trigger the lifecycle warnings is kept by the 'tracker', so your use-case-specific logger can mostly ignore that.

This is low-priority ATM, but something that may be useful for us as we think about how Loggers might need to change to more easily react to LLMs and other tools. For example, @richlander has a prototype logger that emits markdown - I'm pretty sure that logger doesn't understand the relationship between 'outer' builds and 'inner' like TL does. If it built on this base and then it could more easily get that understanding for free.

I kind of think of this interface as a step towards a more user-friendly Logger programming model - for loggers that care about rendering the 'intent' of the build and reshaping/papering over MSBuild specifics in favor of a more user-centric model this base can hide a lot of the guts.

This is opened as a new PR because rebasing the previous iteration closed the PR and I was unable to open it.