### PR TITLE
Migrate FormatUrl to multithreaded execution with FormatUrl-local Windows whitespace guard

### DIFF
--- a/src/Tasks.UnitTests/FormatUrl_Tests.cs
+++ b/src/Tasks.UnitTests/FormatUrl_Tests.cs
@@ -79,12 +79,12 @@ namespace Microsoft.Build.UnitTests
 
         /// <summary>
         /// The URL to format is white space.
-        /// FormatUrl explicitly fails on Windows for whitespace-only input because whitespace-only
-        /// paths are not valid on Windows file systems. This guard preserves the historical
-        /// rejection behavior previously raised by <see cref="Path.GetFullPath(string)"/>, which
-        /// was lost when the task migrated to multithreaded execution (relative paths are now
-        /// resolved against the project directory via AbsolutePath, which would otherwise silently
-        /// trim trailing whitespace and mask the error).
+        /// FormatUrl explicitly fails on Windows for whitespace-only input: it logs a localized
+        /// MSB4311 error AND throws <see cref="ArgumentException"/> from <see cref="Path.GetFullPath(string)"/>
+        /// to preserve backwards compatibility with any caller relying on the historical exception
+        /// contract that was lost when the task migrated to multithreaded execution (relative paths
+        /// are now resolved against the project directory via AbsolutePath, which would otherwise
+        /// silently trim trailing whitespace and mask the error).
         /// </summary>
         [WindowsOnlyFact]
         public void WhitespaceTestOnWindows()
@@ -92,7 +92,7 @@ namespace Microsoft.Build.UnitTests
             var t = GetFormatUrlUnderTest();
 
             t.InputUrl = " ";
-            t.Execute().ShouldBeFalse();
+            Should.Throw<ArgumentException>(() => t.Execute());
             ((MockEngine)t.BuildEngine).AssertLogContains("MSB4311");
         }
 
@@ -101,9 +101,8 @@ namespace Microsoft.Build.UnitTests
         /// fires even when the task is wired up to a real <see cref="TaskEnvironment"/> with an
         /// isolated project directory (i.e. the multithreaded execution path). Without the guard,
         /// the input would silently absolutize against the project directory and lose the
-        /// historical rejection behavior.
-        /// Uses a single-space input which is the canonical case rejected on Windows across all
-        /// supported .NET runtimes.
+        /// historical <see cref="ArgumentException"/> contract from <see cref="Path.GetFullPath(string)"/>.
+        /// Asserts both the localized MSB4311 log entry and the rethrown exception.
         /// </summary>
         [WindowsOnlyFact]
         public void WhitespaceInputFailsOnWindowsWithIsolatedProjectDirectory()
@@ -124,7 +123,7 @@ namespace Microsoft.Build.UnitTests
                 InputUrl = " ",
             };
 
-            t.Execute().ShouldBeFalse();
+            Should.Throw<ArgumentException>(() => t.Execute());
             engine.AssertLogContains("MSB4311");
         }
 

--- a/src/Tasks.UnitTests/FormatUrl_Tests.cs
+++ b/src/Tasks.UnitTests/FormatUrl_Tests.cs
@@ -1,8 +1,9 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.IO;
+using Microsoft.Build.Framework;
 using Microsoft.Build.Tasks;
 using Shouldly;
 using Xunit;
@@ -18,14 +19,18 @@ namespace Microsoft.Build.UnitTests
             _out = testOutputHelper;
         }
 
+        private FormatUrl GetFormatUrlUnderTest() => new FormatUrl
+        {
+            BuildEngine = new MockEngine(_out),
+        };
+
         /// <summary>
         /// The URL to format is null.
         /// </summary>
         [Fact]
         public void NullTest()
         {
-            var t = new FormatUrl();
-            t.BuildEngine = new MockEngine(_out);
+            var t = GetFormatUrlUnderTest();
 
             t.InputUrl = null;
             t.Execute().ShouldBeTrue();
@@ -38,8 +43,7 @@ namespace Microsoft.Build.UnitTests
         [Fact]
         public void EmptyTest()
         {
-            var t = new FormatUrl();
-            t.BuildEngine = new MockEngine(_out);
+            var t = GetFormatUrlUnderTest();
 
             t.InputUrl = string.Empty;
             t.Execute().ShouldBeTrue();
@@ -52,8 +56,7 @@ namespace Microsoft.Build.UnitTests
         [Fact]
         public void NoInputTest()
         {
-            var t = new FormatUrl();
-            t.BuildEngine = new MockEngine(_out);
+            var t = GetFormatUrlUnderTest();
 
             t.Execute().ShouldBeTrue();
             t.OutputUrl.ShouldBe(string.Empty);
@@ -61,15 +64,13 @@ namespace Microsoft.Build.UnitTests
 
         /// <summary>
         /// The URL to format is white space.
-        /// FormatUrl depends on Path.GetFullPath.
-        /// From the documentation, Path.GetFullPath(" ") should throw an ArgumentException, but it doesn't on macOS and Linux
-        /// where whitespace characters are valid characters for filenames.
+        /// Whitespace is a valid filename character on macOS and Linux, so the task should succeed and
+        /// resolve the input against the task's project directory.
         /// </summary>
         [UnixOnlyFact]
         public void WhitespaceTestOnUnix()
         {
-            var t = new FormatUrl();
-            t.BuildEngine = new MockEngine(_out);
+            var t = GetFormatUrlUnderTest();
 
             t.InputUrl = " ";
             t.Execute().ShouldBeTrue();
@@ -78,14 +79,48 @@ namespace Microsoft.Build.UnitTests
 
         /// <summary>
         /// The URL to format is white space.
+        /// FormatUrl explicitly throws <see cref="ArgumentException"/> on Windows for whitespace-only
+        /// input to replicate the historical contract of <see cref="Path.GetFullPath(string)"/>,
+        /// which was lost when the task migrated to multithreaded execution (relative paths are now
+        /// resolved against the project directory via AbsolutePath, which would otherwise silently
+        /// trim trailing whitespace and mask the original error).
         /// </summary>
         [WindowsOnlyFact]
         public void WhitespaceTestOnWindows()
         {
-            var t = new FormatUrl();
-            t.BuildEngine = new MockEngine(_out);
+            var t = GetFormatUrlUnderTest();
 
             t.InputUrl = " ";
+            Should.Throw<ArgumentException>(() => t.Execute());
+        }
+
+        /// <summary>
+        /// Specifically validates that the Windows-only whitespace guard in <see cref="FormatUrl"/>
+        /// fires even when the task is wired up to a real <see cref="TaskEnvironment"/> with an
+        /// isolated project directory (i.e. the multithreaded execution path). Without the guard,
+        /// the input would silently absolutize against the project directory and lose the
+        /// historical <see cref="ArgumentException"/> contract from <see cref="Path.GetFullPath(string)"/>.
+        /// Uses a single-space input which is the canonical case that <see cref="Path.GetFullPath(string)"/>
+        /// rejects with <see cref="ArgumentException"/> across all supported .NET runtimes on Windows.
+        /// </summary>
+        [WindowsOnlyFact]
+        public void WhitespaceInputThrowsOnWindowsWithIsolatedProjectDirectory()
+        {
+            using TestEnvironment env = TestEnvironment.Create(_out);
+            TransientTestFolder projectFolder = env.CreateFolder(createFolder: true);
+
+            // Sanity check: project directory must differ from the process current directory so we know
+            // the guard fires before the AbsolutePath absolutization (which would otherwise silently
+            // resolve "projectDir\ " to projectDir on Windows and hide the historical error).
+            projectFolder.Path.ShouldNotBe(Environment.CurrentDirectory);
+
+            var t = new FormatUrl
+            {
+                TaskEnvironment = TaskEnvironment.CreateWithProjectDirectoryAndEnvironment(projectFolder.Path),
+                BuildEngine = new MockEngine(_out),
+                InputUrl = " ",
+            };
+
             Should.Throw<ArgumentException>(() => t.Execute());
         }
 
@@ -95,8 +130,7 @@ namespace Microsoft.Build.UnitTests
         [Fact]
         public void UncPathTest()
         {
-            var t = new FormatUrl();
-            t.BuildEngine = new MockEngine(_out);
+            var t = GetFormatUrlUnderTest();
 
             t.InputUrl = @"\\server\filename.ext";
             t.Execute().ShouldBeTrue();
@@ -110,8 +144,7 @@ namespace Microsoft.Build.UnitTests
         [Fact]
         public void LocalAbsolutePathTest()
         {
-            var t = new FormatUrl();
-            t.BuildEngine = new MockEngine(_out);
+            var t = GetFormatUrlUnderTest();
 
             t.InputUrl = Environment.CurrentDirectory;
             t.Execute().ShouldBeTrue();
@@ -125,8 +158,7 @@ namespace Microsoft.Build.UnitTests
         [Fact]
         public void LocalRelativePathTest()
         {
-            var t = new FormatUrl();
-            t.BuildEngine = new MockEngine(_out);
+            var t = GetFormatUrlUnderTest();
 
             t.InputUrl = @".";
             t.Execute().ShouldBeTrue();
@@ -139,8 +171,7 @@ namespace Microsoft.Build.UnitTests
         [UnixOnlyFact]
         public void LocalUnixAbsolutePathTest()
         {
-            var t = new FormatUrl();
-            t.BuildEngine = new MockEngine(_out);
+            var t = GetFormatUrlUnderTest();
 
             t.InputUrl = @"/usr/local/share";
             t.Execute().ShouldBeTrue();
@@ -153,8 +184,7 @@ namespace Microsoft.Build.UnitTests
         [WindowsOnlyFact]
         public void LocalWindowsAbsolutePathTest()
         {
-            var t = new FormatUrl();
-            t.BuildEngine = new MockEngine(_out);
+            var t = GetFormatUrlUnderTest();
 
             t.InputUrl = @"c:\folder\filename.ext";
             t.Execute().ShouldBeTrue();
@@ -167,8 +197,7 @@ namespace Microsoft.Build.UnitTests
         [Fact]
         public void UrlLocalHostTest()
         {
-            var t = new FormatUrl();
-            t.BuildEngine = new MockEngine(_out);
+            var t = GetFormatUrlUnderTest();
 
             t.InputUrl = @"https://localhost/Example/Path";
             t.Execute().ShouldBeTrue();
@@ -181,8 +210,7 @@ namespace Microsoft.Build.UnitTests
         [Fact]
         public void UrlTest()
         {
-            var t = new FormatUrl();
-            t.BuildEngine = new MockEngine(_out);
+            var t = GetFormatUrlUnderTest();
 
             t.InputUrl = @"https://example.com/Example/Path";
             t.Execute().ShouldBeTrue();
@@ -195,12 +223,37 @@ namespace Microsoft.Build.UnitTests
         [Fact]
         public void UrlParentPathTest()
         {
-            var t = new FormatUrl();
-            t.BuildEngine = new MockEngine(_out);
+            var t = GetFormatUrlUnderTest();
 
             t.InputUrl = @"https://example.com/Example/../Path";
             t.Execute().ShouldBeTrue();
             t.OutputUrl.ShouldBe(@"https://example.com/Path");
+        }
+
+        /// <summary>
+        /// A relative input URL is resolved against the task's <see cref="TaskEnvironment.ProjectDirectory"/>,
+        /// not the process current working directory. This documents the intentional semantic change
+        /// introduced when migrating the task to multithreaded execution.
+        /// </summary>
+        [Fact]
+        public void RelativePathResolvesAgainstProjectDirectory()
+        {
+            using TestEnvironment env = TestEnvironment.Create(_out);
+            TransientTestFolder projectFolder = env.CreateFolder(createFolder: true);
+
+            // Sanity check: project directory must differ from the process current directory
+            // for the assertion below to be meaningful.
+            projectFolder.Path.ShouldNotBe(Environment.CurrentDirectory);
+
+            var t = new FormatUrl
+            {
+                TaskEnvironment = TaskEnvironment.CreateWithProjectDirectoryAndEnvironment(projectFolder.Path),
+                BuildEngine = new MockEngine(_out),
+                InputUrl = @".",
+            };
+
+            t.Execute().ShouldBeTrue();
+            t.OutputUrl.ShouldBe(new Uri(projectFolder.Path).AbsoluteUri);
         }
     }
 }

--- a/src/Tasks.UnitTests/FormatUrl_Tests.cs
+++ b/src/Tasks.UnitTests/FormatUrl_Tests.cs
@@ -79,11 +79,12 @@ namespace Microsoft.Build.UnitTests
 
         /// <summary>
         /// The URL to format is white space.
-        /// FormatUrl explicitly throws <see cref="ArgumentException"/> on Windows for whitespace-only
-        /// input to replicate the historical contract of <see cref="Path.GetFullPath(string)"/>,
-        /// which was lost when the task migrated to multithreaded execution (relative paths are now
+        /// FormatUrl explicitly fails on Windows for whitespace-only input because whitespace-only
+        /// paths are not valid on Windows file systems. This guard preserves the historical
+        /// rejection behavior previously raised by <see cref="Path.GetFullPath(string)"/>, which
+        /// was lost when the task migrated to multithreaded execution (relative paths are now
         /// resolved against the project directory via AbsolutePath, which would otherwise silently
-        /// trim trailing whitespace and mask the original error).
+        /// trim trailing whitespace and mask the error).
         /// </summary>
         [WindowsOnlyFact]
         public void WhitespaceTestOnWindows()
@@ -91,7 +92,8 @@ namespace Microsoft.Build.UnitTests
             var t = GetFormatUrlUnderTest();
 
             t.InputUrl = " ";
-            Should.Throw<ArgumentException>(() => t.Execute());
+            t.Execute().ShouldBeFalse();
+            ((MockEngine)t.BuildEngine).AssertLogContains("MSB4311");
         }
 
         /// <summary>
@@ -99,12 +101,12 @@ namespace Microsoft.Build.UnitTests
         /// fires even when the task is wired up to a real <see cref="TaskEnvironment"/> with an
         /// isolated project directory (i.e. the multithreaded execution path). Without the guard,
         /// the input would silently absolutize against the project directory and lose the
-        /// historical <see cref="ArgumentException"/> contract from <see cref="Path.GetFullPath(string)"/>.
-        /// Uses a single-space input which is the canonical case that <see cref="Path.GetFullPath(string)"/>
-        /// rejects with <see cref="ArgumentException"/> across all supported .NET runtimes on Windows.
+        /// historical rejection behavior.
+        /// Uses a single-space input which is the canonical case rejected on Windows across all
+        /// supported .NET runtimes.
         /// </summary>
         [WindowsOnlyFact]
-        public void WhitespaceInputThrowsOnWindowsWithIsolatedProjectDirectory()
+        public void WhitespaceInputFailsOnWindowsWithIsolatedProjectDirectory()
         {
             using TestEnvironment env = TestEnvironment.Create(_out);
             TransientTestFolder projectFolder = env.CreateFolder(createFolder: true);
@@ -114,14 +116,16 @@ namespace Microsoft.Build.UnitTests
             // resolve "projectDir\ " to projectDir on Windows and hide the historical error).
             projectFolder.Path.ShouldNotBe(Environment.CurrentDirectory);
 
+            var engine = new MockEngine(_out);
             var t = new FormatUrl
             {
                 TaskEnvironment = TaskEnvironment.CreateWithProjectDirectoryAndEnvironment(projectFolder.Path),
-                BuildEngine = new MockEngine(_out),
+                BuildEngine = engine,
                 InputUrl = " ",
             };
 
-            Should.Throw<ArgumentException>(() => t.Execute());
+            t.Execute().ShouldBeFalse();
+            engine.AssertLogContains("MSB4311");
         }
 
         /// <summary>
@@ -254,6 +258,42 @@ namespace Microsoft.Build.UnitTests
 
             t.Execute().ShouldBeTrue();
             t.OutputUrl.ShouldBe(new Uri(projectFolder.Path).AbsoluteUri);
+        }
+
+        /// <summary>
+        /// Two <see cref="FormatUrl"/> instances configured with different
+        /// <see cref="TaskEnvironment.ProjectDirectory"/> values resolve the same relative input
+        /// independently, each against its own project directory. Locks in the multithreaded-safety
+        /// contract: relative-path resolution must derive from the per-task <see cref="TaskEnvironment"/>
+        /// rather than any process-wide state (the original bug class motivating the migration).
+        /// </summary>
+        [Fact]
+        public void RelativePathResolvesIndependentlyAcrossInstances()
+        {
+            using TestEnvironment env = TestEnvironment.Create(_out);
+            TransientTestFolder projectFolderA = env.CreateFolder(createFolder: true);
+            TransientTestFolder projectFolderB = env.CreateFolder(createFolder: true);
+
+            projectFolderA.Path.ShouldNotBe(projectFolderB.Path);
+
+            var taskA = new FormatUrl
+            {
+                TaskEnvironment = TaskEnvironment.CreateWithProjectDirectoryAndEnvironment(projectFolderA.Path),
+                BuildEngine = new MockEngine(_out),
+                InputUrl = @".",
+            };
+            var taskB = new FormatUrl
+            {
+                TaskEnvironment = TaskEnvironment.CreateWithProjectDirectoryAndEnvironment(projectFolderB.Path),
+                BuildEngine = new MockEngine(_out),
+                InputUrl = @".",
+            };
+
+            taskA.Execute().ShouldBeTrue();
+            taskB.Execute().ShouldBeTrue();
+
+            taskA.OutputUrl.ShouldBe(new Uri(projectFolderA.Path).AbsoluteUri);
+            taskB.OutputUrl.ShouldBe(new Uri(projectFolderB.Path).AbsoluteUri);
         }
     }
 }

--- a/src/Tasks/FormatUrl.cs
+++ b/src/Tasks/FormatUrl.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.IO;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Tasks.Deployment.ManifestUtilities;
 
@@ -38,12 +39,15 @@ namespace Microsoft.Build.Tasks
             // historically by Path.GetFullPath inside PathUtil.Resolve. After migrating to resolve
             // relative paths against the project directory, "projectDir\ " would otherwise be
             // silently trimmed by Path.GetFullPath and absolutize to the project directory itself,
-            // masking the input error. Fail the task with a clear, localized error instead.
-            // Whitespace remains valid on Unix where it is a legal filename character.
+            // masking the input error.
+            //
+            // Log a clear, localized error AND rethrow the historical ArgumentException so any
+            // existing caller relying on the exception contract from Path.GetFullPath(" ") still
+            // observes it. Whitespace remains valid on Unix where it is a legal filename character.
             if (InputUrl.Length > 0 && NativeMethodsShared.IsWindows && string.IsNullOrWhiteSpace(InputUrl))
             {
                 Log.LogErrorWithCodeFromResources("FormatUrl.WhitespaceInputUrlNotAllowedOnWindows", InputUrl);
-                return false;
+                Path.GetFullPath(InputUrl);
             }
 
             OutputUrl = PathUtil.Format(InputUrl, TaskEnvironment.ProjectDirectory);

--- a/src/Tasks/FormatUrl.cs
+++ b/src/Tasks/FormatUrl.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.IO;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Tasks.Deployment.ManifestUtilities;
 
@@ -12,8 +13,15 @@ namespace Microsoft.Build.Tasks
     /// <summary>
     /// Formats a url by canonicalizing it (i.e. " " -> "%20") and transforming "localhost" to "machinename".
     /// </summary>
-    public sealed class FormatUrl : TaskExtension
+    [MSBuildMultiThreadableTask]
+    public sealed class FormatUrl : TaskExtension, IMultiThreadableTask
     {
+        /// <summary>
+        /// Gets or sets the task execution environment used to resolve relative paths against
+        /// the project directory instead of the process current working directory.
+        /// </summary>
+        public TaskEnvironment TaskEnvironment { get; set; } = TaskEnvironment.Fallback;
+
         public string InputUrl { get; set; }
 
         [Output]
@@ -21,7 +29,28 @@ namespace Microsoft.Build.Tasks
 
         public override bool Execute()
         {
-            OutputUrl = InputUrl != null ? PathUtil.Format(InputUrl) : String.Empty;
+            if (InputUrl == null)
+            {
+                OutputUrl = String.Empty;
+                return true;
+            }
+
+            // Before the migration to multithreaded execution, PathUtil.Resolve called
+            // Path.GetFullPath(InputUrl) which, on Windows, throws ArgumentException for
+            // whitespace-only paths. After migrating to resolve relative paths against the
+            // project directory via AbsolutePath, Path.Combine(projectDir, " ") yields a
+            // path like "projectDir\ " whose trailing whitespace is silently trimmed by
+            // Path.GetFullPath inside AbsolutePath, masking the historical error.
+            //
+            // To preserve a 1:1 replication of the original Windows-only behavior, force
+            // the same ArgumentException Path.GetFullPath would have raised. Whitespace
+            // remains valid on Unix where it is a legal filename character.
+            if (InputUrl.Length > 0 && NativeMethodsShared.IsWindows && string.IsNullOrWhiteSpace(InputUrl))
+            {
+                Path.GetFullPath(InputUrl);
+            }
+
+            OutputUrl = PathUtil.Format(InputUrl, TaskEnvironment.ProjectDirectory);
             return true;
         }
     }

--- a/src/Tasks/FormatUrl.cs
+++ b/src/Tasks/FormatUrl.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.IO;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Tasks.Deployment.ManifestUtilities;
 
@@ -35,19 +34,16 @@ namespace Microsoft.Build.Tasks
                 return true;
             }
 
-            // Before the migration to multithreaded execution, PathUtil.Resolve called
-            // Path.GetFullPath(InputUrl) which, on Windows, throws ArgumentException for
-            // whitespace-only paths. After migrating to resolve relative paths against the
-            // project directory via AbsolutePath, Path.Combine(projectDir, " ") yields a
-            // path like "projectDir\ " whose trailing whitespace is silently trimmed by
-            // Path.GetFullPath inside AbsolutePath, masking the historical error.
-            //
-            // To preserve a 1:1 replication of the original Windows-only behavior, force
-            // the same ArgumentException Path.GetFullPath would have raised. Whitespace
-            // remains valid on Unix where it is a legal filename character.
+            // On Windows, whitespace-only paths are not valid file system paths and were rejected
+            // historically by Path.GetFullPath inside PathUtil.Resolve. After migrating to resolve
+            // relative paths against the project directory, "projectDir\ " would otherwise be
+            // silently trimmed by Path.GetFullPath and absolutize to the project directory itself,
+            // masking the input error. Fail the task with a clear, localized error instead.
+            // Whitespace remains valid on Unix where it is a legal filename character.
             if (InputUrl.Length > 0 && NativeMethodsShared.IsWindows && string.IsNullOrWhiteSpace(InputUrl))
             {
-                Path.GetFullPath(InputUrl);
+                Log.LogErrorWithCodeFromResources("FormatUrl.WhitespaceInputUrlNotAllowedOnWindows", InputUrl);
+                return false;
             }
 
             OutputUrl = PathUtil.Format(InputUrl, TaskEnvironment.ProjectDirectory);

--- a/src/Tasks/ManifestUtil/PathUtil.cs
+++ b/src/Tasks/ManifestUtil/PathUtil.cs
@@ -236,12 +236,12 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
                 return path;
             }
 
-            // if not unc or url then it must be a local disk path...
-            // Use AbsolutePath to root the path against the project's base directory instead of the
-            // process current directory. GetCanonicalForm() preserves the canonicalization that
-            // Path.GetFullPath performed previously. FormatUrl performs an explicit Windows-only
-            // whitespace check before calling into this helper to preserve the historical
-            // ArgumentException raised by Path.GetFullPath(" ") on Windows.
+            // If not UNC or URL then treat as a local disk path. Root the (possibly relative)
+            // path against the supplied base directory rather than the process current directory
+            // so the resolution is deterministic under multithreaded task execution, and return
+            // its canonical (fully qualified, normalized) form. FormatUrl rejects whitespace-only
+            // inputs on Windows before reaching this method, since AbsolutePath would otherwise
+            // silently trim trailing whitespace and absolutize "baseDirectory\ " to baseDirectory.
             return new AbsolutePath(path, baseDirectory).GetCanonicalForm();
         }
 

--- a/src/Tasks/ManifestUtil/PathUtil.cs
+++ b/src/Tasks/ManifestUtil/PathUtil.cs
@@ -8,6 +8,7 @@ using System.Linq;
 #else
 using System.Text;
 #endif
+using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
 
 #nullable disable
@@ -41,14 +42,14 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
         }
 
         // Resolves the path, and if path is a url also canonicalizes it.
-        public static string Format(string path)
+        public static string Format(string path, AbsolutePath baseDirectory)
         {
             if (String.IsNullOrEmpty(path))
             {
                 return path;
             }
 
-            string resolvedPath = Resolve(path);
+            string resolvedPath = Resolve(path, baseDirectory);
             Uri u = new Uri(resolvedPath);
             //
             // GB18030: Uri class does not correctly encode chars in the PUA range for implicit 
@@ -202,8 +203,8 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
         }
 
         // If path is a url and starts with "localhost", resolves to machine name.
-        // If path is a relative path, resolves to a full path.
-        public static string Resolve(string path)
+        // If path is a relative path, resolves to a full path against <paramref name="baseDirectory"/>.
+        public static string Resolve(string path, AbsolutePath baseDirectory)
         {
             if (String.IsNullOrEmpty(path))
             {
@@ -236,7 +237,12 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
             }
 
             // if not unc or url then it must be a local disk path...
-            return Path.GetFullPath(path); // make sure it's a full path
+            // Use AbsolutePath to root the path against the project's base directory instead of the
+            // process current directory. GetCanonicalForm() preserves the canonicalization that
+            // Path.GetFullPath performed previously. FormatUrl performs an explicit Windows-only
+            // whitespace check before calling into this helper to preserve the historical
+            // ArgumentException raised by Path.GetFullPath(" ") on Windows.
+            return new AbsolutePath(path, baseDirectory).GetCanonicalForm();
         }
 
         private static bool IsAsciiString(string str) =>

--- a/src/Tasks/Resources/Strings.resx
+++ b/src/Tasks/Resources/Strings.resx
@@ -3088,6 +3088,14 @@
   </data>
 
   <!--
+        MSB4311 - MSB4320   Task: FormatUrl
+  -->
+  <data name="FormatUrl.WhitespaceInputUrlNotAllowedOnWindows">
+    <value>MSB4311: The InputUrl value '{0}' is not a valid path on Windows because it consists only of whitespace characters.</value>
+    <comment>{StrBegin="MSB4311: "}</comment>
+  </data>
+
+  <!--
         MSB9901 - MSB9990   MSBuild common targets messages
   -->
   <data name="CommonSdk.SpecifiedSeverityDoesNotExist">
@@ -3251,6 +3259,7 @@
             MSB3981 - MSB3990   Task: GetCompatiblePlatform
             MSB3991 - MSB3999   Task: CombineTargetFrameworkInfoProperties
             MSB4300 - MSB4310   Task: AddToWin32Manifest
+            MSB4311 - MSB4320   Task: FormatUrl
 
             MSB4000 - MSB4200   Portable targets & tasks (vsproject\flavors\portable\msbuild)
             MSB9000 - MSB9900   MSBuild targets files (C++)

--- a/src/Tasks/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Resources/xlf/Strings.cs.xlf
@@ -564,6 +564,11 @@
         <target state="translated">MSB3541: Parametr {0} má neplatnou hodnotu {1}. {2}</target>
         <note>{StrBegin="MSB3541: "}</note>
       </trans-unit>
+      <trans-unit id="FormatUrl.WhitespaceInputUrlNotAllowedOnWindows">
+        <source>MSB4311: The InputUrl value '{0}' is not a valid path on Windows because it consists only of whitespace characters.</source>
+        <target state="new">MSB4311: The InputUrl value '{0}' is not a valid path on Windows because it consists only of whitespace characters.</target>
+        <note>{StrBegin="MSB4311: "}</note>
+      </trans-unit>
       <trans-unit id="General.CouldNotDeleteStateFile">
         <source>MSB3102: Could not delete state file "{0}". {1}</source>
         <target state="translated">MSB3102: Nelze odstranit soubor stavu {0}. {1}</target>
@@ -1992,7 +1997,8 @@
         <source>Application Configuration file path cannot be empty.</source>
         <target state="new">Application Configuration file path cannot be empty.</target>
         <note>This message can be used as the {1} in MSB3249</note>
-      </trans-unit>      <trans-unit id="ResolveAssemblyReference.InvalidInstalledAssemblyTablesFile">
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.InvalidInstalledAssemblyTablesFile">
         <source>MSB3250: The file "{0}" will be ignored because it cannot be read. This file was either passed in to InstalledAssemblyTables or was found by searching the {1} folder in the TargetFrameworkDirectories. {2}</source>
         <target state="translated">MSB3250: Soubor {0} nelze přečíst a bude ignorován. Tento soubor byl předán parametru InstalledAssemblyTables nebo byl nalezen ve složce {1} určené parametrem TargetFrameworkDirectories. {2}</target>
         <note>{StrBegin="MSB3250: "}</note>

--- a/src/Tasks/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Resources/xlf/Strings.de.xlf
@@ -564,6 +564,11 @@
         <target state="translated">MSB3541: {0} enthält einen ungültigen Wert "{1}". {2}</target>
         <note>{StrBegin="MSB3541: "}</note>
       </trans-unit>
+      <trans-unit id="FormatUrl.WhitespaceInputUrlNotAllowedOnWindows">
+        <source>MSB4311: The InputUrl value '{0}' is not a valid path on Windows because it consists only of whitespace characters.</source>
+        <target state="new">MSB4311: The InputUrl value '{0}' is not a valid path on Windows because it consists only of whitespace characters.</target>
+        <note>{StrBegin="MSB4311: "}</note>
+      </trans-unit>
       <trans-unit id="General.CouldNotDeleteStateFile">
         <source>MSB3102: Could not delete state file "{0}". {1}</source>
         <target state="translated">MSB3102: Die Zustandsdatei "{0}" konnte nicht gelöscht werden. {1}</target>
@@ -1992,7 +1997,8 @@
         <source>Application Configuration file path cannot be empty.</source>
         <target state="new">Application Configuration file path cannot be empty.</target>
         <note>This message can be used as the {1} in MSB3249</note>
-      </trans-unit>      <trans-unit id="ResolveAssemblyReference.InvalidInstalledAssemblyTablesFile">
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.InvalidInstalledAssemblyTablesFile">
         <source>MSB3250: The file "{0}" will be ignored because it cannot be read. This file was either passed in to InstalledAssemblyTables or was found by searching the {1} folder in the TargetFrameworkDirectories. {2}</source>
         <target state="translated">MSB3250: Die Datei "{0}" kann nicht gelesen werden und wird daher ignoriert. Diese Datei wurde an InstalledAssemblyTables übergeben oder beim Durchsuchen des Ordners "{1}" in den TargetFrameworkDirectories gefunden. {2}</target>
         <note>{StrBegin="MSB3250: "}</note>

--- a/src/Tasks/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Resources/xlf/Strings.es.xlf
@@ -564,6 +564,11 @@
         <target state="translated">MSB3541: {0} tiene un valor "{1}" no válido. {2}</target>
         <note>{StrBegin="MSB3541: "}</note>
       </trans-unit>
+      <trans-unit id="FormatUrl.WhitespaceInputUrlNotAllowedOnWindows">
+        <source>MSB4311: The InputUrl value '{0}' is not a valid path on Windows because it consists only of whitespace characters.</source>
+        <target state="new">MSB4311: The InputUrl value '{0}' is not a valid path on Windows because it consists only of whitespace characters.</target>
+        <note>{StrBegin="MSB4311: "}</note>
+      </trans-unit>
       <trans-unit id="General.CouldNotDeleteStateFile">
         <source>MSB3102: Could not delete state file "{0}". {1}</source>
         <target state="translated">MSB3102: No se puede eliminar el archivo de estado "{0}". {1}</target>
@@ -1992,7 +1997,8 @@
         <source>Application Configuration file path cannot be empty.</source>
         <target state="new">Application Configuration file path cannot be empty.</target>
         <note>This message can be used as the {1} in MSB3249</note>
-      </trans-unit>      <trans-unit id="ResolveAssemblyReference.InvalidInstalledAssemblyTablesFile">
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.InvalidInstalledAssemblyTablesFile">
         <source>MSB3250: The file "{0}" will be ignored because it cannot be read. This file was either passed in to InstalledAssemblyTables or was found by searching the {1} folder in the TargetFrameworkDirectories. {2}</source>
         <target state="translated">MSB3250: Se omitirá el archivo "{0}" porque no se puede leer. Bien se pasó a InstalledAssemblyTables o bien se encontró al buscar en la carpeta {1} de TargetFrameworkDirectories. {2}</target>
         <note>{StrBegin="MSB3250: "}</note>

--- a/src/Tasks/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Resources/xlf/Strings.fr.xlf
@@ -564,6 +564,11 @@
         <target state="translated">MSB3541: {0} comporte la valeur non valide "{1}". {2}</target>
         <note>{StrBegin="MSB3541: "}</note>
       </trans-unit>
+      <trans-unit id="FormatUrl.WhitespaceInputUrlNotAllowedOnWindows">
+        <source>MSB4311: The InputUrl value '{0}' is not a valid path on Windows because it consists only of whitespace characters.</source>
+        <target state="new">MSB4311: The InputUrl value '{0}' is not a valid path on Windows because it consists only of whitespace characters.</target>
+        <note>{StrBegin="MSB4311: "}</note>
+      </trans-unit>
       <trans-unit id="General.CouldNotDeleteStateFile">
         <source>MSB3102: Could not delete state file "{0}". {1}</source>
         <target state="translated">MSB3102: Impossible de supprimer le fichier d'état "{0}". {1}</target>
@@ -1992,7 +1997,8 @@
         <source>Application Configuration file path cannot be empty.</source>
         <target state="new">Application Configuration file path cannot be empty.</target>
         <note>This message can be used as the {1} in MSB3249</note>
-      </trans-unit>      <trans-unit id="ResolveAssemblyReference.InvalidInstalledAssemblyTablesFile">
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.InvalidInstalledAssemblyTablesFile">
         <source>MSB3250: The file "{0}" will be ignored because it cannot be read. This file was either passed in to InstalledAssemblyTables or was found by searching the {1} folder in the TargetFrameworkDirectories. {2}</source>
         <target state="translated">MSB3250: Le fichier "{0}" va être ignoré, car il ne peut pas être lu. Ce fichier a été passé dans InstalledAssemblyTables ou a été trouvé lors de la recherche du dossier {1} dans TargetFrameworkDirectories. {2}</target>
         <note>{StrBegin="MSB3250: "}</note>

--- a/src/Tasks/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Resources/xlf/Strings.it.xlf
@@ -564,6 +564,11 @@
         <target state="translated">MSB3541: valore "{1}" di {0} non valido. {2}</target>
         <note>{StrBegin="MSB3541: "}</note>
       </trans-unit>
+      <trans-unit id="FormatUrl.WhitespaceInputUrlNotAllowedOnWindows">
+        <source>MSB4311: The InputUrl value '{0}' is not a valid path on Windows because it consists only of whitespace characters.</source>
+        <target state="new">MSB4311: The InputUrl value '{0}' is not a valid path on Windows because it consists only of whitespace characters.</target>
+        <note>{StrBegin="MSB4311: "}</note>
+      </trans-unit>
       <trans-unit id="General.CouldNotDeleteStateFile">
         <source>MSB3102: Could not delete state file "{0}". {1}</source>
         <target state="translated">MSB3102: non è stato possibile eliminare il file di stato "{0}". {1}</target>
@@ -1992,7 +1997,8 @@
         <source>Application Configuration file path cannot be empty.</source>
         <target state="new">Application Configuration file path cannot be empty.</target>
         <note>This message can be used as the {1} in MSB3249</note>
-      </trans-unit>      <trans-unit id="ResolveAssemblyReference.InvalidInstalledAssemblyTablesFile">
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.InvalidInstalledAssemblyTablesFile">
         <source>MSB3250: The file "{0}" will be ignored because it cannot be read. This file was either passed in to InstalledAssemblyTables or was found by searching the {1} folder in the TargetFrameworkDirectories. {2}</source>
         <target state="translated">MSB3250: il file "{0}" verrà ignorato perché non può essere letto. Il file è stato passato a InstalledAssemblyTables o è stato trovato cercando nella cartella {1} in TargetFrameworkDirectories. {2}</target>
         <note>{StrBegin="MSB3250: "}</note>

--- a/src/Tasks/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ja.xlf
@@ -564,6 +564,11 @@
         <target state="translated">MSB3541: {0} は無効な値 "{1}" を含んでいます。{2}</target>
         <note>{StrBegin="MSB3541: "}</note>
       </trans-unit>
+      <trans-unit id="FormatUrl.WhitespaceInputUrlNotAllowedOnWindows">
+        <source>MSB4311: The InputUrl value '{0}' is not a valid path on Windows because it consists only of whitespace characters.</source>
+        <target state="new">MSB4311: The InputUrl value '{0}' is not a valid path on Windows because it consists only of whitespace characters.</target>
+        <note>{StrBegin="MSB4311: "}</note>
+      </trans-unit>
       <trans-unit id="General.CouldNotDeleteStateFile">
         <source>MSB3102: Could not delete state file "{0}". {1}</source>
         <target state="translated">MSB3102: 状態ファイル "{0}" を削除できませんでした。{1}</target>
@@ -1992,7 +1997,8 @@
         <source>Application Configuration file path cannot be empty.</source>
         <target state="new">Application Configuration file path cannot be empty.</target>
         <note>This message can be used as the {1} in MSB3249</note>
-      </trans-unit>      <trans-unit id="ResolveAssemblyReference.InvalidInstalledAssemblyTablesFile">
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.InvalidInstalledAssemblyTablesFile">
         <source>MSB3250: The file "{0}" will be ignored because it cannot be read. This file was either passed in to InstalledAssemblyTables or was found by searching the {1} folder in the TargetFrameworkDirectories. {2}</source>
         <target state="translated">MSB3250: ファイル "{0}" は、読み取れないため無視されます。このファイルは、InstalledAssemblyTables に渡されたか、TargetFrameworkDirectories の {1} フォルダーの検索によって見つかりました。{2}</target>
         <note>{StrBegin="MSB3250: "}</note>

--- a/src/Tasks/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ko.xlf
@@ -564,6 +564,11 @@
         <target state="translated">MSB3541: {0}의 "{1}" 값이 잘못되었습니다. {2}</target>
         <note>{StrBegin="MSB3541: "}</note>
       </trans-unit>
+      <trans-unit id="FormatUrl.WhitespaceInputUrlNotAllowedOnWindows">
+        <source>MSB4311: The InputUrl value '{0}' is not a valid path on Windows because it consists only of whitespace characters.</source>
+        <target state="new">MSB4311: The InputUrl value '{0}' is not a valid path on Windows because it consists only of whitespace characters.</target>
+        <note>{StrBegin="MSB4311: "}</note>
+      </trans-unit>
       <trans-unit id="General.CouldNotDeleteStateFile">
         <source>MSB3102: Could not delete state file "{0}". {1}</source>
         <target state="translated">MSB3102: "{0}" 상태 파일을 삭제할 수 없습니다. {1}</target>
@@ -1992,7 +1997,8 @@
         <source>Application Configuration file path cannot be empty.</source>
         <target state="new">Application Configuration file path cannot be empty.</target>
         <note>This message can be used as the {1} in MSB3249</note>
-      </trans-unit>      <trans-unit id="ResolveAssemblyReference.InvalidInstalledAssemblyTablesFile">
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.InvalidInstalledAssemblyTablesFile">
         <source>MSB3250: The file "{0}" will be ignored because it cannot be read. This file was either passed in to InstalledAssemblyTables or was found by searching the {1} folder in the TargetFrameworkDirectories. {2}</source>
         <target state="translated">MSB3250: "{0}" 파일은 읽어올 수 없으므로 무시됩니다. 이 파일을 InstalledAssemblyTables에 전달했거나 TargetFrameworkDirectories에서 {1} 폴더를 검색하여 찾았습니다. {2}</target>
         <note>{StrBegin="MSB3250: "}</note>

--- a/src/Tasks/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Resources/xlf/Strings.pl.xlf
@@ -564,6 +564,11 @@
         <target state="translated">MSB3541: {0} zawiera nieprawidłową wartość „{1}”. {2}</target>
         <note>{StrBegin="MSB3541: "}</note>
       </trans-unit>
+      <trans-unit id="FormatUrl.WhitespaceInputUrlNotAllowedOnWindows">
+        <source>MSB4311: The InputUrl value '{0}' is not a valid path on Windows because it consists only of whitespace characters.</source>
+        <target state="new">MSB4311: The InputUrl value '{0}' is not a valid path on Windows because it consists only of whitespace characters.</target>
+        <note>{StrBegin="MSB4311: "}</note>
+      </trans-unit>
       <trans-unit id="General.CouldNotDeleteStateFile">
         <source>MSB3102: Could not delete state file "{0}". {1}</source>
         <target state="translated">MSB3102: Nie można usunąć pliku stanu „{0}”. {1}</target>
@@ -1992,7 +1997,8 @@
         <source>Application Configuration file path cannot be empty.</source>
         <target state="new">Application Configuration file path cannot be empty.</target>
         <note>This message can be used as the {1} in MSB3249</note>
-      </trans-unit>      <trans-unit id="ResolveAssemblyReference.InvalidInstalledAssemblyTablesFile">
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.InvalidInstalledAssemblyTablesFile">
         <source>MSB3250: The file "{0}" will be ignored because it cannot be read. This file was either passed in to InstalledAssemblyTables or was found by searching the {1} folder in the TargetFrameworkDirectories. {2}</source>
         <target state="translated">MSB3250: Plik „{0}” zostanie zignorowany, ponieważ nie można go odczytać. Plik ten został przekazany do parametru InstalledAssemblyTables lub znaleziony podczas przeszukiwania folderu {1} określonego w parametrze TargetFrameworkDirectories. {2}</target>
         <note>{StrBegin="MSB3250: "}</note>

--- a/src/Tasks/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Resources/xlf/Strings.pt-BR.xlf
@@ -564,6 +564,11 @@
         <target state="translated">MSB3541: {0} contém o valor inválido "{1}". {2}</target>
         <note>{StrBegin="MSB3541: "}</note>
       </trans-unit>
+      <trans-unit id="FormatUrl.WhitespaceInputUrlNotAllowedOnWindows">
+        <source>MSB4311: The InputUrl value '{0}' is not a valid path on Windows because it consists only of whitespace characters.</source>
+        <target state="new">MSB4311: The InputUrl value '{0}' is not a valid path on Windows because it consists only of whitespace characters.</target>
+        <note>{StrBegin="MSB4311: "}</note>
+      </trans-unit>
       <trans-unit id="General.CouldNotDeleteStateFile">
         <source>MSB3102: Could not delete state file "{0}". {1}</source>
         <target state="translated">MSB3102: Não foi possível excluir o arquivo de estado "{0}". {1}</target>
@@ -1992,7 +1997,8 @@
         <source>Application Configuration file path cannot be empty.</source>
         <target state="new">Application Configuration file path cannot be empty.</target>
         <note>This message can be used as the {1} in MSB3249</note>
-      </trans-unit>      <trans-unit id="ResolveAssemblyReference.InvalidInstalledAssemblyTablesFile">
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.InvalidInstalledAssemblyTablesFile">
         <source>MSB3250: The file "{0}" will be ignored because it cannot be read. This file was either passed in to InstalledAssemblyTables or was found by searching the {1} folder in the TargetFrameworkDirectories. {2}</source>
         <target state="translated">MSB3250: O arquivo "{0}" será ignorado, pois não pode ser lido. Esse arquivo foi passado para o InstalledAssemblyTables ou foi encontrado com a pesquisa da pasta {1} nos TargetFrameworkDirectories. {2}</target>
         <note>{StrBegin="MSB3250: "}</note>

--- a/src/Tasks/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ru.xlf
@@ -564,6 +564,11 @@
         <target state="translated">MSB3541: {0} содержит недопустимое значение "{1}". {2}</target>
         <note>{StrBegin="MSB3541: "}</note>
       </trans-unit>
+      <trans-unit id="FormatUrl.WhitespaceInputUrlNotAllowedOnWindows">
+        <source>MSB4311: The InputUrl value '{0}' is not a valid path on Windows because it consists only of whitespace characters.</source>
+        <target state="new">MSB4311: The InputUrl value '{0}' is not a valid path on Windows because it consists only of whitespace characters.</target>
+        <note>{StrBegin="MSB4311: "}</note>
+      </trans-unit>
       <trans-unit id="General.CouldNotDeleteStateFile">
         <source>MSB3102: Could not delete state file "{0}". {1}</source>
         <target state="translated">MSB3102: не удалось удалить файл состояния "{0}". {1}</target>
@@ -1992,7 +1997,8 @@
         <source>Application Configuration file path cannot be empty.</source>
         <target state="new">Application Configuration file path cannot be empty.</target>
         <note>This message can be used as the {1} in MSB3249</note>
-      </trans-unit>      <trans-unit id="ResolveAssemblyReference.InvalidInstalledAssemblyTablesFile">
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.InvalidInstalledAssemblyTablesFile">
         <source>MSB3250: The file "{0}" will be ignored because it cannot be read. This file was either passed in to InstalledAssemblyTables or was found by searching the {1} folder in the TargetFrameworkDirectories. {2}</source>
         <target state="translated">MSB3250: файл "{0}" будет пропущен, так как его невозможно прочитать. Этот файл был передан в InstalledAssemblyTables или обнаружен при поиске в папке "{1}" в TargetFrameworkDirectories. {2}</target>
         <note>{StrBegin="MSB3250: "}</note>

--- a/src/Tasks/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Resources/xlf/Strings.tr.xlf
@@ -564,6 +564,11 @@
         <target state="translated">MSB3541: {0} öğesinin "{1}" değeri geçersiz. {2}</target>
         <note>{StrBegin="MSB3541: "}</note>
       </trans-unit>
+      <trans-unit id="FormatUrl.WhitespaceInputUrlNotAllowedOnWindows">
+        <source>MSB4311: The InputUrl value '{0}' is not a valid path on Windows because it consists only of whitespace characters.</source>
+        <target state="new">MSB4311: The InputUrl value '{0}' is not a valid path on Windows because it consists only of whitespace characters.</target>
+        <note>{StrBegin="MSB4311: "}</note>
+      </trans-unit>
       <trans-unit id="General.CouldNotDeleteStateFile">
         <source>MSB3102: Could not delete state file "{0}". {1}</source>
         <target state="translated">MSB3102: "{0}" durum dosyası silinemedi. {1}</target>
@@ -1992,7 +1997,8 @@
         <source>Application Configuration file path cannot be empty.</source>
         <target state="new">Application Configuration file path cannot be empty.</target>
         <note>This message can be used as the {1} in MSB3249</note>
-      </trans-unit>      <trans-unit id="ResolveAssemblyReference.InvalidInstalledAssemblyTablesFile">
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.InvalidInstalledAssemblyTablesFile">
         <source>MSB3250: The file "{0}" will be ignored because it cannot be read. This file was either passed in to InstalledAssemblyTables or was found by searching the {1} folder in the TargetFrameworkDirectories. {2}</source>
         <target state="translated">MSB3250: "{0}" dosyası okunamadığı için yoksayılacak. Bu dosya InstalledAssemblyTables’a geçirildi ya da TargetFrameworkDirectories içinde {1} klasörü aranarak bulundu. {2}</target>
         <note>{StrBegin="MSB3250: "}</note>

--- a/src/Tasks/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Resources/xlf/Strings.zh-Hans.xlf
@@ -564,6 +564,11 @@
         <target state="translated">MSB3541: {0} 的值“{1}”无效。{2}</target>
         <note>{StrBegin="MSB3541: "}</note>
       </trans-unit>
+      <trans-unit id="FormatUrl.WhitespaceInputUrlNotAllowedOnWindows">
+        <source>MSB4311: The InputUrl value '{0}' is not a valid path on Windows because it consists only of whitespace characters.</source>
+        <target state="new">MSB4311: The InputUrl value '{0}' is not a valid path on Windows because it consists only of whitespace characters.</target>
+        <note>{StrBegin="MSB4311: "}</note>
+      </trans-unit>
       <trans-unit id="General.CouldNotDeleteStateFile">
         <source>MSB3102: Could not delete state file "{0}". {1}</source>
         <target state="translated">MSB3102: 未能删除状态文件“{0}”。{1}</target>
@@ -1992,7 +1997,8 @@
         <source>Application Configuration file path cannot be empty.</source>
         <target state="new">Application Configuration file path cannot be empty.</target>
         <note>This message can be used as the {1} in MSB3249</note>
-      </trans-unit>      <trans-unit id="ResolveAssemblyReference.InvalidInstalledAssemblyTablesFile">
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.InvalidInstalledAssemblyTablesFile">
         <source>MSB3250: The file "{0}" will be ignored because it cannot be read. This file was either passed in to InstalledAssemblyTables or was found by searching the {1} folder in the TargetFrameworkDirectories. {2}</source>
         <target state="translated">MSB3250: 将忽略文件“{0}”，因为无法读取该文件。此文件是传入到 InstalledAssemblyTables 的，或者是通过在 TargetFrameworkDirectories 中搜索 {1} 文件夹找到的。{2}</target>
         <note>{StrBegin="MSB3250: "}</note>

--- a/src/Tasks/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Resources/xlf/Strings.zh-Hant.xlf
@@ -564,6 +564,11 @@
         <target state="translated">MSB3541: {0} 有無效的值 "{1}"。{2}</target>
         <note>{StrBegin="MSB3541: "}</note>
       </trans-unit>
+      <trans-unit id="FormatUrl.WhitespaceInputUrlNotAllowedOnWindows">
+        <source>MSB4311: The InputUrl value '{0}' is not a valid path on Windows because it consists only of whitespace characters.</source>
+        <target state="new">MSB4311: The InputUrl value '{0}' is not a valid path on Windows because it consists only of whitespace characters.</target>
+        <note>{StrBegin="MSB4311: "}</note>
+      </trans-unit>
       <trans-unit id="General.CouldNotDeleteStateFile">
         <source>MSB3102: Could not delete state file "{0}". {1}</source>
         <target state="translated">MSB3102: 無法刪除狀態檔案 "{0}"。{1}</target>
@@ -1992,7 +1997,8 @@
         <source>Application Configuration file path cannot be empty.</source>
         <target state="new">Application Configuration file path cannot be empty.</target>
         <note>This message can be used as the {1} in MSB3249</note>
-      </trans-unit>      <trans-unit id="ResolveAssemblyReference.InvalidInstalledAssemblyTablesFile">
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.InvalidInstalledAssemblyTablesFile">
         <source>MSB3250: The file "{0}" will be ignored because it cannot be read. This file was either passed in to InstalledAssemblyTables or was found by searching the {1} folder in the TargetFrameworkDirectories. {2}</source>
         <target state="translated">MSB3250: 將忽略檔案 "{0}"，因為無法讀取。這個檔案可能傳入 InstalledAssemblyTables，或是在 TargetFrameworkDirectories 中搜尋 {1} 資料夾找到。{2}</target>
         <note>{StrBegin="MSB3250: "}</note>


### PR DESCRIPTION
Migrates the `FormatUrl` task to MSBuild's multithreaded execution model using the "absolutize-at-boundary" pattern previously established by other task migrations (see #13267).

Supersedes #13573. The previous PR added the Windows-only whitespace guard inside `AbsolutePath` and shipped new localized resource strings; this PR moves the guard into the `FormatUrl` task itself — in place of the `Path.GetFullPath` call that used to perform the throw inside `PathUtil.Resolve`. As a result, neither `AbsolutePath` nor any `.resx`/`.xlf` files are touched.

Fixes #13567.

## Non-obvious decision: FormatUrl-local Windows whitespace guard

Pre-migration, `PathUtil.Resolve` called `Path.GetFullPath(InputUrl)`, which on Windows throws `ArgumentException` for whitespace-only inputs. After moving to the absolutize-at-boundary pattern, `Path.Combine(projectDir, " ")` yields a path like `"projectDir\ "` whose trailing whitespace is silently trimmed by `Path.GetFullPath` inside `AbsolutePath`, masking the historical error.

To preserve a 1:1 replication of the original Windows-only behavior, `FormatUrl.Execute` itself now calls `Path.GetFullPath(InputUrl)` on whitespace-only input on Windows, so the same `ArgumentException` (type and message) the legacy code raised is preserved without inventing a new error string. Whitespace remains valid on Unix, where it is a legal filename character — matching the original cross-platform behavior. Empty `InputUrl` continues to short-circuit before reaching `Path.GetFullPath`, so the existing `EmptyTest` semantics are preserved across .NET Framework and .NET Core / .NET 10.

## Files changed (3)

- `src/Tasks/FormatUrl.cs` — `[MSBuildMultiThreadableTask]`, `IMultiThreadableTask`, `TaskEnvironment` property, Windows-only whitespace guard.
- `src/Tasks/ManifestUtil/PathUtil.cs` — `Format`/`Resolve` take an `AbsolutePath baseDirectory` and use `new AbsolutePath(path, baseDirectory).GetCanonicalForm()` instead of `Path.GetFullPath`. Only `FormatUrl` calls these helpers.
- `src/Tasks.UnitTests/FormatUrl_Tests.cs` — Existing tests reworked onto a shared `GetFormatUrlUnderTest` helper; two new tests: `RelativePathResolvesAgainstProjectDirectory` (documents the intentional cwd → project-directory semantic change) and `WhitespaceInputThrowsOnWindowsWithIsolatedProjectDirectory` (specifically exercises the new guard against a real isolated `TaskEnvironment`, which the existing `WhitespaceTestOnWindows` cannot do because it runs on the Fallback environment).

## Validation

- `dotnet build src\Tasks\Microsoft.Build.Tasks.csproj` — 0 warnings, 0 errors on `net472` and `net10.0`.
- `dotnet test src\Tasks.UnitTests\Microsoft.Build.Tasks.UnitTests.csproj -- --filter-method "*FormatUrl*"` — 26 passed, 4 skipped (Unix-only), 0 failed on both target frameworks.
