### PR TITLE
Respect MSBUILDCOPYTASKPARALLELISM for Copy parallelism

### DIFF
--- a/src/Framework.UnitTests/Traits_Tests.cs
+++ b/src/Framework.UnitTests/Traits_Tests.cs
@@ -1,0 +1,33 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.UnitTests.Shared;
+using Shouldly;
+using Xunit;
+
+#nullable disable
+
+namespace Microsoft.Build.UnitTests
+{
+    public class Traits_Tests
+    {
+        [Theory]
+        [InlineData(null, -1)]
+        [InlineData("", -1)]
+        [InlineData("0", 0)]
+        [InlineData("-1", -1)]
+        [InlineData("garbage", -1)]
+        [InlineData("1", 1)]
+        [InlineData("16", 16)]
+        public void CopyTaskParallelismReadsIntegerOverride(string value, int expectedParallelism)
+        {
+            using TestEnvironment env = TestEnvironment.Create();
+            env.SetEnvironmentVariable("MSBUILDCOPYTASKPARALLELISM", value);
+
+            Traits traits = new Traits();
+
+            traits.CopyTaskParallelism.ShouldBe(expectedParallelism);
+        }
+    }
+}

--- a/src/Tasks.UnitTests/Copy_Tests.cs
+++ b/src/Tasks.UnitTests/Copy_Tests.cs
@@ -118,6 +118,30 @@ namespace Microsoft.Build.UnitTests
             Environment.SetEnvironmentVariable(Copy.AlwaysRetryEnvVar, _alwaysRetry);
         }
 
+        [Theory]
+        [InlineData("1")]
+        [InlineData("16")]
+        public void CopyTaskParallelismEnvironmentVariableControlsChildProcessCopy(string parallelism)
+        {
+            using TestEnvironment env = TestEnvironment.Create(_testOutputHelper);
+            env.SetEnvironmentVariable("MSBUILDCOPYTASKPARALLELISM", parallelism);
+
+            env.CreateFile("source1.txt", "source1");
+            env.CreateFile("source2.txt", "source2");
+            TransientTestFile project = env.CreateFile("copy.proj",
+                @"<Project>
+  <Target Name=""CopyFiles"">
+    <Copy SourceFiles=""source1.txt;source2.txt"" DestinationFiles=""destination1.txt;destination2.txt"" />
+  </Target>
+</Project>");
+
+            string output = RunnerUtilities.ExecBootstrapedMSBuild($"\"{project.Path}\" -nologo -t:CopyFiles -v:diag -nr:false", out bool success, outputHelper: _testOutputHelper, timeoutMilliseconds: 120_000);
+
+            success.ShouldBeTrue(output);
+            // Verify the override took effect via the diagnostic log.
+            output.ShouldContain($"Copy parallelism = {parallelism} (overridden)");
+        }
+
         [Fact]
         public void CopyWithNoInput()
         {

--- a/src/Tasks/Copy.cs
+++ b/src/Tasks/Copy.cs
@@ -42,9 +42,15 @@ namespace Microsoft.Build.Tasks
         // threads at the advantage of performing file copies more quickly in the kernel - we must avoid
         // taking up the whole threadpool esp. when hosted in Visual Studio. IOW we use a specific number
         // instead of int.MaxValue.
-        private static readonly int DefaultCopyParallelism = NativeMethodsShared.GetLogicalCoreCount() > 4 ? 6 : 4;
+        // Computed once at process start from Traits.Instance.CopyTaskParallelism.
+        // > 0 = explicit override; < 0 (default) or 0 = use empirical heuristic below.
+        private static readonly int DefaultCopyParallelism =
+            Traits.Instance.CopyTaskParallelism > 0
+                ? Traits.Instance.CopyTaskParallelism
+                : NativeMethodsShared.GetLogicalCoreCount() > 4 ? 6 : 4;
         private static Thread[] copyThreads;
         private static AutoResetEvent[] copyThreadSignals;
+        private static int s_loggedDefaultCopyParallelism;
         private AutoResetEvent _signalCopyTasksCompleted;
 
         private static ConcurrentQueue<Action> _copyActionQueue = new ConcurrentQueue<Action>();
@@ -435,6 +441,8 @@ namespace Microsoft.Build.Tasks
             CopyFileWithState copyFile,
             bool copyInParallel)
         {
+            LogDefaultCopyParallelism();
+
             // If there are no source files then just return success.
             if (IsSourceSetEmpty())
             {
@@ -1158,10 +1166,18 @@ namespace Microsoft.Build.Tasks
             return source.Path == destination.Path;
         }
 
+        private void LogDefaultCopyParallelism()
+        {
+            if (Interlocked.Exchange(ref s_loggedDefaultCopyParallelism, 1) == 0)
+            {
+                bool overridden = Traits.Instance.CopyTaskParallelism > 0;
+                Log.LogMessage(MessageImportance.Low, "Copy parallelism = {0}{1}", DefaultCopyParallelism, overridden ? " (overridden)" : "");
+            }
+        }
+
         private static bool GetParallelismFromEnvironment()
         {
-            int parallelism = Traits.Instance.CopyTaskParallelism;
-            return parallelism != 1;
+            return Traits.Instance.CopyTaskParallelism != 1;
         }
     }
 }


### PR DESCRIPTION
🚧 Draft for discussion

## Motivation

I'm hoping to merge this so I can run it on our perf bench with different core counts to see if it moves the numbers for MT since we've effectively lowered the max-parallelization of copies as before we would have potentially have copies spread out over multiple processes.

## Mechanism

I noticed we already do have some override already, but it's not fully being used, so this PR could hopefully bring it full circle and then I could try runs on PerfStar with different counts just so see if there is any impact on OC.