### PR TITLE
Stable branding for 18.9 release

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -3,8 +3,8 @@
   <Import Project="Version.Details.props" />
 
   <PropertyGroup>
-    <VersionPrefix>18.9.0</VersionPrefix>
-    <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
+    <VersionPrefix>18.9.0</VersionPrefix><DotNetFinalVersionKind>release</DotNetFinalVersionKind><!-- Keep next to VersionPrefix to create a conflict in forward-flow -->
+    <PreReleaseVersionLabel>servicing</PreReleaseVersionLabel>
     <PackageValidationBaselineVersion>18.8.0-preview-26276-02</PackageValidationBaselineVersion>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>
 


### PR DESCRIPTION
Phase 4.2/4.3 of the 18.9 release (#14213). **Targets `vs18.9`** (the release branch), not `main`.

Final branding via `scripts/Stabilize-Release.ps1`:
- Adds `<DotNetFinalVersionKind>release</DotNetFinalVersionKind>` on the `VersionPrefix` line — switches `vs18.9` to final-versioned (non-preview) builds. Kept next to `VersionPrefix` intentionally to create a forward-flow merge conflict (so this branding does not auto-flow into `main`).
- Changes `PreReleaseVersionLabel` `preview` → `servicing`.

**Phase 4.1 (public API promotion) is a no-op** — the repo has no `PublicAPI.Unshipped.txt` entries to promote (consistent with the 18.8 final-branding PR #13883, which also only touched `eng/Versions.props`).

After merge:
- **4.4** The auto-triggered official build for `vs18.9` will fail for lack of OptProf data → cancel it and re-run manually with the OptProf override from `main`'s latest drop.
- **4.6** Babysit the auto-generated VS insertion PR (`vs18.9` → VS `main`); final-branded bits must land in VS `main` before the insiders snap (**2026-07-02**).