### PR TITLE
Fix CTS tool install: --version and --prerelease are mutually exclusive

### DIFF
--- a/azure-pipelines/cts-steps/apply-steps.yml
+++ b/azure-pipelines/cts-steps/apply-steps.yml
@@ -95,9 +95,12 @@ steps:
       '</configuration>'
     )
     Set-Content -Path $cfgPath -Value $lines -Encoding utf8
-    $installArgs = @('tool', 'update', 'cts', '--global', '--prerelease', '--configfile', "$cfgPath")
+    $installArgs = @('tool', 'update', 'cts', '--global', '--configfile', "$cfgPath")
     $toolVersion = '${{ parameters.ctsToolVersion }}'
-    if ($toolVersion) { $installArgs += @('--version', $toolVersion) }
+    # `--version` and `--prerelease` are mutually exclusive: an explicit
+    # prerelease version already selects a prerelease, so only fall back to
+    # `--prerelease` (latest) when no version is pinned.
+    if ($toolVersion) { $installArgs += @('--version', $toolVersion) } else { $installArgs += '--prerelease' }
     dotnet @installArgs
     if ($LASTEXITCODE -ne 0) { throw "cts install/update failed" }
     $toolsDir = if ($IsWindows) { Join-Path $env:USERPROFILE '.dotnet\tools' } else { Join-Path $env:HOME '.dotnet/tools' }

--- a/azure-pipelines/cts-steps/collect-steps.yml
+++ b/azure-pipelines/cts-steps/collect-steps.yml
@@ -82,9 +82,12 @@ steps:
     Set-Content -Path $cfgPath -Value $lines -Encoding utf8
     # `tool update` is idempotent: installs if missing, updates if outdated.
     # Avoids the "tool already installed" exit on warm self-hosted agents.
-    $installArgs = @('tool', 'update', 'cts', '--global', '--prerelease', '--configfile', "$cfgPath")
+    $installArgs = @('tool', 'update', 'cts', '--global', '--configfile', "$cfgPath")
     $toolVersion = '${{ parameters.ctsToolVersion }}'
-    if ($toolVersion) { $installArgs += @('--version', $toolVersion) }
+    # `--version` and `--prerelease` are mutually exclusive: an explicit
+    # prerelease version already selects a prerelease, so only fall back to
+    # `--prerelease` (latest) when no version is pinned.
+    if ($toolVersion) { $installArgs += @('--version', $toolVersion) } else { $installArgs += '--prerelease' }
     dotnet @installArgs
     if ($LASTEXITCODE -ne 0) { throw "cts install/update failed" }
     $toolsDir = if ($IsWindows) { Join-Path $env:USERPROFILE '.dotnet\tools' } else { Join-Path $env:HOME '.dotnet/tools' }


### PR DESCRIPTION
### Problem

The `Install cts tool` step in the CTS pipeline step templates runs:

```
dotnet tool update cts --global --prerelease --version <ctsToolVersion>
```

`dotnet tool update` rejects passing both `--prerelease` and `--version` in the same command:

> The --prerelease and --version options are not supported in the same command

When `ctsToolVersion` is left empty (the default) this never surfaces. But as soon as the version is pinned — as intended, to keep the daily collect and per-PR apply on the same tool build — the install step fails on every OS leg and cascades into all downstream steps.

Observed on CTS-Collect build 14610126 when pinning `ctsToolVersion=2.9.0-alpha.26322.1`.

### Fix

In both `cts-steps/collect-steps.yml` and `cts-steps/apply-steps.yml`, only pass `--prerelease` when no version is pinned. An explicit prerelease version already selects a prerelease, so the two flags never need to coexist.

### Validation

Verified against the DevDiv mirror pipeline (CTS-Collect, def 28380) on a branch carrying this fix with `ctsToolVersion=2.9.0-alpha.26322.1` — the `Install cts tool` step now succeeds on both Windows and Linux and the build proceeds into the collect phase.

cc @janprovaznik for review.