### PR TITLE
Source bootstrap dotnet-install script from a repo-local path

### DIFF
--- a/eng/BootStrapMsBuild.targets
+++ b/eng/BootStrapMsBuild.targets
@@ -238,9 +238,13 @@
 
     <PropertyGroup>
       <InstallDir>$(ArtifactsBinDir)bootstrap\core\</InstallDir>
+      <!-- The dotnet-install script is just a build tool, so keep it repo-local instead of writing it into
+           $(DotNetRoot), which can resolve to a machine-global, possibly non-writable path such as
+           "C:\Program Files\dotnet\" (see https://github.com/dotnet/msbuild/issues/13962). -->
+      <DotNetInstallScriptRootPath>$(ArtifactsObjDir)bootstrap\</DotNetInstallScriptRootPath>
     </PropertyGroup>
 
-    <InstallDotNetCoreTask DotNetInstallScriptRootPath="$(DotNetRoot)" InstallDir="$(InstallDir)" Version="$(BootstrapSdkVersion)"/>
+    <InstallDotNetCoreTask DotNetInstallScriptRootPath="$(DotNetInstallScriptRootPath)" InstallDir="$(InstallDir)" Version="$(BootstrapSdkVersion)"/>
   </Target>
 
   <Target Name="BootstrapNetCore" DependsOnTargets="AcquireSdk">

--- a/src/MSBuild.Bootstrap.Utils/Tasks/InstallDotNetCoreTask.cs
+++ b/src/MSBuild.Bootstrap.Utils/Tasks/InstallDotNetCoreTask.cs
@@ -36,7 +36,9 @@ namespace MSBuild.Bootstrap.Utils.Tasks
         public string InstallDir { get; set; }
 
         /// <summary>
-        /// Gets or sets the root path where the .NET Core installation script is located. This property is required.
+        /// Gets or sets the repo-local root path where the .NET Core installation script is downloaded to and run from.
+        /// This must be a writable directory; it is intentionally independent of where the SDK itself is installed so the
+        /// script is never written into a machine-global location such as "C:\Program Files\dotnet\". This property is required.
         /// </summary>
         [Required]
         public string DotNetInstallScriptRootPath { get; set; }
@@ -71,6 +73,8 @@ namespace MSBuild.Bootstrap.Utils.Tasks
             ScriptExecutionSettings executionSettings = SetupScriptsExecutionSettings();
             if (!File.Exists(executionSettings.ScriptsFullPath))
             {
+                // The script root is repo-local and may not exist yet, so make sure it is there before downloading into it.
+                Directory.CreateDirectory(DotNetInstallScriptRootPath);
                 AsyncTasks.Task.Run(() => DownloadScriptAsync(executionSettings.ScriptName, executionSettings.ScriptsFullPath)).GetAwaiter().GetResult();
             }
 


### PR DESCRIPTION
Fixes #13962

### Context

The MSBuild bootstrap task `InstallDotNetCoreTask` sourced/downloaded the `dotnet-install` script from `$(DotNetRoot)`. On agents where `global.json` matches a machine-wide SDK (e.g. the `windows.vs2026.amd64` image shipping SDK 10.0.300 at `C:\Program Files\dotnet`), `$(DotNetRoot)` resolves to `C:\Program Files\dotnet\` — a machine-global, non-writable path that also contains a space. Writing the script there needs elevation and pollutes a global directory, and the embedded space is the class of failure patched in the VMR (dotnet/dotnet#7061, #7075, #7076, #7080).

Per @rainersigwald's [follow-up request](https://github.com/dotnet/dotnet/pull/7061#discussion_r3363210107), the script — which is just a build tool — should always be repo-local and decoupled from wherever the SDK happens to live. This builds on top of the already-backflowed quoting fixes in `SetupScriptsExecutionSettings`.

### Change

- `eng/BootStrapMsBuild.targets`: pass the repo-local `$(ArtifactsObjDir)bootstrap\` as `DotNetInstallScriptRootPath` instead of `$(DotNetRoot)`. `InstallDir` remains repo-local and intentionally separate.
- `src/MSBuild.Bootstrap.Utils/Tasks/InstallDotNetCoreTask.cs`: create the (now repo-local) script directory before downloading, since it may not pre-exist; clarify the property doc.

### Validation

Removed `artifacts/bin/bootstrap` and `artifacts/obj/bootstrap`, then ran `build.cmd` (full build, 0 warnings / 0 errors). Confirmed the script is now written to `artifacts/obj/bootstrap/dotnet-install.ps1` and the bootstrap SDK installs to `artifacts/bin/bootstrap/core/sdk/`. The bootstrap task no longer writes into `$(DotNetRoot)`.

No user-facing behavior change — this only affects MSBuild's own bootstrap acquisition, so no ChangeWave is needed.
