### PR TITLE
Serialize BuildRequestConfiguration.RequestedTargets to fix solution metaproject MSB4057 in parallel builds

### DIFF
--- a/src/Build.UnitTests/BackEnd/BuildRequestConfiguration_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/BuildRequestConfiguration_Tests.cs
@@ -254,6 +254,9 @@ namespace Microsoft.Build.UnitTests.BackEnd
             BuildRequestConfiguration deserializedConfig = packet as BuildRequestConfiguration;
 
             Assert.Equal(config, deserializedConfig);
+
+            // RequestedTargets is excluded from InternalEquals, so assert the empty-list round-trip explicitly.
+            deserializedConfig.RequestedTargets.ShouldBeEmpty();
         }
 
         /// <summary>

--- a/src/Build.UnitTests/BackEnd/BuildRequestConfiguration_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/BuildRequestConfiguration_Tests.cs
@@ -269,17 +269,17 @@ namespace Microsoft.Build.UnitTests.BackEnd
             PropertyDictionary<ProjectPropertyInstance> properties = new PropertyDictionary<ProjectPropertyInstance>();
             properties.Set(ProjectPropertyInstance.Create("this", "that"));
 
-            BuildRequestData data = new BuildRequestData("file", properties.ToDictionary(), "4.0", new[] { "Build", "Pack" }, null);
+            BuildRequestData data = new BuildRequestData("file", properties.ToDictionary(), "4.0", ["Build", "Pack"], null);
             BuildRequestConfiguration config = new BuildRequestConfiguration(data, "2.0");
 
-            config.RequestedTargets.ShouldBe(new[] { "Build", "Pack" });
+            config.RequestedTargets.ShouldBe(["Build", "Pack"]);
 
             ((ITranslatable)config).Translate(TranslationHelpers.GetWriteTranslator());
             INodePacket packet = BuildRequestConfiguration.FactoryForDeserialization(TranslationHelpers.GetReadTranslator());
 
             BuildRequestConfiguration deserializedConfig = packet as BuildRequestConfiguration;
 
-            deserializedConfig.RequestedTargets.ShouldBe(new[] { "Build", "Pack" });
+            deserializedConfig.RequestedTargets.ShouldBe(["Build", "Pack"]);
         }
 
         [Fact]

--- a/src/Build.UnitTests/BackEnd/BuildRequestConfiguration_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/BuildRequestConfiguration_Tests.cs
@@ -256,6 +256,32 @@ namespace Microsoft.Build.UnitTests.BackEnd
             Assert.Equal(config, deserializedConfig);
         }
 
+        /// <summary>
+        /// Regression test for the solution metaproject bug where building a solution with a
+        /// non-standard target (e.g. "Pack") in a multi-node/parallel build fails with MSB4057.
+        /// The requested targets must round-trip through translation; otherwise a configuration
+        /// that crosses a node boundary loses them and the generated solution metaproject omits
+        /// the user-requested targets.
+        /// </summary>
+        [Fact]
+        public void TestTranslationPreservesRequestedTargets()
+        {
+            PropertyDictionary<ProjectPropertyInstance> properties = new PropertyDictionary<ProjectPropertyInstance>();
+            properties.Set(ProjectPropertyInstance.Create("this", "that"));
+
+            BuildRequestData data = new BuildRequestData("file", properties.ToDictionary(), "4.0", new[] { "Build", "Pack" }, null);
+            BuildRequestConfiguration config = new BuildRequestConfiguration(data, "2.0");
+
+            config.RequestedTargets.ShouldBe(new[] { "Build", "Pack" });
+
+            ((ITranslatable)config).Translate(TranslationHelpers.GetWriteTranslator());
+            INodePacket packet = BuildRequestConfiguration.FactoryForDeserialization(TranslationHelpers.GetReadTranslator());
+
+            BuildRequestConfiguration deserializedConfig = packet as BuildRequestConfiguration;
+
+            deserializedConfig.RequestedTargets.ShouldBe(new[] { "Build", "Pack" });
+        }
+
         [Fact]
         public void TestTranslationWithEntireProjectState()
         {

--- a/src/Build/BackEnd/Shared/BuildRequestConfiguration.cs
+++ b/src/Build/BackEnd/Shared/BuildRequestConfiguration.cs
@@ -148,9 +148,17 @@ namespace Microsoft.Build.BackEnd
         #endregion
 
         /// <summary>
+        /// The target names that were requested to execute. Backed by a field so that it can be
+        /// serialized across nodes; without this, a configuration that crosses a node boundary
+        /// would lose its requested targets, which is needed (for example) to generate the correct
+        /// set of targets in a solution metaproject.
+        /// </summary>
+        private List<string> _requestedTargets = [];
+
+        /// <summary>
         /// The target names that were requested to execute.
         /// </summary>
-        internal IReadOnlyCollection<string> RequestedTargets { get; }
+        internal IReadOnlyCollection<string> RequestedTargets => _requestedTargets;
 
         /// <summary>
         /// Initializes a configuration from a BuildRequestData structure.  Used by the BuildManager.
@@ -182,7 +190,7 @@ namespace Microsoft.Build.BackEnd
             _explicitToolsVersionSpecified = data.ExplicitToolsVersionSpecified;
             _toolsVersion = ResolveToolsVersion(data, defaultToolsVersion);
             _globalProperties = data.GlobalPropertiesDictionary;
-            RequestedTargets = new List<string>(data.TargetNames);
+            _requestedTargets = new List<string>(data.TargetNames);
 
             // The following information only exists when the request is populated with an existing project.
             if (data.ProjectInstance != null)
@@ -253,7 +261,7 @@ namespace Microsoft.Build.BackEnd
             _globalProperties = other._globalProperties;
             IsCacheable = other.IsCacheable;
             _configId = configId;
-            RequestedTargets = other.RequestedTargets;
+            _requestedTargets = other._requestedTargets;
             _projectEvaluationId = other._projectEvaluationId;
         }
 
@@ -956,6 +964,7 @@ namespace Microsoft.Build.BackEnd
             translator.Translate(ref _savedCurrentDirectory);
             translator.TranslateDictionary(ref _savedEnvironmentVariables, CommunicationsUtilities.EnvironmentVariableComparer);
             translator.Translate(ref _projectEvaluationId);
+            translator.Translate(ref _requestedTargets);
 
             // if the  entire state is translated, then the transferred state represents the full evaluation data
             if (translator.Mode == TranslationDirection.ReadFromStream && _transferredState?.TranslateEntireState == true)


### PR DESCRIPTION
Unblocks https://github.com/dotnet/dotnet/pull/7491

### Summary

Fixes a bug where building a solution that requests a non-default target (e.g. `Pack`) fails with `MSB4057: The target "Pack" does not exist in the project` in **parallel / multithreaded** builds, while the same build succeeds serially.

This was observed building the `dotnet/dotnet` VMR (Arcade builds the solution in two phases with different `__BuildPhase` global properties; the `SolutionBuild` phase requests `Build;Pack`).

### Root cause

`BuildRequestConfiguration.RequestedTargets` was a get-only auto-property that was **never serialized** in `Translate`. In parallel/MT builds the configuration is round-tripped through translation (even when the work appears to run in-proc on node 1), so the deserialized configuration reset `RequestedTargets` to an empty collection.

`SolutionProjectGenerator` only emits user-requested targets (such as `Pack`) into the generated `.slnx.metaproj` when they are present in `config.RequestedTargets`. With an empty set, `Pack` was omitted from the metaproject and the build failed with `MSB4057`. Serial builds never serialized the configuration, so they were unaffected.

### Fix

Back `RequestedTargets` with a `List<string>` field and translate it in `BuildRequestConfiguration.Translate`.

### Validation

Reproduced end-to-end against the `dotnet/dotnet` VMR (`symreader`). A/B with patched MSBuild deployed into the VMR SDK:

| Serialization | targets reaching `SolutionBuild` generation | Result |
| --- | --- | --- |
| disabled (before) | `[]` | metaproject lacks `Pack` -> **MSB4057** |
| enabled (this fix) | `[Build;Pack]` | metaproject contains `Pack` -> **build succeeds** |

Added regression test `TestTranslationPreservesRequestedTargets`; full `*TestTranslation*` suite passes (56/56, net10.0 + net472).
