### PR TITLE
[mock] validate job-level CI skip for .github-only PR

### DIFF
--- a/.github/ci-validation-mock.md
+++ b/.github/ci-validation-mock.md
@@ -1,0 +1,4 @@
+# CI validation (mock)
+
+Validates that a documentation/.github-only PR skips the whole CI legs
+(job-level condition) without allocating agents. Safe to delete.


### PR DESCRIPTION
Throwaway validation for #14384. Touches only `.github/**`; with job-level gating every heavy leg should be **skipped** (no agent allocated), only the detection job runs. Closed after inspection.