### PR TITLE
[TEST - do not merge] branch-freeze status smoke test

### DIFF
--- a/.branch-freeze-smoke-test
+++ b/.branch-freeze-smoke-test
@@ -1,0 +1,2 @@
+Temporary smoke test for the branch-freeze required status check (PR #14470 rollout).
+This branch and its PR are throwaway and will be deleted. Not for merge.

--- a/.branch-freeze-smoke-test
+++ b/.branch-freeze-smoke-test
@@ -1,2 +1,1 @@
-Temporary smoke test for the branch-freeze required status check (PR #14470 rollout).
-This branch and its PR are throwaway and will be deleted. Not for merge.
+Temporary smoke test marker (updated to trigger a synchronize event). Throwaway.


### PR DESCRIPTION
**Temporary smoke test — do not merge; will be deleted.**

Rollout verification for the branch-freeze automation (#14470). This draft PR targets the throwaway branch 	est/branch-freeze-smoke (never main) purely to confirm the `Set branch freeze PR status` workflow posts the required `branch-freeze` commit status. No `/freeze` is involved.

Expected: a green `branch-freeze` check with description **Branch open**.