### PR TITLE
Add vs18.10 to merge-flow config; retire vs18.7

### DIFF
--- a/.config/git-merge-flow-config.jsonc
+++ b/.config/git-merge-flow-config.jsonc
@@ -27,20 +27,21 @@
         "vs18.0": {
             "MergeToBranch": "vs18.6"
         },
-        // Automate opening PRs to merge msbuild's vs18.6 (VS, SDK 10.0.3xx) into vs18.7 (VS)
+        // Automate opening PRs to merge msbuild's vs18.6 (VS, SDK 10.0.3xx) into vs18.8 (VS)
+        // vs18.7 (VS-only) retired 2026-07: VS 18.7 out of support (oldest serviced VS is 18.8 on rel/oobstable) and no SDK band is paired with it.
         "vs18.6": {
-            "MergeToBranch": "vs18.7"
-        },
-        // Automate opening PRs to merge msbuild's vs18.7 (VS) into vs18.8 (VS)
-        "vs18.7": {
             "MergeToBranch": "vs18.8"
         },
         // Automate opening PRs to merge msbuild's vs18.8 (VS) into vs18.9 (VS, SDK 10.0.4xx)
         "vs18.8": {
             "MergeToBranch": "vs18.9"
         },
-        // Automate opening PRs to merge msbuild's vs18.9 (VS, SDK 10.0.4xx) into main (VS canary, SDK main & next-feature-band)
+        // Automate opening PRs to merge msbuild's vs18.9 (VS, SDK 10.0.4xx) into vs18.10 (VS)
         "vs18.9": {
+            "MergeToBranch": "vs18.10"
+        },
+        // Automate opening PRs to merge msbuild's vs18.10 (VS) into main (VS canary, SDK main & next-feature-band)
+        "vs18.10": {
             "MergeToBranch": "main"
         }
     }


### PR DESCRIPTION
Phase 1.3 of the [18.10 release checklist](https://github.com/dotnet/msbuild/issues/14562).

### Changes Made

**1.3a — add `vs18.10` to the chain.** Inserted between `vs18.9` and `main` so forward-merge PRs keep flowing into the new release branch.

**1.3b — retire `vs18.7`.** Removed its entry and rewired `vs18.6 → vs18.8`.

### Retirement rationale

The checklist rule is that a branch retires only when **both** its SDK and VS lifecycles say it is out of support.

| Branch | Paired SDK band | SDK support | VS support | Verdict |
|---|---|---|---|---|
| `vs17.12` | 9.0.1xx | through **Nov '26** | VS 17.12 ended 14 Jul '26 | **Keep** — SDK still supported |
| `vs18.6` | 10.0.3xx | through **Aug '26** | out of support | **Keep** — SDK supported ~1 more month |
| `vs18.7` | *none (VS-only)* | n/a | out of support | **Retire** |

`vs18.7` is a VS-only branch with no paired SDK band, so it retires purely on the VS lifecycle. The oldest still-serviced VS version is 18.8 (`rel/oobstable` = 18.8.3 per the [VS Dates wiki](https://dev.azure.com/devdiv/DevDiv/_wiki/wikis/DevDiv.wiki/49807/VS-Dates)), which matches the checklist's `THIS_RELEASE - 3` rule of thumb.

SDK band support dates are from the [.NET SDK / MSBuild / VS versioning lifecycle table](https://learn.microsoft.com/en-us/dotnet/core/porting/versioning-sdk-msbuild-vs#lifecycle).

`vs18.6` is the expected retirement candidate for the 18.11 release, once 10.0.3xx goes out of support in Aug '26.

### Resulting chain

```
vs16.11 -> vs17.8 -> vs17.11 -> vs17.12 -> vs17.14 -> vs18.0
        -> vs18.6 -> vs18.8 -> vs18.9 -> vs18.10 -> main
```

### Testing

Config-only change. Verified the file still parses as JSONC after comment stripping, that the chain walks unbroken from `vs16.11` to `main`, and that no entry is orphaned (every entry except the head is the merge target of exactly one other entry).

Branch `vs18.10` was created at c88db8eb054510123cf4511ae3398225099a598f (HEAD of `main` at snap time) in step 1.1, so every branch named here exists.
