### PR TITLE
Fix TaskParameterTaskItem.ToString() returning type name instead of item-spec

### DIFF
--- a/src/MSBuildTaskHost/BackEnd/TaskParameter.cs
+++ b/src/MSBuildTaskHost/BackEnd/TaskParameter.cs
@@ -561,6 +561,14 @@ internal class TaskParameter : MarshalByRefObject, ITranslatable
         }
 
         /// <summary>
+        /// Returns the item-spec, matching the behavior of other <see cref="ITaskItem"/> implementations.
+        /// Tasks that receive this item (e.g. when task parameters are marshaled to an out-of-proc TaskHost)
+        /// may call ToString() expecting the item-spec; without this override they would get the .NET type
+        /// name instead. See https://github.com/dotnet/msbuild/issues/13896.
+        /// </summary>
+        public override string ToString() => _escapedItemSpec ?? string.Empty;
+
+        /// <summary>
         /// Overridden to give this class infinite lease time. Otherwise we end up with a limited
         /// lease (5 minutes I think) and instances can expire if they take long time processing.
         /// </summary>

--- a/src/MSBuildTaskHost/BackEnd/TaskParameter.cs
+++ b/src/MSBuildTaskHost/BackEnd/TaskParameter.cs
@@ -561,14 +561,6 @@ internal class TaskParameter : MarshalByRefObject, ITranslatable
         }
 
         /// <summary>
-        /// Returns the item-spec, matching the behavior of other <see cref="ITaskItem"/> implementations.
-        /// Tasks that receive this item (e.g. when task parameters are marshaled to an out-of-proc TaskHost)
-        /// may call ToString() expecting the item-spec; without this override they would get the .NET type
-        /// name instead. See https://github.com/dotnet/msbuild/issues/13896.
-        /// </summary>
-        public override string ToString() => _escapedItemSpec ?? string.Empty;
-
-        /// <summary>
         /// Overridden to give this class infinite lease time. Otherwise we end up with a limited
         /// lease (5 minutes I think) and instances can expire if they take long time processing.
         /// </summary>

--- a/src/Shared/TaskParameter.cs
+++ b/src/Shared/TaskParameter.cs
@@ -640,10 +640,7 @@ namespace Microsoft.Build.BackEnd
             }
 
             /// <summary>
-            /// Returns the item-spec, matching the behavior of other <see cref="ITaskItem"/> implementations.
-            /// Tasks that receive this item (e.g. when task parameters are marshaled in -mt mode or to an
-            /// out-of-proc TaskHost) may call ToString() expecting the item-spec; without this override they
-            /// would get the .NET type name instead. See https://github.com/dotnet/msbuild/issues/13896.
+            /// Returns the item-spec, matching other <see cref="ITaskItem"/> implementations.
             /// </summary>
             public override string ToString() => _escapedItemSpec;
 

--- a/src/Shared/TaskParameter.cs
+++ b/src/Shared/TaskParameter.cs
@@ -640,7 +640,7 @@ namespace Microsoft.Build.BackEnd
             }
 
             /// <summary>
-            /// Returns the item-spec, matching other <see cref="ITaskItem"/> implementations.
+            /// Returns the escaped item-spec (evaluated include), matching engine task items.
             /// </summary>
             public override string ToString() => _escapedItemSpec;
 

--- a/src/Shared/TaskParameter.cs
+++ b/src/Shared/TaskParameter.cs
@@ -640,6 +640,14 @@ namespace Microsoft.Build.BackEnd
             }
 
             /// <summary>
+            /// Returns the item-spec, matching the behavior of other <see cref="ITaskItem"/> implementations.
+            /// Tasks that receive this item (e.g. when task parameters are marshaled in -mt mode or to an
+            /// out-of-proc TaskHost) may call ToString() expecting the item-spec; without this override they
+            /// would get the .NET type name instead. See https://github.com/dotnet/msbuild/issues/13896.
+            /// </summary>
+            public override string ToString() => _escapedItemSpec;
+
+            /// <summary>
             /// Gets or sets the item "specification" e.g. for disk-based items this would be the file path.
             /// </summary>
             /// <remarks>

--- a/src/Shared/UnitTests/TaskParameter_Tests.cs
+++ b/src/Shared/UnitTests/TaskParameter_Tests.cs
@@ -515,6 +515,37 @@ namespace Microsoft.Build.UnitTests
             (t2.WrappedParameter as ITaskItem).GetMetadata("RecursiveDir").ShouldBe(expectedRecursiveDir);
         }
 
+        /// <summary>
+        /// Regression test for https://github.com/dotnet/msbuild/issues/13896
+        /// ToString() on the marshaled task item must return the item-spec (matching every other
+        /// ITaskItem implementation), not the .NET type name. In -mt mode (and out-of-proc TaskHost)
+        /// task outputs come back as TaskParameterTaskItem; tasks that consume them may call ToString()
+        /// expecting the spec. Without the override they would get
+        /// "Microsoft.Build.BackEnd.TaskParameter+TaskParameterTaskItem" instead.
+        /// </summary>
+        [Fact]
+        public void ITaskItemParameter_ToStringReturnsItemSpec()
+        {
+            TaskParameter t = new TaskParameter(new TaskItem("some/path/foo.dll"));
+
+            ITaskItem wrapped = t.WrappedParameter as ITaskItem;
+            wrapped.ShouldNotBeNull();
+            wrapped.ToString().ShouldBe("some/path/foo.dll");
+
+            // The spec is returned in its escaped form, matching ProjectItemInstance.TaskItem.ToString().
+            ITaskItem wrappedEscaped = new TaskParameter(new TaskItem("foo%3bbar")).WrappedParameter as ITaskItem;
+            wrappedEscaped.ToString().ShouldBe("foo%3bbar");
+            wrappedEscaped.ItemSpec.ShouldBe("foo;bar");
+
+            // The spec survives serialization (the TaskHost / -mt marshaling boundary).
+            ((ITranslatable)t).Translate(TranslationHelpers.GetWriteTranslator());
+            TaskParameter t2 = TaskParameter.FactoryForDeserialization(TranslationHelpers.GetReadTranslator());
+
+            ITaskItem wrapped2 = t2.WrappedParameter as ITaskItem;
+            wrapped2.ShouldNotBeNull();
+            wrapped2.ToString().ShouldBe("some/path/foo.dll");
+        }
+
 #if FEATURE_APPDOMAIN
         private sealed class RemoteTaskItemFactory : MarshalByRefObject
         {

--- a/src/Shared/UnitTests/TaskParameter_Tests.cs
+++ b/src/Shared/UnitTests/TaskParameter_Tests.cs
@@ -534,6 +534,7 @@ namespace Microsoft.Build.UnitTests
 
             // The spec is returned in its escaped form, matching ProjectItemInstance.TaskItem.ToString().
             ITaskItem wrappedEscaped = new TaskParameter(new TaskItem("foo%3bbar")).WrappedParameter as ITaskItem;
+            wrappedEscaped.ShouldNotBeNull();
             wrappedEscaped.ToString().ShouldBe("foo%3bbar");
             wrappedEscaped.ItemSpec.ShouldBe("foo;bar");
 


### PR DESCRIPTION
Fix TaskParameterTaskItem.ToString() returning type name instead of item-spec

Fixes #13896

### Context

When building xunit with a freshly built MSBuild using the `/mt` (multithreaded)
flag, the build fails with:

> Could not find input reference assembly 'Microsoft.Build.BackEnd.TaskParameter+TaskParameterTaskItem'

The same build succeeds without `/mt`.

`TaskParameterTaskItem` is the internal wrapper MSBuild uses to marshal `ITaskItem` instances across node/thread boundaries. It did not override `ToString()`, so it fell back to `object.ToString()` and returned its full .NET type name
(`Microsoft.Build.BackEnd.TaskParameter+TaskParameterTaskItem`) instead of the item-spec. Every other `ITaskItem` implementation (`ProjectItemInstance.TaskItem`, `Utilities.TaskItem`, `TaskItemData`) overrides `ToString()` to return the item-spec.

This only surfaces under `/mt`: non-thread-safe tasks are routed to a TaskHost for isolation (`TaskRouter.NeedsTaskHostInMultiThreadedMode` → `AssemblyTaskFactory` → `TaskHostTask`), so task **outputs** come back wrapped as `TaskParameterTaskItem` (`TaskHostTask.cs:641`). When a downstream task builds a path via `item.ToString()` — here the third-party `AnnotateReferenceAssemblies` task from `TunnelVisionLabs.ReferenceAssemblyAnnotator`, used by xunit — it gets the type name instead of the path and fails. Without `/mt`, the same tasks run in-process via `TaskExecutionHost` and receive native `ProjectItemInstance.TaskItem` objects (correct `ToString()`), so the build succeeds.

This is a long-standing latent bug; it only became visible now because `/mt` marshals task parameters broadly. Most tasks use `item.ItemSpec`, which is always correct, which is why only repos that use a task calling `item.ToString()` (like xunit) are affected.

### Changes Made

- Added a `ToString()` override to `TaskParameterTaskItem` in `src/Shared/TaskParameter.cs`, returning the escaped item-spec to match `ProjectItemInstance.TaskItem.ToString()`.

The reported `/mt` (sidecar TaskHost) scenario deserializes items on the engine side using the `src/Shared/TaskParameter.cs` copy, so the fix there fully resolves the issue. The separate `src/MSBuildTaskHost/BackEnd/TaskParameter.cs` copy (the legacy net35/net472 out-of-proc task host) is intentionally left unchanged to keep the scope minimal, per review.

### Testing


### Notes

