### PR TITLE
Raise un-quarantine bar to 50 distinct builds / 14 days

### DIFF
--- a/.github/workflows/flaky-test-detector.agent.md
+++ b/.github/workflows/flaky-test-detector.agent.md
@@ -161,7 +161,7 @@ tests that have gone consistently green. (Tests still flaking there simply **sta
 detector** with `-IncludePassed`, which also records passing observations:
 
 ```bash
-pwsh -File .github/workflows/scripts/Get-FlakyTests.ps1 -DefinitionId 344 -TargetBranch main -DaysBack 21 -MinSources 2 -MaxBuilds 150 -MaxArtifactDownloads 400 -IncludePassed -JsonOut quarantine-health.json
+pwsh -File .github/workflows/scripts/Get-FlakyTests.ps1 -DefinitionId 344 -TargetBranch main -DaysBack 30 -MinSources 2 -MaxBuilds 150 -MaxArtifactDownloads 600 -IncludePassed -JsonOut quarantine-health.json
 ```
 
 This emits the usual JSON plus a `passedTests` array (per normalized test: `distinctBuilds`,
@@ -365,8 +365,9 @@ the same single PR.
 
 **Un-quarantine candidates** — a currently-quarantined test `T` (from the `grep`) qualifies only if:
 
-- `T` is in `passedTests` with `distinctBuilds >= 4` **and** `distinctDays >= 3` (genuinely green across
-  many real **main-branch** CI runs spanning multiple days — not a one-off). These counts already
+- `T` is in `passedTests` with `distinctBuilds >= 50` **and** `distinctDays >= 14` (genuinely green across
+  a large number of real **main-branch** CI runs spanning at least two weeks — not a short green streak).
+  These counts already
   exclude def-344 PR-validation builds, so a fix PR's own green (or any unmerged PR's) can never satisfy
   this — only the fix proven on `main` over time does, **and**
 - `T` is **not** in the Step 1b `flakyTests` at all (zero failures in 344 over the window), **and**


### PR DESCRIPTION
The flaky-test detector's evidence-based un-quarantine path previously cleared an [ActiveIssue] after just 4 distinct green def-344 builds across 3 days, which is too low a bar to be confident a quarantined test is genuinely stable.

Raise the bar to 50 distinct main-branch builds across 14 days, and widen the def-344 quarantine-health scan window from 21 to 30 days (with -MaxArtifactDownloads 400 to 600) so 50 distinct builds is reachable and not truncated.