### PR TITLE
Bump main to 18.9.0 after vs18.8 snap

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -3,9 +3,9 @@
   <Import Project="Version.Details.props" />
 
   <PropertyGroup>
-    <VersionPrefix>18.8.0</VersionPrefix>
+    <VersionPrefix>18.9.0</VersionPrefix>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
-    <PackageValidationBaselineVersion>18.7.0-preview-26230-02</PackageValidationBaselineVersion>
+    <PackageValidationBaselineVersion>18.8.0-preview-26276-02</PackageValidationBaselineVersion>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>
 
     <!-- differentiate experimental insertions to avoid package id conflicts, 


### PR DESCRIPTION
Phase 2 of the 18.8 release checklist: bump `main` to 18.9 now that `vs18.8` has been snapped. 
### Changes
- `VersionPrefix`: `18.8.0` → `18.9.0`
- `PackageValidationBaselineVersion`: `18.7.0-preview-26230-02` → `18.8.0-preview-26276-02`
  - This is the latest `18.8.0-preview-*` MSBuild build produced from the `vs18.8` branch-point commit (`b210215ff8`, official build `20260526.2`) and present on the public dotnet-tools feed — i.e. the ApiCompat baseline cannot drift forward into 18.9-content builds wearing 18.8 branding.


