### PR TITLE
Add vs18.9 to merge-flow config; retire vs18.3

### DIFF
--- a/.config/git-merge-flow-config.jsonc
+++ b/.config/git-merge-flow-config.jsonc
@@ -22,12 +22,9 @@
         "vs17.14": {
             "MergeToBranch": "vs18.0"
         },
-        // Automate opening PRs to merge msbuild's vs18.0 (SDK 10.0.1xx) into vs18.3 (SDK 10.0.2xx, VS)
+        // Automate opening PRs to merge msbuild's vs18.0 (SDK 10.0.1xx) into vs18.6 (SDK 10.0.3xx, VS)
+        // vs18.3 (SDK 10.0.2xx) retired 2026-06: SDK band 10.0.2xx out of support (EoS May 2026) and VS 18.3 out of support.
         "vs18.0": {
-            "MergeToBranch": "vs18.3"
-        },
-        // Automate opening PRs to merge msbuild's vs18.3 (SDK 10.0.2xx) into vs18.6 (VS, SDK 10.0.3xx)
-        "vs18.3": {
             "MergeToBranch": "vs18.6"
         },
         // Automate opening PRs to merge msbuild's vs18.6 (VS, SDK 10.0.3xx) into vs18.7 (VS)
@@ -38,8 +35,12 @@
         "vs18.7": {
             "MergeToBranch": "vs18.8"
         },
-        // Automate opening PRs to merge msbuild's vs18.8 (VS) into main (VS canary, SDK main & next-feature-band)
+        // Automate opening PRs to merge msbuild's vs18.8 (VS) into vs18.9 (VS, SDK 10.0.4xx)
         "vs18.8": {
+            "MergeToBranch": "vs18.9"
+        },
+        // Automate opening PRs to merge msbuild's vs18.9 (VS, SDK 10.0.4xx) into main (VS canary, SDK main & next-feature-band)
+        "vs18.9": {
             "MergeToBranch": "main"
         }
     }


### PR DESCRIPTION
Phase 1.3 of the 18.9 release (#14213).

### 1.3a — add `vs18.9` to the merge chain
`vs18.9` was snapped from `main` on 2026-06-30. This routes `vs18.8 -> vs18.9` and adds `vs18.9 -> main` so forward-merge automation reaches `main` through the new release branch.

### 1.3b — retire `vs18.3`
Applying the combined SDK + VS retirement rule (retire only when **both** lifecycles are out of support):

- **SDK**: band `10.0.2xx` (paired with `vs18.3`) is past end-of-support — EoS **May 2026** per the [SDK/MSBuild/VS versioning lifecycle table](https://learn.microsoft.com/dotnet/core/porting/versioning-sdk-msbuild-vs#lifecycle).
- **VS**: 18.3 is superseded (current stable is 18.7) and out of support.

Both agree, so `vs18.3` is removed and `vs18.0` now forwards directly to `vs18.6`. `vs18.0` (SDK `10.0.1xx`) stays in the chain because `.1xx` bands are supported throughout the .NET 10 lifecycle, so its fixes keep flowing forward.

Resulting chain:
`vs16.11 -> vs17.8 -> vs17.11 -> vs17.12 -> vs17.14 -> vs18.0 -> vs18.6 -> vs18.7 -> vs18.8 -> vs18.9 -> main`