### PR TITLE
Phase out ChangeWaves 17.10, 17.12, 17.14 and 18.3

### DIFF
--- a/documentation/Property-tracking-capabilities.md
+++ b/documentation/Property-tracking-capabilities.md
@@ -25,7 +25,7 @@ The feature implements specialized event handling for four tracking scenarios (p
 1. `PropertyReassignmentEventArgs`
    - Triggered when a property value is changed
    - `set MsBuildLogPropertyTracking=1`
-   - **Note:** Property reassignment tracking is automatically enabled with ChangeWaves.Wave17_10, even when `MsBuildLogPropertyTracking=0`
+   - **Note:** Property reassignment tracking is enabled by default, even when `MsBuildLogPropertyTracking=0`
 
 2. `PropertyInitialValueSetEventArgs`
    - Triggered when a property is first initialized
@@ -49,6 +49,6 @@ If you want to enable all these events reporting, enable it by `set MsBuildLogPr
 
 Property reassignment tracking has special enabling logic. It is enabled when:
 - `PropertyReassignment` flag is explicitly set (value includes `1`), OR
-- `MsBuildLogPropertyTracking=0` AND ChangeWaves.Wave17_10 features are enabled
+- `MsBuildLogPropertyTracking=0`
 
-This means that in projects with Wave17_10 enabled, property reassignments will be tracked even when property tracking appears to be disabled.
+This means that property reassignments will be tracked even when property tracking appears to be disabled.

--- a/documentation/aot/sdk-resolution.md
+++ b/documentation/aot/sdk-resolution.md
@@ -71,10 +71,6 @@ Knobs:
 * `MSBUILDADDITIONALSDKRESOLVERSFOLDER` (and `_NET` / `_NETFRAMEWORK` variants) - test hook
   that adds an override resolver folder.
 * `MSBUILDINCLUDEDEFAULTSDKRESOLVER=false` - drop the built-in default resolver.
-* Legacy path: when ChangeWave 17.10 is **disabled**, `SdkResolverService` uses a
-  non-caching `SdkResolverLoader` and the eager `LoadAllResolvers`, which scans
-  `MSBuildToolsDirectory32\SdkResolvers` and loads **every** resolver up front. The default
-  (17.10 enabled) path is manifest-based and lazy via `CachingSdkResolverLoader`.
 
 ### 1.3 The built-in fallback resolver
 
@@ -318,10 +314,6 @@ it, can be removed. Drop `[RequiresUnreferencedCode]` from (build-verify after e
 through the guard: `SdkResolverLoader.LoadResolverAssembly`, `GetResolverTypes`,
 `LoadResolvers`, `LoadResolversFromManifest`, `LoadAllResolvers`, and
 `CachingSdkResolverLoader.LoadResolversFromManifest`.
-
-Legacy note: the `LoadAllResolvers` path (only used when ChangeWave 17.10 is disabled) is also
-reflective. Either apply the same guard there, or document that disabling Wave17.10 is not part
-of the trim-safe contract (the default, caching, manifest-based path is what trims).
 
 ### 2.5 Step 4 - the error resource
 

--- a/documentation/wiki/ChangeWaves.md
+++ b/documentation/wiki/ChangeWaves.md
@@ -64,13 +64,6 @@ Change wave checks around features will be removed in the release that accompani
 ### 18.3
 - [Replace Transactional property with ChangeWave control, implement atomic file replacement with retry logic, and update tests.](https://github.com/dotnet/msbuild/pull/12627)
 
-### 17.14
-- ~[.SLNX support - use the new parser for .sln and .slnx](https://github.com/dotnet/msbuild/pull/10836)~ reverted after compat problems discovered
-- ~~[Support custom culture in RAR](https://github.com/dotnet/msbuild/pull/11000)~~ - see [11607](https://github.com/dotnet/msbuild/pull/11607) for details
-- [VS Telemetry](https://github.com/dotnet/msbuild/pull/11255)
-
-
-
 ## Change Waves No Longer In Rotation
 
 ### 16.8
@@ -144,3 +137,9 @@ Change wave checks around features will be removed in the release that accompani
 - [Add ParameterName and PropertyName to TaskParameterEventArgs](https://github.com/dotnet/msbuild/pull/10130)
 - [Emit eval props if requested by any sink](https://github.com/dotnet/msbuild/pull/10243)
 - [Load Microsoft.DotNet.MSBuildSdkResolver into default load context (MSBuild.exe only)](https://github.com/dotnet/msbuild/pull/10603)
+
+### 17.14
+
+- ~[.SLNX support - use the new parser for .sln and .slnx](https://github.com/dotnet/msbuild/pull/10836)~ reverted after compat problems discovered
+- ~~[Support custom culture in RAR](https://github.com/dotnet/msbuild/pull/11000)~~ - see [11607](https://github.com/dotnet/msbuild/pull/11607) for details
+- [VS Telemetry](https://github.com/dotnet/msbuild/pull/11255)

--- a/documentation/wiki/ChangeWaves.md
+++ b/documentation/wiki/ChangeWaves.md
@@ -59,11 +59,6 @@ Change wave checks around features will be removed in the release that accompani
 ### 18.4
 - [Start throwing on null or empty paths in MultiProcess and MultiThreaded Task Environment Drivers.](https://github.com/dotnet/msbuild/pull/12914)
 
-## Change waves that will be removed in the release accompanying .NET 11
-
-### 18.3
-- [Replace Transactional property with ChangeWave control, implement atomic file replacement with retry logic, and update tests.](https://github.com/dotnet/msbuild/pull/12627)
-
 ## Change Waves No Longer In Rotation
 
 ### 16.8
@@ -143,3 +138,7 @@ Change wave checks around features will be removed in the release that accompani
 - ~[.SLNX support - use the new parser for .sln and .slnx](https://github.com/dotnet/msbuild/pull/10836)~ reverted after compat problems discovered
 - ~~[Support custom culture in RAR](https://github.com/dotnet/msbuild/pull/11000)~~ - see [11607](https://github.com/dotnet/msbuild/pull/11607) for details
 - [VS Telemetry](https://github.com/dotnet/msbuild/pull/11255)
+
+### 18.3
+
+- [Replace Transactional property with ChangeWave control, implement atomic file replacement with retry logic, and update tests.](https://github.com/dotnet/msbuild/pull/12627)

--- a/documentation/wiki/ChangeWaves.md
+++ b/documentation/wiki/ChangeWaves.md
@@ -69,13 +69,7 @@ Change wave checks around features will be removed in the release that accompani
 - ~~[Support custom culture in RAR](https://github.com/dotnet/msbuild/pull/11000)~~ - see [11607](https://github.com/dotnet/msbuild/pull/11607) for details
 - [VS Telemetry](https://github.com/dotnet/msbuild/pull/11255)
 
-### 17.12
-- [Log TaskParameterEvent for scalar parameters](https://github.com/dotnet/msbuild/pull/9908)
-- [Convert.ToString during a property evaluation uses the InvariantCulture for all types](https://github.com/dotnet/msbuild/pull/9874)
-- [Fix oversharing of build results in ResultsCache](https://github.com/dotnet/msbuild/pull/9987)
-- [Add ParameterName and PropertyName to TaskParameterEventArgs](https://github.com/dotnet/msbuild/pull/10130)
-- [Emit eval props if requested by any sink](https://github.com/dotnet/msbuild/pull/10243)
-- [Load Microsoft.DotNet.MSBuildSdkResolver into default load context (MSBuild.exe only)](https://github.com/dotnet/msbuild/pull/10603)
+
 
 ## Change Waves No Longer In Rotation
 
@@ -141,3 +135,12 @@ Change wave checks around features will be removed in the release that accompani
 - [Exec task does not trim leading whitespaces for ConsoleOutput](https://github.com/dotnet/msbuild/pull/9722)
 - [Introduce [MSBuild]::StableStringHash overloads](https://github.com/dotnet/msbuild/issues/9519)
 - [Keep the encoding of standard output & error consistent with the console code page for ToolTask](https://github.com/dotnet/msbuild/pull/9539)
+
+### 17.12
+
+- [Log TaskParameterEvent for scalar parameters](https://github.com/dotnet/msbuild/pull/9908)
+- [Convert.ToString during a property evaluation uses the InvariantCulture for all types](https://github.com/dotnet/msbuild/pull/9874)
+- [Fix oversharing of build results in ResultsCache](https://github.com/dotnet/msbuild/pull/9987)
+- [Add ParameterName and PropertyName to TaskParameterEventArgs](https://github.com/dotnet/msbuild/pull/10130)
+- [Emit eval props if requested by any sink](https://github.com/dotnet/msbuild/pull/10243)
+- [Load Microsoft.DotNet.MSBuildSdkResolver into default load context (MSBuild.exe only)](https://github.com/dotnet/msbuild/pull/10603)

--- a/documentation/wiki/ChangeWaves.md
+++ b/documentation/wiki/ChangeWaves.md
@@ -77,19 +77,6 @@ Change wave checks around features will be removed in the release that accompani
 - [Emit eval props if requested by any sink](https://github.com/dotnet/msbuild/pull/10243)
 - [Load Microsoft.DotNet.MSBuildSdkResolver into default load context (MSBuild.exe only)](https://github.com/dotnet/msbuild/pull/10603)
 
-### 17.10
-- [AppDomain configuration is serialized without using BinFmt](https://github.com/dotnet/msbuild/pull/9320) - feature can be opted out only if [BinaryFormatter](https://learn.microsoft.com/en-us/dotnet/api/system.runtime.serialization.formatters.binary.binaryformatter) is allowed at runtime by editing `MSBuild.runtimeconfig.json`. **Please note that [any usage of BinaryFormatter is insecure](https://learn.microsoft.com/dotnet/standard/serialization/binaryformatter-security-guide).**
-- [Warning on serialization custom events by default in .NET framework](https://github.com/dotnet/msbuild/pull/9318)
-- [Cache SDK resolver data process-wide](https://github.com/dotnet/msbuild/pull/9335)
-- [Target parameters will be unquoted](https://github.com/dotnet/msbuild/pull/9452), meaning  the ';' symbol in the parameter target name will always be treated as separator
-- [Add Link metadata to Resources in AssignLinkMetadata target](https://github.com/dotnet/msbuild/pull/9464)
-- [Change Version switch output to finish with a newline](https://github.com/dotnet/msbuild/pull/9485)
-- [Load NuGet.Frameworks into secondary AppDomain (MSBuild.exe only)](https://github.com/dotnet/msbuild/pull/9446)
-- [Update Traits when environment has been changed](https://github.com/dotnet/msbuild/pull/9655)
-- [Exec task does not trim leading whitespaces for ConsoleOutput](https://github.com/dotnet/msbuild/pull/9722)
-- [Introduce [MSBuild]::StableStringHash overloads](https://github.com/dotnet/msbuild/issues/9519)
-- [Keep the encoding of standard output & error consistent with the console code page for ToolTask](https://github.com/dotnet/msbuild/pull/9539)
-
 ## Change Waves No Longer In Rotation
 
 ### 16.8
@@ -140,3 +127,17 @@ Change wave checks around features will be removed in the release that accompani
 - [Delete destination file before copy](https://github.com/dotnet/msbuild/pull/8685)
 - [Moving from SHA1 to SHA256 for Hash task](https://github.com/dotnet/msbuild/pull/8812)
 - [Deprecating custom derived BuildEventArgs](https://github.com/dotnet/msbuild/pull/8917) - feature can be opted out only if [BinaryFormatter](https://learn.microsoft.com/dotnet/api/system.runtime.serialization.formatters.binary.binaryformatter) is allowed at runtime by editing `MSBuild.runtimeconfig.json`
+
+### 17.10
+
+- [AppDomain configuration is serialized without using BinFmt](https://github.com/dotnet/msbuild/pull/9320) - feature can be opted out only if [BinaryFormatter](https://learn.microsoft.com/en-us/dotnet/api/system.runtime.serialization.formatters.binary.binaryformatter) is allowed at runtime by editing `MSBuild.runtimeconfig.json`. **Please note that [any usage of BinaryFormatter is insecure](https://learn.microsoft.com/dotnet/standard/serialization/binaryformatter-security-guide).**
+- [Warning on serialization custom events by default in .NET framework](https://github.com/dotnet/msbuild/pull/9318)
+- [Cache SDK resolver data process-wide](https://github.com/dotnet/msbuild/pull/9335)
+- [Target parameters will be unquoted](https://github.com/dotnet/msbuild/pull/9452), meaning  the ';' symbol in the parameter target name will always be treated as separator
+- [Add Link metadata to Resources in AssignLinkMetadata target](https://github.com/dotnet/msbuild/pull/9464)
+- [Change Version switch output to finish with a newline](https://github.com/dotnet/msbuild/pull/9485)
+- [Load NuGet.Frameworks into secondary AppDomain (MSBuild.exe only)](https://github.com/dotnet/msbuild/pull/9446)
+- [Update Traits when environment has been changed](https://github.com/dotnet/msbuild/pull/9655)
+- [Exec task does not trim leading whitespaces for ConsoleOutput](https://github.com/dotnet/msbuild/pull/9722)
+- [Introduce [MSBuild]::StableStringHash overloads](https://github.com/dotnet/msbuild/issues/9519)
+- [Keep the encoding of standard output & error consistent with the console code page for ToolTask](https://github.com/dotnet/msbuild/pull/9539)

--- a/documentation/wiki/Results-Cache.md
+++ b/documentation/wiki/Results-Cache.md
@@ -31,7 +31,6 @@ MSBuild uses caching to speed up builds. It does this by remembering the outcome
 ### How `BuildRequestDataFlags` Affect Caching
 
 When MSBuild decides to build something, the request (`BuildRequest`) carries special instructions called `BuildRequestDataFlags`. These flags tell MSBuild *how* to perform the build and *what kind of result* is expected. The `ResultsCache` pays close attention to these flags because they are crucial for determining if a cached outcome is truly a match for a new request.
-It's an out-in feature that can be disabled with change wave `17.12`. See more details in [ChangeWaves.md](ChangeWaves.md)
 
 Here's how some important flags interact with caching:
 

--- a/eng/BootStrapMsBuild.targets
+++ b/eng/BootStrapMsBuild.targets
@@ -306,6 +306,30 @@
           DestinationFiles="@(FreshlyBuiltNetBinaries->'$(InstallDir)sdk\$(BootstrapSdkVersion)\%(RecursiveDir)%(Filename)%(Extension)')" />
 
     <!--
+      The .NET SDK layout keeps some of MSBuild's own props/targets under sdk\<ver>\Current\ rather than at the
+      SDK root, because they are imported through $(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\... and
+      $(MSBuildToolsVersion) is "Current" there. Microsoft.Common.props is the notable one: it exists *only*
+      under Current\, and Microsoft.NET.Sdk's Sdk.props imports it from that path for every SDK-style project.
+
+      Our build output has no Current\ subdirectory, so the overlay above lands those files at the SDK root only
+      and leaves the acquired SDK's copies - belonging to whatever older MSBuild it shipped with - in place. Every
+      bootstrap build then silently evaluates the stale file, so changes to src\Tasks\Microsoft.Common.props never
+      take effect in bootstrap-based tests.
+
+      Overlay our freshly-built copy of any file the acquired SDK keeps in Current\. Directories under Current\
+      (the Microsoft.Common.targets\ImportAfter\ style extension points) are not matched by the glob and are
+      correctly left alone.
+    -->
+    <ItemGroup>
+      <_AcquiredSdkCurrentFile Include="$(InstallDir)sdk\$(BootstrapSdkVersion)\Current\*.*" />
+      <_FreshlyBuiltCurrentFile Include="$(OutDir)%(_AcquiredSdkCurrentFile.Filename)%(_AcquiredSdkCurrentFile.Extension)"
+                                Condition="Exists('$(OutDir)%(_AcquiredSdkCurrentFile.Filename)%(_AcquiredSdkCurrentFile.Extension)')" />
+    </ItemGroup>
+
+    <Copy SourceFiles="@(_FreshlyBuiltCurrentFile)"
+          DestinationFolder="$(InstallDir)sdk\$(BootstrapSdkVersion)\Current" />
+
+    <!--
       MSBuild can target an earlier .NET runtime than the SDK we overlay it onto.
       In that case the freshly-built *.runtimeconfig.json files pin Microsoft.NETCore.App to a runtime version
       (e.g. 10.0.0) that isn't present in the bootstrap layout, so the just-built MSBuild would fail to start.

--- a/src/Build.UnitTests/BinaryLogger_Tests.cs
+++ b/src/Build.UnitTests/BinaryLogger_Tests.cs
@@ -813,17 +813,9 @@ namespace Microsoft.Build.UnitTests
         [InlineData("LogFile={}.binlog")]  // Wildcard with LogFile= prefix
         public void ParseParameters_WildcardPath_ReturnsNullPath(string parametersString)
         {
-            using (TestEnvironment env = TestEnvironment.Create())
-            {
-                // Enable Wave17_12 to support wildcard parameters
-                ChangeWaves.ResetStateForTests();
-                env.SetEnvironmentVariable("MSBUILDDISABLEFEATURESFROMVERSION", "");
-                BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly();
+            var result = BinaryLogger.ParseParameters(parametersString);
 
-                var result = BinaryLogger.ParseParameters(parametersString);
-
-                result.LogFilePath.ShouldBeNull();
-            }
+            result.LogFilePath.ShouldBeNull();
 
             // Create the expected log file to satisfy test environment expectations
             File.Create(_logFile).Dispose();

--- a/src/Build.UnitTests/Evaluation/Expander_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/Expander_Tests.cs
@@ -5190,53 +5190,6 @@ $(
             }
         }
 
-        [Fact]
-        public void ExpandItem_ConvertToStringUsingInvariantCultureForNumberData_RespectingChangeWave()
-        {
-            // Note: Skipping the test since it is not a valid scenario when ICU mode is not used.
-            if (!ICUModeAvailable())
-            {
-                return;
-            }
-
-            var currentThread = Thread.CurrentThread;
-            var originalCulture = currentThread.CurrentCulture;
-            var originalUICulture = currentThread.CurrentUICulture;
-
-            try
-            {
-                var svSECultureInfo = new CultureInfo("sv-SE");
-                using (var env = TestEnvironment.Create())
-                {
-                    env.SetEnvironmentVariable("MSBUILDDISABLEFEATURESFROMVERSION", ChangeWaves.Wave17_12.ToString());
-                    ChangeWaves.ResetStateForTests();
-                    currentThread.CurrentCulture = svSECultureInfo;
-                    currentThread.CurrentUICulture = svSECultureInfo;
-                    var root = env.CreateFolder();
-
-                    var projectFile = env.CreateFile(root, ".proj",
-                        @"<Project>
-
-  <PropertyGroup>
-    <_value>$([MSBuild]::Subtract(0, 1))</_value>
-    <_otherValue Condition=""'$(_value)' &gt;= -1"">test-value</_otherValue>
-  </PropertyGroup>
-  <Target Name=""Build"" />
-</Project>");
-                    var exception = Should.Throw<InvalidProjectFileException>(() =>
-                    {
-                        new ProjectInstance(projectFile.Path);
-                    });
-                    exception.BaseMessage.ShouldContain("A numeric comparison was attempted on \"$(_value)\"");
-                }
-            }
-            finally
-            {
-                currentThread.CurrentCulture = originalCulture;
-                currentThread.CurrentUICulture = originalUICulture;
-            }
-        }
-
         [Theory]
         [InlineData("getType")]
         [InlineData("GetType")]
@@ -5344,18 +5297,6 @@ $(
                 // the fast path was successfully resolved without reflection.
                 File.Exists(reflectionInfoPath).ShouldBeFalse();
             }
-        }
-
-        /// <summary>
-        /// Determines if ICU mode is enabled.
-        /// Copied from: https://learn.microsoft.com/en-us/dotnet/core/extensions/globalization-icu#determine-if-your-app-is-using-icu
-        /// </summary>
-        private static bool ICUModeAvailable()
-        {
-            SortVersion sortVersion = CultureInfo.InvariantCulture.CompareInfo.Version;
-            byte[] bytes = sortVersion.SortId.ToByteArray();
-            int version = bytes[3] << 24 | bytes[2] << 16 | bytes[1] << 8 | bytes[0];
-            return version != 0 && version == sortVersion.FullVersion;
         }
 
         [Fact]

--- a/src/Build/BackEnd/Components/Caching/ResultsCache.cs
+++ b/src/Build/BackEnd/Components/Caching/ResultsCache.cs
@@ -6,7 +6,6 @@ using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using Microsoft.Build.Execution;
-using Microsoft.Build.Framework;
 
 #nullable disable
 
@@ -168,10 +167,7 @@ namespace Microsoft.Build.BackEnd
             {
                 if (_resultsByConfiguration.TryGetValue(request.ConfigurationId, out BuildResult allResults))
                 {
-                    bool buildDataFlagsSatisfied = ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_12)
-                        ? AreBuildResultFlagsCompatible(request, allResults) : true;
-
-                    if (buildDataFlagsSatisfied)
+                    if (AreBuildResultFlagsCompatible(request, allResults))
                     {
                         // Check for targets explicitly specified.
                         bool explicitTargetsSatisfied = CheckResults(allResults, request.Targets, checkTargetsMissingResults: true, skippedResultsDoNotCauseCacheMiss);

--- a/src/Build/BackEnd/Components/Logging/LoggingService.cs
+++ b/src/Build/BackEnd/Components/Logging/LoggingService.cs
@@ -612,23 +612,13 @@ namespace Microsoft.Build.BackEnd.Logging
             {
                 var sinks = _eventSinkDictionary.Values.OfType<EventSourceSink>().ToList();
 
-                if (ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_12))
-                {
-                    // If any logger requested the data - we need to emit them
-                    IncludeEvaluationPropertiesAndItemsInEvaluationFinishedEvent =
-                        sinks.Any(sink => sink.IncludeEvaluationPropertiesAndItems);
-                    // If any logger didn't request the data - hence it's likely legacy logger
-                    //  - we need to populate the data in legacy way
-                    IncludeEvaluationPropertiesAndItemsInProjectStartedEvent =
-                        sinks.Any(sink => !sink.IncludeEvaluationPropertiesAndItems);
-                }
-                else
-                {
-                    bool allSinksIncludeEvalData = sinks.Any() && sinks.All(sink => sink.IncludeEvaluationPropertiesAndItems);
-
-                    IncludeEvaluationPropertiesAndItemsInEvaluationFinishedEvent = allSinksIncludeEvalData;
-                    IncludeEvaluationPropertiesAndItemsInProjectStartedEvent = !allSinksIncludeEvalData;
-                }
+                // If any logger requested the data - we need to emit them
+                IncludeEvaluationPropertiesAndItemsInEvaluationFinishedEvent =
+                    sinks.Any(sink => sink.IncludeEvaluationPropertiesAndItems);
+                // If any logger didn't request the data - hence it's likely legacy logger
+                //  - we need to populate the data in legacy way
+                IncludeEvaluationPropertiesAndItemsInProjectStartedEvent =
+                    sinks.Any(sink => !sink.IncludeEvaluationPropertiesAndItems);
             }
         }
 

--- a/src/Build/BackEnd/Components/SdkResolution/SdkResolverLoader.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/SdkResolverLoader.cs
@@ -245,37 +245,35 @@ namespace Microsoft.Build.BackEnd.SdkResolution
         protected virtual Assembly LoadResolverAssembly(string resolverPath)
         {
 #if !FEATURE_ASSEMBLYLOADCONTEXT
-            if (ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_12))
+            string resolverFileName = Path.GetFileNameWithoutExtension(resolverPath);
+            if (resolverFileName.Equals("Microsoft.DotNet.MSBuildSdkResolver", StringComparison.OrdinalIgnoreCase))
             {
-                string resolverFileName = Path.GetFileNameWithoutExtension(resolverPath);
-                if (resolverFileName.Equals("Microsoft.DotNet.MSBuildSdkResolver", StringComparison.OrdinalIgnoreCase))
+                // This will load the resolver assembly into the default load context if possible, and fall back to LoadFrom context.
+                // We very much prefer the default load context because it allows native images to be used by the CLR, improving startup perf.
+                var buildEnvironment = BuildEnvironmentHelper.Instance;
+                AssemblyName assemblyName = CreateAssemblyNameWithCodeBase(resolverFileName, resolverPath);
+
+                // Need fallback for scenarios where we're not running directly in MSBuild.exe app host.
+                // RunningInMSBuildExe is true when the actual process is MSBuild.exe (app host),
+                // false when running via dotnet CLI (dotnet MSBuild.dll), external API callers, or test runners.
+                // VS and MSBuild.exe app host can use Assembly.Load reliably and benefit from NGEN.
+                bool needsFallback = buildEnvironment.Mode == BuildEnvironmentMode.Standalone && !buildEnvironment.RunningInMSBuildExe;
+
+                if (needsFallback)
                 {
-                    // This will load the resolver assembly into the default load context if possible, and fall back to LoadFrom context.
-                    // We very much prefer the default load context because it allows native images to be used by the CLR, improving startup perf.
-                    var buildEnvironment = BuildEnvironmentHelper.Instance;
-                    AssemblyName assemblyName = CreateAssemblyNameWithCodeBase(resolverFileName, resolverPath);
-
-                    // Need fallback for scenarios where we're not running directly in MSBuild.exe app host.
-                    // RunningInMSBuildExe is true when the actual process is MSBuild.exe (app host),
-                    // false when running via dotnet CLI (dotnet MSBuild.dll), external API callers, or test runners.
-                    // VS and MSBuild.exe app host can use Assembly.Load reliably and benefit from NGEN.
-                    bool needsFallback = buildEnvironment.Mode == BuildEnvironmentMode.Standalone && !buildEnvironment.RunningInMSBuildExe;
-
-                    if (needsFallback)
-                    {
-                        // For external API users and dotnet CLI, use LoadFrom directly
-                        // Assembly.Load fails in these scenarios due to assembly resolution context,
-                        // so we use LoadFrom which works reliably without needing try-catch
-                        return Assembly.LoadFrom(resolverPath);
-                    }
-                    else
-                    {
-                        // VS and MSBuild.exe direct usage: use Assembly.Load directly without fallback
-                        // These scenarios should work reliably with Assembly.Load and benefit from NGEN
-                        return Assembly.Load(assemblyName);
-                    }
+                    // For external API users and dotnet CLI, use LoadFrom directly
+                    // Assembly.Load fails in these scenarios due to assembly resolution context,
+                    // so we use LoadFrom which works reliably without needing try-catch
+                    return Assembly.LoadFrom(resolverPath);
+                }
+                else
+                {
+                    // VS and MSBuild.exe direct usage: use Assembly.Load directly without fallback
+                    // These scenarios should work reliably with Assembly.Load and benefit from NGEN
+                    return Assembly.Load(assemblyName);
                 }
             }
+
             return Assembly.LoadFrom(resolverPath);
 #else
             return s_loader.LoadFromPath(resolverPath);

--- a/src/Build/BackEnd/Components/SdkResolution/SdkResolverService.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/SdkResolverService.cs
@@ -58,12 +58,10 @@ namespace Microsoft.Build.BackEnd.SdkResolution
         /// Stores an <see cref="SdkResolverLoader"/> which can load registered SDK resolvers.
         /// </summary>
         /// <remarks>
-        /// Unless the 17.10 changewave is disabled, we use a singleton instance because the set of SDK resolvers
-        /// is not expected to change during the lifetime of the process.
+        /// We use a singleton instance because the set of SDK resolvers is not expected to change
+        /// during the lifetime of the process.
         /// </remarks>
-        protected SdkResolverLoader _sdkResolverLoader = ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_10)
-            ? CachingSdkResolverLoader.Instance
-            : new SdkResolverLoader();
+        protected SdkResolverLoader _sdkResolverLoader = CachingSdkResolverLoader.Instance;
 
         public SdkResolverService()
         {
@@ -139,24 +137,21 @@ namespace Microsoft.Build.BackEnd.SdkResolution
             // Overall, while Sdk resolvers look like a general plug-in system, there are good reasons why some of the logic is hard-coded.
             // It's not really meant to be modified outside of very special/internal scenarios.
 #if NET
-            if (ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_10))
+            if (TryResolveSdkUsingSpecifiedResolvers(
+                _sdkResolverLoader.GetDefaultResolvers(),
+                BuildEventContext.InvalidSubmissionId, // disables GetResolverState/SetResolverState
+                sdk,
+                loggingContext,
+                sdkReferenceLocation,
+                solutionPath,
+                projectPath,
+                interactive,
+                isRunningInVisualStudio,
+                out SdkResult sdkResult,
+                out _,
+                out _))
             {
-                if (TryResolveSdkUsingSpecifiedResolvers(
-                    _sdkResolverLoader.GetDefaultResolvers(),
-                    BuildEventContext.InvalidSubmissionId, // disables GetResolverState/SetResolverState
-                    sdk,
-                    loggingContext,
-                    sdkReferenceLocation,
-                    solutionPath,
-                    projectPath,
-                    interactive,
-                    isRunningInVisualStudio,
-                    out SdkResult sdkResult,
-                    out _,
-                    out _))
-                {
-                    return sdkResult;
-                }
+                return sdkResult;
             }
 #endif
 
@@ -506,18 +501,15 @@ namespace Microsoft.Build.BackEnd.SdkResolution
                 _manifestToResolvers = new Dictionary<SdkResolverManifest, IReadOnlyList<SdkResolver>>();
 
                 SdkResolverManifest sdkDefaultResolversManifest = null;
-#if NET
-                if (!ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_10))
-#endif
+#if !NET
+                // Load and add the manifest for the default resolvers, located directly in this dll.
+                IReadOnlyList<SdkResolver> defaultResolvers = _sdkResolverLoader.GetDefaultResolvers();
+                if (defaultResolvers.Count > 0)
                 {
-                    // Load and add the manifest for the default resolvers, located directly in this dll.
-                    IReadOnlyList<SdkResolver> defaultResolvers = _sdkResolverLoader.GetDefaultResolvers();
-                    if (defaultResolvers.Count > 0)
-                    {
-                        sdkDefaultResolversManifest = new SdkResolverManifest(DisplayName: "DefaultResolversManifest", Path: null, ResolvableSdkRegex: null);
-                        _manifestToResolvers[sdkDefaultResolversManifest] = defaultResolvers;
-                    }
+                    sdkDefaultResolversManifest = new SdkResolverManifest(DisplayName: "DefaultResolversManifest", Path: null, ResolvableSdkRegex: null);
+                    _manifestToResolvers[sdkDefaultResolversManifest] = defaultResolvers;
                 }
+#endif
 
                 var specificResolversManifestsRegistry = new List<SdkResolverManifest>();
                 var generalResolversManifestsRegistry = new List<SdkResolverManifest>();

--- a/src/Build/BackEnd/TaskExecutionHost/TaskExecutionHost.cs
+++ b/src/Build/BackEnd/TaskExecutionHost/TaskExecutionHost.cs
@@ -1710,8 +1710,6 @@ namespace Microsoft.Build.BackEnd
             return success;
         }
 
-        private static readonly string TaskParameterFormatString = ItemGroupLoggingHelper.TaskParameterPrefix + "{0}={1}";
-
         /// <summary>
         /// Given an instantiated task, this helper method sets the specified parameter
         /// </summary>
@@ -1724,22 +1722,11 @@ namespace Microsoft.Build.BackEnd
             if (LogTaskInputs && !_taskLoggingContext.LoggingService.OnlyLogCriticalEvents)
             {
                 IList parameterValueAsList = parameterValue as IList;
-                bool legacyBehavior = !ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_12);
-
-                // Legacy textual logging for parameters that are not lists.
-                if (legacyBehavior && parameterValueAsList == null)
-                {
-                    _taskLoggingContext.LogCommentFromText(
-                       MessageImportance.Low,
-                       TaskParameterFormatString,
-                       parameter.Name,
-                       ItemGroupLoggingHelper.GetStringFromParameterValue(parameterValue));
-                }
 
                 if (parameter.Log)
                 {
                     // Structured logging for all parameters that have logging enabled and are not empty lists.
-                    if (parameterValueAsList?.Count > 0 || (parameterValueAsList == null && !legacyBehavior))
+                    if (parameterValueAsList?.Count > 0 || parameterValueAsList == null)
                     {
                         // Note: We're setting TaskParameterEventArgs.ItemType to parameter name for backward compatibility with
                         // older loggers and binlog viewers.
@@ -1928,23 +1915,16 @@ namespace Microsoft.Build.BackEnd
                         var outputString = joinedOutputs.ToString();
                         if (LogTaskInputs && !_taskLoggingContext.LoggingService.OnlyLogCriticalEvents)
                         {
-                            if (ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_12))
-                            {
-                                // Note: We're setting TaskParameterEventArgs.ItemType to property name for backward compatibility with
-                                // older loggers and binlog viewers.
-                                ItemGroupLoggingHelper.LogTaskParameter(
-                                    _taskLoggingContext,
-                                    TaskParameterMessageKind.TaskOutput,
-                                    parameterName: parameter.Name,
-                                    propertyName: outputTargetName,
-                                    itemType: outputTargetName,
-                                    (object[])[outputString],
-                                    parameter.LogItemMetadata);
-                            }
-                            else
-                            {
-                                _taskLoggingContext.LogComment(MessageImportance.Low, "OutputPropertyLogMessage", outputTargetName, outputString);
-                            }
+                            // Note: We're setting TaskParameterEventArgs.ItemType to property name for backward compatibility with
+                            // older loggers and binlog viewers.
+                            ItemGroupLoggingHelper.LogTaskParameter(
+                                _taskLoggingContext,
+                                TaskParameterMessageKind.TaskOutput,
+                                parameterName: parameter.Name,
+                                propertyName: outputTargetName,
+                                itemType: outputTargetName,
+                                (object[])[outputString],
+                                parameter.LogItemMetadata);
                         }
 
                         _batchBucket.Lookup.SetProperty(ProjectPropertyInstance.Create(outputTargetName, outputString, parameterLocation, _projectInstance.IsImmutable));
@@ -2015,23 +1995,16 @@ namespace Microsoft.Build.BackEnd
                         var outputString = joinedOutputs.ToString();
                         if (LogTaskInputs && !_taskLoggingContext.LoggingService.OnlyLogCriticalEvents)
                         {
-                            if (ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_12))
-                            {
-                                // Note: We're setting TaskParameterEventArgs.ItemType to property name for backward compatibility with
-                                // older loggers and binlog viewers.
-                                ItemGroupLoggingHelper.LogTaskParameter(
-                                    _taskLoggingContext,
-                                    TaskParameterMessageKind.TaskOutput,
-                                    parameterName: parameter.Name,
-                                    propertyName: outputTargetName,
-                                    itemType: outputTargetName,
-                                    (object[])[outputString],
-                                    parameter.LogItemMetadata);
-                            }
-                            else
-                            {
-                                _taskLoggingContext.LogComment(MessageImportance.Low, "OutputPropertyLogMessage", outputTargetName, outputString);
-                            }
+                            // Note: We're setting TaskParameterEventArgs.ItemType to property name for backward compatibility with
+                            // older loggers and binlog viewers.
+                            ItemGroupLoggingHelper.LogTaskParameter(
+                                _taskLoggingContext,
+                                TaskParameterMessageKind.TaskOutput,
+                                parameterName: parameter.Name,
+                                propertyName: outputTargetName,
+                                itemType: outputTargetName,
+                                (object[])[outputString],
+                                parameter.LogItemMetadata);
                         }
 
                         PropertyTrackingUtils.LogPropertyAssignment(

--- a/src/Build/Construction/Solution/SolutionFile.cs
+++ b/src/Build/Construction/Solution/SolutionFile.cs
@@ -228,7 +228,7 @@ namespace Microsoft.Build.Construction
 
             set
             {
-                if (ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_14) && string.IsNullOrEmpty(value))
+                if (string.IsNullOrEmpty(value))
                 {
                     throw new ArgumentNullException(nameof(FullPath));
                 }

--- a/src/Build/Evaluation/Expander.PropertyExpander.cs
+++ b/src/Build/Evaluation/Expander.PropertyExpander.cs
@@ -438,14 +438,7 @@ internal partial class Expander<P, I>
             {
                 // The fall back is always to just convert to a string directly.
                 // Issue: https://github.com/dotnet/msbuild/issues/9757
-                if (ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_12))
-                {
-                    convertedString = Convert.ToString(valueToConvert, CultureInfo.InvariantCulture);
-                }
-                else
-                {
-                    convertedString = valueToConvert.ToString();
-                }
+                convertedString = Convert.ToString(valueToConvert, CultureInfo.InvariantCulture);
             }
 
             return convertedString;

--- a/src/Build/Evaluation/Expander/WellKnownFunctions.cs
+++ b/src/Build/Evaluation/Expander/WellKnownFunctions.cs
@@ -643,10 +643,7 @@ namespace Microsoft.Build.Evaluation.Expander
             {
                 if (ParseArgs.TryGetArg(args, out string? arg0))
                 {
-                    // Prevent loading methods refs from StringTools if ChangeWave opted out.
-                    returnVal = ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_10)
-                        ? IntrinsicFunctions.StableStringHash(arg0)
-                        : IntrinsicFunctions.StableStringHashLegacy(arg0);
+                    returnVal = IntrinsicFunctions.StableStringHash(arg0);
                     return true;
                 }
                 else if (ParseArgs.TryGetArgs(args, out string? arg1, out string? arg2) && Enum.TryParse<IntrinsicFunctions.StringHashingAlgorithm>(arg2, true, out var hashAlgorithm) && arg1 != null && arg2 != null)

--- a/src/Build/Evaluation/IntrinsicFunctions.cs
+++ b/src/Build/Evaluation/IntrinsicFunctions.cs
@@ -7,7 +7,6 @@ using System.IO;
 #if NETFRAMEWORK
 using System.Linq;
 #endif
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using System.Security.Cryptography;
@@ -427,19 +426,8 @@ namespace Microsoft.Build.Evaluation
         }
 
         /// <summary>
-        /// Legacy implementation that doesn't lead to JIT pulling the new functions from StringTools (so those must not be referenced anywhere in the function body)
-        ///  - for cases where the calling code would erroneously load old version of StringTools alongside of the new version of Microsoft.Build.
-        /// Should be removed once Wave17_10 is removed.
-        /// </summary>
-        public static object StableStringHashLegacy(string toHash)
-            => CommunicationsUtilities.GetHashCode(toHash);
-
-        /// <summary>
         /// Hash the string independent of bitness, target framework and default codepage of the environment.
-        /// We do not want this to be inlined, as then the Expander would call directly the new overload, and hence
-        ///  JIT load the functions from StringTools - so we would not be able to prevent their loading with ChangeWave as we do now.
         /// </summary>
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static object StableStringHash(string toHash)
             => StableStringHash(toHash, StringHashingAlgorithm.Legacy);
 

--- a/src/Build/Evaluation/PropertyTrackingEvaluatorDataWrapper.cs
+++ b/src/Build/Evaluation/PropertyTrackingEvaluatorDataWrapper.cs
@@ -437,7 +437,7 @@ namespace Microsoft.Build.Evaluation
         // Either we want to specifically track property reassignments
         // or we do not want to track nothing - in which case the prop reassignment is enabled by default.
         internal static bool IsPropertyReassignmentEnabled(PropertyTrackingSetting currentTrackingSetting) => IsPropertyTrackingEnabled(currentTrackingSetting, PropertyTrackingSetting.PropertyReassignment)
-                || (currentTrackingSetting == PropertyTrackingSetting.None && ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_10));
+                || currentTrackingSetting == PropertyTrackingSetting.None;
 
         /// <summary>
         /// Logs property assignment information during execution, providing detailed tracking of property value changes.

--- a/src/Build/Logging/BinaryLogger/BinaryLogger.cs
+++ b/src/Build/Logging/BinaryLogger/BinaryLogger.cs
@@ -278,7 +278,7 @@ namespace Microsoft.Build.Logging
 
             parameter = parameter.Trim('"');
 
-            bool isWildcard = ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_12) && parameter.Contains("{}");
+            bool isWildcard = parameter.Contains("{}");
             bool hasProperExtension = parameter.EndsWith(BinlogFileExtension, StringComparison.OrdinalIgnoreCase);
 
             filePath = parameter;
@@ -779,7 +779,7 @@ namespace Microsoft.Build.Logging
 
             parameter = parameter.Trim('"');
 
-            bool isWildcard = ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_12) && parameter.Contains("{}");
+            bool isWildcard = parameter.Contains("{}");
             bool hasProperExtension = parameter.EndsWith(BinlogFileExtension, StringComparison.OrdinalIgnoreCase);
             filePath = parameter;
 

--- a/src/Build/Utilities/NuGetFrameworkWrapper.Reflection.cs
+++ b/src/Build/Utilities/NuGetFrameworkWrapper.Reflection.cs
@@ -169,8 +169,7 @@ namespace Microsoft.Build.Evaluation
 
             NuGetFrameworkWrapper instance = null;
             AssemblyName assemblyName = null;
-            if (ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_10) &&
-                (BuildEnvironmentHelper.Instance.RunningInMSBuildExe || BuildEnvironmentHelper.Instance.RunningInVisualStudio))
+            if (BuildEnvironmentHelper.Instance.RunningInMSBuildExe || BuildEnvironmentHelper.Instance.RunningInVisualStudio)
             {
                 // If we are running in MSBuild.exe or VS, we can load the assembly with Assembly.Load, which enables
                 // the runtime to bind to the native image, eliminating some non-trivial JITting cost. Devenv.exe knows how to

--- a/src/Framework/ChangeWaves.cs
+++ b/src/Framework/ChangeWaves.cs
@@ -27,7 +27,6 @@ namespace Microsoft.Build.Framework
     /// For dev docs: https://github.com/dotnet/msbuild/blob/main/documentation/wiki/ChangeWaves-Dev.md
     internal static class ChangeWaves
     {
-        internal static readonly Version Wave17_10 = new Version(17, 10);
         internal static readonly Version Wave17_12 = new Version(17, 12);
         internal static readonly Version Wave17_14 = new Version(17, 14);
         internal static readonly Version Wave18_3 = new Version(18, 3);
@@ -38,7 +37,7 @@ namespace Microsoft.Build.Framework
         internal static readonly Version Wave18_8 = new Version(18, 8);
         internal static readonly Version Wave18_9 = new Version(18, 9);
         internal static readonly Version Wave18_10 = new Version(18, 10);
-        internal static readonly Version[] AllWaves = [Wave17_10, Wave17_12, Wave17_14, Wave18_3, Wave18_4, Wave18_5, Wave18_6, Wave18_7, Wave18_8, Wave18_9, Wave18_10];
+        internal static readonly Version[] AllWaves = [Wave17_12, Wave17_14, Wave18_3, Wave18_4, Wave18_5, Wave18_6, Wave18_7, Wave18_8, Wave18_9, Wave18_10];
 
         /// <summary>
         /// Special value indicating that all features behind all Change Waves should be enabled.

--- a/src/Framework/ChangeWaves.cs
+++ b/src/Framework/ChangeWaves.cs
@@ -27,7 +27,6 @@ namespace Microsoft.Build.Framework
     /// For dev docs: https://github.com/dotnet/msbuild/blob/main/documentation/wiki/ChangeWaves-Dev.md
     internal static class ChangeWaves
     {
-        internal static readonly Version Wave17_12 = new Version(17, 12);
         internal static readonly Version Wave17_14 = new Version(17, 14);
         internal static readonly Version Wave18_3 = new Version(18, 3);
         internal static readonly Version Wave18_4 = new Version(18, 4);
@@ -37,7 +36,7 @@ namespace Microsoft.Build.Framework
         internal static readonly Version Wave18_8 = new Version(18, 8);
         internal static readonly Version Wave18_9 = new Version(18, 9);
         internal static readonly Version Wave18_10 = new Version(18, 10);
-        internal static readonly Version[] AllWaves = [Wave17_12, Wave17_14, Wave18_3, Wave18_4, Wave18_5, Wave18_6, Wave18_7, Wave18_8, Wave18_9, Wave18_10];
+        internal static readonly Version[] AllWaves = [Wave17_14, Wave18_3, Wave18_4, Wave18_5, Wave18_6, Wave18_7, Wave18_8, Wave18_9, Wave18_10];
 
         /// <summary>
         /// Special value indicating that all features behind all Change Waves should be enabled.

--- a/src/Framework/ChangeWaves.cs
+++ b/src/Framework/ChangeWaves.cs
@@ -27,7 +27,6 @@ namespace Microsoft.Build.Framework
     /// For dev docs: https://github.com/dotnet/msbuild/blob/main/documentation/wiki/ChangeWaves-Dev.md
     internal static class ChangeWaves
     {
-        internal static readonly Version Wave17_14 = new Version(17, 14);
         internal static readonly Version Wave18_3 = new Version(18, 3);
         internal static readonly Version Wave18_4 = new Version(18, 4);
         internal static readonly Version Wave18_5 = new Version(18, 5);
@@ -36,7 +35,7 @@ namespace Microsoft.Build.Framework
         internal static readonly Version Wave18_8 = new Version(18, 8);
         internal static readonly Version Wave18_9 = new Version(18, 9);
         internal static readonly Version Wave18_10 = new Version(18, 10);
-        internal static readonly Version[] AllWaves = [Wave17_14, Wave18_3, Wave18_4, Wave18_5, Wave18_6, Wave18_7, Wave18_8, Wave18_9, Wave18_10];
+        internal static readonly Version[] AllWaves = [Wave18_3, Wave18_4, Wave18_5, Wave18_6, Wave18_7, Wave18_8, Wave18_9, Wave18_10];
 
         /// <summary>
         /// Special value indicating that all features behind all Change Waves should be enabled.

--- a/src/Framework/ChangeWaves.cs
+++ b/src/Framework/ChangeWaves.cs
@@ -27,7 +27,6 @@ namespace Microsoft.Build.Framework
     /// For dev docs: https://github.com/dotnet/msbuild/blob/main/documentation/wiki/ChangeWaves-Dev.md
     internal static class ChangeWaves
     {
-        internal static readonly Version Wave18_3 = new Version(18, 3);
         internal static readonly Version Wave18_4 = new Version(18, 4);
         internal static readonly Version Wave18_5 = new Version(18, 5);
         internal static readonly Version Wave18_6 = new Version(18, 6);
@@ -35,7 +34,7 @@ namespace Microsoft.Build.Framework
         internal static readonly Version Wave18_8 = new Version(18, 8);
         internal static readonly Version Wave18_9 = new Version(18, 9);
         internal static readonly Version Wave18_10 = new Version(18, 10);
-        internal static readonly Version[] AllWaves = [Wave18_3, Wave18_4, Wave18_5, Wave18_6, Wave18_7, Wave18_8, Wave18_9, Wave18_10];
+        internal static readonly Version[] AllWaves = [Wave18_4, Wave18_5, Wave18_6, Wave18_7, Wave18_8, Wave18_9, Wave18_10];
 
         /// <summary>
         /// Special value indicating that all features behind all Change Waves should be enabled.

--- a/src/Framework/ProjectStartedEventArgs.cs
+++ b/src/Framework/ProjectStartedEventArgs.cs
@@ -250,9 +250,7 @@ namespace Microsoft.Build.Framework
         {
             get
             {
-                return globalProperties ?? (ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_12)
-                    ? ImmutableDictionary<string, string>.Empty
-                    : null);
+                return globalProperties ?? ImmutableDictionary<string, string>.Empty;
             }
 
             internal set
@@ -301,9 +299,7 @@ namespace Microsoft.Build.Framework
                 // up the live list of properties from the loaded project, which is stored in the configuration as well.
                 // By doing this, we no longer need to transmit properties using this message because they've already
                 // been transmitted as part of the BuildRequestConfiguration.
-                return properties ?? (ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_12)
-                    ? (DictionaryEntry[])[]
-                    : null);
+                return properties ?? (DictionaryEntry[])[];
             }
         }
 
@@ -327,9 +323,7 @@ namespace Microsoft.Build.Framework
                 // case, this access is to the live list.  For the central logger in the multi-proc case, the main node
                 // has likely not loaded this project, and therefore the live items would not be available to them, which is
                 // the same as the current functionality.
-                return items ?? (ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_12)
-                    ? (DictionaryEntry[])[]
-                    : null);
+                return items ?? (DictionaryEntry[])[];
             }
         }
 

--- a/src/Framework/Traits.cs
+++ b/src/Framework/Traits.cs
@@ -232,10 +232,7 @@ namespace Microsoft.Build.Framework
         public static void UpdateFromEnvironment()
         {
             // Re-create Traits instance to update values in Traits according to current environment.
-            if (ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_10))
-            {
-                _instance = new Traits();
-            }
+            _instance = new Traits();
         }
     }
 
@@ -484,14 +481,6 @@ namespace Microsoft.Build.Framework
                 }
 
                 return _sdkReferencePropertyExpansionValue;
-            }
-        }
-
-        public bool UnquoteTargetSwitchParameters
-        {
-            get
-            {
-                return ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_10);
             }
         }
 

--- a/src/MSBuild.UnitTests/CommandLineSwitches_Tests.cs
+++ b/src/MSBuild.UnitTests/CommandLineSwitches_Tests.cs
@@ -1124,26 +1124,6 @@ namespace Microsoft.Build.UnitTests
             switches.GetParameterizedSwitchCommandLineArg(CommandLineSwitches.ParameterizedSwitch.Target).ShouldBe(commandLineArg);
         }
 
-        /// <summary>
-        /// Verifies that the parsing behavior of quoted target properties is not changed when ChangeWave configured.
-        /// </summary>
-        [Fact]
-        public void ParameterizedSwitchTargetQuotedChangeWaveTest()
-        {
-            using (TestEnvironment env = TestEnvironment.Create())
-            {
-                env.SetEnvironmentVariable("MSBUILDDISABLEFEATURESFROMVERSION", "17.10");
-                ChangeWaves.ResetStateForTests();
-
-                CommandLineSwitches switches = new CommandLineSwitches();
-                switches.SetParameterizedSwitch(CommandLineSwitches.ParameterizedSwitch.Target, "/t:Clean;Build", "\"Clean;Build\"", true, true, false);
-                switches.IsParameterizedSwitchSet(CommandLineSwitches.ParameterizedSwitch.Target).ShouldBeTrue();
-
-                switches[CommandLineSwitches.ParameterizedSwitch.Target].Length.ShouldBe(1);
-                switches[CommandLineSwitches.ParameterizedSwitch.Target][0].ShouldBe("Clean;Build");
-            }
-        }
-
         [Fact]
         public void AppendParameterizedSwitchesTests3()
         {

--- a/src/MSBuild.UnitTests/XMake_Tests.cs
+++ b/src/MSBuild.UnitTests/XMake_Tests.cs
@@ -553,11 +553,6 @@ namespace Microsoft.Build.UnitTests
         {
             using TestEnvironment env = TestEnvironment.Create();
 
-            // Ensure Change Wave 17.10 is enabled.
-            ChangeWaves.ResetStateForTests();
-            env.SetEnvironmentVariable("MSBUILDDISABLEFEATURESFROMVERSION", "");
-            BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly();
-
             List<string> cmdLine = new()
             {
                 "-nologo",
@@ -581,46 +576,6 @@ namespace Microsoft.Build.UnitTests
 
             string output = process.StandardOutput.ReadToEnd();
             output.EndsWith(Environment.NewLine, StringComparison.Ordinal).ShouldBeTrue();
-
-            process.Close();
-        }
-
-        /// <summary>
-        /// PR: Change Version switch output to finish with a newline https://github.com/dotnet/msbuild/pull/9485
-        /// </summary>
-        [Fact]
-        public void VersionSwitchDisableChangeWave()
-        {
-            using TestEnvironment env = TestEnvironment.Create();
-
-            // Disable Change Wave 17.10
-            ChangeWaves.ResetStateForTests();
-            env.SetEnvironmentVariable("MSBUILDDISABLEFEATURESFROMVERSION", ChangeWaves.Wave17_10.ToString());
-            BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly();
-
-            List<string> cmdLine = new()
-            {
-                "-nologo",
-                "-version"
-            };
-
-            using Process process = new()
-            {
-                StartInfo =
-                {
-                    FileName = RunnerUtilities.PathToCurrentlyRunningMsBuildExe,
-                    Arguments = string.Join(" ", cmdLine),
-                    UseShellExecute = false,
-                    RedirectStandardOutput = true,
-                },
-            };
-
-            process.Start();
-            process.WaitForExit();
-            process.ExitCode.ShouldBe(0);
-
-            string output = process.StandardOutput.ReadToEnd();
-            output.EndsWith(Environment.NewLine, StringComparison.Ordinal).ShouldBeFalse();
 
             process.Close();
         }

--- a/src/MSBuild/CommandLine/CommandLineSwitches.cs
+++ b/src/MSBuild/CommandLine/CommandLineSwitches.cs
@@ -714,13 +714,11 @@ namespace Microsoft.Build.CommandLine.Experimental
 
         /// <summary>
         /// Checks if the provided multiple valued parametrized switch needs to be unquoted.
-        /// The method will return 'true' in case:
-        ///     The changewave 17.10 is not set and
-        ///     The parametrized switch is 'Target'
+        /// The method will return 'true' in case the parametrized switch is 'Target'.
         /// </summary>
         private bool IsMultipleAllowedSwitchParameterDueToUnquote(bool unquoteParameter, ParameterizedSwitch parameterizedSwitch)
         {
-            if (!unquoteParameter || !Traits.Instance.EscapeHatches.UnquoteTargetSwitchParameters)
+            if (!unquoteParameter)
             {
                 return false;
             }

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -4688,15 +4688,7 @@ namespace Microsoft.Build.CommandLine
         /// </summary>
         private static void ShowVersion()
         {
-            // Change Version switch output to finish with a newline https://github.com/dotnet/msbuild/pull/9485
-            if (ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_10))
-            {
-                Console.WriteLine(ProjectCollection.Version.ToString());
-            }
-            else
-            {
-                Console.Write(ProjectCollection.Version.ToString());
-            }
+            Console.WriteLine(ProjectCollection.Version.ToString());
         }
 
         private static void ShowFeatureAvailability(string[] features)

--- a/src/Tasks.UnitTests/Exec_Tests.cs
+++ b/src/Tasks.UnitTests/Exec_Tests.cs
@@ -68,39 +68,21 @@ namespace Microsoft.Build.UnitTests
             }
         }
 
-        [UnixOnlyTheory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void ExecSetsLocaleOnUnix(bool enableChangeWave)
+        [UnixOnlyFact]
+        public void ExecDoesNotSetLocaleOnUnix()
         {
             using (var env = TestEnvironment.Create())
             {
                 env.SetEnvironmentVariable("LANG", null);
                 env.SetEnvironmentVariable("LC_ALL", null);
 
-                if (enableChangeWave)
-                {
-                    ChangeWaves.ResetStateForTests();
-                    // Important: use the version here
-                    env.SetEnvironmentVariable("MSBUILDDISABLEFEATURESFROMVERSION", ChangeWaves.Wave17_10.ToString());
-                    BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly();
-                }
-
                 Exec exec = PrepareExec("echo LANG=$LANG; echo LC_ALL=$LC_ALL;");
                 bool result = exec.Execute();
                 Assert.True(result);
 
                 MockEngine engine = (MockEngine)exec.BuildEngine;
-                if (enableChangeWave)
-                {
-                    engine.AssertLogContains("LANG=en_US.UTF-8");
-                    engine.AssertLogContains("LC_ALL=en_US.UTF-8");
-                }
-                else
-                {
-                    engine.AssertLogDoesntContain("LANG=en_US.UTF-8");
-                    engine.AssertLogDoesntContain("LC_ALL=en_US.UTF-8");
-                }
+                engine.AssertLogDoesntContain("LANG=en_US.UTF-8");
+                engine.AssertLogDoesntContain("LC_ALL=en_US.UTF-8");
             }
         }
 

--- a/src/Tasks.UnitTests/WriteLinesToFile_Tests.cs
+++ b/src/Tasks.UnitTests/WriteLinesToFile_Tests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -589,89 +589,6 @@ namespace Microsoft.Build.Tasks.UnitTests
                     }
                 }
                 foundProject.ShouldBeTrue("At least one project's output should be in the file");
-            }
-        }
-
-        [ActiveIssue("https://github.com/dotnet/msbuild/issues/14426")]
-        [Fact]
-        public void NonTransactionalModeCausesDataLoss()
-        {
-            using (var testEnv = TestEnvironment.Create(_output))
-            {
-                // Disable transactional mode via changewave to test non-transactional behavior
-                ChangeWaves.ResetStateForTests();
-                testEnv.SetEnvironmentVariable("MSBUILDDISABLEFEATURESFROMVERSION", ChangeWaves.Wave18_3.ToString());
-                BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly();
-                var outputFile = testEnv.CreateFile("output.txt").Path;
-                var projectCount = 20; 
-
-                var parallelProjectContent = @$"
-            <Project xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
-                <ItemGroup>
-            {string.Join("\n", Enumerable.Range(1, projectCount).Select(i => $@"<Project Include=""TestProject{i}.csproj"" />"))}
-                </ItemGroup>
-                <Target Name=""Build"">
-                <MSBuild Projects=""@(Project)"" Targets=""WriteToFile"" BuildInParallel=""true""/>
-                </Target>
-            </Project>";
-                var parallelProjectFile = testEnv.CreateFile("ParallelBuildProject.csproj", parallelProjectContent).Path;
-
-                for (int i = 0; i < projectCount; i++)
-                {
-                    var projectContent = @$"
-                <Project xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
-                    <ItemGroup>
-                    <LinesToWrite Include=""Line from Project {i + 1}"" />
-                    </ItemGroup>
-                    <Target Name=""WriteToFile"">
-                    <!-- NO Transactional mode, Overwrite=true -->
-                    <WriteLinesToFile File=""{outputFile}"" Lines=""@(LinesToWrite)"" Overwrite=""true""/>
-                    <WriteLinesToFile File=""{outputFile}"" Lines=""@(LinesToWrite)"" Overwrite=""true""/>
-                    <WriteLinesToFile File=""{outputFile}"" Lines=""@(LinesToWrite)"" Overwrite=""true""/>
-                    <WriteLinesToFile File=""{outputFile}"" Lines=""@(LinesToWrite)"" Overwrite=""true""/>
-                    <WriteLinesToFile File=""{outputFile}"" Lines=""@(LinesToWrite)"" Overwrite=""true""/>
-                    </Target>
-                </Project>";
-                    testEnv.CreateFile($"TestProject{i + 1}.csproj", projectContent);
-                }
-
-                // Build using ProjectCollection as recommended by Change Waves documentation
-                using (var collection = new ProjectCollection(
-                    globalProperties: null,
-                    loggers: null,
-                    remoteLoggers: null,
-                    toolsetDefinitionLocations: ToolsetDefinitionLocations.Default,
-                    maxNodeCount: Environment.ProcessorCount,
-                    onlyLogCriticalEvents: false))
-                {
-                    var project = collection.LoadProject(parallelProjectFile);
-                    var buildSucceeded = project.Build("Build");
-
-                    // With non-transactional mode and concurrent writes, build may fail due to file locking
-                    // or succeed with data loss. Either outcome demonstrates the problem with non-transactional mode.
-                    // If build succeeded, verify data loss occurred
-                    if (buildSucceeded)
-                {
-
-                var content = File.ReadAllText(outputFile);
-                var lines = content.Split(new[] { '\n', '\r' }, StringSplitOptions.RemoveEmptyEntries);
-
-                var expectedWithoutRace = projectCount * 5;
-
-                // Without transactional mode and with Overwrite=true, concurrent writes will overwrite each other
-                // We expect significant data loss - only the last write(s) will survive
-                lines.Length.ShouldBeLessThan(expectedWithoutRace,
-                    $"Without transactional mode, data loss should occur. " +
-                    $"Expected significant data loss from {expectedWithoutRace} lines, but got {lines.Length}");
-
-                    // With Overwrite=true and parallel builds without transactional mode, 
-                    // only the last few writes should survive (typically 1-5 lines)
-                    lines.Length.ShouldBeLessThanOrEqualTo(5,
-                        "With Overwrite=true and parallel builds without transactional mode, " +
-                        "only last project's writes should survive due to race conditions");
-                    }
-                    // If build failed, that's also acceptable - it demonstrates file locking issues with non-transactional mode
-                }
             }
         }
     }

--- a/src/Tasks/CreateCSharpManifestResourceName.cs
+++ b/src/Tasks/CreateCSharpManifestResourceName.cs
@@ -118,8 +118,8 @@ namespace Microsoft.Build.Tasks
             else
             {
                 info = Culture.GetItemCultureInfo(embeddedFileName, dependentUponFileName, treatAsCultureNeutral);
+
                 // If the item has a culture override, respect that.
-                // We need to recheck here due to changewave in condition above - after Wave17_14 removal, this should be unconditional.
                 if (!string.IsNullOrEmpty(culture))
                 {
                     info.culture = culture;

--- a/src/Tasks/CreateVisualBasicManifestResourceName.cs
+++ b/src/Tasks/CreateVisualBasicManifestResourceName.cs
@@ -117,8 +117,8 @@ namespace Microsoft.Build.Tasks
             else
             {
                 info = Culture.GetItemCultureInfo(embeddedFileName, dependentUponFileName, treatAsCultureNeutral);
+
                 // If the item has a culture override, respect that.
-                // We need to recheck here due to changewave in condition above - after Wave17_14 removal, this should be unconditional.
                 if (!string.IsNullOrEmpty(culture))
                 {
                     info.culture = culture;

--- a/src/Tasks/Exec.cs
+++ b/src/Tasks/Exec.cs
@@ -396,9 +396,7 @@ namespace Microsoft.Build.Tasks
 
             if (ConsoleToMSBuild)
             {
-                string trimmedTextLine = ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_10) ?
-                    singleLine.TrimEnd() :
-                    singleLine.Trim();
+                string trimmedTextLine = singleLine.TrimEnd();
 
                 if (trimmedTextLine.Length > 0)
                 {
@@ -605,11 +603,6 @@ namespace Microsoft.Build.Tasks
             {
                 commandLine.AppendSwitch("-c");
                 commandLine.AppendTextUnquoted(" \"");
-                bool setLocale = !ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_10);
-                if (setLocale)
-                {
-                    commandLine.AppendTextUnquoted("export LANG=en_US.UTF-8; export LC_ALL=en_US.UTF-8; ");
-                }
                 commandLine.AppendTextUnquoted(". ");
                 commandLine.AppendFileNameIfNotNull(batchFileForCommandLine);
                 commandLine.AppendTextUnquoted("\"");

--- a/src/Tasks/FileIO/WriteLinesToFile.cs
+++ b/src/Tasks/FileIO/WriteLinesToFile.cs
@@ -131,43 +131,7 @@ namespace Microsoft.Build.Tasks
                 }
             }
 
-            // Use transactional mode by default when ChangeWave 18.3 is enabled
-            if (ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave18_3))
-            {
-                return ExecuteTransactional(filePath, directoryPath, contentsAsString, encoding);
-            }
-            else
-            {
-                return ExecuteNonTransactional(filePath, directoryPath, contentsAsString, encoding);
-            }
-        }
-
-        private bool ExecuteNonTransactional(AbsolutePath filePath, string directoryPath, string contentsAsString, Encoding encoding)
-        {
-            try
-            {
-                if (Overwrite)
-                {
-                    System.IO.File.WriteAllText(filePath, contentsAsString, encoding);
-                }
-                else
-                {
-                    if (WriteOnlyWhenDifferent)
-                    {
-                        Log.LogMessageFromResources(MessageImportance.Normal, "WriteLinesToFile.UnusedWriteOnlyWhenDifferent", filePath.OriginalValue);
-                    }
-
-                    System.IO.File.AppendAllText(filePath, contentsAsString, encoding);
-                }
-
-                return !Log.HasLoggedErrors;
-            }
-            catch (Exception e) when (ExceptionHandling.IsIoRelatedException(e))
-            {
-                string lockedFileMessage = LockCheck.GetLockedFileMessage(filePath);
-                Log.LogErrorWithCodeFromResources("WriteLinesToFile.ErrorOrWarning", filePath.OriginalValue, e.Message, lockedFileMessage);
-                return !Log.HasLoggedErrors;
-            }
+            return ExecuteTransactional(filePath, directoryPath, contentsAsString, encoding);
         }
 
         private bool ExecuteTransactional(AbsolutePath filePath, string directoryPath, string contentsAsString, Encoding encoding)

--- a/src/Tasks/Microsoft.Common.CrossTargeting.targets
+++ b/src/Tasks/Microsoft.Common.CrossTargeting.targets
@@ -262,7 +262,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         the pre-restore files in the binary log and then NuGet won't be able to embed the generated one after restore.  If some other
         project extension mechanism wants to import project extensions during restore, they need to explicitly set ImportProjectExtensionTargets
     -->
-    <ImportProjectExtensionTargets Condition="$([MSBuild]::AreFeaturesEnabled('17.10')) And '$(ImportProjectExtensionTargets)' == '' And '$(MSBuildIsRestoring)' == 'true'">false</ImportProjectExtensionTargets>
+    <ImportProjectExtensionTargets Condition="'$(ImportProjectExtensionTargets)' == '' And '$(MSBuildIsRestoring)' == 'true'">false</ImportProjectExtensionTargets>
     
     <ImportProjectExtensionTargets Condition="'$(ImportProjectExtensionTargets)' == ''">true</ImportProjectExtensionTargets>
   </PropertyGroup>

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -1387,11 +1387,11 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
     <!-- RESOURCE ITEMS -->
     <AssignLinkMetadata Items="@(Resource)"
-                        Condition="'@(Resource)' != '' and '%(Resource.DefiningProjectFullPath)' != '$(MSBuildProjectFullPath)' and $([MSBuild]::AreFeaturesEnabled('17.10'))">
+                        Condition="'@(Resource)' != '' and '%(Resource.DefiningProjectFullPath)' != '$(MSBuildProjectFullPath)'">
       <Output TaskParameter="OutputItems" ItemName="_Temp" />
     </AssignLinkMetadata>
 
-    <ItemGroup Condition="$([MSBuild]::AreFeaturesEnabled('17.10'))">
+    <ItemGroup>
       <Resource Remove="@(_Temp)" />
       <Resource Include="@(_Temp)" />
       <_Temp Remove="@(_Temp)" />

--- a/src/Tasks/Microsoft.Common.props
+++ b/src/Tasks/Microsoft.Common.props
@@ -65,7 +65,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         the pre-restore files in the binary log and then NuGet won't be able to embed the generated one after restore.  If some other
         project extension mechanism wants to import project extensions during restore, they need to explicitly set ImportProjectExtensionProps
     -->
-    <ImportProjectExtensionProps Condition="$([MSBuild]::AreFeaturesEnabled('17.10')) And '$(ImportProjectExtensionProps)' == '' And '$(MSBuildIsRestoring)' == 'true'">false</ImportProjectExtensionProps>
+    <ImportProjectExtensionProps Condition="'$(ImportProjectExtensionProps)' == '' And '$(MSBuildIsRestoring)' == 'true'">false</ImportProjectExtensionProps>
     
     <ImportProjectExtensionProps Condition="'$(ImportProjectExtensionProps)' == ''">true</ImportProjectExtensionProps>
     <_InitialMSBuildProjectExtensionsPath Condition=" '$(ImportProjectExtensionProps)' == 'true' ">$(MSBuildProjectExtensionsPath)</_InitialMSBuildProjectExtensionsPath>

--- a/src/Tasks/Microsoft.Common.targets
+++ b/src/Tasks/Microsoft.Common.targets
@@ -34,7 +34,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         the pre-restore files in the binary log and then NuGet won't be able to embed the generated one after restore.  If some other
         project extension mechanism wants to import project extensions during restore, they need to explicitly set ImportProjectExtensionTargets
     -->
-    <ImportProjectExtensionTargets Condition="$([MSBuild]::AreFeaturesEnabled('17.10')) And '$(ImportProjectExtensionTargets)' == '' And '$(MSBuildIsRestoring)' == 'true'">false</ImportProjectExtensionTargets>
+    <ImportProjectExtensionTargets Condition="'$(ImportProjectExtensionTargets)' == '' And '$(MSBuildIsRestoring)' == 'true'">false</ImportProjectExtensionTargets>
     
     <ImportProjectExtensionTargets Condition="'$(ImportProjectExtensionTargets)' == ''">true</ImportProjectExtensionTargets>
   </PropertyGroup>

--- a/src/Utilities/ToolTask.cs
+++ b/src/Utilities/ToolTask.cs
@@ -246,14 +246,12 @@ namespace Microsoft.Build.Utilities
         {
             get
             {
-                if (ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_10))
+                if (_encoding != null)
                 {
-                    if (_encoding != null)
-                    {
-                        // Keep the encoding of standard output & error consistent with the console code page.
-                        return _encoding;
-                    }
+                    // Keep the encoding of standard output & error consistent with the console code page.
+                    return _encoding;
                 }
+
                 return EncodingUtilities.CurrentSystemOemEncoding;
             }
         }
@@ -270,14 +268,12 @@ namespace Microsoft.Build.Utilities
         {
             get
             {
-                if (ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_10))
+                if (_encoding != null)
                 {
-                    if (_encoding != null)
-                    {
-                        // Keep the encoding of standard output & error consistent with the console code page.
-                        return _encoding;
-                    }
+                    // Keep the encoding of standard output & error consistent with the console code page.
+                    return _encoding;
                 }
+
                 return EncodingUtilities.CurrentSystemOemEncoding;
             }
         }
@@ -1558,10 +1554,7 @@ namespace Microsoft.Build.Utilities
                         }
 
                         File.AppendAllText(_temporaryBatchFile, commandLineCommands, encoding);
-                        if (ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_10))
-                        {
-                            _encoding = encoding;
-                        }
+                        _encoding = encoding;
 
                         string batchFileForCommandLine = _temporaryBatchFile;
 


### PR DESCRIPTION
Fixes #13264
Fixes #13265
Fixes #13266

### Context

Change waves 17.10, 17.12 and 17.14 are long out of rotation, and 18.3 rotates out with them now that the repo is on 18.10. Per [ChangeWaves-Dev.md](https://github.com/dotnet/msbuild/blob/main/documentation/wiki/ChangeWaves-Dev.md#change-wave-end-of-lifespan-procedure), retiring a wave means deleting the `Version` field, removing the `AreFeaturesEnabled` conditions so the feature becomes standard behavior, dropping the tests that pinned the opted-out behavior, and cleaning up the dead code left behind.

After this the rotation is 18.4 – 18.10, and the "will be removed in the release accompanying .NET 11" bucket in `ChangeWaves.md` is empty, so it is dropped.

### Changes Made

One commit per wave, plus one prerequisite bootstrap fix:

**`Overlay freshly-built MSBuild files into the bootstrap SDK's Current folder`**

`BootstrapNetCore` overlays our build output onto the acquired SDK at `sdk\<ver>\`, but the .NET SDK layout keeps some of MSBuild's own props/targets under `sdk\<ver>\Current\`, because they are imported through `$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\...` and `$(MSBuildToolsVersion)` is `Current` there. `Microsoft.Common.props` is the notable case: in an SDK layout it exists **only** under `Current\`, and `Microsoft.NET.Sdk`'s `Sdk.props` imports it from that path for every SDK-style project.

Our build output has no `Current\` subdirectory, so the overlay never replaced it. That means every bootstrap build has silently been evaluating the `Microsoft.Common.props` belonging to whatever older MSBuild the acquired SDK shipped with, and changes to `src\Tasks\Microsoft.Common.props` never took effect in bootstrap-based tests.

Retiring 17.10 made that visible: the stale props still evaluated `$([MSBuild]::AreFeaturesEnabled('17.10'))`, which trips the Debug assert in `ChangeWaves` and took down 54 BuildCheck end-to-end tests. Fixing the overlay addresses the root cause and leaves the assert doing exactly the job it was added for.

**`Phase out ChangeWave 17.10`** — makes unconditional: NuGet.Frameworks/AppDomain assembly loading in MSBuild.exe and VS, process-wide SDK resolver caching (`CachingSdkResolverLoader`) plus the .NET-only default-resolver fast path, target switch unquoting, `Link` metadata on `Resource` items, `-version` trailing newline, `Traits` refresh on environment change, `Exec` not trimming leading whitespace and not exporting `LANG`/`LC_ALL` on Unix, `ToolTask` console-code-page encoding, skipping project extension imports during restore, and property reassignment tracking. Also deletes `StableStringHashLegacy` and the `NoInlining` guard on `StableStringHash` that only existed to keep StringTools out of the opted-out path.

**`Phase out ChangeWave 17.12`** — makes unconditional: `TaskParameterEventArgs` for scalar task parameters and output properties (the legacy textual form and `OutputPropertyLogMessage` path are gone), `InvariantCulture` for `Convert.ToString` during evaluation, `BuildRequestDataFlags` compatibility in `ResultsCache`, emitting evaluation props/items when any sink asks, `ProjectStartedEventArgs` returning empty collections instead of `null`, binlog `{}` wildcard file names, and loading `Microsoft.DotNet.MSBuildSdkResolver` into the default load context.

**`Phase out ChangeWave 17.14`** — the only live gate left was `SolutionFile.FullPath`, which now always throws `ArgumentNullException` for a null/empty path. The .slnx-parser and RAR custom-culture features originally under this wave were already reverted/replaced (see #11607), so only stale `Wave17_14` comments remained in `Create{CSharp,VisualBasic}ManifestResourceName`.

**`Phase out ChangeWave 18.3`** — `WriteLinesToFile` always writes atomically (temp file + replace with retry); the non-transactional path and the quarantined test asserting the old data-losing behavior are deleted.

### Testing

`build.cmd -test` on Windows (net11.0 x64 + net472 x86). Everything passes except `PortableTasks_Tests.TestDesktopMSBuildShouldRunPortableTask`, which shells out to `msbuild` and fails for lack of a Visual Studio install on this machine, not because of these changes.

### Notes

Behavior only changes for builds that were **opting out** via `MSBUILDDISABLEFEATURESFROMVERSION`; the default (all waves enabled) code paths make exactly the same decisions as before. Setting `MSBUILDDISABLEFEATURESFROMVERSION` to a retired wave now clamps to `18.4` and warns MSB4272, which is the documented out-of-rotation behavior.
