### PR TITLE
Fix FindPublicMethodBySignature matching static methods for instance calls

### DIFF
--- a/src/Build.UnitTests/Evaluation/Expander_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/Expander_Tests.cs
@@ -3391,6 +3391,22 @@ namespace Microsoft.Build.UnitTests.Evaluation
             expander.ExpandIntoStringLeaveEscaped(propertyFunction, ExpanderOptions.ExpandProperties, MockElementLocation.Instance).ShouldBe(expectedExpansion);
         }
 
+        [Theory]
+        [InlineData("AString", "linux", "$(AString.Equals($(AString.ToLower()), 'StringComparison.InvariantCulture'))", "True")]
+        [InlineData("AString", "Linux", "$(AString.Equals($(AString.ToLower()), 'StringComparison.InvariantCulture'))", "False")]
+        [InlineData("AString", "hello", "$(AString.Equals('hello', 'StringComparison.OrdinalIgnoreCase'))", "True")]
+        [InlineData("AString", "hello", "$(AString.Equals('HELLO', 'StringComparison.OrdinalIgnoreCase'))", "True")]
+        [InlineData("AString", "hello", "$(AString.Equals('HELLO', 'StringComparison.Ordinal'))", "False")]
+        public void StringEqualsWithStringComparisonTests(string propertyName, string propertyValue, string propertyFunction, string expectedExpansion)
+        {
+            var pg = new PropertyDictionary<ProjectPropertyInstance>
+            { [propertyName] = ProjectPropertyInstance.Create(propertyName, propertyValue) };
+
+            var expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
+
+            expander.ExpandIntoStringLeaveEscaped(propertyFunction, ExpanderOptions.ExpandProperties, MockElementLocation.Instance).ShouldBe(expectedExpansion);
+        }
+
         [Fact]
         public void IsOsPlatformShouldBeCaseInsensitiveToParameter()
         {

--- a/src/Build/Evaluation/Expander.Function.cs
+++ b/src/Build/Evaluation/Expander.Function.cs
@@ -512,7 +512,7 @@ internal partial class Expander<P, I>
                             // If there are any out parameters, try to figure out their type and create defaults for them as appropriate before calling the method.
                             if (args.Any(a => "out _".Equals(a)))
                             {
-                                IEnumerable<MethodInfo> methods = _receiverType.GetMethods().Where(m => m.Name.Equals(_methodMethodName) && m.GetParameters().Length == args.Length);
+                                IEnumerable<MethodInfo> methods = _receiverType.GetMethods(_bindingFlags).Where(m => m.Name.Equals(_methodMethodName) && m.GetParameters().Length == args.Length);
                                 functionResult = GetMethodResult(objectInstance, methods, args, 0);
                             }
                             else
@@ -1157,7 +1157,7 @@ internal partial class Expander<P, I>
 
         /// <summary>
         /// Finds a public method on the receiver type by name (case-insensitive) and exact
-        /// parameter-type signature, using the public-only <see cref="Type.GetMethods()"/> overload.
+        /// parameter-type signature, filtering by the current binding flags (instance/static).
         /// </summary>
         private MethodInfo FindPublicMethodBySignature(string methodName, Type[] parameterTypes)
         {
@@ -1215,7 +1215,7 @@ internal partial class Expander<P, I>
             {
                 // Match a public method by name (case-insensitive) and exact parameter signature.
                 // Equivalent to the prior GetMethod(..., BindingFlags, ...) call but uses the
-                // public-only GetMethods() overload, since BindingFlags.NonPublic is never set here.
+                // public-only GetMethods(_bindingFlags) call, since BindingFlags.NonPublic is never set here.
                 memberInfo = FindPublicMethodBySignature(_methodMethodName, types);
             }
 
@@ -1244,7 +1244,7 @@ internal partial class Expander<P, I>
                 }
                 else
                 {
-                    members = _receiverType.GetMethods().Where(m => string.Equals(m.Name, _methodMethodName, StringComparison.OrdinalIgnoreCase));
+                    members = _receiverType.GetMethods(_bindingFlags).Where(m => string.Equals(m.Name, _methodMethodName, StringComparison.OrdinalIgnoreCase));
                 }
 
                 foreach (MethodBase member in members)

--- a/src/Build/Evaluation/Expander.Function.cs
+++ b/src/Build/Evaluation/Expander.Function.cs
@@ -1161,7 +1161,7 @@ internal partial class Expander<P, I>
         /// </summary>
         private MethodInfo FindPublicMethodBySignature(string methodName, Type[] parameterTypes)
         {
-            foreach (MethodInfo method in _receiverType.GetMethods())
+            foreach (MethodInfo method in _receiverType.GetMethods(_bindingFlags))
             {
                 if (!string.Equals(method.Name, methodName, StringComparison.OrdinalIgnoreCase))
                 {


### PR DESCRIPTION
## Summary

`FindPublicMethodBySignature` (introduced in #14079) uses `_receiverType.GetMethods()` without binding flags, which returns all public methods including static ones. When resolving an instance call like `String.Equals` with types `[string, string]`, it incorrectly matches the **static** `String.Equals(String, String)` overload instead of falling through to `CoerceArguments` which would parse the enum string argument (`"StringComparison.InvariantCulture"`) correctly.

The old `Type.GetMethod(name, bindingFlags, null, types, null)` respected `BindingFlags.Instance` and excluded static methods, so it returned null and correctly fell through to enum coercion.

## Fix

Pass `_bindingFlags` to `GetMethods()` so it filters by instance/static correctly, matching the behavior of the replaced code.

## Reproduction

The bug breaks any MSBuild condition using instance methods with enum parameters passed as strings. For example, runtime's `Directory.Build.targets`:
```xml
Condition="!$(TargetOS.Equals($(TargetOS.ToLower()), StringComparison.InvariantCulture))"
```

This fires an error claiming `TargetOS='linux'` is not lowercase, because `String.Equals("linux", "StringComparison.InvariantCulture")` (static, ordinal comparison) returns `false`.

Reproduced locally by building MSBuild from commit 161f9eab and running against a minimal test project. Fix verified.

## Impact

This regression blocks the msbuild flow PR to the VMR (dotnet/dotnet#7406) — the `SB_CentOSStream10_Offline` leg fails because it's the first consumer of the newly-built MSBuild.

Fixes #14190