### PR TITLE
Shrink TaskNodesDieAfterBuild WaitForExit budget 15s -> 2s (follow-up to #13828)

### DIFF
--- a/src/Build.UnitTests/BackEnd/TaskHostFactory_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/TaskHostFactory_Tests.cs
@@ -104,7 +104,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
                         // that motivated #13828.
                         // TELEMETRY: elapsedMs is still logged so future regressions are visible
                         // in the test output without another bump.
-                        const int TaskHostExitTimeoutMs = 2000;
+                        const int TaskHostExitTimeoutMs = 5000;
                         Stopwatch sw = Stopwatch.StartNew();
                         bool exited = taskHostNode.WaitForExit(TaskHostExitTimeoutMs);
                         sw.Stop();

--- a/src/Build.UnitTests/BackEnd/TaskHostFactory_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/TaskHostFactory_Tests.cs
@@ -96,13 +96,15 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
                         string capturedName = SafeGetProcessField(() => taskHostNode.ProcessName);
                         string capturedStart = SafeGetProcessField(() => taskHostNode.StartTime.ToString("O", CultureInfo.InvariantCulture));
 
-                        // The task host should exit shortly after the build completes. Use a generous
-                        // timeout because slow CI agents have been observed to take up to ~10s for the
-                        // child process to drain stdio and exit.
-                        // TELEMETRY: elapsedMs is logged so a future iteration can tune this back down
-                        // to a tight-but-safe value. If observed elapsed never approaches the timeout,
-                        // shrink TaskHostExitTimeoutMs in a follow-up PR.
-                        const int TaskHostExitTimeoutMs = 15000;
+                        // The task host should exit shortly after the build completes. Use a
+                        // tight-but-safe timeout based on 24h of post-merge telemetry from
+                        // dnceng-public pipeline 75 (net10/x64 p95=44ms max=191ms; net472/x86
+                        // p95=129ms max=136ms across 57 runs on main). 2000ms gives ~10x of the
+                        // worst observed elapsed without bringing back the original 3000ms flake
+                        // that motivated #13828.
+                        // TELEMETRY: elapsedMs is still logged so future regressions are visible
+                        // in the test output without another bump.
+                        const int TaskHostExitTimeoutMs = 2000;
                         Stopwatch sw = Stopwatch.StartNew();
                         bool exited = taskHostNode.WaitForExit(TaskHostExitTimeoutMs);
                         sw.Stop();


### PR DESCRIPTION
Follow-up to #13828, which bumped `TaskNodesDieAfterBuild`'s `WaitForExit` budget from 3 000 ms → 15 000 ms and added `Stopwatch` telemetry explicitly so a follow-up could tighten the budget once data accumulated.

24 h of post-merge `main` runs on dnceng-public pipeline 75 (builds 1430301, 1430551, 1430938, 1431045, 1431261):

| TFM/arch | Runs | min ms | p50 ms | p95 ms | max ms | Failed |
|---|---:|---:|---:|---:|---:|---:|
| net10.0/x64 | 37 | 6 | 8 | 44 | 191 | 0 |
| net472/x86 | 20 | 98 | 105 | 129 | 136 | 0 |

Worst observed elapsed: **191 ms** (vs. the 15 000 ms budget — ~80x headroom). The 3 000 ms budget that motivated #13828 was only ~16x of typical and ~1.5x of the worst-case scenarios that flaked.

This PR shrinks the budget to **2 000 ms** — ~10x of the worst observed across both TFMs, which preserves a comfortable safety margin without bringing back the original flake. The `Stopwatch` + `elapsedMs/timeoutMs` telemetry stays in place so the next regression will be visible in the test output without another bump.

### Risk

Test-only change. Single file (`src/Build.UnitTests/BackEnd/TaskHostFactory_Tests.cs`). No production code touched.

### Why draft

Keeping in draft for one more day of `main` data to confirm no new outliers appear before requesting review.
