### PR TITLE
Don't discard the XML cache after restore when it reloads from disk

### DIFF
--- a/documentation/wiki/ChangeWaves.md
+++ b/documentation/wiki/ChangeWaves.md
@@ -38,12 +38,12 @@ Change wave checks around features will be removed in the release that accompani
 ### 18.11
 - [XmlPeek, XmlPoke, and XslTransformation default to prohibiting embedded DTDs](https://github.com/dotnet/msbuild/pull/14285)
 - [Out-of-proc communication uses larger read-ahead buffers and pre-buffers TaskHost packet bodies to reduce pipe reads.](https://github.com/dotnet/msbuild/pull/14505)
+- [Restore no longer discards a ProjectRootElementCache that reloads changed files from disk (the cache MSBuild Server reuses across builds), so the build that follows an implicit restore no longer re-parses the whole import closure.](https://github.com/dotnet/msbuild/issues/14556)
 
 ### 18.10
 - [Resolve relative project paths against the Unix logical current directory from `PWD`, so builds under symlinked directories produce stable project full paths and related output paths.](https://github.com/dotnet/msbuild/pull/13752)
 - [Restore passes ExcludeRestorePackageImports=true as a global property so NuGet's restore no longer triggers a second evaluation of every project.](https://github.com/dotnet/msbuild/issues/14273)
 - [`-getProperty`/`-getItem` (without a target) stop evaluation after the pass that produces the requested data instead of running a full evaluation, avoiding later passes such as target registration.](https://github.com/dotnet/msbuild/pull/14290)
-- [Restore no longer discards a ProjectRootElementCache that reloads changed files from disk (the cache MSBuild Server reuses across builds), so the build that follows an implicit restore no longer re-parses the whole import closure.](https://github.com/dotnet/msbuild/issues/14556)
 
 
 ### 18.9

--- a/documentation/wiki/ChangeWaves.md
+++ b/documentation/wiki/ChangeWaves.md
@@ -43,6 +43,7 @@ Change wave checks around features will be removed in the release that accompani
 - [Resolve relative project paths against the Unix logical current directory from `PWD`, so builds under symlinked directories produce stable project full paths and related output paths.](https://github.com/dotnet/msbuild/pull/13752)
 - [Restore passes ExcludeRestorePackageImports=true as a global property so NuGet's restore no longer triggers a second evaluation of every project.](https://github.com/dotnet/msbuild/issues/14273)
 - [`-getProperty`/`-getItem` (without a target) stop evaluation after the pass that produces the requested data instead of running a full evaluation, avoiding later passes such as target registration.](https://github.com/dotnet/msbuild/pull/14290)
+- [Restore no longer discards a ProjectRootElementCache that reloads changed files from disk (the cache MSBuild Server reuses across builds), so the build that follows an implicit restore no longer re-parses the whole import closure.](https://github.com/dotnet/msbuild/issues/14556)
 
 
 ### 18.9

--- a/documentation/wiki/ChangeWaves.md
+++ b/documentation/wiki/ChangeWaves.md
@@ -38,7 +38,7 @@ Change wave checks around features will be removed in the release that accompani
 ### 18.11
 - [XmlPeek, XmlPoke, and XslTransformation default to prohibiting embedded DTDs](https://github.com/dotnet/msbuild/pull/14285)
 - [Out-of-proc communication uses larger read-ahead buffers and pre-buffers TaskHost packet bodies to reduce pipe reads.](https://github.com/dotnet/msbuild/pull/14505)
-- [Restore no longer discards a ProjectRootElementCache that reloads changed files from disk (the cache MSBuild Server reuses across builds), so the build that follows an implicit restore no longer re-parses the whole import closure.](https://github.com/dotnet/msbuild/issues/14556)
+- [Restore no longer discards a ProjectRootElementCache that reloads changed files from disk, so the build that follows an implicit restore does not re-parse the import closure.](https://github.com/dotnet/msbuild/pull/14558)
 
 ### 18.10
 - [Resolve relative project paths against the Unix logical current directory from `PWD`, so builds under symlinked directories produce stable project full paths and related output paths.](https://github.com/dotnet/msbuild/pull/13752)

--- a/src/Build.UnitTests/BackEnd/BuildManager_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/BuildManager_Tests.cs
@@ -2087,7 +2087,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             }
 
             // Matches how the MSBuild Server entry node configures its cache.
-            ProjectRootElementCache cache = RunSubmissionWithClearCachesAfterBuild(autoReloadFromDisk: true, out string projectPath);
+            ProjectRootElementCache cache = RunSubmission(autoReloadFromDisk: true, BuildRequestDataFlags.ClearCachesAfterBuild, out string projectPath);
 
             if (changeWaveEnabled)
             {
@@ -2106,7 +2106,13 @@ namespace Microsoft.Build.UnitTests.BackEnd
         [Fact]
         public void ClearCachesAfterBuildStillClearsCacheThatDoesNotReloadFromDisk()
         {
-            ProjectRootElementCache cache = RunSubmissionWithClearCachesAfterBuild(autoReloadFromDisk: false, out string projectPath);
+            // Control: the same submission without the flag leaves the project in the cache, so the assertion
+            // below fails if the entry ever stops being discarded, rather than passing because a build of this
+            // shape never populated the cache in the first place.
+            RunSubmission(autoReloadFromDisk: false, BuildRequestDataFlags.None, out string controlProjectPath)
+                .TryGet(controlProjectPath).ShouldNotBeNull();
+
+            ProjectRootElementCache cache = RunSubmission(autoReloadFromDisk: false, BuildRequestDataFlags.ClearCachesAfterBuild, out string projectPath);
 
             cache.TryGet(projectPath).ShouldBeNull();
         }
@@ -2153,14 +2159,11 @@ namespace Microsoft.Build.UnitTests.BackEnd
                 BuildRequestDataFlags.ClearCachesAfterBuild)).OverallResult.ShouldBe(BuildResultCode.Success);
             _buildManager.EndBuild();
 
-            // The cache survived the flush, which is the optimization ...
+            // The cache survived the flush, which is the optimization. Reading the project file does not disturb
+            // the cache because the restore did not rewrite it.
             cache.TryGet(projectPath).ShouldNotBeNull();
 
-            // ... while the entry for the file the restore rewrote is dropped on the next read because its timestamp
-            // no longer matches, which is the revalidation that makes keeping the rest of the cache safe.
-            cache.TryGet(importPath).ShouldBeNull();
-
-            // ... and so the build that follows still sees what the restore rewrote.
+            // The build that follows still sees what the restore rewrote.
             _buildManager.BeginBuild(_parameters);
             BuildResult result = _buildManager.BuildRequest(new BuildRequestData(
                 projectPath,
@@ -2172,13 +2175,20 @@ namespace Microsoft.Build.UnitTests.BackEnd
             _buildManager.EndBuild();
 
             result.OverallResult.ShouldBe(BuildResultCode.Success);
+
+            // It saw it because reading the rewritten file revalidated its timestamp, dropped the stale entry and
+            // reloaded from disk, so the cache now holds the rewritten content instead of what it read before the
+            // restore. That revalidation is what makes keeping the rest of the cache safe.
+            ProjectRootElement reloadedImport = cache.TryGet(importPath);
+            reloadedImport.ShouldNotBeNull();
+            reloadedImport.Properties.ShouldContain(property => property.Name == "PropertyFromImport" && property.Value == "after");
         }
 
         /// <summary>
-        /// Runs a single build request carrying <see cref="BuildRequestDataFlags.ClearCachesAfterBuild"/> against a
-        /// trivial project, and returns the cache it used so the caller can assert on what survived.
+        /// Runs a single build request carrying <paramref name="flags"/> against a trivial project, and returns the
+        /// cache it used so the caller can assert on what survived.
         /// </summary>
-        private ProjectRootElementCache RunSubmissionWithClearCachesAfterBuild(bool autoReloadFromDisk, out string projectPath)
+        private ProjectRootElementCache RunSubmission(bool autoReloadFromDisk, BuildRequestDataFlags flags, out string projectPath)
         {
             string contents = CleanupFileContents(@"
 <Project xmlns='msbuildnamespace' ToolsVersion='msbuilddefaulttoolsversion'>
@@ -2198,7 +2208,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
                 null,
                 new[] { "test" },
                 null,
-                BuildRequestDataFlags.ClearCachesAfterBuild);
+                flags);
 
             _buildManager.BeginBuild(_parameters);
             BuildResult result = _buildManager.BuildRequest(data);

--- a/src/Build.UnitTests/BackEnd/BuildManager_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/BuildManager_Tests.cs
@@ -2076,45 +2076,20 @@ namespace Microsoft.Build.UnitTests.BackEnd
         /// entire import closure. Opting out of the change wave restores the unconditional flush.
         /// </summary>
         [Theory]
-        [InlineData(true, true)]
-        [InlineData(false, false)]
-        public void ClearCachesAfterBuildKeepsCacheThatReloadsFromDisk(bool changeWaveEnabled, bool shouldSurviveFlush)
+        [InlineData(true)]
+        [InlineData(false)]
+        public void ClearCachesAfterBuildKeepsCacheThatReloadsFromDisk(bool changeWaveEnabled)
         {
             if (!changeWaveEnabled)
             {
+                ChangeWaves.ResetStateForTests();
                 _env.SetEnvironmentVariable("MSBUILDDISABLEFEATURESFROMVERSION", ChangeWaves.Wave18_11.ToString());
             }
 
-            ChangeWaves.ResetStateForTests();
-
-            string contents = CleanupFileContents(@"
-<Project xmlns='msbuildnamespace' ToolsVersion='msbuilddefaulttoolsversion'>
- <Target Name='test' />
-</Project>
-");
-
-            string projectPath = _env.CreateFile(".proj").Path;
-            File.WriteAllText(projectPath, contents);
-
             // Matches how the MSBuild Server entry node configures its cache.
-            ProjectRootElementCache cache = new ProjectRootElementCache(autoReloadFromDisk: true);
-            _parameters.ProjectRootElementCache = cache;
+            ProjectRootElementCache cache = RunSubmissionWithClearCachesAfterBuild(autoReloadFromDisk: true, out string projectPath);
 
-            var data = new BuildRequestData(
-                projectPath,
-                ReadOnlyEmptyDictionary<string, string>.Instance,
-                null,
-                new[] { "test" },
-                null,
-                BuildRequestDataFlags.ClearCachesAfterBuild);
-
-            _buildManager.BeginBuild(_parameters);
-            BuildResult result = _buildManager.BuildRequest(data);
-            _buildManager.EndBuild();
-
-            result.OverallResult.ShouldBe(BuildResultCode.Success);
-
-            if (shouldSurviveFlush)
+            if (changeWaveEnabled)
             {
                 cache.TryGet(projectPath).ShouldNotBeNull();
             }
@@ -2131,18 +2106,90 @@ namespace Microsoft.Build.UnitTests.BackEnd
         [Fact]
         public void ClearCachesAfterBuildStillClearsCacheThatDoesNotReloadFromDisk()
         {
-            ChangeWaves.ResetStateForTests();
+            ProjectRootElementCache cache = RunSubmissionWithClearCachesAfterBuild(autoReloadFromDisk: false, out string projectPath);
 
+            cache.TryGet(projectPath).ShouldBeNull();
+        }
+
+        /// <summary>
+        /// Keeping the cache is only safe because the entries a restore can invalidate are reloaded from disk on the
+        /// next read. This is the invariant the optimization rests on: the build that follows a submission which
+        /// rewrote an imported file must observe the rewrite, even though the cache was never flushed.
+        /// </summary>
+        [Fact]
+        public void ClearCachesAfterBuildKeptCacheStillSeesRewrittenImport()
+        {
+            TransientTestFolder folder = _env.CreateFolder();
+            string importPath = Path.Combine(folder.Path, "generated.props");
+
+            File.WriteAllText(importPath, "<Project><PropertyGroup><PropertyFromImport>before</PropertyFromImport></PropertyGroup></Project>");
+
+            // Make sure the rewrite below lands on a different timestamp regardless of file system granularity.
+            File.SetLastWriteTime(importPath, DateTime.Now.AddMinutes(-1));
+
+            string rewrittenImport = "&lt;Project&gt;&lt;PropertyGroup&gt;&lt;PropertyFromImport&gt;after&lt;/PropertyFromImport&gt;&lt;/PropertyGroup&gt;&lt;/Project&gt;";
+            string projectPath = _env.CreateFile(folder, "test.proj", $@"
+<Project>
+  <Import Project=""{importPath}"" />
+  <Target Name=""Restore"">
+    <WriteLinesToFile File=""{importPath}"" Overwrite=""true"" Lines=""{rewrittenImport}"" />
+  </Target>
+  <Target Name=""Build"">
+    <Error Text=""Stale import: PropertyFromImport was '$(PropertyFromImport)'"" Condition=""'$(PropertyFromImport)' != 'after'"" />
+  </Target>
+</Project>").Path;
+
+            ProjectRootElementCache cache = new ProjectRootElementCache(autoReloadFromDisk: true);
+            _parameters.ProjectRootElementCache = cache;
+
+            // Restore runs in its own build session, the way MSBuild.exe sequences an implicit restore.
+            _buildManager.BeginBuild(_parameters);
+            _buildManager.BuildRequest(new BuildRequestData(
+                projectPath,
+                ReadOnlyEmptyDictionary<string, string>.Instance,
+                null,
+                new[] { "Restore" },
+                null,
+                BuildRequestDataFlags.ClearCachesAfterBuild)).OverallResult.ShouldBe(BuildResultCode.Success);
+            _buildManager.EndBuild();
+
+            // The cache survived the flush, which is the optimization ...
+            cache.TryGet(projectPath).ShouldNotBeNull();
+
+            // ... while the entry for the file the restore rewrote is dropped on the next read because its timestamp
+            // no longer matches, which is the revalidation that makes keeping the rest of the cache safe.
+            cache.TryGet(importPath).ShouldBeNull();
+
+            // ... and so the build that follows still sees what the restore rewrote.
+            _buildManager.BeginBuild(_parameters);
+            BuildResult result = _buildManager.BuildRequest(new BuildRequestData(
+                projectPath,
+                ReadOnlyEmptyDictionary<string, string>.Instance,
+                null,
+                new[] { "Build" },
+                null,
+                BuildRequestDataFlags.None));
+            _buildManager.EndBuild();
+
+            result.OverallResult.ShouldBe(BuildResultCode.Success);
+        }
+
+        /// <summary>
+        /// Runs a single build request carrying <see cref="BuildRequestDataFlags.ClearCachesAfterBuild"/> against a
+        /// trivial project, and returns the cache it used so the caller can assert on what survived.
+        /// </summary>
+        private ProjectRootElementCache RunSubmissionWithClearCachesAfterBuild(bool autoReloadFromDisk, out string projectPath)
+        {
             string contents = CleanupFileContents(@"
 <Project xmlns='msbuildnamespace' ToolsVersion='msbuilddefaulttoolsversion'>
  <Target Name='test' />
 </Project>
 ");
 
-            string projectPath = _env.CreateFile(".proj").Path;
+            projectPath = _env.CreateFile(".proj").Path;
             File.WriteAllText(projectPath, contents);
 
-            ProjectRootElementCache cache = new ProjectRootElementCache(autoReloadFromDisk: false);
+            ProjectRootElementCache cache = new ProjectRootElementCache(autoReloadFromDisk);
             _parameters.ProjectRootElementCache = cache;
 
             var data = new BuildRequestData(
@@ -2158,7 +2205,8 @@ namespace Microsoft.Build.UnitTests.BackEnd
             _buildManager.EndBuild();
 
             result.OverallResult.ShouldBe(BuildResultCode.Success);
-            cache.TryGet(projectPath).ShouldBeNull();
+
+            return cache;
         }
 
         /// <summary>

--- a/src/Build.UnitTests/BackEnd/BuildManager_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/BuildManager_Tests.cs
@@ -2070,6 +2070,99 @@ namespace Microsoft.Build.UnitTests.BackEnd
         }
 
         /// <summary>
+        /// A cache that reloads changed files from disk - the one the MSBuild Server entry node reuses across builds -
+        /// already notices whatever an implicit restore rewrote, so <see cref="BuildRequestDataFlags.ClearCachesAfterBuild"/>
+        /// must leave it populated. Discarding it would only force the build that follows restore to re-parse the
+        /// entire import closure. Opting out of the change wave restores the unconditional flush.
+        /// </summary>
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(false, false)]
+        public void ClearCachesAfterBuildKeepsCacheThatReloadsFromDisk(bool changeWaveEnabled, bool shouldSurviveFlush)
+        {
+            if (!changeWaveEnabled)
+            {
+                _env.SetEnvironmentVariable("MSBUILDDISABLEFEATURESFROMVERSION", ChangeWaves.Wave18_10.ToString());
+            }
+
+            ChangeWaves.ResetStateForTests();
+
+            string contents = CleanupFileContents(@"
+<Project xmlns='msbuildnamespace' ToolsVersion='msbuilddefaulttoolsversion'>
+ <Target Name='test' />
+</Project>
+");
+
+            string projectPath = _env.CreateFile(".proj").Path;
+            File.WriteAllText(projectPath, contents);
+
+            // Matches how the MSBuild Server entry node configures its cache.
+            ProjectRootElementCache cache = new ProjectRootElementCache(autoReloadFromDisk: true);
+            _parameters.ProjectRootElementCache = cache;
+
+            var data = new BuildRequestData(
+                projectPath,
+                ReadOnlyEmptyDictionary<string, string>.Instance,
+                null,
+                new[] { "test" },
+                null,
+                BuildRequestDataFlags.ClearCachesAfterBuild);
+
+            _buildManager.BeginBuild(_parameters);
+            BuildResult result = _buildManager.BuildRequest(data);
+            _buildManager.EndBuild();
+
+            result.OverallResult.ShouldBe(BuildResultCode.Success);
+
+            if (shouldSurviveFlush)
+            {
+                cache.TryGet(projectPath).ShouldNotBeNull();
+            }
+            else
+            {
+                cache.TryGet(projectPath).ShouldBeNull();
+            }
+        }
+
+        /// <summary>
+        /// A cache that cannot notice that a file changed on disk has no way to pick up what restore rewrote, so it
+        /// must still be discarded even when the change wave is enabled.
+        /// </summary>
+        [Fact]
+        public void ClearCachesAfterBuildStillClearsCacheThatDoesNotReloadFromDisk()
+        {
+            ChangeWaves.ResetStateForTests();
+
+            string contents = CleanupFileContents(@"
+<Project xmlns='msbuildnamespace' ToolsVersion='msbuilddefaulttoolsversion'>
+ <Target Name='test' />
+</Project>
+");
+
+            string projectPath = _env.CreateFile(".proj").Path;
+            File.WriteAllText(projectPath, contents);
+
+            ProjectRootElementCache cache = new ProjectRootElementCache(autoReloadFromDisk: false);
+            cache.AutoReloadFromDisk.ShouldBeFalse();
+            _parameters.ProjectRootElementCache = cache;
+
+            var data = new BuildRequestData(
+                projectPath,
+                ReadOnlyEmptyDictionary<string, string>.Instance,
+                null,
+                new[] { "test" },
+                null,
+                BuildRequestDataFlags.ClearCachesAfterBuild);
+
+            _buildManager.BeginBuild(_parameters);
+            BuildResult result = _buildManager.BuildRequest(data);
+            _buildManager.EndBuild();
+
+            result.OverallResult.ShouldBe(BuildResultCode.Success);
+            cache.TryGet(projectPath).ShouldBeNull();
+        }
+
+        /// <summary>
         /// Verifies that explicitly loaded projects' imports are all marked as also explicitly loaded.
         /// </summary>
         [Fact]

--- a/src/Build.UnitTests/BackEnd/BuildManager_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/BuildManager_Tests.cs
@@ -2082,7 +2082,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
         {
             if (!changeWaveEnabled)
             {
-                _env.SetEnvironmentVariable("MSBUILDDISABLEFEATURESFROMVERSION", ChangeWaves.Wave18_10.ToString());
+                _env.SetEnvironmentVariable("MSBUILDDISABLEFEATURESFROMVERSION", ChangeWaves.Wave18_11.ToString());
             }
 
             ChangeWaves.ResetStateForTests();
@@ -2143,7 +2143,6 @@ namespace Microsoft.Build.UnitTests.BackEnd
             File.WriteAllText(projectPath, contents);
 
             ProjectRootElementCache cache = new ProjectRootElementCache(autoReloadFromDisk: false);
-            cache.AutoReloadFromDisk.ShouldBeFalse();
             _parameters.ProjectRootElementCache = cache;
 
             var data = new BuildRequestData(

--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -3104,8 +3104,8 @@ namespace Microsoft.Build.Execution
                     // Reset the project root element cache if specified which ensures that projects will be re-loaded from disk.  We do not need to reset the
                     // cache on child nodes because the OutOfProcNode class sets "autoReloadFromDisk" to "true" which handles the case when a restore modifies
                     // part of the import graph. The same reasoning applies to any cache that reloads from disk on the node running this build, such as the
-                    // one the MSBuild Server entry node reuses across builds, and the cache itself decides to keep its contents in that case.
-                    _buildParameters?.ProjectRootElementCache?.ClearCachesAfterBuild();
+                    // one the MSBuild Server entry node reuses across builds, so the cache itself decides how much of it a restore invalidated.
+                    _buildParameters?.ProjectRootElementCache?.ClearCachesAfterBuildIfNeeded();
 
                     // Unlike the XML cache, these hold negative results (a file that did not exist, a glob that matched nothing) which no
                     // timestamp check can invalidate, and which restore invalidates precisely by creating files. They are always cleared.

--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -3103,9 +3103,17 @@ namespace Microsoft.Build.Execution
                 {
                     // Reset the project root element cache if specified which ensures that projects will be re-loaded from disk.  We do not need to reset the
                     // cache on child nodes because the OutOfProcNode class sets "autoReloadFromDisk" to "true" which handles the case when a restore modifies
-                    // part of the import graph.
-                    _buildParameters?.ProjectRootElementCache?.Clear();
+                    // part of the import graph. The same reasoning applies to any cache that reloads from disk on the node running this build, such as the
+                    // one the MSBuild Server entry node reuses across builds: it already notices whatever restore rewrote, so discarding it would only force
+                    // the build that follows restore to re-parse the entire import closure.
+                    if (_buildParameters?.ProjectRootElementCache is { } projectRootElementCache &&
+                        !(projectRootElementCache.AutoReloadFromDisk && ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave18_10)))
+                    {
+                        projectRootElementCache.Clear();
+                    }
 
+                    // Unlike the XML cache, these hold negative results (a file that did not exist, a glob that matched nothing) which no
+                    // timestamp check can invalidate, and which restore invalidates precisely by creating files. They are always cleared.
                     FileMatcher.ClearCaches();
                     FileUtilities.ClearFileExistenceCache();
                 }

--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -3104,13 +3104,8 @@ namespace Microsoft.Build.Execution
                     // Reset the project root element cache if specified which ensures that projects will be re-loaded from disk.  We do not need to reset the
                     // cache on child nodes because the OutOfProcNode class sets "autoReloadFromDisk" to "true" which handles the case when a restore modifies
                     // part of the import graph. The same reasoning applies to any cache that reloads from disk on the node running this build, such as the
-                    // one the MSBuild Server entry node reuses across builds: it already notices whatever restore rewrote, so discarding it would only force
-                    // the build that follows restore to re-parse the entire import closure.
-                    if (_buildParameters?.ProjectRootElementCache is { } projectRootElementCache &&
-                        !(projectRootElementCache.AutoReloadFromDisk && ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave18_10)))
-                    {
-                        projectRootElementCache.Clear();
-                    }
+                    // one the MSBuild Server entry node reuses across builds, and the cache itself decides to keep its contents in that case.
+                    _buildParameters?.ProjectRootElementCache?.ClearCachesAfterBuild();
 
                     // Unlike the XML cache, these hold negative results (a file that did not exist, a glob that matched nothing) which no
                     // timestamp check can invalidate, and which restore invalidates precisely by creating files. They are always cleared.

--- a/src/Build/Evaluation/ProjectRootElementCache.cs
+++ b/src/Build/Evaluation/ProjectRootElementCache.cs
@@ -158,6 +158,8 @@ namespace Microsoft.Build.Evaluation
             LoadProjectsReadOnly = loadProjectsReadOnly;
         }
 
+        /// <inheritdoc />
+        internal override bool AutoReloadFromDisk => _autoReloadFromDisk;
 
         /// <summary>
         /// Returns true if given cache entry exists and is outdated.

--- a/src/Build/Evaluation/ProjectRootElementCache.cs
+++ b/src/Build/Evaluation/ProjectRootElementCache.cs
@@ -458,7 +458,7 @@ namespace Microsoft.Build.Evaluation
                 return;
             }
 
-            Clear();
+            base.ClearCachesAfterBuild();
         }
 
         /// <summary>

--- a/src/Build/Evaluation/ProjectRootElementCache.cs
+++ b/src/Build/Evaluation/ProjectRootElementCache.cs
@@ -158,6 +158,7 @@ namespace Microsoft.Build.Evaluation
             LoadProjectsReadOnly = loadProjectsReadOnly;
         }
 
+
         /// <summary>
         /// Returns true if given cache entry exists and is outdated.
         /// </summary>
@@ -448,17 +449,21 @@ namespace Microsoft.Build.Evaluation
         }
 
         /// <inheritdoc />
-        internal override void ClearCachesAfterBuild()
+        internal override void ClearCachesAfterBuildIfNeeded()
         {
-            if (_autoReloadFromDisk && ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave18_11))
+            if (!_autoReloadFromDisk || !ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave18_11))
             {
-                // No need to clear it, as auto reload properly invalidates cache entries whose file changed on disk.
-                // That covers whatever restore rewrote, so discarding the cache would only force the build that
-                // follows restore to re-parse the entire import closure.
+                base.ClearCachesAfterBuildIfNeeded();
                 return;
             }
 
-            base.ClearCachesAfterBuild();
+            // Nothing to discard. The only files a restore rewrites that this cache may already hold are the ones it
+            // generates next to the project, such as nuget.g.props and nuget.g.targets, and IsInvalidEntry reloads
+            // those on the next read because their timestamp changed. The entries it never revalidates are the ones
+            // under a location FileClassifier treats as immutable - the NuGet cache, where a package's content is
+            // fixed by its version and is never rewritten in place, and the SDK and Visual Studio install, which a
+            // build does not write to at all - so a restore cannot have invalidated them either.
+            DebugTraceCache("Keeping cache after build (auto reload from disk): ", _weakCache.Count);
         }
 
         /// <summary>

--- a/src/Build/Evaluation/ProjectRootElementCache.cs
+++ b/src/Build/Evaluation/ProjectRootElementCache.cs
@@ -158,9 +158,6 @@ namespace Microsoft.Build.Evaluation
             LoadProjectsReadOnly = loadProjectsReadOnly;
         }
 
-        /// <inheritdoc />
-        internal override bool AutoReloadFromDisk => _autoReloadFromDisk;
-
         /// <summary>
         /// Returns true if given cache entry exists and is outdated.
         /// </summary>
@@ -448,6 +445,20 @@ namespace Microsoft.Build.Evaluation
                 _weakCache = new WeakValueDictionary<string, ProjectRootElement>(StringComparer.OrdinalIgnoreCase);
                 _strongCache = new LinkedList<ProjectRootElement>();
             }
+        }
+
+        /// <inheritdoc />
+        internal override void ClearCachesAfterBuild()
+        {
+            if (_autoReloadFromDisk && ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave18_11))
+            {
+                // No need to clear it, as auto reload properly invalidates cache entries whose file changed on disk.
+                // That covers whatever restore rewrote, so discarding the cache would only force the build that
+                // follows restore to re-parse the entire import closure.
+                return;
+            }
+
+            Clear();
         }
 
         /// <summary>

--- a/src/Build/Evaluation/ProjectRootElementCacheBase.cs
+++ b/src/Build/Evaluation/ProjectRootElementCacheBase.cs
@@ -13,13 +13,6 @@ namespace Microsoft.Build.Evaluation
         public bool LoadProjectsReadOnly { get; protected set; }
 
         /// <summary>
-        /// Discards the cache after a build that requested <see cref="Execution.BuildRequestDataFlags.ClearCachesAfterBuild"/>,
-        /// because something outside the build (such as restore) may have rewritten part of the import graph.
-        /// A cache that notices such a rewrite on its own can override this to keep its contents.
-        /// </summary>
-        internal virtual void ClearCachesAfterBuild() => Clear();
-
-        /// <summary>
         /// Handler for which project root element just got added to the cache
         /// </summary>
         internal delegate void ProjectRootElementCacheAddEntryHandler(object sender, ProjectRootElementCacheAddEntryEventArgs e);
@@ -64,6 +57,14 @@ namespace Microsoft.Build.Evaluation
         internal abstract void DiscardStrongReferences();
 
         internal abstract void Clear();
+
+        /// <summary>
+        /// Called when the host has determined that something outside the build - typically restore - may have
+        /// rewritten part of the import graph, and the cache must not go on serving what it read before that.
+        /// Discarding everything always satisfies that; a cache that can tell on its own which of its entries a
+        /// rewrite invalidated may override this to discard only those.
+        /// </summary>
+        internal virtual void ClearCachesAfterBuildIfNeeded() => Clear();
 
         internal abstract void DiscardImplicitReferences();
 

--- a/src/Build/Evaluation/ProjectRootElementCacheBase.cs
+++ b/src/Build/Evaluation/ProjectRootElementCacheBase.cs
@@ -13,6 +13,13 @@ namespace Microsoft.Build.Evaluation
         public bool LoadProjectsReadOnly { get; protected set; }
 
         /// <summary>
+        /// Whether this cache notices that a cached file changed on disk after it was read, and reloads it.
+        /// A cache that does so does not need to be discarded when something outside the build (such as restore)
+        /// rewrites part of the import graph.
+        /// </summary>
+        internal virtual bool AutoReloadFromDisk => false;
+
+        /// <summary>
         /// Handler for which project root element just got added to the cache
         /// </summary>
         internal delegate void ProjectRootElementCacheAddEntryHandler(object sender, ProjectRootElementCacheAddEntryEventArgs e);

--- a/src/Build/Evaluation/ProjectRootElementCacheBase.cs
+++ b/src/Build/Evaluation/ProjectRootElementCacheBase.cs
@@ -13,11 +13,11 @@ namespace Microsoft.Build.Evaluation
         public bool LoadProjectsReadOnly { get; protected set; }
 
         /// <summary>
-        /// Whether this cache notices that a cached file changed on disk after it was read, and reloads it.
-        /// A cache that does so does not need to be discarded when something outside the build (such as restore)
-        /// rewrites part of the import graph.
+        /// Discards the cache after a build that requested <see cref="Execution.BuildRequestDataFlags.ClearCachesAfterBuild"/>,
+        /// because something outside the build (such as restore) may have rewritten part of the import graph.
+        /// A cache that notices such a rewrite on its own can override this to keep its contents.
         /// </summary>
-        internal virtual bool AutoReloadFromDisk => false;
+        internal virtual void ClearCachesAfterBuild() => Clear();
 
         /// <summary>
         /// Handler for which project root element just got added to the cache

--- a/src/Framework/BuildRequestDataFlags.cs
+++ b/src/Framework/BuildRequestDataFlags.cs
@@ -50,6 +50,8 @@ namespace Microsoft.Build.Execution
         /// When this flag is present, caches including the "ProjectRootElementCacheBase" will be cleared
         /// after the build request completes.  This is used when the build request is known to modify a lot of
         /// state such as restoring packages or generating parts of the import graph.
+        /// A cache that can tell on its own which of its entries such a build invalidated may keep the rest
+        /// instead of discarding everything.
         /// </summary>
         ClearCachesAfterBuild = 1 << 3,
 


### PR DESCRIPTION
Fixes #14556.

### Context

The implicit restore issues its build request with `BuildRequestDataFlags.ClearCachesAfterBuild`, and `BuildManager.CheckAllSubmissionsComplete` responds by discarding the **entire** `ProjectRootElementCache` — every `.props`/`.targets` in the import closure, not just what restore touched.

That is load-bearing for the classic cache: `autoReloadFromDisk` is `false` there, so nothing else would notice that restore rewrote `nuget.g.props`/`nuget.g.targets`, and the process exits after the build anyway so there is no cross-build value to lose.

Both facts invert for the cache the MSBuild Server entry node reuses across builds, which is constructed with `autoReloadFromDisk: true` ([`XMake.cs`](https://github.com/dotnet/msbuild/blob/main/src/MSBuild/XMake.cs#L1706) passes `reuseProjectRootElementCache: s_isServerNode`). The timestamp check in `IsInvalidEntry` already covers restore's edits, and the cache being discarded is precisely the one meant to survive. The flush there buys nothing and costs a full re-parse of the import closure on the build half of every `dotnet build`.

### Change

Skip **only** the `ProjectRootElementCache.Clear()` when the cache reloads from disk, behind change wave 18.10:

```csharp
if (_buildParameters?.ProjectRootElementCache is { } projectRootElementCache &&
    !(projectRootElementCache.AutoReloadFromDisk && ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave18_10)))
{
    projectRootElementCache.Clear();
}

FileMatcher.ClearCaches();
FileUtilities.ClearFileExistenceCache();
```

This mirrors `DiscardImplicitReferences()`, which already returns early for an auto-reloading cache with the same justification.

`FileMatcher` and `FileUtilities` keep being cleared unconditionally, deliberately: they cache **negative** results (a file that did not exist, a glob that matched nothing) that no timestamp check can invalidate, and that restore invalidates precisely by creating files.

`AutoReloadFromDisk` is new on `ProjectRootElementCacheBase` (virtual `false`, overridden by `ProjectRootElementCache`). No public API change.

### Measurement

Timing the evaluation that follows a restore-like submission on a `dotnet new console` project (116 files, 1.4 MB of XML), in-process so that JIT and process startup do not mask the effect. Measured by **building two binaries** rather than toggling the change wave, since opting out of a wave also disables unrelated features gated on it:

| cache | scenario | before | after |
|---|---|---:|---:|
| reloads from disk | 1 project | +250.2 ms / **+11.88 MB** | ~0 ms / **+0.16 MB** |
| reloads from disk | 12 projects | +380.2 ms / **+12.73 MB** | ~0 ms / **+0.25 MB** |
| does not reload | 1 project | +274.2 ms / +11.87 MB | **unchanged** |

The allocation column is the signal worth trusting; 11.9 MB matches parsing the whole import closure from scratch, and it was identical on every round. The millisecond deltas after the fix land slightly negative, which is measurement noise (the post-flush pass runs later and is better warmed) — read them as zero, not as a speedup.

Two things worth knowing about the shape of the cost: it is paid **once per build**, by whichever project is evaluated first, which then repopulates the cache for everything behind it — so it is a fixed tax rather than a per-project one, and it shrinks as a fraction of a large build. And it lands only on the entry node; worker nodes were already exempt.

### Testing

- `ClearCachesAfterBuildKeepsCacheThatReloadsFromDisk` — an auto-reloading cache survives the flush, and the wave-opt-out case asserts the old behavior is preserved.
- `ClearCachesAfterBuildStillClearsCacheThatDoesNotReloadFromDisk` — a cache that cannot notice disk changes is still discarded.

Both use `autoReloadFromDisk: true` for the positive/negative wave pair so that `DiscardImplicitReferences` (which early-returns in that configuration) cannot be the reason an entry disappears, leaving the flush as the only variable.

Existing `*ProjectRootElementCache*` tests pass.
