### PR TITLE
ensure we build the analyzer in sourcebuild so downstream projects can use it

### DIFF
--- a/MSBuild.SourceBuild.slnf
+++ b/MSBuild.SourceBuild.slnf
@@ -9,7 +9,8 @@
       "src\\Package\\Localization\\Localization.csproj",
       "src\\Tasks\\Microsoft.Build.Tasks.csproj",
       "src\\Utilities\\Microsoft.Build.Utilities.csproj",
-      "src\\StringTools\\StringTools.csproj"
+      "src\\StringTools\\StringTools.csproj",
+      "src\\TaskAnalyzer\\TaskAnalyzer.csproj"
     ]
   }
 }


### PR DESCRIPTION
Fixes the build gap for source build of the analyzer package that @dsplaisted reported in https://github.com/dotnet/dotnet/pull/7409#issuecomment-4827605716 in the way that @akoeplinger suggested - adding the analyzer to the source build list of projects.