### PR TITLE
Avoid boxing the struct enumerator in PropertyDictionary<T>.GetEnumerator()

### DIFF
--- a/src/Build/Collections/PropertyDictionary.cs
+++ b/src/Build/Collections/PropertyDictionary.cs
@@ -240,9 +240,25 @@ namespace Microsoft.Build.Collections
         {
             using (_lock.EnterDisposableReadLock())
             {
-                foreach (T item in _properties.Values)
+                // PERF: Prefer the struct enumerator from the concrete hash set to avoid the allocation
+                // caused by boxing when iterating _properties.Values through the ICollection<T> interface.
+                // This fast path is the common case and hot (e.g. per-item metadata enumeration during
+                // ProjectInstance creation): all metadata and normally-constructed property dictionaries
+                // are backed by RetrievableValuedEntryHashSet<T>. The else branch only covers the rare
+                // linked/immutable-project converter types that also implement IRetrievableValuedEntryHashSet<T>.
+                if (_properties is RetrievableValuedEntryHashSet<T> hashSet)
                 {
-                    yield return item;
+                    foreach (T item in hashSet)
+                    {
+                        yield return item;
+                    }
+                }
+                else
+                {
+                    foreach (T item in _properties.Values)
+                    {
+                        yield return item;
+                    }
                 }
             }
         }
@@ -250,16 +266,7 @@ namespace Microsoft.Build.Collections
         /// <summary>
         /// Get an enumerator over entries.
         /// </summary>
-        IEnumerator IEnumerable.GetEnumerator()
-        {
-            using (_lock.EnterDisposableReadLock())
-            {
-                foreach (T item in _properties.Values)
-                {
-                    yield return item;
-                }
-            }
-        }
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
         #region IEquatable<PropertyDictionary<T>> Members
 


### PR DESCRIPTION
**&#129302; AI-Generated Pull Request &#129302;**

This pull request was generated by the **VS Perf Rel AI Agent**. Please review this AI-generated PR with extra care! For more information, visit our [wiki](https://devdiv.visualstudio.com/DevDiv/_wiki/wikis/DevDiv.wiki/49206/PerfRel-Agent).

---

- **Issue**:
`PropertyDictionary<T>.GetEnumerator()` enumerates its backing set through the `IEnumerable<T>` interface — it iterates `_properties.Values`, and `RetrievableEntryHashSet<T>.Values` returns `this` typed as `ICollection<T>`. Because the backing `RetrievableEntryHashSet<T>` exposes a **value-type** `Enumerator`, dispatching through the interface boxes that struct onto the heap on every enumeration: `IEnumerable<T>.GetEnumerator()` does `return new Enumerator(this)`, and the struct is boxed to satisfy the interface return type.
This runs once per project item that carries direct metadata during `ProjectInstance` construction (VS design-time / project-snapshot builds), making it a meaningful source of GC pressure during solution load.

  **Allocation sites** (`TypeAllocated!Enumerator[Microsoft.Build.Evaluation.ProjectMetadata]`, ~97% of sampled allocations; a further ~3% as `Enumerator[…Execution.ProjectPropertyInstance]`):
  ```
  PropertyDictionary<T>.GetEnumerator   (yield iterator)
   → foreach over _properties.Values          ← ICollection<T>, forces interface dispatch
     → RetrievableEntryHashSet<T>.IEnumerable<T>.GetEnumerator   ← return new Enumerator(this)
       → clr.dll!JIT_New → boxed Enumerator[ProjectMetadata]     ← discarded after enumeration
  ```
  **Callers on hot path as per Perfwatson traces** (all funnel through `PropertyDictionary<T>.GetEnumerator`):
  ```
  InstantiateProjectItemInstance → ImmutableDictionaryExtensions.SetItems → PropertyDictionary.GetEnumerator          (~67%)
  InstantiateProjectItemInstance → CopyOnWritePropertyDictionary.ImportProperties → PropertyDictionary.GetEnumerator  (~31%)
  InstantiateProjectItemInstance → PropertyDictionary..ctor(IEnumerable<T>) → PropertyDictionary.GetEnumerator          (~3%)
  ```
  All variants converge on the same boxed value-type-enumerator leaf at `RetrievableEntryHashSet<T>.IEnumerable<T>.GetEnumerator`, rooted at `ProjectSnapshotService.GenerateProjectInstance → ProjectInstance..ctor → CreateItemsSnapshot` and attributed to GC pause time.

  [See related failure in PRISM](https://prism.vsdata.io/failure/?eventType=allocation&failureType=dualdirection&failureHash=45a811ce-539e-a7c9-f646-2695062b6319)

- **Issue type**: Avoid boxing a value-type enumerator when an allocation-free struct enumerator exists on the same concrete type.

- **Proposed fix**: In `PropertyDictionary<T>.GetEnumerator()`, pattern-match the backing field to its concrete `RetrievableValuedEntryHashSet<T>` type and `foreach` over it, so the C# `foreach` binds to the struct-returning `public Enumerator GetEnumerator()` — no boxing. An `else` branch preserves the original interface enumeration for the non-deriving `IRetrievableValuedEntryHashSet<T>` implementers (`ImmutableGlobalPropertiesCollectionConverter`, `ImmutableProjectPropertyCollectionConverter`). The non-generic `IEnumerable.GetEnumerator()` now delegates to the generic method, removing a second boxing site. Because every hot-path caller routes through this single sink, one change covers all of them. The change mirrors the allocation-free pattern already used by `PropertyDictionary<T>.Filter`, is internal-only, and is behavior-preserving — identical enumeration order, version/concurrent-modification check, and read-lock scope (both paths drive the same `RetrievableEntryHashSet<T>.Enumerator`). Net effect: −1 heap allocation per enumeration on the concrete path, 0 new allocations introduced.

[Best practices wiki](https://dev.azure.com/devdiv/DevDiv/_wiki/wikis/DevDiv.wiki/24181/Garbage-collection-(GC))
[See related failure in PRISM](https://prism.vsdata.io/failure/?eventType=allocation&failureType=dualdirection&failureHash=45a811ce-539e-a7c9-f646-2695062b6319)
[ADO work item](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/3028242)
