### PR TITLE
Fix broken component-governance.yml template reference

### DIFF
--- a/azure-pipelines/.vsts-dotnet-build-jobs.yml
+++ b/azure-pipelines/.vsts-dotnet-build-jobs.yml
@@ -268,14 +268,6 @@ jobs:
     displayName: Execute cleanup tasks
     condition: succeededOrFailed()
 
-  # Component Governance is injected automatically by the 1ES Official
-  # Pipeline Template (templates-official/job/job.yml) since arcade
-  # 10.0.0-beta.26222.2 (PR dotnet/msbuild#13434), which removed the
-  # standalone eng/common/templates-official/steps/component-governance.yml
-  # shim. No explicit step is needed here. To opt out for a specific
-  # pipeline, set sdl.componentgovernance.* in the extends parameters of
-  # that pipeline (e.g. .vsts-dotnet-exp-perf.yml).
-
 - template: /eng/common/templates-official/jobs/source-build.yml@self
   parameters:
     platforms:

--- a/azure-pipelines/.vsts-dotnet-build-jobs.yml
+++ b/azure-pipelines/.vsts-dotnet-build-jobs.yml
@@ -268,12 +268,13 @@ jobs:
     displayName: Execute cleanup tasks
     condition: succeededOrFailed()
 
-  - template: /eng/common/templates-official/steps/component-governance.yml@self
-    parameters:
-      ${{ if or(startsWith(variables['Build.SourceBranch'], 'refs/heads/vs'), eq(variables['Build.SourceBranch'], 'refs/heads/main')) }}:
-        disableComponentGovernance: false
-      ${{ else }}:
-        disableComponentGovernance: true
+  # Component Governance is injected automatically by the 1ES Official
+  # Pipeline Template (templates-official/job/job.yml) since arcade
+  # 10.0.0-beta.26222.2 (PR dotnet/msbuild#13434), which removed the
+  # standalone eng/common/templates-official/steps/component-governance.yml
+  # shim. No explicit step is needed here. To opt out for a specific
+  # pipeline, set sdl.componentgovernance.* in the extends parameters of
+  # that pipeline (e.g. .vsts-dotnet-exp-perf.yml).
 
 - template: /eng/common/templates-official/jobs/source-build.yml@self
   parameters:


### PR DESCRIPTION
 ### Context
 
 PR #13434 (an Arcade Darc update to `10.0.0-beta.26222.2`) deleted 
`eng/common/templates-official/steps/component-governance.yml`, but `azure-pipelines/.vsts-dotnet-build-jobs.yml` was 
still referencing it directly. As a result, the official internal pipeline (`.vsts-dotnet.yml`) broke on `main` 
because it tried to include a template that no longer exists.
 
 ### Changes Made
 
 - Removed the  `template: /eng/common/templates-official/steps/component-governance.yml` reference from 
`azure-pipelines/.vsts-dotnet-build-jobs.yml`