### PR TITLE
Report actual launch path in MSB4216 for Runtime="NET" task host

### DIFF
--- a/src/Build.UnitTests/BackEnd/AppHostSupport_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/AppHostSupport_Tests.cs
@@ -279,5 +279,34 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
             }
         }
 #endif
+
+        [Fact]
+        public void ResolveNetTaskHostLaunchPath_ReturnsAppHost_WhenAppHostFileExists()
+        {
+            using TestEnvironment env = TestEnvironment.Create(_output);
+            string sdkPath = env.CreateFolder().Path;
+            string appHostPath = Path.Combine(sdkPath, Constants.MSBuildExecutableName);
+            File.WriteAllText(appHostPath, string.Empty);
+            File.WriteAllText(Path.Combine(sdkPath, Constants.MSBuildAssemblyName), string.Empty);
+
+            (string launchPath, bool useAppHost) = NodeProviderOutOfProcTaskHost.ResolveNetTaskHostLaunchPath(sdkPath);
+
+            useAppHost.ShouldBeTrue();
+            launchPath.ShouldBe(appHostPath);
+        }
+
+        [Fact]
+        public void ResolveNetTaskHostLaunchPath_FallsBackToMSBuildDll_WhenAppHostMissing()
+        {
+            using TestEnvironment env = TestEnvironment.Create(_output);
+            string sdkPath = env.CreateFolder().Path;
+            string msbuildDllPath = Path.Combine(sdkPath, Constants.MSBuildAssemblyName);
+            File.WriteAllText(msbuildDllPath, string.Empty);
+
+            (string launchPath, bool useAppHost) = NodeProviderOutOfProcTaskHost.ResolveNetTaskHostLaunchPath(sdkPath);
+
+            useAppHost.ShouldBeFalse();
+            launchPath.ShouldBe(msbuildDllPath);
+        }
     }
 }

--- a/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcTaskHost.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcTaskHost.cs
@@ -847,8 +847,8 @@ namespace Microsoft.Build.BackEnd
 
         /// <summary>
         /// Resolves the .NET task host launch target for an SDK directory: the MSBuild app host
-        /// (<c>MSBuild.exe</c>) when present, otherwise <c>MSBuild.dll</c> (which is launched via
-        /// <c>dotnet.exe</c>). Single source of truth for the apphost-vs-fallback decision,
+        /// (<c>MSBuild[.exe]</c>) when present, otherwise <c>MSBuild.dll</c> (which is launched via
+        /// <c>dotnet[.exe]</c>). Single source of truth for the apphost-vs-fallback decision,
         /// shared by the launch path and any caller that needs to describe the launch target
         /// (e.g. error messages).
         /// </summary>

--- a/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcTaskHost.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcTaskHost.cs
@@ -791,8 +791,8 @@ namespace Microsoft.Build.BackEnd
             HandshakeOptions hostContext,
             bool nodeReuseEnabled)
         {
-            string appHostPath = Path.Combine(msbuildAssemblyPath, Constants.MSBuildExecutableName);
             string commandLineArgs = BuildCommandLineArgs(nodeReuseEnabled);
+            (string launchPath, bool useAppHost) = ResolveNetTaskHostLaunchPath(msbuildAssemblyPath);
 
             // The child task host (NodeEndpointOutOfProcTaskHost) computes its handshake
             // toolsDirectory from BuildEnvironmentHelper.Instance.MSBuildToolsDirectoryRoot,
@@ -813,16 +813,16 @@ namespace Microsoft.Build.BackEnd
             Handshake handshake = new Handshake(hostContext, toolsDirectory: msbuildAssemblyPath);
 #endif
 
-            if (FileSystems.Default.FileExists(appHostPath))
+            if (useAppHost)
             {
-                CommunicationsUtilities.Trace($"For a host context of {hostContext}, using app host from {appHostPath}.");
+                CommunicationsUtilities.Trace($"For a host context of {hostContext}, using app host from {launchPath}.");
 
                 IDictionary<string, string> dotnetOverrides = DotnetHostEnvironmentHelper.CreateDotnetRootEnvironmentOverrides(dotnetHostPath);
 
                 return dotnetOverrides == null
                     ? throw new NodeFailedToLaunchException(errorCode: null, ResourceUtilities.GetResourceString("DotnetHostPathNotSet"))
                     : new NodeLaunchData(
-                        appHostPath,
+                        launchPath,
                         commandLineArgs,
                         handshake,
                         dotnetOverrides);
@@ -837,12 +837,27 @@ namespace Microsoft.Build.BackEnd
             }
 #endif
 
-            CommunicationsUtilities.Trace($"For a host context of {hostContext}, app host not found at {appHostPath}, falling back to dotnet.exe from {resolvedDotnetHostPath}.");
+            CommunicationsUtilities.Trace($"For a host context of {hostContext}, app host not found, falling back to dotnet.exe ({resolvedDotnetHostPath}) hosting {launchPath}.");
 
             return new NodeLaunchData(
                 resolvedDotnetHostPath,
-                $"\"{Path.Combine(msbuildAssemblyPath, Constants.MSBuildAssemblyName)}\" {commandLineArgs}",
+                $"\"{launchPath}\" {commandLineArgs}",
                 handshake);
+        }
+
+        /// <summary>
+        /// Resolves the .NET task host launch target for an SDK directory: the MSBuild app host
+        /// (<c>MSBuild.exe</c>) when present, otherwise <c>MSBuild.dll</c> (which is launched via
+        /// <c>dotnet.exe</c>). Single source of truth for the apphost-vs-fallback decision,
+        /// shared by the launch path and any caller that needs to describe the launch target
+        /// (e.g. error messages).
+        /// </summary>
+        internal static (string LaunchPath, bool UseAppHost) ResolveNetTaskHostLaunchPath(string msbuildAssemblyPath)
+        {
+            string appHostPath = Path.Combine(msbuildAssemblyPath, Constants.MSBuildExecutableName);
+            return FileSystems.Default.FileExists(appHostPath)
+                ? (appHostPath, true)
+                : (Path.Combine(msbuildAssemblyPath, Constants.MSBuildAssemblyName), false);
         }
 
         private string BuildCommandLineArgs(bool nodeReuseEnabled) => $"/nologo {NodeModeHelper.ToCommandLineArgument(NodeMode.OutOfProcTaskHostNode)} /nodereuse:{nodeReuseEnabled} /low:{ComponentHost.BuildParameters.LowPriority} /parentpacketversion:{NodePacketTypeExtensions.PacketVersion} ";

--- a/src/Build/Instance/TaskFactories/TaskHostTask.cs
+++ b/src/Build/Instance/TaskFactories/TaskHostTask.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
 using System.Reflection;
 using System.Threading;
 using Microsoft.Build.BackEnd.Logging;
@@ -15,7 +14,6 @@ using Microsoft.Build.Execution;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Internal;
 using Microsoft.Build.Shared;
-using Constants = Microsoft.Build.Framework.Constants;
 #if FEATURE_REPORTFILEACCESSES
 using Microsoft.Build.Experimental.FileAccess;
 using Microsoft.Build.FileAccesses;
@@ -814,14 +812,15 @@ namespace Microsoft.Build.BackEnd
         /// </summary>
         private void LogErrorUnableToCreateTaskHost(HandshakeOptions requiredContext, string runtime, string architecture, Exception e)
         {
-            string taskHostLocation;
+            string taskHostLocation = null;
 
             if (Handshake.IsHandshakeOptionEnabled(requiredContext, HandshakeOptions.NET))
             {
                 (_, string msbuildPath) = NodeProviderOutOfProcTaskHost.GetMSBuildLocationForNETRuntime(requiredContext, _taskHostParameters);
-                taskHostLocation = msbuildPath != null
-                    ? Path.Combine(msbuildPath, Constants.MSBuildExecutableName)
-                    : null;
+                if (msbuildPath != null)
+                {
+                    (taskHostLocation, _) = NodeProviderOutOfProcTaskHost.ResolveNetTaskHostLaunchPath(msbuildPath);
+                }
             }
             else
             {


### PR DESCRIPTION
Fixes https://github.com/dotnet/msbuild/issues/13888

## Summary

When a `Runtime="NET"` task host launch fails, the MSB4216 error message
always pointed at `<sdk>\MSBuild.exe` — the .NET task host app host — even
when the launcher fell back to `dotnet.exe MSBuild.dll` because no app host
was present in the SDK.

SDK 10.0.x ships `MSBuild.dll` only; the app host first appears in 10.0.300.
On those SDKs users see an MSB4216 referencing a file that never existed
(see #13879 for a concrete repro on Windows-ARM with SDK 10.0.108).

## Change

Centralize the apphost-vs-fallback decision in a new
`NodeProviderOutOfProcTaskHost.ResolveNetTaskHostLaunchPath` helper that
returns `(LaunchPath, UseAppHost)`. Use it from both the launcher
(`ResolveAppHostOrFallback`) and the error path
(`TaskHostTask.LogErrorUnableToCreateTaskHost`) so the reported path
always matches the path that was actually launched.

This is a logging-only change; launch behavior is unchanged.

## Notes

This is a partial fix for #13879. The underlying handshake bug
(`IsAllowedBitnessMismatch` missing Arm64 tolerance) remains and will be
fixed separately.