### PR TITLE
WinMDExp Migration

### DIFF
--- a/MSBuild.slnx
+++ b/MSBuild.slnx
@@ -76,6 +76,10 @@
   </Project>
   <Project Path="src/MSBuild.EndToEnd.Tests/Microsoft.Build.EndToEnd.Tests.csproj">
     <Platform Solution="*|x64" Project="x64" />
+    <Platform Solution="Debug|ARM64" Project="arm64" />
+    <Build Solution="Debug|Any CPU" Project="false" />
+    <Build Solution="Debug|ARM64" Project="false" />
+    <Build Solution="Debug|x86" Project="false" />
   </Project>
   <Project Path="src/MSBuild.UnitTests/Microsoft.Build.CommandLine.UnitTests.csproj">
     <Platform Solution="*|x64" Project="x64" />
@@ -105,8 +109,8 @@
   <Project Path="src/Tasks/Microsoft.Build.Tasks.csproj">
     <Platform Solution="*|x64" Project="x64" />
   </Project>
-  <Project Path="src/ThreadSafeTaskAnalyzer/ThreadSafeTaskAnalyzer.csproj" />
   <Project Path="src/ThreadSafeTaskAnalyzer.Tests/ThreadSafeTaskAnalyzer.Tests.csproj" />
+  <Project Path="src/ThreadSafeTaskAnalyzer/ThreadSafeTaskAnalyzer.csproj" />
   <Project Path="src/UnitTests.Shared/Microsoft.Build.UnitTests.Shared.csproj">
     <Platform Solution="*|ARM64" Project="arm64" />
     <Platform Solution="*|x64" Project="x64" />

--- a/MSBuild.slnx
+++ b/MSBuild.slnx
@@ -76,10 +76,6 @@
   </Project>
   <Project Path="src/MSBuild.EndToEnd.Tests/Microsoft.Build.EndToEnd.Tests.csproj">
     <Platform Solution="*|x64" Project="x64" />
-    <Platform Solution="Debug|ARM64" Project="arm64" />
-    <Build Solution="Debug|Any CPU" Project="false" />
-    <Build Solution="Debug|ARM64" Project="false" />
-    <Build Solution="Debug|x86" Project="false" />
   </Project>
   <Project Path="src/MSBuild.UnitTests/Microsoft.Build.CommandLine.UnitTests.csproj">
     <Platform Solution="*|x64" Project="x64" />
@@ -109,8 +105,8 @@
   <Project Path="src/Tasks/Microsoft.Build.Tasks.csproj">
     <Platform Solution="*|x64" Project="x64" />
   </Project>
-  <Project Path="src/ThreadSafeTaskAnalyzer.Tests/ThreadSafeTaskAnalyzer.Tests.csproj" />
   <Project Path="src/ThreadSafeTaskAnalyzer/ThreadSafeTaskAnalyzer.csproj" />
+  <Project Path="src/ThreadSafeTaskAnalyzer.Tests/ThreadSafeTaskAnalyzer.Tests.csproj" />
   <Project Path="src/UnitTests.Shared/Microsoft.Build.UnitTests.Shared.csproj">
     <Platform Solution="*|ARM64" Project="arm64" />
     <Platform Solution="*|x64" Project="x64" />

--- a/src/Tasks/WinMDExp.cs
+++ b/src/Tasks/WinMDExp.cs
@@ -22,10 +22,10 @@ namespace Microsoft.Build.Tasks
     /// <summary>
     /// Exports a managed assembly to a windows runtime metadata.
     /// </summary>
+    [MSBuildMultiThreadableTask]
     public class WinMDExp : ToolTaskExtension, IWinMDExpTaskContract
     {
         #region Properties
-
         /// <summary>
         /// Set of references to pass to the winmdexp tool.
         /// </summary>
@@ -240,10 +240,15 @@ namespace Microsoft.Build.Tasks
         /// <summary>
         /// The full path of the tool to execute.
         /// </summary>
-        protected override string GenerateFullPathToTool()
-        {
-            return SdkToolsPathUtility.GeneratePathToTool(SdkToolsPathUtility.FileInfoExists, Microsoft.Build.Utilities.ProcessorArchitecture.CurrentProcessArchitecture, SdkToolsPath, ToolExe, Log, true);
-        }
+        protected override string GenerateFullPathToTool() => SdkToolsPathUtility.GeneratePathToTool(
+                f => !string.IsNullOrEmpty(f)
+                    ? SdkToolsPathUtility.FileInfoExists(TaskEnvironment.GetAbsolutePath(f))
+                    : SdkToolsPathUtility.FileInfoExists(f),
+                Utilities.ProcessorArchitecture.CurrentProcessArchitecture,
+                SdkToolsPath,
+                ToolExe,
+                Log,
+                true);
 
         /// <summary>
         /// Validate parameters, log errors and warnings and return true if Execute should proceed.
@@ -266,11 +271,12 @@ namespace Microsoft.Build.Tasks
         {
             if (!String.IsNullOrEmpty(OutputWindowsMetadataFile))
             {
-                var outputWriteTime = NativeMethodsShared.GetLastWriteFileUtcTime(OutputWindowsMetadataFile);
-                var winMDModuleWriteTime = NativeMethodsShared.GetLastWriteFileUtcTime(WinMDModule);
+                AbsolutePath outputWindowsMetadataFile = TaskEnvironment.GetAbsolutePath(OutputWindowsMetadataFile);
+                AbsolutePath winMDModule = TaskEnvironment.GetAbsolutePath(WinMDModule);
 
-                // If the last write time of the input file is less than the last write time of the output file
-                // then the output is newer then the input so we do not need to re-run the tool.
+                var outputWriteTime = NativeMethodsShared.GetLastWriteFileUtcTime(outputWindowsMetadataFile);
+                var winMDModuleWriteTime = NativeMethodsShared.GetLastWriteFileUtcTime(winMDModule);
+
                 if (outputWriteTime > winMDModuleWriteTime)
                 {
                     return true;
@@ -279,6 +285,7 @@ namespace Microsoft.Build.Tasks
 
             return false;
         }
+
         #endregion
     }
 

--- a/src/Tasks/WinMDExp.cs
+++ b/src/Tasks/WinMDExp.cs
@@ -3,6 +3,7 @@
 
 #if NETFRAMEWORK
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.Text;
 
@@ -249,6 +250,16 @@ namespace Microsoft.Build.Tasks
                 ToolExe,
                 Log,
                 true);
+
+        protected override ProcessStartInfo GetProcessStartInfo(string pathToTool, string commandLineCommands, string responseFileSwitch)
+        {
+            if (!string.IsNullOrEmpty(pathToTool) && Path.GetFileName(pathToTool).Length != pathToTool.Length)
+            {
+                pathToTool = TaskEnvironment.GetAbsolutePath(pathToTool);
+            }
+
+            return base.GetProcessStartInfo(pathToTool, commandLineCommands, responseFileSwitch);
+        }
 
         /// <summary>
         /// Validate parameters, log errors and warnings and return true if Execute should proceed.

--- a/src/Tasks/WinMDExp.cs
+++ b/src/Tasks/WinMDExp.cs
@@ -288,6 +288,7 @@ namespace Microsoft.Build.Tasks
                 var outputWriteTime = NativeMethodsShared.GetLastWriteFileUtcTime(outputWindowsMetadataFile);
                 var winMDModuleWriteTime = NativeMethodsShared.GetLastWriteFileUtcTime(winMDModule);
 
+                // If the last write time of the input file is less than the last write time of the output file
                 if (outputWriteTime > winMDModuleWriteTime)
                 {
                     return true;


### PR DESCRIPTION
Fixes #13635

 
 ### Context
 
 Migrates `WinMDExp` to the multithreaded task model so its path handling, environment access, and `winmdexp.exe` process 
launch go through `TaskEnvironment`.
 
 ### Changes Made
 
 - Added multithreaded task support with `[MSBuildMultiThreadableTask]` and `IMultiThreadableTask`.
 - Absolutized task input/tool paths through `TaskEnvironment.GetAbsolutePath()` before filesystem probes and tool 
execution.
 - Routed SDK lookup environment access through `TaskEnvironment.GetEnvironmentVariable()`.
 - Routed `winmdexp.exe` process creation through `TaskEnvironment.GetProcessStartInfo()`.
 - Preserved output property values so absolutized internal paths do not leak into task outputs.
 
 ### Testing
 
 - Built successfully with no new warnings.
 - Ran existing relevant tests.
 - Audited output/error path behavior for Sin 1 and Sin 2 concerns.