### PR TITLE
Skip whole CI legs for documentation/.github-only PRs

### DIFF
--- a/.vsts-dotnet-ci.yml
+++ b/.vsts-dotnet-ci.yml
@@ -35,17 +35,12 @@ jobs:
 # when it reports onlyDocChanged=1, so a docs-only PR never waits on the build pools.
 - job: EvaluateDocumentationOnlyChange
   displayName: "Evaluate documentation-only change"
-  # Runs on the Microsoft-hosted pool (free and uncongested for this public project), NOT the
-  # self-hosted NetCore-Public pool that the heavy legs use. This always-on gate exists only to let
-  # a docs-only PR skip the heavy legs without allocating a self-hosted agent; running it on the
-  # self-hosted pool would add it to the very queue it is meant to relieve. So: a docs-only PR
-  # allocates zero self-hosted agents, and a code PR waits only for this short hosted job before the
-  # heavy legs start.
-  # NOTE: the true zero-job fix is a Path filter on the AzDO branch-policy build validation for this
-  # pipeline (exclude documentation/* and .github/*). If that is ever configured, this gate job and
-  # every "condition: ${{ parameters.runUnlessDocumentationOnly }}" below can be removed.
   pool:
-    vmImage: 'ubuntu-latest'
+    ${{ if eq(variables['System.TeamProject'], 'public') }}:
+      name: NetCore-Public
+      demands: ImageOverride -equals Build.Ubuntu.2204.Amd64.Open
+    ${{ if ne(variables['System.TeamProject'], 'public') }}:
+      vmImage: 'ubuntu-latest'
   steps:
   - template: azure-pipelines/check-documentation-only-change.yml
 

--- a/.vsts-dotnet-ci.yml
+++ b/.vsts-dotnet-ci.yml
@@ -36,7 +36,7 @@ jobs:
 
 - job: BootstrapMSBuildOnFullFrameworkWindows
   dependsOn: EvaluateDocumentationOnlyChange
-  condition: eq(dependencies.EvaluateDocumentationOnlyChange.outputs['CheckDocumentationOnlyChange.onlyDocChanged'], '0')
+  condition: or(not(succeeded('EvaluateDocumentationOnlyChange')), eq(dependencies.EvaluateDocumentationOnlyChange.outputs['CheckDocumentationOnlyChange.onlyDocChanged'], '0'))
   variables:
     coverageArtifactsDir: $(Build.SourcesDirectory)/CoverageStaging
     coverageReportName: WindowsFullFrameworkCoverage
@@ -151,7 +151,7 @@ jobs:
 
 - job: BootstrapMSBuildOnCoreWindows
   dependsOn: EvaluateDocumentationOnlyChange
-  condition: eq(dependencies.EvaluateDocumentationOnlyChange.outputs['CheckDocumentationOnlyChange.onlyDocChanged'], '0')
+  condition: or(not(succeeded('EvaluateDocumentationOnlyChange')), eq(dependencies.EvaluateDocumentationOnlyChange.outputs['CheckDocumentationOnlyChange.onlyDocChanged'], '0'))
   displayName: "Windows Core"
   variables:
     coverageArtifactsDir: $(Build.SourcesDirectory)/CoverageStaging
@@ -241,7 +241,7 @@ jobs:
 # bootstrapped CI jobs (which all run /mt now too) do not need it.
 - job: BootstrapMSBuildWithMTMode
   dependsOn: EvaluateDocumentationOnlyChange
-  condition: eq(dependencies.EvaluateDocumentationOnlyChange.outputs['CheckDocumentationOnlyChange.onlyDocChanged'], '0')
+  condition: or(not(succeeded('EvaluateDocumentationOnlyChange')), eq(dependencies.EvaluateDocumentationOnlyChange.outputs['CheckDocumentationOnlyChange.onlyDocChanged'], '0'))
   displayName: "Linux Core Multithreaded Mode"
   pool:
     vmImage: 'ubuntu-latest'
@@ -273,7 +273,7 @@ jobs:
 
 - job: FullReleaseOnWindows
   dependsOn: EvaluateDocumentationOnlyChange
-  condition: eq(dependencies.EvaluateDocumentationOnlyChange.outputs['CheckDocumentationOnlyChange.onlyDocChanged'], '0')
+  condition: or(not(succeeded('EvaluateDocumentationOnlyChange')), eq(dependencies.EvaluateDocumentationOnlyChange.outputs['CheckDocumentationOnlyChange.onlyDocChanged'], '0'))
   displayName: "Windows Full Release (no bootstrap)"
   variables:
     coverageArtifactsDir: $(Build.SourcesDirectory)/CoverageStaging
@@ -358,7 +358,7 @@ jobs:
 
 - job: CoreBootstrappedOnLinux
   dependsOn: EvaluateDocumentationOnlyChange
-  condition: eq(dependencies.EvaluateDocumentationOnlyChange.outputs['CheckDocumentationOnlyChange.onlyDocChanged'], '0')
+  condition: or(not(succeeded('EvaluateDocumentationOnlyChange')), eq(dependencies.EvaluateDocumentationOnlyChange.outputs['CheckDocumentationOnlyChange.onlyDocChanged'], '0'))
   displayName: "Linux Core"
   pool:
     ${{ if eq(variables['System.TeamProject'], 'public') }}:
@@ -455,7 +455,7 @@ jobs:
 
 - job: CoreOnMac
   dependsOn: EvaluateDocumentationOnlyChange
-  condition: eq(dependencies.EvaluateDocumentationOnlyChange.outputs['CheckDocumentationOnlyChange.onlyDocChanged'], '0')
+  condition: or(not(succeeded('EvaluateDocumentationOnlyChange')), eq(dependencies.EvaluateDocumentationOnlyChange.outputs['CheckDocumentationOnlyChange.onlyDocChanged'], '0'))
   displayName: "macOS Core"
   pool:
     vmImage: 'macOS-latest'
@@ -553,7 +553,7 @@ jobs:
   - FullReleaseOnWindows
   - CoreBootstrappedOnLinux
   - CoreOnMac
-  condition: and(succeeded(), eq(dependencies.EvaluateDocumentationOnlyChange.outputs['CheckDocumentationOnlyChange.onlyDocChanged'], '0'))
+  condition: and(succeeded(), or(not(succeeded('EvaluateDocumentationOnlyChange')), eq(dependencies.EvaluateDocumentationOnlyChange.outputs['CheckDocumentationOnlyChange.onlyDocChanged'], '0')))
   variables:
     onlyDocChanged: $[ dependencies.EvaluateDocumentationOnlyChange.outputs['CheckDocumentationOnlyChange.onlyDocChanged'] ]
   pool:
@@ -625,4 +625,4 @@ jobs:
       container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream-10-amd64'
       jobProperties:
         dependsOn: EvaluateDocumentationOnlyChange
-        condition: eq(dependencies.EvaluateDocumentationOnlyChange.outputs['CheckDocumentationOnlyChange.onlyDocChanged'], '0')
+        condition: or(not(succeeded('EvaluateDocumentationOnlyChange')), eq(dependencies.EvaluateDocumentationOnlyChange.outputs['CheckDocumentationOnlyChange.onlyDocChanged'], '0'))

--- a/.vsts-dotnet-ci.yml
+++ b/.vsts-dotnet-ci.yml
@@ -1,3 +1,13 @@
+parameters:
+# Condition (compile-time constant) reused by every heavy build/test job below. It runs the leg
+# UNLESS the EvaluateDocumentationOnlyChange gate succeeded and classified the change as
+# documentation/.github-only. Fail-open: if the gate did not succeed we still run the leg. Kept in
+# one place and referenced via ${{ parameters.runUnlessDocumentationOnly }} so the long expression
+# is authored exactly once instead of copied onto each job.
+- name: runUnlessDocumentationOnly
+  type: string
+  default: "or(not(succeeded('EvaluateDocumentationOnlyChange')), eq(dependencies.EvaluateDocumentationOnlyChange.outputs['CheckDocumentationOnlyChange.onlyDocChanged'], '0'))"
+
 trigger:
   branches:
     include:
@@ -36,7 +46,7 @@ jobs:
 
 - job: BootstrapMSBuildOnFullFrameworkWindows
   dependsOn: EvaluateDocumentationOnlyChange
-  condition: or(not(succeeded('EvaluateDocumentationOnlyChange')), eq(dependencies.EvaluateDocumentationOnlyChange.outputs['CheckDocumentationOnlyChange.onlyDocChanged'], '0'))
+  condition: ${{ parameters.runUnlessDocumentationOnly }}
   variables:
     coverageArtifactsDir: $(Build.SourcesDirectory)/CoverageStaging
     coverageReportName: WindowsFullFrameworkCoverage
@@ -151,7 +161,7 @@ jobs:
 
 - job: BootstrapMSBuildOnCoreWindows
   dependsOn: EvaluateDocumentationOnlyChange
-  condition: or(not(succeeded('EvaluateDocumentationOnlyChange')), eq(dependencies.EvaluateDocumentationOnlyChange.outputs['CheckDocumentationOnlyChange.onlyDocChanged'], '0'))
+  condition: ${{ parameters.runUnlessDocumentationOnly }}
   displayName: "Windows Core"
   variables:
     coverageArtifactsDir: $(Build.SourcesDirectory)/CoverageStaging
@@ -241,7 +251,7 @@ jobs:
 # bootstrapped CI jobs (which all run /mt now too) do not need it.
 - job: BootstrapMSBuildWithMTMode
   dependsOn: EvaluateDocumentationOnlyChange
-  condition: or(not(succeeded('EvaluateDocumentationOnlyChange')), eq(dependencies.EvaluateDocumentationOnlyChange.outputs['CheckDocumentationOnlyChange.onlyDocChanged'], '0'))
+  condition: ${{ parameters.runUnlessDocumentationOnly }}
   displayName: "Linux Core Multithreaded Mode"
   pool:
     vmImage: 'ubuntu-latest'
@@ -273,7 +283,7 @@ jobs:
 
 - job: FullReleaseOnWindows
   dependsOn: EvaluateDocumentationOnlyChange
-  condition: or(not(succeeded('EvaluateDocumentationOnlyChange')), eq(dependencies.EvaluateDocumentationOnlyChange.outputs['CheckDocumentationOnlyChange.onlyDocChanged'], '0'))
+  condition: ${{ parameters.runUnlessDocumentationOnly }}
   displayName: "Windows Full Release (no bootstrap)"
   variables:
     coverageArtifactsDir: $(Build.SourcesDirectory)/CoverageStaging
@@ -358,7 +368,7 @@ jobs:
 
 - job: CoreBootstrappedOnLinux
   dependsOn: EvaluateDocumentationOnlyChange
-  condition: or(not(succeeded('EvaluateDocumentationOnlyChange')), eq(dependencies.EvaluateDocumentationOnlyChange.outputs['CheckDocumentationOnlyChange.onlyDocChanged'], '0'))
+  condition: ${{ parameters.runUnlessDocumentationOnly }}
   displayName: "Linux Core"
   pool:
     ${{ if eq(variables['System.TeamProject'], 'public') }}:
@@ -455,7 +465,7 @@ jobs:
 
 - job: CoreOnMac
   dependsOn: EvaluateDocumentationOnlyChange
-  condition: or(not(succeeded('EvaluateDocumentationOnlyChange')), eq(dependencies.EvaluateDocumentationOnlyChange.outputs['CheckDocumentationOnlyChange.onlyDocChanged'], '0'))
+  condition: ${{ parameters.runUnlessDocumentationOnly }}
   displayName: "macOS Core"
   pool:
     vmImage: 'macOS-latest'
@@ -553,7 +563,7 @@ jobs:
   - FullReleaseOnWindows
   - CoreBootstrappedOnLinux
   - CoreOnMac
-  condition: and(succeeded(), or(not(succeeded('EvaluateDocumentationOnlyChange')), eq(dependencies.EvaluateDocumentationOnlyChange.outputs['CheckDocumentationOnlyChange.onlyDocChanged'], '0')))
+  condition: and(succeeded(), ${{ parameters.runUnlessDocumentationOnly }})
   variables:
     onlyDocChanged: $[ dependencies.EvaluateDocumentationOnlyChange.outputs['CheckDocumentationOnlyChange.onlyDocChanged'] ]
   pool:
@@ -625,4 +635,4 @@ jobs:
       container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream-10-amd64'
       jobProperties:
         dependsOn: EvaluateDocumentationOnlyChange
-        condition: or(not(succeeded('EvaluateDocumentationOnlyChange')), eq(dependencies.EvaluateDocumentationOnlyChange.outputs['CheckDocumentationOnlyChange.onlyDocChanged'], '0'))
+        condition: ${{ parameters.runUnlessDocumentationOnly }}

--- a/.vsts-dotnet-ci.yml
+++ b/.vsts-dotnet-ci.yml
@@ -35,12 +35,17 @@ jobs:
 # when it reports onlyDocChanged=1, so a docs-only PR never waits on the build pools.
 - job: EvaluateDocumentationOnlyChange
   displayName: "Evaluate documentation-only change"
+  # Runs on the Microsoft-hosted pool (free and uncongested for this public project), NOT the
+  # self-hosted NetCore-Public pool that the heavy legs use. This always-on gate exists only to let
+  # a docs-only PR skip the heavy legs without allocating a self-hosted agent; running it on the
+  # self-hosted pool would add it to the very queue it is meant to relieve. So: a docs-only PR
+  # allocates zero self-hosted agents, and a code PR waits only for this short hosted job before the
+  # heavy legs start.
+  # NOTE: the true zero-job fix is a Path filter on the AzDO branch-policy build validation for this
+  # pipeline (exclude documentation/* and .github/*). If that is ever configured, this gate job and
+  # every "condition: ${{ parameters.runUnlessDocumentationOnly }}" below can be removed.
   pool:
-    ${{ if eq(variables['System.TeamProject'], 'public') }}:
-      name: NetCore-Public
-      demands: ImageOverride -equals Build.Ubuntu.2204.Amd64.Open
-    ${{ if ne(variables['System.TeamProject'], 'public') }}:
-      vmImage: 'ubuntu-latest'
+    vmImage: 'ubuntu-latest'
   steps:
   - template: azure-pipelines/check-documentation-only-change.yml
 

--- a/.vsts-dotnet-ci.yml
+++ b/.vsts-dotnet-ci.yml
@@ -20,7 +20,23 @@ variables:
   value: none
 
 jobs:
+# Lightweight gate: determine once whether the PR changed only documentation/.github files.
+# Every heavy build/test job depends on this and is skipped entirely -- no agent is allocated --
+# when it reports onlyDocChanged=1, so a docs-only PR never waits on the build pools.
+- job: EvaluateDocumentationOnlyChange
+  displayName: "Evaluate documentation-only change"
+  pool:
+    ${{ if eq(variables['System.TeamProject'], 'public') }}:
+      name: NetCore-Public
+      demands: ImageOverride -equals Build.Ubuntu.2204.Amd64.Open
+    ${{ if ne(variables['System.TeamProject'], 'public') }}:
+      vmImage: 'ubuntu-latest'
+  steps:
+  - template: azure-pipelines/check-documentation-only-change.yml
+
 - job: BootstrapMSBuildOnFullFrameworkWindows
+  dependsOn: EvaluateDocumentationOnlyChange
+  condition: eq(dependencies.EvaluateDocumentationOnlyChange.outputs['CheckDocumentationOnlyChange.onlyDocChanged'], '0')
   variables:
     coverageArtifactsDir: $(Build.SourcesDirectory)/CoverageStaging
     coverageReportName: WindowsFullFrameworkCoverage
@@ -134,6 +150,8 @@ jobs:
       ArtifactName: 'Windows-on-full Verify $(System.JobAttempt)'
 
 - job: BootstrapMSBuildOnCoreWindows
+  dependsOn: EvaluateDocumentationOnlyChange
+  condition: eq(dependencies.EvaluateDocumentationOnlyChange.outputs['CheckDocumentationOnlyChange.onlyDocChanged'], '0')
   displayName: "Windows Core"
   variables:
     coverageArtifactsDir: $(Build.SourcesDirectory)/CoverageStaging
@@ -222,6 +240,8 @@ jobs:
 # kept as a separate Linux Core job because the analyzer is more expensive and the regular
 # bootstrapped CI jobs (which all run /mt now too) do not need it.
 - job: BootstrapMSBuildWithMTMode
+  dependsOn: EvaluateDocumentationOnlyChange
+  condition: eq(dependencies.EvaluateDocumentationOnlyChange.outputs['CheckDocumentationOnlyChange.onlyDocChanged'], '0')
   displayName: "Linux Core Multithreaded Mode"
   pool:
     vmImage: 'ubuntu-latest'
@@ -252,6 +272,8 @@ jobs:
     condition: always()
 
 - job: FullReleaseOnWindows
+  dependsOn: EvaluateDocumentationOnlyChange
+  condition: eq(dependencies.EvaluateDocumentationOnlyChange.outputs['CheckDocumentationOnlyChange.onlyDocChanged'], '0')
   displayName: "Windows Full Release (no bootstrap)"
   variables:
     coverageArtifactsDir: $(Build.SourcesDirectory)/CoverageStaging
@@ -335,6 +357,8 @@ jobs:
     condition: eq(variables.onlyDocChanged, 0)
 
 - job: CoreBootstrappedOnLinux
+  dependsOn: EvaluateDocumentationOnlyChange
+  condition: eq(dependencies.EvaluateDocumentationOnlyChange.outputs['CheckDocumentationOnlyChange.onlyDocChanged'], '0')
   displayName: "Linux Core"
   pool:
     ${{ if eq(variables['System.TeamProject'], 'public') }}:
@@ -430,6 +454,8 @@ jobs:
       ArtifactName: 'Linux Verify $(System.JobAttempt)'
 
 - job: CoreOnMac
+  dependsOn: EvaluateDocumentationOnlyChange
+  condition: eq(dependencies.EvaluateDocumentationOnlyChange.outputs['CheckDocumentationOnlyChange.onlyDocChanged'], '0')
   displayName: "macOS Core"
   pool:
     vmImage: 'macOS-latest'
@@ -521,13 +547,15 @@ jobs:
 - job: CodeCoverage
   displayName: "Code Coverage"
   dependsOn:
+  - EvaluateDocumentationOnlyChange
   - BootstrapMSBuildOnFullFrameworkWindows
   - BootstrapMSBuildOnCoreWindows
   - FullReleaseOnWindows
   - CoreBootstrappedOnLinux
   - CoreOnMac
+  condition: and(succeeded(), eq(dependencies.EvaluateDocumentationOnlyChange.outputs['CheckDocumentationOnlyChange.onlyDocChanged'], '0'))
   variables:
-    onlyDocChanged: $[ dependencies.BootstrapMSBuildOnFullFrameworkWindows.outputs['CheckDocumentationOnlyChange.onlyDocChanged'] ]
+    onlyDocChanged: $[ dependencies.EvaluateDocumentationOnlyChange.outputs['CheckDocumentationOnlyChange.onlyDocChanged'] ]
   pool:
     ${{ if eq(variables['System.TeamProject'], 'public') }}:
       name: NetCore-Public
@@ -590,3 +618,11 @@ jobs:
       pathToSources: $(Build.SourcesDirectory)
     condition: eq(variables.onlyDocChanged, 0)
 - template: /eng/common/templates/jobs/source-build.yml
+  parameters:
+    # Skip the source-build leg entirely (no agent allocated) for documentation/.github-only PRs.
+    defaultManagedPlatform:
+      name: 'Managed'
+      container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream-10-amd64'
+      jobProperties:
+        dependsOn: EvaluateDocumentationOnlyChange
+        condition: eq(dependencies.EvaluateDocumentationOnlyChange.outputs['CheckDocumentationOnlyChange.onlyDocChanged'], '0')

--- a/azure-pipelines/check-documentation-only-change.yml
+++ b/azure-pipelines/check-documentation-only-change.yml
@@ -1,20 +1,42 @@
 # Template to check if only non-build files have changed (documentation and .github)
 # Sets a pipeline variable 'onlyDocChanged' to 1 if only non-build files changed, 0 otherwise
 # This template should be included at the start of test jobs to determine if tests should run
+#
+# Diff semantics:
+#   For PR validation builds Azure DevOps checks out the GitHub-generated merge ref
+#   (refs/pull/<N>/merge). Its first parent (HEAD~1) is the tip of the PR's base branch,
+#   so 'git diff HEAD HEAD~1' is the FULL cumulative PR diff regardless of how many
+#   commits the PR contains -- not just the last commit.
+#
+# Fail-open:
+#   Detection defaults to onlyDocChanged=0 (run full CI) on any git error or an empty
+#   diff. This is the safe direction: a detection problem never skips CI for a code
+#   change, it only ever runs more than strictly necessary. Job-level conditions layer
+#   a second fail-open on top (they run when this gate job does not succeed).
 
 steps:
 - powershell: |
-    $changedFiles = git diff --name-only HEAD HEAD~1
-    $changedFiles
-    $onlyDocChanged = 1
-    foreach ($file in $changedFiles) {
-      $isNonBuildFile = ($file -match "^documentation/") -or ($file -match "^\.github/")
-      if(!$isNonBuildFile)
-      {
-        $onlyDocChanged = 0
-        break;
+    $onlyDocChanged = 0
+    try {
+      $changedFiles = git diff --name-only HEAD HEAD~1
+      if ($LASTEXITCODE -ne 0) { throw "git diff exited with code $LASTEXITCODE" }
+      $changedFiles
+      if ($changedFiles) {
+        $onlyDocChanged = 1
+        foreach ($file in $changedFiles) {
+          $isNonBuildFile = ($file -match "^documentation/") -or ($file -match "^\.github/")
+          if (!$isNonBuildFile) {
+            $onlyDocChanged = 0
+            break
+          }
+        }
       }
     }
+    catch {
+      Write-Host "Documentation-only detection failed; defaulting to running full CI. $_"
+      $onlyDocChanged = 0
+    }
+    Write-Host "onlyDocChanged=$onlyDocChanged"
     Write-Host "##vso[task.setvariable variable=onlyDocChanged]$onlyDocChanged"
     Write-Host "##vso[task.setvariable variable=onlyDocChanged;isoutput=true]$onlyDocChanged"
   name: CheckDocumentationOnlyChange

--- a/azure-pipelines/quarantine.yml
+++ b/azure-pipelines/quarantine.yml
@@ -72,9 +72,10 @@ jobs:
 # run, so the quarantined-test signal keeps tracking main regardless of this gate.
 - job: EvaluateDocumentationOnlyChange
   displayName: "Evaluate documentation-only change"
+  # Microsoft-hosted (free and uncongested for public), not the self-hosted NetCore-Public pool the
+  # quarantine legs use, so this always-on gate never adds to that queue.
   pool:
-    name: NetCore-Public
-    demands: ImageOverride -equals Build.Ubuntu.2204.Amd64.Open
+    vmImage: 'ubuntu-latest'
   steps:
   - template: azure-pipelines/check-documentation-only-change.yml
 

--- a/azure-pipelines/quarantine.yml
+++ b/azure-pipelines/quarantine.yml
@@ -72,7 +72,7 @@ jobs:
 - job: RunQuarantinedTestsWindows
   displayName: "Run quarantined tests (Windows)"
   dependsOn: EvaluateDocumentationOnlyChange
-  condition: or(ne(variables['Build.Reason'], 'PullRequest'), eq(dependencies.EvaluateDocumentationOnlyChange.outputs['CheckDocumentationOnlyChange.onlyDocChanged'], '0'))
+  condition: or(ne(variables['Build.Reason'], 'PullRequest'), not(succeeded('EvaluateDocumentationOnlyChange')), eq(dependencies.EvaluateDocumentationOnlyChange.outputs['CheckDocumentationOnlyChange.onlyDocChanged'], '0'))
   pool:
     name: NetCore-Public
     demands: ImageOverride -equals windows.vs2026preview.scout.amd64.open
@@ -127,7 +127,7 @@ jobs:
 - job: RunQuarantinedTestsLinux
   displayName: "Run quarantined tests (Linux)"
   dependsOn: EvaluateDocumentationOnlyChange
-  condition: or(ne(variables['Build.Reason'], 'PullRequest'), eq(dependencies.EvaluateDocumentationOnlyChange.outputs['CheckDocumentationOnlyChange.onlyDocChanged'], '0'))
+  condition: or(ne(variables['Build.Reason'], 'PullRequest'), not(succeeded('EvaluateDocumentationOnlyChange')), eq(dependencies.EvaluateDocumentationOnlyChange.outputs['CheckDocumentationOnlyChange.onlyDocChanged'], '0'))
   pool:
     name: NetCore-Public
     demands: ImageOverride -equals Build.Ubuntu.2204.Amd64.Open
@@ -171,7 +171,7 @@ jobs:
 - job: RunQuarantinedTestsMac
   displayName: "Run quarantined tests (macOS)"
   dependsOn: EvaluateDocumentationOnlyChange
-  condition: or(ne(variables['Build.Reason'], 'PullRequest'), eq(dependencies.EvaluateDocumentationOnlyChange.outputs['CheckDocumentationOnlyChange.onlyDocChanged'], '0'))
+  condition: or(ne(variables['Build.Reason'], 'PullRequest'), not(succeeded('EvaluateDocumentationOnlyChange')), eq(dependencies.EvaluateDocumentationOnlyChange.outputs['CheckDocumentationOnlyChange.onlyDocChanged'], '0'))
   pool:
     vmImage: 'macOS-latest'
   timeoutInMinutes: 120

--- a/azure-pipelines/quarantine.yml
+++ b/azure-pipelines/quarantine.yml
@@ -29,6 +29,15 @@
 # targeting `main` (so a fix PR's effect on the quarantined tests is validated on the PR itself), and
 # manual queue. Consumers that aggregate this data treat rolling and scheduled `main` runs the same
 # (reasons batchedCI/individualCI/schedule), so the mix of triggers is transparent to them.
+parameters:
+# Condition (compile-time constant) reused by every quarantine leg. Runs the leg on any non-PR build
+# (rolling/batched and scheduled re-validation on main), or -- fail-open -- if the gate did not
+# succeed, or when the gate classified the PR as documentation/.github-only. Authored once here and
+# referenced via ${{ parameters.runUnlessDocumentationOnly }} instead of copied onto each job.
+- name: runUnlessDocumentationOnly
+  type: string
+  default: "or(ne(variables['Build.Reason'], 'PullRequest'), not(succeeded('EvaluateDocumentationOnlyChange')), eq(dependencies.EvaluateDocumentationOnlyChange.outputs['CheckDocumentationOnlyChange.onlyDocChanged'], '0'))"
+
 trigger:
   batch: true
   branches:
@@ -72,7 +81,7 @@ jobs:
 - job: RunQuarantinedTestsWindows
   displayName: "Run quarantined tests (Windows)"
   dependsOn: EvaluateDocumentationOnlyChange
-  condition: or(ne(variables['Build.Reason'], 'PullRequest'), not(succeeded('EvaluateDocumentationOnlyChange')), eq(dependencies.EvaluateDocumentationOnlyChange.outputs['CheckDocumentationOnlyChange.onlyDocChanged'], '0'))
+  condition: ${{ parameters.runUnlessDocumentationOnly }}
   pool:
     name: NetCore-Public
     demands: ImageOverride -equals windows.vs2026preview.scout.amd64.open
@@ -127,7 +136,7 @@ jobs:
 - job: RunQuarantinedTestsLinux
   displayName: "Run quarantined tests (Linux)"
   dependsOn: EvaluateDocumentationOnlyChange
-  condition: or(ne(variables['Build.Reason'], 'PullRequest'), not(succeeded('EvaluateDocumentationOnlyChange')), eq(dependencies.EvaluateDocumentationOnlyChange.outputs['CheckDocumentationOnlyChange.onlyDocChanged'], '0'))
+  condition: ${{ parameters.runUnlessDocumentationOnly }}
   pool:
     name: NetCore-Public
     demands: ImageOverride -equals Build.Ubuntu.2204.Amd64.Open
@@ -171,7 +180,7 @@ jobs:
 - job: RunQuarantinedTestsMac
   displayName: "Run quarantined tests (macOS)"
   dependsOn: EvaluateDocumentationOnlyChange
-  condition: or(ne(variables['Build.Reason'], 'PullRequest'), not(succeeded('EvaluateDocumentationOnlyChange')), eq(dependencies.EvaluateDocumentationOnlyChange.outputs['CheckDocumentationOnlyChange.onlyDocChanged'], '0'))
+  condition: ${{ parameters.runUnlessDocumentationOnly }}
   pool:
     vmImage: 'macOS-latest'
   timeoutInMinutes: 120

--- a/azure-pipelines/quarantine.yml
+++ b/azure-pipelines/quarantine.yml
@@ -72,10 +72,9 @@ jobs:
 # run, so the quarantined-test signal keeps tracking main regardless of this gate.
 - job: EvaluateDocumentationOnlyChange
   displayName: "Evaluate documentation-only change"
-  # Microsoft-hosted (free and uncongested for public), not the self-hosted NetCore-Public pool the
-  # quarantine legs use, so this always-on gate never adds to that queue.
   pool:
-    vmImage: 'ubuntu-latest'
+    name: NetCore-Public
+    demands: ImageOverride -equals Build.Ubuntu.2204.Amd64.Open
   steps:
   - template: azure-pipelines/check-documentation-only-change.yml
 

--- a/azure-pipelines/quarantine.yml
+++ b/azure-pipelines/quarantine.yml
@@ -57,8 +57,22 @@ variables:
   value: false
 
 jobs:
+# Lightweight gate: determine once whether the PR changed only documentation/.github files.
+# The quarantine legs depend on this and are skipped entirely -- no agent is allocated -- for a
+# docs-only pull request. Non-PR runs (rolling/batched and scheduled re-validation on main) always
+# run, so the quarantined-test signal keeps tracking main regardless of this gate.
+- job: EvaluateDocumentationOnlyChange
+  displayName: "Evaluate documentation-only change"
+  pool:
+    name: NetCore-Public
+    demands: ImageOverride -equals Build.Ubuntu.2204.Amd64.Open
+  steps:
+  - template: azure-pipelines/check-documentation-only-change.yml
+
 - job: RunQuarantinedTestsWindows
   displayName: "Run quarantined tests (Windows)"
+  dependsOn: EvaluateDocumentationOnlyChange
+  condition: or(ne(variables['Build.Reason'], 'PullRequest'), eq(dependencies.EvaluateDocumentationOnlyChange.outputs['CheckDocumentationOnlyChange.onlyDocChanged'], '0'))
   pool:
     name: NetCore-Public
     demands: ImageOverride -equals windows.vs2026preview.scout.amd64.open
@@ -112,6 +126,8 @@ jobs:
 
 - job: RunQuarantinedTestsLinux
   displayName: "Run quarantined tests (Linux)"
+  dependsOn: EvaluateDocumentationOnlyChange
+  condition: or(ne(variables['Build.Reason'], 'PullRequest'), eq(dependencies.EvaluateDocumentationOnlyChange.outputs['CheckDocumentationOnlyChange.onlyDocChanged'], '0'))
   pool:
     name: NetCore-Public
     demands: ImageOverride -equals Build.Ubuntu.2204.Amd64.Open
@@ -154,6 +170,8 @@ jobs:
 
 - job: RunQuarantinedTestsMac
   displayName: "Run quarantined tests (macOS)"
+  dependsOn: EvaluateDocumentationOnlyChange
+  condition: or(ne(variables['Build.Reason'], 'PullRequest'), eq(dependencies.EvaluateDocumentationOnlyChange.outputs['CheckDocumentationOnlyChange.onlyDocChanged'], '0'))
   pool:
     vmImage: 'macOS-latest'
   timeoutInMinutes: 120


### PR DESCRIPTION
## Problem

The previous docs-only optimization (#14371) gated the heavy **steps** of each CI leg with `condition: eq(variables.onlyDocChanged, 0)`. That still allocated an agent for **every** leg — a docs-only PR would sit waiting for machine allocation across all legs (Windows Full/Core, Linux, macOS, MT, Full Release, Code Coverage, Source-Build) before skipping the actual build. As seen on the mock PR, a leg can get stuck waiting on the pool even though it does nothing.

## Fix

Gate at the **job** level so a docs-only PR never requests an agent for the heavy legs:

- Add one lightweight `EvaluateDocumentationOnlyChange` job that runs the existing detection template once and exposes `onlyDocChanged` as an **output variable**.
- Every heavy job in `.vsts-dotnet-ci.yml` now `dependsOn` it and carries a job-level `condition: eq(dependencies.EvaluateDocumentationOnlyChange.outputs['CheckDocumentationOnlyChange.onlyDocChanged'], '0')`. Skipped jobs allocate no machine.
- The templated **source-build** leg is gated the same way via `jobProperties` (no changes to Arcade-managed `eng/common`).
- `azure-pipelines/quarantine.yml` gets the same treatment, but keeps the existing semantics: non-PR runs (rolling/batched and the daily schedule) **always** run, so the quarantined-test signal on `main` is unaffected — only docs-only **PR** runs are skipped.

Net effect for a documentation/`.github`-only PR: only the ~seconds-long detection job runs; all build/test legs show as *skipped* without ever waiting on a pool. Real code PRs are unaffected (this PR itself touches pipeline YAML, so it runs full CI).

The per-job detection step is intentionally retained inside each heavy job so the existing per-step conditions and the `-onlyDocChanged` script argument keep working unchanged when a leg does run.
</body>
<draft>true</draft>
</invoke>