### PR TITLE
Allow netfx MSBuild to be loaded in .NET runtime

### DIFF
--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -3080,7 +3080,10 @@ namespace Microsoft.Build.Execution
                 _buildParameters,
                 loggingService.LoggerDescriptions.ToArray()
 #if FEATURE_APPDOMAIN
-                , AppDomain.CurrentDomain.SetupInformation
+                // On the .NET runtime the AppDomainSetup has no configuration bytes to propagate to
+                // task AppDomains (and its Get/SetConfigurationBytes do not exist, so translating a
+                // non-null setup would throw when this .NET Framework assembly is hosted on .NET).
+                , NodeProviderOutOfProcBase.IsHostedOnDotNetRuntime ? null : AppDomain.CurrentDomain.SetupInformation
 #endif
                 , new LoggingNodeConfiguration(
                     loggingService.IncludeEvaluationMetaprojects,

--- a/src/Build/BackEnd/Client/MSBuildClient.cs
+++ b/src/Build/BackEnd/Client/MSBuildClient.cs
@@ -185,6 +185,8 @@ namespace Microsoft.Build.Experimental
                 PipeOptions.Asynchronous
 #if FEATURE_PIPEOPTIONS_CURRENTUSERONLY
                 | PipeOptions.CurrentUserOnly
+#else
+                | (NodeProviderOutOfProcBase.IsHostedOnDotNetRuntime ? NodeProviderOutOfProcBase.PipeOptionsCurrentUserOnly : PipeOptions.None)
 #endif
             );
 #pragma warning restore SA1111, SA1009 // Closing parenthesis should be on line of last parameter

--- a/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
@@ -791,6 +791,17 @@ namespace Microsoft.Build.BackEnd
         }
 
 #if !FEATURE_PIPEOPTIONS_CURRENTUSERONLY
+        // When the .NET Framework flavor of MSBuild is hosted on the .NET runtime (e.g. an IDE that
+        // loads MSBuild.exe's assemblies in-proc via MSBuildLocator), PipeSecurity and
+        // PipeStream.GetAccessControl do not exist there, so ValidateRemotePipeSecurityOnWindows
+        // cannot run. That runtime does support PipeOptions.CurrentUserOnly — the mechanism the
+        // .NET flavor of MSBuild uses instead (see FEATURE_PIPEOPTIONS_CURRENTUSERONLY) — which
+        // makes Connect perform the equivalent remote-owner validation.
+        internal static readonly bool IsHostedOnDotNetRuntime = Environment.Version.Major >= 5;
+
+        // The enum value is absent from the .NET Framework reference assemblies, so it is spelled numerically.
+        internal const PipeOptions PipeOptionsCurrentUserOnly = (PipeOptions)0x20000000;
+
         // This code needs to be in a separate method so that we don't try (and fail) to load the Windows-only APIs when JIT-ing the code
         //  on non-Windows operating systems
         private static void ValidateRemotePipeSecurityOnWindows(NamedPipeClientStream nodeStream)
@@ -822,6 +833,8 @@ namespace Microsoft.Build.BackEnd
                 PipeOptions.Asynchronous
 #if FEATURE_PIPEOPTIONS_CURRENTUSERONLY
                 | PipeOptions.CurrentUserOnly
+#else
+                | (IsHostedOnDotNetRuntime ? PipeOptionsCurrentUserOnly : PipeOptions.None)
 #endif
             );
 #pragma warning restore SA1111, SA1009 // Closing parenthesis should be on line of last parameter
@@ -869,7 +882,9 @@ namespace Microsoft.Build.BackEnd
             nodeStream.Connect(timeout);
 
 #if !FEATURE_PIPEOPTIONS_CURRENTUSERONLY
-            if (NativeMethodsShared.IsWindows)
+            // On the .NET runtime the pipe is opened with PipeOptionsCurrentUserOnly, which made
+            // Connect perform this same remote-owner validation (and PipeSecurity APIs don't exist).
+            if (NativeMethodsShared.IsWindows && !IsHostedOnDotNetRuntime)
             {
                 // Verify that the owner of the pipe is us.  This prevents a security hole where a remote node has
                 // been faked up with ACLs that would let us attach to it.  It could then issue fake build requests back to

--- a/src/Build/BackEnd/Components/SdkResolution/SdkResolverLoader.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/SdkResolverLoader.cs
@@ -270,9 +270,20 @@ namespace Microsoft.Build.BackEnd.SdkResolution
                     }
                     else
                     {
-                        // VS and MSBuild.exe direct usage: use Assembly.Load directly without fallback
+                        // VS and MSBuild.exe direct usage: use Assembly.Load directly
                         // These scenarios should work reliably with Assembly.Load and benefit from NGEN
-                        return Assembly.Load(assemblyName);
+                        try
+                        {
+                            return Assembly.Load(assemblyName);
+                        }
+                        catch (FileNotFoundException)
+                        {
+                            // Assembly.Load honors the CodeBase hint only on .NET Framework (Fusion).
+                            // When this assembly is hosted on .NET (e.g. an IDE running MSBuild.exe's
+                            // assemblies on .NET via MSBuildLocator), the CodeBase is ignored and the
+                            // simple-name load fails — fall back to loading from the resolver path.
+                            return Assembly.LoadFrom(resolverPath);
+                        }
                     }
                 }
             }

--- a/src/Build/BackEnd/Node/NodeConfiguration.cs
+++ b/src/Build/BackEnd/Node/NodeConfiguration.cs
@@ -3,6 +3,7 @@
 
 #if FEATURE_APPDOMAIN
 using System;
+using System.Runtime.CompilerServices;
 #endif
 using System.Diagnostics;
 
@@ -164,21 +165,38 @@ namespace Microsoft.Build.BackEnd
             byte[] appDomainConfigBytes = null;
 
             // Set the configuration bytes just before serialization in case the SetConfigurationBytes was invoked during lifetime of this instance.
-            if (translator.Mode == TranslationDirection.WriteToStream)
+            // The null guard also keeps the JIT-isolated helper uninvoked when hosted on the .NET
+            // runtime, where the setup is always null (see BuildManager.GetNodeConfiguration).
+            if (translator.Mode == TranslationDirection.WriteToStream && _appDomainSetup != null)
             {
-                appDomainConfigBytes = _appDomainSetup?.GetConfigurationBytes();
+                appDomainConfigBytes = GetAppDomainConfigBytes(_appDomainSetup);
             }
 
             translator.Translate(ref appDomainConfigBytes);
 
             if (translator.Mode == TranslationDirection.ReadFromStream)
             {
-                _appDomainSetup = new AppDomainSetup();
-                _appDomainSetup.SetConfigurationBytes(appDomainConfigBytes);
+                _appDomainSetup = CreateAppDomainSetupFromConfigBytes(appDomainConfigBytes);
             }
 #endif
             translator.Translate(ref _loggingNodeConfiguration);
         }
+
+#if FEATURE_APPDOMAIN
+        // The AppDomainSetup configuration-bytes APIs do not exist when this .NET Framework assembly
+        // is hosted on the .NET runtime, and an unresolvable member fails the JIT of the entire
+        // referencing method — these never-inlined helpers keep those references out of Translate.
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static byte[] GetAppDomainConfigBytes(AppDomainSetup appDomainSetup) => appDomainSetup.GetConfigurationBytes();
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static AppDomainSetup CreateAppDomainSetupFromConfigBytes(byte[] appDomainConfigBytes)
+        {
+            AppDomainSetup appDomainSetup = new AppDomainSetup();
+            appDomainSetup.SetConfigurationBytes(appDomainConfigBytes);
+            return appDomainSetup;
+        }
+#endif
 
         /// <summary>
         /// Factory for deserialization.

--- a/src/Build/Utilities/NuGetFrameworkWrapper.Reflection.cs
+++ b/src/Build/Utilities/NuGetFrameworkWrapper.Reflection.cs
@@ -5,6 +5,7 @@ using System;
 using System.Globalization;
 using System.IO;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Text;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
@@ -158,6 +159,27 @@ namespace Microsoft.Build.Evaluation
             return appDomainSetup;
         }
 
+        /// <summary>
+        /// Creates the wrapper in a separate AppDomain. Kept in a separate never-inlined method:
+        /// the AppDomain.CreateDomain overload used here has System.Security.Policy.Evidence in its
+        /// signature, a type that does not exist when a .NET host loads this .NET Framework assembly.
+        /// An unresolvable signature fails the JIT of the entire calling method (bypassing its
+        /// try/catch), so the reference must stay out of <see cref="CreateInstance"/> for its
+        /// fallback path to be reachable on .NET.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static NuGetFrameworkWrapper CreateInstanceInAppDomain(AssemblyName assemblyName, string assemblyPath)
+        {
+            AppDomainSetup appDomainSetup = CreateAppDomainSetup(assemblyName, assemblyPath);
+            if (appDomainSetup == null)
+            {
+                return null;
+            }
+
+            AppDomain appDomain = AppDomain.CreateDomain(nameof(NuGetFrameworkWrapper), null, appDomainSetup);
+            return (NuGetFrameworkWrapper)appDomain.CreateInstanceAndUnwrap(Assembly.GetExecutingAssembly().FullName, typeof(NuGetFrameworkWrapper).FullName);
+        }
+
         public static NuGetFrameworkWrapper CreateInstance()
         {
             // Resolve the location of the NuGet.Frameworks assembly
@@ -181,12 +203,7 @@ namespace Microsoft.Build.Evaluation
                     assemblyName = AssemblyName.GetAssemblyName(assemblyPath);
                     if (assemblyName != null && BuildEnvironmentHelper.Instance.RunningInMSBuildExe)
                     {
-                        AppDomainSetup appDomainSetup = CreateAppDomainSetup(assemblyName, assemblyPath);
-                        if (appDomainSetup != null)
-                        {
-                            AppDomain appDomain = AppDomain.CreateDomain(nameof(NuGetFrameworkWrapper), null, appDomainSetup);
-                            instance = (NuGetFrameworkWrapper)appDomain.CreateInstanceAndUnwrap(Assembly.GetExecutingAssembly().FullName, typeof(NuGetFrameworkWrapper).FullName);
-                        }
+                        instance = CreateInstanceInAppDomain(assemblyName, assemblyPath);
                     }
                 }
                 catch

--- a/src/Shared/TaskHostConfiguration.cs
+++ b/src/Shared/TaskHostConfiguration.cs
@@ -5,6 +5,9 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
+#if FEATURE_APPDOMAIN
+using System.Runtime.CompilerServices;
+#endif
 using Microsoft.Build.Execution;
 
 #nullable disable
@@ -531,17 +534,18 @@ namespace Microsoft.Build.BackEnd
                 byte[] appDomainConfigBytes = null;
 
                 // Set the configuration bytes just before serialization in case the SetConfigurationBytes was invoked during lifetime of this instance.
-                if (translator.Mode == TranslationDirection.WriteToStream)
+                // The null guard also keeps the JIT-isolated helper uninvoked when hosted on the .NET
+                // runtime, where the AppDomainSetup configuration-bytes APIs do not exist.
+                if (translator.Mode == TranslationDirection.WriteToStream && _appDomainSetup != null)
                 {
-                    appDomainConfigBytes = _appDomainSetup?.GetConfigurationBytes();
+                    appDomainConfigBytes = GetAppDomainConfigBytes(_appDomainSetup);
                 }
 
                 translator.Translate(ref appDomainConfigBytes);
 
                 if (translator.Mode == TranslationDirection.ReadFromStream)
                 {
-                    _appDomainSetup = new AppDomainSetup();
-                    _appDomainSetup.SetConfigurationBytes(appDomainConfigBytes);
+                    _appDomainSetup = CreateAppDomainSetupFromConfigBytes(appDomainConfigBytes);
                 }
             }
 #endif
@@ -576,6 +580,22 @@ namespace Microsoft.Build.BackEnd
                                  objectTranslator: (ITranslator t, ref string s) => t.Translate(ref s),
                                  collectionFactory: count => new HashSet<string>(count, StringComparer.OrdinalIgnoreCase));
         }
+
+#if FEATURE_APPDOMAIN
+        // The AppDomainSetup configuration-bytes APIs do not exist when this .NET Framework assembly
+        // is hosted on the .NET runtime, and an unresolvable member fails the JIT of the entire
+        // referencing method — these never-inlined helpers keep those references out of Translate.
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static byte[] GetAppDomainConfigBytes(AppDomainSetup appDomainSetup) => appDomainSetup.GetConfigurationBytes();
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static AppDomainSetup CreateAppDomainSetupFromConfigBytes(byte[] appDomainConfigBytes)
+        {
+            AppDomainSetup appDomainSetup = new AppDomainSetup();
+            appDomainSetup.SetConfigurationBytes(appDomainConfigBytes);
+            return appDomainSetup;
+        }
+#endif
 
         /// <summary>
         /// Translates the build process environment.

--- a/src/Shared/TaskLoader.cs
+++ b/src/Shared/TaskLoader.cs
@@ -5,6 +5,7 @@ using System;
 using Microsoft.Build.Framework;
 #if FEATURE_APPDOMAIN
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using Microsoft.Build.Shared.Debugging;
 #endif
 
@@ -75,40 +76,7 @@ namespace Microsoft.Build.Shared
                     }
                     else
                     {
-                        // Our task depend on this name to be precisely that, so if you change it make sure
-                        // you also change the checks in the tasks run in separate AppDomains. Better yet, just don't change it.
-
-                        // Make sure we copy the appdomain configuration and send it to the appdomain we create so that if the creator of the current appdomain
-                        // has done the binding redirection in code, that we will get those settings as well.
-                        AppDomainSetup appDomainInfo = new AppDomainSetup();
-
-                        // Get the current app domain setup settings
-                        byte[] currentAppdomainBytes = appDomainSetup.GetConfigurationBytes();
-
-                        // Apply the appdomain settings to the new appdomain before creating it
-                        appDomainInfo.SetConfigurationBytes(currentAppdomainBytes);
-
-                        if (BuildEnvironmentHelper.Instance.RunningTests)
-                        {
-                            // Prevent the new app domain from looking in the VS test runner location. If this
-                            // is not done, we will not be able to find Microsoft.Build.* assemblies.
-                            appDomainInfo.ApplicationBase = BuildEnvironmentHelper.Instance.CurrentMSBuildToolsDirectory;
-                            appDomainInfo.ConfigurationFile = BuildEnvironmentHelper.Instance.CurrentMSBuildConfigurationFile;
-                        }
-
-                        AppDomain.CurrentDomain.AssemblyResolve += AssemblyResolver;
-                        s_resolverLoadedType = loadedType;
-
-                        taskAppDomain = AppDomain.CreateDomain(isOutOfProc ? "taskAppDomain (out-of-proc)" : "taskAppDomain (in-proc)", null, appDomainInfo);
-
-                        if (loadedType.LoadedAssembly != null)
-                        {
-                            taskAppDomain.Load(loadedType.LoadedAssemblyName);
-                        }
-
-                        // Hook up last minute dumping of any exceptions
-                        taskAppDomain.UnhandledException += DebugUtils.UnhandledExceptionHandler;
-                        appDomainCreated?.Invoke(taskAppDomain);
+                        taskAppDomain = CreateTaskAppDomain(loadedType, appDomainSetup, appDomainCreated, isOutOfProc);
                     }
                 }
                 else
@@ -165,6 +133,55 @@ namespace Microsoft.Build.Shared
         }
 
 #if FEATURE_APPDOMAIN
+        /// <summary>
+        /// Creates the AppDomain a [LoadInSeparateAppDomain] task will run in. Kept in a separate
+        /// never-inlined method: the AppDomain.CreateDomain overload used here has
+        /// System.Security.Policy.Evidence in its signature, a type that does not exist when a .NET
+        /// host loads this .NET Framework assembly, and an unresolvable signature fails the JIT of
+        /// the entire calling method. Isolating it here keeps <see cref="CreateTask"/> JITtable on
+        /// .NET so the (overwhelmingly common) same-AppDomain path still works there.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static AppDomain CreateTaskAppDomain(LoadedType loadedType, AppDomainSetup appDomainSetup, Action<AppDomain> appDomainCreated, bool isOutOfProc)
+        {
+            // Our task depend on this name to be precisely that, so if you change it make sure
+            // you also change the checks in the tasks run in separate AppDomains. Better yet, just don't change it.
+
+            // Make sure we copy the appdomain configuration and send it to the appdomain we create so that if the creator of the current appdomain
+            // has done the binding redirection in code, that we will get those settings as well.
+            AppDomainSetup appDomainInfo = new AppDomainSetup();
+
+            // Get the current app domain setup settings
+            byte[] currentAppdomainBytes = appDomainSetup.GetConfigurationBytes();
+
+            // Apply the appdomain settings to the new appdomain before creating it
+            appDomainInfo.SetConfigurationBytes(currentAppdomainBytes);
+
+            if (BuildEnvironmentHelper.Instance.RunningTests)
+            {
+                // Prevent the new app domain from looking in the VS test runner location. If this
+                // is not done, we will not be able to find Microsoft.Build.* assemblies.
+                appDomainInfo.ApplicationBase = BuildEnvironmentHelper.Instance.CurrentMSBuildToolsDirectory;
+                appDomainInfo.ConfigurationFile = BuildEnvironmentHelper.Instance.CurrentMSBuildConfigurationFile;
+            }
+
+            AppDomain.CurrentDomain.AssemblyResolve += AssemblyResolver;
+            s_resolverLoadedType = loadedType;
+
+            AppDomain taskAppDomain = AppDomain.CreateDomain(isOutOfProc ? "taskAppDomain (out-of-proc)" : "taskAppDomain (in-proc)", null, appDomainInfo);
+
+            if (loadedType.LoadedAssembly != null)
+            {
+                taskAppDomain.Load(loadedType.LoadedAssemblyName);
+            }
+
+            // Hook up last minute dumping of any exceptions
+            taskAppDomain.UnhandledException += DebugUtils.UnhandledExceptionHandler;
+            appDomainCreated?.Invoke(taskAppDomain);
+
+            return taskAppDomain;
+        }
+
         /// <summary>
         /// This is a resolver to help created AppDomains when they are unable to load an assembly into their domain we will help
         /// them succeed by providing the already loaded one in the currentdomain so that they can derive AssemblyName info from it

--- a/src/Tasks/GenerateResource.cs
+++ b/src/Tasks/GenerateResource.cs
@@ -22,6 +22,7 @@ using System.Resources.Extensions;
 using System.Reflection;
 using System.Runtime.InteropServices;
 #if FEATURE_APPDOMAIN
+using System.Runtime.CompilerServices;
 using System.Runtime.Remoting;
 using System.Runtime.Serialization.Formatters.Binary;
 #endif
@@ -806,10 +807,7 @@ namespace Microsoft.Build.Tasks
                                 // create the list that we'll use to disconnect the taskitems once we're done
                                 _remotedTaskItems = new List<ITaskItem>();
 
-                                appDomain = AppDomain.CreateDomain(
-                                    "generateResourceAppDomain",
-                                    null,
-                                    AppDomain.CurrentDomain.SetupInformation);
+                                appDomain = CreateGenerateResourceAppDomain();
 
                                 object obj = appDomain.CreateInstanceFromAndUnwrap(
                                        typeof(ProcessResourceFiles).Module.FullyQualifiedName,
@@ -1807,6 +1805,23 @@ namespace Microsoft.Build.Tasks
         }
 
 #if FEATURE_APPDOMAIN
+        /// <summary>
+        /// Creates the AppDomain resource processing runs in when one is needed. Kept in a separate
+        /// never-inlined method: the AppDomain.CreateDomain overload used here has
+        /// System.Security.Policy.Evidence in its signature, a type that does not exist when a .NET
+        /// host loads this .NET Framework assembly, and an unresolvable signature fails the JIT of
+        /// the entire calling method. Isolating it here keeps <see cref="Execute"/> JITtable on .NET
+        /// so the common no-separate-AppDomain path still works there.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static AppDomain CreateGenerateResourceAppDomain()
+        {
+            return AppDomain.CreateDomain(
+                "generateResourceAppDomain",
+                null,
+                AppDomain.CurrentDomain.SetupInformation);
+        }
+
         /// <summary>
         /// Make the decision about whether a separate AppDomain is needed.
         /// If this algorithm is unsure about whether a separate AppDomain is


### PR DESCRIPTION
An IDE or tool running on .NET 10 can load MSBuild.exe's assemblies in-proc (via MSBuildLocator) to get the full VS toolset. Most of this already works; this change fixes the remaining failures, all rooted in .NET Framework APIs that don't exist on the .NET runtime:

 * Move AppDomain.CreateDomain and AppDomainSetup config-bytes calls into separate NoInlining methods. A reference to an unresolvable member fails the JIT of the whole containing method (even past its try/catch), which broke common paths that never create AppDomains.

 * Don't propagate AppDomainSetup to nodes when hosted on .NET; it has no configuration bytes to carry there.

 * Validate named-pipe ownership with PipeOptions.CurrentUserOnly (as .NET MSBuild already does) instead of PipeSecurity, which doesn't exist on .NET.

 * Fall back to Assembly.LoadFrom when loading SDK resolvers, since Assembly.Load only honors the CodeBase hint on .NET Framework.

No behavior change when running normally on .NET Framework. I validated by dogfooding this build to do builds and design-time builds from a .NET 10 process.