### PR TITLE
Embed the solution file in binlog for graph build of a solution

### DIFF
--- a/src/Build.UnitTests/BinaryLogger_Tests.cs
+++ b/src/Build.UnitTests/BinaryLogger_Tests.cs
@@ -11,9 +11,11 @@ using System.Threading;
 using FakeItEasy;
 using FluentAssertions;
 using Microsoft.Build.BackEnd.Logging;
+using Microsoft.Build.Engine.UnitTests;
 using Microsoft.Build.Evaluation;
 using Microsoft.Build.Execution;
 using Microsoft.Build.Framework;
+using Microsoft.Build.Graph;
 using Microsoft.Build.Logging;
 using Microsoft.Build.Shared;
 using Microsoft.Build.UnitTests.Shared;
@@ -551,6 +553,42 @@ namespace Microsoft.Build.UnitTests
 </Project>";
 
             ObjectModelHelpers.BuildProjectExpectSuccess(project, binaryLogger);
+        }
+
+        [Fact]
+        public void GraphBuildFromSolutionShouldEmbedSolutionFile()
+        {
+            var graph = Helpers.CreateProjectGraph(_env, new Dictionary<int, int[]> { { 1, new[] { 2 } } });
+            string solutionContents = SolutionFileBuilder.FromGraph(graph).BuildSolution();
+            string solutionFile = _env.CreateFile("graph.sln", solutionContents).Path;
+
+            using var buildManager = new BuildManager();
+            var binaryLogger = new BinaryLogger
+            {
+                Parameters = $"LogFile={_logFile}",
+                CollectProjectImports = BinaryLogger.ProjectImportsCollectionMode.ZipFile,
+            };
+
+            GraphBuildResult graphBuildResult = buildManager.Build(
+                new BuildParameters
+                {
+                    EnableNodeReuse = false,
+                    Loggers = [binaryLogger],
+                },
+                new GraphBuildRequestData(new ProjectGraph(solutionFile), Array.Empty<string>()));
+
+            graphBuildResult.OverallResult.ShouldBe(BuildResultCode.Success);
+
+            string projectImportsZipPath = Path.ChangeExtension(_logFile, ".ProjectImports.zip");
+            using var fileStream = new FileStream(projectImportsZipPath, FileMode.Open);
+            using var zipArchive = new ZipArchive(fileStream, ZipArchiveMode.Read);
+
+            string solutionFileName = Path.GetFileName(solutionFile);
+
+            // Compare by entry name only because ZipArchive entry full names can vary by platform separators.
+            zipArchive.Entries.ShouldContain(
+                entry => entry.Name.EndsWith(solutionFileName, StringComparison.OrdinalIgnoreCase),
+                customMessage: $"Embedded files: {string.Join(",", zipArchive.Entries)}");
         }
 
         /// <summary>

--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -2237,17 +2237,14 @@ namespace Microsoft.Build.Execution
                     globalProperties: null,
                     toolsVersion: null);
 
-                solutionBuildEventContext = new BuildEventContext(
+                solutionBuildEventContext = loggingService.CreateProjectCacheBuildEventContext(
                     submission.SubmissionId,
-                    _buildParameters!.NodeId,
                     BuildEventContext.InvalidEvaluationId,
                     BuildEventContext.InvalidProjectInstanceId,
-                    BuildEventContext.InvalidProjectContextId,
-                    BuildEventContext.InvalidTargetId,
-                    BuildEventContext.InvalidTaskId);
+                    projectGraph.Solution.FullPath);
 
                 solutionProjectStartedEvent.BuildEventContext = solutionBuildEventContext;
-                loggingService.LogBuildEvent(solutionProjectStartedEvent);
+                loggingService.LogProjectStarted(solutionProjectStartedEvent);
             }
 
             LogMessage(
@@ -2302,16 +2299,7 @@ namespace Microsoft.Build.Execution
             {
                 if (solutionBuildEventContext is not null)
                 {
-                    var solutionProjectFinishedEvent = new ProjectFinishedEventArgs(
-                        message: null,
-                        helpKeyword: null,
-                        projectFile: projectGraph.Solution!.FullPath,
-                        succeeded: graphBuildSucceeded)
-                    {
-                        BuildEventContext = solutionBuildEventContext
-                    };
-
-                    loggingService.LogBuildEvent(solutionProjectFinishedEvent);
+                    loggingService.LogProjectFinished(solutionBuildEventContext, projectGraph.Solution!.FullPath, graphBuildSucceeded);
                 }
             }
 

--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -2171,6 +2171,8 @@ namespace Microsoft.Build.Execution
                 throw new BuildAbortedException();
             }
 
+            ILoggingService loggingService = ((IBuildComponentHost)this).LoggingService;
+
             LogMessage(
                 ResourceUtilities.FormatResourceStringIgnoreCodeAndKeyword(
                     "StaticGraphConstructionStarted"));
@@ -2214,6 +2216,40 @@ namespace Microsoft.Build.Execution
                     });
             }
 
+            BuildEventContext? solutionBuildEventContext = null;
+            if (projectGraph.Solution is not null)
+            {
+                string targetNames = submission.BuildRequestData.TargetNames is { Count: > 0 }
+                    ? string.Join(
+                        ";",
+                        submission.BuildRequestData.TargetNames.Where(target => !string.IsNullOrEmpty(target)))
+                    : string.Empty;
+
+                var solutionProjectStartedEvent = new ProjectStartedEventArgs(
+                    ProjectStartedEventArgs.InvalidProjectId,
+                    message: string.Empty,
+                    helpKeyword: string.Empty,
+                    projectFile: projectGraph.Solution.FullPath,
+                    targetNames: targetNames,
+                    properties: null,
+                    items: null,
+                    parentBuildEventContext: BuildEventContext.Invalid,
+                    globalProperties: null,
+                    toolsVersion: null);
+
+                solutionBuildEventContext = new BuildEventContext(
+                    submission.SubmissionId,
+                    _buildParameters!.NodeId,
+                    BuildEventContext.InvalidEvaluationId,
+                    BuildEventContext.InvalidProjectInstanceId,
+                    BuildEventContext.InvalidProjectContextId,
+                    BuildEventContext.InvalidTargetId,
+                    BuildEventContext.InvalidTaskId);
+
+                solutionProjectStartedEvent.BuildEventContext = solutionBuildEventContext;
+                loggingService.LogBuildEvent(solutionProjectStartedEvent);
+            }
+
             LogMessage(
                 ResourceUtilities.FormatResourceStringIgnoreCodeAndKeyword(
                     "StaticGraphConstructionMetrics",
@@ -2222,37 +2258,62 @@ namespace Microsoft.Build.Execution
                     projectGraph.ConstructionMetrics.EdgeCount));
 
             Dictionary<ProjectGraphNode, BuildResult>? resultsPerNode = null;
+            bool graphBuildSucceeded = false;
 
-            if (submission.BuildRequestData.GraphBuildOptions.Build)
+            try
             {
-                _projectCacheService!.InitializePluginsForGraph(projectGraph, submission.BuildRequestData.TargetNames, _executionCancellationTokenSource!.Token);
 
-                IReadOnlyDictionary<ProjectGraphNode, ImmutableList<string>> targetsPerNode = projectGraph.GetTargetLists(submission.BuildRequestData.TargetNames);
-
-                DumpGraph(projectGraph, targetsPerNode);
-
-                // Non-graph builds verify this in RequestBuilder, but for graph builds we need to disambiguate
-                // between entry nodes and other nodes in the graph since only entry nodes should error. Just do
-                // the verification explicitly before the build even starts.
-                foreach (ProjectGraphNode entryPointNode in projectGraph.EntryPointNodes)
+                if (submission.BuildRequestData.GraphBuildOptions.Build)
                 {
-                    ProjectErrorUtilities.VerifyThrowInvalidProject(entryPointNode.ProjectInstance.Targets.Count > 0, entryPointNode.ProjectInstance.ProjectFileLocation, "NoTargetSpecified");
+                    _projectCacheService!.InitializePluginsForGraph(projectGraph, submission.BuildRequestData.TargetNames, _executionCancellationTokenSource!.Token);
+
+                    IReadOnlyDictionary<ProjectGraphNode, ImmutableList<string>> targetsPerNode = projectGraph.GetTargetLists(submission.BuildRequestData.TargetNames);
+
+                    DumpGraph(projectGraph, targetsPerNode);
+
+                    // Non-graph builds verify this in RequestBuilder, but for graph builds we need to disambiguate
+                    // between entry nodes and other nodes in the graph since only entry nodes should error. Just do
+                    // the verification explicitly before the build even starts.
+                    foreach (ProjectGraphNode entryPointNode in projectGraph.EntryPointNodes)
+                    {
+                        ProjectErrorUtilities.VerifyThrowInvalidProject(entryPointNode.ProjectInstance.Targets.Count > 0, entryPointNode.ProjectInstance.ProjectFileLocation, "NoTargetSpecified");
+                    }
+
+                    resultsPerNode = BuildGraph(projectGraph, targetsPerNode, submission.BuildRequestData);
+
+                    graphBuildSucceeded = resultsPerNode.Values.All(result => result.OverallResult == BuildResultCode.Success);
+                }
+                else
+                {
+                    DumpGraph(projectGraph);
+
+                    graphBuildSucceeded = true;
                 }
 
-                resultsPerNode = BuildGraph(projectGraph, targetsPerNode, submission.BuildRequestData);
+                Assumed.Null(submission.BuildResult?.Exception, "Exceptions only get set when the graph submission gets completed with an exception in OnThreadException. That should not happen during graph builds.");
+
+                // The overall submission is complete, so report it as complete
+                ReportResultsToSubmission<GraphBuildRequestData, GraphBuildResult>(
+                    new GraphBuildResult(
+                        submission.SubmissionId,
+                        new ReadOnlyDictionary<ProjectGraphNode, BuildResult>(resultsPerNode ?? new Dictionary<ProjectGraphNode, BuildResult>())));
             }
-            else
+            finally
             {
-                DumpGraph(projectGraph);
+                if (solutionBuildEventContext is not null)
+                {
+                    var solutionProjectFinishedEvent = new ProjectFinishedEventArgs(
+                        message: null,
+                        helpKeyword: null,
+                        projectFile: projectGraph.Solution!.FullPath,
+                        succeeded: graphBuildSucceeded)
+                    {
+                        BuildEventContext = solutionBuildEventContext
+                    };
+
+                    loggingService.LogBuildEvent(solutionProjectFinishedEvent);
+                }
             }
-
-            Assumed.Null(submission.BuildResult?.Exception, "Exceptions only get set when the graph submission gets completed with an exception in OnThreadException. That should not happen during graph builds.");
-
-            // The overall submission is complete, so report it as complete
-            ReportResultsToSubmission<GraphBuildRequestData, GraphBuildResult>(
-                new GraphBuildResult(
-                    submission.SubmissionId,
-                    new ReadOnlyDictionary<ProjectGraphNode, BuildResult>(resultsPerNode ?? new Dictionary<ProjectGraphNode, BuildResult>())));
 
             static void DumpGraph(ProjectGraph graph, IReadOnlyDictionary<ProjectGraphNode, ImmutableList<string>>? targetList = null)
             {


### PR DESCRIPTION
Fixes #8170

### Context
Graph build of a solution does not embed .sln file in binlog

### Changes Made
In the scheduler of executing graph build, add ProjectStartedEventArgs with the solution file.

### Testing


### Notes
