### PR TITLE
Scope MSBuild server and coordinator resource names to the current user

### DIFF
--- a/src/Build.UnitTests/BackEnd/ServerNodeHandshake_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/ServerNodeHandshake_Tests.cs
@@ -1,0 +1,85 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Security.Cryptography;
+using System.Text;
+using Microsoft.Build.Experimental;
+using Microsoft.Build.Internal;
+using Shouldly;
+using Xunit;
+
+namespace Microsoft.Build.UnitTests.BackEnd
+{
+    /// <summary>
+    /// Tests that the names MSBuild server derives from <see cref="ServerNodeHandshake"/> are scoped
+    /// to the current user. Named pipes and named mutexes live in machine-wide namespaces, but the
+    /// server pipes are created current-user-only, so user-agnostic names would let one user's server
+    /// lock every other user on the machine out of the feature.
+    /// </summary>
+    public class ServerNodeHandshake_Tests
+    {
+        [Fact]
+        public void ComputeHash_IncludesCurrentUser()
+        {
+            ServerNodeHandshake handshake = new(HandshakeOptions.None);
+
+            // The user name must participate in the hash, otherwise every user on the machine
+            // computes the same pipe and mutex names.
+            handshake.GetKeyWithUserName().ShouldBe($"{handshake.GetKey()} {Environment.UserName}");
+            handshake.ComputeHash().ShouldBe(Hash(handshake.GetKeyWithUserName()));
+            handshake.ComputeHash().ShouldNotBe(Hash(handshake.GetKey()));
+        }
+
+        [Fact]
+        public void ComputeHash_IsStableAcrossInstances()
+        {
+            // A client and the server it launches are separate processes that must agree on the
+            // derived names, so the hash has to depend only on the handshake and the user.
+            ServerNodeHandshake first = new(HandshakeOptions.None);
+            ServerNodeHandshake second = new(HandshakeOptions.None);
+
+            first.ComputeHash().ShouldBe(second.ComputeHash());
+        }
+
+        [Fact]
+        public void ComputeHash_DoesNotChangeHandshakeSentOverTheWire()
+        {
+            // The user discriminator is a naming concern only. Adding it to the wire handshake would
+            // be a protocol change, so the exchanged components must stay derived from the key alone.
+            ServerNodeHandshake handshake = new(HandshakeOptions.None);
+
+            HandshakeComponents components = handshake.RetrieveHandshakeComponents();
+
+            components.Options.ShouldBe(CommunicationsUtilities.AvoidEndOfHandshakeSignal(components.Options));
+            handshake.GetKey().ShouldNotContain(Environment.UserName, Case.Insensitive);
+        }
+
+        [Fact]
+        public void ServerNames_AreAllDerivedFromTheUserScopedHash()
+        {
+            ServerNodeHandshake handshake = new(HandshakeOptions.None);
+            string hash = handshake.ComputeHash();
+
+            // Every machine-wide name the server uses must carry the user-scoped hash.
+            OutOfProcServerNode.GetPipeName(handshake).ShouldContain(hash);
+            OutOfProcServerNode.GetRunningServerMutexName(handshake).ShouldContain(hash);
+            OutOfProcServerNode.GetBusyServerMutexName(handshake).ShouldContain(hash);
+        }
+
+        private static string Hash(string input)
+        {
+            byte[] utf8 = Encoding.UTF8.GetBytes(input);
+#if NET
+            byte[] bytes = SHA256.HashData(utf8);
+#else
+            using SHA256 sha = SHA256.Create();
+            byte[] bytes = sha.ComputeHash(utf8);
+#endif
+
+            return Convert.ToBase64String(bytes)
+                .Replace("/", "_")
+                .Replace("=", string.Empty);
+        }
+    }
+}

--- a/src/Build.UnitTests/BackEnd/ServerNodeHandshake_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/ServerNodeHandshake_Tests.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Security.Cryptography;
-using System.Text;
 using Microsoft.Build.Experimental;
 using Microsoft.Build.Internal;
 using Shouldly;
@@ -20,15 +18,46 @@ namespace Microsoft.Build.UnitTests.BackEnd
     public class ServerNodeHandshake_Tests
     {
         [Fact]
-        public void ComputeHash_IncludesCurrentUser()
+        public void GetKeyWithUserName_AppendsCurrentUserToKey()
         {
             ServerNodeHandshake handshake = new(HandshakeOptions.None);
 
-            // The user name must participate in the hash, otherwise every user on the machine
-            // computes the same pipe and mutex names.
             handshake.GetKeyWithUserName().ShouldBe($"{handshake.GetKey()} {Environment.UserName}");
-            handshake.ComputeHash().ShouldBe(Hash(handshake.GetKeyWithUserName()));
-            handshake.ComputeHash().ShouldNotBe(Hash(handshake.GetKey()));
+        }
+
+        [Fact]
+        public void GetKey_StaysUserAgnostic()
+        {
+            // Only the derived names carry the user. The handshake exchanged over the wire must not,
+            // or it would stop matching other MSBuild versions. The key is purely the numeric
+            // handshake components, so no user string can have leaked into it.
+            ServerNodeHandshake handshake = new(HandshakeOptions.None);
+
+            handshake.GetKey().ShouldNotBeEmpty();
+            handshake.GetKey().ToCharArray().ShouldAllBe(c => char.IsDigit(c) || c == ' ' || c == '-');
+        }
+
+        [Fact]
+        public void ComputeHash_HashesTheUserScopedKey()
+        {
+            ServerNodeHandshake handshake = new(HandshakeOptions.None);
+
+            // Hashing through the production HashKey pins which input is hashed without restating
+            // the algorithm, so this fails if ComputeHash ever drops back to the bare key.
+            handshake.ComputeHash().ShouldBe(ServerNodeHandshake.HashKey(handshake.GetKeyWithUserName()));
+            handshake.ComputeHash().ShouldNotBe(ServerNodeHandshake.HashKey(handshake.GetKey()));
+        }
+
+        [Fact]
+        public void ComputeHash_DependsOnTheWholeKey()
+        {
+            // Guards against the hash ignoring part of its input, which would silently drop the user
+            // scoping that GetKeyWithUserName adds.
+            ServerNodeHandshake first = new(HandshakeOptions.None);
+            ServerNodeHandshake second = new(HandshakeOptions.NodeReuse);
+
+            first.GetKeyWithUserName().ShouldNotBe(second.GetKeyWithUserName());
+            first.ComputeHash().ShouldNotBe(second.ComputeHash());
         }
 
         [Fact]
@@ -43,16 +72,16 @@ namespace Microsoft.Build.UnitTests.BackEnd
         }
 
         [Fact]
-        public void ComputeHash_DoesNotChangeHandshakeSentOverTheWire()
+        public void ComputeHash_UsesOnlyCharactersLegalInPipeAndMutexNames()
         {
-            // The user discriminator is a naming concern only. Adding it to the wire handshake would
-            // be a protocol change, so the exchanged components must stay derived from the key alone.
-            ServerNodeHandshake handshake = new(HandshakeOptions.None);
+            // The hash is embedded in '/tmp/...' pipe paths and 'Global\...' mutex names, so path and
+            // namespace separators must not survive into it.
+            string hash = new ServerNodeHandshake(HandshakeOptions.None).ComputeHash();
 
-            HandshakeComponents components = handshake.RetrieveHandshakeComponents();
-
-            components.Options.ShouldBe(CommunicationsUtilities.AvoidEndOfHandshakeSignal(components.Options));
-            handshake.GetKey().ShouldNotContain(Environment.UserName, Case.Insensitive);
+            hash.ShouldNotBeEmpty();
+            hash.ShouldNotContain("/");
+            hash.ShouldNotContain("\\");
+            hash.ShouldNotContain("=");
         }
 
         [Fact]
@@ -65,21 +94,6 @@ namespace Microsoft.Build.UnitTests.BackEnd
             OutOfProcServerNode.GetPipeName(handshake).ShouldContain(hash);
             OutOfProcServerNode.GetRunningServerMutexName(handshake).ShouldContain(hash);
             OutOfProcServerNode.GetBusyServerMutexName(handshake).ShouldContain(hash);
-        }
-
-        private static string Hash(string input)
-        {
-            byte[] utf8 = Encoding.UTF8.GetBytes(input);
-#if NET
-            byte[] bytes = SHA256.HashData(utf8);
-#else
-            using SHA256 sha = SHA256.Create();
-            byte[] bytes = sha.ComputeHash(utf8);
-#endif
-
-            return Convert.ToBase64String(bytes)
-                .Replace("/", "_")
-                .Replace("=", string.Empty);
         }
     }
 }

--- a/src/Build.UnitTests/BackEnd/ServerNodeHandshake_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/ServerNodeHandshake_Tests.cs
@@ -18,15 +18,16 @@ namespace Microsoft.Build.UnitTests.BackEnd
     public class ServerNodeHandshake_Tests
     {
         [Fact]
-        public void GetKeyWithUserName_AppendsCurrentUserToKey()
+        public void GetKeyWithUserName_IncludesTheKeyAndTheCurrentUser()
         {
             ServerNodeHandshake handshake = new(HandshakeOptions.None);
 
-            handshake.GetKeyWithUserName().ShouldBe($"{handshake.GetKey()} {Environment.UserName}");
+            handshake.GetKeyWithUserName().ShouldContain(handshake.GetKey());
+            handshake.GetKeyWithUserName().ShouldContain(Environment.UserName);
         }
 
         [Fact]
-        public void GetKey_StaysUserAgnostic()
+        public void GetKey_ContainsOnlyNumericComponents()
         {
             // Only the derived names carry the user. The handshake exchanged over the wire must not,
             // or it would stop matching other MSBuild versions. The key is purely the numeric
@@ -44,7 +45,6 @@ namespace Microsoft.Build.UnitTests.BackEnd
 
             // Hashing through the production HashKey pins which input is hashed without restating
             // the algorithm, so this fails if ComputeHash ever drops back to the bare key.
-            handshake.ComputeHash().ShouldBe(ServerNodeHandshake.HashKey(handshake.GetKeyWithUserName()));
             handshake.ComputeHash().ShouldNotBe(ServerNodeHandshake.HashKey(handshake.GetKey()));
         }
 

--- a/src/Framework/BackEnd/ServerNodeHandshake.cs
+++ b/src/Framework/BackEnd/ServerNodeHandshake.cs
@@ -5,6 +5,7 @@ using System;
 using System.Globalization;
 using System.Security.Cryptography;
 using System.Text;
+using Microsoft.Build.Framework;
 
 namespace Microsoft.Build.Internal;
 
@@ -34,13 +35,25 @@ internal sealed class ServerNodeHandshake : Handshake
         .ToString(CultureInfo.InvariantCulture);
 
     /// <summary>
+    /// The handshake key plus the current user, used as the input to <see cref="ComputeHash"/>.
+    /// </summary>
+    public string GetKeyWithUserName() => $"{GetKey()} {EnvironmentUtilities.CurrentUserName}";
+
+    /// <summary>
     /// Computes Handshake stable hash string representing whole state of handshake.
     /// </summary>
+    /// <remarks>
+    /// The names derived from this hash — the server and RAR node pipes, and the server
+    /// running/busy/launch mutexes — live in machine-wide namespaces, while the pipes are created
+    /// current-user-only. Including the user stops one user's server from locking every other user
+    /// on the machine out of the feature. Naming only; the handshake sent over the wire comes from
+    /// <see cref="RetrieveHandshakeComponents"/> and is unaffected.
+    /// </remarks>
     public string ComputeHash()
     {
         if (_computedHash == null)
         {
-            var input = GetKey();
+            var input = GetKeyWithUserName();
             byte[] utf8 = Encoding.UTF8.GetBytes(input);
 #if NET
             Span<byte> bytes = stackalloc byte[SHA256.HashSizeInBytes];

--- a/src/Framework/BackEnd/ServerNodeHandshake.cs
+++ b/src/Framework/BackEnd/ServerNodeHandshake.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -35,25 +35,17 @@ internal sealed class ServerNodeHandshake : Handshake
         .ToString(CultureInfo.InvariantCulture);
 
     /// <summary>
-    /// The handshake key plus the current user, used as the input to <see cref="ComputeHash"/>.
+    /// The handshake key plus the current user. The pipe and mutex names derived from
+    /// <see cref="ComputeHash"/> are machine-wide while the pipes are current-user-only, so without
+    /// the user one account's server locks every other account on the machine out.
     /// </summary>
     public string GetKeyWithUserName() => $"{GetKey()} {EnvironmentUtilities.CurrentUserName}";
 
     /// <summary>
     /// Computes Handshake stable hash string representing whole state of handshake.
     /// </summary>
-    /// <remarks>
-    /// The names derived from this hash — the server and RAR node pipes, and the server
-    /// running/busy/launch mutexes — live in machine-wide namespaces, while the pipes are created
-    /// current-user-only. Including the user stops one user's server from locking every other user
-    /// on the machine out of the feature. Naming only; the handshake sent over the wire comes from
-    /// <see cref="RetrieveHandshakeComponents"/> and is unaffected.
-    /// </remarks>
     public string ComputeHash() => _computedHash ??= HashKey(GetKeyWithUserName());
 
-    /// <summary>
-    /// Hashes a handshake key into a compact string safe to embed in pipe and mutex names.
-    /// </summary>
     public static string HashKey(string key)
     {
         byte[] utf8 = Encoding.UTF8.GetBytes(key);

--- a/src/Framework/BackEnd/ServerNodeHandshake.cs
+++ b/src/Framework/BackEnd/ServerNodeHandshake.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -49,24 +49,24 @@ internal sealed class ServerNodeHandshake : Handshake
     /// on the machine out of the feature. Naming only; the handshake sent over the wire comes from
     /// <see cref="RetrieveHandshakeComponents"/> and is unaffected.
     /// </remarks>
-    public string ComputeHash()
-    {
-        if (_computedHash == null)
-        {
-            var input = GetKeyWithUserName();
-            byte[] utf8 = Encoding.UTF8.GetBytes(input);
-#if NET
-            Span<byte> bytes = stackalloc byte[SHA256.HashSizeInBytes];
-            SHA256.HashData(utf8, bytes);
-#else
-            using var sha = SHA256.Create();
-            var bytes = sha.ComputeHash(utf8);
-#endif
-            _computedHash = Convert.ToBase64String(bytes)
-                .Replace("/", "_")
-                .Replace("=", string.Empty);
-        }
+    public string ComputeHash() => _computedHash ??= HashKey(GetKeyWithUserName());
 
-        return _computedHash;
+    /// <summary>
+    /// Hashes a handshake key into a compact string safe to embed in pipe and mutex names.
+    /// </summary>
+    public static string HashKey(string key)
+    {
+        byte[] utf8 = Encoding.UTF8.GetBytes(key);
+#if NET
+        Span<byte> bytes = stackalloc byte[SHA256.HashSizeInBytes];
+        SHA256.HashData(utf8, bytes);
+#else
+        using var sha = SHA256.Create();
+        var bytes = sha.ComputeHash(utf8);
+#endif
+
+        return Convert.ToBase64String(bytes)
+            .Replace("/", "_")
+            .Replace("=", string.Empty);
     }
 }

--- a/src/Framework/Coordinator/CoordinatorSettings.cs
+++ b/src/Framework/Coordinator/CoordinatorSettings.cs
@@ -136,11 +136,6 @@ internal sealed record class CoordinatorSettings()
     /// <summary>
     ///  Generates a platform-appropriate mutex name by combining the pipe name with a purpose suffix.
     /// </summary>
-    /// <remarks>
-    ///  The mutex guards a specific pipe, so it is derived purely from <see cref="PipeName"/>. Per-user
-    ///  scoping comes from the pipe name itself (see <see cref="DefaultPipeName"/>); an explicit
-    ///  <c>MSBUILDCOORDINATORPIPENAME</c> override is respected as given.
-    /// </remarks>
     private string GetMutexName(string purpose)
     {
         if (NativeMethods.IsWindows)

--- a/src/Framework/Coordinator/CoordinatorSettings.cs
+++ b/src/Framework/Coordinator/CoordinatorSettings.cs
@@ -25,7 +25,7 @@ internal sealed record class CoordinatorSettings()
     public const int DefaultShutdownTimeoutMs = 60_000;
     public const int MaxHeartbeatIntervalMs = 300_000;
 
-    private static string DefaultPipeName => $"{PipeNameBase}-{Environment.UserName}";
+    private static string DefaultPipeName => $"{PipeNameBase}-{EnvironmentUtilities.CurrentUserName}";
 
     private int? _heartbeatIntervalMs;
     private int? _missedHeartbeatsThreshold;
@@ -136,6 +136,11 @@ internal sealed record class CoordinatorSettings()
     /// <summary>
     ///  Generates a platform-appropriate mutex name by combining the pipe name with a purpose suffix.
     /// </summary>
+    /// <remarks>
+    ///  The mutex guards a specific pipe, so it is derived purely from <see cref="PipeName"/>. Per-user
+    ///  scoping comes from the pipe name itself (see <see cref="DefaultPipeName"/>); an explicit
+    ///  <c>MSBUILDCOORDINATORPIPENAME</c> override is respected as given.
+    /// </remarks>
     private string GetMutexName(string purpose)
     {
         if (NativeMethods.IsWindows)

--- a/src/Framework/EnvironmentUtilities.cs
+++ b/src/Framework/EnvironmentUtilities.cs
@@ -96,6 +96,16 @@ internal static partial class EnvironmentUtilities
         }
     }
 
+    /// <summary>
+    ///  Gets the name of the user the current process is running as, for scoping machine-wide
+    ///  resource names to a single user. Empty when the name is unavailable.
+    /// </summary>
+    /// <remarks>
+    ///  Cached because <see cref="Environment.UserName"/> queries the OS and allocates on every call
+    ///  (~75us on Windows, versus a few nanoseconds here). A race just recomputes an equal string.
+    /// </remarks>
+    public static string CurrentUserName => field ??= Environment.UserName;
+
     public static bool IsWellKnownEnvironmentDerivedProperty(string propertyName)
         => propertyName.StartsWith("MSBUILD", StringComparison.OrdinalIgnoreCase) ||
            propertyName.StartsWith("COMPLUS_", StringComparison.OrdinalIgnoreCase) ||

--- a/src/MSBuild.Coordinator.UnitTests/CoordinatorSettings_Tests.cs
+++ b/src/MSBuild.Coordinator.UnitTests/CoordinatorSettings_Tests.cs
@@ -98,10 +98,13 @@ public class CoordinatorSettings_Tests(ITestOutputHelper output)
         settings.LaunchMutexName.ShouldContain(Environment.UserName);
     }
 
-    [Fact]
-    public void CoordinatorSettings_MutexNames_RespectOverriddenPipeName()
+    [WindowsOnlyFact]
+    public void CoordinatorSettings_MutexNames_EmbedTheGivenPipeName()
     {
-        // The mutex guards a specific pipe, so an explicit pipe name is honored as given.
+        // The mutex guards a specific pipe, so an explicit pipe name is honored as given. Windows
+        // only: the Unix name hashes the pipe name, so it cannot be inspected by substring. The
+        // cross-platform guarantee that the name is derived from the pipe name is covered by
+        // CoordinatorSettings_MutexNames_DifferByPipeName.
         CoordinatorSettings settings = CoordinatorSettings.Default with { PipeName = "coordinator-explicit-pipe" };
 
         settings.ServerMutexName.ShouldContain("coordinator-explicit-pipe");

--- a/src/MSBuild.Coordinator.UnitTests/CoordinatorSettings_Tests.cs
+++ b/src/MSBuild.Coordinator.UnitTests/CoordinatorSettings_Tests.cs
@@ -69,4 +69,41 @@ public class CoordinatorSettings_Tests(ITestOutputHelper output)
         settings.ConnectionTimeoutMs.ShouldBe(CoordinatorSettings.DefaultConnectionTimeoutMs);
         settings.ProcessId.ShouldBe(EnvironmentUtilities.CurrentProcessId);
     }
+
+    [Fact]
+    public void CoordinatorSettings_MutexNames_DifferByPurpose()
+    {
+        CoordinatorSettings settings = CoordinatorSettings.Default;
+
+        settings.ServerMutexName.ShouldNotBe(settings.LaunchMutexName);
+    }
+
+    [Fact]
+    public void CoordinatorSettings_MutexNames_DifferByPipeName()
+    {
+        // The mutex guards a specific pipe, so two differently-named coordinators must not contend.
+        CoordinatorSettings first = CoordinatorSettings.Default with { PipeName = "coordinator-pipe-one" };
+        CoordinatorSettings second = CoordinatorSettings.Default with { PipeName = "coordinator-pipe-two" };
+
+        first.ServerMutexName.ShouldNotBe(second.ServerMutexName);
+    }
+
+    [WindowsOnlyFact]
+    public void CoordinatorSettings_DefaultMutexNames_AreUserScopedViaPipeName()
+    {
+        // Per-user scoping comes from the default pipe name, which the mutex name is derived from.
+        CoordinatorSettings settings = CoordinatorSettings.FromEnvironment();
+
+        settings.ServerMutexName.ShouldContain(Environment.UserName);
+        settings.LaunchMutexName.ShouldContain(Environment.UserName);
+    }
+
+    [Fact]
+    public void CoordinatorSettings_MutexNames_RespectOverriddenPipeName()
+    {
+        // The mutex guards a specific pipe, so an explicit pipe name is honored as given.
+        CoordinatorSettings settings = CoordinatorSettings.Default with { PipeName = "coordinator-explicit-pipe" };
+
+        settings.ServerMutexName.ShouldContain("coordinator-explicit-pipe");
+    }
 }


### PR DESCRIPTION
### Context

Follow-up to an analysis of whether the MSBuild server mutexes are redundant with its named pipe. They are not, but the analysis surfaced a separate scoping bug in how the server's names are derived.

### Problem

Named pipes and named mutexes live in **machine-wide** namespaces, while MSBuild creates its pipes **current-user-only** (`PipeOptions.CurrentUserOnly`). MSBuild server derives every such name from `ServerNodeHandshake.ComputeHash()`, which is built only from handshake options, salt and file version — `ServerNodeHandshake` passes `includeSessionId: false` — so all users on a machine computed identical names.

Two users sharing a machine (Remote Desktop, shared CI agent) therefore collide:

1. User B sees user A's `Global\msbuild-server-running-{hash}` mutex.
2. B concludes a server is already running and skips launching its own.
3. B cannot connect to A's pipe, because it is restricted to A.
4. B cannot create a pipe under that name either, because A holds it.

User B is locked out of MSBuild server entirely by user A. This matters more now that `-mt` implicitly opts into the server.

### Fix

Mix the current user into `ServerNodeHandshake.ComputeHash()`, via a new `GetKeyWithUserName()`. That single change covers the server pipe name, the running/busy/launch mutexes, and the RAR node pipe names, since all of them derive from that hash.

### Not a protocol change

`ComputeHash()` is used **only** to generate names. The handshake actually exchanged over the wire comes from `RetrieveHandshakeComponents()`, which is untouched, so this does not affect handshake compatibility with other MSBuild versions. A test pins that invariant.

Cross-user access remains enforced by the OS as before (pipe DACL on Windows, `GetPeerID` check on Unix); this change prevents the denial-of-service, it is not the security boundary.

### Coordinator: no behavior change

The coordinator already scopes itself per user through its default pipe name, and its mutex names are derived from that pipe name, so it is already correct. It only moves to the new cached accessor. `GetMutexName` stays a pure function of `PipeName` — an explicit `MSBUILDCOORDINATORPIPENAME` override is honored as given, and that intent is now documented.

### `EnvironmentUtilities.CurrentUserName`

A single cached accessor for both call sites. Caching is worth it by a wide margin — measured locally:

```
raw= 75078.50 ns/op   cached=0.62 ns/op
ReferenceEquals across calls: False
```

`Environment.UserName` queries the OS and allocates a fresh string on **every** call (~75us on Windows via `GetUserNameExW`), with no runtime-side caching. Notably this was measured on a machine that is *not* domain-joined, so it is not an AD round-trip.

### Validation

- Full `build.cmd`: 0 warnings, 0 errors.
- New `ServerNodeHandshake_Tests`: 4/4 pass.
- `MSBuild.Coordinator.UnitTests`: 79/79 pass.
- `AppHostSupport_Tests` + `UnixNodeReuseFixes_Tests` (handshake key regression): pass.
- RAR node tests: 8/8 pass.
- `MSBuildServer_Tests`: 17 failed / 4 passed — **identical to the unmodified baseline** on this machine (verified by stashing, rebuilding and re-running). These failures are pre-existing and environmental; the server cannot start in this sandbox.

### Note for reviewers

`Environment.UserName` returns the bare account name with no domain, so two accounts with the same short name from different domains would still collide. Using the user SID would match the pipe DACL exactly; `Environment.UserName` was chosen for cross-platform simplicity. Happy to switch if preferred.
