### PR TITLE
Align ITaskItem<T> binding with ValueTypeParser and flag culture-sensitive conversions

### DIFF
--- a/src/Build.UnitTests/BackEnd/TaskBuilderTestTask.cs
+++ b/src/Build.UnitTests/BackEnd/TaskBuilderTestTask.cs
@@ -726,6 +726,28 @@ namespace Microsoft.Build.UnitTests.BackEnd
         }
 
         /// <summary>
+        /// A TaskItem&lt;string&gt; parameter.
+        /// </summary>
+        public ITaskItem<string> TaskItemStringParam
+        {
+            set
+            {
+                _testTaskHost?.ParameterSet("TaskItemStringParam", value);
+            }
+        }
+
+        /// <summary>
+        /// A TaskItem&lt;bool&gt; parameter.
+        /// </summary>
+        public ITaskItem<bool> TaskItemBoolParam
+        {
+            set
+            {
+                _testTaskHost?.ParameterSet("TaskItemBoolParam", value);
+            }
+        }
+
+        /// <summary>
         /// A TaskItem&lt;int&gt; array parameter.
         /// </summary>
         public ITaskItem<int>[] TaskItemIntArrayParam

--- a/src/Build.UnitTests/BackEnd/TaskBuilderTestTask.cs
+++ b/src/Build.UnitTests/BackEnd/TaskBuilderTestTask.cs
@@ -252,6 +252,16 @@ namespace Microsoft.Build.UnitTests.BackEnd
         private System.IO.FileInfo _fileInfoOutput;
 
         /// <summary>
+        /// The value for the TaskItemIntOutput.
+        /// </summary>
+        private ITaskItem<int> _taskItemIntOutput;
+
+        /// <summary>
+        /// The value for the TaskItemIntArrayOutput.
+        /// </summary>
+        private ITaskItem<int>[] _taskItemIntArrayOutput;
+
+        /// <summary>
         /// The value for the FileInfoArrayOutput.
         /// </summary>
         private System.IO.FileInfo[] _fileInfoArrayOutput;
@@ -700,6 +710,30 @@ namespace Microsoft.Build.UnitTests.BackEnd
             {
                 _absolutePathArrayOutput = value;
                 _testTaskHost?.ParameterSet("AbsolutePathArrayParam", value);
+            }
+        }
+
+        /// <summary>
+        /// A TaskItem&lt;int&gt; parameter.
+        /// </summary>
+        public ITaskItem<int> TaskItemIntParam
+        {
+            set
+            {
+                _taskItemIntOutput = value;
+                _testTaskHost?.ParameterSet("TaskItemIntParam", value);
+            }
+        }
+
+        /// <summary>
+        /// A TaskItem&lt;int&gt; array parameter.
+        /// </summary>
+        public ITaskItem<int>[] TaskItemIntArrayParam
+        {
+            set
+            {
+                _taskItemIntArrayOutput = value;
+                _testTaskHost?.ParameterSet("TaskItemIntArrayParam", value);
             }
         }
 
@@ -1381,6 +1415,32 @@ namespace Microsoft.Build.UnitTests.BackEnd
             {
                 _testTaskHost?.OutputRead("FileInfoOutput", _fileInfoOutput);
                 return _fileInfoOutput;
+            }
+        }
+
+        /// <summary>
+        /// A TaskItem&lt;int&gt; output.
+        /// </summary>
+        [Output]
+        public ITaskItem<int> TaskItemIntOutput
+        {
+            get
+            {
+                _testTaskHost?.OutputRead("TaskItemIntOutput", _taskItemIntOutput);
+                return _taskItemIntOutput;
+            }
+        }
+
+        /// <summary>
+        /// A TaskItem&lt;int&gt; array output.
+        /// </summary>
+        [Output]
+        public ITaskItem<int>[] TaskItemIntArrayOutput
+        {
+            get
+            {
+                _testTaskHost?.OutputRead("TaskItemIntArrayOutput", _taskItemIntArrayOutput);
+                return _taskItemIntArrayOutput;
             }
         }
 

--- a/src/Build.UnitTests/BackEnd/TaskExecutionHost_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/TaskExecutionHost_Tests.cs
@@ -577,7 +577,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
         }
 
         /// <summary>
-        /// Validate that setting a TaskItem&lt;string&gt; parameter preserves the item identity.
+        /// Validate that setting a TaskItem&lt;string&gt; parameter preserves the item value.
         /// </summary>
         [Fact]
         public void TestSetTaskItemStringParam()

--- a/src/Build.UnitTests/BackEnd/TaskExecutionHost_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/TaskExecutionHost_Tests.cs
@@ -577,6 +577,24 @@ namespace Microsoft.Build.UnitTests.BackEnd
         }
 
         /// <summary>
+        /// Validate that setting a TaskItem&lt;string&gt; parameter preserves the item identity.
+        /// </summary>
+        [Fact]
+        public void TestSetTaskItemStringParam()
+        {
+            ValidateTaskParameter("TaskItemStringParam", "value", new Microsoft.Build.Framework.TaskItem<string>("value"));
+        }
+
+        /// <summary>
+        /// Validate that setting a TaskItem&lt;bool&gt; parameter uses MSBuild boolean parsing.
+        /// </summary>
+        [Fact]
+        public void TestSetTaskItemBoolParam()
+        {
+            ValidateTaskParameter("TaskItemBoolParam", "yes", new Microsoft.Build.Framework.TaskItem<bool>(true));
+        }
+
+        /// <summary>
         /// Validate that parse failures from TaskItem&lt;T&gt; scalar binding are reported as invalid task parameter values.
         /// </summary>
         [Fact]

--- a/src/Build.UnitTests/BackEnd/TaskExecutionHost_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/TaskExecutionHost_Tests.cs
@@ -565,6 +565,123 @@ namespace Microsoft.Build.UnitTests.BackEnd
 
         #endregion
 
+        #region TaskItem<T> Params
+
+        /// <summary>
+        /// Validate that setting a TaskItem&lt;int&gt; parameter with a valid integer works.
+        /// </summary>
+        [Fact]
+        public void TestSetTaskItemIntParam()
+        {
+            ValidateTaskParameter("TaskItemIntParam", "42", new Microsoft.Build.Framework.TaskItem<int>(42));
+        }
+
+        /// <summary>
+        /// Validate that parse failures from TaskItem&lt;T&gt; scalar binding are reported as invalid task parameter values.
+        /// </summary>
+        [Fact]
+        public void TestSetTaskItemIntParamInvalidValue()
+        {
+            var parameters = GetStandardParametersDictionary(true);
+            parameters["TaskItemIntParam"] = ("not-an-int", ElementLocation.Create("foo.proj"));
+
+            Should.Throw<InvalidProjectFileException>(() => _host.SetTaskParameters(parameters));
+        }
+
+        /// <summary>
+        /// Validate that setting the parameter with an empty value does not cause it to be set.
+        /// </summary>
+        [Fact]
+        public void TestSetTaskItemIntParamEmptyAttribute()
+        {
+            ValidateTaskParameterNotSet("TaskItemIntParam", "");
+        }
+
+        /// <summary>
+        /// Validate that setting the parameter with a property which evaluates to an empty value does not cause it to be set.
+        /// </summary>
+        [Fact]
+        public void TestSetTaskItemIntParamEmptyProperty()
+        {
+            ValidateTaskParameterNotSet("TaskItemIntParam", "$(NonExistentProperty)");
+        }
+
+        /// <summary>
+        /// Validate that setting the parameter with an item which evaluates to an empty value does not cause it to be set.
+        /// </summary>
+        [Fact]
+        public void TestSetTaskItemIntParamEmptyItem()
+        {
+            ValidateTaskParameterNotSet("TaskItemIntParam", "@(NonExistentItem)");
+        }
+
+        #endregion
+
+        #region TaskItem<T> Array Params
+
+        /// <summary>
+        /// Validate that setting a TaskItem&lt;int&gt; array with a single value sets the correct value.
+        /// </summary>
+        [Fact]
+        public void TestSetTaskItemIntArrayParam()
+        {
+            ValidateTaskParameterArray("TaskItemIntArrayParam", "42", new Microsoft.Build.Framework.TaskItem<int>[] { new Microsoft.Build.Framework.TaskItem<int>(42) });
+        }
+
+        /// <summary>
+        /// Validate that setting a TaskItem&lt;int&gt; array with multiple values sets the correct values.
+        /// </summary>
+        [Fact]
+        public void TestSetTaskItemIntArrayParamMultiple()
+        {
+            ValidateTaskParameterArray("TaskItemIntArrayParam", "10;20;30", new Microsoft.Build.Framework.TaskItem<int>[] {
+                new Microsoft.Build.Framework.TaskItem<int>(10),
+                new Microsoft.Build.Framework.TaskItem<int>(20),
+                new Microsoft.Build.Framework.TaskItem<int>(30)
+            });
+        }
+
+        /// <summary>
+        /// Validate that parse failures from TaskItem&lt;T&gt; array binding are reported as invalid task parameter values.
+        /// </summary>
+        [Fact]
+        public void TestSetTaskItemIntArrayParamInvalidValue()
+        {
+            var parameters = GetStandardParametersDictionary(true);
+            parameters["TaskItemIntArrayParam"] = ("10;not-an-int", ElementLocation.Create("foo.proj"));
+
+            Should.Throw<InvalidProjectFileException>(() => _host.SetTaskParameters(parameters));
+        }
+
+        /// <summary>
+        /// Validate that setting the parameter with an empty value does not cause it to be set.
+        /// </summary>
+        [Fact]
+        public void TestSetTaskItemIntArrayParamEmptyAttribute()
+        {
+            ValidateTaskParameterNotSet("TaskItemIntArrayParam", "");
+        }
+
+        /// <summary>
+        /// Validate that setting the parameter with a property which evaluates to an empty value does not cause it to be set.
+        /// </summary>
+        [Fact]
+        public void TestSetTaskItemIntArrayParamEmptyProperty()
+        {
+            ValidateTaskParameterNotSet("TaskItemIntArrayParam", "$(NonExistentProperty)");
+        }
+
+        /// <summary>
+        /// Validate that setting the parameter with an item which evaluates to an empty value does not cause it to be set.
+        /// </summary>
+        [Fact]
+        public void TestSetTaskItemIntArrayParamEmptyItem()
+        {
+            ValidateTaskParameterNotSet("TaskItemIntArrayParam", "@(NonExistentItem)");
+        }
+
+        #endregion
+
         #region FileInfo Params
 
         /// <summary>
@@ -1356,6 +1473,50 @@ namespace Microsoft.Build.UnitTests.BackEnd
         {
             SetTaskParameter("ItemArrayParam", "@(ItemListContainingTwoItems)");
             ValidateOutputProperty("ItemArrayOutput", String.Concat(_twoItems[0].ItemSpec, ";", _twoItems[1].ItemSpec));
+        }
+
+        #endregion
+
+        #region TaskItem<T> Outputs
+
+        /// <summary>
+        /// Validate that a TaskItem&lt;int&gt; output to an item produces the correct evaluated include.
+        /// </summary>
+        [Fact]
+        public void TestOutputTaskItemIntToItem()
+        {
+            SetTaskParameter("TaskItemIntParam", "42");
+            ValidateOutputItem("TaskItemIntOutput", "42");
+        }
+
+        /// <summary>
+        /// Validate that a TaskItem&lt;int&gt; output to a property produces the correct evaluated value.
+        /// </summary>
+        [Fact]
+        public void TestOutputTaskItemIntToProperty()
+        {
+            SetTaskParameter("TaskItemIntParam", "42");
+            ValidateOutputProperty("TaskItemIntOutput", "42");
+        }
+
+        /// <summary>
+        /// Validate that a TaskItem&lt;int&gt; array output to items produces the correct evaluated includes.
+        /// </summary>
+        [Fact]
+        public void TestOutputTaskItemIntArrayToItems()
+        {
+            SetTaskParameter("TaskItemIntArrayParam", "42;99");
+            ValidateOutputItems("TaskItemIntArrayOutput", new string[] { "42", "99" });
+        }
+
+        /// <summary>
+        /// Validate that a TaskItem&lt;int&gt; array output to a property produces the correct semi-colon-delimited evaluated value.
+        /// </summary>
+        [Fact]
+        public void TestOutputTaskItemIntArrayToProperty()
+        {
+            SetTaskParameter("TaskItemIntArrayParam", "42;99");
+            ValidateOutputProperty("TaskItemIntArrayOutput", "42;99");
         }
 
         #endregion

--- a/src/Build.UnitTests/BackEnd/TaskParameterTypeVerifier_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/TaskParameterTypeVerifier_Tests.cs
@@ -343,9 +343,21 @@ namespace Microsoft.Build.UnitTests.BackEnd
         }
 
         [Fact]
+        public void IsValidScalarInputParameter_ITaskItemOfInt_ReturnsTrue()
+        {
+            Assert.True(TaskParameterTypeVerifier.IsValidScalarInputParameter(typeof(ITaskItem<int>)));
+        }
+
+        [Fact]
         public void IsValidVectorInputParameter_ITaskItemOfAbsolutePathArray_ReturnsTrue()
         {
             Assert.True(TaskParameterTypeVerifier.IsValidVectorInputParameter(typeof(ITaskItem<AbsolutePath>[])));
+        }
+
+        [Fact]
+        public void IsValidVectorInputParameter_ITaskItemOfIntArray_ReturnsTrue()
+        {
+            Assert.True(TaskParameterTypeVerifier.IsValidVectorInputParameter(typeof(ITaskItem<int>[])));
         }
 
         [Fact]
@@ -361,6 +373,18 @@ namespace Microsoft.Build.UnitTests.BackEnd
         }
 
         [Fact]
+        public void IsAssignableToITaskItem_ITaskItemOfInt_ReturnsTrue()
+        {
+            Assert.True(TaskParameterTypeVerifier.IsAssignableToITaskItem(typeof(ITaskItem<int>)));
+        }
+
+        [Fact]
+        public void IsAssignableToITaskItem_ITaskItemOfIntArray_ReturnsTrue()
+        {
+            Assert.True(TaskParameterTypeVerifier.IsAssignableToITaskItem(typeof(ITaskItem<int>[])));
+        }
+
+        [Fact]
         public void IsValidOutputParameter_ITaskItemOfAbsolutePath_ReturnsTrue()
         {
             Assert.True(TaskParameterTypeVerifier.IsValidOutputParameter(typeof(ITaskItem<AbsolutePath>)));
@@ -370,6 +394,18 @@ namespace Microsoft.Build.UnitTests.BackEnd
         public void IsValidOutputParameter_ITaskItemOfAbsolutePathArray_ReturnsTrue()
         {
             Assert.True(TaskParameterTypeVerifier.IsValidOutputParameter(typeof(ITaskItem<AbsolutePath>[])));
+        }
+
+        [Fact]
+        public void IsValidOutputParameter_ITaskItemOfInt_ReturnsTrue()
+        {
+            Assert.True(TaskParameterTypeVerifier.IsValidOutputParameter(typeof(ITaskItem<int>)));
+        }
+
+        [Fact]
+        public void IsValidOutputParameter_ITaskItemOfIntArray_ReturnsTrue()
+        {
+            Assert.True(TaskParameterTypeVerifier.IsValidOutputParameter(typeof(ITaskItem<int>[])));
         }
 
         [Fact]
@@ -383,6 +419,19 @@ namespace Microsoft.Build.UnitTests.BackEnd
         public void IsValidOutputParameter_TaskItemOfAbsolutePathArray_ReturnsTrue()
         {
             TaskParameterTypeVerifier.IsValidOutputParameter(typeof(TaskItem<AbsolutePath>[])).ShouldBeTrue();
+        }
+
+        [Fact]
+        public void IsAssignableToITaskItem_TaskItemOfIntArray_ReturnsTrue()
+        {
+            typeof(ITaskItem[]).IsAssignableFrom(typeof(TaskItem<int>[])).ShouldBeFalse();
+            TaskParameterTypeVerifier.IsAssignableToITaskItem(typeof(TaskItem<int>[])).ShouldBeTrue();
+        }
+
+        [Fact]
+        public void IsValidOutputParameter_TaskItemOfIntArray_ReturnsTrue()
+        {
+            TaskParameterTypeVerifier.IsValidOutputParameter(typeof(TaskItem<int>[])).ShouldBeTrue();
         }
 
         #endregion

--- a/src/Build.UnitTests/BackEnd/TaskParameterTypeVerifier_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/TaskParameterTypeVerifier_Tests.cs
@@ -322,90 +322,68 @@ namespace Microsoft.Build.UnitTests.BackEnd
             Assert.False(TaskParameterTypeVerifier.IsValidOutputParameter(typeof(object[])));
         }
 
-        // ─── ITaskItem<T> and ITaskItem<T>[] coverage (path-like types) ────────
+        // ─── ITaskItem<T> and ITaskItem<T>[] coverage ─────────────────────────
 
-        [Fact]
-        public void IsValidScalarInputParameter_ITaskItemOfAbsolutePath_ReturnsTrue()
+        public static TheoryData<Type> SupportedTaskItemTypeArguments =>
+            new TheoryData<Type>
+            {
+                typeof(string),
+                typeof(bool),
+                typeof(char),
+                typeof(byte),
+                typeof(sbyte),
+                typeof(short),
+                typeof(ushort),
+                typeof(int),
+                typeof(uint),
+                typeof(long),
+                typeof(ulong),
+                typeof(float),
+                typeof(double),
+                typeof(decimal),
+                typeof(DateTime),
+                typeof(AbsolutePath),
+                typeof(FileInfo),
+                typeof(DirectoryInfo),
+            };
+
+        public static TheoryData<Type> UnsupportedTaskItemTypeArguments =>
+            new TheoryData<Type>
+            {
+                typeof(Guid),
+                typeof(TimeSpan),
+                typeof(int?),
+                typeof(TestEnum),
+                typeof(TestStruct),
+            };
+
+        [Theory]
+        [MemberData(nameof(SupportedTaskItemTypeArguments))]
+        public void SupportedITaskItemTypeArgument_IsAccepted(Type typeArgument)
         {
-            Assert.True(TaskParameterTypeVerifier.IsValidScalarInputParameter(typeof(ITaskItem<AbsolutePath>)));
+            AssertTaskItemTypeArgumentSupport(typeof(ITaskItem<>), typeArgument, expected: true);
+            AssertTaskItemTypeArgumentSupport(typeof(TaskItem<>), typeArgument, expected: true);
         }
 
-        [Fact]
-        public void IsValidScalarInputParameter_ITaskItemOfFileInfo_ReturnsTrue()
+        [Theory]
+        [MemberData(nameof(UnsupportedTaskItemTypeArguments))]
+        public void UnsupportedITaskItemTypeArgument_IsRejected(Type typeArgument)
         {
-            Assert.True(TaskParameterTypeVerifier.IsValidScalarInputParameter(typeof(ITaskItem<FileInfo>)));
+            AssertTaskItemTypeArgumentSupport(typeof(ITaskItem<>), typeArgument, expected: false);
+            AssertTaskItemTypeArgumentSupport(typeof(TaskItem<>), typeArgument, expected: false);
         }
 
-        [Fact]
-        public void IsValidScalarInputParameter_ITaskItemOfDirectoryInfo_ReturnsTrue()
+        private static void AssertTaskItemTypeArgumentSupport(Type genericTaskItemType, Type typeArgument, bool expected)
         {
-            Assert.True(TaskParameterTypeVerifier.IsValidScalarInputParameter(typeof(ITaskItem<DirectoryInfo>)));
-        }
+            Type taskItemType = genericTaskItemType.MakeGenericType(typeArgument);
+            Type taskItemArrayType = taskItemType.MakeArrayType();
 
-        [Fact]
-        public void IsValidScalarInputParameter_ITaskItemOfInt_ReturnsTrue()
-        {
-            Assert.True(TaskParameterTypeVerifier.IsValidScalarInputParameter(typeof(ITaskItem<int>)));
-        }
-
-        [Fact]
-        public void IsValidVectorInputParameter_ITaskItemOfAbsolutePathArray_ReturnsTrue()
-        {
-            Assert.True(TaskParameterTypeVerifier.IsValidVectorInputParameter(typeof(ITaskItem<AbsolutePath>[])));
-        }
-
-        [Fact]
-        public void IsValidVectorInputParameter_ITaskItemOfIntArray_ReturnsTrue()
-        {
-            Assert.True(TaskParameterTypeVerifier.IsValidVectorInputParameter(typeof(ITaskItem<int>[])));
-        }
-
-        [Fact]
-        public void IsAssignableToITaskItem_ITaskItemOfAbsolutePath_ReturnsTrue()
-        {
-            Assert.True(TaskParameterTypeVerifier.IsAssignableToITaskItem(typeof(ITaskItem<AbsolutePath>)));
-        }
-
-        [Fact]
-        public void IsAssignableToITaskItem_ITaskItemOfAbsolutePathArray_ReturnsTrue()
-        {
-            Assert.True(TaskParameterTypeVerifier.IsAssignableToITaskItem(typeof(ITaskItem<AbsolutePath>[])));
-        }
-
-        [Fact]
-        public void IsAssignableToITaskItem_ITaskItemOfInt_ReturnsTrue()
-        {
-            Assert.True(TaskParameterTypeVerifier.IsAssignableToITaskItem(typeof(ITaskItem<int>)));
-        }
-
-        [Fact]
-        public void IsAssignableToITaskItem_ITaskItemOfIntArray_ReturnsTrue()
-        {
-            Assert.True(TaskParameterTypeVerifier.IsAssignableToITaskItem(typeof(ITaskItem<int>[])));
-        }
-
-        [Fact]
-        public void IsValidOutputParameter_ITaskItemOfAbsolutePath_ReturnsTrue()
-        {
-            Assert.True(TaskParameterTypeVerifier.IsValidOutputParameter(typeof(ITaskItem<AbsolutePath>)));
-        }
-
-        [Fact]
-        public void IsValidOutputParameter_ITaskItemOfAbsolutePathArray_ReturnsTrue()
-        {
-            Assert.True(TaskParameterTypeVerifier.IsValidOutputParameter(typeof(ITaskItem<AbsolutePath>[])));
-        }
-
-        [Fact]
-        public void IsValidOutputParameter_ITaskItemOfInt_ReturnsTrue()
-        {
-            Assert.True(TaskParameterTypeVerifier.IsValidOutputParameter(typeof(ITaskItem<int>)));
-        }
-
-        [Fact]
-        public void IsValidOutputParameter_ITaskItemOfIntArray_ReturnsTrue()
-        {
-            Assert.True(TaskParameterTypeVerifier.IsValidOutputParameter(typeof(ITaskItem<int>[])));
+            TaskParameterTypeVerifier.IsValidScalarInputParameter(taskItemType).ShouldBe(expected);
+            TaskParameterTypeVerifier.IsValidVectorInputParameter(taskItemArrayType).ShouldBe(expected);
+            TaskParameterTypeVerifier.IsAssignableToITaskItem(taskItemType).ShouldBe(expected);
+            TaskParameterTypeVerifier.IsAssignableToITaskItem(taskItemArrayType).ShouldBe(expected);
+            TaskParameterTypeVerifier.IsValidOutputParameter(taskItemType).ShouldBe(expected);
+            TaskParameterTypeVerifier.IsValidOutputParameter(taskItemArrayType).ShouldBe(expected);
         }
 
         [Fact]
@@ -432,6 +410,15 @@ namespace Microsoft.Build.UnitTests.BackEnd
         public void IsValidOutputParameter_TaskItemOfIntArray_ReturnsTrue()
         {
             TaskParameterTypeVerifier.IsValidOutputParameter(typeof(TaskItem<int>[])).ShouldBeTrue();
+        }
+
+        private enum TestEnum
+        {
+            Value,
+        }
+
+        private readonly struct TestStruct
+        {
         }
 
         #endregion

--- a/src/Build.UnitTests/BackEnd/TaskParameterTypeVerifier_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/TaskParameterTypeVerifier_Tests.cs
@@ -72,6 +72,12 @@ namespace Microsoft.Build.UnitTests.BackEnd
             Assert.False(TaskParameterTypeVerifier.IsValidScalarInputParameter(typeof(string[])));
         }
 
+        [Fact]
+        public void IsValidScalarInputParameter_CustomValueType_ReturnsTrue()
+        {
+            TaskParameterTypeVerifier.IsValidScalarInputParameter(typeof(TestStruct)).ShouldBeTrue();
+        }
+
         #endregion
 
         #region IsValidVectorInputParameter Tests
@@ -192,6 +198,18 @@ namespace Microsoft.Build.UnitTests.BackEnd
         public void IsValueTypeOutputParameter_Object_ReturnsFalse()
         {
             Assert.False(TaskParameterTypeVerifier.IsValueTypeOutputParameter(typeof(object)));
+        }
+
+        [Fact]
+        public void IsValueTypeOutputParameter_TaskItemOfInt_ReturnsFalse()
+        {
+            TaskParameterTypeVerifier.IsValueTypeOutputParameter(typeof(TaskItem<int>)).ShouldBeFalse();
+        }
+
+        [Fact]
+        public void IsValueTypeOutputParameter_CustomValueType_ReturnsTrue()
+        {
+            TaskParameterTypeVerifier.IsValueTypeOutputParameter(typeof(TestStruct)).ShouldBeTrue();
         }
 
         #endregion
@@ -373,6 +391,15 @@ namespace Microsoft.Build.UnitTests.BackEnd
             AssertTaskItemTypeArgumentSupport(typeof(TaskItem<>), typeArgument, expected: false);
         }
 
+        [Fact]
+        public void DerivedTaskItemInterface_IsRejectedForInputAndAcceptedForOutput()
+        {
+            TaskParameterTypeVerifier.IsValidScalarInputParameter(typeof(ICustomTaskItem<int>)).ShouldBeFalse();
+            TaskParameterTypeVerifier.IsValidVectorInputParameter(typeof(ICustomTaskItem<int>[])).ShouldBeFalse();
+            TaskParameterTypeVerifier.IsValidOutputParameter(typeof(ICustomTaskItem<int>)).ShouldBeTrue();
+            TaskParameterTypeVerifier.IsValidOutputParameter(typeof(ICustomTaskItem<int>[])).ShouldBeTrue();
+        }
+
         private static void AssertTaskItemTypeArgumentSupport(Type genericTaskItemType, Type typeArgument, bool expected)
         {
             Type taskItemType = genericTaskItemType.MakeGenericType(typeArgument);
@@ -418,6 +445,10 @@ namespace Microsoft.Build.UnitTests.BackEnd
         }
 
         private readonly struct TestStruct
+        {
+        }
+
+        private interface ICustomTaskItem<T> : ITaskItem<T>
         {
         }
 

--- a/src/Build/BackEnd/TaskExecutionHost/TaskExecutionHost.cs
+++ b/src/Build/BackEnd/TaskExecutionHost/TaskExecutionHost.cs
@@ -914,7 +914,8 @@ namespace Microsoft.Build.BackEnd
         #region Local Methods
 
         /// <summary>
-        /// Checks if a type is TaskItem&lt;T&gt; or ITaskItem&lt;T&gt; where T is path-like.
+        /// Checks if a type is TaskItem&lt;T&gt; or ITaskItem&lt;T&gt; where T is a supported value type
+        /// (including AbsolutePath) or FileInfo/DirectoryInfo.
         /// </summary>
         private static bool IsPathLikeTaskItemOrITaskItemOfT(Type parameterType)
             => TaskParameterTypeVerifier.IsPathLikeITaskItemOfT(parameterType)

--- a/src/Build/BackEnd/TaskExecutionHost/TaskExecutionHost.cs
+++ b/src/Build/BackEnd/TaskExecutionHost/TaskExecutionHost.cs
@@ -914,13 +914,6 @@ namespace Microsoft.Build.BackEnd
         #region Local Methods
 
         /// <summary>
-        /// Checks if a type is TaskItem&lt;T&gt; or ITaskItem&lt;T&gt; where T is supported by ValueTypeParser.
-        /// </summary>
-        private static bool IsSupportedTaskItemOrITaskItemOfT(Type parameterType)
-            => TaskParameterTypeVerifier.IsSupportedITaskItemOfT(parameterType)
-                || TaskParameterTypeVerifier.IsSupportedTaskItemOfT(parameterType, typeof(TaskItem<>).FullName);
-
-        /// <summary>
         /// Cache of compiled constructor delegates that wrap an <see cref="ITaskItem"/> into a
         /// <see cref="TaskItem{T}"/>, keyed by the generic argument T. Building the closed generic type and
         /// resolving the constructor via reflection on every parameter binding is expensive, so the delegate
@@ -1030,7 +1023,7 @@ namespace Microsoft.Build.BackEnd
 
                     return InternalSetTaskParameter(parameter, finalInputs);
                 }
-                else if (IsSupportedTaskItemOrITaskItemOfT(elementType))
+                else if (TaskParameterTypeVerifier.TryGetSupportedTaskItemValueType(elementType, out Type taskItemValueType))
                 {
                     // TaskItem<T> / ITaskItem<T> arrays: wrap each item into the closed generic TaskItem<T>.
 #if NET
@@ -1044,7 +1037,7 @@ namespace Microsoft.Build.BackEnd
                         TaskItem item = taskItems[i];
                         currentItem = item;
                         RecordItemForDisconnectIfNecessary(item);
-                        ITaskItem taskItemOfT = CreateTaskItemOfT(elementType.GetGenericArguments()[0], item);
+                        ITaskItem taskItemOfT = CreateTaskItemOfT(taskItemValueType, item);
                         finalInputs.SetValue(taskItemOfT, i);
                     }
 
@@ -1140,7 +1133,7 @@ namespace Microsoft.Build.BackEnd
             }
 
             Type outputType = outputs.GetType();
-            if (outputType.IsArray && IsSupportedTaskItemOrITaskItemOfT(outputType.GetElementType()))
+            if (outputType.IsArray && typeof(ITaskItem).IsAssignableFrom(outputType.GetElementType()))
             {
                 Array taskItemArray = (Array)outputs;
                 ITaskItem[] result = new ITaskItem[taskItemArray.Length];
@@ -1559,7 +1552,8 @@ namespace Microsoft.Build.BackEnd
 
             try
             {
-                if (parameterType == typeof(ITaskItem) || IsSupportedTaskItemOrITaskItemOfT(parameterType))
+                bool isSupportedTypedTaskItem = TaskParameterTypeVerifier.TryGetSupportedTaskItemValueType(parameterType, out Type taskItemValueType);
+                if (parameterType == typeof(ITaskItem) || isSupportedTypedTaskItem)
                 {
                     // We don't know how many items we're going to end up with, but we'll
                     // keep adding them to this arraylist as we find them.
@@ -1587,9 +1581,9 @@ namespace Microsoft.Build.BackEnd
 
                         RecordItemForDisconnectIfNecessary(finalTaskItems[0]);
 
-                        if (IsSupportedTaskItemOrITaskItemOfT(parameterType))
+                        if (isSupportedTypedTaskItem)
                         {
-                            ITaskItem taskItemOfT = CreateTaskItemOfT(parameterType.GetGenericArguments()[0], finalTaskItems[0]);
+                            ITaskItem taskItemOfT = CreateTaskItemOfT(taskItemValueType, finalTaskItems[0]);
                             success = InternalSetTaskParameter(parameter, taskItemOfT);
                         }
                         else

--- a/src/Build/BackEnd/TaskExecutionHost/TaskExecutionHost.cs
+++ b/src/Build/BackEnd/TaskExecutionHost/TaskExecutionHost.cs
@@ -914,12 +914,11 @@ namespace Microsoft.Build.BackEnd
         #region Local Methods
 
         /// <summary>
-        /// Checks if a type is TaskItem&lt;T&gt; or ITaskItem&lt;T&gt; where T is a supported value type
-        /// (including AbsolutePath) or FileInfo/DirectoryInfo.
+        /// Checks if a type is TaskItem&lt;T&gt; or ITaskItem&lt;T&gt; where T is supported by ValueTypeParser.
         /// </summary>
-        private static bool IsPathLikeTaskItemOrITaskItemOfT(Type parameterType)
-            => TaskParameterTypeVerifier.IsPathLikeITaskItemOfT(parameterType)
-                || TaskParameterTypeVerifier.IsPathLikeTaskItemOfT(parameterType, typeof(TaskItem<>).FullName);
+        private static bool IsSupportedTaskItemOrITaskItemOfT(Type parameterType)
+            => TaskParameterTypeVerifier.IsSupportedITaskItemOfT(parameterType)
+                || TaskParameterTypeVerifier.IsSupportedTaskItemOfT(parameterType, typeof(TaskItem<>).FullName);
 
         /// <summary>
         /// Cache of compiled constructor delegates that wrap an <see cref="ITaskItem"/> into a
@@ -1031,7 +1030,7 @@ namespace Microsoft.Build.BackEnd
 
                     return InternalSetTaskParameter(parameter, finalInputs);
                 }
-                else if (IsPathLikeTaskItemOrITaskItemOfT(elementType))
+                else if (IsSupportedTaskItemOrITaskItemOfT(elementType))
                 {
                     // TaskItem<T> / ITaskItem<T> arrays: wrap each item into the closed generic TaskItem<T>.
 #if NET
@@ -1141,7 +1140,7 @@ namespace Microsoft.Build.BackEnd
             }
 
             Type outputType = outputs.GetType();
-            if (outputType.IsArray && IsPathLikeTaskItemOrITaskItemOfT(outputType.GetElementType()))
+            if (outputType.IsArray && IsSupportedTaskItemOrITaskItemOfT(outputType.GetElementType()))
             {
                 Array taskItemArray = (Array)outputs;
                 ITaskItem[] result = new ITaskItem[taskItemArray.Length];
@@ -1560,7 +1559,7 @@ namespace Microsoft.Build.BackEnd
 
             try
             {
-                if (parameterType == typeof(ITaskItem) || IsPathLikeTaskItemOrITaskItemOfT(parameterType))
+                if (parameterType == typeof(ITaskItem) || IsSupportedTaskItemOrITaskItemOfT(parameterType))
                 {
                     // We don't know how many items we're going to end up with, but we'll
                     // keep adding them to this arraylist as we find them.
@@ -1588,7 +1587,7 @@ namespace Microsoft.Build.BackEnd
 
                         RecordItemForDisconnectIfNecessary(finalTaskItems[0]);
 
-                        if (IsPathLikeTaskItemOrITaskItemOfT(parameterType))
+                        if (IsSupportedTaskItemOrITaskItemOfT(parameterType))
                         {
                             ITaskItem taskItemOfT = CreateTaskItemOfT(parameterType.GetGenericArguments()[0], finalTaskItems[0]);
                             success = InternalSetTaskParameter(parameter, taskItemOfT);

--- a/src/Framework/TaskItemTypeDetector.cs
+++ b/src/Framework/TaskItemTypeDetector.cs
@@ -25,6 +25,11 @@ namespace Microsoft.Build.Shared
         internal static bool IsSupportedPathType(Type type)
             => type == typeof(AbsolutePath) || type == typeof(FileInfo) || type == typeof(DirectoryInfo);
 
+        /// <summary>
+        /// Checks if <paramref name="parameterType"/> is the generic TaskItem type identified by
+        /// <paramref name="genericTaskItemTypeDefinitionFullName"/> where <c>T</c> is a supported value
+        /// type (including <see cref="AbsolutePath"/>) or <see cref="FileInfo"/>/<see cref="DirectoryInfo"/>.
+        /// </summary>
         internal static bool IsPathLikeTaskItemOfT(Type parameterType, string genericTaskItemTypeDefinitionFullName)
         {
             if (!parameterType.IsGenericType)
@@ -45,7 +50,7 @@ namespace Microsoft.Build.Shared
             }
 
             Type typeArg = genericArguments[0];
-            return IsSupportedPathType(typeArg);
+            return typeArg.IsValueType || typeArg == typeof(FileInfo) || typeArg == typeof(DirectoryInfo);
         }
 
         internal static bool IsPathLikeITaskItemOfT(Type parameterType)

--- a/src/Framework/TaskItemTypeDetector.cs
+++ b/src/Framework/TaskItemTypeDetector.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using Microsoft.Build.Framework;
 
@@ -9,10 +10,6 @@ namespace Microsoft.Build.Shared
 {
     internal static class TaskItemTypeDetector
     {
-        // The generic type definitions (ITaskItem<T>/TaskItem<T>) are matched by full type name because
-        // callers pass the FullName of whichever definition they care about (see IsSupportedTaskItemOfT).
-        private const string GenericITaskItemFullName = "Microsoft.Build.Framework.ITaskItem`1";
-
         internal static bool IsAbsolutePathType(Type type) => type == typeof(AbsolutePath);
 
         /// <summary>
@@ -26,62 +23,26 @@ namespace Microsoft.Build.Shared
             => type == typeof(AbsolutePath) || type == typeof(FileInfo) || type == typeof(DirectoryInfo);
 
         /// <summary>
-        /// Returns true if <paramref name="type"/> is supported by <see cref="ValueTypeParser"/>.
+        /// Gets the value type from a declared <see cref="ITaskItem{T}"/> or <see cref="TaskItem{T}"/> type.
         /// </summary>
-        internal static bool IsSupportedTaskItemType(Type type)
-            => type == typeof(string)
-                || type == typeof(bool)
-                || type == typeof(char)
-                || type == typeof(byte)
-                || type == typeof(sbyte)
-                || type == typeof(short)
-                || type == typeof(ushort)
-                || type == typeof(int)
-                || type == typeof(uint)
-                || type == typeof(long)
-                || type == typeof(ulong)
-                || type == typeof(float)
-                || type == typeof(double)
-                || type == typeof(decimal)
-                || type == typeof(DateTime)
-                || IsSupportedPathType(type);
-
-        /// <summary>
-        /// Checks if <paramref name="parameterType"/> is the generic TaskItem type identified by
-        /// <paramref name="genericTaskItemTypeDefinitionFullName"/>.
-        /// </summary>
-        internal static bool IsTaskItemOfT(Type parameterType, string genericTaskItemTypeDefinitionFullName)
+        internal static bool TryGetTaskItemValueType(Type parameterType, [NotNullWhen(true)] out Type? valueType)
         {
             if (!parameterType.IsGenericType)
             {
+                valueType = null;
                 return false;
             }
 
             Type genericTypeDefinition = parameterType.GetGenericTypeDefinition();
-            if (!string.Equals(genericTypeDefinition.FullName, genericTaskItemTypeDefinitionFullName, StringComparison.Ordinal))
+            if (genericTypeDefinition != typeof(ITaskItem<>)
+                && genericTypeDefinition != typeof(TaskItem<>))
             {
+                valueType = null;
                 return false;
             }
 
-            return parameterType.GetGenericArguments().Length == 1;
+            valueType = parameterType.GetGenericArguments()[0];
+            return true;
         }
-
-        /// <summary>
-        /// Checks if <paramref name="parameterType"/> is the generic TaskItem type identified by
-        /// <paramref name="genericTaskItemTypeDefinitionFullName"/> where <c>T</c> is supported by
-        /// <see cref="ValueTypeParser"/>.
-        /// </summary>
-        internal static bool IsSupportedTaskItemOfT(Type parameterType, string genericTaskItemTypeDefinitionFullName)
-        {
-            if (!IsTaskItemOfT(parameterType, genericTaskItemTypeDefinitionFullName))
-            {
-                return false;
-            }
-
-            return IsSupportedTaskItemType(parameterType.GetGenericArguments()[0]);
-        }
-
-        internal static bool IsSupportedITaskItemOfT(Type parameterType)
-            => IsSupportedTaskItemOfT(parameterType, GenericITaskItemFullName);
     }
 }

--- a/src/Framework/TaskItemTypeDetector.cs
+++ b/src/Framework/TaskItemTypeDetector.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Build.Shared
     internal static class TaskItemTypeDetector
     {
         // The generic type definitions (ITaskItem<T>/TaskItem<T>) are matched by full type name because
-        // callers pass the FullName of whichever definition they care about (see IsPathLikeTaskItemOfT).
+        // callers pass the FullName of whichever definition they care about (see IsSupportedTaskItemOfT).
         private const string GenericITaskItemFullName = "Microsoft.Build.Framework.ITaskItem`1";
 
         internal static bool IsAbsolutePathType(Type type) => type == typeof(AbsolutePath);
@@ -26,11 +26,31 @@ namespace Microsoft.Build.Shared
             => type == typeof(AbsolutePath) || type == typeof(FileInfo) || type == typeof(DirectoryInfo);
 
         /// <summary>
-        /// Checks if <paramref name="parameterType"/> is the generic TaskItem type identified by
-        /// <paramref name="genericTaskItemTypeDefinitionFullName"/> where <c>T</c> is a supported value
-        /// type (including <see cref="AbsolutePath"/>) or <see cref="FileInfo"/>/<see cref="DirectoryInfo"/>.
+        /// Returns true if <paramref name="type"/> is supported by <see cref="ValueTypeParser"/>.
         /// </summary>
-        internal static bool IsPathLikeTaskItemOfT(Type parameterType, string genericTaskItemTypeDefinitionFullName)
+        internal static bool IsSupportedTaskItemType(Type type)
+            => type == typeof(string)
+                || type == typeof(bool)
+                || type == typeof(char)
+                || type == typeof(byte)
+                || type == typeof(sbyte)
+                || type == typeof(short)
+                || type == typeof(ushort)
+                || type == typeof(int)
+                || type == typeof(uint)
+                || type == typeof(long)
+                || type == typeof(ulong)
+                || type == typeof(float)
+                || type == typeof(double)
+                || type == typeof(decimal)
+                || type == typeof(DateTime)
+                || IsSupportedPathType(type);
+
+        /// <summary>
+        /// Checks if <paramref name="parameterType"/> is the generic TaskItem type identified by
+        /// <paramref name="genericTaskItemTypeDefinitionFullName"/>.
+        /// </summary>
+        internal static bool IsTaskItemOfT(Type parameterType, string genericTaskItemTypeDefinitionFullName)
         {
             if (!parameterType.IsGenericType)
             {
@@ -43,17 +63,25 @@ namespace Microsoft.Build.Shared
                 return false;
             }
 
-            Type[] genericArguments = parameterType.GetGenericArguments();
-            if (genericArguments.Length != 1)
+            return parameterType.GetGenericArguments().Length == 1;
+        }
+
+        /// <summary>
+        /// Checks if <paramref name="parameterType"/> is the generic TaskItem type identified by
+        /// <paramref name="genericTaskItemTypeDefinitionFullName"/> where <c>T</c> is supported by
+        /// <see cref="ValueTypeParser"/>.
+        /// </summary>
+        internal static bool IsSupportedTaskItemOfT(Type parameterType, string genericTaskItemTypeDefinitionFullName)
+        {
+            if (!IsTaskItemOfT(parameterType, genericTaskItemTypeDefinitionFullName))
             {
                 return false;
             }
 
-            Type typeArg = genericArguments[0];
-            return typeArg.IsValueType || typeArg == typeof(FileInfo) || typeArg == typeof(DirectoryInfo);
+            return IsSupportedTaskItemType(parameterType.GetGenericArguments()[0]);
         }
 
-        internal static bool IsPathLikeITaskItemOfT(Type parameterType)
-            => IsPathLikeTaskItemOfT(parameterType, GenericITaskItemFullName);
+        internal static bool IsSupportedITaskItemOfT(Type parameterType)
+            => IsSupportedTaskItemOfT(parameterType, GenericITaskItemFullName);
     }
 }

--- a/src/Framework/ValueTypeParser.cs
+++ b/src/Framework/ValueTypeParser.cs
@@ -15,6 +15,27 @@ namespace Microsoft.Build.Shared
     internal static class ValueTypeParser
     {
         /// <summary>
+        /// Returns true if <paramref name="type"/> is an intended target type for typed task-item binding.
+        /// </summary>
+        internal static bool IsSupportedType(Type type)
+            => type == typeof(string)
+                || type == typeof(bool)
+                || type == typeof(char)
+                || type == typeof(byte)
+                || type == typeof(sbyte)
+                || type == typeof(short)
+                || type == typeof(ushort)
+                || type == typeof(int)
+                || type == typeof(uint)
+                || type == typeof(long)
+                || type == typeof(ulong)
+                || type == typeof(float)
+                || type == typeof(double)
+                || type == typeof(decimal)
+                || type == typeof(DateTime)
+                || TaskItemTypeDetector.IsSupportedPathType(type);
+
+        /// <summary>
         /// Parses a boolean value using MSBuild's boolean conventions.
         /// Supports: true/on/yes/!false/!off/!no for true, false/off/no/!true/!on/!yes for false.
         /// </summary>

--- a/src/Shared/TaskParameterTypeVerifier.cs
+++ b/src/Shared/TaskParameterTypeVerifier.cs
@@ -2,12 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Collections.Generic;
-using System.IO;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
-
-#nullable disable
 
 namespace Microsoft.Build.BackEnd
 {
@@ -16,71 +13,59 @@ namespace Microsoft.Build.BackEnd
     /// </summary>
     internal static class TaskParameterTypeVerifier
     {
-        /// <summary>
-        /// The non-value scalar types (and array element types) that MSBuild supports as task parameters
-        /// by converting them to/from their string representation.
-        /// </summary>
-        private static readonly HashSet<Type> s_supportedTypes =
-        [
-            typeof(string),
-            typeof(AbsolutePath),
-            typeof(FileInfo),
-            typeof(DirectoryInfo),
-        ];
-
-        /// <summary>
-        /// Checks if a type is the provided generic TaskItem type where T is supported by ValueTypeParser.
-        /// </summary>
-        internal static bool IsSupportedTaskItemOfT(Type parameterType, string genericTaskItemTypeDefinitionFullName)
-            => TaskItemTypeDetector.IsSupportedTaskItemOfT(parameterType, genericTaskItemTypeDefinitionFullName);
-
-        /// <summary>
-        /// Checks if a type is ITaskItem&lt;T&gt; where T is supported by ValueTypeParser.
-        /// </summary>
-        internal static bool IsSupportedITaskItemOfT(Type parameterType)
-            => TaskItemTypeDetector.IsSupportedITaskItemOfT(parameterType);
-
-        private static bool IsUnsupportedTaskItemOfT(Type parameterType)
+        internal static bool TryGetSupportedTaskItemValueType(Type parameterType, [NotNullWhen(true)] out Type? valueType)
         {
-            if (!TaskItemTypeDetector.IsTaskItemOfT(parameterType, typeof(ITaskItem<>).FullName)
-                && !TaskItemTypeDetector.IsTaskItemOfT(parameterType, typeof(Microsoft.Build.Framework.TaskItem<>).FullName))
+            if (TaskItemTypeDetector.TryGetTaskItemValueType(parameterType, out valueType))
             {
-                return false;
+                return ValueTypeParser.IsSupportedType(valueType);
             }
 
-            return !TaskItemTypeDetector.IsSupportedTaskItemType(parameterType.GetGenericArguments()[0]);
+            return false;
+        }
+
+        private static bool IsValidValueParameterType(Type parameterType)
+            => parameterType.IsValueType || ValueTypeParser.IsSupportedType(parameterType);
+
+        private static bool IsValidInputElementType(Type parameterType)
+        {
+            if (TaskItemTypeDetector.TryGetTaskItemValueType(parameterType, out Type? valueType))
+            {
+                return ValueTypeParser.IsSupportedType(valueType);
+            }
+
+            if (typeof(ITaskItem).IsAssignableFrom(parameterType))
+            {
+                return parameterType == typeof(ITaskItem);
+            }
+
+            return IsValidValueParameterType(parameterType);
         }
 
         /// <summary>
-        /// Is the parameter type a valid scalar input value
+        /// Is the parameter type a valid scalar input value - meaning not an array and a valid input element type
         /// </summary>
         internal static bool IsValidScalarInputParameter(Type parameterType) =>
-            !IsUnsupportedTaskItemOfT(parameterType)
-            && (parameterType.IsValueType
-                || parameterType == typeof(ITaskItem)
-                || s_supportedTypes.Contains(parameterType)
-                || IsSupportedITaskItemOfT(parameterType));
+            !TryGetArrayElement(parameterType, out _) && IsValidInputElementType(parameterType);
 
         /// <summary>
-        /// Is the passed in parameterType a valid vector input parameter
+        /// Is the passed in parameterType a valid vector input parameter - meaning is an array and the element type is a valid input element type
         /// </summary>
-        internal static bool IsValidVectorInputParameter(Type parameterType)
+        internal static bool IsValidVectorInputParameter(Type parameterType) =>
+            TryGetArrayElement(parameterType, out Type? elementType) && IsValidInputElementType(elementType);
+
+        /// <summary>
+        /// Helper that returns the element type of an array parameter type, or null if the parameter type is not an array - useful to handle nullability flow analysis for array element types in the calling code.
+        /// </summary>
+        private static bool TryGetArrayElement(Type parameterType, [NotNullWhen(true)] out Type? elementType)
         {
-            if (!parameterType.IsArray)
+            if (parameterType.IsArray)
             {
-                return false;
+                elementType = parameterType.GetElementType()!; // GetElementType is non-null because parameterType is an array
+                return true;
             }
 
-            Type elementType = parameterType.GetElementType();
-            if (IsUnsupportedTaskItemOfT(elementType))
-            {
-                return false;
-            }
-
-            return elementType.IsValueType ||
-                        parameterType == typeof(ITaskItem[]) ||
-                        s_supportedTypes.Contains(elementType) ||
-                        IsSupportedITaskItemOfT(elementType);
+            elementType = null;
+            return false;
         }
 
         /// <summary>
@@ -88,35 +73,13 @@ namespace Microsoft.Build.BackEnd
         /// </summary>
         internal static bool IsAssignableToITaskItem(Type parameterType)
         {
-            Type elementType = parameterType.IsArray ? parameterType.GetElementType() : parameterType;
-            if (IsUnsupportedTaskItemOfT(elementType))
+            Type elementType = TryGetArrayElement(parameterType, out Type? arrayElementType) ? arrayElementType : parameterType;
+            if (TaskItemTypeDetector.TryGetTaskItemValueType(elementType, out Type? valueType))
             {
-                return false;
+                return ValueTypeParser.IsSupportedType(valueType);
             }
 
-            if (parameterType.IsArray && typeof(ITaskItem).IsAssignableFrom(elementType))
-            {
-                return true;
-            }
-
-            // Check if it's directly assignable
-            bool result = typeof(ITaskItem[]).IsAssignableFrom(parameterType) ||    /* ITaskItem array or derived type, or */
-                          typeof(ITaskItem).IsAssignableFrom(parameterType);        /* ITaskItem or derived type */
-
-            // Also check for TaskItem<T> or TaskItem<T>[]
-            if (!result)
-            {
-                if (parameterType.IsArray)
-                {
-                    result = IsSupportedITaskItemOfT(elementType);
-                }
-                else
-                {
-                    result = IsSupportedITaskItemOfT(parameterType);
-                }
-            }
-
-            return result;
+            return typeof(ITaskItem).IsAssignableFrom(elementType);
         }
 
         /// <summary>
@@ -124,19 +87,9 @@ namespace Microsoft.Build.BackEnd
         /// </summary>
         internal static bool IsValueTypeOutputParameter(Type parameterType)
         {
-            Type elementType = parameterType.IsArray ? parameterType.GetElementType() : parameterType;
-            if (IsUnsupportedTaskItemOfT(elementType))
-            {
-                return false;
-            }
-
-            return parameterType switch
-            {
-                { IsValueType: true } => true,                                      // value type
-                { IsArray: true } => parameterType.GetElementType() is { } element
-                    && (element.IsValueType || s_supportedTypes.Contains(element)), // array of value type or supported type
-                _ => s_supportedTypes.Contains(parameterType),                      // supported scalar type
-            };
+            Type elementType = TryGetArrayElement(parameterType, out Type? arrayElementType) ? arrayElementType : parameterType;
+            return !typeof(ITaskItem).IsAssignableFrom(elementType)
+                && IsValidValueParameterType(elementType);
         }
 
         /// <summary>

--- a/src/Shared/TaskParameterTypeVerifier.cs
+++ b/src/Shared/TaskParameterTypeVerifier.cs
@@ -29,26 +29,37 @@ namespace Microsoft.Build.BackEnd
         ];
 
         /// <summary>
-        /// Checks if a type is the provided generic TaskItem type where T is a supported value type
-        /// (including AbsolutePath) or FileInfo/DirectoryInfo.
+        /// Checks if a type is the provided generic TaskItem type where T is supported by ValueTypeParser.
         /// </summary>
-        internal static bool IsPathLikeTaskItemOfT(Type parameterType, string genericTaskItemTypeDefinitionFullName)
-            => TaskItemTypeDetector.IsPathLikeTaskItemOfT(parameterType, genericTaskItemTypeDefinitionFullName);
+        internal static bool IsSupportedTaskItemOfT(Type parameterType, string genericTaskItemTypeDefinitionFullName)
+            => TaskItemTypeDetector.IsSupportedTaskItemOfT(parameterType, genericTaskItemTypeDefinitionFullName);
 
         /// <summary>
-        /// Checks if a type is ITaskItem&lt;T&gt; where T is path-like.
+        /// Checks if a type is ITaskItem&lt;T&gt; where T is supported by ValueTypeParser.
         /// </summary>
-        internal static bool IsPathLikeITaskItemOfT(Type parameterType)
-            => TaskItemTypeDetector.IsPathLikeITaskItemOfT(parameterType);
+        internal static bool IsSupportedITaskItemOfT(Type parameterType)
+            => TaskItemTypeDetector.IsSupportedITaskItemOfT(parameterType);
+
+        private static bool IsUnsupportedTaskItemOfT(Type parameterType)
+        {
+            if (!TaskItemTypeDetector.IsTaskItemOfT(parameterType, typeof(ITaskItem<>).FullName)
+                && !TaskItemTypeDetector.IsTaskItemOfT(parameterType, typeof(Microsoft.Build.Framework.TaskItem<>).FullName))
+            {
+                return false;
+            }
+
+            return !TaskItemTypeDetector.IsSupportedTaskItemType(parameterType.GetGenericArguments()[0]);
+        }
 
         /// <summary>
         /// Is the parameter type a valid scalar input value
         /// </summary>
         internal static bool IsValidScalarInputParameter(Type parameterType) =>
-            parameterType.IsValueType ||
-            parameterType == typeof(ITaskItem) ||
-            s_supportedTypes.Contains(parameterType) ||
-            IsPathLikeITaskItemOfT(parameterType);
+            !IsUnsupportedTaskItemOfT(parameterType)
+            && (parameterType.IsValueType
+                || parameterType == typeof(ITaskItem)
+                || s_supportedTypes.Contains(parameterType)
+                || IsSupportedITaskItemOfT(parameterType));
 
         /// <summary>
         /// Is the passed in parameterType a valid vector input parameter
@@ -61,11 +72,15 @@ namespace Microsoft.Build.BackEnd
             }
 
             Type elementType = parameterType.GetElementType();
+            if (IsUnsupportedTaskItemOfT(elementType))
+            {
+                return false;
+            }
 
             return elementType.IsValueType ||
                         parameterType == typeof(ITaskItem[]) ||
                         s_supportedTypes.Contains(elementType) ||
-                        IsPathLikeITaskItemOfT(elementType);
+                        IsSupportedITaskItemOfT(elementType);
         }
 
         /// <summary>
@@ -73,7 +88,13 @@ namespace Microsoft.Build.BackEnd
         /// </summary>
         internal static bool IsAssignableToITaskItem(Type parameterType)
         {
-            if (parameterType.IsArray && typeof(ITaskItem).IsAssignableFrom(parameterType.GetElementType()))
+            Type elementType = parameterType.IsArray ? parameterType.GetElementType() : parameterType;
+            if (IsUnsupportedTaskItemOfT(elementType))
+            {
+                return false;
+            }
+
+            if (parameterType.IsArray && typeof(ITaskItem).IsAssignableFrom(elementType))
             {
                 return true;
             }
@@ -87,11 +108,11 @@ namespace Microsoft.Build.BackEnd
             {
                 if (parameterType.IsArray)
                 {
-                    result = IsPathLikeITaskItemOfT(parameterType.GetElementType());
+                    result = IsSupportedITaskItemOfT(elementType);
                 }
                 else
                 {
-                    result = IsPathLikeITaskItemOfT(parameterType);
+                    result = IsSupportedITaskItemOfT(parameterType);
                 }
             }
 
@@ -102,13 +123,21 @@ namespace Microsoft.Build.BackEnd
         /// Is the passed parameter a valid value type output parameter
         /// </summary>
         internal static bool IsValueTypeOutputParameter(Type parameterType)
-            => parameterType switch
+        {
+            Type elementType = parameterType.IsArray ? parameterType.GetElementType() : parameterType;
+            if (IsUnsupportedTaskItemOfT(elementType))
+            {
+                return false;
+            }
+
+            return parameterType switch
             {
                 { IsValueType: true } => true,                                      // value type
                 { IsArray: true } => parameterType.GetElementType() is { } element
                     && (element.IsValueType || s_supportedTypes.Contains(element)), // array of value type or supported type
                 _ => s_supportedTypes.Contains(parameterType),                      // supported scalar type
             };
+        }
 
         /// <summary>
         /// Is the parameter type a valid scalar or value type input parameter

--- a/src/Shared/TaskParameterTypeVerifier.cs
+++ b/src/Shared/TaskParameterTypeVerifier.cs
@@ -29,8 +29,8 @@ namespace Microsoft.Build.BackEnd
         ];
 
         /// <summary>
-        /// Checks if a type is the provided generic TaskItem type where T is a path-like type
-        /// (AbsolutePath, FileInfo, or DirectoryInfo).
+        /// Checks if a type is the provided generic TaskItem type where T is a supported value type
+        /// (including AbsolutePath) or FileInfo/DirectoryInfo.
         /// </summary>
         internal static bool IsPathLikeTaskItemOfT(Type parameterType, string genericTaskItemTypeDefinitionFullName)
             => TaskItemTypeDetector.IsPathLikeTaskItemOfT(parameterType, genericTaskItemTypeDefinitionFullName);

--- a/src/TaskAnalyzer.Tests/UnsupportedTaskItemTypeAnalyzerTests.cs
+++ b/src/TaskAnalyzer.Tests/UnsupportedTaskItemTypeAnalyzerTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
 using Shouldly;
 using Xunit;
 using static Microsoft.Build.TaskAuthoring.Analyzer.Tests.TestHelpers;
@@ -9,31 +10,14 @@ using static Microsoft.Build.TaskAuthoring.Analyzer.Tests.TestHelpers;
 namespace Microsoft.Build.TaskAuthoring.Analyzer.Tests;
 
 /// <summary>
-/// Tests for <see cref="UnsupportedTaskItemTypeAnalyzer"/> covering MSBuildTask0009.
+/// Tests for <see cref="UnsupportedTaskItemTypeAnalyzer"/> covering MSBuildTask0009 and MSBuildTask0010.
 /// </summary>
 public class UnsupportedTaskItemTypeAnalyzerTests
 {
-    // ═══════════════════════════════════════════════════════════════════════
-    // Value types are not yet supported by the task parameter binder
-    // ═══════════════════════════════════════════════════════════════════════
-
     [Theory]
-    [InlineData("int")]
     [InlineData("bool")]
-    [InlineData("long")]
-    [InlineData("double")]
-    [InlineData("float")]
-    [InlineData("decimal")]
-    [InlineData("byte")]
-    [InlineData("sbyte")]
-    [InlineData("short")]
-    [InlineData("ushort")]
-    [InlineData("uint")]
-    [InlineData("ulong")]
-    [InlineData("char")]
-    [InlineData("System.DateTime")]
     [InlineData("string")]
-    public async Task ValueType_ProducesDiagnostic(string typeName)
+    public async Task DedicatedParserType_NoDiagnostic(string typeName)
     {
         var diags = await GetUnsupportedTaskItemTypeDiagnosticsAsync($$"""
             using Microsoft.Build.Framework;
@@ -44,7 +28,40 @@ public class UnsupportedTaskItemTypeAnalyzerTests
             }
             """);
 
-        diags.ShouldContain(d => d.Id == DiagnosticIds.UnsupportedTaskItemType);
+        diags.ShouldBeEmpty();
+    }
+
+    [Theory]
+    [InlineData("char")]
+    [InlineData("byte")]
+    [InlineData("sbyte")]
+    [InlineData("short")]
+    [InlineData("ushort")]
+    [InlineData("int")]
+    [InlineData("uint")]
+    [InlineData("long")]
+    [InlineData("ulong")]
+    [InlineData("float")]
+    [InlineData("double")]
+    [InlineData("decimal")]
+    [InlineData("System.DateTime")]
+    public async Task ConvertChangeTypeType_ProducesError(string typeName)
+    {
+        var diags = await GetUnsupportedTaskItemTypeDiagnosticsAsync($$"""
+            using Microsoft.Build.Framework;
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                public ITaskItem<{{typeName}}> Item { get; set; } = null!;
+                public override bool Execute() => true;
+            }
+            """);
+
+        diags.ShouldNotContain(d => d.Id == DiagnosticIds.UnsupportedTaskItemType);
+        Diagnostic diagnostic = diags.ShouldHaveSingleItem();
+        diagnostic.Id.ShouldBe(DiagnosticIds.CultureSensitiveTaskItemType);
+        diagnostic.Severity.ShouldBe(Microsoft.CodeAnalysis.DiagnosticSeverity.Error);
+        diagnostic.GetMessage().ShouldContain("Convert.ChangeType");
+        diagnostic.GetMessage().ShouldContain("CultureInfo");
     }
 
     [Fact]
@@ -59,7 +76,7 @@ public class UnsupportedTaskItemTypeAnalyzerTests
             }
             """);
 
-        diags.ShouldNotContain(d => d.Id == DiagnosticIds.UnsupportedTaskItemType);
+        diags.ShouldBeEmpty();
     }
 
     [Fact]
@@ -75,7 +92,7 @@ public class UnsupportedTaskItemTypeAnalyzerTests
             }
             """);
 
-        diags.ShouldNotContain(d => d.Id == DiagnosticIds.UnsupportedTaskItemType);
+        diags.ShouldBeEmpty();
     }
 
     [Fact]
@@ -91,7 +108,7 @@ public class UnsupportedTaskItemTypeAnalyzerTests
             }
             """);
 
-        diags.ShouldNotContain(d => d.Id == DiagnosticIds.UnsupportedTaskItemType);
+        diags.ShouldBeEmpty();
     }
 
     // ═══════════════════════════════════════════════════════════════════════
@@ -99,18 +116,54 @@ public class UnsupportedTaskItemTypeAnalyzerTests
     // ═══════════════════════════════════════════════════════════════════════
 
     [Fact]
-    public async Task SupportedPathTypeArray_NoDiagnostic()
+    public async Task ConvertChangeTypeArray_ProducesError()
     {
         var diags = await GetUnsupportedTaskItemTypeDiagnosticsAsync("""
             using Microsoft.Build.Framework;
             public class MyTask : Microsoft.Build.Utilities.Task
             {
-                public ITaskItem<AbsolutePath>[] Items { get; set; } = null!;
+                public ITaskItem<int>[] Items { get; set; } = null!;
                 public override bool Execute() => true;
             }
             """);
 
-        diags.ShouldNotContain(d => d.Id == DiagnosticIds.UnsupportedTaskItemType);
+        Diagnostic diagnostic = diags.ShouldHaveSingleItem();
+        diagnostic.Id.ShouldBe(DiagnosticIds.CultureSensitiveTaskItemType);
+        diagnostic.Severity.ShouldBe(Microsoft.CodeAnalysis.DiagnosticSeverity.Error);
+    }
+
+    [Fact]
+    public async Task SupportedOutputProperty_NoDiagnostic()
+    {
+        var diags = await GetUnsupportedTaskItemTypeDiagnosticsAsync("""
+            using Microsoft.Build.Framework;
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                [Output]
+                public ITaskItem<string> Item { get; set; } = null!;
+                public override bool Execute() => true;
+            }
+            """);
+
+        diags.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task ConvertChangeTypeOutputProperty_ProducesError()
+    {
+        var diags = await GetUnsupportedTaskItemTypeDiagnosticsAsync("""
+            using Microsoft.Build.Framework;
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                [Output]
+                public ITaskItem<decimal> Item { get; set; } = null!;
+                public override bool Execute() => true;
+            }
+            """);
+
+        Diagnostic diagnostic = diags.ShouldHaveSingleItem();
+        diagnostic.Id.ShouldBe(DiagnosticIds.CultureSensitiveTaskItemType);
+        diagnostic.Severity.ShouldBe(Microsoft.CodeAnalysis.DiagnosticSeverity.Error);
     }
 
     [Fact]
@@ -150,6 +203,8 @@ public class UnsupportedTaskItemTypeAnalyzerTests
         diags.ShouldContain(d => d.Id == DiagnosticIds.UnsupportedTaskItemType);
         diags[0].GetMessage().ShouldContain("Item");
         diags[0].GetMessage().ShouldContain("Guid");
+        diags[0].GetMessage().ShouldContain("string, bool, AbsolutePath, FileInfo, DirectoryInfo");
+        diags[0].GetMessage().ShouldNotContain("int,");
     }
 
     [Fact]
@@ -168,6 +223,53 @@ public class UnsupportedTaskItemTypeAnalyzerTests
         diags.ShouldContain(d => d.Id == DiagnosticIds.UnsupportedTaskItemType);
         diags[0].GetMessage().ShouldContain("Duration");
         diags[0].GetMessage().ShouldContain("TimeSpan");
+    }
+
+    [Fact]
+    public async Task Enum_ProducesDiagnostic()
+    {
+        var diags = await GetUnsupportedTaskItemTypeDiagnosticsAsync("""
+            using Microsoft.Build.Framework;
+            public enum Mode { First, Second }
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                public ITaskItem<Mode> Item { get; set; } = null!;
+                public override bool Execute() => true;
+            }
+            """);
+
+        diags.ShouldContain(d => d.Id == DiagnosticIds.UnsupportedTaskItemType);
+    }
+
+    [Fact]
+    public async Task NullableValueType_ProducesDiagnostic()
+    {
+        var diags = await GetUnsupportedTaskItemTypeDiagnosticsAsync("""
+            using Microsoft.Build.Framework;
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                public ITaskItem<int?> Item { get; set; } = null!;
+                public override bool Execute() => true;
+            }
+            """);
+
+        diags.ShouldContain(d => d.Id == DiagnosticIds.UnsupportedTaskItemType);
+    }
+
+    [Fact]
+    public async Task CustomStruct_ProducesDiagnostic()
+    {
+        var diags = await GetUnsupportedTaskItemTypeDiagnosticsAsync("""
+            using Microsoft.Build.Framework;
+            public struct CustomValue { }
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                public ITaskItem<CustomValue> Item { get; set; } = null!;
+                public override bool Execute() => true;
+            }
+            """);
+
+        diags.ShouldContain(d => d.Id == DiagnosticIds.UnsupportedTaskItemType);
     }
 
     [Fact]

--- a/src/TaskAnalyzer.Tests/UnsupportedTaskItemTypeAnalyzerTests.cs
+++ b/src/TaskAnalyzer.Tests/UnsupportedTaskItemTypeAnalyzerTests.cs
@@ -61,7 +61,7 @@ public class UnsupportedTaskItemTypeAnalyzerTests
         diagnostic.Id.ShouldBe(DiagnosticIds.CultureSensitiveTaskItemType);
         diagnostic.Severity.ShouldBe(Microsoft.CodeAnalysis.DiagnosticSeverity.Error);
         diagnostic.GetMessage().ShouldContain("Convert.ChangeType");
-        diagnostic.GetMessage().ShouldContain("CultureInfo");
+        diagnostic.GetMessage().ShouldContain("CultureInfo.InvariantCulture");
     }
 
     [Fact]

--- a/src/TaskAnalyzer/AnalyzerReleases.Unshipped.md
+++ b/src/TaskAnalyzer/AnalyzerReleases.Unshipped.md
@@ -11,3 +11,4 @@ MSBuildTask0006 | MSBuild.TaskAuthoring | Info | Prefer typed path parameter (Ab
 MSBuildTask0007 | MSBuild.TaskAuthoring | Info | Prefer ITaskItem<T> over manual ItemSpec parsing (code fix available)
 MSBuildTask0008 | MSBuild.TaskAuthoring | Info | Initialize a relative default path in Execute() so TaskEnvironment can root it when the property is retyped (code fix available)
 MSBuildTask0009 | MSBuild.TaskAuthoring | Warning | ITaskItem<T> used with a type argument T that MSBuild cannot bind as a task parameter
+MSBuildTask0010 | MSBuild.TaskAuthoring | Error | ITaskItem<T> used with a type argument T that MSBuild parses through Convert.ChangeType

--- a/src/TaskAnalyzer/DiagnosticDescriptors.cs
+++ b/src/TaskAnalyzer/DiagnosticDescriptors.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
 {
     /// <summary>
     /// Diagnostic descriptors for the thread-safe task analyzer.
-    /// All rules default to Warning severity. MSBuildTask0001 defaults to Error.
+    /// Rules default to the severity appropriate for the behavior they diagnose.
     /// </summary>
     internal static class DiagnosticDescriptors
     {
@@ -88,11 +88,20 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
         public static readonly DiagnosticDescriptor UnsupportedTaskItemType = new(
             id: DiagnosticIds.UnsupportedTaskItemType,
             title: "ITaskItem<T> used with unsupported type argument",
-            messageFormat: "Task property '{0}' uses ITaskItem<{1}> but MSBuild cannot automatically parse '{1}' from item metadata. Use one of the supported types: {2}.",
+            messageFormat: "Task property '{0}' uses ITaskItem<{1}> but MSBuild cannot automatically parse '{1}' from item metadata. Use one of the directly parsed types: {2}.",
             category: "MSBuild.TaskAuthoring",
             defaultSeverity: DiagnosticSeverity.Warning,
             isEnabledByDefault: true,
             description: "MSBuild can only bind ITaskItem<T> properties when T is a supported type. Using an unsupported type will cause a runtime failure when MSBuild tries to bind the parameter.");
+
+        public static readonly DiagnosticDescriptor CultureSensitiveTaskItemType = new(
+            id: DiagnosticIds.CultureSensitiveTaskItemType,
+            title: "ITaskItem<T> type argument relies on culture-sensitive conversion",
+            messageFormat: "Task property '{0}' uses ITaskItem<{1}>, which MSBuild parses through Convert.ChangeType and therefore relies on CultureInfo conversion semantics. Use ITaskItem<string> and parse explicitly with a chosen culture.",
+            category: "MSBuild.TaskAuthoring",
+            defaultSeverity: DiagnosticSeverity.Error,
+            isEnabledByDefault: true,
+            description: "ITaskItem<T> type arguments parsed through Convert.ChangeType rely on culture-sensitive conversion semantics. Bind the item as a string and parse it explicitly with the intended culture.");
 
         public static ImmutableArray<DiagnosticDescriptor> All { get; } = ImmutableArray.Create(
             CriticalError,
@@ -103,6 +112,7 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
             PreferTypedPathParameter,
             PreferTypedTaskItem,
             InitializeRelativeDefaultInExecute,
-            UnsupportedTaskItemType);
+            UnsupportedTaskItemType,
+            CultureSensitiveTaskItemType);
     }
 }

--- a/src/TaskAnalyzer/DiagnosticDescriptors.cs
+++ b/src/TaskAnalyzer/DiagnosticDescriptors.cs
@@ -97,11 +97,11 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
         public static readonly DiagnosticDescriptor CultureSensitiveTaskItemType = new(
             id: DiagnosticIds.CultureSensitiveTaskItemType,
             title: "ITaskItem<T> type argument relies on culture-sensitive conversion",
-            messageFormat: "Task property '{0}' uses ITaskItem<{1}>, which MSBuild parses through Convert.ChangeType and therefore relies on CultureInfo conversion semantics. Use ITaskItem<string> and parse explicitly with a chosen culture.",
+            messageFormat: "Task property '{0}' uses ITaskItem<{1}>, which MSBuild parses through Convert.ChangeType using CultureInfo.InvariantCulture. Use ITaskItem<string> and parse explicitly with a chosen culture.",
             category: "MSBuild.TaskAuthoring",
             defaultSeverity: DiagnosticSeverity.Error,
             isEnabledByDefault: true,
-            description: "ITaskItem<T> type arguments parsed through Convert.ChangeType rely on culture-sensitive conversion semantics. Bind the item as a string and parse it explicitly with the intended culture.");
+            description: "ITaskItem<T> type arguments parsed through Convert.ChangeType use CultureInfo.InvariantCulture. Bind the item as a string and parse it explicitly with the intended culture.");
 
         public static ImmutableArray<DiagnosticDescriptor> All { get; } = ImmutableArray.Create(
             CriticalError,

--- a/src/TaskAnalyzer/DiagnosticIds.cs
+++ b/src/TaskAnalyzer/DiagnosticIds.cs
@@ -35,5 +35,8 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
 
         /// <summary>Task property uses ITaskItem&lt;T&gt; with a type argument not supported by MSBuild's task parameter binder.</summary>
         public const string UnsupportedTaskItemType = "MSBuildTask0009";
+
+        /// <summary>Task property uses ITaskItem&lt;T&gt; with a type argument parsed through Convert.ChangeType.</summary>
+        public const string CultureSensitiveTaskItemType = "MSBuildTask0010";
     }
 }

--- a/src/TaskAnalyzer/README.md
+++ b/src/TaskAnalyzer/README.md
@@ -251,7 +251,7 @@ No code fix is offered for MSBuildTask0009 — the resolution depends on the int
 
 ### MSBuildTask0010 — Culture-Sensitive `ITaskItem<T>` Conversion
 
-MSBuild binds `ITaskItem<T>` for `char`, numeric primitives, `decimal`, and `DateTime` through `Convert.ChangeType`. These conversions rely on `CultureInfo` conversion semantics, so the analyzer reports an **Error** whenever one of these types is used.
+MSBuild binds `ITaskItem<T>` for `char`, numeric primitives, `decimal`, and `DateTime` through `Convert.ChangeType` using `CultureInfo.InvariantCulture`. Because this implicit conversion may not match the task's intended culture, the analyzer reports an **Error** whenever one of these types is used.
 
 ```csharp
 public class MyTask : Task

--- a/src/TaskAnalyzer/README.md
+++ b/src/TaskAnalyzer/README.md
@@ -23,6 +23,7 @@ This analyzer catches unsafe API usage at compile time and offers code fixes to 
 | **MSBuildTask0007** | Info | Tasks with `[MSBuildMultiThreadableTask]` applied directly | Prefer `ITaskItem<T>` over manual ItemSpec parsing |
 | **MSBuildTask0008** | Info | Tasks with `[MSBuildMultiThreadableTask]` applied directly | Initialize a relative-default path property in `Execute()` |
 | **MSBuildTask0009** | Warning | All `ITask` implementations | `ITaskItem<T>` used with unsupported type argument |
+| **MSBuildTask0010** | Error | All `ITask` implementations | `ITaskItem<T>` relies on culture-sensitive conversion |
 
 ### MSBuildTask0001 — Critical: No Safe Alternative
 
@@ -230,7 +231,9 @@ For a reference-typed target (`FileInfo`/`DirectoryInfo`) the guard is a null-co
 
 When a task property is typed as `ITaskItem<T>` or `ITaskItem<T>[]` but `T` is not supported by MSBuild's task parameter binder, a **Warning** is emitted. Using an unsupported type will cause a runtime failure when MSBuild tries to bind the parameter.
 
-**Supported type arguments:** `AbsolutePath`, `FileInfo`, `DirectoryInfo`.
+**Directly parsed type arguments:** `string`, `bool`, `AbsolutePath`, `FileInfo`, `DirectoryInfo`.
+
+The binder also accepts `char`, numeric primitives, `decimal`, and `DateTime`, but MSBuildTask0010 rejects those types because they rely on `Convert.ChangeType`.
 
 ```csharp
 // ⚠️ MSBuildTask0009: Task property 'Id' uses ITaskItem<Guid> but 'Guid' is not supported
@@ -238,7 +241,7 @@ public class MyTask : Task
 {
     public ITaskItem<System.Guid> Id { get; set; }       // warning
     public ITaskItem<System.TimeSpan>[] Durations { get; set; }  // warning
-    public ITaskItem<int> Count { get; set; }             // warning until value-type binding is supported
+    public ITaskItem<int> Count { get; set; }             // MSBuildTask0010 error
 }
 ```
 
@@ -246,15 +249,31 @@ No code fix is offered for MSBuildTask0009 — the resolution depends on the int
 
 **Scope:** All `ITask` implementations (not just multithreaded tasks), since using an unsupported T is always a runtime correctness problem.
 
+### MSBuildTask0010 — Culture-Sensitive `ITaskItem<T>` Conversion
+
+MSBuild binds `ITaskItem<T>` for `char`, numeric primitives, `decimal`, and `DateTime` through `Convert.ChangeType`. These conversions rely on `CultureInfo` conversion semantics, so the analyzer reports an **Error** whenever one of these types is used.
+
+```csharp
+public class MyTask : Task
+{
+    public ITaskItem<int> Count { get; set; }       // error
+    public ITaskItem<DateTime>[] Dates { get; set; } // error
+}
+```
+
+Use `ITaskItem<string>` and parse `Value` explicitly with the intended culture. `ITaskItem<bool>`, `ITaskItem<AbsolutePath>`, `ITaskItem<FileInfo>`, and `ITaskItem<DirectoryInfo>` use dedicated parser paths and do not produce MSBuildTask0010.
+
+**Scope:** All `ITask` implementations, including input, output, scalar, and array properties.
+
 ## Analysis Scope
 
 The analyzer determines what to check based on the type declaration:
 
 | Type | Rules Applied |
 |---|---|
-| Any class implementing `ITask` | MSBuildTask0001–MSBuildTask0005, MSBuildTask0009 |
+| Any class implementing `ITask` | MSBuildTask0001–MSBuildTask0005, MSBuildTask0009–MSBuildTask0010 |
 | Class with `[MSBuildMultiThreadableTask]` attribute applied directly | MSBuildTask0006–MSBuildTask0008 (in addition to MSBuildTask0001–0005) |
-| Class implementing `IMultiThreadableTask` without the attribute | MSBuildTask0001–MSBuildTask0005 and MSBuildTask0009 only |
+| Class implementing `IMultiThreadableTask` without the attribute | MSBuildTask0001–MSBuildTask0005 and MSBuildTask0009–MSBuildTask0010 only |
 | Helper class with `[MSBuildMultiThreadableTaskAnalyzed]` attribute | MSBuildTask0001–MSBuildTask0005 |
 | Regular class (no task interface or attribute) | Not analyzed |
 
@@ -267,6 +286,7 @@ The `[MSBuildMultiThreadableTaskAnalyzed]` attribute allows opting helper classe
 ### Severity Levels
 
 - **MSBuildTask0001** is always **Error** — these APIs are never safe in any MSBuild task.
+- **MSBuildTask0010** is always **Error** — task item conversions must not rely on `Convert.ChangeType`.
 - **MSBuildTask0002–MSBuildTask0005 and MSBuildTask0009** report as **Warning** for all task types.
 - **MSBuildTask0006–MSBuildTask0008** report as **Info** — these are modernization suggestions, not correctness issues.
 

--- a/src/TaskAnalyzer/SupportedTaskItemTypes.cs
+++ b/src/TaskAnalyzer/SupportedTaskItemTypes.cs
@@ -8,8 +8,7 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
 {
     internal static class SupportedTaskItemTypes
     {
-        // These are the types ValueTypeParser can parse and MSBuildTask0007 may suggest. This set is
-        // intentionally broader than the ITaskItem<T> types accepted by the current engine binder below.
+        // These are the special types supported by ValueTypeParser and the ITaskItem<T> binder.
         private readonly struct SupportedSpecialType
         {
             internal SupportedSpecialType(SpecialType specialType, string displayName)
@@ -40,9 +39,9 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                 new SupportedSpecialType(SpecialType.System_DateTime, "DateTime"),
                 new SupportedSpecialType(SpecialType.System_String, "string"));
 
-        // Keep the user-facing list next to IsSupportedTaskItemType. Both mirror the runtime Type-based
-        // TaskItemTypeDetector, which the Roslyn analyzer cannot call with compile-time ITypeSymbol values.
-        internal const string SupportedTaskItemTypeDisplayNames = "AbsolutePath, FileInfo, DirectoryInfo";
+        // These types have dedicated parsing paths and do not rely on Convert.ChangeType.
+        internal const string DirectlyParsedTaskItemTypeDisplayNames =
+            "string, bool, AbsolutePath, FileInfo, DirectoryInfo";
 
         internal static bool TryGetSpecialTypeDisplayName(SpecialType specialType, out string? displayName)
         {
@@ -59,13 +58,30 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
             return false;
         }
 
+        internal static bool IsConvertChangeTypeTaskItemType(SpecialType specialType)
+            => specialType is
+                SpecialType.System_Char or
+                SpecialType.System_Byte or
+                SpecialType.System_SByte or
+                SpecialType.System_Int16 or
+                SpecialType.System_UInt16 or
+                SpecialType.System_Int32 or
+                SpecialType.System_UInt32 or
+                SpecialType.System_Int64 or
+                SpecialType.System_UInt64 or
+                SpecialType.System_Single or
+                SpecialType.System_Double or
+                SpecialType.System_Decimal or
+                SpecialType.System_DateTime;
+
         internal static bool IsSupportedTaskItemType(
             ITypeSymbol type,
             INamedTypeSymbol? absolutePathType,
             INamedTypeSymbol? fileInfoType,
             INamedTypeSymbol? directoryInfoType)
         {
-            return (absolutePathType is not null && SymbolEqualityComparer.Default.Equals(type, absolutePathType))
+            return TryGetSpecialTypeDisplayName(type.SpecialType, out _)
+                || (absolutePathType is not null && SymbolEqualityComparer.Default.Equals(type, absolutePathType))
                 || (fileInfoType is not null && SymbolEqualityComparer.Default.Equals(type, fileInfoType))
                 || (directoryInfoType is not null && SymbolEqualityComparer.Default.Equals(type, directoryInfoType));
         }

--- a/src/TaskAnalyzer/UnsupportedTaskItemTypeAnalyzer.cs
+++ b/src/TaskAnalyzer/UnsupportedTaskItemTypeAnalyzer.cs
@@ -10,16 +10,19 @@ using static Microsoft.Build.TaskAuthoring.Analyzer.SharedAnalyzerHelpers;
 namespace Microsoft.Build.TaskAuthoring.Analyzer
 {
     /// <summary>
-    /// Roslyn analyzer that warns when a task property is typed as <c>ITaskItem&lt;T&gt;</c> or
-    /// <c>ITaskItem&lt;T&gt;[]</c> where <c>T</c> is not supported by MSBuild's task parameter binder.
+    /// Roslyn analyzer that reports when a task property is typed as <c>ITaskItem&lt;T&gt;</c> or
+    /// <c>ITaskItem&lt;T&gt;[]</c> where <c>T</c> is unsupported or relies on Convert.ChangeType.
     ///
     /// MSBuildTask0009: ITaskItem&lt;T&gt; used with unsupported type argument.
+    /// MSBuildTask0010: ITaskItem&lt;T&gt; type argument relies on culture-sensitive conversion.
     /// </summary>
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public sealed class UnsupportedTaskItemTypeAnalyzer : DiagnosticAnalyzer
     {
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
-            ImmutableArray.Create(DiagnosticDescriptors.UnsupportedTaskItemType);
+            ImmutableArray.Create(
+                DiagnosticDescriptors.UnsupportedTaskItemType,
+                DiagnosticDescriptors.CultureSensitiveTaskItemType);
 
         public override void Initialize(AnalysisContext context)
         {
@@ -92,6 +95,16 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
 
                     ITypeSymbol typeArg = namedPropertyType.TypeArguments[0];
 
+                    if (SupportedTaskItemTypes.IsConvertChangeTypeTaskItemType(typeArg.SpecialType))
+                    {
+                        symbolContext.ReportDiagnostic(Diagnostic.Create(
+                            DiagnosticDescriptors.CultureSensitiveTaskItemType,
+                            GetDiagnosticLocation(property, namedType),
+                            property.Name,
+                            typeArg.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat)));
+                        continue;
+                    }
+
                     // Check if T is in the supported set
                     if (SupportedTaskItemTypes.IsSupportedTaskItemType(typeArg, absolutePathType, fileInfoType, directoryInfoType))
                     {
@@ -103,7 +116,7 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                         GetDiagnosticLocation(property, namedType),
                         property.Name,
                         typeArg.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat),
-                        SupportedTaskItemTypes.SupportedTaskItemTypeDisplayNames));
+                        SupportedTaskItemTypes.DirectlyParsedTaskItemTypeDisplayNames));
                 }
             }, SymbolKind.NamedType);
         }


### PR DESCRIPTION
## Summary

Expands `ITaskItem<T>` / `TaskItem<T>` engine binding beyond path types while keeping the accepted type set aligned with `ValueTypeParser`.

The binder now accepts:

- Directly parsed types: `string`, `bool`, `AbsolutePath`, `FileInfo`, `DirectoryInfo`
- `Convert.ChangeType` types: `char`, numeric primitives, `decimal`, and `DateTime`

Enums, nullable value types, `Guid`, `TimeSpan`, and custom structs remain unsupported.

## Changes

- Replaces broad `IsValueType` checks with an explicit `ValueTypeParser`-aligned allowlist.
- Applies the same validation to scalar and array inputs and outputs for both `ITaskItem<T>` and concrete `TaskItem<T>`.
- Adds binding coverage for `string`, MSBuild boolean syntax, and the full supported/unsupported type matrix.
- Updates MSBuildTask0009 to match runtime support and recommend only directly parsed types.
- Adds **MSBuildTask0010** as an error when `ITaskItem<T>` uses a type parsed through `Convert.ChangeType`. These conversions use `CultureInfo.InvariantCulture`, which may not match the task's intended culture. Authors should bind as `ITaskItem<string>` and parse explicitly with the intended culture.

## Dependency status

The preceding PRs (#13971, #13972, and #13973) are merged, and this PR is rebased directly on `main`.

/cc @baronfel