### PR TITLE
Revert passing ExcludeRestorePackageImports during restore (#14274)

### DIFF
--- a/documentation/wiki/ChangeWaves.md
+++ b/documentation/wiki/ChangeWaves.md
@@ -30,7 +30,6 @@ Change wave checks around features will be removed in the release that accompani
 ## Current Rotation of Change Waves
 
 ### 18.10
-- [Restore passes ExcludeRestorePackageImports=true as a global property so NuGet's restore no longer triggers a second evaluation of every project.](https://github.com/dotnet/msbuild/issues/14273)
 - [`-getProperty`/`-getItem` (without a target) stop evaluation after the pass that produces the requested data instead of running a full evaluation, avoiding later passes such as target registration.](https://github.com/dotnet/msbuild/pull/14290)arget)
 
 ### 18.9

--- a/documentation/wiki/ChangeWaves.md
+++ b/documentation/wiki/ChangeWaves.md
@@ -30,7 +30,7 @@ Change wave checks around features will be removed in the release that accompani
 ## Current Rotation of Change Waves
 
 ### 18.10
-- [`-getProperty`/`-getItem` (without a target) stop evaluation after the pass that produces the requested data instead of running a full evaluation, avoiding later passes such as target registration.](https://github.com/dotnet/msbuild/pull/14290)arget)
+- [`-getProperty`/`-getItem` (without a target) stop evaluation after the pass that produces the requested data instead of running a full evaluation, avoiding later passes such as target registration.](https://github.com/dotnet/msbuild/pull/14290)
 
 ### 18.9
 - [GenerateResource: typed ResX data/metadata entries in Mark-of-the-Web files are now treated as untrusted and blocked with MSB3821; unblock the file (or set MSBUILDDISABLEFEATURESFROMVERSION=18.9) to restore prior behavior. ResXFileRef entries are always blocked regardless of this wave.](https://github.com/dotnet/msbuild/pull/14015)

--- a/src/Framework/MSBuildConstants.cs
+++ b/src/Framework/MSBuildConstants.cs
@@ -81,20 +81,6 @@ namespace Microsoft.Build.Shared
         internal const string MSBuildIsRestoring = nameof(MSBuildIsRestoring);
 
         /// <summary>
-        /// A property set during an implicit restore (/restore) or explicit restore (/t:restore) to instruct projects to exclude imports that are
-        /// provided by NuGet packages. NuGet passes this same global property when it re-invokes the build, so setting it up front ensures the
-        /// initial evaluation is reused rather than being discarded and re-evaluated.
-        /// </summary>
-        internal const string ExcludeRestorePackageImports = nameof(ExcludeRestorePackageImports);
-
-        /// <summary>
-        /// The value MSBuild assigns to <see cref="ExcludeRestorePackageImports"/> during restore. It must match the literal value NuGet passes
-        /// (lowercase "true" from NuGet.targets) because global property values are compared case-sensitively when matching build configurations
-        /// for evaluation reuse.
-        /// </summary>
-        internal const string ExcludeRestorePackageImportsValue = "true";
-
-        /// <summary>
         /// The most current VSGeneralAssemblyVersion known to this version of MSBuild.
         /// </summary>
         internal const string CurrentAssemblyVersion = "15.1.0.0";

--- a/src/MSBuild.UnitTests/XMake_Tests.cs
+++ b/src/MSBuild.UnitTests/XMake_Tests.cs
@@ -2651,49 +2651,6 @@ $@"<Project>
         }
 
         /// <summary>
-        /// Verifies restore sets the ExcludeRestorePackageImports global property so that NuGet's restore reuses the initial
-        /// evaluation instead of forcing a second evaluation of every project.
-        /// </summary>
-        [Fact]
-        public void RestoreSetsExcludeRestorePackageImports()
-        {
-            string projectContents = ObjectModelHelpers.CleanupFileContents(
-                @"<Project>
-  <Target Name=""Restore"">
-    <Message Text=""ExcludeRestorePackageImports=[$(ExcludeRestorePackageImports)]"" Importance=""High"" />
-  </Target>
-</Project>");
-
-            string logContents = ExecuteMSBuildExeExpectSuccess(projectContents, arguments: "/t:restore");
-
-            // The value must be the literal lowercase "true" to exactly match the global property NuGet's restore passes
-            // (NuGet.targets sets ExcludeRestorePackageImports=true), otherwise evaluation reuse would not occur.
-            logContents.ShouldContain($"ExcludeRestorePackageImports=[{MSBuildConstants.ExcludeRestorePackageImportsValue}]");
-        }
-
-        /// <summary>
-        /// Verifies restore does not set the ExcludeRestorePackageImports global property when change wave 18.10 is disabled,
-        /// preserving the prior behavior for repositories that opt out.
-        /// </summary>
-        [Fact]
-        public void RestoreDoesNotSetExcludeRestorePackageImportsWhenWaveDisabled()
-        {
-            string projectContents = ObjectModelHelpers.CleanupFileContents(
-                @"<Project>
-  <Target Name=""Restore"">
-    <Message Text=""ExcludeRestorePackageImports=[$(ExcludeRestorePackageImports)]"" Importance=""High"" />
-  </Target>
-</Project>");
-
-            Dictionary<string, string> envVars = new() { { "MSBUILDDISABLEFEATURESFROMVERSION", ChangeWaves.Wave18_10.ToString() } };
-
-            string logContents = ExecuteMSBuildExeExpectSuccess(projectContents, envsToCreate: envVars, arguments: "/t:restore");
-
-            // When the wave is disabled, the property must not be injected.
-            logContents.ShouldContain("ExcludeRestorePackageImports=[]");
-        }
-
-        /// <summary>
         /// We check if there is only one target name specified and this logic caused a regression: https://github.com/dotnet/msbuild/issues/3317
         /// </summary>
         [Fact]

--- a/src/MSBuild.UnitTests/XMake_Tests.cs
+++ b/src/MSBuild.UnitTests/XMake_Tests.cs
@@ -2651,6 +2651,28 @@ $@"<Project>
         }
 
         /// <summary>
+        /// Regression test for dotnet/msbuild#14274 / dotnet/sdk#55245: restore must not inject the ExcludeRestorePackageImports
+        /// global property. Doing so aligns MSBuild's restore evaluation with the global property set NuGet's inner restore walk
+        /// uses, which makes a nonexistent &lt;ProjectReference&gt; leak into NuGet's _GenerateRestoreGraphProjectEntry MSBuild call
+        /// (which does not skip nonexistent projects) and fail with MSB3202 instead of being skipped.
+        /// </summary>
+        [Fact]
+        public void RestoreDoesNotInjectExcludeRestorePackageImports()
+        {
+            string projectContents = ObjectModelHelpers.CleanupFileContents(
+                @"<Project>
+  <Target Name=""Restore"">
+    <Message Text=""ExcludeRestorePackageImports=[$(ExcludeRestorePackageImports)]"" Importance=""High"" />
+  </Target>
+</Project>");
+
+            string logContents = ExecuteMSBuildExeExpectSuccess(projectContents, arguments: "/t:restore");
+
+            // The property must remain empty; MSBuild must not set it during restore.
+            logContents.ShouldContain("ExcludeRestorePackageImports=[]");
+        }
+
+        /// <summary>
         /// We check if there is only one target name specified and this logic caused a regression: https://github.com/dotnet/msbuild/issues/3317
         /// </summary>
         [Fact]

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -2094,18 +2094,15 @@ namespace Microsoft.Build.CommandLine
             // Add a property to indicate that a Restore is executing
             restoreGlobalProperties[MSBuildConstants.MSBuildIsRestoring] = bool.TrueString;
 
-            // Add the property that NuGet passes when it re-invokes the build during restore. NuGet's restore targets pass
-            // ExcludeRestorePackageImports=true as a global property, which normally forces a second evaluation of every project.
-            // Setting it up front here means the initial evaluation already matches, so it is reused instead of being discarded.
-            // The value must match NuGet's exactly (the literal lowercase "true" from NuGet.targets) because global property values
-            // are compared case-sensitively when matching build configurations for evaluation reuse.
-            // Only set it when the user has not explicitly supplied a value so that an explicit opt-out (e.g.
-            // /p:ExcludeRestorePackageImports=false) is respected instead of being silently overwritten.
-            if (ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave18_10)
-                && !globalProperties.ContainsKey(MSBuildConstants.ExcludeRestorePackageImports))
-            {
-                restoreGlobalProperties[MSBuildConstants.ExcludeRestorePackageImports] = MSBuildConstants.ExcludeRestorePackageImportsValue;
-            }
+            // NOTE: Do NOT add ExcludeRestorePackageImports=true here to try to match the global properties that NuGet's
+            // restore targets pass when they re-invoke the build. It is tempting because it would let the initial restore
+            // evaluation be reused instead of re-evaluated, but it breaks restore for projects that have a nonexistent
+            // <ProjectReference>. When the top-level restore evaluation shares the same global property set as NuGet's inner
+            // _GenerateRestoreProjectPathWalk invocation, that walk runs in the same project instance and its unfiltered
+            // _RestoreProjectPathItems (which contains the raw ProjectReference paths, including missing ones) leaks into
+            // _GenerateRestoreGraph's _GenerateRestoreGraphProjectEntry MSBuild call, which does not set SkipNonexistentProjects
+            // and therefore fails with MSB3202 instead of skipping the missing project. See dotnet/msbuild#14274 (reverted)
+            // and dotnet/sdk#55245.
 
             // Create a new request with a Restore target only and specify:
             //  - BuildRequestDataFlags.ClearCachesAfterBuild to ensure the projects will be reloaded from disk for subsequent builds


### PR DESCRIPTION
Reverts the change from #14274, which injected `ExcludeRestorePackageImports=true` into the implicit restore global properties (behind change wave 18.10) so that NuGet's restore re-invocation would reuse MSBuild's initial evaluation instead of forcing a second one.

### Why revert

The change breaks restore for projects that have a **nonexistent `<ProjectReference>`**. Once the top-level restore evaluation shares the same global property set that NuGet's inner `_GenerateRestoreProjectPathWalk` invocation uses, that walk runs in the *same* project instance and its unfiltered `_RestoreProjectPathItems` (which contains the raw `ProjectReference` paths, including missing ones) leaks into `_GenerateRestoreGraph`'s `_GenerateRestoreGraphProjectEntry` MSBuild call. That call does not set `SkipNonexistentProjects`, so it fails with `MSB3202` instead of skipping the missing project.

```
NuGet.targets(571,5): error MSB3202: The project file "...\TestLibrary\TestLibrary.csproj" was not found.
```

This regressed the dotnet/sdk test `ItCanTestAMultiTFMProjectWithImplicitRestore` — see dotnet/sdk#55245 for the full root-cause analysis and repro.

### Details

- Only the implicit-restore (`-restore` switch / `ExecuteRestore`) path was affected; explicit `dotnet restore` / `-t:Restore` never added the property.
- Reproduced with `dotnet build -t:Restore /p:ExcludeRestorePackageImports=true` on a multi-TFM project with a dangling `ProjectReference`: without the property restore succeeds (missing project skipped gracefully); with it, `MSB3202`.

### What this PR does

- Removes the `ExcludeRestorePackageImports=true` injection in `XMake.ExecuteRestore`, replacing it with a comment documenting **why** the property must not be set there.
- Removes the `ExcludeRestorePackageImports` / `ExcludeRestorePackageImportsValue` constants and the two related unit tests.
- Removes the 18.10 ChangeWaves.md bullet for this feature.
- **Retains** change wave `18.10` itself — it is still used by the `-getProperty`/`-getItem` evaluation change (#14290).
