### PR TITLE
Enable AOT/trim analyzers for Framework and StringTools

### DIFF
--- a/.github/skills/dotnet-aot-compat/SKILL.md
+++ b/.github/skills/dotnet-aot-compat/SKILL.md
@@ -1,0 +1,269 @@
+---
+name: dotnet-aot-compat
+description: >
+  Make .NET projects compatible with Native AOT and trimming by systematically
+  resolving IL trim/AOT analyzer warnings. USE FOR: making projects AOT-compatible,
+  fixing trimming warnings, resolving IL warnings (IL2026, IL2070, IL2067, IL2072,
+  IL3050), adding DynamicallyAccessedMembers annotations, enabling IsAotCompatible.
+  DO NOT USE FOR: publishing native AOT binaries, optimizing binary size, replacing
+  reflection-heavy libraries with alternatives.
+  INVOKES: no tools — pure knowledge skill.
+license: MIT
+---
+
+# dotnet-aot-compat
+
+Make .NET projects compatible with Native AOT and trimming by systematically resolving all IL trim/AOT analyzer warnings.
+
+## When to Use This Skill
+
+- **"Make this project AOT-compatible"**
+- **"Fix trimming warnings"** or **"fix IL warnings"**
+- **"Resolve IL2070 / IL2067 / IL2072 / IL2026 / IL3050 warnings"**
+- **"Add DynamicallyAccessedMembers annotations"**
+- **"Enable IsAotCompatible in my .csproj"**
+- **"My project has trim analyzer warnings after upgrading to net8.0"**
+- **"Annotate reflection code for the trimmer"**
+
+## When Not to Use This Skill
+
+Do not use this skill when the project exclusively targets .NET Framework (net4x), which does not support the trim/AOT analyzers.
+
+## Prerequisites
+
+An existing .NET project targeting net8.0 or later (or multi-targeting with at least one net8.0+ TFM) and the corresponding .NET SDK installed.
+
+## Background: What AOT Compatibility Means
+
+Native AOT and the IL trimmer perform static analysis to determine what code is reachable. Reflection can break this analysis because the trimmer can't see what types/members are accessed at runtime. The `IsAotCompatible` property enables analyzers that flag these issues as build warnings (ILXXXX codes).
+
+## Critical Rules
+
+### ❌ Never suppress warnings incorrectly
+
+- **NEVER** use `#pragma warning disable` for IL warnings. It hides warnings from the Roslyn analyzer at build time, but the IL linker and AOT compiler still see the issue. The code will fail at trim/publish time.
+- **NEVER** use `[UnconditionalSuppressMessage]`. It tells both the analyzer AND the linker to ignore the warning, meaning the trimmer cannot verify safety. Raising an error at build time is always preferable to hiding the issue and having it silently break at runtime.
+
+### 💡 Preferred approaches
+
+- **Prefer** `[DynamicallyAccessedMembers]` annotations to flow type information through the call chain.
+- **Prefer** refactoring to eliminate patterns that break annotation flow (e.g., boxing `Type` through `object[]`).
+- **Use** `[RequiresUnreferencedCode]` / `[RequiresDynamicCode]` / `[RequiresAssemblyFiles]` to mark methods as fundamentally incompatible with trimming, propagating the requirement to callers. This surfaces the issue clearly rather than hiding it — callers must explicitly acknowledge the incompatibility.
+
+### Annotation flow is key
+
+The trimmer tracks `[DynamicallyAccessedMembers]` annotations through assignments, parameter passing, and return values. If this flow is broken (e.g., by boxing a `Type` into `object`, storing in an untyped collection, or casting through interfaces), the trimmer loses track and warns. The fix is to preserve the flow, not suppress the warning.
+
+## Step-by-Step Procedure
+
+> **Do not explore the codebase up-front.** The build warnings tell you exactly which files and lines need changes. Follow a tight loop: **build → pick a warning → open that file at that line → apply the fix recipe → rebuild**. Reading or analyzing source files beyond what a specific warning points you to is wasted effort and leads to timeouts. Let the compiler guide you.
+>
+> ❌ Do NOT run `find`, `ls`, or `grep` to understand the project structure before building. Do NOT read README, docs, or architecture files. Your first action should be Step 1 (enable AOT analysis), then build.
+
+### Step 1: Enable AOT analysis in the .csproj
+
+Add `IsAotCompatible`. If the project doesn't exclusively target net8.0+, add a TFM condition (AOT analysis requires net8.0+):
+
+```xml
+<PropertyGroup>
+  <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">true</IsAotCompatible>
+</PropertyGroup>
+```
+
+This automatically sets `EnableTrimAnalyzer=true` and `EnableAotAnalyzer=true` for compatible TFMs. For multi-targeting projects (e.g., `netstandard2.0;net8.0`), the condition ensures no `NETSDK1210` warnings on older TFMs.
+
+### Step 2: Build and collect warnings
+
+```bash
+dotnet build <project.csproj> -f <net8.0-or-later-tfm> --no-incremental 2>&1 | grep 'IL[0-9]\{4\}'
+```
+
+Sort and deduplicate. Common warning codes:
+- **IL2070**: Reflection call on a `Type` parameter missing `[DynamicallyAccessedMembers]`
+- **IL2067**: Passing an unannotated `Type` to a method expecting `[DynamicallyAccessedMembers]`
+- **IL2072**: Return value or extracted value missing annotation (often from unboxing)
+- **IL2057**: `Type.GetType(string)` with a non-constant argument
+- **IL2026**: Calling a method marked `[RequiresUnreferencedCode]`
+- **IL2050**: P/invoke method with COM marshalling parameters
+- **IL2075**: Return value flows into reflection without annotation
+- **IL2091**: Generic argument missing `[DynamicallyAccessedMembers]` required by constraint
+- **IL3000**: `Assembly.Location` returns empty string in single-file/AOT apps
+- **IL3050**: Calling a method marked `[RequiresDynamicCode]`
+
+### Step 3: Triage warnings by code (do NOT read every file)
+
+Group the warnings from Step 2 by warning code and count them. **Do not open individual files yet.** Identify the top 1-2 patterns by count — these drive your fix strategy:
+
+| Pattern | Typical fix |
+|---------|-------------|
+| Many IL2026 + IL3050 from `JsonSerializer` | **Go to Strategy C immediately** — create a `JsonSerializerContext`, then batch-update all call sites |
+| IL2070/IL2087 on `Type` parameters | Add `[DynamicallyAccessedMembers]` to the innermost method, then cascade outward |
+| IL2067 passing unannotated `Type` | Annotate the parameter at the source |
+
+**In most real projects, IL2026/IL3050 from JsonSerializer dominate.** Start with Strategy C unless the warning breakdown clearly shows otherwise. After the batch JSON fix, handle remaining warnings with Strategies A–B. Only use Strategy D as a last resort.
+
+### Step 4: Fix warnings iteratively (innermost first)
+
+Work from the **innermost** reflection call outward. Each fix may cascade new warnings to callers.
+
+**Stay warning-driven.** For each warning, open only the file and line the compiler reported, identify the pattern, apply the matching fix recipe below, and move on. Do not scan the codebase for similar patterns or try to understand the full architecture — fix what the compiler tells you, rebuild, and let new warnings guide the next change. Fix a small batch of warnings (5-10), then rebuild immediately to check progress.
+
+**Use sub-agents when available.** If you can launch sub-agents (e.g., via a `task` tool), dispatch **multiple sub-agents in parallel** to edit different files simultaneously. Keep the main loop focused on building, parsing warnings, and dispatching — delegate actual file edits to sub-agents. For batch JSON updates, give each sub-agent 5-10 files to update in one prompt. **After 2 build-fix cycles, dispatch all remaining file edits to sub-agents in parallel — do not continue fixing files sequentially.** Example:
+
+> Update these files to use source-generated JSON: `src/Models/Resource.Serialization.cs`, `src/Models/Identity.Serialization.cs`, `src/Models/Plan.Serialization.cs`. In each file, replace `JsonSerializer.Serialize(writer, value)` with `JsonSerializer.Serialize(writer, value, MyProjectJsonContext.Default.TypeName)` and `JsonSerializer.Deserialize<T>(ref reader)` with `JsonSerializer.Deserialize(ref reader, MyProjectJsonContext.Default.TypeName)`. Only edit the JsonSerializer call sites.
+
+#### Strategy A: Add `[DynamicallyAccessedMembers]` (preferred)
+
+When a method uses reflection on a `Type` parameter, annotate the parameter to tell the trimmer what members are needed:
+
+```csharp
+using System.Diagnostics.CodeAnalysis;
+
+// Before (warns IL2070):
+void Process(Type t) {
+    var method = t.GetMethod("Foo");  // trimmer can't verify
+}
+
+// After (clean):
+void Process([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] Type t) {
+    var method = t.GetMethod("Foo");  // trimmer preserves public methods
+}
+```
+
+When you annotate a parameter, **all callers** must now pass properly annotated types. This cascades outward — follow each caller and annotate or refactor as needed. **The caller's annotation must include at least the same member types as the callee's.** If the callee requires `PublicConstructors | NonPublicConstructors`, the caller must specify the same or a superset — using only `NonPublicConstructors` will produce IL2091.
+
+#### Strategy B: Refactor to preserve annotation flow
+
+When annotation flow is broken by boxing (storing `Type` in `object`, `object[]`, or untyped collections), **refactor** to pass the `Type` directly:
+
+```csharp
+// BROKEN: Type boxed into object[], annotation lost
+void Process(object[] args) {
+    Type t = (Type)args[0];  // IL2072: annotation lost through boxing
+    Evaluate(t, ...);
+}
+
+// FIXED: Pass Type as a separate, annotated parameter
+void Process(
+    object[] args,
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] Type calleeType,
+    ...) {
+    Evaluate(calleeType, ...);  // annotation flows cleanly
+}
+```
+
+Common patterns that break flow and how to fix them:
+- **`object[]` parameter bags**: Extract the `Type` into a dedicated annotated parameter
+- **Dictionary/List storage**: Use a typed field with annotation instead
+- **Interface indirection**: Add annotation to the interface method's parameter
+- **Property with boxing getter**: Annotate the property's return type
+
+#### Strategy C: Source-generated JSON serialization (batch fix)
+
+When most warnings are IL2026/IL3050 from `JsonSerializer.Serialize`/`Deserialize`, this is a single mechanical fix applied in bulk:
+
+1. **Collect affected types** — grep for all `JsonSerializer.Serialize` and `JsonSerializer.Deserialize` call sites. Extract the type being serialized (the `<T>` in `Deserialize<T>`, or the runtime type of the object in `Serialize`).
+
+2. **Create one `JsonSerializerContext`** with `[JsonSerializable]` for every type found. **Skip types from external packages** (e.g., `ResponseError` from `Azure.Core`) — they won't source-generate for types you don't own. Handle external types separately via Gotcha #1 below.
+
+```csharp
+[JsonSerializerContext]
+[JsonSerializable(typeof(ManagedServiceIdentity))]
+[JsonSerializable(typeof(SystemData))]
+// ... one attribute per type YOU OWN
+// Do NOT add types from external packages (e.g., ResponseError)
+internal partial class MyProjectJsonContext : JsonSerializerContext { }
+```
+
+3. **Batch-update all call sites** — do not read each file individually. Apply the pattern mechanically:
+   - `JsonSerializer.Serialize(obj)` → `JsonSerializer.Serialize(obj, MyProjectJsonContext.Default.TypeName)`
+   - `JsonSerializer.Deserialize<T>(json)` → `JsonSerializer.Deserialize(json, MyProjectJsonContext.Default.TypeName)`
+
+   Find and update all call sites in one pass:
+   ```bash
+   # Find all files with JsonSerializer calls
+   grep -rl 'JsonSerializer\.\(Serialize\|Deserialize\)' src/ --include='*.cs'
+   ```
+   Then use sequential `edit` calls to apply the same transformation to every matching file. **Do not use `sed` for C# code** — generics like `Deserialize<T>()` have angle brackets and nested parentheses that sed will mangle.
+
+4. **Build once** to verify. Remaining warnings will be non-serialization issues — handle those with Strategies A–B or D.
+
+#### Strategy D: `[RequiresUnreferencedCode]` (last resort)
+
+When a method fundamentally requires arbitrary reflection that cannot be statically described:
+
+```csharp
+[RequiresUnreferencedCode("Loads plugins by name using Assembly.Load")]
+public void LoadPlugin(string assemblyName) {
+    var asm = Assembly.Load(assemblyName);
+    // ...
+}
+```
+
+This propagates to callers — they must also be annotated with `[RequiresUnreferencedCode]`. Use sparingly; it marks the entire call chain as trim-incompatible.
+
+### Step 5: Rebuild and repeat
+
+After each small batch of fixes (5-10 warnings), rebuild with `--no-incremental` and check for new warnings. **Do not attempt to fix all warnings before rebuilding** — frequent rebuilds catch mistakes early and reveal cascading warnings. Fixes cascade — annotating an inner method may surface warnings in its callers. Repeat until `0 Warning(s)`.
+
+### Step 6: Validate all TFMs
+
+Build all target frameworks to ensure:
+- **0 IL warnings** on net8.0+ TFMs
+- **No NETSDK1210 warnings** (the `IsAotCompatible` condition handles this)
+- **Clean builds** on older TFMs (netstandard2.0, net472, etc.)
+
+```bash
+dotnet build <project.csproj>  # builds all TFMs
+```
+
+## Stop Signals
+
+- **Do not analyze more than 2-3 representative files per warning pattern.** After identifying the fix for a pattern, apply it to all matching files without reading each one first.
+- **Start fixing after one build.** Do not do a second analysis pass — begin implementing fixes for the most common warning pattern immediately after Step 3 triage.
+- Stop after achieving **0 IL warnings** for net8.0+ TFMs. Don't optimize or refactor already-clean annotations.
+- If a warning requires **architectural refactoring** beyond annotation flow fixes (e.g., replacing an entire serialization layer), document it and stop — don't rewrite large subsystems.
+- Limit to **3 build-fix iterations** per warning. If annotation flow doesn't resolve it after 3 attempts, escalate to `[RequiresUnreferencedCode]`.
+- Don't chase warnings in **third-party dependencies** you can't modify. Note them and move on.
+- If the user asked a scoped question (e.g., "fix warnings in this file"), don't expand to the entire project.
+
+## Polyfills for Older TFMs
+
+For multi-targeting projects that include netstandard2.0 or net472, you need polyfills for `DynamicallyAccessedMembersAttribute` and related types. See [references/polyfills.md](references/polyfills.md).
+
+## Common Gotchas
+
+1. **External types without AOT-safe serialization**: When a type comes from a dependency you can't modify (e.g., `ResponseError` from `Azure.Core`) and it lacks a source-generated serializer, `Options.GetConverter<T>()` is reflection-based and will produce IL warnings. First check if the type implements `IJsonModel<T>` (common in Azure SDK) — if so, bypass `JsonSerializer` entirely:
+
+```csharp
+// Before (IL2026 — JsonSerializer uses reflection):
+JsonSerializer.Serialize(writer, errorValue);
+
+// After (AOT-safe — uses IJsonModel directly):
+((IJsonModel<ResponseError>)errorValue).Write(writer, ModelReaderWriterOptions.Json);
+
+// For deserialization:
+var error = ((IJsonModel<ResponseError>)new ResponseError()).Create(ref reader, ModelReaderWriterOptions.Json);
+```
+
+Do **not** add the external type to your `JsonSerializerContext` — it won't source-generate for types you don't own. If the type doesn't implement `IJsonModel<T>`, write a custom `JsonConverter<T>` with manual `Utf8JsonReader`/`Utf8JsonWriter` logic and register it via `[JsonSourceGenerationOptions]` on your context.
+
+2. **Serialization libraries**: Most reflection-based serializers (e.g., `Newtonsoft.Json`, `XmlSerializer`) are not AOT-compatible. Migrate to a source-generation-based serializer such as `System.Text.Json` with a `JsonSerializerContext`. If migration is not feasible, mark the serialization call site with `[RequiresUnreferencedCode]`.
+
+3. **Shared projects / projitems**: When source is shared between multiple projects via `<Import>`, annotations added to shared code affect ALL consuming projects. Verify that all consumers still build cleanly.
+
+## References
+
+[Limitations](https://learn.microsoft.com/en-us/dotnet/core/deploying/native-aot/?tabs=windows%2Cnet8#limitations-of-native-aot-deployment)
+[Conceptual: Understanding trimming](https://learn.microsoft.com/en-us/dotnet/core/deploying/trimming/trimming-concepts)
+[How-to: trim compat](https://learn.microsoft.com/en-us/dotnet/core/deploying/trimming/fixing-warnings)
+
+## Checklist
+
+- [ ] Added `<IsAotCompatible>` with TFM condition to .csproj
+- [ ] Built with AOT analyzers enabled (net8.0+ TFM)
+- [ ] Fixed all IL warnings via annotations or refactoring
+- [ ] No `#pragma warning disable` or `[UnconditionalSuppressMessage]` used for any IL warning
+- [ ] Polyfills present for older TFMs if needed
+- [ ] All target frameworks build with 0 warnings
+- [ ] Verified shared/linked source doesn't break sibling projects

--- a/.github/skills/dotnet-aot-compat/references/polyfills.md
+++ b/.github/skills/dotnet-aot-compat/references/polyfills.md
@@ -1,0 +1,43 @@
+# Polyfills for Older TFMs
+
+`DynamicallyAccessedMembersAttribute` shipped in .NET 5. For projects targeting netstandard2.0 or net472, you need a polyfill. The trimmer recognizes the attribute by name, so a local copy works:
+
+```csharp
+#if !NET
+namespace System.Diagnostics.CodeAnalysis
+{
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.ReturnValue |
+                    AttributeTargets.GenericParameter | AttributeTargets.Parameter |
+                    AttributeTargets.Property, Inherited = false)]
+    internal sealed class DynamicallyAccessedMembersAttribute : Attribute
+    {
+        public DynamicallyAccessedMembersAttribute(DynamicallyAccessedMemberTypes memberTypes)
+            => MemberTypes = memberTypes;
+        public DynamicallyAccessedMemberTypes MemberTypes { get; }
+    }
+
+    [Flags]
+    internal enum DynamicallyAccessedMemberTypes
+    {
+        None = 0,
+        PublicParameterlessConstructor = 0x0001,
+        PublicConstructors = 0x0002 | PublicParameterlessConstructor,
+        NonPublicConstructors = 0x0004,
+        PublicMethods = 0x0008,
+        NonPublicMethods = 0x0010,
+        PublicFields = 0x0020,
+        NonPublicFields = 0x0040,
+        PublicNestedTypes = 0x0080,
+        NonPublicNestedTypes = 0x0100,
+        PublicProperties = 0x0200,
+        NonPublicProperties = 0x0400,
+        PublicEvents = 0x0800,
+        NonPublicEvents = 0x1000,
+        Interfaces = 0x2000,
+        All = ~None // Discouraged — prefer specific flags
+    }
+}
+#endif
+```
+
+Similarly for `RequiresUnreferencedCodeAttribute` and `UnconditionalSuppressMessageAttribute` if needed on older TFMs.

--- a/src/Build/Errors/InternalLoggerException.cs
+++ b/src/Build/Errors/InternalLoggerException.cs
@@ -10,6 +10,7 @@ using System.Security.Permissions;
 using Microsoft.Build.Shared;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Framework.BuildException;
+using Microsoft.Build.Framework.Telemetry;
 using System.Collections.Generic;
 
 #nullable disable
@@ -24,7 +25,7 @@ namespace Microsoft.Build.Exceptions
     // promise to never change the type's fields i.e. the type is immutable; adding new fields in the next version of the type
     // without following certain special FX guidelines, can break both forward and backward compatibility
     [Serializable]
-    public sealed class InternalLoggerException : BuildExceptionBase
+    public sealed class InternalLoggerException : BuildExceptionBase, IBuildEventArgsTelemetryProvider
     {
         #region Unusable constructors
 
@@ -191,6 +192,14 @@ namespace Microsoft.Build.Exceptions
                 return e;
             }
         }
+
+        /// <summary>
+        /// Surfaces the simple type name of the <see cref="BuildEventArgs"/> being logged (if any)
+        /// for crash telemetry. Implemented explicitly so it stays off the public surface; lets
+        /// Microsoft.Build.Framework read the value via <see cref="IBuildEventArgsTelemetryProvider"/>
+        /// without reflecting over this type.
+        /// </summary>
+        string IBuildEventArgsTelemetryProvider.BuildEventArgsTypeName => e?.GetType().Name;
 
         /// <summary>
         /// Gets the error code associated with this exception's message (not the inner exception).

--- a/src/Framework.UnitTests/CrashTelemetry_Tests.cs
+++ b/src/Framework.UnitTests/CrashTelemetry_Tests.cs
@@ -1015,7 +1015,7 @@ public class CrashTelemetry_Tests
         public override string? StackTrace => _stack;
     }
 
-    private sealed class ExceptionWithBuildEventArgs : Exception
+    private sealed class ExceptionWithBuildEventArgs : Exception, IBuildEventArgsTelemetryProvider
     {
         public ExceptionWithBuildEventArgs(string message, BuildEventArgs buildEventArgs) : base(message)
         {
@@ -1023,5 +1023,9 @@ public class CrashTelemetry_Tests
         }
 
         public BuildEventArgs BuildEventArgs { get; }
+
+        // Mirrors InternalLoggerException: surface the event type name through the telemetry
+        // contract so CrashTelemetry can read it without reflection.
+        string? IBuildEventArgsTelemetryProvider.BuildEventArgsTypeName => BuildEventArgs?.GetType().Name;
     }
 }

--- a/src/Framework/BuildEnvironmentHelper.cs
+++ b/src/Framework/BuildEnvironmentHelper.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -374,6 +375,11 @@ namespace Microsoft.Build.Shared
         private static bool? _runningTests;
         private static readonly LockType _runningTestsLock = new LockType();
 
+        [UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode",
+            Justification = "Deliberately reads the internal Microsoft.Build.Framework.TestInfo.s_runningTests field by reflection so this type can be shared across assemblies without a hard reference. The DynamicDependency below keeps the field under trimming.")]
+        [UnconditionalSuppressMessage("Trimming", "IL2075:UnrecognizedReflectionPattern",
+            Justification = "TestInfo.s_runningTests is preserved by the DynamicDependency below, so the GetField lookup remains valid under trimming.")]
+        [DynamicDependency("s_runningTests", "Microsoft.Build.Framework.TestInfo", "Microsoft.Build.Framework")]
         private static bool CheckIfRunningTests()
         {
             if (_runningTests != null)

--- a/src/Framework/Loader/CoreCLRAssemblyLoader.cs
+++ b/src/Framework/Loader/CoreCLRAssemblyLoader.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Reflection;
 using System.Runtime.Loader;
@@ -43,6 +44,7 @@ namespace Microsoft.Build.Shared
             }
         }
 
+        [RequiresUnreferencedCode("Loads task and plugin assemblies from runtime-determined paths, which is incompatible with trimming.")]
         public Assembly LoadFromPath(string fullPath)
         {
             if (fullPath == null)
@@ -67,6 +69,7 @@ namespace Microsoft.Build.Shared
             }
         }
 
+        [RequiresUnreferencedCode("Loads task and plugin assemblies from runtime-determined paths, which is incompatible with trimming.")]
         private Assembly LoadUsingLegacyDefaultContext(string fullPath)
         {
             lock (_guard)
@@ -87,6 +90,7 @@ namespace Microsoft.Build.Shared
             }
         }
 
+        [RequiresUnreferencedCode("Loads task and plugin assemblies from runtime-determined paths, which is incompatible with trimming.")]
         private Assembly LoadUsingPluginContext(string fullPath)
         {
             lock (_guard)
@@ -110,6 +114,7 @@ namespace Microsoft.Build.Shared
             }
         }
 
+        [RequiresUnreferencedCode("Loads task and plugin assemblies from runtime-determined paths, which is incompatible with trimming.")]
         private Assembly TryGetWellKnownAssembly(AssemblyLoadContext context, AssemblyName assemblyName)
         {
             if (!MSBuildLoadContext.WellKnownAssemblyNames.Contains(assemblyName.Name))
@@ -125,6 +130,7 @@ namespace Microsoft.Build.Shared
             return TryResolveAssemblyFromPaths(context, assemblyName, searchPaths);
         }
 
+        [RequiresUnreferencedCode("Loads task and plugin assemblies from runtime-determined paths, which is incompatible with trimming.")]
         private Assembly TryResolveAssembly(AssemblyLoadContext context, AssemblyName assemblyName)
         {
             lock (_guard)
@@ -145,6 +151,7 @@ namespace Microsoft.Build.Shared
             }
         }
 
+        [RequiresUnreferencedCode("Loads task and plugin assemblies from runtime-determined paths, which is incompatible with trimming.")]
         private Assembly TryResolveAssemblyFromPaths(AssemblyLoadContext context, AssemblyName assemblyName, IEnumerable<string> searchPaths)
         {
             foreach (string cultureSubfolder in string.IsNullOrEmpty(assemblyName.CultureName)
@@ -184,6 +191,7 @@ namespace Microsoft.Build.Shared
         /// <remarks>
         /// Assumes we have a lock on _guard
         /// </remarks>
+        [RequiresUnreferencedCode("Loads task and plugin assemblies from runtime-determined paths, which is incompatible with trimming.")]
         private Assembly LoadAndCache(AssemblyLoadContext context, string fullPath)
         {
             var assembly = context.LoadFromAssemblyPath(fullPath);

--- a/src/Framework/Loader/LoadedType.cs
+++ b/src/Framework/Loader/LoadedType.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Reflection;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.Build.Execution;
 using Microsoft.Build.Framework;
 
@@ -27,6 +28,7 @@ namespace Microsoft.Build.Shared
         /// <param name="architecture">Assembly architecture extracted from PE flags</param>
         /// <param name="loadedViaMetadataLoadContext">Whether this type was loaded via MetadataLoadContext</param>
         internal LoadedType(
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)]
             Type type,
             AssemblyLoadInfo assemblyLoadInfo,
             Assembly loadedAssembly,

--- a/src/Framework/Loader/MSBuildLoadContext.cs
+++ b/src/Framework/Loader/MSBuildLoadContext.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Reflection;
 using System.Runtime.Loader;
@@ -47,6 +48,8 @@ namespace Microsoft.Build.Shared
                 null;
         }
 
+        [UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode",
+            Justification = "This overrides AssemblyLoadContext.Load, which is not annotated with RequiresUnreferencedCode, so the requirement cannot be propagated to this method. Loading plugin assemblies by path is the intended purpose of this isolated load context.")]
         protected override Assembly? Load(AssemblyName assemblyName)
         {
             if (WellKnownAssemblyNames.Contains(assemblyName.Name!))

--- a/src/Framework/Microsoft.Build.Framework.csproj
+++ b/src/Framework/Microsoft.Build.Framework.csproj
@@ -2,6 +2,9 @@
   <PropertyGroup>
     <TargetFrameworks>$(LibraryTargetFrameworks)</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <!-- Enable the trim/AOT analyzers. They only run on net8.0+ TFMs; the condition keeps
+         older TFMs (net472, netstandard2.0) from emitting NETSDK1210. -->
+    <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">true</IsAotCompatible>
     <GenerateReferenceAssemblySource>true</GenerateReferenceAssemblySource>
     <!-- Do not create Tlbs when building in source-build mode (no net472 TFM available).
          In VMR Windows builds and VS builds, generate the .tlb from the net472 output. -->

--- a/src/Framework/Polyfills/AotTrimmingPolyfills.cs
+++ b/src/Framework/Polyfills/AotTrimmingPolyfills.cs
@@ -1,0 +1,129 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// Polyfills for the trimming / Native AOT analyzer attributes that ship in the runtime
+// starting with .NET 5. Microsoft.Build.Framework enables the trim/AOT analyzers
+// (IsAotCompatible) on its net8.0+ build, but the annotations themselves are written
+// unconditionally so they remain in the public metadata for every target framework.
+//
+// On net10.0 these types come from the runtime. On net472 and netstandard2.0 they are not
+// available to reference: several dependencies (System.Text.Json, System.Collections.Immutable,
+// Microsoft.IO.Redist, ...) embed their own *internal* copies of these attributes, so the
+// types appear "already declared" - PolySharp therefore skips generating them, yet those
+// copies are inaccessible from this assembly. Defining our own internal copies here makes the
+// annotations resolve. The trim/AOT analyzer never runs on net472 or netstandard2.0, so these
+// definitions only need to exist for the annotations to compile - the trimmer recognizes them
+// by full type name on net10.0 where the real runtime types are used.
+#if !NET
+
+namespace System.Diagnostics.CodeAnalysis
+{
+    /// <summary>
+    /// Specifies the types of members that are dynamically accessed. This enumeration has a
+    /// <see cref="FlagsAttribute"/> attribute that allows a bitwise combination of its member values.
+    /// </summary>
+    [Flags]
+    internal enum DynamicallyAccessedMemberTypes
+    {
+        None = 0,
+        PublicParameterlessConstructor = 0x0001,
+        PublicConstructors = 0x0002 | PublicParameterlessConstructor,
+        NonPublicConstructors = 0x0004,
+        PublicMethods = 0x0008,
+        NonPublicMethods = 0x0010,
+        PublicFields = 0x0020,
+        NonPublicFields = 0x0040,
+        PublicNestedTypes = 0x0080,
+        NonPublicNestedTypes = 0x0100,
+        PublicProperties = 0x0200,
+        NonPublicProperties = 0x0400,
+        PublicEvents = 0x0800,
+        NonPublicEvents = 0x1000,
+        Interfaces = 0x2000,
+        All = ~None,
+    }
+
+    /// <summary>
+    /// Indicates that certain members on a specified <see cref="Type"/> are accessed dynamically,
+    /// for example, through <see cref="System.Reflection"/>.
+    /// </summary>
+    [AttributeUsage(
+        AttributeTargets.Field | AttributeTargets.ReturnValue | AttributeTargets.GenericParameter |
+        AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.Method,
+        Inherited = false)]
+    internal sealed class DynamicallyAccessedMembersAttribute : Attribute
+    {
+        public DynamicallyAccessedMembersAttribute(DynamicallyAccessedMemberTypes memberTypes) => MemberTypes = memberTypes;
+
+        public DynamicallyAccessedMemberTypes MemberTypes { get; }
+    }
+
+    /// <summary>
+    /// Indicates that the specified method requires dynamic access to code that is not referenced
+    /// statically, for example, through <see cref="System.Reflection"/>.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Constructor | AttributeTargets.Method, Inherited = false)]
+    internal sealed class RequiresUnreferencedCodeAttribute : Attribute
+    {
+        public RequiresUnreferencedCodeAttribute(string message) => Message = message;
+
+        public string Message { get; }
+
+        public string? Url { get; set; }
+    }
+
+    /// <summary>
+    /// Suppresses reporting of a specific rule violation, allowing multiple suppressions on a single code artifact.
+    /// Unlike <see cref="SuppressMessageAttribute"/>, this attribute is preserved in metadata and applied by the trimmer.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.All, Inherited = false, AllowMultiple = true)]
+    internal sealed class UnconditionalSuppressMessageAttribute : Attribute
+    {
+        public UnconditionalSuppressMessageAttribute(string category, string checkId)
+        {
+            Category = category;
+            CheckId = checkId;
+        }
+
+        public string Category { get; }
+
+        public string CheckId { get; }
+
+        public string? Scope { get; set; }
+
+        public string? Target { get; set; }
+
+        public string? MessageId { get; set; }
+
+        public string? Justification { get; set; }
+    }
+
+    /// <summary>
+    /// States a dependency that one member has on another, ensuring the dependency is kept by the trimmer.
+    /// </summary>
+    [AttributeUsage(
+        AttributeTargets.Method | AttributeTargets.Constructor | AttributeTargets.Field,
+        AllowMultiple = true,
+        Inherited = false)]
+    internal sealed class DynamicDependencyAttribute : Attribute
+    {
+        public DynamicDependencyAttribute(string memberSignature) => MemberSignature = memberSignature;
+
+        public DynamicDependencyAttribute(string memberSignature, string typeName, string assemblyName)
+        {
+            MemberSignature = memberSignature;
+            TypeName = typeName;
+            AssemblyName = assemblyName;
+        }
+
+        public string? MemberSignature { get; }
+
+        public string? TypeName { get; }
+
+        public string? AssemblyName { get; }
+
+        public string? Condition { get; set; }
+    }
+}
+
+#endif

--- a/src/Framework/ReflectableTaskPropertyInfo.cs
+++ b/src/Framework/ReflectableTaskPropertyInfo.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Linq;
 using System.Reflection;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.Build.Framework;
 
 #nullable disable
@@ -23,6 +24,7 @@ namespace Microsoft.Build.Execution
         /// <summary>
         /// The type of the generated tasks.
         /// </summary>
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.NonPublicProperties)]
         private Type _taskType;
 
         /// <summary>
@@ -30,7 +32,10 @@ namespace Microsoft.Build.Execution
         /// </summary>
         /// <param name="taskPropertyInfo">The original property info that generated this instance.</param>
         /// <param name="taskType">The type to reflect over to get the reflection propertyinfo later.</param>
-        internal ReflectableTaskPropertyInfo(TaskPropertyInfo taskPropertyInfo, Type taskType)
+        internal ReflectableTaskPropertyInfo(
+            TaskPropertyInfo taskPropertyInfo,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.NonPublicProperties)]
+            Type taskType)
             : base(taskPropertyInfo.Name, taskPropertyInfo.PropertyType, taskPropertyInfo.Output, taskPropertyInfo.Required)
         {
             ArgumentNullException.ThrowIfNull(taskType);

--- a/src/Framework/Telemetry/CrashTelemetry.cs
+++ b/src/Framework/Telemetry/CrashTelemetry.cs
@@ -428,19 +428,13 @@ internal class CrashTelemetry : TelemetryBase, IActivityTelemetryDataHolder
             InnerExceptionMessage = TruncateMessage(inner.Message);
         }
 
-        // Extract BuildEventArgs type from InternalLoggerException without taking
-        // a direct dependency on Microsoft.Build.dll. The property is public.
-        try
+        // InternalLoggerException (in Microsoft.Build) carries the type name of the BuildEventArgs
+        // it was delivering. It implements IBuildEventArgsTelemetryProvider so we can read it without
+        // a hard dependency on Microsoft.Build.dll and without reflection - a plain type check is
+        // trimming- and Native AOT-safe.
+        if (exception is IBuildEventArgsTelemetryProvider buildEventArgsProvider)
         {
-            var buildEventArgsProp = exception.GetType().GetProperty("BuildEventArgs");
-            if (buildEventArgsProp?.GetValue(exception) is object eventArgs)
-            {
-                LoggerEventType = eventArgs.GetType().Name;
-            }
-        }
-        catch
-        {
-            // Best effort: reflection failures must not cause a secondary failure.
+            LoggerEventType = buildEventArgsProvider.BuildEventArgsTypeName;
         }
     }
 

--- a/src/Framework/Telemetry/CrashTelemetry.cs
+++ b/src/Framework/Telemetry/CrashTelemetry.cs
@@ -434,7 +434,14 @@ internal class CrashTelemetry : TelemetryBase, IActivityTelemetryDataHolder
         // trimming- and Native AOT-safe.
         if (exception is IBuildEventArgsTelemetryProvider buildEventArgsProvider)
         {
-            LoggerEventType = buildEventArgsProvider.BuildEventArgsTypeName;
+            try
+            {
+                LoggerEventType = buildEventArgsProvider.BuildEventArgsTypeName;
+            }
+            catch
+            {
+                // Best effort: a provider must never cause a secondary failure while collecting crash telemetry.
+            }
         }
     }
 

--- a/src/Framework/Telemetry/IBuildEventArgsTelemetryProvider.cs
+++ b/src/Framework/Telemetry/IBuildEventArgsTelemetryProvider.cs
@@ -1,0 +1,26 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Build.Framework.Telemetry
+{
+    /// <summary>
+    /// Implemented by exception types that can surface the simple type name of the
+    /// <see cref="BuildEventArgs"/> they were processing when they failed - most notably
+    /// <c>InternalLoggerException</c> in Microsoft.Build.
+    /// </summary>
+    /// <remarks>
+    /// This lets crash telemetry (which lives in Microsoft.Build.Framework) capture the event
+    /// type without taking a hard dependency on Microsoft.Build.dll and without reflecting over
+    /// the exception. A plain type check (<c>is IBuildEventArgsTelemetryProvider</c>) is
+    /// trimming- and Native AOT-safe, unlike the previous <c>Type.GetProperty</c> probe.
+    /// </remarks>
+    internal interface IBuildEventArgsTelemetryProvider
+    {
+        /// <summary>
+        /// Gets the simple type name of the <see cref="BuildEventArgs"/> that was being delivered
+        /// when the failure occurred (for example, <c>"BuildFinishedEventArgs"</c>), or
+        /// <see langword="null"/> if no build event was associated with the failure.
+        /// </summary>
+        string? BuildEventArgsTypeName { get; }
+    }
+}

--- a/src/Framework/Utilities/FrameworkLocationHelper.cs
+++ b/src/Framework/Utilities/FrameworkLocationHelper.cs
@@ -1441,9 +1441,19 @@ namespace Microsoft.Build.Shared
                 // single-file/Native AOT safe). On .NET Framework this points at the framework we want
                 // to locate; on .NET (Core) it points at the shared runtime, where the heuristic below
                 // finds no v4.x sibling and returns null.
+                string currentRuntimePath = NativeMethods.FrameworkCurrentPath;
+                if (string.IsNullOrEmpty(currentRuntimePath))
+                {
+                    // In single-file or Native AOT scenarios Assembly.Location returns an empty string,
+                    // so the running runtime's directory is unknown and we cannot locate an installed
+                    // .NET Framework relative to it. Returning null matches the "not found" contract and
+                    // avoids passing an empty path into FindDotNetFrameworkPath.
+                    return null;
+                }
+
                 string generatedPathToDotNetFramework =
                                 FindDotNetFrameworkPath(
-                                    NativeMethods.FrameworkCurrentPath,
+                                    currentRuntimePath,
                                     this.DotNetFrameworkFolderPrefix,
                                     FileSystems.Default.DirectoryExists,
                                     Directory.GetDirectories,

--- a/src/Framework/Utilities/FrameworkLocationHelper.cs
+++ b/src/Framework/Utilities/FrameworkLocationHelper.cs
@@ -1436,9 +1436,14 @@ namespace Microsoft.Build.Shared
 #endif
 
                 // We're installed and we haven't found this framework path yet -- so find it!
+                // FrameworkCurrentPath is the directory of the currently-running runtime's core library
+                // (the same value as typeof(object).Module's directory, but via an accessor that is
+                // single-file/Native AOT safe). On .NET Framework this points at the framework we want
+                // to locate; on .NET (Core) it points at the shared runtime, where the heuristic below
+                // finds no v4.x sibling and returns null.
                 string generatedPathToDotNetFramework =
                                 FindDotNetFrameworkPath(
-                                    Path.GetDirectoryName(typeof(object).Module.FullyQualifiedName),
+                                    NativeMethods.FrameworkCurrentPath,
                                     this.DotNetFrameworkFolderPrefix,
                                     FileSystems.Default.DirectoryExists,
                                     Directory.GetDirectories,

--- a/src/Framework/Utilities/TaskFactoryUtilities.cs
+++ b/src/Framework/Utilities/TaskFactoryUtilities.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using Microsoft.Build.Shared.FileSystem;
 using Microsoft.Build.Framework;
@@ -155,6 +156,7 @@ namespace Microsoft.Build.Shared
         /// </summary>
         /// <param name="assemblyPath">The path to the assembly to load.</param>
         /// <returns>The loaded assembly.</returns>
+        [RequiresUnreferencedCode("Loads a task assembly from disk; the trimmer cannot statically determine which types the assembly contributes.")]
         public static Assembly LoadTaskAssembly(string assemblyPath)
         {
             if (string.IsNullOrEmpty(assemblyPath))
@@ -174,6 +176,7 @@ namespace Microsoft.Build.Shared
         /// during TaskFactory initialization.
         /// </summary>
         /// <param name="taskLocation">The path to the task assembly.</param>
+        [RequiresUnreferencedCode("Registers handlers that load task dependency assemblies from disk, which is incompatible with trimming.")]
         public static void RegisterAssemblyResolveHandlersFromManifest(string taskLocation)
         {
             if (string.IsNullOrEmpty(taskLocation))
@@ -206,6 +209,7 @@ namespace Microsoft.Build.Shared
         /// </summary>
         /// <param name="searchDirectories">The directories to search for assemblies.</param>
         /// <returns>A ResolveEventHandler that can be used with AppDomain.CurrentDomain.AssemblyResolve.</returns>
+        [RequiresUnreferencedCode("The returned handler loads task dependency assemblies from disk, which is incompatible with trimming.")]
         public static ResolveEventHandler CreateAssemblyResolver(List<string> searchDirectories)
         {
             if (searchDirectories == null)
@@ -245,6 +249,7 @@ namespace Microsoft.Build.Shared
         /// <param name="directories">The directories to search in.</param>
         /// <param name="assemblyName">The name of the assembly to load.</param>
         /// <returns>The loaded assembly if found, otherwise null.</returns>
+        [RequiresUnreferencedCode("Loads a task dependency assembly from disk; the trimmer cannot statically determine which types the assembly contributes.")]
         private static Assembly? TryLoadAssembly(List<string> directories, AssemblyName assemblyName)
         {
             foreach (string directory in directories)

--- a/src/StringTools/StringTools.csproj
+++ b/src/StringTools/StringTools.csproj
@@ -3,6 +3,9 @@
     <TargetFrameworks>$(LibraryTargetFrameworks);net35</TargetFrameworks>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <!-- Enable the trim/AOT analyzers. They only run on net8.0+ TFMs; the condition keeps
+         older TFMs (net472, netstandard2.0, net35) from emitting NETSDK1210. -->
+    <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">true</IsAotCompatible>
     <IsPackable>true</IsPackable>
     <GenerateReferenceAssemblySource>true</GenerateReferenceAssemblySource>
     <PackageId>Microsoft.NET.StringTools</PackageId>


### PR DESCRIPTION
### Summary

Enables the trim / Native AOT analyzers (`IsAotCompatible`) on the two lowest assemblies in the MSBuild dependency graph - `Microsoft.Build.Framework` and `Microsoft.NET.StringTools` - and resolves every IL warning the analyzers surface. This is a foundational step toward broader trim/AOT compatibility: the analyzers now run on every build of these projects, so new trim-unsafe patterns are caught at PR time rather than discovered downstream.

`IsAotCompatible` is gated to net8.0+ TFMs, so it only activates on the `net10.0` build. `net472` and `netstandard2.0` are unaffected (no `NETSDK1210`).

### How the 14 IL warnings were resolved

Preferred annotation-based fixes (no suppression):

- **`[DynamicallyAccessedMembers]`** on `Type` reflection - `LoadedType`, `ReflectableTaskPropertyInfo`.
- **`[RequiresUnreferencedCode]`** on assembly-loading APIs - `CoreClrAssemblyLoader`, `TaskFactoryUtilities`.
- **IL2075 in `CrashTelemetry`** - replaced a reflection probe for `InternalLoggerException.BuildEventArgs` with a small internal contract, `IBuildEventArgsTelemetryProvider`. `InternalLoggerException` implements it explicitly so the event type name is read with a plain type check instead of `Type.GetProperty` - trimming-safe and verifiable.
- **IL3002 in `FrameworkLocationHelper`** - replaced `typeof(object).Module.FullyQualifiedName` with the existing `NativeMethods.FrameworkCurrentPath` accessor (same value on every TFM, single-file/AOT safe, and a more honest argument for `FindDotNetFrameworkPath`'s `currentRuntimePath` parameter).

Only two cases use `[UnconditionalSuppressMessage]`, both structurally unavoidable:

1. `MSBuildLoadContext.Load` overrides a non-`RequiresUnreferencedCode` virtual, so the requirement can't be propagated.
2. `BuildEnvironmentHelper.CheckIfRunningTests` reflects the internal `TestInfo.s_runningTests` field; paired with `[DynamicDependency]` so the field is preserved under trimming rather than merely silenced.

### Polyfills

The trim attributes ship in the runtime starting with .NET 5. For `net472`/`netstandard2.0` they are provided by internal copies under `src/Framework/Polyfills/AotTrimmingPolyfills.cs` (gated `#if !NET`). PolySharp does not supply these because several dependencies embed their own `internal` copies that shadow the type, so a local definition is required.

### Testing

- `Microsoft.Build.Framework` (net10.0, net472, netstandard2.0): **0 warnings**.
- `Microsoft.NET.StringTools` (all TFMs): **0 warnings**.
- Downstream `Microsoft.Build` (net10.0): **0 warnings** - confirms the new `RequiresUnreferencedCode` attributes and the `IBuildEventArgsTelemetryProvider` implementation don't break callers.
- `CrashTelemetry_Tests` pass (the existing `BuildEventArgs` test now exercises the interface path).
- `ToolLocationHelper_Tests.ExerciseMiscToolLocationHelperMethods` passes on net472 and net10.0, confirming `GetPathToDotNetFramework` behavior is unchanged.

### Notes

- No public API changes - all annotated types are `internal`.
- Also vendors the `dotnet-aot-compat` skill under `.github/skills/` for future use.
