### PR TITLE
Bump main to 18.10.0 after vs18.9 snap

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -3,9 +3,9 @@
   <Import Project="Version.Details.props" />
 
   <PropertyGroup>
-    <VersionPrefix>18.9.0</VersionPrefix>
+    <VersionPrefix>18.10.0</VersionPrefix>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
-    <PackageValidationBaselineVersion>18.8.0-preview-26276-02</PackageValidationBaselineVersion>
+    <PackageValidationBaselineVersion>18.9.0-preview-26330-01</PackageValidationBaselineVersion>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>
 
     <!-- differentiate experimental insertions to avoid package id conflicts, 


### PR DESCRIPTION
Phase 3 of the 18.9 release (#14213).

Bumps `main` to the next version now that `vs18.9` has been snapped.

- **3.1** `VersionPrefix` `18.9.0` → **`18.10.0`**
- **3.2** `PackageValidationBaselineVersion` → **`18.9.0-preview-26330-01`**
  - Latest `18.9.0-preview-NNNNN-NN` build reachable from `vs18.9`: the branch-point `main` build (official build pipeline 9434, run `20260630.1`, source `0ac5599` = `merge-base(main, vs18.9)`), published to the [dotnet-tools feed](https://dev.azure.com/dnceng/public/_artifacts/feed/dotnet-tools).
  - `vs18.9` had no successful pre-stabilization preview build (its only run failed), so per the [release skill procedure](https://github.com/dotnet/msbuild/blob/main/.github/skills/release/SKILL.md#how-to-determine-package_validation_baseline_version) we fall back to the branch-point `main` build. The later `18.9.0-preview-26330-101` was intentionally **not** used — it is a post-branch `main` build carrying 18.10 content under 18.9 branding.

**3.3** If CI fails on API-compat, regenerate suppressions with `dotnet pack MSBuild.Dev.slnf /p:ApiCompatGenerateSuppressionFile=true` (fix-up only).

> ⚠️ Ordering: ideally merge **after** the Phase 2 maestro-configuration PR ([62558](https://dev.azure.com/dnceng/internal/_git/maestro-configuration/pullrequest/62558)) so the first 18.10 `main` build publishes to `VS 18.10` rather than the stale `VS 18.9` channel.