### PR TITLE
Default the out-of-proc node read-pipe buffer to 256 KB (change wave 18.10)

### DIFF
--- a/documentation/wiki/ChangeWaves.md
+++ b/documentation/wiki/ChangeWaves.md
@@ -33,6 +33,7 @@ Change wave checks around features will be removed in the release that accompani
 - [Resolve relative project paths against the Unix logical current directory from `PWD`, so builds under symlinked directories produce stable project full paths and related output paths.](https://github.com/dotnet/msbuild/pull/13752)
 - [Restore passes ExcludeRestorePackageImports=true as a global property so NuGet's restore no longer triggers a second evaluation of every project.](https://github.com/dotnet/msbuild/issues/14273)
 - [`-getProperty`/`-getItem` (without a target) stop evaluation after the pass that produces the requested data instead of running a full evaluation, avoiding later passes such as target registration.](https://github.com/dotnet/msbuild/pull/14290)
+- [The out-of-proc node read-pipe buffer (`BufferedReadStream`) defaults to 256 KB (was 1 KB), cutting the number of pipe reads needed to drain a large packet body such as a TaskHostConfiguration carrying NuGet restore's RestoreGraphItems. Tunable via MSBUILDNODEREADBUFFERSIZE; set MSBUILDDISABLEFEATURESFROMVERSION=18.10 to revert to 1 KB.](https://github.com/dotnet/msbuild/pull/14485)
 
 ### 18.9
 - [GenerateResource: typed ResX data/metadata entries in Mark-of-the-Web files are now treated as untrusted and blocked with MSB3821; unblock the file (or set MSBUILDDISABLEFEATURESFROMVERSION=18.9) to restore prior behavior. ResXFileRef entries are always blocked regardless of this wave.](https://github.com/dotnet/msbuild/pull/14015)

--- a/src/Framework/BackEnd/BufferedReadStream.cs
+++ b/src/Framework/BackEnd/BufferedReadStream.cs
@@ -6,12 +6,12 @@ using System.IO;
 using System.IO.Pipes;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Build.Framework;
 
 namespace Microsoft.Build.BackEnd
 {
     internal class BufferedReadStream : Stream
     {
-        private const int BUFFER_SIZE = 1024;
         private NamedPipeServerStream _innerStream;
         private byte[] _buffer;
 
@@ -22,7 +22,7 @@ namespace Microsoft.Build.BackEnd
         public BufferedReadStream(NamedPipeServerStream innerStream)
         {
             _innerStream = innerStream;
-            _buffer = new byte[BUFFER_SIZE];
+            _buffer = new byte[Traits.Instance.NodeReadBufferSize];
 
             _currentlyBufferedByteCount = 0;
         }
@@ -64,7 +64,7 @@ namespace Microsoft.Build.BackEnd
 
         public override int Read(byte[] buffer, int offset, int count)
         {
-            if (count > BUFFER_SIZE)
+            if (count > _buffer.Length)
             {
                 // Trying to read more data than the buffer can hold
                 int alreadyCopied = 0;
@@ -98,7 +98,7 @@ namespace Microsoft.Build.BackEnd
                     _currentlyBufferedByteCount = 0;
                 }
 
-                int innerReadCount = _innerStream.Read(_buffer, 0, BUFFER_SIZE);
+                int innerReadCount = _innerStream.Read(_buffer, 0, _buffer.Length);
                 _currentIndexInBuffer = 0;
                 _currentlyBufferedByteCount = innerReadCount;
 
@@ -123,7 +123,7 @@ namespace Microsoft.Build.BackEnd
 
         public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
-            if (count > BUFFER_SIZE)
+            if (count > _buffer.Length)
             {
                 // Trying to read more data than the buffer can hold
                 int alreadyCopied = CopyToBuffer(buffer, offset);
@@ -147,7 +147,7 @@ namespace Microsoft.Build.BackEnd
                 int alreadyCopied = CopyToBuffer(buffer, offset);
 
 #pragma warning disable CA1835 // Prefer the 'Memory'-based overloads for 'ReadAsync' and 'WriteAsync'
-                int innerReadCount = await _innerStream.ReadAsync(_buffer, 0, BUFFER_SIZE, cancellationToken);
+                int innerReadCount = await _innerStream.ReadAsync(_buffer, 0, _buffer.Length, cancellationToken);
 #pragma warning restore CA1835 // Prefer the 'Memory'-based overloads for 'ReadAsync' and 'WriteAsync'
                 _currentIndexInBuffer = 0;
                 _currentlyBufferedByteCount = innerReadCount;

--- a/src/Framework/Traits.cs
+++ b/src/Framework/Traits.cs
@@ -155,6 +155,33 @@ namespace Microsoft.Build.Framework
         }
 
         /// <summary>
+        /// Size in bytes of the application-level read buffer that <c>BufferedReadStream</c> uses to drain the
+        /// named pipe feeding an out-of-process .NET node (worker node or .NET TaskHost). A packet body is
+        /// deserialized by streaming through this buffer, so a large packet - e.g. a TaskHostConfiguration
+        /// carrying a big ITaskItem[] such as NuGet restore's RestoreGraphItems - costs roughly
+        /// packetBytes / this-size individual pipe reads. The historical value was 1 KB, which makes a
+        /// multi-hundred-MB restore packet cost hundreds of thousands of pipe reads on Windows. Defaults to
+        /// 256 KB under change wave 18.10; set MSBUILDDISABLEFEATURESFROMVERSION=18.10 to revert to the
+        /// historical 1 KB. Explicitly tunable via MSBUILDNODEREADBUFFERSIZE, which overrides both. This is
+        /// distinct from <see cref="NodeConnectionBufferSize"/>, which sizes the kernel pipe buffer rather
+        /// than this user-space refill buffer.
+        /// </summary>
+        public readonly int NodeReadBufferSize = GetNodeReadBufferSize();
+
+        private static int GetNodeReadBufferSize()
+        {
+            int configured = EnvironmentUtilities.GetValueAsInt32OrDefault("MSBUILDNODEREADBUFFERSIZE", -1);
+            if (configured > 0)
+            {
+                return configured;
+            }
+
+            const int DefaultBufferSize = 256 * 1024;
+            const int LegacyBufferSize = 1024;
+            return ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave18_10) ? DefaultBufferSize : LegacyBufferSize;
+        }
+
+        /// <summary>
         /// Launches a persistent RAR process.
         /// </summary>
         /// TODO: Replace with command line flag when feature is completed. The environment variable is intented to avoid exposing the flag early.


### PR DESCRIPTION
### Context

`BufferedReadStream` wraps the named pipe that feeds an out-of-process .NET node (a worker node or a .NET TaskHost) and drains it through a fixed **1 KB** buffer (`src/Framework/BackEnd/BufferedReadStream.cs`). Packet bodies are deserialized by streaming through this buffer, so a large body is refilled roughly `body / 1 KB` times — approximately one underlying pipe read per ~1 KB.

This is most visible under the experimental multi-threaded mode (`-mt`), where tasks that are not task-host-safe run in an out-of-proc sidecar TaskHost. When such a task has a very large input — for example NuGet restore's `RestoreTask`, whose `RestoreGraphItems` can be ~223K items / ~2.9M metadata strings (hundreds of MB) — the `TaskHostConfiguration` packet is large, and draining it ~1 KB at a time is a dominant cost over Windows named pipes. (On Linux the same path uses Unix domain sockets and does not exhibit this.)

### Change

Raise the default read buffer from the historical **1 KB to 256 KB**, and make it explicitly overridable:

- **Default 256 KB, gated behind change wave 18.10.** Setting `MSBUILDDISABLEFEATURESFROMVERSION=18.10` reverts to the historical 1 KB, matching the existing opt-out mechanism for risky changes.
- **`MSBUILDNODEREADBUFFERSIZE`** overrides the wave default with an explicit size (mirrors the existing `MSBUILDNODECONNECTIONBUFFERSIZE`).
- This is distinct from `MSBUILDNODECONNECTIONBUFFERSIZE`, which sizes the *kernel* pipe buffer, not this user-space refill buffer.
- Only the modern `src/Framework` copy is changed; the legacy net35 `MSBuildTaskHost` copy is intentionally left untouched.

### Evidence

Sweep on an internal Windows performance-lab machine (16 logical cores), OrchardCore `dotnet restore -mt` (warm restore), same experimental MSBuild build with only `MSBUILDNODEREADBUFFERSIZE` varied per run. `RestoreTask` runs out-of-proc in a reusable sidecar TaskHost in every case (verified in the binlogs). The figure is the **median of 10 steady-state iterations** (a first, in-proc warmup iteration is excluded); the range is min–max across those 10.

| `MSBUILDNODEREADBUFFERSIZE` | RestoreTask median | (min–max) | total `restore` wall (median) |
| --- | --- | --- | --- |
| 1024 (old default) | **96.0 s** | 91.8–97.1 | 105 s |
| 4096 | 26.8 s | 25.5–28.7 | 36 s |
| 16384 | 9.9 s | 9.0–10.9 | 19 s |
| 65536 | 4.8 s | 3.8–5.9 | 17.5 s |
| **262144 (new default)** | **3.9 s** | 3.2–5.0 | 17.6 s |
| 1048576 | 3.7 s | 3.1–4.9 | 17.4 s |

Reading of the curve (with the caveat that this is a **single scenario on a single machine in the experimental `-mt` mode**, so it should not be over-generalized):

- The user-space 1 KB refill granularity accounts for the large majority of this task's out-of-proc cost here: enlarging the buffer takes `RestoreTask` from ~96 s to ~3.7 s (~26×), and the `restore` wall from ~105 s to ~17 s.
- Returns diminish sharply past ~64 KB, and there is a residual floor (~3.7 s here) that a larger buffer does not remove — consistent with the remainder being the actual restore work plus per-operation transfer rather than refill count.
- **256 KB** is chosen as the default because it is at the knee of the curve: it captures essentially all of the win (3.9 s vs the 3.7 s floor at 1 MB) while keeping the per-connection buffer small and fixed. A 256 KB buffer is allocated per out-of-proc connection only for the lifetime of that connection.

### Why a change wave rather than just the knob

The previous revision of this PR left the default at 1 KB and only added the knob. That leaves the regression in place for everyone who doesn't know to set an environment variable. Gating a raised default behind change wave 18.10 gives the fix to everyone while preserving a documented, supported opt-out (`MSBUILDDISABLEFEATURESFROMVERSION=18.10`) for anyone who sees a regression from the larger allocation.

### Relationship to #14486

#14486 proposes reading the whole declared packet body at once, which removes the dependence on any buffer size and reaches the same floor without a magic number. The two are complementary: this PR is a small, low-risk default change with an opt-out; #14486 is the more complete fix. If #14486 lands, this default may become moot. I'm happy to take whichever direction reviewers prefer.
