### PR TITLE
Fix Dreaming workflow: repin gh-aw setup action to v0.79.8 so it can open its PR

### DIFF
--- a/.github/workflows/dreaming.agent.lock.yml
+++ b/.github/workflows/dreaming.agent.lock.yml
@@ -52,7 +52,7 @@
 #   - actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0 (source v9)
 #   - actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
 #   - actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-#   - github/gh-aw-actions/setup@99d9d888952ee25fce70c6b3120ca490d7d8da95 # v0.82.8
+#   - github/gh-aw-actions/setup@c0338fef4749d08c21f8f975fb0e37efa17dda47 # v0.79.8
 #
 # Container images used:
 #   - ghcr.io/github/gh-aw-firewall/agent:0.27.2@sha256:f88e5b17b6b7a600117bc121114d6ce2155c88c983c0c939c5df884f730fa1d6
@@ -112,7 +112,7 @@ jobs:
     steps:
       - name: Setup Scripts
         id: setup
-        uses: github/gh-aw-actions/setup@99d9d888952ee25fce70c6b3120ca490d7d8da95 # v0.82.8
+        uses: github/gh-aw-actions/setup@c0338fef4749d08c21f8f975fb0e37efa17dda47 # v0.79.8
         with:
           destination: ${{ runner.temp }}/gh-aw/actions
           job-name: ${{ github.job }}
@@ -403,7 +403,7 @@ jobs:
     steps:
       - name: Setup Scripts
         id: setup
-        uses: github/gh-aw-actions/setup@99d9d888952ee25fce70c6b3120ca490d7d8da95 # v0.82.8
+        uses: github/gh-aw-actions/setup@c0338fef4749d08c21f8f975fb0e37efa17dda47 # v0.79.8
         with:
           destination: ${{ runner.temp }}/gh-aw/actions
           job-name: ${{ github.job }}
@@ -1047,7 +1047,7 @@ jobs:
     steps:
       - name: Setup Scripts
         id: setup
-        uses: github/gh-aw-actions/setup@99d9d888952ee25fce70c6b3120ca490d7d8da95 # v0.82.8
+        uses: github/gh-aw-actions/setup@c0338fef4749d08c21f8f975fb0e37efa17dda47 # v0.79.8
         with:
           destination: ${{ runner.temp }}/gh-aw/actions
           job-name: ${{ github.job }}
@@ -1239,7 +1239,7 @@ jobs:
     steps:
       - name: Setup Scripts
         id: setup
-        uses: github/gh-aw-actions/setup@99d9d888952ee25fce70c6b3120ca490d7d8da95 # v0.82.8
+        uses: github/gh-aw-actions/setup@c0338fef4749d08c21f8f975fb0e37efa17dda47 # v0.79.8
         with:
           destination: ${{ runner.temp }}/gh-aw/actions
           job-name: ${{ github.job }}
@@ -1561,7 +1561,7 @@ jobs:
     steps:
       - name: Setup Scripts
         id: setup
-        uses: github/gh-aw-actions/setup@99d9d888952ee25fce70c6b3120ca490d7d8da95 # v0.82.8
+        uses: github/gh-aw-actions/setup@c0338fef4749d08c21f8f975fb0e37efa17dda47 # v0.79.8
         with:
           destination: ${{ runner.temp }}/gh-aw/actions
           job-name: ${{ github.job }}
@@ -1624,7 +1624,7 @@ jobs:
     steps:
       - name: Setup Scripts
         id: setup
-        uses: github/gh-aw-actions/setup@99d9d888952ee25fce70c6b3120ca490d7d8da95 # v0.82.8
+        uses: github/gh-aw-actions/setup@c0338fef4749d08c21f8f975fb0e37efa17dda47 # v0.79.8
         with:
           destination: ${{ runner.temp }}/gh-aw/actions
           job-name: ${{ github.job }}


### PR DESCRIPTION
## What this changes

One pin in `dreaming.agent.lock.yml`: `github/gh-aw-actions/setup` **v0.82.8 → v0.79.8** (7 identical lines). Nothing else.

## Why (and why it's not an arbitrary manual edit)

On its first run the Dreaming agent worked correctly and produced a good learning-atom proposal, but the `safe_outputs` job crashed before creating the PR:

```
Error: Cannot find module '.../gh-aw/actions/extract_base_branch_from_agent_output.cjs'
  code: 'MODULE_NOT_FOUND'
```

The lock **body** is generated by gh-aw **v0.79.8**, which emits `require('extract_base_branch_from_agent_output.cjs')`. That helper is staged by the `setup` action, whose script bundle is **version-coupled to the compiler**. The body's `setup` pin had drifted to **v0.82.8**, whose bundle no longer ships that file (source-verified below), so the `require` fails.

Repinning `setup` to **v0.79.8** is the value the repo's own tooling already declares — this is a reconciliation back to the declared inputs, not a hand-picked number:

- **`.github/aw/actions-lock.json`** pins `github/gh-aw-actions/setup@v0.79.8` (`c0338fef`).
- A clean `gh aw compile dreaming.agent` (compiler v0.79.8) **independently emits the same `setup@v0.79.8`** pin.

Source-level confirmation of the coupling:

| `github/gh-aw-actions/setup` | ships `setup/js/extract_base_branch_from_agent_output.cjs`? |
|---|---|
| **v0.79.8** (`c0338fef`) — matches the compiler | ✅ present |
| **v0.82.8** (`99d9d888`) — the drifted body pin | ❌ absent |

I kept the change to the single poisoned pin rather than committing a full recompile, because a clean local recompile *also* reverts `actions/checkout` v7.0.0 → v6.0.3 (my local toolchain is out of sync with the fleet's codemods) — an unrelated churn. This PR keeps `checkout` at the fleet's v7.0.0 and touches only `setup`.

## Fleet-wide note (tracked separately)

`flaky-test-fixer` and `flaky-test-detector` carry the **same drifted `setup@v0.82.8` pin** and fail identically at `safe_outputs` whenever they try to open a PR — every scheduled `flaky-test-fixer` run has been failing this way. Filed as a separate issue for the infra owners to fix fleet-wide (or at the `gh aw upgrade` codemod / `actions-lock.json` level).

## Verification / testing

The `copilot-pat-pool` environment (which the workflow's `pre_activation` job gates on) has a deployment-branch policy restricted to `main`, so an end-to-end branch test can't get past the token gate — the fix must be on `main` to run for real. Confirmed at the source level (table above) and by clean recompile that this is the correct pin; once merged I'll re-trigger to confirm the learning-atom PR opens end-to-end.

## Outcome evidence (first run, 29402080275)

The agent's proposal, exactly the intended small / evidence-based / edit-over-add / no-duplicate behavior:

> **docs: reinforce `#nullable disable` prohibition in test file instructions** — adds two sentences to `.github/instructions/tests.instructions.md`; the same miss recurred independently in **3 PRs in the past week** (#14305, #14307, #14315). `AGENTS.md` covers it repo-wide but it keeps getting missed in new test files, so the path-scoped instruction file is where agents will actually see it.
