### PR TITLE
Harden coordinator client lifecycle races

### DIFF
--- a/src/Build/BackEnd/BuildManager/CoordinatorClient.Connection.cs
+++ b/src/Build/BackEnd/BuildManager/CoordinatorClient.Connection.cs
@@ -6,6 +6,7 @@ using System.Collections.Immutable;
 using System.IO;
 using System.IO.Pipes;
 using System.Text;
+using System.Threading;
 using Microsoft.Build.Framework.Coordinator;
 
 namespace Microsoft.Build.BackEnd;
@@ -17,9 +18,11 @@ internal sealed partial class CoordinatorClient
     /// </summary>
     private sealed class Connection : IDisposable
     {
-        private NamedPipeClientStream? _pipeStream;
-        private BinaryReader? _reader;
-        private BinaryWriter? _writer;
+        private readonly NamedPipeClientStream _pipeStream;
+        private readonly BinaryReader _reader;
+        private readonly BinaryWriter _writer;
+        private readonly LockType _writeLock = new();
+        private int _disposed;
 
         /// <summary>
         ///  Gets the unique identifier sent during the coordinator handshake.
@@ -62,69 +65,78 @@ internal sealed partial class CoordinatorClient
 
         private bool TryHandshake(int processId, ICoordinatorDebugOutput output)
         {
-            output.WriteLine($"CoordinatorClient: Sending handshake (ConnectionId {Id})");
-            WriteClientMessage(new ClientHandshakeMessage(Id, processId, capabilities: [Capabilities.NestedGrants]));
-
-            ServerMessage response = ReadServerMessage();
-
-            if (response is ServerHandshakeMessage serverHandshake)
+            try
             {
-                ServerCapabilities = serverHandshake.Capabilities;
-                output.WriteLine($"CoordinatorClient: Handshake complete (server capabilities: [{string.Join(", ", serverHandshake.Capabilities)}])");
-                return true;
-            }
+                output.WriteLine($"CoordinatorClient: Sending handshake (ConnectionId {Id})");
+                WriteClientMessage(new ClientHandshakeMessage(Id, processId, capabilities: [Capabilities.NestedGrants]));
 
-            if (response is ErrorMessage error)
-            {
-                output.WriteLine($"CoordinatorClient: Server rejected handshake: {error.Message}");
+                ServerMessage response = ReadServerMessage();
+
+                if (response is ServerHandshakeMessage serverHandshake)
+                {
+                    ServerCapabilities = serverHandshake.Capabilities;
+                    output.WriteLine($"CoordinatorClient: Handshake complete (server capabilities: [{string.Join(", ", serverHandshake.Capabilities)}])");
+                    return true;
+                }
+
+                if (response is ErrorMessage error)
+                {
+                    output.WriteLine($"CoordinatorClient: Server rejected handshake: {error.Message}");
+                    return false;
+                }
+
+                output.WriteLine($"CoordinatorClient: Unexpected handshake response: {response.GetType().Name}");
                 return false;
             }
-
-            output.WriteLine($"CoordinatorClient: Unexpected handshake response: {response.GetType().Name}");
-            return false;
+            catch (Exception ex) when (ex is IOException or EndOfStreamException)
+            {
+                output.WriteLine($"CoordinatorClient: Exception during handshake: {ex.Message}");
+                return false;
+            }
         }
 
         /// <summary>
         ///  Reads the next server message from the coordinator pipe.
         /// </summary>
-        public ServerMessage ReadServerMessage()
-        {
-            Assumed.NotNull(_reader);
-            return _reader.ReadServerMessage();
-        }
+        public ServerMessage ReadServerMessage() => _reader.ReadServerMessage();
 
         /// <summary>
         ///  Writes a client message to the coordinator pipe.
         /// </summary>
         public void WriteClientMessage(ClientMessage message)
         {
-            Assumed.NotNull(_writer);
-            _writer.Write(message);
+            lock (_writeLock)
+            {
+                _writer.Write(message);
+            }
         }
 
         /// <summary>
-        ///  Transfers ownership of the pipe, reader, and writer to the caller.
+        ///  Checks whether the coordinator server advertised a capability during handshake.
         /// </summary>
-        public (NamedPipeClientStream PipeStream, BinaryReader Reader, BinaryWriter Writer) TransferOwnership()
-        {
-            Assumed.NotNull(_pipeStream);
-            Assumed.NotNull(_reader);
-            Assumed.NotNull(_writer);
-
-            var result = (_pipeStream, _reader, _writer);
-
-            _pipeStream = null;
-            _reader = null;
-            _writer = null;
-
-            return result;
-        }
+        public bool HasServerCapability(string capability) => ServerCapabilities.Contains(capability);
 
         public void Dispose()
         {
-            _reader?.Dispose();
-            _writer?.Dispose();
-            _pipeStream?.Dispose();
+            if (Interlocked.Exchange(ref _disposed, 1) != 0)
+            {
+                return;
+            }
+
+            try
+            {
+                lock (_writeLock)
+                {
+                    _writer.Dispose();
+                }
+            }
+            catch (IOException)
+            {
+                // Flush in BinaryWriter.Dispose can throw if the pipe is already broken.
+            }
+
+            _reader.Dispose();
+            _pipeStream.Dispose();
         }
     }
 }

--- a/src/Build/BackEnd/BuildManager/CoordinatorClient.HeartbeatTimer.cs
+++ b/src/Build/BackEnd/BuildManager/CoordinatorClient.HeartbeatTimer.cs
@@ -1,0 +1,81 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+using System.Threading;
+using Microsoft.Build.Framework.Coordinator;
+
+namespace Microsoft.Build.BackEnd;
+
+internal sealed partial class CoordinatorClient
+{
+    /// <summary>
+    ///  Sends coordinator heartbeats and waits for in-flight callbacks during disposal.
+    /// </summary>
+    private sealed class HeartbeatTimer : IDisposable
+    {
+        private const int NotDisposed = 0;
+        private const int Disposing = 1;
+        private const int Disposed = 2;
+
+        private readonly Connection _connection;
+        private readonly ICoordinatorDebugOutput _output;
+        private readonly Timer _timer;
+        private int _disposeState;
+
+        private bool IsDisposingOrDisposed => Volatile.Read(ref _disposeState) != NotDisposed;
+
+        public HeartbeatTimer(Connection connection, int intervalMs, ICoordinatorDebugOutput output)
+        {
+            _connection = connection;
+            _output = output;
+            _timer = new Timer(
+                static state => ((HeartbeatTimer)state!).SendHeartbeat(),
+                state: this,
+                dueTime: intervalMs,
+                period: intervalMs);
+        }
+
+        public void Dispose()
+        {
+            if (Interlocked.CompareExchange(ref _disposeState, Disposing, NotDisposed) != NotDisposed)
+            {
+                return;
+            }
+
+            try
+            {
+                using var disposeEvent = new ManualResetEvent(false);
+                if (_timer.Dispose(disposeEvent))
+                {
+                    disposeEvent.WaitOne();
+                }
+            }
+            finally
+            {
+                Volatile.Write(ref _disposeState, Disposed);
+            }
+        }
+
+        private void SendHeartbeat()
+        {
+            if (IsDisposingOrDisposed)
+            {
+                return;
+            }
+
+            try
+            {
+                _connection.WriteClientMessage(HeartbeatMessage.Instance);
+            }
+            catch (IOException)
+            {
+                _output.WriteLine("CoordinatorClient: Heartbeat failed (pipe broken)");
+
+                // Pipe broken -- nothing we can do. The build continues
+                // with whatever nodes were already granted.
+            }
+        }
+    }
+}

--- a/src/Build/BackEnd/BuildManager/CoordinatorClient.TestAccessor.cs
+++ b/src/Build/BackEnd/BuildManager/CoordinatorClient.TestAccessor.cs
@@ -35,19 +35,23 @@ internal sealed partial class CoordinatorClient
                 if (!TryConnectToPipe(pipeStream, settings.ConnectionTimeoutMs))
                 {
                     output.WriteLine("CoordinatorClient: Test connection timed out");
-                    pipeStream.Dispose();
                     return null;
                 }
 
                 output.WriteLine("CoordinatorClient: Connected to test server");
 
-                return TryNegotiate(pipeStream, requestedNodes, settings, output, loggingService: null);
+                CoordinatorClient? client = TryNegotiate(pipeStream, requestedNodes, settings, output, loggingService: null);
+                pipeStream = null; // Ownership transferred unconditionally; TryNegotiate disposes on failure.
+                return client;
             }
             catch (Exception ex) when (!Debugger.IsAttached)
             {
                 output.WriteLine($"CoordinatorClient: Exception during test connect: {ex.Message}");
-                pipeStream?.Dispose();
                 return null;
+            }
+            finally
+            {
+                pipeStream?.Dispose();
             }
         }
     }

--- a/src/Build/BackEnd/BuildManager/CoordinatorClient.cs
+++ b/src/Build/BackEnd/BuildManager/CoordinatorClient.cs
@@ -22,17 +22,15 @@ namespace Microsoft.Build.BackEnd;
 /// </summary>
 internal sealed partial class CoordinatorClient : IDisposable
 {
-    private readonly NamedPipeClientStream _pipeStream;
-    private readonly BinaryReader _reader;
-    private readonly BinaryWriter _writer;
-    private readonly Timer _heartbeatTimer;
+    private readonly Connection _connection;
+    private readonly HeartbeatTimer _heartbeatTimer;
     private readonly ICoordinatorDebugOutput _output;
-    private volatile bool _disposed;
+    private int _disposed;
 
     /// <summary>
     ///  The unique identifier for this connection to the coordinator.
     /// </summary>
-    public Guid ConnectionId { get; }
+    public Guid ConnectionId => _connection.Id;
 
     /// <summary>
     ///  The grant token associated with this coordinator lease.
@@ -62,18 +60,13 @@ internal sealed partial class CoordinatorClient : IDisposable
         int heartbeatIntervalMs,
         ICoordinatorDebugOutput output)
     {
-        ConnectionId = connection.Id;
         GrantId = grantId;
         ServerCapabilities = connection.ServerCapabilities;
-        (_pipeStream, _reader, _writer) = connection.TransferOwnership();
+        _connection = connection;
         _output = output;
         GrantedNodes = grantedNodes;
 
-        _heartbeatTimer = new Timer(
-            SendHeartbeat,
-            state: null,
-            dueTime: heartbeatIntervalMs,
-            period: heartbeatIntervalMs);
+        _heartbeatTimer = new HeartbeatTimer(connection, heartbeatIntervalMs, output);
     }
 
     /// <summary>
@@ -81,43 +74,25 @@ internal sealed partial class CoordinatorClient : IDisposable
     /// </summary>
     public void Dispose()
     {
-        if (_disposed)
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
         {
             return;
         }
 
-        _disposed = true;
-
-        // Stop heartbeat timer and wait for any in-flight callback to complete.
-        // This prevents SendHeartbeat from running after resources are disposed.
-        using (var disposeEvent = new ManualResetEvent(false))
-        {
-            _heartbeatTimer.Dispose(disposeEvent);
-            disposeEvent.WaitOne();
-        }
+        _heartbeatTimer.Dispose();
 
         _output.WriteLine($"CoordinatorClient: Releasing grant ({GrantedNodes} nodes)");
 
         try
         {
-            _writer.Write(ReleaseNodesMessage.Instance);
+            _connection.WriteClientMessage(ReleaseNodesMessage.Instance);
         }
         catch (IOException)
         {
             // Pipe may already be broken.
         }
 
-        try
-        {
-            _writer.Dispose();
-        }
-        catch (IOException)
-        {
-            // Flush in BinaryWriter.Dispose can throw on broken pipe.
-        }
-
-        _reader.Dispose();
-        _pipeStream.Dispose();
+        _connection.Dispose();
     }
 
     private static bool TryGetInheritedGrantId(out Guid grantId)
@@ -138,7 +113,6 @@ internal sealed partial class CoordinatorClient : IDisposable
         ICoordinatorDebugOutput output = DefaultDebugOutput.Instance;
 
         NamedPipeClientStream? pipeStream = null;
-
         try
         {
             pipeStream = new NamedPipeClientStream(".", settings.PipeName, PipeDirection.InOut, PipeOptions.Asynchronous);
@@ -152,9 +126,7 @@ internal sealed partial class CoordinatorClient : IDisposable
                 output.WriteLine("CoordinatorClient: No coordinator running, attempting to launch");
 
                 pipeStream.Dispose();
-#pragma warning disable CA2000 // Ownership transferred to TryNegotiate or disposed in outer finally
                 pipeStream = TryLaunchAndConnect(settings, loggingService, output);
-#pragma warning restore CA2000
 
                 if (pipeStream is null)
                 {
@@ -180,8 +152,11 @@ internal sealed partial class CoordinatorClient : IDisposable
             loggingService.LogComment(BuildEventContext.Invalid, MessageImportance.Normal, "CoordinatorFailedToConnect");
 
             // Any failure in coordinator communication should not break the build.
-            pipeStream?.Dispose();
             return null;
+        }
+        finally
+        {
+            pipeStream?.Dispose();
         }
     }
 
@@ -342,60 +317,76 @@ internal sealed partial class CoordinatorClient : IDisposable
         ICoordinatorDebugOutput output,
         ILoggingService? loggingService)
     {
-        using Connection? connection = Connection.TryCreate(pipeStream, settings.ProcessId, output);
-        if (connection is null)
+        Connection? connection = null;
+        try
         {
-            return null;
-        }
-
-        int processId = settings.ProcessId;
-        GrantOwnership grantOwnership;
-
-        // Child MSBuild processes receive this token through their process environment.
-        // Root builds keep it in BuildParameters.BuildProcessEnvironment to avoid races
-        // between concurrent BuildManager instances in the same process.
-        if (TryGetInheritedGrantId(out Guid inheritedGrantId) &&
-            connection.ServerCapabilities.Contains(Capabilities.NestedGrants))
-        {
-            grantOwnership = GrantOwnership.Nested;
-            output.WriteLine($"CoordinatorClient: Joining coordinator grant {inheritedGrantId} for {requestedNodes} nodes (PID {processId}, ConnectionId {connection.Id})");
-            connection.WriteClientMessage(new JoinGrantMessage(inheritedGrantId, requestedNodes));
-        }
-        else
-        {
-            grantOwnership = GrantOwnership.Root;
-            output.WriteLine($"CoordinatorClient: Requesting {requestedNodes} nodes (PID {processId}, ConnectionId {connection.Id})");
-            connection.WriteClientMessage(new RequestNodesMessage(requestedNodes));
-        }
-
-        // Read the response.
-        ServerMessage response = connection.ReadServerMessage();
-
-        switch (response)
-        {
-            case NodeGrantMessage grant:
-                output.WriteLine($"CoordinatorClient: Granted {grant.GrantedNodes} nodes");
-                loggingService?.LogComment(BuildEventContext.Invalid, MessageImportance.Normal, "CoordinatorNodeGrantReceived", grant.GrantedNodes);
-
-                return grantOwnership == GrantOwnership.Root
-                    ? CreateRootClient(connection, grant, settings.HeartbeatIntervalMs, output)
-                    : CreateNestedClient(connection, grant, settings.HeartbeatIntervalMs, output);
-
-            case WaitMessage:
-                Assumed.Equal(grantOwnership, GrantOwnership.Root, "Nested coordinator grant joins should not wait for global resources.");
-
-                output.WriteLine("CoordinatorClient: Received WaitMessage, waiting for deferred grant");
-                loggingService?.LogComment(BuildEventContext.Invalid, MessageImportance.High, "CoordinatorWaitingForNodes");
-
-                return WaitForDeferredGrant(connection, settings, output, loggingService);
-
-            case ErrorMessage requestError:
-                output.WriteLine($"CoordinatorClient: Server error: {requestError.Message}");
+            connection = Connection.TryCreate(pipeStream, settings.ProcessId, output);
+            if (connection is null)
+            {
                 return null;
+            }
 
-            default:
-                output.WriteLine($"CoordinatorClient: Unexpected response: {response.GetType().Name}");
-                return null;
+            int processId = settings.ProcessId;
+            GrantOwnership grantOwnership;
+
+            // Child MSBuild processes receive this token through their process environment.
+            // Root builds keep it in BuildParameters.BuildProcessEnvironment to avoid races
+            // between concurrent BuildManager instances in the same process.
+            if (TryGetInheritedGrantId(out Guid inheritedGrantId) &&
+                connection.HasServerCapability(Capabilities.NestedGrants))
+            {
+                grantOwnership = GrantOwnership.Nested;
+                output.WriteLine($"CoordinatorClient: Joining coordinator grant {inheritedGrantId} for {requestedNodes} nodes (PID {processId}, ConnectionId {connection.Id})");
+                connection.WriteClientMessage(new JoinGrantMessage(inheritedGrantId, requestedNodes));
+            }
+            else
+            {
+                grantOwnership = GrantOwnership.Root;
+                output.WriteLine($"CoordinatorClient: Requesting {requestedNodes} nodes (PID {processId}, ConnectionId {connection.Id})");
+                connection.WriteClientMessage(new RequestNodesMessage(requestedNodes));
+            }
+
+            // Read the response.
+            ServerMessage response = connection.ReadServerMessage();
+
+            switch (response)
+            {
+                case NodeGrantMessage grant:
+                    output.WriteLine($"CoordinatorClient: Granted {grant.GrantedNodes} nodes");
+                    loggingService?.LogComment(BuildEventContext.Invalid, MessageImportance.Normal, "CoordinatorNodeGrantReceived", grant.GrantedNodes);
+
+                    CoordinatorClient client = grantOwnership == GrantOwnership.Root
+                        ? CreateRootClient(connection, grant, settings.HeartbeatIntervalMs, output)
+                        : CreateNestedClient(connection, grant, settings.HeartbeatIntervalMs, output);
+                    connection = null;
+                    return client;
+
+                case WaitMessage:
+                    Assumed.Equal(grantOwnership, GrantOwnership.Root, "Nested coordinator grant joins should not wait for global resources.");
+
+                    output.WriteLine("CoordinatorClient: Received WaitMessage, waiting for deferred grant");
+                    loggingService?.LogComment(BuildEventContext.Invalid, MessageImportance.High, "CoordinatorWaitingForNodes");
+
+                    CoordinatorClient? deferredClient = WaitForDeferredGrant(connection, settings, output, loggingService);
+                    if (deferredClient is not null)
+                    {
+                        connection = null;
+                    }
+
+                    return deferredClient;
+
+                case ErrorMessage requestError:
+                    output.WriteLine($"CoordinatorClient: Server error: {requestError.Message}");
+                    return null;
+
+                default:
+                    output.WriteLine($"CoordinatorClient: Unexpected response: {response.GetType().Name}");
+                    return null;
+            }
+        }
+        finally
+        {
+            connection?.Dispose();
         }
     }
 
@@ -407,50 +398,32 @@ internal sealed partial class CoordinatorClient : IDisposable
     {
         var waitTimer = Stopwatch.StartNew();
 
-        // Send heartbeats while waiting so the server doesn't consider us stale.
-        using (Timer heartbeatPump = CreateHeartbeatPump(connection, settings.HeartbeatIntervalMs))
+        ServerMessage responseAfterWait;
+
+        // Send heartbeats only while waiting so the server doesn't consider us stale.
+        using (new HeartbeatTimer(connection, settings.HeartbeatIntervalMs, output))
         {
-            ServerMessage responseAfterWait = connection.ReadServerMessage();
-
-            switch (responseAfterWait)
-            {
-                case NodeGrantMessage grant:
-                    waitTimer.Stop();
-
-                    output.WriteLine($"CoordinatorClient: Deferred grant received: {grant.GrantedNodes} nodes (waited {waitTimer.Elapsed.TotalSeconds:F2}s)");
-                    loggingService?.LogComment(BuildEventContext.Invalid, MessageImportance.Normal, "CoordinatorNodeGrantReceived", grant.GrantedNodes);
-
-                    return CreateRootClient(connection, grant, settings.HeartbeatIntervalMs, output, waitTimer.Elapsed);
-
-                case ErrorMessage waitError:
-                    output.WriteLine($"CoordinatorClient: Server error while waiting: {waitError.Message} (waited {waitTimer.Elapsed.TotalSeconds:F2}s)");
-                    return null;
-
-                default:
-                    output.WriteLine($"CoordinatorClient: Unexpected response after wait: {responseAfterWait.GetType().Name} (waited {waitTimer.Elapsed.TotalSeconds:F2}s)");
-                    return null;
-            }
+            responseAfterWait = connection.ReadServerMessage();
         }
 
-        static Timer CreateHeartbeatPump(Connection connection, int intervalMs)
-            => new(
-                static state =>
-                {
-                    try
-                    {
-                        if (state is Connection connection)
-                        {
-                            connection.WriteClientMessage(HeartbeatMessage.Instance);
-                        }
-                    }
-                    catch
-                    {
-                        // Pipe may be broken; swallow and let the next read detect it.
-                    }
-                },
-                state: connection,
-                dueTime: intervalMs,
-                period: intervalMs);
+        waitTimer.Stop();
+
+        switch (responseAfterWait)
+        {
+            case NodeGrantMessage grant:
+                output.WriteLine($"CoordinatorClient: Deferred grant received: {grant.GrantedNodes} nodes (waited {waitTimer.Elapsed.TotalSeconds:F2}s)");
+                loggingService?.LogComment(BuildEventContext.Invalid, MessageImportance.Normal, "CoordinatorNodeGrantReceived", grant.GrantedNodes);
+
+                return CreateRootClient(connection, grant, settings.HeartbeatIntervalMs, output, waitTimer.Elapsed);
+
+            case ErrorMessage waitError:
+                output.WriteLine($"CoordinatorClient: Server error while waiting: {waitError.Message} (waited {waitTimer.Elapsed.TotalSeconds:F2}s)");
+                return null;
+
+            default:
+                output.WriteLine($"CoordinatorClient: Unexpected response after wait: {responseAfterWait.GetType().Name} (waited {waitTimer.Elapsed.TotalSeconds:F2}s)");
+                return null;
+        }
     }
 
     private static CoordinatorClient CreateRootClient(
@@ -540,25 +513,5 @@ internal sealed partial class CoordinatorClient : IDisposable
         }
 
         return null;
-    }
-
-    private void SendHeartbeat(object? state)
-    {
-        if (_disposed)
-        {
-            return;
-        }
-
-        try
-        {
-            _writer.Write(HeartbeatMessage.Instance);
-        }
-        catch (IOException)
-        {
-            _output.WriteLine("CoordinatorClient: Heartbeat failed (pipe broken)");
-
-            // Pipe broken — nothing we can do. The build continues
-            // with whatever nodes were already granted.
-        }
     }
 }

--- a/src/Build/Microsoft.Build.csproj
+++ b/src/Build/Microsoft.Build.csproj
@@ -157,6 +157,7 @@
     <Compile Include="BackEnd\BuildManager\CoordinatorClient.cs" />
     <Compile Include="BackEnd\BuildManager\CoordinatorClient.DefaultDebugOutput.cs" />
     <Compile Include="BackEnd\BuildManager\CoordinatorClient.GrantOwnership.cs" />
+    <Compile Include="BackEnd\BuildManager\CoordinatorClient.HeartbeatTimer.cs" />
     <Compile Include="BackEnd\BuildManager\CoordinatorClient.TestAccessor.cs" />
     <Compile Include="BackEnd\BuildManager\EnvironmentVariableValidator.cs" />
     <Compile Include="BackEnd\BuildManager\GlobalPropertiesLookup.cs" />

--- a/src/MSBuild.Coordinator.UnitTests/CoordinatorClient_Tests.cs
+++ b/src/MSBuild.Coordinator.UnitTests/CoordinatorClient_Tests.cs
@@ -173,7 +173,7 @@ public class CoordinatorClient_Tests(ITestOutputHelper testOutput) : IDisposable
             await serverPipe.WaitForConnectionAsync(_cts.Token);
 
             using BinaryReader reader = new(serverPipe, System.Text.Encoding.UTF8, leaveOpen: true);
-            using BinaryWriter writer = new(serverPipe, System.Text.Encoding.UTF8, leaveOpen: true);
+            BinaryWriter writer = new(serverPipe, System.Text.Encoding.UTF8, leaveOpen: true);
 
             reader.ReadClientMessage().ShouldBeOfType<ClientHandshakeMessage>()
                 .Capabilities.ShouldContain(Capabilities.NestedGrants);
@@ -197,6 +197,109 @@ public class CoordinatorClient_Tests(ITestOutputHelper testOutput) : IDisposable
         client.GrantId.ShouldBe(Guid.Empty);
 
         client.Dispose();
+        await serverTask;
+    }
+
+    [Fact]
+    public async Task Dispose_IsIdempotentAndSendsSingleRelease()
+    {
+        using NamedPipeServerStream serverPipe = new(
+            _pipeName,
+            PipeDirection.InOut,
+            NamedPipeServerStream.MaxAllowedServerInstances,
+            PipeTransmissionMode.Byte,
+            PipeOptions.Asynchronous);
+
+        Task serverTask = Task.Run(async () =>
+        {
+            await serverPipe.WaitForConnectionAsync(_cts.Token);
+
+            using BinaryReader reader = new(serverPipe, System.Text.Encoding.UTF8, leaveOpen: true);
+            BinaryWriter writer = new(serverPipe, System.Text.Encoding.UTF8, leaveOpen: true);
+
+            reader.ReadClientMessage().ShouldBeOfType<ClientHandshakeMessage>();
+            writer.Write(new ServerHandshakeMessage([Capabilities.NestedGrants]));
+
+            reader.ReadClientMessage().ShouldBe(new RequestNodesMessage(requestedNodes: 8));
+            writer.Write(new NodeGrantMessage(Guid.NewGuid(), grantedNodes: 4));
+
+            (await ReadClientMessageWithTimeout(reader)).ShouldBe(ReleaseNodesMessage.Instance);
+
+            Task<ClientMessage> secondRead = Task.Run(reader.ReadClientMessage);
+            (await Task.WhenAny(secondRead, Task.Delay(5000))).ShouldBe(secondRead);
+            Exception ex = await Should.ThrowAsync<Exception>(async () => await secondRead);
+            (ex is IOException or EndOfStreamException).ShouldBeTrue($"Expected {nameof(IOException)} or {nameof(EndOfStreamException)}, got {ex.GetType().FullName}");
+        });
+
+        CoordinatorClient? client = TryConnectToServer(
+            requestedNodes: 8,
+            DefaultSettings with
+            {
+                ProcessId = Pid1,
+            });
+
+        client.ShouldNotBeNull();
+
+        await Task.WhenAll(
+            Task.Run(client.Dispose),
+            Task.Run(client.Dispose),
+            Task.Run(client.Dispose),
+            Task.Run(client.Dispose));
+
+        await serverTask;
+    }
+
+    [Fact]
+    public async Task DeferredGrant_SendsHeartbeatsWhileWaiting()
+    {
+        using NamedPipeServerStream serverPipe = new(
+            _pipeName,
+            PipeDirection.InOut,
+            NamedPipeServerStream.MaxAllowedServerInstances,
+            PipeTransmissionMode.Byte,
+            PipeOptions.Asynchronous);
+
+        Task serverTask = Task.Run(async () =>
+        {
+            await serverPipe.WaitForConnectionAsync(_cts.Token);
+
+            using BinaryReader reader = new(serverPipe, System.Text.Encoding.UTF8, leaveOpen: true);
+            using BinaryWriter writer = new(serverPipe, System.Text.Encoding.UTF8, leaveOpen: true);
+
+            reader.ReadClientMessage().ShouldBeOfType<ClientHandshakeMessage>();
+            writer.Write(new ServerHandshakeMessage([Capabilities.NestedGrants]));
+
+            reader.ReadClientMessage().ShouldBe(new RequestNodesMessage(requestedNodes: 8));
+            writer.Write(WaitMessage.Instance);
+
+            (await ReadClientMessageWithTimeout(reader)).ShouldBe(HeartbeatMessage.Instance);
+
+            writer.Write(new NodeGrantMessage(Guid.NewGuid(), grantedNodes: 3));
+
+            ClientMessage message;
+            do
+            {
+                message = await ReadClientMessageWithTimeout(reader);
+            }
+            while (message is HeartbeatMessage);
+
+            message.ShouldBe(ReleaseNodesMessage.Instance);
+        });
+
+        Task<CoordinatorClient?> clientTask = Task.Run(() =>
+            TryConnectToServer(
+                requestedNodes: 8,
+                DefaultSettings with
+                {
+                    ProcessId = Pid1,
+                    HeartbeatIntervalMs = 50,
+                }));
+
+        using CoordinatorClient? client = await clientTask;
+        client.ShouldNotBeNull();
+        client.GrantedNodes.ShouldBe(3);
+        client.Dispose();
+
         await serverTask;
     }
 
@@ -287,4 +390,11 @@ public class CoordinatorClient_Tests(ITestOutputHelper testOutput) : IDisposable
 
     private CoordinatorClient? TryConnectToServer(int requestedNodes, CoordinatorSettings settings)
         => CoordinatorClient.TestAccessor.TryConnectToServer(requestedNodes, settings, _output);
+
+    private static async Task<ClientMessage> ReadClientMessageWithTimeout(BinaryReader reader)
+    {
+        Task<ClientMessage> readTask = Task.Run(reader.ReadClientMessage);
+        (await Task.WhenAny(readTask, Task.Delay(5000))).ShouldBe(readTask);
+        return await readTask;
+    }
 }

--- a/src/MSBuild.Coordinator.UnitTests/CoordinatorClient_Tests.cs
+++ b/src/MSBuild.Coordinator.UnitTests/CoordinatorClient_Tests.cs
@@ -173,7 +173,7 @@ public class CoordinatorClient_Tests(ITestOutputHelper testOutput) : IDisposable
             await serverPipe.WaitForConnectionAsync(_cts.Token);
 
             using BinaryReader reader = new(serverPipe, System.Text.Encoding.UTF8, leaveOpen: true);
-            BinaryWriter writer = new(serverPipe, System.Text.Encoding.UTF8, leaveOpen: true);
+            using BinaryWriter writer = new(serverPipe, System.Text.Encoding.UTF8, leaveOpen: true);
 
             reader.ReadClientMessage().ShouldBeOfType<ClientHandshakeMessage>()
                 .Capabilities.ShouldContain(Capabilities.NestedGrants);
@@ -216,19 +216,25 @@ public class CoordinatorClient_Tests(ITestOutputHelper testOutput) : IDisposable
 
             using BinaryReader reader = new(serverPipe, System.Text.Encoding.UTF8, leaveOpen: true);
             BinaryWriter writer = new(serverPipe, System.Text.Encoding.UTF8, leaveOpen: true);
+            try
+            {
+                reader.ReadClientMessage().ShouldBeOfType<ClientHandshakeMessage>();
+                writer.Write(new ServerHandshakeMessage([Capabilities.NestedGrants]));
 
-            reader.ReadClientMessage().ShouldBeOfType<ClientHandshakeMessage>();
-            writer.Write(new ServerHandshakeMessage([Capabilities.NestedGrants]));
+                reader.ReadClientMessage().ShouldBe(new RequestNodesMessage(requestedNodes: 8));
+                writer.Write(new NodeGrantMessage(Guid.NewGuid(), grantedNodes: 4));
 
-            reader.ReadClientMessage().ShouldBe(new RequestNodesMessage(requestedNodes: 8));
-            writer.Write(new NodeGrantMessage(Guid.NewGuid(), grantedNodes: 4));
+                (await ReadClientMessageWithTimeout(reader)).ShouldBe(ReleaseNodesMessage.Instance);
 
-            (await ReadClientMessageWithTimeout(reader)).ShouldBe(ReleaseNodesMessage.Instance);
-
-            Task<ClientMessage> secondRead = Task.Run(reader.ReadClientMessage);
-            (await Task.WhenAny(secondRead, Task.Delay(5000))).ShouldBe(secondRead);
-            Exception ex = await Should.ThrowAsync<Exception>(async () => await secondRead);
-            (ex is IOException or EndOfStreamException).ShouldBeTrue($"Expected {nameof(IOException)} or {nameof(EndOfStreamException)}, got {ex.GetType().FullName}");
+                Task<ClientMessage> secondRead = Task.Run(reader.ReadClientMessage);
+                (await Task.WhenAny(secondRead, Task.Delay(5000))).ShouldBe(secondRead);
+                Exception ex = await Should.ThrowAsync<Exception>(async () => await secondRead);
+                (ex is IOException or EndOfStreamException).ShouldBeTrue($"Expected {nameof(IOException)} or {nameof(EndOfStreamException)}, got {ex.GetType().FullName}");
+            }
+            finally
+            {
+                DisposeWriterIgnoringBrokenPipe(writer);
+            }
         });
 
         CoordinatorClient? client = TryConnectToServer(
@@ -396,5 +402,17 @@ public class CoordinatorClient_Tests(ITestOutputHelper testOutput) : IDisposable
         Task<ClientMessage> readTask = Task.Run(reader.ReadClientMessage);
         (await Task.WhenAny(readTask, Task.Delay(5000))).ShouldBe(readTask);
         return await readTask;
+    }
+
+    private static void DisposeWriterIgnoringBrokenPipe(BinaryWriter writer)
+    {
+        try
+        {
+            writer.Dispose();
+        }
+        catch (IOException)
+        {
+            // BinaryWriter.Dispose flushes; the client may already have closed the test pipe.
+        }
     }
 }

--- a/src/MSBuild.Coordinator.UnitTests/TestCoordinatorDebugOutput.cs
+++ b/src/MSBuild.Coordinator.UnitTests/TestCoordinatorDebugOutput.cs
@@ -12,8 +12,10 @@ internal sealed class TestCoordinatorDebugOutput(ITestOutputHelper testOutput) :
     public bool IsEnabled => true;
 
     public void WriteLine(string message)
-        => testOutput.WriteLine(message);
+    {
+        testOutput.WriteLine(message);
+    }
 
     public void WriteLine([InterpolatedStringHandlerArgument("")] ref ICoordinatorDebugOutput.WriteLineInterpolatedStringHandler handler)
-        => testOutput.WriteLine(handler.GetFormattedText());
+        => WriteLine(handler.GetFormattedText());
 }

--- a/src/MSBuild.Coordinator.UnitTests/TestCoordinatorDebugOutput.cs
+++ b/src/MSBuild.Coordinator.UnitTests/TestCoordinatorDebugOutput.cs
@@ -12,10 +12,8 @@ internal sealed class TestCoordinatorDebugOutput(ITestOutputHelper testOutput) :
     public bool IsEnabled => true;
 
     public void WriteLine(string message)
-    {
-        testOutput.WriteLine(message);
-    }
+        => testOutput.WriteLine(message);
 
     public void WriteLine([InterpolatedStringHandlerArgument("")] ref ICoordinatorDebugOutput.WriteLineInterpolatedStringHandler handler)
-        => WriteLine(handler.GetFormattedText());
+        => testOutput.WriteLine(handler.GetFormattedText());
 }

--- a/src/MSBuild.Coordinator/CoordinatorServer.ConnectedClient.cs
+++ b/src/MSBuild.Coordinator/CoordinatorServer.ConnectedClient.cs
@@ -4,6 +4,7 @@
 using System.Collections.Immutable;
 using System.IO;
 using System.IO.Pipes;
+using System.Threading;
 using Microsoft.Build.Framework.Coordinator;
 
 namespace Microsoft.Build.Coordinator;
@@ -18,6 +19,7 @@ internal sealed partial class CoordinatorServer
         private readonly NamedPipeServerStream _pipeStream;
         private readonly BinaryReader _reader;
         private readonly BinaryWriter _writer;
+        private int _disposed;
 
         /// <summary>
         ///  Gets the unique identifier for this connection, assigned by the client during handshake.
@@ -71,6 +73,11 @@ internal sealed partial class CoordinatorServer
 
         public void Dispose()
         {
+            if (Interlocked.Exchange(ref _disposed, 1) != 0)
+            {
+                return;
+            }
+
             try
             {
                 _writer.Dispose();

--- a/src/MSBuild.Coordinator/CoordinatorServer.cs
+++ b/src/MSBuild.Coordinator/CoordinatorServer.cs
@@ -417,6 +417,14 @@ internal sealed partial class CoordinatorServer(CoordinatorSettings settings, IC
     /// <param name="client">The client whose grant is being released.</param>
     private void ReleaseClient(ConnectedClient client)
     {
+        ImmutableArray<BuildGrant> newlyGranted = ReleaseClientAndGrant(client);
+
+        NotifyNewlyGrantedBuilds(newlyGranted);
+        ResetShutdownTimer();
+    }
+
+    private ImmutableArray<BuildGrant> ReleaseClientAndGrant(ConnectedClient client)
+    {
         using (_clientsLock.EnterDisposableWriteLock())
         {
             // Only remove if this connection is still current for the connection ID.
@@ -432,16 +440,23 @@ internal sealed partial class CoordinatorServer(CoordinatorSettings settings, IC
             }
         }
 
-        ImmutableArray<BuildGrant> newlyGranted = _budgetManager.Release(client.Grant);
+        return _budgetManager.Release(client.Grant);
+    }
 
-        if (newlyGranted.Length > 0)
+    private void NotifyNewlyGrantedBuilds(ImmutableArray<BuildGrant> newlyGranted)
+    {
+        if (newlyGranted.IsEmpty)
         {
-            _output.WriteLine($"CoordinatorServer: Draining wait queue, {newlyGranted.Length} build(s) to notify");
+            return;
         }
 
+        Queue<BuildGrant> pendingNotifications = new(newlyGranted.Length);
+        EnqueueNewlyGrantedNotifications(pendingNotifications, newlyGranted);
+
         // Notify newly granted builds outside the locks.
-        foreach (BuildGrant grant in newlyGranted)
+        while (pendingNotifications.Count > 0)
         {
+            BuildGrant grant = pendingNotifications.Dequeue();
             bool found;
             ConnectedClient? waitingClient;
             using (_clientsLock.EnterDisposableReadLock())
@@ -461,13 +476,27 @@ internal sealed partial class CoordinatorServer(CoordinatorSettings settings, IC
                 {
                     _output.WriteLine($"CoordinatorServer: PID {grant.ProcessId} disconnected while waiting");
 
-                    // Client disconnected while waiting. Release their grant too.
-                    ReleaseClient(waitingClient);
+                    // Client disconnected while waiting. Release their grant too, then append
+                    // any newly available grants after the current notification batch.
+                    ImmutableArray<BuildGrant> appendedGrants = ReleaseClientAndGrant(waitingClient);
+                    EnqueueNewlyGrantedNotifications(pendingNotifications, appendedGrants);
                 }
             }
         }
+    }
 
-        ResetShutdownTimer();
+    private void EnqueueNewlyGrantedNotifications(Queue<BuildGrant> pendingNotifications, ImmutableArray<BuildGrant> newlyGranted)
+    {
+        if (newlyGranted.IsEmpty)
+        {
+            return;
+        }
+
+        _output.WriteLine($"CoordinatorServer: Draining wait queue, {newlyGranted.Length} build(s) to notify");
+        foreach (BuildGrant grant in newlyGranted)
+        {
+            pendingNotifications.Enqueue(grant);
+        }
     }
 
     private void TrackRootGrant(BuildGrant grant)


### PR DESCRIPTION
### Context

This PR hardens coordinator client/server lifecycle handling on top of https://github.com/dotnet/msbuild/pull/14224.

Coordinator client writes can come from multiple lifecycle paths: regular heartbeat timers, deferred-wait heartbeat pumps, and `Dispose` releasing a grant. Those paths need to avoid overlapping `BinaryWriter` writes and timer callbacks racing with connection ownership changes or disposal.

### Changes Made

- Keep coordinator client transport ownership centered on `CoordinatorClient.Connection`.
- Serialize client message writes inside `Connection`, so heartbeats, deferred-wait heartbeats, and release messages share one write path.
- Drain deferred-wait and client heartbeat timers before the associated connection can be disposed.
- Track accepted coordinator server connections while they are negotiating so idle shutdown does not race an in-progress client.
- Make deferred grant notification resilient when a waiting client disconnects while being granted nodes.
- Make connected-client disposal idempotent.
- Add targeted regression tests for client disposal, deferred-wait heartbeats, accepted-client shutdown timing, and disconnected deferred waiters.

### Testing

- `.\build.cmd -v quiet`
- `dotnet msbuild src\Build\Microsoft.Build.csproj -p:Configuration=Release -v:q`
- `dotnet msbuild src\MSBuild.Coordinator\MSBuild.Coordinator.csproj -p:Configuration=Release -v:q`
- `dotnet test src\MSBuild.Coordinator.UnitTests\MSBuild.Coordinator.UnitTests.csproj -c Release`