### PR TITLE
Determinize release: hardcode OptProf baseline + Phase 3.2 baseline resolver

### DIFF
--- a/.github/skills/release/SKILL.md
+++ b/.github/skills/release/SKILL.md
@@ -61,6 +61,15 @@ Before starting any phase, ensure you have these values (the user must provide t
 
 **Procedure:**
 
+**Determinized (preferred):** run the helper, which does all of the below mechanically (requires `az login` with devdiv access):
+
+```
+pwsh ./scripts/Get-PackageValidationBaseline.ps1 -ThisReleaseVersion {{THIS_RELEASE_VERSION}}
+# -> prints e.g. 18.9.0-preview-26330-01
+```
+
+It computes `git merge-base origin/main origin/vs{{THIS_RELEASE_VERSION}}`, finds the matching successful build in pipeline 9434, derives the package version from the OfficialBuildId, and verifies it on the dotnet-tools feed. The manual procedure below is the fallback / explanation of what the script does:
+
 1. Open [MSBuild official build pipeline 9434](https://devdiv.visualstudio.com/DevDiv/_build?definitionId=9434).
 2. Filter runs to branch `vs{{THIS_RELEASE_VERSION}}`. Find the run that final-branded the release (it produces `{{THIS_RELEASE_VERSION}}.X` — no `-preview-` — corresponding to the commit that ran `Stabilize-Release.ps1`; see [Phase 4.2 + 4.3](../../../documentation/release-checklist.md#phase-4-final-branding--vs-insertion)). Anything successful **before** that on `vs{{THIS_RELEASE_VERSION}}` is a candidate.
 3. If `vs{{THIS_RELEASE_VERSION}}` has no successful pre-stabilization preview runs (common — the branch sees little churn before stabilization), fall back to the most recent successful `main` run whose commit is the branch-point ancestor: \
@@ -127,6 +136,7 @@ When asked to execute a specific phase:
 | [`azure-pipelines/vs-insertion.yml`](../../../azure-pipelines/vs-insertion.yml) | VS insertion pipeline — `AutoInsertTargetBranch` mappings |
 | [`azure-pipelines/vs-insertion-experimental.yml`](../../../azure-pipelines/vs-insertion-experimental.yml) | Experimental insertion — `TargetBranch` parameter values |
 | [`scripts/Stabilize-Release.ps1`](../../../scripts/Stabilize-Release.ps1) | Final branding automation (`-DryRun` to preview) |
+| [`scripts/Get-PackageValidationBaseline.ps1`](../../../scripts/Get-PackageValidationBaseline.ps1) | Phase 3.2 — resolves `PackageValidationBaselineVersion` deterministically (merge-base → pipeline 9434 → dotnet-tools feed) |
 | [`.vsts-dotnet.yml`](../../../.vsts-dotnet.yml) | Build pipeline — `VisualStudio.ChannelName` setting |
 
 ## Validation

--- a/.github/skills/release/SKILL.md
+++ b/.github/skills/release/SKILL.md
@@ -90,7 +90,7 @@ It computes `git merge-base origin/main origin/vs{{THIS_RELEASE_VERSION}}`, find
 | **0: Instantiate** | User-initiated | Validate inputs, create GitHub tracking issue |
 | **1: Branch & Prepare** | `BRANCH_SNAP_DATE` | Create `vs*` branch, DARC channel setup (batched PR), merge-flow config, `VisualStudio.ChannelName` |
 | **2: DARC Subscription Updates** | Phase 1 branch exists (`vs*` created) | Retarget `main`-targeting subs + VMR backflow to next channel, retired-branch cleanup (batched PR), Arcade verify |
-| **3: Bump Main** | Phase 2 merged | Branding PR in `main` (`VersionPrefix` → next, ApiCompat baseline) |
+| **3: Bump Main** | Phase 2 merged | Branding PR in `main` (`VersionPrefix` → next, ApiCompat baseline, refresh OptProf baseline) |
 | **4: Final Branding** | 7 days before `INSIDERS_SNAP_DATE` | Public API promotion, `Stabilize-Release.ps1`, OptProf bootstrap, get final-branded bits into VS `main` before insiders snap |
 | **5: Post-GA** | VS shipped (`VS_SHIP_DATE`) | nuget.org publish, docs, GitHub release, cleanup |
 
@@ -137,7 +137,8 @@ When asked to execute a specific phase:
 | [`azure-pipelines/vs-insertion-experimental.yml`](../../../azure-pipelines/vs-insertion-experimental.yml) | Experimental insertion — `TargetBranch` parameter values |
 | [`scripts/Stabilize-Release.ps1`](../../../scripts/Stabilize-Release.ps1) | Final branding automation (`-DryRun` to preview) |
 | [`scripts/Get-PackageValidationBaseline.ps1`](../../../scripts/Get-PackageValidationBaseline.ps1) | Phase 3.2 — resolves `PackageValidationBaselineVersion` deterministically (merge-base → pipeline 9434 → dotnet-tools feed) |
-| [`.vsts-dotnet.yml`](../../../.vsts-dotnet.yml) | Build pipeline — `VisualStudio.ChannelName` setting |
+| [`scripts/Get-LatestOptProfDrop.ps1`](../../../scripts/Get-LatestOptProfDrop.ps1) | Phase 3.3 — resolves the latest main OptProf drop (MSBuild-OptProf pipeline 17389) to refresh `OptProfBaselineDrop` in `.vsts-dotnet.yml` |
+| [`.vsts-dotnet.yml`](../../../.vsts-dotnet.yml) | Build pipeline — `VisualStudio.ChannelName`, and `OptProfBaselineDrop` (hardcoded OptProf seed for new `vs*` branches) |
 
 ## Validation
 

--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -30,6 +30,13 @@ variables:
   # if OptProfDrop is not set, string '$(OptProfDrop)' will be passed to the build script.
   - name: OptProfDrop
     value: ''
+  # Hardcoded OptProf baseline: the latest known-good OptimizationData drop from main's
+  # MSBuild-OptProf pipeline. A freshly-cut vs* release branch has no OptProf data of its own,
+  # so it inherits this value (see the vs* block below) and its first official build succeeds
+  # without the manual OptProf bootstrap rerun. Refresh this each release in the main-bump PR
+  # (documentation/release-checklist.md, Phase 3) via scripts/Get-LatestOptProfDrop.ps1.
+  - name: OptProfBaselineDrop
+    value: 'OptimizationData/DotNet-msbuild-Trusted/main/20260623.5/14471019/1'
   - name: requireDefaultChannels
     value: false
   - name: SourceBranch
@@ -38,6 +45,14 @@ variables:
   - ${{ if not(startsWith(variables['Build.SourceBranch'], 'refs/heads/vs')) }}:
     - name: SourceBranch
       value: main
+  # On a vs* release branch, seed OptProf from the hardcoded baseline above instead of trying to
+  # resolve branch-specific data that does not exist yet at branch-cut time. (main is unaffected:
+  # it keeps collecting and resolving its own OptProf via SourceBranch.)
+  - ${{ if startsWith(variables['Build.SourceBranch'], 'refs/heads/vs') }}:
+    - name: OptProfDrop
+      value: $(OptProfBaselineDrop)
+    - name: SourceBranch
+      value: ''
   # if OptProfDropName is set as a parameter, set OptProfDrop to the parameter and unset SourceBranch
   - ${{ if ne(parameters.OptProfDropName, 'default') }}:
     - name: OptProfDrop

--- a/documentation/release-checklist.md
+++ b/documentation/release-checklist.md
@@ -151,7 +151,8 @@ Verifications (**parallel** — read-only, no ordering dependency):
 Create **one PR in `main`** containing all of the following changes:
 
 - [ ] **3.1** `eng/Versions.props`: Update `VersionPrefix` to `{{NEXT_VERSION}}.0`
-- [ ] **3.2** `eng/Versions.props`: Update `PackageValidationBaselineVersion` to `{{PACKAGE_VALIDATION_BASELINE_VERSION}}` (see [How to determine `PACKAGE_VALIDATION_BASELINE_VERSION`](https://github.com/dotnet/msbuild/blob/main/.github/skills/release/SKILL.md#how-to-determine-package_validation_baseline_version) in the release skill).
+- [ ] **3.2** `eng/Versions.props`: Update `PackageValidationBaselineVersion` to `{{PACKAGE_VALIDATION_BASELINE_VERSION}}`. \
+Resolve it deterministically with `pwsh ./scripts/Get-PackageValidationBaseline.ps1 -ThisReleaseVersion {{THIS_RELEASE_VERSION}}` (requires `az login` with devdiv access). See [How to determine `PACKAGE_VALIDATION_BASELINE_VERSION`](https://github.com/dotnet/msbuild/blob/main/.github/skills/release/SKILL.md#how-to-determine-package_validation_baseline_version) in the release skill for the manual fallback.
 - [ ] **3.3** If the build pipeline fails on API-compat (only then — this step is a fix-up, not a routine action), update `CompatibilitySuppressions.xml` files. Run: \
 `dotnet pack MSBuild.Dev.slnf /p:ApiCompatGenerateSuppressionFile=true` \
 See [API compat documentation](https://learn.microsoft.com/en-us/dotnet/fundamentals/apicompat/overview) for details.

--- a/documentation/release-checklist.md
+++ b/documentation/release-checklist.md
@@ -12,7 +12,7 @@ Artifacts produced over the course of the release. Record each URL here as the c
 |---|---|
 | Phase 1.2d — maestro-configuration PR (channels for `{{THIS_RELEASE_VERSION}}` / `{{NEXT_VERSION}}`) | {{URL_OF_PHASE1_DARC_PR}} |
 | Phase 2.3j — maestro-configuration PR (`main`-targeting subs + VMR backflow retargeted, retired-branch cleanup) | {{URL_OF_PHASE2_DARC_PR}} |
-| Phase 3.4 — `main` next-version main-bump PR | {{URL_OF_NEXT_VERSION_MAIN_BUMP_PR}} |
+| Phase 3.5 — `main` next-version main-bump PR | {{URL_OF_NEXT_VERSION_MAIN_BUMP_PR}} |
 | Phase 4.3 — `vs{{THIS_RELEASE_VERSION}}` final branding PR | {{URL_OF_FINAL_BRANDING_PR}} |
 | Phase 4.6 — VS insertion PR | {{URL_OF_VS_INSERTION}} |
 | Phase 5.3 — GitHub release tag | https://github.com/dotnet/msbuild/releases/tag/v{{THIS_RELEASE_EXACT_VERSION}} |
@@ -153,10 +153,13 @@ Create **one PR in `main`** containing all of the following changes:
 - [ ] **3.1** `eng/Versions.props`: Update `VersionPrefix` to `{{NEXT_VERSION}}.0`
 - [ ] **3.2** `eng/Versions.props`: Update `PackageValidationBaselineVersion` to `{{PACKAGE_VALIDATION_BASELINE_VERSION}}`. \
 Resolve it deterministically with `pwsh ./scripts/Get-PackageValidationBaseline.ps1 -ThisReleaseVersion {{THIS_RELEASE_VERSION}}` (requires `az login` with devdiv access). See [How to determine `PACKAGE_VALIDATION_BASELINE_VERSION`](https://github.com/dotnet/msbuild/blob/main/.github/skills/release/SKILL.md#how-to-determine-package_validation_baseline_version) in the release skill for the manual fallback.
-- [ ] **3.3** If the build pipeline fails on API-compat (only then — this step is a fix-up, not a routine action), update `CompatibilitySuppressions.xml` files. Run: \
+- [ ] **3.3** `.vsts-dotnet.yml`: Refresh the hardcoded OptProf baseline so the **next** `vs*` branch cut from `main` inherits valid OptProf data (this is what lets that branch's first official build succeed without the manual Phase 4.4 rerun). \
+Resolve the current value with `pwsh ./scripts/Get-LatestOptProfDrop.ps1` (requires `az login` with devdiv access), then set it as `OptProfBaselineDrop`: \
+`<name: OptProfBaselineDrop` → `value: 'OptimizationData/DotNet-msbuild-Trusted/main/<NNNNNNNN.N>/<buildId>/1'`.
+- [ ] **3.4** If the build pipeline fails on API-compat (only then — this step is a fix-up, not a routine action), update `CompatibilitySuppressions.xml` files. Run: \
 `dotnet pack MSBuild.Dev.slnf /p:ApiCompatGenerateSuppressionFile=true` \
 See [API compat documentation](https://learn.microsoft.com/en-us/dotnet/fundamentals/apicompat/overview) for details.
-- [ ] **3.4** Merge main-bump PR: {{URL_OF_NEXT_VERSION_MAIN_BUMP_PR}}
+- [ ] **3.5** Merge main-bump PR: {{URL_OF_NEXT_VERSION_MAIN_BUMP_PR}}
 
 ---
 
@@ -174,9 +177,9 @@ Move contents of `PublicAPI.Unshipped.txt` → `PublicAPI.Shipped.txt` for all p
 Use `-DryRun` first to preview. The script adds `<DotNetFinalVersionKind>release</DotNetFinalVersionKind>` on the same line as `VersionPrefix` (creates merge conflict for forward-flow) and changes `PreReleaseVersionLabel` from `preview` to `servicing`. \
 _If the script says "already stabilized" — skip (idempotent)._
 - [ ] **4.3** Create and merge final branding PR to `vs{{THIS_RELEASE_VERSION}}`: {{URL_OF_FINAL_BRANDING_PR}}
-- [ ] **4.4** Bootstrap OptProf for `vs{{THIS_RELEASE_VERSION}}`. After the final-branding commit (4.3) merges, the [official build](https://devdiv.visualstudio.com/DevDiv/_build?definitionId=9434) is auto-triggered without OptProf data for the new branch and will fail. To work around:
+- [ ] **4.4** Bootstrap OptProf for `vs{{THIS_RELEASE_VERSION}}`. **If the Phase 3.3 hardcoded `OptProfBaselineDrop` was kept current, the auto-triggered build should already pick it up (`.vsts-dotnet.yml` seeds `OptProfDrop` from it on `vs*` branches) and this step is a no-op.** Only if the official build still fails for lack of OptProf data (e.g. the baseline was stale/empty at branch-cut):
   - [ ] **4.4a** **Cancel** the auto-triggered official build for `vs{{THIS_RELEASE_VERSION}}`.
-  - [ ] **4.4b** **Re-run the official build manually** for `vs{{THIS_RELEASE_VERSION}}` with the OptProf override from `main` — set `Optional OptProfDrop Override` to `main`'s latest OptProf drop path. _(Find the path in main CI logs: Windows_NT → Build → search for `OptimizationData`.)_
+  - [ ] **4.4b** **Re-run the official build manually** for `vs{{THIS_RELEASE_VERSION}}` with the OptProf override from `main` — set `Optional OptProfDrop Override` to `main`'s latest OptProf drop path (`pwsh ./scripts/Get-LatestOptProfDrop.ps1`).
 - [ ] **4.5** Get M2 or QB approval as necessary per the VS schedule. \
 _**Only required if we are behind the VS schedule** — i.e. the insertion didn't land in VS `main` before `{{INSIDERS_SNAP_DATE}}` (4.6 was missed) and a milestone-gate approval is now needed. If the insertion made the schedule, **skip this step**._
 - [ ] **4.6** Babysit the VS insertion PR from `vs{{THIS_RELEASE_VERSION}}` into VS `main` (auto-generated at https://devdiv.visualstudio.com/DevDiv/_git/VS/pullrequests). The final-branded bits must be in VS `main` **before** `{{INSIDERS_SNAP_DATE}}` so they are included when VS snaps to `rel/insiders`: {{URL_OF_VS_INSERTION}} \

--- a/scripts/Get-LatestOptProfDrop.ps1
+++ b/scripts/Get-LatestOptProfDrop.ps1
@@ -1,0 +1,72 @@
+<#
+.SYNOPSIS
+    Prints the latest known-good OptProf optimization-data drop produced for a branch.
+
+.DESCRIPTION
+    The MSBuild official build applies VS optimization (OptProf/IBC) data identified by a drop path
+    (passed as `/p:VisualStudioIbcDrop`). A freshly-cut `vs*` release branch has no collected OptProf
+    data yet, so its first official build fails unless seeded with a known-good drop.
+
+    This resolves that seed deterministically: it reads the latest successful run of the
+    `MSBuild-OptProf` pipeline (definition 17389, devdiv) on the given branch and extracts the value
+    emitted by its "Set PreviousOptimizationInputsDropName" step, e.g.
+    `OptimizationData/DotNet-msbuild-Trusted/main/20260623.5/14471019/1`.
+
+    Use the output as the hardcoded `OptProfBaselineDrop` in `.vsts-dotnet.yml`; refresh it each
+    release (see documentation/release-checklist.md, Phase 3).
+
+    Requires `az login` with access to the devdiv Azure DevOps organization.
+
+.PARAMETER SourceBranch
+    Branch whose latest OptProf run to read. Default: main.
+
+.PARAMETER OptProfPipelineId
+    The MSBuild-OptProf pipeline definition id. Default: 17389.
+
+.EXAMPLE
+    ./Get-LatestOptProfDrop.ps1
+    -> OptimizationData/DotNet-msbuild-Trusted/main/20260623.5/14471019/1
+#>
+
+[CmdletBinding()]
+param(
+    [string]$SourceBranch = 'main',
+    [int]$OptProfPipelineId = 17389
+)
+
+Set-StrictMode -Version 'Latest'
+$ErrorActionPreference = 'Stop'
+
+$DevDivOrg = 'https://devdiv.visualstudio.com/DevDiv'
+$AzureDevOpsResource = '499b84ac-1321-427f-aa17-267ca6975798'
+
+function Write-Info($msg) { Write-Host $msg -ForegroundColor Cyan }
+
+$token = (& az account get-access-token --resource $AzureDevOpsResource --query accessToken -o tsv 2>$null)
+if (-not $token) { throw "Could not get an Azure DevOps token. Run 'az login' with devdiv access." }
+$headers = @{ Authorization = "Bearer $token" }
+
+# Latest successful run on the branch.
+$u = "$DevDivOrg/_apis/build/builds?definitions=$OptProfPipelineId&branchName=refs/heads/$SourceBranch&resultFilter=succeeded&statusFilter=completed&queryOrder=finishTimeDescending&api-version=7.0&`$top=1"
+$run = (Invoke-RestMethod -Uri $u -Headers $headers).value | Select-Object -First 1
+if (-not $run) { throw "No successful MSBuild-OptProf ($OptProfPipelineId) run found on '$SourceBranch'." }
+Write-Info "Latest successful MSBuild-OptProf run on '$SourceBranch': $($run.id) ($($run.buildNumber)), finished $($run.finishTime)"
+
+# Find the 'Set PreviousOptimizationInputsDropName' step and read its log.
+$tl = Invoke-RestMethod -Uri "$DevDivOrg/_apis/build/builds/$($run.id)/timeline?api-version=7.0" -Headers $headers
+$step = $tl.records | Where-Object { $_.name -like '*PreviousOptimizationInputsDropName*' } | Select-Object -First 1
+if (-not $step -or -not $step.log -or -not $step.log.id) {
+    throw "Could not find the 'Set PreviousOptimizationInputsDropName' step (with a log) in run $($run.id)."
+}
+
+$log = Invoke-RestMethod -Uri "$DevDivOrg/_apis/build/builds/$($run.id)/logs/$($step.log.id)?api-version=7.0" -Headers $headers
+$match = [regex]::Match(($log -join "`n"), 'PreviousOptimizationInputsDropName:\s*(OptimizationData/\S+)')
+if (-not $match.Success) {
+    throw "Could not extract an OptimizationData drop path from the step log of run $($run.id)."
+}
+
+$drop = $match.Groups[1].Value.Trim()
+Write-Host ""
+Write-Host "OptProfBaselineDrop = $drop" -ForegroundColor Green
+# Emit the bare value for scripting.
+$drop

--- a/scripts/Get-PackageValidationBaseline.ps1
+++ b/scripts/Get-PackageValidationBaseline.ps1
@@ -1,0 +1,140 @@
+<#
+.SYNOPSIS
+    Deterministically resolves the PackageValidationBaselineVersion for a release's main-bump (Phase 3.2).
+
+.DESCRIPTION
+    The ApiCompat baseline for the bumped `main` is the latest `<THIS>.0-preview-NNNNN-NN` MSBuild
+    package that is BOTH reachable from `vs<THIS>` AND published on the public dotnet-tools feed.
+
+    This script computes it without manual pipeline spelunking:
+      1. Finds the branch point: `git merge-base <MainRef> <ReleaseRef>`.
+      2. Queries the MSBuild official build pipeline (9434, devdiv) for the successful build at that
+         commit (and any successful pre-stabilization preview builds on `vs<THIS>`).
+      3. Derives each build's package version from its OfficialBuildId via the Arcade date encoding
+         `shortDate = (yy * 1000) + (month * 50) + day`, revision zero-padded to 2 digits.
+      4. Verifies the candidate is on the dotnet-tools feed; picks the latest verified `<THIS>.0-preview-*`.
+
+    Requires `az login` with access to the devdiv Azure DevOps organization (see release skill memory).
+    See documentation/release-checklist.md (Phase 3.2) and the release skill SKILL.md.
+
+.PARAMETER ThisReleaseVersion
+    The release being shipped, e.g. "18.9". Defaults to the major.minor of <ReleaseRef>'s VersionPrefix.
+
+.PARAMETER MainRef
+    Git ref for main. Default: origin/main.
+
+.PARAMETER ReleaseRef
+    Git ref for the release branch. Default: origin/vs<ThisReleaseVersion>.
+
+.EXAMPLE
+    ./Get-PackageValidationBaseline.ps1 -ThisReleaseVersion 18.9
+    Prints e.g. 18.9.0-preview-26330-01
+#>
+
+[CmdletBinding()]
+param(
+    [string]$ThisReleaseVersion,
+    [string]$MainRef = 'origin/main',
+    [string]$ReleaseRef
+)
+
+Set-StrictMode -Version 'Latest'
+$ErrorActionPreference = 'Stop'
+
+$PipelineId = 9434
+$DevDivOrg = 'https://devdiv.visualstudio.com/DevDiv'
+$AzureDevOpsResource = '499b84ac-1321-427f-aa17-267ca6975798'
+$ToolsFeedBase = 'https://feeds.dev.azure.com/dnceng/public/_apis/packaging/feeds/dotnet-tools'
+
+function Write-Info($msg) { Write-Host $msg -ForegroundColor Cyan }
+
+# Resolve refs / version.
+if (-not $ThisReleaseVersion) {
+    if (-not $ReleaseRef) { throw "Provide -ThisReleaseVersion (e.g. 18.9) or -ReleaseRef." }
+    $props = & git show "${ReleaseRef}:eng/Versions.props"
+    if ($props -join "`n" -match '<VersionPrefix>(\d+\.\d+)\.\d+</VersionPrefix>') {
+        $ThisReleaseVersion = $Matches[1]
+    } else {
+        throw "Could not read VersionPrefix from ${ReleaseRef}:eng/Versions.props."
+    }
+}
+if (-not $ReleaseRef) { $ReleaseRef = "origin/vs$ThisReleaseVersion" }
+
+Write-Info "Release: $ThisReleaseVersion   main=$MainRef   release=$ReleaseRef"
+
+# 1. Branch point.
+$mergeBase = (& git merge-base $MainRef $ReleaseRef).Trim()
+if (-not $mergeBase) { throw "git merge-base $MainRef $ReleaseRef returned nothing (fetch the refs first?)." }
+Write-Info "Branch point (merge-base): $mergeBase"
+
+# 2. Auth + pipeline query.
+$token = (& az account get-access-token --resource $AzureDevOpsResource --query accessToken -o tsv 2>$null)
+if (-not $token) { throw "Could not get an Azure DevOps token. Run 'az login' with devdiv access." }
+$headers = @{ Authorization = "Bearer $token" }
+
+function Get-Builds($branch) {
+    $u = "$DevDivOrg/_apis/build/builds?definitions=$PipelineId&branchName=refs/heads/$branch&api-version=7.0&`$top=50"
+    (Invoke-RestMethod -Uri $u -Headers $headers).value
+}
+
+# Arcade date encoding -> package version. OfficialBuildId build number is 'yyyyMMdd.rev'.
+function Get-VersionFromBuildNumber([string]$buildNumber) {
+    if ($buildNumber -notmatch '^(\d{4})(\d{2})(\d{2})\.(\d+)$') { return $null }
+    $yy = [int]$Matches[1] % 100
+    $mm = [int]$Matches[2]
+    $dd = [int]$Matches[3]
+    $rev = [int]$Matches[4]
+    $shortDate = ($yy * 1000) + ($mm * 50) + $dd
+    $revStr = if ($rev -lt 100) { '{0:D2}' -f $rev } else { "$rev" }
+    return "$ThisReleaseVersion.0-preview-$shortDate-$revStr"
+}
+
+function Test-Succeeded($build) {
+    return ($build.PSObject.Properties.Match('result').Count -gt 0) -and ($build.result -eq 'succeeded')
+}
+
+# Collect candidate builds: the merge-base build on main, plus pre-stabilization preview builds on the release branch.
+$candidates = [System.Collections.Generic.List[object]]::new()
+
+$mainBuilds = Get-Builds 'main'
+$mbBuild = $mainBuilds | Where-Object { $_.sourceVersion -eq $mergeBase -and (Test-Succeeded $_) } | Select-Object -First 1
+if ($mbBuild) {
+    $candidates.Add([pscustomobject]@{ Source = "main@merge-base"; BuildNumber = $mbBuild.buildNumber; Finish = $mbBuild.finishTime })
+} else {
+    Write-Warning "No successful main build found at the merge-base SHA in the most recent $PipelineId runs; widen the search if needed."
+}
+
+$relBuilds = Get-Builds "vs$ThisReleaseVersion"
+foreach ($b in ($relBuilds | Where-Object { Test-Succeeded $_ })) {
+    $v = Get-VersionFromBuildNumber $b.buildNumber
+    if ($v -and $v -like "$ThisReleaseVersion.0-preview-*") {
+        $candidates.Add([pscustomobject]@{ Source = "vs$ThisReleaseVersion"; BuildNumber = $b.buildNumber; Finish = $b.finishTime })
+    }
+}
+
+if ($candidates.Count -eq 0) { throw "No eligible candidate builds found for $ThisReleaseVersion." }
+
+# 3. Compute versions.
+foreach ($c in $candidates) { $c | Add-Member NoteProperty Version (Get-VersionFromBuildNumber $c.BuildNumber) }
+
+# 4. Verify on the dotnet-tools feed.
+$pkgId = (Invoke-RestMethod -Uri "$ToolsFeedBase/packages?packageNameQuery=Microsoft.Build&api-version=7.1-preview.1" -Headers $headers).value |
+    Where-Object { $_.name -eq 'Microsoft.Build' } | Select-Object -First 1
+if (-not $pkgId) { throw "Microsoft.Build not found on the dotnet-tools feed." }
+$feedVersions = (Invoke-RestMethod -Uri "$ToolsFeedBase/packages/$($pkgId.id)/versions?api-version=7.1-preview.1" -Headers $headers).value |
+    Where-Object { $_.version -like "$ThisReleaseVersion.0-preview-*" } | Select-Object -ExpandProperty version
+
+Write-Info "Candidate builds:"
+$candidates | Sort-Object Version | ForEach-Object {
+    $onFeed = $feedVersions -contains $_.Version
+    Write-Host ("  {0,-18} build {1,-14} -> {2}  [{3}]" -f $_.Source, $_.BuildNumber, $_.Version, ($(if ($onFeed) { 'on feed' } else { 'NOT on feed' })))
+}
+
+$verified = $candidates | Where-Object { $feedVersions -contains $_.Version } | Sort-Object Version
+if (-not $verified) { throw "No candidate version is present on the dotnet-tools feed; widen the build search or verify feed publication." }
+
+$chosen = ($verified | Select-Object -Last 1).Version
+Write-Host ""
+Write-Host "PackageValidationBaselineVersion = $chosen" -ForegroundColor Green
+# Emit the bare value on the pipeline for scripting.
+$chosen


### PR DESCRIPTION
Two release-process determinizations, plus re-includes the Phase 3.2 baseline helper that missed the #14220 merge.

## 1. Hardcode the OptProf baseline (new)
A freshly-cut `vs*` branch has no OptProf optimization data of its own, so its first official build fails — today handled by the manual **Phase 4.4** dance (cancel the auto-build, re-run with an `Optional OptProfDrop Override`). This makes it automatic:

- **`.vsts-dotnet.yml`**: new `OptProfBaselineDrop` variable holding the latest known-good `main` OptimizationData drop. On `vs*` branches the build seeds `OptProfDrop` from it (→ `/p:VisualStudioIbcDrop`) and clears `SourceBranch`, so the first build of a brand-new branch has valid OptProf data.
  - `main` is **unaffected** (still resolves its own OptProf via `SourceBranch`); the manual `OptProfDropName` override still wins; existing `vs*` branches keep their frozen copies (forward-only change).
- **`scripts/Get-LatestOptProfDrop.ps1`**: resolves the value deterministically from the `MSBuild-OptProf` pipeline (def 17389) latest successful `main` run, reading the `Set PreviousOptimizationInputsDropName` step. Validated → `OptimizationData/DotNet-msbuild-Trusted/main/20260623.5/14471019/1`.
- **Process**: new checklist **Phase 3.3** refreshes `OptProfBaselineDrop` in the main-bump PR (API-compat → 3.4, merge → 3.5). **Phase 4.4** demoted to a fallback (only if the seeded build still fails).

> ⚠️ Infra change to the official build — worth a careful review of the `${{ if startsWith(... 'refs/heads/vs') }}` seeding block and a validation run on a `vs*` branch. Trade-off: a `vs*` branch now uses the OptProf data pinned at cut time (deterministic; fine for a servicing branch) rather than resolving its own over its lifetime.

## 2. Deterministic Phase 3.2 baseline (re-include)
`scripts/Get-PackageValidationBaseline.ps1` + its doc wiring — this was committed after #14220 had already merged at its first commit, so it never landed. Re-included here. Resolves `PackageValidationBaselineVersion` via `git merge-base` → pipeline 9434 → dotnet-tools feed. Validated → `18.9.0-preview-26330-01`.

Both scripts require `az login` with devdiv access; the manual procedures remain as fallbacks.