### PR TITLE
Enable numeric and broader value-type binding for typed task items

### DIFF
--- a/documentation/wiki/Tasks.md
+++ b/documentation/wiki/Tasks.md
@@ -14,8 +14,9 @@ A task is a class implementing [`ITask`](https://github.com/dotnet/msbuild/blob/
     - **Numeric value types**: `int`, `long`, `short`, `byte`, `uint`, `ulong`, `ushort`, `sbyte`, `double`, `float`, `decimal`, and their array equivalents
     - **Other value types**: `char`, `DateTime`, and their array equivalents
     - **Item types**: `ITaskItem` (representation of a file system object with metadata), `ITaskItem[]`
-    - **Strongly-typed items**: `ITaskItem<T>` where `T` is `AbsolutePath`, `FileInfo`, or `DirectoryInfo` (for example, `ITaskItem<AbsolutePath>` and `ITaskItem<FileInfo>`), and their array equivalents
-    - **Path types**: `AbsolutePath`, `AbsolutePath[]`, `FileInfo`, `FileInfo[]`, `DirectoryInfo`, `DirectoryInfo[]`
+    - **Strongly-typed items**: `ITaskItem<T>` where `T` is a value type (e.g., `ITaskItem<int>`), and their array equivalents
+    - **Path types**: `AbsolutePath`, `AbsolutePath[]`
+    - **Custom value types**: Any struct implementing `IConvertible` (for output parameters only)
   - The properties can have attributes `[Required]` which causes the engine to check that it has a value when the task is run and `[Output]` which exposes the property to be used again in XML
 
 - Tasks have the `Log` property set by the engine to log messages/errors/warnings.

--- a/src/Build.UnitTests/BackEnd/TaskBuilderTestTask.cs
+++ b/src/Build.UnitTests/BackEnd/TaskBuilderTestTask.cs
@@ -249,52 +249,12 @@ namespace Microsoft.Build.UnitTests.BackEnd
         /// <summary>
         /// The value for the TaskItemIntOutput.
         /// </summary>
-        private ITaskItem<AbsolutePath> _taskItemIntOutput;
+        private ITaskItem<int> _taskItemIntOutput;
 
         /// <summary>
         /// The value for the TaskItemIntArrayOutput.
         /// </summary>
-        private ITaskItem<AbsolutePath>[] _taskItemIntArrayOutput;
-
-        /// <summary>
-        /// The value for the FileInfoOutput.
-        /// </summary>
-        private System.IO.FileInfo _fileInfoOutput;
-
-        /// <summary>
-        /// The value for the FileInfoArrayOutput.
-        /// </summary>
-        private System.IO.FileInfo[] _fileInfoArrayOutput;
-
-        /// <summary>
-        /// The value for the DirectoryInfoOutput.
-        /// </summary>
-        private System.IO.DirectoryInfo _directoryInfoOutput;
-
-        /// <summary>
-        /// The value for the DirectoryInfoArrayOutput.
-        /// </summary>
-        private System.IO.DirectoryInfo[] _directoryInfoArrayOutput;
-
-        /// <summary>
-        /// The value for the TaskItemFileInfoOutput.
-        /// </summary>
-        private ITaskItem<System.IO.FileInfo> _taskItemFileInfoOutput;
-
-        /// <summary>
-        /// The value for the TaskItemFileInfoArrayOutput.
-        /// </summary>
-        private ITaskItem<System.IO.FileInfo>[] _taskItemFileInfoArrayOutput;
-
-        /// <summary>
-        /// The value for the TaskItemDirectoryInfoOutput.
-        /// </summary>
-        private ITaskItem<System.IO.DirectoryInfo> _taskItemDirectoryInfoOutput;
-
-        /// <summary>
-        /// The value for the TaskItemDirectoryInfoArrayOutput.
-        /// </summary>
-        private ITaskItem<System.IO.DirectoryInfo>[] _taskItemDirectoryInfoArrayOutput;
+        private ITaskItem<int>[] _taskItemIntArrayOutput;
 
         /// <summary>
         /// Property determining if Execute() should throw or not.
@@ -714,9 +674,9 @@ namespace Microsoft.Build.UnitTests.BackEnd
         }
 
         /// <summary>
-        /// A TaskItem&lt;AbsolutePath&gt; parameter.
+        /// A TaskItem&lt;int&gt; parameter.
         /// </summary>
-        public ITaskItem<AbsolutePath> TaskItemIntParam
+        public ITaskItem<int> TaskItemIntParam
         {
             set
             {
@@ -726,110 +686,14 @@ namespace Microsoft.Build.UnitTests.BackEnd
         }
 
         /// <summary>
-        /// A TaskItem&lt;AbsolutePath&gt; array parameter.
+        /// A TaskItem&lt;int&gt; array parameter.
         /// </summary>
-        public ITaskItem<AbsolutePath>[] TaskItemIntArrayParam
+        public ITaskItem<int>[] TaskItemIntArrayParam
         {
             set
             {
                 _taskItemIntArrayOutput = value;
                 _testTaskHost?.ParameterSet("TaskItemIntArrayParam", value);
-            }
-        }
-
-        /// <summary>
-        /// A FileInfo parameter.
-        /// </summary>
-        public System.IO.FileInfo FileInfoParam
-        {
-            set
-            {
-                _fileInfoOutput = value;
-                _testTaskHost?.ParameterSet("FileInfoParam", value);
-            }
-        }
-
-        /// <summary>
-        /// A FileInfo array parameter.
-        /// </summary>
-        public System.IO.FileInfo[] FileInfoArrayParam
-        {
-            set
-            {
-                _fileInfoArrayOutput = value;
-                _testTaskHost?.ParameterSet("FileInfoArrayParam", value);
-            }
-        }
-
-        /// <summary>
-        /// A DirectoryInfo parameter.
-        /// </summary>
-        public System.IO.DirectoryInfo DirectoryInfoParam
-        {
-            set
-            {
-                _directoryInfoOutput = value;
-                _testTaskHost?.ParameterSet("DirectoryInfoParam", value);
-            }
-        }
-
-        /// <summary>
-        /// A DirectoryInfo array parameter.
-        /// </summary>
-        public System.IO.DirectoryInfo[] DirectoryInfoArrayParam
-        {
-            set
-            {
-                _directoryInfoArrayOutput = value;
-                _testTaskHost?.ParameterSet("DirectoryInfoArrayParam", value);
-            }
-        }
-
-        /// <summary>
-        /// An ITaskItem&lt;FileInfo&gt; parameter.
-        /// </summary>
-        public ITaskItem<System.IO.FileInfo> TaskItemFileInfoParam
-        {
-            set
-            {
-                _taskItemFileInfoOutput = value;
-                _testTaskHost?.ParameterSet("TaskItemFileInfoParam", value);
-            }
-        }
-
-        /// <summary>
-        /// An ITaskItem&lt;FileInfo&gt; array parameter.
-        /// </summary>
-        public ITaskItem<System.IO.FileInfo>[] TaskItemFileInfoArrayParam
-        {
-            set
-            {
-                _taskItemFileInfoArrayOutput = value;
-                _testTaskHost?.ParameterSet("TaskItemFileInfoArrayParam", value);
-            }
-        }
-
-        /// <summary>
-        /// An ITaskItem&lt;DirectoryInfo&gt; parameter.
-        /// </summary>
-        public ITaskItem<System.IO.DirectoryInfo> TaskItemDirectoryInfoParam
-        {
-            set
-            {
-                _taskItemDirectoryInfoOutput = value;
-                _testTaskHost?.ParameterSet("TaskItemDirectoryInfoParam", value);
-            }
-        }
-
-        /// <summary>
-        /// An ITaskItem&lt;DirectoryInfo&gt; array parameter.
-        /// </summary>
-        public ITaskItem<System.IO.DirectoryInfo>[] TaskItemDirectoryInfoArrayParam
-        {
-            set
-            {
-                _taskItemDirectoryInfoArrayOutput = value;
-                _testTaskHost?.ParameterSet("TaskItemDirectoryInfoArrayParam", value);
             }
         }
 
@@ -1406,10 +1270,10 @@ namespace Microsoft.Build.UnitTests.BackEnd
         }
 
         /// <summary>
-        /// A TaskItem&lt;AbsolutePath&gt; output.
+        /// A TaskItem&lt;int&gt; output.
         /// </summary>
         [Output]
-        public ITaskItem<AbsolutePath> TaskItemIntOutput
+        public ITaskItem<int> TaskItemIntOutput
         {
             get
             {
@@ -1419,119 +1283,15 @@ namespace Microsoft.Build.UnitTests.BackEnd
         }
 
         /// <summary>
-        /// A TaskItem&lt;AbsolutePath&gt; array output.
+        /// A TaskItem&lt;int&gt; array output.
         /// </summary>
         [Output]
-        public ITaskItem<AbsolutePath>[] TaskItemIntArrayOutput
+        public ITaskItem<int>[] TaskItemIntArrayOutput
         {
             get
             {
                 _testTaskHost?.OutputRead("TaskItemIntArrayOutput", _taskItemIntArrayOutput);
                 return _taskItemIntArrayOutput;
-            }
-        }
-
-        /// <summary>
-        /// A FileInfo output.
-        /// </summary>
-        [Output]
-        public System.IO.FileInfo FileInfoOutput
-        {
-            get
-            {
-                _testTaskHost?.OutputRead("FileInfoOutput", _fileInfoOutput);
-                return _fileInfoOutput;
-            }
-        }
-
-        /// <summary>
-        /// A FileInfo array output.
-        /// </summary>
-        [Output]
-        public System.IO.FileInfo[] FileInfoArrayOutput
-        {
-            get
-            {
-                _testTaskHost?.OutputRead("FileInfoArrayOutput", _fileInfoArrayOutput);
-                return _fileInfoArrayOutput;
-            }
-        }
-
-        /// <summary>
-        /// A DirectoryInfo output.
-        /// </summary>
-        [Output]
-        public System.IO.DirectoryInfo DirectoryInfoOutput
-        {
-            get
-            {
-                _testTaskHost?.OutputRead("DirectoryInfoOutput", _directoryInfoOutput);
-                return _directoryInfoOutput;
-            }
-        }
-
-        /// <summary>
-        /// A DirectoryInfo array output.
-        /// </summary>
-        [Output]
-        public System.IO.DirectoryInfo[] DirectoryInfoArrayOutput
-        {
-            get
-            {
-                _testTaskHost?.OutputRead("DirectoryInfoArrayOutput", _directoryInfoArrayOutput);
-                return _directoryInfoArrayOutput;
-            }
-        }
-
-        /// <summary>
-        /// An ITaskItem&lt;FileInfo&gt; output.
-        /// </summary>
-        [Output]
-        public ITaskItem<System.IO.FileInfo> TaskItemFileInfoOutput
-        {
-            get
-            {
-                _testTaskHost?.OutputRead("TaskItemFileInfoOutput", _taskItemFileInfoOutput);
-                return _taskItemFileInfoOutput;
-            }
-        }
-
-        /// <summary>
-        /// An ITaskItem&lt;FileInfo&gt; array output.
-        /// </summary>
-        [Output]
-        public ITaskItem<System.IO.FileInfo>[] TaskItemFileInfoArrayOutput
-        {
-            get
-            {
-                _testTaskHost?.OutputRead("TaskItemFileInfoArrayOutput", _taskItemFileInfoArrayOutput);
-                return _taskItemFileInfoArrayOutput;
-            }
-        }
-
-        /// <summary>
-        /// An ITaskItem&lt;DirectoryInfo&gt; output.
-        /// </summary>
-        [Output]
-        public ITaskItem<System.IO.DirectoryInfo> TaskItemDirectoryInfoOutput
-        {
-            get
-            {
-                _testTaskHost?.OutputRead("TaskItemDirectoryInfoOutput", _taskItemDirectoryInfoOutput);
-                return _taskItemDirectoryInfoOutput;
-            }
-        }
-
-        /// <summary>
-        /// An ITaskItem&lt;DirectoryInfo&gt; array output.
-        /// </summary>
-        [Output]
-        public ITaskItem<System.IO.DirectoryInfo>[] TaskItemDirectoryInfoArrayOutput
-        {
-            get
-            {
-                _testTaskHost?.OutputRead("TaskItemDirectoryInfoArrayOutput", _taskItemDirectoryInfoArrayOutput);
-                return _taskItemDirectoryInfoArrayOutput;
             }
         }
 

--- a/src/Build.UnitTests/BackEnd/TaskExecutionHost_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/TaskExecutionHost_Tests.cs
@@ -568,13 +568,12 @@ namespace Microsoft.Build.UnitTests.BackEnd
         #region TaskItem<T> Params
 
         /// <summary>
-        /// Validate that setting a TaskItem&lt;AbsolutePath&gt; parameter with a valid path works.
+        /// Validate that setting a TaskItem&lt;int&gt; parameter with a valid integer works.
         /// </summary>
         [Fact]
         public void TestSetTaskItemIntParam()
         {
-            string absolutePath = NativeMethodsShared.IsWindows ? @"C:\temp\typed-item.txt" : "/tmp/typed-item.txt";
-            ValidateTaskParameter("TaskItemIntParam", absolutePath, new Microsoft.Build.Utilities.TaskItem<AbsolutePath>(new AbsolutePath(absolutePath)));
+            ValidateTaskParameter("TaskItemIntParam", "42", new Microsoft.Build.Utilities.TaskItem<int>(42));
         }
 
         /// <summary>
@@ -609,37 +608,25 @@ namespace Microsoft.Build.UnitTests.BackEnd
         #region TaskItem<T> Array Params
 
         /// <summary>
-        /// Validate that setting a TaskItem&lt;AbsolutePath&gt; array with a single value sets the correct value.
+        /// Validate that setting a TaskItem&lt;int&gt; array with a single value sets the correct value.
         /// </summary>
         [Fact]
         public void TestSetTaskItemIntArrayParam()
         {
-            string absolutePath = NativeMethodsShared.IsWindows ? @"C:\temp\typed-item.txt" : "/tmp/typed-item.txt";
-            ValidateTaskParameterArray(
-                "TaskItemIntArrayParam",
-                absolutePath,
-                new Microsoft.Build.Utilities.TaskItem<AbsolutePath>[] { new Microsoft.Build.Utilities.TaskItem<AbsolutePath>(new AbsolutePath(absolutePath)) });
+            ValidateTaskParameterArray("TaskItemIntArrayParam", "42", new Microsoft.Build.Utilities.TaskItem<int>[] { new Microsoft.Build.Utilities.TaskItem<int>(42) });
         }
 
         /// <summary>
-        /// Validate that setting a TaskItem&lt;AbsolutePath&gt; array with multiple values sets the correct values.
+        /// Validate that setting a TaskItem&lt;int&gt; array with multiple values sets the correct values.
         /// </summary>
         [Fact]
         public void TestSetTaskItemIntArrayParamMultiple()
         {
-            string path1 = NativeMethodsShared.IsWindows ? @"C:\temp\typed-item-1.txt" : "/tmp/typed-item-1.txt";
-            string path2 = NativeMethodsShared.IsWindows ? @"C:\temp\typed-item-2.txt" : "/tmp/typed-item-2.txt";
-            string path3 = NativeMethodsShared.IsWindows ? @"C:\temp\typed-item-3.txt" : "/tmp/typed-item-3.txt";
-
-            ValidateTaskParameterArray(
-                "TaskItemIntArrayParam",
-                $"{path1};{path2};{path3}",
-                new Microsoft.Build.Utilities.TaskItem<AbsolutePath>[]
-                {
-                    new Microsoft.Build.Utilities.TaskItem<AbsolutePath>(new AbsolutePath(path1)),
-                    new Microsoft.Build.Utilities.TaskItem<AbsolutePath>(new AbsolutePath(path2)),
-                    new Microsoft.Build.Utilities.TaskItem<AbsolutePath>(new AbsolutePath(path3))
-                });
+            ValidateTaskParameterArray("TaskItemIntArrayParam", "10;20;30", new Microsoft.Build.Utilities.TaskItem<int>[] {
+                new Microsoft.Build.Utilities.TaskItem<int>(10),
+                new Microsoft.Build.Utilities.TaskItem<int>(20),
+                new Microsoft.Build.Utilities.TaskItem<int>(30)
+            });
         }
 
         /// <summary>
@@ -667,384 +654,6 @@ namespace Microsoft.Build.UnitTests.BackEnd
         public void TestSetTaskItemIntArrayParamEmptyItem()
         {
             ValidateTaskParameterNotSet("TaskItemIntArrayParam", "@(NonExistentItem)");
-        }
-
-        #endregion
-
-        #region FileInfo Params
-
-        /// <summary>
-        /// Validate that setting a FileInfo parameter with a valid file path works.
-        /// </summary>
-        [Fact]
-        public void TestSetFileInfoParam()
-        {
-            string filePath = NativeMethodsShared.IsWindows ? @"C:\temp\file.txt" : "/tmp/file.txt";
-            ValidateTaskParameter("FileInfoParam", filePath, new FileInfo(filePath));
-        }
-
-        /// <summary>
-        /// Validate that setting the parameter with an empty value does not cause it to be set.
-        /// </summary>
-        [Fact]
-        public void TestSetFileInfoParamEmptyAttribute()
-        {
-            ValidateTaskParameterNotSet("FileInfoParam", "");
-        }
-
-        /// <summary>
-        /// Validate that setting the parameter with a property which evaluates to an empty value does not cause it to be set.
-        /// </summary>
-        [Fact]
-        public void TestSetFileInfoParamEmptyProperty()
-        {
-            ValidateTaskParameterNotSet("FileInfoParam", "$(NonExistentProperty)");
-        }
-
-        /// <summary>
-        /// Validate that setting the parameter with an item which evaluates to an empty value does not cause it to be set.
-        /// </summary>
-        [Fact]
-        public void TestSetFileInfoParamEmptyItem()
-        {
-            ValidateTaskParameterNotSet("FileInfoParam", "@(NonExistentItem)");
-        }
-
-        #endregion
-
-        #region FileInfo Array Params
-
-        /// <summary>
-        /// Validate that setting a FileInfo array with a single value sets the correct value.
-        /// </summary>
-        [Fact]
-        public void TestSetFileInfoArrayParam()
-        {
-            string filePath = NativeMethodsShared.IsWindows ? @"C:\temp\file.txt" : "/tmp/file.txt";
-            ValidateTaskParameterArray("FileInfoArrayParam", filePath, new FileInfo[] { new FileInfo(filePath) });
-        }
-
-        /// <summary>
-        /// Validate that setting a FileInfo array with multiple values sets the correct values.
-        /// </summary>
-        [Fact]
-        public void TestSetFileInfoArrayParamMultiple()
-        {
-            string path1 = NativeMethodsShared.IsWindows ? @"C:\temp\file1.txt" : "/tmp/file1.txt";
-            string path2 = NativeMethodsShared.IsWindows ? @"C:\temp\file2.txt" : "/tmp/file2.txt";
-            ValidateTaskParameterArray("FileInfoArrayParam", path1 + ";" + path2, new FileInfo[] { new FileInfo(path1), new FileInfo(path2) });
-        }
-
-        /// <summary>
-        /// Validate that setting the parameter with an empty value does not cause it to be set.
-        /// </summary>
-        [Fact]
-        public void TestSetFileInfoArrayParamEmptyAttribute()
-        {
-            ValidateTaskParameterNotSet("FileInfoArrayParam", "");
-        }
-
-        /// <summary>
-        /// Validate that setting the parameter with a property which evaluates to an empty value does not cause it to be set.
-        /// </summary>
-        [Fact]
-        public void TestSetFileInfoArrayParamEmptyProperty()
-        {
-            ValidateTaskParameterNotSet("FileInfoArrayParam", "$(NonExistentProperty)");
-        }
-
-        /// <summary>
-        /// Validate that setting the parameter with an item which evaluates to an empty value does not cause it to be set.
-        /// </summary>
-        [Fact]
-        public void TestSetFileInfoArrayParamEmptyItem()
-        {
-            ValidateTaskParameterNotSet("FileInfoArrayParam", "@(NonExistentItem)");
-        }
-
-        #endregion
-
-        #region DirectoryInfo Params
-
-        /// <summary>
-        /// Validate that setting a DirectoryInfo parameter with a valid directory path works.
-        /// </summary>
-        [Fact]
-        public void TestSetDirectoryInfoParam()
-        {
-            string dirPath = NativeMethodsShared.IsWindows ? @"C:\temp" : "/tmp";
-            ValidateTaskParameter("DirectoryInfoParam", dirPath, new DirectoryInfo(dirPath));
-        }
-
-        /// <summary>
-        /// Validate that setting the parameter with an empty value does not cause it to be set.
-        /// </summary>
-        [Fact]
-        public void TestSetDirectoryInfoParamEmptyAttribute()
-        {
-            ValidateTaskParameterNotSet("DirectoryInfoParam", "");
-        }
-
-        /// <summary>
-        /// Validate that setting the parameter with a property which evaluates to an empty value does not cause it to be set.
-        /// </summary>
-        [Fact]
-        public void TestSetDirectoryInfoParamEmptyProperty()
-        {
-            ValidateTaskParameterNotSet("DirectoryInfoParam", "$(NonExistentProperty)");
-        }
-
-        /// <summary>
-        /// Validate that setting the parameter with an item which evaluates to an empty value does not cause it to be set.
-        /// </summary>
-        [Fact]
-        public void TestSetDirectoryInfoParamEmptyItem()
-        {
-            ValidateTaskParameterNotSet("DirectoryInfoParam", "@(NonExistentItem)");
-        }
-
-        #endregion
-
-        #region DirectoryInfo Array Params
-
-        /// <summary>
-        /// Validate that setting a DirectoryInfo array with a single value sets the correct value.
-        /// </summary>
-        [Fact]
-        public void TestSetDirectoryInfoArrayParam()
-        {
-            string dirPath = NativeMethodsShared.IsWindows ? @"C:\temp" : "/tmp";
-            ValidateTaskParameterArray("DirectoryInfoArrayParam", dirPath, new DirectoryInfo[] { new DirectoryInfo(dirPath) });
-        }
-
-        /// <summary>
-        /// Validate that setting a DirectoryInfo array with multiple values sets the correct values.
-        /// </summary>
-        [Fact]
-        public void TestSetDirectoryInfoArrayParamMultiple()
-        {
-            string path1 = NativeMethodsShared.IsWindows ? @"C:\temp" : "/tmp";
-            string path2 = NativeMethodsShared.IsWindows ? @"C:\Windows" : "/usr";
-            ValidateTaskParameterArray("DirectoryInfoArrayParam", path1 + ";" + path2, new DirectoryInfo[] { new DirectoryInfo(path1), new DirectoryInfo(path2) });
-        }
-
-        /// <summary>
-        /// Validate that setting the parameter with an empty value does not cause it to be set.
-        /// </summary>
-        [Fact]
-        public void TestSetDirectoryInfoArrayParamEmptyAttribute()
-        {
-            ValidateTaskParameterNotSet("DirectoryInfoArrayParam", "");
-        }
-
-        /// <summary>
-        /// Validate that setting the parameter with a property which evaluates to an empty value does not cause it to be set.
-        /// </summary>
-        [Fact]
-        public void TestSetDirectoryInfoArrayParamEmptyProperty()
-        {
-            ValidateTaskParameterNotSet("DirectoryInfoArrayParam", "$(NonExistentProperty)");
-        }
-
-        /// <summary>
-        /// Validate that setting the parameter with an item which evaluates to an empty value does not cause it to be set.
-        /// </summary>
-        [Fact]
-        public void TestSetDirectoryInfoArrayParamEmptyItem()
-        {
-            ValidateTaskParameterNotSet("DirectoryInfoArrayParam", "@(NonExistentItem)");
-        }
-
-        #endregion
-
-        #region TaskItem<FileInfo> Params
-
-        /// <summary>
-        /// Validate that setting a TaskItem&lt;FileInfo&gt; parameter with a valid file path works.
-        /// </summary>
-        [Fact]
-        public void TestSetTaskItemFileInfoParam()
-        {
-            string filePath = NativeMethodsShared.IsWindows ? @"C:\temp\file.txt" : "/tmp/file.txt";
-            ValidateTaskParameter("TaskItemFileInfoParam", filePath, new Microsoft.Build.Utilities.TaskItem<FileInfo>(new FileInfo(filePath)));
-        }
-
-        /// <summary>
-        /// Validate that setting the parameter with an empty value does not cause it to be set.
-        /// </summary>
-        [Fact]
-        public void TestSetTaskItemFileInfoParamEmptyAttribute()
-        {
-            ValidateTaskParameterNotSet("TaskItemFileInfoParam", "");
-        }
-
-        /// <summary>
-        /// Validate that setting the parameter with a property which evaluates to an empty value does not cause it to be set.
-        /// </summary>
-        [Fact]
-        public void TestSetTaskItemFileInfoParamEmptyProperty()
-        {
-            ValidateTaskParameterNotSet("TaskItemFileInfoParam", "$(NonExistentProperty)");
-        }
-
-        /// <summary>
-        /// Validate that setting the parameter with an item which evaluates to an empty value does not cause it to be set.
-        /// </summary>
-        [Fact]
-        public void TestSetTaskItemFileInfoParamEmptyItem()
-        {
-            ValidateTaskParameterNotSet("TaskItemFileInfoParam", "@(NonExistentItem)");
-        }
-
-        #endregion
-
-        #region TaskItem<FileInfo> Array Params
-
-        /// <summary>
-        /// Validate that setting a TaskItem&lt;FileInfo&gt; array with a single value sets the correct value.
-        /// </summary>
-        [Fact]
-        public void TestSetTaskItemFileInfoArrayParam()
-        {
-            string filePath = NativeMethodsShared.IsWindows ? @"C:\temp\file.txt" : "/tmp/file.txt";
-            ValidateTaskParameterArray("TaskItemFileInfoArrayParam", filePath, new Microsoft.Build.Utilities.TaskItem<FileInfo>[] { new Microsoft.Build.Utilities.TaskItem<FileInfo>(new FileInfo(filePath)) });
-        }
-
-        /// <summary>
-        /// Validate that setting a TaskItem&lt;FileInfo&gt; array with multiple values sets the correct values.
-        /// </summary>
-        [Fact]
-        public void TestSetTaskItemFileInfoArrayParamMultiple()
-        {
-            string path1 = NativeMethodsShared.IsWindows ? @"C:\temp\file1.txt" : "/tmp/file1.txt";
-            string path2 = NativeMethodsShared.IsWindows ? @"C:\temp\file2.txt" : "/tmp/file2.txt";
-            ValidateTaskParameterArray("TaskItemFileInfoArrayParam", path1 + ";" + path2, new Microsoft.Build.Utilities.TaskItem<FileInfo>[] {
-                new Microsoft.Build.Utilities.TaskItem<FileInfo>(new FileInfo(path1)),
-                new Microsoft.Build.Utilities.TaskItem<FileInfo>(new FileInfo(path2))
-            });
-        }
-
-        /// <summary>
-        /// Validate that setting the parameter with an empty value does not cause it to be set.
-        /// </summary>
-        [Fact]
-        public void TestSetTaskItemFileInfoArrayParamEmptyAttribute()
-        {
-            ValidateTaskParameterNotSet("TaskItemFileInfoArrayParam", "");
-        }
-
-        /// <summary>
-        /// Validate that setting the parameter with a property which evaluates to an empty value does not cause it to be set.
-        /// </summary>
-        [Fact]
-        public void TestSetTaskItemFileInfoArrayParamEmptyProperty()
-        {
-            ValidateTaskParameterNotSet("TaskItemFileInfoArrayParam", "$(NonExistentProperty)");
-        }
-
-        /// <summary>
-        /// Validate that setting the parameter with an item which evaluates to an empty value does not cause it to be set.
-        /// </summary>
-        [Fact]
-        public void TestSetTaskItemFileInfoArrayParamEmptyItem()
-        {
-            ValidateTaskParameterNotSet("TaskItemFileInfoArrayParam", "@(NonExistentItem)");
-        }
-
-        #endregion
-
-        #region TaskItem<DirectoryInfo> Params
-
-        /// <summary>
-        /// Validate that setting a TaskItem&lt;DirectoryInfo&gt; parameter with a valid directory path works.
-        /// </summary>
-        [Fact]
-        public void TestSetTaskItemDirectoryInfoParam()
-        {
-            string dirPath = NativeMethodsShared.IsWindows ? @"C:\temp" : "/tmp";
-            ValidateTaskParameter("TaskItemDirectoryInfoParam", dirPath, new Microsoft.Build.Utilities.TaskItem<DirectoryInfo>(new DirectoryInfo(dirPath)));
-        }
-
-        /// <summary>
-        /// Validate that setting the parameter with an empty value does not cause it to be set.
-        /// </summary>
-        [Fact]
-        public void TestSetTaskItemDirectoryInfoParamEmptyAttribute()
-        {
-            ValidateTaskParameterNotSet("TaskItemDirectoryInfoParam", "");
-        }
-
-        /// <summary>
-        /// Validate that setting the parameter with a property which evaluates to an empty value does not cause it to be set.
-        /// </summary>
-        [Fact]
-        public void TestSetTaskItemDirectoryInfoParamEmptyProperty()
-        {
-            ValidateTaskParameterNotSet("TaskItemDirectoryInfoParam", "$(NonExistentProperty)");
-        }
-
-        /// <summary>
-        /// Validate that setting the parameter with an item which evaluates to an empty value does not cause it to be set.
-        /// </summary>
-        [Fact]
-        public void TestSetTaskItemDirectoryInfoParamEmptyItem()
-        {
-            ValidateTaskParameterNotSet("TaskItemDirectoryInfoParam", "@(NonExistentItem)");
-        }
-
-        #endregion
-
-        #region TaskItem<DirectoryInfo> Array Params
-
-        /// <summary>
-        /// Validate that setting a TaskItem&lt;DirectoryInfo&gt; array with a single value sets the correct value.
-        /// </summary>
-        [Fact]
-        public void TestSetTaskItemDirectoryInfoArrayParam()
-        {
-            string dirPath = NativeMethodsShared.IsWindows ? @"C:\temp" : "/tmp";
-            ValidateTaskParameterArray("TaskItemDirectoryInfoArrayParam", dirPath, new Microsoft.Build.Utilities.TaskItem<DirectoryInfo>[] { new Microsoft.Build.Utilities.TaskItem<DirectoryInfo>(new DirectoryInfo(dirPath)) });
-        }
-
-        /// <summary>
-        /// Validate that setting a TaskItem&lt;DirectoryInfo&gt; array with multiple values sets the correct values.
-        /// </summary>
-        [Fact]
-        public void TestSetTaskItemDirectoryInfoArrayParamMultiple()
-        {
-            string path1 = NativeMethodsShared.IsWindows ? @"C:\temp" : "/tmp";
-            string path2 = NativeMethodsShared.IsWindows ? @"C:\Windows" : "/usr";
-            ValidateTaskParameterArray("TaskItemDirectoryInfoArrayParam", path1 + ";" + path2, new Microsoft.Build.Utilities.TaskItem<DirectoryInfo>[] {
-                new Microsoft.Build.Utilities.TaskItem<DirectoryInfo>(new DirectoryInfo(path1)),
-                new Microsoft.Build.Utilities.TaskItem<DirectoryInfo>(new DirectoryInfo(path2))
-            });
-        }
-
-        /// <summary>
-        /// Validate that setting the parameter with an empty value does not cause it to be set.
-        /// </summary>
-        [Fact]
-        public void TestSetTaskItemDirectoryInfoArrayParamEmptyAttribute()
-        {
-            ValidateTaskParameterNotSet("TaskItemDirectoryInfoArrayParam", "");
-        }
-
-        /// <summary>
-        /// Validate that setting the parameter with a property which evaluates to an empty value does not cause it to be set.
-        /// </summary>
-        [Fact]
-        public void TestSetTaskItemDirectoryInfoArrayParamEmptyProperty()
-        {
-            ValidateTaskParameterNotSet("TaskItemDirectoryInfoArrayParam", "$(NonExistentProperty)");
-        }
-
-        /// <summary>
-        /// Validate that setting the parameter with an item which evaluates to an empty value does not cause it to be set.
-        /// </summary>
-        [Fact]
-        public void TestSetTaskItemDirectoryInfoArrayParamEmptyItem()
-        {
-            ValidateTaskParameterNotSet("TaskItemDirectoryInfoArrayParam", "@(NonExistentItem)");
         }
 
         #endregion
@@ -1474,44 +1083,38 @@ namespace Microsoft.Build.UnitTests.BackEnd
         [Fact]
         public void TestOutputTaskItemIntToItem()
         {
-            string absolutePath = NativeMethodsShared.IsWindows ? @"C:\temp\typed-item-output.txt" : "/tmp/typed-item-output.txt";
-            SetTaskParameter("TaskItemIntParam", absolutePath);
-            ValidateOutputItem("TaskItemIntOutput", absolutePath);
+            SetTaskParameter("TaskItemIntParam", "42");
+            ValidateOutputItem("TaskItemIntOutput", "42");
         }
 
         /// <summary>
-        /// Validate that a TaskItem&lt;AbsolutePath&gt; output to a property produces the correct evaluated value.
+        /// Validate that a TaskItem&lt;int&gt; output to a property produces the correct evaluated value.
         /// </summary>
         [Fact]
         public void TestOutputTaskItemIntToProperty()
         {
-            string absolutePath = NativeMethodsShared.IsWindows ? @"C:\temp\typed-item-output.txt" : "/tmp/typed-item-output.txt";
-            SetTaskParameter("TaskItemIntParam", absolutePath);
-            ValidateOutputProperty("TaskItemIntOutput", absolutePath);
+            SetTaskParameter("TaskItemIntParam", "42");
+            ValidateOutputProperty("TaskItemIntOutput", "42");
         }
 
         /// <summary>
-        /// Validate that a TaskItem&lt;AbsolutePath&gt; array output to items produces the correct evaluated includes.
+        /// Validate that a TaskItem&lt;int&gt; array output to items produces the correct evaluated includes.
         /// </summary>
         [Fact]
         public void TestOutputTaskItemIntArrayToItems()
         {
-            string path1 = NativeMethodsShared.IsWindows ? @"C:\temp\typed-item-output-1.txt" : "/tmp/typed-item-output-1.txt";
-            string path2 = NativeMethodsShared.IsWindows ? @"C:\temp\typed-item-output-2.txt" : "/tmp/typed-item-output-2.txt";
-            SetTaskParameter("TaskItemIntArrayParam", $"{path1};{path2}");
-            ValidateOutputItems("TaskItemIntArrayOutput", [path1, path2]);
+            SetTaskParameter("TaskItemIntArrayParam", "42;99");
+            ValidateOutputItems("TaskItemIntArrayOutput", new string[] { "42", "99" });
         }
 
         /// <summary>
-        /// Validate that a TaskItem&lt;AbsolutePath&gt; array output to a property produces the correct semi-colon-delimited evaluated value.
+        /// Validate that a TaskItem&lt;int&gt; array output to a property produces the correct semi-colon-delimited evaluated value.
         /// </summary>
         [Fact]
         public void TestOutputTaskItemIntArrayToProperty()
         {
-            string path1 = NativeMethodsShared.IsWindows ? @"C:\temp\typed-item-output-1.txt" : "/tmp/typed-item-output-1.txt";
-            string path2 = NativeMethodsShared.IsWindows ? @"C:\temp\typed-item-output-2.txt" : "/tmp/typed-item-output-2.txt";
-            SetTaskParameter("TaskItemIntArrayParam", $"{path1};{path2}");
-            ValidateOutputProperty("TaskItemIntArrayOutput", $"{path1};{path2}");
+            SetTaskParameter("TaskItemIntArrayParam", "42;99");
+            ValidateOutputProperty("TaskItemIntArrayOutput", "42;99");
         }
 
         #endregion
@@ -1989,31 +1592,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             SetTaskParameter(parameterName, value);
 
             Assert.True(_parametersSetOnTask.ContainsKey(parameterName));
-
-            object actualValue = _parametersSetOnTask[parameterName];
-
-            // Special handling for FileInfo and DirectoryInfo - compare FullName instead of object equality
-            if (expectedValue is FileInfo expectedFileInfo && actualValue is FileInfo actualFileInfo)
-            {
-                Assert.Equal(expectedFileInfo.FullName, actualFileInfo.FullName);
-            }
-            else if (expectedValue is DirectoryInfo expectedDirInfo && actualValue is DirectoryInfo actualDirInfo)
-            {
-                Assert.Equal(expectedDirInfo.FullName, actualDirInfo.FullName);
-            }
-            // Special handling for TaskItem<FileInfo> and TaskItem<DirectoryInfo> - compare FullName through ItemSpec
-            else if (expectedValue is ITaskItem<FileInfo> expectedTaskItemFileInfo && actualValue is ITaskItem<FileInfo> actualTaskItemFileInfo)
-            {
-                Assert.Equal(expectedTaskItemFileInfo.Value.FullName, actualTaskItemFileInfo.Value.FullName);
-            }
-            else if (expectedValue is ITaskItem<DirectoryInfo> expectedTaskItemDirInfo && actualValue is ITaskItem<DirectoryInfo> actualTaskItemDirInfo)
-            {
-                Assert.Equal(expectedTaskItemDirInfo.Value.FullName, actualTaskItemDirInfo.Value.FullName);
-            }
-            else
-            {
-                Assert.Equal(expectedValue, actualValue);
-            }
+            Assert.Equal(expectedValue, _parametersSetOnTask[parameterName]);
         }
 
         /// <summary>
@@ -2108,31 +1687,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             Assert.Equal(expectedArray.Length, actualArray.Length);
             for (int i = 0; i < expectedArray.Length; i++)
             {
-                object expected = expectedArray.GetValue(i);
-                object actual = actualArray.GetValue(i);
-
-                // Special handling for FileInfo and DirectoryInfo - compare FullName instead of object equality
-                if (expected is FileInfo expectedFileInfo && actual is FileInfo actualFileInfo)
-                {
-                    Assert.Equal(expectedFileInfo.FullName, actualFileInfo.FullName);
-                }
-                else if (expected is DirectoryInfo expectedDirInfo && actual is DirectoryInfo actualDirInfo)
-                {
-                    Assert.Equal(expectedDirInfo.FullName, actualDirInfo.FullName);
-                }
-                // Special handling for TaskItem<FileInfo> and TaskItem<DirectoryInfo> - compare FullName through ItemSpec
-                else if (expected is ITaskItem<FileInfo> expectedTaskItemFileInfo && actual is ITaskItem<FileInfo> actualTaskItemFileInfo)
-                {
-                    Assert.Equal(expectedTaskItemFileInfo.Value.FullName, actualTaskItemFileInfo.Value.FullName);
-                }
-                else if (expected is ITaskItem<DirectoryInfo> expectedTaskItemDirInfo && actual is ITaskItem<DirectoryInfo> actualTaskItemDirInfo)
-                {
-                    Assert.Equal(expectedTaskItemDirInfo.Value.FullName, actualTaskItemDirInfo.Value.FullName);
-                }
-                else
-                {
-                    Assert.Equal(expected, actual);
-                }
+                Assert.Equal(expectedArray.GetValue(i), actualArray.GetValue(i));
             }
         }
 

--- a/src/Build.UnitTests/BackEnd/TaskExecutionHost_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/TaskExecutionHost_Tests.cs
@@ -577,6 +577,18 @@ namespace Microsoft.Build.UnitTests.BackEnd
         }
 
         /// <summary>
+        /// Validate that parse failures from TaskItem&lt;T&gt; scalar binding are reported as invalid task parameter values.
+        /// </summary>
+        [Fact]
+        public void TestSetTaskItemIntParamInvalidValue()
+        {
+            var parameters = GetStandardParametersDictionary(true);
+            parameters["TaskItemIntParam"] = ("not-an-int", ElementLocation.Create("foo.proj"));
+
+            Should.Throw<InvalidProjectFileException>(() => _host.SetTaskParameters(parameters));
+        }
+
+        /// <summary>
         /// Validate that setting the parameter with an empty value does not cause it to be set.
         /// </summary>
         [Fact]
@@ -627,6 +639,18 @@ namespace Microsoft.Build.UnitTests.BackEnd
                 new Microsoft.Build.Utilities.TaskItem<int>(20),
                 new Microsoft.Build.Utilities.TaskItem<int>(30)
             });
+        }
+
+        /// <summary>
+        /// Validate that parse failures from TaskItem&lt;T&gt; array binding are reported as invalid task parameter values.
+        /// </summary>
+        [Fact]
+        public void TestSetTaskItemIntArrayParamInvalidValue()
+        {
+            var parameters = GetStandardParametersDictionary(true);
+            parameters["TaskItemIntArrayParam"] = ("10;not-an-int", ElementLocation.Create("foo.proj"));
+
+            Should.Throw<InvalidProjectFileException>(() => _host.SetTaskParameters(parameters));
         }
 
         /// <summary>

--- a/src/Build/BackEnd/TaskExecutionHost/TaskExecutionHost.cs
+++ b/src/Build/BackEnd/TaskExecutionHost/TaskExecutionHost.cs
@@ -788,7 +788,15 @@ namespace Microsoft.Build.BackEnd
             Type constructedType = typeof(TaskItem<>).MakeGenericType(valueType);
             ConstructorInfo constructor = constructedType.GetConstructor(new[] { typeof(ITaskItem) });
 
-            return constructor.Invoke(new object[] { item });
+            try
+            {
+                return constructor.Invoke(new object[] { item });
+            }
+            catch (TargetInvocationException e) when (e.InnerException is not null)
+            {
+                System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(e.InnerException).Throw();
+                throw;
+            }
         }
 
         /// <summary>

--- a/src/Build/BackEnd/TaskExecutionHost/TaskExecutionHost.cs
+++ b/src/Build/BackEnd/TaskExecutionHost/TaskExecutionHost.cs
@@ -6,7 +6,6 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
-using System.IO;
 using System.Linq;
 using System.Reflection;
 #if FEATURE_APPDOMAIN
@@ -756,58 +755,24 @@ namespace Microsoft.Build.BackEnd
 
         #region Local Methods
 
-        private static bool IsSupportedTaskItemTypeArgument(Type typeArg) =>
-            typeArg == typeof(AbsolutePath) ||
-            typeArg == typeof(FileInfo) ||
-            typeArg == typeof(DirectoryInfo);
-
         /// <summary>
-        /// Checks if a type is ITaskItem&lt;T&gt; or TaskItem&lt;T&gt; where T is supported by MSBuild task binding.
+        /// Checks if a type is TaskItem&lt;T&gt; where T is a value type.
         /// </summary>
         private static bool IsTaskItemOfT(Type parameterType)
         {
             if (!parameterType.GetTypeInfo().IsGenericType)
             {
-                foreach (Type implementedInterface in parameterType.GetTypeInfo().ImplementedInterfaces)
-                {
-                    if (implementedInterface.GetTypeInfo().IsGenericType &&
-                        implementedInterface.GetGenericTypeDefinition() == typeof(ITaskItem<>))
-                    {
-                        return IsSupportedTaskItemTypeArgument(implementedInterface.GetGenericArguments()[0]);
-                    }
-                }
-
                 return false;
             }
 
             Type genericTypeDefinition = parameterType.GetGenericTypeDefinition();
-            if (genericTypeDefinition == typeof(ITaskItem<>))
+            if (genericTypeDefinition != typeof(ITaskItem<>) && genericTypeDefinition != typeof(TaskItem<>))
             {
-                Type[] genericArguments = parameterType.GetGenericArguments();
-                if (genericArguments.Length != 1)
-                {
-                    return false;
-                }
-
-                return IsSupportedTaskItemTypeArgument(genericArguments[0]);
+                return false;
             }
 
-            if (string.Equals(genericTypeDefinition.FullName, "Microsoft.Build.Utilities.TaskItem`1", StringComparison.Ordinal))
-            {
-                Type[] genericArguments = parameterType.GetGenericArguments();
-                return genericArguments.Length == 1 && IsSupportedTaskItemTypeArgument(genericArguments[0]);
-            }
-
-            foreach (Type implementedInterface in parameterType.GetTypeInfo().ImplementedInterfaces)
-            {
-                if (implementedInterface.GetTypeInfo().IsGenericType &&
-                    implementedInterface.GetGenericTypeDefinition() == typeof(ITaskItem<>))
-                {
-                    return IsSupportedTaskItemTypeArgument(implementedInterface.GetGenericArguments()[0]);
-                }
-            }
-
-            return false;
+            Type[] genericArguments = parameterType.GetGenericArguments();
+            return genericArguments.Length == 1 && genericArguments[0].GetTypeInfo().IsValueType;
         }
 
         /// <summary>
@@ -820,7 +785,7 @@ namespace Microsoft.Build.BackEnd
             Type valueType = genericArguments[0];
 
             // Create TaskItem<T> using the constructor that takes ITaskItem
-            Type constructedType = typeof(Microsoft.Build.Utilities.TaskItem<>).MakeGenericType(valueType);
+            Type constructedType = typeof(TaskItem<>).MakeGenericType(valueType);
             ConstructorInfo constructor = constructedType.GetConstructor(new[] { typeof(ITaskItem) });
 
             return constructor.Invoke(new object[] { item });
@@ -843,20 +808,6 @@ namespace Microsoft.Build.BackEnd
             if (parameterType == typeof(AbsolutePath))
             {
                 return InternalSetTaskParameter(parameter, TaskEnvironment.GetAbsolutePath(expandedParameterValue));
-            }
-
-            // Special handling for FileInfo - validate path through AbsolutePath first
-            if (parameterType == typeof(FileInfo))
-            {
-                AbsolutePath absolutePath = TaskEnvironment.GetAbsolutePath(expandedParameterValue);
-                return InternalSetTaskParameter(parameter, new FileInfo(absolutePath.Value));
-            }
-
-            // Special handling for DirectoryInfo - validate path through AbsolutePath first
-            if (parameterType == typeof(DirectoryInfo))
-            {
-                AbsolutePath absolutePath = TaskEnvironment.GetAbsolutePath(expandedParameterValue);
-                return InternalSetTaskParameter(parameter, new DirectoryInfo(absolutePath.Value));
             }
 
             // Use the unified ValueTypeParser for all other types
@@ -894,16 +845,6 @@ namespace Microsoft.Build.BackEnd
                         else if (parameterType == typeof(AbsolutePath[]))
                         {
                             finalTaskInputs.Add(TaskEnvironment.GetAbsolutePath(item.ItemSpec));
-                        }
-                        else if (parameterType == typeof(FileInfo[]))
-                        {
-                            AbsolutePath absolutePath = TaskEnvironment.GetAbsolutePath(item.ItemSpec);
-                            finalTaskInputs.Add(new FileInfo(absolutePath.Value));
-                        }
-                        else if (parameterType == typeof(DirectoryInfo[]))
-                        {
-                            AbsolutePath absolutePath = TaskEnvironment.GetAbsolutePath(item.ItemSpec);
-                            finalTaskInputs.Add(new DirectoryInfo(absolutePath.Value));
                         }
                         else
                         {

--- a/src/Framework/ITaskItem_T.cs
+++ b/src/Framework/ITaskItem_T.cs
@@ -9,13 +9,12 @@ namespace Microsoft.Build.Framework
     /// A strongly-typed task item interface that wraps a value of type <typeparamref name="T"/>
     /// and provides access to it along with standard task item functionality.
     /// </summary>
-    /// <typeparam name="T">The type of the value. Must be a value type.</typeparam>
+    /// <typeparam name="T">The type of the value.</typeparam>
     /// <remarks>
     /// This interface allows tasks to receive strongly-typed parameters while still working with MSBuild's item system.
     /// The value is parsed from the item's identity (ItemSpec) using MSBuild's standard parsing conventions.
     /// </remarks>
     public interface ITaskItem<T> : ITaskItem2
-        where T : struct
     {
         /// <summary>
         /// Gets the strongly-typed value parsed from the item's identity.

--- a/src/Framework/ITaskItem_T.cs
+++ b/src/Framework/ITaskItem_T.cs
@@ -9,13 +9,13 @@ namespace Microsoft.Build.Framework
     /// A strongly-typed task item interface that wraps a value of type <typeparamref name="T"/>
     /// and provides access to it along with standard task item functionality.
     /// </summary>
-    /// <typeparam name="T">The type of the value. Can be a value type, FileInfo, or DirectoryInfo.</typeparam>
+    /// <typeparam name="T">The type of the value. Must be a value type.</typeparam>
     /// <remarks>
     /// This interface allows tasks to receive strongly-typed parameters while still working with MSBuild's item system.
     /// The value is parsed from the item's identity (ItemSpec) using MSBuild's standard parsing conventions.
-    /// Supported types include primitive value types (int, bool, etc.), AbsolutePath, FileInfo, and DirectoryInfo.
     /// </remarks>
     public interface ITaskItem<T> : ITaskItem2
+        where T : struct
     {
         /// <summary>
         /// Gets the strongly-typed value parsed from the item's identity.

--- a/src/Shared/TaskParameter.cs
+++ b/src/Shared/TaskParameter.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 using Microsoft.Build.Collections;
@@ -41,12 +42,14 @@ namespace Microsoft.Build.BackEnd
         PrimitiveTypeArray,
 
         /// <summary>
-        /// Parameter is a value type.  Note:  Must be <see cref="IConvertible"/>.
+        /// Parameter is a non-primitive value serialized as a string (for example a value type
+        /// such as <see cref="AbsolutePath"/>, or <see cref="FileInfo"/>/<see cref="DirectoryInfo"/>).
         /// </summary>
         ValueType,
 
         /// <summary>
-        /// Parameter is an array of value types.  Note:  Must be <see cref="IConvertible"/>.
+        /// Parameter is an array of non-primitive values serialized as strings (for example an array
+        /// of value types, or <see cref="FileInfo"/>[]/<see cref="DirectoryInfo"/>[]).
         /// </summary>
         ValueTypeArray,
 
@@ -141,8 +144,11 @@ namespace Microsoft.Build.BackEnd
 
                     _wrappedParameter = taskItemArrayParameter;
                 }
-                else if (wrappedParameterType.GetElementType().GetTypeInfo().IsValueType)
+                else if (wrappedParameterType.GetElementType().GetTypeInfo().IsValueType
+                    || wrappedParameterType.GetElementType() == typeof(FileInfo)
+                    || wrappedParameterType.GetElementType() == typeof(DirectoryInfo))
                 {
+                    // Value-type arrays as well as FileInfo[]/DirectoryInfo[] are serialized as strings.
                     _parameterType = TaskParameterType.ValueTypeArray;
                     _wrappedParameter = wrappedParameter;
                 }
@@ -176,8 +182,11 @@ namespace Microsoft.Build.BackEnd
                     _parameterType = TaskParameterType.ITaskItem;
                     _wrappedParameter = new TaskParameterTaskItem((ITaskItem)wrappedParameter);
                 }
-                else if (wrappedParameterType.GetTypeInfo().IsValueType)
+                else if (wrappedParameterType.GetTypeInfo().IsValueType
+                    || wrappedParameterType == typeof(FileInfo)
+                    || wrappedParameterType == typeof(DirectoryInfo))
                 {
+                    // Value types as well as FileInfo/DirectoryInfo are serialized as strings.
                     _parameterType = TaskParameterType.ValueType;
                     _wrappedParameter = wrappedParameter;
                 }
@@ -465,37 +474,39 @@ namespace Microsoft.Build.BackEnd
         }
 
         /// <summary>
-        /// Serializes or deserializes the value type instance wrapped by this <see cref="TaskParameter"/>.
+        /// Serializes or deserializes the value instance wrapped by this <see cref="TaskParameter"/>.
         /// </summary>
         /// <remarks>
-        /// The value type is converted to/from string using the <see cref="Convert"/> class. Note that we require
-        /// task parameter types to be <see cref="IConvertible"/> so this conversion is guaranteed to work for parameters
-        /// that have made it this far.
+        /// The value is converted to a string on the write side using <see cref="ValueTypeParser.ToString"/>,
+        /// the same canonical conversion the in-process engine uses when gathering task outputs
+        /// (see TaskExecutionHost.GetValueOutputs). This guarantees identical string output across the
+        /// in-process and out-of-process task host paths. The value is not converted back to its original
+        /// type on the read side: this is fine because output task parameters are anyway converted to strings
+        /// by the engine and input task parameters of custom value types are not supported.
         /// </remarks>
         private void TranslateValueType(ITranslator translator)
         {
             string valueString = null;
             if (translator.Mode == TranslationDirection.WriteToStream)
             {
-                valueString = (string)Convert.ChangeType(_wrappedParameter, typeof(string), CultureInfo.InvariantCulture);
+                valueString = ValueTypeParser.ToString(_wrappedParameter);
             }
 
             translator.Translate(ref valueString);
 
             if (translator.Mode == TranslationDirection.ReadFromStream)
             {
-                // We don't know how to convert the string back to the original value type. This is fine because output
-                // task parameters are anyway converted to strings by the engine (see TaskExecutionHost.GetValueOutputs)
-                // and input task parameters of custom value types are not supported.
                 _wrappedParameter = valueString;
             }
         }
 
         /// <summary>
-        /// Serializes or deserializes the value type array instance wrapped by this <see cref="TaskParameter"/>.
+        /// Serializes or deserializes the array instance wrapped by this <see cref="TaskParameter"/>.
         /// </summary>
         /// <remarks>
-        /// The array is assumed to be non-null.
+        /// The array is assumed to be non-null. Each element is converted to a string on the write side
+        /// using <see cref="ValueTypeParser.ToString"/>, the same canonical conversion the in-process engine
+        /// uses when gathering task outputs.
         /// </remarks>
         private void TranslateValueTypeArray(ITranslator translator)
         {
@@ -508,7 +519,7 @@ namespace Microsoft.Build.BackEnd
 
                 for (int i = 0; i < length; i++)
                 {
-                    string valueString = Convert.ToString(array.GetValue(i), CultureInfo.InvariantCulture);
+                    string valueString = ValueTypeParser.ToString(array.GetValue(i));
                     translator.Translate(ref valueString);
                 }
             }

--- a/src/Shared/TaskParameterTypeVerifier.cs
+++ b/src/Shared/TaskParameterTypeVerifier.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.IO;
 using System.Reflection;
 using Microsoft.Build.Framework;
 
@@ -15,76 +14,27 @@ namespace Microsoft.Build.BackEnd
     /// </summary>
     internal static class TaskParameterTypeVerifier
     {
-        private static bool IsSupportedTaskItemTypeArgument(Type typeArg) =>
-            typeArg == typeof(AbsolutePath) ||
-            typeArg == typeof(FileInfo) ||
-            typeArg == typeof(DirectoryInfo);
-
-        private static bool IsTaskItemGenericType(Type type)
-        {
-            if (type.GetTypeInfo().IsGenericType && type.GetGenericTypeDefinition() == typeof(ITaskItem<>))
-            {
-                return true;
-            }
-
-            if (type.GetTypeInfo().IsGenericType &&
-                string.Equals(type.GetGenericTypeDefinition().FullName, "Microsoft.Build.Utilities.TaskItem`1", StringComparison.Ordinal))
-            {
-                return true;
-            }
-
-            foreach (Type implementedInterface in type.GetTypeInfo().ImplementedInterfaces)
-            {
-                if (implementedInterface.GetTypeInfo().IsGenericType &&
-                    implementedInterface.GetGenericTypeDefinition() == typeof(ITaskItem<>))
-                {
-                    return true;
-                }
-            }
-
-            return false;
-        }
-
+#if !TASKHOST
         /// <summary>
-        /// Checks if a type is ITaskItem&lt;T&gt; or TaskItem&lt;T&gt; where T is supported by MSBuild task binding.
+        /// Checks if a type is ITaskItem&lt;T&gt; where T is a value type.
         /// </summary>
         private static bool IsTaskItemOfT(Type parameterType)
         {
-            if (!IsTaskItemGenericType(parameterType))
+            if (!parameterType.GetTypeInfo().IsGenericType)
             {
                 return false;
             }
 
-            Type taskItemType = parameterType;
-            if (!(taskItemType.GetTypeInfo().IsGenericType && taskItemType.GetGenericTypeDefinition() == typeof(ITaskItem<>)))
+            Type genericTypeDefinition = parameterType.GetGenericTypeDefinition();
+            if (genericTypeDefinition != typeof(ITaskItem<>))
             {
-                if (taskItemType.GetTypeInfo().IsGenericType &&
-                    string.Equals(taskItemType.GetGenericTypeDefinition().FullName, "Microsoft.Build.Utilities.TaskItem`1", StringComparison.Ordinal))
-                {
-                    return IsSupportedTaskItemTypeArgument(taskItemType.GetGenericArguments()[0]);
-                }
-
-                taskItemType = null;
-
-                foreach (Type implementedInterface in parameterType.GetTypeInfo().ImplementedInterfaces)
-                {
-                    if (implementedInterface.GetTypeInfo().IsGenericType &&
-                        implementedInterface.GetGenericTypeDefinition() == typeof(ITaskItem<>))
-                    {
-                        taskItemType = implementedInterface;
-                        break;
-                    }
-                }
-
-                if (taskItemType is null)
-                {
-                    return false;
-                }
+                return false;
             }
 
-            Type[] genericArguments = taskItemType.GetGenericArguments();
-            return genericArguments.Length == 1 && IsSupportedTaskItemTypeArgument(genericArguments[0]);
+            Type[] genericArguments = parameterType.GetGenericArguments();
+            return genericArguments.Length == 1 && genericArguments[0].GetTypeInfo().IsValueType;
         }
+#endif
 
         /// <summary>
         /// Is the parameter type a valid scalar input value
@@ -93,10 +43,10 @@ namespace Microsoft.Build.BackEnd
             parameterType.GetTypeInfo().IsValueType ||
             parameterType == typeof(string) ||
             parameterType == typeof(ITaskItem)
+#if !TASKHOST
             || parameterType == typeof(AbsolutePath)
-            || parameterType == typeof(FileInfo)
-            || parameterType == typeof(DirectoryInfo)
             || IsTaskItemOfT(parameterType)
+#endif
             ;
 
         /// <summary>
@@ -114,10 +64,10 @@ namespace Microsoft.Build.BackEnd
             bool result = elementType.GetTypeInfo().IsValueType ||
                         parameterType == typeof(string[]) ||
                         parameterType == typeof(ITaskItem[])
+#if !TASKHOST
                         || parameterType == typeof(AbsolutePath[])
-                        || parameterType == typeof(FileInfo[])
-                        || parameterType == typeof(DirectoryInfo[])
                         || IsTaskItemOfT(elementType)
+#endif
                         ;
             return result;
         }
@@ -127,24 +77,26 @@ namespace Microsoft.Build.BackEnd
         /// </summary>
         internal static bool IsAssignableToITaskItem(Type parameterType)
         {
-            if (parameterType.IsArray)
-            {
-                Type elementType = parameterType.GetElementType();
+            // Check if it's directly assignable
+            bool result = typeof(ITaskItem[]).GetTypeInfo().IsAssignableFrom(parameterType.GetTypeInfo()) ||    /* ITaskItem array or derived type, or */
+                          typeof(ITaskItem).IsAssignableFrom(parameterType);                                    /* ITaskItem or derived type */
 
-                if (IsTaskItemGenericType(elementType))
+#if !TASKHOST
+            // Also check for TaskItem<T> or TaskItem<T>[]
+            if (!result)
+            {
+                if (parameterType.IsArray)
                 {
-                    return IsTaskItemOfT(elementType);
+                    result = IsTaskItemOfT(parameterType.GetElementType());
                 }
-
-                return typeof(ITaskItem).IsAssignableFrom(elementType);
+                else
+                {
+                    result = IsTaskItemOfT(parameterType);
+                }
             }
+#endif
 
-            if (IsTaskItemGenericType(parameterType))
-            {
-                return IsTaskItemOfT(parameterType);
-            }
-
-            return typeof(ITaskItem).IsAssignableFrom(parameterType);
+            return result;
         }
 
         /// <summary>
@@ -154,14 +106,14 @@ namespace Microsoft.Build.BackEnd
         {
             bool result = (parameterType.IsArray && parameterType.GetElementType().GetTypeInfo().IsValueType) ||    /* array of value types, or */
                           parameterType == typeof(string[]) ||                                                      /* string array, or */
+#if !TASKHOST
                           parameterType == typeof(AbsolutePath[]) ||                                                /* AbsolutePath array, or */
-                          parameterType == typeof(FileInfo[]) ||                                                    /* FileInfo array, or */
-                          parameterType == typeof(DirectoryInfo[]) ||                                               /* DirectoryInfo array, or */
+#endif
                           parameterType.GetTypeInfo().IsValueType ||                                                /* value type, or */
                           parameterType == typeof(string)                                                           /* string, or */
-                          || parameterType == typeof(AbsolutePath)                                                  /* AbsolutePath, or */
-                          || parameterType == typeof(FileInfo)                                                      /* FileInfo, or */
-                          || parameterType == typeof(DirectoryInfo)                                                 /* DirectoryInfo */
+#if !TASKHOST
+                          || parameterType == typeof(AbsolutePath)                                                  /* AbsolutePath */
+#endif
                           ;
             return result;
         }
@@ -179,19 +131,6 @@ namespace Microsoft.Build.BackEnd
         /// </summary>
         internal static bool IsValidOutputParameter(Type parameterType)
         {
-            if (parameterType.IsArray)
-            {
-                Type elementType = parameterType.GetElementType();
-                if (IsTaskItemGenericType(elementType) && !IsTaskItemOfT(elementType))
-                {
-                    return false;
-                }
-            }
-            else if (IsTaskItemGenericType(parameterType) && !IsTaskItemOfT(parameterType))
-            {
-                return false;
-            }
-
             return IsValueTypeOutputParameter(parameterType) || IsAssignableToITaskItem(parameterType);
         }
     }

--- a/src/Shared/UnitTests/TaskParameter_Tests.cs
+++ b/src/Shared/UnitTests/TaskParameter_Tests.cs
@@ -165,6 +165,135 @@ namespace Microsoft.Build.UnitTests
             Assert.Equal(value[1].ToString(CultureInfo.InvariantCulture), stringArray[1]);
         }
 
+        /// <summary>
+        /// A default <see cref="AbsolutePath"/> (null Value) must serialize cleanly. This is the
+        /// scenario that crashed the out-of-proc task host: a struct-typed output is never null, so
+        /// it always gets serialized, and the old code threw InvalidCastException because AbsolutePath
+        /// is not IConvertible. See https://github.com/dotnet/msbuild/pull/13016.
+        /// </summary>
+        [Fact]
+        public void DefaultAbsolutePathParameter()
+        {
+            TaskParameter t = new TaskParameter(default(AbsolutePath));
+
+            Assert.Equal(TaskParameterType.ValueType, t.ParameterType);
+
+            ((ITranslatable)t).Translate(TranslationHelpers.GetWriteTranslator());
+            TaskParameter t2 = TaskParameter.FactoryForDeserialization(TranslationHelpers.GetReadTranslator());
+
+            // A default AbsolutePath has a null Value and serializes to the empty string.
+            Assert.Equal(string.Empty, t2.WrappedParameter);
+            Assert.Equal(TaskParameterType.ValueType, t2.ParameterType);
+        }
+
+        [Fact]
+        public void AbsolutePathParameter()
+        {
+            string path = Path.Combine(Path.GetTempPath(), "TaskParameterTests_file.txt");
+            AbsolutePath value = new AbsolutePath(path);
+            TaskParameter t = new TaskParameter(value);
+
+            Assert.Equal(TaskParameterType.ValueType, t.ParameterType);
+
+            ((ITranslatable)t).Translate(TranslationHelpers.GetWriteTranslator());
+            TaskParameter t2 = TaskParameter.FactoryForDeserialization(TranslationHelpers.GetReadTranslator());
+
+            // Path types are serialized using the same canonical conversion as the in-process engine.
+            Assert.Equal(value.Value, t2.WrappedParameter);
+            Assert.Equal(TaskParameterType.ValueType, t2.ParameterType);
+        }
+
+        [Fact]
+        public void AbsolutePathArrayParameter()
+        {
+            AbsolutePath[] value = new AbsolutePath[]
+            {
+                new AbsolutePath(Path.Combine(Path.GetTempPath(), "a.txt")),
+                new AbsolutePath(Path.Combine(Path.GetTempPath(), "b.txt")),
+            };
+            TaskParameter t = new TaskParameter(value);
+
+            Assert.Equal(TaskParameterType.ValueTypeArray, t.ParameterType);
+
+            ((ITranslatable)t).Translate(TranslationHelpers.GetWriteTranslator());
+            TaskParameter t2 = TaskParameter.FactoryForDeserialization(TranslationHelpers.GetReadTranslator());
+
+            string[] stringArray = Assert.IsType<string[]>(t2.WrappedParameter);
+            Assert.Equal(value[0].Value, stringArray[0]);
+            Assert.Equal(value[1].Value, stringArray[1]);
+        }
+
+        [Fact]
+        public void FileInfoParameter()
+        {
+            FileInfo value = new FileInfo(Path.Combine(Path.GetTempPath(), "TaskParameterTests_file.txt"));
+            TaskParameter t = new TaskParameter(value);
+
+            Assert.Equal(TaskParameterType.ValueType, t.ParameterType);
+
+            ((ITranslatable)t).Translate(TranslationHelpers.GetWriteTranslator());
+            TaskParameter t2 = TaskParameter.FactoryForDeserialization(TranslationHelpers.GetReadTranslator());
+
+            // FileInfo is serialized as its full path, matching ValueTypeParser/the in-process engine.
+            Assert.Equal(value.FullName, t2.WrappedParameter);
+            Assert.Equal(TaskParameterType.ValueType, t2.ParameterType);
+        }
+
+        [Fact]
+        public void DirectoryInfoParameter()
+        {
+            DirectoryInfo value = new DirectoryInfo(Path.Combine(Path.GetTempPath(), "TaskParameterTests_dir"));
+            TaskParameter t = new TaskParameter(value);
+
+            Assert.Equal(TaskParameterType.ValueType, t.ParameterType);
+
+            ((ITranslatable)t).Translate(TranslationHelpers.GetWriteTranslator());
+            TaskParameter t2 = TaskParameter.FactoryForDeserialization(TranslationHelpers.GetReadTranslator());
+
+            Assert.Equal(value.FullName, t2.WrappedParameter);
+            Assert.Equal(TaskParameterType.ValueType, t2.ParameterType);
+        }
+
+        [Fact]
+        public void FileInfoArrayParameter()
+        {
+            FileInfo[] value = new FileInfo[]
+            {
+                new FileInfo(Path.Combine(Path.GetTempPath(), "a.txt")),
+                new FileInfo(Path.Combine(Path.GetTempPath(), "b.txt")),
+            };
+            TaskParameter t = new TaskParameter(value);
+
+            Assert.Equal(TaskParameterType.ValueTypeArray, t.ParameterType);
+
+            ((ITranslatable)t).Translate(TranslationHelpers.GetWriteTranslator());
+            TaskParameter t2 = TaskParameter.FactoryForDeserialization(TranslationHelpers.GetReadTranslator());
+
+            string[] stringArray = Assert.IsType<string[]>(t2.WrappedParameter);
+            Assert.Equal(value[0].FullName, stringArray[0]);
+            Assert.Equal(value[1].FullName, stringArray[1]);
+        }
+
+        [Fact]
+        public void DirectoryInfoArrayParameter()
+        {
+            DirectoryInfo[] value = new DirectoryInfo[]
+            {
+                new DirectoryInfo(Path.Combine(Path.GetTempPath(), "dirA")),
+                new DirectoryInfo(Path.Combine(Path.GetTempPath(), "dirB")),
+            };
+            TaskParameter t = new TaskParameter(value);
+
+            Assert.Equal(TaskParameterType.ValueTypeArray, t.ParameterType);
+
+            ((ITranslatable)t).Translate(TranslationHelpers.GetWriteTranslator());
+            TaskParameter t2 = TaskParameter.FactoryForDeserialization(TranslationHelpers.GetReadTranslator());
+
+            string[] stringArray = Assert.IsType<string[]>(t2.WrappedParameter);
+            Assert.Equal(value[0].FullName, stringArray[0]);
+            Assert.Equal(value[1].FullName, stringArray[1]);
+        }
+
         private enum TestEnumForParameter
         {
             Something,

--- a/src/Shared/ValueTypeParser.cs
+++ b/src/Shared/ValueTypeParser.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Globalization;
-using System.IO;
 using Microsoft.Build.Framework;
 
 #nullable enable
@@ -62,18 +61,6 @@ namespace Microsoft.Build.Shared
                 if (targetType == typeof(AbsolutePath))
                 {
                     return new AbsolutePath(value);
-                }
-
-                // Special handling for FileInfo
-                if (targetType == typeof(FileInfo))
-                {
-                    return new FileInfo(value);
-                }
-
-                // Special handling for DirectoryInfo
-                if (targetType == typeof(DirectoryInfo))
-                {
-                    return new DirectoryInfo(value);
                 }
 
                 // Special handling for bool - MSBuild supports various boolean representations
@@ -143,17 +130,6 @@ namespace Microsoft.Build.Shared
             if (value is AbsolutePath absolutePath)
             {
                 return absolutePath.Value;
-            }
-
-            // FileInfo and DirectoryInfo need special handling to return their path
-            if (value is FileInfo fileInfo)
-            {
-                return fileInfo.FullName;
-            }
-
-            if (value is DirectoryInfo directoryInfo)
-            {
-                return directoryInfo.FullName;
             }
 
             // Use InvariantCulture for consistent formatting

--- a/src/Shared/ValueTypeParser.cs
+++ b/src/Shared/ValueTypeParser.cs
@@ -129,7 +129,7 @@ namespace Microsoft.Build.Shared
             // AbsolutePath needs special handling because Convert.ChangeType doesn't work with implicit operators
             if (value is AbsolutePath absolutePath)
             {
-                return absolutePath.Value;
+                return absolutePath.Value ?? string.Empty;
             }
 
             // Use InvariantCulture for consistent formatting

--- a/src/TaskAnalyzer.Tests/PreferTypedParameterAnalyzerTests.cs
+++ b/src/TaskAnalyzer.Tests/PreferTypedParameterAnalyzerTests.cs
@@ -931,4 +931,73 @@ public class PreferTypedParameterAnalyzerTests
         task7[0].GetMessage().ShouldNotContain("FileInfo");
         task7[0].GetMessage().ShouldNotContain("DirectoryInfo");
     }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Fix #5: Restrict to ValueTypeParser-supported types only
+    // ═══════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task GuidParse_FromItemSpec_NoDiagnostic()
+    {
+        // Guid is not supported by ValueTypeParser, so no diagnostic should be emitted.
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+            using System;
+            using Microsoft.Build.Framework;
+            [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
+            public class MyTask : Microsoft.Build.Utilities.Task, Microsoft.Build.Framework.IMultiThreadableTask
+            {
+                public ITaskItem Item { get; set; } = null!;
+                public override bool Execute()
+                {
+                    var id = Guid.Parse(Item.ItemSpec);
+                    return true;
+                }
+            }
+            """);
+
+        diags.ShouldNotContain(d => d.Id == DiagnosticIds.PreferTypedTaskItem);
+    }
+
+    [Fact]
+    public async Task TimeSpanParse_FromItemSpec_NoDiagnostic()
+    {
+        // TimeSpan is not supported by ValueTypeParser, so no diagnostic should be emitted.
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+            using System;
+            using Microsoft.Build.Framework;
+            [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
+            public class MyTask : Microsoft.Build.Utilities.Task, Microsoft.Build.Framework.IMultiThreadableTask
+            {
+                public ITaskItem Item { get; set; } = null!;
+                public override bool Execute()
+                {
+                    var ts = TimeSpan.Parse(Item.ItemSpec);
+                    return true;
+                }
+            }
+            """);
+
+        diags.ShouldNotContain(d => d.Id == DiagnosticIds.PreferTypedTaskItem);
+    }
+
+    [Fact]
+    public async Task IntParse_FromItemSpec_StillProducesDiagnostic()
+    {
+        // int is supported by ValueTypeParser, so the diagnostic should still fire.
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+            using Microsoft.Build.Framework;
+            [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
+            public class MyTask : Microsoft.Build.Utilities.Task, Microsoft.Build.Framework.IMultiThreadableTask
+            {
+                public ITaskItem Item { get; set; } = null!;
+                public override bool Execute()
+                {
+                    var n = int.Parse(Item.ItemSpec);
+                    return true;
+                }
+            }
+            """);
+
+        diags.ShouldContain(d => d.Id == DiagnosticIds.PreferTypedTaskItem);
+    }
 }

--- a/src/TaskAnalyzer/PreferTypedParameterAnalyzer.cs
+++ b/src/TaskAnalyzer/PreferTypedParameterAnalyzer.cs
@@ -534,16 +534,19 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
         /// <summary>
         /// Determines the parsed target type from a Parse/TryParse/Convert method call.
         /// Returns the simple type name suitable for ITaskItem&lt;T&gt; suggestion, or null if not a recognized parse call.
+        /// Only returns suggestions for types supported by ValueTypeParser.
         /// </summary>
         private static string? GetParsedTypeFromMethod(IMethodSymbol method)
         {
             // Static Parse/TryParse on value types: int.Parse, bool.Parse, etc.
+            // Restrict to types supported by ValueTypeParser to avoid suggesting unsupported types like Guid.
             if ((method.Name == "Parse" || method.Name == "TryParse") &&
                 method.IsStatic &&
                 method.ContainingType is not null &&
                 method.ContainingType.IsValueType)
             {
-                return method.ContainingType.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
+                string typeName = method.ContainingType.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
+                return s_supportedValueTypeNames.Contains(typeName) ? typeName : null;
             }
 
             // Convert.ToXxx methods
@@ -571,6 +574,28 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
 
             return null;
         }
+
+        /// <summary>
+        /// Value type names (as minimal C# names) that ValueTypeParser supports.
+        /// Only these types should be suggested by the analyzer.
+        /// </summary>
+        private static readonly System.Collections.Generic.HashSet<string> s_supportedValueTypeNames =
+            new(System.StringComparer.Ordinal)
+            {
+                "bool",
+                "char",
+                "byte",
+                "sbyte",
+                "short",
+                "ushort",
+                "int",
+                "uint",
+                "long",
+                "ulong",
+                "float",
+                "double",
+                "decimal",
+            };
 
         /// <summary>
         /// Checks if the given operation traces back (with at most one level of local indirection)

--- a/src/Utilities.UnitTests/TaskItem_Tests.cs
+++ b/src/Utilities.UnitTests/TaskItem_Tests.cs
@@ -439,4 +439,38 @@ namespace Microsoft.Build.UnitTests
         }
 #endif
     }
+
+    /// <summary>
+    /// Tests for the generic <see cref="TaskItem{T}"/> struct.
+    /// </summary>
+    public class TaskItemOfTTests
+    {
+        [Fact]
+        public void SetMetadata_DoesNotThrow()
+        {
+            var item = new TaskItem<int>(42);
+            // Should not throw - backing is a mutable TaskItem, not TaskItemData
+            item.SetMetadata("key", "value");
+            item.GetMetadata("key").ShouldBe("value");
+        }
+
+        [Fact]
+        public void RemoveMetadata_DoesNotThrow()
+        {
+            var item = new TaskItem<int>(42);
+            item.SetMetadata("key", "value");
+            item.RemoveMetadata("key");
+            item.GetMetadata("key").ShouldBeNullOrEmpty();
+        }
+
+        [Fact]
+        public void CopyMetadataTo_DoesNotThrow()
+        {
+            var source = new TaskItem<int>(42);
+            source.SetMetadata("key", "value");
+            var dest = new TaskItem("dest");
+            source.CopyMetadataTo(dest);
+            dest.GetMetadata("key").ShouldBe("value");
+        }
+    }
 }

--- a/src/Utilities.UnitTests/TaskItem_Tests.cs
+++ b/src/Utilities.UnitTests/TaskItem_Tests.cs
@@ -472,5 +472,26 @@ namespace Microsoft.Build.UnitTests
             source.CopyMetadataTo(dest);
             dest.GetMetadata("key").ShouldBe("value");
         }
+
+        [Fact]
+        public void FromITaskItem_PathLikeType_UsesFullPathMetadata()
+        {
+            // FullPath is a reserved metadata computed by the MSBuild item system as the absolute path.
+            // TaskItem<FileInfo> should use FullPath so relative ItemSpecs resolve to absolute paths.
+            var backingItem = new TaskItem("relative\\path.txt");
+            string expectedAbsolutePath = backingItem.GetMetadata("FullPath");
+            expectedAbsolutePath.ShouldNotBeNullOrEmpty();
+
+            var item = new TaskItem<System.IO.FileInfo>(backingItem);
+            item.Value.FullName.ShouldBe(expectedAbsolutePath);
+        }
+
+        [Fact]
+        public void FromITaskItem_NonPathType_UsesItemSpec()
+        {
+            var backingItem = new TaskItem("42");
+            var item = new TaskItem<int>(backingItem);
+            item.Value.ShouldBe(42);
+        }
     }
 }

--- a/src/Utilities.UnitTests/TaskItem_Tests.cs
+++ b/src/Utilities.UnitTests/TaskItem_Tests.cs
@@ -493,5 +493,47 @@ namespace Microsoft.Build.UnitTests
             var item = new TaskItem<int>(backingItem);
             item.Value.ShouldBe(42);
         }
+
+        [Fact]
+        public void Equals_SameValue_ReturnsTrue()
+        {
+            var a = new TaskItem<int>(42);
+            var b = new TaskItem<int>(42);
+            a.Equals(b).ShouldBeTrue();
+            (a == b).ShouldBeTrue();
+        }
+
+        [Fact]
+        public void Equals_DifferentValue_ReturnsFalse()
+        {
+            var a = new TaskItem<int>(1);
+            var b = new TaskItem<int>(2);
+            a.Equals(b).ShouldBeFalse();
+            (a != b).ShouldBeTrue();
+        }
+
+        [Fact]
+        public void Equals_NullStringValue_HandledCorrectly()
+        {
+            // EqualityComparer<string>.Default handles null without boxing or NullReferenceException
+            var a = new TaskItem<string>((string)null!);
+            var b = new TaskItem<string>((string)null!);
+            a.Equals(b).ShouldBeTrue();
+        }
+
+        [Fact]
+        public void GetHashCode_NullValue_ReturnsZero()
+        {
+            var item = new TaskItem<string>((string)null!);
+            item.GetHashCode().ShouldBe(0);
+        }
+
+        [Fact]
+        public void GetHashCode_ConsistentWithEquality()
+        {
+            var a = new TaskItem<int>(42);
+            var b = new TaskItem<int>(42);
+            a.GetHashCode().ShouldBe(b.GetHashCode());
+        }
     }
 }

--- a/src/Utilities/TaskItem_T.cs
+++ b/src/Utilities/TaskItem_T.cs
@@ -12,13 +12,14 @@ namespace Microsoft.Build.Utilities
     /// A strongly-typed wrapper around <see cref="ITaskItem"/> that parses the item's identity
     /// as a value of type <typeparamref name="T"/>.
     /// </summary>
-    /// <typeparam name="T">The type to parse the item identity as. Can be a value type, FileInfo, or DirectoryInfo.</typeparam>
+    /// <typeparam name="T">The type to parse the item identity as. Must be a value type.</typeparam>
     /// <remarks>
     /// This allows tasks to receive strongly-typed parameters while still working with MSBuild's item system.
-    /// The identity (ItemSpec) is parsed using <see cref="ValueTypeParser"/> which handles value types,
-    /// AbsolutePath, FileInfo, and DirectoryInfo.
+    /// The identity (ItemSpec) is parsed using <see cref="Convert.ChangeType(object?, Type)"/> or special handling for
+    /// types like <see cref="AbsolutePath"/>.
     /// </remarks>
     public readonly struct TaskItem<T> : ITaskItem<T>, IEquatable<TaskItem<T>>
+        where T : struct
     {
         private readonly ITaskItem _backingItem;
 
@@ -154,14 +155,13 @@ namespace Microsoft.Build.Utilities
         #region Equality and Conversion
 
         /// <inheritdoc/>
-        public bool Equals(TaskItem<T> other) =>
-            Value?.Equals(other.Value) ?? (other.Value == null);
+        public bool Equals(TaskItem<T> other) => Value.Equals(other.Value);
 
         /// <inheritdoc/>
         public override bool Equals(object? obj) => obj is TaskItem<T> other && Equals(other);
 
         /// <inheritdoc/>
-        public override int GetHashCode() => Value?.GetHashCode() ?? 0;
+        public override int GetHashCode() => Value.GetHashCode();
 
         /// <summary>
         /// Determines whether two <see cref="TaskItem{T}"/> instances are equal.

--- a/src/Utilities/TaskItem_T.cs
+++ b/src/Utilities/TaskItem_T.cs
@@ -6,6 +6,10 @@ using System.Collections;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
 
+// Alias to avoid ambiguity: within TaskItem<T>, "TaskItem" refers to this generic struct;
+// use TaskItemImpl to refer to the non-generic Utilities.TaskItem class.
+using TaskItemImpl = Microsoft.Build.Utilities.TaskItem;
+
 namespace Microsoft.Build.Utilities
 {
     /// <summary>
@@ -36,9 +40,9 @@ namespace Microsoft.Build.Utilities
         {
             Value = value;
 
-            // Create a backing item with the stringified value as ItemSpec
+            // Use a mutable TaskItem as backing so metadata mutations are supported
             string itemSpec = ValueTypeParser.ToString(value);
-            _backingItem = new TaskItemData(itemSpec, null);
+            _backingItem = new TaskItemImpl(itemSpec);
         }
 
         /// <summary>

--- a/src/Utilities/TaskItem_T.cs
+++ b/src/Utilities/TaskItem_T.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
 
@@ -16,14 +17,13 @@ namespace Microsoft.Build.Utilities
     /// A strongly-typed wrapper around <see cref="ITaskItem"/> that parses the item's identity
     /// as a value of type <typeparamref name="T"/>.
     /// </summary>
-    /// <typeparam name="T">The type to parse the item identity as. Must be a value type.</typeparam>
+    /// <typeparam name="T">The type to parse the item identity as. Can be a value type, FileInfo, or DirectoryInfo.</typeparam>
     /// <remarks>
     /// This allows tasks to receive strongly-typed parameters while still working with MSBuild's item system.
-    /// The identity (ItemSpec) is parsed using <see cref="Convert.ChangeType(object?, Type)"/> or special handling for
-    /// types like <see cref="AbsolutePath"/>.
+    /// The identity (ItemSpec) is parsed using <see cref="ValueTypeParser"/> which handles value types,
+    /// AbsolutePath, FileInfo, and DirectoryInfo.
     /// </remarks>
     public readonly struct TaskItem<T> : ITaskItem<T>, IEquatable<TaskItem<T>>
-        where T : struct
     {
         private readonly ITaskItem _backingItem;
 
@@ -177,13 +177,14 @@ namespace Microsoft.Build.Utilities
         #region Equality and Conversion
 
         /// <inheritdoc/>
-        public bool Equals(TaskItem<T> other) => Value.Equals(other.Value);
+        public bool Equals(TaskItem<T> other) =>
+            EqualityComparer<T>.Default.Equals(Value, other.Value);
 
         /// <inheritdoc/>
         public override bool Equals(object? obj) => obj is TaskItem<T> other && Equals(other);
 
         /// <inheritdoc/>
-        public override int GetHashCode() => Value.GetHashCode();
+        public override int GetHashCode() => Value is null ? 0 : EqualityComparer<T>.Default.GetHashCode(Value);
 
         /// <summary>
         /// Determines whether two <see cref="TaskItem{T}"/> instances are equal.

--- a/src/Utilities/TaskItem_T.cs
+++ b/src/Utilities/TaskItem_T.cs
@@ -66,8 +66,26 @@ namespace Microsoft.Build.Utilities
                 throw new ArgumentException($"Cannot create TaskItem<{typeof(T).Name}> from an item with empty identity.", nameof(item));
             }
 
-            // Parse the value from ItemSpec
-            Value = ParseValue(itemSpec);
+            // For path-like types, prefer the FullPath metadata (which is always absolute)
+            // over ItemSpec which may be relative.
+            string parseFrom = IsPathLikeType() ? GetFullPathOrItemSpec(item, itemSpec) : itemSpec;
+            Value = ParseValue(parseFrom);
+        }
+
+        /// <summary>Returns true if T is a path-like type that benefits from absolute path resolution.</summary>
+        private static bool IsPathLikeType()
+        {
+            Type t = typeof(T);
+            return t == typeof(System.IO.FileInfo) ||
+                   t == typeof(System.IO.DirectoryInfo) ||
+                   t == typeof(AbsolutePath);
+        }
+
+        /// <summary>Returns the FullPath metadata value if non-empty, otherwise falls back to itemSpec.</summary>
+        private static string GetFullPathOrItemSpec(ITaskItem item, string itemSpec)
+        {
+            string fullPath = item.GetMetadata("FullPath");
+            return !string.IsNullOrEmpty(fullPath) ? fullPath : itemSpec;
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
Final stacked PR from #13016.

### Included
- value-type expansion for typed task item binding
- supporting runtime parsing/serialization updates
- analyzer narrowing tied to ValueTypeParser-supported types