### PR TITLE
Emit Warning When Using CLI Switches from Auto-Response File Lead to Errors

### DIFF
--- a/src/MSBuild.UnitTests/XMake_Tests.cs
+++ b/src/MSBuild.UnitTests/XMake_Tests.cs
@@ -1571,6 +1571,23 @@ namespace Microsoft.Build.UnitTests
             successfulExit.ShouldBeTrue();
         }
 
+        [Fact]
+        public void ResponseFileNoticeIsPrintedOnSwitchError()
+        {
+            var directory = _env.CreateFolder();
+            var content = ObjectModelHelpers.CleanupFileContents("<Project><Target Name='t'><Message Text='Completed'/></Target></Project>");
+            directory.CreateFile("foo.proj", content);
+            var projectPath = directory.CreateFile("bar.proj", content).Path;
+            var rspPath = directory.CreateFile("Directory.Build.rsp", "foo.proj").Path;
+
+            string output = RunnerUtilities.ExecMSBuild($"\"{projectPath}\"", out var successfulExit, _output);
+
+            successfulExit.ShouldBeFalse();
+            output.ShouldContain("Some command line switches were read from the auto-response file");
+            output.ShouldContain(rspPath);
+            output.ShouldContain("MSB1008");
+        }
+
         /// <summary>
         /// Any msbuild.rsp in the directory of the specified project/solution should be read, and should
         /// take priority over any other response files. Sanity test when there isn't one.

--- a/src/MSBuild.UnitTests/XMake_Tests.cs
+++ b/src/MSBuild.UnitTests/XMake_Tests.cs
@@ -1574,6 +1574,7 @@ namespace Microsoft.Build.UnitTests
         [Fact]
         public void ResponseFileNoticeIsPrintedOnSwitchError()
         {
+            _env.SetEnvironmentVariable("DOTNET_CLI_UI_LANGUAGE", "en-US");
             var directory = _env.CreateFolder();
             var content = ObjectModelHelpers.CleanupFileContents("<Project><Target Name='t'><Message Text='Completed'/></Target></Project>");
             directory.CreateFile("foo.proj", content);
@@ -1583,8 +1584,28 @@ namespace Microsoft.Build.UnitTests
             string output = RunnerUtilities.ExecMSBuild($"\"{projectPath}\"", out var successfulExit, _output);
 
             successfulExit.ShouldBeFalse();
-            output.ShouldContain("Some command line switches were read from the auto-response file");
+            int noticeIndex = output.IndexOf("Some command line switches were read from the auto-response file", StringComparison.OrdinalIgnoreCase);
+            int errorIndex = output.IndexOf("MSB1008", StringComparison.OrdinalIgnoreCase);
+            noticeIndex.ShouldBeGreaterThanOrEqualTo(0);
+            errorIndex.ShouldBeGreaterThanOrEqualTo(0);
+            noticeIndex.ShouldBeLessThan(errorIndex);
             output.ShouldContain(rspPath);
+        }
+
+        [Fact]
+        public void ExplicitResponseFileNoticeIsNotPrintedOnSwitchError()
+        {
+            _env.SetEnvironmentVariable("DOTNET_CLI_UI_LANGUAGE", "en-US");
+            var directory = _env.CreateFolder();
+            var content = ObjectModelHelpers.CleanupFileContents("<Project><Target Name='t'><Message Text='Completed'/></Target></Project>");
+            directory.CreateFile("foo.proj", content);
+            var projectPath = directory.CreateFile("bar.proj", content).Path;
+            var rspPath = directory.CreateFile("explicit.rsp", "foo.proj").Path;
+
+            string output = RunnerUtilities.ExecMSBuild($"\"{projectPath}\" @\"{rspPath}\" -noAutoResponse", out var successfulExit, _output);
+
+            successfulExit.ShouldBeFalse();
+            output.ShouldNotContain("Some command line switches were read from the auto-response file");
             output.ShouldContain("MSB1008");
         }
 

--- a/src/MSBuild.UnitTests/XMake_Tests.cs
+++ b/src/MSBuild.UnitTests/XMake_Tests.cs
@@ -1584,7 +1584,7 @@ namespace Microsoft.Build.UnitTests
             string output = RunnerUtilities.ExecMSBuild($"\"{projectPath}\"", out var successfulExit, _output);
 
             successfulExit.ShouldBeFalse();
-            int noticeIndex = output.IndexOf("Some command line switches were read from the auto-response file", StringComparison.OrdinalIgnoreCase);
+            int noticeIndex = output.IndexOf("Some command line switches were read from this response file", StringComparison.OrdinalIgnoreCase);
             int errorIndex = output.IndexOf("MSB1008", StringComparison.OrdinalIgnoreCase);
             noticeIndex.ShouldBeGreaterThanOrEqualTo(0);
             errorIndex.ShouldBeGreaterThanOrEqualTo(0);
@@ -1593,7 +1593,7 @@ namespace Microsoft.Build.UnitTests
         }
 
         [Fact]
-        public void ExplicitResponseFileNoticeIsNotPrintedOnSwitchError()
+        public void ExplicitResponseFileNoticeIsPrintedOnSwitchError()
         {
             _env.SetEnvironmentVariable("DOTNET_CLI_UI_LANGUAGE", "en-US");
             var directory = _env.CreateFolder();
@@ -1605,8 +1605,12 @@ namespace Microsoft.Build.UnitTests
             string output = RunnerUtilities.ExecMSBuild($"\"{projectPath}\" @\"{rspPath}\" -noAutoResponse", out var successfulExit, _output);
 
             successfulExit.ShouldBeFalse();
-            output.ShouldNotContain("Some command line switches were read from the auto-response file");
-            output.ShouldContain("MSB1008");
+            int noticeIndex = output.IndexOf("Some command line switches were read from this response file", StringComparison.OrdinalIgnoreCase);
+            int errorIndex = output.IndexOf("MSB1008", StringComparison.OrdinalIgnoreCase);
+            noticeIndex.ShouldBeGreaterThanOrEqualTo(0);
+            errorIndex.ShouldBeGreaterThanOrEqualTo(0);
+            noticeIndex.ShouldBeLessThan(errorIndex);
+            output.ShouldContain(rspPath);
         }
 
         /// <summary>

--- a/src/MSBuild.UnitTests/XMake_Tests.cs
+++ b/src/MSBuild.UnitTests/XMake_Tests.cs
@@ -1584,7 +1584,7 @@ namespace Microsoft.Build.UnitTests
             string output = RunnerUtilities.ExecMSBuild($"\"{projectPath}\"", out var successfulExit, _output);
 
             successfulExit.ShouldBeFalse();
-            int noticeIndex = output.IndexOf("Some command line switches were read from this response file", StringComparison.OrdinalIgnoreCase);
+            int noticeIndex = output.IndexOf("Some command line switches were read from", StringComparison.OrdinalIgnoreCase);
             int errorIndex = output.IndexOf("MSB1008", StringComparison.OrdinalIgnoreCase);
             noticeIndex.ShouldBeGreaterThanOrEqualTo(0);
             errorIndex.ShouldBeGreaterThanOrEqualTo(0);
@@ -1605,7 +1605,7 @@ namespace Microsoft.Build.UnitTests
             string output = RunnerUtilities.ExecMSBuild($"\"{projectPath}\" @\"{rspPath}\" -noAutoResponse", out var successfulExit, _output);
 
             successfulExit.ShouldBeFalse();
-            int noticeIndex = output.IndexOf("Some command line switches were read from this response file", StringComparison.OrdinalIgnoreCase);
+            int noticeIndex = output.IndexOf("Some command line switches were read from", StringComparison.OrdinalIgnoreCase);
             int errorIndex = output.IndexOf("MSB1008", StringComparison.OrdinalIgnoreCase);
             noticeIndex.ShouldBeGreaterThanOrEqualTo(0);
             errorIndex.ShouldBeGreaterThanOrEqualTo(0);

--- a/src/MSBuild/CommandLine/CommandLineParser.cs
+++ b/src/MSBuild/CommandLine/CommandLineParser.cs
@@ -47,6 +47,13 @@ namespace Microsoft.Build.CommandLine.Experimental
         internal IReadOnlyList<string> IncludedResponseFiles => includedResponseFiles ?? (IReadOnlyList<string>)Array.Empty<string>();
 
         /// <summary>
+        /// Used to keep track of response files automatically discovered by MSBuild.
+        /// </summary>
+        private List<string> autoResponseFiles;
+
+        internal IReadOnlyList<string> AutoResponseFiles => autoResponseFiles ?? (IReadOnlyList<string>)Array.Empty<string>();
+
+        /// <summary>
         /// Parses the provided command-line arguments into a <see cref="CommandLineSwitchesAccessor"/>.
         /// </summary>
         /// <param name="commandLineArgs">
@@ -666,6 +673,7 @@ namespace Microsoft.Build.CommandLine.Experimental
             {
                 found = true;
                 GatherResponseFileSwitch($"@{autoResponseFile}", switchesFromAutoResponseFile, commandLine);
+                autoResponseFiles.Add(Path.GetFullPath(autoResponseFile));
 
                 // if the "/noautoresponse" switch was set in the auto-response file, flag an error
                 if (switchesFromAutoResponseFile[CommandLineSwitches.ParameterlessSwitch.NoAutoResponse])
@@ -724,6 +732,7 @@ namespace Microsoft.Build.CommandLine.Experimental
         public void ResetGatheringSwitchesState()
         {
             includedResponseFiles = new List<string>();
+            autoResponseFiles = new List<string>();
             CommandLineSwitches.SwitchesFromResponseFiles = new();
         }
     }

--- a/src/MSBuild/CommandLine/CommandLineParser.cs
+++ b/src/MSBuild/CommandLine/CommandLineParser.cs
@@ -47,13 +47,6 @@ namespace Microsoft.Build.CommandLine.Experimental
         internal IReadOnlyList<string> IncludedResponseFiles => includedResponseFiles ?? (IReadOnlyList<string>)Array.Empty<string>();
 
         /// <summary>
-        /// Used to keep track of response files automatically discovered by MSBuild.
-        /// </summary>
-        private List<string> autoResponseFiles;
-
-        internal IReadOnlyList<string> AutoResponseFiles => autoResponseFiles ?? (IReadOnlyList<string>)Array.Empty<string>();
-
-        /// <summary>
         /// Parses the provided command-line arguments into a <see cref="CommandLineSwitchesAccessor"/>.
         /// </summary>
         /// <param name="commandLineArgs">
@@ -673,7 +666,6 @@ namespace Microsoft.Build.CommandLine.Experimental
             {
                 found = true;
                 GatherResponseFileSwitch($"@{autoResponseFile}", switchesFromAutoResponseFile, commandLine);
-                autoResponseFiles.Add(Path.GetFullPath(autoResponseFile));
 
                 // if the "/noautoresponse" switch was set in the auto-response file, flag an error
                 if (switchesFromAutoResponseFile[CommandLineSwitches.ParameterlessSwitch.NoAutoResponse])
@@ -732,7 +724,6 @@ namespace Microsoft.Build.CommandLine.Experimental
         public void ResetGatheringSwitchesState()
         {
             includedResponseFiles = new List<string>();
-            autoResponseFiles = new List<string>();
             CommandLineSwitches.SwitchesFromResponseFiles = new();
         }
     }

--- a/src/MSBuild/Resources/Strings.resx
+++ b/src/MSBuild/Resources/Strings.resx
@@ -1321,6 +1321,20 @@
       where the switches are coming from.
     </comment>
   </data>
+  <data name="PickedUpSwitchesFromResponseFile" xml:space="preserve">
+    <value>Some command line switches were read from this response file:</value>
+    <comment>
+      UE: This message appears before a command-line parsing error when switches were read from a response file: otherwise the user may be unaware where the switches are coming from.
+      LOCALIZATION: The response file path is printed on a separate line after this message.
+    </comment>
+  </data>
+  <data name="PickedUpSwitchesFromResponseFiles" xml:space="preserve">
+    <value>Some command line switches were read from these response files:</value>
+    <comment>
+      UE: This message appears before a command-line parsing error when switches were read from response files: otherwise the user may be unaware where the switches are coming from.
+      LOCALIZATION: The response file paths are printed on separate lines after this message.
+    </comment>
+  </data>
   <data name="ProjectNotFoundError" xml:space="preserve">
     <value>MSBUILD : error MSB1009: Project file does not exist.</value>
     <comment>{StrBegin="MSBUILD : error MSB1009: "}UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.

--- a/src/MSBuild/Resources/xlf/Strings.cs.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.cs.xlf
@@ -1731,6 +1731,22 @@ Když se nastaví na MessageUponIsolationViolation (nebo jeho krátký
       where the switches are coming from.
     </note>
       </trans-unit>
+      <trans-unit id="PickedUpSwitchesFromResponseFile">
+        <source>Some command line switches were read from this response file:</source>
+        <target state="new">Some command line switches were read from this response file:</target>
+        <note>
+      UE: This message appears before a command-line parsing error when switches were read from a response file: otherwise the user may be unaware where the switches are coming from.
+      LOCALIZATION: The response file path is printed on a separate line after this message.
+    </note>
+      </trans-unit>
+      <trans-unit id="PickedUpSwitchesFromResponseFiles">
+        <source>Some command line switches were read from these response files:</source>
+        <target state="new">Some command line switches were read from these response files:</target>
+        <note>
+      UE: This message appears before a command-line parsing error when switches were read from response files: otherwise the user may be unaware where the switches are coming from.
+      LOCALIZATION: The response file paths are printed on separate lines after this message.
+    </note>
+      </trans-unit>
       <trans-unit id="Process">
         <source>Process = "{0}"</source>
         <target state="translated">Proces = {0}</target>

--- a/src/MSBuild/Resources/xlf/Strings.de.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.de.xlf
@@ -1719,6 +1719,22 @@ Hinweis: Ausführlichkeit der Dateiprotokollierungen
       where the switches are coming from.
     </note>
       </trans-unit>
+      <trans-unit id="PickedUpSwitchesFromResponseFile">
+        <source>Some command line switches were read from this response file:</source>
+        <target state="new">Some command line switches were read from this response file:</target>
+        <note>
+      UE: This message appears before a command-line parsing error when switches were read from a response file: otherwise the user may be unaware where the switches are coming from.
+      LOCALIZATION: The response file path is printed on a separate line after this message.
+    </note>
+      </trans-unit>
+      <trans-unit id="PickedUpSwitchesFromResponseFiles">
+        <source>Some command line switches were read from these response files:</source>
+        <target state="new">Some command line switches were read from these response files:</target>
+        <note>
+      UE: This message appears before a command-line parsing error when switches were read from response files: otherwise the user may be unaware where the switches are coming from.
+      LOCALIZATION: The response file paths are printed on separate lines after this message.
+    </note>
+      </trans-unit>
       <trans-unit id="Process">
         <source>Process = "{0}"</source>
         <target state="translated">Prozess = "{0}"</target>

--- a/src/MSBuild/Resources/xlf/Strings.es.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.es.xlf
@@ -1725,6 +1725,22 @@ Esta marca es experimental y puede que no funcione según lo previsto.
       where the switches are coming from.
     </note>
       </trans-unit>
+      <trans-unit id="PickedUpSwitchesFromResponseFile">
+        <source>Some command line switches were read from this response file:</source>
+        <target state="new">Some command line switches were read from this response file:</target>
+        <note>
+      UE: This message appears before a command-line parsing error when switches were read from a response file: otherwise the user may be unaware where the switches are coming from.
+      LOCALIZATION: The response file path is printed on a separate line after this message.
+    </note>
+      </trans-unit>
+      <trans-unit id="PickedUpSwitchesFromResponseFiles">
+        <source>Some command line switches were read from these response files:</source>
+        <target state="new">Some command line switches were read from these response files:</target>
+        <note>
+      UE: This message appears before a command-line parsing error when switches were read from response files: otherwise the user may be unaware where the switches are coming from.
+      LOCALIZATION: The response file paths are printed on separate lines after this message.
+    </note>
+      </trans-unit>
       <trans-unit id="Process">
         <source>Process = "{0}"</source>
         <target state="translated">Proceso: "{0}"</target>

--- a/src/MSBuild/Resources/xlf/Strings.fr.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.fr.xlf
@@ -1719,6 +1719,22 @@ Remarque : verbosité des enregistreurs d’événements de fichiers
       where the switches are coming from.
     </note>
       </trans-unit>
+      <trans-unit id="PickedUpSwitchesFromResponseFile">
+        <source>Some command line switches were read from this response file:</source>
+        <target state="new">Some command line switches were read from this response file:</target>
+        <note>
+      UE: This message appears before a command-line parsing error when switches were read from a response file: otherwise the user may be unaware where the switches are coming from.
+      LOCALIZATION: The response file path is printed on a separate line after this message.
+    </note>
+      </trans-unit>
+      <trans-unit id="PickedUpSwitchesFromResponseFiles">
+        <source>Some command line switches were read from these response files:</source>
+        <target state="new">Some command line switches were read from these response files:</target>
+        <note>
+      UE: This message appears before a command-line parsing error when switches were read from response files: otherwise the user may be unaware where the switches are coming from.
+      LOCALIZATION: The response file paths are printed on separate lines after this message.
+    </note>
+      </trans-unit>
       <trans-unit id="Process">
         <source>Process = "{0}"</source>
         <target state="translated">Processus = "{0}"</target>

--- a/src/MSBuild/Resources/xlf/Strings.it.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.it.xlf
@@ -1729,6 +1729,22 @@ Nota: livello di dettaglio dei logger di file
       where the switches are coming from.
     </note>
       </trans-unit>
+      <trans-unit id="PickedUpSwitchesFromResponseFile">
+        <source>Some command line switches were read from this response file:</source>
+        <target state="new">Some command line switches were read from this response file:</target>
+        <note>
+      UE: This message appears before a command-line parsing error when switches were read from a response file: otherwise the user may be unaware where the switches are coming from.
+      LOCALIZATION: The response file path is printed on a separate line after this message.
+    </note>
+      </trans-unit>
+      <trans-unit id="PickedUpSwitchesFromResponseFiles">
+        <source>Some command line switches were read from these response files:</source>
+        <target state="new">Some command line switches were read from these response files:</target>
+        <note>
+      UE: This message appears before a command-line parsing error when switches were read from response files: otherwise the user may be unaware where the switches are coming from.
+      LOCALIZATION: The response file paths are printed on separate lines after this message.
+    </note>
+      </trans-unit>
       <trans-unit id="Process">
         <source>Process = "{0}"</source>
         <target state="translated">Processo = "{0}"</target>

--- a/src/MSBuild/Resources/xlf/Strings.ja.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.ja.xlf
@@ -1719,6 +1719,22 @@
       where the switches are coming from.
     </note>
       </trans-unit>
+      <trans-unit id="PickedUpSwitchesFromResponseFile">
+        <source>Some command line switches were read from this response file:</source>
+        <target state="new">Some command line switches were read from this response file:</target>
+        <note>
+      UE: This message appears before a command-line parsing error when switches were read from a response file: otherwise the user may be unaware where the switches are coming from.
+      LOCALIZATION: The response file path is printed on a separate line after this message.
+    </note>
+      </trans-unit>
+      <trans-unit id="PickedUpSwitchesFromResponseFiles">
+        <source>Some command line switches were read from these response files:</source>
+        <target state="new">Some command line switches were read from these response files:</target>
+        <note>
+      UE: This message appears before a command-line parsing error when switches were read from response files: otherwise the user may be unaware where the switches are coming from.
+      LOCALIZATION: The response file paths are printed on separate lines after this message.
+    </note>
+      </trans-unit>
       <trans-unit id="Process">
         <source>Process = "{0}"</source>
         <target state="translated">プロセス = "{0}"</target>

--- a/src/MSBuild/Resources/xlf/Strings.ko.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.ko.xlf
@@ -1720,6 +1720,22 @@
       where the switches are coming from.
     </note>
       </trans-unit>
+      <trans-unit id="PickedUpSwitchesFromResponseFile">
+        <source>Some command line switches were read from this response file:</source>
+        <target state="new">Some command line switches were read from this response file:</target>
+        <note>
+      UE: This message appears before a command-line parsing error when switches were read from a response file: otherwise the user may be unaware where the switches are coming from.
+      LOCALIZATION: The response file path is printed on a separate line after this message.
+    </note>
+      </trans-unit>
+      <trans-unit id="PickedUpSwitchesFromResponseFiles">
+        <source>Some command line switches were read from these response files:</source>
+        <target state="new">Some command line switches were read from these response files:</target>
+        <note>
+      UE: This message appears before a command-line parsing error when switches were read from response files: otherwise the user may be unaware where the switches are coming from.
+      LOCALIZATION: The response file paths are printed on separate lines after this message.
+    </note>
+      </trans-unit>
       <trans-unit id="Process">
         <source>Process = "{0}"</source>
         <target state="translated">프로세스 = "{0}"</target>

--- a/src/MSBuild/Resources/xlf/Strings.pl.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.pl.xlf
@@ -1728,6 +1728,22 @@ Ta flaga jest eksperymentalna i może nie działać zgodnie z oczekiwaniami.
       where the switches are coming from.
     </note>
       </trans-unit>
+      <trans-unit id="PickedUpSwitchesFromResponseFile">
+        <source>Some command line switches were read from this response file:</source>
+        <target state="new">Some command line switches were read from this response file:</target>
+        <note>
+      UE: This message appears before a command-line parsing error when switches were read from a response file: otherwise the user may be unaware where the switches are coming from.
+      LOCALIZATION: The response file path is printed on a separate line after this message.
+    </note>
+      </trans-unit>
+      <trans-unit id="PickedUpSwitchesFromResponseFiles">
+        <source>Some command line switches were read from these response files:</source>
+        <target state="new">Some command line switches were read from these response files:</target>
+        <note>
+      UE: This message appears before a command-line parsing error when switches were read from response files: otherwise the user may be unaware where the switches are coming from.
+      LOCALIZATION: The response file paths are printed on separate lines after this message.
+    </note>
+      </trans-unit>
       <trans-unit id="Process">
         <source>Process = "{0}"</source>
         <target state="translated">Proces = „{0}”</target>

--- a/src/MSBuild/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.pt-BR.xlf
@@ -1719,6 +1719,22 @@ arquivo de resposta.
       where the switches are coming from.
     </note>
       </trans-unit>
+      <trans-unit id="PickedUpSwitchesFromResponseFile">
+        <source>Some command line switches were read from this response file:</source>
+        <target state="new">Some command line switches were read from this response file:</target>
+        <note>
+      UE: This message appears before a command-line parsing error when switches were read from a response file: otherwise the user may be unaware where the switches are coming from.
+      LOCALIZATION: The response file path is printed on a separate line after this message.
+    </note>
+      </trans-unit>
+      <trans-unit id="PickedUpSwitchesFromResponseFiles">
+        <source>Some command line switches were read from these response files:</source>
+        <target state="new">Some command line switches were read from these response files:</target>
+        <note>
+      UE: This message appears before a command-line parsing error when switches were read from response files: otherwise the user may be unaware where the switches are coming from.
+      LOCALIZATION: The response file paths are printed on separate lines after this message.
+    </note>
+      </trans-unit>
       <trans-unit id="Process">
         <source>Process = "{0}"</source>
         <target state="translated">Processo = "{0}"</target>

--- a/src/MSBuild/Resources/xlf/Strings.ru.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.ru.xlf
@@ -1717,6 +1717,22 @@
       where the switches are coming from.
     </note>
       </trans-unit>
+      <trans-unit id="PickedUpSwitchesFromResponseFile">
+        <source>Some command line switches were read from this response file:</source>
+        <target state="new">Some command line switches were read from this response file:</target>
+        <note>
+      UE: This message appears before a command-line parsing error when switches were read from a response file: otherwise the user may be unaware where the switches are coming from.
+      LOCALIZATION: The response file path is printed on a separate line after this message.
+    </note>
+      </trans-unit>
+      <trans-unit id="PickedUpSwitchesFromResponseFiles">
+        <source>Some command line switches were read from these response files:</source>
+        <target state="new">Some command line switches were read from these response files:</target>
+        <note>
+      UE: This message appears before a command-line parsing error when switches were read from response files: otherwise the user may be unaware where the switches are coming from.
+      LOCALIZATION: The response file paths are printed on separate lines after this message.
+    </note>
+      </trans-unit>
       <trans-unit id="Process">
         <source>Process = "{0}"</source>
         <target state="translated">Процесс = "{0}"</target>

--- a/src/MSBuild/Resources/xlf/Strings.tr.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.tr.xlf
@@ -1722,6 +1722,22 @@
       where the switches are coming from.
     </note>
       </trans-unit>
+      <trans-unit id="PickedUpSwitchesFromResponseFile">
+        <source>Some command line switches were read from this response file:</source>
+        <target state="new">Some command line switches were read from this response file:</target>
+        <note>
+      UE: This message appears before a command-line parsing error when switches were read from a response file: otherwise the user may be unaware where the switches are coming from.
+      LOCALIZATION: The response file path is printed on a separate line after this message.
+    </note>
+      </trans-unit>
+      <trans-unit id="PickedUpSwitchesFromResponseFiles">
+        <source>Some command line switches were read from these response files:</source>
+        <target state="new">Some command line switches were read from these response files:</target>
+        <note>
+      UE: This message appears before a command-line parsing error when switches were read from response files: otherwise the user may be unaware where the switches are coming from.
+      LOCALIZATION: The response file paths are printed on separate lines after this message.
+    </note>
+      </trans-unit>
       <trans-unit id="Process">
         <source>Process = "{0}"</source>
         <target state="translated">İşlem = "{0}"</target>

--- a/src/MSBuild/Resources/xlf/Strings.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.xlf
@@ -719,6 +719,20 @@
       where the switches are coming from.
     </note>
       </trans-unit>
+      <trans-unit id="PickedUpSwitchesFromResponseFile">
+        <source>Some command line switches were read from this response file:</source>
+        <note>
+      UE: This message appears before a command-line parsing error when switches were read from a response file: otherwise the user may be unaware where the switches are coming from.
+      LOCALIZATION: The response file path is printed on a separate line after this message.
+    </note>
+      </trans-unit>
+      <trans-unit id="PickedUpSwitchesFromResponseFiles">
+        <source>Some command line switches were read from these response files:</source>
+        <note>
+      UE: This message appears before a command-line parsing error when switches were read from response files: otherwise the user may be unaware where the switches are coming from.
+      LOCALIZATION: The response file paths are printed on separate lines after this message.
+    </note>
+      </trans-unit>
       <trans-unit id="ProjectNotFoundError">
         <source>MSBUILD : error MSB1009: Project file does not exist.</source>
         <note>{StrBegin="MSBUILD : error MSB1009: "}UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.

--- a/src/MSBuild/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.zh-Hans.xlf
@@ -1719,6 +1719,22 @@
       where the switches are coming from.
     </note>
       </trans-unit>
+      <trans-unit id="PickedUpSwitchesFromResponseFile">
+        <source>Some command line switches were read from this response file:</source>
+        <target state="new">Some command line switches were read from this response file:</target>
+        <note>
+      UE: This message appears before a command-line parsing error when switches were read from a response file: otherwise the user may be unaware where the switches are coming from.
+      LOCALIZATION: The response file path is printed on a separate line after this message.
+    </note>
+      </trans-unit>
+      <trans-unit id="PickedUpSwitchesFromResponseFiles">
+        <source>Some command line switches were read from these response files:</source>
+        <target state="new">Some command line switches were read from these response files:</target>
+        <note>
+      UE: This message appears before a command-line parsing error when switches were read from response files: otherwise the user may be unaware where the switches are coming from.
+      LOCALIZATION: The response file paths are printed on separate lines after this message.
+    </note>
+      </trans-unit>
       <trans-unit id="Process">
         <source>Process = "{0}"</source>
         <target state="translated">进程 = "{0}"</target>

--- a/src/MSBuild/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.zh-Hant.xlf
@@ -1719,6 +1719,22 @@
       where the switches are coming from.
     </note>
       </trans-unit>
+      <trans-unit id="PickedUpSwitchesFromResponseFile">
+        <source>Some command line switches were read from this response file:</source>
+        <target state="new">Some command line switches were read from this response file:</target>
+        <note>
+      UE: This message appears before a command-line parsing error when switches were read from a response file: otherwise the user may be unaware where the switches are coming from.
+      LOCALIZATION: The response file path is printed on a separate line after this message.
+    </note>
+      </trans-unit>
+      <trans-unit id="PickedUpSwitchesFromResponseFiles">
+        <source>Some command line switches were read from these response files:</source>
+        <target state="new">Some command line switches were read from these response files:</target>
+        <note>
+      UE: This message appears before a command-line parsing error when switches were read from response files: otherwise the user may be unaware where the switches are coming from.
+      LOCALIZATION: The response file paths are printed on separate lines after this message.
+    </note>
+      </trans-unit>
       <trans-unit id="Process">
         <source>Process = "{0}"</source>
         <target state="translated">流程 = "{0}"</target>

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -937,6 +937,11 @@ namespace Microsoft.Build.CommandLine
             // handle switch errors
             catch (CommandLineSwitchException e)
             {
+                if (commandLineParser.IncludedResponseFiles.Count > 0)
+                {
+                    PrintResponseFileNotices();
+                }
+
                 Console.WriteLine(e.Message);
                 Console.WriteLine();
                 // prompt user to display help for proper switch usage
@@ -4207,6 +4212,17 @@ namespace Microsoft.Build.CommandLine
         private static void ShowHelpPrompt()
         {
             Console.WriteLine(AssemblyResources.GetString("HelpPrompt"));
+        }
+
+        private static void PrintResponseFileNotices()
+        {
+            foreach (string responseFilePath in commandLineParser.IncludedResponseFiles)
+            {
+                Console.WriteLine(
+                    ResourceUtilities.FormatResourceStringIgnoreCodeAndKeyword(
+                        "PickedUpSwitchesFromAutoResponse",
+                        responseFilePath));
+            }
         }
 
         /// <summary>

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -937,9 +937,9 @@ namespace Microsoft.Build.CommandLine
             // handle switch errors
             catch (CommandLineSwitchException e)
             {
-                if (commandLineParser.IncludedResponseFiles.Count > 0)
+                if (commandLineParser.AutoResponseFiles.Count > 0)
                 {
-                    PrintResponseFileNotices();
+                    PrintAutoResponseFileNotices();
                 }
 
                 Console.WriteLine(e.Message);
@@ -4214,9 +4214,9 @@ namespace Microsoft.Build.CommandLine
             Console.WriteLine(AssemblyResources.GetString("HelpPrompt"));
         }
 
-        private static void PrintResponseFileNotices()
+        private static void PrintAutoResponseFileNotices()
         {
-            foreach (string responseFilePath in commandLineParser.IncludedResponseFiles)
+            foreach (string responseFilePath in commandLineParser.AutoResponseFiles)
             {
                 Console.WriteLine(
                     ResourceUtilities.FormatResourceStringIgnoreCodeAndKeyword(

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -937,9 +937,9 @@ namespace Microsoft.Build.CommandLine
             // handle switch errors
             catch (CommandLineSwitchException e)
             {
-                if (commandLineParser.AutoResponseFiles.Count > 0)
+                if (commandLineParser.IncludedResponseFiles.Count > 0)
                 {
-                    PrintAutoResponseFileNotices();
+                    PrintResponseFileNotices();
                 }
 
                 Console.WriteLine(e.Message);
@@ -4214,14 +4214,17 @@ namespace Microsoft.Build.CommandLine
             Console.WriteLine(AssemblyResources.GetString("HelpPrompt"));
         }
 
-        private static void PrintAutoResponseFileNotices()
+        private static void PrintResponseFileNotices()
         {
-            foreach (string responseFilePath in commandLineParser.AutoResponseFiles)
+            Console.WriteLine(
+                AssemblyResources.GetString(
+                    commandLineParser.IncludedResponseFiles.Count == 1
+                        ? "PickedUpSwitchesFromResponseFile"
+                        : "PickedUpSwitchesFromResponseFiles"));
+
+            foreach (string responseFilePath in commandLineParser.IncludedResponseFiles)
             {
-                Console.WriteLine(
-                    ResourceUtilities.FormatResourceStringIgnoreCodeAndKeyword(
-                        "PickedUpSwitchesFromAutoResponse",
-                        responseFilePath));
+                Console.WriteLine($"  {responseFilePath}");
             }
         }
 


### PR DESCRIPTION
Fixes #3789

## Context
Currently, if there is a directory.build.rsp with one project specified and then MSBuild is invoked passing a different project through CLI, MSBuild prints an error message:
`
MSBUILD : error MSB1008: Only one project can be specified.
`

However, there is no indication what is the second project for the user. In MSBuild, there is a warning already implemented which satisfies this. However, it is not printed early enough for this specific scenario. It would be beneficial if the warning would be printed before the error, so the user knows where is the second project specified

## Changes Made
### XMake.cs
Added a line which emits this warning before the error so the user is notified. The warning used is the one that is already implemented in the MSBuild.
`Some command line switches were read from the auto-response file "MSBuild.rsp". To disable this file, use the "/noautoresponse" switch.`

## Testing
### XMake_Tests.cs
Added a unit tests for this scenario.