### PR TITLE
Update expert-reviewer models: Opus 5, GPT-5.6 Sol, Gemini 3.6 Flash

### DIFF
--- a/.github/agents/expert-reviewer.agent.md
+++ b/.github/agents/expert-reviewer.agent.md
@@ -570,7 +570,7 @@ Use this to prioritize dimensions based on changed files.
 
 1b. **Historical context** (for bug fix and follow-up PRs): Read the linked issue and the original feature PR discussions. Identify design intent, constraints, and reviewer-established principles. Feed this context to every dimension agent so they can evaluate whether the fix aligns with the original design, not just whether the code compiles.
 
-2. Launch **one sub-agent per dimension** (`task` tool, `agent_type: "general-purpose"`, `model: "claude-opus-4.6"`). Each agent evaluates exactly one dimension against the full PR diff. Run in **parallel batches of 6** (4 batches for 24 dimensions).
+2. Launch **one sub-agent per dimension** (`task` tool, `agent_type: "general-purpose"`, `model: "claude-opus-5"`). Each agent evaluates exactly one dimension against the full PR diff. Run in **parallel batches of 6** (4 batches for 24 dimensions).
 
    Each sub-agent receives: the PR diff, PR description, the single dimension's rules and checklist, and the folder context.
 
@@ -626,7 +626,7 @@ Use this to prioritize dimensions based on changed files.
 
    Confirm only with concrete evidence. Dispute if a lock, blocking call, or control flow prevents the scenario. **Never validate against `main`.**
 
-4. For borderline findings, run the same validation on 3 models (`claude-opus-4.6`, `gpt-5.2-codex`, `gemini-3-pro-preview`). Keep findings confirmed by ≥2/3.
+4. For borderline findings, run the same validation on 3 models (`claude-opus-5`, `gpt-5.6-sol`, `gemini-3.6-flash`). Keep findings confirmed by ≥2/3.
 
 ### Wave 3: Post
 

--- a/.github/workflows/shared/review-shared.md
+++ b/.github/workflows/shared/review-shared.md
@@ -35,7 +35,7 @@ Review pull request #${{ github.event.pull_request.number || github.event.issue.
 ## Instructions
 
 1. Fetch the full diff for the pull request.
-2. Call the `expert-reviewer` agent. Make sure to call it as subagent (`task` tool, `agent_type: "general-purpose"`, `model: "claude-opus-4.6"`). And make sure to follow the guidance on subagent calls from within the `expert-reviewer` agent. We expect 2+ levels of agents to be called.
+2. Call the `expert-reviewer` agent. Make sure to call it as subagent (`task` tool, `agent_type: "general-purpose"`, `model: "claude-opus-5"`). And make sure to follow the guidance on subagent calls from within the `expert-reviewer` agent. We expect 2+ levels of agents to be called.
 3. Do **not** post comments or reviews yourself, except for the fallback in step 4 if the subagent posts nothing. The subagent will post its own comments using the available safe-output tools:
    - **Inline review comments** on specific diff lines via `create_pull_request_review_comment`
    - **Design-level concerns** (not tied to a line) via `add_comment`


### PR DESCRIPTION
## Problem

Two of the three models named in the expert-review pipeline have been **retired** by GitHub Copilot, and the third is three generations behind.

| Location | Was | Status |
|---|---|---|
| `expert-reviewer.agent.md:573` (24 dimension sub-agents) | `claude-opus-4.6` | Superseded by Opus 5 |
| `expert-reviewer.agent.md:629` (consensus validation) | `gpt-5.2-codex` | ❌ Retired |
| `expert-reviewer.agent.md:629` (consensus validation) | `gemini-3-pro-preview` | ❌ Retired |
| `review-shared.md:38` (reviewer sub-agent) | `claude-opus-4.6` | Superseded by Opus 5 |

Retirement confirmed in the [Copilot changelog (2026-05-20)](https://github.blog/changelog/2026-05-20-updates-to-available-models-in-copilot-on-web/). Because two of the three IDs in Wave 2 are invalid, the cross-model consensus step ("keep findings confirmed by >=2/3") could not run as written.

## Change

```diff
-2. Launch one sub-agent per dimension (..., model: "claude-opus-4.6").
+2. Launch one sub-agent per dimension (..., model: "claude-opus-5").

-4. ... run the same validation on 3 models (`claude-opus-4.6`, `gpt-5.2-codex`, `gemini-3-pro-preview`).
+4. ... run the same validation on 3 models (`claude-opus-5`, `gpt-5.6-sol`, `gemini-3.6-flash`).

-2. Call the `expert-reviewer` agent ... (..., model: "claude-opus-4.6").
+2. Call the `expert-reviewer` agent ... (..., model: "claude-opus-5").
```

Three lines, two files. The `>=2/3` consensus rule is deliberately kept — the third slot stays filled (Gemini 3.6 Flash) so the arithmetic still works, and it keeps provider diversity in the validation step.

## Why no `.lock.yml` regeneration

Both edited files reach the agent through `{{#runtime-import}}` (`review.agent.lock.yml:309-310`), i.e. they are read from the checked-out repo at run time rather than baked into the compiled workflow. Only body prose changed; no frontmatter (`permissions`, `tools`, `safe-outputs`, `engine`) was touched, so the compiled output is unchanged. Confirmed no CI job verifies lock freshness.

## Follow-up (not in this PR)

The gh-aw orchestrator that *calls* the reviewer still defaults to `claude-sonnet-4.6` (`vars.GH_AW_MODEL_AGENT_COPILOT || vars.GH_AW_DEFAULT_MODEL_COPILOT || 'claude-sonnet-4.6'`). That can be raised without recompiling any lock file by setting the repo variable `GH_AW_MODEL_AGENT_COPILOT`.

Separately, an audit of the reviewer's rules turned up several checks that produce guaranteed false positives regardless of model quality (e.g. requiring `PublicAPI.Unshipped.txt`, which does not exist in this repo; listing a `Diagnostic` `MessageImportance`, which does not exist in the enum). Those are worth a separate PR — raising model quality will not help while the rules themselves are wrong.
