### PR TITLE
Enlighten SignFile for multithreaded mode

### DIFF
--- a/src/Tasks/SignFile.cs
+++ b/src/Tasks/SignFile.cs
@@ -52,9 +52,10 @@ namespace Microsoft.Build.Tasks
                 Log.LogErrorWithCodeFromResources("General.TaskRequiresWindows", nameof(SignFile));
                 return false;
             }
+            AbsolutePath signingTargetPath = TaskEnvironment.GetAbsolutePath(SigningTarget.ItemSpec);
+            string SanitizeMessage(string msg) => msg?.Replace((string)signingTargetPath, signingTargetPath.OriginalValue) ?? msg;
             try
             {
-                AbsolutePath signingTargetPath = TaskEnvironment.GetAbsolutePath(SigningTarget.ItemSpec);
                 SecurityUtilities.SignFile(
                     CertificateThumbprint,
                     TimestampUrl == null ? null : new Uri(TimestampUrl),
@@ -69,29 +70,29 @@ namespace Microsoft.Build.Tasks
                 Log.LogErrorWithCodeFromResources("SignFile.CertNotInStore");
                 return false;
             }
-            catch (FileNotFoundException ex)
+            catch (FileNotFoundException)
             {
-                Log.LogErrorWithCodeFromResources("SignFile.TargetFileNotFound", ex.FileName);
+                Log.LogErrorWithCodeFromResources("SignFile.TargetFileNotFound", signingTargetPath.OriginalValue);
                 return false;
             }
             catch (ApplicationException ex)
             {
-                Log.LogErrorWithCodeFromResources("SignFile.SignToolError", ex.Message.Trim());
+                Log.LogErrorWithCodeFromResources("SignFile.SignToolError", SanitizeMessage(ex.Message).Trim());
                 return false;
             }
             catch (WarningException ex)
             {
-                Log.LogWarningWithCodeFromResources("SignFile.SignToolWarning", ex.Message.Trim());
+                Log.LogWarningWithCodeFromResources("SignFile.SignToolWarning", SanitizeMessage(ex.Message).Trim());
                 return true;
             }
             catch (CryptographicException ex)
             {
-                Log.LogErrorWithCodeFromResources("SignFile.SignToolError", ex.Message.Trim());
+                Log.LogErrorWithCodeFromResources("SignFile.SignToolError", SanitizeMessage(ex.Message).Trim());
                 return false;
             }
             catch (Win32Exception ex)
             {
-                Log.LogErrorWithCodeFromResources("SignFile.SignToolError", ex.Message.Trim());
+                Log.LogErrorWithCodeFromResources("SignFile.SignToolError", SanitizeMessage(ex.Message).Trim());
                 return false;
             }
             catch (UriFormatException ex)

--- a/src/Tasks/SignFile.cs
+++ b/src/Tasks/SignFile.cs
@@ -22,8 +22,11 @@ namespace Microsoft.Build.Tasks
     /// It can sign ClickOnce manifests as well as exe's.
     /// </summary>
     [SupportedOSPlatform("windows")]
-    public sealed class SignFile : Task
+    [MSBuildMultiThreadableTask]
+    public sealed class SignFile : Task, IMultiThreadableTask
     {
+        public TaskEnvironment TaskEnvironment { get; set; } = TaskEnvironment.Fallback;
+
         public SignFile()
             : base(AssemblyResources.PrimaryResources, "MSBuild.")
         {
@@ -51,10 +54,11 @@ namespace Microsoft.Build.Tasks
             }
             try
             {
+                AbsolutePath signingTargetPath = TaskEnvironment.GetAbsolutePath(SigningTarget.ItemSpec);
                 SecurityUtilities.SignFile(
                     CertificateThumbprint,
                     TimestampUrl == null ? null : new Uri(TimestampUrl),
-                    SigningTarget.ItemSpec,
+                    signingTargetPath,
                     TargetFrameworkVersion,
                     TargetFrameworkIdentifier,
                     DisallowMansignTimestampFallback);

--- a/src/Tasks/SignFile.cs
+++ b/src/Tasks/SignFile.cs
@@ -23,8 +23,11 @@ namespace Microsoft.Build.Tasks
     /// It can sign ClickOnce manifests as well as exe's.
     /// </summary>
     [SupportedOSPlatform("windows")]
-    public sealed class SignFile : Task
+    [MSBuildMultiThreadableTask]
+    public sealed class SignFile : Task, IMultiThreadableTask
     {
+        public TaskEnvironment TaskEnvironment { get; set; } = TaskEnvironment.Fallback;
+
         public SignFile()
             : base(AssemblyResources.PrimaryResources, "MSBuild.")
         {
@@ -56,10 +59,11 @@ namespace Microsoft.Build.Tasks
             }
             try
             {
+                AbsolutePath signingTargetPath = TaskEnvironment.GetAbsolutePath(SigningTarget.ItemSpec);
                 SecurityUtilities.SignFile(
                     CertificateThumbprint,
                     TimestampUrl == null ? null : new Uri(TimestampUrl),
-                    SigningTarget.ItemSpec,
+                    signingTargetPath,
                     TargetFrameworkVersion,
                     TargetFrameworkIdentifier,
                     DisallowMansignTimestampFallback);

--- a/src/Tasks/SignFile.cs
+++ b/src/Tasks/SignFile.cs
@@ -57,9 +57,10 @@ namespace Microsoft.Build.Tasks
                 Log.LogErrorWithCodeFromResources("General.TaskRequiresWindows", nameof(SignFile));
                 return false;
             }
+            AbsolutePath signingTargetPath = TaskEnvironment.GetAbsolutePath(SigningTarget.ItemSpec);
+            string SanitizeMessage(string msg) => msg?.Replace((string)signingTargetPath, signingTargetPath.OriginalValue) ?? msg;
             try
             {
-                AbsolutePath signingTargetPath = TaskEnvironment.GetAbsolutePath(SigningTarget.ItemSpec);
                 SecurityUtilities.SignFile(
                     CertificateThumbprint,
                     TimestampUrl == null ? null : new Uri(TimestampUrl),
@@ -74,29 +75,29 @@ namespace Microsoft.Build.Tasks
                 Log.LogErrorWithCodeFromResources("SignFile.CertNotInStore");
                 return false;
             }
-            catch (FileNotFoundException ex)
+            catch (FileNotFoundException)
             {
-                Log.LogErrorWithCodeFromResources("SignFile.TargetFileNotFound", ex.FileName);
+                Log.LogErrorWithCodeFromResources("SignFile.TargetFileNotFound", signingTargetPath.OriginalValue);
                 return false;
             }
             catch (ApplicationException ex)
             {
-                Log.LogErrorWithCodeFromResources("SignFile.SignToolError", ex.Message.Trim());
+                Log.LogErrorWithCodeFromResources("SignFile.SignToolError", SanitizeMessage(ex.Message).Trim());
                 return false;
             }
             catch (WarningException ex)
             {
-                Log.LogWarningWithCodeFromResources("SignFile.SignToolWarning", ex.Message.Trim());
+                Log.LogWarningWithCodeFromResources("SignFile.SignToolWarning", SanitizeMessage(ex.Message).Trim());
                 return true;
             }
             catch (CryptographicException ex)
             {
-                Log.LogErrorWithCodeFromResources("SignFile.SignToolError", ex.Message.Trim());
+                Log.LogErrorWithCodeFromResources("SignFile.SignToolError", SanitizeMessage(ex.Message).Trim());
                 return false;
             }
             catch (Win32Exception ex)
             {
-                Log.LogErrorWithCodeFromResources("SignFile.SignToolError", ex.Message.Trim());
+                Log.LogErrorWithCodeFromResources("SignFile.SignToolError", SanitizeMessage(ex.Message).Trim());
                 return false;
             }
             catch (UriFormatException ex)


### PR DESCRIPTION
Adds `[MSBuildMultiThreadableTask]` and `IMultiThreadableTask` to `SignFile`. Absolutizes `SigningTarget.ItemSpec` before passing to `SecurityUtilities.SignFile()`.

Fixes #13618
Parent epic: #11834