### PR TITLE
Command-line log replay is no longer too aggressive about versioning

### DIFF
--- a/src/Build.UnitTests/BinaryLogger_Tests.cs
+++ b/src/Build.UnitTests/BinaryLogger_Tests.cs
@@ -967,6 +967,88 @@ namespace Microsoft.Build.UnitTests
 
         #endregion
 
+        #region Forward Compatibility Replay Tests
+
+        [Fact]
+        public void OpenBuildEventsReader_ThrowsForIncompatibleVersion()
+        {
+            // fileFormatVersion > current AND minimumReaderVersion > current => fatal
+            var stream = new MemoryStream();
+            using var writer = new BinaryWriter(stream, Encoding.UTF8, leaveOpen: true);
+            writer.Write(BinaryLogger.FileFormatVersion + 10); // fileFormatVersion
+            writer.Write(BinaryLogger.FileFormatVersion + 5);  // minimumReaderVersion (too high)
+            writer.Flush();
+            stream.Position = 0;
+
+            using var reader = new BinaryReader(stream);
+            Assert.Throws<NotSupportedException>(() =>
+                BinaryLogReplayEventSource.OpenBuildEventsReader(reader, closeInput: false, allowForwardCompatibility: true));
+
+            // Satisfy the ExpectFile constraint from the test fixture.
+            File.Create(_logFile).Dispose();
+        }
+
+        [Fact]
+        public void OpenBuildEventsReader_SucceedsForForwardCompatibleVersion()
+        {
+            // fileFormatVersion > current but minimumReaderVersion <= current => should succeed
+            var stream = new MemoryStream();
+            using var writer = new BinaryWriter(stream, Encoding.UTF8, leaveOpen: true);
+            writer.Write(BinaryLogger.FileFormatVersion + 5);         // fileFormatVersion (newer)
+            writer.Write(BinaryLogger.ForwardCompatibilityMinimalVersion); // minimumReaderVersion (compatible)
+            writer.Flush();
+            stream.Position = 0;
+
+            using var reader = new BinaryReader(stream);
+            using var eventsReader = BinaryLogReplayEventSource.OpenBuildEventsReader(reader, closeInput: false, allowForwardCompatibility: true);
+            eventsReader.ShouldNotBeNull();
+            eventsReader.FileFormatVersion.ShouldBe(BinaryLogger.FileFormatVersion + 5);
+
+            File.Create(_logFile).Dispose();
+        }
+
+        [Fact]
+        public void OpenBuildEventsReader_ThrowsWithoutForwardCompatibility()
+        {
+            // fileFormatVersion > current, allowForwardCompatibility = false => fatal even if minimumReaderVersion is ok
+            var stream = new MemoryStream();
+            using var writer = new BinaryWriter(stream, Encoding.UTF8, leaveOpen: true);
+            writer.Write(BinaryLogger.FileFormatVersion + 5);         // fileFormatVersion (newer)
+            writer.Write(BinaryLogger.ForwardCompatibilityMinimalVersion); // minimumReaderVersion (compatible)
+            writer.Flush();
+            stream.Position = 0;
+
+            using var reader = new BinaryReader(stream);
+            Assert.Throws<NotSupportedException>(() =>
+                BinaryLogReplayEventSource.OpenBuildEventsReader(reader, closeInput: false, allowForwardCompatibility: false));
+
+            File.Create(_logFile).Dispose();
+        }
+
+        [Fact]
+        public void FormatVersionMismatchWarning_NullForCurrentVersion()
+        {
+            using var env = TestEnvironment.Create();
+            env.SetEnvironmentVariable("MSBUILDTARGETOUTPUTLOGGING", "1");
+
+            var binaryLogger = new BinaryLogger { Parameters = _logFile };
+
+            using (ProjectCollection collection = new())
+            {
+                Project project = ObjectModelHelpers.CreateInMemoryProject(collection, s_testProject);
+                project.Build(new ILogger[] { binaryLogger }).ShouldBeTrue();
+            }
+
+            var replayEventSource = new BinaryLogReplayEventSource();
+            replayEventSource.RecoverableReadError += _ => { };
+            replayEventSource.BuildFinished += (_, _) => { };
+            replayEventSource.Replay(_logFile);
+
+            replayEventSource.FormatVersionMismatchWarning.ShouldBeNull();
+        }
+
+        #endregion
+
         public void Dispose()
         {
             _env.Dispose();

--- a/src/Build.UnitTests/BinaryLogger_Tests.cs
+++ b/src/Build.UnitTests/BinaryLogger_Tests.cs
@@ -981,7 +981,7 @@ namespace Microsoft.Build.UnitTests
             stream.Position = 0;
 
             using var reader = new BinaryReader(stream);
-            Assert.Throws<NotSupportedException>(() =>
+            Should.Throw<NotSupportedException>(() =>
                 BinaryLogReplayEventSource.OpenBuildEventsReader(reader, closeInput: false, allowForwardCompatibility: true));
 
             // Satisfy the ExpectFile constraint from the test fixture.
@@ -1019,7 +1019,7 @@ namespace Microsoft.Build.UnitTests
             stream.Position = 0;
 
             using var reader = new BinaryReader(stream);
-            Assert.Throws<NotSupportedException>(() =>
+            Should.Throw<NotSupportedException>(() =>
                 BinaryLogReplayEventSource.OpenBuildEventsReader(reader, closeInput: false, allowForwardCompatibility: false));
 
             File.Create(_logFile).Dispose();
@@ -1028,8 +1028,7 @@ namespace Microsoft.Build.UnitTests
         [Fact]
         public void FormatVersionMismatchWarning_NullForCurrentVersion()
         {
-            using var env = TestEnvironment.Create();
-            env.SetEnvironmentVariable("MSBUILDTARGETOUTPUTLOGGING", "1");
+            _env.SetEnvironmentVariable("MSBUILDTARGETOUTPUTLOGGING", "1");
 
             var binaryLogger = new BinaryLogger { Parameters = _logFile };
 

--- a/src/Build.UnitTests/BinaryLogger_Tests.cs
+++ b/src/Build.UnitTests/BinaryLogger_Tests.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.IO.Compression;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using FakeItEasy;
 using FluentAssertions;
 using Microsoft.Build.BackEnd.Logging;
@@ -968,6 +969,8 @@ namespace Microsoft.Build.UnitTests
         #endregion
 
         #region Forward Compatibility Replay Tests
+        // These tests exercise in-memory streams rather than .binlog files,
+        // but the fixture's _logFile must exist at Dispose time.
 
         [Fact]
         public void OpenBuildEventsReader_ThrowsForIncompatibleVersion()
@@ -984,8 +987,7 @@ namespace Microsoft.Build.UnitTests
             Should.Throw<NotSupportedException>(() =>
                 BinaryLogReplayEventSource.OpenBuildEventsReader(reader, closeInput: false, allowForwardCompatibility: true));
 
-            // Satisfy the ExpectFile constraint from the test fixture.
-            File.Create(_logFile).Dispose();
+            CreateExpectedLogFile();
         }
 
         [Fact]
@@ -1004,7 +1006,7 @@ namespace Microsoft.Build.UnitTests
             eventsReader.ShouldNotBeNull();
             eventsReader.FileFormatVersion.ShouldBe(BinaryLogger.FileFormatVersion + 5);
 
-            File.Create(_logFile).Dispose();
+            CreateExpectedLogFile();
         }
 
         [Fact]
@@ -1022,8 +1024,14 @@ namespace Microsoft.Build.UnitTests
             Should.Throw<NotSupportedException>(() =>
                 BinaryLogReplayEventSource.OpenBuildEventsReader(reader, closeInput: false, allowForwardCompatibility: false));
 
-            File.Create(_logFile).Dispose();
+            CreateExpectedLogFile();
         }
+
+        /// <summary>
+        /// Creates an empty placeholder so the fixture's Dispose doesn't fail
+        /// when the test didn't produce a real .binlog file.
+        /// </summary>
+        private void CreateExpectedLogFile() => File.Create(_logFile).Dispose();
 
         [Fact]
         public void FormatVersionMismatchWarning_NullForCurrentVersion()
@@ -1044,6 +1052,34 @@ namespace Microsoft.Build.UnitTests
             replayEventSource.Replay(_logFile);
 
             replayEventSource.FormatVersionMismatchWarning.ShouldBeNull();
+        }
+
+        [Fact]
+        public void FormatVersionMismatchWarning_NonNullForNewerVersion()
+        {
+            int newerVersion = BinaryLogger.FileFormatVersion + 5;
+
+            var stream = new MemoryStream();
+            using var writer = new BinaryWriter(stream, Encoding.UTF8, leaveOpen: true);
+            writer.Write(newerVersion);                                     // fileFormatVersion
+            writer.Write(BinaryLogger.ForwardCompatibilityMinimalVersion);  // minimumReaderVersion
+            stream.WriteByte(0);                                            // EndOfFile record
+            writer.Flush();
+            stream.Position = 0;
+
+            using var binaryReader = new BinaryReader(stream);
+            using var eventsReader = BinaryLogReplayEventSource.OpenBuildEventsReader(binaryReader, closeInput: false, allowForwardCompatibility: true);
+
+            var replayEventSource = new BinaryLogReplayEventSource();
+            replayEventSource.RecoverableReadError += _ => { };
+            replayEventSource.BuildFinished += (_, _) => { };
+            replayEventSource.Replay(eventsReader, CancellationToken.None);
+
+            replayEventSource.FormatVersionMismatchWarning.ShouldNotBeNull();
+            replayEventSource.FormatVersionMismatchWarning.ShouldContain(newerVersion.ToString());
+            replayEventSource.FormatVersionMismatchWarning.ShouldContain(BinaryLogger.FileFormatVersion.ToString());
+
+            CreateExpectedLogFile();
         }
 
         #endregion

--- a/src/Build/Logging/BinaryLogger/BinaryLogReplayEventSource.cs
+++ b/src/Build/Logging/BinaryLogger/BinaryLogReplayEventSource.cs
@@ -69,6 +69,13 @@ namespace Microsoft.Build.Logging
         public int FileFormatVersion => _fileFormatVersion ?? throw new InvalidOperationException(ResourceUtilities.GetResourceString("Binlog_Source_VersionUninitialized"));
         public int MinimumReaderVersion => _minimumReaderVersion ?? throw new InvalidOperationException(ResourceUtilities.GetResourceString("Binlog_Source_VersionUninitialized"));
 
+        /// <summary>
+        /// After replay, contains a warning message if the binlog was produced by a newer version of MSBuild; null otherwise.
+        /// </summary>
+        public string? FormatVersionMismatchWarning => _fileFormatVersion > BinaryLogger.FileFormatVersion
+            ? ResourceUtilities.FormatResourceStringStripCodeAndKeyword("BinlogFormatVersionMismatch", _fileFormatVersion, BinaryLogger.FileFormatVersion)
+            : null;
+
         /// Touches the <see cref="ItemGroupLoggingHelper"/> static constructor
         /// to ensure it initializes <see cref="TaskParameterEventArgs.MessageGetter"/>
         /// and <see cref="TaskParameterEventArgs.DictionaryFactory"/>
@@ -197,7 +204,7 @@ namespace Microsoft.Build.Logging
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> indicating the replay should stop as soon as possible.</param>
         public void Replay(string sourceFilePath, CancellationToken cancellationToken)
         {
-            using var eventsReader = OpenBuildEventsReader(sourceFilePath);
+            using var eventsReader = OpenBuildEventsReader(OpenReader(sourceFilePath), true, AllowForwardCompatibility);
             Replay(eventsReader, cancellationToken);
         }
 

--- a/src/Build/Logging/BinaryLogger/BinaryLogReplayEventSource.cs
+++ b/src/Build/Logging/BinaryLogger/BinaryLogReplayEventSource.cs
@@ -72,8 +72,8 @@ namespace Microsoft.Build.Logging
         /// <summary>
         /// After replay, contains a warning message if the binlog was produced by a newer version of MSBuild; null otherwise.
         /// </summary>
-        public string? FormatVersionMismatchWarning => _fileFormatVersion > BinaryLogger.FileFormatVersion
-            ? ResourceUtilities.FormatResourceStringStripCodeAndKeyword("BinlogFormatVersionMismatch", _fileFormatVersion, BinaryLogger.FileFormatVersion)
+        public string? FormatVersionMismatchWarning => _fileFormatVersion is int version && version > BinaryLogger.FileFormatVersion
+            ? ResourceUtilities.FormatResourceStringStripCodeAndKeyword("BinlogFormatVersionMismatch", version, BinaryLogger.FileFormatVersion)
             : null;
 
         /// Touches the <see cref="ItemGroupLoggingHelper"/> static constructor

--- a/src/Build/Logging/BinaryLogger/BinaryLogReplayEventSource.cs
+++ b/src/Build/Logging/BinaryLogger/BinaryLogReplayEventSource.cs
@@ -65,16 +65,16 @@ namespace Microsoft.Build.Logging
     {
         private int? _fileFormatVersion;
         private int? _minimumReaderVersion;
+        private string? _formatVersionMismatchWarning;
 
         public int FileFormatVersion => _fileFormatVersion ?? throw new InvalidOperationException(ResourceUtilities.GetResourceString("Binlog_Source_VersionUninitialized"));
         public int MinimumReaderVersion => _minimumReaderVersion ?? throw new InvalidOperationException(ResourceUtilities.GetResourceString("Binlog_Source_VersionUninitialized"));
 
         /// <summary>
-        /// After replay, contains a warning message if the binlog was produced by a newer version of MSBuild; null otherwise.
+        /// After replay, contains a warning message if the binlog was produced by a newer version of MSBuild.
+        /// Returns <see langword="null" /> if <see cref="Replay(string)"/> has not been called yet or if the versions match.
         /// </summary>
-        public string? FormatVersionMismatchWarning => _fileFormatVersion is int version && version > BinaryLogger.FileFormatVersion
-            ? ResourceUtilities.FormatResourceStringStripCodeAndKeyword("BinlogFormatVersionMismatch", version, BinaryLogger.FileFormatVersion)
-            : null;
+        public string? FormatVersionMismatchWarning => _formatVersionMismatchWarning;
 
         /// Touches the <see cref="ItemGroupLoggingHelper"/> static constructor
         /// to ensure it initializes <see cref="TaskParameterEventArgs.MessageGetter"/>
@@ -237,6 +237,9 @@ namespace Microsoft.Build.Logging
         {
             _fileFormatVersion = reader.FileFormatVersion;
             _minimumReaderVersion = reader.MinimumReaderVersion;
+            _formatVersionMismatchWarning = reader.FileFormatVersion > BinaryLogger.FileFormatVersion
+                ? ResourceUtilities.FormatResourceStringStripCodeAndKeyword("BinlogFormatVersionMismatch", reader.FileFormatVersion, BinaryLogger.FileFormatVersion)
+                : null;
             bool supportsForwardCompatibility = reader.FileFormatVersion >= BinaryLogger.ForwardCompatibilityMinimalVersion;
 
             // Allow any possible deferred subscriptions to be registered
@@ -261,9 +264,12 @@ namespace Microsoft.Build.Logging
                         ResourceUtilities.GetResourceString("Binlog_Source_MultiSubscribeError"));
                 }
 
-                // Forward compatible reading makes sense only for structured events reading.
-                reader.SkipUnknownEvents = supportsForwardCompatibility && AllowForwardCompatibility;
-                reader.SkipUnknownEventParts = supportsForwardCompatibility && AllowForwardCompatibility;
+                // Forward compatible reading makes sense only for structured events reading
+                // and only when the binlog is actually from a newer version.
+                bool skipUnknown = supportsForwardCompatibility && AllowForwardCompatibility
+                    && reader.FileFormatVersion > BinaryLogger.FileFormatVersion;
+                reader.SkipUnknownEvents = skipUnknown;
+                reader.SkipUnknownEventParts = skipUnknown;
                 reader.RecoverableReadError += RecoverableReadError;
 
                 while (!cancellationToken.IsCancellationRequested && reader.Read() is { } instance)

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -2136,8 +2136,8 @@ Utilization:          {0} Average Utilization: {1:###.0}</value>
     </comment>
   </data>
   <data name="BinlogFormatVersionMismatch" xml:space="preserve">
-    <value>MSB4268: The binary log file was created with a newer version of MSBuild (format version {0}) than the current version (format version {1}). Some data may be missing from the replay.</value>
-    <comment>{StrBegin="MSB4268: "}{0} is the binlog file format version. {1} is the current MSBuild file format version.</comment>
+    <value>MSB4281: The binary log file was created with a newer version of MSBuild (format version {0}) than the current version (format version {1}). Some data may be missing from the replay.</value>
+    <comment>{StrBegin="MSB4281: "}{0} is the binlog file format version. {1} is the current MSBuild file format version.</comment>
   </data>
   <data name="CustomCheckSuccessfulAcquisition" xml:space="preserve">
     <value>Custom check rule: '{0}' has been registered successfully.</value>
@@ -2481,7 +2481,7 @@ Utilization:          {0} Average Utilization: {1:###.0}</value>
   <!--
         The Build message bucket is: MSB4000 - MSB4999
 
-        Next message code should be MSB4281
+        Next message code should be MSB4282
 
         Don't forget to update this comment after using a new code.
   -->

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -2135,6 +2135,10 @@ Utilization:          {0} Average Utilization: {1:###.0}</value>
       LOCALIZATION: {0} is integer number denoting number of bytes. 'int.MaxValue' should not be translated.
     </comment>
   </data>
+  <data name="BinlogFormatVersionMismatch" xml:space="preserve">
+    <value>MSB4268: The binary log file was created with a newer version of MSBuild (format version {0}) than the current version (format version {1}). Some data may be missing from the replay.</value>
+    <comment>{StrBegin="MSB4268: "}{0} is the binlog file format version. {1} is the current MSBuild file format version.</comment>
+  </data>
   <data name="CustomCheckSuccessfulAcquisition" xml:space="preserve">
     <value>Custom check rule: '{0}' has been registered successfully.</value>
     <comment>The message is emitted on successful loading of the custom check rule in process.</comment>

--- a/src/Build/Resources/xlf/Strings.cs.xlf
+++ b/src/Build/Resources/xlf/Strings.cs.xlf
@@ -36,6 +36,11 @@
         <note>{StrBegin="MSB4003: "}UE: Tasks are not allowed to use incorrect case for reserved attributes on the task nodes e.g. "continueonerror"
     instead of the "ContinueOnError".</note>
       </trans-unit>
+      <trans-unit id="BinlogFormatVersionMismatch">
+        <source>MSB4268: The binary log file was created with a newer version of MSBuild (format version {0}) than the current version (format version {1}). Some data may be missing from the replay.</source>
+        <target state="new">MSB4268: The binary log file was created with a newer version of MSBuild (format version {0}) than the current version (format version {1}). Some data may be missing from the replay.</target>
+        <note>{StrBegin="MSB4268: "}{0} is the binlog file format version. {1} is the current MSBuild file format version.</note>
+      </trans-unit>
       <trans-unit id="Binlog_ArchiveFile_AcquiredAsStream">
         <source>Content already acquired as StreamReader via GetContentReader.</source>
         <target state="translated">Obsah se už získal jako StreamReader přes GetContentReader.</target>

--- a/src/Build/Resources/xlf/Strings.cs.xlf
+++ b/src/Build/Resources/xlf/Strings.cs.xlf
@@ -37,9 +37,9 @@
     instead of the "ContinueOnError".</note>
       </trans-unit>
       <trans-unit id="BinlogFormatVersionMismatch">
-        <source>MSB4268: The binary log file was created with a newer version of MSBuild (format version {0}) than the current version (format version {1}). Some data may be missing from the replay.</source>
-        <target state="new">MSB4268: The binary log file was created with a newer version of MSBuild (format version {0}) than the current version (format version {1}). Some data may be missing from the replay.</target>
-        <note>{StrBegin="MSB4268: "}{0} is the binlog file format version. {1} is the current MSBuild file format version.</note>
+        <source>MSB4281: The binary log file was created with a newer version of MSBuild (format version {0}) than the current version (format version {1}). Some data may be missing from the replay.</source>
+        <target state="new">MSB4281: The binary log file was created with a newer version of MSBuild (format version {0}) than the current version (format version {1}). Some data may be missing from the replay.</target>
+        <note>{StrBegin="MSB4281: "}{0} is the binlog file format version. {1} is the current MSBuild file format version.</note>
       </trans-unit>
       <trans-unit id="Binlog_ArchiveFile_AcquiredAsStream">
         <source>Content already acquired as StreamReader via GetContentReader.</source>

--- a/src/Build/Resources/xlf/Strings.de.xlf
+++ b/src/Build/Resources/xlf/Strings.de.xlf
@@ -36,6 +36,11 @@
         <note>{StrBegin="MSB4003: "}UE: Tasks are not allowed to use incorrect case for reserved attributes on the task nodes e.g. "continueonerror"
     instead of the "ContinueOnError".</note>
       </trans-unit>
+      <trans-unit id="BinlogFormatVersionMismatch">
+        <source>MSB4268: The binary log file was created with a newer version of MSBuild (format version {0}) than the current version (format version {1}). Some data may be missing from the replay.</source>
+        <target state="new">MSB4268: The binary log file was created with a newer version of MSBuild (format version {0}) than the current version (format version {1}). Some data may be missing from the replay.</target>
+        <note>{StrBegin="MSB4268: "}{0} is the binlog file format version. {1} is the current MSBuild file format version.</note>
+      </trans-unit>
       <trans-unit id="Binlog_ArchiveFile_AcquiredAsStream">
         <source>Content already acquired as StreamReader via GetContentReader.</source>
         <target state="translated">Inhalt, der bereits als „StreamReader“ über „GetContentReader“ abgerufen wurde.</target>

--- a/src/Build/Resources/xlf/Strings.de.xlf
+++ b/src/Build/Resources/xlf/Strings.de.xlf
@@ -37,9 +37,9 @@
     instead of the "ContinueOnError".</note>
       </trans-unit>
       <trans-unit id="BinlogFormatVersionMismatch">
-        <source>MSB4268: The binary log file was created with a newer version of MSBuild (format version {0}) than the current version (format version {1}). Some data may be missing from the replay.</source>
-        <target state="new">MSB4268: The binary log file was created with a newer version of MSBuild (format version {0}) than the current version (format version {1}). Some data may be missing from the replay.</target>
-        <note>{StrBegin="MSB4268: "}{0} is the binlog file format version. {1} is the current MSBuild file format version.</note>
+        <source>MSB4281: The binary log file was created with a newer version of MSBuild (format version {0}) than the current version (format version {1}). Some data may be missing from the replay.</source>
+        <target state="new">MSB4281: The binary log file was created with a newer version of MSBuild (format version {0}) than the current version (format version {1}). Some data may be missing from the replay.</target>
+        <note>{StrBegin="MSB4281: "}{0} is the binlog file format version. {1} is the current MSBuild file format version.</note>
       </trans-unit>
       <trans-unit id="Binlog_ArchiveFile_AcquiredAsStream">
         <source>Content already acquired as StreamReader via GetContentReader.</source>

--- a/src/Build/Resources/xlf/Strings.es.xlf
+++ b/src/Build/Resources/xlf/Strings.es.xlf
@@ -37,9 +37,9 @@
     instead of the "ContinueOnError".</note>
       </trans-unit>
       <trans-unit id="BinlogFormatVersionMismatch">
-        <source>MSB4268: The binary log file was created with a newer version of MSBuild (format version {0}) than the current version (format version {1}). Some data may be missing from the replay.</source>
-        <target state="new">MSB4268: The binary log file was created with a newer version of MSBuild (format version {0}) than the current version (format version {1}). Some data may be missing from the replay.</target>
-        <note>{StrBegin="MSB4268: "}{0} is the binlog file format version. {1} is the current MSBuild file format version.</note>
+        <source>MSB4281: The binary log file was created with a newer version of MSBuild (format version {0}) than the current version (format version {1}). Some data may be missing from the replay.</source>
+        <target state="new">MSB4281: The binary log file was created with a newer version of MSBuild (format version {0}) than the current version (format version {1}). Some data may be missing from the replay.</target>
+        <note>{StrBegin="MSB4281: "}{0} is the binlog file format version. {1} is the current MSBuild file format version.</note>
       </trans-unit>
       <trans-unit id="Binlog_ArchiveFile_AcquiredAsStream">
         <source>Content already acquired as StreamReader via GetContentReader.</source>

--- a/src/Build/Resources/xlf/Strings.es.xlf
+++ b/src/Build/Resources/xlf/Strings.es.xlf
@@ -36,6 +36,11 @@
         <note>{StrBegin="MSB4003: "}UE: Tasks are not allowed to use incorrect case for reserved attributes on the task nodes e.g. "continueonerror"
     instead of the "ContinueOnError".</note>
       </trans-unit>
+      <trans-unit id="BinlogFormatVersionMismatch">
+        <source>MSB4268: The binary log file was created with a newer version of MSBuild (format version {0}) than the current version (format version {1}). Some data may be missing from the replay.</source>
+        <target state="new">MSB4268: The binary log file was created with a newer version of MSBuild (format version {0}) than the current version (format version {1}). Some data may be missing from the replay.</target>
+        <note>{StrBegin="MSB4268: "}{0} is the binlog file format version. {1} is the current MSBuild file format version.</note>
+      </trans-unit>
       <trans-unit id="Binlog_ArchiveFile_AcquiredAsStream">
         <source>Content already acquired as StreamReader via GetContentReader.</source>
         <target state="translated">Contenido ya adquirido como StreamReader a través de GetContentReader.</target>

--- a/src/Build/Resources/xlf/Strings.fr.xlf
+++ b/src/Build/Resources/xlf/Strings.fr.xlf
@@ -36,6 +36,11 @@
         <note>{StrBegin="MSB4003: "}UE: Tasks are not allowed to use incorrect case for reserved attributes on the task nodes e.g. "continueonerror"
     instead of the "ContinueOnError".</note>
       </trans-unit>
+      <trans-unit id="BinlogFormatVersionMismatch">
+        <source>MSB4268: The binary log file was created with a newer version of MSBuild (format version {0}) than the current version (format version {1}). Some data may be missing from the replay.</source>
+        <target state="new">MSB4268: The binary log file was created with a newer version of MSBuild (format version {0}) than the current version (format version {1}). Some data may be missing from the replay.</target>
+        <note>{StrBegin="MSB4268: "}{0} is the binlog file format version. {1} is the current MSBuild file format version.</note>
+      </trans-unit>
       <trans-unit id="Binlog_ArchiveFile_AcquiredAsStream">
         <source>Content already acquired as StreamReader via GetContentReader.</source>
         <target state="translated">Contenu déjà acquis en tant que StreamReader par le biais de GetContentReader.</target>

--- a/src/Build/Resources/xlf/Strings.fr.xlf
+++ b/src/Build/Resources/xlf/Strings.fr.xlf
@@ -37,9 +37,9 @@
     instead of the "ContinueOnError".</note>
       </trans-unit>
       <trans-unit id="BinlogFormatVersionMismatch">
-        <source>MSB4268: The binary log file was created with a newer version of MSBuild (format version {0}) than the current version (format version {1}). Some data may be missing from the replay.</source>
-        <target state="new">MSB4268: The binary log file was created with a newer version of MSBuild (format version {0}) than the current version (format version {1}). Some data may be missing from the replay.</target>
-        <note>{StrBegin="MSB4268: "}{0} is the binlog file format version. {1} is the current MSBuild file format version.</note>
+        <source>MSB4281: The binary log file was created with a newer version of MSBuild (format version {0}) than the current version (format version {1}). Some data may be missing from the replay.</source>
+        <target state="new">MSB4281: The binary log file was created with a newer version of MSBuild (format version {0}) than the current version (format version {1}). Some data may be missing from the replay.</target>
+        <note>{StrBegin="MSB4281: "}{0} is the binlog file format version. {1} is the current MSBuild file format version.</note>
       </trans-unit>
       <trans-unit id="Binlog_ArchiveFile_AcquiredAsStream">
         <source>Content already acquired as StreamReader via GetContentReader.</source>

--- a/src/Build/Resources/xlf/Strings.it.xlf
+++ b/src/Build/Resources/xlf/Strings.it.xlf
@@ -36,6 +36,11 @@
         <note>{StrBegin="MSB4003: "}UE: Tasks are not allowed to use incorrect case for reserved attributes on the task nodes e.g. "continueonerror"
     instead of the "ContinueOnError".</note>
       </trans-unit>
+      <trans-unit id="BinlogFormatVersionMismatch">
+        <source>MSB4268: The binary log file was created with a newer version of MSBuild (format version {0}) than the current version (format version {1}). Some data may be missing from the replay.</source>
+        <target state="new">MSB4268: The binary log file was created with a newer version of MSBuild (format version {0}) than the current version (format version {1}). Some data may be missing from the replay.</target>
+        <note>{StrBegin="MSB4268: "}{0} is the binlog file format version. {1} is the current MSBuild file format version.</note>
+      </trans-unit>
       <trans-unit id="Binlog_ArchiveFile_AcquiredAsStream">
         <source>Content already acquired as StreamReader via GetContentReader.</source>
         <target state="translated">Contenuto già acquisito come StreamReader tramite GetContentReader.</target>

--- a/src/Build/Resources/xlf/Strings.it.xlf
+++ b/src/Build/Resources/xlf/Strings.it.xlf
@@ -37,9 +37,9 @@
     instead of the "ContinueOnError".</note>
       </trans-unit>
       <trans-unit id="BinlogFormatVersionMismatch">
-        <source>MSB4268: The binary log file was created with a newer version of MSBuild (format version {0}) than the current version (format version {1}). Some data may be missing from the replay.</source>
-        <target state="new">MSB4268: The binary log file was created with a newer version of MSBuild (format version {0}) than the current version (format version {1}). Some data may be missing from the replay.</target>
-        <note>{StrBegin="MSB4268: "}{0} is the binlog file format version. {1} is the current MSBuild file format version.</note>
+        <source>MSB4281: The binary log file was created with a newer version of MSBuild (format version {0}) than the current version (format version {1}). Some data may be missing from the replay.</source>
+        <target state="new">MSB4281: The binary log file was created with a newer version of MSBuild (format version {0}) than the current version (format version {1}). Some data may be missing from the replay.</target>
+        <note>{StrBegin="MSB4281: "}{0} is the binlog file format version. {1} is the current MSBuild file format version.</note>
       </trans-unit>
       <trans-unit id="Binlog_ArchiveFile_AcquiredAsStream">
         <source>Content already acquired as StreamReader via GetContentReader.</source>

--- a/src/Build/Resources/xlf/Strings.ja.xlf
+++ b/src/Build/Resources/xlf/Strings.ja.xlf
@@ -36,6 +36,11 @@
         <note>{StrBegin="MSB4003: "}UE: Tasks are not allowed to use incorrect case for reserved attributes on the task nodes e.g. "continueonerror"
     instead of the "ContinueOnError".</note>
       </trans-unit>
+      <trans-unit id="BinlogFormatVersionMismatch">
+        <source>MSB4268: The binary log file was created with a newer version of MSBuild (format version {0}) than the current version (format version {1}). Some data may be missing from the replay.</source>
+        <target state="new">MSB4268: The binary log file was created with a newer version of MSBuild (format version {0}) than the current version (format version {1}). Some data may be missing from the replay.</target>
+        <note>{StrBegin="MSB4268: "}{0} is the binlog file format version. {1} is the current MSBuild file format version.</note>
+      </trans-unit>
       <trans-unit id="Binlog_ArchiveFile_AcquiredAsStream">
         <source>Content already acquired as StreamReader via GetContentReader.</source>
         <target state="translated">GetContentReader を介して StreamReader として既に取得されたコンテンツ。</target>

--- a/src/Build/Resources/xlf/Strings.ja.xlf
+++ b/src/Build/Resources/xlf/Strings.ja.xlf
@@ -37,9 +37,9 @@
     instead of the "ContinueOnError".</note>
       </trans-unit>
       <trans-unit id="BinlogFormatVersionMismatch">
-        <source>MSB4268: The binary log file was created with a newer version of MSBuild (format version {0}) than the current version (format version {1}). Some data may be missing from the replay.</source>
-        <target state="new">MSB4268: The binary log file was created with a newer version of MSBuild (format version {0}) than the current version (format version {1}). Some data may be missing from the replay.</target>
-        <note>{StrBegin="MSB4268: "}{0} is the binlog file format version. {1} is the current MSBuild file format version.</note>
+        <source>MSB4281: The binary log file was created with a newer version of MSBuild (format version {0}) than the current version (format version {1}). Some data may be missing from the replay.</source>
+        <target state="new">MSB4281: The binary log file was created with a newer version of MSBuild (format version {0}) than the current version (format version {1}). Some data may be missing from the replay.</target>
+        <note>{StrBegin="MSB4281: "}{0} is the binlog file format version. {1} is the current MSBuild file format version.</note>
       </trans-unit>
       <trans-unit id="Binlog_ArchiveFile_AcquiredAsStream">
         <source>Content already acquired as StreamReader via GetContentReader.</source>

--- a/src/Build/Resources/xlf/Strings.ko.xlf
+++ b/src/Build/Resources/xlf/Strings.ko.xlf
@@ -36,6 +36,11 @@
         <note>{StrBegin="MSB4003: "}UE: Tasks are not allowed to use incorrect case for reserved attributes on the task nodes e.g. "continueonerror"
     instead of the "ContinueOnError".</note>
       </trans-unit>
+      <trans-unit id="BinlogFormatVersionMismatch">
+        <source>MSB4268: The binary log file was created with a newer version of MSBuild (format version {0}) than the current version (format version {1}). Some data may be missing from the replay.</source>
+        <target state="new">MSB4268: The binary log file was created with a newer version of MSBuild (format version {0}) than the current version (format version {1}). Some data may be missing from the replay.</target>
+        <note>{StrBegin="MSB4268: "}{0} is the binlog file format version. {1} is the current MSBuild file format version.</note>
+      </trans-unit>
       <trans-unit id="Binlog_ArchiveFile_AcquiredAsStream">
         <source>Content already acquired as StreamReader via GetContentReader.</source>
         <target state="translated">GetContentReader를 통해 이미 StreamReader로 획득한 콘텐츠입니다.</target>

--- a/src/Build/Resources/xlf/Strings.ko.xlf
+++ b/src/Build/Resources/xlf/Strings.ko.xlf
@@ -37,9 +37,9 @@
     instead of the "ContinueOnError".</note>
       </trans-unit>
       <trans-unit id="BinlogFormatVersionMismatch">
-        <source>MSB4268: The binary log file was created with a newer version of MSBuild (format version {0}) than the current version (format version {1}). Some data may be missing from the replay.</source>
-        <target state="new">MSB4268: The binary log file was created with a newer version of MSBuild (format version {0}) than the current version (format version {1}). Some data may be missing from the replay.</target>
-        <note>{StrBegin="MSB4268: "}{0} is the binlog file format version. {1} is the current MSBuild file format version.</note>
+        <source>MSB4281: The binary log file was created with a newer version of MSBuild (format version {0}) than the current version (format version {1}). Some data may be missing from the replay.</source>
+        <target state="new">MSB4281: The binary log file was created with a newer version of MSBuild (format version {0}) than the current version (format version {1}). Some data may be missing from the replay.</target>
+        <note>{StrBegin="MSB4281: "}{0} is the binlog file format version. {1} is the current MSBuild file format version.</note>
       </trans-unit>
       <trans-unit id="Binlog_ArchiveFile_AcquiredAsStream">
         <source>Content already acquired as StreamReader via GetContentReader.</source>

--- a/src/Build/Resources/xlf/Strings.pl.xlf
+++ b/src/Build/Resources/xlf/Strings.pl.xlf
@@ -36,6 +36,11 @@
         <note>{StrBegin="MSB4003: "}UE: Tasks are not allowed to use incorrect case for reserved attributes on the task nodes e.g. "continueonerror"
     instead of the "ContinueOnError".</note>
       </trans-unit>
+      <trans-unit id="BinlogFormatVersionMismatch">
+        <source>MSB4268: The binary log file was created with a newer version of MSBuild (format version {0}) than the current version (format version {1}). Some data may be missing from the replay.</source>
+        <target state="new">MSB4268: The binary log file was created with a newer version of MSBuild (format version {0}) than the current version (format version {1}). Some data may be missing from the replay.</target>
+        <note>{StrBegin="MSB4268: "}{0} is the binlog file format version. {1} is the current MSBuild file format version.</note>
+      </trans-unit>
       <trans-unit id="Binlog_ArchiveFile_AcquiredAsStream">
         <source>Content already acquired as StreamReader via GetContentReader.</source>
         <target state="translated">Zawartość została już pobrana jako element StreamReader za pośrednictwem metody GetContentReader.</target>

--- a/src/Build/Resources/xlf/Strings.pl.xlf
+++ b/src/Build/Resources/xlf/Strings.pl.xlf
@@ -37,9 +37,9 @@
     instead of the "ContinueOnError".</note>
       </trans-unit>
       <trans-unit id="BinlogFormatVersionMismatch">
-        <source>MSB4268: The binary log file was created with a newer version of MSBuild (format version {0}) than the current version (format version {1}). Some data may be missing from the replay.</source>
-        <target state="new">MSB4268: The binary log file was created with a newer version of MSBuild (format version {0}) than the current version (format version {1}). Some data may be missing from the replay.</target>
-        <note>{StrBegin="MSB4268: "}{0} is the binlog file format version. {1} is the current MSBuild file format version.</note>
+        <source>MSB4281: The binary log file was created with a newer version of MSBuild (format version {0}) than the current version (format version {1}). Some data may be missing from the replay.</source>
+        <target state="new">MSB4281: The binary log file was created with a newer version of MSBuild (format version {0}) than the current version (format version {1}). Some data may be missing from the replay.</target>
+        <note>{StrBegin="MSB4281: "}{0} is the binlog file format version. {1} is the current MSBuild file format version.</note>
       </trans-unit>
       <trans-unit id="Binlog_ArchiveFile_AcquiredAsStream">
         <source>Content already acquired as StreamReader via GetContentReader.</source>

--- a/src/Build/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Build/Resources/xlf/Strings.pt-BR.xlf
@@ -36,6 +36,11 @@
         <note>{StrBegin="MSB4003: "}UE: Tasks are not allowed to use incorrect case for reserved attributes on the task nodes e.g. "continueonerror"
     instead of the "ContinueOnError".</note>
       </trans-unit>
+      <trans-unit id="BinlogFormatVersionMismatch">
+        <source>MSB4268: The binary log file was created with a newer version of MSBuild (format version {0}) than the current version (format version {1}). Some data may be missing from the replay.</source>
+        <target state="new">MSB4268: The binary log file was created with a newer version of MSBuild (format version {0}) than the current version (format version {1}). Some data may be missing from the replay.</target>
+        <note>{StrBegin="MSB4268: "}{0} is the binlog file format version. {1} is the current MSBuild file format version.</note>
+      </trans-unit>
       <trans-unit id="Binlog_ArchiveFile_AcquiredAsStream">
         <source>Content already acquired as StreamReader via GetContentReader.</source>
         <target state="translated">Conteúdo já adquirido como StreamReader por meio de GetContentReader.</target>

--- a/src/Build/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Build/Resources/xlf/Strings.pt-BR.xlf
@@ -37,9 +37,9 @@
     instead of the "ContinueOnError".</note>
       </trans-unit>
       <trans-unit id="BinlogFormatVersionMismatch">
-        <source>MSB4268: The binary log file was created with a newer version of MSBuild (format version {0}) than the current version (format version {1}). Some data may be missing from the replay.</source>
-        <target state="new">MSB4268: The binary log file was created with a newer version of MSBuild (format version {0}) than the current version (format version {1}). Some data may be missing from the replay.</target>
-        <note>{StrBegin="MSB4268: "}{0} is the binlog file format version. {1} is the current MSBuild file format version.</note>
+        <source>MSB4281: The binary log file was created with a newer version of MSBuild (format version {0}) than the current version (format version {1}). Some data may be missing from the replay.</source>
+        <target state="new">MSB4281: The binary log file was created with a newer version of MSBuild (format version {0}) than the current version (format version {1}). Some data may be missing from the replay.</target>
+        <note>{StrBegin="MSB4281: "}{0} is the binlog file format version. {1} is the current MSBuild file format version.</note>
       </trans-unit>
       <trans-unit id="Binlog_ArchiveFile_AcquiredAsStream">
         <source>Content already acquired as StreamReader via GetContentReader.</source>

--- a/src/Build/Resources/xlf/Strings.ru.xlf
+++ b/src/Build/Resources/xlf/Strings.ru.xlf
@@ -36,6 +36,11 @@
         <note>{StrBegin="MSB4003: "}UE: Tasks are not allowed to use incorrect case for reserved attributes on the task nodes e.g. "continueonerror"
     instead of the "ContinueOnError".</note>
       </trans-unit>
+      <trans-unit id="BinlogFormatVersionMismatch">
+        <source>MSB4268: The binary log file was created with a newer version of MSBuild (format version {0}) than the current version (format version {1}). Some data may be missing from the replay.</source>
+        <target state="new">MSB4268: The binary log file was created with a newer version of MSBuild (format version {0}) than the current version (format version {1}). Some data may be missing from the replay.</target>
+        <note>{StrBegin="MSB4268: "}{0} is the binlog file format version. {1} is the current MSBuild file format version.</note>
+      </trans-unit>
       <trans-unit id="Binlog_ArchiveFile_AcquiredAsStream">
         <source>Content already acquired as StreamReader via GetContentReader.</source>
         <target state="translated">Содержимое, уже получено как StreamReader через GetContentReader.</target>

--- a/src/Build/Resources/xlf/Strings.ru.xlf
+++ b/src/Build/Resources/xlf/Strings.ru.xlf
@@ -37,9 +37,9 @@
     instead of the "ContinueOnError".</note>
       </trans-unit>
       <trans-unit id="BinlogFormatVersionMismatch">
-        <source>MSB4268: The binary log file was created with a newer version of MSBuild (format version {0}) than the current version (format version {1}). Some data may be missing from the replay.</source>
-        <target state="new">MSB4268: The binary log file was created with a newer version of MSBuild (format version {0}) than the current version (format version {1}). Some data may be missing from the replay.</target>
-        <note>{StrBegin="MSB4268: "}{0} is the binlog file format version. {1} is the current MSBuild file format version.</note>
+        <source>MSB4281: The binary log file was created with a newer version of MSBuild (format version {0}) than the current version (format version {1}). Some data may be missing from the replay.</source>
+        <target state="new">MSB4281: The binary log file was created with a newer version of MSBuild (format version {0}) than the current version (format version {1}). Some data may be missing from the replay.</target>
+        <note>{StrBegin="MSB4281: "}{0} is the binlog file format version. {1} is the current MSBuild file format version.</note>
       </trans-unit>
       <trans-unit id="Binlog_ArchiveFile_AcquiredAsStream">
         <source>Content already acquired as StreamReader via GetContentReader.</source>

--- a/src/Build/Resources/xlf/Strings.tr.xlf
+++ b/src/Build/Resources/xlf/Strings.tr.xlf
@@ -36,6 +36,11 @@
         <note>{StrBegin="MSB4003: "}UE: Tasks are not allowed to use incorrect case for reserved attributes on the task nodes e.g. "continueonerror"
     instead of the "ContinueOnError".</note>
       </trans-unit>
+      <trans-unit id="BinlogFormatVersionMismatch">
+        <source>MSB4268: The binary log file was created with a newer version of MSBuild (format version {0}) than the current version (format version {1}). Some data may be missing from the replay.</source>
+        <target state="new">MSB4268: The binary log file was created with a newer version of MSBuild (format version {0}) than the current version (format version {1}). Some data may be missing from the replay.</target>
+        <note>{StrBegin="MSB4268: "}{0} is the binlog file format version. {1} is the current MSBuild file format version.</note>
+      </trans-unit>
       <trans-unit id="Binlog_ArchiveFile_AcquiredAsStream">
         <source>Content already acquired as StreamReader via GetContentReader.</source>
         <target state="translated">İçerik zaten GetContentReader ara StreamReader olarak alındı.</target>

--- a/src/Build/Resources/xlf/Strings.tr.xlf
+++ b/src/Build/Resources/xlf/Strings.tr.xlf
@@ -37,9 +37,9 @@
     instead of the "ContinueOnError".</note>
       </trans-unit>
       <trans-unit id="BinlogFormatVersionMismatch">
-        <source>MSB4268: The binary log file was created with a newer version of MSBuild (format version {0}) than the current version (format version {1}). Some data may be missing from the replay.</source>
-        <target state="new">MSB4268: The binary log file was created with a newer version of MSBuild (format version {0}) than the current version (format version {1}). Some data may be missing from the replay.</target>
-        <note>{StrBegin="MSB4268: "}{0} is the binlog file format version. {1} is the current MSBuild file format version.</note>
+        <source>MSB4281: The binary log file was created with a newer version of MSBuild (format version {0}) than the current version (format version {1}). Some data may be missing from the replay.</source>
+        <target state="new">MSB4281: The binary log file was created with a newer version of MSBuild (format version {0}) than the current version (format version {1}). Some data may be missing from the replay.</target>
+        <note>{StrBegin="MSB4281: "}{0} is the binlog file format version. {1} is the current MSBuild file format version.</note>
       </trans-unit>
       <trans-unit id="Binlog_ArchiveFile_AcquiredAsStream">
         <source>Content already acquired as StreamReader via GetContentReader.</source>

--- a/src/Build/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hans.xlf
@@ -36,6 +36,11 @@
         <note>{StrBegin="MSB4003: "}UE: Tasks are not allowed to use incorrect case for reserved attributes on the task nodes e.g. "continueonerror"
     instead of the "ContinueOnError".</note>
       </trans-unit>
+      <trans-unit id="BinlogFormatVersionMismatch">
+        <source>MSB4268: The binary log file was created with a newer version of MSBuild (format version {0}) than the current version (format version {1}). Some data may be missing from the replay.</source>
+        <target state="new">MSB4268: The binary log file was created with a newer version of MSBuild (format version {0}) than the current version (format version {1}). Some data may be missing from the replay.</target>
+        <note>{StrBegin="MSB4268: "}{0} is the binlog file format version. {1} is the current MSBuild file format version.</note>
+      </trans-unit>
       <trans-unit id="Binlog_ArchiveFile_AcquiredAsStream">
         <source>Content already acquired as StreamReader via GetContentReader.</source>
         <target state="translated">已通过 GetContentReader 以 StreamReader 形式获取的内容。</target>

--- a/src/Build/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hans.xlf
@@ -37,9 +37,9 @@
     instead of the "ContinueOnError".</note>
       </trans-unit>
       <trans-unit id="BinlogFormatVersionMismatch">
-        <source>MSB4268: The binary log file was created with a newer version of MSBuild (format version {0}) than the current version (format version {1}). Some data may be missing from the replay.</source>
-        <target state="new">MSB4268: The binary log file was created with a newer version of MSBuild (format version {0}) than the current version (format version {1}). Some data may be missing from the replay.</target>
-        <note>{StrBegin="MSB4268: "}{0} is the binlog file format version. {1} is the current MSBuild file format version.</note>
+        <source>MSB4281: The binary log file was created with a newer version of MSBuild (format version {0}) than the current version (format version {1}). Some data may be missing from the replay.</source>
+        <target state="new">MSB4281: The binary log file was created with a newer version of MSBuild (format version {0}) than the current version (format version {1}). Some data may be missing from the replay.</target>
+        <note>{StrBegin="MSB4281: "}{0} is the binlog file format version. {1} is the current MSBuild file format version.</note>
       </trans-unit>
       <trans-unit id="Binlog_ArchiveFile_AcquiredAsStream">
         <source>Content already acquired as StreamReader via GetContentReader.</source>

--- a/src/Build/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hant.xlf
@@ -36,6 +36,11 @@
         <note>{StrBegin="MSB4003: "}UE: Tasks are not allowed to use incorrect case for reserved attributes on the task nodes e.g. "continueonerror"
     instead of the "ContinueOnError".</note>
       </trans-unit>
+      <trans-unit id="BinlogFormatVersionMismatch">
+        <source>MSB4268: The binary log file was created with a newer version of MSBuild (format version {0}) than the current version (format version {1}). Some data may be missing from the replay.</source>
+        <target state="new">MSB4268: The binary log file was created with a newer version of MSBuild (format version {0}) than the current version (format version {1}). Some data may be missing from the replay.</target>
+        <note>{StrBegin="MSB4268: "}{0} is the binlog file format version. {1} is the current MSBuild file format version.</note>
+      </trans-unit>
       <trans-unit id="Binlog_ArchiveFile_AcquiredAsStream">
         <source>Content already acquired as StreamReader via GetContentReader.</source>
         <target state="translated">內容已透過 GetContentReader 取得為 StreamReader。</target>

--- a/src/Build/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hant.xlf
@@ -37,9 +37,9 @@
     instead of the "ContinueOnError".</note>
       </trans-unit>
       <trans-unit id="BinlogFormatVersionMismatch">
-        <source>MSB4268: The binary log file was created with a newer version of MSBuild (format version {0}) than the current version (format version {1}). Some data may be missing from the replay.</source>
-        <target state="new">MSB4268: The binary log file was created with a newer version of MSBuild (format version {0}) than the current version (format version {1}). Some data may be missing from the replay.</target>
-        <note>{StrBegin="MSB4268: "}{0} is the binlog file format version. {1} is the current MSBuild file format version.</note>
+        <source>MSB4281: The binary log file was created with a newer version of MSBuild (format version {0}) than the current version (format version {1}). Some data may be missing from the replay.</source>
+        <target state="new">MSB4281: The binary log file was created with a newer version of MSBuild (format version {0}) than the current version (format version {1}). Some data may be missing from the replay.</target>
+        <note>{StrBegin="MSB4281: "}{0} is the binlog file format version. {1} is the current MSBuild file format version.</note>
       </trans-unit>
       <trans-unit id="Binlog_ArchiveFile_AcquiredAsStream">
         <source>Content already acquired as StreamReader via GetContentReader.</source>

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -4046,7 +4046,8 @@ namespace Microsoft.Build.CommandLine
             bool isBuildCheckEnabled)
         {
 
-            var replayEventSource = new BinaryLogReplayEventSource();
+            var replayEventSource = new BinaryLogReplayEventSource() { AllowForwardCompatibility = true };
+            replayEventSource.RecoverableReadError += _ => { };
 
             var eventSource = isBuildCheckEnabled ?
                 BuildCheckReplayModeConnector.GetMergedEventSource(BuildManager.DefaultBuildManager, replayEventSource) :
@@ -4080,6 +4081,17 @@ namespace Microsoft.Build.CommandLine
             try
             {
                 replayEventSource.Replay(binaryLogFilePath, s_buildCancellationSource.Token);
+
+                if (replayEventSource.FormatVersionMismatchWarning is string warning)
+                {
+                    Console.WriteLine(warning);
+                }
+            }
+            catch (NotSupportedException ex)
+            {
+                // The log file format is not supported (e.g. minimum reader version too high).
+                var message = ResourceUtilities.FormatResourceStringStripCodeAndKeyword("InvalidLogFileFormat", ex.Message);
+                Console.WriteLine(message);
             }
             catch (Exception ex)
             {

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -4047,6 +4047,10 @@ namespace Microsoft.Build.CommandLine
         {
 
             var replayEventSource = new BinaryLogReplayEventSource() { AllowForwardCompatibility = true };
+
+            // Required when AllowForwardCompatibility is true — the reader requires a subscriber
+            // for recoverable errors when skipping unknown events from newer-version binlogs.
+            // For same-version binlogs the skip flags are not set, so this handler never fires.
             replayEventSource.RecoverableReadError += _ => { };
 
             var eventSource = isBuildCheckEnabled ?

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -4091,12 +4091,6 @@ namespace Microsoft.Build.CommandLine
                     Console.WriteLine(warning);
                 }
             }
-            catch (NotSupportedException ex)
-            {
-                // The log file format is not supported (e.g. minimum reader version too high).
-                var message = ResourceUtilities.FormatResourceStringStripCodeAndKeyword("InvalidLogFileFormat", ex.Message);
-                Console.WriteLine(message);
-            }
             catch (Exception ex)
             {
                 var message = ResourceUtilities.FormatResourceStringStripCodeAndKeyword("InvalidLogFileFormat", ex.Message);


### PR DESCRIPTION
Fixes #12254

## Context
Currently, when replaying a log from an older MSBuild, the replay is not done at all and a message indicating this is emitted. It makes sense to replay the log, skip the new entries and still emit this warning message.

## Changes Made
### XMake.cs 
Added a forward compatibility flag. Also emitting the message after the log is replayed to notify the customer that not all of the messages in the log can be present in the replay.
### BinaryLogReplayEventSource.cs
Added a version mismatch to emit the warning.
## Testing
### BinaryLogger_Tests.cs 
Added unit tests that test this behaviour.
