### PR TITLE
Quote --ignore-exit-code values so the quarantine pipeline does not shell-split on Unix

### DIFF
--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -41,7 +41,7 @@
          an actual infrastructure problem. The per-test signal is the published TRX, not exit code.
          The "8;2" value MUST stay quoted: arcade runs the test command through <Exec>, which on
          non-Windows executes via /bin/sh, where an unquoted ';' is a command separator (it would
-         split the command and the trailing "2 --results-directory ..." fragment fails with code 127). -->
+         split the command and the trailing "2" + remaining arguments fragment fails with code 127). -->
     <XunitOptions Condition="'$(RunQuarantinedTests)' == 'true'">$(XunitOptions) --filter-trait Category=failing --ignore-exit-code "8;2"</XunitOptions>
     
     <!-- Enable code coverage -->

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -38,8 +38,11 @@
     <XunitOptions Condition="'$(RunQuarantinedTests)' != 'true'">$(XunitOptions) --filter-not-trait Category=failing</XunitOptions>
     <!-- Quarantined tests are expected to be flaky, and most assemblies contain zero quarantined
          tests; treat exit code 8 (zero tests ran) and 2 (test failures) as success so a red run means
-         an actual infrastructure problem. The per-test signal is the published TRX, not exit code. -->
-    <XunitOptions Condition="'$(RunQuarantinedTests)' == 'true'">$(XunitOptions) --filter-trait Category=failing --ignore-exit-code 8;2</XunitOptions>
+         an actual infrastructure problem. The per-test signal is the published TRX, not exit code.
+         The "8;2" value MUST stay quoted: arcade runs the test command through <Exec>, which on
+         non-Windows executes via /bin/sh, where an unquoted ';' is a command separator (it would
+         split the command and the trailing "2 --results-directory ..." fragment fails with code 127). -->
+    <XunitOptions Condition="'$(RunQuarantinedTests)' == 'true'">$(XunitOptions) --filter-trait Category=failing --ignore-exit-code "8;2"</XunitOptions>
     
     <!-- Enable code coverage -->
     <!-- There are separate runsettings files for Windows and non-Windows. -->


### PR DESCRIPTION
## Problem

The scheduled quarantine pipeline ([`azure-pipelines/quarantine.yml`](https://dev.azure.com/dnceng-public/public/_build?definitionId=344), definition 344) failed on its first real run — [build 1445333](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1445333) — on the Linux and macOS legs with:

```
error MSB3073: The command "echo ... --ignore-exit-code 8;2 --results-directory ..." exited with code 127.
```

## Root cause

`RunQuarantinedTests=true` adds `--ignore-exit-code 8;2` to the xUnit v3 test command (so a quarantined-only run treats exit code `8` = zero tests ran and `2` = test failures as success — the per-test signal is the published TRX, not the exit code).

Arcade's `XUnitV3.Runner.targets` assembles the command and runs it via `<Exec>`, which on non-Windows executes through `/bin/sh`. The **unquoted `;`** was interpreted by the shell as a command separator, splitting the line into:

1. `<runner> ... --ignore-exit-code 8`
2. `2 --results-directory ...`

The second fragment starts with the token `2`, which is not a command, so the step failed with exit code **127** (command not found).

## Fix

Quote the value: `--ignore-exit-code "8;2"`. This keeps `8;2` as a single argument on both `/bin/sh` and `cmd`. `8;2` is the correct semicolon-separated multi-code syntax for Microsoft.Testing.Platform; only the shell-level quoting was missing.

Verified the parse through `/bin/sh`:
- unquoted -> `2: command not found`
- quoted -> `--ignore-exit-code` receives a single arg `8;2`

Windows was unaffected (`cmd` does not treat `;` as a command separator), but the quoted form is correct on both.

Follow-up to #13915.
