### PR TITLE
Scope .NET TaskHost handshake leniency to architecture

### DIFF
--- a/src/Build.UnitTests/BackEnd/NodeEndpointOutOfProcBase_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/NodeEndpointOutOfProcBase_Tests.cs
@@ -72,6 +72,62 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
                 expectedOptions: (int)BaseNet,
                 receivedOptions: (int)BaseNet).ShouldBeFalse();
         }
+
+        [Fact]
+        public void NonSidecarParent_SidecarTaskHost_NotTolerated()
+        {
+            // NodeReuse is what separates a long-lived sidecar TaskHost from one that exits with
+            // the build. A parent that did not ask for a sidecar must not be admitted to one just
+            // because it omitted its architecture bit, or it would take the sidecar over and later
+            // return it to the global reconnectable pool.
+            NodeEndpointOutOfProcBase.IsAllowedBitnessMismatch(
+                expectedOptions: (int)(BaseNet | HandshakeOptions.NodeReuse | HandshakeOptions.X64),
+                receivedOptions: (int)BaseNet).ShouldBeFalse();
+        }
+
+        [Fact]
+        public void SidecarParent_NonSidecarTaskHost_NotTolerated()
+        {
+            NodeEndpointOutOfProcBase.IsAllowedBitnessMismatch(
+                expectedOptions: (int)(BaseNet | HandshakeOptions.X64),
+                receivedOptions: (int)(BaseNet | HandshakeOptions.NodeReuse)).ShouldBeFalse();
+        }
+
+        [Fact]
+        public void SidecarParent_SidecarTaskHost_ArchitectureStillTolerated()
+        {
+            // Scoping the tolerance to architecture must not break the case it exists for.
+            NodeEndpointOutOfProcBase.IsAllowedBitnessMismatch(
+                expectedOptions: (int)(BaseNet | HandshakeOptions.NodeReuse | HandshakeOptions.X64),
+                receivedOptions: (int)(BaseNet | HandshakeOptions.NodeReuse)).ShouldBeTrue();
+        }
+
+        [Fact]
+        public void DifferingLowPriority_NotTolerated()
+        {
+            NodeEndpointOutOfProcBase.IsAllowedBitnessMismatch(
+                expectedOptions: (int)(BaseNet | HandshakeOptions.LowPriority | HandshakeOptions.X64),
+                receivedOptions: (int)BaseNet).ShouldBeFalse();
+        }
+
+        [Fact]
+        public void DifferingAdministrator_NotTolerated()
+        {
+            NodeEndpointOutOfProcBase.IsAllowedBitnessMismatch(
+                expectedOptions: (int)(BaseNet | HandshakeOptions.Administrator | HandshakeOptions.X64),
+                receivedOptions: (int)BaseNet).ShouldBeFalse();
+        }
+
+        [Fact]
+        public void HandshakeVersionInUpperByte_IsIgnored()
+        {
+            // The upper byte carries the handshake version and must not affect the comparison.
+            const int VersionBits = 13 << 24;
+
+            NodeEndpointOutOfProcBase.IsAllowedBitnessMismatch(
+                expectedOptions: (int)(BaseNet | HandshakeOptions.NodeReuse | HandshakeOptions.X64) | VersionBits,
+                receivedOptions: (int)(BaseNet | HandshakeOptions.NodeReuse)).ShouldBeTrue();
+        }
     }
 }
 

--- a/src/Build.UnitTests/BackEnd/NodeEndpointOutOfProcBase_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/NodeEndpointOutOfProcBase_Tests.cs
@@ -67,10 +67,31 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
         public void NoArchBitWorkerNode_NoArchBitTaskHost_NotTolerated()
         {
             // The tolerance is scoped to x64/arm64 TaskHost nodes; an x86-equivalent (no arch bit)
-            // TaskHost node must not silently accept any handshake.
+            // TaskHost node must not silently accept any handshake. Such a parent and TaskHost node
+            // agree exactly anyway, so IsHandshakePartValid accepts them before reaching here.
             NodeEndpointOutOfProcBase.IsAllowedBitnessMismatch(
                 expectedOptions: (int)BaseNet,
                 receivedOptions: (int)BaseNet).ShouldBeFalse();
+        }
+
+        [Fact]
+        public void X64WorkerNode_X86TaskHost_NotTolerated()
+        {
+            // x86 is encoded as the absence of X64/Arm64 rather than a flag of its own, so an
+            // x86 TaskHost node expects no architecture bit. A parent that positively declared x64
+            // is a genuine bitness mismatch and must be rejected: the tolerance only ever widens
+            // what an x64/arm64 TaskHost node accepts, never what an x86 one does.
+            NodeEndpointOutOfProcBase.IsAllowedBitnessMismatch(
+                expectedOptions: (int)BaseNet,
+                receivedOptions: (int)(BaseNet | HandshakeOptions.X64)).ShouldBeFalse();
+        }
+
+        [Fact]
+        public void Arm64WorkerNode_X86TaskHost_NotTolerated()
+        {
+            NodeEndpointOutOfProcBase.IsAllowedBitnessMismatch(
+                expectedOptions: (int)BaseNet,
+                receivedOptions: (int)(BaseNet | HandshakeOptions.Arm64)).ShouldBeFalse();
         }
 
         [Fact]

--- a/src/Shared/NodeEndpointOutOfProcBase.cs
+++ b/src/Shared/NodeEndpointOutOfProcBase.cs
@@ -612,6 +612,14 @@ namespace Microsoft.Build.BackEnd
         /// True cross-arch mismatches (e.g. worker node sent X64 but TaskHost node expects
         /// Arm64, or vice versa) remain rejected.
         ///
+        /// The tolerance is scoped to architecture: every non-architecture flag must still
+        /// match. Those flags carry the node's identity, most importantly <see cref="HandshakeOptions.NodeReuse"/>,
+        /// which is what separates a long-lived sidecar TaskHost from a TaskHost that exits
+        /// with the build. Tolerating a difference there would let a process that is not the
+        /// sidecar's owner connect to it, take it over for its own build, and afterwards
+        /// return it to the global reconnectable pool, defeating the sidecar's lifetime
+        /// guarantees.
+        ///
         /// The lower 24 bits (mask 0x00FFFFFF) carry the HandshakeOptions flags; the upper
         /// byte carries the handshake version and is ignored here.
         /// </summary>
@@ -619,6 +627,13 @@ namespace Microsoft.Build.BackEnd
         {
             var expectedNodeType = (HandshakeOptions)(expectedOptions & 0x00FFFFFF);
             var receivedNodeType = (HandshakeOptions)(receivedOptions & 0x00FFFFFF);
+            const HandshakeOptions ArchitectureFlags = HandshakeOptions.X64 | HandshakeOptions.Arm64;
+
+            // Only the architecture may differ; everything else identifies the node and must match.
+            if ((expectedNodeType & ~ArchitectureFlags) != (receivedNodeType & ~ArchitectureFlags))
+            {
+                return false;
+            }
 
             // not X64 or Arm64 means the wire-form architecture is x86 (or no arch bit).
             bool receivedIsX86 = !Handshake.IsHandshakeOptionEnabled(receivedNodeType, HandshakeOptions.X64) &&


### PR DESCRIPTION
Part of the node-ownership work specced in #14508, but standalone: it depends on nothing else in that stack and is a correctness fix on its own.

## The bug

`IsAllowedBitnessMismatch` exists so a parent that cannot describe the architecture of the SDK TaskHost it launches can still connect to it. A .NET Framework parent launching a `Runtime="NET"` TaskHost is the motivating case, and to make it work the parent deliberately suppresses its own architecture bit.

The tolerance was never scoped to architecture. It returned true whenever the parent sent no architecture bit and the child expected x64/arm64 — **regardless of every other flag in the options word**:

```csharp
bool receivedIsX86 = !X64 && !Arm64;
return receivedIsX86 && (expectedIsX64 || expectedIsArm64);
```

So any parent that suppressed its architecture bit also matched a TaskHost that differed from it in identity flags.

That matters most for `NodeReuse`, because `NodeReuse` is the *only* thing separating a long-lived sidecar TaskHost from one that exits with the build:

- `effectiveNodeReuse = EnableNodeReuse && _useSidecarTaskHost` (`TaskHostTask.cs`)
- that flows into `GetHandshakeOptions(taskHost: true, nodeReuse: effectiveNodeReuse, ...)`, which sets `HandshakeOptions.NodeReuse`
- the resulting word is both the in-process pool key and the wire handshake

Nothing else separates them for this connection: a sidecar is a .NET TaskHost, and .NET TaskHost handshakes deliberately neutralize the file-version components with the `NetTaskHostHandshakeVersion = 99` sentinel, while the salt is the tools directory, which coincides whenever a parent resolves the same installed SDK.

**Consequence:** a parent that never asked for a sidecar could be admitted to one, take it over for its own build, and afterwards return it to the global reconnectable pool. `LowPriority` and `Administrator` were ignored the same way.

## The fix

Require every non-architecture flag to match; allow divergence only in `X64`/`Arm64`.

The case the tolerance exists for is unaffected — those parents differ from the TaskHost only in architecture, which is exactly what stays tolerated.

## Compatibility

The blast radius is flags that should already agree between a matched parent and child:

- `NodeReuse` and `LowPriority` are handed to the child as launch arguments by the same parent that computed them
- `Administrator` is derived on both sides from elevation the child inherits
- `CLR2` / `NET` / `TaskHost` are structural

This is nonetheless the one change in the stack that can surface as MSB4216, so it is landing on its own, ahead of the lifetime work, and carries a cross-version check of a `Runtime="NET"` `UsingTask` in both directions across the 10.0.3xx boundary.

## Tests

Six added to `NodeEndpointOutOfProcBase_Tests`. Four are load-bearing — verified failing against the unpatched method and passing after:

- `NonSidecarParent_SidecarTaskHost_NotTolerated`
- `SidecarParent_NonSidecarTaskHost_NotTolerated`
- `DifferingLowPriority_NotTolerated`
- `DifferingAdministrator_NotTolerated`

Two are regression guards that must keep passing either way:

- `SidecarParent_SidecarTaskHost_ArchitectureStillTolerated` — the motivating case still connects
- `HandshakeVersionInUpperByte_IsIgnored` — the version byte still does not affect comparison

All 12 tests in the class pass (`net11.0`).

## Why this is separate from the lifetime fix

This does **not** fix #14313 on its own. That leak is a sidecar disconnecting after a build and relisting on its pipe, which only the ownership-lifetime change stops.

The two are complementary and this one is a precondition: once sidecars are owned, an owned sidecar could still be adopted in the window before its owner connects, or by a differently-versioned MSBuild during rollout, if this hole stayed open.
