### PR TITLE
[Server] -mt implies MSBuild Server

### DIFF
--- a/documentation/specs/multithreading/multithreaded-msbuild.md
+++ b/documentation/specs/multithreading/multithreaded-msbuild.md
@@ -293,3 +293,17 @@ deactivate Thread1_Project1
 ## MSBuild Server integration
 
 To avoid regressing CLI incremental build performance, it is essential to fully support the MSBuild server feature in multithreaded mode. Out-of-process nodes offer significant benefits by preserving caches across build command executions when node reuse is enabled. However, caches in the entry process are lost at the end of each build unless the MSBuild server feature is used. In multiprocess execution, that is a fraction of the caches and processes, but with multithreading, it is the entire process. As a result, opting into multithreading on the command line should automatically enable MSBuild server.
+
+### `-mt` implies MSBuild Server
+
+When `-mt` (`-multithreaded`) is on the command line and `MSBUILDUSESERVER` is unset, MSBuild Server is engaged automatically. Explicit `MSBUILDUSESERVER=0` opts out and takes precedence over the implicit `-mt` opt-in.
+
+| `MSBUILDUSESERVER` | `-mt` build | Server engaged? | Telemetry `ServerEnableReason` |
+|---|---|---|---|
+| `1` | (any) | Yes | `EnvVar` |
+| `0` | (any) | No (explicit opt-out) | — |
+| unset | yes | **Yes** | `ImpliedByMt` |
+| unset | no | No | — |
+
+The multithreaded determination is computed once (a lightweight command-line scan plus the `MSBUILDFORCEMULTITHREADED` opt-in) and drives both this server opt-in and, when the server is engaged for a multithreaded build, the server process's [Server GC](../../MSBuild-Server.md#garbage-collection) selection.
+

--- a/documentation/specs/multithreading/multithreaded-msbuild.md
+++ b/documentation/specs/multithreading/multithreaded-msbuild.md
@@ -296,7 +296,7 @@ To avoid regressing CLI incremental build performance, it is essential to fully 
 
 ### `-mt` implies MSBuild Server
 
-When this is a `-mt` (`-multithreaded`) build and `MSBUILDUSESERVER` is unset, MSBuild Server is engaged automatically. Setting `MSBUILDUSESERVER` to any explicit value opts out of the implicit path: `1` keeps the server on, and any other value (e.g. `0`, `false`) keeps it off — only `1` engages the server, matching the pre-existing rule. `-mt` is itself experimental and opt-in, so the implicit server engagement is not separately gated.
+When this is a `-mt` (`-multithreaded`) build and `MSBUILDUSESERVER` is unset, MSBuild Server is engaged automatically. Setting `MSBUILDUSESERVER` to any explicit value opts out of the implicit path: `1` keeps the server on, and any other value (e.g. `0`, `false`) keeps it off, matching the pre-existing behavior. `-mt` is itself experimental and opt-in, so the implicit server engagement is not separately gated.
 
 | `MSBUILDUSESERVER` | `-mt` build | Server engaged? | Telemetry `ServerEnableReason` |
 |---|---|---|---|
@@ -305,6 +305,6 @@ When this is a `-mt` (`-multithreaded`) build and `MSBUILDUSESERVER` is unset, M
 | unset | yes | **Yes** | `ImpliedByMt` |
 | unset | no | No | — |
 
-A single authoritative `-mt` determination drives everything. The command line is parsed once, up front, by the MSBuild Server eligibility check (`CanRunServerBasedOnCommandLineSwitches`), which uses the same `IsMultiThreadedEnabled` logic as the in-proc build path. Because this is the full, response-file-aware parse, `-mt` is detected wherever it is supplied — on the command line, in the auto-response file, in a project `Directory.Build.rsp`, in an `@response` file, or via `MSBUILDFORCEMULTITHREADED`. That same value also decides, once the server is engaged, whether the server process is launched with [Server GC](../../MSBuild-Server.md#garbage-collection). The gathered switches are threaded into the in-proc build path so the command line is **not** parsed a second time.
+`-mt` is detected from the full, response-file-aware command-line parse, so it counts wherever it is supplied — command line, auto-response file, a project `Directory.Build.rsp`, an `@response` file, or `MSBUILDFORCEMULTITHREADED`. The same value decides whether an engaged server is launched with [Server GC](../../MSBuild-Server.md#garbage-collection).
 
 

--- a/documentation/specs/multithreading/multithreaded-msbuild.md
+++ b/documentation/specs/multithreading/multithreaded-msbuild.md
@@ -296,13 +296,13 @@ To avoid regressing CLI incremental build performance, it is essential to fully 
 
 ### `-mt` implies MSBuild Server
 
-When `-mt` (`-multithreaded`) is on the command line and `MSBUILDUSESERVER` is unset, MSBuild Server is engaged automatically (gated behind change wave 18.8). Setting `MSBUILDUSESERVER` to any explicit value opts out of the implicit path: `1` keeps the server on, and any other value (e.g. `0`, `false`) keeps it off — only `1` engages the server, matching the pre-existing rule. The implicit path can also be disabled via `MSBUILDDISABLEFEATURESFROMVERSION=18.8`.
+When `-mt` (`-multithreaded`) is on the command line and `MSBUILDUSESERVER` is unset, MSBuild Server is engaged automatically. Setting `MSBUILDUSESERVER` to any explicit value opts out of the implicit path: `1` keeps the server on, and any other value (e.g. `0`, `false`) keeps it off — only `1` engages the server, matching the pre-existing rule. `-mt` is itself experimental and opt-in, so the implicit server engagement is not separately gated.
 
 | `MSBUILDUSESERVER` | `-mt` on command line | Server engaged? | Telemetry `ServerEnableReason` |
 |---|---|---|---|
 | `1` | (any) | Yes | `EnvVar` |
 | any other non-empty value (`0`, `false`, …) | (any) | No (explicit opt-out) | — |
-| unset | yes | **Yes** (wave 18.8) | `ImpliedByMt` |
+| unset | yes | **Yes** | `ImpliedByMt` |
 | unset | no | No | — |
 
 Two `-mt` determinations are used, with distinct purposes:

--- a/documentation/specs/multithreading/multithreaded-msbuild.md
+++ b/documentation/specs/multithreading/multithreaded-msbuild.md
@@ -296,14 +296,17 @@ To avoid regressing CLI incremental build performance, it is essential to fully 
 
 ### `-mt` implies MSBuild Server
 
-When `-mt` (`-multithreaded`) is on the command line and `MSBUILDUSESERVER` is unset, MSBuild Server is engaged automatically. Explicit `MSBUILDUSESERVER=0` opts out and takes precedence over the implicit `-mt` opt-in.
+When `-mt` (`-multithreaded`) is on the command line and `MSBUILDUSESERVER` is unset, MSBuild Server is engaged automatically (gated behind change wave 18.8). Setting `MSBUILDUSESERVER` to any explicit value opts out of the implicit path: `1` keeps the server on, and any other value (e.g. `0`, `false`) keeps it off — only `1` engages the server, matching the pre-existing rule. The implicit path can also be disabled via `MSBUILDDISABLEFEATURESFROMVERSION=18.8`.
 
-| `MSBUILDUSESERVER` | `-mt` build | Server engaged? | Telemetry `ServerEnableReason` |
+| `MSBUILDUSESERVER` | `-mt` on command line | Server engaged? | Telemetry `ServerEnableReason` |
 |---|---|---|---|
 | `1` | (any) | Yes | `EnvVar` |
-| `0` | (any) | No (explicit opt-out) | — |
-| unset | yes | **Yes** | `ImpliedByMt` |
+| any other non-empty value (`0`, `false`, …) | (any) | No (explicit opt-out) | — |
+| unset | yes | **Yes** (wave 18.8) | `ImpliedByMt` |
 | unset | no | No | — |
 
-The multithreaded determination is computed once (a lightweight command-line scan plus the `MSBUILDFORCEMULTITHREADED` opt-in) and drives both this server opt-in and, when the server is engaged for a multithreaded build, the server process's [Server GC](../../MSBuild-Server.md#garbage-collection) selection.
+Two `-mt` determinations are used, with distinct purposes:
+- A cheap command-line scan (`IsMultiThreadedRequested`) drives the *implicit server opt-in* above. It runs on every invocation, so it avoids the full command-line parse; consequently `-mt` from a response file does not trigger the implicit opt-in, and `MSBUILDFORCEMULTITHREADED` (a force/testing knob) does **not** by itself engage the server.
+- The authoritative full parse (`IsMultiThreadedEnabled`, which expands response files and honors `MSBUILDFORCEMULTITHREADED`) decides, once the server is engaged, whether the server process is launched with [Server GC](../../MSBuild-Server.md#garbage-collection).
+
 

--- a/documentation/specs/multithreading/multithreaded-msbuild.md
+++ b/documentation/specs/multithreading/multithreaded-msbuild.md
@@ -296,17 +296,15 @@ To avoid regressing CLI incremental build performance, it is essential to fully 
 
 ### `-mt` implies MSBuild Server
 
-When `-mt` (`-multithreaded`) is on the command line and `MSBUILDUSESERVER` is unset, MSBuild Server is engaged automatically. Setting `MSBUILDUSESERVER` to any explicit value opts out of the implicit path: `1` keeps the server on, and any other value (e.g. `0`, `false`) keeps it off — only `1` engages the server, matching the pre-existing rule. `-mt` is itself experimental and opt-in, so the implicit server engagement is not separately gated.
+When this is a `-mt` (`-multithreaded`) build and `MSBUILDUSESERVER` is unset, MSBuild Server is engaged automatically. Setting `MSBUILDUSESERVER` to any explicit value opts out of the implicit path: `1` keeps the server on, and any other value (e.g. `0`, `false`) keeps it off — only `1` engages the server, matching the pre-existing rule. `-mt` is itself experimental and opt-in, so the implicit server engagement is not separately gated.
 
-| `MSBUILDUSESERVER` | `-mt` on command line | Server engaged? | Telemetry `ServerEnableReason` |
+| `MSBUILDUSESERVER` | `-mt` build | Server engaged? | Telemetry `ServerEnableReason` |
 |---|---|---|---|
 | `1` | (any) | Yes | `EnvVar` |
 | any other non-empty value (`0`, `false`, …) | (any) | No (explicit opt-out) | — |
 | unset | yes | **Yes** | `ImpliedByMt` |
 | unset | no | No | — |
 
-Two `-mt` determinations are used, with distinct purposes:
-- A cheap command-line scan (`IsMultiThreadedRequested`) drives the *implicit server opt-in* above. It runs on every invocation, so it avoids the full command-line parse; consequently `-mt` from a response file does not trigger the implicit opt-in, and `MSBUILDFORCEMULTITHREADED` (a force/testing knob) does **not** by itself engage the server.
-- The authoritative full parse (`IsMultiThreadedEnabled`, which expands response files and honors `MSBUILDFORCEMULTITHREADED`) decides, once the server is engaged, whether the server process is launched with [Server GC](../../MSBuild-Server.md#garbage-collection).
+A single authoritative `-mt` determination drives everything. The command line is parsed once, up front, by the MSBuild Server eligibility check (`CanRunServerBasedOnCommandLineSwitches`), which uses the same `IsMultiThreadedEnabled` logic as the in-proc build path. Because this is the full, response-file-aware parse, `-mt` is detected wherever it is supplied — on the command line, in the auto-response file, in a project `Directory.Build.rsp`, in an `@response` file, or via `MSBUILDFORCEMULTITHREADED`. That same value also decides, once the server is engaged, whether the server process is launched with [Server GC](../../MSBuild-Server.md#garbage-collection). The gathered switches are threaded into the in-proc build path so the command line is **not** parsed a second time.
 
 

--- a/documentation/wiki/ChangeWaves.md
+++ b/documentation/wiki/ChangeWaves.md
@@ -32,7 +32,6 @@ Change wave checks around features will be removed in the release that accompani
 ### 18.8
 - [RAR task: across multiple input properties, resolve relative paths against the project directory (not the process current directory)](https://github.com/dotnet/msbuild/pull/13319)
 - [Console, parallel console, and terminal loggers print the paths of log files written by registered loggers (e.g. file logger and binary logger) as part of the end-of-build summary.](https://github.com/dotnet/msbuild/pull/13577)
-- [`-mt` (multithreaded) builds implicitly engage MSBuild Server when `MSBUILDUSESERVER` is unset](https://github.com/dotnet/msbuild/pull/13758) - set `MSBUILDUSESERVER=0` or disable this wave to opt out.
 
 ### 18.7
 - [Copy task retries on ERROR_ACCESS_DENIED on non-Windows platforms to handle transient lock conflicts (e.g. macOS CoW filesystems)](https://github.com/dotnet/msbuild/issues/13463)

--- a/documentation/wiki/ChangeWaves.md
+++ b/documentation/wiki/ChangeWaves.md
@@ -32,6 +32,7 @@ Change wave checks around features will be removed in the release that accompani
 ### 18.8
 - [RAR task: across multiple input properties, resolve relative paths against the project directory (not the process current directory)](https://github.com/dotnet/msbuild/pull/13319)
 - [Console, parallel console, and terminal loggers print the paths of log files written by registered loggers (e.g. file logger and binary logger) as part of the end-of-build summary.](https://github.com/dotnet/msbuild/pull/13577)
+- [`-mt` (multithreaded) builds implicitly engage MSBuild Server when `MSBUILDUSESERVER` is unset](https://github.com/dotnet/msbuild/pull/13758) - set `MSBUILDUSESERVER=0` or disable this wave to opt out.
 
 ### 18.7
 - [Copy task retries on ERROR_ACCESS_DENIED on non-Windows platforms to handle transient lock conflicts (e.g. macOS CoW filesystems)](https://github.com/dotnet/msbuild/issues/13463)

--- a/src/Build/BackEnd/Client/MSBuildClient.cs
+++ b/src/Build/BackEnd/Client/MSBuildClient.cs
@@ -577,7 +577,8 @@ namespace Microsoft.Build.Experimental
                 : new PartialBuildTelemetry(
                     startedAt: KnownTelemetry.PartialBuildTelemetry.StartAt.GetValueOrDefault(),
                     initialServerState: KnownTelemetry.PartialBuildTelemetry.InitialMSBuildServerState,
-                    serverFallbackReason: KnownTelemetry.PartialBuildTelemetry.ServerFallbackReason);
+                    serverFallbackReason: KnownTelemetry.PartialBuildTelemetry.ServerFallbackReason,
+                    serverEnableReason: KnownTelemetry.PartialBuildTelemetry.ServerEnableReason);
 
             return new ServerNodeBuildCommand(
                         _commandLine,

--- a/src/Build/BackEnd/Node/OutOfProcServerNode.cs
+++ b/src/Build/BackEnd/Node/OutOfProcServerNode.cs
@@ -409,6 +409,7 @@ namespace Microsoft.Build.Experimental
                 buildTelemetry.StartAt = command.PartialBuildTelemetry.StartedAt;
                 buildTelemetry.InitialMSBuildServerState = command.PartialBuildTelemetry.InitialServerState;
                 buildTelemetry.ServerFallbackReason = command.PartialBuildTelemetry.ServerFallbackReason;
+                buildTelemetry.ServerEnableReason = command.PartialBuildTelemetry.ServerEnableReason;
             }
 
             // Also try our best to increase chance custom Loggers which use Console static members will work as expected.

--- a/src/Build/BackEnd/Node/PartialBuildTelemetry.cs
+++ b/src/Build/BackEnd/Node/PartialBuildTelemetry.cs
@@ -14,12 +14,14 @@ internal sealed class PartialBuildTelemetry : ITranslatable
     private DateTime _startedAt = default;
     private string? _initialServerState = default;
     private string? _serverFallbackReason = default;
+    private string? _serverEnableReason = default;
 
-    public PartialBuildTelemetry(DateTime startedAt, string? initialServerState, string? serverFallbackReason)
+    public PartialBuildTelemetry(DateTime startedAt, string? initialServerState, string? serverFallbackReason, string? serverEnableReason)
     {
         _startedAt = startedAt;
         _initialServerState = initialServerState;
         _serverFallbackReason = serverFallbackReason;
+        _serverEnableReason = serverEnableReason;
     }
 
     /// <summary>
@@ -35,11 +37,14 @@ internal sealed class PartialBuildTelemetry : ITranslatable
 
     public string? ServerFallbackReason => _serverFallbackReason;
 
+    public string? ServerEnableReason => _serverEnableReason;
+
     public void Translate(ITranslator translator)
     {
         translator.Translate(ref _startedAt);
         translator.Translate(ref _initialServerState);
         translator.Translate(ref _serverFallbackReason);
+        translator.Translate(ref _serverEnableReason);
     }
 
     internal static PartialBuildTelemetry FactoryForDeserialization(ITranslator translator)

--- a/src/Framework/Telemetry/BuildTelemetry.cs
+++ b/src/Framework/Telemetry/BuildTelemetry.cs
@@ -62,6 +62,16 @@ namespace Microsoft.Build.Framework.Telemetry
         public string? ServerFallbackReason { get; set; }
 
         /// <summary>
+        /// Why MSBuild server was engaged for this invocation. One of:
+        ///   "EnvVar"      — MSBUILDUSESERVER=1 was set (explicit opt-in)
+        ///   "ImpliedByMt" — this is a multithreaded (-mt) build and MSBUILDUSESERVER was unset
+        ///   null          — server was not engaged
+        /// Lets dashboards measure adoption of the implicit -mt-implies-server path separately
+        /// from the explicit env-var path.
+        /// </summary>
+        public string? ServerEnableReason { get; set; }
+
+        /// <summary>
         /// Version of MSBuild.
         /// </summary>
         public Version? BuildEngineVersion { get; set; }
@@ -200,6 +210,7 @@ namespace Microsoft.Build.Framework.Telemetry
             AddIfNotNull(InitialMSBuildServerState);
             AddIfNotNull(ProjectPath != null ? Path.GetFileName(ProjectPath) : null, nameof(ProjectPath));
             AddIfNotNull(ServerFallbackReason);
+            AddIfNotNull(ServerEnableReason);
             AddIfNotNull(SanitizeBuildTarget(BuildTarget), nameof(BuildTarget));
             AddIfNotNull(BuildEngineVersion?.ToString(), nameof(BuildEngineVersion));
             AddIfNotNull(BuildSuccess?.ToString(), nameof(BuildSuccess));

--- a/src/MSBuild.UnitTests/MSBuildServer_Tests.cs
+++ b/src/MSBuild.UnitTests/MSBuildServer_Tests.cs
@@ -316,6 +316,37 @@ namespace Microsoft.Build.Engine.UnitTests
         }
 
         [Fact]
+        public void ServerStartsWhenMtPresentEvenWithoutEnvVar()
+        {
+            // Regression test for the "-mt implies MSBuild Server" routing decision
+            // (investigation #9379, ShouldUseMSBuildServer / IsMultiThreadedRequested).
+            // When MSBUILDUSESERVER is unset and the user passes -mt, the client should engage
+            // the server automatically. Verified by running two builds back-to-back and asserting
+            // the server process PID is the SAME for both — server reuse is the unique signature
+            // of MSBuild server engagement (a non-server build would always get a fresh worker PID).
+            TransientTestFile project = _env.CreateFile("testProject.proj", printPidContents);
+            // Explicitly clear MSBUILDUSESERVER so we test the -mt-implies-server path.
+            _env.SetEnvironmentVariable("MSBUILDUSESERVER", null);
+
+            // Make sure we start with no server running.
+            MSBuildClient.ShutdownServer(CancellationToken.None);
+
+            string output1 = RunnerUtilities.ExecMSBuild(BuildEnvironmentHelper.Instance.CurrentMSBuildExePath, project.Path + " -mt", out bool success1, false, _output);
+            success1.ShouldBeTrue();
+            int serverPid1 = ParseNumber(output1, "Server ID is ");
+
+            string output2 = RunnerUtilities.ExecMSBuild(BuildEnvironmentHelper.Instance.CurrentMSBuildExePath, project.Path + " -mt", out bool success2, false, _output);
+            success2.ShouldBeTrue();
+            int serverPid2 = ParseNumber(output2, "Server ID is ");
+
+            serverPid1.ShouldBe(serverPid2, "When -mt implies server, two consecutive builds should reuse the same server process. PIDs were " + serverPid1 + " and " + serverPid2 + ".");
+
+            _env.WithTransientProcess(serverPid1);
+            // Clean up the server we spun up.
+            MSBuildClient.ShutdownServer(CancellationToken.None);
+        }
+
+        [Fact]
         public void PropertyMSBuildStartupDirectoryOnServer()
         {
             // This test seems to be flaky, lets enable better logging to investigate it next time

--- a/src/MSBuild.UnitTests/MSBuildServer_Tests.cs
+++ b/src/MSBuild.UnitTests/MSBuildServer_Tests.cs
@@ -350,6 +350,43 @@ namespace Microsoft.Build.Engine.UnitTests
         }
 
         [Fact]
+        public void ServerStartsWhenMtInResponseFileEvenWithoutEnvVar()
+        {
+            // Regression test for rainersigwald's review concern (#13758): -mt enabled via a response file
+            // (here a project Directory.Build.rsp) - not on the command line - must still implicitly engage the
+            // server. This is the expected dogfooding mechanism, so the authoritative, response-file-aware parse
+            // drives the decision. Verified the same way as ServerStartsWhenMtPresentEvenWithoutEnvVar: two builds
+            // back-to-back reuse the SAME server PID, the unique signature of server engagement.
+            TransientTestFolder folder = _env.CreateFolder();
+            TransientTestFile project = _env.CreateFile(folder, "testProject.proj", printPidContents);
+            // -mt comes ONLY from the response file; it is NOT passed on the command line below.
+            _env.CreateFile(folder, "Directory.Build.rsp", "-mt");
+
+            // Explicitly clear MSBUILDUSESERVER so we test the implicit path, and isolate this test's server with
+            // a unique handshake salt so it can't reuse/shut down an unrelated server.
+            _env.SetEnvironmentVariable("MSBUILDUSESERVER", null);
+            _env.SetEnvironmentVariable("MSBUILDNODEHANDSHAKESALT", Guid.NewGuid().ToString("N"));
+
+            // Make sure we start with no server running.
+            MSBuildClient.ShutdownServer(CancellationToken.None);
+
+            string output1 = RunnerUtilities.ExecMSBuild(BuildEnvironmentHelper.Instance.CurrentMSBuildExePath, project.Path, out bool success1, false, _output);
+            success1.ShouldBeTrue();
+            int serverPid1 = ParseNumber(output1, "Server ID is ");
+            // Register cleanup before any assertion so the server does not leak if an assertion throws.
+            _env.WithTransientProcess(serverPid1);
+
+            string output2 = RunnerUtilities.ExecMSBuild(BuildEnvironmentHelper.Instance.CurrentMSBuildExePath, project.Path, out bool success2, false, _output);
+            success2.ShouldBeTrue();
+            int serverPid2 = ParseNumber(output2, "Server ID is ");
+
+            serverPid1.ShouldBe(serverPid2, "When -mt from a response file implies server, two consecutive builds should reuse the same server process. PIDs were " + serverPid1 + " and " + serverPid2 + ".");
+
+            // Clean up the server we spun up.
+            MSBuildClient.ShutdownServer(CancellationToken.None);
+        }
+
+        [Fact]
         public void PropertyMSBuildStartupDirectoryOnServer()
         {
             // This test seems to be flaky, lets enable better logging to investigate it next time

--- a/src/MSBuild.UnitTests/MSBuildServer_Tests.cs
+++ b/src/MSBuild.UnitTests/MSBuildServer_Tests.cs
@@ -325,8 +325,10 @@ namespace Microsoft.Build.Engine.UnitTests
             // the server process PID is the SAME for both — server reuse is the unique signature
             // of MSBuild server engagement (a non-server build would always get a fresh worker PID).
             TransientTestFile project = _env.CreateFile("testProject.proj", printPidContents);
-            // Explicitly clear MSBUILDUSESERVER so we test the -mt-implies-server path.
+            // Explicitly clear MSBUILDUSESERVER so we test the -mt-implies-server path, and isolate this
+            // test's server with a unique handshake salt so it can't reuse/shut down an unrelated server.
             _env.SetEnvironmentVariable("MSBUILDUSESERVER", null);
+            _env.SetEnvironmentVariable("MSBUILDNODEHANDSHAKESALT", Guid.NewGuid().ToString("N"));
 
             // Make sure we start with no server running.
             MSBuildClient.ShutdownServer(CancellationToken.None);
@@ -334,6 +336,8 @@ namespace Microsoft.Build.Engine.UnitTests
             string output1 = RunnerUtilities.ExecMSBuild(BuildEnvironmentHelper.Instance.CurrentMSBuildExePath, project.Path + " -mt", out bool success1, false, _output);
             success1.ShouldBeTrue();
             int serverPid1 = ParseNumber(output1, "Server ID is ");
+            // Register cleanup before any assertion so the server does not leak if an assertion throws.
+            _env.WithTransientProcess(serverPid1);
 
             string output2 = RunnerUtilities.ExecMSBuild(BuildEnvironmentHelper.Instance.CurrentMSBuildExePath, project.Path + " -mt", out bool success2, false, _output);
             success2.ShouldBeTrue();
@@ -341,7 +345,6 @@ namespace Microsoft.Build.Engine.UnitTests
 
             serverPid1.ShouldBe(serverPid2, "When -mt implies server, two consecutive builds should reuse the same server process. PIDs were " + serverPid1 + " and " + serverPid2 + ".");
 
-            _env.WithTransientProcess(serverPid1);
             // Clean up the server we spun up.
             MSBuildClient.ShutdownServer(CancellationToken.None);
         }

--- a/src/MSBuild.UnitTests/XMake_Tests.cs
+++ b/src/MSBuild.UnitTests/XMake_Tests.cs
@@ -3218,40 +3218,7 @@ EndGlobal
         }
 
         [Theory]
-        [InlineData(new[] { "proj.proj", "-mt" }, true)]
-        [InlineData(new[] { "proj.proj", "/mt" }, true)]
-        [InlineData(new[] { "proj.proj", "-multithreaded" }, true)]
-        [InlineData(new[] { "proj.proj", "-mt:true" }, true)]
-        [InlineData(new[] { "proj.proj", "-mt:false" }, false)]
-        [InlineData(new[] { "proj.proj", "-mt:0" }, false)]
-        [InlineData(new[] { "proj.proj", "-mt:" }, true)]
-        [InlineData(new[] { "proj.proj" }, false)]
-        [InlineData(new[] { "proj.proj", "-multiproc" }, false)]
-        // Last occurrence wins, matching MSBuild's boolean-switch semantics.
-        [InlineData(new[] { "proj.proj", "-mt:false", "-mt" }, true)]
-        [InlineData(new[] { "proj.proj", "-mt", "-mt:false" }, false)]
-        public void IsMultiThreadedRequestedDetectsCommandLineSwitch(string[] args, bool expected)
-        {
-            // MSBUILDFORCEMULTITHREADED must NOT influence the command-line detection used for the
-            // implicit server opt-in.
-            using TestEnvironment testEnvironment = TestEnvironment.Create();
-            testEnvironment.SetEnvironmentVariable("MSBUILDFORCEMULTITHREADED", null);
-
-            MSBuildApp.IsMultiThreadedRequested(args).ShouldBe(expected);
-        }
-
-        [Fact]
-        public void IsMultiThreadedRequestedIgnoresForceMultiThreadedEnvVar()
-        {
-            // The force/testing knob should not by itself imply the command-line -mt switch.
-            using TestEnvironment testEnvironment = TestEnvironment.Create();
-            testEnvironment.SetEnvironmentVariable("MSBUILDFORCEMULTITHREADED", "1");
-
-            MSBuildApp.IsMultiThreadedRequested(["proj.proj"]).ShouldBeFalse();
-        }
-
-        [Theory]
-        // MSBUILDUSESERVER value, -mt on command line, expected server use, expected reason.
+        // MSBUILDUSESERVER value, -mt build, expected server use, expected reason.
         [InlineData("1", false, true, "EnvVar")]
         [InlineData("1", true, true, "EnvVar")]
         [InlineData("0", true, false, "")]
@@ -3261,12 +3228,12 @@ EndGlobal
         [InlineData(null, true, true, "ImpliedByMt")]
         [InlineData(null, false, false, "")]
         [InlineData("", true, true, "ImpliedByMt")] // empty is treated as unset
-        public void ShouldUseMSBuildServerDecisionTree(string useServerValue, bool isMtOnCommandLine, bool expectedUseServer, string expectedReason)
+        public void ShouldUseMSBuildServerDecisionTree(string useServerValue, bool isMultiThreaded, bool expectedUseServer, string expectedReason)
         {
             using TestEnvironment testEnvironment = TestEnvironment.Create();
             testEnvironment.SetEnvironmentVariable("MSBUILDUSESERVER", useServerValue);
 
-            bool useServer = MSBuildApp.ShouldUseMSBuildServer(isMtOnCommandLine, out string reason);
+            bool useServer = MSBuildApp.ShouldUseMSBuildServer(isMultiThreaded, out string reason);
 
             useServer.ShouldBe(expectedUseServer);
             reason.ShouldBe(expectedReason);

--- a/src/MSBuild.UnitTests/XMake_Tests.cs
+++ b/src/MSBuild.UnitTests/XMake_Tests.cs
@@ -3265,33 +3265,11 @@ EndGlobal
         {
             using TestEnvironment testEnvironment = TestEnvironment.Create();
             testEnvironment.SetEnvironmentVariable("MSBUILDUSESERVER", useServerValue);
-            // Ensure the implicit -mt path's change wave is enabled for the test.
-            testEnvironment.SetEnvironmentVariable("MSBUILDDISABLEFEATURESFROMVERSION", null);
-            ChangeWaves.ResetStateForTests();
 
             bool useServer = MSBuildApp.ShouldUseMSBuildServer(isMtOnCommandLine, out string reason);
 
             useServer.ShouldBe(expectedUseServer);
             reason.ShouldBe(expectedReason);
-
-            ChangeWaves.ResetStateForTests();
-        }
-
-        [Fact]
-        public void ShouldUseMSBuildServerImpliedByMtRespectsChangeWave()
-        {
-            // With the change wave disabled, -mt must NOT implicitly engage the server.
-            using TestEnvironment testEnvironment = TestEnvironment.Create();
-            testEnvironment.SetEnvironmentVariable("MSBUILDUSESERVER", null);
-            testEnvironment.SetEnvironmentVariable("MSBUILDDISABLEFEATURESFROMVERSION", ChangeWaves.Wave18_8.ToString());
-            ChangeWaves.ResetStateForTests();
-
-            bool useServer = MSBuildApp.ShouldUseMSBuildServer(isMultiThreadedOnCommandLine: true, out string reason);
-
-            useServer.ShouldBeFalse();
-            reason.ShouldBe(string.Empty);
-
-            ChangeWaves.ResetStateForTests();
         }
 
         private string CopyMSBuild()

--- a/src/MSBuild.UnitTests/XMake_Tests.cs
+++ b/src/MSBuild.UnitTests/XMake_Tests.cs
@@ -3217,6 +3217,83 @@ EndGlobal
             MSBuildApp.IsMultiThreadedEnabled(switches).ShouldBeFalse();
         }
 
+        [Theory]
+        [InlineData(new[] { "proj.proj", "-mt" }, true)]
+        [InlineData(new[] { "proj.proj", "/mt" }, true)]
+        [InlineData(new[] { "proj.proj", "-multithreaded" }, true)]
+        [InlineData(new[] { "proj.proj", "-mt:true" }, true)]
+        [InlineData(new[] { "proj.proj", "-mt:false" }, false)]
+        [InlineData(new[] { "proj.proj", "-mt:0" }, false)]
+        [InlineData(new[] { "proj.proj", "-mt:" }, true)]
+        [InlineData(new[] { "proj.proj" }, false)]
+        [InlineData(new[] { "proj.proj", "-multiproc" }, false)]
+        // Last occurrence wins, matching MSBuild's boolean-switch semantics.
+        [InlineData(new[] { "proj.proj", "-mt:false", "-mt" }, true)]
+        [InlineData(new[] { "proj.proj", "-mt", "-mt:false" }, false)]
+        public void IsMultiThreadedRequestedDetectsCommandLineSwitch(string[] args, bool expected)
+        {
+            // MSBUILDFORCEMULTITHREADED must NOT influence the command-line detection used for the
+            // implicit server opt-in.
+            using TestEnvironment testEnvironment = TestEnvironment.Create();
+            testEnvironment.SetEnvironmentVariable("MSBUILDFORCEMULTITHREADED", null);
+
+            MSBuildApp.IsMultiThreadedRequested(args).ShouldBe(expected);
+        }
+
+        [Fact]
+        public void IsMultiThreadedRequestedIgnoresForceMultiThreadedEnvVar()
+        {
+            // The force/testing knob should not by itself imply the command-line -mt switch.
+            using TestEnvironment testEnvironment = TestEnvironment.Create();
+            testEnvironment.SetEnvironmentVariable("MSBUILDFORCEMULTITHREADED", "1");
+
+            MSBuildApp.IsMultiThreadedRequested(["proj.proj"]).ShouldBeFalse();
+        }
+
+        [Theory]
+        // MSBUILDUSESERVER value, -mt on command line, expected server use, expected reason.
+        [InlineData("1", false, true, "EnvVar")]
+        [InlineData("1", true, true, "EnvVar")]
+        [InlineData("0", true, false, "")]
+        [InlineData("0", false, false, "")]
+        [InlineData("false", true, false, "")] // any explicit non-"1" value opts out
+        [InlineData("true", true, false, "")]
+        [InlineData(null, true, true, "ImpliedByMt")]
+        [InlineData(null, false, false, "")]
+        [InlineData("", true, true, "ImpliedByMt")] // empty is treated as unset
+        public void ShouldUseMSBuildServerDecisionTree(string useServerValue, bool isMtOnCommandLine, bool expectedUseServer, string expectedReason)
+        {
+            using TestEnvironment testEnvironment = TestEnvironment.Create();
+            testEnvironment.SetEnvironmentVariable("MSBUILDUSESERVER", useServerValue);
+            // Ensure the implicit -mt path's change wave is enabled for the test.
+            testEnvironment.SetEnvironmentVariable("MSBUILDDISABLEFEATURESFROMVERSION", null);
+            ChangeWaves.ResetStateForTests();
+
+            bool useServer = MSBuildApp.ShouldUseMSBuildServer(isMtOnCommandLine, out string reason);
+
+            useServer.ShouldBe(expectedUseServer);
+            reason.ShouldBe(expectedReason);
+
+            ChangeWaves.ResetStateForTests();
+        }
+
+        [Fact]
+        public void ShouldUseMSBuildServerImpliedByMtRespectsChangeWave()
+        {
+            // With the change wave disabled, -mt must NOT implicitly engage the server.
+            using TestEnvironment testEnvironment = TestEnvironment.Create();
+            testEnvironment.SetEnvironmentVariable("MSBUILDUSESERVER", null);
+            testEnvironment.SetEnvironmentVariable("MSBUILDDISABLEFEATURESFROMVERSION", ChangeWaves.Wave18_8.ToString());
+            ChangeWaves.ResetStateForTests();
+
+            bool useServer = MSBuildApp.ShouldUseMSBuildServer(isMultiThreadedOnCommandLine: true, out string reason);
+
+            useServer.ShouldBeFalse();
+            reason.ShouldBe(string.Empty);
+
+            ChangeWaves.ResetStateForTests();
+        }
+
         private string CopyMSBuild()
         {
             string dest = null;

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -309,14 +309,26 @@ namespace Microsoft.Build.CommandLine
                 DumpCounters(true /* initialize only */);
             }
 
+            // Determine once whether this is a multithreaded (/mt) build. This single value drives
+            // two related decisions:
+            //   (1) whether to engage MSBuild Server implicitly (this PR: -mt implies server), and
+            //   (2) whether the server, once engaged, is launched with Server GC (the base PR).
+            // Computed with a cheap command-line scan (plus the MSBUILDFORCEMULTITHREADED opt-in) so
+            // the common no-server path does not pay for the full GatherAllSwitches parse here.
+            bool multiThreaded = IsMultiThreadedRequested(args);
+
             int exitCode;
             if (
-                Environment.GetEnvironmentVariable(Traits.UseMSBuildServerEnvVarName) == "1" &&
+                ShouldUseMSBuildServer(multiThreaded, out string serverEnableReason) &&
                 !Traits.Instance.EscapeHatches.EnsureStdOutForChildNodesIsPrimaryStdout &&
-                CanRunServerBasedOnCommandLineSwitches(args, out bool multiThreaded))
+                CanRunServerBasedOnCommandLineSwitches(args))
             {
                 Console.CancelKeyPress += Console_CancelKeyPress;
 
+                if (KnownTelemetry.PartialBuildTelemetry != null)
+                {
+                    KnownTelemetry.PartialBuildTelemetry.ServerEnableReason = serverEnableReason;
+                }
 
                 // Use the client app to execute build in msbuild server. Opt-in feature.
                 exitCode = ((s_initialized && MSBuildClientApp.Execute(args, multiThreaded, s_buildCancellationSource.Token) == ExitType.Success) ? 0 : 1);
@@ -343,10 +355,9 @@ namespace Microsoft.Build.CommandLine
         /// <remarks>
         /// Will not throw. If arguments processing fails, we will not run it on server - no reason as it will not run any build anyway.
         /// </remarks>
-        private static bool CanRunServerBasedOnCommandLineSwitches(string[] commandLine, out bool multiThreaded)
+        private static bool CanRunServerBasedOnCommandLineSwitches(string[] commandLine)
         {
             bool canRunServer = true;
-            multiThreaded = false;
             try
             {
                 commandLineParser.GatherAllSwitches(
@@ -362,11 +373,6 @@ namespace Microsoft.Build.CommandLine
                 {
                     commandLineSwitches = CombineSwitchesRespectingPriority(switchesFromAutoResponseFile, switchesNotFromAutoResponseFile, fullCommandLine);
                 }
-
-                // Determine multithreaded mode from the fully-parsed switches (which include any
-                // response-file-provided switches) using the same logic as the in-proc build path.
-                multiThreaded = IsMultiThreadedEnabled(commandLineSwitches);
-
                 string projectFile = ProcessProjectSwitch(commandLineSwitches[CommandLineSwitches.ParameterizedSwitch.Project], commandLineSwitches[CommandLineSwitches.ParameterizedSwitch.IgnoreProjectExtensions], Directory.GetFiles);
                 if (commandLineSwitches[CommandLineSwitches.ParameterlessSwitch.Help] ||
                     commandLineSwitches.IsParameterizedSwitchSet(CommandLineSwitches.ParameterizedSwitch.NodeMode) ||
@@ -392,6 +398,121 @@ namespace Microsoft.Build.CommandLine
             }
 
             return canRunServer;
+        }
+
+        /// <summary>
+        /// Returns true if MSBuild Server should be used for this invocation.
+        /// </summary>
+        /// <remarks>
+        /// Decision tree:
+        /// <list type="bullet">
+        ///   <item><c>MSBUILDUSESERVER=1</c> → use server (existing explicit opt-in).</item>
+        ///   <item><c>MSBUILDUSESERVER=0</c> → do NOT use server (explicit opt-out, takes precedence over -mt).</item>
+        ///   <item><c>MSBUILDUSESERVER</c> unset AND this is a multithreaded (<c>-mt</c>) build → use server.
+        ///         Rationale: <c>-mt</c> users already accept process-shared state (in-proc thread workers
+        ///         instead of multi-process worker nodes), so server reuse barely adds risk and recovers the
+        ///         per-invocation JIT/SDK-resolution warm-up cost that <c>-mt</c> would otherwise pay every
+        ///         build (because <c>-mt</c> shares the entry process with the build instead of the workers).
+        ///         See <see href="https://github.com/dotnet/msbuild/issues/9379">#9379</see>.</item>
+        ///   <item>Otherwise → no server (existing default).</item>
+        /// </list>
+        /// </remarks>
+        /// <param name="multiThreaded">Whether this is a multithreaded (/mt) build, as determined by
+        /// <see cref="IsMultiThreadedRequested"/>.</param>
+        /// <param name="serverEnableReason">Telemetry-friendly reason: "EnvVar", "ImpliedByMt", or empty when not enabled.</param>
+        /// <returns>True if server should be used.</returns>
+        private static bool ShouldUseMSBuildServer(bool multiThreaded, out string serverEnableReason)
+        {
+            serverEnableReason = string.Empty;
+            string envVar = Environment.GetEnvironmentVariable(Traits.UseMSBuildServerEnvVarName);
+
+            if (envVar == "1")
+            {
+                serverEnableReason = "EnvVar";
+                return true;
+            }
+
+            // Explicit opt-out: MSBUILDUSESERVER=0 always wins, even if -mt is on the command line.
+            if (envVar == "0")
+            {
+                return false;
+            }
+
+            // Implicit opt-in via -mt.
+            if (multiThreaded)
+            {
+                serverEnableReason = "ImpliedByMt";
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Determines whether this invocation requests a multithreaded (/mt) build. This single
+        /// determination feeds both the implicit server opt-in (<see cref="ShouldUseMSBuildServer"/>)
+        /// and the server's Server GC decision (passed to <see cref="MSBuildClientApp.Execute(string[], bool, System.Threading.CancellationToken)"/>).
+        /// </summary>
+        /// <remarks>
+        /// Uses a lightweight command-line scan (plus the <c>MSBUILDFORCEMULTITHREADED</c> opt-in) rather
+        /// than the full <c>GatherAllSwitches</c> parse: this runs on every invocation (including the
+        /// common no-server path), and the full parse is expensive and already runs later for the actual
+        /// build. Intentionally conservative — returns false on any parse problem, which only declines the
+        /// implicit server opt-in; the explicit <c>MSBUILDUSESERVER=1</c> path is unaffected. A consequence
+        /// is that <c>-mt</c> supplied via a response file is not detected here.
+        /// </remarks>
+        /// <param name="args">Raw command-line arguments.</param>
+        /// <returns>True if this is a multithreaded build.</returns>
+        private static bool IsMultiThreadedRequested(string[] args)
+        {
+            if (Traits.Instance.ForceMultiThreaded)
+            {
+                return true;
+            }
+
+            if (args is null)
+            {
+                return false;
+            }
+
+            foreach (string arg in args)
+            {
+                if (string.IsNullOrEmpty(arg) || arg.Length < 2)
+                {
+                    continue;
+                }
+
+                // Switches start with - or / (and on Unix, - is the only convention).
+                char prefix = arg[0];
+                if (prefix != '-' && prefix != '/')
+                {
+                    continue;
+                }
+
+                // Strip leading - or /, then split on : to get the switch name (ignore any value/parameters).
+                string body = arg.Substring(1);
+                int colonIndex = body.IndexOf(':');
+                string switchName = colonIndex >= 0 ? body.Substring(0, colonIndex) : body;
+
+                if (switchName.Equals("mt", StringComparison.OrdinalIgnoreCase) ||
+                    switchName.Equals("multithreaded", StringComparison.OrdinalIgnoreCase))
+                {
+                    // Honor an explicit ":false" value if present (matches ProcessBooleanSwitch semantics).
+                    if (colonIndex >= 0)
+                    {
+                        string value = body.Substring(colonIndex + 1);
+                        if (value.Equals("false", StringComparison.OrdinalIgnoreCase) ||
+                            value.Equals("0", StringComparison.OrdinalIgnoreCase))
+                        {
+                            return false;
+                        }
+                    }
+
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         /// <summary>

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -309,28 +309,29 @@ namespace Microsoft.Build.CommandLine
                 DumpCounters(true /* initialize only */);
             }
 
-            // Determine once whether this is a multithreaded (/mt) build. This single value drives
-            // two related decisions:
-            //   (1) whether to engage MSBuild Server implicitly (this PR: -mt implies server), and
-            //   (2) whether the server, once engaged, is launched with Server GC (the base PR).
-            // Computed with a cheap command-line scan (plus the MSBUILDFORCEMULTITHREADED opt-in) so
-            // the common no-server path does not pay for the full GatherAllSwitches parse here.
-            bool multiThreaded = IsMultiThreadedRequested(args);
+            // Whether -mt was passed on the command line. This is the cheap, early signal used to
+            // decide implicit server engagement (this PR: -mt implies server) - it runs on every
+            // invocation (including the common no-server path), so it must not pay for the full
+            // GatherAllSwitches parse. It deliberately does NOT consider MSBUILDFORCEMULTITHREADED or
+            // response-file content (see IsMultiThreadedRequested remarks).
+            bool isMultiThreadedOnCommandLine = IsMultiThreadedRequested(args);
 
             int exitCode;
             if (
-                ShouldUseMSBuildServer(multiThreaded, out string serverEnableReason) &&
+                ShouldUseMSBuildServer(isMultiThreadedOnCommandLine, out string serverEnableReason) &&
                 !Traits.Instance.EscapeHatches.EnsureStdOutForChildNodesIsPrimaryStdout &&
-                CanRunServerBasedOnCommandLineSwitches(args))
+                CanRunServerBasedOnCommandLineSwitches(args, out bool multiThreaded))
             {
                 Console.CancelKeyPress += Console_CancelKeyPress;
 
-                if (KnownTelemetry.PartialBuildTelemetry != null)
+                if (KnownTelemetry.PartialBuildTelemetry is not null)
                 {
                     KnownTelemetry.PartialBuildTelemetry.ServerEnableReason = serverEnableReason;
                 }
 
-                // Use the client app to execute build in msbuild server. Opt-in feature.
+                // Use the client app to execute build in msbuild server. The authoritative multiThreaded
+                // value (from the full parse, which expands response files and honors
+                // MSBUILDFORCEMULTITHREADED) decides whether the server is launched with Server GC.
                 exitCode = ((s_initialized && MSBuildClientApp.Execute(args, multiThreaded, s_buildCancellationSource.Token) == ExitType.Success) ? 0 : 1);
             }
             else
@@ -355,9 +356,15 @@ namespace Microsoft.Build.CommandLine
         /// <remarks>
         /// Will not throw. If arguments processing fails, we will not run it on server - no reason as it will not run any build anyway.
         /// </remarks>
-        private static bool CanRunServerBasedOnCommandLineSwitches(string[] commandLine)
+        /// <param name="commandLine">Raw command-line arguments.</param>
+        /// <param name="multiThreaded">Set to whether this is a multithreaded (/mt) build, determined from
+        /// the fully-parsed switches (which expand response files and honor MSBUILDFORCEMULTITHREADED) using
+        /// the same logic as the in-proc build path. This is the authoritative value used to decide whether
+        /// the server is launched with Server GC.</param>
+        private static bool CanRunServerBasedOnCommandLineSwitches(string[] commandLine, out bool multiThreaded)
         {
             bool canRunServer = true;
+            multiThreaded = false;
             try
             {
                 commandLineParser.GatherAllSwitches(
@@ -373,6 +380,12 @@ namespace Microsoft.Build.CommandLine
                 {
                     commandLineSwitches = CombineSwitchesRespectingPriority(switchesFromAutoResponseFile, switchesNotFromAutoResponseFile, fullCommandLine);
                 }
+
+                // Authoritative /mt determination from the fully-parsed switches (includes response-file
+                // switches and MSBUILDFORCEMULTITHREADED), matching the in-proc build path. Used to decide
+                // Server GC for the launched server.
+                multiThreaded = IsMultiThreadedEnabled(commandLineSwitches);
+
                 string projectFile = ProcessProjectSwitch(commandLineSwitches[CommandLineSwitches.ParameterizedSwitch.Project], commandLineSwitches[CommandLineSwitches.ParameterizedSwitch.IgnoreProjectExtensions], Directory.GetFiles);
                 if (commandLineSwitches[CommandLineSwitches.ParameterlessSwitch.Help] ||
                     commandLineSwitches.IsParameterizedSwitchSet(CommandLineSwitches.ParameterizedSwitch.NodeMode) ||
@@ -381,7 +394,7 @@ namespace Microsoft.Build.CommandLine
                     !ProcessNodeReuseSwitch(commandLineSwitches[CommandLineSwitches.ParameterizedSwitch.NodeReuse]))
                 {
                     canRunServer = false;
-                    if (KnownTelemetry.PartialBuildTelemetry != null)
+                    if (KnownTelemetry.PartialBuildTelemetry is not null)
                     {
                         KnownTelemetry.PartialBuildTelemetry.ServerFallbackReason = "Arguments";
                     }
@@ -390,7 +403,7 @@ namespace Microsoft.Build.CommandLine
             catch (Exception ex)
             {
                 CommunicationsUtilities.Trace($"Unexpected exception during command line parsing. Can not determine if it is allowed to use Server. Fall back to old behavior. Exception: {ex}");
-                if (KnownTelemetry.PartialBuildTelemetry != null)
+                if (KnownTelemetry.PartialBuildTelemetry is not null)
                 {
                     KnownTelemetry.PartialBuildTelemetry.ServerFallbackReason = "ErrorParsingCommandLine";
                 }
@@ -407,21 +420,24 @@ namespace Microsoft.Build.CommandLine
         /// Decision tree:
         /// <list type="bullet">
         ///   <item><c>MSBUILDUSESERVER=1</c> → use server (existing explicit opt-in).</item>
-        ///   <item><c>MSBUILDUSESERVER=0</c> → do NOT use server (explicit opt-out, takes precedence over -mt).</item>
-        ///   <item><c>MSBUILDUSESERVER</c> unset AND this is a multithreaded (<c>-mt</c>) build → use server.
-        ///         Rationale: <c>-mt</c> users already accept process-shared state (in-proc thread workers
-        ///         instead of multi-process worker nodes), so server reuse barely adds risk and recovers the
-        ///         per-invocation JIT/SDK-resolution warm-up cost that <c>-mt</c> would otherwise pay every
-        ///         build (because <c>-mt</c> shares the entry process with the build instead of the workers).
-        ///         See <see href="https://github.com/dotnet/msbuild/issues/9379">#9379</see>.</item>
+        ///   <item><c>MSBUILDUSESERVER</c> set to any other non-empty value (e.g. <c>0</c>, <c>false</c>) →
+        ///         do NOT use server (explicit opt-out, takes precedence over -mt). Only <c>1</c> opts in,
+        ///         matching the pre-existing "only <c>1</c> enables the server" semantics.</item>
+        ///   <item><c>MSBUILDUSESERVER</c> unset AND <c>-mt</c> was on the command line AND the change wave
+        ///         is enabled → use server. Rationale: <c>-mt</c> users already accept process-shared state
+        ///         (in-proc thread workers instead of multi-process worker nodes), so server reuse barely
+        ///         adds risk and recovers the per-invocation JIT/SDK-resolution warm-up cost that <c>-mt</c>
+        ///         would otherwise pay every build. See <see href="https://github.com/dotnet/msbuild/issues/9379">#9379</see>.</item>
         ///   <item>Otherwise → no server (existing default).</item>
         /// </list>
+        /// The implicit <c>-mt</c> path is gated behind <see cref="ChangeWaves.Wave18_8"/> so it can be
+        /// disabled via <c>MSBUILDDISABLEFEATURESFROMVERSION</c> for users who are not ready for the server.
         /// </remarks>
-        /// <param name="multiThreaded">Whether this is a multithreaded (/mt) build, as determined by
-        /// <see cref="IsMultiThreadedRequested"/>.</param>
+        /// <param name="isMultiThreadedOnCommandLine">Whether <c>-mt</c> was passed on the command line, as
+        /// determined by <see cref="IsMultiThreadedRequested"/>.</param>
         /// <param name="serverEnableReason">Telemetry-friendly reason: "EnvVar", "ImpliedByMt", or empty when not enabled.</param>
         /// <returns>True if server should be used.</returns>
-        private static bool ShouldUseMSBuildServer(bool multiThreaded, out string serverEnableReason)
+        internal static bool ShouldUseMSBuildServer(bool isMultiThreadedOnCommandLine, out string serverEnableReason)
         {
             serverEnableReason = string.Empty;
             string envVar = Environment.GetEnvironmentVariable(Traits.UseMSBuildServerEnvVarName);
@@ -432,14 +448,16 @@ namespace Microsoft.Build.CommandLine
                 return true;
             }
 
-            // Explicit opt-out: MSBUILDUSESERVER=0 always wins, even if -mt is on the command line.
-            if (envVar == "0")
+            // Any explicit non-empty MSBUILDUSESERVER value other than "1" opts out (e.g. "0", "false").
+            // Only a genuinely unset/empty value falls through to the implicit -mt opt-in, preserving the
+            // pre-existing rule that only "1" engages the server.
+            if (!string.IsNullOrEmpty(envVar))
             {
                 return false;
             }
 
-            // Implicit opt-in via -mt.
-            if (multiThreaded)
+            // Implicit opt-in via -mt, gated behind a change wave so it can be turned off.
+            if (isMultiThreadedOnCommandLine && ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave18_8))
             {
                 serverEnableReason = "ImpliedByMt";
                 return true;
@@ -449,31 +467,33 @@ namespace Microsoft.Build.CommandLine
         }
 
         /// <summary>
-        /// Determines whether this invocation requests a multithreaded (/mt) build. This single
-        /// determination feeds both the implicit server opt-in (<see cref="ShouldUseMSBuildServer"/>)
-        /// and the server's Server GC decision (passed to <see cref="MSBuildClientApp.Execute(string[], bool, System.Threading.CancellationToken)"/>).
+        /// Lightweight check for whether <c>-mt</c>/<c>-multithreaded</c> was passed on the command line,
+        /// used for the early implicit-server-opt-in decision in <see cref="ShouldUseMSBuildServer"/>.
         /// </summary>
         /// <remarks>
-        /// Uses a lightweight command-line scan (plus the <c>MSBUILDFORCEMULTITHREADED</c> opt-in) rather
-        /// than the full <c>GatherAllSwitches</c> parse: this runs on every invocation (including the
-        /// common no-server path), and the full parse is expensive and already runs later for the actual
-        /// build. Intentionally conservative — returns false on any parse problem, which only declines the
-        /// implicit server opt-in; the explicit <c>MSBUILDUSESERVER=1</c> path is unaffected. A consequence
-        /// is that <c>-mt</c> supplied via a response file is not detected here.
+        /// Deliberately cheap and allocation-free: this runs on every invocation (including the common
+        /// no-server path), so it does NOT do the full <c>GatherAllSwitches</c> parse (which is expensive
+        /// and already runs later for the actual build). Consequences, all acceptable for an opt-in
+        /// heuristic (the authoritative /mt value for Server GC comes from
+        /// <see cref="CanRunServerBasedOnCommandLineSwitches"/>):
+        /// <list type="bullet">
+        ///   <item><c>-mt</c> supplied via a response file is not detected here, so it does not trigger the
+        ///         implicit server opt-in.</item>
+        ///   <item><c>MSBUILDFORCEMULTITHREADED</c> is intentionally NOT considered: that force/testing knob
+        ///         should not by itself engage the long-lived server.</item>
+        /// </list>
+        /// Matches MSBuild's "last occurrence wins" semantics for the boolean switch.
         /// </remarks>
         /// <param name="args">Raw command-line arguments.</param>
-        /// <returns>True if this is a multithreaded build.</returns>
-        private static bool IsMultiThreadedRequested(string[] args)
+        /// <returns>True if <c>-mt</c>/<c>-multithreaded</c> was last set to a truthy value on the command line.</returns>
+        internal static bool IsMultiThreadedRequested(string[] args)
         {
-            if (Traits.Instance.ForceMultiThreaded)
-            {
-                return true;
-            }
-
             if (args is null)
             {
                 return false;
             }
+
+            bool result = false;
 
             foreach (string arg in args)
             {
@@ -483,36 +503,37 @@ namespace Microsoft.Build.CommandLine
                 }
 
                 // Switches start with - or / (and on Unix, - is the only convention).
-                char prefix = arg[0];
-                if (prefix != '-' && prefix != '/')
+                if (arg[0] != '-' && arg[0] != '/')
                 {
                     continue;
                 }
 
-                // Strip leading - or /, then split on : to get the switch name (ignore any value/parameters).
-                string body = arg.Substring(1);
+                // Strip leading - or /, then split on : into switch name and (optional) value.
+                ReadOnlySpan<char> body = arg.AsSpan(1);
                 int colonIndex = body.IndexOf(':');
-                string switchName = colonIndex >= 0 ? body.Substring(0, colonIndex) : body;
+                ReadOnlySpan<char> switchName = colonIndex >= 0 ? body.Slice(0, colonIndex) : body;
 
-                if (switchName.Equals("mt", StringComparison.OrdinalIgnoreCase) ||
-                    switchName.Equals("multithreaded", StringComparison.OrdinalIgnoreCase))
+                if (!switchName.Equals("mt".AsSpan(), StringComparison.OrdinalIgnoreCase) &&
+                    !switchName.Equals("multithreaded".AsSpan(), StringComparison.OrdinalIgnoreCase))
                 {
-                    // Honor an explicit ":false" value if present (matches ProcessBooleanSwitch semantics).
-                    if (colonIndex >= 0)
-                    {
-                        string value = body.Substring(colonIndex + 1);
-                        if (value.Equals("false", StringComparison.OrdinalIgnoreCase) ||
-                            value.Equals("0", StringComparison.OrdinalIgnoreCase))
-                        {
-                            return false;
-                        }
-                    }
+                    continue;
+                }
 
-                    return true;
+                // Honor an explicit ":false"/":0" value (matches ProcessBooleanSwitch semantics). Do not
+                // return early: a later occurrence wins, so keep scanning and record this occurrence's value.
+                if (colonIndex >= 0)
+                {
+                    ReadOnlySpan<char> value = body.Slice(colonIndex + 1);
+                    result = !value.Equals("false".AsSpan(), StringComparison.OrdinalIgnoreCase) &&
+                             !value.Equals("0".AsSpan(), StringComparison.OrdinalIgnoreCase);
+                }
+                else
+                {
+                    result = true;
                 }
             }
 
-            return false;
+            return result;
         }
 
         /// <summary>

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -322,9 +322,9 @@ namespace Microsoft.Build.CommandLine
 
             int exitCode;
             if (
+                canRunServer &&
                 ShouldUseMSBuildServer(multiThreaded, out string serverEnableReason) &&
-                !Traits.Instance.EscapeHatches.EnsureStdOutForChildNodesIsPrimaryStdout &&
-                canRunServer)
+                !Traits.Instance.EscapeHatches.EnsureStdOutForChildNodesIsPrimaryStdout)
             {
                 Console.CancelKeyPress += Console_CancelKeyPress;
 
@@ -333,16 +333,15 @@ namespace Microsoft.Build.CommandLine
                     KnownTelemetry.PartialBuildTelemetry.ServerEnableReason = serverEnableReason;
                 }
 
-                // Use the client app to execute build in msbuild server. The authoritative multiThreaded
-                // value (from the full parse, which expands response files and honors
-                // MSBUILDFORCEMULTITHREADED) decides whether the server is launched with Server GC.
+                // Hand the build off to the MSBuild Server client. The server (not this process) decides
+                // Server GC for itself from the multiThreaded value we pass through.
                 exitCode = ((s_initialized && MSBuildClientApp.Execute(args, multiThreaded, s_buildCancellationSource.Token) == ExitType.Success) ? 0 : 1);
             }
             else
             {
                 // return 0 on success, non-zero on failure. Reuse the switches already gathered above (when the
-                // parse succeeded) so the build is not parsed a second time; on parse failure they are null and
-                // Execute re-parses to surface the error.
+                // parse succeeded) so the command line is not parsed a second time; on parse failure they are null
+                // and Execute re-parses to surface the error.
                 exitCode = ((s_initialized && Execute(args, switchesFromAutoResponseFile, switchesNotFromAutoResponseFile) == ExitType.Success) ? 0 : 1);
             }
 
@@ -407,9 +406,6 @@ namespace Microsoft.Build.CommandLine
                 // (commandLineParser.IncludedResponseFiles) stays intact - even if a validation step below throws.
                 switchesFullyGathered = true;
 
-                // Authoritative /mt determination from the fully-parsed switches (includes response-file
-                // switches and MSBUILDFORCEMULTITHREADED), matching the in-proc build path. Used to decide
-                // both implicit server engagement and Server GC for the launched server.
                 multiThreaded = IsMultiThreadedEnabled(commandLineSwitches);
 
                 string projectFile = ProcessProjectSwitch(commandLineSwitches[CommandLineSwitches.ParameterizedSwitch.Project], commandLineSwitches[CommandLineSwitches.ParameterizedSwitch.IgnoreProjectExtensions], Directory.GetFiles);

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -309,18 +309,22 @@ namespace Microsoft.Build.CommandLine
                 DumpCounters(true /* initialize only */);
             }
 
-            // Whether -mt was passed on the command line. This is the cheap, early signal used to
-            // decide implicit server engagement (this PR: -mt implies server) - it runs on every
-            // invocation (including the common no-server path), so it must not pay for the full
-            // GatherAllSwitches parse. It deliberately does NOT consider MSBUILDFORCEMULTITHREADED or
-            // response-file content (see IsMultiThreadedRequested remarks).
-            bool isMultiThreadedOnCommandLine = IsMultiThreadedRequested(args);
+            // Perform the single authoritative command-line parse for this process. It yields:
+            //   - canRunServer: whether switches (help/version/binlog/nodereuse/...) permit the server;
+            //   - multiThreaded: the response-file-aware /mt determination (includes the auto-response file,
+            //     any project Directory.Build.rsp, @response files, and MSBUILDFORCEMULTITHREADED);
+            //   - the gathered switches, which the in-proc build path below reuses so it does not re-parse.
+            bool canRunServer = CanRunServerBasedOnCommandLineSwitches(
+                args,
+                out bool multiThreaded,
+                out CommandLineSwitches switchesFromAutoResponseFile,
+                out CommandLineSwitches switchesNotFromAutoResponseFile);
 
             int exitCode;
             if (
-                ShouldUseMSBuildServer(isMultiThreadedOnCommandLine, out string serverEnableReason) &&
+                ShouldUseMSBuildServer(multiThreaded, out string serverEnableReason) &&
                 !Traits.Instance.EscapeHatches.EnsureStdOutForChildNodesIsPrimaryStdout &&
-                CanRunServerBasedOnCommandLineSwitches(args, out bool multiThreaded))
+                canRunServer)
             {
                 Console.CancelKeyPress += Console_CancelKeyPress;
 
@@ -336,8 +340,10 @@ namespace Microsoft.Build.CommandLine
             }
             else
             {
-                // return 0 on success, non-zero on failure
-                exitCode = ((s_initialized && Execute(args) == ExitType.Success) ? 0 : 1);
+                // return 0 on success, non-zero on failure. Reuse the switches already gathered above (when the
+                // parse succeeded) so the build is not parsed a second time; on parse failure they are null and
+                // Execute re-parses to surface the error.
+                exitCode = ((s_initialized && Execute(args, switchesFromAutoResponseFile, switchesNotFromAutoResponseFile) == ExitType.Success) ? 0 : 1);
             }
 
             if (Environment.GetEnvironmentVariable("MSBUILDDUMPPROCESSCOUNTERS") == "1")
@@ -355,23 +361,38 @@ namespace Microsoft.Build.CommandLine
         /// </summary>
         /// <remarks>
         /// Will not throw. If arguments processing fails, we will not run it on server - no reason as it will not run any build anyway.
+        /// This performs the single authoritative command-line parse for the process: the gathered switches are
+        /// returned so the in-proc build path (<see cref="Execute(string[], CommandLineSwitches, CommandLineSwitches)"/>)
+        /// can reuse them instead of parsing a second time.
         /// </remarks>
         /// <param name="commandLine">Raw command-line arguments.</param>
         /// <param name="multiThreaded">Set to whether this is a multithreaded (/mt) build, determined from
-        /// the fully-parsed switches (which expand response files and honor MSBUILDFORCEMULTITHREADED) using
-        /// the same logic as the in-proc build path. This is the authoritative value used to decide whether
+        /// the fully-parsed switches (which expand response files - including any project <c>Directory.Build.rsp</c> -
+        /// and honor MSBUILDFORCEMULTITHREADED) using the same logic as the in-proc build path. This is the
+        /// authoritative value used both to decide whether <c>-mt</c> implicitly engages the server and whether
         /// the server is launched with Server GC.</param>
-        private static bool CanRunServerBasedOnCommandLineSwitches(string[] commandLine, out bool multiThreaded)
+        /// <param name="switchesFromAutoResponseFile">The gathered response-file switches (auto-response file plus any
+        /// project <c>Directory.Build.rsp</c>), or <see langword="null"/> if parsing failed.</param>
+        /// <param name="switchesNotFromAutoResponseFile">The gathered command-line/environment switches, or
+        /// <see langword="null"/> if parsing failed.</param>
+        private static bool CanRunServerBasedOnCommandLineSwitches(
+            string[] commandLine,
+            out bool multiThreaded,
+            out CommandLineSwitches switchesFromAutoResponseFile,
+            out CommandLineSwitches switchesNotFromAutoResponseFile)
         {
             bool canRunServer = true;
             multiThreaded = false;
+            switchesFromAutoResponseFile = null;
+            switchesNotFromAutoResponseFile = null;
+            bool switchesFullyGathered = false;
             try
             {
                 commandLineParser.GatherAllSwitches(
                     commandLine,
                     s_globalMessagesToLogInBuildLoggers,
-                    out CommandLineSwitches switchesFromAutoResponseFile,
-                    out CommandLineSwitches switchesNotFromAutoResponseFile,
+                    out switchesFromAutoResponseFile,
+                    out switchesNotFromAutoResponseFile,
                     out string fullCommandLine,
                     out s_exeName);
 
@@ -381,9 +402,14 @@ namespace Microsoft.Build.CommandLine
                     commandLineSwitches = CombineSwitchesRespectingPriority(switchesFromAutoResponseFile, switchesNotFromAutoResponseFile, fullCommandLine);
                 }
 
+                // From here the switches are fully gathered (including any project Directory.Build.rsp), so the
+                // in-proc build path can safely reuse them - and the gather's response-file bookkeeping
+                // (commandLineParser.IncludedResponseFiles) stays intact - even if a validation step below throws.
+                switchesFullyGathered = true;
+
                 // Authoritative /mt determination from the fully-parsed switches (includes response-file
                 // switches and MSBUILDFORCEMULTITHREADED), matching the in-proc build path. Used to decide
-                // Server GC for the launched server.
+                // both implicit server engagement and Server GC for the launched server.
                 multiThreaded = IsMultiThreadedEnabled(commandLineSwitches);
 
                 string projectFile = ProcessProjectSwitch(commandLineSwitches[CommandLineSwitches.ParameterizedSwitch.Project], commandLineSwitches[CommandLineSwitches.ParameterizedSwitch.IgnoreProjectExtensions], Directory.GetFiles);
@@ -408,6 +434,17 @@ namespace Microsoft.Build.CommandLine
                     KnownTelemetry.PartialBuildTelemetry.ServerFallbackReason = "ErrorParsingCommandLine";
                 }
                 canRunServer = false;
+
+                if (!switchesFullyGathered)
+                {
+                    // Gathering itself did not complete (e.g. a malformed @response file); discard the partial
+                    // results so the in-proc path re-parses from scratch and surfaces the error exactly as it
+                    // would without the server check. When the switches were fully gathered and only a later
+                    // validation step threw, keep them so Execute reuses the single parse and surfaces the error
+                    // with consistent response-file state.
+                    switchesFromAutoResponseFile = null;
+                    switchesNotFromAutoResponseFile = null;
+                }
             }
 
             return canRunServer;
@@ -423,7 +460,7 @@ namespace Microsoft.Build.CommandLine
         ///   <item><c>MSBUILDUSESERVER</c> set to any other non-empty value (e.g. <c>0</c>, <c>false</c>) →
         ///         do NOT use server (explicit opt-out, takes precedence over -mt). Only <c>1</c> opts in,
         ///         matching the pre-existing "only <c>1</c> enables the server" semantics.</item>
-        ///   <item><c>MSBUILDUSESERVER</c> unset AND <c>-mt</c> was on the command line → use server.
+        ///   <item><c>MSBUILDUSESERVER</c> unset AND this is a <c>-mt</c> (multithreaded) build → use server.
         ///         Rationale: <c>-mt</c> users already accept process-shared state
         ///         (in-proc thread workers instead of multi-process worker nodes), so server reuse barely
         ///         adds risk and recovers the per-invocation JIT/SDK-resolution warm-up cost that <c>-mt</c>
@@ -432,11 +469,13 @@ namespace Microsoft.Build.CommandLine
         ///   <item>Otherwise → no server (existing default).</item>
         /// </list>
         /// </remarks>
-        /// <param name="isMultiThreadedOnCommandLine">Whether <c>-mt</c> was passed on the command line, as
-        /// determined by <see cref="IsMultiThreadedRequested"/>.</param>
+        /// <param name="isMultiThreaded">Whether this is a multithreaded (<c>-mt</c>) build, as determined by the
+        /// authoritative response-file-aware parse in <see cref="CanRunServerBasedOnCommandLineSwitches"/>. This
+        /// includes <c>-mt</c> supplied via the auto-response file, a project <c>Directory.Build.rsp</c>, an
+        /// <c>@response</c> file, or <c>MSBUILDFORCEMULTITHREADED</c>.</param>
         /// <param name="serverEnableReason">Telemetry-friendly reason: "EnvVar", "ImpliedByMt", or empty when not enabled.</param>
         /// <returns>True if server should be used.</returns>
-        internal static bool ShouldUseMSBuildServer(bool isMultiThreadedOnCommandLine, out string serverEnableReason)
+        internal static bool ShouldUseMSBuildServer(bool isMultiThreaded, out string serverEnableReason)
         {
             serverEnableReason = string.Empty;
             string envVar = Environment.GetEnvironmentVariable(Traits.UseMSBuildServerEnvVarName);
@@ -457,7 +496,7 @@ namespace Microsoft.Build.CommandLine
 
             // Implicit opt-in via -mt. -mt is itself experimental and opt-in (MSBUILDUSESERVER=0 remains the
             // explicit escape hatch), so this does not need a separate change-wave gate.
-            if (isMultiThreadedOnCommandLine)
+            if (isMultiThreaded)
             {
                 serverEnableReason = "ImpliedByMt";
                 return true;
@@ -466,75 +505,6 @@ namespace Microsoft.Build.CommandLine
             return false;
         }
 
-        /// <summary>
-        /// Lightweight check for whether <c>-mt</c>/<c>-multithreaded</c> was passed on the command line,
-        /// used for the early implicit-server-opt-in decision in <see cref="ShouldUseMSBuildServer"/>.
-        /// </summary>
-        /// <remarks>
-        /// Deliberately cheap and allocation-free: this runs on every invocation (including the common
-        /// no-server path), so it does NOT do the full <c>GatherAllSwitches</c> parse (which is expensive
-        /// and already runs later for the actual build). Consequences, all acceptable for an opt-in
-        /// heuristic (the authoritative /mt value for Server GC comes from
-        /// <see cref="CanRunServerBasedOnCommandLineSwitches"/>):
-        /// <list type="bullet">
-        ///   <item><c>-mt</c> supplied via a response file is not detected here, so it does not trigger the
-        ///         implicit server opt-in.</item>
-        ///   <item><c>MSBUILDFORCEMULTITHREADED</c> is intentionally NOT considered: that force/testing knob
-        ///         should not by itself engage the long-lived server.</item>
-        /// </list>
-        /// Matches MSBuild's "last occurrence wins" semantics for the boolean switch.
-        /// </remarks>
-        /// <param name="args">Raw command-line arguments.</param>
-        /// <returns>True if <c>-mt</c>/<c>-multithreaded</c> was last set to a truthy value on the command line.</returns>
-        internal static bool IsMultiThreadedRequested(string[] args)
-        {
-            if (args is null)
-            {
-                return false;
-            }
-
-            bool result = false;
-
-            foreach (string arg in args)
-            {
-                if (string.IsNullOrEmpty(arg) || arg.Length < 2)
-                {
-                    continue;
-                }
-
-                // Switches start with - or / (and on Unix, - is the only convention).
-                if (arg[0] != '-' && arg[0] != '/')
-                {
-                    continue;
-                }
-
-                // Strip leading - or /, then split on : into switch name and (optional) value.
-                ReadOnlySpan<char> body = arg.AsSpan(1);
-                int colonIndex = body.IndexOf(':');
-                ReadOnlySpan<char> switchName = colonIndex >= 0 ? body.Slice(0, colonIndex) : body;
-
-                if (!switchName.Equals("mt".AsSpan(), StringComparison.OrdinalIgnoreCase) &&
-                    !switchName.Equals("multithreaded".AsSpan(), StringComparison.OrdinalIgnoreCase))
-                {
-                    continue;
-                }
-
-                // Honor an explicit ":false"/":0" value (matches ProcessBooleanSwitch semantics). Do not
-                // return early: a later occurrence wins, so keep scanning and record this occurrence's value.
-                if (colonIndex >= 0)
-                {
-                    ReadOnlySpan<char> value = body.Slice(colonIndex + 1);
-                    result = !value.Equals("false".AsSpan(), StringComparison.OrdinalIgnoreCase) &&
-                             !value.Equals("0".AsSpan(), StringComparison.OrdinalIgnoreCase);
-                }
-                else
-                {
-                    result = true;
-                }
-            }
-
-            return result;
-        }
 
         /// <summary>
         /// Append output file with elapsedTime
@@ -789,7 +759,27 @@ namespace Microsoft.Build.CommandLine
         /// is ignored.</param>
         /// <returns>A value of type ExitType that indicates whether the build succeeded,
         /// or the manner in which it failed.</returns>
-        public static ExitType Execute(string[] commandLine)
+        public static ExitType Execute(string[] commandLine) => Execute(commandLine, null, null);
+
+        /// <summary>
+        /// Orchestrates the execution of the application, optionally reusing command-line switches
+        /// that have already been gathered (e.g. by the MSBuild Server eligibility check in
+        /// <see cref="Main"/>) so they are not parsed a second time.
+        /// </summary>
+        /// <param name="commandLine">The command line to process. The first argument
+        /// on the command line is assumed to be the name/path of the executable, and
+        /// is ignored.</param>
+        /// <param name="preGatheredSwitchesFromAutoResponseFile">Switches already gathered from response files
+        /// (auto-response file plus any project <c>Directory.Build.rsp</c>), or <see langword="null"/> to gather here.</param>
+        /// <param name="preGatheredSwitchesNotFromAutoResponseFile">Switches already gathered from the command line
+        /// (and environment), or <see langword="null"/> to gather here. Must be non-null iff
+        /// <paramref name="preGatheredSwitchesFromAutoResponseFile"/> is non-null.</param>
+        /// <returns>A value of type ExitType that indicates whether the build succeeded,
+        /// or the manner in which it failed.</returns>
+        internal static ExitType Execute(
+            string[] commandLine,
+            CommandLineSwitches preGatheredSwitchesFromAutoResponseFile,
+            CommandLineSwitches preGatheredSwitchesNotFromAutoResponseFile)
         {
             DebuggerLaunchCheck();
 
@@ -828,8 +818,16 @@ namespace Microsoft.Build.CommandLine
                 // check the operating system the code is running on
                 VerifyThrowSupportedOS();
 
-                // reset the application state for this new build
-                ResetBuildState();
+                // reset the application state for this new build. When we are reusing switches already gathered by
+                // the MSBuild Server eligibility check in Main, skip this: ResetBuildState clears the parser's
+                // response-file bookkeeping (IncludedResponseFiles / SwitchesFromResponseFiles), which is normally
+                // repopulated by the GatherAllSwitches call below - but on the reuse path that call is skipped, so
+                // clearing it here would discard the bookkeeping the in-proc path still needs (e.g. for the
+                // "switches read from response file" notice). The single gather in Main already reset this state.
+                if (preGatheredSwitchesFromAutoResponseFile is null)
+                {
+                    ResetBuildState();
+                }
 
                 // process the detected command line switches -- gather build information, take action on non-build switches, and
                 // check for non-trivial errors
@@ -874,7 +872,22 @@ namespace Microsoft.Build.CommandLine
                 bool reportFileAccesses = false;
 #endif
 
-                commandLineParser.GatherAllSwitches(commandLine, s_globalMessagesToLogInBuildLoggers, out var switchesFromAutoResponseFile, out var switchesNotFromAutoResponseFile, out _, out s_exeName);
+                CommandLineSwitches switchesFromAutoResponseFile;
+                CommandLineSwitches switchesNotFromAutoResponseFile;
+                bool switchesAlreadyGathered;
+                if (preGatheredSwitchesFromAutoResponseFile is not null)
+                {
+                    // The MSBuild Server eligibility check in Main already gathered every switch (including any
+                    // project Directory.Build.rsp). Reuse that single parse instead of re-reading response files.
+                    switchesFromAutoResponseFile = preGatheredSwitchesFromAutoResponseFile;
+                    switchesNotFromAutoResponseFile = preGatheredSwitchesNotFromAutoResponseFile;
+                    switchesAlreadyGathered = true;
+                }
+                else
+                {
+                    commandLineParser.GatherAllSwitches(commandLine, s_globalMessagesToLogInBuildLoggers, out switchesFromAutoResponseFile, out switchesNotFromAutoResponseFile, out _, out s_exeName);
+                    switchesAlreadyGathered = false;
+                }
 
                 bool buildCanBeInvoked = ProcessCommandLineSwitches(
                                             switchesFromAutoResponseFile,
@@ -921,7 +934,8 @@ namespace Microsoft.Build.CommandLine
                                             ref getTargetResult,
                                             ref getResultOutputFile,
                                             recursing: false,
-                                            string.Join(" ", commandLine));
+                                            string.Join(" ", commandLine),
+                                            switchesAlreadyGathered);
 
                 CommandLineSwitches.SwitchesFromResponseFiles = null;
 
@@ -2215,7 +2229,8 @@ namespace Microsoft.Build.CommandLine
             ref string[] getTargetResult,
             ref string getResultOutputFile,
             bool recursing,
-            string commandLine)
+            string commandLine,
+            bool switchesAlreadyGathered = false)
         {
             bool invokeBuild = false;
 
@@ -2316,7 +2331,9 @@ namespace Microsoft.Build.CommandLine
                 }
                 else
                 {
-                    bool foundProjectAutoResponseFile = commandLineParser.CheckAndGatherProjectAutoResponseFile(switchesFromAutoResponseFile, commandLineSwitches, recursing, commandLine);
+                    // When the switches were already fully gathered (including any project Directory.Build.rsp) by the
+                    // MSBuild Server eligibility check in Main, skip re-gathering so response files are not read twice.
+                    bool foundProjectAutoResponseFile = !switchesAlreadyGathered && commandLineParser.CheckAndGatherProjectAutoResponseFile(switchesFromAutoResponseFile, commandLineSwitches, recursing, commandLine);
 
                     if (foundProjectAutoResponseFile)
                     {

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -423,15 +423,14 @@ namespace Microsoft.Build.CommandLine
         ///   <item><c>MSBUILDUSESERVER</c> set to any other non-empty value (e.g. <c>0</c>, <c>false</c>) →
         ///         do NOT use server (explicit opt-out, takes precedence over -mt). Only <c>1</c> opts in,
         ///         matching the pre-existing "only <c>1</c> enables the server" semantics.</item>
-        ///   <item><c>MSBUILDUSESERVER</c> unset AND <c>-mt</c> was on the command line AND the change wave
-        ///         is enabled → use server. Rationale: <c>-mt</c> users already accept process-shared state
+        ///   <item><c>MSBUILDUSESERVER</c> unset AND <c>-mt</c> was on the command line → use server.
+        ///         Rationale: <c>-mt</c> users already accept process-shared state
         ///         (in-proc thread workers instead of multi-process worker nodes), so server reuse barely
         ///         adds risk and recovers the per-invocation JIT/SDK-resolution warm-up cost that <c>-mt</c>
-        ///         would otherwise pay every build. See <see href="https://github.com/dotnet/msbuild/issues/9379">#9379</see>.</item>
+        ///         would otherwise pay every build. <c>-mt</c> is itself experimental and opt-in, so no
+        ///         additional gate is needed. See <see href="https://github.com/dotnet/msbuild/issues/9379">#9379</see>.</item>
         ///   <item>Otherwise → no server (existing default).</item>
         /// </list>
-        /// The implicit <c>-mt</c> path is gated behind <see cref="ChangeWaves.Wave18_8"/> so it can be
-        /// disabled via <c>MSBUILDDISABLEFEATURESFROMVERSION</c> for users who are not ready for the server.
         /// </remarks>
         /// <param name="isMultiThreadedOnCommandLine">Whether <c>-mt</c> was passed on the command line, as
         /// determined by <see cref="IsMultiThreadedRequested"/>.</param>
@@ -456,8 +455,9 @@ namespace Microsoft.Build.CommandLine
                 return false;
             }
 
-            // Implicit opt-in via -mt, gated behind a change wave so it can be turned off.
-            if (isMultiThreadedOnCommandLine && ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave18_8))
+            // Implicit opt-in via -mt. -mt is itself experimental and opt-in (MSBUILDUSESERVER=0 remains the
+            // explicit escape hatch), so this does not need a separate change-wave gate.
+            if (isMultiThreadedOnCommandLine)
             {
                 serverEnableReason = "ImpliedByMt";
                 return true;

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -367,9 +367,7 @@ namespace Microsoft.Build.CommandLine
         /// <param name="commandLine">Raw command-line arguments.</param>
         /// <param name="multiThreaded">Set to whether this is a multithreaded (/mt) build, determined from
         /// the fully-parsed switches (which expand response files - including any project <c>Directory.Build.rsp</c> -
-        /// and honor MSBUILDFORCEMULTITHREADED) using the same logic as the in-proc build path. This is the
-        /// authoritative value used both to decide whether <c>-mt</c> implicitly engages the server and whether
-        /// the server is launched with Server GC.</param>
+        /// and honor MSBUILDFORCEMULTITHREADED) using the same logic as the in-proc build path.</param>
         /// <param name="switchesFromAutoResponseFile">The gathered response-file switches (auto-response file plus any
         /// project <c>Directory.Build.rsp</c>), or <see langword="null"/> if parsing failed.</param>
         /// <param name="switchesNotFromAutoResponseFile">The gathered command-line/environment switches, or
@@ -457,18 +455,13 @@ namespace Microsoft.Build.CommandLine
         ///         do NOT use server (explicit opt-out, takes precedence over -mt). Only <c>1</c> opts in,
         ///         matching the pre-existing "only <c>1</c> enables the server" semantics.</item>
         ///   <item><c>MSBUILDUSESERVER</c> unset AND this is a <c>-mt</c> (multithreaded) build → use server.
-        ///         Rationale: <c>-mt</c> users already accept process-shared state
-        ///         (in-proc thread workers instead of multi-process worker nodes), so server reuse barely
-        ///         adds risk and recovers the per-invocation JIT/SDK-resolution warm-up cost that <c>-mt</c>
-        ///         would otherwise pay every build. <c>-mt</c> is itself experimental and opt-in, so no
-        ///         additional gate is needed. See <see href="https://github.com/dotnet/msbuild/issues/9379">#9379</see>.</item>
+        ///         Rationale: <c>-mt</c> already shares process state, so server reuse adds little risk while
+        ///         recovering per-invocation warm-up cost. See <see href="https://github.com/dotnet/msbuild/issues/9379">#9379</see>.</item>
         ///   <item>Otherwise → no server (existing default).</item>
         /// </list>
         /// </remarks>
         /// <param name="isMultiThreaded">Whether this is a multithreaded (<c>-mt</c>) build, as determined by the
-        /// authoritative response-file-aware parse in <see cref="CanRunServerBasedOnCommandLineSwitches"/>. This
-        /// includes <c>-mt</c> supplied via the auto-response file, a project <c>Directory.Build.rsp</c>, an
-        /// <c>@response</c> file, or <c>MSBUILDFORCEMULTITHREADED</c>.</param>
+        /// authoritative response-file-aware parse in <see cref="CanRunServerBasedOnCommandLineSwitches"/>.</param>
         /// <param name="serverEnableReason">Telemetry-friendly reason: "EnvVar", "ImpliedByMt", or empty when not enabled.</param>
         /// <returns>True if server should be used.</returns>
         internal static bool ShouldUseMSBuildServer(bool isMultiThreaded, out string serverEnableReason)
@@ -491,7 +484,7 @@ namespace Microsoft.Build.CommandLine
             }
 
             // Implicit opt-in via -mt. -mt is itself experimental and opt-in (MSBUILDUSESERVER=0 remains the
-            // explicit escape hatch), so this does not need a separate change-wave gate.
+            // explicit escape hatch), so it does not need a separate opt-out gate.
             if (isMultiThreaded)
             {
                 serverEnableReason = "ImpliedByMt";
@@ -760,7 +753,7 @@ namespace Microsoft.Build.CommandLine
         /// <summary>
         /// Orchestrates the execution of the application, optionally reusing command-line switches
         /// that have already been gathered (e.g. by the MSBuild Server eligibility check in
-        /// <see cref="Main"/>) so they are not parsed a second time.
+        /// <see cref="Main"/>) so the command line is not parsed a second time.
         /// </summary>
         /// <param name="commandLine">The command line to process. The first argument
         /// on the command line is assumed to be the name/path of the executable, and


### PR DESCRIPTION
fixes #13605 

## `-mt` implies MSBuild Server (with `MSBUILDUSESERVER=0` opt-out)

When this is a `-mt` (multithreaded) build and `MSBUILDUSESERVER` is unset, automatically engage MSBuild Server. Explicit `MSBUILDUSESERVER=0` always opts out (takes precedence over the implicit `-mt` opt-in). `-mt` is detected from the full, response-file-aware command-line parse, so it counts wherever it is supplied — command line, auto-response file, a project `Directory.Build.rsp`, an `@response` file, or `MSBUILDFORCEMULTITHREADED`.

> ### 📦 Builds on #14043 (Server GC) — now merged
> This PR follows #14043 (merged to `main`) and reuses its `-mt` determination: one response-file-aware parse feeds both #14043's Server GC decision and this PR's server-engagement decision.

### Why stack on the Server GC PR?

#14043 introduced a single canonical answer to **"is this a `-mt` build?"** and used it to decide whether the server gets Server GC. This PR needs the *same* answer to decide whether to engage the server at all. Stacking lets both decisions share one `-mt` determination instead of each shipping its own — the earlier version of this PR carried a private `CommandLineContainsMultiThreadedSwitch`, duplicating exactly what #14043 already had to reason about.

### Combined decision flow

```
                          MSBuild.exe Main(args)
                                   │
                                   ▼   ONE command-line parse (response-file aware)
   ┌────────────────────────────────────────────────────────────┐
   │ CanRunServerBasedOnCommandLineSwitches(args,                 │  -mt detected from:
   │     out multiThreaded, out gatheredSwitches)                 │   - command line
   │   multiThreaded = IsMultiThreadedEnabled(switches)           │   - auto-response file
   │   canRunServer  = help/version/binlog/nodereuse gate         │   - Directory.Build.rsp
   └───────────────┬───────────────────────────┬─────────────────┘   - @response file
                   │ multiThreaded             │ gatheredSwitches      - MSBUILDFORCEMULTITHREADED
                   ▼                           │
   ┌─────────────────────┐                     │
   │ ShouldUseMSBuild     │  THIS PR           │
   │ Server(multiThreaded)│                    │
   ├─────────────────────-┤                    │
   │ USESERVER=1 → yes  (EnvVar)               │
   │ USESERVER=0 → no   (opt-out wins)         │
   │ unset & mt  → yes  (ImpliedByMt)          │
   │ unset & !mt → no                          │
   └──────────┬──────────┘                     │
   use server?│                                │
        ┌──────┴───────────────┐               │
        ▼ yes                  ▼ no            │
 ┌────────────────────────┐  ┌─────────────────▼──────────────────┐
 │ MSBuildClientApp.Execute│  │ Execute(args, gatheredSwitches)    │
 │   (args, multiThreaded) │  │   reuses the single parse —        │
 │     ▼ TryLaunchServer   │  │   no second GatherAllSwitches      │
 │  if (multiThreaded &&   │  └────────────────────────────────────┘
 │      DOTNET_gcServer    │
 │      unset)             │  #14043
 │   server w/ Server GC   │
 └────────────────────────┘
```

The single `multiThreaded` value drives **two** decisions: (1) *whether* to engage the server (this PR), and (2) *how* the server launches — Server GC (#14043). They stay distinct (`MSBUILDUSESERVER=1` + non-`-mt` engages the server **without** Server GC) but share one input. The gathered switches are threaded into the in-proc `Execute` so the command line is **not** parsed a second time.

### Decision table

| `MSBUILDUSESERVER` | `-mt` build | Server engaged? | Server GC? | Telemetry `ServerEnableReason` |
|---|---|---|---|---|
| `1` | no  | Yes (existing) | No  | `EnvVar` |
| `1` | yes | Yes (existing) | **Yes** (#14043) | `EnvVar` |
| `0` | (any) | No (opt-out) | — | — |
| unset | yes | **Yes (NEW)** | **Yes** (#14043) | `ImpliedByMt` |
| unset | no  | No (existing) | — | — |

### Rationale

`-mt` users already accept process-shared state (in-proc thread workers instead of multi-process worker nodes), so server reuse barely adds risk and recovers the per-invocation JIT/SDK-resolution warm-up cost that `-mt` would otherwise pay every build (because `-mt` shares the entry process with the build instead of with the workers). The cost of a cold first build is the same whether the server starts then or on the next build; once warm, every subsequent invocation benefits. Investigation #9379, Thread F.

### What stacking refactored (decision + telemetry)

1. **One response-file-aware `-mt` determination.** `CanRunServerBasedOnCommandLineSwitches` performs the single command-line parse, returns the gathered switches, and its `IsMultiThreadedEnabled` result drives **both** implicit server engagement and #14043's Server GC flag. The previous private `CommandLineContainsMultiThreadedSwitch` duplicate — and the interim command-line-only `IsMultiThreadedRequested` scan — are gone.
2. **No reparse.** The gathered switches are threaded into `Execute` (new internal overload + a `switchesAlreadyGathered` flag on `ProcessCommandLineSwitches`), so the in-proc build path reuses the single parse instead of calling `GatherAllSwitches` again.
3. **Centralized engagement decision.** `ShouldUseMSBuildServer(multiThreaded, out reason)` replaces the inline `MSBUILDUSESERVER == "1"` check in `Main` — *the* place server routing is decided. New inputs (config-file default, future switch) plug in here.
4. **Telemetry alongside the decision.** `BuildTelemetry.ServerEnableReason` (`EnvVar` / `ImpliedByMt`) is set right where the decision is made, complementing the existing `ServerFallbackReason` to form a coherent server-routing telemetry surface.

### Implementation
- `CanRunServerBasedOnCommandLineSwitches(args, out multiThreaded, out switchesFromAutoResponseFile, out switchesNotFromAutoResponseFile)`: the one parse. On parse failure the gathered switches are discarded only when the gather itself did not complete, so `Execute` re-parses and surfaces the error unchanged.
- `XMake.Main`: parse once; gate on `ShouldUseMSBuildServer(multiThreaded, out reason)` + `canRunServer`; set `ServerEnableReason`; pass the gathered switches to `Execute` on the in-proc path.
- `Execute`: new internal overload accepting pre-gathered switches; `ResetBuildState` is skipped on the reuse path so the parser's response-file bookkeeping (used for the "switches read from response file" notice) is preserved.
- `BuildTelemetry.ServerEnableReason`.
- Spec: `documentation/specs/multithreading/multithreaded-msbuild.md`.

### Tests
- `MSBuildServer_Tests.ServerStartsWhenMtPresentEvenWithoutEnvVar` — two consecutive `-mt` builds with `MSBUILDUSESERVER` unset reuse the **same server PID** (server reuse is the unique signature of engagement; a non-server build would always get a fresh worker PID).
- `MSBuildServer_Tests.ServerStartsWhenMtInResponseFileEvenWithoutEnvVar` — same assertion but `-mt` comes **only** from a project `Directory.Build.rsp`, not the command line (covers the response-file dogfooding path).
- `ShouldUseMSBuildServerDecisionTree` unit theory covers the full env-var × `-mt` matrix.

All 15 `MSBuildServer_Tests` pass, including #14043's Server-GC tests. End-to-end verified that the response-file notice and normal `Directory.Build.rsp` property flow still work.

**Why no automated opt-out test:** the opt-out case (`MSBUILDUSESERVER=0` + `-mt`) is verified by the `ShouldUseMSBuildServer` unit theory. An end-to-end PID-pattern test would be unreliable because `-mt`'s worker placement is independent of server engagement, so "PIDs match → no server" is not a sound inference under `-mt`. The reliable signal is the opposite ("PIDs same across invocations → server reused"), which the server tests use.

### Open questions
1. Telemetry value name `"ImpliedByMt"` — or something more neutral (`"MtSwitch"`)?
2. Should the opt-out also accept `MSBUILDUSESERVER=false`/`no` for symmetry with other Boolean MSBuild env vars?
3. `MSBUILDFORCEMULTITHREADED=1` now implies server too (for consistency with #14043's Server GC determination) — confirm desired.

### Context
Investigation #9379 — broader MSBuild Server default-on analysis. Server-state hygiene PRs: #13756 (`CurrentCulture` restore), #13757 (console color/encoding restore), and this one (`-mt` implies server), now stacked on the Server GC work (#14043).

Ready for review of the design.
