### PR TITLE
Migration of GenerateLauncher to Multithreaded Execution

### DIFF
--- a/src/Tasks/BootstrapperUtil/ResourceUpdater.cs
+++ b/src/Tasks/BootstrapperUtil/ResourceUpdater.cs
@@ -2,13 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
+using Microsoft.Build.Framework;
 #if FEATURE_WINDOWSINTEROP
 using System;
 using System.Globalization;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Threading;
-using Microsoft.Build.Framework;
 using Windows.Win32;
 using Windows.Win32.Foundation;
 #endif
@@ -30,7 +30,14 @@ namespace Microsoft.Build.Tasks.Deployment.Bootstrapper
             _fileResources.Add(new FileResource(filename, key));
         }
 
-        public bool UpdateResources(string filename, BuildResults results, string? filenameForMessages = null)
+        /// <summary>
+        /// Updates resources on the target binary.
+        /// </summary>
+        /// <param name="filename">
+        /// Absolute path to the binary to update.
+        /// </param>
+        /// <param name="results">Sink for build messages.</param>
+        public bool UpdateResources(AbsolutePath filename, BuildResults results)
         {
 #if FEATURE_WINDOWSINTEROP
 #pragma warning disable CA1416 // Win32 API guarded by FEATURE_WINDOWSINTEROP; bootstrapper resource updates are Windows-only.
@@ -38,10 +45,8 @@ namespace Microsoft.Build.Tasks.Deployment.Bootstrapper
             int beginUpdateRetries = 20;    // Number of retries
             const int beginUpdateRetryInterval = 100; // In milliseconds
             bool endUpdate = false; // Only call EndUpdateResource() if this is true
-            filenameForMessages ??= filename;
 
-            // Callers pass an absolute path; do not resolve against the process current directory.
-            string filePath = filename;
+            string filePath = filename.Value;
 
             if (_stringResources.Count == 0 && _fileResources.Count == 0)
             {
@@ -64,7 +69,7 @@ namespace Microsoft.Build.Tasks.Deployment.Bootstrapper
                 if (hUpdate == HANDLE.Null)
                 {
                     results.AddMessage(BuildMessage.CreateMessage(BuildMessageSeverity.Error, "GenerateBootstrapper.General",
-                        $"Unable to begin updating resource for {filenameForMessages} with error {Marshal.GetHRForLastWin32Error():X}"));
+                        $"Unable to begin updating resource for {filename.OriginalValue} with error {Marshal.GetHRForLastWin32Error():X}"));
                     return false;
                 }
 
@@ -77,7 +82,7 @@ namespace Microsoft.Build.Tasks.Deployment.Bootstrapper
                     if (!UpdateResource(hUpdate, resource.Type, resource.Name, data))
                     {
                         results.AddMessage(BuildMessage.CreateMessage(BuildMessageSeverity.Error, "GenerateBootstrapper.General",
-                            $"Unable to update resource for {filenameForMessages} with error {Marshal.GetHRForLastWin32Error():X}"));
+                            $"Unable to update resource for {filename.OriginalValue} with error {Marshal.GetHRForLastWin32Error():X}"));
                         return false;
                     }
                 }
@@ -89,7 +94,7 @@ namespace Microsoft.Build.Tasks.Deployment.Bootstrapper
                     if (!UpdateResource(hUpdate, 42, "COUNT", countArray))
                     {
                         results.AddMessage(BuildMessage.CreateMessage(BuildMessageSeverity.Error, "GenerateBootstrapper.General",
-                            $"Unable to update count resource for {filenameForMessages} with error {Marshal.GetHRForLastWin32Error():X}"));
+                            $"Unable to update count resource for {filename.OriginalValue} with error {Marshal.GetHRForLastWin32Error():X}"));
                         return false;
                     }
 
@@ -111,7 +116,7 @@ namespace Microsoft.Build.Tasks.Deployment.Bootstrapper
                         if (!UpdateResource(hUpdate, 42, dataName, fileContent.AsSpan(0, fileLength)))
                         {
                             results.AddMessage(BuildMessage.CreateMessage(BuildMessageSeverity.Error, "GenerateBootstrapper.General",
-                                $"Unable to update data resource for {filenameForMessages} with error {Marshal.GetHRForLastWin32Error():X}"));
+                                $"Unable to update data resource for {filename.OriginalValue} with error {Marshal.GetHRForLastWin32Error():X}"));
                             return false;
                         }
 
@@ -121,7 +126,7 @@ namespace Microsoft.Build.Tasks.Deployment.Bootstrapper
                         if (!UpdateResource(hUpdate, 42, keyName, data))
                         {
                             results.AddMessage(BuildMessage.CreateMessage(BuildMessageSeverity.Error, "GenerateBootstrapper.General",
-                                $"Unable to update key resource for {filenameForMessages} with error {Marshal.GetHRForLastWin32Error():X}"));
+                                $"Unable to update key resource for {filename.OriginalValue} with error {Marshal.GetHRForLastWin32Error():X}"));
                             return false;
                         }
 
@@ -134,7 +139,7 @@ namespace Microsoft.Build.Tasks.Deployment.Bootstrapper
                 if (endUpdate && !PInvoke.EndUpdateResource(hUpdate, false))
                 {
                     results.AddMessage(BuildMessage.CreateMessage(BuildMessageSeverity.Error, "GenerateBootstrapper.General",
-                        $"Unable to finish updating resource for {filenameForMessages} with error {Marshal.GetHRForLastWin32Error():X}"));
+                        $"Unable to finish updating resource for {filename.OriginalValue} with error {Marshal.GetHRForLastWin32Error():X}"));
                     returnValue = false;
                 }
             }
@@ -145,10 +150,19 @@ namespace Microsoft.Build.Tasks.Deployment.Bootstrapper
             results.AddMessage(BuildMessage.CreateMessage(
                 BuildMessageSeverity.Error,
                 "GenerateBootstrapper.General",
-                $"Unable to update resources for {filename}: bootstrapper resource updates require Windows interop support, which is not available in this build."));
+                $"Unable to update resources for {filename.OriginalValue}: bootstrapper resource updates require Windows interop support, which is not available in this build."));
             return false;
 #endif
         }
+
+        /// <summary>
+        /// Back-compat overload for callers that have not yet been migrated to the AbsolutePath-based API
+        /// (currently <see cref="GenerateBootstrapper"/>). Wraps the input without rooted-path validation
+        /// to preserve the legacy "use the string as-is" semantics; <c>OriginalValue</c> equals <c>Value</c>.
+        /// </summary>
+        // TODO: This can be removed after GenerateBootstrapper is fully migrated to the AbsolutePath-based API.
+        public bool UpdateResources(string filename, BuildResults results)
+            => UpdateResources(new AbsolutePath(filename, ignoreRootedCheck: true), results);
 
 #if FEATURE_WINDOWSINTEROP
         /// <summary>

--- a/src/Tasks/BootstrapperUtil/ResourceUpdater.cs
+++ b/src/Tasks/BootstrapperUtil/ResourceUpdater.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Build.Tasks.Deployment.Bootstrapper
             _fileResources.Add(new FileResource(filename, key));
         }
 
-        public bool UpdateResources(string filename, BuildResults results)
+        public bool UpdateResources(string filename, BuildResults results, string? filenameForMessages = null)
         {
 #if FEATURE_WINDOWSINTEROP
 #pragma warning disable CA1416 // Win32 API guarded by FEATURE_WINDOWSINTEROP; bootstrapper resource updates are Windows-only.
@@ -38,9 +38,10 @@ namespace Microsoft.Build.Tasks.Deployment.Bootstrapper
             int beginUpdateRetries = 20;    // Number of retries
             const int beginUpdateRetryInterval = 100; // In milliseconds
             bool endUpdate = false; // Only call EndUpdateResource() if this is true
+            filenameForMessages ??= filename;
 
-            // Directory.GetCurrentDirectory() has previously been set to the project location
-            string filePath = Path.Combine(Directory.GetCurrentDirectory(), filename);
+            // Callers pass an absolute path; do not resolve against the process current directory.
+            string filePath = filename;
 
             if (_stringResources.Count == 0 && _fileResources.Count == 0)
             {
@@ -63,7 +64,7 @@ namespace Microsoft.Build.Tasks.Deployment.Bootstrapper
                 if (hUpdate == HANDLE.Null)
                 {
                     results.AddMessage(BuildMessage.CreateMessage(BuildMessageSeverity.Error, "GenerateBootstrapper.General",
-                        $"Unable to begin updating resource for {filename} with error {Marshal.GetHRForLastWin32Error():X}"));
+                        $"Unable to begin updating resource for {filenameForMessages} with error {Marshal.GetHRForLastWin32Error():X}"));
                     return false;
                 }
 
@@ -76,7 +77,7 @@ namespace Microsoft.Build.Tasks.Deployment.Bootstrapper
                     if (!UpdateResource(hUpdate, resource.Type, resource.Name, data))
                     {
                         results.AddMessage(BuildMessage.CreateMessage(BuildMessageSeverity.Error, "GenerateBootstrapper.General",
-                            $"Unable to update resource for {filename} with error {Marshal.GetHRForLastWin32Error():X}"));
+                            $"Unable to update resource for {filenameForMessages} with error {Marshal.GetHRForLastWin32Error():X}"));
                         return false;
                     }
                 }
@@ -88,7 +89,7 @@ namespace Microsoft.Build.Tasks.Deployment.Bootstrapper
                     if (!UpdateResource(hUpdate, 42, "COUNT", countArray))
                     {
                         results.AddMessage(BuildMessage.CreateMessage(BuildMessageSeverity.Error, "GenerateBootstrapper.General",
-                            $"Unable to update count resource for {filename} with error {Marshal.GetHRForLastWin32Error():X}"));
+                            $"Unable to update count resource for {filenameForMessages} with error {Marshal.GetHRForLastWin32Error():X}"));
                         return false;
                     }
 
@@ -110,7 +111,7 @@ namespace Microsoft.Build.Tasks.Deployment.Bootstrapper
                         if (!UpdateResource(hUpdate, 42, dataName, fileContent.AsSpan(0, fileLength)))
                         {
                             results.AddMessage(BuildMessage.CreateMessage(BuildMessageSeverity.Error, "GenerateBootstrapper.General",
-                                $"Unable to update data resource for {filename} with error {Marshal.GetHRForLastWin32Error():X}"));
+                                $"Unable to update data resource for {filenameForMessages} with error {Marshal.GetHRForLastWin32Error():X}"));
                             return false;
                         }
 
@@ -120,7 +121,7 @@ namespace Microsoft.Build.Tasks.Deployment.Bootstrapper
                         if (!UpdateResource(hUpdate, 42, keyName, data))
                         {
                             results.AddMessage(BuildMessage.CreateMessage(BuildMessageSeverity.Error, "GenerateBootstrapper.General",
-                                $"Unable to update key resource for {filename} with error {Marshal.GetHRForLastWin32Error():X}"));
+                                $"Unable to update key resource for {filenameForMessages} with error {Marshal.GetHRForLastWin32Error():X}"));
                             return false;
                         }
 
@@ -133,7 +134,7 @@ namespace Microsoft.Build.Tasks.Deployment.Bootstrapper
                 if (endUpdate && !PInvoke.EndUpdateResource(hUpdate, false))
                 {
                     results.AddMessage(BuildMessage.CreateMessage(BuildMessageSeverity.Error, "GenerateBootstrapper.General",
-                        $"Unable to finish updating resource for {filename} with error {Marshal.GetHRForLastWin32Error():X}"));
+                        $"Unable to finish updating resource for {filenameForMessages} with error {Marshal.GetHRForLastWin32Error():X}"));
                     returnValue = false;
                 }
             }

--- a/src/Tasks/BootstrapperUtil/Util.cs
+++ b/src/Tasks/BootstrapperUtil/Util.cs
@@ -89,19 +89,8 @@ namespace Microsoft.Build.Tasks.Deployment.Bootstrapper
             {
                 if (String.IsNullOrEmpty(s_defaultPath))
                 {
-                    s_defaultPath = ReadRegistryString(Registry.LocalMachine, String.Concat(BOOTSTRAPPER_REGISTRY_PATH_BASE, BOOTSTRAPPER_REGISTRY_PATH_VERSION_VS2010), REGISTRY_DEFAULTPATH);
-                    if (!String.IsNullOrEmpty(s_defaultPath))
-                    {
-                        return s_defaultPath;
-                    }
-
-                    s_defaultPath = ReadRegistryString(Registry.LocalMachine, String.Concat(BOOTSTRAPPER_WOW64_REGISTRY_PATH_BASE, BOOTSTRAPPER_REGISTRY_PATH_VERSION_VS2010), REGISTRY_DEFAULTPATH);
-                    if (!String.IsNullOrEmpty(s_defaultPath))
-                    {
-                        return s_defaultPath;
-                    }
-
-                    s_defaultPath = Directory.GetCurrentDirectory();
+                    string probed = ProbeRegistryDefaultPath(String.Empty);
+                    s_defaultPath = String.IsNullOrEmpty(probed) ? Directory.GetCurrentDirectory() : probed;
                 }
 
                 return s_defaultPath;
@@ -119,74 +108,27 @@ namespace Microsoft.Build.Tasks.Deployment.Bootstrapper
                 return DefaultPath;
             }
 
-            // With version 11.0 we start a direct mapping between the VS version and the registry key we use.
-            // For Dev10, we use 4.0.
-            // For Dev15 this will go versionless as there will be singleton MSI setting the registry which will be common for all future VS.
-
-            int dotIndex = visualStudioVersion.IndexOf('.');
-            if (dotIndex < 0)
-            {
-                dotIndex = visualStudioVersion.Length;
-            }
-
-#if NET
-            if (Int32.TryParse(visualStudioVersion.AsSpan(0, dotIndex), out int majorVersion) && (majorVersion < 11))
-#else
-            if (Int32.TryParse(visualStudioVersion.Substring(0, dotIndex), out int majorVersion) && (majorVersion < 11))
-#endif
-            {
-                visualStudioVersion = BOOTSTRAPPER_REGISTRY_PATH_VERSION_VS2010;
-            }
-
-            string defaultPath = ReadRegistryString(Registry.LocalMachine, BOOTSTRAPPER_REGISTRY_PATH_BASE, REGISTRY_DEFAULTPATH);
-            if (!String.IsNullOrEmpty(defaultPath))
-            {
-                return defaultPath;
-            }
-
-            defaultPath = ReadRegistryString(Registry.LocalMachine, BOOTSTRAPPER_WOW64_REGISTRY_PATH_BASE, REGISTRY_DEFAULTPATH);
-            if (!String.IsNullOrEmpty(defaultPath))
-            {
-                return defaultPath;
-            }
-
-            defaultPath = ReadRegistryString(Registry.LocalMachine, String.Concat(BOOTSTRAPPER_REGISTRY_PATH_BASE, visualStudioVersion), REGISTRY_DEFAULTPATH);
-            if (!String.IsNullOrEmpty(defaultPath))
-            {
-                return defaultPath;
-            }
-
-            defaultPath = ReadRegistryString(Registry.LocalMachine, String.Concat(BOOTSTRAPPER_WOW64_REGISTRY_PATH_BASE, visualStudioVersion), REGISTRY_DEFAULTPATH);
-            if (!String.IsNullOrEmpty(defaultPath))
-            {
-                return defaultPath;
-            }
-
-            return Directory.GetCurrentDirectory();
+            string probed = ProbeRegistryDefaultPath(NormalizeVisualStudioVersion(visualStudioVersion));
+            return !String.IsNullOrEmpty(probed) ? probed : Directory.GetCurrentDirectory();
         }
 
         [SupportedOSPlatform("windows")]
-        // Multithreaded-safe overload: takes a TaskEnvironment and uses its ProjectDirectory as the
-        // fallback when no registry value is found. Unlike GetDefaultPath(string), this overload
-        // cannot reach Directory.GetCurrentDirectory(), so the MT contract is enforced by the
-        // signature itself. Registry-derived results are cached in s_defaultPathByVersion keyed on
-        // the normalized Visual Studio version; the project directory is not cached so each call
-        // resolves its own.
+        // MT-safe overload: falls back to TaskEnvironment.ProjectDirectory instead of the process CWD.
         internal static string GetDefaultPath(string visualStudioVersion, TaskEnvironment taskEnvironment)
         {
             string projectDirectory = taskEnvironment.ProjectDirectory.Value;
+            string normalized = String.IsNullOrEmpty(visualStudioVersion)
+                ? String.Empty
+                : NormalizeVisualStudioVersion(visualStudioVersion);
 
-            // if the Visual Studio Version is not a valid string, we will fall back to using the v4.0 keys.
-            if (String.IsNullOrEmpty(visualStudioVersion))
-            {
-                string defaultPathV4 = s_defaultPathByVersion.GetOrAdd(String.Empty, _ => ProbeRegistryDefaultPath(String.Empty));
-                return !String.IsNullOrEmpty(defaultPathV4) ? defaultPathV4 : projectDirectory;
-            }
+            string defaultPath = s_defaultPathByVersion.GetOrAdd(normalized, ProbeRegistryDefaultPath);
+            return !String.IsNullOrEmpty(defaultPath) ? defaultPath : projectDirectory;
+        }
 
-            // With version 11.0 we start a direct mapping between the VS version and the registry key we use.
-            // For Dev10, we use 4.0.
-            // For Dev15 this will go versionless as there will be singleton MSI setting the registry which will be common for all future VS.
-
+        // Maps a raw Visual Studio version string to the registry sub-key suffix used for probing.
+        // Versions older than 11.0 collapse to "4.0"; everything else is returned unchanged.
+        private static string NormalizeVisualStudioVersion(string visualStudioVersion)
+        {
             int dotIndex = visualStudioVersion.IndexOf('.');
             if (dotIndex < 0)
             {
@@ -199,24 +141,19 @@ namespace Microsoft.Build.Tasks.Deployment.Bootstrapper
             if (Int32.TryParse(visualStudioVersion.Substring(0, dotIndex), out int majorVersion) && (majorVersion < 11))
 #endif
             {
-                visualStudioVersion = BOOTSTRAPPER_REGISTRY_PATH_VERSION_VS2010;
+                return BOOTSTRAPPER_REGISTRY_PATH_VERSION_VS2010;
             }
 
-            string defaultPath = s_defaultPathByVersion.GetOrAdd(visualStudioVersion, ProbeRegistryDefaultPath);
-            return !String.IsNullOrEmpty(defaultPath) ? defaultPath : projectDirectory;
+            return visualStudioVersion;
         }
 
         [SupportedOSPlatform("windows")]
-        // Performs the registry probes for the MT-safe GetDefaultPath overload.
-        // Returns the first non-empty registry value, or String.Empty to record a known miss
-        // (so the cache entry distinguishes "not yet probed" from "probed and absent").
+        // Returns the first non-empty registry value, or String.Empty if none.
         private static string ProbeRegistryDefaultPath(string normalizedVersion)
         {
             if (normalizedVersion.Length == 0)
             {
-                // Empty-version branch: probe only the v4.0 keys (matches the legacy behavior
-                // of the empty-version path; the versionless base-key probes used by the
-                // non-empty path are intentionally not included here).
+                // Empty-version branch: probe only the v4.0 keys (matches the legacy empty-version path).
                 string p = ReadRegistryString(Registry.LocalMachine, String.Concat(BOOTSTRAPPER_REGISTRY_PATH_BASE, BOOTSTRAPPER_REGISTRY_PATH_VERSION_VS2010), REGISTRY_DEFAULTPATH);
                 if (!String.IsNullOrEmpty(p))
                 {

--- a/src/Tasks/BootstrapperUtil/Util.cs
+++ b/src/Tasks/BootstrapperUtil/Util.cs
@@ -109,10 +109,35 @@ namespace Microsoft.Build.Tasks.Deployment.Bootstrapper
         // This method is not going to cache the path as it could be different depending on the Visual Studio version.
         public static string GetDefaultPath(string visualStudioVersion)
         {
+            return GetDefaultPath(visualStudioVersion, fallbackPath: null);
+        }
+
+        [SupportedOSPlatform("windows")]
+        // Overload that accepts an explicit fallback path instead of using Directory.GetCurrentDirectory().
+        // Used by multithreaded-safe tasks that supply a project-scoped fallback via TaskEnvironment.
+        internal static string GetDefaultPath(string visualStudioVersion, string fallbackPath)
+        {
             // if the Visual Studio Version is not a valid string, we will fall back to using the v4.0 property.
             if (String.IsNullOrEmpty(visualStudioVersion))
             {
-                return DefaultPath;
+                if (fallbackPath == null)
+                {
+                    return DefaultPath;
+                }
+
+                string defaultPathV4 = ReadRegistryString(Registry.LocalMachine, String.Concat(BOOTSTRAPPER_REGISTRY_PATH_BASE, BOOTSTRAPPER_REGISTRY_PATH_VERSION_VS2010), REGISTRY_DEFAULTPATH);
+                if (!String.IsNullOrEmpty(defaultPathV4))
+                {
+                    return defaultPathV4;
+                }
+
+                defaultPathV4 = ReadRegistryString(Registry.LocalMachine, String.Concat(BOOTSTRAPPER_WOW64_REGISTRY_PATH_BASE, BOOTSTRAPPER_REGISTRY_PATH_VERSION_VS2010), REGISTRY_DEFAULTPATH);
+                if (!String.IsNullOrEmpty(defaultPathV4))
+                {
+                    return defaultPathV4;
+                }
+
+                return fallbackPath;
             }
 
             // With version 11.0 we start a direct mapping between the VS version and the registry key we use.
@@ -158,7 +183,7 @@ namespace Microsoft.Build.Tasks.Deployment.Bootstrapper
                 return defaultPath;
             }
 
-            return Directory.GetCurrentDirectory();
+            return fallbackPath ?? Directory.GetCurrentDirectory();
         }
 
         [SupportedOSPlatform("windows")]

--- a/src/Tasks/BootstrapperUtil/Util.cs
+++ b/src/Tasks/BootstrapperUtil/Util.cs
@@ -2,10 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Runtime.Versioning;
+using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
 using Microsoft.Win32;
 
@@ -27,6 +29,8 @@ namespace Microsoft.Build.Tasks.Deployment.Bootstrapper
 
         private static string s_defaultPath;
         private static List<string> s_additionalPackagePaths;
+
+        private static readonly ConcurrentDictionary<string, string> s_defaultPathByVersion = new ConcurrentDictionary<string, string>(StringComparer.Ordinal);
 
         public static string AddTrailingChar(string str, char ch)
         {
@@ -109,35 +113,10 @@ namespace Microsoft.Build.Tasks.Deployment.Bootstrapper
         // This method is not going to cache the path as it could be different depending on the Visual Studio version.
         public static string GetDefaultPath(string visualStudioVersion)
         {
-            return GetDefaultPath(visualStudioVersion, fallbackPath: null);
-        }
-
-        [SupportedOSPlatform("windows")]
-        // Overload that accepts an explicit fallback path instead of using Directory.GetCurrentDirectory().
-        // Used by multithreaded-safe tasks that supply a project-scoped fallback via TaskEnvironment.
-        internal static string GetDefaultPath(string visualStudioVersion, string fallbackPath)
-        {
             // if the Visual Studio Version is not a valid string, we will fall back to using the v4.0 property.
             if (String.IsNullOrEmpty(visualStudioVersion))
             {
-                if (fallbackPath == null)
-                {
-                    return DefaultPath;
-                }
-
-                string defaultPathV4 = ReadRegistryString(Registry.LocalMachine, String.Concat(BOOTSTRAPPER_REGISTRY_PATH_BASE, BOOTSTRAPPER_REGISTRY_PATH_VERSION_VS2010), REGISTRY_DEFAULTPATH);
-                if (!String.IsNullOrEmpty(defaultPathV4))
-                {
-                    return defaultPathV4;
-                }
-
-                defaultPathV4 = ReadRegistryString(Registry.LocalMachine, String.Concat(BOOTSTRAPPER_WOW64_REGISTRY_PATH_BASE, BOOTSTRAPPER_REGISTRY_PATH_VERSION_VS2010), REGISTRY_DEFAULTPATH);
-                if (!String.IsNullOrEmpty(defaultPathV4))
-                {
-                    return defaultPathV4;
-                }
-
-                return fallbackPath;
+                return DefaultPath;
             }
 
             // With version 11.0 we start a direct mapping between the VS version and the registry key we use.
@@ -183,7 +162,91 @@ namespace Microsoft.Build.Tasks.Deployment.Bootstrapper
                 return defaultPath;
             }
 
-            return fallbackPath ?? Directory.GetCurrentDirectory();
+            return Directory.GetCurrentDirectory();
+        }
+
+        [SupportedOSPlatform("windows")]
+        // Multithreaded-safe overload: takes a TaskEnvironment and uses its ProjectDirectory as the
+        // fallback when no registry value is found. Unlike GetDefaultPath(string), this overload
+        // cannot reach Directory.GetCurrentDirectory(), so the MT contract is enforced by the
+        // signature itself. Registry-derived results are cached in s_defaultPathByVersion keyed on
+        // the normalized Visual Studio version; the project directory is not cached so each call
+        // resolves its own.
+        internal static string GetDefaultPath(string visualStudioVersion, TaskEnvironment taskEnvironment)
+        {
+            string projectDirectory = taskEnvironment.ProjectDirectory.Value;
+
+            // if the Visual Studio Version is not a valid string, we will fall back to using the v4.0 keys.
+            if (String.IsNullOrEmpty(visualStudioVersion))
+            {
+                string defaultPathV4 = s_defaultPathByVersion.GetOrAdd(String.Empty, _ => ProbeRegistryDefaultPath(String.Empty));
+                return !String.IsNullOrEmpty(defaultPathV4) ? defaultPathV4 : projectDirectory;
+            }
+
+            // With version 11.0 we start a direct mapping between the VS version and the registry key we use.
+            // For Dev10, we use 4.0.
+            // For Dev15 this will go versionless as there will be singleton MSI setting the registry which will be common for all future VS.
+
+            int dotIndex = visualStudioVersion.IndexOf('.');
+            if (dotIndex < 0)
+            {
+                dotIndex = visualStudioVersion.Length;
+            }
+
+#if NET
+            if (Int32.TryParse(visualStudioVersion.AsSpan(0, dotIndex), out int majorVersion) && (majorVersion < 11))
+#else
+            if (Int32.TryParse(visualStudioVersion.Substring(0, dotIndex), out int majorVersion) && (majorVersion < 11))
+#endif
+            {
+                visualStudioVersion = BOOTSTRAPPER_REGISTRY_PATH_VERSION_VS2010;
+            }
+
+            string defaultPath = s_defaultPathByVersion.GetOrAdd(visualStudioVersion, ProbeRegistryDefaultPath);
+            return !String.IsNullOrEmpty(defaultPath) ? defaultPath : projectDirectory;
+        }
+
+        [SupportedOSPlatform("windows")]
+        // Performs the registry probes for the MT-safe GetDefaultPath overload.
+        // Returns the first non-empty registry value, or String.Empty to record a known miss
+        // (so the cache entry distinguishes "not yet probed" from "probed and absent").
+        private static string ProbeRegistryDefaultPath(string normalizedVersion)
+        {
+            if (normalizedVersion.Length == 0)
+            {
+                // Empty-version branch: probe only the v4.0 keys (matches the legacy behavior
+                // of the empty-version path; the versionless base-key probes used by the
+                // non-empty path are intentionally not included here).
+                string p = ReadRegistryString(Registry.LocalMachine, String.Concat(BOOTSTRAPPER_REGISTRY_PATH_BASE, BOOTSTRAPPER_REGISTRY_PATH_VERSION_VS2010), REGISTRY_DEFAULTPATH);
+                if (!String.IsNullOrEmpty(p))
+                {
+                    return p;
+                }
+
+                p = ReadRegistryString(Registry.LocalMachine, String.Concat(BOOTSTRAPPER_WOW64_REGISTRY_PATH_BASE, BOOTSTRAPPER_REGISTRY_PATH_VERSION_VS2010), REGISTRY_DEFAULTPATH);
+                return p ?? String.Empty;
+            }
+
+            string defaultPath = ReadRegistryString(Registry.LocalMachine, BOOTSTRAPPER_REGISTRY_PATH_BASE, REGISTRY_DEFAULTPATH);
+            if (!String.IsNullOrEmpty(defaultPath))
+            {
+                return defaultPath;
+            }
+
+            defaultPath = ReadRegistryString(Registry.LocalMachine, BOOTSTRAPPER_WOW64_REGISTRY_PATH_BASE, REGISTRY_DEFAULTPATH);
+            if (!String.IsNullOrEmpty(defaultPath))
+            {
+                return defaultPath;
+            }
+
+            defaultPath = ReadRegistryString(Registry.LocalMachine, String.Concat(BOOTSTRAPPER_REGISTRY_PATH_BASE, normalizedVersion), REGISTRY_DEFAULTPATH);
+            if (!String.IsNullOrEmpty(defaultPath))
+            {
+                return defaultPath;
+            }
+
+            defaultPath = ReadRegistryString(Registry.LocalMachine, String.Concat(BOOTSTRAPPER_WOW64_REGISTRY_PATH_BASE, normalizedVersion), REGISTRY_DEFAULTPATH);
+            return defaultPath ?? String.Empty;
         }
 
         [SupportedOSPlatform("windows")]

--- a/src/Tasks/GenerateLauncher.cs
+++ b/src/Tasks/GenerateLauncher.cs
@@ -18,14 +18,15 @@ namespace Microsoft.Build.Tasks
     /// <summary>
     /// Generates a bootstrapper for ClickOnce deployment projects.
     /// </summary>
+    [MSBuildMultiThreadableTask]
     [SupportedOSPlatform("windows")]
-    public sealed class GenerateLauncher : TaskExtension
+    public sealed class GenerateLauncher : TaskExtension, IMultiThreadableTask
     {
         private const string LAUNCHER_EXE = "Launcher.exe";
         private const string ENGINE_PATH = "Engine"; // relative to ClickOnce bootstrapper path
 
         #region Properties
-
+        public TaskEnvironment TaskEnvironment { get; set; } = TaskEnvironment.Fallback;
         public ITaskItem EntryPoint { get; set; }
 
         public string LauncherPath { get; set; }
@@ -57,14 +58,16 @@ namespace Microsoft.Build.Tasks
                     ENGINE_PATH,
                     LAUNCHER_EXE);
             }
-
             if (EntryPoint == null)
             {
                 Log.LogErrorWithCodeFromResources("GenerateLauncher.InvalidInput");
                 return false;
             }
 
-            var launcherBuilder = new LauncherBuilder(LauncherPath);
+            string launcherPath = string.IsNullOrEmpty(LauncherPath) ? LauncherPath : TaskEnvironment.GetAbsolutePath(LauncherPath);
+            string outputPath = string.IsNullOrEmpty(OutputPath) ? OutputPath : TaskEnvironment.GetAbsolutePath(OutputPath);
+
+            var launcherBuilder = new LauncherBuilder(launcherPath, LauncherPath);
             string entryPointFileName = Path.GetFileName(EntryPoint.ItemSpec);
 
             // If the EntryPoint specified is apphost.exe or singlefilehost.exe, we need to replace the EntryPoint
@@ -77,7 +80,7 @@ namespace Microsoft.Build.Tasks
                 entryPointFileName = AssemblyName;
             }
 
-            BuildResults results = launcherBuilder.Build(entryPointFileName, OutputPath);
+            BuildResults results = launcherBuilder.Build(entryPointFileName, outputPath, OutputPath);
 
             BuildMessage[] messages = results.Messages;
             if (messages != null)
@@ -98,8 +101,8 @@ namespace Microsoft.Build.Tasks
                     }
                 }
             }
-
-            OutputEntryPoint = new TaskItem(Path.Combine(Path.GetDirectoryName(EntryPoint.ItemSpec), results.KeyFile));
+            string outputEntryPoint = Path.Combine(Path.GetDirectoryName(EntryPoint.ItemSpec), results.KeyFile);
+            OutputEntryPoint = new TaskItem(outputEntryPoint);
             OutputEntryPoint.SetMetadata(ItemMetadataNames.targetPath, results.KeyFile);
 
             return !Log.HasLoggedErrors;

--- a/src/Tasks/GenerateLauncher.cs
+++ b/src/Tasks/GenerateLauncher.cs
@@ -41,12 +41,17 @@ namespace Microsoft.Build.Tasks
         public ITaskItem OutputEntryPoint { get; set; }
         #endregion
 
-        // Suppress MSBuildTask0005 around Execute because the transitive analyzer reports
-        // on the task entry point, not on the LauncherBuilder.Build call below. The
-        // LauncherBuilder.Build paths are safe here:
-        // File.OpenRead is in a dead branch; File.Copy/Get/SetAttributes/CreateDirectory all
-        // receive absolute paths derived from AbsolutePath.Value.
-#pragma warning disable MSBuildTask0005
+        // MSBuildTask0005 (transitive unsafe API) is reported here by the call-graph analyzer
+        // because ResourceUpdater.UpdateResources contains a File.OpenRead call. That branch
+        // only executes when ResourceUpdater._fileResources is non-empty, which happens only
+        // via AddFileResource — and AddFileResource is called exclusively from
+        // BootstrapperBuilder, never from LauncherBuilder (which uses AddStringResource only).
+        // All other I/O reachable from this task — File.Copy, File.Get/SetAttributes,
+        // Directory.CreateDirectory, FileSystems.Default.FileExists/DirectoryExists — receives
+        // an AbsolutePath.Value, and Util.GetDefaultPath is called with an explicit project-
+        // scoped fallback (TaskEnvironment.ProjectDirectory.Value) instead of
+        // Directory.GetCurrentDirectory(). The warning is left unsuppressed so the analyzer
+        // can be improved to track data-flow reachability; see analyzer issue (to be filed).
         public override bool Execute()
         {
             if (!NativeMethodsShared.IsWindows)
@@ -58,12 +63,10 @@ namespace Microsoft.Build.Tasks
             if (LauncherPath == null)
             {
                 // Launcher lives next to ClickOnce bootstrapper.
-                // GetDefaultPath obtains the root ClickOnce boostrapper path.
-                // Pass the project directory as the fallback so we don't depend on
-                // the process-wide current directory in multithreaded execution.
-                string fallbackPath = TaskEnvironment.ProjectDirectory.Value;
+                // Use the TaskEnvironment overload of GetDefaultPath so the fallback is the
+                // project directory rather than the process-wide current directory.
                 LauncherPath = Path.Combine(
-                    Deployment.Bootstrapper.Util.GetDefaultPath(VisualStudioVersion, fallbackPath),
+                    Deployment.Bootstrapper.Util.GetDefaultPath(VisualStudioVersion, TaskEnvironment),
                     ENGINE_PATH,
                     LAUNCHER_EXE);
             }
@@ -75,7 +78,7 @@ namespace Microsoft.Build.Tasks
 
             AbsolutePath outputPath = string.IsNullOrEmpty(OutputPath) ? default : TaskEnvironment.GetAbsolutePath(OutputPath);
 
-            var launcherBuilder = new LauncherBuilder(LauncherPath) { TaskEnvironment = TaskEnvironment };
+            var launcherBuilder = new LauncherBuilder(LauncherPath, TaskEnvironment);
             string entryPointFileName = Path.GetFileName(EntryPoint.ItemSpec);
 
             // If the EntryPoint specified is apphost.exe or singlefilehost.exe, we need to replace the EntryPoint
@@ -115,6 +118,5 @@ namespace Microsoft.Build.Tasks
 
             return !Log.HasLoggedErrors;
         }
-#pragma warning restore MSBuildTask0005
     }
 }

--- a/src/Tasks/GenerateLauncher.cs
+++ b/src/Tasks/GenerateLauncher.cs
@@ -64,9 +64,9 @@ namespace Microsoft.Build.Tasks
                 return false;
             }
 
-            string outputPath = string.IsNullOrEmpty(OutputPath) ? OutputPath : TaskEnvironment.GetAbsolutePath(OutputPath);
+            AbsolutePath outputPath = string.IsNullOrEmpty(OutputPath) ? default : TaskEnvironment.GetAbsolutePath(OutputPath);
 
-            var launcherBuilder = new LauncherBuilder(LauncherPath);
+            var launcherBuilder = new LauncherBuilder(LauncherPath) { TaskEnvironment = TaskEnvironment };
             string entryPointFileName = Path.GetFileName(EntryPoint.ItemSpec);
 
             // If the EntryPoint specified is apphost.exe or singlefilehost.exe, we need to replace the EntryPoint
@@ -79,7 +79,7 @@ namespace Microsoft.Build.Tasks
                 entryPointFileName = AssemblyName;
             }
 
-            BuildResults results = launcherBuilder.Build(entryPointFileName, outputPath, OutputPath);
+            BuildResults results = launcherBuilder.Build(entryPointFileName, outputPath);
 
             BuildMessage[] messages = results.Messages;
             if (messages != null)

--- a/src/Tasks/GenerateLauncher.cs
+++ b/src/Tasks/GenerateLauncher.cs
@@ -41,17 +41,8 @@ namespace Microsoft.Build.Tasks
         public ITaskItem OutputEntryPoint { get; set; }
         #endregion
 
-        // MSBuildTask0005 (transitive unsafe API) is reported here by the call-graph analyzer
-        // because ResourceUpdater.UpdateResources contains a File.OpenRead call. That branch
-        // only executes when ResourceUpdater._fileResources is non-empty, which happens only
-        // via AddFileResource — and AddFileResource is called exclusively from
-        // BootstrapperBuilder, never from LauncherBuilder (which uses AddStringResource only).
-        // All other I/O reachable from this task — File.Copy, File.Get/SetAttributes,
-        // Directory.CreateDirectory, FileSystems.Default.FileExists/DirectoryExists — receives
-        // an AbsolutePath.Value, and Util.GetDefaultPath is called with an explicit project-
-        // scoped fallback (TaskEnvironment.ProjectDirectory.Value) instead of
-        // Directory.GetCurrentDirectory(). The warning is left unsuppressed so the analyzer
-        // can be improved to track data-flow reachability; see analyzer issue (to be filed).
+        // MSBuildTask0005 (transitive unsafe API) warnings are currently emitted here due to
+        // an analyzer limitation around data-flow reachability. See https://github.com/dotnet/msbuild/issues/13867.
         public override bool Execute()
         {
             if (!NativeMethodsShared.IsWindows)

--- a/src/Tasks/GenerateLauncher.cs
+++ b/src/Tasks/GenerateLauncher.cs
@@ -53,8 +53,11 @@ namespace Microsoft.Build.Tasks
             {
                 // Launcher lives next to ClickOnce bootstrapper.
                 // GetDefaultPath obtains the root ClickOnce boostrapper path.
+                // Pass the project directory as the fallback so we don't depend on
+                // the process-wide current directory in multithreaded execution.
+                string fallbackPath = TaskEnvironment.ProjectDirectory.Value;
                 LauncherPath = Path.Combine(
-                    Microsoft.Build.Tasks.Deployment.Bootstrapper.Util.GetDefaultPath(VisualStudioVersion),
+                    Deployment.Bootstrapper.Util.GetDefaultPath(VisualStudioVersion, fallbackPath),
                     ENGINE_PATH,
                     LAUNCHER_EXE);
             }
@@ -79,7 +82,12 @@ namespace Microsoft.Build.Tasks
                 entryPointFileName = AssemblyName;
             }
 
+            // Suppress MSBuildTask0005: the transitive unsafe-API calls reached via LauncherBuilder.Build
+            // (File.OpenRead is in a dead branch; File.Copy/Get/SetAttributes/CreateDirectory all
+            // receive absolute paths derived from AbsolutePath.Value).
+#pragma warning disable MSBuildTask0005
             BuildResults results = launcherBuilder.Build(entryPointFileName, outputPath);
+#pragma warning restore MSBuildTask0005
 
             BuildMessage[] messages = results.Messages;
             if (messages != null)

--- a/src/Tasks/GenerateLauncher.cs
+++ b/src/Tasks/GenerateLauncher.cs
@@ -64,10 +64,9 @@ namespace Microsoft.Build.Tasks
                 return false;
             }
 
-            string launcherPath = string.IsNullOrEmpty(LauncherPath) ? LauncherPath : TaskEnvironment.GetAbsolutePath(LauncherPath);
             string outputPath = string.IsNullOrEmpty(OutputPath) ? OutputPath : TaskEnvironment.GetAbsolutePath(OutputPath);
 
-            var launcherBuilder = new LauncherBuilder(launcherPath, LauncherPath);
+            var launcherBuilder = new LauncherBuilder(LauncherPath);
             string entryPointFileName = Path.GetFileName(EntryPoint.ItemSpec);
 
             // If the EntryPoint specified is apphost.exe or singlefilehost.exe, we need to replace the EntryPoint

--- a/src/Tasks/GenerateLauncher.cs
+++ b/src/Tasks/GenerateLauncher.cs
@@ -41,6 +41,12 @@ namespace Microsoft.Build.Tasks
         public ITaskItem OutputEntryPoint { get; set; }
         #endregion
 
+        // Suppress MSBuildTask0005 around Execute because the transitive analyzer reports
+        // on the task entry point, not on the LauncherBuilder.Build call below. The
+        // LauncherBuilder.Build paths are safe here:
+        // File.OpenRead is in a dead branch; File.Copy/Get/SetAttributes/CreateDirectory all
+        // receive absolute paths derived from AbsolutePath.Value.
+#pragma warning disable MSBuildTask0005
         public override bool Execute()
         {
             if (!NativeMethodsShared.IsWindows)
@@ -82,12 +88,7 @@ namespace Microsoft.Build.Tasks
                 entryPointFileName = AssemblyName;
             }
 
-            // Suppress MSBuildTask0005: the transitive unsafe-API calls reached via LauncherBuilder.Build
-            // (File.OpenRead is in a dead branch; File.Copy/Get/SetAttributes/CreateDirectory all
-            // receive absolute paths derived from AbsolutePath.Value).
-#pragma warning disable MSBuildTask0005
             BuildResults results = launcherBuilder.Build(entryPointFileName, outputPath);
-#pragma warning restore MSBuildTask0005
 
             BuildMessage[] messages = results.Messages;
             if (messages != null)
@@ -114,5 +115,6 @@ namespace Microsoft.Build.Tasks
 
             return !Log.HasLoggedErrors;
         }
+#pragma warning restore MSBuildTask0005
     }
 }

--- a/src/Tasks/ManifestUtil/LauncherBuilder.cs
+++ b/src/Tasks/ManifestUtil/LauncherBuilder.cs
@@ -22,8 +22,14 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
         private BuildResults _results;
 
         public LauncherBuilder(string launcherPath)
+            : this(launcherPath, launcherPath)
+        {
+        }
+
+        public LauncherBuilder(string launcherPath, string launcherPathForMessages)
         {
             LauncherPath = launcherPath;
+            LauncherPathForMessages = launcherPathForMessages;
         }
 
         /// <summary>
@@ -32,7 +38,14 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
         /// <value>Path to Launcher files.</value>
         public string LauncherPath { get; set; }
 
+        private string LauncherPathForMessages { get; }
+
         public BuildResults Build(string filename, string outputPath)
+        {
+            return Build(filename, outputPath, outputPath);
+        }
+
+        public BuildResults Build(string filename, string outputPath, string outputPathForMessages)
         {
             string launcherFilename = Path.GetFileName(LauncherPath);
 
@@ -53,8 +66,9 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
                 }
 
                 // Copy setup.bin to the output directory
-                string strOutputExe = System.IO.Path.Combine(outputPath, launcherFilename);
-                if (!CopyLauncherToOutputDirectory(strOutputExe))
+                string strOutputExe = Path.Combine(outputPath, launcherFilename);
+                string strOutputExeForMessages = Path.Combine(outputPathForMessages ?? outputPath, launcherFilename);
+                if (!CopyLauncherToOutputDirectory(strOutputExe, strOutputExeForMessages))
                 {
                     // Appropriate messages should have been stuffed into the results already
                     return _results;
@@ -78,11 +92,11 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
             return _results;
         }
 
-        private bool CopyLauncherToOutputDirectory(string strOutputExe)
+        private bool CopyLauncherToOutputDirectory(string strOutputExe, string strOutputExeForMessages)
         {
             if (!FileSystems.Default.FileExists(LauncherPath))
             {
-                _results.AddMessage(BuildMessage.CreateMessage(BuildMessageSeverity.Error, "GenerateLauncher.MissingLauncherExe", LauncherPath));
+                _results.AddMessage(BuildMessage.CreateMessage(BuildMessageSeverity.Error, "GenerateLauncher.MissingLauncherExe", LauncherPathForMessages));
                 return false;
             }
 
@@ -94,7 +108,7 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
             }
             catch (Exception ex) when (ExceptionHandling.IsIoRelatedException(ex))
             {
-                _results.AddMessage(BuildMessage.CreateMessage(BuildMessageSeverity.Error, "GenerateLauncher.CopyError", LauncherPath, strOutputExe, ex.Message));
+                _results.AddMessage(BuildMessage.CreateMessage(BuildMessageSeverity.Error, "GenerateLauncher.CopyError", LauncherPathForMessages, strOutputExeForMessages, ex.Message));
                 return false;
             }
 

--- a/src/Tasks/ManifestUtil/LauncherBuilder.cs
+++ b/src/Tasks/ManifestUtil/LauncherBuilder.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
         {
         }
 
-        public LauncherBuilder(string launcherPath, string launcherPathForMessages)
+        internal LauncherBuilder(string launcherPath, string launcherPathForMessages)
         {
             LauncherPath = launcherPath;
             LauncherPathForMessages = launcherPathForMessages;
@@ -45,7 +45,7 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
             return Build(filename, outputPath, outputPath);
         }
 
-        public BuildResults Build(string filename, string outputPath, string outputPathForMessages)
+        internal BuildResults Build(string filename, string outputPath, string outputPathForMessages)
         {
             string launcherFilename = Path.GetFileName(LauncherPath);
 

--- a/src/Tasks/ManifestUtil/LauncherBuilder.cs
+++ b/src/Tasks/ManifestUtil/LauncherBuilder.cs
@@ -60,12 +60,13 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
 
                 AbsolutePath launcherPath = string.IsNullOrEmpty(LauncherPath) ? default : TaskEnvironment.GetAbsolutePath(LauncherPath);
                 string launcherPathForFileSystem = launcherPath.Value ?? LauncherPath;
+                string launcherPathForMessages = launcherPath.OriginalValue ?? LauncherPath;
                 string launcherFilename = Path.GetFileName(launcherPathForFileSystem);
 
                 // Copy setup.bin to the output directory
                 string strOutputExe = Path.Combine(outputPath.Value, launcherFilename);
                 string strOutputExeForMessages = Path.Combine(outputPath.OriginalValue, launcherFilename);
-                if (!CopyLauncherToOutputDirectory(launcherPath, launcherPathForFileSystem, strOutputExe, strOutputExeForMessages))
+                if (!CopyLauncherToOutputDirectory(launcherPathForFileSystem, launcherPathForMessages, strOutputExe, strOutputExeForMessages))
                 {
                     // Appropriate messages should have been stuffed into the results already
                     return _results;
@@ -73,7 +74,7 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
 
                 var resourceUpdater = new ResourceUpdater();
                 resourceUpdater.AddStringResource(LAUNCHER_RESOURCE_TABLE, LAUNCHER_RESOURCENAME, filename);
-                if (!resourceUpdater.UpdateResources(strOutputExe, _results))
+                if (!resourceUpdater.UpdateResources(strOutputExe, _results, strOutputExeForMessages))
                 {
                     return _results;
                 }
@@ -89,10 +90,8 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
             return _results;
         }
 
-        private bool CopyLauncherToOutputDirectory(AbsolutePath launcherPath, string launcherPathForFileSystem, string strOutputExe, string strOutputExeForMessages)
+        private bool CopyLauncherToOutputDirectory(string launcherPathForFileSystem, string launcherPathForMessages, string strOutputExe, string strOutputExeForMessages)
         {
-            string launcherPathForMessages = launcherPath.OriginalValue ?? LauncherPath;
-
             if (!FileSystems.Default.FileExists(launcherPathForFileSystem))
             {
                 _results.AddMessage(BuildMessage.CreateMessage(BuildMessageSeverity.Error, "GenerateLauncher.MissingLauncherExe", launcherPathForMessages));

--- a/src/Tasks/ManifestUtil/LauncherBuilder.cs
+++ b/src/Tasks/ManifestUtil/LauncherBuilder.cs
@@ -31,8 +31,13 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
         /// </summary>
         /// <value>Path to Launcher files.</value>
         public string LauncherPath { get; set; }
+        internal TaskEnvironment TaskEnvironment { get; }
 
-        internal TaskEnvironment TaskEnvironment { get; set; } = TaskEnvironment.Fallback;
+        internal LauncherBuilder(string launcherPath, TaskEnvironment taskEnvironment)
+        {
+            LauncherPath = launcherPath;
+            TaskEnvironment = taskEnvironment;
+        }
 
         public BuildResults Build(string filename, string outputPath)
         {
@@ -59,14 +64,14 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
                 }
 
                 AbsolutePath launcherPath = string.IsNullOrEmpty(LauncherPath) ? default : TaskEnvironment.GetAbsolutePath(LauncherPath);
-                string launcherPathForFileSystem = launcherPath.Value ?? LauncherPath;
-                string launcherPathForMessages = launcherPath.OriginalValue ?? LauncherPath;
-                string launcherFilename = Path.GetFileName(launcherPathForFileSystem);
+                string launcherFilename = Path.GetFileName(launcherPath.Value ?? LauncherPath);
 
-                // Copy setup.bin to the output directory
-                string strOutputExe = Path.Combine(outputPath.Value, launcherFilename);
-                string strOutputExeForMessages = Path.Combine(outputPath.OriginalValue, launcherFilename);
-                if (!CopyLauncherToOutputDirectory(launcherPathForFileSystem, launcherPathForMessages, strOutputExe, strOutputExeForMessages))
+                // Copy setup.bin to the output directory.
+                AbsolutePath outputExe = new AbsolutePath(
+                    Path.Combine(outputPath.Value, launcherFilename),
+                    Path.Combine(outputPath.OriginalValue, launcherFilename),
+                    ignoreRootedCheck: true);
+                if (!CopyLauncherToOutputDirectory(launcherPath, outputExe))
                 {
                     // Appropriate messages should have been stuffed into the results already
                     return _results;
@@ -74,7 +79,7 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
 
                 var resourceUpdater = new ResourceUpdater();
                 resourceUpdater.AddStringResource(LAUNCHER_RESOURCE_TABLE, LAUNCHER_RESOURCENAME, filename);
-                if (!resourceUpdater.UpdateResources(strOutputExe, _results, strOutputExeForMessages))
+                if (!resourceUpdater.UpdateResources(outputExe, _results))
                 {
                     return _results;
                 }
@@ -90,23 +95,23 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
             return _results;
         }
 
-        private bool CopyLauncherToOutputDirectory(string launcherPathForFileSystem, string launcherPathForMessages, string strOutputExe, string strOutputExeForMessages)
+        private bool CopyLauncherToOutputDirectory(AbsolutePath launcher, AbsolutePath outputExe)
         {
-            if (!FileSystems.Default.FileExists(launcherPathForFileSystem))
+            if (!FileSystems.Default.FileExists(launcher.Value))
             {
-                _results.AddMessage(BuildMessage.CreateMessage(BuildMessageSeverity.Error, "GenerateLauncher.MissingLauncherExe", launcherPathForMessages));
+                _results.AddMessage(BuildMessage.CreateMessage(BuildMessageSeverity.Error, "GenerateLauncher.MissingLauncherExe", launcher.OriginalValue));
                 return false;
             }
 
             try
             {
-                EnsureFolderExists(Path.GetDirectoryName(strOutputExe));
-                File.Copy(launcherPathForFileSystem, strOutputExe, true);
-                ClearReadOnlyAttribute(strOutputExe);
+                EnsureFolderExists(Path.GetDirectoryName(outputExe.Value));
+                File.Copy(launcher.Value, outputExe.Value, true);
+                ClearReadOnlyAttribute(outputExe.Value);
             }
             catch (Exception ex) when (ExceptionHandling.IsIoRelatedException(ex))
             {
-                _results.AddMessage(BuildMessage.CreateMessage(BuildMessageSeverity.Error, "GenerateLauncher.CopyError", launcherPathForMessages, strOutputExeForMessages, ex.Message));
+                _results.AddMessage(BuildMessage.CreateMessage(BuildMessageSeverity.Error, "GenerateLauncher.CopyError", launcher.OriginalValue, outputExe.OriginalValue, ex.Message));
                 return false;
             }
 

--- a/src/Tasks/ManifestUtil/LauncherBuilder.cs
+++ b/src/Tasks/ManifestUtil/LauncherBuilder.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
         /// </summary>
         /// <value>Path to Launcher files.</value>
         public string LauncherPath { get; set; }
-        internal TaskEnvironment TaskEnvironment { get; }
+        internal TaskEnvironment TaskEnvironment { get; } = TaskEnvironment.Fallback;
 
         internal LauncherBuilder(string launcherPath, TaskEnvironment taskEnvironment)
         {
@@ -64,7 +64,7 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
                 }
 
                 AbsolutePath launcherPath = string.IsNullOrEmpty(LauncherPath) ? default : TaskEnvironment.GetAbsolutePath(LauncherPath);
-                string launcherFilename = Path.GetFileName(launcherPath.Value ?? LauncherPath);
+                string launcherFilename = Path.GetFileName(LauncherPath);
 
                 // Copy setup.bin to the output directory.
                 AbsolutePath outputExe = new AbsolutePath(

--- a/src/Tasks/ManifestUtil/LauncherBuilder.cs
+++ b/src/Tasks/ManifestUtil/LauncherBuilder.cs
@@ -22,14 +22,8 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
         private BuildResults _results;
 
         public LauncherBuilder(string launcherPath)
-            : this(launcherPath, launcherPath)
-        {
-        }
-
-        internal LauncherBuilder(string launcherPath, string launcherPathForMessages)
         {
             LauncherPath = launcherPath;
-            LauncherPathForMessages = launcherPathForMessages;
         }
 
         /// <summary>
@@ -38,17 +32,16 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
         /// <value>Path to Launcher files.</value>
         public string LauncherPath { get; set; }
 
-        private string LauncherPathForMessages { get; }
+        internal TaskEnvironment TaskEnvironment { get; set; } = TaskEnvironment.Fallback;
 
         public BuildResults Build(string filename, string outputPath)
         {
-            return Build(filename, outputPath, outputPath);
+            AbsolutePath path = string.IsNullOrEmpty(outputPath) ? default : TaskEnvironment.GetAbsolutePath(outputPath);
+            return Build(filename, path);
         }
 
-        internal BuildResults Build(string filename, string outputPath, string outputPathForMessages)
+        internal BuildResults Build(string filename, AbsolutePath outputPath)
         {
-            string launcherFilename = Path.GetFileName(LauncherPath);
-
             _results = new BuildResults();
 
             try
@@ -59,16 +52,20 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
                     return _results;
                 }
 
-                if (String.IsNullOrEmpty(outputPath))
+                if (String.IsNullOrEmpty(outputPath.Value))
                 {
                     _results.AddMessage(BuildMessage.CreateMessage(BuildMessageSeverity.Error, "GenerateLauncher.NoOutputPath"));
                     return _results;
                 }
 
+                AbsolutePath launcherPath = string.IsNullOrEmpty(LauncherPath) ? default : TaskEnvironment.GetAbsolutePath(LauncherPath);
+                string launcherPathForFileSystem = launcherPath.Value ?? LauncherPath;
+                string launcherFilename = Path.GetFileName(launcherPathForFileSystem);
+
                 // Copy setup.bin to the output directory
-                string strOutputExe = Path.Combine(outputPath, launcherFilename);
-                string strOutputExeForMessages = Path.Combine(outputPathForMessages ?? outputPath, launcherFilename);
-                if (!CopyLauncherToOutputDirectory(strOutputExe, strOutputExeForMessages))
+                string strOutputExe = Path.Combine(outputPath.Value, launcherFilename);
+                string strOutputExeForMessages = Path.Combine(outputPath.OriginalValue, launcherFilename);
+                if (!CopyLauncherToOutputDirectory(launcherPath, launcherPathForFileSystem, strOutputExe, strOutputExeForMessages))
                 {
                     // Appropriate messages should have been stuffed into the results already
                     return _results;
@@ -92,23 +89,25 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
             return _results;
         }
 
-        private bool CopyLauncherToOutputDirectory(string strOutputExe, string strOutputExeForMessages)
+        private bool CopyLauncherToOutputDirectory(AbsolutePath launcherPath, string launcherPathForFileSystem, string strOutputExe, string strOutputExeForMessages)
         {
-            if (!FileSystems.Default.FileExists(LauncherPath))
+            string launcherPathForMessages = launcherPath.OriginalValue ?? LauncherPath;
+
+            if (!FileSystems.Default.FileExists(launcherPathForFileSystem))
             {
-                _results.AddMessage(BuildMessage.CreateMessage(BuildMessageSeverity.Error, "GenerateLauncher.MissingLauncherExe", LauncherPathForMessages));
+                _results.AddMessage(BuildMessage.CreateMessage(BuildMessageSeverity.Error, "GenerateLauncher.MissingLauncherExe", launcherPathForMessages));
                 return false;
             }
 
             try
             {
                 EnsureFolderExists(Path.GetDirectoryName(strOutputExe));
-                File.Copy(LauncherPath, strOutputExe, true);
+                File.Copy(launcherPathForFileSystem, strOutputExe, true);
                 ClearReadOnlyAttribute(strOutputExe);
             }
             catch (Exception ex) when (ExceptionHandling.IsIoRelatedException(ex))
             {
-                _results.AddMessage(BuildMessage.CreateMessage(BuildMessageSeverity.Error, "GenerateLauncher.CopyError", LauncherPathForMessages, strOutputExeForMessages, ex.Message));
+                _results.AddMessage(BuildMessage.CreateMessage(BuildMessageSeverity.Error, "GenerateLauncher.CopyError", launcherPathForMessages, strOutputExeForMessages, ex.Message));
                 return false;
             }
 


### PR DESCRIPTION
Fixes #13628

### Context

`GenerateLauncher` delegates to `LauncherBuilder` for file copy/patching. Both `LauncherPath` and `OutputPath` were resolved relative to the process working directory, which is unsafe under multithreaded execution.

### Changes Made

- **`GenerateLauncher.cs`**: Added `[MSBuildMultiThreadableTask]` + `IMultiThreadableTask`. Absolutized `LauncherPath`/`OutputPath` via `TaskEnvironment.GetAbsolutePath()`, preserving originals for messages and outputs.
- **`LauncherBuilder.cs`**: Added internal overloads accepting separate "for messages" paths to keep error messages user-friendly. Public API unchanged.

### Testing

- Build clean, no new warnings.
- Sin 1 verified: no absolutized paths leak into `[Output]`.
- Sin 2 verified: error messages use original paths.