### PR TITLE
Make Runtime=NET task host handshake architecture-agnostic

### DIFF
--- a/src/Build.UnitTests/BackEnd/CommunicationsUtilities_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/CommunicationsUtilities_Tests.cs
@@ -1,0 +1,95 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Internal;
+using Microsoft.Build.Shared;
+using Shouldly;
+using Xunit;
+
+namespace Microsoft.Build.Engine.UnitTests.BackEnd
+{
+    /// <summary>
+    /// Tests for <see cref="CommunicationsUtilities.GetHandshakeOptions"/> covering the parent
+    /// side of NET task host launches: the parent must suppress its own architecture bit on
+    /// the wire so already-shipped SDK children (whose <c>IsAllowedBitnessMismatch</c> tolerates
+    /// "parent sent no arch bit") accept the connection regardless of either process arch.
+    /// </summary>
+    public sealed class CommunicationsUtilities_Tests
+    {
+        [Theory]
+        [InlineData(XMakeAttributes.MSBuildArchitectureValues.x64)]
+        [InlineData(XMakeAttributes.MSBuildArchitectureValues.arm64)]
+        [InlineData(XMakeAttributes.MSBuildArchitectureValues.x86)]
+        public void GetHandshakeOptions_NetTaskHostParent_SuppressesArchBit(string parentArchitecture)
+        {
+            var parameters = new TaskHostParameters(
+                runtime: XMakeAttributes.MSBuildRuntimeValues.net,
+                architecture: parentArchitecture);
+
+            HandshakeOptions options = CommunicationsUtilities.GetHandshakeOptions(
+                taskHost: true,
+                taskHostParameters: parameters);
+
+            options.HasFlag(HandshakeOptions.NET).ShouldBeTrue();
+            options.HasFlag(HandshakeOptions.X64).ShouldBeFalse();
+            options.HasFlag(HandshakeOptions.Arm64).ShouldBeFalse();
+        }
+
+        [Fact]
+        public void GetHandshakeOptions_NonNetTaskHostParent_KeepsX64ArchBit()
+        {
+            var parameters = new TaskHostParameters(
+                runtime: XMakeAttributes.MSBuildRuntimeValues.clr4,
+                architecture: XMakeAttributes.MSBuildArchitectureValues.x64);
+
+            HandshakeOptions options = CommunicationsUtilities.GetHandshakeOptions(
+                taskHost: true,
+                taskHostParameters: parameters);
+
+            options.HasFlag(HandshakeOptions.X64).ShouldBeTrue();
+        }
+
+        [Fact]
+        public void GetHandshakeOptions_NonNetTaskHostParent_KeepsArm64ArchBit()
+        {
+            var parameters = new TaskHostParameters(
+                runtime: XMakeAttributes.MSBuildRuntimeValues.clr4,
+                architecture: XMakeAttributes.MSBuildArchitectureValues.arm64);
+
+            HandshakeOptions options = CommunicationsUtilities.GetHandshakeOptions(
+                taskHost: true,
+                taskHostParameters: parameters);
+
+            options.HasFlag(HandshakeOptions.Arm64).ShouldBeTrue();
+        }
+
+        [Fact]
+        public void GetHandshakeOptions_NetTaskHostChild_KeepsArchBit()
+        {
+            // The child invokes GetHandshakeOptions with TaskHostParameters.Empty; the helper
+            // then derives architectureFlagToSet from GetCurrentMSBuildArchitecture(). The
+            // suppression must not apply: the child needs to keep its own arch bit so
+            // already-deployed parents that still emit one continue to match.
+            HandshakeOptions options = CommunicationsUtilities.GetHandshakeOptions(
+                taskHost: true,
+                taskHostParameters: TaskHostParameters.Empty);
+
+            string currentArch = XMakeAttributes.GetCurrentMSBuildArchitecture();
+            if (currentArch.Equals(XMakeAttributes.MSBuildArchitectureValues.x64, System.StringComparison.OrdinalIgnoreCase))
+            {
+                options.HasFlag(HandshakeOptions.X64).ShouldBeTrue();
+            }
+            else if (currentArch.Equals(XMakeAttributes.MSBuildArchitectureValues.arm64, System.StringComparison.OrdinalIgnoreCase))
+            {
+                options.HasFlag(HandshakeOptions.Arm64).ShouldBeTrue();
+            }
+            else
+            {
+                // x86 or unknown: no arch bit is expected on the child side either.
+                options.HasFlag(HandshakeOptions.X64).ShouldBeFalse();
+                options.HasFlag(HandshakeOptions.Arm64).ShouldBeFalse();
+            }
+        }
+    }
+}

--- a/src/Build.UnitTests/BackEnd/CommunicationsUtilities_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/CommunicationsUtilities_Tests.cs
@@ -10,10 +10,11 @@ using Xunit;
 namespace Microsoft.Build.Engine.UnitTests.BackEnd
 {
     /// <summary>
-    /// Tests for <see cref="CommunicationsUtilities.GetHandshakeOptions"/> covering the parent
-    /// side of NET task host launches: the parent must suppress its own architecture bit on
-    /// the wire so already-shipped SDK children (whose <c>IsAllowedBitnessMismatch</c> tolerates
-    /// "parent sent no arch bit") accept the connection regardless of either process arch.
+    /// Tests for <see cref="CommunicationsUtilities.GetHandshakeOptions"/> covering the worker
+    /// node side of NET task host launches: the worker node must suppress its own architecture
+    /// bit on the wire so already-shipped SDK TaskHost nodes (whose <c>IsAllowedBitnessMismatch</c>
+    /// tolerates "worker node sent no arch bit") accept the connection regardless of either
+    /// process arch.
     /// </summary>
     public sealed class CommunicationsUtilities_Tests
     {
@@ -21,11 +22,11 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
         [InlineData(XMakeAttributes.MSBuildArchitectureValues.x64)]
         [InlineData(XMakeAttributes.MSBuildArchitectureValues.arm64)]
         [InlineData(XMakeAttributes.MSBuildArchitectureValues.x86)]
-        public void GetHandshakeOptions_NetTaskHostParent_SuppressesArchBit(string parentArchitecture)
+        public void GetHandshakeOptions_NetTaskHostWorkerNode_SuppressesArchBit(string workerArchitecture)
         {
             var parameters = new TaskHostParameters(
                 runtime: XMakeAttributes.MSBuildRuntimeValues.net,
-                architecture: parentArchitecture);
+                architecture: workerArchitecture);
 
             HandshakeOptions options = CommunicationsUtilities.GetHandshakeOptions(
                 taskHost: true,
@@ -37,7 +38,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
         }
 
         [Fact]
-        public void GetHandshakeOptions_NonNetTaskHostParent_KeepsX64ArchBit()
+        public void GetHandshakeOptions_NonNetTaskHostWorkerNode_KeepsX64ArchBit()
         {
             var parameters = new TaskHostParameters(
                 runtime: XMakeAttributes.MSBuildRuntimeValues.clr4,
@@ -51,7 +52,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
         }
 
         [Fact]
-        public void GetHandshakeOptions_NonNetTaskHostParent_KeepsArm64ArchBit()
+        public void GetHandshakeOptions_NonNetTaskHostWorkerNode_KeepsArm64ArchBit()
         {
             var parameters = new TaskHostParameters(
                 runtime: XMakeAttributes.MSBuildRuntimeValues.clr4,
@@ -65,12 +66,12 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
         }
 
         [Fact]
-        public void GetHandshakeOptions_NetTaskHostChild_KeepsArchBit()
+        public void GetHandshakeOptions_NetTaskHostNode_KeepsArchBit()
         {
-            // The child invokes GetHandshakeOptions with TaskHostParameters.Empty; the helper
-            // then derives architectureFlagToSet from GetCurrentMSBuildArchitecture(). The
-            // suppression must not apply: the child needs to keep its own arch bit so
-            // already-deployed parents that still emit one continue to match.
+            // The TaskHost node invokes GetHandshakeOptions with TaskHostParameters.Empty; the
+            // helper then derives architectureFlagToSet from GetCurrentMSBuildArchitecture(). The
+            // suppression must not apply: the TaskHost node needs to keep its own arch bit so
+            // already-deployed worker nodes that still emit one continue to match.
             HandshakeOptions options = CommunicationsUtilities.GetHandshakeOptions(
                 taskHost: true,
                 taskHostParameters: TaskHostParameters.Empty);
@@ -86,7 +87,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
             }
             else
             {
-                // x86 or unknown: no arch bit is expected on the child side either.
+                // x86 or unknown: no arch bit is expected on the TaskHost node side either.
                 options.HasFlag(HandshakeOptions.X64).ShouldBeFalse();
                 options.HasFlag(HandshakeOptions.Arm64).ShouldBeFalse();
             }

--- a/src/Build.UnitTests/BackEnd/NodeEndpointOutOfProcBase_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/NodeEndpointOutOfProcBase_Tests.cs
@@ -1,0 +1,67 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#if NET
+
+using Microsoft.Build.BackEnd;
+using Microsoft.Build.Internal;
+using Shouldly;
+using Xunit;
+
+namespace Microsoft.Build.Engine.UnitTests.BackEnd
+{
+    /// <summary>
+    /// Tests for <see cref="NodeEndpointOutOfProcBase.IsAllowedBitnessMismatch"/>, the .NET task
+    /// host child-side tolerance that lets a parent which did not emit an architecture bit
+    /// (e.g. a .NET Framework MSBuild) connect to an SDK child running on x64 or arm64.
+    /// </summary>
+    public sealed class NodeEndpointOutOfProcBase_Tests
+    {
+        private const HandshakeOptions BaseNet = HandshakeOptions.TaskHost | HandshakeOptions.NET;
+
+        [Fact]
+        public void NoArchBitParent_X64Child_IsTolerated()
+        {
+            NodeEndpointOutOfProcBase.IsAllowedBitnessMismatch(
+                expectedOptions: (int)(BaseNet | HandshakeOptions.X64),
+                receivedOptions: (int)BaseNet).ShouldBeTrue();
+        }
+
+        [Fact]
+        public void NoArchBitParent_Arm64Child_IsTolerated()
+        {
+            NodeEndpointOutOfProcBase.IsAllowedBitnessMismatch(
+                expectedOptions: (int)(BaseNet | HandshakeOptions.Arm64),
+                receivedOptions: (int)BaseNet).ShouldBeTrue();
+        }
+
+        [Fact]
+        public void X64Parent_X64Child_NotConsideredMismatch()
+        {
+            // Equal handshakes never hit IsAllowedBitnessMismatch in production; verify it
+            // still returns false so the tolerance is scoped to the no-arch-bit parent only.
+            NodeEndpointOutOfProcBase.IsAllowedBitnessMismatch(
+                expectedOptions: (int)(BaseNet | HandshakeOptions.X64),
+                receivedOptions: (int)(BaseNet | HandshakeOptions.X64)).ShouldBeFalse();
+        }
+
+        [Fact]
+        public void X64Parent_Arm64Child_NotTolerated()
+        {
+            // True architecture mismatch (parent sent X64, child expects Arm64) is rejected.
+            NodeEndpointOutOfProcBase.IsAllowedBitnessMismatch(
+                expectedOptions: (int)(BaseNet | HandshakeOptions.Arm64),
+                receivedOptions: (int)(BaseNet | HandshakeOptions.X64)).ShouldBeFalse();
+        }
+
+        [Fact]
+        public void Arm64Parent_X64Child_NotTolerated()
+        {
+            NodeEndpointOutOfProcBase.IsAllowedBitnessMismatch(
+                expectedOptions: (int)(BaseNet | HandshakeOptions.X64),
+                receivedOptions: (int)(BaseNet | HandshakeOptions.Arm64)).ShouldBeFalse();
+        }
+    }
+}
+
+#endif

--- a/src/Build.UnitTests/BackEnd/NodeEndpointOutOfProcBase_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/NodeEndpointOutOfProcBase_Tests.cs
@@ -12,15 +12,16 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
 {
     /// <summary>
     /// Tests for <see cref="NodeEndpointOutOfProcBase.IsAllowedBitnessMismatch"/>, the .NET task
-    /// host child-side tolerance that lets a parent which did not emit an architecture bit
-    /// (e.g. a .NET Framework MSBuild) connect to an SDK child running on x64 or arm64.
+    /// host (TaskHost node) side tolerance that lets a worker node which did not emit an
+    /// architecture bit (e.g. a .NET Framework MSBuild) connect to an SDK TaskHost node running
+    /// on x64 or arm64.
     /// </summary>
     public sealed class NodeEndpointOutOfProcBase_Tests
     {
         private const HandshakeOptions BaseNet = HandshakeOptions.TaskHost | HandshakeOptions.NET;
 
         [Fact]
-        public void NoArchBitParent_X64Child_IsTolerated()
+        public void NoArchBitWorkerNode_X64TaskHost_IsTolerated()
         {
             NodeEndpointOutOfProcBase.IsAllowedBitnessMismatch(
                 expectedOptions: (int)(BaseNet | HandshakeOptions.X64),
@@ -28,7 +29,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
         }
 
         [Fact]
-        public void NoArchBitParent_Arm64Child_IsTolerated()
+        public void NoArchBitWorkerNode_Arm64TaskHost_IsTolerated()
         {
             NodeEndpointOutOfProcBase.IsAllowedBitnessMismatch(
                 expectedOptions: (int)(BaseNet | HandshakeOptions.Arm64),
@@ -36,26 +37,26 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
         }
 
         [Fact]
-        public void X64Parent_X64Child_NotConsideredMismatch()
+        public void X64WorkerNode_X64TaskHost_NotConsideredMismatch()
         {
             // Equal handshakes never hit IsAllowedBitnessMismatch in production; verify it
-            // still returns false so the tolerance is scoped to the no-arch-bit parent only.
+            // still returns false so the tolerance is scoped to the no-arch-bit worker node only.
             NodeEndpointOutOfProcBase.IsAllowedBitnessMismatch(
                 expectedOptions: (int)(BaseNet | HandshakeOptions.X64),
                 receivedOptions: (int)(BaseNet | HandshakeOptions.X64)).ShouldBeFalse();
         }
 
         [Fact]
-        public void X64Parent_Arm64Child_NotTolerated()
+        public void X64WorkerNode_Arm64TaskHost_NotTolerated()
         {
-            // True architecture mismatch (parent sent X64, child expects Arm64) is rejected.
+            // True architecture mismatch (worker node sent X64, TaskHost node expects Arm64) is rejected.
             NodeEndpointOutOfProcBase.IsAllowedBitnessMismatch(
                 expectedOptions: (int)(BaseNet | HandshakeOptions.Arm64),
                 receivedOptions: (int)(BaseNet | HandshakeOptions.X64)).ShouldBeFalse();
         }
 
         [Fact]
-        public void Arm64Parent_X64Child_NotTolerated()
+        public void Arm64WorkerNode_X64TaskHost_NotTolerated()
         {
             NodeEndpointOutOfProcBase.IsAllowedBitnessMismatch(
                 expectedOptions: (int)(BaseNet | HandshakeOptions.X64),
@@ -63,10 +64,10 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
         }
 
         [Fact]
-        public void NoArchBitParent_NoArchBitChild_NotTolerated()
+        public void NoArchBitWorkerNode_NoArchBitTaskHost_NotTolerated()
         {
-            // The tolerance is scoped to x64/arm64 children; an x86-equivalent (no arch bit)
-            // child must not silently accept any handshake.
+            // The tolerance is scoped to x64/arm64 TaskHost nodes; an x86-equivalent (no arch bit)
+            // TaskHost node must not silently accept any handshake.
             NodeEndpointOutOfProcBase.IsAllowedBitnessMismatch(
                 expectedOptions: (int)BaseNet,
                 receivedOptions: (int)BaseNet).ShouldBeFalse();

--- a/src/Build.UnitTests/BackEnd/NodeEndpointOutOfProcBase_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/NodeEndpointOutOfProcBase_Tests.cs
@@ -61,6 +61,16 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
                 expectedOptions: (int)(BaseNet | HandshakeOptions.X64),
                 receivedOptions: (int)(BaseNet | HandshakeOptions.Arm64)).ShouldBeFalse();
         }
+
+        [Fact]
+        public void NoArchBitParent_NoArchBitChild_NotTolerated()
+        {
+            // The tolerance is scoped to x64/arm64 children; an x86-equivalent (no arch bit)
+            // child must not silently accept any handshake.
+            NodeEndpointOutOfProcBase.IsAllowedBitnessMismatch(
+                expectedOptions: (int)BaseNet,
+                receivedOptions: (int)BaseNet).ShouldBeFalse();
+        }
     }
 }
 

--- a/src/Framework/BackEnd/CommunicationsUtilities.cs
+++ b/src/Framework/BackEnd/CommunicationsUtilities.cs
@@ -580,7 +580,25 @@ internal static class CommunicationsUtilities
             }
         }
 
-        if (!string.IsNullOrEmpty(architectureFlagToSet))
+        // For the NET task host, the launched child process's architecture is determined by
+        // what the .NET SDK shipped (x64 today, arm64 in the future), not by the parent's
+        // process architecture. Emitting the parent's arch bit here creates a wire-level
+        // mismatch with already-shipped SDK children whose arch differs (e.g. arm64 VS
+        // launching an x64 SDK MSBuild.dll). Suppress the arch bit so the child's existing
+        // IsAllowedBitnessMismatch tolerance ("parent sent no arch bit") accepts the
+        // connection regardless of either side's process architecture.
+        //
+        // Only the parent suppresses — i.e. when GetHandshakeOptions is invoked with concrete
+        // taskHostParameters describing a specific runtime/architecture to launch. The child
+        // (which calls GetHandshakeOptions with TaskHostParameters.Empty) keeps its own arch
+        // bit so that already-deployed parents that still emit an arch bit continue to match
+        // (or fall through to IsAllowedBitnessMismatch's tolerance).
+        bool isNetTaskHostParent =
+            taskHost &&
+            !taskHostParameters.IsEmpty &&
+            XMakeAttributes.MSBuildRuntimeValues.net.Equals(taskHostParameters.Runtime, StringComparison.OrdinalIgnoreCase);
+
+        if (!isNetTaskHostParent && !string.IsNullOrEmpty(architectureFlagToSet))
         {
             if (architectureFlagToSet!.Equals(XMakeAttributes.MSBuildArchitectureValues.x64, StringComparison.OrdinalIgnoreCase))
             {

--- a/src/Framework/BackEnd/CommunicationsUtilities.cs
+++ b/src/Framework/BackEnd/CommunicationsUtilities.cs
@@ -580,25 +580,19 @@ internal static class CommunicationsUtilities
             }
         }
 
-        // For the NET task host, the launched child process's architecture is determined by
-        // what the .NET SDK shipped (x64 today, arm64 in the future), not by the parent's
-        // process architecture. Emitting the parent's arch bit here creates a wire-level
-        // mismatch with already-shipped SDK children whose arch differs (e.g. arm64 VS
-        // launching an x64 SDK MSBuild.dll). Suppress the arch bit so the child's existing
-        // IsAllowedBitnessMismatch tolerance ("parent sent no arch bit") accepts the
-        // connection regardless of either side's process architecture.
-        //
-        // Only the parent suppresses — i.e. when GetHandshakeOptions is invoked with concrete
-        // taskHostParameters describing a specific runtime/architecture to launch. The child
-        // (which calls GetHandshakeOptions with TaskHostParameters.Empty) keeps its own arch
-        // bit so that already-deployed parents that still emit an arch bit continue to match
-        // (or fall through to IsAllowedBitnessMismatch's tolerance).
-        bool isNetTaskHostParent =
+        // For a NET task host the launched TaskHost node runs whatever architecture the .NET
+        // SDK shipped, which the worker node cannot know. Suppress the worker node's arch bit
+        // so the handshake stays architecture-agnostic: any architecture of worker node may
+        // connect to any architecture of the resolved SDK TaskHost node (the TaskHost node
+        // tolerates a missing arch bit via IsAllowedBitnessMismatch). Only the worker node
+        // suppresses; the TaskHost node itself (TaskHostParameters.Empty) keeps its arch bit so
+        // already-deployed worker nodes that still emit one continue to connect.
+        bool isNetTaskHostWorkerNode =
             taskHost &&
             !taskHostParameters.IsEmpty &&
             XMakeAttributes.MSBuildRuntimeValues.net.Equals(taskHostParameters.Runtime, StringComparison.OrdinalIgnoreCase);
 
-        if (!isNetTaskHostParent && !string.IsNullOrEmpty(architectureFlagToSet))
+        if (!isNetTaskHostWorkerNode && !string.IsNullOrEmpty(architectureFlagToSet))
         {
             if (architectureFlagToSet!.Equals(XMakeAttributes.MSBuildArchitectureValues.x64, StringComparison.OrdinalIgnoreCase))
             {

--- a/src/Shared/NodeEndpointOutOfProcBase.cs
+++ b/src/Shared/NodeEndpointOutOfProcBase.cs
@@ -593,7 +593,8 @@ namespace Microsoft.Build.BackEnd
         /// True cross-arch mismatches (e.g. parent sent X64 but child expects Arm64, or vice
         /// versa) remain rejected.
         ///
-        /// 0x00FFFFFF is the handshake version included in component, the rest is the node type.
+        /// The lower 24 bits (mask 0x00FFFFFF) carry the HandshakeOptions flags; the upper
+        /// byte carries the handshake version and is ignored here.
         /// </summary>
         internal static bool IsAllowedBitnessMismatch(int expectedOptions, int receivedOptions)
         {

--- a/src/Shared/NodeEndpointOutOfProcBase.cs
+++ b/src/Shared/NodeEndpointOutOfProcBase.cs
@@ -561,8 +561,8 @@ namespace Microsoft.Build.BackEnd
 
             if (component.Key == nameof(HandshakeComponents.Options))
             {
-                // NET Task host allows MSBuild.exe to connect to it even if they have bitness mismatch.
-                // 0x00FFFFFF is the handshake version included in component, the rest is the node type.
+                // NET task host tolerates a worker node connecting with an architecture mismatch.
+                // The lower 24 bits carry the HandshakeOptions flags; the upper byte is the handshake version.
                 isAllowedMismatch = IsAllowedBitnessMismatch(component.Value, handshakePart);
             }
             else
@@ -584,14 +584,15 @@ namespace Microsoft.Build.BackEnd
 
 #if NET
         /// <summary>
-        /// The .NET task host child tolerates a parent that did not emit an architecture bit
-        /// on the wire (which is indistinguishable from x86) when the child itself is x64 or
-        /// arm64. This is the .NET Framework parent → .NET SDK child scenario: the parent
-        /// typically cannot describe the SDK child's architecture, but the launched task host
-        /// process is whatever the SDK ships (x64 on Windows-x64, arm64 on Windows-arm64).
+        /// The .NET task host (TaskHost node) tolerates a worker node that did not emit an
+        /// architecture bit on the wire (indistinguishable from x86) when the TaskHost node
+        /// itself is x64 or arm64. This is the .NET Framework worker node → .NET SDK TaskHost
+        /// node scenario: the worker node typically cannot describe the TaskHost node's
+        /// architecture, but the launched process is whatever the SDK ships (x64 on
+        /// Windows-x64, arm64 on Windows-arm64).
         ///
-        /// True cross-arch mismatches (e.g. parent sent X64 but child expects Arm64, or vice
-        /// versa) remain rejected.
+        /// True cross-arch mismatches (e.g. worker node sent X64 but TaskHost node expects
+        /// Arm64, or vice versa) remain rejected.
         ///
         /// The lower 24 bits (mask 0x00FFFFFF) carry the HandshakeOptions flags; the upper
         /// byte carries the handshake version and is ignored here.

--- a/src/Shared/NodeEndpointOutOfProcBase.cs
+++ b/src/Shared/NodeEndpointOutOfProcBase.cs
@@ -584,21 +584,30 @@ namespace Microsoft.Build.BackEnd
 
 #if NET
         /// <summary>
-        /// NET Task host allows MSBuild.exe to connect to it even if they have bitness mismatch.
+        /// The .NET task host child tolerates a parent that did not emit an architecture bit
+        /// on the wire (which is indistinguishable from x86) when the child itself is x64 or
+        /// arm64. This is the .NET Framework parent → .NET SDK child scenario: the parent
+        /// typically cannot describe the SDK child's architecture, but the launched task host
+        /// process is whatever the SDK ships (x64 on Windows-x64, arm64 on Windows-arm64).
+        ///
+        /// True cross-arch mismatches (e.g. parent sent X64 but child expects Arm64, or vice
+        /// versa) remain rejected.
+        ///
         /// 0x00FFFFFF is the handshake version included in component, the rest is the node type.
         /// </summary>
-        private bool IsAllowedBitnessMismatch(int expectedOptions, int receivedOptions)
+        internal static bool IsAllowedBitnessMismatch(int expectedOptions, int receivedOptions)
         {
             var expectedNodeType = (HandshakeOptions)(expectedOptions & 0x00FFFFFF);
             var receivedNodeType = (HandshakeOptions)(receivedOptions & 0x00FFFFFF);
 
-            // not X64 or Arm64 means we are running on x86
+            // not X64 or Arm64 means the wire-form architecture is x86 (or no arch bit).
             bool receivedIsX86 = !Handshake.IsHandshakeOptionEnabled(receivedNodeType, HandshakeOptions.X64) &&
                                  !Handshake.IsHandshakeOptionEnabled(receivedNodeType, HandshakeOptions.Arm64);
 
             bool expectedIsX64 = Handshake.IsHandshakeOptionEnabled(expectedNodeType, HandshakeOptions.X64);
+            bool expectedIsArm64 = Handshake.IsHandshakeOptionEnabled(expectedNodeType, HandshakeOptions.Arm64);
 
-            return receivedIsX86 && expectedIsX64;
+            return receivedIsX86 && (expectedIsX64 || expectedIsArm64);
         }
 #endif
 


### PR DESCRIPTION
## Summary

`Runtime="NET"` task host launches fail with `MSB4216` whenever the worker node and TaskHost node architectures don't line up the way the original implementation expected. Tracked as [#13879](https://github.com/dotnet/msbuild/issues/13879) (Bug A).

> Terminology: the **worker node** is the MSBuild process that launches the task host (the "parent"); the **TaskHost node** is the launched `Runtime="NET"` task host process (the "child"). This wording was adopted following review feedback.

Two coordinated handshake changes — one on each side — close every reasonable worker/TaskHost arch combination:

### 1. Worker node side — `CommunicationsUtilities.GetHandshakeOptions`

For a NET task host the launched TaskHost node's architecture is whatever the .NET SDK shipped, not the worker node's. Emitting the worker node's arch bit produces a wire-level mismatch with already-shipped SDK TaskHost nodes whose arch differs.

Suppress the `X64`/`Arm64` bit when invoked by the worker node for a NET task host (detected by `Runtime="net"` in the explicit `TaskHostParameters`). The TaskHost-node path (`TaskHostParameters.Empty`) is unaffected, so already-deployed worker nodes that still emit an arch bit continue to match.

### 2. TaskHost node side — `NodeEndpointOutOfProcBase.IsAllowedBitnessMismatch`

The .NET task host side relaxation that lets a worker node without an arch bit on the wire connect to an SDK TaskHost node. Previously only tolerated `expected = X64`, so any arm64 SDK TaskHost node rejected the connection. Now also tolerates `expected = Arm64`. True cross-arch mismatches (worker `X64` ↔ TaskHost `Arm64`) remain rejected.

Method is promoted to `internal static` so the test project can exercise the tolerance matrix directly. It was a stateless pure predicate already.

## Effect across worker node / SDK combinations

`current` = behavior with this PR applied (worker-node change in VS MSBuild, TaskHost-node change in a future SDK). For each combo, "current behavior" notes whether the SDK side needs to update.

| Worker node | TaskHost node (SDK MSBuild.dll) | Wire arch bit | Old behavior | Current behavior |
|---|---|---|---|---|
| x86 .NET Fx VS | x64 SDK | none → x64 | ✅ (existing `expectedIsX64` tolerance) | ✅ |
| x86 .NET Fx VS | arm64 SDK | none → arm64 | ❌ MSB4216 (Bug A) — **the user's binlog** | ✅ once SDK ships with TaskHost-side `expectedIsArm64` tolerance |
| amd64 .NET Fx VS | x64 SDK | x64 → x64 | ✅ (matches exactly) | ✅ (after worker fix: no bit on wire; already-shipped SDK tolerates none → x64) |
| amd64 .NET Fx VS | arm64 SDK | x64 → arm64 | ❌ MSB4216 | ✅ once VS picks up worker-side suppression; SDK must also have TaskHost-side Arm64 tolerance |
| arm64 .NET Fx VS | x64 SDK | arm64 → x64 | ❌ MSB4216 | ✅ once VS picks up worker-side suppression (works against already-shipped SDKs) |
| arm64 .NET Fx VS | arm64 SDK | arm64 → arm64 | ✅ (matches exactly) | ✅ |
| old worker node (pre-this-PR) | new SDK TaskHost node | x64/arm64 → matching | unchanged | unchanged — still works if arches match, still hits Bug A if they don't (worker has no fix) |

## Where each fix takes effect

| Failing combo | Fixed by | Ships in |
|---|---|---|
| x86 .NET Fx VS → win-arm64 SDK | TaskHost-side Arm64 tolerance | a new .NET SDK build that picks up this PR |
| amd64 .NET Fx VS → win-arm64 SDK | worker-side arch suppression + TaskHost-side Arm64 tolerance | next VS insertion of MSBuild (worker side) plus a new SDK build (TaskHost side) |
| arm64 .NET Fx VS → win-x64 SDK | worker-side arch suppression (existing `expectedIsX64` tolerance already covers the TaskHost node) | next VS insertion of MSBuild only — no SDK update needed |

The reported binlog (Roslyn build on Windows-ARM, SDK 10.0.108, x86 VS 18 MSBuild worker node) is the first row — needs the SDK side to pick this up.

## Tests

`src/Build.UnitTests/BackEnd/NodeEndpointOutOfProcBase_Tests.cs` (6 cases):

- `NoArchBitWorkerNode_X64TaskHost_IsTolerated`
- `NoArchBitWorkerNode_Arm64TaskHost_IsTolerated`
- `X64WorkerNode_X64TaskHost_NotConsideredMismatch`
- `X64WorkerNode_Arm64TaskHost_NotTolerated`
- `Arm64WorkerNode_X64TaskHost_NotTolerated`
- `NoArchBitWorkerNode_NoArchBitTaskHost_NotTolerated` (guards against a future simplification to `return receivedIsX86;`)

`src/Build.UnitTests/BackEnd/CommunicationsUtilities_Tests.cs` (5 cases):

- `GetHandshakeOptions_NetTaskHostWorkerNode_SuppressesArchBit` × { x64, arm64, x86 }
- `GetHandshakeOptions_NonNetTaskHostWorkerNode_KeepsX64ArchBit`
- `GetHandshakeOptions_NonNetTaskHostWorkerNode_KeepsArm64ArchBit`
- `GetHandshakeOptions_NetTaskHostNode_KeepsArchBit`

All 11 pass on net10.0.

## References

- Closes #13879 (Bug A).
- Companion logging fix: #13889.
