### PR TITLE
Don't NGEN MSBuild.Coordinator.exe on x86

### DIFF
--- a/src/Package/MSBuild.VSSetup/files.swr
+++ b/src/Package/MSBuild.VSSetup/files.swr
@@ -33,7 +33,7 @@ folder InstallDir:\MSBuild\Current\Bin
   file source=$(X86BinPath)Microsoft.IO.Redist.dll vs.file.ngenApplications="[installDir]\Common7\IDE\vsn.exe" vs.file.ngenApplications="[installDir]\MSBuild\Current\Bin\MSBuild.exe" vs.file.ngenArchitecture=all vs.file.ngenPriority=2
   file source=$(X86BinPath)MSBuild.exe vs.file.ngenArchitecture=x86 vs.file.ngenPriority=2
   file source=$(X86BinPath)MSBuild.exe.config
-  file source=$(CoordinatorBinPath)MSBuild.Coordinator.exe vs.file.ngenArchitecture=x86 vs.file.ngenPriority=3
+  file source=$(CoordinatorBinPath)MSBuild.Coordinator.exe
   file source=$(CoordinatorBinPath)MSBuild.Coordinator.exe.config
   file source=$(TaskHostBinPath)MSBuildTaskHost.exe
   file source=$(TaskHostBinPath)MSBuildTaskHost.exe.config


### PR DESCRIPTION
This should unblock VS insertions. For now, it's OK if the MSBuild.Coordinator.exe needs to JIT for 32-bit. In reality, users shouldn't be launching the coordinator on x86.

I pushed `exp/dustinca/dont-ngen-x86-coordinator` for a test VS insertion.