### PR TITLE
Remove local fork requirement from contributing guide

### DIFF
--- a/documentation/wiki/Contributing-Code.md
+++ b/documentation/wiki/Contributing-Code.md
@@ -17,7 +17,7 @@ You will have to sign a Contributor License Agreement (CLA) before we can accept
 ### Developer Workflow
 
 1. Work item is assigned to a developer during the triage process
-2. Both Microsoft and external contributors are expected to do their work in a local fork and submit code for consideration via a pull request.
+2. Both Microsoft and external contributors submit code for consideration via a pull request.
 3. When the pull request process deems the change ready it will be merged directly into the tree. 
 
 ### Creating New Issues


### PR DESCRIPTION
The Developer Workflow section of the contributing guide stated that both Microsoft and external contributors are "expected to do their work in a local fork and submit code for consideration via a pull request."

This requirement is no longer accurate — contributors can work in a branch and submit a pull request without necessarily forking. This small change drops the mandatory-fork wording while keeping the pull-request submission guidance.

Note: The README itself does not mention forking; the fork requirement lived in the linked [Contributing Guide](documentation/wiki/Contributing-Code.md), which is what this PR updates.