### PR TITLE
Partial Stream Read Fix and Floating Node Fix

### DIFF
--- a/src/Build.UnitTests/BackEnd/IpcStreamFragment_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/IpcStreamFragment_Tests.cs
@@ -1,0 +1,175 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Build.BackEnd;
+using Microsoft.Build.Shared;
+using Microsoft.Build.Internal;
+using Shouldly;
+using Xunit;
+
+#nullable disable
+
+namespace Microsoft.Build.UnitTests.BackEnd
+{
+    public sealed class IpcStreamFragment_Tests
+    {
+        private sealed class FragmentedStream : Stream
+        {
+            private readonly byte[] _buffer;
+            private int _position;
+            private readonly int _fragmentSize;
+
+            public FragmentedStream(byte[] buffer, int fragmentSize)
+            {
+                _buffer = buffer;
+                _fragmentSize = fragmentSize;
+            }
+
+            public override bool CanRead => true;
+            public override bool CanSeek => false;
+            public override bool CanWrite => false;
+            public override long Length => _buffer.Length;
+            public override long Position { get => _position; set => throw new NotSupportedException(); }
+
+            public override void Flush() { }
+
+            public override int Read(byte[] buffer, int offset, int count)
+            {
+                if (_position >= _buffer.Length)
+                {
+                    return 0; // EOF
+                }
+
+                int toRead = Math.Min(count, _fragmentSize);
+                toRead = Math.Min(toRead, _buffer.Length - _position);
+
+                Array.Copy(_buffer, _position, buffer, offset, toRead);
+                _position += toRead;
+
+                return toRead;
+            }
+
+            public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+            {
+                return Task.FromResult(Read(buffer, offset, count));
+            }
+
+#if FEATURE_APM
+            public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback callback, object state)
+            {
+                var result = new StreamAsyncResult(state);
+                result.BytesRead = Read(buffer, offset, count);
+                result.IsCompleted = true;
+                callback?.Invoke(result);
+                return result;
+            }
+
+            public override int EndRead(IAsyncResult asyncResult)
+            {
+                return ((StreamAsyncResult)asyncResult).BytesRead;
+            }
+
+            private sealed class StreamAsyncResult : IAsyncResult
+            {
+                public StreamAsyncResult(object state) => AsyncState = state;
+                public int BytesRead { get; set; }
+                public object AsyncState { get; }
+                public WaitHandle AsyncWaitHandle => throw new NotSupportedException();
+                public bool CompletedSynchronously => true;
+                public bool IsCompleted { get; set; }
+            }
+#endif
+
+#if NETCOREAPP
+            public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+            {
+                if (_position >= _buffer.Length)
+                {
+                    return new ValueTask<int>(0);
+                }
+
+                int toRead = Math.Min(buffer.Length, _fragmentSize);
+                toRead = Math.Min(toRead, _buffer.Length - _position);
+
+                _buffer.AsMemory(_position, toRead).CopyTo(buffer);
+                _position += toRead;
+
+                return new ValueTask<int>(toRead);
+            }
+#endif
+
+            public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+            public override void SetLength(long value) => throw new NotSupportedException();
+            public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+        }
+
+        private sealed class MockPacketFactory : INodePacketFactory
+        {
+            public int RoutePacketCalls { get; private set; }
+            public INodePacket LastPacket { get; private set; }
+
+            public void RoutePacket(int nodeId, INodePacket packet)
+            {
+                RoutePacketCalls++;
+                LastPacket = packet;
+            }
+
+            public void DeserializeAndRoutePacket(int nodeId, NodePacketType packetType, ITranslator translator)
+            {
+                RoutePacketCalls++;
+            }
+
+            public void RegisterPacketHandler(NodePacketType packetType, NodePacketFactoryMethod factory, INodePacketHandler handler)
+            {
+            }
+
+            public void UnregisterPacketHandler(NodePacketType packetType)
+            {
+            }
+
+            public INodePacket DeserializePacket(NodePacketType packetType, ITranslator translator)
+            {
+                return null;
+            }
+        }
+
+        [Fact]
+        public async Task RunPacketReadLoopAsync_HandlesFragmentedHeader()
+        {
+            // Prepare a mock packet stream.
+            byte packetType = (byte)NodePacketType.NodeShutdown;
+            byte[] packetBytes = new byte[] { packetType, 0, 0, 0, 0 }; // 5 byte header, 0 length body
+
+            // Fragment size of 2 will force a partial read of the 5-byte header (2 bytes, then 2 bytes, then 1 byte)
+            var fragmentedStream = new FragmentedStream(packetBytes, fragmentSize: 2);
+            var factory = new MockPacketFactory();
+
+            var context = new NodeProviderOutOfProcBase.NodeContext(
+                nodeId: 1,
+                process: null,
+                nodePipe: fragmentedStream,
+                factory: factory,
+                terminateDelegate: (nodeId) => { },
+                negotiatedVersion: 0,
+                handshakeOptions: HandshakeOptions.None);
+
+#if !FEATURE_APM
+            await context.RunPacketReadLoopAsync();
+#else
+            context.BeginAsyncPacketRead();
+            await Task.Yield(); // Just let it synchronously finish inside BeginAsyncPacketRead
+#endif
+            
+            if (factory.LastPacket is NodeShutdown shutdownPacket)
+            {
+                // The NodeShutdown packet should NOT be a ConnectionFailed reason with an exception.
+                shutdownPacket.Reason.ShouldNotBe(NodeShutdownReason.ConnectionFailed);
+            }
+        }
+    }
+}

--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -2846,8 +2846,12 @@ namespace Microsoft.Build.Execution
                     }
                 }
 
-                _nodeManager!.ShutdownConnectedNodes(_buildParameters!.EnableNodeReuse);
-                _taskHostNodeManager!.ShutdownConnectedNodes(_buildParameters.EnableNodeReuse);
+                // We are aborting the build because a node exited unexpectedly.
+                // Do not reuse nodes, as their state may be compromised by attempts to shut down while the build is in-progress.
+                _nodeManager!.ShutdownConnectedNodes(false /* enableNodeReuse */);
+                
+                // Do not cleanly shut down the task host nodes here because we are aborting;
+                // the task host will hear about it in time through the task building infrastructure.
 
                 foreach (BuildSubmissionBase submission in _buildSubmissions.Values)
                 {

--- a/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
@@ -1105,7 +1105,17 @@ namespace Microsoft.Build.BackEnd
                 {
                     try
                     {
-                        int bytesRead = await _pipeStream.ReadAsync(_headerByte.AsMemory(), CancellationToken.None).ConfigureAwait(false);
+                        int bytesRead = 0;
+                        while (bytesRead < _headerByte.Length)
+                        {
+                            int read = await _pipeStream.ReadAsync(_headerByte.AsMemory(bytesRead, _headerByte.Length - bytesRead), CancellationToken.None).ConfigureAwait(false);
+                            if (read == 0)
+                            {
+                                break;
+                            }
+                            bytesRead += read;
+                        }
+
                         if (!ProcessHeaderBytesRead(bytesRead))
                         {
                             return;
@@ -1467,6 +1477,16 @@ namespace Microsoft.Build.BackEnd
                         return;
                     }
 
+                    while (bytesRead > 0 && bytesRead < _headerByte.Length)
+                    {
+                        int additionalBytesRead = _pipeStream.Read(_headerByte, bytesRead, _headerByte.Length - bytesRead);
+                        if (additionalBytesRead == 0)
+                        {
+                            break;
+                        }
+                        bytesRead += additionalBytesRead;
+                    }
+
                     if (!ProcessHeaderBytesRead(bytesRead))
                     {
                         return;
@@ -1546,6 +1566,17 @@ namespace Microsoft.Build.BackEnd
                     {
                         CommunicationsUtilities.Trace(_nodeId, "Hit CLR bug #825607: called back twice on same async result; ignoring");
                         return;
+                    }
+
+                    while (bytesRead > 0 && bytesRead < _currentPacketLength)
+                    {
+                        byte[] packetData = _readBufferMemoryStream.GetBuffer();
+                        int additionalBytesRead = _pipeStream.Read(packetData, bytesRead, _currentPacketLength - bytesRead);
+                        if (additionalBytesRead == 0)
+                        {
+                            break;
+                        }
+                        bytesRead += additionalBytesRead;
                     }
 
                     if (!ProcessBodyBytesRead(bytesRead, _currentPacketLength, packetType))

--- a/src/Shared/NodeEndpointOutOfProcBase.cs
+++ b/src/Shared/NodeEndpointOutOfProcBase.cs
@@ -682,6 +682,15 @@ namespace Microsoft.Build.BackEnd
 #else
                                 bytesRead = localReadPipe.EndRead(result);
 #endif
+                                while (bytesRead > 0 && bytesRead < headerByte.Length)
+                                {
+                                    int additionalBytesRead = localReadPipe.Read(headerByte, bytesRead, headerByte.Length - bytesRead);
+                                    if (additionalBytesRead == 0)
+                                    {
+                                        break;
+                                    }
+                                    bytesRead += additionalBytesRead;
+                                }
                             }
                             catch (Exception e)
                             {


### PR DESCRIPTION
Fixes #12944

cc @Thefrank @arrowd @am11

Confirmed the fix by doing full VMR builds under FreeBSD 14 and 15 (soon arm64 should also complete).

### 1. Floating Node Fix (Shutdown Logic)
**Context:** When a build fails or aborts and MSBuild is tearing down, child nodes were sometimes left floating as zombie processes if the build was initially started with `/nodeReuse:true`. 

**Fix:** Modified `BuildManager.HandleNodeShutdown` to explicitly pass `enableNodeReuse: false` when aborting the build (e.g., when the `shutdownPacket` indicates `ConnectionFailed`). This guarantees that nodes are correctly forcefully shut down upon an abnormal termination instead of lingering in the background waiting for a new connection.

### 2. Partial Stream Read Fix (`MSB4166` crash on FreeBSD 15)
**Context:** When building the `dotnet` VMR on FreeBSD 15, MSBuild frequently crashes with `MSB4166: Child node "N" exited prematurely`.
**Root Cause:** MSBuild had a long-standing assumption in its IPC code where it assumed that a single `Stream.ReadAsync` or `Stream.EndRead` call on a NamedPipe/Unix Domain Socket would always return the exact requested number of bytes (in this case, the 5-byte MSBuild packet header). While this generally holds true for Windows Named Pipes operating in message mode, Unix Domain Sockets on Linux/FreeBSD are purely stream-oriented. The FreeBSD 15 kernel occasionally fragments the UDS packet delivery (e.g., delivering 2 bytes, then 3 bytes). When MSBuild received only 2 bytes from `ReadAsync`, it immediately failed its `bytesRead == Expected` check and threw a `ConnectionFailed` exception, killing the child process that was otherwise completely healthy.

**Fix:** Rewrote the IPC stream reading loops on both the parent side (`NodeProviderOutOfProcBase.cs`) and the child side (`NodeEndpointOutOfProcBase.cs`). The logic now correctly utilizes `while` loops that accumulate stream fragments synchronously and asynchronously until the full 5-byte header or packet body is received, fully mitigating fragmentation on Unix Domain Sockets.
