### PR TITLE
Disable Bootstrapper for vs17.14

### DIFF
--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -15,8 +15,11 @@ parameters:
   default: 'default'
 - name: enableOptProf
   displayName: Enable OptProf data collection for this build
+  # vs17.14 is in servicing and no longer collects fresh OptProf data: the VS
+  # bootstrapper build (required only for OptProf collection) is disabled by default.
+  # We keep applying the last-collected optimization data (see SkipApplyOptimizationData below).
   type: boolean
-  default: true
+  default: false
 - name: enableSigningValidation
   displayName: Enable Signing Validation
   type: boolean
@@ -42,10 +45,11 @@ variables:
       value: ${{ parameters.OptProfDropName }}
     - name: SourceBranch
       value: ''
-  # Override SkipApplyOptimizationData to true when disabling OptProf data collection
-  - ${{ if eq(parameters.enableOptProf, false) }}:
-    - name: SkipApplyOptimizationData
-      value: true
+  # NOTE (vs17.14 servicing): historically, disabling OptProf collection also forced
+  # SkipApplyOptimizationData to true (stop applying data). On this branch we intentionally
+  # decouple the two: collection is disabled, but we keep applying the last-collected
+  # optimization data so shipped binaries stay optimized. SkipApplyOptimizationData is
+  # therefore governed solely by the pipeline variable (default 'false' = apply existing data).
   - name: EnableReleaseOneLocBuild
     value: false # Disable loc for vs17.14
   - name: Codeql.Enabled

--- a/azure-pipelines/.vsts-dotnet-build-jobs.yml
+++ b/azure-pipelines/.vsts-dotnet-build-jobs.yml
@@ -147,7 +147,8 @@ jobs:
       ArtifactName: MicroBuildOutputs
       ArtifactType: Container
     displayName: 'OptProf - Publish Artifact: MicroBuildOutputs'
-    condition: succeeded()
+    # Only produced when the OptProf bootstrapper runs; skip when OptProf collection is disabled.
+    condition: and(succeeded(), ${{ parameters.enableOptProf }})
 
   - task: 1ES.PublishBuildArtifacts@1
     displayName: 'Publish Artifact: logs'

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,7 +2,7 @@
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the MIT license. See License.txt in the project root for full license information. -->
 <Project>
   <PropertyGroup>
-    <VersionPrefix>17.14.49</VersionPrefix>
+    <VersionPrefix>17.14.50</VersionPrefix>
     <DotNetFinalVersionKind>release</DotNetFinalVersionKind>
     <PackageValidationBaselineVersion>17.13.9</PackageValidationBaselineVersion>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>


### PR DESCRIPTION
### Context

On the `vs17.14` servicing branch, the official build (pipeline `MSBuild` / definition `9434`) fails in the `OptProf - Build VS bootstrapper` step (`MicroBuildBuildVSBootstrapper@3`) with `Failed to obtain an access token from the VSDrop Managed Identity`. `vs17.14` is in servicing and no longer needs to collect fresh OptProf data, so this disables OptProf collection (including the failing bootstrapper build) while continuing to apply the last-collected optimization data so shipped binaries stay optimized.

### Changes Made

- Changed the `enableOptProf` parameter default from `true` to `false` in `.vsts-dotnet.yml`, which gates off all OptProf-collection steps (`MicroBuildOptProfPlugin@6`, `MicroBuildBuildVSBootstrapper@3`, `VisualStudio.BuildIbcTrainingSettings`, ProfilingInputs publish, `ready-for-training` tag).
- Removed the `${{ if eq(parameters.enableOptProf, false) }}` block in `.vsts-dotnet.yml` that forced `SkipApplyOptimizationData` to `true`, decoupling data *collection* from data *application*; `SkipApplyOptimizationData` is now governed solely by the pipeline variable (default `false` = keep applying existing data).
- Gated the `OptProf - Publish Artifact: MicroBuildOutputs` task in `azure-pipelines/.vsts-dotnet-build-jobs.yml` on `${{ parameters.enableOptProf }}`, since `BootstrapperInfo.json` is only produced when the bootstrapper runs.

### Testing

- Validated both YAML files parse successfully.
- Pending: queue official build `9434` on the merged `vs17.14` branch and confirm `OptProf - Build VS bootstrapper` is skipped, the build is green, and the `Build` step log shows optimization data is still applied (i.e., `EnableNgenOptimization` is not set to `false`).
- Result: <fill in build link / outcome after the official run>.

### Notes

- `enableOptProf` remains a queue-time parameter, so OptProf collection can be re-enabled per-run if the VSDrop managed-identity/channel issue is later resolved.
- No product code changes; VSSetup/packages are still produced, so downstream VS insertion is unaffected.