### PR TITLE
Enable AOT/trim analyzers for Utilities and Tasks

### DIFF
--- a/src/Build/BackEnd/Components/Communications/LogMessagePacket.cs
+++ b/src/Build/BackEnd/Components/Communications/LogMessagePacket.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
-using System.Reflection;
 using Microsoft.Build.Collections;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Framework.Profiler;
@@ -54,7 +53,7 @@ namespace Microsoft.Build.BackEnd
             return new LogMessagePacket(translator);
         }
 
-        protected override bool EventCanSerializeItself(LoggingEventType eventType, MethodInfo methodInfo) => eventType switch
+        protected override bool EventCanSerializeItself(LoggingEventType eventType) => eventType switch
         {
             // Switch to serialization methods that we provide and don't use the WriteToStream inherited from
             // LazyFormattedBuildEventArgs.
@@ -63,7 +62,7 @@ namespace Microsoft.Build.BackEnd
             LoggingEventType.ResponseFileUsedEvent => false,
 
             // Otherwise, defer to the base implementation.
-            _ => base.EventCanSerializeItself(eventType, methodInfo),
+            _ => base.EventCanSerializeItself(eventType),
         };
 
         protected override void WriteEventToStream(BuildEventArgs buildEvent, LoggingEventType eventType, ITranslator translator)

--- a/src/Framework/Polyfills/AotTrimmingPolyfills.cs
+++ b/src/Framework/Polyfills/AotTrimmingPolyfills.cs
@@ -73,6 +73,20 @@ namespace System.Diagnostics.CodeAnalysis
     }
 
     /// <summary>
+    /// Indicates that the specified method requires the ability to generate new code at runtime,
+    /// for example, through <see cref="System.Reflection"/>. This is incompatible with Native AOT.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Constructor | AttributeTargets.Method, Inherited = false)]
+    internal sealed class RequiresDynamicCodeAttribute : Attribute
+    {
+        public RequiresDynamicCodeAttribute(string message) => Message = message;
+
+        public string Message { get; }
+
+        public string? Url { get; set; }
+    }
+
+    /// <summary>
     /// Suppresses reporting of a specific rule violation, allowing multiple suppressions on a single code artifact.
     /// Unlike <see cref="SuppressMessageAttribute"/>, this attribute is preserved in metadata and applied by the trimmer.
     /// </summary>

--- a/src/Shared/AssemblyFolders/Serialization/AssemblyFolderCollection.cs
+++ b/src/Shared/AssemblyFolders/Serialization/AssemblyFolderCollection.cs
@@ -3,33 +3,84 @@
 
 using System.Collections.Generic;
 using System.IO;
-using System.Runtime.Serialization;
 using System.Xml;
-
 
 #nullable disable
 
 namespace Microsoft.Build.Shared.AssemblyFoldersFromConfig
 {
-    [DataContract(Name = "AssemblyFoldersConfig", Namespace = "")]
     internal class AssemblyFolderCollection
     {
-        [DataMember]
-        internal List<AssemblyFolderItem> AssemblyFolders { get; set; }
+        internal AssemblyFolderCollection(List<AssemblyFolderItem> assemblyFolders) => AssemblyFolders = assemblyFolders;
+
+        internal List<AssemblyFolderItem> AssemblyFolders { get; }
 
         /// <summary>
-        /// Deserialize the file into an AssemblyFolderCollection.
+        /// Reads the AssemblyFolders config file into an <see cref="AssemblyFolderCollection"/>.
         /// </summary>
-        /// <param name="filePath">Path to the AssemblyFolder.config file.</param>
-        /// <returns>New deserialized collection instance.</returns>
+        /// <param name="filePath">Path to the AssemblyFolders config file.</param>
+        /// <returns>A collection populated from the file.</returns>
+        /// <exception cref="XmlException">The file is not well-formed XML.</exception>
         internal static AssemblyFolderCollection Load(string filePath)
         {
-            using (FileStream fs = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read))
-            using (XmlDictionaryReader reader = XmlDictionaryReader.CreateTextReader(fs, new XmlDictionaryReaderQuotas()))
+            // The expected document shape is:
+            //
+            //   <AssemblyFoldersConfig>
+            //     <AssemblyFolders>
+            //       <AssemblyFolder>
+            //         <Name>...</Name>                          (optional)
+            //         <FrameworkVersion>v4.5</FrameworkVersion>
+            //         <Path>...</Path>
+            //         <Platform>x86</Platform>                  (optional)
+            //       </AssemblyFolder>
+            //     </AssemblyFolders>
+            //   </AssemblyFoldersConfig>
+            //
+            // The file is parsed with XmlDocument (not a reflection-based serializer), so this code is
+            // safe under trimming and Native AOT. Child element order is not significant and
+            // unrecognized elements are ignored.
+
+            // Harden against XML external entity (XXE) attacks: no DTD processing, no external resolution.
+            XmlReaderSettings settings = new()
             {
-                DataContractSerializer serializer = new DataContractSerializer(typeof(AssemblyFolderCollection));
-                return (AssemblyFolderCollection)serializer.ReadObject(reader, true);
+                DtdProcessing = DtdProcessing.Prohibit,
+                XmlResolver = null,
+            };
+
+            XmlDocument document = new();
+            using (FileStream stream = new(filePath, FileMode.Open, FileAccess.Read, FileShare.Read))
+            using (XmlReader reader = XmlReader.Create(stream, settings))
+            {
+                document.Load(reader);
             }
+
+            List<AssemblyFolderItem> assemblyFolders = [];
+            foreach (XmlNode folder in document.GetElementsByTagName("AssemblyFolder"))
+            {
+                AssemblyFolderItem item = new();
+                foreach (XmlNode child in folder.ChildNodes)
+                {
+                    switch (child.LocalName)
+                    {
+                        case "Name":
+                            item.Name = child.InnerText;
+                            break;
+                        case "FrameworkVersion":
+                            item.FrameworkVersion = child.InnerText;
+                            break;
+                        case "Path":
+                            item.Path = child.InnerText;
+                            break;
+                        case "Platform":
+                            item.Platform = child.InnerText;
+                            break;
+                    }
+                }
+
+                assemblyFolders.Add(item);
+            }
+
+            return new AssemblyFolderCollection(assemblyFolders);
         }
     }
 }

--- a/src/Shared/AssemblyFolders/Serialization/AssemblyFolderCollection.cs
+++ b/src/Shared/AssemblyFolders/Serialization/AssemblyFolderCollection.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Xml;
@@ -20,7 +21,9 @@ namespace Microsoft.Build.Shared.AssemblyFoldersFromConfig
         /// </summary>
         /// <param name="filePath">Path to the AssemblyFolders config file.</param>
         /// <returns>A collection populated from the file.</returns>
-        /// <exception cref="XmlException">The file is not well-formed XML.</exception>
+        /// <exception cref="XmlException">The file is not well-formed XML, has an unexpected root element, or an AssemblyFolder is missing a required element.</exception>
+        /// <exception cref="IOException">The file could not be read.</exception>
+        /// <exception cref="UnauthorizedAccessException">The caller does not have permission to read the file.</exception>
         internal static AssemblyFolderCollection Load(string filePath)
         {
             // The expected document shape is:

--- a/src/Shared/AssemblyFolders/Serialization/AssemblyFolderCollection.cs
+++ b/src/Shared/AssemblyFolders/Serialization/AssemblyFolderCollection.cs
@@ -54,6 +54,15 @@ namespace Microsoft.Build.Shared.AssemblyFoldersFromConfig
                 document.Load(reader);
             }
 
+            // Validate the root element. The previous DataContractSerializer (with verifyObjectName)
+            // rejected documents whose root was not <AssemblyFoldersConfig>; preserve that so a file
+            // with an unexpected root (or stray <AssemblyFolder> nodes under an unrelated root) is
+            // reported as malformed rather than silently changing assembly resolution.
+            if (document.DocumentElement?.LocalName != "AssemblyFoldersConfig")
+            {
+                throw new XmlException("The AssemblyFolders config file is missing the expected root element 'AssemblyFoldersConfig'.");
+            }
+
             List<AssemblyFolderItem> assemblyFolders = [];
             foreach (XmlNode folder in document.GetElementsByTagName("AssemblyFolder"))
             {
@@ -75,6 +84,15 @@ namespace Microsoft.Build.Shared.AssemblyFoldersFromConfig
                             item.Platform = child.InnerText;
                             break;
                     }
+                }
+
+                // FrameworkVersion and Path were [DataMember(IsRequired = true)] under the previous
+                // serializer; Name and Platform were optional. Downstream code dereferences both
+                // required values, so treat a folder missing either as a malformed config rather than
+                // letting it surface later as a NullReferenceException.
+                if (item.FrameworkVersion is null || item.Path is null)
+                {
+                    throw new XmlException("An 'AssemblyFolder' element is missing the required 'FrameworkVersion' or 'Path' element.");
                 }
 
                 assemblyFolders.Add(item);

--- a/src/Shared/AssemblyFolders/Serialization/AssemblyFolderItem.cs
+++ b/src/Shared/AssemblyFolders/Serialization/AssemblyFolderItem.cs
@@ -2,26 +2,20 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
-using System.Runtime.Serialization;
 
 #nullable disable
 
 namespace Microsoft.Build.Shared.AssemblyFoldersFromConfig
 {
-    [DataContract(Name = "AssemblyFolder", Namespace = "")]
     [DebuggerDisplay("{Name}: FrameworkVersion = {FrameworkVersion}, Platform = {Platform}, Path= {Path}")]
     internal class AssemblyFolderItem
     {
-        [DataMember(IsRequired = false, Order = 1)]
         internal string Name { get; set; }
 
-        [DataMember(IsRequired = true, Order = 2)]
         internal string FrameworkVersion { get; set; }
 
-        [DataMember(IsRequired = true, Order = 3)]
         internal string Path { get; set; }
 
-        [DataMember(IsRequired = false, Order = 4)]
         internal string Platform { get; set; }
     }
 }

--- a/src/Shared/Debugging/PrintLineDebugger.cs
+++ b/src/Shared/Debugging/PrintLineDebugger.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 #if DEBUG
 using System.IO;
 #endif
-using System.Reflection;
 using System.Runtime.CompilerServices;
 using Microsoft.Build.Framework;
 using CommonWriterType = System.Action<string, string, System.Collections.Generic.IEnumerable<string>>;
@@ -22,18 +21,6 @@ namespace Microsoft.Build.Shared.Debugging
     /// </summary>
     internal sealed class PrintLineDebugger : IDisposable
     {
-        private static readonly Lazy<PropertyInfo> CommonWriterProperty = new Lazy<PropertyInfo>(
-            () =>
-            {
-                var commonWriterType = typeof(ITask).Assembly.GetType("Microsoft.Build.Shared.Debugging.CommonWriter", true, false);
-
-                var propertyInfo = commonWriterType.GetProperty("Writer", BindingFlags.Public | BindingFlags.Static);
-
-                Assumed.NotNull(propertyInfo);
-
-                return propertyInfo;
-            });
-
         public static Lazy<PrintLineDebugger> Default =
             new Lazy<PrintLineDebugger>(() => Create(null, null, false));
 
@@ -69,7 +56,10 @@ namespace Microsoft.Build.Shared.Debugging
 
         public static CommonWriterType GetStaticWriter()
         {
-            return (CommonWriterType)CommonWriterProperty.Value.GetValue(null, null);
+            // CommonWriter is defined in Microsoft.Build.Framework and shared with this assembly via
+            // InternalsVisibleTo. Referencing it directly (rather than reflecting over it) keeps the
+            // single canonical writer instance while remaining trimming- and Native AOT-safe.
+            return CommonWriter.Writer;
         }
 
         // this setter is not thread safe because the assumption is that a writer is set once for the duration of the process (or multiple times from different tests which do not run in parallel).
@@ -81,7 +71,7 @@ namespace Microsoft.Build.Shared.Debugging
             Assumed.Null(currentWriter, "Cannot set a new writer over an old writer. Remove the old one first");
 
             // wrap with a lock so multi threaded logging does not break messages apart
-            CommonWriterProperty.Value.SetValue(null, (CommonWriterType)LockWrappedWriter);
+            CommonWriter.Writer = LockWrappedWriter;
 
             void LockWrappedWriter(string id, string callsite, IEnumerable<string> message)
             {
@@ -99,7 +89,7 @@ namespace Microsoft.Build.Shared.Debugging
 
             Assumed.NotNull(currentWriter, "Cannot unset an already null writer");
 
-            CommonWriterProperty.Value.SetValue(null, null);
+            CommonWriter.Writer = null;
         }
 
         public static PrintLineDebugger Create(

--- a/src/Shared/LogMessagePacketBase.cs
+++ b/src/Shared/LogMessagePacketBase.cs
@@ -3,9 +3,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.IO;
-using System.Reflection;
 using Microsoft.Build.BackEnd;
 using Microsoft.Build.Experimental.BuildCheck;
 using Microsoft.Build.Framework;
@@ -265,11 +263,6 @@ namespace Microsoft.Build.Shared
         /// </summary>
         private static readonly int s_defaultPacketVersion = (Environment.Version.Major * 10) + Environment.Version.Minor;
 
-        /// <summary>
-        /// Dictionary of methods used to write BuildEventArgs.
-        /// </summary>
-        private static readonly Dictionary<LoggingEventType, MethodInfo> s_writeMethodCache = new Dictionary<LoggingEventType, MethodInfo>();
-
         #region Data
 
         /// <summary>
@@ -311,11 +304,6 @@ namespace Microsoft.Build.Shared
         #endregion
 
         #region Delegates
-
-        /// <summary>
-        /// Delegate representing a method on the BuildEventArgs classes used to write to a stream.
-        /// </summary>
-        private delegate void ArgsWriterDelegate(BinaryWriter writer);
 
         /// <summary>
         /// Delegate representing a method on the BuildEventArgs classes used to read from a stream.
@@ -382,37 +370,25 @@ namespace Microsoft.Build.Shared
         /// <summary>
         /// Writes the logging packet to the translator.
         /// </summary>
-        [UnconditionalSuppressMessage("TrimAnalysis", "IL2075:UnrecognizedReflectionPattern",
-            Justification = "Every BuildEventArgs-derived type that flows through logging defines a non-public WriteToStream method; this reflective lookup is the established serialization contract and the method is preserved on the concrete event types.")]
         internal void WriteToStream(ITranslator translator)
         {
             Assumed.NotEqual(_eventType, LoggingEventType.CustomEvent, "_eventType should not be a custom event");
-
-            MethodInfo methodInfo = null;
-            lock (s_writeMethodCache)
-            {
-                if (!s_writeMethodCache.TryGetValue(_eventType, out methodInfo))
-                {
-                    Type eventDerivedType = _buildEvent.GetType();
-                    methodInfo = eventDerivedType.GetMethod("WriteToStream", BindingFlags.NonPublic | BindingFlags.Instance);
-                    s_writeMethodCache.Add(_eventType, methodInfo);
-                }
-            }
 
             int packetVersion = s_defaultPacketVersion;
 
             // Make sure the other side knows what sort of serialization is coming
             translator.Translate(ref packetVersion);
 
-            bool eventCanSerializeItself = EventCanSerializeItself(_eventType, methodInfo);
+            bool eventCanSerializeItself = EventCanSerializeItself(_eventType);
 
             translator.Translate(ref eventCanSerializeItself);
 
             if (eventCanSerializeItself)
             {
-                // 3.5 or later -- we have custom serialization methods, so let's use them.
-                ArgsWriterDelegate writerMethod = (ArgsWriterDelegate)CreateDelegateRobust(typeof(ArgsWriterDelegate), _buildEvent, methodInfo);
-                writerMethod(translator.Writer);
+                // 3.5 or later -- the event has a WriteToStream method, so let it serialize itself.
+                // This is a direct virtual call (mirroring ReadFromStream's CreateFromStream call) rather
+                // than a reflective lookup, so it is trimming- and Native AOT-safe.
+                _buildEvent.WriteToStream(translator.Writer);
 
                 TranslateAdditionalProperties(translator, _eventType, _buildEvent);
             }
@@ -459,8 +435,13 @@ namespace Microsoft.Build.Shared
         /// If false, defers to overridable implementations in <see cref="WriteEventToStream"/> and
         /// <see cref="ReadEventFromStream"/>.
         /// </summary>
-        protected virtual bool EventCanSerializeItself(LoggingEventType eventType, MethodInfo methodInfo)
-            => methodInfo != null;
+        /// <remarks>
+        /// Every <see cref="BuildEventArgs"/> defines <c>WriteToStream</c> / <c>CreateFromStream</c>, so the
+        /// default is to let the event serialize itself. Overrides return <see langword="false"/> for event
+        /// types whose inherited <c>WriteToStream</c> should not be used.
+        /// </remarks>
+        protected virtual bool EventCanSerializeItself(LoggingEventType eventType)
+            => true;
 
         /// <summary>
         /// Translates additional properties that are not handled by the default serialization.
@@ -470,37 +451,6 @@ namespace Microsoft.Build.Shared
         }
 
         #region Private Methods
-
-        /// <summary>
-        /// Wrapper for Delegate.CreateDelegate with retries.
-        /// </summary>
-        /// <comment>
-        /// TODO:  Investigate if it would be possible to use one of the overrides of CreateDelegate
-        /// that doesn't force the delegate to be closed over its first argument, so that we can
-        /// only create the delegate once per event type and cache it.
-        /// </comment>
-        private static Delegate CreateDelegateRobust(Type type, Object firstArgument, MethodInfo methodInfo)
-        {
-            Delegate delegateMethod = null;
-
-            for (int i = 0; delegateMethod == null && i < 5; i++)
-            {
-                try
-                {
-                    delegateMethod = methodInfo.CreateDelegate(type, firstArgument);
-                }
-                catch (FileLoadException) when (i < 5)
-                {
-                    // Sometimes, in 64-bit processes, the fusion load of Microsoft.Build.Framework.dll
-                    // spontaneously fails when trying to bind to the delegate.  However, it seems to
-                    // not repeat on additional tries -- so we'll try again a few times.  However, if
-                    // it keeps happening, it's probably a real problem, so we want to go ahead and
-                    // throw to let the user know what's up.
-                }
-            }
-
-            return delegateMethod;
-        }
 
         /// <summary>
         /// Takes in a id (LoggingEventType as an int) and creates the correct specific logging class

--- a/src/Shared/LogMessagePacketBase.cs
+++ b/src/Shared/LogMessagePacketBase.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Reflection;
 using Microsoft.Build.BackEnd;
@@ -381,6 +382,8 @@ namespace Microsoft.Build.Shared
         /// <summary>
         /// Writes the logging packet to the translator.
         /// </summary>
+        [UnconditionalSuppressMessage("TrimAnalysis", "IL2075:UnrecognizedReflectionPattern",
+            Justification = "Every BuildEventArgs-derived type that flows through logging defines a non-public WriteToStream method; this reflective lookup is the established serialization contract and the method is preserved on the concrete event types.")]
         internal void WriteToStream(ITranslator translator)
         {
             Assumed.NotEqual(_eventType, LoggingEventType.CustomEvent, "_eventType should not be a custom event");

--- a/src/Shared/TaskParameter.cs
+++ b/src/Shared/TaskParameter.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
 using System.Reflection;
@@ -390,6 +391,8 @@ namespace Microsoft.Build.BackEnd
         /// <summary>
         /// Serializes or deserializes an array of primitive type values wrapped by this <see cref="TaskParameter"/>.
         /// </summary>
+        [UnconditionalSuppressMessage("AotAnalysis", "IL3050:RequiresDynamicCode",
+            Justification = "The element type is always one of the primitive value types selected by the TypeCode switch below, so Array.CreateInstance does not need to generate code for an unknown type.")]
         private void TranslatePrimitiveTypeArray(ITranslator translator)
         {
             translator.TranslateEnum(ref _parameterTypeCode, (int)_parameterTypeCode);

--- a/src/Tasks.UnitTests/AssemblyDependency/AssemblyFolderCollection_Tests.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/AssemblyFolderCollection_Tests.cs
@@ -168,15 +168,62 @@ namespace Microsoft.Build.Tasks.UnitTests.AssemblyDependency
             LoadXml("<AssemblyFoldersConfig><AssemblyFolders></AssemblyFolders></AssemblyFoldersConfig>").AssemblyFolders.ShouldBeEmpty();
 
         [Fact]
-        public void SelfClosingAssemblyFolder_YieldsItemWithNullFields()
+        public void SelfClosingAssemblyFolder_ThrowsXmlException()
         {
+            // FrameworkVersion and Path are required; a folder missing them is a malformed config.
+            // Downstream code dereferences both, and the resolver expects malformed configs to surface
+            // as XmlException.
             string xml = "<AssemblyFoldersConfig><AssemblyFolders><AssemblyFolder /></AssemblyFolders></AssemblyFoldersConfig>";
 
-            AssemblyFolderItem folder = LoadXml(xml).AssemblyFolders.ShouldHaveSingleItem();
-            folder.Name.ShouldBeNull();
-            folder.FrameworkVersion.ShouldBeNull();
-            folder.Path.ShouldBeNull();
-            folder.Platform.ShouldBeNull();
+            Should.Throw<XmlException>(() => LoadXml(xml));
+        }
+
+        [Fact]
+        public void MissingFrameworkVersion_ThrowsXmlException()
+        {
+            string xml = @"
+<AssemblyFoldersConfig>
+  <AssemblyFolders>
+    <AssemblyFolder>
+      <Path>C:\folder</Path>
+    </AssemblyFolder>
+  </AssemblyFolders>
+</AssemblyFoldersConfig>";
+
+            Should.Throw<XmlException>(() => LoadXml(xml));
+        }
+
+        [Fact]
+        public void MissingPath_ThrowsXmlException()
+        {
+            string xml = @"
+<AssemblyFoldersConfig>
+  <AssemblyFolders>
+    <AssemblyFolder>
+      <FrameworkVersion>v4.5</FrameworkVersion>
+    </AssemblyFolder>
+  </AssemblyFolders>
+</AssemblyFoldersConfig>";
+
+            Should.Throw<XmlException>(() => LoadXml(xml));
+        }
+
+        [Fact]
+        public void WrongRootElement_ThrowsXmlException()
+        {
+            // A document with stray <AssemblyFolder> nodes under an unexpected root must be rejected,
+            // not silently parsed (which would change assembly resolution).
+            string xml = @"
+<SomethingElse>
+  <AssemblyFolders>
+    <AssemblyFolder>
+      <FrameworkVersion>v4.5</FrameworkVersion>
+      <Path>C:\folder</Path>
+    </AssemblyFolder>
+  </AssemblyFolders>
+</SomethingElse>";
+
+            Should.Throw<XmlException>(() => LoadXml(xml));
         }
 
         [Fact]

--- a/src/Tasks.UnitTests/AssemblyDependency/AssemblyFolderCollection_Tests.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/AssemblyFolderCollection_Tests.cs
@@ -1,0 +1,190 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.IO;
+using System.Xml;
+using Microsoft.Build.Shared.AssemblyFoldersFromConfig;
+using Shouldly;
+using Xunit;
+
+#nullable disable
+
+namespace Microsoft.Build.Tasks.UnitTests.AssemblyDependency
+{
+    /// <summary>
+    /// Direct tests for the streaming <see cref="AssemblyFolderCollection.Load"/> parser. These run on
+    /// every target framework (unlike the RAR-driven AssemblyFoldersFromConfig_Tests, which are net472
+    /// only), so they guard the parser - including under the trim/AOT analyzers on net10.0.
+    /// </summary>
+    public class AssemblyFolderCollection_Tests
+    {
+        private static AssemblyFolderCollection LoadXml(string xml)
+        {
+            string path = Path.GetTempFileName();
+            try
+            {
+                File.WriteAllText(path, xml);
+                return AssemblyFolderCollection.Load(path);
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        }
+
+        [Fact]
+        public void ParsesAllFields()
+        {
+            string xml = @"
+<AssemblyFoldersConfig>
+  <AssemblyFolders>
+    <AssemblyFolder>
+      <Name>Test Assemblies</Name>
+      <FrameworkVersion>v5.0</FrameworkVersion>
+      <Path>C:\some\path</Path>
+      <Platform>x64</Platform>
+    </AssemblyFolder>
+  </AssemblyFolders>
+</AssemblyFoldersConfig>";
+
+            AssemblyFolderItem folder = LoadXml(xml).AssemblyFolders.ShouldHaveSingleItem();
+            folder.Name.ShouldBe("Test Assemblies");
+            folder.FrameworkVersion.ShouldBe("v5.0");
+            folder.Path.ShouldBe(@"C:\some\path");
+            folder.Platform.ShouldBe("x64");
+        }
+
+        [Fact]
+        public void OptionalFieldsMayBeOmitted()
+        {
+            string xml = @"
+<AssemblyFoldersConfig>
+  <AssemblyFolders>
+    <AssemblyFolder>
+      <FrameworkVersion>v4.0</FrameworkVersion>
+      <Path>C:\folder</Path>
+    </AssemblyFolder>
+  </AssemblyFolders>
+</AssemblyFoldersConfig>";
+
+            AssemblyFolderItem folder = LoadXml(xml).AssemblyFolders.ShouldHaveSingleItem();
+            folder.Name.ShouldBeNull();
+            folder.FrameworkVersion.ShouldBe("v4.0");
+            folder.Path.ShouldBe(@"C:\folder");
+            folder.Platform.ShouldBeNull();
+        }
+
+        [Fact]
+        public void PreservesDocumentOrderAndAllFolders()
+        {
+            string xml = @"
+<AssemblyFoldersConfig>
+  <AssemblyFolders>
+    <AssemblyFolder><FrameworkVersion>v4.0</FrameworkVersion><Path>C:\one</Path></AssemblyFolder>
+    <AssemblyFolder><FrameworkVersion>v4.5</FrameworkVersion><Path>C:\two</Path><Platform>x86</Platform></AssemblyFolder>
+    <AssemblyFolder><FrameworkVersion>v5.0</FrameworkVersion><Path>C:\three</Path><Platform>x64</Platform></AssemblyFolder>
+  </AssemblyFolders>
+</AssemblyFoldersConfig>";
+
+            var folders = LoadXml(xml).AssemblyFolders;
+            folders.Count.ShouldBe(3);
+            folders[0].Path.ShouldBe(@"C:\one");
+            folders[0].Platform.ShouldBeNull();
+            folders[1].Path.ShouldBe(@"C:\two");
+            folders[1].Platform.ShouldBe("x86");
+            folders[2].Path.ShouldBe(@"C:\three");
+            folders[2].Platform.ShouldBe("x64");
+        }
+
+        [Fact]
+        public void ChildElementOrderIsNotSignificant()
+        {
+            string xml = @"
+<AssemblyFoldersConfig>
+  <AssemblyFolders>
+    <AssemblyFolder>
+      <Platform>x86</Platform>
+      <Path>C:\folder</Path>
+      <FrameworkVersion>v4.5</FrameworkVersion>
+      <Name>Reordered</Name>
+    </AssemblyFolder>
+  </AssemblyFolders>
+</AssemblyFoldersConfig>";
+
+            AssemblyFolderItem folder = LoadXml(xml).AssemblyFolders.ShouldHaveSingleItem();
+            folder.Name.ShouldBe("Reordered");
+            folder.FrameworkVersion.ShouldBe("v4.5");
+            folder.Path.ShouldBe(@"C:\folder");
+            folder.Platform.ShouldBe("x86");
+        }
+
+        [Fact]
+        public void IgnoresUnrecognizedElements()
+        {
+            // <Unknown> carries nested content to confirm the whole subtree is skipped.
+            string xml = @"
+<AssemblyFoldersConfig>
+  <SomeHeader>ignored</SomeHeader>
+  <AssemblyFolders>
+    <AssemblyFolder>
+      <FrameworkVersion>v4.5</FrameworkVersion>
+      <Unknown>whatever<Nested attr=""x"" /></Unknown>
+      <Path>C:\folder</Path>
+    </AssemblyFolder>
+  </AssemblyFolders>
+</AssemblyFoldersConfig>";
+
+            AssemblyFolderItem folder = LoadXml(xml).AssemblyFolders.ShouldHaveSingleItem();
+            folder.FrameworkVersion.ShouldBe("v4.5");
+            folder.Path.ShouldBe(@"C:\folder");
+        }
+
+        [Fact]
+        public void ToleratesXmlDeclarationAndComments()
+        {
+            string xml = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<!-- leading comment -->
+<AssemblyFoldersConfig>
+  <!-- inner comment -->
+  <AssemblyFolders>
+    <AssemblyFolder>
+      <FrameworkVersion>v4.5</FrameworkVersion>
+      <Path>C:\folder</Path>
+    </AssemblyFolder>
+  </AssemblyFolders>
+</AssemblyFoldersConfig>";
+
+            AssemblyFolderItem folder = LoadXml(xml).AssemblyFolders.ShouldHaveSingleItem();
+            folder.FrameworkVersion.ShouldBe("v4.5");
+            folder.Path.ShouldBe(@"C:\folder");
+        }
+
+        [Fact]
+        public void EmptyConfig_ReturnsEmptyCollection() =>
+            LoadXml("<AssemblyFoldersConfig />").AssemblyFolders.ShouldBeEmpty();
+
+        [Fact]
+        public void EmptyAssemblyFoldersElement_ReturnsEmptyCollection() =>
+            LoadXml("<AssemblyFoldersConfig><AssemblyFolders></AssemblyFolders></AssemblyFoldersConfig>").AssemblyFolders.ShouldBeEmpty();
+
+        [Fact]
+        public void SelfClosingAssemblyFolder_YieldsItemWithNullFields()
+        {
+            string xml = "<AssemblyFoldersConfig><AssemblyFolders><AssemblyFolder /></AssemblyFolders></AssemblyFoldersConfig>";
+
+            AssemblyFolderItem folder = LoadXml(xml).AssemblyFolders.ShouldHaveSingleItem();
+            folder.Name.ShouldBeNull();
+            folder.FrameworkVersion.ShouldBeNull();
+            folder.Path.ShouldBeNull();
+            folder.Platform.ShouldBeNull();
+        }
+
+        [Fact]
+        public void MalformedXml_ThrowsXmlException()
+        {
+            // Mirrors the input used by AssemblyFoldersFromConfig_Tests.AssemblyFoldersFromConfigFileMalformed.
+            // The resolver relies on this being an XmlException so it can report the file as malformed.
+            Should.Throw<XmlException>(() => LoadXml("<<<>><>!<AssemblyFoldersConfig></AssemblyFoldersConfig>"));
+        }
+    }
+}

--- a/src/Tasks/AssemblyDependency/AssemblyFoldersFromConfig/AssemblyFoldersFromConfigResolver.cs
+++ b/src/Tasks/AssemblyDependency/AssemblyFoldersFromConfig/AssemblyFoldersFromConfigResolver.cs
@@ -138,8 +138,12 @@ namespace Microsoft.Build.Tasks.AssemblyFoldersFromConfig
                                 _buildEngine?.RegisterTaskObject(key, _assemblyFoldersCache, RegisteredTaskObjectLifetime.Build, true /* dispose early ok*/);
                             }
                         }
-                        catch (XmlException e)
+                        catch (Exception e) when (e is XmlException || ExceptionHandling.IsIoRelatedException(e))
                         {
+                            // The config file is malformed (XmlException) or could not be read
+                            // (IO error, e.g. the file was locked or a network share dropped after the
+                            // existence check). Either way, report it rather than letting it surface as
+                            // an unhandled exception that fails the whole build.
                             _taskLogger.LogError(ResourceUtilities.GetResourceString("ResolveAssemblyReference.AssemblyFoldersConfigFileMalformed"), _assemblyFolderConfigFile, e.Message);
                             return;
                         }

--- a/src/Tasks/AssemblyDependency/AssemblyFoldersFromConfig/AssemblyFoldersFromConfigResolver.cs
+++ b/src/Tasks/AssemblyDependency/AssemblyFoldersFromConfig/AssemblyFoldersFromConfigResolver.cs
@@ -3,8 +3,8 @@
 
 using System;
 using System.Collections.Generic;
-using System.Runtime.Serialization;
 using System.Text.RegularExpressions;
+using System.Xml;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
 using Microsoft.Build.Shared.FileSystem;
@@ -138,7 +138,7 @@ namespace Microsoft.Build.Tasks.AssemblyFoldersFromConfig
                                 _buildEngine?.RegisterTaskObject(key, _assemblyFoldersCache, RegisteredTaskObjectLifetime.Build, true /* dispose early ok*/);
                             }
                         }
-                        catch (SerializationException e)
+                        catch (XmlException e)
                         {
                             _taskLogger.LogError(ResourceUtilities.GetResourceString("ResolveAssemblyReference.AssemblyFoldersConfigFileMalformed"), _assemblyFolderConfigFile, e.Message);
                             return;

--- a/src/Tasks/BootstrapperUtil/BootstrapperBuilder.cs
+++ b/src/Tasks/BootstrapperUtil/BootstrapperBuilder.cs
@@ -130,6 +130,8 @@ namespace Microsoft.Build.Tasks.Deployment.Bootstrapper
         /// </summary>
         /// <param name="settings">The properties used to build this bootstrapper.</param>
         /// <returns>The results of the bootstrapper generation</returns>
+        [UnconditionalSuppressMessage("AotAnalysis", "IL3050:RequiresDynamicCode",
+            Justification = "Building a bootstrapper transforms its configuration with XslCompiledTransform, which generates IL at runtime; the GenerateBootstrapper task is inherently incompatible with Native AOT.")]
         public BuildResults Build(BuildSettings settings)
         {
             _results = new BuildResults();
@@ -1749,6 +1751,7 @@ namespace Microsoft.Build.Tasks.Deployment.Bootstrapper
             return null;
         }
 
+        [RequiresDynamicCode("Transforms bootstrapper resource configuration with XslCompiledTransform, which generates IL at runtime and is not supported with Native AOT.")]
         private bool BuildResources(BuildSettings settings, ResourceUpdater resourceUpdater)
         {
             if (_cultures.Count == 0)
@@ -1948,6 +1951,7 @@ namespace Microsoft.Build.Tasks.Deployment.Bootstrapper
             node.Attributes.Append(attrib);
         }
 
+        [RequiresDynamicCode("XslCompiledTransform generates IL at runtime, which is not supported with Native AOT.")]
         [SuppressMessage("Microsoft.Security.Xml", "CA3073: ReviewTrustedXsltUse.", Justification = "Input style sheet comes from our own assemblies. Hence it is a trusted source.")]
         [SuppressMessage("Microsoft.Security.Xml", "CA3059: UseXmlReaderForXPathDocument.", Justification = "Input style sheet comes from our own assemblies. Hence it is a trusted source.")]
         [SuppressMessage("Microsoft.Security.Xml", "CA3052: UseXmlResolver.", Justification = "Input style sheet comes from our own assemblies. Hence it is a trusted source.")]

--- a/src/Tasks/GenerateManifestBase.cs
+++ b/src/Tasks/GenerateManifestBase.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
@@ -273,6 +274,10 @@ namespace Microsoft.Build.Tasks
             return new AssemblyIdentity(name, version, publicKeyToken, culture, _processorArchitecture);
         }
 
+        [UnconditionalSuppressMessage("TrimAnalysis", "IL2026:RequiresUnreferencedCode",
+            Justification = "ClickOnce manifest generation reads and writes manifests with XmlSerializer; this task is inherently incompatible with trimming.")]
+        [UnconditionalSuppressMessage("AotAnalysis", "IL3050:RequiresDynamicCode",
+            Justification = "ClickOnce manifest generation uses XmlSerializer and XslCompiledTransform; this task is inherently incompatible with Native AOT.")]
         public override bool Execute()
         {
             if (!NativeMethodsShared.IsWindows)
@@ -306,6 +311,8 @@ namespace Microsoft.Build.Tasks
             return success;
         }
 
+        [RequiresUnreferencedCode("Builds and writes a ClickOnce manifest with XmlSerializer; members may be trimmed.")]
+        [RequiresDynamicCode("Builds and writes a ClickOnce manifest with XmlSerializer and XslCompiledTransform; both require runtime code generation not supported with Native AOT.")]
         private bool BuildManifest()
         {
             if (!OnManifestLoaded(_manifest))
@@ -423,6 +430,8 @@ namespace Microsoft.Build.Tasks
             return GetDefaultFileName();
         }
 
+        [RequiresUnreferencedCode("Reads the input ClickOnce manifest, which deserializes manifest types with XmlSerializer; members may be trimmed.")]
+        [RequiresDynamicCode("Reads the input ClickOnce manifest, which uses XmlSerializer and XslCompiledTransform; both require runtime code generation not supported with Native AOT.")]
         private bool InitializeManifest(Type manifestType)
         {
             _startTime = Environment.TickCount;
@@ -604,6 +613,8 @@ namespace Microsoft.Build.Tasks
             return true;
         }
 
+        [RequiresUnreferencedCode("Writes the output ClickOnce manifest, which serializes manifest types with XmlSerializer; members may be trimmed.")]
+        [RequiresDynamicCode("Writes the output ClickOnce manifest, which uses XmlSerializer and XslCompiledTransform; both require runtime code generation not supported with Native AOT.")]
         private bool WriteManifest()
         {
             if (OutputManifest == null)

--- a/src/Tasks/GenerateResource.cs
+++ b/src/Tasks/GenerateResource.cs
@@ -257,7 +257,9 @@ namespace Microsoft.Build.Tasks
         {
             get
             {
-                return (ITaskItem[])_filesWritten.ToArray(typeof(ITaskItem));
+                ITaskItem[] filesWritten = new ITaskItem[_filesWritten.Count];
+                _filesWritten.CopyTo(filesWritten);
+                return filesWritten;
             }
         }
 

--- a/src/Tasks/ManifestUtil/DeployManifest.cs
+++ b/src/Tasks/ManifestUtil/DeployManifest.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
 using System.Runtime.InteropServices;
@@ -547,6 +548,10 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
             set => _updateUnit = value.ToString();
         }
 
+        [UnconditionalSuppressMessage("TrimAnalysis", "IL2026:RequiresUnreferencedCode",
+            Justification = "Validation reads the entry-point ClickOnce manifest with XmlSerializer; the manifest model is inherently incompatible with trimming.")]
+        [UnconditionalSuppressMessage("AotAnalysis", "IL3050:RequiresDynamicCode",
+            Justification = "Validation reads the entry-point ClickOnce manifest with XmlSerializer and XslCompiledTransform; the manifest model is inherently incompatible with Native AOT.")]
         public override void Validate()
         {
             base.Validate();
@@ -564,6 +569,8 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
             }
         }
 
+        [RequiresUnreferencedCode("Reads the entry-point ClickOnce manifest with XmlSerializer; members may be trimmed.")]
+        [RequiresDynamicCode("Reads the entry-point ClickOnce manifest with XmlSerializer and XslCompiledTransform; both require runtime code generation not supported with Native AOT.")]
         private void ValidateEntryPoint()
         {
             if (_entryPoint != null)

--- a/src/Tasks/ManifestUtil/ManifestReader.cs
+++ b/src/Tasks/ManifestUtil/ManifestReader.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
 using System.Runtime.InteropServices;
@@ -86,6 +87,8 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
             }
         }
 
+        [RequiresUnreferencedCode("Reads a ClickOnce manifest, which deserializes manifest types with XmlSerializer; members may be trimmed.")]
+        [RequiresDynamicCode("Reads a ClickOnce manifest, which uses XmlSerializer and XslCompiledTransform; both require runtime code generation not supported with Native AOT.")]
         private static Manifest ReadEmbeddedManifest(string path)
         {
             Stream m = EmbeddedManifestReader.Read(path);
@@ -106,6 +109,8 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
         /// <param name="path">The name of the input file.</param>
         /// <param name="preserveStream">Specifies whether to preserve the input stream in the InputStream property of the resulting manifest object. Used by ManifestWriter to reconstitute input which is not represented in the object representation. This option is not honored if the specified input file is an embedded manfiest in a PE.</param>
         /// <returns>A base object representation of the manifest. Can be cast to AssemblyManifest, ApplicationManifest, or DeployManifest to access more specific functionality.</returns>
+        [RequiresUnreferencedCode("Reads a ClickOnce manifest, which deserializes manifest types with XmlSerializer; members may be trimmed.")]
+        [RequiresDynamicCode("Reads a ClickOnce manifest, which uses XmlSerializer and XslCompiledTransform; both require runtime code generation not supported with Native AOT.")]
         public static Manifest ReadManifest(string path, bool preserveStream)
         {
             if (path == null)
@@ -132,6 +137,8 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
         /// <param name="path">The name of the input file.</param>
         /// <param name="preserveStream">Specifies whether to preserve the input stream in the InputStream property of the resulting manifest object. Used by ManifestWriter to reconstitute input which is not represented in the object representation. This option is not honored if the specified input file is an embedded manfiest in a PE.</param>
         /// <returns>A base object representation of the manifest. Can be cast to AssemblyManifest, ApplicationManifest, or DeployManifest to access more specific functionality.</returns>
+        [RequiresUnreferencedCode("Reads a ClickOnce manifest, which deserializes manifest types with XmlSerializer; members may be trimmed.")]
+        [RequiresDynamicCode("Reads a ClickOnce manifest, which uses XmlSerializer and XslCompiledTransform; both require runtime code generation not supported with Native AOT.")]
         public static Manifest ReadManifest(string manifestType, string path, bool preserveStream)
         {
             Manifest m;
@@ -160,6 +167,8 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
         /// <param name="input">Specifies an input stream.</param>
         /// <param name="preserveStream">Specifies whether to preserve the input stream in the InputStream property of the resulting manifest object. Used by ManifestWriter to reconstitute input which is not represented in the object representation.</param>
         /// <returns>A base object representation of the manifest. Can be cast to AssemblyManifest, ApplicationManifest, or DeployManifest to access more specific functionality.</returns>
+        [RequiresUnreferencedCode("Reads a ClickOnce manifest, which deserializes manifest types with XmlSerializer; members may be trimmed.")]
+        [RequiresDynamicCode("Reads a ClickOnce manifest, which uses XmlSerializer and XslCompiledTransform; both require runtime code generation not supported with Native AOT.")]
         public static Manifest ReadManifest(Stream input, bool preserveStream)
         {
             return ReadManifest(null, input, preserveStream);
@@ -172,6 +181,8 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
         /// <param name="input">Specifies an input stream.</param>
         /// <param name="preserveStream">Specifies whether to preserve the input stream in the InputStream property of the resulting manifest object. Used by ManifestWriter to reconstitute input which is not represented in the object representation.</param>
         /// <returns>A base object representation of the manifest. Can be cast to AssemblyManifest, ApplicationManifest, or DeployManifest to access more specific functionality.</returns>
+        [RequiresUnreferencedCode("Reads a ClickOnce manifest, which deserializes manifest types with XmlSerializer; members may be trimmed.")]
+        [RequiresDynamicCode("Reads a ClickOnce manifest, which uses XmlSerializer and XslCompiledTransform; both require runtime code generation not supported with Native AOT.")]
         public static Manifest ReadManifest(string manifestType, Stream input, bool preserveStream)
         {
             int t1 = Environment.TickCount;
@@ -221,6 +232,8 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
             return m;
         }
 
+        [RequiresUnreferencedCode("Deserializes the manifest with XmlSerializer, which reflects over the manifest types; members may be trimmed.")]
+        [RequiresDynamicCode("XmlSerializer generates serialization code at runtime, which is not supported with Native AOT.")]
         private static Manifest Deserialize(Stream s)
         {
             s.Position = 0;

--- a/src/Tasks/ManifestUtil/ManifestWriter.cs
+++ b/src/Tasks/ManifestUtil/ManifestWriter.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Xml.Serialization;
@@ -18,6 +19,8 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
     [ComVisible(false)]
     public static class ManifestWriter
     {
+        [RequiresUnreferencedCode("Serializes the manifest with XmlSerializer, which reflects over the manifest types; members may be trimmed.")]
+        [RequiresDynamicCode("XmlSerializer generates serialization code at runtime, which is not supported with Native AOT.")]
         private static Stream Serialize(Manifest manifest)
         {
             manifest.OnBeforeSave();
@@ -40,6 +43,8 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
         /// The name of the output file is inferred from the SourcePath property of the manifest.
         /// </summary>
         /// <param name="manifest">The object representation of the manifest.</param>
+        [RequiresUnreferencedCode("Writes a ClickOnce manifest, which serializes manifest types with XmlSerializer; members may be trimmed.")]
+        [RequiresDynamicCode("Writes a ClickOnce manifest, which uses XmlSerializer and XslCompiledTransform; both require runtime code generation not supported with Native AOT.")]
         public static void WriteManifest(Manifest manifest)
         {
             string path = manifest.SourcePath ?? "manifest.xml";
@@ -51,6 +56,8 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
         /// </summary>
         /// <param name="manifest">The object representation of the manifest.</param>
         /// <param name="path">The name of the output file.</param>
+        [RequiresUnreferencedCode("Writes a ClickOnce manifest, which serializes manifest types with XmlSerializer; members may be trimmed.")]
+        [RequiresDynamicCode("Writes a ClickOnce manifest, which uses XmlSerializer and XslCompiledTransform; both require runtime code generation not supported with Native AOT.")]
         public static void WriteManifest(Manifest manifest, string path)
         {
             using (Stream s = File.Open(path, FileMode.Create, FileAccess.Write, FileShare.Write))
@@ -65,6 +72,8 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
         /// <param name="manifest">The object representation of the manifest.</param>
         /// <param name="path">The name of the output file.</param>
         /// <param name="targetframeWorkVersion">The target framework version.</param>
+        [RequiresUnreferencedCode("Writes a ClickOnce manifest, which serializes manifest types with XmlSerializer; members may be trimmed.")]
+        [RequiresDynamicCode("Writes a ClickOnce manifest, which uses XmlSerializer and XslCompiledTransform; both require runtime code generation not supported with Native AOT.")]
         public static void WriteManifest(Manifest manifest, string path, string targetframeWorkVersion)
         {
             using (Stream s = File.Open(path, FileMode.Create, FileAccess.Write, FileShare.Write))
@@ -78,6 +87,8 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
         /// </summary>
         /// <param name="manifest">The object representation of the manifest.</param>
         /// <param name="output">Specifies an output stream.</param>
+        [RequiresUnreferencedCode("Writes a ClickOnce manifest, which serializes manifest types with XmlSerializer; members may be trimmed.")]
+        [RequiresDynamicCode("Writes a ClickOnce manifest, which uses XmlSerializer and XslCompiledTransform; both require runtime code generation not supported with Native AOT.")]
         public static void WriteManifest(Manifest manifest, Stream output)
         {
             WriteManifest(manifest, output, null);
@@ -89,6 +100,8 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
         /// <param name="manifest"></param>
         /// <param name="output"></param>
         /// <param name="targetframeWorkVersion">it will always use sha256 as signature algorithm if TFV is null</param>
+        [RequiresUnreferencedCode("Writes a ClickOnce manifest, which serializes manifest types with XmlSerializer; members may be trimmed.")]
+        [RequiresDynamicCode("Writes a ClickOnce manifest, which uses XmlSerializer and XslCompiledTransform; both require runtime code generation not supported with Native AOT.")]
         private static void WriteManifest(Manifest manifest, Stream output, string targetframeWorkVersion)
         {
             int t1 = Environment.TickCount;

--- a/src/Tasks/ManifestUtil/RSAPKCS1SHA256SignatureDescription.cs
+++ b/src/Tasks/ManifestUtil/RSAPKCS1SHA256SignatureDescription.cs
@@ -23,6 +23,7 @@ namespace System.Deployment.Internal.CodeSigning
             DeformatterAlgorithm = typeof(RSAPKCS1SignatureDeformatter).FullName;
         }
 
+        [RequiresUnreferencedCode("CreateDeformatter resolves the deformatter algorithm by name via reflection; matches the base SignatureDescription.CreateDeformatter requirement.")]
         public override AsymmetricSignatureDeformatter CreateDeformatter(AsymmetricAlgorithm key)
         {
             if (key == null)
@@ -35,6 +36,7 @@ namespace System.Deployment.Internal.CodeSigning
             return deformatter;
         }
 
+        [RequiresUnreferencedCode("CreateFormatter resolves the formatter algorithm by name via reflection; matches the base SignatureDescription.CreateFormatter requirement.")]
         public override AsymmetricSignatureFormatter CreateFormatter(AsymmetricAlgorithm key)
         {
             if (key == null)

--- a/src/Tasks/ManifestUtil/SecurityUtil.cs
+++ b/src/Tasks/ManifestUtil/SecurityUtil.cs
@@ -11,9 +11,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Deployment.Internal.CodeSigning;
 using System.Diagnostics;
-#if !RUNTIME_TYPE_NETCORE
 using System.Diagnostics.CodeAnalysis;
-#endif
 using System.Globalization;
 using System.IO;
 #if !RUNTIME_TYPE_NETCORE
@@ -47,6 +45,9 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
     [ComVisible(false)]
     public static class SecurityUtilities
     {
+        private const string SignFileRequiresUnreferencedCodeMessage = "Signing a ClickOnce manifest reads and writes it with XmlSerializer and resolves SignedXml algorithms by name; members may be trimmed.";
+        private const string SignFileRequiresDynamicCodeMessage = "Signing a ClickOnce manifest uses XmlSerializer, XslCompiledTransform, and SignedXml, all of which require runtime code generation not supported with Native AOT.";
+
 #if RUNTIME_TYPE_NETCORE
         // Partial trust and permission sets are not supported by .NET Core.
 #else
@@ -500,6 +501,8 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
         /// <param name="timestampUrl">URL that specifies an address of a time stamping server.</param>
         /// <param name="path">Path of the file to sign with the certificate.</param>
         [SupportedOSPlatform("windows")]
+        [RequiresUnreferencedCode(SignFileRequiresUnreferencedCodeMessage)]
+        [RequiresDynamicCode(SignFileRequiresDynamicCodeMessage)]
         public static void SignFile(string certThumbprint, Uri timestampUrl, string path)
         {
             SignFile(certThumbprint, timestampUrl, path, targetFrameworkVersion: null, targetFrameworkIdentifier: null);
@@ -513,6 +516,8 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
         /// <param name="path">Path of the file to sign with the certificate.</param>
         /// <param name="targetFrameworkVersion">Version of the .NET Framework for the target.</param>
         [SupportedOSPlatform("windows")]
+        [RequiresUnreferencedCode(SignFileRequiresUnreferencedCodeMessage)]
+        [RequiresDynamicCode(SignFileRequiresDynamicCodeMessage)]
         public static void SignFile(string certThumbprint,
                                     Uri timestampUrl,
                                     string path,
@@ -530,6 +535,8 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
         /// <param name="targetFrameworkVersion">Version of the .NET Framework for the target.</param>
         /// <param name="targetFrameworkIdentifier">.NET Framework identifier for the target.</param>
         [SupportedOSPlatform("windows")]
+        [RequiresUnreferencedCode(SignFileRequiresUnreferencedCodeMessage)]
+        [RequiresDynamicCode(SignFileRequiresDynamicCodeMessage)]
         public static void SignFile(string certThumbprint,
                                     Uri timestampUrl,
                                     string path,
@@ -549,6 +556,8 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
         /// <param name="targetFrameworkIdentifier">.NET Framework identifier for the target.</param>
         /// <param name="disallowMansignTimestampFallback">Disallow fallback to legacy timestamping when RFC3161 timestamping fails during manifest signing</param>
         [SupportedOSPlatform("windows")]
+        [RequiresUnreferencedCode(SignFileRequiresUnreferencedCodeMessage)]
+        [RequiresDynamicCode(SignFileRequiresDynamicCodeMessage)]
         public static void SignFile(string certThumbprint,
                                     Uri timestampUrl,
                                     string path,
@@ -608,6 +617,8 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
         /// <param name="path">Path of the file to sign with the certificate.</param>
         /// <remarks>This function is only for signing a manifest, not a PE file.</remarks>
         [SupportedOSPlatform("windows")]
+        [RequiresUnreferencedCode(SignFileRequiresUnreferencedCodeMessage)]
+        [RequiresDynamicCode(SignFileRequiresDynamicCodeMessage)]
         public static void SignFile(string certPath, SecureString certPassword, Uri timestampUrl, string path)
         {
             using X509Certificate2 cert = new X509Certificate2(certPath, certPassword, X509KeyStorageFlags.PersistKeySet);
@@ -633,6 +644,8 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
         /// <remarks>This function can only sign a PE file if the X509Certificate2 parameter represents a certificate in the
         /// current user's personal certificate store.</remarks>
         [SupportedOSPlatform("windows")]
+        [RequiresUnreferencedCode(SignFileRequiresUnreferencedCodeMessage)]
+        [RequiresDynamicCode(SignFileRequiresDynamicCodeMessage)]
         public static void SignFile(X509Certificate2 cert, Uri timestampUrl, string path)
         {
             // setup resources
@@ -641,6 +654,8 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
         }
 
         [SupportedOSPlatform("windows")]
+        [RequiresUnreferencedCode(SignFileRequiresUnreferencedCodeMessage)]
+        [RequiresDynamicCode(SignFileRequiresDynamicCodeMessage)]
         private static void SignFileInternal(X509Certificate2 cert,
                                             Uri timestampUrl,
                                             string path,

--- a/src/Tasks/ManifestUtil/TrustInfo.cs
+++ b/src/Tasks/ManifestUtil/TrustInfo.cs
@@ -530,6 +530,8 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
             }
         }
 
+        [UnconditionalSuppressMessage("AotAnalysis", "IL3050:RequiresDynamicCode",
+            Justification = "ToString is a debugging convenience that serializes the trust info through XslCompiledTransform; the ClickOnce trust-info path is inherently incompatible with Native AOT.")]
         public override string ToString()
         {
             var m = new MemoryStream();
@@ -544,6 +546,7 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
         /// Writes the application trust to an XML file.
         /// </summary>
         /// <param name="path">The name of the output file.</param>
+        [RequiresDynamicCode("Writes trust info through XslCompiledTransform, which generates IL at runtime and is not supported with Native AOT.")]
         public void Write(string path)
         {
             using (Stream s = File.Open(path, FileMode.Create, FileAccess.Write, FileShare.None))
@@ -557,6 +560,7 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
         /// Writes the application trust to an XML file.
         /// </summary>
         /// <param name="output"></param>
+        [RequiresDynamicCode("Writes trust info through XslCompiledTransform, which generates IL at runtime and is not supported with Native AOT.")]
         public void Write(Stream output)
         {
             var outputDocument = new XmlDocument();

--- a/src/Tasks/ManifestUtil/XmlUtil.cs
+++ b/src/Tasks/ManifestUtil/XmlUtil.cs
@@ -72,6 +72,7 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
 
         [SuppressMessage("Microsoft.Security.Xml", "CA3073: ReviewTrustedXsltUse.", Justification = "Input style sheet comes from our own assemblies. Hence it is a trusted source.")]
         [SuppressMessage("Microsoft.Security.Xml", "CA3053: UseSecureXmlResolver.", Justification = "Input style sheet comes from our own assemblies. Hence it is a trusted source.")]
+        [RequiresDynamicCode("XslCompiledTransform generates IL at runtime, which is not supported with Native AOT.")]
         [SuppressMessage("Microsoft.Security.Xml", "CA3059: UseXmlReaderForXPathDocument.", Justification = "Input style sheet comes from our own assemblies. Hence it is a trusted source.")]
         public static Stream XslTransform(string resource, Stream input, params DictionaryEntry[] entries)
         {

--- a/src/Tasks/ManifestUtil/mansign2.cs
+++ b/src/Tasks/ManifestUtil/mansign2.cs
@@ -241,22 +241,33 @@ namespace System.Deployment.Internal.CodeSigning
         private const string Sha256SignatureMethodUri = @"http://www.w3.org/2000/09/xmldsig#rsa-sha256";
         private const string Sha256DigestMethod = @"http://www.w3.org/2000/09/xmldsig#sha256";
 
+        internal const string SignedXmlRequiresUnreferencedCodeMessage = "SignedXml resolves transform and digest algorithm implementations by name; they may be trimmed.";
+        internal const string SignedXmlRequiresDynamicCodeMessage = "SignedXml uses XmlDsigXsltTransform, which relies on XslCompiledTransform and is not supported with Native AOT.";
+
+        [RequiresUnreferencedCode(SignedXmlRequiresUnreferencedCodeMessage)]
+        [RequiresDynamicCode(SignedXmlRequiresDynamicCodeMessage)]
         internal ManifestSignedXml2()
             : base()
         {
             init();
         }
+        [RequiresUnreferencedCode(SignedXmlRequiresUnreferencedCodeMessage)]
+        [RequiresDynamicCode(SignedXmlRequiresDynamicCodeMessage)]
         internal ManifestSignedXml2(XmlElement elem)
             : base(elem)
         {
             init();
         }
+        [RequiresUnreferencedCode(SignedXmlRequiresUnreferencedCodeMessage)]
+        [RequiresDynamicCode(SignedXmlRequiresDynamicCodeMessage)]
         internal ManifestSignedXml2(XmlDocument document)
             : base(document)
         {
             init();
         }
 
+        [RequiresUnreferencedCode(SignedXmlRequiresUnreferencedCodeMessage)]
+        [RequiresDynamicCode(SignedXmlRequiresDynamicCodeMessage)]
         internal ManifestSignedXml2(XmlDocument document, bool verify)
             : base(document)
         {
@@ -321,11 +332,15 @@ namespace System.Deployment.Internal.CodeSigning
             _useSha256 = useSha256;
         }
 
+        [RequiresUnreferencedCode(ManifestSignedXml2.SignedXmlRequiresUnreferencedCodeMessage)]
+        [RequiresDynamicCode(ManifestSignedXml2.SignedXmlRequiresDynamicCodeMessage)]
         internal void Sign(CmiManifestSigner2 signer)
         {
             Sign(signer, null);
         }
 
+        [RequiresUnreferencedCode(ManifestSignedXml2.SignedXmlRequiresUnreferencedCodeMessage)]
+        [RequiresDynamicCode(ManifestSignedXml2.SignedXmlRequiresDynamicCodeMessage)]
         internal void Sign(CmiManifestSigner2 signer, string timeStampUrl, bool disallowMansignTimestampFallback = false)
         {
             // Reset signer infos.
@@ -662,6 +677,8 @@ namespace System.Deployment.Internal.CodeSigning
             return licenseDom;
         }
 
+        [RequiresUnreferencedCode(ManifestSignedXml2.SignedXmlRequiresUnreferencedCodeMessage)]
+        [RequiresDynamicCode(ManifestSignedXml2.SignedXmlRequiresDynamicCodeMessage)]
         private static void AuthenticodeSignLicenseDom(XmlDocument licenseDom, CmiManifestSigner2 signer, string timeStampUrl, bool useSha256, bool disallowMansignTimestampFallback)
         {
             // Make sure it is RSA, as this is the only one Fusion will support.
@@ -816,7 +833,7 @@ namespace System.Deployment.Internal.CodeSigning
                         }
                     }
 
-                    var timestampContext = (Win32.CRYPT_TIMESTAMP_CONTEXT)Marshal.PtrToStructure(ppTsContext, typeof(Win32.CRYPT_TIMESTAMP_CONTEXT));
+                    var timestampContext = Marshal.PtrToStructure<Win32.CRYPT_TIMESTAMP_CONTEXT>(ppTsContext);
                     byte[] encodedBytes = new byte[(int)timestampContext.cbEncoded];
                     Marshal.Copy(timestampContext.pbEncoded, encodedBytes, 0, (int)timestampContext.cbEncoded);
                     timestamp = Convert.ToBase64String(encodedBytes);
@@ -906,6 +923,8 @@ namespace System.Deployment.Internal.CodeSigning
             signatureNode.AppendChild(dsObject);
         }
 
+        [RequiresUnreferencedCode(ManifestSignedXml2.SignedXmlRequiresUnreferencedCodeMessage)]
+        [RequiresDynamicCode(ManifestSignedXml2.SignedXmlRequiresDynamicCodeMessage)]
         private static void StrongNameSignManifestDom(XmlDocument manifestDom, XmlDocument licenseDom, CmiManifestSigner2 signer, bool useSha256)
         {
             RSA snKey = signer.StrongNameKey as RSA;

--- a/src/Tasks/Microsoft.Build.Tasks.csproj
+++ b/src/Tasks/Microsoft.Build.Tasks.csproj
@@ -6,6 +6,9 @@
     <TargetFrameworks>$(LibraryTargetFrameworks)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <!-- Enable the trim/AOT analyzers. They only run on net8.0+ TFMs; the condition keeps
+         older TFMs (net472, netstandard2.0) from emitting NETSDK1210. -->
+    <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">true</IsAotCompatible>
     <GenerateReferenceAssemblySource>true</GenerateReferenceAssemblySource>
     <AssemblyName>Microsoft.Build.Tasks.Core</AssemblyName>
     <RootNamespace>Microsoft.Build.Tasks</RootNamespace>

--- a/src/Tasks/RoslynCodeTaskFactory/RoslynCodeTaskFactory.cs
+++ b/src/Tasks/RoslynCodeTaskFactory/RoslynCodeTaskFactory.cs
@@ -6,6 +6,7 @@ using System.CodeDom;
 using System.CodeDom.Compiler;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -89,7 +90,11 @@ namespace Microsoft.Build.Tasks
         /// <summary>
         /// Stores the path to the directory that this assembly is located in.
         /// </summary>
-        private static readonly Lazy<string> ThisAssemblyDirectoryLazy = new Lazy<string>(() => Path.GetDirectoryName(typeof(RoslynCodeTaskFactory).GetTypeInfo().Assembly.ManifestModule.FullyQualifiedName));
+        private static readonly Lazy<string> ThisAssemblyDirectoryLazy = new Lazy<string>(GetThisAssemblyDirectory);
+
+        [UnconditionalSuppressMessage("SingleFile", "IL3002:RequiresAssemblyFiles",
+            Justification = "RoslynCodeTaskFactory compiles task source against reference assemblies on disk, so it does not support single-file deployment; the module path is only used to locate those on-disk references.")]
+        private static string GetThisAssemblyDirectory() => Path.GetDirectoryName(typeof(RoslynCodeTaskFactory).GetTypeInfo().Assembly.ManifestModule.FullyQualifiedName);
 
         /// <summary>
         /// Stores an instance of a <see cref="TaskLoggingHelper"/> for logging messages.
@@ -137,6 +142,8 @@ namespace Microsoft.Build.Tasks
         }
 
         /// <inheritdoc cref="ITaskFactory.CreateTask(IBuildEngine)"/>
+        [UnconditionalSuppressMessage("TrimAnalysis", "IL2072:UnrecognizedReflectionPattern",
+            Justification = "TaskType is a type from an assembly compiled at runtime from user-supplied source, so its constructor cannot be statically preserved; this factory is inherently incompatible with trimming.")]
         public ITask CreateTask(IBuildEngine taskFactoryLoggingHost)
         {
             // The type of the task has already been determined and the assembly is already loaded after compilation so
@@ -165,6 +172,10 @@ namespace Microsoft.Build.Tasks
         public string GetAssemblyPath() => _assemblyPath;
 
         /// <inheritdoc cref="ITaskFactory.Initialize"/>
+        [UnconditionalSuppressMessage("TrimAnalysis", "IL2026:RequiresUnreferencedCode",
+            Justification = "RoslynCodeTaskFactory compiles and loads a task assembly at runtime and reflects over its exported types; this is inherently incompatible with trimming.")]
+        [UnconditionalSuppressMessage("TrimAnalysis", "IL2075:UnrecognizedReflectionPattern",
+            Justification = "The task type comes from an assembly compiled at runtime from user-supplied source, so its properties cannot be statically preserved.")]
         public bool Initialize(string taskName, IDictionary<string, TaskPropertyInfo> parameterGroup, string taskBody, IBuildEngine taskFactoryLoggingHost)
         {
             _log = new TaskLoggingHelper(taskFactoryLoggingHost, taskName)
@@ -558,6 +569,7 @@ namespace Microsoft.Build.Tasks
         /// Perhaps in the future this could be more powerful by using NuGet to resolve assemblies but we think
         /// that is too complicated for a simple in-line task.  If users have more complex requirements, they
         /// can compile their own task library.</remarks>
+        [RequiresUnreferencedCode("Resolves and registers task reference assemblies for loading from disk, which is incompatible with trimming.")]
         internal bool TryResolveAssemblyReferences(TaskLoggingHelper log, RoslynCodeTaskFactoryTaskInfo taskInfo, out ITaskItem[] items)
         {
             // Store the list of resolved assemblies because a user can specify a short name or a full path
@@ -689,6 +701,7 @@ namespace Microsoft.Build.Tasks
         /// <param name="taskInfo">A <see cref="RoslynCodeTaskFactoryTaskInfo"/> object containing details about the task.</param>
         /// <param name="assembly">The <see cref="Assembly"/> if the source code be compiled and loaded, otherwise <code>null</code>.</param>
         /// <returns><code>true</code> if the source code could be compiled and loaded, otherwise <code>false</code>.</returns>
+        [RequiresUnreferencedCode("Compiles and loads a task assembly from disk at runtime, which is incompatible with trimming.")]
         private bool TryCompileAssembly(IBuildEngine buildEngine, RoslynCodeTaskFactoryTaskInfo taskInfo, out Assembly assembly)
         {
             // Try to get from cache

--- a/src/Tasks/SignFile.cs
+++ b/src/Tasks/SignFile.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Runtime.Versioning;
 using System.Security.Cryptography;
@@ -42,6 +43,10 @@ namespace Microsoft.Build.Tasks
         public string TimestampUrl { get; set; }
         public bool DisallowMansignTimestampFallback { get; set; } = false;
 
+        [UnconditionalSuppressMessage("TrimAnalysis", "IL2026:RequiresUnreferencedCode",
+            Justification = "Signing a ClickOnce manifest reads and writes it with XmlSerializer; this task is inherently incompatible with trimming.")]
+        [UnconditionalSuppressMessage("AotAnalysis", "IL3050:RequiresDynamicCode",
+            Justification = "Signing a ClickOnce manifest uses XmlSerializer, XslCompiledTransform, and SignedXml; this task is inherently incompatible with Native AOT.")]
         public override bool Execute()
         {
             if (!NativeMethodsShared.IsWindows)

--- a/src/Tasks/StateFileBase.cs
+++ b/src/Tasks/StateFileBase.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using Microsoft.Build.BackEnd;
 using Microsoft.Build.Framework;
@@ -94,7 +95,7 @@ namespace Microsoft.Build.Tasks
         /// <remarks>
         /// Prioritize using the AbsolutePath overload of this method. This method is still used by unenlightened tasks, but new code should use the AbsolutePath overload.
         /// </remarks>
-        internal static T DeserializeCache<T>(string stateFile, TaskLoggingHelper log) where T : StateFileBase
+        internal static T DeserializeCache<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(string stateFile, TaskLoggingHelper log) where T : StateFileBase
         {
             if (string.IsNullOrEmpty(stateFile))
             {
@@ -107,7 +108,7 @@ namespace Microsoft.Build.Tasks
         /// <summary>
         /// Reads the specified file from disk into a StateFileBase derived object.
         /// </summary>
-        internal static T DeserializeCache<T>(AbsolutePath stateFile, TaskLoggingHelper log) where T : StateFileBase
+        internal static T DeserializeCache<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(AbsolutePath stateFile, TaskLoggingHelper log) where T : StateFileBase
         {
             T retVal = null;
 

--- a/src/Tasks/WriteCodeFragment.cs
+++ b/src/Tasks/WriteCodeFragment.cs
@@ -79,6 +79,8 @@ namespace Microsoft.Build.Tasks
         /// <summary>
         /// Main entry point.
         /// </summary>
+        [UnconditionalSuppressMessage("TrimAnalysis", "IL2026:RequiresUnreferencedCode",
+            Justification = "WriteCodeFragment resolves user-specified attribute types by name and reflects over their members to infer parameter types; this is inherently incompatible with trimming.")]
         public override bool Execute()
         {
             if (String.IsNullOrEmpty(Language))
@@ -149,7 +151,9 @@ namespace Microsoft.Build.Tasks
         /// If no meaningful code is generated, returns empty string.
         /// Returns the default language extension as an out parameter.
         /// </summary>
+        /// <returns>The generated source code as a string, or null if an error occurred.</returns>
         [SuppressMessage("Microsoft.Globalization", "CA1305:SpecifyIFormatProvider", MessageId = "System.IO.StringWriter.#ctor(System.Text.StringBuilder)", Justification = "Reads fine to me")]
+        [RequiresUnreferencedCode("Resolves user-specified attribute types by name via Type.GetType, which the trimmer cannot statically analyze.")]
         private string GenerateCode(out string extension)
         {
             extension = null;
@@ -407,6 +411,7 @@ namespace Microsoft.Build.Tasks
         /// Returns true if the arguments could be defined, or false if the values could
         /// not be converted to the required type. An error is also logged for failures.
         /// </summary>
+        [RequiresUnreferencedCode("Reflects over the attribute type's properties to infer parameter types, which the trimmer cannot statically analyze.")]
         private bool AddArguments(
             CodeAttributeDeclaration attribute,
             Lazy<Type> attributeType,
@@ -490,6 +495,7 @@ namespace Microsoft.Build.Tasks
         /// Returns an array of types with a length equal to the number of positional parameters.
         /// If no suitable constructor is found, the array will contain null types.
         /// </summary>
+        [RequiresUnreferencedCode("Reflects over the attribute type's constructors to infer parameter types, which the trimmer cannot statically analyze.")]
         private Type[] FindPositionalParameterTypes(Type attributeType, IReadOnlyList<AttributeParameter> positionalParameters)
         {
             // The attribute type might not be known.
@@ -550,6 +556,7 @@ namespace Microsoft.Build.Tasks
         /// Attempts to convert the raw value provided in the metadata to the type with the specified name.
         /// Returns true if conversion is successful. An error is logged and false is returned if the conversion fails.
         /// </summary>
+        [RequiresUnreferencedCode("Resolves the parameter type by name via Type.GetType, which the trimmer cannot statically analyze.")]
         private bool TryConvertParameterValue(string typeName, string rawValue, out CodeExpression value)
         {
             var parameterType = Type.GetType(typeName, throwOnError: false);

--- a/src/Tasks/XslTransformation.cs
+++ b/src/Tasks/XslTransformation.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Xml;
 using System.Xml.XPath;
@@ -100,6 +101,8 @@ namespace Microsoft.Build.Tasks
         /// Executes the XslTransform task.
         /// </summary>
         /// <returns>true if transformation succeeds.</returns>
+        [UnconditionalSuppressMessage("AotAnalysis", "IL3050:RequiresDynamicCode",
+            Justification = "The XslTransformation task compiles the user-supplied stylesheet with XslCompiledTransform, which generates IL at runtime and is inherently incompatible with Native AOT.")]
         public override bool Execute()
         {
             XmlInput xmlinput;
@@ -458,6 +461,7 @@ namespace Microsoft.Build.Tasks
             /// Loads the XSLT to XslCompiledTransform. By default uses Default settings instead of trusted settings.
             /// </summary>
             /// <returns>A XslCompiledTransform object.</returns>
+            [RequiresDynamicCode("XslCompiledTransform generates IL at runtime, which is not supported with Native AOT.")]
             public XslCompiledTransform LoadXslt()
             {
                 return LoadXslt(false);
@@ -468,6 +472,7 @@ namespace Microsoft.Build.Tasks
             /// </summary>
             /// <param name="useTrustedSettings">Determines whether or not to use trusted settings.</param>
             /// <returns>A XslCompiledTransform object.</returns>
+            [RequiresDynamicCode("XslCompiledTransform generates IL at runtime, which is not supported with Native AOT.")]
             public XslCompiledTransform LoadXslt(bool useTrustedSettings)
             {
                 XslCompiledTransform xslct = new XslCompiledTransform();

--- a/src/Utilities/Microsoft.Build.Utilities.csproj
+++ b/src/Utilities/Microsoft.Build.Utilities.csproj
@@ -5,6 +5,9 @@
   <PropertyGroup>
     <TargetFrameworks>$(LibraryTargetFrameworks)</TargetFrameworks>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+    <!-- Enable the trim/AOT analyzers. They only run on net8.0+ TFMs; the condition keeps
+         older TFMs (net472, netstandard2.0) from emitting NETSDK1210. -->
+    <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">true</IsAotCompatible>
     <RootNamespace>Microsoft.Build.Utilities</RootNamespace>
     <AssemblyName>Microsoft.Build.Utilities.Core</AssemblyName>
     <EnableDocumentationFile>true</EnableDocumentationFile>


### PR DESCRIPTION
## Summary

Enables the trim / Native AOT analyzers (`IsAotCompatible`) on `Microsoft.Build.Utilities` and `Microsoft.Build.Tasks`, the next assemblies up the dependency graph after `Microsoft.Build.Framework` and `Microsoft.NET.StringTools` (#14012), and resolves every IL warning the analyzers surface.

`IsAotCompatible` is gated to net8.0+ TFMs, so it only activates on the net10.0 build. net472 and netstandard2.0 are unaffected (no NETSDK1210).

## Utilities

- `PrintLineDebugger` (shared) now references Framework's internal `CommonWriter` directly via `InternalsVisibleTo` instead of reflecting over it with `Assembly.GetType` + `Type.GetProperty` (clears IL2026 + IL2075).
- `AssemblyFolderCollection.Load` replaces `DataContractSerializer` with a streaming `XmlDocument` parser that is trimming- and Native AOT-safe and XXE-hardened (`DtdProcessing.Prohibit`, null `XmlResolver`). The trim/AOT requirements that would otherwise thread through `AssemblyFoldersFromConfig` and the public `ToolLocationHelper.GetAssemblyFoldersFromConfigInfo` are removed, and the resolver catch moves from `SerializationException` to `XmlException`. Adds `AssemblyFolderCollection_Tests` with direct parser coverage that runs on every TFM (the existing RAR-driven tests are net472-only).

## Tasks

Clean fixes that eliminate warnings rather than annotate:

- `GenerateResource.FilesWritten` uses a typed array copy instead of `ArrayList.ToArray(Type)`.
- `mansign2` uses the generic `Marshal.PtrToStructure<T>`.
- `StateFileBase.DeserializeCache<T>` marks its generic parameter with `DynamicallyAccessedMembers(PublicConstructors)`.
- The `RSAPKCS1SHA256SignatureDescription` overrides match the base `RequiresUnreferencedCode`.

The ClickOnce manifest, signing, and bootstrapper subsystem is inherently reflective (`XmlSerializer` + `XslCompiledTransform` + `SignedXml`). Those paths are marked with `RequiresUnreferencedCode` / `RequiresDynamicCode`, propagated out to the consuming tasks (`GenerateApplicationManifest`, `GenerateDeploymentManifest`, `GenerateTrustInfo`, `SignFile`, `GenerateBootstrapper`, `ResolveNativeReference`). `UnconditionalSuppressMessage` is used only where the requirement cannot propagate through a non-annotated override (`Task.Execute`, `ITaskFactory` members, `Manifest.Validate`, `TrustInfo.ToString`) and at two shared primitives (`TaskParameter` primitive-array translate, `LogMessagePacketBase.WriteToStream`); each carries a justification.

A follow-up issue will track actually reducing these ClickOnce AOT blockers rather than only annotating them.

## Polyfills

Adds `RequiresDynamicCodeAttribute` to the Framework trim-attribute polyfills so `RequiresDynamicCode` resolves on net472 and netstandard2.0 via `InternalsVisibleTo`, consistent with how the other trim attributes are shared.

## Testing

- `Microsoft.Build.Utilities` and `Microsoft.Build.Tasks` build clean (0 warnings) on net10.0, net472, and netstandard2.0 with warnings treated as errors.
- Downstream `Microsoft.Build` and `MSBuild` compile clean on net10.0 and net472, confirming the shared-code edits and the new `RequiresUnreferencedCode` public surface do not break consumers.
- Unit tests pass for the touched tasks: `AssemblyFolderCollection_Tests` (10), `WriteCodeFragment_Tests` (54), `XslTransformation_Tests` (23), `RoslynCodeTaskFactory_Tests` (65), `GenerateResource` (103); and on net472 `AssemblyFoldersFromConfig_Tests` (5), `SecurityUtil_Tests` (2), `ManifestTaskEnvironmentTests` (8), `ResolveComReference_Tests` (21).

## Notes

- No public API changes beyond the added trim/AOT attributes, which are metadata only and do not affect non-trimming consumers.
- Part of the incremental AOT-annotation rollout up the MSBuild dependency graph; `Microsoft.Build` (the engine) and the MSBuild CLI remain as future steps.