### PR TITLE
Add unit test coverage for the CombineTargetFrameworkInfoProperties task

### DIFF
--- a/src/Tasks.UnitTests/CombineTargetFrameworkInfoProperties_Tests.cs
+++ b/src/Tasks.UnitTests/CombineTargetFrameworkInfoProperties_Tests.cs
@@ -1,8 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Generic;
+using System.Xml.Linq;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Tasks;
+using Microsoft.Build.Utilities;
 using Shouldly;
 using Xunit;
 
@@ -31,6 +34,102 @@ namespace Microsoft.Build.UnitTests
             task.UseAttributeForTargetFrameworkInfoPropertyNames = UseAttributeForTargetFrameworkInfoPropertyNames;
             task.Execute().ShouldBe(false);
             e.AssertLogContains(errorCode);
+        }
+
+        /// <summary>
+        /// With the default (legacy) schema, the RootElementName becomes the root XML element
+        /// and each item becomes a child element named after its ItemSpec with its Value metadata as content.
+        /// </summary>
+        [Fact]
+        public void CombinesPropertiesIntoXmlUsingRootElementName()
+        {
+            var task = new CombineTargetFrameworkInfoProperties
+            {
+                BuildEngine = new MockEngine(),
+                RootElementName = "PropertyGroup",
+                PropertiesAndValues = new ITaskItem[]
+                {
+                    new TaskItem("Prop1", new Dictionary<string, string> { { "Value", "Val1" } }),
+                    new TaskItem("Prop2", new Dictionary<string, string> { { "Value", "Val2" } }),
+                },
+            };
+
+            task.Execute().ShouldBeTrue();
+
+            XElement root = XElement.Parse(task.Result);
+            root.Name.LocalName.ShouldBe("PropertyGroup");
+            root.Attribute("Name").ShouldBeNull();
+            root.Element("Prop1")!.Value.ShouldBe("Val1");
+            root.Element("Prop2")!.Value.ShouldBe("Val2");
+        }
+
+        /// <summary>
+        /// When opting into the attribute-based schema, the root element is named "TargetFramework"
+        /// and the RootElementName is emitted as its "Name" attribute.
+        /// </summary>
+        [Fact]
+        public void UsesAttributeSchemaWhenOptedIn()
+        {
+            var task = new CombineTargetFrameworkInfoProperties
+            {
+                BuildEngine = new MockEngine(),
+                RootElementName = "net8.0",
+                UseAttributeForTargetFrameworkInfoPropertyNames = true,
+                PropertiesAndValues = new ITaskItem[]
+                {
+                    new TaskItem("Prop1", new Dictionary<string, string> { { "Value", "Val1" } }),
+                },
+            };
+
+            task.Execute().ShouldBeTrue();
+
+            XElement root = XElement.Parse(task.Result);
+            root.Name.LocalName.ShouldBe("TargetFramework");
+            root.Attribute("Name")!.Value.ShouldBe("net8.0");
+            root.Element("Prop1")!.Value.ShouldBe("Val1");
+        }
+
+        /// <summary>
+        /// In the attribute-based schema an empty RootElementName is allowed (only null is rejected),
+        /// producing an empty "Name" attribute.
+        /// </summary>
+        [Fact]
+        public void EmptyRootElementNameIsValidInAttributeSchema()
+        {
+            var task = new CombineTargetFrameworkInfoProperties
+            {
+                BuildEngine = new MockEngine(),
+                RootElementName = "",
+                UseAttributeForTargetFrameworkInfoPropertyNames = true,
+                PropertiesAndValues = new ITaskItem[]
+                {
+                    new TaskItem("Prop1", new Dictionary<string, string> { { "Value", "Val1" } }),
+                },
+            };
+
+            task.Execute().ShouldBeTrue();
+
+            XElement root = XElement.Parse(task.Result);
+            root.Name.LocalName.ShouldBe("TargetFramework");
+            root.Attribute("Name")!.Value.ShouldBe("");
+        }
+
+        /// <summary>
+        /// When PropertiesAndValues is null the task succeeds without producing a result.
+        /// </summary>
+        [Fact]
+        public void NullPropertiesAndValuesSucceedsWithNoResult()
+        {
+            var task = new CombineTargetFrameworkInfoProperties
+            {
+                BuildEngine = new MockEngine(),
+                RootElementName = "PropertyGroup",
+                PropertiesAndValues = null,
+            };
+
+            task.Execute().ShouldBeTrue();
+
+            task.Result.ShouldBeNull();
         }
     }
 }


### PR DESCRIPTION
Adds focused, test-only coverage for the `CombineTargetFrameworkInfoProperties` task (`src/Tasks/CombineTargetFrameworkInfoProperties.cs`).

The existing test file only exercised the error paths (invalid `RootElementName`). This adds success-path coverage for the task's core XML-generation behavior:

- Legacy `RootElementName` schema — root element plus one child per item (`ItemSpec` → `Value` metadata).
- Attribute-based `TargetFramework`/`Name="..."` schema when `UseAttributeForTargetFrameworkInfoPropertyNames` is opted in.
- Empty `RootElementName` accepted in attribute mode (only `null` is rejected).
- `null` `PropertiesAndValues` succeeds with no `Result`.

Test-only diff. All 7 tests in the file pass locally (`dotnet test src/Tasks.UnitTests -- --filter-method "*CombineTargetFrameworkInfoProperties*"`), 0 new warnings.