### PR TITLE
Clarify StreamReader guidance for multithreaded tasks

### DIFF
--- a/documentation/specs/multithreading/thread-safe-tasks-api-analysis.md
+++ b/documentation/specs/multithreading/thread-safe-tasks-api-analysis.md
@@ -83,7 +83,9 @@ The following tables list specific .NET APIs and their threading safety classifi
 
 | API | Level | Short Reason | Recommendation |
 |-----|-------|--------------|-------|
-| Constructor `StreamReader` all overloads | WARNING | Uses current working directory | Use absolute paths |
+| Constructors `StreamReader(string path, ...)` | WARNING | Relative paths use current working directory | Use absolute paths |
+
+`StreamReader(Stream, ...)` constructors do not resolve paths and are not restricted by this rule.
 
 ### System.Diagnostics.Process Class
 

--- a/src/TaskAnalyzer.Tests/MultiThreadableTaskAnalyzerTests.cs
+++ b/src/TaskAnalyzer.Tests/MultiThreadableTaskAnalyzerTests.cs
@@ -359,6 +359,27 @@ public class MultiThreadableTaskAnalyzerTests
     // ═══════════════════════════════════════════════════════════════════════
 
     [Fact]
+    public async Task NewStreamReader_WithStreamArg_NoDiagnostic()
+    {
+        var diags = await GetDiagnosticsAsync("""
+            using System.IO;
+            using Microsoft.Build.Framework;
+            public class MyTask : Microsoft.Build.Utilities.Task, IMultiThreadableTask
+            {
+                public TaskEnvironment TaskEnvironment { get; set; }
+                public override bool Execute()
+                {
+                    using var stream = new MemoryStream();
+                    using var sr = new StreamReader(stream);
+                    return true;
+                }
+            }
+            """);
+
+        diags.ShouldNotContain(d => d.Id == DiagnosticIds.FilePathRequiresAbsolute);
+    }
+
+    [Fact]
     public async Task FileExists_WithGetAbsolutePath_NoDiagnostic()
     {
         var diags = await GetDiagnosticsAsync("""


### PR DESCRIPTION
## Summary
- limit the MT API warning to `StreamReader` constructors that accept a string path
- clarify that `StreamReader(Stream, ...)` does not perform path resolution
- add analyzer regression coverage for the stream-based constructor

## Testing
- `dotnet test src\TaskAnalyzer.Tests\TaskAnalyzer.Tests.csproj -- --filter-method "*NewStreamReader*"`