### PR TITLE
Final branding for 18.7 release

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -3,8 +3,8 @@
   <Import Project="Version.Details.props" />
 
   <PropertyGroup>
-    <VersionPrefix>18.7.0</VersionPrefix>
-    <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
+    <VersionPrefix>18.7.0</VersionPrefix><DotNetFinalVersionKind>release</DotNetFinalVersionKind><!-- Keep next to VersionPrefix to create a conflict in forward-flow -->
+    <PreReleaseVersionLabel>servicing</PreReleaseVersionLabel>
     <PackageValidationBaselineVersion>18.6.0-preview-26180-08</PackageValidationBaselineVersion>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>
 


### PR DESCRIPTION
Phase 4 of the [18.7 release checklist](https://github.com/dotnet/msbuild/issues/13639): final branding for the 18.7.0 release.

### Changes (generated by `scripts/Stabilize-Release.ps1`)
- Add `<DotNetFinalVersionKind>release</DotNetFinalVersionKind>` on the `VersionPrefix` line (kept inline to create a conflict in forward-flow per release docs)
- Change `PreReleaseVersionLabel` from `preview` to `servicing`

### Notes
- **Phase 4.1 (PublicAPI promotion)**: no-op — there are no non-empty `PublicAPI.Unshipped.txt` entries on `vs18.7`.
- Same shape as 18.6 final branding PR #13473.

⚠️ **Time-sensitive**: VS snaps `main` → `rel/insiders` on **2026-05-01**. Final-branded bits need to be in VS `main` before the snap.

Tracks #13639.
