### PR TITLE
Expose item glob patterns via MSBuildProvideItemGlobs

### DIFF
--- a/documentation/Built-in-Properties.md
+++ b/documentation/Built-in-Properties.md
@@ -28,7 +28,35 @@ Each imported file appears at most once (first occurrence in depth-first evaluat
 
 Implementation: items are synthesized in [`Evaluator.SynthesizeImportedProjectItems()`][synthesizeimporteditems] at the start of the items evaluation pass.
 
+## Synthesized item glob items
+
+When the property `MSBuildProvideItemGlobs` is set to a semicolon-separated list of item types (e.g. `Compile;Content`), the engine synthesizes `MSBuildItemGlob` items during evaluation that expose the *unevaluated* include/exclude/remove glob patterns of those item types. This lets a target or task — or any consumer of the build output — recover the wildcard patterns of a project (with their precedence) without re-running evaluation or hosting the MSBuild API.
+
+For each include element of a listed item type that contributes globs, one item is synthesized with:
+
+- **Identity** — the item type (e.g. `Compile`). Multiple include elements of the same type each produce their own item; identities repeat.
+- **`Include`** metadata — the include glob pattern(s) of the element (semicolon-separated, property references expanded, wildcards preserved).
+- **`Exclude`** metadata — the exclude pattern(s) present on the element (literals and globs).
+- **`Remove`** metadata — the remove pattern(s) that apply to the element (literals and globs).
+
+`MSBuildProvideItemGlobs` is intended primarily for tooling that consumes the build output — for example a file watcher or a language service deciding whether a file belongs to the project. It can be set in the project file, in a `Directory.Build.props`, through `ProjectCollection.GlobalProperties`, or as a command-line global property. The synthesized items are regular MSBuild items, so they serialize to out-of-proc worker nodes and are available to any target or task. Projects that don't set the property pay zero cost.
+
+> [!IMPORTANT]
+> On the command line the value separator (`;`) must be escaped as `%3B`, because MSBuild's `/property` (`/p`) switch splits its argument on both `;` and `,`. For example, `/p:MSBuildProvideItemGlobs=Compile%3BContent` sets the value to `Compile;Content`, whereas an unescaped `Compile;Content` (or `Compile,Content`) would be parsed as two separate properties. This only affects command-line callers; values set in a project file or through `GlobalProperties` need no escaping.
+
+The patterns live in metadata (never in the item's include), so they are never expanded against the file system. Items are emitted in document order, and each carries only the removes that apply to it (i.e. removes that appear after it), so replaying the records reproduces the authored include/exclude/remove precedence. The data matches what [`Project.GetAllGlobs()`][getallglobs] returns for the item type; both share [`GlobResultBuilder`][globresultbuilder]. Literal (non-glob) *includes* are omitted (a change to a literally-included file is always accompanied by a project-file change), while literal excludes and removes are retained.
+
+Each metadata value is a standard MSBuild-escaped, semicolon-separated list — separator and escape characters that occur *within* a pattern are escaped (a literal `;` becomes `%3B`, a literal `%` becomes `%25`, and so on). For the common case, where patterns contain no literal `;` or `%`, splitting the value on `;` recovers the patterns exactly. To recover patterns that themselves contain a literal `;` (for example a directory named `a;b`, which is escaped to `a%3Bb`) without ambiguity, split the *escaped* value (e.g. `ITaskItem2.GetMetadataValueEscaped`) and unescape each element, exactly as MSBuild treats item lists — naively splitting the fully-unescaped value would merge such a pattern's embedded `;` with the list separator. Literal semicolons in file paths are rare, so in practice a plain split of the unescaped value is sufficient.
+
+Implementation: items are synthesized in [`Evaluator.SynthesizeItemGlobItems()`][synthesizeitemglobitems] at the end of the items evaluation pass, after all items have been evaluated.
+
 [synthesizeimporteditems]: https://github.com/dotnet/msbuild/blob/main/src/Build/Evaluation/Evaluator.cs
+
+[synthesizeitemglobitems]: https://github.com/dotnet/msbuild/blob/main/src/Build/Evaluation/Evaluator.cs
+
+[getallglobs]: https://github.com/dotnet/msbuild/blob/main/src/Build/Definition/Project.cs
+
+[globresultbuilder]: https://github.com/dotnet/msbuild/blob/main/src/Build/Evaluation/GlobResultBuilder.cs
 
 [addbuiltinproperties]: https://github.com/dotnet/msbuild/blob/24b33188f385cee07804cc63ec805216b3f8b72f/src/Build/Evaluation/Evaluator.cs#L609-L612
 

--- a/src/Build.UnitTests/Evaluation/ItemGlobs_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/ItemGlobs_Tests.cs
@@ -1,0 +1,405 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Build.Evaluation;
+using Microsoft.Build.Execution;
+using Microsoft.Build.Shared;
+using Microsoft.Build.UnitTests;
+using Shouldly;
+using Xunit;
+
+namespace Microsoft.Build.UnitTests.Evaluation;
+
+/// <summary>
+/// Tests for the <c>MSBuildItemGlob</c> items synthesized from the include/exclude/remove globs of
+/// selected item types when the <c>MSBuildProvideItemGlobs</c> property is set.
+/// </summary>
+public sealed class ItemGlobs_Tests(ITestOutputHelper output)
+{
+    private static Project CreateProject(string body, IDictionary<string, string>? globalProperties = null)
+    {
+        string projectContent = $"""
+            <Project>
+            {body}
+            </Project>
+            """;
+
+        using ProjectRootElementFromString rootElement = new(projectContent);
+        return new Project(rootElement.Project, globalProperties, toolsVersion: null);
+    }
+
+    private static List<ProjectItem> GlobItemsFor(Project project, string itemType) =>
+        project.GetItems("MSBuildItemGlob").Where(i => i.EvaluatedInclude == itemType).ToList();
+
+    private static HashSet<string> SplitList(string value) =>
+        new(value.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries), StringComparer.Ordinal);
+
+    [Fact]
+    public void NotCreatedWithoutOptIn()
+    {
+        var project = CreateProject("""
+                <ItemGroup>
+                    <Compile Include="*.cs" />
+                </ItemGroup>
+            """);
+
+        project.GetItems("MSBuildItemGlob").ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void CreatedForRequestedItemType()
+    {
+        var project = CreateProject("""
+                <PropertyGroup>
+                    <MSBuildProvideItemGlobs>Compile</MSBuildProvideItemGlobs>
+                </PropertyGroup>
+                <ItemGroup>
+                    <Compile Include="*.cs" />
+                </ItemGroup>
+            """);
+
+        var items = GlobItemsFor(project, "Compile");
+        items.Count.ShouldBe(1);
+        items[0].EvaluatedInclude.ShouldBe("Compile");
+        items[0].GetMetadataValue("Include").ShouldBe("*.cs");
+        items[0].GetMetadataValue("Exclude").ShouldBeEmpty();
+        items[0].GetMetadataValue("Remove").ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void IncludeExcludeAndRemoveCaptured()
+    {
+        var project = CreateProject("""
+                <PropertyGroup>
+                    <MSBuildProvideItemGlobs>Compile</MSBuildProvideItemGlobs>
+                </PropertyGroup>
+                <ItemGroup>
+                    <Compile Include="*.cs" Exclude="*.g.cs" />
+                    <Compile Remove="*.designer.cs" />
+                </ItemGroup>
+            """);
+
+        var items = GlobItemsFor(project, "Compile");
+        items.Count.ShouldBe(1);
+        items[0].GetMetadataValue("Include").ShouldBe("*.cs");
+        items[0].GetMetadataValue("Exclude").ShouldBe("*.g.cs");
+        items[0].GetMetadataValue("Remove").ShouldBe("*.designer.cs");
+    }
+
+    [Fact]
+    public void LiteralExcludesAndRemovesArePreserved()
+    {
+        // Literal (non-glob) excludes and removes must be retained; only literal *includes* are dropped.
+        var project = CreateProject("""
+                <PropertyGroup>
+                    <MSBuildProvideItemGlobs>Compile</MSBuildProvideItemGlobs>
+                </PropertyGroup>
+                <ItemGroup>
+                    <Compile Include="*.cs" Exclude="Special.cs" />
+                    <Compile Remove="Legacy.cs" />
+                </ItemGroup>
+            """);
+
+        var items = GlobItemsFor(project, "Compile");
+        items.Count.ShouldBe(1);
+        items[0].GetMetadataValue("Exclude").ShouldBe("Special.cs");
+        items[0].GetMetadataValue("Remove").ShouldBe("Legacy.cs");
+    }
+
+    [Fact]
+    public void LiteralOnlyIncludeProducesNoItem()
+    {
+        // An include with no wildcards contributes no glob, matching Project.GetAllGlobs.
+        var project = CreateProject("""
+                <PropertyGroup>
+                    <MSBuildProvideItemGlobs>Compile</MSBuildProvideItemGlobs>
+                </PropertyGroup>
+                <ItemGroup>
+                    <Compile Include="Program.cs" />
+                </ItemGroup>
+            """);
+
+        GlobItemsFor(project, "Compile").ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void OnlyRequestedItemTypesAreExposed()
+    {
+        var project = CreateProject("""
+                <PropertyGroup>
+                    <MSBuildProvideItemGlobs>Compile</MSBuildProvideItemGlobs>
+                </PropertyGroup>
+                <ItemGroup>
+                    <Compile Include="*.cs" />
+                    <Content Include="*.txt" />
+                </ItemGroup>
+            """);
+
+        GlobItemsFor(project, "Compile").Count.ShouldBe(1);
+        GlobItemsFor(project, "Content").ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void MultipleItemTypesAreExposed()
+    {
+        var project = CreateProject("""
+                <PropertyGroup>
+                    <MSBuildProvideItemGlobs>Compile;Content</MSBuildProvideItemGlobs>
+                </PropertyGroup>
+                <ItemGroup>
+                    <Compile Include="*.cs" />
+                    <Content Include="*.txt" />
+                </ItemGroup>
+            """);
+
+        GlobItemsFor(project, "Compile").Single().GetMetadataValue("Include").ShouldBe("*.cs");
+        GlobItemsFor(project, "Content").Single().GetMetadataValue("Include").ShouldBe("*.txt");
+    }
+
+    [Fact]
+    public void PropertyReferencesAreExpandedButWildcardsPreserved()
+    {
+        var project = CreateProject("""
+                <PropertyGroup>
+                    <MSBuildProvideItemGlobs>Compile</MSBuildProvideItemGlobs>
+                    <Prefix>generated</Prefix>
+                </PropertyGroup>
+                <ItemGroup>
+                    <Compile Include="$(Prefix)_*.cs" />
+                </ItemGroup>
+            """);
+
+        GlobItemsFor(project, "Compile").Single().GetMetadataValue("Include").ShouldBe("generated_*.cs");
+    }
+
+    [Fact]
+    public void DocumentOrderIsPreserved()
+    {
+        var project = CreateProject("""
+                <PropertyGroup>
+                    <MSBuildProvideItemGlobs>Compile</MSBuildProvideItemGlobs>
+                </PropertyGroup>
+                <ItemGroup>
+                    <Compile Include="a*.cs" />
+                    <Compile Include="b*.cs" />
+                    <Compile Include="c*.cs" />
+                </ItemGroup>
+            """);
+
+        var includes = GlobItemsFor(project, "Compile").Select(i => i.GetMetadataValue("Include")).ToList();
+        includes.ShouldBe(new[] { "a*.cs", "b*.cs", "c*.cs" });
+    }
+
+    [Fact]
+    public void RemoveIsAttributedOnlyToPrecedingIncludes()
+    {
+        // <Compile Include="*.cs"/> then Remove then a re-including glob. The remove applies only to the
+        // first include; the later "re-add" glob must not be attributed the earlier remove.
+        var project = CreateProject("""
+                <PropertyGroup>
+                    <MSBuildProvideItemGlobs>Compile</MSBuildProvideItemGlobs>
+                </PropertyGroup>
+                <ItemGroup>
+                    <Compile Include="*.cs" />
+                    <Compile Remove="Generated.cs" />
+                    <Compile Include="Generated*.cs" />
+                </ItemGroup>
+            """);
+
+        var items = GlobItemsFor(project, "Compile");
+        items.Count.ShouldBe(2);
+
+        // Document order: first the "*.cs" include (which the remove applies to)...
+        items[0].GetMetadataValue("Include").ShouldBe("*.cs");
+        items[0].GetMetadataValue("Remove").ShouldBe("Generated.cs");
+
+        // ...then the re-adding glob, which must NOT carry the earlier remove.
+        items[1].GetMetadataValue("Include").ShouldBe("Generated*.cs");
+        items[1].GetMetadataValue("Remove").ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void ConditionedOutElementsAreNotExposed()
+    {
+        var project = CreateProject("""
+                <PropertyGroup>
+                    <MSBuildProvideItemGlobs>Compile</MSBuildProvideItemGlobs>
+                </PropertyGroup>
+                <ItemGroup>
+                    <Compile Include="kept*.cs" />
+                    <Compile Include="dropped*.cs" Condition="false" />
+                </ItemGroup>
+            """);
+
+        var includes = GlobItemsFor(project, "Compile").Select(i => i.GetMetadataValue("Include")).ToList();
+        includes.ShouldBe(new[] { "kept*.cs" });
+    }
+
+    [Fact]
+    public void CreatedWhenSetViaGlobalProperty()
+    {
+        var globalProperties = new Dictionary<string, string>
+        {
+            { "MSBuildProvideItemGlobs", "Compile" },
+        };
+
+        var project = CreateProject("""
+                <ItemGroup>
+                    <Compile Include="*.cs" />
+                </ItemGroup>
+            """,
+            globalProperties);
+
+        GlobItemsFor(project, "Compile").Single().GetMetadataValue("Include").ShouldBe("*.cs");
+    }
+
+    [Fact]
+    public void ItemsAreIdenticalOnProjectAndProjectInstance()
+    {
+        // rainersigwald's requirement from #13681: items must not differ between Project and ProjectInstance.
+        var project = CreateProject("""
+                <PropertyGroup>
+                    <MSBuildProvideItemGlobs>Compile</MSBuildProvideItemGlobs>
+                </PropertyGroup>
+                <ItemGroup>
+                    <Compile Include="*.cs" Exclude="*.g.cs" />
+                </ItemGroup>
+            """);
+
+        var projectItem = GlobItemsFor(project, "Compile").Single();
+
+        ProjectInstance instance = project.CreateProjectInstance();
+        var instanceItems = instance.GetItems("MSBuildItemGlob").Where(i => i.EvaluatedInclude == "Compile").ToList();
+        instanceItems.Count.ShouldBe(1);
+
+        instanceItems[0].GetMetadataValue("Include").ShouldBe(projectItem.GetMetadataValue("Include"));
+        instanceItems[0].GetMetadataValue("Exclude").ShouldBe(projectItem.GetMetadataValue("Exclude"));
+    }
+
+    [Fact]
+    public void MatchesGetAllGlobs()
+    {
+        // The synthesized items must carry exactly the include/exclude/remove data that
+        // Project.GetAllGlobs returns for the item type.
+        var project = CreateProject("""
+                <PropertyGroup>
+                    <MSBuildProvideItemGlobs>Compile</MSBuildProvideItemGlobs>
+                </PropertyGroup>
+                <ItemGroup>
+                    <Compile Include="*.cs" Exclude="*.g.cs" />
+                    <Compile Remove="*.designer.cs" />
+                    <Compile Include="extra_*.cs" />
+                </ItemGroup>
+            """);
+
+        List<GlobResult> globResults = project.GetAllGlobs("Compile");
+        var items = GlobItemsFor(project, "Compile");
+
+        items.Count.ShouldBe(globResults.Count);
+
+        var expected = globResults
+            .Select(g => (
+                Include: string.Join(";", g.IncludeGlobs),
+                Exclude: SplitList(string.Join(";", g.Excludes)),
+                Remove: SplitList(string.Join(";", g.Removes))))
+            .OrderBy(t => t.Include, StringComparer.Ordinal)
+            .ToList();
+
+        var actual = items
+            .Select(i => (
+                Include: i.GetMetadataValue("Include"),
+                Exclude: SplitList(i.GetMetadataValue("Exclude")),
+                Remove: SplitList(i.GetMetadataValue("Remove"))))
+            .OrderBy(t => t.Include, StringComparer.Ordinal)
+            .ToList();
+
+        actual.Select(t => t.Include).ShouldBe(expected.Select(t => t.Include));
+        for (int i = 0; i < expected.Count; i++)
+        {
+            actual[i].Exclude.ShouldBe(expected[i].Exclude);
+            actual[i].Remove.ShouldBe(expected[i].Remove);
+        }
+    }
+
+    [Fact]
+    public void PatternsWithPercentEncodingRoundTripAndMatchGetAllGlobs()
+    {
+        // A '%' in a path is authored as %25 and, after evaluation, the glob contains %NN which must not be
+        // re-interpreted as an escape sequence when read back from metadata. The synthesized values must
+        // round-trip to exactly what GetAllGlobs reports (this is the escaping edge case).
+        var project = CreateProject("""
+                <PropertyGroup>
+                    <MSBuildProvideItemGlobs>Compile</MSBuildProvideItemGlobs>
+                </PropertyGroup>
+                <ItemGroup>
+                    <Compile Include="a%2512b_*.cs" Exclude="c%2512d_*.cs" />
+                </ItemGroup>
+            """);
+
+        List<GlobResult> globResults = project.GetAllGlobs("Compile");
+        globResults.Count.ShouldBe(1);
+
+        var item = GlobItemsFor(project, "Compile").Single();
+        item.GetMetadataValue("Include").ShouldBe(string.Join(";", globResults[0].IncludeGlobs));
+        SplitList(item.GetMetadataValue("Exclude")).ShouldBe(SplitList(string.Join(";", globResults[0].Excludes)));
+
+        // The '%12' must survive as-is, not be decoded to control char 0x12.
+        item.GetMetadataValue("Include").ShouldContain("%12");
+    }
+
+    [Fact]
+    public void PatternContainingSemicolonIsRecoverableFromEscapedMetadata()
+    {
+        // A single glob pattern that itself contains a literal ';' (here a directory named "a;b",
+        // authored as %3B) is stored escaped, so it round-trips losslessly only via the escaped
+        // metadata value: split on ';' and unescape each element, the way MSBuild treats item lists.
+        var project = CreateProject("""
+                <PropertyGroup>
+                    <MSBuildProvideItemGlobs>Compile</MSBuildProvideItemGlobs>
+                </PropertyGroup>
+                <ItemGroup>
+                    <Compile Include="a%3Bb/**/*.cs;c/**/*.cs" />
+                </ItemGroup>
+            """);
+
+        // The include authors two patterns; the first contains a literal ';'.
+        List<GlobResult> globResults = project.GetAllGlobs("Compile");
+        List<string> expectedIncludes = globResults.SelectMany(g => g.IncludeGlobs).ToList();
+        expectedIncludes.ShouldBe(new[] { "a;b/**/*.cs", "c/**/*.cs" });
+
+        ProjectItem item = GlobItemsFor(project, "Compile").Single();
+
+        // Lossless recovery: split the ESCAPED value on ';', then unescape each element.
+        string escaped = item.GetMetadata("Include").EvaluatedValueEscaped;
+        List<string> recovered = escaped.Split(';').Select(s => EscapingUtilities.UnescapeAll(s)!).ToList();
+        recovered.ShouldBe(expectedIncludes);
+
+        // By contrast, naively splitting the fully-unescaped value is ambiguous: the pattern's own
+        // ';' is indistinguishable from the list separator, so it yields more elements than patterns.
+        item.GetMetadataValue("Include").Split(';').Length.ShouldBeGreaterThan(expectedIncludes.Count);
+    }
+
+    [Fact]
+    public void AvailableToTargets()
+    {
+        var project = CreateProject("""
+                <PropertyGroup>
+                    <MSBuildProvideItemGlobs>Compile</MSBuildProvideItemGlobs>
+                </PropertyGroup>
+                <ItemGroup>
+                    <Compile Include="*.cs" />
+                </ItemGroup>
+                <Target Name="ShowGlobs">
+                    <Message Text="Glob: %(MSBuildItemGlob.Identity) include=%(MSBuildItemGlob.Include)" Importance="High" />
+                </Target>
+            """);
+
+        ProjectInstance instance = project.CreateProjectInstance();
+        var mockLogger = new MockLogger(output);
+        instance.Build(new[] { "ShowGlobs" }, new[] { mockLogger }).ShouldBeTrue();
+        mockLogger.AssertLogContains("Glob: Compile include=*.cs");
+    }
+}

--- a/src/Build/Definition/Project.cs
+++ b/src/Build/Definition/Project.cs
@@ -2,9 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Buffers;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
@@ -53,16 +51,6 @@ namespace Microsoft.Build.Evaluation
         /// Whether to write information about why we evaluate to debug output.
         /// </summary>
         private static readonly bool s_debugEvaluation = (Environment.GetEnvironmentVariable("MSBUILDDEBUGEVALUATION") != null);
-
-        /// <summary>
-        /// * and ? are invalid file name characters, but they occur in globs as wild cards.
-        /// </summary>
-#if NET
-        private static readonly SearchValues<char> s_invalidGlobChars = SearchValues.Create(
-#else
-        private static readonly char[] s_invalidGlobChars = (
-#endif
-            FileUtilities.InvalidFileNameCharsArray.Where(c => c is not ('*' or '?' or '/' or '\\' or ':')).ToArray());
 
         /// <summary>
         /// Context to log messages and events in.
@@ -2564,167 +2552,9 @@ namespace Microsoft.Build.Evaluation
                 return GetAllGlobs(GetItemElementsByType(GetEvaluatedItemElements(evaluationContext), itemType));
             }
 
-            // represents cumulated remove information for a particular item type
-            private struct CumulativeRemoveElementData
-            {
-                private ImmutableList<IMSBuildGlob>.Builder _globs;
-                private ImmutableHashSet<string>.Builder _fragmentStrings;
-
-                public IEnumerable<IMSBuildGlob> Globs => _globs.ToImmutable();
-                public IEnumerable<string> FragmentStrings => _fragmentStrings.ToImmutable();
-
-                public static CumulativeRemoveElementData Create()
-                {
-                    return new CumulativeRemoveElementData
-                    {
-                        _globs = ImmutableList.CreateBuilder<IMSBuildGlob>(),
-                        _fragmentStrings = ImmutableHashSet.CreateBuilder<string>()
-                    };
-                }
-
-                public readonly void AccumulateInformationFromRemoveItemSpec(EvaluationItemSpec removeSpec)
-                {
-                    IEnumerable<string> removeSpecFragmentStrings = removeSpec.FlattenFragmentsAsStrings();
-                    var removeGlob = removeSpec.ToMSBuildGlob();
-
-                    _globs.Add(removeGlob);
-
-                    foreach (var removeFragment in removeSpecFragmentStrings)
-                    {
-                        _fragmentStrings.Add(removeFragment);
-                    }
-                }
-            }
-
             private List<GlobResult> GetAllGlobs(List<ProjectItemElement> projectItemElements)
             {
-                if (projectItemElements.Count == 0)
-                {
-                    return new List<GlobResult>();
-                }
-
-                // Scan the project elements in reverse order and build globbing information for each include element.
-                // Based on the fact that relevant removes for a particular include element (xml element A) consist of:
-                // - all the removes seen by the next include statement of A's type (xml element B which appears after A in file order)
-                // - new removes between A and B (removes that apply to A but not to B. Spacially, these are placed between A's element and B's element)
-
-                // Example:
-                // 1. <I Include="A"/>
-                // 2. <I Remove="..."/> // this remove applies to the include at 1
-                // 3. <I Include="B"/>
-                // 4. <I Remove="..."/> // this remove applies to the includes at 1, 3
-                // 5. <I Include="C"/>
-                // 6. <I Remove="..."/> // this remove applies to the includes at 1, 3, 5
-                // So A's applicable removes are composed of:
-                //
-                // The applicable removes for the element at position 1 (xml element A) are composed of:
-                // - all the removes seen by the next include statement of I's type (xml element B, position 3, which appears after A in file order). In this example that's Removes at positions 4 and 6.
-                // - new removes between A and B. In this example that's Remove 2.
-
-                // use immutable builders because there will be a lot of structural sharing between includes which share increasing subsets of corresponding remove elements
-                // item type -> aggregated information about all removes seen so far for that item type
-                var removeElementCache = new Dictionary<string, CumulativeRemoveElementData>(projectItemElements.Count);
-                var globResults = new List<GlobResult>(projectItemElements.Count);
-
-                for (var i = projectItemElements.Count - 1; i >= 0; i--)
-                {
-                    var itemElement = projectItemElements[i];
-
-                    if (!string.IsNullOrEmpty(itemElement.Include))
-                    {
-                        var globResult = BuildGlobResultFromIncludeItem(itemElement, removeElementCache);
-
-                        if (globResult != null)
-                        {
-                            globResults.Add(globResult);
-                        }
-                    }
-                    else if (!string.IsNullOrEmpty(itemElement.Remove))
-                    {
-                        CacheInformationFromRemoveItem(itemElement, removeElementCache);
-                    }
-                }
-
-                globResults.TrimExcess();
-
-                return globResults;
-            }
-
-            private GlobResult BuildGlobResultFromIncludeItem(ProjectItemElement itemElement, IReadOnlyDictionary<string, CumulativeRemoveElementData> removeElementCache)
-            {
-                var includeItemspec = new EvaluationItemSpec(itemElement.Include, _data.Expander, itemElement.IncludeLocation, itemElement.ContainingProject.DirectoryPath);
-
-                List<ItemSpecFragment> includeGlobFragmentsList = null;
-                foreach (ItemSpecFragment fragment in includeItemspec.Fragments)
-                {
-                    if (fragment is GlobFragment && fragment.TextFragment.AsSpan().IndexOfAny(s_invalidGlobChars) < 0)
-                    {
-                        includeGlobFragmentsList ??= new List<ItemSpecFragment>(includeItemspec.Fragments.Count);
-                        includeGlobFragmentsList.Add(fragment);
-                    }
-                }
-
-                if (includeGlobFragmentsList == null || includeGlobFragmentsList.Count == 0)
-                {
-                    return null;
-                }
-
-                string[] includeGlobStrings = new string[includeGlobFragmentsList.Count];
-                for (int i = 0; i < includeGlobStrings.Length; ++i)
-                {
-                    includeGlobStrings[i] = includeGlobFragmentsList[i].TextFragment;
-                }
-
-                var includeGlob = CompositeGlob.Create(includeGlobFragmentsList.Select(f => f.ToMSBuildGlob()));
-
-                IEnumerable<string> excludeFragmentStrings = [];
-                IMSBuildGlob excludeGlob = null;
-
-                if (!string.IsNullOrEmpty(itemElement.Exclude))
-                {
-                    var excludeItemspec = new EvaluationItemSpec(itemElement.Exclude, _data.Expander, itemElement.ExcludeLocation, itemElement.ContainingProject.DirectoryPath);
-
-                    excludeFragmentStrings = excludeItemspec.FlattenFragmentsAsStrings().ToImmutableHashSet();
-                    excludeGlob = excludeItemspec.ToMSBuildGlob();
-                }
-
-                IEnumerable<string> removeFragmentStrings = [];
-                IMSBuildGlob removeGlob = null;
-
-                if (removeElementCache.TryGetValue(itemElement.ItemType, out CumulativeRemoveElementData removeItemElement))
-                {
-                    removeFragmentStrings = removeItemElement.FragmentStrings;
-                    removeGlob = CompositeGlob.Create(removeItemElement.Globs);
-                }
-
-                var includeGlobWithGaps = CreateIncludeGlobWithGaps(includeGlob, excludeGlob, removeGlob);
-
-                return new GlobResult(itemElement, includeGlobStrings.ToImmutableArray(), includeGlobWithGaps, excludeFragmentStrings, removeFragmentStrings);
-            }
-
-            private static IMSBuildGlob CreateIncludeGlobWithGaps(IMSBuildGlob includeGlob, IMSBuildGlob excludeGlob, IMSBuildGlob removeGlob)
-            {
-                return (excludeGlob, removeGlob) switch
-                {
-                    (null, null) => includeGlob,
-                    (not null, null) => new MSBuildGlobWithGaps(includeGlob, excludeGlob),
-                    (null, not null) => new MSBuildGlobWithGaps(includeGlob, removeGlob),
-                    (not null, not null) => new MSBuildGlobWithGaps(includeGlob, new CompositeGlob(excludeGlob, removeGlob))
-                };
-            }
-
-            private void CacheInformationFromRemoveItem(ProjectItemElement itemElement, Dictionary<string, CumulativeRemoveElementData> removeElementCache)
-            {
-                if (!removeElementCache.TryGetValue(itemElement.ItemType, out CumulativeRemoveElementData cumulativeRemoveElementData))
-                {
-                    cumulativeRemoveElementData = CumulativeRemoveElementData.Create();
-
-                    removeElementCache[itemElement.ItemType] = cumulativeRemoveElementData;
-                }
-
-                var removeSpec = new EvaluationItemSpec(itemElement.Remove, _data.Expander, itemElement.RemoveLocation, itemElement.ContainingProject.DirectoryPath);
-
-                cumulativeRemoveElementData.AccumulateInformationFromRemoveItemSpec(removeSpec);
+                return GlobResultBuilder.BuildGlobResults(projectItemElements, _data.Expander);
             }
 
             /// <summary>

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -81,6 +81,19 @@ namespace Microsoft.Build.Evaluation
         private readonly List<ProjectItemGroupElement> _itemGroupElements;
 
         /// <summary>
+        /// When <c>MSBuildProvideItemGlobs</c> requests glob information, the set of
+        /// item types to expose; otherwise <see langword="null"/> (the feature is off and costs nothing).
+        /// </summary>
+        private HashSet<string> _itemGlobRequestedTypes;
+
+        /// <summary>
+        /// Evaluated include/exclude/remove item elements (condition-true, in document order) of the item types in
+        /// <see cref="_itemGlobRequestedTypes"/>, collected during the items pass so that <c>MSBuildItemGlob</c>
+        /// items can be synthesized from them. <see langword="null"/> when the feature is off.
+        /// </summary>
+        private List<ProjectItemElement> _itemGlobElements;
+
+        /// <summary>
         /// List of ProjectItemDefinitionElement's traversing into imports.
         /// Gathered during the first pass to avoid traversing again.
         /// </summary>
@@ -733,6 +746,8 @@ namespace Microsoft.Build.Evaluation
 
                     SynthesizeImportedProjectItems();
 
+                    DetectItemGlobRequest();
+
                     foreach (ProjectItemGroupElement itemGroup in _itemGroupElements)
                     {
                         using (_evaluationProfiler.TrackElement(itemGroup))
@@ -766,6 +781,8 @@ namespace Microsoft.Build.Evaluation
                     // lazy evaluator can be collected now, the rest of evaluation does not need it anymore
                     lazyEvaluator = null;
                 }
+
+                SynthesizeItemGlobItems();
 
                 MSBuildEventSource.Log.EvaluatePass3Stop(projectFile);
 
@@ -2563,6 +2580,11 @@ namespace Microsoft.Build.Evaluation
             {
                 _data.EvaluatedItemElements.Add(itemElement);
             }
+
+            if (_itemGlobRequestedTypes != null && _itemGlobRequestedTypes.Contains(itemElement.ItemType))
+            {
+                _itemGlobElements.Add(itemElement);
+            }
         }
 
         /// <summary>
@@ -2722,6 +2744,92 @@ namespace Microsoft.Build.Evaluation
 
                 _data.AddItem(item);
             }
+        }
+
+        /// <summary>
+        /// Detects whether <c>MSBuildProvideItemGlobs</c> requests glob information
+        /// for one or more item types and, if so, prepares to collect their evaluated item elements. Does nothing
+        /// (and allocates nothing) when the property is unset or empty, keeping the feature zero-cost when unused.
+        /// </summary>
+        private void DetectItemGlobRequest()
+        {
+            P provideProperty = _data.GetProperty(Constants.MSBuildProvideItemGlobsPropertyName);
+            if (provideProperty is null || string.IsNullOrWhiteSpace(provideProperty.EvaluatedValue))
+            {
+                return;
+            }
+
+            _itemGlobRequestedTypes = new HashSet<string>(
+                ExpressionShredder.SplitSemiColonSeparatedList(provideProperty.EvaluatedValue),
+                StringComparer.OrdinalIgnoreCase);
+            _itemGlobElements = new List<ProjectItemElement>();
+        }
+
+        /// <summary>
+        /// When one or more item types were requested via <c>MSBuildProvideItemGlobs</c>,
+        /// synthesizes <c>MSBuildItemGlob</c> items exposing the unevaluated include/exclude/remove glob patterns of
+        /// those item types. Each include element yields one item whose identity is the item type and whose
+        /// <c>Include</c>, <c>Exclude</c> and <c>Remove</c> metadata carry the patterns with wildcards preserved.
+        /// The patterns match what <see cref="Project.GetAllGlobs()"/> returns.
+        /// </summary>
+        /// <remarks>
+        /// Called at the end of the items pass, after all items have been evaluated, so that item references in
+        /// exclude/remove specs resolve to their final values — the same point at which <c>GetAllGlobs</c> operates.
+        /// The patterns live in metadata rather than in the item's include, so they are never expanded against the
+        /// file system.
+        /// </remarks>
+        private void SynthesizeItemGlobItems()
+        {
+            if (_itemGlobElements is null || _itemGlobElements.Count == 0)
+            {
+                return;
+            }
+
+            List<GlobResult> globResults = GlobResultBuilder.BuildGlobResults(_itemGlobElements, _expander);
+            if (globResults.Count == 0)
+            {
+                return;
+            }
+
+            // Create a disconnected item element to back the factory — ProjectItemFactory derives the item type
+            // from its backing XML element.
+            ProjectItemElement syntheticItemElement = ProjectItemElement.CreateDisconnected(
+                Constants.MSBuildItemGlobItemType,
+                _projectRootElement);
+            _itemFactory.ItemElement = syntheticItemElement;
+
+            string definingProject = _projectRootElement.FullPath ?? string.Empty;
+
+            // GlobResultBuilder returns results in reverse document order; iterate in reverse so that the synthesized
+            // items appear in document order, preserving the authored include/exclude/remove precedence.
+            for (int i = globResults.Count - 1; i >= 0; i--)
+            {
+                GlobResult globResult = globResults[i];
+
+                // The identity is the item type (e.g. "Compile"). The patterns are carried in metadata, which is
+                // never expanded against the file system, so their wildcards are preserved verbatim.
+                I item = _itemFactory.CreateItem(globResult.ItemElement.ItemType, definingProject);
+
+                SetGlobMetadatum(item, Constants.ItemGlobIncludeMetadataName, globResult.IncludeGlobs);
+                SetGlobMetadatum(item, Constants.ItemGlobExcludeMetadataName, globResult.Excludes);
+                SetGlobMetadatum(item, Constants.ItemGlobRemoveMetadataName, globResult.Removes);
+
+                _data.AddItem(item);
+            }
+        }
+
+        private void SetGlobMetadatum(I item, string metadataName, IEnumerable<string> patterns)
+        {
+            ProjectMetadataElement metadataElement = ProjectMetadataElement.CreateDisconnected(metadataName, _projectRootElement);
+
+            // The pattern strings come from GlobResult: IncludeGlobs are unescaped, while Excludes/Removes are a
+            // mix of escaped literals and unescaped globs. SetMetadata expects an *escaped* value that it unescapes
+            // on read, so escape each pattern before joining. This makes %(Include)/%(Exclude)/%(Remove) round-trip
+            // to exactly the strings Project.GetAllGlobs() reports (even for patterns containing '%'), and keeps ';'
+            // an unambiguous separator. (A single glob pattern containing a literal ';' — vanishingly rare — is
+            // recoverable only from the *escaped* value: split on ';', then unescape each element. A naive split of
+            // the unescaped value cannot distinguish the pattern's own ';' from the separator.)
+            item.SetMetadata(metadataElement, string.Join(";", patterns.Select(p => EscapingUtilities.Escape(p))));
         }
 
         [Conditional("FEATURE_GUIDE_TO_VS_ON_UNSUPPORTED_PROJECTS")]

--- a/src/Build/Evaluation/GlobResultBuilder.cs
+++ b/src/Build/Evaluation/GlobResultBuilder.cs
@@ -1,0 +1,216 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+#if NET
+using System.Buffers;
+#endif
+using Microsoft.Build.Construction;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Globbing;
+
+namespace Microsoft.Build.Evaluation;
+
+/// <summary>
+/// Derives <see cref="GlobResult"/> information (the include globs of an item element together with the
+/// excludes present on it and all the removes that apply to it) from a set of
+/// <see cref="ProjectItemElement"/>s.
+/// </summary>
+/// <remarks>
+/// This logic is shared between <see cref="Project.GetAllGlobs()"/> (which runs after evaluation over the
+/// public object model) and the evaluator's synthesis of <c>MSBuildItemGlob</c> items (which runs during
+/// evaluation). Sharing a single implementation guarantees the two produce identical results, so the globs
+/// observed by a target or task during a command-line build match those returned by <c>GetAllGlobs</c>.
+/// </remarks>
+internal static class GlobResultBuilder
+{
+    /// <summary>
+    /// * and ? are invalid file name characters, but they occur in globs as wild cards.
+    /// </summary>
+#if NET
+    private static readonly SearchValues<char> s_invalidGlobChars = SearchValues.Create(
+#else
+    private static readonly char[] s_invalidGlobChars = (
+#endif
+        FileUtilities.InvalidFileNameCharsArray.Where(c => c is not ('*' or '?' or '/' or '\\' or ':')).ToArray());
+
+    /// <summary>
+    /// Builds a <see cref="GlobResult"/> for each include element in <paramref name="projectItemElements"/>
+    /// that contributes globs.
+    /// </summary>
+    /// <remarks>
+    /// The elements are scanned in reverse document order so that each include element is attributed exactly
+    /// the removes that appear after it (the removes that can affect the items it produced). Consequently the
+    /// returned list is in reverse document order (the last include element first). Because every
+    /// <see cref="GlobResult"/> already folds in its own excludes and applicable removes, membership can be
+    /// decided by testing a file against the union of the results regardless of their order.
+    /// </remarks>
+    public static List<GlobResult> BuildGlobResults<P, I>(IReadOnlyList<ProjectItemElement> projectItemElements, Expander<P, I> expander)
+        where P : class, IProperty
+        where I : class, IItem, IMetadataTable
+    {
+        if (projectItemElements.Count == 0)
+        {
+            return new List<GlobResult>();
+        }
+
+        // Scan the project elements in reverse order and build globbing information for each include element.
+        // Based on the fact that relevant removes for a particular include element (xml element A) consist of:
+        // - all the removes seen by the next include statement of A's type (xml element B which appears after A in file order)
+        // - new removes between A and B (removes that apply to A but not to B. Spatially, these are placed between A's element and B's element)
+
+        // Example:
+        // 1. <I Include="A"/>
+        // 2. <I Remove="..."/> // this remove applies to the include at 1
+        // 3. <I Include="B"/>
+        // 4. <I Remove="..."/> // this remove applies to the includes at 1, 3
+        // 5. <I Include="C"/>
+        // 6. <I Remove="..."/> // this remove applies to the includes at 1, 3, 5
+        // So A's applicable removes are composed of:
+        //
+        // The applicable removes for the element at position 1 (xml element A) are composed of:
+        // - all the removes seen by the next include statement of I's type (xml element B, position 3, which appears after A in file order). In this example that's Removes at positions 4 and 6.
+        // - new removes between A and B. In this example that's Remove 2.
+
+        // use immutable builders because there will be a lot of structural sharing between includes which share increasing subsets of corresponding remove elements
+        // item type -> aggregated information about all removes seen so far for that item type
+        var removeElementCache = new Dictionary<string, CumulativeRemoveElementData>(projectItemElements.Count);
+        var globResults = new List<GlobResult>(projectItemElements.Count);
+
+        for (var i = projectItemElements.Count - 1; i >= 0; i--)
+        {
+            var itemElement = projectItemElements[i];
+
+            if (!string.IsNullOrEmpty(itemElement.Include))
+            {
+                var globResult = BuildGlobResultFromIncludeItem(itemElement, removeElementCache, expander);
+
+                if (globResult != null)
+                {
+                    globResults.Add(globResult);
+                }
+            }
+            else if (!string.IsNullOrEmpty(itemElement.Remove))
+            {
+                CacheInformationFromRemoveItem(itemElement, removeElementCache, expander);
+            }
+        }
+
+        globResults.TrimExcess();
+
+        return globResults;
+    }
+
+    private static GlobResult? BuildGlobResultFromIncludeItem<P, I>(ProjectItemElement itemElement, IReadOnlyDictionary<string, CumulativeRemoveElementData> removeElementCache, Expander<P, I> expander)
+        where P : class, IProperty
+        where I : class, IItem, IMetadataTable
+    {
+        var includeItemspec = new ItemSpec<P, I>(itemElement.Include, expander, itemElement.IncludeLocation, itemElement.ContainingProject.DirectoryPath);
+
+        List<ItemSpecFragment>? includeGlobFragmentsList = null;
+        foreach (ItemSpecFragment fragment in includeItemspec.Fragments)
+        {
+            if (fragment is GlobFragment && fragment.TextFragment.AsSpan().IndexOfAny(s_invalidGlobChars) < 0)
+            {
+                includeGlobFragmentsList ??= new List<ItemSpecFragment>(includeItemspec.Fragments.Count);
+                includeGlobFragmentsList.Add(fragment);
+            }
+        }
+
+        if (includeGlobFragmentsList == null || includeGlobFragmentsList.Count == 0)
+        {
+            return null;
+        }
+
+        string[] includeGlobStrings = new string[includeGlobFragmentsList.Count];
+        for (int i = 0; i < includeGlobStrings.Length; ++i)
+        {
+            includeGlobStrings[i] = includeGlobFragmentsList[i].TextFragment;
+        }
+
+        var includeGlob = CompositeGlob.Create(includeGlobFragmentsList.Select(f => f.ToMSBuildGlob()));
+
+        IEnumerable<string> excludeFragmentStrings = [];
+        IMSBuildGlob? excludeGlob = null;
+
+        if (!string.IsNullOrEmpty(itemElement.Exclude))
+        {
+            var excludeItemspec = new ItemSpec<P, I>(itemElement.Exclude, expander, itemElement.ExcludeLocation, itemElement.ContainingProject.DirectoryPath);
+
+            excludeFragmentStrings = excludeItemspec.FlattenFragmentsAsStrings().ToImmutableHashSet();
+            excludeGlob = excludeItemspec.ToMSBuildGlob();
+        }
+
+        IEnumerable<string> removeFragmentStrings = [];
+        IMSBuildGlob? removeGlob = null;
+
+        if (removeElementCache.TryGetValue(itemElement.ItemType, out CumulativeRemoveElementData removeItemElement))
+        {
+            removeFragmentStrings = removeItemElement.FragmentStrings;
+            removeGlob = CompositeGlob.Create(removeItemElement.Globs);
+        }
+
+        var includeGlobWithGaps = CreateIncludeGlobWithGaps(includeGlob, excludeGlob, removeGlob);
+
+        return new GlobResult(itemElement, includeGlobStrings.ToImmutableArray(), includeGlobWithGaps, excludeFragmentStrings, removeFragmentStrings);
+    }
+
+    private static IMSBuildGlob CreateIncludeGlobWithGaps(IMSBuildGlob includeGlob, IMSBuildGlob? excludeGlob, IMSBuildGlob? removeGlob)
+    {
+        return (excludeGlob, removeGlob) switch
+        {
+            (null, null) => includeGlob,
+            (not null, null) => new MSBuildGlobWithGaps(includeGlob, excludeGlob),
+            (null, not null) => new MSBuildGlobWithGaps(includeGlob, removeGlob),
+            (not null, not null) => new MSBuildGlobWithGaps(includeGlob, new CompositeGlob(excludeGlob, removeGlob))
+        };
+    }
+
+    private static void CacheInformationFromRemoveItem<P, I>(ProjectItemElement itemElement, Dictionary<string, CumulativeRemoveElementData> removeElementCache, Expander<P, I> expander)
+        where P : class, IProperty
+        where I : class, IItem, IMetadataTable
+    {
+        if (!removeElementCache.TryGetValue(itemElement.ItemType, out CumulativeRemoveElementData cumulativeRemoveElementData))
+        {
+            cumulativeRemoveElementData = CumulativeRemoveElementData.Create();
+
+            removeElementCache[itemElement.ItemType] = cumulativeRemoveElementData;
+        }
+
+        var removeSpec = new ItemSpec<P, I>(itemElement.Remove, expander, itemElement.RemoveLocation, itemElement.ContainingProject.DirectoryPath);
+
+        cumulativeRemoveElementData.AccumulateInformationFromRemoveItemSpec(removeSpec.FlattenFragmentsAsStrings(), removeSpec.ToMSBuildGlob());
+    }
+
+    // represents cumulated remove information for a particular item type
+    private struct CumulativeRemoveElementData
+    {
+        private ImmutableList<IMSBuildGlob>.Builder _globs;
+        private ImmutableHashSet<string>.Builder _fragmentStrings;
+
+        public IEnumerable<IMSBuildGlob> Globs => _globs.ToImmutable();
+        public IEnumerable<string> FragmentStrings => _fragmentStrings.ToImmutable();
+
+        public static CumulativeRemoveElementData Create()
+        {
+            return new CumulativeRemoveElementData
+            {
+                _globs = ImmutableList.CreateBuilder<IMSBuildGlob>(),
+                _fragmentStrings = ImmutableHashSet.CreateBuilder<string>()
+            };
+        }
+
+        public readonly void AccumulateInformationFromRemoveItemSpec(IEnumerable<string> removeSpecFragmentStrings, IMSBuildGlob removeGlob)
+        {
+            _globs.Add(removeGlob);
+
+            foreach (var removeFragment in removeSpecFragmentStrings)
+            {
+                _fragmentStrings.Add(removeFragment);
+            }
+        }
+    }
+}

--- a/src/Build/Microsoft.Build.csproj
+++ b/src/Build/Microsoft.Build.csproj
@@ -545,6 +545,7 @@
     <Compile Include="Evaluation\StringMetadataTable.cs" />
     <Compile Include="Evaluation\ExpressionShredder.cs" />
     <Compile Include="Evaluation\Evaluator.cs" />
+    <Compile Include="Evaluation\GlobResultBuilder.cs" />
     <Compile Include="Evaluation\Expander.cs" />
     <Compile Include="Evaluation\ToolsetProvider.cs" />
     <Compile Include="Evaluation\Expander\ArgumentParser.cs" />

--- a/src/Framework/Constants.cs
+++ b/src/Framework/Constants.cs
@@ -116,6 +116,40 @@ namespace Microsoft.Build.Framework
         /// </summary>
         internal const string SdkMetadataName = "Sdk";
 
+        /// <summary>
+        /// Name of the MSBuild property that opts in to synthesizing <c>MSBuildItemGlob</c> items,
+        /// exposing the unevaluated include/exclude/remove glob patterns of selected item types to
+        /// targets and tasks. The value is a semicolon-separated list of item types to expose
+        /// (for example <c>Compile;Content</c>). Projects that do not set it pay zero cost.
+        /// </summary>
+        internal const string MSBuildProvideItemGlobsPropertyName = "MSBuildProvideItemGlobs";
+
+        /// <summary>
+        /// Item type for synthesized glob items created when
+        /// <c>MSBuildProvideItemGlobs</c> lists the owning item type.
+        /// The item's identity is the item type (for example <c>Compile</c>); the glob patterns are
+        /// carried in metadata so that they are never expanded against the file system.
+        /// </summary>
+        internal const string MSBuildItemGlobItemType = "MSBuildItemGlob";
+
+        /// <summary>
+        /// Metadata name on <c>MSBuildItemGlob</c> items holding the include glob
+        /// pattern(s) of a single item element (semicolon-separated, wildcards preserved).
+        /// </summary>
+        internal const string ItemGlobIncludeMetadataName = "Include";
+
+        /// <summary>
+        /// Metadata name on <c>MSBuildItemGlob</c> items holding the exclude
+        /// pattern(s) that apply to the include (semicolon-separated; literals and globs).
+        /// </summary>
+        internal const string ItemGlobExcludeMetadataName = "Exclude";
+
+        /// <summary>
+        /// Metadata name on <c>MSBuildItemGlob</c> items holding the remove
+        /// pattern(s) that apply to the include (semicolon-separated; literals and globs).
+        /// </summary>
+        internal const string ItemGlobRemoveMetadataName = "Remove";
+
         internal const string TaskHostExplicitlyRequested = "TaskHostExplicitlyRequested";
     }
 }

--- a/src/MSBuild/MSBuild/Microsoft.Build.CommonTypes.xsd
+++ b/src/MSBuild/MSBuild/Microsoft.Build.CommonTypes.xsd
@@ -1223,6 +1223,36 @@ elementFormDefault="qualified">
             </xs:complexContent>
         </xs:complexType>
     </xs:element>
+    <xs:element name="MSBuildItemGlob" substitutionGroup="msb:Item">
+        <xs:annotation>
+            <xs:documentation><!-- _locID_text="MSBuildItemGlob" _locComment="" -->Synthesized by the engine for each item type listed in MSBuildProvideItemGlobs. Each item's identity is the item type; its metadata carry the unevaluated include/exclude/remove glob patterns of one item element.</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="msb:SimpleItemType">
+                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                        <xs:choice>
+                            <xs:element name="Include">
+                                <xs:annotation>
+                                    <xs:documentation><!-- _locID_text="MSBuildItemGlob_Include" _locComment="" -->The include glob pattern(s) of the item element (semicolon-separated, wildcards preserved).</xs:documentation>
+                                </xs:annotation>
+                            </xs:element>
+                            <xs:element name="Exclude">
+                                <xs:annotation>
+                                    <xs:documentation><!-- _locID_text="MSBuildItemGlob_Exclude" _locComment="" -->The exclude pattern(s) that apply to the include (semicolon-separated; literals and globs).</xs:documentation>
+                                </xs:annotation>
+                            </xs:element>
+                            <xs:element name="Remove">
+                                <xs:annotation>
+                                    <xs:documentation><!-- _locID_text="MSBuildItemGlob_Remove" _locComment="" -->The remove pattern(s) that apply to the include (semicolon-separated; literals and globs).</xs:documentation>
+                                </xs:annotation>
+                            </xs:element>
+                        </xs:choice>
+                    </xs:sequence>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
     <xs:element name="WebReferences" type="msb:SimpleItemType" substitutionGroup="msb:Item">
         <xs:annotation>
             <xs:documentation><!-- _locID_text="WebReferences" _locComment="" -->Name of Web References folder to display in user interface</xs:documentation>
@@ -1945,6 +1975,11 @@ elementFormDefault="qualified">
     <xs:element name="MSBuildProvideImportedProjects" type="msb:StringPropertyType" substitutionGroup="msb:Property">
         <xs:annotation>
             <xs:documentation><!-- _locID_text="MSBuildProvideImportedProjects" _locComment="" -->When set to 'true', the engine synthesizes MSBuildImportedProject items representing the import tree of the project. Each item's identity is the full path of an imported file, with ImportingProjectPath and Sdk metadata.</xs:documentation>
+        </xs:annotation>
+    </xs:element>
+    <xs:element name="MSBuildProvideItemGlobs" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+        <xs:annotation>
+            <xs:documentation><!-- _locID_text="MSBuildProvideItemGlobs" _locComment="" -->A semicolon-separated list of item types (e.g. 'Compile;Content'). For each listed item type, the engine synthesizes MSBuildItemGlob items exposing the unevaluated include/exclude/remove glob patterns of that item type. Projects that do not set it pay zero cost.</xs:documentation>
         </xs:annotation>
     </xs:element>
     <xs:element name="MSBuildTreatWarningsAsErrors" type="msb:StringPropertyType" substitutionGroup="msb:Property">

--- a/src/MSBuild/MSBuild/Microsoft.Build.CommonTypes.xsd
+++ b/src/MSBuild/MSBuild/Microsoft.Build.CommonTypes.xsd
@@ -1223,36 +1223,6 @@ elementFormDefault="qualified">
             </xs:complexContent>
         </xs:complexType>
     </xs:element>
-    <xs:element name="MSBuildItemGlob" substitutionGroup="msb:Item">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="MSBuildItemGlob" _locComment="" -->Synthesized by the engine for each item type listed in MSBuildProvideItemGlobs. Each item's identity is the item type; its metadata carry the unevaluated include/exclude/remove glob patterns of one item element.</xs:documentation>
-        </xs:annotation>
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:SimpleItemType">
-                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
-                        <xs:choice>
-                            <xs:element name="Include">
-                                <xs:annotation>
-                                    <xs:documentation><!-- _locID_text="MSBuildItemGlob_Include" _locComment="" -->The include glob pattern(s) of the item element (semicolon-separated, wildcards preserved).</xs:documentation>
-                                </xs:annotation>
-                            </xs:element>
-                            <xs:element name="Exclude">
-                                <xs:annotation>
-                                    <xs:documentation><!-- _locID_text="MSBuildItemGlob_Exclude" _locComment="" -->The exclude pattern(s) that apply to the include (semicolon-separated; literals and globs).</xs:documentation>
-                                </xs:annotation>
-                            </xs:element>
-                            <xs:element name="Remove">
-                                <xs:annotation>
-                                    <xs:documentation><!-- _locID_text="MSBuildItemGlob_Remove" _locComment="" -->The remove pattern(s) that apply to the include (semicolon-separated; literals and globs).</xs:documentation>
-                                </xs:annotation>
-                            </xs:element>
-                        </xs:choice>
-                    </xs:sequence>
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
     <xs:element name="WebReferences" type="msb:SimpleItemType" substitutionGroup="msb:Item">
         <xs:annotation>
             <xs:documentation><!-- _locID_text="WebReferences" _locComment="" -->Name of Web References folder to display in user interface</xs:documentation>
@@ -1979,7 +1949,7 @@ elementFormDefault="qualified">
     </xs:element>
     <xs:element name="MSBuildProvideItemGlobs" type="msb:StringPropertyType" substitutionGroup="msb:Property">
         <xs:annotation>
-            <xs:documentation><!-- _locID_text="MSBuildProvideItemGlobs" _locComment="" -->A semicolon-separated list of item types (e.g. 'Compile;Content'). For each listed item type, the engine synthesizes MSBuildItemGlob items exposing the unevaluated include/exclude/remove glob patterns of that item type. Projects that do not set it pay zero cost.</xs:documentation>
+            <xs:documentation><!-- _locID_text="MSBuildProvideItemGlobs" _locComment="" -->A semicolon-separated list of item types (e.g. 'Compile;Content'). For each listed item type, the engine synthesizes MSBuildItemGlob items exposing the unevaluated include/exclude/remove glob patterns of that item type. Do not use generated MSBuildItemGlob items to influence the build process.</xs:documentation>
         </xs:annotation>
     </xs:element>
     <xs:element name="MSBuildTreatWarningsAsErrors" type="msb:StringPropertyType" substitutionGroup="msb:Property">


### PR DESCRIPTION
## Summary

Adds an opt-in mechanism that surfaces a project's *unevaluated* include/exclude/remove glob patterns to targets and tasks during an ordinary command-line build. When the `MSBuildProvideItemGlobs` property is set to a semicolon-separated list of item types (for example `Compile;Content`), the engine synthesizes `MSBuildItemGlob` items during evaluation — one per include element that contributes globs — carrying the patterns in item metadata.

This follows the same pattern as [#13681](https://github.com/dotnet/msbuild/pull/13681), which exposed a project's import tree to targets and tasks as `MSBuildImportedProject` items. This change does the equivalent for a project's item globs.

## Motivation

External tooling frequently needs to answer a simple question cheaply and often: *"a file just appeared on disk — does it belong to this project, and to which item type?"* A file watcher, for instance, wants to know whether a newly created `.cs` file is picked up by the project's compile globs without re-running a full evaluation on every file-system event.

Today the only reliable ways to obtain a project's wildcard patterns are to re-evaluate the project or to drive MSBuild through its object model and call `Project.GetAllGlobs()`. Both require hosting the engine in-process, as Visual Studio's project system and the C#/Roslyn language server do. There is no way to extract the same information from a plain `dotnet build` or `msbuild` invocation, where a tool has only the build output to work with.

This change closes that gap using regular MSBuild items. Because they are ordinary items, they flow to every target and task automatically, serialize to out-of-proc worker nodes for free, and require no new public API surface.

## Usage

Set the property to the item types of interest, then read the synthesized items from a target or task:

```xml
<PropertyGroup>
  <MSBuildProvideItemGlobs>Compile;Content</MSBuildProvideItemGlobs>
</PropertyGroup>

<Target Name="ShowGlobs">
  <Message Importance="high"
           Text="%(MSBuildItemGlob.Identity): include=%(MSBuildItemGlob.Include); exclude=%(MSBuildItemGlob.Exclude); remove=%(MSBuildItemGlob.Remove)" />
</Target>
```

The property is intended primarily for tooling that consumes the build output, so it is typically supplied as a global property rather than authored into the project. It can be set in the project file, in a `Directory.Build.props`, through `ProjectCollection.GlobalProperties`, or on the command line.

Each synthesized `MSBuildItemGlob` item represents a single include element and carries:

- `Identity` — the item type (for example `Compile`). Multiple include elements of the same type each produce their own item, so identities repeat and appear in document order.
- `Include` — the include glob pattern(s) of the element, with property references expanded and wildcards preserved.
- `Exclude` — the exclude pattern(s) present on the element (literals and globs).
- `Remove` — the remove pattern(s) that apply to the element (literals and globs).

## How it works

The patterns are derived by exactly the same logic that backs `Project.GetAllGlobs()`. That logic has been lifted out of `Project` into a new shared, generic `GlobResultBuilder`, so the public API and the synthesized items are guaranteed to produce identical results and cannot drift apart.

Synthesis happens in the evaluator at the end of the items pass, in `Evaluator.SynthesizeItemGlobItems`. Doing it during evaluation — rather than during `ProjectInstance` construction — ensures the items appear identically on both `Project` and `ProjectInstance`. Doing it at the *end* of the pass, after all items have been evaluated, ensures that item references (`@(...)`) inside exclude and remove expressions resolve to their final values, matching `GetAllGlobs`.

## Design notes

- **Zero cost when unused.** If `MSBuildProvideItemGlobs` is not set, the feature does no work and allocates nothing.
- **Wildcards are never expanded.** The patterns live in item *metadata*, which is never globbed against the file system, so `**/*.cs` is preserved verbatim rather than being expanded into a file list. Metadata values are standard MSBuild-escaped, semicolon-separated lists, so each pattern round-trips to exactly the string `GetAllGlobs` reports — including patterns containing `%`, and (recovered from the escaped value, as with any MSBuild item list) even the rare pattern containing a literal `;`.
- **Precedence is preserved.** Items are emitted in document order, and each include record carries only the removes that apply to it (those that appear after it in the file). Replaying the records therefore reproduces the authored include/exclude/remove precedence, including "included, then removed, then re-included" sequences where ordering is significant.
- **Literal includes are omitted; literal excludes and removes are kept.** A change to a file that is included by an exact path is always accompanied by a project-file edit, so a watcher re-evaluates anyway. Excludes and removes retain both their literal and glob fragments, which a consumer needs in order to decide membership.

## Tests

`ItemGlobs_Tests` covers opt-out (no items synthesized), opt-in, include/exclude/remove capture, retention of literal excludes and removes, omission of literal includes, item-type filtering, multiple item types, property expansion with wildcard preservation, document order, remove attribution and re-inclusion ordering, conditioned-out elements, the global-property path, `Project` and `ProjectInstance` parity, parity with `Project.GetAllGlobs()`, escaping round-trips for patterns containing `%`, lossless recovery of a pattern that itself contains a literal `;`, and end-to-end availability to a building target.

## After merge

File an issue to add a BuildCheck analyzer to prevent use of these items. BuildCheck supports property checks, but not yet item checks. So there's some infrastructural work required before this can be added, which is why it's not part of this PR.