### PR TITLE
Add support for Haiku

### DIFF
--- a/src/Framework/NativeMethods.cs
+++ b/src/Framework/NativeMethods.cs
@@ -734,7 +734,7 @@ internal static class NativeMethods
     /// <summary>
     /// Cached value for IsUnixLike (this method is called frequently during evaluation).
     /// </summary>
-    private static readonly bool s_isUnixLike = IsLinux || IsOSX || IsBSD;
+    private static readonly bool s_isUnixLike = IsLinux || IsOSX || IsBSD || IsHaiku;
 
     /// <summary>
     /// Gets a flag indicating if we are running under a Unix-like system (Mac, Linux, etc.)
@@ -764,6 +764,18 @@ internal static class NativeMethods
             return RuntimeInformation.IsOSPlatform(OSPlatform.Create("FREEBSD")) ||
                    RuntimeInformation.IsOSPlatform(OSPlatform.Create("NETBSD")) ||
                    RuntimeInformation.IsOSPlatform(OSPlatform.Create("OPENBSD"));
+        }
+    }
+
+    /// <summary>
+    /// Gets a flag indicating if we are running under Haiku
+    /// </summary>
+    [SupportedOSPlatformGuard("haiku")]
+    internal static bool IsHaiku
+    {
+        get
+        {
+            return RuntimeInformation.IsOSPlatform(OSPlatform.Create("HAIKU"));
         }
     }
 


### PR DESCRIPTION
Part of dotnet/runtime#55803

### Context

.NET support for Haiku is getting more mature. The runtime has been successfully built for Haiku since .NET 8.0, and dotnet/sdk started recognizing the `haiku-x64` RID since .NET 11.0.

This change allows MSBuild to be run correctly on Haiku.

### Changes Made

Add a `IsHaiku` boolean flag indicator to allow checking whether MSBuild is running on Haiku. The flag is added to `IsUnixLike`, allowing MSBuild to enter shared code paths for UNIX-like systems (e.g. calling `.sh` scripts instead of `.cmd` files).

### Testing

Code compiles and runs correctly.
