### PR TITLE
Launch the MSBuild server process with Server GC

### DIFF
--- a/documentation/MSBuild-Server.md
+++ b/documentation/MSBuild-Server.md
@@ -9,7 +9,7 @@ To re-enable MSBuild Server, remove the variable or set its value to `0`.
 
 ## Garbage collection
 
-When a build is multithreaded (`/mt`), the server node is launched with [Server GC](https://learn.microsoft.com/dotnet/standard/garbage-collection/workstation-server-gc) enabled. Under `/mt` the server runs all project work on threads in this single process, so Server GC's higher throughput is beneficial; without `/mt` the server only orchestrates and delegates project work to separate worker nodes, so it keeps the default Workstation GC. GC mode is fixed at CLR startup, so it is set via the `DOTNET_gcServer` environment variable in the server's launch environment (decided from the launching invocation's command line). This is scoped to the server process only: sidecar TaskHosts and worker nodes keep the default Workstation GC.
+When a build is multithreaded (`/mt`), the server node is launched with [Server GC](https://learn.microsoft.com/dotnet/standard/garbage-collection/workstation-server-gc) enabled. Under `/mt` the server runs all project work on threads in this single process, so Server GC's higher throughput is beneficial; without `/mt` the server only orchestrates and delegates project work to separate worker nodes, so it keeps the default Workstation GC. GC mode is fixed at CLR startup, so it is set via the `DOTNET_gcServer` environment variable in the server's launch environment (decided from the launching invocation's command line). An explicit user-set `DOTNET_gcServer` is honored (e.g. set `DOTNET_gcServer=0` to keep Workstation GC in a memory-constrained environment). This is scoped to the server process only: sidecar TaskHosts and worker nodes keep the default Workstation GC.
 
 ## Communication protocol
 

--- a/documentation/MSBuild-Server.md
+++ b/documentation/MSBuild-Server.md
@@ -7,6 +7,10 @@ MSBuild Server nodes accept build requests from clients and use worker nodes in 
 The primary ways to use MSBuild are via Visual Studio and via the CLI using the `dotnet build`/`dotnet msbuild` commands. MSBuild Server is not supported in Visual Studio because Visual Studio itself works like MSBuild Server. For the CLI, the server functionality is enabled by default and can be disabled by setting the `DOTNET_CLI_DO_NOT_USE_MSBUILD_SERVER` environment variable to value `1`.
 To re-enable MSBuild Server, remove the variable or set its value to `0`.
 
+## Garbage collection
+
+The server node is launched with [Server GC](https://learn.microsoft.com/dotnet/standard/garbage-collection/workstation-server-gc) enabled. The server hosts the build itself - under a multithreaded (`/mt`) build it runs all project work on threads in this single process - so Server GC's higher throughput is beneficial. GC mode is fixed at CLR startup, so it is set via the `DOTNET_gcServer` environment variable in the server's launch environment. This is scoped to the server process only: sidecar TaskHosts and worker nodes keep the default Workstation GC.
+
 ## Communication protocol
 
 The server node uses same IPC approach as current worker nodes - named pipes. This solution allows to reuse existing code. When process starts, pipe with deterministic name is opened and waiting for commands. Client has following worfklow:

--- a/documentation/MSBuild-Server.md
+++ b/documentation/MSBuild-Server.md
@@ -9,7 +9,7 @@ To re-enable MSBuild Server, remove the variable or set its value to `0`.
 
 ## Garbage collection
 
-The server node is launched with [Server GC](https://learn.microsoft.com/dotnet/standard/garbage-collection/workstation-server-gc) enabled. The server hosts the build itself - under a multithreaded (`/mt`) build it runs all project work on threads in this single process - so Server GC's higher throughput is beneficial. GC mode is fixed at CLR startup, so it is set via the `DOTNET_gcServer` environment variable in the server's launch environment. This is scoped to the server process only: sidecar TaskHosts and worker nodes keep the default Workstation GC.
+When a build is multithreaded (`/mt`), the server node is launched with [Server GC](https://learn.microsoft.com/dotnet/standard/garbage-collection/workstation-server-gc) enabled. Under `/mt` the server runs all project work on threads in this single process, so Server GC's higher throughput is beneficial; without `/mt` the server only orchestrates and delegates project work to separate worker nodes, so it keeps the default Workstation GC. GC mode is fixed at CLR startup, so it is set via the `DOTNET_gcServer` environment variable in the server's launch environment (decided from the launching invocation's command line). This is scoped to the server process only: sidecar TaskHosts and worker nodes keep the default Workstation GC.
 
 ## Communication protocol
 

--- a/documentation/wiki/MSBuild-Environment-Variables.md
+++ b/documentation/wiki/MSBuild-Environment-Variables.md
@@ -36,5 +36,7 @@ Some of the env variables listed here are unsupported, meaning there is no guara
   - Set this to force all inline tasks to run out of process. It is not compatible with custom TaskFactories.
 - `MSBUILDFORCEMULTITHREADED=1`
   - Set this to force MSBuild to run in multi-threaded mode (using in-proc nodes for parallel build), equivalent to passing `-multiThreaded` / `-mt` on the command line. Useful for opting in without modifying command lines.
+- `MSBUILDDISABLESERVERGC=1`
+  - By default the MSBuild server (the long-lived build process used when `MSBUILDUSESERVER=1`) is launched with Server GC, which improves throughput for the build orchestrator (especially under multi-threaded `/mt` builds). Set this to launch the server with the default Workstation GC instead - for example in memory-constrained environments. Only affects newly launched servers (GC mode is fixed at process startup); shut down an already-running server for the change to take effect. An explicit `DOTNET_gcServer` setting is honored over this default. Sidecar TaskHosts and worker nodes are never launched with Server GC.
 - `MSBUILD_CONSOLE_USE_DEFAULT_ENCODING`
   - It opts out automatic console encoding UTF-8. Make Console use default encoding in the system.

--- a/documentation/wiki/MSBuild-Environment-Variables.md
+++ b/documentation/wiki/MSBuild-Environment-Variables.md
@@ -36,7 +36,5 @@ Some of the env variables listed here are unsupported, meaning there is no guara
   - Set this to force all inline tasks to run out of process. It is not compatible with custom TaskFactories.
 - `MSBUILDFORCEMULTITHREADED=1`
   - Set this to force MSBuild to run in multi-threaded mode (using in-proc nodes for parallel build), equivalent to passing `-multiThreaded` / `-mt` on the command line. Useful for opting in without modifying command lines.
-- `MSBUILDDISABLESERVERGC=1`
-  - By default the MSBuild server (the long-lived build process used when `MSBUILDUSESERVER=1`) is launched with Server GC, which improves throughput for the build orchestrator (especially under multi-threaded `/mt` builds). Set this to launch the server with the default Workstation GC instead - for example in memory-constrained environments. Only affects newly launched servers (GC mode is fixed at process startup); shut down an already-running server for the change to take effect. An explicit `DOTNET_gcServer` setting is honored over this default. Sidecar TaskHosts and worker nodes are never launched with Server GC.
 - `MSBUILD_CONSOLE_USE_DEFAULT_ENCODING`
   - It opts out automatic console encoding UTF-8. Make Console use default encoding in the system.

--- a/src/Build/BackEnd/Client/MSBuildClient.cs
+++ b/src/Build/BackEnd/Client/MSBuildClient.cs
@@ -484,17 +484,12 @@ namespace Microsoft.Build.Experimental
                 // DOTNET_gcServer is removed before it ever spawns children). Those nodes therefore keep
                 // the default Workstation GC.
                 //
-                // An explicit user-set DOTNET_gcServer (e.g. "0" to force Workstation GC) is honored, and
-                // MSBUILDDISABLESERVERGC=1 opts out. CreateDotnetRootEnvironmentOverrides returns a shared
-                // cached dictionary reused by other node launches, so copy it before adding the override.
-                if (Environment.GetEnvironmentVariable("DOTNET_gcServer") is null &&
-                    Environment.GetEnvironmentVariable("MSBUILDDISABLESERVERGC") != "1")
-                {
-                    environmentOverrides = environmentOverrides is null
-                        ? new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase)
-                        : new Dictionary<string, string?>(environmentOverrides, StringComparer.OrdinalIgnoreCase);
-                    environmentOverrides["DOTNET_gcServer"] = "1";
-                }
+                // CreateDotnetRootEnvironmentOverrides returns a shared cached dictionary reused by other
+                // node launches, so copy it before adding the GC override.
+                environmentOverrides = environmentOverrides is null
+                    ? new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase)
+                    : new Dictionary<string, string?>(environmentOverrides, StringComparer.OrdinalIgnoreCase);
+                environmentOverrides["DOTNET_gcServer"] = "1";
 
                 NodeLaunchData launchData = new(
                     MSBuildLocation: _msbuildLocation,

--- a/src/Build/BackEnd/Client/MSBuildClient.cs
+++ b/src/Build/BackEnd/Client/MSBuildClient.cs
@@ -469,7 +469,10 @@ namespace Microsoft.Build.Experimental
                 // Set DOTNET_ROOT so the apphost server child can locate the runtime; this
                 // override is replaced by the client's environment on the first build command
                 // (see OutOfProcServerNode.HandleServerNodeBuildCommand → SetEnvironment).
-                IDictionary<string, string?>? environmentOverrides = DotnetHostEnvironmentHelper.CreateDotnetRootEnvironmentOverrides();
+                // This is a shared cached dictionary reused by other node launches, so it must not
+                // be mutated in place.
+                IDictionary<string, string?>? baseOverrides = DotnetHostEnvironmentHelper.CreateDotnetRootEnvironmentOverrides();
+                IDictionary<string, string?>? environmentOverrides = baseOverrides;
 
                 // When this build is multithreaded (/mt), launch the long-lived server (build
                 // orchestrator) process with Server GC. Under /mt the server runs all project work on
@@ -488,13 +491,15 @@ namespace Microsoft.Build.Experimental
                 // DOTNET_gcServer is removed before it ever spawns children). Those nodes therefore keep
                 // the default Workstation GC.
                 //
-                // CreateDotnetRootEnvironmentOverrides returns a shared cached dictionary reused by other
-                // node launches, so copy it before adding the GC override.
-                if (IsMultiThreadedBuildRequested())
+                // Copy the shared base overrides (preserving its comparer) before adding the GC override.
+                // Honor an explicit user-set DOTNET_gcServer (e.g. "0" to force Workstation GC in a
+                // memory-constrained container): only inject the default when the user hasn't set it.
+                if (IsMultiThreadedBuildRequested() &&
+                    Environment.GetEnvironmentVariable("DOTNET_gcServer") is null)
                 {
-                    environmentOverrides = environmentOverrides is null
-                        ? new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase)
-                        : new Dictionary<string, string?>(environmentOverrides, StringComparer.OrdinalIgnoreCase);
+                    environmentOverrides = baseOverrides is null
+                        ? new Dictionary<string, string?>()
+                        : new Dictionary<string, string?>(baseOverrides);
                     environmentOverrides["DOTNET_gcServer"] = "1";
                 }
 

--- a/src/Build/BackEnd/Client/MSBuildClient.cs
+++ b/src/Build/BackEnd/Client/MSBuildClient.cs
@@ -471,12 +471,16 @@ namespace Microsoft.Build.Experimental
                 // (see OutOfProcServerNode.HandleServerNodeBuildCommand → SetEnvironment).
                 IDictionary<string, string?>? environmentOverrides = DotnetHostEnvironmentHelper.CreateDotnetRootEnvironmentOverrides();
 
-                // Launch the long-lived server (build orchestrator) process with Server GC. The server
-                // hosts the build itself - under a multithreaded (/mt) build it runs all project work on
-                // threads in this single process - so Server GC's higher throughput pays off here. GC mode
-                // is fixed at CLR startup, so it must be set in the child's launch environment via
-                // DOTNET_gcServer (which only affects .NET/CoreCLR and, since .NET 9, takes precedence over
-                // runtimeconfig.json).
+                // When this build is multithreaded (/mt), launch the long-lived server (build
+                // orchestrator) process with Server GC. Under /mt the server runs all project work on
+                // threads in this single process, so Server GC's higher throughput pays off; without
+                // /mt the server only orchestrates and delegates project work to separate worker nodes,
+                // so Server GC on the server would add memory cost for no benefit. GC mode is fixed at
+                // CLR startup, so it must be set in the child's launch environment via DOTNET_gcServer
+                // (which only affects .NET/CoreCLR and, since .NET 9, takes precedence over
+                // runtimeconfig.json). The decision is made from this (launch-time) invocation's command
+                // line; a server is keyed by handshake and reused, so a later differing /mt choice does
+                // not re-launch it.
                 //
                 // This is scoped to the server process only. Sidecar TaskHost (nodemode 2) and worker
                 // (nodemode 1) nodes are launched through other code paths that never set this knob, and
@@ -486,10 +490,13 @@ namespace Microsoft.Build.Experimental
                 //
                 // CreateDotnetRootEnvironmentOverrides returns a shared cached dictionary reused by other
                 // node launches, so copy it before adding the GC override.
-                environmentOverrides = environmentOverrides is null
-                    ? new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase)
-                    : new Dictionary<string, string?>(environmentOverrides, StringComparer.OrdinalIgnoreCase);
-                environmentOverrides["DOTNET_gcServer"] = "1";
+                if (IsMultiThreadedBuildRequested())
+                {
+                    environmentOverrides = environmentOverrides is null
+                        ? new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase)
+                        : new Dictionary<string, string?>(environmentOverrides, StringComparer.OrdinalIgnoreCase);
+                    environmentOverrides["DOTNET_gcServer"] = "1";
+                }
 
                 NodeLaunchData launchData = new(
                     MSBuildLocation: _msbuildLocation,
@@ -508,6 +515,50 @@ namespace Microsoft.Build.Experimental
             }
 
             return true;
+        }
+
+        /// <summary>
+        /// Determines whether this invocation requests a multithreaded (/mt) build, by inspecting the
+        /// command line this client was constructed with and the MSBUILDFORCEMULTITHREADED opt-in.
+        /// Mirrors the "switch is present" semantics of <c>MSBuildApp.IsMultiThreadedEnabled</c>; the
+        /// switch-prefix handling (-, --, /) matches MSBuild's command-line parser.
+        /// </summary>
+        private bool IsMultiThreadedBuildRequested()
+        {
+            if (Traits.Instance.ForceMultiThreaded)
+            {
+                return true;
+            }
+
+            foreach (string arg in _commandLine)
+            {
+                if (string.IsNullOrEmpty(arg))
+                {
+                    continue;
+                }
+
+                // Strip the leading switch indicator: "--" (length 2), or "-"/"/" (length 1).
+                int indicatorLength = arg.StartsWith("--", StringComparison.Ordinal)
+                    ? 2
+                    : (arg[0] == '-' || arg[0] == '/') ? 1 : 0;
+                if (indicatorLength == 0)
+                {
+                    continue;
+                }
+
+                // The switch name runs up to the first switch/parameter separator (':').
+                int separatorIndex = arg.IndexOf(':', indicatorLength);
+                int nameLength = (separatorIndex < 0 ? arg.Length : separatorIndex) - indicatorLength;
+                ReadOnlySpan<char> switchName = arg.AsSpan(indicatorLength, nameLength);
+
+                if (switchName.Equals("mt".AsSpan(), StringComparison.OrdinalIgnoreCase) ||
+                    switchName.Equals("multithreaded".AsSpan(), StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         private bool TrySendBuildCommand() => TrySendPacket(() => GetServerNodeBuildCommand());

--- a/src/Build/BackEnd/Client/MSBuildClient.cs
+++ b/src/Build/BackEnd/Client/MSBuildClient.cs
@@ -108,6 +108,12 @@ namespace Microsoft.Build.Experimental
         private int? _launchedServerPid;
 
         /// <summary>
+        /// Whether this build is multithreaded (/mt). Determines whether the launched server process
+        /// gets Server GC (the server only does in-process project work under /mt).
+        /// </summary>
+        private readonly bool _multiThreaded;
+
+        /// <summary>
         /// Public constructor with parameters.
         /// </summary>
         /// <param name="commandLine">The command line to process. The first argument
@@ -115,6 +121,20 @@ namespace Microsoft.Build.Experimental
         /// <param name="msbuildLocation"> Full path to current MSBuild.exe if executable is MSBuild.exe,
         /// or to version of MSBuild.dll found to be associated with the current process.</param>
         public MSBuildClient(string[] commandLine, string msbuildLocation)
+            : this(commandLine, msbuildLocation, multiThreaded: false)
+        {
+        }
+
+        /// <summary>
+        /// Public constructor with parameters.
+        /// </summary>
+        /// <param name="commandLine">The command line to process. The first argument
+        /// on the command line is assumed to be the name/path of the executable, and is ignored</param>
+        /// <param name="msbuildLocation"> Full path to current MSBuild.exe if executable is MSBuild.exe,
+        /// or to version of MSBuild.dll found to be associated with the current process.</param>
+        /// <param name="multiThreaded">Whether this build is multithreaded (/mt). When true, the launched
+        /// server process is started with Server GC.</param>
+        public MSBuildClient(string[] commandLine, string msbuildLocation, bool multiThreaded)
         {
             _serverEnvironmentVariables = new();
             _exitResult = new();
@@ -122,6 +142,7 @@ namespace Microsoft.Build.Experimental
             // dll & exe locations
             _commandLine = commandLine;
             _msbuildLocation = msbuildLocation;
+            _multiThreaded = multiThreaded;
 
             // Client <-> Server communication stream
             _handshake = GetHandshake();
@@ -494,7 +515,7 @@ namespace Microsoft.Build.Experimental
                 // Copy the shared base overrides (preserving its comparer) before adding the GC override.
                 // Honor an explicit user-set DOTNET_gcServer (e.g. "0" to force Workstation GC in a
                 // memory-constrained container): only inject the default when the user hasn't set it.
-                if (IsMultiThreadedBuildRequested() &&
+                if (_multiThreaded &&
                     Environment.GetEnvironmentVariable("DOTNET_gcServer") is null)
                 {
                     environmentOverrides = baseOverrides is null
@@ -520,50 +541,6 @@ namespace Microsoft.Build.Experimental
             }
 
             return true;
-        }
-
-        /// <summary>
-        /// Determines whether this invocation requests a multithreaded (/mt) build, by inspecting the
-        /// command line this client was constructed with and the MSBUILDFORCEMULTITHREADED opt-in.
-        /// Mirrors the "switch is present" semantics of <c>MSBuildApp.IsMultiThreadedEnabled</c>; the
-        /// switch-prefix handling (-, --, /) matches MSBuild's command-line parser.
-        /// </summary>
-        private bool IsMultiThreadedBuildRequested()
-        {
-            if (Traits.Instance.ForceMultiThreaded)
-            {
-                return true;
-            }
-
-            foreach (string arg in _commandLine)
-            {
-                if (string.IsNullOrEmpty(arg))
-                {
-                    continue;
-                }
-
-                // Strip the leading switch indicator: "--" (length 2), or "-"/"/" (length 1).
-                int indicatorLength = arg.StartsWith("--", StringComparison.Ordinal)
-                    ? 2
-                    : (arg[0] == '-' || arg[0] == '/') ? 1 : 0;
-                if (indicatorLength == 0)
-                {
-                    continue;
-                }
-
-                // The switch name runs up to the first switch/parameter separator (':').
-                int separatorIndex = arg.IndexOf(':', indicatorLength);
-                int nameLength = (separatorIndex < 0 ? arg.Length : separatorIndex) - indicatorLength;
-                ReadOnlySpan<char> switchName = arg.AsSpan(indicatorLength, nameLength);
-
-                if (switchName.Equals("mt".AsSpan(), StringComparison.OrdinalIgnoreCase) ||
-                    switchName.Equals("multithreaded".AsSpan(), StringComparison.OrdinalIgnoreCase))
-                {
-                    return true;
-                }
-            }
-
-            return false;
         }
 
         private bool TrySendBuildCommand() => TrySendPacket(() => GetServerNodeBuildCommand());

--- a/src/Build/BackEnd/Client/MSBuildClient.cs
+++ b/src/Build/BackEnd/Client/MSBuildClient.cs
@@ -496,10 +496,9 @@ namespace Microsoft.Build.Experimental
                 IDictionary<string, string?>? environmentOverrides = baseOverrides;
 
                 // When this build is multithreaded (/mt), launch the long-lived server (build
-                // orchestrator) process with Server GC. Under /mt the server runs all project work on
-                // threads in this single process, so Server GC's higher throughput pays off; without
-                // /mt the server only orchestrates and delegates project work to separate worker nodes,
-                // so Server GC on the server would add memory cost for no benefit. GC mode is fixed at
+                // orchestrator) process with Server GC. Other processes may get higher throughput
+                // with Server GC, but we want to enable it only for the highest-impact one where
+                // most of the work of the actual build will happen in MT mode. GC mode is fixed at
                 // CLR startup, so it must be set in the child's launch environment via DOTNET_gcServer
                 // (which only affects .NET/CoreCLR and, since .NET 9, takes precedence over
                 // runtimeconfig.json). The decision is made from this (launch-time) invocation's command

--- a/src/Build/BackEnd/Client/MSBuildClient.cs
+++ b/src/Build/BackEnd/Client/MSBuildClient.cs
@@ -469,10 +469,37 @@ namespace Microsoft.Build.Experimental
                 // Set DOTNET_ROOT so the apphost server child can locate the runtime; this
                 // override is replaced by the client's environment on the first build command
                 // (see OutOfProcServerNode.HandleServerNodeBuildCommand → SetEnvironment).
+                IDictionary<string, string?>? environmentOverrides = DotnetHostEnvironmentHelper.CreateDotnetRootEnvironmentOverrides();
+
+                // Launch the long-lived server (build orchestrator) process with Server GC. The server
+                // hosts the build itself - under a multithreaded (/mt) build it runs all project work on
+                // threads in this single process - so Server GC's higher throughput pays off here. GC mode
+                // is fixed at CLR startup, so it must be set in the child's launch environment via
+                // DOTNET_gcServer (which only affects .NET/CoreCLR and, since .NET 9, takes precedence over
+                // runtimeconfig.json).
+                //
+                // This is scoped to the server process only. Sidecar TaskHost (nodemode 2) and worker
+                // (nodemode 1) nodes are launched through other code paths that never set this knob, and
+                // the server resets its own environment to the client's on the first build command (so
+                // DOTNET_gcServer is removed before it ever spawns children). Those nodes therefore keep
+                // the default Workstation GC.
+                //
+                // An explicit user-set DOTNET_gcServer (e.g. "0" to force Workstation GC) is honored, and
+                // MSBUILDDISABLESERVERGC=1 opts out. CreateDotnetRootEnvironmentOverrides returns a shared
+                // cached dictionary reused by other node launches, so copy it before adding the override.
+                if (Environment.GetEnvironmentVariable("DOTNET_gcServer") is null &&
+                    Environment.GetEnvironmentVariable("MSBUILDDISABLESERVERGC") != "1")
+                {
+                    environmentOverrides = environmentOverrides is null
+                        ? new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase)
+                        : new Dictionary<string, string?>(environmentOverrides, StringComparer.OrdinalIgnoreCase);
+                    environmentOverrides["DOTNET_gcServer"] = "1";
+                }
+
                 NodeLaunchData launchData = new(
                     MSBuildLocation: _msbuildLocation,
                     CommandLineArgs: string.Join(" ", msBuildServerOptions),
-                    EnvironmentOverrides: DotnetHostEnvironmentHelper.CreateDotnetRootEnvironmentOverrides());
+                    EnvironmentOverrides: environmentOverrides);
 
                 using Process msbuildProcess = nodeLauncher.Start(launchData, nodeId: 0);
                 _launchedServerPid = msbuildProcess.Id;

--- a/src/MSBuild.UnitTests/MSBuildServer_Tests.cs
+++ b/src/MSBuild.UnitTests/MSBuildServer_Tests.cs
@@ -44,13 +44,17 @@ namespace Microsoft.Build.Engine.UnitTests
         [Output]
         public int Pid { get; set; }
 
+        [Output]
+        public bool IsServerGC { get; set; }
+
         /// <summary>
-        /// Log the id for this process.
+        /// Log the id for this process and whether it is running with Server GC.
         /// </summary>
         /// <returns></returns>
         public override bool Execute()
         {
             Pid = Process.GetCurrentProcess().Id;
+            IsServerGC = System.Runtime.GCSettings.IsServerGC;
             return true;
         }
     }
@@ -348,6 +352,137 @@ namespace Microsoft.Build.Engine.UnitTests
             pidOfNewServerProcess.ShouldBe(pidOfServerProcess);
             output.ShouldContain($@":MSBuildStartupDirectory:{Environment.CurrentDirectory}:");
         }
+
+#if NET
+        /// <summary>
+        /// Builds a project that reports, for the process that executes <see cref="ProcessIdTask"/>,
+        /// its PID and whether it runs with Server GC. When <paramref name="useTaskHostFactory"/> is
+        /// true the task is forced out-of-proc into a TaskHost, so its PID is the TaskHost's rather
+        /// than the build node's.
+        /// </summary>
+        private static string GetServerGCProbeProjectContents(bool useTaskHostFactory)
+        {
+            string taskFactoryAttribute = useTaskHostFactory ? @" TaskFactory=""TaskHostFactory""" : string.Empty;
+            return $@"
+<Project>
+<UsingTask TaskName=""ProcessIdTask"" AssemblyFile=""{Assembly.GetExecutingAssembly().Location}""{taskFactoryAttribute} />
+    <Target Name='Probe'>
+        <ProcessIdTask>
+            <Output PropertyName=""PID"" TaskParameter=""Pid"" />
+            <Output PropertyName=""SERVERGC"" TaskParameter=""IsServerGC"" />
+        </ProcessIdTask>
+        <Message Text=""[Work around Github issue #9667 with --interactive]TaskRanInPID=$(PID)"" Importance=""High"" />
+        <Message Text=""TaskNodeServerGC=$(SERVERGC)"" Importance=""High"" />
+    </Target>
+</Project>";
+        }
+
+        /// <summary>
+        /// Isolates a server-related test: a unique handshake salt guarantees a freshly launched server
+        /// (so no leftover server from another test or local run is reused with a different GC mode), and
+        /// a clean GC environment ensures the test - not an ambient CI/user setting - controls Server GC.
+        /// </summary>
+        private void PrepareIsolatedServerEnv(bool useServer = true, bool disableServerGC = false)
+        {
+            // Child node launches (TaskHost, worker) need DOTNET_HOST_PATH to locate the runtime.
+            RunnerUtilities.ApplyDotnetHostPathEnvironmentVariable(_env);
+            _env.SetEnvironmentVariable("MSBUILDNODEHANDSHAKESALT", Guid.NewGuid().ToString("N"));
+            _env.SetEnvironmentVariable("DOTNET_gcServer", null);
+            _env.SetEnvironmentVariable("COMPlus_gcServer", null);
+            _env.SetEnvironmentVariable("MSBUILDUSESERVER", useServer ? "1" : null);
+            _env.SetEnvironmentVariable("MSBUILDDISABLESERVERGC", disableServerGC ? "1" : null);
+        }
+
+        /// <summary>
+        /// The MSBuild server (build orchestrator) process must be launched with Server GC.
+        /// </summary>
+        [Fact]
+        public void ServerProcessUsesServerGC()
+        {
+            if (Environment.ProcessorCount < 2)
+            {
+                Assert.Skip("Server GC can report as Workstation GC on single-processor machines.");
+            }
+
+            PrepareIsolatedServerEnv();
+            TransientTestFile project = _env.CreateFile("serverGcProbe.proj", GetServerGCProbeProjectContents(useTaskHostFactory: false));
+            string output = RunnerUtilities.ExecMSBuild(BuildEnvironmentHelper.Instance.CurrentMSBuildExePath, project.Path, out bool success, false, _output);
+
+            success.ShouldBeTrue();
+            int clientPid = ParseNumber(output, "Process ID is ");
+            int serverPid = ParseNumber(output, "TaskRanInPID=");
+            _env.WithTransientProcess(serverPid);
+            serverPid.ShouldNotBe(clientPid, "The build should run in the server node, not the entry process.");
+            output.ShouldContain("TaskNodeServerGC=True", customMessage: "The MSBuild server process should run with Server GC.");
+        }
+
+        /// <summary>
+        /// A TaskHost process must keep the default Workstation GC, even though the server uses Server GC.
+        /// Runs two builds against the same (uniquely salted) server: one in-proc to capture the
+        /// Server-GC server PID, then one that forces the task into a TaskHost.
+        /// </summary>
+        [Fact]
+        public void TaskHostProcessDoesNotUseServerGC()
+        {
+            PrepareIsolatedServerEnv();
+
+            // First build runs the task in-proc in the server node so we can capture the server PID.
+            TransientTestFile serverProbe = _env.CreateFile("serverProbe.proj", GetServerGCProbeProjectContents(useTaskHostFactory: false));
+            string serverOutput = RunnerUtilities.ExecMSBuild(BuildEnvironmentHelper.Instance.CurrentMSBuildExePath, serverProbe.Path, out bool serverSuccess, false, _output);
+            serverSuccess.ShouldBeTrue();
+            int serverPid = ParseNumber(serverOutput, "TaskRanInPID=");
+            _env.WithTransientProcess(serverPid);
+
+            // Second build (same server, reused via the shared handshake salt) forces the task out-of-proc.
+            TransientTestFile taskHostProbe = _env.CreateFile("taskHostProbe.proj", GetServerGCProbeProjectContents(useTaskHostFactory: true));
+            string taskHostOutput = RunnerUtilities.ExecMSBuild(BuildEnvironmentHelper.Instance.CurrentMSBuildExePath, taskHostProbe.Path, out bool taskHostSuccess, false, _output);
+            taskHostSuccess.ShouldBeTrue();
+            int clientPid = ParseNumber(taskHostOutput, "Process ID is ");
+            int taskHostPid = ParseNumber(taskHostOutput, "TaskRanInPID=");
+            _env.WithTransientProcess(taskHostPid);
+
+            taskHostPid.ShouldNotBe(clientPid, "The task should run out-of-proc in a TaskHost, not the entry process.");
+            taskHostPid.ShouldNotBe(serverPid, "The task should run in a TaskHost, not in the server node.");
+            taskHostOutput.ShouldContain("TaskNodeServerGC=False", customMessage: "A TaskHost process must use Workstation GC even when the server uses Server GC.");
+        }
+
+        /// <summary>
+        /// An out-of-proc worker node must keep the default Workstation GC.
+        /// </summary>
+        [Fact]
+        public void WorkerNodeDoesNotUseServerGC()
+        {
+            PrepareIsolatedServerEnv(useServer: false);
+            _env.SetEnvironmentVariable("MSBUILDNOINPROCNODE", "1");
+            TransientTestFile project = _env.CreateFile("workerGcProbe.proj", GetServerGCProbeProjectContents(useTaskHostFactory: false));
+            string output = RunnerUtilities.ExecMSBuild(BuildEnvironmentHelper.Instance.CurrentMSBuildExePath, $"{project.Path} /m:1", out bool success, false, _output);
+
+            success.ShouldBeTrue();
+            int clientPid = ParseNumber(output, "Process ID is ");
+            int workerPid = ParseNumber(output, "TaskRanInPID=");
+            _env.WithTransientProcess(workerPid);
+            workerPid.ShouldNotBe(clientPid, "The build should run in an out-of-proc worker node, not the entry process.");
+            output.ShouldContain("TaskNodeServerGC=False", customMessage: "A worker node must use the default Workstation GC.");
+        }
+
+        /// <summary>
+        /// MSBUILDDISABLESERVERGC=1 opts the server process out of Server GC.
+        /// </summary>
+        [Fact]
+        public void ServerProcessServerGCCanBeDisabled()
+        {
+            PrepareIsolatedServerEnv(disableServerGC: true);
+            TransientTestFile project = _env.CreateFile("serverGcOptOut.proj", GetServerGCProbeProjectContents(useTaskHostFactory: false));
+            string output = RunnerUtilities.ExecMSBuild(BuildEnvironmentHelper.Instance.CurrentMSBuildExePath, project.Path, out bool success, false, _output);
+
+            success.ShouldBeTrue();
+            int clientPid = ParseNumber(output, "Process ID is ");
+            int serverPid = ParseNumber(output, "TaskRanInPID=");
+            _env.WithTransientProcess(serverPid);
+            serverPid.ShouldNotBe(clientPid, "The build should run in the server node, not the entry process.");
+            output.ShouldContain("TaskNodeServerGC=False", customMessage: "MSBUILDDISABLESERVERGC=1 should keep the server process on Workstation GC.");
+        }
+#endif
 
         private int ParseNumber(string searchString, string toFind)
         {

--- a/src/MSBuild.UnitTests/MSBuildServer_Tests.cs
+++ b/src/MSBuild.UnitTests/MSBuildServer_Tests.cs
@@ -379,10 +379,11 @@ namespace Microsoft.Build.Engine.UnitTests
 
         /// <summary>
         /// Isolates a server-related test: a unique handshake salt guarantees a freshly launched server
-        /// (so no leftover server from another test or local run is reused with a different GC mode), and
-        /// a clean GC environment ensures the test - not an ambient CI/user setting - controls Server GC.
+        /// (so no leftover server from another test or local run is reused), and a clean GC environment
+        /// ensures the server's Server GC comes from the launch injection rather than an ambient
+        /// CI/user setting leaking into child nodes.
         /// </summary>
-        private void PrepareIsolatedServerEnv(bool useServer = true, bool disableServerGC = false)
+        private void PrepareIsolatedServerEnv(bool useServer = true)
         {
             // Child node launches (TaskHost, worker) need DOTNET_HOST_PATH to locate the runtime.
             RunnerUtilities.ApplyDotnetHostPathEnvironmentVariable(_env);
@@ -390,7 +391,6 @@ namespace Microsoft.Build.Engine.UnitTests
             _env.SetEnvironmentVariable("DOTNET_gcServer", null);
             _env.SetEnvironmentVariable("COMPlus_gcServer", null);
             _env.SetEnvironmentVariable("MSBUILDUSESERVER", useServer ? "1" : null);
-            _env.SetEnvironmentVariable("MSBUILDDISABLESERVERGC", disableServerGC ? "1" : null);
         }
 
         /// <summary>
@@ -463,24 +463,6 @@ namespace Microsoft.Build.Engine.UnitTests
             _env.WithTransientProcess(workerPid);
             workerPid.ShouldNotBe(clientPid, "The build should run in an out-of-proc worker node, not the entry process.");
             output.ShouldContain("TaskNodeServerGC=False", customMessage: "A worker node must use the default Workstation GC.");
-        }
-
-        /// <summary>
-        /// MSBUILDDISABLESERVERGC=1 opts the server process out of Server GC.
-        /// </summary>
-        [Fact]
-        public void ServerProcessServerGCCanBeDisabled()
-        {
-            PrepareIsolatedServerEnv(disableServerGC: true);
-            TransientTestFile project = _env.CreateFile("serverGcOptOut.proj", GetServerGCProbeProjectContents(useTaskHostFactory: false));
-            string output = RunnerUtilities.ExecMSBuild(BuildEnvironmentHelper.Instance.CurrentMSBuildExePath, project.Path, out bool success, false, _output);
-
-            success.ShouldBeTrue();
-            int clientPid = ParseNumber(output, "Process ID is ");
-            int serverPid = ParseNumber(output, "TaskRanInPID=");
-            _env.WithTransientProcess(serverPid);
-            serverPid.ShouldNotBe(clientPid, "The build should run in the server node, not the entry process.");
-            output.ShouldContain("TaskNodeServerGC=False", customMessage: "MSBUILDDISABLESERVERGC=1 should keep the server process on Workstation GC.");
         }
 #endif
 

--- a/src/MSBuild.UnitTests/MSBuildServer_Tests.cs
+++ b/src/MSBuild.UnitTests/MSBuildServer_Tests.cs
@@ -375,7 +375,7 @@ namespace Microsoft.Build.Engine.UnitTests
             <Output PropertyName=""PID"" TaskParameter=""Pid"" />
             <Output PropertyName=""SERVERGC"" TaskParameter=""IsServerGC"" />
         </ProcessIdTask>
-        <Message Text=""[Work around Github issue #9667 with --interactive]TaskRanInPID=$(PID)"" Importance=""High"" />
+        <Message Text=""[Work around GitHub issue #9667 with --interactive]TaskRanInPID=$(PID)"" Importance=""High"" />
         <Message Text=""TaskNodeServerGC=$(SERVERGC)"" Importance=""High"" />
     </Target>
 </Project>";

--- a/src/MSBuild.UnitTests/MSBuildServer_Tests.cs
+++ b/src/MSBuild.UnitTests/MSBuildServer_Tests.cs
@@ -39,6 +39,10 @@ namespace Microsoft.Build.Engine.UnitTests
         }
     }
 
+    // Marked multithreadable so that under /mt the engine runs it in-process on a server thread
+    // (rather than routing it to a sidecar TaskHost), letting it observe the server process's GC mode.
+    // The task only reads its own PID and GCSettings, so it is genuinely thread-safe.
+    [Microsoft.Build.Framework.MSBuildMultiThreadableTask]
     public class ProcessIdTask : Microsoft.Build.Utilities.Task
     {
         [Output]
@@ -394,10 +398,11 @@ namespace Microsoft.Build.Engine.UnitTests
         }
 
         /// <summary>
-        /// The MSBuild server (build orchestrator) process must be launched with Server GC.
+        /// The MSBuild server (build orchestrator) process must be launched with Server GC when the
+        /// build is multithreaded (/mt) - that is when the server itself does the project work.
         /// </summary>
         [Fact]
-        public void ServerProcessUsesServerGC()
+        public void MultiThreadedServerProcessUsesServerGC()
         {
             if (Environment.ProcessorCount < 2)
             {
@@ -406,6 +411,25 @@ namespace Microsoft.Build.Engine.UnitTests
 
             PrepareIsolatedServerEnv();
             TransientTestFile project = _env.CreateFile("serverGcProbe.proj", GetServerGCProbeProjectContents(useTaskHostFactory: false));
+            string output = RunnerUtilities.ExecMSBuild(BuildEnvironmentHelper.Instance.CurrentMSBuildExePath, $"{project.Path} -mt", out bool success, false, _output);
+
+            success.ShouldBeTrue();
+            int clientPid = ParseNumber(output, "Process ID is ");
+            int serverPid = ParseNumber(output, "TaskRanInPID=");
+            _env.WithTransientProcess(serverPid);
+            serverPid.ShouldNotBe(clientPid, "The build should run in the server node, not the entry process.");
+            output.ShouldContain("TaskNodeServerGC=True", customMessage: "A multithreaded MSBuild server process should run with Server GC.");
+        }
+
+        /// <summary>
+        /// Without /mt the server only orchestrates (project work happens in separate worker nodes),
+        /// so the server process must keep the default Workstation GC.
+        /// </summary>
+        [Fact]
+        public void NonMultiThreadedServerProcessDoesNotUseServerGC()
+        {
+            PrepareIsolatedServerEnv();
+            TransientTestFile project = _env.CreateFile("serverGcProbeNoMt.proj", GetServerGCProbeProjectContents(useTaskHostFactory: false));
             string output = RunnerUtilities.ExecMSBuild(BuildEnvironmentHelper.Instance.CurrentMSBuildExePath, project.Path, out bool success, false, _output);
 
             success.ShouldBeTrue();
@@ -413,29 +437,35 @@ namespace Microsoft.Build.Engine.UnitTests
             int serverPid = ParseNumber(output, "TaskRanInPID=");
             _env.WithTransientProcess(serverPid);
             serverPid.ShouldNotBe(clientPid, "The build should run in the server node, not the entry process.");
-            output.ShouldContain("TaskNodeServerGC=True", customMessage: "The MSBuild server process should run with Server GC.");
+            output.ShouldContain("TaskNodeServerGC=False", customMessage: "A non-multithreaded MSBuild server process should keep the default Workstation GC.");
         }
 
         /// <summary>
-        /// A TaskHost process must keep the default Workstation GC, even though the server uses Server GC.
-        /// Runs two builds against the same (uniquely salted) server: one in-proc to capture the
-        /// Server-GC server PID, then one that forces the task into a TaskHost.
+        /// A TaskHost process must keep the default Workstation GC, even though a multithreaded server
+        /// uses Server GC. Runs two /mt builds against the same (uniquely salted) server: one in-proc to
+        /// capture the Server-GC server PID, then one that forces the task into a TaskHost.
         /// </summary>
         [Fact]
         public void TaskHostProcessDoesNotUseServerGC()
         {
+            if (Environment.ProcessorCount < 2)
+            {
+                Assert.Skip("Server GC can report as Workstation GC on single-processor machines.");
+            }
+
             PrepareIsolatedServerEnv();
 
-            // First build runs the task in-proc in the server node so we can capture the server PID.
+            // First /mt build runs the task in-proc in the server node so we can capture the Server-GC server PID.
             TransientTestFile serverProbe = _env.CreateFile("serverProbe.proj", GetServerGCProbeProjectContents(useTaskHostFactory: false));
-            string serverOutput = RunnerUtilities.ExecMSBuild(BuildEnvironmentHelper.Instance.CurrentMSBuildExePath, serverProbe.Path, out bool serverSuccess, false, _output);
+            string serverOutput = RunnerUtilities.ExecMSBuild(BuildEnvironmentHelper.Instance.CurrentMSBuildExePath, $"{serverProbe.Path} -mt", out bool serverSuccess, false, _output);
             serverSuccess.ShouldBeTrue();
             int serverPid = ParseNumber(serverOutput, "TaskRanInPID=");
             _env.WithTransientProcess(serverPid);
+            serverOutput.ShouldContain("TaskNodeServerGC=True", customMessage: "A multithreaded MSBuild server process should run with Server GC.");
 
-            // Second build (same server, reused via the shared handshake salt) forces the task out-of-proc.
+            // Second /mt build (same server, reused via the shared handshake salt) forces the task out-of-proc.
             TransientTestFile taskHostProbe = _env.CreateFile("taskHostProbe.proj", GetServerGCProbeProjectContents(useTaskHostFactory: true));
-            string taskHostOutput = RunnerUtilities.ExecMSBuild(BuildEnvironmentHelper.Instance.CurrentMSBuildExePath, taskHostProbe.Path, out bool taskHostSuccess, false, _output);
+            string taskHostOutput = RunnerUtilities.ExecMSBuild(BuildEnvironmentHelper.Instance.CurrentMSBuildExePath, $"{taskHostProbe.Path} -mt", out bool taskHostSuccess, false, _output);
             taskHostSuccess.ShouldBeTrue();
             int clientPid = ParseNumber(taskHostOutput, "Process ID is ");
             int taskHostPid = ParseNumber(taskHostOutput, "TaskRanInPID=");

--- a/src/MSBuild/MSBuildClientApp.cs
+++ b/src/MSBuild/MSBuildClientApp.cs
@@ -29,19 +29,21 @@ namespace Microsoft.Build.CommandLine
         /// <param name="commandLine">The command line to process. The first argument
         /// on the command line is assumed to be the name/path of the executable, and
         /// is ignored.</param>
+        /// <param name="multiThreaded">Whether this build is multithreaded (/mt).</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>A value of type <see cref="MSBuildApp.ExitType"/> that indicates whether the build succeeded,
         /// or the manner in which it failed.</returns>
         /// <remarks>
         /// The locations of msbuild exe/dll and dotnet.exe would be automatically detected if called from dotnet or msbuild cli. Calling this function from other executables might not work.
         /// </remarks>
-        public static MSBuildApp.ExitType Execute(string[] commandLineArgs, CancellationToken cancellationToken)
+        public static MSBuildApp.ExitType Execute(string[] commandLineArgs, bool multiThreaded, CancellationToken cancellationToken)
         {
             string msbuildLocation = BuildEnvironmentHelper.Instance.CurrentMSBuildExePath;
 
             return Execute(
                 commandLineArgs,
                 msbuildLocation,
+                multiThreaded,
                 cancellationToken);
         }
 
@@ -53,12 +55,13 @@ namespace Microsoft.Build.CommandLine
         /// is ignored.</param>
         /// <param name="msbuildLocation"> Full path to current MSBuild.exe if executable is MSBuild.exe,
         /// or to version of MSBuild.dll found to be associated with the current process.</param>
+        /// <param name="multiThreaded">Whether this build is multithreaded (/mt).</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>A value of type <see cref="MSBuildApp.ExitType"/> that indicates whether the build succeeded,
         /// or the manner in which it failed.</returns>
-        public static MSBuildApp.ExitType Execute(string[] commandLineArgs, string msbuildLocation, CancellationToken cancellationToken)
+        public static MSBuildApp.ExitType Execute(string[] commandLineArgs, string msbuildLocation, bool multiThreaded, CancellationToken cancellationToken)
         {
-            MSBuildClient msbuildClient = new MSBuildClient(commandLineArgs, msbuildLocation);
+            MSBuildClient msbuildClient = new MSBuildClient(commandLineArgs, msbuildLocation, multiThreaded);
             MSBuildClientExitResult exitResult = msbuildClient.Execute(cancellationToken);
 
             if (exitResult.MSBuildClientExitType == MSBuildClientExitType.ServerBusy ||

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -313,13 +313,13 @@ namespace Microsoft.Build.CommandLine
             if (
                 Environment.GetEnvironmentVariable(Traits.UseMSBuildServerEnvVarName) == "1" &&
                 !Traits.Instance.EscapeHatches.EnsureStdOutForChildNodesIsPrimaryStdout &&
-                CanRunServerBasedOnCommandLineSwitches(args))
+                CanRunServerBasedOnCommandLineSwitches(args, out bool multiThreaded))
             {
                 Console.CancelKeyPress += Console_CancelKeyPress;
 
 
                 // Use the client app to execute build in msbuild server. Opt-in feature.
-                exitCode = ((s_initialized && MSBuildClientApp.Execute(args, s_buildCancellationSource.Token) == ExitType.Success) ? 0 : 1);
+                exitCode = ((s_initialized && MSBuildClientApp.Execute(args, multiThreaded, s_buildCancellationSource.Token) == ExitType.Success) ? 0 : 1);
             }
             else
             {
@@ -343,9 +343,10 @@ namespace Microsoft.Build.CommandLine
         /// <remarks>
         /// Will not throw. If arguments processing fails, we will not run it on server - no reason as it will not run any build anyway.
         /// </remarks>
-        private static bool CanRunServerBasedOnCommandLineSwitches(string[] commandLine)
+        private static bool CanRunServerBasedOnCommandLineSwitches(string[] commandLine, out bool multiThreaded)
         {
             bool canRunServer = true;
+            multiThreaded = false;
             try
             {
                 commandLineParser.GatherAllSwitches(
@@ -361,6 +362,11 @@ namespace Microsoft.Build.CommandLine
                 {
                     commandLineSwitches = CombineSwitchesRespectingPriority(switchesFromAutoResponseFile, switchesNotFromAutoResponseFile, fullCommandLine);
                 }
+
+                // Determine multithreaded mode from the fully-parsed switches (which include any
+                // response-file-provided switches) using the same logic as the in-proc build path.
+                multiThreaded = IsMultiThreadedEnabled(commandLineSwitches);
+
                 string projectFile = ProcessProjectSwitch(commandLineSwitches[CommandLineSwitches.ParameterizedSwitch.Project], commandLineSwitches[CommandLineSwitches.ParameterizedSwitch.IgnoreProjectExtensions], Directory.GetFiles);
                 if (commandLineSwitches[CommandLineSwitches.ParameterlessSwitch.Help] ||
                     commandLineSwitches.IsParameterizedSwitchSet(CommandLineSwitches.ParameterizedSwitch.NodeMode) ||


### PR DESCRIPTION
### Summary

Launch the MSBuild **server** process (the long-lived `/nodemode:8` process used when `MSBUILDUSESERVER=1`) with **Server GC**.

The server *hosts the build itself* — under a multithreaded (`/mt`) build it runs all project work on threads in a single process — so Server GC's higher throughput is beneficial. This is scoped to the server process only; sidecar TaskHosts and worker nodes keep the default Workstation GC.

The MSBuild server is experimental, so this is an unconditional change: no opt-out env var and no ChangeWave.

### Why this approach

GC mode is locked at CLR startup and can't be changed at runtime. The server node is a freshly spawned process whose launch environment we control in `MSBuildClient.TryLaunchServer`, so we inject `DOTNET_gcServer=1` there. We deliberately do **not** set `System.GC.Server` in `MSBuild.runtimeconfig.json`, because that file is shared by all roles (entry/worker/server/TaskHost) and would flip the sidecars too.

`DOTNET_gcServer` only affects .NET (CoreCLR) and, since .NET 9, takes precedence over `runtimeconfig.json`. On .NET Framework it is a no-op (Framework GC is `app.config`-driven), so this is effectively a .NET-Core-server optimization.

### Scoping / no leak to other nodes

Only the server launch sets the knob. Sidecar TaskHost (nodemode 2) and worker (nodemode 1) nodes are launched via separate code paths that never set it. Additionally, on the first build command the server resets its own environment to the client's (`OutOfProcServerNode` → `CommunicationsUtilities.SetEnvironment`), which removes `DOTNET_gcServer` before the server ever spawns children — so it can't leak via inheritance either. (As a side effect, `DOTNET_gcServer` reads back as null inside the server even though `IsServerGC` is true; the GC mode was already locked at startup.)

### Benchmark (local)

OrchardCore full solution (`OrchardCore.slnx`, 233 projects), `Rebuild -mt -m`, 16 cores, warm reused server, drift-controlled (baseline measured first and last):

| Config (order) | Median build (s) | Server peak working set |
|---|---|---|
| Workstation GC (1st) | 90.6 | 1903 MB |
| **Server GC** | **81.0** | 2165 MB |
| Workstation GC (last) | 93.9 | 1800 MB |

**~10–13% faster.** Every Server-GC iteration beat every Workstation iteration (no distribution overlap), and the last Workstation block was slower than the first, so machine drift worked *against* the result. Cost: ~+300 MB peak working set, as expected for Server GC.

### Tests

`src/MSBuild.UnitTests/MSBuildServer_Tests.cs` (gated `#if NET`; each test uses a unique `MSBUILDNODEHANDSHAKESALT` so no leftover server is reused, clears ambient GC env vars, and registers spawned PIDs for cleanup):

- `ServerProcessUsesServerGC` — server process reports `IsServerGC == true`.
- `TaskHostProcessDoesNotUseServerGC` — a TaskHost spawned by a Server-GC server reports `false`.
- `WorkerNodeDoesNotUseServerGC` — an out-of-proc worker reports `false`.

`GCSettings.IsServerGC` is surfaced through a new `[Output]` on the existing `ProcessIdTask`.

### Notes

- .NET Framework server is unaffected (`DOTNET_gcServer` is a no-op there); tests are `#if NET`.
- Behavior documented in `documentation/MSBuild-Server.md`.
- Draft — opening for design/feedback.
