### PR TITLE
Fix flaky DistributedFileLoggerParameters test with test isolation

### DIFF
--- a/src/Build.UnitTests/FileLogger_Tests.cs
+++ b/src/Build.UnitTests/FileLogger_Tests.cs
@@ -18,6 +18,13 @@ namespace Microsoft.Build.UnitTests
 {
     public class FileLogger_Tests
     {
+        private readonly ITestOutputHelper _output;
+
+        public FileLogger_Tests(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
         /// <summary>
         /// Basic test of the file logger.  Writes to a log file in the temp directory.
         /// </summary>
@@ -482,49 +489,45 @@ namespace Microsoft.Build.UnitTests
         [Fact]
         public void DistributedFileLoggerParameters()
         {
+            using TestEnvironment env = TestEnvironment.Create(_output);
+            TransientTestFolder folder = env.CreateFolder();
+            env.SetCurrentDirectory(folder.Path);
+
             DistributedFileLogger fileLogger = new DistributedFileLogger();
-            try
-            {
-                fileLogger.NodeId = 0;
-                fileLogger.Initialize(new EventSourceSink());
-                Assert.Equal(0, string.Compare(fileLogger.InternalFilelogger.Parameters, "ForceNoAlign;ShowEventId;ShowCommandLine;logfile=msbuild0.log;", StringComparison.OrdinalIgnoreCase));
-                fileLogger.Shutdown();
 
-                fileLogger.NodeId = 3;
-                fileLogger.Parameters = "logfile=" + Path.Combine(Directory.GetCurrentDirectory(), "mylogfile.log");
-                fileLogger.Initialize(new EventSourceSink());
-                Assert.Equal(0, string.Compare(fileLogger.InternalFilelogger.Parameters, "ForceNoAlign;ShowEventId;ShowCommandLine;logfile=" + Path.Combine(Directory.GetCurrentDirectory(), "mylogfile3.log") + ";", StringComparison.OrdinalIgnoreCase));
-                fileLogger.Shutdown();
+            fileLogger.NodeId = 0;
+            fileLogger.Initialize(new EventSourceSink());
+            Assert.Equal(0, string.Compare(fileLogger.InternalFilelogger.Parameters, "ForceNoAlign;ShowEventId;ShowCommandLine;logfile=msbuild0.log;", StringComparison.OrdinalIgnoreCase));
+            fileLogger.Shutdown();
 
-                fileLogger.NodeId = 4;
-                fileLogger.Parameters = "logfile=" + Path.Combine(Directory.GetCurrentDirectory(), "mylogfile.log");
-                fileLogger.Initialize(new EventSourceSink());
-                Assert.Equal(0, string.Compare(fileLogger.InternalFilelogger.Parameters, "ForceNoAlign;ShowEventId;ShowCommandLine;logfile=" + Path.Combine(Directory.GetCurrentDirectory(), "mylogfile4.log") + ";", StringComparison.OrdinalIgnoreCase));
-                fileLogger.Shutdown();
+            fileLogger.NodeId = 3;
+            fileLogger.Parameters = "logfile=" + Path.Combine(folder.Path, "mylogfile.log");
+            fileLogger.Initialize(new EventSourceSink());
+            Assert.Equal(0, string.Compare(fileLogger.InternalFilelogger.Parameters, "ForceNoAlign;ShowEventId;ShowCommandLine;logfile=" + Path.Combine(folder.Path, "mylogfile3.log") + ";", StringComparison.OrdinalIgnoreCase));
+            fileLogger.Shutdown();
 
-                Directory.CreateDirectory(Path.Combine(Directory.GetCurrentDirectory(), "tempura"));
-                fileLogger.NodeId = 1;
-                fileLogger.Parameters = "logfile=" + Path.Combine(Directory.GetCurrentDirectory(), "tempura", "mylogfile.log");
-                fileLogger.Initialize(new EventSourceSink());
-                Assert.Equal(0, string.Compare(fileLogger.InternalFilelogger.Parameters, "ForceNoAlign;ShowEventId;ShowCommandLine;logfile=" + Path.Combine(Directory.GetCurrentDirectory(), "tempura", "mylogfile1.log") + ";", StringComparison.OrdinalIgnoreCase));
-                fileLogger.Shutdown();
-            }
-            finally
-            {
-                if (Directory.Exists(Path.Combine(Directory.GetCurrentDirectory(), "tempura")))
-                {
-                    File.Delete(Path.Combine(Directory.GetCurrentDirectory(), "tempura", "mylogfile1.log"));
-                    FileUtilities.DeleteWithoutTrailingBackslash(Path.Combine(Directory.GetCurrentDirectory(), "tempura"));
-                }
-                File.Delete(Path.Combine(Directory.GetCurrentDirectory(), "mylogfile0.log"));
-                File.Delete(Path.Combine(Directory.GetCurrentDirectory(), "mylogfile3.log"));
-                File.Delete(Path.Combine(Directory.GetCurrentDirectory(), "mylogfile4.log"));
-            }
+            fileLogger.NodeId = 4;
+            fileLogger.Parameters = "logfile=" + Path.Combine(folder.Path, "mylogfile.log");
+            fileLogger.Initialize(new EventSourceSink());
+            Assert.Equal(0, string.Compare(fileLogger.InternalFilelogger.Parameters, "ForceNoAlign;ShowEventId;ShowCommandLine;logfile=" + Path.Combine(folder.Path, "mylogfile4.log") + ";", StringComparison.OrdinalIgnoreCase));
+            fileLogger.Shutdown();
+
+            string tempuraDir = Path.Combine(folder.Path, "tempura");
+            Directory.CreateDirectory(tempuraDir);
+            fileLogger.NodeId = 1;
+            fileLogger.Parameters = "logfile=" + Path.Combine(tempuraDir, "mylogfile.log");
+            fileLogger.Initialize(new EventSourceSink());
+            Assert.Equal(0, string.Compare(fileLogger.InternalFilelogger.Parameters, "ForceNoAlign;ShowEventId;ShowCommandLine;logfile=" + Path.Combine(tempuraDir, "mylogfile1.log") + ";", StringComparison.OrdinalIgnoreCase));
+            fileLogger.Shutdown();
         }
 
         [Fact]
         public void DistributedLoggerNullEmpty()
         {
+            using TestEnvironment env = TestEnvironment.Create(_output);
+            TransientTestFolder folder = env.CreateFolder();
+            env.SetCurrentDirectory(folder.Path);
+
             Assert.Throws<LoggerException>(() =>
             {
                 DistributedFileLogger fileLogger = new DistributedFileLogger();

--- a/src/Build.UnitTests/FileLogger_Tests.cs
+++ b/src/Build.UnitTests/FileLogger_Tests.cs
@@ -8,6 +8,7 @@ using System.IO;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Logging;
 using Microsoft.Build.Shared;
+using Shouldly;
 using Xunit;
 using EventSourceSink = Microsoft.Build.BackEnd.Logging.EventSourceSink;
 using Project = Microsoft.Build.Evaluation.Project;
@@ -497,19 +498,25 @@ namespace Microsoft.Build.UnitTests
 
             fileLogger.NodeId = 0;
             fileLogger.Initialize(new EventSourceSink());
-            Assert.Equal(0, string.Compare(fileLogger.InternalFilelogger.Parameters, "ForceNoAlign;ShowEventId;ShowCommandLine;logfile=msbuild0.log;", StringComparison.OrdinalIgnoreCase));
+            fileLogger.InternalFilelogger.Parameters.ShouldBe(
+                "ForceNoAlign;ShowEventId;ShowCommandLine;logfile=msbuild0.log;",
+                StringCompareShould.IgnoreCase);
             fileLogger.Shutdown();
 
             fileLogger.NodeId = 3;
             fileLogger.Parameters = "logfile=" + Path.Combine(folder.Path, "mylogfile.log");
             fileLogger.Initialize(new EventSourceSink());
-            Assert.Equal(0, string.Compare(fileLogger.InternalFilelogger.Parameters, "ForceNoAlign;ShowEventId;ShowCommandLine;logfile=" + Path.Combine(folder.Path, "mylogfile3.log") + ";", StringComparison.OrdinalIgnoreCase));
+            fileLogger.InternalFilelogger.Parameters.ShouldBe(
+                "ForceNoAlign;ShowEventId;ShowCommandLine;logfile=" + Path.Combine(folder.Path, "mylogfile3.log") + ";",
+                StringCompareShould.IgnoreCase);
             fileLogger.Shutdown();
 
             fileLogger.NodeId = 4;
             fileLogger.Parameters = "logfile=" + Path.Combine(folder.Path, "mylogfile.log");
             fileLogger.Initialize(new EventSourceSink());
-            Assert.Equal(0, string.Compare(fileLogger.InternalFilelogger.Parameters, "ForceNoAlign;ShowEventId;ShowCommandLine;logfile=" + Path.Combine(folder.Path, "mylogfile4.log") + ";", StringComparison.OrdinalIgnoreCase));
+            fileLogger.InternalFilelogger.Parameters.ShouldBe(
+                "ForceNoAlign;ShowEventId;ShowCommandLine;logfile=" + Path.Combine(folder.Path, "mylogfile4.log") + ";",
+                StringCompareShould.IgnoreCase);
             fileLogger.Shutdown();
 
             string tempuraDir = Path.Combine(folder.Path, "tempura");
@@ -517,7 +524,9 @@ namespace Microsoft.Build.UnitTests
             fileLogger.NodeId = 1;
             fileLogger.Parameters = "logfile=" + Path.Combine(tempuraDir, "mylogfile.log");
             fileLogger.Initialize(new EventSourceSink());
-            Assert.Equal(0, string.Compare(fileLogger.InternalFilelogger.Parameters, "ForceNoAlign;ShowEventId;ShowCommandLine;logfile=" + Path.Combine(tempuraDir, "mylogfile1.log") + ";", StringComparison.OrdinalIgnoreCase));
+            fileLogger.InternalFilelogger.Parameters.ShouldBe(
+                "ForceNoAlign;ShowEventId;ShowCommandLine;logfile=" + Path.Combine(tempuraDir, "mylogfile1.log") + ";",
+                StringCompareShould.IgnoreCase);
             fileLogger.Shutdown();
         }
 


### PR DESCRIPTION
## Problem

`DistributedFileLoggerParameters` intermittently fails in CI with:

> LoggerException: Failed to write to log file "msbuild0.log". The process cannot access the file because it is being used by another process.

Both `DistributedFileLoggerParameters` and `DistributedLoggerNullEmpty` create `msbuild0.log` in the shared working directory. When tests run concurrently they contend on the same file. The old `finally` block also never cleaned up `msbuild0.log` itself.

## Fix

- Use `TestEnvironment` with an isolated temp folder and `SetCurrentDirectory` so each test operates on its own files
- `TestEnvironment.Dispose()` handles all cleanup automatically, replacing the brittle manual `try/finally`
- Added `ITestOutputHelper` to the test class for proper test output capture