### PR TITLE
Introduce mode for project graph construction to load entire graph 

### DIFF
--- a/src/Build.UnitTests/Graph/ProjectGraph_Tests.cs
+++ b/src/Build.UnitTests/Graph/ProjectGraph_Tests.cs
@@ -14,6 +14,7 @@ using Microsoft.Build.Exceptions;
 using Microsoft.Build.Execution;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
+using Microsoft.Build.Tasks;
 using Microsoft.Build.UnitTests;
 using Shouldly;
 using Xunit;
@@ -3001,6 +3002,142 @@ $@"
             bool mentionsProject1 = innerException.Message.Contains(project1.Path);
             bool mentionsProject2 = innerException.Message.Contains(project2.Path);
             (mentionsProject1 || mentionsProject2).ShouldBeTrue();
+        }
+
+        [Fact]
+        public void FullGraphModeLoadsAllTargetFrameworksIgnoringSetTargetFramework()
+        {
+            using var env = TestEnvironment.Create();
+
+            TransientTestFile project1 = env.CreateFile("project1.proj", """
+                <Project>
+                  <PropertyGroup>
+                    <TargetFrameworks>net472;net10.0</TargetFrameworks>
+                    <InnerBuildProperty>TargetFramework</InnerBuildProperty>
+                    <InnerBuildPropertyValues>TargetFrameworks</InnerBuildPropertyValues>
+                  </PropertyGroup>
+                </Project>
+                """);
+
+            TransientTestFile project2 = env.CreateFile("project2.proj", $"""
+                <Project>
+                  <PropertyGroup>
+                    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+                  </PropertyGroup>
+                  <ItemGroup>
+                    <ProjectReference Include="{project1.Path}">
+                      <SetTargetFramework>TargetFramework=net472</SetTargetFramework>
+                    </ProjectReference>
+                  </ItemGroup>
+                </Project>
+                """);
+
+            var projectGraph = new ProjectGraph(
+                new ProjectGraphOptions
+                {
+                    EntryPoints = [new ProjectGraphEntryPoint(project2.Path)],
+                    Mode = ProjectGraphMode.Full
+                });
+
+            var sorted = projectGraph.ProjectNodesTopologicallySorted.ToList();
+
+            // In Full mode, all target frameworks should be loaded despite SetTargetFramework constraint
+            sorted.Count.ShouldBe(4);
+
+            // Find the inner builds for net10.0 and net472
+            var net10Build = sorted.FirstOrDefault(n => n.ProjectInstance.FullPath == project1.Path &&
+                n.ProjectInstance.GlobalProperties.TryGetValue("TargetFramework", out var tf) && tf == "net10.0");
+            net10Build.ShouldNotBeNull("Should load inner build for net10.0");
+            net10Build.ProjectType.ShouldBe(ProjectInterpretation.ProjectType.InnerBuild);
+            net10Build.ProjectReferences.ShouldBeEmpty();
+
+            var net472Build = sorted.FirstOrDefault(n => n.ProjectInstance.FullPath == project1.Path &&
+                n.ProjectInstance.GlobalProperties.TryGetValue("TargetFramework", out var tf) && tf == "net472");
+            net472Build.ShouldNotBeNull("Should load inner build for net472");
+            net472Build.ProjectType.ShouldBe(ProjectInterpretation.ProjectType.InnerBuild);
+            net472Build.ProjectReferences.ShouldBeEmpty();
+
+            var outerBuild = sorted.FirstOrDefault(n => n.ProjectInstance.FullPath == project1.Path &&
+                !n.ProjectInstance.GlobalProperties.ContainsKey("TargetFramework"));
+            outerBuild.ShouldNotBeNull("Should load outer build");
+            outerBuild.ProjectType.ShouldBe(ProjectInterpretation.ProjectType.OuterBuild);
+            outerBuild.ProjectReferences.Count.ShouldBe(2); // References to the two inner builds
+
+            var project2Node = sorted.FirstOrDefault(n => n.ProjectInstance.FullPath == project2.Path);
+            project2Node.ShouldNotBeNull("Should load project2");
+            project2Node.ProjectType.ShouldBe(ProjectInterpretation.ProjectType.NonMultitargeting);
+            project2Node.ProjectReferences.Count.ShouldBe(3); // References to outer build and two inner builds of project1
+        }
+
+        [Fact]
+        public void FullGraphModeIgnoresSetTargetFrameworkForSingleTargetProject()
+        {
+            using var env = TestEnvironment.Create();
+
+            TransientTestFile project1 = env.CreateFile("project1.proj", """
+                <Project>
+                  <PropertyGroup>
+                    <TargetFramework>net10.0</TargetFramework>
+                  </PropertyGroup>
+                </Project>
+                """);
+
+            TransientTestFile project2 = env.CreateFile("project2.proj", $"""
+                <Project>
+                  <ItemGroup>
+                    <ProjectReference Include="{project1.Path}">
+                      <SetTargetFramework>TargetFramework=net472</SetTargetFramework>
+                    </ProjectReference>
+                  </ItemGroup>
+                </Project>
+                """);
+
+            var projectGraph = new ProjectGraph(
+                new ProjectGraphOptions
+                {
+                    EntryPoints = [new ProjectGraphEntryPoint(project2.Path)],
+                    Mode = ProjectGraphMode.Full
+                });
+
+            var sorted = projectGraph.ProjectNodesTopologicallySorted.ToList();
+            sorted.Count.ShouldBe(2);
+
+            var project1Node = sorted.FirstOrDefault(n => n.ProjectInstance.FullPath == project1.Path);
+            project1Node.ShouldNotBeNull("Should load the referenced single-target project");
+            project1Node.ProjectType.ShouldBe(ProjectInterpretation.ProjectType.NonMultitargeting);
+            project1Node.ProjectInstance.GlobalProperties.ContainsKey("TargetFramework").ShouldBeFalse();
+
+            var project2Node = sorted.FirstOrDefault(n => n.ProjectInstance.FullPath == project2.Path);
+            project2Node.ShouldNotBeNull("Should load the entry project");
+            project2Node.ProjectReferences.ShouldHaveSingleItem();
+            project2Node.ProjectReferences.Single().ShouldBe(project1Node);
+        }
+
+        [Fact]
+        public void ConstructWithProjectGraphOptionsAndNullEntryPointsThrows()
+        {
+            var exception = Should.Throw<ArgumentNullException>(() => new ProjectGraph(
+                new ProjectGraphOptions
+                {
+                    EntryPoints = null
+                }));
+
+            exception.ParamName.ShouldBe("EntryPoints");
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(-1)]
+        public void ConstructWithProjectGraphOptionsAndNonPositiveDegreeOfParallelismThrows(int degreeOfParallelism)
+        {
+            var exception = Should.Throw<ArgumentOutOfRangeException>(() => new ProjectGraph(
+                new ProjectGraphOptions
+                {
+                    EntryPoints = Enumerable.Empty<ProjectGraphEntryPoint>(),
+                    DegreeOfParallelism = degreeOfParallelism
+                }));
+
+            exception.ParamName.ShouldBe("DegreeOfParallelism");
         }
 
         public void Dispose()

--- a/src/Build.UnitTests/Graph/ProjectGraph_Tests.cs
+++ b/src/Build.UnitTests/Graph/ProjectGraph_Tests.cs
@@ -1037,8 +1037,17 @@ namespace Microsoft.Build.Graph.UnitTests
             using (var env = TestEnvironment.Create())
             {
                 // Root project has no default targets.
-                // The project file does not contain any targets
-                TransientTestFile entryProject = CreateProjectFile(env: env, projectNumber: 1, projectReferences: new[] { 2 }, projectReferenceTargets: new Dictionary<string, string[]> { { "A", new[] { "B" } } }, defaultTargets: string.Empty);
+                // The project file does not contain any targets, so it is created inline rather than via the
+                // CreateProjectFile helper (which always injects a 'Build' target).
+                TransientTestFile entryProject = env.CreateFile("1.proj", @"
+<Project>
+  <ItemGroup>
+    <ProjectReference Include=""2.proj"" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReferenceTargets Include=""A"" Targets=""B"" />
+  </ItemGroup>
+</Project>");
 
                 // Dependency has default targets. Even though it gets called with empty targets, B will not get called,
                 // because target propagation only equates empty targets to default targets for the root nodes.
@@ -2671,6 +2680,16 @@ $@"
                 {
                     { 1, new[] { 2 } },
                 },
+                // Give each project an explicit default target so the helper's auto-injected 'Build' target
+                // (which is emitted first and would otherwise become the default) does not hide it.
+                createProjectFile: (env, projectNumber, projectReferences, projectReferenceTargets, defaultTargets, extraContent) =>
+                    Helpers.CreateProjectFile(
+                        env,
+                        projectNumber,
+                        projectReferences,
+                        projectReferenceTargets,
+                        defaultTargets: $"SomeDefaultTarget{projectNumber}",
+                        extraContent: extraContent),
                 extraContentPerProjectNumber: new Dictionary<int, string>()
                 {
                     {
@@ -2684,13 +2703,7 @@ $@"
 <ItemGroup>
     <ProjectReferenceTargets Include='SomeDefaultTarget1' Targets='{MSBuildConstants.ProjectReferenceTargetsOrDefaultTargetsMarker}' />
 </ItemGroup>
-
-<Target Name='SomeDefaultTarget1' />
 "
-                    },
-                    {
-                        2,
-                        @"<Target Name='SomeDefaultTarget2' />"
                     }
                 });
 
@@ -2713,6 +2726,16 @@ $@"
                 {
                     {1, new[] {2}},
                 },
+                // Give each project an explicit default target so the helper's auto-injected 'Build' target
+                // (which is emitted first and would otherwise become the default) does not hide it.
+                createProjectFile: (env, projectNumber, projectReferences, projectReferenceTargets, defaultTargets, extraContent) =>
+                    Helpers.CreateProjectFile(
+                        env,
+                        projectNumber,
+                        projectReferences,
+                        projectReferenceTargets,
+                        defaultTargets: $"SomeDefaultTarget{projectNumber}",
+                        extraContent: extraContent),
                 extraContentPerProjectNumber: new Dictionary<int, string>()
                 {
                     {
@@ -2726,13 +2749,7 @@ $@"
 <ItemGroup>
     <ProjectReferenceTargets Include='SomeDefaultTarget1' Targets='{MSBuildConstants.ProjectReferenceTargetsOrDefaultTargetsMarker}' />
 </ItemGroup>
-
-<Target Name='SomeDefaultTarget1' />
 "
-                    },
-                    {
-                        2,
-                        @"<Target Name='SomeDefaultTarget2' />"
                     }
                 });
 

--- a/src/Build/Graph/GraphBuilder.cs
+++ b/src/Build/Graph/GraphBuilder.cs
@@ -50,6 +50,7 @@ namespace Microsoft.Build.Graph
         private readonly ProjectInterpretation _projectInterpretation;
 
         private readonly ProjectGraph.ProjectInstanceFactoryFunc _projectInstanceFactory;
+        private readonly ProjectGraphMode _graphMode;
         private IReadOnlyDictionary<string, IReadOnlyCollection<string>> _solutionDependencies;
         private ConcurrentDictionary<ConfigurationMetadata, Lazy<ProjectInstance>> _platformNegotiationInstancesCache = new();
 
@@ -67,6 +68,7 @@ namespace Microsoft.Build.Graph
             ProjectGraph.ProjectInstanceFactoryFunc projectInstanceFactory,
             ProjectInterpretation projectInterpretation,
             int degreeOfParallelism,
+            ProjectGraphMode mode,
             CancellationToken cancellationToken)
         {
             var (actualEntryPoints, solutionDependencies) = ExpandSolutionIfPresent(entryPoints.ToImmutableArray());
@@ -85,6 +87,7 @@ namespace Microsoft.Build.Graph
             _projectCollection = projectCollection;
             _projectInstanceFactory = projectInstanceFactory;
             _projectInterpretation = projectInterpretation;
+            _graphMode = mode;
         }
 
         public void BuildGraph()
@@ -615,7 +618,7 @@ namespace Microsoft.Build.Graph
         {
             var referenceInfos = new List<ProjectInterpretation.ReferenceInfo>();
 
-            foreach (var referenceInfo in _projectInterpretation.GetReferences(parsedProject, _projectCollection, GetInstanceForPlatformNegotiationWithCaching))
+            foreach (var referenceInfo in _projectInterpretation.GetReferences(parsedProject, _projectCollection, GetInstanceForPlatformNegotiationWithCaching, _graphMode))
             {
                 if (FileUtilities.IsSolutionFilename(referenceInfo.ReferenceConfiguration.ProjectFullPath))
                 {

--- a/src/Build/Graph/ProjectGraph.cs
+++ b/src/Build/Graph/ProjectGraph.cs
@@ -420,10 +420,38 @@ namespace Microsoft.Build.Graph
             ProjectInstanceFactoryFunc projectInstanceFactory,
             int degreeOfParallelism,
             CancellationToken cancellationToken)
+            : this(new ProjectGraphOptions
+                    {
+                        EntryPoints = entryPoints,
+                        ProjectCollection = projectCollection,
+                        ProjectInstanceFactoryFunc = projectInstanceFactory,
+                        DegreeOfParallelism = degreeOfParallelism
+                    },
+                  cancellationToken)
         {
-            ArgumentNullException.ThrowIfNull(projectCollection);
+        }
+
+        /// <summary>
+        /// Constructs a graph starting from the given graph options.
+        /// </summary>
+        /// <param name="options">A <see cref="ProjectGraphOptions" /> containing the entry projects, project collection, and other details about the graph.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> to observe.</param>
+        /// <exception cref="InvalidProjectFileException">If the evaluation of any project in the graph fails.</exception>
+        /// <exception cref="CircularDependencyException">If the evaluation is successful but the project graph contains a circular dependency.</exception>
+        public ProjectGraph(
+            ProjectGraphOptions options,
+            CancellationToken cancellationToken = default)
+        {
+            ArgumentNullException.ThrowIfNull(options.ProjectCollection, nameof(options.ProjectCollection));
+            ArgumentNullException.ThrowIfNull(options.EntryPoints, nameof(options.EntryPoints));
+            if (options.DegreeOfParallelism <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(options.DegreeOfParallelism), "DegreeOfParallelism must be greater than zero.");
+            }
 
             var measurementInfo = BeginMeasurement();
+
+            ProjectInstanceFactoryFunc projectInstanceFactory = options.ProjectInstanceFactoryFunc;
 
             if (projectInstanceFactory is null)
             {
@@ -432,11 +460,12 @@ namespace Microsoft.Build.Graph
             }
 
             var graphBuilder = new GraphBuilder(
-                entryPoints,
-                projectCollection,
+                options.EntryPoints,
+                options.ProjectCollection,
                 projectInstanceFactory,
                 ProjectInterpretation.Instance,
-                degreeOfParallelism,
+                options.DegreeOfParallelism,
+                options.Mode,
                 cancellationToken);
             graphBuilder.BuildGraph();
 
@@ -456,7 +485,7 @@ namespace Microsoft.Build.Graph
 
                 if (MSBuildEventSource.Log.IsEnabled())
                 {
-                    etwArgs = string.Join(";", entryPoints.Select(
+                    etwArgs = string.Join(";", options.EntryPoints.Select(
                         e =>
                         {
                             var globalPropertyString = e.GlobalProperties == null

--- a/src/Build/Graph/ProjectGraphOptions.cs
+++ b/src/Build/Graph/ProjectGraphOptions.cs
@@ -1,0 +1,55 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using Microsoft.Build.Evaluation;
+
+namespace Microsoft.Build.Graph
+{
+    /// <summary>
+    /// Represents the mode to use when constructing a <see cref="ProjectGraph"/>.
+    /// </summary>
+    public enum ProjectGraphMode
+    {
+        /// <summary>
+        /// Loads only the projects needed for a build, as specified by the entry points. This is the default mode.
+        /// </summary>
+        Default = 0,
+
+        /// <summary>
+        /// Loads a complete representation of the graph, even if they are not needed for the build.
+        /// </summary>
+        Full = 1,
+    }
+
+    /// <summary>
+    /// Represents options to use when constructing a <see cref="ProjectGraph" />.
+    /// </summary>
+    public readonly struct ProjectGraphOptions()
+    {
+        /// <summary>
+        /// The degree of parallelism to use when constructing the graph. Defaults to the number of logical cores on the machine.
+        /// </summary>
+        public int DegreeOfParallelism { get; init; } = NativeMethodsShared.GetLogicalCoreCount();
+
+        /// <summary>
+        /// A list of <see cref="ProjectGraphEntryPoint" /> objects representing the entry points to use when constructing the graph.
+        /// </summary>
+        public required IEnumerable<ProjectGraphEntryPoint> EntryPoints { get; init; }
+
+        /// <summary>
+        /// The <see cref="ProjectGraphMode" /> to use when constructing the graph. Defaults to <see cref="ProjectGraphMode.Default" />.
+        /// </summary>
+        public ProjectGraphMode Mode { get; init; } = ProjectGraphMode.Default;
+
+        /// <summary>
+        /// The <see cref="ProjectCollection" /> to load projects into when constructing the graph. Defaults to <see cref="ProjectCollection.GlobalProjectCollection" />.
+        /// </summary>
+        public ProjectCollection ProjectCollection { get; init; } = ProjectCollection.GlobalProjectCollection;
+
+        /// <summary>
+        /// An optional <see cref="ProjectGraph.ProjectInstanceFactoryFunc" /> to use when evaluating individual projects in the graph.
+        /// </summary>
+        public ProjectGraph.ProjectInstanceFactoryFunc? ProjectInstanceFactoryFunc { get; init; }
+    }
+}

--- a/src/Build/Graph/ProjectInterpretation.cs
+++ b/src/Build/Graph/ProjectInterpretation.cs
@@ -72,7 +72,7 @@ namespace Microsoft.Build.Graph
             public bool SkipIfNonexistent { get; }
         }
 
-        public IEnumerable<ReferenceInfo> GetReferences(ProjectGraphNode projectGraphNode, ProjectCollection projectCollection, ProjectGraph.ProjectInstanceFactoryFunc projectInstanceFactory)
+        public IEnumerable<ReferenceInfo> GetReferences(ProjectGraphNode projectGraphNode, ProjectCollection projectCollection, ProjectGraph.ProjectInstanceFactoryFunc projectInstanceFactory, ProjectGraphMode graphMode)
         {
             IEnumerable<ProjectItemInstance> projectReferenceItems;
             IEnumerable<GlobalPropertiesModifier> globalPropertiesModifiers = null;
@@ -195,6 +195,48 @@ namespace Microsoft.Build.Graph
                 }
 
                 var referenceConfig = new ConfigurationMetadata(projectReferenceFullPath, referenceGlobalProperties);
+
+                // When in Full graph mode, enumerate all target frameworks regardless of SetTargetFramework
+                if (graphMode == ProjectGraphMode.Full && projectReferenceItem.HasMetadata(SetTargetFrameworkMetadataName))
+                {
+                    // Evaluate the referenced project with no global properties to discover all its target frameworks
+                    var projectInstanceForDiscovery = projectInstanceFactory(
+                        projectReferenceFullPath,
+                        null,
+                        projectCollection);
+
+                    string targetFrameworksValue = projectInstanceForDiscovery.GetPropertyValue(PropertyNames.TargetFrameworks);
+
+                    // If the project has multiple target frameworks, yield the outer build only
+                    // The normal ConstructInnerBuildReferences logic will discover and create all inner builds
+                    if (!string.IsNullOrWhiteSpace(targetFrameworksValue))
+                    {
+                        // Create outer build reference by removing TargetFramework from the global properties
+                        // This allows all inner builds to be discovered while respecting other modifiers
+                        var outerBuildProperties = new PropertyDictionary<ProjectPropertyInstance>(referenceGlobalProperties);
+                        outerBuildProperties.Remove("TargetFramework");
+                        
+                        // Yield only the outer build (no TargetFramework override)
+                        // The ConstructInnerBuildReferences logic will discover and create the inner builds
+                        yield return new ReferenceInfo(new ConfigurationMetadata(projectReferenceFullPath, outerBuildProperties), projectReferenceItem);
+                        
+                        continue;
+                    }
+                    else
+                    {
+                        string targetFrameworkValue = projectInstanceForDiscovery.GetPropertyValue(PropertyNames.TargetFramework);
+                        
+                        // Single target framework project - yield it without SetTargetFramework constraint
+                        if (!string.IsNullOrWhiteSpace(targetFrameworkValue))
+                        {
+                            // Remove TargetFramework that was set by SetTargetFramework metadata
+                            var singleTargetProperties = new PropertyDictionary<ProjectPropertyInstance>(referenceGlobalProperties);
+                            singleTargetProperties.Remove("TargetFramework");
+                            yield return new ReferenceInfo(new ConfigurationMetadata(projectReferenceFullPath, singleTargetProperties), projectReferenceItem);
+                            continue;
+                        }
+                    }
+                }
 
                 yield return new ReferenceInfo(referenceConfig, projectReferenceItem);
 

--- a/src/Build/Graph/ProjectInterpretation.cs
+++ b/src/Build/Graph/ProjectInterpretation.cs
@@ -214,7 +214,7 @@ namespace Microsoft.Build.Graph
                         // Create outer build reference by removing TargetFramework from the global properties
                         // This allows all inner builds to be discovered while respecting other modifiers
                         var outerBuildProperties = new PropertyDictionary<ProjectPropertyInstance>(referenceGlobalProperties);
-                        outerBuildProperties.Remove("TargetFramework");
+                        outerBuildProperties.Remove(PropertyNames.TargetFramework);
                         
                         // Yield only the outer build (no TargetFramework override)
                         // The ConstructInnerBuildReferences logic will discover and create the inner builds
@@ -231,7 +231,7 @@ namespace Microsoft.Build.Graph
                         {
                             // Remove TargetFramework that was set by SetTargetFramework metadata
                             var singleTargetProperties = new PropertyDictionary<ProjectPropertyInstance>(referenceGlobalProperties);
-                            singleTargetProperties.Remove("TargetFramework");
+                            singleTargetProperties.Remove(PropertyNames.TargetFramework);
                             yield return new ReferenceInfo(new ConfigurationMetadata(projectReferenceFullPath, singleTargetProperties), projectReferenceItem);
                             continue;
                         }

--- a/src/Build/Microsoft.Build.csproj
+++ b/src/Build/Microsoft.Build.csproj
@@ -226,6 +226,7 @@
     <Compile Include="Evaluation\PropertyTrackingEvaluatorDataWrapper.cs" />
     <Compile Include="Graph\GraphBuilder.cs" />
     <Compile Include="Graph\ParallelWorkSet.cs" />
+    <Compile Include="Graph\ProjectGraphOptions.cs" />
     <Compile Include="Graph\ProjectInterpretation.cs" />
     <Compile Include="Graph\GraphBuildResult.cs" />
     <Compile Include="Graph\GraphBuildSubmission.cs" />


### PR DESCRIPTION
Enables accurate NuGet package dependency resolution across all target frameworks and configurations.

### Context

NuGet Package Manager needs to resolve package dependencies for restore operations. The current ProjectGraphMode.Default only loads projects needed for a specific build, which would require separate graph constructions for each target framework. By providing a complete graph that includes all outer and inner builds regardless of SetTargetFramework constraints, NuGet can efficiently perform package resolution in a single pass. This is especially important for multi-targeted projects where different frameworks may have different dependencies.

### Changes Made

Introduced a new ProjectGraphOptions struct because project graph construction happens in a constructor and adding a new overload seemed like a worse design. This way we can add new options to the struct and not keep having to modify the constructor.

```csharp
var projectGraph = new ProjectGraph(
    new ProjectGraphOptions
    {
        EntryPoints = [new ProjectGraphEntryPoint("path")],
        Mode = ProjectGraphMode.Full
    });
```

In the new ProjectGraphMode.Full mode:
- SetTargetFramework metadata is ignored during graph construction
- All outer and inner builds are evaluated, regardless of framework filters
- This provides a complete view of the dependency graph needed for restore operations
- Note: Using the "full" graph for an actual build would technically overbuild, but it's the correct mode for package resolution

### Testing

Added unit test demonstrating that ProjectGraphMode.Full loads all target framework instances even when SetTargetFramework would normally filter them.

Had to fix a few tests that were broken. These tests are marked as inactive and it wasn't caught.

### Notes