### PR TITLE
Grant pull-requests: write to branch freeze command workflow

### DIFF
--- a/.github/branch-freeze/workflows/handle-command.ps1
+++ b/.github/branch-freeze/workflows/handle-command.ps1
@@ -44,7 +44,7 @@ function Add-Reaction {
             -Content $Content
     }
     catch {
-        return
+        Write-Host "::warning::Failed to add the '$Content' reaction to comment $CommentId."
     }
 }
 

--- a/.github/workflows/branch-freeze-command.yml
+++ b/.github/workflows/branch-freeze-command.yml
@@ -16,9 +16,10 @@ on:
 
 permissions:
   contents: read        # checkout the shared scripts
-  issues: write         # create/close/label the tracking issue, react, comment
-  # `statuses: write` and `pull-requests: read` are required only by the reusable
-  # refresh workflow and are granted on the `refresh` job below (least privilege).
+  issues: write         # create/close/label the tracking issue; react/reply on issue comments
+  pull-requests: write  # react/reply when the command comes from a pull request comment
+  # `statuses: write` is required only by the reusable refresh workflow and is
+  # granted on the `refresh` job below (least privilege).
 
 concurrency:
   # Do not let two freeze/unfreeze operations modify tracking issues at once.


### PR DESCRIPTION
### Context

Follow-up to #14470. The `/freeze` /unfreeze` command workflow only requested `issues: write`, but it reacts to and replies on the *triggering comment*. When a command is issued from a **pull request** comment, GitHub requires `pull-requests: write` for those operations, so the best-effort acknowledgement (👍 reaction + confirmation reply) failed with `HTTP 403`. The freeze/unfreeze state change itself always succeeded; only the acknowledgement on PR comments was affected. Confirmed live during rollout testing (a `/freeze` from a PR comment applied the freeze and stamped the required status red, but posted no ack).

### Changes Made

- Added `pull-requests: write` to the `command` job permissions in `branch-freeze-command.yml` so reactions/replies succeed when the command originates from a PR comment. This also covers the `deny-command` step (same job).
- Changed `Add-Reaction` in `handle-command.ps1` to log a `::warning::` instead of silently swallowing a failed reaction, so any future permission gap is diagnosable.
- Tightened the adjacent permissions comment (removed the now-inaccurate `pull-requests: read` note; `statuses: write` remains scoped to the refresh job).

### Testing

- Ran `pwsh .github/branch-freeze/tests/run-tests.ps1`: **73 passed, 0 failed**.
- Validated PowerShell parser over `.github/branch-freeze/**` (`*.ps1`/`*.psm1`): no errors.
- Parsed `branch-freeze-command.yml` with `powershell-yaml`: valid; command-job permissions now `{contents: read, issues: write, pull-requests: write}`.

### Notes

- Behavior when commanded from a regular **issue** comment was already correct and is unchanged.
- The `deny-command` path already logged reaction failures via `Write-Warning` and needs no change beyond the shared permission.