### PR TITLE
Migration of CallTarget

### DIFF
--- a/src/Tasks/CallTarget.cs
+++ b/src/Tasks/CallTarget.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Build.Tasks
     /// id validation checks to fail.
     /// </remarks>
     [RunInMTA]
+    [MSBuildMultiThreadableTask]
     public class CallTarget : TaskExtension
     {
         #region Properties


### PR DESCRIPTION
Fixes #13611

### Context
Migrates the `CallTarget` task to the multithreaded execution model.

### Changes Made
- Added `[MSBuildMultiThreadableTask]` to `CallTarget`.

`CallTarget` is a pure delegation task — it has no file I/O, no environment variable access, no process spawning, and no path handling. It simply forwards to `MSBuild.ExecuteTargets` via `BuildEngine3`. Per the multithreaded-task-migration skill, the attribute alone is sufficient; `IMultiThreadableTask` / `TaskEnvironment` are not needed.

### Testing
- Existing `CallTarget` tests pass.
- No new behavior introduced, so no new tests required.