### PR TITLE
Make IActivity.SetTag/SetTags return non-nullable IActivity

### DIFF
--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -1245,13 +1245,12 @@ namespace Microsoft.Build.Execution
         {
             TelemetryManager.Instance.Initialize(isStandalone: false);
 
-            using IActivity? activity = TelemetryManager.Instance
-                ?.DefaultActivitySource
+            using IActivity? activity = TelemetryManager.Instance.DefaultActivitySource
                 ?.StartActivity(TelemetryConstants.Build)
                 ?.SetTags(_buildTelemetry)
-                ?.SetTags(_telemetryConsumingLogger?.WorkerNodeTelemetryData.AsActivityDataHolder(
-                        includeTasksDetails: !Traits.Instance.ExcludeTasksDetailsFromTelemetry,
-                        includeTargetDetails: false));
+                .SetTags(_telemetryConsumingLogger?.WorkerNodeTelemetryData.AsActivityDataHolder(
+                    includeTasksDetails: !Traits.Instance.ExcludeTasksDetailsFromTelemetry,
+                    includeTargetDetails: false));
         }
 
         /// <summary>
@@ -3483,7 +3482,7 @@ namespace Microsoft.Build.Execution
                         s_singletonInstance = null;
                     }
 
-                    TelemetryManager.Instance?.Dispose();
+                    TelemetryManager.Instance.Dispose();
 
                     _disposed = true;
                 }

--- a/src/Framework/Telemetry/CrashTelemetryRecorder.cs
+++ b/src/Framework/Telemetry/CrashTelemetryRecorder.cs
@@ -84,11 +84,11 @@ internal static class CrashTelemetryRecorder
             // Initialize here because the process is about to die — this may be
             // the only chance to set up telemetry (e.g., crash before Main() init,
             // or in a task AppDomain with separate static state).
-            TelemetryManager.Instance?.Initialize(isStandalone: false);
+            TelemetryManager.Instance.Initialize(isStandalone: false);
 
-            using IActivity? activity = TelemetryManager.Instance
-                ?.DefaultActivitySource
+            using IActivity? activity = TelemetryManager.Instance.DefaultActivitySource
                 ?.StartActivity(TelemetryConstants.Crash);
+
             activity?.SetTags(crashTelemetry);
 
             PostFaultEvent(crashTelemetry);
@@ -120,8 +120,7 @@ internal static class CrashTelemetryRecorder
             // is responsible for initialization. Calling Initialize from here would create a
             // VS telemetry session when tests call MSBuildApp.Execute() in-process, causing
             // environment variable side effects.
-            using IActivity? activity = TelemetryManager.Instance
-                ?.DefaultActivitySource
+            using IActivity? activity = TelemetryManager.Instance.DefaultActivitySource
                 ?.StartActivity(TelemetryConstants.Crash);
             activity?.SetTags(crashTelemetry);
 
@@ -225,10 +224,9 @@ internal static class CrashTelemetryRecorder
     {
         try
         {
-            TelemetryManager.Instance?.Initialize(crashTelemetry.IsStandaloneExecution ?? false);
+            TelemetryManager.Instance.Initialize(crashTelemetry.IsStandaloneExecution ?? false);
 
-            using IActivity? activity = TelemetryManager.Instance
-                ?.DefaultActivitySource
+            using IActivity? activity = TelemetryManager.Instance.DefaultActivitySource
                 ?.StartActivity(TelemetryConstants.Crash);
             activity?.SetTags(crashTelemetry);
         }

--- a/src/Framework/Telemetry/DiagnosticActivity.cs
+++ b/src/Framework/Telemetry/DiagnosticActivity.cs
@@ -21,25 +21,25 @@ namespace Microsoft.Build.Framework.Telemetry
             _activity = activity;
         }
 
-        public IActivity? SetTags(IActivityTelemetryDataHolder? dataHolder)
+        public IActivity SetTags(IActivityTelemetryDataHolder? dataHolder)
         {
             Dictionary<string, object>? tags = dataHolder?.GetActivityProperties();
             if (tags != null)
             {
                 foreach (KeyValuePair<string, object> tag in tags)
                 {
-                    SetTag(tag.Key, tag.Value);
+                    _ = SetTag(tag.Key, tag.Value);
                 }
             }
 
             return this;
         }
 
-        public IActivity? SetTag(string key, object? value)
+        public IActivity SetTag(string key, object? value)
         {
             if (value != null)
             {
-                _activity.SetTag($"{TelemetryConstants.PropertyPrefix}{key}", value);
+                _ = _activity.SetTag($"{TelemetryConstants.PropertyPrefix}{key}", value);
             }
 
             return this;

--- a/src/Framework/Telemetry/IActivity.cs
+++ b/src/Framework/Telemetry/IActivity.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Build.Framework.Telemetry
         /// </summary>
         /// <param name="dataHolder">Telemetry data holder.</param>
         /// <returns>The activity instance for method chaining.</returns>
-        IActivity? SetTags(IActivityTelemetryDataHolder? dataHolder);
+        IActivity SetTags(IActivityTelemetryDataHolder? dataHolder);
 
         /// <summary>
         /// Sets a tag on the activity.
@@ -23,6 +23,6 @@ namespace Microsoft.Build.Framework.Telemetry
         /// <param name="key">The tag key.</param>
         /// <param name="value">The tag value.</param>
         /// <returns>The activity instance for method chaining.</returns>
-        IActivity? SetTag(string key, object? value);
+        IActivity SetTag(string key, object? value);
     }
 }

--- a/src/Framework/Telemetry/VSTelemetryActivity.cs
+++ b/src/Framework/Telemetry/VSTelemetryActivity.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Build.Framework.Telemetry
             _scope = scope;
         }
 
-        public IActivity? SetTags(IActivityTelemetryDataHolder? dataHolder)
+        public IActivity SetTags(IActivityTelemetryDataHolder? dataHolder)
         {
             Dictionary<string, object>? tags = dataHolder?.GetActivityProperties();
 
@@ -40,7 +40,7 @@ namespace Microsoft.Build.Framework.Telemetry
             return this;
         }
 
-        public IActivity? SetTag(string key, object? value)
+        public IActivity SetTag(string key, object? value)
         {
             if (value != null)
             {

--- a/src/MSBuild.Coordinator/CoordinatorTelemetry.cs
+++ b/src/MSBuild.Coordinator/CoordinatorTelemetry.cs
@@ -41,12 +41,12 @@ internal static class CoordinatorTelemetry
     {
         using IActivity? _ = StartActivity(GrantActivity)
             ?.SetTag(ConnectionIdTag, grant.ConnectionId)
-            ?.SetTag(ProcessIdTag, grant.ProcessId)
-            ?.SetTag(NodesRequestedTag, grant.RequestedNodes)
-            ?.SetTag(NodesGrantedTag, grant.GrantedNodes)
-            ?.SetTag(QueueDepthTag, queueDepth)
-            ?.SetTag(ActiveBuildsTag, activeBuilds)
-            ?.SetTag(AllocatedNodesTag, allocatedNodes);
+            .SetTag(ProcessIdTag, grant.ProcessId)
+            .SetTag(NodesRequestedTag, grant.RequestedNodes)
+            .SetTag(NodesGrantedTag, grant.GrantedNodes)
+            .SetTag(QueueDepthTag, queueDepth)
+            .SetTag(ActiveBuildsTag, activeBuilds)
+            .SetTag(AllocatedNodesTag, allocatedNodes);
     }
 
     /// <summary>
@@ -56,9 +56,9 @@ internal static class CoordinatorTelemetry
     {
         using IActivity? _ = StartActivity(DeferredActivity)
             ?.SetTag(ConnectionIdTag, grant.ConnectionId)
-            ?.SetTag(ProcessIdTag, grant.ProcessId)
-            ?.SetTag(NodesRequestedTag, grant.RequestedNodes)
-            ?.SetTag(QueueDepthTag, queueDepth);
+            .SetTag(ProcessIdTag, grant.ProcessId)
+            .SetTag(NodesRequestedTag, grant.RequestedNodes)
+            .SetTag(QueueDepthTag, queueDepth);
     }
 
     /// <summary>
@@ -68,11 +68,11 @@ internal static class CoordinatorTelemetry
     {
         using IActivity? _ = StartActivity(DeferredGrantFulfilledActivity)
             ?.SetTag(ConnectionIdTag, grant.ConnectionId)
-            ?.SetTag(ProcessIdTag, grant.ProcessId)
-            ?.SetTag(NodesGrantedTag, grant.GrantedNodes)
-            ?.SetTag(QueueDepthTag, queueDepth)
-            ?.SetTag(ActiveBuildsTag, activeBuilds)
-            ?.SetTag(AllocatedNodesTag, allocatedNodes);
+            .SetTag(ProcessIdTag, grant.ProcessId)
+            .SetTag(NodesGrantedTag, grant.GrantedNodes)
+            .SetTag(QueueDepthTag, queueDepth)
+            .SetTag(ActiveBuildsTag, activeBuilds)
+            .SetTag(AllocatedNodesTag, allocatedNodes);
     }
 
     /// <summary>
@@ -82,10 +82,10 @@ internal static class CoordinatorTelemetry
     {
         using IActivity? _ = StartActivity(ReleasedActivity)
             ?.SetTag(ConnectionIdTag, grant.ConnectionId)
-            ?.SetTag(ProcessIdTag, grant.ProcessId)
-            ?.SetTag(NodesReleasedTag, grant.GrantedNodes)
-            ?.SetTag(QueueDepthTag, queueDepth)
-            ?.SetTag(ActiveBuildsTag, activeBuilds)
-            ?.SetTag(AllocatedNodesTag, allocatedNodes);
+            .SetTag(ProcessIdTag, grant.ProcessId)
+            .SetTag(NodesReleasedTag, grant.GrantedNodes)
+            .SetTag(QueueDepthTag, queueDepth)
+            .SetTag(ActiveBuildsTag, activeBuilds)
+            .SetTag(AllocatedNodesTag, allocatedNodes);
     }
 }

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -300,7 +300,7 @@ namespace Microsoft.Build.CommandLine
             // Initialize new build telemetry and record start of this build.
             KnownTelemetry.PartialBuildTelemetry = new BuildTelemetry { StartAt = DateTime.UtcNow, IsStandaloneExecution = true };
 
-            TelemetryManager.Instance?.Initialize(isStandalone: true);
+            TelemetryManager.Instance.Initialize(isStandalone: true);
 
             using PerformanceLogEventListener eventListener = PerformanceLogEventListener.Create();
 
@@ -350,7 +350,7 @@ namespace Microsoft.Build.CommandLine
                 DumpCounters(false /* log to console */);
             }
 
-            TelemetryManager.Instance?.Dispose();
+            TelemetryManager.Instance.Dispose();
 
             return exitCode;
         }


### PR DESCRIPTION
While adding telemetry reporting to the MSBuild coordinator, I noticed that the `SetTag` and `SetTags` methods on `IActivity` always return `this`, so their return type should be non-nullable. This removes unnecessary null-conditional chaining (?.) after the first call in fluent chains, since the activity reference is already known to be non-null after `StartActivity` succeeds. Also removes the redundant ?. on `TelemetryManager.Instance` which is never null.