### PR TITLE
[vs18.6] Fix VMR validation pipeline endpoint

### DIFF
--- a/azure-pipelines/vmr-sb-validation.yml
+++ b/azure-pipelines/vmr-sb-validation.yml
@@ -29,7 +29,7 @@ resources:
   - repository: vmr
     type: github
     name: dotnet/dotnet
-    endpoint: dotnet
+    endpoint: public
 
 stages:
 - template: /eng/pipelines/templates/stages/vmr-build.yml@vmr

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -3,7 +3,7 @@
   <Import Project="Version.Details.props" />
 
   <PropertyGroup>
-    <VersionPrefix>18.6.12</VersionPrefix><DotNetFinalVersionKind>release</DotNetFinalVersionKind><!-- Keep next to VersionPrefix to create a conflict in forward-flow -->
+    <VersionPrefix>18.6.13</VersionPrefix><DotNetFinalVersionKind>release</DotNetFinalVersionKind><!-- Keep next to VersionPrefix to create a conflict in forward-flow -->
     <PreReleaseVersionLabel>servicing</PreReleaseVersionLabel>
     <PackageValidationBaselineVersion>18.5.0-preview-26126-01</PackageValidationBaselineVersion>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>


### PR DESCRIPTION
Backports the VMR repository service-connection change from #13871 to `vs18.6`.

The release branch still uses the `dotnet` endpoint, causing Azure Pipelines YAML preflight to fail on branch and PR events and create canceled, sub-second informational runs. Using `public`, as on `main`, lets Azure load the YAML and honor `trigger: none` and `pr: none`.

Also advances the servicing `VersionPrefix` from `18.6.12` to `18.6.13`.