### PR TITLE
Prototype cross-process evaluation cache

### DIFF
--- a/documentation/specs/proposed/evaluation-metrics.md
+++ b/documentation/specs/proposed/evaluation-metrics.md
@@ -1,0 +1,46 @@
+# MSBuild evaluation metrics
+
+## Motivation
+
+MSBuild project evaluations can be initiated by a build submission or directly through the object model. The latter includes SDK operations such as loading a `Project` or creating a `ProjectInstance` before a build begins. These evaluations do not necessarily reach the binary logger attached to the subsequent build, which makes their performance difficult to track consistently.
+
+MSBuild exposes process-local evaluation measurements through `System.Diagnostics.Metrics`. MSBuild does not configure an exporter or send these measurements anywhere. Hosts and diagnostic tools choose whether and how to collect them.
+
+## Meter
+
+The meter name is `Microsoft.Build`, matching the assembly that emits the measurements. This is intentionally separate from the `Microsoft.Build.Telemetry*` activity sources used for sampled Visual Studio telemetry.
+
+| Instrument | Type | Unit | Description |
+| --- | --- | --- | --- |
+| `msbuild.project.evaluations` | `Counter<long>` | `{evaluation}` | Number of project evaluations |
+| `msbuild.project.evaluation.duration` | `Histogram<double>` | `s` | Duration of project evaluations |
+
+The histogram also exposes a count to consumers that aggregate histogram measurements. The separate counter supports lightweight consumers that only subscribe to evaluation counts. The two counts describe the same evaluations and must not be added together.
+
+Both instruments use the following low-cardinality tags:
+
+| Tag | Values | Description |
+| --- | --- | --- |
+| `msbuild.project.evaluation.stage` | `properties`, `item_definitions`, `items`, `using_tasks`, `full` | Last evaluation stage requested by the caller |
+| `msbuild.project.evaluation.origin` | `build_submission`, `standalone` | Whether the evaluation belongs to a build submission or was initiated directly through the object model |
+| `msbuild.project.evaluation.succeeded` | `true`, `false` | Whether evaluation completed successfully |
+
+Project paths, target frameworks, global properties, and other potentially sensitive or high-cardinality values are intentionally excluded.
+
+Each invocation of the evaluator is recorded separately, including explicit project reevaluations. Duration measures the evaluator passes themselves and excludes evaluator setup and final logging.
+
+## Relationship to existing diagnostics
+
+`MSBuildEventSource.EvaluateStart` and `EvaluateStop` remain the detailed tracing mechanism. Project evaluation build events remain available to loggers and binary logs when a binary logger is attached to the relevant logging service.
+
+The metrics provide a low-volume aggregate view and also cover standalone evaluations without requiring a logger. A build evaluation can appear in both a binlog and the metrics stream, so consumers must not add the two counts together.
+
+## Collection
+
+Consumers can subscribe with `MeterListener` or an OpenTelemetry `MeterProvider`. Collection is process-local: a host that needs measurements from SDK processes, MSBuild server processes, and worker nodes must collect the `Microsoft.Build` meter from each process.
+
+The metrics are also available on .NET Framework, where the `Microsoft.Build` package declares its `System.Diagnostics.DiagnosticSource` dependency. Metrics initialization and listener failures degrade to a no-op rather than affecting evaluation.
+
+Metrics are local diagnostics and MSBuild does not export them. Consequently, the MSBuild and .NET SDK telemetry opt-out environment variables do not disable metric publication. A host that configures an exporter remains responsible for honoring its applicable collection and consent policies.
+
+Evaluations performed while constructing a project graph are categorized as `standalone` because they do not belong to an active build submission.

--- a/src/Build.UnitTests/Telemetry/EvaluationMetrics_Tests.cs
+++ b/src/Build.UnitTests/Telemetry/EvaluationMetrics_Tests.cs
@@ -1,0 +1,222 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics.Metrics;
+using System.IO;
+using System.Xml;
+using Microsoft.Build.Construction;
+using Microsoft.Build.Definition;
+using Microsoft.Build.Evaluation;
+using Microsoft.Build.Exceptions;
+using Microsoft.Build.Execution;
+using Microsoft.Build.Framework;
+using Microsoft.Build.TelemetryInfra;
+using Microsoft.Build.UnitTests;
+using Shouldly;
+using Xunit;
+
+namespace Microsoft.Build.Engine.UnitTests;
+
+[CollectionDefinition(CollectionName, DisableParallelization = true)]
+public sealed class EvaluationMetricsTestCollection
+{
+    public const string CollectionName = nameof(EvaluationMetricsTestCollection);
+}
+
+[Collection(EvaluationMetricsTestCollection.CollectionName)]
+public sealed class EvaluationMetrics_Tests
+{
+    private readonly ITestOutputHelper _output;
+
+    public EvaluationMetrics_Tests(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    [Theory]
+    [InlineData(ProjectEvaluationStage.Properties, "properties")]
+    [InlineData(ProjectEvaluationStage.ItemDefinitions, "item_definitions")]
+    [InlineData(ProjectEvaluationStage.Items, "items")]
+    [InlineData(ProjectEvaluationStage.UsingTasks, "using_tasks")]
+    [InlineData(ProjectEvaluationStage.Full, "full")]
+    public void EvaluationMetricsCaptureStageAndDuration(ProjectEvaluationStage stage, string expectedStage)
+    {
+        using MetricCollector collector = new();
+        using ProjectCollection collection = new();
+
+        _ = ProjectInstance.FromProjectRootElement(
+            CreateRootElement("<Project />"),
+            new ProjectOptions
+            {
+                EvaluationStage = stage,
+                ProjectCollection = collection,
+            });
+
+        collector.Measurements.ShouldContain(measurement =>
+            measurement.InstrumentName == EvaluationMetrics.ProjectEvaluationCountName &&
+            measurement.Value == 1 &&
+            measurement.HasTag(EvaluationMetrics.StageTagName, expectedStage) &&
+            measurement.HasTag(EvaluationMetrics.OriginTagName, EvaluationMetrics.StandaloneOrigin) &&
+            measurement.HasTag(EvaluationMetrics.SucceededTagName, true));
+
+        collector.Measurements.ShouldContain(measurement =>
+            measurement.InstrumentName == EvaluationMetrics.ProjectEvaluationDurationName &&
+            measurement.Value >= 0 &&
+            measurement.HasTag(EvaluationMetrics.StageTagName, expectedStage) &&
+            measurement.HasTag(EvaluationMetrics.OriginTagName, EvaluationMetrics.StandaloneOrigin) &&
+            measurement.HasTag(EvaluationMetrics.SucceededTagName, true));
+    }
+
+    [Fact]
+    public void EvaluationMetricsCaptureBuildSubmissionOrigin()
+    {
+        using MetricCollector collector = new();
+        using TestEnvironment env = TestEnvironment.Create(_output);
+
+        TransientTestFile buildProject = env.CreateFile(
+            "evaluation-metrics.proj",
+            """
+            <Project>
+              <Target Name="Build" />
+            </Project>
+            """);
+        MockLogger logger = new(_output);
+        using (BuildManager buildManager = new())
+        {
+            BuildResult result = buildManager.Build(
+                new BuildParameters { Loggers = [logger] },
+                new BuildRequestData(
+                    buildProject.Path,
+                    new Dictionary<string, string?>(),
+                    null,
+                    ["Build"],
+                    null));
+            result.ShouldHaveSucceeded();
+        }
+
+        collector.Measurements.ShouldContain(measurement =>
+            measurement.InstrumentName == EvaluationMetrics.ProjectEvaluationCountName &&
+            measurement.HasTag(EvaluationMetrics.StageTagName, "full") &&
+            measurement.HasTag(EvaluationMetrics.OriginTagName, EvaluationMetrics.BuildSubmissionOrigin) &&
+            measurement.HasTag(EvaluationMetrics.SucceededTagName, true));
+    }
+
+    [Fact]
+    public void EvaluationMetricsCaptureFailedEvaluation()
+    {
+        using MetricCollector collector = new();
+        using ProjectCollection collection = new();
+
+        Should.Throw<InvalidProjectFileException>(() =>
+            ProjectInstance.FromProjectRootElement(
+                CreateRootElement(
+                    """
+                    <Project>
+                      <PropertyGroup Condition="'invalid' ==">
+                        <Value>1</Value>
+                      </PropertyGroup>
+                    </Project>
+                    """),
+                new ProjectOptions { ProjectCollection = collection }));
+
+        collector.Measurements.ShouldContain(measurement =>
+            measurement.InstrumentName == EvaluationMetrics.ProjectEvaluationCountName &&
+            measurement.HasTag(EvaluationMetrics.StageTagName, "full") &&
+            measurement.HasTag(EvaluationMetrics.OriginTagName, EvaluationMetrics.StandaloneOrigin) &&
+            measurement.HasTag(EvaluationMetrics.SucceededTagName, false));
+    }
+
+    [Fact]
+    public void ThrowingMetricsListenerDoesNotBreakEvaluation()
+    {
+        using ResetMetricsOnDispose reset = new();
+        using MeterListener listener = new();
+        listener.InstrumentPublished = (instrument, meterListener) =>
+        {
+            if (instrument.Meter.Name == EvaluationMetrics.MeterName &&
+                instrument.Name == EvaluationMetrics.ProjectEvaluationCountName)
+            {
+                meterListener.EnableMeasurementEvents(instrument);
+            }
+        };
+        listener.SetMeasurementEventCallback<long>((_, _, _, _) => throw new InvalidOperationException("Test listener failure"));
+        listener.Start();
+
+        using ProjectCollection collection = new();
+        Should.NotThrow(() =>
+            ProjectInstance.FromProjectRootElement(
+                CreateRootElement("<Project />"),
+                new ProjectOptions { ProjectCollection = collection }));
+    }
+
+    private static ProjectRootElement CreateRootElement(string projectXml)
+    {
+        using StringReader stringReader = new(projectXml);
+        using XmlReader xmlReader = XmlReader.Create(stringReader);
+        return ProjectRootElement.Create(xmlReader);
+    }
+
+    private sealed class MetricCollector : IDisposable
+    {
+        private readonly MeterListener _listener = new();
+
+        public MetricCollector()
+        {
+            _listener.InstrumentPublished = (instrument, listener) =>
+            {
+                if (instrument.Meter.Name == EvaluationMetrics.MeterName)
+                {
+                    listener.EnableMeasurementEvents(instrument);
+                }
+            };
+            _listener.SetMeasurementEventCallback<long>((instrument, value, tags, _) => Add(instrument, value, tags));
+            _listener.SetMeasurementEventCallback<double>((instrument, value, tags, _) => Add(instrument, value, tags));
+            _listener.Start();
+        }
+
+        public ConcurrentQueue<MetricMeasurement> Measurements { get; } = new();
+
+        public void Dispose()
+        {
+            _listener.Dispose();
+        }
+
+        private void Add<T>(
+            Instrument instrument,
+            T value,
+            ReadOnlySpan<KeyValuePair<string, object?>> tags)
+            where T : struct
+        {
+            Dictionary<string, object?> copiedTags = new(tags.Length, StringComparer.Ordinal);
+            foreach (KeyValuePair<string, object?> tag in tags)
+            {
+                copiedTags.Add(tag.Key, tag.Value);
+            }
+
+            Measurements.Enqueue(new MetricMeasurement(
+                instrument.Name,
+                Convert.ToDouble(value, System.Globalization.CultureInfo.InvariantCulture),
+                copiedTags));
+        }
+    }
+
+    private sealed record MetricMeasurement(
+        string InstrumentName,
+        double Value,
+        Dictionary<string, object?> Tags)
+    {
+        public bool HasTag(string name, object expected) =>
+            Tags.TryGetValue(name, out object? actual) && Equals(actual, expected);
+    }
+
+    private sealed class ResetMetricsOnDispose : IDisposable
+    {
+        public void Dispose()
+        {
+            EvaluationMetrics.ResetForTests();
+        }
+    }
+}

--- a/src/Build/BackEnd/Shared/BuildRequestConfiguration.cs
+++ b/src/Build/BackEnd/Shared/BuildRequestConfiguration.cs
@@ -2,12 +2,16 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.Metrics;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
 using Microsoft.Build.BackEnd.SdkResolution;
 using Microsoft.Build.Collections;
 using Microsoft.Build.Evaluation;
@@ -35,6 +39,40 @@ namespace Microsoft.Build.BackEnd
         public const int InvalidConfigurationId = 0;
 
         #region Static State
+
+        private const string EvaluationCacheEnvironmentVariable = "MSBUILDPROTOTYPEEVALUATIONCACHE";
+        private const string EvaluationCacheDirectoryEnvironmentVariable = "MSBUILDPROTOTYPEEVALUATIONCACHEDIRECTORY";
+        private const string EvaluationCacheKindTagName = "cache.kind";
+
+        private static readonly bool s_evaluationCacheEnabled =
+            Environment.GetEnvironmentVariable(EvaluationCacheEnvironmentVariable) == "1";
+
+        private static readonly string s_evaluationCacheDirectory =
+            Environment.GetEnvironmentVariable(EvaluationCacheDirectoryEnvironmentVariable);
+
+        private static readonly string[] s_evaluationCacheKeyProperties =
+        [
+            "BuildingSolutionFile",
+            "Configuration",
+            "ExcludeRestorePackageImports",
+            "MSBuildIsRestoring",
+            "Platform",
+            "RuntimeIdentifier",
+            "SelfContained",
+            "SolutionPath",
+            "TargetFramework",
+        ];
+
+        // Deliberately unsafe prototype: entries live for the process lifetime and have no input invalidation.
+        private static readonly ConcurrentDictionary<string, ProjectInstance> s_evaluationCache =
+            new(StringComparer.Ordinal);
+
+        private static readonly Meter s_evaluationCacheMeter = new("Microsoft.Build.EvaluationCachePrototype");
+
+        private static readonly Histogram<double> s_evaluationCacheHitDuration =
+            s_evaluationCacheMeter.CreateHistogram<double>(
+                "msbuild.prototype.evaluation_cache.hit.duration",
+                unit: "s");
 
         /// <summary>
         /// This is the ID of the configuration as set by the generator of the configuration.  When
@@ -474,6 +512,19 @@ namespace Microsoft.Build.BackEnd
 
             InitializeProject(componentHost.BuildParameters, () =>
             {
+                string prototypeCacheKey = null;
+                if (s_evaluationCacheEnabled)
+                {
+                    prototypeCacheKey = GetEvaluationCacheKey();
+                    if (TryGetCachedProject(
+                        prototypeCacheKey,
+                        componentHost.BuildParameters,
+                        out ProjectInstance cachedProject))
+                    {
+                        return cachedProject;
+                    }
+                }
+
                 if (componentHost.BuildParameters.SaveOperatingEnvironment)
                 {
                     try
@@ -513,7 +564,7 @@ namespace Microsoft.Build.BackEnd
                     projectLoadSettings |= ProjectLoadSettings.FailOnUnresolvedSdk;
                 }
 
-                return new ProjectInstance(
+                ProjectInstance project = new ProjectInstance(
                     ProjectFullPath,
                     globalProperties,
                     toolsVersionOverride,
@@ -530,7 +581,144 @@ namespace Microsoft.Build.BackEnd
                     sdkResolverService,
                     submissionId,
                     projectLoadSettings);
+
+                if (prototypeCacheKey != null)
+                {
+                    CacheProject(prototypeCacheKey, project);
+                }
+
+                return project;
             });
+        }
+
+        private static bool TryGetCachedProject(
+            string cacheKey,
+            BuildParameters buildParameters,
+            out ProjectInstance project)
+        {
+            if (s_evaluationCache.TryGetValue(cacheKey, out ProjectInstance cachedProject))
+            {
+                long startTimestamp = GetCacheHitStartTimestamp();
+                project = cachedProject.DeepCopy(isImmutable: false);
+                RecordCacheHit(startTimestamp, "memory");
+                return true;
+            }
+
+            if (string.IsNullOrEmpty(s_evaluationCacheDirectory))
+            {
+                project = null;
+                return false;
+            }
+
+            string cacheFile = GetEvaluationCacheFile(cacheKey);
+            if (!FileSystems.Default.FileExists(cacheFile))
+            {
+                project = null;
+                return false;
+            }
+
+            long sharedCacheStartTimestamp = GetCacheHitStartTimestamp();
+            using Stream stream = File.Open(cacheFile, FileMode.Open, FileAccess.Read, FileShare.Read);
+            using ITranslator translator = GetConfigurationTranslator(TranslationDirection.ReadFromStream, stream);
+            project = ProjectInstance.FactoryForDeserialization(translator);
+            project.LateInitialize(buildParameters.ProjectRootElementCache, buildParameters.HostServices);
+            RecordCacheHit(sharedCacheStartTimestamp, "shared");
+            return true;
+        }
+
+        private static long GetCacheHitStartTimestamp() =>
+            s_evaluationCacheHitDuration.Enabled ? Stopwatch.GetTimestamp() : 0;
+
+        private static void RecordCacheHit(long startTimestamp, string cacheKind)
+        {
+            if (startTimestamp == 0)
+            {
+                return;
+            }
+
+            TagList tags = default;
+            tags.Add(EvaluationCacheKindTagName, cacheKind);
+            s_evaluationCacheHitDuration.Record(
+                (Stopwatch.GetTimestamp() - startTimestamp) / (double)Stopwatch.Frequency,
+                in tags);
+        }
+
+        private static void CacheProject(string cacheKey, ProjectInstance project)
+        {
+            s_evaluationCache.TryAdd(cacheKey, project.DeepCopy(isImmutable: true));
+
+            if (string.IsNullOrEmpty(s_evaluationCacheDirectory))
+            {
+                return;
+            }
+
+            Directory.CreateDirectory(s_evaluationCacheDirectory);
+            string cacheFile = GetEvaluationCacheFile(cacheKey);
+            if (FileSystems.Default.FileExists(cacheFile))
+            {
+                return;
+            }
+
+            string temporaryFile = $"{cacheFile}.{EnvironmentUtilities.CurrentProcessId}.{Environment.CurrentManagedThreadId}.tmp";
+            try
+            {
+                ProjectInstance serializableProject = project.DeepCopy(isImmutable: false);
+                serializableProject.TranslateEntireState = true;
+                using (Stream stream = File.Create(temporaryFile))
+                using (ITranslator translator = GetConfigurationTranslator(TranslationDirection.WriteToStream, stream))
+                {
+                    ((ITranslatable)serializableProject).Translate(translator);
+                }
+
+                File.Move(temporaryFile, cacheFile);
+            }
+            catch (IOException) when (FileSystems.Default.FileExists(cacheFile))
+            {
+            }
+            finally
+            {
+                FileUtilities.DeleteNoThrow(temporaryFile);
+            }
+        }
+
+        private string GetEvaluationCacheKey()
+        {
+            StringBuilder keyBuilder = new();
+            AppendCacheKeyPart(keyBuilder, ProjectFullPath);
+            AppendCacheKeyPart(keyBuilder, ToolsVersion);
+
+            foreach (string propertyName in s_evaluationCacheKeyProperties)
+            {
+                AppendCacheKeyPart(keyBuilder, propertyName);
+                ProjectPropertyInstance property = GlobalProperties[propertyName];
+                AppendCacheKeyPart(
+                    keyBuilder,
+                    property is null ? null : ((IProperty)property).EvaluatedValueEscaped);
+            }
+
+            return keyBuilder.ToString();
+        }
+
+        private static string GetEvaluationCacheFile(string cacheKey)
+        {
+            using SHA256 sha256 = SHA256.Create();
+            byte[] hash = sha256.ComputeHash(Encoding.UTF8.GetBytes(
+                typeof(BuildRequestConfiguration).Assembly.FullName + cacheKey));
+            string fileName = BitConverter.ToString(hash).Replace("-", string.Empty) + ".evaluationcache";
+            return Path.Combine(s_evaluationCacheDirectory, fileName);
+        }
+
+        private static void AppendCacheKeyPart(StringBuilder keyBuilder, string value)
+        {
+            if (value is null)
+            {
+                keyBuilder.Append("-1:");
+                return;
+            }
+
+            keyBuilder.Append(value.Length);
+            keyBuilder.Append(':');
+            keyBuilder.Append(value);
         }
 
         private void InitializeProject(BuildParameters buildParameters, Func<ProjectInstance> loadProjectFromFile)
@@ -1102,7 +1290,7 @@ namespace Microsoft.Build.BackEnd
         /// <summary>
         /// Gets the translator for this configuration.
         /// </summary>
-        private ITranslator GetConfigurationTranslator(TranslationDirection direction, Stream stream) =>
+        private static ITranslator GetConfigurationTranslator(TranslationDirection direction, Stream stream) =>
             direction == TranslationDirection.WriteToStream
                     ? BinaryTranslator.GetWriteTranslator(stream)
                     // Not using sharedReadBuffer because this is not a memory stream and so the buffer won't be used anyway.

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -25,6 +25,7 @@ using Microsoft.Build.Framework.Profiler;
 using Microsoft.Build.Internal;
 using Microsoft.Build.Shared;
 using Microsoft.Build.Shared.FileSystem;
+using Microsoft.Build.TelemetryInfra;
 using static Microsoft.Build.Execution.ProjectPropertyInstance;
 using Constants = Microsoft.Build.Framework.Constants;
 using EngineFileUtilities = Microsoft.Build.Internal.EngineFileUtilities;
@@ -357,9 +358,12 @@ namespace Microsoft.Build.Evaluation
                 buildEventContext,
                 evaluationStage);
 
+            long evaluationStartTimestamp = EvaluationMetrics.GetEvaluationStartTimestamp();
+            bool evaluationSucceeded = false;
             try
             {
                 evaluator.Evaluate();
+                evaluationSucceeded = true;
             }
             catch (PathTooLongException ex)
             {
@@ -368,6 +372,12 @@ namespace Microsoft.Build.Evaluation
             }
             finally
             {
+                EvaluationMetrics.RecordProjectEvaluation(
+                    evaluationStartTimestamp,
+                    evaluationStage,
+                    submissionId != BuildEventContext.InvalidSubmissionId,
+                    evaluationSucceeded);
+
                 IEnumerable globalProperties = null;
                 IEnumerable properties = null;
                 IEnumerable items = null;

--- a/src/Build/Microsoft.Build.csproj
+++ b/src/Build/Microsoft.Build.csproj
@@ -72,6 +72,7 @@
     <Reference Include="System.IO.Compression" />
     <PackageReference Include="System.Memory" />
     <PackageReference Include="System.Security.Principal.Windows" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" />
     <PackageReference Include="System.Text.Json" />
     <PackageReference Include="System.Collections.Immutable" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" />
@@ -218,6 +219,7 @@
     <Compile Include="Logging\BuildEventArgsExtensions.cs" />
     <Compile Include="Logging\TerminalLogger\**\*.cs" />
     <Compile Include="Logging\ReusableLogger.cs" />
+    <Compile Include="TelemetryInfra\EvaluationMetrics.cs" />
     <Compile Include="TelemetryInfra\InternalTelemetryConsumingLogger.cs" />
     <Compile Include="TelemetryInfra\ITelemetryCollector.cs" />
     <Compile Include="TelemetryInfra\TelemetryCollectorProvider.cs" />

--- a/src/Build/TelemetryInfra/EvaluationMetrics.cs
+++ b/src/Build/TelemetryInfra/EvaluationMetrics.cs
@@ -1,0 +1,148 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using Microsoft.Build.Evaluation;
+using Microsoft.Build.Framework;
+
+namespace Microsoft.Build.TelemetryInfra;
+
+internal static class EvaluationMetrics
+{
+    internal const string MeterName = "Microsoft.Build";
+    internal const string ProjectEvaluationCountName = "msbuild.project.evaluations";
+    internal const string ProjectEvaluationDurationName = "msbuild.project.evaluation.duration";
+
+    internal const string StageTagName = "msbuild.project.evaluation.stage";
+    internal const string OriginTagName = "msbuild.project.evaluation.origin";
+    internal const string SucceededTagName = "msbuild.project.evaluation.succeeded";
+
+    internal const string BuildSubmissionOrigin = "build_submission";
+    internal const string StandaloneOrigin = "standalone";
+
+    private static readonly object s_boxedTrue = true;
+    private static readonly object s_boxedFalse = false;
+    private static int s_disabled;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    internal static long GetEvaluationStartTimestamp()
+    {
+        if (Volatile.Read(ref s_disabled) != 0)
+        {
+            return 0;
+        }
+
+        try
+        {
+            return Instruments.ProjectEvaluationDuration.Enabled ? Stopwatch.GetTimestamp() : 0;
+        }
+        catch (Exception ex) when (!ExceptionHandling.IsCriticalException(ex))
+        {
+            Disable(ex);
+            return 0;
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    internal static void RecordProjectEvaluation(
+        long startTimestamp,
+        ProjectEvaluationStage stage,
+        bool isBuildSubmission,
+        bool succeeded)
+    {
+        if (Volatile.Read(ref s_disabled) != 0)
+        {
+            return;
+        }
+
+        try
+        {
+            bool countEnabled = Instruments.ProjectEvaluationCount.Enabled;
+            bool durationEnabled = startTimestamp != 0 && Instruments.ProjectEvaluationDuration.Enabled;
+            if (!countEnabled && !durationEnabled)
+            {
+                return;
+            }
+
+            TagList tags = default;
+            tags.Add(StageTagName, GetStageName(stage));
+            tags.Add(OriginTagName, isBuildSubmission ? BuildSubmissionOrigin : StandaloneOrigin);
+            tags.Add(SucceededTagName, succeeded ? s_boxedTrue : s_boxedFalse);
+
+            if (countEnabled)
+            {
+                Instruments.ProjectEvaluationCount.Add(1, in tags);
+            }
+
+            if (durationEnabled)
+            {
+                double elapsedSeconds = (Stopwatch.GetTimestamp() - startTimestamp) / (double)Stopwatch.Frequency;
+                Instruments.ProjectEvaluationDuration.Record(elapsedSeconds, in tags);
+            }
+        }
+        catch (Exception ex) when (!ExceptionHandling.IsCriticalException(ex))
+        {
+            Disable(ex);
+        }
+    }
+
+    internal static void ResetForTests()
+    {
+        Volatile.Write(ref s_disabled, 0);
+    }
+
+    private static void Disable(Exception ex)
+    {
+        Volatile.Write(ref s_disabled, 1);
+        Debug.WriteLine($"MSBuild evaluation metrics disabled after an instrumentation failure: {ex}");
+    }
+
+    private static string GetStageName(ProjectEvaluationStage stage) => stage switch
+    {
+        ProjectEvaluationStage.Properties => "properties",
+        ProjectEvaluationStage.ItemDefinitions => "item_definitions",
+        ProjectEvaluationStage.Items => "items",
+        ProjectEvaluationStage.UsingTasks => "using_tasks",
+        ProjectEvaluationStage.Full => "full",
+        _ => "unknown",
+    };
+
+    private static class Instruments
+    {
+        private static readonly Meter s_meter = new(MeterName);
+
+        internal static readonly Counter<long> ProjectEvaluationCount = s_meter.CreateCounter<long>(
+            ProjectEvaluationCountName,
+            unit: "{evaluation}",
+            description: "Number of MSBuild project evaluations.");
+
+        internal static readonly Histogram<double> ProjectEvaluationDuration = s_meter.CreateHistogram<double>(
+            ProjectEvaluationDurationName,
+            unit: "s",
+            description: "Duration of MSBuild project evaluations.",
+            tags: null,
+            advice: new InstrumentAdvice<double>
+            {
+                HistogramBucketBoundaries =
+                [
+                    0.001,
+                    0.005,
+                    0.01,
+                    0.025,
+                    0.05,
+                    0.1,
+                    0.25,
+                    0.5,
+                    1,
+                    2.5,
+                    5,
+                    10,
+                    30,
+                ],
+            });
+    }
+}

--- a/src/MSBuild/app.amd64.config
+++ b/src/MSBuild/app.amd64.config
@@ -107,6 +107,11 @@
           <codeBase version="10.0.0.9" href="..\System.Collections.Immutable.dll"/>
         </dependentAssembly>
         <dependentAssembly>
+          <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+          <bindingRedirect oldVersion="0.0.0.0-10.0.0.9" newVersion="10.0.0.9" />
+          <codeBase version="10.0.0.9" href="..\System.Diagnostics.DiagnosticSource.dll"/>
+        </dependentAssembly>
+        <dependentAssembly>
           <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
           <codeBase version="13.0.0.0" href="..\Newtonsoft.Json.dll" />
         </dependentAssembly>

--- a/src/MSBuild/app.config
+++ b/src/MSBuild/app.config
@@ -61,6 +61,10 @@
           <bindingRedirect oldVersion="0.0.0.0-10.0.0.9" newVersion="10.0.0.9" />
         </dependentAssembly>
         <dependentAssembly>
+          <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+          <bindingRedirect oldVersion="0.0.0.0-10.0.0.9" newVersion="10.0.0.9" />
+        </dependentAssembly>
+        <dependentAssembly>
           <assemblyIdentity name="System.Formats.Nrbf" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
           <bindingRedirect oldVersion="0.0.0.0-10.0.0.9" newVersion="10.0.0.9" />
         </dependentAssembly>


### PR DESCRIPTION
Fixes #

### Context

This is an intentionally unsafe prototype for measuring the happy-path benefit of reusing project evaluations across consecutive MSBuild invocations and worker processes.

The prototype assumes project files, imports, SDK inputs, environment inputs, and global properties are unchanged. It is not intended for production use.

### Changes Made

- Add an opt-in process-local evaluated `ProjectInstance` cache enabled by `MSBUILDPROTOTYPEEVALUATIONCACHE=1`.
- Add an optional serialized cross-process cache configured by `MSBUILDPROTOTYPEEVALUATIONCACHEDIRECTORY`.
- Key the happy-path cache by project identity and the stable configuration dimensions needed by the OrchardCore restore/build outer and inner configurations.
- Deep-copy cached in-memory instances so target execution receives mutable state.
- Record cache-hit materialization duration through a prototype metrics instrument.
- Leave build-result caching unchanged, so targets continue to execute.

### Testing

- Full repository build: passed with 0 warnings and 0 errors.
- Focused `BuildRequestConfiguration_Tests`: 42 passed on `net10.0`.
- Broader Build engine test run: 10,619 passed, 118 skipped, and 17 failures in unrelated graph, platform, task-host, preprocessor, and terminal-logger tests.
- Execution probe: two cache-enabled builds produced two execution records, confirming execution was not skipped.

OrchardCore Release warm no-op build, 232 solution projects, 32 logical processors:

| Metric | Cache disabled | Shared-cache hit | Zero-overhead estimate |
| --- | ---: | ---: | ---: |
| Evaluation count | 916 | 2 | 2 |
| Evaluation CPU time | 131.34 s | 0.138 s | 0.138 s |
| Median wall-clock time | 65.075 s | 56.076 s | 48.375 s |
| Cache materialization wall-time union | — | 7.701 s | 0 s |
| Wall-clock saving | — | 8.999 s | 16.700 s |
| Wall-clock improvement | — | 13.8% | 25.7% |

### Notes

- There is no invalidation.
- The selected global-property key is deliberately incomplete and only represents the measured happy path.
- The serialized cache includes filesystem and cloning overhead and is only a way to share evaluated state between fresh CLI, server, and worker processes.
- A production cache would need complete dependency tracking, versioning, eviction, concurrency design, and a safer representation than serialized mutable engine state.
