### PR TITLE
Fix quoting in eng/build.sh

### DIFF
--- a/.vsts-dotnet-ci.yml
+++ b/.vsts-dotnet-ci.yml
@@ -47,7 +47,7 @@ jobs:
     displayName: Build (with -mt in stage2)
     inputs:
       filename: 'build.cmd'
-      arguments: '-ci -test -stage2Arguments /mt'
+      arguments: '-ci -test -stage2Argument /mt'
     condition: eq(variables.onlyDocChanged, 0)
 # Task to collect code coverage on Windows. Disabled by default due to being unstable and sometimes it stucks forever
 #   - task: PowerShell@2
@@ -158,7 +158,7 @@ jobs:
     displayName: Build (with -mt in stage2)
     inputs:
       filename: 'build.cmd'
-      arguments: '-msbuildEngine dotnet -ci -test -stage2Arguments /mt'
+      arguments: '-msbuildEngine dotnet -ci -test -stage2Argument /mt'
     condition: eq(variables.onlyDocChanged, 0)
     env:
       MSBUILDUSESERVER: "1"
@@ -237,7 +237,7 @@ jobs:
   - bash: sudo apt-get update
   - bash: sudo apt-get install -y libxml2
   # Intentionally not running tests
-  - bash: . 'build.sh' --ci --stage2Arguments '/mt /p:BuildAnalyzer=true'
+  - bash: . 'build.sh' --ci --stage2Argument '/mt' --stage2Argument '/p:BuildAnalyzer=true'
     displayName: Build (with -mt in stage2)
     condition: eq(variables.onlyDocChanged, 0)
     env:
@@ -353,7 +353,7 @@ jobs:
         Token: $(dn-bot-dnceng-artifact-feeds-rw)
   - bash: sudo apt-get update
   - bash: sudo apt-get install -y libxml2
-  - bash: . 'build.sh' --ci --test --stage2Arguments '/mt'
+  - bash: . 'build.sh' --ci --test --stage2Argument '/mt'
     displayName: Build (with -mt in stage2)
     condition: eq(variables.onlyDocChanged, 0)
     env:
@@ -442,7 +442,7 @@ jobs:
         arguments: $(Build.SourcesDirectory)/NuGet.config $Token
       env:
         Token: $(dn-bot-dnceng-artifact-feeds-rw)
-  - bash: . 'build.sh' --ci --test --stage2Arguments '/mt'
+  - bash: . 'build.sh' --ci --test --stage2Argument '/mt'
     displayName: Build (with -mt in stage2)
     condition: eq(variables.onlyDocChanged, 0)
     env:

--- a/azure-pipelines/quarantine.yml
+++ b/azure-pipelines/quarantine.yml
@@ -69,7 +69,7 @@ jobs:
     displayName: Build (quarantined tests only)
     inputs:
       filename: 'build.cmd'
-      arguments: "-ci -test -stage2Arguments '/p:RunQuarantinedTests=true'"
+      arguments: "-ci -test -stage2Argument '/p:RunQuarantinedTests=true'"
     condition: or(ne(variables['Build.Reason'], 'PullRequest'), eq(variables.onlyDocChanged, 0))
   - task: PublishTestResults@2
     displayName: Publish .NET Framework Test Results
@@ -118,7 +118,7 @@ jobs:
   - template: azure-pipelines/check-documentation-only-change.yml
   - bash: sudo apt-get update
   - bash: sudo apt-get install -y libxml2
-  - bash: . 'build.sh' --ci --test --stage2Arguments '/p:RunQuarantinedTests=true'
+  - bash: . 'build.sh' --ci --test --stage2Argument '/p:RunQuarantinedTests=true'
     displayName: Build (quarantined tests only)
     condition: or(ne(variables['Build.Reason'], 'PullRequest'), eq(variables.onlyDocChanged, 0))
     env:
@@ -157,7 +157,7 @@ jobs:
   timeoutInMinutes: 120
   steps:
   - template: azure-pipelines/check-documentation-only-change.yml
-  - bash: . 'build.sh' --ci --test --stage2Arguments '/p:RunQuarantinedTests=true'
+  - bash: . 'build.sh' --ci --test --stage2Argument '/p:RunQuarantinedTests=true'
     displayName: Build (quarantined tests only)
     condition: or(ne(variables['Build.Reason'], 'PullRequest'), eq(variables.onlyDocChanged, 0))
     env:

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -7,7 +7,7 @@ Param(
   [switch][Alias('bl')] $binaryLog,
   [switch][Alias('nobl')] $excludeCIBinarylog,
   [switch] $stage2,
-  [string[]] $stage2Arguments = @(),
+  [string[]][Alias('stage2Argument')] $stage2Arguments = @(),
   [Parameter(ValueFromRemainingArguments=$true)][String[]]$properties
 )
 

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -7,7 +7,7 @@ Param(
   [switch][Alias('bl')] $binaryLog,
   [switch][Alias('nobl')] $excludeCIBinarylog,
   [switch] $stage2,
-  [string[]][Alias('stage2Argument')] $stage2Arguments = @(),
+  [string[]] $stage2Argument = @(),
   [Parameter(ValueFromRemainingArguments=$true)][String[]]$properties
 )
 
@@ -35,7 +35,7 @@ if ($excludeCIBinarylog) {
 }
 
 # Supplying stage2Arguments implies a multi-stage build
-if ($stage2Arguments.Count -gt 0) {
+if ($stage2Argument.Count -gt 0) {
   $stage2 = $true
 }
 
@@ -136,10 +136,10 @@ $env:DOTNET_PERFLOG_DIR=$PerfLogDir
 $env:DOTNET_HOST_PATH = Join-Path $BootstrapRoot 'core\dotnet.exe'
 $env:DOTNET_INSTALL_DIR = Join-Path $BootstrapRoot 'core'
 
-# $stage2Arguments are appended to the stage 2 build only.
+# $stage2Argument are appended to the stage 2 build only.
 # Use this for switches like /mt that should not be passed to the stage1 build
 # until a stable version of MT is available in the images.
-$stage2Args = $stage2Arguments
+$stage2Args = $stage2Argument
 
 $stage2BuildArgs = $commonBuildArgs
 

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -7,7 +7,7 @@ Param(
   [switch][Alias('bl')] $binaryLog,
   [switch][Alias('nobl')] $excludeCIBinarylog,
   [switch] $stage2,
-  [string] $stage2Arguments = "",
+  [string[]] $stage2Arguments = @(),
   [Parameter(ValueFromRemainingArguments=$true)][String[]]$properties
 )
 
@@ -35,7 +35,7 @@ if ($excludeCIBinarylog) {
 }
 
 # Supplying stage2Arguments implies a multi-stage build
-if ($stage2Arguments) {
+if ($stage2Arguments.Count -gt 0) {
   $stage2 = $true
 }
 
@@ -139,10 +139,7 @@ $env:DOTNET_INSTALL_DIR = Join-Path $BootstrapRoot 'core'
 # $stage2Arguments are appended to the stage 2 build only.
 # Use this for switches like /mt that should not be passed to the stage1 build
 # until a stable version of MT is available in the images.
-# The @(...) wrapper is important: when -split returns exactly one element PowerShell gives back a
-# string, which would later splat one character per argument (so "/mt" becomes "/", "m", "t").
-# Wrapping with @() forces an array even for a single token.
-$stage2Args = @(if ($stage2Arguments) { $stage2Arguments -split '\s+' | Where-Object { $_ } } else { @() })
+$stage2Args = $stage2Arguments
 
 $stage2BuildArgs = $commonBuildArgs
 

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -6,7 +6,7 @@ ci=false
 binary_log=false
 exclude_ci_binary_log=false
 stage2=false
-stage2Arguments=
+stage2Arguments=()
 properties=()
 
 source="${BASH_SOURCE[0]}"
@@ -23,7 +23,7 @@ done
 
 scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
 while [[ $# -gt 0 ]]; do
-  lowerI="$(echo "$1" | awk '{print tolower($0)}')"
+  lowerI="$(echo $1 | awk '{print tolower($0)}')"
   case "$lowerI" in
     --configuration)
       configuration=$2
@@ -49,9 +49,9 @@ while [[ $# -gt 0 ]]; do
       stage2=true
       shift 1
       ;;
-    --stage2arguments)
-      stage2Arguments=$2
-      # Supplying stage2Arguments implies a multi-stage build.
+    --stage2argument)
+      stage2Arguments+=( "$2" )
+      # Supplying stage2Argument implies a multi-stage build.
       stage2=true
       shift 2
       ;;
@@ -172,7 +172,7 @@ fi
 # $stage2Arguments are appended to the stage 2 build only.
 # Use this for switches like /mt that should not be passed to the stage1 build
 # until a stable version of MT is available in the images.
-stage2_build_args+=( $stage2Arguments )
+stage2_build_args+=( ${stage2Arguments[@]+"${stage2Arguments[@]}"} )
 
 echo "Stage 2 build: /bin/bash \"$build_script\" ${stage2_build_args[*]}"
 # Needs to run out-of-proc to not inherit the stage 1 build's state variables.

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -7,7 +7,7 @@ binary_log=false
 exclude_ci_binary_log=false
 stage2=false
 stage2Arguments=
-properties=
+properties=()
 
 source="${BASH_SOURCE[0]}"
 
@@ -23,7 +23,7 @@ done
 
 scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
 while [[ $# -gt 0 ]]; do
-  lowerI="$(echo $1 | awk '{print tolower($0)}')"
+  lowerI="$(echo "$1" | awk '{print tolower($0)}')"
   case "$lowerI" in
     --configuration)
       configuration=$2
@@ -56,7 +56,7 @@ while [[ $# -gt 0 ]]; do
       shift 2
       ;;
     *)
-      properties="$properties $1"
+      properties+=( "$1" )
       shift 1
       ;;
   esac
@@ -65,37 +65,37 @@ done
 build_script="$scriptroot/common/build.sh"
 
 # Arguments common to the stage1 and stage2 builds, including any caller-supplied properties.
-common_build_args="--configuration $configuration $properties"
+common_build_args=( "--configuration" "$configuration" ${properties[@]+"${properties[@]}"} )
 
 # Forward the binary-log-related switches to both the stage 1 and stage 2 builds.
 if [ "$ci" = true ]; then
-  common_build_args="$common_build_args --ci"
+  common_build_args+=("--ci")
 fi
 if [ "$binary_log" = true ]; then
-  common_build_args="$common_build_args --binaryLog"
+  common_build_args+=("--binaryLog")
 fi
 if [ "$exclude_ci_binary_log" = true ]; then
-  common_build_args="$common_build_args --excludeCIBinarylog"
+  common_build_args+=("--excludeCIBinarylog")
 fi
 
-build_args="$common_build_args"
+build_args=("${common_build_args[@]}")
 
 # If the caller requested a multi-stage build, add the --prepareMachine switch to the stage 1 build so that it kills any lingering processes from stage 1 before stage 2 starts.
 # Also disable the pipeline set result masking for stage 1 so that a stage 1 failure surfaces its real exit code to this wrapper (stage 2 is the terminal build that reports the pipeline result).
 if [ "$stage2" = true ]; then
-  build_args="$build_args --prepareMachine --disablePipelineSetResult"
+  build_args+=("--prepareMachine" "--disablePipelineSetResult")
 fi
 
 if [ "$test" = true ] && [ "$stage2" != true ]; then
-  build_args="$build_args --test"
+  build_args+=("--test")
 fi
 
 # Log the stage 1 build command so that it's clear which arguments flow to it.
 if [ "$stage2" = true ]; then
-  echo "Stage 1 build: /bin/bash \"$build_script\" $build_args"
+  echo "Stage 1 build: /bin/bash \"$build_script\" ${build_args[*]}"
 fi
 
-/bin/bash "$build_script" $build_args
+/bin/bash "$build_script" "${build_args[@]}"
 stage1_exit_code=$?
 
 if [ "$stage2" != true ]; then
@@ -153,7 +153,7 @@ export DOTNET_PERFLOG_DIR="$perf_log_dir"
 export DOTNET_HOST_PATH="$bootstrap_root/core/dotnet"
 export DOTNET_INSTALL_DIR="$bootstrap_root/core"
 
-stage2_build_args="$common_build_args"
+stage2_build_args=( "${common_build_args[@]}" )
 
 # Give the stage 2 binary log a distinct name so it doesn't collide with the stage 1 binlog
 # (both otherwise default to Build.binlog) when CI publishes them to the same artifacts location.
@@ -161,20 +161,20 @@ stage2_build_args="$common_build_args"
 # Arcade emits a binlog for CI builds (--ci) or when --binaryLog is passed explicitly, unless it's
 # suppressed with --excludeCIBinarylog.
 if { [ "$ci" = true ] || [ "$binary_log" = true ]; } && [ "$exclude_ci_binary_log" != true ]; then
-  stage2_build_args="$stage2_build_args --binaryLogName Build.stage2.binlog"
+  stage2_build_args+=("--binaryLogName" "Build.stage2.binlog")
 fi
 
 # Only run tests in stage2 when supplying the '--test' switch in a multi-stage build.
 if [ "$test" = true ]; then
-  stage2_build_args="$stage2_build_args --test"
+  stage2_build_args+=("--test")
 fi
 
 # $stage2Arguments are appended to the stage 2 build only.
 # Use this for switches like /mt that should not be passed to the stage1 build
 # until a stable version of MT is available in the images.
-stage2_build_args="$stage2_build_args $stage2Arguments"
+stage2_build_args+=( $stage2Arguments )
 
-echo "Stage 2 build: /bin/bash \"$build_script\" $stage2_build_args"
+echo "Stage 2 build: /bin/bash \"$build_script\" ${stage2_build_args[*]}"
 # Needs to run out-of-proc to not inherit the stage 1 build's state variables.
-/bin/bash "$build_script" $stage2_build_args
+/bin/bash "$build_script" "${stage2_build_args[@]}"
 exit $?


### PR DESCRIPTION
I use a particular set of flags to build .NET VMR, which flows something like this to the msbuild build scripts:

    $ ./build.sh /p:OfficialBuilder="Red Hat Inc."

This regressed recently (probably
https://github.com/dotnet/msbuild/pull/14361). This change fixes the issue.

For arrays which can be empty, use the ${var[@]+"${var[@]}"} syntax, as discussed in https://github.com/dotnet/dotnet/pull/797, to avoid issues on macOS.

Assisted-By: Claude Opus 4.6 <noreply@anthropic.com>
