### PR TITLE
Log Copy task destination delete (diagnostic for MSB3030 race)

### DIFF
--- a/src/Tasks/Copy.cs
+++ b/src/Tasks/Copy.cs
@@ -325,6 +325,14 @@ namespace Microsoft.Build.Tasks
                 destinationFileState.FileExists &&
                 !destinationFileState.IsReadOnly)
             {
+                // DIAGNOSTIC (dotnet/aspnetcore#62807 / dotnet/msbuild#12927): the Copy task
+                // unlinks an existing destination before overwriting it. When two parallel
+                // builds copy to/from the same shared output, this delete can briefly remove a
+                // file another project is reading as a Copy SOURCE, surfacing as MSB3030
+                // ("Could not copy ... because it was not found"). This delete is otherwise
+                // invisible in the binlog, so log it (Low importance => binlog only) to confirm
+                // the culprit and correlate the deleted path with any MSB3030 source path.
+                Log.LogMessage(MessageImportance.Low, "MSB-COPY-DELETE: deleting existing destination before overwrite: {0}", destinationFileState.Path.OriginalValue);
                 FileUtilities.DeleteNoThrow(destinationFileState.Path);
             }
 


### PR DESCRIPTION
## Summary

Adds a single **Low-importance (binlog-only)** diagnostic log message in the `Copy` task, emitted right before it deletes an existing destination file prior to overwriting it.

## Why

The `Copy` task unlinks an existing destination before re-creating it (`FileUtilities.DeleteNoThrow(destinationFileState.Path)`). When parallel project builds copy **to/from a shared output file**, this delete can briefly remove a file that another project is simultaneously reading as a Copy **source**, which surfaces intermittently as:

> **MSB3030**: Could not copy the file `...` because it was not found.

This delete is **not logged anywhere today** — the binary log only records `Copying file from X to Y` *after* the delete — which has made the intermittent failures in **dotnet/aspnetcore#62807** very hard to attribute. Filesystem auditing (auditd) confirmed the deleter is MSBuild's own Copy task, but the binlog had no corresponding event to correlate against.

## Change

``csharp
Log.LogMessage(MessageImportance.Low,
    "MSB-COPY-DELETE: deleting existing destination before overwrite: {0}",
    destinationFileState.Path.OriginalValue);
``

- `MessageImportance.Low` => captured by the `BinaryLogger` but kept out of normal console output (no perf / log-spam impact at default verbosity).
- Unique `MSB-COPY-DELETE:` prefix so the deleted path is trivially greppable and can be correlated with the source path in any `MSB3030`.

## Notes

- Diagnostic in nature (investigation aid for the parallel-copy race). Opening as **draft**.
- Related: dotnet/msbuild#12927, dotnet/aspnetcore#62807