### PR TITLE
[vs18.8] Replace ToolTask #13351 revert with STA-safe EOF fix (#13917)

### DIFF
--- a/documentation/wiki/ChangeWaves.md
+++ b/documentation/wiki/ChangeWaves.md
@@ -41,6 +41,7 @@ Change wave checks around features will be removed in the release that accompani
 - [AbsolutePath.GetCanonicalForm optimization - avoid expensive Path.GetFullPath calls when paths don't need canonicalization](https://github.com/dotnet/msbuild/pull/13369)
 - [TaskHostTask forwards request-level global properties (e.g. MSBuildRestoreSessionId) to out-of-proc TaskHost in -mt mode](https://github.com/dotnet/msbuild/pull/13443)
 - [Fix ShouldTreatWarningAsError in OOP TaskHost checking wrong collection (WarningsAsMessages instead of WarningsAsErrors)](https://github.com/dotnet/msbuild/issues/11952)
+- [Fix ToolTask hang when tool spawns grandchild processes that inherit stdout/stderr pipe handles](https://github.com/dotnet/msbuild/issues/2981)
 
 ### 18.5
 - [FindUnderPath and AssignTargetPath tasks no longer throw on invalid path characters when using TaskEnvironment.GetAbsolutePath](https://github.com/dotnet/msbuild/pull/13069)

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -1,9 +1,9 @@
-﻿<Project>
+<Project>
 
   <Import Project="Version.Details.props" />
 
   <PropertyGroup>
-    <VersionPrefix>18.8.2</VersionPrefix><DotNetFinalVersionKind>release</DotNetFinalVersionKind><!-- Keep next to VersionPrefix to create a conflict in forward-flow -->
+    <VersionPrefix>18.8.3</VersionPrefix><DotNetFinalVersionKind>release</DotNetFinalVersionKind><!-- Keep next to VersionPrefix to create a conflict in forward-flow -->
     <PreReleaseVersionLabel>servicing</PreReleaseVersionLabel>
     <PackageValidationBaselineVersion>18.7.0-preview-26230-02</PackageValidationBaselineVersion>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>

--- a/src/Utilities.UnitTests/ToolTask_Tests.cs
+++ b/src/Utilities.UnitTests/ToolTask_Tests.cs
@@ -1126,21 +1126,25 @@ namespace Microsoft.Build.UnitTests
                 t.BuildEngine = engine;
 
                 // cmd echoes "hello", then starts a background ping that inherits
-                // pipe handles. cmd exits immediately; ping outlives the 2s EOF timeout.
+                // pipe handles. cmd exits immediately; ping outlives the 30s EOF timeout.
                 t.MockCommandLineCommands = NativeMethodsShared.IsWindows
-                    ? "/c echo hello & start /b ping -n 10 127.0.0.1 > nul"
-                    : "-c \"echo hello; sleep 10 &\"";
+                    ? "/c echo hello & start /b ping -n 40 127.0.0.1 > nul"
+                    : "-c \"echo hello; sleep 40 &\"";
 
-                // Set a generous timeout - without the fix this would hang for the full ping duration
-                t.Timeout = 30000;
+                // Outer task timeout is generous; the EOF timeout (30s) is what bounds us.
+                t.Timeout = 60000;
 
+                var sw = Stopwatch.StartNew();
                 bool result = t.Execute();
+                sw.Stop();
 
-                // The tool should complete without hanging.
-                // The exit code may be non-zero depending on timing, but the key thing
-                // is that Execute() returns at all rather than hanging forever.
                 _output.WriteLine(engine.Log);
+
                 engine.Log.ShouldContain("hello");
+                // The task must return within ~30s (EOF timeout) even though the grandchild lives longer.
+                sw.Elapsed.TotalSeconds.ShouldBeLessThan(35, "ToolTask should be bounded by the 30s EOF timeout, not the grandchild's lifetime");
+                // The diagnostic message must appear so CI reports show why the wait ended.
+                engine.Log.ShouldContain("Pipe EOF not received");
             }
         }
 

--- a/src/Utilities.UnitTests/ToolTask_Tests.cs
+++ b/src/Utilities.UnitTests/ToolTask_Tests.cs
@@ -1113,6 +1113,68 @@ namespace Microsoft.Build.UnitTests
         }
 
         /// <summary>
+        /// Verifies that ToolTask does not hang when the tool process spawns a grandchild
+        /// process that inherits stdout/stderr pipe handles and outlives the tool.
+        /// This is a regression test for https://github.com/dotnet/msbuild/issues/2981.
+        /// </summary>
+        [Fact]
+        public void ToolTaskDoesNotHangWhenGrandchildInheritsPipeHandles()
+        {
+            using (MyTool t = new MyTool())
+            {
+                MockEngine3 engine = new MockEngine3();
+                t.BuildEngine = engine;
+
+                // cmd echoes "hello", then starts a background ping that inherits
+                // pipe handles. cmd exits immediately; ping outlives the 2s EOF timeout.
+                t.MockCommandLineCommands = NativeMethodsShared.IsWindows
+                    ? "/c echo hello & start /b ping -n 10 127.0.0.1 > nul"
+                    : "-c \"echo hello; sleep 10 &\"";
+
+                // Set a generous timeout - without the fix this would hang for the full ping duration
+                t.Timeout = 30000;
+
+                bool result = t.Execute();
+
+                // The tool should complete without hanging.
+                // The exit code may be non-zero depending on timing, but the key thing
+                // is that Execute() returns at all rather than hanging forever.
+                _output.WriteLine(engine.Log);
+                engine.Log.ShouldContain("hello");
+            }
+        }
+
+        /// <summary>
+        /// Verifies that ToolTask still captures all output from the tool process
+        /// even with the grandchild pipe fix enabled. This is a regression test for
+        /// https://github.com/dotnet/msbuild/issues/10378 where switching to
+        /// WaitForExit(int) caused output to be lost.
+        /// </summary>
+        [Fact]
+        public void ToolTaskCapturesAllOutputWithFix()
+        {
+            using (MyTool t = new MyTool())
+            {
+                MockEngine3 engine = new MockEngine3();
+                t.BuildEngine = engine;
+
+                // Echo multiple lines to verify all output is captured
+                t.MockCommandLineCommands = NativeMethodsShared.IsWindows ?
+                    "/c echo line1 & echo line2 & echo line3"
+                    : "-c \"echo line1; echo line2; echo line3\"";
+
+                bool result = t.Execute();
+
+                _output.WriteLine(engine.Log);
+
+                result.ShouldBeTrue();
+                engine.Log.ShouldContain("line1");
+                engine.Log.ShouldContain("line2");
+                engine.Log.ShouldContain("line3");
+            }
+        }
+
+        /// <summary>
         /// A simple implementation of <see cref="ToolTask"/> to sleep for a while.
         /// </summary>
         /// <remarks>

--- a/src/Utilities/Resources/Strings.resx
+++ b/src/Utilities/Resources/Strings.resx
@@ -168,6 +168,9 @@
   <data name="ToolTask.EnvironmentVariableHeader">
     <value>Environment Variables passed to tool:</value>
   </data>
+  <data name="ToolTask.PipeEOFTimeout" xml:space="preserve">
+    <value>Pipe EOF not received within {0} seconds. A grandchild process may still be holding the pipe open. Output already delivered has been logged.</value>
+  </data>
   <data name="ToolTask.ValidateParametersFailed">
     <value>MSB6011: Invalid parameters passed to the {0} task.</value>
     <comment>{StrBegin="MSB6011: "}</comment>

--- a/src/Utilities/Resources/xlf/Strings.cs.xlf
+++ b/src/Utilities/Resources/xlf/Strings.cs.xlf
@@ -72,6 +72,11 @@
         <target state="translated">Úlohu nelze přeskočit, protože není aktuální.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ToolTask.PipeEOFTimeout">
+        <source>Pipe EOF not received within {0} seconds. A grandchild process may still be holding the pipe open. Output already delivered has been logged.</source>
+        <target state="new">Pipe EOF not received within {0} seconds. A grandchild process may still be holding the pipe open. Output already delivered has been logged.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ToolTask.ToolCommandFailed">
         <source>MSB6006: "{0}" exited with code {1}.</source>
         <target state="translated">MSB6006: Příkaz {0} byl ukončen s kódem {1}.</target>

--- a/src/Utilities/Resources/xlf/Strings.de.xlf
+++ b/src/Utilities/Resources/xlf/Strings.de.xlf
@@ -72,6 +72,11 @@
         <target state="translated">Die Aufgabe kann nicht übersprungen werden, da sie nicht auf dem neuesten Stand ist.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ToolTask.PipeEOFTimeout">
+        <source>Pipe EOF not received within {0} seconds. A grandchild process may still be holding the pipe open. Output already delivered has been logged.</source>
+        <target state="new">Pipe EOF not received within {0} seconds. A grandchild process may still be holding the pipe open. Output already delivered has been logged.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ToolTask.ToolCommandFailed">
         <source>MSB6006: "{0}" exited with code {1}.</source>
         <target state="translated">MSB6006: "{0}" wurde mit dem Code {1} beendet.</target>

--- a/src/Utilities/Resources/xlf/Strings.es.xlf
+++ b/src/Utilities/Resources/xlf/Strings.es.xlf
@@ -72,6 +72,11 @@
         <target state="translated">No se puede omitir la tarea porque no está actualizada.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ToolTask.PipeEOFTimeout">
+        <source>Pipe EOF not received within {0} seconds. A grandchild process may still be holding the pipe open. Output already delivered has been logged.</source>
+        <target state="new">Pipe EOF not received within {0} seconds. A grandchild process may still be holding the pipe open. Output already delivered has been logged.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ToolTask.ToolCommandFailed">
         <source>MSB6006: "{0}" exited with code {1}.</source>
         <target state="translated">MSB6006: "{0}" salió con el código {1}.</target>

--- a/src/Utilities/Resources/xlf/Strings.fr.xlf
+++ b/src/Utilities/Resources/xlf/Strings.fr.xlf
@@ -72,6 +72,11 @@
         <target state="translated">Nous n’avons pas pu ignorer la tâche, car elle n’est pas à jour.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ToolTask.PipeEOFTimeout">
+        <source>Pipe EOF not received within {0} seconds. A grandchild process may still be holding the pipe open. Output already delivered has been logged.</source>
+        <target state="new">Pipe EOF not received within {0} seconds. A grandchild process may still be holding the pipe open. Output already delivered has been logged.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ToolTask.ToolCommandFailed">
         <source>MSB6006: "{0}" exited with code {1}.</source>
         <target state="translated">MSB6006: Arrêt de "{0}" avec le code {1}.</target>

--- a/src/Utilities/Resources/xlf/Strings.it.xlf
+++ b/src/Utilities/Resources/xlf/Strings.it.xlf
@@ -72,6 +72,11 @@
         <target state="translated">Non è possibile ignorare l'attività perché non è aggiornata.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ToolTask.PipeEOFTimeout">
+        <source>Pipe EOF not received within {0} seconds. A grandchild process may still be holding the pipe open. Output already delivered has been logged.</source>
+        <target state="new">Pipe EOF not received within {0} seconds. A grandchild process may still be holding the pipe open. Output already delivered has been logged.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ToolTask.ToolCommandFailed">
         <source>MSB6006: "{0}" exited with code {1}.</source>
         <target state="translated">MSB6006: "{0}" terminato con il codice {1}.</target>

--- a/src/Utilities/Resources/xlf/Strings.ja.xlf
+++ b/src/Utilities/Resources/xlf/Strings.ja.xlf
@@ -72,6 +72,11 @@
         <target state="translated">タスクは最新ではないため、スキップできません。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ToolTask.PipeEOFTimeout">
+        <source>Pipe EOF not received within {0} seconds. A grandchild process may still be holding the pipe open. Output already delivered has been logged.</source>
+        <target state="new">Pipe EOF not received within {0} seconds. A grandchild process may still be holding the pipe open. Output already delivered has been logged.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ToolTask.ToolCommandFailed">
         <source>MSB6006: "{0}" exited with code {1}.</source>
         <target state="translated">MSB6006: "{0}" はコード {1} を伴って終了しました。</target>

--- a/src/Utilities/Resources/xlf/Strings.ko.xlf
+++ b/src/Utilities/Resources/xlf/Strings.ko.xlf
@@ -72,6 +72,11 @@
         <target state="translated">작업이 최신 상태가 아니므로 건너뛸 수 없습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ToolTask.PipeEOFTimeout">
+        <source>Pipe EOF not received within {0} seconds. A grandchild process may still be holding the pipe open. Output already delivered has been logged.</source>
+        <target state="new">Pipe EOF not received within {0} seconds. A grandchild process may still be holding the pipe open. Output already delivered has been logged.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ToolTask.ToolCommandFailed">
         <source>MSB6006: "{0}" exited with code {1}.</source>
         <target state="translated">MSB6006: "{0}"이(가) 종료되었습니다(코드: {1}).</target>

--- a/src/Utilities/Resources/xlf/Strings.pl.xlf
+++ b/src/Utilities/Resources/xlf/Strings.pl.xlf
@@ -72,6 +72,11 @@
         <target state="translated">Nie można pominąć zadania, ponieważ nie jest ono aktualne.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ToolTask.PipeEOFTimeout">
+        <source>Pipe EOF not received within {0} seconds. A grandchild process may still be holding the pipe open. Output already delivered has been logged.</source>
+        <target state="new">Pipe EOF not received within {0} seconds. A grandchild process may still be holding the pipe open. Output already delivered has been logged.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ToolTask.ToolCommandFailed">
         <source>MSB6006: "{0}" exited with code {1}.</source>
         <target state="translated">MSB6006: Polecenie „{0}” zakończone przez kod {1}.</target>

--- a/src/Utilities/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Utilities/Resources/xlf/Strings.pt-BR.xlf
@@ -72,6 +72,11 @@
         <target state="translated">Não foi possível ignorar a tarefa porque ela não está atualizada.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ToolTask.PipeEOFTimeout">
+        <source>Pipe EOF not received within {0} seconds. A grandchild process may still be holding the pipe open. Output already delivered has been logged.</source>
+        <target state="new">Pipe EOF not received within {0} seconds. A grandchild process may still be holding the pipe open. Output already delivered has been logged.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ToolTask.ToolCommandFailed">
         <source>MSB6006: "{0}" exited with code {1}.</source>
         <target state="translated">MSB6006: "{0}" foi encerrado com o código {1}.</target>

--- a/src/Utilities/Resources/xlf/Strings.ru.xlf
+++ b/src/Utilities/Resources/xlf/Strings.ru.xlf
@@ -72,6 +72,11 @@
         <target state="translated">Невозможно пропустить задачу, поскольку она не обновлена.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ToolTask.PipeEOFTimeout">
+        <source>Pipe EOF not received within {0} seconds. A grandchild process may still be holding the pipe open. Output already delivered has been logged.</source>
+        <target state="new">Pipe EOF not received within {0} seconds. A grandchild process may still be holding the pipe open. Output already delivered has been logged.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ToolTask.ToolCommandFailed">
         <source>MSB6006: "{0}" exited with code {1}.</source>
         <target state="translated">MSB6006: "{0}" завершилась с кодом {1}.</target>

--- a/src/Utilities/Resources/xlf/Strings.tr.xlf
+++ b/src/Utilities/Resources/xlf/Strings.tr.xlf
@@ -72,6 +72,11 @@
         <target state="translated">Güncel olmadığı için görev atlanamıyor.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ToolTask.PipeEOFTimeout">
+        <source>Pipe EOF not received within {0} seconds. A grandchild process may still be holding the pipe open. Output already delivered has been logged.</source>
+        <target state="new">Pipe EOF not received within {0} seconds. A grandchild process may still be holding the pipe open. Output already delivered has been logged.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ToolTask.ToolCommandFailed">
         <source>MSB6006: "{0}" exited with code {1}.</source>
         <target state="translated">MSB6006: "{0}" öğesinden {1} koduyla çıkıldı.</target>

--- a/src/Utilities/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Utilities/Resources/xlf/Strings.zh-Hans.xlf
@@ -72,6 +72,11 @@
         <target state="translated">无法跳过任务，因为它不是最新的。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ToolTask.PipeEOFTimeout">
+        <source>Pipe EOF not received within {0} seconds. A grandchild process may still be holding the pipe open. Output already delivered has been logged.</source>
+        <target state="new">Pipe EOF not received within {0} seconds. A grandchild process may still be holding the pipe open. Output already delivered has been logged.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ToolTask.ToolCommandFailed">
         <source>MSB6006: "{0}" exited with code {1}.</source>
         <target state="translated">MSB6006: “{0}”已退出，代码为 {1}。</target>

--- a/src/Utilities/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Utilities/Resources/xlf/Strings.zh-Hant.xlf
@@ -72,6 +72,11 @@
         <target state="translated">無法略過工作，因為它不是最新的。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ToolTask.PipeEOFTimeout">
+        <source>Pipe EOF not received within {0} seconds. A grandchild process may still be holding the pipe open. Output already delivered has been logged.</source>
+        <target state="new">Pipe EOF not received within {0} seconds. A grandchild process may still be holding the pipe open. Output already delivered has been logged.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ToolTask.ToolCommandFailed">
         <source>MSB6006: "{0}" exited with code {1}.</source>
         <target state="translated">MSB6006: "{0}" 以返回碼 {1} 結束。</target>

--- a/src/Utilities/ToolTask.cs
+++ b/src/Utilities/ToolTask.cs
@@ -1129,10 +1129,18 @@ namespace Microsoft.Build.Utilities
                 //
                 // Use a bounded timeout as a safety net for the grandchild case where
                 // EOF never arrives because grand child inherited the pipe and keeps it open.
-                const int eofTimeoutSec = 2;
+                const int eofTimeoutSec = 30;
 
                 WaitHandle[] eofEvents = [_standardOutputEOF, _standardErrorEOF];
-                WaitHandle.WaitAll(eofEvents, TimeSpan.FromSeconds(eofTimeoutSec));
+                bool allEOFReceived = WaitHandle.WaitAll(eofEvents, TimeSpan.FromSeconds(eofTimeoutSec));
+                if (!allEOFReceived)
+                {
+                    // Timeout: a grandchild process likely still holds the pipe open.
+                    // Drain whatever data has already arrived before returning.
+                    LogMessagesFromStandardError();
+                    LogMessagesFromStandardOutput();
+                    LogPrivate.LogMessageFromResources(MessageImportance.Low, "ToolTask.PipeEOFTimeout", eofTimeoutSec);
+                }
             }
             else
             {

--- a/src/Utilities/ToolTask.cs
+++ b/src/Utilities/ToolTask.cs
@@ -768,8 +768,8 @@ namespace Microsoft.Build.Utilities
 
             if (ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave18_6))
             {
-                _standardOutputEOF = new ManualResetEvent(false);
-                _standardErrorEOF = new ManualResetEvent(false);
+                // One count each for the stdout and stderr EOF notifications.
+                _eofCountdown = new CountdownEvent(2);
             }
 
             _toolExited = new ManualResetEvent(false);
@@ -865,8 +865,8 @@ namespace Microsoft.Build.Utilities
                     _standardErrorDataAvailable.Dispose();
                     _standardOutputDataAvailable.Dispose();
 
-                    _standardOutputEOF?.Dispose();
-                    _standardErrorEOF?.Dispose();
+                    _eofCountdown?.Dispose();
+                    _eofCountdown = null;
 
                     _toolExited.Dispose();
                     _toolTimeoutExpired.Dispose();
@@ -1131,8 +1131,11 @@ namespace Microsoft.Build.Utilities
                 // EOF never arrives because grand child inherited the pipe and keeps it open.
                 const int eofTimeoutSec = 30;
 
-                WaitHandle[] eofEvents = [_standardOutputEOF, _standardErrorEOF];
-                bool allEOFReceived = WaitHandle.WaitAll(eofEvents, TimeSpan.FromSeconds(eofTimeoutSec));
+                // CountdownEvent.Wait is STA-safe (it falls back to a single-handle wait),
+                // unlike WaitHandle.WaitAll over multiple handles which throws
+                // NotSupportedException on STA threads (for example when a task such as
+                // AspNetCompiler runs on an STA thread).
+                bool allEOFReceived = _eofCountdown.Wait(TimeSpan.FromSeconds(eofTimeoutSec));
                 if (!allEOFReceived)
                 {
                     // Timeout: a grandchild process likely still holds the pipe open.
@@ -1315,18 +1318,14 @@ namespace Microsoft.Build.Utilities
         {
             if (e.Data == null)
             {
-                // The AsyncStreamReader sends Data=null when the pipe reaches EOF.
-                // Signal the appropriate EOF event so WaitForProcessExit knows
-                // all data from this stream has been delivered.
-                ManualResetEvent eofEvent = (dataQueue == _standardErrorData) ? _standardErrorEOF : _standardOutputEOF;
-                if (eofEvent != null)
+                // The AsyncStreamReader sends Data=null exactly once per stream when the
+                // pipe reaches EOF. Count it down so WaitForProcessExit knows when all
+                // data from both streams has been delivered.
+                lock (_eventCloseLock)
                 {
-                    lock (_eventCloseLock)
+                    if (!_eventsDisposed && _eofCountdown is { IsSet: false })
                     {
-                        if (!_eventsDisposed)
-                        {
-                            eofEvent.Set();
-                        }
+                        _eofCountdown.Signal();
                     }
                 }
 
@@ -1869,16 +1868,11 @@ namespace Microsoft.Build.Utilities
         private bool _eventsDisposed;
 
         /// <summary>
-        /// Signalled when the stdout AsyncStreamReader reaches EOF (sends Data=null).
-        /// Used by WaitForProcessExit to know when all stdout data has been delivered.
+        /// Counts down once for each of stdout/stderr when its AsyncStreamReader reaches
+        /// EOF (sends Data=null). Used by WaitForProcessExit to know when all data from
+        /// both streams has been delivered.
         /// </summary>
-        private ManualResetEvent _standardOutputEOF;
-
-        /// <summary>
-        /// Signalled when the stderr AsyncStreamReader reaches EOF (sends Data=null).
-        /// Used by WaitForProcessExit to know when all stderr data has been delivered.
-        /// </summary>
-        private ManualResetEvent _standardErrorEOF;
+        private CountdownEvent _eofCountdown;
 
         /// <summary>
         /// List of name, value pairs to be passed to the spawned tool's environment.

--- a/src/Utilities/ToolTask.cs
+++ b/src/Utilities/ToolTask.cs
@@ -766,6 +766,12 @@ namespace Microsoft.Build.Utilities
             _standardErrorDataAvailable = new ManualResetEvent(false);
             _standardOutputDataAvailable = new ManualResetEvent(false);
 
+            if (ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave18_6))
+            {
+                _standardOutputEOF = new ManualResetEvent(false);
+                _standardErrorEOF = new ManualResetEvent(false);
+            }
+
             _toolExited = new ManualResetEvent(false);
             _terminatedTool = false;
             _toolTimeoutExpired = new ManualResetEvent(false);
@@ -858,6 +864,9 @@ namespace Microsoft.Build.Utilities
                     _eventsDisposed = true;
                     _standardErrorDataAvailable.Dispose();
                     _standardOutputDataAvailable.Dispose();
+
+                    _standardOutputEOF?.Dispose();
+                    _standardErrorEOF?.Dispose();
 
                     _toolExited.Dispose();
                     _toolTimeoutExpired.Dispose();
@@ -1097,13 +1106,40 @@ namespace Microsoft.Build.Utilities
         /// process is still finishing up, this method waits until it is done.
         /// </summary>
         /// <remarks>
-        /// This method is a hack, but it needs to be called after both
-        /// Process.WaitForExit() and Process.Kill().
+        /// On both .NET Framework and modern .NET, the parameterless Process.WaitForExit() waits not
+        /// only for the process to exit, but also for stdout/stderr pipe EOF via
+        /// AsyncStreamReader.WaitUtilEOF() (Framework) or awaiting the EOF task (Core).
+        /// If the tool spawned child processes that inherited the pipe handles, the EOF wait blocks
+        /// forever even though the tool itself has exited — causing the entire build node to hang.
         /// </remarks>
         /// <param name="proc"></param>
-        private static void WaitForProcessExit(Process proc)
+        private void WaitForProcessExit(Process proc)
         {
-            proc.WaitForExit();
+            if (ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave18_6))
+            {
+                // Step 1: Wait for the process handle to be signaled.
+                // Use int.MaxValue to avoid blocking on pipe EOF,
+                // as Process.WaitForExit does not wait for EOF when any timeout is provided.
+                proc.WaitForExit(int.MaxValue);
+
+                // Step 2: Wait for the AsyncStreamReader to deliver all remaining data.
+                // When the pipe reaches EOF, AsyncStreamReader flushes its StringBuilder
+                // (delivering any final partial line) and sends Data=null via the callback.
+                // Our ReceiveStandardErrorOrOutputData handler signals the EOF events.
+                //
+                // Use a bounded timeout as a safety net for the grandchild case where
+                // EOF never arrives because grand child inherited the pipe and keeps it open.
+                const int eofTimeoutSec = 2;
+
+                WaitHandle[] eofEvents = [_standardOutputEOF, _standardErrorEOF];
+                WaitHandle.WaitAll(eofEvents, TimeSpan.FromSeconds(eofTimeoutSec));
+            }
+            else
+            {
+                // Legacy behavior: parameterless WaitForExit waits for pipe EOF.
+                // This can hang if grandchild processes hold pipe handles.
+                proc.WaitForExit();
+            }
 
             // Process.WaitForExit() may return prematurely. We need to check to be sure.
             while (!proc.HasExited)
@@ -1269,36 +1305,52 @@ namespace Microsoft.Build.Utilities
         /// <param name="dataAvailableSignal"></param>
         private void ReceiveStandardErrorOrOutputData(DataReceivedEventArgs e, Queue dataQueue, ManualResetEvent dataAvailableSignal)
         {
-            // NOTE: don't ignore empty string, because we need to log that
-            if (e.Data != null)
+            if (e.Data == null)
             {
-                ErrorUtilities.VerifyThrow(dataQueue != null,
-                    "The data queue must be available.");
-
-                // synchronize access to the queue -- this is a producer-consumer problem
-                // NOTE: we lock the entire queue instead of using synchronized queue
-                // wrappers, because ManualResetEvents don't have ref counts, and it's
-                // difficult to discretely signal the availability of each instance of
-                // data in the queue -- so instead we let the consumer lock and empty
-                // the queue and reset the ManualResetEvent, before we add more data
-                // into the queue, and signal the ManualResetEvent again
-                lock (dataQueue.SyncRoot)
+                // The AsyncStreamReader sends Data=null when the pipe reaches EOF.
+                // Signal the appropriate EOF event so WaitForProcessExit knows
+                // all data from this stream has been delivered.
+                ManualResetEvent eofEvent = (dataQueue == _standardErrorData) ? _standardErrorEOF : _standardOutputEOF;
+                if (eofEvent != null)
                 {
-                    dataQueue.Enqueue(e.Data);
-
-                    ErrorUtilities.VerifyThrow(dataAvailableSignal != null,
-                        "The signalling event must be available.");
-
-                    // signal the availability of data
-                    // NOTE: intentionally, do the signalling inside the lock, because
-                    // ManualResetEvents don't have ref counts, and we want to make sure
-                    // we don't signal the notification just before the consumer resets it
                     lock (_eventCloseLock)
                     {
                         if (!_eventsDisposed)
                         {
-                            dataAvailableSignal.Set();
+                            eofEvent.Set();
                         }
+                    }
+                }
+
+                return;
+            }
+
+            // NOTE: don't ignore empty string, because we need to log that
+            ErrorUtilities.VerifyThrow(dataQueue != null, "The data queue must be available.");
+
+            // synchronize access to the queue -- this is a producer-consumer problem
+            // NOTE: we lock the entire queue instead of using synchronized queue
+            // wrappers, because ManualResetEvents don't have ref counts, and it's
+            // difficult to discretely signal the availability of each instance of
+            // data in the queue -- so instead we let the consumer lock and empty
+            // the queue and reset the ManualResetEvent, before we add more data
+            // into the queue, and signal the ManualResetEvent again
+            lock (dataQueue.SyncRoot)
+            {
+                dataQueue.Enqueue(e.Data);
+
+                ErrorUtilities.VerifyThrow(dataAvailableSignal != null,
+                    "The signalling event must be available.");
+
+                // signal the availability of data
+                // NOTE: intentionally, do the signalling inside the lock, because
+                // ManualResetEvents don't have ref counts, and we want to make sure
+                // we don't signal the notification just before the consumer resets it
+                lock (_eventCloseLock)
+                {
+                    if (!_eventsDisposed)
+                    {
+                        dataAvailableSignal.Set();
                     }
                 }
             }
@@ -1807,6 +1859,18 @@ namespace Microsoft.Build.Utilities
         /// calls on the event handlers don't try to reset a disposed event
         /// </summary>
         private bool _eventsDisposed;
+
+        /// <summary>
+        /// Signalled when the stdout AsyncStreamReader reaches EOF (sends Data=null).
+        /// Used by WaitForProcessExit to know when all stdout data has been delivered.
+        /// </summary>
+        private ManualResetEvent _standardOutputEOF;
+
+        /// <summary>
+        /// Signalled when the stderr AsyncStreamReader reaches EOF (sends Data=null).
+        /// Used by WaitForProcessExit to know when all stderr data has been delivered.
+        /// </summary>
+        private ManualResetEvent _standardErrorEOF;
 
         /// <summary>
         /// List of name, value pairs to be passed to the spawned tool's environment.


### PR DESCRIPTION
Reasoning: fix in main is in VS canary channel for 2 weeks without issues, we can replace the revert reintroducing hang potential with the long term fix in servicing as promised to QB.



Replaces the earlier revert of the ToolTask grandchild-pipe-handle fix (#13351) on this servicing branch with the correct, STA-safe fix.

### What this does
- Reverts the revert (#13946), reapplying the #13351 ToolTask fix, its unit tests, and the ChangeWaves.md entry. The earlier revert's correct `vs-insertion.yml` TargetBranch (`rel/insiders`) is preserved.
- Cherry-picks `24787e2ec6` (increase EOF pipe timeout 2s -> 30s; adds the `ToolTask.PipeEOFTimeout` resource string).
- Cherry-picks #13917 (`1722e4d`) which makes the EOF wait STA-safe via `CountdownEvent` (fixes MSB4018 in AspNetCompiler on STA threads).
- Bumps `VersionPrefix` 18.8.2 -> 18.8.3.

The resulting `ToolTask.cs` EOF-handling logic is identical to `main`. Feature stays gated behind ChangeWave `Wave18_6`.
