### PR TITLE
Fix official build as -officialBuild parameter is now just a property

### DIFF
--- a/azure-pipelines/.vsts-dotnet-build-jobs.yml
+++ b/azure-pipelines/.vsts-dotnet-build-jobs.yml
@@ -120,8 +120,8 @@ jobs:
   - script: build.cmd
               -pack -sign -publish -ci
               -configuration $(BuildConfiguration)
-              -officialBuildId $(Build.BuildNumber)
               $(SkipApplyOptimizationDataArg)
+              /p:OfficialBuildId=$(Build.BuildNumber)
               /p:RepositoryName=$(Build.Repository.Name)
               /p:VisualStudioIbcSourceBranchName=$(SourceBranch)
               /p:VisualStudioDropAccessToken=$(System.AccessToken)


### PR DESCRIPTION
Fixes broken official build. Regressed with https://github.com/dotnet/msbuild/commit/9b7c97b8b10554deafe3fe9794d7eea9847b85d3