### PR TITLE
Run -mt VMR validation three times weekly

### DIFF
--- a/azure-pipelines/vmr-sb-validation.yml
+++ b/azure-pipelines/vmr-sb-validation.yml
@@ -21,7 +21,7 @@ parameters:
 - name: extraPropertiesStage2
   displayName: 'Extra MSBuild properties for stage 2 (e.g., /p:DotNetBuildMT=true)'
   type: string
-  default: '/p:DotNetBuildMT=true /p:MSBuildMTExcludedReposOverride=noexclusion'
+  default: '/p:DotNetBuildMT=true'
 
 variables:
 - template: /eng/common/templates/variables/pool-providers.yml@self

--- a/azure-pipelines/vmr-sb-validation.yml
+++ b/azure-pipelines/vmr-sb-validation.yml
@@ -3,17 +3,25 @@
 # Builds the VMR in source-build mode to validate MSBuild changes.
 # Supports passing extra MSBuild properties to stage 2 builds (e.g., -mt mode).
 #
-# Trigger: Manual only (queue from Azure DevOps UI)
+# Trigger: Monday, Wednesday, and Friday at 04:00 UTC or manual (queue from Azure DevOps UI)
 # Uses the same pattern as runtime's vmr-build-pr.yml.
 
 trigger: none
 pr: none
 
+schedules:
+- cron: '0 4 * * 1,3,5'
+  displayName: Mon/Wed/Fri -mt VMR build validation (04:00 UTC)
+  branches:
+    include:
+    - main
+  always: true
+
 parameters:
 - name: extraPropertiesStage2
   displayName: 'Extra MSBuild properties for stage 2 (e.g., /p:DotNetBuildMT=true)'
   type: string
-  default: '/p:DotNetBuildMT=true /p:MSBuildMTExcludedReposOverride=roslyn'
+  default: '/p:DotNetBuildMT=true /p:MSBuildMTExcludedReposOverride=noexclusion'
 
 variables:
 - template: /eng/common/templates/variables/pool-providers.yml@self


### PR DESCRIPTION
Runs the -mt VMR source-build validation at 04:00 UTC every Monday, Wednesday, and Friday.

The scheduled run passes only `/p:DotNetBuildMT=true` and always runs even when there are no new commits. Manual runs can still override `extraPropertiesStage2`.

Paired with dotnet/dotnet#7820, which removes the VMR repository exclusion machinery so the opt-in applies to every repository.