### PR TITLE
Remove flaky ExitCode assertion in ToolTaskThatTimeoutAndRetry test

### DIFF
--- a/src/Utilities.UnitTests/ToolTask_Tests.cs
+++ b/src/Utilities.UnitTests/ToolTask_Tests.cs
@@ -1046,10 +1046,6 @@ namespace Microsoft.Build.UnitTests
                 {
                     task.ExitCode.ShouldBe(0);
                 }
-                else
-                {
-                    task.ExitCode.ShouldNotBe(0);
-                }
             }
         }
 


### PR DESCRIPTION
Fixes #

### Context
`ToolTaskThatTimeoutAndRetry(repeats: 3, timeoutOnFirstExecution: true)` is a flaky test.
When the test runs on a heavily loaded machine (e.g. CI), the 2-second timeout timercallback can be delayed by thread pool starvation. By the time it fires, `ping -n 6` may have already exited naturally with exit code 0. `TerminateToolProcess` then becomes a no-op (`proc.HasExited == true`), leaving `ExitCode = 0` even though `_terminatedTool` is set and `Execute()` correctly returns `false`.

### Changes Made
- Removed the `task.ExitCode.ShouldNotBe(0)` assertion in the timeout/failure branch of `ToolTaskThatTimeoutAndRetry`. The assertion is non-deterministic because `ExitCode` depends on whether the process was killed or exited naturally during the race.

### Testing

### Notes
