### PR TITLE
Include effective temp directory in node-reuse handshake salt (fixes #13594)

### DIFF
--- a/src/Build.UnitTests/BackEnd/HandshakeTempDir_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/HandshakeTempDir_Tests.cs
@@ -1,0 +1,161 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.IO;
+using Microsoft.Build.Internal;
+using Microsoft.Build.UnitTests;
+using Shouldly;
+using Xunit;
+
+namespace Microsoft.Build.Engine.UnitTests.BackEnd;
+
+/// <summary>
+/// Regression tests for https://github.com/dotnet/msbuild/issues/13594.
+///
+/// Two MSBuild invocations launched with different temporary directories
+/// (e.g. different <c>TMP</c>/<c>TEMP</c>/<c>TMPDIR</c> environment variables)
+/// must NOT reuse each other's worker nodes. Otherwise build A finishing and
+/// clearing its temp folder breaks the still-running build B which expected its
+/// own folder to remain available on the shared node.
+///
+/// The contract validated here: the <see cref="Handshake"/> salt incorporates
+/// the per-process effective temp directory for non-TaskHost paths, so the
+/// handshake key differs when the temp directory differs and the node-reuse
+/// lookup will refuse to bind to a foreign node.
+///
+/// TaskHost paths are intentionally exempted from the salt input. By default
+/// task-host processes do not survive past a single build (cross-build TaskHost
+/// reuse requires the rarely-set <c>MSBUILDREUSETASKHOSTNODES=1</c> opt-in and
+/// crashed parents kill sidecars via the pipe-link monitor), so the bug from
+/// #13594 cannot manifest there in normal use. Excluding TaskHost paths from
+/// the salt also avoids introducing a handshake-protocol mismatch on the NET
+/// TaskHost path (parent .NET Framework MSBuild ↔ child shipped from a
+/// separately-released .NET SDK), which intentionally tolerates parent/child
+/// version skew.
+/// </summary>
+public sealed class HandshakeTempDir_Tests
+{
+    private readonly ITestOutputHelper _output;
+
+    public HandshakeTempDir_Tests(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    [Fact]
+    public void Handshake_DifferentTempDirectory_ProducesDifferentKey()
+    {
+        // Use distinct, fully qualified directories so Path.GetTempPath() returns
+        // a different normalized value in each TestEnvironment scope.
+        string keyA;
+        string keyB;
+
+        using (TestEnvironment env = TestEnvironment.Create(_output))
+        {
+            TransientTestFolder folder = env.CreateFolder(createFolder: true);
+            env.SetTempPath(folder.Path);
+            keyA = new Handshake(HandshakeOptions.NodeReuse).GetKey();
+        }
+
+        using (TestEnvironment env = TestEnvironment.Create(_output))
+        {
+            TransientTestFolder folder = env.CreateFolder(createFolder: true);
+            env.SetTempPath(folder.Path);
+            keyB = new Handshake(HandshakeOptions.NodeReuse).GetKey();
+        }
+
+        keyA.ShouldNotBe(keyB,
+            "Two MSBuild invocations using different temp directories must produce " +
+            "distinct handshake keys so they do not reuse each other's nodes (issue #13594).");
+    }
+
+    [Fact]
+    public void Handshake_SameTempDirectory_ProducesSameKey()
+    {
+        // Sanity check: the temp dir contribution is deterministic, so two handshakes
+        // built under the same temp dir still match (otherwise legitimate node reuse breaks).
+        using TestEnvironment env = TestEnvironment.Create(_output);
+        TransientTestFolder folder = env.CreateFolder(createFolder: true);
+        env.SetTempPath(folder.Path);
+
+        string key1 = new Handshake(HandshakeOptions.NodeReuse).GetKey();
+        string key2 = new Handshake(HandshakeOptions.NodeReuse).GetKey();
+
+        key1.ShouldBe(key2,
+            "Identical environments must still produce identical handshake keys; " +
+            "otherwise node reuse would never succeed.");
+    }
+
+    [Fact]
+    public void ServerNodeHandshake_DifferentTempDirectory_ProducesDifferentHash()
+    {
+        // MSBuildServer pipe names are derived from ServerNodeHandshake.ComputeHash();
+        // changing TMP must yield a different server pipe so different temp envs do not
+        // collide on the same long-lived server process.
+        string hashA;
+        string hashB;
+
+        using (TestEnvironment env = TestEnvironment.Create(_output))
+        {
+            TransientTestFolder folder = env.CreateFolder(createFolder: true);
+            env.SetTempPath(folder.Path);
+            hashA = new ServerNodeHandshake(HandshakeOptions.None).ComputeHash();
+        }
+
+        using (TestEnvironment env = TestEnvironment.Create(_output))
+        {
+            TransientTestFolder folder = env.CreateFolder(createFolder: true);
+            env.SetTempPath(folder.Path);
+            hashB = new ServerNodeHandshake(HandshakeOptions.None).ComputeHash();
+        }
+
+        hashA.ShouldNotBe(hashB,
+            "MSBuildServer pipe-name hashes must differ when the temp directory differs " +
+            "so two builds with different TMP cannot share the same server (issue #13594).");
+    }
+
+    /// <summary>
+    /// TaskHost handshakes (here: NET TaskHost) intentionally do NOT incorporate the temp
+    /// directory in their salt. This pins that exemption so a future change cannot accidentally
+    /// re-introduce a handshake-protocol mismatch on the NET TaskHost path, which is the only
+    /// handshake that tolerates parent (VS) / child (SDK) version skew across release trains.
+    ///
+    /// The exemption is also safe with respect to the original #13594 bug because cross-build
+    /// TaskHost reuse is gated on the off-by-default <c>MSBUILDREUSETASKHOSTNODES=1</c> escape
+    /// hatch (see <c>Traits.EscapeHatches.ReuseTaskHostNodes</c>) and on the parent surviving
+    /// long enough to send <c>NodeBuildComplete(PrepareForReuse=true)</c>; if the parent
+    /// crashes, the sidecar shuts itself down via <c>OnLinkStatusChanged(ConnectionFailed)</c>.
+    /// </summary>
+    [Fact]
+    public void Handshake_NetTaskHost_DifferentTempDirectory_ProducesSameKey()
+    {
+        const HandshakeOptions netTaskHostOptions = HandshakeOptions.NET | HandshakeOptions.TaskHost;
+        // A toolsDirectory must be supplied for NET TaskHost handshakes; the actual path
+        // is irrelevant as long as it is identical across the two constructions.
+        string toolsDirectory = Path.Combine(Path.GetTempPath(), "fixed_tools_dir_for_test");
+
+        string keyA;
+        string keyB;
+
+        using (TestEnvironment env = TestEnvironment.Create(_output))
+        {
+            TransientTestFolder folder = env.CreateFolder(createFolder: true);
+            env.SetTempPath(folder.Path);
+            keyA = new Handshake(netTaskHostOptions, toolsDirectory).GetKey();
+        }
+
+        using (TestEnvironment env = TestEnvironment.Create(_output))
+        {
+            TransientTestFolder folder = env.CreateFolder(createFolder: true);
+            env.SetTempPath(folder.Path);
+            keyB = new Handshake(netTaskHostOptions, toolsDirectory).GetKey();
+        }
+
+        keyA.ShouldBe(keyB,
+            "NET TaskHost handshake salt must NOT incorporate Path.GetTempPath(): the NET " +
+            "TaskHost path tolerates VS-vs-SDK version skew and an unsynchronized salt input " +
+            "would introduce a protocol mismatch. The bug from #13594 cannot manifest here " +
+            "in practice anyway because cross-build TaskHost reuse requires the off-by-default " +
+            "MSBUILDREUSETASKHOSTNODES=1 opt-in.");
+    }
+}

--- a/src/Framework/BackEnd/Handshake.cs
+++ b/src/Framework/BackEnd/Handshake.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics;
+using System.IO;
 using System.Reflection;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
@@ -77,13 +78,31 @@ internal class Handshake
         var options = (int)nodeType | (handshakeVersion << 24);
         CommunicationsUtilities.Trace($"Building handshake for node type {nodeType}, (version {handshakeVersion}): options {options}.");
 
-        // Calculate salt from environment and tools directory
+        // Calculate salt from environment, tools directory, and (for non-TaskHost paths) the
+        // effective temp directory. The temp directory is included so that two MSBuild invocations
+        // launched with different TMP/TEMP/TMPDIR environments do not reuse each other's worker
+        // nodes — without this, build A finishing and clearing its per-build temp folder would
+        // break a still-running build B that inherited the same node and expected its own temp
+        // folder to remain available (https://github.com/dotnet/msbuild/issues/13594).
+        //
+        // TaskHost paths are intentionally excluded from the temp-dir contribution:
+        //   - NET TaskHost (parent .NET Framework MSBuild ↔ child shipped from a separately-
+        //     released .NET SDK) tolerates version skew via NetTaskHostHandshakeVersion below;
+        //     adding a salt input that isn't synchronized across both drops would break VS+SDK
+        //     combinations until both sides picked up the change.
+        //   - CLR2 TaskHost has NodeReuse disabled by design, so there is no cross-build reuse
+        //     surface to protect.
         string handshakeSalt = Environment.GetEnvironmentVariable("MSBUILDNODEHANDSHAKESALT") ?? "";
-
-        int salt = CommunicationsUtilities.GetHashCode($"{handshakeSalt}{toolsDirectory}");
+        bool isTaskHost = IsHandshakeOptionEnabled(nodeType, HandshakeOptions.TaskHost);
+        string tempDirectory = isTaskHost ? string.Empty : Path.GetTempPath();
+        int salt = CommunicationsUtilities.GetHashCode($"{handshakeSalt}{toolsDirectory}{tempDirectory}");
 
         CommunicationsUtilities.Trace($"Handshake salt is {handshakeSalt}");
         CommunicationsUtilities.Trace($"Tools directory root is {toolsDirectory}");
+        if (!isTaskHost)
+        {
+            CommunicationsUtilities.Trace($"Temp directory is {tempDirectory}");
+        }
 
         // Get session ID if needed (expensive call)
         int sessionId = 0;


### PR DESCRIPTION
## Fixes #13594

Two MSBuild invocations launched with different `TMP`/`TEMP`/`TMPDIR` environments could bind to each other''s reusable worker nodes because the handshake salt was derived only from `MSBUILDNODEHANDSHAKESALT` and the tools-directory path. When build A finished and cleaned its per-build temp folder, the still-running build B (now driving a node that thought A''s temp was its own) failed with warnings such as `MSB5018` or fatal "system cannot find the path specified" errors pointing at A''s deleted folder.

## Fix

Mix `Path.GetTempPath()` into the salt for **non-TaskHost** handshakes in `src/Framework/BackEnd/Handshake.cs`. Both parent and child read the same env at handshake-construction time (the launcher copies the parent env wholesale and only ever sets `DOTNET_ROOT*` overrides — never temp vars), so matching environments still produce matching salts (legitimate worker-node reuse keeps working) and distinct temp environments now produce distinct salts and refuse to bind. `ServerNodeHandshake` derives from `Handshake`, so MSBuild Server pipe names and the per-server mutex are isolated per temp env as well.

The exclusion is implemented as a single `IsHandshakeOptionEnabled(nodeType, HandshakeOptions.TaskHost)` check. Worker nodes (`HandshakeOptions.NodeReuse` without `TaskHost`) and `ServerNodeHandshake` (`HandshakeOptions.None`) keep the new salt input. TaskHost paths skip it.

## Why TaskHost paths are exempted (and why that''s a non-issue in practice)

Cross-build TaskHost reuse is not on the default path:

- **`MSBUILDREUSETASKHOSTNODES=1` is required.** `MSBuildTaskHost/OutOfProcTaskHostNode.cs:509-512` and the parallel `MSBuild/OutOfProcTaskHostNode.cs:1275`:
  ```csharp
  // TaskHostNodes lock assemblies with custom tasks produced by build scripts if NodeReuse is on.
  // This causes failures if the user builds twice.
  _shutdownReason = buildComplete.PrepareForReuse && Traits.Instance.EscapeHatches.ReuseTaskHostNodes
      ? NodeEngineShutdownReason.BuildCompleteReuse
      : NodeEngineShutdownReason.BuildComplete;
  ```
  And `Framework/Traits.cs:334`: `ReuseTaskHostNodes = Environment.GetEnvironmentVariable("MSBUILDREUSETASKHOSTNODES") == "1"`. **Default is off.** Even though the parent advertises `PrepareForReuse=true`, every TaskHost shuts down at end-of-build unless the user has flipped this rarely-used escape hatch.
- **Crashed parents kill sidecars.** `MSBuildTaskHost/OutOfProcTaskHostNode.cs:570-578`:
  ```csharp
  case LinkStatus.ConnectionFailed:
  case LinkStatus.Failed:
      _shutdownReason = NodeEngineShutdownReason.ConnectionFailed;
      _shutdownEvent.Set();
  ```
  If the parent dies abruptly the named-pipe link breaks, the sidecar TaskHost detects it and shuts itself down. So sidecars don''t outlive their parent under any normal failure mode.

For #13594 to bite on the TaskHost path, **all** of the following must hold simultaneously: `MSBUILDREUSETASKHOSTNODES=1` set, `Runtime="NET"` (or `MSBUILDFORCEALLTASKSOUTOFPROC=1`) tasks actually used, the first parent exits cleanly, the second parent has a different `TMP`, and tasks in the second build consume `Path.GetTempPath()`-derived files. That combination is essentially nonexistent in real workloads, and users who do hit it have always had `MSBUILDDISABLENODEREUSE=1` and per-build `MSBUILDNODEHANDSHAKESALT` as workarounds (both of which the PR leaves in place and continues to honor).

The exemption is therefore not a deferred-problem caveat — **it is the right design**:

- The NET TaskHost handshake is the only handshake that intentionally tolerates parent (.NET Framework MSBuild bundled in VS) ↔ child (MSBuild bundled in a separately-released .NET SDK) version skew, via the magic `NetTaskHostHandshakeVersion = 99` in the file-version slots. Adding a salt input that isn''t synchronized across both release trains would introduce a hard handshake mismatch on any VS+SDK pairing where one side has the change and the other doesn''t. Since the bug doesn''t manifest there in practice, the salt input is correctly omitted.
- CLR2 TaskHost has `NodeReuse` disabled by design (`NodeProviderOutOfProcTaskHost.IsNodeReuseEnabled`, line 762: `&& !Handshake.IsHandshakeOptionEnabled(hostContext, HandshakeOptions.CLR2)`), so each CLR2 host is single-shot and exits at end of build. No bug surface.

## Before — handshake salt does not depend on temp dir

```mermaid
sequenceDiagram
    autonumber
    participant ShellA as Shell A<br/>TMP=C:\tmpA
    participant BuildA as Build A (parent)
    participant Node as Reusable worker node
    participant BuildB as Build B (parent)
    participant ShellB as Shell B<br/>TMP=C:\tmpB

    ShellA->>BuildA: msbuild ...
    BuildA->>BuildA: salt = hash(saltVar + toolsDir)
    BuildA->>Node: spawn (inherits TMP=C:\tmpA)
    Node->>Node: opens C:\tmpA\MSBuildTemp{guid}
    Note over BuildA,Node: salt matches → bound

    ShellB->>BuildB: msbuild ...
    BuildB->>BuildB: salt = hash(saltVar + toolsDir)
    Note over BuildA,BuildB: ⚠ same salt despite different TMP
    BuildB->>Node: discover & reuse (handshake passes)
    Note over BuildB,Node: Node is still rooted under C:\tmpA

    BuildA-->>ShellA: done
    ShellA->>ShellA: rm -rf C:\tmpA  (per-build cleanup)
    Node->>Node: write to C:\tmpA\... 💥
    Node-->>BuildB: MSB5018 / "path not found"
    BuildB-->>ShellB: ❌ build fails
```

## After — temp dir is part of the salt for worker nodes

```mermaid
sequenceDiagram
    autonumber
    participant ShellA as Shell A<br/>TMP=C:\tmpA
    participant BuildA as Build A (parent)
    participant NodeA as Worker node A
    participant NodeB as Worker node B
    participant BuildB as Build B (parent)
    participant ShellB as Shell B<br/>TMP=C:\tmpB

    ShellA->>BuildA: msbuild ...
    BuildA->>BuildA: salt = hash(saltVar + toolsDir + "C:\tmpA\")
    BuildA->>NodeA: spawn (inherits TMP=C:\tmpA)
    NodeA->>NodeA: salt = hash(... + "C:\tmpA\")  ✅ matches BuildA

    ShellB->>BuildB: msbuild ...
    BuildB->>BuildB: salt = hash(saltVar + toolsDir + "C:\tmpB\")
    BuildB->>NodeA: probe (handshake)
    NodeA-->>BuildB: salt mismatch → reject
    BuildB->>NodeB: spawn fresh (inherits TMP=C:\tmpB)
    NodeB->>NodeB: salt = hash(... + "C:\tmpB\")  ✅ matches BuildB

    BuildA-->>ShellA: done
    ShellA->>ShellA: rm -rf C:\tmpA
    NodeA-->>NodeA: idles (no other build can bind)
    NodeB->>NodeB: keeps writing under C:\tmpB ✅
    BuildB-->>ShellB: ✔ build succeeds
```

## Salt composition

```mermaid
flowchart LR
    subgraph BEFORE [Before]
        A1[MSBUILDNODEHANDSHAKESALT env]
        A2[toolsDirectory]
        A1 --> AC{{concat}}
        A2 --> AC
        AC --> AH[GetHashCode → int salt]
    end

    subgraph AFTER [After - non-TaskHost only]
        B1[MSBUILDNODEHANDSHAKESALT env]
        B2[toolsDirectory]
        B3[Path.GetTempPath]
        B1 --> BC{{concat}}
        B2 --> BC
        B3 --> BC
        BC --> BH[GetHashCode → int salt]
    end

    subgraph AFTER_TH [After - TaskHost paths unchanged]
        C1[MSBUILDNODEHANDSHAKESALT env]
        C2[toolsDirectory]
        C1 --> CC{{concat}}
        C2 --> CC
        CC --> CH[GetHashCode → int salt]
    end
```

## Why this approach

- **Symmetric by construction.** Parent and child both compute `Path.GetTempPath()` from the same inherited environment at handshake time.
- **Reuse is preserved.** Identical envs ⇒ identical salts ⇒ reuse still works. Only genuinely-distinct temp envs are isolated.
- **Smallest possible change.** ~10 lines of production code in a single file, gated by one `IsHandshakeOptionEnabled(..., TaskHost)` check.
- **No cross-release breakage.** Worker nodes and the MSBuild Server are shipped in the same drop as the parent that talks to them, so they always agree on the formula. TaskHost paths — the only ones with parent/child release skew — are explicitly opted out.
- **No new env var, flag, or ChangeWave.** Worker reuse becomes strictly more conservative; no new warnings or errors are emitted.
- **Self-invalidating on upgrade.** Pre-upgrade worker nodes have a different salt than upgraded parents and are naturally ignored; they idle out within the existing reuse timeout.

Alternatives considered and rejected: hashing the full environment block (kills all reuse — `PWD`, `_`, `OLDPWD`, `CMDCMDLINE` etc. churn per shell), moving the per-node temp folder to a fixed system path (ignores users who deliberately set `TMP`, doesn''t reach `ToolTask` / user task code that re-resolves `Path.GetTempPath()`), pinning temp at startup (same gap), runtime detection + respawn (reactive and racy — corruption already happened), full env diff over the wire (much larger handshake, no extra benefit over hashing into the salt), and documenting `MSBUILDNODEHANDSHAKESALT` as the workaround (the existing workaround — pushes the burden to every caller).

## Blast radius

| Scope | Change |
|---|---|
| `Microsoft.Build` worker nodes | Salt now varies by temp env. Same-env reuse unchanged; distinct-env reuse correctly refused. |
| MSBuild Server (`MSBuildServer-{hash}` pipe + `Global\msbuild-server-running-{hash}` mutex) | Now scoped per temp env. Different `TMP` values no longer share a server. `--shutdown` from a different temp env will not see the foreign server, but stale servers idle out via existing timeouts. |
| NET TaskHost (parent .NET Framework MSBuild ↔ child SDK MSBuild) | **Unchanged by design.** Cross-build NET TaskHost reuse is gated on `MSBUILDREUSETASKHOSTNODES=1` (off by default) and on the parent surviving long enough to send a clean shutdown; the bug from #13594 cannot manifest on this path under normal conditions, and excluding the salt input avoids introducing a handshake-protocol skew across the VS+SDK release boundary. |
| CLR2 TaskHost | Unchanged. `NodeReuse` is disabled there by design, so no bug surface. |
| `MSBuildTaskHost.exe` (legacy CLR2 binary) | Unchanged — single-shot process, no reuse to protect. |

## Tests

`src/Build.UnitTests/BackEnd/HandshakeTempDir_Tests.cs` (new) covers:

| Test | Purpose |
|---|---|
| `Handshake_DifferentTempDirectory_ProducesDifferentKey` | Regression for #13594 — failed before the fix, passes after. |
| `Handshake_SameTempDirectory_ProducesSameKey` | Sanity — legitimate worker reuse not regressed. |
| `ServerNodeHandshake_DifferentTempDirectory_ProducesDifferentHash` | MSBuild Server pipe name is isolated per temp env. |
| `Handshake_NetTaskHost_DifferentTempDirectory_ProducesSameKey` | Pins the TaskHost exemption so a future change cannot accidentally re-introduce a NET-TaskHost handshake-protocol skew. |

All tests use the standard `ITestOutputHelper` injection pattern so test diagnostics are captured. Existing tests in the related neighborhood (`AppHostSupport_Tests`, `UnixNodeReuseFixes_Tests`, `TaskHostNodeKey_Tests`) continue to pass.
