### PR TITLE
Route NuGet RestoreTask to transient TaskHost in MT/server mode

### DIFF
--- a/src/Build.UnitTests/BackEnd/TaskRouter_IntegrationTests.cs
+++ b/src/Build.UnitTests/BackEnd/TaskRouter_IntegrationTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
+using Microsoft.Build.BackEnd;
 using Microsoft.Build.Execution;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
@@ -381,7 +382,168 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
             logger.FullLog.ShouldContain("TaskWithAttribute executed");
         }
 
+        /// <summary>
+        /// Verifies that TaskRouter.IsKnownProblematicTask returns true for NuGet.Build.Tasks.RestoreTask.
+        /// </summary>
+        [Fact]
+        public void IsKnownProblematicTask_ReturnsTrueForRestoreTask()
+        {
+            TaskRouter.IsKnownProblematicTask(typeof(global::NuGet.Build.Tasks.RestoreTask)).ShouldBeTrue();
+        }
 
+        /// <summary>
+        /// Verifies that TaskRouter.IsKnownProblematicTask returns false for regular tasks.
+        /// </summary>
+        [Fact]
+        public void IsKnownProblematicTask_ReturnsFalseForRegularTask()
+        {
+            TaskRouter.IsKnownProblematicTask(typeof(NonEnlightenedTestTask)).ShouldBeFalse();
+            TaskRouter.IsKnownProblematicTask(typeof(AttributeTestTask)).ShouldBeFalse();
+        }
+
+        /// <summary>
+        /// Verifies that a known problematic task (RestoreTask) is routed to TaskHost
+        /// in multi-threaded mode.
+        /// </summary>
+        [Fact]
+        public void ProblematicTask_RoutedToTaskHost_InMultiThreadedMode()
+        {
+            // Arrange
+            string projectContent = $@"
+<Project>
+    <UsingTask TaskName=""RestoreTask"" AssemblyFile=""{Assembly.GetExecutingAssembly().Location}"" />
+    
+    <Target Name=""TestTarget"">
+        <RestoreTask />
+    </Target>
+</Project>";
+
+            string projectFile = Path.Combine(_testProjectsDir, "RestoreTaskMT.proj");
+            File.WriteAllText(projectFile, projectContent);
+
+            var logger = new MockLogger(_output);
+            var buildParameters = new BuildParameters
+            {
+                MultiThreaded = true,
+                Loggers = new[] { logger },
+                DisableInProcNode = false,
+                EnableNodeReuse = false,
+            };
+
+            var buildRequestData = new BuildRequestData(
+                projectFile,
+                new Dictionary<string, string>(),
+                null,
+                new[] { "TestTarget" },
+                null);
+
+            // Act
+            var buildManager = BuildManager.DefaultBuildManager;
+            var result = buildManager.Build(buildParameters, buildRequestData);
+
+            // Assert
+            result.OverallResult.ShouldBe(BuildResultCode.Success);
+            TaskRouterTestHelper.AssertTaskUsedTaskHost(logger, "RestoreTask");
+            logger.FullLog.ShouldContain("RestoreTask executed");
+        }
+
+        /// <summary>
+        /// Verifies that a known problematic task (RestoreTask) is routed to TaskHost
+        /// when MSBuild server mode is active (even without multi-threaded mode).
+        /// </summary>
+        [Fact]
+        public void ProblematicTask_RoutedToTaskHost_InServerMode()
+        {
+            // Arrange
+            _env.SetEnvironmentVariable(Traits.UseMSBuildServerEnvVarName, "1");
+
+            string projectContent = $@"
+<Project>
+    <UsingTask TaskName=""RestoreTask"" AssemblyFile=""{Assembly.GetExecutingAssembly().Location}"" />
+    
+    <Target Name=""TestTarget"">
+        <RestoreTask />
+    </Target>
+</Project>";
+
+            string projectFile = Path.Combine(_testProjectsDir, "RestoreTaskServer.proj");
+            File.WriteAllText(projectFile, projectContent);
+
+            var logger = new MockLogger(_output);
+            var buildParameters = new BuildParameters
+            {
+                MultiThreaded = false,
+                Loggers = new[] { logger },
+                DisableInProcNode = false,
+                EnableNodeReuse = false,
+            };
+
+            var buildRequestData = new BuildRequestData(
+                projectFile,
+                new Dictionary<string, string>(),
+                null,
+                new[] { "TestTarget" },
+                null);
+
+            // Act
+            var buildManager = BuildManager.DefaultBuildManager;
+            var result = buildManager.Build(buildParameters, buildRequestData);
+
+            // Assert
+            result.OverallResult.ShouldBe(BuildResultCode.Success);
+            TaskRouterTestHelper.AssertTaskUsedTaskHost(logger, "RestoreTask");
+            logger.FullLog.ShouldContain("RestoreTask executed");
+        }
+
+        /// <summary>
+        /// Verifies that a known problematic task (RestoreTask) runs in-process
+        /// when neither multi-threaded mode nor server mode is active.
+        /// </summary>
+        [Fact]
+        public void ProblematicTask_RunsInProcess_WhenNoMTOrServer()
+        {
+            // Arrange
+            _env.SetEnvironmentVariable(Traits.UseMSBuildServerEnvVarName, "0");
+
+            string projectContent = $@"
+<Project>
+    <UsingTask TaskName=""RestoreTask"" AssemblyFile=""{Assembly.GetExecutingAssembly().Location}"" />
+    
+    <Target Name=""TestTarget"">
+        <RestoreTask />
+    </Target>
+</Project>";
+
+            string projectFile = Path.Combine(_testProjectsDir, "RestoreTaskNoMT.proj");
+            File.WriteAllText(projectFile, projectContent);
+
+            var logger = new MockLogger(_output);
+            var buildParameters = new BuildParameters
+            {
+                MultiThreaded = false,
+                Loggers = new[] { logger },
+                DisableInProcNode = false,
+                EnableNodeReuse = false,
+            };
+
+            var buildRequestData = new BuildRequestData(
+                projectFile,
+                new Dictionary<string, string>(),
+                null,
+                new[] { "TestTarget" },
+                null);
+
+            // Act
+            var buildManager = BuildManager.DefaultBuildManager;
+            var result = buildManager.Build(buildParameters, buildRequestData);
+
+            // Assert
+            result.OverallResult.ShouldBe(BuildResultCode.Success);
+
+            // Should run in-process when neither MT nor server mode
+            TaskRouterTestHelper.AssertTaskRanInProcess(logger, "RestoreTask");
+            logger.FullLog.ShouldContain("RestoreTask executed");
+        }
 
         private string CreateTestProject(string taskName, string taskClass)
         {
@@ -481,6 +643,24 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
     }
 
     #endregion
+}
+
+// Test task in the NuGet.Build.Tasks namespace to simulate the real RestoreTask for routing tests.
+// TaskRouter identifies problematic tasks by full type name.
+namespace NuGet.Build.Tasks
+{
+    /// <summary>
+    /// Simulates the NuGet RestoreTask for testing task routing workaround.
+    /// Has the same full name (NuGet.Build.Tasks.RestoreTask) that TaskRouter checks.
+    /// </summary>
+    public class RestoreTask : Microsoft.Build.Utilities.Task
+    {
+        public override bool Execute()
+        {
+            Log.LogMessage(MessageImportance.High, "RestoreTask executed");
+            return true;
+        }
+    }
 }
 
 // Custom attribute definition in Microsoft.Build.Framework namespace to match what TaskRouter expects

--- a/src/Build/BackEnd/Components/RequestBuilder/TaskRouter.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TaskRouter.cs
@@ -85,6 +85,48 @@ namespace Microsoft.Build.BackEnd
         }
 
         /// <summary>
+        /// Known task full names that have problematic static singleton state and must not
+        /// run in a sidecar TaskHost (which persists across invocations). Instead, these tasks
+        /// should run in an explicit (transient) TaskHost that terminates after execution,
+        /// ensuring static state is cleaned up.
+        /// This is a temporary workaround until the task authors fix their static state issues.
+        /// See https://github.com/dotnet/msbuild/issues/13315
+        /// </summary>
+        private static readonly string[] s_knownProblematicTaskNames =
+        [
+            "NuGet.Build.Tasks.RestoreTask",
+        ];
+
+        /// <summary>
+        /// Determines if a task is known to have problematic static singleton state that
+        /// makes it unsafe to run in a long-lived sidecar TaskHost process.
+        /// Such tasks should be routed to an explicit (transient) TaskHost that terminates
+        /// after execution, ensuring all static state is cleaned up.
+        /// </summary>
+        /// <param name="taskType">The type of the task to evaluate.</param>
+        /// <returns>True if the task is known to be problematic; false otherwise.</returns>
+        public static bool IsKnownProblematicTask(Type taskType)
+        {
+            ErrorUtilities.VerifyThrowArgumentNull(taskType, nameof(taskType));
+
+            string? fullName = taskType.FullName;
+            if (fullName is null)
+            {
+                return false;
+            }
+
+            foreach (string name in s_knownProblematicTaskNames)
+            {
+                if (string.Equals(fullName, name, StringComparison.Ordinal))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
         /// Clears the thread-safety cache. Used primarily for testing.
         /// </summary>
         internal static void ClearCache()

--- a/src/Build/Instance/TaskFactories/AssemblyTaskFactory.cs
+++ b/src/Build/Instance/TaskFactories/AssemblyTaskFactory.cs
@@ -348,6 +348,23 @@ namespace Microsoft.Build.BackEnd
                 }
             }
 
+            // Workaround for tasks with problematic static singleton state (e.g., NuGet RestoreTask).
+            // In MT mode or when MSBuild server is active, these tasks must run in a transient (non-sidecar)
+            // TaskHost to ensure static state is cleaned up after each invocation.
+            // See https://github.com/dotnet/msbuild/issues/13315
+            bool forceTransientTaskHost = false;
+            if (_loadedType?.Type != null && TaskRouter.IsKnownProblematicTask(_loadedType.Type))
+            {
+                bool isMultiThreaded = buildComponentHost?.BuildParameters?.MultiThreaded == true;
+                bool isServerMode = Traits.Instance.UseMSBuildServer;
+
+                if (isMultiThreaded || isServerMode)
+                {
+                    useTaskFactory = true;
+                    forceTransientTaskHost = true;
+                }
+            }
+
             taskLoggingContext?.TargetLoggingContext?.ProjectLoggingContext?.ProjectTelemetry?.AddTaskExecution(GetType().FullName, isTaskHost: useTaskFactory);
 
             if (useTaskFactory)
@@ -362,7 +379,8 @@ namespace Microsoft.Build.BackEnd
                 // If the task host factory is explicitly requested, do not act as a sidecar task host.
                 // This is important as customers use task host factories for short lived tasks to release
                 // potential locks.
-                bool useSidecarTaskHost = !(_factoryIdentityParameters.TaskHostFactoryExplicitlyRequested ?? false);
+                // Also disable sidecar for known problematic tasks to ensure static state cleanup.
+                bool useSidecarTaskHost = !forceTransientTaskHost && !(_factoryIdentityParameters.TaskHostFactoryExplicitlyRequested ?? false);
 
                 TaskHostTask task = new(
                     taskLocation,

--- a/src/Framework/Traits.cs
+++ b/src/Framework/Traits.cs
@@ -142,6 +142,11 @@ namespace Microsoft.Build.Framework
         public const string UseMSBuildServerEnvVarName = "MSBUILDUSESERVER";
 
         /// <summary>
+        /// Whether MSBuild server mode is enabled via the MSBUILDUSESERVER environment variable.
+        /// </summary>
+        public readonly bool UseMSBuildServer = Environment.GetEnvironmentVariable(UseMSBuildServerEnvVarName) == "1";
+
+        /// <summary>
         /// Name of environment variable for logging arguments (e.g., -bl, -check).
         /// </summary>
         public const string MSBuildLoggingArgsEnvVarName = "MSBUILD_LOGGING_ARGS";


### PR DESCRIPTION
Workaround for static singleton state issues in NuGet RestoreTask (e.g., PluginManager, EnvironmentWrapper) that persist across builds when running in sidecar TaskHost processes.

When /mt mode or MSBuild server (MSBUILDUSESERVER=1) is active, RestoreTask is now forced to run in a transient (non-sidecar) TaskHost that terminates after execution, ensuring all static state is cleaned up.

Changes:
- TaskRouter: Add IsKnownProblematicTask() to identify tasks by full name
- AssemblyTaskFactory: Force transient TaskHost for problematic tasks
- Tests: Add unit and integration tests for the workaround

Fixes dotnet/msbuild#13315

Fixes #

### Context


### Changes Made


### Testing


### Notes
