### PR TITLE
[vs18.6] Fix OptProf bootstrapper channel: use 'release' not 'stable'

### DIFF
--- a/azure-pipelines/.vsts-dotnet-build-jobs.yml
+++ b/azure-pipelines/.vsts-dotnet-build-jobs.yml
@@ -77,7 +77,7 @@ jobs:
   - name: VisualStudio.MajorVersion
     value: 18
   - name: VisualStudio.ChannelName
-    value: 'stable'
+    value: 'release'
   - name: VisualStudio.DropName
     value: Products/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildNumber)
 


### PR DESCRIPTION
### Problem
PR #13923 changed `VisualStudio.ChannelName` from `int.main` to `stable` to stop OptProf training against the moving `int.main` channel (which caused assembly-version drift, e.g. System.Text.Json 10.0.0.4). Since then the official build fails at **OptProf - Build VS bootstrapper**:

> The drop url https://download.visualstudio.microsoft.com/.../VisualStudio.vsman is invalid. Expected the drop url to have the format {prefix};{suffix}

### Root cause
The MicroBuild `MicroBuildBuildVSBootstrapper` task only special-cases the literal channel names **`release`** and **`preview`** as public channels. **Any other value — including `stable` — is assumed to be an *internal* channel** whose installer-manifest URL is a vsdrop drop in `{prefix};{suffix}` form. The public `stable` channel resolves (`aka.ms/vs/18/stable/channel`) to `VisualStudio.18.Release.chman`, whose installer-manifest URL is the public CDN `download.visualstudio.microsoft.com/.../VisualStudio.vsman` (no semicolon) -> the task throws.

The relevant task logic (`CreateConfigFile`): https://dev.azure.com/devdiv/Engineering/_git/MicroBuild?path=/src/Tasks/BuildVSBootstrapper/plugin.ps1&line=286&lineEnd=307&lineStartColumn=1&lineEndColumn=1&lineStyle=plain&_a=contents

### Fix
Use `release` instead of `stable`. Both resolve to the **same** public channel manifest (`VisualStudio.18.Release.chman`), so OptProf trains against the identical shipping bits — but `release` is one of the two special-cased names, so the task uses the aka.ms config template instead of attempting to parse a vsdrop URL.

No behavioral change to trained bits; this only unblocks the bootstrapper build.

Companion to #13993 (vs18.7).
