### PR TITLE
Use partial evaluation for -preprocess, schema validation, and .wdproj dependency scan

### DIFF
--- a/documentation/wiki/ChangeWaves.md
+++ b/documentation/wiki/ChangeWaves.md
@@ -31,8 +31,8 @@ Change wave checks around features will be removed in the release that accompani
 
 ### 18.10
 - [Restore passes ExcludeRestorePackageImports=true as a global property so NuGet's restore no longer triggers a second evaluation of every project.](https://github.com/dotnet/msbuild/issues/14273)
-- [`-getProperty`/`-getItem` (without a target) stop evaluation after the pass that produces the requested data instead of running a full evaluation, avoiding later passes such as target registration.](https://github.com/dotnet/msbuild/pull/14290)
-- [Additional consumers use partial (stop-after-pass) evaluation: `-preprocess` and project schema validation stop after the Properties pass, and the solution generator's web-deployment (`.wdproj`) dependency scan stops after the Items pass.](https://github.com/dotnet/msbuild/pull/14290)
+- [`-getProperty`/`-getItem` (without a target) stop evaluation after the pass that produces the requested data instead of running a full evaluation, avoiding later passes such as target registration.](https://github.com/dotnet/msbuild/pull/14296)
+- [Additional consumers use partial (stop-after-pass) evaluation: `-preprocess` and project schema validation stop after the Properties pass, and the solution generator's web-deployment (`.wdproj`) dependency scan stops after the Items pass.](https://github.com/dotnet/msbuild/pull/14326)
 
 ### 18.9
 - [GenerateResource: typed ResX data/metadata entries in Mark-of-the-Web files are now treated as untrusted and blocked with MSB3821; unblock the file (or set MSBUILDDISABLEFEATURESFROMVERSION=18.9) to restore prior behavior. ResXFileRef entries are always blocked regardless of this wave.](https://github.com/dotnet/msbuild/pull/14015)

--- a/documentation/wiki/ChangeWaves.md
+++ b/documentation/wiki/ChangeWaves.md
@@ -31,7 +31,8 @@ Change wave checks around features will be removed in the release that accompani
 
 ### 18.10
 - [Restore passes ExcludeRestorePackageImports=true as a global property so NuGet's restore no longer triggers a second evaluation of every project.](https://github.com/dotnet/msbuild/issues/14273)
-- [`-getProperty`/`-getItem` (without a target) stop evaluation after the pass that produces the requested data instead of running a full evaluation, avoiding later passes such as target registration.](https://github.com/dotnet/msbuild/pull/14290)arget)
+- [`-getProperty`/`-getItem` (without a target) stop evaluation after the pass that produces the requested data instead of running a full evaluation, avoiding later passes such as target registration.](https://github.com/dotnet/msbuild/pull/14290)
+- [Additional consumers use partial (stop-after-pass) evaluation: `-preprocess` and project schema validation stop after the Properties pass, and the solution generator's web-deployment (`.wdproj`) dependency scan stops after the Items pass.](https://github.com/dotnet/msbuild/pull/14290)
 
 ### 18.9
 - [GenerateResource: typed ResX data/metadata entries in Mark-of-the-Web files are now treated as untrusted and blocked with MSB3821; unblock the file (or set MSBUILDDISABLEFEATURESFROMVERSION=18.9) to restore prior behavior. ResXFileRef entries are always blocked regardless of this wave.](https://github.com/dotnet/msbuild/pull/14015)

--- a/src/Build/Construction/Solution/SolutionProjectGenerator.cs
+++ b/src/Build/Construction/Solution/SolutionProjectGenerator.cs
@@ -2216,7 +2216,18 @@ namespace Microsoft.Build.Construction
 
                     try
                     {
-                        Project msbuildProject = new Project(project.AbsolutePath, _globalProperties, childProjectToolsVersion);
+                        // Only the ProjectDependency items and SourceWebProject property are read below, both
+                        // available after the Items pass. Stop evaluation there instead of running a full
+                        // evaluation. Gated behind change wave 18.10 so the historical full-evaluation behavior
+                        // can be restored if needed.
+                        Project msbuildProject = Project.FromFile(project.AbsolutePath, new Microsoft.Build.Definition.ProjectOptions
+                        {
+                            GlobalProperties = _globalProperties,
+                            ToolsVersion = childProjectToolsVersion,
+                            EvaluationStage = ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave18_10)
+                                ? Microsoft.Build.Evaluation.ProjectEvaluationStage.Items
+                                : Microsoft.Build.Evaluation.ProjectEvaluationStage.Full,
+                        });
 
                         // ProjectDependency items work exactly like ProjectReference items from the point of
                         // view of determining that project B depends on project A.  This item must cause

--- a/src/MSBuild.UnitTests/XMake_Tests.cs
+++ b/src/MSBuild.UnitTests/XMake_Tests.cs
@@ -896,6 +896,42 @@ namespace Microsoft.Build.UnitTests
             }
         }
 
+        /// <summary>
+        /// <c>-preprocess</c> only walks the import closure, which is resolved during the Properties pass
+        /// (partial evaluation, gated behind change wave 18.10). A project whose only error is in the
+        /// targets pass therefore preprocesses successfully, but reverts to failing when the change wave
+        /// is opted out (full evaluation).
+        /// </summary>
+        [Theory]
+        [InlineData(null, true)]      // wave enabled (default): partial evaluation stops before the failing targets pass
+        [InlineData("18.10", false)]  // wave disabled: full evaluation hits the failing targets pass
+        public void PreprocessUsesPartialEvaluation(string disableFeaturesFromVersion, bool expectedSuccess)
+        {
+            using TestEnvironment env = TestEnvironment.Create();
+            if (disableFeaturesFromVersion is not null)
+            {
+                env.SetEnvironmentVariable("MSBUILDDISABLEFEATURESFROMVERSION", disableFeaturesFromVersion);
+            }
+
+            // The BeforeTargets expression only fails when the targets pass runs (pass 5); the import
+            // closure and properties (pass 1) are unaffected, so a partial evaluation preprocesses the
+            // project without hitting the error.
+            TransientTestFile project = env.CreateFile("testProject.csproj", @"
+<Project>
+  <PropertyGroup>
+    <Foo>EvalValue</Foo>
+  </PropertyGroup>
+  <Target Name=""Bad"" BeforeTargets=""$([System.Int32]::Parse('notanumber'))"" />
+</Project>
+");
+            string results = RunnerUtilities.ExecMSBuild($" {project.Path} -preprocess", out bool success);
+            success.ShouldBe(expectedSuccess, results);
+            if (expectedSuccess)
+            {
+                results.ShouldContain("EvalValue");
+            }
+        }
+
         [Fact]
         public void BuildFailsWithBadPropertyName()
         {

--- a/src/MSBuild.UnitTests/XMake_Tests.cs
+++ b/src/MSBuild.UnitTests/XMake_Tests.cs
@@ -907,7 +907,7 @@ namespace Microsoft.Build.UnitTests
         [InlineData("18.10", false)]  // wave disabled: full evaluation hits the failing targets pass
         public void PreprocessUsesPartialEvaluation(string disableFeaturesFromVersion, bool expectedSuccess)
         {
-            using TestEnvironment env = TestEnvironment.Create();
+            using TestEnvironment env = TestEnvironment.Create(_output);
             if (disableFeaturesFromVersion is not null)
             {
                 env.SetEnvironmentVariable("MSBUILDDISABLEFEATURESFROMVERSION", disableFeaturesFromVersion);
@@ -924,7 +924,7 @@ namespace Microsoft.Build.UnitTests
   <Target Name=""Bad"" BeforeTargets=""$([System.Int32]::Parse('notanumber'))"" />
 </Project>
 ");
-            string results = RunnerUtilities.ExecMSBuild($" {project.Path} -preprocess", out bool success);
+            string results = RunnerUtilities.ExecMSBuild($" {project.Path} -preprocess", out bool success, _output);
             success.ShouldBe(expectedSuccess, results);
             if (expectedSuccess)
             {

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -1638,7 +1638,19 @@ namespace Microsoft.Build.CommandLine
                 // If the user has requested that the schema be validated, do that here.
                 if (needToValidateProject && !isSolution)
                 {
-                    Microsoft.Build.Evaluation.Project project = projectCollection.LoadProject(projectFile, globalProperties, toolsVersion);
+                    // Schema validation only needs the toolset resolved from the project's ToolsVersion,
+                    // which is final after the Properties pass. Stop evaluation there instead of running a
+                    // full evaluation. Gated behind change wave 18.10 so the historical full-evaluation
+                    // behavior can be restored if needed.
+                    Microsoft.Build.Evaluation.Project project = Project.FromFile(projectFile, new ProjectOptions
+                    {
+                        ProjectCollection = projectCollection,
+                        GlobalProperties = globalProperties,
+                        ToolsVersion = toolsVersion,
+                        EvaluationStage = ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave18_10)
+                            ? ProjectEvaluationStage.Properties
+                            : ProjectEvaluationStage.Full,
+                    });
                     Microsoft.Build.Evaluation.Toolset toolset = projectCollection.GetToolset(toolsVersion ?? project.ToolsVersion);
 
                     if (toolset == null)
@@ -1665,7 +1677,19 @@ namespace Microsoft.Build.CommandLine
                     }
                     else
                     {
-                        Project project = projectCollection.LoadProject(projectFile, globalProperties, toolsVersion);
+                        // Preprocessing (SaveLogicalProject) only walks the import closure, which is resolved
+                        // during the Properties pass. Stop evaluation there instead of running a full
+                        // evaluation. Gated behind change wave 18.10 so the historical full-evaluation
+                        // behavior can be restored if needed.
+                        Project project = Project.FromFile(projectFile, new ProjectOptions
+                        {
+                            ProjectCollection = projectCollection,
+                            GlobalProperties = globalProperties,
+                            ToolsVersion = toolsVersion,
+                            EvaluationStage = ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave18_10)
+                                ? ProjectEvaluationStage.Properties
+                                : ProjectEvaluationStage.Full,
+                        });
 
                         project.SaveLogicalProject(preprocessWriter);
 


### PR DESCRIPTION
### Context

Builds on the opt-in partial (stop-after-pass) evaluation added in #14290 and adopted by `-getProperty`/`-getItem` in #14296. This extends partial evaluation to three more consumers that only read early-pass data and never build a project.

### Changes

| Consumer | Data read | Stops after |
| --- | --- | --- |
| `-preprocess` / `-pp` (`SaveLogicalProject`) | import closure only (resolved in pass 1) | **Properties** |
| `-validate` schema validation | project `ToolsVersion` only | **Properties** (net472 only) |
| `SolutionProjectGenerator.ScanProjectDependencies` (legacy `.wdproj`) | `ProjectDependency` items + `SourceWebProject` property | **Items** |

All three skip the later using-tasks and target-registration passes.

### Change wave

Gated behind change wave **18.10** (same wave as #14296). Setting `MSBUILDDISABLEFEATURESFROMVERSION=18.10` restores the historical full-evaluation behavior.

### Tests

- New `PreprocessUsesPartialEvaluation` change-wave test in `XMake_Tests.cs`, mirroring the existing `-getProperty` test: a project whose only error is in the targets pass preprocesses successfully with the wave on, and fails (full evaluation) when the wave is disabled. Passes on net10.0 + net472.
- Regression green: engine dependency tests (48).
- Clean build of `Microsoft.Build` and the `MSBuild` CLI (net10.0 + net472), 0 warnings / 0 errors.

### Docs

- Documents the new consumers in `ChangeWaves.md` (and fixes a stray typo on the existing 18.10 entry).
