### PR TITLE
Bump XML cryptography packages to 10.0.10

### DIFF
--- a/eng/Version.Details.props
+++ b/eng/Version.Details.props
@@ -16,14 +16,14 @@ This file should be imported by eng/Versions.props
     <SystemConfigurationConfigurationManagerPackageVersion>10.0.9</SystemConfigurationConfigurationManagerPackageVersion>
     <SystemDiagnosticsDiagnosticSourcePackageVersion>10.0.9</SystemDiagnosticsDiagnosticSourcePackageVersion>
     <SystemDiagnosticsEventLogPackageVersion>10.0.9</SystemDiagnosticsEventLogPackageVersion>
-    <SystemFormatsAsn1PackageVersion>10.0.9</SystemFormatsAsn1PackageVersion>
+    <SystemFormatsAsn1PackageVersion>10.0.10</SystemFormatsAsn1PackageVersion>
     <SystemFormatsNrbfPackageVersion>10.0.9</SystemFormatsNrbfPackageVersion>
     <SystemReflectionMetadataPackageVersion>10.0.9</SystemReflectionMetadataPackageVersion>
     <SystemReflectionMetadataLoadContextPackageVersion>10.0.9</SystemReflectionMetadataLoadContextPackageVersion>
     <SystemResourcesExtensionsPackageVersion>10.0.9</SystemResourcesExtensionsPackageVersion>
-    <SystemSecurityCryptographyPkcsPackageVersion>10.0.9</SystemSecurityCryptographyPkcsPackageVersion>
+    <SystemSecurityCryptographyPkcsPackageVersion>10.0.10</SystemSecurityCryptographyPkcsPackageVersion>
     <SystemSecurityCryptographyProtectedDataPackageVersion>10.0.9</SystemSecurityCryptographyProtectedDataPackageVersion>
-    <SystemSecurityCryptographyXmlPackageVersion>10.0.9</SystemSecurityCryptographyXmlPackageVersion>
+    <SystemSecurityCryptographyXmlPackageVersion>10.0.10</SystemSecurityCryptographyXmlPackageVersion>
     <SystemTextEncodingCodePagesPackageVersion>10.0.9</SystemTextEncodingCodePagesPackageVersion>
     <SystemTextJsonPackageVersion>10.0.9</SystemTextJsonPackageVersion>
     <SystemThreadingChannelsPackageVersion>10.0.9</SystemThreadingChannelsPackageVersion>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -33,7 +33,7 @@
       </Sha>
     </Dependency>
     <!-- Necessary for source-build. This allows the live version of the package to be used by source-build. -->
-    <Dependency Name="System.Formats.Asn1" Version="10.0.9">
+    <Dependency Name="System.Formats.Asn1" Version="10.0.10">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>
       </Sha>
@@ -69,13 +69,13 @@
       </Sha>
     </Dependency>
     <!-- Necessary for source-build. This allows the live version of the package to be used by source-build. -->
-    <Dependency Name="System.Security.Cryptography.Pkcs" Version="10.0.9">
+    <Dependency Name="System.Security.Cryptography.Pkcs" Version="10.0.10">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>
       </Sha>
     </Dependency>
     <!-- Necessary for source-build. This allows the live version of the package to be used by source-build. -->
-    <Dependency Name="System.Security.Cryptography.Xml" Version="10.0.9">
+    <Dependency Name="System.Security.Cryptography.Xml" Version="10.0.10">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>
       </Sha>


### PR DESCRIPTION
Related to dotnet/core#10474

### Context

Updates the XML cryptography dependency set to the patched .NET 10.0.10 servicing release. `System.Security.Cryptography.Pkcs` and `System.Formats.Asn1` must be updated with `System.Security.Cryptography.Xml` to avoid NuGet package downgrade errors.

### Changes Made

- Updated `System.Security.Cryptography.Xml` from `10.0.9` to `10.0.10`.
- Updated `System.Security.Cryptography.Pkcs` from `10.0.9` to `10.0.10`.
- Updated `System.Formats.Asn1` from `10.0.9` to `10.0.10`.
- Updated source-build dependency metadata for the three packages.

### Testing

- Built the repository with `.\build.cmd -verbosity quiet` — 0 warnings, 0 errors.