### PR TITLE
[mock] validate .github-only PR skips CI

### DIFF
--- a/.github/ci-validation-mock.md
+++ b/.github/ci-validation-mock.md
@@ -1,0 +1,4 @@
+# CI validation (mock)
+
+Temporary file to validate that PRs touching only `.github/**` skip the
+msbuild-pr build legs (onlyDocChanged=1). Safe to delete.


### PR DESCRIPTION
Throwaway validation PR. Touches only `.github/**`, so onlyDocChanged=1 and the msbuild-pr build legs should skip. Will be closed after pipelines finish.