### PR TITLE
Add OIDC workflow for CEINTL localization feedback

### DIFF
--- a/.github/workflows/file-ceintl-localization-feedback.yml
+++ b/.github/workflows/file-ceintl-localization-feedback.yml
@@ -1,8 +1,8 @@
 name: File CEINTL localization feedback
 
 on:
-  pull_request_target:
-    types: [labeled]
+  schedule:
+    - cron: "7,22,37,52 * * * *"
   workflow_dispatch:
     inputs:
       pull_request:
@@ -10,37 +10,121 @@ on:
         required: true
         type: number
 
-permissions:
-  contents: read
-  id-token: write
-  pull-requests: write
-
-concurrency:
-  group: ceintl-localization-feedback-${{ github.event.pull_request.number || inputs.pull_request }}
-  cancel-in-progress: false
-
 jobs:
-  file-feedback:
-    if: >-
-      github.repository == 'dotnet/msbuild' &&
-      (github.event_name == 'workflow_dispatch' ||
-       github.event.label.name == 'file-ceintl-feedback')
+  discover:
+    if: github.repository == 'dotnet/msbuild'
     runs-on: ubuntu-latest
-    environment: ceintl-ticketing
+    permissions:
+      issues: read
+      pull-requests: read
+    outputs:
+      pull-requests: ${{ steps.discover.outputs.pull-requests }}
+      count: ${{ steps.discover.outputs.count }}
 
     steps:
-      # pull_request_target runs trusted default-branch workflow code. Explicitly
-      # check out the base commit and never execute files from the PR head.
+      - name: Find unfiled OneLoc findings
+        id: discover
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          PR_NUMBER: ${{ inputs.pull_request || '' }}
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const requestedNumber = Number(process.env.PR_NUMBER);
+            let pulls;
+
+            if (Number.isSafeInteger(requestedNumber) && requestedNumber > 0) {
+              const { data: pull } = await github.rest.pulls.get({
+                owner,
+                repo,
+                pull_number: requestedNumber
+              });
+              pulls = [pull];
+            } else {
+              pulls = await github.paginate(github.rest.pulls.list, {
+                owner,
+                repo,
+                state: 'open',
+                per_page: 100
+              });
+            }
+
+            const pullNumbers = [];
+            for (const pull of pulls) {
+              if (pull.user?.login !== 'dotnet-bot' ||
+                  !pull.title.startsWith('Localized file check-in by OneLocBuild Task:') ||
+                  !pull.head.ref.startsWith('locfiles/')) {
+                continue;
+              }
+
+              const reviews = await github.paginate(github.rest.pulls.listReviews, {
+                owner,
+                repo,
+                pull_number: pull.number,
+                per_page: 100
+              });
+              const hasFinding = reviews.some(review =>
+                review.user?.login === 'github-actions[bot]' &&
+                review.body?.includes('MSBuild Code Review') &&
+                /<!-- gh-aw-workflow-call-id: dotnet\/msbuild\/review(?:-on-open)?\.agent -->/.test(review.body) &&
+                /^### Findings?:\s*[1-9]\d*\b/im.test(review.body));
+              if (!hasFinding) {
+                continue;
+              }
+
+              if (!Number.isSafeInteger(requestedNumber) || requestedNumber <= 0) {
+                const comments = await github.paginate(github.rest.issues.listComments, {
+                  owner,
+                  repo,
+                  issue_number: pull.number,
+                  per_page: 100
+                });
+                if (comments.some(comment =>
+                  comment.user?.login === 'github-actions[bot]' &&
+                  comment.body?.includes('<!-- ceintl-localization-feedback -->'))) {
+                  continue;
+                }
+              }
+
+              pullNumbers.push(pull.number);
+            }
+
+            core.setOutput('pull-requests', JSON.stringify(pullNumbers));
+            core.setOutput('count', pullNumbers.length);
+
+  file-feedback:
+    if: needs.discover.outputs.count != '0'
+    needs: discover
+    runs-on: ubuntu-latest
+    environment: ceintl-ticketing
+    permissions:
+      contents: read
+      id-token: write
+      issues: write
+      pull-requests: write
+    strategy:
+      fail-fast: false
+      matrix:
+        pull_request: ${{ fromJSON(needs.discover.outputs.pull-requests) }}
+    concurrency:
+      group: ceintl-localization-feedback-${{ matrix.pull_request }}
+      cancel-in-progress: false
+
+    steps:
+      # Scheduled workflows execute trusted default-branch code. Explicitly
+      # check out that branch and never execute files from the reviewed PR.
       - name: Check out trusted workflow code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          ref: ${{ github.event.pull_request.base.sha || github.sha }}
+          ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false
 
       - name: Validate OneLoc pull request
+        id: validate
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
-          PR_NUMBER: ${{ github.event.pull_request.number || inputs.pull_request }}
+          PR_NUMBER: ${{ matrix.pull_request }}
           CONTEXT_PATH: ${{ runner.temp }}/ceintl-context.json
         with:
           script: |
@@ -97,14 +181,15 @@ jobs:
               pull_number,
               per_page: 100
             });
-            const review = reviews
+            const matchingReviews = reviews
               .filter(item =>
                 item.user?.login === 'github-actions[bot]' &&
                 item.body?.includes('MSBuild Code Review') &&
                 /<!-- gh-aw-workflow-call-id: dotnet\/msbuild\/review(?:-on-open)?\.agent -->/.test(item.body) &&
                 /^### Findings?:\s*[1-9]\d*\b/im.test(item.body))
               .sort((left, right) =>
-                new Date(right.submitted_at) - new Date(left.submitted_at))[0];
+                new Date(right.submitted_at) - new Date(left.submitted_at));
+            const review = matchingReviews[0];
 
             if (!review) {
               failures.push('no GitHub Actions expert review with one or more findings was found');
@@ -125,6 +210,7 @@ jobs:
               reviewUrl: review.html_url,
               reviewBody: review.body
             }, null, 2));
+            core.setOutput('pr-number', pull.number);
 
       - name: Sign in to Microsoft Entra with OIDC
         uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
@@ -147,7 +233,7 @@ jobs:
       - name: Link CEINTL feedback from pull request
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
-          PR_NUMBER: ${{ github.event.pull_request.number || inputs.pull_request }}
+          PR_NUMBER: ${{ steps.validate.outputs.pr-number }}
           WORK_ITEM_URL: ${{ steps.ceintl.outputs.work-item-url }}
           WORK_ITEM_ID: ${{ steps.ceintl.outputs.work-item-id }}
           CREATED: ${{ steps.ceintl.outputs.created }}
@@ -158,5 +244,5 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: Number(process.env.PR_NUMBER),
-              body: `${verb} CEINTL localization feedback: [${process.env.WORK_ITEM_ID}](${process.env.WORK_ITEM_URL})`
+              body: `<!-- ceintl-localization-feedback -->\n${verb} CEINTL localization feedback: [${process.env.WORK_ITEM_ID}](${process.env.WORK_ITEM_URL})`
             });

--- a/.github/workflows/file-ceintl-localization-feedback.yml
+++ b/.github/workflows/file-ceintl-localization-feedback.yml
@@ -2,7 +2,7 @@ name: File CEINTL localization feedback
 
 on:
   schedule:
-    - cron: "7,22,37,52 * * * *"
+    - cron: "17 8 * * *"
   workflow_dispatch:
     inputs:
       pull_request:

--- a/.github/workflows/file-ceintl-localization-feedback.yml
+++ b/.github/workflows/file-ceintl-localization-feedback.yml
@@ -1,0 +1,162 @@
+name: File CEINTL localization feedback
+
+on:
+  pull_request_target:
+    types: [labeled]
+  workflow_dispatch:
+    inputs:
+      pull_request:
+        description: OneLoc pull request number
+        required: true
+        type: number
+
+permissions:
+  contents: read
+  id-token: write
+  pull-requests: write
+
+concurrency:
+  group: ceintl-localization-feedback-${{ github.event.pull_request.number || inputs.pull_request }}
+  cancel-in-progress: false
+
+jobs:
+  file-feedback:
+    if: >-
+      github.repository == 'dotnet/msbuild' &&
+      (github.event_name == 'workflow_dispatch' ||
+       github.event.label.name == 'file-ceintl-feedback')
+    runs-on: ubuntu-latest
+    environment: ceintl-ticketing
+
+    steps:
+      # pull_request_target runs trusted default-branch workflow code. Explicitly
+      # check out the base commit and never execute files from the PR head.
+      - name: Check out trusted workflow code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
+          persist-credentials: false
+
+      - name: Validate OneLoc pull request
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number || inputs.pull_request }}
+          CONTEXT_PATH: ${{ runner.temp }}/ceintl-context.json
+        with:
+          script: |
+            const fs = require('fs');
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const pull_number = Number(process.env.PR_NUMBER);
+
+            if (!Number.isSafeInteger(pull_number) || pull_number <= 0) {
+              core.setFailed(`Invalid pull request number: ${process.env.PR_NUMBER}`);
+              return;
+            }
+
+            const { data: pull } = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number
+            });
+
+            const failures = [];
+            if (pull.user?.login !== 'dotnet-bot') {
+              failures.push(`author is '${pull.user?.login}', not 'dotnet-bot'`);
+            }
+            if (!pull.title.startsWith('Localized file check-in by OneLocBuild Task:')) {
+              failures.push('title is not a OneLocBuild check-in title');
+            }
+            if (!pull.head.ref.startsWith('locfiles/')) {
+              failures.push(`head branch '${pull.head.ref}' does not start with 'locfiles/'`);
+            }
+            if (pull.head.repo?.full_name !== `${owner}/${repo}`) {
+              failures.push(`head repository is '${pull.head.repo?.full_name}', not '${owner}/${repo}'`);
+            }
+
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner,
+              repo,
+              pull_number,
+              per_page: 100
+            });
+
+            const isLocalizationFile = path =>
+              /(^|\/)xlf\/.+\.xlf$/i.test(path) ||
+              /(^|\/)Resources\/.+\.resx$/i.test(path);
+            const unexpectedFiles = files
+              .map(file => file.filename)
+              .filter(path => !isLocalizationFile(path));
+            if (unexpectedFiles.length > 0) {
+              failures.push(`unexpected files: ${unexpectedFiles.join(', ')}`);
+            }
+
+            const reviews = await github.paginate(github.rest.pulls.listReviews, {
+              owner,
+              repo,
+              pull_number,
+              per_page: 100
+            });
+            const review = reviews
+              .filter(item =>
+                item.user?.login === 'github-actions[bot]' &&
+                item.body?.includes('MSBuild Code Review') &&
+                /<!-- gh-aw-workflow-call-id: dotnet\/msbuild\/review(?:-on-open)?\.agent -->/.test(item.body) &&
+                /^### Findings?:\s*[1-9]\d*\b/im.test(item.body))
+              .sort((left, right) =>
+                new Date(right.submitted_at) - new Date(left.submitted_at))[0];
+
+            if (!review) {
+              failures.push('no GitHub Actions expert review with one or more findings was found');
+            }
+
+            if (failures.length > 0) {
+              core.setFailed(`Refusing to file CEINTL feedback: ${failures.join('; ')}`);
+              return;
+            }
+
+            fs.writeFileSync(process.env.CONTEXT_PATH, JSON.stringify({
+              prNumber: pull.number,
+              prUrl: pull.html_url,
+              prTitle: pull.title,
+              baseRef: pull.base.ref,
+              headRef: pull.head.ref,
+              files: files.map(file => file.filename),
+              reviewUrl: review.html_url,
+              reviewBody: review.body
+            }, null, 2));
+
+      - name: Sign in to Microsoft Entra with OIDC
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
+        with:
+          client-id: ${{ vars.CEINTL_CLIENT_ID }}
+          tenant-id: ${{ vars.CEINTL_TENANT_ID }}
+          allow-no-subscriptions: true
+
+      - name: File or find CEINTL feedback
+        id: ceintl
+        shell: pwsh
+        env:
+          CEINTL_TEAM: ${{ vars.CEINTL_TEAM }}
+          CONTEXT_PATH: ${{ runner.temp }}/ceintl-context.json
+        run: >-
+          ./scripts/New-CeintlLocalizationFeedback.ps1
+          -ContextPath $env:CONTEXT_PATH
+          -Team $env:CEINTL_TEAM
+
+      - name: Link CEINTL feedback from pull request
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number || inputs.pull_request }}
+          WORK_ITEM_URL: ${{ steps.ceintl.outputs.work-item-url }}
+          WORK_ITEM_ID: ${{ steps.ceintl.outputs.work-item-id }}
+          CREATED: ${{ steps.ceintl.outputs.created }}
+        with:
+          script: |
+            const verb = process.env.CREATED === 'true' ? 'Created' : 'Found existing';
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: Number(process.env.PR_NUMBER),
+              body: `${verb} CEINTL localization feedback: [${process.env.WORK_ITEM_ID}](${process.env.WORK_ITEM_URL})`
+            });

--- a/documentation/wiki/Localization.md
+++ b/documentation/wiki/Localization.md
@@ -24,6 +24,18 @@
 - 3 weeks cadence for main, initiated by loc team
 - on demand for main / release branches, initiated by msbuild team
 
+### Filing feedback from a OneLoc pull request
+
+When the automated expert review identifies a translation problem in a
+`dotnet-bot` OneLoc pull request, apply the `file-ceintl-feedback` label. The
+protected `ceintl-ticketing` GitHub environment requires maintainer approval,
+then the workflow files or reuses a CEINTL feedback item and comments its link
+on the pull request.
+
+The workflow uses GitHub OIDC and a dedicated Microsoft Entra service principal.
+It does not use a PAT, does not check out the pull request head, and refuses
+pull requests that are not OneLoc changes containing only localization files.
+
 ## Contributing a better translation
 
 - send a PR with an updated `<target>` element of the xlf resource (do not include other non-localization changes)

--- a/documentation/wiki/Localization.md
+++ b/documentation/wiki/Localization.md
@@ -27,7 +27,7 @@
 ### Filing feedback from a OneLoc pull request
 
 When the automated expert review identifies a translation problem in a
-`dotnet-bot` OneLoc pull request, a scheduled workflow detects the finding,
+`dotnet-bot` OneLoc pull request, a daily scheduled workflow detects the finding,
 files or reuses a CEINTL feedback item, and comments its link on the pull
 request.
 

--- a/documentation/wiki/Localization.md
+++ b/documentation/wiki/Localization.md
@@ -27,10 +27,9 @@
 ### Filing feedback from a OneLoc pull request
 
 When the automated expert review identifies a translation problem in a
-`dotnet-bot` OneLoc pull request, apply the `file-ceintl-feedback` label. The
-protected `ceintl-ticketing` GitHub environment requires maintainer approval,
-then the workflow files or reuses a CEINTL feedback item and comments its link
-on the pull request.
+`dotnet-bot` OneLoc pull request, a scheduled workflow detects the finding,
+files or reuses a CEINTL feedback item, and comments its link on the pull
+request.
 
 The workflow uses GitHub OIDC and a dedicated Microsoft Entra service principal.
 It does not use a PAT, does not check out the pull request head, and refuses

--- a/scripts/New-CeintlLocalizationFeedback.ps1
+++ b/scripts/New-CeintlLocalizationFeedback.ps1
@@ -1,0 +1,230 @@
+<#
+.SYNOPSIS
+    Files localization feedback in CEINTL for a validated OneLoc pull request.
+
+.DESCRIPTION
+    Uses the current Microsoft Entra identity to retrieve the CEINTL feedback
+    work item template, find an existing item for the pull request, or create a
+    new item. The GitHub workflow obtains the identity through OIDC; this script
+    does not accept or persist a PAT or client secret.
+
+.PARAMETER ContextPath
+    Path to the trusted JSON context produced by the GitHub workflow.
+
+.PARAMETER Team
+    CEINTL team name or ID that owns the feedback work item template.
+#>
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$ContextPath,
+
+    [Parameter(Mandatory = $true)]
+    [string]$Team,
+
+    [string]$Organization = 'ceapex',
+
+    [string]$Project = 'CEINTL',
+
+    [guid]$TemplateId = '9a48bdd1-98da-4592-8d8d-c52c0856301d'
+)
+
+Set-StrictMode -Version 'Latest'
+$ErrorActionPreference = 'Stop'
+
+$AzureDevOpsResource = '499b84ac-1321-427f-aa17-267ca6975798'
+
+function Invoke-AzureDevOpsRequest
+{
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateSet('Get', 'Post')]
+        [string]$Method,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Uri,
+
+        [string]$Body,
+
+        [string]$ContentType = 'application/json'
+    )
+
+    $parameters = @{
+        Method = $Method
+        Uri = $Uri
+        Headers = @{ Authorization = "Bearer $script:AccessToken" }
+        ContentType = $ContentType
+    }
+    if ($Body)
+    {
+        $parameters.Body = $Body
+    }
+
+    Invoke-RestMethod @parameters
+}
+
+function Set-WorkflowOutput
+{
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Name,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Value
+    )
+
+    if ($env:GITHUB_OUTPUT)
+    {
+        Add-Content -Path $env:GITHUB_OUTPUT -Value "$Name=$Value"
+    }
+    else
+    {
+        Write-Host "$Name=$Value"
+    }
+}
+
+if (-not (Test-Path -LiteralPath $ContextPath -PathType Leaf))
+{
+    throw "Context file '$ContextPath' does not exist."
+}
+if ([string]::IsNullOrWhiteSpace($Team))
+{
+    throw 'CEINTL_TEAM is not configured in the ceintl-ticketing GitHub environment.'
+}
+if (-not (Get-Command az -ErrorAction SilentlyContinue))
+{
+    throw "Azure CLI was not found. The workflow must run 'azure/login' before this script."
+}
+
+$context = Get-Content -LiteralPath $ContextPath -Raw | ConvertFrom-Json
+$prNumber = [int]$context.prNumber
+$expectedPrUrl = "https://github.com/dotnet/msbuild/pull/$prNumber"
+if ($prNumber -le 0 -or $context.prUrl -ne $expectedPrUrl)
+{
+    throw "The context does not identify a dotnet/msbuild pull request."
+}
+if ([string]::IsNullOrWhiteSpace($context.reviewBody))
+{
+    throw 'The context does not contain an expert-review finding.'
+}
+
+$script:AccessToken = (& az account get-access-token --resource $AzureDevOpsResource --query accessToken --output tsv --only-show-errors)
+if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($script:AccessToken))
+{
+    throw 'Could not obtain a Microsoft Entra token for Azure DevOps.'
+}
+
+$encodedOrganization = [Uri]::EscapeDataString($Organization)
+$encodedProject = [Uri]::EscapeDataString($Project)
+$encodedTeam = [Uri]::EscapeDataString($Team)
+$baseUri = "https://dev.azure.com/$encodedOrganization/$encodedProject"
+$witApiBaseUri = "$baseUri/_apis/wit"
+
+$template = Invoke-AzureDevOpsRequest -Method Get -Uri "$baseUri/$encodedTeam/_apis/wit/templates/$TemplateId`?api-version=7.1"
+if ([string]::IsNullOrWhiteSpace($template.workItemTypeName))
+{
+    throw "CEINTL template '$TemplateId' did not specify a work item type."
+}
+
+$dedupTag = "GitHubPR-dotnet-msbuild-$prNumber"
+$escapedDedupTag = $dedupTag.Replace("'", "''")
+$escapedWorkItemType = ([string]$template.workItemTypeName).Replace("'", "''")
+$wiql = @{
+    query = @"
+SELECT [System.Id]
+FROM WorkItems
+WHERE [System.TeamProject] = @project
+  AND [System.WorkItemType] = '$escapedWorkItemType'
+  AND [System.Tags] CONTAINS '$escapedDedupTag'
+ORDER BY [System.CreatedDate] DESC
+"@
+} | ConvertTo-Json
+$queryResult = Invoke-AzureDevOpsRequest -Method Post -Uri "$witApiBaseUri/wiql?api-version=7.1" -Body $wiql
+$existing = $null
+foreach ($existingReference in $queryResult.workItems)
+{
+    $candidate = Invoke-AzureDevOpsRequest -Method Get -Uri "$witApiBaseUri/workitems/$($existingReference.id)?api-version=7.1&`$expand=fields"
+    $candidateTags = [string]$candidate.fields.'System.Tags' -split ';' |
+        ForEach-Object { $_.Trim() } |
+        Where-Object { $_ }
+    if ($candidateTags -contains $dedupTag)
+    {
+        $existing = $candidate
+        break
+    }
+}
+if ($existing)
+{
+    Set-WorkflowOutput -Name 'work-item-id' -Value ([string]$existing.id)
+    Set-WorkflowOutput -Name 'work-item-url' -Value ([string]$existing._links.html.href)
+    Set-WorkflowOutput -Name 'created' -Value 'false'
+    return
+}
+
+$fieldResponse = Invoke-AzureDevOpsRequest -Method Get -Uri "$witApiBaseUri/fields?api-version=7.1"
+$writableFields = @{}
+foreach ($field in $fieldResponse.value)
+{
+    if (-not $field.readOnly -or $field.referenceName -in @('System.AreaPath', 'System.IterationPath'))
+    {
+        $writableFields[$field.referenceName] = $true
+    }
+}
+
+$fields = @{}
+foreach ($property in $template.fields.PSObject.Properties)
+{
+    if ($writableFields.ContainsKey($property.Name))
+    {
+        $fields[$property.Name] = $property.Value
+    }
+}
+
+$encodedReview = [System.Net.WebUtility]::HtmlEncode([string]$context.reviewBody)
+$encodedFiles = $context.files |
+    ForEach-Object { "<li><code>$([System.Net.WebUtility]::HtmlEncode([string]$_))</code></li>" }
+$description = @"
+<p>An automated MSBuild review found a possible localization problem in
+<a href="$expectedPrUrl">dotnet/msbuild#$prNumber</a>.</p>
+<p><strong>Base:</strong> $([System.Net.WebUtility]::HtmlEncode([string]$context.baseRef))<br/>
+<strong>Head:</strong> $([System.Net.WebUtility]::HtmlEncode([string]$context.headRef))</p>
+<p><strong>Changed localization files:</strong></p>
+<ul>$($encodedFiles -join '')</ul>
+<p><strong>Expert review:</strong> <a href="$([System.Net.WebUtility]::HtmlEncode([string]$context.reviewUrl))">GitHub review</a></p>
+<pre>$encodedReview</pre>
+"@
+
+$templateTags = @()
+if ($fields.ContainsKey('System.Tags') -and $fields['System.Tags'])
+{
+    $templateTags = [string]$fields['System.Tags'] -split ';'
+}
+$fields['System.Title'] = "[dotnet/msbuild#$prNumber] OneLocBuild localization feedback"
+$fields['System.Description'] = $description
+$fields['System.Tags'] = (@($templateTags) + @($dedupTag, 'OneLocBuild', 'GitHub automation') |
+        ForEach-Object { $_.Trim() } |
+        Where-Object { $_ } |
+        Select-Object -Unique) -join '; '
+
+$patch = [System.Collections.Generic.List[object]]::new()
+foreach ($fieldName in ($fields.Keys | Sort-Object))
+{
+    $patch.Add(@{
+            op = 'add'
+            path = "/fields/$fieldName"
+            value = $fields[$fieldName]
+        })
+}
+
+$workItemType = [Uri]::EscapeDataString([string]$template.workItemTypeName)
+$createUri = "$witApiBaseUri/workitems/`$${workItemType}?api-version=7.1"
+$created = Invoke-AzureDevOpsRequest `
+    -Method Post `
+    -Uri $createUri `
+    -Body ($patch | ConvertTo-Json -Depth 20) `
+    -ContentType 'application/json-patch+json'
+
+Set-WorkflowOutput -Name 'work-item-id' -Value ([string]$created.id)
+Set-WorkflowOutput -Name 'work-item-url' -Value ([string]$created._links.html.href)
+Set-WorkflowOutput -Name 'created' -Value 'true'


### PR DESCRIPTION
Related to #14246

### Context

The expert-review workflow can identify translation defects in OneLoc pull requests, but filing the corresponding CEINTL feedback is manual. This adds fully automatic filing that uses GitHub OIDC and a dedicated Microsoft Entra identity instead of a PAT.

### Changes Made

- Added `.github/workflows/file-ceintl-localization-feedback.yml` to scan open pull requests once daily and select unhandled OneLoc findings.
- Added validation for the `dotnet-bot` author, OneLoc title and branch, trusted repository, localization-only files, and findings from the MSBuild expert-review workflows.
- Added a hidden pull-request comment marker so scheduled scans process each finding once while CEINTL tag matching remains the authoritative deduplication check.
- Added OIDC authentication through the `ceintl-ticketing` environment without checking out or executing pull-request code.
- Added `scripts/New-CeintlLocalizationFeedback.ps1` to load the CEINTL Feedback template, preserve writable template fields, deduplicate by an exact pull-request tag, create the work item, and return its URL.
- Added a pull-request comment linking the created or existing CEINTL item.
- Added manual dispatch for the first live test and recovery scenarios.
- Documented the automatic flow in `documentation/wiki/Localization.md`.

### Testing

- Parsed `scripts/New-CeintlLocalizationFeedback.ps1` with the PowerShell AST parser.
- Parsed the workflow with `ConvertFrom-Yaml`.
- Verified that PR #14246 satisfies the discovery and validation rules.
- Exercised mocked CEINTL creation and exact-tag deduplication paths, including the Entra bearer-token header and workflow outputs.
- Exercised scheduled discovery against the current open `dotnet-bot` pull requests.
- No live CEINTL work item was created because the service identity and GitHub environment are not configured yet.

### Notes

- Create a dedicated Microsoft Entra app/service principal with GitHub federation: issuer `https://token.actions.githubusercontent.com`, subject `repo:dotnet/msbuild:environment:ceintl-ticketing`, and audience `api://AzureADTokenExchange`.
- Add the service principal object to the `ceapex` Azure DevOps organization and `CEINTL` project, granting only the work-item/template read access and work-item creation access required by this workflow.
- Create the GitHub environment `ceintl-ticketing` without required reviewers. Restrict its deployment branches to the default branch so scheduled jobs can obtain OIDC tokens only from trusted workflow code.
- Configure environment variables `CEINTL_CLIENT_ID`, `CEINTL_TENANT_ID`, and `CEINTL_TEAM`. `CEINTL_TEAM` must identify the team that owns Feedback template `9a48bdd1-98da-4592-8d8d-c52c0856301d`.
- Configure the identity and environment before merging. After merge, run the workflow manually against a known OneLoc finding to confirm the CEINTL template fields and permissions; subsequent findings require no human interaction.
