### PR TITLE
Add Roslyn analyzers (MSBuildTask0006/0007) to suggest typed task parameters

### DIFF
--- a/src/TaskAnalyzer.Tests/PathDefaultClassifierTests.cs
+++ b/src/TaskAnalyzer.Tests/PathDefaultClassifierTests.cs
@@ -1,0 +1,67 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.InteropServices;
+using Shouldly;
+using Xunit;
+
+namespace Microsoft.Build.TaskAuthoring.Analyzer.Tests
+{
+    public class PathDefaultClassifierTests
+    {
+        private static bool IsWindows => RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("obj")]
+        [InlineData("obj/generated")]
+        [InlineData(@"sub\dir")]
+        [InlineData("./relative")]
+        public void RelativeForms_AreNotFullyQualified(string value)
+        {
+            PathDefaultClassifier.IsFullyQualifiedPath(value).ShouldBeFalse();
+        }
+
+        [Fact]
+        public void UnixRoot_IsFullyQualifiedOnUnixOnly()
+        {
+            // A leading '/' is absolute on Unix; on Windows it is only rooted to the current drive, so it is
+            // NOT fully qualified there.
+            PathDefaultClassifier.IsFullyQualifiedPath("/etc/config").ShouldBe(!IsWindows);
+        }
+
+        [Fact]
+        public void WindowsDriveAbsolute_IsFullyQualifiedOnWindowsOnly()
+        {
+            // "C:/x" and "C:\x" are absolute on Windows; on Unix they are ordinary relative paths, matching how
+            // AbsolutePath would root them.
+            PathDefaultClassifier.IsFullyQualifiedPath(@"C:\temp\out").ShouldBe(IsWindows);
+            PathDefaultClassifier.IsFullyQualifiedPath("C:/temp/out").ShouldBe(IsWindows);
+        }
+
+        [Fact]
+        public void WindowsUncPath_IsFullyQualifiedOnWindowsOnly()
+        {
+            PathDefaultClassifier.IsFullyQualifiedPath(@"\\server\share").ShouldBe(IsWindows);
+        }
+
+        [Fact]
+        public void WindowsDriveRelative_IsNeverFullyQualified()
+        {
+            // "C:foo" (no separator after the colon) is drive-relative — its meaning depends on the drive's
+            // current directory — so it is not fully qualified on any OS.
+            PathDefaultClassifier.IsFullyQualifiedPath("C:foo").ShouldBeFalse();
+        }
+
+        [Fact]
+        public void RelativeDefault_IsTrueForPlausibleRelativePathsOnly()
+        {
+            PathDefaultClassifier.IsRelativePathDefault("obj").ShouldBeTrue();
+            PathDefaultClassifier.IsRelativePathDefault("").ShouldBeFalse();
+
+            // A fully-qualified default (on this OS) is not a relative default.
+            string absolute = IsWindows ? @"C:\out" : "/out";
+            PathDefaultClassifier.IsRelativePathDefault(absolute).ShouldBeFalse();
+        }
+    }
+}

--- a/src/TaskAnalyzer.Tests/PreferTypedParameterAnalyzerTests.cs
+++ b/src/TaskAnalyzer.Tests/PreferTypedParameterAnalyzerTests.cs
@@ -543,6 +543,34 @@ public class PreferTypedParameterAnalyzerTests
     }
 
     [Fact]
+    public async Task ArrayProperty_SuggestsArrayType()
+    {
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+            using Microsoft.Build.Framework;
+            [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
+            public class MyTask : Microsoft.Build.Utilities.Task, Microsoft.Build.Framework.IMultiThreadableTask
+            {
+                public TaskEnvironment TaskEnvironment { get; set; } = new();
+                public ITaskItem[] Directories { get; set; } = null!;
+                public override bool Execute()
+                {
+                    foreach (ITaskItem item in Directories)
+                    {
+                        AbsolutePath abs = TaskEnvironment.GetAbsolutePath(item.ItemSpec);
+                    }
+                    return true;
+                }
+            }
+            """);
+
+        var task7 = diags.Where(d => d.Id == DiagnosticIds.PreferTypedTaskItem).ToArray();
+        task7.Length.ShouldBeGreaterThanOrEqualTo(1);
+        // Should suggest array type, not singular
+        task7.ShouldContain(d => d.GetMessage().Contains("AbsolutePath[]"));
+        task7.ShouldNotContain(d => d.GetMessage().Contains("'AbsolutePath'") && !d.GetMessage().Contains("[]"));
+    }
+
+    [Fact]
     public async Task NewDirectoryInfo_FromAbsolutePathLocal_SuggestsDirectoryInfo()
     {
         var diags = await GetTypedParameterDiagnosticsAsync("""

--- a/src/TaskAnalyzer.Tests/PreferTypedParameterAnalyzerTests.cs
+++ b/src/TaskAnalyzer.Tests/PreferTypedParameterAnalyzerTests.cs
@@ -128,6 +128,52 @@ public class PreferTypedParameterAnalyzerTests
         diags.ShouldContain(d => d.Id == DiagnosticIds.PreferTypedPathParameter);
     }
 
+    [Fact]
+    public async Task PathCombine_WithStringProp_ProducesDiagnostic()
+    {
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+            using System.IO;
+            using Microsoft.Build.Framework;
+            [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                public string BasePath { get; set; } = "";
+                public override bool Execute()
+                {
+                    var combined = Path.Combine(BasePath, "sub", "file.txt");
+                    return true;
+                }
+            }
+            """);
+
+        diags.ShouldContain(d => d.Id == DiagnosticIds.PreferTypedPathParameter);
+        diags.Length.ShouldBe(1);
+        diags[0].GetMessage().ShouldContain("BasePath");
+    }
+
+    [Fact]
+    public async Task HelperMethodWrapping_StringProp_ProducesDiagnostic()
+    {
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+            using Microsoft.Build.Framework;
+            [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                public string InputPath { get; set; } = "";
+                public override bool Execute()
+                {
+                    var abs = new AbsolutePath(FixPath(InputPath));
+                    return true;
+                }
+                private static string FixPath(string p) => p.Replace('/', '\\');
+            }
+            """);
+
+        diags.ShouldContain(d => d.Id == DiagnosticIds.PreferTypedPathParameter);
+        diags.Length.ShouldBe(1);
+        diags[0].GetMessage().ShouldContain("InputPath");
+    }
+
     // ── Negative cases for MSBuildTask0006 ──
 
     [Fact]
@@ -448,6 +494,52 @@ public class PreferTypedParameterAnalyzerTests
             """);
 
         diags.ShouldContain(d => d.Id == DiagnosticIds.PreferTypedTaskItem);
+    }
+
+    [Fact]
+    public async Task PathCombine_WithItemSpec_ProducesDiagnostic()
+    {
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+            using System.IO;
+            using Microsoft.Build.Framework;
+            [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                public ITaskItem OutputDir { get; set; } = null!;
+                public ITaskItem OutputFile { get; set; } = null!;
+                public override bool Execute()
+                {
+                    var combined = Path.Combine(OutputDir.ItemSpec, OutputFile.ItemSpec);
+                    return true;
+                }
+            }
+            """);
+
+        diags.Where(d => d.Id == DiagnosticIds.PreferTypedTaskItem).Count().ShouldBeGreaterThanOrEqualTo(1);
+    }
+
+    [Fact]
+    public async Task HelperMethodWrapping_ItemSpec_ProducesDiagnostic()
+    {
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+            using Microsoft.Build.Framework;
+            [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
+            public class MyTask : Microsoft.Build.Utilities.Task, Microsoft.Build.Framework.IMultiThreadableTask
+            {
+                public TaskEnvironment TaskEnvironment { get; set; } = new();
+                public ITaskItem FileItem { get; set; } = null!;
+                public override bool Execute()
+                {
+                    var abs = TaskEnvironment.GetAbsolutePath(FixPath(FileItem.ItemSpec));
+                    return true;
+                }
+                private static string FixPath(string p) => p.Replace('/', '\\');
+            }
+            """);
+
+        diags.ShouldContain(d => d.Id == DiagnosticIds.PreferTypedTaskItem);
+        diags.Length.ShouldBe(1);
+        diags[0].GetMessage().ShouldContain("FileItem");
     }
 
     // ── Negative cases for MSBuildTask0007 ──

--- a/src/TaskAnalyzer.Tests/PreferTypedParameterAnalyzerTests.cs
+++ b/src/TaskAnalyzer.Tests/PreferTypedParameterAnalyzerTests.cs
@@ -23,6 +23,7 @@ public class PreferTypedParameterAnalyzerTests
     {
         var diags = await GetTypedParameterDiagnosticsAsync("""
             using Microsoft.Build.Framework;
+            [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
             public class MyTask : Microsoft.Build.Utilities.Task
             {
                 public string InputPath { get; set; } = "";
@@ -45,6 +46,7 @@ public class PreferTypedParameterAnalyzerTests
     {
         var diags = await GetTypedParameterDiagnosticsAsync("""
             using System.IO;
+            [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
             public class MyTask : Microsoft.Build.Utilities.Task
             {
                 public string FilePath { get; set; } = "";
@@ -66,6 +68,7 @@ public class PreferTypedParameterAnalyzerTests
     {
         var diags = await GetTypedParameterDiagnosticsAsync("""
             using System.IO;
+            [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
             public class MyTask : Microsoft.Build.Utilities.Task
             {
                 public string DirPath { get; set; } = "";
@@ -109,6 +112,7 @@ public class PreferTypedParameterAnalyzerTests
     {
         var diags = await GetTypedParameterDiagnosticsAsync("""
             using Microsoft.Build.Framework;
+            [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
             public class MyTask : Microsoft.Build.Utilities.Task
             {
                 public string InputPath { get; set; } = "";
@@ -131,6 +135,7 @@ public class PreferTypedParameterAnalyzerTests
     {
         var diags = await GetTypedParameterDiagnosticsAsync("""
             using Microsoft.Build.Framework;
+            [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
             public class MyTask : Microsoft.Build.Utilities.Task
             {
                 public override bool Execute()
@@ -149,6 +154,7 @@ public class PreferTypedParameterAnalyzerTests
     {
         var diags = await GetTypedParameterDiagnosticsAsync("""
             using Microsoft.Build.Framework;
+            [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
             public class MyTask : Microsoft.Build.Utilities.Task
             {
                 public string InputPath { get; set; } = "";
@@ -170,6 +176,7 @@ public class PreferTypedParameterAnalyzerTests
     {
         var diags = await GetTypedParameterDiagnosticsAsync("""
             using Microsoft.Build.Framework;
+            [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
             public class MyTask : Microsoft.Build.Utilities.Task
             {
                 [Output]
@@ -190,6 +197,7 @@ public class PreferTypedParameterAnalyzerTests
     {
         var diags = await GetTypedParameterDiagnosticsAsync("""
             using Microsoft.Build.Framework;
+            [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
             public class MyTask : Microsoft.Build.Utilities.Task
             {
                 private string InternalPath { get; set; } = "";
@@ -209,6 +217,7 @@ public class PreferTypedParameterAnalyzerTests
     {
         var diags = await GetTypedParameterDiagnosticsAsync("""
             using Microsoft.Build.Framework;
+            [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
             public class MyTask : Microsoft.Build.Utilities.Task
             {
                 public string ComputedPath { get; } = "/fixed";
@@ -250,6 +259,7 @@ public class PreferTypedParameterAnalyzerTests
     {
         var diags = await GetTypedParameterDiagnosticsAsync("""
             using Microsoft.Build.Framework;
+            [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
             public class MyTask : Microsoft.Build.Utilities.Task
             {
                 public ITaskItem Item { get; set; } = null!;
@@ -272,6 +282,7 @@ public class PreferTypedParameterAnalyzerTests
     {
         var diags = await GetTypedParameterDiagnosticsAsync("""
             using Microsoft.Build.Framework;
+            [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
             public class MyTask : Microsoft.Build.Utilities.Task
             {
                 public ITaskItem Flag { get; set; } = null!;
@@ -293,6 +304,7 @@ public class PreferTypedParameterAnalyzerTests
         var diags = await GetTypedParameterDiagnosticsAsync("""
             using System;
             using Microsoft.Build.Framework;
+            [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
             public class MyTask : Microsoft.Build.Utilities.Task
             {
                 public ITaskItem Count { get; set; } = null!;
@@ -313,6 +325,7 @@ public class PreferTypedParameterAnalyzerTests
     {
         var diags = await GetTypedParameterDiagnosticsAsync("""
             using Microsoft.Build.Framework;
+            [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
             public class MyTask : Microsoft.Build.Utilities.Task
             {
                 public ITaskItem PathItem { get; set; } = null!;
@@ -334,6 +347,7 @@ public class PreferTypedParameterAnalyzerTests
         var diags = await GetTypedParameterDiagnosticsAsync("""
             using System.IO;
             using Microsoft.Build.Framework;
+            [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
             public class MyTask : Microsoft.Build.Utilities.Task
             {
                 public ITaskItem FileItem { get; set; } = null!;
@@ -376,6 +390,7 @@ public class PreferTypedParameterAnalyzerTests
     {
         var diags = await GetTypedParameterDiagnosticsAsync("""
             using Microsoft.Build.Framework;
+            [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
             public class MyTask : Microsoft.Build.Utilities.Task
             {
                 public ITaskItem Item { get; set; } = null!;
@@ -396,6 +411,7 @@ public class PreferTypedParameterAnalyzerTests
     {
         var diags = await GetTypedParameterDiagnosticsAsync("""
             using Microsoft.Build.Framework;
+            [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
             public class MyTask : Microsoft.Build.Utilities.Task
             {
                 public ITaskItem[] Items { get; set; } = null!;
@@ -419,6 +435,7 @@ public class PreferTypedParameterAnalyzerTests
     {
         var diags = await GetTypedParameterDiagnosticsAsync("""
             using Microsoft.Build.Framework;
+            [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
             public class MyTask : Microsoft.Build.Utilities.Task
             {
                 public ITaskItem[] Items { get; set; } = null!;
@@ -440,6 +457,7 @@ public class PreferTypedParameterAnalyzerTests
     {
         var diags = await GetTypedParameterDiagnosticsAsync("""
             using Microsoft.Build.Framework;
+            [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
             public class MyTask : Microsoft.Build.Utilities.Task
             {
                 public ITaskItem Item { get; set; } = null!;
@@ -459,6 +477,7 @@ public class PreferTypedParameterAnalyzerTests
     {
         var diags = await GetTypedParameterDiagnosticsAsync("""
             using Microsoft.Build.Framework;
+            [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
             public class MyTask : Microsoft.Build.Utilities.Task
             {
                 public string CountStr { get; set; } = "0";
@@ -479,6 +498,7 @@ public class PreferTypedParameterAnalyzerTests
     {
         var diags = await GetTypedParameterDiagnosticsAsync("""
             using Microsoft.Build.Framework;
+            [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
             public class MyTask : Microsoft.Build.Utilities.Task
             {
                 [Output]
@@ -505,6 +525,48 @@ public class PreferTypedParameterAnalyzerTests
                 public void DoWork()
                 {
                     int value = int.Parse(Item.ItemSpec);
+                }
+            }
+            """);
+
+        diags.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task NonMultiThreadableTask_NoDiagnostic()
+    {
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+            using Microsoft.Build.Framework;
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                public string InputPath { get; set; } = "";
+                public ITaskItem FileItem { get; set; } = null!;
+                public override bool Execute()
+                {
+                    var abs = new AbsolutePath(InputPath);
+                    int value = int.Parse(FileItem.ItemSpec);
+                    return true;
+                }
+            }
+            """);
+
+        diags.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task MultiThreadableAttribute_ButNotITask_NoDiagnostic()
+    {
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+            using Microsoft.Build.Framework;
+            [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
+            public class NotATask
+            {
+                public string InputPath { get; set; } = "";
+                public ITaskItem FileItem { get; set; } = null!;
+                public void DoWork()
+                {
+                    var abs = new AbsolutePath(InputPath);
+                    int value = int.Parse(FileItem.ItemSpec);
                 }
             }
             """);

--- a/src/TaskAnalyzer.Tests/PreferTypedParameterAnalyzerTests.cs
+++ b/src/TaskAnalyzer.Tests/PreferTypedParameterAnalyzerTests.cs
@@ -931,4 +931,73 @@ public class PreferTypedParameterAnalyzerTests
         task7[0].GetMessage().ShouldNotContain("FileInfo");
         task7[0].GetMessage().ShouldNotContain("DirectoryInfo");
     }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Fix #5: Restrict to ValueTypeParser-supported types only
+    // ═══════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task GuidParse_FromItemSpec_NoDiagnostic()
+    {
+        // Guid is not supported by ValueTypeParser, so no diagnostic should be emitted.
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+            using System;
+            using Microsoft.Build.Framework;
+            [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
+            public class MyTask : Microsoft.Build.Utilities.Task, Microsoft.Build.Framework.IMultiThreadableTask
+            {
+                public ITaskItem Item { get; set; } = null!;
+                public override bool Execute()
+                {
+                    var id = Guid.Parse(Item.ItemSpec);
+                    return true;
+                }
+            }
+            """);
+
+        diags.ShouldNotContain(d => d.Id == DiagnosticIds.PreferTypedTaskItem);
+    }
+
+    [Fact]
+    public async Task TimeSpanParse_FromItemSpec_NoDiagnostic()
+    {
+        // TimeSpan is not supported by ValueTypeParser, so no diagnostic should be emitted.
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+            using System;
+            using Microsoft.Build.Framework;
+            [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
+            public class MyTask : Microsoft.Build.Utilities.Task, Microsoft.Build.Framework.IMultiThreadableTask
+            {
+                public ITaskItem Item { get; set; } = null!;
+                public override bool Execute()
+                {
+                    var ts = TimeSpan.Parse(Item.ItemSpec);
+                    return true;
+                }
+            }
+            """);
+
+        diags.ShouldNotContain(d => d.Id == DiagnosticIds.PreferTypedTaskItem);
+    }
+
+    [Fact]
+    public async Task IntParse_FromItemSpec_StillProducesDiagnostic()
+    {
+        // int is supported by ValueTypeParser, so the diagnostic should still fire.
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+            using Microsoft.Build.Framework;
+            [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
+            public class MyTask : Microsoft.Build.Utilities.Task, Microsoft.Build.Framework.IMultiThreadableTask
+            {
+                public ITaskItem Item { get; set; } = null!;
+                public override bool Execute()
+                {
+                    var n = int.Parse(Item.ItemSpec);
+                    return true;
+                }
+            }
+            """);
+
+        diags.ShouldContain(d => d.Id == DiagnosticIds.PreferTypedTaskItem);
+    }
 }

--- a/src/TaskAnalyzer.Tests/PreferTypedParameterAnalyzerTests.cs
+++ b/src/TaskAnalyzer.Tests/PreferTypedParameterAnalyzerTests.cs
@@ -542,6 +542,58 @@ public class PreferTypedParameterAnalyzerTests
         diags[0].GetMessage().ShouldContain("FileItem");
     }
 
+    [Fact]
+    public async Task NewDirectoryInfo_FromAbsolutePathLocal_SuggestsDirectoryInfo()
+    {
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+            using System.IO;
+            using Microsoft.Build.Framework;
+            [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
+            public class MyTask : Microsoft.Build.Utilities.Task, Microsoft.Build.Framework.IMultiThreadableTask
+            {
+                public TaskEnvironment TaskEnvironment { get; set; } = new();
+                public ITaskItem SourceDir { get; set; } = null!;
+                public override bool Execute()
+                {
+                    AbsolutePath abs = TaskEnvironment.GetAbsolutePath(SourceDir.ItemSpec);
+                    var dir = new DirectoryInfo(abs);
+                    return true;
+                }
+            }
+            """);
+
+        // Should get MSBuildTask0007 for GetAbsolutePath(item.ItemSpec) AND for new DirectoryInfo(abs)
+        var task7 = diags.Where(d => d.Id == DiagnosticIds.PreferTypedTaskItem).ToArray();
+        task7.Length.ShouldBeGreaterThanOrEqualTo(1);
+        // At least one diagnostic should suggest DirectoryInfo
+        task7.ShouldContain(d => d.GetMessage().Contains("DirectoryInfo"));
+    }
+
+    [Fact]
+    public async Task NewFileInfo_FromAbsolutePathLocal_SuggestsFileInfo()
+    {
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+            using System.IO;
+            using Microsoft.Build.Framework;
+            [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
+            public class MyTask : Microsoft.Build.Utilities.Task, Microsoft.Build.Framework.IMultiThreadableTask
+            {
+                public TaskEnvironment TaskEnvironment { get; set; } = new();
+                public ITaskItem DestFile { get; set; } = null!;
+                public override bool Execute()
+                {
+                    AbsolutePath abs = TaskEnvironment.GetAbsolutePath(DestFile.ItemSpec);
+                    var fi = new FileInfo(abs);
+                    return true;
+                }
+            }
+            """);
+
+        var task7 = diags.Where(d => d.Id == DiagnosticIds.PreferTypedTaskItem).ToArray();
+        task7.Length.ShouldBeGreaterThanOrEqualTo(1);
+        task7.ShouldContain(d => d.GetMessage().Contains("FileInfo"));
+    }
+
     // ── Negative cases for MSBuildTask0007 ──
 
     [Fact]

--- a/src/TaskAnalyzer.Tests/PreferTypedParameterAnalyzerTests.cs
+++ b/src/TaskAnalyzer.Tests/PreferTypedParameterAnalyzerTests.cs
@@ -1,0 +1,492 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Linq;
+using System.Threading.Tasks;
+using Shouldly;
+using Xunit;
+using static Microsoft.Build.TaskAuthoring.Analyzer.Tests.TestHelpers;
+
+namespace Microsoft.Build.TaskAuthoring.Analyzer.Tests;
+
+/// <summary>
+/// Tests for <see cref="PreferTypedParameterAnalyzer"/> covering MSBuildTask0006 and MSBuildTask0007.
+/// </summary>
+public class PreferTypedParameterAnalyzerTests
+{
+    // ═══════════════════════════════════════════════════════════════════════
+    // MSBuildTask0006: Prefer typed path parameters
+    // ═══════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task NewAbsolutePath_FromStringProp_ProducesDiagnostic()
+    {
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+            using Microsoft.Build.Framework;
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                public string InputPath { get; set; } = "";
+                public override bool Execute()
+                {
+                    var abs = new AbsolutePath(InputPath);
+                    return true;
+                }
+            }
+            """);
+
+        diags.ShouldContain(d => d.Id == DiagnosticIds.PreferTypedPathParameter);
+        diags.Length.ShouldBe(1);
+        diags[0].GetMessage().ShouldContain("InputPath");
+        diags[0].GetMessage().ShouldContain("AbsolutePath");
+    }
+
+    [Fact]
+    public async Task NewFileInfo_FromStringProp_ProducesDiagnostic()
+    {
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+            using System.IO;
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                public string FilePath { get; set; } = "";
+                public override bool Execute()
+                {
+                    var fi = new FileInfo(FilePath);
+                    return true;
+                }
+            }
+            """);
+
+        diags.ShouldContain(d => d.Id == DiagnosticIds.PreferTypedPathParameter);
+        diags.Length.ShouldBe(1);
+        diags[0].GetMessage().ShouldContain("FileInfo");
+    }
+
+    [Fact]
+    public async Task NewDirectoryInfo_FromStringProp_ProducesDiagnostic()
+    {
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+            using System.IO;
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                public string DirPath { get; set; } = "";
+                public override bool Execute()
+                {
+                    var di = new DirectoryInfo(DirPath);
+                    return true;
+                }
+            }
+            """);
+
+        diags.ShouldContain(d => d.Id == DiagnosticIds.PreferTypedPathParameter);
+        diags[0].GetMessage().ShouldContain("DirectoryInfo");
+    }
+
+    [Fact]
+    public async Task TaskEnvironmentGetAbsolutePath_FromStringProp_ProducesDiagnostic()
+    {
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+            using Microsoft.Build.Framework;
+            public class MyTask : Microsoft.Build.Framework.IMultiThreadableTask
+            {
+                public IBuildEngine BuildEngine { get; set; } = null!;
+                public TaskEnvironment TaskEnvironment { get; set; } = null!;
+                public string InputPath { get; set; } = "";
+                public bool Execute()
+                {
+                    var abs = TaskEnvironment.GetAbsolutePath(InputPath);
+                    return true;
+                }
+            }
+            """);
+
+        diags.ShouldContain(d => d.Id == DiagnosticIds.PreferTypedPathParameter);
+        diags.Length.ShouldBe(1);
+        diags[0].GetMessage().ShouldContain("InputPath");
+    }
+
+    [Fact]
+    public async Task NewAbsolutePath_WithLocalIndirection_ProducesDiagnostic()
+    {
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+            using Microsoft.Build.Framework;
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                public string InputPath { get; set; } = "";
+                public override bool Execute()
+                {
+                    var path = InputPath;
+                    var abs = new AbsolutePath(path);
+                    return true;
+                }
+            }
+            """);
+
+        diags.ShouldContain(d => d.Id == DiagnosticIds.PreferTypedPathParameter);
+    }
+
+    // ── Negative cases for MSBuildTask0006 ──
+
+    [Fact]
+    public async Task NewAbsolutePath_FromLiteral_NoDiagnostic()
+    {
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+            using Microsoft.Build.Framework;
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                public override bool Execute()
+                {
+                    var abs = new AbsolutePath("/some/path");
+                    return true;
+                }
+            }
+            """);
+
+        diags.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task NewAbsolutePath_FromNonTaskProperty_NoDiagnostic()
+    {
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+            using Microsoft.Build.Framework;
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                public string InputPath { get; set; } = "";
+                public override bool Execute()
+                {
+                    string localPath = ComputePath();
+                    var abs = new AbsolutePath(localPath);
+                    return true;
+                }
+                private string ComputePath() => "/computed";
+            }
+            """);
+
+        diags.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task OutputProperty_Excluded_NoDiagnostic()
+    {
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+            using Microsoft.Build.Framework;
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                [Output]
+                public string OutputPath { get; set; } = "";
+                public override bool Execute()
+                {
+                    var abs = new AbsolutePath(OutputPath);
+                    return true;
+                }
+            }
+            """);
+
+        diags.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task PrivateProperty_Excluded_NoDiagnostic()
+    {
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+            using Microsoft.Build.Framework;
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                private string InternalPath { get; set; } = "";
+                public override bool Execute()
+                {
+                    var abs = new AbsolutePath(InternalPath);
+                    return true;
+                }
+            }
+            """);
+
+        diags.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task ReadOnlyProperty_Excluded_NoDiagnostic()
+    {
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+            using Microsoft.Build.Framework;
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                public string ComputedPath { get; } = "/fixed";
+                public override bool Execute()
+                {
+                    var abs = new AbsolutePath(ComputedPath);
+                    return true;
+                }
+            }
+            """);
+
+        diags.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task NonTaskClass_NoDiagnostic()
+    {
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+            using Microsoft.Build.Framework;
+            public class NotATask
+            {
+                public string InputPath { get; set; } = "";
+                public void DoWork()
+                {
+                    var abs = new AbsolutePath(InputPath);
+                }
+            }
+            """);
+
+        diags.ShouldBeEmpty();
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // MSBuildTask0007: Prefer ITaskItem<T> over manual ItemSpec parsing
+    // ═══════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task IntParse_FromItemSpec_ProducesDiagnostic()
+    {
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+            using Microsoft.Build.Framework;
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                public ITaskItem Item { get; set; } = null!;
+                public override bool Execute()
+                {
+                    int value = int.Parse(Item.ItemSpec);
+                    return true;
+                }
+            }
+            """);
+
+        diags.ShouldContain(d => d.Id == DiagnosticIds.PreferTypedTaskItem);
+        diags.Length.ShouldBe(1);
+        diags[0].GetMessage().ShouldContain("int");
+        diags[0].GetMessage().ShouldContain("Item");
+    }
+
+    [Fact]
+    public async Task BoolParse_FromItemSpec_ProducesDiagnostic()
+    {
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+            using Microsoft.Build.Framework;
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                public ITaskItem Flag { get; set; } = null!;
+                public override bool Execute()
+                {
+                    bool value = bool.Parse(Flag.ItemSpec);
+                    return true;
+                }
+            }
+            """);
+
+        diags.ShouldContain(d => d.Id == DiagnosticIds.PreferTypedTaskItem);
+        diags[0].GetMessage().ShouldContain("bool");
+    }
+
+    [Fact]
+    public async Task ConvertToInt32_FromItemSpec_ProducesDiagnostic()
+    {
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+            using System;
+            using Microsoft.Build.Framework;
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                public ITaskItem Count { get; set; } = null!;
+                public override bool Execute()
+                {
+                    int value = Convert.ToInt32(Count.ItemSpec);
+                    return true;
+                }
+            }
+            """);
+
+        diags.ShouldContain(d => d.Id == DiagnosticIds.PreferTypedTaskItem);
+        diags[0].GetMessage().ShouldContain("int");
+    }
+
+    [Fact]
+    public async Task NewAbsolutePath_FromItemSpec_ProducesDiagnostic()
+    {
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+            using Microsoft.Build.Framework;
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                public ITaskItem PathItem { get; set; } = null!;
+                public override bool Execute()
+                {
+                    var abs = new AbsolutePath(PathItem.ItemSpec);
+                    return true;
+                }
+            }
+            """);
+
+        diags.ShouldContain(d => d.Id == DiagnosticIds.PreferTypedTaskItem);
+        diags[0].GetMessage().ShouldContain("AbsolutePath");
+    }
+
+    [Fact]
+    public async Task NewFileInfo_FromItemSpec_ProducesDiagnostic()
+    {
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+            using System.IO;
+            using Microsoft.Build.Framework;
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                public ITaskItem FileItem { get; set; } = null!;
+                public override bool Execute()
+                {
+                    var fi = new FileInfo(FileItem.ItemSpec);
+                    return true;
+                }
+            }
+            """);
+
+        diags.ShouldContain(d => d.Id == DiagnosticIds.PreferTypedTaskItem);
+        diags[0].GetMessage().ShouldContain("FileInfo");
+    }
+
+    [Fact]
+    public async Task IntParse_FromItemSpec_WithLocalIndirection_ProducesDiagnostic()
+    {
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+            using Microsoft.Build.Framework;
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                public ITaskItem Item { get; set; } = null!;
+                public override bool Execute()
+                {
+                    var spec = Item.ItemSpec;
+                    int value = int.Parse(spec);
+                    return true;
+                }
+            }
+            """);
+
+        diags.ShouldContain(d => d.Id == DiagnosticIds.PreferTypedTaskItem);
+    }
+
+    [Fact]
+    public async Task IntParse_FromArrayItemSpec_InForeach_ProducesDiagnostic()
+    {
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+            using Microsoft.Build.Framework;
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                public ITaskItem[] Items { get; set; } = null!;
+                public override bool Execute()
+                {
+                    foreach (var item in Items)
+                    {
+                        int value = int.Parse(item.ItemSpec);
+                    }
+                    return true;
+                }
+            }
+            """);
+
+        diags.ShouldContain(d => d.Id == DiagnosticIds.PreferTypedTaskItem);
+        diags[0].GetMessage().ShouldContain("ITaskItem[]");
+    }
+
+    [Fact]
+    public async Task IntParse_FromArrayElementItemSpec_ProducesDiagnostic()
+    {
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+            using Microsoft.Build.Framework;
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                public ITaskItem[] Items { get; set; } = null!;
+                public override bool Execute()
+                {
+                    int value = int.Parse(Items[0].ItemSpec);
+                    return true;
+                }
+            }
+            """);
+
+        diags.ShouldContain(d => d.Id == DiagnosticIds.PreferTypedTaskItem);
+    }
+
+    // ── Negative cases for MSBuildTask0007 ──
+
+    [Fact]
+    public async Task IntParse_FromNonItemSpec_NoDiagnostic()
+    {
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+            using Microsoft.Build.Framework;
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                public ITaskItem Item { get; set; } = null!;
+                public override bool Execute()
+                {
+                    int value = int.Parse(Item.GetMetadata("Count"));
+                    return true;
+                }
+            }
+            """);
+
+        diags.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task IntParse_FromStringProp_NoDiagnostic()
+    {
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+            using Microsoft.Build.Framework;
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                public string CountStr { get; set; } = "0";
+                public override bool Execute()
+                {
+                    int value = int.Parse(CountStr);
+                    return true;
+                }
+            }
+            """);
+
+        // MSBuildTask0007 should not fire; 0006 wouldn't either since int is not a path type
+        diags.Where(d => d.Id == DiagnosticIds.PreferTypedTaskItem).ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task OutputItemProperty_Excluded_NoDiagnostic()
+    {
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+            using Microsoft.Build.Framework;
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                [Output]
+                public ITaskItem ResultItem { get; set; } = null!;
+                public override bool Execute()
+                {
+                    int value = int.Parse(ResultItem.ItemSpec);
+                    return true;
+                }
+            }
+            """);
+
+        diags.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task NonTaskClass_ItemSpec_NoDiagnostic()
+    {
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+            using Microsoft.Build.Framework;
+            public class NotATask
+            {
+                public ITaskItem Item { get; set; } = null!;
+                public void DoWork()
+                {
+                    int value = int.Parse(Item.ItemSpec);
+                }
+            }
+            """);
+
+        diags.ShouldBeEmpty();
+    }
+}

--- a/src/TaskAnalyzer.Tests/PreferTypedParameterAnalyzerTests.cs
+++ b/src/TaskAnalyzer.Tests/PreferTypedParameterAnalyzerTests.cs
@@ -1163,6 +1163,165 @@ public class PreferTypedParameterAnalyzerTests
         task7[0].GetMessage().ShouldNotContain("DirectoryInfo");
     }
 
+    // ── MSBuildTask0006 over raw-string 0002/0003 scenarios (one-shot instead of daisy-chaining) ──
+
+    [Fact]
+    public async Task PathGetFullPath_OnStringProp_SuggestsAbsolutePath()
+    {
+        // Path.GetFullPath(prop) is the raw normalization that MSBuildTask0002 flags. MSBuildTask0006 also
+        // surfaces it so the property can be retyped in one shot.
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+        using System.IO;
+        using Microsoft.Build.Framework;
+        [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
+        public class MyTask : Microsoft.Build.Utilities.Task, Microsoft.Build.Framework.IMultiThreadableTask
+        {
+            public TaskEnvironment TaskEnvironment { get; set; } = new();
+            public string InputPath { get; set; } = "";
+            public override bool Execute()
+            {
+                var full = Path.GetFullPath(InputPath);
+                return true;
+            }
+        }
+        """);
+
+        var task6 = diags.Where(d => d.Id == DiagnosticIds.PreferTypedPathParameter).ToArray();
+        task6.Length.ShouldBe(1);
+        task6[0].GetMessage().ShouldContain("InputPath");
+        task6[0].GetMessage().ShouldContain("AbsolutePath");
+    }
+
+    [Fact]
+    public async Task FileDelete_OnStringProp_SuggestsFileInfo()
+    {
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+        using System.IO;
+        using Microsoft.Build.Framework;
+        [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
+        public class MyTask : Microsoft.Build.Utilities.Task, Microsoft.Build.Framework.IMultiThreadableTask
+        {
+            public TaskEnvironment TaskEnvironment { get; set; } = new();
+            public string Target { get; set; } = "";
+            public override bool Execute()
+            {
+                File.Delete(Target);
+                return true;
+            }
+        }
+        """);
+
+        var task6 = diags.Where(d => d.Id == DiagnosticIds.PreferTypedPathParameter).ToArray();
+        task6.Length.ShouldBe(1);
+        task6[0].GetMessage().ShouldContain("Target");
+        task6[0].GetMessage().ShouldContain("FileInfo");
+    }
+
+    [Fact]
+    public async Task DirectoryCreate_OnStringProp_SuggestsDirectoryInfo()
+    {
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+        using System.IO;
+        using Microsoft.Build.Framework;
+        [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
+        public class MyTask : Microsoft.Build.Utilities.Task, Microsoft.Build.Framework.IMultiThreadableTask
+        {
+            public TaskEnvironment TaskEnvironment { get; set; } = new();
+            public string DestinationFolder { get; set; } = "";
+            public override bool Execute()
+            {
+                Directory.CreateDirectory(DestinationFolder);
+                return true;
+            }
+        }
+        """);
+
+        var task6 = diags.Where(d => d.Id == DiagnosticIds.PreferTypedPathParameter).ToArray();
+        task6.Length.ShouldBe(1);
+        task6[0].GetMessage().ShouldContain("DestinationFolder");
+        task6[0].GetMessage().ShouldContain("DirectoryInfo");
+    }
+
+    [Fact]
+    public async Task NewFileStream_OnStringProp_SuggestsFileInfo()
+    {
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+        using System.IO;
+        using Microsoft.Build.Framework;
+        [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
+        public class MyTask : Microsoft.Build.Utilities.Task, Microsoft.Build.Framework.IMultiThreadableTask
+        {
+            public TaskEnvironment TaskEnvironment { get; set; } = new();
+            public string InputPath { get; set; } = "";
+            public override bool Execute()
+            {
+                using var stream = new FileStream(InputPath, FileMode.Open);
+                return true;
+            }
+        }
+        """);
+
+        var task6 = diags.Where(d => d.Id == DiagnosticIds.PreferTypedPathParameter).ToArray();
+        task6.Length.ShouldBe(1);
+        task6[0].GetMessage().ShouldContain("InputPath");
+        task6[0].GetMessage().ShouldContain("FileInfo");
+    }
+
+    [Fact]
+    public async Task FileDelete_OnAlreadyWrappedStringProp_SuggestsAbsolutePathNotFileInfo()
+    {
+        // The argument is already rooted through TaskEnvironment.GetAbsolutePath, so the raw-consumption rule
+        // must not fire a FileInfo suggestion. The inner GetAbsolutePath(prop) still yields the standard
+        // AbsolutePath suggestion.
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+        using System.IO;
+        using Microsoft.Build.Framework;
+        [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
+        public class MyTask : Microsoft.Build.Utilities.Task, Microsoft.Build.Framework.IMultiThreadableTask
+        {
+            public TaskEnvironment TaskEnvironment { get; set; } = new();
+            public string Target { get; set; } = "";
+            public override bool Execute()
+            {
+                File.Delete(TaskEnvironment.GetAbsolutePath(Target));
+                return true;
+            }
+        }
+        """);
+
+        var task6 = diags.Where(d => d.Id == DiagnosticIds.PreferTypedPathParameter).ToArray();
+        task6.Length.ShouldBe(1);
+        task6[0].GetMessage().ShouldContain("AbsolutePath");
+        task6[0].GetMessage().ShouldNotContain("FileInfo");
+    }
+
+    [Fact]
+    public async Task FileWriteAllText_DoesNotFlagNonPathContentsArgument_StringProp()
+    {
+        // Only the path-named parameter is flagged; the "contents" string argument is not a path.
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+        using System.IO;
+        using Microsoft.Build.Framework;
+        [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
+        public class MyTask : Microsoft.Build.Utilities.Task, Microsoft.Build.Framework.IMultiThreadableTask
+        {
+            public TaskEnvironment TaskEnvironment { get; set; } = new();
+            public string OutputFile { get; set; } = "";
+            public string Contents { get; set; } = "";
+            public override bool Execute()
+            {
+                File.WriteAllText(OutputFile, Contents);
+                return true;
+            }
+        }
+        """);
+
+        var task6 = diags.Where(d => d.Id == DiagnosticIds.PreferTypedPathParameter).ToArray();
+        task6.Length.ShouldBe(1);
+        task6[0].GetMessage().ShouldContain("OutputFile");
+        task6[0].GetMessage().ShouldContain("FileInfo");
+    }
+
     // ═══════════════════════════════════════════════════════════════════════
     // Fix #5: Restrict to ValueTypeParser-supported types only
     // ═══════════════════════════════════════════════════════════════════════

--- a/src/TaskAnalyzer.Tests/PreferTypedParameterAnalyzerTests.cs
+++ b/src/TaskAnalyzer.Tests/PreferTypedParameterAnalyzerTests.cs
@@ -367,6 +367,28 @@ public class PreferTypedParameterAnalyzerTests
     }
 
     [Fact]
+    public async Task TryParse_FromItemSpec_ProducesNoDiagnostic()
+    {
+        // TryParse is defensive (bool result + out parameter). Suggesting ITaskItem<int> would change
+        // error handling to a bind-time throw, and the code fix can never rewrite its multi-argument shape,
+        // so the analyzer must not flag it.
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+            using Microsoft.Build.Framework;
+            [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                public ITaskItem Count { get; set; } = null!;
+                public override bool Execute()
+                {
+                    return int.TryParse(Count.ItemSpec, out _);
+                }
+            }
+            """);
+
+        diags.ShouldNotContain(d => d.Id == DiagnosticIds.PreferTypedTaskItem);
+    }
+
+    [Fact]
     public async Task NewAbsolutePath_FromItemSpec_ProducesDiagnostic()
     {
         var diags = await GetTypedParameterDiagnosticsAsync("""

--- a/src/TaskAnalyzer.Tests/PreferTypedParameterAnalyzerTests.cs
+++ b/src/TaskAnalyzer.Tests/PreferTypedParameterAnalyzerTests.cs
@@ -42,6 +42,55 @@ public class PreferTypedParameterAnalyzerTests
     }
 
     [Fact]
+    public async Task RelativeDefault_EmitsMoveToExecute_AndSuppressesPathDiagnostic()
+    {
+        // A relative default can't be rooted in the initializer, so the property is redirected from
+        // MSBuildTask0006 to MSBuildTask0008 (initialize in Execute()); only the 0008 diagnostic is reported.
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+            using Microsoft.Build.Framework;
+            [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                public string InputPath { get; set; } = "obj";
+                public override bool Execute()
+                {
+                    var abs = new AbsolutePath(InputPath);
+                    return true;
+                }
+            }
+            """);
+
+        diags.Length.ShouldBe(1);
+        diags[0].Id.ShouldBe(DiagnosticIds.InitializeRelativeDefaultInExecute);
+        diags.ShouldNotContain(d => d.Id == DiagnosticIds.PreferTypedPathParameter);
+        diags[0].GetMessage().ShouldContain("InputPath");
+        diags[0].GetMessage().ShouldContain("AbsolutePath");
+    }
+
+    [Fact]
+    public async Task FullyQualifiedDefault_StaysOnPathDiagnostic()
+    {
+        // A fully-qualified default can be reproduced in the initializer, so it stays on MSBuildTask0006.
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+            using Microsoft.Build.Framework;
+            [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                public string InputPath { get; set; } = "C:/work/obj";
+                public override bool Execute()
+                {
+                    var abs = new AbsolutePath(InputPath);
+                    return true;
+                }
+            }
+            """);
+
+        diags.Length.ShouldBe(1);
+        diags[0].Id.ShouldBe(DiagnosticIds.PreferTypedPathParameter);
+        diags.ShouldNotContain(d => d.Id == DiagnosticIds.InitializeRelativeDefaultInExecute);
+    }
+
+    [Fact]
     public async Task NewFileInfo_FromStringProp_ProducesDiagnostic()
     {
         var diags = await GetTypedParameterDiagnosticsAsync("""
@@ -432,6 +481,69 @@ public class PreferTypedParameterAnalyzerTests
     }
 
     [Fact]
+    public async Task NewAbsolutePath_FromGetMetadataFullPath_ProducesDiagnostic()
+    {
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+            using Microsoft.Build.Framework;
+            [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                public ITaskItem PathItem { get; set; } = null!;
+                public override bool Execute()
+                {
+                    var abs = new AbsolutePath(PathItem.GetMetadata("FullPath"));
+                    return true;
+                }
+            }
+            """);
+
+        diags.ShouldContain(d => d.Id == DiagnosticIds.PreferTypedTaskItem);
+        diags[0].GetMessage().ShouldContain("AbsolutePath");
+    }
+
+    [Fact]
+    public async Task NewFileInfo_FromGetMetadataFullPath_CaseInsensitive_ProducesDiagnostic()
+    {
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+            using System.IO;
+            using Microsoft.Build.Framework;
+            [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                public ITaskItem FileItem { get; set; } = null!;
+                public override bool Execute()
+                {
+                    var fi = new FileInfo(FileItem.GetMetadata("fullpath"));
+                    return true;
+                }
+            }
+            """);
+
+        diags.ShouldContain(d => d.Id == DiagnosticIds.PreferTypedTaskItem);
+        diags[0].GetMessage().ShouldContain("FileInfo");
+    }
+
+    [Fact]
+    public async Task NewAbsolutePath_FromGetMetadataOtherName_DoesNotProduceItemDiagnostic()
+    {
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+            using Microsoft.Build.Framework;
+            [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                public ITaskItem PathItem { get; set; } = null!;
+                public override bool Execute()
+                {
+                    var abs = new AbsolutePath(PathItem.GetMetadata("Culture"));
+                    return true;
+                }
+            }
+            """);
+
+        diags.ShouldNotContain(d => d.Id == DiagnosticIds.PreferTypedTaskItem);
+    }
+
+    [Fact]
     public async Task GetAbsolutePath_FromItemSpec_ProducesDiagnostic()
     {
         var diags = await GetTypedParameterDiagnosticsAsync("""
@@ -537,11 +649,54 @@ public class PreferTypedParameterAnalyzerTests
             }
             """);
 
-        // Every argument that flows from a task input is flagged, not just the first.
+        // Only the first argument is flagged: Path.Combine restarts from the last rooted segment, so making
+        // a later argument absolute could change the result. OutputDir (first) is flagged; OutputFile is not.
         var task7 = diags.Where(d => d.Id == DiagnosticIds.PreferTypedTaskItem).ToArray();
-        task7.Length.ShouldBe(2);
-        task7.ShouldContain(d => d.GetMessage().Contains("OutputDir"));
-        task7.ShouldContain(d => d.GetMessage().Contains("OutputFile"));
+        task7.Length.ShouldBe(1);
+        task7[0].GetMessage().ShouldContain("OutputDir");
+    }
+
+    [Fact]
+    public async Task PathCombine_StringProp_NotFirstArgument_ProducesNoDiagnostic()
+    {
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+            using System.IO;
+            using Microsoft.Build.Framework;
+            [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                public string SubPath { get; set; } = "";
+                public override bool Execute()
+                {
+                    var combined = Path.Combine("base", SubPath);
+                    return true;
+                }
+            }
+            """);
+
+        // SubPath only appears in a non-first position, where suggesting AbsolutePath could change semantics.
+        diags.ShouldNotContain(d => d.Id == DiagnosticIds.PreferTypedPathParameter);
+    }
+
+    [Fact]
+    public async Task PathCombine_ItemSpec_NotFirstArgument_ProducesNoDiagnostic()
+    {
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+            using System.IO;
+            using Microsoft.Build.Framework;
+            [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                public ITaskItem SubItem { get; set; } = null!;
+                public override bool Execute()
+                {
+                    var combined = Path.Combine("base", SubItem.ItemSpec);
+                    return true;
+                }
+            }
+            """);
+
+        diags.ShouldNotContain(d => d.Id == DiagnosticIds.PreferTypedTaskItem);
     }
 
     [Fact]

--- a/src/TaskAnalyzer.Tests/PreferTypedParameterAnalyzerTests.cs
+++ b/src/TaskAnalyzer.Tests/PreferTypedParameterAnalyzerTests.cs
@@ -71,12 +71,12 @@ public class PreferTypedParameterAnalyzerTests
     public async Task FullyQualifiedDefault_StaysOnPathDiagnostic()
     {
         // A fully-qualified default can be reproduced in the initializer, so it stays on MSBuildTask0006.
-        var diags = await GetTypedParameterDiagnosticsAsync("""
+        var diags = await GetTypedParameterDiagnosticsAsync($$"""
             using Microsoft.Build.Framework;
             [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
             public class MyTask : Microsoft.Build.Utilities.Task
             {
-                public string InputPath { get; set; } = "C:/work/obj";
+                public string InputPath { get; set; } = "{{TestHelpers.FullyQualifiedPath("work/obj")}}";
                 public override bool Execute()
                 {
                     var abs = new AbsolutePath(InputPath);

--- a/src/TaskAnalyzer.Tests/PreferTypedParameterAnalyzerTests.cs
+++ b/src/TaskAnalyzer.Tests/PreferTypedParameterAnalyzerTests.cs
@@ -565,9 +565,8 @@ public class PreferTypedParameterAnalyzerTests
 
         var task7 = diags.Where(d => d.Id == DiagnosticIds.PreferTypedTaskItem).ToArray();
         task7.Length.ShouldBeGreaterThanOrEqualTo(1);
-        // Should suggest array type, not singular
-        task7.ShouldContain(d => d.GetMessage().Contains("AbsolutePath[]"));
-        task7.ShouldNotContain(d => d.GetMessage().Contains("'AbsolutePath'") && !d.GetMessage().Contains("[]"));
+        // Should suggest ITaskItem<AbsolutePath>[] — brackets outside the angle brackets
+        task7.ShouldContain(d => d.GetMessage().Contains("ITaskItem<AbsolutePath>[]"));
     }
 
     [Fact]

--- a/src/TaskAnalyzer.Tests/PreferTypedParameterAnalyzerTests.cs
+++ b/src/TaskAnalyzer.Tests/PreferTypedParameterAnalyzerTests.cs
@@ -138,6 +138,7 @@ public class PreferTypedParameterAnalyzerTests
     {
         var diags = await GetTypedParameterDiagnosticsAsync("""
             using Microsoft.Build.Framework;
+            [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
             public class MyTask : Microsoft.Build.Framework.IMultiThreadableTask
             {
                 public IBuildEngine BuildEngine { get; set; } = null!;
@@ -548,6 +549,7 @@ public class PreferTypedParameterAnalyzerTests
     {
         var diags = await GetTypedParameterDiagnosticsAsync("""
             using Microsoft.Build.Framework;
+            [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
             public class MyTask : Microsoft.Build.Framework.IMultiThreadableTask
             {
                 public IBuildEngine BuildEngine { get; set; } = null!;
@@ -556,6 +558,58 @@ public class PreferTypedParameterAnalyzerTests
                 public bool Execute()
                 {
                     var abs = TaskEnvironment.GetAbsolutePath(PathItem.ItemSpec);
+                    return true;
+                }
+            }
+            """);
+
+        diags.ShouldContain(d => d.Id == DiagnosticIds.PreferTypedTaskItem);
+        diags[0].GetMessage().ShouldContain("AbsolutePath");
+    }
+
+    [Fact]
+    public async Task InheritsMultiThreadableInterface_WithoutAttribute_ProducesNoDiagnostic()
+    {
+        // The task derives from a base that implements IMultiThreadableTask but does not itself carry the
+        // [MSBuildMultiThreadableTask] attribute (which is Inherited = false), so it has not opted into
+        // multithreaded support and must not be analyzed.
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+            using Microsoft.Build.Framework;
+            public abstract class BaseTask : Microsoft.Build.Utilities.Task, IMultiThreadableTask
+            {
+                public TaskEnvironment TaskEnvironment { get; set; } = null!;
+            }
+            public class MyTask : BaseTask
+            {
+                public ITaskItem PathItem { get; set; } = null!;
+                public override bool Execute()
+                {
+                    var abs = new AbsolutePath(PathItem.ItemSpec);
+                    return true;
+                }
+            }
+            """);
+
+        diags.ShouldNotContain(d => d.Id == DiagnosticIds.PreferTypedTaskItem);
+    }
+
+    [Fact]
+    public async Task InputPropertyDeclaredOnBaseClass_WithAttribute_ProducesDiagnostic()
+    {
+        // The input property is declared on a base class while the attribute is on the derived task. Applicability
+        // must consider inherited properties, not just those declared directly on the attributed type.
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+            using Microsoft.Build.Framework;
+            public abstract class BaseTask : Microsoft.Build.Utilities.Task
+            {
+                public ITaskItem PathItem { get; set; } = null!;
+            }
+            [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
+            public class MyTask : BaseTask
+            {
+                public override bool Execute()
+                {
+                    var abs = new AbsolutePath(PathItem.ItemSpec);
                     return true;
                 }
             }

--- a/src/TaskAnalyzer.Tests/PreferTypedParameterAnalyzerTests.cs
+++ b/src/TaskAnalyzer.Tests/PreferTypedParameterAnalyzerTests.cs
@@ -350,6 +350,28 @@ public class PreferTypedParameterAnalyzerTests
     }
 
     [Fact]
+    public async Task GetAbsolutePath_FromItemSpec_ProducesDiagnostic()
+    {
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+            using Microsoft.Build.Framework;
+            public class MyTask : Microsoft.Build.Framework.IMultiThreadableTask
+            {
+                public IBuildEngine BuildEngine { get; set; } = null!;
+                public TaskEnvironment TaskEnvironment { get; set; } = null!;
+                public ITaskItem PathItem { get; set; } = null!;
+                public bool Execute()
+                {
+                    var abs = TaskEnvironment.GetAbsolutePath(PathItem.ItemSpec);
+                    return true;
+                }
+            }
+            """);
+
+        diags.ShouldContain(d => d.Id == DiagnosticIds.PreferTypedTaskItem);
+        diags[0].GetMessage().ShouldContain("AbsolutePath");
+    }
+
+    [Fact]
     public async Task IntParse_FromItemSpec_WithLocalIndirection_ProducesDiagnostic()
     {
         var diags = await GetTypedParameterDiagnosticsAsync("""

--- a/src/TaskAnalyzer.Tests/PreferTypedParameterAnalyzerTests.cs
+++ b/src/TaskAnalyzer.Tests/PreferTypedParameterAnalyzerTests.cs
@@ -515,7 +515,11 @@ public class PreferTypedParameterAnalyzerTests
             }
             """);
 
-        diags.Where(d => d.Id == DiagnosticIds.PreferTypedTaskItem).Count().ShouldBeGreaterThanOrEqualTo(1);
+        // Every argument that flows from a task input is flagged, not just the first.
+        var task7 = diags.Where(d => d.Id == DiagnosticIds.PreferTypedTaskItem).ToArray();
+        task7.Length.ShouldBe(2);
+        task7.ShouldContain(d => d.GetMessage().Contains("OutputDir"));
+        task7.ShouldContain(d => d.GetMessage().Contains("OutputFile"));
     }
 
     [Fact]
@@ -744,5 +748,187 @@ public class PreferTypedParameterAnalyzerTests
             """);
 
         diags.ShouldBeEmpty();
+    }
+
+    // ── System.IO consumption-site inference (File.* => FileInfo, Directory.* => DirectoryInfo) ──
+
+    [Fact]
+    public async Task FileDelete_OnItemSpec_SuggestsFileInfo()
+    {
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+        using System.IO;
+        using Microsoft.Build.Framework;
+        [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
+        public class MyTask : Microsoft.Build.Utilities.Task, Microsoft.Build.Framework.IMultiThreadableTask
+        {
+            public TaskEnvironment TaskEnvironment { get; set; } = new();
+            public ITaskItem Target { get; set; } = null!;
+            public override bool Execute()
+            {
+                File.Delete(Target.ItemSpec);
+                return true;
+            }
+        }
+        """);
+
+        var task7 = diags.Where(d => d.Id == DiagnosticIds.PreferTypedTaskItem).ToArray();
+        task7.Length.ShouldBe(1);
+        task7[0].GetMessage().ShouldContain("FileInfo");
+    }
+
+    [Fact]
+    public async Task DirectoryCreate_OnItemSpec_SuggestsDirectoryInfo()
+    {
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+        using System.IO;
+        using Microsoft.Build.Framework;
+        [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
+        public class MyTask : Microsoft.Build.Utilities.Task, Microsoft.Build.Framework.IMultiThreadableTask
+        {
+            public TaskEnvironment TaskEnvironment { get; set; } = new();
+            public ITaskItem DestinationFolder { get; set; } = null!;
+            public override bool Execute()
+            {
+                Directory.CreateDirectory(DestinationFolder.ItemSpec);
+                return true;
+            }
+        }
+        """);
+
+        var task7 = diags.Where(d => d.Id == DiagnosticIds.PreferTypedTaskItem).ToArray();
+        task7.Length.ShouldBe(1);
+        task7[0].GetMessage().ShouldContain("DirectoryInfo");
+    }
+
+    [Fact]
+    public async Task FileReadAllLines_ThroughAbsolutePath_SuggestsFileInfoAndSuppressesAbsolutePath()
+    {
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+        using System.IO;
+        using Microsoft.Build.Framework;
+        [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
+        public class MyTask : Microsoft.Build.Utilities.Task, Microsoft.Build.Framework.IMultiThreadableTask
+        {
+            public TaskEnvironment TaskEnvironment { get; set; } = new();
+            public ITaskItem Input { get; set; } = null!;
+            public override bool Execute()
+            {
+                var lines = File.ReadAllLines(TaskEnvironment.GetAbsolutePath(Input.ItemSpec));
+                return true;
+            }
+        }
+        """);
+
+        var task7 = diags.Where(d => d.Id == DiagnosticIds.PreferTypedTaskItem).ToArray();
+        task7.Length.ShouldBe(1);
+        task7[0].GetMessage().ShouldContain("FileInfo");
+        task7[0].GetMessage().ShouldNotContain("AbsolutePath");
+    }
+
+    [Fact]
+    public async Task NewFileStream_OnItemSpec_SuggestsFileInfo()
+    {
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+        using System.IO;
+        using Microsoft.Build.Framework;
+        [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
+        public class MyTask : Microsoft.Build.Utilities.Task, Microsoft.Build.Framework.IMultiThreadableTask
+        {
+            public TaskEnvironment TaskEnvironment { get; set; } = new();
+            public ITaskItem XmlInputPath { get; set; } = null!;
+            public override bool Execute()
+            {
+                using var stream = new FileStream(XmlInputPath.ItemSpec, FileMode.Open);
+                return true;
+            }
+        }
+        """);
+
+        var task7 = diags.Where(d => d.Id == DiagnosticIds.PreferTypedTaskItem).ToArray();
+        task7.Length.ShouldBe(1);
+        task7[0].GetMessage().ShouldContain("FileInfo");
+    }
+
+    [Fact]
+    public async Task FileWriteAllText_DoesNotFlagNonPathContentsArgument()
+    {
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+        using System.IO;
+        using Microsoft.Build.Framework;
+        [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
+        public class MyTask : Microsoft.Build.Utilities.Task, Microsoft.Build.Framework.IMultiThreadableTask
+        {
+            public TaskEnvironment TaskEnvironment { get; set; } = new();
+            public ITaskItem OutputFile { get; set; } = null!;
+            public ITaskItem Contents { get; set; } = null!;
+            public override bool Execute()
+            {
+                File.WriteAllText(OutputFile.ItemSpec, Contents.ItemSpec);
+                return true;
+            }
+        }
+        """);
+
+        var task7 = diags.Where(d => d.Id == DiagnosticIds.PreferTypedTaskItem).ToArray();
+        task7.Length.ShouldBe(1);
+        task7[0].GetMessage().ShouldContain("OutputFile");
+        task7[0].GetMessage().ShouldContain("FileInfo");
+    }
+
+    [Fact]
+    public async Task DirectoryCreate_OnReassignedNullableLocal_SuggestsDirectoryInfo()
+    {
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+            using System.IO;
+            using Microsoft.Build.Framework;
+            [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
+            public class MyTask : Microsoft.Build.Utilities.Task, Microsoft.Build.Framework.IMultiThreadableTask
+            {
+                public TaskEnvironment TaskEnvironment { get; set; } = new();
+                public ITaskItem Directories { get; set; } = null!;
+                public override bool Execute()
+                {
+                    AbsolutePath? absolutePath = null;
+                    absolutePath = TaskEnvironment.GetAbsolutePath(Directories.ItemSpec);
+                    Directory.CreateDirectory(absolutePath);
+                    return true;
+                }
+            }
+            """);
+
+        // The local is declared `= null` then assigned once; the consumption site still resolves to DirectoryInfo.
+        var task7 = diags.Where(d => d.Id == DiagnosticIds.PreferTypedTaskItem).ToArray();
+        task7.Length.ShouldBe(1);
+        task7[0].GetMessage().ShouldContain("DirectoryInfo");
+        task7[0].GetMessage().ShouldNotContain("AbsolutePath");
+    }
+
+    [Fact]
+    public async Task FileAndDirectoryConflict_FallsBackToAbsolutePath()
+    {
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+        using System.IO;
+        using Microsoft.Build.Framework;
+        [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
+        public class MyTask : Microsoft.Build.Utilities.Task, Microsoft.Build.Framework.IMultiThreadableTask
+        {
+            public TaskEnvironment TaskEnvironment { get; set; } = new();
+            public ITaskItem Ambiguous { get; set; } = null!;
+            public override bool Execute()
+            {
+                AbsolutePath abs = TaskEnvironment.GetAbsolutePath(Ambiguous.ItemSpec);
+                File.Delete(abs);
+                Directory.CreateDirectory(abs);
+                return true;
+            }
+        }
+        """);
+
+        // Contradictory file/dir inference for one property: keep the AbsolutePath fallback, drop the specifics.
+        var task7 = diags.Where(d => d.Id == DiagnosticIds.PreferTypedTaskItem).ToArray();
+        task7.Length.ShouldBe(1);
+        task7[0].GetMessage().ShouldContain("AbsolutePath");
+        task7[0].GetMessage().ShouldNotContain("FileInfo");
+        task7[0].GetMessage().ShouldNotContain("DirectoryInfo");
     }
 }

--- a/src/TaskAnalyzer.Tests/PreferTypedParameterAnalyzerTests.cs
+++ b/src/TaskAnalyzer.Tests/PreferTypedParameterAnalyzerTests.cs
@@ -589,11 +589,11 @@ public class PreferTypedParameterAnalyzerTests
             }
             """);
 
-        // Should get MSBuildTask0007 for GetAbsolutePath(item.ItemSpec) AND for new DirectoryInfo(abs)
+        // The AbsolutePath suggestion should be suppressed in favor of DirectoryInfo
         var task7 = diags.Where(d => d.Id == DiagnosticIds.PreferTypedTaskItem).ToArray();
-        task7.Length.ShouldBeGreaterThanOrEqualTo(1);
-        // At least one diagnostic should suggest DirectoryInfo
-        task7.ShouldContain(d => d.GetMessage().Contains("DirectoryInfo"));
+        task7.Length.ShouldBe(1);
+        task7[0].GetMessage().ShouldContain("DirectoryInfo");
+        task7[0].GetMessage().ShouldNotContain("AbsolutePath");
     }
 
     [Fact]
@@ -617,8 +617,9 @@ public class PreferTypedParameterAnalyzerTests
             """);
 
         var task7 = diags.Where(d => d.Id == DiagnosticIds.PreferTypedTaskItem).ToArray();
-        task7.Length.ShouldBeGreaterThanOrEqualTo(1);
-        task7.ShouldContain(d => d.GetMessage().Contains("FileInfo"));
+        task7.Length.ShouldBe(1);
+        task7[0].GetMessage().ShouldContain("FileInfo");
+        task7[0].GetMessage().ShouldNotContain("AbsolutePath");
     }
 
     // ── Negative cases for MSBuildTask0007 ──

--- a/src/TaskAnalyzer.Tests/PreferTypedParameterAnalyzerTests.cs
+++ b/src/TaskAnalyzer.Tests/PreferTypedParameterAnalyzerTests.cs
@@ -1163,6 +1163,40 @@ public class PreferTypedParameterAnalyzerTests
         task7[0].GetMessage().ShouldNotContain("DirectoryInfo");
     }
 
+    [Fact]
+    public async Task FileAndDirectoryConflict_NoAbsolutePathSite_StillFlagsWithAbsolutePath()
+    {
+        // A string property consumed as BOTH a file and a directory, with no AbsolutePath site to carry the
+        // suggestion. Neither FileInfo nor DirectoryInfo is safe, so the property must still be flagged, but
+        // with the AbsolutePath fallback rather than emitting two contradictory specific suggestions.
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+        using System.IO;
+        using Microsoft.Build.Framework;
+        [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
+        public class MyTask : Microsoft.Build.Utilities.Task, Microsoft.Build.Framework.IMultiThreadableTask
+        {
+            public TaskEnvironment TaskEnvironment { get; set; } = new();
+            public string Ambiguous { get; set; } = "";
+            public override bool Execute()
+            {
+                File.Delete(Ambiguous);
+                Directory.CreateDirectory(Ambiguous);
+                return true;
+            }
+        }
+        """);
+
+        var task6 = diags.Where(d => d.Id == DiagnosticIds.PreferTypedPathParameter).ToArray();
+        task6.Length.ShouldBeGreaterThan(0);
+        foreach (var diag in task6)
+        {
+            diag.GetMessage().ShouldContain("Ambiguous");
+            diag.GetMessage().ShouldContain("AbsolutePath");
+            diag.GetMessage().ShouldNotContain("FileInfo");
+            diag.GetMessage().ShouldNotContain("DirectoryInfo");
+        }
+    }
+
     // ── MSBuildTask0006 over raw-string 0002/0003 scenarios (one-shot instead of daisy-chaining) ──
 
     [Fact]

--- a/src/TaskAnalyzer.Tests/PreferTypedParameterCodeFixProviderTests.cs
+++ b/src/TaskAnalyzer.Tests/PreferTypedParameterCodeFixProviderTests.cs
@@ -1,0 +1,220 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using Xunit;
+using static Microsoft.Build.TaskAuthoring.Analyzer.Tests.TestHelpers;
+
+namespace Microsoft.Build.TaskAuthoring.Analyzer.Tests;
+
+public class PreferTypedParameterCodeFixProviderTests
+{
+    private static CSharpCodeFixTest<PreferTypedParameterAnalyzer, PreferTypedParameterCodeFixProvider, DefaultVerifier> CreateFixTest(
+        string testCode, string fixedCode, params DiagnosticResult[] expected)
+    {
+        var test = new CSharpCodeFixTest<PreferTypedParameterAnalyzer, PreferTypedParameterCodeFixProvider, DefaultVerifier>
+        {
+            TestCode = testCode,
+            FixedCode = fixedCode,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        };
+        test.TestState.Sources.Add(("Stubs.cs", FrameworkStubs));
+        test.FixedState.Sources.Add(("Stubs.cs", FrameworkStubs));
+        test.ExpectedDiagnostics.AddRange(expected);
+        return test;
+    }
+
+    private static DiagnosticResult Diag(string id) => id switch
+    {
+        DiagnosticIds.PreferTypedPathParameter => new DiagnosticResult(DiagnosticDescriptors.PreferTypedPathParameter),
+        DiagnosticIds.PreferTypedTaskItem => new DiagnosticResult(DiagnosticDescriptors.PreferTypedTaskItem),
+        _ => new DiagnosticResult(id, DiagnosticSeverity.Info),
+    };
+
+    [Fact]
+    public async Task Fix_0006_NewAbsolutePath_RetypesPropertyAndRemovesConversion()
+    {
+        await CreateFixTest(
+            testCode: """
+                using Microsoft.Build.Framework;
+                [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
+                public class MyTask : Microsoft.Build.Utilities.Task
+                {
+                    public string InputPath { get; set; } = "";
+                    public override bool Execute()
+                    {
+                        var abs = {|#0:new AbsolutePath(InputPath)|};
+                        return true;
+                    }
+                }
+                """,
+            fixedCode: """
+                using Microsoft.Build.Framework;
+                [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
+                public class MyTask : Microsoft.Build.Utilities.Task
+                {
+                    public AbsolutePath InputPath { get; set; } = default;
+                    public override bool Execute()
+                    {
+                        var abs = InputPath;
+                        return true;
+                    }
+                }
+                """,
+            Diag(DiagnosticIds.PreferTypedPathParameter).WithLocation(0)
+                .WithArguments("InputPath", "string", "AbsolutePath")).RunAsync();
+    }
+
+    [Fact]
+    public async Task Fix_0006_NewFileInfo_RetypesPropertyAndUsesTypedValue()
+    {
+        await CreateFixTest(
+            testCode: """
+                using System.IO;
+                using Microsoft.Build.Framework;
+                [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
+                public class MyTask : Microsoft.Build.Utilities.Task
+                {
+                    public string FilePath { get; set; } = "";
+                    public override bool Execute()
+                    {
+                        var fi = {|#0:new FileInfo(FilePath)|};
+                        return true;
+                    }
+                }
+                """,
+            fixedCode: """
+                using System.IO;
+                using Microsoft.Build.Framework;
+                [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
+                public class MyTask : Microsoft.Build.Utilities.Task
+                {
+                    public FileInfo FilePath { get; set; } = null!;
+                    public override bool Execute()
+                    {
+                        var fi = FilePath;
+                        return true;
+                    }
+                }
+                """,
+            Diag(DiagnosticIds.PreferTypedPathParameter).WithLocation(0)
+                .WithArguments("FilePath", "string", "FileInfo")).RunAsync();
+    }
+
+    [Fact]
+    public async Task Fix_0007_IntParse_RetypesTaskItemAndUsesValue()
+    {
+        await CreateFixTest(
+            testCode: """
+                using Microsoft.Build.Framework;
+                [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
+                public class MyTask : Microsoft.Build.Utilities.Task
+                {
+                    public ITaskItem Item { get; set; } = null!;
+                    public override bool Execute()
+                    {
+                        int value = {|#0:int.Parse(Item.ItemSpec)|};
+                        return true;
+                    }
+                }
+                """,
+            fixedCode: """
+                using Microsoft.Build.Framework;
+                [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
+                public class MyTask : Microsoft.Build.Utilities.Task
+                {
+                    public ITaskItem<int> Item { get; set; } = null!;
+                    public override bool Execute()
+                    {
+                        int value = Item.Value;
+                        return true;
+                    }
+                }
+                """,
+            Diag(DiagnosticIds.PreferTypedTaskItem).WithLocation(0)
+                .WithArguments("Item", "ITaskItem", "int", "")).RunAsync();
+    }
+
+    [Fact]
+    public async Task Fix_0007_ArrayForeach_RetypesArrayAndUsesValue()
+    {
+        await CreateFixTest(
+            testCode: """
+                using System.IO;
+                using Microsoft.Build.Framework;
+                [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
+                public class MyTask : Microsoft.Build.Utilities.Task
+                {
+                    public ITaskItem[] Items { get; set; } = null!;
+                    public override bool Execute()
+                    {
+                        foreach (var item in Items)
+                        {
+                            var fi = {|#0:new FileInfo(item.ItemSpec)|};
+                        }
+                        return true;
+                    }
+                }
+                """,
+            fixedCode: """
+                using System.IO;
+                using Microsoft.Build.Framework;
+                [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
+                public class MyTask : Microsoft.Build.Utilities.Task
+                {
+                    public ITaskItem<FileInfo>[] Items { get; set; } = null!;
+                    public override bool Execute()
+                    {
+                        foreach (var item in Items)
+                        {
+                            var fi = item.Value;
+                        }
+                        return true;
+                    }
+                }
+                """,
+            Diag(DiagnosticIds.PreferTypedTaskItem).WithLocation(0)
+                .WithArguments("Items", "ITaskItem[]", "FileInfo", "[]")).RunAsync();
+    }
+
+    [Fact]
+    public async Task Fix_0006_RewritesAllSitesForProperty()
+    {
+        await CreateFixTest(
+            testCode: """
+                using Microsoft.Build.Framework;
+                [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
+                public class MyTask : Microsoft.Build.Utilities.Task
+                {
+                    public string InputPath { get; set; } = "";
+                    public override bool Execute()
+                    {
+                        var first = {|#0:new AbsolutePath(InputPath)|};
+                        var second = {|#1:new AbsolutePath(InputPath)|};
+                        return true;
+                    }
+                }
+                """,
+            fixedCode: """
+                using Microsoft.Build.Framework;
+                [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
+                public class MyTask : Microsoft.Build.Utilities.Task
+                {
+                    public AbsolutePath InputPath { get; set; } = default;
+                    public override bool Execute()
+                    {
+                        var first = InputPath;
+                        var second = InputPath;
+                        return true;
+                    }
+                }
+                """,
+            Diag(DiagnosticIds.PreferTypedPathParameter).WithLocation(0)
+                .WithArguments("InputPath", "string", "AbsolutePath"),
+            Diag(DiagnosticIds.PreferTypedPathParameter).WithLocation(1)
+                .WithArguments("InputPath", "string", "AbsolutePath")).RunAsync();
+    }
+}

--- a/src/TaskAnalyzer.Tests/PreferTypedParameterCodeFixProviderTests.cs
+++ b/src/TaskAnalyzer.Tests/PreferTypedParameterCodeFixProviderTests.cs
@@ -139,6 +139,76 @@ public class PreferTypedParameterCodeFixProviderTests
     }
 
     [Fact]
+    public async Task Fix_0007_ConvertToInt32_RetypesTaskItemAndUsesValue()
+    {
+        await CreateFixTest(
+            testCode: """
+                using System;
+                using Microsoft.Build.Framework;
+                [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
+                public class MyTask : Microsoft.Build.Utilities.Task
+                {
+                    public ITaskItem Item { get; set; } = null!;
+                    public override bool Execute()
+                    {
+                        int value = {|#0:Convert.ToInt32(Item.ItemSpec)|};
+                        return true;
+                    }
+                }
+                """,
+            fixedCode: """
+                using System;
+                using Microsoft.Build.Framework;
+                [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
+                public class MyTask : Microsoft.Build.Utilities.Task
+                {
+                    public ITaskItem<int> Item { get; set; } = null!;
+                    public override bool Execute()
+                    {
+                        int value = Item.Value;
+                        return true;
+                    }
+                }
+                """,
+            Diag(DiagnosticIds.PreferTypedTaskItem).WithLocation(0)
+                .WithArguments("Item", "ITaskItem", "int", "")).RunAsync();
+    }
+
+    [Fact]
+    public async Task Fix_0007_GetAbsolutePath_RetypesTaskItemAndUsesValue()
+    {
+        await CreateFixTest(
+            testCode: """
+                using Microsoft.Build.Framework;
+                public class MyTask : Microsoft.Build.Utilities.Task, IMultiThreadableTask
+                {
+                    public TaskEnvironment TaskEnvironment { get; set; }
+                    public ITaskItem Item { get; set; } = null!;
+                    public override bool Execute()
+                    {
+                        var path = {|#0:TaskEnvironment.GetAbsolutePath(Item.ItemSpec)|};
+                        return true;
+                    }
+                }
+                """,
+            fixedCode: """
+                using Microsoft.Build.Framework;
+                public class MyTask : Microsoft.Build.Utilities.Task, IMultiThreadableTask
+                {
+                    public TaskEnvironment TaskEnvironment { get; set; }
+                    public ITaskItem<AbsolutePath> Item { get; set; } = null!;
+                    public override bool Execute()
+                    {
+                        var path = Item.Value;
+                        return true;
+                    }
+                }
+                """,
+            Diag(DiagnosticIds.PreferTypedTaskItem).WithLocation(0)
+                .WithArguments("Item", "ITaskItem", "AbsolutePath", "")).RunAsync();
+    }
+
+    [Fact]
     public async Task Fix_0007_ArrayForeach_RetypesArrayAndUsesValue()
     {
         await CreateFixTest(

--- a/src/TaskAnalyzer.Tests/PreferTypedParameterCodeFixProviderTests.cs
+++ b/src/TaskAnalyzer.Tests/PreferTypedParameterCodeFixProviderTests.cs
@@ -326,6 +326,118 @@ public class PreferTypedParameterCodeFixProviderTests
     }
 
     [Fact]
+    public async Task Fix_0006_PathGetFullPath_RetypesToAbsolutePathAndRemovesCall()
+    {
+        // Path.GetFullPath(prop) is the raw MSBuildTask0002 normalization. Retyping the property to AbsolutePath
+        // makes the value already-absolute, so the whole call collapses to the property (one-shot, no daisy-chain).
+        await CreateFixTest(
+            testCode: """
+                using System.IO;
+                using Microsoft.Build.Framework;
+                [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
+                public class MyTask : Microsoft.Build.Utilities.Task
+                {
+                    public string InputPath { get; set; } = "";
+                    public override bool Execute()
+                    {
+                        var full = {|#0:Path.GetFullPath(InputPath)|};
+                        return true;
+                    }
+                }
+                """,
+            fixedCode: """
+                using System.IO;
+                using Microsoft.Build.Framework;
+                [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
+                public class MyTask : Microsoft.Build.Utilities.Task
+                {
+                    public AbsolutePath InputPath { get; set; } = default;
+                    public override bool Execute()
+                    {
+                        var full = InputPath;
+                        return true;
+                    }
+                }
+                """,
+            Diag(DiagnosticIds.PreferTypedPathParameter).WithLocation(0)
+                .WithArguments("InputPath", "string", "AbsolutePath")).RunAsync();
+    }
+
+    [Fact]
+    public async Task Fix_0006_FileConsumption_RetypesToFileInfoAndUsesFullName()
+    {
+        // File.Delete(prop) is the raw MSBuildTask0003 consumption. Retyping to FileInfo requires feeding the
+        // string API through .FullName (FileInfo has no implicit string conversion).
+        await CreateFixTest(
+            testCode: """
+                using System.IO;
+                using Microsoft.Build.Framework;
+                [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
+                public class MyTask : Microsoft.Build.Utilities.Task
+                {
+                    public string Target { get; set; } = "";
+                    public override bool Execute()
+                    {
+                        {|#0:File.Delete(Target)|};
+                        return true;
+                    }
+                }
+                """,
+            fixedCode: """
+                using System.IO;
+                using Microsoft.Build.Framework;
+                [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
+                public class MyTask : Microsoft.Build.Utilities.Task
+                {
+                    public FileInfo Target { get; set; } = null!;
+                    public override bool Execute()
+                    {
+                        File.Delete(Target.FullName);
+                        return true;
+                    }
+                }
+                """,
+            Diag(DiagnosticIds.PreferTypedPathParameter).WithLocation(0)
+                .WithArguments("Target", "string", "FileInfo")).RunAsync();
+    }
+
+    [Fact]
+    public async Task Fix_0006_DirectoryConsumption_RetypesToDirectoryInfoAndUsesFullName()
+    {
+        await CreateFixTest(
+            testCode: """
+                using System.IO;
+                using Microsoft.Build.Framework;
+                [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
+                public class MyTask : Microsoft.Build.Utilities.Task
+                {
+                    public string DestinationFolder { get; set; } = "";
+                    public override bool Execute()
+                    {
+                        {|#0:Directory.CreateDirectory(DestinationFolder)|};
+                        return true;
+                    }
+                }
+                """,
+            fixedCode: """
+                using System.IO;
+                using Microsoft.Build.Framework;
+                [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
+                public class MyTask : Microsoft.Build.Utilities.Task
+                {
+                    public DirectoryInfo DestinationFolder { get; set; } = null!;
+                    public override bool Execute()
+                    {
+                        Directory.CreateDirectory(DestinationFolder.FullName);
+                        return true;
+                    }
+                }
+                """,
+            Diag(DiagnosticIds.PreferTypedPathParameter).WithLocation(0)
+                .WithArguments("DestinationFolder", "string", "DirectoryInfo")).RunAsync();
+    }
+
+    [Fact]
     public async Task Fix_0006_AbsolutePathDefault_NormalizedThroughAbsolutePath()
     {
         // A fully-qualified string default is preserved after retyping by constructing the AbsolutePath in the

--- a/src/TaskAnalyzer.Tests/PreferTypedParameterCodeFixProviderTests.cs
+++ b/src/TaskAnalyzer.Tests/PreferTypedParameterCodeFixProviderTests.cs
@@ -31,6 +31,7 @@ public class PreferTypedParameterCodeFixProviderTests
     {
         DiagnosticIds.PreferTypedPathParameter => new DiagnosticResult(DiagnosticDescriptors.PreferTypedPathParameter),
         DiagnosticIds.PreferTypedTaskItem => new DiagnosticResult(DiagnosticDescriptors.PreferTypedTaskItem),
+        DiagnosticIds.InitializeRelativeDefaultInExecute => new DiagnosticResult(DiagnosticDescriptors.InitializeRelativeDefaultInExecute),
         _ => new DiagnosticResult(id, DiagnosticSeverity.Info),
     };
 
@@ -209,6 +210,40 @@ public class PreferTypedParameterCodeFixProviderTests
     }
 
     [Fact]
+    public async Task Fix_0007_NewAbsolutePath_FromGetMetadataFullPath_RetypesTaskItemAndUsesValue()
+    {
+        await CreateFixTest(
+            testCode: """
+                using Microsoft.Build.Framework;
+                [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
+                public class MyTask : Microsoft.Build.Utilities.Task
+                {
+                    public ITaskItem Item { get; set; } = null!;
+                    public override bool Execute()
+                    {
+                        var path = {|#0:new AbsolutePath(Item.GetMetadata("FullPath"))|};
+                        return true;
+                    }
+                }
+                """,
+            fixedCode: """
+                using Microsoft.Build.Framework;
+                [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
+                public class MyTask : Microsoft.Build.Utilities.Task
+                {
+                    public ITaskItem<AbsolutePath> Item { get; set; } = null!;
+                    public override bool Execute()
+                    {
+                        var path = Item.Value;
+                        return true;
+                    }
+                }
+                """,
+            Diag(DiagnosticIds.PreferTypedTaskItem).WithLocation(0)
+                .WithArguments("Item", "ITaskItem", "AbsolutePath", "")).RunAsync();
+    }
+
+    [Fact]
     public async Task Fix_0007_ArrayForeach_RetypesArrayAndUsesValue()
     {
         await CreateFixTest(
@@ -286,5 +321,392 @@ public class PreferTypedParameterCodeFixProviderTests
                 .WithArguments("InputPath", "string", "AbsolutePath"),
             Diag(DiagnosticIds.PreferTypedPathParameter).WithLocation(1)
                 .WithArguments("InputPath", "string", "AbsolutePath")).RunAsync();
+    }
+
+    [Fact]
+    public async Task Fix_0006_AbsolutePathDefault_NormalizedThroughAbsolutePath()
+    {
+        // A fully-qualified string default is preserved after retyping by constructing the AbsolutePath in the
+        // initializer. This is only safe because the value is already rooted: MSBuild normally roots a relative
+        // string via TaskEnvironment, which is not available inside a property initializer (it runs in the ctor).
+        await CreateFixTest(
+            testCode: """
+                using Microsoft.Build.Framework;
+                [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
+                public class MyTask : Microsoft.Build.Utilities.Task
+                {
+                    public string InputPath { get; set; } = "C:/logs";
+                    public override bool Execute()
+                    {
+                        var abs = {|#0:new AbsolutePath(InputPath)|};
+                        return true;
+                    }
+                }
+                """,
+            fixedCode: """
+                using Microsoft.Build.Framework;
+                [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
+                public class MyTask : Microsoft.Build.Utilities.Task
+                {
+                    public AbsolutePath InputPath { get; set; } = new AbsolutePath("C:/logs");
+                    public override bool Execute()
+                    {
+                        var abs = InputPath;
+                        return true;
+                    }
+                }
+                """,
+            Diag(DiagnosticIds.PreferTypedPathParameter).WithLocation(0)
+                .WithArguments("InputPath", "string", "AbsolutePath")).RunAsync();
+    }
+
+    [Fact]
+    public async Task Fix_0006_AbsolutePathDefault_FileInfo_NormalizedThroughAbsolutePath()
+    {
+        // For FileInfo the engine goes string -> AbsolutePath -> FileInfo, so the fix constructs through
+        // AbsolutePath rather than passing the raw string to FileInfo directly.
+        await CreateFixTest(
+            testCode: """
+                using System.IO;
+                using Microsoft.Build.Framework;
+                [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
+                public class MyTask : Microsoft.Build.Utilities.Task
+                {
+                    public string FilePath { get; set; } = "C:/logs/out.txt";
+                    public override bool Execute()
+                    {
+                        var fi = {|#0:new FileInfo(FilePath)|};
+                        return true;
+                    }
+                }
+                """,
+            fixedCode: """
+                using System.IO;
+                using Microsoft.Build.Framework;
+                [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
+                public class MyTask : Microsoft.Build.Utilities.Task
+                {
+                    public FileInfo FilePath { get; set; } = new FileInfo(new AbsolutePath("C:/logs/out.txt"));
+                    public override bool Execute()
+                    {
+                        var fi = FilePath;
+                        return true;
+                    }
+                }
+                """,
+            Diag(DiagnosticIds.PreferTypedPathParameter).WithLocation(0)
+                .WithArguments("FilePath", "string", "FileInfo")).RunAsync();
+    }
+
+    [Fact]
+    public async Task Fix_0008_RelativeDefault_AbsolutePath_InitializedInExecute()
+    {
+        // A relative default cannot be rooted in a property initializer (TaskEnvironment is only available after
+        // construction), so MSBuildTask0008 moves it into Execute() with a guarded assignment that only applies
+        // when the property is still unset (so a value bound from the project XML is not clobbered).
+        await CreateFixTest(
+            testCode: """
+                using Microsoft.Build.Framework;
+                public class MyTask : Microsoft.Build.Utilities.Task, IMultiThreadableTask
+                {
+                    public TaskEnvironment TaskEnvironment { get; set; }
+                    public string InputPath { get; set; } = {|#0:"obj"|};
+                    public override bool Execute()
+                    {
+                        var abs = new AbsolutePath(InputPath);
+                        return true;
+                    }
+                }
+                """,
+            fixedCode: """
+                using Microsoft.Build.Framework;
+                public class MyTask : Microsoft.Build.Utilities.Task, IMultiThreadableTask
+                {
+                    public TaskEnvironment TaskEnvironment { get; set; }
+                    public AbsolutePath InputPath { get; set; } = default;
+                    public override bool Execute()
+                    {
+                        if (InputPath == default)
+                        {
+                            InputPath = TaskEnvironment.GetAbsolutePath("obj");
+                        }
+
+                        var abs = InputPath;
+                        return true;
+                    }
+                }
+                """,
+            Diag(DiagnosticIds.InitializeRelativeDefaultInExecute).WithLocation(0)
+                .WithArguments("InputPath", "AbsolutePath")).RunAsync();
+    }
+
+    [Fact]
+    public async Task Fix_0008_RelativeDefault_FileInfo_InitializedInExecute()
+    {
+        // For a reference type the guard is a null-coalescing assignment, and the value is built through the
+        // string -> AbsolutePath -> FileInfo chain (AbsolutePath converts implicitly to string).
+        await CreateFixTest(
+            testCode: """
+                using System.IO;
+                using Microsoft.Build.Framework;
+                public class MyTask : Microsoft.Build.Utilities.Task, IMultiThreadableTask
+                {
+                    public TaskEnvironment TaskEnvironment { get; set; }
+                    public string LogPath { get; set; } = {|#0:"logs"|};
+                    public override bool Execute()
+                    {
+                        var fi = new FileInfo(LogPath);
+                        return true;
+                    }
+                }
+                """,
+            fixedCode: """
+                using System.IO;
+                using Microsoft.Build.Framework;
+                public class MyTask : Microsoft.Build.Utilities.Task, IMultiThreadableTask
+                {
+                    public TaskEnvironment TaskEnvironment { get; set; }
+                    public FileInfo LogPath { get; set; } = null!;
+                    public override bool Execute()
+                    {
+                        LogPath ??= new FileInfo(TaskEnvironment.GetAbsolutePath("logs"));
+                        var fi = LogPath;
+                        return true;
+                    }
+                }
+                """,
+            Diag(DiagnosticIds.InitializeRelativeDefaultInExecute).WithLocation(0)
+                .WithArguments("LogPath", "FileInfo")).RunAsync();
+    }
+
+    [Fact]
+    public async Task Fix_0008_RelativeDefault_DirectoryInfo_InitializedInExecute()
+    {
+        await CreateFixTest(
+            testCode: """
+                using System.IO;
+                using Microsoft.Build.Framework;
+                public class MyTask : Microsoft.Build.Utilities.Task, IMultiThreadableTask
+                {
+                    public TaskEnvironment TaskEnvironment { get; set; }
+                    public string OutputDir { get; set; } = {|#0:"bin"|};
+                    public override bool Execute()
+                    {
+                        var di = new DirectoryInfo(OutputDir);
+                        return true;
+                    }
+                }
+                """,
+            fixedCode: """
+                using System.IO;
+                using Microsoft.Build.Framework;
+                public class MyTask : Microsoft.Build.Utilities.Task, IMultiThreadableTask
+                {
+                    public TaskEnvironment TaskEnvironment { get; set; }
+                    public DirectoryInfo OutputDir { get; set; } = null!;
+                    public override bool Execute()
+                    {
+                        OutputDir ??= new DirectoryInfo(TaskEnvironment.GetAbsolutePath("bin"));
+                        var di = OutputDir;
+                        return true;
+                    }
+                }
+                """,
+            Diag(DiagnosticIds.InitializeRelativeDefaultInExecute).WithLocation(0)
+                .WithArguments("OutputDir", "DirectoryInfo")).RunAsync();
+    }
+
+    [Fact]
+    public async Task Fix_0008_NoTaskEnvironment_NoFixOffered()
+    {
+        // Without an accessible TaskEnvironment member the relative default cannot be rooted, so the diagnostic
+        // is reported but no fix is offered.
+        await CreateNoFixTest(
+            """
+            using Microsoft.Build.Framework;
+            [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                public string InputPath { get; set; } = {|#0:"obj"|};
+                public override bool Execute()
+                {
+                    var abs = new AbsolutePath(InputPath);
+                    return true;
+                }
+            }
+            """,
+            Diag(DiagnosticIds.InitializeRelativeDefaultInExecute).WithLocation(0)
+                .WithArguments("InputPath", "AbsolutePath"));
+    }
+
+    [Fact]
+    public async Task Fix_0008_ExpressionBodiedExecute_NoFixOffered()
+    {
+        // An expression-bodied Execute() has no statement block to insert the guarded initialization into, so
+        // the diagnostic is reported but no fix is offered.
+        await CreateNoFixTest(
+            """
+            using System.IO;
+            using Microsoft.Build.Framework;
+            public class MyTask : Microsoft.Build.Utilities.Task, IMultiThreadableTask
+            {
+                public TaskEnvironment TaskEnvironment { get; set; }
+                public string InputPath { get; set; } = {|#0:"obj"|};
+                public override bool Execute() => File.Exists(new AbsolutePath(InputPath));
+            }
+            """,
+            Diag(DiagnosticIds.InitializeRelativeDefaultInExecute).WithLocation(0)
+                .WithArguments("InputPath", "AbsolutePath"));
+    }
+
+    [Fact]
+    public async Task Fix_0006_NonConstantDefault_NoFixOffered()
+    {
+        // The default is not a compile-time constant, so it can't be safely re-expressed as the new type.
+        // The diagnostic is still reported, but no code fix is offered (the source is left unchanged).
+        await CreateNoFixTest(
+            """
+            using Microsoft.Build.Framework;
+            [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                public string InputPath { get; set; } = System.IO.Path.GetTempPath();
+                public override bool Execute()
+                {
+                    var abs = {|#0:new AbsolutePath(InputPath)|};
+                    return true;
+                }
+            }
+            """,
+            Diag(DiagnosticIds.PreferTypedPathParameter).WithLocation(0)
+                .WithArguments("InputPath", "string", "AbsolutePath"));
+    }
+
+    [Fact]
+    public async Task Fix_0006_InvalidPathDefault_NoFixOffered()
+    {
+        // The default contains a character that is never valid in a path, so it isn't a plausible path value.
+        // The diagnostic is still reported, but no code fix is offered.
+        await CreateNoFixTest(
+            """
+            using Microsoft.Build.Framework;
+            [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                public string InputPath { get; set; } = "bad\u0000path";
+                public override bool Execute()
+                {
+                    var abs = {|#0:new AbsolutePath(InputPath)|};
+                    return true;
+                }
+            }
+            """,
+            Diag(DiagnosticIds.PreferTypedPathParameter).WithLocation(0)
+                .WithArguments("InputPath", "string", "AbsolutePath"));
+    }
+
+    [Fact]
+    public async Task Fix_0006_PartialClass_SingleFile_AppliesFix()
+    {
+        // The property is declared in one partial part and converted in another (same file); the fix must
+        // find the property via its symbol and rewrite the conversion.
+        await CreateFixTest(
+            testCode: """
+                using Microsoft.Build.Framework;
+                [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
+                public partial class MyTask : Microsoft.Build.Utilities.Task
+                {
+                    public string InputPath { get; set; } = "";
+                }
+                public partial class MyTask
+                {
+                    public override bool Execute()
+                    {
+                        var abs = {|#0:new AbsolutePath(InputPath)|};
+                        return true;
+                    }
+                }
+                """,
+            fixedCode: """
+                using Microsoft.Build.Framework;
+                [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
+                public partial class MyTask : Microsoft.Build.Utilities.Task
+                {
+                    public AbsolutePath InputPath { get; set; } = default;
+                }
+                public partial class MyTask
+                {
+                    public override bool Execute()
+                    {
+                        var abs = InputPath;
+                        return true;
+                    }
+                }
+                """,
+            Diag(DiagnosticIds.PreferTypedPathParameter).WithLocation(0)
+                .WithArguments("InputPath", "string", "AbsolutePath")).RunAsync();
+    }
+
+    [Fact]
+    public async Task Fix_0006_PartialClass_NonRewritableReferenceInOtherFile_NoFixOffered()
+    {
+        // A partial part in another file uses the property as a plain string. Retyping it there would not
+        // compile, and a single-document fix can't rewrite the other file, so no fix must be offered.
+        const string file1 = """
+            using Microsoft.Build.Framework;
+            [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
+            public partial class MyTask : Microsoft.Build.Utilities.Task
+            {
+                public string InputPath { get; set; } = "";
+                public override bool Execute()
+                {
+                    var abs = {|#0:new AbsolutePath(InputPath)|};
+                    return true;
+                }
+            }
+            """;
+        const string file2 = """
+            public partial class MyTask
+            {
+                private string Echo() => InputPath;
+            }
+            """;
+
+        var test = new CSharpCodeFixTest<PreferTypedParameterAnalyzer, PreferTypedParameterCodeFixProvider, DefaultVerifier>
+        {
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        };
+        test.TestState.Sources.Add(("File1.cs", file1));
+        test.TestState.Sources.Add(("File2.cs", file2));
+        test.TestState.Sources.Add(("Stubs.cs", FrameworkStubs));
+        test.FixedState.Sources.Add(("File1.cs", file1));
+        test.FixedState.Sources.Add(("File2.cs", file2));
+        test.FixedState.Sources.Add(("Stubs.cs", FrameworkStubs));
+
+        var diag = Diag(DiagnosticIds.PreferTypedPathParameter).WithLocation(0)
+            .WithArguments("InputPath", "string", "AbsolutePath");
+        test.TestState.ExpectedDiagnostics.Add(diag);
+        test.FixedState.ExpectedDiagnostics.Add(diag);
+
+        await test.RunAsync();
+    }
+
+    /// <summary>
+    /// Builds a code-fix test where the diagnostic is expected but no fix is offered: the fixed source is
+    /// identical to the test source, so applying any offered fix would fail the comparison.
+    /// </summary>
+    private static async Task CreateNoFixTest(string code, params DiagnosticResult[] expected)
+    {
+        var test = new CSharpCodeFixTest<PreferTypedParameterAnalyzer, PreferTypedParameterCodeFixProvider, DefaultVerifier>
+        {
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        };
+        test.TestState.Sources.Add(("Test.cs", code));
+        test.TestState.Sources.Add(("Stubs.cs", FrameworkStubs));
+        test.FixedState.Sources.Add(("Test.cs", code));
+        test.FixedState.Sources.Add(("Stubs.cs", FrameworkStubs));
+        test.TestState.ExpectedDiagnostics.AddRange(expected);
+        test.FixedState.ExpectedDiagnostics.AddRange(expected);
+        await test.RunAsync();
     }
 }

--- a/src/TaskAnalyzer.Tests/PreferTypedParameterCodeFixProviderTests.cs
+++ b/src/TaskAnalyzer.Tests/PreferTypedParameterCodeFixProviderTests.cs
@@ -181,6 +181,7 @@ public class PreferTypedParameterCodeFixProviderTests
         await CreateFixTest(
             testCode: """
                 using Microsoft.Build.Framework;
+                [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
                 public class MyTask : Microsoft.Build.Utilities.Task, IMultiThreadableTask
                 {
                     public TaskEnvironment TaskEnvironment { get; set; }
@@ -194,6 +195,7 @@ public class PreferTypedParameterCodeFixProviderTests
                 """,
             fixedCode: """
                 using Microsoft.Build.Framework;
+                [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
                 public class MyTask : Microsoft.Build.Utilities.Task, IMultiThreadableTask
                 {
                     public TaskEnvironment TaskEnvironment { get; set; }
@@ -407,6 +409,7 @@ public class PreferTypedParameterCodeFixProviderTests
         await CreateFixTest(
             testCode: """
                 using Microsoft.Build.Framework;
+                [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
                 public class MyTask : Microsoft.Build.Utilities.Task, IMultiThreadableTask
                 {
                     public TaskEnvironment TaskEnvironment { get; set; }
@@ -420,6 +423,7 @@ public class PreferTypedParameterCodeFixProviderTests
                 """,
             fixedCode: """
                 using Microsoft.Build.Framework;
+                [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
                 public class MyTask : Microsoft.Build.Utilities.Task, IMultiThreadableTask
                 {
                     public TaskEnvironment TaskEnvironment { get; set; }
@@ -449,6 +453,7 @@ public class PreferTypedParameterCodeFixProviderTests
             testCode: """
                 using System.IO;
                 using Microsoft.Build.Framework;
+                [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
                 public class MyTask : Microsoft.Build.Utilities.Task, IMultiThreadableTask
                 {
                     public TaskEnvironment TaskEnvironment { get; set; }
@@ -463,6 +468,7 @@ public class PreferTypedParameterCodeFixProviderTests
             fixedCode: """
                 using System.IO;
                 using Microsoft.Build.Framework;
+                [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
                 public class MyTask : Microsoft.Build.Utilities.Task, IMultiThreadableTask
                 {
                     public TaskEnvironment TaskEnvironment { get; set; }
@@ -486,6 +492,7 @@ public class PreferTypedParameterCodeFixProviderTests
             testCode: """
                 using System.IO;
                 using Microsoft.Build.Framework;
+                [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
                 public class MyTask : Microsoft.Build.Utilities.Task, IMultiThreadableTask
                 {
                     public TaskEnvironment TaskEnvironment { get; set; }
@@ -500,6 +507,7 @@ public class PreferTypedParameterCodeFixProviderTests
             fixedCode: """
                 using System.IO;
                 using Microsoft.Build.Framework;
+                [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
                 public class MyTask : Microsoft.Build.Utilities.Task, IMultiThreadableTask
                 {
                     public TaskEnvironment TaskEnvironment { get; set; }
@@ -548,6 +556,7 @@ public class PreferTypedParameterCodeFixProviderTests
             """
             using System.IO;
             using Microsoft.Build.Framework;
+            [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
             public class MyTask : Microsoft.Build.Utilities.Task, IMultiThreadableTask
             {
                 public TaskEnvironment TaskEnvironment { get; set; }

--- a/src/TaskAnalyzer.Tests/PreferTypedParameterCodeFixProviderTests.cs
+++ b/src/TaskAnalyzer.Tests/PreferTypedParameterCodeFixProviderTests.cs
@@ -816,6 +816,102 @@ public class PreferTypedParameterCodeFixProviderTests
     /// Builds a code-fix test where the diagnostic is expected but no fix is offered: the fixed source is
     /// identical to the test source, so applying any offered fix would fail the comparison.
     /// </summary>
+    [Fact]
+    public async Task Fix_0006_FileInfo_NullGuardedReference_NoFixOffered()
+    {
+        // The property is consumed by string.IsNullOrEmpty(prop), which is deliberately null-tolerant. Rewriting
+        // that argument to prop.FullName after retyping to FileInfo would dereference a possibly-null property and
+        // throw at runtime, so the diagnostic is reported but no fix is offered.
+        await CreateNoFixTest(
+            """
+            using System.IO;
+            using Microsoft.Build.Framework;
+            [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                public string InputPath { get; set; } = "";
+                public override bool Execute()
+                {
+                    if (!string.IsNullOrEmpty(InputPath))
+                    {
+                        var fi = {|#0:new FileInfo(InputPath)|};
+                    }
+                    return true;
+                }
+            }
+            """,
+            Diag(DiagnosticIds.PreferTypedPathParameter).WithLocation(0)
+                .WithArguments("InputPath", "string", "FileInfo"));
+    }
+
+    [Fact]
+    public async Task Fix_0006_DirectoryInfo_NullWhiteSpaceGuardedReference_NoFixOffered()
+    {
+        // Same null-guard hazard via string.IsNullOrWhiteSpace(prop) for a DirectoryInfo retype.
+        await CreateNoFixTest(
+            """
+            using System.IO;
+            using Microsoft.Build.Framework;
+            [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                public string OutputDir { get; set; } = "";
+                public override bool Execute()
+                {
+                    if (!string.IsNullOrWhiteSpace(OutputDir))
+                    {
+                        var di = {|#0:new DirectoryInfo(OutputDir)|};
+                    }
+                    return true;
+                }
+            }
+            """,
+            Diag(DiagnosticIds.PreferTypedPathParameter).WithLocation(0)
+                .WithArguments("OutputDir", "string", "DirectoryInfo"));
+    }
+
+    [Fact]
+    public async Task Fix_0006_AbsolutePath_NullGuardedReference_StillFixed()
+    {
+        // AbsolutePath is a struct with an implicit string conversion, so string.IsNullOrEmpty(prop) compiles
+        // unchanged after the retype and cannot NRE — the fix is still safely offered.
+        await CreateFixTest(
+            testCode: """
+                using Microsoft.Build.Framework;
+                [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
+                public class MyTask : Microsoft.Build.Utilities.Task
+                {
+                    public string InputPath { get; set; } = "";
+                    public override bool Execute()
+                    {
+                        if (!string.IsNullOrEmpty(InputPath))
+                        {
+                            var abs = {|#0:new AbsolutePath(InputPath)|};
+                        }
+                        return true;
+                    }
+                }
+                """,
+            fixedCode: """
+                using Microsoft.Build.Framework;
+                [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
+                public class MyTask : Microsoft.Build.Utilities.Task
+                {
+                    public AbsolutePath InputPath { get; set; } = default;
+                    public override bool Execute()
+                    {
+                        if (!string.IsNullOrEmpty(InputPath))
+                        {
+                            var abs = InputPath;
+                        }
+                        return true;
+                    }
+                }
+                """,
+            Diag(DiagnosticIds.PreferTypedPathParameter).WithLocation(0)
+                .WithArguments("InputPath", "string", "AbsolutePath")).RunAsync();
+    }
+
     private static async Task CreateNoFixTest(string code, params DiagnosticResult[] expected)
     {
         var test = new CSharpCodeFixTest<PreferTypedParameterAnalyzer, PreferTypedParameterCodeFixProvider, DefaultVerifier>

--- a/src/TaskAnalyzer.Tests/PreferTypedParameterCodeFixProviderTests.cs
+++ b/src/TaskAnalyzer.Tests/PreferTypedParameterCodeFixProviderTests.cs
@@ -444,12 +444,12 @@ public class PreferTypedParameterCodeFixProviderTests
         // initializer. This is only safe because the value is already rooted: MSBuild normally roots a relative
         // string via TaskEnvironment, which is not available inside a property initializer (it runs in the ctor).
         await CreateFixTest(
-            testCode: """
+            testCode: $$"""
                 using Microsoft.Build.Framework;
                 [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
                 public class MyTask : Microsoft.Build.Utilities.Task
                 {
-                    public string InputPath { get; set; } = "C:/logs";
+                    public string InputPath { get; set; } = "{{TestHelpers.FullyQualifiedPath("logs")}}";
                     public override bool Execute()
                     {
                         var abs = {|#0:new AbsolutePath(InputPath)|};
@@ -457,12 +457,12 @@ public class PreferTypedParameterCodeFixProviderTests
                     }
                 }
                 """,
-            fixedCode: """
+            fixedCode: $$"""
                 using Microsoft.Build.Framework;
                 [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
                 public class MyTask : Microsoft.Build.Utilities.Task
                 {
-                    public AbsolutePath InputPath { get; set; } = new AbsolutePath("C:/logs");
+                    public AbsolutePath InputPath { get; set; } = new AbsolutePath("{{TestHelpers.FullyQualifiedPath("logs")}}");
                     public override bool Execute()
                     {
                         var abs = InputPath;
@@ -480,13 +480,13 @@ public class PreferTypedParameterCodeFixProviderTests
         // For FileInfo the engine goes string -> AbsolutePath -> FileInfo, so the fix constructs through
         // AbsolutePath rather than passing the raw string to FileInfo directly.
         await CreateFixTest(
-            testCode: """
+            testCode: $$"""
                 using System.IO;
                 using Microsoft.Build.Framework;
                 [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
                 public class MyTask : Microsoft.Build.Utilities.Task
                 {
-                    public string FilePath { get; set; } = "C:/logs/out.txt";
+                    public string FilePath { get; set; } = "{{TestHelpers.FullyQualifiedPath("logs/out.txt")}}";
                     public override bool Execute()
                     {
                         var fi = {|#0:new FileInfo(FilePath)|};
@@ -494,13 +494,13 @@ public class PreferTypedParameterCodeFixProviderTests
                     }
                 }
                 """,
-            fixedCode: """
+            fixedCode: $$"""
                 using System.IO;
                 using Microsoft.Build.Framework;
                 [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
                 public class MyTask : Microsoft.Build.Utilities.Task
                 {
-                    public FileInfo FilePath { get; set; } = new FileInfo(new AbsolutePath("C:/logs/out.txt"));
+                    public FileInfo FilePath { get; set; } = new FileInfo(new AbsolutePath("{{TestHelpers.FullyQualifiedPath("logs/out.txt")}}"));
                     public override bool Execute()
                     {
                         var fi = FilePath;

--- a/src/TaskAnalyzer.Tests/TestHelpers.cs
+++ b/src/TaskAnalyzer.Tests/TestHelpers.cs
@@ -48,12 +48,17 @@ internal static class TestHelpers
                 public System.Diagnostics.ProcessStartInfo GetProcessStartInfo() => new();
             }
 
-            public struct AbsolutePath
+            public struct AbsolutePath : System.IEquatable<AbsolutePath>
             {
                 public AbsolutePath(string path) { Value = path; OriginalValue = path; }
                 public string Value { get; }
                 public string OriginalValue { get; }
                 public static implicit operator string(AbsolutePath p) => p.Value;
+                public bool Equals(AbsolutePath other) => Value == other.Value;
+                public override bool Equals(object? obj) => obj is AbsolutePath other && Equals(other);
+                public override int GetHashCode() => Value is null ? 0 : Value.GetHashCode();
+                public static bool operator ==(AbsolutePath left, AbsolutePath right) => left.Equals(right);
+                public static bool operator !=(AbsolutePath left, AbsolutePath right) => !left.Equals(right);
             }
 
             public interface ITaskItem

--- a/src/TaskAnalyzer.Tests/TestHelpers.cs
+++ b/src/TaskAnalyzer.Tests/TestHelpers.cs
@@ -50,6 +50,7 @@ internal static class TestHelpers
 
             public struct AbsolutePath
             {
+                public AbsolutePath(string path) { Value = path; OriginalValue = path; }
                 public string Value { get; }
                 public string OriginalValue { get; }
                 public static implicit operator string(AbsolutePath p) => p.Value;
@@ -61,12 +62,24 @@ internal static class TestHelpers
                 string GetMetadata(string metadataName);
             }
 
+            public interface ITaskItem2 : ITaskItem
+            {
+            }
+
+            public interface ITaskItem<T> : ITaskItem2
+            {
+                T Value { get; }
+            }
+
             public class TaskItem : ITaskItem
             {
                 public string ItemSpec { get; set; } = string.Empty;
                 public string GetMetadata(string metadataName) => string.Empty;
                 public string GetMetadataValue(string metadataName) => string.Empty;
             }
+
+            [System.AttributeUsage(System.AttributeTargets.Property)]
+            public sealed class OutputAttribute : System.Attribute { }
 
             [System.AttributeUsage(System.AttributeTargets.Class)]
             public class MSBuildMultiThreadableTaskAnalyzedAttribute : System.Attribute { }
@@ -159,6 +172,21 @@ internal static class TestHelpers
         return allDiagnostics
             .Where(d => d.Location.SourceTree?.FilePath == "Test.cs")
             .ToImmutableArray();
+    }
+
+    /// <summary>
+    /// Runs the PreferTypedParameterAnalyzer on the given source code and returns analyzer diagnostics.
+    /// Source is combined with framework stubs automatically.
+    /// </summary>
+    public static async System.Threading.Tasks.Task<ImmutableArray<Diagnostic>> GetTypedParameterDiagnosticsAsync(string source)
+    {
+        var compilation = CreateCompilation(source);
+        var analyzer = new PreferTypedParameterAnalyzer();
+        var compilationWithAnalyzers = compilation.WithAnalyzers(
+            ImmutableArray.Create<DiagnosticAnalyzer>(analyzer));
+
+        var allDiags = await compilationWithAnalyzers.GetAnalyzerDiagnosticsAsync();
+        return allDiags;
     }
 
     /// <summary>

--- a/src/TaskAnalyzer.Tests/TestHelpers.cs
+++ b/src/TaskAnalyzer.Tests/TestHelpers.cs
@@ -121,6 +121,18 @@ internal static class TestHelpers
     private static readonly MetadataReference[] s_coreReferences = CreateCoreReferences();
 
     /// <summary>
+    /// Returns a fully-qualified path literal that is absolute on the OS the tests are running on: a
+    /// drive-rooted path on Windows (<c>C:/…</c>) and a leading-slash path on Unix (<c>/…</c>). Use this when
+    /// analyzer test source needs a default value that must classify as fully-qualified regardless of OS —
+    /// a single hard-coded literal cannot satisfy both, since <c>C:/x</c> is relative on Unix and <c>/x</c> is
+    /// not fully-qualified on Windows.
+    /// </summary>
+    public static string FullyQualifiedPath(string tail) =>
+        System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows)
+            ? "C:/" + tail
+            : "/" + tail;
+
+    /// <summary>
     /// Returns the core runtime references used by test compilations.
     /// </summary>
     public static MetadataReference[] GetCoreReferences() => s_coreReferences;

--- a/src/TaskAnalyzer/AnalyzerReleases.Unshipped.md
+++ b/src/TaskAnalyzer/AnalyzerReleases.Unshipped.md
@@ -7,3 +7,5 @@ MSBuildTask0002 | MSBuild.TaskAuthoring | Warning | APIs that should use TaskEnv
 MSBuildTask0003 | MSBuild.TaskAuthoring | Warning | File APIs that need absolute paths
 MSBuildTask0004 | MSBuild.TaskAuthoring | Warning | APIs that may cause issues in multithreaded task execution
 MSBuildTask0005 | MSBuild.TaskAuthoring | Warning | Transitive unsafe API usage detected in task call chain
+MSBuildTask0006 | MSBuild.TaskAuthoring | Info | Prefer typed path parameter (AbsolutePath/FileInfo/DirectoryInfo) over string
+MSBuildTask0007 | MSBuild.TaskAuthoring | Info | Prefer ITaskItem<T> over manual ItemSpec parsing

--- a/src/TaskAnalyzer/AnalyzerReleases.Unshipped.md
+++ b/src/TaskAnalyzer/AnalyzerReleases.Unshipped.md
@@ -7,5 +7,5 @@ MSBuildTask0002 | MSBuild.TaskAuthoring | Warning | APIs that should use TaskEnv
 MSBuildTask0003 | MSBuild.TaskAuthoring | Warning | File APIs that need absolute paths
 MSBuildTask0004 | MSBuild.TaskAuthoring | Warning | APIs that may cause issues in multithreaded task execution
 MSBuildTask0005 | MSBuild.TaskAuthoring | Warning | Transitive unsafe API usage detected in task call chain
-MSBuildTask0006 | MSBuild.TaskAuthoring | Info | Prefer typed path parameter (AbsolutePath/FileInfo/DirectoryInfo) over string
-MSBuildTask0007 | MSBuild.TaskAuthoring | Info | Prefer ITaskItem<T> over manual ItemSpec parsing
+MSBuildTask0006 | MSBuild.TaskAuthoring | Info | Prefer typed path parameter (AbsolutePath/FileInfo/DirectoryInfo) over string (code fix available)
+MSBuildTask0007 | MSBuild.TaskAuthoring | Info | Prefer ITaskItem<T> over manual ItemSpec parsing (code fix available)

--- a/src/TaskAnalyzer/AnalyzerReleases.Unshipped.md
+++ b/src/TaskAnalyzer/AnalyzerReleases.Unshipped.md
@@ -9,3 +9,4 @@ MSBuildTask0004 | MSBuild.TaskAuthoring | Warning | APIs that may cause issues i
 MSBuildTask0005 | MSBuild.TaskAuthoring | Warning | Transitive unsafe API usage detected in task call chain
 MSBuildTask0006 | MSBuild.TaskAuthoring | Info | Prefer typed path parameter (AbsolutePath/FileInfo/DirectoryInfo) over string (code fix available)
 MSBuildTask0007 | MSBuild.TaskAuthoring | Info | Prefer ITaskItem<T> over manual ItemSpec parsing (code fix available)
+MSBuildTask0008 | MSBuild.TaskAuthoring | Info | Initialize a relative default path in Execute() so TaskEnvironment can root it when the property is retyped (code fix available)

--- a/src/TaskAnalyzer/DiagnosticDescriptors.cs
+++ b/src/TaskAnalyzer/DiagnosticDescriptors.cs
@@ -58,11 +58,31 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
             description: "A method called from this task transitively uses an API that is unsafe in multithreaded task execution. Review the call chain and migrate the callee.",
             customTags: WellKnownDiagnosticTags.CompilationEnd);
 
+        public static readonly DiagnosticDescriptor PreferTypedPathParameter = new(
+            id: DiagnosticIds.PreferTypedPathParameter,
+            title: "Prefer typed path parameter over manual path construction",
+            messageFormat: "Consider changing task property '{0}' from '{1}' to '{2}' instead of converting inside the task body",
+            category: "MSBuild.TaskAuthoring",
+            defaultSeverity: DiagnosticSeverity.Info,
+            isEnabledByDefault: true,
+            description: "MSBuild can bind AbsolutePath, FileInfo, and DirectoryInfo task parameters automatically. Using these types avoids manual path construction in the task body.");
+
+        public static readonly DiagnosticDescriptor PreferTypedTaskItem = new(
+            id: DiagnosticIds.PreferTypedTaskItem,
+            title: "Prefer ITaskItem<T> over manual ItemSpec parsing",
+            messageFormat: "Consider changing task property '{0}' from '{1}' to 'ITaskItem<{2}>' instead of parsing ItemSpec manually",
+            category: "MSBuild.TaskAuthoring",
+            defaultSeverity: DiagnosticSeverity.Info,
+            isEnabledByDefault: true,
+            description: "MSBuild can bind ITaskItem<T> task parameters that provide a strongly-typed Value property parsed from ItemSpec. Using ITaskItem<T> avoids manual parsing in the task body.");
+
         public static ImmutableArray<DiagnosticDescriptor> All { get; } = ImmutableArray.Create(
             CriticalError,
             TaskEnvironmentRequired,
             FilePathRequiresAbsolute,
             PotentialIssue,
-            TransitiveUnsafeCall);
+            TransitiveUnsafeCall,
+            PreferTypedPathParameter,
+            PreferTypedTaskItem);
     }
 }

--- a/src/TaskAnalyzer/DiagnosticDescriptors.cs
+++ b/src/TaskAnalyzer/DiagnosticDescriptors.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
         public static readonly DiagnosticDescriptor PreferTypedTaskItem = new(
             id: DiagnosticIds.PreferTypedTaskItem,
             title: "Prefer ITaskItem<T> over manual ItemSpec parsing",
-            messageFormat: "Consider changing task property '{0}' from '{1}' to 'ITaskItem<{2}>' instead of parsing ItemSpec manually",
+            messageFormat: "Consider changing task property '{0}' from '{1}' to 'ITaskItem<{2}>{3}' instead of parsing ItemSpec manually",
             category: "MSBuild.TaskAuthoring",
             defaultSeverity: DiagnosticSeverity.Info,
             isEnabledByDefault: true,

--- a/src/TaskAnalyzer/DiagnosticDescriptors.cs
+++ b/src/TaskAnalyzer/DiagnosticDescriptors.cs
@@ -76,6 +76,15 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
             isEnabledByDefault: true,
             description: "MSBuild can bind ITaskItem<T> task parameters that provide a strongly-typed Value property parsed from ItemSpec for tasks that opt into multithreaded support. Using ITaskItem<T> avoids manual parsing in the task body.");
 
+        public static readonly DiagnosticDescriptor InitializeRelativeDefaultInExecute = new(
+            id: DiagnosticIds.InitializeRelativeDefaultInExecute,
+            title: "Initialize relative default path in Execute()",
+            messageFormat: "Task property '{0}' has a relative default path; initialize it in Execute() so it can be rooted through TaskEnvironment when the property is changed to '{1}'",
+            category: "MSBuild.TaskAuthoring",
+            defaultSeverity: DiagnosticSeverity.Info,
+            isEnabledByDefault: true,
+            description: "A relative default path cannot be rooted in a property initializer because the MSBuild engine only assigns TaskEnvironment after the task is constructed. Move the default into Execute(), where TaskEnvironment.GetAbsolutePath can resolve it, guarding the assignment so a value bound from the project is not overwritten.");
+
         public static ImmutableArray<DiagnosticDescriptor> All { get; } = ImmutableArray.Create(
             CriticalError,
             TaskEnvironmentRequired,
@@ -83,6 +92,7 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
             PotentialIssue,
             TransitiveUnsafeCall,
             PreferTypedPathParameter,
-            PreferTypedTaskItem);
+            PreferTypedTaskItem,
+            InitializeRelativeDefaultInExecute);
     }
 }

--- a/src/TaskAnalyzer/DiagnosticDescriptors.cs
+++ b/src/TaskAnalyzer/DiagnosticDescriptors.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
             category: "MSBuild.TaskAuthoring",
             defaultSeverity: DiagnosticSeverity.Info,
             isEnabledByDefault: true,
-            description: "MSBuild can bind AbsolutePath, FileInfo, and DirectoryInfo task parameters automatically. Using these types avoids manual path construction in the task body.");
+            description: "MSBuild can bind AbsolutePath, FileInfo, and DirectoryInfo task parameters automatically for tasks that opt into multithreaded support. Using these types avoids manual path construction in the task body.");
 
         public static readonly DiagnosticDescriptor PreferTypedTaskItem = new(
             id: DiagnosticIds.PreferTypedTaskItem,
@@ -74,7 +74,7 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
             category: "MSBuild.TaskAuthoring",
             defaultSeverity: DiagnosticSeverity.Info,
             isEnabledByDefault: true,
-            description: "MSBuild can bind ITaskItem<T> task parameters that provide a strongly-typed Value property parsed from ItemSpec. Using ITaskItem<T> avoids manual parsing in the task body.");
+            description: "MSBuild can bind ITaskItem<T> task parameters that provide a strongly-typed Value property parsed from ItemSpec for tasks that opt into multithreaded support. Using ITaskItem<T> avoids manual parsing in the task body.");
 
         public static ImmutableArray<DiagnosticDescriptor> All { get; } = ImmutableArray.Create(
             CriticalError,

--- a/src/TaskAnalyzer/DiagnosticIds.cs
+++ b/src/TaskAnalyzer/DiagnosticIds.cs
@@ -23,5 +23,11 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
 
         /// <summary>Transitive unsafe API usage detected in task call chain.</summary>
         public const string TransitiveUnsafeCall = "MSBuildTask0005";
+
+        /// <summary>Task input property should use AbsolutePath, FileInfo, or DirectoryInfo instead of string.</summary>
+        public const string PreferTypedPathParameter = "MSBuildTask0006";
+
+        /// <summary>Task input property should use ITaskItem&lt;T&gt; instead of ITaskItem with manual ItemSpec parsing.</summary>
+        public const string PreferTypedTaskItem = "MSBuildTask0007";
     }
 }

--- a/src/TaskAnalyzer/DiagnosticIds.cs
+++ b/src/TaskAnalyzer/DiagnosticIds.cs
@@ -29,5 +29,8 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
 
         /// <summary>Task input property should use ITaskItem&lt;T&gt; instead of ITaskItem with manual ItemSpec parsing.</summary>
         public const string PreferTypedTaskItem = "MSBuildTask0007";
+
+        /// <summary>Task input property has a relative default path that should be initialized in Execute() where TaskEnvironment can root it.</summary>
+        public const string InitializeRelativeDefaultInExecute = "MSBuildTask0008";
     }
 }

--- a/src/TaskAnalyzer/PathDefaultClassifier.cs
+++ b/src/TaskAnalyzer/PathDefaultClassifier.cs
@@ -1,0 +1,62 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Build.TaskAuthoring.Analyzer
+{
+    /// <summary>
+    /// Classifies string default values for path-typed task properties. Shared by the analyzer (to decide
+    /// whether a default is a relative path that must be moved into <c>Execute()</c>) and the code fixer (to
+    /// decide whether a default can be reproduced directly in a property initializer).
+    /// </summary>
+    internal static class PathDefaultClassifier
+    {
+        /// <summary>
+        /// Determines whether a default string value is an already fully-qualified (absolute) path, recognizing
+        /// both Windows and Unix absolute forms independently of the host OS. Only such values can be reproduced
+        /// in a property initializer, because rooting a relative path requires <c>TaskEnvironment</c>, which the
+        /// engine does not set until after the task is constructed. This mirrors the check
+        /// <c>AbsolutePath</c>'s constructor performs (<see cref="System.IO.Path.IsPathFullyQualified(string)"/>),
+        /// which is unavailable on netstandard2.0.
+        /// </summary>
+        public static bool IsFullyQualifiedPath(string value)
+        {
+            if (string.IsNullOrEmpty(value) || value.IndexOfAny(System.IO.Path.GetInvalidPathChars()) >= 0)
+            {
+                return false;
+            }
+
+            char first = value[0];
+
+            // Unix absolute path: leading '/'. (Also covers "//..." device/UNC-style prefixes.)
+            if (first == '/')
+            {
+                return true;
+            }
+
+            // Windows UNC / device path: two leading separators, e.g. "\\server\share" or "\\?\C:\".
+            if (first == '\\')
+            {
+                return value.Length >= 2 && (value[1] == '\\' || value[1] == '/');
+            }
+
+            // Windows drive-absolute path: "X:\" or "X:/". A drive-relative form like "X:foo" is intentionally
+            // rejected because it is not fully qualified (its meaning depends on the drive's current directory).
+            return value.Length >= 3 &&
+                ((first >= 'A' && first <= 'Z') || (first >= 'a' && first <= 'z')) &&
+                value[1] == ':' &&
+                (value[2] == '\\' || value[2] == '/');
+        }
+
+        /// <summary>
+        /// Determines whether a default string value is a plausible <em>relative</em> path: non-empty, free of
+        /// characters that are never valid in a path, and not already fully qualified. These are the defaults
+        /// that need rooting through <c>TaskEnvironment</c> inside <c>Execute()</c> (MSBuildTask0008).
+        /// </summary>
+        public static bool IsRelativePathDefault(string value)
+        {
+            return !string.IsNullOrEmpty(value) &&
+                value.IndexOfAny(System.IO.Path.GetInvalidPathChars()) < 0 &&
+                !IsFullyQualifiedPath(value);
+        }
+    }
+}

--- a/src/TaskAnalyzer/PathDefaultClassifier.cs
+++ b/src/TaskAnalyzer/PathDefaultClassifier.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.InteropServices;
+
 namespace Microsoft.Build.TaskAuthoring.Analyzer
 {
     /// <summary>
@@ -11,12 +13,16 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
     internal static class PathDefaultClassifier
     {
         /// <summary>
-        /// Determines whether a default string value is an already fully-qualified (absolute) path, recognizing
-        /// both Windows and Unix absolute forms independently of the host OS. Only such values can be reproduced
-        /// in a property initializer, because rooting a relative path requires <c>TaskEnvironment</c>, which the
-        /// engine does not set until after the task is constructed. This mirrors the check
-        /// <c>AbsolutePath</c>'s constructor performs (<see cref="System.IO.Path.IsPathFullyQualified(string)"/>),
-        /// which is unavailable on netstandard2.0.
+        /// Determines whether a default string value is an already fully-qualified (absolute) path. Only such
+        /// values can be reproduced in a property initializer, because rooting a relative path requires
+        /// <c>TaskEnvironment</c>, which the engine does not set until after the task is constructed.
+        /// <para>
+        /// This mirrors what <c>AbsolutePath</c> does at runtime (<see cref="System.IO.Path.IsPathFullyQualified(string)"/>,
+        /// which is unavailable on netstandard2.0) by polyfilling the runtime's OS-specific
+        /// <c>PathInternal.IsPartiallyQualified</c> logic. The check is OS-specific on purpose: on Unix only a
+        /// path rooted at <c>'/'</c> is fully qualified, so a drive-style value like <c>"C:/x"</c> is treated as
+        /// relative there — matching how <c>AbsolutePath</c> would root it.
+        /// </para>
         /// </summary>
         public static bool IsFullyQualifiedPath(string value)
         {
@@ -25,27 +31,47 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                 return false;
             }
 
-            char first = value[0];
-
-            // Unix absolute path: leading '/'. (Also covers "//..." device/UNC-style prefixes.)
-            if (first == '/')
-            {
-                return true;
-            }
-
-            // Windows UNC / device path: two leading separators, e.g. "\\server\share" or "\\?\C:\".
-            if (first == '\\')
-            {
-                return value.Length >= 2 && (value[1] == '\\' || value[1] == '/');
-            }
-
-            // Windows drive-absolute path: "X:\" or "X:/". A drive-relative form like "X:foo" is intentionally
-            // rejected because it is not fully qualified (its meaning depends on the drive's current directory).
-            return value.Length >= 3 &&
-                ((first >= 'A' && first <= 'Z') || (first >= 'a' && first <= 'z')) &&
-                value[1] == ':' &&
-                (value[2] == '\\' || value[2] == '/');
+            return RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                ? IsFullyQualifiedWindows(value)
+                : IsFullyQualifiedUnix(value);
         }
+
+        /// <summary>
+        /// Unix rule: a path is fully qualified only if it is rooted at <c>'/'</c>. Anything else (including
+        /// Windows drive-relative or drive-absolute forms, which are meaningless on Unix) is relative.
+        /// </summary>
+        private static bool IsFullyQualifiedUnix(string value) => value[0] == '/';
+
+        /// <summary>
+        /// Windows rule, mirroring the negation of <c>PathInternal.IsPartiallyQualified</c>: a leading pair of
+        /// separators (UNC/device, e.g. <c>\\server\share</c> or <c>\\?\</c>) or the drive-absolute
+        /// <c>X:\</c>/<c>X:/</c> form is fully qualified. A single leading separator (<c>\foo</c>) is
+        /// drive-relative and a drive-relative <c>X:foo</c> is not fully qualified.
+        /// </summary>
+        private static bool IsFullyQualifiedWindows(string value)
+        {
+            if (value.Length < 2)
+            {
+                return false;
+            }
+
+            if (IsDirectorySeparator(value[0]))
+            {
+                // Two leading separators, or "\?" (device-path prefix), are fully qualified.
+                return value[1] == '?' || IsDirectorySeparator(value[1]);
+            }
+
+            // Drive-absolute "X:\" or "X:/" with a valid drive letter.
+            return value.Length >= 3 &&
+                value[1] == ':' &&
+                IsDirectorySeparator(value[2]) &&
+                IsValidDriveChar(value[0]);
+        }
+
+        private static bool IsDirectorySeparator(char c) => c == '\\' || c == '/';
+
+        private static bool IsValidDriveChar(char c) =>
+            (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z');
 
         /// <summary>
         /// Determines whether a default string value is a plausible <em>relative</em> path: non-empty, free of

--- a/src/TaskAnalyzer/PreferTypedParameterAnalyzer.cs
+++ b/src/TaskAnalyzer/PreferTypedParameterAnalyzer.cs
@@ -36,6 +36,44 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
         private const string PropertyNameKey = "PropertyName";
         private const string SuggestedTypeKey = "SuggestedType";
 
+        /// <summary>
+        /// The set of types looked up once per compilation and reused for every analyzed task symbol.
+        /// <see cref="ITask"/> and <see cref="MultiThreadableTaskAttribute"/> are mandatory; the rest may be
+        /// null when the type is not referenced by the compilation, in which case the corresponding
+        /// suggestions are simply not produced.
+        /// </summary>
+        private readonly struct WellKnownTaskTypes
+        {
+            public WellKnownTaskTypes(
+                INamedTypeSymbol iTask,
+                INamedTypeSymbol multiThreadableTaskAttribute,
+                INamedTypeSymbol? absolutePath,
+                INamedTypeSymbol? taskEnvironment,
+                INamedTypeSymbol? iTaskItem,
+                INamedTypeSymbol? outputAttribute,
+                INamedTypeSymbol? fileInfo,
+                INamedTypeSymbol? directoryInfo)
+            {
+                ITask = iTask;
+                MultiThreadableTaskAttribute = multiThreadableTaskAttribute;
+                AbsolutePath = absolutePath;
+                TaskEnvironment = taskEnvironment;
+                ITaskItem = iTaskItem;
+                OutputAttribute = outputAttribute;
+                FileInfo = fileInfo;
+                DirectoryInfo = directoryInfo;
+            }
+
+            public INamedTypeSymbol ITask { get; }
+            public INamedTypeSymbol MultiThreadableTaskAttribute { get; }
+            public INamedTypeSymbol? AbsolutePath { get; }
+            public INamedTypeSymbol? TaskEnvironment { get; }
+            public INamedTypeSymbol? ITaskItem { get; }
+            public INamedTypeSymbol? OutputAttribute { get; }
+            public INamedTypeSymbol? FileInfo { get; }
+            public INamedTypeSymbol? DirectoryInfo { get; }
+        }
+
         public override void Initialize(AnalysisContext context)
         {
             context.EnableConcurrentExecution();
@@ -45,96 +83,32 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
 
         private static void OnCompilationStart(CompilationStartAnalysisContext compilationContext)
         {
-            // The class must implement ITask to be considered a task at all
-            var iTaskType = compilationContext.Compilation.GetTypeByMetadataName(WellKnownTypeNames.ITaskFullName);
-            if (iTaskType is null)
+            if (!TryResolveWellKnownTaskTypes(compilationContext.Compilation, out WellKnownTaskTypes types))
             {
                 return;
             }
 
-            // Additionally, the task must opt into multithreaded support by applying the
-            // [MSBuildMultiThreadableTask] attribute. Implementing IMultiThreadableTask is not
-            // sufficient: the attribute is Inherited = false, so a task that merely derives from a
-            // base class implementing the interface has not itself opted into multithreaded support.
-            var multiThreadableTaskAttributeType = compilationContext.Compilation.GetTypeByMetadataName(WellKnownTypeNames.MultiThreadableTaskAttributeFullName);
-            if (multiThreadableTaskAttributeType is null)
-            {
-                return;
-            }
-
-            var absolutePathType = compilationContext.Compilation.GetTypeByMetadataName(WellKnownTypeNames.AbsolutePathFullName);
-            var taskEnvironmentType = compilationContext.Compilation.GetTypeByMetadataName(WellKnownTypeNames.TaskEnvironmentFullName);
-            var iTaskItemType = compilationContext.Compilation.GetTypeByMetadataName(WellKnownTypeNames.ITaskItemFullName);
-            var outputAttributeType = compilationContext.Compilation.GetTypeByMetadataName(WellKnownTypeNames.OutputAttributeFullName);
-            var fileInfoType = compilationContext.Compilation.GetTypeByMetadataName("System.IO.FileInfo");
-            var directoryInfoType = compilationContext.Compilation.GetTypeByMetadataName("System.IO.DirectoryInfo");
+            var iTaskType = types.ITask;
+            var multiThreadableTaskAttributeType = types.MultiThreadableTaskAttribute;
+            var absolutePathType = types.AbsolutePath;
+            var taskEnvironmentType = types.TaskEnvironment;
+            var iTaskItemType = types.ITaskItem;
+            var outputAttributeType = types.OutputAttribute;
+            var fileInfoType = types.FileInfo;
+            var directoryInfoType = types.DirectoryInfo;
 
             compilationContext.RegisterSymbolStartAction(symbolStartContext =>
             {
                 var namedType = (INamedTypeSymbol)symbolStartContext.Symbol;
 
-                // Gate 1: Must be an ITask implementation
-                if (!ImplementsInterface(namedType, iTaskType))
+                // Only multithreadable tasks (ITask + directly-applied [MSBuildMultiThreadableTask]) are analyzed.
+                if (!IsMultiThreadableTaskType(namedType, iTaskType, multiThreadableTaskAttributeType))
                 {
                     return;
                 }
 
-                // Gate 2: Must have opted into multithreaded support via the attribute applied
-                // directly to this type. GetAttributes() returns only directly-applied attributes,
-                // which matches the attribute's Inherited = false semantics.
-                bool isMultiThreadable = namedType.GetAttributes().Any(
-                    attr => SymbolEqualityComparer.Default.Equals(attr.AttributeClass, multiThreadableTaskAttributeType));
-
-                if (!isMultiThreadable)
-                {
-                    return;
-                }
-
-                // Collect string-typed task input properties (candidates for MSBuildTask0006)
-                var stringInputProps = new HashSet<IPropertySymbol>(SymbolEqualityComparer.Default);
-                // Collect ITaskItem/ITaskItem[]-typed task input properties (candidates for MSBuildTask0007)
-                var taskItemInputProps = new HashSet<IPropertySymbol>(SymbolEqualityComparer.Default);
-
-                // Enumerate input properties declared on this type and all base types (most-derived
-                // first). A task can declare its ITaskItem/string inputs on a base class, so limiting
-                // to namedType.GetMembers() would miss them. Properties hidden or overridden in a more
-                // derived type are processed once, via their most-derived declaration.
-                foreach (var member in GetPropertiesIncludingBaseTypes(namedType))
-                {
-                    if (member.DeclaredAccessibility != Accessibility.Public)
-                    {
-                        continue;
-                    }
-
-                    if (member.SetMethod is null || member.SetMethod.DeclaredAccessibility != Accessibility.Public)
-                    {
-                        continue;
-                    }
-
-                    // Exclude [Output] properties — they are set by the task, not MSBuild
-                    if (outputAttributeType is not null && member.GetAttributes().Any(
-                        a => SymbolEqualityComparer.Default.Equals(a.AttributeClass, outputAttributeType)))
-                    {
-                        continue;
-                    }
-
-                    if (member.Type.SpecialType == SpecialType.System_String)
-                    {
-                        stringInputProps.Add(member);
-                    }
-                    else if (iTaskItemType is not null)
-                    {
-                        if (SymbolEqualityComparer.Default.Equals(member.Type, iTaskItemType))
-                        {
-                            taskItemInputProps.Add(member);
-                        }
-                        else if (member.Type is IArrayTypeSymbol arrayType &&
-                                 SymbolEqualityComparer.Default.Equals(arrayType.ElementType, iTaskItemType))
-                        {
-                            taskItemInputProps.Add(member);
-                        }
-                    }
-                }
+                CollectInputProperties(namedType, iTaskItemType, outputAttributeType,
+                    out var stringInputProps, out var taskItemInputProps);
 
                 if (stringInputProps.Count == 0 && taskItemInputProps.Count == 0)
                 {
@@ -155,115 +129,237 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                 OperationKind.ObjectCreation,
                 OperationKind.Invocation);
 
-                symbolStartContext.RegisterSymbolEndAction(endCtx =>
-                {
-                    // Group diagnostics by property name + rule ID using structured metadata,
-                    // then resolve AbsolutePath vs FileInfo/DirectoryInfo overlaps:
-                    //   - exactly one specific type inferred  => suppress AbsolutePath, keep the specific type
-                    //   - both FileInfo AND DirectoryInfo     => suppress the specifics, fall back to AbsolutePath
-                    var diagnosticsList = pendingDiagnostics.ToList();
-
-                    var suggestedTypesByPropertyKey = new Dictionary<string, HashSet<string>>(System.StringComparer.Ordinal);
-                    foreach (var diag in diagnosticsList)
-                    {
-                        if (TryGetDiagnosticKey(diag, out string propertyKey, out string suggestedType))
-                        {
-                            if (!suggestedTypesByPropertyKey.TryGetValue(propertyKey, out var suggestedTypes))
-                            {
-                                suggestedTypes = new HashSet<string>(System.StringComparer.Ordinal);
-                                suggestedTypesByPropertyKey[propertyKey] = suggestedTypes;
-                            }
-
-                            suggestedTypes.Add(suggestedType);
-                        }
-                    }
-
-                    // First, determine which path/item diagnostics survive the type-resolution dedup.
-                    var surviving = new List<Diagnostic>();
-                    foreach (var diag in diagnosticsList.OrderBy(d => d.Location.SourceSpan.Start))
-                    {
-                        if (TryGetDiagnosticKey(diag, out string propertyKey, out string suggestedType) &&
-                            suggestedTypesByPropertyKey.TryGetValue(propertyKey, out var suggestedTypes))
-                        {
-                            bool hasFile = suggestedTypes.Contains("FileInfo");
-                            bool hasDir = suggestedTypes.Contains("DirectoryInfo");
-                            bool hasAbsolutePath = suggestedTypes.Contains("AbsolutePath");
-
-                            if (suggestedType == "AbsolutePath")
-                            {
-                                // Suppress when exactly one specific type was inferred (no file/dir conflict).
-                                if (hasFile ^ hasDir)
-                                {
-                                    continue;
-                                }
-                            }
-                            else if (suggestedType == "FileInfo" || suggestedType == "DirectoryInfo")
-                            {
-                                // The same value is consumed as both a file and a directory, so neither
-                                // specific type is safe — collapse to the AbsolutePath fallback.
-                                if (hasFile && hasDir)
-                                {
-                                    if (hasAbsolutePath)
-                                    {
-                                        // An AbsolutePath suggestion already exists for this property; drop this
-                                        // specific one and let the surviving AbsolutePath diagnostics carry it.
-                                        continue;
-                                    }
-
-                                    // No AbsolutePath site exists, so suppressing both specifics would leave the
-                                    // property unflagged. Rewrite this diagnostic to AbsolutePath so the property
-                                    // is still reported with a coherent fallback type.
-                                    surviving.Add(ToAbsolutePathFallback(diag));
-                                    continue;
-                                }
-                            }
-                        }
-
-                        surviving.Add(diag);
-                    }
-
-                    // A path property (MSBuildTask0006) with a relative default cannot be rooted in a property
-                    // initializer, so instead of the 0006 "retype" suggestion (whose fix is inapplicable here)
-                    // we redirect it to MSBuildTask0008: initialize the property in Execute() where
-                    // TaskEnvironment is available. Record such properties, keyed by name, with the resolved type.
-                    var relativeDefaultProps = new Dictionary<string, (IPropertySymbol Property, string ResolvedType, Location Location)>(System.StringComparer.Ordinal);
-                    foreach (var diag in surviving)
-                    {
-                        if (diag.Id != DiagnosticIds.PreferTypedPathParameter ||
-                            !diag.Properties.TryGetValue(PropertyNameKey, out var propName) || propName is null ||
-                            !diag.Properties.TryGetValue(SuggestedTypeKey, out var suggestedType) || suggestedType is null ||
-                            relativeDefaultProps.ContainsKey(propName))
-                        {
-                            continue;
-                        }
-
-                        var propSymbol = stringInputProps.FirstOrDefault(p => p.Name == propName);
-                        if (propSymbol is not null &&
-                            TryGetRelativeDefaultInitializerLocation(propSymbol, endCtx.CancellationToken, out Location initializerLocation))
-                        {
-                            relativeDefaultProps[propName] = (propSymbol, suggestedType, initializerLocation);
-                        }
-                    }
-
-                    foreach (var diag in surviving)
-                    {
-                        // Suppress the 0006 diagnostics for properties redirected to 0008.
-                        if (diag.Id == DiagnosticIds.PreferTypedPathParameter &&
-                            diag.Properties.TryGetValue(PropertyNameKey, out var pn) && pn is not null &&
-                            relativeDefaultProps.ContainsKey(pn))
-                        {
-                            continue;
-                        }
-
-                        endCtx.ReportDiagnostic(diag);
-                    }
-
-                    foreach (var entry in relativeDefaultProps.Values)
-                    {
-                        endCtx.ReportDiagnostic(CreateMoveDefaultDiagnostic(entry.Location, entry.Property.Name, entry.ResolvedType));
-                    }
-                });
+                symbolStartContext.RegisterSymbolEndAction(
+                    endCtx => DeduplicateAndReportDiagnostics(endCtx, pendingDiagnostics, stringInputProps));
             }, SymbolKind.NamedType);
+        }
+
+        /// <summary>
+        /// Resolves overlapping path/item suggestions for each property, redirects relative-default path
+        /// properties to MSBuildTask0008, and reports the surviving diagnostics. Runs once per task symbol after
+        /// all operations have been analyzed.
+        /// </summary>
+        private static void DeduplicateAndReportDiagnostics(
+            SymbolAnalysisContext endCtx,
+            ConcurrentBag<Diagnostic> pendingDiagnostics,
+            HashSet<IPropertySymbol> stringInputProps)
+        {
+            // Group diagnostics by property name + rule ID using structured metadata,
+            // then resolve AbsolutePath vs FileInfo/DirectoryInfo overlaps:
+            //   - exactly one specific type inferred  => suppress AbsolutePath, keep the specific type
+            //   - both FileInfo AND DirectoryInfo     => suppress the specifics, fall back to AbsolutePath
+            var diagnosticsList = pendingDiagnostics.ToList();
+
+            var suggestedTypesByPropertyKey = new Dictionary<string, HashSet<string>>(System.StringComparer.Ordinal);
+            foreach (var diag in diagnosticsList)
+            {
+                if (TryGetDiagnosticKey(diag, out string propertyKey, out string suggestedType))
+                {
+                    if (!suggestedTypesByPropertyKey.TryGetValue(propertyKey, out var suggestedTypes))
+                    {
+                        suggestedTypes = new HashSet<string>(System.StringComparer.Ordinal);
+                        suggestedTypesByPropertyKey[propertyKey] = suggestedTypes;
+                    }
+
+                    suggestedTypes.Add(suggestedType);
+                }
+            }
+
+            // First, determine which path/item diagnostics survive the type-resolution dedup.
+            var surviving = new List<Diagnostic>();
+            foreach (var diag in diagnosticsList.OrderBy(d => d.Location.SourceSpan.Start))
+            {
+                if (TryGetDiagnosticKey(diag, out string propertyKey, out string suggestedType) &&
+                    suggestedTypesByPropertyKey.TryGetValue(propertyKey, out var suggestedTypes))
+                {
+                    bool hasFile = suggestedTypes.Contains("FileInfo");
+                    bool hasDir = suggestedTypes.Contains("DirectoryInfo");
+                    bool hasAbsolutePath = suggestedTypes.Contains("AbsolutePath");
+
+                    if (suggestedType == "AbsolutePath")
+                    {
+                        // Suppress when exactly one specific type was inferred (no file/dir conflict).
+                        if (hasFile ^ hasDir)
+                        {
+                            continue;
+                        }
+                    }
+                    else if (suggestedType == "FileInfo" || suggestedType == "DirectoryInfo")
+                    {
+                        // The same value is consumed as both a file and a directory, so neither
+                        // specific type is safe — collapse to the AbsolutePath fallback.
+                        if (hasFile && hasDir)
+                        {
+                            if (hasAbsolutePath)
+                            {
+                                // An AbsolutePath suggestion already exists for this property; drop this
+                                // specific one and let the surviving AbsolutePath diagnostics carry it.
+                                continue;
+                            }
+
+                            // No AbsolutePath site exists, so suppressing both specifics would leave the
+                            // property unflagged. Rewrite this diagnostic to AbsolutePath so the property
+                            // is still reported with a coherent fallback type.
+                            surviving.Add(ToAbsolutePathFallback(diag));
+                            continue;
+                        }
+                    }
+                }
+
+                surviving.Add(diag);
+            }
+
+            // A path property (MSBuildTask0006) with a relative default cannot be rooted in a property
+            // initializer, so instead of the 0006 "retype" suggestion (whose fix is inapplicable here)
+            // we redirect it to MSBuildTask0008: initialize the property in Execute() where
+            // TaskEnvironment is available. Record such properties, keyed by name, with the resolved type.
+            var relativeDefaultProps = new Dictionary<string, (IPropertySymbol Property, string ResolvedType, Location Location)>(System.StringComparer.Ordinal);
+            foreach (var diag in surviving)
+            {
+                if (diag.Id != DiagnosticIds.PreferTypedPathParameter ||
+                    !diag.Properties.TryGetValue(PropertyNameKey, out var propName) || propName is null ||
+                    !diag.Properties.TryGetValue(SuggestedTypeKey, out var suggestedType) || suggestedType is null ||
+                    relativeDefaultProps.ContainsKey(propName))
+                {
+                    continue;
+                }
+
+                var propSymbol = stringInputProps.FirstOrDefault(p => p.Name == propName);
+                if (propSymbol is not null &&
+                    TryGetRelativeDefaultInitializerLocation(propSymbol, endCtx.CancellationToken, out Location initializerLocation))
+                {
+                    relativeDefaultProps[propName] = (propSymbol, suggestedType, initializerLocation);
+                }
+            }
+
+            foreach (var diag in surviving)
+            {
+                // Suppress the 0006 diagnostics for properties redirected to 0008.
+                if (diag.Id == DiagnosticIds.PreferTypedPathParameter &&
+                    diag.Properties.TryGetValue(PropertyNameKey, out var pn) && pn is not null &&
+                    relativeDefaultProps.ContainsKey(pn))
+                {
+                    continue;
+                }
+
+                endCtx.ReportDiagnostic(diag);
+            }
+
+            foreach (var entry in relativeDefaultProps.Values)
+            {
+                endCtx.ReportDiagnostic(CreateMoveDefaultDiagnostic(entry.Location, entry.Property.Name, entry.ResolvedType));
+            }
+        }
+
+        /// <summary>
+        /// Resolves the types required for analysis. Returns false when the mandatory ITask interface or the
+        /// [MSBuildMultiThreadableTask] attribute type is unavailable in the compilation — without either, no
+        /// type can be a multithreadable task, so there is nothing to analyze.
+        /// </summary>
+        private static bool TryResolveWellKnownTaskTypes(Compilation compilation, out WellKnownTaskTypes types)
+        {
+            types = default;
+
+            // The class must implement ITask to be considered a task at all.
+            var iTaskType = compilation.GetTypeByMetadataName(WellKnownTypeNames.ITaskFullName);
+            if (iTaskType is null)
+            {
+                return false;
+            }
+
+            // The task must additionally opt into multithreaded support by applying the
+            // [MSBuildMultiThreadableTask] attribute. Implementing IMultiThreadableTask is not sufficient: the
+            // attribute is Inherited = false, so a task that merely derives from a base class implementing the
+            // interface has not itself opted into multithreaded support.
+            var multiThreadableTaskAttributeType = compilation.GetTypeByMetadataName(WellKnownTypeNames.MultiThreadableTaskAttributeFullName);
+            if (multiThreadableTaskAttributeType is null)
+            {
+                return false;
+            }
+
+            types = new WellKnownTaskTypes(
+                iTaskType,
+                multiThreadableTaskAttributeType,
+                compilation.GetTypeByMetadataName(WellKnownTypeNames.AbsolutePathFullName),
+                compilation.GetTypeByMetadataName(WellKnownTypeNames.TaskEnvironmentFullName),
+                compilation.GetTypeByMetadataName(WellKnownTypeNames.ITaskItemFullName),
+                compilation.GetTypeByMetadataName(WellKnownTypeNames.OutputAttributeFullName),
+                compilation.GetTypeByMetadataName("System.IO.FileInfo"),
+                compilation.GetTypeByMetadataName("System.IO.DirectoryInfo"));
+            return true;
+        }
+
+        /// <summary>
+        /// Returns true when <paramref name="namedType"/> implements ITask and directly carries the
+        /// [MSBuildMultiThreadableTask] attribute. GetAttributes() returns only directly-applied attributes,
+        /// matching the attribute's Inherited = false semantics — a type that merely derives from a
+        /// multithreadable base has not itself opted in.
+        /// </summary>
+        private static bool IsMultiThreadableTaskType(
+            INamedTypeSymbol namedType,
+            INamedTypeSymbol iTaskType,
+            INamedTypeSymbol multiThreadableTaskAttributeType)
+        {
+            return ImplementsInterface(namedType, iTaskType) &&
+                namedType.GetAttributes().Any(
+                    attr => SymbolEqualityComparer.Default.Equals(attr.AttributeClass, multiThreadableTaskAttributeType));
+        }
+
+        /// <summary>
+        /// Collects the public, settable, non-[Output] input properties of a task — including those declared on
+        /// base types — partitioned into string candidates (MSBuildTask0006) and ITaskItem/ITaskItem[]
+        /// candidates (MSBuildTask0007).
+        /// </summary>
+        private static void CollectInputProperties(
+            INamedTypeSymbol namedType,
+            INamedTypeSymbol? iTaskItemType,
+            INamedTypeSymbol? outputAttributeType,
+            out HashSet<IPropertySymbol> stringInputProps,
+            out HashSet<IPropertySymbol> taskItemInputProps)
+        {
+            stringInputProps = new HashSet<IPropertySymbol>(SymbolEqualityComparer.Default);
+            taskItemInputProps = new HashSet<IPropertySymbol>(SymbolEqualityComparer.Default);
+
+            // Enumerate input properties declared on this type and all base types (most-derived first). A task
+            // can declare its ITaskItem/string inputs on a base class, so limiting to namedType.GetMembers()
+            // would miss them. Properties hidden or overridden in a more derived type are processed once, via
+            // their most-derived declaration.
+            foreach (var member in GetPropertiesIncludingBaseTypes(namedType))
+            {
+                if (member.DeclaredAccessibility != Accessibility.Public)
+                {
+                    continue;
+                }
+
+                if (member.SetMethod is null || member.SetMethod.DeclaredAccessibility != Accessibility.Public)
+                {
+                    continue;
+                }
+
+                // Exclude [Output] properties — they are set by the task, not MSBuild.
+                if (outputAttributeType is not null && member.GetAttributes().Any(
+                    a => SymbolEqualityComparer.Default.Equals(a.AttributeClass, outputAttributeType)))
+                {
+                    continue;
+                }
+
+                if (member.Type.SpecialType == SpecialType.System_String)
+                {
+                    stringInputProps.Add(member);
+                }
+                else if (iTaskItemType is not null)
+                {
+                    if (SymbolEqualityComparer.Default.Equals(member.Type, iTaskItemType))
+                    {
+                        taskItemInputProps.Add(member);
+                    }
+                    else if (member.Type is IArrayTypeSymbol arrayType &&
+                             SymbolEqualityComparer.Default.Equals(arrayType.ElementType, iTaskItemType))
+                    {
+                        taskItemInputProps.Add(member);
+                    }
+                }
+            }
         }
 
         private static void AnalyzeOperation(

--- a/src/TaskAnalyzer/PreferTypedParameterAnalyzer.cs
+++ b/src/TaskAnalyzer/PreferTypedParameterAnalyzer.cs
@@ -187,6 +187,7 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                         {
                             bool hasFile = set.Contains("FileInfo");
                             bool hasDir = set.Contains("DirectoryInfo");
+                            bool hasAbsolutePath = set.Contains("AbsolutePath");
 
                             if (suggestedType == "AbsolutePath")
                             {
@@ -196,11 +197,25 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                                     continue;
                                 }
                             }
-                            else if ((suggestedType == "FileInfo" || suggestedType == "DirectoryInfo") &&
-                                     hasFile && hasDir && set.Contains("AbsolutePath"))
+                            else if (suggestedType == "FileInfo" || suggestedType == "DirectoryInfo")
                             {
-                                // Conflicting file/dir inference: prefer the AbsolutePath fallback.
-                                continue;
+                                // The same value is consumed as both a file and a directory, so neither
+                                // specific type is safe — collapse to the AbsolutePath fallback.
+                                if (hasFile && hasDir)
+                                {
+                                    if (hasAbsolutePath)
+                                    {
+                                        // An AbsolutePath suggestion already exists for this property; drop this
+                                        // specific one and let the surviving AbsolutePath diagnostics carry it.
+                                        continue;
+                                    }
+
+                                    // No AbsolutePath site exists, so suppressing both specifics would leave the
+                                    // property unflagged. Rewrite this diagnostic to AbsolutePath so the property
+                                    // is still reported with a coherent fallback type.
+                                    surviving.Add(ToAbsolutePathFallback(diag));
+                                    continue;
+                                }
                             }
                         }
 
@@ -347,6 +362,20 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                 location,
                 properties,
                 propertyName, "string", suggestedType);
+        }
+
+        /// <summary>
+        /// Rewrites a specific FileInfo/DirectoryInfo path diagnostic into an equivalent AbsolutePath one at
+        /// the same location. Used when a property's value is consumed as both a file and a directory (so no
+        /// single specific type is safe) and no AbsolutePath site already exists to carry the suggestion.
+        /// </summary>
+        private static Diagnostic ToAbsolutePathFallback(Diagnostic diagnostic)
+        {
+            string propertyName = diagnostic.Properties.TryGetValue(PropertyNameKey, out var name) && name is not null
+                ? name
+                : string.Empty;
+
+            return CreatePathDiagnostic(diagnostic.Location, propertyName, "AbsolutePath");
         }
 
         private static Diagnostic CreateItemDiagnostic(Location location, string propertyName, bool isArray, string suggestedType)

--- a/src/TaskAnalyzer/PreferTypedParameterAnalyzer.cs
+++ b/src/TaskAnalyzer/PreferTypedParameterAnalyzer.cs
@@ -36,8 +36,17 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
 
         private static void OnCompilationStart(CompilationStartAnalysisContext compilationContext)
         {
+            // The class must implement ITask to be considered a task at all
             var iTaskType = compilationContext.Compilation.GetTypeByMetadataName(WellKnownTypeNames.ITaskFullName);
             if (iTaskType is null)
+            {
+                return;
+            }
+
+            // Additionally, the task must opt into multithreaded support
+            var iMultiThreadableTaskType = compilationContext.Compilation.GetTypeByMetadataName(WellKnownTypeNames.IMultiThreadableTaskFullName);
+            var multiThreadableTaskAttributeType = compilationContext.Compilation.GetTypeByMetadataName(WellKnownTypeNames.MultiThreadableTaskAttributeFullName);
+            if (iMultiThreadableTaskType is null && multiThreadableTaskAttributeType is null)
             {
                 return;
             }
@@ -52,7 +61,20 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
             compilationContext.RegisterSymbolStartAction(symbolStartContext =>
             {
                 var namedType = (INamedTypeSymbol)symbolStartContext.Symbol;
+
+                // Gate 1: Must be an ITask implementation
                 if (!ImplementsInterface(namedType, iTaskType))
+                {
+                    return;
+                }
+
+                // Gate 2: Must have opted into multithreaded support
+                bool isMultiThreadable =
+                    (iMultiThreadableTaskType is not null && ImplementsInterface(namedType, iMultiThreadableTaskType)) ||
+                    (multiThreadableTaskAttributeType is not null && namedType.GetAttributes().Any(
+                        attr => SymbolEqualityComparer.Default.Equals(attr.AttributeClass, multiThreadableTaskAttributeType)));
+
+                if (!isMultiThreadable)
                 {
                     return;
                 }

--- a/src/TaskAnalyzer/PreferTypedParameterAnalyzer.cs
+++ b/src/TaskAnalyzer/PreferTypedParameterAnalyzer.cs
@@ -534,16 +534,19 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
         /// <summary>
         /// Determines the parsed target type from a Parse/TryParse/Convert method call.
         /// Returns the simple type name suitable for ITaskItem&lt;T&gt; suggestion, or null if not a recognized parse call.
+        /// Only returns suggestions for types supported by ValueTypeParser.
         /// </summary>
         private static string? GetParsedTypeFromMethod(IMethodSymbol method)
         {
             // Static Parse/TryParse on value types: int.Parse, bool.Parse, etc.
+            // Restrict to types supported by ValueTypeParser to avoid suggesting unsupported types like Guid.
             if ((method.Name == "Parse" || method.Name == "TryParse") &&
                 method.IsStatic &&
                 method.ContainingType is not null &&
                 method.ContainingType.IsValueType)
             {
-                return method.ContainingType.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
+                string typeName = method.ContainingType.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
+                return s_supportedValueTypeNames.Contains(typeName) ? typeName : null;
             }
 
             // Convert.ToXxx methods
@@ -571,6 +574,28 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
 
             return null;
         }
+
+        /// <summary>
+        /// Value type names (as minimal C# names) that ValueTypeParser supports.
+        /// Only these types should be suggested by the analyzer.
+        /// </summary>
+        private static readonly System.Collections.Generic.HashSet<string> s_supportedValueTypeNames =
+            new(System.StringComparer.Ordinal)
+            {
+                "bool",
+                "char",
+                "byte",
+                "sbyte",
+                "short",
+                "ushort",
+                "int",
+                "uint",
+                "long",
+                "ulong",
+                "float",
+                "double",
+                "decimal",
+            };
 
         /// <summary>
         /// Checks if the given operation traces back (with at most one level of local indirection)

--- a/src/TaskAnalyzer/PreferTypedParameterAnalyzer.cs
+++ b/src/TaskAnalyzer/PreferTypedParameterAnalyzer.cs
@@ -151,7 +151,7 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
             {
                 case IObjectCreationOperation creation:
                     AnalyzeObjectCreation(context, creation, stringInputProps, taskItemInputProps,
-                        absolutePathType, iTaskItemType, fileInfoType, directoryInfoType);
+                        absolutePathType, taskEnvironmentType, iTaskItemType, fileInfoType, directoryInfoType);
                     break;
 
                 case IInvocationOperation invocation:
@@ -168,6 +168,7 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
             HashSet<IPropertySymbol> stringInputProps,
             HashSet<IPropertySymbol> taskItemInputProps,
             INamedTypeSymbol? absolutePathType,
+            INamedTypeSymbol? taskEnvironmentType,
             INamedTypeSymbol? iTaskItemType,
             INamedTypeSymbol? fileInfoType,
             INamedTypeSymbol? directoryInfoType)
@@ -228,6 +229,7 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
 
                 if (suggestedTypeArg is not null)
                 {
+                    // Direct: new FileInfo(item.ItemSpec) or new AbsolutePath(item.ItemSpec)
                     var (sourceProp, _) = FindItemSpecSource(creation.Arguments[0].Value, taskItemInputProps, iTaskItemType);
                     if (sourceProp is not null)
                     {
@@ -236,6 +238,22 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                             DiagnosticDescriptors.PreferTypedTaskItem,
                             creation.Syntax.GetLocation(),
                             sourceProp.Name, currentType, suggestedTypeArg));
+                        return;
+                    }
+
+                    // Indirect via AbsolutePath: new FileInfo(absLocal) where absLocal = GetAbsolutePath(item.ItemSpec)
+                    if (suggestedTypeArg != "AbsolutePath" && taskEnvironmentType is not null)
+                    {
+                        var itemProp = FindItemSpecSourceThroughAbsolutePath(
+                            creation.Arguments[0].Value, taskItemInputProps, iTaskItemType, taskEnvironmentType);
+                        if (itemProp is not null)
+                        {
+                            string currentType = itemProp.Type is IArrayTypeSymbol ? "ITaskItem[]" : "ITaskItem";
+                            context.ReportDiagnostic(Diagnostic.Create(
+                                DiagnosticDescriptors.PreferTypedTaskItem,
+                                creation.Syntax.GetLocation(),
+                                itemProp.Name, currentType, suggestedTypeArg));
+                        }
                     }
                 }
             }
@@ -616,6 +634,58 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
             }
 
             return (null, false);
+        }
+
+        /// <summary>
+        /// Traces through an AbsolutePath intermediary to find the original ITaskItem source.
+        /// Handles patterns like:
+        ///   AbsolutePath abs = TaskEnvironment.GetAbsolutePath(item.ItemSpec);
+        ///   new FileInfo(abs);  // abs traces back to item.ItemSpec
+        /// </summary>
+        private static IPropertySymbol? FindItemSpecSourceThroughAbsolutePath(
+            IOperation operation,
+            HashSet<IPropertySymbol> taskItemInputProps,
+            INamedTypeSymbol iTaskItemType,
+            INamedTypeSymbol taskEnvironmentType)
+        {
+            // Unwrap conversions
+            while (operation is IConversionOperation conversion)
+            {
+                operation = conversion.Operand;
+            }
+
+            // Direct: new FileInfo(TaskEnvironment.GetAbsolutePath(item.ItemSpec))
+            if (operation is IInvocationOperation invocation &&
+                invocation.TargetMethod.Name == "GetAbsolutePath" &&
+                SymbolEqualityComparer.Default.Equals(invocation.TargetMethod.ContainingType, taskEnvironmentType) &&
+                invocation.Arguments.Length > 0)
+            {
+                var (sourceProp, _) = FindItemSpecSource(invocation.Arguments[0].Value, taskItemInputProps, iTaskItemType);
+                return sourceProp;
+            }
+
+            // Local indirection: var abs = TaskEnvironment.GetAbsolutePath(item.ItemSpec); new FileInfo(abs);
+            if (operation is ILocalReferenceOperation localRef)
+            {
+                var local = localRef.Local;
+                if (local.DeclaringSyntaxReferences.Length == 1)
+                {
+                    var syntax = local.DeclaringSyntaxReferences[0].GetSyntax();
+                    var semanticModel = operation.SemanticModel;
+                    if (semanticModel is not null)
+                    {
+                        var declOp = semanticModel.GetOperation(syntax);
+                        if (declOp is IVariableDeclaratorOperation declarator &&
+                            declarator.Initializer?.Value is IOperation initValue)
+                        {
+                            return FindItemSpecSourceThroughAbsolutePath(
+                                initValue, taskItemInputProps, iTaskItemType, taskEnvironmentType);
+                        }
+                    }
+                }
+            }
+
+            return null;
         }
     }
 }

--- a/src/TaskAnalyzer/PreferTypedParameterAnalyzer.cs
+++ b/src/TaskAnalyzer/PreferTypedParameterAnalyzer.cs
@@ -300,6 +300,44 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                     }
                 }
             }
+
+            // Path.Combine(...) with any argument tracing to a task input property
+            if (method.ContainingType?.ToDisplayString() == "System.IO.Path" &&
+                method.Name == "Combine" &&
+                invocation.Arguments.Length >= 2)
+            {
+                foreach (var arg in invocation.Arguments)
+                {
+                    // MSBuildTask0006: Path.Combine(stringProp, ...) or Path.Combine(..., stringProp)
+                    if (stringInputProps.Count > 0)
+                    {
+                        var sourceProp = FindSourceProperty(arg.Value, stringInputProps);
+                        if (sourceProp is not null)
+                        {
+                            context.ReportDiagnostic(Diagnostic.Create(
+                                DiagnosticDescriptors.PreferTypedPathParameter,
+                                invocation.Syntax.GetLocation(),
+                                sourceProp.Name, "string", "AbsolutePath"));
+                            break;
+                        }
+                    }
+
+                    // MSBuildTask0007: Path.Combine(item.ItemSpec, ...) or Path.Combine(..., item.ItemSpec)
+                    if (taskItemInputProps.Count > 0 && iTaskItemType is not null)
+                    {
+                        var (itemProp, _) = FindItemSpecSource(arg.Value, taskItemInputProps, iTaskItemType);
+                        if (itemProp is not null)
+                        {
+                            string currentType = itemProp.Type is IArrayTypeSymbol ? "ITaskItem[]" : "ITaskItem";
+                            context.ReportDiagnostic(Diagnostic.Create(
+                                DiagnosticDescriptors.PreferTypedTaskItem,
+                                invocation.Syntax.GetLocation(),
+                                itemProp.Name, currentType, "AbsolutePath"));
+                            break;
+                        }
+                    }
+                }
+            }
         }
 
         /// <summary>
@@ -384,6 +422,20 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                 }
             }
 
+            // One level of method call wrapping: SomeMethod(stringProp)
+            // e.g., FileUtilities.FixFilePath(stringProp)
+            if (operation is IInvocationOperation wrappingCall && wrappingCall.Arguments.Length > 0)
+            {
+                foreach (var arg in wrappingCall.Arguments)
+                {
+                    var result = FindSourcePropertyDirect(arg.Value, candidateProps);
+                    if (result is not null)
+                    {
+                        return result;
+                    }
+                }
+            }
+
             return null;
         }
 
@@ -412,6 +464,7 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
         /// Checks if the given operation is an access to .ItemSpec on an ITaskItem
         /// that traces back to one of the collected task input properties.
         /// Returns the source property and whether it came from an array element.
+        /// Also traces through one level of method call wrapping (e.g., FixFilePath(item.ItemSpec)).
         /// </summary>
         private static (IPropertySymbol? sourceProp, bool fromArray) FindItemSpecSource(
             IOperation operation,
@@ -445,6 +498,20 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                 }
 
                 return (null, false);
+            }
+
+            // One level of method call wrapping: SomeMethod(item.ItemSpec)
+            // e.g., FileUtilities.FixFilePath(item.ItemSpec)
+            if (operation is IInvocationOperation wrappingCall && wrappingCall.Arguments.Length > 0)
+            {
+                foreach (var arg in wrappingCall.Arguments)
+                {
+                    var result = FindItemSpecSourceDirect(arg.Value, taskItemInputProps, iTaskItemType);
+                    if (result.sourceProp is not null)
+                    {
+                        return result;
+                    }
+                }
             }
 
             return FindItemSpecSourceDirect(operation, taskItemInputProps, iTaskItemType);

--- a/src/TaskAnalyzer/PreferTypedParameterAnalyzer.cs
+++ b/src/TaskAnalyzer/PreferTypedParameterAnalyzer.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -126,19 +127,77 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                     return;
                 }
 
+                // Collect diagnostics during operation analysis, then deduplicate in SymbolEndAction.
+                // This allows suppressing AbsolutePath suggestions when a more specific
+                // FileInfo/DirectoryInfo suggestion exists for the same property.
+                var pendingDiagnostics = new ConcurrentBag<Diagnostic>();
+
                 symbolStartContext.RegisterOperationAction(ctx =>
                 {
-                    AnalyzeOperation(ctx, stringInputProps, taskItemInputProps,
+                    AnalyzeOperation(ctx, pendingDiagnostics, stringInputProps, taskItemInputProps,
                         absolutePathType, taskEnvironmentType, iTaskItemType,
                         fileInfoType, directoryInfoType);
                 },
                 OperationKind.ObjectCreation,
                 OperationKind.Invocation);
+
+                symbolStartContext.RegisterSymbolEndAction(endCtx =>
+                {
+                    // Group diagnostics by property name + rule ID, then suppress AbsolutePath
+                    // suggestions when a FileInfo/DirectoryInfo suggestion exists for the same property.
+                    var diagnosticsList = pendingDiagnostics.ToList();
+
+                    // Find properties that have FileInfo or DirectoryInfo suggestions
+                    var propsWithSpecificType = new HashSet<string>();
+                    foreach (var diag in diagnosticsList)
+                    {
+                        string message = diag.GetMessage();
+                        if (message.Contains("FileInfo") || message.Contains("DirectoryInfo"))
+                        {
+                            // Extract property name from message format: "... property '{0}' from ..."
+                            int startIdx = message.IndexOf('\'');
+                            if (startIdx >= 0)
+                            {
+                                int endIdx = message.IndexOf('\'', startIdx + 1);
+                                if (endIdx > startIdx)
+                                {
+                                    string propName = message.Substring(startIdx + 1, endIdx - startIdx - 1);
+                                    propsWithSpecificType.Add(diag.Id + "|" + propName);
+                                }
+                            }
+                        }
+                    }
+
+                    foreach (var diag in diagnosticsList)
+                    {
+                        string message = diag.GetMessage();
+                        // Suppress AbsolutePath suggestions when FileInfo/DirectoryInfo exists for same property
+                        if (message.Contains("AbsolutePath") && propsWithSpecificType.Count > 0)
+                        {
+                            int startIdx = message.IndexOf('\'');
+                            if (startIdx >= 0)
+                            {
+                                int endIdx = message.IndexOf('\'', startIdx + 1);
+                                if (endIdx > startIdx)
+                                {
+                                    string propName = message.Substring(startIdx + 1, endIdx - startIdx - 1);
+                                    if (propsWithSpecificType.Contains(diag.Id + "|" + propName))
+                                    {
+                                        continue; // Suppress — more specific type available
+                                    }
+                                }
+                            }
+                        }
+
+                        endCtx.ReportDiagnostic(diag);
+                    }
+                });
             }, SymbolKind.NamedType);
         }
 
         private static void AnalyzeOperation(
             OperationAnalysisContext context,
+            ConcurrentBag<Diagnostic> pendingDiagnostics,
             HashSet<IPropertySymbol> stringInputProps,
             HashSet<IPropertySymbol> taskItemInputProps,
             INamedTypeSymbol? absolutePathType,
@@ -150,12 +209,12 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
             switch (context.Operation)
             {
                 case IObjectCreationOperation creation:
-                    AnalyzeObjectCreation(context, creation, stringInputProps, taskItemInputProps,
+                    AnalyzeObjectCreation(pendingDiagnostics, creation, stringInputProps, taskItemInputProps,
                         absolutePathType, taskEnvironmentType, iTaskItemType, fileInfoType, directoryInfoType);
                     break;
 
                 case IInvocationOperation invocation:
-                    AnalyzeInvocation(context, invocation, stringInputProps, taskItemInputProps,
+                    AnalyzeInvocation(pendingDiagnostics, invocation, stringInputProps, taskItemInputProps,
                         absolutePathType, taskEnvironmentType, iTaskItemType,
                         fileInfoType, directoryInfoType);
                     break;
@@ -163,7 +222,7 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
         }
 
         private static void AnalyzeObjectCreation(
-            OperationAnalysisContext context,
+            ConcurrentBag<Diagnostic> pendingDiagnostics,
             IObjectCreationOperation creation,
             HashSet<IPropertySymbol> stringInputProps,
             HashSet<IPropertySymbol> taskItemInputProps,
@@ -201,7 +260,7 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                     var sourceProp = FindSourceProperty(creation.Arguments[0].Value, stringInputProps);
                     if (sourceProp is not null)
                     {
-                        context.ReportDiagnostic(Diagnostic.Create(
+                        pendingDiagnostics.Add(Diagnostic.Create(
                             DiagnosticDescriptors.PreferTypedPathParameter,
                             creation.Syntax.GetLocation(),
                             sourceProp.Name, "string", suggestedType));
@@ -235,7 +294,7 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                     {
                         bool isArray = sourceProp.Type is IArrayTypeSymbol;
                         string currentType = isArray ? "ITaskItem[]" : "ITaskItem";
-                        context.ReportDiagnostic(Diagnostic.Create(
+                        pendingDiagnostics.Add(Diagnostic.Create(
                             DiagnosticDescriptors.PreferTypedTaskItem,
                             creation.Syntax.GetLocation(),
                             sourceProp.Name, currentType, suggestedTypeArg, isArray ? "[]" : ""));
@@ -251,7 +310,7 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                         {
                             bool isArray = itemProp.Type is IArrayTypeSymbol;
                             string currentType = isArray ? "ITaskItem[]" : "ITaskItem";
-                            context.ReportDiagnostic(Diagnostic.Create(
+                            pendingDiagnostics.Add(Diagnostic.Create(
                                 DiagnosticDescriptors.PreferTypedTaskItem,
                                 creation.Syntax.GetLocation(),
                                 itemProp.Name, currentType, suggestedTypeArg, isArray ? "[]" : ""));
@@ -262,7 +321,7 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
         }
 
         private static void AnalyzeInvocation(
-            OperationAnalysisContext context,
+            ConcurrentBag<Diagnostic> pendingDiagnostics,
             IInvocationOperation invocation,
             HashSet<IPropertySymbol> stringInputProps,
             HashSet<IPropertySymbol> taskItemInputProps,
@@ -284,7 +343,7 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                 var sourceProp = FindSourceProperty(invocation.Arguments[0].Value, stringInputProps);
                 if (sourceProp is not null)
                 {
-                    context.ReportDiagnostic(Diagnostic.Create(
+                    pendingDiagnostics.Add(Diagnostic.Create(
                         DiagnosticDescriptors.PreferTypedPathParameter,
                         invocation.Syntax.GetLocation(),
                         sourceProp.Name, "string", "AbsolutePath"));
@@ -314,7 +373,7 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                     {
                         bool isArray = sourceProp.Type is IArrayTypeSymbol;
                         string currentType = isArray ? "ITaskItem[]" : "ITaskItem";
-                        context.ReportDiagnostic(Diagnostic.Create(
+                        pendingDiagnostics.Add(Diagnostic.Create(
                             DiagnosticDescriptors.PreferTypedTaskItem,
                             invocation.Syntax.GetLocation(),
                             sourceProp.Name, currentType, suggestedTypeArg, isArray ? "[]" : ""));
@@ -335,7 +394,7 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                         var sourceProp = FindSourceProperty(arg.Value, stringInputProps);
                         if (sourceProp is not null)
                         {
-                            context.ReportDiagnostic(Diagnostic.Create(
+                            pendingDiagnostics.Add(Diagnostic.Create(
                                 DiagnosticDescriptors.PreferTypedPathParameter,
                                 invocation.Syntax.GetLocation(),
                                 sourceProp.Name, "string", "AbsolutePath"));
@@ -351,7 +410,7 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                         {
                             bool isArray = itemProp.Type is IArrayTypeSymbol;
                             string currentType = isArray ? "ITaskItem[]" : "ITaskItem";
-                            context.ReportDiagnostic(Diagnostic.Create(
+                            pendingDiagnostics.Add(Diagnostic.Create(
                                 DiagnosticDescriptors.PreferTypedTaskItem,
                                 invocation.Syntax.GetLocation(),
                                 itemProp.Name, currentType, "AbsolutePath", isArray ? "[]" : ""));

--- a/src/TaskAnalyzer/PreferTypedParameterAnalyzer.cs
+++ b/src/TaskAnalyzer/PreferTypedParameterAnalyzer.cs
@@ -1,0 +1,522 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+using static Microsoft.Build.TaskAuthoring.Analyzer.SharedAnalyzerHelpers;
+
+namespace Microsoft.Build.TaskAuthoring.Analyzer
+{
+    /// <summary>
+    /// Roslyn analyzer that suggests using strongly-typed task parameters instead of
+    /// manual path construction or ItemSpec parsing inside task bodies.
+    ///
+    /// MSBuildTask0006: Prefer AbsolutePath/FileInfo/DirectoryInfo parameters over converting from string.
+    /// MSBuildTask0007: Prefer ITaskItem&lt;T&gt; parameters over parsing ItemSpec manually.
+    /// </summary>
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class PreferTypedParameterAnalyzer : DiagnosticAnalyzer
+    {
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
+            ImmutableArray.Create(
+                DiagnosticDescriptors.PreferTypedPathParameter,
+                DiagnosticDescriptors.PreferTypedTaskItem);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.EnableConcurrentExecution();
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.RegisterCompilationStartAction(OnCompilationStart);
+        }
+
+        private static void OnCompilationStart(CompilationStartAnalysisContext compilationContext)
+        {
+            var iTaskType = compilationContext.Compilation.GetTypeByMetadataName(WellKnownTypeNames.ITaskFullName);
+            if (iTaskType is null)
+            {
+                return;
+            }
+
+            var absolutePathType = compilationContext.Compilation.GetTypeByMetadataName(WellKnownTypeNames.AbsolutePathFullName);
+            var taskEnvironmentType = compilationContext.Compilation.GetTypeByMetadataName(WellKnownTypeNames.TaskEnvironmentFullName);
+            var iTaskItemType = compilationContext.Compilation.GetTypeByMetadataName(WellKnownTypeNames.ITaskItemFullName);
+            var outputAttributeType = compilationContext.Compilation.GetTypeByMetadataName(WellKnownTypeNames.OutputAttributeFullName);
+            var fileInfoType = compilationContext.Compilation.GetTypeByMetadataName("System.IO.FileInfo");
+            var directoryInfoType = compilationContext.Compilation.GetTypeByMetadataName("System.IO.DirectoryInfo");
+
+            compilationContext.RegisterSymbolStartAction(symbolStartContext =>
+            {
+                var namedType = (INamedTypeSymbol)symbolStartContext.Symbol;
+                if (!ImplementsInterface(namedType, iTaskType))
+                {
+                    return;
+                }
+
+                // Collect string-typed task input properties (candidates for MSBuildTask0006)
+                var stringInputProps = new HashSet<IPropertySymbol>(SymbolEqualityComparer.Default);
+                // Collect ITaskItem/ITaskItem[]-typed task input properties (candidates for MSBuildTask0007)
+                var taskItemInputProps = new HashSet<IPropertySymbol>(SymbolEqualityComparer.Default);
+
+                foreach (var member in namedType.GetMembers().OfType<IPropertySymbol>())
+                {
+                    if (member.DeclaredAccessibility != Accessibility.Public)
+                    {
+                        continue;
+                    }
+
+                    if (member.SetMethod is null || member.SetMethod.DeclaredAccessibility != Accessibility.Public)
+                    {
+                        continue;
+                    }
+
+                    // Exclude [Output] properties — they are set by the task, not MSBuild
+                    if (outputAttributeType is not null && member.GetAttributes().Any(
+                        a => SymbolEqualityComparer.Default.Equals(a.AttributeClass, outputAttributeType)))
+                    {
+                        continue;
+                    }
+
+                    if (member.Type.SpecialType == SpecialType.System_String)
+                    {
+                        stringInputProps.Add(member);
+                    }
+                    else if (iTaskItemType is not null)
+                    {
+                        if (SymbolEqualityComparer.Default.Equals(member.Type, iTaskItemType))
+                        {
+                            taskItemInputProps.Add(member);
+                        }
+                        else if (member.Type is IArrayTypeSymbol arrayType &&
+                                 SymbolEqualityComparer.Default.Equals(arrayType.ElementType, iTaskItemType))
+                        {
+                            taskItemInputProps.Add(member);
+                        }
+                    }
+                }
+
+                if (stringInputProps.Count == 0 && taskItemInputProps.Count == 0)
+                {
+                    return;
+                }
+
+                symbolStartContext.RegisterOperationAction(ctx =>
+                {
+                    AnalyzeOperation(ctx, stringInputProps, taskItemInputProps,
+                        absolutePathType, taskEnvironmentType, iTaskItemType,
+                        fileInfoType, directoryInfoType);
+                },
+                OperationKind.ObjectCreation,
+                OperationKind.Invocation);
+            }, SymbolKind.NamedType);
+        }
+
+        private static void AnalyzeOperation(
+            OperationAnalysisContext context,
+            HashSet<IPropertySymbol> stringInputProps,
+            HashSet<IPropertySymbol> taskItemInputProps,
+            INamedTypeSymbol? absolutePathType,
+            INamedTypeSymbol? taskEnvironmentType,
+            INamedTypeSymbol? iTaskItemType,
+            INamedTypeSymbol? fileInfoType,
+            INamedTypeSymbol? directoryInfoType)
+        {
+            switch (context.Operation)
+            {
+                case IObjectCreationOperation creation:
+                    AnalyzeObjectCreation(context, creation, stringInputProps, taskItemInputProps,
+                        absolutePathType, iTaskItemType, fileInfoType, directoryInfoType);
+                    break;
+
+                case IInvocationOperation invocation:
+                    AnalyzeInvocation(context, invocation, stringInputProps, taskItemInputProps,
+                        absolutePathType, taskEnvironmentType, iTaskItemType,
+                        fileInfoType, directoryInfoType);
+                    break;
+            }
+        }
+
+        private static void AnalyzeObjectCreation(
+            OperationAnalysisContext context,
+            IObjectCreationOperation creation,
+            HashSet<IPropertySymbol> stringInputProps,
+            HashSet<IPropertySymbol> taskItemInputProps,
+            INamedTypeSymbol? absolutePathType,
+            INamedTypeSymbol? iTaskItemType,
+            INamedTypeSymbol? fileInfoType,
+            INamedTypeSymbol? directoryInfoType)
+        {
+            var createdType = creation.Type;
+            if (createdType is null || creation.Arguments.Length == 0)
+            {
+                return;
+            }
+
+            // MSBuildTask0006: new AbsolutePath(stringProp), new FileInfo(stringProp), new DirectoryInfo(stringProp)
+            if (stringInputProps.Count > 0)
+            {
+                string? suggestedType = null;
+                if (absolutePathType is not null && SymbolEqualityComparer.Default.Equals(createdType, absolutePathType))
+                {
+                    suggestedType = "AbsolutePath";
+                }
+                else if (fileInfoType is not null && SymbolEqualityComparer.Default.Equals(createdType, fileInfoType))
+                {
+                    suggestedType = "FileInfo";
+                }
+                else if (directoryInfoType is not null && SymbolEqualityComparer.Default.Equals(createdType, directoryInfoType))
+                {
+                    suggestedType = "DirectoryInfo";
+                }
+
+                if (suggestedType is not null)
+                {
+                    var sourceProp = FindSourceProperty(creation.Arguments[0].Value, stringInputProps);
+                    if (sourceProp is not null)
+                    {
+                        context.ReportDiagnostic(Diagnostic.Create(
+                            DiagnosticDescriptors.PreferTypedPathParameter,
+                            creation.Syntax.GetLocation(),
+                            sourceProp.Name, "string", suggestedType));
+                        return;
+                    }
+                }
+            }
+
+            // MSBuildTask0007: new AbsolutePath(item.ItemSpec), new FileInfo(item.ItemSpec), new DirectoryInfo(item.ItemSpec)
+            if (taskItemInputProps.Count > 0 && iTaskItemType is not null)
+            {
+                string? suggestedTypeArg = null;
+                if (absolutePathType is not null && SymbolEqualityComparer.Default.Equals(createdType, absolutePathType))
+                {
+                    suggestedTypeArg = "AbsolutePath";
+                }
+                else if (fileInfoType is not null && SymbolEqualityComparer.Default.Equals(createdType, fileInfoType))
+                {
+                    suggestedTypeArg = "FileInfo";
+                }
+                else if (directoryInfoType is not null && SymbolEqualityComparer.Default.Equals(createdType, directoryInfoType))
+                {
+                    suggestedTypeArg = "DirectoryInfo";
+                }
+
+                if (suggestedTypeArg is not null)
+                {
+                    var (sourceProp, _) = FindItemSpecSource(creation.Arguments[0].Value, taskItemInputProps, iTaskItemType);
+                    if (sourceProp is not null)
+                    {
+                        string currentType = sourceProp.Type is IArrayTypeSymbol ? "ITaskItem[]" : "ITaskItem";
+                        context.ReportDiagnostic(Diagnostic.Create(
+                            DiagnosticDescriptors.PreferTypedTaskItem,
+                            creation.Syntax.GetLocation(),
+                            sourceProp.Name, currentType, suggestedTypeArg));
+                    }
+                }
+            }
+        }
+
+        private static void AnalyzeInvocation(
+            OperationAnalysisContext context,
+            IInvocationOperation invocation,
+            HashSet<IPropertySymbol> stringInputProps,
+            HashSet<IPropertySymbol> taskItemInputProps,
+            INamedTypeSymbol? absolutePathType,
+            INamedTypeSymbol? taskEnvironmentType,
+            INamedTypeSymbol? iTaskItemType,
+            INamedTypeSymbol? fileInfoType,
+            INamedTypeSymbol? directoryInfoType)
+        {
+            var method = invocation.TargetMethod;
+
+            // MSBuildTask0006: TaskEnvironment.GetAbsolutePath(stringProp)
+            if (stringInputProps.Count > 0 &&
+                taskEnvironmentType is not null &&
+                method.Name == "GetAbsolutePath" &&
+                SymbolEqualityComparer.Default.Equals(method.ContainingType, taskEnvironmentType) &&
+                invocation.Arguments.Length > 0)
+            {
+                var sourceProp = FindSourceProperty(invocation.Arguments[0].Value, stringInputProps);
+                if (sourceProp is not null)
+                {
+                    context.ReportDiagnostic(Diagnostic.Create(
+                        DiagnosticDescriptors.PreferTypedPathParameter,
+                        invocation.Syntax.GetLocation(),
+                        sourceProp.Name, "string", "AbsolutePath"));
+                    return;
+                }
+            }
+
+            // MSBuildTask0007: Parse methods on ItemSpec
+            if (taskItemInputProps.Count > 0 && iTaskItemType is not null && invocation.Arguments.Length > 0)
+            {
+                // Check for Type.Parse(item.ItemSpec) and Convert.ToType(item.ItemSpec)
+                string? suggestedTypeArg = GetParsedTypeFromMethod(method);
+                if (suggestedTypeArg is not null)
+                {
+                    var (sourceProp, _) = FindItemSpecSource(invocation.Arguments[0].Value, taskItemInputProps, iTaskItemType);
+                    if (sourceProp is not null)
+                    {
+                        string currentType = sourceProp.Type is IArrayTypeSymbol ? "ITaskItem[]" : "ITaskItem";
+                        context.ReportDiagnostic(Diagnostic.Create(
+                            DiagnosticDescriptors.PreferTypedTaskItem,
+                            invocation.Syntax.GetLocation(),
+                            sourceProp.Name, currentType, suggestedTypeArg));
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Determines the parsed target type from a Parse/TryParse/Convert method call.
+        /// Returns the simple type name suitable for ITaskItem&lt;T&gt; suggestion, or null if not a recognized parse call.
+        /// </summary>
+        private static string? GetParsedTypeFromMethod(IMethodSymbol method)
+        {
+            // Static Parse/TryParse on value types: int.Parse, bool.Parse, etc.
+            if ((method.Name == "Parse" || method.Name == "TryParse") &&
+                method.IsStatic &&
+                method.ContainingType is not null &&
+                method.ContainingType.IsValueType)
+            {
+                return method.ContainingType.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
+            }
+
+            // Convert.ToXxx methods
+            if (method.IsStatic &&
+                method.ContainingType?.ToDisplayString() == "System.Convert" &&
+                method.Name.StartsWith("To", System.StringComparison.Ordinal))
+            {
+                switch (method.Name)
+                {
+                    case "ToInt32": return "int";
+                    case "ToInt64": return "long";
+                    case "ToBoolean": return "bool";
+                    case "ToDouble": return "double";
+                    case "ToSingle": return "float";
+                    case "ToDecimal": return "decimal";
+                    case "ToByte": return "byte";
+                    case "ToSByte": return "sbyte";
+                    case "ToInt16": return "short";
+                    case "ToUInt16": return "ushort";
+                    case "ToUInt32": return "uint";
+                    case "ToUInt64": return "ulong";
+                    case "ToChar": return "char";
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Checks if the given operation traces back (with at most one level of local indirection)
+        /// to one of the collected string task input properties.
+        /// </summary>
+        private static IPropertySymbol? FindSourceProperty(
+            IOperation operation,
+            HashSet<IPropertySymbol> candidateProps)
+        {
+            // Unwrap conversions
+            while (operation is IConversionOperation conversion)
+            {
+                operation = conversion.Operand;
+            }
+
+            // Direct property reference: this.MyProp or MyProp
+            if (operation is IPropertyReferenceOperation propRef &&
+                candidateProps.Contains(propRef.Property))
+            {
+                return propRef.Property;
+            }
+
+            // One level of local indirection: var x = this.MyProp; ... use x ...
+            if (operation is ILocalReferenceOperation localRef)
+            {
+                var local = localRef.Local;
+                if (local.DeclaringSyntaxReferences.Length == 1)
+                {
+                    var syntax = local.DeclaringSyntaxReferences[0].GetSyntax();
+                    var semanticModel = operation.SemanticModel;
+                    if (semanticModel is not null)
+                    {
+                        var declOp = semanticModel.GetOperation(syntax);
+                        if (declOp is IVariableDeclaratorOperation declarator &&
+                            declarator.Initializer?.Value is IOperation initValue)
+                        {
+                            return FindSourcePropertyDirect(initValue, candidateProps);
+                        }
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Direct property reference check without local indirection (prevents infinite recursion).
+        /// </summary>
+        private static IPropertySymbol? FindSourcePropertyDirect(
+            IOperation operation,
+            HashSet<IPropertySymbol> candidateProps)
+        {
+            while (operation is IConversionOperation conversion)
+            {
+                operation = conversion.Operand;
+            }
+
+            if (operation is IPropertyReferenceOperation propRef &&
+                candidateProps.Contains(propRef.Property))
+            {
+                return propRef.Property;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Checks if the given operation is an access to .ItemSpec on an ITaskItem
+        /// that traces back to one of the collected task input properties.
+        /// Returns the source property and whether it came from an array element.
+        /// </summary>
+        private static (IPropertySymbol? sourceProp, bool fromArray) FindItemSpecSource(
+            IOperation operation,
+            HashSet<IPropertySymbol> taskItemInputProps,
+            INamedTypeSymbol iTaskItemType)
+        {
+            // Unwrap conversions
+            while (operation is IConversionOperation conversion)
+            {
+                operation = conversion.Operand;
+            }
+
+            // One level of local indirection for the ItemSpec value:
+            // var spec = item.ItemSpec; int.Parse(spec);
+            if (operation is ILocalReferenceOperation specLocal)
+            {
+                var local = specLocal.Local;
+                if (local.DeclaringSyntaxReferences.Length == 1)
+                {
+                    var syntax = local.DeclaringSyntaxReferences[0].GetSyntax();
+                    var semanticModel = operation.SemanticModel;
+                    if (semanticModel is not null)
+                    {
+                        var declOp = semanticModel.GetOperation(syntax);
+                        if (declOp is IVariableDeclaratorOperation declarator &&
+                            declarator.Initializer?.Value is IOperation initValue)
+                        {
+                            return FindItemSpecSourceDirect(initValue, taskItemInputProps, iTaskItemType);
+                        }
+                    }
+                }
+
+                return (null, false);
+            }
+
+            return FindItemSpecSourceDirect(operation, taskItemInputProps, iTaskItemType);
+        }
+
+        /// <summary>
+        /// Direct check: is this operation item.ItemSpec where item traces to a task property?
+        /// </summary>
+        private static (IPropertySymbol? sourceProp, bool fromArray) FindItemSpecSourceDirect(
+            IOperation operation,
+            HashSet<IPropertySymbol> taskItemInputProps,
+            INamedTypeSymbol iTaskItemType)
+        {
+            while (operation is IConversionOperation conversion)
+            {
+                operation = conversion.Operand;
+            }
+
+            // Check for .ItemSpec property access
+            if (operation is IPropertyReferenceOperation itemSpecRef &&
+                itemSpecRef.Property.Name == "ItemSpec")
+            {
+                var receiverType = itemSpecRef.Property.ContainingType;
+                if (receiverType is not null &&
+                    (SymbolEqualityComparer.Default.Equals(receiverType, iTaskItemType) ||
+                     ImplementsInterface(receiverType, iTaskItemType)))
+                {
+                    // Check if the receiver traces to a task input property
+                    var receiver = itemSpecRef.Instance;
+                    if (receiver is not null)
+                    {
+                        return FindTaskItemPropertySource(receiver, taskItemInputProps);
+                    }
+                }
+            }
+
+            return (null, false);
+        }
+
+        /// <summary>
+        /// Traces an ITaskItem receiver back to a task input property,
+        /// including through foreach iteration variables and array indexing.
+        /// </summary>
+        private static (IPropertySymbol? sourceProp, bool fromArray) FindTaskItemPropertySource(
+            IOperation operation,
+            HashSet<IPropertySymbol> taskItemInputProps)
+        {
+            while (operation is IConversionOperation conversion)
+            {
+                operation = conversion.Operand;
+            }
+
+            // Direct property reference: this.MyItemProp.ItemSpec
+            if (operation is IPropertyReferenceOperation propRef &&
+                taskItemInputProps.Contains(propRef.Property))
+            {
+                return (propRef.Property, false);
+            }
+
+            // Local variable tracing (foreach variable or simple assignment)
+            if (operation is ILocalReferenceOperation localRef)
+            {
+                var local = localRef.Local;
+                var syntaxRef = local.DeclaringSyntaxReferences.FirstOrDefault();
+                if (syntaxRef is not null)
+                {
+                    var syntax = syntaxRef.GetSyntax();
+                    var semanticModel = operation.SemanticModel;
+                    if (semanticModel is not null)
+                    {
+                        var declOp = semanticModel.GetOperation(syntax);
+
+                        // Simple local assignment: var item = this.MyItemProp;
+                        if (declOp is IVariableDeclaratorOperation declarator &&
+                            declarator.Initializer?.Value is IOperation initValue)
+                        {
+                            return FindTaskItemPropertySource(initValue, taskItemInputProps);
+                        }
+
+                        // Foreach iteration variable: walk up syntax to find the foreach statement
+                        // The variable's declaring syntax may be the identifier token or designation
+                        // within a ForEachStatementSyntax
+                        var current = syntax;
+                        while (current is not null)
+                        {
+                            var op = semanticModel.GetOperation(current);
+                            if (op is IForEachLoopOperation foreachOp)
+                            {
+                                return FindTaskItemPropertySource(foreachOp.Collection, taskItemInputProps);
+                            }
+
+                            current = current.Parent;
+                        }
+                    }
+                }
+            }
+
+            // Array element access: this.MyItems[i].ItemSpec
+            if (operation is IArrayElementReferenceOperation arrayRef)
+            {
+                return FindTaskItemPropertySource(arrayRef.ArrayReference, taskItemInputProps);
+            }
+
+            return (null, false);
+        }
+    }
+}

--- a/src/TaskAnalyzer/PreferTypedParameterAnalyzer.cs
+++ b/src/TaskAnalyzer/PreferTypedParameterAnalyzer.cs
@@ -52,10 +52,12 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                 return;
             }
 
-            // Additionally, the task must opt into multithreaded support
-            var iMultiThreadableTaskType = compilationContext.Compilation.GetTypeByMetadataName(WellKnownTypeNames.IMultiThreadableTaskFullName);
+            // Additionally, the task must opt into multithreaded support by applying the
+            // [MSBuildMultiThreadableTask] attribute. Implementing IMultiThreadableTask is not
+            // sufficient: the attribute is Inherited = false, so a task that merely derives from a
+            // base class implementing the interface has not itself opted into multithreaded support.
             var multiThreadableTaskAttributeType = compilationContext.Compilation.GetTypeByMetadataName(WellKnownTypeNames.MultiThreadableTaskAttributeFullName);
-            if (iMultiThreadableTaskType is null && multiThreadableTaskAttributeType is null)
+            if (multiThreadableTaskAttributeType is null)
             {
                 return;
             }
@@ -77,11 +79,11 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                     return;
                 }
 
-                // Gate 2: Must have opted into multithreaded support
-                bool isMultiThreadable =
-                    (iMultiThreadableTaskType is not null && ImplementsInterface(namedType, iMultiThreadableTaskType)) ||
-                    (multiThreadableTaskAttributeType is not null && namedType.GetAttributes().Any(
-                        attr => SymbolEqualityComparer.Default.Equals(attr.AttributeClass, multiThreadableTaskAttributeType)));
+                // Gate 2: Must have opted into multithreaded support via the attribute applied
+                // directly to this type. GetAttributes() returns only directly-applied attributes,
+                // which matches the attribute's Inherited = false semantics.
+                bool isMultiThreadable = namedType.GetAttributes().Any(
+                    attr => SymbolEqualityComparer.Default.Equals(attr.AttributeClass, multiThreadableTaskAttributeType));
 
                 if (!isMultiThreadable)
                 {
@@ -93,7 +95,11 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                 // Collect ITaskItem/ITaskItem[]-typed task input properties (candidates for MSBuildTask0007)
                 var taskItemInputProps = new HashSet<IPropertySymbol>(SymbolEqualityComparer.Default);
 
-                foreach (var member in namedType.GetMembers().OfType<IPropertySymbol>())
+                // Enumerate input properties declared on this type and all base types (most-derived
+                // first). A task can declare its ITaskItem/string inputs on a base class, so limiting
+                // to namedType.GetMembers() would miss them. Properties hidden or overridden in a more
+                // derived type are processed once, via their most-derived declaration.
+                foreach (var member in GetPropertiesIncludingBaseTypes(namedType))
                 {
                     if (member.DeclaredAccessibility != Accessibility.Public)
                     {

--- a/src/TaskAnalyzer/PreferTypedParameterAnalyzer.cs
+++ b/src/TaskAnalyzer/PreferTypedParameterAnalyzer.cs
@@ -532,15 +532,18 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
         }
 
         /// <summary>
-        /// Determines the parsed target type from a Parse/TryParse/Convert method call.
+        /// Determines the parsed target type from a Parse/Convert method call.
         /// Returns the simple type name suitable for ITaskItem&lt;T&gt; suggestion, or null if not a recognized parse call.
         /// Only returns suggestions for types supported by ValueTypeParser.
         /// </summary>
         private static string? GetParsedTypeFromMethod(IMethodSymbol method)
         {
-            // Static Parse/TryParse on value types: int.Parse, bool.Parse, etc.
+            // Static Parse on value types: int.Parse, bool.Parse, etc.
+            // TryParse is deliberately excluded: it is defensive (bool result + out parameter), the suggested
+            // ITaskItem<T> would change error handling to a bind-time throw, and its multi-argument shape is
+            // never rewritable by the code fix, so flagging it would only produce unfixable false positives.
             // Restrict to types supported by ValueTypeParser to avoid suggesting unsupported types like Guid.
-            if ((method.Name == "Parse" || method.Name == "TryParse") &&
+            if (method.Name == "Parse" &&
                 method.IsStatic &&
                 method.ContainingType is not null &&
                 method.ContainingType.IsValueType)

--- a/src/TaskAnalyzer/PreferTypedParameterAnalyzer.cs
+++ b/src/TaskAnalyzer/PreferTypedParameterAnalyzer.cs
@@ -6,6 +6,8 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Operations;
 
@@ -26,7 +28,8 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
             ImmutableArray.Create(
                 DiagnosticDescriptors.PreferTypedPathParameter,
-                DiagnosticDescriptors.PreferTypedTaskItem);
+                DiagnosticDescriptors.PreferTypedTaskItem,
+                DiagnosticDescriptors.InitializeRelativeDefaultInExecute);
 
         // Structured metadata carried on each diagnostic so deduplication can reason over the
         // inferred property and suggested type without parsing the human-readable message.
@@ -169,6 +172,8 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                         }
                     }
 
+                    // First, determine which path/item diagnostics survive the type-resolution dedup.
+                    var surviving = new List<Diagnostic>();
                     foreach (var diag in diagnosticsList.OrderBy(d => d.Location.SourceSpan.Start))
                     {
                         if (TryGetDiagnosticKey(diag, out string key, out string suggestedType) &&
@@ -193,7 +198,48 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                             }
                         }
 
+                        surviving.Add(diag);
+                    }
+
+                    // A path property (MSBuildTask0006) with a relative default cannot be rooted in a property
+                    // initializer, so instead of the 0006 "retype" suggestion (whose fix is inapplicable here)
+                    // we redirect it to MSBuildTask0008: initialize the property in Execute() where
+                    // TaskEnvironment is available. Record such properties, keyed by name, with the resolved type.
+                    var relativeDefaultProps = new Dictionary<string, (IPropertySymbol Property, string ResolvedType, Location Location)>(System.StringComparer.Ordinal);
+                    foreach (var diag in surviving)
+                    {
+                        if (diag.Id != DiagnosticIds.PreferTypedPathParameter ||
+                            !diag.Properties.TryGetValue(PropertyNameKey, out var propName) || propName is null ||
+                            !diag.Properties.TryGetValue(SuggestedTypeKey, out var suggestedType) || suggestedType is null ||
+                            relativeDefaultProps.ContainsKey(propName))
+                        {
+                            continue;
+                        }
+
+                        var propSymbol = stringInputProps.FirstOrDefault(p => p.Name == propName);
+                        if (propSymbol is not null &&
+                            TryGetRelativeDefaultInitializerLocation(propSymbol, endCtx.CancellationToken, out Location initializerLocation))
+                        {
+                            relativeDefaultProps[propName] = (propSymbol, suggestedType, initializerLocation);
+                        }
+                    }
+
+                    foreach (var diag in surviving)
+                    {
+                        // Suppress the 0006 diagnostics for properties redirected to 0008.
+                        if (diag.Id == DiagnosticIds.PreferTypedPathParameter &&
+                            diag.Properties.TryGetValue(PropertyNameKey, out var pn) && pn is not null &&
+                            relativeDefaultProps.ContainsKey(pn))
+                        {
+                            continue;
+                        }
+
                         endCtx.ReportDiagnostic(diag);
+                    }
+
+                    foreach (var entry in relativeDefaultProps.Values)
+                    {
+                        endCtx.ReportDiagnostic(CreateMoveDefaultDiagnostic(entry.Location, entry.Property.Name, entry.ResolvedType));
                     }
                 });
             }, SymbolKind.NamedType);
@@ -238,6 +284,50 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
             key = string.Empty;
             suggestedType = string.Empty;
             return false;
+        }
+
+        /// <summary>
+        /// If <paramref name="property"/> has exactly one declaration whose initializer is a string literal
+        /// holding a relative path, returns true and sets <paramref name="location"/> to the initializer value's
+        /// location. Such defaults cannot be rooted in a property initializer and are redirected to
+        /// MSBuildTask0008. Only plain string literals are considered (the realistic default form); other
+        /// initializer shapes leave the property on the standard 0006 path.
+        /// </summary>
+        private static bool TryGetRelativeDefaultInitializerLocation(
+            IPropertySymbol property,
+            System.Threading.CancellationToken cancellationToken,
+            out Location location)
+        {
+            location = Location.None;
+
+            if (property.DeclaringSyntaxReferences.Length != 1 ||
+                property.DeclaringSyntaxReferences[0].GetSyntax(cancellationToken) is not PropertyDeclarationSyntax declaration ||
+                declaration.Initializer?.Value is not LiteralExpressionSyntax literal ||
+                !literal.IsKind(SyntaxKind.StringLiteralExpression))
+            {
+                return false;
+            }
+
+            if (PathDefaultClassifier.IsRelativePathDefault(literal.Token.ValueText))
+            {
+                location = literal.GetLocation();
+                return true;
+            }
+
+            return false;
+        }
+
+        private static Diagnostic CreateMoveDefaultDiagnostic(Location location, string propertyName, string suggestedType)
+        {
+            var properties = ImmutableDictionary<string, string?>.Empty
+                .Add(PropertyNameKey, propertyName)
+                .Add(SuggestedTypeKey, suggestedType);
+
+            return Diagnostic.Create(
+                DiagnosticDescriptors.InitializeRelativeDefaultInExecute,
+                location,
+                properties,
+                propertyName, suggestedType);
         }
 
         private static Diagnostic CreatePathDiagnostic(Location location, string propertyName, string suggestedType)
@@ -494,38 +584,38 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                 }
             }
 
-            // Path.Combine(...) — any argument tracing to a task input property indicates that
-            // property is used to build an absolute path, regardless of its position in the call.
+            // Path.Combine(...) — only the FIRST argument is safe to suggest as an absolute path.
+            // Path.Combine restarts from the last rooted segment: if any argument after the first is an
+            // absolute (rooted) path, all preceding segments are discarded. Retyping a non-first argument
+            // to AbsolutePath would normalize it to a rooted path and silently change the result
+            // (e.g. Path.Combine("C:\\base", "sub") == "C:\\base\\sub", but if "sub" becomes rooted the
+            // result changes to that rooted path). The first argument is always the base, so typing it as
+            // an absolute path preserves the combine semantics.
             if (method.ContainingType?.ToDisplayString() == "System.IO.Path" &&
                 method.Name == "Combine" &&
                 invocation.Arguments.Length >= 2)
             {
-                var flaggedStringProps = new HashSet<IPropertySymbol>(SymbolEqualityComparer.Default);
-                var flaggedItemProps = new HashSet<IPropertySymbol>(SymbolEqualityComparer.Default);
+                IOperation firstArg = invocation.Arguments[0].Value;
 
-                foreach (var arg in invocation.Arguments)
+                // MSBuildTask0006: Path.Combine(stringProp, ...)
+                if (stringInputProps.Count > 0)
                 {
-                    // MSBuildTask0006: Path.Combine(..., stringProp, ...)
-                    if (stringInputProps.Count > 0)
+                    var sourceProp = FindSourceProperty(firstArg, stringInputProps);
+                    if (sourceProp is not null)
                     {
-                        var sourceProp = FindSourceProperty(arg.Value, stringInputProps);
-                        if (sourceProp is not null && flaggedStringProps.Add(sourceProp))
-                        {
-                            pendingDiagnostics.Add(CreatePathDiagnostic(
-                                invocation.Syntax.GetLocation(), sourceProp.Name, "AbsolutePath"));
-                            continue;
-                        }
+                        pendingDiagnostics.Add(CreatePathDiagnostic(
+                            invocation.Syntax.GetLocation(), sourceProp.Name, "AbsolutePath"));
                     }
+                }
 
-                    // MSBuildTask0007: Path.Combine(..., item.ItemSpec, ...)
-                    if (taskItemInputProps.Count > 0 && iTaskItemType is not null)
+                // MSBuildTask0007: Path.Combine(item.ItemSpec, ...)
+                if (taskItemInputProps.Count > 0 && iTaskItemType is not null)
+                {
+                    var (itemProp, _) = FindItemSpecSource(firstArg, taskItemInputProps, iTaskItemType);
+                    if (itemProp is not null)
                     {
-                        var (itemProp, _) = FindItemSpecSource(arg.Value, taskItemInputProps, iTaskItemType);
-                        if (itemProp is not null && flaggedItemProps.Add(itemProp))
-                        {
-                            pendingDiagnostics.Add(CreateItemDiagnostic(
-                                invocation.Syntax.GetLocation(), itemProp.Name, itemProp.Type is IArrayTypeSymbol, "AbsolutePath"));
-                        }
+                        pendingDiagnostics.Add(CreateItemDiagnostic(
+                            invocation.Syntax.GetLocation(), itemProp.Name, itemProp.Type is IArrayTypeSymbol, "AbsolutePath"));
                     }
                 }
             }
@@ -737,7 +827,9 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
         }
 
         /// <summary>
-        /// Direct check: is this operation item.ItemSpec where item traces to a task property?
+        /// Direct check: is this operation <c>item.ItemSpec</c> or <c>item.GetMetadata("FullPath")</c> where
+        /// item traces to a task property? <c>GetMetadata("FullPath")</c> is the documented way to obtain an
+        /// item's absolute path, so it is treated the same as reading the item's path directly.
         /// </summary>
         private static (IPropertySymbol? sourceProp, bool fromArray) FindItemSpecSourceDirect(
             IOperation operation,
@@ -764,6 +856,23 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                     {
                         return FindTaskItemPropertySource(receiver, taskItemInputProps);
                     }
+                }
+            }
+
+            // Check for item.GetMetadata("FullPath") — the documented way to get an item's absolute path.
+            if (operation is IInvocationOperation getMetadataCall &&
+                getMetadataCall.TargetMethod.Name == "GetMetadata" &&
+                getMetadataCall.Arguments.Length == 1 &&
+                getMetadataCall.Instance is IOperation metadataReceiver &&
+                getMetadataCall.Arguments[0].Value.ConstantValue is { HasValue: true, Value: string metadataName } &&
+                string.Equals(metadataName, "FullPath", System.StringComparison.OrdinalIgnoreCase))
+            {
+                var receiverType = getMetadataCall.TargetMethod.ContainingType;
+                if (receiverType is not null &&
+                    (SymbolEqualityComparer.Default.Equals(receiverType, iTaskItemType) ||
+                     ImplementsInterface(receiverType, iTaskItemType)))
+                {
+                    return FindTaskItemPropertySource(metadataReceiver, taskItemInputProps);
                 }
             }
 

--- a/src/TaskAnalyzer/PreferTypedParameterAnalyzer.cs
+++ b/src/TaskAnalyzer/PreferTypedParameterAnalyzer.cs
@@ -233,11 +233,13 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                     var (sourceProp, _) = FindItemSpecSource(creation.Arguments[0].Value, taskItemInputProps, iTaskItemType);
                     if (sourceProp is not null)
                     {
-                        string currentType = sourceProp.Type is IArrayTypeSymbol ? "ITaskItem[]" : "ITaskItem";
+                        bool isArray = sourceProp.Type is IArrayTypeSymbol;
+                        string currentType = isArray ? "ITaskItem[]" : "ITaskItem";
+                        string suggested = isArray ? suggestedTypeArg + "[]" : suggestedTypeArg;
                         context.ReportDiagnostic(Diagnostic.Create(
                             DiagnosticDescriptors.PreferTypedTaskItem,
                             creation.Syntax.GetLocation(),
-                            sourceProp.Name, currentType, suggestedTypeArg));
+                            sourceProp.Name, currentType, suggested));
                         return;
                     }
 
@@ -248,11 +250,13 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                             creation.Arguments[0].Value, taskItemInputProps, iTaskItemType, taskEnvironmentType);
                         if (itemProp is not null)
                         {
-                            string currentType = itemProp.Type is IArrayTypeSymbol ? "ITaskItem[]" : "ITaskItem";
+                            bool isArray = itemProp.Type is IArrayTypeSymbol;
+                            string currentType = isArray ? "ITaskItem[]" : "ITaskItem";
+                            string suggested = isArray ? suggestedTypeArg + "[]" : suggestedTypeArg;
                             context.ReportDiagnostic(Diagnostic.Create(
                                 DiagnosticDescriptors.PreferTypedTaskItem,
                                 creation.Syntax.GetLocation(),
-                                itemProp.Name, currentType, suggestedTypeArg));
+                                itemProp.Name, currentType, suggested));
                         }
                     }
                 }
@@ -310,11 +314,13 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                     var (sourceProp, _) = FindItemSpecSource(invocation.Arguments[0].Value, taskItemInputProps, iTaskItemType);
                     if (sourceProp is not null)
                     {
-                        string currentType = sourceProp.Type is IArrayTypeSymbol ? "ITaskItem[]" : "ITaskItem";
+                        bool isArray = sourceProp.Type is IArrayTypeSymbol;
+                        string currentType = isArray ? "ITaskItem[]" : "ITaskItem";
+                        string suggested = isArray ? suggestedTypeArg + "[]" : suggestedTypeArg;
                         context.ReportDiagnostic(Diagnostic.Create(
                             DiagnosticDescriptors.PreferTypedTaskItem,
                             invocation.Syntax.GetLocation(),
-                            sourceProp.Name, currentType, suggestedTypeArg));
+                            sourceProp.Name, currentType, suggested));
                     }
                 }
             }
@@ -346,11 +352,13 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                         var (itemProp, _) = FindItemSpecSource(arg.Value, taskItemInputProps, iTaskItemType);
                         if (itemProp is not null)
                         {
-                            string currentType = itemProp.Type is IArrayTypeSymbol ? "ITaskItem[]" : "ITaskItem";
+                            bool isArray = itemProp.Type is IArrayTypeSymbol;
+                            string currentType = isArray ? "ITaskItem[]" : "ITaskItem";
+                            string suggested = isArray ? "AbsolutePath[]" : "AbsolutePath";
                             context.ReportDiagnostic(Diagnostic.Create(
                                 DiagnosticDescriptors.PreferTypedTaskItem,
                                 invocation.Syntax.GetLocation(),
-                                itemProp.Name, currentType, "AbsolutePath"));
+                                itemProp.Name, currentType, suggested));
                             break;
                         }
                     }

--- a/src/TaskAnalyzer/PreferTypedParameterAnalyzer.cs
+++ b/src/TaskAnalyzer/PreferTypedParameterAnalyzer.cs
@@ -255,6 +255,16 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
             {
                 // Check for Type.Parse(item.ItemSpec) and Convert.ToType(item.ItemSpec)
                 string? suggestedTypeArg = GetParsedTypeFromMethod(method);
+
+                // Check for TaskEnvironment.GetAbsolutePath(item.ItemSpec)
+                if (suggestedTypeArg is null &&
+                    taskEnvironmentType is not null &&
+                    method.Name == "GetAbsolutePath" &&
+                    SymbolEqualityComparer.Default.Equals(method.ContainingType, taskEnvironmentType))
+                {
+                    suggestedTypeArg = "AbsolutePath";
+                }
+
                 if (suggestedTypeArg is not null)
                 {
                     var (sourceProp, _) = FindItemSpecSource(invocation.Arguments[0].Value, taskItemInputProps, iTaskItemType);

--- a/src/TaskAnalyzer/PreferTypedParameterAnalyzer.cs
+++ b/src/TaskAnalyzer/PreferTypedParameterAnalyzer.cs
@@ -418,6 +418,48 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
             return null;
         }
 
+        /// <summary>
+        /// Reports an AbsolutePath/FileInfo/DirectoryInfo suggestion (MSBuildTask0006) for every distinct string
+        /// task input property whose raw value flows into a path-like argument of a System.IO consumption site
+        /// (e.g. <c>File.Delete(prop)</c>, <c>new FileStream(prop, ...)</c>). Arguments that are already safely
+        /// wrapped (e.g. <c>GetAbsolutePath(prop)</c>, <c>new AbsolutePath(prop)</c>) are skipped — those are the
+        /// resolved forms already handled by the other 0006 branches.
+        /// </summary>
+        private static void ReportStringPathConsumers(
+            ConcurrentBag<Diagnostic> pendingDiagnostics,
+            ImmutableArray<IArgumentOperation> arguments,
+            Location location,
+            string suggestedType,
+            HashSet<IPropertySymbol> stringInputProps,
+            INamedTypeSymbol? taskEnvironmentType,
+            INamedTypeSymbol? absolutePathType,
+            INamedTypeSymbol? iTaskItemType)
+        {
+            var flagged = new HashSet<IPropertySymbol>(SymbolEqualityComparer.Default);
+            foreach (var arg in arguments)
+            {
+                if (arg.Parameter is null ||
+                    arg.Parameter.Type.SpecialType != SpecialType.System_String ||
+                    !IsPathParameterName(arg.Parameter.Name))
+                {
+                    continue;
+                }
+
+                // Only raw (unwrapped) string arguments represent the daisy-chain scenario. A safely-wrapped
+                // argument is either already correct or covered by the existing 0006 conversion branches.
+                if (IsWrappedSafely(arg.Value, taskEnvironmentType, absolutePathType, iTaskItemType))
+                {
+                    continue;
+                }
+
+                var sourceProp = FindSourceProperty(arg.Value, stringInputProps);
+                if (sourceProp is not null && flagged.Add(sourceProp))
+                {
+                    pendingDiagnostics.Add(CreatePathDiagnostic(location, sourceProp.Name, suggestedType));
+                }
+            }
+        }
+
         private static void AnalyzeObjectCreation(
             ConcurrentBag<Diagnostic> pendingDiagnostics,
             IObjectCreationOperation creation,
@@ -516,6 +558,18 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                         "FileInfo", taskItemInputProps, iTaskItemType, taskEnvironmentType);
                 }
             }
+
+            // MSBuildTask0006: new FileStream/StreamReader/StreamWriter(stringProp) consuming a raw string => FileInfo.
+            // Mirrors the ITaskItem consumption above so a raw string path property gets the same one-shot retype.
+            if (stringInputProps.Count > 0)
+            {
+                string createdTypeName = createdType.ToDisplayString();
+                if (createdTypeName is "System.IO.FileStream" or "System.IO.StreamReader" or "System.IO.StreamWriter")
+                {
+                    ReportStringPathConsumers(pendingDiagnostics, creation.Arguments, creation.Syntax.GetLocation(),
+                        "FileInfo", stringInputProps, taskEnvironmentType, absolutePathType, iTaskItemType);
+                }
+            }
         }
 
         private static void AnalyzeInvocation(
@@ -536,6 +590,23 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                 taskEnvironmentType is not null &&
                 method.Name == "GetAbsolutePath" &&
                 SymbolEqualityComparer.Default.Equals(method.ContainingType, taskEnvironmentType) &&
+                invocation.Arguments.Length > 0)
+            {
+                var sourceProp = FindSourceProperty(invocation.Arguments[0].Value, stringInputProps);
+                if (sourceProp is not null)
+                {
+                    pendingDiagnostics.Add(CreatePathDiagnostic(
+                        invocation.Syntax.GetLocation(), sourceProp.Name, "AbsolutePath"));
+                    return;
+                }
+            }
+
+            // MSBuildTask0006: Path.GetFullPath(stringProp). This is the raw normalization pattern that
+            // MSBuildTask0002 also flags; surfacing it here too lets the user retype the property in one shot
+            // instead of first applying the 0002 fix (which introduces a conversion) and only then seeing 0006.
+            if (stringInputProps.Count > 0 &&
+                method.Name == "GetFullPath" &&
+                method.ContainingType?.ToDisplayString() == "System.IO.Path" &&
                 invocation.Arguments.Length > 0)
             {
                 var sourceProp = FindSourceProperty(invocation.Arguments[0].Value, stringInputProps);
@@ -587,6 +658,25 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                 {
                     ReportPathConsumers(pendingDiagnostics, invocation.Arguments, invocation.Syntax.GetLocation(),
                         consumerType, taskItemInputProps, iTaskItemType, taskEnvironmentType);
+                }
+            }
+
+            // MSBuildTask0006: File.X(path)/Directory.X(path) consuming a raw string property => FileInfo/DirectoryInfo.
+            // This is the raw consumption pattern that MSBuildTask0003 flags; surfacing it here as well lets the
+            // user retype the property in one shot instead of daisy-chaining through the 0003 fix first.
+            if (stringInputProps.Count > 0 && invocation.Arguments.Length > 0)
+            {
+                string? consumerType = method.ContainingType?.ToDisplayString() switch
+                {
+                    "System.IO.File" => "FileInfo",
+                    "System.IO.Directory" => "DirectoryInfo",
+                    _ => null
+                };
+
+                if (consumerType is not null)
+                {
+                    ReportStringPathConsumers(pendingDiagnostics, invocation.Arguments, invocation.Syntax.GetLocation(),
+                        consumerType, stringInputProps, taskEnvironmentType, absolutePathType, iTaskItemType);
                 }
             }
 

--- a/src/TaskAnalyzer/PreferTypedParameterAnalyzer.cs
+++ b/src/TaskAnalyzer/PreferTypedParameterAnalyzer.cs
@@ -284,8 +284,8 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                 compilation.GetTypeByMetadataName(WellKnownTypeNames.TaskEnvironmentFullName),
                 compilation.GetTypeByMetadataName(WellKnownTypeNames.ITaskItemFullName),
                 compilation.GetTypeByMetadataName(WellKnownTypeNames.OutputAttributeFullName),
-                compilation.GetTypeByMetadataName("System.IO.FileInfo"),
-                compilation.GetTypeByMetadataName("System.IO.DirectoryInfo"));
+                compilation.GetTypeByMetadataName(WellKnownTypeNames.FileInfoFullName),
+                compilation.GetTypeByMetadataName(WellKnownTypeNames.DirectoryInfoFullName));
             return true;
         }
 

--- a/src/TaskAnalyzer/PreferTypedParameterAnalyzer.cs
+++ b/src/TaskAnalyzer/PreferTypedParameterAnalyzer.cs
@@ -163,18 +163,18 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                     //   - both FileInfo AND DirectoryInfo     => suppress the specifics, fall back to AbsolutePath
                     var diagnosticsList = pendingDiagnostics.ToList();
 
-                    var suggestedTypesByProp = new Dictionary<string, HashSet<string>>(System.StringComparer.Ordinal);
+                    var suggestedTypesByPropertyKey = new Dictionary<string, HashSet<string>>(System.StringComparer.Ordinal);
                     foreach (var diag in diagnosticsList)
                     {
-                        if (TryGetDiagnosticKey(diag, out string key, out string suggestedType))
+                        if (TryGetDiagnosticKey(diag, out string propertyKey, out string suggestedType))
                         {
-                            if (!suggestedTypesByProp.TryGetValue(key, out var set))
+                            if (!suggestedTypesByPropertyKey.TryGetValue(propertyKey, out var suggestedTypes))
                             {
-                                set = new HashSet<string>(System.StringComparer.Ordinal);
-                                suggestedTypesByProp[key] = set;
+                                suggestedTypes = new HashSet<string>(System.StringComparer.Ordinal);
+                                suggestedTypesByPropertyKey[propertyKey] = suggestedTypes;
                             }
 
-                            set.Add(suggestedType);
+                            suggestedTypes.Add(suggestedType);
                         }
                     }
 
@@ -182,12 +182,12 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                     var surviving = new List<Diagnostic>();
                     foreach (var diag in diagnosticsList.OrderBy(d => d.Location.SourceSpan.Start))
                     {
-                        if (TryGetDiagnosticKey(diag, out string key, out string suggestedType) &&
-                            suggestedTypesByProp.TryGetValue(key, out var set))
+                        if (TryGetDiagnosticKey(diag, out string propertyKey, out string suggestedType) &&
+                            suggestedTypesByPropertyKey.TryGetValue(propertyKey, out var suggestedTypes))
                         {
-                            bool hasFile = set.Contains("FileInfo");
-                            bool hasDir = set.Contains("DirectoryInfo");
-                            bool hasAbsolutePath = set.Contains("AbsolutePath");
+                            bool hasFile = suggestedTypes.Contains("FileInfo");
+                            bool hasDir = suggestedTypes.Contains("DirectoryInfo");
+                            bool hasAbsolutePath = suggestedTypes.Contains("AbsolutePath");
 
                             if (suggestedType == "AbsolutePath")
                             {
@@ -292,17 +292,17 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
             }
         }
 
-        private static bool TryGetDiagnosticKey(Diagnostic diagnostic, out string key, out string suggestedType)
+        private static bool TryGetDiagnosticKey(Diagnostic diagnostic, out string propertyKey, out string suggestedType)
         {
             if (diagnostic.Properties.TryGetValue(PropertyNameKey, out var propName) && propName is not null &&
                 diagnostic.Properties.TryGetValue(SuggestedTypeKey, out var type) && type is not null)
             {
-                key = diagnostic.Id + "|" + propName;
+                propertyKey = diagnostic.Id + "|" + propName;
                 suggestedType = type;
                 return true;
             }
 
-            key = string.Empty;
+            propertyKey = string.Empty;
             suggestedType = string.Empty;
             return false;
         }

--- a/src/TaskAnalyzer/PreferTypedParameterAnalyzer.cs
+++ b/src/TaskAnalyzer/PreferTypedParameterAnalyzer.cs
@@ -28,6 +28,11 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                 DiagnosticDescriptors.PreferTypedPathParameter,
                 DiagnosticDescriptors.PreferTypedTaskItem);
 
+        // Structured metadata carried on each diagnostic so deduplication can reason over the
+        // inferred property and suggested type without parsing the human-readable message.
+        private const string PropertyNameKey = "PropertyName";
+        private const string SuggestedTypeKey = "SuggestedType";
+
         public override void Initialize(AnalysisContext context)
         {
             context.EnableConcurrentExecution();
@@ -143,49 +148,48 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
 
                 symbolStartContext.RegisterSymbolEndAction(endCtx =>
                 {
-                    // Group diagnostics by property name + rule ID, then suppress AbsolutePath
-                    // suggestions when a FileInfo/DirectoryInfo suggestion exists for the same property.
+                    // Group diagnostics by property name + rule ID using structured metadata,
+                    // then resolve AbsolutePath vs FileInfo/DirectoryInfo overlaps:
+                    //   - exactly one specific type inferred  => suppress AbsolutePath, keep the specific type
+                    //   - both FileInfo AND DirectoryInfo     => suppress the specifics, fall back to AbsolutePath
                     var diagnosticsList = pendingDiagnostics.ToList();
 
-                    // Find properties that have FileInfo or DirectoryInfo suggestions
-                    var propsWithSpecificType = new HashSet<string>();
+                    var suggestedTypesByProp = new Dictionary<string, HashSet<string>>(System.StringComparer.Ordinal);
                     foreach (var diag in diagnosticsList)
                     {
-                        string message = diag.GetMessage();
-                        if (message.Contains("FileInfo") || message.Contains("DirectoryInfo"))
+                        if (TryGetDiagnosticKey(diag, out string key, out string suggestedType))
                         {
-                            // Extract property name from message format: "... property '{0}' from ..."
-                            int startIdx = message.IndexOf('\'');
-                            if (startIdx >= 0)
+                            if (!suggestedTypesByProp.TryGetValue(key, out var set))
                             {
-                                int endIdx = message.IndexOf('\'', startIdx + 1);
-                                if (endIdx > startIdx)
-                                {
-                                    string propName = message.Substring(startIdx + 1, endIdx - startIdx - 1);
-                                    propsWithSpecificType.Add(diag.Id + "|" + propName);
-                                }
+                                set = new HashSet<string>(System.StringComparer.Ordinal);
+                                suggestedTypesByProp[key] = set;
                             }
+
+                            set.Add(suggestedType);
                         }
                     }
 
-                    foreach (var diag in diagnosticsList)
+                    foreach (var diag in diagnosticsList.OrderBy(d => d.Location.SourceSpan.Start))
                     {
-                        string message = diag.GetMessage();
-                        // Suppress AbsolutePath suggestions when FileInfo/DirectoryInfo exists for same property
-                        if (message.Contains("AbsolutePath") && propsWithSpecificType.Count > 0)
+                        if (TryGetDiagnosticKey(diag, out string key, out string suggestedType) &&
+                            suggestedTypesByProp.TryGetValue(key, out var set))
                         {
-                            int startIdx = message.IndexOf('\'');
-                            if (startIdx >= 0)
+                            bool hasFile = set.Contains("FileInfo");
+                            bool hasDir = set.Contains("DirectoryInfo");
+
+                            if (suggestedType == "AbsolutePath")
                             {
-                                int endIdx = message.IndexOf('\'', startIdx + 1);
-                                if (endIdx > startIdx)
+                                // Suppress when exactly one specific type was inferred (no file/dir conflict).
+                                if (hasFile ^ hasDir)
                                 {
-                                    string propName = message.Substring(startIdx + 1, endIdx - startIdx - 1);
-                                    if (propsWithSpecificType.Contains(diag.Id + "|" + propName))
-                                    {
-                                        continue; // Suppress — more specific type available
-                                    }
+                                    continue;
                                 }
+                            }
+                            else if ((suggestedType == "FileInfo" || suggestedType == "DirectoryInfo") &&
+                                     hasFile && hasDir && set.Contains("AbsolutePath"))
+                            {
+                                // Conflicting file/dir inference: prefer the AbsolutePath fallback.
+                                continue;
                             }
                         }
 
@@ -219,6 +223,103 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                         fileInfoType, directoryInfoType);
                     break;
             }
+        }
+
+        private static bool TryGetDiagnosticKey(Diagnostic diagnostic, out string key, out string suggestedType)
+        {
+            if (diagnostic.Properties.TryGetValue(PropertyNameKey, out var propName) && propName is not null &&
+                diagnostic.Properties.TryGetValue(SuggestedTypeKey, out var type) && type is not null)
+            {
+                key = diagnostic.Id + "|" + propName;
+                suggestedType = type;
+                return true;
+            }
+
+            key = string.Empty;
+            suggestedType = string.Empty;
+            return false;
+        }
+
+        private static Diagnostic CreatePathDiagnostic(Location location, string propertyName, string suggestedType)
+        {
+            var properties = ImmutableDictionary<string, string?>.Empty
+                .Add(PropertyNameKey, propertyName)
+                .Add(SuggestedTypeKey, suggestedType);
+
+            return Diagnostic.Create(
+                DiagnosticDescriptors.PreferTypedPathParameter,
+                location,
+                properties,
+                propertyName, "string", suggestedType);
+        }
+
+        private static Diagnostic CreateItemDiagnostic(Location location, string propertyName, bool isArray, string suggestedType)
+        {
+            var properties = ImmutableDictionary<string, string?>.Empty
+                .Add(PropertyNameKey, propertyName)
+                .Add(SuggestedTypeKey, suggestedType);
+
+            string currentType = isArray ? "ITaskItem[]" : "ITaskItem";
+            return Diagnostic.Create(
+                DiagnosticDescriptors.PreferTypedTaskItem,
+                location,
+                properties,
+                propertyName, currentType, suggestedType, isArray ? "[]" : "");
+        }
+
+        /// <summary>
+        /// Reports an <c>ITaskItem&lt;T&gt;</c> suggestion for every distinct task input property whose
+        /// ItemSpec (directly, or through an AbsolutePath intermediary) flows into a path-like argument of a
+        /// System.IO consumption site (e.g. <c>File.ReadAllLines(...)</c>, <c>Directory.CreateDirectory(...)</c>).
+        /// </summary>
+        private static void ReportPathConsumers(
+            ConcurrentBag<Diagnostic> pendingDiagnostics,
+            ImmutableArray<IArgumentOperation> arguments,
+            Location location,
+            string suggestedType,
+            HashSet<IPropertySymbol> taskItemInputProps,
+            INamedTypeSymbol iTaskItemType,
+            INamedTypeSymbol? taskEnvironmentType)
+        {
+            var flagged = new HashSet<IPropertySymbol>(SymbolEqualityComparer.Default);
+            foreach (var arg in arguments)
+            {
+                if (arg.Parameter is null || !IsPathParameterName(arg.Parameter.Name))
+                {
+                    continue;
+                }
+
+                var itemProp = FindPathConsumerSource(arg.Value, taskItemInputProps, iTaskItemType, taskEnvironmentType);
+                if (itemProp is not null && flagged.Add(itemProp))
+                {
+                    pendingDiagnostics.Add(CreateItemDiagnostic(
+                        location, itemProp.Name, itemProp.Type is IArrayTypeSymbol, suggestedType));
+                }
+            }
+        }
+
+        /// <summary>
+        /// Traces a path argument back to a source ITaskItem property, either directly via
+        /// <c>item.ItemSpec</c> or through an AbsolutePath intermediary.
+        /// </summary>
+        private static IPropertySymbol? FindPathConsumerSource(
+            IOperation argument,
+            HashSet<IPropertySymbol> taskItemInputProps,
+            INamedTypeSymbol iTaskItemType,
+            INamedTypeSymbol? taskEnvironmentType)
+        {
+            var (direct, _) = FindItemSpecSource(argument, taskItemInputProps, iTaskItemType);
+            if (direct is not null)
+            {
+                return direct;
+            }
+
+            if (taskEnvironmentType is not null)
+            {
+                return FindItemSpecSourceThroughAbsolutePath(argument, taskItemInputProps, iTaskItemType, taskEnvironmentType);
+            }
+
+            return null;
         }
 
         private static void AnalyzeObjectCreation(
@@ -260,10 +361,8 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                     var sourceProp = FindSourceProperty(creation.Arguments[0].Value, stringInputProps);
                     if (sourceProp is not null)
                     {
-                        pendingDiagnostics.Add(Diagnostic.Create(
-                            DiagnosticDescriptors.PreferTypedPathParameter,
-                            creation.Syntax.GetLocation(),
-                            sourceProp.Name, "string", suggestedType));
+                        pendingDiagnostics.Add(CreatePathDiagnostic(
+                            creation.Syntax.GetLocation(), sourceProp.Name, suggestedType));
                         return;
                     }
                 }
@@ -292,12 +391,8 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                     var (sourceProp, _) = FindItemSpecSource(creation.Arguments[0].Value, taskItemInputProps, iTaskItemType);
                     if (sourceProp is not null)
                     {
-                        bool isArray = sourceProp.Type is IArrayTypeSymbol;
-                        string currentType = isArray ? "ITaskItem[]" : "ITaskItem";
-                        pendingDiagnostics.Add(Diagnostic.Create(
-                            DiagnosticDescriptors.PreferTypedTaskItem,
-                            creation.Syntax.GetLocation(),
-                            sourceProp.Name, currentType, suggestedTypeArg, isArray ? "[]" : ""));
+                        pendingDiagnostics.Add(CreateItemDiagnostic(
+                            creation.Syntax.GetLocation(), sourceProp.Name, sourceProp.Type is IArrayTypeSymbol, suggestedTypeArg));
                         return;
                     }
 
@@ -308,14 +403,21 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                             creation.Arguments[0].Value, taskItemInputProps, iTaskItemType, taskEnvironmentType);
                         if (itemProp is not null)
                         {
-                            bool isArray = itemProp.Type is IArrayTypeSymbol;
-                            string currentType = isArray ? "ITaskItem[]" : "ITaskItem";
-                            pendingDiagnostics.Add(Diagnostic.Create(
-                                DiagnosticDescriptors.PreferTypedTaskItem,
-                                creation.Syntax.GetLocation(),
-                                itemProp.Name, currentType, suggestedTypeArg, isArray ? "[]" : ""));
+                            pendingDiagnostics.Add(CreateItemDiagnostic(
+                                creation.Syntax.GetLocation(), itemProp.Name, itemProp.Type is IArrayTypeSymbol, suggestedTypeArg));
                         }
                     }
+                }
+            }
+
+            // MSBuildTask0007: new FileStream/StreamReader/StreamWriter(item.ItemSpec) consuming an ItemSpec => FileInfo
+            if (taskItemInputProps.Count > 0 && iTaskItemType is not null)
+            {
+                string createdTypeName = createdType.ToDisplayString();
+                if (createdTypeName is "System.IO.FileStream" or "System.IO.StreamReader" or "System.IO.StreamWriter")
+                {
+                    ReportPathConsumers(pendingDiagnostics, creation.Arguments, creation.Syntax.GetLocation(),
+                        "FileInfo", taskItemInputProps, iTaskItemType, taskEnvironmentType);
                 }
             }
         }
@@ -343,10 +445,8 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                 var sourceProp = FindSourceProperty(invocation.Arguments[0].Value, stringInputProps);
                 if (sourceProp is not null)
                 {
-                    pendingDiagnostics.Add(Diagnostic.Create(
-                        DiagnosticDescriptors.PreferTypedPathParameter,
-                        invocation.Syntax.GetLocation(),
-                        sourceProp.Name, "string", "AbsolutePath"));
+                    pendingDiagnostics.Add(CreatePathDiagnostic(
+                        invocation.Syntax.GetLocation(), sourceProp.Name, "AbsolutePath"));
                     return;
                 }
             }
@@ -371,50 +471,60 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                     var (sourceProp, _) = FindItemSpecSource(invocation.Arguments[0].Value, taskItemInputProps, iTaskItemType);
                     if (sourceProp is not null)
                     {
-                        bool isArray = sourceProp.Type is IArrayTypeSymbol;
-                        string currentType = isArray ? "ITaskItem[]" : "ITaskItem";
-                        pendingDiagnostics.Add(Diagnostic.Create(
-                            DiagnosticDescriptors.PreferTypedTaskItem,
-                            invocation.Syntax.GetLocation(),
-                            sourceProp.Name, currentType, suggestedTypeArg, isArray ? "[]" : ""));
+                        pendingDiagnostics.Add(CreateItemDiagnostic(
+                            invocation.Syntax.GetLocation(), sourceProp.Name, sourceProp.Type is IArrayTypeSymbol, suggestedTypeArg));
                     }
                 }
             }
 
-            // Path.Combine(...) with any argument tracing to a task input property
+            // MSBuildTask0007: File.X(path)/Directory.X(path) consuming an ItemSpec => FileInfo/DirectoryInfo
+            if (taskItemInputProps.Count > 0 && iTaskItemType is not null && invocation.Arguments.Length > 0)
+            {
+                string? consumerType = method.ContainingType?.ToDisplayString() switch
+                {
+                    "System.IO.File" => "FileInfo",
+                    "System.IO.Directory" => "DirectoryInfo",
+                    _ => null
+                };
+
+                if (consumerType is not null)
+                {
+                    ReportPathConsumers(pendingDiagnostics, invocation.Arguments, invocation.Syntax.GetLocation(),
+                        consumerType, taskItemInputProps, iTaskItemType, taskEnvironmentType);
+                }
+            }
+
+            // Path.Combine(...) — any argument tracing to a task input property indicates that
+            // property is used to build an absolute path, regardless of its position in the call.
             if (method.ContainingType?.ToDisplayString() == "System.IO.Path" &&
                 method.Name == "Combine" &&
                 invocation.Arguments.Length >= 2)
             {
+                var flaggedStringProps = new HashSet<IPropertySymbol>(SymbolEqualityComparer.Default);
+                var flaggedItemProps = new HashSet<IPropertySymbol>(SymbolEqualityComparer.Default);
+
                 foreach (var arg in invocation.Arguments)
                 {
-                    // MSBuildTask0006: Path.Combine(stringProp, ...) or Path.Combine(..., stringProp)
+                    // MSBuildTask0006: Path.Combine(..., stringProp, ...)
                     if (stringInputProps.Count > 0)
                     {
                         var sourceProp = FindSourceProperty(arg.Value, stringInputProps);
-                        if (sourceProp is not null)
+                        if (sourceProp is not null && flaggedStringProps.Add(sourceProp))
                         {
-                            pendingDiagnostics.Add(Diagnostic.Create(
-                                DiagnosticDescriptors.PreferTypedPathParameter,
-                                invocation.Syntax.GetLocation(),
-                                sourceProp.Name, "string", "AbsolutePath"));
-                            break;
+                            pendingDiagnostics.Add(CreatePathDiagnostic(
+                                invocation.Syntax.GetLocation(), sourceProp.Name, "AbsolutePath"));
+                            continue;
                         }
                     }
 
-                    // MSBuildTask0007: Path.Combine(item.ItemSpec, ...) or Path.Combine(..., item.ItemSpec)
+                    // MSBuildTask0007: Path.Combine(..., item.ItemSpec, ...)
                     if (taskItemInputProps.Count > 0 && iTaskItemType is not null)
                     {
                         var (itemProp, _) = FindItemSpecSource(arg.Value, taskItemInputProps, iTaskItemType);
-                        if (itemProp is not null)
+                        if (itemProp is not null && flaggedItemProps.Add(itemProp))
                         {
-                            bool isArray = itemProp.Type is IArrayTypeSymbol;
-                            string currentType = isArray ? "ITaskItem[]" : "ITaskItem";
-                            pendingDiagnostics.Add(Diagnostic.Create(
-                                DiagnosticDescriptors.PreferTypedTaskItem,
-                                invocation.Syntax.GetLocation(),
-                                itemProp.Name, currentType, "AbsolutePath", isArray ? "[]" : ""));
-                            break;
+                            pendingDiagnostics.Add(CreateItemDiagnostic(
+                                invocation.Syntax.GetLocation(), itemProp.Name, itemProp.Type is IArrayTypeSymbol, "AbsolutePath"));
                         }
                     }
                 }
@@ -710,6 +820,14 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
             HashSet<IPropertySymbol> taskItemInputProps,
             INamedTypeSymbol iTaskItemType,
             INamedTypeSymbol taskEnvironmentType)
+            => FindItemSpecSourceThroughAbsolutePath(operation, taskItemInputProps, iTaskItemType, taskEnvironmentType, visitedLocals: null);
+
+        private static IPropertySymbol? FindItemSpecSourceThroughAbsolutePath(
+            IOperation operation,
+            HashSet<IPropertySymbol> taskItemInputProps,
+            INamedTypeSymbol iTaskItemType,
+            INamedTypeSymbol taskEnvironmentType,
+            HashSet<ILocalSymbol>? visitedLocals)
         {
             // Unwrap conversions
             while (operation is IConversionOperation conversion)
@@ -727,28 +845,94 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                 return sourceProp;
             }
 
-            // Local indirection: var abs = TaskEnvironment.GetAbsolutePath(item.ItemSpec); new FileInfo(abs);
+            // Local indirection. Handles both:
+            //   AbsolutePath abs = TaskEnvironment.GetAbsolutePath(item.ItemSpec); ... use abs ...
+            //   AbsolutePath? abs = null; try { abs = TaskEnvironment.GetAbsolutePath(item.ItemSpec); } ... use abs ...
             if (operation is ILocalReferenceOperation localRef)
             {
                 var local = localRef.Local;
-                if (local.DeclaringSyntaxReferences.Length == 1)
+
+                // Guard against cycles (e.g. self-referencing assignments).
+                visitedLocals ??= new HashSet<ILocalSymbol>(SymbolEqualityComparer.Default);
+                if (!visitedLocals.Add(local))
+                {
+                    return null;
+                }
+
+                // (a) Declaration initializer: AbsolutePath abs = GetAbsolutePath(item.ItemSpec);
+                if (local.DeclaringSyntaxReferences.Length == 1 && operation.SemanticModel is SemanticModel declModel)
                 {
                     var syntax = local.DeclaringSyntaxReferences[0].GetSyntax();
-                    var semanticModel = operation.SemanticModel;
-                    if (semanticModel is not null)
+                    if (declModel.GetOperation(syntax) is IVariableDeclaratorOperation declarator &&
+                        declarator.Initializer?.Value is IOperation initValue)
                     {
-                        var declOp = semanticModel.GetOperation(syntax);
-                        if (declOp is IVariableDeclaratorOperation declarator &&
-                            declarator.Initializer?.Value is IOperation initValue)
+                        var fromInitializer = FindItemSpecSourceThroughAbsolutePath(
+                            initValue, taskItemInputProps, iTaskItemType, taskEnvironmentType, visitedLocals);
+                        if (fromInitializer is not null)
                         {
-                            return FindItemSpecSourceThroughAbsolutePath(
-                                initValue, taskItemInputProps, iTaskItemType, taskEnvironmentType);
+                            return fromInitializer;
                         }
+                    }
+                }
+
+                // (b) A single unconditional assignment elsewhere in the method body.
+                return FindLocalAssignmentSource(localRef, local, taskItemInputProps, iTaskItemType, taskEnvironmentType, visitedLocals);
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Finds the ITaskItem source for a local that is assigned (rather than initialized) via
+        /// <c>local = TaskEnvironment.GetAbsolutePath(item.ItemSpec)</c>. Returns the source property only
+        /// when every resolvable assignment to the local maps to the same property; otherwise returns null
+        /// to stay conservative in the face of ambiguous data flow.
+        /// </summary>
+        private static IPropertySymbol? FindLocalAssignmentSource(
+            ILocalReferenceOperation localRef,
+            ILocalSymbol local,
+            HashSet<IPropertySymbol> taskItemInputProps,
+            INamedTypeSymbol iTaskItemType,
+            INamedTypeSymbol taskEnvironmentType,
+            HashSet<ILocalSymbol> visitedLocals)
+        {
+            if (localRef.SemanticModel is not SemanticModel semanticModel ||
+                local.ContainingSymbol is not IMethodSymbol method ||
+                method.DeclaringSyntaxReferences.Length != 1)
+            {
+                return null;
+            }
+
+            var methodSyntax = method.DeclaringSyntaxReferences[0].GetSyntax();
+            var methodOperation = semanticModel.GetOperation(methodSyntax);
+            if (methodOperation is null)
+            {
+                return null;
+            }
+
+            IPropertySymbol? found = null;
+            foreach (var descendant in methodOperation.Descendants())
+            {
+                if (descendant is ISimpleAssignmentOperation assignment &&
+                    assignment.Target is ILocalReferenceOperation targetRef &&
+                    SymbolEqualityComparer.Default.Equals(targetRef.Local, local))
+                {
+                    var prop = FindItemSpecSourceThroughAbsolutePath(
+                        assignment.Value, taskItemInputProps, iTaskItemType, taskEnvironmentType, visitedLocals);
+                    if (prop is not null)
+                    {
+                        if (found is not null && !SymbolEqualityComparer.Default.Equals(found, prop))
+                        {
+                            // The local is assigned from more than one distinct property — ambiguous.
+                            return null;
+                        }
+
+                        found = prop;
                     }
                 }
             }
 
-            return null;
+            return found;
         }
     }
 }

--- a/src/TaskAnalyzer/PreferTypedParameterAnalyzer.cs
+++ b/src/TaskAnalyzer/PreferTypedParameterAnalyzer.cs
@@ -235,11 +235,10 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                     {
                         bool isArray = sourceProp.Type is IArrayTypeSymbol;
                         string currentType = isArray ? "ITaskItem[]" : "ITaskItem";
-                        string suggested = isArray ? suggestedTypeArg + "[]" : suggestedTypeArg;
                         context.ReportDiagnostic(Diagnostic.Create(
                             DiagnosticDescriptors.PreferTypedTaskItem,
                             creation.Syntax.GetLocation(),
-                            sourceProp.Name, currentType, suggested));
+                            sourceProp.Name, currentType, suggestedTypeArg, isArray ? "[]" : ""));
                         return;
                     }
 
@@ -252,11 +251,10 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                         {
                             bool isArray = itemProp.Type is IArrayTypeSymbol;
                             string currentType = isArray ? "ITaskItem[]" : "ITaskItem";
-                            string suggested = isArray ? suggestedTypeArg + "[]" : suggestedTypeArg;
                             context.ReportDiagnostic(Diagnostic.Create(
                                 DiagnosticDescriptors.PreferTypedTaskItem,
                                 creation.Syntax.GetLocation(),
-                                itemProp.Name, currentType, suggested));
+                                itemProp.Name, currentType, suggestedTypeArg, isArray ? "[]" : ""));
                         }
                     }
                 }
@@ -316,11 +314,10 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                     {
                         bool isArray = sourceProp.Type is IArrayTypeSymbol;
                         string currentType = isArray ? "ITaskItem[]" : "ITaskItem";
-                        string suggested = isArray ? suggestedTypeArg + "[]" : suggestedTypeArg;
                         context.ReportDiagnostic(Diagnostic.Create(
                             DiagnosticDescriptors.PreferTypedTaskItem,
                             invocation.Syntax.GetLocation(),
-                            sourceProp.Name, currentType, suggested));
+                            sourceProp.Name, currentType, suggestedTypeArg, isArray ? "[]" : ""));
                     }
                 }
             }
@@ -354,11 +351,10 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                         {
                             bool isArray = itemProp.Type is IArrayTypeSymbol;
                             string currentType = isArray ? "ITaskItem[]" : "ITaskItem";
-                            string suggested = isArray ? "AbsolutePath[]" : "AbsolutePath";
                             context.ReportDiagnostic(Diagnostic.Create(
                                 DiagnosticDescriptors.PreferTypedTaskItem,
                                 invocation.Syntax.GetLocation(),
-                                itemProp.Name, currentType, suggested));
+                                itemProp.Name, currentType, "AbsolutePath", isArray ? "[]" : ""));
                             break;
                         }
                     }

--- a/src/TaskAnalyzer/PreferTypedParameterCodeFixProvider.cs
+++ b/src/TaskAnalyzer/PreferTypedParameterCodeFixProvider.cs
@@ -1,0 +1,547 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Editing;
+using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.CodeAnalysis.Simplification;
+
+namespace Microsoft.Build.TaskAuthoring.Analyzer
+{
+    /// <summary>
+    /// Code fixer for the strongly-typed task parameter analyzer.
+    /// Fixes:
+    /// - MSBuildTask0006: Retypes a string task property to AbsolutePath/FileInfo/DirectoryInfo and
+    ///   removes the now-redundant conversion at every use site.
+    /// - MSBuildTask0007: Retypes an ITaskItem/ITaskItem[] task property to ITaskItem&lt;T&gt;/ITaskItem&lt;T&gt;[]
+    ///   and replaces the manual ItemSpec parsing with the strongly-typed Value at every use site.
+    /// </summary>
+    /// <remarks>
+    /// The fix is intentionally conservative: changing a property's type affects every reference to it, so a
+    /// fix is only offered when EVERY reference to the property is a conversion the analyzer knows how to
+    /// rewrite. Otherwise a leftover string-typed use (for example <c>File.Exists(InputPath)</c>) would no
+    /// longer compile once the property is retyped. This guarantees the produced code compiles.
+    /// </remarks>
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(PreferTypedParameterCodeFixProvider))]
+    [Shared]
+    public sealed class PreferTypedParameterCodeFixProvider : CodeFixProvider
+    {
+        private const string EquivalenceKey = "PreferTypedParameter";
+
+        public override ImmutableArray<string> FixableDiagnosticIds =>
+            ImmutableArray.Create(DiagnosticIds.PreferTypedPathParameter, DiagnosticIds.PreferTypedTaskItem);
+
+        public override FixAllProvider GetFixAllProvider() => new PreferTypedParameterFixAllProvider();
+
+        public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+            var semanticModel = await context.Document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
+            if (root is null || semanticModel is null)
+            {
+                return;
+            }
+
+            foreach (var diagnostic in context.Diagnostics)
+            {
+                var plan = TryBuildPlan(semanticModel, root, diagnostic, context.CancellationToken);
+                if (plan is null)
+                {
+                    continue;
+                }
+
+                context.RegisterCodeFix(
+                    CodeAction.Create(
+                        title: $"Change '{plan.Property.Name}' to '{plan.NewTypeDisplay}'",
+                        createChangedDocument: ct => ApplyPlansAsync(context.Document, new[] { diagnostic }, ct),
+                        equivalenceKey: EquivalenceKey),
+                    diagnostic);
+            }
+        }
+
+        /// <summary>
+        /// Applies fixes for the supplied diagnostics, grouping them by target property so that a property whose
+        /// type changes is retyped exactly once even when it has multiple conversion sites.
+        /// </summary>
+        internal static async Task<Document> ApplyPlansAsync(Document document, IReadOnlyList<Diagnostic> diagnostics, CancellationToken cancellationToken)
+        {
+            var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+            var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+            if (root is null || semanticModel is null)
+            {
+                return document;
+            }
+
+            var plans = new List<PropertyFixPlan>();
+            var seenProperties = new List<IPropertySymbol>();
+            foreach (var diagnostic in diagnostics)
+            {
+                var plan = TryBuildPlan(semanticModel, root, diagnostic, cancellationToken);
+                if (plan is null)
+                {
+                    continue;
+                }
+
+                // Each plan already rewrites every site for its property; dedupe so we don't process a property twice.
+                if (seenProperties.Any(p => SymbolEqualityComparer.Default.Equals(p, plan.Property)))
+                {
+                    continue;
+                }
+
+                seenProperties.Add(plan.Property);
+                plans.Add(plan);
+            }
+
+            if (plans.Count == 0)
+            {
+                return document;
+            }
+
+            var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
+            foreach (var plan in plans)
+            {
+                editor.ReplaceNode(plan.PropertyDeclaration, BuildRetypedProperty(plan));
+                foreach (var (oldNode, newNode) in plan.SiteEdits)
+                {
+                    editor.ReplaceNode(oldNode, newNode);
+                }
+            }
+
+            return editor.GetChangedDocument();
+        }
+
+        /// <summary>
+        /// Validates that the diagnostic's target property can be safely retyped (every reference is a
+        /// rewritable conversion) and, if so, produces the set of edits to apply.
+        /// </summary>
+        private static PropertyFixPlan? TryBuildPlan(SemanticModel semanticModel, SyntaxNode root, Diagnostic diagnostic, CancellationToken cancellationToken)
+        {
+            if (!diagnostic.Properties.TryGetValue("PropertyName", out var propertyName) || propertyName is null ||
+                !diagnostic.Properties.TryGetValue("SuggestedType", out var suggestedType) || suggestedType is null)
+            {
+                return null;
+            }
+
+            var conversionNode = root.FindNode(diagnostic.Location.SourceSpan);
+            var typeDeclaration = conversionNode.AncestorsAndSelf().OfType<TypeDeclarationSyntax>().FirstOrDefault();
+            if (typeDeclaration is null)
+            {
+                return null;
+            }
+
+            if (semanticModel.GetDeclaredSymbol(typeDeclaration, cancellationToken) is not INamedTypeSymbol taskType)
+            {
+                return null;
+            }
+
+            var property = taskType.GetMembers(propertyName).OfType<IPropertySymbol>().FirstOrDefault();
+            if (property is null)
+            {
+                return null;
+            }
+
+            // The property must be declared exactly once, in this syntax tree, as a property declaration we can edit.
+            if (property.DeclaringSyntaxReferences.Length != 1 ||
+                property.DeclaringSyntaxReferences[0].GetSyntax(cancellationToken) is not PropertyDeclarationSyntax propertyDeclaration ||
+                propertyDeclaration.SyntaxTree != root.SyntaxTree)
+            {
+                return null;
+            }
+
+            bool isItemRule = diagnostic.Id == DiagnosticIds.PreferTypedTaskItem;
+            bool isArray = propertyDeclaration.Type is ArrayTypeSyntax;
+
+            // The strong type the rewritten conversions must produce (used to guard against losing semantics).
+            ITypeSymbol? expectedResultType = ResolvePathTypeSymbol(semanticModel.Compilation, suggestedType);
+
+            var siteEdits = new List<(SyntaxNode, SyntaxNode)>();
+            if (!TryCollectSiteEdits(semanticModel, typeDeclaration, property, suggestedType, expectedResultType, isItemRule, isArray, siteEdits, cancellationToken))
+            {
+                return null;
+            }
+
+            if (siteEdits.Count == 0)
+            {
+                return null;
+            }
+
+            string newTypeName = BuildNewTypeName(suggestedType, isItemRule, isArray);
+            string newTypeDisplay = BuildDisplayTypeName(suggestedType, isItemRule, isArray);
+            bool newTypeIsValueType = !isItemRule && suggestedType == "AbsolutePath";
+
+            return new PropertyFixPlan(property, propertyDeclaration, newTypeName, newTypeDisplay, newTypeIsValueType, siteEdits);
+        }
+
+        /// <summary>
+        /// Visits every reference to <paramref name="property"/> within the task type and verifies each one is a
+        /// conversion that can be rewritten. Populates <paramref name="siteEdits"/>; returns false if any reference
+        /// cannot be safely rewritten (in which case no fix should be offered).
+        /// </summary>
+        private static bool TryCollectSiteEdits(
+            SemanticModel semanticModel,
+            TypeDeclarationSyntax typeDeclaration,
+            IPropertySymbol property,
+            string suggestedType,
+            ITypeSymbol? expectedResultType,
+            bool isItemRule,
+            bool isArray,
+            List<(SyntaxNode, SyntaxNode)> siteEdits,
+            CancellationToken cancellationToken)
+        {
+            foreach (var identifier in typeDeclaration.DescendantNodes().OfType<IdentifierNameSyntax>())
+            {
+                if (identifier.Identifier.Text != property.Name)
+                {
+                    continue;
+                }
+
+                if (!SymbolEqualityComparer.Default.Equals(semanticModel.GetSymbolInfo(identifier, cancellationToken).Symbol, property))
+                {
+                    continue;
+                }
+
+                ExpressionSyntax propertyAccess = GetPropertyAccessExpression(identifier);
+
+                if (isItemRule && isArray)
+                {
+                    if (!TryRewriteForEachArray(semanticModel, propertyAccess, suggestedType, expectedResultType, siteEdits, cancellationToken))
+                    {
+                        return false;
+                    }
+                }
+                else if (isItemRule)
+                {
+                    if (!TryRewriteItemSpecConversion(semanticModel, propertyAccess, propertyAccess, suggestedType, expectedResultType, siteEdits, cancellationToken))
+                    {
+                        return false;
+                    }
+                }
+                else
+                {
+                    if (!TryRewritePathConversion(semanticModel, propertyAccess, suggestedType, expectedResultType, siteEdits, cancellationToken))
+                    {
+                        return false;
+                    }
+                }
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// MSBuildTask0006: rewrites <c>new T(prop)</c> or <c>TaskEnvironment.GetAbsolutePath(prop)</c> to just
+        /// <c>prop</c> after the property is retyped to <paramref name="suggestedType"/>.
+        /// </summary>
+        private static bool TryRewritePathConversion(
+            SemanticModel semanticModel,
+            ExpressionSyntax propertyAccess,
+            string suggestedType,
+            ITypeSymbol? expectedResultType,
+            List<(SyntaxNode, SyntaxNode)> siteEdits,
+            CancellationToken cancellationToken)
+        {
+            var conversion = GetSingleArgumentConversion(propertyAccess);
+            if (conversion is null || !IsExpectedConversion(semanticModel, conversion, suggestedType, expectedResultType, isItemRule: false, cancellationToken))
+            {
+                return false;
+            }
+
+            var replacement = propertyAccess
+                .WithoutTrivia()
+                .WithTriviaFrom(conversion)
+                .WithAdditionalAnnotations(Formatter.Annotation);
+
+            siteEdits.Add((conversion, replacement));
+            return true;
+        }
+
+        /// <summary>
+        /// MSBuildTask0007 (scalar): rewrites <c>new T(item.ItemSpec)</c> or <c>int.Parse(item.ItemSpec)</c> to
+        /// <c>item.Value</c> after the property is retyped to <c>ITaskItem&lt;T&gt;</c>.
+        /// </summary>
+        private static bool TryRewriteItemSpecConversion(
+            SemanticModel semanticModel,
+            ExpressionSyntax itemAccess,
+            ExpressionSyntax valueReceiver,
+            string suggestedType,
+            ITypeSymbol? expectedResultType,
+            List<(SyntaxNode, SyntaxNode)> siteEdits,
+            CancellationToken cancellationToken)
+        {
+            // itemAccess must be the receiver of an `.ItemSpec` member access.
+            if (itemAccess.Parent is not MemberAccessExpressionSyntax itemSpecAccess ||
+                itemSpecAccess.Expression != itemAccess ||
+                itemSpecAccess.Name.Identifier.Text != "ItemSpec")
+            {
+                return false;
+            }
+
+            var conversion = GetSingleArgumentConversion(itemSpecAccess);
+            if (conversion is null || !IsExpectedConversion(semanticModel, conversion, suggestedType, expectedResultType, isItemRule: true, cancellationToken))
+            {
+                return false;
+            }
+
+            var valueAccess = SyntaxFactory.MemberAccessExpression(
+                    SyntaxKind.SimpleMemberAccessExpression,
+                    valueReceiver.WithoutTrivia(),
+                    SyntaxFactory.IdentifierName("Value"))
+                .WithTriviaFrom(conversion)
+                .WithAdditionalAnnotations(Formatter.Annotation);
+
+            siteEdits.Add((conversion, valueAccess));
+            return true;
+        }
+
+        /// <summary>
+        /// MSBuildTask0007 (array): the property is the source of a <c>foreach (var x in Prop)</c> whose loop
+        /// variable's every use is an <c>x.ItemSpec</c> conversion. Rewrites each conversion to <c>x.Value</c>.
+        /// Only <c>var</c> loop variables are handled so the element re-infers to <c>ITaskItem&lt;T&gt;</c>.
+        /// </summary>
+        private static bool TryRewriteForEachArray(
+            SemanticModel semanticModel,
+            ExpressionSyntax propertyAccess,
+            string suggestedType,
+            ITypeSymbol? expectedResultType,
+            List<(SyntaxNode, SyntaxNode)> siteEdits,
+            CancellationToken cancellationToken)
+        {
+            if (propertyAccess.Parent is not ForEachStatementSyntax forEach ||
+                forEach.Expression != propertyAccess ||
+                !forEach.Type.IsVar)
+            {
+                return false;
+            }
+
+            if (semanticModel.GetDeclaredSymbol(forEach, cancellationToken) is not ILocalSymbol loopVariable)
+            {
+                return false;
+            }
+
+            bool sawConversion = false;
+            foreach (var identifier in forEach.Statement.DescendantNodes().OfType<IdentifierNameSyntax>())
+            {
+                if (identifier.Identifier.Text != loopVariable.Name ||
+                    !SymbolEqualityComparer.Default.Equals(semanticModel.GetSymbolInfo(identifier, cancellationToken).Symbol, loopVariable))
+                {
+                    continue;
+                }
+
+                var loopVariableReference = SyntaxFactory.IdentifierName(loopVariable.Name);
+                if (!TryRewriteItemSpecConversion(semanticModel, identifier, loopVariableReference, suggestedType, expectedResultType, siteEdits, cancellationToken))
+                {
+                    return false;
+                }
+
+                sawConversion = true;
+            }
+
+            return sawConversion;
+        }
+
+        /// <summary>
+        /// Returns the conversion expression (object creation or <c>Type.Parse</c> invocation) when
+        /// <paramref name="argument"/> is its single argument; otherwise null.
+        /// </summary>
+        private static ExpressionSyntax? GetSingleArgumentConversion(ExpressionSyntax argument)
+        {
+            if (argument.Parent is not ArgumentSyntax arg ||
+                arg.Parent is not ArgumentListSyntax argumentList ||
+                argumentList.Arguments.Count != 1)
+            {
+                return null;
+            }
+
+            return argumentList.Parent switch
+            {
+                ObjectCreationExpressionSyntax creation => creation,
+                InvocationExpressionSyntax invocation => invocation,
+                _ => null,
+            };
+        }
+
+        /// <summary>
+        /// Verifies the conversion produces exactly the suggested strong type, so replacing it does not change
+        /// the static type observed by surrounding code (e.g. <c>var x = ...;</c>).
+        /// </summary>
+        private static bool IsExpectedConversion(
+            SemanticModel semanticModel,
+            ExpressionSyntax conversion,
+            string suggestedType,
+            ITypeSymbol? expectedResultType,
+            bool isItemRule,
+            CancellationToken cancellationToken)
+        {
+            switch (conversion)
+            {
+                case ObjectCreationExpressionSyntax:
+                    break;
+
+                case InvocationExpressionSyntax invocation when invocation.Expression is MemberAccessExpressionSyntax memberAccess:
+                    // For the path rule only TaskEnvironment.GetAbsolutePath qualifies; for the item rule, a Parse call.
+                    string methodName = memberAccess.Name.Identifier.Text;
+                    if (!isItemRule && methodName != "GetAbsolutePath")
+                    {
+                        return false;
+                    }
+
+                    if (isItemRule && methodName != "Parse")
+                    {
+                        return false;
+                    }
+
+                    break;
+
+                default:
+                    return false;
+            }
+
+            var resultType = semanticModel.GetTypeInfo(conversion, cancellationToken).Type;
+            if (resultType is null)
+            {
+                return false;
+            }
+
+            return expectedResultType is not null
+                ? SymbolEqualityComparer.Default.Equals(resultType, expectedResultType)
+                : resultType.ToDisplayString() == suggestedType;
+        }
+
+        /// <summary>
+        /// Returns the expression that yields the property value: the identifier itself, or the enclosing
+        /// <c>this.Prop</c> member access when the identifier is the member name.
+        /// </summary>
+        private static ExpressionSyntax GetPropertyAccessExpression(IdentifierNameSyntax identifier)
+        {
+            if (identifier.Parent is MemberAccessExpressionSyntax memberAccess && memberAccess.Name == identifier)
+            {
+                return memberAccess;
+            }
+
+            return identifier;
+        }
+
+        private static PropertyDeclarationSyntax BuildRetypedProperty(PropertyFixPlan plan)
+        {
+            var newType = SyntaxFactory.ParseTypeName(plan.NewTypeName)
+                .WithTriviaFrom(plan.PropertyDeclaration.Type)
+                .WithAdditionalAnnotations(Simplifier.Annotation);
+
+            var newProperty = plan.PropertyDeclaration.WithType(newType);
+
+            // A string initializer (e.g. = "") is invalid once the type changes; replace it with a compatible default.
+            if (plan.PropertyDeclaration.Initializer is not null)
+            {
+                ExpressionSyntax defaultValue = plan.NewTypeIsValueType
+                    ? SyntaxFactory.LiteralExpression(SyntaxKind.DefaultLiteralExpression, SyntaxFactory.Token(SyntaxKind.DefaultKeyword))
+                    : SyntaxFactory.PostfixUnaryExpression(
+                        SyntaxKind.SuppressNullableWarningExpression,
+                        SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression));
+
+                newProperty = newProperty.WithInitializer(
+                    plan.PropertyDeclaration.Initializer.WithValue(defaultValue));
+            }
+
+            return newProperty.WithAdditionalAnnotations(Formatter.Annotation);
+        }
+
+        private static ITypeSymbol? ResolvePathTypeSymbol(Compilation compilation, string suggestedType) => suggestedType switch
+        {
+            "AbsolutePath" => compilation.GetTypeByMetadataName(WellKnownTypeNames.AbsolutePathFullName),
+            "FileInfo" => compilation.GetTypeByMetadataName("System.IO.FileInfo"),
+            "DirectoryInfo" => compilation.GetTypeByMetadataName("System.IO.DirectoryInfo"),
+            _ => null,
+        };
+
+        private static string FullyQualify(string typeName) => typeName switch
+        {
+            "AbsolutePath" => "global::" + WellKnownTypeNames.AbsolutePathFullName,
+            "FileInfo" => "global::System.IO.FileInfo",
+            "DirectoryInfo" => "global::System.IO.DirectoryInfo",
+            _ => typeName,
+        };
+
+        private static string BuildNewTypeName(string suggestedType, bool isItemRule, bool isArray)
+        {
+            if (!isItemRule)
+            {
+                return FullyQualify(suggestedType);
+            }
+
+            string itemType = $"global::{WellKnownTypeNames.ITaskItemFullName}<{FullyQualify(suggestedType)}>";
+            return isArray ? itemType + "[]" : itemType;
+        }
+
+        private static string BuildDisplayTypeName(string suggestedType, bool isItemRule, bool isArray)
+        {
+            if (!isItemRule)
+            {
+                return suggestedType;
+            }
+
+            string itemType = $"ITaskItem<{suggestedType}>";
+            return isArray ? itemType + "[]" : itemType;
+        }
+
+        /// <summary>
+        /// The set of edits required to retype one property and rewrite all of its conversion sites.
+        /// </summary>
+        private sealed class PropertyFixPlan
+        {
+            public PropertyFixPlan(
+                IPropertySymbol property,
+                PropertyDeclarationSyntax propertyDeclaration,
+                string newTypeName,
+                string newTypeDisplay,
+                bool newTypeIsValueType,
+                List<(SyntaxNode, SyntaxNode)> siteEdits)
+            {
+                Property = property;
+                PropertyDeclaration = propertyDeclaration;
+                NewTypeName = newTypeName;
+                NewTypeDisplay = newTypeDisplay;
+                NewTypeIsValueType = newTypeIsValueType;
+                SiteEdits = siteEdits;
+            }
+
+            public IPropertySymbol Property { get; }
+
+            public PropertyDeclarationSyntax PropertyDeclaration { get; }
+
+            public string NewTypeName { get; }
+
+            public string NewTypeDisplay { get; }
+
+            public bool NewTypeIsValueType { get; }
+
+            public List<(SyntaxNode OldNode, SyntaxNode NewNode)> SiteEdits { get; }
+        }
+
+        /// <summary>
+        /// Applies the property-scoped fix across all diagnostics in a document, grouping by property so each
+        /// property is retyped once even when reported at multiple conversion sites.
+        /// </summary>
+        private sealed class PreferTypedParameterFixAllProvider : DocumentBasedFixAllProvider
+        {
+            protected override async Task<Document?> FixAllAsync(FixAllContext fixAllContext, Document document, ImmutableArray<Diagnostic> diagnostics)
+            {
+                if (diagnostics.IsDefaultOrEmpty)
+                {
+                    return document;
+                }
+
+                return await ApplyPlansAsync(document, diagnostics, fixAllContext.CancellationToken).ConfigureAwait(false);
+            }
+        }
+    }
+}

--- a/src/TaskAnalyzer/PreferTypedParameterCodeFixProvider.cs
+++ b/src/TaskAnalyzer/PreferTypedParameterCodeFixProvider.cs
@@ -388,16 +388,28 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                     break;
 
                 case InvocationExpressionSyntax invocation when invocation.Expression is MemberAccessExpressionSyntax memberAccess:
-                    // For the path rule only TaskEnvironment.GetAbsolutePath qualifies; for the item rule, a Parse call.
                     string methodName = memberAccess.Name.Identifier.Text;
-                    if (!isItemRule && methodName != "GetAbsolutePath")
+                    if (!isItemRule)
                     {
-                        return false;
+                        // Path rule: only TaskEnvironment.GetAbsolutePath qualifies.
+                        if (methodName != "GetAbsolutePath")
+                        {
+                            return false;
+                        }
                     }
-
-                    if (isItemRule && methodName != "Parse")
+                    else
                     {
-                        return false;
+                        // Item rule: Parse, Convert.ToXxx, or TaskEnvironment.GetAbsolutePath. These mirror the
+                        // conversions the analyzer reports as MSBuildTask0007; the result-type equality check
+                        // below guarantees the rewrite to .Value preserves the statically observed type.
+                        bool isConvertMethod = methodName.StartsWith("To", System.StringComparison.Ordinal) &&
+                            semanticModel.GetSymbolInfo(invocation, cancellationToken).Symbol is IMethodSymbol convertMethod &&
+                            convertMethod.ContainingType?.ToDisplayString() == "System.Convert";
+
+                        if (methodName != "Parse" && methodName != "GetAbsolutePath" && !isConvertMethod)
+                        {
+                            return false;
+                        }
                     }
 
                     break;

--- a/src/TaskAnalyzer/PreferTypedParameterCodeFixProvider.cs
+++ b/src/TaskAnalyzer/PreferTypedParameterCodeFixProvider.cs
@@ -612,6 +612,15 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                 // alone is the fix. FileInfo/DirectoryInfo have no implicit string conversion, so pass .FullName.
                 if (suggestedType != "AbsolutePath")
                 {
+                    // A null-guard such as string.IsNullOrEmpty(prop) is specifically tolerant of a null property.
+                    // Rewriting it to prop.FullName would dereference a possibly-null FileInfo/DirectoryInfo and
+                    // throw, silently defeating the guard. We cannot safely rewrite this shape, so withhold the
+                    // whole fix (the diagnostic still surfaces) rather than emit code that can NRE.
+                    if (IsNullGuardArgument(semanticModel, propertyAccess, cancellationToken))
+                    {
+                        return false;
+                    }
+
                     var replacement = AppendFullName(propertyAccess)
                         .WithTriviaFrom(propertyAccess)
                         .WithAdditionalAnnotations(Formatter.Annotation);
@@ -623,6 +632,29 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
             }
 
             return false;
+        }
+
+        /// <summary>
+        /// True when <paramref name="propertyAccess"/> is the argument of a <c>string.IsNullOrEmpty</c> or
+        /// <c>string.IsNullOrWhiteSpace</c> call. These are null-tolerant by design, so a FileInfo/DirectoryInfo
+        /// retype cannot rewrite them to <c>prop.FullName</c> without risking a <see cref="System.NullReferenceException"/>.
+        /// </summary>
+        private static bool IsNullGuardArgument(
+            SemanticModel semanticModel,
+            ExpressionSyntax propertyAccess,
+            CancellationToken cancellationToken)
+        {
+            if (propertyAccess.Parent is not ArgumentSyntax argument ||
+                argument.Parent is not ArgumentListSyntax argumentList ||
+                argumentList.Arguments.Count != 1 ||
+                argumentList.Parent is not InvocationExpressionSyntax candidate)
+            {
+                return false;
+            }
+
+            return semanticModel.GetSymbolInfo(candidate, cancellationToken).Symbol is IMethodSymbol method &&
+                method.ContainingType?.SpecialType == SpecialType.System_String &&
+                method.Name is "IsNullOrEmpty" or "IsNullOrWhiteSpace";
         }
 
         /// <summary>

--- a/src/TaskAnalyzer/PreferTypedParameterCodeFixProvider.cs
+++ b/src/TaskAnalyzer/PreferTypedParameterCodeFixProvider.cs
@@ -14,6 +14,7 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.CodeAnalysis.Operations;
 using Microsoft.CodeAnalysis.Simplification;
 
 namespace Microsoft.Build.TaskAuthoring.Analyzer
@@ -558,8 +559,15 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
         }
 
         /// <summary>
-        /// MSBuildTask0006: rewrites <c>new T(prop)</c> or <c>TaskEnvironment.GetAbsolutePath(prop)</c> to just
-        /// <c>prop</c> after the property is retyped to <paramref name="suggestedType"/>.
+        /// MSBuildTask0006: rewrites the site where a retyped path property is used. Handles three shapes:
+        /// <list type="bullet">
+        /// <item><c>new T(prop)</c> / <c>TaskEnvironment.GetAbsolutePath(prop)</c> collapses to <c>prop</c>.</item>
+        /// <item><c>Path.GetFullPath(prop)</c> (the banned normalization) collapses to <c>prop</c> for AbsolutePath,
+        /// or <c>prop.FullName</c> for FileInfo/DirectoryInfo, since the retyped value is already absolute.</item>
+        /// <item>A raw string consumption (<c>File.Delete(prop)</c>, <c>new FileStream(prop, ...)</c>) needs no edit
+        /// for AbsolutePath (it converts to string implicitly), or <c>prop.FullName</c> for FileInfo/DirectoryInfo.</item>
+        /// </list>
+        /// Returns false for any other reference shape so the conservative "all references rewritable" guarantee holds.
         /// </summary>
         private static bool TryRewritePathConversion(
             SemanticModel semanticModel,
@@ -569,19 +577,133 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
             List<(SyntaxNode, SyntaxNode)> siteEdits,
             CancellationToken cancellationToken)
         {
+            // Conversion site: new T(prop) / TaskEnvironment.GetAbsolutePath(prop) => prop
             var conversion = GetSingleArgumentConversion(propertyAccess);
-            if (conversion is null || !IsExpectedConversion(semanticModel, conversion, suggestedType, expectedResultType, isItemRule: false, cancellationToken))
+            if (conversion is not null &&
+                IsExpectedConversion(semanticModel, conversion, suggestedType, expectedResultType, isItemRule: false, cancellationToken))
+            {
+                var replacement = propertyAccess
+                    .WithoutTrivia()
+                    .WithTriviaFrom(conversion)
+                    .WithAdditionalAnnotations(Formatter.Annotation);
+
+                siteEdits.Add((conversion, replacement));
+                return true;
+            }
+
+            // Banned normalization site: Path.GetFullPath(prop). The retyped value is already absolute, so the
+            // whole call collapses to the property (AbsolutePath, implicitly a string) or its absolute string.
+            if (IsPathGetFullPathInvocation(semanticModel, propertyAccess, cancellationToken, out var getFullPath))
+            {
+                ExpressionSyntax replacement = (suggestedType == "AbsolutePath"
+                        ? (ExpressionSyntax)propertyAccess.WithoutTrivia()
+                        : AppendFullName(propertyAccess))
+                    .WithTriviaFrom(getFullPath)
+                    .WithAdditionalAnnotations(Formatter.Annotation);
+
+                siteEdits.Add((getFullPath, replacement));
+                return true;
+            }
+
+            // Raw string consumption: prop passed where a string is expected (File.Delete(prop), new FileStream(prop)).
+            if (IsStringArgument(semanticModel, propertyAccess, cancellationToken))
+            {
+                // AbsolutePath converts to string implicitly, so the call still compiles unchanged; the retype
+                // alone is the fix. FileInfo/DirectoryInfo have no implicit string conversion, so pass .FullName.
+                if (suggestedType != "AbsolutePath")
+                {
+                    var replacement = AppendFullName(propertyAccess)
+                        .WithTriviaFrom(propertyAccess)
+                        .WithAdditionalAnnotations(Formatter.Annotation);
+
+                    siteEdits.Add((propertyAccess, replacement));
+                }
+
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Builds <c>prop.FullName</c> — the absolute path string exposed by FileInfo/DirectoryInfo (via
+        /// FileSystemInfo) — used to feed a retyped path property into APIs that still expect a string.
+        /// </summary>
+        private static ExpressionSyntax AppendFullName(ExpressionSyntax propertyAccess) =>
+            SyntaxFactory.MemberAccessExpression(
+                SyntaxKind.SimpleMemberAccessExpression,
+                propertyAccess.WithoutTrivia(),
+                SyntaxFactory.IdentifierName("FullName"));
+
+        /// <summary>
+        /// True when <paramref name="propertyAccess"/> is the single argument of a <c>System.IO.Path.GetFullPath</c>
+        /// call; outputs that invocation so it can be replaced wholesale.
+        /// </summary>
+        private static bool IsPathGetFullPathInvocation(
+            SemanticModel semanticModel,
+            ExpressionSyntax propertyAccess,
+            CancellationToken cancellationToken,
+            out InvocationExpressionSyntax invocation)
+        {
+            invocation = null!;
+
+            if (propertyAccess.Parent is not ArgumentSyntax argument ||
+                argument.Parent is not ArgumentListSyntax argumentList ||
+                argumentList.Arguments.Count != 1 ||
+                argumentList.Parent is not InvocationExpressionSyntax candidate)
             {
                 return false;
             }
 
-            var replacement = propertyAccess
-                .WithoutTrivia()
-                .WithTriviaFrom(conversion)
-                .WithAdditionalAnnotations(Formatter.Annotation);
+            if (semanticModel.GetSymbolInfo(candidate, cancellationToken).Symbol is not IMethodSymbol method ||
+                method.Name != "GetFullPath" ||
+                method.ContainingType?.ToDisplayString() != "System.IO.Path")
+            {
+                return false;
+            }
 
-            siteEdits.Add((conversion, replacement));
+            invocation = candidate;
             return true;
+        }
+
+        /// <summary>
+        /// True when <paramref name="propertyAccess"/> is an argument bound to a <c>string</c> parameter of an
+        /// invocation or object creation, i.e. a site where a retyped path property must be converted back to a
+        /// string (AbsolutePath implicitly, FileInfo/DirectoryInfo via <c>.FullName</c>).
+        /// </summary>
+        private static bool IsStringArgument(
+            SemanticModel semanticModel,
+            ExpressionSyntax propertyAccess,
+            CancellationToken cancellationToken)
+        {
+            if (propertyAccess.Parent is not ArgumentSyntax argument ||
+                argument.Parent is not ArgumentListSyntax argumentList ||
+                argumentList.Parent is not (InvocationExpressionSyntax or ObjectCreationExpressionSyntax))
+            {
+                return false;
+            }
+
+            ImmutableArray<IArgumentOperation> argumentOperations = semanticModel.GetOperation(argumentList.Parent, cancellationToken) switch
+            {
+                IInvocationOperation invocation => invocation.Arguments,
+                IObjectCreationOperation creation => creation.Arguments,
+                _ => default,
+            };
+
+            if (argumentOperations.IsDefault)
+            {
+                return false;
+            }
+
+            foreach (var argumentOperation in argumentOperations)
+            {
+                if (argumentOperation.Syntax == argument)
+                {
+                    return argumentOperation.Parameter?.Type.SpecialType == SpecialType.System_String;
+                }
+            }
+
+            return false;
         }
 
         /// <summary>

--- a/src/TaskAnalyzer/PreferTypedParameterCodeFixProvider.cs
+++ b/src/TaskAnalyzer/PreferTypedParameterCodeFixProvider.cs
@@ -940,8 +940,8 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
         private static ITypeSymbol? ResolvePathTypeSymbol(Compilation compilation, string suggestedType) => suggestedType switch
         {
             "AbsolutePath" => compilation.GetTypeByMetadataName(WellKnownTypeNames.AbsolutePathFullName),
-            "FileInfo" => compilation.GetTypeByMetadataName("System.IO.FileInfo"),
-            "DirectoryInfo" => compilation.GetTypeByMetadataName("System.IO.DirectoryInfo"),
+            "FileInfo" => compilation.GetTypeByMetadataName(WellKnownTypeNames.FileInfoFullName),
+            "DirectoryInfo" => compilation.GetTypeByMetadataName(WellKnownTypeNames.DirectoryInfoFullName),
             _ => null,
         };
 

--- a/src/TaskAnalyzer/PreferTypedParameterCodeFixProvider.cs
+++ b/src/TaskAnalyzer/PreferTypedParameterCodeFixProvider.cs
@@ -25,6 +25,9 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
     ///   removes the now-redundant conversion at every use site.
     /// - MSBuildTask0007: Retypes an ITaskItem/ITaskItem[] task property to ITaskItem&lt;T&gt;/ITaskItem&lt;T&gt;[]
     ///   and replaces the manual ItemSpec parsing with the strongly-typed Value at every use site.
+    /// - MSBuildTask0008: Retypes a path property whose default is a relative string and moves that default into
+    ///   a guarded, TaskEnvironment-rooted assignment at the top of Execute() (since a relative default cannot be
+    ///   rooted in a property initializer, which runs before the engine sets TaskEnvironment).
     /// </summary>
     /// <remarks>
     /// The fix is intentionally conservative: changing a property's type affects every reference to it, so a
@@ -39,7 +42,10 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
         private const string EquivalenceKey = "PreferTypedParameter";
 
         public override ImmutableArray<string> FixableDiagnosticIds =>
-            ImmutableArray.Create(DiagnosticIds.PreferTypedPathParameter, DiagnosticIds.PreferTypedTaskItem);
+            ImmutableArray.Create(
+                DiagnosticIds.PreferTypedPathParameter,
+                DiagnosticIds.PreferTypedTaskItem,
+                DiagnosticIds.InitializeRelativeDefaultInExecute);
 
         public override FixAllProvider GetFixAllProvider() => new PreferTypedParameterFixAllProvider();
 
@@ -62,7 +68,9 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
 
                 context.RegisterCodeFix(
                     CodeAction.Create(
-                        title: $"Change '{plan.Property.Name}' to '{plan.NewTypeDisplay}'",
+                        title: plan.InitializeInExecute
+                            ? $"Change '{plan.Property.Name}' to '{plan.NewTypeDisplay}' and initialize it in Execute()"
+                            : $"Change '{plan.Property.Name}' to '{plan.NewTypeDisplay}'",
                         createChangedDocument: ct => ApplyPlansAsync(context.Document, new[] { diagnostic }, ct),
                         equivalenceKey: EquivalenceKey),
                     diagnostic);
@@ -115,6 +123,24 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                 {
                     editor.ReplaceNode(oldNode, newNode);
                 }
+
+                if (plan.ExecutePrologue is not null)
+                {
+                    if (plan.ExecuteAnchor is not null)
+                    {
+                        // Insert as the first statement of Execute() without replacing the whole method, so this
+                        // does not conflict with the site edits that rewrite nodes inside the method body.
+                        editor.InsertBefore(plan.ExecuteAnchor, plan.ExecutePrologue);
+                    }
+                    else if (plan.ExecuteBody is not null)
+                    {
+                        // Execute() has an empty body: no descendant edits can exist there, so replacing the
+                        // block outright is safe.
+                        editor.ReplaceNode(
+                            plan.ExecuteBody,
+                            plan.ExecuteBody.WithStatements(SyntaxFactory.SingletonList(plan.ExecutePrologue)));
+                    }
+                }
             }
 
             return editor.GetChangedDocument();
@@ -159,13 +185,41 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
             }
 
             bool isItemRule = diagnostic.Id == DiagnosticIds.PreferTypedTaskItem;
+            bool isMoveDefaultRule = diagnostic.Id == DiagnosticIds.InitializeRelativeDefaultInExecute;
             bool isArray = propertyDeclaration.Type is ArrayTypeSyntax;
 
             // The strong type the rewritten conversions must produce (used to guard against losing semantics).
             ITypeSymbol? expectedResultType = ResolvePathTypeSymbol(semanticModel.Compilation, suggestedType);
 
+            string newTypeName = BuildNewTypeName(suggestedType, isItemRule, isArray);
+            string newTypeDisplay = BuildDisplayTypeName(suggestedType, isItemRule, isArray);
+            bool newTypeIsValueType = !isItemRule && suggestedType == "AbsolutePath";
+
+            ExpressionSyntax? initializerValue;
+            if (isMoveDefaultRule)
+            {
+                // The relative default cannot live in the initializer once the property is retyped; it is moved
+                // into Execute(). Leave the property with an "unset" default so an unset parameter is detectable.
+                initializerValue = UnsetDefaultValue(newTypeIsValueType);
+            }
+            else if (!TryBuildInitializerValue(semanticModel, propertyDeclaration, suggestedType, newTypeIsValueType, isItemRule, cancellationToken, out initializerValue))
+            {
+                // Decide how to carry over an existing property initializer to the retyped property. A string
+                // initializer is not assignable to the new type as-is, so it must be replaced or re-expressed;
+                // if it can't be done safely the whole fix is skipped rather than dropping/corrupting the default.
+                return null;
+            }
+
+            // Partial classes can spread references across multiple declarations (and files). Collect every
+            // partial declaration of the task type so the "all references must be rewritable" guarantee holds
+            // over the whole type, not just the part that happens to contain the flagged conversion.
+            var typeDeclarations = taskType.DeclaringSyntaxReferences
+                .Select(reference => reference.GetSyntax(cancellationToken))
+                .OfType<TypeDeclarationSyntax>()
+                .ToList();
+
             var siteEdits = new List<(SyntaxNode, SyntaxNode)>();
-            if (!TryCollectSiteEdits(semanticModel, typeDeclaration, property, suggestedType, expectedResultType, isItemRule, isArray, siteEdits, cancellationToken))
+            if (!TryCollectSiteEdits(semanticModel, typeDeclarations, property, suggestedType, expectedResultType, isItemRule, isArray, siteEdits, cancellationToken))
             {
                 return null;
             }
@@ -175,21 +229,270 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                 return null;
             }
 
-            string newTypeName = BuildNewTypeName(suggestedType, isItemRule, isArray);
-            string newTypeDisplay = BuildDisplayTypeName(suggestedType, isItemRule, isArray);
-            bool newTypeIsValueType = !isItemRule && suggestedType == "AbsolutePath";
+            StatementSyntax? executePrologue = null;
+            StatementSyntax? executeAnchor = null;
+            BlockSyntax? executeBody = null;
+            if (isMoveDefaultRule &&
+                !TryBuildExecutePrologue(taskType, property, propertyDeclaration, suggestedType, newTypeIsValueType, root, cancellationToken, out executePrologue, out executeAnchor, out executeBody))
+            {
+                // No Execute() to root the default in (missing/expression-bodied), or no TaskEnvironment to root
+                // it through: keep the diagnostic but offer no fix.
+                return null;
+            }
 
-            return new PropertyFixPlan(property, propertyDeclaration, newTypeName, newTypeDisplay, newTypeIsValueType, siteEdits);
+            return new PropertyFixPlan(property, propertyDeclaration, newTypeName, newTypeDisplay, initializerValue, siteEdits, isMoveDefaultRule, executePrologue, executeAnchor, executeBody);
+        }
+
+        private static ExpressionSyntax UnsetDefaultValue(bool newTypeIsValueType) => newTypeIsValueType
+            ? SyntaxFactory.LiteralExpression(SyntaxKind.DefaultLiteralExpression, SyntaxFactory.Token(SyntaxKind.DefaultKeyword))
+            : SyntaxFactory.PostfixUnaryExpression(
+                SyntaxKind.SuppressNullableWarningExpression,
+                SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression));
+
+        /// <summary>
+        /// Builds the guarded normalization statement to insert at the top of <c>Execute()</c> for a property
+        /// whose relative default was moved out of its initializer (MSBuildTask0008). The statement only applies
+        /// the default when the property is still unset, so a value bound from the project XML is not clobbered.
+        /// Returns false (skip the fix) when there is no editable <c>Execute()</c> in this document or no
+        /// accessible <c>TaskEnvironment</c> member to root the relative path through.
+        /// </summary>
+        private static bool TryBuildExecutePrologue(
+            INamedTypeSymbol taskType,
+            IPropertySymbol property,
+            PropertyDeclarationSyntax propertyDeclaration,
+            string suggestedType,
+            bool newTypeIsValueType,
+            SyntaxNode root,
+            CancellationToken cancellationToken,
+            out StatementSyntax? prologue,
+            out StatementSyntax? anchor,
+            out BlockSyntax? body)
+        {
+            prologue = null;
+            anchor = null;
+            body = null;
+
+            // The relative literal we are relocating; only a plain string literal default reaches 0008.
+            if (propertyDeclaration.Initializer?.Value is not LiteralExpressionSyntax relativeLiteral ||
+                !relativeLiteral.IsKind(SyntaxKind.StringLiteralExpression))
+            {
+                return false;
+            }
+
+            if (!HasAccessibleTaskEnvironment(taskType))
+            {
+                return false;
+            }
+
+            var executeMethod = FindEditableExecuteMethod(taskType, root, cancellationToken);
+            if (executeMethod?.Body is null)
+            {
+                return false;
+            }
+
+            body = executeMethod.Body;
+            anchor = body.Statements.FirstOrDefault();
+
+            // TaskEnvironment.GetAbsolutePath("relative")
+            ExpressionSyntax rooted = SyntaxFactory.InvocationExpression(
+                    SyntaxFactory.MemberAccessExpression(
+                        SyntaxKind.SimpleMemberAccessExpression,
+                        SyntaxFactory.IdentifierName("TaskEnvironment"),
+                        SyntaxFactory.IdentifierName("GetAbsolutePath")))
+                .WithArgumentList(SyntaxFactory.ArgumentList(
+                    SyntaxFactory.SingletonSeparatedList(
+                        SyntaxFactory.Argument(relativeLiteral.WithoutTrivia()))));
+
+            // For FileInfo/DirectoryInfo the engine goes string -> AbsolutePath -> FileInfo/DirectoryInfo;
+            // AbsolutePath implicitly converts to string, so new FileInfo(GetAbsolutePath(...)) mirrors that.
+            ExpressionSyntax rhs = newTypeIsValueType
+                ? rooted
+                : SyntaxFactory.ObjectCreationExpression(
+                        SyntaxFactory.ParseTypeName(FullyQualify(suggestedType)).WithAdditionalAnnotations(Simplifier.Annotation))
+                    .WithArgumentList(SyntaxFactory.ArgumentList(
+                        SyntaxFactory.SingletonSeparatedList(
+                            SyntaxFactory.Argument(rooted))));
+
+            var propertyAccess = SyntaxFactory.IdentifierName(property.Name);
+
+            if (newTypeIsValueType)
+            {
+                // if (Prop == default) { Prop = TaskEnvironment.GetAbsolutePath("relative"); }
+                prologue = SyntaxFactory.IfStatement(
+                    SyntaxFactory.BinaryExpression(
+                        SyntaxKind.EqualsExpression,
+                        propertyAccess,
+                        SyntaxFactory.LiteralExpression(SyntaxKind.DefaultLiteralExpression, SyntaxFactory.Token(SyntaxKind.DefaultKeyword))),
+                    SyntaxFactory.Block(
+                        SyntaxFactory.ExpressionStatement(
+                            SyntaxFactory.AssignmentExpression(SyntaxKind.SimpleAssignmentExpression, propertyAccess, rhs))));
+            }
+            else
+            {
+                // Prop ??= new FileInfo(TaskEnvironment.GetAbsolutePath("relative"));
+                prologue = SyntaxFactory.ExpressionStatement(
+                    SyntaxFactory.AssignmentExpression(SyntaxKind.CoalesceAssignmentExpression, propertyAccess, rhs));
+            }
+
+            prologue = prologue.WithAdditionalAnnotations(Formatter.Annotation);
+            return true;
         }
 
         /// <summary>
-        /// Visits every reference to <paramref name="property"/> within the task type and verifies each one is a
-        /// conversion that can be rewritten. Populates <paramref name="siteEdits"/>; returns false if any reference
-        /// cannot be safely rewritten (in which case no fix should be offered).
+        /// True when the task type (or a base type) exposes a member named <c>TaskEnvironment</c> the generated
+        /// prologue can read.
+        /// </summary>
+        private static bool HasAccessibleTaskEnvironment(INamedTypeSymbol taskType)
+        {
+            for (INamedTypeSymbol? type = taskType; type is not null; type = type.BaseType)
+            {
+                if (type.GetMembers("TaskEnvironment").Any(m => m is IPropertySymbol or IFieldSymbol))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Locates the parameterless <c>Execute()</c> method of the task declared in the same syntax tree as the
+        /// document being fixed, or null when there is none we can edit here.
+        /// </summary>
+        private static MethodDeclarationSyntax? FindEditableExecuteMethod(INamedTypeSymbol taskType, SyntaxNode root, CancellationToken cancellationToken)
+        {
+            foreach (var method in taskType.GetMembers("Execute").OfType<IMethodSymbol>())
+            {
+                if (method.Parameters.Length != 0)
+                {
+                    continue;
+                }
+
+                foreach (var reference in method.DeclaringSyntaxReferences)
+                {
+                    if (reference.GetSyntax(cancellationToken) is MethodDeclarationSyntax declaration &&
+                        declaration.SyntaxTree == root.SyntaxTree)
+                    {
+                        return declaration;
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Determines the value expression to use for the retyped property's initializer when the original
+        /// property has one. Returns false (skip the whole fix) when the existing default cannot be safely
+        /// re-expressed as the new type.
+        /// </summary>
+        private static bool TryBuildInitializerValue(
+            SemanticModel semanticModel,
+            PropertyDeclarationSyntax propertyDeclaration,
+            string suggestedType,
+            bool newTypeIsValueType,
+            bool isItemRule,
+            CancellationToken cancellationToken,
+            out ExpressionSyntax? initializerValue)
+        {
+            initializerValue = null;
+
+            if (propertyDeclaration.Initializer is null)
+            {
+                // No initializer to carry over.
+                return true;
+            }
+
+            ExpressionSyntax initExpr = propertyDeclaration.Initializer.Value;
+
+            // Empty string / null / string.Empty: nothing meaningful to preserve — use a type-compatible default.
+            if (IsEmptyOrNullDefault(semanticModel, initExpr, cancellationToken))
+            {
+                initializerValue = newTypeIsValueType
+                    ? SyntaxFactory.LiteralExpression(SyntaxKind.DefaultLiteralExpression, SyntaxFactory.Token(SyntaxKind.DefaultKeyword))
+                    : SyntaxFactory.PostfixUnaryExpression(
+                        SyntaxKind.SuppressNullableWarningExpression,
+                        SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression));
+                return true;
+            }
+
+            // A non-empty compile-time string default on a path property (MSBuildTask0006) is preserved by
+            // constructing the typed value in the initializer. MSBuild normally normalizes an incoming string
+            // to a fully-qualified path via TaskEnvironment.GetAbsolutePath before binding it to a typed
+            // parameter, but TaskEnvironment is only set by the engine *after* the task is constructed, so it
+            // is not available inside a property initializer (which runs in the constructor). Therefore only a
+            // default that is *already* fully qualified can be reproduced here without TaskEnvironment; a
+            // relative default would need rooting we cannot perform at construction time, so the fix is skipped.
+            if (!isItemRule &&
+                semanticModel.GetConstantValue(initExpr, cancellationToken) is { HasValue: true, Value: string defaultString } &&
+                PathDefaultClassifier.IsFullyQualifiedPath(defaultString))
+            {
+                // AbsolutePath itself validates that the literal is fully qualified. For FileInfo/DirectoryInfo
+                // the engine goes string -> AbsolutePath -> FileInfo/DirectoryInfo, so mirror that chain by
+                // constructing through AbsolutePath rather than passing the raw string.
+                ExpressionSyntax absolutePathExpr = SyntaxFactory.ObjectCreationExpression(
+                        SyntaxFactory.ParseTypeName(FullyQualify("AbsolutePath")).WithAdditionalAnnotations(Simplifier.Annotation))
+                    .WithArgumentList(SyntaxFactory.ArgumentList(
+                        SyntaxFactory.SingletonSeparatedList(
+                            SyntaxFactory.Argument(initExpr.WithoutTrivia()))));
+
+                initializerValue = suggestedType == "AbsolutePath"
+                    ? absolutePathExpr
+                    : SyntaxFactory.ObjectCreationExpression(
+                            SyntaxFactory.ParseTypeName(FullyQualify(suggestedType)).WithAdditionalAnnotations(Simplifier.Annotation))
+                        .WithArgumentList(SyntaxFactory.ArgumentList(
+                            SyntaxFactory.SingletonSeparatedList(
+                                SyntaxFactory.Argument(absolutePathExpr))));
+                return true;
+            }
+
+            // Anything else (a non-constant default, or a relative/invalid path that would require rooting via
+            // TaskEnvironment) can't be safely re-expressed as the new type. Skip the fix for this property
+            // instead of silently changing behavior or emitting code that would throw at construction time.
+            return false;
+        }
+
+        /// <summary>
+        /// True when a property initializer represents an "empty" default that carries no meaningful value:
+        /// the <c>null</c> literal, an empty string literal, or <c>string.Empty</c>.
+        /// </summary>
+        private static bool IsEmptyOrNullDefault(SemanticModel semanticModel, ExpressionSyntax expr, CancellationToken cancellationToken)
+        {
+            if (expr is LiteralExpressionSyntax literal)
+            {
+                if (literal.IsKind(SyntaxKind.NullLiteralExpression))
+                {
+                    return true;
+                }
+
+                if (literal.IsKind(SyntaxKind.StringLiteralExpression))
+                {
+                    return literal.Token.ValueText.Length == 0;
+                }
+            }
+
+            var constant = semanticModel.GetConstantValue(expr, cancellationToken);
+            if (constant.HasValue)
+            {
+                return constant.Value is null || (constant.Value is string s && s.Length == 0);
+            }
+
+            // string.Empty / String.Empty is a field (not a compile-time constant) but is semantically empty.
+            return expr is MemberAccessExpressionSyntax memberAccess &&
+                memberAccess.Name.Identifier.Text == "Empty" &&
+                semanticModel.GetSymbolInfo(expr, cancellationToken).Symbol?.ContainingType?.SpecialType == SpecialType.System_String;
+        }
+
+        /// <summary>
+        /// Visits every reference to <paramref name="property"/> across all partial declarations of the task
+        /// type and verifies each one is a conversion that can be rewritten. Populates <paramref name="siteEdits"/>;
+        /// returns false if any reference cannot be safely rewritten (in which case no fix should be offered).
+        /// A reference living in a different syntax tree than the document being fixed also fails, because a
+        /// single-document code fix cannot rewrite it and leaving it behind would not compile after retyping.
         /// </summary>
         private static bool TryCollectSiteEdits(
             SemanticModel semanticModel,
-            TypeDeclarationSyntax typeDeclaration,
+            IReadOnlyList<TypeDeclarationSyntax> typeDeclarations,
             IPropertySymbol property,
             string suggestedType,
             ITypeSymbol? expectedResultType,
@@ -198,39 +501,55 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
             List<(SyntaxNode, SyntaxNode)> siteEdits,
             CancellationToken cancellationToken)
         {
-            foreach (var identifier in typeDeclaration.DescendantNodes().OfType<IdentifierNameSyntax>())
+            SyntaxTree documentTree = semanticModel.SyntaxTree;
+
+            foreach (var typeDeclaration in typeDeclarations)
             {
-                if (identifier.Identifier.Text != property.Name)
-                {
-                    continue;
-                }
+                bool sameTree = typeDeclaration.SyntaxTree == documentTree;
+                SemanticModel model = sameTree
+                    ? semanticModel
+                    : semanticModel.Compilation.GetSemanticModel(typeDeclaration.SyntaxTree);
 
-                if (!SymbolEqualityComparer.Default.Equals(semanticModel.GetSymbolInfo(identifier, cancellationToken).Symbol, property))
+                foreach (var identifier in typeDeclaration.DescendantNodes().OfType<IdentifierNameSyntax>())
                 {
-                    continue;
-                }
+                    if (identifier.Identifier.Text != property.Name)
+                    {
+                        continue;
+                    }
 
-                ExpressionSyntax propertyAccess = GetPropertyAccessExpression(identifier);
+                    if (!SymbolEqualityComparer.Default.Equals(model.GetSymbolInfo(identifier, cancellationToken).Symbol, property))
+                    {
+                        continue;
+                    }
 
-                if (isItemRule && isArray)
-                {
-                    if (!TryRewriteForEachArray(semanticModel, propertyAccess, suggestedType, expectedResultType, siteEdits, cancellationToken))
+                    // The property is referenced in another document; this fix can only edit the current one.
+                    if (!sameTree)
                     {
                         return false;
                     }
-                }
-                else if (isItemRule)
-                {
-                    if (!TryRewriteItemSpecConversion(semanticModel, propertyAccess, propertyAccess, suggestedType, expectedResultType, siteEdits, cancellationToken))
+
+                    ExpressionSyntax propertyAccess = GetPropertyAccessExpression(identifier);
+
+                    if (isItemRule && isArray)
                     {
-                        return false;
+                        if (!TryRewriteForEachArray(semanticModel, propertyAccess, suggestedType, expectedResultType, siteEdits, cancellationToken))
+                        {
+                            return false;
+                        }
                     }
-                }
-                else
-                {
-                    if (!TryRewritePathConversion(semanticModel, propertyAccess, suggestedType, expectedResultType, siteEdits, cancellationToken))
+                    else if (isItemRule)
                     {
-                        return false;
+                        if (!TryRewriteItemSpecConversion(semanticModel, propertyAccess, propertyAccess, suggestedType, expectedResultType, siteEdits, cancellationToken))
+                        {
+                            return false;
+                        }
+                    }
+                    else
+                    {
+                        if (!TryRewritePathConversion(semanticModel, propertyAccess, suggestedType, expectedResultType, siteEdits, cancellationToken))
+                        {
+                            return false;
+                        }
                     }
                 }
             }
@@ -266,8 +585,9 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
         }
 
         /// <summary>
-        /// MSBuildTask0007 (scalar): rewrites <c>new T(item.ItemSpec)</c> or <c>int.Parse(item.ItemSpec)</c> to
-        /// <c>item.Value</c> after the property is retyped to <c>ITaskItem&lt;T&gt;</c>.
+        /// MSBuildTask0007 (scalar): rewrites <c>new T(item.ItemSpec)</c>, <c>int.Parse(item.ItemSpec)</c>, or the
+        /// equivalent over <c>item.GetMetadata("FullPath")</c> to <c>item.Value</c> after the property is retyped
+        /// to <c>ITaskItem&lt;T&gt;</c>.
         /// </summary>
         private static bool TryRewriteItemSpecConversion(
             SemanticModel semanticModel,
@@ -278,15 +598,14 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
             List<(SyntaxNode, SyntaxNode)> siteEdits,
             CancellationToken cancellationToken)
         {
-            // itemAccess must be the receiver of an `.ItemSpec` member access.
-            if (itemAccess.Parent is not MemberAccessExpressionSyntax itemSpecAccess ||
-                itemSpecAccess.Expression != itemAccess ||
-                itemSpecAccess.Name.Identifier.Text != "ItemSpec")
+            // The path access is either `item.ItemSpec` or `item.GetMetadata("FullPath")`.
+            ExpressionSyntax? pathAccess = GetItemPathAccess(itemAccess);
+            if (pathAccess is null)
             {
                 return false;
             }
 
-            var conversion = GetSingleArgumentConversion(itemSpecAccess);
+            var conversion = GetSingleArgumentConversion(pathAccess);
             if (conversion is null || !IsExpectedConversion(semanticModel, conversion, suggestedType, expectedResultType, isItemRule: true, cancellationToken))
             {
                 return false;
@@ -301,6 +620,40 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
 
             siteEdits.Add((conversion, valueAccess));
             return true;
+        }
+
+        /// <summary>
+        /// When <paramref name="itemAccess"/> is the receiver of an item path access — <c>item.ItemSpec</c> or
+        /// <c>item.GetMetadata("FullPath")</c> (the documented way to read an item's absolute path) — returns the
+        /// full path-access expression; otherwise null.
+        /// </summary>
+        private static ExpressionSyntax? GetItemPathAccess(ExpressionSyntax itemAccess)
+        {
+            if (itemAccess.Parent is not MemberAccessExpressionSyntax memberAccess ||
+                memberAccess.Expression != itemAccess)
+            {
+                return null;
+            }
+
+            // item.ItemSpec
+            if (memberAccess.Name.Identifier.Text == "ItemSpec")
+            {
+                return memberAccess;
+            }
+
+            // item.GetMetadata("FullPath")
+            if (memberAccess.Name.Identifier.Text == "GetMetadata" &&
+                memberAccess.Parent is InvocationExpressionSyntax invocation &&
+                invocation.Expression == memberAccess &&
+                invocation.ArgumentList.Arguments.Count == 1 &&
+                invocation.ArgumentList.Arguments[0].Expression is LiteralExpressionSyntax literal &&
+                literal.IsKind(SyntaxKind.StringLiteralExpression) &&
+                string.Equals(literal.Token.ValueText, "FullPath", System.StringComparison.OrdinalIgnoreCase))
+            {
+                return invocation;
+            }
+
+            return null;
         }
 
         /// <summary>
@@ -451,17 +804,12 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
 
             var newProperty = plan.PropertyDeclaration.WithType(newType);
 
-            // A string initializer (e.g. = "") is invalid once the type changes; replace it with a compatible default.
-            if (plan.PropertyDeclaration.Initializer is not null)
+            // The original string initializer is invalid once the type changes; swap in the value computed by
+            // TryBuildInitializerValue (a type-compatible default, or the default re-expressed as the new type).
+            if (plan.PropertyDeclaration.Initializer is not null && plan.InitializerValue is not null)
             {
-                ExpressionSyntax defaultValue = plan.NewTypeIsValueType
-                    ? SyntaxFactory.LiteralExpression(SyntaxKind.DefaultLiteralExpression, SyntaxFactory.Token(SyntaxKind.DefaultKeyword))
-                    : SyntaxFactory.PostfixUnaryExpression(
-                        SyntaxKind.SuppressNullableWarningExpression,
-                        SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression));
-
                 newProperty = newProperty.WithInitializer(
-                    plan.PropertyDeclaration.Initializer.WithValue(defaultValue));
+                    plan.PropertyDeclaration.Initializer.WithValue(plan.InitializerValue));
             }
 
             return newProperty.WithAdditionalAnnotations(Formatter.Annotation);
@@ -515,15 +863,23 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                 PropertyDeclarationSyntax propertyDeclaration,
                 string newTypeName,
                 string newTypeDisplay,
-                bool newTypeIsValueType,
-                List<(SyntaxNode, SyntaxNode)> siteEdits)
+                ExpressionSyntax? initializerValue,
+                List<(SyntaxNode, SyntaxNode)> siteEdits,
+                bool initializeInExecute = false,
+                StatementSyntax? executePrologue = null,
+                StatementSyntax? executeAnchor = null,
+                BlockSyntax? executeBody = null)
             {
                 Property = property;
                 PropertyDeclaration = propertyDeclaration;
                 NewTypeName = newTypeName;
                 NewTypeDisplay = newTypeDisplay;
-                NewTypeIsValueType = newTypeIsValueType;
+                InitializerValue = initializerValue;
                 SiteEdits = siteEdits;
+                InitializeInExecute = initializeInExecute;
+                ExecutePrologue = executePrologue;
+                ExecuteAnchor = executeAnchor;
+                ExecuteBody = executeBody;
             }
 
             public IPropertySymbol Property { get; }
@@ -534,9 +890,25 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
 
             public string NewTypeDisplay { get; }
 
-            public bool NewTypeIsValueType { get; }
+            /// <summary>
+            /// The value to use for the retyped property's initializer when the original property had one;
+            /// null when the property has no initializer to carry over.
+            /// </summary>
+            public ExpressionSyntax? InitializerValue { get; }
 
             public List<(SyntaxNode OldNode, SyntaxNode NewNode)> SiteEdits { get; }
+
+            /// <summary>True for MSBuildTask0008: the relative default is (re)initialized in Execute().</summary>
+            public bool InitializeInExecute { get; }
+
+            /// <summary>The guarded normalization statement to insert at the top of Execute(); null otherwise.</summary>
+            public StatementSyntax? ExecutePrologue { get; }
+
+            /// <summary>The existing first statement of Execute() to insert before; null when the body is empty.</summary>
+            public StatementSyntax? ExecuteAnchor { get; }
+
+            /// <summary>The Execute() body, used to place the prologue when the body has no statements yet.</summary>
+            public BlockSyntax? ExecuteBody { get; }
         }
 
         /// <summary>

--- a/src/TaskAnalyzer/README.md
+++ b/src/TaskAnalyzer/README.md
@@ -118,10 +118,16 @@ public class MyTask : Task
         var abs2 = TaskEnvironment.GetAbsolutePath(InputPath); // flagged
         var fi = new FileInfo(InputPath);                 // flagged (suggests FileInfo)
         var di = new DirectoryInfo(InputPath);            // flagged (suggests DirectoryInfo)
+        var full = Path.GetFullPath(InputPath);           // flagged (suggests AbsolutePath)
+        File.Delete(InputPath);                           // flagged (suggests FileInfo)
+        Directory.CreateDirectory(InputPath);             // flagged (suggests DirectoryInfo)
+        using var s = new FileStream(InputPath, FileMode.Open); // flagged (suggests FileInfo)
         return true;
     }
 }
 ```
+
+The last four patterns are the same raw-string shapes that MSBuildTask0002 (`Path.GetFullPath`) and MSBuildTask0003 (a raw string flowing into a `System.IO` path parameter) flag. Surfacing them under MSBuildTask0006 as well means the property can be retyped in **one shot** instead of first applying the 0002/0003 fix (which only introduces a conversion) and then being told to apply 0006. The code fix rewrites each raw site as part of the retype: `Path.GetFullPath(prop)` collapses to `prop` (or `prop.FullName`), and a raw string consumption is fed through `prop.FullName` for `FileInfo`/`DirectoryInfo` (or left unchanged for `AbsolutePath`, which converts to `string` implicitly). Arguments already rooted through `TaskEnvironment.GetAbsolutePath`/`new AbsolutePath(...)` are not re-flagged.
 
 **Not flagged:** `[Output]` properties, non-public properties, read-only properties, values from method calls or literals.
 
@@ -258,6 +264,8 @@ The analyzer ships with a code fix provider that offers automatic replacements:
 | MSBuildTask0003: `File.Exists(relativePath)` | → `File.Exists(TaskEnvironment.GetAbsolutePath(relativePath))` |
 | MSBuildTask0006: `new AbsolutePath(InputPath)` | → Retype `InputPath` to `AbsolutePath` and replace conversion with direct property usage |
 | MSBuildTask0006: `new FileInfo(FilePath)` / `new DirectoryInfo(DirPath)` | → Retype property to `FileInfo`/`DirectoryInfo` and replace conversion with direct property usage |
+| MSBuildTask0006: `Path.GetFullPath(InputPath)` | → Retype `InputPath` to `AbsolutePath` and collapse the call to the property (one-shot for the 0002 shape) |
+| MSBuildTask0006: `File.Delete(Target)` / `Directory.CreateDirectory(Folder)` | → Retype property to `FileInfo`/`DirectoryInfo` and feed the string API through `.FullName` (one-shot for the 0003 shape) |
 | MSBuildTask0007: `int.Parse(Item.ItemSpec)` | → Retype `Item` to ``ITaskItem<int>`` and replace parse with `Item.Value` |
 | MSBuildTask0007: `new FileInfo(item.ItemSpec)` in `foreach` over `ITaskItem[]` | → Retype source property to ``ITaskItem<FileInfo>[]`` and replace with `item.Value` |
 | MSBuildTask0007: `new AbsolutePath(Item.GetMetadata("FullPath"))` | → Retype `Item` to ``ITaskItem<AbsolutePath>`` and replace with `Item.Value` |
@@ -358,7 +366,7 @@ public class CopyFiles : Task, IMultiThreadableTask
 
 ## Tests
 
-184 tests covering all rules, safe patterns, edge cases, code fixes, and compiler diagnostic suppression:
+193 tests covering all rules, safe patterns, edge cases, code fixes, and compiler diagnostic suppression:
 
 ```
 cd src/TaskAnalyzer.Tests

--- a/src/TaskAnalyzer/README.md
+++ b/src/TaskAnalyzer/README.md
@@ -153,10 +153,21 @@ public class MyTask : Task
         var fi = new FileInfo(absPath);                   // flagged (suggests ITaskItem<FileInfo>)
         var di = new DirectoryInfo(absPath);              // flagged (suggests ITaskItem<DirectoryInfo>)
 
+        // System.IO consumption sites infer the most specific type:
+        File.Delete(TaskEnvironment.GetAbsolutePath(Item.ItemSpec));   // flagged (suggests ITaskItem<FileInfo>)
+        Directory.CreateDirectory(absPath);                            // flagged (suggests ITaskItem<DirectoryInfo>)
+        using var s = new FileStream(Item.ItemSpec, FileMode.Open);    // flagged (suggests ITaskItem<FileInfo>)
+
+        var combined = Path.Combine(Item.ItemSpec, "sub");             // flagged (suggests ITaskItem<AbsolutePath>)
+
         return true;
     }
 }
 ```
+
+**Biasing toward `FileInfo`/`DirectoryInfo`:** When a rooted path flows into a `System.IO.File.*` call or a `FileStream`/`StreamReader`/`StreamWriter` constructor, the analyzer suggests `ITaskItem<FileInfo>`; when it flows into a `System.IO.Directory.*` call, it suggests `ITaskItem<DirectoryInfo>`. These more specific suggestions replace the generic `ITaskItem<AbsolutePath>` for the same property. Tracing follows both a direct `item.ItemSpec` and an `AbsolutePath` intermediary, including a local that is declared and then assigned once (the common `AbsolutePath? p = null; try { p = GetAbsolutePath(...); }` pattern). If one property is used as both a file and a directory, the analyzer falls back to `ITaskItem<AbsolutePath>`.
+
+**`Path.Combine`:** A task input flowing into *any* argument position of `Path.Combine` is flagged (each distinct property is reported once per call), since the value is being used to build an absolute path.
 
 **Array properties:** When the source property is `ITaskItem[]`, the suggestion correctly formats as `ITaskItem<T>[]` (brackets outside the angle brackets), e.g., `ITaskItem<AbsolutePath>[]`.
 
@@ -307,7 +318,7 @@ dotnet test
 | `SharedAnalyzerHelpers.cs` | Shared path safety analysis, banned API resolution, and interface checking helpers |
 | `DiagnosticDescriptors.cs` | Seven diagnostic descriptors in category `MSBuild.TaskAuthoring` |
 | `DiagnosticIds.cs` | Public constants: `MSBuildTask0001`–`MSBuildTask0007` |
-| `PreferTypedParameterAnalyzer.cs` | Analyzer for MSBuildTask0006 and MSBuildTask0007 — detects manual path construction, ItemSpec parsing, Path.Combine usage, helper method wrapping, and FileInfo/DirectoryInfo construction through AbsolutePath intermediaries |
+| `PreferTypedParameterAnalyzer.cs` | Analyzer for MSBuildTask0006 and MSBuildTask0007 — detects manual path construction, ItemSpec parsing, Path.Combine usage (any argument position), helper method wrapping, FileInfo/DirectoryInfo construction through AbsolutePath intermediaries, and System.IO consumption sites (`File.*`/`Directory.*`/`FileStream`/`StreamReader`/`StreamWriter`) that bias suggestions toward `FileInfo`/`DirectoryInfo` |
 
 ### Performance
 

--- a/src/TaskAnalyzer/README.md
+++ b/src/TaskAnalyzer/README.md
@@ -19,6 +19,8 @@ This analyzer catches unsafe API usage at compile time and offers code fixes to 
 | **MSBuildTask0003** | Warning | All `ITask` implementations | File system API requires absolute path |
 | **MSBuildTask0004** | Warning | All `ITask` implementations | API may cause issues in multithreaded tasks |
 | **MSBuildTask0005** | Warning | All `ITask` implementations | Transitive unsafe API usage in task call chain |
+| **MSBuildTask0006** | Info | All `ITask` implementations | Prefer typed path parameter over string |
+| **MSBuildTask0007** | Info | All `ITask` implementations | Prefer `ITaskItem<T>` over manual ItemSpec parsing |
 
 ### MSBuildTask0001 — Critical: No Safe Alternative
 
@@ -97,16 +99,71 @@ These APIs may cause version conflicts or other issues in a shared task host.
 | `Activator.CreateInstanceFrom` | May cause version conflicts |
 | `AppDomain.Load`, `CreateInstance`, `CreateInstanceFrom` | May cause version conflicts |
 
+### MSBuildTask0006 — Prefer Typed Path Parameters
+
+When a task has a `string` input property and converts it to `AbsolutePath`, `FileInfo`, or `DirectoryInfo` inside the task body, the analyzer suggests changing the property type directly. MSBuild can bind these types automatically.
+
+**Detected patterns:**
+
+```csharp
+// ⚠️ MSBuildTask0006: Consider changing 'InputPath' from 'string' to 'AbsolutePath'
+public class MyTask : Task
+{
+    public string InputPath { get; set; }
+
+    public override bool Execute()
+    {
+        var abs = new AbsolutePath(InputPath);           // flagged
+        var abs2 = TaskEnvironment.GetAbsolutePath(InputPath); // flagged
+        var fi = new FileInfo(InputPath);                 // flagged (suggests FileInfo)
+        var di = new DirectoryInfo(InputPath);            // flagged (suggests DirectoryInfo)
+        return true;
+    }
+}
+```
+
+**Not flagged:** `[Output]` properties, non-public properties, read-only properties, values from method calls or literals.
+
+### MSBuildTask0007 — Prefer `ITaskItem<T>` Over ItemSpec Parsing
+
+When a task has an `ITaskItem` or `ITaskItem[]` input property and parses `ItemSpec` to a value type or path type, the analyzer suggests using `ITaskItem<T>` instead.
+
+**Detected patterns:**
+
+```csharp
+// ⚠️ MSBuildTask0007: Consider changing 'Item' from 'ITaskItem' to 'ITaskItem<int>'
+public class MyTask : Task
+{
+    public ITaskItem Item { get; set; }
+    public ITaskItem[] Items { get; set; }
+
+    public override bool Execute()
+    {
+        int value = int.Parse(Item.ItemSpec);             // flagged
+        bool flag = Convert.ToBoolean(Item.ItemSpec);     // flagged
+        var abs = new AbsolutePath(Item.ItemSpec);        // flagged (suggests ITaskItem<AbsolutePath>)
+
+        foreach (var item in Items)
+        {
+            int v = int.Parse(item.ItemSpec);             // flagged (suggests ITaskItem<int>[])
+        }
+        return true;
+    }
+}
+```
+
+**Not flagged:** Metadata access (`item.GetMetadata(...)`), `[Output]` properties, non-task classes.
+
 ## Analysis Scope
 
 The analyzer determines what to check based on the type declaration:
 
 | Type | Rules Applied |
 |---|---|
-| Any class implementing `ITask` | MSBuildTask0001–MSBuildTask0005 |
-| Class implementing `IMultiThreadableTask` | All five rules |
-| Class with `[MSBuildMultiThreadableTask]` attribute | All five rules |
-| Helper class with `[MSBuildMultiThreadableTaskAnalyzed]` attribute | All five rules |
+| Any class implementing `ITask` | MSBuildTask0001–MSBuildTask0007 |
+| Class implementing `IMultiThreadableTask` | All seven rules |
+| Class with `[MSBuildMultiThreadableTask]` attribute | All seven rules |
+| Helper class with `[MSBuildMultiThreadableTaskAnalyzed]` attribute | MSBuildTask0001–MSBuildTask0005 |
 | Regular class (no task interface or attribute) | Not analyzed |
 
 The `[MSBuildMultiThreadableTaskAnalyzed]` attribute allows opting helper classes into **direct** analysis by the `MultiThreadableTaskAnalyzer` (MSBuildTask0001–0004). Without it, only classes implementing `ITask` receive per-line diagnostics and code fixes for those rules. The **transitive** analyzer (MSBuildTask0005) already discovers helpers via call graph analysis, but it reports only at the task entry point. Adding this attribute to a helper class gives you inline diagnostics and code fixes directly in the helper's source.
@@ -117,6 +174,7 @@ The `[MSBuildMultiThreadableTaskAnalyzed]` attribute allows opting helper classe
 
 - **MSBuildTask0001** is always **Error** — these APIs are never safe in any MSBuild task.
 - **MSBuildTask0002–MSBuildTask0005** report as **Warning** for all task types.
+- **MSBuildTask0006–MSBuildTask0007** report as **Info** — these are modernization suggestions, not correctness issues.
 
 ## Code Fixes
 
@@ -223,7 +281,7 @@ public class CopyFiles : Task, IMultiThreadableTask
 
 ## Tests
 
-111 tests covering all rules, safe patterns, edge cases, code fixes, and compiler diagnostic suppression:
+135 tests covering all rules, safe patterns, edge cases, code fixes, and compiler diagnostic suppression:
 
 ```
 cd src/TaskAnalyzer.Tests
@@ -238,8 +296,9 @@ dotnet test
 | `MultiThreadableTaskCodeFixProvider.cs` | Code fixes for MSBuildTask0002 and MSBuildTask0003 |
 | `BannedApiDefinitions.cs` | ~50 banned API entries resolved via `DocumentationCommentId` for O(1) symbol lookup |
 | `SharedAnalyzerHelpers.cs` | Shared path safety analysis, banned API resolution, and interface checking helpers |
-| `DiagnosticDescriptors.cs` | Five diagnostic descriptors in category `MSBuild.TaskAuthoring` |
-| `DiagnosticIds.cs` | Public constants: `MSBuildTask0001`–`MSBuildTask0005` |
+| `DiagnosticDescriptors.cs` | Seven diagnostic descriptors in category `MSBuild.TaskAuthoring` |
+| `DiagnosticIds.cs` | Public constants: `MSBuildTask0001`–`MSBuildTask0007` |
+| `PreferTypedParameterAnalyzer.cs` | Analyzer for MSBuildTask0006 and MSBuildTask0007 — detects manual path construction and ItemSpec parsing |
 
 ### Performance
 

--- a/src/TaskAnalyzer/README.md
+++ b/src/TaskAnalyzer/README.md
@@ -147,10 +147,18 @@ public class MyTask : Task
         {
             int v = int.Parse(item.ItemSpec);             // flagged (suggests ITaskItem<int>[])
         }
+
+        // FileInfo/DirectoryInfo through AbsolutePath intermediary:
+        AbsolutePath absPath = TaskEnvironment.GetAbsolutePath(Item.ItemSpec);
+        var fi = new FileInfo(absPath);                   // flagged (suggests ITaskItem<FileInfo>)
+        var di = new DirectoryInfo(absPath);              // flagged (suggests ITaskItem<DirectoryInfo>)
+
         return true;
     }
 }
 ```
+
+**Array properties:** When the source property is `ITaskItem[]`, the suggestion correctly formats as `ITaskItem<T>[]` (brackets outside the angle brackets), e.g., `ITaskItem<AbsolutePath>[]`.
 
 **Not flagged:** Metadata access (`item.GetMetadata(...)`), `[Output]` properties, non-task classes.
 
@@ -299,7 +307,7 @@ dotnet test
 | `SharedAnalyzerHelpers.cs` | Shared path safety analysis, banned API resolution, and interface checking helpers |
 | `DiagnosticDescriptors.cs` | Seven diagnostic descriptors in category `MSBuild.TaskAuthoring` |
 | `DiagnosticIds.cs` | Public constants: `MSBuildTask0001`–`MSBuildTask0007` |
-| `PreferTypedParameterAnalyzer.cs` | Analyzer for MSBuildTask0006 and MSBuildTask0007 — detects manual path construction and ItemSpec parsing |
+| `PreferTypedParameterAnalyzer.cs` | Analyzer for MSBuildTask0006 and MSBuildTask0007 — detects manual path construction, ItemSpec parsing, Path.Combine usage, helper method wrapping, and FileInfo/DirectoryInfo construction through AbsolutePath intermediaries |
 
 ### Performance
 

--- a/src/TaskAnalyzer/README.md
+++ b/src/TaskAnalyzer/README.md
@@ -19,8 +19,8 @@ This analyzer catches unsafe API usage at compile time and offers code fixes to 
 | **MSBuildTask0003** | Warning | All `ITask` implementations | File system API requires absolute path |
 | **MSBuildTask0004** | Warning | All `ITask` implementations | API may cause issues in multithreaded tasks |
 | **MSBuildTask0005** | Warning | All `ITask` implementations | Transitive unsafe API usage in task call chain |
-| **MSBuildTask0006** | Info | All `ITask` implementations | Prefer typed path parameter over string |
-| **MSBuildTask0007** | Info | All `ITask` implementations | Prefer `ITaskItem<T>` over manual ItemSpec parsing |
+| **MSBuildTask0006** | Info | Multithreaded tasks (`IMultiThreadableTask` or `[MSBuildMultiThreadableTask]`) | Prefer typed path parameter over string |
+| **MSBuildTask0007** | Info | Multithreaded tasks (`IMultiThreadableTask` or `[MSBuildMultiThreadableTask]`) | Prefer `ITaskItem<T>` over manual ItemSpec parsing |
 
 ### MSBuildTask0001 — Critical: No Safe Alternative
 
@@ -160,7 +160,8 @@ The analyzer determines what to check based on the type declaration:
 
 | Type | Rules Applied |
 |---|---|
-| Any class implementing `ITask` | MSBuildTask0001–MSBuildTask0007 |
+| Any class implementing `ITask` | MSBuildTask0001–MSBuildTask0005 |
+| Multithreaded tasks (`IMultiThreadableTask` or `[MSBuildMultiThreadableTask]`) | MSBuildTask0006–MSBuildTask0007 |
 | Class implementing `IMultiThreadableTask` | All seven rules |
 | Class with `[MSBuildMultiThreadableTask]` attribute | All seven rules |
 | Helper class with `[MSBuildMultiThreadableTaskAnalyzed]` attribute | MSBuildTask0001–MSBuildTask0005 |

--- a/src/TaskAnalyzer/README.md
+++ b/src/TaskAnalyzer/README.md
@@ -19,9 +19,9 @@ This analyzer catches unsafe API usage at compile time and offers code fixes to 
 | **MSBuildTask0003** | Warning | All `ITask` implementations | File system API requires absolute path |
 | **MSBuildTask0004** | Warning | All `ITask` implementations | API may cause issues in multithreaded tasks |
 | **MSBuildTask0005** | Warning | All `ITask` implementations | Transitive unsafe API usage in task call chain |
-| **MSBuildTask0006** | Info | Multithreaded tasks (`IMultiThreadableTask` or `[MSBuildMultiThreadableTask]`) | Prefer typed path parameter over string |
-| **MSBuildTask0007** | Info | Multithreaded tasks (`IMultiThreadableTask` or `[MSBuildMultiThreadableTask]`) | Prefer `ITaskItem<T>` over manual ItemSpec parsing |
-| **MSBuildTask0008** | Info | Multithreaded tasks (`IMultiThreadableTask` or `[MSBuildMultiThreadableTask]`) | Initialize a relative-default path property in `Execute()` |
+| **MSBuildTask0006** | Info | Tasks with `[MSBuildMultiThreadableTask]` applied directly | Prefer typed path parameter over string |
+| **MSBuildTask0007** | Info | Tasks with `[MSBuildMultiThreadableTask]` applied directly | Prefer `ITaskItem<T>` over manual ItemSpec parsing |
+| **MSBuildTask0008** | Info | Tasks with `[MSBuildMultiThreadableTask]` applied directly | Initialize a relative-default path property in `Execute()` |
 
 ### MSBuildTask0001 — Critical: No Safe Alternative
 
@@ -226,11 +226,12 @@ The analyzer determines what to check based on the type declaration:
 | Type | Rules Applied |
 |---|---|
 | Any class implementing `ITask` | MSBuildTask0001–MSBuildTask0005 |
-| Multithreaded tasks (`IMultiThreadableTask` or `[MSBuildMultiThreadableTask]`) | MSBuildTask0006–MSBuildTask0008 |
-| Class implementing `IMultiThreadableTask` | All seven rules |
-| Class with `[MSBuildMultiThreadableTask]` attribute | All seven rules |
+| Class with `[MSBuildMultiThreadableTask]` attribute applied directly | MSBuildTask0006–MSBuildTask0008 (in addition to MSBuildTask0001–0005) |
+| Class implementing `IMultiThreadableTask` without the attribute | MSBuildTask0001–MSBuildTask0005 only |
 | Helper class with `[MSBuildMultiThreadableTaskAnalyzed]` attribute | MSBuildTask0001–MSBuildTask0005 |
 | Regular class (no task interface or attribute) | Not analyzed |
+
+MSBuildTask0006–MSBuildTask0008 apply only when the `[MSBuildMultiThreadableTask]` attribute is applied **directly** to the task class. The attribute is `Inherited = false`, so a task that merely derives from a base class implementing `IMultiThreadableTask` (or carrying the attribute) has not itself opted into multithreaded support and is not subject to these three rules. Input properties are collected from the task class **and its base classes**, so an `ITaskItem`/`string` input declared on a shared base task is still analyzed.
 
 The `[MSBuildMultiThreadableTaskAnalyzed]` attribute allows opting helper classes into **direct** analysis by the `MultiThreadableTaskAnalyzer` (MSBuildTask0001–0004). Without it, only classes implementing `ITask` receive per-line diagnostics and code fixes for those rules. The **transitive** analyzer (MSBuildTask0005) already discovers helpers via call graph analysis, but it reports only at the task entry point. Adding this attribute to a helper class gives you inline diagnostics and code fixes directly in the helper's source.
 
@@ -357,7 +358,7 @@ public class CopyFiles : Task, IMultiThreadableTask
 
 ## Tests
 
-182 tests covering all rules, safe patterns, edge cases, code fixes, and compiler diagnostic suppression:
+184 tests covering all rules, safe patterns, edge cases, code fixes, and compiler diagnostic suppression:
 
 ```
 cd src/TaskAnalyzer.Tests

--- a/src/TaskAnalyzer/README.md
+++ b/src/TaskAnalyzer/README.md
@@ -21,6 +21,7 @@ This analyzer catches unsafe API usage at compile time and offers code fixes to 
 | **MSBuildTask0005** | Warning | All `ITask` implementations | Transitive unsafe API usage in task call chain |
 | **MSBuildTask0006** | Info | Multithreaded tasks (`IMultiThreadableTask` or `[MSBuildMultiThreadableTask]`) | Prefer typed path parameter over string |
 | **MSBuildTask0007** | Info | Multithreaded tasks (`IMultiThreadableTask` or `[MSBuildMultiThreadableTask]`) | Prefer `ITaskItem<T>` over manual ItemSpec parsing |
+| **MSBuildTask0008** | Info | Multithreaded tasks (`IMultiThreadableTask` or `[MSBuildMultiThreadableTask]`) | Initialize a relative-default path property in `Execute()` |
 
 ### MSBuildTask0001 — Critical: No Safe Alternative
 
@@ -126,7 +127,7 @@ public class MyTask : Task
 
 ### MSBuildTask0007 — Prefer `ITaskItem<T>` Over ItemSpec Parsing
 
-When a task has an `ITaskItem` or `ITaskItem[]` input property and parses `ItemSpec` to a value type or path type, the analyzer suggests using `ITaskItem<T>` instead.
+When a task has an `ITaskItem` or `ITaskItem[]` input property and parses `ItemSpec` (or reads the item's absolute path via `GetMetadata("FullPath")`) to a value type or path type, the analyzer suggests using `ITaskItem<T>` instead.
 
 **Detected patterns:**
 
@@ -142,6 +143,7 @@ public class MyTask : Task
         int value = int.Parse(Item.ItemSpec);             // flagged
         bool flag = Convert.ToBoolean(Item.ItemSpec);     // flagged
         var abs = new AbsolutePath(Item.ItemSpec);        // flagged (suggests ITaskItem<AbsolutePath>)
+        var abs2 = new AbsolutePath(Item.GetMetadata("FullPath")); // flagged (GetMetadata("FullPath") is the item's absolute path)
 
         foreach (var item in Items)
         {
@@ -167,11 +169,55 @@ public class MyTask : Task
 
 **Biasing toward `FileInfo`/`DirectoryInfo`:** When a rooted path flows into a `System.IO.File.*` call or a `FileStream`/`StreamReader`/`StreamWriter` constructor, the analyzer suggests `ITaskItem<FileInfo>`; when it flows into a `System.IO.Directory.*` call, it suggests `ITaskItem<DirectoryInfo>`. These more specific suggestions replace the generic `ITaskItem<AbsolutePath>` for the same property. Tracing follows both a direct `item.ItemSpec` and an `AbsolutePath` intermediary, including a local that is declared and then assigned once (the common `AbsolutePath? p = null; try { p = GetAbsolutePath(...); }` pattern). If one property is used as both a file and a directory, the analyzer falls back to `ITaskItem<AbsolutePath>`.
 
-**`Path.Combine`:** A task input flowing into *any* argument position of `Path.Combine` is flagged (each distinct property is reported once per call), since the value is being used to build an absolute path.
+**`Path.Combine`:** A task input flowing into the **first** argument position of `Path.Combine` is flagged, since that first segment is the base the combined absolute path is built from. Later argument positions are intentionally *not* flagged: `Path.Combine` restarts from the last rooted segment, so retyping a later argument to an absolute (rooted) path would discard the earlier segments and silently change the result.
 
 **Array properties:** When the source property is `ITaskItem[]`, the suggestion correctly formats as `ITaskItem<T>[]` (brackets outside the angle brackets), e.g., `ITaskItem<AbsolutePath>[]`.
 
-**Not flagged:** Metadata access (`item.GetMetadata(...)`), `[Output]` properties, non-task classes.
+**`GetMetadata("FullPath")`:** `ITaskItem.GetMetadata("FullPath")` (metadata name compared case-insensitively) returns the item's absolute path as a `string`, so it is treated the same as `item.ItemSpec` — both as a detection source and, when wrapped in a conversion, as a fixable site rewritten to `item.Value`. Other metadata names (e.g. `item.GetMetadata("Culture")`) are not flagged.
+
+**Not flagged:** Non-`FullPath` metadata access (`item.GetMetadata("Culture")`), `[Output]` properties, non-task classes.
+
+### MSBuildTask0008 — Initialize a Relative-Default Path Property in `Execute()`
+
+MSBuildTask0006 offers to retype a `string` path property and reproduce any string default in the property initializer. That only works when the default is already **fully qualified**: rooting a *relative* default requires `TaskEnvironment`, which the engine only supplies **after** the task is constructed, so it is unavailable inside a property initializer (which runs in the constructor).
+
+When a property flagged by MSBuildTask0006 has a **relative** string default, the analyzer suppresses the 0006 suggestion for that property and instead reports MSBuildTask0008 on the initializer:
+
+```csharp
+[MSBuildMultiThreadableTask]
+public class MyTask : Task
+{
+    // ⚠️ MSBuildTask0008: 'InputPath' has a relative default; initialize it in Execute()
+    public string InputPath { get; set; } = "obj";
+
+    public override bool Execute()
+    {
+        var abs = new AbsolutePath(InputPath);   // the 0006-style conversion
+        return true;
+    }
+}
+```
+
+The code fix retypes the property (leaving it with an *unset* default) and moves the default into the top of `Execute()` as a **guarded** assignment, so a value bound by MSBuild from the project XML is not overwritten:
+
+```csharp
+public AbsolutePath InputPath { get; set; } = default;
+
+public override bool Execute()
+{
+    if (InputPath == default)
+    {
+        InputPath = TaskEnvironment.GetAbsolutePath("obj");
+    }
+
+    var abs = InputPath;
+    return true;
+}
+```
+
+For a reference-typed target (`FileInfo`/`DirectoryInfo`) the guard is a null-coalescing assignment built through the `string` → `AbsolutePath` → `FileInfo`/`DirectoryInfo` chain, e.g. `LogPath ??= new FileInfo(TaskEnvironment.GetAbsolutePath("logs"));`.
+
+**Fix skipped (diagnostic still reported):** when there is no editable `Execute()` in the current document, when `Execute()` is expression-bodied (no statement block to prepend to), or when the task has no accessible `TaskEnvironment` member to root the path through.
 
 ## Analysis Scope
 
@@ -180,7 +226,7 @@ The analyzer determines what to check based on the type declaration:
 | Type | Rules Applied |
 |---|---|
 | Any class implementing `ITask` | MSBuildTask0001–MSBuildTask0005 |
-| Multithreaded tasks (`IMultiThreadableTask` or `[MSBuildMultiThreadableTask]`) | MSBuildTask0006–MSBuildTask0007 |
+| Multithreaded tasks (`IMultiThreadableTask` or `[MSBuildMultiThreadableTask]`) | MSBuildTask0006–MSBuildTask0008 |
 | Class implementing `IMultiThreadableTask` | All seven rules |
 | Class with `[MSBuildMultiThreadableTask]` attribute | All seven rules |
 | Helper class with `[MSBuildMultiThreadableTaskAnalyzed]` attribute | MSBuildTask0001–MSBuildTask0005 |
@@ -194,7 +240,7 @@ The `[MSBuildMultiThreadableTaskAnalyzed]` attribute allows opting helper classe
 
 - **MSBuildTask0001** is always **Error** — these APIs are never safe in any MSBuild task.
 - **MSBuildTask0002–MSBuildTask0005** report as **Warning** for all task types.
-- **MSBuildTask0006–MSBuildTask0007** report as **Info** — these are modernization suggestions, not correctness issues.
+- **MSBuildTask0006–MSBuildTask0008** report as **Info** — these are modernization suggestions, not correctness issues.
 
 ## Code Fixes
 
@@ -213,10 +259,14 @@ The analyzer ships with a code fix provider that offers automatic replacements:
 | MSBuildTask0006: `new FileInfo(FilePath)` / `new DirectoryInfo(DirPath)` | → Retype property to `FileInfo`/`DirectoryInfo` and replace conversion with direct property usage |
 | MSBuildTask0007: `int.Parse(Item.ItemSpec)` | → Retype `Item` to ``ITaskItem<int>`` and replace parse with `Item.Value` |
 | MSBuildTask0007: `new FileInfo(item.ItemSpec)` in `foreach` over `ITaskItem[]` | → Retype source property to ``ITaskItem<FileInfo>[]`` and replace with `item.Value` |
+| MSBuildTask0007: `new AbsolutePath(Item.GetMetadata("FullPath"))` | → Retype `Item` to ``ITaskItem<AbsolutePath>`` and replace with `Item.Value` |
+| MSBuildTask0008: relative default `= "obj"` on a path property | → Retype the property (unset default) and move the default into `Execute()` as a guarded, `TaskEnvironment`-rooted assignment |
 
 The MSBuildTask0003 fixer intelligently finds the first **unwrapped** path argument rather than blindly wrapping the first argument — so for `File.Copy(safePath, unsafePath)` it correctly wraps the second argument.
 
-The MSBuildTask0006/MSBuildTask0007 fixer is conservative by design: it only offers a fix when every reference to the property can be safely rewritten as part of the same change, so the resulting code keeps compiling after the property type is updated.
+The MSBuildTask0006/MSBuildTask0007 fixer is conservative by design: it only offers a fix when every reference to the property — across all partial declarations of the task type, in the current document — can be safely rewritten as part of the same change, so the resulting code keeps compiling after the property type is updated. If the property is referenced from another file (a partial class spread across documents) in a way this single-document fix can't rewrite, no fix is offered.
+
+When the property has a meaningful default (a non-empty string literal), the fixer only preserves it when the literal is **already fully qualified** (e.g. `= "C:/logs"`), re-expressing it through the `AbsolutePath` constructor: `= new AbsolutePath("C:/logs")` for an `AbsolutePath` property, and `= new FileInfo(new AbsolutePath("C:/logs"))` / `= new DirectoryInfo(new AbsolutePath("C:/logs"))` for the `FileInfo`/`DirectoryInfo` cases (mirroring the engine's string → `AbsolutePath` → `FileInfo`/`DirectoryInfo` chain). A **relative** default (such as `= "obj"`) is deliberately *not* rewritten: MSBuild roots a relative path via `TaskEnvironment.GetAbsolutePath`, but `TaskEnvironment` is only set by the engine *after* the task is constructed, so it isn't available inside a property initializer (which runs in the constructor). Emitting `new AbsolutePath("obj")` there would throw at construction time, so the fix is skipped instead. The fix is likewise skipped when the default isn't a compile-time constant or isn't a plausible path value, rather than dropping or corrupting the default.
 
 ## Compiler Diagnostic Suppressions
 
@@ -307,7 +357,7 @@ public class CopyFiles : Task, IMultiThreadableTask
 
 ## Tests
 
-135 tests covering all rules, safe patterns, edge cases, code fixes, and compiler diagnostic suppression:
+182 tests covering all rules, safe patterns, edge cases, code fixes, and compiler diagnostic suppression:
 
 ```
 cd src/TaskAnalyzer.Tests
@@ -322,9 +372,10 @@ dotnet test
 | `MultiThreadableTaskCodeFixProvider.cs` | Code fixes for MSBuildTask0002 and MSBuildTask0003 |
 | `BannedApiDefinitions.cs` | ~50 banned API entries resolved via `DocumentationCommentId` for O(1) symbol lookup |
 | `SharedAnalyzerHelpers.cs` | Shared path safety analysis, banned API resolution, and interface checking helpers |
-| `DiagnosticDescriptors.cs` | Seven diagnostic descriptors in category `MSBuild.TaskAuthoring` |
-| `DiagnosticIds.cs` | Public constants: `MSBuildTask0001`–`MSBuildTask0007` |
-| `PreferTypedParameterAnalyzer.cs` | Analyzer for MSBuildTask0006 and MSBuildTask0007 — detects manual path construction, ItemSpec parsing, Path.Combine usage (any argument position), helper method wrapping, FileInfo/DirectoryInfo construction through AbsolutePath intermediaries, and System.IO consumption sites (`File.*`/`Directory.*`/`FileStream`/`StreamReader`/`StreamWriter`) that bias suggestions toward `FileInfo`/`DirectoryInfo` |
+| `DiagnosticDescriptors.cs` | Eight diagnostic descriptors in category `MSBuild.TaskAuthoring` |
+| `DiagnosticIds.cs` | Public constants: `MSBuildTask0001`–`MSBuildTask0008` |
+| `PreferTypedParameterAnalyzer.cs` | Analyzer for MSBuildTask0006, MSBuildTask0007, and MSBuildTask0008 — detects manual path construction, ItemSpec parsing, Path.Combine usage (first argument only), helper method wrapping, FileInfo/DirectoryInfo construction through AbsolutePath intermediaries, System.IO consumption sites (`File.*`/`Directory.*`/`FileStream`/`StreamReader`/`StreamWriter`) that bias suggestions toward `FileInfo`/`DirectoryInfo`, and relative default paths that must be initialized in `Execute()` |
+| `PathDefaultClassifier.cs` | Shared classification of string path defaults as fully-qualified vs relative (host-independent, netstandard2.0-safe) |
 
 ### Performance
 

--- a/src/TaskAnalyzer/README.md
+++ b/src/TaskAnalyzer/README.md
@@ -209,8 +209,14 @@ The analyzer ships with a code fix provider that offers automatic replacements:
 | MSBuildTask0002: `Environment.CurrentDirectory` | → `TaskEnvironment.ProjectDirectory` |
 | MSBuildTask0002: `Directory.GetCurrentDirectory()` | → `TaskEnvironment.ProjectDirectory` |
 | MSBuildTask0003: `File.Exists(relativePath)` | → `File.Exists(TaskEnvironment.GetAbsolutePath(relativePath))` |
+| MSBuildTask0006: `new AbsolutePath(InputPath)` | → Retype `InputPath` to `AbsolutePath` and replace conversion with direct property usage |
+| MSBuildTask0006: `new FileInfo(FilePath)` / `new DirectoryInfo(DirPath)` | → Retype property to `FileInfo`/`DirectoryInfo` and replace conversion with direct property usage |
+| MSBuildTask0007: `int.Parse(Item.ItemSpec)` | → Retype `Item` to ``ITaskItem<int>`` and replace parse with `Item.Value` |
+| MSBuildTask0007: `new FileInfo(item.ItemSpec)` in `foreach` over `ITaskItem[]` | → Retype source property to ``ITaskItem<FileInfo>[]`` and replace with `item.Value` |
 
 The MSBuildTask0003 fixer intelligently finds the first **unwrapped** path argument rather than blindly wrapping the first argument — so for `File.Copy(safePath, unsafePath)` it correctly wraps the second argument.
+
+The MSBuildTask0006/MSBuildTask0007 fixer is conservative by design: it only offers a fix when every reference to the property can be safely rewritten as part of the same change, so the resulting code keeps compiling after the property type is updated.
 
 ## Compiler Diagnostic Suppressions
 

--- a/src/TaskAnalyzer/SharedAnalyzerHelpers.cs
+++ b/src/TaskAnalyzer/SharedAnalyzerHelpers.cs
@@ -208,7 +208,7 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
             if (operation is IPropertyReferenceOperation propRef && propRef.Property.Name == "FullName")
             {
                 var containingTypeName = propRef.Property.ContainingType?.ToDisplayString();
-                if (containingTypeName is "System.IO.FileSystemInfo" or "System.IO.FileInfo" or "System.IO.DirectoryInfo")
+                if (containingTypeName is WellKnownTypeNames.FileSystemInfoFullName or WellKnownTypeNames.FileInfoFullName or WellKnownTypeNames.DirectoryInfoFullName)
                 {
                     return true;
                 }
@@ -317,8 +317,8 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                 // Core System.IO file/directory types
                 "System.IO.File",
                 "System.IO.Directory",
-                "System.IO.FileInfo",
-                "System.IO.DirectoryInfo",
+                WellKnownTypeNames.FileInfoFullName,
+                WellKnownTypeNames.DirectoryInfoFullName,
                 "System.IO.FileStream",
                 "System.IO.StreamReader",
                 "System.IO.StreamWriter",

--- a/src/TaskAnalyzer/SharedAnalyzerHelpers.cs
+++ b/src/TaskAnalyzer/SharedAnalyzerHelpers.cs
@@ -388,5 +388,28 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
 
             return false;
         }
+
+        /// <summary>
+        /// Enumerates the properties declared on <paramref name="type"/> and all of its base types,
+        /// most-derived first. A property hidden or overridden in a more derived type is yielded only
+        /// once, via its most-derived declaration (matched by name). The <see cref="object"/> base is
+        /// skipped since it declares no task-relevant properties.
+        /// </summary>
+        internal static IEnumerable<IPropertySymbol> GetPropertiesIncludingBaseTypes(INamedTypeSymbol type)
+        {
+            var seen = new HashSet<string>(StringComparer.Ordinal);
+            for (INamedTypeSymbol? current = type;
+                 current is not null && current.SpecialType != SpecialType.System_Object;
+                 current = current.BaseType)
+            {
+                foreach (var member in current.GetMembers())
+                {
+                    if (member is IPropertySymbol property && seen.Add(property.Name))
+                    {
+                        yield return property;
+                    }
+                }
+            }
+        }
     }
 }

--- a/src/TaskAnalyzer/WellKnownTypeNames.cs
+++ b/src/TaskAnalyzer/WellKnownTypeNames.cs
@@ -13,6 +13,9 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
         internal const string TaskEnvironmentFullName = "Microsoft.Build.Framework.TaskEnvironment";
         internal const string AbsolutePathFullName = "Microsoft.Build.Framework.AbsolutePath";
         internal const string ITaskItemFullName = "Microsoft.Build.Framework.ITaskItem";
+        internal const string ITaskItem2FullName = "Microsoft.Build.Framework.ITaskItem2";
+        internal const string ITaskItemOfTFullName = "Microsoft.Build.Framework.ITaskItem`1";
+        internal const string OutputAttributeFullName = "Microsoft.Build.Framework.OutputAttribute";
         internal const string RequiredAttributeFullName = "Microsoft.Build.Framework.RequiredAttribute";
         internal const string AnalyzedAttributeFullName = "Microsoft.Build.Framework.MSBuildMultiThreadableTaskAnalyzedAttribute";
         internal const string MultiThreadableTaskAttributeFullName = "Microsoft.Build.Framework.MSBuildMultiThreadableTaskAttribute";

--- a/src/TaskAnalyzer/WellKnownTypeNames.cs
+++ b/src/TaskAnalyzer/WellKnownTypeNames.cs
@@ -20,5 +20,8 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
         internal const string AnalyzedAttributeFullName = "Microsoft.Build.Framework.MSBuildMultiThreadableTaskAnalyzedAttribute";
         internal const string MultiThreadableTaskAttributeFullName = "Microsoft.Build.Framework.MSBuildMultiThreadableTaskAttribute";
         internal const string ConsoleFullName = "System.Console";
+        internal const string FileSystemInfoFullName = "System.IO.FileSystemInfo";
+        internal const string FileInfoFullName = "System.IO.FileInfo";
+        internal const string DirectoryInfoFullName = "System.IO.DirectoryInfo";
     }
 }


### PR DESCRIPTION
## Summary

Adds two Roslyn analyzers to the MSBuild task analyzer package that suggest migration from string to typed task parameters (AbsolutePath/FileInfo/DirectoryInfo/ITaskItem<T>):

- **MSBuildTask0006 (PreferTypedPathParameter)**: Fires when a task property uses 
new AbsolutePath(Prop), 
new FileInfo(Prop), or similar patterns, suggesting the property be retyped to the stronger type.
- **MSBuildTask0007 (PreferTypedTaskItem)**: Fires when item.ItemSpec is passed to a path/type constructor, suggesting the property use ITaskItem<T> instead.

Both analyzers include code-fix providers that automatically apply the suggested retyping.

Analyzers are restricted to multithreaded tasks only (classes implementing `IMultiThreadableTask` or annotated with the `[MSBuildMultiThreadableTask]` attribute).

## Stacked on
- Requires: #13971 (core typed parameter support)
- Next: #13973 (unsupported type analyzer)

/cc @baronfel
