### PR TITLE
Docudocument that public Microsoft.Build.Tasks.CallTarget is not the live implementation

### DIFF
--- a/src/Tasks/CallTarget.cs
+++ b/src/Tasks/CallTarget.cs
@@ -13,6 +13,11 @@ namespace Microsoft.Build.Tasks
     /// project file.  Marked RunInMTA because we do not want this task to ever be invoked explicitly
     /// on the STA if the RequestBuilder is running on another thread, as this will cause thread
     /// id validation checks to fail.
+    ///
+    /// NOTE: This class is not the implementation that actually runs at build time. The MSBuild engine
+    /// resolves &lt;CallTarget&gt; to the intrinsic implementation in
+    /// Microsoft.Build.BackEnd.IntrinsicTasks.CallTarget. This type is retained only for backwards
+    /// compatibility in case a third-party task derives from it; it should not be used directly.
     /// </remarks>
     [RunInMTA]
     public class CallTarget : TaskExtension

--- a/src/Tasks/CallTarget.cs
+++ b/src/Tasks/CallTarget.cs
@@ -15,10 +15,9 @@ namespace Microsoft.Build.Tasks
     /// id validation checks to fail.
     ///
     /// NOTE: This class is not the implementation that actually runs at build time. The MSBuild engine
-    /// resolves &lt;CallTarget&gt; to the intrinsic implementation in <c>Microsoft.Build.BackEnd.CallTarget</c>
-    /// (under <c>src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/CallTarget.cs</c>). This type
-    /// is retained only for backwards compatibility in case a third-party task derives from it; it should
-    /// not be used directly.
+    /// NOTE: This class is not the implementation that actually runs at build time. The MSBuild engine
+    /// resolves &lt;CallTarget&gt; to a private implementation. This type is retained only for
+    /// backwards compatibility in case a third-party task derives from it; it should not be used.
     /// </remarks>
     [RunInMTA]
     public class CallTarget : TaskExtension

--- a/src/Tasks/CallTarget.cs
+++ b/src/Tasks/CallTarget.cs
@@ -15,7 +15,6 @@ namespace Microsoft.Build.Tasks
     /// id validation checks to fail.
     ///
     /// NOTE: This class is not the implementation that actually runs at build time. The MSBuild engine
-    /// NOTE: This class is not the implementation that actually runs at build time. The MSBuild engine
     /// resolves &lt;CallTarget&gt; to a private implementation. This type is retained only for
     /// backwards compatibility in case a third-party task derives from it; it should not be used.
     /// </remarks>

--- a/src/Tasks/CallTarget.cs
+++ b/src/Tasks/CallTarget.cs
@@ -15,9 +15,10 @@ namespace Microsoft.Build.Tasks
     /// id validation checks to fail.
     ///
     /// NOTE: This class is not the implementation that actually runs at build time. The MSBuild engine
-    /// resolves &lt;CallTarget&gt; to the intrinsic implementation in
-    /// Microsoft.Build.BackEnd.IntrinsicTasks.CallTarget. This type is retained only for backwards
-    /// compatibility in case a third-party task derives from it; it should not be used directly.
+    /// resolves &lt;CallTarget&gt; to the intrinsic implementation in <c>Microsoft.Build.BackEnd.CallTarget</c>
+    /// (under <c>src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/CallTarget.cs</c>). This type
+    /// is retained only for backwards compatibility in case a third-party task derives from it; it should
+    /// not be used directly.
     /// </remarks>
     [RunInMTA]
     public class CallTarget : TaskExtension


### PR DESCRIPTION
Per @rainersigwald's [comment on #13616](https://github.com/dotnet/msbuild/pull/13616#discussion_r3149700193): the public `Microsoft.Build.Tasks.CallTarget` class is not the implementation that actually runs at build time — the MSBuild engine resolves `<CallTarget>` to the intrinsic implementation in `Microsoft.Build.BackEnd.IntrinsicTasks.CallTarget` (which is already enlightened for multithreaded mode). This type is retained only in case some third-party task derives from it.

This PR adds a `<remarks>` note to that effect on the public class so future readers/contributors don't try to enlighten or otherwise modify this dead-code path.

No behavioral change.