### PR TITLE
[MOCK/validation] .github-only change — expect CI build legs to SKIP

### DIFF
--- a/.github/ci-validation-mock.md
+++ b/.github/ci-validation-mock.md
@@ -1,0 +1,4 @@
+# CI validation (mock)
+
+Temporary file to validate that PRs touching only `.github/**` skip the
+msbuild-pr build legs (onlyDocChanged=1). Safe to delete.


### PR DESCRIPTION
**Throwaway validation PR — do not merge; will be closed.**

Validates the skip logic from #14371: this PR's diff touches only `.github/**`, so `onlyDocChanged` should evaluate to **1** and the msbuild-pr build legs should be **skipped** (fast, ~1 min).

Base is the #14371 branch so the new gating logic is exercised. Will `/azp run msbuild-pr` to trigger, observe, then close.