### PR TITLE
[Experimental] Shared-memory transport for large node IPC payloads

### DIFF
--- a/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
@@ -1016,6 +1016,14 @@ namespace Microsoft.Build.BackEnd
             /// </summary>
             private readonly byte _negotiatedPacketVersion;
 
+#if NET
+            /// <summary>
+            /// Optional shared-memory channel used to transfer large packet bodies, bypassing the pipe.
+            /// Null unless the feature is enabled. See <see cref="NodeSharedMemoryChannel"/>.
+            /// </summary>
+            private readonly NodeSharedMemoryChannel _sharedChannel;
+#endif
+
 
 #if FEATURE_APM
             // used in BodyReadComplete callback to avoid allocations due to passing state through BeginRead
@@ -1046,6 +1054,12 @@ namespace Microsoft.Build.BackEnd
                 _terminateDelegate = terminateDelegate;
                 _handshakeOptions = handshakeOptions;
                 _negotiatedPacketVersion = negotiatedVersion;
+#if NET
+                if (NodeSharedMemoryChannel.FeatureEnabled)
+                {
+                    _sharedChannel = new NodeSharedMemoryChannel(process.Id, isParent: true);
+                }
+#endif
 #if FEATURE_APM
                 _headerReadCompleteCallback = HeaderReadComplete;
                 _bodyReadCompleteCallback = BodyReadComplete;
@@ -1107,27 +1121,58 @@ namespace Microsoft.Build.BackEnd
 
                     NodePacketType packetType = (NodePacketType)_headerByte[0];
                     int packetLength = BinaryPrimitives.ReadInt32LittleEndian(new Span<byte>(_headerByte, 1, 4));
+#if NET
+                    bool bodyInSharedMemory = _sharedChannel != null && (packetLength & NodeSharedMemoryChannel.SharedMemoryFlag) != 0;
+                    if (bodyInSharedMemory)
+                    {
+                        packetLength &= NodeSharedMemoryChannel.LengthMask;
+                    }
+#endif
 
                     _readBufferMemoryStream.SetLength(packetLength);
                     byte[] packetData = _readBufferMemoryStream.GetBuffer();
 
                     try
                     {
-                        int totalBytesRead = 0;
-                        while (totalBytesRead < packetLength)
+#if NET
+                        if (bodyInSharedMemory)
                         {
-                            int bytesRead = await _pipeStream.ReadAsync(packetData.AsMemory(totalBytesRead, packetLength - totalBytesRead), CancellationToken.None).ConfigureAwait(false);
-                            if (bytesRead == 0)
+                            long shmStart = IpcTransferStats.StartTimestamp();
+                            _sharedChannel.ReceivePayload(packetData, 0, packetLength);
+                            if (IpcTransferStats.Enabled)
                             {
-                                break;
+                                IpcTransferStats.RecordShmRecv(shmStart, packetLength);
+                            }
+                        }
+                        else
+#endif
+                        {
+#if NET
+                            bool measure = IpcTransferStats.Enabled && packetLength >= NodeSharedMemoryChannel.PayloadThreshold;
+                            long pipeStart = measure ? IpcTransferStats.StartTimestamp() : 0;
+#endif
+                            int totalBytesRead = 0;
+                            while (totalBytesRead < packetLength)
+                            {
+                                int bytesRead = await _pipeStream.ReadAsync(packetData.AsMemory(totalBytesRead, packetLength - totalBytesRead), CancellationToken.None).ConfigureAwait(false);
+                                if (bytesRead == 0)
+                                {
+                                    break;
+                                }
+
+                                totalBytesRead += bytesRead;
                             }
 
-                            totalBytesRead += bytesRead;
-                        }
-
-                        if (!ProcessBodyBytesRead(totalBytesRead, packetLength, packetType))
-                        {
-                            return;
+                            if (!ProcessBodyBytesRead(totalBytesRead, packetLength, packetType))
+                            {
+                                return;
+                            }
+#if NET
+                            if (measure)
+                            {
+                                IpcTransferStats.RecordPipeRead(pipeStart, packetLength);
+                            }
+#endif
                         }
                     }
                     catch (IOException e)
@@ -1219,18 +1264,53 @@ namespace Microsoft.Build.BackEnd
                             packet.Translate(writeTranslator);
 
                             int writeStreamLength = (int)writeStream.Position;
+                            int payloadLength = writeStreamLength - 5;
 
                             // Now plug in the real packet length
                             writeStream.Position = 1;
-                            WriteInt32(writeStream, writeStreamLength - 5);
 
                             byte[] writeStreamBuffer = writeStream.GetBuffer();
-
-                            for (int i = 0; i < writeStreamLength; i += MaxPacketWriteSize)
+#if NET
+                            if (context._sharedChannel != null && NodeSharedMemoryChannel.ShouldUseSharedMemory(payloadLength))
                             {
-                                int lengthToWrite = Math.Min(writeStreamLength - i, MaxPacketWriteSize);
+                                // Flag the length and deliver the payload through shared memory. The slot
+                                // must exist before the header reaches the pipe so the reader can open it
+                                // as soon as it observes the flag.
+                                WriteInt32(writeStream, payloadLength | NodeSharedMemoryChannel.SharedMemoryFlag);
+                                context._sharedChannel.EnsureOutgoingReady();
 
-                                serverToClientStream.Write(writeStreamBuffer, i, lengthToWrite);
+                                // Header first: the child can begin draining the slot as soon as it sees
+                                // the header, which minimizes producer backpressure on this thread (the
+                                // parent sends many configs back-to-back). Body-before-header was measured
+                                // ~25x slower here due to AcquireEmpty stalls.
+                                serverToClientStream.Write(writeStreamBuffer, 0, 5);
+                                long shmStart = IpcTransferStats.StartTimestamp();
+                                context._sharedChannel.SendPayload(writeStreamBuffer, 5, payloadLength);
+                                if (IpcTransferStats.Enabled)
+                                {
+                                    IpcTransferStats.RecordShmSend(shmStart, payloadLength);
+                                }
+                            }
+                            else
+#endif
+                            {
+                                WriteInt32(writeStream, payloadLength);
+#if NET
+                                bool measure = IpcTransferStats.Enabled && payloadLength >= NodeSharedMemoryChannel.PayloadThreshold;
+                                long pipeStart = measure ? IpcTransferStats.StartTimestamp() : 0;
+#endif
+                                for (int i = 0; i < writeStreamLength; i += MaxPacketWriteSize)
+                                {
+                                    int lengthToWrite = Math.Min(writeStreamLength - i, MaxPacketWriteSize);
+
+                                    serverToClientStream.Write(writeStreamBuffer, i, lengthToWrite);
+                                }
+#if NET
+                                if (measure)
+                                {
+                                    IpcTransferStats.RecordPipeWrite(pipeStart, payloadLength);
+                                }
+#endif
                             }
 
                             if (packet is NodeBuildComplete)
@@ -1278,6 +1358,9 @@ namespace Microsoft.Build.BackEnd
             /// </summary>
             private void Close()
             {
+#if NET
+                _sharedChannel?.Dispose();
+#endif
                 _pipeStream.Dispose();
                 _terminateDelegate(_nodeId);
             }

--- a/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
@@ -1128,6 +1128,9 @@ namespace Microsoft.Build.BackEnd
                         packetLength &= NodeSharedMemoryChannel.LengthMask;
                     }
 #endif
+#if NET
+                    IpcTransferStats.RecordReceive(packetType, packetLength);
+#endif
 
                     _readBufferMemoryStream.SetLength(packetLength);
                     byte[] packetData = _readBufferMemoryStream.GetBuffer();

--- a/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
@@ -1265,6 +1265,9 @@ namespace Microsoft.Build.BackEnd
 
                             int writeStreamLength = (int)writeStream.Position;
                             int payloadLength = writeStreamLength - 5;
+#if NET
+                            IpcTransferStats.RecordSend(packet, payloadLength);
+#endif
 
                             // Now plug in the real packet length
                             writeStream.Position = 1;

--- a/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
@@ -1128,9 +1128,6 @@ namespace Microsoft.Build.BackEnd
                         packetLength &= NodeSharedMemoryChannel.LengthMask;
                     }
 #endif
-#if NET
-                    IpcTransferStats.RecordReceive(packetType, packetLength);
-#endif
 
                     _readBufferMemoryStream.SetLength(packetLength);
                     byte[] packetData = _readBufferMemoryStream.GetBuffer();
@@ -1138,22 +1135,15 @@ namespace Microsoft.Build.BackEnd
                     try
                     {
 #if NET
+                        long recvStart = IpcTransferStats.StartTimestamp();
                         if (bodyInSharedMemory)
                         {
-                            long shmStart = IpcTransferStats.StartTimestamp();
                             _sharedChannel.ReceivePayload(packetData, 0, packetLength);
-                            if (IpcTransferStats.Enabled)
-                            {
-                                IpcTransferStats.RecordShmRecv(shmStart, packetLength);
-                            }
+                            IpcTransferStats.RecordReceive(packetType, packetLength, IpcTransferStats.Elapsed(recvStart), viaSharedMemory: true);
                         }
                         else
 #endif
                         {
-#if NET
-                            bool measure = IpcTransferStats.Enabled && packetLength >= NodeSharedMemoryChannel.PayloadThreshold;
-                            long pipeStart = measure ? IpcTransferStats.StartTimestamp() : 0;
-#endif
                             int totalBytesRead = 0;
                             while (totalBytesRead < packetLength)
                             {
@@ -1171,10 +1161,7 @@ namespace Microsoft.Build.BackEnd
                                 return;
                             }
 #if NET
-                            if (measure)
-                            {
-                                IpcTransferStats.RecordPipeRead(pipeStart, packetLength);
-                            }
+                            IpcTransferStats.RecordReceive(packetType, packetLength, IpcTransferStats.Elapsed(recvStart), viaSharedMemory: false);
 #endif
                         }
                     }
@@ -1268,17 +1255,18 @@ namespace Microsoft.Build.BackEnd
 
                             int writeStreamLength = (int)writeStream.Position;
                             int payloadLength = writeStreamLength - 5;
-#if NET
-                            IpcTransferStats.RecordSend(packet, payloadLength);
-#endif
 
                             // Now plug in the real packet length
                             writeStream.Position = 1;
 
                             byte[] writeStreamBuffer = writeStream.GetBuffer();
 #if NET
-                            if (context._sharedChannel != null && NodeSharedMemoryChannel.ShouldUseSharedMemory(payloadLength))
+                            long sendStart = IpcTransferStats.StartTimestamp();
+                            bool sentViaShm = false;
+                            if (context._sharedChannel != null && context._sharedChannel.ShouldSendViaSharedMemory(payloadLength))
                             {
+                                sentViaShm = true;
+
                                 // Flag the length and deliver the payload through shared memory. The slot
                                 // must exist before the header reaches the pipe so the reader can open it
                                 // as soon as it observes the flag.
@@ -1290,34 +1278,22 @@ namespace Microsoft.Build.BackEnd
                                 // parent sends many configs back-to-back). Body-before-header was measured
                                 // ~25x slower here due to AcquireEmpty stalls.
                                 serverToClientStream.Write(writeStreamBuffer, 0, 5);
-                                long shmStart = IpcTransferStats.StartTimestamp();
                                 context._sharedChannel.SendPayload(writeStreamBuffer, 5, payloadLength);
-                                if (IpcTransferStats.Enabled)
-                                {
-                                    IpcTransferStats.RecordShmSend(shmStart, payloadLength);
-                                }
                             }
                             else
 #endif
                             {
                                 WriteInt32(writeStream, payloadLength);
-#if NET
-                                bool measure = IpcTransferStats.Enabled && payloadLength >= NodeSharedMemoryChannel.PayloadThreshold;
-                                long pipeStart = measure ? IpcTransferStats.StartTimestamp() : 0;
-#endif
                                 for (int i = 0; i < writeStreamLength; i += MaxPacketWriteSize)
                                 {
                                     int lengthToWrite = Math.Min(writeStreamLength - i, MaxPacketWriteSize);
 
                                     serverToClientStream.Write(writeStreamBuffer, i, lengthToWrite);
                                 }
-#if NET
-                                if (measure)
-                                {
-                                    IpcTransferStats.RecordPipeWrite(pipeStart, payloadLength);
-                                }
-#endif
                             }
+#if NET
+                            IpcTransferStats.RecordSend(packet, payloadLength, IpcTransferStats.Elapsed(sendStart), sentViaShm);
+#endif
 
                             if (packet is NodeBuildComplete)
                             {

--- a/src/Build/Microsoft.Build.csproj
+++ b/src/Build/Microsoft.Build.csproj
@@ -105,6 +105,8 @@
     <Compile Include="..\Shared\NodeEngineShutdownReason.cs" />
     <Compile Include="..\Shared\INodeEndpoint.cs" />
     <Compile Include="..\Shared\NodeEndpointOutOfProcBase.cs" />
+    <Compile Include="..\Shared\NodeSharedMemoryChannel.cs" />
+    <Compile Include="..\Shared\IpcTransferStats.cs" />
     <Compile Include="..\Shared\INodePacketFactory.cs" />
     <Compile Include="..\Shared\INodePacketHandler.cs" />
     <Compile Include="..\Shared\LogMessagePacketBase.cs" />

--- a/src/MSBuild/MSBuild.csproj
+++ b/src/MSBuild/MSBuild.csproj
@@ -64,6 +64,7 @@
     <Compile Include="..\GlobalUsings.cs" Link="GlobalUsings.cs" />
     <Compile Include="..\Shared\INodeEndpoint.cs" />
     <Compile Include="..\Shared\NodeEndpointOutOfProcBase.cs" />
+    <Compile Include="..\Shared\NodeSharedMemoryChannel.cs" />
     <Compile Include="..\Shared\LogMessagePacketBase.cs" />
     <Compile Include="..\Shared\INodePacketFactory.cs" />
     <Compile Include="..\Shared\NodePacketFactory.cs" />

--- a/src/Shared/IpcTransferStats.cs
+++ b/src/Shared/IpcTransferStats.cs
@@ -20,8 +20,8 @@ namespace Microsoft.Build.Internal
     /// shared memory) and by direction (send vs receive). Enabled with <c>MSBUILDIPCSTATS=1</c>.
     /// </summary>
     /// <remarks>
-    /// Only payloads at or above <see cref="NodeSharedMemoryChannel.PayloadThreshold"/> are timed, so
-    /// the same set of packets is compared whether or not the shared-memory feature is on. The hot
+    /// Only payloads at or above the direction-specific threshold are diverted, so the same set of
+    /// packets is compared whether or not the shared-memory feature is on. The hot
     /// path is a single <see cref="Stopwatch.GetTimestamp"/> pair plus a few interlocked adds. Totals
     /// are written to the file named by <c>MSBUILDIPCSTATSFILE</c> (or the comm trace) at process exit.
     /// </remarks>
@@ -46,8 +46,8 @@ namespace Microsoft.Build.Internal
         private static long s_shmRecvBytes;
         private static long s_shmRecvCount;
 
-        // Per-packet-type and per-task breakdown of EVERY sent packet (regardless of size), to
-        // answer "which packets / which tasks are big". Keyed by packet type name and task name.
+        // Per-packet-type and per-task breakdown of EVERY sent packet (regardless of size), with
+        // time split by mechanism (pipe vs shm), to answer "which tasks improve by how much".
         private static readonly ConcurrentDictionary<string, SizeBucket> s_byPacketType = new(StringComparer.Ordinal);
         private static readonly ConcurrentDictionary<string, SizeBucket> s_byTask = new(StringComparer.Ordinal);
 
@@ -66,67 +66,66 @@ namespace Microsoft.Build.Internal
 
         internal static long StartTimestamp() => Enabled ? Stopwatch.GetTimestamp() : 0;
 
-        internal static void RecordPipeWrite(long startTimestamp, int bytes)
-        {
-            Interlocked.Add(ref s_pipeWriteTicks, Stopwatch.GetTimestamp() - startTimestamp);
-            Interlocked.Add(ref s_pipeWriteBytes, bytes);
-            Interlocked.Increment(ref s_pipeWriteCount);
-        }
-
-        internal static void RecordPipeRead(long startTimestamp, int bytes)
-        {
-            Interlocked.Add(ref s_pipeReadTicks, Stopwatch.GetTimestamp() - startTimestamp);
-            Interlocked.Add(ref s_pipeReadBytes, bytes);
-            Interlocked.Increment(ref s_pipeReadCount);
-        }
-
-        internal static void RecordShmSend(long startTimestamp, int bytes)
-        {
-            Interlocked.Add(ref s_shmSendTicks, Stopwatch.GetTimestamp() - startTimestamp);
-            Interlocked.Add(ref s_shmSendBytes, bytes);
-            Interlocked.Increment(ref s_shmSendCount);
-        }
-
-        internal static void RecordShmRecv(long startTimestamp, int bytes)
-        {
-            Interlocked.Add(ref s_shmRecvTicks, Stopwatch.GetTimestamp() - startTimestamp);
-            Interlocked.Add(ref s_shmRecvBytes, bytes);
-            Interlocked.Increment(ref s_shmRecvCount);
-        }
+        internal static long Elapsed(long startTimestamp) => Stopwatch.GetTimestamp() - startTimestamp;
 
         /// <summary>
-        /// Records the type and size of every packet sent (any size), plus the task name when the
-        /// packet is a <see cref="TaskHostConfiguration"/>, so we can report which packet types and
-        /// which tasks dominate the payload.
+        /// Records a packet sent (parent -&gt; child): aggregate mechanism totals plus per-type and
+        /// per-task (for <see cref="TaskHostConfiguration"/>) bytes and time, split by mechanism.
         /// </summary>
-        internal static void RecordSend(INodePacket packet, int payloadLength)
+        internal static void RecordSend(INodePacket packet, int payloadLength, long elapsedTicks, bool viaSharedMemory)
         {
             if (!Enabled)
             {
                 return;
             }
 
-            s_byPacketType.GetOrAdd(packet.Type.ToString(), static _ => new SizeBucket()).Add(payloadLength);
+            if (viaSharedMemory)
+            {
+                Interlocked.Add(ref s_shmSendTicks, elapsedTicks);
+                Interlocked.Add(ref s_shmSendBytes, payloadLength);
+                Interlocked.Increment(ref s_shmSendCount);
+            }
+            else
+            {
+                Interlocked.Add(ref s_pipeWriteTicks, elapsedTicks);
+                Interlocked.Add(ref s_pipeWriteBytes, payloadLength);
+                Interlocked.Increment(ref s_pipeWriteCount);
+            }
+
+            s_byPacketType.GetOrAdd(packet.Type.ToString(), static _ => new SizeBucket()).Add(payloadLength, elapsedTicks, viaSharedMemory);
 
             if (packet is TaskHostConfiguration config)
             {
                 string taskName = string.IsNullOrEmpty(config.TaskName) ? "(unknown)" : config.TaskName;
-                s_byTask.GetOrAdd(taskName, static _ => new SizeBucket()).Add(payloadLength);
+                s_byTask.GetOrAdd(taskName, static _ => new SizeBucket()).Add(payloadLength, elapsedTicks, viaSharedMemory);
             }
         }
 
         /// <summary>
-        /// Records the type and size of every packet received (parent &lt;- child), so we can report
-        /// the logging and task-output traffic that flows back from TaskHosts.
+        /// Records a packet received (parent &lt;- child): aggregate mechanism totals plus per-type
+        /// bytes and time (logging + task outputs), split by mechanism.
         /// </summary>
-        internal static void RecordReceive(NodePacketType packetType, int payloadLength)
+        internal static void RecordReceive(NodePacketType packetType, int payloadLength, long elapsedTicks, bool viaSharedMemory)
         {
             if (!Enabled)
             {
                 return;
             }
 
-            s_recvByPacketType.GetOrAdd(packetType.ToString(), static _ => new SizeBucket()).Add(payloadLength);
+            if (viaSharedMemory)
+            {
+                Interlocked.Add(ref s_shmRecvTicks, elapsedTicks);
+                Interlocked.Add(ref s_shmRecvBytes, payloadLength);
+                Interlocked.Increment(ref s_shmRecvCount);
+            }
+            else
+            {
+                Interlocked.Add(ref s_pipeReadTicks, elapsedTicks);
+                Interlocked.Add(ref s_pipeReadBytes, payloadLength);
+                Interlocked.Increment(ref s_pipeReadCount);
+            }
+
+            s_recvByPacketType.GetOrAdd(packetType.ToString(), static _ => new SizeBucket()).Add(payloadLength, elapsedTicks, viaSharedMemory);
         }
 
         internal static void Dump()
@@ -169,16 +168,16 @@ namespace Microsoft.Build.Internal
 
             int pid = Environment.ProcessId;
             var sb = new StringBuilder();
-            sb.AppendLine($"IPCSTATS pid={pid} (large-packet body transfer, threshold={NodeSharedMemoryChannel.PayloadThreshold} bytes)");
+            sb.AppendLine($"IPCSTATS pid={pid} sendThr={NodeSharedMemoryChannel.SendThreshold} returnThr={NodeSharedMemoryChannel.ReturnThreshold} slot={NodeSharedMemoryChannel.SlotCapacity} shmEnabled={NodeSharedMemoryChannel.FeatureEnabled}");
             sb.AppendLine(line("pipe-write", s_pipeWriteCount, s_pipeWriteBytes, s_pipeWriteTicks));
             sb.AppendLine(line("pipe-read", s_pipeReadCount, s_pipeReadBytes, s_pipeReadTicks));
             sb.AppendLine(line("shm-send", s_shmSendCount, s_shmSendBytes, s_shmSendTicks));
             sb.AppendLine(line("shm-recv", s_shmRecvCount, s_shmRecvBytes, s_shmRecvTicks));
-            sb.AppendLine($"  pipe total time = {ms(s_pipeWriteTicks + s_pipeReadTicks):N2} ms; shm total time = {ms(s_shmSendTicks + s_shmRecvTicks):N2} ms");
+            sb.AppendLine($"  send total time = {ms(s_pipeWriteTicks + s_shmSendTicks):N2} ms; recv total time = {ms(s_pipeReadTicks + s_shmRecvTicks):N2} ms; ALL = {ms(s_pipeWriteTicks + s_shmSendTicks + s_pipeReadTicks + s_shmRecvTicks):N2} ms");
 
-            AppendBreakdown(sb, "SENT PACKETS BY TYPE (parent -> child, all sizes)", s_byPacketType);
-            AppendBreakdown(sb, "SENT TaskHostConfiguration BY TASK (all sizes)", s_byTask);
-            AppendBreakdown(sb, "RECEIVED PACKETS BY TYPE (parent <- child, all sizes)", s_recvByPacketType);
+            AppendBreakdown(sb, "SENT PACKETS BY TYPE (parent -> child)", s_byPacketType);
+            AppendBreakdown(sb, "SENT TaskHostConfiguration BY TASK", s_byTask);
+            AppendBreakdown(sb, "RECEIVED PACKETS BY TYPE (parent <- child)", s_recvByPacketType);
             return sb.ToString().TrimEnd();
         }
 
@@ -189,20 +188,23 @@ namespace Microsoft.Build.Internal
                 return;
             }
 
+            double ms(long ticks) => ticks * 1000.0 / Stopwatch.Frequency;
             sb.AppendLine($"  --- {title} ---");
-            sb.AppendLine(string.Format(CultureInfo.InvariantCulture, "    {0,-40} {1,7} {2,15} {3,11} {4,11}", "name", "count", "total bytes", "avg bytes", "max bytes"));
+            sb.AppendLine(string.Format(CultureInfo.InvariantCulture, "    {0,-42} {1,7} {2,14} {3,10} {4,10} {5,11} {6,11}", "name", "count", "total bytes", "avg", "max", "pipe ms", "shm ms"));
             foreach (var kvp in map.OrderByDescending(p => p.Value.TotalBytes))
             {
                 SizeBucket b = kvp.Value;
                 long count = b.Count;
                 sb.AppendLine(string.Format(
                     CultureInfo.InvariantCulture,
-                    "    {0,-40} {1,7} {2,15:N0} {3,11:N0} {4,11:N0}",
-                    kvp.Key.Length <= 40 ? kvp.Key : kvp.Key.Substring(0, 39) + "…",
+                    "    {0,-42} {1,7} {2,14:N0} {3,10:N0} {4,10:N0} {5,11:N2} {6,11:N2}",
+                    kvp.Key.Length <= 42 ? kvp.Key : kvp.Key.Substring(0, 41) + "…",
                     count,
                     b.TotalBytes,
                     count > 0 ? b.TotalBytes / count : 0,
-                    b.MaxBytes));
+                    b.MaxBytes,
+                    ms(b.PipeTicks),
+                    ms(b.ShmTicks)));
             }
         }
 
@@ -211,6 +213,8 @@ namespace Microsoft.Build.Internal
             private long _count;
             private long _totalBytes;
             private long _maxBytes;
+            private long _pipeTicks;
+            private long _shmTicks;
 
             internal long Count => Interlocked.Read(ref _count);
 
@@ -218,10 +222,15 @@ namespace Microsoft.Build.Internal
 
             internal long MaxBytes => Interlocked.Read(ref _maxBytes);
 
-            internal void Add(int bytes)
+            internal long PipeTicks => Interlocked.Read(ref _pipeTicks);
+
+            internal long ShmTicks => Interlocked.Read(ref _shmTicks);
+
+            internal void Add(int bytes, long ticks, bool viaSharedMemory)
             {
                 Interlocked.Increment(ref _count);
                 Interlocked.Add(ref _totalBytes, bytes);
+                Interlocked.Add(ref viaSharedMemory ? ref _shmTicks : ref _pipeTicks, ticks);
 
                 long current = Interlocked.Read(ref _maxBytes);
                 while (bytes > current)

--- a/src/Shared/IpcTransferStats.cs
+++ b/src/Shared/IpcTransferStats.cs
@@ -3,10 +3,14 @@
 
 #if NET
 using System;
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
+using System.Linq;
+using System.Text;
 using System.Threading;
+using Microsoft.Build.BackEnd;
 
 namespace Microsoft.Build.Internal
 {
@@ -41,6 +45,11 @@ namespace Microsoft.Build.Internal
         private static long s_shmRecvTicks;
         private static long s_shmRecvBytes;
         private static long s_shmRecvCount;
+
+        // Per-packet-type and per-task breakdown of EVERY sent packet (regardless of size), to
+        // answer "which packets / which tasks are big". Keyed by packet type name and task name.
+        private static readonly ConcurrentDictionary<string, SizeBucket> s_byPacketType = new(StringComparer.Ordinal);
+        private static readonly ConcurrentDictionary<string, SizeBucket> s_byTask = new(StringComparer.Ordinal);
 
         private static int s_dumped;
 
@@ -82,6 +91,27 @@ namespace Microsoft.Build.Internal
             Interlocked.Increment(ref s_shmRecvCount);
         }
 
+        /// <summary>
+        /// Records the type and size of every packet sent (any size), plus the task name when the
+        /// packet is a <see cref="TaskHostConfiguration"/>, so we can report which packet types and
+        /// which tasks dominate the payload.
+        /// </summary>
+        internal static void RecordSend(INodePacket packet, int payloadLength)
+        {
+            if (!Enabled)
+            {
+                return;
+            }
+
+            s_byPacketType.GetOrAdd(packet.Type.ToString(), static _ => new SizeBucket()).Add(payloadLength);
+
+            if (packet is TaskHostConfiguration config)
+            {
+                string taskName = string.IsNullOrEmpty(config.TaskName) ? "(unknown)" : config.TaskName;
+                s_byTask.GetOrAdd(taskName, static _ => new SizeBucket()).Add(payloadLength);
+            }
+        }
+
         internal static void Dump()
         {
             if (!Enabled || Interlocked.Exchange(ref s_dumped, 1) != 0)
@@ -121,14 +151,72 @@ namespace Microsoft.Build.Internal
                     ms(ticks) > 0 ? (bytes / 1024.0 / 1024.0) / (ms(ticks) / 1000.0) : 0);
 
             int pid = Environment.ProcessId;
-            return string.Join(
-                Environment.NewLine,
-                $"IPCSTATS pid={pid} (large-packet body transfer, threshold={NodeSharedMemoryChannel.PayloadThreshold} bytes)",
-                line("pipe-write", s_pipeWriteCount, s_pipeWriteBytes, s_pipeWriteTicks),
-                line("pipe-read", s_pipeReadCount, s_pipeReadBytes, s_pipeReadTicks),
-                line("shm-send", s_shmSendCount, s_shmSendBytes, s_shmSendTicks),
-                line("shm-recv", s_shmRecvCount, s_shmRecvBytes, s_shmRecvTicks),
-                $"  pipe total time = {ms(s_pipeWriteTicks + s_pipeReadTicks):N2} ms; shm total time = {ms(s_shmSendTicks + s_shmRecvTicks):N2} ms");
+            var sb = new StringBuilder();
+            sb.AppendLine($"IPCSTATS pid={pid} (large-packet body transfer, threshold={NodeSharedMemoryChannel.PayloadThreshold} bytes)");
+            sb.AppendLine(line("pipe-write", s_pipeWriteCount, s_pipeWriteBytes, s_pipeWriteTicks));
+            sb.AppendLine(line("pipe-read", s_pipeReadCount, s_pipeReadBytes, s_pipeReadTicks));
+            sb.AppendLine(line("shm-send", s_shmSendCount, s_shmSendBytes, s_shmSendTicks));
+            sb.AppendLine(line("shm-recv", s_shmRecvCount, s_shmRecvBytes, s_shmRecvTicks));
+            sb.AppendLine($"  pipe total time = {ms(s_pipeWriteTicks + s_pipeReadTicks):N2} ms; shm total time = {ms(s_shmSendTicks + s_shmRecvTicks):N2} ms");
+
+            AppendBreakdown(sb, "SENT PACKETS BY TYPE (all sizes)", s_byPacketType);
+            AppendBreakdown(sb, "SENT TaskHostConfiguration BY TASK (all sizes)", s_byTask);
+            return sb.ToString().TrimEnd();
+        }
+
+        private static void AppendBreakdown(StringBuilder sb, string title, ConcurrentDictionary<string, SizeBucket> map)
+        {
+            if (map.IsEmpty)
+            {
+                return;
+            }
+
+            sb.AppendLine($"  --- {title} ---");
+            sb.AppendLine(string.Format(CultureInfo.InvariantCulture, "    {0,-40} {1,7} {2,15} {3,11} {4,11}", "name", "count", "total bytes", "avg bytes", "max bytes"));
+            foreach (var kvp in map.OrderByDescending(p => p.Value.TotalBytes))
+            {
+                SizeBucket b = kvp.Value;
+                long count = b.Count;
+                sb.AppendLine(string.Format(
+                    CultureInfo.InvariantCulture,
+                    "    {0,-40} {1,7} {2,15:N0} {3,11:N0} {4,11:N0}",
+                    kvp.Key.Length <= 40 ? kvp.Key : kvp.Key.Substring(0, 39) + "…",
+                    count,
+                    b.TotalBytes,
+                    count > 0 ? b.TotalBytes / count : 0,
+                    b.MaxBytes));
+            }
+        }
+
+        private sealed class SizeBucket
+        {
+            private long _count;
+            private long _totalBytes;
+            private long _maxBytes;
+
+            internal long Count => Interlocked.Read(ref _count);
+
+            internal long TotalBytes => Interlocked.Read(ref _totalBytes);
+
+            internal long MaxBytes => Interlocked.Read(ref _maxBytes);
+
+            internal void Add(int bytes)
+            {
+                Interlocked.Increment(ref _count);
+                Interlocked.Add(ref _totalBytes, bytes);
+
+                long current = Interlocked.Read(ref _maxBytes);
+                while (bytes > current)
+                {
+                    long prior = Interlocked.CompareExchange(ref _maxBytes, bytes, current);
+                    if (prior == current)
+                    {
+                        break;
+                    }
+
+                    current = prior;
+                }
+            }
         }
     }
 }

--- a/src/Shared/IpcTransferStats.cs
+++ b/src/Shared/IpcTransferStats.cs
@@ -1,0 +1,135 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#if NET
+using System;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.Threading;
+
+namespace Microsoft.Build.Internal
+{
+    /// <summary>
+    /// Opt-in, low-overhead instrumentation that measures the wall-clock time the engine spends
+    /// transferring large packet bodies over the node transport, split by mechanism (named pipe vs
+    /// shared memory) and by direction (send vs receive). Enabled with <c>MSBUILDIPCSTATS=1</c>.
+    /// </summary>
+    /// <remarks>
+    /// Only payloads at or above <see cref="NodeSharedMemoryChannel.PayloadThreshold"/> are timed, so
+    /// the same set of packets is compared whether or not the shared-memory feature is on. The hot
+    /// path is a single <see cref="Stopwatch.GetTimestamp"/> pair plus a few interlocked adds. Totals
+    /// are written to the file named by <c>MSBUILDIPCSTATSFILE</c> (or the comm trace) at process exit.
+    /// </remarks>
+    internal static class IpcTransferStats
+    {
+        internal static readonly bool Enabled =
+            Environment.GetEnvironmentVariable("MSBUILDIPCSTATS") == "1";
+
+        private static long s_pipeWriteTicks;
+        private static long s_pipeWriteBytes;
+        private static long s_pipeWriteCount;
+
+        private static long s_pipeReadTicks;
+        private static long s_pipeReadBytes;
+        private static long s_pipeReadCount;
+
+        private static long s_shmSendTicks;
+        private static long s_shmSendBytes;
+        private static long s_shmSendCount;
+
+        private static long s_shmRecvTicks;
+        private static long s_shmRecvBytes;
+        private static long s_shmRecvCount;
+
+        private static int s_dumped;
+
+        static IpcTransferStats()
+        {
+            if (Enabled)
+            {
+                AppDomain.CurrentDomain.ProcessExit += static (_, _) => Dump();
+            }
+        }
+
+        internal static long StartTimestamp() => Enabled ? Stopwatch.GetTimestamp() : 0;
+
+        internal static void RecordPipeWrite(long startTimestamp, int bytes)
+        {
+            Interlocked.Add(ref s_pipeWriteTicks, Stopwatch.GetTimestamp() - startTimestamp);
+            Interlocked.Add(ref s_pipeWriteBytes, bytes);
+            Interlocked.Increment(ref s_pipeWriteCount);
+        }
+
+        internal static void RecordPipeRead(long startTimestamp, int bytes)
+        {
+            Interlocked.Add(ref s_pipeReadTicks, Stopwatch.GetTimestamp() - startTimestamp);
+            Interlocked.Add(ref s_pipeReadBytes, bytes);
+            Interlocked.Increment(ref s_pipeReadCount);
+        }
+
+        internal static void RecordShmSend(long startTimestamp, int bytes)
+        {
+            Interlocked.Add(ref s_shmSendTicks, Stopwatch.GetTimestamp() - startTimestamp);
+            Interlocked.Add(ref s_shmSendBytes, bytes);
+            Interlocked.Increment(ref s_shmSendCount);
+        }
+
+        internal static void RecordShmRecv(long startTimestamp, int bytes)
+        {
+            Interlocked.Add(ref s_shmRecvTicks, Stopwatch.GetTimestamp() - startTimestamp);
+            Interlocked.Add(ref s_shmRecvBytes, bytes);
+            Interlocked.Increment(ref s_shmRecvCount);
+        }
+
+        internal static void Dump()
+        {
+            if (!Enabled || Interlocked.Exchange(ref s_dumped, 1) != 0)
+            {
+                return;
+            }
+
+            string report = BuildReport();
+
+            string? file = Environment.GetEnvironmentVariable("MSBUILDIPCSTATSFILE");
+            if (!string.IsNullOrEmpty(file))
+            {
+                try
+                {
+                    File.AppendAllText(file, report + Environment.NewLine);
+                }
+                catch (IOException)
+                {
+                    CommunicationsUtilities.Trace($"IPC stats: failed to write '{file}'.");
+                }
+            }
+
+            CommunicationsUtilities.Trace($"IPC transfer stats:{Environment.NewLine}{report}");
+        }
+
+        private static string BuildReport()
+        {
+            double ms(long ticks) => ticks * 1000.0 / Stopwatch.Frequency;
+            string line(string name, long count, long bytes, long ticks) =>
+                string.Format(
+                    CultureInfo.InvariantCulture,
+                    "  {0,-10} count={1,6} bytes={2,12:N0} time={3,10:N2} ms  ({4:N1} MB/s)",
+                    name,
+                    count,
+                    bytes,
+                    ms(ticks),
+                    ms(ticks) > 0 ? (bytes / 1024.0 / 1024.0) / (ms(ticks) / 1000.0) : 0);
+
+            int pid = Environment.ProcessId;
+            return string.Join(
+                Environment.NewLine,
+                $"IPCSTATS pid={pid} (large-packet body transfer, threshold={NodeSharedMemoryChannel.PayloadThreshold} bytes)",
+                line("pipe-write", s_pipeWriteCount, s_pipeWriteBytes, s_pipeWriteTicks),
+                line("pipe-read", s_pipeReadCount, s_pipeReadBytes, s_pipeReadTicks),
+                line("shm-send", s_shmSendCount, s_shmSendBytes, s_shmSendTicks),
+                line("shm-recv", s_shmRecvCount, s_shmRecvBytes, s_shmRecvTicks),
+                $"  pipe total time = {ms(s_pipeWriteTicks + s_pipeReadTicks):N2} ms; shm total time = {ms(s_shmSendTicks + s_shmRecvTicks):N2} ms");
+        }
+    }
+}
+#endif

--- a/src/Shared/IpcTransferStats.cs
+++ b/src/Shared/IpcTransferStats.cs
@@ -51,6 +51,9 @@ namespace Microsoft.Build.Internal
         private static readonly ConcurrentDictionary<string, SizeBucket> s_byPacketType = new(StringComparer.Ordinal);
         private static readonly ConcurrentDictionary<string, SizeBucket> s_byTask = new(StringComparer.Ordinal);
 
+        // Per-packet-type breakdown of EVERY received packet (parent <- child: logging + outputs).
+        private static readonly ConcurrentDictionary<string, SizeBucket> s_recvByPacketType = new(StringComparer.Ordinal);
+
         private static int s_dumped;
 
         static IpcTransferStats()
@@ -112,6 +115,20 @@ namespace Microsoft.Build.Internal
             }
         }
 
+        /// <summary>
+        /// Records the type and size of every packet received (parent &lt;- child), so we can report
+        /// the logging and task-output traffic that flows back from TaskHosts.
+        /// </summary>
+        internal static void RecordReceive(NodePacketType packetType, int payloadLength)
+        {
+            if (!Enabled)
+            {
+                return;
+            }
+
+            s_recvByPacketType.GetOrAdd(packetType.ToString(), static _ => new SizeBucket()).Add(payloadLength);
+        }
+
         internal static void Dump()
         {
             if (!Enabled || Interlocked.Exchange(ref s_dumped, 1) != 0)
@@ -159,8 +176,9 @@ namespace Microsoft.Build.Internal
             sb.AppendLine(line("shm-recv", s_shmRecvCount, s_shmRecvBytes, s_shmRecvTicks));
             sb.AppendLine($"  pipe total time = {ms(s_pipeWriteTicks + s_pipeReadTicks):N2} ms; shm total time = {ms(s_shmSendTicks + s_shmRecvTicks):N2} ms");
 
-            AppendBreakdown(sb, "SENT PACKETS BY TYPE (all sizes)", s_byPacketType);
+            AppendBreakdown(sb, "SENT PACKETS BY TYPE (parent -> child, all sizes)", s_byPacketType);
             AppendBreakdown(sb, "SENT TaskHostConfiguration BY TASK (all sizes)", s_byTask);
+            AppendBreakdown(sb, "RECEIVED PACKETS BY TYPE (parent <- child, all sizes)", s_recvByPacketType);
             return sb.ToString().TrimEnd();
         }
 

--- a/src/Shared/NodeEndpointOutOfProcBase.cs
+++ b/src/Shared/NodeEndpointOutOfProcBase.cs
@@ -46,9 +46,18 @@ namespace Microsoft.Build.BackEnd
 #endif // NETCOREAPP2_1
 
         /// <summary>
-        /// The size of the buffers to use for named pipes
+        /// The size of the buffers to use for named pipes. Tunable via MSBUILDPIPEBUFFERSIZE for
+        /// experiments with the pipe-only (no shared-memory) transport.
         /// </summary>
-        private const int PipeBufferSize = 131072;
+        private static readonly int PipeBufferSize = GetPipeBufferSize();
+
+        private static int GetPipeBufferSize()
+        {
+            string value = Environment.GetEnvironmentVariable("MSBUILDPIPEBUFFERSIZE");
+            return !string.IsNullOrEmpty(value) && int.TryParse(value, out int parsed) && parsed > 0
+                ? parsed
+                : 131072;
+        }
 
         /// <summary>
         /// The current communication status of the node.

--- a/src/Shared/NodeEndpointOutOfProcBase.cs
+++ b/src/Shared/NodeEndpointOutOfProcBase.cs
@@ -118,6 +118,19 @@ namespace Microsoft.Build.BackEnd
         /// </summary>
         private BinaryWriter _binaryWriter;
 
+#if NET
+        /// <summary>
+        /// Optional shared-memory channel used to transfer large packet bodies, bypassing the pipe.
+        /// Null unless the feature is enabled. See <see cref="NodeSharedMemoryChannel"/>.
+        /// </summary>
+        private NodeSharedMemoryChannel _sharedChannel;
+
+        /// <summary>
+        /// Reusable buffer for deserializing a packet body that arrived via shared memory.
+        /// </summary>
+        private MemoryStream _shmReadStream;
+#endif
+
         /// <summary>
         /// Represents the version of the parent packet associated with the node instantiation.
         /// </summary>
@@ -518,12 +531,24 @@ namespace Microsoft.Build.BackEnd
                 }
             }
 
+#if NET
+            if (NodeSharedMemoryChannel.FeatureEnabled)
+            {
+                _sharedChannel = new NodeSharedMemoryChannel(Environment.ProcessId, isParent: false);
+            }
+#endif
+
             RunReadLoop(
                 new BufferedReadStream(_pipeServer),
                 _pipeServer,
                 localPacketQueue, localPacketAvailable, localTerminatePacketPump);
 
             CommunicationsUtilities.Trace("Ending read loop");
+
+#if NET
+            _sharedChannel?.Dispose();
+            _sharedChannel = null;
+#endif
 
             try
             {
@@ -697,15 +722,32 @@ namespace Microsoft.Build.BackEnd
                             bool hasExtendedHeader = NodePacketTypeExtensions.HasExtendedHeader(rawType);
                             NodePacketType packetType = hasExtendedHeader ? NodePacketTypeExtensions.GetNodePacketType(rawType) : (NodePacketType)rawType;
 
+                            // By default the payload (optional version byte + body) follows the header
+                            // inline on the pipe. For large payloads the writer instead delivers it via
+                            // shared memory and flags the length field; in that case we read it here.
+                            Stream payloadStream = localReadPipe;
+#if NET
+                            int lengthField = headerByte[1] | (headerByte[2] << 8) | (headerByte[3] << 16) | (headerByte[4] << 24);
+                            if (_sharedChannel != null && (lengthField & NodeSharedMemoryChannel.SharedMemoryFlag) != 0)
+                            {
+                                int payloadLength = lengthField & NodeSharedMemoryChannel.LengthMask;
+                                _shmReadStream ??= new MemoryStream();
+                                _shmReadStream.SetLength(payloadLength);
+                                _shmReadStream.Position = 0;
+                                _sharedChannel.ReceivePayload(_shmReadStream.GetBuffer(), 0, payloadLength);
+                                payloadStream = _shmReadStream;
+                            }
+#endif
+
                             byte parentVersion = 0;
                             if (hasExtendedHeader)
                             {
-                                parentVersion = NodePacketTypeExtensions.ReadVersion(localReadPipe);
+                                parentVersion = NodePacketTypeExtensions.ReadVersion(payloadStream);
                             }
 
                             try
                             {
-                                ITranslator readTranslator = BinaryTranslator.GetReadTranslator(localReadPipe, _sharedReadBuffer);
+                                ITranslator readTranslator = BinaryTranslator.GetReadTranslator(payloadStream, _sharedReadBuffer);
 
                                 // parent sends a packet version that is already negotiated during handshake.
                                 // For Framework task hosts (CLR2/CLR4) without extended headers, defaults to 0.
@@ -764,12 +806,37 @@ namespace Microsoft.Build.BackEnd
                                 packet.Translate(writeTranslator);
 
                                 int packetStreamLength = (int)packetStream.Position;
+                                int payloadLength = packetStreamLength - 5;
 
                                 // Now write in the actual packet length
                                 packetStream.Position = 1;
-                                _binaryWriter.Write(packetStreamLength - 5);
-
-                                localWritePipe.Write(packetStream.GetBuffer(), 0, packetStreamLength);
+#if NET
+                                if (_sharedChannel != null && NodeSharedMemoryChannel.ShouldUseSharedMemory(payloadLength))
+                                {
+                                    // Flag the length and deliver the payload through shared memory.
+                                    // The slot must exist before the header reaches the pipe so the
+                                    // reader can open it as soon as it observes the flag.
+                                    _binaryWriter.Write(payloadLength | NodeSharedMemoryChannel.SharedMemoryFlag);
+                                    _sharedChannel.EnsureOutgoingReady();
+                                    if (NodeSharedMemoryChannel.IsSingleChunk(payloadLength))
+                                    {
+                                        // Single chunk: publish the body before the header so the
+                                        // parent does not stall waiting for it after reading the header.
+                                        _sharedChannel.SendPayload(packetStream.GetBuffer(), 5, payloadLength);
+                                        localWritePipe.Write(packetStream.GetBuffer(), 0, 5);
+                                    }
+                                    else
+                                    {
+                                        localWritePipe.Write(packetStream.GetBuffer(), 0, 5);
+                                        _sharedChannel.SendPayload(packetStream.GetBuffer(), 5, payloadLength);
+                                    }
+                                }
+                                else
+#endif
+                                {
+                                    _binaryWriter.Write(payloadLength);
+                                    localWritePipe.Write(packetStream.GetBuffer(), 0, packetStreamLength);
+                                }
                             }
                         }
                         catch (Exception e)

--- a/src/Shared/NodeEndpointOutOfProcBase.cs
+++ b/src/Shared/NodeEndpointOutOfProcBase.cs
@@ -811,7 +811,7 @@ namespace Microsoft.Build.BackEnd
                                 // Now write in the actual packet length
                                 packetStream.Position = 1;
 #if NET
-                                if (_sharedChannel != null && NodeSharedMemoryChannel.ShouldUseSharedMemory(payloadLength))
+                                if (_sharedChannel != null && _sharedChannel.ShouldSendViaSharedMemory(payloadLength))
                                 {
                                     // Flag the length and deliver the payload through shared memory.
                                     // The slot must exist before the header reaches the pipe so the

--- a/src/Shared/NodeSharedMemoryChannel.cs
+++ b/src/Shared/NodeSharedMemoryChannel.cs
@@ -1,0 +1,333 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#if NET
+using System;
+using System.Globalization;
+using System.IO;
+using System.IO.MemoryMappedFiles;
+using System.Runtime.InteropServices;
+using System.Threading;
+
+// All Windows-only kernel-object APIs below (named MemoryMappedFile / Semaphore) are only ever
+// reached when FeatureEnabled is true, which itself requires NativeMethodsShared.IsWindows.
+#pragma warning disable CA1416 // Validate platform compatibility
+
+namespace Microsoft.Build.Internal
+{
+    /// <summary>
+    /// A shared-memory fast path for large node packet payloads.
+    /// </summary>
+    /// <remarks>
+    /// The existing named-pipe transport continues to carry every packet header and all small
+    /// payloads inline, so framing, ordering, version negotiation, and the connection lifecycle
+    /// (handshake, disconnect detection, node reuse, shutdown) are completely unchanged. Only the
+    /// body of a packet whose serialized payload exceeds <see cref="PayloadThreshold"/> is moved
+    /// out of the pipe and copied through a per-direction memory-mapped slot, signalled by a pair
+    /// of semaphores. When this happens the writer sets <see cref="SharedMemoryFlag"/> on the
+    /// 32-bit packet-length field of the pipe header; the reader detects the flag and reads the
+    /// body from shared memory instead of the pipe.
+    ///
+    /// Each direction is strictly single-producer / single-consumer: the parent process writes the
+    /// "p2c" slot and reads the "c2p" slot; the child does the opposite. The writer of a slot
+    /// creates the underlying objects, the reader opens them (with a brief retry to absorb the
+    /// creation race). Because the writer always creates its slot before placing the flagged header
+    /// on the pipe, and the reader only opens after observing that header, opening is race-free.
+    ///
+    /// The feature is Windows-only (it relies on cross-process named memory-mapped files and
+    /// semaphores) and opt-in via the <c>MSBUILDSHAREDMEMORYIPC</c> environment variable, which is
+    /// inherited by launched nodes so both endpoints agree. Compiled only for modern .NET; the
+    /// .NET Framework / CLR2 task host always uses the pipe.
+    /// </remarks>
+    internal sealed class NodeSharedMemoryChannel : IDisposable
+    {
+        /// <summary>
+        /// High bit of the 32-bit packet length field, used to flag that the packet body was
+        /// delivered through shared memory rather than inline on the pipe. Packet bodies never
+        /// approach 2 GiB, so this bit is always free.
+        /// </summary>
+        internal const int SharedMemoryFlag = unchecked((int)0x80000000);
+
+        /// <summary>
+        /// Mask that recovers the real payload length from a (possibly flagged) length field.
+        /// </summary>
+        internal const int LengthMask = 0x7FFFFFFF;
+
+        /// <summary>
+        /// Default minimum serialized payload size (in bytes) for which the shared-memory path is used.
+        /// </summary>
+        private const int DefaultThreshold = 8 * 1024;
+
+        /// <summary>
+        /// Size of each direction's shared-memory window. Payloads larger than this are streamed
+        /// through the window in multiple chunks.
+        /// </summary>
+        private const int SlotCapacity = 1024 * 1024;
+
+        /// <summary>
+        /// Maximum time to block on a semaphore between checks for disposal.
+        /// </summary>
+        private const int WaitQuantumMs = 100;
+
+        /// <summary>
+        /// Overall safety timeout for a single chunk hand-off, in case a peer dies mid-transfer.
+        /// </summary>
+        private const int AbandonTimeoutMs = 120_000;
+
+        internal static readonly bool FeatureEnabled = ComputeEnabled();
+
+        internal static readonly int PayloadThreshold = ComputeThreshold();
+
+        /// <summary>Number of packets transferred out of this process via shared memory (diagnostics).</summary>
+        internal static long PacketsSentViaSharedMemory;
+
+        /// <summary>Number of payload bytes transferred out of this process via shared memory (diagnostics).</summary>
+        internal static long BytesSentViaSharedMemory;
+
+        private readonly string _baseName;
+        private readonly bool _isParent;
+        private readonly object _outgoingLock = new();
+
+        private Slot? _outgoing;
+        private Slot? _incoming;
+        private volatile bool _disposed;
+
+        internal NodeSharedMemoryChannel(int childProcessId, bool isParent)
+        {
+            _baseName = "MSBuildShm_" + childProcessId.ToString(CultureInfo.InvariantCulture);
+            _isParent = isParent;
+        }
+
+        internal bool IsDisposed => _disposed;
+
+        /// <summary>
+        /// Returns true if a payload of the given size should be transferred via shared memory.
+        /// </summary>
+        internal static bool ShouldUseSharedMemory(int payloadLength) =>
+            FeatureEnabled && payloadLength >= PayloadThreshold;
+
+        /// <summary>
+        /// True if the payload fits in a single slot window, so the producer can publish the whole
+        /// body up front (before signalling the header on the pipe) without risk of deadlock.
+        /// </summary>
+        internal static bool IsSingleChunk(int payloadLength) => payloadLength <= SlotCapacity;
+
+        /// <summary>
+        /// Creates the outgoing slot if needed. Must be called by the writer before the flagged
+        /// header is written to the pipe so the reader can open the slot once it sees the header.
+        /// </summary>
+        internal void EnsureOutgoingReady()
+        {
+            if (_outgoing is null)
+            {
+                lock (_outgoingLock)
+                {
+                    _outgoing ??= Slot.Create(OutgoingName);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Writes a payload to the outgoing slot, chunking if it exceeds the window size.
+        /// </summary>
+        internal void SendPayload(byte[] buffer, int offset, int count)
+        {
+            Slot slot = _outgoing ?? throw new InvalidOperationException("Outgoing shared-memory slot is not initialized.");
+            int sent = 0;
+            while (sent < count)
+            {
+                int chunk = Math.Min(count - sent, SlotCapacity);
+                AcquireOrThrow(slot.Empty);
+                slot.Write(buffer, offset + sent, chunk);
+                Release(slot.Full);
+                sent += chunk;
+            }
+
+            Interlocked.Increment(ref PacketsSentViaSharedMemory);
+            Interlocked.Add(ref BytesSentViaSharedMemory, count);
+        }
+
+        /// <summary>
+        /// Reads a payload of the given size from the incoming slot, opening it lazily on first use.
+        /// </summary>
+        internal void ReceivePayload(byte[] buffer, int offset, int count)
+        {
+            Slot slot = _incoming ??= Slot.Open(IncomingName, this);
+            int received = 0;
+            while (received < count)
+            {
+                int chunk = Math.Min(count - received, SlotCapacity);
+                AcquireOrThrow(slot.Full);
+                slot.Read(buffer, offset + received, chunk);
+                Release(slot.Empty);
+                received += chunk;
+            }
+        }
+
+        public void Dispose()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
+            CommunicationsUtilities.Trace($"Shared-memory IPC channel '{_baseName}' disposed. Process total: {PacketsSentViaSharedMemory} packets / {BytesSentViaSharedMemory} bytes sent via shared memory.");
+            _outgoing?.Dispose();
+            _incoming?.Dispose();
+        }
+
+        private void AcquireOrThrow(Semaphore semaphore)
+        {
+            int waited = 0;
+            while (true)
+            {
+                if (_disposed)
+                {
+                    throw new IOException("Shared-memory channel has been disposed.");
+                }
+
+                bool signaled;
+                try
+                {
+                    signaled = semaphore.WaitOne(WaitQuantumMs);
+                }
+                catch (ObjectDisposedException)
+                {
+                    throw new IOException("Shared-memory channel has been disposed.");
+                }
+
+                if (signaled)
+                {
+                    return;
+                }
+
+                waited += WaitQuantumMs;
+                if (waited >= AbandonTimeoutMs)
+                {
+                    throw new IOException("Timed out waiting on the shared-memory channel.");
+                }
+            }
+        }
+
+        private static void Release(Semaphore semaphore)
+        {
+            try
+            {
+                semaphore.Release();
+            }
+            catch (SemaphoreFullException)
+            {
+                // Best-effort signal; the slot is single-entry so an extra release is harmless.
+            }
+            catch (ObjectDisposedException)
+            {
+                // The channel was disposed concurrently; nothing left to signal.
+            }
+        }
+
+        private string OutgoingName => _isParent ? _baseName + "_p2c" : _baseName + "_c2p";
+
+        private string IncomingName => _isParent ? _baseName + "_c2p" : _baseName + "_p2c";
+
+        private static bool ComputeEnabled()
+        {
+            if (!NativeMethodsShared.IsWindows)
+            {
+                return false;
+            }
+
+            string? value = Environment.GetEnvironmentVariable("MSBUILDSHAREDMEMORYIPC");
+            return value == "1" || string.Equals(value, "true", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static int ComputeThreshold()
+        {
+            string? value = Environment.GetEnvironmentVariable("MSBUILDSHAREDMEMORYIPCTHRESHOLD");
+            return !string.IsNullOrEmpty(value) && int.TryParse(value, out int parsed) && parsed > 0
+                ? parsed
+                : DefaultThreshold;
+        }
+
+        /// <summary>
+        /// One direction of the channel: a memory-mapped window plus the two semaphores used to
+        /// hand a single chunk back and forth between the producer and consumer.
+        /// </summary>
+        private sealed class Slot : IDisposable
+        {
+            private readonly MemoryMappedFile _mmf;
+            private readonly MemoryMappedViewAccessor _view;
+            private readonly IntPtr _dataPtr;
+
+            private Slot(MemoryMappedFile mmf, MemoryMappedViewAccessor view, Semaphore empty, Semaphore full)
+            {
+                _mmf = mmf;
+                _view = view;
+                Empty = empty;
+                Full = full;
+                _dataPtr = IntPtr.Add(view.SafeMemoryMappedViewHandle.DangerousGetHandle(), (int)view.PointerOffset);
+            }
+
+            /// <summary>Signalled when the window is free for the producer to fill.</summary>
+            internal Semaphore Empty { get; }
+
+            /// <summary>Signalled when the window holds a chunk for the consumer to drain.</summary>
+            internal Semaphore Full { get; }
+
+            internal static Slot Create(string name)
+            {
+                MemoryMappedFile mmf = MemoryMappedFile.CreateNew(name, SlotCapacity);
+                MemoryMappedViewAccessor view = mmf.CreateViewAccessor(0, SlotCapacity, MemoryMappedFileAccess.ReadWrite);
+                Semaphore empty = new(initialCount: 1, maximumCount: 1, name + "_e");
+                Semaphore full = new(initialCount: 0, maximumCount: 1, name + "_f");
+                CommunicationsUtilities.Trace($"Shared-memory IPC: created slot '{name}'.");
+                return new Slot(mmf, view, empty, full);
+            }
+
+            internal static Slot Open(string name, NodeSharedMemoryChannel owner)
+            {
+                int waited = 0;
+                while (true)
+                {
+                    try
+                    {
+                        MemoryMappedFile mmf = MemoryMappedFile.OpenExisting(name, MemoryMappedFileRights.ReadWrite);
+                        MemoryMappedViewAccessor view = mmf.CreateViewAccessor(0, SlotCapacity, MemoryMappedFileAccess.ReadWrite);
+                        Semaphore empty = Semaphore.OpenExisting(name + "_e");
+                        Semaphore full = Semaphore.OpenExisting(name + "_f");
+                        CommunicationsUtilities.Trace($"Shared-memory IPC: opened slot '{name}'.");
+                        return new Slot(mmf, view, empty, full);
+                    }
+                    catch (Exception e) when (e is FileNotFoundException or WaitHandleCannotBeOpenedException)
+                    {
+                        if (owner._disposed)
+                        {
+                            throw new IOException("Shared-memory channel has been disposed.");
+                        }
+
+                        Thread.Sleep(WaitQuantumMs);
+                        waited += WaitQuantumMs;
+                        if (waited >= AbandonTimeoutMs)
+                        {
+                            throw new IOException("Timed out opening the shared-memory channel.", e);
+                        }
+                    }
+                }
+            }
+
+            internal void Write(byte[] buffer, int offset, int count) => Marshal.Copy(buffer, offset, _dataPtr, count);
+
+            internal void Read(byte[] buffer, int offset, int count) => Marshal.Copy(_dataPtr, buffer, offset, count);
+
+            public void Dispose()
+            {
+                _view.Dispose();
+                _mmf.Dispose();
+                Empty.Dispose();
+                Full.Dispose();
+            }
+        }
+    }
+}
+#pragma warning restore CA1416 // Validate platform compatibility
+#endif

--- a/src/Shared/NodeSharedMemoryChannel.cs
+++ b/src/Shared/NodeSharedMemoryChannel.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Build.Internal
     /// The existing named-pipe transport continues to carry every packet header and all small
     /// payloads inline, so framing, ordering, version negotiation, and the connection lifecycle
     /// (handshake, disconnect detection, node reuse, shutdown) are completely unchanged. Only the
-    /// body of a packet whose serialized payload exceeds <see cref="PayloadThreshold"/> is moved
+    /// body of a packet whose serialized payload exceeds the direction-specific threshold is moved
     /// out of the pipe and copied through a per-direction memory-mapped slot, signalled by a pair
     /// of semaphores. When this happens the writer sets <see cref="SharedMemoryFlag"/> on the
     /// 32-bit packet-length field of the pipe header; the reader detects the flag and reads the
@@ -54,20 +54,35 @@ namespace Microsoft.Build.Internal
         internal const int LengthMask = 0x7FFFFFFF;
 
         /// <summary>
-        /// Default minimum serialized payload size (in bytes) for which the shared-memory path is used.
+        /// Default minimum serialized payload size (in bytes) for which the shared-memory path is used
+        /// on the parent -&gt; child (TaskHostConfiguration) direction. These packets are large; a higher
+        /// threshold keeps the few small ones off the single-entry slot. Override with
+        /// <c>MSBUILDSHAREDMEMORYIPCTHRESHOLD</c>.
         /// </summary>
-        private const int DefaultThreshold = 8 * 1024;
+        private const int DefaultSendThreshold = 16 * 1024;
 
         /// <summary>
-        /// Size of each direction's shared-memory window. Payloads larger than this are streamed
-        /// through the window in multiple chunks.
+        /// Default threshold for the child -&gt; parent (logging + task outputs) direction. This traffic is
+        /// many small packets; a low threshold pushes them through shared memory to escape per-packet pipe
+        /// syscall overhead (measured ~18x faster on the return path). Kept above tiny control packets so
+        /// lifecycle packets (NodeShutdown, NodeBuildComplete) stay on the pipe. Override with
+        /// <c>MSBUILDSHAREDMEMORYIPCRETURNTHRESHOLD</c>.
         /// </summary>
-        private const int SlotCapacity = 1024 * 1024;
+        private const int DefaultReturnThreshold = 512;
 
         /// <summary>
-        /// Maximum time to block on a semaphore between checks for disposal.
+        /// Default size of each direction's shared-memory window. Payloads larger than this are
+        /// streamed through the window in multiple chunks. 512 KB measured best (256 KB over-chunks the
+        /// ~1.5 MB max packet; ≥1 MB gives no gain since the send path is consumer-coupling-bound, not
+        /// chunk-bound). Override with <c>MSBUILDSHAREDMEMORYIPCSLOTSIZE</c>.
         /// </summary>
-        private const int WaitQuantumMs = 100;
+        private const int DefaultSlotCapacity = 512 * 1024;
+
+        /// <summary>
+        /// Default time to block on a semaphore between checks for disposal.
+        /// Override with <c>MSBUILDSHAREDMEMORYIPCWAITQUANTUM</c>.
+        /// </summary>
+        private const int DefaultWaitQuantumMs = 100;
 
         /// <summary>
         /// Overall safety timeout for a single chunk hand-off, in case a peer dies mid-transfer.
@@ -76,7 +91,16 @@ namespace Microsoft.Build.Internal
 
         internal static readonly bool FeatureEnabled = ComputeEnabled();
 
-        internal static readonly int PayloadThreshold = ComputeThreshold();
+        /// <summary>Minimum payload size to divert to shared memory on the parent -&gt; child path.</summary>
+        internal static readonly int SendThreshold = ReadPositiveIntEnv("MSBUILDSHAREDMEMORYIPCTHRESHOLD", DefaultSendThreshold);
+
+        /// <summary>Minimum payload size to divert to shared memory on the child -&gt; parent path.</summary>
+        internal static readonly int ReturnThreshold = ReadPositiveIntEnv("MSBUILDSHAREDMEMORYIPCRETURNTHRESHOLD", DefaultReturnThreshold);
+
+        /// <summary>Size of each direction's shared-memory window (tunable via env var).</summary>
+        internal static readonly int SlotCapacity = ComputeSlotCapacity();
+
+        private static readonly int WaitQuantumMs = ComputeWaitQuantum();
 
         /// <summary>Number of packets transferred out of this process via shared memory (diagnostics).</summary>
         internal static long PacketsSentViaSharedMemory;
@@ -86,6 +110,7 @@ namespace Microsoft.Build.Internal
 
         private readonly string _baseName;
         private readonly bool _isParent;
+        private readonly int _outgoingThreshold;
         private readonly object _outgoingLock = new();
 
         private Slot? _outgoing;
@@ -96,15 +121,20 @@ namespace Microsoft.Build.Internal
         {
             _baseName = "MSBuildShm_" + childProcessId.ToString(CultureInfo.InvariantCulture);
             _isParent = isParent;
+
+            // The threshold applies to what THIS endpoint sends: the parent sends large configs
+            // (SendThreshold), the child sends many small logging/output packets (ReturnThreshold).
+            _outgoingThreshold = isParent ? SendThreshold : ReturnThreshold;
         }
 
         internal bool IsDisposed => _disposed;
 
         /// <summary>
-        /// Returns true if a payload of the given size should be transferred via shared memory.
+        /// Returns true if a payload this endpoint is about to send should go through shared memory,
+        /// using the threshold appropriate for this endpoint's outgoing direction.
         /// </summary>
-        internal static bool ShouldUseSharedMemory(int payloadLength) =>
-            FeatureEnabled && payloadLength >= PayloadThreshold;
+        internal bool ShouldSendViaSharedMemory(int payloadLength) =>
+            FeatureEnabled && payloadLength >= _outgoingThreshold;
 
         /// <summary>
         /// True if the payload fits in a single slot window, so the producer can publish the whole
@@ -241,12 +271,16 @@ namespace Microsoft.Build.Internal
             return value == "1" || string.Equals(value, "true", StringComparison.OrdinalIgnoreCase);
         }
 
-        private static int ComputeThreshold()
+        private static int ComputeSlotCapacity() => ReadPositiveIntEnv("MSBUILDSHAREDMEMORYIPCSLOTSIZE", DefaultSlotCapacity);
+
+        private static int ComputeWaitQuantum() => ReadPositiveIntEnv("MSBUILDSHAREDMEMORYIPCWAITQUANTUM", DefaultWaitQuantumMs);
+
+        private static int ReadPositiveIntEnv(string name, int defaultValue)
         {
-            string? value = Environment.GetEnvironmentVariable("MSBUILDSHAREDMEMORYIPCTHRESHOLD");
+            string? value = Environment.GetEnvironmentVariable(name);
             return !string.IsNullOrEmpty(value) && int.TryParse(value, out int parsed) && parsed > 0
                 ? parsed
-                : DefaultThreshold;
+                : defaultValue;
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary

**Experimental / exploratory — not for merge as-is.** This PR adds an opt-in **shared-memory fast path** for large MSBuild node-IPC payloads, plus the instrumentation used to measure it. It targets `-mt` (multithreaded) builds, where non-thread-safe tasks (notably **Csc/Vbc**, which are not `[MSBuildMultiThreadableTask]`) are routed to out-of-proc **TaskHost** sidecars and their `TaskHostConfiguration` / result packets cross the node transport.

The named pipe still carries every packet **header** and all small/control packets inline, so framing, version negotiation, disconnect detection, node reuse and shutdown are unchanged. Only packet **bodies ≥ 8 KB** are moved through a per-direction memory-mapped slot.

---

## Background: how the transport works today

Each out-of-proc node (worker or TaskHost) has one duplex **named pipe** to the parent. On the parent, a dedicated per-node "drain" thread (`NodeProviderOutOfProcBase.DrainPacketQueue`) serializes each queued packet into a `MemoryStream` and then does a **synchronous** `PipeStream.Write`. The child's read loop reads the 5-byte header, then the body, deserializes, routes the packet, and loops.

The pipe is created with **128 KB** kernel in/out buffers (`NodeEndpointOutOfProcBase.PipeBufferSize = 131072`).

## What "backpressure-bound" means here

A named pipe write is **flow-controlled**: `WriteFile` copies your bytes into the pipe's fixed-size **kernel buffer**, and the bytes leave that buffer only when the reader calls `ReadFile`. When the buffer is full, the writer **blocks inside `Write`** until the reader drains enough room. So the producer's effective rate is capped by the consumer's drain cadence, not by memory bandwidth — it is *bound by backpressure*.

In `-mt`, the parent ships ~5,000 `TaskHostConfiguration` packets (~90 KB avg, **434 MB total** for an OrchardCore.Cms.Web `-mt` Rebuild) down these pipes. Because each ~90 KB packet is comparable to the 128 KB buffer, the drain thread spends almost all its time **blocked in `Write`** waiting for the child to read the previous packet — a near-synchronous ping-pong with a kernel copy in each direction plus syscall/context-switch overhead per packet.

Measured with the `IpcTransferStats` instrumentation in this PR (wall-clock spent **inside** the transfer call, same deterministic build, 2 runs):

| codepath (main process, packets ≥ 8 KB) | baseline (128 KB pipe) | speed |
|---|---|---|
| **send** (~5,000 pkts / 434 MB) | **83.4 / 109.4 s** | **3.8–5.0 MB/s** |
| receive (1,664 pkts / 120 MB) | 0.32 / 0.34 s | ~300–480 MB/s |

5 MB/s for an in-memory transfer is the smoking gun: the cost is *blocking*, not bandwidth.

---

## Why not just change the pipe buffer size? (measured)

This is the obvious first mitigation, so I tested it: bumped `PipeBufferSize` 128 KB → **16 MB** (128×) and re-measured the **same** build with shared memory **off**:

| send path | 128 KB buffer (baseline) | 16 MB buffer | shared memory |
|---|---|---|---|
| time | 83.4 / 109.4 s | **6.7 / 11.9 s** | **0.38 / 0.40 s** |
| throughput | 3.8–5.0 MB/s | 35–62 MB/s | ~1.1 GB/s |

Findings:
1. **Buffer size is a real lever** — a 128× buffer gives a **7–13×** speedup. This *confirms* the bottleneck was backpressure (the producer could run ahead instead of blocking per packet).
2. **But it plateaus far below shared memory** — even 16 MB tops out at ~35–62 MB/s, still **~20× slower** than the shared-memory path. The residual cost is the pipe's intrinsic **double copy** (user→kernel on write, kernel→user on read) plus per-operation syscall/transition overhead. A bigger buffer hides *blocking*; it cannot remove the copies.

### Drawbacks of a big pipe buffer (why it's not the fix)

- **Pinned kernel memory that scales with node count.** Named-pipe buffers are **non-paged kernel pool** — physical RAM that can never be paged out. The buffer is committed per pipe, in *both* directions. With the concurrency actually measured on this build (**peak 25 sidecar TaskHosts**, plus worker nodes), a 16 MB buffer means `25 × 2 × 16 MB ≈ 0.8 GB` of non-paged pool **for buffers alone**. Non-paged pool is a shared, finite OS resource; exhausting it degrades the **whole machine**, not just the build.
- **Massively over-sized for the typical packet.** The measured distribution (below) is avg 46 KB and a *mode* around 7–10 KB; only a few task types reach ~0.8–1.5 MB. A 16 MB buffer is ~350× the average packet — you pay worst-case memory on every pipe to help a small minority of packets.
- **You must guess the size up front.** Pipe buffers are fixed at creation. Too small → backpressure returns (128 KB → 5 MB/s, as measured); too big → the kernel-memory problem above. The right value is workload-dependent (here the max packet is 1.53 MB, but another build could differ).
- **Still never reaches memcpy speed** — capped at ~35–62 MB/s by the unavoidable two copies + syscalls.

**Decreasing** the buffer is strictly worse (more frequent blocking).

Shared memory sidesteps all of this: a single **1 MB** slot per direction (larger payloads stream in chunks), in ordinary pageable memory, sized to the *transfer* rather than to peak node concurrency.

## What's actually on the wire (measured)

A single task execution in a sidecar TaskHost is a **round trip**: the parent sends the inputs, the child runs the task and sends back logging + outputs. The `IpcTransferStats` instrumentation in this PR breaks down **both directions by packet type** (one OrchardCore.Cms.Web `-mt` Rebuild; "task" is a sub-breakdown of `TaskHostConfiguration` keyed by its `TaskName`):

**parent → child (the inputs) — dominated by `TaskHostConfiguration`:**

| packet type | count | total bytes | avg | max |
|---|---|---|---|---|
| `TaskHostConfiguration` | 10,392 | 476 MB | 46 KB | **1,527,428 (1.53 MB)** |
| `NodeBuildComplete` | 16 | 32 B | 2 B | 2 B |

**child → parent (logging + outputs):**

| packet type | count | total bytes | avg | max |
|---|---|---|---|---|
| `TaskHostTaskComplete` (task outputs) | 10,392 | 158 MB | 15 KB | 404 KB |
| `LogMessage` (task logging) | 23,504 | 27 MB | 1.1 KB | 124 KB |
| `NodeShutdown` | 16 | 80 B | 5 B | 5 B |

So per task execution: **1** `TaskHostConfiguration` out, and back come **1** `TaskHostTaskComplete` + ~2 `LogMessage` packets (10,392 task runs ↔ 10,392 completions; 23,504 log packets). The **send** side (configs, 476 MB) is ~2.5× the **receive** side (outputs+logging, 185 MB) and carries the largest individual packets, which is why the parent→child path is the throughput bottleneck.

**By task (heaviest `TaskHostConfiguration` senders):**

| task | configs | total bytes | avg | max |
|---|---|---|---|---|
| `Microsoft.NET.Build.Tasks.GenerateDepsFile` | 192 | 152 MB | 792 KB | 1.53 MB |
| `Microsoft.CodeAnalysis.BuildTasks.Csc` | 192 | 84.6 MB | 441 KB | 1.00 MB |
| `Microsoft.NET.Build.Tasks.CheckForUnsupportedNetCoreVersion` | 191 | 69 MB | 361 KB | 897 KB |
| `Microsoft.NET.Build.Tasks.ResolvePackageFileConflicts` | 192 | 52.6 MB | 274 KB | 462 KB |
| `Microsoft.NET.Build.Tasks.GetPackageDirectories` | 1,910 | 15 MB | 7.9 KB | 13.7 KB |
| `…StaticWebAssets.*`, `JoinItems`, `ValidateExecutableReferences`, … | (long tail) | | 7–25 KB | |

The config payload is dominated by tasks whose **input item arrays** are large — the full package/dependency closure (`GenerateDepsFile`, `ResolvePackageFileConflicts`) or all sources + references + analyzers (`Csc`). `TaskHostConfiguration` serializes the task's parameters + global properties + environment block, so big inputs → big configs. The 1.53 MB max exceeds the 1 MB slot, so the chunked-transfer path **is** exercised by real builds.

## Why shared memory is the right shape

A memory-mapped file shared between parent and child is the **same physical pages mapped into both address spaces**. The producer does **one** `memcpy` into the slot and signals a semaphore; the consumer does **one** `memcpy` out and signals back. There is **no kernel data copy and no per-byte syscall** — only two lightweight semaphore wakeups per packet. That is why the send path hits ~1.1 GB/s (memcpy-bound) at **0.4 s** vs the pipe's best-case 6.7 s, and why it needs only a single fixed **1 MB** slot per direction (streamed in chunks for rare larger payloads) instead of a huge pinned kernel buffer.

The named pipe is kept for what it's *good* at — tiny, latency-sensitive header/control traffic and the existing, battle-tested connection lifecycle. We only divert the bulk bytes.

### Final result (asymmetric ordering, both directions)

| codepath | baseline pipe (128 KB) | shared memory | speedup |
|---|---|---|---|
| **send** (~5,000 pkts / 434 MB) | 83.4 / 109.4 s | 0.38 / 0.40 s | **~210–290×** |
| **receive** (1,664 pkts / 120 MB) | 0.32 / 0.34 s | 0.054 / 0.078 s | ~4–6× |
| **total transport time** | 83.7 / 109.8 s | **0.43 / 0.48 s** | **~190–250×** |

> **Ordering matters per direction (measured).** The parent sends configs back-to-back and must write the header first, then publish the body (body-first there was ~25× *slower* — 12–14 s — because the producer stalls on `AcquireEmpty`). The child sends results spaced by task execution, so it publishes the body *before* the header, which collapses the parent's receive time from ~1.7 s to ~0.05 s.

---

## Other mitigations considered (and why shared memory wins)

- **Bigger pipe buffer** — measured above: 7–13×, but ~20× short of shm and costs pinned kernel memory; doesn't scale to many nodes.
- **Asynchronous / overlapped pipe writes** (don't block the drain thread): removes *blocking* from the critical thread but keeps the two kernel copies + syscalls; the bytes still move at pipe speed, just off the drain thread. Helps latency-hiding, not throughput, and complicates ordering/lifetime.
- **Sockets (TCP loopback / Unix domain)**: same fundamental two-copy + syscall model as pipes; loopback TCP is typically *slower* than a named pipe locally. Not a throughput win.
- **Compress payloads before sending**: trades CPU for bytes; `TaskHostConfiguration` is largely environment-block + properties (compressible), but it adds CPU on the hot path and still pays the copy/syscall cost on what's left. Orthogonal — could stack on top.
- **Send less data** (the real long-term fix): the dominant payload is the environment block, re-serialized in full on *every* `TaskHostConfiguration`. Diffing/caching it per reused TaskHost would cut bytes at the source. This is the most promising structural change but is a larger, separate effort; this PR speeds up whatever bytes remain.
- **Zero-copy read** (deserialize directly from the MMF view, skipping the reader-side `memcpy` into a managed array): evaluated and **rejected** — the reader copy already runs at ~1.5–2.1 GB/s, so it would save ~30–60 ms/build for real correctness risk on the IPC path.

---

## Correctness & safety

- **Opt-in** via `MSBUILDSHAREDMEMORYIPC=1`; default behavior is byte-for-byte unchanged. The env var is inherited by launched nodes so both endpoints agree; the measurement runs also set a distinct `MSBUILDNODEHANDSHAKESALT` so flagged/unflagged nodes can never pair (defense against node reuse mixing).
- A spare high bit of the 32-bit packet-length header flags "body in shared memory" (independent of the type-byte extended-header bit). The reader checks the flag and reads from the slot instead of the pipe.
- `NodeSharedMemoryChannel`: one memory-mapped slot (1 MB) + two named semaphores per direction, strictly single-producer/single-consumer. Writer creates, reader opens (race-free: the writer creates its slot *before* the flagged header reaches the pipe; the reader only opens *after* observing that header). Larger payloads stream in chunks.
- **No serialization change**: both paths do the full `Translate` / `BinaryTranslator` round-trip; only the byte transport differs.
- **Windows-only** at runtime (named MMF/semaphores are cross-process there) and `#if NET` — the .NET Framework / CLR2 task host always uses the pipe.
- Validated: a standalone two-role protocol test (round-trips up to 5 MB, multi-chunk, byte-for-byte); every instrumented OrchardCore build exits 0; tracing confirms both-side engagement (~16 MB offloaded per project across all TaskHost children).

## End-to-end effect (for honesty)

Full `-mt` Rebuild wall-clock improved only ~2–6% best case (often within machine noise): that 80–110 s of pipe-write is largely **overlapped** across many parallel TaskHost drain threads and sits off the critical path, and compilation dominates total time. When IPC is forced to be the bottleneck (`MSBUILDFORCEALLTASKSOUTOFPROC=1`), shm is a consistent ~5% faster with no overlap between arms. **The headline is the transport codepath number, not e2e.**

## Limitations / open questions (why this is a draft)

- **Cross-platform**: needs a Unix story (named semaphores/MMF differ); currently Windows-gated.
- **Engagement should be negotiated in the handshake**, not via env-var + salt, before shipping.
- **Node reuse across builds** is only lightly exercised here (measurements use `-nr:false`); slot lifetime/renaming across reconnects needs hardening.
- **Threshold (8 KB) and slot size (1 MB)** are untuned.
- `IpcTransferStats` is measurement scaffolding (opt-in, zero overhead when off) — would be dropped or moved behind ETW for a real change.

## Try it

```
set MSBUILDSHAREDMEMORYIPC=1
set MSBUILDNODEHANDSHAKESALT=shmopt
dotnet msbuild <proj> -t:Rebuild -mt
```
Add `MSBUILDIPCSTATS=1` (and optionally `MSBUILDIPCSTATSFILE=<path>`) to dump per-mechanism transfer timings at process exit.

---

# Tuning (3 runs each, OrchardCore.Cms.Web `-mt`, transport codepath via `MSBUILDIPCSTATS`)

All constants are now env-tunable: `MSBUILDSHAREDMEMORYIPCTHRESHOLD` (send), `MSBUILDSHAREDMEMORYIPCRETURNTHRESHOLD`, `MSBUILDSHAREDMEMORYIPCSLOTSIZE`, `MSBUILDSHAREDMEMORYIPCWAITQUANTUM`.

## A correction to the earlier "190–250×" claim

With consolidated, consistent instrumentation the aggregate **producer-blocked send time** is ~20s (shm) vs ~90–100s (pipe) — about **4–5×**, not 190×. The earlier figure was an artifact of timer placement that excluded **consumer-coupling**: the single-entry slot makes the parent wait for the child to drain, and the child only drains between task executions. The clean, defensible numbers are the per-task table and the microbenchmark below.

## Threshold sweep (median of 3) — the two directions want opposite thresholds

| threshold | send med | recv med | all med |
|---|---|---|---|
| baseline (pipe) | 98.0s | 4.3s | 102.0s |
| 1 (everything shm) | 23.5s | **0.36s** | 23.9s |
| 8192 | 20.6s | 6.5s | 27.3s |
| 65536 | 15.1s | 5.8s | 20.9s |

- **Send** (parent→child, big configs) is ~flat/noisy across thresholds (consumer-coupling-bound), mildly favoring a *higher* threshold to keep small packets off the single-entry slot.
- **Receive** (child→parent, ~23.5k small log+output packets) strongly favors a *low* threshold — **0.36s vs 6.5s (18×)** by escaping per-packet pipe syscall overhead.

→ Implemented **direction-specific thresholds**: `SendThreshold` default 16 KB, `ReturnThreshold` default 512 B (kept above tiny lifecycle packets so `NodeShutdown`/`NodeBuildComplete` stay on the pipe).

## Slot-size sweep (median of 3, send=16K/return=512)

| slot | send med | all med |
|---|---|---|
| 256 KB | 20.5s | 23.2s |
| **512 KB** | **15.8s** | **19.0s** |
| 1 MB | 17.1s | 20.8s |
| 2 MB | 18.7s | 22.1s |
| 4 MB | 17.6s | 20.9s |

→ **512 KB optimal.** 256 KB over-chunks the ~1.5 MB max packet; ≥1 MB gives nothing because the send path is consumer-coupling-bound, not chunk-bound. Default changed 1 MB → 512 KB.

## Per-task send transport time (median of 3): baseline pipe → tuned shm

| task | configs | avg cfg | pipe ms | shm ms | speedup |
|---|---|---|---|---|---|
| `GenerateDepsFile` | 192 | 774 KB | 38,069 | 870 | **43.8×** |
| `CheckForUnsupportedNetCoreVersion` | 191 | 353 KB | 16,251 | 671 | **24.2×** |
| `Csc` | 192 | 430 KB | 15,642 | 426 | **36.7×** |
| `ResolvePackageFileConflicts` | 192 | 268 KB | 11,020 | 322 | **34.2×** |
| `GetPackageDirectories` | 1,910 | 7.8 KB | 3,028 | 3,336 | 0.9× (below 16 KB → stays on pipe) |
| **TOTAL (all tasks)** | | | **89,298** | **10,941** | **8.2×** |

Intended behavior confirmed: large-config tasks get **24–44×**; small-config tasks are left on the pipe (no change, no regression).

# Unix overhead — real numbers (microbenchmark, 256 MB, raw transport ceiling)

Identical .NET microbenchmark on Windows 10.0.26100 and Ubuntu 24.04 (WSL2), NamedPipe (128 KB buffer) vs shared-memory (memcpy + semaphore handoff):

| payload | Windows pipe | Windows shm | Win × | Linux pipe (UDS) | Linux shm | Linux × |
|---|---|---|---|---|---|---|
| 8 KB | 59 MB/s | 5,836 MB/s | **98.6×** | 1,263 MB/s | 5,567 MB/s | 4.4× |
| 90 KB | 581 MB/s | 13,242 MB/s | **22.8×** | 3,693 MB/s | 11,493 MB/s | 3.1× |
| 1500 KB | 2,219 MB/s | 5,542 MB/s | 2.5× | 4,862 MB/s | 12,977 MB/s | 2.7× |
| 90 KB + 200 µs consumer delay | 244 MB/s | 417 MB/s | 1.7× | 347 MB/s | 377 MB/s | 1.1× |

**Analysis / can Unix be drastically improved? — No.**
- The **Windows named pipe is the pathology**: 59 MB/s at 8 KB, 581 MB/s at 90 KB. Its per-operation kernel/overlapped-I/O overhead is brutal for small packets. That's what shm fixes (23–99× raw).
- **Linux Unix-domain sockets are 6–23× faster than Windows pipes** for the same packets (1.3–4.9 GB/s) — already near memory bandwidth. So shm adds only **2.7–4.4×** raw on Linux, and just **~1.1×** once realistic consumer-coupling is modeled.
- Under consumer coupling (the real `-mt` situation, where the child runs tasks between reads) the benefit collapses to ~1.1–1.7× on **both** OSes — which is exactly why the e2e build moved only ~2–6% while the transport codepath moved ~8×.
- Plus, .NET on Linux has no named `Semaphore` (throws `PlatformNotSupportedException`); a Linux port would need `sem_open`/`eventfd`/`futex` P/Invoke for more complexity and far less payoff.

**Conclusion:** this is primarily a **Windows** optimization. On Linux the transport isn't the bottleneck; the better levers there are reducing payload (the env-block re-serialized in every `TaskHostConfiguration`) and the consumer-coupling (a multi-entry/ring slot so the producer can run further ahead — the next real lever on both OSes).

---

# No-MMF path: how big should the pipe buffer be?

Since the gains turned out to be largely about **buffer depth** (pipelining), I swept the named-pipe
buffer size with shared memory **off** (`MSBUILDPIPEBUFFERSIZE`, 3 runs each, send transport time, median):

| pipe buffer | send med | all med |
|---|---|---|
| 128 KB (default) | 114.2s | 120.0s |
| 256 KB | 59.9s | 63.8s |
| 512 KB | 30.5s | 35.5s |
| **1 MB** | **9.0s** | **12.9s** |
| 4 MB | 8.5s | 12.2s |
| 16 MB | 11.7s | 15.5s |
| 64 MB | 8.3s | 12.3s |

**Conclusion: ~1 MB.** Send time roughly halves per buffer doubling up to ~1 MB, then plateaus (4 MB is
marginally better but not worth 4× the memory; ≥16 MB no gain). At 1 MB the pipe-only path does the
send in **~9s vs ~114s at the 128 KB default (~12×)** — and **matches or beats the shared-memory path**
(~13s all vs ~19–22s for the tuned single-entry shm slot).

**Why the simple buffer bump wins the send path:** a 1 MB pipe buffer is a *deep* queue (~11 configs, or
one whole big config) so the producer dumps and moves on instead of blocking on consumer-coupling. The
shared-memory slot is **single-entry (depth 1)**, so despite far higher raw throughput it caps pipelining
and the producer stalls waiting for the child to drain. Memory cost of 1 MB buffers is ~50 MB of
non-paged pool at the measured 25-TaskHost concurrency (vs ~0.8 GB at 16 MB) — acceptable.

## Revised overall recommendation

1. **Cheapest, cross-platform, lowest-risk: raise the pipe buffer to ~1 MB.** ~12× on the send path,
   matches the shm prototype, no Windows-only code, no slot lifecycle, no new failure modes. This is
   likely the right first change for the product.
2. **Shared memory only clearly wins the return path** (many tiny `LogMessage` packets): low return
   threshold gives recv 0.36s vs ~4–5s, which the pipe buffer does *not* fix (small-packet syscall
   overhead, not buffer depth). That's a smaller absolute win (~4s).
3. **To make shared memory decisively beat the buffer bump, it needs a multi-entry (ring) slot** so the
   producer can run several packets ahead — the same pipelining depth a big pipe buffer gives for free.
   That's the identified next lever (and it helps on Linux too, where the transport is already fast).
