### PR TITLE
Make property functions and reflection-heavy paths trim-compatible

### DIFF
--- a/src/Build.UnitTests/Evaluation/PropertyFunctionReceiverRestriction_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/PropertyFunctionReceiverRestriction_Tests.cs
@@ -1,0 +1,353 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+using System.Runtime.Versioning;
+using Microsoft.Build.Collections;
+using Microsoft.Build.Evaluation;
+using Microsoft.Build.Execution;
+using Microsoft.Build.Shared.FileSystem;
+using Microsoft.Win32;
+using Shouldly;
+using Xunit;
+using InvalidProjectFileException = Microsoft.Build.Exceptions.InvalidProjectFileException;
+
+namespace Microsoft.Build.UnitTests.Evaluation;
+
+/// <summary>
+/// Tests for the property-function receiver restriction
+/// (the <c>Microsoft.Build.RestrictPropertyFunctionReceivers</c> AppContext switch) and its
+/// interaction with the <c>Microsoft.Build.EnableAllPropertyFunctions</c> escape hatch.
+/// </summary>
+/// <remarks>
+/// The restriction is driven through its AppContext switch (set explicitly per test and reset to false
+/// afterwards) because an AppContext switch, once set, cannot be returned to the "unset" state in
+/// process. The <c>EnableAllPropertyFunctions</c> escape hatch is exercised through its environment
+/// variable so that its AppContext switch stays unset, preserving the behavior the existing
+/// env-var-based tests rely on. The new restriction switch intentionally has no environment variable.
+/// </remarks>
+public class PropertyFunctionReceiverRestriction_Tests
+{
+    private const string RestrictSwitch = "Microsoft.Build.RestrictPropertyFunctionReceivers";
+    private const string RestrictEnvVar = "MSBUILDRESTRICTPROPERTYFUNCTIONS";
+    private const string EnableAllEnvVar = "MSBUILDENABLEALLPROPERTYFUNCTIONS";
+
+    private static string Evaluate(string expression, params (string name, string value)[] properties)
+    {
+        var propertyDictionary = new PropertyDictionary<ProjectPropertyInstance>();
+        foreach ((string name, string value) in properties)
+        {
+            propertyDictionary.Set(ProjectPropertyInstance.Create(name, value));
+        }
+
+        var expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(propertyDictionary, FileSystems.Default);
+        return expander.ExpandIntoStringLeaveEscaped(expression, ExpanderOptions.ExpandProperties, MockElementLocation.Instance);
+    }
+
+    private static IDisposable SetSwitch(string name, bool value)
+    {
+        AppContext.SetSwitch(name, value);
+        return new SwitchReset(name);
+    }
+
+    // AppContext has no API to return a switch to "unset", so reset to false (the untrimmed default,
+    // which means "not restricted"), keeping other tests on their default behavior.
+    private sealed class SwitchReset : IDisposable
+    {
+        private readonly string _name;
+
+        public SwitchReset(string name) => _name = name;
+
+        public void Dispose() => AppContext.SetSwitch(_name, false);
+    }
+
+    private static (string folder, string file) CreateFolderWithFile(TestEnvironment env)
+    {
+        string folder = env.CreateFolder().Path;
+        string file = Path.Combine(folder, "data.txt");
+        File.WriteAllText(file, "content");
+        return (folder, file);
+    }
+
+    // ---- Restricted: side-effect-free receivers remain callable ----
+
+    [Fact]
+    public void Restricted_StringChain_IsAllowed()
+    {
+        using (SetSwitch(RestrictSwitch, true))
+        {
+            Evaluate("$(S.Substring(0,5))", ("S", "HelloWorld")).ShouldBe("Hello");
+        }
+    }
+
+    [Fact]
+    public void Restricted_ArrayMembers_AreAllowed()
+    {
+        using (SetSwitch(RestrictSwitch, true))
+        {
+            // ToCharArray() returns char[]; Array members (Length) are permitted because array element
+            // access is re-checked at the next chain hop.
+            Evaluate("$(S.ToCharArray().Length)", ("S", "HelloWorld")).ShouldBe("10");
+        }
+    }
+
+    [Fact]
+    public void Restricted_AllowListedStaticFunction_StillWorks()
+    {
+        using (SetSwitch(RestrictSwitch, true))
+        {
+            Evaluate("$([System.Math]::Max(1, 2))").ShouldBe("2");
+        }
+    }
+
+    [Fact]
+    public void Restricted_DirectoryInfoReadOnlyNavigation_IsAllowed()
+    {
+        using TestEnvironment env = TestEnvironment.Create();
+        (string folder, string file) = CreateFolderWithFile(env);
+
+        using (SetSwitch(RestrictSwitch, true))
+        {
+            // GetParent(file) -> DirectoryInfo(folder); FullName / Parent are read-only navigation.
+            Evaluate("$([System.IO.Directory]::GetParent($(File)).FullName)", ("File", file))
+                .ShouldBe(folder);
+            Evaluate("$([System.IO.Directory]::GetParent($(File)).Parent.FullName)", ("File", file))
+                .ShouldBe(Directory.GetParent(folder)!.FullName);
+        }
+    }
+
+    // ---- Restricted: chains to non-listed receivers are not permitted ----
+
+    [Fact]
+    public void Restricted_DirectoryInfoMutation_IsBlocked()
+    {
+        using TestEnvironment env = TestEnvironment.Create();
+        (_, string file) = CreateFolderWithFile(env);
+
+        using (SetSwitch(RestrictSwitch, true))
+        {
+            // CreateSubdirectory changes the file system; it is not in the read-only navigation allowlist
+            // and is rejected before invocation (so no directory is created).
+            Assert.Throws<InvalidProjectFileException>(() =>
+                Evaluate("$([System.IO.Directory]::GetParent($(File)).CreateSubdirectory('sub'))", ("File", file)));
+        }
+    }
+
+    [Fact]
+    public void Restricted_DirectoryInfoEnumeration_IsBlocked()
+    {
+        using TestEnvironment env = TestEnvironment.Create();
+        (_, string file) = CreateFolderWithFile(env);
+
+        using (SetSwitch(RestrictSwitch, true))
+        {
+            // GetFiles returns FileInfo[] and is not in the navigation allowlist, so the chain to FileInfo
+            // (and OpenRead/OpenWrite) stops here.
+            Assert.Throws<InvalidProjectFileException>(() =>
+                Evaluate("$([System.IO.Directory]::GetParent($(File)).GetFiles())", ("File", file)));
+        }
+    }
+
+    [Fact]
+    public void Restricted_FileOpenChain_IsBlocked()
+    {
+        using TestEnvironment env = TestEnvironment.Create();
+        (_, string file) = CreateFolderWithFile(env);
+
+        using (SetSwitch(RestrictSwitch, true))
+        {
+            // The chain to OpenWrite is not permitted; it stops at GetFiles, before any FileInfo is produced.
+            Assert.Throws<InvalidProjectFileException>(() =>
+                Evaluate("$([System.IO.Directory]::GetParent($(File)).GetFiles().GetValue(0).OpenWrite().CanWrite)", ("File", file)));
+        }
+    }
+
+    [Fact]
+    public void Restricted_GetType_IsBlocked()
+    {
+        using (SetSwitch(RestrictSwitch, true))
+        {
+            Assert.Throws<InvalidProjectFileException>(() =>
+                Evaluate("$(S.GetType())", ("S", "HelloWorld")));
+        }
+    }
+
+    // ---- Default (unrestricted) behavior is preserved ----
+
+    [Fact]
+    public void Unrestricted_DirectoryInfoEnumeration_IsAllowed()
+    {
+        using TestEnvironment env = TestEnvironment.Create();
+        (_, string file) = CreateFolderWithFile(env);
+
+        using (SetSwitch(RestrictSwitch, false))
+        {
+            // With the restriction off, the historical dotting behavior is unchanged.
+            Evaluate("$([System.IO.Directory]::GetParent($(File)).GetFiles().Length)", ("File", file))
+                .ShouldBe("1");
+        }
+    }
+
+    // ---- The new restriction switch has no environment-variable opt-in ----
+
+    [Fact]
+    public void EnvironmentVariable_DoesNotEnableRestriction()
+    {
+        using TestEnvironment env = TestEnvironment.Create();
+        (_, string file) = CreateFolderWithFile(env);
+
+        // The new switch deliberately has no environment-variable opt-in; setting the (non-wired)
+        // variable must not turn the restriction on.
+        env.SetEnvironmentVariable(RestrictEnvVar, "1");
+
+        Evaluate("$([System.IO.Directory]::GetParent($(File)).GetFiles().Length)", ("File", file))
+            .ShouldBe("1");
+    }
+
+    // ---- EnableAll escape hatch bypasses the restriction ----
+
+    [Fact]
+    public void EnableAllPropertyFunctions_BypassesRestriction()
+    {
+        using TestEnvironment env = TestEnvironment.Create();
+        env.SetEnvironmentVariable(EnableAllEnvVar, "1");
+
+        using (SetSwitch(RestrictSwitch, true))
+        {
+            // EnableAll takes precedence over the restriction (and over the GetType block), preserving
+            // the documented "anything goes" escape hatch.
+            Evaluate("$(S.GetType().Name)", ("S", "HelloWorld")).ShouldBe("String");
+        }
+    }
+
+    // ---- Restricted: property setters and their special method names cannot run ----
+
+    [Theory]
+    [InlineData("set_Attributes(2)")] // FileSystemInfo.Attributes setter mutates the file system
+    [InlineData("set_CreationTime('2000-01-01')")]
+    [InlineData("set_LastWriteTime('2000-01-01')")]
+    [InlineData("set_LastAccessTime('2000-01-01')")]
+    public void Restricted_FileSystemInfoSetter_IsBlocked(string setterCall)
+    {
+        using TestEnvironment env = TestEnvironment.Create();
+        (string folder, string file) = CreateFolderWithFile(env);
+        FileAttributes attributesBefore = File.GetAttributes(folder);
+
+        using (SetSwitch(RestrictSwitch, true))
+        {
+            // A property setter is reachable only by its set_ special method name (the property-access
+            // form is getter-only - it binds with GetProperty/GetField, never SetProperty). That name is
+            // not in the FileSystemInfo navigation allowlist, so the call is rejected at the receiver
+            // check, before any argument is bound or the setter runs.
+            Assert.Throws<InvalidProjectFileException>(() =>
+                Evaluate($"$([System.IO.Directory]::GetParent($(File)).{setterCall})", ("File", file)));
+        }
+
+        // The setter never executed: the directory on disk is unchanged.
+        File.GetAttributes(folder).ShouldBe(attributesBefore);
+    }
+
+    [Fact]
+    public void Restricted_PropertyGetter_IsAllowed()
+    {
+        using TestEnvironment env = TestEnvironment.Create();
+        (_, string file) = CreateFolderWithFile(env);
+
+        using (SetSwitch(RestrictSwitch, true))
+        {
+            // Reading the property through property-access syntax (the getter) is allowed; only the
+            // matching setter is blocked.
+            Evaluate("$([System.IO.Directory]::GetParent($(File)).Attributes)", ("File", file))
+                .ShouldContain("Directory");
+        }
+    }
+
+    [Fact]
+    public void Restricted_GetterSpecialMethodName_IsBlocked()
+    {
+        using TestEnvironment env = TestEnvironment.Create();
+        (_, string file) = CreateFolderWithFile(env);
+
+        using (SetSwitch(RestrictSwitch, true))
+        {
+            // Even the getter's get_ special method name is a method that is not in the navigation
+            // allowlist, so it too is blocked; only the property-access form (validated by name) works.
+            Assert.Throws<InvalidProjectFileException>(() =>
+                Evaluate("$([System.IO.Directory]::GetParent($(File)).get_Attributes())", ("File", file)));
+        }
+    }
+
+    [Fact]
+    public void Unrestricted_SpecialMethodName_IsReachable()
+    {
+        using TestEnvironment env = TestEnvironment.Create();
+        (_, string file) = CreateFolderWithFile(env);
+
+        using (SetSwitch(RestrictSwitch, false))
+        {
+            // With the restriction off, get_/set_ special method names are genuinely invocable as
+            // methods - which is exactly why the blocked-setter tests above are meaningful.
+            Evaluate("$([System.IO.Directory]::GetParent($(File)).get_Attributes())", ("File", file))
+                .ShouldContain("Directory");
+        }
+    }
+
+    // ---- Restricted: state-mutating static functions stay blocked ----
+
+    [Theory]
+    [InlineData("$([System.Environment]::SetEnvironmentVariable('MSBUILD_RPF_TEST', 'x'))")]
+    [InlineData("$([System.Environment]::set_CurrentDirectory('.'))")]
+    public void Restricted_StaticStateMutation_StaysBlocked(string expression)
+    {
+        using (SetSwitch(RestrictSwitch, true))
+        {
+            // The receiver restriction governs instance "dotting in"; static calls remain governed by
+            // the static allowlist. Neither process-state mutator is allowlisted, so both stay blocked
+            // (and never run).
+            Assert.Throws<InvalidProjectFileException>(() => Evaluate(expression));
+        }
+
+        Environment.GetEnvironmentVariable("MSBUILD_RPF_TEST").ShouldBeNull();
+    }
+
+    // ---- Restricted: registry reads are unaffected ----
+
+    [Fact]
+    public void Restricted_RegistryValue_NonexistentKey_IsNotBlocked()
+    {
+        using (SetSwitch(RestrictSwitch, true))
+        {
+            // GetRegistryValue is a static [MSBuild] intrinsic, gated by the static allowlist (which
+            // permits it), not by the receiver restriction. A missing key yields the default (empty) and
+            // must not raise the restriction's "function unavailable" error.
+            Evaluate(@"$([MSBuild]::GetRegistryValue('HKEY_CURRENT_USER\Software\Microsoft\MSBuild_NonexistentRpfKey', 'None'))")
+                .ShouldBe(string.Empty);
+        }
+    }
+
+    [WindowsOnlyFact]
+    [SupportedOSPlatform("windows")]
+    public void Restricted_RegistryRead_StillWorks()
+    {
+        using (SetSwitch(RestrictSwitch, true))
+        {
+            try
+            {
+                RegistryKey key = Registry.CurrentUser.CreateSubKey(@"Software\Microsoft\MSBuild_test_rpf");
+                key.SetValue("Value", "RegistryString", RegistryValueKind.String);
+
+                // Both registry read paths - the [MSBuild]::GetRegistryValue function and the
+                // $(Registry:...) prefix - are read-only and unaffected by the receiver restriction.
+                Evaluate(@"$([MSBuild]::GetRegistryValue('HKEY_CURRENT_USER\Software\Microsoft\MSBuild_test_rpf', 'Value'))")
+                    .ShouldBe("RegistryString");
+                Evaluate(@"$(Registry:HKEY_CURRENT_USER\Software\Microsoft\MSBuild_test_rpf@Value)")
+                    .ShouldBe("RegistryString");
+            }
+            finally
+            {
+                Registry.CurrentUser.DeleteSubKey(@"Software\Microsoft\MSBuild_test_rpf");
+            }
+        }
+    }
+}

--- a/src/Build/BackEnd/Components/Logging/BuildErrorTelemetryTracker.cs
+++ b/src/Build/BackEnd/Components/Logging/BuildErrorTelemetryTracker.cs
@@ -34,12 +34,19 @@ namespace Microsoft.Build.BackEnd.Logging
             WPF,
             AspNet,
             Other,
+
+            /// <summary>
+            /// Sentinel that must remain the last member. Used to size <see cref="_errorCounts"/>
+            /// without reflection (which would trigger trim/AOT warnings) while staying self-maintaining
+            /// as categories are added. Never returned by <see cref="CategorizeError"/>.
+            /// </summary>
+            Count,
         }
 
         /// <summary>
         /// Error counts by category index (using enum ordinal).
         /// </summary>
-        private readonly int[] _errorCounts = new int[Enum.GetValues(typeof(ErrorCategory)).Length];
+        private readonly int[] _errorCounts = new int[(int)ErrorCategory.Count];
 
         /// <summary>
         /// Tracks the primary failure category (category with highest count).

--- a/src/Build/BackEnd/Components/Logging/LoggingService.cs
+++ b/src/Build/BackEnd/Components/Logging/LoggingService.cs
@@ -1040,8 +1040,8 @@ namespace Microsoft.Build.BackEnd.Logging
                 if (_centralForwardingLoggerSinkId == -1)
                 {
                     // Create a forwarding logger which forwards all events to an eventSourceSink
-                    Assembly engineAssembly = typeof(LoggingService).Assembly;
-                    string loggerClassName = "Microsoft.Build.BackEnd.Logging.CentralForwardingLogger";
+                    Assembly engineAssembly = typeof(CentralForwardingLogger).Assembly;
+                    string loggerClassName = typeof(CentralForwardingLogger).FullName;
                     string loggerAssemblyName = engineAssembly.GetName().FullName;
                     LoggerDescription centralForwardingLoggerDescription = new LoggerDescription(
                                                                                       loggerClassName,
@@ -1050,9 +1050,9 @@ namespace Microsoft.Build.BackEnd.Logging
                                                                                       string.Empty /*No parameters needed as we are forwarding all events*/,
                                                                                       LoggerVerbosity.Diagnostic); /*Not used, but the spirit of the logger is to forward everything so this is the most appropriate verbosity */
 
-                    // Registering a distributed logger will initialize the logger, and create and initialize the forwarding logger.
+                    // Registering a distributed logger will initialize the logger, and initialize the forwarding logger.
                     // In addition it will register the logging description so that it can be instantiated on a node.
-                    RegisterDistributedLogger(logger, centralForwardingLoggerDescription);
+                    RegisterDistributedLoggerCore(logger, centralForwardingLoggerDescription, new CentralForwardingLogger());
 
                     // Get the Id of the eventSourceSink which was created for the first logger.
                     // We keep a reference to this Id so that all other central loggers registered on this logging service (from registerLogger)
@@ -1121,50 +1121,60 @@ namespace Microsoft.Build.BackEnd.Logging
                     centralLogger = new NullCentralLogger();
                 }
 
-                IForwardingLogger localForwardingLogger = null;
-
-                // create an eventSourceSink which the central logger will register with to receive the events from the forwarding logger
-                EventSourceSink eventSourceSink = new EventSourceSink();
-
-                // If the logger is already in the list it should not be registered again.
-                // Note here that we are checking for direct equivalence (fast)
-                // and if we're dealing with a reusable logger, we need to check its original logger (slower)
-                if (_loggers.Contains(centralLogger) || _loggers.Any(l => l is ReusableLogger rl && rl.OriginalLogger == centralLogger))
-                {
-                    return false;
-                }
-
-                // Assign a unique logger Id to this distributed logger
-                int sinkId = _nextSinkId++;
-                forwardingLogger.LoggerId = sinkId;
-                eventSourceSink.Name = $"Sink for forwarding logger \"{sinkId}\".";
-
-                // Initialize and register the central logger
-                InitializeLogger(centralLogger, eventSourceSink);
-
-                localForwardingLogger = forwardingLogger.CreateForwardingLogger();
-                EventRedirectorToSink newRedirector = new EventRedirectorToSink(sinkId, eventSourceSink);
-                localForwardingLogger.BuildEventRedirector = newRedirector;
-                localForwardingLogger.Parameters = forwardingLogger.LoggerSwitchParameters;
-                localForwardingLogger.Verbosity = forwardingLogger.Verbosity;
-
-                // Give the forwarding logger registered on the inproc node the correct ID.
-                localForwardingLogger.NodeId = 1;
-
-                // Convert the path to the logger DLL to full path before passing it to the node provider
-                forwardingLogger.ConvertPathsToFullPaths();
-
-                CreateFilterEventSource();
-
-                // Initialize and register the forwarding logger
-                InitializeLogger(localForwardingLogger, _filterEventSource);
-
-                _loggerDescriptions.Add(forwardingLogger);
-
-                _eventSinkDictionary.Add(sinkId, eventSourceSink);
-
-                return true;
+                return RegisterDistributedLoggerCore(centralLogger, forwardingLogger, forwardingLogger.CreateForwardingLogger());
             }
+        }
+
+        private bool RegisterDistributedLoggerCore(ILogger centralLogger, LoggerDescription forwardingLogger, IForwardingLogger localForwardingLogger)
+        {
+            Assumed.NotEqual(_serviceState, LoggingServiceState.Shutdown, " The object is shutdown, should not do any operations on a shutdown component");
+            Assumed.NotNull(forwardingLogger, "forwardingLogger was null");
+            Assumed.NotNull(localForwardingLogger, "localForwardingLogger was null");
+            if (centralLogger == null)
+            {
+                centralLogger = new NullCentralLogger();
+            }
+
+            // create an eventSourceSink which the central logger will register with to receive the events from the forwarding logger
+            EventSourceSink eventSourceSink = new EventSourceSink();
+
+            // If the logger is already in the list it should not be registered again.
+            // Note here that we are checking for direct equivalence (fast)
+            // and if we're dealing with a reusable logger, we need to check its original logger (slower)
+            if (_loggers.Contains(centralLogger) || _loggers.Any(l => l is ReusableLogger rl && rl.OriginalLogger == centralLogger))
+            {
+                return false;
+            }
+
+            // Assign a unique logger Id to this distributed logger
+            int sinkId = _nextSinkId++;
+            forwardingLogger.LoggerId = sinkId;
+            eventSourceSink.Name = $"Sink for forwarding logger \"{sinkId}\".";
+
+            // Initialize and register the central logger
+            InitializeLogger(centralLogger, eventSourceSink);
+
+            EventRedirectorToSink newRedirector = new EventRedirectorToSink(sinkId, eventSourceSink);
+            localForwardingLogger.BuildEventRedirector = newRedirector;
+            localForwardingLogger.Parameters = forwardingLogger.LoggerSwitchParameters;
+            localForwardingLogger.Verbosity = forwardingLogger.Verbosity;
+
+            // Give the forwarding logger registered on the inproc node the correct ID.
+            localForwardingLogger.NodeId = 1;
+
+            // Convert the path to the logger DLL to full path before passing it to the node provider
+            forwardingLogger.ConvertPathsToFullPaths();
+
+            CreateFilterEventSource();
+
+            // Initialize and register the forwarding logger
+            InitializeLogger(localForwardingLogger, _filterEventSource);
+
+            _loggerDescriptions.Add(forwardingLogger);
+
+            _eventSinkDictionary.Add(sinkId, eventSourceSink);
+
+            return true;
         }
 
         /// <summary>

--- a/src/Build/BackEnd/TaskExecutionHost/TaskExecutionHost.cs
+++ b/src/Build/BackEnd/TaskExecutionHost/TaskExecutionHost.cs
@@ -790,41 +790,64 @@ namespace Microsoft.Build.BackEnd
 
             try
             {
-                // Loop through all the TaskItems in our arraylist, and convert them.
-                ArrayList finalTaskInputs = new ArrayList(taskItems.Count);
+                Type elementType = parameterType.GetElementType();
 
-                if (parameterType != typeof(ITaskItem[]))
+                if (parameterType == typeof(ITaskItem[]))
                 {
-                    foreach (TaskItem item in taskItems)
+                    ITaskItem[] finalInputs = new ITaskItem[taskItems.Count];
+                    for (int i = 0; i < taskItems.Count; i++)
                     {
+                        TaskItem item = taskItems[i];
                         currentItem = item;
-                        if (parameterType == typeof(string[]))
-                        {
-                            finalTaskInputs.Add(item.ItemSpec);
-                        }
-                        else if (parameterType == typeof(bool[]))
-                        {
-                            finalTaskInputs.Add(ConversionUtilities.ConvertStringToBool(item.ItemSpec));
-                        }
-                        else
-                        {
-                            finalTaskInputs.Add(Convert.ChangeType(item.ItemSpec, parameterType.GetElementType(), CultureInfo.InvariantCulture));
-                        }
-                    }
-                }
-                else
-                {
-                    foreach (TaskItem item in taskItems)
-                    {
+
                         // if we've been asked to remote these items then
                         // remember them so we can disconnect them from remoting later
                         RecordItemForDisconnectIfNecessary(item);
-
-                        finalTaskInputs.Add(item);
+                        finalInputs[i] = item;
                     }
-                }
 
-                return InternalSetTaskParameter(parameter, finalTaskInputs.ToArray(parameterType.GetElementType()));
+                    return InternalSetTaskParameter(parameter, finalInputs);
+                }
+                else if (parameterType == typeof(string[]))
+                {
+                    string[] finalInputs = new string[taskItems.Count];
+                    for (int i = 0; i < taskItems.Count; i++)
+                    {
+                        currentItem = taskItems[i];
+                        finalInputs[i] = currentItem.ItemSpec;
+                    }
+
+                    return InternalSetTaskParameter(parameter, finalInputs);
+                }
+                else if (parameterType == typeof(bool[]))
+                {
+                    bool[] finalInputs = new bool[taskItems.Count];
+                    for (int i = 0; i < taskItems.Count; i++)
+                    {
+                        currentItem = taskItems[i];
+                        finalInputs[i] = ConversionUtilities.ConvertStringToBool(currentItem.ItemSpec);
+                    }
+
+                    return InternalSetTaskParameter(parameter, finalInputs);
+                }
+                else
+                {
+                    // Fallback for custom value types
+#if NET
+                    // AOT friendly
+                    Array finalTaskInputs = Array.CreateInstanceFromArrayType(parameterType, taskItems.Count);
+#else
+                    Array finalTaskInputs = Array.CreateInstance(elementType, taskItems.Count);
+#endif
+                    for (int i = 0; i < taskItems.Count; i++)
+                    {
+                        TaskItem item = taskItems[i];
+                        currentItem = item;
+                        finalTaskInputs.SetValue(Convert.ChangeType(item.ItemSpec, elementType, CultureInfo.InvariantCulture), i);
+                    }
+
+                    return InternalSetTaskParameter(parameter, finalTaskInputs);
+                }
             }
             catch (Exception ex)
             {

--- a/src/Build/Evaluation/Expander.Function.cs
+++ b/src/Build/Evaluation/Expander.Function.cs
@@ -10,7 +10,6 @@ using System.IO;
 #endif
 using System.Linq;
 using System.Reflection;
-using System.Runtime.CompilerServices;
 using Microsoft.Build.BackEnd.Logging;
 using Microsoft.Build.Evaluation.Expander;
 using Microsoft.Build.Framework;
@@ -18,6 +17,7 @@ using Microsoft.Build.Shared;
 using Microsoft.Build.Shared.FileSystem;
 using Microsoft.NET.StringTools;
 using AvailableStaticMethods = Microsoft.Build.Internal.AvailableStaticMethods;
+using FeatureSwitches = Microsoft.Build.Internal.FeatureSwitches;
 using ParseArgs = Microsoft.Build.Evaluation.Expander.ArgumentParser;
 
 #if FEATURE_MSIOREDIST
@@ -43,6 +43,17 @@ internal partial class Expander<P, I>
         /// <summary>
         /// The type of this function's receiver.
         /// </summary>
+        /// <remarks>
+        /// Property-function evaluation only ever binds public members (BindingFlags.NonPublic is
+        /// never set on this path), so only the public member surface needs to be preserved for
+        /// trimming. Keep in sync with Constants.PropertyFunctionMembers, which preserves the same
+        /// set on every allowlisted receiver type.
+        /// </remarks>
+        [DynamicallyAccessedMembers(
+            DynamicallyAccessedMemberTypes.PublicConstructors |
+            DynamicallyAccessedMemberTypes.PublicMethods |
+            DynamicallyAccessedMemberTypes.PublicProperties |
+            DynamicallyAccessedMemberTypes.PublicFields)]
         private Type _receiverType;
 
         /// <summary>
@@ -66,8 +77,30 @@ internal partial class Expander<P, I>
         private readonly string _receiver;
 
         /// <summary>
+        /// The complete set of <see cref="BindingFlags"/> the property-function binder is permitted
+        /// to use. This set intentionally excludes <see cref="BindingFlags.NonPublic"/>: property
+        /// functions only ever bind public members. That exclusion is what lets a receiver type
+        /// preserve only its public member surface for trimming (see Constants.PropertyFunctionMembers)
+        /// and keeps the flags handed to <c>TypeExtensions.InvokePublicMember</c> free of
+        /// <see cref="BindingFlags.NonPublic"/>.
+        /// </summary>
+        private const BindingFlags AllowedBindingFlags =
+            BindingFlags.IgnoreCase
+            | BindingFlags.Public
+            | BindingFlags.Static
+            | BindingFlags.Instance
+            | BindingFlags.InvokeMethod
+            | BindingFlags.GetProperty
+            | BindingFlags.GetField;
+
+        /// <summary>
         /// The binding flags that will be used during invocation of this function.
         /// </summary>
+        /// <remarks>
+        /// Always a subset of <see cref="AllowedBindingFlags"/> - constrained at construction and only
+        /// ever augmented with <see cref="BindingFlags.Static"/> / <see cref="BindingFlags.Instance"/>
+        /// thereafter - so it can never carry <see cref="BindingFlags.NonPublic"/>.
+        /// </remarks>
         private BindingFlags _bindingFlags;
 
         /// <summary>
@@ -88,7 +121,11 @@ internal partial class Expander<P, I>
         /// Construct a function that will be executed during property evaluation.
         /// </summary>
         internal Function(
-            Type receiverType,
+            [DynamicallyAccessedMembers(
+                DynamicallyAccessedMemberTypes.PublicConstructors |
+                DynamicallyAccessedMemberTypes.PublicMethods |
+                DynamicallyAccessedMemberTypes.PublicProperties |
+                DynamicallyAccessedMemberTypes.PublicFields)] Type receiverType,
             string expression,
             string receiver,
             string methodName,
@@ -112,7 +149,17 @@ internal partial class Expander<P, I>
             _receiver = receiver;
             _expression = expression;
             _receiverType = receiverType;
-            _bindingFlags = bindingFlags;
+
+            // Property functions never bind non-public members. Constrain the incoming flags to the
+            // allowed set so that invariant holds by construction: the only in-class mutations after
+            // this add Static/Instance (both already allowed), so _bindingFlags can never carry
+            // BindingFlags.NonPublic, so the flags handed to TypeExtensions.InvokePublicMember never
+            // request non-public members.
+            System.Diagnostics.Debug.Assert(
+                (bindingFlags & ~AllowedBindingFlags) == 0,
+                $"Property-function binding flags '{bindingFlags}' include flags outside the allowed set; BindingFlags.NonPublic in particular is never permitted.");
+            _bindingFlags = bindingFlags & AllowedBindingFlags;
+
             _remainder = remainder;
             _propertiesUseTracker = propertiesUseTracker;
             _fileSystem = fileSystem;
@@ -291,6 +338,8 @@ internal partial class Expander<P, I>
         /// <summary>
         /// Execute the function on the given instance.
         /// </summary>
+        [UnconditionalSuppressMessage("Trimming", "IL2074:UnrecognizedReflectionPattern",
+            Justification = "_receiverType is reassigned from a runtime property value whose type is restricted to the property-function allowlist, whose members are preserved for trimming.")]
         internal object Execute(object objectInstance, IPropertyProvider<P> properties, ExpanderOptions options, IElementLocation elementLocation)
         {
             object functionResult = String.Empty;
@@ -308,18 +357,11 @@ internal partial class Expander<P, I>
                     }
 
                     _bindingFlags |= BindingFlags.Static;
-
-                    // For our intrinsic function we need to support calling of internal methods
-                    // since we don't want them to be public
-                    if (_receiverType == typeof(IntrinsicFunctions))
-                    {
-                        _bindingFlags |= BindingFlags.NonPublic;
-                    }
                 }
                 else
                 {
                     // Check that the function that we're going to call is valid to call
-                    if (!IsInstanceMethodAvailable(_methodMethodName))
+                    if (!IsInstanceMethodAvailable(_receiverType, _methodMethodName))
                     {
                         ProjectErrorUtilities.ThrowInvalidProject(elementLocation, "InvalidFunctionMethodUnavailable", _methodMethodName, _receiverType.FullName);
                     }
@@ -470,13 +512,13 @@ internal partial class Expander<P, I>
                             // If there are any out parameters, try to figure out their type and create defaults for them as appropriate before calling the method.
                             if (args.Any(a => "out _".Equals(a)))
                             {
-                                IEnumerable<MethodInfo> methods = _receiverType.GetMethods(_bindingFlags).Where(m => m.Name.Equals(_methodMethodName) && m.GetParameters().Length == args.Length);
+                                IEnumerable<MethodInfo> methods = _receiverType.GetMethods().Where(m => m.Name.Equals(_methodMethodName) && m.GetParameters().Length == args.Length);
                                 functionResult = GetMethodResult(objectInstance, methods, args, 0);
                             }
                             else
                             {
                                 // If there are no out parameters, use InvokeMember using the standard binder - this will match and coerce as needed
-                                functionResult = _receiverType.InvokeMember(_methodMethodName, _bindingFlags, Type.DefaultBinder, objectInstance, args, CultureInfo.InvariantCulture);
+                                functionResult = _receiverType.InvokePublicMember(_methodMethodName, _bindingFlags, objectInstance, args);
                             }
                         }
                         // If we're invoking a method, then there are deeper attempts that can be made to invoke the method.
@@ -562,7 +604,7 @@ internal partial class Expander<P, I>
                     foreach (MethodInfo method in methods)
                     {
                         Type t = method.GetParameters()[i].ParameterType;
-                        args[i] = t.IsValueType ? Activator.CreateInstance(t) : null;
+                        args[i] = t.CreateDefault();
                         object currentReturnValue = GetMethodResult(objectInstance, methods, args, i + 1);
                         if (currentReturnValue is not null)
                         {
@@ -585,7 +627,7 @@ internal partial class Expander<P, I>
 
             try
             {
-                return _receiverType.InvokeMember(_methodMethodName, _bindingFlags, Type.DefaultBinder, objectInstance, args, CultureInfo.InvariantCulture) ?? "null";
+                return _receiverType.InvokePublicMember(_methodMethodName, _bindingFlags, objectInstance, args) ?? "null";
             }
             catch (Exception)
             {
@@ -600,6 +642,10 @@ internal partial class Expander<P, I>
         /// <param name="typeName">May be full name or assembly qualified name.</param>
         /// <param name="simpleMethodName">simple name of the method.</param>
         /// <returns></returns>
+        [UnconditionalSuppressMessage("Trimming", "IL2096:UnrecognizedReflectionPattern",
+            Justification = "The type name is resolved against the curated AvailableStaticMethods allowlist; the case-insensitive lookup only resolves to allowlist types, whose members are preserved for trimming.")]
+        [UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode",
+            Justification = "The GetTypeFromAssembly / GetTypeFromAssemblyUsingNamespace calls below are reached only when the EnableAllPropertyFunctions feature switch is enabled (MSBUILDENABLEALLPROPERTYFUNCTIONS=1). That switch is a FeatureSwitchDefinition defaulting to false under trimming (see the RuntimeHostConfigurationOption in Microsoft.Build.csproj), so the trimmer removes this branch from a trimmed application; the trim analyzer does not evaluate the feature-switch default and therefore still reports the call as reachable.")]
         private static Type GetTypeForStaticMethod(string typeName, string simpleMethodName)
         {
             Type receiverType;
@@ -658,8 +704,11 @@ internal partial class Expander<P, I>
             }
 
             // Note the following code path is only entered when MSBUILDENABLEALLPROPERTYFUNCTIONS == 1.
-            // This environment variable must not be cached - it should be dynamically settable while the application is executing.
-            if (Environment.GetEnvironmentVariable("MSBUILDENABLEALLPROPERTYFUNCTIONS") == "1")
+            // It is modeled as a trimmer feature switch (see FeatureSwitches) so this reflective
+            // probing is removed from trimmed applications, where only the curated allowlist of
+            // receiver types is supported. The environment variable is still honored at runtime when
+            // not trimmed, and must not be cached so it stays dynamically settable.
+            if (FeatureSwitches.EnableAllPropertyFunctions)
             {
                 // We didn't find the type, so go probing. First in System
                 receiverType = GetTypeFromAssembly(typeName, "System");
@@ -690,6 +739,7 @@ internal partial class Expander<P, I>
         /// <summary>
         /// Gets the specified type using the namespace to guess the assembly that its in.
         /// </summary>
+        [RequiresUnreferencedCode("Resolves a property-function receiver type by probing and loading assemblies at runtime; reachable only via the MSBUILDENABLEALLPROPERTYFUNCTIONS feature switch, which is disabled under trimming.")]
         private static Type GetTypeFromAssemblyUsingNamespace(string typeName)
         {
             string baseName = typeName;
@@ -731,6 +781,7 @@ internal partial class Expander<P, I>
         /// Get the specified type from the assembly partial name supplied.
         /// </summary>
         [SuppressMessage("Microsoft.Reliability", "CA2001:AvoidCallingProblematicMethods", MessageId = "System.Reflection.Assembly.LoadWithPartialName", Justification = "Necessary since we don't have the full assembly name. ")]
+        [RequiresUnreferencedCode("Resolves a property-function receiver type by loading an assembly by partial name at runtime; reachable only via the MSBUILDENABLEALLPROPERTYFUNCTIONS feature switch, which is disabled under trimming.")]
         private static Type GetTypeFromAssembly(string typeName, string candidateAssemblyName)
         {
             Type objectType = null;
@@ -1065,7 +1116,7 @@ internal partial class Expander<P, I>
                 return true;
             }
 
-            if (Traits.Instance.EnableAllPropertyFunctions)
+            if (FeatureSwitches.EnableAllPropertyFunctions)
             {
                 // anything goes
                 return true;
@@ -1074,17 +1125,72 @@ internal partial class Expander<P, I>
             return AvailableStaticMethods.GetTypeInformationFromTypeCache(receiverType.FullName, methodName) != null;
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static bool IsInstanceMethodAvailable(string methodName)
+        private static bool IsInstanceMethodAvailable(Type receiverType, string methodName)
         {
-            if (Traits.Instance.EnableAllPropertyFunctions)
+            // The escape hatch opens everything (this preserves the historical behavior, including
+            // allowing GetType). Under trimming EnableAllPropertyFunctions is substituted false and
+            // this branch is removed.
+            if (FeatureSwitches.EnableAllPropertyFunctions)
             {
-                // anything goes
                 return true;
             }
 
-            // This could be expanded to an allow / deny list.
-            return !string.Equals("GetType", methodName, StringComparison.OrdinalIgnoreCase);
+            // GetType is excluded outside the escape hatch: it returns an open-ended Type that would
+            // make the reachable member surface unpredictable.
+            if (string.Equals("GetType", methodName, StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            // When restriction is on - the default under trimming, opt-in otherwise - instance
+            // "dotting in" is limited to a curated set of receiver types so the members reachable by
+            // reflection are predictable and statically known. Under trimming
+            // RestrictPropertyFunctionReceivers is substituted true, so the unrestricted 'return true'
+            // below is removed, keeping the property-function path trim compatible.
+            if (FeatureSwitches.RestrictPropertyFunctionReceivers)
+            {
+                return PropertyFunctionReceiver.IsAllowed(receiverType, methodName);
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Finds a public method on the receiver type by name (case-insensitive) and exact
+        /// parameter-type signature, using the public-only <see cref="Type.GetMethods()"/> overload.
+        /// </summary>
+        private MethodInfo FindPublicMethodBySignature(string methodName, Type[] parameterTypes)
+        {
+            foreach (MethodInfo method in _receiverType.GetMethods())
+            {
+                if (!string.Equals(method.Name, methodName, StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                ParameterInfo[] parameters = method.GetParameters();
+                if (parameters.Length != parameterTypes.Length)
+                {
+                    continue;
+                }
+
+                bool match = true;
+                for (int i = 0; i < parameters.Length; i++)
+                {
+                    if (parameters[i].ParameterType != parameterTypes[i])
+                    {
+                        match = false;
+                        break;
+                    }
+                }
+
+                if (match)
+                {
+                    return method;
+                }
+            }
+
+            return null;
         }
 
         /// <summary>
@@ -1103,11 +1209,14 @@ internal partial class Expander<P, I>
             MethodBase memberInfo;
             if (isConstructor)
             {
-                memberInfo = _receiverType.GetConstructor(bindingFlags, null, types, null);
+                memberInfo = _receiverType.GetConstructor(types);
             }
             else
             {
-                memberInfo = _receiverType.GetMethod(_methodMethodName, bindingFlags, null, types, null);
+                // Match a public method by name (case-insensitive) and exact parameter signature.
+                // Equivalent to the prior GetMethod(..., BindingFlags, ...) call but uses the
+                // public-only GetMethods() overload, since BindingFlags.NonPublic is never set here.
+                memberInfo = FindPublicMethodBySignature(_methodMethodName, types);
             }
 
             // If we didn't get a match on all string arguments,
@@ -1118,11 +1227,14 @@ internal partial class Expander<P, I>
                 IEnumerable<MethodBase> members;
                 if (isConstructor)
                 {
-                    members = _receiverType.GetConstructors(bindingFlags);
+                    members = _receiverType.GetConstructors();
                 }
                 else if (_receiverType == typeof(IntrinsicFunctions) && IntrinsicFunctionOverload.IsKnownOverloadMethodName(_methodMethodName))
                 {
-                    MemberInfo[] foundMembers = _receiverType.FindMembers(
+                    // FindMembers is invoked on the statically-known IntrinsicFunctions type (the
+                    // only receiver that reaches this branch), so its broad reflection contract is
+                    // satisfied by that concrete, rooted type rather than the receiver-type field.
+                    MemberInfo[] foundMembers = typeof(IntrinsicFunctions).FindMembers(
                         MemberTypes.Method,
                         bindingFlags,
                         (info, criteria) => string.Equals(info.Name, (string)criteria, StringComparison.OrdinalIgnoreCase),
@@ -1132,7 +1244,7 @@ internal partial class Expander<P, I>
                 }
                 else
                 {
-                    members = _receiverType.GetMethods(bindingFlags).Where(m => string.Equals(m.Name, _methodMethodName, StringComparison.OrdinalIgnoreCase));
+                    members = _receiverType.GetMethods().Where(m => string.Equals(m.Name, _methodMethodName, StringComparison.OrdinalIgnoreCase));
                 }
 
                 foreach (MethodBase member in members)

--- a/src/Build/Evaluation/Expander.FunctionBuilder.cs
+++ b/src/Build/Evaluation/Expander.FunctionBuilder.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using Microsoft.Build.BackEnd.Logging;
 using Microsoft.Build.Shared.FileSystem;
@@ -60,6 +61,8 @@ internal partial class Expander<P, I>
         /// </summary>
         public PropertiesUseTracker PropertiesUseTracker { get; set; }
 
+        [UnconditionalSuppressMessage("Trimming", "IL2072:UnrecognizedReflectionPattern",
+            Justification = "The receiver type stored in ReceiverType is a property-function receiver, restricted to the curated AvailableStaticMethods allowlist (whose members are preserved for trimming) or to a property value of an allowlist type; the DynamicallyAccessedMembers requirement of the Function constructor is satisfied for those preserved types.")]
         internal readonly Function Build()
         {
             return new Function(

--- a/src/Build/Evaluation/IntrinsicFunctions.cs
+++ b/src/Build/Evaluation/IntrinsicFunctions.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Build.Evaluation
         /// <summary>
         /// Add two doubles
         /// </summary>
-        internal static double Add(double a, double b)
+        public static double Add(double a, double b)
         {
             return a + b;
         }
@@ -63,7 +63,7 @@ namespace Microsoft.Build.Evaluation
         /// <summary>
         /// Add two longs
         /// </summary>
-        internal static long Add(long a, long b)
+        public static long Add(long a, long b)
         {
             return a + b;
         }
@@ -71,7 +71,7 @@ namespace Microsoft.Build.Evaluation
         /// <summary>
         /// Subtract two doubles
         /// </summary>
-        internal static double Subtract(double a, double b)
+        public static double Subtract(double a, double b)
         {
             return a - b;
         }
@@ -79,7 +79,7 @@ namespace Microsoft.Build.Evaluation
         /// <summary>
         /// Subtract two longs
         /// </summary>
-        internal static long Subtract(long a, long b)
+        public static long Subtract(long a, long b)
         {
             return a - b;
         }
@@ -87,7 +87,7 @@ namespace Microsoft.Build.Evaluation
         /// <summary>
         /// Multiply two doubles
         /// </summary>
-        internal static double Multiply(double a, double b)
+        public static double Multiply(double a, double b)
         {
             return a * b;
         }
@@ -95,7 +95,7 @@ namespace Microsoft.Build.Evaluation
         /// <summary>
         /// Multiply two longs
         /// </summary>
-        internal static long Multiply(long a, long b)
+        public static long Multiply(long a, long b)
         {
             return a * b;
         }
@@ -103,7 +103,7 @@ namespace Microsoft.Build.Evaluation
         /// <summary>
         /// Divide two doubles
         /// </summary>
-        internal static double Divide(double a, double b)
+        public static double Divide(double a, double b)
         {
             return a / b;
         }
@@ -111,7 +111,7 @@ namespace Microsoft.Build.Evaluation
         /// <summary>
         /// Divide two longs
         /// </summary>
-        internal static long Divide(long a, long b)
+        public static long Divide(long a, long b)
         {
             return a / b;
         }
@@ -119,7 +119,7 @@ namespace Microsoft.Build.Evaluation
         /// <summary>
         /// Modulo two doubles
         /// </summary>
-        internal static double Modulo(double a, double b)
+        public static double Modulo(double a, double b)
         {
             return a % b;
         }
@@ -127,7 +127,7 @@ namespace Microsoft.Build.Evaluation
         /// <summary>
         /// Modulo two longs
         /// </summary>
-        internal static long Modulo(long a, long b)
+        public static long Modulo(long a, long b)
         {
             return a % b;
         }
@@ -135,7 +135,7 @@ namespace Microsoft.Build.Evaluation
         /// <summary>
         /// Escape the string according to MSBuild's escaping rules
         /// </summary>
-        internal static string Escape(string unescaped)
+        public static string Escape(string unescaped)
         {
             return EscapingUtilities.Escape(unescaped);
         }
@@ -143,7 +143,7 @@ namespace Microsoft.Build.Evaluation
         /// <summary>
         /// Unescape the string according to MSBuild's escaping rules
         /// </summary>
-        internal static string Unescape(string escaped)
+        public static string Unescape(string escaped)
         {
             return EscapingUtilities.UnescapeAll(escaped);
         }
@@ -151,7 +151,7 @@ namespace Microsoft.Build.Evaluation
         /// <summary>
         /// Perform a bitwise OR on the first and second (first | second)
         /// </summary>
-        internal static int BitwiseOr(int first, int second)
+        public static int BitwiseOr(int first, int second)
         {
             return first | second;
         }
@@ -159,7 +159,7 @@ namespace Microsoft.Build.Evaluation
         /// <summary>
         /// Perform a bitwise AND on the first and second (first &amp; second)
         /// </summary>
-        internal static int BitwiseAnd(int first, int second)
+        public static int BitwiseAnd(int first, int second)
         {
             return first & second;
         }
@@ -167,7 +167,7 @@ namespace Microsoft.Build.Evaluation
         /// <summary>
         /// Perform a bitwise XOR on the first and second (first ^ second)
         /// </summary>
-        internal static int BitwiseXor(int first, int second)
+        public static int BitwiseXor(int first, int second)
         {
             return first ^ second;
         }
@@ -175,22 +175,22 @@ namespace Microsoft.Build.Evaluation
         /// <summary>
         /// Perform a bitwise NOT on the first and second (~first)
         /// </summary>
-        internal static int BitwiseNot(int first)
+        public static int BitwiseNot(int first)
         {
             return ~first;
         }
 
-        internal static int LeftShift(int operand, int count)
+        public static int LeftShift(int operand, int count)
         {
             return operand << count;
         }
 
-        internal static int RightShift(int operand, int count)
+        public static int RightShift(int operand, int count)
         {
             return operand >> count;
         }
 
-        internal static int RightShiftUnsigned(int operand, int count)
+        public static int RightShiftUnsigned(int operand, int count)
         {
             return operand >>> count;
         }
@@ -198,7 +198,7 @@ namespace Microsoft.Build.Evaluation
         /// <summary>
         /// Get the value of the registry key and value, default value is null
         /// </summary>
-        internal static object GetRegistryValue(string keyName, string valueName)
+        public static object GetRegistryValue(string keyName, string valueName)
         {
 #if RUNTIME_TYPE_NETCORE
             // .NET Core MSBuild used to always return empty, so match that behavior
@@ -214,7 +214,7 @@ namespace Microsoft.Build.Evaluation
         /// <summary>
         /// Get the value of the registry key and value
         /// </summary>
-        internal static object GetRegistryValue(string keyName, string valueName, object defaultValue)
+        public static object GetRegistryValue(string keyName, string valueName, object defaultValue)
         {
 #if RUNTIME_TYPE_NETCORE
             // .NET Core MSBuild used to always return empty, so match that behavior
@@ -227,7 +227,7 @@ namespace Microsoft.Build.Evaluation
             return Registry.GetValue(keyName, valueName, defaultValue);
         }
 
-        internal static object GetRegistryValueFromView(string keyName, string valueName, object defaultValue, params object[] views)
+        public static object GetRegistryValueFromView(string keyName, string valueName, object defaultValue, params object[] views)
         {
 #if RUNTIME_TYPE_NETCORE
             // .NET Core MSBuild used to always return empty, so match that behavior
@@ -249,7 +249,7 @@ namespace Microsoft.Build.Evaluation
         /// <summary>
         /// Get the value of the registry key from one of the RegistryView's specified
         /// </summary>
-        internal static object GetRegistryValueFromView(string keyName, string valueName, object defaultValue, ArraySegment<object> views)
+        public static object GetRegistryValueFromView(string keyName, string valueName, object defaultValue, ArraySegment<object> views)
         {
 #if RUNTIME_TYPE_NETCORE
             // .NET Core MSBuild used to always return empty, so match that behavior
@@ -342,7 +342,7 @@ namespace Microsoft.Build.Evaluation
         /// If the path cannot be made relative to the base path (for example, it is on another drive), it is returned verbatim.
         /// </param>
         /// <returns>relative path (can be the full path)</returns>
-        internal static string MakeRelative(string basePath, string path)
+        public static string MakeRelative(string basePath, string path)
         {
             string result = FileUtilities.MakeRelative(basePath, path);
 
@@ -356,7 +356,7 @@ namespace Microsoft.Build.Evaluation
         /// <param name="fileName">The name of the file to search for.</param>
         /// <param name="fileSystem">The file system abstraction to use that implements file system operations</param>
         /// <returns>The full path of the directory containing the file if it is found, otherwise an empty string. </returns>
-        internal static string GetDirectoryNameOfFileAbove(string startingDirectory, string fileName, IFileSystem fileSystem)
+        public static string GetDirectoryNameOfFileAbove(string startingDirectory, string fileName, IFileSystem fileSystem)
         {
             return FileUtilities.GetDirectoryNameOfFileAbove(startingDirectory, fileName, fileSystem);
         }
@@ -369,7 +369,7 @@ namespace Microsoft.Build.Evaluation
         /// <param name="fileSystem">The file system abstraction to use that implements file system operations</param>
         /// of the file containing the property function.</param>
         /// <returns>The full path of the file if it is found, otherwise an empty string.</returns>
-        internal static string GetPathOfFileAbove(string file, string startingDirectory, IFileSystem fileSystem)
+        public static string GetPathOfFileAbove(string file, string startingDirectory, IFileSystem fileSystem)
         {
             return FileUtilities.GetPathOfFileAbove(file, startingDirectory, fileSystem);
         }
@@ -378,7 +378,7 @@ namespace Microsoft.Build.Evaluation
         /// Return the string in parameter 'defaultValue' only if parameter 'conditionValue' is empty
         /// else, return the value conditionValue
         /// </summary>
-        internal static string ValueOrDefault(string conditionValue, string defaultValue)
+        public static string ValueOrDefault(string conditionValue, string defaultValue)
         {
             if (String.IsNullOrEmpty(conditionValue))
             {
@@ -395,7 +395,7 @@ namespace Microsoft.Build.Evaluation
         /// </summary>
         /// <param name="toEncode">String to encode in base 64.</param>
         /// <returns>The encoded string.</returns>
-        internal static string ConvertToBase64(string toEncode)
+        public static string ConvertToBase64(string toEncode)
         {
             return Convert.ToBase64String(Encoding.UTF8.GetBytes(toEncode));
         }
@@ -405,7 +405,7 @@ namespace Microsoft.Build.Evaluation
         /// </summary>
         /// <param name="toDecode">The string to decode.</param>
         /// <returns>The decoded string.</returns>
-        internal static string ConvertFromBase64(string toDecode)
+        public static string ConvertFromBase64(string toDecode)
         {
             return Encoding.UTF8.GetString(Convert.FromBase64String(toDecode));
         }
@@ -431,7 +431,7 @@ namespace Microsoft.Build.Evaluation
         ///  - for cases where the calling code would erroneously load old version of StringTools alongside of the new version of Microsoft.Build.
         /// Should be removed once Wave17_10 is removed.
         /// </summary>
-        internal static object StableStringHashLegacy(string toHash)
+        public static object StableStringHashLegacy(string toHash)
             => CommunicationsUtilities.GetHashCode(toHash);
 
         /// <summary>
@@ -440,10 +440,10 @@ namespace Microsoft.Build.Evaluation
         ///  JIT load the functions from StringTools - so we would not be able to prevent their loading with ChangeWave as we do now.
         /// </summary>
         [MethodImpl(MethodImplOptions.NoInlining)]
-        internal static object StableStringHash(string toHash)
+        public static object StableStringHash(string toHash)
             => StableStringHash(toHash, StringHashingAlgorithm.Legacy);
 
-        internal static object StableStringHash(string toHash, StringHashingAlgorithm algo) =>
+        public static object StableStringHash(string toHash, StringHashingAlgorithm algo) =>
             algo switch
             {
                 StringHashingAlgorithm.Legacy => CommunicationsUtilities.GetHashCode(toHash),
@@ -477,7 +477,7 @@ namespace Microsoft.Build.Evaluation
         /// Returns true if a task host exists that can service the requested runtime and architecture
         /// values, and false otherwise.
         /// </summary>
-        internal static bool DoesTaskHostExist(string runtime, string architecture)
+        public static bool DoesTaskHostExist(string runtime, string architecture)
         {
             if (runtime != null)
             {
@@ -523,7 +523,7 @@ namespace Microsoft.Build.Evaluation
         /// </summary>
         /// <param name="path">The path to check.</param>
         /// <returns>The specified path with a trailing slash.</returns>
-        internal static string EnsureTrailingSlash(string path)
+        public static string EnsureTrailingSlash(string path)
         {
             return FileUtilities.EnsureTrailingSlash(path);
         }
@@ -534,7 +534,7 @@ namespace Microsoft.Build.Evaluation
         /// </summary>
         /// <param name="path">One or more directory paths to combine and normalize.</param>
         /// <returns>A canonicalized full directory path with the correct directory separators and a trailing slash.</returns>
-        internal static string NormalizeDirectory(params string[] path)
+        public static string NormalizeDirectory(params string[] path)
         {
             return EnsureTrailingSlash(NormalizePath(path));
         }
@@ -544,7 +544,7 @@ namespace Microsoft.Build.Evaluation
         /// </summary>
         /// <param name="path">The path to check</param>
         /// <returns></returns>
-        internal static bool FileExists(string path)
+        public static bool FileExists(string path)
         {
             return FileUtilities.FileExistsNoThrow(path);
         }
@@ -554,7 +554,7 @@ namespace Microsoft.Build.Evaluation
         /// </summary>
         /// <param name="path">The path to check</param>
         /// <returns></returns>
-        internal static bool DirectoryExists(string path)
+        public static bool DirectoryExists(string path)
         {
             return FileUtilities.DirectoryExistsNoThrow(path);
         }
@@ -564,7 +564,7 @@ namespace Microsoft.Build.Evaluation
         /// </summary>
         /// <param name="path">One or more paths to combine and normalize.</param>
         /// <returns>A canonicalized full path with the correct directory separators.</returns>
-        internal static string NormalizePath(params string[] path)
+        public static string NormalizePath(params string[] path)
         {
             return FileUtilities.NormalizePath(path);
         }
@@ -574,7 +574,7 @@ namespace Microsoft.Build.Evaluation
         /// </summary>
         /// <param name="platformString">The platform string. Must be a member of <see cref="OSPlatform"/>. Case Insensitive</param>
         /// <returns></returns>
-        internal static bool IsOSPlatform(string platformString)
+        public static bool IsOSPlatform(string platformString)
         {
             return RuntimeInformation.IsOSPlatform(OSPlatform.Create(platformString.ToUpperInvariant()));
         }
@@ -583,7 +583,7 @@ namespace Microsoft.Build.Evaluation
         /// True if current OS is a Unix system.
         /// </summary>
         /// <returns></returns>
-        internal static bool IsOsUnixLike()
+        public static bool IsOsUnixLike()
         {
             return NativeMethodsShared.IsUnixLike;
         }
@@ -592,77 +592,77 @@ namespace Microsoft.Build.Evaluation
         /// True if current OS is a BSD system.
         /// </summary>
         /// <returns></returns>
-        internal static bool IsOsBsdLike()
+        public static bool IsOsBsdLike()
         {
             return NativeMethodsShared.IsBSD;
         }
 
-        internal static bool VersionEquals(string a, string b)
+        public static bool VersionEquals(string a, string b)
         {
             return SimpleVersion.Parse(a) == SimpleVersion.Parse(b);
         }
 
-        internal static bool VersionNotEquals(string a, string b)
+        public static bool VersionNotEquals(string a, string b)
         {
             return SimpleVersion.Parse(a) != SimpleVersion.Parse(b);
         }
 
-        internal static bool VersionGreaterThan(string a, string b)
+        public static bool VersionGreaterThan(string a, string b)
         {
             return SimpleVersion.Parse(a) > SimpleVersion.Parse(b);
         }
 
-        internal static bool VersionGreaterThanOrEquals(string a, string b)
+        public static bool VersionGreaterThanOrEquals(string a, string b)
         {
             return SimpleVersion.Parse(a) >= SimpleVersion.Parse(b);
         }
 
-        internal static bool VersionLessThan(string a, string b)
+        public static bool VersionLessThan(string a, string b)
         {
             return SimpleVersion.Parse(a) < SimpleVersion.Parse(b);
         }
 
-        internal static bool VersionLessThanOrEquals(string a, string b)
+        public static bool VersionLessThanOrEquals(string a, string b)
         {
             return SimpleVersion.Parse(a) <= SimpleVersion.Parse(b);
         }
 
-        internal static string GetTargetFrameworkIdentifier(string tfm)
+        public static string GetTargetFrameworkIdentifier(string tfm)
         {
             return NuGetFramework.Value.GetTargetFrameworkIdentifier(tfm);
         }
 
-        internal static string GetTargetFrameworkVersion(string tfm, int versionPartCount = 2)
+        public static string GetTargetFrameworkVersion(string tfm, int versionPartCount = 2)
         {
             return NuGetFramework.Value.GetTargetFrameworkVersion(tfm, versionPartCount);
         }
 
-        internal static bool IsTargetFrameworkCompatible(string target, string candidate)
+        public static bool IsTargetFrameworkCompatible(string target, string candidate)
         {
             return NuGetFramework.Value.IsCompatible(target, candidate);
         }
 
-        internal static string GetTargetPlatformIdentifier(string tfm)
+        public static string GetTargetPlatformIdentifier(string tfm)
         {
             return NuGetFramework.Value.GetTargetPlatformIdentifier(tfm);
         }
 
-        internal static string GetTargetPlatformVersion(string tfm, int versionPartCount = 2)
+        public static string GetTargetPlatformVersion(string tfm, int versionPartCount = 2)
         {
             return NuGetFramework.Value.GetTargetPlatformVersion(tfm, versionPartCount);
         }
 
-        internal static string FilterTargetFrameworks(string incoming, string filter)
+        public static string FilterTargetFrameworks(string incoming, string filter)
         {
             return NuGetFramework.Value.FilterTargetFrameworks(incoming, filter);
         }
 
-        internal static bool AreFeaturesEnabled(Version wave)
+        public static bool AreFeaturesEnabled(Version wave)
         {
             return ChangeWaves.AreFeaturesEnabled(wave);
         }
 
-        internal static string SubstringByAsciiChars(string input, int start, int length)
+        public static string SubstringByAsciiChars(string input, int start, int length)
         {
             if (start > input.Length)
             {
@@ -690,7 +690,7 @@ namespace Microsoft.Build.Evaluation
             return sb.ToString();
         }
 
-        internal static string CheckFeatureAvailability(string featureName)
+        public static string CheckFeatureAvailability(string featureName)
         {
             return Features.CheckFeatureAvailability(featureName).ToString();
         }
@@ -752,7 +752,7 @@ namespace Microsoft.Build.Evaluation
         /// <summary>
         /// returns if the string contains escaped wildcards
         /// </summary>
-        internal static List<string> __GetListTest()
+        public static List<string> __GetListTest()
         {
             return new List<string> { "A", "B", "C", "D" };
         }

--- a/src/Build/Evaluation/PropertyFunctionReceiver.cs
+++ b/src/Build/Evaluation/PropertyFunctionReceiver.cs
@@ -1,0 +1,103 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Frozen;
+using System.Globalization;
+using System.Text.RegularExpressions;
+
+namespace Microsoft.Build.Evaluation;
+
+/// <summary>
+/// Decides which instance property-function calls ("dotting in") are permitted under the restricted mode.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Used when <see cref="Internal.FeatureSwitches.RestrictPropertyFunctionReceivers"/> is enabled. It
+/// limits dotting to a curated, bounded set of receiver types so the members reachable by reflection are
+/// predictable and statically known, which keeps the property-function path trim compatible.
+/// </para>
+/// <para>
+/// Common read-only navigation such as <c>$([System.IO.Directory]::GetParent(x).Parent.FullName)</c>
+/// remains available; chains that would otherwise reach an open-ended type graph (for example
+/// <c>$([System.IO.Directory]::GetParent(x).GetFiles().GetValue(0).OpenWrite())</c>) are not permitted.
+/// </para>
+/// </remarks>
+internal static class PropertyFunctionReceiver
+{
+    /// <summary>
+    /// Non-primitive receiver types whose entire public instance surface is permitted. Primitive types
+    /// (the numeric types, <see cref="bool"/>, and <see cref="char"/>) are covered by
+    /// <see cref="Type.IsPrimitive"/> in <see cref="IsAllowed"/> and are intentionally not listed here.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// These are the value-like and text-processing types that common function chains flow through
+    /// (string and decimal operations, date math, globalization, regex results).
+    /// </para>
+    /// </remarks>
+    private static readonly FrozenSet<Type> s_allowedReceivers = new[]
+    {
+        typeof(string), typeof(decimal),
+        typeof(DateTime), typeof(DateTimeOffset), typeof(TimeSpan),
+        typeof(Guid), typeof(Version), typeof(CultureInfo),
+        typeof(Uri), typeof(Regex), typeof(Match), typeof(Group), typeof(Capture),
+    }.ToFrozenSet();
+
+    /// <summary>
+    /// The members permitted on a <c>FileSystemInfo</c> (<c>DirectoryInfo</c> / <c>FileInfo</c>):
+    /// read-only metadata and navigation.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This is an allowlist on purpose - enumeration (<c>GetFiles</c>, <c>EnumerateFiles</c>, ...), stream
+    /// creation (<c>Open*</c>, <c>Create*</c>), and the members that change the file system (<c>Delete</c>,
+    /// <c>MoveTo</c>, <c>CopyTo</c>, <c>Replace</c>, ...) are not listed, so the reachable surface stays
+    /// bounded and predictable.
+    /// </para>
+    /// </remarks>
+    private static readonly FrozenSet<string> s_fileSystemInfoMembers = new[]
+    {
+        "FullName", "Name", "Exists", "Extension", "Length", "DirectoryName",
+        "IsReadOnly", "LinkTarget", "ToString",
+        "Parent", "Root", "Directory",
+        "Attributes",
+        "CreationTime", "CreationTimeUtc",
+        "LastAccessTime", "LastAccessTimeUtc",
+        "LastWriteTime", "LastWriteTimeUtc",
+    }.ToFrozenSet(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Returns <see langword="true"/> if an instance member named <paramref name="methodName"/> may
+    /// be invoked on a receiver of type <paramref name="receiverType"/> under the restricted mode.
+    /// </summary>
+    internal static bool IsAllowed(Type receiverType, string methodName)
+    {
+        // Primitives (the numeric types, bool, char), enums, and arrays are permitted in full. These
+        // are single flag reads, so they run before the set lookup. Array element access
+        // (Array.GetValue) and enum members return values whose runtime type is re-checked at the next
+        // chain hop, so every receiver in the chain is validated.
+        if (receiverType.IsPrimitive || receiverType.IsEnum || receiverType.IsArray)
+        {
+            return true;
+        }
+
+        // Other value/text types whose entire public instance surface is permitted (string, decimal,
+        // date/time, globalization, regex results).
+        if (s_allowedReceivers.Contains(receiverType))
+        {
+            return true;
+        }
+
+        // FileSystemInfo (DirectoryInfo / FileInfo): read-only navigation/metadata members only.
+        // The file/directory static functions are registered against the real System.IO types (see
+        // Constants.InitializeAvailableMethods), so receivers reached by dotting in (GetParent, Parent,
+        // Directory, Root, ...) are always System.IO.*; the Microsoft.IO.Redist variants never surface.
+        if (typeof(System.IO.FileSystemInfo).IsAssignableFrom(receiverType))
+        {
+            return s_fileSystemInfoMembers.Contains(methodName);
+        }
+
+        return false;
+    }
+}

--- a/src/Build/FeatureSwitches.cs
+++ b/src/Build/FeatureSwitches.cs
@@ -1,0 +1,58 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.Build.Internal;
+
+/// <summary>
+/// Aggregates MSBuild trimmer feature switches.
+/// </summary>
+/// <remarks>
+/// Each property is annotated with <see cref="FeatureSwitchDefinitionAttribute"/> and mapped to an
+/// AppContext switch. When <c>Microsoft.Build</c> is trimmed (for example when publishing a trimmed
+/// application that embeds it), the trimmer can substitute a constant value for the property and
+/// remove the statically unreachable code it guards. The default value used during trimming is
+/// declared with a matching <c>RuntimeHostConfigurationOption</c> item in Microsoft.Build.csproj.
+/// New feature switches should be added here so they can be discovered and configured in one place.
+/// </remarks>
+internal static class FeatureSwitches
+{
+    /// <summary>
+    /// When <see langword="false"/> (the default in a trimmed application), property-function
+    /// receiver types are restricted to the curated allowlist in <c>AvailableStaticMethods</c>,
+    /// all of which are statically known and preserved. When <see langword="true"/>
+    /// (<c>MSBUILDENABLEALLPROPERTYFUNCTIONS=1</c> or the matching AppContext switch), MSBuild
+    /// additionally probes assemblies at runtime to resolve arbitrary receiver types - reflection
+    /// that is incompatible with trimming. This is modeled as a trimmer feature switch: under
+    /// trimming the property is substituted with a constant <see langword="false"/>, removing the
+    /// probing path; at run time (untrimmed) the environment variable and AppContext switch are
+    /// read fresh so the setting stays dynamically settable.
+    /// </summary>
+    [FeatureSwitchDefinition("Microsoft.Build.EnableAllPropertyFunctions")]
+    internal static bool EnableAllPropertyFunctions =>
+        (AppContext.TryGetSwitch("Microsoft.Build.EnableAllPropertyFunctions", out bool isEnabled) && isEnabled)
+        || Environment.GetEnvironmentVariable("MSBUILDENABLEALLPROPERTYFUNCTIONS") == "1";
+
+    /// <summary>
+    /// Whether instance property-function calls are limited to a curated set of receiver types.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// When enabled, instance "dotting in" is restricted to a curated set of receiver types (see
+    /// <see cref="Evaluation.PropertyFunctionReceiver"/>), so the members reachable by reflection are
+    /// predictable and statically known. When disabled, any public instance member except <c>GetType</c>
+    /// is callable, preserving the historical behavior.
+    /// </para>
+    /// <para>
+    /// The untrimmed default is <see langword="false"/>; under trimming the constant is substituted
+    /// <see langword="true"/> so the unrestricted branch is removed, keeping the property-function path
+    /// trim compatible. This switch is set only through its AppContext switch; it has no environment
+    /// variable.
+    /// </para>
+    /// </remarks>
+    [FeatureSwitchDefinition("Microsoft.Build.RestrictPropertyFunctionReceivers")]
+    internal static bool RestrictPropertyFunctionReceivers =>
+        AppContext.TryGetSwitch("Microsoft.Build.RestrictPropertyFunctionReceivers", out bool isEnabled) && isEnabled;
+}

--- a/src/Build/Graph/ParallelWorkSet.cs
+++ b/src/Build/Graph/ParallelWorkSet.cs
@@ -24,14 +24,14 @@ namespace Microsoft.Build.Graph
         /// </summary>
         private readonly int _degreeOfParallelism;
 
-        private readonly ConcurrentDictionary<TKey, Lazy<TResult>> _inProgressOrCompletedWork;
+        private readonly ConcurrentDictionary<TKey, WorkItem> _inProgressOrCompletedWork;
 
         private bool _isSchedulingCompleted;
 
         private long _pendingCount;
 
-        private readonly ConcurrentQueue<Lazy<TResult>> _queue =
-            new ConcurrentQueue<Lazy<TResult>>();
+        private readonly ConcurrentQueue<WorkItem> _queue =
+            new ConcurrentQueue<WorkItem>();
 
         private readonly SemaphoreSlim _semaphore;
 
@@ -48,9 +48,9 @@ namespace Microsoft.Build.Graph
             {
                 var completedWork = new Dictionary<TKey, TResult>(_inProgressOrCompletedWork.Count);
 
-                foreach (KeyValuePair<TKey, Lazy<TResult>> kvp in _inProgressOrCompletedWork)
+                foreach (KeyValuePair<TKey, WorkItem> kvp in _inProgressOrCompletedWork)
                 {
-                    Lazy<TResult> workItem = kvp.Value;
+                    WorkItem workItem = kvp.Value;
 
                     if (workItem.IsValueCreated)
                     {
@@ -85,7 +85,7 @@ namespace Microsoft.Build.Graph
 
             _cancellationToken = cancellationToken;
             _degreeOfParallelism = degreeOfParallelism;
-            _inProgressOrCompletedWork = new ConcurrentDictionary<TKey, Lazy<TResult>>(comparer);
+            _inProgressOrCompletedWork = new ConcurrentDictionary<TKey, WorkItem>(comparer);
 
             // Semaphore count is 0 to ensure that all the tasks are blocked unless new data is scheduled.
             _semaphore = new SemaphoreSlim(0, int.MaxValue);
@@ -109,7 +109,7 @@ namespace Microsoft.Build.Graph
                 throw new InvalidOperationException("Cannot add new work after work set is marked as completed.");
             }
 
-            var workItem = new Lazy<TResult>(workFunc);
+            WorkItem workItem = new(workFunc);
 
             if (!_inProgressOrCompletedWork.TryAdd(key, workItem))
             {
@@ -192,7 +192,7 @@ namespace Microsoft.Build.Graph
 
         private void ExecuteWorkItem()
         {
-            if (_queue.TryDequeue(out Lazy<TResult> workItem))
+            if (_queue.TryDequeue(out WorkItem workItem))
             {
                 try
                 {
@@ -208,6 +208,47 @@ namespace Microsoft.Build.Graph
                 finally
                 {
                     Interlocked.Decrement(ref _pendingCount);
+                }
+            }
+        }
+
+        /// <summary>
+        /// A lazily-evaluated work item. Unlike <see cref="Lazy{T}"/>, this does not place a
+        /// <c>DynamicallyAccessedMembers</c> requirement on <typeparamref name="TResult"/> (<see cref="Lazy{T}"/>
+        /// annotates its type argument for the parameterless constructor, which triggers IL2091 here), and it is
+        /// only ever evaluated once by a single worker before the result is read after
+        /// <see cref="WaitForAllWorkAndComplete"/> establishes a happens-before barrier.
+        /// </summary>
+        private sealed class WorkItem
+        {
+            private Func<TResult> _workFunc;
+            private bool _isValueCreated;
+            private TResult _value;
+
+            internal WorkItem(Func<TResult> workFunc)
+            {
+                _workFunc = workFunc;
+            }
+
+            internal bool IsValueCreated => _isValueCreated;
+
+            internal TResult Value
+            {
+                get
+                {
+                    if (!_isValueCreated)
+                    {
+                        _value = _workFunc();
+                        _isValueCreated = true;
+
+                        // Release the factory (and anything its closure captured) once the value is
+                        // computed. Completed work items are retained in the set for reuse, so holding
+                        // the delegate would keep captured graph state alive for the whole build.
+                        // Matches Lazy<T>, which also drops its value factory after evaluation.
+                        _workFunc = null;
+                    }
+
+                    return _value;
                 }
             }
         }

--- a/src/Build/Microsoft.Build.csproj
+++ b/src/Build/Microsoft.Build.csproj
@@ -41,6 +41,25 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!--
+      Property functions resolve receiver types outside the curated allowlist (by probing and loading
+      assemblies at runtime) only when MSBUILDENABLEALLPROPERTYFUNCTIONS=1. That reflection is
+      incompatible with trimming, so the feature switch defaults to disabled for trim analysis, which
+      lets the trimmer remove the unreachable probing path. The environment variable is still honored
+      at run time (this library emits no runtimeconfig.json, so the AppContext switch stays unset).
+    -->
+    <RuntimeHostConfigurationOption Include="Microsoft.Build.EnableAllPropertyFunctions" Value="false" Trim="true" />
+    <!--
+      Instance "dotting in" is limited to a curated set of receiver types (see PropertyFunctionReceiver.cs)
+      so the members reachable by reflection are predictable and statically known. The switch defaults to
+      enabled for trim analysis, letting the trimmer remove the unrestricted path; untrimmed it stays off
+      (it has no environment variable, and this library emits no runtimeconfig.json so the AppContext
+      switch stays unset).
+    -->
+    <RuntimeHostConfigurationOption Include="Microsoft.Build.RestrictPropertyFunctionReceivers" Value="true" Trim="true" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.Collections" PrivateAssets="all" />
 
     <!-- Display files included by the Microsoft.CodeAnalysis.Collections source package in a 'SourcePackages\Collections' folder -->
@@ -199,7 +218,9 @@
     <Compile Include="Evaluation\IItemTypeDefinition.cs" />
     <Compile Include="Evaluation\IntrinsicFunctionOverload.cs" />
     <Compile Include="Evaluation\PropertiesUseTracker.cs" />
+    <Compile Include="Evaluation\PropertyFunctionReceiver.cs" />
     <Compile Include="Evaluation\ToolsetElement.cs" />
+    <Compile Include="FeatureSwitches.cs" />
     <Compile Include="FileAccess\DesiredAccess.cs" />
     <Compile Include="FileAccess\FileAccessData.cs" />
     <Compile Include="FileAccess\FlagsAndAttributes.cs" />

--- a/src/Build/Resources/Constants.cs
+++ b/src/Build/Resources/Constants.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
 using System.Runtime.InteropServices;
@@ -221,8 +222,64 @@ namespace Microsoft.Build.Internal
         }
 
         /// <summary>
+        /// The reflection surface that property-function evaluation uses on an allowlisted receiver
+        /// type: public constructors (for <c>[Type]::new(...)</c>) plus public methods, properties, and
+        /// fields, reached as static or instance members via <c>Type.InvokeMember</c>, <c>GetMethod(s)</c>,
+        /// and <c>GetConstructor(s)</c> (see Expander.Function.Execute and LateBindExecute). The
+        /// property-function path never sets <c>BindingFlags.NonPublic</c>, so events, nested types,
+        /// interfaces, and non-public members are never reflected over.
+        /// </summary>
+        private const DynamicallyAccessedMemberTypes PropertyFunctionMembers =
+            DynamicallyAccessedMemberTypes.PublicConstructors
+            | DynamicallyAccessedMemberTypes.PublicMethods
+            | DynamicallyAccessedMemberTypes.PublicProperties
+            | DynamicallyAccessedMemberTypes.PublicFields;
+
+        /// <summary>
         /// Fill up the dictionary for first use
         /// </summary>
+        // Preserve the PropertyFunctionMembers set on every type in the property-function allowlist
+        // below. Property functions dispatch over the allowlisted receiver type by reflection (see
+        // Expander.Function), and receiver types are restricted to this allowlist unless the
+        // MSBUILDENABLEALLPROPERTYFUNCTIONS feature switch is enabled. Preserving these members is what
+        // makes the IL2072/IL2074/IL2080/IL2096 suppressions in Expander honest under trimming. Keep in
+        // sync with the entries added below.
+        [DynamicDependency(PropertyFunctionMembers, typeof(Environment))]
+        [DynamicDependency(PropertyFunctionMembers, typeof(Directory))]
+        [DynamicDependency(PropertyFunctionMembers, typeof(File))]
+        [DynamicDependency(PropertyFunctionMembers, typeof(RuntimeInformation))]
+        [DynamicDependency(PropertyFunctionMembers, typeof(OSPlatform))]
+        [DynamicDependency(PropertyFunctionMembers, typeof(CultureInfo))]
+        [DynamicDependency(PropertyFunctionMembers, typeof(IntrinsicFunctions))]
+        [DynamicDependency(PropertyFunctionMembers, typeof(byte))]
+        [DynamicDependency(PropertyFunctionMembers, typeof(char))]
+        [DynamicDependency(PropertyFunctionMembers, typeof(Convert))]
+        [DynamicDependency(PropertyFunctionMembers, typeof(DateTime))]
+        [DynamicDependency(PropertyFunctionMembers, typeof(DateTimeOffset))]
+        [DynamicDependency(PropertyFunctionMembers, typeof(decimal))]
+        [DynamicDependency(PropertyFunctionMembers, typeof(double))]
+        [DynamicDependency(PropertyFunctionMembers, typeof(Enum))]
+        [DynamicDependency(PropertyFunctionMembers, typeof(Guid))]
+        [DynamicDependency(PropertyFunctionMembers, typeof(short))]
+        [DynamicDependency(PropertyFunctionMembers, typeof(int))]
+        [DynamicDependency(PropertyFunctionMembers, typeof(long))]
+        [DynamicDependency(PropertyFunctionMembers, typeof(Path))]
+        [DynamicDependency(PropertyFunctionMembers, typeof(Math))]
+        [DynamicDependency(PropertyFunctionMembers, typeof(ushort))]
+        [DynamicDependency(PropertyFunctionMembers, typeof(uint))]
+        [DynamicDependency(PropertyFunctionMembers, typeof(ulong))]
+        [DynamicDependency(PropertyFunctionMembers, typeof(sbyte))]
+        [DynamicDependency(PropertyFunctionMembers, typeof(float))]
+        [DynamicDependency(PropertyFunctionMembers, typeof(string))]
+        [DynamicDependency(PropertyFunctionMembers, typeof(StringComparer))]
+        [DynamicDependency(PropertyFunctionMembers, typeof(TimeSpan))]
+        [DynamicDependency(PropertyFunctionMembers, typeof(Regex))]
+        [DynamicDependency(PropertyFunctionMembers, typeof(Uri))]
+        [DynamicDependency(PropertyFunctionMembers, typeof(UriBuilder))]
+        [DynamicDependency(PropertyFunctionMembers, typeof(Version))]
+#if NET
+        [DynamicDependency(PropertyFunctionMembers, typeof(OperatingSystem))]
+#endif
         private static void InitializeAvailableMethods()
         {
             if (s_availableStaticMethods == null)
@@ -270,7 +327,7 @@ namespace Microsoft.Build.Internal
                         availableStaticMethods.TryAdd("System.IO.Directory::GetFiles", directoryType);
                         availableStaticMethods.TryAdd("System.IO.Directory::GetLastAccessTime", directoryType);
                         availableStaticMethods.TryAdd("System.IO.Directory::GetLastWriteTime", directoryType);
-                        availableStaticMethods.TryAdd("System.IO.Directory::GetParent", directoryType);                      
+                        availableStaticMethods.TryAdd("System.IO.Directory::GetParent", directoryType);
 
                         availableStaticMethods.TryAdd("System.IO.File::Exists", fileType);
                         availableStaticMethods.TryAdd("System.IO.File::GetCreationTime", fileType);

--- a/src/Framework/Polyfills/AotTrimmingPolyfills.cs
+++ b/src/Framework/Polyfills/AotTrimmingPolyfills.cs
@@ -130,13 +130,36 @@ namespace System.Diagnostics.CodeAnalysis
             AssemblyName = assemblyName;
         }
 
+        public DynamicDependencyAttribute(DynamicallyAccessedMemberTypes memberTypes, Type type)
+        {
+            MemberTypes = memberTypes;
+            Type = type;
+        }
+
         public string? MemberSignature { get; }
+
+        public DynamicallyAccessedMemberTypes MemberTypes { get; }
+
+        public Type? Type { get; }
 
         public string? TypeName { get; }
 
         public string? AssemblyName { get; }
 
         public string? Condition { get; set; }
+    }
+
+    /// <summary>
+    /// Indicates that a boolean property or field is a feature switch, mapped to the named
+    /// AppContext switch. The trimmer can substitute a constant value for the switch and remove
+    /// guarded, statically unreachable branches.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property, Inherited = false)]
+    internal sealed class FeatureSwitchDefinitionAttribute : Attribute
+    {
+        public FeatureSwitchDefinitionAttribute(string switchName) => SwitchName = switchName;
+
+        public string SwitchName { get; }
     }
 }
 

--- a/src/Framework/ReflectableTaskPropertyInfo.cs
+++ b/src/Framework/ReflectableTaskPropertyInfo.cs
@@ -81,8 +81,25 @@ namespace Microsoft.Build.Execution
             {
                 if (_propertyInfo == null)
                 {
-                    _propertyInfo = _taskType.GetProperty(Name, BindingFlags.Instance | BindingFlags.Public | BindingFlags.IgnoreCase);
-                    Assumed.NotNull(_propertyInfo, $"Could not find property {Name} on type {_taskType.FullName} that the task factory indicated should exist.");
+                    PropertyInfo foundProperty = null;
+                    foreach (PropertyInfo propertyInfo in _taskType.GetProperties(BindingFlags.Instance | BindingFlags.Public))
+                    {
+                        if (string.Equals(propertyInfo.Name, Name, StringComparison.OrdinalIgnoreCase))
+                        {
+                            if (foundProperty != null)
+                            {
+                                // Multiple case-insensitive matches indicate shadowed properties or a malformed task type.
+                                throw new AmbiguousMatchException($"""
+                                    Multiple properties matching '{Name}' (case-insensitive) found on type '{_taskType.FullName}'.
+                                    Shadowed or duplicate property definitions are not supported.
+                                    """);
+                            }
+                            foundProperty = propertyInfo;
+                        }
+                    }
+
+                    Assumed.NotNull(foundProperty, $"Could not find property {Name} on type {_taskType.FullName} that the task factory indicated should exist.");
+                    _propertyInfo = foundProperty;
                 }
 
                 return _propertyInfo;

--- a/src/Framework/Utilities/TypeExtensions.cs
+++ b/src/Framework/Utilities/TypeExtensions.cs
@@ -2,12 +2,88 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.IO;
+using System.Reflection;
+using System.Runtime.CompilerServices;
 
 namespace Microsoft.Build.Shared;
 
 internal static class TypeExtensions
 {
-    public static string GetAssemblyPath(this Type type)
-        => Path.GetFullPath(type.Assembly.Location);
+    /// <summary>
+    /// The member set a late-bound (property-function) receiver type must preserve for trimming.
+    /// <c>InvokePublicMember</c> only ever binds members in this set, so preserving it is
+    /// sufficient; annotating the receiver with it makes that requirement machine-checked at every
+    /// call site, so a caller passing a type whose public surface is not preserved fails the build.
+    /// </summary>
+    private const DynamicallyAccessedMemberTypes PublicMemberSurface =
+        DynamicallyAccessedMemberTypes.PublicConstructors |
+        DynamicallyAccessedMemberTypes.PublicMethods |
+        DynamicallyAccessedMemberTypes.PublicProperties |
+        DynamicallyAccessedMemberTypes.PublicFields;
+
+    extension(Type type)
+    {
+        public string GetAssemblyPath()
+            => Path.GetFullPath(type.Assembly.Location);
+
+        /// <summary>
+        /// Returns a boxed zero-initialized instance when the receiver is a value type, or
+        /// <see langword="null"/> for a reference type. Used to seed an argument slot for a value-type
+        /// <c>out</c> parameter so late-bound member resolution has a correctly typed box to write into.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [UnconditionalSuppressMessage("Trimming", "IL2067",
+            Justification = "Activator.CreateInstance is only invoked for value types (guarded by Type.IsValueType), which always have a public parameterless constructor.")]
+        public object? CreateDefault()
+            => type.IsValueType ? Activator.CreateInstance(type) : null;
+    }
+
+    extension([DynamicallyAccessedMembers(PublicMemberSurface)] Type type)
+    {
+        /// <summary>
+        /// Invokes a public member on the receiver type using the standard binder, after verifying
+        /// that <paramref name="bindingFlags"/> cannot reach non-public members.
+        /// </summary>
+        /// <remarks>
+        /// This is the un-suppressed, public half of the pair. It owns both guarantees the trim suppression
+        /// below depends on: the runtime guarantee (it throws if <see cref="BindingFlags.NonPublic"/> is set,
+        /// so only public members can be bound) and the machine-checked guarantee (the
+        /// <see cref="DynamicallyAccessedMembersAttribute"/> on the receiver, which the trim analyzer enforces
+        /// at every call site). It delegates the single reflective call that needs a suppression to the private
+        /// <c>InvokeMemberPublicOnly</c>, so that suppression cannot be reached except through this validated
+        /// entry point and therefore cannot be misused or silently invalidated.
+        /// </remarks>
+        public object? InvokePublicMember(string name, BindingFlags bindingFlags, object? target, object?[]? args)
+        {
+            Assumed.Zero(
+                (int)(bindingFlags & BindingFlags.NonPublic),
+                $"'{BindingFlags.NonPublic}' is not permitted for {nameof(InvokePublicMember)}; only public members may be bound.");
+
+            return InvokeMemberPublicOnly(type, name, bindingFlags, target, args);
+        }
+    }
+
+    /// <summary>
+    /// Performs the actual <see cref="Type.InvokeMember(string, BindingFlags, Binder, object, object[], CultureInfo)"/>
+    /// call. This private method is the single, encapsulated home of the IL2070 suppression for property-function
+    /// invocation; it must only ever be reached through <c>InvokePublicMember</c>.
+    /// </summary>
+    [UnconditionalSuppressMessage("Trimming", "IL2070",
+        Justification = "Type.InvokeMember's reflection contract always lists non-public members, but the sole caller InvokePublicMember rejects BindingFlags.NonPublic (re-asserted below), so only public members are bound. The public surface of the receiver type is preserved for trimming by the [DynamicallyAccessedMembers] annotation on InvokePublicMember's receiver, which the trim analyzer enforces at every call site. Keeping this method private prevents the suppression from being bypassed or misused.")]
+    private static object? InvokeMemberPublicOnly(
+        [DynamicallyAccessedMembers(PublicMemberSurface)] Type type,
+        string name,
+        BindingFlags bindingFlags,
+        object? target,
+        object?[]? args)
+    {
+        Debug.Assert(
+            (bindingFlags & BindingFlags.NonPublic) == 0,
+            "InvokeMemberPublicOnly must never be called with BindingFlags.NonPublic; InvokePublicMember rejects it before delegating here.");
+        return type.InvokeMember(name, bindingFlags, Type.DefaultBinder, target, args, CultureInfo.InvariantCulture);
+    }
 }

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -783,6 +783,7 @@ namespace Microsoft.Build.CommandLine
             // because tasks in the build can (and occasionally do) load MSBuild format files
             // with our OM and modify and save them. They'll never do this for Microsoft.*.targets, though,
             // and those form the great majority of our unnecessary memory use.
+            string oldMSBuildLoadMicrosoftTargetsReadOnly = Environment.GetEnvironmentVariable("MSBuildLoadMicrosoftTargetsReadOnly");
             Environment.SetEnvironmentVariable("MSBuildLoadMicrosoftTargetsReadOnly", "true");
 
             ArgumentException.ThrowIfNullOrEmpty(commandLine);
@@ -1235,6 +1236,8 @@ namespace Microsoft.Build.CommandLine
                 s_cancelComplete.WaitOne();
 
                 NativeMethodsShared.RestoreConsoleMode(s_originalConsoleMode);
+
+                Environment.SetEnvironmentVariable("MSBuildLoadMicrosoftTargetsReadOnly", oldMSBuildLoadMicrosoftTargetsReadOnly);
 
                 preprocessWriter?.Dispose();
                 targetsWriter?.Dispose();

--- a/src/Shared/TaskParameter.cs
+++ b/src/Shared/TaskParameter.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
 using Microsoft.Build.Collections;
@@ -390,8 +389,6 @@ namespace Microsoft.Build.BackEnd
         /// <summary>
         /// Serializes or deserializes an array of primitive type values wrapped by this <see cref="TaskParameter"/>.
         /// </summary>
-        [UnconditionalSuppressMessage("AotAnalysis", "IL3050:RequiresDynamicCode",
-            Justification = "The element type is always one of the primitive value types selected by the TypeCode switch below, so Array.CreateInstance does not need to generate code for an unknown type.")]
         private void TranslatePrimitiveTypeArray(ITranslator translator)
         {
             translator.TranslateEnum(ref _parameterTypeCode, (int)_parameterTypeCode);
@@ -433,27 +430,31 @@ namespace Microsoft.Build.BackEnd
                     }
                     else
                     {
-                        Type elementType = _parameterTypeCode switch
+                        Type arrayType = _parameterTypeCode switch
                         {
-                            TypeCode.Char => typeof(char),
-                            TypeCode.SByte => typeof(sbyte),
-                            TypeCode.Byte => typeof(byte),
-                            TypeCode.Int16 => typeof(short),
-                            TypeCode.UInt16 => typeof(ushort),
-                            TypeCode.UInt32 => typeof(uint),
-                            TypeCode.Int64 => typeof(long),
-                            TypeCode.UInt64 => typeof(ulong),
-                            TypeCode.Single => typeof(float),
-                            TypeCode.Double => typeof(double),
-                            TypeCode.Decimal => typeof(decimal),
-                            TypeCode.DateTime => typeof(DateTime),
+                            TypeCode.Char => typeof(char[]),
+                            TypeCode.SByte => typeof(sbyte[]),
+                            TypeCode.Byte => typeof(byte[]),
+                            TypeCode.Int16 => typeof(short[]),
+                            TypeCode.UInt16 => typeof(ushort[]),
+                            TypeCode.UInt32 => typeof(uint[]),
+                            TypeCode.Int64 => typeof(long[]),
+                            TypeCode.UInt64 => typeof(ulong[]),
+                            TypeCode.Single => typeof(float[]),
+                            TypeCode.Double => typeof(double[]),
+                            TypeCode.Decimal => typeof(decimal[]),
+                            TypeCode.DateTime => typeof(DateTime[]),
                             _ => throw new NotImplementedException(),
                         };
 
                         int length = 0;
                         translator.Translate(ref length);
 
-                        Array array = Array.CreateInstance(elementType, length);
+#if NET
+                        Array array = Array.CreateInstanceFromArrayType(arrayType, length);
+#else
+                        Array array = Array.CreateInstance(arrayType.GetElementType(), length);
+#endif
                         for (int i = 0; i < length; i++)
                         {
                             string valueString = null;


### PR DESCRIPTION
## Summary

Splits the **functional / method-body changes** out of the broader trim-enablement work (#14064) so they can be reviewed independently of the annotation churn. This PR contains **no** `[RequiresUnreferencedCode]`/`[DynamicallyAccessedMembers]` propagation cascade and does **not** flip on the trim/AOT analyzers — those remain in #14064.

### Property-function evaluation (made trim-compatible by construction)
- `Function<T>._receiverType` (and the `Function` ctor `receiverType` parameter) are annotated with `[DynamicallyAccessedMembers(All)]` as a single chokepoint, with proof-based suppressions on the `InvokeMember`/`GetMethods`/`GetConstructor` sites.
- The curated receiver-type allowlist (`AvailableStaticMethods`) is preserved with `[DynamicDependency]`, constrained to the members property functions actually use (public ctors/methods/properties/fields; non-public methods for `IntrinsicFunctions`).
- The runtime assembly-probing path (`MSBUILDENABLEALLPROPERTYFUNCTIONS=1`) is gated behind the `EnableAllPropertyFunctions` trimmer feature switch so the trimmer removes it; the env var stays honored at run time. net472 polyfills added for `FeatureSwitchDefinition`/`DynamicDependency`.

### Functional changes making reflection AOT/trim-friendly (no behavior change)
- **TaskParameter / TaskExecutionHost**: construct typed arrays via `Array.CreateInstanceFromArrayType` instead of `Array.CreateInstance(elementType)`.
- **ParallelWorkSet**: a custom `WorkItem` replaces `Lazy<TResult>` (avoids the DAM requirement `Lazy<T>` places on `TResult`).
- **BuildErrorTelemetryTracker**: size the count array from a `Count` sentinel instead of `Enum.GetValues(...)`.
- **LoggingService**: instantiate the built-in `CentralForwardingLogger` directly instead of via reflection.
- **ReflectableTaskPropertyInfo**: resolve the property via `GetProperties()` enumeration (also avoids `AmbiguousMatchException` on shadowed properties).

## Validation
- `Microsoft.Build` compiles for **net10.0** (`-p:IsTrimmable=true`) and **net472**.
- Targeted unit tests pass: `ParallelWorkSet`, `TaskExecutionHost_Tests`, `LoggingService_Tests`, `TaskParameter`.