### PR TITLE
 Don't disable the MSBuild server for /mt builds when node reuse is off

### DIFF
--- a/src/MSBuild.UnitTests/MSBuildServer_Tests.cs
+++ b/src/MSBuild.UnitTests/MSBuildServer_Tests.cs
@@ -597,6 +597,66 @@ namespace Microsoft.Build.Engine.UnitTests
             workerPid.ShouldNotBe(clientPid, "The build should run in an out-of-proc worker node, not the entry process.");
             output.ShouldContain("TaskNodeServerGC=False", customMessage: "A worker node must use the default Workstation GC.");
         }
+
+        /// <summary>
+        /// Disabling node reuse (e.g. <c>-nr:false</c>, as <c>dotnet restore</c> does) must NOT prevent a
+        /// multithreaded (/mt) build from using the server. Instead of skipping the server, the no-reuse intent is
+        /// honored by shutting the server down after the build. This test verifies both halves: the build runs in a
+        /// separate server process, and that process does not survive the build (so a subsequent build gets a fresh server).
+        /// </summary>
+        [Fact]
+        public void MultiThreadedServerIsUsedButShutDownWhenNodeReuseDisabled()
+        {
+            // Clear MSBUILDUSESERVER so we exercise the -mt-implies-server path, and isolate this test's server
+            // with a unique handshake salt and a clean environment.
+            PrepareIsolatedServerEnv(useServer: false);
+            TransientTestFile project = _env.CreateFile("mtNoReuseProbe.proj", GetServerGCProbeProjectContents(useTaskHostFactory: false));
+
+            // Make sure we start with no server running.
+            MSBuildClient.ShutdownServer(CancellationToken.None);
+
+            // -mt forces the server on even though node reuse is disabled.
+            string output1 = RunnerUtilities.ExecMSBuild(BuildEnvironmentHelper.Instance.CurrentMSBuildExePath, $"{project.Path} -mt -nr:false", out bool success1, false, _output);
+            success1.ShouldBeTrue();
+            int clientPid1 = ParseNumber(output1, "Process ID is ");
+            int serverPid1 = ParseNumber(output1, "TaskRanInPID=");
+            // Register cleanup before any assertion so the server does not leak if an assertion throws.
+            _env.WithTransientProcess(serverPid1);
+
+            // The build ran in a separate server process: proof the server was engaged despite -nr:false.
+            serverPid1.ShouldNotBe(clientPid1, "Even with node reuse disabled, -mt must run the build in the server node, not the entry process.");
+
+            // Because node reuse is disabled, the server must not persist past the build: its process should exit.
+            WaitForProcessExit(serverPid1).ShouldBeTrue($"Server process {serverPid1} should have been shut down after the build when node reuse is disabled.");
+
+            // A second build cannot reuse the (now gone) server, so it must launch a fresh server process.
+            string output2 = RunnerUtilities.ExecMSBuild(BuildEnvironmentHelper.Instance.CurrentMSBuildExePath, $"{project.Path} -mt -nr:false", out bool success2, false, _output);
+            success2.ShouldBeTrue();
+            int serverPid2 = ParseNumber(output2, "TaskRanInPID=");
+            _env.WithTransientProcess(serverPid2);
+            serverPid2.ShouldNotBe(serverPid1, "With node reuse disabled, each -mt build should get a fresh, non-persistent server process.");
+
+            // Clean up the second server.
+            MSBuildClient.ShutdownServer(CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Waits up to <paramref name="timeoutMs"/> for the process with the given PID to exit. Returns true if
+        /// the process exited (or was already gone), false if it was still running when the timeout elapsed.
+        /// </summary>
+        private static bool WaitForProcessExit(int pid, int timeoutMs = 10000)
+        {
+            try
+            {
+                using Process process = Process.GetProcessById(pid);
+                return process.WaitForExit(timeoutMs);
+            }
+            catch (ArgumentException)
+            {
+                // No process with that PID is running - it has already exited.
+                return true;
+            }
+        }
 #endif
 
         private int ParseNumber(string searchString, string toFind)

--- a/src/MSBuild/MSBuildClientApp.cs
+++ b/src/MSBuild/MSBuildClientApp.cs
@@ -30,13 +30,15 @@ namespace Microsoft.Build.CommandLine
         /// on the command line is assumed to be the name/path of the executable, and
         /// is ignored.</param>
         /// <param name="multiThreaded">Whether this build is multithreaded (/mt).</param>
+        /// <param name="shutdownServerAfterBuild">Whether to shut the server down once the build completes
+        /// instead of leaving it resident for reuse.
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>A value of type <see cref="MSBuildApp.ExitType"/> that indicates whether the build succeeded,
         /// or the manner in which it failed.</returns>
         /// <remarks>
         /// The locations of msbuild exe/dll and dotnet.exe would be automatically detected if called from dotnet or msbuild cli. Calling this function from other executables might not work.
         /// </remarks>
-        public static MSBuildApp.ExitType Execute(string[] commandLineArgs, bool multiThreaded, CancellationToken cancellationToken)
+        public static MSBuildApp.ExitType Execute(string[] commandLineArgs, bool multiThreaded, bool shutdownServerAfterBuild, CancellationToken cancellationToken)
         {
             string msbuildLocation = BuildEnvironmentHelper.Instance.CurrentMSBuildExePath;
 
@@ -44,6 +46,7 @@ namespace Microsoft.Build.CommandLine
                 commandLineArgs,
                 msbuildLocation,
                 multiThreaded,
+                shutdownServerAfterBuild,
                 cancellationToken);
         }
 
@@ -56,10 +59,12 @@ namespace Microsoft.Build.CommandLine
         /// <param name="msbuildLocation"> Full path to current MSBuild.exe if executable is MSBuild.exe,
         /// or to version of MSBuild.dll found to be associated with the current process.</param>
         /// <param name="multiThreaded">Whether this build is multithreaded (/mt).</param>
+        /// <param name="shutdownServerAfterBuild">Whether to shut the server down once the build completes
+        /// instead of leaving it resident for reuse.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>A value of type <see cref="MSBuildApp.ExitType"/> that indicates whether the build succeeded,
         /// or the manner in which it failed.</returns>
-        public static MSBuildApp.ExitType Execute(string[] commandLineArgs, string msbuildLocation, bool multiThreaded, CancellationToken cancellationToken)
+        public static MSBuildApp.ExitType Execute(string[] commandLineArgs, string msbuildLocation, bool multiThreaded, bool shutdownServerAfterBuild, CancellationToken cancellationToken)
         {
             MSBuildClient msbuildClient = new MSBuildClient(commandLineArgs, msbuildLocation, multiThreaded);
             MSBuildClientExitResult exitResult = msbuildClient.Execute(cancellationToken);
@@ -93,7 +98,13 @@ namespace Microsoft.Build.CommandLine
                 Enum.TryParse(exitResult.MSBuildAppExitTypeString, out MSBuildApp.ExitType MSBuildAppExitType))
             {
                 // The client successfully set up a build task for MSBuild server and received the result.
-                // (Which could be a failure as well). Return the received exit type.
+                // (Which could be a failure as well). Return the received exit type and shut the server down now if requested.
+                
+                if (shutdownServerAfterBuild)
+                {
+                    MSBuildClient.ShutdownServer(CancellationToken.None);
+                }
+
                 return MSBuildAppExitType;
             }
 

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -310,13 +310,15 @@ namespace Microsoft.Build.CommandLine
             }
 
             // Perform the single authoritative command-line parse for this process. It yields:
-            //   - canRunServer: whether switches (help/version/binlog/nodereuse/...) permit the server;
+            //   - canRunServer: whether switches (help/version/binlog/nodemode/...) permit the server;
             //   - multiThreaded: the response-file-aware /mt determination (includes the auto-response file,
             //     any project Directory.Build.rsp, @response files, and MSBUILDFORCEMULTITHREADED);
+            //   - shutdownServerAfterBuild: whether the server must be torn down once the build finishes
             //   - the gathered switches, which the in-proc build path below reuses so it does not re-parse.
             bool canRunServer = CanRunServerBasedOnCommandLineSwitches(
                 args,
                 out bool multiThreaded,
+                out bool shutdownServerAfterBuild,
                 out CommandLineSwitches switchesFromAutoResponseFile,
                 out CommandLineSwitches switchesNotFromAutoResponseFile);
 
@@ -334,8 +336,10 @@ namespace Microsoft.Build.CommandLine
                 }
 
                 // Hand the build off to the MSBuild Server client. The server (not this process) decides
-                // Server GC for itself from the multiThreaded value we pass through.
-                exitCode = ((s_initialized && MSBuildClientApp.Execute(args, multiThreaded, s_buildCancellationSource.Token) == ExitType.Success) ? 0 : 1);
+                // Server GC for itself from the multiThreaded value we pass through. When -mt forced the
+                // server on despite node reuse being disabled, shutdownServerAfterBuild ensures the server
+                // process does not persist past this build.
+                exitCode = ((s_initialized && MSBuildClientApp.Execute(args, multiThreaded, shutdownServerAfterBuild, s_buildCancellationSource.Token) == ExitType.Success) ? 0 : 1);
             }
             else
             {
@@ -368,6 +372,8 @@ namespace Microsoft.Build.CommandLine
         /// <param name="multiThreaded">Set to whether this is a multithreaded (/mt) build, determined from
         /// the fully-parsed switches (which expand response files - including any project <c>Directory.Build.rsp</c> -
         /// and honor MSBUILDFORCEMULTITHREADED) using the same logic as the in-proc build path.</param>
+        /// <param name="shutdownServerAfterBuild">Set to <see langword="true"/> when the server should be shut
+        /// down immediately after the build instead of being left resident for reuse.</param>
         /// <param name="switchesFromAutoResponseFile">The gathered response-file switches (auto-response file plus any
         /// project <c>Directory.Build.rsp</c>), or <see langword="null"/> if parsing failed.</param>
         /// <param name="switchesNotFromAutoResponseFile">The gathered command-line/environment switches, or
@@ -375,11 +381,13 @@ namespace Microsoft.Build.CommandLine
         private static bool CanRunServerBasedOnCommandLineSwitches(
             string[] commandLine,
             out bool multiThreaded,
+            out bool shutdownServerAfterBuild,
             out CommandLineSwitches switchesFromAutoResponseFile,
             out CommandLineSwitches switchesNotFromAutoResponseFile)
         {
             bool canRunServer = true;
             multiThreaded = false;
+            shutdownServerAfterBuild = false;
             switchesFromAutoResponseFile = null;
             switchesNotFromAutoResponseFile = null;
             bool switchesFullyGathered = false;
@@ -406,12 +414,26 @@ namespace Microsoft.Build.CommandLine
 
                 multiThreaded = IsMultiThreadedEnabled(commandLineSwitches);
 
+                bool nodeReuse = ProcessNodeReuseSwitch(commandLineSwitches[CommandLineSwitches.ParameterizedSwitch.NodeReuse]);
+
                 string projectFile = ProcessProjectSwitch(commandLineSwitches[CommandLineSwitches.ParameterizedSwitch.Project], commandLineSwitches[CommandLineSwitches.ParameterizedSwitch.IgnoreProjectExtensions], Directory.GetFiles);
-                if (commandLineSwitches[CommandLineSwitches.ParameterlessSwitch.Help] ||
+
+                // These switches are fundamentally incompatible with hosting the build in a separate server
+                // process (help/version produce immediate output, -nodeMode is itself a node, and a binary-log
+                // "project" is replayed, not built), so they always disqualify the server.
+                bool serverIncompatibleSwitch =
+                    commandLineSwitches[CommandLineSwitches.ParameterlessSwitch.Help] ||
                     commandLineSwitches.IsParameterizedSwitchSet(CommandLineSwitches.ParameterizedSwitch.NodeMode) ||
                     commandLineSwitches[CommandLineSwitches.ParameterlessSwitch.Version] ||
-                    FileUtilities.IsBinaryLogFilename(projectFile) ||
-                    !ProcessNodeReuseSwitch(commandLineSwitches[CommandLineSwitches.ParameterizedSwitch.NodeReuse]))
+                    FileUtilities.IsBinaryLogFilename(projectFile);
+
+                // Node reuse being disabled normally disqualifies the server because the server is a persistent
+                // process. The exception is a multithreaded (/mt) build: it requires the server purely to enable
+                // Server GC. So for /mt we still use the server even when node reuse is off, and instead shut the server down after
+                // the build (see shutdownServerAfterBuild) to honor the no-reuse intent.
+                bool nodeReuseDisqualifies = !nodeReuse && !multiThreaded;
+
+                if (serverIncompatibleSwitch || nodeReuseDisqualifies)
                 {
                     canRunServer = false;
                     if (KnownTelemetry.PartialBuildTelemetry is not null)
@@ -419,6 +441,10 @@ namespace Microsoft.Build.CommandLine
                         KnownTelemetry.PartialBuildTelemetry.ServerFallbackReason = "Arguments";
                     }
                 }
+
+                // When /mt forced the server on despite node reuse being disabled, the server must not persist
+                // past this build. (When node reuse is on, the server is reused as usual.)
+                shutdownServerAfterBuild = canRunServer && multiThreaded && !nodeReuse;
             }
             catch (Exception ex)
             {
@@ -428,6 +454,7 @@ namespace Microsoft.Build.CommandLine
                     KnownTelemetry.PartialBuildTelemetry.ServerFallbackReason = "ErrorParsingCommandLine";
                 }
                 canRunServer = false;
+                shutdownServerAfterBuild = false;
 
                 if (!switchesFullyGathered)
                 {


### PR DESCRIPTION
Fixes #14157

### Context
 When node reuse is disabled (`-nr:false`), MSBuild refused to use the server node. For a multithreaded ( /mt ) build that's a problem: the server is the only way to get Server  GC, which  /mt  builds depend on for performance reasons.

### Changes Made
 Decouple "may we use the server for this build?" from "may the server stay resident afterward?":

-  /mt  now uses the server even when node reuse is disabled, purely to obtain Server GC.
-  To honor the no-reuse intent, a new  `shutdownServerAfterBuild` flag tears the server down immediately after the build    completes, so it doesn't persist and each build gets a fresh process.
-  Node reuse being off still disqualifies the server for non- /mt  builds (unchanged behavior).

### Testing
Added a unit test.
