### PR TITLE
Restrict partial evaluation to ProjectInstance

### DIFF
--- a/documentation/specs/proposed/partial-evaluation.md
+++ b/documentation/specs/proposed/partial-evaluation.md
@@ -55,13 +55,18 @@ public class ProjectOptions
 }
 ```
 
-The stage flows through the existing factory methods:
+The stage flows through the `ProjectInstance` factory methods:
 
 - `ProjectInstance.FromFile(path, options)` / `ProjectInstance.FromProjectRootElement(xml, options)`
-- `Project.FromFile(path, options)` / `Project.FromProjectRootElement(xml, options)` / `Project.FromXmlReader(reader, options)`
 
-Both `Project.EvaluationStage` and `ProjectInstance.EvaluationStage` report the stage the object was
-evaluated to.
+`ProjectInstance.EvaluationStage` reports the stage the instance was evaluated to.
+
+Partial evaluation is intentionally **not** supported on the mutable `Project` object model. `Project`
+is an editable model that is cached in the `ProjectCollection`; a partially-evaluated `Project` would
+either serve stale state from that cache or be silently upgraded to a full evaluation, discarding the
+work the partial evaluation saved. The `Project` factory methods (`Project.FromFile`,
+`Project.FromProjectRootElement`, `Project.FromXmlReader`) therefore throw `ArgumentException` when a
+non-`Full` `EvaluationStage` is requested; use `ProjectInstance` for partial evaluation.
 
 Example:
 
@@ -81,11 +86,10 @@ string value = instance.GetPropertyValue("PublishRelease"); // fast: only passes
 - **Properties are always valid** for any stage ≥ `Properties` (`GetProperty`, `GetPropertyValue`,
   `Properties`, `GlobalProperties`). `InitialTargets` is also available from `Properties` onward
   because it is computed during pass 1.
-- **Reading not-yet-computed state fails fast.** Members that expose state from a later pass throw
-  `InvalidOperationException` naming the member and the stage the object reached. Guarded members
-  include `ItemDefinitions` (available from `ItemDefinitions` onward), `Items`, `GetItems`,
-  `ItemsIgnoringCondition`, `AllEvaluatedItems`, `Targets`, and `DefaultTargets` (and their
-  `ProjectInstance` equivalents).
+- **Reading not-yet-computed state fails fast.** `ProjectInstance` members that expose state from a
+  later pass throw `InvalidOperationException` naming the member and the stage the instance reached.
+  Guarded members include `ItemDefinitions` (available from `ItemDefinitions` onward), `Items`,
+  `GetItems`, `Targets`, and `DefaultTargets`.
 - **A partial `ProjectInstance` cannot be built.** Constructing a `BuildRequestData` from a partial
   instance throws `InvalidOperationException`; a build requires a full evaluation.
 
@@ -93,15 +97,11 @@ The default (`Full`) is unchanged, so existing callers are unaffected.
 
 ## Evaluation caching
 
-`ProjectCollection` caches loaded `Project`s keyed on (path, global properties, tools version) — the
-evaluation stage is not part of the key. To avoid serving stale partial state:
-
-- A cached project satisfies a request only if `cachedStage >= requestedStage`.
-- `ProjectCollection.LoadProject` requests `Full`. If the only cached project for a key was
-  partially evaluated, it is **upgraded in place** (re-evaluated to `Full`) and returned, rather than
-  returning partial state or creating a duplicate cache entry.
-- Calling the public `Project.ReevaluateIfNecessary()` on a partial project upgrades it to `Full`
-  (a partial evaluation leaves the project non-dirty, so the re-evaluation is forced).
+Partial evaluation applies only to `ProjectInstance`, which is an immutable evaluation snapshot that
+is **not** stored in the `ProjectCollection` loaded-project cache. A partial `ProjectInstance` can
+therefore never be returned in place of a fully-evaluated object for a later `Full` request, so there
+is no cache-staleness or upgrade-in-place concern. This is a primary reason partial evaluation is
+limited to `ProjectInstance`: the cached, mutable `Project` model cannot expose partial state safely.
 
 ## Relationship to `EvaluationContext`
 

--- a/src/Build.UnitTests/Evaluation/PartialEvaluation_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/PartialEvaluation_Tests.cs
@@ -105,18 +105,25 @@ namespace Microsoft.Build.UnitTests.Evaluation
         }
 
         [Fact]
-        public void PropertiesStage_ExposesPropertiesButNotItemsOrTargets_Project()
+        public void ProjectFactories_RejectPartialEvaluationStage()
         {
-            Project project = Project.FromProjectRootElement(CreateRootElement(), OptionsFor(ProjectEvaluationStage.Properties));
+            // Project only supports full evaluation. A partial stage passed through ProjectOptions
+            // must be rejected up front rather than silently ignored.
+            Should.Throw<ArgumentException>(() =>
+                Project.FromProjectRootElement(CreateRootElement(), OptionsFor(ProjectEvaluationStage.Properties)));
 
-            project.EvaluationStage.ShouldBe(ProjectEvaluationStage.Properties);
+            Should.Throw<ArgumentException>(() =>
+                Project.FromProjectRootElement(CreateRootElement(), OptionsFor(ProjectEvaluationStage.Items)));
+        }
+
+        [Fact]
+        public void ProjectFactories_AllowFullEvaluationStage()
+        {
+            Project project = Project.FromProjectRootElement(CreateRootElement(), OptionsFor(ProjectEvaluationStage.Full));
+
             project.GetPropertyValue("Derived").ShouldBe("Debug-x");
-
-            Should.Throw<InvalidOperationException>(() => project.Items);
-            Should.Throw<InvalidOperationException>(() => project.ItemDefinitions);
-            Should.Throw<InvalidOperationException>(() => project.GetItems("Compile"));
-            Should.Throw<InvalidOperationException>(() => project.AllEvaluatedItems);
-            Should.Throw<InvalidOperationException>(() => project.Targets);
+            project.GetItems("Compile").Count.ShouldBe(2);
+            project.Targets.ShouldContainKey("Build");
         }
 
         [Fact]
@@ -166,62 +173,11 @@ namespace Microsoft.Build.UnitTests.Evaluation
         }
 
         [Fact]
-        public void ReevaluateUpgradesPartialProjectToFull()
-        {
-            Project project = Project.FromProjectRootElement(CreateRootElement(), OptionsFor(ProjectEvaluationStage.Properties));
-
-            project.EvaluationStage.ShouldBe(ProjectEvaluationStage.Properties);
-            Should.Throw<InvalidOperationException>(() => project.Targets);
-
-            project.ReevaluateIfNecessary();
-
-            project.EvaluationStage.ShouldBe(ProjectEvaluationStage.Full);
-            project.Targets.ShouldContainKey("Build");
-            project.GetItems("Compile").Count.ShouldBe(2);
-        }
-
-        [Fact]
-        public void CreateProjectInstanceFromPartialProjectUpgradesToFull()
-        {
-            Project project = Project.FromProjectRootElement(CreateRootElement(), OptionsFor(ProjectEvaluationStage.Properties));
-            project.EvaluationStage.ShouldBe(ProjectEvaluationStage.Properties);
-
-            ProjectInstance instance = project.CreateProjectInstance();
-
-            instance.EvaluationStage.ShouldBe(ProjectEvaluationStage.Full);
-            instance.Targets.ShouldContainKey("Build");
-            project.EvaluationStage.ShouldBe(ProjectEvaluationStage.Full);
-        }
-
-        [Fact]
         public void PartialProjectInstanceCannotBeBuilt()
         {
             ProjectInstance instance = ProjectInstance.FromProjectRootElement(CreateRootElement(), OptionsFor(ProjectEvaluationStage.Properties));
 
             Should.Throw<InvalidOperationException>(() => new BuildRequestData(instance, new[] { "Build" }));
-        }
-
-        [Fact]
-        public void CacheDoesNotServePartialProjectForFullLoad()
-        {
-            TransientTestFile file = _env.CreateFile("test.proj", ProjectXml);
-
-            Project partial = Project.FromFile(file.Path, new ProjectOptions
-            {
-                EvaluationStage = ProjectEvaluationStage.Properties,
-                ProjectCollection = _collection,
-            });
-            partial.EvaluationStage.ShouldBe(ProjectEvaluationStage.Properties);
-
-            // A subsequent full LoadProject on the same key must return a fully-evaluated project
-            // (the cached partial one is upgraded in place), never partial state.
-            Project full = _collection.LoadProject(file.Path);
-            full.EvaluationStage.ShouldBe(ProjectEvaluationStage.Full);
-            full.Targets.ShouldContainKey("Build");
-
-            // The partial and full references point at the same upgraded cached project.
-            ReferenceEquals(partial, full).ShouldBeTrue();
-            partial.EvaluationStage.ShouldBe(ProjectEvaluationStage.Full);
         }
     }
 }

--- a/src/Build.UnitTests/Evaluation/PartialEvaluation_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/PartialEvaluation_Tests.cs
@@ -117,6 +117,15 @@ namespace Microsoft.Build.UnitTests.Evaluation
         }
 
         [Fact]
+        public void ProjectFactories_RejectNullOptions()
+        {
+            // The partial-stage guard is the first thing the factories do, so it must not dereference
+            // a null ProjectOptions; callers get the canonical ArgumentNullException instead.
+            Should.Throw<ArgumentNullException>(() =>
+                Project.FromProjectRootElement(CreateRootElement(), null));
+        }
+
+        [Fact]
         public void ProjectFactories_AllowFullEvaluationStage()
         {
             Project project = Project.FromProjectRootElement(CreateRootElement(), OptionsFor(ProjectEvaluationStage.Full));

--- a/src/Build/Definition/Project.cs
+++ b/src/Build/Definition/Project.cs
@@ -558,6 +558,8 @@ namespace Microsoft.Build.Evaluation
         /// </summary>
         private static void ThrowIfPartialEvaluationRequested(ProjectOptions options)
         {
+            ArgumentNullException.ThrowIfNull(options);
+
             if (options.EvaluationStage != ProjectEvaluationStage.Full)
             {
                 ErrorUtilities.ThrowArgument("OM_PartialEvaluationNotSupportedForProject", options.EvaluationStage);

--- a/src/Build/Definition/Project.cs
+++ b/src/Build/Definition/Project.cs
@@ -268,7 +268,7 @@ namespace Microsoft.Build.Evaluation
         }
 
         private Project(ProjectRootElement xml, IDictionary<string, string> globalProperties, string toolsVersion, string subToolsetVersion, ProjectCollection projectCollection, ProjectLoadSettings loadSettings,
-            EvaluationContext evaluationContext, IDirectoryCacheFactory directoryCacheFactory, bool interactive, ProjectEvaluationStage evaluationStage = ProjectEvaluationStage.Full)
+            EvaluationContext evaluationContext, IDirectoryCacheFactory directoryCacheFactory, bool interactive)
         {
             ArgumentNullException.ThrowIfNull(xml);
             ErrorUtilities.VerifyThrowArgumentLengthIfNotNull(toolsVersion, nameof(toolsVersion));
@@ -279,7 +279,7 @@ namespace Microsoft.Build.Evaluation
             implementation = defaultImplementation;
 
             _directoryCacheFactory = directoryCacheFactory;
-            defaultImplementation.Initialize(globalProperties, toolsVersion, subToolsetVersion, loadSettings, evaluationContext, interactive, evaluationStage);
+            defaultImplementation.Initialize(globalProperties, toolsVersion, subToolsetVersion, loadSettings, evaluationContext, interactive);
         }
 
         /// <summary>
@@ -362,7 +362,7 @@ namespace Microsoft.Build.Evaluation
         }
 
         private Project(XmlReader xmlReader, IDictionary<string, string> globalProperties, string toolsVersion, string subToolsetVersion, ProjectCollection projectCollection, ProjectLoadSettings loadSettings,
-            EvaluationContext evaluationContext, IDirectoryCacheFactory directoryCacheFactory, bool interactive, ProjectEvaluationStage evaluationStage = ProjectEvaluationStage.Full)
+            EvaluationContext evaluationContext, IDirectoryCacheFactory directoryCacheFactory, bool interactive)
         {
             ArgumentNullException.ThrowIfNull(xmlReader);
             ErrorUtilities.VerifyThrowArgumentLengthIfNotNull(toolsVersion, nameof(toolsVersion));
@@ -373,7 +373,7 @@ namespace Microsoft.Build.Evaluation
             implementation = defaultImplementation;
 
             _directoryCacheFactory = directoryCacheFactory;
-            defaultImplementation.Initialize(globalProperties, toolsVersion, subToolsetVersion, loadSettings, evaluationContext, interactive, evaluationStage);
+            defaultImplementation.Initialize(globalProperties, toolsVersion, subToolsetVersion, loadSettings, evaluationContext, interactive);
         }
 
         /// <summary>
@@ -458,7 +458,7 @@ namespace Microsoft.Build.Evaluation
         }
 
         private Project(string projectFile, IDictionary<string, string> globalProperties, string toolsVersion, string subToolsetVersion, ProjectCollection projectCollection, ProjectLoadSettings loadSettings,
-            EvaluationContext evaluationContext, IDirectoryCacheFactory directoryCacheFactory, bool interactive, ProjectEvaluationStage evaluationStage = ProjectEvaluationStage.Full)
+            EvaluationContext evaluationContext, IDirectoryCacheFactory directoryCacheFactory, bool interactive)
         {
             ArgumentNullException.ThrowIfNull(projectFile);
             ErrorUtilities.VerifyThrowArgumentLengthIfNotNull(toolsVersion, nameof(toolsVersion));
@@ -475,7 +475,7 @@ namespace Microsoft.Build.Evaluation
             // seems the XmlReader based one should also clean the same way.
             try
             {
-                defaultImplementation.Initialize(globalProperties, toolsVersion, subToolsetVersion, loadSettings, evaluationContext, interactive, evaluationStage);
+                defaultImplementation.Initialize(globalProperties, toolsVersion, subToolsetVersion, loadSettings, evaluationContext, interactive);
             }
             catch (Exception ex) when (!ExceptionHandling.IsCriticalException(ex))
             {
@@ -498,6 +498,7 @@ namespace Microsoft.Build.Evaluation
         /// <returns></returns>
         public static Project FromFile(string file, ProjectOptions options)
         {
+            ThrowIfPartialEvaluationRequested(options);
             return new Project(
                 file,
                 options.GlobalProperties,
@@ -507,8 +508,7 @@ namespace Microsoft.Build.Evaluation
                 options.LoadSettings,
                 options.EvaluationContext,
                 options.DirectoryCacheFactory,
-                options.Interactive,
-                options.EvaluationStage);
+                options.Interactive);
         }
 
         /// <summary>
@@ -518,6 +518,7 @@ namespace Microsoft.Build.Evaluation
         /// <param name="options">The <see cref="ProjectOptions"/> to use.</param>
         public static Project FromProjectRootElement(ProjectRootElement rootElement, ProjectOptions options)
         {
+            ThrowIfPartialEvaluationRequested(options);
             return new Project(
                 rootElement,
                 options.GlobalProperties,
@@ -527,8 +528,7 @@ namespace Microsoft.Build.Evaluation
                 options.LoadSettings,
                 options.EvaluationContext,
                 options.DirectoryCacheFactory,
-                options.Interactive,
-                options.EvaluationStage);
+                options.Interactive);
         }
 
         /// <summary>
@@ -538,6 +538,7 @@ namespace Microsoft.Build.Evaluation
         /// <param name="options">The <see cref="ProjectOptions"/> to use.</param>
         public static Project FromXmlReader(XmlReader reader, ProjectOptions options)
         {
+            ThrowIfPartialEvaluationRequested(options);
             return new Project(
                 reader,
                 options.GlobalProperties,
@@ -547,8 +548,20 @@ namespace Microsoft.Build.Evaluation
                 options.LoadSettings,
                 options.EvaluationContext,
                 options.DirectoryCacheFactory,
-                options.Interactive,
-                options.EvaluationStage);
+                options.Interactive);
+        }
+
+        /// <summary>
+        /// <see cref="Project"/> only supports full evaluation. Throws if a caller requests a partial
+        /// evaluation via <see cref="ProjectOptions.EvaluationStage"/>; use <see cref="ProjectInstance"/>
+        /// for partial (stop-after-pass) evaluation.
+        /// </summary>
+        private static void ThrowIfPartialEvaluationRequested(ProjectOptions options)
+        {
+            if (options.EvaluationStage != ProjectEvaluationStage.Full)
+            {
+                ErrorUtilities.ThrowArgument("OM_PartialEvaluationNotSupportedForProject", options.EvaluationStage);
+            }
         }
 
         /// <summary>
@@ -842,16 +855,6 @@ namespace Microsoft.Build.Evaluation
         /// evaluation logging events back to the Project instance.
         /// </summary>
         public int LastEvaluationId => implementation.LastEvaluationId;
-
-        /// <summary>
-        /// How far evaluation proceeded when this project was last evaluated.
-        /// When this is not <see cref="ProjectEvaluationStage.Full"/>, the project is the result of a
-        /// partial evaluation (requested via <see cref="ProjectOptions.EvaluationStage"/>) and members
-        /// exposing state from later passes (for example items or targets) throw
-        /// <see cref="InvalidOperationException"/> until the project is re-evaluated via
-        /// <see cref="ReevaluateIfNecessary()"/>.
-        /// </summary>
-        public ProjectEvaluationStage EvaluationStage => (implementation as ProjectImpl)?.EvaluationStageInternal ?? ProjectEvaluationStage.Full;
 
         /// <summary>
         /// List of names of the properties that, while global, are still treated as overridable.
@@ -1887,14 +1890,6 @@ namespace Microsoft.Build.Evaluation
             private ProjectLoadSettings _loadSettings;
 
             /// <summary>
-            /// The evaluation stage reached by the most recent evaluation. <see cref="ProjectEvaluationStage.Full"/>
-            /// unless the project was created via a <see cref="ProjectOptions"/> requesting a partial evaluation.
-            /// Retained so that member accessors can fail fast on not-yet-computed state, and so re-evaluation
-            /// can restore the requested stage.
-            /// </summary>
-            private ProjectEvaluationStage _evaluationStage = ProjectEvaluationStage.Full;
-
-            /// <summary>
             /// The delegate registered with the ProjectRootElement to be called if the file name
             /// is changed. Retained so that ultimately it can be unregistered.
             /// If it has been set to null, the project has been unloaded from its collection.
@@ -2251,25 +2246,7 @@ namespace Microsoft.Build.Evaluation
             {
                 get
                 {
-                    VerifyThrowEvaluationStageReached(ProjectEvaluationStage.ItemDefinitions, nameof(ItemDefinitions));
                     return _data.ItemDefinitions;
-                }
-            }
-
-            /// <summary>
-            /// The evaluation stage reached by the most recent evaluation. See <see cref="ProjectEvaluationStage"/>.
-            /// </summary>
-            internal ProjectEvaluationStage EvaluationStageInternal => _evaluationStage;
-
-            /// <summary>
-            /// Throws <see cref="InvalidOperationException"/> if the most recent evaluation stopped before
-            /// <paramref name="requiredStage"/>, meaning the requested member's state was never computed.
-            /// </summary>
-            private void VerifyThrowEvaluationStageReached(ProjectEvaluationStage requiredStage, string memberName)
-            {
-                if (_evaluationStage < requiredStage)
-                {
-                    ErrorUtilities.ThrowInvalidOperation("OM_PartialEvaluationMemberUnavailable", memberName, _evaluationStage, requiredStage);
                 }
             }
 
@@ -2281,7 +2258,6 @@ namespace Microsoft.Build.Evaluation
             {
                 get
                 {
-                    VerifyThrowEvaluationStageReached(ProjectEvaluationStage.Items, nameof(Items));
                     return new ReadOnlyCollection<ProjectItem>(_data.Items);
                 }
             }
@@ -2299,8 +2275,6 @@ namespace Microsoft.Build.Evaluation
                 [DebuggerStepThrough]
                 get
                 {
-                    VerifyThrowEvaluationStageReached(ProjectEvaluationStage.Items, nameof(ItemsIgnoringCondition));
-
                     if (!(_data.ShouldEvaluateForDesignTime && _data.CanEvaluateElementsWithFalseConditions))
                     {
                         ErrorUtilities.ThrowInvalidOperation("OM_NotEvaluatedBecauseShouldEvaluateForDesignTimeIsFalse", nameof(ItemsIgnoringCondition));
@@ -2371,8 +2345,6 @@ namespace Microsoft.Build.Evaluation
                 [DebuggerStepThrough]
                 get
                 {
-                    VerifyThrowEvaluationStageReached(ProjectEvaluationStage.Full, nameof(Targets));
-
                     if (_data.Targets == null)
                     {
                         return ReadOnlyEmptyDictionary<string, ProjectTargetInstance>.Instance;
@@ -2439,8 +2411,6 @@ namespace Microsoft.Build.Evaluation
             {
                 get
                 {
-                    VerifyThrowEvaluationStageReached(ProjectEvaluationStage.Items, nameof(AllEvaluatedItems));
-
                     ICollection<ProjectItem> allEvaluatedItems = _data.AllEvaluatedItems;
 
                     if (allEvaluatedItems == null)
@@ -3183,7 +3153,6 @@ namespace Microsoft.Build.Evaluation
             /// </comments>
             public override ICollection<ProjectItem> GetItems(string itemType)
             {
-                VerifyThrowEvaluationStageReached(ProjectEvaluationStage.Items, nameof(GetItems));
                 ICollection<ProjectItem> items = _data.GetItems(itemType);
                 return items;
             }
@@ -3198,7 +3167,6 @@ namespace Microsoft.Build.Evaluation
             /// </comments>
             public override ICollection<ProjectItem> GetItemsIgnoringCondition(string itemType)
             {
-                VerifyThrowEvaluationStageReached(ProjectEvaluationStage.Items, nameof(GetItemsIgnoringCondition));
                 ICollection<ProjectItem> items = _data.ItemsIgnoringCondition[itemType];
                 return items;
             }
@@ -3216,7 +3184,6 @@ namespace Microsoft.Build.Evaluation
             /// </comments>
             public override ICollection<ProjectItem> GetItemsByEvaluatedInclude(string evaluatedInclude)
             {
-                VerifyThrowEvaluationStageReached(ProjectEvaluationStage.Items, nameof(GetItemsByEvaluatedInclude));
                 ICollection<ProjectItem> items = _data.GetItemsByEvaluatedInclude(evaluatedInclude);
                 return items;
             }
@@ -3382,15 +3349,6 @@ namespace Microsoft.Build.Evaluation
             /// <param name="evaluationContext">The <see cref="EvaluationContext"/> to use. See <see cref="EvaluationContext"/>.</param>
             public override void ReevaluateIfNecessary(EvaluationContext evaluationContext)
             {
-                // A public re-evaluation request implies the caller wants a fully-evaluated project.
-                // A partial evaluation leaves the project non-dirty, so force a re-evaluation to
-                // compute the remaining passes and restore full behavior.
-                if (_evaluationStage != ProjectEvaluationStage.Full)
-                {
-                    _evaluationStage = ProjectEvaluationStage.Full;
-                    _explicitlyMarkedDirty = true;
-                }
-
                 ReevaluateIfNecessary(LoggingService, evaluationContext);
             }
 
@@ -3793,15 +3751,6 @@ namespace Microsoft.Build.Evaluation
                 ProjectInstanceSettings settings,
                 EvaluationContext evaluationContext)
             {
-                // Materializing a ProjectInstance implies a fully-evaluated project (it may be built,
-                // and it is labeled Full). If this project was only partially evaluated, upgrade it to
-                // a full evaluation first so the snapshot is complete rather than silently partial.
-                if (_evaluationStage != ProjectEvaluationStage.Full)
-                {
-                    _evaluationStage = ProjectEvaluationStage.Full;
-                    _explicitlyMarkedDirty = true;
-                }
-
                 ReevaluateIfNecessary(loggingServiceForEvaluation, evaluationContext);
 
                 return new ProjectInstance(_data, DirectoryPath, FullPath, ProjectCollection.HostServices, ProjectCollection.EnvironmentProperties, settings);
@@ -3831,8 +3780,7 @@ namespace Microsoft.Build.Evaluation
                     evaluationContext.SdkResolverService,
                     BuildEventContext.InvalidSubmissionId,
                     evaluationContext,
-                    _interactive,
-                    _evaluationStage);
+                    _interactive);
 
                 Assumed.NotEqual(LastEvaluationId, BuildEventContext.InvalidEvaluationId, "Evaluation should produce an evaluation ID");
 
@@ -3865,7 +3813,7 @@ namespace Microsoft.Build.Evaluation
             /// Global properties may be null.
             /// Tools version may be null.
             /// </summary>
-            internal void Initialize(IDictionary<string, string> globalProperties, string toolsVersion, string subToolsetVersion, ProjectLoadSettings loadSettings, EvaluationContext evaluationContext, bool interactive, ProjectEvaluationStage evaluationStage = ProjectEvaluationStage.Full)
+            internal void Initialize(IDictionary<string, string> globalProperties, string toolsVersion, string subToolsetVersion, ProjectLoadSettings loadSettings, EvaluationContext evaluationContext, bool interactive)
             {
                 Xml.MarkAsExplicitlyLoaded();
 
@@ -3901,13 +3849,9 @@ namespace Microsoft.Build.Evaluation
 
                 _loadSettings = loadSettings;
                 _interactive = interactive;
-                _evaluationStage = evaluationStage;
 
                 Assumed.Equal(LastEvaluationId, BuildEventContext.InvalidEvaluationId, "This is the first evaluation therefore the last evaluation id is invalid");
 
-                // Call the private overload directly so an initial partial evaluation is honored. The
-                // public ReevaluateIfNecessary(EvaluationContext) override intentionally upgrades a
-                // partial project to a full evaluation, which must not happen during initial construction.
                 ReevaluateIfNecessary(LoggingService, evaluationContext);
 
                 Assumed.NotEqual(LastEvaluationId, BuildEventContext.InvalidEvaluationId, "Last evaluation ID must be valid after the first evaluation");

--- a/src/Build/Definition/ProjectCollection.cs
+++ b/src/Build/Definition/ProjectCollection.cs
@@ -1323,16 +1323,6 @@ namespace Microsoft.Build.Evaluation
                 string effectiveToolsVersion = Utilities.GenerateToolsVersionToUse(toolsVersion, toolsVersionFromProject, GetToolset, DefaultToolsVersion, out _);
                 Project project = _loadedProjects.GetMatchingProjectIfAny(fileName, globalProperties, effectiveToolsVersion);
 
-                // A cached project only satisfies a (full) LoadProject if it was fully evaluated. If a matching
-                // project exists but was only partially evaluated, upgrade it in place (re-evaluate) so the same
-                // cache slot is reused rather than returning stale partial state or creating a duplicate entry.
-                // This mutation runs under the per-path load lock taken above, so concurrent loads of the same
-                // path cannot upgrade (and thus re-evaluate) the same project instance simultaneously.
-                if (project is not null && project.EvaluationStage < ProjectEvaluationStage.Full)
-                {
-                    project.ReevaluateIfNecessary();
-                }
-
                 // The Project constructor adds itself to our collection, it is not done by us
                 project ??= new Project(fileName, globalProperties, effectiveToolsVersion, this);
 

--- a/src/Build/Definition/ProjectOptions.cs
+++ b/src/Build/Definition/ProjectOptions.cs
@@ -59,6 +59,10 @@ namespace Microsoft.Build.Definition
         /// <summary>
         /// The <see cref="ProjectEvaluationStage"/> controlling how far evaluation should proceed.
         /// Defaults to <see cref="ProjectEvaluationStage.Full"/> (a complete evaluation).
+        /// A non-<see cref="ProjectEvaluationStage.Full"/> (partial) stage is only honored when creating a
+        /// <see cref="Microsoft.Build.Execution.ProjectInstance"/>; passing a partial stage to a <see cref="Project"/> factory
+        /// (for example <see cref="Project.FromFile(string, ProjectOptions)"/>) throws
+        /// <see cref="System.ArgumentException"/>.
         /// </summary>
         public ProjectEvaluationStage EvaluationStage
         {

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -1595,6 +1595,10 @@ Utilization:          {0} Average Utilization: {1:###.0}</value>
     <value>The project instance cannot be built because it was only partially evaluated (evaluation stopped after the "{0}" stage). A full evaluation is required to build a project.</value>
     <comment>UE: This message is shown when the user tries to build a ProjectInstance produced by a partial evaluation. {0} is the ProjectEvaluationStage the instance was evaluated to.</comment>
   </data>
+  <data name="OM_PartialEvaluationNotSupportedForProject" xml:space="preserve">
+    <value>Partial evaluation (the "{0}" evaluation stage) is not supported when creating a Project. Use ProjectInstance to perform a partial evaluation, or use the Full evaluation stage to create a Project.</value>
+    <comment>UE: This message is shown when a partial (non-Full) ProjectEvaluationStage is passed to a Project factory method such as Project.FromFile. {0} is the requested ProjectEvaluationStage.</comment>
+  </data>
   <data name="OM_CannotCreateReservedProperty" xml:space="preserve">
     <value>The "{0}" property name is reserved.</value>
     <comment>UE: This message is shown when the user tries to redefine one of the reserved MSBuild properties e.g. $(MSBuildProjectFile) through the object model</comment>

--- a/src/Build/Resources/xlf/Strings.cs.xlf
+++ b/src/Build/Resources/xlf/Strings.cs.xlf
@@ -729,6 +729,11 @@
         <target state="new">The "{0}" member is not available because the project was only partially evaluated (evaluation stopped after the "{1}" stage). Re-evaluate the project with at least the "{2}" evaluation stage to access this member.</target>
         <note>UE: This message is shown when the user reads a member (for example items or targets) that a partial evaluation did not compute. {0} is the member name, {1} is the ProjectEvaluationStage the project was evaluated to, {2} is the minimum ProjectEvaluationStage required to access the member.</note>
       </trans-unit>
+      <trans-unit id="OM_PartialEvaluationNotSupportedForProject">
+        <source>Partial evaluation (the "{0}" evaluation stage) is not supported when creating a Project. Use ProjectInstance to perform a partial evaluation, or use the Full evaluation stage to create a Project.</source>
+        <target state="new">Partial evaluation (the "{0}" evaluation stage) is not supported when creating a Project. Use ProjectInstance to perform a partial evaluation, or use the Full evaluation stage to create a Project.</target>
+        <note>UE: This message is shown when a partial (non-Full) ProjectEvaluationStage is passed to a Project factory method such as Project.FromFile. {0} is the requested ProjectEvaluationStage.</note>
+      </trans-unit>
       <trans-unit id="OM_TargetNameNullOrEmpty">
         <source>Method {0} cannot be called with a collection containing null or empty target names.</source>
         <target state="translated">Metoda {0} se nedá zavolat s kolekcí, která obsahuje prázdné cílové názvy nebo názvy null.</target>

--- a/src/Build/Resources/xlf/Strings.de.xlf
+++ b/src/Build/Resources/xlf/Strings.de.xlf
@@ -729,6 +729,11 @@
         <target state="new">The "{0}" member is not available because the project was only partially evaluated (evaluation stopped after the "{1}" stage). Re-evaluate the project with at least the "{2}" evaluation stage to access this member.</target>
         <note>UE: This message is shown when the user reads a member (for example items or targets) that a partial evaluation did not compute. {0} is the member name, {1} is the ProjectEvaluationStage the project was evaluated to, {2} is the minimum ProjectEvaluationStage required to access the member.</note>
       </trans-unit>
+      <trans-unit id="OM_PartialEvaluationNotSupportedForProject">
+        <source>Partial evaluation (the "{0}" evaluation stage) is not supported when creating a Project. Use ProjectInstance to perform a partial evaluation, or use the Full evaluation stage to create a Project.</source>
+        <target state="new">Partial evaluation (the "{0}" evaluation stage) is not supported when creating a Project. Use ProjectInstance to perform a partial evaluation, or use the Full evaluation stage to create a Project.</target>
+        <note>UE: This message is shown when a partial (non-Full) ProjectEvaluationStage is passed to a Project factory method such as Project.FromFile. {0} is the requested ProjectEvaluationStage.</note>
+      </trans-unit>
       <trans-unit id="OM_TargetNameNullOrEmpty">
         <source>Method {0} cannot be called with a collection containing null or empty target names.</source>
         <target state="translated">Die Methode "{0}" kann nicht mit einer Sammlung aufgerufen werden, die NULL oder leere Zielnamen enthält.</target>

--- a/src/Build/Resources/xlf/Strings.es.xlf
+++ b/src/Build/Resources/xlf/Strings.es.xlf
@@ -729,6 +729,11 @@
         <target state="new">The "{0}" member is not available because the project was only partially evaluated (evaluation stopped after the "{1}" stage). Re-evaluate the project with at least the "{2}" evaluation stage to access this member.</target>
         <note>UE: This message is shown when the user reads a member (for example items or targets) that a partial evaluation did not compute. {0} is the member name, {1} is the ProjectEvaluationStage the project was evaluated to, {2} is the minimum ProjectEvaluationStage required to access the member.</note>
       </trans-unit>
+      <trans-unit id="OM_PartialEvaluationNotSupportedForProject">
+        <source>Partial evaluation (the "{0}" evaluation stage) is not supported when creating a Project. Use ProjectInstance to perform a partial evaluation, or use the Full evaluation stage to create a Project.</source>
+        <target state="new">Partial evaluation (the "{0}" evaluation stage) is not supported when creating a Project. Use ProjectInstance to perform a partial evaluation, or use the Full evaluation stage to create a Project.</target>
+        <note>UE: This message is shown when a partial (non-Full) ProjectEvaluationStage is passed to a Project factory method such as Project.FromFile. {0} is the requested ProjectEvaluationStage.</note>
+      </trans-unit>
       <trans-unit id="OM_TargetNameNullOrEmpty">
         <source>Method {0} cannot be called with a collection containing null or empty target names.</source>
         <target state="translated">No se puede llamar al método {0} con una colección que contiene nombres de destino nulos o vacíos.</target>

--- a/src/Build/Resources/xlf/Strings.fr.xlf
+++ b/src/Build/Resources/xlf/Strings.fr.xlf
@@ -729,6 +729,11 @@
         <target state="new">The "{0}" member is not available because the project was only partially evaluated (evaluation stopped after the "{1}" stage). Re-evaluate the project with at least the "{2}" evaluation stage to access this member.</target>
         <note>UE: This message is shown when the user reads a member (for example items or targets) that a partial evaluation did not compute. {0} is the member name, {1} is the ProjectEvaluationStage the project was evaluated to, {2} is the minimum ProjectEvaluationStage required to access the member.</note>
       </trans-unit>
+      <trans-unit id="OM_PartialEvaluationNotSupportedForProject">
+        <source>Partial evaluation (the "{0}" evaluation stage) is not supported when creating a Project. Use ProjectInstance to perform a partial evaluation, or use the Full evaluation stage to create a Project.</source>
+        <target state="new">Partial evaluation (the "{0}" evaluation stage) is not supported when creating a Project. Use ProjectInstance to perform a partial evaluation, or use the Full evaluation stage to create a Project.</target>
+        <note>UE: This message is shown when a partial (non-Full) ProjectEvaluationStage is passed to a Project factory method such as Project.FromFile. {0} is the requested ProjectEvaluationStage.</note>
+      </trans-unit>
       <trans-unit id="OM_TargetNameNullOrEmpty">
         <source>Method {0} cannot be called with a collection containing null or empty target names.</source>
         <target state="translated">Impossible d'appeler la méthode {0} avec une collection contenant des noms de cibles qui ont une valeur null ou qui sont vides.</target>

--- a/src/Build/Resources/xlf/Strings.it.xlf
+++ b/src/Build/Resources/xlf/Strings.it.xlf
@@ -729,6 +729,11 @@
         <target state="new">The "{0}" member is not available because the project was only partially evaluated (evaluation stopped after the "{1}" stage). Re-evaluate the project with at least the "{2}" evaluation stage to access this member.</target>
         <note>UE: This message is shown when the user reads a member (for example items or targets) that a partial evaluation did not compute. {0} is the member name, {1} is the ProjectEvaluationStage the project was evaluated to, {2} is the minimum ProjectEvaluationStage required to access the member.</note>
       </trans-unit>
+      <trans-unit id="OM_PartialEvaluationNotSupportedForProject">
+        <source>Partial evaluation (the "{0}" evaluation stage) is not supported when creating a Project. Use ProjectInstance to perform a partial evaluation, or use the Full evaluation stage to create a Project.</source>
+        <target state="new">Partial evaluation (the "{0}" evaluation stage) is not supported when creating a Project. Use ProjectInstance to perform a partial evaluation, or use the Full evaluation stage to create a Project.</target>
+        <note>UE: This message is shown when a partial (non-Full) ProjectEvaluationStage is passed to a Project factory method such as Project.FromFile. {0} is the requested ProjectEvaluationStage.</note>
+      </trans-unit>
       <trans-unit id="OM_TargetNameNullOrEmpty">
         <source>Method {0} cannot be called with a collection containing null or empty target names.</source>
         <target state="translated">Non è possibile chiamare il metodo {0} con una raccolta contenente nomi di destinazione Null o vuoti.</target>

--- a/src/Build/Resources/xlf/Strings.ja.xlf
+++ b/src/Build/Resources/xlf/Strings.ja.xlf
@@ -729,6 +729,11 @@
         <target state="new">The "{0}" member is not available because the project was only partially evaluated (evaluation stopped after the "{1}" stage). Re-evaluate the project with at least the "{2}" evaluation stage to access this member.</target>
         <note>UE: This message is shown when the user reads a member (for example items or targets) that a partial evaluation did not compute. {0} is the member name, {1} is the ProjectEvaluationStage the project was evaluated to, {2} is the minimum ProjectEvaluationStage required to access the member.</note>
       </trans-unit>
+      <trans-unit id="OM_PartialEvaluationNotSupportedForProject">
+        <source>Partial evaluation (the "{0}" evaluation stage) is not supported when creating a Project. Use ProjectInstance to perform a partial evaluation, or use the Full evaluation stage to create a Project.</source>
+        <target state="new">Partial evaluation (the "{0}" evaluation stage) is not supported when creating a Project. Use ProjectInstance to perform a partial evaluation, or use the Full evaluation stage to create a Project.</target>
+        <note>UE: This message is shown when a partial (non-Full) ProjectEvaluationStage is passed to a Project factory method such as Project.FromFile. {0} is the requested ProjectEvaluationStage.</note>
+      </trans-unit>
       <trans-unit id="OM_TargetNameNullOrEmpty">
         <source>Method {0} cannot be called with a collection containing null or empty target names.</source>
         <target state="translated">Null または空のターゲット名を含むコレクションを指定してメソッド {0} を呼び出すことはできません。</target>

--- a/src/Build/Resources/xlf/Strings.ko.xlf
+++ b/src/Build/Resources/xlf/Strings.ko.xlf
@@ -729,6 +729,11 @@
         <target state="new">The "{0}" member is not available because the project was only partially evaluated (evaluation stopped after the "{1}" stage). Re-evaluate the project with at least the "{2}" evaluation stage to access this member.</target>
         <note>UE: This message is shown when the user reads a member (for example items or targets) that a partial evaluation did not compute. {0} is the member name, {1} is the ProjectEvaluationStage the project was evaluated to, {2} is the minimum ProjectEvaluationStage required to access the member.</note>
       </trans-unit>
+      <trans-unit id="OM_PartialEvaluationNotSupportedForProject">
+        <source>Partial evaluation (the "{0}" evaluation stage) is not supported when creating a Project. Use ProjectInstance to perform a partial evaluation, or use the Full evaluation stage to create a Project.</source>
+        <target state="new">Partial evaluation (the "{0}" evaluation stage) is not supported when creating a Project. Use ProjectInstance to perform a partial evaluation, or use the Full evaluation stage to create a Project.</target>
+        <note>UE: This message is shown when a partial (non-Full) ProjectEvaluationStage is passed to a Project factory method such as Project.FromFile. {0} is the requested ProjectEvaluationStage.</note>
+      </trans-unit>
       <trans-unit id="OM_TargetNameNullOrEmpty">
         <source>Method {0} cannot be called with a collection containing null or empty target names.</source>
         <target state="translated">null 또는 빈 대상 이름을 포함하는 컬렉션을 사용하여 {0} 메서드를 호출할 수 없습니다.</target>

--- a/src/Build/Resources/xlf/Strings.pl.xlf
+++ b/src/Build/Resources/xlf/Strings.pl.xlf
@@ -729,6 +729,11 @@
         <target state="new">The "{0}" member is not available because the project was only partially evaluated (evaluation stopped after the "{1}" stage). Re-evaluate the project with at least the "{2}" evaluation stage to access this member.</target>
         <note>UE: This message is shown when the user reads a member (for example items or targets) that a partial evaluation did not compute. {0} is the member name, {1} is the ProjectEvaluationStage the project was evaluated to, {2} is the minimum ProjectEvaluationStage required to access the member.</note>
       </trans-unit>
+      <trans-unit id="OM_PartialEvaluationNotSupportedForProject">
+        <source>Partial evaluation (the "{0}" evaluation stage) is not supported when creating a Project. Use ProjectInstance to perform a partial evaluation, or use the Full evaluation stage to create a Project.</source>
+        <target state="new">Partial evaluation (the "{0}" evaluation stage) is not supported when creating a Project. Use ProjectInstance to perform a partial evaluation, or use the Full evaluation stage to create a Project.</target>
+        <note>UE: This message is shown when a partial (non-Full) ProjectEvaluationStage is passed to a Project factory method such as Project.FromFile. {0} is the requested ProjectEvaluationStage.</note>
+      </trans-unit>
       <trans-unit id="OM_TargetNameNullOrEmpty">
         <source>Method {0} cannot be called with a collection containing null or empty target names.</source>
         <target state="translated">Metody {0} nie można wywołać przy użyciu kolekcji zawierającej nazwy docelowe o wartości null lub puste.</target>

--- a/src/Build/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Build/Resources/xlf/Strings.pt-BR.xlf
@@ -729,6 +729,11 @@
         <target state="new">The "{0}" member is not available because the project was only partially evaluated (evaluation stopped after the "{1}" stage). Re-evaluate the project with at least the "{2}" evaluation stage to access this member.</target>
         <note>UE: This message is shown when the user reads a member (for example items or targets) that a partial evaluation did not compute. {0} is the member name, {1} is the ProjectEvaluationStage the project was evaluated to, {2} is the minimum ProjectEvaluationStage required to access the member.</note>
       </trans-unit>
+      <trans-unit id="OM_PartialEvaluationNotSupportedForProject">
+        <source>Partial evaluation (the "{0}" evaluation stage) is not supported when creating a Project. Use ProjectInstance to perform a partial evaluation, or use the Full evaluation stage to create a Project.</source>
+        <target state="new">Partial evaluation (the "{0}" evaluation stage) is not supported when creating a Project. Use ProjectInstance to perform a partial evaluation, or use the Full evaluation stage to create a Project.</target>
+        <note>UE: This message is shown when a partial (non-Full) ProjectEvaluationStage is passed to a Project factory method such as Project.FromFile. {0} is the requested ProjectEvaluationStage.</note>
+      </trans-unit>
       <trans-unit id="OM_TargetNameNullOrEmpty">
         <source>Method {0} cannot be called with a collection containing null or empty target names.</source>
         <target state="translated">O método {0} não pode ser chamado com uma coleção que contém nomes de destino nulos ou vazios.</target>

--- a/src/Build/Resources/xlf/Strings.ru.xlf
+++ b/src/Build/Resources/xlf/Strings.ru.xlf
@@ -729,6 +729,11 @@
         <target state="new">The "{0}" member is not available because the project was only partially evaluated (evaluation stopped after the "{1}" stage). Re-evaluate the project with at least the "{2}" evaluation stage to access this member.</target>
         <note>UE: This message is shown when the user reads a member (for example items or targets) that a partial evaluation did not compute. {0} is the member name, {1} is the ProjectEvaluationStage the project was evaluated to, {2} is the minimum ProjectEvaluationStage required to access the member.</note>
       </trans-unit>
+      <trans-unit id="OM_PartialEvaluationNotSupportedForProject">
+        <source>Partial evaluation (the "{0}" evaluation stage) is not supported when creating a Project. Use ProjectInstance to perform a partial evaluation, or use the Full evaluation stage to create a Project.</source>
+        <target state="new">Partial evaluation (the "{0}" evaluation stage) is not supported when creating a Project. Use ProjectInstance to perform a partial evaluation, or use the Full evaluation stage to create a Project.</target>
+        <note>UE: This message is shown when a partial (non-Full) ProjectEvaluationStage is passed to a Project factory method such as Project.FromFile. {0} is the requested ProjectEvaluationStage.</note>
+      </trans-unit>
       <trans-unit id="OM_TargetNameNullOrEmpty">
         <source>Method {0} cannot be called with a collection containing null or empty target names.</source>
         <target state="translated">Метод {0} не может быть вызван с коллекцией, содержащей целевые имена, которые пусты или равны NULL.</target>

--- a/src/Build/Resources/xlf/Strings.tr.xlf
+++ b/src/Build/Resources/xlf/Strings.tr.xlf
@@ -729,6 +729,11 @@
         <target state="new">The "{0}" member is not available because the project was only partially evaluated (evaluation stopped after the "{1}" stage). Re-evaluate the project with at least the "{2}" evaluation stage to access this member.</target>
         <note>UE: This message is shown when the user reads a member (for example items or targets) that a partial evaluation did not compute. {0} is the member name, {1} is the ProjectEvaluationStage the project was evaluated to, {2} is the minimum ProjectEvaluationStage required to access the member.</note>
       </trans-unit>
+      <trans-unit id="OM_PartialEvaluationNotSupportedForProject">
+        <source>Partial evaluation (the "{0}" evaluation stage) is not supported when creating a Project. Use ProjectInstance to perform a partial evaluation, or use the Full evaluation stage to create a Project.</source>
+        <target state="new">Partial evaluation (the "{0}" evaluation stage) is not supported when creating a Project. Use ProjectInstance to perform a partial evaluation, or use the Full evaluation stage to create a Project.</target>
+        <note>UE: This message is shown when a partial (non-Full) ProjectEvaluationStage is passed to a Project factory method such as Project.FromFile. {0} is the requested ProjectEvaluationStage.</note>
+      </trans-unit>
       <trans-unit id="OM_TargetNameNullOrEmpty">
         <source>Method {0} cannot be called with a collection containing null or empty target names.</source>
         <target state="translated">{0} metosu null veya boş hedef adları içeren bir koleksiyonla çağrılamaz.</target>

--- a/src/Build/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hans.xlf
@@ -729,6 +729,11 @@
         <target state="new">The "{0}" member is not available because the project was only partially evaluated (evaluation stopped after the "{1}" stage). Re-evaluate the project with at least the "{2}" evaluation stage to access this member.</target>
         <note>UE: This message is shown when the user reads a member (for example items or targets) that a partial evaluation did not compute. {0} is the member name, {1} is the ProjectEvaluationStage the project was evaluated to, {2} is the minimum ProjectEvaluationStage required to access the member.</note>
       </trans-unit>
+      <trans-unit id="OM_PartialEvaluationNotSupportedForProject">
+        <source>Partial evaluation (the "{0}" evaluation stage) is not supported when creating a Project. Use ProjectInstance to perform a partial evaluation, or use the Full evaluation stage to create a Project.</source>
+        <target state="new">Partial evaluation (the "{0}" evaluation stage) is not supported when creating a Project. Use ProjectInstance to perform a partial evaluation, or use the Full evaluation stage to create a Project.</target>
+        <note>UE: This message is shown when a partial (non-Full) ProjectEvaluationStage is passed to a Project factory method such as Project.FromFile. {0} is the requested ProjectEvaluationStage.</note>
+      </trans-unit>
       <trans-unit id="OM_TargetNameNullOrEmpty">
         <source>Method {0} cannot be called with a collection containing null or empty target names.</source>
         <target state="translated">无法使用包含 null 或空目标名称的集合调用方法 {0}。</target>

--- a/src/Build/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hant.xlf
@@ -729,6 +729,11 @@
         <target state="new">The "{0}" member is not available because the project was only partially evaluated (evaluation stopped after the "{1}" stage). Re-evaluate the project with at least the "{2}" evaluation stage to access this member.</target>
         <note>UE: This message is shown when the user reads a member (for example items or targets) that a partial evaluation did not compute. {0} is the member name, {1} is the ProjectEvaluationStage the project was evaluated to, {2} is the minimum ProjectEvaluationStage required to access the member.</note>
       </trans-unit>
+      <trans-unit id="OM_PartialEvaluationNotSupportedForProject">
+        <source>Partial evaluation (the "{0}" evaluation stage) is not supported when creating a Project. Use ProjectInstance to perform a partial evaluation, or use the Full evaluation stage to create a Project.</source>
+        <target state="new">Partial evaluation (the "{0}" evaluation stage) is not supported when creating a Project. Use ProjectInstance to perform a partial evaluation, or use the Full evaluation stage to create a Project.</target>
+        <note>UE: This message is shown when a partial (non-Full) ProjectEvaluationStage is passed to a Project factory method such as Project.FromFile. {0} is the requested ProjectEvaluationStage.</note>
+      </trans-unit>
       <trans-unit id="OM_TargetNameNullOrEmpty">
         <source>Method {0} cannot be called with a collection containing null or empty target names.</source>
         <target state="translated">無法使用內含 null 或空白目標名稱的集合呼叫方法 {0}。</target>

--- a/src/MSBuild.Benchmarks/PartialEvaluationBenchmark.cs
+++ b/src/MSBuild.Benchmarks/PartialEvaluationBenchmark.cs
@@ -5,6 +5,7 @@ using System.Text;
 using BenchmarkDotNet.Attributes;
 using Microsoft.Build.Definition;
 using Microsoft.Build.Evaluation;
+using Microsoft.Build.Execution;
 
 namespace MSBuild.Benchmarks;
 
@@ -16,7 +17,7 @@ namespace MSBuild.Benchmarks;
 /// </summary>
 /// <remarks>
 /// Each invocation mirrors the CLI path in <c>XMake.cs</c>: a fresh <see cref="ProjectCollection"/>
-/// is created, the project is loaded via <see cref="Project.FromFile(string, ProjectOptions)"/>, and
+/// is created, the project is loaded via <see cref="ProjectInstance.FromFile(string, ProjectOptions)"/>, and
 /// a single property value is read. The project XML is written to disk once in
 /// <see cref="GlobalSetup"/> and re-parsed on every invocation (as the CLI does), so the reported
 /// delta reflects the evaluation passes that partial evaluation skips, not parsing.
@@ -106,7 +107,7 @@ public class PartialEvaluationBenchmark
         // A fresh collection per invocation mirrors the CLI and avoids cross-iteration caching so the
         // project XML is re-parsed and re-evaluated every time, exactly as `msbuild -getProperty` does.
         using ProjectCollection collection = new();
-        Project project = Project.FromFile(_projectPath, new ProjectOptions
+        ProjectInstance project = ProjectInstance.FromFile(_projectPath, new ProjectOptions
         {
             ProjectCollection = collection,
             EvaluationStage = stage,
@@ -118,7 +119,7 @@ public class PartialEvaluationBenchmark
     private string EvaluateAndReadItems(ProjectEvaluationStage stage)
     {
         using ProjectCollection collection = new();
-        Project project = Project.FromFile(_projectPath, new ProjectOptions
+        ProjectInstance project = ProjectInstance.FromFile(_projectPath, new ProjectOptions
         {
             ProjectCollection = collection,
             EvaluationStage = stage,

--- a/src/MSBuild/JsonOutputFormatter.cs
+++ b/src/MSBuild/JsonOutputFormatter.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Text.Json;
 using System.Text.Json.Nodes;
-using Microsoft.Build.Evaluation;
 using Microsoft.Build.Execution;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
@@ -61,47 +60,6 @@ namespace Microsoft.Build.CommandLine
                     JsonObject jsonItem = new();
                     jsonItem["Identity"] = item.GetMetadataValue("Identity");
                     foreach (string metadatumName in item.MetadataNames)
-                    {
-                        if (metadatumName.Equals("Identity"))
-                        {
-                            continue;
-                        }
-
-                        jsonItem[metadatumName] = TryGetMetadataValue(item, metadatumName);
-                    }
-
-                    itemArray.Add(jsonItem);
-                }
-
-                itemsNode[itemName] = itemArray;
-            }
-
-            _topLevelNode["Items"] = itemsNode;
-        }
-
-        internal void AddItemsInJsonFormat(string[] itemNames, Project project)
-        {
-            if (itemNames.Length == 0)
-            {
-                return;
-            }
-
-            Assumed.Null(_topLevelNode["Items"], "Should not add multiple lists of items to the json format.");
-
-            JsonObject itemsNode = new();
-            foreach (string itemName in itemNames)
-            {
-                JsonArray itemArray = new();
-                foreach (ProjectItem item in project.GetItems(itemName))
-                {
-                    JsonObject jsonItem = new();
-                    jsonItem["Identity"] = item.GetMetadataValue("Identity");
-                    foreach (ProjectMetadata metadatum in item.Metadata)
-                    {
-                        jsonItem[metadatum.Name] = metadatum.EvaluatedValue;
-                    }
-
-                    foreach (string metadatumName in ItemSpecModifiers.All)
                     {
                         if (metadatumName.Equals("Identity"))
                         {
@@ -185,25 +143,6 @@ namespace Microsoft.Build.CommandLine
         /// this will catch the InvalidOperationException and return an empty string.
         /// </summary>
         private static string TryGetMetadataValue(ProjectItemInstance item, string metadataName)
-        {
-            try
-            {
-                return item.GetMetadataValue(metadataName);
-            }
-            catch (InvalidOperationException)
-            {
-                // Built-in metadata like FullPath, Directory, etc. require path computation.
-                // If the item spec contains illegal path characters, return empty string.
-                return string.Empty;
-            }
-        }
-
-        /// <summary>
-        /// Attempts to get metadata value from a ProjectItem. If the metadata is a built-in metadata
-        /// (like FullPath, Directory, etc.) and the item spec contains illegal path characters,
-        /// this will catch the InvalidOperationException and return an empty string.
-        /// </summary>
-        private static string TryGetMetadataValue(ProjectItem item, string metadataName)
         {
             try
             {

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -1006,12 +1006,15 @@ namespace Microsoft.Build.CommandLine
                                 // Properties pass; items require the Items pass. This skips the later passes
                                 // (using-tasks and target registration) entirely. Gated behind change wave 18.10
                                 // so the historical full-evaluation behavior can be restored if needed.
+                                // A ProjectInstance (an uncached evaluation snapshot) is used rather than a Project
+                                // because this is a read-only "evaluate, read, discard" scenario and partial
+                                // evaluation is only supported on ProjectInstance.
                                 ProjectEvaluationStage evaluationStage =
                                     ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave18_10)
                                         ? (getItem.Length == 0 ? ProjectEvaluationStage.Properties : ProjectEvaluationStage.Items)
                                         : ProjectEvaluationStage.Full;
 
-                                Project project = Project.FromFile(projectFile, new ProjectOptions
+                                ProjectInstance project = ProjectInstance.FromFile(projectFile, new ProjectOptions
                                 {
                                     ProjectCollection = collection,
                                     GlobalProperties = globalProperties,
@@ -1033,8 +1036,17 @@ namespace Microsoft.Build.CommandLine
                                 collection.LogBuildFinishedEvent(exitType == ExitType.Success);
                             }
                         }
-                        catch (InvalidProjectFileException)
+                        catch (InvalidProjectFileException ex)
                         {
+                            // ProjectInstance evaluation logs semantic evaluation errors through the collection's
+                            // loggers, but a pre-evaluation failure (for example malformed project XML) throws
+                            // before any logging occurs. Surface the latter in canonical format so the CLI still
+                            // reports the project load error (for example MSB4025) rather than failing silently.
+                            if (!ex.HasBeenLogged)
+                            {
+                                Console.WriteLine($"MSBUILD : error {ex.ErrorCode}: {ex.BaseMessage}");
+                            }
+
                             exitType = ExitType.BuildError;
                         }
                     }
@@ -1315,7 +1327,7 @@ namespace Microsoft.Build.CommandLine
                 isStandaloneExecution: !s_isNodeMode);
         }
 
-        private static ExitType OutputPropertiesAfterEvaluation(string[] getProperty, string[] getItem, Project project, TextWriter outputStream)
+        private static ExitType OutputPropertiesAfterEvaluation(string[] getProperty, string[] getItem, ProjectInstance project, TextWriter outputStream)
         {
             // Special case if the user requests exactly one property: skip json formatting
             if (getProperty.Length == 1 && getItem.Length == 0)
@@ -1326,7 +1338,7 @@ namespace Microsoft.Build.CommandLine
             {
                 JsonOutputFormatter jsonOutputFormatter = new();
                 jsonOutputFormatter.AddPropertiesInJsonFormat(getProperty, property => project.GetPropertyValue(property));
-                jsonOutputFormatter.AddItemsInJsonFormat(getItem, project);
+                jsonOutputFormatter.AddItemInstancesInJsonFormat(getItem, project);
                 outputStream.WriteLine(jsonOutputFormatter.ToString());
             }
 

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -1044,7 +1044,7 @@ namespace Microsoft.Build.CommandLine
                             // reports the project load error (for example MSB4025) rather than failing silently.
                             if (!ex.HasBeenLogged)
                             {
-                                Console.WriteLine($"MSBUILD : error {ex.ErrorCode}: {ex.BaseMessage}");
+                                Console.WriteLine($"MSBUILD : error {ex.ErrorCode}: {ex.Message}");
                             }
 
                             exitType = ExitType.BuildError;


### PR DESCRIPTION
### Summary

Partial (stop-after-pass) evaluation was exposed on **both** `Project` and `ProjectInstance`. This PR restricts it to `ProjectInstance` only.

`Project` is mutable and cached by `ProjectCollection`, which makes a partially-evaluated `Project` a footgun:

- A cached partial `Project` can be handed back to a caller expecting a full evaluation, serving **stale partial state**, or
- It gets **silently upgraded to a full evaluation** (re-evaluated in place) when something touches later-pass state — discarding the performance win the caller asked for, as hidden work.

`ProjectInstance` is an uncached, read-only evaluation snapshot with none of these traps, so partial evaluation now lives there exclusively.

### Changes

- **`Project`**: removed all partial-eval honoring — the public `EvaluationStage` property, the `ProjectImpl` stage field + member guards, the partial→Full upgrade blocks in `ReevaluateIfNecessary`/`CreateProjectInstance`, and the `evaluationStage` constructor parameters. `Project.FromFile`/`FromProjectRootElement`/`FromXmlReader` now throw `ArgumentException` when a non-`Full` stage is requested via `ProjectOptions` (new `OM_PartialEvaluationNotSupportedForProject` resource + xlf entries).
- **`ProjectCollection.LoadProject`**: dropped the now-dead partial cache upgrade-in-place logic.
- **`XMake` (`-getProperty`/`-getItem`, no-target path)**: switched from `Project.FromFile` to `ProjectInstance.FromFile`. `ProjectInstance` does not log pre-evaluation project-load failures (malformed XML) the way `Project` did, so the catch block now surfaces `MSB4025` in canonical format (guarded by `HasBeenLogged` to avoid double-logging genuine evaluation errors).
- **`JsonOutputFormatter`**: removed orphaned `Project`-based item formatter overloads.
- **Benchmark**: `PartialEvaluationBenchmark` now uses `ProjectInstance`.
- **Docs/tests**: updated the partial-evaluation spec and reworked the unit tests.

`ProjectInstance` retains full partial-evaluation support (`EvaluationStage`, member guards, `OM_PartialEvaluationMemberUnavailable`/`OM_PartialEvaluationCannotBuild`).

### Testing

- `PartialEvaluation_Tests` (Engine.UnitTests): 13/13 pass.
- `-getProperty`/`-getItem` CLI tests + full `XMakeAppTests` (CommandLine.UnitTests): pass (incl. `GetPropertyWithInvalidProjectThrowsInvalidProjectFileExceptionNotInternalError`, which verifies `MSB4025` is still emitted).
- Full repo build clean.
