### PR TITLE
Use macOS clonefile(2) for copy-on-write file cloning in Copy task

### DIFF
--- a/src/Tasks.UnitTests/Copy_Tests.cs
+++ b/src/Tasks.UnitTests/Copy_Tests.cs
@@ -3226,5 +3226,184 @@ namespace Microsoft.Build.UnitTests
                 }
             }
         }
+
+        #region clonefile tests
+
+        /// <summary>
+        /// Creates a Copy task targeting a single file, with the experimental clone env var set as specified.
+        /// </summary>
+        private Copy CreateCloneCopyTask(TestEnvironment env, string sourcePath, string destPath, bool enableClone, bool skipUnchanged = false)
+        {
+            env.SetEnvironmentVariable(Copy.ExperimentalCopyEnvVar, enableClone ? "1" : null);
+            return new Copy
+            {
+                TaskEnvironment = TaskEnvironmentHelper.CreateForTest(),
+                BuildEngine = new MockEngine(_testOutputHelper),
+                SourceFiles = [new TaskItem(sourcePath)],
+                DestinationFiles = [new TaskItem(destPath)],
+                SkipUnchangedFiles = skipUnchanged,
+                RetryDelayMilliseconds = 1,
+            };
+        }
+
+        [MacOSOnlyFact]
+        public void CloneFile_HappyPath_ProducesIdenticalContent()
+        {
+            using var env = TestEnvironment.Create(_testOutputHelper);
+            string destPath = Path.Combine(env.DefaultTestDirectory.Path, "dest.txt");
+
+            CreateCloneCopyTask(env, env.CreateFile("source.txt", "Hello, clonefile!").Path, destPath, enableClone: true)
+                .Execute().ShouldBeTrue();
+
+            File.ReadAllText(destPath).ShouldBe("Hello, clonefile!");
+        }
+
+        [MacOSOnlyFact]
+        public void CloneFile_CopyOnWriteDivergence_WritingDestDoesNotAffectSource()
+        {
+            using var env = TestEnvironment.Create(_testOutputHelper);
+            var sourceFile = env.CreateFile("source.txt", "Original source content");
+            string destPath = Path.Combine(env.DefaultTestDirectory.Path, "dest.txt");
+
+            CreateCloneCopyTask(env, sourceFile.Path, destPath, enableClone: true).Execute().ShouldBeTrue();
+            File.WriteAllText(destPath, "Modified destination content");
+
+            File.ReadAllText(sourceFile.Path).ShouldBe("Original source content");
+        }
+
+        [MacOSOnlyFact]
+        public void CloneFile_ReadOnlySource_ProducesWritableDestination()
+        {
+            using var env = TestEnvironment.Create(_testOutputHelper);
+            var sourceFile = env.CreateFile("source.txt", "read-only content");
+            File.SetAttributes(sourceFile.Path, FileAttributes.ReadOnly);
+            string destPath = Path.Combine(env.DefaultTestDirectory.Path, "dest.txt");
+
+            try
+            {
+                CreateCloneCopyTask(env, sourceFile.Path, destPath, enableClone: true).Execute().ShouldBeTrue();
+                File.ReadAllText(destPath).ShouldBe("read-only content");
+                (File.GetAttributes(destPath) & FileAttributes.ReadOnly).ShouldBe((FileAttributes)0);
+            }
+            finally
+            {
+                File.SetAttributes(sourceFile.Path, FileAttributes.Normal);
+                if (File.Exists(destPath))
+                {
+                    File.SetAttributes(destPath, FileAttributes.Normal);
+                }
+            }
+        }
+
+        [MacOSOnlyFact]
+        public void CloneFile_EnvVarNotSet_FallsBackToFileCopy()
+        {
+            using var env = TestEnvironment.Create(_testOutputHelper);
+            string destPath = Path.Combine(env.DefaultTestDirectory.Path, "dest.txt");
+
+            CreateCloneCopyTask(env, env.CreateFile("source.txt", "file copy content").Path, destPath, enableClone: false)
+                .Execute().ShouldBeTrue();
+
+            File.ReadAllText(destPath).ShouldBe("file copy content");
+        }
+
+        [MacOSOnlyFact]
+        public void CloneFile_IncrementalBuild_SecondCopyIsSkipped()
+        {
+            using var env = TestEnvironment.Create(_testOutputHelper);
+            var sourceFile = env.CreateFile("source.txt", "incremental content");
+            string destPath = Path.Combine(env.DefaultTestDirectory.Path, "dest.txt");
+
+            var task1 = CreateCloneCopyTask(env, sourceFile.Path, destPath, enableClone: true);
+            task1.Execute().ShouldBeTrue();
+            task1.WroteAtLeastOneFile.ShouldBeTrue();
+
+            var task2 = CreateCloneCopyTask(env, sourceFile.Path, destPath, enableClone: true, skipUnchanged: true);
+            task2.Execute().ShouldBeTrue();
+            task2.WroteAtLeastOneFile.ShouldBeFalse();
+        }
+
+        /// <summary>
+        /// Performance: clonefile should be meaningfully faster than File.Copy for bulk file
+        /// operations on macOS APFS. Files range from 1 KB to 1 MB to simulate realistic build output.
+        /// </summary>
+        [MacOSOnlyFact]
+        public void CloneFile_Performance_FasterThanFileCopy()
+        {
+            const int fileCount = 1000;
+            const int minSizeBytes = 1024;        // 1 KB
+            const int maxSizeBytes = 1024 * 1024;  // 1 MB
+
+            using var env = TestEnvironment.Create(_testOutputHelper);
+            string sourceDir = Path.Combine(env.DefaultTestDirectory.Path, "perf_source");
+            Directory.CreateDirectory(sourceDir);
+
+            // Create source files with gradually increasing sizes
+            string[] sourceFiles = new string[fileCount];
+            for (int i = 0; i < fileCount; i++)
+            {
+                int size = minSizeBytes + (int)((long)(maxSizeBytes - minSizeBytes) * i / (fileCount - 1));
+                byte[] content = new byte[size];
+                Random.Shared.NextBytes(content);
+                sourceFiles[i] = Path.Combine(sourceDir, $"file_{i:D4}.bin");
+                File.WriteAllBytes(sourceFiles[i], content);
+            }
+
+            // Helper to build task items for a destination directory
+            (ITaskItem[] src, ITaskItem[] dst) BuildItems(string destDir)
+            {
+                Directory.CreateDirectory(destDir);
+                var s = new ITaskItem[fileCount];
+                var d = new ITaskItem[fileCount];
+                for (int i = 0; i < fileCount; i++)
+                {
+                    s[i] = new TaskItem(sourceFiles[i]);
+                    d[i] = new TaskItem(Path.Combine(destDir, $"file_{i:D4}.bin"));
+                }
+                return (s, d);
+            }
+
+            // Measure File.Copy
+            var (normalSrc, normalDst) = BuildItems(Path.Combine(env.DefaultTestDirectory.Path, "perf_dest_normal"));
+            env.SetEnvironmentVariable(Copy.ExperimentalCopyEnvVar, null);
+            var taskNormal = new Copy
+            {
+                TaskEnvironment = TaskEnvironmentHelper.CreateForTest(),
+                BuildEngine = new MockEngine(_testOutputHelper),
+                SourceFiles = normalSrc,
+                DestinationFiles = normalDst,
+                RetryDelayMilliseconds = 1,
+            };
+            var swNormal = Stopwatch.StartNew();
+            taskNormal.Execute().ShouldBeTrue();
+            swNormal.Stop();
+
+            // Measure clonefile
+            var (cloneSrc, cloneDst) = BuildItems(Path.Combine(env.DefaultTestDirectory.Path, "perf_dest_clone"));
+            env.SetEnvironmentVariable(Copy.ExperimentalCopyEnvVar, "1");
+            var taskClone = new Copy
+            {
+                TaskEnvironment = TaskEnvironmentHelper.CreateForTest(),
+                BuildEngine = new MockEngine(_testOutputHelper),
+                SourceFiles = cloneSrc,
+                DestinationFiles = cloneDst,
+                RetryDelayMilliseconds = 1,
+            };
+            var swClone = Stopwatch.StartNew();
+            taskClone.Execute().ShouldBeTrue();
+            swClone.Stop();
+
+            long normalMs = swNormal.ElapsedMilliseconds;
+            long cloneMs = swClone.ElapsedMilliseconds;
+            _testOutputHelper.WriteLine($"File.Copy: {normalMs}ms, clonefile: {cloneMs}ms, speedup: {(double)normalMs / Math.Max(cloneMs, 1):F1}x");
+
+            // Spot-check correctness
+            File.Exists(cloneDst[0].ItemSpec).ShouldBeTrue();
+            File.Exists(cloneDst[fileCount - 1].ItemSpec).ShouldBeTrue();
+
+            cloneMs.ShouldBeLessThan(normalMs, $"clonefile ({cloneMs}ms) should be faster than File.Copy ({normalMs}ms)");
+        }
+
+        #endregion
     }
 }

--- a/src/Tasks/Copy.cs
+++ b/src/Tasks/Copy.cs
@@ -110,6 +110,7 @@ namespace Microsoft.Build.Tasks
 
         internal const string AlwaysRetryEnvVar = "MSBUILDALWAYSRETRY";
         internal const string AlwaysOverwriteReadOnlyFilesEnvVar = "MSBUILDALWAYSOVERWRITEREADONLYFILES";
+        internal const string ExperimentalCopyEnvVar = "MSBUILD_EXPERIMENTAL_COPY";
 
         /// <summary>
         /// Force the copy to retry even when it hits ERROR_ACCESS_DENIED -- normally we wouldn't retry in this case since
@@ -118,6 +119,12 @@ namespace Microsoft.Build.Tasks
         /// Initialized from TaskEnvironment in Execute() for MT-safety.
         /// </summary>
         private bool _alwaysRetryCopy;
+
+        /// <summary>
+        /// When true, attempt to use macOS clonefile(2) for copy-on-write clones before falling
+        /// back to File.Copy. Enabled by the MSBUILD_EXPERIMENTAL_COPY=1 environment variable.
+        /// </summary>
+        private bool _useCloneFile;
 
         private static readonly bool s_copyInParallel = GetParallelismFromEnvironment();
 
@@ -376,7 +383,25 @@ namespace Microsoft.Build.Tasks
                 // Do not log a fake command line as well, as it's superfluous, and also potentially expensive
                 Log.LogMessage(MessageImportance.Normal, FileComment, sourceFileState.Path, destinationFileState.Path);
 
-                File.Copy(sourceFileState.Path, destinationFileState.Path, true);
+                bool cloned = false;
+#if !TASKHOST
+                // On macOS APFS, clonefile(2) creates a copy-on-write clone in O(1) time.
+                // Skip when CopyWithoutDelete is active and dest exists, since clonefile requires dest not to exist.
+                if (_useCloneFile
+                    && !(Traits.Instance.EscapeHatches.CopyWithoutDelete && destinationFileState.FileExists))
+                {
+                    cloned = NativeMethods.TryCloneFile(sourceFileState.Path, destinationFileState.Path, out errorMessage);
+                    if (!cloned)
+                    {
+                        Log.LogMessage(MessageImportance.Low, RetryingAsFileCopy, sourceFileState.Path, destinationFileState.Path, errorMessage);
+                    }
+                }
+#endif
+
+                if (!cloned)
+                {
+                    File.Copy(sourceFileState.Path, destinationFileState.Path, true);
+                }
             }
 
             // If the destinationFile file exists, then make sure it's read-write.
@@ -454,6 +479,9 @@ namespace Microsoft.Build.Tasks
             }
 
             _alwaysRetryCopy = TaskEnvironment.GetEnvironmentVariable(AlwaysRetryEnvVar) != null;
+
+            _useCloneFile = NativeMethodsShared.IsOSX
+                && TaskEnvironment.GetEnvironmentVariable(ExperimentalCopyEnvVar) == "1";
 
             // Env var sets the default for UseSymboliclinksIfPossible, but explicit task parameter wins.
             if (!_useSymboliclinksIfPossibleExplicitlySet

--- a/src/Tasks/NativeMethods.cs
+++ b/src/Tasks/NativeMethods.cs
@@ -794,6 +794,33 @@ namespace Microsoft.Build.Tasks
 #endif
 
         //------------------------------------------------------------------------------
+        // clonefile (macOS APFS copy-on-write clone)
+        //------------------------------------------------------------------------------
+#if !TASKHOST
+        [DllImport("libc", SetLastError = true)]
+        private static extern int clonefile(string src, string dst, uint flags);
+
+        /// <summary>
+        /// Attempts to create a copy-on-write clone of a file using macOS clonefile(2).
+        /// Returns true on success. On any failure (non-APFS filesystem, cross-device,
+        /// destination exists, etc.), returns false and sets errorMessage — the caller
+        /// should fall back to File.Copy.
+        /// </summary>
+        internal static bool TryCloneFile(string source, string destination, out string errorMessage)
+        {
+            if (clonefile(source, destination, 0) == 0)
+            {
+                errorMessage = null;
+                return true;
+            }
+
+            int errno = Marshal.GetLastWin32Error();
+            errorMessage = $"clonefile failed with errno {errno}";
+            return false;
+        }
+#endif
+
+        //------------------------------------------------------------------------------
         // CreateHardLink
         //------------------------------------------------------------------------------
         [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]


### PR DESCRIPTION
## Summary

Add an experimental optimization that uses macOS `clonefile(2)` syscall for O(1) copy-on-write file cloning on APFS, gated behind the `MSBUILD_EXPERIMENTAL_COPY=1` environment variable.

## What is clonefile(2)?

`clonefile(2)` is a macOS syscall (Sierra 10.12+) that creates a copy-on-write clone of a file on APFS. It only copies metadata; data blocks are shared until either side is modified, then diverge transparently. Cost is O(1) — typically 50–200 µs regardless of file size.

## Why not hardlinks?

Hardlinks share an inode: `chmod`/`chown` on the destination affects the source, and any tool that opens the destination for writing without `O_TRUNC` mutates the source. Build outputs that get post-processed (codesign, ilrepack) can't safely use hardlinks. Clonefile gives the speed of a hardlink with the semantics of a copy.

## Changes

- **`src/Tasks/NativeMethods.cs`**: Added `clonefile(2)` P/Invoke and `TryCloneFile()` helper
- **`src/Tasks/Copy.cs`**: Integrated clone attempt before `File.Copy` fallback, gated behind `MSBUILD_EXPERIMENTAL_COPY=1` env var
- **`src/Tasks.UnitTests/Copy_Tests.cs`**: 6 macOS-only tests (`[MacOSOnlyFact]`)

## Performance (macOS APFS, Apple Silicon)

| Scenario | File.Copy | clonefile | Speedup |
|----------|-----------|-----------|---------|
| 200 × 1 MB uniform files | 255ms | 25ms | **10.2×** |
| 1000 files, 1 KB → 1 MB gradual | 238ms | 93ms | **2.6×** |

## Design decisions

- Gated behind `MSBUILD_EXPERIMENTAL_COPY=1` — no behavioral change without opt-in
- Silent fallback to `File.Copy` on any `clonefile` error (non-APFS, cross-device, Docker, etc.)
- Skips clone attempt when `CopyWithoutDelete` escape hatch is active and dest exists
- No new task parameter — internal optimization only
- `clonefile` preserves mtime/attributes → incremental builds work correctly
