### PR TITLE
Add telemetry for task execution reasons in TaskHost

### DIFF
--- a/documentation/VS-Telemetry-Data.md
+++ b/documentation/VS-Telemetry-Data.md
@@ -82,6 +82,18 @@ Tracks which task factories are being used.
 | `XamlTaskFactoryTasksExecutedCount` | int | Tasks created via XamlTaskFactory |
 | `CustomTaskFactoryTasksExecutedCount` | int | Tasks from custom task factories |
 
+### Tasks Event (`build/tasks`)
+
+Tracks task execution totals, including how many tasks ran out-of-process in a TaskHost and why.
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `TasksExecutedCount` | int | Total number of tasks executed |
+| `TaskHostTasksExecutedCount` | int | Tasks executed out-of-process in a TaskHost |
+| `TaskHostExplicitlyRequestedCount` | int | TaskHost tasks routed out-of-proc because the task/project explicitly opted in (e.g. `TaskHostFactory`, or force-out-of-proc knobs for inline task factories) |
+| `TaskHostRuntimeOrArchitectureMismatchCount` | int | TaskHost tasks routed out-of-proc because they requested an `MSBuildRuntime`/`MSBuildArchitecture` that does not match the current process |
+| `TaskHostNonMultiThreadedTaskCount` | int | TaskHost tasks routed out-of-proc in multi-threaded mode for isolation: tasks that are not MT-enlightened (lack `MSBuildMultiThreadableTaskAttribute`), including those force-routed to a transient TaskHost as a temporary workaround (e.g. NuGet's `RestoreTask`) |
+
 ## 4. Build Incrementality Telemetry
 
 Classifies builds as full or incremental based on target execution patterns.

--- a/src/Build.UnitTests/BackEnd/ProjectTelemetry_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/ProjectTelemetry_Tests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using Microsoft.Build.BackEnd;
 using Microsoft.Build.BackEnd.Logging;
 using Microsoft.Build.Evaluation;
 using Microsoft.Build.Framework;
@@ -115,6 +116,128 @@ namespace Microsoft.Build.UnitTests.BackEnd
             var method = typeof(ProjectTelemetry).GetMethod("GetMSBuildTaskSubclassProperties",
                 System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
             return (System.Collections.Generic.Dictionary<string, string>)method!.Invoke(telemetry, null)!;
+        }
+
+        /// <summary>
+        /// Helper method to get task properties (totals and task host reason counts) from telemetry using reflection
+        /// </summary>
+        private System.Collections.Generic.Dictionary<string, string> GetTaskProperties(ProjectTelemetry telemetry)
+        {
+            var method = typeof(ProjectTelemetry).GetMethod("GetTaskProperties",
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+            return (System.Collections.Generic.Dictionary<string, string>)method!.Invoke(telemetry, null)!;
+        }
+
+        /// <summary>
+        /// Test that AddTaskExecution does not record any task host reason counts for in-proc tasks.
+        /// </summary>
+        [Fact]
+        public void AddTaskExecution_InProc_RecordsNoTaskHostCounts()
+        {
+            var telemetry = new ProjectTelemetry();
+
+            telemetry.AddTaskExecution("Microsoft.Build.BackEnd.AssemblyTaskFactory", isTaskHost: false);
+
+            var properties = GetTaskProperties(telemetry);
+
+            properties.ShouldContainKeyAndValue("TasksExecutedCount", "1");
+            properties.ShouldNotContainKey("TaskHostTasksExecutedCount");
+            properties.ShouldNotContainKey("TaskHostExplicitlyRequestedCount");
+            properties.ShouldNotContainKey("TaskHostRuntimeOrArchitectureMismatchCount");
+            properties.ShouldNotContainKey("TaskHostNonMultiThreadedTaskCount");
+        }
+
+        /// <summary>
+        /// Test that AddTaskExecution records the correct count when a task host is used because it was explicitly requested.
+        /// </summary>
+        [Fact]
+        public void AddTaskExecution_TaskHost_RecordsExplicitlyRequestedCount()
+        {
+            var telemetry = new ProjectTelemetry();
+
+            telemetry.AddTaskExecution("Microsoft.Build.BackEnd.AssemblyTaskFactory", isTaskHost: true, taskHostReason: TaskHostReason.ExplicitlyRequested);
+
+            var properties = GetTaskProperties(telemetry);
+
+            properties.ShouldContainKeyAndValue("TaskHostTasksExecutedCount", "1");
+            properties.ShouldContainKeyAndValue("TaskHostExplicitlyRequestedCount", "1");
+            properties.ShouldNotContainKey("TaskHostRuntimeOrArchitectureMismatchCount");
+            properties.ShouldNotContainKey("TaskHostNonMultiThreadedTaskCount");
+        }
+
+        /// <summary>
+        /// Test that AddTaskExecution records the correct count when a task host is used due to a runtime/architecture mismatch.
+        /// </summary>
+        [Fact]
+        public void AddTaskExecution_TaskHost_RecordsRuntimeOrArchitectureMismatchCount()
+        {
+            var telemetry = new ProjectTelemetry();
+
+            telemetry.AddTaskExecution("Microsoft.Build.BackEnd.AssemblyTaskFactory", isTaskHost: true, taskHostReason: TaskHostReason.RuntimeOrArchitectureMismatch);
+
+            var properties = GetTaskProperties(telemetry);
+
+            properties.ShouldContainKeyAndValue("TaskHostTasksExecutedCount", "1");
+            properties.ShouldContainKeyAndValue("TaskHostRuntimeOrArchitectureMismatchCount", "1");
+            properties.ShouldNotContainKey("TaskHostExplicitlyRequestedCount");
+            properties.ShouldNotContainKey("TaskHostNonMultiThreadedTaskCount");
+        }
+
+        /// <summary>
+        /// Test that AddTaskExecution records the correct count when a non-MT task is routed to a task host.
+        /// </summary>
+        [Fact]
+        public void AddTaskExecution_TaskHost_RecordsNonMultiThreadedTaskCount()
+        {
+            var telemetry = new ProjectTelemetry();
+
+            telemetry.AddTaskExecution("Microsoft.Build.BackEnd.AssemblyTaskFactory", isTaskHost: true, taskHostReason: TaskHostReason.NonMultiThreadedTask);
+
+            var properties = GetTaskProperties(telemetry);
+
+            properties.ShouldContainKeyAndValue("TaskHostTasksExecutedCount", "1");
+            properties.ShouldContainKeyAndValue("TaskHostNonMultiThreadedTaskCount", "1");
+            properties.ShouldNotContainKey("TaskHostExplicitlyRequestedCount");
+            properties.ShouldNotContainKey("TaskHostRuntimeOrArchitectureMismatchCount");
+        }
+
+        /// <summary>
+        /// Test that AddTaskExecution aggregates task host reason counts across multiple invocations.
+        /// </summary>
+        [Fact]
+        public void AddTaskExecution_TaskHost_AggregatesReasonCounts()
+        {
+            var telemetry = new ProjectTelemetry();
+
+            telemetry.AddTaskExecution("Microsoft.Build.BackEnd.AssemblyTaskFactory", isTaskHost: true, taskHostReason: TaskHostReason.ExplicitlyRequested);
+            telemetry.AddTaskExecution("Microsoft.Build.BackEnd.AssemblyTaskFactory", isTaskHost: true, taskHostReason: TaskHostReason.RuntimeOrArchitectureMismatch);
+            telemetry.AddTaskExecution("Microsoft.Build.BackEnd.AssemblyTaskFactory", isTaskHost: true, taskHostReason: TaskHostReason.NonMultiThreadedTask);
+            telemetry.AddTaskExecution("Microsoft.Build.BackEnd.AssemblyTaskFactory", isTaskHost: true, taskHostReason: TaskHostReason.NonMultiThreadedTask);
+
+            var properties = GetTaskProperties(telemetry);
+
+            properties.ShouldContainKeyAndValue("TaskHostTasksExecutedCount", "4");
+            properties.ShouldContainKeyAndValue("TaskHostExplicitlyRequestedCount", "1");
+            properties.ShouldContainKeyAndValue("TaskHostRuntimeOrArchitectureMismatchCount", "1");
+            properties.ShouldContainKeyAndValue("TaskHostNonMultiThreadedTaskCount", "2");
+        }
+
+        /// <summary>
+        /// Test that a task host execution with an unspecified reason still increments the total but no reason bucket.
+        /// </summary>
+        [Fact]
+        public void AddTaskExecution_TaskHost_NoneReason_OnlyIncrementsTotal()
+        {
+            var telemetry = new ProjectTelemetry();
+
+            telemetry.AddTaskExecution("Microsoft.Build.BackEnd.AssemblyTaskFactory", isTaskHost: true, taskHostReason: TaskHostReason.None);
+
+            var properties = GetTaskProperties(telemetry);
+
+            properties.ShouldContainKeyAndValue("TaskHostTasksExecutedCount", "1");
+            properties.ShouldNotContainKey("TaskHostExplicitlyRequestedCount");
+            properties.ShouldNotContainKey("TaskHostRuntimeOrArchitectureMismatchCount");
+            properties.ShouldNotContainKey("TaskHostNonMultiThreadedTaskCount");
         }
 
         /// <summary>

--- a/src/Build/BackEnd/Components/Logging/ProjectTelemetry.cs
+++ b/src/Build/BackEnd/Components/Logging/ProjectTelemetry.cs
@@ -37,6 +37,11 @@ namespace Microsoft.Build.BackEnd.Logging
 
         private int _taskHostTasksExecutedCount = 0;
 
+        // Reasons a task was routed to an out-of-process TaskHost. See TaskHostReason.
+        private int _taskHostExplicitlyRequestedCount = 0;
+        private int _taskHostRuntimeOrArchitectureMismatchCount = 0;
+        private int _taskHostNonMultiThreadedTaskCount = 0;
+
         // Telemetry for non-sealed subclasses of Microsoft-owned MSBuild tasks
         // Maps Microsoft task names to counts of their non-sealed usage
         private readonly Dictionary<string, int> _msbuildTaskSubclassUsage = new();
@@ -44,11 +49,29 @@ namespace Microsoft.Build.BackEnd.Logging
         /// <summary>
         /// Adds a task execution to the telemetry data.
         /// </summary>
-        public void AddTaskExecution(string taskFactoryTypeName, bool isTaskHost)
+        public void AddTaskExecution(string taskFactoryTypeName, bool isTaskHost, TaskHostReason taskHostReason = TaskHostReason.None)
         {
             if (isTaskHost)
             {
                 _taskHostTasksExecutedCount++;
+
+                switch (taskHostReason)
+                {
+                    case TaskHostReason.ExplicitlyRequested:
+                        _taskHostExplicitlyRequestedCount++;
+                        break;
+
+                    case TaskHostReason.RuntimeOrArchitectureMismatch:
+                        _taskHostRuntimeOrArchitectureMismatchCount++;
+                        break;
+
+                    case TaskHostReason.NonMultiThreadedTask:
+                        _taskHostNonMultiThreadedTaskCount++;
+                        break;
+
+                    default:
+                        break;
+                }
             }
 
             switch (taskFactoryTypeName)
@@ -170,6 +193,9 @@ namespace Microsoft.Build.BackEnd.Logging
             _customTaskFactoryTasksExecutedCount = 0;
 
             _taskHostTasksExecutedCount = 0;
+            _taskHostExplicitlyRequestedCount = 0;
+            _taskHostRuntimeOrArchitectureMismatchCount = 0;
+            _taskHostNonMultiThreadedTaskCount = 0;
 
             _msbuildTaskSubclassUsage.Clear();
         }
@@ -209,6 +235,9 @@ namespace Microsoft.Build.BackEnd.Logging
 
             AddCountIfNonZero(properties, "TasksExecutedCount", totalTasksExecuted);
             AddCountIfNonZero(properties, "TaskHostTasksExecutedCount", _taskHostTasksExecutedCount);
+            AddCountIfNonZero(properties, "TaskHostExplicitlyRequestedCount", _taskHostExplicitlyRequestedCount);
+            AddCountIfNonZero(properties, "TaskHostRuntimeOrArchitectureMismatchCount", _taskHostRuntimeOrArchitectureMismatchCount);
+            AddCountIfNonZero(properties, "TaskHostNonMultiThreadedTaskCount", _taskHostNonMultiThreadedTaskCount);
 
             return properties;
         }

--- a/src/Build/BackEnd/Components/RequestBuilder/TaskRouter.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TaskRouter.cs
@@ -7,6 +7,39 @@ using System.Collections.Concurrent;
 namespace Microsoft.Build.BackEnd
 {
     /// <summary>
+    /// Describes why a task was dispatched to an out-of-process TaskHost rather than executed in-process.
+    /// Used for telemetry to understand the distribution of task host usage across real-world builds.
+    /// </summary>
+    internal enum TaskHostReason
+    {
+        /// <summary>
+        /// The task ran in-process and was not routed to a TaskHost.
+        /// </summary>
+        None = 0,
+
+        /// <summary>
+        /// The task or project explicitly opted into out-of-process execution, e.g. via
+        /// <c>TaskHostFactory</c> (or the <c>MSBUILDFORCEALLTASKSOUTOFPROC</c> /
+        /// <c>MSBUILDNOINPROCNODE</c> style force-out-of-proc knobs for inline task factories).
+        /// </summary>
+        ExplicitlyRequested,
+
+        /// <summary>
+        /// The task requested a specific <c>MSBuildRuntime</c>/<c>MSBuildArchitecture</c> that does
+        /// not match the current process, so it must run in a TaskHost matching that identity.
+        /// </summary>
+        RuntimeOrArchitectureMismatch,
+
+        /// <summary>
+        /// The build is running in multi-threaded mode and the task is routed to a sidecar
+        /// TaskHost for isolation. This covers tasks that are not MT-enlightened (they lack the
+        /// <c>MSBuildMultiThreadableTaskAttribute</c>), as well as tasks force-routed to a
+        /// transient TaskHost as a temporary workaround (e.g. NuGet's <c>RestoreTask</c>).
+        /// </summary>
+        NonMultiThreadedTask,
+    }
+
+    /// <summary>
     /// Determines where a task should be executed in multi-threaded mode.
     /// In multi-threaded execution mode, tasks implementing IMultiThreadableTask or marked with
     /// MSBuildMultiThreadableTaskAttribute run in-process within thread nodes, while legacy tasks

--- a/src/Build/BackEnd/TaskExecutionHost/TaskExecutionHost.cs
+++ b/src/Build/BackEnd/TaskExecutionHost/TaskExecutionHost.cs
@@ -1032,6 +1032,7 @@ namespace Microsoft.Build.BackEnd
                 {
                     TaskFactoryEngineContext taskFactoryEngineContext = new TaskFactoryEngineContext(_buildEngine.IsRunningMultipleNodes, _taskLocation, _taskLoggingContext, _buildComponentHost?.BuildParameters?.MultiThreaded ?? false, Traits.Instance.ForceTaskFactoryOutOfProc);
                     bool isTaskHost = false;
+                    TaskHostReason taskHostReason = TaskHostReason.None;
                     try
                     {
                         // Check if we should force out-of-process execution for non-AssemblyTaskFactory instances
@@ -1055,6 +1056,13 @@ namespace Microsoft.Build.BackEnd
 
                             task = CreateTaskHostTaskForOutOfProcFactory(taskIdentityParameters, taskFactoryEngineContext, outOfProcTaskFactory, scheduledNodeId);
                             isTaskHost = true;
+
+                            // In multi-threaded mode the factory-produced task is not MT-enlightened, so it is
+                            // routed out-of-proc for isolation; otherwise it was forced out-of-proc explicitly
+                            // (e.g. via the MSBUILDFORCETASKFACTORYOUTOFPROC environment variable).
+                            taskHostReason = (_buildComponentHost?.BuildParameters?.MultiThreaded ?? false)
+                                ? TaskHostReason.NonMultiThreadedTask
+                                : TaskHostReason.ExplicitlyRequested;
                         }
 
                         // Normal in-process execution for custom task factories
@@ -1074,7 +1082,7 @@ namespace Microsoft.Build.BackEnd
                         }
 
                         // Track telemetry for non-AssemblyTaskFactory task factories
-                        _taskLoggingContext?.TargetLoggingContext?.ProjectLoggingContext?.ProjectTelemetry?.AddTaskExecution(_taskFactoryWrapper.TaskFactory.GetType().FullName, isTaskHost);
+                        _taskLoggingContext?.TargetLoggingContext?.ProjectLoggingContext?.ProjectTelemetry?.AddTaskExecution(_taskFactoryWrapper.TaskFactory.GetType().FullName, isTaskHost, taskHostReason);
                     }
                     finally
                     {

--- a/src/Build/Instance/TaskFactories/AssemblyTaskFactory.cs
+++ b/src/Build/Instance/TaskFactories/AssemblyTaskFactory.cs
@@ -325,6 +325,18 @@ namespace Microsoft.Build.BackEnd
                 useTaskFactory = _loadedType.LoadedViaMetadataLoadContext || !TaskHostParametersMatchCurrentProcess(mergedParameters);
             }
 
+            // Determine and track the reason a task is routed to a TaskHost for telemetry.
+            // If useTaskFactory is already true at this point, the task is forced out-of-process
+            // either because TaskHostFactory was explicitly requested, or because a specific
+            // MSBuildRuntime/MSBuildArchitecture was requested that doesn't match the current process.
+            TaskHostReason taskHostReason = TaskHostReason.None;
+            if (useTaskFactory)
+            {
+                taskHostReason = (_factoryIdentityParameters.TaskHostFactoryExplicitlyRequested ?? false)
+                    ? TaskHostReason.ExplicitlyRequested
+                    : TaskHostReason.RuntimeOrArchitectureMismatch;
+            }
+
             // Multi-threaded mode routing: Determine if non-thread-safe tasks need TaskHost isolation.
             if (!useTaskFactory
                 && _loadedType?.Type != null
@@ -333,6 +345,7 @@ namespace Microsoft.Build.BackEnd
                 if (TaskRouter.NeedsTaskHostInMultiThreadedMode(_loadedType.Type))
                 {
                     useTaskFactory = true;
+                    taskHostReason = TaskHostReason.NonMultiThreadedTask;
                 }
             }
 
@@ -350,10 +363,14 @@ namespace Microsoft.Build.BackEnd
                 {
                     useTaskFactory = true;
                     forceTransientTaskHost = true;
+
+                    // The transient TaskHost workaround is temporary; count it together with the
+                    // non-MT-enlightened tasks rather than giving it its own telemetry bucket.
+                    taskHostReason = TaskHostReason.NonMultiThreadedTask;
                 }
             }
 
-            taskLoggingContext?.TargetLoggingContext?.ProjectLoggingContext?.ProjectTelemetry?.AddTaskExecution(GetType().FullName, isTaskHost: useTaskFactory);
+            taskLoggingContext?.TargetLoggingContext?.ProjectLoggingContext?.ProjectTelemetry?.AddTaskExecution(GetType().FullName, isTaskHost: useTaskFactory, taskHostReason: taskHostReason);
 
             if (useTaskFactory)
             {


### PR DESCRIPTION
Fixes #13882

### Context
When MSBuild runs a task out-of-process in a TaskHost, we previously only recorded that it happened ( TaskHostTasksExecutedCount ), not why. The team wants to understand the distribution of task-host routing reasons across real-world builds to inform multi-threaded-mode work.

### Changes Made
Introduces a  TaskHostReason  enum and threads it from the routing decision into  ProjectTelemetry , which emits per-reason integer counts on the existing  build/tasks  telemetry event.

### Testing
Added unit tests
