### PR TITLE
[Server] Restore Console color/encoding at end of each request (LOG-2)

### DIFF
--- a/src/Build/BackEnd/Node/OutOfProcServerNode.cs
+++ b/src/Build/BackEnd/Node/OutOfProcServerNode.cs
@@ -70,6 +70,17 @@ namespace Microsoft.Build.Experimental
         private bool _cancelRequested = false;
         private string _serverBusyMutexName = default!;
 
+        // Snapshot of process-global Console state captured once at server startup.
+        // Restored at the end of each request to prevent loggers (e.g. BaseConsoleLogger
+        // which sets ForegroundColor in SetColor() but only sometimes restores via ResetColor)
+        // or per-request ConsoleConfiguration application from leaking visible state into the
+        // next request or into the idle server's state.
+        private ConsoleColor _originalForegroundColor;
+        private ConsoleColor _originalBackgroundColor;
+        private bool _originalConsoleColorsCaptured;
+        private System.Text.Encoding _originalOutputEncoding = default!;
+        private bool _originalOutputEncodingCaptured;
+
         public OutOfProcServerNode(BuildCallback buildFunction)
         {
             _buildFunction = buildFunction;
@@ -93,6 +104,31 @@ namespace Microsoft.Build.Experimental
         /// <returns>The reason for shutting down.</returns>
         public NodeEngineShutdownReason Run(out Exception? shutdownException)
         {
+            // Capture process-global Console state once. Restoring per-request keeps reused
+            // server requests from observing each other's color/encoding mutations.
+            // Wrapped in try/catch because Console.ForegroundColor/BackgroundColor throw on
+            // some redirected/headless setups (e.g. CI without a TTY).
+            try
+            {
+                _originalForegroundColor = Console.ForegroundColor;
+                _originalBackgroundColor = Console.BackgroundColor;
+                _originalConsoleColorsCaptured = true;
+            }
+            catch
+            {
+                _originalConsoleColorsCaptured = false;
+            }
+
+            try
+            {
+                _originalOutputEncoding = Console.OutputEncoding;
+                _originalOutputEncodingCaptured = true;
+            }
+            catch
+            {
+                _originalOutputEncodingCaptured = false;
+            }
+
             ServerNodeHandshake handshake = new(
                 CommunicationsUtilities.GetHandshakeOptions(taskHost: false, taskHostParameters: TaskHostParameters.Empty, architectureFlagToSet: XMakeAttributes.GetCurrentMSBuildArchitecture()));
 
@@ -363,6 +399,53 @@ namespace Microsoft.Build.Experimental
         }
 
         private void HandleServerNodeBuildCommand(ServerNodeBuildCommand command)
+        {
+            try
+            {
+                HandleServerNodeBuildCommandCore(command);
+            }
+            finally
+            {
+                RestoreConsoleStateAfterRequest();
+            }
+        }
+
+        /// <summary>
+        /// Restore process-global Console state to the snapshot captured at server startup.
+        /// Called from a finally block in <see cref="HandleServerNodeBuildCommand"/> so that
+        /// per-request mutations (loggers writing to Console.ForegroundColor, the per-request
+        /// application of ConsoleConfiguration.BackgroundColor, etc.) do not leak across
+        /// requests in a reused server. See investigation #9379 (LOG-2 / W1c).
+        /// </summary>
+        private void RestoreConsoleStateAfterRequest()
+        {
+            if (_originalConsoleColorsCaptured)
+            {
+                try
+                {
+                    Console.ForegroundColor = _originalForegroundColor;
+                    Console.BackgroundColor = _originalBackgroundColor;
+                }
+                catch
+                {
+                    // Console color mutation can throw on redirected stdout in CI; safe to ignore.
+                }
+            }
+
+            if (_originalOutputEncodingCaptured)
+            {
+                try
+                {
+                    Console.OutputEncoding = _originalOutputEncoding;
+                }
+                catch
+                {
+                    // Some hosts disallow OutputEncoding mutation after Console initialization.
+                }
+            }
+        }
+
+        private void HandleServerNodeBuildCommandCore(ServerNodeBuildCommand command)
         {
             CommunicationsUtilities.Trace($"Building with MSBuild server with command line {command.CommandLine}");
             using var serverBusyMutex = ServerNamedMutex.OpenOrCreateMutex(name: _serverBusyMutexName, createdNew: out var holdsMutex);


### PR DESCRIPTION
## Server: Restore Console color/encoding at end of each request (LOG-2)

> **Honest framing (post-review feedback): the observable failure mode is narrow.** A misbehaving task or custom logger that mutates the server process's `Console.ForegroundColor`/`BackgroundColor`/`OutputEncoding` and forgets to restore it leaks that state into subsequent requests. **But the leak is only USER-VISIBLE when the server has a real attached console** (e.g. `MSBUILDNODEWINDOW=1`, used by devs debugging the server interactively). Under the default headless launch (`CreateNoWindow=true`, `RedirectStandardOutput=true` in `NodeLauncher.cs:113,136`), the server's `Console.ForegroundColor` writes to a hidden Windows console-buffer attribute that nothing renders, so the leak isn't observable. See "Where this is observable" below.

Snapshot `Console.ForegroundColor`, `Console.BackgroundColor`, and `Console.OutputEncoding` once at server startup (in `OutOfProcServerNode.Run`, before the listener loop), then restore them in a `try/finally` around each `HandleServerNodeBuildCommand` invocation.

### Where this is observable

The fix matters when the MSBuild server runs with a **real attached console**:
- `MSBUILDNODEWINDOW=1` — existing escape hatch that triggers `CREATE_NEW_CONSOLE` (`NodeLauncher.cs:104,112`); used by people debugging MSBuild server interactively
- The asymmetric `ConsoleConfiguration.BackgroundColor` set at `OutOfProcServerNode.cs:414-417` (set per request, never restored — pure hygiene)
- Any future feature that exposes the server window to the user

The fix does NOT meaningfully change behavior for the default headless server. Color in the headless case reaches the user via ANSI escape sequences embedded in the redirected text stream — those are self-contained per message and unaffected by `Console.ForegroundColor` mutations. The W1c logger audit confirmed `BaseConsoleLogger` writes to the text stream via `SetColorAnsi`/`ResetColorAnsi` on modern terminals, falling back to `Console.ForegroundColor` only when ANSI is unsupported.

### Repro

A manual repro folder is at `session-notes/console-repro/` on the prototype branch with a custom Roslyn-code task that mutates `Console.ForegroundColor` server-side without restoring, and a PowerShell script that runs it twice with `MSBUILDNODEWINDOW=1`. **Run the script twice — once with public dotnet (no fix, server window stays red across builds) and once with the bootstrap (with fix, resets between builds).**

### Implementation

- Snapshot taken once in `Run()` in `try/catch` since `Console.ForegroundColor`/`BackgroundColor` throw on redirected/headless stdout (CI without a TTY).
- `_originalConsoleColorsCaptured` / `_originalOutputEncodingCaptured` flags track whether the snapshot succeeded so restore is skipped if the platform doesn't support the property.
- Restore is wrapped in `try/catch` for the same headless-CI scenario.

### Test

No unit test (the failure scenario requires `MSBUILDNODEWINDOW=1` + a visible console window, which doesn't compose with xUnit-on-CI). Manual repro provided as above. The change is mechanical; the symmetry with the existing CWD reset pattern is the main safety argument.

### Why merge anyway

1. Fixes the `MSBUILDNODEWINDOW=1` debug scenario (real but niche).
2. Fixes the `ConsoleConfiguration.BackgroundColor` asymmetry that's already in the code today (set per request, never restored).
3. Defense-in-depth: if MSBuild ever exposes server console state in a new way (debug feature, attach scenarios), it's already correct.
4. Cost is tiny — ~80 lines including comments, no perf impact, no risk to existing scenarios.

### Recommendation

Merge as low-cost hygiene if the maintainers value the `MSBUILDNODEWINDOW=1` fix + symmetry; close as premature if not. The repro folder is in the prototype branch's `session-notes/console-repro/` for evaluation.

### Context

Investigation [#9379](https://github.com/dotnet/msbuild/issues/9379) — broader MSBuild Server default-on analysis, LOG-2 from the W1c logger-lifecycle audit. One of three small server-state hygiene PRs:
- #13756 — `CurrentCulture`/`CurrentUICulture` restore (also reframed honestly as defense-in-depth)
- (this) — Console color/encoding restore
- #13758 — `-mt` implies server with explicit `MSBUILDUSESERVER=0` opt-out

This is a **draft** for review of the approach.
