### PR TITLE
Bootstrap PowerShell modules in flaky test detector

### DIFF
--- a/.github/workflows/scripts/Get-FlakyTests.ps1
+++ b/.github/workflows/scripts/Get-FlakyTests.ps1
@@ -126,6 +126,19 @@ param(
     [string]$JsonOut
 )
 
+# AWF chroot sessions can expose PowerShell's built-in module files without loading
+# their manifests. Import the required modules directly when command discovery fails.
+if (-not (Get-Command Get-Date -ErrorAction SilentlyContinue)) {
+    Import-Module ([System.IO.Path]::Combine($PSHOME, "Microsoft.PowerShell.Commands.Utility.dll")) -ErrorAction Stop
+}
+if (-not (Get-Command Get-Item -ErrorAction SilentlyContinue)) {
+    Import-Module ([System.IO.Path]::Combine($PSHOME, "Microsoft.PowerShell.Commands.Management.dll")) -ErrorAction Stop
+}
+if (-not (Get-Command Expand-Archive -ErrorAction SilentlyContinue)) {
+    $archiveModule = [System.IO.Path]::Combine($PSHOME, "Modules", "Microsoft.PowerShell.Archive", "Microsoft.PowerShell.Archive.psd1")
+    Import-Module $archiveModule -ErrorAction Stop
+}
+
 $ErrorActionPreference = "Stop"
 $ProgressPreference = "SilentlyContinue"   # large speedup for Invoke-WebRequest
 


### PR DESCRIPTION
Fixes #14278

### Context

The gh-aw chroot can start PowerShell 7.6.3 without autoloading built-in module manifests. `Get-FlakyTests.ps1` then fails on commands such as `Get-Date`, while a missing `Expand-Archive` could prevent test artifacts from being processed.

### Changes Made

- Added guarded direct imports for `Microsoft.PowerShell.Commands.Utility.dll` and `Microsoft.PowerShell.Commands.Management.dll` from `$PSHOME`.
- Added a guarded import for `Microsoft.PowerShell.Archive.psd1` so ZIP extraction remains available.
- Preserved normal PowerShell startup behavior by importing modules only when representative commands are missing.

### Testing

- Parsed `.github/workflows/scripts/Get-FlakyTests.ps1` with the PowerShell parser successfully.
- Ran the detector with `PSModulePath` empty and confirmed it produced a complete zero-build report.
- Extracted a real ZIP with `Expand-Archive` after the bootstrap and verified the extracted content.