### PR TITLE
[Prototype] UsingTask TaskHostRouting attribute for multithreaded task routing

### DIFF
--- a/documentation/specs/multithreading/task-host-routing-override.md
+++ b/documentation/specs/multithreading/task-host-routing-override.md
@@ -1,0 +1,88 @@
+# UsingTask `TaskHostRouting` attribute (prototype)
+
+> **Status: prototype.** This document describes an experimental knob for overriding the
+> multi-threaded task-routing decision from project XML. It is being prototyped to inform the
+> design discussion on [dotnet/msbuild#13738](https://github.com/dotnet/msbuild/issues/13738).
+
+## Motivation
+
+In multi-threaded mode MSBuild routes each task to one of three execution locations:
+
+- **In-process** in the thread node (for tasks known to be thread-safe), or
+- a **sidecar** TaskHost process (long-lived, reused across invocations), or
+- a **transient** TaskHost process (terminates after each invocation).
+
+Today the routing decision is made entirely by the engine: tasks marked with
+`MSBuildMultiThreadableTaskAttribute` run in-process, everything else runs in a sidecar, and a
+hard-coded engine list (currently only `NuGet.Build.Tasks.RestoreTask`) forces a transient host.
+
+A **build/repo engineer** sometimes needs to override this per task without changing the task
+assembly — for example to pin a task they trust to the in-proc path for performance, or to isolate
+a task that misbehaves in a reused host. This is the XML counterpart to the environment-variable
+escape hatch; it is aimed at the person authoring the build, targets the same three locations, and
+travels with the project rather than the shell environment.
+
+## Design
+
+A new optional attribute `TaskHostRouting` is added to the `UsingTask` element, analogous to the
+existing `Runtime` and `Architecture` attributes.
+
+```xml
+<UsingTask TaskName="My.Trusted.Task"
+           AssemblyFile="MyTasks.dll"
+           TaskHostRouting="InProc" />
+
+<UsingTask TaskName="Some.Legacy.Task"
+           AssemblyFile="Legacy.dll"
+           TaskHostRouting="Transient" />
+```
+
+### Allowed values
+
+| Value | Effect in multi-threaded mode |
+| --- | --- |
+| `InProc` | Force the task in-process within the thread node. Asserts the task is thread-safe. |
+| `Sidecar` | Force the task into a reusable (sidecar) TaskHost process. |
+| `Transient` | Force the task into a transient TaskHost that terminates after execution. |
+| *(unset)* | No override; the engine applies its default routing decision. |
+
+Values are matched case-insensitively. Any other value is rejected during evaluation with the
+standard `InvalidAttributeValue` diagnostic. The override only has an effect in multi-threaded mode;
+in single-proc / multi-proc builds it is inert.
+
+### Precedence vs. engine routing
+
+`TaskHostRouting` takes precedence over the attribute/interface-based engine decision:
+
+- `InProc` runs the task in-process even if it lacks `MSBuildMultiThreadableTaskAttribute`.
+- `Sidecar` / `Transient` run the task out of process even if it is marked thread-safe.
+- `Transient` also overrides the sidecar-vs-transient choice, giving a fresh process per invocation
+  (the same mechanism used for the built-in `RestoreTask` workaround).
+
+### Interaction with override `UsingTask`
+
+Because `TaskHostRouting` is an ordinary `UsingTask` attribute, the existing override-`UsingTask`
+mechanism applies unchanged: a later (or `Override="true"`) `UsingTask` registration for the same
+task name wins, including its `TaskHostRouting` value. This lets a repo-level `.props`/`.targets`
+pin routing for a task defined elsewhere.
+
+## Implementation notes
+
+- `XMakeAttributes` defines the attribute name, the allowed value set, and
+  `IsValidTaskHostRoutingValue`.
+- `ProjectParser` accepts the attribute on `UsingTask`; `ProjectUsingTaskElement` exposes it as the
+  `TaskHostRouting` property.
+- `TaskRegistry` expands and validates the value, stores it on the `RegisteredTaskRecord` (and
+  serializes it so it survives out-of-proc node marshaling), and passes it to
+  `AssemblyTaskFactory.InitializeFactory`.
+- `AssemblyTaskFactory` parses it into a `TaskHostRoutingOverride` (via `TaskRouter.ParseRoutingOverride`)
+  and applies it in `CreateTaskInstance`, alongside the existing routing logic.
+
+## Open questions
+
+1. Attribute/value naming (`TaskHostRouting` vs. e.g. `Threading`/`ExecutionLocation`; `InProc` vs.
+   `InProcess`).
+2. Whether `InProc` should hard-fail (vs. silently fall back to a host) when the assembly could not
+   be loaded in-process for another reason (e.g. a `Runtime`/`Architecture` mismatch).
+3. Whether to keep the environment-variable escape hatch as a testing convenience alongside this XML
+   knob (see #13738).

--- a/src/Build.UnitTests/BackEnd/TaskRouter_IntegrationTests.cs
+++ b/src/Build.UnitTests/BackEnd/TaskRouter_IntegrationTests.cs
@@ -635,6 +635,206 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
             logger.FullLog.ShouldContain("RestoreTask executed");
         }
 
+        #region UsingTask TaskHostRouting attribute (prototype) tests
+
+        /// <summary>
+        /// PROTOTYPE. A task that would normally be routed to a TaskHost (no thread-safety attribute)
+        /// is forced in-process by TaskHostRouting="InProc" on its UsingTask.
+        /// </summary>
+        [Fact]
+        public void UsingTaskRouting_InProc_RunsInProcess_InMultiThreadedMode()
+        {
+            string projectContent = CreateTestProjectWithRouting("PidLoggingTestTask", "InProc");
+            string projectFile = Path.Combine(_testProjectsDir, "RoutingInProc.proj");
+            File.WriteAllText(projectFile, projectContent);
+
+            MockLogger logger = BuildRoutingProject(projectFile, multiThreaded: true, out BuildResult result);
+
+            result.OverallResult.ShouldBe(BuildResultCode.Success);
+            TaskRouterTestHelper.AssertTaskRanInProcess(logger, "PidLoggingTestTask");
+
+            int[] pids = ExtractReportedPids(logger.FullLog, "PidLoggingTestTask");
+            pids.Length.ShouldBe(1, $"Expected one invocation. Log:{Environment.NewLine}{logger.FullLog}");
+            pids[0].ShouldBe(Process.GetCurrentProcess().Id, "Task pinned to InProc must run in the build process.");
+        }
+
+        /// <summary>
+        /// PROTOTYPE. A task that would normally run in-process (marked with the thread-safety attribute)
+        /// is forced into a sidecar TaskHost by TaskHostRouting="Sidecar".
+        /// </summary>
+        [Fact]
+        public void UsingTaskRouting_Sidecar_RunsInTaskHost_InMultiThreadedMode()
+        {
+            string projectContent = CreateTestProjectWithRouting("PidLoggingMultiThreadableTestTask", "Sidecar");
+            string projectFile = Path.Combine(_testProjectsDir, "RoutingSidecar.proj");
+            File.WriteAllText(projectFile, projectContent);
+
+            MockLogger logger = BuildRoutingProject(projectFile, multiThreaded: true, out BuildResult result);
+
+            result.OverallResult.ShouldBe(BuildResultCode.Success);
+            TaskRouterTestHelper.AssertTaskUsedTaskHost(logger, "PidLoggingMultiThreadableTestTask");
+
+            int[] pids = ExtractReportedPids(logger.FullLog, "PidLoggingMultiThreadableTestTask");
+            pids.Length.ShouldBe(1, $"Expected one invocation. Log:{Environment.NewLine}{logger.FullLog}");
+            pids[0].ShouldNotBe(Process.GetCurrentProcess().Id, "Task pinned to Sidecar must run out of process.");
+        }
+
+        /// <summary>
+        /// PROTOTYPE. A task pinned to a transient TaskHost by TaskHostRouting="Transient" gets a fresh
+        /// process on each build, even with node reuse enabled.
+        /// </summary>
+        [Fact]
+        public void UsingTaskRouting_Transient_GetsFreshProcess_InMultiThreadedMode()
+        {
+            string projectContent = CreateTestProjectWithRouting("PidLoggingMultiThreadableTestTask", "Transient");
+            string projectFile = Path.Combine(_testProjectsDir, "RoutingTransient.proj");
+            File.WriteAllText(projectFile, projectContent);
+
+            var logger = new MockLogger(_output);
+            var buildParameters = new BuildParameters
+            {
+                MultiThreaded = true,
+                Loggers = [logger],
+                DisableInProcNode = false,
+
+                // Reuse stays ON: a transient TaskHost must still die between builds.
+                EnableNodeReuse = true,
+            };
+
+            var buildRequestData = new BuildRequestData(
+                projectFile,
+                new Dictionary<string, string>(),
+                null,
+                ["TestTarget"],
+                null);
+
+            BuildManager buildManager = BuildManager.DefaultBuildManager;
+            BuildResult result1 = buildManager.Build(buildParameters, buildRequestData);
+            BuildResult result2 = buildManager.Build(buildParameters, buildRequestData);
+
+            result1.OverallResult.ShouldBe(BuildResultCode.Success);
+            result2.OverallResult.ShouldBe(BuildResultCode.Success);
+            TaskRouterTestHelper.AssertTaskUsedTaskHost(logger, "PidLoggingMultiThreadableTestTask");
+
+            int[] pids = ExtractReportedPids(logger.FullLog, "PidLoggingMultiThreadableTestTask");
+            pids.Length.ShouldBe(2, $"Expected two invocations to log a PID. Log:{Environment.NewLine}{logger.FullLog}");
+            pids[0].ShouldNotBe(pids[1], "Each build must spawn a fresh transient TaskHost.");
+            pids.ShouldNotContain(Process.GetCurrentProcess().Id, "Transient TaskHost must be out-of-process.");
+        }
+
+        /// <summary>
+        /// PROTOTYPE. The TaskHostRouting override has no effect outside multi-threaded mode.
+        /// </summary>
+        [Fact]
+        public void UsingTaskRouting_Ignored_WhenNotMultiThreaded()
+        {
+            string projectContent = CreateTestProjectWithRouting("PidLoggingMultiThreadableTestTask", "Sidecar");
+            string projectFile = Path.Combine(_testProjectsDir, "RoutingIgnored.proj");
+            File.WriteAllText(projectFile, projectContent);
+
+            MockLogger logger = BuildRoutingProject(projectFile, multiThreaded: false, out BuildResult result);
+
+            result.OverallResult.ShouldBe(BuildResultCode.Success);
+            TaskRouterTestHelper.AssertTaskRanInProcess(logger, "PidLoggingMultiThreadableTestTask");
+        }
+
+        /// <summary>
+        /// PROTOTYPE. An invalid TaskHostRouting value is rejected during evaluation.
+        /// </summary>
+        [Fact]
+        public void UsingTaskRouting_InvalidValue_FailsEvaluation()
+        {
+            string projectContent = CreateTestProjectWithRouting("PidLoggingTestTask", "Bogus");
+            string projectFile = Path.Combine(_testProjectsDir, "RoutingInvalid.proj");
+            File.WriteAllText(projectFile, projectContent);
+
+            MockLogger logger = BuildRoutingProject(projectFile, multiThreaded: true, out BuildResult result);
+
+            result.OverallResult.ShouldBe(BuildResultCode.Failure);
+
+            // The attribute name is an invariant token in the InvalidAttributeValue diagnostic.
+            logger.FullLog.ShouldContain("TaskHostRouting");
+        }
+
+        /// <summary>
+        /// PROTOTYPE. TaskHostRouting values map to the expected routing override (case-insensitive),
+        /// and unknown/empty values yield no override.
+        /// </summary>
+        [Theory]
+        [InlineData("InProc", nameof(TaskHostRoutingOverride.InProc))]
+        [InlineData("inproc", nameof(TaskHostRoutingOverride.InProc))]
+        [InlineData("Sidecar", nameof(TaskHostRoutingOverride.Sidecar))]
+        [InlineData("Transient", nameof(TaskHostRoutingOverride.Transient))]
+        [InlineData("", nameof(TaskHostRoutingOverride.None))]
+        [InlineData("Bogus", nameof(TaskHostRoutingOverride.None))]
+        public void ParseRoutingOverride_MapsValues(string value, string expected)
+        {
+            TaskRouter.ParseRoutingOverride(value).ToString().ShouldBe(expected);
+        }
+
+        /// <summary>
+        /// PROTOTYPE. The TaskHostRouting attribute round-trips through the construction object model.
+        /// </summary>
+        [Fact]
+        public void ProjectUsingTaskElement_TaskHostRouting_RoundTrips()
+        {
+            var root = Microsoft.Build.Construction.ProjectRootElement.Create();
+            Microsoft.Build.Construction.ProjectUsingTaskElement usingTask = root.AddUsingTask("MyTask", "MyAssembly.dll", null);
+
+            usingTask.TaskHostRouting.ShouldBe(string.Empty);
+
+            usingTask.TaskHostRouting = "Sidecar";
+            usingTask.TaskHostRouting.ShouldBe("Sidecar");
+        }
+
+        #endregion
+
+        private MockLogger BuildRoutingProject(string projectFile, bool multiThreaded, out BuildResult result)
+        {
+            var logger = new MockLogger(_output);
+            var buildParameters = new BuildParameters
+            {
+                MultiThreaded = multiThreaded,
+                Loggers = [logger],
+                DisableInProcNode = false,
+                EnableNodeReuse = false,
+            };
+
+            var buildRequestData = new BuildRequestData(
+                projectFile,
+                new Dictionary<string, string>(),
+                null,
+                ["TestTarget"],
+                null);
+
+            BuildManager buildManager = BuildManager.DefaultBuildManager;
+            result = buildManager.Build(buildParameters, buildRequestData);
+            return logger;
+        }
+
+        private string CreateTestProjectWithRouting(string taskName, string routing)
+        {
+            return $@"
+<Project>
+    <UsingTask TaskName=""{taskName}"" AssemblyFile=""{Assembly.GetExecutingAssembly().Location}"" TaskHostRouting=""{routing}"" />
+
+    <Target Name=""TestTarget"">
+        <{taskName} />
+    </Target>
+</Project>";
+        }
+
+        private static int[] ExtractReportedPids(string log, string taskName)
+        {
+            var pids = new List<int>();
+            foreach (Match m in Regex.Matches(log, Regex.Escape(taskName) + @" executed in PID=(\d+)"))
+            {
+                pids.Add(int.Parse(m.Groups[1].Value));
+            }
+
+            return pids.ToArray();
+        }
+
         private string CreateTestProject(string taskName, string taskClass)
         {
             return $@"
@@ -728,6 +928,37 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
         public override bool Execute()
         {
             Log.LogMessage(MessageImportance.High, "TaskWithAttribute executed");
+            return true;
+        }
+    }
+
+    /// <summary>
+    /// PROTOTYPE. A non-enlightened task (no attribute, normally routed to a TaskHost in
+    /// multi-threaded mode) that logs the PID of the process it runs in, so tests can verify the
+    /// UsingTask TaskHostRouting override actually changed where it executed.
+    /// </summary>
+    public class PidLoggingTestTask : Task
+    {
+        public override bool Execute()
+        {
+            Log.LogMessage(MessageImportance.High, $"PidLoggingTestTask executed in PID={Process.GetCurrentProcess().Id}");
+            return true;
+        }
+    }
+
+    /// <summary>
+    /// PROTOTYPE. A task marked with MSBuildMultiThreadableTaskAttribute (normally runs in-process in
+    /// multi-threaded mode) that logs its PID, used to verify the UsingTask TaskHostRouting override
+    /// can push it into a sidecar or transient TaskHost.
+    /// </summary>
+#pragma warning disable CS0436 // Type conflicts with imported type - intentional for testing
+    [MSBuildMultiThreadableTask]
+#pragma warning restore CS0436
+    public class PidLoggingMultiThreadableTestTask : Task
+    {
+        public override bool Execute()
+        {
+            Log.LogMessage(MessageImportance.High, $"PidLoggingMultiThreadableTestTask executed in PID={Process.GetCurrentProcess().Id}");
             return true;
         }
     }

--- a/src/Build/BackEnd/Components/RequestBuilder/TaskRouter.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TaskRouter.cs
@@ -3,9 +3,41 @@
 
 using System;
 using System.Collections.Concurrent;
+using Microsoft.Build.Shared;
 
 namespace Microsoft.Build.BackEnd
 {
+    /// <summary>
+    /// Describes an explicit override of the engine's multi-threaded task-routing decision.
+    /// </summary>
+    /// <remarks>
+    /// PROTOTYPE. In this design the override is expressed by the <c>TaskHostRouting</c> metadata on a
+    /// <c>UsingTask</c> element. It only has meaning in multi-threaded mode.
+    /// See https://github.com/dotnet/msbuild/issues/13738.
+    /// </remarks>
+    internal enum TaskHostRoutingOverride
+    {
+        /// <summary>
+        /// No override; the engine applies its default routing decision.
+        /// </summary>
+        None,
+
+        /// <summary>
+        /// Force the task to run in-process within the thread node.
+        /// </summary>
+        InProc,
+
+        /// <summary>
+        /// Force the task to run in a reusable (sidecar) TaskHost process.
+        /// </summary>
+        Sidecar,
+
+        /// <summary>
+        /// Force the task to run in a transient TaskHost process that terminates after execution.
+        /// </summary>
+        Transient,
+    }
+
     /// <summary>
     /// Determines where a task should be executed in multi-threaded mode.
     /// In multi-threaded execution mode, tasks implementing IMultiThreadableTask or marked with
@@ -112,6 +144,38 @@ namespace Microsoft.Build.BackEnd
             }
 
             return string.Equals(fullName, TaskRequiringTransientTaskHostFullName, StringComparison.Ordinal);
+        }
+
+        /// <summary>
+        /// PROTOTYPE. Maps the value of a <c>UsingTask</c> <c>TaskHostRouting</c> attribute to a
+        /// <see cref="TaskHostRoutingOverride"/>. Recognizes InProc / Sidecar / Transient case-insensitively;
+        /// any other value (including empty) yields <see cref="TaskHostRoutingOverride.None"/>.
+        /// </summary>
+        /// <param name="taskHostRouting">The attribute value from the UsingTask element.</param>
+        /// <returns>The corresponding routing override.</returns>
+        public static TaskHostRoutingOverride ParseRoutingOverride(string taskHostRouting)
+        {
+            if (string.IsNullOrEmpty(taskHostRouting))
+            {
+                return TaskHostRoutingOverride.None;
+            }
+
+            if (string.Equals(taskHostRouting, XMakeAttributes.TaskHostRoutingValues.inProc, StringComparison.OrdinalIgnoreCase))
+            {
+                return TaskHostRoutingOverride.InProc;
+            }
+
+            if (string.Equals(taskHostRouting, XMakeAttributes.TaskHostRoutingValues.sidecar, StringComparison.OrdinalIgnoreCase))
+            {
+                return TaskHostRoutingOverride.Sidecar;
+            }
+
+            if (string.Equals(taskHostRouting, XMakeAttributes.TaskHostRoutingValues.transient, StringComparison.OrdinalIgnoreCase))
+            {
+                return TaskHostRoutingOverride.Transient;
+            }
+
+            return TaskHostRoutingOverride.None;
         }
 
         /// <summary>

--- a/src/Build/Construction/ProjectUsingTaskElement.cs
+++ b/src/Build/Construction/ProjectUsingTaskElement.cs
@@ -143,6 +143,22 @@ namespace Microsoft.Build.Construction
         }
 
         /// <summary>
+        /// PROTOTYPE. Gets and sets the value of the TaskHostRouting attribute, which pins the task to a
+        /// specific execution location (InProc, Sidecar, or Transient) in multi-threaded mode.
+        /// Returns empty string if it is not present.
+        /// See https://github.com/dotnet/msbuild/issues/13738.
+        /// </summary>
+        public string TaskHostRouting
+        {
+            get => GetAttributeValue(XMakeAttributes.taskHostRouting);
+
+            set
+            {
+                SetOrRemoveAttribute(XMakeAttributes.taskHostRouting, value, "Set usingtask TaskHostRouting {0}", value);
+            }
+        }
+
+        /// <summary>
         /// Get any contained TaskElement.
         /// </summary>
         public ProjectUsingTaskBodyElement TaskBody
@@ -200,6 +216,11 @@ namespace Microsoft.Build.Construction
         /// Location of the Override attribute, if any
         /// </summary>
         public ElementLocation OverrideLocation => GetAttributeLocation(XMakeAttributes.overrideUsingTask);
+
+        /// <summary>
+        /// PROTOTYPE. Location of the TaskHostRouting attribute, if any
+        /// </summary>
+        public ElementLocation TaskHostRoutingLocation => GetAttributeLocation(XMakeAttributes.taskHostRouting);
 
         /// <summary>
         /// Convenience method that picks a location based on a heuristic:

--- a/src/Build/Evaluation/ProjectParser.cs
+++ b/src/Build/Evaluation/ProjectParser.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Build.Construction
         /// <summary>
         /// Valid attributes on usingtask element
         /// </summary>
-        private static readonly HashSet<string> ValidAttributesOnUsingTask = new HashSet<string> { XMakeAttributes.condition, XMakeAttributes.label, XMakeAttributes.taskName, XMakeAttributes.assemblyFile, XMakeAttributes.assemblyName, XMakeAttributes.taskFactory, XMakeAttributes.architecture, XMakeAttributes.runtime, XMakeAttributes.requiredPlatform, XMakeAttributes.requiredRuntime, XMakeAttributes.overrideUsingTask };
+        private static readonly HashSet<string> ValidAttributesOnUsingTask = new HashSet<string> { XMakeAttributes.condition, XMakeAttributes.label, XMakeAttributes.taskName, XMakeAttributes.assemblyFile, XMakeAttributes.assemblyName, XMakeAttributes.taskFactory, XMakeAttributes.architecture, XMakeAttributes.runtime, XMakeAttributes.requiredPlatform, XMakeAttributes.requiredRuntime, XMakeAttributes.overrideUsingTask, XMakeAttributes.taskHostRouting };
 
         /// <summary>
         /// Valid attributes on target element

--- a/src/Build/Instance/TaskFactories/AssemblyTaskFactory.cs
+++ b/src/Build/Instance/TaskFactories/AssemblyTaskFactory.cs
@@ -63,6 +63,12 @@ namespace Microsoft.Build.BackEnd
         /// </summary>
         private TaskHostParameters _factoryIdentityParameters;
 
+        /// <summary>
+        /// PROTOTYPE. Explicit multi-threaded routing override declared via the UsingTask
+        /// TaskHostRouting attribute. See https://github.com/dotnet/msbuild/issues/13738.
+        /// </summary>
+        private TaskHostRoutingOverride _taskHostRoutingOverride = TaskHostRoutingOverride.None;
+
 
         #endregion
 
@@ -236,10 +242,14 @@ namespace Microsoft.Build.BackEnd
             bool taskHostExplicitlyRequested,
             LoggingContext targetLoggingContext,
             ElementLocation elementLocation,
-            string taskProjectFile)
+            string taskProjectFile,
+            string taskHostRouting = null)
         {
             ArgumentNullException.ThrowIfNull(loadInfo);
             VerifyThrowIdentityParametersValid(taskFactoryIdentityParameters, elementLocation, taskName, "Runtime", "Architecture");
+
+            // PROTOTYPE: capture the UsingTask TaskHostRouting override (in-proc / sidecar / transient).
+            _taskHostRoutingOverride = TaskRouter.ParseRoutingOverride(taskHostRouting);
 
             bool taskHostParamsMatchCurrentProc = true;
             if (!taskFactoryIdentityParameters.IsEmpty)
@@ -326,11 +336,25 @@ namespace Microsoft.Build.BackEnd
             }
 
             // Multi-threaded mode routing: Determine if non-thread-safe tasks need TaskHost isolation.
+            // PROTOTYPE: the UsingTask TaskHostRouting attribute may explicitly override the routing
+            // decision (in-proc / transient / sidecar). See https://github.com/dotnet/msbuild/issues/13738.
+            bool isMultiThreaded = buildComponentHost?.BuildParameters?.MultiThreaded == true;
+            TaskHostRoutingOverride routingOverride = isMultiThreaded ? _taskHostRoutingOverride : TaskHostRoutingOverride.None;
+
             if (!useTaskFactory
-                && _loadedType?.Type != null
-                && buildComponentHost?.BuildParameters?.MultiThreaded == true)
+                && isMultiThreaded
+                && _loadedType?.Type != null)
             {
-                if (TaskRouter.NeedsTaskHostInMultiThreadedMode(_loadedType.Type))
+                bool needsTaskHost = routingOverride switch
+                {
+                    // An explicit in-proc override asserts the task is safe to run in the thread node.
+                    TaskHostRoutingOverride.InProc => false,
+                    TaskHostRoutingOverride.Sidecar => true,
+                    TaskHostRoutingOverride.Transient => true,
+                    _ => TaskRouter.NeedsTaskHostInMultiThreadedMode(_loadedType.Type),
+                };
+
+                if (needsTaskHost)
                 {
                     useTaskFactory = true;
                 }
@@ -340,10 +364,11 @@ namespace Microsoft.Build.BackEnd
             // (e.g., NuGet RestoreTask). In MT mode or when MSBuild server is active, these tasks
             // must run in a transient (non-sidecar) TaskHost so static state is cleaned up after
             // each invocation. See https://github.com/dotnet/msbuild/issues/13315
+            // An explicit Transient routing override (prototype) has the same effect.
             bool forceTransientTaskHost = false;
-            if (_loadedType?.Type != null && TaskRouter.RequiresTransientTaskHost(_loadedType.Type))
+            if (_loadedType?.Type != null
+                && (routingOverride == TaskHostRoutingOverride.Transient || TaskRouter.RequiresTransientTaskHost(_loadedType.Type)))
             {
-                bool isMultiThreaded = buildComponentHost?.BuildParameters?.MultiThreaded == true;
                 bool isLongLivedHost = buildComponentHost?.BuildParameters?.IsLongLivedHost == true;
 
                 if (isMultiThreaded || isLongLivedHost)

--- a/src/Build/Instance/TaskRegistry.cs
+++ b/src/Build/Instance/TaskRegistry.cs
@@ -423,6 +423,17 @@ namespace Microsoft.Build.Execution
             string architecture = expander.ExpandIntoStringLeaveEscaped(projectUsingTaskXml.Architecture, expanderOptions, projectUsingTaskXml.ArchitectureLocation);
             string overrideUsingTask = expander.ExpandIntoStringLeaveEscaped(projectUsingTaskXml.Override, expanderOptions, projectUsingTaskXml.OverrideLocation);
 
+            // PROTOTYPE: TaskHostRouting pins the task to a specific execution location in multi-threaded
+            // mode. See https://github.com/dotnet/msbuild/issues/13738.
+            string taskHostRouting = expander.ExpandIntoStringLeaveEscaped(projectUsingTaskXml.TaskHostRouting, expanderOptions, projectUsingTaskXml.TaskHostRoutingLocation);
+            ProjectErrorUtilities.VerifyThrowInvalidProject(
+                XMakeAttributes.IsValidTaskHostRoutingValue(taskHostRouting),
+                projectUsingTaskXml.TaskHostRoutingLocation,
+                "InvalidAttributeValue",
+                taskHostRouting,
+                XMakeAttributes.taskHostRouting,
+                XMakeElements.usingTask);
+
             if ((runtime != string.Empty) || (architecture != string.Empty))
             {
                 taskFactoryParameters = new TaskHostParameters(
@@ -438,7 +449,8 @@ namespace Microsoft.Build.Execution
                 parameterGroupAndTaskElementRecord,
                 loggingContext,
                 projectUsingTaskXml,
-                ConversionUtilities.ValidBooleanTrue(overrideUsingTask));
+                ConversionUtilities.ValidBooleanTrue(overrideUsingTask),
+                taskHostRouting);
         }
 
         /// <summary>
@@ -679,7 +691,8 @@ namespace Microsoft.Build.Execution
             RegisteredTaskRecord.ParameterGroupAndTaskElementRecord inlineTaskRecord,
             LoggingContext loggingContext,
             ProjectUsingTaskElement projectUsingTaskInXml,
-            bool overrideTask)
+            bool overrideTask,
+            string taskHostRouting)
         {
             Assumed.NotNullOrEmpty(taskName);
             Assumed.NotNull(assemblyLoadInfo);
@@ -707,7 +720,8 @@ namespace Microsoft.Build.Execution
                 taskFactoryParameters,
                 inlineTaskRecord,
                 Interlocked.Increment(ref _nextRegistrationOrderId),
-                projectUsingTaskInXml.ContainingProject.FullPath);
+                projectUsingTaskInXml.ContainingProject.FullPath,
+                taskHostRouting);
 
             if (overrideTask)
             {
@@ -1099,6 +1113,13 @@ namespace Microsoft.Build.Execution
             private string _definingFileFullPath;
 
             /// <summary>
+            /// PROTOTYPE. The value of the UsingTask TaskHostRouting attribute, which pins the task to a
+            /// specific execution location (InProc / Sidecar / Transient) in multi-threaded mode.
+            /// Empty when unspecified. See https://github.com/dotnet/msbuild/issues/13738.
+            /// </summary>
+            private string _taskHostRouting = string.Empty;
+
+            /// <summary>
             /// Execution statistics for the tasks.
             /// Not translatable - the statistics are anyway expected to be reset after each project request.
             /// </summary>
@@ -1153,7 +1174,8 @@ namespace Microsoft.Build.Execution
                 in TaskHostParameters taskFactoryParameters,
                 ParameterGroupAndTaskElementRecord inlineTask,
                 int registrationOrderId,
-                string containingFileFullPath)
+                string containingFileFullPath,
+                string taskHostRouting = null)
             {
                 ArgumentNullException.ThrowIfNull(assemblyLoadInfo, "AssemblyLoadInfo");
                 _registeredName = registeredName;
@@ -1162,6 +1184,7 @@ namespace Microsoft.Build.Execution
                 _taskIdentity = new RegisteredTaskIdentity(registeredName, taskFactoryParameters);
                 _parameterGroupAndTaskBody = inlineTask;
                 _registrationOrderId = registrationOrderId;
+                _taskHostRouting = taskHostRouting ?? string.Empty;
 
                 if (string.IsNullOrEmpty(taskFactory))
                 {
@@ -1252,6 +1275,16 @@ namespace Microsoft.Build.Execution
             {
                 [DebuggerStepThrough]
                 get => _taskFactoryParameters;
+            }
+
+            /// <summary>
+            /// PROTOTYPE. Gets the value of the UsingTask TaskHostRouting attribute (empty when unspecified).
+            /// See https://github.com/dotnet/msbuild/issues/13738.
+            /// </summary>
+            internal string TaskHostRouting
+            {
+                [DebuggerStepThrough]
+                get => _taskHostRouting;
             }
 
             /// <summary>
@@ -1435,7 +1468,7 @@ namespace Microsoft.Build.Execution
 
                         // Create an instance of the internal assembly task factory, it has the error handling built into its methods.
                         AssemblyTaskFactory taskFactory = new AssemblyTaskFactory();
-                        loadedType = taskFactory.InitializeFactory(taskFactoryLoadInfo, RegisteredName, ParameterGroupAndTaskBody.UsingTaskParameters, ParameterGroupAndTaskBody.InlineTaskXmlBody, TaskFactoryParameters, launchTaskHost, targetLoggingContext, elementLocation, taskProjectFile);
+                        loadedType = taskFactory.InitializeFactory(taskFactoryLoadInfo, RegisteredName, ParameterGroupAndTaskBody.UsingTaskParameters, ParameterGroupAndTaskBody.InlineTaskXmlBody, TaskFactoryParameters, launchTaskHost, targetLoggingContext, elementLocation, taskProjectFile, TaskHostRouting);
                         factory = taskFactory;
                     }
                     else
@@ -1877,6 +1910,7 @@ namespace Microsoft.Build.Execution
                 translator.Translate(ref _registrationOrderId);
                 translator.Translate(ref _definingFileFullPath);
                 translator.Translate(ref _taskFactoryParameters);
+                translator.Translate(ref _taskHostRouting);
             }
 
             internal static RegisteredTaskRecord FactoryForDeserialization(ITranslator translator)

--- a/src/Framework/XMakeAttributes.cs
+++ b/src/Framework/XMakeAttributes.cs
@@ -56,6 +56,13 @@ namespace Microsoft.Build.Shared
         internal const string architecture = "Architecture";
         internal const string msbuildArchitecture = "MSBuildArchitecture";
         internal const string taskFactory = "TaskFactory";
+
+        /// <summary>
+        /// PROTOTYPE. UsingTask attribute overriding the multi-threaded task-routing decision.
+        /// See https://github.com/dotnet/msbuild/issues/13738.
+        /// </summary>
+        internal const string taskHostRouting = "TaskHostRouting";
+
         internal const string parameterType = "ParameterType";
         internal const string required = "Required";
         internal const string output = "Output";
@@ -93,6 +100,23 @@ namespace Microsoft.Build.Shared
             internal const string any = "*";
         }
 
+        /// <summary>
+        /// PROTOTYPE. Allowed values for the UsingTask <c>TaskHostRouting</c> attribute, which pins a
+        /// task to a specific execution location in multi-threaded mode.
+        /// See https://github.com/dotnet/msbuild/issues/13738.
+        /// </summary>
+        internal struct TaskHostRoutingValues
+        {
+            /// <summary>Run the task in-process within the thread node.</summary>
+            internal const string inProc = "InProc";
+
+            /// <summary>Run the task in a reusable (sidecar) TaskHost process.</summary>
+            internal const string sidecar = "Sidecar";
+
+            /// <summary>Run the task in a transient TaskHost process that terminates after execution.</summary>
+            internal const string transient = "Transient";
+        }
+
         /////////////////////////////////////////////////////////////////////////////////////////////
         // If we ever add a new MSBuild namespace (or change this one) we must update the registry key
         // we set during install to disable the XSL debugger from working on MSBuild format files.
@@ -108,6 +132,8 @@ namespace Microsoft.Build.Shared
         private static readonly HashSet<string> ValidMSBuildRuntimeValues = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { MSBuildRuntimeValues.clr2, MSBuildRuntimeValues.clr4, MSBuildRuntimeValues.currentRuntime, MSBuildRuntimeValues.net, MSBuildRuntimeValues.any };
 
         private static readonly HashSet<string> ValidMSBuildArchitectureValues = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { MSBuildArchitectureValues.x86, MSBuildArchitectureValues.x64, MSBuildArchitectureValues.arm64, MSBuildArchitectureValues.currentArchitecture, MSBuildArchitectureValues.any };
+
+        private static readonly HashSet<string> ValidTaskHostRoutingValues = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { TaskHostRoutingValues.inProc, TaskHostRoutingValues.sidecar, TaskHostRoutingValues.transient };
 
         /// <summary>
         /// Returns true if and only if the specified attribute is one of the attributes that the engine specifically recognizes
@@ -153,6 +179,12 @@ namespace Microsoft.Build.Shared
         /// Returns true if the given string is a valid member of the MSBuildArchitectureValues set
         /// </summary>
         internal static bool IsValidMSBuildArchitectureValue(string architecture) => architecture == null || ValidMSBuildArchitectureValues.Contains(architecture);
+
+        /// <summary>
+        /// PROTOTYPE. Returns true if the given string is a valid member of the TaskHostRoutingValues set.
+        /// An empty or null value means "unspecified" and is treated as valid.
+        /// </summary>
+        internal static bool IsValidTaskHostRoutingValue(string taskHostRouting) => string.IsNullOrEmpty(taskHostRouting) || ValidTaskHostRoutingValues.Contains(taskHostRouting);
 
         /// <summary>
         /// Compares two members of MSBuildRuntimeValues, returning true if they count as a match, and false otherwise.


### PR DESCRIPTION
> [!NOTE]
> **This is a prototype** to inform the design discussion on #13738. It implements the
> preferred, build-engineer-facing XML knob called out in the grooming notes and is intended
> to be evaluated alongside the environment-variable prototype (separate PR).

Implements the `UsingTask` metadata design from #13738.

### Summary

Adds an optional `TaskHostRouting` attribute to the `<UsingTask>` element — analogous to the
existing `Runtime` and `Architecture` attributes — that overrides MSBuild's multi-threaded
task-routing decision for a specific task without touching the task assembly.

```xml
<UsingTask TaskName="My.Trusted.Task" AssemblyFile="MyTasks.dll" TaskHostRouting="InProc" />
<UsingTask TaskName="Some.Legacy.Task" AssemblyFile="Legacy.dll" TaskHostRouting="Transient" />
```

| Value | Effect in multi-threaded mode |
| --- | --- |
| `InProc` | Force the task **in-process** in the thread node (asserts thread-safety) |
| `Sidecar` | Force the task into a **reusable (sidecar)** TaskHost |
| `Transient` | Force the task into a **transient** TaskHost that terminates after execution |
| *(unset)* | No override; engine default routing |

Values are case-insensitive. Invalid values are rejected during evaluation with the standard
`InvalidAttributeValue` diagnostic. The override is inert outside multi-threaded mode, and it
composes with the existing override-`UsingTask` mechanism (a later/`Override="true"` registration
wins, carrying its `TaskHostRouting`).

### Why XML (per the grooming notes on #13738)

The persona here is the **build/repo engineer**, not the end developer. Deciding "is this task
safe in-proc?" or "does it tolerate a transient host?" is specialized reasoning that belongs with
the build definition and travels with the repo, rather than a copy/pasteable environment variable.
This mirrors the precedent set by override-`UsingTask`.

### Implementation

- `src/Framework/XMakeAttributes.cs` — attribute name, allowed-value set, `IsValidTaskHostRoutingValue`.
- `src/Build/Evaluation/ProjectParser.cs` — accept the attribute on `UsingTask`.
- `src/Build/Construction/ProjectUsingTaskElement.cs` — `TaskHostRouting` property + location.
- `src/Build/Instance/TaskRegistry.cs` — expand + validate, store on `RegisteredTaskRecord`
  (serialized for out-of-proc nodes), and pass to the factory.
- `src/Build/Instance/TaskFactories/AssemblyTaskFactory.cs` — parse into a `TaskHostRoutingOverride`
  and apply in `CreateTaskInstance`.
- Spec: `documentation/specs/multithreading/task-host-routing-override.md`.

### Tests

Extended `TaskRouter_IntegrationTests.cs` with real multi-threaded builds covering each routing
value (in-proc vs. TaskHost, and fresh-process-per-build for transient), an invalid-value failure,
the not-multi-threaded no-op, value-parsing, and an object-model round-trip. All 26 tests in the
class pass.

### Open questions (see spec)

1. Attribute/value naming (`TaskHostRouting`, `InProc`).
2. Whether `InProc` should hard-fail vs. silently fall back when the assembly can't load in-proc
   for another reason (e.g. `Runtime`/`Architecture` mismatch).
3. Whether to keep the env-var escape hatch as a testing convenience alongside this knob.
