### PR TITLE
Add experimental MTP-mode CTS config

### DIFF
--- a/scripts/cts/README.md
+++ b/scripts/cts/README.md
@@ -13,6 +13,7 @@ surface stays in sync; only the runner stack differs.
 | -------------------------- | ---------------------------------------------------------- |
 | `projects.json`            | Registry of `*.UnitTests.VSTest` projects + demo files     |
 | `cts.config.json`          | CTS configuration (Modules / SourceCodeFiles / Filter)     |
+| `cts.config.mtp.json`      | Experimental MTP-mode config (see [MTP mode](#mtp-mode-experimental)) |
 | `_Common.ps1`              | Tiny PS helpers (paths, build, registry lookup)            |
 | `Collect-Local.ps1`        | `cts collect vstest --coverage` → baseline in `.cts/`      |
 | `Run-Local.ps1`            | `cts apply vstest --local-development` → impacted-only run |
@@ -104,9 +105,38 @@ silently skip the other. It is wired into `azure-pipelines/cts-apply.yml` as
 a **non-blocking** PR-time step, and can also be run locally:
 `pwsh ./scripts/cts/Check-SlnxParity.ps1`.
 
-## Notes
+## MTP mode (experimental)
 
-* Baseline + logs live at `<repo>/.cts/` (gitignored).
+> The VSTest path above remains the supported, non-blocking CI mode. The MTP
+> path below is opt-in and **not yet wired into CI** — see the caveat.
+
+CTS originally could not drive this repo's tests in their native
+**Microsoft.Testing.Platform (MTP)** form (the default xUnit.v3 runner) because
+the CTS↔host JsonRpc session could hang indefinitely — the reason the VSTest
+wrappers exist. That hang has two independent causes, both now addressed in the
+CTS tool itself (driver resilience: wait for real host exit + bounded output
+drain, and a per-batch response timeout that kills a wedged host and lets CTS
+retry it on a fresh process):
+
+1. A Windows stdout/stderr pipe-inheritance leak past host exit.
+2. A wedged JSON-RPC handshake with no timeout.
+
+`cts.config.mtp.json` drives the **regular `*.UnitTests` MTP DLLs directly**
+(no `.VSTest` wrapper): `Filter.Include` targets
+`**/artifacts/bin/*.UnitTests/Debug/net10.0/*.UnitTests.dll`, and
+`RunConfiguration.TestHostResponseTimeoutSeconds` (120s here) tunes the new
+per-batch wedged-host timeout. Point `cts collect testingplatform` /
+`cts apply testingplatform` at this config instead of `cts.config.json`.
+
+**Caveat (why this is still experimental):** with xUnit.v3 3.2.2, a specific
+batch of tests can deterministically deadlock the test host in MTP *server*
+mode (the auto-generated entry point blocks sync-over-async on its run task).
+The CTS timeout+retry converts that from an infinite hang into a bounded
+outcome, but the deadlocking batch can still surface as a spurious failure.
+Fully green MTP-mode CTS is therefore gated on an upstream xUnit.v3 fix; until
+then, VSTest mode remains the CI path.
+
+
 * The `.VSTest.csproj` wrappers output to
   `artifacts/bin/<MSBuildProjectName>/Debug/net10.0/` — distinct from the
   default MTP variant.

--- a/scripts/cts/README.md
+++ b/scripts/cts/README.md
@@ -115,8 +115,8 @@ CTS originally could not drive this repo's tests in their native
 the CTS↔host JsonRpc session could hang indefinitely — the reason the VSTest
 wrappers exist. That hang has two independent causes, both now addressed in the
 CTS tool itself (driver resilience: wait for real host exit + bounded output
-drain, and a per-batch response timeout that kills a wedged host and lets CTS
-retry it on a fresh process):
+drain, and an **opt-in inactivity timeout** that kills a host which has gone
+completely silent and lets CTS retry it on a fresh process):
 
 1. A Windows stdout/stderr pipe-inheritance leak past host exit.
 2. A wedged JSON-RPC handshake with no timeout.
@@ -124,8 +124,14 @@ retry it on a fresh process):
 `cts.config.mtp.json` drives the **regular `*.UnitTests` MTP DLLs directly**
 (no `.VSTest` wrapper): `Filter.Include` targets
 `**/artifacts/bin/*.UnitTests/Debug/net10.0/*.UnitTests.dll`, and
-`RunConfiguration.TestHostResponseTimeoutSeconds` (120s here) tunes the new
-per-batch wedged-host timeout. Point `cts collect testingplatform` /
+`RunConfiguration.TestHostResponseTimeoutSeconds` (120s here) opts into the new
+inactivity timeout. This is **not** a cap on total batch time — it is the
+maximum time the host may go without producing *any* activity (a test-node
+update or a client log) before CTS treats it as wedged. Every update from the
+host resets the countdown, so a batch that keeps streaming progress runs as long
+as it needs; only a host that falls silent for the whole window is killed and
+retried. The CTS default is `0` (disabled), so the timeout only engages because
+this config sets it. Point `cts collect testingplatform` /
 `cts apply testingplatform` at this config instead of `cts.config.json`.
 
 **Caveat (why this is still experimental):** with xUnit.v3 3.2.2, a specific

--- a/scripts/cts/cts.config.mtp.json
+++ b/scripts/cts/cts.config.mtp.json
@@ -1,0 +1,54 @@
+{
+  "SourceCodeFiles": {
+    "Include": [
+      "src/**/*.cs"
+    ],
+    "Exclude": [
+      "**/obj/**",
+      "**/bin/**",
+      "**/TestAssets/**"
+    ]
+  },
+  "Files": {
+    "Exclude": [
+      "**/*.md",
+      "**/*.yml",
+      "**/*.yaml",
+      "**/*.png",
+      "documentation/**"
+    ]
+  },
+  "Modules": {
+    "Include": [],
+    "Exclude": [
+      "**/Microsoft.Testing.*.dll",
+      "**/Microsoft.TestPlatform*.dll",
+      "**/Microsoft.VisualStudio.TestPlatform*.dll",
+      "**/Microsoft.VisualStudio.CodeCoverage*.dll",
+      "**/Microsoft.DotNet.*.dll",
+      "**/xunit.*.dll",
+      "**/Xunit.*.dll",
+      "**/testhost*",
+      "**/Microsoft.Bcl.*.dll",
+      "**/Microsoft.ApplicationInsights.dll",
+      "**/Newtonsoft.Json.dll",
+      "**/Shouldly.dll",
+      "**/AwesomeAssertions.dll",
+      "**/FakeItEasy.dll",
+      "**/Verify.*.dll",
+      "**/System*.dll",
+      "**/runtimes/**"
+    ]
+  },
+  "Filter": {
+    "Include": [
+      "**/artifacts/bin/*.UnitTests/Debug/net10.0/*.UnitTests.dll"
+    ],
+    "Exclude": [
+      "**/*.resources.dll"
+    ]
+  },
+  "RunConfiguration": {
+    "TestHostResponseTimeoutSeconds": 120
+  }
+}


### PR DESCRIPTION
## Summary

Adds an **experimental, opt-in** CTS (Clever Test Selection) configuration that drives this repo's tests in their native **Microsoft.Testing.Platform (MTP)** form (the default xUnit.v3 runner), instead of the `*.VSTest` wrappers that VSTest-mode CTS uses today.

- New: `scripts/cts/cts.config.mtp.json` — targets the regular `*.UnitTests` MTP DLLs (`**/artifacts/bin/*.UnitTests/Debug/net10.0/*.UnitTests.dll`) and sets `RunConfiguration.TestHostResponseTimeoutSeconds` to tune the CTS per-batch wedged-host timeout.
- Updated: `scripts/cts/README.md` — new "MTP mode (experimental)" section documenting usage and the caveat.

The **VSTest path is intentionally left untouched** (`scripts/cts/cts.config.json`, `scripts/cts/*.ps1`, `azure-pipelines/cts-*.yml`) and remains the CI mode.

## Background

CTS could not previously drive MSBuild's tests in MTP form because the CTS↔host JSON-RPC session could hang indefinitely (the reason the `*.VSTest` wrappers exist). That hang was root-caused to **two independent issues in the CTS tool's Testing Platform driver**, both fixed on the CTS side (separate PR in the `vs-code-coverage` repo):

1. **Windows pipe-inheritance leak** — the host's redirected stdout/stderr pipe handles could be inherited by a grandchild the host spawns; `WaitForExitAsync` then waits for a pipe EOF that never arrives.
2. **Wedged JSON-RPC handshake** — a host could connect but never drive the session to completion, with no timeout on the driver side.

The CTS fix waits for real process exit + bounded output drain, and adds a per-batch timeout that kills a wedged host and retries the affected tests on a fresh process. That timeout is what `TestHostResponseTimeoutSeconds` in this config tunes.

## Why experimental / draft

With **xUnit.v3 3.2.2**, a specific batch can still *deterministically* deadlock the test host in MTP **server** mode (the auto-generated entry point blocks sync-over-async on its run task — captured stack: `Monitor.Wait ← TaskAwaiter.GetResult() ← XunitAutoGeneratedEntryPoint.Main`). The CTS timeout+retry converts that from an infinite hang into a *bounded* outcome, but the deadlocking batch can still surface as a spurious failure. **Fully green MTP-mode CTS is therefore gated on an upstream xUnit.v3 fix.** Until then, VSTest mode remains the CI path and this config is opt-in only (not wired into any pipeline).

## Testing

Validated end-to-end with the fixed CTS driver against real `StringTools.UnitTests` MTP tests: the driver now always terminates and writes a baseline (previously: infinite hang). The config-driven timeout was confirmed to be honored from the JSON file.
