### PR TITLE
[vs17.14] Remove the ConfigurationManager binding redirect

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,7 +2,7 @@
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the MIT license. See License.txt in the project root for full license information. -->
 <Project>
   <PropertyGroup>
-    <VersionPrefix>17.14.57</VersionPrefix>
+    <VersionPrefix>17.14.58</VersionPrefix>
     <DotNetFinalVersionKind>release</DotNetFinalVersionKind>
     <PackageValidationBaselineVersion>17.13.9</PackageValidationBaselineVersion>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,7 +2,7 @@
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the MIT license. See License.txt in the project root for full license information. -->
 <Project>
   <PropertyGroup>
-    <VersionPrefix>17.14.53</VersionPrefix>
+    <VersionPrefix>17.14.54</VersionPrefix>
     <DotNetFinalVersionKind>release</DotNetFinalVersionKind>
     <PackageValidationBaselineVersion>17.13.9</PackageValidationBaselineVersion>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>

--- a/src/MSBuild/app.amd64.config
+++ b/src/MSBuild/app.amd64.config
@@ -239,11 +239,6 @@
           <codeBase version="10.0.0.8" href="..\System.Threading.Tasks.Dataflow.dll"/>
         </dependentAssembly>
         <dependentAssembly>
-          <assemblyIdentity name="System.Configuration.ConfigurationManager" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-          <bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-          <codeBase version="10.0.0.8" href="..\System.Configuration.ConfigurationManager.dll"/>
-        </dependentAssembly>
-        <dependentAssembly>
           <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
           <bindingRedirect oldVersion="0.0.0.0-4.2.4.0" newVersion="4.2.4.0" />
           <codeBase version="4.2.4.0" href="..\System.Threading.Tasks.Extensions.dll"/>

--- a/src/MSBuild/app.config
+++ b/src/MSBuild/app.config
@@ -113,10 +113,6 @@
           <bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
         </dependentAssembly>
         <dependentAssembly>
-          <assemblyIdentity name="System.Configuration.ConfigurationManager" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-          <bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
-        </dependentAssembly>
-        <dependentAssembly>
           <assemblyIdentity name="System.Threading.Channels" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
           <bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
         </dependentAssembly>


### PR DESCRIPTION
Fixes #14404

## Context

`MSBuild.exe.config` redirects `System.Configuration.ConfigurationManager` to `10.0.0.8`, and the amd64/arm64 config adds a `codeBase` pointing at `MSBuild\Current\Bin\System.Configuration.ConfigurationManager.dll`. That assembly is not in `Microsoft.Build.vsix`, so an in-proc task that carries its own ConfigurationManager has its bind hijacked to a file that does not exist and fails with `FileNotFoundException`. Regression from #14127 (17.14.40 -> 17.14.51).

The redirect is not needed by MSBuild. On .NET Framework the `System.Configuration.ConfigurationManager` reference assembly only type-forwards into the GAC's `System.Configuration`, so the shipped binaries reference `System.Configuration, Version=4.0.0.0` and never bind to the package assembly:

```
Microsoft.Build.dll                          -> System.Configuration 4.0.0.0
Microsoft.Build.Framework.dll                -> (none)
Microsoft.Build.Utilities.Core.dll           -> (none)
Microsoft.Build.Tasks.Core.dll               -> (none)
MSBuild.exe                                  -> (none)
System.Configuration.ConfigurationManager.dll -> System.Configuration 4.0.0.0
```

This is the alternative to #14496, which instead added the missing assembly to the VSIX payload.

## Changes Made

- Remove the `System.Configuration.ConfigurationManager` `dependentAssembly` entry from `src/MSBuild/app.config` and `src/MSBuild/app.amd64.config` (redirect + `codeBase`), leaving a comment explaining why there is none.
- Bump the servicing version to 17.14.54.

Task-local `System.Configuration.ConfigurationManager` binds now resolve the way they did before 17.14.51.

## Testing

- `./build.cmd -v quiet /p:RunAnalyzers=false` — `ValidateMSBuildPackageDependencyVersions` passes for x86, x64 and arm64. The only failure is the pre-existing local-only arcade OptProf `GenerateTrainingInputFiles` error, which reproduces unchanged on the unmodified base commit.
- Verified the generated `MSBuild.exe.config` for all three platforms no longer contains a ConfigurationManager `dependentAssembly` and that the generated `NuGetFrameworkWrapper.redirects.cs` (which mirrors these redirects into the task AppDomain config) no longer contains one either.

