### PR TITLE
Enlighten CallTarget for multithreaded mode

### DIFF
--- a/src/Tasks.UnitTests/CallTarget_Tests.cs
+++ b/src/Tasks.UnitTests/CallTarget_Tests.cs
@@ -220,15 +220,18 @@ namespace Microsoft.Build.UnitTests
         }
 
         /// <summary>
-        /// Verifies that separate CallTarget task instances maintain independent output state.
-        /// Two sequential invocations targeting different targets produce correct, independent
-        /// outputs with no shared mutable state interference.
+        /// Regression guard for instance isolation: verifies that two sequential CallTarget
+        /// invocations (in separate projects) each report their own <see cref="CallTarget.TargetOutputs"/>
+        /// without leaking results between instances. This is a sequential test, not a concurrency
+        /// test — BuildManager is process-global and serializes builds, so true parallel execution
+        /// is not exercised here.
         /// </summary>
         [Fact]
         public void CallTargetInstances_MaintainIndependentOutputState()
         {
             // Build two projects sequentially (BuildManager is process-global),
-            // verifying that each CallTarget instance maintains independent _targetOutputs.
+            // verifying that each CallTarget instance reports its own TargetOutputs
+            // without cross-instance leakage.
             MockLogger loggerA = ObjectModelHelpers.BuildProjectExpectSuccess("""
                 <Project>
                     <Target Name="Build">

--- a/src/Tasks.UnitTests/CallTarget_Tests.cs
+++ b/src/Tasks.UnitTests/CallTarget_Tests.cs
@@ -218,5 +218,52 @@ namespace Microsoft.Build.UnitTests
             // All three targets should have been run.
             logger.AssertLogContains("CallTarget Outputs: a.txt;b.txt;c.txt");
         }
+
+        /// <summary>
+        /// Verifies that separate CallTarget task instances maintain independent output state.
+        /// Two sequential invocations targeting different targets produce correct, independent
+        /// outputs with no shared mutable state interference.
+        /// </summary>
+        [Fact]
+        public void CallTargetInstances_MaintainIndependentOutputState()
+        {
+            // Build two projects sequentially (BuildManager is process-global),
+            // verifying that each CallTarget instance maintains independent _targetOutputs.
+            MockLogger loggerA = ObjectModelHelpers.BuildProjectExpectSuccess("""
+                <Project>
+                    <Target Name="Build">
+                        <CallTarget Targets="TargetA">
+                            <Output TaskParameter="TargetOutputs" ItemName="ResultA" />
+                        </CallTarget>
+                        <Message Text="OutputA: @(ResultA)" />
+                    </Target>
+                    <Target Name="TargetA" Outputs="alpha.txt">
+                        <Message Text="Inside TargetA" />
+                    </Target>
+                </Project>
+                """);
+
+            MockLogger loggerB = ObjectModelHelpers.BuildProjectExpectSuccess("""
+                <Project>
+                    <Target Name="Build">
+                        <CallTarget Targets="TargetB">
+                            <Output TaskParameter="TargetOutputs" ItemName="ResultB" />
+                        </CallTarget>
+                        <Message Text="OutputB: @(ResultB)" />
+                    </Target>
+                    <Target Name="TargetB" Outputs="beta.txt">
+                        <Message Text="Inside TargetB" />
+                    </Target>
+                </Project>
+                """);
+
+            loggerA.AssertLogContains("Inside TargetA");
+            loggerA.AssertLogContains("OutputA: alpha.txt");
+            loggerA.AssertLogDoesntContain("Inside TargetB");
+
+            loggerB.AssertLogContains("Inside TargetB");
+            loggerB.AssertLogContains("OutputB: beta.txt");
+            loggerB.AssertLogDoesntContain("Inside TargetA");
+        }
     }
 }

--- a/src/Tasks/CallTarget.cs
+++ b/src/Tasks/CallTarget.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Build.Tasks
     /// id validation checks to fail.
     /// </remarks>
     [RunInMTA]
+    [MSBuildMultiThreadableTask]
     public class CallTarget : TaskExtension
     {
         #region Properties

--- a/src/Tasks/CallTarget.cs
+++ b/src/Tasks/CallTarget.cs
@@ -13,6 +13,9 @@ namespace Microsoft.Build.Tasks
     /// project file.  Marked RunInMTA because we do not want this task to ever be invoked explicitly
     /// on the STA if the RequestBuilder is running on another thread, as this will cause thread
     /// id validation checks to fail.
+    /// Note: <see cref="MSBuildMultiThreadableTaskAttribute"/> has Inherited = false, so subclasses
+    /// of CallTarget must re-apply [MSBuildMultiThreadableTask] to be eligible for in-process
+    /// scheduling under multithreaded mode.
     /// </remarks>
     [RunInMTA]
     [MSBuildMultiThreadableTask]


### PR DESCRIPTION
## Summary

Attribute-only migration for the public `CallTarget` task — adds `[MSBuildMultiThreadableTask]` alongside existing `[RunInMTA]` to declare the task safe for multithreaded scheduling.

### Why attribute-only?

- Zero file I/O, zero environment variable access, zero process launches
- All work delegated to MSBuild engine via `BuildEngine3`
- Only instance state is a `List<ITaskItem>` for target outputs
- No static mutable state

No `IMultiThreadableTask` implementation needed. No behavioral change. No ChangeWave required.

Includes an instance-isolation test verifying independent output state across task instances.

Fixes #13611
Parent epic: #11834