### PR TITLE
Add elapsed-time telemetry to RunProcessAndGetOutput test helper

### DIFF
--- a/src/UnitTests.Shared/RunnerUtilities.cs
+++ b/src/UnitTests.Shared/RunnerUtilities.cs
@@ -172,6 +172,7 @@ namespace Microsoft.Build.UnitTests.Shared
                 p.StandardInput.Dispose();
 
                 TimeSpan timeout = TimeSpan.FromMilliseconds(timeoutMilliseconds);
+                Stopwatch sw = Stopwatch.StartNew();
                 if (Traits.Instance.DebugUnitTests)
                 {
                     p.WaitForExit();
@@ -184,13 +185,31 @@ namespace Microsoft.Build.UnitTests.Shared
                     throw new TimeoutException($"Test failed due to timeout: process {p.Id} is active for more than {timeout.TotalSeconds} sec.");
                 }
 
+                // Capture elapsed at process exit, before the post-exit drain below, so the
+                // telemetry below reports the budget-relevant time only (the drain is bookkeeping).
+                long exitElapsedMs = sw.ElapsedMilliseconds;
+
                 // We need the WaitForExit call without parameters because our processing of output/error streams is not synchronous.
                 // See https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.process.waitforexit?view=net-6.0#system-diagnostics-process-waitforexit(system-int32).
                 // The overload WaitForExit() waits for the error and output to be handled. The WaitForExit(int timeout) overload does not, so we could lose the data.
                 p.WaitForExit();
+                sw.Stop();
 
                 pid = p.Id;
                 successfulExit = p.ExitCode == 0;
+
+                // Telemetry: log actual elapsed time so callers tuning their timeouts can see
+                // how close to the budget we ran. In DebugUnitTests mode the budget is not
+                // enforced (WaitForExit without timeout above), so the budget/headroom fields
+                // would be misleading and are omitted.
+                if (Traits.Instance.DebugUnitTests)
+                {
+                    WriteOutput($"Process {pid} exited in {exitElapsedMs}ms (DebugUnitTests: budget not enforced)");
+                }
+                else
+                {
+                    WriteOutput($"Process {pid} exited in {exitElapsedMs}ms (budget {timeoutMilliseconds}ms, headroom {timeoutMilliseconds - exitElapsedMs}ms)");
+                }
             }
 
             if (attachProcessId)

--- a/src/UnitTests.Shared/RunnerUtilities.cs
+++ b/src/UnitTests.Shared/RunnerUtilities.cs
@@ -208,7 +208,7 @@ namespace Microsoft.Build.UnitTests.Shared
                 }
                 else
                 {
-                    WriteOutput($"Process {pid} exited in {exitElapsedMs}ms (budget {timeoutMilliseconds}ms, headroom {timeoutMilliseconds - exitElapsedMs}ms)");
+                    WriteOutput($"Process {pid} exited in {exitElapsedMs}ms (budget {timeoutMilliseconds}ms, {timeoutMilliseconds - exitElapsedMs}ms remaining)");
                 }
             }
 


### PR DESCRIPTION
Re-opening of #13829 to get a fresh `license/cla` check.

#13829 has been blocked for hours with `mergeStateStatus=BLOCKED` even though every `msbuild-pr` leg is green and the PR is approved (@AlesProkop). Root cause: the required `license/cla` check is missing on the head commit `c0801793` — the Microsoft policy service reported on earlier commits in the PR but never on the merge commit. Same code, identical SHA pushed to a new branch to mint a fresh CLA check.

Below is the original description from #13829:

---

`RunProcessAndGetOutput` is the helper that almost every cross-process MSBuild test uses (`net472`/`netcore` task host launches, multi-proc node smoke tests, etc.). It already enforces a per-call timeout, but on failure we only see "process X is active for more than N sec" — no signal at all on the *happy path* about how close we ran to the budget.

This is exactly the kind of data we need to retune the three flaky `ToolTask` tests stabilized in the sibling PRs (#13828, #13830) — they pick their timeouts and slow-vs-fast gaps blind right now.

### Changes

- Capture `sw.ElapsedMilliseconds` immediately after `WaitForExit()` returns, *before* the post-exit drain loop, so the telemetry reports budget-relevant time only.
- Log one line per process exit:
  - Normal mode: `Process {pid} exited in {N}ms (budget {T}ms, {T-N}ms remaining)`
  - `DebugUnitTests` mode (no enforced timeout): `Process {pid} exited in {N}ms (DebugUnitTests: budget not enforced)`
- No behavioral change. Test-only file.

### Risk

Test-helper-only changes. Single file: `src/UnitTests.Shared/RunnerUtilities.cs`. No product code touched.

Closes #13829.
