### PR TITLE
Fix false and over-broad checks in the expert-reviewer agent

### DIFF
--- a/.github/agents/expert-reviewer.agent.md
+++ b/.github/agents/expert-reviewer.agent.md
@@ -48,7 +48,7 @@ Apply **all** dimensions on every review, weighted by file location (see [Folder
 6. Never remove CLI switches or aliases — deprecate with warnings first.
 
 **CHECK — Flag if:**
-- [ ] A change can be percieved by customers as breaking
+- [ ] A change can be perceived by customers as breaking (name the specific scenario)
 - [ ] Risky behavioral change has no ChangeWave gate
 - [ ] New warnings emitted
 - [ ] A property default value has changed
@@ -89,7 +89,7 @@ Hot paths: `Evaluator.cs`, `Expander.cs`, file I/O operations.
 4. Profile before optimizing — claims require evidence.
 
 **CHECK — Flag if:**
-- [ ] LINQ
+- [ ] LINQ on a hot path (cold-path LINQ is idiomatic here — don't flag it)
 - [ ] Strings allocated that could be reused or avoided
 - [ ] A value recomputed on every call when cacheable
 - [ ] `Dictionary` for <10 items, or `List` for frequent lookups of >100 items
@@ -148,7 +148,7 @@ See `../../documentation/wiki/Binary-Log.md` and `../../documentation/wiki/Loggi
 
 **Rules:**
 1. Changes must be captured in the binary log.
-2. Use appropriate `MessageImportance`: `High` = always shown, `Normal` = default, `Low` = detailed, `Diagnostic` = debug.
+2. Use appropriate `MessageImportance`: `High` = always shown, `Normal` = default, `Low` = detailed.
 3. Add diagnostic logging for complex code paths.
 4. Use structured logging events with sufficient context (project path, target name, item identity).
 5. Binary log format changes must be backward-compatible.
@@ -413,13 +413,11 @@ See `../../documentation/ProjectReference-Protocol.md`.
 See `../../documentation/wiki/Bootstrap.md`.
 
 **Rules:**
-1. Dependency versions must be pinned via Darc/Maestro. Manual edits to `eng/Versions.props` require justification.
-2. Verify compatibility with all build entry points: Arcade CLI, VS, `dotnet build`, bootstrap.
-3. CI/CD pipeline changes require validation before merge.
-4. Follow VS servicing and branching conventions.
+1. Verify compatibility with all build entry points: Arcade CLI, VS, `dotnet build`, bootstrap.
+2. CI/CD pipeline changes require validation before merge.
+3. Follow VS servicing and branching conventions.
 
 **CHECK — Flag if:**
-- [ ] `eng/Versions.props` manually edited without Darc justification
 - [ ] CI YAML change not validated
 - [ ] Bootstrap build compatibility not verified
 - [ ] Change works in one build entry point but may fail in others
@@ -606,7 +604,7 @@ Use this to prioritize dimensions based on changed files.
 3. For each non-LGTM finding, launch a validation agent that **proves or disproves it** using:
 
    - **Code flow tracing**: Read full source from the PR branch (`github-mcp-server-get_file_contents` with `ref: "refs/pull/{pr}/head"`). Trace callers, callees, locks, thread boundaries.
-   - **Build and test**: Build the PR branch locally. Run existing tests. Check coverage of the claimed scenario.
+   - **Build and test**: if the PR head is checked out, build it and run the tests covering the claimed scenario. Otherwise validate by reading the diff and source via GitHub MCP.
    - **Proof-of-concept test**: Write a minimal test that demonstrates the issue — include in PR feedback as evidence.
    - **Thread timeline**: For concurrency issues, write the interleaving step-by-step:
      ```
@@ -632,7 +630,9 @@ Use this to prioritize dimensions based on changed files.
 
 > **Tool availability note**: Steps 5–7 reference gh-aw safe-output tools (`create_pull_request_review_comment`, `submit_pull_request_review`, `add_comment`). When running outside an agentic workflow (e.g. locally in VS Code), these tools are unavailable — use the closest GitHub MCP or CLI equivalents instead (e.g. `gh api` to create PR review comments, `gh pr review` to submit a review, `gh pr comment` to post general comments).
 
-5. Post **inline review comments** on the exact diff lines using the `create_pull_request_review_comment` safe-output tool. Each comment must target a specific `path` and `line` in the PR diff. Format:
+5. **Deduplicate first.** Dimensions overlap, so the same defect can be reported by several of them. Group findings by `FILE` + `LINES` and post one comment per root cause, under the highest-severity dimension.
+
+   Post **inline review comments** on the exact diff lines using the `create_pull_request_review_comment` safe-output tool. Each comment must target a specific `path` and `line` in the PR diff. Format:
 
    ```markdown
    **[$SEVERITY] $DimensionName**


### PR DESCRIPTION
Rules that don't match this repo, so the reviewer flags correct code. Each fix is a one-liner.

| # | Was | Now | Why |
|---|---|---|---|
| 6 | `Low` = detailed, **`Diagnostic` = debug** | `Low` = detailed | The enum only has `High`, `Normal`, `Low` — `src/Framework/BuildMessageEventArgs.cs:22,27,32`. `logging.instructions.md:25` (auto-applied to `src/Build/Logging/**`) already states it correctly, so the reviewer was contradicting an always-loaded file. |
| 3 | `- [ ] LINQ` | `- [ ] LINQ on a hot path` | 181 non-test files use `System.Linq`; the bare check fires on nearly every PR. |
| 1 | `can be percieved by customers as breaking` | `...(name the specific scenario)` | Unbounded, misspelled, and BLOCKING — which forces `REQUEST_CHANGES` (line 685) as the default verdict. |
| — | "Build the PR branch locally. Run existing tests." | "if the PR head is checked out, build it... Otherwise validate via GitHub MCP" | `review-on-open.agent.md:38-40` checks out only the trusted base repo at `base.sha` and never executes PR code. The instruction was impossible where the reviewer actually runs. |
| 19/23 | Same `eng/Versions.props`-without-Darc check in both | Kept only in 23 | Duplicate comments on the same line. |

Plus one addition to Wave 3: deduplicate findings before posting. Dimensions overlap and each runs as an independent sub-agent, so one defect can produce several comments against a 30-comment budget (`review-shared.md:23`).

10 insertions / 10 deletions, one file. No dimension removed, no severity lowered. The `PublicAPI.Unshipped.txt` rule in dimension 8 is untouched.

No `.lock.yml` regeneration needed — `expert-reviewer.agent.md` is read from the checked-out repo at run time.
