### PR TITLE
Refresh copy marker when implementation output changes

### DIFF
--- a/src/Tasks.UnitTests/RegressionTests.cs
+++ b/src/Tasks.UnitTests/RegressionTests.cs
@@ -118,16 +118,16 @@ namespace Microsoft.Build.Tasks.UnitTests
             ObjectModelHelpers.BuildTempProjectFileExpectSuccess("MarkerTest.csproj", logger);
 
             string markerPath = Path.Combine(ObjectModelHelpers.TempProjectDir, "obj", "Debug", "MarkerTest.csproj.Up2Date");
-            Assert.True(File.Exists(markerPath), $"Expected marker to exist at {markerPath}");
+            File.Exists(markerPath).ShouldBeTrue($"Expected marker to exist at {markerPath}");
             DateTime markerAfterFirstBuild = File.GetLastWriteTimeUtc(markerPath);
 
             ObjectModelHelpers.BuildTempProjectFileExpectSuccess("MarkerTest.csproj", logger);
 
             DateTime markerAfterNoOpBuild = File.GetLastWriteTimeUtc(markerPath);
-            Assert.Equal(markerAfterFirstBuild, markerAfterNoOpBuild);
+            markerAfterNoOpBuild.ShouldBe(markerAfterFirstBuild);
 
             string intermediateRefAssemblyPath = Path.Combine(ObjectModelHelpers.TempProjectDir, "obj", "Debug", "refint", "MarkerTest.dll");
-            Assert.True(File.Exists(intermediateRefAssemblyPath), $"Expected intermediate reference assembly to exist at {intermediateRefAssemblyPath}");
+            File.Exists(intermediateRefAssemblyPath).ShouldBeTrue($"Expected intermediate reference assembly to exist at {intermediateRefAssemblyPath}");
 
             Thread.Sleep(TimeSpan.FromSeconds(2));
             File.WriteAllText(intermediateRefAssemblyPath, "Reference output changed");
@@ -135,7 +135,7 @@ namespace Microsoft.Build.Tasks.UnitTests
             ObjectModelHelpers.BuildTempProjectFileExpectSuccess("MarkerTest.csproj", logger);
 
             DateTime markerAfterReferenceAssemblyOnlyChange = File.GetLastWriteTimeUtc(markerPath);
-            Assert.Equal(markerAfterNoOpBuild, markerAfterReferenceAssemblyOnlyChange);
+            markerAfterReferenceAssemblyOnlyChange.ShouldBe(markerAfterNoOpBuild);
 
             Thread.Sleep(TimeSpan.FromSeconds(2));
             File.WriteAllText(Path.Combine(ObjectModelHelpers.TempProjectDir, "input.txt"), "changed");
@@ -143,8 +143,7 @@ namespace Microsoft.Build.Tasks.UnitTests
             ObjectModelHelpers.BuildTempProjectFileExpectSuccess("MarkerTest.csproj", logger);
 
             DateTime markerAfterImplementationChange = File.GetLastWriteTimeUtc(markerPath);
-            Assert.True(
-                markerAfterImplementationChange > markerAfterReferenceAssemblyOnlyChange,
+            (markerAfterImplementationChange > markerAfterReferenceAssemblyOnlyChange).ShouldBeTrue(
                 $"Expected marker to advance from {markerAfterReferenceAssemblyOnlyChange:O}, but it was {markerAfterImplementationChange:O}.");
         }
 
@@ -162,7 +161,7 @@ namespace Microsoft.Build.Tasks.UnitTests
             ObjectModelHelpers.BuildTempProjectFileExpectSuccess("MarkerTest.csproj", logger);
 
             string markerPath = Path.Combine(ObjectModelHelpers.TempProjectDir, "obj", "Debug", "MarkerTest.csproj.Up2Date");
-            Assert.False(File.Exists(markerPath), $"Did not expect marker to exist at {markerPath}");
+            File.Exists(markerPath).ShouldBeFalse($"Did not expect marker to exist at {markerPath}");
         }
 
         private static void CreateCopyMarkerTestProject(bool produceReferenceAssembly)

--- a/src/Tasks.UnitTests/RegressionTests.cs
+++ b/src/Tasks.UnitTests/RegressionTests.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using Microsoft.Build.Evaluation;
 using Microsoft.Build.Shared;
 using Microsoft.Build.UnitTests;
+using Shouldly;
 using Xunit;
 
 #nullable disable

--- a/src/Tasks.UnitTests/RegressionTests.cs
+++ b/src/Tasks.UnitTests/RegressionTests.cs
@@ -181,6 +181,9 @@ namespace Microsoft.Build.Tasks.UnitTests
 
   <Import Project=""$(MSBuildToolsPath)\Microsoft.CSharp.targets"" />
 
+  <Target Name=""GetReferenceAssemblyPaths"" />
+  <Target Name=""ResolveAssemblyReferences"" />
+
   <Target Name=""CoreCompile""
           Inputs=""input.txt""
           Outputs=""@(IntermediateAssembly)"">

--- a/src/Tasks.UnitTests/RegressionTests.cs
+++ b/src/Tasks.UnitTests/RegressionTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.IO;
+using System.Threading;
 using Microsoft.Build.Evaluation;
 using Microsoft.Build.Shared;
 using Microsoft.Build.UnitTests;
@@ -101,6 +102,98 @@ namespace Microsoft.Build.Tasks.UnitTests
             ObjectModelHelpers.CreateFileInTempProjectDirectory("Foo.txt", "foo");
             MockLogger logger = new MockLogger(_output);
             ObjectModelHelpers.BuildTempProjectFileExpectSuccess("Myapp.proj", logger);
+        }
+
+        /// <summary>
+        /// Test for https://github.com/dotnet/msbuild/issues/13478.
+        /// </summary>
+        [Fact]
+        public void CopyUpToDateMarkerTracksImplementationAssemblyWrites()
+        {
+            ObjectModelHelpers.DeleteTempProjectDirectory();
+            CreateCopyMarkerTestProject(produceReferenceAssembly: true);
+
+            MockLogger logger = new MockLogger(_output);
+
+            ObjectModelHelpers.BuildTempProjectFileExpectSuccess("MarkerTest.csproj", logger);
+
+            string markerPath = Path.Combine(ObjectModelHelpers.TempProjectDir, "obj", "Debug", "MarkerTest.csproj.Up2Date");
+            Assert.True(File.Exists(markerPath), $"Expected marker to exist at {markerPath}");
+            DateTime markerAfterFirstBuild = File.GetLastWriteTimeUtc(markerPath);
+
+            ObjectModelHelpers.BuildTempProjectFileExpectSuccess("MarkerTest.csproj", logger);
+
+            DateTime markerAfterNoOpBuild = File.GetLastWriteTimeUtc(markerPath);
+            Assert.Equal(markerAfterFirstBuild, markerAfterNoOpBuild);
+
+            string intermediateRefAssemblyPath = Path.Combine(ObjectModelHelpers.TempProjectDir, "obj", "Debug", "refint", "MarkerTest.dll");
+            Assert.True(File.Exists(intermediateRefAssemblyPath), $"Expected intermediate reference assembly to exist at {intermediateRefAssemblyPath}");
+
+            Thread.Sleep(TimeSpan.FromSeconds(2));
+            File.WriteAllText(intermediateRefAssemblyPath, "Reference output changed");
+
+            ObjectModelHelpers.BuildTempProjectFileExpectSuccess("MarkerTest.csproj", logger);
+
+            DateTime markerAfterReferenceAssemblyOnlyChange = File.GetLastWriteTimeUtc(markerPath);
+            Assert.Equal(markerAfterNoOpBuild, markerAfterReferenceAssemblyOnlyChange);
+
+            Thread.Sleep(TimeSpan.FromSeconds(2));
+            File.WriteAllText(Path.Combine(ObjectModelHelpers.TempProjectDir, "input.txt"), "changed");
+
+            ObjectModelHelpers.BuildTempProjectFileExpectSuccess("MarkerTest.csproj", logger);
+
+            DateTime markerAfterImplementationChange = File.GetLastWriteTimeUtc(markerPath);
+            Assert.True(
+                markerAfterImplementationChange > markerAfterReferenceAssemblyOnlyChange,
+                $"Expected marker to advance from {markerAfterReferenceAssemblyOnlyChange:O}, but it was {markerAfterImplementationChange:O}.");
+        }
+
+        /// <summary>
+        /// Test for https://github.com/dotnet/msbuild/issues/13478.
+        /// </summary>
+        [Fact]
+        public void CopyUpToDateMarkerIsNotCreatedForMainAssemblyWritesWhenReferenceAssembliesAreNotProduced()
+        {
+            ObjectModelHelpers.DeleteTempProjectDirectory();
+            CreateCopyMarkerTestProject(produceReferenceAssembly: false);
+
+            MockLogger logger = new MockLogger(_output);
+
+            ObjectModelHelpers.BuildTempProjectFileExpectSuccess("MarkerTest.csproj", logger);
+
+            string markerPath = Path.Combine(ObjectModelHelpers.TempProjectDir, "obj", "Debug", "MarkerTest.csproj.Up2Date");
+            Assert.False(File.Exists(markerPath), $"Did not expect marker to exist at {markerPath}");
+        }
+
+        private static void CreateCopyMarkerTestProject(bool produceReferenceAssembly)
+        {
+            ObjectModelHelpers.CreateFileInTempProjectDirectory("input.txt", "initial");
+            ObjectModelHelpers.CreateFileInTempProjectDirectory("MarkerTest.csproj", $@"
+<Project DefaultTargets=""Build"" xmlns=""msbuildnamespace"" ToolsVersion=""msbuilddefaulttoolsversion"">
+  <Import Project=""$(MSBuildToolsPath)\Microsoft.Common.props"" />
+
+  <PropertyGroup>
+    <AssemblyName>MarkerTest</AssemblyName>
+    <OutputType>Library</OutputType>
+    <TargetFrameworkVersion>{MSBuildConstants.StandardTestTargetFrameworkVersion}</TargetFrameworkVersion>
+    <ProduceReferenceAssembly>{produceReferenceAssembly.ToString().ToLowerInvariant()}</ProduceReferenceAssembly>
+  </PropertyGroup>
+
+  <Import Project=""$(MSBuildToolsPath)\Microsoft.CSharp.targets"" />
+
+  <Target Name=""CoreCompile""
+          Inputs=""input.txt""
+          Outputs=""@(IntermediateAssembly)"">
+    <MakeDir Directories=""@(IntermediateAssembly->'%(RootDir)%(Directory)');@(IntermediateRefAssembly->'%(RootDir)%(Directory)')"" />
+    <WriteLinesToFile File=""@(IntermediateAssembly)""
+                      Lines=""Implementation output""
+                      Overwrite=""true"" />
+    <WriteLinesToFile File=""@(IntermediateRefAssembly)""
+                      Lines=""Reference output""
+                      Overwrite=""true""
+                      Condition=""'@(IntermediateRefAssembly)' != '' and !Exists('@(IntermediateRefAssembly)')"" />
+  </Target>
+</Project>");
         }
     }
 }

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -4913,7 +4913,6 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <CopyBuildOutputToOutputDirectory Condition="'$(CopyBuildOutputToOutputDirectory)'==''">true</CopyBuildOutputToOutputDirectory>
       <CopyOutputSymbolsToOutputDirectory Condition="'$(CopyOutputSymbolsToOutputDirectory)'==''">true</CopyOutputSymbolsToOutputDirectory>
       <CopyDocumentationFileToOutputDirectory Condition="'$(CopyDocumentationFileToOutputDirectory)'==''">true</CopyDocumentationFileToOutputDirectory>
-      <_WroteMainAssemblyToOutputDirectory>false</_WroteMainAssemblyToOutputDirectory>
     </PropertyGroup>
 
     <!-- Copy the build product (.dll or .exe). -->

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -4913,6 +4913,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <CopyBuildOutputToOutputDirectory Condition="'$(CopyBuildOutputToOutputDirectory)'==''">true</CopyBuildOutputToOutputDirectory>
       <CopyOutputSymbolsToOutputDirectory Condition="'$(CopyOutputSymbolsToOutputDirectory)'==''">true</CopyOutputSymbolsToOutputDirectory>
       <CopyDocumentationFileToOutputDirectory Condition="'$(CopyDocumentationFileToOutputDirectory)'==''">true</CopyDocumentationFileToOutputDirectory>
+      <_WroteMainAssemblyToOutputDirectory>false</_WroteMainAssemblyToOutputDirectory>
     </PropertyGroup>
 
     <!-- Copy the build product (.dll or .exe). -->
@@ -4931,6 +4932,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
       <Output TaskParameter="DestinationFiles" ItemName="MainAssembly"/>
       <Output TaskParameter="DestinationFiles" ItemName="FileWrites"/>
+      <Output TaskParameter="WroteAtLeastOneFile" PropertyName="_WroteMainAssemblyToOutputDirectory"/>
 
     </Copy>
 
@@ -4947,6 +4949,21 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     </CopyRefAssembly>
 
     <Message Importance="High" Text="$(MSBuildProjectName) -&gt; @(MainAssembly->'%(FullPath)')" Condition="'$(CopyBuildOutputToOutputDirectory)' == 'true' and '$(SkipCopyBuildProduct)'!='true'" />
+
+    <!--
+      If this project produces reference assemblies and its implementation assembly changed,
+      subsequent builds of projects that depend on it may need to copy the updated implementation.
+      Touch the marker considered by those projects' up-to-date checks. This is separate from
+      _CopyFilesMarkedCopyLocal so implementation-only changes can advance the marker even when
+      no copy-local references were copied.
+    -->
+    <Touch Files="@(CopyUpToDateMarker)"
+      AlwaysCreate="true"
+      Condition="'$(ProduceReferenceAssembly)' == 'true' and '$(_WroteMainAssemblyToOutputDirectory)' == 'true'" />
+
+    <ItemGroup Condition="'$(ProduceReferenceAssembly)' == 'true'">
+      <FileWrites Include="@(CopyUpToDateMarker)" />
+    </ItemGroup>
 
     <!-- Copy the additional modules. -->
     <Copy

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -4950,15 +4950,19 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <Message Importance="High" Text="$(MSBuildProjectName) -&gt; @(MainAssembly->'%(FullPath)')" Condition="'$(CopyBuildOutputToOutputDirectory)' == 'true' and '$(SkipCopyBuildProduct)'!='true'" />
 
     <!--
-      If this project produces reference assemblies and its implementation assembly changed,
-      subsequent builds of projects that depend on it may need to copy the updated implementation.
-      Touch the marker considered by those projects' up-to-date checks. This is separate from
-      _CopyFilesMarkedCopyLocal so implementation-only changes can advance the marker even when
-      no copy-local references were copied.
+      Advance the marker considered by projects that reference this one during their up-to-date
+      checks. It must move forward when either:
+        * this project produces reference assemblies and its implementation assembly changed on
+          this build (referencing projects may need to copy the updated implementation), or
+        * copy-local (possibly transitive) references were actually copied on this build, as
+          captured by _CopyFilesMarkedCopyLocal in $(_CopyLocalReferencesCopiedInThisBuild).
+      Both signals are OR'd into this single Touch so the marker is written at most once per
+      build. _CopyFilesMarkedCopyLocal is a DependsOnTargets dependency of this target, so its
+      capture always runs before this Touch.
     -->
     <Touch Files="@(CopyUpToDateMarker)"
       AlwaysCreate="true"
-      Condition="'$(ProduceReferenceAssembly)' == 'true' and '$(_WroteMainAssemblyToOutputDirectory)' == 'true'" />
+      Condition="('$(ProduceReferenceAssembly)' == 'true' and '$(_WroteMainAssemblyToOutputDirectory)' == 'true') or '$(_CopyLocalReferencesCopiedInThisBuild)' == 'true'" />
 
     <ItemGroup Condition="'$(ProduceReferenceAssembly)' == 'true'">
       <FileWrites Include="@(CopyUpToDateMarker)" />
@@ -5127,13 +5131,13 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
     </Copy>
 
-    <!-- If this project produces reference assemblies *and* copied (possibly transitive)
-         references on this build, subsequent builds of projects that depend on it must
-         not be considered up to date, so touch this marker file that is considered an
-         input to projects that reference this one. -->
-    <Touch Files="@(CopyUpToDateMarker)"
-      AlwaysCreate="true"
-      Condition="'@(ReferencesCopiedInThisBuild)' != '' and '$(WroteAtLeastOneFile)' == 'true'" />
+    <!-- Record whether copy-local (possibly transitive) references were actually copied on this
+         build. When they were, projects that depend on this one must not be considered up to date.
+         The marker file that carries that signal is touched once, later, in CopyFilesToOutputDirectory
+         (which depends on this target), so the same file isn't written twice in a normal build. -->
+    <PropertyGroup>
+      <_CopyLocalReferencesCopiedInThisBuild Condition="'@(ReferencesCopiedInThisBuild)' != '' and '$(WroteAtLeastOneFile)' == 'true'">true</_CopyLocalReferencesCopiedInThisBuild>
+    </PropertyGroup>
 
     <ItemGroup>
       <FileWrites Include="@(CopyUpToDateMarker)" />


### PR DESCRIPTION
Fixes #13478.

## Context

`CopyUpToDateMarker` is used by Visual Studio's fast up-to-date check to decide whether referencing projects may need to observe updated implementation outputs when reference assemblies are unchanged.

Today the marker only advances from `_CopyFilesMarkedCopyLocal` when a copy-local reference is actually written. That preserves no-op incremental builds, but misses implementation-only changes where the project's main assembly is updated and no copy-local references were copied.

## Changes

- Capture `WroteAtLeastOneFile` from the main assembly copy in `CopyFilesToOutputDirectory`.
- Touch `@(CopyUpToDateMarker)` when `ProduceReferenceAssembly=true` and the main implementation assembly was actually copied to `OutDir`.
- Keep no-op builds from advancing the marker.
- Add regression coverage for marker advancement, no-op behavior, and `ProduceReferenceAssembly=false`.

## Validation

- `dotnet test D:\msbuild\src\Tasks.UnitTests\Microsoft.Build.Tasks.UnitTests.csproj --framework net472 --filter "FullyQualifiedName~Microsoft.Build.Tasks.UnitTests.RegressionTests.CopyUpToDateMarker"`
- `D:\msbuild\build.cmd -v quiet`
- Manual end-to-end MSBuild check with the built `artifacts\bin\MSBuild\Debug\net472\MSBuild.exe`: marker unchanged on no-op build and advanced after implementation-output change.
