### PR TITLE
[CI] Build all PR legs with -mt + MSBuild server; stop forcing node reuse off in CI

### DIFF
--- a/.vsts-dotnet-ci.yml
+++ b/.vsts-dotnet-ci.yml
@@ -101,6 +101,8 @@ jobs:
       arguments: '-onlyDocChanged $(onlyDocChanged) -stage2Properties /mt'
     env:
       ForceUseXCopyMSBuild: 1
+      MSBUILDUSESERVER: "1"
+      DOTNET_CLI_USE_MSBUILD_SERVER: "1"
 # Task to collect code coverage on Windows. Disabled by default due to being unstable and sometimes it stucks forever
 #   - task: PowerShell@2
 #     displayName: Process coverage reports
@@ -213,6 +215,7 @@ jobs:
       arguments: '-msbuildEngine dotnet -onlyDocChanged $(onlyDocChanged) -stage2Properties /mt'
     env:
       MSBUILDUSESERVER: "1"
+      DOTNET_CLI_USE_MSBUILD_SERVER: "1"
 # Task to collect code coverage on Windows. Disabled by default due to being unstable and sometimes it stucks forever
 #   - task: PowerShell@2
 #     displayName: Process coverage reports
@@ -292,6 +295,7 @@ jobs:
     condition: eq(variables.onlyDocChanged, 0)
     env:
       MSBUILDUSESERVER: "1"
+      DOTNET_CLI_USE_MSBUILD_SERVER: "1"
   - task: PublishBuildArtifacts@1
     displayName: 'Publish Artifact: logs'
     inputs:
@@ -327,14 +331,20 @@ jobs:
     displayName: cibuild.cmd
     inputs:
       filename: 'eng/cibuild.cmd'
-      arguments: '-configuration Release -test'
+      arguments: '-configuration Release -test /mt'
     condition: eq(variables.onlyDocChanged, 0)
+    env:
+      MSBUILDUSESERVER: "1"
+      DOTNET_CLI_USE_MSBUILD_SERVER: "1"
   - task: BatchScript@1
     displayName: cibuild.cmd without test
     inputs:
       filename: 'eng/cibuild.cmd'
-      arguments: '-configuration Release'
+      arguments: '-configuration Release /mt'
     condition: eq(variables.onlyDocChanged, 1)
+    env:
+      MSBUILDUSESERVER: "1"
+      DOTNET_CLI_USE_MSBUILD_SERVER: "1"
 # Task to collect code coverage on Windows. Disabled by default due to being unstable and sometimes it stucks forever
 #   - task: PowerShell@2
 #     displayName: Process coverage reports
@@ -413,6 +423,7 @@ jobs:
     displayName: CI Build
     env:
         MSBUILDUSESERVER: "1"
+        DOTNET_CLI_USE_MSBUILD_SERVER: "1"
   - task: Bash@3
     displayName: Process coverage reports
     continueOnError: false
@@ -501,6 +512,7 @@ jobs:
     displayName: CI Build
     env:
         MSBUILDUSESERVER: "1"
+        DOTNET_CLI_USE_MSBUILD_SERVER: "1"
   - task: Bash@3
     displayName: Process coverage reports
     continueOnError: false

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -81,7 +81,11 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <BootstrapSdkVersion>10.0.300</BootstrapSdkVersion>
+    <!-- TEMPORARY (this PR only): bump stage-1/bootstrap SDK to a 10.0.4xx daily.
+         SDK 10.0.300's MSBuild (18.6.3) crashes instead of falling back when
+         DOTNET_CLI_USE_MSBUILD_SERVER=1 and the server can't be reached, which broke the
+         Linux/macOS Core legs once we enabled the server. Keep in sync with global.json. -->
+    <BootstrapSdkVersion>10.0.400-preview.0.26352.102</BootstrapSdkVersion>
   </PropertyGroup>
 
   <Target Name="OverrideArcadeFileVersion" AfterTargets="_InitializeAssemblyVersion">

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -101,7 +101,6 @@ function Process-Arguments() {
 
   if ($ci) {
     $script:binaryLog = $true
-    $script:nodeReuse = $false
   }
 }
 

--- a/eng/cibuild_bootstrapped_msbuild.ps1
+++ b/eng/cibuild_bootstrapped_msbuild.ps1
@@ -128,7 +128,7 @@ try {
   $env:DOTNET_HOST_PATH=$dotnetExePath
 
   # When using bootstrapped MSBuild:
-  # - Turn off node reuse (so that bootstrapped MSBuild processes don't stay running and lock files)
+  # - Keep node reuse enabled so the MSBuild server can be used (the server is disabled when node reuse is off)
   # - Create bootstrap environment as it's required when also running tests
   # - $stage2Properties are appended to the stage 2 build only (matching cibuild_bootstrapped_msbuild.sh).
   #   Use this for switches like /mt that should not be passed to the stable MSBuild used in stage 1
@@ -143,13 +143,13 @@ try {
   # single token.
   $stage2Args = @(if ($stage2Properties) { $stage2Properties -split '\s+' | Where-Object { $_ } } else { @() })
   if ($onlyDocChanged) {
-    & $PSScriptRoot\Common\Build.ps1 -restore -build -ci /p:CreateBootstrap=false /nr:false @properties @stage2Args
+    & $PSScriptRoot\Common\Build.ps1 -restore -build -ci /p:CreateBootstrap=false @properties @stage2Args
   }
   elseif ($skipTests) {
-    & $PSScriptRoot\Common\Build.ps1 -restore -build -ci /nr:false @properties @stage2Args
+    & $PSScriptRoot\Common\Build.ps1 -restore -build -ci @properties @stage2Args
   }
   else {
-    & $PSScriptRoot\Common\Build.ps1 -restore -build -test -ci /nr:false @properties @stage2Args
+    & $PSScriptRoot\Common\Build.ps1 -restore -build -test -ci @properties @stage2Args
   }
 
   exit $lastExitCode

--- a/eng/cibuild_bootstrapped_msbuild.sh
+++ b/eng/cibuild_bootstrapped_msbuild.sh
@@ -96,17 +96,17 @@ export DOTNET_PERFLOG_DIR=$PerfLogDir
 export DOTNET_HOST_PATH="$_InitializeDotNetCli/dotnet"
 
 # When using bootstrapped MSBuild:
-# - Turn off node reuse (so that bootstrapped MSBuild processes don't stay running and lock files)
+# - Keep node reuse enabled so the MSBuild server can be used (the server is disabled when node reuse is off)
 # - Create bootstrap environment as it's required when also running tests
 # - stage2Properties are passed to all Stage 2 builds since some MSBuild switches (like /mt) may not work with the SDK MSBuild used in Stage 1
 if [ $onlyDocChanged = 0 ]
 then
     if [ "$skipTests" = true ]
     then
-        . "$ScriptRoot/common/build.sh" --restore --build --ci --nodereuse false --configuration $configuration $properties $extra_properties $stage2Properties
+        . "$ScriptRoot/common/build.sh" --restore --build --ci --configuration $configuration $properties $extra_properties $stage2Properties
     else
-        . "$ScriptRoot/common/build.sh" --restore --build --test --ci --nodereuse false --configuration $configuration $properties $extra_properties $stage2Properties
+        . "$ScriptRoot/common/build.sh" --restore --build --test --ci --configuration $configuration $properties $extra_properties $stage2Properties
     fi
 else
-    . "$ScriptRoot/common/build.sh" --restore --build --ci --nodereuse false --configuration $configuration /p:CreateBootstrap=false $properties $extra_properties $stage2Properties
+    . "$ScriptRoot/common/build.sh" --restore --build --ci --configuration $configuration /p:CreateBootstrap=false $properties $extra_properties $stage2Properties
 fi

--- a/eng/common/build.ps1
+++ b/eng/common/build.ps1
@@ -157,7 +157,6 @@ try {
     if (-not $excludeCIBinarylog) {
       $binaryLog = $true
     }
-    $nodeReuse = $false
   }
 
   if ($nativeToolsOnMachine) {

--- a/eng/common/build.sh
+++ b/eng/common/build.sh
@@ -205,7 +205,6 @@ fi
 
 if [[ "$ci" == true ]]; then
   pipelines_log=true
-  node_reuse=false
   if [[ "$exclude_ci_binary_log" == false ]]; then
     binary_log=true
   fi

--- a/eng/common/msbuild.ps1
+++ b/eng/common/msbuild.ps1
@@ -13,10 +13,6 @@ Param(
 . $PSScriptRoot\tools.ps1
 
 try {
-  if ($ci) {
-    $nodeReuse = $false
-  }
-
   MSBuild @extraArgs
 } 
 catch {

--- a/eng/common/msbuild.sh
+++ b/eng/common/msbuild.sh
@@ -50,9 +50,5 @@ done
 
 . "$scriptroot/tools.sh"
 
-if [[ "$ci" == true ]]; then
-  node_reuse=false
-fi
-
 MSBuild $extra_args
 ExitWithExitCode 0

--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -811,11 +811,6 @@ function MSBuild-Core() {
       Write-PipelineTelemetryError -Category 'Build' -Message 'Binary log must be enabled in CI build, or explicitly opted-out from with the -excludeCIBinarylog switch.'
       ExitWithExitCode 1
     }
-
-    if ($nodeReuse) {
-      Write-PipelineTelemetryError -Category 'Build' -Message 'Node reuse must be disabled in CI build.'
-      ExitWithExitCode 1
-    }
   }
 
   Enable-Nuget-EnhancedRetry

--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -490,11 +490,6 @@ function MSBuild-Core {
       Write-PipelineTelemetryError -category 'Build'  "Binary log must be enabled in CI build, or explicitly opted-out from with the -noBinaryLog switch."
       ExitWithExitCode 1
     fi
-
-    if [[ "$node_reuse" == true ]]; then
-      Write-PipelineTelemetryError -category 'Build'  "Node reuse must be disabled in CI build."
-      ExitWithExitCode 1
-    fi
   fi
 
   InitializeBuildTool

--- a/global.json
+++ b/global.json
@@ -10,7 +10,7 @@
     "runner": "Microsoft.Testing.Platform"
   },
   "tools": {
-    "dotnet": "10.0.300",
+    "dotnet": "10.0.400-preview.0.26352.102",
     "vs": {
       "version": "18.0"
     },


### PR DESCRIPTION
## What

Make the **PR check pipeline** (`.vsts-dotnet-ci.yml`) always build with:

- the multithreaded switch **`/mt`**, and
- the MSBuild server enabled via **`MSBUILDUSESERVER=1`** and **`DOTNET_CLI_USE_MSBUILD_SERVER=1`**

on **every** build leg: Windows Full, Windows Core, Linux Core, Linux Core (MT mode), macOS Core, and Windows Full Release (no bootstrap).

## Why the node-reuse changes

The MSBuild server is **disabled when node reuse is off** (`XMake.cs` `CanRunServerBasedOnCommandLineSwitches` → `MSBuildServerReasonNodeReuseDisabled`). Our bootstrap scripts and Arcade force node reuse off in CI — and `tools.{ps1,sh}` even hard-error if it is on — so the server would never actually run. This PR removes that logic:

- `eng/cibuild_bootstrapped_msbuild.{ps1,sh}` — drop `/nr:false` / `--nodereuse false` on the stage-2 build
- `eng/build.ps1`, `eng/common/build.{ps1,sh}`, `eng/common/msbuild.{ps1,sh}` — stop setting `nodeReuse=false` in CI
- `eng/common/tools.{ps1,sh}` — remove the "Node reuse must be disabled in CI build" guard

## Notes

- ⚠️ `eng/common/*` are Arcade-managed files, edited here **intentionally** for this experiment; a future Arcade update may revert them.
- Draft: opened to observe the server + `/mt` behavior across all CI legs.
