### PR TITLE
[Server] Restore CurrentCulture/CurrentUICulture at end of each request

### DIFF
--- a/src/Build/BackEnd/Node/OutOfProcServerNode.cs
+++ b/src/Build/BackEnd/Node/OutOfProcServerNode.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.Globalization;
 using System.IO;
 using System.Text;
 using System.Threading;
@@ -69,6 +70,8 @@ namespace Microsoft.Build.Experimental
         /// </summary>
         private bool _cancelRequested = false;
         private string _serverBusyMutexName = default!;
+        private CultureInfo _originalCulture = default!;
+        private CultureInfo _originalUICulture = default!;
 
         public OutOfProcServerNode(BuildCallback buildFunction)
         {
@@ -93,6 +96,9 @@ namespace Microsoft.Build.Experimental
         /// <returns>The reason for shutting down.</returns>
         public NodeEngineShutdownReason Run(out Exception? shutdownException)
         {
+            _originalCulture = CultureInfo.CurrentCulture;
+            _originalUICulture = CultureInfo.CurrentUICulture;
+
             ServerNodeHandshake handshake = new(
                 CommunicationsUtilities.GetHandshakeOptions(taskHost: false, taskHostParameters: TaskHostParameters.Empty, architectureFlagToSet: XMakeAttributes.GetCurrentMSBuildArchitecture()));
 
@@ -363,6 +369,19 @@ namespace Microsoft.Build.Experimental
         }
 
         private void HandleServerNodeBuildCommand(ServerNodeBuildCommand command)
+        {
+            try
+            {
+                HandleServerNodeBuildCommandCore(command);
+            }
+            finally
+            {
+                Thread.CurrentThread.CurrentCulture = _originalCulture;
+                Thread.CurrentThread.CurrentUICulture = _originalUICulture;
+            }
+        }
+
+        private void HandleServerNodeBuildCommandCore(ServerNodeBuildCommand command)
         {
             CommunicationsUtilities.Trace($"Building with MSBuild server with command line {command.CommandLine}");
             using var serverBusyMutex = ServerNamedMutex.OpenOrCreateMutex(name: _serverBusyMutexName, createdNew: out var holdsMutex);

--- a/src/MSBuild.UnitTests/MSBuildServer_Tests.cs
+++ b/src/MSBuild.UnitTests/MSBuildServer_Tests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Globalization;
 using System.Reflection;
 using System.Text.RegularExpressions;
 using System.Threading;
@@ -55,6 +56,18 @@ namespace Microsoft.Build.Engine.UnitTests
         }
     }
 
+    public class CultureInfoTask : Microsoft.Build.Utilities.Task
+    {
+        [Required]
+        public string OutputFile { get; set; } = string.Empty;
+
+        public override bool Execute()
+        {
+            File.WriteAllText(OutputFile, string.Join("|", Process.GetCurrentProcess().Id, CultureInfo.CurrentCulture.Name, CultureInfo.CurrentUICulture.Name));
+            return true;
+        }
+    }
+
     public class MSBuildServer_Tests : IDisposable
     {
         private readonly ITestOutputHelper _output;
@@ -76,6 +89,13 @@ namespace Microsoft.Build.Engine.UnitTests
         <!-- create a marker file that represents the build is started. -->
         <WriteLinesToFile File=""{{0}}"" />
         <SleepingTask SleepTime=""100000"" />
+    </Target>
+</Project>";
+        private static string cultureInfoTaskContents = @$"
+<Project>
+<UsingTask TaskName=""CultureInfoTask"" AssemblyFile=""{Assembly.GetExecutingAssembly().Location}"" />
+    <Target Name='RecordCulture'>
+        <CultureInfoTask OutputFile=""$(CultureOutputFile)"" />
     </Target>
 </Project>";
 
@@ -134,6 +154,43 @@ namespace Microsoft.Build.Engine.UnitTests
             newPidOfInitialProcess.ShouldNotBe(pidOfInitialProcess, "Process started by two MSBuild executions should be different.");
             newPidOfInitialProcess.ShouldNotBe(newServerProcessId, "We started a server node to execute the target rather than running it in-proc, so its pid should be different.");
             pidOfServerProcess.ShouldNotBe(newServerProcessId, "Node used by both the first and second build should not be the same.");
+        }
+
+        [Fact]
+        public void ServerBuildsUseCultureFromEachRequest()
+        {
+            TransientTestFile project = _env.CreateFile("cultureProject.proj", cultureInfoTaskContents);
+            TransientTestFile firstCultureOutput = _env.ExpectFile();
+            TransientTestFile secondCultureOutput = _env.ExpectFile();
+            CultureInfo originalCulture = CultureInfo.CurrentCulture;
+            CultureInfo originalUICulture = CultureInfo.CurrentUICulture;
+
+            try
+            {
+                MSBuildClient.ShutdownServer(CancellationToken.None).ShouldBeTrue();
+
+                MSBuildClientExitResult firstResult = ExecuteServerBuildWithCulture(project.Path, firstCultureOutput.Path, new CultureInfo("en-US"));
+                firstResult.MSBuildClientExitType.ShouldBe(MSBuildClientExitType.Success);
+                firstResult.MSBuildAppExitTypeString.ShouldBe("Success");
+                CultureRecord firstCultureRecord = ReadCultureRecord(firstCultureOutput.Path);
+                _env.WithTransientProcess(firstCultureRecord.ProcessId);
+                firstCultureRecord.Culture.ShouldBe("en-US");
+                firstCultureRecord.UICulture.ShouldBe("en-US");
+
+                MSBuildClientExitResult secondResult = ExecuteServerBuildWithCulture(project.Path, secondCultureOutput.Path, new CultureInfo("fr-FR"));
+                secondResult.MSBuildClientExitType.ShouldBe(MSBuildClientExitType.Success);
+                secondResult.MSBuildAppExitTypeString.ShouldBe("Success");
+                CultureRecord secondCultureRecord = ReadCultureRecord(secondCultureOutput.Path);
+                secondCultureRecord.ProcessId.ShouldBe(firstCultureRecord.ProcessId, "The second build should reuse the same server process.");
+                secondCultureRecord.Culture.ShouldBe("fr-FR");
+                secondCultureRecord.UICulture.ShouldBe("fr-FR");
+            }
+            finally
+            {
+                Thread.CurrentThread.CurrentCulture = originalCulture;
+                Thread.CurrentThread.CurrentUICulture = originalUICulture;
+                MSBuildClient.ShutdownServer(CancellationToken.None);
+            }
         }
 
         [Fact]
@@ -348,6 +405,35 @@ namespace Microsoft.Build.Engine.UnitTests
             pidOfNewServerProcess.ShouldBe(pidOfServerProcess);
             output.ShouldContain($@":MSBuildStartupDirectory:{Environment.CurrentDirectory}:");
         }
+
+        private static MSBuildClientExitResult ExecuteServerBuildWithCulture(string projectPath, string outputFile, CultureInfo culture)
+        {
+            Thread.CurrentThread.CurrentCulture = culture;
+            Thread.CurrentThread.CurrentUICulture = culture;
+
+            MSBuildClient client = new(
+                [
+                    BuildEnvironmentHelper.Instance.CurrentMSBuildExePath,
+                    projectPath,
+                    "/t:RecordCulture",
+                    $"/p:CultureOutputFile={outputFile}",
+                    "/nologo",
+                    "/v:m",
+                ],
+                BuildEnvironmentHelper.Instance.CurrentMSBuildExePath);
+
+            return client.Execute(CancellationToken.None);
+        }
+
+        private static CultureRecord ReadCultureRecord(string path)
+        {
+            string[] parts = File.ReadAllText(path).Split('|');
+            parts.Length.ShouldBe(3);
+
+            return new CultureRecord(int.Parse(parts[0], CultureInfo.InvariantCulture), parts[1], parts[2]);
+        }
+
+        private readonly record struct CultureRecord(int ProcessId, string Culture, string UICulture);
 
         private int ParseNumber(string searchString, string toFind)
         {


### PR DESCRIPTION
## Server: Restore `CurrentCulture`/`CurrentUICulture` at end of each request

> **Honest framing (post-review feedback): this is defense-in-depth hygiene, not a fix for any observable bug today.** See "Why the failure mode is weak" below before deciding whether to merge.

Snapshot `Thread.CurrentThread.CurrentCulture` and `CurrentUICulture` once at server startup (in `OutOfProcServerNode.Run`, before the listener loop), then restore them in a `try/finally` around each `HandleServerNodeBuildCommand` invocation.

### Why the failure mode is weak

Each request explicitly sets `Thread.CurrentThread.CurrentCulture = command.Culture` (`OutOfProcServerNode.cs:386-387`) **before** any culture-sensitive build work runs. Build work runs synchronously on the same `Task.Run`-spawned ThreadPool thread, so the per-request set covers the whole request. Walking the lifecycle:

1. Request N → `Task.Run` picks a ThreadPool thread → sets culture to N's → build runs → returns.
2. Thread goes back to the pool with culture still set to N's.
3. Request N+1 → `Task.Run` picks **some** ThreadPool thread (maybe the same one) → sets culture to N+1's → build runs.

Whichever thread N+1's `Task.Run` picks, the very first thing it does is overwrite the culture. So **the prior request's culture cannot leak into N+1's build**. The narrow scenarios where the leftover culture *could* matter are all weak:

| Scenario | Real? |
|---|---|
| Listener / packet-pump thread reads `CurrentCulture` for trace formatting | Pump thread never has `command.Culture` set, so it uses the process default — unaffected by this PR |
| Finalizer / GC callback reads `CurrentCulture` | Runs on dedicated finalizer/GC threads, never the request handler — unaffected |
| Async continuation on a recycled handler thread between requests | Continuations on ThreadPool threads don't preserve thread-local culture; whatever the picked thread happens to have is non-deterministic regardless |
| Fire-and-forget work outliving the request | Bad practice in tasks; doesn't actually capture `Thread.CurrentThread.CurrentCulture` for use later |
| Debugger / heap-dump inspector observing idle server thread cultures | Real but cosmetic, not a build correctness issue |

### What the test actually proves (and doesn't)

`MSBuildServer_Tests.ServerBuildsUseCultureFromEachRequest` runs back-to-back en-US then fr-FR builds and asserts each build's task observes its own culture and that the server PID is reused. **The test passes with or without the restore code in this PR**, because the explicit set in `HandleServerNodeBuildCommand` already guarantees correctness for what the test observes.

So the test is a useful regression for the existing per-request set behavior, but it does NOT validate that this PR fixes any concrete bug.

### Why merge anyway (defense-in-depth case)

1. **Symmetry** with the existing reset patterns: `HandleShutdown` already resets the working directory; CWD restore was added for the same "between-requests cleanliness" reason. This PR extends that pattern to culture.
2. **Future-proofing**: if MSBuild ever adds between-request work (a periodic stats emitter, a passive cache eviction timer, a server-startup background task) that would otherwise see stale culture from the last request handler thread, it would be predictable instead of "whatever the last build set it to".
3. **Idle-server inspection**: a debugger attached to a long-running idle server sees baseline cultures rather than the last build's request culture.
4. **Cost is tiny** — ~20 lines, no risk to existing scenarios, no performance impact.

### What this PR is NOT

It is not a fix for:
- Any specific user-reported bug
- The fsharp VMR `TimeoutException` (that's #13716 + the prototype's M1)
- The cross-request server-state leaks documented in #9379 that DO have real failure modes (Console color → #13757; engine statics → separate work)

### Implementation

- Snapshot `_originalCulture` / `_originalUICulture` in `Run()` before the listener loop.
- Wrap the body of `HandleServerNodeBuildCommand` in a `try/finally` that restores both.
- Two files changed: `OutOfProcServerNode.cs` (+19 lines), `MSBuildServer_Tests.cs` (+86 lines for the regression test + helper task).

### Recommendation

Merge if the maintainers value defense-in-depth hygiene + symmetry with the existing CWD reset; close as "premature optimization" if not. I have no strong preference but lean toward merge given the very low cost.

Investigation context: [#9379](https://github.com/dotnet/msbuild/issues/9379) Thread G item 3.
