### PR TITLE
[vs17.14] Include ConfigurationManager in Microsoft.Build.vsix

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,7 +2,7 @@
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the MIT license. See License.txt in the project root for full license information. -->
 <Project>
   <PropertyGroup>
-    <VersionPrefix>17.14.52</VersionPrefix>
+    <VersionPrefix>17.14.53</VersionPrefix>
     <DotNetFinalVersionKind>release</DotNetFinalVersionKind>
     <PackageValidationBaselineVersion>17.13.9</PackageValidationBaselineVersion>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>

--- a/src/Package/MSBuild.VSSetup/files.swr
+++ b/src/Package/MSBuild.VSSetup/files.swr
@@ -59,6 +59,7 @@ folder InstallDir:\MSBuild\Current\Bin
   file source=$(X86BinPath)System.Runtime.CompilerServices.Unsafe.dll vs.file.ngenApplications="[installDir]\MSBuild\Current\Bin\MSBuild.exe" vs.file.ngenArchitecture=all vs.file.ngenPriority=1
   file source=$(X86BinPath)System.Threading.Tasks.Dataflow.dll vs.file.ngenApplications="[installDir]\MSBuild\Current\Bin\MSBuild.exe" vs.file.ngenArchitecture=all vs.file.ngenPriority=1
   file source=$(X86BinPath)System.Collections.Immutable.dll vs.file.ngenApplications="[installDir]\MSBuild\Current\Bin\MSBuild.exe" vs.file.ngenArchitecture=all vs.file.ngenPriority=1
+  file source=$(X86BinPath)System.Configuration.ConfigurationManager.dll
   file source=$(X86BinPath)Microsoft.Bcl.HashCode.dll
   file source=$(X86BinPath)Microsoft.NET.StringTools.dll vs.file.ngenArchitecture=all
   file source=$(TaskHostBinPath)Microsoft.NET.StringTools.net35.dll


### PR DESCRIPTION
Fixes #14404

## Context

The MSBuild configuration redirects `System.Configuration.ConfigurationManager` to version 10.0.0.8, but the explicit `Microsoft.Build.vsix` payload omitted the assembly.

## Changes Made

- Include `System.Configuration.ConfigurationManager.dll` in `MSBuild\Current\Bin`.
- Increment the servicing version to 17.14.53.

## Testing

- `./build.cmd -v quiet /p:RunAnalyzers=false`
- Built `src/Package/MSBuild.VSSetup/MSBuild.VSSetup.csproj` with full-framework MSBuild.