### PR TITLE
Add Roslyn analyzer (MSBuildTask0009) warning for unsupported ITaskItem<T> type arguments

### DIFF
--- a/src/TaskAnalyzer.Tests/PreferTypedParameterAnalyzerTests.cs
+++ b/src/TaskAnalyzer.Tests/PreferTypedParameterAnalyzerTests.cs
@@ -1424,4 +1424,27 @@ public class PreferTypedParameterAnalyzerTests
 
         diags.ShouldContain(d => d.Id == DiagnosticIds.PreferTypedTaskItem);
     }
+
+    [Fact]
+    public async Task DateTimeParse_FromItemSpec_ProducesDiagnostic()
+    {
+        var diags = await GetTypedParameterDiagnosticsAsync("""
+            using System;
+            using Microsoft.Build.Framework;
+            [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
+            public class MyTask : Microsoft.Build.Utilities.Task, Microsoft.Build.Framework.IMultiThreadableTask
+            {
+                public ITaskItem Item { get; set; } = null!;
+                public TaskEnvironment TaskEnvironment { get; set; } = null!;
+                public override bool Execute()
+                {
+                    var timestamp = DateTime.Parse(Item.ItemSpec);
+                    return true;
+                }
+            }
+            """);
+
+        diags.ShouldContain(d => d.Id == DiagnosticIds.PreferTypedTaskItem);
+        diags[0].GetMessage().ShouldContain("DateTime");
+    }
 }

--- a/src/TaskAnalyzer.Tests/TestHelpers.cs
+++ b/src/TaskAnalyzer.Tests/TestHelpers.cs
@@ -207,6 +207,21 @@ internal static class TestHelpers
     }
 
     /// <summary>
+    /// Runs the UnsupportedTaskItemTypeAnalyzer on the given source code and returns analyzer diagnostics.
+    /// Source is combined with framework stubs automatically.
+    /// </summary>
+    public static async System.Threading.Tasks.Task<ImmutableArray<Diagnostic>> GetUnsupportedTaskItemTypeDiagnosticsAsync(string source)
+    {
+        var compilation = CreateCompilation(source);
+        var analyzer = new UnsupportedTaskItemTypeAnalyzer();
+        var compilationWithAnalyzers = compilation.WithAnalyzers(
+            ImmutableArray.Create<DiagnosticAnalyzer>(analyzer));
+
+        var allDiags = await compilationWithAnalyzers.GetAnalyzerDiagnosticsAsync();
+        return allDiags;
+    }
+
+    /// <summary>
     /// Creates a compilation with the given source code and framework stubs.
     /// </summary>
     public static CSharpCompilation CreateCompilation(string source)

--- a/src/TaskAnalyzer.Tests/UnsupportedTaskItemTypeAnalyzerTests.cs
+++ b/src/TaskAnalyzer.Tests/UnsupportedTaskItemTypeAnalyzerTests.cs
@@ -114,7 +114,7 @@ public class UnsupportedTaskItemTypeAnalyzerTests
     }
 
     [Fact]
-    public async Task OutputProperty_NoDiagnostic()
+    public async Task OutputProperty_ProducesDiagnostic()
     {
         var diags = await GetUnsupportedTaskItemTypeDiagnosticsAsync("""
             using System;
@@ -127,7 +127,7 @@ public class UnsupportedTaskItemTypeAnalyzerTests
             }
             """);
 
-        diags.ShouldNotContain(d => d.Id == DiagnosticIds.UnsupportedTaskItemType);
+        diags.ShouldContain(d => d.Id == DiagnosticIds.UnsupportedTaskItemType);
     }
 
     // ═══════════════════════════════════════════════════════════════════════
@@ -184,6 +184,42 @@ public class UnsupportedTaskItemTypeAnalyzerTests
             """);
 
         diags.ShouldContain(d => d.Id == DiagnosticIds.UnsupportedTaskItemType);
+    }
+
+    [Fact]
+    public async Task InheritedProperty_ProducesDiagnostic()
+    {
+        var diags = await GetUnsupportedTaskItemTypeDiagnosticsAsync("""
+            using System;
+            using Microsoft.Build.Framework;
+            public class BaseParameters
+            {
+                public ITaskItem<Guid> Item { get; set; } = null!;
+            }
+            public class MyTask : BaseParameters, ITask
+            {
+                public IBuildEngine BuildEngine { get; set; } = new BuildEngineStub();
+                public bool Execute() => true;
+            }
+            """);
+
+        diags.ShouldContain(d => d.Id == DiagnosticIds.UnsupportedTaskItemType);
+    }
+
+    [Fact]
+    public async Task StaticProperty_NoDiagnostic()
+    {
+        var diags = await GetUnsupportedTaskItemTypeDiagnosticsAsync("""
+            using System;
+            using Microsoft.Build.Framework;
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                public static ITaskItem<Guid> Item { get; set; } = null!;
+                public override bool Execute() => true;
+            }
+            """);
+
+        diags.ShouldNotContain(d => d.Id == DiagnosticIds.UnsupportedTaskItemType);
     }
 
     // ═══════════════════════════════════════════════════════════════════════

--- a/src/TaskAnalyzer.Tests/UnsupportedTaskItemTypeAnalyzerTests.cs
+++ b/src/TaskAnalyzer.Tests/UnsupportedTaskItemTypeAnalyzerTests.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer.Tests;
 public class UnsupportedTaskItemTypeAnalyzerTests
 {
     // ═══════════════════════════════════════════════════════════════════════
-    // Supported types — no diagnostic expected
+    // Value types are not yet supported by the task parameter binder
     // ═══════════════════════════════════════════════════════════════════════
 
     [Theory]
@@ -33,7 +33,7 @@ public class UnsupportedTaskItemTypeAnalyzerTests
     [InlineData("char")]
     [InlineData("System.DateTime")]
     [InlineData("string")]
-    public async Task SupportedValueType_NoDiagnostic(string typeName)
+    public async Task ValueType_ProducesDiagnostic(string typeName)
     {
         var diags = await GetUnsupportedTaskItemTypeDiagnosticsAsync($$"""
             using Microsoft.Build.Framework;
@@ -44,7 +44,7 @@ public class UnsupportedTaskItemTypeAnalyzerTests
             }
             """);
 
-        diags.ShouldNotContain(d => d.Id == DiagnosticIds.UnsupportedTaskItemType);
+        diags.ShouldContain(d => d.Id == DiagnosticIds.UnsupportedTaskItemType);
     }
 
     [Fact]
@@ -95,17 +95,17 @@ public class UnsupportedTaskItemTypeAnalyzerTests
     }
 
     // ═══════════════════════════════════════════════════════════════════════
-    // Array variants of supported types — no diagnostic expected
+    // Array variants
     // ═══════════════════════════════════════════════════════════════════════
 
     [Fact]
-    public async Task SupportedTypeArray_NoDiagnostic()
+    public async Task SupportedPathTypeArray_NoDiagnostic()
     {
         var diags = await GetUnsupportedTaskItemTypeDiagnosticsAsync("""
             using Microsoft.Build.Framework;
             public class MyTask : Microsoft.Build.Utilities.Task
             {
-                public ITaskItem<int>[] Items { get; set; } = null!;
+                public ITaskItem<AbsolutePath>[] Items { get; set; } = null!;
                 public override bool Execute() => true;
             }
             """);

--- a/src/TaskAnalyzer.Tests/UnsupportedTaskItemTypeAnalyzerTests.cs
+++ b/src/TaskAnalyzer.Tests/UnsupportedTaskItemTypeAnalyzerTests.cs
@@ -1,0 +1,209 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Threading.Tasks;
+using Shouldly;
+using Xunit;
+using static Microsoft.Build.TaskAuthoring.Analyzer.Tests.TestHelpers;
+
+namespace Microsoft.Build.TaskAuthoring.Analyzer.Tests;
+
+/// <summary>
+/// Tests for <see cref="UnsupportedTaskItemTypeAnalyzer"/> covering MSBuildTask0009.
+/// </summary>
+public class UnsupportedTaskItemTypeAnalyzerTests
+{
+    // ═══════════════════════════════════════════════════════════════════════
+    // Supported types — no diagnostic expected
+    // ═══════════════════════════════════════════════════════════════════════
+
+    [Theory]
+    [InlineData("int")]
+    [InlineData("bool")]
+    [InlineData("long")]
+    [InlineData("double")]
+    [InlineData("float")]
+    [InlineData("decimal")]
+    [InlineData("byte")]
+    [InlineData("sbyte")]
+    [InlineData("short")]
+    [InlineData("ushort")]
+    [InlineData("uint")]
+    [InlineData("ulong")]
+    [InlineData("char")]
+    [InlineData("System.DateTime")]
+    [InlineData("string")]
+    public async Task SupportedValueType_NoDiagnostic(string typeName)
+    {
+        var diags = await GetUnsupportedTaskItemTypeDiagnosticsAsync($$"""
+            using Microsoft.Build.Framework;
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                public ITaskItem<{{typeName}}> Item { get; set; } = null!;
+                public override bool Execute() => true;
+            }
+            """);
+
+        diags.ShouldNotContain(d => d.Id == DiagnosticIds.UnsupportedTaskItemType);
+    }
+
+    [Fact]
+    public async Task AbsolutePath_NoDiagnostic()
+    {
+        var diags = await GetUnsupportedTaskItemTypeDiagnosticsAsync("""
+            using Microsoft.Build.Framework;
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                public ITaskItem<AbsolutePath> Item { get; set; } = null!;
+                public override bool Execute() => true;
+            }
+            """);
+
+        diags.ShouldNotContain(d => d.Id == DiagnosticIds.UnsupportedTaskItemType);
+    }
+
+    [Fact]
+    public async Task FileInfo_NoDiagnostic()
+    {
+        var diags = await GetUnsupportedTaskItemTypeDiagnosticsAsync("""
+            using System.IO;
+            using Microsoft.Build.Framework;
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                public ITaskItem<FileInfo> Item { get; set; } = null!;
+                public override bool Execute() => true;
+            }
+            """);
+
+        diags.ShouldNotContain(d => d.Id == DiagnosticIds.UnsupportedTaskItemType);
+    }
+
+    [Fact]
+    public async Task DirectoryInfo_NoDiagnostic()
+    {
+        var diags = await GetUnsupportedTaskItemTypeDiagnosticsAsync("""
+            using System.IO;
+            using Microsoft.Build.Framework;
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                public ITaskItem<DirectoryInfo> Item { get; set; } = null!;
+                public override bool Execute() => true;
+            }
+            """);
+
+        diags.ShouldNotContain(d => d.Id == DiagnosticIds.UnsupportedTaskItemType);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Array variants of supported types — no diagnostic expected
+    // ═══════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task SupportedTypeArray_NoDiagnostic()
+    {
+        var diags = await GetUnsupportedTaskItemTypeDiagnosticsAsync("""
+            using Microsoft.Build.Framework;
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                public ITaskItem<int>[] Items { get; set; } = null!;
+                public override bool Execute() => true;
+            }
+            """);
+
+        diags.ShouldNotContain(d => d.Id == DiagnosticIds.UnsupportedTaskItemType);
+    }
+
+    [Fact]
+    public async Task OutputProperty_NoDiagnostic()
+    {
+        var diags = await GetUnsupportedTaskItemTypeDiagnosticsAsync("""
+            using System;
+            using Microsoft.Build.Framework;
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                [Output]
+                public ITaskItem<Guid> Item { get; set; } = null!;
+                public override bool Execute() => true;
+            }
+            """);
+
+        diags.ShouldNotContain(d => d.Id == DiagnosticIds.UnsupportedTaskItemType);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Unsupported types — diagnostic expected
+    // ═══════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task Guid_ProducesDiagnostic()
+    {
+        var diags = await GetUnsupportedTaskItemTypeDiagnosticsAsync("""
+            using System;
+            using Microsoft.Build.Framework;
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                public ITaskItem<Guid> Item { get; set; } = null!;
+                public override bool Execute() => true;
+            }
+            """);
+
+        diags.ShouldContain(d => d.Id == DiagnosticIds.UnsupportedTaskItemType);
+        diags[0].GetMessage().ShouldContain("Item");
+        diags[0].GetMessage().ShouldContain("Guid");
+    }
+
+    [Fact]
+    public async Task TimeSpan_ProducesDiagnostic()
+    {
+        var diags = await GetUnsupportedTaskItemTypeDiagnosticsAsync("""
+            using System;
+            using Microsoft.Build.Framework;
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                public ITaskItem<TimeSpan> Duration { get; set; } = null!;
+                public override bool Execute() => true;
+            }
+            """);
+
+        diags.ShouldContain(d => d.Id == DiagnosticIds.UnsupportedTaskItemType);
+        diags[0].GetMessage().ShouldContain("Duration");
+        diags[0].GetMessage().ShouldContain("TimeSpan");
+    }
+
+    [Fact]
+    public async Task UnsupportedTypeArray_ProducesDiagnostic()
+    {
+        var diags = await GetUnsupportedTaskItemTypeDiagnosticsAsync("""
+            using System;
+            using Microsoft.Build.Framework;
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                public ITaskItem<Guid>[] Items { get; set; } = null!;
+                public override bool Execute() => true;
+            }
+            """);
+
+        diags.ShouldContain(d => d.Id == DiagnosticIds.UnsupportedTaskItemType);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Non-task classes — no diagnostic expected
+    // ═══════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task NonTaskClass_NoDiagnostic()
+    {
+        // A class that does not implement ITask should not trigger the diagnostic,
+        // even if it has an ITaskItem<Guid> property.
+        var diags = await GetUnsupportedTaskItemTypeDiagnosticsAsync("""
+            using System;
+            using Microsoft.Build.Framework;
+            public class NotATask
+            {
+                public ITaskItem<Guid> Item { get; set; } = null!;
+            }
+            """);
+
+        diags.ShouldNotContain(d => d.Id == DiagnosticIds.UnsupportedTaskItemType);
+    }
+}

--- a/src/TaskAnalyzer/AnalyzerReleases.Unshipped.md
+++ b/src/TaskAnalyzer/AnalyzerReleases.Unshipped.md
@@ -10,3 +10,4 @@ MSBuildTask0005 | MSBuild.TaskAuthoring | Warning | Transitive unsafe API usage 
 MSBuildTask0006 | MSBuild.TaskAuthoring | Info | Prefer typed path parameter (AbsolutePath/FileInfo/DirectoryInfo) over string (code fix available)
 MSBuildTask0007 | MSBuild.TaskAuthoring | Info | Prefer ITaskItem<T> over manual ItemSpec parsing (code fix available)
 MSBuildTask0008 | MSBuild.TaskAuthoring | Info | Initialize a relative default path in Execute() so TaskEnvironment can root it when the property is retyped (code fix available)
+MSBuildTask0009 | MSBuild.TaskAuthoring | Warning | ITaskItem<T> used with a type argument T that ValueTypeParser cannot parse at runtime

--- a/src/TaskAnalyzer/AnalyzerReleases.Unshipped.md
+++ b/src/TaskAnalyzer/AnalyzerReleases.Unshipped.md
@@ -10,4 +10,4 @@ MSBuildTask0005 | MSBuild.TaskAuthoring | Warning | Transitive unsafe API usage 
 MSBuildTask0006 | MSBuild.TaskAuthoring | Info | Prefer typed path parameter (AbsolutePath/FileInfo/DirectoryInfo) over string (code fix available)
 MSBuildTask0007 | MSBuild.TaskAuthoring | Info | Prefer ITaskItem<T> over manual ItemSpec parsing (code fix available)
 MSBuildTask0008 | MSBuild.TaskAuthoring | Info | Initialize a relative default path in Execute() so TaskEnvironment can root it when the property is retyped (code fix available)
-MSBuildTask0009 | MSBuild.TaskAuthoring | Warning | ITaskItem<T> used with a type argument T that ValueTypeParser cannot parse at runtime
+MSBuildTask0009 | MSBuild.TaskAuthoring | Warning | ITaskItem<T> used with a type argument T that MSBuild cannot bind as a task parameter

--- a/src/TaskAnalyzer/DiagnosticDescriptors.cs
+++ b/src/TaskAnalyzer/DiagnosticDescriptors.cs
@@ -88,11 +88,11 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
         public static readonly DiagnosticDescriptor UnsupportedTaskItemType = new(
             id: DiagnosticIds.UnsupportedTaskItemType,
             title: "ITaskItem<T> used with unsupported type argument",
-            messageFormat: "Task property '{0}' uses ITaskItem<{1}> but '{1}' is not supported by MSBuild's ValueTypeParser. Use one of the supported types: {2}.",
+            messageFormat: "Task property '{0}' uses ITaskItem<{1}> but MSBuild cannot automatically parse '{1}' from item metadata. Use one of the supported types: {2}.",
             category: "MSBuild.TaskAuthoring",
             defaultSeverity: DiagnosticSeverity.Warning,
             isEnabledByDefault: true,
-            description: "MSBuild can only parse ITaskItem<T> properties when T is a type supported by ValueTypeParser. Using an unsupported type will cause a runtime failure when MSBuild tries to bind the parameter.");
+            description: "MSBuild can only bind ITaskItem<T> properties when T is a supported type. Using an unsupported type will cause a runtime failure when MSBuild tries to bind the parameter.");
 
         public static ImmutableArray<DiagnosticDescriptor> All { get; } = ImmutableArray.Create(
             CriticalError,

--- a/src/TaskAnalyzer/DiagnosticDescriptors.cs
+++ b/src/TaskAnalyzer/DiagnosticDescriptors.cs
@@ -85,6 +85,15 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
             isEnabledByDefault: true,
             description: "A relative default path cannot be rooted in a property initializer because the MSBuild engine only assigns TaskEnvironment after the task is constructed. Move the default into Execute(), where TaskEnvironment.GetAbsolutePath can resolve it, guarding the assignment so a value bound from the project is not overwritten.");
 
+        public static readonly DiagnosticDescriptor UnsupportedTaskItemType = new(
+            id: DiagnosticIds.UnsupportedTaskItemType,
+            title: "ITaskItem<T> used with unsupported type argument",
+            messageFormat: "Task property '{0}' uses ITaskItem<{1}> but '{1}' is not supported by MSBuild's ValueTypeParser. Use one of the supported types: {2}.",
+            category: "MSBuild.TaskAuthoring",
+            defaultSeverity: DiagnosticSeverity.Warning,
+            isEnabledByDefault: true,
+            description: "MSBuild can only parse ITaskItem<T> properties when T is a type supported by ValueTypeParser. Using an unsupported type will cause a runtime failure when MSBuild tries to bind the parameter.");
+
         public static ImmutableArray<DiagnosticDescriptor> All { get; } = ImmutableArray.Create(
             CriticalError,
             TaskEnvironmentRequired,
@@ -93,6 +102,7 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
             TransitiveUnsafeCall,
             PreferTypedPathParameter,
             PreferTypedTaskItem,
-            InitializeRelativeDefaultInExecute);
+            InitializeRelativeDefaultInExecute,
+            UnsupportedTaskItemType);
     }
 }

--- a/src/TaskAnalyzer/DiagnosticIds.cs
+++ b/src/TaskAnalyzer/DiagnosticIds.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
         /// <summary>Task input property has a relative default path that should be initialized in Execute() where TaskEnvironment can root it.</summary>
         public const string InitializeRelativeDefaultInExecute = "MSBuildTask0008";
 
-        /// <summary>Task property uses ITaskItem&lt;T&gt; with a type argument not supported by ValueTypeParser.</summary>
+        /// <summary>Task property uses ITaskItem&lt;T&gt; with a type argument not supported by MSBuild's task parameter binder.</summary>
         public const string UnsupportedTaskItemType = "MSBuildTask0009";
     }
 }

--- a/src/TaskAnalyzer/DiagnosticIds.cs
+++ b/src/TaskAnalyzer/DiagnosticIds.cs
@@ -32,5 +32,8 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
 
         /// <summary>Task input property has a relative default path that should be initialized in Execute() where TaskEnvironment can root it.</summary>
         public const string InitializeRelativeDefaultInExecute = "MSBuildTask0008";
+
+        /// <summary>Task property uses ITaskItem&lt;T&gt; with a type argument not supported by ValueTypeParser.</summary>
+        public const string UnsupportedTaskItemType = "MSBuildTask0009";
     }
 }

--- a/src/TaskAnalyzer/PreferTypedParameterAnalyzer.cs
+++ b/src/TaskAnalyzer/PreferTypedParameterAnalyzer.cs
@@ -859,8 +859,11 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                 method.ContainingType is not null &&
                 method.ContainingType.IsValueType)
             {
-                string typeName = method.ContainingType.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
-                return s_supportedValueTypeNames.Contains(typeName) ? typeName : null;
+                return SupportedTaskItemTypes.TryGetSpecialTypeDisplayName(
+                    method.ContainingType.SpecialType,
+                    out string? typeName)
+                    ? typeName
+                    : null;
             }
 
             // Convert.ToXxx methods
@@ -888,28 +891,6 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
 
             return null;
         }
-
-        /// <summary>
-        /// Value type names (as minimal C# names) that ValueTypeParser supports.
-        /// Only these types should be suggested by the analyzer.
-        /// </summary>
-        private static readonly System.Collections.Generic.HashSet<string> s_supportedValueTypeNames =
-            new(System.StringComparer.Ordinal)
-            {
-                "bool",
-                "char",
-                "byte",
-                "sbyte",
-                "short",
-                "ushort",
-                "int",
-                "uint",
-                "long",
-                "ulong",
-                "float",
-                "double",
-                "decimal",
-            };
 
         /// <summary>
         /// Checks if the given operation traces back (with at most one level of local indirection)

--- a/src/TaskAnalyzer/README.md
+++ b/src/TaskAnalyzer/README.md
@@ -22,6 +22,7 @@ This analyzer catches unsafe API usage at compile time and offers code fixes to 
 | **MSBuildTask0006** | Info | Tasks with `[MSBuildMultiThreadableTask]` applied directly | Prefer typed path parameter over string |
 | **MSBuildTask0007** | Info | Tasks with `[MSBuildMultiThreadableTask]` applied directly | Prefer `ITaskItem<T>` over manual ItemSpec parsing |
 | **MSBuildTask0008** | Info | Tasks with `[MSBuildMultiThreadableTask]` applied directly | Initialize a relative-default path property in `Execute()` |
+| **MSBuildTask0009** | Warning | All `ITask` implementations | `ITaskItem<T>` used with unsupported type argument |
 
 ### MSBuildTask0001 — Critical: No Safe Alternative
 
@@ -225,15 +226,35 @@ For a reference-typed target (`FileInfo`/`DirectoryInfo`) the guard is a null-co
 
 **Fix skipped (diagnostic still reported):** when there is no editable `Execute()` in the current document, when `Execute()` is expression-bodied (no statement block to prepend to), or when the task has no accessible `TaskEnvironment` member to root the path through.
 
+### MSBuildTask0009 — Unsupported `ITaskItem<T>` Type Argument
+
+When a task property is typed as `ITaskItem<T>` or `ITaskItem<T>[]` but `T` is not a type that MSBuild's `ValueTypeParser` can parse at runtime, a **Warning** is emitted. Using an unsupported type will cause a runtime failure when MSBuild tries to bind the parameter.
+
+**Supported type arguments:** `bool`, `char`, `byte`, `sbyte`, `short`, `ushort`, `int`, `uint`, `long`, `ulong`, `float`, `double`, `decimal`, `DateTime`, `string`, `AbsolutePath`, `FileInfo`, `DirectoryInfo`.
+
+```csharp
+// ⚠️ MSBuildTask0009: Task property 'Id' uses ITaskItem<Guid> but 'Guid' is not supported
+public class MyTask : Task
+{
+    public ITaskItem<System.Guid> Id { get; set; }       // warning
+    public ITaskItem<System.TimeSpan>[] Durations { get; set; }  // warning
+    public ITaskItem<int> Count { get; set; }             // OK
+}
+```
+
+No code fix is offered for MSBuildTask0009 — the resolution depends on the intended semantics (e.g., switching to `string` and parsing manually, or choosing a different supported type).
+
+**Scope:** All `ITask` implementations (not just multithreaded tasks), since using an unsupported T is always a runtime correctness problem.
+
 ## Analysis Scope
 
 The analyzer determines what to check based on the type declaration:
 
 | Type | Rules Applied |
 |---|---|
-| Any class implementing `ITask` | MSBuildTask0001–MSBuildTask0005 |
+| Any class implementing `ITask` | MSBuildTask0001–MSBuildTask0005, MSBuildTask0009 |
 | Class with `[MSBuildMultiThreadableTask]` attribute applied directly | MSBuildTask0006–MSBuildTask0008 (in addition to MSBuildTask0001–0005) |
-| Class implementing `IMultiThreadableTask` without the attribute | MSBuildTask0001–MSBuildTask0005 only |
+| Class implementing `IMultiThreadableTask` without the attribute | MSBuildTask0001–MSBuildTask0005 and MSBuildTask0009 only |
 | Helper class with `[MSBuildMultiThreadableTaskAnalyzed]` attribute | MSBuildTask0001–MSBuildTask0005 |
 | Regular class (no task interface or attribute) | Not analyzed |
 
@@ -246,7 +267,7 @@ The `[MSBuildMultiThreadableTaskAnalyzed]` attribute allows opting helper classe
 ### Severity Levels
 
 - **MSBuildTask0001** is always **Error** — these APIs are never safe in any MSBuild task.
-- **MSBuildTask0002–MSBuildTask0005** report as **Warning** for all task types.
+- **MSBuildTask0002–MSBuildTask0005 and MSBuildTask0009** report as **Warning** for all task types.
 - **MSBuildTask0006–MSBuildTask0008** report as **Info** — these are modernization suggestions, not correctness issues.
 
 ## Code Fixes

--- a/src/TaskAnalyzer/README.md
+++ b/src/TaskAnalyzer/README.md
@@ -228,9 +228,9 @@ For a reference-typed target (`FileInfo`/`DirectoryInfo`) the guard is a null-co
 
 ### MSBuildTask0009 — Unsupported `ITaskItem<T>` Type Argument
 
-When a task property is typed as `ITaskItem<T>` or `ITaskItem<T>[]` but `T` is not a type that MSBuild's `ValueTypeParser` can parse at runtime, a **Warning** is emitted. Using an unsupported type will cause a runtime failure when MSBuild tries to bind the parameter.
+When a task property is typed as `ITaskItem<T>` or `ITaskItem<T>[]` but `T` is not supported by MSBuild's task parameter binder, a **Warning** is emitted. Using an unsupported type will cause a runtime failure when MSBuild tries to bind the parameter.
 
-**Supported type arguments:** `bool`, `char`, `byte`, `sbyte`, `short`, `ushort`, `int`, `uint`, `long`, `ulong`, `float`, `double`, `decimal`, `DateTime`, `string`, `AbsolutePath`, `FileInfo`, `DirectoryInfo`.
+**Supported type arguments:** `AbsolutePath`, `FileInfo`, `DirectoryInfo`.
 
 ```csharp
 // ⚠️ MSBuildTask0009: Task property 'Id' uses ITaskItem<Guid> but 'Guid' is not supported
@@ -238,7 +238,7 @@ public class MyTask : Task
 {
     public ITaskItem<System.Guid> Id { get; set; }       // warning
     public ITaskItem<System.TimeSpan>[] Durations { get; set; }  // warning
-    public ITaskItem<int> Count { get; set; }             // OK
+    public ITaskItem<int> Count { get; set; }             // warning until value-type binding is supported
 }
 ```
 

--- a/src/TaskAnalyzer/SupportedTaskItemTypes.cs
+++ b/src/TaskAnalyzer/SupportedTaskItemTypes.cs
@@ -1,0 +1,91 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Immutable;
+using System.Text;
+using Microsoft.CodeAnalysis;
+
+namespace Microsoft.Build.TaskAuthoring.Analyzer
+{
+    internal static class SupportedTaskItemTypes
+    {
+        private readonly struct SupportedSpecialType
+        {
+            internal SupportedSpecialType(SpecialType specialType, string displayName)
+            {
+                SpecialType = specialType;
+                DisplayName = displayName;
+            }
+
+            internal SpecialType SpecialType { get; }
+            internal string DisplayName { get; }
+        }
+
+        private static readonly ImmutableArray<SupportedSpecialType> s_specialTypes =
+            ImmutableArray.Create(
+                new SupportedSpecialType(SpecialType.System_Boolean, "bool"),
+                new SupportedSpecialType(SpecialType.System_Char, "char"),
+                new SupportedSpecialType(SpecialType.System_Byte, "byte"),
+                new SupportedSpecialType(SpecialType.System_SByte, "sbyte"),
+                new SupportedSpecialType(SpecialType.System_Int16, "short"),
+                new SupportedSpecialType(SpecialType.System_UInt16, "ushort"),
+                new SupportedSpecialType(SpecialType.System_Int32, "int"),
+                new SupportedSpecialType(SpecialType.System_UInt32, "uint"),
+                new SupportedSpecialType(SpecialType.System_Int64, "long"),
+                new SupportedSpecialType(SpecialType.System_UInt64, "ulong"),
+                new SupportedSpecialType(SpecialType.System_Single, "float"),
+                new SupportedSpecialType(SpecialType.System_Double, "double"),
+                new SupportedSpecialType(SpecialType.System_Decimal, "decimal"),
+                new SupportedSpecialType(SpecialType.System_DateTime, "DateTime"),
+                new SupportedSpecialType(SpecialType.System_String, "string"));
+
+        internal static string DisplayNames { get; } = CreateDisplayNames();
+
+        internal static bool TryGetSpecialTypeDisplayName(SpecialType specialType, out string? displayName)
+        {
+            foreach (SupportedSpecialType supportedType in s_specialTypes)
+            {
+                if (supportedType.SpecialType == specialType)
+                {
+                    displayName = supportedType.DisplayName;
+                    return true;
+                }
+            }
+
+            displayName = null;
+            return false;
+        }
+
+        internal static bool IsSupported(
+            ITypeSymbol type,
+            INamedTypeSymbol? absolutePathType,
+            INamedTypeSymbol? fileInfoType,
+            INamedTypeSymbol? directoryInfoType)
+        {
+            if (TryGetSpecialTypeDisplayName(type.SpecialType, out _))
+            {
+                return true;
+            }
+
+            return (absolutePathType is not null && SymbolEqualityComparer.Default.Equals(type, absolutePathType))
+                || (fileInfoType is not null && SymbolEqualityComparer.Default.Equals(type, fileInfoType))
+                || (directoryInfoType is not null && SymbolEqualityComparer.Default.Equals(type, directoryInfoType));
+        }
+
+        private static string CreateDisplayNames()
+        {
+            var builder = new StringBuilder();
+            foreach (SupportedSpecialType supportedType in s_specialTypes)
+            {
+                if (builder.Length > 0)
+                {
+                    builder.Append(", ");
+                }
+
+                builder.Append(supportedType.DisplayName);
+            }
+
+            return builder.Append(", AbsolutePath, FileInfo, DirectoryInfo").ToString();
+        }
+    }
+}

--- a/src/TaskAnalyzer/SupportedTaskItemTypes.cs
+++ b/src/TaskAnalyzer/SupportedTaskItemTypes.cs
@@ -8,6 +8,8 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
 {
     internal static class SupportedTaskItemTypes
     {
+        // These are the types ValueTypeParser can parse and MSBuildTask0007 may suggest. This set is
+        // intentionally broader than the ITaskItem<T> types accepted by the current engine binder below.
         private readonly struct SupportedSpecialType
         {
             internal SupportedSpecialType(SpecialType specialType, string displayName)
@@ -38,7 +40,9 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                 new SupportedSpecialType(SpecialType.System_DateTime, "DateTime"),
                 new SupportedSpecialType(SpecialType.System_String, "string"));
 
-        internal const string DisplayNames = "AbsolutePath, FileInfo, DirectoryInfo";
+        // Keep the user-facing list next to IsSupportedTaskItemType. Both mirror the runtime Type-based
+        // TaskItemTypeDetector, which the Roslyn analyzer cannot call with compile-time ITypeSymbol values.
+        internal const string SupportedTaskItemTypeDisplayNames = "AbsolutePath, FileInfo, DirectoryInfo";
 
         internal static bool TryGetSpecialTypeDisplayName(SpecialType specialType, out string? displayName)
         {

--- a/src/TaskAnalyzer/SupportedTaskItemTypes.cs
+++ b/src/TaskAnalyzer/SupportedTaskItemTypes.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Immutable;
-using System.Text;
 using Microsoft.CodeAnalysis;
 
 namespace Microsoft.Build.TaskAuthoring.Analyzer
@@ -39,7 +38,7 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                 new SupportedSpecialType(SpecialType.System_DateTime, "DateTime"),
                 new SupportedSpecialType(SpecialType.System_String, "string"));
 
-        internal static string DisplayNames { get; } = CreateDisplayNames();
+        internal const string DisplayNames = "AbsolutePath, FileInfo, DirectoryInfo";
 
         internal static bool TryGetSpecialTypeDisplayName(SpecialType specialType, out string? displayName)
         {
@@ -56,36 +55,15 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
             return false;
         }
 
-        internal static bool IsSupported(
+        internal static bool IsSupportedTaskItemType(
             ITypeSymbol type,
             INamedTypeSymbol? absolutePathType,
             INamedTypeSymbol? fileInfoType,
             INamedTypeSymbol? directoryInfoType)
         {
-            if (TryGetSpecialTypeDisplayName(type.SpecialType, out _))
-            {
-                return true;
-            }
-
             return (absolutePathType is not null && SymbolEqualityComparer.Default.Equals(type, absolutePathType))
                 || (fileInfoType is not null && SymbolEqualityComparer.Default.Equals(type, fileInfoType))
                 || (directoryInfoType is not null && SymbolEqualityComparer.Default.Equals(type, directoryInfoType));
-        }
-
-        private static string CreateDisplayNames()
-        {
-            var builder = new StringBuilder();
-            foreach (SupportedSpecialType supportedType in s_specialTypes)
-            {
-                if (builder.Length > 0)
-                {
-                    builder.Append(", ");
-                }
-
-                builder.Append(supportedType.DisplayName);
-            }
-
-            return builder.Append(", AbsolutePath, FileInfo, DirectoryInfo").ToString();
         }
     }
 }

--- a/src/TaskAnalyzer/UnsupportedTaskItemTypeAnalyzer.cs
+++ b/src/TaskAnalyzer/UnsupportedTaskItemTypeAnalyzer.cs
@@ -1,0 +1,126 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using static Microsoft.Build.TaskAuthoring.Analyzer.SharedAnalyzerHelpers;
+
+namespace Microsoft.Build.TaskAuthoring.Analyzer
+{
+    /// <summary>
+    /// Roslyn analyzer that warns when a task property is typed as <c>ITaskItem&lt;T&gt;</c> or
+    /// <c>ITaskItem&lt;T&gt;[]</c> where <c>T</c> is not in the set of types that MSBuild's
+    /// <c>ValueTypeParser</c> can parse at runtime.
+    ///
+    /// MSBuildTask0009: ITaskItem&lt;T&gt; used with unsupported type argument.
+    /// </summary>
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class UnsupportedTaskItemTypeAnalyzer : DiagnosticAnalyzer
+    {
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
+            ImmutableArray.Create(DiagnosticDescriptors.UnsupportedTaskItemType);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.EnableConcurrentExecution();
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.RegisterCompilationStartAction(OnCompilationStart);
+        }
+
+        private static void OnCompilationStart(CompilationStartAnalysisContext compilationContext)
+        {
+            var iTaskType = compilationContext.Compilation.GetTypeByMetadataName(WellKnownTypeNames.ITaskFullName);
+            if (iTaskType is null)
+            {
+                return;
+            }
+
+            var iTaskItemOfTType = compilationContext.Compilation.GetTypeByMetadataName(WellKnownTypeNames.ITaskItemOfTFullName);
+            if (iTaskItemOfTType is null)
+            {
+                return;
+            }
+
+            var outputAttributeType = compilationContext.Compilation.GetTypeByMetadataName(WellKnownTypeNames.OutputAttributeFullName);
+            var absolutePathType = compilationContext.Compilation.GetTypeByMetadataName(WellKnownTypeNames.AbsolutePathFullName);
+            var fileInfoType = compilationContext.Compilation.GetTypeByMetadataName(WellKnownTypeNames.FileInfoFullName);
+            var directoryInfoType = compilationContext.Compilation.GetTypeByMetadataName(WellKnownTypeNames.DirectoryInfoFullName);
+
+            compilationContext.RegisterSymbolAction(symbolContext =>
+            {
+                var namedType = (INamedTypeSymbol)symbolContext.Symbol;
+
+                // Only check ITask implementations
+                if (!ImplementsInterface(namedType, iTaskType))
+                {
+                    return;
+                }
+
+                foreach (var member in namedType.GetMembers())
+                {
+                    if (member is not IPropertySymbol property)
+                    {
+                        continue;
+                    }
+
+                    if (property.DeclaredAccessibility != Accessibility.Public ||
+                        property.SetMethod is null ||
+                        HasAttribute(property, outputAttributeType))
+                    {
+                        continue;
+                    }
+
+                    // Unwrap array: ITaskItem<T>[] → ITaskItem<T>
+                    ITypeSymbol propertyType = property.Type;
+                    if (propertyType is IArrayTypeSymbol arrayType)
+                    {
+                        propertyType = arrayType.ElementType;
+                    }
+
+                    // Check if the property type is ITaskItem<T>
+                    if (propertyType is not INamedTypeSymbol namedPropertyType ||
+                        !namedPropertyType.IsGenericType ||
+                        !SymbolEqualityComparer.Default.Equals(namedPropertyType.OriginalDefinition, iTaskItemOfTType))
+                    {
+                        continue;
+                    }
+
+                    ITypeSymbol typeArg = namedPropertyType.TypeArguments[0];
+
+                    // Check if T is in the supported set
+                    if (SupportedTaskItemTypes.IsSupported(typeArg, absolutePathType, fileInfoType, directoryInfoType))
+                    {
+                        continue;
+                    }
+
+                    symbolContext.ReportDiagnostic(Diagnostic.Create(
+                        DiagnosticDescriptors.UnsupportedTaskItemType,
+                        property.Locations[0],
+                        property.Name,
+                        typeArg.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat),
+                        SupportedTaskItemTypes.DisplayNames));
+                }
+            }, SymbolKind.NamedType);
+        }
+
+        private static bool HasAttribute(IPropertySymbol property, INamedTypeSymbol? attributeType)
+        {
+            if (attributeType is null)
+            {
+                return false;
+            }
+
+            foreach (AttributeData attribute in property.GetAttributes())
+            {
+                if (SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, attributeType))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/TaskAnalyzer/UnsupportedTaskItemTypeAnalyzer.cs
+++ b/src/TaskAnalyzer/UnsupportedTaskItemTypeAnalyzer.cs
@@ -43,7 +43,6 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                 return;
             }
 
-            var outputAttributeType = compilationContext.Compilation.GetTypeByMetadataName(WellKnownTypeNames.OutputAttributeFullName);
             var absolutePathType = compilationContext.Compilation.GetTypeByMetadataName(WellKnownTypeNames.AbsolutePathFullName);
             var fileInfoType = compilationContext.Compilation.GetTypeByMetadataName(WellKnownTypeNames.FileInfoFullName);
             var directoryInfoType = compilationContext.Compilation.GetTypeByMetadataName(WellKnownTypeNames.DirectoryInfoFullName);
@@ -58,16 +57,21 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                     return;
                 }
 
-                foreach (var member in namedType.GetMembers())
+                foreach (IPropertySymbol property in GetPropertiesIncludingBaseTypes(namedType))
                 {
-                    if (member is not IPropertySymbol property)
+                    if (property.DeclaredAccessibility != Accessibility.Public ||
+                        property.SetMethod?.DeclaredAccessibility != Accessibility.Public ||
+                        property.IsStatic)
                     {
                         continue;
                     }
 
-                    if (property.DeclaredAccessibility != Accessibility.Public ||
-                        property.SetMethod is null ||
-                        HasAttribute(property, outputAttributeType))
+                    // A source-declared base task is analyzed by its own symbol action. Avoid reporting its
+                    // properties again for every source-derived task while still covering metadata base tasks.
+                    if (!SymbolEqualityComparer.Default.Equals(property.ContainingType, namedType) &&
+                        property.ContainingType is not null &&
+                        ImplementsInterface(property.ContainingType, iTaskType) &&
+                        HasSourceLocation(property))
                     {
                         continue;
                     }
@@ -97,7 +101,7 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
 
                     symbolContext.ReportDiagnostic(Diagnostic.Create(
                         DiagnosticDescriptors.UnsupportedTaskItemType,
-                        property.Locations[0],
+                        GetDiagnosticLocation(property, namedType),
                         property.Name,
                         typeArg.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat),
                         SupportedTaskItemTypes.DisplayNames));
@@ -105,22 +109,30 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
             }, SymbolKind.NamedType);
         }
 
-        private static bool HasAttribute(IPropertySymbol property, INamedTypeSymbol? attributeType)
+        private static bool HasSourceLocation(ISymbol symbol)
         {
-            if (attributeType is null)
+            foreach (Location location in symbol.Locations)
             {
-                return false;
-            }
-
-            foreach (AttributeData attribute in property.GetAttributes())
-            {
-                if (SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, attributeType))
+                if (location.IsInSource)
                 {
                     return true;
                 }
             }
 
             return false;
+        }
+
+        private static Location GetDiagnosticLocation(IPropertySymbol property, INamedTypeSymbol taskType)
+        {
+            foreach (Location location in property.Locations)
+            {
+                if (location.IsInSource)
+                {
+                    return location;
+                }
+            }
+
+            return taskType.Locations.Length > 0 ? taskType.Locations[0] : Location.None;
         }
     }
 }

--- a/src/TaskAnalyzer/UnsupportedTaskItemTypeAnalyzer.cs
+++ b/src/TaskAnalyzer/UnsupportedTaskItemTypeAnalyzer.cs
@@ -11,8 +11,7 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
 {
     /// <summary>
     /// Roslyn analyzer that warns when a task property is typed as <c>ITaskItem&lt;T&gt;</c> or
-    /// <c>ITaskItem&lt;T&gt;[]</c> where <c>T</c> is not in the set of types that MSBuild's
-    /// <c>ValueTypeParser</c> can parse at runtime.
+    /// <c>ITaskItem&lt;T&gt;[]</c> where <c>T</c> is not supported by MSBuild's task parameter binder.
     ///
     /// MSBuildTask0009: ITaskItem&lt;T&gt; used with unsupported type argument.
     /// </summary>
@@ -94,7 +93,7 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                     ITypeSymbol typeArg = namedPropertyType.TypeArguments[0];
 
                     // Check if T is in the supported set
-                    if (SupportedTaskItemTypes.IsSupported(typeArg, absolutePathType, fileInfoType, directoryInfoType))
+                    if (SupportedTaskItemTypes.IsSupportedTaskItemType(typeArg, absolutePathType, fileInfoType, directoryInfoType))
                     {
                         continue;
                     }

--- a/src/TaskAnalyzer/UnsupportedTaskItemTypeAnalyzer.cs
+++ b/src/TaskAnalyzer/UnsupportedTaskItemTypeAnalyzer.cs
@@ -103,7 +103,7 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                         GetDiagnosticLocation(property, namedType),
                         property.Name,
                         typeArg.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat),
-                        SupportedTaskItemTypes.DisplayNames));
+                        SupportedTaskItemTypes.SupportedTaskItemTypeDisplayNames));
                 }
             }, SymbolKind.NamedType);
         }


### PR DESCRIPTION
## Summary

Adds **MSBuildTask0009 (UnsupportedTaskItemType)**: a Roslyn analyzer that fires when a task property uses `ITaskItem<T>` where `T` is not currently supported by MSBuild's task parameter binder. This catches generic type arguments that would fail at runtime.

The analyzer currently recognizes `AbsolutePath`, `FileInfo`, and `DirectoryInfo`. Primitive and other value types will be added when the engine-side binding support lands.

## Stacked on
- Requires: #13972 (MSBuildTask0006/0007 migration analyzers)
- Next: #13974 (value type support)

/cc @baronfel