### PR TITLE
Bump BootstrapSDKVerions to 10.0.106

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -81,7 +81,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <BootstrapSdkVersion>10.0.104</BootstrapSdkVersion>
+    <BootstrapSdkVersion>10.0.106</BootstrapSdkVersion>
   </PropertyGroup>
 
   <Target Name="OverrideArcadeFileVersion" AfterTargets="_InitializeAssemblyVersion">


### PR DESCRIPTION
### Context
[ PR #13434 ([main] Update dependencies from dotnet/arcade)](https://github.com/dotnet/msbuild/pull/13434) updated `global.json` to pin `tools.dotnet` to **`10.0.106`**.

### Changes Made
- `eng/Versions.props`: bump `<BootstrapSdkVersion>` from `10.0.104` → `10.0.106` to match the SDK that #13434 pinned
 in `global.json`.
