### PR TITLE
Migrate ResolveCodeAnalysisRuleSet to multithreaded execution

### DIFF
--- a/src/Tasks/ResolveCodeAnalysisRuleSet.cs
+++ b/src/Tasks/ResolveCodeAnalysisRuleSet.cs
@@ -13,9 +13,15 @@ namespace Microsoft.Build.Tasks
     /// Determines which file, if any, to be used as the code analysis rule set based
     /// on the supplied code analysis properties.
     /// </summary>
-    public sealed class ResolveCodeAnalysisRuleSet : TaskExtension
+    [MSBuildMultiThreadableTask]
+    public sealed class ResolveCodeAnalysisRuleSet : TaskExtension, IMultiThreadableTask
     {
         #region Properties
+
+        /// <summary>
+        /// Gets or sets the task execution environment for thread-safe path resolution.
+        /// </summary>
+        public TaskEnvironment TaskEnvironment { get; set; } = TaskEnvironment.Fallback;
 
         /// <summary>
         /// The desired code analysis rule set file. May be a simple name, relative
@@ -84,7 +90,8 @@ namespace Microsoft.Build.Tasks
                 if (!string.IsNullOrEmpty(MSBuildProjectDirectory))
                 {
                     string fullName = Path.Combine(MSBuildProjectDirectory, CodeAnalysisRuleSet);
-                    if (FileSystems.Default.FileExists(fullName))
+                    AbsolutePath absolute = TaskEnvironment.GetAbsolutePath(fullName);
+                    if (FileSystems.Default.FileExists(absolute))
                     {
                         return CodeAnalysisRuleSet;
                     }
@@ -96,7 +103,8 @@ namespace Microsoft.Build.Tasks
                     foreach (string directory in CodeAnalysisRuleSetDirectories)
                     {
                         string fullName = Path.Combine(directory, CodeAnalysisRuleSet);
-                        if (FileSystems.Default.FileExists(fullName))
+                        AbsolutePath absolute = TaskEnvironment.GetAbsolutePath(fullName);
+                        if (FileSystems.Default.FileExists(absolute))
                         {
                             return fullName;
                         }
@@ -109,16 +117,21 @@ namespace Microsoft.Build.Tasks
                 if (!string.IsNullOrEmpty(MSBuildProjectDirectory))
                 {
                     string fullName = Path.Combine(MSBuildProjectDirectory, CodeAnalysisRuleSet);
-                    if (FileSystems.Default.FileExists(fullName))
+                    AbsolutePath absolute = TaskEnvironment.GetAbsolutePath(fullName);
+                    if (FileSystems.Default.FileExists(absolute))
                     {
                         return CodeAnalysisRuleSet;
                     }
                 }
             }
-            else if (FileSystems.Default.FileExists(CodeAnalysisRuleSet))
+            else
             {
                 // This is a full path.
-                return CodeAnalysisRuleSet;
+                AbsolutePath absolute = TaskEnvironment.GetAbsolutePath(CodeAnalysisRuleSet);
+                if (FileSystems.Default.FileExists(absolute))
+                {
+                    return CodeAnalysisRuleSet;
+                }
             }
 
             // We can't resolve the rule set to any existing file.


### PR DESCRIPTION
Migrates `ResolveCodeAnalysisRuleSet` to support MSBuild's multithreaded execution model.

## Changes
- `[MSBuildMultiThreadableTask]` applied; class implements `IMultiThreadableTask` with `TaskEnvironment = TaskEnvironment.Fallback` default.
- Ruleset and include-directory path resolution routed through `TaskEnvironment.GetAbsolutePath`.

## Compatibility audit
Ran the 6-deadly-sins playbook (see `.github/skills/multithreaded-task-migration/SKILL.md`):
- Sin 1 ([Output] contamination): `ResolvedCodeAnalysisRuleSet` is assigned the original `CodeAnalysisRuleSet` value or the unaltered `Path.Combine(directory, CodeAnalysisRuleSet)` joined string — no `AbsolutePath` is ever leaked into the output. Absolutization is used solely for the `File.Exists` probes.
- Sin 2 (error message inflation): The `Compiler.UnableToFindRuleSet` warning continues to be formatted with the original `CodeAnalysisRuleSet` user input.
- Sin 3 (?? swallowing exceptions): N/A — no null-coalescing was introduced.
- Sin 4 (try-catch scope): N/A — no try/catch in this task.
- Sin 5 (canonicalization): N/A — paths are not used as dictionary/set keys, and the previous code did not call `Path.GetFullPath`.
- Sin 6 (empty/null inputs): Empty/null `CodeAnalysisRuleSet` is short-circuited at the top before any `GetAbsolutePath` call, preserving the original `return null` behavior. Empty `MSBuildProjectDirectory` is still gated by `!string.IsNullOrEmpty` so we never call `GetAbsolutePath` with a degenerate combined path.

## Validation
- `Microsoft.Build.Tasks.csproj` builds clean (0 warnings, 0 errors).
- `ResolveAnalyzerRuleSet_Tests` passes on both `net10.0` and `net472` (12 tests × 2 TFMs = 24 passing).

Part of #11834. Closes #13569.