### PR TITLE
[MOCK/validation] code change — expect CI build legs to RUN

### DIFF
--- a/src/Framework/AssemblyLoadingContext.cs
+++ b/src/Framework/AssemblyLoadingContext.cs
@@ -10,3 +10,5 @@ public enum AssemblyLoadingContext
     SdkResolution,
     LoggerInitialization,
 }
+
+// CI validation (mock): trivial comment to exercise a code-touching PR. Safe to revert.


### PR DESCRIPTION
**Throwaway validation PR — do not merge; will be closed.**

Validates the skip logic from #14371: this PR's diff touches a source file, so `onlyDocChanged` should evaluate to **0** and the msbuild-pr build legs should **run in full**.

Base is the #14371 branch so the new gating logic is exercised. Will `/azp run msbuild-pr` to trigger, confirm the build starts (not skipped), then close early to conserve CI.