### PR TITLE
Make CoreCompileInputs.cache hash location-independent under DeterministicSourcePaths

### DIFF
--- a/src/Tasks.UnitTests/Hash_Tests.cs
+++ b/src/Tasks.UnitTests/Hash_Tests.cs
@@ -145,13 +145,38 @@ namespace Microsoft.Build.Tasks.UnitTests
             Assert.Equal(mixedcaseHash, lowercaseHash);
         }
 
-        private string ExecuteHashTask(ITaskItem[] items, bool ignoreCase = false)
+        [Fact]
+        public void HashTaskPathMapMakesHashLocationIndependent()
+        {
+            // Identical inputs built under two different roots hash differently without a path map...
+            ITaskItem[] underRootA = [new TaskItem(@"C:\rootA\src\a.cs"), new TaskItem(@"C:\rootA\obj\ref.dll")];
+            ITaskItem[] underRootB = [new TaskItem(@"C:\rootB\src\a.cs"), new TaskItem(@"C:\rootB\obj\ref.dll")];
+
+            Assert.NotEqual(ExecuteHashTask(underRootA), ExecuteHashTask(underRootB));
+
+            // ...but converge once each root is mapped to the same deterministic prefix.
+            string hashA = ExecuteHashTask(underRootA, pathMap: @"C:\rootA\=/_/");
+            string hashB = ExecuteHashTask(underRootB, pathMap: @"C:\rootB\=/_/");
+            Assert.Equal(hashA, hashB);
+        }
+
+        [Fact]
+        public void HashTaskEmptyPathMapIsUnchanged()
+        {
+            // An empty path map must not alter the legacy hash, so enabling the feature is opt-in.
+            ITaskItem[] items = [new TaskItem("Item1"), new TaskItem("Item2")];
+            Assert.Equal(ExecuteHashTask(items), ExecuteHashTask(items, pathMap: ""));
+            Assert.Equal(ExecuteHashTask(items), ExecuteHashTask(items, pathMap: null));
+        }
+
+        private string ExecuteHashTask(ITaskItem[] items, bool ignoreCase = false, string pathMap = null)
         {
             var hashTask = new Hash
             {
                 BuildEngine = new MockEngine(),
                 ItemsToHash = items,
-                IgnoreCase = ignoreCase
+                IgnoreCase = ignoreCase,
+                PathMap = pathMap
             };
 
             Assert.True(hashTask.Execute());

--- a/src/Tasks.UnitTests/Hash_Tests.cs
+++ b/src/Tasks.UnitTests/Hash_Tests.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.IO;
 using System.Linq;
 using Microsoft.Build.Framework;
 using Microsoft.Build.UnitTests;
@@ -148,15 +149,22 @@ namespace Microsoft.Build.Tasks.UnitTests
         [Fact]
         public void HashTaskPathMapMakesHashLocationIndependent()
         {
-            // Identical inputs built under two different roots hash differently without a path map...
-            ITaskItem[] underRootA = [new TaskItem(@"C:\rootA\src\a.cs"), new TaskItem(@"C:\rootA\obj\ref.dll")];
-            ITaskItem[] underRootB = [new TaskItem(@"C:\rootB\src\a.cs"), new TaskItem(@"C:\rootB\obj\ref.dll")];
+            // Paths use the host's native separator: TaskItem normalizes item specs to native
+            // separators (backslashes become forward slashes on Unix), and a real build derives both
+            // $(PathMap) and @(Compile) on the same OS, so the path map prefixes match the items.
+            string sep = Path.DirectorySeparatorChar.ToString();
+            string rootA = Path.DirectorySeparatorChar == '\\' ? @"C:\rootA" : "/rootA";
+            string rootB = Path.DirectorySeparatorChar == '\\' ? @"C:\rootB" : "/rootB";
 
+            ITaskItem[] underRootA = [new TaskItem($"{rootA}{sep}src{sep}a.cs"), new TaskItem($"{rootA}{sep}obj{sep}ref.dll")];
+            ITaskItem[] underRootB = [new TaskItem($"{rootB}{sep}src{sep}a.cs"), new TaskItem($"{rootB}{sep}obj{sep}ref.dll")];
+
+            // Identical inputs built under two different roots hash differently without a path map...
             Assert.NotEqual(ExecuteHashTask(underRootA), ExecuteHashTask(underRootB));
 
             // ...but converge once each root is mapped to the same deterministic prefix.
-            string hashA = ExecuteHashTask(underRootA, pathMap: @"C:\rootA\=/_/");
-            string hashB = ExecuteHashTask(underRootB, pathMap: @"C:\rootB\=/_/");
+            string hashA = ExecuteHashTask(underRootA, pathMap: $"{rootA}{sep}=/_/");
+            string hashB = ExecuteHashTask(underRootB, pathMap: $"{rootB}{sep}=/_/");
             Assert.Equal(hashA, hashB);
         }
 

--- a/src/Tasks/Hash.cs
+++ b/src/Tasks/Hash.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections.Generic;
+using System.IO;
 using System.Security.Cryptography;
 using System.Text;
 using Microsoft.Build.Framework;
@@ -49,6 +51,15 @@ namespace Microsoft.Build.Tasks
         public bool IgnoreCase { get; set; }
 
         /// <summary>
+        /// Optional path map, in the same "from=to,from2=to2" form the compiler accepts for <c>/pathmap</c>.
+        /// When set, each mapping is applied (as a path-prefix replacement) to every item before it is hashed.
+        /// This makes the hash independent of absolute, machine- or checkout-location-specific paths, matching
+        /// the determinism the compiler already applies to its own output. When empty (the default) the task
+        /// behaves exactly as before, so enabling it is opt-in for the caller.
+        /// </summary>
+        public string PathMap { get; set; }
+
+        /// <summary>
         /// Hash of the ItemsToHash ItemSpec.
         /// </summary>
         [Output]
@@ -62,6 +73,9 @@ namespace Microsoft.Build.Tasks
         {
             if (ItemsToHash?.Length > 0)
             {
+                // Parse the optional path map once. When empty, items are hashed verbatim (legacy behavior).
+                List<KeyValuePair<string, string>> pathMap = ParsePathMap(PathMap);
+
                 using (var sha = CreateHashAlgorithm())
                 {
                     // Buffer in which bytes of the strings are to be stored until their number reaches the limit size.
@@ -79,7 +93,8 @@ namespace Microsoft.Build.Tasks
                         int shaBufferPosition = 0;
                         for (int i = 0; i < ItemsToHash.Length; i++)
                         {
-                            string itemSpec = IgnoreCase ? ItemsToHash[i].ItemSpec.ToUpperInvariant() : ItemsToHash[i].ItemSpec;
+                            string mappedItemSpec = NormalizePathPrefix(ItemsToHash[i].ItemSpec, pathMap);
+                            string itemSpec = IgnoreCase ? mappedItemSpec.ToUpperInvariant() : mappedItemSpec;
 
                             // Slice the itemSpec string into chunks of reasonable size and add them to sha buffer.
                             for (int itemSpecPosition = 0; itemSpecPosition < itemSpec.Length; itemSpecPosition += MaxInputChunkLength)
@@ -127,6 +142,154 @@ namespace Microsoft.Build.Tasks
         private HashAlgorithm CreateHashAlgorithm()
         {
             return SHA256.Create();
+        }
+
+        /// <summary>
+        /// Parses a "from=to,from2=to2" path map (the same value the compiler receives via /pathmap) into
+        /// prefix-replacement pairs, ordered longest key first so the most specific prefix wins. Returns an
+        /// empty list when there is nothing to apply. Kept in sync with the compiler's path-map parsing
+        /// (Microsoft.CodeAnalysis.CommandLineParser.ParsePathMap / SortPathMap) so the hashed paths match
+        /// the paths the compiler produces.
+        /// </summary>
+        private static List<KeyValuePair<string, string>> ParsePathMap(string pathMap)
+        {
+            var result = new List<KeyValuePair<string, string>>();
+            if (string.IsNullOrEmpty(pathMap))
+            {
+                return result;
+            }
+
+            foreach (var kEqualsV in SplitWithDoubledSeparatorEscaping(pathMap, ','))
+            {
+                if (kEqualsV.Length == 0)
+                {
+                    continue;
+                }
+
+                var kv = SplitWithDoubledSeparatorEscaping(kEqualsV, '=');
+                if (kv.Length != 2)
+                {
+                    continue;
+                }
+
+                var from = kv[0];
+                var to = kv[1];
+                if (from.Length == 0 || to.Length == 0)
+                {
+                    continue;
+                }
+
+                result.Add(new KeyValuePair<string, string>(EnsureTrailingSeparator(from), EnsureTrailingSeparator(to)));
+            }
+
+            result.Sort((x, y) => -x.Key.Length.CompareTo(y.Key.Length));
+            return result;
+        }
+
+        /// <summary>
+        /// Kept in sync with Microsoft.CodeAnalysis.CommandLineParser.SplitWithDoubledSeparatorEscaping.
+        /// </summary>
+        private static string[] SplitWithDoubledSeparatorEscaping(string str, char separator)
+        {
+            if (str.Length == 0)
+            {
+                return Array.Empty<string>();
+            }
+
+            var result = new List<string>();
+            var part = new StringBuilder();
+
+            int i = 0;
+            while (i < str.Length)
+            {
+                char c = str[i++];
+                if (c == separator)
+                {
+                    if (i < str.Length && str[i] == separator)
+                    {
+                        i++;
+                    }
+                    else
+                    {
+                        result.Add(part.ToString());
+                        part.Clear();
+                        continue;
+                    }
+                }
+
+                part.Append(c);
+            }
+
+            result.Add(part.ToString());
+            return result.ToArray();
+        }
+
+        /// <summary>
+        /// Kept in sync with Roslyn.Utilities.PathUtilities.EnsureTrailingSeparator.
+        /// </summary>
+        private static string EnsureTrailingSeparator(string s)
+        {
+            if (s.Length == 0 || s[s.Length - 1] == '/' || s[s.Length - 1] == '\\')
+            {
+                return s;
+            }
+
+            // Use the existing slashes in the path, if they're consistent.
+            bool hasSlash = s.IndexOf('/') >= 0;
+            bool hasBackslash = s.IndexOf('\\') >= 0;
+            if (hasSlash && !hasBackslash)
+            {
+                return s + '/';
+            }
+            else if (!hasSlash && hasBackslash)
+            {
+                return s + '\\';
+            }
+            else
+            {
+                // If there are no slashes or they are inconsistent, use the current platform's slash.
+                return s + Path.DirectorySeparatorChar;
+            }
+        }
+
+        /// <summary>
+        /// Applies the first matching path-prefix mapping to <paramref name="filePath"/>. Kept in sync with
+        /// Roslyn.Utilities.PathUtilities.NormalizePathPrefix. Comparison is ordinal because the compiler
+        /// expects consistent capitalization for path-map keys.
+        /// </summary>
+        private static string NormalizePathPrefix(string filePath, List<KeyValuePair<string, string>> pathMap)
+        {
+            if (pathMap.Count == 0 || string.IsNullOrEmpty(filePath))
+            {
+                return filePath;
+            }
+
+            foreach (var kv in pathMap)
+            {
+                var oldPrefix = kv.Key;
+                if (!(oldPrefix?.Length > 0))
+                {
+                    continue;
+                }
+
+                // oldPrefix always ends with a path separator, so a prefix match cannot be a partial segment
+                // (e.g. map /goo=/bar does not match /goooo).
+                if (filePath.StartsWith(oldPrefix, StringComparison.Ordinal))
+                {
+                    var replacementPrefix = kv.Value;
+                    var replacement = replacementPrefix + filePath.Substring(oldPrefix.Length);
+
+                    // Normalize the path separators if they are used uniformly in the replacement prefix.
+                    bool hasSlash = replacementPrefix.IndexOf('/') >= 0;
+                    bool hasBackslash = replacementPrefix.IndexOf('\\') >= 0;
+                    return
+                        (hasSlash && !hasBackslash) ? replacement.Replace('\\', '/') :
+                        (hasBackslash && !hasSlash) ? replacement.Replace('/', '\\') :
+                        replacement;
+                }
+            }
+
+            return filePath;
         }
 
         /// <summary>

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -3870,13 +3870,32 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <CoreCompileCache Include="$(DefineConstants)" />
       <CoreCompileCache Include="$(LangVersion)" />
       <CoreCompileCache Include="$(Deterministic)" />
-      <CoreCompileCache Include="$(PathMap)" />
+      <!--
+        Under DeterministicSourcePaths the PathMap is derived from SourceRoot and each key is an
+        absolute checkout path, so hashing the raw property would reintroduce the location
+        dependence that the mapping below removes. The mapping's effect on the compilation is
+        already captured by the mapped @(Compile)/@(ReferencePath) entries, so the raw property is
+        only hashed in the legacy (non-deterministic) case.
+      -->
+      <CoreCompileCache Include="$(PathMap)" Condition="'$(DeterministicSourcePaths)' != 'true'" />
       <CoreCompileCache Include="@(_CoreCompileResourceInputs)"/>
     </ItemGroup>
 
+    <!--
+      When the compiler is already producing location-independent output (DeterministicSourcePaths), apply the
+      same PathMap to the hashed inputs so this incremental cache is likewise independent of the checkout
+      location. This lets the compile stay up to date when identical sources are built under a different root
+      (for example a cache seeded from another machine/agent). Empty by default, so the hash is unchanged for
+      normal builds.
+    -->
+    <PropertyGroup>
+      <_CoreCompileDependencyCachePathMap Condition="'$(DeterministicSourcePaths)' == 'true'">$(PathMap)</_CoreCompileDependencyCachePathMap>
+    </PropertyGroup>
+
     <Hash
       ItemsToHash="@(CoreCompileCache)"
-      IgnoreCase="$([MSBuild]::ValueOrDefault(`$(CoreCompileCacheIgnoreCase)`, `true`))">
+      IgnoreCase="$([MSBuild]::ValueOrDefault(`$(CoreCompileCacheIgnoreCase)`, `true`))"
+      PathMap="$(_CoreCompileDependencyCachePathMap)">
       <Output TaskParameter="HashResult" PropertyName="CoreCompileDependencyHash" />
     </Hash>
 


### PR DESCRIPTION
> [!NOTE]
> **Prototype / RFC — not requesting merge yet.** This is part of the 1ES build-speedup effort and is opened as a draft to gather expert feedback on the approach. See the "Open questions" below.

## Motivation

We are prototyping a content-addressed, cross-machine build cache (part of the 1ES build-speedup effort). For a cache to hit across different agents/checkout locations, a project built from identical sources under a *different repository root* must produce identical incremental state — otherwise every agent re-does work the cache should let it skip.

Today `_GenerateCompileDependencyCache` writes `CoreCompileInputs.cache` as `Hash(@(Compile) + @(ReferencePath) + $(DefineConstants) + $(LangVersion) + $(Deterministic) + $(PathMap) + @(_CoreCompileResourceInputs))`. Three of those inputs embed the absolute checkout path (the compile item paths, the reference paths, and `$(PathMap)` itself), so an otherwise-identical build under a different root produces a different hash and needlessly invalidates the compile — even when the compiler is already producing location-independent output via `/pathmap`.

## Change

Add an optional `PathMap` input to the `Hash` task that applies the compiler's own path mapping (prefix replacement) to each hashed item, and pass `$(PathMap)` from `_GenerateCompileDependencyCache` **only when `$(DeterministicSourcePaths)` is true**.

- The parameter is **empty by default**, so the hash and behavior are **unchanged** for normal builds — this is opt-in, not a breaking change.
- Because the map is applied per item and rewrites only a leading prefix, the raw `$(PathMap)` property (which embeds every root mid-string) is dropped from the hash under `DeterministicSourcePaths`; its effect is already captured by the mapped compile inputs.
- The path-map parsing/normalization mirrors the compiler's own logic (`CommandLineParser.ParsePathMap` / `PathUtilities.NormalizePathPrefix`).

## Validation

- New unit tests: identical inputs under two roots hash differently without a map and converge once each root maps to the same deterministic prefix; an empty/null map reproduces the legacy hash.
- Verified end-to-end in a composed SDK (this change + the sibling dotnet/sdk change): a cold-seeded cross-root build skips `CoreCompile`.

## Open questions for reviewers

1. Is `_GenerateCompileDependencyCache` the right layer for this, or would you prefer it elsewhere?
2. The `Hash` task now carries a copy of the compiler's path-map parsing helpers. There are sibling copies in dotnet/sdk and dotnet/roslyn. **Suggestions for a shared, non-duplicated home welcome** — given MSBuild sits below Roslyn in the dependency graph and can't reference `Microsoft.CodeAnalysis`.
3. Any concerns with gating on `$(DeterministicSourcePaths)` as the opt-in signal?
