### PR TITLE
[wip experiment] Key transient MSBuild Server per build root, not one-per-machine

### DIFF
--- a/documentation/MSBuild-Server.md
+++ b/documentation/MSBuild-Server.md
@@ -21,6 +21,10 @@ MSBuild Server is a form of node reuse: the whole point of the server is to stay
 
 The client makes a single, response-file-aware determination and sets the `ShutdownAfterBuild` flag on the `ServerNodeBuildCommand` packet if server needs shutdown.
 
+### Per-root keying of transient servers
+
+A resident (reusable) server is keyed one-per-machine (per architecture/user/version/etc.) so any compatible client reuses it. A **transient** server - a `/mt` build with node reuse off, which shuts down after its build - is instead keyed **per build root**: the entry project's full path (or the current directory when none is resolved) is folded into the handshake salt. This means parallel builds of *different* roots each launch and use their own short-lived Server-GC server, instead of contending for a single machine-wide server where all but one build would find it busy and fall back to an in-process, Workstation-GC build. Builds of the *same* root still share one server (the second concurrent build of the same root falls back), so it is "one transient server per root", not one unbounded server per invocation. Because the salt drives the pipe and mutex names (see [Pipe name convention & handshake](#pipe-name-convention--handshake)) and the launched server inherits the client's environment, both the client and its server derive the same per-root names.
+
 ## Communication protocol
 
 The server node uses same IPC approach as current worker nodes - named pipes. This solution allows to reuse existing code. When process starts, pipe with deterministic name is opened and waiting for commands. Client has following worfklow:

--- a/src/MSBuild.UnitTests/MSBuildServer_Tests.cs
+++ b/src/MSBuild.UnitTests/MSBuildServer_Tests.cs
@@ -468,6 +468,88 @@ namespace Microsoft.Build.Engine.UnitTests
         }
 
         /// <summary>
+        /// A transient (/mt with node reuse off) server is keyed per build root, not one-per-machine. Two builds
+        /// of <em>different</em> roots running concurrently must therefore each get their own Server-GC server
+        /// process, rather than contending for a single machine-wide server (where the second would find it busy
+        /// and fall back to an in-process, Workstation-GC build). This verifies that two concurrent distinct-root
+        /// builds run in two distinct, simultaneously-alive server processes, both with Server GC, and that both
+        /// servers shut down afterward (honoring the no-reuse intent).
+        /// </summary>
+        [Fact]
+        public void TransientServerIsKeyedPerRootAllowingConcurrentServers()
+        {
+            if (Environment.ProcessorCount < 2)
+            {
+                Assert.Skip("Server GC can report as Workstation GC on single-processor machines.");
+            }
+
+            // Clear MSBUILDUSESERVER so we exercise the -mt-implies-server path, and isolate this test's servers
+            // with a unique base handshake salt (each root then adds its own suffix on top of it).
+            PrepareIsolatedServerEnv(useServer: false);
+
+            // Two different roots: distinct project files => distinct entry-project full paths => distinct salts.
+            TransientTestFile markerA = _env.ExpectFile();
+            TransientTestFile markerB = _env.ExpectFile();
+            TransientTestFile projectA = _env.CreateFile("rootA.proj", GetConcurrentServerGCProbeProjectContents(markerA.Path, sleepMs: 6000));
+            TransientTestFile projectB = _env.CreateFile("rootB.proj", GetConcurrentServerGCProbeProjectContents(markerB.Path, sleepMs: 6000));
+
+            // Make sure we start with no server running.
+            MSBuildClient.ShutdownServer(CancellationToken.None);
+
+            string exePath = BuildEnvironmentHelper.Instance.CurrentMSBuildExePath;
+            bool successA = false, successB = false;
+            string? outputA = null, outputB = null;
+            try
+            {
+                // Launch both builds concurrently. Each build's task sleeps a few seconds, guaranteeing the two
+                // builds overlap in time so their servers must coexist.
+                Task<string> buildA = Task.Run(() => RunnerUtilities.ExecMSBuild(exePath, $"{projectA.Path} -mt -nr:false", out successA, false, _output));
+                Task<string> buildB = Task.Run(() => RunnerUtilities.ExecMSBuild(exePath, $"{projectB.Path} -mt -nr:false", out successB, false, _output));
+
+                // While both builds are still sleeping, capture the two server PIDs from their markers and prove
+                // both processes are alive at the same time - two concurrent servers, which a single machine-wide
+                // server could not provide.
+                int serverPidA = WaitForMarkerPid(markerA.Path);
+                int serverPidB = WaitForMarkerPid(markerB.Path);
+                _env.WithTransientProcess(serverPidA);
+                _env.WithTransientProcess(serverPidB);
+
+                serverPidA.ShouldNotBe(serverPidB, "Concurrent builds of different roots must run in different server processes when the transient server is keyed per root.");
+                IsProcessAlive(serverPidA).ShouldBeTrue($"Server process {serverPidA} for root A should be alive concurrently with root B's server.");
+                IsProcessAlive(serverPidB).ShouldBeTrue($"Server process {serverPidB} for root B should be alive concurrently with root A's server.");
+
+                outputA = buildA.GetAwaiter().GetResult();
+                outputB = buildB.GetAwaiter().GetResult();
+            }
+            finally
+            {
+                MSBuildClient.ShutdownServer(CancellationToken.None);
+            }
+
+            successA.ShouldBeTrue();
+            successB.ShouldBeTrue();
+
+            // Both builds completed successfully above, so their outputs are populated.
+            string resultA = outputA!;
+            string resultB = outputB!;
+
+            // Each build ran in its own server node (not the entry process) with Server GC.
+            int clientPidA = ParseNumber(resultA, "Process ID is ");
+            int clientPidB = ParseNumber(resultB, "Process ID is ");
+            int serverTaskPidA = ParseNumber(resultA, "TaskRanInPID=");
+            int serverTaskPidB = ParseNumber(resultB, "TaskRanInPID=");
+            serverTaskPidA.ShouldNotBe(clientPidA, "Root A's build should run in its server node, not the entry process.");
+            serverTaskPidB.ShouldNotBe(clientPidB, "Root B's build should run in its server node, not the entry process.");
+            serverTaskPidA.ShouldNotBe(serverTaskPidB, "Each root should build in its own dedicated server process.");
+            resultA.ShouldContain("TaskNodeServerGC=True", customMessage: "Root A's transient /mt server should run with Server GC.");
+            resultB.ShouldContain("TaskNodeServerGC=True", customMessage: "Root B's transient /mt server should run with Server GC.");
+
+            // Transient: because node reuse is disabled, both server processes must be gone after their builds.
+            WaitForProcessExit(serverTaskPidA).ShouldBeTrue($"Server {serverTaskPidA} should shut down after root A's build (node reuse disabled).");
+            WaitForProcessExit(serverTaskPidB).ShouldBeTrue($"Server {serverTaskPidB} should shut down after root B's build (node reuse disabled).");
+        }
+
+        /// <summary>
         /// Waits up to <paramref name="timeoutMs"/> for the process with the given PID to exit. Returns true if
         /// the process exited (or was already gone), false if it was still running when the timeout elapsed.
         /// </summary>
@@ -482,6 +564,56 @@ namespace Microsoft.Build.Engine.UnitTests
             {
                 // No process with that PID is running - it has already exited.
                 return true;
+            }
+        }
+
+        /// <summary>
+        /// Polls <paramref name="markerPath"/> until the probe task has written a server PID into it (or the
+        /// timeout elapses). Used to observe a running server while its build sleeps.
+        /// </summary>
+        private static int WaitForMarkerPid(string markerPath, int timeoutMs = 30000)
+        {
+            Stopwatch stopwatch = Stopwatch.StartNew();
+            while (stopwatch.ElapsedMilliseconds < timeoutMs)
+            {
+                if (File.Exists(markerPath))
+                {
+                    string? text = null;
+                    try
+                    {
+                        text = File.ReadAllText(markerPath).Trim();
+                    }
+                    catch (IOException)
+                    {
+                        // The probe may still be writing the file; retry.
+                    }
+
+                    if (!string.IsNullOrEmpty(text) && int.TryParse(text, out int pid))
+                    {
+                        return pid;
+                    }
+                }
+
+                Thread.Sleep(50);
+            }
+
+            throw new TimeoutException($"Marker file '{markerPath}' did not report a server PID within {timeoutMs} ms.");
+        }
+
+        /// <summary>
+        /// Returns true if a process with the given PID currently exists and has not exited.
+        /// </summary>
+        private static bool IsProcessAlive(int pid)
+        {
+            try
+            {
+                using Process process = Process.GetProcessById(pid);
+                return !process.HasExited;
+            }
+            catch (ArgumentException)
+            {
+                // No process with that PID is running.
+                return false;
             }
         }
 #endif
@@ -548,6 +680,31 @@ namespace Microsoft.Build.Engine.UnitTests
         </ProcessIdTask>
         <Message Text=""[Work around GitHub issue #9667 with --interactive]TaskRanInPID=$(PID)"" Importance=""High"" />
         <Message Text=""TaskNodeServerGC=$(SERVERGC)"" Importance=""High"" />
+    </Target>
+</Project>";
+        }
+
+        /// <summary>
+        /// Like <see cref="GetServerGCProbeProjectContents"/> but, after reporting its PID and GC mode, records the
+        /// executing process's PID to <paramref name="markerFile"/> and then sleeps for <paramref name="sleepMs"/>
+        /// milliseconds. The marker lets a test observe the running server, and the sleep keeps concurrent builds of
+        /// different roots overlapping in time so their servers must coexist.
+        /// </summary>
+        private static string GetConcurrentServerGCProbeProjectContents(string markerFile, int sleepMs)
+        {
+            return $@"
+<Project>
+<UsingTask TaskName=""ProcessIdTask"" AssemblyFile=""{Assembly.GetExecutingAssembly().Location}"" />
+<UsingTask TaskName=""SleepingTask"" AssemblyFile=""{Assembly.GetExecutingAssembly().Location}"" />
+    <Target Name='Probe'>
+        <ProcessIdTask>
+            <Output PropertyName=""PID"" TaskParameter=""Pid"" />
+            <Output PropertyName=""SERVERGC"" TaskParameter=""IsServerGC"" />
+        </ProcessIdTask>
+        <WriteLinesToFile File=""{markerFile}"" Lines=""$(PID)"" Overwrite=""true"" />
+        <Message Text=""[Work around GitHub issue #9667 with --interactive]TaskRanInPID=$(PID)"" Importance=""High"" />
+        <Message Text=""TaskNodeServerGC=$(SERVERGC)"" Importance=""High"" />
+        <SleepingTask SleepTime=""{sleepMs}"" />
     </Target>
 </Project>";
         }

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -319,6 +319,7 @@ namespace Microsoft.Build.CommandLine
                 args,
                 out bool multiThreaded,
                 out bool shutdownServerAfterBuild,
+                out string serverRootKey,
                 out CommandLineSwitches switchesFromAutoResponseFile,
                 out CommandLineSwitches switchesNotFromAutoResponseFile);
 
@@ -333,6 +334,18 @@ namespace Microsoft.Build.CommandLine
                 if (KnownTelemetry.PartialBuildTelemetry is not null)
                 {
                     KnownTelemetry.PartialBuildTelemetry.ServerEnableReason = serverEnableReason;
+                }
+
+                // A transient server (a /mt build with node reuse off) is not shared for reuse, so it is
+                // keyed per build root instead of one-per-machine: parallel builds of different roots each
+                // get their own short-lived Server-GC server rather than contending for a single machine-wide
+                // server (where all but one would fall back to an in-process, Workstation-GC build). The root
+                // is folded into the handshake salt, which both this client and the server it launches (which
+                // inherits this environment) read, so their pipe and mutex names differ per root.
+                if (shutdownServerAfterBuild && !string.IsNullOrEmpty(serverRootKey))
+                {
+                    string existingSalt = Environment.GetEnvironmentVariable("MSBUILDNODEHANDSHAKESALT") ?? string.Empty;
+                    Environment.SetEnvironmentVariable("MSBUILDNODEHANDSHAKESALT", $"{existingSalt}|root={serverRootKey}");
                 }
 
                 // Hand the build off to the MSBuild Server client. The server (not this process) decides
@@ -373,6 +386,11 @@ namespace Microsoft.Build.CommandLine
         /// and honor MSBUILDFORCEMULTITHREADED) using the same logic as the in-proc build path.</param>
         /// <param name="shutdownServerAfterBuild">Set to <see langword="true"/> when the server should tear itself
         /// down after this build instead of staying resident for reuse.</param>
+        /// <param name="serverRootKey">Set to a per-build-root key (the normalized full path of the entry
+        /// project, or the current directory when none is resolved) when <paramref name="shutdownServerAfterBuild"/>
+        /// is <see langword="true"/>; otherwise <see langword="null"/>. A transient server is keyed per root so
+        /// parallel builds of different roots each get their own short-lived server instead of one machine-wide
+        /// server. Reusable servers stay machine-wide (this is <see langword="null"/> for them).</param>
         /// <param name="switchesFromAutoResponseFile">The gathered response-file switches (auto-response file plus any
         /// project <c>Directory.Build.rsp</c>), or <see langword="null"/> if parsing failed.</param>
         /// <param name="switchesNotFromAutoResponseFile">The gathered command-line/environment switches, or
@@ -381,12 +399,14 @@ namespace Microsoft.Build.CommandLine
             string[] commandLine,
             out bool multiThreaded,
             out bool shutdownServerAfterBuild,
+            out string serverRootKey,
             out CommandLineSwitches switchesFromAutoResponseFile,
             out CommandLineSwitches switchesNotFromAutoResponseFile)
         {
             bool canRunServer = true;
             multiThreaded = false;
             shutdownServerAfterBuild = false;
+            serverRootKey = null;
             switchesFromAutoResponseFile = null;
             switchesNotFromAutoResponseFile = null;
             bool switchesFullyGathered = false;
@@ -440,6 +460,16 @@ namespace Microsoft.Build.CommandLine
 
                 // When /mt forced the server on despite node reuse being disabled, the server must not persist past this build. 
                 shutdownServerAfterBuild = canRunServer && multiThreaded && !nodeReuse;
+
+                // A transient (non-reused) server is keyed per build root, so parallel builds of different
+                // roots each get their own short-lived Server-GC server instead of contending for one
+                // machine-wide server. The entry project's full path identifies the root; fall back to the
+                // current directory when no project was resolved (e.g. a directory-only invocation).
+                if (shutdownServerAfterBuild)
+                {
+                    string root = string.IsNullOrEmpty(projectFile) ? Directory.GetCurrentDirectory() : projectFile;
+                    serverRootKey = Path.GetFullPath(root);
+                }
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
### Context

A `/mt` build with node reuse off (`-nr:false`, as `dotnet restore` does) engages the MSBuild Server purely to obtain [Server GC](https://learn.microsoft.com/dotnet/standard/garbage-collection/workstation-server-gc), which `/mt` depends on for performance, and then shuts the server down after the build (added in #14248).

But the server's pipe and mutex names are **one-per-machine** (keyed by architecture/user/version/session). So when two such transient builds run at the same time, they contend for a single server: all but one find it busy and fall back to an in-process, **Workstation-GC** build — defeating the whole point of engaging the server under `/mt`.

### Change

Key transient (non-reused) servers **per build root** instead of one-per-machine:

- `CanRunServerBasedOnCommandLineSwitches` now emits a `serverRootKey` — the entry project's full path, or the current directory when no project is resolved — whenever `shutdownServerAfterBuild` is set (`/mt` + node reuse off).
- `Main` folds that key into the `MSBUILDNODEHANDSHAKESALT` before handing off to the client. The salt drives the handshake hash that names the pipe and mutex, and the launched server inherits the client's environment, so **both** derive the same per-root names.
- Parallel builds of **different** roots each get their own short-lived Server-GC server. Builds of the **same** root still share one server (the second concurrent build falls back), so it is "one transient server per root", not an unbounded number per invocation.
- **Reusable (non-transient) servers are unchanged** and remain one-per-machine.

### Testing

New unit test `TransientServerIsKeyedPerRootAllowingConcurrentServers`: two concurrent distinct-root `-mt -nr:false` builds run in two distinct, simultaneously-alive server processes, both with Server GC, and both shut down afterward. All existing `MSBuildServer_Tests` pass.

Verified live on the bootstrap:
- **3 / 5 distinct roots in parallel** → 3 / 5 distinct concurrent `/nodemode:8` servers, each `ServerGC=True`, 0 survivors afterward.
- **Same-root contrast** (3 clients, 1 root) → exactly **1** server (`ServerGC=True`); the other two fall back to in-proc Workstation-GC builds.
- **Real `dotnet build` muxer** (`DOTNET_CLI_USE_MSBUILD_SERVER=1`), 2 roots → two distinct `MSBuild.exe /nodemode:8` Server-GC servers concurrently, both transient.

Docs updated in `documentation/MSBuild-Server.md`.
