### PR TITLE
Flaky-test: fix duplicate-issue bug by switching dedup key to a visible code-block key

### DIFF
--- a/.github/workflows/flaky-test-detector.agent.md
+++ b/.github/workflows/flaky-test-detector.agent.md
@@ -220,7 +220,7 @@ bug — so be conservative and treat the following as **likely regression, NOT f
 - failures are clustered in time (recent `firstSeen`, not spread sporadically across the window).
 
 For a **likely regression**: do **not** create a `flaky-test` issue, do **not** add the
-`<!-- flaky-test-id: -->` marker, and do **not** edit/quarantine the test (quarantining would mask the
+`flaky-test-id` key, and do **not** edit/quarantine the test (quarantining would mask the
 bug). If an open related issue already exists (`relatedIssues`), post one `add_comment` noting the test
 now looks like a **possible regression needing human investigation**. Otherwise emit a `noop` line in
 your report flagging it for human triage. Then move on.
@@ -232,17 +232,29 @@ proceed to track and quarantine it.
 ## Step 4 — File or update the tracking issue
 
 For each likely-flake test to track, first establish whether an issue already exists. Use
-`relatedIssues` from the JSON **and** explicitly search issues for the stable marker (open and
-recently-closed), e.g. via the `github` tools or:
+`relatedIssues` from the JSON **and** explicitly search issues (open and recently-closed) for the
+test's fully-qualified name. Match on **both** the visible `flaky-test-id` body key **and** the title,
+and treat a hit in **either** as "already exists" — so that a human re-titling the issue (or editing
+the body) cannot by itself cause a duplicate:
 
 ```bash
-gh issue list --repo dotnet/msbuild --state all --search '"<!-- flaky-test-id: <testName> -->" in:body' --json number,state,title
+# Visible body key (a plain token, so — unlike a hidden HTML comment — it survives gh-aw sanitization).
+gh issue list --repo dotnet/msbuild --state all --search '"flaky-test-id: <testName>" in:body' --json number,state,title
+# Plus the fully-qualified name in the title — restricted to flaky-test-labeled issues so an
+# unrelated issue that merely mentions the method name cannot suppress a real new flake.
+gh issue list --repo dotnet/msbuild --state all --label flaky-test --search '"<testName>" in:title' --json number,state,title
 ```
 
-Older tracking issues may **predate the marker convention** and have none, so if the marker search
-finds nothing, also fall back to a **title search** for the test's short name before concluding no
-issue exists (e.g. `gh issue list --repo dotnet/msbuild --state all --search '<shortName> in:title'`)
-— this avoids re-filing a duplicate of a pre-existing issue. (Note: the sandboxed `gh` may print a
+A raw search hit is only a **candidate**: GitHub full-text search tokenizes `.`/`_` and matches
+prefixes, so confirm each candidate genuinely covers **this** test before skipping it — the body must
+contain `flaky-test-id: <testName>` as a **complete line** (an exact whole-line match, so a longer
+name such as `<testName>Extended` does **not** count), **or** the title must be exactly the
+fully-qualified `<testName>`. Discard candidates that only match as a substring/prefix.
+
+Older tracking issues may **predate this convention** and contain neither — so if both searches come
+up empty, also fall back to a **short-name title search** before concluding no issue exists (e.g.
+`gh issue list --repo dotnet/msbuild --state all --search '<shortName> in:title'`); this avoids
+re-filing a duplicate of a pre-existing hand-filed issue. (Note: the sandboxed `gh` may print a
 benign `Malformed version:` warning to stderr; it is harmless — judge success by the JSON on stdout
 and the exit code, not by that line.)
 
@@ -273,13 +285,17 @@ and the exit code, not by that line.)
   quarantine this test this run (see Step 5 — it becomes quarantine-eligible next run). Just file it:
   - Title: the test's short name (the `[Flaky Test] ` prefix is added automatically), e.g.
     `Microsoft.Build.Engine.UnitTests.SomeClass.SomeMethod`.
-  - Body **must** start with the hidden stable marker on its own line, copied **exactly** (the
-    `-id` is required — `<!-- flaky-test: ... -->` without `-id` will not be found by future runs and
-    causes duplicate issues):
+  - Body **must** include the visible **flaky-test key** so future runs can de-duplicate. Unlike the
+    old hidden `<!-- ... -->` marker (which gh-aw's output sanitizer strips, causing duplicate issues),
+    a **visible** token survives. Put it near the top of the body as a bold label followed by a fenced
+    code block — the code block signals "machine key, do not edit" — containing **exactly** one line
+    with the normalized `testName` (the format the scan engine searches for, verbatim):
+    ````
+    **Flaky-test key** (automated de-duplication — do not edit):
+    ```text
+    flaky-test-id: <testName>
     ```
-    <!-- flaky-test-id: <testName> -->
-    ```
-    using the normalized `testName` exactly.
+    ````
   - Then include an evidence summary: distinct sources (PRs + rolling builds), PR numbers, rolling
     build ids, affected legs/TFMs, assemblies, first/last seen, a representative error message, and
     links to `sampleBuildUrl`. **Render every rolling build id as a markdown link** to its AzDO build
@@ -312,15 +328,16 @@ of these hold:
 - It is **not already covered by an open `flaky-test` PR** (this is the primary cross-run dedup — a
   previous run's combined PR may still be open and unmerged, and its quarantines live on **that PR's
   branch, not `main`**, so they will not show up in your fresh `main` checkout). Fetch the bodies of all
-  open `flaky-test` PRs **once** up front and **exact-string-match** each candidate's marker locally —
-  do **not** rely on GitHub's fuzzy `--search ... in:body`, which strips the HTML-comment punctuation and
-  can miss/over-match the marker:
+  open `flaky-test` PRs **once** up front and **match each candidate locally** against the PR title and
+  body — local matching avoids GitHub search-index latency for very recently opened PRs:
   ```bash
   # One call; there are only ever a handful of open flaky-test PRs. Keep the JSON for Step 8.
-  gh pr list --repo dotnet/msbuild --state open --label flaky-test --json number,body --limit 100 > open-flaky-prs.json
+  gh pr list --repo dotnet/msbuild --state open --label flaky-test --json number,title,body --limit 100 > open-flaky-prs.json
   ```
-  Treat a candidate as covered if the literal string `<!-- flaky-test-id: <testName> -->` (normalized
-  `testName`, exact) appears in any open PR body. Skip every covered candidate.
+  Treat a candidate as covered if `flaky-test-id: <testName>` (the visible key, normalized `testName`)
+  appears as a **complete line** in any open PR body — a whole-line match, so a longer test name such
+  as `<testName>Extended` does **not** spuriously cover `<testName>` — **or** the normalized
+  `<testName>` appears in a PR title. Skip every covered candidate.
 
   **An empty array (`[]`) is the normal, expected result** — most runs have **no** flaky-test PR in
   flight, which simply means there are no cross-run duplicates to skip. Do **not** treat `[]` as a tool
@@ -454,20 +471,25 @@ First confirm the diff is **limited and correct**:
    **test source file for one of the tests you selected this run**. If **any** path is under `.github/`,
    is a root manifest, is product (non-test) code, or is a `.cs` file you did not intend to edit,
    **revert that change** — the PR must contain only the intended `[ActiveIssue]` add/remove edits.
-2. Re-fetch the open `flaky-test` PR bodies (re-run the Step 5 `gh pr list ... --label flaky-test`
-   command) and exact-string-match each remaining test's marker against them again — a concurrent run
-   may have opened a combined PR since Step 5. Revert and drop any test now covered by an open PR.
+2. Re-fetch the open `flaky-test` PRs (re-run the Step 5 `gh pr list ... --label flaky-test`
+   command) and match each remaining test's `flaky-test-id` key against their bodies (as a complete
+   line, not a substring) — or its `<testName>` against their titles — again; a concurrent run may
+   have opened a combined PR since Step 5. Revert and drop any test now covered by an open PR.
 
 If, after this, no edits remain, open **no** PR and emit a `noop`. Otherwise open **exactly one**
 ready-for-review PR (`create_pull_request`, base `main`, label `flaky-test`) containing all accumulated edits:
 
 - Title: e.g. `Quarantine/un-quarantine <N> flaky tests` (the `[Flaky Test] ` prefix is added
   automatically); summarize the mix of actions.
-- Body **must**, for **every** included test, contain its marker on its own line so future runs detect the
-  in-flight PR:
+- Body **must**, for **every** included test, contain its visible **flaky-test key** so future runs
+  detect the in-flight PR (a visible token survives gh-aw sanitization; the old hidden `<!-- -->` marker
+  did not). Render it in that test's section as a bold label followed by a fenced code block:
+  ````
+  **Flaky-test key** (automated de-duplication — do not edit):
+  ```text
+  flaky-test-id: <testName>
   ```
-  <!-- flaky-test-id: <testName> -->
-  ```
+  ````
 - Then, per test, a short section stating whether it was a **quarantine (6a)** or an **un-quarantine
   (6b)**, the affected sources/evidence, and the issue reference:
   - **Quarantine:** `Tracked by #<issue>` (must **not** auto-close — the issue stays open until a real

--- a/.github/workflows/flaky-test-fixer.agent.md
+++ b/.github/workflows/flaky-test-fixer.agent.md
@@ -186,10 +186,19 @@ name (`Namespace.Class.Method`) from its source file to match it against `flakyT
 From `flakyTests`, build the set of tests to attempt a fix on. A still-flaking quarantined test `T`
 qualifies **only if all** of these hold:
 
-- **It is genuinely quarantined now.** `T` appears in the Step 1 `grep` with a live `[ActiveIssue]`
-  on `main`, and that attribute's issue number maps to an issue that is **currently OPEN** (verify
-  with `gh issue view <NNNN> --repo dotnet/msbuild --json state`). If the issue is closed, skip `T`
-  (a human likely already handled it; you must not reference a closed issue).
+- **It is genuinely quarantined now, and the tracking issue does not already explain it as a product
+  change.** `T` appears in the Step 1 `grep` with a live `[ActiveIssue]` on `main`, and that
+  attribute's issue number maps to an issue that is **currently OPEN**. Read the issue's **state,
+  title, body, and most recent comments** (`gh issue view <NNNN> --repo dotnet/msbuild --json
+  state,title,body,comments`), not just its state. If the issue is closed, skip `T` (a human likely
+  already handled it; you must not reference a closed issue). **Critically, treat the maintainer's
+  written diagnosis as authoritative**: if the body or a comment attributes the failure to a **product
+  behavior change**, a specific **product PR/commit**, or says the new behavior is **expected / "by
+  design" / "probably ok"** (i.e. the test — not the product — is what is now wrong), then this is
+  **not** a test-only-fixable flake — **skip `T` and leave it quarantined** for a human. Authoring a
+  test-assertion change here would silently **mask a documented product regression**, which is
+  forbidden. (Example: an issue saying "PR #NNNN regresses this test because X is no longer Y" means
+  the fix, if any, belongs in product code or human judgement — never in this workflow.)
 - **It has enough over-time history.** `distinctSources >= 2` **and** the failures span **at least 2
   distinct days** (look at `firstSeen`/`lastSeen` and the spread). For a flake seen on only **one**
   OS family (all `legs`/`tfms` on a single platform), require **≥ 3 distinct days** — a single
@@ -203,6 +212,15 @@ qualifies **only if all** of these hold:
   unrelated hashes, or the dominant one is **timeout-only / has no usable stack / looks like
   infrastructure** (agent lost, disk full, port in use, OOM) — those are not test-logic bugs you can
   fix here.
+- **It actually looks nondeterministic — not a 100%-consistent break.** A test that fails on
+  **essentially every** def-344 run with **no** interleaved greens (a deterministic ~100% failure) is
+  almost never *flaky*; it is far more likely a **real regression** (often a product behavior change)
+  that merely got quarantined. Only treat such a test as fixable here if the dominant signature
+  **unambiguously matches a known test-side nondeterminism pattern** (an un-awaited task/race, an
+  ordering/culture/temp-path/port-collision/shared-state leak — see Step 4). If a near-100% failure has
+  **no** such nondeterminism story (e.g. a plain assertion that the produced output no longer contains
+  something), **skip `T` and leave it quarantined** — re-deriving a "test-only" cause for a
+  consistent break risks papering over a product regression.
 - **It is not trending green.** `T` is **not** in `passedTests` with a strong recent green window
   (e.g. `distinctBuilds >= 3` over recent days). A test both failing and passing a lot is unstable;
   prefer to leave it for the detector to keep watching. (`passedTests` green counts are

--- a/.github/workflows/flaky-test-fixer.agent.md
+++ b/.github/workflows/flaky-test-fixer.agent.md
@@ -214,9 +214,12 @@ qualifies **only if all** of these hold:
   ```bash
   gh pr list --repo dotnet/msbuild --state open --label flaky-test --json number,title,body,files --limit 100 > open-flaky-prs.json
   ```
-  Skip `T` if **any** of these appears in an open PR: the exact marker `<!-- flaky-test-id: <testName> -->`
-  (normalized `testName`); the string `#<NNNN>` referencing `T`'s tracking issue; or the **test
-  source file** you would edit (a path under `files`). An empty array (`[]`) is the **normal,
+  Skip `T` if **any** of these appears in an open PR: the visible key `flaky-test-id: <testName>`
+  (normalized `testName`) as a **complete line** in the body — a whole-line match, so a longer name
+  such as `<testName>Extended` does **not** spuriously cover `<testName>` — **or** the normalized
+  `<testName>` in the title; the string
+  `#<NNNN>` referencing `T`'s tracking issue; or the **test source file** you would edit (a path under
+  `files`). An empty array (`[]`) is the **normal,
   expected** result — most runs have no flaky-test PR in flight; do not treat `[]` as a failure or
   re-run the command to "double-check".
 
@@ -386,14 +389,18 @@ Each PR:
 
 - **Title:** the test's short name (the `[Flaky Test Fix] ` prefix is added automatically), e.g.
   `Microsoft.Build.Engine.UnitTests.SomeClass.SomeMethod`.
-- **Body must** start with the stable marker on its own line (so the detector and future fixer runs
-  detect this in-flight PR and don't double-act on the test), copied exactly with the normalized
-  `testName` (add the third line **only** when you removed the `[ActiveIssue]` via Step 5b):
+- **Body must** include the visible **flaky-test key** near the top (so the detector and future fixer
+  runs detect this in-flight PR and don't double-act on the test). A visible token survives gh-aw's
+  output sanitization; the old hidden `<!-- -->` markers did not. Render it as a bold label followed by
+  a fenced code block, using the normalized `testName` exactly:
+  ````
+  **Flaky-test key** (automated de-duplication — do not edit):
+  ```text
+  flaky-test-id: <testName>
   ```
-  <!-- flaky-test-id: <testName> -->
-  <!-- flaky-test-fix -->
-  <!-- flaky-test-unquarantine -->
-  ```
+  ````
+  If you removed the `[ActiveIssue]` via Step 5b, state that explicitly in the PR body prose (see
+  below) — do not rely on any hidden marker to convey it.
 - Then:
   - **Root cause:** the concrete test-only nondeterminism you identified.
   - **Evidence:** the def-344 data that supports it — the dominant signature (message + the key stack

--- a/.github/workflows/scripts/Get-FlakyTests.ps1
+++ b/.github/workflows/scripts/Get-FlakyTests.ps1
@@ -654,7 +654,7 @@ if ($flakyTests.Count -gt 0 -and $ghAvailable) {
     Write-Log "`n=== Step 4: Cross-referencing existing flaky-test issues ===" "Cyan"
     $savedPager = $env:GH_PAGER; $env:GH_PAGER = ""
     foreach ($test in $flakyTests) {
-        # Prefer the stable hidden marker, then fall back to the short test name.
+        # Prefer the stable visible key, then fall back to the short test name.
         $found = @()
         foreach ($q in @("flaky-test-id: $($test.TestName)", (($test.TestName -split '\.')[-1]))) {
             if ($q.Length -lt 5) { continue }

--- a/.github/workflows/scripts/Get-FlakyTests.ps1
+++ b/.github/workflows/scripts/Get-FlakyTests.ps1
@@ -658,8 +658,11 @@ if ($flakyTests.Count -gt 0 -and $ghAvailable) {
         $found = @()
         foreach ($q in @("flaky-test-id: $($test.TestName)", (($test.TestName -split '\.')[-1]))) {
             if ($q.Length -lt 5) { continue }
+            # Wrap the value in double quotes so GitHub treats it as a literal phrase; otherwise the
+            # colon in "flaky-test-id:" is parsed as a (nonexistent) search qualifier and ignored.
+            $searchExpr = '"' + $q + '" in:body,title'
             try {
-                $json = gh issue list --repo $Repo --state all --search "$q in:body,title" --limit 5 --json number,title,state 2>$null
+                $json = gh issue list --repo $Repo --state all --search $searchExpr --limit 5 --json number,title,state 2>$null
                 if ($json) { $found += ($json | ConvertFrom-Json) }
             }
             catch { }


### PR DESCRIPTION
## Problem

The flaky-test detector and auto-fixer used a **hidden HTML comment** marker (`<!-- flaky-test-id: <FQN> -->`) in filed issue/PR bodies as the cross-run de-duplication key. gh-aw's safe-output sanitizer **strips agent-authored HTML comments**, so the marker never survived in the published body. The dedup search therefore always came up empty and the same flaky test was re-filed as a brand-new issue on consecutive daily runs (e.g. #13922 / #13948 / #13949 / #13950 / #13951 were duplicates of the canonical Jun-3 issues).

This was proven empirically: the bot-authored `flaky-test-id` comment is absent from every filed body, while gh-aw's *own* `gh-aw-workflow-id` footer comment survives (it is appended **after** sanitization).

## Fix

Switch the dedup key from a hidden comment to a **visible** `flaky-test-id: <testName>` token, rendered in a fenced code block in every filed issue body and every per-test PR section. A visible token survives sanitization, and it matches what `Get-FlakyTests.ps1` **already** searches for (`--search "flaky-test-id: <name> in:body,title"`), so no scan-engine logic change is required.

De-dup rule at every site (issue filing, in-flight-PR checks, fixer selection, pre-PR re-check):
- match `flaky-test-id: <testName>` as a **complete line** (not a substring — avoids `MyTest` spuriously matching `MyTestExtended`) in the body, **or**
- match the normalized fully-qualified `<testName>` in the title,
- in **either** field, so a human editing one field cannot reintroduce a duplicate.

Also:
- Scope the issue **title** fallback search to `flaky-test`-labeled issues, so an unrelated issue that merely mentions a method name can't suppress a real new flake.
- Drop two hidden status markers (`flaky-test-fix` / `flaky-test-unquarantine`) that nothing ever read.

## Scope

Instruction-only (`.md` bodies are runtime-imported) plus a one-line comment in `Get-FlakyTests.ps1` — **no frontmatter change, so no lock recompile**. The duplicate issues this addresses were already closed manually.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>