### PR TITLE
[vs18.7] Fix OptProf bootstrapper channel: use 'int.stable' not 'release'

### DIFF
--- a/azure-pipelines/.vsts-dotnet-build-jobs.yml
+++ b/azure-pipelines/.vsts-dotnet-build-jobs.yml
@@ -77,7 +77,7 @@ jobs:
   - name: VisualStudio.MajorVersion
     value: 18
   - name: VisualStudio.ChannelName
-    value: 'release'
+    value: 'int.stable'
   - name: VisualStudio.DropName
     value: Products/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildNumber)
 


### PR DESCRIPTION
### Problem
The previous fix (#13993, `stable` -> `release`) was wrong. On the official build it fails with:

> ##[error]Invalid JSON primitive: .

because `release` is **not a valid channel moniker for VS 18**. `https://aka.ms/vs/18/release/channel` bounces to a Bing fallback page, which the bootstrapper task saves as the `.chman` and then fails to parse as JSON.

### Why `release` and `stable` are both wrong
The aka.ms moniker convention changed between VS17 and VS18:

| moniker | VS 17 | VS 18 |
| --- | --- | --- |
| `release` | real CDN manifest | bounces to bing.com (broken) |
| `stable`  | bounces to bing.com | real **public** CDN manifest (`VisualStudio.18.Release.chman`) |
| `int.stable` | n/a | **internal vsdrop** manifest (`VisualStudio.18.int.stable.chman`) |

So for VS 18 the public GA channel is `stable` (not `release`). But the MicroBuild `MicroBuildBuildVSBootstrapper` task's `CreateConfigFile` only special-cases the VS17-era public names `release`/`preview`. Any other name — including `stable` — is routed down the **internal** path, where it parses the installer-manifest URL as a vsdrop `{prefix};{suffix}` drop. `stable`'s public CDN URL has no semicolon, hence the original *"drop url ... is invalid"* failure.

### Fix
Use **`int.stable`**: the **internal, vsdrop-backed** equivalent of `stable`. It tracks the stable 18.x bits (not the moving `int.main` that caused the System.Text.Json 10.0.0.4 drift in #13923), and because it is an internal channel its installer-manifest URL is a vsdrop `{prefix};{suffix}` URL that `CreateConfigFile` accepts.

- `https://aka.ms/vs/18/int.stable/channel` resolves to `VisualStudio.18.int.stable.chman` on `vsdrop.microsoft.com` (verified).

Relevant task logic (`CreateConfigFile`): https://dev.azure.com/devdiv/Engineering/_git/MicroBuild?path=/src/Tasks/BuildVSBootstrapper/plugin.ps1&line=286&lineEnd=307&lineStartColumn=1&lineEndColumn=1&lineStyle=plain&_a=contents



Companion to #14005 (vs18.6).




---

### Local validation (verified before merge)
Replicated every step the `MicroBuildBuildVSBootstrapper` task performs, using the same VSDrop token audience the task uses 

| Check | Result | Failure mode it rules out |
| --- | --- | --- |
| (a) `aka.ms/vs/18/int.stable/channel` redirects to **vsdrop** (not bing.com) | ✅ | the `release` "Invalid JSON primitive" (Bing fallback page) |
| (b) `.chman` downloads and is valid JSON (11 channelItems) | ✅ | the `release` "Invalid JSON primitive" |
| (c) installer-manifest URL splits into `{prefix};{suffix}` (2 parts) | ✅ | the `stable` "drop url ... is invalid" (`CreateConfigFile` `Split(";")` check) |
| (d) config payload `…;bootstrappers/Enterprise/configuration/vs_setup_bootstrapper.config` returns **HTTP 200** (after the corp→ZTN host rewrite the task does) | ✅ | the only downstream config-download risk |
| (bonus) installer `.vsman` downloads and parses (20,527 packages) | ✅ | the `vsman overlay` step input |

This is the same code path `int.main` already runs successfully; `int.stable` only pins it to stable 18.x bits.

> Note: the `int.stable` channel's installer manifest is named `VisualStudioIntPreview.vsman` (`...Channels.IntPreviewInstallerManifest`). That is just the drop's internal naming for the stable-pinned channel and does not affect correctness — all checks above passed.
