### PR TITLE
Migrate GetAssembliesMetadata to multithreaded execution

### DIFF
--- a/src/Tasks/GetAssembliesMetadata.cs
+++ b/src/Tasks/GetAssembliesMetadata.cs
@@ -18,8 +18,12 @@ namespace Microsoft.Build.Tasks
     /// Resolves metadata for the specified set of assemblies.
     /// </summary>
     [SupportedOSPlatform("windows")]
-    public class GetAssembliesMetadata : TaskExtension
+    [MSBuildMultiThreadableTask]
+    public class GetAssembliesMetadata : TaskExtension, IMultiThreadableTask
     {
+        /// <inheritdoc />
+        public TaskEnvironment TaskEnvironment { get; set; } = TaskEnvironment.Fallback;
+
         /// <summary>
         /// Assembly paths.
         /// </summary>
@@ -38,15 +42,27 @@ namespace Microsoft.Build.Tasks
             var assembliesMetadata = new List<ITaskItem>();
             foreach (string assemblyPath in AssemblyPaths)
             {
-                // During DTB the referenced project may not has been built yet, so we need to check if the assembly already exists.
-                if (FileSystems.Default.FileExists(assemblyPath))
+                // Preserve original behavior: silently skip null/empty entries instead of throwing
+                // ArgumentException from GetAbsolutePath (Sin 6).
+                if (string.IsNullOrEmpty(assemblyPath))
                 {
-                    using (AssemblyInformation assemblyInformation = new(assemblyPath))
+                    continue;
+                }
+
+                AbsolutePath absoluteAssemblyPath = TaskEnvironment.GetAbsolutePath(assemblyPath);
+
+                // During DTB the referenced project may not has been built yet, so we need to check if the assembly already exists.
+                if (FileSystems.Default.FileExists(absoluteAssemblyPath))
+                {
+                    using (AssemblyInformation assemblyInformation = new(absoluteAssemblyPath))
                     {
                         AssemblyAttributes attributes = assemblyInformation.GetAssemblyMetadata();
 
                         if (attributes != null)
                         {
+                            // Preserve original [Output] behavior (Sin 1): emit the user-supplied path,
+                            // not the absolutized form, as the resulting item's ItemSpec.
+                            attributes.AssemblyFullPath = absoluteAssemblyPath.OriginalValue;
                             assembliesMetadata.Add(CreateItemWithMetadata(attributes));
                         }
                     }

--- a/src/Tasks/GetAssembliesMetadata.cs
+++ b/src/Tasks/GetAssembliesMetadata.cs
@@ -17,8 +17,12 @@ namespace Microsoft.Build.Tasks
     /// Resolves metadata for the specified set of assemblies.
     /// </summary>
     [SupportedOSPlatform("windows")]
-    public class GetAssembliesMetadata : TaskExtension
+    [MSBuildMultiThreadableTask]
+    public class GetAssembliesMetadata : TaskExtension, IMultiThreadableTask
     {
+        /// <inheritdoc />
+        public TaskEnvironment TaskEnvironment { get; set; } = TaskEnvironment.Fallback;
+
         /// <summary>
         /// Assembly paths.
         /// </summary>
@@ -37,15 +41,27 @@ namespace Microsoft.Build.Tasks
             var assembliesMetadata = new List<ITaskItem>();
             foreach (string assemblyPath in AssemblyPaths)
             {
-                // During DTB the referenced project may not has been built yet, so we need to check if the assembly already exists.
-                if (FileSystems.Default.FileExists(assemblyPath))
+                // Preserve original behavior: silently skip null/empty entries instead of throwing
+                // ArgumentException from GetAbsolutePath (Sin 6).
+                if (string.IsNullOrEmpty(assemblyPath))
                 {
-                    using (AssemblyInformation assemblyInformation = new(assemblyPath))
+                    continue;
+                }
+
+                AbsolutePath absoluteAssemblyPath = TaskEnvironment.GetAbsolutePath(assemblyPath);
+
+                // During DTB the referenced project may not has been built yet, so we need to check if the assembly already exists.
+                if (FileSystems.Default.FileExists(absoluteAssemblyPath))
+                {
+                    using (AssemblyInformation assemblyInformation = new(absoluteAssemblyPath))
                     {
                         AssemblyAttributes attributes = assemblyInformation.GetAssemblyMetadata();
 
                         if (attributes != null)
                         {
+                            // Preserve original [Output] behavior (Sin 1): emit the user-supplied path,
+                            // not the absolutized form, as the resulting item's ItemSpec.
+                            attributes.AssemblyFullPath = absoluteAssemblyPath.OriginalValue;
                             assembliesMetadata.Add(CreateItemWithMetadata(attributes));
                         }
                     }

--- a/src/Tasks/GetAssembliesMetadata.cs
+++ b/src/Tasks/GetAssembliesMetadata.cs
@@ -41,9 +41,10 @@ namespace Microsoft.Build.Tasks
             var assembliesMetadata = new List<ITaskItem>();
             foreach (string assemblyPath in AssemblyPaths)
             {
-                // Preserve original behavior: silently skip null/empty entries instead of throwing
-                // ArgumentException from GetAbsolutePath (Sin 6).
-                if (string.IsNullOrEmpty(assemblyPath))
+                // Preserve original behavior: entries that are null, empty, or whitespace-only previously
+                // fell through FileExists and were skipped silently. Skip them here so GetAbsolutePath is
+                // never handed a value it could reject with an ArgumentException.
+                if (string.IsNullOrWhiteSpace(assemblyPath))
                 {
                     continue;
                 }
@@ -59,9 +60,9 @@ namespace Microsoft.Build.Tasks
 
                         if (attributes != null)
                         {
-                            // Preserve original [Output] behavior (Sin 1): emit the user-supplied path,
-                            // not the absolutized form, as the resulting item's ItemSpec.
-                            attributes.AssemblyFullPath = absoluteAssemblyPath.OriginalValue;
+                            // Preserve the original [Output] behavior: the resulting item's ItemSpec must be
+                            // the exact path the caller supplied, not the absolutized form used to read metadata.
+                            attributes.AssemblyFullPath = assemblyPath;
                             assembliesMetadata.Add(CreateItemWithMetadata(attributes));
                         }
                     }


### PR DESCRIPTION
Migrates `GetAssembliesMetadata` to support MSBuild's multithreaded execution model.

## Changes
- `[MSBuildMultiThreadableTask]` applied; class implements `IMultiThreadableTask` with `TaskEnvironment = TaskEnvironment.Fallback` default.
- Each assembly file path absolutized via `TaskEnvironment.GetAbsolutePath` before `MetadataReader`-based access (`AssemblyInformation` opens the file via `File.OpenRead` / `OpenScope` / native metadata reads, all of which need an absolute path on a thread node).

## Compatibility audit
Ran the 6-deadly-sins playbook (see `.github/skills/multithreaded-task-migration/SKILL.md`):
- **Sin 1 ([Output] contamination)**: `AssembliesMetadata[i].ItemSpec` is sourced from `AssemblyAttributes.AssemblyFullPath`, which `AssemblyInformation` initializes from the path passed into its constructor. To avoid leaking the absolutized path into the output items (which would change the user-observable `ItemSpec`), we overwrite `attributes.AssemblyFullPath` with `absoluteAssemblyPath.OriginalValue` before constructing the `TaskItem`.
- **Sin 2 (error message inflation)**: N/A — task logs no errors/warnings/messages that include the path.
- **Sin 3 (?? swallowing exceptions)**: N/A — no null-coalescing added.
- **Sin 4 (try-catch scope)**: N/A — no try/catch in `Execute`.
- **Sin 5 (canonicalization)**: N/A — no dictionary/set keyed on the path; `FileSystems.Default.FileExists` does not require canonical form.
- **Sin 6 (empty/null inputs)**: Original code passed empty/null entries to `FileSystems.Default.FileExists` which silently returned `false` and skipped them; `GetAbsolutePath("")` would now throw `ArgumentException` and abort the entire batch. Guarded with `string.IsNullOrEmpty(assemblyPath) -> continue` to preserve original skip-silently semantics.

## Validation
- `Microsoft.Build.Tasks.csproj` builds clean (0 warnings, 0 errors).
- All `GetAssembliesMetadata`-filtered tests pass (2/2 on net472 — the test class is `#if NETFRAMEWORK`-gated, so net10.0 has no tests for this task).

Part of #11834. Closes #13570.