### PR TITLE
Fix MSBuild Server client dropping build result under WaitAny race (#14172)

### DIFF
--- a/src/Build.UnitTests/BackEnd/MSBuildClient_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/MSBuildClient_Tests.cs
@@ -121,12 +121,29 @@ namespace Microsoft.Build.UnitTests.BackEnd
             pump.PacketReceivedEvent.Set();
             pump.PacketPumpCompleted.Set();
 
-            MSBuildClientExitResult result = client.ProcessSeededPacketsForTests(pump);
+            // Capture stdout so we can assert the dropped-summary symptom directly (and keep the seeded
+            // console write out of the real test-run output).
+            MSBuildClientExitResult result;
+            using StringWriter capturedConsole = new StringWriter();
+            TextWriter originalConsoleOut = Console.Out;
+            Console.SetOut(capturedConsole);
+            try
+            {
+                result = client.ProcessSeededPacketsForTests(pump);
+            }
+            finally
+            {
+                Console.SetOut(originalConsoleOut);
+            }
 
             // The build result must be surfaced, not dropped: the client stays Success and forwards the
             // server's exit type string (which MSBuildClientApp maps to a zero process exit code).
             result.MSBuildClientExitType.ShouldBe(MSBuildClientExitType.Success);
             result.MSBuildAppExitTypeString.ShouldBe("Success");
+
+            // The trailing console write queued right before the result - the "Build succeeded." summary
+            // that #14172 dropped - must also be flushed, not stranded behind the drained result.
+            capturedConsole.ToString().ShouldContain("Build succeeded.");
         }
     }
 }

--- a/src/Build.UnitTests/BackEnd/MSBuildClient_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/MSBuildClient_Tests.cs
@@ -6,6 +6,8 @@
 using System;
 using System.IO;
 using System.Threading;
+using Microsoft.Build.BackEnd;
+using Microsoft.Build.BackEnd.Client;
 using Microsoft.Build.Experimental;
 using Microsoft.Build.UnitTests;
 using Shouldly;
@@ -84,6 +86,47 @@ namespace Microsoft.Build.UnitTests.BackEnd
             // signal to pick the generic "server unavailable" message rather than the more
             // specific "crashed with exit code N" one.)
             result.ServerProcessExitCode.ShouldBeNull();
+        }
+
+        /// <summary>
+        /// Regression coverage for https://github.com/dotnet/msbuild/issues/14172. On Linux under full CPU
+        /// saturation, a warm <c>/mt</c> MSBuild Server build that succeeded would intermittently exit 1 with
+        /// the final <c>Build succeeded.</c> summary dropped.
+        /// </summary>
+        /// <remarks>
+        /// Root cause: the client's packet-processing loop waits on
+        /// <c>WaitAny([cancel, PacketPumpCompleted, PacketReceivedEvent])</c>. The pump enqueues the final
+        /// <see cref="ServerNodeBuildResult"/> (and trailing console writes) and then sets
+        /// <c>PacketPumpCompleted</c> - a sticky <see cref="ManualResetEvent"/> that sorts before
+        /// <c>PacketReceivedEvent</c>. If the (descheduled) main loop reaches <c>WaitAny</c> after both are
+        /// signaled, it took the completed branch, which set <c>_buildFinished</c> WITHOUT draining the queue,
+        /// dropping the result. That left <see cref="MSBuildClientExitResult.MSBuildAppExitTypeString"/> null,
+        /// which <c>MSBuildClientApp</c> maps to a non-zero process exit. This test arranges that exact event
+        /// ordering deterministically (both events pre-signaled with the result already queued, so
+        /// <c>WaitAny</c> returns the completed branch) and asserts the result is still processed.
+        /// </remarks>
+        [Fact]
+        public void ProcessPackets_WhenPumpCompletedRacesQueuedResult_DoesNotDropBuildResult()
+        {
+            using TestEnvironment env = TestEnvironment.Create(_output);
+
+            MSBuildClient client = new MSBuildClient(["dummy.proj"], "MSBuild.dll");
+
+            using MSBuildClientPacketPump pump = new MSBuildClientPacketPump(new MemoryStream());
+
+            // Seed the queue with the trailing console write and the build result, then signal both the
+            // received event and the (sticky) completion event, mirroring the server's teardown ordering.
+            pump.ReceivedPacketsQueue.Enqueue(new ServerNodeConsoleWrite("Build succeeded." + Environment.NewLine, ConsoleOutput.Standard));
+            pump.ReceivedPacketsQueue.Enqueue(new ServerNodeBuildResult(0, "Success"));
+            pump.PacketReceivedEvent.Set();
+            pump.PacketPumpCompleted.Set();
+
+            MSBuildClientExitResult result = client.ProcessSeededPacketsForTests(pump);
+
+            // The build result must be surfaced, not dropped: the client stays Success and forwards the
+            // server's exit type string (which MSBuildClientApp maps to a zero process exit code).
+            result.MSBuildClientExitType.ShouldBe(MSBuildClientExitType.Success);
+            result.MSBuildAppExitTypeString.ShouldBe("Success");
         }
     }
 }

--- a/src/Build/BackEnd/Client/MSBuildClient.cs
+++ b/src/Build/BackEnd/Client/MSBuildClient.cs
@@ -339,48 +339,72 @@ namespace Microsoft.Build.Experimental
                 packetPump.RegisterPacketHandler(NodePacketType.ServerNodeBuildResult, ServerNodeBuildResult.FactoryForDeserialization, packetPump);
                 packetPump.Start();
 
-                WaitHandle[] waitHandles =
-                {
-                    cancellationToken.WaitHandle,
-                    packetPump.PacketPumpCompleted,
-                    packetPump.PacketReceivedEvent
-                };
-
-                while (!_buildFinished)
-                {
-                    int index = WaitHandle.WaitAny(waitHandles);
-                    switch (index)
-                    {
-                        case 0:
-                            HandleCancellation();
-                            // After the cancelation, we want to wait to server gracefuly finish the build.
-                            // We have to replace the cancelation handle, because WaitAny would cause to repeatedly hit this branch of code.
-                            waitHandles[0] = CancellationToken.None.WaitHandle;
-                            break;
-
-                        case 1:
-                            HandlePacketPumpCompleted(packetPump);
-                            break;
-
-                        case 2:
-                            while (packetPump.ReceivedPacketsQueue.TryDequeue(out INodePacket? packet) &&
-                                   !_buildFinished)
-                            {
-                                if (packet != null)
-                                {
-                                    HandlePacket(packet);
-                                }
-                            }
-
-                            break;
-                    }
-                }
+                ProcessPacketsUntilBuildFinished(packetPump, cancellationToken);
             }
             catch (Exception ex)
             {
                 CommunicationsUtilities.Trace($"MSBuild client error: problem during packet handling occurred: {ex}.");
                 _exitResult.MSBuildClientExitType = MSBuildClientExitType.Unexpected;
             }
+        }
+
+        /// <summary>
+        /// Consumes packets produced by <paramref name="packetPump"/> until the build finishes (the
+        /// <see cref="ServerNodeBuildResult"/> is processed), the pump completes, or cancellation is requested.
+        /// </summary>
+        private void ProcessPacketsUntilBuildFinished(MSBuildClientPacketPump packetPump, CancellationToken cancellationToken)
+        {
+            WaitHandle[] waitHandles =
+            {
+                cancellationToken.WaitHandle,
+                packetPump.PacketPumpCompleted,
+                packetPump.PacketReceivedEvent
+            };
+
+            while (!_buildFinished)
+            {
+                int index = WaitHandle.WaitAny(waitHandles);
+                switch (index)
+                {
+                    case 0:
+                        HandleCancellation();
+                        // After the cancelation, we want to wait to server gracefuly finish the build.
+                        // We have to replace the cancelation handle, because WaitAny would cause to repeatedly hit this branch of code.
+                        waitHandles[0] = CancellationToken.None.WaitHandle;
+                        break;
+
+                    case 1:
+                        // The packet pump signals PacketPumpCompleted (a sticky ManualResetEvent at a
+                        // lower WaitAny index than PacketReceivedEvent) immediately after enqueuing the
+                        // final ServerNodeBuildResult. Drain any packets it enqueued right before
+                        // completing - that result plus trailing console writes such as the
+                        // "Build succeeded." summary - before treating the pump as finished. Otherwise a
+                        // race where WaitAny observes index 1 before the queue is drained would drop the
+                        // build result and exit 1 on a successful build (#14172).
+                        DrainPacketQueue(packetPump);
+                        if (!_buildFinished)
+                        {
+                            HandlePacketPumpCompleted(packetPump);
+                        }
+
+                        break;
+
+                    case 2:
+                        DrainPacketQueue(packetPump);
+                        break;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Test hook for the #14172 regression: drives <see cref="ProcessPacketsUntilBuildFinished"/> against a
+        /// pump whose received-packets queue and completion event have already been seeded, without needing a
+        /// live server pipe, and returns the resulting <see cref="MSBuildClientExitResult"/>.
+        /// </summary>
+        internal MSBuildClientExitResult ProcessSeededPacketsForTests(MSBuildClientPacketPump packetPump)
+        {
+            ProcessPacketsUntilBuildFinished(packetPump, CancellationToken.None);
+            return _exitResult;
         }
 
         private void ConfigureAndQueryConsoleProperties()
@@ -617,6 +641,25 @@ namespace Microsoft.Build.Experimental
             }
 
             _buildFinished = true;
+        }
+
+        /// <summary>
+        /// Processes every packet currently sitting in the packet pump's received queue, stopping early
+        /// once the build result has been handled. Shared by the PacketReceivedEvent and
+        /// PacketPumpCompleted branches so that packets the pump enqueues immediately before it completes
+        /// (notably the final <see cref="ServerNodeBuildResult"/> and trailing console output) are never
+        /// dropped by an event-ordering race. See https://github.com/dotnet/msbuild/issues/14172.
+        /// </summary>
+        private void DrainPacketQueue(MSBuildClientPacketPump packetPump)
+        {
+            while (packetPump.ReceivedPacketsQueue.TryDequeue(out INodePacket? packet) &&
+                   !_buildFinished)
+            {
+                if (packet != null)
+                {
+                    HandlePacket(packet);
+                }
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary

Addresses #14172: on Linux with MSBuild Server (`/mt`), a build that **succeeds** intermittently makes the entry process **exit 1** with the final `Build succeeded.` summary dropped (no error printed).

## Root cause

The MSBuild Server client's packet loop waits on `WaitAny([cancellation, PacketPumpCompleted, PacketReceivedEvent])`:

- `PacketPumpCompleted` is a **sticky `ManualResetEvent` at a lower `WaitAny` index** than `PacketReceivedEvent`.
- The packet pump enqueues the final `ServerNodeBuildResult` (setting `PacketReceivedEvent`) and then, a few instructions later, sets `PacketPumpCompleted`.
- If the main loop reaches `WaitAny` when **both** are already signaled, it returns the lower index and runs `HandlePacketPumpCompleted`, which set `_buildFinished = true` **without draining the queue** — dropping the queued `ServerNodeBuildResult` and any trailing console writes (e.g. the `Build succeeded.` summary).
- With no result processed, `MSBuildAppExitTypeString` stays `null`, so `MSBuildClientApp.Execute` returns `MSBuildApp.ExitType.MSBuildClientFailure` → the process exits **1** on a successful build.

This regressed in #7852, which changed the index‑1 wait handle from an **error‑only** event to the **always‑set** `PacketPumpCompleted` without making the handler drain the received-packets queue. Before that change, the low‑priority handle only fired on genuine errors, so a successful result was always drained via the `PacketReceivedEvent` branch.

## Fix

Drain the received-packets queue **before** honoring `PacketPumpCompleted`:

- Extracted the loop into `ProcessPacketsUntilBuildFinished` and added a shared `DrainPacketQueue` helper used by both the `PacketReceivedEvent` and `PacketPumpCompleted` branches.
- A **delivered result is honored even if the pump also recorded an exception** (`DrainPacketQueue`, then `if (!_buildFinished) HandlePacketPumpCompleted(...)`), and queued console output is flushed on all completion paths.
- Exception propagation for a genuine mid-build disconnect (no result delivered) is preserved.

## Testing

- **Deterministic reproduction (both Windows and Linux):** with an env‑gated stall that arranges the main loop to reach `WaitAny` after both events are set (the descheduling that CPU saturation causes naturally), the pre‑fix binary reproduces the exact symptom — exit 1, `Build succeeded.` dropped, no error, output truncated, with the trace confirming the `ServerNodeBuildResult` was still queued. With the fix, the same scenario exits 0 with the summary shown, and normal builds are unaffected. (Scaffolding not included in this PR.)
- **Regression unit test** (`MSBuildClient_Tests.ProcessPackets_WhenPumpCompletedRacesQueuedResult_DoesNotDropBuildResult`): drives the real loop with the result + summary queued and both events pre‑signaled; **fails on the pre‑fix loop, passes on the fixed one.**

## Notes on reproduction confidence

The field symptom only reproduces naturally under heavy CPU load on ~32‑core Linux (~2.3%); it did not reproduce end‑to‑end on a 16‑vCPU box. The mechanism is confirmed by the deterministic forced‑race and by ruling out the two competing hypotheses in code (the server writes the result before closing the pipe — `Join()` before `Dispose()` with drain‑on‑terminate — so it is always delivered; and the build's exit type is frozen before the result is sent, so late node/TaskHost teardown cannot corrupt it). A failing‑build client `MSBUILDDEBUGCOMM` trace would make the attribution airtight; this change removes a real latent defect matching the symptom with no behavioral regression.
