### PR TITLE
Default restore to true in sdk-task scripts

### DIFF
--- a/eng/common/sdk-task.ps1
+++ b/eng/common/sdk-task.ps1
@@ -4,7 +4,9 @@ Param(
   [string] $task,
   [string] $verbosity = 'minimal',
   [string] $msbuildEngine = $null,
-  [switch] $restore,
+  # -restore is always on now; the switch is retained only so existing consumers that pass it don't break. Use -norestore to opt out.
+  [switch] $restore = $true,
+  [switch] $norestore,
   [switch] $prepareMachine,
   [switch][Alias('nobl')]$excludeCIBinaryLog,
   [switch]$noWarnAsError,
@@ -23,7 +25,8 @@ $warnAsError = if ($noWarnAsError) { $false } else { $true }
 function Print-Usage() {
   Write-Host "Common settings:"
   Write-Host "  -task <value>           Name of Arcade task (name of a project in toolset directory of the Arcade SDK package)"
-  Write-Host "  -restore                Restore dependencies"
+  Write-Host "  -restore                (Legacy/no-op) Restore is always on; retained for backward compatibility"
+  Write-Host "  -norestore              Skip restoring dependencies"
   Write-Host "  -verbosity <value>      Msbuild verbosity: q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic]"
   Write-Host "  -help                   Print help and exit"
   Write-Host ""
@@ -75,7 +78,7 @@ try {
     ExitWithExitCode 1
   }
 
-  if ($restore) {
+  if (-not $norestore) {
     Build 'Restore'
   }
 

--- a/eng/common/sdk-task.sh
+++ b/eng/common/sdk-task.sh
@@ -3,7 +3,8 @@
 show_usage() {
     echo "Common settings:"
     echo "  --task <value>           Name of Arcade task (name of a project in toolset directory of the Arcade SDK package)"
-    echo "  --restore                Restore dependencies"
+    echo "  --restore                (Legacy/no-op) Restore is always on; retained for backward compatibility"
+    echo "  --norestore              Skip restoring dependencies"
     echo "  --verbosity <value>      Msbuild verbosity: q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic]"
     echo "  --help                   Print help and exit"
     echo ""
@@ -50,7 +51,8 @@ binary_log=true
 configuration="Debug"
 verbosity="minimal"
 exclude_ci_binary_log=false
-restore=false
+# restore is always on now; --restore is retained only so existing consumers that pass it don't break. Use --norestore to opt out.
+restore=true
 help=false
 properties=''
 warnAsError=true
@@ -64,6 +66,10 @@ while (($# > 0)); do
       ;;
     --restore)
       restore=true
+      shift 1
+      ;;
+    --norestore)
+      restore=false
       shift 1
       ;;
     --verbosity)


### PR DESCRIPTION
> **Upstreamed:** This change is already submitted upstream to Arcade in dotnet/arcade#17116. Since `eng/common` is mirrored from [dotnet/arcade](https://github.com/dotnet/arcade), this PR applies the same fix directly to msbuild so we don't have to wait for the Arcade flow.

## Summary
`sdk-task.ps1`/`sdk-task.sh` defaulted `restore` to **false**, diverging from `tools.ps1`'s default of `true` (the `.ps1` shadowed the `tools.ps1` default via its own `[switch] $restore`, which is always `false` unless passed).

This regressed upstream in [dotnet/arcade@ea5fa16](https://github.com/dotnet/arcade/commit/ea5fa1675a08347dde19aee855e04a21bd8586b4), which flipped the default from restoring-by-default to not restoring. That same commit reworked the SDK tasks to use `PackageReference` items, which means the tasks now need a restore in certain cases - so defaulting `restore` to false leaves those consumers broken.

This changes both scripts to default restore to **true** and adds a `-norestore`/`--norestore` opt-out.

## Behavior
- `restore` now defaults to **true** in both scripts.
- New `-norestore` / `--norestore` flag skips the restore step.
- `-restore` / `--restore` is retained as a **legacy no-op** so existing consumers that pass it don't break.