### PR TITLE
Default out-of-proc node pipe buffers to 1 MB (change wave 18.9)

### DIFF
--- a/documentation/wiki/ChangeWaves.md
+++ b/documentation/wiki/ChangeWaves.md
@@ -31,6 +31,7 @@ Change wave checks around features will be removed in the release that accompani
 
 ### 18.9
 - [GenerateResource: typed ResX data/metadata entries in Mark-of-the-Web files are now treated as untrusted and blocked with MSB3821; unblock the file (or set MSBUILDDISABLEFEATURESFROMVERSION=18.9) to restore prior behavior. ResXFileRef entries are always blocked regardless of this wave.](https://github.com/dotnet/msbuild/pull/14015)
+- [Out-of-process .NET node/TaskHost named-pipe buffers default to 1 MB (was 128 KB), greatly reducing send backpressure for large TaskHostConfiguration packets in -mt builds. Tunable via MSBUILDNODECONNECTIONBUFFERSIZE; opt out with MSBUILDDISABLEFEATURESFROMVERSION=18.9. The legacy .NET Framework 3.5 task host keeps 128 KB.](https://github.com/dotnet/msbuild/pull/PLACEHOLDER)
 
 ### 18.8
 - [RAR task: across multiple input properties, resolve relative paths against the project directory (not the process current directory)](https://github.com/dotnet/msbuild/pull/13319)

--- a/documentation/wiki/ChangeWaves.md
+++ b/documentation/wiki/ChangeWaves.md
@@ -31,7 +31,7 @@ Change wave checks around features will be removed in the release that accompani
 
 ### 18.9
 - [GenerateResource: typed ResX data/metadata entries in Mark-of-the-Web files are now treated as untrusted and blocked with MSB3821; unblock the file (or set MSBUILDDISABLEFEATURESFROMVERSION=18.9) to restore prior behavior. ResXFileRef entries are always blocked regardless of this wave.](https://github.com/dotnet/msbuild/pull/14015)
-- [Out-of-process .NET node/TaskHost named-pipe buffers default to 1 MB (was 128 KB), greatly reducing send backpressure for large TaskHostConfiguration packets in -mt builds. Tunable via MSBUILDNODECONNECTIONBUFFERSIZE; opt out with MSBUILDDISABLEFEATURESFROMVERSION=18.9. The legacy .NET Framework 3.5 task host keeps 128 KB.](https://github.com/dotnet/msbuild/pull/PLACEHOLDER)
+- [Out-of-process .NET node/TaskHost named-pipe buffers default to 1 MB (was 128 KB), greatly reducing send backpressure for large TaskHostConfiguration packets in -mt builds. Tunable via MSBUILDNODECONNECTIONBUFFERSIZE; opt out with MSBUILDDISABLEFEATURESFROMVERSION=18.9. The legacy .NET Framework 3.5 task host keeps 128 KB.](https://github.com/dotnet/msbuild/pull/14094)
 
 ### 18.8
 - [RAR task: across multiple input properties, resolve relative paths against the project directory (not the process current directory)](https://github.com/dotnet/msbuild/pull/13319)

--- a/documentation/wiki/ChangeWaves.md
+++ b/documentation/wiki/ChangeWaves.md
@@ -31,7 +31,7 @@ Change wave checks around features will be removed in the release that accompani
 
 ### 18.9
 - [GenerateResource: typed ResX data/metadata entries in Mark-of-the-Web files are now treated as untrusted and blocked with MSB3821; unblock the file (or set MSBUILDDISABLEFEATURESFROMVERSION=18.9) to restore prior behavior. ResXFileRef entries are always blocked regardless of this wave.](https://github.com/dotnet/msbuild/pull/14015)
-- [Out-of-process .NET node/TaskHost named-pipe buffers default to 1 MB (was 128 KB), greatly reducing send backpressure for large TaskHostConfiguration packets in -mt builds. Tunable via MSBUILDNODECONNECTIONBUFFERSIZE; opt out with MSBUILDDISABLEFEATURESFROMVERSION=18.9. The legacy .NET Framework 3.5 task host keeps 128 KB.](https://github.com/dotnet/msbuild/pull/14094)
+- [TaskHost named-pipe buffers default to 1 MB (was 128 KB), reducing send backpressure for large TaskHostConfiguration packets. Tunable via MSBUILDNODECONNECTIONBUFFERSIZE](https://github.com/dotnet/msbuild/pull/14094)
 
 ### 18.8
 - [RAR task: across multiple input properties, resolve relative paths against the project directory (not the process current directory)](https://github.com/dotnet/msbuild/pull/13319)

--- a/src/Build.UnitTests/ChangeWaves_Tests.cs
+++ b/src/Build.UnitTests/ChangeWaves_Tests.cs
@@ -230,5 +230,48 @@ namespace Microsoft.Build.Engine.UnitTests
                 }
             }
         }
+
+        [Fact]
+        public void NodeConnectionBufferSizeIsLargeWhenWaveEnabled()
+        {
+            using (TestEnvironment env = TestEnvironment.Create())
+            {
+                // No MSBUILDDISABLEFEATURESFROMVERSION => all waves enabled => 1 MB buffer.
+                // In unit tests BuildEnvironmentState.s_runningTests is true, so Traits.Instance
+                // returns a fresh instance each access and reflects the current environment.
+                env.SetEnvironmentVariable("MSBUILDNODECONNECTIONBUFFERSIZE", null);
+                SetChangeWave(string.Empty, env);
+
+                ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave18_9).ShouldBeTrue();
+                Traits.Instance.NodeConnectionBufferSize.ShouldBe(1024 * 1024);
+            }
+        }
+
+        [Fact]
+        public void NodeConnectionBufferSizeStaysLegacyWhenWaveDisabled()
+        {
+            using (TestEnvironment env = TestEnvironment.Create())
+            {
+                // Opting out of wave 18.9 must restore the historical 128 KB buffer.
+                env.SetEnvironmentVariable("MSBUILDNODECONNECTIONBUFFERSIZE", null);
+                SetChangeWave(ChangeWaves.Wave18_9.ToString(), env);
+
+                ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave18_9).ShouldBeFalse();
+                Traits.Instance.NodeConnectionBufferSize.ShouldBe(128 * 1024);
+            }
+        }
+
+        [Fact]
+        public void NodeConnectionBufferSizeRespectsEnvironmentOverride()
+        {
+            using (TestEnvironment env = TestEnvironment.Create())
+            {
+                // An explicit override wins regardless of the change wave.
+                SetChangeWave(ChangeWaves.Wave18_9.ToString(), env);
+                env.SetEnvironmentVariable("MSBUILDNODECONNECTIONBUFFERSIZE", (256 * 1024).ToString());
+
+                Traits.Instance.NodeConnectionBufferSize.ShouldBe(256 * 1024);
+            }
+        }
     }
 }

--- a/src/Build.UnitTests/ChangeWaves_Tests.cs
+++ b/src/Build.UnitTests/ChangeWaves_Tests.cs
@@ -234,6 +234,11 @@ namespace Microsoft.Build.Engine.UnitTests
         [Fact]
         public void NodeConnectionBufferSizeIsLargeWhenWaveEnabled()
         {
+            // NOTE: these tests cover the value produced by Traits.NodeConnectionBufferSize only.
+            // The single delegation that wires it into the pipe
+            // (NodeEndpointOutOfProcBase.PipeBufferSize => Traits.Instance.NodeConnectionBufferSize)
+            // is intentionally not unit-tested - exercising it would require spawning a real node and
+            // inspecting the kernel pipe buffer. It is a trivial, verified-by-inspection delegation.
             using (TestEnvironment env = TestEnvironment.Create())
             {
                 // No MSBUILDDISABLEFEATURESFROMVERSION => all waves enabled => 1 MB buffer.

--- a/src/Framework/Traits.cs
+++ b/src/Framework/Traits.cs
@@ -149,9 +149,9 @@ namespace Microsoft.Build.Framework
                 return configured;
             }
 
-            const int LargeBufferSize = 1024 * 1024;
+            const int DefaultBufferSize = 1024 * 1024;
             const int LegacyBufferSize = 128 * 1024;
-            return ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave18_9) ? LargeBufferSize : LegacyBufferSize;
+            return ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave18_9) ? DefaultBufferSize : LegacyBufferSize;
         }
 
         /// <summary>

--- a/src/Framework/Traits.cs
+++ b/src/Framework/Traits.cs
@@ -130,6 +130,31 @@ namespace Microsoft.Build.Framework
         public readonly int DictionaryBasedItemRemoveThreshold = EnvironmentUtilities.GetValueAsInt32OrDefault("MSBUILDDICTIONARYBASEDITEMREMOVETHRESHOLD", 100);
 
         /// <summary>
+        /// Size in bytes of the kernel buffers backing the named pipes used to communicate with out-of-process
+        /// .NET nodes (worker nodes and .NET TaskHosts). A larger buffer lets the sending side queue more (or
+        /// larger) packets before it blocks waiting for the receiver to drain, which removes most of the
+        /// backpressure stalls when shipping large TaskHostConfiguration packets to sidecar TaskHosts in
+        /// multi-threaded (-mt) builds. Tunable via MSBUILDNODECONNECTIONBUFFERSIZE; when unset it defaults to
+        /// 1 MB under change wave 18.9, falling back to the historical 128 KB when that wave is opted out.
+        /// Note: the legacy .NET Framework 3.5 task host (MSBuildTaskHost) uses its own endpoint and is
+        /// intentionally unaffected by this setting - it keeps the historical 128 KB buffer.
+        /// </summary>
+        public readonly int NodeConnectionBufferSize = GetNodeConnectionBufferSize();
+
+        private static int GetNodeConnectionBufferSize()
+        {
+            int configured = EnvironmentUtilities.GetValueAsInt32OrDefault("MSBUILDNODECONNECTIONBUFFERSIZE", -1);
+            if (configured > 0)
+            {
+                return configured;
+            }
+
+            const int LargeBufferSize = 1024 * 1024;
+            const int LegacyBufferSize = 128 * 1024;
+            return ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave18_9) ? LargeBufferSize : LegacyBufferSize;
+        }
+
+        /// <summary>
         /// Launches a persistent RAR process.
         /// </summary>
         /// TODO: Replace with command line flag when feature is completed. The environment variable is intented to avoid exposing the flag early.

--- a/src/Shared/NodeEndpointOutOfProcBase.cs
+++ b/src/Shared/NodeEndpointOutOfProcBase.cs
@@ -45,9 +45,10 @@ namespace Microsoft.Build.BackEnd
 #endif // NETCOREAPP2_1
 
         /// <summary>
-        /// The size of the buffers to use for named pipes
+        /// The size of the buffers to use for named pipes. Read from <see cref="Traits.NodeConnectionBufferSize"/>
+        /// at construction so it honors the change wave / env override (and Traits reset in tests).
         /// </summary>
-        private const int PipeBufferSize = 131072;
+        private static int PipeBufferSize => Traits.Instance.NodeConnectionBufferSize;
 
         /// <summary>
         /// The current communication status of the node.

--- a/src/Shared/NodeEndpointOutOfProcBase.cs
+++ b/src/Shared/NodeEndpointOutOfProcBase.cs
@@ -45,8 +45,9 @@ namespace Microsoft.Build.BackEnd
 #endif // NETCOREAPP2_1
 
         /// <summary>
-        /// The size of the buffers to use for named pipes. Read from <see cref="Traits.NodeConnectionBufferSize"/>
-        /// at construction so it honors the change wave / env override (and Traits reset in tests).
+        /// The size of the buffers to use for named pipes. Re-evaluated on each access via
+        /// <see cref="Traits.NodeConnectionBufferSize"/> so it honors the change wave / env override
+        /// (and the per-access <see cref="Traits.Instance"/> reset used in tests).
         /// </summary>
         private static int PipeBufferSize => Traits.Instance.NodeConnectionBufferSize;
 
@@ -232,6 +233,8 @@ namespace Microsoft.Build.BackEnd
             _parentPacketVersion = parentPacketVersion;
 
             pipeName ??= NamedPipeUtil.GetPlatformSpecificPipeName();
+
+            CommunicationsUtilities.Trace($"Creating pipe '{pipeName}' with buffer size {PipeBufferSize}.");
 
 #if FEATURE_PIPE_SECURITY && FEATURE_NAMED_PIPE_SECURITY_CONSTRUCTOR
             SecurityIdentifier identifier = WindowsIdentity.GetCurrent().Owner;


### PR DESCRIPTION
## Summary

Out-of-process .NET node and TaskHost communication uses a named pipe whose kernel buffer has been fixed at **128 KB**. Because the sender writes packets synchronously, a named-pipe write **blocks until the receiver drains the buffer** when the buffer is full. In multi-threaded (`-mt`) builds, non-thread-safe tasks (notably **Csc/Vbc**) run in sidecar TaskHosts, and their `TaskHostConfiguration` packets are large (avg ~46 KB, up to ~1.5 MB). With a 128 KB buffer the sender spends almost all its time blocked on backpressure.

This change makes the buffer size a **Traits** setting (`NodeConnectionBufferSize`) — so it is resettable for tests and tunable via `MSBUILDNODECONNECTIONBUFFERSIZE` — and **defaults it to 1 MB under change wave 18.9**, falling back to the historical 128 KB when the wave is opted out.

## Why 1 MB (data)

Sweeping the pipe buffer with no other changes (3 runs each, `OrchardCore.Cms.Web -t:Rebuild -mt`, parent→child transport time, median):

| pipe buffer | send time |
|---|---|
| 128 KB (old default) | 114.2 s |
| 256 KB | 59.9 s |
| 512 KB | 30.5 s |
| **1 MB** | **9.0 s** |
| 4 MB | 8.5 s |
| 16 MB | 11.7 s |
| 64 MB | 8.3 s |

Send time roughly halves per doubling up to ~1 MB, then plateaus. **1 MB gives ~12× on the send path** for a modest, bounded memory cost. A 1 MB buffer is a deep enough queue (~11 average configs, or one whole large config) that the sender dumps-and-moves-on instead of blocking per packet. Bigger buffers add non-paged kernel pool for no further benefit.

## Why a change wave

This is a behavioral/resource change (more non-paged kernel pool per node — ~50 MB at a measured peak of 25 concurrent TaskHosts) rather than a pure bug fix, so it ships behind change wave **18.9** with an opt-out (`MSBUILDDISABLEFEATURESFROMVERSION=18.9`) per repo policy.

## Compatibility / legacy task host

- The **legacy .NET Framework 3.5 task host** (`src/MSBuildTaskHost`) uses its **own** endpoint with its own unchanged 128 KB constant, so it is intentionally unaffected and keeps 128 KB.
- Named-pipe buffer sizes are **per-stream OS hints that are never negotiated** and are not part of the handshake or framing. The parent always connects as a **client without specifying a buffer**; the buffer is set solely by the child/server. So a new (1 MB) parent and an old (128 KB) child — or any mix — interoperate exactly as before. Writing a large payload to a small-buffer pipe is already today's shipping behavior (128 KB buffer, 1.5 MB packets).

## Tests

`ChangeWaves_Tests` adds coverage that `Traits.NodeConnectionBufferSize` is:
- 1 MB when wave 18.9 is enabled,
- 128 KB when the wave is opted out (legacy preserved),
- equal to an explicit `MSBUILDNODECONNECTIONBUFFERSIZE` override regardless of the wave.

All pass on net10.0 and net472. Repo builds clean (0 warnings / 0 errors); an end-to-end `-mt` TaskHost build succeeds with the new default.

## Notes

This is the focused, product-ready slice of a broader IPC investigation (the larger shared-memory transport prototype, with full per-task measurements and a Unix analysis, is tracked separately in #14054). The pipe-buffer bump is the cheapest, lowest-risk, cross-platform win and is independent of that prototype.
