### PR TITLE
Don't log TaskAssemblyLocationMismatch for task-host-routed tasks

### DIFF
--- a/src/Build.UnitTests/BackEnd/TaskRouter_IntegrationTests.cs
+++ b/src/Build.UnitTests/BackEnd/TaskRouter_IntegrationTests.cs
@@ -381,6 +381,72 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
             logger.FullLog.ShouldContain("TaskWithAttribute executed");
         }
 
+        /// <summary>
+        /// Regression test: a task routed to a TaskHost must not log <c>TaskAssemblyLocationMismatch</c>.
+        /// <c>TaskHostTask</c> is only an in-proc proxy for a task that is loaded in a separate process, so
+        /// its own assembly location (Microsoft.Build.dll) can never match the resolved task assembly path
+        /// and the diagnostic carries no information. In multi-threaded mode this is the common path, so a
+        /// stale check produced one spurious message per task execution.
+        /// The registered path deliberately contains a redundant "." segment so that it is not byte-identical
+        /// to <c>Assembly.Location</c> - the same normalization difference real builds hit.
+        /// </summary>
+        [Theory]
+        [InlineData(true, "")] // Routed to the sidecar TaskHost because multi-threaded mode is on.
+        [InlineData(false, @" TaskFactory=""TaskHostFactory""")] // Routed to a TaskHost by explicit request.
+        public void TaskHostRoutedTask_DoesNotLogAssemblyLocationMismatch(bool multiThreaded, string taskFactoryAttribute)
+        {
+            // Arrange
+            string assemblyPath = Assembly.GetExecutingAssembly().Location;
+            string nonNormalizedAssemblyPath = Path.Combine(Path.GetDirectoryName(assemblyPath), ".", Path.GetFileName(assemblyPath));
+
+            string projectContent = $@"
+<Project>
+    <UsingTask TaskName=""NonEnlightenedTestTask"" AssemblyFile=""{nonNormalizedAssemblyPath}""{taskFactoryAttribute} />
+
+    <Target Name=""TestTarget"">
+        <NonEnlightenedTestTask />
+    </Target>
+</Project>";
+
+            string projectFile = Path.Combine(_testProjectsDir, $"NoAssemblyLocationMismatch_{multiThreaded}.proj");
+            File.WriteAllText(projectFile, projectContent);
+
+            var logger = new MockLogger(_output);
+            var buildParameters = new BuildParameters
+            {
+                MultiThreaded = multiThreaded,
+                Loggers = new[] { logger },
+                DisableInProcNode = false,
+                EnableNodeReuse = false
+            };
+
+            var buildRequestData = new BuildRequestData(
+                projectFile,
+                new Dictionary<string, string>(),
+                null,
+                new[] { "TestTarget" },
+                null);
+
+            // Act
+            var result = BuildManager.DefaultBuildManager.Build(buildParameters, buildRequestData);
+
+            // Assert
+            result.OverallResult.ShouldBe(BuildResultCode.Success);
+            TaskRouterTestHelper.AssertTaskUsedTaskHost(logger, "NonEnlightenedTestTask");
+            logger.FullLog.ShouldContain("NonEnlightenedTask executed");
+
+            // Assert on the localized text preceding the first format argument so the test is locale-safe
+            // and does not depend on the exact paths that would have been reported.
+            const string ArgumentSentinel = "<<arg>>";
+            string mismatchMessage = ResourceUtilities.FormatResourceStringIgnoreCodeAndKeyword(
+                "TaskAssemblyLocationMismatch",
+                ArgumentSentinel,
+                ArgumentSentinel);
+            string mismatchMessagePrefix = mismatchMessage.Substring(0, mismatchMessage.IndexOf(ArgumentSentinel, StringComparison.Ordinal));
+
+            logger.FullLog.ShouldNotContain(mismatchMessagePrefix);
+        }
+
         private string CreateTestProject(string taskName, string taskClass)
         {
             return $@"

--- a/src/Build/BackEnd/TaskExecutionHost/TaskExecutionHost.cs
+++ b/src/Build/BackEnd/TaskExecutionHost/TaskExecutionHost.cs
@@ -517,8 +517,13 @@ namespace Microsoft.Build.BackEnd
             // meaningless) in a single-file/Native AOT host - and a registered task is already the loaded
             // type. On .NET, guard the read on dynamic-code support so ILC dead-strips it (and its IL3000)
             // under Native AOT while the JIT keeps the diagnostic; .NET Framework (no AOT) always runs it.
+            // A TaskHostTask is only an in-proc proxy - the task assembly it stands for is loaded in the task
+            // host process, so the proxy's own location (always Microsoft.Build.dll) says nothing about where
+            // the task came from and comparing it would report a mismatch for every out-of-proc task.
 #if NET
-            if (RuntimeFeature.IsDynamicCodeSupported)
+            if (RuntimeFeature.IsDynamicCodeSupported && TaskInstance is not TaskHostTask)
+#else
+            if (TaskInstance is not TaskHostTask)
 #endif
             {
                 // When MSBuild loads a task assembly, it uses Assembly.LoadFrom() with a specific path, but
@@ -530,10 +535,7 @@ namespace Microsoft.Build.BackEnd
                 string realTaskAssemblyLocation = TaskInstance.GetType().Assembly.Location;
                 if (!string.IsNullOrWhiteSpace(realTaskAssemblyLocation) && realTaskAssemblyLocation != _taskFactoryWrapper.TaskFactoryLoadedType.Path)
                 {
-                    if (!IsTaskAssemblyMatchFactoryType())
-                    {
-                        _taskLoggingContext.LogComment(MessageImportance.Normal, "TaskAssemblyLocationMismatch", realTaskAssemblyLocation, _taskFactoryWrapper.TaskFactoryLoadedType.Path);
-                    }
+                    _taskLoggingContext.LogComment(MessageImportance.Normal, "TaskAssemblyLocationMismatch", realTaskAssemblyLocation, _taskFactoryWrapper.TaskFactoryLoadedType.Path);
                 }
             }
 
@@ -546,10 +548,6 @@ namespace Microsoft.Build.BackEnd
             }
 
             return true;
-
-            // Function to validate that if this is a TaskHostTask, the assembly it loaded is the same one we found in the registry.
-            bool IsTaskAssemblyMatchFactoryType() => TaskInstance is not TaskHostTask tht
-                || tht.LoadedTaskAssemblyInfo.AssemblyLocation == _taskFactoryWrapper.TaskFactoryLoadedType.Path;
         }
 
         /// <summary>

--- a/src/Build/Instance/TaskFactories/TaskHostTask.cs
+++ b/src/Build/Instance/TaskFactories/TaskHostTask.cs
@@ -241,11 +241,6 @@ namespace Microsoft.Build.BackEnd
         }
 
         /// <summary>
-        /// Gets information about the assembly from which the task type was loaded.
-        /// </summary>
-        public AssemblyLoadInfo LoadedTaskAssemblyInfo => _taskType.Assembly;
-
-        /// <summary>
         /// Sets the requested task parameter to the requested value.
         /// </summary>
         public void SetPropertyValue(TaskPropertyInfo property, object value)


### PR DESCRIPTION
### Context

`-mt` builds of OrchardCore emit ~1200 spurious `TaskAssemblyLocationMismatch` messages at normal importance that a baseline build does not:

```
Task assembly was loaded from 'C:\...\sdk\<version>\Microsoft.Build.dll'
  while the desired location was 'C:\...\sdk\<version>\Roslyn\Microsoft.Build.Tasks.CodeAnalysis.dll'.
```

They are pure noise — no build output changes — but they drown out real assembly-identity problems, inflate binlogs, and give 11 otherwise-silent targets a target header at `-v:n`.

### Root cause

The diagnostic reads `TaskInstance.GetType().Assembly.Location` to detect when `Assembly.LoadFrom()` resolved a task assembly to a location other than the one we probed. That read is only meaningful when `TaskInstance` **is** the task. For a task routed to a TaskHost, `TaskInstance` is a `TaskHostTask` proxy declared in `Microsoft.Build.dll`, and the real assembly is loaded in the task host process — so the read can never say anything about where the task came from.

`IsTaskAssemblyMatchFactoryType()` (added in #12509) was meant to suppress the message in that case, but it compared `AssemblyLoadInfo.AssemblyLocation` with `LoadedType.Path`:

* `AssemblyLoadInfo.AssemblyLocation` returns the assembly **name** for tasks registered by `AssemblyName` — nearly everything in `Microsoft.Common.tasks`.
* For tasks registered by `AssemblyFile` it returns the registration-time path, which is not always byte-identical to the normalized `Assembly.Location`.

Either way the comparison fails and the message is logged.

The guard was also tautological in every real code path: `AssemblyTaskFactory` hands the *same* `LoadedType` instance to both `TaskFactoryWrapper.TaskFactoryLoadedType` and `TaskHostTask`, so it could only ever produce false positives — it could not detect a genuine mismatch.

Because virtually nothing runs in a TaskHost in a normal build, this was never exercised. `-mt` routes every task without `[MSBuildMultiThreadableTask]` to a sidecar TaskHost, making it the common path.

### Changes

Skip the diagnostic when `TaskInstance is TaskHostTask`, before the (now wasted) `Assembly.Location` read. The in-proc `Assembly.LoadFrom` identity-redirect case the diagnostic was written for is unchanged.

This also covers the second TaskHost route — `CreateTaskHostTaskForOutOfProcFactory`, used for inline tasks under `-mt` — which a fix that merely compared `AssemblyLoadInfo` objects would have missed.

Removed the now-dead `IsTaskAssemblyMatchFactoryType` local function and `TaskHostTask.LoadedTaskAssemblyInfo` (internal type, no API surface change).

No ChangeWave: this only removes bogus normal-importance messages; no build behavior changes.

### Testing

New `TaskHostRoutedTask_DoesNotLogAssemblyLocationMismatch` theory in `TaskRouter_IntegrationTests`, covering both TaskHost routes:

* `MultiThreaded = true` with the default factory (sidecar TaskHost — the reported scenario)
* explicit `TaskFactory="TaskHostFactory"` without `-mt` (proves the bug isn't `-mt`-specific)

The registered `AssemblyFile` deliberately contains a redundant `.` segment so it is not byte-identical to `Assembly.Location` — the same normalization difference real builds hit. Verified the test **fails on `main`** with exactly the reported message and passes with the fix.

Also ran `TaskRouter_IntegrationTests`, `TaskHostFactory_Tests` and `TaskExecutionHost_Tests` (165/165 on `net11.0` and `net472`) plus the full `Microsoft.Build.Engine.UnitTests` suite; remaining failures are pre-existing/environmental and unrelated.

### Notes

Reviewers may want to consider a follow-up that makes the diagnostic meaningful for out-of-proc tasks by reporting it from the task host process, where the assembly is actually loaded.
