### PR TITLE
Add MSBuildTask0008 for unsupported ITaskItem<T> type arguments

### DIFF
--- a/src/TaskAnalyzer.Tests/TestHelpers.cs
+++ b/src/TaskAnalyzer.Tests/TestHelpers.cs
@@ -190,6 +190,21 @@ internal static class TestHelpers
     }
 
     /// <summary>
+    /// Runs the UnsupportedTaskItemTypeAnalyzer on the given source code and returns analyzer diagnostics.
+    /// Source is combined with framework stubs automatically.
+    /// </summary>
+    public static async System.Threading.Tasks.Task<ImmutableArray<Diagnostic>> GetUnsupportedTaskItemTypeDiagnosticsAsync(string source)
+    {
+        var compilation = CreateCompilation(source);
+        var analyzer = new UnsupportedTaskItemTypeAnalyzer();
+        var compilationWithAnalyzers = compilation.WithAnalyzers(
+            ImmutableArray.Create<DiagnosticAnalyzer>(analyzer));
+
+        var allDiags = await compilationWithAnalyzers.GetAnalyzerDiagnosticsAsync();
+        return allDiags;
+    }
+
+    /// <summary>
     /// Creates a compilation with the given source code and framework stubs.
     /// </summary>
     public static CSharpCompilation CreateCompilation(string source)

--- a/src/TaskAnalyzer.Tests/UnsupportedTaskItemTypeAnalyzerTests.cs
+++ b/src/TaskAnalyzer.Tests/UnsupportedTaskItemTypeAnalyzerTests.cs
@@ -1,0 +1,191 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Threading.Tasks;
+using Shouldly;
+using Xunit;
+using static Microsoft.Build.TaskAuthoring.Analyzer.Tests.TestHelpers;
+
+namespace Microsoft.Build.TaskAuthoring.Analyzer.Tests;
+
+/// <summary>
+/// Tests for <see cref="UnsupportedTaskItemTypeAnalyzer"/> covering MSBuildTask0008.
+/// </summary>
+public class UnsupportedTaskItemTypeAnalyzerTests
+{
+    // ═══════════════════════════════════════════════════════════════════════
+    // Supported types — no diagnostic expected
+    // ═══════════════════════════════════════════════════════════════════════
+
+    [Theory]
+    [InlineData("int")]
+    [InlineData("bool")]
+    [InlineData("long")]
+    [InlineData("double")]
+    [InlineData("float")]
+    [InlineData("decimal")]
+    [InlineData("byte")]
+    [InlineData("sbyte")]
+    [InlineData("short")]
+    [InlineData("ushort")]
+    [InlineData("uint")]
+    [InlineData("ulong")]
+    [InlineData("char")]
+    [InlineData("string")]
+    public async Task SupportedValueType_NoDiagnostic(string typeName)
+    {
+        var diags = await GetUnsupportedTaskItemTypeDiagnosticsAsync($$"""
+            using Microsoft.Build.Framework;
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                public ITaskItem<{{typeName}}> Item { get; set; } = null!;
+                public override bool Execute() => true;
+            }
+            """);
+
+        diags.ShouldNotContain(d => d.Id == DiagnosticIds.UnsupportedTaskItemType);
+    }
+
+    [Fact]
+    public async Task AbsolutePath_NoDiagnostic()
+    {
+        var diags = await GetUnsupportedTaskItemTypeDiagnosticsAsync("""
+            using Microsoft.Build.Framework;
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                public ITaskItem<AbsolutePath> Item { get; set; } = null!;
+                public override bool Execute() => true;
+            }
+            """);
+
+        diags.ShouldNotContain(d => d.Id == DiagnosticIds.UnsupportedTaskItemType);
+    }
+
+    [Fact]
+    public async Task FileInfo_NoDiagnostic()
+    {
+        var diags = await GetUnsupportedTaskItemTypeDiagnosticsAsync("""
+            using System.IO;
+            using Microsoft.Build.Framework;
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                public ITaskItem<FileInfo> Item { get; set; } = null!;
+                public override bool Execute() => true;
+            }
+            """);
+
+        diags.ShouldNotContain(d => d.Id == DiagnosticIds.UnsupportedTaskItemType);
+    }
+
+    [Fact]
+    public async Task DirectoryInfo_NoDiagnostic()
+    {
+        var diags = await GetUnsupportedTaskItemTypeDiagnosticsAsync("""
+            using System.IO;
+            using Microsoft.Build.Framework;
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                public ITaskItem<DirectoryInfo> Item { get; set; } = null!;
+                public override bool Execute() => true;
+            }
+            """);
+
+        diags.ShouldNotContain(d => d.Id == DiagnosticIds.UnsupportedTaskItemType);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Array variants of supported types — no diagnostic expected
+    // ═══════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task SupportedTypeArray_NoDiagnostic()
+    {
+        var diags = await GetUnsupportedTaskItemTypeDiagnosticsAsync("""
+            using Microsoft.Build.Framework;
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                public ITaskItem<int>[] Items { get; set; } = null!;
+                public override bool Execute() => true;
+            }
+            """);
+
+        diags.ShouldNotContain(d => d.Id == DiagnosticIds.UnsupportedTaskItemType);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Unsupported types — diagnostic expected
+    // ═══════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task Guid_ProducesDiagnostic()
+    {
+        var diags = await GetUnsupportedTaskItemTypeDiagnosticsAsync("""
+            using System;
+            using Microsoft.Build.Framework;
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                public ITaskItem<Guid> Item { get; set; } = null!;
+                public override bool Execute() => true;
+            }
+            """);
+
+        diags.ShouldContain(d => d.Id == DiagnosticIds.UnsupportedTaskItemType);
+        diags[0].GetMessage().ShouldContain("Item");
+        diags[0].GetMessage().ShouldContain("Guid");
+    }
+
+    [Fact]
+    public async Task TimeSpan_ProducesDiagnostic()
+    {
+        var diags = await GetUnsupportedTaskItemTypeDiagnosticsAsync("""
+            using System;
+            using Microsoft.Build.Framework;
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                public ITaskItem<TimeSpan> Duration { get; set; } = null!;
+                public override bool Execute() => true;
+            }
+            """);
+
+        diags.ShouldContain(d => d.Id == DiagnosticIds.UnsupportedTaskItemType);
+        diags[0].GetMessage().ShouldContain("Duration");
+        diags[0].GetMessage().ShouldContain("TimeSpan");
+    }
+
+    [Fact]
+    public async Task UnsupportedTypeArray_ProducesDiagnostic()
+    {
+        var diags = await GetUnsupportedTaskItemTypeDiagnosticsAsync("""
+            using System;
+            using Microsoft.Build.Framework;
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                public ITaskItem<Guid>[] Items { get; set; } = null!;
+                public override bool Execute() => true;
+            }
+            """);
+
+        diags.ShouldContain(d => d.Id == DiagnosticIds.UnsupportedTaskItemType);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Non-task classes — no diagnostic expected
+    // ═══════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task NonTaskClass_NoDiagnostic()
+    {
+        // A class that does not implement ITask should not trigger the diagnostic,
+        // even if it has an ITaskItem<Guid> property.
+        var diags = await GetUnsupportedTaskItemTypeDiagnosticsAsync("""
+            using System;
+            using Microsoft.Build.Framework;
+            public class NotATask
+            {
+                public ITaskItem<Guid> Item { get; set; } = null!;
+            }
+            """);
+
+        diags.ShouldNotContain(d => d.Id == DiagnosticIds.UnsupportedTaskItemType);
+    }
+}

--- a/src/TaskAnalyzer/AnalyzerReleases.Unshipped.md
+++ b/src/TaskAnalyzer/AnalyzerReleases.Unshipped.md
@@ -9,3 +9,4 @@ MSBuildTask0004 | MSBuild.TaskAuthoring | Warning | APIs that may cause issues i
 MSBuildTask0005 | MSBuild.TaskAuthoring | Warning | Transitive unsafe API usage detected in task call chain
 MSBuildTask0006 | MSBuild.TaskAuthoring | Info | Prefer typed path parameter (AbsolutePath/FileInfo/DirectoryInfo) over string (code fix available)
 MSBuildTask0007 | MSBuild.TaskAuthoring | Info | Prefer ITaskItem<T> over manual ItemSpec parsing (code fix available)
+MSBuildTask0008 | MSBuild.TaskAuthoring | Warning | ITaskItem<T> used with a type argument T that ValueTypeParser cannot parse at runtime

--- a/src/TaskAnalyzer/DiagnosticDescriptors.cs
+++ b/src/TaskAnalyzer/DiagnosticDescriptors.cs
@@ -76,6 +76,15 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
             isEnabledByDefault: true,
             description: "MSBuild can bind ITaskItem<T> task parameters that provide a strongly-typed Value property parsed from ItemSpec for tasks that opt into multithreaded support. Using ITaskItem<T> avoids manual parsing in the task body.");
 
+        public static readonly DiagnosticDescriptor UnsupportedTaskItemType = new(
+            id: DiagnosticIds.UnsupportedTaskItemType,
+            title: "ITaskItem<T> used with unsupported type argument",
+            messageFormat: "Task property '{0}' uses ITaskItem<{1}> but '{1}' is not supported by MSBuild's ValueTypeParser. Supported types are: bool, char, byte, sbyte, short, ushort, int, uint, long, ulong, float, double, decimal, string, AbsolutePath, FileInfo, DirectoryInfo.",
+            category: "MSBuild.TaskAuthoring",
+            defaultSeverity: DiagnosticSeverity.Warning,
+            isEnabledByDefault: true,
+            description: "MSBuild can only parse ITaskItem<T> properties when T is a type supported by ValueTypeParser. Using an unsupported type will cause a runtime failure when MSBuild tries to bind the parameter.");
+
         public static ImmutableArray<DiagnosticDescriptor> All { get; } = ImmutableArray.Create(
             CriticalError,
             TaskEnvironmentRequired,
@@ -83,6 +92,7 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
             PotentialIssue,
             TransitiveUnsafeCall,
             PreferTypedPathParameter,
-            PreferTypedTaskItem);
+            PreferTypedTaskItem,
+            UnsupportedTaskItemType);
     }
 }

--- a/src/TaskAnalyzer/DiagnosticIds.cs
+++ b/src/TaskAnalyzer/DiagnosticIds.cs
@@ -29,5 +29,8 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
 
         /// <summary>Task input property should use ITaskItem&lt;T&gt; instead of ITaskItem with manual ItemSpec parsing.</summary>
         public const string PreferTypedTaskItem = "MSBuildTask0007";
+
+        /// <summary>Task property uses ITaskItem&lt;T&gt; with a type argument not supported by ValueTypeParser.</summary>
+        public const string UnsupportedTaskItemType = "MSBuildTask0008";
     }
 }

--- a/src/TaskAnalyzer/README.md
+++ b/src/TaskAnalyzer/README.md
@@ -21,6 +21,7 @@ This analyzer catches unsafe API usage at compile time and offers code fixes to 
 | **MSBuildTask0005** | Warning | All `ITask` implementations | Transitive unsafe API usage in task call chain |
 | **MSBuildTask0006** | Info | Multithreaded tasks (`IMultiThreadableTask` or `[MSBuildMultiThreadableTask]`) | Prefer typed path parameter over string |
 | **MSBuildTask0007** | Info | Multithreaded tasks (`IMultiThreadableTask` or `[MSBuildMultiThreadableTask]`) | Prefer `ITaskItem<T>` over manual ItemSpec parsing |
+| **MSBuildTask0008** | Warning | All `ITask` implementations | `ITaskItem<T>` used with unsupported type argument |
 
 ### MSBuildTask0001 — Critical: No Safe Alternative
 
@@ -173,16 +174,36 @@ public class MyTask : Task
 
 **Not flagged:** Metadata access (`item.GetMetadata(...)`), `[Output]` properties, non-task classes.
 
+### MSBuildTask0008 — Unsupported `ITaskItem<T>` Type Argument
+
+When a task property is typed as `ITaskItem<T>` or `ITaskItem<T>[]` but `T` is not a type that MSBuild's `ValueTypeParser` can parse at runtime, a **Warning** is emitted. Using an unsupported type will cause a runtime failure when MSBuild tries to bind the parameter.
+
+**Supported type arguments:** `bool`, `char`, `byte`, `sbyte`, `short`, `ushort`, `int`, `uint`, `long`, `ulong`, `float`, `double`, `decimal`, `string`, `AbsolutePath`, `FileInfo`, `DirectoryInfo`.
+
+```csharp
+// ⚠️ MSBuildTask0008: Task property 'Id' uses ITaskItem<Guid> but 'Guid' is not supported
+public class MyTask : Task
+{
+    public ITaskItem<System.Guid> Id { get; set; }       // warning
+    public ITaskItem<System.TimeSpan>[] Durations { get; set; }  // warning
+    public ITaskItem<int> Count { get; set; }             // OK
+}
+```
+
+No code fix is offered for MSBuildTask0008 — the resolution depends on the intended semantics (e.g., switching to `string` and parsing manually, or choosing a different supported type).
+
+**Scope:** All `ITask` implementations (not just multithreaded tasks), since using an unsupported T is always a runtime correctness problem.
+
 ## Analysis Scope
 
 The analyzer determines what to check based on the type declaration:
 
 | Type | Rules Applied |
 |---|---|
-| Any class implementing `ITask` | MSBuildTask0001–MSBuildTask0005 |
+| Any class implementing `ITask` | MSBuildTask0001–MSBuildTask0005, MSBuildTask0008 |
 | Multithreaded tasks (`IMultiThreadableTask` or `[MSBuildMultiThreadableTask]`) | MSBuildTask0006–MSBuildTask0007 |
-| Class implementing `IMultiThreadableTask` | All seven rules |
-| Class with `[MSBuildMultiThreadableTask]` attribute | All seven rules |
+| Class implementing `IMultiThreadableTask` | All eight rules |
+| Class with `[MSBuildMultiThreadableTask]` attribute | All eight rules |
 | Helper class with `[MSBuildMultiThreadableTaskAnalyzed]` attribute | MSBuildTask0001–MSBuildTask0005 |
 | Regular class (no task interface or attribute) | Not analyzed |
 
@@ -193,7 +214,7 @@ The `[MSBuildMultiThreadableTaskAnalyzed]` attribute allows opting helper classe
 ### Severity Levels
 
 - **MSBuildTask0001** is always **Error** — these APIs are never safe in any MSBuild task.
-- **MSBuildTask0002–MSBuildTask0005** report as **Warning** for all task types.
+- **MSBuildTask0002–MSBuildTask0005, MSBuildTask0008** report as **Warning** for all task types.
 - **MSBuildTask0006–MSBuildTask0007** report as **Info** — these are modernization suggestions, not correctness issues.
 
 ## Code Fixes

--- a/src/TaskAnalyzer/UnsupportedTaskItemTypeAnalyzer.cs
+++ b/src/TaskAnalyzer/UnsupportedTaskItemTypeAnalyzer.cs
@@ -1,0 +1,154 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using static Microsoft.Build.TaskAuthoring.Analyzer.SharedAnalyzerHelpers;
+
+namespace Microsoft.Build.TaskAuthoring.Analyzer
+{
+    /// <summary>
+    /// Roslyn analyzer that warns when a task property is typed as <c>ITaskItem&lt;T&gt;</c> or
+    /// <c>ITaskItem&lt;T&gt;[]</c> where <c>T</c> is not in the set of types that MSBuild's
+    /// <c>ValueTypeParser</c> can parse at runtime.
+    ///
+    /// MSBuildTask0008: ITaskItem&lt;T&gt; used with unsupported type argument.
+    /// </summary>
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class UnsupportedTaskItemTypeAnalyzer : DiagnosticAnalyzer
+    {
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
+            ImmutableArray.Create(DiagnosticDescriptors.UnsupportedTaskItemType);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.EnableConcurrentExecution();
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.RegisterCompilationStartAction(OnCompilationStart);
+        }
+
+        private static void OnCompilationStart(CompilationStartAnalysisContext compilationContext)
+        {
+            var iTaskType = compilationContext.Compilation.GetTypeByMetadataName(WellKnownTypeNames.ITaskFullName);
+            if (iTaskType is null)
+            {
+                return;
+            }
+
+            var iTaskItemOfTType = compilationContext.Compilation.GetTypeByMetadataName(WellKnownTypeNames.ITaskItemOfTFullName);
+            if (iTaskItemOfTType is null)
+            {
+                return;
+            }
+
+            // Collect fully-qualified metadata names for supported T types (mirrors ValueTypeParser)
+            var absolutePathType = compilationContext.Compilation.GetTypeByMetadataName(WellKnownTypeNames.AbsolutePathFullName);
+            var fileInfoType = compilationContext.Compilation.GetTypeByMetadataName("System.IO.FileInfo");
+            var directoryInfoType = compilationContext.Compilation.GetTypeByMetadataName("System.IO.DirectoryInfo");
+
+            var supportedSpecialTypes = new HashSet<SpecialType>
+            {
+                SpecialType.System_Boolean,
+                SpecialType.System_Char,
+                SpecialType.System_Byte,
+                SpecialType.System_SByte,
+                SpecialType.System_Int16,
+                SpecialType.System_UInt16,
+                SpecialType.System_Int32,
+                SpecialType.System_UInt32,
+                SpecialType.System_Int64,
+                SpecialType.System_UInt64,
+                SpecialType.System_Single,
+                SpecialType.System_Double,
+                SpecialType.System_Decimal,
+                SpecialType.System_String,
+            };
+
+            compilationContext.RegisterSymbolAction(symbolContext =>
+            {
+                var namedType = (INamedTypeSymbol)symbolContext.Symbol;
+
+                // Only check ITask implementations
+                if (!ImplementsInterface(namedType, iTaskType))
+                {
+                    return;
+                }
+
+                foreach (var member in namedType.GetMembers())
+                {
+                    if (member is not IPropertySymbol property)
+                    {
+                        continue;
+                    }
+
+                    if (property.DeclaredAccessibility != Accessibility.Public || property.SetMethod is null)
+                    {
+                        continue;
+                    }
+
+                    // Unwrap array: ITaskItem<T>[] → ITaskItem<T>
+                    ITypeSymbol propertyType = property.Type;
+                    if (propertyType is IArrayTypeSymbol arrayType)
+                    {
+                        propertyType = arrayType.ElementType;
+                    }
+
+                    // Check if the property type is ITaskItem<T>
+                    if (propertyType is not INamedTypeSymbol namedPropertyType ||
+                        !namedPropertyType.IsGenericType ||
+                        !SymbolEqualityComparer.Default.Equals(namedPropertyType.OriginalDefinition, iTaskItemOfTType))
+                    {
+                        continue;
+                    }
+
+                    ITypeSymbol typeArg = namedPropertyType.TypeArguments[0];
+
+                    // Check if T is in the supported set
+                    if (IsSupportedTypeArgument(typeArg, supportedSpecialTypes, absolutePathType, fileInfoType, directoryInfoType))
+                    {
+                        continue;
+                    }
+
+                    symbolContext.ReportDiagnostic(Diagnostic.Create(
+                        DiagnosticDescriptors.UnsupportedTaskItemType,
+                        property.Locations[0],
+                        property.Name,
+                        typeArg.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat)));
+                }
+            }, SymbolKind.NamedType);
+        }
+
+        private static bool IsSupportedTypeArgument(
+            ITypeSymbol typeArg,
+            HashSet<SpecialType> supportedSpecialTypes,
+            INamedTypeSymbol? absolutePathType,
+            INamedTypeSymbol? fileInfoType,
+            INamedTypeSymbol? directoryInfoType)
+        {
+            if (typeArg.SpecialType != SpecialType.None && supportedSpecialTypes.Contains(typeArg.SpecialType))
+            {
+                return true;
+            }
+
+            if (absolutePathType is not null && SymbolEqualityComparer.Default.Equals(typeArg, absolutePathType))
+            {
+                return true;
+            }
+
+            if (fileInfoType is not null && SymbolEqualityComparer.Default.Equals(typeArg, fileInfoType))
+            {
+                return true;
+            }
+
+            if (directoryInfoType is not null && SymbolEqualityComparer.Default.Equals(typeArg, directoryInfoType))
+            {
+                return true;
+            }
+
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Third stacked PR from #13016.

Adds MSBuildTask0008 warning and tests for unsupported ITaskItem<T> type arguments.