### PR TITLE
Use builder pattern for ImmutableDictionary construction in ProjectItemInstance

### DIFF
--- a/src/Build/Instance/ProjectItemInstance.cs
+++ b/src/Build/Instance/ProjectItemInstance.cs
@@ -1917,14 +1917,19 @@ namespace Microsoft.Build.Execution
                         int count = translator.Reader.ReadInt32();
                         if (count > 0)
                         {
-                            IEnumerable<KeyValuePair<string, string>> metaData =
-                                Enumerable.Range(0, count).Select(_ =>
-                                {
-                                    int key = translator.Reader.ReadInt32();
-                                    int value = translator.Reader.ReadInt32();
-                                    return new KeyValuePair<string, string>(interner.GetString(key), interner.GetString(value));
-                                });
-                            _directMetadata = ImmutableDictionaryExtensions.EmptyMetadata.SetItems(metaData);
+                            // Use a builder to construct the dictionary in one pass instead of
+                            // calling SetItems with a lazy enumerable, which creates O(count * log(count))
+                            // intermediate SortedInt32KeyNode objects. Those intermediate nodes become
+                            // gen2-to-young-gen references that inflate MarkOlder GC pause time.
+                            var builder = ImmutableDictionary.CreateBuilder<string, string>(MSBuildNameIgnoreCaseComparer.Default);
+                            for (int i = 0; i < count; i++)
+                            {
+                                int key = translator.Reader.ReadInt32();
+                                int value = translator.Reader.ReadInt32();
+                                builder[interner.GetString(key)] = interner.GetString(value);
+                            }
+
+                            _directMetadata = builder.ToImmutable();
                         }
                         else
                         {

--- a/src/Build/Instance/ProjectItemInstance.cs
+++ b/src/Build/Instance/ProjectItemInstance.cs
@@ -1255,18 +1255,28 @@ namespace Microsoft.Build.Execution
 
                     // Otherwise, merge remaining inherited item definitions. Front of the list is highest priority,
                     // so walk backwards. Skip the last entry since we've already used it as the base.
+                    // Use a builder to merge all definitions at once instead of creating N-1 intermediate
+                    // immutable trees from chained SetItems calls.
+                    var builder = lastItemDefinition.ToBuilder();
+
                     for (int i = _itemDefinitions.Count - 2; i >= 0; i--)
                     {
-                        lastItemDefinition = lastItemDefinition.SetItems(_itemDefinitions[i].BackingMetadata);
+                        foreach (var kvp in _itemDefinitions[i].BackingMetadata)
+                        {
+                            builder[kvp.Key] = kvp.Value;
+                        }
                     }
 
                     // Finally any direct metadata win.
                     if (_directMetadata != null)
                     {
-                        lastItemDefinition = lastItemDefinition.SetItems(_directMetadata);
+                        foreach (var kvp in _directMetadata)
+                        {
+                            builder[kvp.Key] = kvp.Value;
+                        }
                     }
 
-                    return lastItemDefinition;
+                    return builder.ToImmutable();
                 }
             }
 
@@ -1917,11 +1927,9 @@ namespace Microsoft.Build.Execution
                         int count = translator.Reader.ReadInt32();
                         if (count > 0)
                         {
-                            // Use a builder to construct the dictionary in one pass instead of
-                            // calling SetItems with a lazy enumerable, which creates O(count * log(count))
-                            // intermediate SortedInt32KeyNode objects. Those intermediate nodes become
-                            // gen2-to-young-gen references that inflate MarkOlder GC pause time.
-                            var builder = ImmutableDictionary.CreateBuilder<string, string>(MSBuildNameIgnoreCaseComparer.Default);
+                            // Use a builder to avoid intermediate immutable dictionary allocations
+                            // from feeding a lazy enumerable into SetItems.
+                            var builder = ImmutableDictionaryExtensions.EmptyMetadata.ToBuilder();
                             for (int i = 0; i < count; i++)
                             {
                                 int key = translator.Reader.ReadInt32();


### PR DESCRIPTION
## Use builder pattern for ImmutableDictionary construction in ProjectItemInstance

Two places in `ProjectItemInstance` build `ImmutableDictionary` instances by feeding data into `SetItems`, which creates intermediate immutable trees that are immediately discarded. Switch both to use `ImmutableDictionaryExtensions.EmptyMetadata.ToBuilder()` (or the existing dictionary's `.ToBuilder()`) to build mutably, then produce one final immutable dictionary via `ToImmutable()`.

### Change 1: `TranslateWithInterning` deserialization

`TranslateWithInterning` used a lazy LINQ enumerable (`Enumerable.Range(0, count).Select(...)`) fed into `EmptyMetadata.SetItems()`, building the immutable dictionary one entry at a time. Each entry creates a new intermediate dictionary tree, and the previous tree is discarded. Allocation traces show this path at **286 MB sampled** (2.9% of total allocations during Visual Studio solution load).

Switch to `EmptyMetadata.ToBuilder()` with an eager for-loop, then `ToImmutable()`. This also eliminates the LINQ/closure allocations from `Enumerable.Range` + `Select`.

### Change 2: `MetadataCollection` multi-definition merge

`MetadataCollection` merged inherited item definitions by calling `SetItems` in a loop, creating N-1 intermediate immutable trees. Switch to `.ToBuilder()` on the base dictionary, merge all definitions mutably, then `ToImmutable()`.

### Before
- Lazy enumerable or loop feeds N entries/definitions into `.SetItems()` -- N intermediate `ImmutableDictionary` trees
- Each intermediate tree is discarded on the next iteration

### After
- Eager for-loop or merge into a `Builder` (mutable, no intermediate trees)
- One final dictionary from `Builder.ToImmutable()`

*Cowritten with Copilot*