### PR TITLE
Bump .NET runtime packages to 10.0.10

### DIFF
--- a/eng/Version.Details.props
+++ b/eng/Version.Details.props
@@ -11,23 +11,23 @@ This file should be imported by eng/Versions.props
     <!-- dotnet-roslyn dependencies -->
     <MicrosoftNetCompilersToolsetPackageVersion>5.10.0-1.26365.3</MicrosoftNetCompilersToolsetPackageVersion>
     <!-- dotnet-runtime dependencies -->
-    <SystemCodeDomPackageVersion>10.0.9</SystemCodeDomPackageVersion>
-    <SystemCollectionsImmutablePackageVersion>10.0.9</SystemCollectionsImmutablePackageVersion>
-    <SystemConfigurationConfigurationManagerPackageVersion>10.0.9</SystemConfigurationConfigurationManagerPackageVersion>
-    <SystemDiagnosticsDiagnosticSourcePackageVersion>10.0.9</SystemDiagnosticsDiagnosticSourcePackageVersion>
-    <SystemDiagnosticsEventLogPackageVersion>10.0.9</SystemDiagnosticsEventLogPackageVersion>
+    <SystemCodeDomPackageVersion>10.0.10</SystemCodeDomPackageVersion>
+    <SystemCollectionsImmutablePackageVersion>10.0.10</SystemCollectionsImmutablePackageVersion>
+    <SystemConfigurationConfigurationManagerPackageVersion>10.0.10</SystemConfigurationConfigurationManagerPackageVersion>
+    <SystemDiagnosticsDiagnosticSourcePackageVersion>10.0.10</SystemDiagnosticsDiagnosticSourcePackageVersion>
+    <SystemDiagnosticsEventLogPackageVersion>10.0.10</SystemDiagnosticsEventLogPackageVersion>
     <SystemFormatsAsn1PackageVersion>10.0.10</SystemFormatsAsn1PackageVersion>
-    <SystemFormatsNrbfPackageVersion>10.0.9</SystemFormatsNrbfPackageVersion>
-    <SystemReflectionMetadataPackageVersion>10.0.9</SystemReflectionMetadataPackageVersion>
-    <SystemReflectionMetadataLoadContextPackageVersion>10.0.9</SystemReflectionMetadataLoadContextPackageVersion>
-    <SystemResourcesExtensionsPackageVersion>10.0.9</SystemResourcesExtensionsPackageVersion>
+    <SystemFormatsNrbfPackageVersion>10.0.10</SystemFormatsNrbfPackageVersion>
+    <SystemReflectionMetadataPackageVersion>10.0.10</SystemReflectionMetadataPackageVersion>
+    <SystemReflectionMetadataLoadContextPackageVersion>10.0.10</SystemReflectionMetadataLoadContextPackageVersion>
+    <SystemResourcesExtensionsPackageVersion>10.0.10</SystemResourcesExtensionsPackageVersion>
     <SystemSecurityCryptographyPkcsPackageVersion>10.0.10</SystemSecurityCryptographyPkcsPackageVersion>
-    <SystemSecurityCryptographyProtectedDataPackageVersion>10.0.9</SystemSecurityCryptographyProtectedDataPackageVersion>
+    <SystemSecurityCryptographyProtectedDataPackageVersion>10.0.10</SystemSecurityCryptographyProtectedDataPackageVersion>
     <SystemSecurityCryptographyXmlPackageVersion>10.0.10</SystemSecurityCryptographyXmlPackageVersion>
-    <SystemTextEncodingCodePagesPackageVersion>10.0.9</SystemTextEncodingCodePagesPackageVersion>
-    <SystemTextJsonPackageVersion>10.0.9</SystemTextJsonPackageVersion>
-    <SystemThreadingChannelsPackageVersion>10.0.9</SystemThreadingChannelsPackageVersion>
-    <SystemThreadingTasksDataflowPackageVersion>10.0.9</SystemThreadingTasksDataflowPackageVersion>
+    <SystemTextEncodingCodePagesPackageVersion>10.0.10</SystemTextEncodingCodePagesPackageVersion>
+    <SystemTextJsonPackageVersion>10.0.10</SystemTextJsonPackageVersion>
+    <SystemThreadingChannelsPackageVersion>10.0.10</SystemThreadingChannelsPackageVersion>
+    <SystemThreadingTasksDataflowPackageVersion>10.0.10</SystemThreadingTasksDataflowPackageVersion>
     <!-- nuget-nuget.client dependencies -->
     <NuGetBuildTasksPackageVersion>7.10.0-rc.40</NuGetBuildTasksPackageVersion>
   </PropertyGroup>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -3,31 +3,31 @@
   <Source Uri="https://github.com/dotnet/dotnet" Mapping="msbuild" Sha="ecc427bc7d7b4ee32b943f71196ab377f67c1105" BarId="322911" />
   <ProductDependencies>
     <!-- Necessary for source-build. This allows the live version of the package to be used by source-build. -->
-    <Dependency Name="System.CodeDom" Version="10.0.9">
+    <Dependency Name="System.CodeDom" Version="10.0.10">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>
       </Sha>
     </Dependency>
     <!-- Necessary for source-build. This allows the live version of the package to be used by source-build. -->
-    <Dependency Name="System.Collections.Immutable" Version="10.0.9">
+    <Dependency Name="System.Collections.Immutable" Version="10.0.10">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>
       </Sha>
     </Dependency>
     <!-- Necessary for source-build. This allows the live version of the package to be used by source-build. -->
-    <Dependency Name="System.Configuration.ConfigurationManager" Version="10.0.9">
+    <Dependency Name="System.Configuration.ConfigurationManager" Version="10.0.10">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>
       </Sha>
     </Dependency>
     <!-- Necessary for source-build. This allows the live version of the package to be used by source-build. -->
-    <Dependency Name="System.Diagnostics.DiagnosticSource" Version="10.0.9">
+    <Dependency Name="System.Diagnostics.DiagnosticSource" Version="10.0.10">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>
       </Sha>
     </Dependency>
     <!-- Necessary for source-build. This allows the live version of the package to be used by source-build. -->
-    <Dependency Name="System.Diagnostics.EventLog" Version="10.0.9">
+    <Dependency Name="System.Diagnostics.EventLog" Version="10.0.10">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>
       </Sha>
@@ -39,31 +39,31 @@
       </Sha>
     </Dependency>
     <!-- Necessary for source-build. This allows the live version of the package to be used by source-build. -->
-    <Dependency Name="System.Formats.Nrbf" Version="10.0.9">
+    <Dependency Name="System.Formats.Nrbf" Version="10.0.10">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>
       </Sha>
     </Dependency>
     <!-- Necessary for source-build. This allows the live version of the package to be used by source-build. -->
-    <Dependency Name="System.Reflection.Metadata" Version="10.0.9">
+    <Dependency Name="System.Reflection.Metadata" Version="10.0.10">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>
       </Sha>
     </Dependency>
     <!-- Necessary for source-build. This allows the live version of the package to be used by source-build. -->
-    <Dependency Name="System.Reflection.MetadataLoadContext" Version="10.0.9">
+    <Dependency Name="System.Reflection.MetadataLoadContext" Version="10.0.10">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>
       </Sha>
     </Dependency>
     <!-- Necessary for source-build. This allows the live version of the package to be used by source-build. -->
-    <Dependency Name="System.Resources.Extensions" Version="10.0.9">
+    <Dependency Name="System.Resources.Extensions" Version="10.0.10">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>
       </Sha>
     </Dependency>
     <!-- Necessary for source-build. This allows the live version of the package to be used by source-build. -->
-    <Dependency Name="System.Security.Cryptography.ProtectedData" Version="10.0.9">
+    <Dependency Name="System.Security.Cryptography.ProtectedData" Version="10.0.10">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>
       </Sha>
@@ -81,25 +81,25 @@
       </Sha>
     </Dependency>
     <!-- Necessary for source-build. This allows the live version of the package to be used by source-build. -->
-    <Dependency Name="System.Text.Encoding.CodePages" Version="10.0.9">
+    <Dependency Name="System.Text.Encoding.CodePages" Version="10.0.10">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>
       </Sha>
     </Dependency>
     <!-- Necessary for source-build. This allows the live version of the package to be used by source-build. -->
-    <Dependency Name="System.Text.Json" Version="10.0.9">
+    <Dependency Name="System.Text.Json" Version="10.0.10">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>
       </Sha>
     </Dependency>
     <!-- Necessary for source-build. This allows the live version of the package to be used by source-build. -->
-    <Dependency Name="System.Threading.Channels" Version="10.0.9">
+    <Dependency Name="System.Threading.Channels" Version="10.0.10">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>
       </Sha>
     </Dependency>
     <!-- Necessary for source-build. This allows the live version of the package to be used by source-build. -->
-    <Dependency Name="System.Threading.Tasks.Dataflow" Version="10.0.9">
+    <Dependency Name="System.Threading.Tasks.Dataflow" Version="10.0.10">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>
       </Sha>

--- a/src/MSBuild/app.amd64.config
+++ b/src/MSBuild/app.amd64.config
@@ -62,18 +62,18 @@
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="System.Formats.Nrbf" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-          <bindingRedirect oldVersion="0.0.0.0-10.0.0.9" newVersion="10.0.0.9" />
-          <codeBase version="10.0.0.9" href="..\System.Formats.Nrbf.dll"/>
+          <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+          <codeBase version="10.0.0.10" href="..\System.Formats.Nrbf.dll"/>
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="System.IO.Pipelines" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-          <bindingRedirect oldVersion="0.0.0.0-10.0.0.9" newVersion="10.0.0.9" />
-          <codeBase version="10.0.0.9" href="..\System.IO.Pipelines.dll"/>
+          <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+          <codeBase version="10.0.0.10" href="..\System.IO.Pipelines.dll"/>
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="Microsoft.Bcl.AsyncInterfaces" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-          <bindingRedirect oldVersion="0.0.0.0-10.0.0.9" newVersion="10.0.0.9" />
-          <codeBase version="10.0.0.9" href="..\Microsoft.Bcl.AsyncInterfaces.dll"/>
+          <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+          <codeBase version="10.0.0.10" href="..\Microsoft.Bcl.AsyncInterfaces.dll"/>
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="Microsoft.Bcl.HashCode" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
@@ -103,8 +103,8 @@
         <!-- Pull plugins that reference SCI up to our version in case they depended on our copy of the older version -->
         <dependentAssembly>
           <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-          <bindingRedirect oldVersion="0.0.0.0-10.0.0.9" newVersion="10.0.0.9" />
-          <codeBase version="10.0.0.9" href="..\System.Collections.Immutable.dll"/>
+          <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+          <codeBase version="10.0.0.10" href="..\System.Collections.Immutable.dll"/>
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
@@ -122,18 +122,18 @@
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-          <bindingRedirect oldVersion="0.0.0.0-10.0.0.9" newVersion="10.0.0.9" />
-          <codeBase version="10.0.0.9" href="..\System.Reflection.Metadata.dll" />
+          <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+          <codeBase version="10.0.0.10" href="..\System.Reflection.Metadata.dll" />
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="System.Reflection.MetadataLoadContext" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-          <bindingRedirect oldVersion="0.0.0.0-10.0.0.9" newVersion="10.0.0.9" />
-          <codeBase version="10.0.0.9" href="..\System.Reflection.MetadataLoadContext.dll" />
+          <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+          <codeBase version="10.0.0.10" href="..\System.Reflection.MetadataLoadContext.dll" />
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="System.Resources.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-          <bindingRedirect oldVersion="0.0.0.0-10.0.0.9" newVersion="10.0.0.9" />
-          <codeBase version="10.0.0.9" href="..\System.Resources.Extensions.dll"/>
+          <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+          <codeBase version="10.0.0.10" href="..\System.Resources.Extensions.dll"/>
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
@@ -142,23 +142,23 @@
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="System.Text.Encodings.Web" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-          <bindingRedirect oldVersion="0.0.0.0-10.0.0.9" newVersion="10.0.0.9" />
-          <codeBase version="10.0.0.9" href="..\System.Text.Encodings.Web.dll"/>
+          <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+          <codeBase version="10.0.0.10" href="..\System.Text.Encodings.Web.dll"/>
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="System.Text.Json" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-          <bindingRedirect oldVersion="0.0.0.0-10.0.0.9" newVersion="10.0.0.9" />
-          <codeBase version="10.0.0.9" href="..\System.Text.Json.dll"/>
+          <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+          <codeBase version="10.0.0.10" href="..\System.Text.Json.dll"/>
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="System.Threading.Channels" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-          <bindingRedirect oldVersion="0.0.0.0-10.0.0.9" newVersion="10.0.0.9" />
-          <codeBase version="10.0.0.9" href="..\System.Threading.Channels.dll"/>
+          <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+          <codeBase version="10.0.0.10" href="..\System.Threading.Channels.dll"/>
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="System.Threading.Tasks.Dataflow" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-          <bindingRedirect oldVersion="0.0.0.0-10.0.0.9" newVersion="10.0.0.9" />
-          <codeBase version="10.0.0.9" href="..\System.Threading.Tasks.Dataflow.dll"/>
+          <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
+          <codeBase version="10.0.0.10" href="..\System.Threading.Tasks.Dataflow.dll"/>
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />

--- a/src/MSBuild/app.config
+++ b/src/MSBuild/app.config
@@ -33,7 +33,7 @@
         <!-- Redirects for assemblies redistributed by MSBuild (in the .vsix). -->
         <dependentAssembly>
           <assemblyIdentity name="Microsoft.Bcl.AsyncInterfaces" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-          <bindingRedirect oldVersion="0.0.0.0-10.0.0.9" newVersion="10.0.0.9" />
+          <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="Microsoft.Bcl.HashCode" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
@@ -58,15 +58,15 @@
         <!-- Pull plugins that reference SCI up to our version in case they depended on our copy of the older version -->
         <dependentAssembly>
           <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-          <bindingRedirect oldVersion="0.0.0.0-10.0.0.9" newVersion="10.0.0.9" />
+          <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="System.Formats.Nrbf" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-          <bindingRedirect oldVersion="0.0.0.0-10.0.0.9" newVersion="10.0.0.9" />
+          <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="System.IO.Pipelines" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-          <bindingRedirect oldVersion="0.0.0.0-10.0.0.9" newVersion="10.0.0.9" />
+          <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
@@ -78,15 +78,15 @@
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-          <bindingRedirect oldVersion="0.0.0.0-10.0.0.9" newVersion="10.0.0.9" />
+          <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="System.Reflection.MetadataLoadContext" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-          <bindingRedirect oldVersion="0.0.0.0-10.0.0.9" newVersion="10.0.0.9" />
+          <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="System.Resources.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-          <bindingRedirect oldVersion="0.0.0.0-10.0.0.9" newVersion="10.0.0.9" />
+          <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
@@ -94,19 +94,19 @@
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="System.Text.Encodings.Web" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-          <bindingRedirect oldVersion="0.0.0.0-10.0.0.9" newVersion="10.0.0.9" />
+          <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="System.Text.Json" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-          <bindingRedirect oldVersion="0.0.0.0-10.0.0.9" newVersion="10.0.0.9" />
+          <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="System.Threading.Channels" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-          <bindingRedirect oldVersion="0.0.0.0-10.0.0.9" newVersion="10.0.0.9" />
+          <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="System.Threading.Tasks.Dataflow" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-          <bindingRedirect oldVersion="0.0.0.0-10.0.0.9" newVersion="10.0.0.9" />
+          <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />

--- a/src/Tasks/System.Resources.Extensions.pkgdef
+++ b/src/Tasks/System.Resources.Extensions.pkgdef
@@ -3,5 +3,5 @@
 "codeBase"="$BaseInstallDir$\MSBuild\Current\Bin\System.Resources.Extensions.dll"
 "publicKeyToken"="cc7b13ffcd2ddd51"
 "culture"="neutral"
-"oldVersion"="0.0.0.0-10.0.0.9"
-"newVersion"="10.0.0.9"
+"oldVersion"="0.0.0.0-10.0.0.10"
+"newVersion"="10.0.0.10"


### PR DESCRIPTION
### Context

Aligns MSBuild''s .NET runtime dependencies and binding redirects with the 10.0.10 servicing release, so app-local framework assemblies resolve to the version actually deployed.

`System.Formats.Asn1`, `System.Security.Cryptography.Pkcs` and `System.Security.Cryptography.Xml` were already moved to 10.0.10 in #14472 (they had to move together to avoid NuGet downgrade errors). This brings the remaining 14 runtime packages up to match.

Follows the same shape as #14343 (the 10.0.9 bump).

### Changes Made

- `eng/Version.Details.props` / `eng/Version.Details.xml` — bumped the remaining 14 `System.*` runtime dependencies from `10.0.9` to `10.0.10`.
- `src/MSBuild/app.config` — binding redirects `10.0.0.9` -> `10.0.0.10`.
- `src/MSBuild/app.amd64.config` — binding redirects and `codeBase` versions `10.0.0.9` -> `10.0.0.10`.
- `src/Tasks/System.Resources.Extensions.pkgdef` — `oldVersion`/`newVersion` `10.0.0.9` -> `10.0.0.10`.

### Testing

- Built the repository with `.\build.cmd -verbosity quiet` — 0 warnings, 0 errors.
- Verified every `bindingRedirect` in the generated `MSBuild.exe.config` (both `Bin` and `Bin\amd64`) resolves to a deployed assembly with a matching `AssemblyVersion` of `10.0.0.10`, including transitively-pulled assemblies that are not pinned in `Version.Details.props` (`Microsoft.Bcl.AsyncInterfaces`, `System.IO.Pipelines`, `System.Text.Encodings.Web`, `System.Formats.Nrbf`).
- Verified the amd64 `codeBase` `version` attributes match the deployed assemblies.

A matching VS-side change (`DotNetRuntimePackagesVersion` / `AssemblyVersions.tt`) will be combined with the MSBuild insertion so both halves land together.
