### PR TITLE
Remove NuGet restore task for internal tools

### DIFF
--- a/azure-pipelines/.vsts-dotnet-build-jobs.yml
+++ b/azure-pipelines/.vsts-dotnet-build-jobs.yml
@@ -97,16 +97,6 @@ jobs:
     env:
       Token: $(dn-bot-dnceng-artifact-feeds-rw)
 
-
-  - task: NuGetCommand@2
-    displayName: Restore internal tools
-    inputs:
-      command: restore
-      feedsToUse: config
-      restoreSolution: 'eng\common\internal\Tools.csproj'
-      nugetConfigPath: 'eng\common\internal\NuGet.config'
-      restoreDirectory: '$(Build.SourcesDirectory)\.packages'
-
   - task: MicroBuildSigningPlugin@4
     displayName: Install MicroBuild plugin
     inputs:


### PR DESCRIPTION
Removed the NuGet command task for restoring internal tools.

This now happens automatically as part of the Arcade toolset restore

Fixes the broken official build