### PR TITLE
Enlighten ResolveNonMSBuildProjectOutput for multithreaded mode

### DIFF
--- a/src/Tasks/ResolveNonMSBuildProjectOutput.cs
+++ b/src/Tasks/ResolveNonMSBuildProjectOutput.cs
@@ -22,6 +22,7 @@ namespace Microsoft.Build.Tasks
     /// references (i.e. calling into specific targets of references to get the manifest file name)
     /// which would not be possible with a mixed list of MSBuild and non-MSBuild references.
     /// </remarks>
+    [MSBuildMultiThreadableTask]
     public class ResolveNonMSBuildProjectOutput : ResolveProjectBase
     {
         #region Constructors


### PR DESCRIPTION
## Summary

Attribute-only migration for `ResolveNonMSBuildProjectOutput` — adds `[MSBuildMultiThreadableTask]` to declare the task safe for multithreaded scheduling.

### Why attribute-only?

- No `Environment.CurrentDirectory`, `Path.GetFullPath`, or direct `File.*`/`Directory.*` usage
- Only file I/O is `AssemblyName.GetAssemblyName()` on pre-resolved absolute paths from IDE/solution configuration XML
- Base class uses `GetMetadata("FullPath")` — engine-resolved absolute paths
- All mutable state is instance-scoped

No `IMultiThreadableTask` implementation needed. No behavioral change. No ChangeWave required.

Fixes #13612
Parent epic: #11834