### PR TITLE
Update BootstrapSdkVersion to 10.0.107

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -81,7 +81,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <BootstrapSdkVersion>10.0.106</BootstrapSdkVersion>
+    <BootstrapSdkVersion>10.0.107</BootstrapSdkVersion>
   </PropertyGroup>
 
   <Target Name="OverrideArcadeFileVersion" AfterTargets="_InitializeAssemblyVersion">


### PR DESCRIPTION
Follow-up to #13721, which bumped the real SDK to 107 but didn't adjust this, leading to test flakiness #13732.

Work around that flakiness by updating the bootstrap base SDK to one that provides the same runtime the Arcade SDK requires.
