### PR TITLE
Add analyzer for TaskEnvironment constructor injection

### DIFF
--- a/documentation/specs/multithreading/thread-safe-tasks.md
+++ b/documentation/specs/multithreading/thread-safe-tasks.md
@@ -73,6 +73,8 @@ In multi-process execution (out-of-proc task host) and when a task is instantiat
 
 Constructor injection also applies to host-registered tasks (the reflection-free `Microsoft.Build.Utilities.Task.RegisterTask` path used for trimming/Native AOT). The generic `RegisterTask<T>(string)` overload injects the `TaskEnvironment` when `T` declares such a constructor (its public constructors are already trim-rooted). Because that overload's `new()` constraint requires a parameterless constructor, a task whose *only* constructor takes a `TaskEnvironment` is registered through the `RegisterTask(string, Func<TaskEnvironment, ITask>)` factory overload, which hands the environment to the factory. See [task-class-registration-api.md](../task-class-registration-api.md).
 
+The task-authoring analyzer reports `MSBuildTask0011` at Info severity for concrete `IMultiThreadableTask` implementations that rely only on post-construction property injection. Add a public constructor whose single parameter is `TaskEnvironment` to make the environment available during construction. A task may retain a public parameterless constructor for callers that instantiate it directly; the engine prefers the injecting constructor when both are present.
+
 Task authors who want to support older MSBuild versions need to:
 - Maintain both thread-safe and legacy implementations.
 - Use conditional task declarations based on MSBuild version to select which assembly to load the task from.

--- a/src/TaskAnalyzer.Tests/TaskEnvironmentConstructorInjectionAnalyzerTests.cs
+++ b/src/TaskAnalyzer.Tests/TaskEnvironmentConstructorInjectionAnalyzerTests.cs
@@ -1,0 +1,194 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Shouldly;
+using Xunit;
+using static Microsoft.Build.TaskAuthoring.Analyzer.Tests.TestHelpers;
+
+namespace Microsoft.Build.TaskAuthoring.Analyzer.Tests;
+
+public class TaskEnvironmentConstructorInjectionAnalyzerTests
+{
+    [Fact]
+    public async Task ConcreteMultiThreadableTaskWithoutInjectingConstructor_ProducesInfoDiagnostic()
+    {
+        var diagnostics = await GetDiagnosticsAsync("""
+            using Microsoft.Build.Framework;
+
+            public class MyTask : Microsoft.Build.Utilities.Task, IMultiThreadableTask
+            {
+                public TaskEnvironment TaskEnvironment { get; set; } = null!;
+                public override bool Execute() => true;
+            }
+            """);
+
+        Diagnostic diagnostic = diagnostics.Single();
+        diagnostic.Id.ShouldBe(DiagnosticIds.PreferTaskEnvironmentConstructorInjection);
+        diagnostic.Severity.ShouldBe(DiagnosticSeverity.Info);
+        diagnostic.GetMessage().ShouldContain("MyTask");
+    }
+
+    [Fact]
+    public async Task PublicTaskEnvironmentConstructor_DoesNotProduceDiagnostic()
+    {
+        var diagnostics = await GetDiagnosticsAsync("""
+            using Microsoft.Build.Framework;
+
+            public class MyTask : Microsoft.Build.Utilities.Task, IMultiThreadableTask
+            {
+                public MyTask(TaskEnvironment taskEnvironment)
+                {
+                    TaskEnvironment = taskEnvironment;
+                }
+
+                public TaskEnvironment TaskEnvironment { get; set; }
+                public override bool Execute() => true;
+            }
+            """);
+
+        diagnostics.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task PublicParameterlessAndTaskEnvironmentConstructors_DoNotProduceDiagnostic()
+    {
+        var diagnostics = await GetDiagnosticsAsync("""
+            using Microsoft.Build.Framework;
+
+            public class MyTask : Microsoft.Build.Utilities.Task, IMultiThreadableTask
+            {
+                public MyTask()
+                {
+                    TaskEnvironment = null!;
+                }
+
+                public MyTask(TaskEnvironment taskEnvironment)
+                {
+                    TaskEnvironment = taskEnvironment;
+                }
+
+                public TaskEnvironment TaskEnvironment { get; set; }
+                public override bool Execute() => true;
+            }
+            """);
+
+        diagnostics.ShouldBeEmpty();
+    }
+
+    [Theory]
+    [InlineData("private MyTask(TaskEnvironment taskEnvironment)")]
+    [InlineData("public MyTask(TaskEnvironment taskEnvironment, string value)")]
+    public async Task ConstructorNotUsableForInjection_ProducesDiagnostic(string constructorDeclaration)
+    {
+        var diagnostics = await GetDiagnosticsAsync($$"""
+            using Microsoft.Build.Framework;
+
+            public class MyTask : Microsoft.Build.Utilities.Task, IMultiThreadableTask
+            {
+                {{constructorDeclaration}}
+                {
+                    TaskEnvironment = taskEnvironment;
+                }
+
+                public TaskEnvironment TaskEnvironment { get; set; }
+                public override bool Execute() => true;
+            }
+            """);
+
+        diagnostics.Single().Id.ShouldBe(DiagnosticIds.PreferTaskEnvironmentConstructorInjection);
+    }
+
+    [Fact]
+    public async Task AbstractMultiThreadableTask_DoesNotProduceDiagnostic()
+    {
+        var diagnostics = await GetDiagnosticsAsync("""
+            using Microsoft.Build.Framework;
+
+            public abstract class MyTask : Microsoft.Build.Utilities.Task, IMultiThreadableTask
+            {
+                public TaskEnvironment TaskEnvironment { get; set; } = null!;
+            }
+            """);
+
+        diagnostics.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task RegularTask_DoesNotProduceDiagnostic()
+    {
+        var diagnostics = await GetDiagnosticsAsync("""
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                public override bool Execute() => true;
+            }
+            """);
+
+        diagnostics.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task ConcreteTaskInheritingMultiThreadableImplementation_ProducesDiagnostic()
+    {
+        var diagnostics = await GetDiagnosticsAsync("""
+            using Microsoft.Build.Framework;
+
+            public abstract class MultiThreadableTask : Microsoft.Build.Utilities.Task, IMultiThreadableTask
+            {
+                public TaskEnvironment TaskEnvironment { get; set; } = null!;
+            }
+
+            public class MyTask : MultiThreadableTask
+            {
+                public override bool Execute() => true;
+            }
+            """);
+
+        Diagnostic diagnostic = diagnostics.Single();
+        diagnostic.GetMessage().ShouldContain("MyTask");
+    }
+
+    [Fact]
+    public async Task InheritedTaskEnvironmentConstructor_ProducesDiagnostic()
+    {
+        var diagnostics = await GetDiagnosticsAsync("""
+            using Microsoft.Build.Framework;
+
+            public abstract class MultiThreadableTask : Microsoft.Build.Utilities.Task, IMultiThreadableTask
+            {
+                protected MultiThreadableTask()
+                {
+                    TaskEnvironment = null!;
+                }
+
+                protected MultiThreadableTask(TaskEnvironment taskEnvironment)
+                {
+                    TaskEnvironment = taskEnvironment;
+                }
+
+                public TaskEnvironment TaskEnvironment { get; set; }
+            }
+
+            public class MyTask : MultiThreadableTask
+            {
+                public override bool Execute() => true;
+            }
+            """);
+
+        Diagnostic diagnostic = diagnostics.Single();
+        diagnostic.GetMessage().ShouldContain("MyTask");
+    }
+
+    private static async Task<Diagnostic[]> GetDiagnosticsAsync(string source)
+    {
+        var diagnostics = await GetCompilerAndAnalyzerDiagnosticsAsync(
+            source,
+            new TaskEnvironmentConstructorInjectionAnalyzer());
+
+        return diagnostics
+            .Where(diagnostic => diagnostic.Id == DiagnosticIds.PreferTaskEnvironmentConstructorInjection)
+            .ToArray();
+    }
+}

--- a/src/TaskAnalyzer/AnalyzerReleases.Unshipped.md
+++ b/src/TaskAnalyzer/AnalyzerReleases.Unshipped.md
@@ -12,3 +12,4 @@ MSBuildTask0007 | MSBuild.TaskAuthoring | Info | Prefer ITaskItem<T> over manual
 MSBuildTask0008 | MSBuild.TaskAuthoring | Info | Initialize a relative default path in Execute() so TaskEnvironment can root it when the property is retyped (code fix available)
 MSBuildTask0009 | MSBuild.TaskAuthoring | Warning | ITaskItem<T> used with a type argument T that MSBuild cannot bind as a task parameter
 MSBuildTask0010 | MSBuild.TaskAuthoring | Error | ITaskItem<T> used with a type argument T that MSBuild parses through Convert.ChangeType
+MSBuildTask0011 | MSBuild.TaskAuthoring | Info | Prefer constructor injection for TaskEnvironment

--- a/src/TaskAnalyzer/DiagnosticDescriptors.cs
+++ b/src/TaskAnalyzer/DiagnosticDescriptors.cs
@@ -103,6 +103,15 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
             isEnabledByDefault: true,
             description: "ITaskItem<T> type arguments parsed through Convert.ChangeType use CultureInfo.InvariantCulture. Bind the item as a string and parse it explicitly with the intended culture.");
 
+        public static readonly DiagnosticDescriptor PreferTaskEnvironmentConstructorInjection = new(
+            id: DiagnosticIds.PreferTaskEnvironmentConstructorInjection,
+            title: "Prefer constructor injection for TaskEnvironment",
+            messageFormat: "Task '{0}' receives TaskEnvironment only after construction; add a public constructor with a single TaskEnvironment parameter to make it available during construction",
+            category: "MSBuild.TaskAuthoring",
+            defaultSeverity: DiagnosticSeverity.Info,
+            isEnabledByDefault: true,
+            description: "Constructor injection makes TaskEnvironment available to constructor logic and environment-dependent default initialization. The MSBuild engine prefers a public constructor with a single TaskEnvironment parameter when one is available.");
+
         public static ImmutableArray<DiagnosticDescriptor> All { get; } = ImmutableArray.Create(
             CriticalError,
             TaskEnvironmentRequired,
@@ -113,6 +122,7 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
             PreferTypedTaskItem,
             InitializeRelativeDefaultInExecute,
             UnsupportedTaskItemType,
-            CultureSensitiveTaskItemType);
+            CultureSensitiveTaskItemType,
+            PreferTaskEnvironmentConstructorInjection);
     }
 }

--- a/src/TaskAnalyzer/DiagnosticIds.cs
+++ b/src/TaskAnalyzer/DiagnosticIds.cs
@@ -38,5 +38,8 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
 
         /// <summary>Task property uses ITaskItem&lt;T&gt; with a type argument parsed through Convert.ChangeType.</summary>
         public const string CultureSensitiveTaskItemType = "MSBuildTask0010";
+
+        /// <summary>Task should receive TaskEnvironment through constructor injection.</summary>
+        public const string PreferTaskEnvironmentConstructorInjection = "MSBuildTask0011";
     }
 }

--- a/src/TaskAnalyzer/README.md
+++ b/src/TaskAnalyzer/README.md
@@ -24,6 +24,7 @@ This analyzer catches unsafe API usage at compile time and offers code fixes to 
 | **MSBuildTask0008** | Info | Tasks with `[MSBuildMultiThreadableTask]` applied directly | Initialize a relative-default path property in `Execute()` |
 | **MSBuildTask0009** | Warning | All `ITask` implementations | `ITaskItem<T>` used with unsupported type argument |
 | **MSBuildTask0010** | Error | All `ITask` implementations | `ITaskItem<T>` relies on culture-sensitive conversion |
+| **MSBuildTask0011** | Info | Concrete `IMultiThreadableTask` implementations | Prefer constructor injection for `TaskEnvironment` |
 
 ### MSBuildTask0001 — Critical: No Safe Alternative
 
@@ -265,6 +266,27 @@ Use `ITaskItem<string>` and parse `Value` explicitly with the intended culture. 
 
 **Scope:** All `ITask` implementations, including input, output, scalar, and array properties.
 
+### MSBuildTask0011 — Prefer `TaskEnvironment` Constructor Injection
+
+Concrete `IMultiThreadableTask` implementations receive `TaskEnvironment` through their property before execution, but that is too late for constructor logic and property initializers. Add a public constructor whose single parameter is `TaskEnvironment` when construction needs the current task environment:
+
+```csharp
+public class MyTask : Task, IMultiThreadableTask
+{
+    public MyTask(TaskEnvironment taskEnvironment)
+    {
+        TaskEnvironment = taskEnvironment;
+    }
+
+    public TaskEnvironment TaskEnvironment { get; set; }
+    public override bool Execute() => true;
+}
+```
+
+The engine prefers this constructor when it is present. A public parameterless constructor may remain for callers that instantiate the task directly.
+
+**Scope:** Concrete classes implementing `IMultiThreadableTask`. Abstract base classes and tasks that already declare a public single-`TaskEnvironment` constructor do not produce the diagnostic.
+
 ## Analysis Scope
 
 The analyzer determines what to check based on the type declaration:
@@ -273,7 +295,7 @@ The analyzer determines what to check based on the type declaration:
 |---|---|
 | Any class implementing `ITask` | MSBuildTask0001–MSBuildTask0005, MSBuildTask0009–MSBuildTask0010 |
 | Class with `[MSBuildMultiThreadableTask]` attribute applied directly | MSBuildTask0006–MSBuildTask0008 (in addition to MSBuildTask0001–0005) |
-| Class implementing `IMultiThreadableTask` without the attribute | MSBuildTask0001–MSBuildTask0005 and MSBuildTask0009–MSBuildTask0010 only |
+| Concrete class implementing `IMultiThreadableTask` without the attribute | MSBuildTask0001–MSBuildTask0005 and MSBuildTask0009–MSBuildTask0011 |
 | Helper class with `[MSBuildMultiThreadableTaskAnalyzed]` attribute | MSBuildTask0001–MSBuildTask0005 |
 | Regular class (no task interface or attribute) | Not analyzed |
 
@@ -288,7 +310,7 @@ The `[MSBuildMultiThreadableTaskAnalyzed]` attribute allows opting helper classe
 - **MSBuildTask0001** is always **Error** — these APIs are never safe in any MSBuild task.
 - **MSBuildTask0010** is always **Error** — task item conversions must not rely on `Convert.ChangeType`.
 - **MSBuildTask0002–MSBuildTask0005 and MSBuildTask0009** report as **Warning** for all task types.
-- **MSBuildTask0006–MSBuildTask0008** report as **Info** — these are modernization suggestions, not correctness issues.
+- **MSBuildTask0006–MSBuildTask0008 and MSBuildTask0011** report as **Info** — these are modernization suggestions, not correctness issues.
 
 ## Code Fixes
 

--- a/src/TaskAnalyzer/TaskEnvironmentConstructorInjectionAnalyzer.cs
+++ b/src/TaskAnalyzer/TaskEnvironmentConstructorInjectionAnalyzer.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public sealed class TaskEnvironmentConstructorInjectionAnalyzer : DiagnosticAnalyzer
     {
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
             ImmutableArray.Create(DiagnosticDescriptors.PreferTaskEnvironmentConstructorInjection);
 
         public override void Initialize(AnalysisContext context)

--- a/src/TaskAnalyzer/TaskEnvironmentConstructorInjectionAnalyzer.cs
+++ b/src/TaskAnalyzer/TaskEnvironmentConstructorInjectionAnalyzer.cs
@@ -1,0 +1,90 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Microsoft.Build.TaskAuthoring.Analyzer
+{
+    /// <summary>
+    /// Suggests constructor injection for concrete tasks that implement <c>IMultiThreadableTask</c>.
+    /// </summary>
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class TaskEnvironmentConstructorInjectionAnalyzer : DiagnosticAnalyzer
+    {
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+            ImmutableArray.Create(DiagnosticDescriptors.PreferTaskEnvironmentConstructorInjection);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.EnableConcurrentExecution();
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.RegisterCompilationStartAction(OnCompilationStart);
+        }
+
+        private static void OnCompilationStart(CompilationStartAnalysisContext context)
+        {
+            INamedTypeSymbol? multiThreadableTaskType =
+                context.Compilation.GetTypeByMetadataName(WellKnownTypeNames.IMultiThreadableTaskFullName);
+            INamedTypeSymbol? taskEnvironmentType =
+                context.Compilation.GetTypeByMetadataName(WellKnownTypeNames.TaskEnvironmentFullName);
+
+            if (multiThreadableTaskType is null || taskEnvironmentType is null)
+            {
+                return;
+            }
+
+            context.RegisterSymbolAction(
+                symbolContext => AnalyzeNamedType(
+                    symbolContext,
+                    multiThreadableTaskType,
+                    taskEnvironmentType),
+                SymbolKind.NamedType);
+        }
+
+        private static void AnalyzeNamedType(
+            SymbolAnalysisContext context,
+            INamedTypeSymbol multiThreadableTaskType,
+            INamedTypeSymbol taskEnvironmentType)
+        {
+            var taskType = (INamedTypeSymbol)context.Symbol;
+            if (taskType.TypeKind != TypeKind.Class ||
+                taskType.IsAbstract ||
+                !SharedAnalyzerHelpers.ImplementsInterface(taskType, multiThreadableTaskType) ||
+                HasTaskEnvironmentConstructor(taskType, taskEnvironmentType))
+            {
+                return;
+            }
+
+            foreach (Location location in taskType.Locations)
+            {
+                if (location.IsInSource)
+                {
+                    context.ReportDiagnostic(Diagnostic.Create(
+                        DiagnosticDescriptors.PreferTaskEnvironmentConstructorInjection,
+                        location,
+                        taskType.Name));
+                    return;
+                }
+            }
+        }
+
+        private static bool HasTaskEnvironmentConstructor(
+            INamedTypeSymbol taskType,
+            INamedTypeSymbol taskEnvironmentType)
+        {
+            foreach (IMethodSymbol constructor in taskType.InstanceConstructors)
+            {
+                if (constructor.DeclaredAccessibility == Accessibility.Public &&
+                    constructor.Parameters.Length == 1 &&
+                    SymbolEqualityComparer.Default.Equals(constructor.Parameters[0].Type, taskEnvironmentType))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/TaskAnalyzer/TaskEnvironmentConstructorInjectionAnalyzer.cs
+++ b/src/TaskAnalyzer/TaskEnvironmentConstructorInjectionAnalyzer.cs
@@ -27,10 +27,14 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
         {
             INamedTypeSymbol? multiThreadableTaskType =
                 context.Compilation.GetTypeByMetadataName(WellKnownTypeNames.IMultiThreadableTaskFullName);
+            if (multiThreadableTaskType is null)
+            {
+                return;
+            }
+
             INamedTypeSymbol? taskEnvironmentType =
                 context.Compilation.GetTypeByMetadataName(WellKnownTypeNames.TaskEnvironmentFullName);
-
-            if (multiThreadableTaskType is null || taskEnvironmentType is null)
+            if (taskEnvironmentType is null)
             {
                 return;
             }


### PR DESCRIPTION
## Summary

- add `MSBuildTask0011` at Info severity for concrete `IMultiThreadableTask` implementations that do not expose a public single-`TaskEnvironment` constructor
- cover valid, invalid, abstract, and inherited-constructor cases
- document the recommended constructor-injection pattern in the analyzer README and thread-safe task specification

Replaces #14400, which GitHub automatically closed when its stacked base branch was deleted after #14315 merged. The branch is now rebased directly onto `main`. The rule moved from the originally proposed ID 0010 to 0011 because `main` assigned `MSBuildTask0010` in #13974.

## Compatibility

The task-authoring analyzer is currently non-shipping/opt-in, and this diagnostic defaults to Info severity, so it does not break builds using warnings-as-errors. No ChangeWave is needed.

## Performance

Measured with the BenchmarkDotNet harness from #14387 in a disposable integration checkout, using the default job on an Apple M4 Max with .NET 10.0.8 / SDK 10.0.300. `MSBuildTask0009` is the closest existing symbol-action analyzer.

| Diagnostics | MSBuildTask0009 | MSBuildTask0011 | 0009 allocated | 0011 allocated |
|---:|---:|---:|---:|---:|
| 1 | 358.4 us | 357.9 us | 352.02 KB | 352.26 KB |
| 10 | 563.5 us | 588.8 us | 693.73 KB | 683.04 KB |
| 100 | 2.731 ms | 2.835 ms | 3,570.28 KB | 3,584.23 KB |

The initial no-reference path measured 48.08 us / 32.41 KB. Short-circuiting after the mandatory `IMultiThreadableTask` lookup reduced that to 35.52 us / 30.56 KB, close to `MSBuildTask0009` at 31.46 us / 30.56 KB. Diagnostic time, allocations, and 1/10/100 scaling are comparable, so no further complexity is justified.

## Validation

- `./build.sh -v quiet`
- `dotnet test --project src/TaskAnalyzer.Tests/TaskAnalyzer.Tests.csproj -c Release`
- #14387 BenchmarkDotNet no-op and exact-count 1/10/100 diagnostic scenarios

Fixes #14378
