### PR TITLE
Fix skill-validation workflow failing when agents directory is deleted

### DIFF
--- a/.github/workflows/skill-validation.yml
+++ b/.github/workflows/skill-validation.yml
@@ -186,8 +186,8 @@ jobs:
             if [ "$rc" -eq 0 ]; then
               echo "All checks passed."
               echo ""
-              skill_count=$(find .github/skills -mindepth 1 -maxdepth 1 -type d 2>/dev/null | wc -l)
-              agent_count=$(find .github/agents -name '*.agent.md' 2>/dev/null | wc -l)
+              skill_count=$(find .github/skills -mindepth 1 -maxdepth 1 -type d 2>/dev/null | wc -l || true)
+              agent_count=$(find .github/agents -name '*.agent.md' 2>/dev/null | wc -l || true)
               echo "Validated **${skill_count}** skill(s) and **${agent_count}** agent(s)."
             else
               for f in skill-check-skills.txt skill-check-agents.txt; do
@@ -217,8 +217,8 @@ jobs:
           if [ -z "$exit_code" ]; then
             exit_code=0
           else
-            skill_count=$(find .github/skills -mindepth 1 -maxdepth 1 -type d 2>/dev/null | wc -l)
-            agent_count=$(find .github/agents -name '*.agent.md' 2>/dev/null | wc -l)
+            skill_count=$(find .github/skills -mindepth 1 -maxdepth 1 -type d 2>/dev/null | wc -l || true)
+            agent_count=$(find .github/agents -name '*.agent.md' 2>/dev/null | wc -l || true)
             total=$((skill_count + agent_count))
           fi
           echo "${{ github.event.pull_request.number }}" > sv-results/pr-number.txt


### PR DESCRIPTION
The filter step deletes .github/agents/ when no agent files are changed in the PR. Later, the step summary and metadata steps run:

  `find .github/agents -name '*.agent.md' 2>/dev/null | wc -l`

`find` returns exit code 1 on a missing directory. `2>/dev/null` suppresses the error message but not the exit code. Under `-o pipefail` (set by the shell: `bash --noprofile --norc -e -o pipefail`), the pipeline exit code is 1. Under `set -e`, this terminates the script before reaching exit, causing the step to report failure even though the validator printed 'All checks passed'.

Add `|| true` to all four `find|wc` pipelines so a missing directory produces a count of 0 instead of aborting the script.

Fixes the same issue for .github/skills/ which can also be deleted when only agent files are changed.