### PR TITLE
Fix internal error 'Invalid node id specified' from out-of-proc node teardown race (#12438)

### DIFF
--- a/src/Build.UnitTests/BackEnd/NodeManager_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/NodeManager_Tests.cs
@@ -1,0 +1,140 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Reflection;
+using Microsoft.Build.BackEnd;
+using Shouldly;
+using Xunit;
+
+#nullable disable
+
+namespace Microsoft.Build.UnitTests.BackEnd
+{
+    /// <summary>
+    /// Unit tests for <see cref="NodeManager"/> node-lifecycle bookkeeping.
+    /// These lock in the teardown-serialization contract introduced to fix dotnet/msbuild#12438:
+    /// routing a <see cref="NodeShutdown"/> packet must NOT remove the node from the manager's
+    /// node-to-provider map (doing so on the pipe read/IO thread races the scheduler's SendData
+    /// and throws "Invalid node id specified"). Removal happens only via the serialized
+    /// <see cref="NodeManager.RemoveNode"/>, called from BuildManager.HandleNodeShutdown under the
+    /// build's sync lock.
+    /// </summary>
+    public class NodeManager_Tests
+    {
+        /// <summary>
+        /// <see cref="NodeManager.RemoveNode"/> must drop both the owning provider's node context
+        /// (via <see cref="INodeProvider.RemoveNodeContext"/>) and the manager's own mapping.
+        /// </summary>
+        [Fact]
+        public void RemoveNode_RemovesProviderMappingAndContext()
+        {
+            NodeManager manager = CreateNodeManager();
+            StubNodeProvider provider = new();
+            const int NodeId = 2;
+            MapNodeToProvider(manager, NodeId, provider);
+
+            IsNodeMapped(manager, NodeId).ShouldBeTrue();
+
+            manager.RemoveNode(NodeId);
+
+            provider.RemovedContextNode.ShouldBe(NodeId);
+            IsNodeMapped(manager, NodeId).ShouldBeFalse();
+        }
+
+        /// <summary>
+        /// Regression for dotnet/msbuild#12438: routing a NodeShutdown must still deliver the packet
+        /// to the handler but must leave the node mapped. Removing it here (as the pre-fix code did)
+        /// races a concurrent scheduler SendData on the work-queue thread.
+        /// </summary>
+        [Fact]
+        public void RoutePacket_NodeShutdown_DoesNotRemoveMapping()
+        {
+            NodeManager manager = CreateNodeManager();
+            StubPacketHandler handler = new();
+            manager.RegisterPacketHandler(NodePacketType.NodeShutdown, NodeShutdown.FactoryForDeserialization, handler);
+
+            StubNodeProvider provider = new();
+            const int NodeId = 2;
+            MapNodeToProvider(manager, NodeId, provider);
+
+            manager.RoutePacket(NodeId, new NodeShutdown(NodeShutdownReason.ConnectionFailed));
+
+            handler.ReceivedNode.ShouldBe(NodeId);
+            IsNodeMapped(manager, NodeId).ShouldBeTrue();
+        }
+
+        /// <summary>
+        /// <see cref="NodeManager.RemoveNode"/> is idempotent: removing an unknown / already-removed
+        /// node is a no-op, so a duplicate shutdown never throws.
+        /// </summary>
+        [Fact]
+        public void RemoveNode_UnknownNode_IsNoOp()
+        {
+            NodeManager manager = CreateNodeManager();
+
+            Should.NotThrow(() => manager.RemoveNode(42));
+        }
+
+        private static NodeManager CreateNodeManager()
+            => (NodeManager)NodeManager.CreateComponent(BuildComponentType.NodeManager);
+
+        private static ConcurrentDictionary<int, INodeProvider> GetNodeIdToProvider(NodeManager manager)
+        {
+            FieldInfo field = typeof(NodeManager).GetField("_nodeIdToProvider", BindingFlags.NonPublic | BindingFlags.Instance);
+            return (ConcurrentDictionary<int, INodeProvider>)field.GetValue(manager);
+        }
+
+        private static void MapNodeToProvider(NodeManager manager, int nodeId, INodeProvider provider)
+            => GetNodeIdToProvider(manager)[nodeId] = provider;
+
+        private static bool IsNodeMapped(NodeManager manager, int nodeId)
+            => GetNodeIdToProvider(manager).ContainsKey(nodeId);
+
+        private sealed class StubNodeProvider : INodeProvider
+        {
+            public int LastSentNode { get; private set; } = -1;
+
+            public int RemovedContextNode { get; private set; } = -1;
+
+            public NodeProviderType ProviderType => NodeProviderType.OutOfProc;
+
+            public int AvailableNodes => 0;
+
+            public IList<NodeInfo> CreateNodes(int nextNodeId, INodePacketFactory packetFactory, Func<NodeInfo, NodeConfiguration> configurationFactory, int numberOfNodesToCreate)
+                => throw new NotImplementedException();
+
+            public void SendData(int node, INodePacket packet) => LastSentNode = node;
+
+            public void RemoveNodeContext(int nodeId) => RemovedContextNode = nodeId;
+
+            public void ShutdownConnectedNodes(bool enableReuse)
+            {
+            }
+
+            public void ShutdownAllNodes()
+            {
+            }
+
+            public IEnumerable<Process> GetProcesses() => Array.Empty<Process>();
+
+            public void InitializeComponent(IBuildComponentHost host)
+            {
+            }
+
+            public void ShutdownComponent()
+            {
+            }
+        }
+
+        private sealed class StubPacketHandler : INodePacketHandler
+        {
+            public int ReceivedNode { get; private set; } = -1;
+
+            public void PacketReceived(int node, INodePacket packet) => ReceivedNode = node;
+        }
+    }
+}

--- a/src/Build.UnitTests/BackEnd/NodeManager_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/NodeManager_Tests.cs
@@ -85,6 +85,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
         private static ConcurrentDictionary<int, INodeProvider> GetNodeIdToProvider(NodeManager manager)
         {
             FieldInfo field = typeof(NodeManager).GetField("_nodeIdToProvider", BindingFlags.NonPublic | BindingFlags.Instance);
+            field.ShouldNotBeNull("NodeManager._nodeIdToProvider field not found; the field may have been renamed.");
             return (ConcurrentDictionary<int, INodeProvider>)field.GetValue(manager);
         }
 

--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -2738,6 +2738,12 @@ namespace Microsoft.Build.Execution
             Assumed.True(_activeNodes.Contains(node), $"Unexpected shutdown from node {node} which shouldn't exist.");
             _activeNodes.Remove(node);
 
+            // Remove the node's provider mapping and context here, on the serialized work-queue thread under
+            // _syncLock, rather than eagerly on the pipe read/IO thread. This guarantees node teardown never
+            // races a concurrent scheduler SendData (which also runs under _syncLock), eliminating the
+            // "Invalid node id specified" / "does not have a provider" internal errors. See dotnet/msbuild#12438.
+            _nodeManager!.RemoveNode(node);
+
             if (shutdownPacket.Reason != NodeShutdownReason.Requested)
             {
                 if (shutdownPacket.Reason == NodeShutdownReason.ConnectionFailed)

--- a/src/Build/BackEnd/Components/Communications/INodeManager.cs
+++ b/src/Build/BackEnd/Components/Communications/INodeManager.cs
@@ -53,6 +53,15 @@ namespace Microsoft.Build.BackEnd
         /// </summary>
         void ClearPerBuildState();
 
+        /// <summary>
+        /// Removes a node from the manager's bookkeeping after it has shut down: drops the node-to-provider
+        /// mapping and the owning provider's node context. This must be called on the BuildManager work-queue
+        /// thread (under its sync lock) in response to a NodeShutdown packet, so that node teardown is serialized
+        /// with scheduling and never races a concurrent SendData. See dotnet/msbuild#12438.
+        /// </summary>
+        /// <param name="nodeId">The node to remove.</param>
+        void RemoveNode(int nodeId);
+
         IEnumerable<Process> GetProcesses();
         #endregion
     }

--- a/src/Build/BackEnd/Components/Communications/INodeProvider.cs
+++ b/src/Build/BackEnd/Components/Communications/INodeProvider.cs
@@ -78,6 +78,14 @@ namespace Microsoft.Build.BackEnd
         void SendData(int node, INodePacket packet);
 
         /// <summary>
+        /// Removes the provider's bookkeeping for a node that has shut down. Called on the serialized
+        /// node-shutdown path (under the BuildManager sync lock) so that context removal does not race a
+        /// concurrent SendData on the read/IO thread. See dotnet/msbuild#12438.
+        /// </summary>
+        /// <param name="nodeId">The node whose context should be removed.</param>
+        void RemoveNodeContext(int nodeId);
+
+        /// <summary>
         /// Shuts down all of the connected, managed nodes.  This call will not return until all nodes are shut down.
         /// </summary>
         /// <param name="enableReuse">Flag indicating if nodes should prepare for reuse.</param>

--- a/src/Build/BackEnd/Components/Communications/NodeManager.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeManager.cs
@@ -346,7 +346,9 @@ namespace Microsoft.Build.BackEnd
 
             foreach (NodeInfo node in nodes)
             {
-                _nodeIdToProvider[node.NodeId] = nodeProvider;
+                // Node ids are unique within a build, so this must be a fresh mapping. Use TryAdd + assert
+                // (rather than the indexer) to preserve the original Dictionary.Add fail-fast on duplicates.
+                Assumed.True(_nodeIdToProvider.TryAdd(node.NodeId, nodeProvider), $"Node {node.NodeId} already has a provider.");
             }
 
             return nodes;

--- a/src/Build/BackEnd/Components/Communications/NodeManager.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeManager.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;
@@ -33,7 +34,12 @@ namespace Microsoft.Build.BackEnd
         /// <summary>
         /// Mapping of manager-produced node IDs to the provider hosting the node.
         /// </summary>
-        private readonly Dictionary<int, INodeProvider> _nodeIdToProvider;
+        /// <remarks>
+        /// Concurrent because it is read off the BuildManager sync lock by senders that run on a
+        /// node's pipe read/IO thread (for example the SDK resolver response handler), while it is
+        /// written under the sync lock by RemoveNode / AttemptCreateNode. See dotnet/msbuild#12438.
+        /// </remarks>
+        private readonly ConcurrentDictionary<int, INodeProvider> _nodeIdToProvider;
 
         /// <summary>
         /// The packet factory used to translate and route packets
@@ -74,7 +80,7 @@ namespace Microsoft.Build.BackEnd
         /// </summary>
         private NodeManager()
         {
-            _nodeIdToProvider = new Dictionary<int, INodeProvider>();
+            _nodeIdToProvider = new ConcurrentDictionary<int, INodeProvider>();
             _packetFactory = new NodePacketFactory();
             _nextNodeId = _inprocNodeId + 1;
         }
@@ -241,11 +247,6 @@ namespace Microsoft.Build.BackEnd
         /// <param name="translator">The translator containing the data from which the packet should be reconstructed.</param>
         public void DeserializeAndRoutePacket(int nodeId, NodePacketType packetType, ITranslator translator)
         {
-            if (packetType == NodePacketType.NodeShutdown)
-            {
-                RemoveNodeFromMapping(nodeId);
-            }
-
             _packetFactory.DeserializeAndRoutePacket(nodeId, packetType, translator);
         }
 
@@ -266,11 +267,6 @@ namespace Microsoft.Build.BackEnd
         /// <param name="packet">The packet to route.</param>
         public void RoutePacket(int nodeId, INodePacket packet)
         {
-            if (packet.Type == NodePacketType.NodeShutdown)
-            {
-                RemoveNodeFromMapping(nodeId);
-            }
-
             _packetFactory.RoutePacket(nodeId, packet);
         }
 
@@ -290,12 +286,28 @@ namespace Microsoft.Build.BackEnd
         /// </summary>
         private void RemoveNodeFromMapping(int nodeId)
         {
-            _nodeIdToProvider.Remove(nodeId);
-            if (_nodeIdToProvider.Count == 0)
+            _nodeIdToProvider.TryRemove(nodeId, out _);
+            if (_nodeIdToProvider.IsEmpty)
             {
                 // The inproc node is always 1 therefore when new nodes are requested we need to start at 2
                 _nextNodeId = _inprocNodeId + 1;
             }
+        }
+
+        /// <summary>
+        /// Removes all bookkeeping for a node that has shut down. Drops the owning provider's node context
+        /// and then the node-to-provider mapping. This runs on the BuildManager work-queue thread (under its
+        /// sync lock) in response to a NodeShutdown packet, which serializes teardown with scheduling so that
+        /// a concurrent SendData can never observe a half-torn-down node. See dotnet/msbuild#12438.
+        /// </summary>
+        public void RemoveNode(int nodeId)
+        {
+            if (_nodeIdToProvider.TryGetValue(nodeId, out INodeProvider? provider))
+            {
+                provider.RemoveNodeContext(nodeId);
+            }
+
+            RemoveNodeFromMapping(nodeId);
         }
 
         /// <summary>
@@ -334,7 +346,7 @@ namespace Microsoft.Build.BackEnd
 
             foreach (NodeInfo node in nodes)
             {
-                _nodeIdToProvider.Add(node.NodeId, nodeProvider);
+                _nodeIdToProvider[node.NodeId] = nodeProvider;
             }
 
             return nodes;

--- a/src/Build/BackEnd/Components/Communications/NodeProviderInProc.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderInProc.cs
@@ -164,6 +164,14 @@ namespace Microsoft.Build.BackEnd
         }
 
         /// <summary>
+        /// No-op for the in-proc provider. The in-proc node's context is removed by its own RoutePacket when
+        /// a NodeShutdown is routed; it is not subject to the out-of-proc teardown race in dotnet/msbuild#12438.
+        /// </summary>
+        public void RemoveNodeContext(int nodeId)
+        {
+        }
+
+        /// <summary>
         /// Causes all connected nodes to be shut down.
         /// </summary>
         /// <param name="enableReuse">Flag indicating if the nodes should prepare for reuse.</param>

--- a/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProc.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProc.cs
@@ -206,6 +206,20 @@ namespace Microsoft.Build.BackEnd
         /// </summary>
         private void NodeContextTerminated(int nodeId)
         {
+            // Intentionally does NOT remove the node context here. Close() runs on the pipe read/IO thread
+            // (outside the BuildManager sync lock), so removing the context here would race a concurrent
+            // scheduler SendData and could throw "Invalid node id specified" (dotnet/msbuild#12438). The
+            // context is instead removed via RemoveNodeContext on the serialized node-shutdown path. The
+            // NodeShutdown packet that drives that path is always routed before Close() is called.
+        }
+
+        /// <summary>
+        /// Removes the node context. Called on the serialized node-shutdown path (BuildManager work-queue
+        /// thread, under its sync lock) via NodeManager.RemoveNode, so it never races a concurrent SendData.
+        /// The pipe has already been disposed by NodeContext.Close. See dotnet/msbuild#12438.
+        /// </summary>
+        public void RemoveNodeContext(int nodeId)
+        {
             _nodeContexts.TryRemove(nodeId, out _);
         }
 

--- a/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcTaskHost.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcTaskHost.cs
@@ -200,6 +200,15 @@ namespace Microsoft.Build.BackEnd
         }
 
         /// <summary>
+        /// No-op for the task host provider. Task host nodes are not registered in the build NodeManager's
+        /// node-to-provider map, so this is never invoked via NodeManager.RemoveNode; task host node contexts
+        /// are torn down by their own shutdown path. Present only to satisfy <see cref="INodeProvider"/>.
+        /// </summary>
+        public void RemoveNodeContext(int nodeId)
+        {
+        }
+
+        /// <summary>
         /// Sends data to the specified task host node.
         /// </summary>
         /// <param name="nodeKey">The task host node key identifying the target node.</param>

--- a/src/Build/BackEnd/Components/Communications/TaskHostNodeManager.cs
+++ b/src/Build/BackEnd/Components/Communications/TaskHostNodeManager.cs
@@ -59,6 +59,14 @@ namespace Microsoft.Build.BackEnd
         }
 
         /// <summary>
+        /// Not used - task host nodes are not tracked in this manager's node-to-provider map.
+        /// </summary>
+        public void RemoveNode(int nodeId)
+        {
+            throw new NotSupportedException("not used");
+        }
+
+        /// <summary>
         /// Shuts down all of the connected managed nodes.
         /// </summary>
         /// <param name="enableReuse">Flag indicating if nodes should prepare for reuse.</param>

--- a/src/Build/BackEnd/Components/Communications/TaskHostNodeManager.cs
+++ b/src/Build/BackEnd/Components/Communications/TaskHostNodeManager.cs
@@ -59,11 +59,12 @@ namespace Microsoft.Build.BackEnd
         }
 
         /// <summary>
-        /// Not used - task host nodes are not tracked in this manager's node-to-provider map.
+        /// Not used - task host nodes are not tracked in this manager's node-to-provider map; their lifetime
+        /// is managed by the build <see cref="NodeManager"/>.
         /// </summary>
         public void RemoveNode(int nodeId)
         {
-            throw new NotSupportedException("not used");
+            throw new NotSupportedException("RemoveNode is not supported on TaskHostNodeManager: task host nodes are not tracked in a node-to-provider map.");
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #12438.

## Symptom

Intermittent internal error during parallel builds (seen in CI and by external users):

```
MSBUILD : error MSB1025: An internal failure occurred while running MSBuild.
Microsoft.Build.Framework.InternalErrorException: MSB0001: Internal MSBuild Error: Invalid node id specified: 2.
   at Microsoft.Build.BackEnd.NodeProviderOutOfProc.SendData(Int32 nodeId, INodePacket packet)
   at Microsoft.Build.BackEnd.NodeManager.SendData(Int32 node, INodePacket packet)
   at Microsoft.Build.Execution.BuildManager.PerformSchedulingActions(IEnumerable`1 responses)
   at Microsoft.Build.Execution.BuildManager.ProcessPacket(Int32 node, INodePacket packet)
```

It sometimes manifests instead as `Node N does not have a provider` or the graceful `MSB4166 Child node "N" exited prematurely`.

## Root cause — a node-teardown race

When an out-of-proc worker node dies/disconnects mid-build, its pipe **read/IO thread** tears the node down **outside `BuildManager._syncLock`**:

- `NodeManager.RoutePacket` / `DeserializeAndRoutePacket` → `RemoveNodeFromMapping` removes it from `_nodeIdToProvider`, and
- `NodeContext.Close` → `NodeContextTerminated` removes it from `NodeProviderOutOfProc._nodeContexts`.

Meanwhile the scheduler, on the single work-queue thread **under `_syncLock`**, calls `NodeManager.SendData(node)` → `provider.SendData` → `_nodeContexts.ContainsKey(...)`. The authoritative "node is gone" signal (`NodeShutdown` → `HandleNodeShutdown`, which sets `_shuttingDown` and aborts) is only processed *later* on the serialized work queue. So there is a window in which the scheduler routes work to a node whose context/mapping the read thread just removed → the internal error. Whether you get the internal error vs. the graceful `MSB4166` is pure timing.

This is a long-standing latent race (present since the multiproc engine's original design); recent IPC refactors and oversubscribed CI agents raised its probability enough to surface it. It reproduces only with out-of-proc nodes — which is why `-m:1` (and, less reliably, `-nr:false`) work around it.

## Fix — serialize node teardown through the work queue

Move all out-of-proc node-map removal onto the work-queue thread under `_syncLock`, driven by the `NodeShutdown` packet that `HandleNodeShutdown` already processes. The read/IO thread now only routes the `NodeShutdown` and disposes its own pipe — it no longer mutates the maps.

- `NodeManager.RoutePacket` / `DeserializeAndRoutePacket` no longer call `RemoveNodeFromMapping`.
- New `NodeManager.RemoveNode(nodeId)` (drops the provider context via `INodeProvider.RemoveNodeContext`, then the mapping) is called from `BuildManager.HandleNodeShutdown` under `_syncLock`.
- `NodeProviderOutOfProc.NodeContextTerminated` is now a no-op; removal moves to `RemoveNodeContext`.
- `NodeManager._nodeIdToProvider` becomes a `ConcurrentDictionary` — it is read **off** the sync lock by the SDK-resolver response path (`MainNodeSdkResolverService.PacketReceived` runs synchronously on a node's read/IO thread), so the non-concurrent `Dictionary` was a latent data race independent of this fix.

### No new lock contention

The read/IO thread stays lock-free (it only `Post`s the `NodeShutdown` and disposes its pipe). The two O(1) map removals relocate into `HandleNodeShutdown`, which **already** holds `_syncLock`; node contexts are only ever removed at node death/shutdown (never on the build hot path), so nothing on a hot path is newly serialized.

### New node lifecycle

```
Alive ──(HandleNodeShutdown → NodeManager.RemoveNode, under _syncLock)──► Dead
```
No "ghost window": the maps are only ever mutated while `_syncLock` is held.

## Validation

- **Deterministic repro:** a local build with the real race window widened, plus a harness that kills worker nodes mid-build, reproduced the exact issue stack **10/10** before the fix and **0/10** after.
- **Stock bits:** on unmodified SDK bits the race reproduced ~**4/30**; **0** after the fix.
- **Unit tests:** new `NodeManager_Tests` (3 tests) lock in the contract — `RoutePacket(NodeShutdown)` must not remove the mapping, `RemoveNode` removes both the mapping and the provider context, and `RemoveNode` is idempotent.

## Notes / follow-ups (out of scope here)

- `MainNodeSdkResolverService` sends responses on a node read/IO thread (off `_syncLock`). Because that send targets the **requesting** node on that node's own serial read loop, it cannot race its own teardown; the only real hazard there was the `_nodeIdToProvider` data race, now closed by the `ConcurrentDictionary`. Routing SDK responses through the work queue could be a future hardening.
- Multi-threaded in-proc mode (`BuildParameters.MultiThreaded`) removes the in-proc node context in `NodeProviderInProc.RoutePacket`; an analogous serialization could be applied there as a follow-up (separate, experimental path).
