### PR TITLE
Fix graph solution builds to run traversal-based solution hooks without redispatching project builds.

### DIFF
--- a/src/Build.UnitTests/BackEnd/BuildManager_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/BuildManager_Tests.cs
@@ -4554,10 +4554,77 @@ $@"<Project InitialTargets=`Sleep`>
             _logger.AssertLogContains("[BeforeHook]");
             _logger.AssertLogContains("[AfterHook]");
 
+            int beforeHookIndex = _logger.FullLog.IndexOf("[BeforeHook]", StringComparison.Ordinal);
+            int projectBuildIndex = _logger.FullLog.IndexOf("[ProjectBuild]", StringComparison.Ordinal);
+            int afterHookIndex = _logger.FullLog.IndexOf("[AfterHook]", StringComparison.Ordinal);
+            beforeHookIndex.ShouldBeGreaterThanOrEqualTo(0);
+            projectBuildIndex.ShouldBeGreaterThan(beforeHookIndex);
+            afterHookIndex.ShouldBeGreaterThan(projectBuildIndex);
+
             _logger.AllBuildEvents
                 .OfType<BuildMessageEventArgs>()
                 .Count(e => e.Message.Contains("[ProjectBuild]", StringComparison.Ordinal))
                 .ShouldBe(1);
+        }
+
+        [Fact]
+        public void GraphBuildFromSolutionFailsBeforeBuildingProjectsWhenBeforeHookFails()
+        {
+            string projectContents = """
+                <Project>
+                  <Target Name="Build">
+                    <Message Text="[ProjectBuild]" />
+                  </Target>
+                </Project>
+                """.Cleanup();
+
+            string projectPath = _env.CreateFile("GraphBeforeHookFailProject.csproj", projectContents).Path;
+
+            string solutionContents = new SolutionFileBuilder
+            {
+                Projects = new Dictionary<string, string>
+                {
+                    { "1", projectPath }
+                }
+            }.BuildSolution();
+
+            string solutionPath = _env.CreateFile("GraphBeforeHookFailSolution.sln", solutionContents).Path;
+
+            _env.CreateFile(
+                $"before.{Path.GetFileName(solutionPath)}.targets",
+                """
+                <Project>
+                  <Target Name="FailBeforeHook" BeforeTargets="Build">
+                    <Error Text="[BeforeHookError]" />
+                  </Target>
+                </Project>
+                """.Cleanup());
+
+            _env.CreateFile(
+                $"after.{Path.GetFileName(solutionPath)}.targets",
+                """
+                <Project>
+                  <Target Name="AfterHook" AfterTargets="Build">
+                    <Message Text="[AfterHook]" />
+                  </Target>
+                </Project>
+                """.Cleanup());
+
+            var data = new GraphBuildRequestData(
+                new[] { new ProjectGraphEntryPoint(solutionPath, new Dictionary<string, string>()) },
+                Array.Empty<string>(),
+                null);
+
+            GraphBuildResult result = _buildManager.Build(_parameters, data);
+
+            result.OverallResult.ShouldBe(BuildResultCode.Failure);
+            result.Exception.ShouldNotBeNull();
+            result.Exception.Message.ShouldContain("Graph solution compatibility build failed.");
+            result.ResultsByNode.ShouldBeEmpty();
+
+            _logger.AssertLogContains("[BeforeHookError]");
+            _logger.AssertLogDoesntContain("[ProjectBuild]");
+            _logger.AssertLogDoesntContain("[AfterHook]");
         }
 
         [Fact]

--- a/src/Build.UnitTests/BackEnd/BuildManager_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/BuildManager_Tests.cs
@@ -14,6 +14,7 @@ using System.Threading;
 using Microsoft.Build.BackEnd;
 using Microsoft.Build.Collections;
 using Microsoft.Build.Construction;
+using Microsoft.Build.Engine.UnitTests;
 using Microsoft.Build.Evaluation;
 using Microsoft.Build.Exceptions;
 using Microsoft.Build.Execution;
@@ -4494,6 +4495,177 @@ $@"<Project InitialTargets=`Sleep`>
             logger.FullLog.ShouldContain("Static graph construction started.");
             logger.FullLog.ShouldContain("Static graph loaded in");
             logger.FullLog.ShouldContain("3 nodes, 2 edges");
+        }
+
+        [Fact]
+        public void GraphBuildFromSolutionRunsSolutionHooksWithoutRebuildingProjects()
+        {
+            string projectContents = """
+                <Project>
+                  <Target Name="Build">
+                    <Message Text="[ProjectBuild]" />
+                  </Target>
+                </Project>
+                """.Cleanup();
+
+            string projectPath = _env.CreateFile("GraphHookProject.csproj", projectContents).Path;
+
+            string solutionContents = new SolutionFileBuilder
+            {
+                Projects = new Dictionary<string, string>
+                {
+                    { "1", projectPath }
+                }
+            }.BuildSolution();
+
+            string solutionPath = _env.CreateFile("GraphHookSolution.sln", solutionContents).Path;
+
+            _env.CreateFile(
+                $"before.{Path.GetFileName(solutionPath)}.targets",
+                """
+                <Project>
+                  <Target Name="BeforeHook" BeforeTargets="Build">
+                    <Message Text="[BeforeHook]" />
+                  </Target>
+                </Project>
+                """.Cleanup());
+
+            _env.CreateFile(
+                $"after.{Path.GetFileName(solutionPath)}.targets",
+                """
+                <Project>
+                  <Target Name="AfterHook" AfterTargets="Build">
+                    <Message Text="[AfterHook]" />
+                  </Target>
+                </Project>
+                """.Cleanup());
+
+            var data = new GraphBuildRequestData(
+                new[] { new ProjectGraphEntryPoint(solutionPath, new Dictionary<string, string>()) },
+                Array.Empty<string>(),
+                null);
+
+            GraphBuildResult result = _buildManager.Build(_parameters, data);
+
+            result.OverallResult.ShouldBe(BuildResultCode.Success);
+            result.ResultsByNode.Count.ShouldBe(1);
+            result.ResultsByNode.Values.All(r => r.OverallResult == BuildResultCode.Success).ShouldBeTrue();
+
+            _logger.AssertLogContains("[BeforeHook]");
+            _logger.AssertLogContains("[AfterHook]");
+
+            _logger.AllBuildEvents
+                .OfType<BuildMessageEventArgs>()
+                .Count(e => e.Message.Contains("[ProjectBuild]", StringComparison.Ordinal))
+                .ShouldBe(1);
+        }
+
+        [Fact]
+        public void GraphBuildFromSolutionFailsWhenCompatibilityTraversalFails()
+        {
+            string projectContents = """
+                <Project>
+                  <Target Name="Build">
+                    <Message Text="[ProjectBuild]" />
+                  </Target>
+                </Project>
+                """.Cleanup();
+
+            string projectPath = _env.CreateFile("GraphHookFailProject.csproj", projectContents).Path;
+
+            string solutionContents = new SolutionFileBuilder
+            {
+                Projects = new Dictionary<string, string>
+                {
+                    { "1", projectPath }
+                }
+            }.BuildSolution();
+
+            string solutionPath = _env.CreateFile("GraphHookFailSolution.sln", solutionContents).Path;
+
+            _env.CreateFile(
+                $"after.{Path.GetFileName(solutionPath)}.targets",
+                """
+                <Project>
+                  <Target Name="FailAfterHook" AfterTargets="Build">
+                    <Error Text="[AfterHookError]" />
+                  </Target>
+                </Project>
+                """.Cleanup());
+
+            var data = new GraphBuildRequestData(
+                new[] { new ProjectGraphEntryPoint(solutionPath, new Dictionary<string, string>()) },
+                Array.Empty<string>(),
+                null);
+
+            GraphBuildResult result = _buildManager.Build(_parameters, data);
+
+            result.OverallResult.ShouldBe(BuildResultCode.Failure);
+            result.Exception.ShouldNotBeNull();
+            result.Exception.Message.ShouldContain("Graph solution compatibility build failed.");
+            result.ResultsByNode.Count.ShouldBe(1);
+            result.ResultsByNode.Values.All(r => r.OverallResult == BuildResultCode.Success).ShouldBeTrue();
+        }
+
+        [Fact]
+        public void GraphBuildFromSolutionRunsDirectorySolutionPropsAndTargetsHooks()
+        {
+            string projectContents = """
+                <Project>
+                  <Target Name="Build">
+                    <Message Text="[ProjectBuild]" />
+                  </Target>
+                </Project>
+                """.Cleanup();
+
+            string projectPath = _env.CreateFile("GraphDirectoryHookProject.csproj", projectContents).Path;
+
+            string solutionContents = new SolutionFileBuilder
+            {
+                Projects = new Dictionary<string, string>
+                {
+                    { "1", projectPath }
+                }
+            }.BuildSolution();
+
+            string solutionPath = _env.CreateFile("GraphDirectoryHookSolution.sln", solutionContents).Path;
+
+            _env.CreateFile(
+                "Directory.Solution.props",
+                """
+                <Project>
+                  <PropertyGroup>
+                    <DirectorySolutionMarker>[FromDirectorySolutionProps]</DirectorySolutionMarker>
+                  </PropertyGroup>
+                </Project>
+                """.Cleanup());
+
+            _env.CreateFile(
+                "Directory.Solution.targets",
+                """
+                <Project>
+                  <Target Name="DirectorySolutionHook" BeforeTargets="Build">
+                    <Message Text="[DirectorySolutionHook] $(DirectorySolutionMarker)" />
+                  </Target>
+                </Project>
+                """.Cleanup());
+
+            var data = new GraphBuildRequestData(
+                new[] { new ProjectGraphEntryPoint(solutionPath, new Dictionary<string, string>()) },
+                Array.Empty<string>(),
+                null);
+
+            GraphBuildResult result = _buildManager.Build(_parameters, data);
+
+            result.OverallResult.ShouldBe(BuildResultCode.Success);
+            result.ResultsByNode.Count.ShouldBe(1);
+            result.ResultsByNode.Values.All(r => r.OverallResult == BuildResultCode.Success).ShouldBeTrue();
+
+            _logger.AssertLogContains("[DirectorySolutionHook] [FromDirectorySolutionProps]");
+            _logger.AllBuildEvents
+                .OfType<BuildMessageEventArgs>()
+                .Count(e => e.Message.Contains("[ProjectBuild]", StringComparison.Ordinal))
+                .ShouldBe(1);
         }
 
         /// <summary>

--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -21,6 +21,7 @@ using Microsoft.Build.BackEnd;
 using Microsoft.Build.BackEnd.Logging;
 using Microsoft.Build.BackEnd.SdkResolution;
 using Microsoft.Build.Collections;
+using Microsoft.Build.Construction;
 using Microsoft.Build.Evaluation;
 using Microsoft.Build.Eventing;
 using Microsoft.Build.Exceptions;
@@ -1752,16 +1753,26 @@ namespace Microsoft.Build.Execution
             }
         }
 
-        private ProjectInstance[] CreateGraphSolutionCompatibilityInstances(GraphBuildSubmission submission, ProjectGraph projectGraph)
+        [RequiresUnreferencedCode("Evaluates a solution's projects, which resolves SDKs and reflects over their types; incompatible with trimming.")]
+        private ProjectInstance[] CreateGraphSolutionCompatibilityInstances(
+            GraphBuildSubmission submission,
+            ProjectGraph projectGraph,
+            SolutionProjectGenerator.GraphBuildSolutionCompatibilityPhase? compatibilityPhase = null)
         {
             Assumed.NotNull(projectGraph.Solution, "Graph solution compatibility step requires a solution graph.");
 
-            var globalProperties = new PropertyDictionary<ProjectPropertyInstance>(submission.BuildRequestData.GlobalPropertiesLookup.Count + 1);
+            var globalProperties = new PropertyDictionary<ProjectPropertyInstance>(submission.BuildRequestData.GlobalPropertiesLookup.Count + 2);
             foreach (KeyValuePair<string, string?> propertyPair in submission.BuildRequestData.GlobalPropertiesLookup)
             {
                 globalProperties.Set(ProjectPropertyInstance.Create(propertyPair.Key, propertyPair.Value));
             }
             globalProperties.Set(ProjectPropertyInstance.Create("IsGraphBuild", "true"));
+            if (compatibilityPhase is not null)
+            {
+                globalProperties.Set(ProjectPropertyInstance.Create(
+                    SolutionProjectGenerator.GraphBuildSolutionCompatibilityPhasePropertyName,
+                    SolutionProjectGenerator.GetGraphBuildSolutionCompatibilityPhaseValue(compatibilityPhase.Value)));
+            }
 
             var buildEventContext = new BuildEventContext(
                 submission.SubmissionId,
@@ -1785,6 +1796,31 @@ namespace Microsoft.Build.Execution
                 targetNames,
                 SdkResolverService,
                 submission.SubmissionId);
+        }
+
+        [RequiresUnreferencedCode("Evaluates a solution's projects, which resolves SDKs and reflects over their types; incompatible with trimming.")]
+        private BuildResult ExecuteGraphSolutionCompatibilityBuild(
+            GraphBuildSubmission submission,
+            ProjectGraph projectGraph,
+            SolutionProjectGenerator.GraphBuildSolutionCompatibilityPhase compatibilityPhase)
+        {
+            ProjectInstance[] instances = CreateGraphSolutionCompatibilityInstances(submission, projectGraph, compatibilityPhase);
+            ProjectRootElementCacheBase? originalProjectRootElementCache = _buildParameters!.ProjectRootElementCache;
+            _buildParameters.ProjectRootElementCache = instances[0].ProjectRootElementCache;
+            BuildRequestData compatibilityRequestData = new(
+                instances[0],
+                submission.BuildRequestData.TargetNames.ToArray(),
+                submission.BuildRequestData.HostServices,
+                submission.BuildRequestData.Flags);
+            BuildSubmission compatibilitySubmission = PendBuildRequest(compatibilityRequestData);
+            try
+            {
+                return compatibilitySubmission.Execute();
+            }
+            finally
+            {
+                _buildParameters.ProjectRootElementCache = originalProjectRootElementCache;
+            }
         }
 
         /// <summary>
@@ -2294,21 +2330,26 @@ namespace Microsoft.Build.Execution
                     ProjectErrorUtilities.VerifyThrowInvalidProject(entryPointNode.ProjectInstance.Targets.Count > 0, entryPointNode.ProjectInstance.ProjectFileLocation, "NoTargetSpecified");
                 }
 
-                resultsPerNode = BuildGraph(projectGraph, targetsPerNode, submission.BuildRequestData);
-
-                // Synthetic solution traversal project compatibility step. Traversal can run after node
-                // execution and restore before/after.<solution>.targets and Directory.Solution.* behavior.
                 if (projectGraph.Solution != null)
                 {
-                    ProjectInstance[] instances = CreateGraphSolutionCompatibilityInstances(submission, projectGraph);
-                    _buildParameters!.ProjectRootElementCache = instances[0].ProjectRootElementCache;
-                    BuildRequestData compatibilityRequestData = new(
-                        instances[0],
-                        submission.BuildRequestData.TargetNames.ToArray(),
-                        submission.BuildRequestData.HostServices,
-                        submission.BuildRequestData.Flags);
-                    BuildSubmission compatibilitySubmission = PendBuildRequest(compatibilityRequestData);
-                    compatibilityResult = compatibilitySubmission.Execute();
+                    compatibilityResult = ExecuteGraphSolutionCompatibilityBuild(
+                        submission,
+                        projectGraph,
+                        SolutionProjectGenerator.GraphBuildSolutionCompatibilityPhase.Before);
+                }
+
+                if (compatibilityResult?.OverallResult != BuildResultCode.Failure)
+                {
+                    resultsPerNode = BuildGraph(projectGraph, targetsPerNode, submission.BuildRequestData);
+
+                    // Synthetic solution traversal project compatibility step for after hooks.
+                    if (projectGraph.Solution != null)
+                    {
+                        compatibilityResult = ExecuteGraphSolutionCompatibilityBuild(
+                            submission,
+                            projectGraph,
+                            SolutionProjectGenerator.GraphBuildSolutionCompatibilityPhase.After);
+                    }
                 }
             }
             else

--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -20,6 +20,7 @@ using System.Threading.Tasks.Dataflow;
 using Microsoft.Build.BackEnd;
 using Microsoft.Build.BackEnd.Logging;
 using Microsoft.Build.BackEnd.SdkResolution;
+using Microsoft.Build.Collections;
 using Microsoft.Build.Evaluation;
 using Microsoft.Build.Eventing;
 using Microsoft.Build.Exceptions;
@@ -1751,6 +1752,41 @@ namespace Microsoft.Build.Execution
             }
         }
 
+        private ProjectInstance[] CreateGraphSolutionCompatibilityInstances(GraphBuildSubmission submission, ProjectGraph projectGraph)
+        {
+            Assumed.NotNull(projectGraph.Solution, "Graph solution compatibility step requires a solution graph.");
+
+            var globalProperties = new PropertyDictionary<ProjectPropertyInstance>(submission.BuildRequestData.GlobalPropertiesLookup.Count + 1);
+            foreach (KeyValuePair<string, string?> propertyPair in submission.BuildRequestData.GlobalPropertiesLookup)
+            {
+                globalProperties.Set(ProjectPropertyInstance.Create(propertyPair.Key, propertyPair.Value));
+            }
+            globalProperties.Set(ProjectPropertyInstance.Create("IsGraphBuild", "true"));
+
+            var buildEventContext = new BuildEventContext(
+                submission.SubmissionId,
+                _buildParameters!.NodeId,
+                BuildEventContext.InvalidProjectInstanceId,
+                BuildEventContext.InvalidProjectContextId,
+                BuildEventContext.InvalidTargetId,
+                BuildEventContext.InvalidTaskId);
+
+            IReadOnlyCollection<string> targetNames = submission.BuildRequestData.TargetNames as IReadOnlyCollection<string>
+                ?? submission.BuildRequestData.TargetNames.ToList();
+
+            return ProjectInstance.LoadSolutionForBuild(
+                projectGraph.Solution.FullPath,
+                globalProperties,
+                toolsVersion: null,
+                _buildParameters,
+                ((IBuildComponentHost)this).LoggingService,
+                buildEventContext,
+                false /* loaded by solution parser */,
+                targetNames,
+                SdkResolverService,
+                submission.SubmissionId);
+        }
+
         /// <summary>
         /// Creates the traversal and metaproject instances necessary to represent the solution and populates new configurations with them.
         /// </summary>
@@ -2240,6 +2276,7 @@ namespace Microsoft.Build.Execution
                     projectGraph.ConstructionMetrics.EdgeCount));
 
             Dictionary<ProjectGraphNode, BuildResult>? resultsPerNode = null;
+            BuildResult? compatibilityResult = null;
 
             if (submission.BuildRequestData.GraphBuildOptions.Build)
             {
@@ -2258,6 +2295,21 @@ namespace Microsoft.Build.Execution
                 }
 
                 resultsPerNode = BuildGraph(projectGraph, targetsPerNode, submission.BuildRequestData);
+
+                // Synthetic solution traversal project compatibility step. Traversal can run after node
+                // execution and restore before/after.<solution>.targets and Directory.Solution.* behavior.
+                if (projectGraph.Solution != null)
+                {
+                    ProjectInstance[] instances = CreateGraphSolutionCompatibilityInstances(submission, projectGraph);
+                    _buildParameters!.ProjectRootElementCache = instances[0].ProjectRootElementCache;
+                    BuildRequestData compatibilityRequestData = new(
+                        instances[0],
+                        submission.BuildRequestData.TargetNames.ToArray(),
+                        submission.BuildRequestData.HostServices,
+                        submission.BuildRequestData.Flags);
+                    BuildSubmission compatibilitySubmission = PendBuildRequest(compatibilityRequestData);
+                    compatibilityResult = compatibilitySubmission.Execute();
+                }
             }
             else
             {
@@ -2266,11 +2318,17 @@ namespace Microsoft.Build.Execution
 
             Assumed.Null(submission.BuildResult?.Exception, "Exceptions only get set when the graph submission gets completed with an exception in OnThreadException. That should not happen during graph builds.");
 
+            var graphBuildResult = new GraphBuildResult(
+                submission.SubmissionId,
+                new ReadOnlyDictionary<ProjectGraphNode, BuildResult>(resultsPerNode ?? new Dictionary<ProjectGraphNode, BuildResult>()));
+
+            if (compatibilityResult?.OverallResult == BuildResultCode.Failure)
+            {
+                graphBuildResult.Exception = compatibilityResult.Exception ?? new InvalidOperationException("Graph solution compatibility build failed.");
+            }
+
             // The overall submission is complete, so report it as complete
-            ReportResultsToSubmission<GraphBuildRequestData, GraphBuildResult>(
-                new GraphBuildResult(
-                    submission.SubmissionId,
-                    new ReadOnlyDictionary<ProjectGraphNode, BuildResult>(resultsPerNode ?? new Dictionary<ProjectGraphNode, BuildResult>())));
+            ReportResultsToSubmission<GraphBuildRequestData, GraphBuildResult>(graphBuildResult);
 
             static void DumpGraph(ProjectGraph graph, IReadOnlyDictionary<ProjectGraphNode, ImmutableList<string>>? targetList = null)
             {

--- a/src/Build/Construction/Solution/SolutionProjectGenerator.cs
+++ b/src/Build/Construction/Solution/SolutionProjectGenerator.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections;
 #endif
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Collections.Immutable;
 using System.Collections.ObjectModel;
@@ -74,6 +75,25 @@ namespace Microsoft.Build.Construction
         /// The Special Target name which when <see cref="_batchProjectTargets"/> is enabled, all P2P references will just execute this target.
         /// </summary>
         internal const string SolutionProjectReferenceAllTargets = "SlnProjectResolveProjectReference";
+
+        /// <summary>
+        /// Graph solution compatibility phase property used to split before/after solution imports.
+        /// </summary>
+        internal const string GraphBuildSolutionCompatibilityPhasePropertyName = "_MSBuildGraphSolutionCompatibilityPhase";
+
+        internal enum GraphBuildSolutionCompatibilityPhase
+        {
+            Before,
+            After,
+        }
+
+        internal static string GetGraphBuildSolutionCompatibilityPhaseValue(GraphBuildSolutionCompatibilityPhase phase)
+            => phase switch
+            {
+                GraphBuildSolutionCompatibilityPhase.Before => nameof(GraphBuildSolutionCompatibilityPhase.Before),
+                GraphBuildSolutionCompatibilityPhase.After => nameof(GraphBuildSolutionCompatibilityPhase.After),
+                _ => throw new InvalidEnumArgumentException(nameof(phase), (int)phase, typeof(GraphBuildSolutionCompatibilityPhase)),
+            };
 
         /// <summary>
         /// A known list of target names to create.  This is for backwards compatibility.
@@ -933,11 +953,13 @@ namespace Microsoft.Build.Construction
             // Add our global extensibility points to the project representing the solution:
             // Imported at the top:  $(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\SolutionFile\ImportBefore\*
             // Imported at the bottom:  $(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\SolutionFile\ImportAfter\*
+            string graphBuildSolutionCompatibilityAfterPhaseValue = GetGraphBuildSolutionCompatibilityPhaseValue(GraphBuildSolutionCompatibilityPhase.After);
+            string graphBuildSolutionCompatibilityBeforePhaseValue = GetGraphBuildSolutionCompatibilityPhaseValue(GraphBuildSolutionCompatibilityPhase.Before);
             ProjectImportElement importBefore = traversalProject.CreateImportElement(@"$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\SolutionFile\ImportBefore\*");
-            importBefore.Condition = @"'$(ImportByWildcardBeforeSolution)' != 'false' and exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\SolutionFile\ImportBefore')"; // Avoids wildcard perf problem
+            importBefore.Condition = $@"'$(ImportByWildcardBeforeSolution)' != 'false' and exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\SolutionFile\ImportBefore') and '$({GraphBuildSolutionCompatibilityPhasePropertyName})' != '{graphBuildSolutionCompatibilityAfterPhaseValue}'"; // Avoids wildcard perf problem
 
             ProjectImportElement importAfter = traversalProject.CreateImportElement(@"$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\SolutionFile\ImportAfter\*");
-            importAfter.Condition = @"'$(ImportByWildcardBeforeSolution)' != 'false' and exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\SolutionFile\ImportAfter')"; // Avoids wildcard perf problem
+            importAfter.Condition = $@"'$(ImportByWildcardBeforeSolution)' != 'false' and exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\SolutionFile\ImportAfter') and '$({GraphBuildSolutionCompatibilityPhasePropertyName})' != '{graphBuildSolutionCompatibilityBeforePhaseValue}'"; // Avoids wildcard perf problem
 
             /* The code below adds the following XML:
 
@@ -1079,13 +1101,15 @@ namespace Microsoft.Build.Construction
             }
 
             string escapedSolutionDirectory = EscapingUtilities.Escape(_solutionFile.SolutionFileDirectory);
+            string graphBuildSolutionCompatibilityAfterPhaseValue = GetGraphBuildSolutionCompatibilityPhaseValue(GraphBuildSolutionCompatibilityPhase.After);
+            string graphBuildSolutionCompatibilityBeforePhaseValue = GetGraphBuildSolutionCompatibilityPhaseValue(GraphBuildSolutionCompatibilityPhase.Before);
             string localFile = Path.Combine(escapedSolutionDirectory, $"before.{escapedSolutionFileName}.targets");
             ProjectImportElement importBeforeLocal = traversalProject.CreateImportElement(localFile);
-            importBeforeLocal.Condition = $"exists('{localFile}')";
+            importBeforeLocal.Condition = $"exists('{localFile}') and '$({GraphBuildSolutionCompatibilityPhasePropertyName})' != '{graphBuildSolutionCompatibilityAfterPhaseValue}'";
 
             localFile = Path.Combine(escapedSolutionDirectory, $"after.{escapedSolutionFileName}.targets");
             ProjectImportElement importAfterLocal = traversalProject.CreateImportElement(localFile);
-            importAfterLocal.Condition = $"exists('{localFile}')";
+            importAfterLocal.Condition = $"exists('{localFile}') and '$({GraphBuildSolutionCompatibilityPhasePropertyName})' != '{graphBuildSolutionCompatibilityBeforePhaseValue}'";
 
             return (importBeforeLocal, importAfterLocal);
         }

--- a/src/Build/Construction/Solution/SolutionProjectGenerator.cs
+++ b/src/Build/Construction/Solution/SolutionProjectGenerator.cs
@@ -1421,13 +1421,17 @@ namespace Microsoft.Build.Construction
             // Add the task to build the actual project.
             AddProjectBuildTask(traversalProject, projectConfiguration, target, targetName, EscapingUtilities.Escape(project.AbsolutePath), String.Empty, outputItem);
         }
+        private const string NotGraphBuildCondition = "'$(IsGraphBuild)' != 'true'";
 
         /// <summary>
         /// Adds an MSBuild task to a real project.
         /// </summary>
         private static void AddProjectBuildTask(ProjectInstance traversalProject, ProjectConfigurationInSolution projectConfiguration, ProjectTargetInstance target, string targetToBuild, string sourceItems, string condition, string outputItem)
         {
-            ProjectTaskInstance task = target.AddTask("MSBuild", condition, String.Empty);
+            // Graph compatibility execution should keep the traversal targets and imports alive while
+            // suppressing this direct project-dispatch task because the graph scheduler already built the node.
+            string combinedCondition = string.IsNullOrEmpty(condition) ? NotGraphBuildCondition : $"({condition}) and {NotGraphBuildCondition}";
+            ProjectTaskInstance task = target.AddTask("MSBuild", combinedCondition, String.Empty);
             task.SetParameter("Projects", sourceItems);
             if (targetToBuild != null)
             {
@@ -1458,7 +1462,11 @@ namespace Microsoft.Build.Construction
         /// </summary>
         private void AddMetaprojectBuildTask(ProjectInSolution project, ProjectTargetInstance target, string targetToBuild, string outputItem)
         {
-            ProjectTaskInstance task = target.AddTask("MSBuild", Strings.WeakIntern($"'%(ProjectReference.Identity)' == '{GetMetaprojectName(project)}'"), String.Empty);
+            // Graph compatibility execution should also suppress metaproject dispatch. This pass exists
+            // only to run solution-level extensibility hooks, not to re-enter project or metaproject builds.
+            string projectMatchCondition = Strings.WeakIntern($"'%(ProjectReference.Identity)' == '{GetMetaprojectName(project)}'");
+            string combinedCondition = string.IsNullOrEmpty(projectMatchCondition) ? NotGraphBuildCondition : $"({projectMatchCondition}) and {NotGraphBuildCondition}";
+            ProjectTaskInstance task = target.AddTask("MSBuild", combinedCondition, String.Empty);
             task.SetParameter("Projects", "@(ProjectReference)");
 
             if (targetToBuild != null)
@@ -2061,7 +2069,9 @@ namespace Microsoft.Build.Construction
         /// </summary>
         private static void AddReferencesBuildTask(ProjectTargetInstance target, string targetToBuild, string outputItem)
         {
-            ProjectTaskInstance task = target.AddTask("MSBuild", String.Empty, String.Empty);
+            // In graph compatibility mode the surrounding target should 
+            // still execute, but this inner MSBuild task should be skipped.
+            ProjectTaskInstance task = target.AddTask("MSBuild", NotGraphBuildCondition, String.Empty);
             if (String.Equals(targetToBuild, "Clean", StringComparison.OrdinalIgnoreCase))
             {
                 task.SetParameter("Projects", "@(ProjectReference->Reverse())");


### PR DESCRIPTION
Fixes #8170 #10657

**Context**
Graph builds loaded solution entry points but skipped the solution traversal/metaproject execution path, so solution-level extensibility hooks (before/after solution targets and solution-level props/targets behavior) were not executed consistently with non-graph builds.

**Changes Made**
- Added graph solution compatibility instance creation in BuildManager:
  - creates traversal/metaproject instances via `LoadSolutionForBuild`
  - stamps compatibility global property `IsGraphBuild=true`
- Added graph-aware dispatch guards in `SolutionProjectGenerator`:
  - direct project dispatch tasks are skipped when `$(IsGraphBuild) == 'true'`
  - metaproject dispatch tasks are skipped when `$(IsGraphBuild) == 'true'`
  - traversal reference dispatch task is skipped when `$(IsGraphBuild) == 'true'`
- Wired graph compatibility execution after graph node build completion:
  - executes traversal instance (`instances[0]`) as an inner submission
  - merges compatibility-step failure into overall `GraphBuildResult`

**Testing**
- Added `GraphBuildFromSolutionRunsSolutionHooksWithoutRebuildingProjects`
- Added `GraphBuildFromSolutionFailsWhenCompatibilityTraversalFails`

**Notes**
- Compatibility execution is intentionally post-graph to preserve graph scheduling behavior while restoring solution-level hook parity.
- `GraphBuildResult.ResultsByNode` remains graph-node scoped; compatibility-step impact is reflected via overall result/exception.