### PR TITLE
(nit) Update README 2026

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,21 +11,21 @@ The [changelog](documentation/Changelog.md) has detailed information about chang
 
 ## Building
 
-### Building MSBuild with Visual Studio 2022 on Windows
+### Building MSBuild with Visual Studio 2026 on Windows
 
-For the full supported experience, you will need to have Visual Studio 2022 or higher.
+For the full supported experience, you will need to have Visual Studio 2026 or higher.
 
-To get started on **Visual Studio 2022**:
+To get started on **Visual Studio 2026**:
 
-1. [Install Visual Studio 2022](https://www.visualstudio.com/vs/).  Select the following Workloads:
+1. [Install Visual Studio 2026](https://www.visualstudio.com/vs/).  Select the following Workloads:
    - .NET desktop development
    - .NET Core cross-platform development
 2. Ensure [long path support](https://learn.microsoft.com/windows/win32/fileio/maximum-file-path-limitation?tabs=registry#enable-long-paths-in-windows-10-version-1607-and-later) is enabled at the Windows level.
-3. Open a `Developer Command Prompt for VS 2022` prompt.
+3. Open a `Developer Command Prompt for VS 2026` prompt.
 4. Clone the source code: `git clone https://github.com/dotnet/msbuild`
    - You may have to [download Git](https://git-scm.com/downloads) first.
 5. Run `.\build.cmd` from the root of the repo to build the code. This also restores packages needed to open the projects in Visual Studio.
-6. Open `MSBuild.slnx` or `MSBuild.Dev.slnf` in Visual Studio 2022.
+6. Open `MSBuild.slnx` or `MSBuild.Dev.slnf` in Visual Studio 2026.
 
 This newly-built MSBuild will be located at `artifacts\bin\bootstrap\net472\MSBuild\Current\Bin\MSBuild.exe`. It may not work for all scenarios, including C++ builds.
 


### PR DESCRIPTION
this just annoyed me 😄 
### Context

The README and other docs referenced Visual Studio 2022. These references were updated to Visual Studio 2026.

### Changes Made

- Updated `README.md` Windows build instructions to reference Visual Studio 2026.
- Updated the "Latest Microsoft Visual Studio 2022" requirement to 2026 in `documentation/wiki/Building-Testing-and-Debugging-on-Full-Framework-MSBuild.md`.
- Updated Visual Studio install-path examples (`\2022\Enterprise\`) to `\2026\` in the Full-Framework build doc and `documentation/wiki/MSBuild-Tips-&-Tricks.md`.
- Left `Changelog.md` historical entries and `?view=vs-2022` external documentation links unchanged to preserve historical accuracy and avoid broken links.

### Testing


### Notes