### PR TITLE
Use BCL APIs to resolve link targets.

### DIFF
--- a/src/Framework/NativeMethods.cs
+++ b/src/Framework/NativeMethods.cs
@@ -1304,56 +1304,6 @@ internal static class NativeMethods
     [DllImport("libc", SetLastError = true)]
     internal static extern int symlink(string oldpath, string newpath);
 
-#if NET
-    [DllImport("libc", EntryPoint = "realpath", SetLastError = true)]
-    private static extern IntPtr realpath_native(string path, IntPtr resolved);
-
-    [DllImport("libc", EntryPoint = "free")]
-    private static extern void free_native(IntPtr ptr);
-
-    /// <summary>
-    /// Resolves <paramref name="path"/> to its canonical form via POSIX <c>realpath(3)</c>, following
-    /// symlinks. Returns <c>null</c> on Windows, on null/empty input, or when the call fails.
-    /// Unlike <see cref="System.IO.Path.GetFullPath(string)"/>, this resolves symlinks against the real
-    /// filesystem without mutating process-global state, so it is safe to call from any thread.
-    /// </summary>
-    internal static string RealPath(string path)
-    {
-        if (IsWindows || string.IsNullOrEmpty(path))
-        {
-            return null;
-        }
-
-        IntPtr ptr = IntPtr.Zero;
-        try
-        {
-            ptr = realpath_native(path, IntPtr.Zero);
-            if (ptr == IntPtr.Zero)
-            {
-                return null;
-            }
-
-            return Marshal.PtrToStringUTF8(ptr);
-        }
-        finally
-        {
-            if (ptr != IntPtr.Zero)
-            {
-                // realpath() with NULL second arg returns a malloc()'d buffer; caller must free().
-                // Free it through libc's free() - the same library realpath() allocated it from -
-                // rather than relying on the managed runtime's allocator matching that libc.
-                free_native(ptr);
-            }
-        }
-    }
-#else
-    /// <summary>
-    /// .NET Framework builds of MSBuild only ship for Windows, where POSIX <c>realpath(3)</c> does not
-    /// exist, so this is always a no-op returning <c>null</c>.
-    /// </summary>
-    internal static string RealPath(string path) => null;
-#endif
-
 #if FEATURE_WINDOWSINTEROP
     [SupportedOSPlatform("windows6.1")]
     internal static unsafe bool SetThreadErrorMode(int newMode, out int oldMode)

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -3640,6 +3640,8 @@ namespace Microsoft.Build.CommandLine
         /// No-op on Windows, for absolute paths or paths containing <c>..</c>, when <c>PWD</c> is
         /// unset/relative/stale, or when change wave 18.10 is disabled.
         /// </summary>
+#if NET
+#nullable enable
         internal static string ResolveProjectPathAgainstLogicalCurrentDirectory(string projectFile)
         {
             if (!ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave18_10)
@@ -3653,15 +3655,15 @@ namespace Microsoft.Build.CommandLine
                 return projectFile;
             }
 
-            string logicalCurrentDirectory = Environment.GetEnvironmentVariable("PWD");
+            string? logicalCurrentDirectory = Environment.GetEnvironmentVariable("PWD");
             if (string.IsNullOrEmpty(logicalCurrentDirectory) || !Path.IsPathRooted(logicalCurrentDirectory))
             {
                 return projectFile;
             }
 
             // Confirm $PWD physically resolves to the same directory as getcwd(); otherwise PWD is stale.
-            string physicalPwd = NativeMethodsShared.RealPath(logicalCurrentDirectory);
-            string physicalCwd = NativeMethodsShared.RealPath(Directory.GetCurrentDirectory());
+            string? physicalPwd = File.ResolveLinkTarget(logicalCurrentDirectory, true)?.FullName;
+            string? physicalCwd = File.ResolveLinkTarget(Directory.GetCurrentDirectory(), true)?.FullName;
             if (physicalPwd is null || physicalCwd is null
                 || !string.Equals(physicalPwd, physicalCwd, StringComparison.Ordinal))
             {
@@ -3678,6 +3680,10 @@ namespace Microsoft.Build.CommandLine
 
             return rebasedProjectFile;
         }
+#nullable disable
+#else
+        internal static string ResolveProjectPathAgainstLogicalCurrentDirectory(string projectFile) => projectFile;
+#endif
 
         private static void ValidateExtensions(string[] projectExtensionsToIgnore)
         {


### PR DESCRIPTION
Fixes #

### Context

#13752 had to resolve paths to symlinks, and did it by P/Invoking to `realpath(3)`, while there is the `File.ResolveLinkTarget` method in the BCL. This PR moves to using it.

### Changes Made

* Removed `NativeMethods.RealPath` and related P/Invoke definitions.
* Replaced uses with `File.ResolveLinkTarget`.
  * This API exists only in modern .NET, but so was `NativeMethods.RealPath`. The body of the only method using this API was covered in `#if NET`.
    * Also added some nullable annotations to this method.

### Testing


### Notes
