### PR TITLE
Fix TerminalLogger auto-detection under MSBuild Server on Unix

### DIFF
--- a/src/Build.UnitTests/TerminalLogger_Tests.cs
+++ b/src/Build.UnitTests/TerminalLogger_Tests.cs
@@ -235,6 +235,37 @@ namespace Microsoft.Build.UnitTests
             logger.Verbosity.ShouldBe(expectedVerbosity);
         }
 
+        /// <summary>
+        /// Regression test for dotnet/msbuild#13940. Under MSBuild Server, TerminalLogger
+        /// auto-detection runs in the server node, whose own stdout is redirected. The node receives
+        /// the client's real console capabilities and exposes them via
+        /// <c>NativeMethods.ConsoleConfigurationOverride</c>. When the client transmitted a
+        /// screen-capable console, '-tl:auto' must auto-select <see cref="TerminalLogger"/> (the bug
+        /// was that it fell back to the console logger); when the client transmitted a redirected
+        /// console, it must fall back to <see cref="ConsoleLogger"/>. This exercises the real
+        /// <c>QueryIsScreenAndTryEnableAnsiColorCodes</c> path and needs no real terminal.
+        /// </summary>
+        [Theory]
+        [InlineData(true, true, typeof(TerminalLogger))]
+        [InlineData(false, false, typeof(ConsoleLogger))]
+        public void CreateTerminalOrConsoleLogger_AutoHonorsServerTransmittedConsoleConfiguration(bool acceptAnsi, bool outputIsScreen, Type expectedType)
+        {
+            using TestEnvironment env = TestEnvironment.Create(_outputHelper);
+            env.SetEnvironmentVariable("MSBUILDTERMINALLOGGER", "");
+
+            try
+            {
+                Microsoft.Build.Framework.NativeMethods.ConsoleConfigurationOverride = (acceptAnsi, outputIsScreen);
+
+                ILogger logger = TerminalLogger.CreateTerminalOrConsoleLogger(["-tl:auto"]);
+
+                logger.ShouldBeOfType(expectedType);
+            }
+            finally
+            {
+                Microsoft.Build.Framework.NativeMethods.ConsoleConfigurationOverride = null;
+            }
+        }
 
         #region Helper methods to create BuildEventArgs with BuildEventContext
 

--- a/src/Build.UnitTests/TerminalLogger_Tests.cs
+++ b/src/Build.UnitTests/TerminalLogger_Tests.cs
@@ -248,6 +248,8 @@ namespace Microsoft.Build.UnitTests
         [Theory]
         [InlineData(true, true, typeof(TerminalLogger))]
         [InlineData(false, false, typeof(ConsoleLogger))]
+        [InlineData(true, false, typeof(ConsoleLogger))]
+        [InlineData(false, true, typeof(ConsoleLogger))]
         public void CreateTerminalOrConsoleLogger_AutoHonorsServerTransmittedConsoleConfiguration(bool acceptAnsi, bool outputIsScreen, Type expectedType)
         {
             using TestEnvironment env = TestEnvironment.Create(_outputHelper);

--- a/src/Build/BackEnd/Node/OutOfProcServerNode.cs
+++ b/src/Build/BackEnd/Node/OutOfProcServerNode.cs
@@ -406,44 +406,46 @@ namespace Microsoft.Build.Experimental
             // reflects the client's terminal instead of this node's redirected stdout.
             NativeMethodsShared.ConsoleConfigurationOverride =
                 (command.ConsoleConfiguration.AcceptAnsiColorCodes, command.ConsoleConfiguration.OutputIsScreen);
+            CommunicationsUtilities.Trace($"ConsoleConfigurationOverride: acceptAnsi={command.ConsoleConfiguration.AcceptAnsiColorCodes}, outputIsScreen={command.ConsoleConfiguration.OutputIsScreen}");
 
-            // Initiate build telemetry
-            if (command.PartialBuildTelemetry != null)
-            {
-                BuildTelemetry buildTelemetry = KnownTelemetry.PartialBuildTelemetry ??= new BuildTelemetry();
-
-                buildTelemetry.StartAt = command.PartialBuildTelemetry.StartedAt;
-                buildTelemetry.InitialMSBuildServerState = command.PartialBuildTelemetry.InitialServerState;
-                buildTelemetry.ServerFallbackReason = command.PartialBuildTelemetry.ServerFallbackReason;
-                buildTelemetry.ServerEnableReason = command.PartialBuildTelemetry.ServerEnableReason;
-            }
-
-            // Also try our best to increase chance custom Loggers which use Console static members will work as expected.
-            try
-            {
-                if (NativeMethodsShared.IsWindows && command.ConsoleConfiguration.BufferWidth > 0)
-                {
-                    Console.BufferWidth = command.ConsoleConfiguration.BufferWidth;
-                }
-
-                if ((int)command.ConsoleConfiguration.BackgroundColor != -1)
-                {
-                    Console.BackgroundColor = command.ConsoleConfiguration.BackgroundColor;
-                }
-            }
-            catch (Exception)
-            {
-                // Ignore exception, it is best effort only
-            }
-
-            // Configure console output redirection
             var oldOut = Console.Out;
             var oldErr = Console.Error;
             (int exitCode, string exitType) buildResult;
 
-            // Dispose must be called before the server sends ServerNodeBuildResult packet
+            // Everything below is wrapped so that on any failure path the original Console writers are
+            // restored and the override is cleared - important for a long-lived, reusable server node.
             try
             {
+                // Initiate build telemetry
+                if (command.PartialBuildTelemetry != null)
+                {
+                    BuildTelemetry buildTelemetry = KnownTelemetry.PartialBuildTelemetry ??= new BuildTelemetry();
+
+                    buildTelemetry.StartAt = command.PartialBuildTelemetry.StartedAt;
+                    buildTelemetry.InitialMSBuildServerState = command.PartialBuildTelemetry.InitialServerState;
+                    buildTelemetry.ServerFallbackReason = command.PartialBuildTelemetry.ServerFallbackReason;
+                    buildTelemetry.ServerEnableReason = command.PartialBuildTelemetry.ServerEnableReason;
+                }
+
+                // Also try our best to increase chance custom Loggers which use Console static members will work as expected.
+                try
+                {
+                    if (NativeMethodsShared.IsWindows && command.ConsoleConfiguration.BufferWidth > 0)
+                    {
+                        Console.BufferWidth = command.ConsoleConfiguration.BufferWidth;
+                    }
+
+                    if ((int)command.ConsoleConfiguration.BackgroundColor != -1)
+                    {
+                        Console.BackgroundColor = command.ConsoleConfiguration.BackgroundColor;
+                    }
+                }
+                catch (Exception)
+                {
+                    // Ignore exception, it is best effort only
+                }
+
+                // Dispose must be called before the server sends ServerNodeBuildResult packet
                 using (RedirectConsoleWriter outWriter = new(text => SendPacket(new ServerNodeConsoleWrite(text, ConsoleOutput.Standard))))
                 using (RedirectConsoleWriter errWriter = new(text => SendPacket(new ServerNodeConsoleWrite(text, ConsoleOutput.Error))))
                 {
@@ -451,14 +453,14 @@ namespace Microsoft.Build.Experimental
                     Console.SetError(errWriter);
 
                     buildResult = _buildFunction(command.CommandLine);
-
-                    Console.SetOut(oldOut);
-                    Console.SetError(oldErr);
                 }
             }
             finally
             {
-                // Reset the override so a later idle/in-proc query does not observe stale client capabilities.
+                // Restore the original Console writers and clear the override on all paths so a reusable
+                // server node never observes stale state (or disposed writers) between builds.
+                Console.SetOut(oldOut);
+                Console.SetError(oldErr);
                 NativeMethodsShared.ConsoleConfigurationOverride = null;
             }
 

--- a/src/Build/BackEnd/Node/OutOfProcServerNode.cs
+++ b/src/Build/BackEnd/Node/OutOfProcServerNode.cs
@@ -401,6 +401,12 @@ namespace Microsoft.Build.Experimental
             // Configure console configuration so Loggers can change their behavior based on Target (client) Console properties.
             ConsoleConfiguration.Provider = command.ConsoleConfiguration;
 
+            // TerminalLogger/ANSI auto-detection runs in this node, but the real terminal belongs to the client.
+            // Override the local console query with the capabilities the client transmitted so that e.g. '-tl:auto'
+            // reflects the client's terminal instead of this node's redirected stdout.
+            NativeMethodsShared.ConsoleConfigurationOverride =
+                (command.ConsoleConfiguration.AcceptAnsiColorCodes, command.ConsoleConfiguration.OutputIsScreen);
+
             // Initiate build telemetry
             if (command.PartialBuildTelemetry != null)
             {
@@ -436,16 +442,24 @@ namespace Microsoft.Build.Experimental
             (int exitCode, string exitType) buildResult;
 
             // Dispose must be called before the server sends ServerNodeBuildResult packet
-            using (RedirectConsoleWriter outWriter = new(text => SendPacket(new ServerNodeConsoleWrite(text, ConsoleOutput.Standard))))
-            using (RedirectConsoleWriter errWriter = new(text => SendPacket(new ServerNodeConsoleWrite(text, ConsoleOutput.Error))))
+            try
             {
-                Console.SetOut(outWriter);
-                Console.SetError(errWriter);
+                using (RedirectConsoleWriter outWriter = new(text => SendPacket(new ServerNodeConsoleWrite(text, ConsoleOutput.Standard))))
+                using (RedirectConsoleWriter errWriter = new(text => SendPacket(new ServerNodeConsoleWrite(text, ConsoleOutput.Error))))
+                {
+                    Console.SetOut(outWriter);
+                    Console.SetError(errWriter);
 
-                buildResult = _buildFunction(command.CommandLine);
+                    buildResult = _buildFunction(command.CommandLine);
 
-                Console.SetOut(oldOut);
-                Console.SetError(oldErr);
+                    Console.SetOut(oldOut);
+                    Console.SetError(oldErr);
+                }
+            }
+            finally
+            {
+                // Reset the override so a later idle/in-proc query does not observe stale client capabilities.
+                NativeMethodsShared.ConsoleConfigurationOverride = null;
             }
 
             // On Windows, a process holds a handle to the current directory,

--- a/src/Framework.UnitTests/NativeMethods_Tests.cs
+++ b/src/Framework.UnitTests/NativeMethods_Tests.cs
@@ -1,0 +1,65 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Shouldly;
+using Xunit;
+using NativeMethods = Microsoft.Build.Framework.NativeMethods;
+
+namespace Microsoft.Build.UnitTests
+{
+    /// <summary>
+    /// Tests for <see cref="NativeMethods.QueryIsScreenAndTryEnableAnsiColorCodes"/>, specifically the
+    /// <see cref="NativeMethods.ConsoleConfigurationOverride"/> seam used by the MSBuild Server node to
+    /// report the client's terminal capabilities instead of the node's own redirected stdout
+    /// (see dotnet/msbuild#13940).
+    /// </summary>
+    public class NativeMethods_Tests
+    {
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        [InlineData(false, false)]
+        public void QueryIsScreenAndTryEnableAnsiColorCodes_HonorsOverride(bool acceptAnsi, bool outputIsScreen)
+        {
+            try
+            {
+                NativeMethods.ConsoleConfigurationOverride = (acceptAnsi, outputIsScreen);
+
+                (bool actualAnsi, bool actualScreen, uint? originalConsoleMode) =
+                    NativeMethods.QueryIsScreenAndTryEnableAnsiColorCodes();
+
+                actualAnsi.ShouldBe(acceptAnsi);
+                actualScreen.ShouldBe(outputIsScreen);
+
+                // The node must not touch its own console mode when an override is present, so there is
+                // nothing to restore.
+                originalConsoleMode.ShouldBeNull();
+            }
+            finally
+            {
+                NativeMethods.ConsoleConfigurationOverride = null;
+            }
+        }
+
+        [Fact]
+        public void QueryIsScreenAndTryEnableAnsiColorCodes_OverrideAppliesToStandardError()
+        {
+            try
+            {
+                NativeMethods.ConsoleConfigurationOverride = (acceptAnsiColorCodes: true, outputIsScreen: true);
+
+                (bool actualAnsi, bool actualScreen, uint? originalConsoleMode) =
+                    NativeMethods.QueryIsScreenAndTryEnableAnsiColorCodes(useStandardError: true);
+
+                actualAnsi.ShouldBeTrue();
+                actualScreen.ShouldBeTrue();
+                originalConsoleMode.ShouldBeNull();
+            }
+            finally
+            {
+                NativeMethods.ConsoleConfigurationOverride = null;
+            }
+        }
+    }
+}

--- a/src/Framework/NativeMethods.cs
+++ b/src/Framework/NativeMethods.cs
@@ -1247,7 +1247,8 @@ internal static class NativeMethods
     /// Overrides the console capabilities reported by <see cref="QueryIsScreenAndTryEnableAnsiColorCodes"/>.
     /// Set by a node (e.g. the MSBuild Server node) to the capabilities transmitted from the client process,
     /// so that auto-detection reflects the client's real terminal rather than the node's own redirected stdout.
-    /// Null when running in-proc, in which case the local <see cref="Console"/> is queried as usual.
+    /// Null when no override is active - i.e. during in-proc builds, or when a server node is idle between
+    /// out-of-proc builds - in which case the local <see cref="Console"/> is queried as usual.
     /// </summary>
     internal static (bool acceptAnsiColorCodes, bool outputIsScreen)? ConsoleConfigurationOverride { get; set; }
 

--- a/src/Framework/NativeMethods.cs
+++ b/src/Framework/NativeMethods.cs
@@ -1243,8 +1243,23 @@ internal static class NativeMethods
 
 #endif
 
+    /// <summary>
+    /// Overrides the console capabilities reported by <see cref="QueryIsScreenAndTryEnableAnsiColorCodes"/>.
+    /// Set by a node (e.g. the MSBuild Server node) to the capabilities transmitted from the client process,
+    /// so that auto-detection reflects the client's real terminal rather than the node's own redirected stdout.
+    /// Null when running in-proc, in which case the local <see cref="Console"/> is queried as usual.
+    /// </summary>
+    internal static (bool acceptAnsiColorCodes, bool outputIsScreen)? ConsoleConfigurationOverride { get; set; }
+
     internal static (bool acceptAnsiColorCodes, bool outputIsScreen, uint? originalConsoleMode) QueryIsScreenAndTryEnableAnsiColorCodes(bool useStandardError = false)
     {
+        if (ConsoleConfigurationOverride is (bool overrideAcceptAnsiColorCodes, bool overrideOutputIsScreen))
+        {
+            // The real terminal lives in a separate client process; use the capabilities it transmitted.
+            // We must not change this node's console mode, so there is no original mode to restore.
+            return (acceptAnsiColorCodes: overrideAcceptAnsiColorCodes, outputIsScreen: overrideOutputIsScreen, originalConsoleMode: null);
+        }
+
         if (Console.IsOutputRedirected)
         {
             // There's no ANSI terminal support if console output is redirected.

--- a/src/MSBuild.UnitTests/MSBuildServer_Tests.cs
+++ b/src/MSBuild.UnitTests/MSBuildServer_Tests.cs
@@ -144,6 +144,38 @@ namespace Microsoft.Build.Engine.UnitTests
             pidOfServerProcess.ShouldNotBe(newServerProcessId, "Node used by both the first and second build should not be the same.");
         }
 
+        /// <summary>
+        /// Regression test for dotnet/msbuild#13940. With the server enabled, TerminalLogger
+        /// auto-detection runs in the server node. It must honor the client's transmitted console
+        /// configuration rather than the node's own (redirected) stdout. Here the build output is
+        /// captured/redirected, so '-tl:auto' must fall back to the console logger and emit no
+        /// TerminalLogger ANSI escape sequences.
+        /// </summary>
+        [Fact]
+        public void TerminalLoggerAutoIsNotSelectedWhenServerOutputIsRedirected()
+        {
+            TransientTestFile project = _env.CreateFile("tlAutoProject.proj", printPidContents);
+            _env.SetEnvironmentVariable("MSBUILDUSESERVER", "1");
+
+            string output = RunnerUtilities.ExecMSBuild(
+                BuildEnvironmentHelper.Instance.CurrentMSBuildExePath,
+                $"{project.Path} -tl:auto",
+                out bool success,
+                false,
+                _output);
+
+            success.ShouldBeTrue();
+
+            int pidOfInitialProcess = ParseNumber(output, "Process ID is ");
+            int pidOfServerProcess = ParseNumber(output, "Server ID is ");
+            _env.WithTransientProcess(pidOfServerProcess);
+            pidOfInitialProcess.ShouldNotBe(pidOfServerProcess, "The build should have run on a separate server node.");
+
+            // The output is redirected here, so TerminalLogger must not be auto-selected; its
+            // characteristic ANSI cursor-hide sequence must not appear in the captured output.
+            output.ShouldNotContain("\x1b[?25l");
+        }
+
         [Fact]
         public void VerifyMixedLegacyBehavior()
         {


### PR DESCRIPTION
Fixes #13940

### Context

With MSBuild Server enabled (`MSBUILDUSESERVER=1` / `DOTNET_CLI_USE_MSBUILD_SERVER=true`), `-tl:auto` (and the default) does **not** select TerminalLogger even from a real interactive terminal — it falls back to the classic console logger. The same invocation with the server disabled selects TL correctly. Reproduces on **Unix** (macOS/Linux); on **Windows** the inverse mis-detection happens (TL stays on under `msbuild > file.txt`).

**Root cause:** TerminalLogger auto-detection runs in `XMake.ProcessTerminalLoggerConfiguration`, which under the server executes **in the server node**. `NativeMethods.QueryIsScreenAndTryEnableAnsiColorCodes()` inspects the *current process's* `Console`, but the node's stdout is a redirected pipe, so the decision uses the node's console state instead of the client's. The client already captures the real terminal's capabilities into a `TargetConsoleConfiguration` and transmits them (stored as `ConsoleConfiguration.Provider`), but the query never consulted it.

### Changes

- **`src/Framework/NativeMethods.cs`** — add `ConsoleConfigurationOverride`. When set, `QueryIsScreenAndTryEnableAnsiColorCodes` returns the client's transmitted screen/ANSI capabilities and `null` for the original console mode (the node must not change/restore its own console).
- **`src/Build/BackEnd/Node/OutOfProcServerNode.cs`** — set the override from `command.ConsoleConfiguration` alongside `ConsoleConfiguration.Provider`, and clear it in a `finally`.

This is a single shared seam: `XMake`, `TerminalLogger.CreateTerminalOrConsoleLogger*`, and `SimpleErrorLogger` all call the query and become correct under the server with no further changes. In-proc builds are unaffected (override is `null`). It also corrects the Windows `> file.txt` case.

The override is set **unconditionally from each build's own transmitted configuration** before the build reads it, so a long-lived, reused server node never observes stale state across builds.

No ChangeWave: this is a correctness fix that aligns server behavior with the non-server (and documented default-TL) behavior, in an already opt-in scenario, with no new warnings/errors.

### Testing

- `src/Framework.UnitTests/NativeMethods_Tests.cs` — deterministic tests that the query honors `ConsoleConfigurationOverride` (incl. `useStandardError`), with `null` original console mode.
- `src/Build.UnitTests/TerminalLogger_Tests.cs` — positive regression test driving the real `QueryIsScreenAndTryEnableAnsiColorCodes` path via the override: a screen-capable transmitted config auto-selects `TerminalLogger`; a redirected one selects `ConsoleLogger`. Verified it fails without the fix (returns `ConsoleLogger`) and passes with it.
- `src/MSBuild.UnitTests/MSBuildServer_Tests.cs` — E2E guard that `-tl:auto` is not selected when the server build's output is redirected.

Manually verified end-to-end on WSL (Ubuntu) under a sized pseudo-terminal:

| Scenario | Before (shipped) | After (this change) |
|---|---|---|
| no server, `-tl:auto` | TerminalLogger | TerminalLogger |
| **server, `-tl:auto`** | **ConsoleLogger (bug)** | **TerminalLogger** |
| server, `-tl:on` | TerminalLogger | TerminalLogger |

Also confirmed that four alternating builds (TL-expected / not-expected) on the **same reused server node** each select the correct logger — no stale-state leakage.

### Notes

The user-visible behavior requires a real TTY to observe, which headless CI cannot easily provide; the deterministic unit tests above exercise the exact fix via the same override seam the server node uses, without needing a terminal.
