### PR TITLE
Corrected grammar mistake in german translation

### DIFF
--- a/src/Build/Resources/xlf/Strings.de.xlf
+++ b/src/Build/Resources/xlf/Strings.de.xlf
@@ -283,7 +283,7 @@
       </trans-unit>
       <trans-unit id="BuildFinished">
         <source>Build {0} in {1}s</source>
-        <target state="translated">Erstellen von {0} in {1}s</target>
+        <target state="translated">Erstellen {0} in {1}s</target>
         <note>
       Overall build summary
       {0}: BuildResult_X (below)
@@ -886,7 +886,7 @@
       </trans-unit>
       <trans-unit id="RestoreCompleteWithMessage">
         <source>Restore {0} in {1}s</source>
-        <target state="translated">Wiederherstellen von {0} in {1}s</target>
+        <target state="translated">Wiederherstellen {0} in {1}s</target>
         <note>
       Restore summary when finished with warning or error
       {0}: BuildResult_X (below)


### PR DESCRIPTION
Fixes #13841

### Context

The final conclusion part of the Console output messages for `build` and `restore` command does not make sense grammatically in the German language.
The build message would be evaluated to "Erstellen von Erfolgreich in 1,0s". When translated back to English it would roughly equate to "Build of successful in 1.0s".

### Changes Made

Corrected the message to be evaluated to "Erstellen Erfolgreich in 1,0s", which is better in line with the english translation "Build successful in 1.0s".  
Same applies to the message for restore. Corrected to "Wiederherstellen Erfolgreich in 1,0s".

### Testing


### Notes
