### PR TITLE
Bump labeler-cache-retention to use issue-labeler v2.1.0

### DIFF
--- a/.github/workflows/labeler-cache-retention.yml
+++ b/.github/workflows/labeler-cache-retention.yml
@@ -33,7 +33,7 @@ jobs:
       matrix:
         type: ["issues"] # Pulls are disabled in this repository, so "pulls" is removed from the matrix
     steps:
-      - uses: dotnet/issue-labeler/restore@46125e85e6a568dc712f358c39f35317366f5eed # v2.0.0
+      - uses: dotnet/issue-labeler/restore@98f1d9b85686147ffdc155547cdd3469546c4e26 # v2.1.0
         with:
           type: ${{ matrix.type }}
           cache_key: ${{ env.CACHE_KEY }}


### PR DESCRIPTION
This updates Labeler: Cache Retention to use dotnet/issue-labeler/restore v2.1.0 (pinned SHA), aligned with dotnet/issue-labeler's own retention workflow.

Recent retention failures were observed, for example:
https://github.com/dotnet/msbuild/actions/runs/28217536331/job/83591655131

This change is intentionally scoped to only .github/workflows/labeler-cache-retention.yml; other labeler workflows are not being bumped in this PR and the versions are compatible with each other.

This bump is suspected, but not certain, to resolve the failing retention workflow.