### PR TITLE
Make the branch-freeze required status self-healing

### DIFF
--- a/.github/branch-freeze/components/github/GitHubPullRequestsClient.psm1
+++ b/.github/branch-freeze/components/github/GitHubPullRequestsClient.psm1
@@ -1,5 +1,20 @@
 Import-Module (Join-Path $PSScriptRoot 'GitHubCli.psm1') -Force
 
+function Get-GitHubPullRequest {
+    [OutputType([System.Management.Automation.PSCustomObject])]
+    param(
+        [Parameter(Mandatory)][string]$Repository,
+        [Parameter(Mandatory)][string]$Number
+    )
+
+    $pullRequestJson = Invoke-GitHubCli -Arguments @(
+        'pr', 'view', $Number,
+        '--repo', $Repository,
+        '--json', 'number,headRefOid,baseRefName'
+    )
+    return $pullRequestJson | ConvertFrom-Json
+}
+
 function Get-GitHubOpenPullRequest {
     [OutputType([System.Management.Automation.PSCustomObject])]
     param(
@@ -21,4 +36,7 @@ function Get-GitHubOpenPullRequest {
     return @(Invoke-GitHubCli -Arguments $arguments | ConvertFrom-Json)
 }
 
-Export-ModuleMember -Function 'Get-GitHubOpenPullRequest'
+Export-ModuleMember -Function @(
+    'Get-GitHubOpenPullRequest',
+    'Get-GitHubPullRequest'
+)

--- a/.github/branch-freeze/components/github/GitHubStatusChecksClient.psm1
+++ b/.github/branch-freeze/components/github/GitHubStatusChecksClient.psm1
@@ -1,5 +1,55 @@
 Import-Module (Join-Path $PSScriptRoot 'GitHubCli.psm1') -Force
 
+function Get-GitHubCommitStatus {
+    [OutputType([System.Management.Automation.PSCustomObject])]
+    param(
+        [Parameter(Mandatory)][string]$Repository,
+        [Parameter(Mandatory)][string]$HeadSha,
+        [Parameter(Mandatory)][string]$Context
+    )
+
+    # Use the list endpoint rather than the combined `/status` one: only the list
+    # reports `creator`, which is what proves a status came from this workflow.
+    # Entries are newest first, so the first context match is the current status.
+    $statusesJson = Invoke-GitHubCli -Arguments @(
+        'api', "repos/$Repository/commits/$HeadSha/statuses?per_page=100"
+    )
+    return @($statusesJson | ConvertFrom-Json) |
+        Where-Object {
+            [StringComparer]::OrdinalIgnoreCase.Equals([string]$_.context, $Context)
+        } |
+        Select-Object -First 1
+}
+
+function Test-GitHubCommitStatusMatches {
+    [OutputType([bool])]
+    param(
+        [AllowNull()]$Status,
+        [Parameter(Mandatory)][string]$State,
+        [Parameter(Mandatory)][string]$Description,
+        [Parameter(Mandatory)][AllowEmptyString()][string]$TargetUrl
+    )
+
+    if ($null -eq $Status) {
+        return $false
+    }
+
+    # The required check is satisfied only by a status from the GitHub Actions
+    # integration, so anything posted by someone else -- including a status whose
+    # creator the API did not report -- counts as a mismatch and is replaced.
+    $creatorLogin = if ($null -eq $Status.creator) { '' } else { [string]$Status.creator.login }
+    if (-not [StringComparer]::OrdinalIgnoreCase.Equals($creatorLogin, 'github-actions[bot]')) {
+        return $false
+    }
+
+    $currentTargetUrl = if ($null -eq $Status.target_url) { '' } else { [string]$Status.target_url }
+    return (
+        [StringComparer]::OrdinalIgnoreCase.Equals([string]$Status.state, $State) -and
+        [StringComparer]::Ordinal.Equals([string]$Status.description, $Description) -and
+        [StringComparer]::Ordinal.Equals($currentTargetUrl, $TargetUrl)
+    )
+}
+
 function Set-GitHubCommitStatus {
     [OutputType([void])]
     param(
@@ -10,6 +60,27 @@ function Set-GitHubCommitStatus {
         [Parameter(Mandatory)][string]$Description,
         [string]$TargetUrl = ''
     )
+
+    # Reading the current status only avoids burning the 1000-statuses-per-context
+    # API budget on no-op writes, so it must never be able to prevent a write:
+    # a redundant status is harmless, a missing one leaves a required check
+    # unanswered and the pull request unmergeable.
+    $currentStatus = $null
+    try {
+        $currentStatus = Get-GitHubCommitStatus -Repository $Repository `
+            -HeadSha $HeadSha -Context $Context
+    }
+    catch {
+        Write-Host "::warning::Could not read the current '$Context' status on $HeadSha; posting it anyway."
+    }
+
+    if (
+        Test-GitHubCommitStatusMatches -Status $currentStatus -State $State `
+            -Description $Description -TargetUrl $TargetUrl
+    ) {
+        Write-Host "Commit status '$Context' on $HeadSha is already up to date."
+        return
+    }
 
     $arguments = @(
         'api', '-X', 'POST', "repos/$Repository/statuses/$HeadSha",

--- a/.github/branch-freeze/tests/mock-gh.ps1
+++ b/.github/branch-freeze/tests/mock-gh.ps1
@@ -6,6 +6,12 @@
 #                                                         $env:GH_ISSUE_FILE
 #   * `gh issue comment ...`                           -> fails when
 #                                                         $env:MOCK_ISSUE_COMMENT_FAILURE=1
+#   * `gh pr view ... --json ...`                      -> prints $env:MOCK_PR
+#                                                        (default {}).
+#   * `gh api .../commits/<sha>/statuses`             -> prints $env:MOCK_STATUSES
+#                                                        (default []), or fails
+#                                                        while
+#                                                        $env:MOCK_STATUS_READ_FAILURE=1.
 #   * `gh api -X POST .../statuses/<sha> -f key=value` -> appends each key=value
 #                                                        line to $env:GH_STATUS_FILE.
 #   * any command                                      -> fails while the counter in
@@ -104,8 +110,15 @@ switch -CaseSensitive ($command) {
     }
   }
   'pr' {
-    if ($CliArguments.Count -gt 1 -and $CliArguments[1] -eq 'list') {
-      Write-Output $(if ([string]::IsNullOrEmpty($env:MOCK_PRS)) { '[]' } else { $env:MOCK_PRS })
+    if ($CliArguments.Count -gt 1) {
+      switch -CaseSensitive ($CliArguments[1]) {
+        'list' {
+          Write-Output $(if ([string]::IsNullOrEmpty($env:MOCK_PRS)) { '[]' } else { $env:MOCK_PRS })
+        }
+        'view' {
+          Write-Output $(if ([string]::IsNullOrEmpty($env:MOCK_PR)) { '{}' } else { $env:MOCK_PR })
+        }
+      }
     }
   }
   'api' {
@@ -132,7 +145,12 @@ switch -CaseSensitive ($command) {
       }
     }
 
-    if ($endpoint -like '*/statuses/*') {
+    if ($endpoint -like '*/commits/*/statuses*') {
+      if ($env:MOCK_STATUS_READ_FAILURE -eq '1') {
+        exit 1
+      }
+      Write-Output $(if ([string]::IsNullOrEmpty($env:MOCK_STATUSES)) { '[]' } else { $env:MOCK_STATUSES })
+    } elseif ($endpoint -like '*/statuses/*') {
       if (
         -not [string]::IsNullOrEmpty($env:MOCK_STATUS_FAILURE_SHA) -and
         $endpoint.EndsWith("/$($env:MOCK_STATUS_FAILURE_SHA)", [StringComparison]::Ordinal)

--- a/.github/branch-freeze/tests/mock-gh.ps1
+++ b/.github/branch-freeze/tests/mock-gh.ps1
@@ -7,7 +7,9 @@
 #   * `gh issue comment ...`                           -> fails when
 #                                                         $env:MOCK_ISSUE_COMMENT_FAILURE=1
 #   * `gh pr view ... --json ...`                      -> prints $env:MOCK_PR
-#                                                        (default {}).
+#                                                        (default {}), or fails
+#                                                        while
+#                                                        $env:MOCK_PR_VIEW_FAILURE=1.
 #   * `gh api .../commits/<sha>/statuses`             -> prints $env:MOCK_STATUSES
 #                                                        (default []), or fails
 #                                                        while
@@ -116,6 +118,9 @@ switch -CaseSensitive ($command) {
           Write-Output $(if ([string]::IsNullOrEmpty($env:MOCK_PRS)) { '[]' } else { $env:MOCK_PRS })
         }
         'view' {
+          if ($env:MOCK_PR_VIEW_FAILURE -eq '1') {
+            exit 1
+          }
           Write-Output $(if ([string]::IsNullOrEmpty($env:MOCK_PR)) { '{}' } else { $env:MOCK_PR })
         }
       }

--- a/.github/branch-freeze/tests/run-tests.ps1
+++ b/.github/branch-freeze/tests/run-tests.ps1
@@ -6,10 +6,13 @@
 #   * is-allowed.ps1     - who may run /freeze /unfreeze (deny-by-default).
 #   * handle-command.ps1 - untrusted branch and reason text cannot execute PowerShell.
 #   * set-pr-status.ps1  - only the open permanent issue for the exact branch title
-#                          freezes that branch.
+#                          freezes that branch; identical statuses are not reposted;
+#                          current PR state wins over stale event data.
 #   * handle-command.ps1 - one issue is created per branch, then reopened/closed.
 #   * handle-command.ps1 - notification failure cannot suppress refresh after a
 #                          successful state change.
+#   * workflow YAML       - all status writers share one queued lock and
+#                          automation-created PR workflows trigger a refresh.
 #
 # Uses a PowerShell mock of `gh`; no live repository or external JSON tool is needed.
 # Run:  pwsh .github/branch-freeze/tests/run-tests.ps1
@@ -161,6 +164,80 @@ try {
         $env:MOCK_TRANSIENT_FAILURE_FILE = ''
     }
 
+    Write-Output '== workflow contracts (triggers and concurrency) =='
+    $statusWorkflowPath = Join-Path $repositoryRoot '.github/workflows/branch-freeze-pr-status.yml'
+    $refreshWorkflowPath = Join-Path $repositoryRoot '.github/workflows/branch-freeze-refresh.yml'
+    $statusWorkflow = Get-Content -LiteralPath $statusWorkflowPath -Raw
+    $refreshWorkflow = Get-Content -LiteralPath $refreshWorkflowPath -Raw
+
+    Assert-Equal (
+        [regex]::IsMatch($statusWorkflow, '(?m)^\s*group:\s*branch-freeze-write\s*$')
+    ) $true 'single-PR workflow uses the shared writer group'
+    Assert-Equal (
+        $statusWorkflow.IndexOf(
+            'PR_NUMBER: ${{ github.event.pull_request.number }}',
+            [StringComparison]::Ordinal
+        ) -ge 0
+    ) $true 'single-PR workflow passes only the PR identity into the writer lock'
+    Assert-Equal (
+        $statusWorkflow.IndexOf(
+            '${{ github.event.pull_request.base.ref }}',
+            [StringComparison]::Ordinal
+        )
+    ) -1 'single-PR workflow does not trust an event-captured base branch'
+    Assert-Equal (
+        $statusWorkflow.IndexOf('queue: max', [StringComparison]::Ordinal) -ge 0
+    ) $true 'single-PR workflow preserves pending status jobs'
+    Assert-Equal (
+        [regex]::IsMatch($refreshWorkflow, '(?m)^\s*group:\s*branch-freeze-write\s*$')
+    ) $true 'bulk workflow uses the shared writer group'
+    Assert-Equal (
+        $refreshWorkflow.IndexOf('queue: max', [StringComparison]::Ordinal) -ge 0
+    ) $true 'bulk workflow preserves pending status jobs'
+    Assert-Equal (
+        $refreshWorkflow.IndexOf(
+            "github.event.workflow_run.conclusion != 'skipped'",
+            [StringComparison]::Ordinal
+        ) -ge 0
+    ) $true 'bulk workflow ignores skipped source workflows'
+    Assert-Equal (
+        $refreshWorkflow.IndexOf('cron: "23 5,17 * * *"', [StringComparison]::Ordinal) -ge 0
+    ) $true 'bulk workflow keeps the twice-daily safety-net schedule'
+
+    $pullRequestCreatingWorkflows = [ordered]@{
+        'backport.yml' = 'Backport PR to branch'
+        'dreaming.agent.lock.yml' = 'Dreaming (learning atoms curation)'
+        'flaky-test-fixer.agent.lock.yml' = 'Flaky Test Auto-Fixer'
+        'flaky-test-detector.agent.lock.yml' = 'Flaky Test Triage'
+        'inter-branch-merge-flow.yml' = 'Inter-branch merge workflow'
+        'SyncAnalyzerTemplateMSBuildVersion.yml' = 'Sync Microsoft.Build version in analyzer template with Version.props'
+    }
+    $testsWorkflowPath = Join-Path $repositoryRoot '.github/workflows/branch-freeze-tests.yml'
+    $testsWorkflow = Get-Content -LiteralPath $testsWorkflowPath -Raw
+    foreach ($entry in $pullRequestCreatingWorkflows.GetEnumerator()) {
+        $sourceWorkflow = Get-Content -LiteralPath (
+            Join-Path $repositoryRoot ".github/workflows/$($entry.Key)"
+        ) -Raw
+        $escapedName = [regex]::Escape($entry.Value)
+        Assert-Equal (
+            [regex]::IsMatch($sourceWorkflow, "(?m)^name:\s*`"?$escapedName`"?\s*$")
+        ) $true "$($entry.Key) declares the expected workflow name"
+        Assert-Equal (
+            $refreshWorkflow.IndexOf(
+                "- `"$($entry.Value)`"",
+                [StringComparison]::Ordinal
+            ) -ge 0
+        ) $true "bulk workflow listens for $($entry.Value)"
+        # Without this the rename guard above never runs on the pull request that
+        # renames the workflow, which is the only change that can break it.
+        Assert-Equal (
+            $testsWorkflow.IndexOf(
+                "- `".github/workflows/$($entry.Key)`"",
+                [StringComparison]::Ordinal
+            ) -ge 0
+        ) $true "these tests run when $($entry.Key) changes"
+    }
+
     Write-Output '== comment modules (pure parsing and composition) =='
     $branchFreezeModule = Import-Module `
         (Join-Path $componentsDirectory 'BranchFreeze.psm1') -Force -PassThru
@@ -235,6 +312,7 @@ try {
 
     Write-Output '== set-pr-status.ps1 (freeze detection) =='
     $env:REPO = 'o/r'
+    $env:MOCK_STATUSES = '[]'
 
     $statusFile = Initialize-TestStatusFile
     $env:MOCK_ISSUES = '[]'
@@ -243,26 +321,91 @@ try {
     Assert-Equal (Get-StatusField $statusFile 'state') 'success' 'no tracking issue -> branch open (success)'
 
     $statusFile = Initialize-TestStatusFile
+    $env:MOCK_STATUSES = '[{"state":"SUCCESS","context":"Branch-Freeze","description":"Branch open","target_url":null,"creator":{"login":"GitHub-Actions[bot]"}}]'
+    $code = Invoke-TestScript (Join-Path $workflowScriptsDirectory 'set-pr-status.ps1') @('sha-current-open', 'main')
+    Assert-Equal $code 0 'matching open branch status command succeeds'
+    Assert-Equal (
+        @(Get-Content -LiteralPath $statusFile).Count
+    ) 0 'matching open branch status is not reposted'
+
+    $statusFile = Initialize-TestStatusFile
+    $env:MOCK_STATUSES = '[{"state":"success","context":"branch-freeze","description":"Branch open","target_url":null,"creator":{"login":"github-actions[bot]"}}]'
+    $env:MOCK_STATUS_READ_FAILURE = '1'
+    $code = Invoke-TestScript (Join-Path $workflowScriptsDirectory 'set-pr-status.ps1') @('sha-read-failure', 'main')
+    $env:MOCK_STATUS_READ_FAILURE = '0'
+    Assert-Equal $code 0 'unreadable current status does not fail the command'
+    Assert-Equal (
+        Get-StatusField $statusFile 'state'
+    ) 'success' 'unreadable current status still posts the required status'
+
+    $statusFile = Initialize-TestStatusFile
+    $env:MOCK_STATUSES = '[{"state":"success","context":"branch-freeze","description":"Branch open","target_url":null}]'
+    $code = Invoke-TestScript (Join-Path $workflowScriptsDirectory 'set-pr-status.ps1') @('sha-no-creator', 'main')
+    Assert-Equal $code 0 'status without a creator command succeeds'
+    Assert-Equal (
+        Get-StatusField $statusFile 'state'
+    ) 'success' 'status of unknown origin is replaced rather than trusted'
+
+    $statusFile = Initialize-TestStatusFile
+    $env:MOCK_STATUSES = '[{"state":"success","context":"branch-freeze","description":"Branch open","target_url":null,"creator":{"login":"another-app[bot]"}}]'
+    $code = Invoke-TestScript (Join-Path $workflowScriptsDirectory 'set-pr-status.ps1') @('sha-other-creator', 'main')
+    Assert-Equal $code 0 'matching status from another integration is replaced'
+    Assert-Equal (
+        Get-StatusField $statusFile 'state'
+    ) 'success' 'GitHub Actions reposts a status created by another integration'
+
+    $statusFile = Initialize-TestStatusFile
+    # Simulate an old event that captured an open base, followed by a newer
+    # retarget back to a frozen branch. The workflow now passes only PR #42, so
+    # the script must use this current GitHub state rather than stale event data.
+    $env:MOCK_PR = '{"number":42,"headRefOid":"sha-current","baseRefName":"release"}'
+    $env:MOCK_STATUSES = '[]'
+    $env:MOCK_ISSUES = '[{"number":8,"title":"Branch freeze: release","url":"https://github.com/o/r/issues/8","state":"OPEN","body":"## Current state\n\nBranch `release` is **frozen** by @rainersigwald.\n\n### Reason\n\nServicing validation\n\n<!-- branch-freeze-by:rainersigwald -->"}]'
+    $code = Invoke-TestScript (Join-Path $workflowScriptsDirectory 'set-pr-status.ps1') @(
+        '-PullRequestNumber', '42'
+    )
+    Assert-Equal $code 0 'current PR status command succeeds'
+    Assert-Equal (
+        Get-StatusField $statusFile 'state'
+    ) 'failure' 'current frozen base wins over stale event data'
+    Assert-Equal (
+        Get-StatusField $statusFile 'target_url'
+    ) 'https://github.com/o/r/issues/8' 'current PR status links the current base freeze'
+
+    $statusFile = Initialize-TestStatusFile
+    $env:MOCK_PR = ''
+    $env:MOCK_STATUSES = '[{"state":"success","context":"branch-freeze","description":"Branch open","target_url":null,"creator":{"login":"github-actions[bot]"}}]'
     $env:MOCK_ISSUES = '[{"number":7,"title":"Branch freeze: main","url":"https://github.com/o/r/issues/7","state":"OPEN","body":"## Current state\n\nBranch `main` is **frozen** by @rainersigwald.\n\n### Reason\n\nSDK insertion broke\n\n<!-- branch-freeze-by:rainersigwald -->"}]'
     $code = Invoke-TestScript (Join-Path $workflowScriptsDirectory 'set-pr-status.ps1') @('sha-frozen', 'main')
     Assert-Equal $code 0 'frozen branch status command succeeds'
-    Assert-Equal (Get-StatusField $statusFile 'state') 'failure' 'open permanent issue -> branch frozen (failure)'
+    Assert-Equal (Get-StatusField $statusFile 'state') 'failure' 'freeze replaces the previous success status'
     Assert-Equal (Get-StatusField $statusFile 'description') 'Frozen by @rainersigwald: SDK insertion broke' 'status names who froze it'
     Assert-Equal (Get-StatusField $statusFile 'target_url') 'https://github.com/o/r/issues/7' 'status links the tracking issue'
 
     $statusFile = Initialize-TestStatusFile
+    $env:MOCK_STATUSES = '[{"state":"failure","context":"branch-freeze","description":"Frozen by @rainersigwald: SDK insertion broke","target_url":"https://github.com/o/r/issues/7","creator":{"login":"github-actions[bot]"}}]'
+    $code = Invoke-TestScript (Join-Path $workflowScriptsDirectory 'set-pr-status.ps1') @('sha-current-frozen', 'main')
+    Assert-Equal $code 0 'matching frozen branch status command succeeds'
+    Assert-Equal (
+        @(Get-Content -LiteralPath $statusFile).Count
+    ) 0 'matching frozen branch status is not reposted'
+
+    $statusFile = Initialize-TestStatusFile
+    $env:MOCK_STATUSES = '[{"state":"failure","context":"branch-freeze","description":"Frozen: old reason","target_url":"u","creator":{"login":"github-actions[bot]"}}]'
     $env:MOCK_ISSUES = '[{"number":9,"title":"Branch freeze: main","url":"u","state":"CLOSED","body":"old reason"}]'
     $code = Invoke-TestScript (Join-Path $workflowScriptsDirectory 'set-pr-status.ps1') @('sha-closed', 'main')
     Assert-Equal $code 0 'closed permanent issue status command succeeds'
-    Assert-Equal (Get-StatusField $statusFile 'state') 'success' 'closed permanent issue -> branch open'
+    Assert-Equal (Get-StatusField $statusFile 'state') 'success' 'unfreeze replaces the previous failure status'
 
     $statusFile = Initialize-TestStatusFile
+    $env:MOCK_STATUSES = '[]'
     $env:MOCK_ISSUES = '[{"number":9,"title":"Branch freeze: release","url":"u","state":"OPEN","body":"release only"}]'
     $code = Invoke-TestScript (Join-Path $workflowScriptsDirectory 'set-pr-status.ps1') @('sha-other', 'main')
     Assert-Equal $code 0 'different branch issue status command succeeds'
     Assert-Equal (Get-StatusField $statusFile 'state') 'success' 'different exact title does not freeze the branch'
 
     $statusFile = Initialize-TestStatusFile
+    $env:MOCK_STATUSES = '[]'
     $longReason = ('a' * 128) + '😀' + ('b' * 10)
     $env:MOCK_ISSUES = @(
         @{
@@ -494,6 +637,7 @@ SDK insertion broke
     Write-Output '== refresh-pr-statuses.ps1 (bulk refresh) =='
     $statusFile = Initialize-TestStatusFile
     $env:MOCK_ISSUES = '[]'
+    $env:MOCK_STATUSES = '[]'
     $env:MOCK_PRS = '[{"number":1,"headRefOid":"sha-1","baseRefName":"main"},{"number":2,"headRefOid":"sha-2","baseRefName":"main"}]'
     $code = Invoke-TestScript (Join-Path $workflowScriptsDirectory 'refresh-pr-statuses.ps1') @('main')
     Assert-Equal $code 0 'bulk refresh succeeds'

--- a/.github/branch-freeze/tests/run-tests.ps1
+++ b/.github/branch-freeze/tests/run-tests.ps1
@@ -181,13 +181,28 @@ try {
     ) $true 'single-PR workflow passes only the PR identity into the writer lock'
     Assert-Equal (
         $statusWorkflow.IndexOf(
-            '${{ github.event.pull_request.base.ref }}',
+            'FALLBACK_BASE_REF: ${{ github.event.pull_request.base.ref }}',
             [StringComparison]::Ordinal
-        )
-    ) -1 'single-PR workflow does not trust an event-captured base branch'
+        ) -ge 0
+    ) $true 'single-PR workflow captures the event base only as a fallback'
+    # The event-captured base is allowed to appear exactly once, on the fallback
+    # line above. Anywhere else it would reintroduce the stale-retarget bug.
+    Assert-Equal (
+        [regex]::Matches(
+            $statusWorkflow,
+            [regex]::Escape('${{ github.event.pull_request.base.ref }}')
+        ).Count
+    ) 1 'single-PR workflow does not otherwise trust an event-captured base branch'
     Assert-Equal (
         $statusWorkflow.IndexOf('queue: max', [StringComparison]::Ordinal) -ge 0
     ) $true 'single-PR workflow preserves pending status jobs'
+    # The command workflow holds its own group until its refresh job drains the
+    # shared writer queue, so it needs the same protection against eviction.
+    Assert-Equal (
+        (Get-Content -LiteralPath (
+            Join-Path $repositoryRoot '.github/workflows/branch-freeze-command.yml'
+        ) -Raw).IndexOf('queue: max', [StringComparison]::Ordinal) -ge 0
+    ) $true 'command workflow preserves pending freeze/unfreeze commands'
     Assert-Equal (
         [regex]::IsMatch($refreshWorkflow, '(?m)^\s*group:\s*branch-freeze-write\s*$')
     ) $true 'bulk workflow uses the shared writer group'
@@ -371,6 +386,33 @@ try {
     Assert-Equal (
         Get-StatusField $statusFile 'target_url'
     ) 'https://github.com/o/r/issues/8' 'current PR status links the current base freeze'
+
+    $statusFile = Initialize-TestStatusFile
+    # Reading the pull request is preferred but, like the current-status read, it
+    # must not be able to suppress the write: an unanswered required status is
+    # worse than one stamped from a possibly stale event payload.
+    $env:MOCK_PR_VIEW_FAILURE = '1'
+    $code = Invoke-TestScript (Join-Path $workflowScriptsDirectory 'set-pr-status.ps1') @(
+        '-PullRequestNumber', '42',
+        '-FallbackHeadSha', 'sha-fallback',
+        '-FallbackBaseRef', 'release'
+    )
+    Assert-Equal $code 0 'unreadable pull request does not fail the command'
+    Assert-Equal (
+        Get-StatusField $statusFile 'state'
+    ) 'failure' 'unreadable pull request falls back to the event-captured base'
+
+    $statusFile = Initialize-TestStatusFile
+    # With nothing to fall back to there is no head commit to stamp, so fail
+    # loudly rather than silently stamping the wrong commit.
+    $code = Invoke-TestScript (Join-Path $workflowScriptsDirectory 'set-pr-status.ps1') @(
+        '-PullRequestNumber', '42'
+    )
+    $env:MOCK_PR_VIEW_FAILURE = '0'
+    Assert-Equal ($code -ne 0) $true 'unreadable pull request without a fallback fails loudly'
+    Assert-Equal (
+        @(Get-Content -LiteralPath $statusFile).Count
+    ) 0 'unresolvable pull request stamps no commit'
 
     $statusFile = Initialize-TestStatusFile
     $env:MOCK_PR = ''

--- a/.github/branch-freeze/workflows/set-pr-status.ps1
+++ b/.github/branch-freeze/workflows/set-pr-status.ps1
@@ -6,8 +6,9 @@
 # required status description.
 [CmdletBinding()]
 param(
-    [Parameter(Mandatory, Position = 0)][string]$HeadSha,
-    [Parameter(Mandatory, Position = 1)][string]$BaseRef
+    [Parameter(Mandatory, Position = 0, ParameterSetName = 'Commit')][string]$HeadSha,
+    [Parameter(Mandatory, Position = 1, ParameterSetName = 'Commit')][string]$BaseRef,
+    [Parameter(Mandatory, ParameterSetName = 'PullRequest')][string]$PullRequestNumber
 )
 
 function Invoke-Main {
@@ -39,7 +40,19 @@ $ErrorActionPreference = 'Stop'
 $componentsDirectory = Join-Path (Split-Path -Parent $PSScriptRoot) 'components'
 Import-Module (Join-Path $componentsDirectory 'BranchFreeze.psm1') -Force
 Import-Module (Join-Path $componentsDirectory 'issue-comments/BranchFreezeCommentComposer.psm1') -Force
+Import-Module (Join-Path $componentsDirectory 'github/GitHubPullRequestsClient.psm1') -Force
 Import-Module (Join-Path $componentsDirectory 'github/GitHubRepositoryClient.psm1') -Force
 Import-Module (Join-Path $componentsDirectory 'github/GitHubStatusChecksClient.psm1') -Force
+
+if ($PSCmdlet.ParameterSetName -eq 'PullRequest') {
+    # Resolve these after the workflow has acquired the global status-writer
+    # lock. Event payloads can be stale when a PR is retargeted repeatedly, and
+    # GitHub does not guarantee that queued workflow jobs start in dispatch order.
+    $pullRequest = Get-GitHubPullRequest -Repository (Get-GitHubRepositoryName) `
+        -Number $PullRequestNumber
+    $HeadSha = [string]$pullRequest.headRefOid
+    $BaseRef = [string]$pullRequest.baseRefName
+}
+
 $exitCode = Invoke-Main
 exit $exitCode

--- a/.github/branch-freeze/workflows/set-pr-status.ps1
+++ b/.github/branch-freeze/workflows/set-pr-status.ps1
@@ -8,7 +8,9 @@
 param(
     [Parameter(Mandatory, Position = 0, ParameterSetName = 'Commit')][string]$HeadSha,
     [Parameter(Mandatory, Position = 1, ParameterSetName = 'Commit')][string]$BaseRef,
-    [Parameter(Mandatory, ParameterSetName = 'PullRequest')][string]$PullRequestNumber
+    [Parameter(Mandatory, ParameterSetName = 'PullRequest')][string]$PullRequestNumber,
+    [Parameter(ParameterSetName = 'PullRequest')][AllowEmptyString()][string]$FallbackHeadSha = '',
+    [Parameter(ParameterSetName = 'PullRequest')][AllowEmptyString()][string]$FallbackBaseRef = ''
 )
 
 function Invoke-Main {
@@ -48,10 +50,31 @@ if ($PSCmdlet.ParameterSetName -eq 'PullRequest') {
     # Resolve these after the workflow has acquired the global status-writer
     # lock. Event payloads can be stale when a PR is retargeted repeatedly, and
     # GitHub does not guarantee that queued workflow jobs start in dispatch order.
-    $pullRequest = Get-GitHubPullRequest -Repository (Get-GitHubRepositoryName) `
-        -Number $PullRequestNumber
-    $HeadSha = [string]$pullRequest.headRefOid
-    $BaseRef = [string]$pullRequest.baseRefName
+    $HeadSha = ''
+    $BaseRef = ''
+    try {
+        $pullRequest = Get-GitHubPullRequest -Repository (Get-GitHubRepositoryName) `
+            -Number $PullRequestNumber
+        $HeadSha = [string]$pullRequest.headRefOid
+        $BaseRef = [string]$pullRequest.baseRefName
+    }
+    catch {
+        Write-Host "::warning::Could not read pull request #$PullRequestNumber ($($_.Exception.Message))."
+    }
+
+    # The live read is authoritative but must never be able to prevent a write,
+    # for the same reason the current-status read cannot: a stale status is
+    # corrected by the next event or by the scheduled sweep, while a missing one
+    # leaves the required check unanswered and the pull request unmergeable.
+    if ([string]::IsNullOrEmpty($HeadSha) -or [string]::IsNullOrEmpty($BaseRef)) {
+        if ([string]::IsNullOrEmpty($FallbackHeadSha) -or [string]::IsNullOrEmpty($FallbackBaseRef)) {
+            throw "Could not resolve the head commit and base branch of pull request #$PullRequestNumber."
+        }
+
+        Write-Host "::warning::Falling back to the event payload head and base for pull request #$PullRequestNumber."
+        $HeadSha = $FallbackHeadSha
+        $BaseRef = $FallbackBaseRef
+    }
 }
 
 $exitCode = Invoke-Main

--- a/.github/workflows/branch-freeze-command.yml
+++ b/.github/workflows/branch-freeze-command.yml
@@ -23,8 +23,14 @@ permissions:
 
 concurrency:
   # Do not let two freeze/unfreeze operations modify tracking issues at once.
+  # This group is held for the whole run, including the `refresh` job below,
+  # which waits on the repository-wide `branch-freeze-write` queue. `queue: max`
+  # keeps up to 100 commands pending for that window instead of letting a newer
+  # command evict an older pending one -- an evicted command never toggles the
+  # freeze at all, and its author is never told.
   group: branch-freeze-command
   cancel-in-progress: false
+  queue: max
 
 jobs:
   command:

--- a/.github/workflows/branch-freeze-command.yml
+++ b/.github/workflows/branch-freeze-command.yml
@@ -101,9 +101,9 @@ jobs:
         # exposes the affected branch for the refresh job below.
         run: pwsh -NoLogo -NoProfile -File "$env:GITHUB_WORKSPACE/.github/branch-freeze/workflows/handle-command.ps1"
 
-  # Refresh every open PR on the affected branch. The refresh and single-PR
-  # workflows share the same per-branch concurrency group, preventing a stale
-  # status write from winning a race with /freeze or /unfreeze.
+  # Refresh every open PR on the affected branch. All branch-freeze status
+  # writers share one queued concurrency group, preventing a stale write from
+  # winning a race with /freeze, /unfreeze, or a PR retarget.
   refresh:
     needs: command
     if: needs.command.outputs.changed == 'true'

--- a/.github/workflows/branch-freeze-pr-status.yml
+++ b/.github/workflows/branch-freeze-pr-status.yml
@@ -13,9 +13,10 @@ on:
     types: [opened, synchronize, reopened, edited]
 
 permissions:
-  contents: read   # checkout the shared scripts
-  statuses: write  # post the branch-freeze commit status
-  issues: read     # read the branch-freeze tracking issue
+  contents: read       # checkout the shared scripts
+  statuses: write      # post the branch-freeze commit status
+  issues: read         # read the branch-freeze tracking issue
+  pull-requests: read  # resolve the PR's current head and base inside the lock
 
 jobs:
   status:
@@ -25,9 +26,15 @@ jobs:
       github.event.action != 'edited' ||
       github.event.changes.base != null
     runs-on: ubuntu-latest
+    # Every branch-freeze status writer shares this group. `queue: max`
+    # preserves up to 100 pending jobs instead of replacing an older pending job,
+    # so bursty activity cannot drop a required status. Queued runs do not have a
+    # guaranteed dispatch order, so the step below resolves the PR's current head
+    # and base only after this lock has been acquired.
     concurrency:
-      group: branch-freeze-write-${{ github.event.pull_request.base.ref }}
+      group: branch-freeze-write
       cancel-in-progress: false
+      queue: max
     steps:
       # Pin the action implementation to immutable v7.0.0. Separately, `ref`
       # checks out trusted MSBuild scripts from the default branch rather than
@@ -41,11 +48,9 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         shell: pwsh
         run: |
           pwsh -NoLogo -NoProfile -File `
             "$env:GITHUB_WORKSPACE/.github/branch-freeze/workflows/set-pr-status.ps1" `
-            $env:HEAD_SHA `
-            $env:BASE_REF
+            -PullRequestNumber $env:PR_NUMBER

--- a/.github/workflows/branch-freeze-pr-status.yml
+++ b/.github/workflows/branch-freeze-pr-status.yml
@@ -49,8 +49,16 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          # Last resort only: the script prefers the head and base it reads from
+          # the API after taking the lock, and uses these -- which can be stale
+          # for a retargeted PR -- solely when that read fails. A stale status is
+          # corrected by the next event or sweep; a missing one blocks merging.
+          FALLBACK_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          FALLBACK_BASE_REF: ${{ github.event.pull_request.base.ref }}
         shell: pwsh
         run: |
           pwsh -NoLogo -NoProfile -File `
             "$env:GITHUB_WORKSPACE/.github/branch-freeze/workflows/set-pr-status.ps1" `
-            -PullRequestNumber $env:PR_NUMBER
+            -PullRequestNumber $env:PR_NUMBER `
+            -FallbackHeadSha $env:FALLBACK_HEAD_SHA `
+            -FallbackBaseRef $env:FALLBACK_BASE_REF

--- a/.github/workflows/branch-freeze-refresh.yml
+++ b/.github/workflows/branch-freeze-refresh.yml
@@ -1,11 +1,20 @@
 name: Refresh branch freeze PR statuses
 
 # Refreshes the required `branch-freeze` commit status on existing pull requests.
-# This workflow has two entry points:
+# This workflow has four entry points:
 #
 #   * workflow_dispatch - manual refresh or initial rollout seed.
 #   * workflow_call     - refresh invoked after /freeze or /unfreeze changes the
 #                         tracking issue state.
+#   * workflow_run      - stamps pull requests opened by our own workflows.
+#   * schedule          - safety net for anything the other entry points missed.
+#
+# Why workflow_run and schedule exist: `branch-freeze-pr-status.yml` reacts to
+# `pull_request_target`, but GitHub suppresses workflow runs for pull request
+# events created with the built-in `GITHUB_TOKEN` to avoid recursion. Some of
+# our agentic and automation workflows can fall back to that token, so those
+# pull requests would otherwise wait forever on a `branch-freeze` status that
+# nobody posts, and stay unmergeable.
 
 on:
   workflow_dispatch:
@@ -20,6 +29,21 @@ on:
         description: "Refresh open pull requests targeting this base branch."
         required: true
         type: string
+  # Every workflow here can open a pull request from Actions. Keep this list in
+  # sync when a workflow gains or loses that ability.
+  workflow_run:
+    workflows:
+      - "Backport PR to branch"
+      - "Dreaming (learning atoms curation)"
+      - "Flaky Test Auto-Fixer"
+      - "Flaky Test Triage"
+      - "Inter-branch merge workflow"
+      - "Sync Microsoft.Build version in analyzer template with Version.props"
+    types: [completed]
+  # Off-peak minute: runs scheduled on the hour are the most likely to be
+  # delayed or dropped when GitHub is busy.
+  schedule:
+    - cron: "23 5,17 * * *"
 
 permissions:
   contents: read       # checkout the shared scripts
@@ -30,10 +54,23 @@ permissions:
 jobs:
   refresh:
     name: Refresh open pull requests
+    # `Backport PR to branch` is requested for every issue comment and skips its
+    # job unless the comment is a backport command. Do not turn those skipped
+    # runs into repository-wide status sweeps.
+    if: >-
+      github.event_name != 'workflow_run' ||
+      github.event.workflow_run.conclusion != 'skipped'
     runs-on: ubuntu-latest
+    # Every branch-freeze status writer shares this group, so a sweep can never
+    # interleave with a /freeze refresh or a single-PR update. `queue: max` keeps
+    # up to 100 runs pending instead of discarding the older one. A blank
+    # base_ref means "every open PR", and refresh-pr-statuses.ps1 already stamps
+    # each PR against its own current base branch, so this needs no per-branch
+    # fan-out.
     concurrency:
-      group: branch-freeze-write-${{ inputs.base_ref }}
+      group: branch-freeze-write
       cancel-in-progress: false
+      queue: max
     steps:
       # Keep checkout pinned to the immutable v7.0.0 commit; the @v7 tag can move.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/branch-freeze-tests.yml
+++ b/.github/workflows/branch-freeze-tests.yml
@@ -13,6 +13,16 @@ on:
       - ".github/workflows/branch-freeze-tests.yml"
       - ".github/branch-freeze/**"
       - ".github/branch-freeze-allowlist.txt"
+      # branch-freeze-refresh.yml keys its `workflow_run` trigger off these
+      # workflows' `name:` values, so a rename here silently stops stamping
+      # automation-created pull requests. Run the contract tests on those edits
+      # too, otherwise the guard never fires on the change that breaks it.
+      - ".github/workflows/backport.yml"
+      - ".github/workflows/dreaming.agent.lock.yml"
+      - ".github/workflows/flaky-test-detector.agent.lock.yml"
+      - ".github/workflows/flaky-test-fixer.agent.lock.yml"
+      - ".github/workflows/inter-branch-merge-flow.yml"
+      - ".github/workflows/SyncAnalyzerTemplateMSBuildVersion.yml"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
### Context

The `branch-freeze` commit status is a required check, but nothing posts it for pull requests opened by our own workflows. `branch-freeze-pr-status.yml` reacts to `pull_request_target`, and GitHub suppresses workflow runs for pull request events created with the built-in `GITHUB_TOKEN`, so those pull requests wait forever on a status nobody writes and stay unmergeable — for example #14542, which has 10 passing checks, zero commit statuses, and `mergeStateStatus: BLOCKED`.

### Changes Made

- Added a `workflow_run` trigger to `branch-freeze-refresh.yml` for the six workflows that can open a pull request from Actions (`Backport PR to branch`, `Dreaming (learning atoms curation)`, `Flaky Test Auto-Fixer`, `Flaky Test Triage`, `Inter-branch merge workflow`, `Sync Microsoft.Build version in analyzer template with Version.props`).
- Added a twice-daily `schedule` (`23 5,17 * * *`) as a safety net for anything the other entry points miss.
- Skipped `workflow_run` events whose conclusion is `skipped`, so `Backport PR to branch` — which is requested on every issue comment — does not trigger repository-wide sweeps.
- Replaced the per-base-branch concurrency group with a single `branch-freeze-write` group plus `queue: max` in both `branch-freeze-pr-status.yml` and `branch-freeze-refresh.yml`. The old group put nearly every pull request in one queue, and `cancel-in-progress: false` only protects the *running* job — a newer run evicted an already-pending one, silently dropping a required status.
- Changed `set-pr-status.ps1` to accept `-PullRequestNumber` and resolve the pull request's current head and base via the new `Get-GitHubPullRequest` **after** acquiring the concurrency lock, instead of trusting the event payload. Queued runs have no guaranteed start order, so a stale retarget event could otherwise report a frozen branch as open.
- Added `Get-GitHubCommitStatus` and `Test-GitHubCommitStatusMatches` to `GitHubStatusChecksClient.psm1` so `Set-GitHubCommitStatus` skips writes that would not change the status, keeping long-lived pull requests away from the 1000-statuses-per-context API limit.
- Made that read best-effort: a failed status read emits a `::warning::` and still posts the status, since a redundant status is harmless but a missing one blocks merging.
- Treated a status whose `creator` is missing or is not `github-actions[bot]` as a mismatch, so a status from another integration is replaced rather than trusted — the ruleset is only satisfied by the GitHub Actions integration.
- Added the six source workflow paths to `branch-freeze-tests.yml` so the workflow-name contract tests run on the pull requests that can break them.

### Testing

- Ran `.github/branch-freeze/tests/run-tests.ps1` — **112 passed, 0 failed** (was 73 before this change).
- New coverage in `run-tests.ps1`:
  - `current frozen base wins over stale event data` — asserts a stale retarget event still reports the current frozen base.
  - `unreadable current status still posts the required status` — asserts a failed status read does not suppress the write.
  - `status of unknown origin is replaced rather than trusted` — asserts a status with no `creator` is reposted.
  - `GitHub Actions reposts a status created by another integration` — asserts a foreign `creator` is not treated as satisfying the check.
  - `matching open/frozen branch status is not reposted` — asserts identical statuses are skipped.
  - `single-PR workflow does not trust an event-captured base branch` — asserts the workflow no longer passes `github.event.pull_request.base.ref`.
  - `<workflow> declares the expected workflow name` / `these tests run when <workflow> changes` — pins the six `workflow_run` names and their test-trigger paths.
- Validated all four branch-freeze workflow YAML files parse with `js-yaml`, and all `.ps1`/`.psm1` files parse with `[System.Management.Automation.Language.Parser]` (the same check CI runs).
- Verified `Get-GitHubPullRequest` against the live API (`dotnet/msbuild#14542`) and confirmed `/commits/{sha}/statuses` returns `creator` while the combined `/commits/{sha}/status` endpoint does not.
- Did not run the MSBuild build or unit tests; no product code is touched.

### Notes

- This does not back-fill already-stuck pull requests such as #14542. After merge they are fixed by the first scheduled sweep, or immediately by running **Refresh branch freeze PR statuses** via `workflow_dispatch` with a blank `base_ref`.
- `queue: max` requires the concurrency queue support announced 2026-05-07; it cannot be combined with `cancel-in-progress: true`, which this change does not use.
- The bulk sweep still stamps each pull request from the `gh pr list` snapshot taken at job start rather than re-resolving per pull request. A retarget mid-sweep is corrected by the retarget's own `pull_request_target` run, which queues on the same lock and executes afterwards.
