### PR TITLE
Fix source-build prebuilt violation from TaskAnalyzer's Roslyn dependencies

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,6 +18,12 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.Collections" Version="$(MicrosoftCodeAnalysisCollectionsVersion)" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Contracts" Version="$(MicrosoftCodeAnalysisContractsVersion)" />
     <PackageVersion Include="Microsoft.CodeAnalysis.PooledObjects" Version="$(MicrosoftCodeAnalysisPooledObjectsVersion)" />
+    <!-- Consumed compile-time (PrivateAssets="all") by Microsoft.Build.TaskAuthoring.Analyzer (src/TaskAnalyzer).
+         Declared in eng/Version.Details.xml so source-build overrides them to the live source-built Roslyn;
+         non-source builds use the pinned defaults from eng/Version.Details.props. -->
+    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="$(MicrosoftCodeAnalysisAnalyzersVersion)" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="$(MicrosoftCodeAnalysisCSharpVersion)" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(MicrosoftCodeAnalysisCSharpWorkspacesVersion)" />
     <PackageVersion Include="Microsoft.DotNet.XUnitV3Extensions" Version="$(MicrosoftDotNetXUnitV3ExtensionsVersion)" />
     <PackageVersion Include="Microsoft.IO.Redist" Version="$(MicrosoftIORedistVersion)" />
     <PackageVersion Include="Microsoft.Net.Compilers.Toolset" Version="$(MicrosoftNetCompilersToolsetVersion)" Condition="'$(UsingToolMicrosoftNetCompilers)' != 'true'" />

--- a/eng/Version.Details.props
+++ b/eng/Version.Details.props
@@ -9,6 +9,9 @@ This file should be imported by eng/Versions.props
     <MicrosoftDotNetArcadeSdkPackageVersion>10.0.0-beta.26324.4</MicrosoftDotNetArcadeSdkPackageVersion>
     <MicrosoftDotNetXUnitV3ExtensionsPackageVersion>10.0.0-beta.26324.4</MicrosoftDotNetXUnitV3ExtensionsPackageVersion>
     <!-- dotnet-roslyn dependencies -->
+    <MicrosoftCodeAnalysisAnalyzersPackageVersion>3.11.0</MicrosoftCodeAnalysisAnalyzersPackageVersion>
+    <MicrosoftCodeAnalysisCSharpPackageVersion>4.12.0</MicrosoftCodeAnalysisCSharpPackageVersion>
+    <MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>4.12.0</MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>
     <MicrosoftNetCompilersToolsetPackageVersion>5.9.0-1.26328.17</MicrosoftNetCompilersToolsetPackageVersion>
     <!-- dotnet-runtime dependencies -->
     <SystemCodeDomPackageVersion>10.0.8</SystemCodeDomPackageVersion>
@@ -37,6 +40,9 @@ This file should be imported by eng/Versions.props
     <MicrosoftDotNetArcadeSdkVersion>$(MicrosoftDotNetArcadeSdkPackageVersion)</MicrosoftDotNetArcadeSdkVersion>
     <MicrosoftDotNetXUnitV3ExtensionsVersion>$(MicrosoftDotNetXUnitV3ExtensionsPackageVersion)</MicrosoftDotNetXUnitV3ExtensionsVersion>
     <!-- dotnet-roslyn dependencies -->
+    <MicrosoftCodeAnalysisAnalyzersVersion>$(MicrosoftCodeAnalysisAnalyzersPackageVersion)</MicrosoftCodeAnalysisAnalyzersVersion>
+    <MicrosoftCodeAnalysisCSharpVersion>$(MicrosoftCodeAnalysisCSharpPackageVersion)</MicrosoftCodeAnalysisCSharpVersion>
+    <MicrosoftCodeAnalysisCSharpWorkspacesVersion>$(MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion)</MicrosoftCodeAnalysisCSharpWorkspacesVersion>
     <MicrosoftNetCompilersToolsetVersion>$(MicrosoftNetCompilersToolsetPackageVersion)</MicrosoftNetCompilersToolsetVersion>
     <!-- dotnet-runtime dependencies -->
     <SystemCodeDomVersion>$(SystemCodeDomPackageVersion)</SystemCodeDomVersion>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -104,6 +104,21 @@
       <Sha>
       </Sha>
     </Dependency>
+    <!-- Roslyn packages consumed compile-time (PrivateAssets="all") by the Microsoft.Build.TaskAuthoring.Analyzer
+         (src/TaskAnalyzer). Necessary for source-build: this allows the live (source-built) Roslyn version to be
+         used, avoiding prebuilt package violations. Non-source builds use the versions pinned below. -->
+    <Dependency Name="Microsoft.CodeAnalysis.CSharp" Version="4.12.0">
+      <Uri>https://github.com/dotnet/roslyn</Uri>
+      <Sha />
+    </Dependency>
+    <Dependency Name="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.12.0">
+      <Uri>https://github.com/dotnet/roslyn</Uri>
+      <Sha />
+    </Dependency>
+    <Dependency Name="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0">
+      <Uri>https://github.com/dotnet/roslyn</Uri>
+      <Sha />
+    </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="10.0.0-beta.26324.4">

--- a/eng/dependabot/Directory.Packages.props
+++ b/eng/dependabot/Directory.Packages.props
@@ -72,13 +72,6 @@
     <PackageVersion Update="PolySharp" Condition="'$(PolySharpVersion)' != ''" Version="$(PolySharpVersion)" />
   </ItemGroup>
 
-  <!-- Roslyn analyzer authoring packages (used by TaskAnalyzer) -->
-  <ItemGroup>
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.12.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.12.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" />
-  </ItemGroup>
-
   <ItemGroup Condition="'$(DotNetBuildSourceOnly)' != 'true'">
     <GlobalPackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="3.3.4" />
     <GlobalPackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556" PrivateAssets="all"/>


### PR DESCRIPTION
### Context

`src/TaskAnalyzer/TaskAnalyzer.csproj` (`Microsoft.Build.TaskAuthoring.Analyzer`) was added to `MSBuild.SourceBuild.slnf` in #14209. It references three Roslyn packages at compile time (`PrivateAssets="all"`):

- `Microsoft.CodeAnalysis.CSharp` 4.12.0
- `Microsoft.CodeAnalysis.CSharp.Workspaces` 4.12.0
- `Microsoft.CodeAnalysis.Analyzers` 3.11.0

These versions were pinned in `eng/dependabot/Directory.Packages.props` to the nuget.org releases. In the [dotnet/dotnet](https://github.com/dotnet/dotnet) VMR **source-only** build, those external versions are treated as forbidden prebuilt packages, so `eng/finish-source-only.proj` fails with:

> Prebuilt packages are not allowed in source-only builds. Detected 11 prebuilt package(s)

(the three above plus transitive `Microsoft.CodeAnalysis.Workspaces.Common` 4.12.0, `System.Composition.*` 8.0.0, and `System.IO.Pipelines` 8.0.0).

This blocks the VMR codeflow PRs dotnet/dotnet#7406 (main) and dotnet/dotnet#7470 (release/10.0.4xx).

### Changes Made

Redirect the three packages to the live source-built Roslyn during the VMR source-only build, mirroring the existing `dotnet/runtime` `System.*` source-build precedent already in this repo:

- **`eng/Version.Details.xml`** — declare the three packages as `ProductDependencies` with `Uri=https://github.com/dotnet/roslyn` and an empty `<Sha />`. Declaring them here lets the VMR override their versions to the source-built Roslyn (`WritePackageVersionsProps`, which only overrides non-pinned dependencies present in `Version.Details.xml`).
- **`eng/Version.Details.props`** — add the generated `{Id}PackageVersion` defaults (4.12.0 / 4.12.0 / 3.11.0) and `{Id}Version` aliases.
- **`Directory.Packages.props`** (root, Darc-managed) — declare the three `PackageVersion`s referencing the alias properties.
- **`eng/dependabot/Directory.Packages.props`** — remove the previously hardcoded versions (they now live in the Darc-managed root file, per that file's own convention).

`TaskAnalyzer.csproj` is unchanged (still references the packages by id).

Non-source-build (normal) builds keep the pinned 4.12.0 / 3.11.0 versions from `eng/Version.Details.props`. As with the compiler toolset, these dependencies will flow from `dotnet/roslyn` via the existing Maestro subscription over time.

### Testing

- `dotnet restore src/TaskAnalyzer/TaskAnalyzer.csproj` → 0 warnings / 0 errors.
- `dotnet list src/TaskAnalyzer/TaskAnalyzer.csproj package` → resolves `Microsoft.CodeAnalysis.Analyzers 3.11.0`, `Microsoft.CodeAnalysis.CSharp 4.12.0`, `Microsoft.CodeAnalysis.CSharp.Workspaces 4.12.0` (normal build unchanged).
- Verified the target Roslyn assets are published to the channel the VMR consumes, and that `MSBuild.SourceBuild.slnf` includes `TaskAnalyzer.csproj` whose three direct package references are exactly the three declared here.

> [!NOTE]
> This fixes the flow into `dotnet/dotnet` **main** (#7406). The `release/10.0.4xx` flow (#7470) is fed by an MSBuild release branch and will need the same change ported/backported there.
