### PR TITLE
Add analyzer for TaskEnvironment constructor injection

### DIFF
--- a/documentation/specs/multithreading/thread-safe-tasks.md
+++ b/documentation/specs/multithreading/thread-safe-tasks.md
@@ -73,6 +73,8 @@ In multi-process execution (out-of-proc task host) and when a task is instantiat
 
 Constructor injection also applies to host-registered tasks (the reflection-free `Microsoft.Build.Utilities.Task.RegisterTask` path used for trimming/Native AOT). The generic `RegisterTask<T>(string)` overload injects the `TaskEnvironment` when `T` declares such a constructor (its public constructors are already trim-rooted). Because that overload's `new()` constraint requires a parameterless constructor, a task whose *only* constructor takes a `TaskEnvironment` is registered through the `RegisterTask(string, Func<TaskEnvironment, ITask>)` factory overload, which hands the environment to the factory. See [task-class-registration-api.md](../task-class-registration-api.md).
 
+The task-authoring analyzer reports `MSBuildTask0010` at Info severity for concrete `IMultiThreadableTask` implementations that rely only on post-construction property injection. Add a public constructor whose single parameter is `TaskEnvironment` to make the environment available during construction. A task may retain a public parameterless constructor for callers that instantiate it directly; the engine prefers the injecting constructor when both are present.
+
 Task authors who want to support older MSBuild versions need to:
 - Maintain both thread-safe and legacy implementations.
 - Use conditional task declarations based on MSBuild version to select which assembly to load the task from.

--- a/src/TaskAnalyzer.Tests/TaskEnvironmentConstructorInjectionAnalyzerTests.cs
+++ b/src/TaskAnalyzer.Tests/TaskEnvironmentConstructorInjectionAnalyzerTests.cs
@@ -1,0 +1,194 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Shouldly;
+using Xunit;
+using static Microsoft.Build.TaskAuthoring.Analyzer.Tests.TestHelpers;
+
+namespace Microsoft.Build.TaskAuthoring.Analyzer.Tests;
+
+public class TaskEnvironmentConstructorInjectionAnalyzerTests
+{
+    [Fact]
+    public async Task ConcreteMultiThreadableTaskWithoutInjectingConstructor_ProducesInfoDiagnostic()
+    {
+        var diagnostics = await GetDiagnosticsAsync("""
+            using Microsoft.Build.Framework;
+
+            public class MyTask : Microsoft.Build.Utilities.Task, IMultiThreadableTask
+            {
+                public TaskEnvironment TaskEnvironment { get; set; } = null!;
+                public override bool Execute() => true;
+            }
+            """);
+
+        Diagnostic diagnostic = diagnostics.Single();
+        diagnostic.Id.ShouldBe(DiagnosticIds.PreferTaskEnvironmentConstructorInjection);
+        diagnostic.Severity.ShouldBe(DiagnosticSeverity.Info);
+        diagnostic.GetMessage().ShouldContain("MyTask");
+    }
+
+    [Fact]
+    public async Task PublicTaskEnvironmentConstructor_DoesNotProduceDiagnostic()
+    {
+        var diagnostics = await GetDiagnosticsAsync("""
+            using Microsoft.Build.Framework;
+
+            public class MyTask : Microsoft.Build.Utilities.Task, IMultiThreadableTask
+            {
+                public MyTask(TaskEnvironment taskEnvironment)
+                {
+                    TaskEnvironment = taskEnvironment;
+                }
+
+                public TaskEnvironment TaskEnvironment { get; set; }
+                public override bool Execute() => true;
+            }
+            """);
+
+        diagnostics.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task PublicParameterlessAndTaskEnvironmentConstructors_DoNotProduceDiagnostic()
+    {
+        var diagnostics = await GetDiagnosticsAsync("""
+            using Microsoft.Build.Framework;
+
+            public class MyTask : Microsoft.Build.Utilities.Task, IMultiThreadableTask
+            {
+                public MyTask()
+                {
+                    TaskEnvironment = null!;
+                }
+
+                public MyTask(TaskEnvironment taskEnvironment)
+                {
+                    TaskEnvironment = taskEnvironment;
+                }
+
+                public TaskEnvironment TaskEnvironment { get; set; }
+                public override bool Execute() => true;
+            }
+            """);
+
+        diagnostics.ShouldBeEmpty();
+    }
+
+    [Theory]
+    [InlineData("private MyTask(TaskEnvironment taskEnvironment)")]
+    [InlineData("public MyTask(TaskEnvironment taskEnvironment, string value)")]
+    public async Task ConstructorNotUsableForInjection_ProducesDiagnostic(string constructorDeclaration)
+    {
+        var diagnostics = await GetDiagnosticsAsync($$"""
+            using Microsoft.Build.Framework;
+
+            public class MyTask : Microsoft.Build.Utilities.Task, IMultiThreadableTask
+            {
+                {{constructorDeclaration}}
+                {
+                    TaskEnvironment = taskEnvironment;
+                }
+
+                public TaskEnvironment TaskEnvironment { get; set; }
+                public override bool Execute() => true;
+            }
+            """);
+
+        diagnostics.Single().Id.ShouldBe(DiagnosticIds.PreferTaskEnvironmentConstructorInjection);
+    }
+
+    [Fact]
+    public async Task AbstractMultiThreadableTask_DoesNotProduceDiagnostic()
+    {
+        var diagnostics = await GetDiagnosticsAsync("""
+            using Microsoft.Build.Framework;
+
+            public abstract class MyTask : Microsoft.Build.Utilities.Task, IMultiThreadableTask
+            {
+                public TaskEnvironment TaskEnvironment { get; set; } = null!;
+            }
+            """);
+
+        diagnostics.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task RegularTask_DoesNotProduceDiagnostic()
+    {
+        var diagnostics = await GetDiagnosticsAsync("""
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                public override bool Execute() => true;
+            }
+            """);
+
+        diagnostics.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task ConcreteTaskInheritingMultiThreadableImplementation_ProducesDiagnostic()
+    {
+        var diagnostics = await GetDiagnosticsAsync("""
+            using Microsoft.Build.Framework;
+
+            public abstract class MultiThreadableTask : Microsoft.Build.Utilities.Task, IMultiThreadableTask
+            {
+                public TaskEnvironment TaskEnvironment { get; set; } = null!;
+            }
+
+            public class MyTask : MultiThreadableTask
+            {
+                public override bool Execute() => true;
+            }
+            """);
+
+        Diagnostic diagnostic = diagnostics.Single();
+        diagnostic.GetMessage().ShouldContain("MyTask");
+    }
+
+    [Fact]
+    public async Task InheritedTaskEnvironmentConstructor_ProducesDiagnostic()
+    {
+        var diagnostics = await GetDiagnosticsAsync("""
+            using Microsoft.Build.Framework;
+
+            public abstract class MultiThreadableTask : Microsoft.Build.Utilities.Task, IMultiThreadableTask
+            {
+                protected MultiThreadableTask()
+                {
+                    TaskEnvironment = null!;
+                }
+
+                protected MultiThreadableTask(TaskEnvironment taskEnvironment)
+                {
+                    TaskEnvironment = taskEnvironment;
+                }
+
+                public TaskEnvironment TaskEnvironment { get; set; }
+            }
+
+            public class MyTask : MultiThreadableTask
+            {
+                public override bool Execute() => true;
+            }
+            """);
+
+        Diagnostic diagnostic = diagnostics.Single();
+        diagnostic.GetMessage().ShouldContain("MyTask");
+    }
+
+    private static async Task<Diagnostic[]> GetDiagnosticsAsync(string source)
+    {
+        var diagnostics = await GetCompilerAndAnalyzerDiagnosticsAsync(
+            source,
+            new TaskEnvironmentConstructorInjectionAnalyzer());
+
+        return diagnostics
+            .Where(diagnostic => diagnostic.Id == DiagnosticIds.PreferTaskEnvironmentConstructorInjection)
+            .ToArray();
+    }
+}

--- a/src/TaskAnalyzer/AnalyzerReleases.Unshipped.md
+++ b/src/TaskAnalyzer/AnalyzerReleases.Unshipped.md
@@ -11,3 +11,4 @@ MSBuildTask0006 | MSBuild.TaskAuthoring | Info | Prefer typed path parameter (Ab
 MSBuildTask0007 | MSBuild.TaskAuthoring | Info | Prefer ITaskItem<T> over manual ItemSpec parsing (code fix available)
 MSBuildTask0008 | MSBuild.TaskAuthoring | Info | Initialize a relative default path in Execute() so TaskEnvironment can root it when the property is retyped (code fix available)
 MSBuildTask0009 | MSBuild.TaskAuthoring | Warning | ITaskItem<T> used with a type argument T that MSBuild cannot bind as a task parameter
+MSBuildTask0010 | MSBuild.TaskAuthoring | Info | Prefer constructor injection for TaskEnvironment

--- a/src/TaskAnalyzer/DiagnosticDescriptors.cs
+++ b/src/TaskAnalyzer/DiagnosticDescriptors.cs
@@ -94,6 +94,15 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
             isEnabledByDefault: true,
             description: "MSBuild can only bind ITaskItem<T> properties when T is a supported type. Using an unsupported type will cause a runtime failure when MSBuild tries to bind the parameter.");
 
+        public static readonly DiagnosticDescriptor PreferTaskEnvironmentConstructorInjection = new(
+            id: DiagnosticIds.PreferTaskEnvironmentConstructorInjection,
+            title: "Prefer constructor injection for TaskEnvironment",
+            messageFormat: "Task '{0}' receives TaskEnvironment only after construction; add a public constructor with a single TaskEnvironment parameter to make it available during construction",
+            category: "MSBuild.TaskAuthoring",
+            defaultSeverity: DiagnosticSeverity.Info,
+            isEnabledByDefault: true,
+            description: "Constructor injection makes TaskEnvironment available to constructor logic and environment-dependent default initialization. The MSBuild engine prefers a public constructor with a single TaskEnvironment parameter when one is available.");
+
         public static ImmutableArray<DiagnosticDescriptor> All { get; } = ImmutableArray.Create(
             CriticalError,
             TaskEnvironmentRequired,
@@ -103,6 +112,7 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
             PreferTypedPathParameter,
             PreferTypedTaskItem,
             InitializeRelativeDefaultInExecute,
-            UnsupportedTaskItemType);
+            UnsupportedTaskItemType,
+            PreferTaskEnvironmentConstructorInjection);
     }
 }

--- a/src/TaskAnalyzer/DiagnosticIds.cs
+++ b/src/TaskAnalyzer/DiagnosticIds.cs
@@ -35,5 +35,8 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
 
         /// <summary>Task property uses ITaskItem&lt;T&gt; with a type argument not supported by MSBuild's task parameter binder.</summary>
         public const string UnsupportedTaskItemType = "MSBuildTask0009";
+
+        /// <summary>Task should receive TaskEnvironment through constructor injection.</summary>
+        public const string PreferTaskEnvironmentConstructorInjection = "MSBuildTask0010";
     }
 }

--- a/src/TaskAnalyzer/TaskEnvironmentConstructorInjectionAnalyzer.cs
+++ b/src/TaskAnalyzer/TaskEnvironmentConstructorInjectionAnalyzer.cs
@@ -1,0 +1,90 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Microsoft.Build.TaskAuthoring.Analyzer
+{
+    /// <summary>
+    /// Suggests constructor injection for concrete tasks that implement <c>IMultiThreadableTask</c>.
+    /// </summary>
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class TaskEnvironmentConstructorInjectionAnalyzer : DiagnosticAnalyzer
+    {
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+            ImmutableArray.Create(DiagnosticDescriptors.PreferTaskEnvironmentConstructorInjection);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.EnableConcurrentExecution();
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.RegisterCompilationStartAction(OnCompilationStart);
+        }
+
+        private static void OnCompilationStart(CompilationStartAnalysisContext context)
+        {
+            INamedTypeSymbol? multiThreadableTaskType =
+                context.Compilation.GetTypeByMetadataName(WellKnownTypeNames.IMultiThreadableTaskFullName);
+            INamedTypeSymbol? taskEnvironmentType =
+                context.Compilation.GetTypeByMetadataName(WellKnownTypeNames.TaskEnvironmentFullName);
+
+            if (multiThreadableTaskType is null || taskEnvironmentType is null)
+            {
+                return;
+            }
+
+            context.RegisterSymbolAction(
+                symbolContext => AnalyzeNamedType(
+                    symbolContext,
+                    multiThreadableTaskType,
+                    taskEnvironmentType),
+                SymbolKind.NamedType);
+        }
+
+        private static void AnalyzeNamedType(
+            SymbolAnalysisContext context,
+            INamedTypeSymbol multiThreadableTaskType,
+            INamedTypeSymbol taskEnvironmentType)
+        {
+            var taskType = (INamedTypeSymbol)context.Symbol;
+            if (taskType.TypeKind != TypeKind.Class ||
+                taskType.IsAbstract ||
+                !SharedAnalyzerHelpers.ImplementsInterface(taskType, multiThreadableTaskType) ||
+                HasTaskEnvironmentConstructor(taskType, taskEnvironmentType))
+            {
+                return;
+            }
+
+            foreach (Location location in taskType.Locations)
+            {
+                if (location.IsInSource)
+                {
+                    context.ReportDiagnostic(Diagnostic.Create(
+                        DiagnosticDescriptors.PreferTaskEnvironmentConstructorInjection,
+                        location,
+                        taskType.Name));
+                    return;
+                }
+            }
+        }
+
+        private static bool HasTaskEnvironmentConstructor(
+            INamedTypeSymbol taskType,
+            INamedTypeSymbol taskEnvironmentType)
+        {
+            foreach (IMethodSymbol constructor in taskType.InstanceConstructors)
+            {
+                if (constructor.DeclaredAccessibility == Accessibility.Public &&
+                    constructor.Parameters.Length == 1 &&
+                    SymbolEqualityComparer.Default.Equals(constructor.Parameters[0].Type, taskEnvironmentType))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/TaskAnalyzer/TaskEnvironmentConstructorInjectionAnalyzer.cs
+++ b/src/TaskAnalyzer/TaskEnvironmentConstructorInjectionAnalyzer.cs
@@ -27,10 +27,14 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
         {
             INamedTypeSymbol? multiThreadableTaskType =
                 context.Compilation.GetTypeByMetadataName(WellKnownTypeNames.IMultiThreadableTaskFullName);
+            if (multiThreadableTaskType is null)
+            {
+                return;
+            }
+
             INamedTypeSymbol? taskEnvironmentType =
                 context.Compilation.GetTypeByMetadataName(WellKnownTypeNames.TaskEnvironmentFullName);
-
-            if (multiThreadableTaskType is null || taskEnvironmentType is null)
+            if (taskEnvironmentType is null)
             {
                 return;
             }


### PR DESCRIPTION
## Summary

- add `MSBuildTask0010` at Info severity for concrete `IMultiThreadableTask` implementations that do not expose a public single-`TaskEnvironment` constructor
- cover valid, invalid, abstract, and inherited-constructor cases
- document the recommended constructor-injection pattern and track the analyzer rule

This is a fast-follow stacked on #14315. The rule uses ID 0010 because IDs 0006-0009 are already assigned on `main`, although this parent branch predates those rules.

## Compatibility

The task-authoring analyzer is currently non-shipping/opt-in, and this diagnostic defaults to Info severity, so it does not break builds using warnings-as-errors. No ChangeWave is needed.

## Performance

Measured with the BenchmarkDotNet harness from #14387 in a disposable integration checkout, using the default job on an Apple M4 Max with .NET 10.0.8 / SDK 10.0.300. `MSBuildTask0009` is the closest existing symbol-action analyzer.

| Diagnostics | MSBuildTask0009 | MSBuildTask0010 | 0009 allocated | 0010 allocated |
|---:|---:|---:|---:|---:|
| 1 | 358.4 us | 357.9 us | 352.02 KB | 352.26 KB |
| 10 | 563.5 us | 588.8 us | 693.73 KB | 683.04 KB |
| 100 | 2.731 ms | 2.835 ms | 3,570.28 KB | 3,584.23 KB |

The initial no-reference path measured 48.08 us / 32.41 KB. Short-circuiting after the mandatory `IMultiThreadableTask` lookup reduced that to 35.52 us / 30.56 KB, close to `MSBuildTask0009` at 31.46 us / 30.56 KB. Diagnostic time, allocations, and 1/10/100 scaling are comparable, so no further complexity is justified.

## Validation

- `./build.sh -v quiet`
- `dotnet test --project src/TaskAnalyzer.Tests/TaskAnalyzer.Tests.csproj -c Release`
- bootstrap build of `src/Samples/Dependency/Dependency.csproj`
- bootstrap `MSBuild.dll --help`
- #14387 BenchmarkDotNet no-op and exact-count 1/10/100 diagnostic scenarios

Fixes #14378