### PR TITLE
Add MSBuild.Coordinator.exe.config files to VS layout

### DIFF
--- a/src/Package/MSBuild.VSSetup.Arm64/files.arm64.swr
+++ b/src/Package/MSBuild.VSSetup.Arm64/files.arm64.swr
@@ -13,6 +13,7 @@ folder InstallDir:\MSBuild\Current\Bin\arm64
   file source=$(Arm64BinPath)MSBuild.exe vs.file.ngenArchitecture=arm64
   file source=$(Arm64BinPath)MSBuild.exe.config
   file source=$(CoordinatorArm64BinPath)MSBuild.Coordinator.exe vs.file.ngenArchitecture=arm64
+  file source=$(CoordinatorArm64BinPath)MSBuild.Coordinator.exe.config
 
   file source=$(FrameworkBinPath)x64\Microsoft.Build.Framework.tlb
   file source=$(Arm64BinPath)Microsoft.Build.dll vs.file.ngenArchitecture=arm64

--- a/src/Package/MSBuild.VSSetup/files.swr
+++ b/src/Package/MSBuild.VSSetup/files.swr
@@ -34,6 +34,7 @@ folder InstallDir:\MSBuild\Current\Bin
   file source=$(X86BinPath)MSBuild.exe vs.file.ngenArchitecture=x86 vs.file.ngenPriority=2
   file source=$(X86BinPath)MSBuild.exe.config
   file source=$(CoordinatorBinPath)MSBuild.Coordinator.exe vs.file.ngenArchitecture=x86 vs.file.ngenPriority=2
+  file source=$(CoordinatorBinPath)MSBuild.Coordinator.exe.config
   file source=$(TaskHostBinPath)MSBuildTaskHost.exe
   file source=$(TaskHostBinPath)MSBuildTaskHost.exe.config
   file source=$(X86BinPath)BuildXL.Native.dll
@@ -198,6 +199,7 @@ folder InstallDir:\MSBuild\Current\Bin\amd64
   file source=$(X64BinPath)MSBuild.exe vs.file.ngenArchitecture=x64
   file source=$(X64BinPath)MSBuild.exe.config
   file source=$(CoordinatorX64BinPath)MSBuild.Coordinator.exe vs.file.ngenArchitecture=x64
+  file source=$(CoordinatorX64BinPath)MSBuild.Coordinator.exe.config
   file source=$(TaskHostX64BinPath)MSBuildTaskHost.exe
   file source=$(TaskHostX64BinPath)MSBuildTaskHost.exe.config
 


### PR DESCRIPTION
These were missed in https://github.com/dotnet/msbuild/pull/13653 and may be the cause of an NGEN issue.

I pushed these changes to exp/dustinca/coordinator-config-files-take2 to trigger a VS test insertion as well.