### PR TITLE
Fix existence cache kind poisoning

### DIFF
--- a/src/Build.UnitTests/Definition/ProjectEvaluationContext_Tests.cs
+++ b/src/Build.UnitTests/Definition/ProjectEvaluationContext_Tests.cs
@@ -13,6 +13,7 @@ using Microsoft.Build.Evaluation;
 using Microsoft.Build.Evaluation.Context;
 using Microsoft.Build.Execution;
 using Microsoft.Build.Framework;
+using Microsoft.Build.Shared.FileSystem;
 using Microsoft.Build.Unittest;
 using Shouldly;
 using Xunit;
@@ -894,6 +895,53 @@ namespace Microsoft.Build.UnitTests.Definition
                 });
 
             evaluationCount.ShouldBe(2);
+        }
+
+        [Fact]
+        public void CachingFileSystemWrapperDistinguishesFileAndDirectoryExistence()
+        {
+            var directory = _env.DefaultTestDirectory.CreateDirectory("subDirectory");
+            var file = _env.DefaultTestDirectory.CreateFile("file");
+            var fileSystem = new CachingFileSystemWrapper(FileSystems.Default);
+
+            fileSystem.FileExists(directory.Path).ShouldBeFalse();
+            fileSystem.DirectoryExists(directory.Path).ShouldBeTrue();
+            fileSystem.FileOrDirectoryExists(directory.Path).ShouldBeTrue();
+
+            fileSystem.DirectoryExists(file.Path).ShouldBeFalse();
+            fileSystem.FileExists(file.Path).ShouldBeTrue();
+            fileSystem.FileOrDirectoryExists(file.Path).ShouldBeTrue();
+        }
+
+        [Theory]
+        [InlineData(EvaluationContext.SharingPolicy.Isolated)]
+        [InlineData(EvaluationContext.SharingPolicy.SharedSDKCache)]
+        [InlineData(EvaluationContext.SharingPolicy.Shared)]
+        public void GetDirectoryNameOfFileAboveWithEmptyFileNameDoesNotPoisonProjectLevelWildcards(EvaluationContext.SharingPolicy policy)
+        {
+            var context = EvaluationContext.Create(policy);
+            _env.DefaultTestDirectory.CreateFile("Source.cs");
+
+            EvaluateProjects(
+                new[]
+                {
+                    """
+                    <Project>
+                      <PropertyGroup>
+                        <SearchedPath>$([MSBuild]::GetDirectoryNameOfFileAbove('$(MSBuildProjectDirectory)', ''))</SearchedPath>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <i Include="*.cs" />
+                      </ItemGroup>
+                    </Project>
+                    """
+                },
+                context,
+                project =>
+                {
+                    project.GetPropertyValue("SearchedPath").ShouldBeEmpty();
+                    ObjectModelHelpers.AssertItems(["Source.cs"], project.GetItems("i"));
+                });
         }
 
         [Theory]

--- a/src/Framework/FileSystem/CachingFileSystemWrapper.cs
+++ b/src/Framework/FileSystem/CachingFileSystemWrapper.cs
@@ -12,10 +12,10 @@ namespace Microsoft.Build.Shared.FileSystem
     internal sealed class CachingFileSystemWrapper : IFileSystem
     {
         private readonly IFileSystem _fileSystem;
-        private readonly ConcurrentDictionary<string, bool> _directoryExistenceCache = new ConcurrentDictionary<string, bool>();
-        private readonly ConcurrentDictionary<string, bool> _fileExistenceCache = new ConcurrentDictionary<string, bool>();
-        private readonly ConcurrentDictionary<string, bool> _fileOrDirectoryExistenceCache = new ConcurrentDictionary<string, bool>();
-        private readonly ConcurrentDictionary<string, DateTime> _lastWriteTimeCache = new ConcurrentDictionary<string, DateTime>();
+        private readonly ConcurrentDictionary<string, bool> _directoryExistenceCache = new();
+        private readonly ConcurrentDictionary<string, bool> _fileExistenceCache = new();
+        private readonly ConcurrentDictionary<string, bool> _fileOrDirectoryExistenceCache = new();
+        private readonly ConcurrentDictionary<string, DateTime> _lastWriteTimeCache = new();
 
         public CachingFileSystemWrapper(IFileSystem fileSystem)
         {
@@ -24,6 +24,13 @@ namespace Microsoft.Build.Shared.FileSystem
 
         public bool FileOrDirectoryExists(string path)
         {
+            // A positive result from either specific cache implies existence, so we can avoid a redundant filesystem stat.
+            if ((_fileExistenceCache.TryGetValue(path, out bool fileExists) && fileExists) ||
+                (_directoryExistenceCache.TryGetValue(path, out bool directoryExists) && directoryExists))
+            {
+                return true;
+            }
+
             return _fileOrDirectoryExistenceCache.GetOrAdd(path, p => _fileSystem.FileOrDirectoryExists(p));
         }
 

--- a/src/Framework/FileSystem/CachingFileSystemWrapper.cs
+++ b/src/Framework/FileSystem/CachingFileSystemWrapper.cs
@@ -12,7 +12,9 @@ namespace Microsoft.Build.Shared.FileSystem
     internal sealed class CachingFileSystemWrapper : IFileSystem
     {
         private readonly IFileSystem _fileSystem;
-        private readonly ConcurrentDictionary<string, bool> _existenceCache = new ConcurrentDictionary<string, bool>();
+        private readonly ConcurrentDictionary<string, bool> _directoryExistenceCache = new ConcurrentDictionary<string, bool>();
+        private readonly ConcurrentDictionary<string, bool> _fileExistenceCache = new ConcurrentDictionary<string, bool>();
+        private readonly ConcurrentDictionary<string, bool> _fileOrDirectoryExistenceCache = new ConcurrentDictionary<string, bool>();
         private readonly ConcurrentDictionary<string, DateTime> _lastWriteTimeCache = new ConcurrentDictionary<string, DateTime>();
 
         public CachingFileSystemWrapper(IFileSystem fileSystem)
@@ -22,7 +24,7 @@ namespace Microsoft.Build.Shared.FileSystem
 
         public bool FileOrDirectoryExists(string path)
         {
-            return CachedExistenceCheck(path, p => _fileSystem.FileOrDirectoryExists(p));
+            return _fileOrDirectoryExistenceCache.GetOrAdd(path, p => _fileSystem.FileOrDirectoryExists(p));
         }
 
         public FileAttributes GetAttributes(string path)
@@ -37,12 +39,12 @@ namespace Microsoft.Build.Shared.FileSystem
 
         public bool DirectoryExists(string path)
         {
-            return CachedExistenceCheck(path, p => _fileSystem.DirectoryExists(p));
+            return _directoryExistenceCache.GetOrAdd(path, p => _fileSystem.DirectoryExists(p));
         }
 
         public bool FileExists(string path)
         {
-            return CachedExistenceCheck(path, p => _fileSystem.FileExists(p));
+            return _fileExistenceCache.GetOrAdd(path, p => _fileSystem.FileExists(p));
         }
 
         public IEnumerable<string> EnumerateDirectories(string path, string searchPattern = "*", SearchOption searchOption = SearchOption.TopDirectoryOnly)
@@ -78,11 +80,6 @@ namespace Microsoft.Build.Shared.FileSystem
         public IEnumerable<string> EnumerateFileSystemEntries(string path, string searchPattern = "*", SearchOption searchOption = SearchOption.TopDirectoryOnly)
         {
             return _fileSystem.EnumerateFileSystemEntries(path, searchPattern, searchOption);
-        }
-
-        private bool CachedExistenceCheck(string path, Func<string, bool> existenceCheck)
-        {
-            return _existenceCache.GetOrAdd(path, existenceCheck);
         }
     }
 }


### PR DESCRIPTION
Fixes #13566

### Context
`CachingFileSystemWrapper` used a single existence cache for `FileExists`, `DirectoryExists`, and `FileOrDirectoryExists`. That allowed a `FileExists(directoryPath)` miss to poison a later `DirectoryExists(directoryPath)` lookup, which could make project-level wildcard expansion return empty results after calls such as `GetDirectoryNameOfFileAbove(..., '')`.

### Changes Made
- Split cached file, directory, and file-or-directory existence checks by query kind.
- Added direct regression coverage for file/directory existence cache poisoning.
- Added an evaluation-level regression for `GetDirectoryNameOfFileAbove(..., '')` followed by project-level wildcard item expansion.

### Compatibility
This is a bug fix that restores correct filesystem query semantics. It does not add warnings, errors, public API, or ChangeWave-gated behavior.

### Testing
- `dotnet test src\Build.UnitTests\Microsoft.Build.Engine.UnitTests.csproj -f net10.0 -- --filter-class "*ProjectEvaluationContext_Tests"`
- Reproduced the original issue with installed `dotnet`, then verified it passes with `artifacts\bin\bootstrap\core\dotnet.exe` from this branch.
- Reproduced and verified the pure MSBuild `.proj` repro with installed `dotnet msbuild` vs this branch's bootstrap.