### PR TITLE
De-stale the release skill after #14277 removed stabilization

### DIFF
--- a/.github/skills/release/SKILL.md
+++ b/.github/skills/release/SKILL.md
@@ -36,52 +36,44 @@ Before starting any phase, ensure you have these values (the user must provide t
 
 | Input | Example | How to determine |
 |---|---|---|
-| `PREVIOUS_RELEASE_VERSION` | `18.5` | Previous entry in the merge-flow chain |
-| `THIS_RELEASE_VERSION` | `18.6` | Current `VersionPrefix` in `eng/Versions.props` (drop `.0`) |
-| `NEXT_VERSION` | `18.7` | User-provided — not computable from current version |
-| `BRANCH_SNAP_DATE` | `2026-04-08` | From [VS-Dates wiki](https://dev.azure.com/devdiv/DevDiv/_wiki/wikis/DevDiv.wiki/49807/VS-Dates) — when MSBuild branches `vs*` from main, insertion targets VS `main` |
-| `INSIDERS_SNAP_DATE` | `2026-04-22` | From [VS-Dates wiki](https://dev.azure.com/devdiv/DevDiv/_wiki/wikis/DevDiv.wiki/49807/VS-Dates) — when VS snaps `main` → `rel/insiders`; final-branded bits must be in VS `main` before this |
-| `STABLE_SNAP_DATE` | `2026-05-06` | From [VS-Dates wiki](https://dev.azure.com/devdiv/DevDiv/_wiki/wikis/DevDiv.wiki/49807/VS-Dates) — when VS promotes `rel/insiders` → `rel/stable` |
-| `VS_SHIP_DATE` | `2026-05-12` | When VS ships publicly (GA) — triggers post-release tasks |
-| `PACKAGE_VALIDATION_BASELINE_VERSION` | `18.7.0-preview-26230-02` | See [How to determine `PACKAGE_VALIDATION_BASELINE_VERSION`](#how-to-determine-package_validation_baseline_version) below — non-trivial: most "obvious" picks are wrong. |
+| `PREVIOUS_RELEASE_VERSION` | `18.9` | Previous entry in the merge-flow chain |
+| `THIS_RELEASE_VERSION` | `18.10` | Current `VersionPrefix` in `eng/Versions.props` (drop `.0`) |
+| `NEXT_VERSION` | `18.11` | User-provided — not computable from current version |
+| `BRANCH_SNAP_DATE` | `YYYY-MM-DD` | From [VS-Dates wiki](https://dev.azure.com/devdiv/DevDiv/_wiki/wikis/DevDiv.wiki/49807/VS-Dates) — when MSBuild branches `vs*` from main, insertion targets VS `main` |
+| `INSIDERS_SNAP_DATE` | `YYYY-MM-DD` | From [VS-Dates wiki](https://dev.azure.com/devdiv/DevDiv/_wiki/wikis/DevDiv.wiki/49807/VS-Dates) — when VS snaps `main` → `rel/insiders`; final-branded bits must be in VS `main` before this |
+| `STABLE_SNAP_DATE` | `YYYY-MM-DD` | From [VS-Dates wiki](https://dev.azure.com/devdiv/DevDiv/_wiki/wikis/DevDiv.wiki/49807/VS-Dates) — when VS promotes `rel/insiders` → `rel/stable` |
+| `VS_SHIP_DATE` | `YYYY-MM-DD` | When VS ships publicly (GA) — triggers post-release tasks |
+| `PACKAGE_VALIDATION_BASELINE_VERSION` | `18.9.0-preview-26330-01` | See [How to determine `PACKAGE_VALIDATION_BASELINE_VERSION`](#how-to-determine-package_validation_baseline_version) below — non-trivial: most "obvious" picks are wrong. |
+
+> Version examples above track the current cycle (`eng/Versions.props` `VersionPrefix` is `18.10.0`). Dates are intentionally shown as a format only — always read the real ones from the VS-Dates wiki.
 
 ### How to determine `PACKAGE_VALIDATION_BASELINE_VERSION`
 
 **The value is the latest `{{THIS_RELEASE_VERSION}}.0-preview-NNNNN-NN` MSBuild package that is both:**
 
-1. **Published on the public [dotnet-tools feed](https://dev.azure.com/dnceng/public/_artifacts/feed/dotnet-tools)** — this is the feed `darc publish` pushes to and that ApiCompat restores baselines from. If the version isn't here, ApiCompat fails with `NU1102`.
-2. **Produced from a commit reachable from `vs{{THIS_RELEASE_VERSION}}`** — i.e. a `vs{{THIS_RELEASE_VERSION}}` commit prior to [stabilization (Phase 4.2)](../../../documentation/release-checklist.md#phase-4-final-branding--vs-insertion), or the `main` commit `vs{{THIS_RELEASE_VERSION}}` was branched from.
+1. **Published on the public [dotnet-tools feed](https://dev.azure.com/dnceng/public/_artifacts/feed/dotnet-tools)** — this is the feed the official build publishes to and that ApiCompat restores baselines from. If the version isn't here, ApiCompat fails with `NU1102`.
+2. **Produced from a commit reachable from `vs{{THIS_RELEASE_VERSION}}`** — i.e. a commit on `vs{{THIS_RELEASE_VERSION}}`, or the `main` commit `vs{{THIS_RELEASE_VERSION}}` was branched from.
 
 **Two tempting wrong answers — and why they're wrong:**
 
 | Wrong pick | Why it fails |
 |---|---|
-| ❌ The `{{THIS_RELEASE_VERSION}}.X` package that actually ships in VS (e.g. `18.7.1`) | After Phase 4.2 `Stabilize-Release.ps1` runs, builds become **final-versioned**. So such package is not resolvable from public CI. |
+| ❌ The release-versioned `{{THIS_RELEASE_VERSION}}.X` package that ships in VS / on nuget.org | Since [#14277](https://github.com/dotnet/msbuild/pull/14277) release branches build and insert **prerelease** versions, exactly like `main`; the release-versioned variants are produced by NuGetRepack at manual publish time. They never exist on the public CI feed, so ApiCompat cannot restore them. |
 | ❌ Blindly the most recent `{{THIS_RELEASE_VERSION}}.0-preview-*` on `dotnet-tools` | After `vs{{THIS_RELEASE_VERSION}}` branches, `main` keeps producing `{{THIS_RELEASE_VERSION}}.0-preview-*` until **this** main-bump PR merges — so the most recent feed entries may be `{{NEXT_VERSION}}`-content builds wearing `{{THIS_RELEASE_VERSION}}` branding. Picking one drifts the API baseline forward and silently hides real compat breaks. |
 
-**Procedure:**
-
-**Determinized (preferred):** run the helper, which does all of the below mechanically (requires `az login` with devdiv access):
+**Procedure:** run the helper — it does the whole resolution mechanically (requires `az login` with devdiv access):
 
 ```
 pwsh ./scripts/Get-PackageValidationBaseline.ps1 -ThisReleaseVersion {{THIS_RELEASE_VERSION}}
 # -> prints e.g. 18.9.0-preview-26330-01
 ```
 
-It computes `git merge-base origin/main origin/vs{{THIS_RELEASE_VERSION}}`, finds the matching successful build in pipeline 9434, derives the package version from the OfficialBuildId, and verifies it on the dotnet-tools feed. The manual procedure below is the fallback / explanation of what the script does:
-
-1. Open [MSBuild official build pipeline 9434](https://devdiv.visualstudio.com/DevDiv/_build?definitionId=9434).
-2. Filter runs to branch `vs{{THIS_RELEASE_VERSION}}`. Find the run that final-branded the release (it produces `{{THIS_RELEASE_VERSION}}.X` — no `-preview-` — corresponding to the commit that ran `Stabilize-Release.ps1`; see [Phase 4.2 + 4.3](../../../documentation/release-checklist.md#phase-4-final-branding--vs-insertion)). Anything successful **before** that on `vs{{THIS_RELEASE_VERSION}}` is a candidate.
-3. If `vs{{THIS_RELEASE_VERSION}}` has no successful pre-stabilization preview runs (common — the branch sees little churn before stabilization), fall back to the most recent successful `main` run whose commit is the branch-point ancestor: \
-`git merge-base origin/main origin/vs{{THIS_RELEASE_VERSION}}` gives the SHA — find a `main` run at or before that SHA in pipeline 9434.
-4. Read the package version from that run's `Pack` step output: `{{THIS_RELEASE_VERSION}}.0-preview-NNNNN-NN` (example: `18.7.0-preview-26230-02`).
-5. Verify the exact version is on the [dotnet-tools feed](https://dev.azure.com/dnceng/public/_artifacts/feed/dotnet-tools) (search `Microsoft.Build`). If not, fall back to the next-older eligible run.
-6. Use that version. Do **not** include any `+sha` suffix.
+It computes `git merge-base origin/main origin/vs{{THIS_RELEASE_VERSION}}`, finds the matching successful build in [pipeline 9434](https://devdiv.visualstudio.com/DevDiv/_build?definitionId=9434), derives the package version from the OfficialBuildId, and verifies it on the dotnet-tools feed. If it fails, read the script's own `.DESCRIPTION` header for the manual equivalent rather than reproducing it here.
 
 ### Prerequisites
 - gh cli
 - az cli
-- darc cli
+- darc cli — Arcade enforces a minimum version; if `darc` refuses with a "below the minimum required version" error, run `.\eng\common\darc-init.ps1`
 
 ## Phase Summary
 
@@ -91,7 +83,7 @@ It computes `git merge-base origin/main origin/vs{{THIS_RELEASE_VERSION}}`, find
 | **1: Branch & Prepare** | `BRANCH_SNAP_DATE` | Create `vs*` branch, DARC channel setup (batched PR), merge-flow config, `VisualStudio.ChannelName` |
 | **2: DARC Subscription Updates** | Phase 1 branch exists (`vs*` created) | Retarget `main`-targeting subs + VMR backflow to next channel, retired-branch cleanup (batched PR), Arcade verify |
 | **3: Bump Main** | Phase 2 merged | Branding PR in `main` (`VersionPrefix` → next, ApiCompat baseline, refresh OptProf baseline) |
-| **4: Final Branding** | 7 days before `INSIDERS_SNAP_DATE` | Public API promotion, `Stabilize-Release.ps1`, OptProf bootstrap, get final-branded bits into VS `main` before insiders snap |
+| **4: Final Branding** | 7 days before `INSIDERS_SNAP_DATE` | Public API promotion, OptProf bootstrap (usually a no-op), M2/QB approval only if behind schedule, babysit the VS insertion into VS `main` before insiders snap |
 | **5: Post-GA** | VS shipped (`VS_SHIP_DATE`) | nuget.org publish, docs, GitHub release, cleanup |
 
 ## DARC Batching
@@ -135,10 +127,10 @@ When asked to execute a specific phase:
 | [`.config/git-merge-flow-config.jsonc`](../../../.config/git-merge-flow-config.jsonc) | Branch merge chain — update each release |
 | [`azure-pipelines/vs-insertion.yml`](../../../azure-pipelines/vs-insertion.yml) | VS insertion pipeline — `AutoInsertTargetBranch` mappings |
 | [`azure-pipelines/vs-insertion-experimental.yml`](../../../azure-pipelines/vs-insertion-experimental.yml) | Experimental insertion — `TargetBranch` parameter values |
-| [`scripts/Stabilize-Release.ps1`](../../../scripts/Stabilize-Release.ps1) | Final branding automation (`-DryRun` to preview) |
 | [`scripts/Get-PackageValidationBaseline.ps1`](../../../scripts/Get-PackageValidationBaseline.ps1) | Phase 3.2 — resolves `PackageValidationBaselineVersion` deterministically (merge-base → pipeline 9434 → dotnet-tools feed) |
 | [`scripts/Get-LatestOptProfDrop.ps1`](../../../scripts/Get-LatestOptProfDrop.ps1) | Phase 3.3 — resolves the latest main OptProf drop (MSBuild-OptProf pipeline 17389) to refresh `OptProfBaselineDrop` in `.vsts-dotnet.yml` |
-| [`.vsts-dotnet.yml`](../../../.vsts-dotnet.yml) | Build pipeline — `VisualStudio.ChannelName`, and `OptProfBaselineDrop` (hardcoded OptProf seed for new `vs*` branches) |
+| [`.vsts-dotnet.yml`](../../../.vsts-dotnet.yml) | Build pipeline entry point — `OptProfBaselineDrop` (hardcoded OptProf seed for new `vs*` branches) |
+| [`azure-pipelines/.vsts-dotnet-build-jobs.yml`](../../../azure-pipelines/.vsts-dotnet-build-jobs.yml) | Build jobs — `VisualStudio.ChannelName` (update each release) |
 
 ## Validation
 
@@ -156,7 +148,6 @@ After completing all phases, verify:
 
 - **Branch already exists**: Release was partially started — check the tracking issue for progress
 - **DARC channel already exists**: Safe to continue — `add-channel` is idempotent
-- **`Stabilize-Release.ps1` says "already stabilized"**: Skip — idempotent
 - **OptProf fails on first build**: Expected — that's why we use main's OptProf data as fallback
 - **DARC configuration PR conflicts**: Rebase the configuration branch on `production` and force-push
 


### PR DESCRIPTION
## Problem

[#14277](https://github.com/dotnet/msbuild/pull/14277) ("Stop requiring `VersionPrefix` updates in servicing — insert prerelease versions to VS", merged 2026-07-08) deleted `scripts/Stabilize-Release.ps1` and updated `documentation/release-checklist.md` and the `merge-dependency-updates` skill — but **this skill was missed**. It still walks the agent through a workflow that no longer exists.

`git grep Stabilize-Release` currently matches **only this file**.

## Fixes

| Was | Now | Evidence |
|---|---|---|
| `scripts/Stabilize-Release.ps1` referenced **5×** (L59, 74, 94, 138, 159) | removed | File deleted in `9ffbeaad04`; `Test-Path` → False |
| "After Phase 4.2 `Stabilize-Release.ps1` runs, builds become **final-versioned**" | Release branches now build/insert **prerelease** versions like `main`; release-versioned packages come from NuGetRepack at manual publish time | #14277 commit message |
| Links to "stabilization (Phase 4.2)" and "Phase 4.2 + 4.3" | Phase Summary now matches the real checklist: 4.1 public API, 4.2 OptProf bootstrap, 4.3 M2/QB, 4.4 babysit insertion | `documentation/release-checklist.md:173-181` |
| `darc publish` | "the feed the official build publishes to" | Not a verb in `darc --help` |
| `.vsts-dotnet.yml` holds `VisualStudio.ChannelName` | It holds only `OptProfBaselineDrop` (L32, 47); added a row for the real location | `azure-pipelines/.vsts-dotnet-build-jobs.yml:80,156` |
| Examples `18.5` / `18.6` / `18.7`, baseline `18.7.0-preview-26230-02`, dates `2026-04-08`…`2026-05-12` | `18.9` / `18.10` / `18.11`, baseline `18.9.0-preview-26330-01`, dates shown as `YYYY-MM-DD` | `eng/Versions.props:6,9` |
| Prereq "darc cli" | + the Arcade minimum-version floor and `eng/common/darc-init.ps1` | `darc` refuses to run when older than Arcade's floor |

The four hardcoded dates are replaced with a `YYYY-MM-DD` format hint rather than newer dates, so that row cannot rot again — the skill already tells you to read the real dates from the VS-Dates wiki.

## Also

Collapsed the six-step manual `PACKAGE_VALIDATION_BASELINE_VERSION` fallback (L72-79) into a pointer at `Get-PackageValidationBaseline.ps1`'s own `.DESCRIPTION`, which documents the identical procedure and cannot drift from the script. Two of those six steps were the ones referencing the deleted stabilization run.

Net **168 → 159 lines**, 19 insertions / 28 deletions. All relative links verified to resolve.
