### PR TITLE
Set vs.file.ngenPriority for MSBuild.Coordinator.exe on x64

### DIFF
--- a/src/Package/MSBuild.VSSetup/files.swr
+++ b/src/Package/MSBuild.VSSetup/files.swr
@@ -33,7 +33,7 @@ folder InstallDir:\MSBuild\Current\Bin
   file source=$(X86BinPath)Microsoft.IO.Redist.dll vs.file.ngenApplications="[installDir]\Common7\IDE\vsn.exe" vs.file.ngenApplications="[installDir]\MSBuild\Current\Bin\MSBuild.exe" vs.file.ngenArchitecture=all vs.file.ngenPriority=2
   file source=$(X86BinPath)MSBuild.exe vs.file.ngenArchitecture=x86 vs.file.ngenPriority=2
   file source=$(X86BinPath)MSBuild.exe.config
-  file source=$(CoordinatorBinPath)MSBuild.Coordinator.exe vs.file.ngenArchitecture=x86 vs.file.ngenPriority=2
+  file source=$(CoordinatorBinPath)MSBuild.Coordinator.exe vs.file.ngenArchitecture=x86 vs.file.ngenPriority=3
   file source=$(CoordinatorBinPath)MSBuild.Coordinator.exe.config
   file source=$(TaskHostBinPath)MSBuildTaskHost.exe
   file source=$(TaskHostBinPath)MSBuildTaskHost.exe.config
@@ -198,7 +198,7 @@ folder InstallDir:\MSBuild\Current\Bin\zh-Hant
 folder InstallDir:\MSBuild\Current\Bin\amd64
   file source=$(X64BinPath)MSBuild.exe vs.file.ngenArchitecture=x64
   file source=$(X64BinPath)MSBuild.exe.config
-  file source=$(CoordinatorX64BinPath)MSBuild.Coordinator.exe vs.file.ngenArchitecture=x64
+  file source=$(CoordinatorX64BinPath)MSBuild.Coordinator.exe vs.file.ngenArchitecture=x64 vs.file.ngenPriority=3
   file source=$(CoordinatorX64BinPath)MSBuild.Coordinator.exe.config
   file source=$(TaskHostX64BinPath)MSBuildTaskHost.exe
   file source=$(TaskHostX64BinPath)MSBuildTaskHost.exe.config


### PR DESCRIPTION
Set to ngenPriority=3. I hope this addresses the issue with NGEN blocking VS RPS tests. I've push exp/dustinca/set-ngenPriority-3 to queue a test insertion.