### PR TITLE
Improve symlink cycle condition

### DIFF
--- a/src/Framework.UnitTests/FileMatcher_Tests.cs
+++ b/src/Framework.UnitTests/FileMatcher_Tests.cs
@@ -91,6 +91,50 @@ namespace Microsoft.Build.UnitTests
                 }
             }
         }
+
+        [RequiresSymbolicLinksFact]
+        public void ShouldNotSkipSymlinkDirectoryWhenProjectDirectoryIsPrefixedWithSymlinkTargetName()
+        {
+            TransientTestFolder rootFolder = _env.CreateFolder();
+
+            string targetFolderName = "target";
+            string fileAName = "A.cs";
+            string targetSubFolderName = "foo";
+            string fileBName = "B.cs";
+            TransientTestFolder targetFolder = _env.CreateFolder(Path.Combine(rootFolder.Path, targetFolderName));
+            _env.CreateFile(targetFolder, fileName: fileAName);
+            TransientTestFolder targetSubFolder = _env.CreateFolder(Path.Combine(targetFolder.Path, targetSubFolderName));
+            _env.CreateFile(targetSubFolder, fileName: fileBName);
+
+            TransientTestFolder projectFolder = _env.CreateFolder(Path.Combine(rootFolder.Path, $"{targetFolderName}Test"));
+            string symlinkName = "mySymlink";
+            string symlinkPath = Path.Combine(projectFolder.Path, symlinkName);
+            string include = Path.Combine(symlinkName, "**", "*.cs");
+
+            string[] expectedFiles =
+            [
+                Path.Combine(symlinkName, fileAName),
+                Path.Combine(symlinkName, targetSubFolderName, fileBName)
+            ];
+
+            try
+            {
+                Directory.CreateSymbolicLink(symlinkPath, targetFolder.Path);
+                string[] fileMatches = FileMatcher.Default.GetFiles(projectFolder.Path, include).FileList;
+                fileMatches.Length.ShouldBe(expectedFiles.Length);
+                foreach (var item in fileMatches)
+                {
+                    expectedFiles.ShouldContain(item);
+                }
+            }
+            finally
+            {
+                if (Directory.Exists(symlinkPath))
+                {
+                    Directory.Delete(symlinkPath);
+                }
+            }
+        }
 #endif
 
         [Theory]

--- a/src/Framework/Utilities/FileMatcher.cs
+++ b/src/Framework/Utilities/FileMatcher.cs
@@ -838,7 +838,7 @@ namespace Microsoft.Build.Shared
             try
             {
                 FileSystemInfo linkTarget = Directory.ResolveLinkTarget(recursionState.BaseDirectory, returnFinalTarget: true);
-                if (linkTarget is not null && recursionState.BaseDirectory.Contains(linkTarget.FullName))
+                if (linkTarget is not null && IsSubdirectoryOf(recursionState.BaseDirectory, linkTarget.FullName))
                 {
                     return;
                 }

--- a/src/Framework/Utilities/FileMatcher.cs
+++ b/src/Framework/Utilities/FileMatcher.cs
@@ -838,7 +838,7 @@ namespace Microsoft.Build.Shared
             try
             {
                 FileSystemInfo linkTarget = Directory.ResolveLinkTarget(recursionState.BaseDirectory, returnFinalTarget: true);
-                if (linkTarget is not null && IsSubdirectoryOf(recursionState.BaseDirectory, linkTarget.FullName))
+                if (linkTarget is not null && IsSubdirectoryOf(recursionState.BaseDirectory, linkTarget.FullName, FileUtilities.PathComparison))
                 {
                     return;
                 }
@@ -2647,7 +2647,7 @@ namespace Microsoft.Build.Shared
             return ex.Flatten().InnerExceptions.All(ExceptionHandling.IsIoRelatedException);
         }
 
-        private static bool IsSubdirectoryOf(string possibleChild, string possibleParent)
+        private static bool IsSubdirectoryOf(string possibleChild, string possibleParent, StringComparison pathComparison = StringComparison.OrdinalIgnoreCase)
         {
             if (possibleParent == string.Empty)
             {
@@ -2655,7 +2655,7 @@ namespace Microsoft.Build.Shared
                 return true;
             }
 
-            bool prefixMatch = possibleChild.StartsWith(possibleParent, StringComparison.OrdinalIgnoreCase);
+            bool prefixMatch = possibleChild.StartsWith(possibleParent, pathComparison);
             if (!prefixMatch)
             {
                 return false;


### PR DESCRIPTION
Fixes #13792

### Context
It uses String.Contains() to check if a path is a subdirectory of another one. In the case as the issue describes, expected files are skipped.

### Changes Made
Improve the symlink cycle condition.

### Testing
Added new one.

### Notes
