### PR TITLE
Guard NuGetRestoreTargets import in Microsoft.Common.CrossTargeting.targets

### DIFF
--- a/src/Tasks.UnitTests/CrossTargetingTargetsImportTests.cs
+++ b/src/Tasks.UnitTests/CrossTargetingTargetsImportTests.cs
@@ -1,0 +1,97 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.IO;
+
+using Microsoft.Build.Evaluation;
+using Microsoft.Build.UnitTests;
+
+using Shouldly;
+
+using Xunit;
+
+namespace Microsoft.Build.Tasks.UnitTests;
+
+/// <summary>
+/// Tests for the NuGet restore targets import in <c>Microsoft.Common.CrossTargeting.targets</c>.
+/// The parallel import in <c>Microsoft.Common.CurrentVersion.targets</c> is guarded with
+/// <c>Exists('$(NuGetRestoreTargets)')</c>, but for years the cross-targeting variant was unguarded
+/// — which meant cross-targeting (multi-TFM) projects loaded in non-NuGet contexts (custom build
+/// systems, focused unit tests) failed with "Imported project not found" unless the caller
+/// manufactured a stub NuGet.targets file. These tests cover the now-guarded import.
+/// </summary>
+public sealed class CrossTargetingTargetsImportTests
+{
+    private readonly ITestOutputHelper _output;
+
+    public CrossTargetingTargetsImportTests(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    /// <summary>
+    /// When <c>NuGetRestoreTargets</c> points at a file that does not exist, evaluating a project
+    /// that imports <c>Microsoft.Common.CrossTargeting.targets</c> must succeed (the import is a
+    /// silent no-op), matching the long-standing behavior of <c>Microsoft.Common.CurrentVersion.targets</c>.
+    /// </summary>
+    [Fact]
+    public void ImportSucceedsWhenNuGetRestoreTargetsDoesNotExist()
+    {
+        using TestEnvironment env = TestEnvironment.Create(_output);
+        TransientTestFolder folder = env.CreateFolder(createFolder: true);
+        string nonExistentNuGetTargets = Path.Combine(folder.Path, "DoesNotExist.NuGet.targets");
+
+        string projectContents = $"""
+            <Project>
+                <PropertyGroup>
+                    <NuGetRestoreTargets>{nonExistentNuGetTargets}</NuGetRestoreTargets>
+                </PropertyGroup>
+                <Import Project="$(MSBuildToolsPath)\Microsoft.Common.CrossTargeting.targets" />
+            </Project>
+            """.Cleanup();
+
+        using ProjectFromString projectFromString = new(projectContents);
+        Project project = projectFromString.Project;
+
+        project.GetPropertyValue("NuGetRestoreTargets").ShouldBe(nonExistentNuGetTargets);
+    }
+
+    /// <summary>
+    /// When <c>NuGetRestoreTargets</c> points at a real file, the import still happens. This
+    /// guards against the new <c>Exists()</c> condition accidentally skipping a valid NuGet
+    /// targets file. The synthetic project does not set <c>IsRestoreTargetsFileLoaded</c>, and
+    /// nothing in the <c>Microsoft.Common.CrossTargeting.targets</c> import chain sets it before
+    /// the guarded import, so the canonical guard does not short-circuit here.
+    /// </summary>
+    [Fact]
+    public void ImportLoadsNuGetTargetsWhenItExists()
+    {
+        using TestEnvironment env = TestEnvironment.Create(_output);
+        TransientTestFolder folder = env.CreateFolder(createFolder: true);
+
+        const string MarkerTargetName = "_CrossTargetingNuGetStubMarker";
+        TransientTestFile nuGetStub = env.CreateFile(
+            folder,
+            "NuGet.targets",
+            $"""
+            <Project>
+                <Target Name="{MarkerTargetName}" />
+            </Project>
+            """.Cleanup());
+
+        string projectContents = $"""
+            <Project>
+                <PropertyGroup>
+                    <NuGetRestoreTargets>{nuGetStub.Path}</NuGetRestoreTargets>
+                </PropertyGroup>
+                <Import Project="$(MSBuildToolsPath)\Microsoft.Common.CrossTargeting.targets" />
+            </Project>
+            """.Cleanup();
+
+        using ProjectFromString projectFromString = new(projectContents);
+        Project project = projectFromString.Project;
+
+        project.Targets.ShouldContainKey(MarkerTargetName);
+    }
+}
+

--- a/src/Tasks/Microsoft.Common.CrossTargeting.targets
+++ b/src/Tasks/Microsoft.Common.CrossTargeting.targets
@@ -201,7 +201,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <NuGetRestoreTargets Condition="'$(NuGetRestoreTargets)'==''">$(MSBuildToolsPath)\NuGet.targets</NuGetRestoreTargets>
   </PropertyGroup>
 
-  <Import Project="$(NuGetRestoreTargets)" />
+  <Import Condition="'$(IsRestoreTargetsFileLoaded)' != 'true' and Exists('$(NuGetRestoreTargets)')" Project="$(NuGetRestoreTargets)" />
 
   <Import Project="$(CustomAfterMicrosoftCommonCrossTargetingTargets)" Condition="'$(CustomAfterMicrosoftCommonCrossTargetingTargets)' != '' and Exists('$(CustomAfterMicrosoftCommonCrossTargetingTargets)')"/>
 


### PR DESCRIPTION
Microsoft.Common.CurrentVersion.targets [guards its NuGet restore targets import](https://github.com/dotnet/msbuild/blob/main/src/Tasks/Microsoft.Common.CurrentVersion.targets#L7046) with `Exists(''$(NuGetRestoreTargets)'')` (and the cooperative `''$(IsRestoreTargetsFileLoaded)'' != ''true''` check added in #4969), but the parallel import in Microsoft.Common.CrossTargeting.targets was unguarded:

| File | Line | Import |
|---|---|---|
| `Microsoft.Common.CurrentVersion.targets` | 7046 | `<Import Condition="''$(IsRestoreTargetsFileLoaded)'' != ''true'' and Exists(''$(NuGetRestoreTargets)'')" Project="$(NuGetRestoreTargets)" />` |
| `Microsoft.Common.CrossTargeting.targets` | 204 (before) | `<Import Project="$(NuGetRestoreTargets)" />` |

### Customer impact

Cross-targeting (multi-TFM) projects loaded in **non-NuGet contexts** -- focused unit tests, custom build systems, stripped-down project types -- failed with `Imported project not found` unless the caller manufactured a stub NuGet.targets file. Single-targeting projects in the same situation worked silently.

### Discovery

While writing tests for #13427 (`ProjectReferenceTargetsProtocol_Tests.cs`), the synthetic cross-targeting test had to inject an empty NuGet.targets stub via `TransientTestFile` and pass it as a global `NuGetRestoreTargets` property, purely to satisfy this unguarded import. The author flagged the asymmetry as a separate follow-up:

> `Microsoft.Common.CrossTargeting.targets:230` has an unconditional `<Import Project="$(NuGetRestoreTargets)" />` -- no `Condition="...Exists(...)"` guard, unlike the parallel import in `Microsoft.Common.CurrentVersion.targets:7102`. [...] **This is arguably a bug in `CrossTargeting.targets` worth a separate follow-up issue/PR** -- adding the `Exists()` condition would make CrossTargeting.targets safer to import in non-NuGet test contexts.

This PR is that follow-up.

### Change

One line in `Microsoft.Common.CrossTargeting.targets`, copying the canonical condition byte-for-byte from `Microsoft.Common.CurrentVersion.targets:7046` (same attribute order, lowercase `and`, single-quotes, identical spacing):

```diff
- <Import Project="$(NuGetRestoreTargets)" />
+ <Import Condition="''$(IsRestoreTargetsFileLoaded)'' != ''true'' and Exists(''$(NuGetRestoreTargets)'')" Project="$(NuGetRestoreTargets)" />
```

### Tests

New `src/Tasks.UnitTests/CrossTargetingTargetsImportTests.cs` with two `[Fact]`s:

1. `ImportSucceedsWhenNuGetRestoreTargetsDoesNotExist` -- synthetic cross-targeting project with `NuGetRestoreTargets` pointed at a non-existent file evaluates successfully. **Fails on the pre-fix targets file** with `InvalidProjectFileException: The imported project "..." was not found`; passes post-fix. Empirically verified by reverting the targets change, rebuilding, and re-running -- output captured to scratch.
2. `ImportLoadsNuGetTargetsWhenItExists` -- forward-looking regression guard: a real stub NuGet.targets with a marker target is still imported under the new guard. Passes both pre- and post-fix.

Both run on net10.0 and net472.

### Backwards compatibility

**Behavior change**: when `NuGetRestoreTargets` resolves to a missing file, cross-targeting projects now evaluate successfully (the NuGet import is a no-op) instead of throwing `InvalidProjectFileException`. Projects that already set `NuGetRestoreTargets` to a real file are **unaffected** -- the import still happens.

**No ChangeWave** -- the canonical fix in CurrentVersion.targets was added in #4969 (2020) without one, and this change just closes the asymmetry rather than introducing a new policy. The new behavior is strictly looser; no consumer can reasonably depend on the prior error path.

### Notes

- #13427 (concurrent PR) injects a NuGet.targets stub purely to satisfy the unguarded import this PR fixes. Post-merge of both, that stub becomes dead code; cleanup is a separate follow-up PR to keep this one focused.
- Other unguarded `$(NuGetRestoreTargets)` imports across the repo: searched -- only the two known parallel spots in `Microsoft.Common.{CurrentVersion,CrossTargeting}.targets`. Nothing else to clean up.

cc @rainersigwald (approved #13427; knows the area).