### PR TITLE
Read the task-host packet body in one pass before deserializing

### DIFF
--- a/src/Shared/NodeEndpointOutOfProcBase.cs
+++ b/src/Shared/NodeEndpointOutOfProcBase.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Buffers.Binary;
 #if NET
 using System.Collections.Frozen;
 #endif
@@ -644,6 +645,11 @@ namespace Microsoft.Build.BackEnd
             // spammed to the endpoint and it never gets an opportunity to shutdown.
             CommunicationsUtilities.Trace("Entering read loop.");
             byte[] headerByte = new byte[5];
+
+            // Reusable buffer holding each packet's body. The body is read off the pipe in full
+            // before it is deserialized from memory (see below). Grown on demand and kept for the
+            // life of the connection, mirroring NodePipeBase's _readBuffer.
+            MemoryStream readBodyStream = new MemoryStream();
             ITranslator writeTranslator = null;
 #if NET451_OR_GREATER
             Task<int> readTask = localReadPipe.ReadAsync(headerByte, 0, headerByte.Length, CancellationToken.None);
@@ -726,15 +732,62 @@ namespace Microsoft.Build.BackEnd
                             bool hasExtendedHeader = NodePacketTypeExtensions.HasExtendedHeader(rawType);
                             NodePacketType packetType = hasExtendedHeader ? NodePacketTypeExtensions.GetNodePacketType(rawType) : (NodePacketType)rawType;
 
+                            // The header carries the exact body length (bytes 1-4, little-endian: the sender
+                            // writes packetStreamLength - 5). Read the whole body into a reusable MemoryStream
+                            // in as few pipe reads as the OS delivers, then deserialize from memory. The
+                            // alternative - streaming the body field-by-field straight off the pipe - drains it
+                            // through BufferedReadStream's small refill buffer (one pipe read per refill), so a
+                            // large packet (e.g. a TaskHostConfiguration carrying NuGet restore's
+                            // RestoreGraphItems) costs a very large number of reads and is slow over Windows
+                            // named pipes. Reading into a MemoryStream also lets InterningBinaryReader take its
+                            // backing-buffer fast path. Mirrors NodePipeBase.ReadPacket.
+                            int packetLength = BinaryPrimitives.ReadInt32LittleEndian(new Span<byte>(headerByte, 1, 4));
+                            readBodyStream.Position = 0;
+                            readBodyStream.SetLength(packetLength);
+
+                            int bodyBytesRead = 0;
+                            try
+                            {
+                                byte[] bodyBuffer = readBodyStream.GetBuffer();
+                                while (bodyBytesRead < packetLength)
+                                {
+                                    int read = localReadPipe.Read(bodyBuffer, bodyBytesRead, packetLength - bodyBytesRead);
+                                    if (read == 0)
+                                    {
+                                        // Pipe disconnected mid-body.
+                                        break;
+                                    }
+
+                                    bodyBytesRead += read;
+                                }
+                            }
+                            catch (Exception e)
+                            {
+                                // Lost communications.  Abort (but allow node reuse)
+                                CommunicationsUtilities.Trace($"Exception reading packet body from server.  {e}");
+                                DebugUtils.DumpExceptionToFile(e);
+                                ChangeLinkStatus(LinkStatus.Inactive);
+                                exitLoop = true;
+                                break;
+                            }
+
+                            if (bodyBytesRead != packetLength)
+                            {
+                                CommunicationsUtilities.Trace($"Incomplete packet body read from server.  {bodyBytesRead} of {packetLength} bytes read");
+                                ChangeLinkStatus(LinkStatus.Failed);
+                                exitLoop = true;
+                                break;
+                            }
+
                             byte parentVersion = 0;
                             if (hasExtendedHeader)
                             {
-                                parentVersion = NodePacketTypeExtensions.ReadVersion(localReadPipe);
+                                parentVersion = NodePacketTypeExtensions.ReadVersion(readBodyStream);
                             }
 
                             try
                             {
-                                ITranslator readTranslator = BinaryTranslator.GetReadTranslator(localReadPipe, _sharedReadBuffer);
+                                ITranslator readTranslator = BinaryTranslator.GetReadTranslator(readBodyStream, _sharedReadBuffer);
 
                                 // parent sends a packet version that is already negotiated during handshake.
                                 // For Framework task hosts (CLR2/CLR4) without extended headers, defaults to 0.
@@ -828,6 +881,8 @@ namespace Microsoft.Build.BackEnd
                 }
             }
             while (!exitLoop);
+
+            readBodyStream.Dispose();
         }
 
         #endregion


### PR DESCRIPTION
### Context

The out-of-proc node read loop (`NodeEndpointOutOfProcBase.RunReadLoop`) deserializes each packet body by streaming it field-by-field straight off the pipe. That drains the pipe through `BufferedReadStream`'s small refill buffer — roughly one pipe read per refill. For a large packet body — e.g. a `TaskHostConfiguration` carrying NuGet restore's `RestoreGraphItems` (hundreds of thousands of items) — that is a very large number of reads, which appears to be slow over Windows named pipes. It is most visible under the experimental multi-threaded mode (`-mt`), where such tasks run in an out-of-proc sidecar TaskHost.

The companion PR #14485 quantifies how much the refill granularity matters, by making the buffer size tuneable and sweeping it on a Windows perf-lab machine (OrchardCore `dotnet restore -mt`, `RestoreTask` out-of-proc, median of 10 steady-state iterations):

| `MSBUILDNODEREADBUFFERSIZE` | RestoreTask median |
| --- | --- |
| 1024 (default) | 96.0 s |
| 16384 | 9.9 s |
| 65536 | 4.8 s |
| 1048576 | 3.7 s |

So the 1 KB refill granularity is most of this task's out-of-proc cost, but even a 1 MB buffer leaves a ~3.7 s floor and requires picking a magic number.

### Change

The 5-byte packet header already carries the exact body length (bytes 1-4, little-endian, written by every sender as `packetStreamLength - 5`). Use it to read the entire body into a reusable `MemoryStream` in as few pipe reads as the OS delivers, then deserialize from memory. Deserializing from a `MemoryStream` additionally lets `InterningBinaryReader` take its backing-buffer fast path. This removes the dependence on any buffer-size knob.

This mirrors the existing `NodePipeBase.ReadPacket` (already used by the RAR and server pipes), which reads the header, `SetLength`s a reusable buffer, reads the whole body, then deserializes.

- Senders verified to write the length field: `NodeProviderOutOfProcBase` (worker nodes / task hosts) and `MSBuildClient` (server node).
- Only the modern endpoint is changed; the legacy net35 `MSBuildTaskHost` endpoint is untouched.

### Trade-offs / open questions

- **Buffer retention.** The body buffer is kept for the connection lifetime and grows to the largest packet seen (the same characteristic as `NodePipeBase`'s reusable read buffer and the write side's reusable `MemoryStream`). For a connection that transfers one very large packet, that capacity is retained; a pooling or `SetLength`-shrinking strategy could be considered if that matters.
- **Synchronous read.** Reading the body is synchronous on the read-loop thread. This matches today's behavior — the field-by-field deserialize already blocks that thread for the whole body.

### Status / data

This is a **draft for discussion**. I have the buffer-sweep numbers above (from #14485) but have **not yet** run this exact-read build on the perf lab; I'll add a direct comparison of this approach against the best buffer value and the 1 KB baseline when I have it. The expectation to be verified is that it reaches roughly the same floor as a large buffer without a tuning knob.
