### PR TITLE
Skip CI build/test legs for documentation- and .github-only changes

### DIFF
--- a/.vsts-dotnet-ci.yml
+++ b/.vsts-dotnet-ci.yml
@@ -48,6 +48,7 @@ jobs:
     inputs:
       filename: 'eng/cibuild_bootstrapped_msbuild.cmd'
       arguments: '-onlyDocChanged $(onlyDocChanged) -stage2Properties /mt'
+    condition: eq(variables.onlyDocChanged, 0)
     env:
       ForceUseXCopyMSBuild: 1
 # Task to collect code coverage on Windows. Disabled by default due to being unstable and sometimes it stucks forever
@@ -160,6 +161,7 @@ jobs:
     inputs:
       filename: 'eng/cibuild_bootstrapped_msbuild.cmd'
       arguments: '-msbuildEngine dotnet -onlyDocChanged $(onlyDocChanged) -stage2Properties /mt'
+    condition: eq(variables.onlyDocChanged, 0)
     env:
       MSBUILDUSESERVER: "1"
 # Task to collect code coverage on Windows. Disabled by default due to being unstable and sometimes it stucks forever
@@ -278,12 +280,6 @@ jobs:
       filename: 'eng/cibuild.cmd'
       arguments: '-configuration Release -test'
     condition: eq(variables.onlyDocChanged, 0)
-  - task: BatchScript@1
-    displayName: cibuild.cmd without test
-    inputs:
-      filename: 'eng/cibuild.cmd'
-      arguments: '-configuration Release'
-    condition: eq(variables.onlyDocChanged, 1)
 # Task to collect code coverage on Windows. Disabled by default due to being unstable and sometimes it stucks forever
 #   - task: PowerShell@2
 #     displayName: Process coverage reports
@@ -360,6 +356,7 @@ jobs:
   - bash: sudo apt-get install -y libxml2
   - bash: . 'eng/cibuild_bootstrapped_msbuild.sh' --onlyDocChanged $(onlyDocChanged) --stage2Properties '/mt'
     displayName: CI Build
+    condition: eq(variables.onlyDocChanged, 0)
     env:
         MSBUILDUSESERVER: "1"
   - task: Bash@3
@@ -448,6 +445,7 @@ jobs:
         Token: $(dn-bot-dnceng-artifact-feeds-rw)
   - bash: . 'eng/cibuild_bootstrapped_msbuild.sh' --onlyDocChanged $(onlyDocChanged) --stage2Properties '/mt'
     displayName: CI Build
+    condition: eq(variables.onlyDocChanged, 0)
     env:
         MSBUILDUSESERVER: "1"
   - task: Bash@3

--- a/azure-pipelines/quarantine.yml
+++ b/azure-pipelines/quarantine.yml
@@ -70,7 +70,7 @@ jobs:
     inputs:
       filename: 'eng/cibuild_bootstrapped_msbuild.cmd'
       arguments: "-onlyDocChanged 0 -stage2Properties '/mt /p:RunQuarantinedTests=true'"
-    condition: eq(variables.onlyDocChanged, 0)
+    condition: or(ne(variables['Build.Reason'], 'PullRequest'), eq(variables.onlyDocChanged, 0))
     env:
       ForceUseXCopyMSBuild: 1
   - task: PublishTestResults@2
@@ -122,7 +122,7 @@ jobs:
   - bash: sudo apt-get install -y libxml2
   - bash: . 'eng/cibuild_bootstrapped_msbuild.sh' --onlyDocChanged 0 --stage2Properties '/mt /p:RunQuarantinedTests=true'
     displayName: CI Build (quarantined tests only)
-    condition: eq(variables.onlyDocChanged, 0)
+    condition: or(ne(variables['Build.Reason'], 'PullRequest'), eq(variables.onlyDocChanged, 0))
     env:
       MSBUILDUSESERVER: "1"
   - task: PublishTestResults@2
@@ -161,7 +161,7 @@ jobs:
   - template: azure-pipelines/check-documentation-only-change.yml
   - bash: . 'eng/cibuild_bootstrapped_msbuild.sh' --onlyDocChanged 0 --stage2Properties '/mt /p:RunQuarantinedTests=true'
     displayName: CI Build (quarantined tests only)
-    condition: eq(variables.onlyDocChanged, 0)
+    condition: or(ne(variables['Build.Reason'], 'PullRequest'), eq(variables.onlyDocChanged, 0))
     env:
       MSBUILDUSESERVER: "1"
   - task: PublishTestResults@2

--- a/azure-pipelines/quarantine.yml
+++ b/azure-pipelines/quarantine.yml
@@ -64,11 +64,13 @@ jobs:
     demands: ImageOverride -equals windows.vs2026preview.scout.amd64.open
   timeoutInMinutes: 120
   steps:
+  - template: azure-pipelines/check-documentation-only-change.yml
   - task: BatchScript@1
     displayName: cibuild_bootstrapped_msbuild.cmd (quarantined tests only)
     inputs:
       filename: 'eng/cibuild_bootstrapped_msbuild.cmd'
       arguments: "-onlyDocChanged 0 -stage2Properties '/mt /p:RunQuarantinedTests=true'"
+    condition: eq(variables.onlyDocChanged, 0)
     env:
       ForceUseXCopyMSBuild: 1
   - task: PublishTestResults@2
@@ -115,10 +117,12 @@ jobs:
     demands: ImageOverride -equals Build.Ubuntu.2204.Amd64.Open
   timeoutInMinutes: 120
   steps:
+  - template: azure-pipelines/check-documentation-only-change.yml
   - bash: sudo apt-get update
   - bash: sudo apt-get install -y libxml2
   - bash: . 'eng/cibuild_bootstrapped_msbuild.sh' --onlyDocChanged 0 --stage2Properties '/mt /p:RunQuarantinedTests=true'
     displayName: CI Build (quarantined tests only)
+    condition: eq(variables.onlyDocChanged, 0)
     env:
       MSBUILDUSESERVER: "1"
   - task: PublishTestResults@2
@@ -154,8 +158,10 @@ jobs:
     vmImage: 'macOS-latest'
   timeoutInMinutes: 120
   steps:
+  - template: azure-pipelines/check-documentation-only-change.yml
   - bash: . 'eng/cibuild_bootstrapped_msbuild.sh' --onlyDocChanged 0 --stage2Properties '/mt /p:RunQuarantinedTests=true'
     displayName: CI Build (quarantined tests only)
+    condition: eq(variables.onlyDocChanged, 0)
     env:
       MSBUILDUSESERVER: "1"
   - task: PublishTestResults@2


### PR DESCRIPTION
## Problem

PRs that touch only `.github/**` or `documentation/**` still run full multi-minute builds on every `msbuild-pr` leg. For example, on #14369 (two `.github/workflows/*` files) the legs ran: Windows Full 12m, Windows Core 9m46s, Linux Core 8m54s, Windows Full Release 6m42s — none of which exercise anything real for a docs/workflow change.

## Root cause

The `onlyDocChanged` detection (`azure-pipelines/check-documentation-only-change.yml`) already covers `.github/` and works correctly — it set `onlyDocChanged=1` for #14369. The problem is what `onlyDocChanged=1` did:

- `cibuild_bootstrapped_msbuild.sh`/`.ps1` still run **both build stages** when `onlyDocChanged=1`; they only drop `--test` and bootstrap creation.
- The `CI Build` steps on **Linux Core** and **macOS Core** had **no `condition`** — the `eq(variables.onlyDocChanged, 0)` line beneath them actually belonged to the *coverage* step — so they always did a full build.
- Only **Linux Core Multithreaded Mode** was correctly gated with a step-level condition.
- `msbuild-quarantine` hardcoded `-onlyDocChanged 0` and had no skip at all.

## Fix

Gate every heavy build step on `condition: eq(variables.onlyDocChanged, 0)`, matching the one leg that already did this, and remove the now-redundant `cibuild.cmd without test` fallback in the Windows Full Release leg. Apply the same inline skip to the three `msbuild-quarantine` legs.

This reuses the **existing inline `check-documentation-only-change.yml` template** in each job — no new cross-job dependency, no added latency for normal PRs, no hardcoded container definitions or Arcade-internal edits. Doc/`.github`-only PRs now finish these legs in agent + checkout time.

**Note:** the arcade `Source-Build (Managed)` leg (~4 min) is intentionally left as-is. Gating it would require duplicating Arcade's default source-build platform/container definition in this repo (a drift/fragility risk), which isn't worth it for a ~4 min leg.

## Behavior for required checks

Jobs still run and report success; only their build/test steps are skipped, so required status checks stay green quickly rather than being left unreported.