### PR TITLE
Lift Windows whitespace-path guard from #13573 into standalone change (#13823)

### DIFF
--- a/src/Framework.UnitTests/AbsolutePath_Tests.cs
+++ b/src/Framework.UnitTests/AbsolutePath_Tests.cs
@@ -82,6 +82,38 @@ namespace Microsoft.Build.UnitTests
             exception.Message.ShouldStartWith("The value cannot be an empty string.");
         }
 
+        [WindowsOnlyTheory]
+        [InlineData(" ")]
+        [InlineData("  ")]
+        [InlineData("\t")]
+        [InlineData(" \t ")]
+        public void AbsolutePath_WhitespaceWithBasePath_ShouldThrowOnWindows(string whitespace)
+        {
+            // Before the multi-threaded migration, Path.GetFullPath(" ") threw ArgumentException on Windows.
+            // The "absolutize-at-boundary" pattern combines the input with a base path first, so without this
+            // guard Path.GetFullPath would silently trim the trailing whitespace and return the base directory,
+            // masking the original error. The constructor explicitly rejects whitespace-only input on Windows.
+            var basePath = GetTestBasePath();
+
+            var exception = Should.Throw<ArgumentException>(() => new AbsolutePath(whitespace, basePath));
+            exception.Message.ShouldContain("Path cannot be null or whitespace on Windows");
+        }
+
+        [UnixOnlyTheory]
+        [InlineData(" ")]
+        [InlineData("  ")]
+        [InlineData("\t")]
+        public void AbsolutePath_WhitespaceWithBasePath_ShouldNotThrowOnUnix(string whitespace)
+        {
+            // Whitespace is a legal filename character on Unix; preserve the historical accepting behavior.
+            var basePath = GetTestBasePath();
+
+            var absolutePath = new AbsolutePath(whitespace, basePath);
+
+            absolutePath.Value.ShouldBe(Path.Combine(basePath.Value, whitespace));
+            absolutePath.OriginalValue.ShouldBe(whitespace);
+        }
+
         [Theory]
         [InlineData("subfolder")]
         [InlineData("deep/nested/path")]

--- a/src/Framework/PathHelpers/AbsolutePath.cs
+++ b/src/Framework/PathHelpers/AbsolutePath.cs
@@ -101,10 +101,25 @@ namespace Microsoft.Build.Framework
         /// </summary>
         /// <param name="path">The path to combine with the base path.</param>
         /// <param name="basePath">The base path to combine with.</param>
-        /// <exception cref="ArgumentException">Thrown if <paramref name="path"/> is null or empty.</exception>
+        /// <exception cref="ArgumentException">
+        /// Thrown if <paramref name="path"/> is null or empty, or if <paramref name="path"/> is whitespace-only on Windows.
+        /// </exception>
+        /// <remarks>
+        /// On Windows, whitespace-only inputs are rejected to preserve the historical contract of
+        /// <see cref="System.IO.Path.GetFullPath(string)"/>, which threw <see cref="ArgumentException"/> for
+        /// whitespace-only paths. Without this guard the "absolutize-at-boundary" pattern used by multi-threadable
+        /// tasks would silently combine a whitespace input with the project directory (e.g. <c>"C:\\proj\\ "</c>),
+        /// which <see cref="System.IO.Path.GetFullPath(string)"/> then trims back to the project directory, masking
+        /// the original error. On Unix whitespace is a valid filename character and the input is accepted.
+        /// </remarks>
         public AbsolutePath(string path, AbsolutePath basePath)
         {
             ArgumentException.ThrowIfNullOrEmpty(path);
+
+            if (NativeMethods.IsWindows && string.IsNullOrWhiteSpace(path))
+            {
+                throw new ArgumentException(SR.WhitespacePathNotAllowedOnWindows, nameof(path));
+            }
 
             // This function should not throw when path has illegal characters.
             // For .NET Framework, Microsoft.IO.Path.Combine should be used instead of System.IO.Path.Combine to achieve it.

--- a/src/Framework/Resources/SR.resx
+++ b/src/Framework/Resources/SR.resx
@@ -153,6 +153,9 @@
   <data name="PathMustBeRooted" xml:space="preserve">
     <value>Path must be rooted.</value>
   </data>
+  <data name="WhitespacePathNotAllowedOnWindows" xml:space="preserve">
+    <value>Path cannot be null or whitespace on Windows.</value>
+  </data>
   <data name="PathTooLong" xml:space="preserve">
     <value>Path: {0} exceeds the OS max path limit. The fully qualified file name must be less than {1} characters.</value>
   </data>

--- a/src/Framework/Resources/xlf/SR.cs.xlf
+++ b/src/Framework/Resources/xlf/SR.cs.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../SR.resx">
     <body>
@@ -105,6 +105,11 @@
       <trans-unit id="PathMustBeRooted">
         <source>Path must be rooted.</source>
         <target state="translated">Cesta musí začínat kořenem.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WhitespacePathNotAllowedOnWindows">
+        <source>Path cannot be null or whitespace on Windows.</source>
+        <target state="new">Path cannot be null or whitespace on Windows.</target>
         <note />
       </trans-unit>
       <trans-unit id="PathTooLong">

--- a/src/Framework/Resources/xlf/SR.de.xlf
+++ b/src/Framework/Resources/xlf/SR.de.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../SR.resx">
     <body>
@@ -105,6 +105,11 @@
       <trans-unit id="PathMustBeRooted">
         <source>Path must be rooted.</source>
         <target state="translated">Der Pfad muss einen Stamm besitzen.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WhitespacePathNotAllowedOnWindows">
+        <source>Path cannot be null or whitespace on Windows.</source>
+        <target state="new">Path cannot be null or whitespace on Windows.</target>
         <note />
       </trans-unit>
       <trans-unit id="PathTooLong">

--- a/src/Framework/Resources/xlf/SR.es.xlf
+++ b/src/Framework/Resources/xlf/SR.es.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../SR.resx">
     <body>
@@ -105,6 +105,11 @@
       <trans-unit id="PathMustBeRooted">
         <source>Path must be rooted.</source>
         <target state="translated">Debe ser una ruta de acceso raíz.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WhitespacePathNotAllowedOnWindows">
+        <source>Path cannot be null or whitespace on Windows.</source>
+        <target state="new">Path cannot be null or whitespace on Windows.</target>
         <note />
       </trans-unit>
       <trans-unit id="PathTooLong">

--- a/src/Framework/Resources/xlf/SR.fr.xlf
+++ b/src/Framework/Resources/xlf/SR.fr.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../SR.resx">
     <body>
@@ -105,6 +105,11 @@
       <trans-unit id="PathMustBeRooted">
         <source>Path must be rooted.</source>
         <target state="translated">Le chemin doit être associé à une racine.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WhitespacePathNotAllowedOnWindows">
+        <source>Path cannot be null or whitespace on Windows.</source>
+        <target state="new">Path cannot be null or whitespace on Windows.</target>
         <note />
       </trans-unit>
       <trans-unit id="PathTooLong">

--- a/src/Framework/Resources/xlf/SR.it.xlf
+++ b/src/Framework/Resources/xlf/SR.it.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../SR.resx">
     <body>
@@ -105,6 +105,11 @@
       <trans-unit id="PathMustBeRooted">
         <source>Path must be rooted.</source>
         <target state="translated">Il percorso deve contenere una radice.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WhitespacePathNotAllowedOnWindows">
+        <source>Path cannot be null or whitespace on Windows.</source>
+        <target state="new">Path cannot be null or whitespace on Windows.</target>
         <note />
       </trans-unit>
       <trans-unit id="PathTooLong">

--- a/src/Framework/Resources/xlf/SR.ja.xlf
+++ b/src/Framework/Resources/xlf/SR.ja.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../SR.resx">
     <body>
@@ -105,6 +105,11 @@
       <trans-unit id="PathMustBeRooted">
         <source>Path must be rooted.</source>
         <target state="translated">パスはルート指定パスである必要があります。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WhitespacePathNotAllowedOnWindows">
+        <source>Path cannot be null or whitespace on Windows.</source>
+        <target state="new">Path cannot be null or whitespace on Windows.</target>
         <note />
       </trans-unit>
       <trans-unit id="PathTooLong">

--- a/src/Framework/Resources/xlf/SR.ko.xlf
+++ b/src/Framework/Resources/xlf/SR.ko.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../SR.resx">
     <body>
@@ -105,6 +105,11 @@
       <trans-unit id="PathMustBeRooted">
         <source>Path must be rooted.</source>
         <target state="translated">루트 경로로 지정해야 합니다.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WhitespacePathNotAllowedOnWindows">
+        <source>Path cannot be null or whitespace on Windows.</source>
+        <target state="new">Path cannot be null or whitespace on Windows.</target>
         <note />
       </trans-unit>
       <trans-unit id="PathTooLong">

--- a/src/Framework/Resources/xlf/SR.pl.xlf
+++ b/src/Framework/Resources/xlf/SR.pl.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../SR.resx">
     <body>
@@ -105,6 +105,11 @@
       <trans-unit id="PathMustBeRooted">
         <source>Path must be rooted.</source>
         <target state="translated">Ścieżka musi zaczynać się od katalogu głównego.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WhitespacePathNotAllowedOnWindows">
+        <source>Path cannot be null or whitespace on Windows.</source>
+        <target state="new">Path cannot be null or whitespace on Windows.</target>
         <note />
       </trans-unit>
       <trans-unit id="PathTooLong">

--- a/src/Framework/Resources/xlf/SR.pt-BR.xlf
+++ b/src/Framework/Resources/xlf/SR.pt-BR.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../SR.resx">
     <body>
@@ -105,6 +105,11 @@
       <trans-unit id="PathMustBeRooted">
         <source>Path must be rooted.</source>
         <target state="translated">Caminho deve ter raiz.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WhitespacePathNotAllowedOnWindows">
+        <source>Path cannot be null or whitespace on Windows.</source>
+        <target state="new">Path cannot be null or whitespace on Windows.</target>
         <note />
       </trans-unit>
       <trans-unit id="PathTooLong">

--- a/src/Framework/Resources/xlf/SR.ru.xlf
+++ b/src/Framework/Resources/xlf/SR.ru.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../SR.resx">
     <body>
@@ -105,6 +105,11 @@
       <trans-unit id="PathMustBeRooted">
         <source>Path must be rooted.</source>
         <target state="translated">Путь должен иметь корень.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WhitespacePathNotAllowedOnWindows">
+        <source>Path cannot be null or whitespace on Windows.</source>
+        <target state="new">Path cannot be null or whitespace on Windows.</target>
         <note />
       </trans-unit>
       <trans-unit id="PathTooLong">

--- a/src/Framework/Resources/xlf/SR.tr.xlf
+++ b/src/Framework/Resources/xlf/SR.tr.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../SR.resx">
     <body>
@@ -105,6 +105,11 @@
       <trans-unit id="PathMustBeRooted">
         <source>Path must be rooted.</source>
         <target state="translated">Yol kökü belirtilmelidir.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WhitespacePathNotAllowedOnWindows">
+        <source>Path cannot be null or whitespace on Windows.</source>
+        <target state="new">Path cannot be null or whitespace on Windows.</target>
         <note />
       </trans-unit>
       <trans-unit id="PathTooLong">

--- a/src/Framework/Resources/xlf/SR.zh-Hans.xlf
+++ b/src/Framework/Resources/xlf/SR.zh-Hans.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../SR.resx">
     <body>
@@ -105,6 +105,11 @@
       <trans-unit id="PathMustBeRooted">
         <source>Path must be rooted.</source>
         <target state="translated">路径必须是根路径。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WhitespacePathNotAllowedOnWindows">
+        <source>Path cannot be null or whitespace on Windows.</source>
+        <target state="new">Path cannot be null or whitespace on Windows.</target>
         <note />
       </trans-unit>
       <trans-unit id="PathTooLong">

--- a/src/Framework/Resources/xlf/SR.zh-Hant.xlf
+++ b/src/Framework/Resources/xlf/SR.zh-Hant.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../SR.resx">
     <body>
@@ -105,6 +105,11 @@
       <trans-unit id="PathMustBeRooted">
         <source>Path must be rooted.</source>
         <target state="translated">路徑必須為根路徑。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WhitespacePathNotAllowedOnWindows">
+        <source>Path cannot be null or whitespace on Windows.</source>
+        <target state="new">Path cannot be null or whitespace on Windows.</target>
         <note />
       </trans-unit>
       <trans-unit id="PathTooLong">

--- a/src/Tasks/AddToWin32Manifest.cs
+++ b/src/Tasks/AddToWin32Manifest.cs
@@ -94,7 +94,7 @@ namespace Microsoft.Build.Tasks
         {
             if (ApplicationManifest != null)
             {
-                if (string.IsNullOrEmpty(ApplicationManifest.ItemSpec))
+                if (string.IsNullOrWhiteSpace(ApplicationManifest.ItemSpec))
                 {
                     Log.LogErrorWithCodeFromResources(null, ApplicationManifest.ItemSpec, 0, 0, 0, 0, "AddToWin32Manifest.SpecifiedApplicationManifestCanNotBeFound");
                     return null;

--- a/src/Tasks/Move.cs
+++ b/src/Tasks/Move.cs
@@ -176,7 +176,7 @@ namespace Microsoft.Build.Tasks
                         success = false;
                     }
                 }
-                catch (Exception e) when (ExceptionHandling.IsIoRelatedException(e))
+                catch (Exception e) when (ExceptionHandling.IsIoRelatedException(e) || e is ArgumentException)
                 {
                     string lockedFileMessage = LockCheck.GetLockedFileMessage(sourceFile?.OriginalValue ?? sourceSpec);
                     Log.LogErrorWithCodeFromResources("Move.Error", sourceSpec, destinationSpec, e.Message, lockedFileMessage);

--- a/src/Utilities/ToolTask.cs
+++ b/src/Utilities/ToolTask.cs
@@ -678,9 +678,11 @@ namespace Microsoft.Build.Utilities
                 startInfo.RedirectStandardInput = true;
             }
 
-            // Generally we won't set a working directory, and it will use the current directory
+            // Generally we won't set a working directory, and it will use the current directory.
+            // Treat whitespace-only working directories the same as null/empty so AbsolutePath's
+            // Windows whitespace guard cannot turn a benign "no working directory" case into a throw.
             string workingDirectory = GetWorkingDirectory();
-            if (!string.IsNullOrEmpty(workingDirectory))
+            if (!string.IsNullOrWhiteSpace(workingDirectory))
             {
                 startInfo.WorkingDirectory = TaskEnvironment.GetAbsolutePath(workingDirectory);
             }


### PR DESCRIPTION
Fixes #13823.

## Context

[#13573](https://github.com/dotnet/msbuild/pull/13573) restored the historical Windows-only behavior of throwing on `Path.GetFullPath(" ")` by guarding `AbsolutePath` against whitespace-only paths. During review, @AR-May flagged this as risky:

> I think this is a very risky change as any task that uses `AbsolutePath` may now start throwing - and this would be change of behavior. We need to be careful with it and make another review of all enlightened tasks that use `AbsolutePath`.

@OvesN agreed it should be split out:

> Yeah, I think we probably should make a separate issue and PR for this.

This PR is that standalone change. The goal is **no new observable behavior** for any enlightened (`IMultiThreadableTask`) task: where a whitespace-only path previously surfaced as a user-facing error or `IOException`, it must continue to do so — not bubble up as an unhandled `ArgumentException`.

## Change

`AbsolutePath(string path, AbsolutePath basePath)` now throws `ArgumentException` on Windows when `path` is whitespace-only. Unix is unchanged because whitespace is a legal filename character there.

Resource string `WhitespacePathNotAllowedOnWindows` added to `src/Framework/Resources/SR.resx` with the corresponding `<trans-unit state="new">` entry in all 13 XLF files (OneLoc will pick these up).

## Audit of enlightened call sites

89 `TaskEnvironment.GetAbsolutePath` / `new AbsolutePath(path, basePath)` call sites reviewed. 6 were AT RISK; 3 needed source changes:

| File | Line | Risk | Resolution |
|------|------|------|------------|
| `src/Tasks/AddToWin32Manifest.cs` | 103 | `ApplicationManifest.ItemSpec` could be whitespace | Tightened guard at line 97: `IsNullOrEmpty` → `IsNullOrWhiteSpace` so the existing user-facing error fires first |
| `src/Tasks/AddToWin32Manifest.cs` | 184 | `OutputDirectory` whitespace | Safe — `Path.Combine(" ", "app.manifest")` produces `" \app.manifest"`, not whitespace |
| `src/Tasks/Copy.cs` | 521, 522, 687, 688 | `SourceFiles` / `DestinationFiles` item specs | Safe — already wrapped in `catch (ArgumentException)` that logs `Copy.Error` |
| `src/Tasks/Move.cs` | 166, 167 | `SourceFiles` / `DestinationFiles` item specs | Catch filter extended from `IsIoRelatedException(e)` to `IsIoRelatedException(e) \|\| e is ArgumentException` so the existing `Move.Error` is logged |
| `src/Utilities/ToolTask.cs` | 685 | `ToolTask.WorkingDirectory` | Tightened guard at line 683: `IsNullOrEmpty(workingDirectory)` → `IsNullOrWhiteSpace(workingDirectory)`. Large blast radius (every `ToolTask`-derived task), called out for reviewer attention |

The other 83 sites either receive non-whitespace inputs by construction (resolved file paths, well-known names, etc.) or already have appropriate exception handling around the call.

## Tests

- `src/Framework.UnitTests/AbsolutePath_Tests.cs` — added `AbsolutePath_WhitespaceWithBasePath_ShouldThrowOnWindows` (`" "`, `"  "`, `"\t"`, `" \t "`) and `AbsolutePath_WhitespaceWithBasePath_ShouldNotThrowOnUnix`.
- Framework.UnitTests `AbsolutePath_Tests`: **90 passed, 8 platform-skipped**.
- Tasks.UnitTests `Copy_Tests` (149), `Move_Tests` (23), `AddToWin32Manifest_Tests` (8), `ToolTask*` (6): **all green**.
- Utilities.UnitTests `*ToolTask*` (62): **all green**.
- Full `.\build.cmd -v quiet`: green.

## Follow-up

Once this merges, the equivalent guard in [#13573](https://github.com/dotnet/msbuild/pull/13573) should be dropped.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
