### PR TITLE
Use higher version for xunit than pinned

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,8 +14,13 @@
 
   <PropertyGroup>
     <TestRunnerName>XUnitV3</TestRunnerName>
-    <XUnitV3Version>3.2.2</XUnitV3Version>
-    <MicrosoftTestingPlatformVersion>1.9.1</MicrosoftTestingPlatformVersion>
+
+    <!-- Pin xunit.v3 / MTP up only when Arcade's default sits below our pin. -->
+    <_MSBuildXUnitV3Pin>3.2.2</_MSBuildXUnitV3Pin>
+    <_MSBuildMTPPin>1.9.1</_MSBuildMTPPin>
+
+    <XUnitV3Version Condition="'$(XUnitV3Version)' == '' or $([MSBuild]::VersionLessThan($(XUnitV3Version), $(_MSBuildXUnitV3Pin)))">$(_MSBuildXUnitV3Pin)</XUnitV3Version>
+    <MicrosoftTestingPlatformVersion Condition="'$(MicrosoftTestingPlatformVersion)' == '' or $([MSBuild]::VersionLessThan($(MicrosoftTestingPlatformVersion), $(_MSBuildMTPPin)))">$(_MSBuildMTPPin)</MicrosoftTestingPlatformVersion>
     <OutputType Condition="$(MSBuildProjectName.EndsWith('.UnitTests')) or $(MSBuildProjectName.EndsWith('.Tests'))">Exe</OutputType>
 
     <!-- xUnit1051: Calls to methods which accept CancellationToken should use TestContext.Current.CancellationToken to allow test cancellation to be more responsive. -->

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -43,7 +43,7 @@
 
     <PackageOutputPath Condition="'$(IsVisualStudioInsertionPackage)' == 'true'">$(DevDivPackagesDir)</PackageOutputPath>
 
-    <DefineConstants Condition="'$(XUnitV3Version)' != '' and $(XUnitV3Version.StartsWith('4.'))">$(DefineConstants);XUNIT_V3_4_OR_LATER</DefineConstants>
+    <DefineConstants Condition="'$(XUnitV3Version)' != '' and $([MSBuild]::VersionGreaterThanOrEquals($(XUnitV3Version), '4.0.0'))">$(DefineConstants);XUNIT_V3_4_OR_LATER</DefineConstants>
 
     <!-- Arcade sdk also carries an xunit.runner.json which sometimes overrides the one in this repo. Assign a value to the arcade properties XUnitDesktopSettingsFile and XUnitCoreSettingsFile to prevent the arcade version of the file being added. -->
     <XUnitDesktopSettingsFile>$(MSBuildThisFileDirectory)Shared\UnitTests\xunit.runner.json</XUnitDesktopSettingsFile>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -43,6 +43,8 @@
 
     <PackageOutputPath Condition="'$(IsVisualStudioInsertionPackage)' == 'true'">$(DevDivPackagesDir)</PackageOutputPath>
 
+    <DefineConstants Condition="'$(XUnitV3Version)' != '' and $(XUnitV3Version.StartsWith('4.'))">$(DefineConstants);XUNIT_V3_4_OR_LATER</DefineConstants>
+
     <!-- Arcade sdk also carries an xunit.runner.json which sometimes overrides the one in this repo. Assign a value to the arcade properties XUnitDesktopSettingsFile and XUnitCoreSettingsFile to prevent the arcade version of the file being added. -->
     <XUnitDesktopSettingsFile>$(MSBuildThisFileDirectory)Shared\UnitTests\xunit.runner.json</XUnitDesktopSettingsFile>
     <XUnitCoreSettingsFile>$(XUnitDesktopSettingsFile)</XUnitCoreSettingsFile>

--- a/src/Shared/UnitTests/TestAssemblyInfo.cs
+++ b/src/Shared/UnitTests/TestAssemblyInfo.cs
@@ -71,7 +71,11 @@ namespace Microsoft.Build.UnitTests
 
             public IXunitTestClass TestClass => _wrapped.TestClass;
 
+#if XUNIT_V3_4_OR_LATER
+            public int? TestClassMetadataToken => _wrapped.TestClassMetadataToken;
+#else
             public int TestClassMetadataToken => _wrapped.TestClassMetadataToken;
+#endif
 
             public string TestClassName => _wrapped.TestClassName;
 
@@ -116,6 +120,16 @@ namespace Microsoft.Build.UnitTests
             int? ITestCaseMetadata.TestClassMetadataToken => TestClassMetadataToken;
 
             int? ITestCaseMetadata.TestMethodMetadataToken => TestMethodMetadataToken;
+
+#if XUNIT_V3_4_OR_LATER
+            int ICoreTestCase.TestMethodArity => TestMethodArity ?? 0;
+
+            ICoreTestClass ICoreTestCase.TestClass => TestClass;
+
+            ICoreTestCollection ICoreTestCase.TestCollection => TestCollection;
+
+            ICoreTestMethod ICoreTestCase.TestMethod => TestMethod;
+#endif
 
             public ValueTask<IReadOnlyCollection<IXunitTest>> CreateTests() => _wrapped.CreateTests();
 


### PR DESCRIPTION
Changes from https://github.com/dotnet/dotnet/pull/6604.
We need to push it to msbuild main in order to it to flow to release and main branch in VMR.

Difference: now i check that XUnit version is equals or greater than 4.
