### PR TITLE
Bump main to 18.8.0 after vs18.7 snap

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -3,9 +3,9 @@
   <Import Project="Version.Details.props" />
 
   <PropertyGroup>
-    <VersionPrefix>18.7.0</VersionPrefix>
+    <VersionPrefix>18.8.0</VersionPrefix>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
-    <PackageValidationBaselineVersion>18.6.0-preview-26180-08</PackageValidationBaselineVersion>
+    <PackageValidationBaselineVersion>18.7.0-preview-26229-01</PackageValidationBaselineVersion>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>
 
     <!-- differentiate experimental insertions to avoid package id conflicts, 

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <VersionPrefix>18.8.0</VersionPrefix>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
-    <PackageValidationBaselineVersion>18.7.1-servicing-26230-11</PackageValidationBaselineVersion>
+    <PackageValidationBaselineVersion>18.4.0</PackageValidationBaselineVersion>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>
 
     <!-- differentiate experimental insertions to avoid package id conflicts, 

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <VersionPrefix>18.8.0</VersionPrefix>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
-    <PackageValidationBaselineVersion>18.7.0-preview-26229-01</PackageValidationBaselineVersion>
+    <PackageValidationBaselineVersion>18.7.1-servicing-26230-11</PackageValidationBaselineVersion>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>
 
     <!-- differentiate experimental insertions to avoid package id conflicts, 

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <VersionPrefix>18.8.0</VersionPrefix>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
-    <PackageValidationBaselineVersion>18.4.0</PackageValidationBaselineVersion>
+    <PackageValidationBaselineVersion>18.7.0-preview-26230-02</PackageValidationBaselineVersion>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>
 
     <!-- differentiate experimental insertions to avoid package id conflicts, 


### PR DESCRIPTION
Phase 2 of the [18.7 release checklist](https://github.com/dotnet/msbuild/issues/13639): bump `main` to 18.8 now that `vs18.7` has been snapped.

### Changes
- `VersionPrefix`: `18.7.0` → `18.8.0`
- `PackageValidationBaselineVersion`: `18.6.0-preview-26180-08` → `18.7.0-preview-26230-02`
  - This is the 18.7 preview that was inserted into VS main via [DevDiv VS#733906](https://devdiv.visualstudio.com/DevDiv/_git/VS/pullrequest/734784) (msbuild commit `f215cd0f`), matching the prior pattern used in #13472 (which set baseline to the latest 18.6 preview at the time of snap).

### Notes
- `CompatibilitySuppressions.xml` files: not updated here. If ApiCompat fails CI, run `dotnet pack MSBuild.Dev.slnf /p:ApiCompatGenerateSuppressionFile=true` to regenerate.
- `azure-pipelines/vs-insertion.yml`: no `AutoInsertTargetBranch` field on this version — no change needed for the main bump.
- `azure-pipelines/vs-insertion-experimental.yml`: already has `main`/`rel/insiders`/`rel/stable` — no change needed.

Tracks #13639.
