### PR TITLE
Fix ToolTask EOF wait to be STA-safe via CountdownEvent (MSB4018 in AspNetCompiler)

### DIFF
--- a/src/Utilities/ToolTask.cs
+++ b/src/Utilities/ToolTask.cs
@@ -768,8 +768,8 @@ namespace Microsoft.Build.Utilities
 
             if (ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave18_6))
             {
-                _standardOutputEOF = new ManualResetEvent(false);
-                _standardErrorEOF = new ManualResetEvent(false);
+                // One count each for the stdout and stderr EOF notifications.
+                _eofCountdown = new CountdownEvent(2);
             }
 
             _toolExited = new ManualResetEvent(false);
@@ -865,8 +865,8 @@ namespace Microsoft.Build.Utilities
                     _standardErrorDataAvailable.Dispose();
                     _standardOutputDataAvailable.Dispose();
 
-                    _standardOutputEOF?.Dispose();
-                    _standardErrorEOF?.Dispose();
+                    _eofCountdown?.Dispose();
+                    _eofCountdown = null;
 
                     _toolExited.Dispose();
                     _toolTimeoutExpired.Dispose();
@@ -1130,18 +1130,11 @@ namespace Microsoft.Build.Utilities
                 // EOF never arrives because grand child inherited the pipe and keeps it open.
                 const int eofTimeoutSec = 30;
 
-                // WaitHandle.WaitAll throws NotSupportedException when called on an STA thread
-                // (for example when a task such as AspNetCompiler runs on an STA thread), so wait
-                // on each EOF event individually while honoring the overall timeout.
-                int eofTimeoutMs = eofTimeoutSec * 1000;
-                var eofTimer = Stopwatch.StartNew();
-                bool allEOFReceived = _standardOutputEOF.WaitOne(eofTimeoutMs);
-                if (allEOFReceived)
-                {
-                    int remainingMs = (int)Math.Max(0, eofTimeoutMs - eofTimer.ElapsedMilliseconds);
-                    allEOFReceived = _standardErrorEOF.WaitOne(remainingMs);
-                }
-
+                // CountdownEvent.Wait is STA-safe (it falls back to a single-handle wait),
+                // unlike WaitHandle.WaitAll over multiple handles which throws
+                // NotSupportedException on STA threads (for example when a task such as
+                // AspNetCompiler runs on an STA thread).
+                bool allEOFReceived = _eofCountdown.Wait(TimeSpan.FromSeconds(eofTimeoutSec));
                 if (!allEOFReceived)
                 {
                     // Timeout: a grandchild process likely still holds the pipe open.
@@ -1320,18 +1313,14 @@ namespace Microsoft.Build.Utilities
         {
             if (e.Data == null)
             {
-                // The AsyncStreamReader sends Data=null when the pipe reaches EOF.
-                // Signal the appropriate EOF event so WaitForProcessExit knows
-                // all data from this stream has been delivered.
-                ManualResetEvent eofEvent = (dataQueue == _standardErrorData) ? _standardErrorEOF : _standardOutputEOF;
-                if (eofEvent != null)
+                // The AsyncStreamReader sends Data=null exactly once per stream when the
+                // pipe reaches EOF. Count it down so WaitForProcessExit knows when all
+                // data from both streams has been delivered.
+                lock (_eventCloseLock)
                 {
-                    lock (_eventCloseLock)
+                    if (!_eventsDisposed && _eofCountdown is { IsSet: false })
                     {
-                        if (!_eventsDisposed)
-                        {
-                            eofEvent.Set();
-                        }
+                        _eofCountdown.Signal();
                     }
                 }
 
@@ -1872,16 +1861,11 @@ namespace Microsoft.Build.Utilities
         private bool _eventsDisposed;
 
         /// <summary>
-        /// Signalled when the stdout AsyncStreamReader reaches EOF (sends Data=null).
-        /// Used by WaitForProcessExit to know when all stdout data has been delivered.
+        /// Counts down once for each of stdout/stderr when its AsyncStreamReader reaches
+        /// EOF (sends Data=null). Used by WaitForProcessExit to know when all data from
+        /// both streams has been delivered.
         /// </summary>
-        private ManualResetEvent _standardOutputEOF;
-
-        /// <summary>
-        /// Signalled when the stderr AsyncStreamReader reaches EOF (sends Data=null).
-        /// Used by WaitForProcessExit to know when all stderr data has been delivered.
-        /// </summary>
-        private ManualResetEvent _standardErrorEOF;
+        private CountdownEvent _eofCountdown;
 
         /// <summary>
         /// List of name, value pairs to be passed to the spawned tool's environment.

--- a/src/Utilities/ToolTask.cs
+++ b/src/Utilities/ToolTask.cs
@@ -1130,8 +1130,18 @@ namespace Microsoft.Build.Utilities
                 // EOF never arrives because grand child inherited the pipe and keeps it open.
                 const int eofTimeoutSec = 30;
 
-                WaitHandle[] eofEvents = [_standardOutputEOF, _standardErrorEOF];
-                bool allEOFReceived = WaitHandle.WaitAll(eofEvents, TimeSpan.FromSeconds(eofTimeoutSec));
+                // WaitHandle.WaitAll throws NotSupportedException when called on an STA thread
+                // (for example when a task such as AspNetCompiler runs on an STA thread), so wait
+                // on each EOF event individually while honoring the overall timeout.
+                int eofTimeoutMs = eofTimeoutSec * 1000;
+                var eofTimer = Stopwatch.StartNew();
+                bool allEOFReceived = _standardOutputEOF.WaitOne(eofTimeoutMs);
+                if (allEOFReceived)
+                {
+                    int remainingMs = (int)Math.Max(0, eofTimeoutMs - eofTimer.ElapsedMilliseconds);
+                    allEOFReceived = _standardErrorEOF.WaitOne(remainingMs);
+                }
+
                 if (!allEOFReceived)
                 {
                     // Timeout: a grandchild process likely still holds the pipe open.


### PR DESCRIPTION
## Summary
Fixes an `MSB4018` crash where `ToolTask`-derived tasks fail with:

```
System.NotSupportedException: WaitAll for multiple handles on a STA thread is not supported.
   at System.Threading.WaitHandle.WaitAll(...)
   at Microsoft.Build.Utilities.ToolTask.WaitForProcessExit(Process proc)
```

This reproduces with tasks that execute on an **STA thread** (e.g. `AspNetCompiler` via `Microsoft.Web.Publishing.AspNetCompileMerge.targets`).

## Root cause
`WaitForProcessExit` (under the `Wave18_6` change wave) waited for both the stdout and stderr EOF events with:

```csharp
WaitHandle[] eofEvents = [_standardOutputEOF, _standardErrorEOF];
bool allEOFReceived = WaitHandle.WaitAll(eofEvents, TimeSpan.FromSeconds(eofTimeoutSec));
```

`WaitHandle.WaitAll` over **multiple** handles is not supported on STA threads and throws `NotSupportedException`, surfacing to the user as `MSB4018`.

## Fix
Replace the two stdout/stderr `ManualResetEvent`s with a single `CountdownEvent` initialized to a count of 2 (one per stream). Each stream signals it once when its `AsyncStreamReader` reaches EOF (`Data=null`), and `WaitForProcessExit` awaits it with `CountdownEvent.Wait`, which is STA-safe (it relies on a single-handle wait rather than `WaitAll` over multiple handles):

```csharp
// init (under Wave18_6 guard)
_eofCountdown = new CountdownEvent(2); // one count each for stdout and stderr EOF

// EOF callback (once per stream)
lock (_eventCloseLock)
{
    if (!_eventsDisposed && _eofCountdown is { IsSet: false })
    {
        _eofCountdown.Signal();
    }
}

// wait
bool allEOFReceived = _eofCountdown.Wait(TimeSpan.FromSeconds(eofTimeoutSec));
```

The success/timeout semantics are unchanged: `allEOFReceived` is `true` only when both streams reached EOF within the timeout; on timeout the task still drains partial output and logs `ToolTask.PipeEOFTimeout`. Signaling and disposal remain serialized by `_eventCloseLock`, and the `IsSet` guard prevents over-signaling.

## Validation
- `Microsoft.Build.Utilities` builds clean (0 warnings, 0 errors).
- Reviewed for races: `CountdownEvent.Signal()` cannot throw (serialized + `IsSet` guarded), no spurious 30s timeout on normal exit, no deadlock, and the Wave18_6-disabled path leaves `_eofCountdown` null and untouched.