### PR TITLE
[Prototype] Environment-variable overrides for multithreaded task routing (testing only)

### DIFF
--- a/documentation/wiki/MSBuild-Environment-Variables.md
+++ b/documentation/wiki/MSBuild-Environment-Variables.md
@@ -36,5 +36,7 @@ Some of the env variables listed here are unsupported, meaning there is no guara
   - Set this to force all inline tasks to run out of process. It is not compatible with custom TaskFactories.
 - `MSBUILDFORCEMULTITHREADED=1`
   - Set this to force MSBuild to run in multi-threaded mode (using in-proc nodes for parallel build), equivalent to passing `-multiThreaded` / `-mt` on the command line. Useful for opting in without modifying command lines.
+- `MSBUILDFORCETASKSINPROCHOSTLIST`, `MSBUILDFORCETASKSTRANSIENTHOSTLIST`, `MSBUILDFORCETASKSSIDECARHOSTLIST`
+  - **Prototype / testing only.** In multi-threaded mode these override the engine's per-task routing decision. Each is a comma- or semicolon-delimited list of task full names (`Namespace.TaskName`) that should be forced to run, respectively, in-process within the thread node, in a transient TaskHost that terminates after execution, or in a reusable (sidecar) TaskHost. If a task appears in more than one list, in-proc wins over transient, which wins over sidecar. These variables are intended to unblock testing of multi-threaded execution against tasks whose source cannot be changed; they are not a supported production configuration. See [dotnet/msbuild#13738](https://github.com/dotnet/msbuild/issues/13738).
 - `MSBUILD_CONSOLE_USE_DEFAULT_ENCODING`
   - It opts out automatic console encoding UTF-8. Make Console use default encoding in the system.

--- a/src/Build.UnitTests/BackEnd/TaskRouter_IntegrationTests.cs
+++ b/src/Build.UnitTests/BackEnd/TaskRouter_IntegrationTests.cs
@@ -635,6 +635,202 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
             logger.FullLog.ShouldContain("RestoreTask executed");
         }
 
+        #region Environment variable routing override (prototype / testing) tests
+
+        /// <summary>
+        /// PROTOTYPE / TESTING ONLY. A task that would normally be routed to a TaskHost (no
+        /// thread-safety attribute) is forced in-process by MSBUILDFORCETASKSINPROCHOSTLIST.
+        /// </summary>
+        [Fact]
+        public void EnvVarOverride_ForceInProc_RunsInProcess_InMultiThreadedMode()
+        {
+            string projectContent = CreateTestProject("PidLoggingTestTask", "PidLoggingTestTask");
+            string projectFile = Path.Combine(_testProjectsDir, "ForceInProc.proj");
+            File.WriteAllText(projectFile, projectContent);
+
+            _env.SetEnvironmentVariable("MSBUILDFORCETASKSINPROCHOSTLIST", typeof(PidLoggingTestTask).FullName);
+
+            var logger = new MockLogger(_output);
+            var buildParameters = new BuildParameters
+            {
+                MultiThreaded = true,
+                Loggers = [logger],
+                DisableInProcNode = false,
+                EnableNodeReuse = false,
+            };
+
+            var buildRequestData = new BuildRequestData(
+                projectFile,
+                new Dictionary<string, string>(),
+                null,
+                ["TestTarget"],
+                null);
+
+            BuildManager buildManager = BuildManager.DefaultBuildManager;
+            BuildResult result = buildManager.Build(buildParameters, buildRequestData);
+
+            result.OverallResult.ShouldBe(BuildResultCode.Success);
+
+            // Even though the task has no thread-safety attribute, the override keeps it in-process.
+            TaskRouterTestHelper.AssertTaskRanInProcess(logger, "PidLoggingTestTask");
+
+            int[] pids = ExtractReportedPids(logger.FullLog, "PidLoggingTestTask");
+            pids.Length.ShouldBe(1, $"Expected one invocation. Log:{Environment.NewLine}{logger.FullLog}");
+            pids[0].ShouldBe(Process.GetCurrentProcess().Id, "Task forced in-proc must run in the build process.");
+        }
+
+        /// <summary>
+        /// PROTOTYPE / TESTING ONLY. A task that would normally run in-process (marked with the
+        /// thread-safety attribute) is forced into a sidecar TaskHost by MSBUILDFORCETASKSSIDECARHOSTLIST.
+        /// </summary>
+        [Fact]
+        public void EnvVarOverride_ForceSidecar_RunsInTaskHost_InMultiThreadedMode()
+        {
+            string projectContent = CreateTestProject("PidLoggingMultiThreadableTestTask", "PidLoggingMultiThreadableTestTask");
+            string projectFile = Path.Combine(_testProjectsDir, "ForceSidecar.proj");
+            File.WriteAllText(projectFile, projectContent);
+
+            _env.SetEnvironmentVariable("MSBUILDFORCETASKSSIDECARHOSTLIST", typeof(PidLoggingMultiThreadableTestTask).FullName);
+
+            var logger = new MockLogger(_output);
+            var buildParameters = new BuildParameters
+            {
+                MultiThreaded = true,
+                Loggers = [logger],
+                DisableInProcNode = false,
+                EnableNodeReuse = false,
+            };
+
+            var buildRequestData = new BuildRequestData(
+                projectFile,
+                new Dictionary<string, string>(),
+                null,
+                ["TestTarget"],
+                null);
+
+            BuildManager buildManager = BuildManager.DefaultBuildManager;
+            BuildResult result = buildManager.Build(buildParameters, buildRequestData);
+
+            result.OverallResult.ShouldBe(BuildResultCode.Success);
+
+            // Despite the attribute, the override pushes the task out of process.
+            TaskRouterTestHelper.AssertTaskUsedTaskHost(logger, "PidLoggingMultiThreadableTestTask");
+
+            int[] pids = ExtractReportedPids(logger.FullLog, "PidLoggingMultiThreadableTestTask");
+            pids.Length.ShouldBe(1, $"Expected one invocation. Log:{Environment.NewLine}{logger.FullLog}");
+            pids[0].ShouldNotBe(Process.GetCurrentProcess().Id, "Task forced to a sidecar TaskHost must run out of process.");
+        }
+
+        /// <summary>
+        /// PROTOTYPE / TESTING ONLY. A task forced into a transient TaskHost by
+        /// MSBUILDFORCETASKSTRANSIENTHOSTLIST gets a fresh process on each build, even with node reuse on.
+        /// </summary>
+        [Fact]
+        public void EnvVarOverride_ForceTransient_GetsFreshProcess_InMultiThreadedMode()
+        {
+            string projectContent = CreateTestProject("PidLoggingMultiThreadableTestTask", "PidLoggingMultiThreadableTestTask");
+            string projectFile = Path.Combine(_testProjectsDir, "ForceTransient.proj");
+            File.WriteAllText(projectFile, projectContent);
+
+            _env.SetEnvironmentVariable("MSBUILDFORCETASKSTRANSIENTHOSTLIST", typeof(PidLoggingMultiThreadableTestTask).FullName);
+
+            var logger = new MockLogger(_output);
+            var buildParameters = new BuildParameters
+            {
+                MultiThreaded = true,
+                Loggers = [logger],
+                DisableInProcNode = false,
+
+                // Reuse stays ON: a transient TaskHost must still die between builds.
+                EnableNodeReuse = true,
+            };
+
+            var buildRequestData = new BuildRequestData(
+                projectFile,
+                new Dictionary<string, string>(),
+                null,
+                ["TestTarget"],
+                null);
+
+            BuildManager buildManager = BuildManager.DefaultBuildManager;
+            BuildResult result1 = buildManager.Build(buildParameters, buildRequestData);
+            BuildResult result2 = buildManager.Build(buildParameters, buildRequestData);
+
+            result1.OverallResult.ShouldBe(BuildResultCode.Success);
+            result2.OverallResult.ShouldBe(BuildResultCode.Success);
+            TaskRouterTestHelper.AssertTaskUsedTaskHost(logger, "PidLoggingMultiThreadableTestTask");
+
+            int[] pids = ExtractReportedPids(logger.FullLog, "PidLoggingMultiThreadableTestTask");
+            pids.Length.ShouldBe(2, $"Expected two invocations to log a PID. Log:{Environment.NewLine}{logger.FullLog}");
+            pids[0].ShouldNotBe(pids[1], "Each build must spawn a fresh transient TaskHost.");
+            pids.ShouldNotContain(Process.GetCurrentProcess().Id, "Transient TaskHost must be out-of-process.");
+        }
+
+        /// <summary>
+        /// PROTOTYPE / TESTING ONLY. The override has no effect outside multi-threaded mode.
+        /// </summary>
+        [Fact]
+        public void EnvVarOverride_Ignored_WhenNotMultiThreaded()
+        {
+            string projectContent = CreateTestProject("PidLoggingMultiThreadableTestTask", "PidLoggingMultiThreadableTestTask");
+            string projectFile = Path.Combine(_testProjectsDir, "OverrideIgnored.proj");
+            File.WriteAllText(projectFile, projectContent);
+
+            _env.SetEnvironmentVariable("MSBUILDFORCETASKSSIDECARHOSTLIST", typeof(PidLoggingMultiThreadableTestTask).FullName);
+
+            var logger = new MockLogger(_output);
+            var buildParameters = new BuildParameters
+            {
+                MultiThreaded = false,
+                Loggers = [logger],
+                DisableInProcNode = false,
+                EnableNodeReuse = false,
+            };
+
+            var buildRequestData = new BuildRequestData(
+                projectFile,
+                new Dictionary<string, string>(),
+                null,
+                ["TestTarget"],
+                null);
+
+            BuildManager buildManager = BuildManager.DefaultBuildManager;
+            BuildResult result = buildManager.Build(buildParameters, buildRequestData);
+
+            result.OverallResult.ShouldBe(BuildResultCode.Success);
+
+            // Not multi-threaded: routing override is inert, task runs in-process.
+            TaskRouterTestHelper.AssertTaskRanInProcess(logger, "PidLoggingMultiThreadableTestTask");
+        }
+
+        /// <summary>
+        /// PROTOTYPE / TESTING ONLY. When a task is listed in multiple override variables,
+        /// in-proc wins over transient, which wins over sidecar.
+        /// </summary>
+        [Fact]
+        public void GetEnvironmentRoutingOverride_Precedence_InProcOverTransientOverSidecar()
+        {
+            string fullName = typeof(PidLoggingTestTask).FullName;
+            _env.SetEnvironmentVariable("MSBUILDFORCETASKSINPROCHOSTLIST", fullName);
+            _env.SetEnvironmentVariable("MSBUILDFORCETASKSTRANSIENTHOSTLIST", fullName);
+            _env.SetEnvironmentVariable("MSBUILDFORCETASKSSIDECARHOSTLIST", fullName);
+
+            TaskRouter.GetEnvironmentRoutingOverride(typeof(PidLoggingTestTask)).ShouldBe(TaskHostRoutingOverride.InProc);
+        }
+
+        /// <summary>
+        /// PROTOTYPE / TESTING ONLY. A task not named in any override variable yields no override.
+        /// </summary>
+        [Fact]
+        public void GetEnvironmentRoutingOverride_ReturnsNone_ForUnlistedTask()
+        {
+            _env.SetEnvironmentVariable("MSBUILDFORCETASKSSIDECARHOSTLIST", "Some.Other.Task");
+
+            TaskRouter.GetEnvironmentRoutingOverride(typeof(PidLoggingTestTask)).ShouldBe(TaskHostRoutingOverride.None);
+        }
+
+        #endregion
+
         private string CreateTestProject(string taskName, string taskClass)
         {
             return $@"
@@ -645,6 +841,17 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
         <{taskName} />
     </Target>
 </Project>";
+        }
+
+        private static int[] ExtractReportedPids(string log, string taskName)
+        {
+            var pids = new List<int>();
+            foreach (Match m in Regex.Matches(log, Regex.Escape(taskName) + @" executed in PID=(\d+)"))
+            {
+                pids.Add(int.Parse(m.Groups[1].Value));
+            }
+
+            return pids.ToArray();
         }
     }
 
@@ -728,6 +935,37 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
         public override bool Execute()
         {
             Log.LogMessage(MessageImportance.High, "TaskWithAttribute executed");
+            return true;
+        }
+    }
+
+    /// <summary>
+    /// PROTOTYPE / TESTING ONLY. A non-enlightened task (no attribute, normally routed to a
+    /// TaskHost in multi-threaded mode) that logs the PID of the process it runs in, so tests can
+    /// verify the environment-variable routing override actually changed where it executed.
+    /// </summary>
+    public class PidLoggingTestTask : Task
+    {
+        public override bool Execute()
+        {
+            Log.LogMessage(MessageImportance.High, $"PidLoggingTestTask executed in PID={Process.GetCurrentProcess().Id}");
+            return true;
+        }
+    }
+
+    /// <summary>
+    /// PROTOTYPE / TESTING ONLY. A task marked with MSBuildMultiThreadableTaskAttribute (normally
+    /// runs in-process in multi-threaded mode) that logs its PID, used to verify the environment
+    /// variable routing override can push it into a sidecar or transient TaskHost.
+    /// </summary>
+#pragma warning disable CS0436 // Type conflicts with imported type - intentional for testing
+    [MSBuildMultiThreadableTask]
+#pragma warning restore CS0436
+    public class PidLoggingMultiThreadableTestTask : Task
+    {
+        public override bool Execute()
+        {
+            Log.LogMessage(MessageImportance.High, $"PidLoggingMultiThreadableTestTask executed in PID={Process.GetCurrentProcess().Id}");
             return true;
         }
     }

--- a/src/Build/BackEnd/Components/RequestBuilder/TaskRouter.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TaskRouter.cs
@@ -3,9 +3,41 @@
 
 using System;
 using System.Collections.Concurrent;
+using Microsoft.Build.Framework;
 
 namespace Microsoft.Build.BackEnd
 {
+    /// <summary>
+    /// Describes an explicit override of the engine's multi-threaded task-routing decision.
+    /// </summary>
+    /// <remarks>
+    /// The override may come from an environment variable (prototype / testing surface, see
+    /// <see cref="TaskRouter.GetEnvironmentRoutingOverride"/>) or, in a separate design, from
+    /// <c>UsingTask</c> metadata. It only has meaning in multi-threaded mode.
+    /// </remarks>
+    internal enum TaskHostRoutingOverride
+    {
+        /// <summary>
+        /// No override; the engine applies its default routing decision.
+        /// </summary>
+        None,
+
+        /// <summary>
+        /// Force the task to run in-process within the thread node.
+        /// </summary>
+        InProc,
+
+        /// <summary>
+        /// Force the task to run in a reusable (sidecar) TaskHost process.
+        /// </summary>
+        Sidecar,
+
+        /// <summary>
+        /// Force the task to run in a transient TaskHost process that terminates after execution.
+        /// </summary>
+        Transient,
+    }
+
     /// <summary>
     /// Determines where a task should be executed in multi-threaded mode.
     /// In multi-threaded execution mode, tasks implementing IMultiThreadableTask or marked with
@@ -112,6 +144,58 @@ namespace Microsoft.Build.BackEnd
             }
 
             return string.Equals(fullName, TaskRequiringTransientTaskHostFullName, StringComparison.Ordinal);
+        }
+
+        /// <summary>
+        /// PROTOTYPE / TESTING ONLY. Determines whether an environment variable explicitly overrides
+        /// the engine's routing decision for the given task, forcing it in-process, into a transient
+        /// TaskHost, or into a sidecar TaskHost.
+        /// </summary>
+        /// <param name="taskType">The type of the task to evaluate.</param>
+        /// <returns>
+        /// The requested <see cref="TaskHostRoutingOverride"/>, or <see cref="TaskHostRoutingOverride.None"/>
+        /// when the task is not named in any of the override environment variables.
+        /// </returns>
+        /// <remarks>
+        /// The override is controlled by the following environment variables, each a comma- or
+        /// semicolon-delimited list of task full names (Namespace.TaskName):
+        /// <list type="bullet">
+        /// <item><c>MSBUILDFORCETASKSINPROCHOSTLIST</c> -&gt; <see cref="TaskHostRoutingOverride.InProc"/></item>
+        /// <item><c>MSBUILDFORCETASKSTRANSIENTHOSTLIST</c> -&gt; <see cref="TaskHostRoutingOverride.Transient"/></item>
+        /// <item><c>MSBUILDFORCETASKSSIDECARHOSTLIST</c> -&gt; <see cref="TaskHostRoutingOverride.Sidecar"/></item>
+        /// </list>
+        /// If a task appears in more than one list, in-proc wins over transient, which wins over sidecar.
+        /// This surface exists to unblock testing of multi-threaded execution against tasks the author
+        /// cannot change; it is not a supported production configuration.
+        /// </remarks>
+        public static TaskHostRoutingOverride GetEnvironmentRoutingOverride(Type taskType)
+        {
+            ArgumentNullException.ThrowIfNull(taskType);
+
+            string? fullName = taskType.FullName;
+            if (fullName is null)
+            {
+                return TaskHostRoutingOverride.None;
+            }
+
+            Traits traits = Traits.Instance;
+
+            if (traits.ForceTasksInProcHostList.Contains(fullName))
+            {
+                return TaskHostRoutingOverride.InProc;
+            }
+
+            if (traits.ForceTasksTransientHostList.Contains(fullName))
+            {
+                return TaskHostRoutingOverride.Transient;
+            }
+
+            if (traits.ForceTasksSidecarHostList.Contains(fullName))
+            {
+                return TaskHostRoutingOverride.Sidecar;
+            }
+
+            return TaskHostRoutingOverride.None;
         }
 
         /// <summary>

--- a/src/Build/Instance/TaskFactories/AssemblyTaskFactory.cs
+++ b/src/Build/Instance/TaskFactories/AssemblyTaskFactory.cs
@@ -326,11 +326,29 @@ namespace Microsoft.Build.BackEnd
             }
 
             // Multi-threaded mode routing: Determine if non-thread-safe tasks need TaskHost isolation.
-            if (!useTaskFactory
-                && _loadedType?.Type != null
-                && buildComponentHost?.BuildParameters?.MultiThreaded == true)
+            // PROTOTYPE / TESTING ONLY: an environment variable may explicitly override the routing
+            // decision (in-proc / transient / sidecar). See https://github.com/dotnet/msbuild/issues/13738.
+            bool isMultiThreaded = buildComponentHost?.BuildParameters?.MultiThreaded == true;
+            TaskHostRoutingOverride routingOverride = TaskHostRoutingOverride.None;
+            if (isMultiThreaded && _loadedType?.Type != null)
             {
-                if (TaskRouter.NeedsTaskHostInMultiThreadedMode(_loadedType.Type))
+                routingOverride = TaskRouter.GetEnvironmentRoutingOverride(_loadedType.Type);
+            }
+
+            if (!useTaskFactory
+                && isMultiThreaded
+                && _loadedType?.Type != null)
+            {
+                bool needsTaskHost = routingOverride switch
+                {
+                    // An explicit in-proc override asserts the task is safe to run in the thread node.
+                    TaskHostRoutingOverride.InProc => false,
+                    TaskHostRoutingOverride.Sidecar => true,
+                    TaskHostRoutingOverride.Transient => true,
+                    _ => TaskRouter.NeedsTaskHostInMultiThreadedMode(_loadedType.Type),
+                };
+
+                if (needsTaskHost)
                 {
                     useTaskFactory = true;
                 }
@@ -340,10 +358,11 @@ namespace Microsoft.Build.BackEnd
             // (e.g., NuGet RestoreTask). In MT mode or when MSBuild server is active, these tasks
             // must run in a transient (non-sidecar) TaskHost so static state is cleaned up after
             // each invocation. See https://github.com/dotnet/msbuild/issues/13315
+            // An explicit Transient routing override (prototype/testing) has the same effect.
             bool forceTransientTaskHost = false;
-            if (_loadedType?.Type != null && TaskRouter.RequiresTransientTaskHost(_loadedType.Type))
+            if (_loadedType?.Type != null
+                && (routingOverride == TaskHostRoutingOverride.Transient || TaskRouter.RequiresTransientTaskHost(_loadedType.Type)))
             {
-                bool isMultiThreaded = buildComponentHost?.BuildParameters?.MultiThreaded == true;
                 bool isLongLivedHost = buildComponentHost?.BuildParameters?.IsLongLivedHost == true;
 
                 if (isMultiThreaded || isLongLivedHost)

--- a/src/Framework/Traits.cs
+++ b/src/Framework/Traits.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections.Generic;
 
 namespace Microsoft.Build.Framework
 {
@@ -44,6 +45,52 @@ namespace Microsoft.Build.Framework
         /// equivalent to passing -multiThreaded / -mt on the command line.
         /// </summary>
         public readonly bool ForceMultiThreaded = Environment.GetEnvironmentVariable("MSBUILDFORCEMULTITHREADED") == "1";
+
+        /// <summary>
+        /// PROTOTYPE / TESTING ONLY. Comma- or semicolon-delimited list of task full names
+        /// (Namespace.TaskName) that should be forced to run in-process within the thread node
+        /// in multi-threaded mode, overriding the engine's routing decision.
+        /// See https://github.com/dotnet/msbuild/issues/13738.
+        /// </summary>
+        public readonly ICollection<string> ForceTasksInProcHostList = ParseTaskRoutingList(Environment.GetEnvironmentVariable("MSBUILDFORCETASKSINPROCHOSTLIST"));
+
+        /// <summary>
+        /// PROTOTYPE / TESTING ONLY. Comma- or semicolon-delimited list of task full names
+        /// (Namespace.TaskName) that should be forced to run in a transient (non-reused) TaskHost
+        /// process in multi-threaded mode, overriding the engine's routing decision.
+        /// See https://github.com/dotnet/msbuild/issues/13738.
+        /// </summary>
+        public readonly ICollection<string> ForceTasksTransientHostList = ParseTaskRoutingList(Environment.GetEnvironmentVariable("MSBUILDFORCETASKSTRANSIENTHOSTLIST"));
+
+        /// <summary>
+        /// PROTOTYPE / TESTING ONLY. Comma- or semicolon-delimited list of task full names
+        /// (Namespace.TaskName) that should be forced to run in a reusable (sidecar) TaskHost
+        /// process in multi-threaded mode, overriding the engine's routing decision.
+        /// See https://github.com/dotnet/msbuild/issues/13738.
+        /// </summary>
+        public readonly ICollection<string> ForceTasksSidecarHostList = ParseTaskRoutingList(Environment.GetEnvironmentVariable("MSBUILDFORCETASKSSIDECARHOSTLIST"));
+
+        /// <summary>
+        /// Parses a comma- or semicolon-delimited list of task full names into a case-insensitive set.
+        /// Returns an empty set when the value is null or empty.
+        /// </summary>
+        private static HashSet<string> ParseTaskRoutingList(string? value)
+        {
+            var set = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            if (!string.IsNullOrWhiteSpace(value))
+            {
+                foreach (string entry in value!.Split([',', ';'], StringSplitOptions.RemoveEmptyEntries))
+                {
+                    string trimmed = entry.Trim();
+                    if (trimmed.Length > 0)
+                    {
+                        set.Add(trimmed);
+                    }
+                }
+            }
+
+            return set;
+        }
 
         /// <summary>
         /// Do not expand wildcards that match a certain pattern


### PR DESCRIPTION
> [!WARNING]
> **This is a prototype, and this design is intended for testing only.** These
> environment variables are not a supported production configuration. They exist to
> unblock testing of multi-threaded execution against tasks whose source cannot be
> changed. The preferred, build-engineer-facing design is the `UsingTask` metadata
> approach tracked in a separate prototype PR.

Fixes part of #13738 (env-var design).

### Summary

Adds three **testing-only** environment variables that override MSBuild's
multi-threaded task-routing decision, keyed by task full name
(`Namespace.TaskName`). This mirrors the precedent of `MSBUILDFORCEALLTASKSOUTOFPROC`,
but lets a specific task be pinned to a specific execution location:

| Environment variable | Effect in multi-threaded mode |
| --- | --- |
| `MSBUILDFORCETASKSINPROCHOSTLIST` | Force the task **in-process** in the thread node |
| `MSBUILDFORCETASKSTRANSIENTHOSTLIST` | Force the task into a **transient** TaskHost that dies after execution |
| `MSBUILDFORCETASKSSIDECARHOSTLIST` | Force the task into a **reusable (sidecar)** TaskHost |

Each variable is a comma- or semicolon-delimited list of task full names. If a
task appears in more than one list, **in-proc wins over transient, which wins
over sidecar**. The override is inert outside multi-threaded mode.

### Motivation

Today the only way to keep a task that isn't multithread-safe out of the
multithreaded path (or to force a task somewhere for testing) is the hard-coded
engine list used for `Restore`. This gives testers an escape hatch to:

- route a task you don't control but are confident is MT-safe to the in-proc path
  to measure the perf benefit, and
- exercise all three routing targets (in-proc / sidecar / transient) without the
  complicated per-test host setup that existing tests need.

### Implementation

- `src/Framework/Traits.cs` — parse the three lists into case-insensitive sets.
- `src/Build/BackEnd/Components/RequestBuilder/TaskRouter.cs` — new
  `TaskHostRoutingOverride` enum and `GetEnvironmentRoutingOverride(Type)`.
- `src/Build/Instance/TaskFactories/AssemblyTaskFactory.cs` — apply the override
  in the existing routing block in `CreateTaskInstance`.
- Docs: `documentation/wiki/MSBuild-Environment-Variables.md`.

### Tests

Extended `TaskRouter_IntegrationTests.cs` with real multi-threaded builds that
verify each override target (asserting in-proc vs. TaskHost and, for transient,
a fresh process PID per build), that the override is ignored outside MT mode, and
that precedence resolves correctly.

### Notes for reviewers

This is intentionally a small, self-contained prototype so we can decide (per the
grooming notes on #13738) whether env vars are still worth keeping as a
debugging/testing convenience alongside the XML (`UsingTask`) knob.
