### PR TITLE
Avoid checkout in insertion pipeline

### DIFF
--- a/azure-pipelines/vs-insertion.yml
+++ b/azure-pipelines/vs-insertion.yml
@@ -98,6 +98,7 @@ extends:
         condition: succeeded()
         timeoutInMinutes: 0
         steps:
+        - checkout: none # artifacts + inline scripts only
           # Check that InsertTargetBranch is valid before running anything else.
         - task: PowerShell@2
           name: CheckInsertTargetBranch
@@ -166,6 +167,7 @@ extends:
               **
               !**/Microsoft.SourceBuild.Intermediate*.nupkg
         steps:
+        - checkout: none # artifacts + inline scripts only
         - task: Powershell@2
           name: PwshMungeExternalAPIsPkgVersion
           displayName: Munge ExternalAPIs package version and set props


### PR DESCRIPTION
This should save something like 30s/insertion, which isn't important, and just generally avoid unnecessary work.
