### PR TITLE
Add vs18.8 to merge-flow config

### DIFF
--- a/.config/git-merge-flow-config.jsonc
+++ b/.config/git-merge-flow-config.jsonc
@@ -38,7 +38,7 @@
         "vs18.7": {
             "MergeToBranch": "vs18.8"
         },
-        // Automate opening PRs to merge msbuild's vs18.8 (VS, SDK 10.0.5xx) into main (VS canary, SDK main & next-feature-band)
+        // Automate opening PRs to merge msbuild's vs18.8 (VS) into main (VS canary, SDK main & next-feature-band)
         "vs18.8": {
             "MergeToBranch": "main"
         }

--- a/.config/git-merge-flow-config.jsonc
+++ b/.config/git-merge-flow-config.jsonc
@@ -34,8 +34,12 @@
         "vs18.6": {
             "MergeToBranch": "vs18.7"
         },
-        // Automate opening PRs to merge msbuild's vs18.7 (VS, SDK 10.0.4xx) into main (VS canary, SDK main & next-feature-band)
+        // Automate opening PRs to merge msbuild's vs18.7 (VS, SDK 10.0.4xx) into vs18.8 (VS, SDK 10.0.5xx)
         "vs18.7": {
+            "MergeToBranch": "vs18.8"
+        },
+        // Automate opening PRs to merge msbuild's vs18.8 (VS, SDK 10.0.5xx) into main (VS canary, SDK main & next-feature-band)
+        "vs18.8": {
             "MergeToBranch": "main"
         }
     }

--- a/.config/git-merge-flow-config.jsonc
+++ b/.config/git-merge-flow-config.jsonc
@@ -34,7 +34,7 @@
         "vs18.6": {
             "MergeToBranch": "vs18.7"
         },
-        // Automate opening PRs to merge msbuild's vs18.7 (VS, SDK 10.0.4xx) into vs18.8 (VS, SDK 10.0.5xx)
+        // Automate opening PRs to merge msbuild's vs18.7 (VS) into vs18.8 (VS)
         "vs18.7": {
             "MergeToBranch": "vs18.8"
         },


### PR DESCRIPTION
Adds `vs18.8` to the merge-flow chain so that commits flow `vs18.7 → vs18.8 → main` once the `vs18.8` release branch is created.

This is part of the 18.8 release, [Phase 1.3 of the release checklist](https://github.com/dotnet/msbuild/blob/main/documentation/release-checklist.md#phase-1-branch--prepare).

### Change

- Repoint `vs18.7.MergeToBranch` from `main` to `vs18.8`
- Add new entry `vs18.8.MergeToBranch: main`
- Updated the surrounding comments to note VS/SDK 10.0.5xx context for vs18.8 (following the pattern: vs18.6 → 10.0.3xx, vs18.7 → 10.0.4xx)

The `vs18.8` branch itself is created as part of Phase 1.1 of the release.
