### PR TITLE
Add opt-in partial (stop-after-pass) project evaluation

### DIFF
--- a/documentation/specs/proposed/partial-evaluation.md
+++ b/documentation/specs/proposed/partial-evaluation.md
@@ -1,0 +1,110 @@
+# Partial (stop-after-pass) project evaluation
+
+Tracking issue: [dotnet/msbuild#14288](https://github.com/dotnet/msbuild/issues/14288)
+Related SDK consumer: [dotnet/sdk#55193](https://github.com/dotnet/sdk/issues/55193)
+
+## Motivation
+
+Some callers only need data produced by an early evaluation pass. The most common example is
+reading a single property (for example the SDK's `ReleasePropertyProjectLocator` reads
+`PublishRelease`/`PackRelease`), which today forces a **full** evaluation of the project — all
+passes, including item globbing, using-task registration, and target registration.
+
+MSBuild evaluation runs a fixed sequence of passes:
+
+| Pass | Work |
+| ---- | ---- |
+| 0 | Initial properties (environment, global, toolset, reserved) |
+| 1 | Properties + imports (also gathers item/item-definition/using-task/target *elements* and `InitialTargets`) |
+| 2 | Item definitions |
+| 3 / 3.1 | Items (includes wildcard/glob expansion) |
+| 4 | Using-tasks (task registry) |
+| 5 | Targets (registration, `DefaultTargets`, before/after maps) |
+
+Property values are final after pass 1: properties cannot depend on items (item references inside
+property values expand to empty even in a full evaluation), so a stop-at-properties evaluation
+produces property values identical to a full evaluation.
+
+On a file-heavy project (500 source files, ~200 properties, 50 targets), stopping after the
+properties pass measured roughly a **46%** reduction in per-evaluation wall-clock versus a full
+evaluation (Debug engine build; relative comparison). Passes 2–5 dominate the remainder, with item
+globbing being the largest single contributor as source-file count grows.
+
+## API
+
+A new opt-in knob on `ProjectOptions` selects how far evaluation proceeds:
+
+```csharp
+namespace Microsoft.Build.Evaluation
+{
+    public enum ProjectEvaluationStage
+    {
+        Properties,         // stop after pass 1
+        ItemDefinitions,    // stop after pass 2
+        Items,              // stop after pass 3 / 3.1
+        UsingTasks,         // stop after pass 4
+        Full = int.MaxValue // default: run every pass (pass 5)
+    }
+}
+```
+
+```csharp
+public class ProjectOptions
+{
+    public ProjectEvaluationStage EvaluationStage { get; set; } = ProjectEvaluationStage.Full;
+}
+```
+
+The stage flows through the existing factory methods:
+
+- `ProjectInstance.FromFile(path, options)` / `ProjectInstance.FromProjectRootElement(xml, options)`
+- `Project.FromFile(path, options)` / `Project.FromProjectRootElement(xml, options)` / `Project.FromXmlReader(reader, options)`
+
+Both `Project.EvaluationStage` and `ProjectInstance.EvaluationStage` report the stage the object was
+evaluated to.
+
+Example:
+
+```csharp
+var options = new ProjectOptions
+{
+    EvaluationStage = ProjectEvaluationStage.Properties,
+    EvaluationContext = sharedContext, // complements partial evaluation; see sdk#55193
+};
+
+ProjectInstance instance = ProjectInstance.FromFile(projectPath, options);
+string value = instance.GetPropertyValue("PublishRelease"); // fast: only passes 0-1 ran
+```
+
+## Behavior of a partially-evaluated object
+
+- **Properties are always valid** for any stage ≥ `Properties` (`GetProperty`, `GetPropertyValue`,
+  `Properties`, `GlobalProperties`). `InitialTargets` is also available from `Properties` onward
+  because it is computed during pass 1.
+- **Reading not-yet-computed state fails fast.** Members that expose state from a later pass throw
+  `InvalidOperationException` naming the member and the stage the object reached. Guarded members
+  include `Items`, `GetItems`, `ItemsIgnoringCondition`, `AllEvaluatedItems`, `Targets`, and
+  `DefaultTargets` (and their `ProjectInstance` equivalents).
+- **A partial `ProjectInstance` cannot be built.** Constructing a `BuildRequestData` from a partial
+  instance throws `InvalidOperationException`; a build requires a full evaluation.
+
+The default (`Full`) is unchanged, so existing callers are unaffected.
+
+## Evaluation caching
+
+`ProjectCollection` caches loaded `Project`s keyed on (path, global properties, tools version) — the
+evaluation stage is not part of the key. To avoid serving stale partial state:
+
+- A cached project satisfies a request only if `cachedStage >= requestedStage`.
+- `ProjectCollection.LoadProject` requests `Full`. If the only cached project for a key was
+  partially evaluated, it is **upgraded in place** (re-evaluated to `Full`) and returned, rather than
+  returning partial state or creating a duplicate cache entry.
+- Calling the public `Project.ReevaluateIfNecessary()` on a partial project upgrades it to `Full`
+  (a partial evaluation leaves the project non-dirty, so the re-evaluation is forced).
+
+## Relationship to `EvaluationContext`
+
+Partial evaluation and a shared `EvaluationContext` are complementary levers. A shared context
+caches file-system probes and SDK resolution across projects; partial evaluation skips whole passes
+within each project. Batch scenarios that read one property from many projects (such as the SDK
+release-property locator) benefit from using both together.

--- a/documentation/specs/proposed/partial-evaluation.md
+++ b/documentation/specs/proposed/partial-evaluation.md
@@ -83,8 +83,9 @@ string value = instance.GetPropertyValue("PublishRelease"); // fast: only passes
   because it is computed during pass 1.
 - **Reading not-yet-computed state fails fast.** Members that expose state from a later pass throw
   `InvalidOperationException` naming the member and the stage the object reached. Guarded members
-  include `Items`, `GetItems`, `ItemsIgnoringCondition`, `AllEvaluatedItems`, `Targets`, and
-  `DefaultTargets` (and their `ProjectInstance` equivalents).
+  include `ItemDefinitions` (available from `ItemDefinitions` onward), `Items`, `GetItems`,
+  `ItemsIgnoringCondition`, `AllEvaluatedItems`, `Targets`, and `DefaultTargets` (and their
+  `ProjectInstance` equivalents).
 - **A partial `ProjectInstance` cannot be built.** Constructing a `BuildRequestData` from a partial
   instance throws `InvalidOperationException`; a build requires a full evaluation.
 

--- a/src/Build.UnitTests/Evaluation/PartialEvaluation_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/PartialEvaluation_Tests.cs
@@ -74,6 +74,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             Should.NotThrow(() => instance.InitialTargets);
 
             Should.Throw<InvalidOperationException>(() => instance.Items);
+            Should.Throw<InvalidOperationException>(() => instance.ItemDefinitions);
             Should.Throw<InvalidOperationException>(() => instance.GetItems("Compile"));
             Should.Throw<InvalidOperationException>(() => instance.Targets);
             Should.Throw<InvalidOperationException>(() => instance.DefaultTargets);
@@ -88,6 +89,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             project.GetPropertyValue("Derived").ShouldBe("Debug-x");
 
             Should.Throw<InvalidOperationException>(() => project.Items);
+            Should.Throw<InvalidOperationException>(() => project.ItemDefinitions);
             Should.Throw<InvalidOperationException>(() => project.GetItems("Compile"));
             Should.Throw<InvalidOperationException>(() => project.AllEvaluatedItems);
             Should.Throw<InvalidOperationException>(() => project.Targets);
@@ -104,6 +106,18 @@ namespace Microsoft.Build.UnitTests.Evaluation
             // Item references in property values expand to empty even in a full evaluation because
             // properties are evaluated before items, so both stages agree.
             partial.GetPropertyValue("FromItem").ShouldBe(full.GetPropertyValue("FromItem"));
+        }
+
+        [Fact]
+        public void ItemDefinitionsStage_ExposesItemDefinitionsButNotItemsOrTargets()
+        {
+            ProjectInstance instance = ProjectInstance.FromProjectRootElement(CreateRootElement(), OptionsFor(ProjectEvaluationStage.ItemDefinitions));
+
+            instance.EvaluationStage.ShouldBe(ProjectEvaluationStage.ItemDefinitions);
+            Should.NotThrow(() => instance.ItemDefinitions);
+
+            Should.Throw<InvalidOperationException>(() => instance.Items);
+            Should.Throw<InvalidOperationException>(() => instance.Targets);
         }
 
         [Fact]

--- a/src/Build.UnitTests/Evaluation/PartialEvaluation_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/PartialEvaluation_Tests.cs
@@ -1,0 +1,198 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+using System.Xml;
+
+using Microsoft.Build.Construction;
+using Microsoft.Build.Definition;
+using Microsoft.Build.Evaluation;
+using Microsoft.Build.Execution;
+using Shouldly;
+using Xunit;
+
+#nullable disable
+
+namespace Microsoft.Build.UnitTests.Evaluation
+{
+    /// <summary>
+    /// Tests for the opt-in partial (stop-after-pass) evaluation model exposed via
+    /// <see cref="ProjectOptions.EvaluationStage"/>.
+    /// </summary>
+    public class PartialEvaluation_Tests
+    {
+        private const string ProjectXml = """
+            <Project>
+              <PropertyGroup>
+                <Config>Debug</Config>
+                <Derived>$(Config)-x</Derived>
+                <FromItem>@(Compile)</FromItem>
+              </PropertyGroup>
+              <ItemDefinitionGroup>
+                <Compile>
+                  <Kind>source</Kind>
+                </Compile>
+              </ItemDefinitionGroup>
+              <ItemGroup>
+                <Compile Include="a.cs" />
+                <Compile Include="b.cs" />
+              </ItemGroup>
+              <UsingTask TaskName="Dummy" AssemblyName="Some.Assembly" />
+              <Target Name="Build" />
+              <Target Name="Other" />
+            </Project>
+            """;
+
+        private static ProjectRootElement CreateRootElement()
+        {
+            using XmlReader reader = XmlReader.Create(new StringReader(ProjectXml));
+            return ProjectRootElement.Create(reader);
+        }
+
+        private static ProjectOptions OptionsFor(ProjectEvaluationStage stage) => new ProjectOptions
+        {
+            EvaluationStage = stage,
+            ProjectCollection = new ProjectCollection(),
+        };
+
+        [Fact]
+        public void DefaultProjectOptionsStageIsFull()
+        {
+            new ProjectOptions().EvaluationStage.ShouldBe(ProjectEvaluationStage.Full);
+        }
+
+        [Fact]
+        public void PropertiesStage_ExposesPropertiesButNotItemsOrTargets_ProjectInstance()
+        {
+            ProjectInstance instance = ProjectInstance.FromProjectRootElement(CreateRootElement(), OptionsFor(ProjectEvaluationStage.Properties));
+
+            instance.EvaluationStage.ShouldBe(ProjectEvaluationStage.Properties);
+            instance.GetPropertyValue("Derived").ShouldBe("Debug-x");
+
+            // InitialTargets are computed during pass 1 and remain available.
+            Should.NotThrow(() => instance.InitialTargets);
+
+            Should.Throw<InvalidOperationException>(() => instance.Items);
+            Should.Throw<InvalidOperationException>(() => instance.GetItems("Compile"));
+            Should.Throw<InvalidOperationException>(() => instance.Targets);
+            Should.Throw<InvalidOperationException>(() => instance.DefaultTargets);
+        }
+
+        [Fact]
+        public void PropertiesStage_ExposesPropertiesButNotItemsOrTargets_Project()
+        {
+            Project project = Project.FromProjectRootElement(CreateRootElement(), OptionsFor(ProjectEvaluationStage.Properties));
+
+            project.EvaluationStage.ShouldBe(ProjectEvaluationStage.Properties);
+            project.GetPropertyValue("Derived").ShouldBe("Debug-x");
+
+            Should.Throw<InvalidOperationException>(() => project.Items);
+            Should.Throw<InvalidOperationException>(() => project.GetItems("Compile"));
+            Should.Throw<InvalidOperationException>(() => project.AllEvaluatedItems);
+            Should.Throw<InvalidOperationException>(() => project.Targets);
+        }
+
+        [Fact]
+        public void PropertyValuesEqualFullEvaluation()
+        {
+            ProjectInstance partial = ProjectInstance.FromProjectRootElement(CreateRootElement(), OptionsFor(ProjectEvaluationStage.Properties));
+            ProjectInstance full = ProjectInstance.FromProjectRootElement(CreateRootElement(), OptionsFor(ProjectEvaluationStage.Full));
+
+            partial.GetPropertyValue("Derived").ShouldBe(full.GetPropertyValue("Derived"));
+
+            // Item references in property values expand to empty even in a full evaluation because
+            // properties are evaluated before items, so both stages agree.
+            partial.GetPropertyValue("FromItem").ShouldBe(full.GetPropertyValue("FromItem"));
+        }
+
+        [Fact]
+        public void ItemsStage_ExposesItemsButNotTargets()
+        {
+            ProjectInstance instance = ProjectInstance.FromProjectRootElement(CreateRootElement(), OptionsFor(ProjectEvaluationStage.Items));
+
+            instance.EvaluationStage.ShouldBe(ProjectEvaluationStage.Items);
+            instance.GetItems("Compile").Count.ShouldBe(2);
+
+            Should.Throw<InvalidOperationException>(() => instance.Targets);
+        }
+
+        [Fact]
+        public void FullStage_IsDefault_AndExposesEverything()
+        {
+            ProjectInstance instance = ProjectInstance.FromProjectRootElement(CreateRootElement(), new ProjectOptions { ProjectCollection = new ProjectCollection() });
+
+            instance.EvaluationStage.ShouldBe(ProjectEvaluationStage.Full);
+            instance.GetItems("Compile").Count.ShouldBe(2);
+            instance.Targets.ShouldContainKey("Build");
+        }
+
+        [Fact]
+        public void ReevaluateUpgradesPartialProjectToFull()
+        {
+            Project project = Project.FromProjectRootElement(CreateRootElement(), OptionsFor(ProjectEvaluationStage.Properties));
+
+            project.EvaluationStage.ShouldBe(ProjectEvaluationStage.Properties);
+            Should.Throw<InvalidOperationException>(() => project.Targets);
+
+            project.ReevaluateIfNecessary();
+
+            project.EvaluationStage.ShouldBe(ProjectEvaluationStage.Full);
+            project.Targets.ShouldContainKey("Build");
+            project.GetItems("Compile").Count.ShouldBe(2);
+        }
+
+        [Fact]
+        public void CreateProjectInstanceFromPartialProjectUpgradesToFull()
+        {
+            Project project = Project.FromProjectRootElement(CreateRootElement(), OptionsFor(ProjectEvaluationStage.Properties));
+            project.EvaluationStage.ShouldBe(ProjectEvaluationStage.Properties);
+
+            ProjectInstance instance = project.CreateProjectInstance();
+
+            instance.EvaluationStage.ShouldBe(ProjectEvaluationStage.Full);
+            instance.Targets.ShouldContainKey("Build");
+            project.EvaluationStage.ShouldBe(ProjectEvaluationStage.Full);
+        }
+
+        [Fact]
+        public void PartialProjectInstanceCannotBeBuilt()
+        {
+            ProjectInstance instance = ProjectInstance.FromProjectRootElement(CreateRootElement(), OptionsFor(ProjectEvaluationStage.Properties));
+
+            Should.Throw<InvalidOperationException>(() => new BuildRequestData(instance, new[] { "Build" }));
+        }
+
+        [Fact]
+        public void CacheDoesNotServePartialProjectForFullLoad()
+        {
+            using ProjectCollection collection = new ProjectCollection();
+            string path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".proj");
+            File.WriteAllText(path, ProjectXml);
+
+            try
+            {
+                Project partial = Project.FromFile(path, new ProjectOptions
+                {
+                    EvaluationStage = ProjectEvaluationStage.Properties,
+                    ProjectCollection = collection,
+                });
+                partial.EvaluationStage.ShouldBe(ProjectEvaluationStage.Properties);
+
+                // A subsequent full LoadProject on the same key must return a fully-evaluated project
+                // (the cached partial one is upgraded in place), never partial state.
+                Project full = collection.LoadProject(path);
+                full.EvaluationStage.ShouldBe(ProjectEvaluationStage.Full);
+                full.Targets.ShouldContainKey("Build");
+
+                // The partial and full references point at the same upgraded cached project.
+                ReferenceEquals(partial, full).ShouldBeTrue();
+                partial.EvaluationStage.ShouldBe(ProjectEvaluationStage.Full);
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        }
+    }
+}

--- a/src/Build.UnitTests/Evaluation/PartialEvaluation_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/PartialEvaluation_Tests.cs
@@ -12,16 +12,30 @@ using Microsoft.Build.Execution;
 using Shouldly;
 using Xunit;
 
-#nullable disable
-
 namespace Microsoft.Build.UnitTests.Evaluation
 {
     /// <summary>
     /// Tests for the opt-in partial (stop-after-pass) evaluation model exposed via
     /// <see cref="ProjectOptions.EvaluationStage"/>.
     /// </summary>
-    public class PartialEvaluation_Tests
+    public class PartialEvaluation_Tests : IDisposable
     {
+        private readonly ITestOutputHelper _output;
+        private readonly TestEnvironment _env;
+        private readonly ProjectCollection _collection = new ProjectCollection();
+
+        public PartialEvaluation_Tests(ITestOutputHelper output)
+        {
+            _output = output;
+            _env = TestEnvironment.Create(_output);
+        }
+
+        public void Dispose()
+        {
+            _collection.Dispose();
+            _env.Dispose();
+        }
+
         private const string ProjectXml = """
             <Project>
               <PropertyGroup>
@@ -50,16 +64,26 @@ namespace Microsoft.Build.UnitTests.Evaluation
             return ProjectRootElement.Create(reader);
         }
 
-        private static ProjectOptions OptionsFor(ProjectEvaluationStage stage) => new ProjectOptions
+        private ProjectOptions OptionsFor(ProjectEvaluationStage stage) => new ProjectOptions
         {
             EvaluationStage = stage,
-            ProjectCollection = new ProjectCollection(),
+            ProjectCollection = _collection,
         };
 
         [Fact]
         public void DefaultProjectOptionsStageIsFull()
         {
             new ProjectOptions().EvaluationStage.ShouldBe(ProjectEvaluationStage.Full);
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(5)]
+        [InlineData(-1)]
+        [InlineData(int.MaxValue - 1)]
+        public void EvaluationStage_RejectsUndefinedValues(int value)
+        {
+            Should.Throw<ArgumentOutOfRangeException>(() => new ProjectOptions { EvaluationStage = (ProjectEvaluationStage)value });
         }
 
         [Fact]
@@ -134,7 +158,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         [Fact]
         public void FullStage_IsDefault_AndExposesEverything()
         {
-            ProjectInstance instance = ProjectInstance.FromProjectRootElement(CreateRootElement(), new ProjectOptions { ProjectCollection = new ProjectCollection() });
+            ProjectInstance instance = ProjectInstance.FromProjectRootElement(CreateRootElement(), new ProjectOptions { ProjectCollection = _collection });
 
             instance.EvaluationStage.ShouldBe(ProjectEvaluationStage.Full);
             instance.GetItems("Compile").Count.ShouldBe(2);
@@ -180,33 +204,24 @@ namespace Microsoft.Build.UnitTests.Evaluation
         [Fact]
         public void CacheDoesNotServePartialProjectForFullLoad()
         {
-            using ProjectCollection collection = new ProjectCollection();
-            string path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".proj");
-            File.WriteAllText(path, ProjectXml);
+            TransientTestFile file = _env.CreateFile("test.proj", ProjectXml);
 
-            try
+            Project partial = Project.FromFile(file.Path, new ProjectOptions
             {
-                Project partial = Project.FromFile(path, new ProjectOptions
-                {
-                    EvaluationStage = ProjectEvaluationStage.Properties,
-                    ProjectCollection = collection,
-                });
-                partial.EvaluationStage.ShouldBe(ProjectEvaluationStage.Properties);
+                EvaluationStage = ProjectEvaluationStage.Properties,
+                ProjectCollection = _collection,
+            });
+            partial.EvaluationStage.ShouldBe(ProjectEvaluationStage.Properties);
 
-                // A subsequent full LoadProject on the same key must return a fully-evaluated project
-                // (the cached partial one is upgraded in place), never partial state.
-                Project full = collection.LoadProject(path);
-                full.EvaluationStage.ShouldBe(ProjectEvaluationStage.Full);
-                full.Targets.ShouldContainKey("Build");
+            // A subsequent full LoadProject on the same key must return a fully-evaluated project
+            // (the cached partial one is upgraded in place), never partial state.
+            Project full = _collection.LoadProject(file.Path);
+            full.EvaluationStage.ShouldBe(ProjectEvaluationStage.Full);
+            full.Targets.ShouldContainKey("Build");
 
-                // The partial and full references point at the same upgraded cached project.
-                ReferenceEquals(partial, full).ShouldBeTrue();
-                partial.EvaluationStage.ShouldBe(ProjectEvaluationStage.Full);
-            }
-            finally
-            {
-                File.Delete(path);
-            }
+            // The partial and full references point at the same upgraded cached project.
+            ReferenceEquals(partial, full).ShouldBeTrue();
+            partial.EvaluationStage.ShouldBe(ProjectEvaluationStage.Full);
         }
     }
 }

--- a/src/Build/BackEnd/BuildManager/BuildRequestData.cs
+++ b/src/Build/BackEnd/BuildManager/BuildRequestData.cs
@@ -60,6 +60,11 @@ namespace Microsoft.Build.Execution
         {
             ArgumentNullException.ThrowIfNull(projectInstance);
 
+            if (projectInstance.EvaluationStage != Evaluation.ProjectEvaluationStage.Full)
+            {
+                Shared.ErrorUtilities.ThrowInvalidOperation("OM_PartialEvaluationCannotBuild", projectInstance.EvaluationStage);
+            }
+
             foreach (string targetName in targetsToBuild)
             {
                 ArgumentNullException.ThrowIfNull(targetName, "target");

--- a/src/Build/Definition/Project.cs
+++ b/src/Build/Definition/Project.cs
@@ -268,7 +268,7 @@ namespace Microsoft.Build.Evaluation
         }
 
         private Project(ProjectRootElement xml, IDictionary<string, string> globalProperties, string toolsVersion, string subToolsetVersion, ProjectCollection projectCollection, ProjectLoadSettings loadSettings,
-            EvaluationContext evaluationContext, IDirectoryCacheFactory directoryCacheFactory, bool interactive)
+            EvaluationContext evaluationContext, IDirectoryCacheFactory directoryCacheFactory, bool interactive, ProjectEvaluationStage evaluationStage = ProjectEvaluationStage.Full)
         {
             ArgumentNullException.ThrowIfNull(xml);
             ErrorUtilities.VerifyThrowArgumentLengthIfNotNull(toolsVersion, nameof(toolsVersion));
@@ -279,7 +279,7 @@ namespace Microsoft.Build.Evaluation
             implementation = defaultImplementation;
 
             _directoryCacheFactory = directoryCacheFactory;
-            defaultImplementation.Initialize(globalProperties, toolsVersion, subToolsetVersion, loadSettings, evaluationContext, interactive);
+            defaultImplementation.Initialize(globalProperties, toolsVersion, subToolsetVersion, loadSettings, evaluationContext, interactive, evaluationStage);
         }
 
         /// <summary>
@@ -362,7 +362,7 @@ namespace Microsoft.Build.Evaluation
         }
 
         private Project(XmlReader xmlReader, IDictionary<string, string> globalProperties, string toolsVersion, string subToolsetVersion, ProjectCollection projectCollection, ProjectLoadSettings loadSettings,
-            EvaluationContext evaluationContext, IDirectoryCacheFactory directoryCacheFactory, bool interactive)
+            EvaluationContext evaluationContext, IDirectoryCacheFactory directoryCacheFactory, bool interactive, ProjectEvaluationStage evaluationStage = ProjectEvaluationStage.Full)
         {
             ArgumentNullException.ThrowIfNull(xmlReader);
             ErrorUtilities.VerifyThrowArgumentLengthIfNotNull(toolsVersion, nameof(toolsVersion));
@@ -373,7 +373,7 @@ namespace Microsoft.Build.Evaluation
             implementation = defaultImplementation;
 
             _directoryCacheFactory = directoryCacheFactory;
-            defaultImplementation.Initialize(globalProperties, toolsVersion, subToolsetVersion, loadSettings, evaluationContext, interactive);
+            defaultImplementation.Initialize(globalProperties, toolsVersion, subToolsetVersion, loadSettings, evaluationContext, interactive, evaluationStage);
         }
 
         /// <summary>
@@ -458,7 +458,7 @@ namespace Microsoft.Build.Evaluation
         }
 
         private Project(string projectFile, IDictionary<string, string> globalProperties, string toolsVersion, string subToolsetVersion, ProjectCollection projectCollection, ProjectLoadSettings loadSettings,
-            EvaluationContext evaluationContext, IDirectoryCacheFactory directoryCacheFactory, bool interactive)
+            EvaluationContext evaluationContext, IDirectoryCacheFactory directoryCacheFactory, bool interactive, ProjectEvaluationStage evaluationStage = ProjectEvaluationStage.Full)
         {
             ArgumentNullException.ThrowIfNull(projectFile);
             ErrorUtilities.VerifyThrowArgumentLengthIfNotNull(toolsVersion, nameof(toolsVersion));
@@ -475,7 +475,7 @@ namespace Microsoft.Build.Evaluation
             // seems the XmlReader based one should also clean the same way.
             try
             {
-                defaultImplementation.Initialize(globalProperties, toolsVersion, subToolsetVersion, loadSettings, evaluationContext, interactive);
+                defaultImplementation.Initialize(globalProperties, toolsVersion, subToolsetVersion, loadSettings, evaluationContext, interactive, evaluationStage);
             }
             catch (Exception ex) when (!ExceptionHandling.IsCriticalException(ex))
             {
@@ -507,7 +507,8 @@ namespace Microsoft.Build.Evaluation
                 options.LoadSettings,
                 options.EvaluationContext,
                 options.DirectoryCacheFactory,
-                options.Interactive);
+                options.Interactive,
+                options.EvaluationStage);
         }
 
         /// <summary>
@@ -526,7 +527,8 @@ namespace Microsoft.Build.Evaluation
                 options.LoadSettings,
                 options.EvaluationContext,
                 options.DirectoryCacheFactory,
-                options.Interactive);
+                options.Interactive,
+                options.EvaluationStage);
         }
 
         /// <summary>
@@ -545,7 +547,8 @@ namespace Microsoft.Build.Evaluation
                 options.LoadSettings,
                 options.EvaluationContext,
                 options.DirectoryCacheFactory,
-                options.Interactive);
+                options.Interactive,
+                options.EvaluationStage);
         }
 
         /// <summary>
@@ -839,6 +842,16 @@ namespace Microsoft.Build.Evaluation
         /// evaluation logging events back to the Project instance.
         /// </summary>
         public int LastEvaluationId => implementation.LastEvaluationId;
+
+        /// <summary>
+        /// How far evaluation proceeded when this project was last evaluated.
+        /// When this is not <see cref="ProjectEvaluationStage.Full"/>, the project is the result of a
+        /// partial evaluation (requested via <see cref="ProjectOptions.EvaluationStage"/>) and members
+        /// exposing state from later passes (for example items or targets) throw
+        /// <see cref="InvalidOperationException"/> until the project is re-evaluated via
+        /// <see cref="ReevaluateIfNecessary()"/>.
+        /// </summary>
+        public ProjectEvaluationStage EvaluationStage => (implementation as ProjectImpl)?.EvaluationStageInternal ?? ProjectEvaluationStage.Full;
 
         /// <summary>
         /// List of names of the properties that, while global, are still treated as overridable.
@@ -1874,6 +1887,14 @@ namespace Microsoft.Build.Evaluation
             private ProjectLoadSettings _loadSettings;
 
             /// <summary>
+            /// The evaluation stage reached by the most recent evaluation. <see cref="ProjectEvaluationStage.Full"/>
+            /// unless the project was created via a <see cref="ProjectOptions"/> requesting a partial evaluation.
+            /// Retained so that member accessors can fail fast on not-yet-computed state, and so re-evaluation
+            /// can restore the requested stage.
+            /// </summary>
+            private ProjectEvaluationStage _evaluationStage = ProjectEvaluationStage.Full;
+
+            /// <summary>
             /// The delegate registered with the ProjectRootElement to be called if the file name
             /// is changed. Retained so that ultimately it can be unregistered.
             /// If it has been set to null, the project has been unloaded from its collection.
@@ -2229,10 +2250,34 @@ namespace Microsoft.Build.Evaluation
             public override IDictionary<string, ProjectItemDefinition> ItemDefinitions => _data.ItemDefinitions;
 
             /// <summary>
+            /// The evaluation stage reached by the most recent evaluation. See <see cref="ProjectEvaluationStage"/>.
+            /// </summary>
+            internal ProjectEvaluationStage EvaluationStageInternal => _evaluationStage;
+
+            /// <summary>
+            /// Throws <see cref="InvalidOperationException"/> if the most recent evaluation stopped before
+            /// <paramref name="requiredStage"/>, meaning the requested member's state was never computed.
+            /// </summary>
+            private void VerifyThrowEvaluationStageReached(ProjectEvaluationStage requiredStage, string memberName)
+            {
+                if (_evaluationStage < requiredStage)
+                {
+                    ErrorUtilities.ThrowInvalidOperation("OM_PartialEvaluationMemberUnavailable", memberName, _evaluationStage);
+                }
+            }
+
+            /// <summary>
             /// Items in this project, ordered within groups of item types.
             /// </summary>
             [SuppressMessage("Microsoft.Naming", "CA1721:PropertyNamesShouldNotMatchGetMethods", Justification = "This is a reasonable choice. API review approved")]
-            public override ICollection<ProjectItem> Items => new ReadOnlyCollection<ProjectItem>(_data.Items);
+            public override ICollection<ProjectItem> Items
+            {
+                get
+                {
+                    VerifyThrowEvaluationStageReached(ProjectEvaluationStage.Items, nameof(Items));
+                    return new ReadOnlyCollection<ProjectItem>(_data.Items);
+                }
+            }
 
             /// <summary>
             /// Items in this project, ordered within groups of item types,
@@ -2247,6 +2292,8 @@ namespace Microsoft.Build.Evaluation
                 [DebuggerStepThrough]
                 get
                 {
+                    VerifyThrowEvaluationStageReached(ProjectEvaluationStage.Items, nameof(ItemsIgnoringCondition));
+
                     if (!(_data.ShouldEvaluateForDesignTime && _data.CanEvaluateElementsWithFalseConditions))
                     {
                         ErrorUtilities.ThrowInvalidOperation("OM_NotEvaluatedBecauseShouldEvaluateForDesignTimeIsFalse", nameof(ItemsIgnoringCondition));
@@ -2317,6 +2364,8 @@ namespace Microsoft.Build.Evaluation
                 [DebuggerStepThrough]
                 get
                 {
+                    VerifyThrowEvaluationStageReached(ProjectEvaluationStage.Full, nameof(Targets));
+
                     if (_data.Targets == null)
                     {
                         return ReadOnlyEmptyDictionary<string, ProjectTargetInstance>.Instance;
@@ -2383,6 +2432,8 @@ namespace Microsoft.Build.Evaluation
             {
                 get
                 {
+                    VerifyThrowEvaluationStageReached(ProjectEvaluationStage.Items, nameof(AllEvaluatedItems));
+
                     ICollection<ProjectItem> allEvaluatedItems = _data.AllEvaluatedItems;
 
                     if (allEvaluatedItems == null)
@@ -3125,6 +3176,7 @@ namespace Microsoft.Build.Evaluation
             /// </comments>
             public override ICollection<ProjectItem> GetItems(string itemType)
             {
+                VerifyThrowEvaluationStageReached(ProjectEvaluationStage.Items, nameof(GetItems));
                 ICollection<ProjectItem> items = _data.GetItems(itemType);
                 return items;
             }
@@ -3139,6 +3191,7 @@ namespace Microsoft.Build.Evaluation
             /// </comments>
             public override ICollection<ProjectItem> GetItemsIgnoringCondition(string itemType)
             {
+                VerifyThrowEvaluationStageReached(ProjectEvaluationStage.Items, nameof(GetItemsIgnoringCondition));
                 ICollection<ProjectItem> items = _data.ItemsIgnoringCondition[itemType];
                 return items;
             }
@@ -3156,6 +3209,7 @@ namespace Microsoft.Build.Evaluation
             /// </comments>
             public override ICollection<ProjectItem> GetItemsByEvaluatedInclude(string evaluatedInclude)
             {
+                VerifyThrowEvaluationStageReached(ProjectEvaluationStage.Items, nameof(GetItemsByEvaluatedInclude));
                 ICollection<ProjectItem> items = _data.GetItemsByEvaluatedInclude(evaluatedInclude);
                 return items;
             }
@@ -3321,6 +3375,15 @@ namespace Microsoft.Build.Evaluation
             /// <param name="evaluationContext">The <see cref="EvaluationContext"/> to use. See <see cref="EvaluationContext"/>.</param>
             public override void ReevaluateIfNecessary(EvaluationContext evaluationContext)
             {
+                // A public re-evaluation request implies the caller wants a fully-evaluated project.
+                // A partial evaluation leaves the project non-dirty, so force a re-evaluation to
+                // compute the remaining passes and restore full behavior.
+                if (_evaluationStage != ProjectEvaluationStage.Full)
+                {
+                    _evaluationStage = ProjectEvaluationStage.Full;
+                    _explicitlyMarkedDirty = true;
+                }
+
                 ReevaluateIfNecessary(LoggingService, evaluationContext);
             }
 
@@ -3723,6 +3786,15 @@ namespace Microsoft.Build.Evaluation
                 ProjectInstanceSettings settings,
                 EvaluationContext evaluationContext)
             {
+                // Materializing a ProjectInstance implies a fully-evaluated project (it may be built,
+                // and it is labeled Full). If this project was only partially evaluated, upgrade it to
+                // a full evaluation first so the snapshot is complete rather than silently partial.
+                if (_evaluationStage != ProjectEvaluationStage.Full)
+                {
+                    _evaluationStage = ProjectEvaluationStage.Full;
+                    _explicitlyMarkedDirty = true;
+                }
+
                 ReevaluateIfNecessary(loggingServiceForEvaluation, evaluationContext);
 
                 return new ProjectInstance(_data, DirectoryPath, FullPath, ProjectCollection.HostServices, ProjectCollection.EnvironmentProperties, settings);
@@ -3752,7 +3824,8 @@ namespace Microsoft.Build.Evaluation
                     evaluationContext.SdkResolverService,
                     BuildEventContext.InvalidSubmissionId,
                     evaluationContext,
-                    _interactive);
+                    _interactive,
+                    _evaluationStage);
 
                 Assumed.NotEqual(LastEvaluationId, BuildEventContext.InvalidEvaluationId, "Evaluation should produce an evaluation ID");
 
@@ -3785,7 +3858,7 @@ namespace Microsoft.Build.Evaluation
             /// Global properties may be null.
             /// Tools version may be null.
             /// </summary>
-            internal void Initialize(IDictionary<string, string> globalProperties, string toolsVersion, string subToolsetVersion, ProjectLoadSettings loadSettings, EvaluationContext evaluationContext, bool interactive)
+            internal void Initialize(IDictionary<string, string> globalProperties, string toolsVersion, string subToolsetVersion, ProjectLoadSettings loadSettings, EvaluationContext evaluationContext, bool interactive, ProjectEvaluationStage evaluationStage = ProjectEvaluationStage.Full)
             {
                 Xml.MarkAsExplicitlyLoaded();
 
@@ -3821,10 +3894,14 @@ namespace Microsoft.Build.Evaluation
 
                 _loadSettings = loadSettings;
                 _interactive = interactive;
+                _evaluationStage = evaluationStage;
 
                 Assumed.Equal(LastEvaluationId, BuildEventContext.InvalidEvaluationId, "This is the first evaluation therefore the last evaluation id is invalid");
 
-                ReevaluateIfNecessary(evaluationContext);
+                // Call the private overload directly so an initial partial evaluation is honored. The
+                // public ReevaluateIfNecessary(EvaluationContext) override intentionally upgrades a
+                // partial project to a full evaluation, which must not happen during initial construction.
+                ReevaluateIfNecessary(LoggingService, evaluationContext);
 
                 Assumed.NotEqual(LastEvaluationId, BuildEventContext.InvalidEvaluationId, "Last evaluation ID must be valid after the first evaluation");
 

--- a/src/Build/Definition/Project.cs
+++ b/src/Build/Definition/Project.cs
@@ -2269,7 +2269,7 @@ namespace Microsoft.Build.Evaluation
             {
                 if (_evaluationStage < requiredStage)
                 {
-                    ErrorUtilities.ThrowInvalidOperation("OM_PartialEvaluationMemberUnavailable", memberName, _evaluationStage);
+                    ErrorUtilities.ThrowInvalidOperation("OM_PartialEvaluationMemberUnavailable", memberName, _evaluationStage, requiredStage);
                 }
             }
 

--- a/src/Build/Definition/Project.cs
+++ b/src/Build/Definition/Project.cs
@@ -2247,7 +2247,14 @@ namespace Microsoft.Build.Evaluation
             /// Read-only dictionary of item definitions in this project.
             /// Keyed by item type.
             /// </summary>
-            public override IDictionary<string, ProjectItemDefinition> ItemDefinitions => _data.ItemDefinitions;
+            public override IDictionary<string, ProjectItemDefinition> ItemDefinitions
+            {
+                get
+                {
+                    VerifyThrowEvaluationStageReached(ProjectEvaluationStage.ItemDefinitions, nameof(ItemDefinitions));
+                    return _data.ItemDefinitions;
+                }
+            }
 
             /// <summary>
             /// The evaluation stage reached by the most recent evaluation. See <see cref="ProjectEvaluationStage"/>.

--- a/src/Build/Definition/ProjectCollection.cs
+++ b/src/Build/Definition/ProjectCollection.cs
@@ -1323,6 +1323,16 @@ namespace Microsoft.Build.Evaluation
                 string effectiveToolsVersion = Utilities.GenerateToolsVersionToUse(toolsVersion, toolsVersionFromProject, GetToolset, DefaultToolsVersion, out _);
                 Project project = _loadedProjects.GetMatchingProjectIfAny(fileName, globalProperties, effectiveToolsVersion);
 
+                // A cached project only satisfies a (full) LoadProject if it was fully evaluated. If a matching
+                // project exists but was only partially evaluated, upgrade it in place (re-evaluate) so the same
+                // cache slot is reused rather than returning stale partial state or creating a duplicate entry.
+                // This mutation runs under the per-path load lock taken above, so concurrent loads of the same
+                // path cannot upgrade (and thus re-evaluate) the same project instance simultaneously.
+                if (project is not null && project.EvaluationStage < ProjectEvaluationStage.Full)
+                {
+                    project.ReevaluateIfNecessary();
+                }
+
                 // The Project constructor adds itself to our collection, it is not done by us
                 project ??= new Project(fileName, globalProperties, effectiveToolsVersion, this);
 
@@ -2028,10 +2038,8 @@ namespace Microsoft.Build.Evaluation
             /// There can be no more than one match.
             /// If none is found, returns null.
             /// </summary>
-            internal Project GetMatchingProjectIfAny(string fullPath, IDictionary<string, string> globalProperties, string toolsVersion, ProjectEvaluationStage requestedStage = ProjectEvaluationStage.Full)
+            internal Project GetMatchingProjectIfAny(string fullPath, IDictionary<string, string> globalProperties, string toolsVersion)
             {
-                Project match = null;
-
                 lock (_loadedProjects)
                 {
                     if (_loadedProjects.TryGetValue(fullPath, out List<Project> candidates))
@@ -2040,24 +2048,13 @@ namespace Microsoft.Build.Evaluation
                         {
                             if (HasEquivalentGlobalPropertiesAndToolsVersion(candidate, globalProperties, toolsVersion))
                             {
-                                match = candidate;
-                                break;
+                                return candidate;
                             }
                         }
                     }
                 }
 
-                // A cached project only satisfies the request if it was evaluated at least as far as
-                // requested. If a matching project exists but was only partially evaluated, upgrade it
-                // in place (re-evaluate) so the same cache slot is reused rather than returning stale
-                // partial state or creating a duplicate entry. Done outside the lock to avoid holding it
-                // across a full evaluation.
-                if (match != null && match.EvaluationStage < requestedStage)
-                {
-                    match.ReevaluateIfNecessary();
-                }
-
-                return match;
+                return null;
             }
 
             /// <summary>

--- a/src/Build/Definition/ProjectCollection.cs
+++ b/src/Build/Definition/ProjectCollection.cs
@@ -2028,8 +2028,10 @@ namespace Microsoft.Build.Evaluation
             /// There can be no more than one match.
             /// If none is found, returns null.
             /// </summary>
-            internal Project GetMatchingProjectIfAny(string fullPath, IDictionary<string, string> globalProperties, string toolsVersion)
+            internal Project GetMatchingProjectIfAny(string fullPath, IDictionary<string, string> globalProperties, string toolsVersion, ProjectEvaluationStage requestedStage = ProjectEvaluationStage.Full)
             {
+                Project match = null;
+
                 lock (_loadedProjects)
                 {
                     if (_loadedProjects.TryGetValue(fullPath, out List<Project> candidates))
@@ -2038,13 +2040,24 @@ namespace Microsoft.Build.Evaluation
                         {
                             if (HasEquivalentGlobalPropertiesAndToolsVersion(candidate, globalProperties, toolsVersion))
                             {
-                                return candidate;
+                                match = candidate;
+                                break;
                             }
                         }
                     }
-
-                    return null;
                 }
+
+                // A cached project only satisfies the request if it was evaluated at least as far as
+                // requested. If a matching project exists but was only partially evaluated, upgrade it
+                // in place (re-evaluate) so the same cache slot is reused rather than returning stale
+                // partial state or creating a duplicate entry. Done outside the lock to avoid holding it
+                // across a full evaluation.
+                if (match != null && match.EvaluationStage < requestedStage)
+                {
+                    match.ReevaluateIfNecessary();
+                }
+
+                return match;
             }
 
             /// <summary>

--- a/src/Build/Definition/ProjectEvaluationStage.cs
+++ b/src/Build/Definition/ProjectEvaluationStage.cs
@@ -1,0 +1,58 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Build.Evaluation
+{
+    /// <summary>
+    /// Specifies how far project evaluation should proceed.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// MSBuild evaluation runs a fixed sequence of passes. Callers that only need data produced by
+    /// an early pass (for example, a property value) can request a partial evaluation that stops
+    /// after that pass, avoiding the cost of the later passes (item globbing, using-tasks, and
+    /// target registration).
+    /// </para>
+    /// <para>
+    /// The values are ordered by how much of evaluation is performed. A larger value performs strictly
+    /// more work than a smaller one. The default is <see cref="Full"/>, which preserves the historical
+    /// behavior of running every pass.
+    /// </para>
+    /// <para>
+    /// Reading state that a partial evaluation did not produce (for example, reading items after
+    /// stopping at <see cref="Properties"/>) throws <see cref="System.InvalidOperationException"/>.
+    /// </para>
+    /// </remarks>
+    public enum ProjectEvaluationStage
+    {
+        /// <summary>
+        /// Evaluate initial properties, properties, and imports (passes 0 and 1), then stop.
+        /// Property values are final and equivalent to a full evaluation. Items, item definitions,
+        /// using-tasks, and targets are not available.
+        /// </summary>
+        Properties = 1,
+
+        /// <summary>
+        /// Evaluate through item definitions (pass 2), then stop. Includes everything from
+        /// <see cref="Properties"/>. Items, using-tasks, and targets are not available.
+        /// </summary>
+        ItemDefinitions = 2,
+
+        /// <summary>
+        /// Evaluate through items (passes 3 and 3.1), then stop. Includes everything from
+        /// <see cref="ItemDefinitions"/>. Using-tasks and targets are not available.
+        /// </summary>
+        Items = 3,
+
+        /// <summary>
+        /// Evaluate through using-tasks (pass 4), then stop. Includes everything from
+        /// <see cref="Items"/>. Targets are not available.
+        /// </summary>
+        UsingTasks = 4,
+
+        /// <summary>
+        /// Perform a complete evaluation, including target registration (pass 5). This is the default.
+        /// </summary>
+        Full = int.MaxValue,
+    }
+}

--- a/src/Build/Definition/ProjectOptions.cs
+++ b/src/Build/Definition/ProjectOptions.cs
@@ -54,5 +54,11 @@ namespace Microsoft.Build.Definition
         /// Gets or sets a value indicating if loading the project is allowed to interact with the user.
         /// </summary>
         public bool Interactive { get; set; }
+
+        /// <summary>
+        /// The <see cref="ProjectEvaluationStage"/> controlling how far evaluation should proceed.
+        /// Defaults to <see cref="ProjectEvaluationStage.Full"/> (a complete evaluation).
+        /// </summary>
+        public ProjectEvaluationStage EvaluationStage { get; set; } = ProjectEvaluationStage.Full;
     }
 }

--- a/src/Build/Definition/ProjectOptions.cs
+++ b/src/Build/Definition/ProjectOptions.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Collections.Generic;
 using Microsoft.Build.Evaluation;
 using Microsoft.Build.Evaluation.Context;
@@ -59,6 +60,23 @@ namespace Microsoft.Build.Definition
         /// The <see cref="ProjectEvaluationStage"/> controlling how far evaluation should proceed.
         /// Defaults to <see cref="ProjectEvaluationStage.Full"/> (a complete evaluation).
         /// </summary>
-        public ProjectEvaluationStage EvaluationStage { get; set; } = ProjectEvaluationStage.Full;
+        public ProjectEvaluationStage EvaluationStage
+        {
+            get => _evaluationStage;
+            set
+            {
+                // The enum intentionally leaves a large numeric gap between UsingTasks and Full. Reject any
+                // undefined value so a stray stage cannot slip through and cause the evaluator to run every
+                // pass while the object-model guards still (incorrectly) report the state as unavailable.
+                if (!Enum.IsDefined(typeof(ProjectEvaluationStage), value))
+                {
+                    throw new ArgumentOutOfRangeException(nameof(value), value, null);
+                }
+
+                _evaluationStage = value;
+            }
+        }
+
+        private ProjectEvaluationStage _evaluationStage = ProjectEvaluationStage.Full;
     }
 }

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -140,6 +140,11 @@ namespace Microsoft.Build.Evaluation
         private readonly ProjectLoadSettings _loadSettings;
 
         /// <summary>
+        /// How far evaluation should proceed. <see cref="ProjectEvaluationStage.Full"/> runs every pass.
+        /// </summary>
+        private readonly ProjectEvaluationStage _evaluationStage;
+
+        /// <summary>
         /// The maximum number of nodes to report for evaluation.
         /// </summary>
         private readonly int _maxNodeCount;
@@ -223,7 +228,8 @@ namespace Microsoft.Build.Evaluation
             bool profileEvaluation,
             bool interactive,
             ILoggingService loggingService,
-            BuildEventContext buildEventContext)
+            BuildEventContext buildEventContext,
+            ProjectEvaluationStage evaluationStage)
         {
             Assumed.NotNull(data);
             Assumed.NotNull(projectRootElementCache);
@@ -263,6 +269,7 @@ namespace Microsoft.Build.Evaluation
             _projectSupportsReturnsAttribute = new Dictionary<ProjectRootElement, bool>();
             _projectRootElement = projectRootElement;
             _loadSettings = loadSettings;
+            _evaluationStage = evaluationStage;
             _maxNodeCount = maxNodeCount;
             _environmentProperties = environmentProperties;
             _propertiesFromCommandLine = propertiesFromCommandLine ?? [];
@@ -324,7 +331,8 @@ namespace Microsoft.Build.Evaluation
             ISdkResolverService sdkResolverService,
             int submissionId,
             EvaluationContext evaluationContext,
-            bool interactive = false)
+            bool interactive = false,
+            ProjectEvaluationStage evaluationStage = ProjectEvaluationStage.Full)
         {
             MSBuildEventSource.Log.EvaluateStart(root.ProjectFileLocation.File);
             var profileEvaluation = (loadSettings & ProjectLoadSettings.ProfileEvaluation) != 0 || loggingService.IncludeEvaluationProfile;
@@ -346,7 +354,8 @@ namespace Microsoft.Build.Evaluation
                 profileEvaluation,
                 interactive,
                 loggingService,
-                buildEventContext);
+                buildEventContext,
+                evaluationStage);
 
             try
             {
@@ -685,6 +694,13 @@ namespace Microsoft.Build.Evaluation
 
                 _data.InitialTargets = initialTargets;
                 MSBuildEventSource.Log.EvaluatePass1Stop(projectFile);
+
+                if (_evaluationStage <= ProjectEvaluationStage.Properties)
+                {
+                    _data.FinishEvaluation();
+                    return;
+                }
+
                 // Pass2: evaluate item definitions
                 // Don't box via IEnumerator and foreach; cache count so not to evaluate via interface each iteration
                 MSBuildEventSource.Log.EvaluatePass2Start(projectFile);
@@ -699,6 +715,13 @@ namespace Microsoft.Build.Evaluation
                     }
                 }
                 MSBuildEventSource.Log.EvaluatePass2Stop(projectFile);
+
+                if (_evaluationStage <= ProjectEvaluationStage.ItemDefinitions)
+                {
+                    _data.FinishEvaluation();
+                    return;
+                }
+
                 LazyItemEvaluator<P, I, M, D> lazyEvaluator = null;
                 using (_evaluationProfiler.TrackPass(EvaluationPass.Items))
                 {
@@ -746,6 +769,12 @@ namespace Microsoft.Build.Evaluation
 
                 MSBuildEventSource.Log.EvaluatePass3Stop(projectFile);
 
+                if (_evaluationStage <= ProjectEvaluationStage.Items)
+                {
+                    _data.FinishEvaluation();
+                    return;
+                }
+
                 // Pass4: evaluate using-tasks
                 MSBuildEventSource.Log.EvaluatePass4Start(projectFile);
                 using (_evaluationProfiler.TrackPass(EvaluationPass.UsingTasks))
@@ -758,6 +787,12 @@ namespace Microsoft.Build.Evaluation
                         _expander,
                         ExpanderOptions.ExpandPropertiesAndItems,
                         _evaluationContext.FileSystem);
+                }
+
+                if (_evaluationStage <= ProjectEvaluationStage.UsingTasks)
+                {
+                    _data.FinishEvaluation();
+                    return;
                 }
 
                 // If there was no DefaultTargets attribute found in the depth first pass,

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -789,6 +789,8 @@ namespace Microsoft.Build.Evaluation
                         _evaluationContext.FileSystem);
                 }
 
+                MSBuildEventSource.Log.EvaluatePass4Stop(projectFile);
+
                 if (_evaluationStage <= ProjectEvaluationStage.UsingTasks)
                 {
                     _data.FinishEvaluation();
@@ -813,7 +815,6 @@ namespace Microsoft.Build.Evaluation
                 Dictionary<string, List<TargetSpecification>> targetsWhichRunAfterByTarget = new Dictionary<string, List<TargetSpecification>>(StringComparer.OrdinalIgnoreCase);
                 LinkedList<ProjectTargetElement> activeTargetsByEvaluationOrder = new LinkedList<ProjectTargetElement>();
                 Dictionary<string, LinkedListNode<ProjectTargetElement>> activeTargets = new Dictionary<string, LinkedListNode<ProjectTargetElement>>(StringComparer.OrdinalIgnoreCase);
-                MSBuildEventSource.Log.EvaluatePass4Stop(projectFile);
 
                 using (_evaluationProfiler.TrackPass(EvaluationPass.Targets))
                 {

--- a/src/Build/Instance/ProjectInstance.cs
+++ b/src/Build/Instance/ProjectInstance.cs
@@ -1247,7 +1247,7 @@ namespace Microsoft.Build.Execution
         {
             if (_evaluationStage < requiredStage)
             {
-                ErrorUtilities.ThrowInvalidOperation("OM_PartialEvaluationMemberUnavailable", memberName, _evaluationStage);
+                ErrorUtilities.ThrowInvalidOperation("OM_PartialEvaluationMemberUnavailable", memberName, _evaluationStage, requiredStage);
             }
         }
 

--- a/src/Build/Instance/ProjectInstance.cs
+++ b/src/Build/Instance/ProjectInstance.cs
@@ -1280,9 +1280,11 @@ namespace Microsoft.Build.Execution
         /// </summary>
         public IDictionary<string, ProjectItemDefinitionInstance> ItemDefinitions
         {
-            [DebuggerStepThrough]
             get
-            { return _itemDefinitions; }
+            {
+                VerifyThrowEvaluationStageReached(ProjectEvaluationStage.ItemDefinitions, nameof(ItemDefinitions));
+                return _itemDefinitions;
+            }
         }
 
         /// <summary>

--- a/src/Build/Instance/ProjectInstance.cs
+++ b/src/Build/Instance/ProjectInstance.cs
@@ -195,6 +195,13 @@ namespace Microsoft.Build.Execution
         private int _evaluationId = BuildEventContext.InvalidEvaluationId;
 
         /// <summary>
+        /// How far evaluation proceeded when this instance was produced. Defaults to
+        /// <see cref="ProjectEvaluationStage.Full"/>. A partial value means later-pass state
+        /// (items, targets, and so on) was not produced and accessing it will throw.
+        /// </summary>
+        private ProjectEvaluationStage _evaluationStage = ProjectEvaluationStage.Full;
+
+        /// <summary>
         /// The property and item filter used when creating this instance, or null if this is not a filtered copy
         /// of another ProjectInstance. <seealso cref="ProjectInstance(ProjectInstance, bool, RequestedProjectState)"/>
         /// </summary>
@@ -297,9 +304,11 @@ namespace Microsoft.Build.Execution
         /// <param name="evaluationContext">The context to use for evaluation.</param>
         /// <param name="directoryCacheFactory">The directory cache factory to use for file I/O.</param>
         /// <param name="interactive">Indicates if loading the project is allowed to interact with the user.</param>
+        /// <param name="evaluationStage">The stage after which to stop evaluation.</param>
         /// <returns>A new project instance</returns>
         private ProjectInstance(string projectFile, IDictionary<string, string> globalProperties, string toolsVersion, string subToolsetVersion, ProjectCollection projectCollection,
-            ProjectLoadSettings? projectLoadSettings, EvaluationContext evaluationContext, IDirectoryCacheFactory directoryCacheFactory, bool interactive)
+            ProjectLoadSettings? projectLoadSettings, EvaluationContext evaluationContext, IDirectoryCacheFactory directoryCacheFactory, bool interactive,
+            ProjectEvaluationStage evaluationStage = ProjectEvaluationStage.Full)
         {
             ArgumentException.ThrowIfNullOrEmpty(projectFile);
             ErrorUtilities.VerifyThrowArgumentLengthIfNotNull(toolsVersion, nameof(toolsVersion));
@@ -317,7 +326,7 @@ namespace Microsoft.Build.Execution
             ProjectRootElement xml = ProjectRootElement.OpenProjectOrSolution(projectFile, globalProperties, toolsVersion, buildParameters.ProjectRootElementCache, true /*Explicitly Loaded*/);
 
             Initialize(xml, globalProperties, toolsVersion, subToolsetVersion, 0 /* no solution version provided */, buildParameters, projectCollection.LoggingService, buildEventContext,
-                projectLoadSettings: projectLoadSettings, evaluationContext: evaluationContext, directoryCacheFactory: directoryCacheFactory);
+                projectLoadSettings: projectLoadSettings, evaluationContext: evaluationContext, directoryCacheFactory: directoryCacheFactory, evaluationStage: evaluationStage);
         }
 
         /// <summary>
@@ -539,9 +548,11 @@ namespace Microsoft.Build.Execution
         /// <param name="evaluationContext">The context to use for evaluation.</param>
         /// <param name="directoryCacheFactory">The directory cache factory to use for file I/O.</param>
         /// <param name="interactive">Indicates if loading the project is allowed to interact with the user.</param>
+        /// <param name="evaluationStage">The stage after which to stop evaluation.</param>
         /// <returns>A new project instance</returns>
         private ProjectInstance(ProjectRootElement xml, IDictionary<string, string> globalProperties, string toolsVersion, string subToolsetVersion, ProjectCollection projectCollection,
-            ProjectLoadSettings? projectLoadSettings, EvaluationContext evaluationContext, IDirectoryCacheFactory directoryCacheFactory, bool interactive)
+            ProjectLoadSettings? projectLoadSettings, EvaluationContext evaluationContext, IDirectoryCacheFactory directoryCacheFactory, bool interactive,
+            ProjectEvaluationStage evaluationStage = ProjectEvaluationStage.Full)
         {
             BuildEventContext buildEventContext = new BuildEventContext(0, BuildEventContext.InvalidTargetId, BuildEventContext.InvalidProjectContextId, BuildEventContext.InvalidTaskId);
 
@@ -551,7 +562,7 @@ namespace Microsoft.Build.Execution
             };
 
             Initialize(xml, globalProperties, toolsVersion, subToolsetVersion, 0 /* no solution version specified */, buildParameters, projectCollection.LoggingService, buildEventContext,
-                projectLoadSettings: projectLoadSettings, evaluationContext: evaluationContext, directoryCacheFactory: directoryCacheFactory);
+                projectLoadSettings: projectLoadSettings, evaluationContext: evaluationContext, directoryCacheFactory: directoryCacheFactory, evaluationStage: evaluationStage);
         }
 
         /// <summary>
@@ -926,7 +937,8 @@ namespace Microsoft.Build.Execution
                 options.LoadSettings,
                 options.EvaluationContext,
                 options.DirectoryCacheFactory,
-                options.Interactive);
+                options.Interactive,
+                options.EvaluationStage);
         }
 
         /// <summary>
@@ -945,7 +957,8 @@ namespace Microsoft.Build.Execution
                 options.LoadSettings,
                 options.EvaluationContext,
                 options.DirectoryCacheFactory,
-                options.Interactive);
+                options.Interactive,
+                options.EvaluationStage);
         }
 
         /// <summary>
@@ -1174,6 +1187,7 @@ namespace Microsoft.Build.Execution
             [DebuggerStepThrough]
             get
             {
+                VerifyThrowEvaluationStageReached(ProjectEvaluationStage.Items, nameof(Items));
                 return (_items == null) ?
                     (ICollection<ProjectItemInstance>)ReadOnlyEmptyCollection<ProjectItemInstance>.Instance :
                     new ReadOnlyCollection<ProjectItemInstance>(_items);
@@ -1211,6 +1225,30 @@ namespace Microsoft.Build.Execution
         {
             get { return _evaluationId; }
             set { _evaluationId = value; }
+        }
+
+        /// <summary>
+        /// How far evaluation proceeded when this instance was produced.
+        /// When this is not <see cref="ProjectEvaluationStage.Full"/>, the instance is the result of a
+        /// partial evaluation and members exposing state from later passes (for example items or targets)
+        /// throw <see cref="InvalidOperationException"/>.
+        /// </summary>
+        public ProjectEvaluationStage EvaluationStage
+        {
+            get { return _evaluationStage; }
+        }
+
+        /// <summary>
+        /// Throws <see cref="InvalidOperationException"/> if this instance was produced by a partial
+        /// evaluation that stopped before <paramref name="requiredStage"/>, meaning the requested
+        /// member's state was never computed.
+        /// </summary>
+        private void VerifyThrowEvaluationStageReached(ProjectEvaluationStage requiredStage, string memberName)
+        {
+            if (_evaluationStage < requiredStage)
+            {
+                ErrorUtilities.ThrowInvalidOperation("OM_PartialEvaluationMemberUnavailable", memberName, _evaluationStage);
+            }
         }
 
         /// <summary>
@@ -1268,8 +1306,16 @@ namespace Microsoft.Build.Execution
         /// </summary>
         public List<string> DefaultTargets
         {
-            get { return _defaultTargets; }
-            private set { _defaultTargets = value; }
+            get
+            {
+                VerifyThrowEvaluationStageReached(ProjectEvaluationStage.Full, nameof(DefaultTargets));
+                return _defaultTargets;
+            }
+
+            private set
+            {
+                _defaultTargets = value;
+            }
         }
 
         /// <summary>
@@ -1292,7 +1338,10 @@ namespace Microsoft.Build.Execution
         {
             [DebuggerStepThrough]
             get
-            { return _targets; }
+            {
+                VerifyThrowEvaluationStageReached(ProjectEvaluationStage.Full, nameof(Targets));
+                return _targets;
+            }
         }
 
         /// <summary>
@@ -2079,6 +2128,8 @@ namespace Microsoft.Build.Execution
         /// </summary>
         public ICollection<ProjectItemInstance> GetItems(string itemType)
         {
+            VerifyThrowEvaluationStageReached(ProjectEvaluationStage.Items, nameof(GetItems));
+
             // GetItems already returns a readonly collection
             return ((IItemProvider<ProjectItemInstance>)this).GetItems(itemType);
         }
@@ -3199,7 +3250,8 @@ namespace Microsoft.Build.Execution
             int submissionId = BuildEventContext.InvalidSubmissionId,
             ProjectLoadSettings? projectLoadSettings = null,
             EvaluationContext evaluationContext = null,
-            IDirectoryCacheFactory directoryCacheFactory = null)
+            IDirectoryCacheFactory directoryCacheFactory = null,
+            ProjectEvaluationStage evaluationStage = ProjectEvaluationStage.Full)
         {
             ArgumentNullException.ThrowIfNull(xml);
             ErrorUtilities.VerifyThrowArgumentLengthIfNotNull(explicitToolsVersion, "toolsVersion");
@@ -3305,7 +3357,10 @@ namespace Microsoft.Build.Execution
                 sdkResolverService ?? evaluationContext.SdkResolverService, /* Use override ISdkResolverService if specified */
                 submissionId,
                 evaluationContext,
-                interactive: buildParameters.Interactive);
+                interactive: buildParameters.Interactive,
+                evaluationStage: evaluationStage);
+
+            _evaluationStage = evaluationStage;
 
             Assumed.NotEqual(EvaluationId, BuildEventContext.InvalidEvaluationId, "Evaluation should produce an evaluation ID");
         }

--- a/src/Build/Microsoft.Build.csproj
+++ b/src/Build/Microsoft.Build.csproj
@@ -313,6 +313,7 @@
     <Compile Include="Definition\ProjectCollectionChangedEventArgs.cs" />
     <Compile Include="Definition\ProjectImportPathMatch.cs" />
     <Compile Include="Definition\ProjectLoadSettings.cs" />
+    <Compile Include="Definition\ProjectEvaluationStage.cs" />
     <Compile Include="Definition\ToolsetLocalReader.cs" />
     <Compile Include="Evaluation\Context\EvaluationContext.cs" />
     <Compile Include="Evaluation\Profiler\EvaluationLocationMarkdownPrettyPrinter.cs" />

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -1588,8 +1588,8 @@ Utilization:          {0} Average Utilization: {1:###.0}</value>
     <value>This collection cannot convert from the specified value to the backing value.</value>
   </data>
   <data name="OM_PartialEvaluationMemberUnavailable" xml:space="preserve">
-    <value>The "{0}" member is not available because the project was only partially evaluated (evaluation stopped after the "{1}" stage). Re-evaluate the project with a later evaluation stage to access this member.</value>
-    <comment>UE: This message is shown when the user reads a member (for example items or targets) that a partial evaluation did not compute. {0} is the member name, {1} is the ProjectEvaluationStage the project was evaluated to.</comment>
+    <value>The "{0}" member is not available because the project was only partially evaluated (evaluation stopped after the "{1}" stage). Re-evaluate the project with at least the "{2}" evaluation stage to access this member.</value>
+    <comment>UE: This message is shown when the user reads a member (for example items or targets) that a partial evaluation did not compute. {0} is the member name, {1} is the ProjectEvaluationStage the project was evaluated to, {2} is the minimum ProjectEvaluationStage required to access the member.</comment>
   </data>
   <data name="OM_PartialEvaluationCannotBuild" xml:space="preserve">
     <value>The project instance cannot be built because it was only partially evaluated (evaluation stopped after the "{0}" stage). A full evaluation is required to build a project.</value>

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -1587,6 +1587,14 @@ Utilization:          {0} Average Utilization: {1:###.0}</value>
   <data name="OM_NotSupportedConvertingCollectionValueToBacking" xml:space="preserve">
     <value>This collection cannot convert from the specified value to the backing value.</value>
   </data>
+  <data name="OM_PartialEvaluationMemberUnavailable" xml:space="preserve">
+    <value>The "{0}" member is not available because the project was only partially evaluated (evaluation stopped after the "{1}" stage). Re-evaluate the project with a later evaluation stage to access this member.</value>
+    <comment>UE: This message is shown when the user reads a member (for example items or targets) that a partial evaluation did not compute. {0} is the member name, {1} is the ProjectEvaluationStage the project was evaluated to.</comment>
+  </data>
+  <data name="OM_PartialEvaluationCannotBuild" xml:space="preserve">
+    <value>The project instance cannot be built because it was only partially evaluated (evaluation stopped after the "{0}" stage). A full evaluation is required to build a project.</value>
+    <comment>UE: This message is shown when the user tries to build a ProjectInstance produced by a partial evaluation. {0} is the ProjectEvaluationStage the instance was evaluated to.</comment>
+  </data>
   <data name="OM_CannotCreateReservedProperty" xml:space="preserve">
     <value>The "{0}" property name is reserved.</value>
     <comment>UE: This message is shown when the user tries to redefine one of the reserved MSBuild properties e.g. $(MSBuildProjectFile) through the object model</comment>

--- a/src/Build/Resources/xlf/Strings.cs.xlf
+++ b/src/Build/Resources/xlf/Strings.cs.xlf
@@ -719,6 +719,16 @@
         <target state="translated">Klíčové slovo MyClass nejde použít vně položky &lt;Target&gt;.</target>
         <note />
       </trans-unit>
+      <trans-unit id="OM_PartialEvaluationCannotBuild">
+        <source>The project instance cannot be built because it was only partially evaluated (evaluation stopped after the "{0}" stage). A full evaluation is required to build a project.</source>
+        <target state="new">The project instance cannot be built because it was only partially evaluated (evaluation stopped after the "{0}" stage). A full evaluation is required to build a project.</target>
+        <note>UE: This message is shown when the user tries to build a ProjectInstance produced by a partial evaluation. {0} is the ProjectEvaluationStage the instance was evaluated to.</note>
+      </trans-unit>
+      <trans-unit id="OM_PartialEvaluationMemberUnavailable">
+        <source>The "{0}" member is not available because the project was only partially evaluated (evaluation stopped after the "{1}" stage). Re-evaluate the project with a later evaluation stage to access this member.</source>
+        <target state="new">The "{0}" member is not available because the project was only partially evaluated (evaluation stopped after the "{1}" stage). Re-evaluate the project with a later evaluation stage to access this member.</target>
+        <note>UE: This message is shown when the user reads a member (for example items or targets) that a partial evaluation did not compute. {0} is the member name, {1} is the ProjectEvaluationStage the project was evaluated to.</note>
+      </trans-unit>
       <trans-unit id="OM_TargetNameNullOrEmpty">
         <source>Method {0} cannot be called with a collection containing null or empty target names.</source>
         <target state="translated">Metoda {0} se nedá zavolat s kolekcí, která obsahuje prázdné cílové názvy nebo názvy null.</target>

--- a/src/Build/Resources/xlf/Strings.cs.xlf
+++ b/src/Build/Resources/xlf/Strings.cs.xlf
@@ -725,9 +725,9 @@
         <note>UE: This message is shown when the user tries to build a ProjectInstance produced by a partial evaluation. {0} is the ProjectEvaluationStage the instance was evaluated to.</note>
       </trans-unit>
       <trans-unit id="OM_PartialEvaluationMemberUnavailable">
-        <source>The "{0}" member is not available because the project was only partially evaluated (evaluation stopped after the "{1}" stage). Re-evaluate the project with a later evaluation stage to access this member.</source>
-        <target state="new">The "{0}" member is not available because the project was only partially evaluated (evaluation stopped after the "{1}" stage). Re-evaluate the project with a later evaluation stage to access this member.</target>
-        <note>UE: This message is shown when the user reads a member (for example items or targets) that a partial evaluation did not compute. {0} is the member name, {1} is the ProjectEvaluationStage the project was evaluated to.</note>
+        <source>The "{0}" member is not available because the project was only partially evaluated (evaluation stopped after the "{1}" stage). Re-evaluate the project with at least the "{2}" evaluation stage to access this member.</source>
+        <target state="new">The "{0}" member is not available because the project was only partially evaluated (evaluation stopped after the "{1}" stage). Re-evaluate the project with at least the "{2}" evaluation stage to access this member.</target>
+        <note>UE: This message is shown when the user reads a member (for example items or targets) that a partial evaluation did not compute. {0} is the member name, {1} is the ProjectEvaluationStage the project was evaluated to, {2} is the minimum ProjectEvaluationStage required to access the member.</note>
       </trans-unit>
       <trans-unit id="OM_TargetNameNullOrEmpty">
         <source>Method {0} cannot be called with a collection containing null or empty target names.</source>

--- a/src/Build/Resources/xlf/Strings.de.xlf
+++ b/src/Build/Resources/xlf/Strings.de.xlf
@@ -719,6 +719,16 @@
         <target state="translated">MatchOnMetadata kann nicht außerhalb eines &lt;Ziels&gt; verwendet werden.</target>
         <note />
       </trans-unit>
+      <trans-unit id="OM_PartialEvaluationCannotBuild">
+        <source>The project instance cannot be built because it was only partially evaluated (evaluation stopped after the "{0}" stage). A full evaluation is required to build a project.</source>
+        <target state="new">The project instance cannot be built because it was only partially evaluated (evaluation stopped after the "{0}" stage). A full evaluation is required to build a project.</target>
+        <note>UE: This message is shown when the user tries to build a ProjectInstance produced by a partial evaluation. {0} is the ProjectEvaluationStage the instance was evaluated to.</note>
+      </trans-unit>
+      <trans-unit id="OM_PartialEvaluationMemberUnavailable">
+        <source>The "{0}" member is not available because the project was only partially evaluated (evaluation stopped after the "{1}" stage). Re-evaluate the project with a later evaluation stage to access this member.</source>
+        <target state="new">The "{0}" member is not available because the project was only partially evaluated (evaluation stopped after the "{1}" stage). Re-evaluate the project with a later evaluation stage to access this member.</target>
+        <note>UE: This message is shown when the user reads a member (for example items or targets) that a partial evaluation did not compute. {0} is the member name, {1} is the ProjectEvaluationStage the project was evaluated to.</note>
+      </trans-unit>
       <trans-unit id="OM_TargetNameNullOrEmpty">
         <source>Method {0} cannot be called with a collection containing null or empty target names.</source>
         <target state="translated">Die Methode "{0}" kann nicht mit einer Sammlung aufgerufen werden, die NULL oder leere Zielnamen enthält.</target>

--- a/src/Build/Resources/xlf/Strings.de.xlf
+++ b/src/Build/Resources/xlf/Strings.de.xlf
@@ -725,9 +725,9 @@
         <note>UE: This message is shown when the user tries to build a ProjectInstance produced by a partial evaluation. {0} is the ProjectEvaluationStage the instance was evaluated to.</note>
       </trans-unit>
       <trans-unit id="OM_PartialEvaluationMemberUnavailable">
-        <source>The "{0}" member is not available because the project was only partially evaluated (evaluation stopped after the "{1}" stage). Re-evaluate the project with a later evaluation stage to access this member.</source>
-        <target state="new">The "{0}" member is not available because the project was only partially evaluated (evaluation stopped after the "{1}" stage). Re-evaluate the project with a later evaluation stage to access this member.</target>
-        <note>UE: This message is shown when the user reads a member (for example items or targets) that a partial evaluation did not compute. {0} is the member name, {1} is the ProjectEvaluationStage the project was evaluated to.</note>
+        <source>The "{0}" member is not available because the project was only partially evaluated (evaluation stopped after the "{1}" stage). Re-evaluate the project with at least the "{2}" evaluation stage to access this member.</source>
+        <target state="new">The "{0}" member is not available because the project was only partially evaluated (evaluation stopped after the "{1}" stage). Re-evaluate the project with at least the "{2}" evaluation stage to access this member.</target>
+        <note>UE: This message is shown when the user reads a member (for example items or targets) that a partial evaluation did not compute. {0} is the member name, {1} is the ProjectEvaluationStage the project was evaluated to, {2} is the minimum ProjectEvaluationStage required to access the member.</note>
       </trans-unit>
       <trans-unit id="OM_TargetNameNullOrEmpty">
         <source>Method {0} cannot be called with a collection containing null or empty target names.</source>

--- a/src/Build/Resources/xlf/Strings.es.xlf
+++ b/src/Build/Resources/xlf/Strings.es.xlf
@@ -719,6 +719,16 @@
         <target state="translated">MatchOnMetadata no se puede usar fuera de un elemento &lt;Target&gt;.</target>
         <note />
       </trans-unit>
+      <trans-unit id="OM_PartialEvaluationCannotBuild">
+        <source>The project instance cannot be built because it was only partially evaluated (evaluation stopped after the "{0}" stage). A full evaluation is required to build a project.</source>
+        <target state="new">The project instance cannot be built because it was only partially evaluated (evaluation stopped after the "{0}" stage). A full evaluation is required to build a project.</target>
+        <note>UE: This message is shown when the user tries to build a ProjectInstance produced by a partial evaluation. {0} is the ProjectEvaluationStage the instance was evaluated to.</note>
+      </trans-unit>
+      <trans-unit id="OM_PartialEvaluationMemberUnavailable">
+        <source>The "{0}" member is not available because the project was only partially evaluated (evaluation stopped after the "{1}" stage). Re-evaluate the project with a later evaluation stage to access this member.</source>
+        <target state="new">The "{0}" member is not available because the project was only partially evaluated (evaluation stopped after the "{1}" stage). Re-evaluate the project with a later evaluation stage to access this member.</target>
+        <note>UE: This message is shown when the user reads a member (for example items or targets) that a partial evaluation did not compute. {0} is the member name, {1} is the ProjectEvaluationStage the project was evaluated to.</note>
+      </trans-unit>
       <trans-unit id="OM_TargetNameNullOrEmpty">
         <source>Method {0} cannot be called with a collection containing null or empty target names.</source>
         <target state="translated">No se puede llamar al método {0} con una colección que contiene nombres de destino nulos o vacíos.</target>

--- a/src/Build/Resources/xlf/Strings.es.xlf
+++ b/src/Build/Resources/xlf/Strings.es.xlf
@@ -725,9 +725,9 @@
         <note>UE: This message is shown when the user tries to build a ProjectInstance produced by a partial evaluation. {0} is the ProjectEvaluationStage the instance was evaluated to.</note>
       </trans-unit>
       <trans-unit id="OM_PartialEvaluationMemberUnavailable">
-        <source>The "{0}" member is not available because the project was only partially evaluated (evaluation stopped after the "{1}" stage). Re-evaluate the project with a later evaluation stage to access this member.</source>
-        <target state="new">The "{0}" member is not available because the project was only partially evaluated (evaluation stopped after the "{1}" stage). Re-evaluate the project with a later evaluation stage to access this member.</target>
-        <note>UE: This message is shown when the user reads a member (for example items or targets) that a partial evaluation did not compute. {0} is the member name, {1} is the ProjectEvaluationStage the project was evaluated to.</note>
+        <source>The "{0}" member is not available because the project was only partially evaluated (evaluation stopped after the "{1}" stage). Re-evaluate the project with at least the "{2}" evaluation stage to access this member.</source>
+        <target state="new">The "{0}" member is not available because the project was only partially evaluated (evaluation stopped after the "{1}" stage). Re-evaluate the project with at least the "{2}" evaluation stage to access this member.</target>
+        <note>UE: This message is shown when the user reads a member (for example items or targets) that a partial evaluation did not compute. {0} is the member name, {1} is the ProjectEvaluationStage the project was evaluated to, {2} is the minimum ProjectEvaluationStage required to access the member.</note>
       </trans-unit>
       <trans-unit id="OM_TargetNameNullOrEmpty">
         <source>Method {0} cannot be called with a collection containing null or empty target names.</source>

--- a/src/Build/Resources/xlf/Strings.fr.xlf
+++ b/src/Build/Resources/xlf/Strings.fr.xlf
@@ -719,6 +719,16 @@
         <target state="translated">Impossible d'utiliser MatchOnMetadata en dehors de &lt;Target&gt;.</target>
         <note />
       </trans-unit>
+      <trans-unit id="OM_PartialEvaluationCannotBuild">
+        <source>The project instance cannot be built because it was only partially evaluated (evaluation stopped after the "{0}" stage). A full evaluation is required to build a project.</source>
+        <target state="new">The project instance cannot be built because it was only partially evaluated (evaluation stopped after the "{0}" stage). A full evaluation is required to build a project.</target>
+        <note>UE: This message is shown when the user tries to build a ProjectInstance produced by a partial evaluation. {0} is the ProjectEvaluationStage the instance was evaluated to.</note>
+      </trans-unit>
+      <trans-unit id="OM_PartialEvaluationMemberUnavailable">
+        <source>The "{0}" member is not available because the project was only partially evaluated (evaluation stopped after the "{1}" stage). Re-evaluate the project with a later evaluation stage to access this member.</source>
+        <target state="new">The "{0}" member is not available because the project was only partially evaluated (evaluation stopped after the "{1}" stage). Re-evaluate the project with a later evaluation stage to access this member.</target>
+        <note>UE: This message is shown when the user reads a member (for example items or targets) that a partial evaluation did not compute. {0} is the member name, {1} is the ProjectEvaluationStage the project was evaluated to.</note>
+      </trans-unit>
       <trans-unit id="OM_TargetNameNullOrEmpty">
         <source>Method {0} cannot be called with a collection containing null or empty target names.</source>
         <target state="translated">Impossible d'appeler la méthode {0} avec une collection contenant des noms de cibles qui ont une valeur null ou qui sont vides.</target>

--- a/src/Build/Resources/xlf/Strings.fr.xlf
+++ b/src/Build/Resources/xlf/Strings.fr.xlf
@@ -725,9 +725,9 @@
         <note>UE: This message is shown when the user tries to build a ProjectInstance produced by a partial evaluation. {0} is the ProjectEvaluationStage the instance was evaluated to.</note>
       </trans-unit>
       <trans-unit id="OM_PartialEvaluationMemberUnavailable">
-        <source>The "{0}" member is not available because the project was only partially evaluated (evaluation stopped after the "{1}" stage). Re-evaluate the project with a later evaluation stage to access this member.</source>
-        <target state="new">The "{0}" member is not available because the project was only partially evaluated (evaluation stopped after the "{1}" stage). Re-evaluate the project with a later evaluation stage to access this member.</target>
-        <note>UE: This message is shown when the user reads a member (for example items or targets) that a partial evaluation did not compute. {0} is the member name, {1} is the ProjectEvaluationStage the project was evaluated to.</note>
+        <source>The "{0}" member is not available because the project was only partially evaluated (evaluation stopped after the "{1}" stage). Re-evaluate the project with at least the "{2}" evaluation stage to access this member.</source>
+        <target state="new">The "{0}" member is not available because the project was only partially evaluated (evaluation stopped after the "{1}" stage). Re-evaluate the project with at least the "{2}" evaluation stage to access this member.</target>
+        <note>UE: This message is shown when the user reads a member (for example items or targets) that a partial evaluation did not compute. {0} is the member name, {1} is the ProjectEvaluationStage the project was evaluated to, {2} is the minimum ProjectEvaluationStage required to access the member.</note>
       </trans-unit>
       <trans-unit id="OM_TargetNameNullOrEmpty">
         <source>Method {0} cannot be called with a collection containing null or empty target names.</source>

--- a/src/Build/Resources/xlf/Strings.it.xlf
+++ b/src/Build/Resources/xlf/Strings.it.xlf
@@ -719,6 +719,16 @@
         <target state="translated">MatchOnMetadata non può essere usato all'esterno di un elemento &lt;Target&gt;.</target>
         <note />
       </trans-unit>
+      <trans-unit id="OM_PartialEvaluationCannotBuild">
+        <source>The project instance cannot be built because it was only partially evaluated (evaluation stopped after the "{0}" stage). A full evaluation is required to build a project.</source>
+        <target state="new">The project instance cannot be built because it was only partially evaluated (evaluation stopped after the "{0}" stage). A full evaluation is required to build a project.</target>
+        <note>UE: This message is shown when the user tries to build a ProjectInstance produced by a partial evaluation. {0} is the ProjectEvaluationStage the instance was evaluated to.</note>
+      </trans-unit>
+      <trans-unit id="OM_PartialEvaluationMemberUnavailable">
+        <source>The "{0}" member is not available because the project was only partially evaluated (evaluation stopped after the "{1}" stage). Re-evaluate the project with a later evaluation stage to access this member.</source>
+        <target state="new">The "{0}" member is not available because the project was only partially evaluated (evaluation stopped after the "{1}" stage). Re-evaluate the project with a later evaluation stage to access this member.</target>
+        <note>UE: This message is shown when the user reads a member (for example items or targets) that a partial evaluation did not compute. {0} is the member name, {1} is the ProjectEvaluationStage the project was evaluated to.</note>
+      </trans-unit>
       <trans-unit id="OM_TargetNameNullOrEmpty">
         <source>Method {0} cannot be called with a collection containing null or empty target names.</source>
         <target state="translated">Non è possibile chiamare il metodo {0} con una raccolta contenente nomi di destinazione Null o vuoti.</target>

--- a/src/Build/Resources/xlf/Strings.it.xlf
+++ b/src/Build/Resources/xlf/Strings.it.xlf
@@ -725,9 +725,9 @@
         <note>UE: This message is shown when the user tries to build a ProjectInstance produced by a partial evaluation. {0} is the ProjectEvaluationStage the instance was evaluated to.</note>
       </trans-unit>
       <trans-unit id="OM_PartialEvaluationMemberUnavailable">
-        <source>The "{0}" member is not available because the project was only partially evaluated (evaluation stopped after the "{1}" stage). Re-evaluate the project with a later evaluation stage to access this member.</source>
-        <target state="new">The "{0}" member is not available because the project was only partially evaluated (evaluation stopped after the "{1}" stage). Re-evaluate the project with a later evaluation stage to access this member.</target>
-        <note>UE: This message is shown when the user reads a member (for example items or targets) that a partial evaluation did not compute. {0} is the member name, {1} is the ProjectEvaluationStage the project was evaluated to.</note>
+        <source>The "{0}" member is not available because the project was only partially evaluated (evaluation stopped after the "{1}" stage). Re-evaluate the project with at least the "{2}" evaluation stage to access this member.</source>
+        <target state="new">The "{0}" member is not available because the project was only partially evaluated (evaluation stopped after the "{1}" stage). Re-evaluate the project with at least the "{2}" evaluation stage to access this member.</target>
+        <note>UE: This message is shown when the user reads a member (for example items or targets) that a partial evaluation did not compute. {0} is the member name, {1} is the ProjectEvaluationStage the project was evaluated to, {2} is the minimum ProjectEvaluationStage required to access the member.</note>
       </trans-unit>
       <trans-unit id="OM_TargetNameNullOrEmpty">
         <source>Method {0} cannot be called with a collection containing null or empty target names.</source>

--- a/src/Build/Resources/xlf/Strings.ja.xlf
+++ b/src/Build/Resources/xlf/Strings.ja.xlf
@@ -719,6 +719,16 @@
         <target state="translated">MatchOnMetadata を &lt;Target&gt; の外で使用することはできません。</target>
         <note />
       </trans-unit>
+      <trans-unit id="OM_PartialEvaluationCannotBuild">
+        <source>The project instance cannot be built because it was only partially evaluated (evaluation stopped after the "{0}" stage). A full evaluation is required to build a project.</source>
+        <target state="new">The project instance cannot be built because it was only partially evaluated (evaluation stopped after the "{0}" stage). A full evaluation is required to build a project.</target>
+        <note>UE: This message is shown when the user tries to build a ProjectInstance produced by a partial evaluation. {0} is the ProjectEvaluationStage the instance was evaluated to.</note>
+      </trans-unit>
+      <trans-unit id="OM_PartialEvaluationMemberUnavailable">
+        <source>The "{0}" member is not available because the project was only partially evaluated (evaluation stopped after the "{1}" stage). Re-evaluate the project with a later evaluation stage to access this member.</source>
+        <target state="new">The "{0}" member is not available because the project was only partially evaluated (evaluation stopped after the "{1}" stage). Re-evaluate the project with a later evaluation stage to access this member.</target>
+        <note>UE: This message is shown when the user reads a member (for example items or targets) that a partial evaluation did not compute. {0} is the member name, {1} is the ProjectEvaluationStage the project was evaluated to.</note>
+      </trans-unit>
       <trans-unit id="OM_TargetNameNullOrEmpty">
         <source>Method {0} cannot be called with a collection containing null or empty target names.</source>
         <target state="translated">Null または空のターゲット名を含むコレクションを指定してメソッド {0} を呼び出すことはできません。</target>

--- a/src/Build/Resources/xlf/Strings.ja.xlf
+++ b/src/Build/Resources/xlf/Strings.ja.xlf
@@ -725,9 +725,9 @@
         <note>UE: This message is shown when the user tries to build a ProjectInstance produced by a partial evaluation. {0} is the ProjectEvaluationStage the instance was evaluated to.</note>
       </trans-unit>
       <trans-unit id="OM_PartialEvaluationMemberUnavailable">
-        <source>The "{0}" member is not available because the project was only partially evaluated (evaluation stopped after the "{1}" stage). Re-evaluate the project with a later evaluation stage to access this member.</source>
-        <target state="new">The "{0}" member is not available because the project was only partially evaluated (evaluation stopped after the "{1}" stage). Re-evaluate the project with a later evaluation stage to access this member.</target>
-        <note>UE: This message is shown when the user reads a member (for example items or targets) that a partial evaluation did not compute. {0} is the member name, {1} is the ProjectEvaluationStage the project was evaluated to.</note>
+        <source>The "{0}" member is not available because the project was only partially evaluated (evaluation stopped after the "{1}" stage). Re-evaluate the project with at least the "{2}" evaluation stage to access this member.</source>
+        <target state="new">The "{0}" member is not available because the project was only partially evaluated (evaluation stopped after the "{1}" stage). Re-evaluate the project with at least the "{2}" evaluation stage to access this member.</target>
+        <note>UE: This message is shown when the user reads a member (for example items or targets) that a partial evaluation did not compute. {0} is the member name, {1} is the ProjectEvaluationStage the project was evaluated to, {2} is the minimum ProjectEvaluationStage required to access the member.</note>
       </trans-unit>
       <trans-unit id="OM_TargetNameNullOrEmpty">
         <source>Method {0} cannot be called with a collection containing null or empty target names.</source>

--- a/src/Build/Resources/xlf/Strings.ko.xlf
+++ b/src/Build/Resources/xlf/Strings.ko.xlf
@@ -719,6 +719,16 @@
         <target state="translated">MatchOnMetadata는 &lt;Target&gt; 외부에 사용할 수 없습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="OM_PartialEvaluationCannotBuild">
+        <source>The project instance cannot be built because it was only partially evaluated (evaluation stopped after the "{0}" stage). A full evaluation is required to build a project.</source>
+        <target state="new">The project instance cannot be built because it was only partially evaluated (evaluation stopped after the "{0}" stage). A full evaluation is required to build a project.</target>
+        <note>UE: This message is shown when the user tries to build a ProjectInstance produced by a partial evaluation. {0} is the ProjectEvaluationStage the instance was evaluated to.</note>
+      </trans-unit>
+      <trans-unit id="OM_PartialEvaluationMemberUnavailable">
+        <source>The "{0}" member is not available because the project was only partially evaluated (evaluation stopped after the "{1}" stage). Re-evaluate the project with a later evaluation stage to access this member.</source>
+        <target state="new">The "{0}" member is not available because the project was only partially evaluated (evaluation stopped after the "{1}" stage). Re-evaluate the project with a later evaluation stage to access this member.</target>
+        <note>UE: This message is shown when the user reads a member (for example items or targets) that a partial evaluation did not compute. {0} is the member name, {1} is the ProjectEvaluationStage the project was evaluated to.</note>
+      </trans-unit>
       <trans-unit id="OM_TargetNameNullOrEmpty">
         <source>Method {0} cannot be called with a collection containing null or empty target names.</source>
         <target state="translated">null 또는 빈 대상 이름을 포함하는 컬렉션을 사용하여 {0} 메서드를 호출할 수 없습니다.</target>

--- a/src/Build/Resources/xlf/Strings.ko.xlf
+++ b/src/Build/Resources/xlf/Strings.ko.xlf
@@ -725,9 +725,9 @@
         <note>UE: This message is shown when the user tries to build a ProjectInstance produced by a partial evaluation. {0} is the ProjectEvaluationStage the instance was evaluated to.</note>
       </trans-unit>
       <trans-unit id="OM_PartialEvaluationMemberUnavailable">
-        <source>The "{0}" member is not available because the project was only partially evaluated (evaluation stopped after the "{1}" stage). Re-evaluate the project with a later evaluation stage to access this member.</source>
-        <target state="new">The "{0}" member is not available because the project was only partially evaluated (evaluation stopped after the "{1}" stage). Re-evaluate the project with a later evaluation stage to access this member.</target>
-        <note>UE: This message is shown when the user reads a member (for example items or targets) that a partial evaluation did not compute. {0} is the member name, {1} is the ProjectEvaluationStage the project was evaluated to.</note>
+        <source>The "{0}" member is not available because the project was only partially evaluated (evaluation stopped after the "{1}" stage). Re-evaluate the project with at least the "{2}" evaluation stage to access this member.</source>
+        <target state="new">The "{0}" member is not available because the project was only partially evaluated (evaluation stopped after the "{1}" stage). Re-evaluate the project with at least the "{2}" evaluation stage to access this member.</target>
+        <note>UE: This message is shown when the user reads a member (for example items or targets) that a partial evaluation did not compute. {0} is the member name, {1} is the ProjectEvaluationStage the project was evaluated to, {2} is the minimum ProjectEvaluationStage required to access the member.</note>
       </trans-unit>
       <trans-unit id="OM_TargetNameNullOrEmpty">
         <source>Method {0} cannot be called with a collection containing null or empty target names.</source>

--- a/src/Build/Resources/xlf/Strings.pl.xlf
+++ b/src/Build/Resources/xlf/Strings.pl.xlf
@@ -725,9 +725,9 @@
         <note>UE: This message is shown when the user tries to build a ProjectInstance produced by a partial evaluation. {0} is the ProjectEvaluationStage the instance was evaluated to.</note>
       </trans-unit>
       <trans-unit id="OM_PartialEvaluationMemberUnavailable">
-        <source>The "{0}" member is not available because the project was only partially evaluated (evaluation stopped after the "{1}" stage). Re-evaluate the project with a later evaluation stage to access this member.</source>
-        <target state="new">The "{0}" member is not available because the project was only partially evaluated (evaluation stopped after the "{1}" stage). Re-evaluate the project with a later evaluation stage to access this member.</target>
-        <note>UE: This message is shown when the user reads a member (for example items or targets) that a partial evaluation did not compute. {0} is the member name, {1} is the ProjectEvaluationStage the project was evaluated to.</note>
+        <source>The "{0}" member is not available because the project was only partially evaluated (evaluation stopped after the "{1}" stage). Re-evaluate the project with at least the "{2}" evaluation stage to access this member.</source>
+        <target state="new">The "{0}" member is not available because the project was only partially evaluated (evaluation stopped after the "{1}" stage). Re-evaluate the project with at least the "{2}" evaluation stage to access this member.</target>
+        <note>UE: This message is shown when the user reads a member (for example items or targets) that a partial evaluation did not compute. {0} is the member name, {1} is the ProjectEvaluationStage the project was evaluated to, {2} is the minimum ProjectEvaluationStage required to access the member.</note>
       </trans-unit>
       <trans-unit id="OM_TargetNameNullOrEmpty">
         <source>Method {0} cannot be called with a collection containing null or empty target names.</source>

--- a/src/Build/Resources/xlf/Strings.pl.xlf
+++ b/src/Build/Resources/xlf/Strings.pl.xlf
@@ -719,6 +719,16 @@
         <target state="translated">Nie można użyć elementu MatchOnMetadata poza elementem &lt;Target&gt;.</target>
         <note />
       </trans-unit>
+      <trans-unit id="OM_PartialEvaluationCannotBuild">
+        <source>The project instance cannot be built because it was only partially evaluated (evaluation stopped after the "{0}" stage). A full evaluation is required to build a project.</source>
+        <target state="new">The project instance cannot be built because it was only partially evaluated (evaluation stopped after the "{0}" stage). A full evaluation is required to build a project.</target>
+        <note>UE: This message is shown when the user tries to build a ProjectInstance produced by a partial evaluation. {0} is the ProjectEvaluationStage the instance was evaluated to.</note>
+      </trans-unit>
+      <trans-unit id="OM_PartialEvaluationMemberUnavailable">
+        <source>The "{0}" member is not available because the project was only partially evaluated (evaluation stopped after the "{1}" stage). Re-evaluate the project with a later evaluation stage to access this member.</source>
+        <target state="new">The "{0}" member is not available because the project was only partially evaluated (evaluation stopped after the "{1}" stage). Re-evaluate the project with a later evaluation stage to access this member.</target>
+        <note>UE: This message is shown when the user reads a member (for example items or targets) that a partial evaluation did not compute. {0} is the member name, {1} is the ProjectEvaluationStage the project was evaluated to.</note>
+      </trans-unit>
       <trans-unit id="OM_TargetNameNullOrEmpty">
         <source>Method {0} cannot be called with a collection containing null or empty target names.</source>
         <target state="translated">Metody {0} nie można wywołać przy użyciu kolekcji zawierającej nazwy docelowe o wartości null lub puste.</target>

--- a/src/Build/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Build/Resources/xlf/Strings.pt-BR.xlf
@@ -719,6 +719,16 @@
         <target state="translated">MatchOnMetadata não pode ser usado fora de um &lt;Target&gt;.</target>
         <note />
       </trans-unit>
+      <trans-unit id="OM_PartialEvaluationCannotBuild">
+        <source>The project instance cannot be built because it was only partially evaluated (evaluation stopped after the "{0}" stage). A full evaluation is required to build a project.</source>
+        <target state="new">The project instance cannot be built because it was only partially evaluated (evaluation stopped after the "{0}" stage). A full evaluation is required to build a project.</target>
+        <note>UE: This message is shown when the user tries to build a ProjectInstance produced by a partial evaluation. {0} is the ProjectEvaluationStage the instance was evaluated to.</note>
+      </trans-unit>
+      <trans-unit id="OM_PartialEvaluationMemberUnavailable">
+        <source>The "{0}" member is not available because the project was only partially evaluated (evaluation stopped after the "{1}" stage). Re-evaluate the project with a later evaluation stage to access this member.</source>
+        <target state="new">The "{0}" member is not available because the project was only partially evaluated (evaluation stopped after the "{1}" stage). Re-evaluate the project with a later evaluation stage to access this member.</target>
+        <note>UE: This message is shown when the user reads a member (for example items or targets) that a partial evaluation did not compute. {0} is the member name, {1} is the ProjectEvaluationStage the project was evaluated to.</note>
+      </trans-unit>
       <trans-unit id="OM_TargetNameNullOrEmpty">
         <source>Method {0} cannot be called with a collection containing null or empty target names.</source>
         <target state="translated">O método {0} não pode ser chamado com uma coleção que contém nomes de destino nulos ou vazios.</target>

--- a/src/Build/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Build/Resources/xlf/Strings.pt-BR.xlf
@@ -725,9 +725,9 @@
         <note>UE: This message is shown when the user tries to build a ProjectInstance produced by a partial evaluation. {0} is the ProjectEvaluationStage the instance was evaluated to.</note>
       </trans-unit>
       <trans-unit id="OM_PartialEvaluationMemberUnavailable">
-        <source>The "{0}" member is not available because the project was only partially evaluated (evaluation stopped after the "{1}" stage). Re-evaluate the project with a later evaluation stage to access this member.</source>
-        <target state="new">The "{0}" member is not available because the project was only partially evaluated (evaluation stopped after the "{1}" stage). Re-evaluate the project with a later evaluation stage to access this member.</target>
-        <note>UE: This message is shown when the user reads a member (for example items or targets) that a partial evaluation did not compute. {0} is the member name, {1} is the ProjectEvaluationStage the project was evaluated to.</note>
+        <source>The "{0}" member is not available because the project was only partially evaluated (evaluation stopped after the "{1}" stage). Re-evaluate the project with at least the "{2}" evaluation stage to access this member.</source>
+        <target state="new">The "{0}" member is not available because the project was only partially evaluated (evaluation stopped after the "{1}" stage). Re-evaluate the project with at least the "{2}" evaluation stage to access this member.</target>
+        <note>UE: This message is shown when the user reads a member (for example items or targets) that a partial evaluation did not compute. {0} is the member name, {1} is the ProjectEvaluationStage the project was evaluated to, {2} is the minimum ProjectEvaluationStage required to access the member.</note>
       </trans-unit>
       <trans-unit id="OM_TargetNameNullOrEmpty">
         <source>Method {0} cannot be called with a collection containing null or empty target names.</source>

--- a/src/Build/Resources/xlf/Strings.ru.xlf
+++ b/src/Build/Resources/xlf/Strings.ru.xlf
@@ -719,6 +719,16 @@
         <target state="translated">MatchOnMetadata не может использоваться вне &lt;Target&gt;.</target>
         <note />
       </trans-unit>
+      <trans-unit id="OM_PartialEvaluationCannotBuild">
+        <source>The project instance cannot be built because it was only partially evaluated (evaluation stopped after the "{0}" stage). A full evaluation is required to build a project.</source>
+        <target state="new">The project instance cannot be built because it was only partially evaluated (evaluation stopped after the "{0}" stage). A full evaluation is required to build a project.</target>
+        <note>UE: This message is shown when the user tries to build a ProjectInstance produced by a partial evaluation. {0} is the ProjectEvaluationStage the instance was evaluated to.</note>
+      </trans-unit>
+      <trans-unit id="OM_PartialEvaluationMemberUnavailable">
+        <source>The "{0}" member is not available because the project was only partially evaluated (evaluation stopped after the "{1}" stage). Re-evaluate the project with a later evaluation stage to access this member.</source>
+        <target state="new">The "{0}" member is not available because the project was only partially evaluated (evaluation stopped after the "{1}" stage). Re-evaluate the project with a later evaluation stage to access this member.</target>
+        <note>UE: This message is shown when the user reads a member (for example items or targets) that a partial evaluation did not compute. {0} is the member name, {1} is the ProjectEvaluationStage the project was evaluated to.</note>
+      </trans-unit>
       <trans-unit id="OM_TargetNameNullOrEmpty">
         <source>Method {0} cannot be called with a collection containing null or empty target names.</source>
         <target state="translated">Метод {0} не может быть вызван с коллекцией, содержащей целевые имена, которые пусты или равны NULL.</target>

--- a/src/Build/Resources/xlf/Strings.ru.xlf
+++ b/src/Build/Resources/xlf/Strings.ru.xlf
@@ -725,9 +725,9 @@
         <note>UE: This message is shown when the user tries to build a ProjectInstance produced by a partial evaluation. {0} is the ProjectEvaluationStage the instance was evaluated to.</note>
       </trans-unit>
       <trans-unit id="OM_PartialEvaluationMemberUnavailable">
-        <source>The "{0}" member is not available because the project was only partially evaluated (evaluation stopped after the "{1}" stage). Re-evaluate the project with a later evaluation stage to access this member.</source>
-        <target state="new">The "{0}" member is not available because the project was only partially evaluated (evaluation stopped after the "{1}" stage). Re-evaluate the project with a later evaluation stage to access this member.</target>
-        <note>UE: This message is shown when the user reads a member (for example items or targets) that a partial evaluation did not compute. {0} is the member name, {1} is the ProjectEvaluationStage the project was evaluated to.</note>
+        <source>The "{0}" member is not available because the project was only partially evaluated (evaluation stopped after the "{1}" stage). Re-evaluate the project with at least the "{2}" evaluation stage to access this member.</source>
+        <target state="new">The "{0}" member is not available because the project was only partially evaluated (evaluation stopped after the "{1}" stage). Re-evaluate the project with at least the "{2}" evaluation stage to access this member.</target>
+        <note>UE: This message is shown when the user reads a member (for example items or targets) that a partial evaluation did not compute. {0} is the member name, {1} is the ProjectEvaluationStage the project was evaluated to, {2} is the minimum ProjectEvaluationStage required to access the member.</note>
       </trans-unit>
       <trans-unit id="OM_TargetNameNullOrEmpty">
         <source>Method {0} cannot be called with a collection containing null or empty target names.</source>

--- a/src/Build/Resources/xlf/Strings.tr.xlf
+++ b/src/Build/Resources/xlf/Strings.tr.xlf
@@ -719,6 +719,16 @@
         <target state="translated">MatchOnMetadata bir &lt;Target&gt; dışında kullanılamaz.</target>
         <note />
       </trans-unit>
+      <trans-unit id="OM_PartialEvaluationCannotBuild">
+        <source>The project instance cannot be built because it was only partially evaluated (evaluation stopped after the "{0}" stage). A full evaluation is required to build a project.</source>
+        <target state="new">The project instance cannot be built because it was only partially evaluated (evaluation stopped after the "{0}" stage). A full evaluation is required to build a project.</target>
+        <note>UE: This message is shown when the user tries to build a ProjectInstance produced by a partial evaluation. {0} is the ProjectEvaluationStage the instance was evaluated to.</note>
+      </trans-unit>
+      <trans-unit id="OM_PartialEvaluationMemberUnavailable">
+        <source>The "{0}" member is not available because the project was only partially evaluated (evaluation stopped after the "{1}" stage). Re-evaluate the project with a later evaluation stage to access this member.</source>
+        <target state="new">The "{0}" member is not available because the project was only partially evaluated (evaluation stopped after the "{1}" stage). Re-evaluate the project with a later evaluation stage to access this member.</target>
+        <note>UE: This message is shown when the user reads a member (for example items or targets) that a partial evaluation did not compute. {0} is the member name, {1} is the ProjectEvaluationStage the project was evaluated to.</note>
+      </trans-unit>
       <trans-unit id="OM_TargetNameNullOrEmpty">
         <source>Method {0} cannot be called with a collection containing null or empty target names.</source>
         <target state="translated">{0} metosu null veya boş hedef adları içeren bir koleksiyonla çağrılamaz.</target>

--- a/src/Build/Resources/xlf/Strings.tr.xlf
+++ b/src/Build/Resources/xlf/Strings.tr.xlf
@@ -725,9 +725,9 @@
         <note>UE: This message is shown when the user tries to build a ProjectInstance produced by a partial evaluation. {0} is the ProjectEvaluationStage the instance was evaluated to.</note>
       </trans-unit>
       <trans-unit id="OM_PartialEvaluationMemberUnavailable">
-        <source>The "{0}" member is not available because the project was only partially evaluated (evaluation stopped after the "{1}" stage). Re-evaluate the project with a later evaluation stage to access this member.</source>
-        <target state="new">The "{0}" member is not available because the project was only partially evaluated (evaluation stopped after the "{1}" stage). Re-evaluate the project with a later evaluation stage to access this member.</target>
-        <note>UE: This message is shown when the user reads a member (for example items or targets) that a partial evaluation did not compute. {0} is the member name, {1} is the ProjectEvaluationStage the project was evaluated to.</note>
+        <source>The "{0}" member is not available because the project was only partially evaluated (evaluation stopped after the "{1}" stage). Re-evaluate the project with at least the "{2}" evaluation stage to access this member.</source>
+        <target state="new">The "{0}" member is not available because the project was only partially evaluated (evaluation stopped after the "{1}" stage). Re-evaluate the project with at least the "{2}" evaluation stage to access this member.</target>
+        <note>UE: This message is shown when the user reads a member (for example items or targets) that a partial evaluation did not compute. {0} is the member name, {1} is the ProjectEvaluationStage the project was evaluated to, {2} is the minimum ProjectEvaluationStage required to access the member.</note>
       </trans-unit>
       <trans-unit id="OM_TargetNameNullOrEmpty">
         <source>Method {0} cannot be called with a collection containing null or empty target names.</source>

--- a/src/Build/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hans.xlf
@@ -719,6 +719,16 @@
         <target state="translated">MatchOnMetadata 不能在 &lt;Target&gt; 外部使用。</target>
         <note />
       </trans-unit>
+      <trans-unit id="OM_PartialEvaluationCannotBuild">
+        <source>The project instance cannot be built because it was only partially evaluated (evaluation stopped after the "{0}" stage). A full evaluation is required to build a project.</source>
+        <target state="new">The project instance cannot be built because it was only partially evaluated (evaluation stopped after the "{0}" stage). A full evaluation is required to build a project.</target>
+        <note>UE: This message is shown when the user tries to build a ProjectInstance produced by a partial evaluation. {0} is the ProjectEvaluationStage the instance was evaluated to.</note>
+      </trans-unit>
+      <trans-unit id="OM_PartialEvaluationMemberUnavailable">
+        <source>The "{0}" member is not available because the project was only partially evaluated (evaluation stopped after the "{1}" stage). Re-evaluate the project with a later evaluation stage to access this member.</source>
+        <target state="new">The "{0}" member is not available because the project was only partially evaluated (evaluation stopped after the "{1}" stage). Re-evaluate the project with a later evaluation stage to access this member.</target>
+        <note>UE: This message is shown when the user reads a member (for example items or targets) that a partial evaluation did not compute. {0} is the member name, {1} is the ProjectEvaluationStage the project was evaluated to.</note>
+      </trans-unit>
       <trans-unit id="OM_TargetNameNullOrEmpty">
         <source>Method {0} cannot be called with a collection containing null or empty target names.</source>
         <target state="translated">无法使用包含 null 或空目标名称的集合调用方法 {0}。</target>

--- a/src/Build/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hans.xlf
@@ -725,9 +725,9 @@
         <note>UE: This message is shown when the user tries to build a ProjectInstance produced by a partial evaluation. {0} is the ProjectEvaluationStage the instance was evaluated to.</note>
       </trans-unit>
       <trans-unit id="OM_PartialEvaluationMemberUnavailable">
-        <source>The "{0}" member is not available because the project was only partially evaluated (evaluation stopped after the "{1}" stage). Re-evaluate the project with a later evaluation stage to access this member.</source>
-        <target state="new">The "{0}" member is not available because the project was only partially evaluated (evaluation stopped after the "{1}" stage). Re-evaluate the project with a later evaluation stage to access this member.</target>
-        <note>UE: This message is shown when the user reads a member (for example items or targets) that a partial evaluation did not compute. {0} is the member name, {1} is the ProjectEvaluationStage the project was evaluated to.</note>
+        <source>The "{0}" member is not available because the project was only partially evaluated (evaluation stopped after the "{1}" stage). Re-evaluate the project with at least the "{2}" evaluation stage to access this member.</source>
+        <target state="new">The "{0}" member is not available because the project was only partially evaluated (evaluation stopped after the "{1}" stage). Re-evaluate the project with at least the "{2}" evaluation stage to access this member.</target>
+        <note>UE: This message is shown when the user reads a member (for example items or targets) that a partial evaluation did not compute. {0} is the member name, {1} is the ProjectEvaluationStage the project was evaluated to, {2} is the minimum ProjectEvaluationStage required to access the member.</note>
       </trans-unit>
       <trans-unit id="OM_TargetNameNullOrEmpty">
         <source>Method {0} cannot be called with a collection containing null or empty target names.</source>

--- a/src/Build/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hant.xlf
@@ -719,6 +719,16 @@
         <target state="translated">MatchOnMetadata 無法在 &lt;Target&gt; 之外使用。</target>
         <note />
       </trans-unit>
+      <trans-unit id="OM_PartialEvaluationCannotBuild">
+        <source>The project instance cannot be built because it was only partially evaluated (evaluation stopped after the "{0}" stage). A full evaluation is required to build a project.</source>
+        <target state="new">The project instance cannot be built because it was only partially evaluated (evaluation stopped after the "{0}" stage). A full evaluation is required to build a project.</target>
+        <note>UE: This message is shown when the user tries to build a ProjectInstance produced by a partial evaluation. {0} is the ProjectEvaluationStage the instance was evaluated to.</note>
+      </trans-unit>
+      <trans-unit id="OM_PartialEvaluationMemberUnavailable">
+        <source>The "{0}" member is not available because the project was only partially evaluated (evaluation stopped after the "{1}" stage). Re-evaluate the project with a later evaluation stage to access this member.</source>
+        <target state="new">The "{0}" member is not available because the project was only partially evaluated (evaluation stopped after the "{1}" stage). Re-evaluate the project with a later evaluation stage to access this member.</target>
+        <note>UE: This message is shown when the user reads a member (for example items or targets) that a partial evaluation did not compute. {0} is the member name, {1} is the ProjectEvaluationStage the project was evaluated to.</note>
+      </trans-unit>
       <trans-unit id="OM_TargetNameNullOrEmpty">
         <source>Method {0} cannot be called with a collection containing null or empty target names.</source>
         <target state="translated">無法使用內含 null 或空白目標名稱的集合呼叫方法 {0}。</target>

--- a/src/Build/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hant.xlf
@@ -725,9 +725,9 @@
         <note>UE: This message is shown when the user tries to build a ProjectInstance produced by a partial evaluation. {0} is the ProjectEvaluationStage the instance was evaluated to.</note>
       </trans-unit>
       <trans-unit id="OM_PartialEvaluationMemberUnavailable">
-        <source>The "{0}" member is not available because the project was only partially evaluated (evaluation stopped after the "{1}" stage). Re-evaluate the project with a later evaluation stage to access this member.</source>
-        <target state="new">The "{0}" member is not available because the project was only partially evaluated (evaluation stopped after the "{1}" stage). Re-evaluate the project with a later evaluation stage to access this member.</target>
-        <note>UE: This message is shown when the user reads a member (for example items or targets) that a partial evaluation did not compute. {0} is the member name, {1} is the ProjectEvaluationStage the project was evaluated to.</note>
+        <source>The "{0}" member is not available because the project was only partially evaluated (evaluation stopped after the "{1}" stage). Re-evaluate the project with at least the "{2}" evaluation stage to access this member.</source>
+        <target state="new">The "{0}" member is not available because the project was only partially evaluated (evaluation stopped after the "{1}" stage). Re-evaluate the project with at least the "{2}" evaluation stage to access this member.</target>
+        <note>UE: This message is shown when the user reads a member (for example items or targets) that a partial evaluation did not compute. {0} is the member name, {1} is the ProjectEvaluationStage the project was evaluated to, {2} is the minimum ProjectEvaluationStage required to access the member.</note>
       </trans-unit>
       <trans-unit id="OM_TargetNameNullOrEmpty">
         <source>Method {0} cannot be called with a collection containing null or empty target names.</source>


### PR DESCRIPTION
Implements #14288.

## Summary
Adds an opt-in **partial (stop-after-pass) evaluation** model. Callers that only need data produced by an early evaluation pass (most commonly a single property, e.g. the SDK's `ReleasePropertyProjectLocator` reading `PublishRelease`/`PackRelease`) can now stop evaluation after any pass instead of forcing a full evaluation.

A new `ProjectEvaluationStage` enum and `ProjectOptions.EvaluationStage` knob select how far evaluation proceeds:

| Value | Stops after |
| --- | --- |
| `Properties` | pass 1 (properties + imports) |
| `ItemDefinitions` | pass 2 |
| `Items` | pass 3 / 3.1 |
| `UsingTasks` | pass 4 |
| `Full` (default) | pass 5 (targets) |

Property values are final after pass 1, so a stop-at-`Properties` evaluation yields property values identical to a full evaluation.

## Changes
- **Engine** (`Evaluator.cs`): early-return after the requested pass, inside the profiler scopes; `FinishEvaluation()` is still called.
- **Plumbing**: stage threaded through `Project`/`ProjectImpl` and `ProjectInstance` construction, `Initialize`, and `FromFile`/`FromProjectRootElement`/`FromXmlReader`. Both types expose `EvaluationStage`.
- **Fail-fast guards**: reading state a partial evaluation didn't compute (`Items`, `GetItems`, `ItemsIgnoringCondition`, `AllEvaluatedItems`, `Targets`, `DefaultTargets`) throws `InvalidOperationException` naming the member and stage. Properties and `InitialTargets` remain valid from `Properties` onward.
- **Cache correctness**: `ProjectCollection` reuses a cached project only if `cachedStage >= requestedStage` and upgrades a partial cached project in place; public `ReevaluateIfNecessary()` and `CreateProjectInstance()` upgrade a partial project to `Full`; constructing `BuildRequestData` from a partial `ProjectInstance` throws.
- **Default behavior (`Full`) is unchanged** — the feature is purely additive/opt-in.
- Adds `PartialEvaluation_Tests.cs` (10 tests) and a spec doc.

## Perf
File-heavy project (500 source files, ~200 properties, 50 targets), Debug engine:

| Stage | ms/eval | vs Full |
| --- | --- | --- |
| Properties | 2.33 | 54% |
| ItemDefinitions | 2.34 | 54% |
| Items | 3.88 | 90% |
| Full | 4.31 | 100% |

**Stop-at-Properties saves ~46%** of evaluation wall-clock. Complements a shared `EvaluationContext` (see dotnet/sdk#55193) — the two levers stack.

## Testing
- New `PartialEvaluation_Tests` — 10 tests, all pass.
- Regression green: `Evaluator_Tests` (153), `ProjectInstance*` (55), `EvaluationContext` (53).
- Clean build of `Microsoft.Build` (net10.0 + net472), 0 warnings / 0 errors.
