### PR TITLE
Fix ObjectDisposedException race in ProjectItemInstance.TaskItem.EnumerateMetadata

### DIFF
--- a/src/Build.UnitTests/Instance/TaskItem_Tests.cs
+++ b/src/Build.UnitTests/Instance/TaskItem_Tests.cs
@@ -373,5 +373,34 @@ namespace Microsoft.Build.UnitTests.OM.Instance
 
             logger.AssertLogContains("i1%2ai2");
         }
+
+        /// <summary>
+        /// Regression test for the ObjectDisposedException race rooted in returning a
+        /// `yield return` iterator from EnumerateMetadata over an ImmutableDictionary.
+        /// See dotnet/runtime#92290 and the EnumerateMetadataEager rationale comment.
+        ///
+        /// The intent of the fix is that callers always receive a materialized snapshot
+        /// (an array), never a compiler-generated state-machine iterator that parks a
+        /// copy of the ImmutableDictionary.Enumerator struct across yield boundaries.
+        /// Asserting on the runtime type makes a future revert of the fix observable.
+        /// </summary>
+        [Fact]
+        public void EnumerateMetadata_ReturnsMaterializedSnapshot_NotYieldIterator()
+        {
+            ProjectItemInstance.TaskItem item = new("foo", "test.proj");
+            item.SetMetadata("a", "1");
+            item.SetMetadata("b", "2");
+
+            IEnumerable<KeyValuePair<string, string>> result = ((IMetadataContainer)item).EnumerateMetadata();
+
+            // The result must NOT be a compiler-generated yield-return state machine. Those box
+            // a copy of the source ImmutableDictionary.Enumerator into a heap field, and that
+            // copy's pooled traversal stack outlives the call frame in ways that have been
+            // observed to interact with logger serialization and produce ObjectDisposedException.
+            result.GetType().FullName.ShouldNotContain("<EnumerateMetadata", Case.Sensitive);
+            // And the no-custom-metadata case must allocation-free (or near-so).
+            ProjectItemInstance.TaskItem empty = new("bar", "test.proj");
+            ((IMetadataContainer)empty).EnumerateMetadata().ShouldBeEmpty();
+        }
     }
 }

--- a/src/Build.UnitTests/Instance/TaskItem_Tests.cs
+++ b/src/Build.UnitTests/Instance/TaskItem_Tests.cs
@@ -393,12 +393,23 @@ namespace Microsoft.Build.UnitTests.OM.Instance
 
             IEnumerable<KeyValuePair<string, string>> result = ((IMetadataContainer)item).EnumerateMetadata();
 
-            // The result must NOT be a compiler-generated yield-return state machine. Those box
-            // a copy of the source ImmutableDictionary.Enumerator into a heap field, and that
-            // copy's pooled traversal stack outlives the call frame in ways that have been
-            // observed to interact with logger serialization and produce ObjectDisposedException.
-            result.GetType().FullName.ShouldNotContain("<EnumerateMetadata", Case.Sensitive);
-            // And the no-custom-metadata case must allocation-free (or near-so).
+            // Type-level invariant: result must be a materialized array, not a compiler-generated
+            // yield-return state machine that parks a copy of the ImmutableDictionary.Enumerator
+            // struct across yield boundaries.
+            result.ShouldBeOfType<KeyValuePair<string, string>[]>();
+
+            // Behavioural invariant: the snapshot must not observe later mutations of the item.
+            // A streaming iterator would re-enumerate _directMetadata on iteration, exposing
+            // mutations made after EnumerateMetadata returned.
+            item.SetMetadata("a", "changed-after-snapshot");
+            item.SetMetadata("c", "added-after-snapshot");
+            result.ShouldBe(new[]
+            {
+                new KeyValuePair<string, string>("a", "1"),
+                new KeyValuePair<string, string>("b", "2"),
+            }, ignoreOrder: true);
+
+            // No-custom-metadata case short-circuits to Array.Empty<>.
             ProjectItemInstance.TaskItem empty = new("bar", "test.proj");
             ((IMetadataContainer)empty).EnumerateMetadata().ShouldBeEmpty();
         }

--- a/src/Build/Instance/ProjectItemInstance.cs
+++ b/src/Build/Instance/ProjectItemInstance.cs
@@ -1117,27 +1117,7 @@ namespace Microsoft.Build.Execution
                 // If we have item definitions, call the expensive property that does the right thing.
                 // Otherwise use _directMetadata to avoid allocations caused by DeepClone().
                 var list = _itemDefinitions != null ? MetadataCollection : DirectMetadata;
-                if (list != null)
-                {
-#if FEATURE_APPDOMAIN
-                    // Can't send a yield-return iterator across AppDomain boundaries
-                    if (!AppDomain.CurrentDomain.IsDefaultAppDomain())
-                    {
-                        return EnumerateMetadataEager(list);
-                    }
-#endif
-                    // Mainline scenario: materialize a snapshot eagerly. A streaming iterator
-                    // would let pooled ImmutableDictionary.Enumerator state escape the call,
-                    // and consumers (e.g. BuildEventArgsWriter from the logger thread) can
-                    // race with the producing thread on the shared SecurePooledObject slot,
-                    // producing ObjectDisposedException mid-MoveNext. See the comment in
-                    // EnumerateMetadata(ImmutableDictionary) below for the full mechanism.
-                    return EnumerateMetadata(list);
-                }
-                else
-                {
-                    return [];
-                }
+                return list != null ? EnumerateMetadataEager(list) : [];
             }
 
             /// <summary>
@@ -1195,51 +1175,25 @@ namespace Microsoft.Build.Execution
                 }
             }
 
-#if FEATURE_APPDOMAIN
             /// <summary>
-            /// Used to return metadata from another AppDomain. Can't use yield return because the
-            /// generated state machine is not marked as [Serializable], so we need to allocate.
+            /// Materialize the metadata snapshot eagerly into a heap-allocated array.
             /// </summary>
+            /// <remarks>
+            /// Used historically only on the AppDomain-crossing path because a yield-iterator
+            /// state machine is not [Serializable]. Now used unconditionally to avoid letting
+            /// a copy of the pooled <see cref="ImmutableDictionary{TKey,TValue}.Enumerator"/>
+            /// struct escape the call frame inside a compiler-generated iterator. That state
+            /// machine has a complex lifetime that has been observed to interact with logger
+            /// serialization to produce ObjectDisposedException in
+            /// <see cref="Microsoft.Build.Logging.BuildEventArgsWriter"/>, surfacing as
+            /// MSB4166 "Child node exited prematurely" — see dotnet/runtime#92290. Eager
+            /// materialization removes the entire class of issues by returning a regular
+            /// array that has no relationship to the BCL enumerator pool.
+            /// </remarks>
             /// <param name="list">The source list to return metadata from.</param>
             /// <returns>An array of string key-value pairs representing metadata.</returns>
             private IEnumerable<KeyValuePair<string, string>> EnumerateMetadataEager(ImmutableDictionary<string, string> list)
             {
-                var result = new List<KeyValuePair<string, string>>(list.Count);
-
-                foreach (KeyValuePair<string, string> projectMetadataInstance in list)
-                {
-                    result.Add(new KeyValuePair<string, string>(projectMetadataInstance.Key, EscapingUtilities.UnescapeAll(projectMetadataInstance.Value)));
-                }
-
-                // Probably better to send the raw array across the wire even if it's another allocation.
-                return result.ToArray();
-            }
-#endif
-
-            private IEnumerable<KeyValuePair<string, string>> EnumerateMetadata(ImmutableDictionary<string, string> list)
-            {
-                // Materialize the metadata snapshot eagerly into a heap-allocated array rather
-                // than yielding from a state-machine iterator.
-                //
-                // Why: ImmutableDictionary<K,V>.Enumerator is a struct whose traversal stack is
-                // rented from a process-wide SecureObjectPool, and the pool uses struct-copy
-                // semantics — every copy of the Enumerator shares the same pooled Stack and the
-                // first copy to be Dispose()'d returns the slot to the pool. Any other live copy
-                // then throws ObjectDisposedException on its next MoveNext call (see
-                // SortedInt32KeyNode.Enumerator.ThrowIfDisposed in System.Collections.Immutable).
-                //
-                // The previous `foreach (...) { yield return ...; }` form parked an Enumerator
-                // copy inside the compiler-generated state machine across yield points. When
-                // the binary logger serialized the same item from a parallel logger sink (or
-                // when MSBuild's parallel build released the project state while the logger
-                // thread was still mid-iteration), the parked struct's pool slot was reclaimed
-                // and a subsequent MoveNext crashed in BuildEventArgsWriter.Write(ITaskItem),
-                // failing the whole build with MSB4166 / "Child node exited prematurely".
-                // See dotnet/runtime#92290 for the long-standing umbrella tracking this.
-                //
-                // Materializing here keeps the entire enumeration of `list` inside a single
-                // stack frame on the caller's thread; the returned array carries no reference
-                // to a pooled enumerator and is safe to walk on any thread.
                 int count = list.Count;
                 if (count == 0)
                 {

--- a/src/Build/Instance/ProjectItemInstance.cs
+++ b/src/Build/Instance/ProjectItemInstance.cs
@@ -1126,9 +1126,12 @@ namespace Microsoft.Build.Execution
                         return EnumerateMetadataEager(list);
                     }
 #endif
-                    // Mainline scenario, returns an iterator to avoid allocating an array
-                    // to store the results. With the iterator, results can stream to the
-                    // consumer (e.g. binlog writer) without allocations.
+                    // Mainline scenario: materialize a snapshot eagerly. A streaming iterator
+                    // would let pooled ImmutableDictionary.Enumerator state escape the call,
+                    // and consumers (e.g. BuildEventArgsWriter from the logger thread) can
+                    // race with the producing thread on the shared SecurePooledObject slot,
+                    // producing ObjectDisposedException mid-MoveNext. See the comment in
+                    // EnumerateMetadata(ImmutableDictionary) below for the full mechanism.
                     return EnumerateMetadata(list);
                 }
                 else
@@ -1237,7 +1240,12 @@ namespace Microsoft.Build.Execution
                 // Materializing here keeps the entire enumeration of `list` inside a single
                 // stack frame on the caller's thread; the returned array carries no reference
                 // to a pooled enumerator and is safe to walk on any thread.
-                var snapshot = new KeyValuePair<string, string>[list.Count];
+                int count = list.Count;
+                if (count == 0)
+                {
+                    return [];
+                }
+                var snapshot = new KeyValuePair<string, string>[count];
                 int i = 0;
                 foreach (KeyValuePair<string, string> projectMetadataInstance in list)
                 {

--- a/src/Build/Instance/ProjectItemInstance.cs
+++ b/src/Build/Instance/ProjectItemInstance.cs
@@ -1215,10 +1215,37 @@ namespace Microsoft.Build.Execution
 
             private IEnumerable<KeyValuePair<string, string>> EnumerateMetadata(ImmutableDictionary<string, string> list)
             {
+                // Materialize the metadata snapshot eagerly into a heap-allocated array rather
+                // than yielding from a state-machine iterator.
+                //
+                // Why: ImmutableDictionary<K,V>.Enumerator is a struct whose traversal stack is
+                // rented from a process-wide SecureObjectPool, and the pool uses struct-copy
+                // semantics — every copy of the Enumerator shares the same pooled Stack and the
+                // first copy to be Dispose()'d returns the slot to the pool. Any other live copy
+                // then throws ObjectDisposedException on its next MoveNext call (see
+                // SortedInt32KeyNode.Enumerator.ThrowIfDisposed in System.Collections.Immutable).
+                //
+                // The previous `foreach (...) { yield return ...; }` form parked an Enumerator
+                // copy inside the compiler-generated state machine across yield points. When
+                // the binary logger serialized the same item from a parallel logger sink (or
+                // when MSBuild's parallel build released the project state while the logger
+                // thread was still mid-iteration), the parked struct's pool slot was reclaimed
+                // and a subsequent MoveNext crashed in BuildEventArgsWriter.Write(ITaskItem),
+                // failing the whole build with MSB4166 / "Child node exited prematurely".
+                // See dotnet/runtime#92290 for the long-standing umbrella tracking this.
+                //
+                // Materializing here keeps the entire enumeration of `list` inside a single
+                // stack frame on the caller's thread; the returned array carries no reference
+                // to a pooled enumerator and is safe to walk on any thread.
+                var snapshot = new KeyValuePair<string, string>[list.Count];
+                int i = 0;
                 foreach (KeyValuePair<string, string> projectMetadataInstance in list)
                 {
-                    yield return new KeyValuePair<string, string>(projectMetadataInstance.Key, EscapingUtilities.UnescapeAll(projectMetadataInstance.Value));
+                    snapshot[i++] = new KeyValuePair<string, string>(
+                        projectMetadataInstance.Key,
+                        EscapingUtilities.UnescapeAll(projectMetadataInstance.Value));
                 }
+                return snapshot;
             }
 
             /// <summary>

--- a/src/Utilities.UnitTests/TaskItem_Tests.cs
+++ b/src/Utilities.UnitTests/TaskItem_Tests.cs
@@ -360,7 +360,19 @@ namespace Microsoft.Build.UnitTests
 
             IEnumerable<KeyValuePair<string, string>> result = ((IMetadataContainer)item).EnumerateMetadata();
 
-            result.GetType().FullName.ShouldNotContain("<EnumerateMetadata", Case.Sensitive);
+            // Type-level invariant: result must be a materialized array, not a compiler-generated
+            // yield-return state machine that parks a copy of the ImmutableDictionary.Enumerator
+            // struct across yield boundaries.
+            result.ShouldBeOfType<KeyValuePair<string, string>[]>();
+
+            // Behavioural invariant: the snapshot must not observe later mutations of the item.
+            item.SetMetadata("a", "changed-after-snapshot");
+            item.SetMetadata("c", "added-after-snapshot");
+            result.ShouldBe(new[]
+            {
+                new KeyValuePair<string, string>("a", "1"),
+                new KeyValuePair<string, string>("b", "2"),
+            }, ignoreOrder: true);
 
             TaskItem empty = new TaskItem("bar");
             ((IMetadataContainer)empty).EnumerateMetadata().ShouldBeEmpty();

--- a/src/Utilities.UnitTests/TaskItem_Tests.cs
+++ b/src/Utilities.UnitTests/TaskItem_Tests.cs
@@ -342,6 +342,30 @@ namespace Microsoft.Build.UnitTests
             Assert.True(actualMetadata.SequenceEqual(expectedMetadata));
         }
 
+        /// <summary>
+        /// Regression test for the ObjectDisposedException race rooted in returning a
+        /// `yield return` iterator from EnumerateMetadata over an ImmutableDictionary.
+        /// See dotnet/runtime#92290.
+        ///
+        /// EnumerateMetadata must return a materialized snapshot (an array), not a
+        /// compiler-generated state-machine iterator that parks a copy of the
+        /// ImmutableDictionary.Enumerator struct (and its pooled traversal stack)
+        /// across yield boundaries.
+        /// </summary>
+        [Fact]
+        public void EnumerateMetadata_ReturnsMaterializedSnapshot_NotYieldIterator()
+        {
+            TaskItem item = new TaskItem("foo");
+            ((IMetadataContainer)item).ImportMetadata(new Dictionary<string, string> { { "a", "1" }, { "b", "2" } });
+
+            IEnumerable<KeyValuePair<string, string>> result = ((IMetadataContainer)item).EnumerateMetadata();
+
+            result.GetType().FullName.ShouldNotContain("<EnumerateMetadata", Case.Sensitive);
+
+            TaskItem empty = new TaskItem("bar");
+            ((IMetadataContainer)empty).EnumerateMetadata().ShouldBeEmpty();
+        }
+
 #if FEATURE_APPDOMAIN
         /// <summary>
         /// Test that task items can be successfully constructed based on a task item from another appdomain.

--- a/src/Utilities/TaskItem.cs
+++ b/src/Utilities/TaskItem.cs
@@ -539,18 +539,15 @@ namespace Microsoft.Build.Utilities
 
         IEnumerable<KeyValuePair<string, string>> IMetadataContainer.EnumerateMetadata()
         {
-#if FEATURE_APPDOMAIN
-            // Can't send a yield-return iterator across AppDomain boundaries
-            // so have to allocate
-            if (!AppDomain.CurrentDomain.IsDefaultAppDomain())
-            {
-                return EnumerateMetadataEager();
-            }
-#endif
-
-            // In general case we want to return an iterator without allocating a collection
-            // to hold the result, so we can stream the items directly to the consumer.
-            return EnumerateMetadataLazy();
+            // Always materialize eagerly. A yield-return iterator over an ImmutableDictionary
+            // parks a copy of the dictionary's pooled enumerator struct inside a heap-allocated
+            // state machine whose lifetime is harder to reason about than a one-shot snapshot;
+            // it has been observed to interact with logger serialization to produce
+            // ObjectDisposedException, surfacing as MSB4166 "Child node exited prematurely"
+            // (dotnet/runtime#92290). Eager materialization removes the entire class of issues
+            // by returning a regular array. Same reasoning as the
+            // Microsoft.Build.Execution.ProjectItemInstance.TaskItem.EnumerateMetadata twin.
+            return EnumerateMetadataEager();
         }
 
         void IMetadataContainer.ImportMetadata(IEnumerable<KeyValuePair<string, string>> metadata)
@@ -565,7 +562,14 @@ namespace Microsoft.Build.Utilities
             _metadata = _metadata.SetItems(metadata.Select(kvp => new KeyValuePair<string, string>(kvp.Key, kvp.Value ?? string.Empty)));
         }
 
-#if FEATURE_APPDOMAIN
+        /// <summary>
+        /// Materialize the metadata snapshot eagerly into a heap-allocated array.
+        /// </summary>
+        /// <remarks>
+        /// Used historically only on the AppDomain-crossing path because a yield-iterator state
+        /// machine is not [Serializable]. Now used unconditionally — see the
+        /// IMetadataContainer.EnumerateMetadata implementation above for the rationale.
+        /// </remarks>
         private IEnumerable<KeyValuePair<string, string>> EnumerateMetadataEager()
         {
             if (_metadata == null)
@@ -583,21 +587,6 @@ namespace Microsoft.Build.Utilities
             }
 
             return result;
-        }
-#endif
-
-        private IEnumerable<KeyValuePair<string, string>> EnumerateMetadataLazy()
-        {
-            if (_metadata == null)
-            {
-                yield break;
-            }
-
-            foreach (var kvp in _metadata)
-            {
-                var unescaped = new KeyValuePair<string, string>(kvp.Key, EscapingUtilities.UnescapeAll(kvp.Value));
-                yield return unescaped;
-            }
         }
     }
 }


### PR DESCRIPTION
## Summary

Materialize `IMetadataContainer.EnumerateMetadata` eagerly in both `Microsoft.Build.Execution.ProjectItemInstance.TaskItem` and `Microsoft.Build.Utilities.TaskItem`, replacing the `yield return ...` over `ImmutableDictionary<string, string>` with a single pre-sized array.

## Evidence

A dump captured by [arcade#16715](https://github.com/dotnet/arcade/pull/16715)'s MSBuild-crash dump-on-fail logging from public CI build [`1472222`](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1472222) produced a stack trace of `ObjectDisposedException` thrown from `ProjectItemInstance.TaskItem.EnumerateMetadata`'s compiler-generated iterator while `Microsoft.Build.Logging.BuildEventArgsWriter.Write(ITaskItem)` was serializing a `TaskParameterEventArgs` on the binary-logger thread. The crash surfaces upstream as `MSB4166 "child node exited prematurely"`. This is the long-standing umbrella tracked as [dotnet/runtime#92290](https://github.com/dotnet/runtime/issues/92290).

## What the fix does

Both implementations of `IMetadataContainer.EnumerateMetadata()` previously had two code paths:

- An **eager** path (returned a `KeyValuePair<string, string>[]`) used only inside `#if FEATURE_APPDOMAIN` when crossing an AppDomain boundary.
- A **lazy** path (`foreach (...) { yield return ...; }`) used in the mainline case.

This PR removes the lazy path on both types and makes the eager path unconditional. The existing `EnumerateMetadataEager` is lifted out of `#if FEATURE_APPDOMAIN` and tightened from `new List<>(count)` + `.ToArray()` (two collections) to a single pre-sized `KeyValuePair<string, string>[]` with an empty-case short-circuit returning `[]` (no allocation).

Net per call:

| | Before (lazy mainline) | After (eager) |
|---|---|---|
| Heap allocations | 1 state-machine box | 1 array (or `Array.Empty<>`) |
| Captures pooled `ImmutableDictionary.Enumerator` across yield boundaries | yes | no |
| Cross-AppDomain serializable | no | yes |

## Why eager removes the hazard (and what we are not claiming)

`ImmutableDictionary<K, V>.Enumerator` is a struct whose traversal stack is rented from a BCL-internal `SecureObjectPool` (`SortedInt32KeyNode.Enumerator.ThrowIfDisposed` is the throw site in the dump). The previous `yield return` form parked a copy of that struct in the compiler-generated state machine's heap fields, so the pooled stack's lifetime was effectively tied to the iterator's, not to a single stack frame. The exact interleaving under which the pool slot gets reclaimed while the binary-logger thread is mid-`MoveNext` is **not** fully proven — and per @rainersigwald's review the pool's `[ThreadStatic]` design rules out the original "two threads share a slot" framing. What this fix demonstrates is that eager materialization confines the `ImmutableDictionary` enumeration to a single stack frame on the caller's thread and hands the consumer back an ordinary `KeyValuePair<string, string>[]` whose lifetime has no relationship to the BCL enumerator pool. That removes the entire class of issues without depending on the exact trigger.

## Historical context

This is a generalisation of [#6382 / `ac7dd0f3`](https://github.com/dotnet/msbuild/pull/6382) (Kirill Osenkov, Apr 2021), which introduced the eager-when-crossing-AppDomain path to fix [#6379](https://github.com/dotnet/msbuild/issues/6379) — a customer crash where the same `yield return ...` iterator captured a cross-AppDomain proxy that outlived the AppDomain it pointed into, producing `AppDomainUnloadedException` mid-`MoveNext` on the same `TaskParameterEventArgs.WriteMetadata` path. The hazard pattern is structurally the same; only the captured state and its lifetime owner differ. The 2021 PR explicitly preserved the lazy path because *"in the general case we want to stream metadata directly to consumers without allocating a collection."* Five years later, the BCL-pool variant of the same hazard has surfaced via #92290, and the consumers of `EnumerateMetadata` (`BuildEventArgsWriter.Write`, `LogMessagePacket.WriteMetadata`, console-logger walks, RAR test scaffolds) all fully enumerate to the end before doing anything else — no caller realises a streaming benefit. Removing the lazy path is therefore not paying for safety.

## Pattern audit (re-done)

After the github-actions automated review correctly flagged that I had missed `src/Utilities/TaskItem.cs`, I re-audited `src/Build`, `src/Framework`, `src/Tasks`, **and `src/Utilities`** for the same `yield return ... ImmutableDictionary` shape. Findings:

- `src/Build/Instance/ProjectItemInstance.cs` — fixed here.
- `src/Utilities/TaskItem.cs` — fixed here.
- `src/Shared/TaskParameter.cs` has an `EnumerateMetadataLazy` but it iterates a plain `Dictionary<string, string>` (not `ImmutableDictionary`) and is intentionally out of scope.

No other matches.

## Tests

Added structural regression tests on both `TaskItem` types (`EnumerateMetadata_ReturnsMaterializedSnapshot_NotYieldIterator`) asserting two invariants:

1. `result.ShouldBeOfType<KeyValuePair<string, string>[]>()` — the caller gets a materialized array, not a generated iterator state machine.
2. **Snapshot semantics**: mutate the item after `EnumerateMetadata()` returns, then assert the returned sequence still reflects the pre-mutation state. A streaming iterator over the underlying dictionary would have observed the mutation.

Both tests fail against the pre-fix source on both `TaskItem` types (verified by reverting the two source files to the parent commit while keeping the new tests in place). I deliberately did **not** add a behavioural test attempting to provoke the `ObjectDisposedException` itself — given the mechanism uncertainty above, any timing-based repro would be flaky on CI, which is strictly worse than no test.

Local test runs after the revision:

| Test class | Passed | Skipped |
|---|---|---|
| `Microsoft.Build.UnitTests.OM.Instance.TaskItem_Tests` | 14/14 | 0 |
| `Microsoft.Build.UnitTests.TaskItemTests` (Utilities) | 24/24 | 1 (Windows-only) |
| `Microsoft.Build.UnitTests.BinaryLoggerTests` | 80/80 | 1 |
| `Microsoft.Build.UnitTests.TaskParameter_Tests` | 45/45 | 0 |

## Notes

- The mechanism-explanation comment in `ProjectItemInstance.cs` is intentionally hedged after @rainersigwald's review pointed out that pool slots are `[ThreadStatic]`. The XML doc on `EnumerateMetadataEager` describes what the fix achieves (lifetime confinement) rather than overclaiming the exact disposing interleaving.
- Tightened eager path allocates fewer collections than the historical AppDomain-crossing eager path it replaces.

> [!NOTE]
> AI-assisted PR draft (Copilot CLI). Triple-check before relying on it.
