### PR TITLE
Add HelpLink attribute to Error and Warning tasks in CommonTypes.xsd

### DIFF
--- a/src/MSBuild/MSBuild/Microsoft.Build.CommonTypes.xsd
+++ b/src/MSBuild/MSBuild/Microsoft.Build.CommonTypes.xsd
@@ -2993,6 +2993,7 @@ elementFormDefault="qualified">
                     <xs:attribute name="Code" />
                     <xs:attribute name="File" />
                     <xs:attribute name="HelpKeyword" />
+                    <xs:attribute name="HelpLink" />
                     <xs:attribute name="Text" />
                 </xs:extension>
             </xs:complexContent>
@@ -3814,6 +3815,7 @@ elementFormDefault="qualified">
                     <xs:attribute name="Code" />
                     <xs:attribute name="File" />
                     <xs:attribute name="HelpKeyword" />
+                    <xs:attribute name="HelpLink" />
                     <xs:attribute name="Text" />
                 </xs:extension>
             </xs:complexContent>


### PR DESCRIPTION
Fixes #5567

The `HelpLink` property was added to the `Error` and `Warning` tasks in PR #5488, but the IntelliSense schema (`Microsoft.Build.CommonTypes.xsd`) was never updated, so Visual Studio does not offer it. This adds the `HelpLink` attribute alongside the existing `HelpKeyword` attribute in both the `Error` and `Warning` task elements.

Verified `HelpLink` exists as a `string` property on both `src/Tasks/Error.cs` and `src/Tasks/Warning.cs`. XSD remains well-formed XML; `dotnet msbuild src/MSBuild/MSBuild.csproj` builds with 0 warnings.