### PR TITLE
Fix MicroBuild plugin feed URL to use allowed pkgs.dev.azure.com format

### DIFF
--- a/azure-pipelines/.vsts-dotnet-build-jobs.yml
+++ b/azure-pipelines/.vsts-dotnet-build-jobs.yml
@@ -112,7 +112,7 @@ jobs:
     inputs:
       signType: ${{ parameters.signTypeParameter }}
       zipSources: false
-      feedSource: https://devdiv.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
+      feedSource: https://pkgs.dev.azure.com/devdiv/_packaging/MicroBuildToolset/nuget/v3/index.json
       ${{ if and(eq(parameters.signTypeParameter, 'real'), eq(variables['System.TeamProject'], 'DevDiv')) }}:
         ConnectedPMEServiceName: 6cc74545-d7b9-4050-9dfa-ebefcc8961ea
     env:
@@ -124,7 +124,7 @@ jobs:
       ProfilingInputsDropName: '$(VisualStudio.DropName)'
       ShouldSkipOptimize: true
       AccessToken: '$(System.AccessToken)'
-      feedSource: 'https://devdiv.pkgs.visualstudio.com/DefaultCollection/_packaging/MicroBuildToolset/nuget/v3/index.json'
+      feedSource: 'https://pkgs.dev.azure.com/devdiv/_packaging/MicroBuildToolset/nuget/v3/index.json'
     displayName: 'Install OptProf Plugin'
     condition: and(succeeded(), ${{ parameters.enableOptProf }})
 


### PR DESCRIPTION
### Fixes

The official MSBuild build (`DotNet-msbuild-Trusted`, DevDiv pipeline "MSBuild" / def 9434) has been failing on `main` since 2026-07-08 at the **Install MicroBuild plugin** step:

```
##[error]The feedSource input 'https://devdiv.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json'
is not an allowed feed. It must start with one of: https://pkgs.dev.azure.com/devdiv,
https://pkgs.dev.azure.com/dnceng, https://pkgs.dev.azure.com/msctoproj, https://pkgs.dev.azure.com/mseng,
https://pkgs.dev.azure.com/xamarin, https://pkgs.dev.azure.com/devdiv-test, https://dnceng.pkgs.visualstudio.com
```

Because the signing plugin fails to install, the build produces no artifacts and every downstream step (Move/Publish artifacts) fails as well. This blocks new signed builds and therefore VS insertion payloads.

### Context

The MicroBuild Signing Plugin (v4) now enforces an allow-list of feed sources. The legacy `https://devdiv.pkgs.visualstudio.com` URL form is no longer accepted; the equivalent Azure DevOps URL `https://pkgs.dev.azure.com/devdiv` is. (Arcade's `eng/common/core-templates/steps/install-microbuild.yml` already uses an allowed `dnceng` URL; only this msbuild-specific pipeline file still used the legacy form.)

### Changes Made

In `azure-pipelines/.vsts-dotnet-build-jobs.yml`, update the `feedSource` for both MicroBuild tasks to the allowed `pkgs.dev.azure.com/devdiv` form (same `MicroBuildToolset` feed, new URL form):

- `MicroBuildSigningPlugin@4`
- `MicroBuildOptProfPlugin@6`

### Testing

Config-only change; validated by the official build pipeline running on this PR.
