### PR TITLE
Add Directory.Parse.config to skip unknown attributes/elements during parsing

### DIFF
--- a/documentation/specs/directory-parse-config.md
+++ b/documentation/specs/directory-parse-config.md
@@ -30,11 +30,9 @@ This enables compatibility scenarios where project files may include attributes/
 
 Matching is case-insensitive. Entries with missing or empty `Element`/`Name` attributes are silently ignored. Unrecognized sections or elements are ignored.
 
-For more details on `Element`:
+### Valid `IgnoreAttributes` Elements
 
-### Valid Attribute Names
-
-For attributes the `Name` can be the name of the following MSBuild elements:
+The `Element` attribute in `<IgnoreAttributes>` entries can be:
 - `Target`
 - `PropertyGroup`
 - `ItemGroup`
@@ -47,19 +45,24 @@ For attributes the `Name` can be the name of the following MSBuild elements:
 - `Otherwise`
 - `ProjectExtensions`
 
-Although the following are not elements, they can be specified to target attributes on these types of elements:
-- `Property`: attributes on elements inside a `PropertyGroup`
-- `Item`: attributes on elements inside a `ItemGroup`
-- `Metadata`: attributes on elements inside an `Item` or `ItemDefinitionGroup`
-- `Parameter`: attributes on elements in a ParameterGroup inside a UsingTask
-- `UsingTaskBody`: attributes on Task elements inside a UsingTask
+Generic names for dynamically-named elements:
 
-### Valid Element Names
+| Generic Name | Applies To |
+|---|---|
+| `Property` | Any property element (child of `PropertyGroup`) |
+| `Item` | Any item element (child of `ItemGroup`) |
+| `ItemDefinition` | Any item definition element (child of `ItemDefinitionGroup`) |
+| `Metadata` | Any metadata element (child of an `Item` or `ItemDefinition`) |
+| `Parameter` | Any parameter element in a `ParameterGroup` inside `UsingTask` |
+| `UsingTaskBody` | The `Task` element inside `UsingTask` |
 
-The following names can be specified:
+### Valid `IgnoreChildren` Elements
+
+The `Element` attribute in `<IgnoreChildren>` entries can be:
 - `Project`
 - `Import`
 - `ImportGroup`
+- `Task`
 - `UsingTask`
 - `OnError`
 - `Output`
@@ -67,66 +70,67 @@ The following names can be specified:
 - `When`
 - `Otherwise`
 
-The following cannot be specified since their children are by definition always valid:
+Not applicable (children are free-form by design):
+
 - `Target`
 - `PropertyGroup`
 - `ItemGroup`
+- `ItemDefinitionGroup`
 - `ProjectExtensions`
 
 ## Discovery and Loading
 
-Configuration files are discovered and merged additively:
+Configuration is discovered from two sources:
 
-1. **Global config at build start**
-   - Next to the MSBuild executable
-   - User profile: `%USERPROFILE%\.msbuild\Directory.Parse.config` (Windows) or `$HOME/.msbuild/Directory.Parse.config` (Unix)
-   - Paths listed in `MSBUILD_PARSE_CONFIG`, split using the platform path separator
-   - The startup directory of MSBuild
+1. **`MSBUILD_PARSE_CONFIG` environment variable** — Semicolon-separated (Windows) or colon-separated (Unix) list of config file paths. Always loaded when a `ProjectCollection` is created.
 
-2. **Directory-specific config at evaluation start**
-   - MSBuild walks up from the project file's directory looking for `Directory.Parse.config`
-   - If found and that file was not already loaded globally, it is loaded and merged for that evaluation
+2. **Project directory walk** — The CLI walks up from the target project file's directory looking for `Directory.Parse.config` (same pattern as `Directory.Build.rsp`). Called via `ProjectCollection.LoadParseConfigForStartup(directory)` before any project is loaded.
 
-## Centralized Loading (BuildManager)
+These are merged additively — entries from either source are combined.
 
-In a normal build flow, the main node loads global config once during `BuildManager.BeginBuild()`. The config is:
-- Stored on `BuildParameters.UnknownElementsConfiguration`
-- Serialized to worker nodes via the standard `ITranslatable` mechanism
-- Set on the shared `ProjectRootElementCache`, so parsing uses the same configuration
+## Public API
 
-At evaluation start, MSBuild may merge in one additional `Directory.Parse.config` discovered from the project file's directory walk.
+### `ProjectCollection.LoadParseConfigForStartup(string startingDirectory)`
 
-Users of the `ProjectCollection` API can also set `ProjectCollection.UnknownElementsConfiguration` directly, which flows into `BuildParameters` when builds are started.
+Walks up from `startingDirectory` to find a `Directory.Parse.config`, merges it with the current config, and sets it on the cache. Must be called before loading projects. Call `UnloadParseConfigForStartup()` after the build to restore the previous state.
+
+### `ProjectCollection.UnloadParseConfigForStartup()`
+
+Restores the parse configuration to the state before `LoadParseConfigForStartup` was called.
+
 
 ## Logging
 
-During evaluation, two low-importance messages can be logged to the binary log:
+- **Config files loaded**: Logged at evaluation start (`MessageImportance.Low`). Lists all loaded config file paths.
+- **Config files embedded**: Each loaded config file is logged as a `ProjectImportedEventArgs`, causing the binary logger to embed the file content in the binlog.
+- **Skipped items summary**: Logged after evaluation completes (`MessageImportance.Low`). Lists all skipped attributes/elements with occurrence counts.
 
-- **Config files loaded**: Lists all discovered and loaded config file paths.
-- **Skipped items summary**: Lists all unrecognized attributes/elements that were skipped, with occurrence counts. This is logged after evaluation work has completed so it reflects actual skips from that evaluation.
+## Feature Flag
 
-Example log messages:
-```
-Loaded Directory.Parse.config from: C:\repo\Directory.Parse.config, C:\Users\me\.msbuild\Directory.Parse.config
-Skipped unrecognized items allowed by Directory.Parse.config: Attribute:Target:CustomAttr (2 occurrences); Element:Project:Widget (1 occurrence)
-```
+Set `MSBUILD_DISABLE_PARSE_CONFIG=1` to disable all automatic config loading.
 
 ## Examples
 
-### Allow a custom attribute on Target elements
+### Allow a custom attribute on all Target elements
 
-Directory.Parse.config:
-```
-Attribute:Target:CustomAttr
+```xml
+<ParseConfig>
+  <IgnoreAttributes>
+    <Ignore Element="Target" Name="CustomAttr" />
+  </IgnoreAttributes>
+</ParseConfig>
 ```
 
-This allows `<Target Name="Build" CustomAttr="value">` without error.
+Allows `<Target Name="Build" CustomAttr="value">` without error.
 
 ### Allow a custom child element under Project
 
-Directory.Parse.config:
-```
-Element:Project:ToolConfiguration
+```xml
+<ParseConfig>
+  <IgnoreChildren>
+    <Ignore Element="Project" Name="ToolConfiguration" />
+  </IgnoreChildren>
+</ParseConfig>
 ```
 
-This allows `<ToolConfiguration ... />` as a direct child of `<Project>` without error.
+Allows `<ToolConfiguration ... />` as a direct child of `<Project>` without error.

--- a/documentation/specs/directory-parse-config.md
+++ b/documentation/specs/directory-parse-config.md
@@ -86,26 +86,21 @@ Configuration is discovered from two sources:
 
 1. **`MSBUILD_PARSE_CONFIG` environment variable** — Semicolon-separated (Windows) or colon-separated (Unix) list of config file paths. Always loaded when a `ProjectCollection` is created.
 
-2. **Project directory walk** — The CLI walks up from the target project file's directory looking for `Directory.Parse.config` (same pattern as `Directory.Build.rsp`). Called via `ProjectCollection.LoadParseConfigForStartup(directory)` before any project is loaded.
+2. **Project directory walk** — The CLI walks up from the target project file's directory looking for `Directory.Parse.config` (same pattern as `Directory.Build.rsp`). This is passed as `parseConfigDirectory` to the `ProjectCollection` constructor.
 
 These are merged additively — entries from either source are combined.
 
-## Public API
+## Integration
 
-### `ProjectCollection.LoadParseConfigForStartup(string startingDirectory)`
+The `ProjectCollection` constructor accepts an optional `parseConfigDirectory` parameter. When provided, it walks up from that directory to find a `Directory.Parse.config` and merges it with the environment variable config. XMake passes the project file's directory.
 
-Walks up from `startingDirectory` to find a `Directory.Parse.config`, merges it with the current config, and sets it on the cache. Must be called before loading projects. Call `UnloadParseConfigForStartup()` after the build to restore the previous state.
-
-### `ProjectCollection.UnloadParseConfigForStartup()`
-
-Restores the parse configuration to the state before `LoadParseConfigForStartup` was called.
-
+The `ParserIgnoreConfiguration` property on `ProjectCollection` and `BuildParameters` is `internal`. External hosts that need to configure parse rules should use the constructor parameter or the environment variable.
 
 ## Logging
 
 - **Config files loaded**: Logged at evaluation start (`MessageImportance.Low`). Lists all loaded config file paths.
-- **Config files embedded**: Each loaded config file is logged as a `ProjectImportedEventArgs`, causing the binary logger to embed the file content in the binlog.
-- **Skipped items summary**: Logged after evaluation completes (`MessageImportance.Low`). Lists all skipped attributes/elements with occurrence counts.
+- **Config files embedded**: Each loaded config file is embedded in the binary log archive (visible as an embedded file, not as a project import).
+- **Skipped items summary**: Logged after each evaluation completes (`MessageImportance.Low`). Lists skipped attributes/elements with occurrence counts for that evaluation.
 
 ## Feature Flag
 

--- a/documentation/specs/directory-parse-config.md
+++ b/documentation/specs/directory-parse-config.md
@@ -8,26 +8,29 @@ This enables compatibility scenarios where project files may include attributes/
 
 ## Configuration File Format
 
-`Directory.Parse.config` is a plain text file with one entry per line:
+`Directory.Parse.config` is an XML file:
 
+```xml
+<ParseConfig>
+  <IgnoreAttributes>
+    <Ignore Element="Target" Name="CustomAttr" />
+    <Ignore Element="Property" Name="NewFeatureFlag" />
+  </IgnoreAttributes>
+  <IgnoreChildren>
+    <Ignore Element="Project" Name="CustomElement" />
+    <Ignore Element="Task" Name="CustomChild" />
+  </IgnoreChildren>
+</ParseConfig>
 ```
-# Lines starting with # are comments
-# Empty lines are ignored
 
-# Format: Type:Name:AllowedName
-Attribute:Target:CustomAttr
-Element:Project:CustomElement
-Attribute:PropertyGroup:NewFeatureFlag
-```
+- **Root element**: `<ParseConfig>`
+- **`<IgnoreAttributes>`**: Contains `<Ignore>` entries for attributes to skip. Appears 0 or 1 times.
+- **`<IgnoreChildren>`**: Contains `<Ignore>` entries for child elements to skip. Appears 0 or 1 times.
+- **`<Ignore>`**: Each entry has `Element` (the parent/owner element name) and `Name` (the attribute or child to allow).
 
-- **Type**: Either `Attribute` or `Element` (case-insensitive)
-- **Name**:  `Attribute`: the name/type of the element; `Element`: the name/type of the parent element
-- **AllowedName**: The name of the attribute or child element to allow
+Matching is case-insensitive. Entries with missing or empty `Element`/`Name` attributes are silently ignored. Unrecognized sections or elements are ignored.
 
-Matching is case-insensitive.
-Invalid lines (wrong format, unknown type, wrong number of colons) are silently ignored.
-
-For more details on `Name`:
+For more details on `Element`:
 
 ### Valid Attribute Names
 

--- a/documentation/specs/directory-parse-config.md
+++ b/documentation/specs/directory-parse-config.md
@@ -56,6 +56,8 @@ Generic names for dynamically-named elements:
 | `Parameter` | Any parameter element in a `ParameterGroup` inside `UsingTask` |
 | `UsingTaskBody` | The `Task` element inside `UsingTask` |
 
+Note: `Item` only applies to attributes with leading underscores as any other attributes are interpreted as metadata names.
+
 ### Valid `IgnoreChildren` Elements
 
 The `Element` attribute in `<IgnoreChildren>` entries can be:

--- a/documentation/specs/directory-parse-config.md
+++ b/documentation/specs/directory-parse-config.md
@@ -1,0 +1,129 @@
+# Directory.Parse.config — Ignoring Unexpected Attributes and Elements
+
+## Summary
+
+MSBuild now supports a configuration file (`Directory.Parse.config`) that allows specific unrecognized attributes or child elements to be silently skipped during project parsing, instead of throwing `InvalidProjectFileException` (MSB4066/MSB4067).
+
+This enables compatibility scenarios where project files may include attributes/elements intended for newer MSBuild versions or third-party tools that can still build without those attributes/elements.
+
+## Configuration File Format
+
+`Directory.Parse.config` is a plain text file with one entry per line:
+
+```
+# Lines starting with # are comments
+# Empty lines are ignored
+
+# Format: Type:Name:AllowedName
+Attribute:Target:CustomAttr
+Element:Project:CustomElement
+Attribute:PropertyGroup:NewFeatureFlag
+```
+
+- **Type**: Either `Attribute` or `Element` (case-insensitive)
+- **Name**:  `Attribute`: the name/type of the element; `Element`: the name/type of the parent element
+- **AllowedName**: The name of the attribute or child element to allow
+
+Matching is case-insensitive.
+Invalid lines (wrong format, unknown type, wrong number of colons) are silently ignored.
+
+For more details on `Name`:
+
+### Valid Attribute Names
+
+For attributes the `Name` can be the name of the following MSBuild elements:
+- `Target`
+- `PropertyGroup`
+- `ItemGroup`
+- `Import`
+- `ImportGroup`
+- `UsingTask`
+- `OnError`
+- `Output`
+- `Choose`
+- `Otherwise`
+- `ProjectExtensions`
+
+Although the following are not elements, they can be specified to target attributes on these types of elements:
+- `Property`: attributes on elements inside a `PropertyGroup`
+- `Item`: attributes on elements inside a `ItemGroup`
+- `Metadata`: attributes on elements inside an `Item` or `ItemDefinitionGroup`
+- `Parameter`: attributes on elements in a ParameterGroup inside a UsingTask
+- `UsingTaskBody`: attributes on Task elements inside a UsingTask
+
+### Valid Element Names
+
+The following names can be specified:
+- `Project`
+- `Import`
+- `ImportGroup`
+- `UsingTask`
+- `OnError`
+- `Output`
+- `Choose`
+- `When`
+- `Otherwise`
+
+The following cannot be specified since their children are by definition always valid:
+- `Target`
+- `PropertyGroup`
+- `ItemGroup`
+- `ProjectExtensions`
+
+## Discovery and Loading
+
+Configuration files are discovered and merged additively:
+
+1. **Global config at build start**
+   - Next to the MSBuild executable
+   - User profile: `%USERPROFILE%\.msbuild\Directory.Parse.config` (Windows) or `$HOME/.msbuild/Directory.Parse.config` (Unix)
+   - Paths listed in `MSBUILD_PARSE_CONFIG`, split using the platform path separator
+   - The startup directory of MSBuild
+
+2. **Directory-specific config at evaluation start**
+   - MSBuild walks up from the project file's directory looking for `Directory.Parse.config`
+   - If found and that file was not already loaded globally, it is loaded and merged for that evaluation
+
+## Centralized Loading (BuildManager)
+
+In a normal build flow, the main node loads global config once during `BuildManager.BeginBuild()`. The config is:
+- Stored on `BuildParameters.UnknownElementsConfiguration`
+- Serialized to worker nodes via the standard `ITranslatable` mechanism
+- Set on the shared `ProjectRootElementCache`, so parsing uses the same configuration
+
+At evaluation start, MSBuild may merge in one additional `Directory.Parse.config` discovered from the project file's directory walk.
+
+Users of the `ProjectCollection` API can also set `ProjectCollection.UnknownElementsConfiguration` directly, which flows into `BuildParameters` when builds are started.
+
+## Logging
+
+During evaluation, two low-importance messages can be logged to the binary log:
+
+- **Config files loaded**: Lists all discovered and loaded config file paths.
+- **Skipped items summary**: Lists all unrecognized attributes/elements that were skipped, with occurrence counts. This is logged after evaluation work has completed so it reflects actual skips from that evaluation.
+
+Example log messages:
+```
+Loaded Directory.Parse.config from: C:\repo\Directory.Parse.config, C:\Users\me\.msbuild\Directory.Parse.config
+Skipped unrecognized items allowed by Directory.Parse.config: Attribute:Target:CustomAttr (2 occurrences); Element:Project:Widget (1 occurrence)
+```
+
+## Examples
+
+### Allow a custom attribute on Target elements
+
+Directory.Parse.config:
+```
+Attribute:Target:CustomAttr
+```
+
+This allows `<Target Name="Build" CustomAttr="value">` without error.
+
+### Allow a custom child element under Project
+
+Directory.Parse.config:
+```
+Element:Project:ToolConfiguration
+```
+
+This allows `<ToolConfiguration ... />` as a direct child of `<Project>` without error.

--- a/src/Build.UnitTests/Evaluation/ParserIgnoreConfiguration_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/ParserIgnoreConfiguration_Tests.cs
@@ -9,7 +9,6 @@ using Microsoft.Build.Evaluation;
 using Shouldly;
 using Xunit;
 
-#nullable disable
 
 namespace Microsoft.Build.UnitTests.Evaluation
 {
@@ -127,7 +126,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             string envConfigPath = Path.Combine(_testDir, "env.config");
             File.WriteAllText(envConfigPath, @"<ParseConfig><IgnoreChildren><Ignore Element=""Project"" Name=""CustomThing"" /></IgnoreChildren></ParseConfig>");
 
-            string oldEnv = Environment.GetEnvironmentVariable(ParserIgnoreConfiguration.EnvironmentVariableName);
+            string? oldEnv = Environment.GetEnvironmentVariable(ParserIgnoreConfiguration.EnvironmentVariableName);
             try
             {
                 Environment.SetEnvironmentVariable(ParserIgnoreConfiguration.EnvironmentVariableName, envConfigPath);
@@ -175,7 +174,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             config.CheckSkipAttribute("Target", "Foo");
             config.CheckSkipAttribute("Target", "Foo");
 
-            string summary = config.GetSkippedSummaryMessage();
+            string? summary = config.GetSkippedSummaryMessage();
             summary.ShouldNotBeNull();
             summary.ShouldContain("Attribute:Target:Foo");
             summary.ShouldContain("2 occurrences");

--- a/src/Build.UnitTests/Evaluation/ParserIgnoreConfiguration_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/ParserIgnoreConfiguration_Tests.cs
@@ -13,11 +13,11 @@ using Xunit;
 
 namespace Microsoft.Build.UnitTests.Evaluation
 {
-    public class UnknownElementsConfiguration_Tests : IDisposable
+    public class ParserIgnoreConfiguration_Tests : IDisposable
     {
         private readonly string _testDir;
 
-        public UnknownElementsConfiguration_Tests()
+        public ParserIgnoreConfiguration_Tests()
         {
             _testDir = Path.Combine(Path.GetTempPath(), "MSBuildTest_UnknownElements_" + Guid.NewGuid().ToString("N"));
             Directory.CreateDirectory(_testDir);
@@ -34,7 +34,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         [Fact]
         public void ParsesValidConfigFile()
         {
-            string configPath = Path.Combine(_testDir, UnknownElementsConfiguration.ConfigFileName);
+            string configPath = Path.Combine(_testDir, ParserIgnoreConfiguration.ConfigFileName);
             File.WriteAllText(configPath, @"<ParseConfig>
   <IgnoreAttributes>
     <Ignore Element=""Target"" Name=""Foo"" />
@@ -45,7 +45,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
   </IgnoreChildren>
 </ParseConfig>");
 
-            var config = UnknownElementsConfiguration.LoadFromFile(configPath);
+            var config = ParserIgnoreConfiguration.LoadFromFile(configPath);
 
             config.LoadedConfigFiles.Count.ShouldBe(1);
             config.CheckSkipAttribute("Target", "Foo").ShouldBeTrue();
@@ -56,10 +56,10 @@ namespace Microsoft.Build.UnitTests.Evaluation
         [Fact]
         public void IsCaseInsensitive()
         {
-            string configPath = Path.Combine(_testDir, UnknownElementsConfiguration.ConfigFileName);
+            string configPath = Path.Combine(_testDir, ParserIgnoreConfiguration.ConfigFileName);
             File.WriteAllText(configPath, @"<ParseConfig><IgnoreAttributes><Ignore Element=""Target"" Name=""Foo"" /></IgnoreAttributes></ParseConfig>");
 
-            var config = UnknownElementsConfiguration.LoadFromFile(configPath);
+            var config = ParserIgnoreConfiguration.LoadFromFile(configPath);
 
             config.CheckSkipAttribute("target", "foo").ShouldBeTrue();
             config.CheckSkipAttribute("TARGET", "FOO").ShouldBeTrue();
@@ -69,7 +69,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         [Fact]
         public void IgnoresInvalidEntries()
         {
-            string configPath = Path.Combine(_testDir, UnknownElementsConfiguration.ConfigFileName);
+            string configPath = Path.Combine(_testDir, ParserIgnoreConfiguration.ConfigFileName);
             File.WriteAllText(configPath, @"<ParseConfig>
   <IgnoreAttributes>
     <Ignore Element="""" Name=""Foo"" />
@@ -84,7 +84,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
   </BogusSection>
 </ParseConfig>");
 
-            var config = UnknownElementsConfiguration.LoadFromFile(configPath);
+            var config = ParserIgnoreConfiguration.LoadFromFile(configPath);
 
             config.CheckSkipAttribute("Target", "ValidOne").ShouldBeTrue();
             config.CheckSkipAttribute("Target", "Foo").ShouldBeFalse();
@@ -96,7 +96,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         [Fact]
         public void ReturnsEmptyWhenNoConfigExists()
         {
-            var config = UnknownElementsConfiguration.LoadFromFile(Path.Combine(_testDir, UnknownElementsConfiguration.ConfigFileName));
+            var config = ParserIgnoreConfiguration.LoadFromFile(Path.Combine(_testDir, ParserIgnoreConfiguration.ConfigFileName));
 
             config.LoadedConfigFiles.Count.ShouldBe(0);
             config.CheckSkipAttribute("Target", "Foo").ShouldBeFalse();
@@ -105,16 +105,16 @@ namespace Microsoft.Build.UnitTests.Evaluation
         [Fact]
         public void MergeCombinesEntriesAndDeduplicatesFiles()
         {
-            string configPath = Path.Combine(_testDir, UnknownElementsConfiguration.ConfigFileName);
+            string configPath = Path.Combine(_testDir, ParserIgnoreConfiguration.ConfigFileName);
             File.WriteAllText(configPath, @"<ParseConfig><IgnoreAttributes><Ignore Element=""Target"" Name=""Foo"" /></IgnoreAttributes></ParseConfig>");
 
             string extraConfigPath = Path.Combine(_testDir, "extra.config");
             File.WriteAllText(extraConfigPath, @"<ParseConfig><IgnoreChildren><Ignore Element=""Project"" Name=""CustomThing"" /></IgnoreChildren></ParseConfig>");
 
-            var merged = UnknownElementsConfiguration.Merge(
-                UnknownElementsConfiguration.LoadFromFile(configPath),
-                UnknownElementsConfiguration.LoadFromFile(extraConfigPath));
-            merged = UnknownElementsConfiguration.Merge(merged, UnknownElementsConfiguration.LoadFromFile(configPath));
+            var merged = ParserIgnoreConfiguration.Merge(
+                ParserIgnoreConfiguration.LoadFromFile(configPath),
+                ParserIgnoreConfiguration.LoadFromFile(extraConfigPath));
+            merged = ParserIgnoreConfiguration.Merge(merged, ParserIgnoreConfiguration.LoadFromFile(configPath));
 
             merged.CheckSkipAttribute("Target", "Foo").ShouldBeTrue();
             merged.CheckSkipElement("Project", "CustomThing").ShouldBeTrue();
@@ -127,27 +127,27 @@ namespace Microsoft.Build.UnitTests.Evaluation
             string envConfigPath = Path.Combine(_testDir, "env.config");
             File.WriteAllText(envConfigPath, @"<ParseConfig><IgnoreChildren><Ignore Element=""Project"" Name=""CustomThing"" /></IgnoreChildren></ParseConfig>");
 
-            string oldEnv = Environment.GetEnvironmentVariable(UnknownElementsConfiguration.EnvironmentVariableName);
+            string oldEnv = Environment.GetEnvironmentVariable(ParserIgnoreConfiguration.EnvironmentVariableName);
             try
             {
-                Environment.SetEnvironmentVariable(UnknownElementsConfiguration.EnvironmentVariableName, envConfigPath);
-                var config = UnknownElementsConfiguration.LoadGlobalConfig();
+                Environment.SetEnvironmentVariable(ParserIgnoreConfiguration.EnvironmentVariableName, envConfigPath);
+                var config = ParserIgnoreConfiguration.LoadGlobalConfig();
 
                 config.CheckSkipElement("Project", "CustomThing").ShouldBeTrue();
             }
             finally
             {
-                Environment.SetEnvironmentVariable(UnknownElementsConfiguration.EnvironmentVariableName, oldEnv);
+                Environment.SetEnvironmentVariable(ParserIgnoreConfiguration.EnvironmentVariableName, oldEnv);
             }
         }
 
         [Fact]
         public void RecordsSkippedItems()
         {
-            string configPath = Path.Combine(_testDir, UnknownElementsConfiguration.ConfigFileName);
+            string configPath = Path.Combine(_testDir, ParserIgnoreConfiguration.ConfigFileName);
             File.WriteAllText(configPath, @"<ParseConfig><IgnoreAttributes><Ignore Element=""Target"" Name=""Foo"" /></IgnoreAttributes></ParseConfig>");
 
-            var config = UnknownElementsConfiguration.LoadFromFile(configPath);
+            var config = ParserIgnoreConfiguration.LoadFromFile(configPath);
 
             config.GetSkippedSummaryMessage().ShouldBeNull();
 
@@ -164,12 +164,12 @@ namespace Microsoft.Build.UnitTests.Evaluation
         [MemberData(nameof(AttributeSkipCases))]
         public void AllowedAttributeIsSkipped(string configElement, string configName, string projectXml)
         {
-            string configPath = Path.Combine(_testDir, UnknownElementsConfiguration.ConfigFileName);
+            string configPath = Path.Combine(_testDir, ParserIgnoreConfiguration.ConfigFileName);
             File.WriteAllText(configPath, $@"<ParseConfig><IgnoreAttributes><Ignore Element=""{configElement}"" Name=""{configName}"" /></IgnoreAttributes></ParseConfig>");
             string projectFile = Path.Combine(_testDir, "test.proj");
             File.WriteAllText(projectFile, projectXml);
 
-            using (var pc = CreateProjectCollection(UnknownElementsConfiguration.LoadFromFile(configPath)))
+            using (var pc = CreateProjectCollection(ParserIgnoreConfiguration.LoadFromFile(configPath)))
             {
                 var project = new Project(projectFile, null, null, pc, ProjectLoadSettings.IgnoreMissingImports | ProjectLoadSettings.IgnoreEmptyImports | ProjectLoadSettings.IgnoreInvalidImports);
                 project.ShouldNotBeNull();
@@ -185,7 +185,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             string projectFile = Path.Combine(_testDir, "test.proj");
             File.WriteAllText(projectFile, projectXml);
 
-            using (var pc = CreateProjectCollection(UnknownElementsConfiguration.Empty))
+            using (var pc = CreateProjectCollection(ParserIgnoreConfiguration.Empty))
             {
                 Should.Throw<InvalidProjectFileException>(() => new Project(projectFile, null, null, pc, ProjectLoadSettings.IgnoreMissingImports | ProjectLoadSettings.IgnoreEmptyImports | ProjectLoadSettings.IgnoreInvalidImports));
             }
@@ -195,12 +195,12 @@ namespace Microsoft.Build.UnitTests.Evaluation
         [MemberData(nameof(ChildSkipCases))]
         public void AllowedChildIsSkipped(string configElement, string configName, string projectXml)
         {
-            string configPath = Path.Combine(_testDir, UnknownElementsConfiguration.ConfigFileName);
+            string configPath = Path.Combine(_testDir, ParserIgnoreConfiguration.ConfigFileName);
             File.WriteAllText(configPath, $@"<ParseConfig><IgnoreChildren><Ignore Element=""{configElement}"" Name=""{configName}"" /></IgnoreChildren></ParseConfig>");
             string projectFile = Path.Combine(_testDir, "test.proj");
             File.WriteAllText(projectFile, projectXml);
 
-            using (var pc = CreateProjectCollection(UnknownElementsConfiguration.LoadFromFile(configPath)))
+            using (var pc = CreateProjectCollection(ParserIgnoreConfiguration.LoadFromFile(configPath)))
             {
                 var project = new Project(projectFile, null, null, pc, ProjectLoadSettings.IgnoreMissingImports | ProjectLoadSettings.IgnoreEmptyImports | ProjectLoadSettings.IgnoreInvalidImports);
                 project.ShouldNotBeNull();
@@ -216,7 +216,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             string projectFile = Path.Combine(_testDir, "test.proj");
             File.WriteAllText(projectFile, projectXml);
 
-            using (var pc = CreateProjectCollection(UnknownElementsConfiguration.Empty))
+            using (var pc = CreateProjectCollection(ParserIgnoreConfiguration.Empty))
             {
                 Should.Throw<InvalidProjectFileException>(() => new Project(projectFile, null, null, pc, ProjectLoadSettings.IgnoreMissingImports | ProjectLoadSettings.IgnoreEmptyImports | ProjectLoadSettings.IgnoreInvalidImports));
             }
@@ -254,10 +254,10 @@ namespace Microsoft.Build.UnitTests.Evaluation
             new object[] { "Task", "Custom", @"<Project><Target Name=""T""><Message Text=""hi""><Custom /></Message></Target></Project>" },
         };
 
-        private static ProjectCollection CreateProjectCollection(UnknownElementsConfiguration config)
+        private static ProjectCollection CreateProjectCollection(ParserIgnoreConfiguration config)
         {
             var projectCollection = new ProjectCollection();
-            projectCollection.UnknownElementsConfiguration = config;
+            projectCollection.ParserIgnoreConfiguration = config;
             return projectCollection;
         }
     }

--- a/src/Build.UnitTests/Evaluation/ParserIgnoreConfiguration_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/ParserIgnoreConfiguration_Tests.cs
@@ -142,6 +142,27 @@ namespace Microsoft.Build.UnitTests.Evaluation
         }
 
         [Fact]
+        public void ConfigurationIsAppliedToSimpleProjectRootElementCache()
+        {
+            string envConfigPath = Path.Combine(_testDir, "env.config");
+            File.WriteAllText(envConfigPath, @"<ParseConfig><IgnoreChildren><Ignore Element=""Project"" Name=""CustomThing"" /></IgnoreChildren></ParseConfig>");
+
+            using TestEnvironment env = TestEnvironment.Create();
+            env.SetEnvironmentVariable("MsBuildUseSimpleProjectRootElementCacheConcurrency", "true");
+            env.SetEnvironmentVariable(ParserIgnoreConfiguration.EnvironmentVariableName, envConfigPath);
+
+            using var projectCollection = new ProjectCollection();
+
+            projectCollection.ProjectRootElementCache.ShouldBeOfType<SimpleProjectRootElementCache>();
+            projectCollection.ParserIgnoreConfiguration.CheckSkipElement("Project", "CustomThing").ShouldBeTrue();
+
+            // Replacing the configuration invalidates what the cache parsed under the old one, which the simple
+            // cache has to be able to do as well.
+            projectCollection.ParserIgnoreConfiguration = ParserIgnoreConfiguration.Empty;
+            projectCollection.ParserIgnoreConfiguration.CheckSkipElement("Project", "CustomThing").ShouldBeFalse();
+        }
+
+        [Fact]
         public void RecordsSkippedItems()
         {
             string configPath = Path.Combine(_testDir, ParserIgnoreConfiguration.ConfigFileName);

--- a/src/Build.UnitTests/Evaluation/SimpleProjectRootElementCache_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/SimpleProjectRootElementCache_Tests.cs
@@ -27,6 +27,20 @@ namespace Microsoft.Build.Engine.UnitTests.Evaluation
         }
 
         [Fact]
+        public void DiscardImplicitReferences_RemovesAllEntries()
+        {
+            string projectFile = NativeMethodsShared.IsUnixLike ? "/foo" : "c:\\foo";
+            ProjectRootElement rootElementToCache = ProjectRootElement.Create(projectFile);
+
+            var cache = new SimpleProjectRootElementCache();
+            cache.AddEntry(rootElementToCache);
+
+            cache.DiscardImplicitReferences();
+
+            cache.Get(projectFile, null, false, null).ShouldBeNull();
+        }
+
+        [Fact]
         public void Get_GivenCachedProjectFile_ReturnsRootElement()
         {
             string projectFile = NativeMethodsShared.IsUnixLike ? "/foo" : "c:\\foo";

--- a/src/Build.UnitTests/Evaluation/UnknownElementsConfiguration_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/UnknownElementsConfiguration_Tests.cs
@@ -34,13 +34,15 @@ namespace Microsoft.Build.UnitTests.Evaluation
         public void ParsesValidConfigFile()
         {
             string configPath = Path.Combine(_testDir, UnknownElementsConfiguration.ConfigFileName);
-            File.WriteAllText(configPath, @"
-# This is a comment
-Attribute:Target:Foo
-Element:Project:CustomThing
-
-Attribute:PropertyGroup:Bar
-");
+            File.WriteAllText(configPath, @"<ParseConfig>
+  <IgnoreAttributes>
+    <Ignore Element=""Target"" Name=""Foo"" />
+    <Ignore Element=""PropertyGroup"" Name=""Bar"" />
+  </IgnoreAttributes>
+  <IgnoreChildren>
+    <Ignore Element=""Project"" Name=""CustomThing"" />
+  </IgnoreChildren>
+</ParseConfig>");
 
             var config = UnknownElementsConfiguration.LoadFromFile(configPath);
 
@@ -54,7 +56,7 @@ Attribute:PropertyGroup:Bar
         public void IsCaseInsensitive()
         {
             string configPath = Path.Combine(_testDir, UnknownElementsConfiguration.ConfigFileName);
-            File.WriteAllText(configPath, "Attribute:Target:Foo\n");
+            File.WriteAllText(configPath, @"<ParseConfig><IgnoreAttributes><Ignore Element=""Target"" Name=""Foo"" /></IgnoreAttributes></ParseConfig>");
 
             var config = UnknownElementsConfiguration.LoadFromFile(configPath);
 
@@ -67,7 +69,7 @@ Attribute:PropertyGroup:Bar
         public void RejectsNonAllowedItems()
         {
             string configPath = Path.Combine(_testDir, UnknownElementsConfiguration.ConfigFileName);
-            File.WriteAllText(configPath, "Attribute:Target:Foo\n");
+            File.WriteAllText(configPath, @"<ParseConfig><IgnoreAttributes><Ignore Element=""Target"" Name=""Foo"" /></IgnoreAttributes></ParseConfig>");
 
             var config = UnknownElementsConfiguration.LoadFromFile(configPath);
 
@@ -77,23 +79,30 @@ Attribute:PropertyGroup:Bar
         }
 
         [Fact]
-        public void IgnoresInvalidLines()
+        public void IgnoresInvalidEntries()
         {
             string configPath = Path.Combine(_testDir, UnknownElementsConfiguration.ConfigFileName);
-            File.WriteAllText(configPath, @"
-# Comment
-InvalidType:Target:Foo
-Attribute:Target
-Attribute
-:Target:Foo
-Attribute:Target:Foo:ExtraColon
-Attribute:Target:ValidOne
-");
+            File.WriteAllText(configPath, @"<ParseConfig>
+  <IgnoreAttributes>
+    <Ignore Element="""" Name=""Foo"" />
+    <Ignore Element=""Target"" Name="""" />
+    <Ignore Name=""Bar"" />
+    <Ignore Element=""Target"" />
+    <NotIgnore Element=""Target"" Name=""Nope"" />
+    <Ignore Element=""Target"" Name=""ValidOne"" />
+  </IgnoreAttributes>
+  <BogusSection>
+    <Ignore Element=""Target"" Name=""Nope2"" />
+  </BogusSection>
+</ParseConfig>");
 
             var config = UnknownElementsConfiguration.LoadFromFile(configPath);
 
             config.CheckSkipAttribute("Target", "ValidOne").ShouldBeTrue();
             config.CheckSkipAttribute("Target", "Foo").ShouldBeFalse();
+            config.CheckSkipAttribute("Target", "Bar").ShouldBeFalse();
+            config.CheckSkipAttribute("Target", "Nope").ShouldBeFalse();
+            config.CheckSkipAttribute("Target", "Nope2").ShouldBeFalse();
         }
 
         [Fact]
@@ -109,10 +118,10 @@ Attribute:Target:ValidOne
         public void MergeCombinesEntriesAndDeduplicatesFiles()
         {
             string configPath = Path.Combine(_testDir, UnknownElementsConfiguration.ConfigFileName);
-            File.WriteAllText(configPath, "Attribute:Target:Foo\n");
+            File.WriteAllText(configPath, @"<ParseConfig><IgnoreAttributes><Ignore Element=""Target"" Name=""Foo"" /></IgnoreAttributes></ParseConfig>");
 
             string extraConfigPath = Path.Combine(_testDir, "extra.config");
-            File.WriteAllText(extraConfigPath, "Element:Project:CustomThing\n");
+            File.WriteAllText(extraConfigPath, @"<ParseConfig><IgnoreChildren><Ignore Element=""Project"" Name=""CustomThing"" /></IgnoreChildren></ParseConfig>");
 
             var merged = UnknownElementsConfiguration.LoadFromFile(configPath)
                 .Merge(UnknownElementsConfiguration.LoadFromFile(extraConfigPath))
@@ -127,7 +136,7 @@ Attribute:Target:ValidOne
         public void LoadGlobalConfigLoadsEnvironmentVariablePaths()
         {
             string envConfigPath = Path.Combine(_testDir, "env.config");
-            File.WriteAllText(envConfigPath, "Element:Project:CustomThing\n");
+            File.WriteAllText(envConfigPath, @"<ParseConfig><IgnoreChildren><Ignore Element=""Project"" Name=""CustomThing"" /></IgnoreChildren></ParseConfig>");
 
             string oldEnv = Environment.GetEnvironmentVariable(UnknownElementsConfiguration.EnvironmentVariableName);
             try
@@ -147,7 +156,7 @@ Attribute:Target:ValidOne
         public void RecordsSkippedItems()
         {
             string configPath = Path.Combine(_testDir, UnknownElementsConfiguration.ConfigFileName);
-            File.WriteAllText(configPath, "Attribute:Target:Foo\n");
+            File.WriteAllText(configPath, @"<ParseConfig><IgnoreAttributes><Ignore Element=""Target"" Name=""Foo"" /></IgnoreAttributes></ParseConfig>");
 
             var config = UnknownElementsConfiguration.LoadFromFile(configPath);
 
@@ -173,7 +182,7 @@ Attribute:Target:ValidOne
         public void GetLoadedConfigsMessageListsFiles()
         {
             string configPath = Path.Combine(_testDir, UnknownElementsConfiguration.ConfigFileName);
-            File.WriteAllText(configPath, "Attribute:Target:Foo\n");
+            File.WriteAllText(configPath, @"<ParseConfig><IgnoreAttributes><Ignore Element=""Target"" Name=""Foo"" /></IgnoreAttributes></ParseConfig>");
 
             var config = UnknownElementsConfiguration.LoadFromFile(configPath);
 
@@ -186,7 +195,7 @@ Attribute:Target:ValidOne
         public void AllowedAttributeDoesNotThrowDuringParsing()
         {
             string configPath = Path.Combine(_testDir, UnknownElementsConfiguration.ConfigFileName);
-            File.WriteAllText(configPath, "Attribute:Target:CustomAttr\n");
+            File.WriteAllText(configPath, @"<ParseConfig><IgnoreAttributes><Ignore Element=""Target"" Name=""CustomAttr"" /></IgnoreAttributes></ParseConfig>");
 
             string projectContent = @"
 <Project>
@@ -226,7 +235,7 @@ Attribute:Target:ValidOne
         public void AllowedChildElementDoesNotThrowDuringParsing()
         {
             string configPath = Path.Combine(_testDir, UnknownElementsConfiguration.ConfigFileName);
-            File.WriteAllText(configPath, "Element:Project:CustomElement\n");
+            File.WriteAllText(configPath, @"<ParseConfig><IgnoreChildren><Ignore Element=""Project"" Name=""CustomElement"" /></IgnoreChildren></ParseConfig>");
 
             string projectContent = @"
 <Project>

--- a/src/Build.UnitTests/Evaluation/UnknownElementsConfiguration_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/UnknownElementsConfiguration_Tests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using Microsoft.Build.Exceptions;
 using Microsoft.Build.Evaluation;
@@ -63,19 +64,6 @@ namespace Microsoft.Build.UnitTests.Evaluation
             config.CheckSkipAttribute("target", "foo").ShouldBeTrue();
             config.CheckSkipAttribute("TARGET", "FOO").ShouldBeTrue();
             config.CheckSkipAttribute("Target", "Foo").ShouldBeTrue();
-        }
-
-        [Fact]
-        public void RejectsNonAllowedItems()
-        {
-            string configPath = Path.Combine(_testDir, UnknownElementsConfiguration.ConfigFileName);
-            File.WriteAllText(configPath, @"<ParseConfig><IgnoreAttributes><Ignore Element=""Target"" Name=""Foo"" /></IgnoreAttributes></ParseConfig>");
-
-            var config = UnknownElementsConfiguration.LoadFromFile(configPath);
-
-            config.CheckSkipAttribute("Target", "Bar").ShouldBeFalse();
-            config.CheckSkipElement("Target", "Foo").ShouldBeFalse();
-            config.CheckSkipAttribute("ItemGroup", "Foo").ShouldBeFalse();
         }
 
         [Fact]
@@ -172,107 +160,99 @@ namespace Microsoft.Build.UnitTests.Evaluation
             summary.ShouldContain("2 occurrences");
         }
 
-        [Fact]
-        public void GetLoadedConfigsMessageReturnsNullWhenEmpty()
-        {
-            var config = UnknownElementsConfiguration.LoadFromFile(Path.Combine(_testDir, UnknownElementsConfiguration.ConfigFileName));
-            config.GetLoadedConfigsMessage().ShouldBeNull();
-        }
-
-        [Fact]
-        public void GetLoadedConfigsMessageListsFiles()
+        [Theory]
+        [MemberData(nameof(AttributeSkipCases))]
+        public void AllowedAttributeIsSkipped(string configElement, string configName, string projectXml)
         {
             string configPath = Path.Combine(_testDir, UnknownElementsConfiguration.ConfigFileName);
-            File.WriteAllText(configPath, @"<ParseConfig><IgnoreAttributes><Ignore Element=""Target"" Name=""Foo"" /></IgnoreAttributes></ParseConfig>");
-
-            var config = UnknownElementsConfiguration.LoadFromFile(configPath);
-
-            string message = config.GetLoadedConfigsMessage();
-            message.ShouldNotBeNull();
-            message.ShouldContain(_testDir);
-        }
-
-        [Fact]
-        public void AllowedAttributeDoesNotThrowDuringParsing()
-        {
-            string configPath = Path.Combine(_testDir, UnknownElementsConfiguration.ConfigFileName);
-            File.WriteAllText(configPath, @"<ParseConfig><IgnoreAttributes><Ignore Element=""Target"" Name=""CustomAttr"" /></IgnoreAttributes></ParseConfig>");
-
-            string projectContent = @"
-<Project>
-  <Target Name=""Build"" CustomAttr=""hello"">
-  </Target>
-</Project>";
-
+            File.WriteAllText(configPath, $@"<ParseConfig><IgnoreAttributes><Ignore Element=""{configElement}"" Name=""{configName}"" /></IgnoreAttributes></ParseConfig>");
             string projectFile = Path.Combine(_testDir, "test.proj");
-            File.WriteAllText(projectFile, projectContent);
+            File.WriteAllText(projectFile, projectXml);
 
-            using (var projectCollection = CreateProjectCollection(UnknownElementsConfiguration.LoadFromFile(configPath)))
+            using (var pc = CreateProjectCollection(UnknownElementsConfiguration.LoadFromFile(configPath)))
             {
-                var project = new Project(projectFile, null, null, projectCollection);
+                var project = new Project(projectFile, null, null, pc, ProjectLoadSettings.IgnoreMissingImports | ProjectLoadSettings.IgnoreEmptyImports | ProjectLoadSettings.IgnoreInvalidImports);
                 project.ShouldNotBeNull();
             }
         }
 
-        [Fact]
-        public void NonAllowedAttributeStillThrows()
+        [Theory]
+        [MemberData(nameof(AttributeSkipCases))]
+        public void NonAllowedAttributeThrows(string configElement, string configName, string projectXml)
         {
-            string projectContent = @"
-<Project>
-  <Target Name=""Build"" BogusAttr=""hello"">
-  </Target>
-</Project>";
-
+            _ = configElement;
+            _ = configName;
             string projectFile = Path.Combine(_testDir, "test.proj");
-            File.WriteAllText(projectFile, projectContent);
+            File.WriteAllText(projectFile, projectXml);
 
-            using (var projectCollection = CreateProjectCollection(UnknownElementsConfiguration.LoadFromFile(Path.Combine(_testDir, UnknownElementsConfiguration.ConfigFileName))))
+            using (var pc = CreateProjectCollection(UnknownElementsConfiguration.Empty))
             {
-                Should.Throw<InvalidProjectFileException>(() => new Project(projectFile, null, null, projectCollection));
+                Should.Throw<InvalidProjectFileException>(() => new Project(projectFile, null, null, pc, ProjectLoadSettings.IgnoreMissingImports | ProjectLoadSettings.IgnoreEmptyImports | ProjectLoadSettings.IgnoreInvalidImports));
             }
         }
 
-        [Fact]
-        public void AllowedChildElementDoesNotThrowDuringParsing()
+        [Theory]
+        [MemberData(nameof(ChildSkipCases))]
+        public void AllowedChildIsSkipped(string configElement, string configName, string projectXml)
         {
             string configPath = Path.Combine(_testDir, UnknownElementsConfiguration.ConfigFileName);
-            File.WriteAllText(configPath, @"<ParseConfig><IgnoreChildren><Ignore Element=""Project"" Name=""CustomElement"" /></IgnoreChildren></ParseConfig>");
-
-            string projectContent = @"
-<Project>
-  <CustomElement />
-  <Target Name=""Build"">
-  </Target>
-</Project>";
-
+            File.WriteAllText(configPath, $@"<ParseConfig><IgnoreChildren><Ignore Element=""{configElement}"" Name=""{configName}"" /></IgnoreChildren></ParseConfig>");
             string projectFile = Path.Combine(_testDir, "test.proj");
-            File.WriteAllText(projectFile, projectContent);
+            File.WriteAllText(projectFile, projectXml);
 
-            using (var projectCollection = CreateProjectCollection(UnknownElementsConfiguration.LoadFromFile(configPath)))
+            using (var pc = CreateProjectCollection(UnknownElementsConfiguration.LoadFromFile(configPath)))
             {
-                var project = new Project(projectFile, null, null, projectCollection);
+                var project = new Project(projectFile, null, null, pc, ProjectLoadSettings.IgnoreMissingImports | ProjectLoadSettings.IgnoreEmptyImports | ProjectLoadSettings.IgnoreInvalidImports);
                 project.ShouldNotBeNull();
             }
         }
 
-        [Fact]
-        public void NonAllowedChildElementStillThrows()
+        [Theory]
+        [MemberData(nameof(ChildSkipCases))]
+        public void NonAllowedChildThrows(string configElement, string configName, string projectXml)
         {
-            string projectContent = @"
-<Project>
-  <BogusElement />
-  <Target Name=""Build"">
-  </Target>
-</Project>";
-
+            _ = configElement;
+            _ = configName;
             string projectFile = Path.Combine(_testDir, "test.proj");
-            File.WriteAllText(projectFile, projectContent);
+            File.WriteAllText(projectFile, projectXml);
 
-            using (var projectCollection = CreateProjectCollection(UnknownElementsConfiguration.LoadFromFile(Path.Combine(_testDir, UnknownElementsConfiguration.ConfigFileName))))
+            using (var pc = CreateProjectCollection(UnknownElementsConfiguration.Empty))
             {
-                Should.Throw<InvalidProjectFileException>(() => new Project(projectFile, null, null, projectCollection));
+                Should.Throw<InvalidProjectFileException>(() => new Project(projectFile, null, null, pc, ProjectLoadSettings.IgnoreMissingImports | ProjectLoadSettings.IgnoreEmptyImports | ProjectLoadSettings.IgnoreInvalidImports));
             }
         }
+
+        public static IEnumerable<object[]> AttributeSkipCases => new[]
+        {
+            new object[] { "Target", "X", @"<Project><Target Name=""T"" X=""1"" /></Project>" },
+            new object[] { "PropertyGroup", "X", @"<Project><PropertyGroup X=""1""><A>1</A></PropertyGroup><Target Name=""T"" /></Project>" },
+            new object[] { "Property", "X", @"<Project><PropertyGroup><A X=""1"">1</A></PropertyGroup><Target Name=""T"" /></Project>" },
+            new object[] { "ItemGroup", "X", @"<Project><ItemGroup X=""1""><Compile Include=""a.cs"" /></ItemGroup><Target Name=""T"" /></Project>" },
+            new object[] { "Item", "_X", @"<Project><ItemGroup><Compile Include=""a.cs"" _X=""1"" /></ItemGroup><Target Name=""T"" /></Project>" },
+            new object[] { "Import", "X", @"<Project><Import Project=""nonexistent.props"" X=""1"" /><Target Name=""T"" /></Project>" },
+            new object[] { "ImportGroup", "X", @"<Project><ImportGroup X=""1""><Import Project=""nonexistent.props"" /></ImportGroup><Target Name=""T"" /></Project>" },
+            new object[] { "UsingTask", "X", @"<Project><UsingTask TaskName=""Foo"" AssemblyName=""Bar"" X=""1"" /><Target Name=""T"" /></Project>" },
+            new object[] { "OnError", "X", @"<Project><Target Name=""T""><OnError ExecuteTargets=""T"" X=""1"" /></Target></Project>" },
+            new object[] { "Output", "X", @"<Project><Target Name=""T""><Message Text=""hi""><Output TaskParameter=""Text"" PropertyName=""P"" X=""1"" /></Message></Target></Project>" },
+            new object[] { "Choose", "X", @"<Project><Choose X=""1""><When Condition=""true""><PropertyGroup><A>1</A></PropertyGroup></When></Choose><Target Name=""T"" /></Project>" },
+            new object[] { "Otherwise", "X", @"<Project><Choose><When Condition=""true""><PropertyGroup><A>1</A></PropertyGroup></When><Otherwise X=""1""><PropertyGroup><B>2</B></PropertyGroup></Otherwise></Choose><Target Name=""T"" /></Project>" },
+            new object[] { "ItemDefinition", "_X", @"<Project><ItemDefinitionGroup><Compile _X=""1"" /></ItemDefinitionGroup><Target Name=""T"" /></Project>" },
+            new object[] { "Metadata", "X", @"<Project><ItemGroup><Compile Include=""a.cs""><MyMeta X=""1"">val</MyMeta></Compile></ItemGroup><Target Name=""T"" /></Project>" },
+            new object[] { "UsingTaskBody", "X", @"<Project><UsingTask TaskName=""Foo"" AssemblyName=""Bar"" TaskFactory=""CodeTaskFactory""><Task X=""1"" /></UsingTask><Target Name=""T"" /></Project>" },
+            new object[] { "Parameter", "X", @"<Project><UsingTask TaskName=""Foo"" AssemblyName=""Bar"" TaskFactory=""CodeTaskFactory""><ParameterGroup><MyParam X=""1"" /></ParameterGroup></UsingTask><Target Name=""T"" /></Project>" },
+            new object[] { "ProjectExtensions", "X", @"<Project><ProjectExtensions X=""1""><Foo>bar</Foo></ProjectExtensions><Target Name=""T"" /></Project>" },
+        };
+
+        public static IEnumerable<object[]> ChildSkipCases => new[]
+        {
+            new object[] { "Project", "Custom", @"<Project><Custom /><Target Name=""T"" /></Project>" },
+            new object[] { "UsingTask", "Custom", @"<Project><UsingTask TaskName=""Foo"" AssemblyName=""Bar"" TaskFactory=""CodeTaskFactory""><Custom /></UsingTask><Target Name=""T"" /></Project>" },
+            new object[] { "ImportGroup", "Custom", @"<Project><ImportGroup><Custom /></ImportGroup><Target Name=""T"" /></Project>" },
+            new object[] { "Choose", "Custom", @"<Project><Choose><When Condition=""true""><PropertyGroup><A>1</A></PropertyGroup></When><Custom /></Choose><Target Name=""T"" /></Project>" },
+            new object[] { "When", "Custom", @"<Project><Choose><When Condition=""true""><PropertyGroup><A>1</A></PropertyGroup><Custom /></When></Choose><Target Name=""T"" /></Project>" },
+            new object[] { "Otherwise", "Custom", @"<Project><Choose><When Condition=""true""><PropertyGroup><A>1</A></PropertyGroup></When><Otherwise><PropertyGroup><B>2</B></PropertyGroup><Custom /></Otherwise></Choose><Target Name=""T"" /></Project>" },
+            new object[] { "Task", "Custom", @"<Project><Target Name=""T""><Message Text=""hi""><Custom /></Message></Target></Project>" },
+        };
 
         private static ProjectCollection CreateProjectCollection(UnknownElementsConfiguration config)
         {

--- a/src/Build.UnitTests/Evaluation/UnknownElementsConfiguration_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/UnknownElementsConfiguration_Tests.cs
@@ -1,0 +1,274 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+using Microsoft.Build.Exceptions;
+using Microsoft.Build.Evaluation;
+using Shouldly;
+using Xunit;
+
+#nullable disable
+
+namespace Microsoft.Build.UnitTests.Evaluation
+{
+    public class UnknownElementsConfiguration_Tests : IDisposable
+    {
+        private readonly string _testDir;
+
+        public UnknownElementsConfiguration_Tests()
+        {
+            _testDir = Path.Combine(Path.GetTempPath(), "MSBuildTest_UnknownElements_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_testDir);
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(_testDir))
+            {
+                Directory.Delete(_testDir, recursive: true);
+            }
+        }
+
+        [Fact]
+        public void ParsesValidConfigFile()
+        {
+            string configPath = Path.Combine(_testDir, UnknownElementsConfiguration.ConfigFileName);
+            File.WriteAllText(configPath, @"
+# This is a comment
+Attribute:Target:Foo
+Element:Project:CustomThing
+
+Attribute:PropertyGroup:Bar
+");
+
+            var config = UnknownElementsConfiguration.LoadFromFile(configPath);
+
+            config.LoadedConfigFiles.Count.ShouldBe(1);
+            config.CheckSkipAttribute("Target", "Foo").ShouldBeTrue();
+            config.CheckSkipElement("Project", "CustomThing").ShouldBeTrue();
+            config.CheckSkipAttribute("PropertyGroup", "Bar").ShouldBeTrue();
+        }
+
+        [Fact]
+        public void IsCaseInsensitive()
+        {
+            string configPath = Path.Combine(_testDir, UnknownElementsConfiguration.ConfigFileName);
+            File.WriteAllText(configPath, "Attribute:Target:Foo\n");
+
+            var config = UnknownElementsConfiguration.LoadFromFile(configPath);
+
+            config.CheckSkipAttribute("target", "foo").ShouldBeTrue();
+            config.CheckSkipAttribute("TARGET", "FOO").ShouldBeTrue();
+            config.CheckSkipAttribute("Target", "Foo").ShouldBeTrue();
+        }
+
+        [Fact]
+        public void RejectsNonAllowedItems()
+        {
+            string configPath = Path.Combine(_testDir, UnknownElementsConfiguration.ConfigFileName);
+            File.WriteAllText(configPath, "Attribute:Target:Foo\n");
+
+            var config = UnknownElementsConfiguration.LoadFromFile(configPath);
+
+            config.CheckSkipAttribute("Target", "Bar").ShouldBeFalse();
+            config.CheckSkipElement("Target", "Foo").ShouldBeFalse();
+            config.CheckSkipAttribute("ItemGroup", "Foo").ShouldBeFalse();
+        }
+
+        [Fact]
+        public void IgnoresInvalidLines()
+        {
+            string configPath = Path.Combine(_testDir, UnknownElementsConfiguration.ConfigFileName);
+            File.WriteAllText(configPath, @"
+# Comment
+InvalidType:Target:Foo
+Attribute:Target
+Attribute
+:Target:Foo
+Attribute:Target:Foo:ExtraColon
+Attribute:Target:ValidOne
+");
+
+            var config = UnknownElementsConfiguration.LoadFromFile(configPath);
+
+            config.CheckSkipAttribute("Target", "ValidOne").ShouldBeTrue();
+            config.CheckSkipAttribute("Target", "Foo").ShouldBeFalse();
+        }
+
+        [Fact]
+        public void ReturnsEmptyWhenNoConfigExists()
+        {
+            var config = UnknownElementsConfiguration.LoadFromFile(Path.Combine(_testDir, UnknownElementsConfiguration.ConfigFileName));
+
+            config.LoadedConfigFiles.Count.ShouldBe(0);
+            config.CheckSkipAttribute("Target", "Foo").ShouldBeFalse();
+        }
+
+        [Fact]
+        public void MergeCombinesEntriesAndDeduplicatesFiles()
+        {
+            string configPath = Path.Combine(_testDir, UnknownElementsConfiguration.ConfigFileName);
+            File.WriteAllText(configPath, "Attribute:Target:Foo\n");
+
+            string extraConfigPath = Path.Combine(_testDir, "extra.config");
+            File.WriteAllText(extraConfigPath, "Element:Project:CustomThing\n");
+
+            var merged = UnknownElementsConfiguration.LoadFromFile(configPath)
+                .Merge(UnknownElementsConfiguration.LoadFromFile(extraConfigPath))
+                .Merge(UnknownElementsConfiguration.LoadFromFile(configPath));
+
+            merged.CheckSkipAttribute("Target", "Foo").ShouldBeTrue();
+            merged.CheckSkipElement("Project", "CustomThing").ShouldBeTrue();
+            merged.LoadedConfigFiles.Count.ShouldBe(2);
+        }
+
+        [Fact]
+        public void LoadGlobalConfigLoadsEnvironmentVariablePaths()
+        {
+            string envConfigPath = Path.Combine(_testDir, "env.config");
+            File.WriteAllText(envConfigPath, "Element:Project:CustomThing\n");
+
+            string oldEnv = Environment.GetEnvironmentVariable(UnknownElementsConfiguration.EnvironmentVariableName);
+            try
+            {
+                Environment.SetEnvironmentVariable(UnknownElementsConfiguration.EnvironmentVariableName, envConfigPath);
+                var config = UnknownElementsConfiguration.LoadGlobalConfig();
+
+                config.CheckSkipElement("Project", "CustomThing").ShouldBeTrue();
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(UnknownElementsConfiguration.EnvironmentVariableName, oldEnv);
+            }
+        }
+
+        [Fact]
+        public void RecordsSkippedItems()
+        {
+            string configPath = Path.Combine(_testDir, UnknownElementsConfiguration.ConfigFileName);
+            File.WriteAllText(configPath, "Attribute:Target:Foo\n");
+
+            var config = UnknownElementsConfiguration.LoadFromFile(configPath);
+
+            config.GetSkippedSummaryMessage().ShouldBeNull();
+
+            config.CheckSkipAttribute("Target", "Foo");
+            config.CheckSkipAttribute("Target", "Foo");
+
+            string summary = config.GetSkippedSummaryMessage();
+            summary.ShouldNotBeNull();
+            summary.ShouldContain("Attribute:Target:Foo");
+            summary.ShouldContain("2 occurrences");
+        }
+
+        [Fact]
+        public void GetLoadedConfigsMessageReturnsNullWhenEmpty()
+        {
+            var config = UnknownElementsConfiguration.LoadFromFile(Path.Combine(_testDir, UnknownElementsConfiguration.ConfigFileName));
+            config.GetLoadedConfigsMessage().ShouldBeNull();
+        }
+
+        [Fact]
+        public void GetLoadedConfigsMessageListsFiles()
+        {
+            string configPath = Path.Combine(_testDir, UnknownElementsConfiguration.ConfigFileName);
+            File.WriteAllText(configPath, "Attribute:Target:Foo\n");
+
+            var config = UnknownElementsConfiguration.LoadFromFile(configPath);
+
+            string message = config.GetLoadedConfigsMessage();
+            message.ShouldNotBeNull();
+            message.ShouldContain(_testDir);
+        }
+
+        [Fact]
+        public void AllowedAttributeDoesNotThrowDuringParsing()
+        {
+            string configPath = Path.Combine(_testDir, UnknownElementsConfiguration.ConfigFileName);
+            File.WriteAllText(configPath, "Attribute:Target:CustomAttr\n");
+
+            string projectContent = @"
+<Project>
+  <Target Name=""Build"" CustomAttr=""hello"">
+  </Target>
+</Project>";
+
+            string projectFile = Path.Combine(_testDir, "test.proj");
+            File.WriteAllText(projectFile, projectContent);
+
+            using (var projectCollection = CreateProjectCollection(UnknownElementsConfiguration.LoadFromFile(configPath)))
+            {
+                var project = new Project(projectFile, null, null, projectCollection);
+                project.ShouldNotBeNull();
+            }
+        }
+
+        [Fact]
+        public void NonAllowedAttributeStillThrows()
+        {
+            string projectContent = @"
+<Project>
+  <Target Name=""Build"" BogusAttr=""hello"">
+  </Target>
+</Project>";
+
+            string projectFile = Path.Combine(_testDir, "test.proj");
+            File.WriteAllText(projectFile, projectContent);
+
+            using (var projectCollection = CreateProjectCollection(UnknownElementsConfiguration.LoadFromFile(Path.Combine(_testDir, UnknownElementsConfiguration.ConfigFileName))))
+            {
+                Should.Throw<InvalidProjectFileException>(() => new Project(projectFile, null, null, projectCollection));
+            }
+        }
+
+        [Fact]
+        public void AllowedChildElementDoesNotThrowDuringParsing()
+        {
+            string configPath = Path.Combine(_testDir, UnknownElementsConfiguration.ConfigFileName);
+            File.WriteAllText(configPath, "Element:Project:CustomElement\n");
+
+            string projectContent = @"
+<Project>
+  <CustomElement />
+  <Target Name=""Build"">
+  </Target>
+</Project>";
+
+            string projectFile = Path.Combine(_testDir, "test.proj");
+            File.WriteAllText(projectFile, projectContent);
+
+            using (var projectCollection = CreateProjectCollection(UnknownElementsConfiguration.LoadFromFile(configPath)))
+            {
+                var project = new Project(projectFile, null, null, projectCollection);
+                project.ShouldNotBeNull();
+            }
+        }
+
+        [Fact]
+        public void NonAllowedChildElementStillThrows()
+        {
+            string projectContent = @"
+<Project>
+  <BogusElement />
+  <Target Name=""Build"">
+  </Target>
+</Project>";
+
+            string projectFile = Path.Combine(_testDir, "test.proj");
+            File.WriteAllText(projectFile, projectContent);
+
+            using (var projectCollection = CreateProjectCollection(UnknownElementsConfiguration.LoadFromFile(Path.Combine(_testDir, UnknownElementsConfiguration.ConfigFileName))))
+            {
+                Should.Throw<InvalidProjectFileException>(() => new Project(projectFile, null, null, projectCollection));
+            }
+        }
+
+        private static ProjectCollection CreateProjectCollection(UnknownElementsConfiguration config)
+        {
+            var projectCollection = new ProjectCollection();
+            projectCollection.UnknownElementsConfiguration = config;
+            return projectCollection;
+        }
+    }
+}

--- a/src/Build.UnitTests/Evaluation/UnknownElementsConfiguration_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/UnknownElementsConfiguration_Tests.cs
@@ -123,9 +123,10 @@ namespace Microsoft.Build.UnitTests.Evaluation
             string extraConfigPath = Path.Combine(_testDir, "extra.config");
             File.WriteAllText(extraConfigPath, @"<ParseConfig><IgnoreChildren><Ignore Element=""Project"" Name=""CustomThing"" /></IgnoreChildren></ParseConfig>");
 
-            var merged = UnknownElementsConfiguration.LoadFromFile(configPath)
-                .Merge(UnknownElementsConfiguration.LoadFromFile(extraConfigPath))
-                .Merge(UnknownElementsConfiguration.LoadFromFile(configPath));
+            var merged = UnknownElementsConfiguration.Merge(
+                UnknownElementsConfiguration.LoadFromFile(configPath),
+                UnknownElementsConfiguration.LoadFromFile(extraConfigPath));
+            merged = UnknownElementsConfiguration.Merge(merged, UnknownElementsConfiguration.LoadFromFile(configPath));
 
             merged.CheckSkipAttribute("Target", "Foo").ShouldBeTrue();
             merged.CheckSkipElement("Project", "CustomThing").ShouldBeTrue();

--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -620,7 +620,7 @@ namespace Microsoft.Build.Execution
 
                 if (!Traits.Instance.EscapeHatches.DisableParseConfig)
                 {
-                    _buildParameters.UnknownElementsConfiguration = _buildParameters.ProjectRootElementCache.UnknownElementsConfiguration;
+                    _buildParameters.ParserIgnoreConfiguration = _buildParameters.ProjectRootElementCache.ParserIgnoreConfiguration;
                 }
 
                 if (_buildParameters.UsesCachedResults() && _buildParameters.ProjectIsolationMode == ProjectIsolationMode.False)

--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -618,10 +618,9 @@ namespace Microsoft.Build.Execution
                 // Initialize additional build parameters.
                 _buildParameters.BuildId = GetNextBuildId();
 
-                if (_buildParameters.UnknownElementsConfiguration is null && !Traits.Instance.EscapeHatches.DisableParseConfig)
+                if (!Traits.Instance.EscapeHatches.DisableParseConfig)
                 {
-                    _buildParameters.UnknownElementsConfiguration = UnknownElementsConfiguration.LoadGlobalConfig(BuildParameters.StartupDirectory);
-                    _buildParameters.ProjectRootElementCache.UnknownElementsConfiguration = _buildParameters.UnknownElementsConfiguration;
+                    _buildParameters.UnknownElementsConfiguration = _buildParameters.ProjectRootElementCache.UnknownElementsConfiguration;
                 }
 
                 if (_buildParameters.UsesCachedResults() && _buildParameters.ProjectIsolationMode == ProjectIsolationMode.False)

--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -618,6 +618,12 @@ namespace Microsoft.Build.Execution
                 // Initialize additional build parameters.
                 _buildParameters.BuildId = GetNextBuildId();
 
+                if (_buildParameters.UnknownElementsConfiguration is null && !Traits.Instance.EscapeHatches.DisableParseConfig)
+                {
+                    _buildParameters.UnknownElementsConfiguration = UnknownElementsConfiguration.LoadGlobalConfig(BuildParameters.StartupDirectory);
+                    _buildParameters.ProjectRootElementCache.UnknownElementsConfiguration = _buildParameters.UnknownElementsConfiguration;
+                }
+
                 if (_buildParameters.UsesCachedResults() && _buildParameters.ProjectIsolationMode == ProjectIsolationMode.False)
                 {
                     // If input or output caches are used and the project isolation mode is set to

--- a/src/Build/BackEnd/BuildManager/BuildParameters.cs
+++ b/src/Build/BackEnd/BuildManager/BuildParameters.cs
@@ -240,7 +240,7 @@ namespace Microsoft.Build.Execution
         /// The configuration for allowed unknown attributes/elements during parsing.
         /// Loaded on the main node and serialized to worker nodes.
         /// </summary>
-        private ParserIgnoreConfiguration _ParserIgnoreConfiguration;
+        private ParserIgnoreConfiguration _ParserIgnoreConfiguration = ParserIgnoreConfiguration.Empty;
 
         /// <summary>
         /// Constructor for those who intend to set all properties themselves.

--- a/src/Build/BackEnd/BuildManager/BuildParameters.cs
+++ b/src/Build/BackEnd/BuildManager/BuildParameters.cs
@@ -237,6 +237,12 @@ namespace Microsoft.Build.Execution
         private bool _reportFileAccesses;
 
         /// <summary>
+        /// The configuration for allowed unknown attributes/elements during parsing.
+        /// Loaded on the main node and serialized to worker nodes.
+        /// </summary>
+        private UnknownElementsConfiguration _unknownElementsConfiguration;
+
+        /// <summary>
         /// Constructor for those who intend to set all properties themselves.
         /// </summary>
         public BuildParameters()
@@ -262,6 +268,7 @@ namespace Microsoft.Build.Execution
 
             _globalProperties = new PropertyDictionary<ProjectPropertyInstance>(projectCollection.GlobalPropertiesCollection);
             _propertiesFromCommandLine = projectCollection.PropertiesFromCommandLine;
+            _unknownElementsConfiguration = projectCollection.UnknownElementsConfiguration;
         }
 
         /// <summary>
@@ -330,6 +337,7 @@ namespace Microsoft.Build.Execution
             IsTelemetryEnabled = other.IsTelemetryEnabled;
             ProjectCacheDescriptor = other.ProjectCacheDescriptor;
             _enableTargetOutputLogging = other.EnableTargetOutputLogging;
+            _unknownElementsConfiguration = other._unknownElementsConfiguration;
         }
 
         /// <summary>
@@ -823,6 +831,16 @@ namespace Microsoft.Build.Execution
         }
 
         /// <summary>
+        /// Gets or sets the configuration for allowed unknown attributes/elements during parsing.
+        /// When set, this configuration is used for parsing and evaluation.
+        /// </summary>
+        internal UnknownElementsConfiguration UnknownElementsConfiguration
+        {
+            get => _unknownElementsConfiguration;
+            set => _unknownElementsConfiguration = value;
+        }
+
+        /// <summary>
         /// Gets or sets a value indicating if the build is allowed to interact with the user.
         /// </summary>
         public bool Interactive
@@ -994,6 +1012,7 @@ namespace Microsoft.Build.Execution
             translator.Translate(ref _reportFileAccesses);
             translator.Translate(ref _enableTargetOutputLogging);
             translator.Translate(ref _multiThreaded);
+            translator.Translate(ref _unknownElementsConfiguration, UnknownElementsConfiguration.FactoryForDeserialization);
 
             // ProjectRootElementCache is not transmitted.
             // ResetCaches is not transmitted.

--- a/src/Build/BackEnd/BuildManager/BuildParameters.cs
+++ b/src/Build/BackEnd/BuildManager/BuildParameters.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -240,7 +240,7 @@ namespace Microsoft.Build.Execution
         /// The configuration for allowed unknown attributes/elements during parsing.
         /// Loaded on the main node and serialized to worker nodes.
         /// </summary>
-        private UnknownElementsConfiguration _unknownElementsConfiguration;
+        private ParserIgnoreConfiguration _ParserIgnoreConfiguration;
 
         /// <summary>
         /// Constructor for those who intend to set all properties themselves.
@@ -268,7 +268,7 @@ namespace Microsoft.Build.Execution
 
             _globalProperties = new PropertyDictionary<ProjectPropertyInstance>(projectCollection.GlobalPropertiesCollection);
             _propertiesFromCommandLine = projectCollection.PropertiesFromCommandLine;
-            _unknownElementsConfiguration = projectCollection.UnknownElementsConfiguration;
+            _ParserIgnoreConfiguration = projectCollection.ParserIgnoreConfiguration;
         }
 
         /// <summary>
@@ -337,7 +337,7 @@ namespace Microsoft.Build.Execution
             IsTelemetryEnabled = other.IsTelemetryEnabled;
             ProjectCacheDescriptor = other.ProjectCacheDescriptor;
             _enableTargetOutputLogging = other.EnableTargetOutputLogging;
-            _unknownElementsConfiguration = other._unknownElementsConfiguration;
+            _ParserIgnoreConfiguration = other._ParserIgnoreConfiguration;
         }
 
         /// <summary>
@@ -834,10 +834,10 @@ namespace Microsoft.Build.Execution
         /// Gets or sets the configuration for allowed unknown attributes/elements during parsing.
         /// When set, this configuration is used for parsing and evaluation.
         /// </summary>
-        internal UnknownElementsConfiguration UnknownElementsConfiguration
+        internal ParserIgnoreConfiguration ParserIgnoreConfiguration
         {
-            get => _unknownElementsConfiguration;
-            set => _unknownElementsConfiguration = value;
+            get => _ParserIgnoreConfiguration;
+            set => _ParserIgnoreConfiguration = value;
         }
 
         /// <summary>
@@ -1012,7 +1012,7 @@ namespace Microsoft.Build.Execution
             translator.Translate(ref _reportFileAccesses);
             translator.Translate(ref _enableTargetOutputLogging);
             translator.Translate(ref _multiThreaded);
-            translator.Translate(ref _unknownElementsConfiguration, UnknownElementsConfiguration.FactoryForDeserialization);
+            translator.Translate(ref _ParserIgnoreConfiguration, ParserIgnoreConfiguration.FactoryForDeserialization);
 
             // ProjectRootElementCache is not transmitted.
             // ResetCaches is not transmitted.

--- a/src/Build/BackEnd/Node/OutOfProcNode.cs
+++ b/src/Build/BackEnd/Node/OutOfProcNode.cs
@@ -715,6 +715,8 @@ namespace Microsoft.Build.Execution
             // Grab the system parameters.
             _buildParameters = configuration.BuildParameters;
 
+            s_projectRootElementCacheBase.SetUnknownElementsConfiguration(configuration.BuildParameters.UnknownElementsConfiguration);
+
             _buildParameters.ProjectRootElementCache = s_projectRootElementCacheBase;
 
             // Snapshot the current environment

--- a/src/Build/BackEnd/Node/OutOfProcNode.cs
+++ b/src/Build/BackEnd/Node/OutOfProcNode.cs
@@ -715,7 +715,7 @@ namespace Microsoft.Build.Execution
             // Grab the system parameters.
             _buildParameters = configuration.BuildParameters;
 
-            s_projectRootElementCacheBase.SetUnknownElementsConfiguration(configuration.BuildParameters.UnknownElementsConfiguration);
+            s_projectRootElementCacheBase.SetParserIgnoreConfiguration(configuration.BuildParameters.ParserIgnoreConfiguration);
 
             _buildParameters.ProjectRootElementCache = s_projectRootElementCacheBase;
 

--- a/src/Build/Construction/ProjectRootElement.cs
+++ b/src/Build/Construction/ProjectRootElement.cs
@@ -181,7 +181,7 @@ namespace Microsoft.Build.Construction
 
             XmlDocumentWithLocation document = LoadDocument(xmlReader, preserveFormatting);
 
-            ProjectParser.Parse(document, this);
+            ProjectParser.Parse(document, this, ProjectRootElementCache.UnknownElementsConfiguration);
         }
 
         private readonly bool _isEphemeral = false;
@@ -217,7 +217,7 @@ namespace Microsoft.Build.Construction
                 document.Load(xr);
             }
 
-            ProjectParser.Parse(document, this);
+            ProjectParser.Parse(document, this, ProjectRootElementCache.UnknownElementsConfiguration);
         }
 
         /// <summary>
@@ -241,7 +241,7 @@ namespace Microsoft.Build.Construction
 
             XmlDocumentWithLocation document = LoadDocument(path, preserveFormatting, projectRootElementCache.LoadProjectsReadOnly);
 
-            ProjectParser.Parse(document, this);
+            ProjectParser.Parse(document, this, ProjectRootElementCache.UnknownElementsConfiguration);
         }
 
         /// <summary>
@@ -261,7 +261,7 @@ namespace Microsoft.Build.Construction
             _directory = Environment.CurrentDirectory;
             IncrementVersion();
 
-            ProjectParser.Parse(document, this);
+            ProjectParser.Parse(document, this, ProjectRootElementCache.UnknownElementsConfiguration);
         }
 
         /// <summary>
@@ -273,7 +273,7 @@ namespace Microsoft.Build.Construction
         /// </remarks>
         private ProjectRootElement(XmlDocumentWithLocation document)
         {
-            ProjectParser.Parse(document, this);
+            ProjectParser.Parse(document, this, ProjectRootElementCache.UnknownElementsConfiguration);
         }
 
         /// <summary>
@@ -1721,7 +1721,7 @@ namespace Microsoft.Build.Construction
 
             RemoveAllChildren();
 
-            ProjectParser.Parse(newDocument, this);
+            ProjectParser.Parse(newDocument, this, ProjectRootElementCache.UnknownElementsConfiguration);
 
             MarkDirty("Project reloaded", null);
         }

--- a/src/Build/Construction/ProjectRootElement.cs
+++ b/src/Build/Construction/ProjectRootElement.cs
@@ -273,7 +273,9 @@ namespace Microsoft.Build.Construction
         /// </remarks>
         private ProjectRootElement(XmlDocumentWithLocation document)
         {
-            ProjectParser.Parse(document, this, ProjectRootElementCache.UnknownElementsConfiguration);
+            // This constructor is only used by ThrowIfDocumentHasParsingErrors to check whether a document
+            // parses; it deliberately has no cache, so there is no configuration to apply.
+            ProjectParser.Parse(document, this, ProjectRootElementCache?.UnknownElementsConfiguration);
         }
 
         /// <summary>

--- a/src/Build/Construction/ProjectRootElement.cs
+++ b/src/Build/Construction/ProjectRootElement.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -181,7 +181,7 @@ namespace Microsoft.Build.Construction
 
             XmlDocumentWithLocation document = LoadDocument(xmlReader, preserveFormatting);
 
-            ProjectParser.Parse(document, this, ProjectRootElementCache.UnknownElementsConfiguration);
+            ProjectParser.Parse(document, this, ProjectRootElementCache.ParserIgnoreConfiguration);
         }
 
         private readonly bool _isEphemeral = false;
@@ -217,7 +217,7 @@ namespace Microsoft.Build.Construction
                 document.Load(xr);
             }
 
-            ProjectParser.Parse(document, this, ProjectRootElementCache.UnknownElementsConfiguration);
+            ProjectParser.Parse(document, this, ProjectRootElementCache.ParserIgnoreConfiguration);
         }
 
         /// <summary>
@@ -241,7 +241,7 @@ namespace Microsoft.Build.Construction
 
             XmlDocumentWithLocation document = LoadDocument(path, preserveFormatting, projectRootElementCache.LoadProjectsReadOnly);
 
-            ProjectParser.Parse(document, this, ProjectRootElementCache.UnknownElementsConfiguration);
+            ProjectParser.Parse(document, this, ProjectRootElementCache.ParserIgnoreConfiguration);
         }
 
         /// <summary>
@@ -261,7 +261,7 @@ namespace Microsoft.Build.Construction
             _directory = Environment.CurrentDirectory;
             IncrementVersion();
 
-            ProjectParser.Parse(document, this, ProjectRootElementCache.UnknownElementsConfiguration);
+            ProjectParser.Parse(document, this, ProjectRootElementCache.ParserIgnoreConfiguration);
         }
 
         /// <summary>
@@ -275,7 +275,7 @@ namespace Microsoft.Build.Construction
         {
             // This constructor is only used by ThrowIfDocumentHasParsingErrors to check whether a document
             // parses; it deliberately has no cache, so there is no configuration to apply.
-            ProjectParser.Parse(document, this, ProjectRootElementCache?.UnknownElementsConfiguration);
+            ProjectParser.Parse(document, this, ProjectRootElementCache?.ParserIgnoreConfiguration);
         }
 
         /// <summary>
@@ -1723,7 +1723,7 @@ namespace Microsoft.Build.Construction
 
             RemoveAllChildren();
 
-            ProjectParser.Parse(newDocument, this, ProjectRootElementCache.UnknownElementsConfiguration);
+            ProjectParser.Parse(newDocument, this, ProjectRootElementCache.ParserIgnoreConfiguration);
 
             MarkDirty("Project reloaded", null);
         }

--- a/src/Build/Definition/ProjectCollection.cs
+++ b/src/Build/Definition/ProjectCollection.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -205,8 +205,6 @@ namespace Microsoft.Build.Evaluation
         /// </summary>
         private int _maxNodeCount;
 
-        private UnknownElementsConfiguration _unknownElementsConfiguration;
-
         /// <summary>
         /// LoggingService Logger mode.
         /// If Asynchronous mode is used
@@ -383,17 +381,16 @@ namespace Microsoft.Build.Evaluation
                 // we do not need to auto reload.
                 bool autoReloadFromDisk = reuseProjectRootElementCache;
                 ProjectRootElementCache = new ProjectRootElementCache(autoReloadFromDisk, loadProjectsReadOnly);
+                
+                if (!Traits.Instance.EscapeHatches.DisableParseConfig)
+                {
+                    ProjectRootElementCache.SetUnknownElementsConfiguration(UnknownElementsConfiguration.LoadGlobalConfig());
+                }
+
                 if (reuseProjectRootElementCache)
                 {
                     s_projectRootElementCache = ProjectRootElementCache;
                 }
-            }
-
-            // Load the global Directory.Parse.config unless explicitly provided or disabled.
-            if (_unknownElementsConfiguration is null && !Traits.Instance.EscapeHatches.DisableParseConfig)
-            {
-                _unknownElementsConfiguration = UnknownElementsConfiguration.LoadGlobalConfig();
-                ProjectRootElementCache.UnknownElementsConfiguration = _unknownElementsConfiguration;
             }
 
             OnlyLogCriticalEvents = onlyLogCriticalEvents;
@@ -578,11 +575,57 @@ namespace Microsoft.Build.Evaluation
         /// </summary>
         internal UnknownElementsConfiguration UnknownElementsConfiguration
         {
-            get => _unknownElementsConfiguration;
-            set
+            get => ProjectRootElementCache.UnknownElementsConfiguration;
+            set => ProjectRootElementCache.SetUnknownElementsConfiguration(value);
+        }
+
+        /// <summary>
+        /// The config state before LoadParseConfigForStartup was called, used to restore on unload.
+        /// </summary>
+        private UnknownElementsConfiguration _preStartupUnknownElementsConfiguration;
+
+        /// <summary>
+        /// Loads a Directory.Parse.config by walking up from the specified directory
+        /// and adds it to the current parse configuration. Call <see cref="UnloadParseConfigForStartup"/>
+        /// to restore the previous state after the build completes.
+        /// </summary>
+        /// <param name="startingDirectory">The directory to start searching from (typically the build's working directory).</param>
+        /// <exception cref="InvalidOperationException">Thrown if startup config is already loaded.</exception>
+        public void LoadParseConfigForStartup(string startingDirectory)
+        {
+            if (_preStartupUnknownElementsConfiguration is not null)
             {
-                _unknownElementsConfiguration = value;
-                ProjectRootElementCache.UnknownElementsConfiguration = value;
+                throw new InvalidOperationException("LoadParseConfigForStartup called while startup config is already loaded. Call UnloadParseConfigForStartup first.");
+            }
+
+            if (Traits.Instance.EscapeHatches.DisableParseConfig || string.IsNullOrEmpty(startingDirectory))
+            {
+                return;
+            }
+
+            var config = ProjectRootElementCache.UnknownElementsConfiguration;
+            if (config is null)
+            {
+                return;
+            }
+
+            string configPath = FileUtilities.GetPathOfFileAbove(UnknownElementsConfiguration.ConfigFileName, startingDirectory);
+            if (!string.IsNullOrEmpty(configPath) && !config.ContainsLoadedFile(configPath))
+            {
+                _preStartupUnknownElementsConfiguration = config;
+                ProjectRootElementCache.SetUnknownElementsConfiguration(UnknownElementsConfiguration.Merge(config, UnknownElementsConfiguration.LoadFromFile(configPath)));
+            }
+        }
+
+        /// <summary>
+        /// Restores the parse configuration to the state before <see cref="LoadParseConfigForStartup"/> was called.
+        /// </summary>
+        public void UnloadParseConfigForStartup()
+        {
+            if (_preStartupUnknownElementsConfiguration is not null)
+            {
+                ProjectRootElementCache.SetUnknownElementsConfiguration(_preStartupUnknownElementsConfiguration);
+                _preStartupUnknownElementsConfiguration = null;
             }
         }
 

--- a/src/Build/Definition/ProjectCollection.cs
+++ b/src/Build/Definition/ProjectCollection.cs
@@ -205,6 +205,8 @@ namespace Microsoft.Build.Evaluation
         /// </summary>
         private int _maxNodeCount;
 
+        private UnknownElementsConfiguration _unknownElementsConfiguration;
+
         /// <summary>
         /// LoggingService Logger mode.
         /// If Asynchronous mode is used
@@ -387,6 +389,13 @@ namespace Microsoft.Build.Evaluation
                 }
             }
 
+            // Load the global Directory.Parse.config unless explicitly provided or disabled.
+            if (_unknownElementsConfiguration is null && !Traits.Instance.EscapeHatches.DisableParseConfig)
+            {
+                _unknownElementsConfiguration = UnknownElementsConfiguration.LoadGlobalConfig();
+                ProjectRootElementCache.UnknownElementsConfiguration = _unknownElementsConfiguration;
+            }
+
             OnlyLogCriticalEvents = onlyLogCriticalEvents;
             EnableTargetOutputLogging = enableTargetOutputLogging;
 
@@ -562,6 +571,20 @@ namespace Microsoft.Build.Evaluation
         /// Properties passed from the command line (e.g. by using /p:).
         /// </summary>
         public ICollection<string> PropertiesFromCommandLine { get; set; }
+
+        /// <summary>
+        /// Gets or sets the configuration for allowed unknown attributes/elements during parsing.
+        /// When set, this configuration will be used by builds started from this collection.
+        /// </summary>
+        internal UnknownElementsConfiguration UnknownElementsConfiguration
+        {
+            get => _unknownElementsConfiguration;
+            set
+            {
+                _unknownElementsConfiguration = value;
+                ProjectRootElementCache.UnknownElementsConfiguration = value;
+            }
+        }
 
         /// <summary>
         /// The default tools version of this project collection. Projects use this tools version if they

--- a/src/Build/Definition/ProjectCollection.cs
+++ b/src/Build/Definition/ProjectCollection.cs
@@ -405,6 +405,8 @@ namespace Microsoft.Build.Evaluation
 
             if (!Traits.Instance.EscapeHatches.DisableParseConfig)
             {
+                ParserIgnoreConfiguration.ClearBinlogEmbedPaths();
+
                 var config = ParserIgnoreConfiguration.LoadGlobalConfig();
 
                 if (!string.IsNullOrEmpty(parseConfigDirectory))

--- a/src/Build/Definition/ProjectCollection.cs
+++ b/src/Build/Definition/ProjectCollection.cs
@@ -384,7 +384,7 @@ namespace Microsoft.Build.Evaluation
                 
                 if (!Traits.Instance.EscapeHatches.DisableParseConfig)
                 {
-                    ProjectRootElementCache.SetUnknownElementsConfiguration(UnknownElementsConfiguration.LoadGlobalConfig());
+                    ProjectRootElementCache.SetParserIgnoreConfiguration(ParserIgnoreConfiguration.LoadGlobalConfig());
                 }
 
                 if (reuseProjectRootElementCache)
@@ -573,16 +573,16 @@ namespace Microsoft.Build.Evaluation
         /// Gets or sets the configuration for allowed unknown attributes/elements during parsing.
         /// When set, this configuration will be used by builds started from this collection.
         /// </summary>
-        internal UnknownElementsConfiguration UnknownElementsConfiguration
+        internal ParserIgnoreConfiguration ParserIgnoreConfiguration
         {
-            get => ProjectRootElementCache.UnknownElementsConfiguration;
-            set => ProjectRootElementCache.SetUnknownElementsConfiguration(value);
+            get => ProjectRootElementCache.ParserIgnoreConfiguration;
+            set => ProjectRootElementCache.SetParserIgnoreConfiguration(value);
         }
 
         /// <summary>
         /// The config state before LoadParseConfigForStartup was called, used to restore on unload.
         /// </summary>
-        private UnknownElementsConfiguration _preStartupUnknownElementsConfiguration;
+        private ParserIgnoreConfiguration _preStartupParserIgnoreConfiguration;
 
         /// <summary>
         /// Loads a Directory.Parse.config by walking up from the specified directory
@@ -593,7 +593,7 @@ namespace Microsoft.Build.Evaluation
         /// <exception cref="InvalidOperationException">Thrown if startup config is already loaded.</exception>
         public void LoadParseConfigForStartup(string startingDirectory)
         {
-            if (_preStartupUnknownElementsConfiguration is not null)
+            if (_preStartupParserIgnoreConfiguration is not null)
             {
                 throw new InvalidOperationException("LoadParseConfigForStartup called while startup config is already loaded. Call UnloadParseConfigForStartup first.");
             }
@@ -603,17 +603,17 @@ namespace Microsoft.Build.Evaluation
                 return;
             }
 
-            var config = ProjectRootElementCache.UnknownElementsConfiguration;
+            var config = ProjectRootElementCache.ParserIgnoreConfiguration;
             if (config is null)
             {
                 return;
             }
 
-            string configPath = FileUtilities.GetPathOfFileAbove(UnknownElementsConfiguration.ConfigFileName, startingDirectory);
+            string configPath = FileUtilities.GetPathOfFileAbove(ParserIgnoreConfiguration.ConfigFileName, startingDirectory);
             if (!string.IsNullOrEmpty(configPath) && !config.ContainsLoadedFile(configPath))
             {
-                _preStartupUnknownElementsConfiguration = config;
-                ProjectRootElementCache.SetUnknownElementsConfiguration(UnknownElementsConfiguration.Merge(config, UnknownElementsConfiguration.LoadFromFile(configPath)));
+                _preStartupParserIgnoreConfiguration = config;
+                ProjectRootElementCache.SetParserIgnoreConfiguration(ParserIgnoreConfiguration.Merge(config, ParserIgnoreConfiguration.LoadFromFile(configPath)));
             }
         }
 
@@ -622,10 +622,10 @@ namespace Microsoft.Build.Evaluation
         /// </summary>
         public void UnloadParseConfigForStartup()
         {
-            if (_preStartupUnknownElementsConfiguration is not null)
+            if (_preStartupParserIgnoreConfiguration is not null)
             {
-                ProjectRootElementCache.SetUnknownElementsConfiguration(_preStartupUnknownElementsConfiguration);
-                _preStartupUnknownElementsConfiguration = null;
+                ProjectRootElementCache.SetParserIgnoreConfiguration(_preStartupParserIgnoreConfiguration);
+                _preStartupParserIgnoreConfiguration = null;
             }
         }
 

--- a/src/Build/Definition/ProjectCollection.cs
+++ b/src/Build/Definition/ProjectCollection.cs
@@ -251,7 +251,7 @@ namespace Microsoft.Build.Evaluation
         /// <param name="loggers">The loggers to register. May be null.</param>
         /// <param name="toolsetDefinitionLocations">The locations from which to load toolsets.</param>
         public ProjectCollection(IDictionary<string, string> globalProperties, IEnumerable<ILogger> loggers, ToolsetDefinitionLocations toolsetDefinitionLocations)
-            : this(globalProperties, loggers, toolsetDefinitionLocations, 1 /* node count */, false /* do not only log critical events */, loadProjectsReadOnly: false, useAsynchronousLogging: false, reuseProjectRootElementCache: false, enableTargetOutputLogging: false)
+            : this(globalProperties, loggers, toolsetDefinitionLocations, 1 /* node count */, false /* do not only log critical events */, loadProjectsReadOnly: false, useAsynchronousLogging: false, reuseProjectRootElementCache: false, enableTargetOutputLogging: false, parseConfigDirectory: null)
         {
         }
 
@@ -338,12 +338,27 @@ namespace Microsoft.Build.Evaluation
         /// <param name="enableTargetOutputLogging">If set to true, loggers will collect and send Target outputs when targets are finished executing.</param>
         [RequiresUnreferencedCode("Registers loggers, which can load forwarding logger assemblies by reflection at runtime; incompatible with trimming.")]
         public ProjectCollection(IDictionary<string, string> globalProperties, IEnumerable<ILogger> loggers, IEnumerable<ForwardingLoggerRecord> remoteLoggers, ToolsetDefinitionLocations toolsetDefinitionLocations, int maxNodeCount, bool onlyLogCriticalEvents, bool loadProjectsReadOnly, bool useAsynchronousLogging, bool reuseProjectRootElementCache, bool enableTargetOutputLogging)
-            : this(globalProperties, loggers, toolsetDefinitionLocations, maxNodeCount, onlyLogCriticalEvents, loadProjectsReadOnly, useAsynchronousLogging, reuseProjectRootElementCache, enableTargetOutputLogging)
+            : this(globalProperties, loggers, toolsetDefinitionLocations, maxNodeCount, onlyLogCriticalEvents, loadProjectsReadOnly, useAsynchronousLogging, reuseProjectRootElementCache, enableTargetOutputLogging, parseConfigDirectory: null)
         {
-            // Forwarding loggers load logger assemblies by reflection, which is incompatible with
-            // trimming - that is why every overload taking forwarding loggers is RequiresUnreferencedCode
-            // while the overloads taking none are not. The trim-safe construction happens in the chained
-            // private constructor above; only this reflective registration is gated behind the attribute.
+            try
+            {
+                RegisterForwardingLoggers(remoteLoggers);
+            }
+            catch (Exception)
+            {
+                ShutDownLoggingService();
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Instantiates a project collection with the specified parameters and a directory to search
+        /// for a Directory.Parse.config file (walked upward from the given directory).
+        /// </summary>
+        [RequiresUnreferencedCode("Registers loggers, which can load forwarding logger assemblies by reflection at runtime; incompatible with trimming.")]
+        public ProjectCollection(IDictionary<string, string> globalProperties, IEnumerable<ILogger> loggers, IEnumerable<ForwardingLoggerRecord> remoteLoggers, ToolsetDefinitionLocations toolsetDefinitionLocations, int maxNodeCount, bool onlyLogCriticalEvents, bool loadProjectsReadOnly, bool useAsynchronousLogging, bool reuseProjectRootElementCache, bool enableTargetOutputLogging, string parseConfigDirectory)
+            : this(globalProperties, loggers, toolsetDefinitionLocations, maxNodeCount, onlyLogCriticalEvents, loadProjectsReadOnly, useAsynchronousLogging, reuseProjectRootElementCache, enableTargetOutputLogging, parseConfigDirectory)
+        {
             try
             {
                 RegisterForwardingLoggers(remoteLoggers);
@@ -360,7 +375,7 @@ namespace Microsoft.Build.Evaluation
         /// registers ordinary (non-forwarding) loggers, but does not load forwarding loggers by
         /// reflection, so the overloads that take none can be called without RequiresUnreferencedCode.
         /// </summary>
-        private ProjectCollection(IDictionary<string, string> globalProperties, IEnumerable<ILogger> loggers, ToolsetDefinitionLocations toolsetDefinitionLocations, int maxNodeCount, bool onlyLogCriticalEvents, bool loadProjectsReadOnly, bool useAsynchronousLogging, bool reuseProjectRootElementCache, bool enableTargetOutputLogging)
+        private ProjectCollection(IDictionary<string, string> globalProperties, IEnumerable<ILogger> loggers, ToolsetDefinitionLocations toolsetDefinitionLocations, int maxNodeCount, bool onlyLogCriticalEvents, bool loadProjectsReadOnly, bool useAsynchronousLogging, bool reuseProjectRootElementCache, bool enableTargetOutputLogging, string parseConfigDirectory)
         {
             _loadedProjects = new LoadedProjectCollection();
             ToolsetLocations = toolsetDefinitionLocations;
@@ -381,16 +396,27 @@ namespace Microsoft.Build.Evaluation
                 // we do not need to auto reload.
                 bool autoReloadFromDisk = reuseProjectRootElementCache;
                 ProjectRootElementCache = new ProjectRootElementCache(autoReloadFromDisk, loadProjectsReadOnly);
-                
-                if (!Traits.Instance.EscapeHatches.DisableParseConfig)
-                {
-                    ProjectRootElementCache.SetParserIgnoreConfiguration(ParserIgnoreConfiguration.LoadGlobalConfig());
-                }
 
                 if (reuseProjectRootElementCache)
                 {
                     s_projectRootElementCache = ProjectRootElementCache;
                 }
+            }
+
+            if (!Traits.Instance.EscapeHatches.DisableParseConfig)
+            {
+                var config = ParserIgnoreConfiguration.LoadGlobalConfig();
+
+                if (!string.IsNullOrEmpty(parseConfigDirectory))
+                {
+                    string configPath = FileUtilities.GetPathOfFileAbove(ParserIgnoreConfiguration.ConfigFileName, parseConfigDirectory);
+                    if (!string.IsNullOrEmpty(configPath) && !config.ContainsLoadedFile(configPath))
+                    {
+                        config = ParserIgnoreConfiguration.Merge(config, ParserIgnoreConfiguration.LoadFromFile(configPath));
+                    }
+                }
+
+                ProjectRootElementCache.SetParserIgnoreConfiguration(config);
             }
 
             OnlyLogCriticalEvents = onlyLogCriticalEvents;
@@ -498,7 +524,7 @@ namespace Microsoft.Build.Evaluation
                     // Take care to ensure that there is never more than one value observed
                     // from this property even in the case of race conditions while lazily initializing.
                     var local = new ProjectCollection(null, null, ToolsetDefinitionLocations.Default,
-                        maxNodeCount: 1, onlyLogCriticalEvents: false, loadProjectsReadOnly: false, useAsynchronousLogging: true, reuseProjectRootElementCache: false, enableTargetOutputLogging: false);
+                        maxNodeCount: 1, onlyLogCriticalEvents: false, loadProjectsReadOnly: false, useAsynchronousLogging: true, reuseProjectRootElementCache: false, enableTargetOutputLogging: false, parseConfigDirectory: null);
 
                     if (Interlocked.CompareExchange(ref s_globalProjectCollection, local, null) != null)
                     {
@@ -577,56 +603,6 @@ namespace Microsoft.Build.Evaluation
         {
             get => ProjectRootElementCache.ParserIgnoreConfiguration;
             set => ProjectRootElementCache.SetParserIgnoreConfiguration(value);
-        }
-
-        /// <summary>
-        /// The config state before LoadParseConfigForStartup was called, used to restore on unload.
-        /// </summary>
-        private ParserIgnoreConfiguration _preStartupParserIgnoreConfiguration;
-
-        /// <summary>
-        /// Loads a Directory.Parse.config by walking up from the specified directory
-        /// and adds it to the current parse configuration. Call <see cref="UnloadParseConfigForStartup"/>
-        /// to restore the previous state after the build completes.
-        /// </summary>
-        /// <param name="startingDirectory">The directory to start searching from (typically the build's working directory).</param>
-        /// <exception cref="InvalidOperationException">Thrown if startup config is already loaded.</exception>
-        public void LoadParseConfigForStartup(string startingDirectory)
-        {
-            if (_preStartupParserIgnoreConfiguration is not null)
-            {
-                throw new InvalidOperationException("LoadParseConfigForStartup called while startup config is already loaded. Call UnloadParseConfigForStartup first.");
-            }
-
-            if (Traits.Instance.EscapeHatches.DisableParseConfig || string.IsNullOrEmpty(startingDirectory))
-            {
-                return;
-            }
-
-            var config = ProjectRootElementCache.ParserIgnoreConfiguration;
-            if (config is null)
-            {
-                return;
-            }
-
-            string configPath = FileUtilities.GetPathOfFileAbove(ParserIgnoreConfiguration.ConfigFileName, startingDirectory);
-            if (!string.IsNullOrEmpty(configPath) && !config.ContainsLoadedFile(configPath))
-            {
-                _preStartupParserIgnoreConfiguration = config;
-                ProjectRootElementCache.SetParserIgnoreConfiguration(ParserIgnoreConfiguration.Merge(config, ParserIgnoreConfiguration.LoadFromFile(configPath)));
-            }
-        }
-
-        /// <summary>
-        /// Restores the parse configuration to the state before <see cref="LoadParseConfigForStartup"/> was called.
-        /// </summary>
-        public void UnloadParseConfigForStartup()
-        {
-            if (_preStartupParserIgnoreConfiguration is not null)
-            {
-                ProjectRootElementCache.SetParserIgnoreConfiguration(_preStartupParserIgnoreConfiguration);
-                _preStartupParserIgnoreConfiguration = null;
-            }
         }
 
         /// <summary>

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -707,6 +707,23 @@ namespace Microsoft.Build.Evaluation
                 if (configMessage is not null)
                 {
                     _evaluationLoggingContext.LogCommentFromText(MessageImportance.Low, configMessage);
+
+                    // Embed the config files in the binlog by logging them as imports
+                    foreach (string configFile in _unknownElementsConfiguration.LoadedConfigFiles)
+                    {
+                        var importArgs = new ProjectImportedEventArgs(
+                            -1,
+                            -1,
+                            "Loaded Directory.Parse.config: {0}",
+                            configFile)
+                        {
+                            BuildEventContext = _evaluationLoggingContext.BuildEventContext,
+                            ImportedProjectFile = configFile,
+                            ProjectFile = _projectRootElement.FullPath,
+                        };
+
+                        _evaluationLoggingContext.LogBuildEvent(importArgs);
+                    }
                 }
 
                 // Track loads only after start of evaluation was actually logged

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -330,14 +330,14 @@ namespace Microsoft.Build.Evaluation
             }
             else if (!_unknownElementsConfiguration.ContainsLoadedFile(projectConfigPath))
             {
-                _unknownElementsConfiguration = _unknownElementsConfiguration.Merge(UnknownElementsConfiguration.LoadFromFile(projectConfigPath));
+                _unknownElementsConfiguration = UnknownElementsConfiguration.Merge(_unknownElementsConfiguration, UnknownElementsConfiguration.LoadFromFile(projectConfigPath));
             }
             else
             {
                 return;
             }
 
-            _projectRootElementCache.UnknownElementsConfiguration = _unknownElementsConfiguration;
+            _projectRootElementCache.SetUnknownElementsConfiguration(_unknownElementsConfiguration);
         }
 
         /// <summary>

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -192,6 +192,8 @@ namespace Microsoft.Build.Evaluation
         /// </summary>
         private readonly ProjectRootElementCacheBase _projectRootElementCache;
 
+        private UnknownElementsConfiguration _unknownElementsConfiguration;
+
         /// <summary>
         /// The logging context to be used and piped down throughout evaluation.
         /// </summary>
@@ -307,6 +309,37 @@ namespace Microsoft.Build.Evaluation
             _streamImports.Add(string.Empty);
         }
 
+        private void InitializeUnknownElementsConfiguration()
+        {
+            _unknownElementsConfiguration = _projectRootElementCache.UnknownElementsConfiguration;
+
+            if (Traits.Instance.EscapeHatches.DisableParseConfig || string.IsNullOrEmpty(_projectRootElement.FullPath))
+            {
+                return;
+            }
+
+            string projectConfigPath = FileUtilities.GetPathOfFileAbove(UnknownElementsConfiguration.ConfigFileName, _projectRootElement.DirectoryPath);
+            if (string.IsNullOrEmpty(projectConfigPath))
+            {
+                return;
+            }
+
+            if (_unknownElementsConfiguration is null)
+            {
+                _unknownElementsConfiguration = UnknownElementsConfiguration.LoadFromFile(projectConfigPath);
+            }
+            else if (!_unknownElementsConfiguration.ContainsLoadedFile(projectConfigPath))
+            {
+                _unknownElementsConfiguration = _unknownElementsConfiguration.Merge(UnknownElementsConfiguration.LoadFromFile(projectConfigPath));
+            }
+            else
+            {
+                return;
+            }
+
+            _projectRootElementCache.UnknownElementsConfiguration = _unknownElementsConfiguration;
+        }
+
         /// <summary>
         /// Delegate passed to methods to provide basic expression evaluation
         /// ability, without having a language service.
@@ -390,6 +423,12 @@ namespace Microsoft.Build.Evaluation
                     globalProperties = evaluator._data.GlobalPropertiesDictionary;
                     properties = Traits.LogAllEnvironmentVariables ? evaluator._data.Properties : evaluator.FilterOutEnvironmentDerivedProperties(evaluator._data.Properties);
                     items = evaluator._data.Items;
+                }
+
+                string skippedMessage = evaluator._unknownElementsConfiguration?.GetSkippedSummaryMessage();
+                if (skippedMessage is not null)
+                {
+                    evaluator._evaluationLoggingContext.LogCommentFromText(MessageImportance.Low, skippedMessage);
                 }
 
                 evaluator._evaluationLoggingContext.LogProjectEvaluationFinished(globalProperties, properties, items, evaluator._evaluationProfiler.ProfiledResult);
@@ -661,6 +700,14 @@ namespace Microsoft.Build.Evaluation
                 Assumed.Equal(_data.EvaluationId, BuildEventContext.InvalidEvaluationId, "There is no prior evaluation ID. The evaluator data needs to be reset at this point");
                 _data.EvaluationId = _evaluationLoggingContext.BuildEventContext.EvaluationId;
                 _evaluationLoggingContext.LogProjectEvaluationStarted();
+
+                InitializeUnknownElementsConfiguration();
+
+                string configMessage = _unknownElementsConfiguration?.GetLoadedConfigsMessage();
+                if (configMessage is not null)
+                {
+                    _evaluationLoggingContext.LogCommentFromText(MessageImportance.Low, configMessage);
+                }
 
                 // Track loads only after start of evaluation was actually logged
                 using var assemblyLoadsTracker =

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -192,7 +192,7 @@ namespace Microsoft.Build.Evaluation
         /// </summary>
         private readonly ProjectRootElementCacheBase _projectRootElementCache;
 
-        private UnknownElementsConfiguration _unknownElementsConfiguration;
+        private ParserIgnoreConfiguration _ParserIgnoreConfiguration;
 
         /// <summary>
         /// The logging context to be used and piped down throughout evaluation.
@@ -309,35 +309,35 @@ namespace Microsoft.Build.Evaluation
             _streamImports.Add(string.Empty);
         }
 
-        private void InitializeUnknownElementsConfiguration()
+        private void InitializeParserIgnoreConfiguration()
         {
-            _unknownElementsConfiguration = _projectRootElementCache.UnknownElementsConfiguration;
+            _ParserIgnoreConfiguration = _projectRootElementCache.ParserIgnoreConfiguration;
 
             if (Traits.Instance.EscapeHatches.DisableParseConfig || string.IsNullOrEmpty(_projectRootElement.FullPath))
             {
                 return;
             }
 
-            string projectConfigPath = FileUtilities.GetPathOfFileAbove(UnknownElementsConfiguration.ConfigFileName, _projectRootElement.DirectoryPath);
+            string projectConfigPath = FileUtilities.GetPathOfFileAbove(ParserIgnoreConfiguration.ConfigFileName, _projectRootElement.DirectoryPath);
             if (string.IsNullOrEmpty(projectConfigPath))
             {
                 return;
             }
 
-            if (_unknownElementsConfiguration is null)
+            if (_ParserIgnoreConfiguration is null)
             {
-                _unknownElementsConfiguration = UnknownElementsConfiguration.LoadFromFile(projectConfigPath);
+                _ParserIgnoreConfiguration = ParserIgnoreConfiguration.LoadFromFile(projectConfigPath);
             }
-            else if (!_unknownElementsConfiguration.ContainsLoadedFile(projectConfigPath))
+            else if (!_ParserIgnoreConfiguration.ContainsLoadedFile(projectConfigPath))
             {
-                _unknownElementsConfiguration = UnknownElementsConfiguration.Merge(_unknownElementsConfiguration, UnknownElementsConfiguration.LoadFromFile(projectConfigPath));
+                _ParserIgnoreConfiguration = ParserIgnoreConfiguration.Merge(_ParserIgnoreConfiguration, ParserIgnoreConfiguration.LoadFromFile(projectConfigPath));
             }
             else
             {
                 return;
             }
 
-            _projectRootElementCache.SetUnknownElementsConfiguration(_unknownElementsConfiguration);
+            _projectRootElementCache.SetParserIgnoreConfiguration(_ParserIgnoreConfiguration);
         }
 
         /// <summary>
@@ -425,7 +425,7 @@ namespace Microsoft.Build.Evaluation
                     items = evaluator._data.Items;
                 }
 
-                string skippedMessage = evaluator._unknownElementsConfiguration?.GetSkippedSummaryMessage();
+                string skippedMessage = evaluator._ParserIgnoreConfiguration?.GetSkippedSummaryMessage();
                 if (skippedMessage is not null)
                 {
                     evaluator._evaluationLoggingContext.LogCommentFromText(MessageImportance.Low, skippedMessage);
@@ -701,9 +701,9 @@ namespace Microsoft.Build.Evaluation
                 _data.EvaluationId = _evaluationLoggingContext.BuildEventContext.EvaluationId;
                 _evaluationLoggingContext.LogProjectEvaluationStarted();
 
-                InitializeUnknownElementsConfiguration();
+                InitializeParserIgnoreConfiguration();
 
-                string configMessage = _unknownElementsConfiguration?.GetLoadedConfigsMessage();
+                string configMessage = _ParserIgnoreConfiguration?.GetLoadedConfigsMessage();
                 if (configMessage is not null)
                 {
                     _evaluationLoggingContext.LogCommentFromText(MessageImportance.Low, configMessage);

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -192,8 +192,6 @@ namespace Microsoft.Build.Evaluation
         /// </summary>
         private readonly ProjectRootElementCacheBase _projectRootElementCache;
 
-        private ParserIgnoreConfiguration _ParserIgnoreConfiguration;
-
         /// <summary>
         /// The logging context to be used and piped down throughout evaluation.
         /// </summary>
@@ -309,36 +307,6 @@ namespace Microsoft.Build.Evaluation
             _streamImports.Add(string.Empty);
         }
 
-        private void InitializeParserIgnoreConfiguration()
-        {
-            _ParserIgnoreConfiguration = _projectRootElementCache.ParserIgnoreConfiguration;
-
-            if (Traits.Instance.EscapeHatches.DisableParseConfig || string.IsNullOrEmpty(_projectRootElement.FullPath))
-            {
-                return;
-            }
-
-            string projectConfigPath = FileUtilities.GetPathOfFileAbove(ParserIgnoreConfiguration.ConfigFileName, _projectRootElement.DirectoryPath);
-            if (string.IsNullOrEmpty(projectConfigPath))
-            {
-                return;
-            }
-
-            if (_ParserIgnoreConfiguration is null)
-            {
-                _ParserIgnoreConfiguration = ParserIgnoreConfiguration.LoadFromFile(projectConfigPath);
-            }
-            else if (!_ParserIgnoreConfiguration.ContainsLoadedFile(projectConfigPath))
-            {
-                _ParserIgnoreConfiguration = ParserIgnoreConfiguration.Merge(_ParserIgnoreConfiguration, ParserIgnoreConfiguration.LoadFromFile(projectConfigPath));
-            }
-            else
-            {
-                return;
-            }
-
-            _projectRootElementCache.SetParserIgnoreConfiguration(_ParserIgnoreConfiguration);
-        }
 
         /// <summary>
         /// Delegate passed to methods to provide basic expression evaluation
@@ -425,7 +393,7 @@ namespace Microsoft.Build.Evaluation
                     items = evaluator._data.Items;
                 }
 
-                string skippedMessage = evaluator._ParserIgnoreConfiguration?.GetSkippedSummaryMessage();
+                string skippedMessage = evaluator._projectRootElementCache.ParserIgnoreConfiguration?.GetSkippedSummaryMessage();
                 if (skippedMessage is not null)
                 {
                     evaluator._evaluationLoggingContext.LogCommentFromText(MessageImportance.Low, skippedMessage);
@@ -701,9 +669,7 @@ namespace Microsoft.Build.Evaluation
                 _data.EvaluationId = _evaluationLoggingContext.BuildEventContext.EvaluationId;
                 _evaluationLoggingContext.LogProjectEvaluationStarted();
 
-                InitializeParserIgnoreConfiguration();
-
-                string configMessage = _ParserIgnoreConfiguration?.GetLoadedConfigsMessage();
+                string configMessage = _projectRootElementCache.ParserIgnoreConfiguration?.GetLoadedConfigsMessage();
                 if (configMessage is not null)
                 {
                     _evaluationLoggingContext.LogCommentFromText(MessageImportance.Low, configMessage);

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -707,23 +707,6 @@ namespace Microsoft.Build.Evaluation
                 if (configMessage is not null)
                 {
                     _evaluationLoggingContext.LogCommentFromText(MessageImportance.Low, configMessage);
-
-                    // Embed the config files in the binlog by logging them as imports
-                    foreach (string configFile in _unknownElementsConfiguration.LoadedConfigFiles)
-                    {
-                        var importArgs = new ProjectImportedEventArgs(
-                            -1,
-                            -1,
-                            "Loaded Directory.Parse.config: {0}",
-                            configFile)
-                        {
-                            BuildEventContext = _evaluationLoggingContext.BuildEventContext,
-                            ImportedProjectFile = configFile,
-                            ProjectFile = _projectRootElement.FullPath,
-                        };
-
-                        _evaluationLoggingContext.LogBuildEvent(importArgs);
-                    }
                 }
 
                 // Track loads only after start of evaluation was actually logged

--- a/src/Build/Evaluation/ParserIgnoreConfiguration.cs
+++ b/src/Build/Evaluation/ParserIgnoreConfiguration.cs
@@ -26,6 +26,14 @@ namespace Microsoft.Build.Evaluation
         internal const string ConfigFileName = "Directory.Parse.config";
         internal const string EnvironmentVariableName = "MSBUILD_PARSE_CONFIG";
 
+        // Generic element names for dynamically-named elements in the config.
+        // These allow rules like Attribute:Property:X to apply to all property elements.
+        internal const string GenericPropertyElement = "Property";
+        internal const string GenericItemElement = "Item";
+        internal const string GenericItemDefinitionElement = "ItemDefinition";
+        internal const string GenericMetadataElement = "Metadata";
+        internal const string GenericUsingTaskBodyElement = "UsingTaskBody";
+
         /// <summary>
         /// Static collection of config file paths to embed in the binlog.
         /// Populated during config loading, consumed by BinaryLogger.Shutdown.

--- a/src/Build/Evaluation/ParserIgnoreConfiguration.cs
+++ b/src/Build/Evaluation/ParserIgnoreConfiguration.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Build.Evaluation
     /// 2. User profile (~/.msbuild/)
     /// 3. MSBUILD_PARSE_CONFIG environment variable paths
     /// </summary>
-    internal sealed class UnknownElementsConfiguration : ITranslatable
+    internal sealed class ParserIgnoreConfiguration : ITranslatable
     {
         internal const string ConfigFileName = "Directory.Parse.config";
         internal const string EnvironmentVariableName = "MSBUILD_PARSE_CONFIG";
@@ -46,14 +46,14 @@ namespace Microsoft.Build.Evaluation
         private HashSet<string> _loadedConfigFiles;
         private readonly ConcurrentDictionary<string, int> _skippedItems = new(StringComparer.OrdinalIgnoreCase);
 
-        private UnknownElementsConfiguration()
+        private ParserIgnoreConfiguration()
         {
             _allowedAttributes = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
             _allowedChildren = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
             _loadedConfigFiles = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         }
 
-        private UnknownElementsConfiguration(ITranslator translator)
+        private ParserIgnoreConfiguration(ITranslator translator)
             : this()
         {
             ((ITranslatable)this).Translate(translator);
@@ -61,9 +61,9 @@ namespace Microsoft.Build.Evaluation
 
         internal IReadOnlyCollection<string> LoadedConfigFiles => _loadedConfigFiles;
 
-        internal static UnknownElementsConfiguration Empty { get; } = new UnknownElementsConfiguration();
+        internal static ParserIgnoreConfiguration Empty { get; } = new ParserIgnoreConfiguration();
 
-        public static bool Equals(UnknownElementsConfiguration? left, UnknownElementsConfiguration? right)
+        public static bool Equals(ParserIgnoreConfiguration? left, ParserIgnoreConfiguration? right)
         {
             if (ReferenceEquals(left, right))
             {
@@ -159,12 +159,12 @@ namespace Microsoft.Build.Evaluation
             return $"Loaded Directory.Parse.config from: {string.Join(", ", _loadedConfigFiles)}";
         }
 
-        internal static UnknownElementsConfiguration Merge(UnknownElementsConfiguration left, UnknownElementsConfiguration right)
+        internal static ParserIgnoreConfiguration Merge(ParserIgnoreConfiguration left, ParserIgnoreConfiguration right)
         {
             ArgumentNullException.ThrowIfNull(left);
             ArgumentNullException.ThrowIfNull(right);
 
-            var merged = new UnknownElementsConfiguration();
+            var merged = new ParserIgnoreConfiguration();
 
             UnionEntries(merged._allowedAttributes, left._allowedAttributes);
             UnionEntries(merged._allowedAttributes, right._allowedAttributes);
@@ -178,16 +178,16 @@ namespace Microsoft.Build.Evaluation
             return merged;
         }
 
-        internal static UnknownElementsConfiguration LoadFromFile(string filePath)
+        internal static ParserIgnoreConfiguration LoadFromFile(string filePath)
         {
-            var config = new UnknownElementsConfiguration();
+            var config = new ParserIgnoreConfiguration();
             config.LoadFile(filePath);
             return config;
         }
 
-        internal static UnknownElementsConfiguration LoadGlobalConfig()
+        internal static ParserIgnoreConfiguration LoadGlobalConfig()
         {
-            var config = new UnknownElementsConfiguration();
+            var config = new ParserIgnoreConfiguration();
 
             string? envValue = Environment.GetEnvironmentVariable(EnvironmentVariableName);
             if (!string.IsNullOrEmpty(envValue))
@@ -225,9 +225,9 @@ namespace Microsoft.Build.Evaluation
             return set ?? new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         }
 
-        internal static UnknownElementsConfiguration FactoryForDeserialization(ITranslator translator)
+        internal static ParserIgnoreConfiguration FactoryForDeserialization(ITranslator translator)
         {
-            return new UnknownElementsConfiguration(translator);
+            return new ParserIgnoreConfiguration(translator);
         }
 
         private static void UnionEntries(Dictionary<string, HashSet<string>> destination, Dictionary<string, HashSet<string>> source)

--- a/src/Build/Evaluation/ParserIgnoreConfiguration.cs
+++ b/src/Build/Evaluation/ParserIgnoreConfiguration.cs
@@ -16,10 +16,9 @@ namespace Microsoft.Build.Evaluation
     /// <summary>
     /// Manages a set of allowed unknown attributes and elements that should be silently skipped
     /// during project parsing instead of throwing an InvalidProjectFileException.
-    /// Configuration is loaded from Directory.Parse.config files discovered additively from:
-    /// 1. Next to the MSBuild executable
-    /// 2. User profile (~/.msbuild/)
-    /// 3. MSBUILD_PARSE_CONFIG environment variable paths
+    /// Configuration is loaded from Directory.Parse.config files discovered from:
+    /// 1. MSBUILD_PARSE_CONFIG environment variable paths
+    /// 2. Walking up from the project file's directory (passed via ProjectCollection constructor)
     /// </summary>
     internal sealed class ParserIgnoreConfiguration : ITranslatable
     {

--- a/src/Build/Evaluation/ParserIgnoreConfiguration.cs
+++ b/src/Build/Evaluation/ParserIgnoreConfiguration.cs
@@ -153,6 +153,8 @@ namespace Microsoft.Build.Evaluation
                 sb.Append($" {kvp.Key} ({kvp.Value} occurrence{(kvp.Value > 1 ? "s" : string.Empty)});");
             }
 
+            _skippedItems.Clear();
+
             sb.Length--;
             return sb.ToString();
         }

--- a/src/Build/Evaluation/ProjectParser.cs
+++ b/src/Build/Evaluation/ProjectParser.cs
@@ -86,7 +86,7 @@ namespace Microsoft.Build.Construction
         /// </summary>
         private readonly XmlDocumentWithLocation _document;
 
-        private readonly UnknownElementsConfiguration _unknownElementsConfiguration;
+        private readonly ParserIgnoreConfiguration _ParserIgnoreConfiguration;
 
         /// <summary>
         /// Whether a ProjectExtensions node has been encountered already.
@@ -97,14 +97,14 @@ namespace Microsoft.Build.Construction
         /// <summary>
         /// Private constructor to give static semantics
         /// </summary>
-        private ProjectParser(XmlDocumentWithLocation document, ProjectRootElement project, UnknownElementsConfiguration unknownElementsConfiguration)
+        private ProjectParser(XmlDocumentWithLocation document, ProjectRootElement project, ParserIgnoreConfiguration ParserIgnoreConfiguration)
         {
             Assumed.NotNull(project);
             Assumed.NotNull(document);
 
             _document = document;
             _project = project;
-            _unknownElementsConfiguration = unknownElementsConfiguration;
+            _ParserIgnoreConfiguration = ParserIgnoreConfiguration;
         }
 
         /// <summary>
@@ -115,11 +115,11 @@ namespace Microsoft.Build.Construction
         /// The code markers here used to be around the Project class constructor in the old code.
         /// In the new code, that's not very interesting; we are repurposing to wrap parsing the XML.
         /// </remarks>
-        internal static void Parse(XmlDocumentWithLocation document, ProjectRootElement projectRootElement, UnknownElementsConfiguration unknownElementsConfiguration)
+        internal static void Parse(XmlDocumentWithLocation document, ProjectRootElement projectRootElement, ParserIgnoreConfiguration ParserIgnoreConfiguration)
         {
             MSBuildEventSource.Log.ParseStart(projectRootElement.ProjectFileLocation.File);
             {
-                ProjectParser parser = new ProjectParser(document, projectRootElement, unknownElementsConfiguration);
+                ProjectParser parser = new ProjectParser(document, projectRootElement, ParserIgnoreConfiguration);
                 parser.Parse();
             }
             MSBuildEventSource.Log.ParseStop(projectRootElement.ProjectFileLocation.File);
@@ -208,7 +208,7 @@ namespace Microsoft.Build.Construction
                         break;
 
                     default:
-                        if (ProjectXmlUtilities.ThrowIfProjectInvalidChildElement(childElement.Name, childElement.ParentNode.Name, childElement.Location, _unknownElementsConfiguration))
+                        if (ProjectXmlUtilities.ThrowIfProjectInvalidChildElement(childElement.Name, childElement.ParentNode.Name, childElement.Location, _ParserIgnoreConfiguration))
                         {
                             continue;
                         }
@@ -223,13 +223,13 @@ namespace Microsoft.Build.Construction
         /// </summary>
         private ProjectPropertyGroupElement ParseProjectPropertyGroupElement(XmlElementWithLocation element, ProjectElementContainer parent)
         {
-            ProjectXmlUtilities.VerifyThrowProjectAttributes(element, ValidAttributesOnlyConditionAndLabel, _unknownElementsConfiguration);
+            ProjectXmlUtilities.VerifyThrowProjectAttributes(element, ValidAttributesOnlyConditionAndLabel, _ParserIgnoreConfiguration);
 
             ProjectPropertyGroupElement propertyGroup = new ProjectPropertyGroupElement(element, parent, _project);
 
             foreach (XmlElementWithLocation childElement in ProjectXmlUtilities.GetVerifyThrowProjectChildElements(element))
             {
-                ProjectXmlUtilities.VerifyThrowProjectAttributes(childElement, ValidAttributesOnlyConditionAndLabel, _unknownElementsConfiguration, "Property");
+                ProjectXmlUtilities.VerifyThrowProjectAttributes(childElement, ValidAttributesOnlyConditionAndLabel, _ParserIgnoreConfiguration, "Property");
                 XmlUtilities.VerifyThrowProjectValidElementName(childElement);
                 ProjectErrorUtilities.VerifyThrowInvalidProject(!XMakeElements.ReservedItemNames.Contains(childElement.Name) && !ReservedPropertyNames.IsReservedProperty(childElement.Name), childElement.Location, "CannotModifyReservedProperty", childElement.Name);
 
@@ -247,7 +247,7 @@ namespace Microsoft.Build.Construction
         /// </summary>
         private ProjectItemGroupElement ParseProjectItemGroupElement(XmlElementWithLocation element, ProjectElementContainer parent)
         {
-            ProjectXmlUtilities.VerifyThrowProjectAttributes(element, ValidAttributesOnlyConditionAndLabel, _unknownElementsConfiguration);
+            ProjectXmlUtilities.VerifyThrowProjectAttributes(element, ValidAttributesOnlyConditionAndLabel, _ParserIgnoreConfiguration);
 
             ProjectItemGroupElement itemGroup = new ProjectItemGroupElement(element, parent, _project);
 
@@ -328,7 +328,7 @@ namespace Microsoft.Build.Construction
 
                 if (!isKnownAttribute && !isValidMetadataNameInAttribute)
                 {
-                    if (_unknownElementsConfiguration?.CheckSkipAttribute("Item", attribute.Name) != true)
+                    if (_ParserIgnoreConfiguration?.CheckSkipAttribute("Item", attribute.Name) != true)
                     {
                         ProjectXmlUtilities.ThrowProjectInvalidAttribute(attribute);
                     }
@@ -403,7 +403,7 @@ namespace Microsoft.Build.Construction
         /// </summary>
         private ProjectMetadataElement ParseProjectMetadataElement(XmlElementWithLocation element, ProjectElementContainer parent)
         {
-            ProjectXmlUtilities.VerifyThrowProjectAttributes(element, ValidAttributesOnlyConditionAndLabel, _unknownElementsConfiguration, "Metadata");
+            ProjectXmlUtilities.VerifyThrowProjectAttributes(element, ValidAttributesOnlyConditionAndLabel, _ParserIgnoreConfiguration, "Metadata");
 
             XmlUtilities.VerifyThrowProjectValidElementName(element);
 
@@ -431,7 +431,7 @@ namespace Microsoft.Build.Construction
         /// <returns>A ProjectImportGroupElement derived from the XML element passed in</returns>
         private ProjectImportGroupElement ParseProjectImportGroupElement(XmlElementWithLocation element, ProjectRootElement parent)
         {
-            ProjectXmlUtilities.VerifyThrowProjectAttributes(element, ValidAttributesOnlyConditionAndLabel, _unknownElementsConfiguration);
+            ProjectXmlUtilities.VerifyThrowProjectAttributes(element, ValidAttributesOnlyConditionAndLabel, _ParserIgnoreConfiguration);
 
             ProjectImportGroupElement importGroup = new ProjectImportGroupElement(element, parent, _project);
 
@@ -439,7 +439,7 @@ namespace Microsoft.Build.Construction
             {
                 if (childElement.Name != XMakeElements.import)
                 {
-                    if (_unknownElementsConfiguration?.CheckSkipElement(element.Name, childElement.Name) == true)
+                    if (_ParserIgnoreConfiguration?.CheckSkipElement(element.Name, childElement.Name) == true)
                     {
                         continue;
                     }
@@ -471,9 +471,9 @@ namespace Microsoft.Build.Construction
                 parent,
                 element);
 
-            ProjectXmlUtilities.VerifyThrowProjectAttributes(element, ValidAttributesOnImport, _unknownElementsConfiguration);
+            ProjectXmlUtilities.VerifyThrowProjectAttributes(element, ValidAttributesOnImport, _ParserIgnoreConfiguration);
             ProjectXmlUtilities.VerifyThrowProjectRequiredAttribute(element, XMakeAttributes.project);
-            ProjectXmlUtilities.VerifyThrowProjectNoChildElements(element, _unknownElementsConfiguration);
+            ProjectXmlUtilities.VerifyThrowProjectNoChildElements(element, _ParserIgnoreConfiguration);
 
             SdkReference sdk = null;
             if (element.HasAttribute(XMakeAttributes.sdk))
@@ -493,7 +493,7 @@ namespace Microsoft.Build.Construction
         private UsingTaskParameterGroupElement ParseUsingTaskParameterGroupElement(XmlElementWithLocation element, ProjectElementContainer parent)
         {
             // There should be no attributes
-            ProjectXmlUtilities.VerifyThrowProjectNoAttributes(element, _unknownElementsConfiguration);
+            ProjectXmlUtilities.VerifyThrowProjectNoAttributes(element, _ParserIgnoreConfiguration);
 
             UsingTaskParameterGroupElement parameterGroup = new UsingTaskParameterGroupElement(element, parent, _project);
 
@@ -507,7 +507,7 @@ namespace Microsoft.Build.Construction
                 }
                 else
                 {
-                    ProjectXmlUtilities.VerifyThrowProjectAttributes(childElement, ValidAttributesOnUsingTaskParameter, _unknownElementsConfiguration, "Parameter");
+                    ProjectXmlUtilities.VerifyThrowProjectAttributes(childElement, ValidAttributesOnUsingTaskParameter, _ParserIgnoreConfiguration, "Parameter");
                     XmlUtilities.VerifyThrowProjectValidElementName(childElement);
                     ProjectUsingTaskParameterElement parameter = new ProjectUsingTaskParameterElement(childElement, parameterGroup, _project);
                     parameterGroup.AppendParentedChildNoChecks(parameter);
@@ -525,7 +525,7 @@ namespace Microsoft.Build.Construction
         /// </summary>
         private ProjectUsingTaskElement ParseProjectUsingTaskElement(XmlElementWithLocation element)
         {
-            ProjectXmlUtilities.VerifyThrowProjectAttributes(element, ValidAttributesOnUsingTask, _unknownElementsConfiguration);
+            ProjectXmlUtilities.VerifyThrowProjectAttributes(element, ValidAttributesOnUsingTask, _ParserIgnoreConfiguration);
             ProjectErrorUtilities.VerifyThrowInvalidProject(element.GetAttribute(XMakeAttributes.taskName).Length > 0, element.Location, "ProjectTaskNameEmpty");
 
             string assemblyName = element.GetAttribute(XMakeAttributes.assemblyName);
@@ -568,13 +568,13 @@ namespace Microsoft.Build.Construction
                             ProjectXmlUtilities.ThrowProjectInvalidChildElementDueToDuplicate(childElement);
                         }
 
-                        ProjectXmlUtilities.VerifyThrowProjectAttributes(childElement, ValidAttributesOnUsingTaskBody, _unknownElementsConfiguration, "UsingTaskBody");
+                        ProjectXmlUtilities.VerifyThrowProjectAttributes(childElement, ValidAttributesOnUsingTaskBody, _ParserIgnoreConfiguration, "UsingTaskBody");
 
                         child = new ProjectUsingTaskBodyElement(childElement, usingTask, _project);
                         foundTaskElement = true;
                         break;
                     default:
-                        if (ProjectXmlUtilities.ThrowIfProjectInvalidChildElement(childElement.Name, element.Name, element.Location, _unknownElementsConfiguration))
+                        if (ProjectXmlUtilities.ThrowIfProjectInvalidChildElement(childElement.Name, element.Name, element.Location, _ParserIgnoreConfiguration))
                         {
                             continue;
                         }
@@ -593,7 +593,7 @@ namespace Microsoft.Build.Construction
         /// </summary>
         private ProjectTargetElement ParseProjectTargetElement(XmlElementWithLocation element)
         {
-            ProjectXmlUtilities.VerifyThrowProjectAttributes(element, ValidAttributesOnTarget, _unknownElementsConfiguration);
+            ProjectXmlUtilities.VerifyThrowProjectAttributes(element, ValidAttributesOnTarget, _ParserIgnoreConfiguration);
             ProjectXmlUtilities.VerifyThrowProjectRequiredAttribute(element, XMakeAttributes.name);
 
             // Orcas compat: all target names are automatically unescaped
@@ -635,9 +635,9 @@ namespace Microsoft.Build.Construction
                     case XMakeElements.onError:
                         // Previous OM accidentally didn't verify ExecuteTargets on parse,
                         // but we do, as it makes no sense
-                        ProjectXmlUtilities.VerifyThrowProjectAttributes(childElement, ValidAttributesOnOnError, _unknownElementsConfiguration);
+                        ProjectXmlUtilities.VerifyThrowProjectAttributes(childElement, ValidAttributesOnOnError, _ParserIgnoreConfiguration);
                         ProjectXmlUtilities.VerifyThrowProjectRequiredAttribute(childElement, XMakeAttributes.executeTargets);
-                        ProjectXmlUtilities.VerifyThrowProjectNoChildElements(childElement, _unknownElementsConfiguration);
+                        ProjectXmlUtilities.VerifyThrowProjectNoChildElements(childElement, _ParserIgnoreConfiguration);
 
                         child = onError = new ProjectOnErrorElement(childElement, target, _project);
                         break;
@@ -689,7 +689,7 @@ namespace Microsoft.Build.Construction
             {
                 if (childElement.Name != XMakeElements.output)
                 {
-                    if (_unknownElementsConfiguration?.CheckSkipElement("Task", childElement.Name) == true)
+                    if (_ParserIgnoreConfiguration?.CheckSkipElement("Task", childElement.Name) == true)
                     {
                         continue;
                     }
@@ -710,9 +710,9 @@ namespace Microsoft.Build.Construction
         /// </summary>
         private ProjectOutputElement ParseProjectOutputElement(XmlElementWithLocation element, ProjectTaskElement parent)
         {
-            ProjectXmlUtilities.VerifyThrowProjectAttributes(element, ValidAttributesOnOutput, _unknownElementsConfiguration);
+            ProjectXmlUtilities.VerifyThrowProjectAttributes(element, ValidAttributesOnOutput, _ParserIgnoreConfiguration);
             ProjectXmlUtilities.VerifyThrowProjectRequiredAttribute(element, XMakeAttributes.taskParameter);
-            ProjectXmlUtilities.VerifyThrowProjectNoChildElements(element, _unknownElementsConfiguration);
+            ProjectXmlUtilities.VerifyThrowProjectNoChildElements(element, _ParserIgnoreConfiguration);
 
             XmlAttributeWithLocation itemNameAttribute = element.GetAttributeWithLocation(XMakeAttributes.itemName);
             XmlAttributeWithLocation propertyNameAttribute = element.GetAttributeWithLocation(XMakeAttributes.propertyName);
@@ -736,7 +736,7 @@ namespace Microsoft.Build.Construction
         /// </summary>
         private ProjectItemDefinitionGroupElement ParseProjectItemDefinitionGroupElement(XmlElementWithLocation element, ProjectElementContainer parent)
         {
-            ProjectXmlUtilities.VerifyThrowProjectAttributes(element, ValidAttributesOnlyConditionAndLabel, _unknownElementsConfiguration);
+            ProjectXmlUtilities.VerifyThrowProjectAttributes(element, ValidAttributesOnlyConditionAndLabel, _ParserIgnoreConfiguration);
 
             ProjectItemDefinitionGroupElement itemDefinitionGroup = new ProjectItemDefinitionGroupElement(element, parent, _project);
 
@@ -767,7 +767,7 @@ namespace Microsoft.Build.Construction
 
                 if (!isKnownAttribute && !isValidMetadataNameInAttribute)
                 {
-                    if (_unknownElementsConfiguration?.CheckSkipAttribute("ItemDefinition", attribute.Name) != true)
+                    if (_ParserIgnoreConfiguration?.CheckSkipAttribute("ItemDefinition", attribute.Name) != true)
                     {
                         ProjectXmlUtilities.ThrowProjectInvalidAttribute(attribute);
                     }
@@ -782,7 +782,7 @@ namespace Microsoft.Build.Construction
                 }
                 else if (!ValidAttributesOnlyConditionAndLabel.Contains(attribute.Name))
                 {
-                    if (_unknownElementsConfiguration?.CheckSkipAttribute("ItemDefinition", attribute.Name) != true)
+                    if (_ParserIgnoreConfiguration?.CheckSkipAttribute("ItemDefinition", attribute.Name) != true)
                     {
                         ProjectXmlUtilities.ThrowProjectInvalidAttribute(attribute);
                     }
@@ -804,7 +804,7 @@ namespace Microsoft.Build.Construction
         /// </summary>
         private ProjectChooseElement ParseProjectChooseElement(XmlElementWithLocation element, ProjectElementContainer parent, int nestingDepth)
         {
-            ProjectXmlUtilities.VerifyThrowProjectNoAttributes(element, _unknownElementsConfiguration);
+            ProjectXmlUtilities.VerifyThrowProjectNoAttributes(element, _ParserIgnoreConfiguration);
 
             ProjectChooseElement choose = new ProjectChooseElement(element, parent, _project);
 
@@ -833,7 +833,7 @@ namespace Microsoft.Build.Construction
                         break;
 
                     default:
-                        if (ProjectXmlUtilities.ThrowIfProjectInvalidChildElement(childElement.Name, element.Name, element.Location, _unknownElementsConfiguration))
+                        if (ProjectXmlUtilities.ThrowIfProjectInvalidChildElement(childElement.Name, element.Name, element.Location, _ParserIgnoreConfiguration))
                         {
                             continue;
                         }
@@ -868,7 +868,7 @@ namespace Microsoft.Build.Construction
         /// </summary>
         private ProjectOtherwiseElement ParseProjectOtherwiseElement(XmlElementWithLocation element, ProjectChooseElement parent, int nestingDepth)
         {
-            ProjectXmlUtilities.VerifyThrowProjectNoAttributes(element, _unknownElementsConfiguration);
+            ProjectXmlUtilities.VerifyThrowProjectNoAttributes(element, _ParserIgnoreConfiguration);
 
             ProjectOtherwiseElement otherwise = new ProjectOtherwiseElement(element, parent, _project);
 
@@ -905,7 +905,7 @@ namespace Microsoft.Build.Construction
                         break;
 
                     default:
-                        if (ProjectXmlUtilities.ThrowIfProjectInvalidChildElement(childElement.Name, element.Name, element.Location, _unknownElementsConfiguration))
+                        if (ProjectXmlUtilities.ThrowIfProjectInvalidChildElement(childElement.Name, element.Name, element.Location, _ParserIgnoreConfiguration))
                         {
                             continue;
                         }
@@ -924,7 +924,7 @@ namespace Microsoft.Build.Construction
         {
             // ProjectExtensions are only found in the main project file - in fact, the code used to ignore them in imported
             // files. We don't.
-            ProjectXmlUtilities.VerifyThrowProjectNoAttributes(element, _unknownElementsConfiguration);
+            ProjectXmlUtilities.VerifyThrowProjectNoAttributes(element, _ParserIgnoreConfiguration);
 
             ProjectErrorUtilities.VerifyThrowInvalidProject(!_seenProjectExtensions, element.Location, "DuplicateProjectExtensions");
             _seenProjectExtensions = true;

--- a/src/Build/Evaluation/ProjectParser.cs
+++ b/src/Build/Evaluation/ProjectParser.cs
@@ -437,12 +437,19 @@ namespace Microsoft.Build.Construction
 
             foreach (XmlElementWithLocation childElement in ProjectXmlUtilities.GetVerifyThrowProjectChildElements(element))
             {
-                ProjectErrorUtilities.VerifyThrowInvalidProject(
-                    childElement.Name == XMakeElements.import,
-                    childElement.Location,
-                    "UnrecognizedChildElement",
-                    childElement.Name,
-                    element.Name);
+                if (childElement.Name != XMakeElements.import)
+                {
+                    if (_unknownElementsConfiguration?.CheckSkipElement(element.Name, childElement.Name) == true)
+                    {
+                        continue;
+                    }
+
+                    ProjectErrorUtilities.ThrowInvalidProject(
+                        childElement.Location,
+                        "UnrecognizedChildElement",
+                        childElement.Name,
+                        element.Name);
+                }
 
                 ProjectImportElement item = ParseProjectImportElement(childElement, importGroup);
 
@@ -567,7 +574,7 @@ namespace Microsoft.Build.Construction
                         foundTaskElement = true;
                         break;
                     default:
-                        if (ProjectXmlUtilities.ThrowIfProjectInvalidChildElement(childElement.Name, "Task", element.Location, _unknownElementsConfiguration))
+                        if (ProjectXmlUtilities.ThrowIfProjectInvalidChildElement(childElement.Name, element.Name, element.Location, _unknownElementsConfiguration))
                         {
                             continue;
                         }

--- a/src/Build/Evaluation/ProjectParser.cs
+++ b/src/Build/Evaluation/ProjectParser.cs
@@ -229,7 +229,7 @@ namespace Microsoft.Build.Construction
 
             foreach (XmlElementWithLocation childElement in ProjectXmlUtilities.GetVerifyThrowProjectChildElements(element))
             {
-                ProjectXmlUtilities.VerifyThrowProjectAttributes(childElement, ValidAttributesOnlyConditionAndLabel, _ParserIgnoreConfiguration, "Property");
+                ProjectXmlUtilities.VerifyThrowProjectAttributes(childElement, ValidAttributesOnlyConditionAndLabel, _ParserIgnoreConfiguration, ParserIgnoreConfiguration.GenericPropertyElement);
                 XmlUtilities.VerifyThrowProjectValidElementName(childElement);
                 ProjectErrorUtilities.VerifyThrowInvalidProject(!XMakeElements.ReservedItemNames.Contains(childElement.Name) && !ReservedPropertyNames.IsReservedProperty(childElement.Name), childElement.Location, "CannotModifyReservedProperty", childElement.Name);
 
@@ -328,7 +328,7 @@ namespace Microsoft.Build.Construction
 
                 if (!isKnownAttribute && !isValidMetadataNameInAttribute)
                 {
-                    if (_ParserIgnoreConfiguration?.CheckSkipAttribute("Item", attribute.Name) != true)
+                    if (_ParserIgnoreConfiguration?.CheckSkipAttribute(ParserIgnoreConfiguration.GenericItemElement, attribute.Name) != true)
                     {
                         ProjectXmlUtilities.ThrowProjectInvalidAttribute(attribute);
                     }
@@ -403,7 +403,7 @@ namespace Microsoft.Build.Construction
         /// </summary>
         private ProjectMetadataElement ParseProjectMetadataElement(XmlElementWithLocation element, ProjectElementContainer parent)
         {
-            ProjectXmlUtilities.VerifyThrowProjectAttributes(element, ValidAttributesOnlyConditionAndLabel, _ParserIgnoreConfiguration, "Metadata");
+            ProjectXmlUtilities.VerifyThrowProjectAttributes(element, ValidAttributesOnlyConditionAndLabel, _ParserIgnoreConfiguration, ParserIgnoreConfiguration.GenericMetadataElement);
 
             XmlUtilities.VerifyThrowProjectValidElementName(element);
 
@@ -507,7 +507,7 @@ namespace Microsoft.Build.Construction
                 }
                 else
                 {
-                    ProjectXmlUtilities.VerifyThrowProjectAttributes(childElement, ValidAttributesOnUsingTaskParameter, _ParserIgnoreConfiguration, "Parameter");
+                    ProjectXmlUtilities.VerifyThrowProjectAttributes(childElement, ValidAttributesOnUsingTaskParameter, _ParserIgnoreConfiguration, XMakeElements.usingTaskParameter);
                     XmlUtilities.VerifyThrowProjectValidElementName(childElement);
                     ProjectUsingTaskParameterElement parameter = new ProjectUsingTaskParameterElement(childElement, parameterGroup, _project);
                     parameterGroup.AppendParentedChildNoChecks(parameter);
@@ -568,7 +568,7 @@ namespace Microsoft.Build.Construction
                             ProjectXmlUtilities.ThrowProjectInvalidChildElementDueToDuplicate(childElement);
                         }
 
-                        ProjectXmlUtilities.VerifyThrowProjectAttributes(childElement, ValidAttributesOnUsingTaskBody, _ParserIgnoreConfiguration, "UsingTaskBody");
+                        ProjectXmlUtilities.VerifyThrowProjectAttributes(childElement, ValidAttributesOnUsingTaskBody, _ParserIgnoreConfiguration, ParserIgnoreConfiguration.GenericUsingTaskBodyElement);
 
                         child = new ProjectUsingTaskBodyElement(childElement, usingTask, _project);
                         foundTaskElement = true;
@@ -689,7 +689,7 @@ namespace Microsoft.Build.Construction
             {
                 if (childElement.Name != XMakeElements.output)
                 {
-                    if (_ParserIgnoreConfiguration?.CheckSkipElement("Task", childElement.Name) == true)
+                    if (_ParserIgnoreConfiguration?.CheckSkipElement(XMakeElements.usingTaskBody, childElement.Name) == true)
                     {
                         continue;
                     }
@@ -767,7 +767,7 @@ namespace Microsoft.Build.Construction
 
                 if (!isKnownAttribute && !isValidMetadataNameInAttribute)
                 {
-                    if (_ParserIgnoreConfiguration?.CheckSkipAttribute("ItemDefinition", attribute.Name) != true)
+                    if (_ParserIgnoreConfiguration?.CheckSkipAttribute(ParserIgnoreConfiguration.GenericItemDefinitionElement, attribute.Name) != true)
                     {
                         ProjectXmlUtilities.ThrowProjectInvalidAttribute(attribute);
                     }
@@ -782,7 +782,7 @@ namespace Microsoft.Build.Construction
                 }
                 else if (!ValidAttributesOnlyConditionAndLabel.Contains(attribute.Name))
                 {
-                    if (_ParserIgnoreConfiguration?.CheckSkipAttribute("ItemDefinition", attribute.Name) != true)
+                    if (_ParserIgnoreConfiguration?.CheckSkipAttribute(ParserIgnoreConfiguration.GenericItemDefinitionElement, attribute.Name) != true)
                     {
                         ProjectXmlUtilities.ThrowProjectInvalidAttribute(attribute);
                     }

--- a/src/Build/Evaluation/ProjectParser.cs
+++ b/src/Build/Evaluation/ProjectParser.cs
@@ -1,9 +1,10 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;
 using System.Xml;
+using Microsoft.Build.Evaluation;
 using Microsoft.Build.Eventing;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
@@ -85,6 +86,8 @@ namespace Microsoft.Build.Construction
         /// </summary>
         private readonly XmlDocumentWithLocation _document;
 
+        private readonly UnknownElementsConfiguration _unknownElementsConfiguration;
+
         /// <summary>
         /// Whether a ProjectExtensions node has been encountered already.
         /// It's not supposed to appear more than once.
@@ -94,13 +97,14 @@ namespace Microsoft.Build.Construction
         /// <summary>
         /// Private constructor to give static semantics
         /// </summary>
-        private ProjectParser(XmlDocumentWithLocation document, ProjectRootElement project)
+        private ProjectParser(XmlDocumentWithLocation document, ProjectRootElement project, UnknownElementsConfiguration unknownElementsConfiguration)
         {
             Assumed.NotNull(project);
             Assumed.NotNull(document);
 
             _document = document;
             _project = project;
+            _unknownElementsConfiguration = unknownElementsConfiguration;
         }
 
         /// <summary>
@@ -111,11 +115,11 @@ namespace Microsoft.Build.Construction
         /// The code markers here used to be around the Project class constructor in the old code.
         /// In the new code, that's not very interesting; we are repurposing to wrap parsing the XML.
         /// </remarks>
-        internal static void Parse(XmlDocumentWithLocation document, ProjectRootElement projectRootElement)
+        internal static void Parse(XmlDocumentWithLocation document, ProjectRootElement projectRootElement, UnknownElementsConfiguration unknownElementsConfiguration)
         {
             MSBuildEventSource.Log.ParseStart(projectRootElement.ProjectFileLocation.File);
             {
-                ProjectParser parser = new ProjectParser(document, projectRootElement);
+                ProjectParser parser = new ProjectParser(document, projectRootElement, unknownElementsConfiguration);
                 parser.Parse();
             }
             MSBuildEventSource.Log.ParseStop(projectRootElement.ProjectFileLocation.File);
@@ -204,7 +208,11 @@ namespace Microsoft.Build.Construction
                         break;
 
                     default:
-                        ProjectXmlUtilities.ThrowProjectInvalidChildElement(childElement.Name, childElement.ParentNode.Name, childElement.Location);
+                        if (ProjectXmlUtilities.ThrowIfProjectInvalidChildElement(childElement.Name, childElement.ParentNode.Name, childElement.Location, _unknownElementsConfiguration))
+                        {
+                            continue;
+                        }
+
                         break;
                 }
             }
@@ -215,13 +223,13 @@ namespace Microsoft.Build.Construction
         /// </summary>
         private ProjectPropertyGroupElement ParseProjectPropertyGroupElement(XmlElementWithLocation element, ProjectElementContainer parent)
         {
-            ProjectXmlUtilities.VerifyThrowProjectAttributes(element, ValidAttributesOnlyConditionAndLabel);
+            ProjectXmlUtilities.VerifyThrowProjectAttributes(element, ValidAttributesOnlyConditionAndLabel, _unknownElementsConfiguration);
 
             ProjectPropertyGroupElement propertyGroup = new ProjectPropertyGroupElement(element, parent, _project);
 
             foreach (XmlElementWithLocation childElement in ProjectXmlUtilities.GetVerifyThrowProjectChildElements(element))
             {
-                ProjectXmlUtilities.VerifyThrowProjectAttributes(childElement, ValidAttributesOnlyConditionAndLabel);
+                ProjectXmlUtilities.VerifyThrowProjectAttributes(childElement, ValidAttributesOnlyConditionAndLabel, _unknownElementsConfiguration, "Property");
                 XmlUtilities.VerifyThrowProjectValidElementName(childElement);
                 ProjectErrorUtilities.VerifyThrowInvalidProject(!XMakeElements.ReservedItemNames.Contains(childElement.Name) && !ReservedPropertyNames.IsReservedProperty(childElement.Name), childElement.Location, "CannotModifyReservedProperty", childElement.Name);
 
@@ -239,7 +247,7 @@ namespace Microsoft.Build.Construction
         /// </summary>
         private ProjectItemGroupElement ParseProjectItemGroupElement(XmlElementWithLocation element, ProjectElementContainer parent)
         {
-            ProjectXmlUtilities.VerifyThrowProjectAttributes(element, ValidAttributesOnlyConditionAndLabel);
+            ProjectXmlUtilities.VerifyThrowProjectAttributes(element, ValidAttributesOnlyConditionAndLabel, _unknownElementsConfiguration);
 
             ProjectItemGroupElement itemGroup = new ProjectItemGroupElement(element, parent, _project);
 
@@ -320,7 +328,10 @@ namespace Microsoft.Build.Construction
 
                 if (!isKnownAttribute && !isValidMetadataNameInAttribute)
                 {
-                    ProjectXmlUtilities.ThrowProjectInvalidAttribute(attribute);
+                    if (_unknownElementsConfiguration?.CheckSkipAttribute("Item", attribute.Name) != true)
+                    {
+                        ProjectXmlUtilities.ThrowProjectInvalidAttribute(attribute);
+                    }
                 }
                 else if (isValidMetadataNameInAttribute)
                 {
@@ -392,7 +403,7 @@ namespace Microsoft.Build.Construction
         /// </summary>
         private ProjectMetadataElement ParseProjectMetadataElement(XmlElementWithLocation element, ProjectElementContainer parent)
         {
-            ProjectXmlUtilities.VerifyThrowProjectAttributes(element, ValidAttributesOnlyConditionAndLabel);
+            ProjectXmlUtilities.VerifyThrowProjectAttributes(element, ValidAttributesOnlyConditionAndLabel, _unknownElementsConfiguration, "Metadata");
 
             XmlUtilities.VerifyThrowProjectValidElementName(element);
 
@@ -420,7 +431,7 @@ namespace Microsoft.Build.Construction
         /// <returns>A ProjectImportGroupElement derived from the XML element passed in</returns>
         private ProjectImportGroupElement ParseProjectImportGroupElement(XmlElementWithLocation element, ProjectRootElement parent)
         {
-            ProjectXmlUtilities.VerifyThrowProjectAttributes(element, ValidAttributesOnlyConditionAndLabel);
+            ProjectXmlUtilities.VerifyThrowProjectAttributes(element, ValidAttributesOnlyConditionAndLabel, _unknownElementsConfiguration);
 
             ProjectImportGroupElement importGroup = new ProjectImportGroupElement(element, parent, _project);
 
@@ -453,9 +464,9 @@ namespace Microsoft.Build.Construction
                 parent,
                 element);
 
-            ProjectXmlUtilities.VerifyThrowProjectAttributes(element, ValidAttributesOnImport);
+            ProjectXmlUtilities.VerifyThrowProjectAttributes(element, ValidAttributesOnImport, _unknownElementsConfiguration);
             ProjectXmlUtilities.VerifyThrowProjectRequiredAttribute(element, XMakeAttributes.project);
-            ProjectXmlUtilities.VerifyThrowProjectNoChildElements(element);
+            ProjectXmlUtilities.VerifyThrowProjectNoChildElements(element, _unknownElementsConfiguration);
 
             SdkReference sdk = null;
             if (element.HasAttribute(XMakeAttributes.sdk))
@@ -475,7 +486,7 @@ namespace Microsoft.Build.Construction
         private UsingTaskParameterGroupElement ParseUsingTaskParameterGroupElement(XmlElementWithLocation element, ProjectElementContainer parent)
         {
             // There should be no attributes
-            ProjectXmlUtilities.VerifyThrowProjectNoAttributes(element);
+            ProjectXmlUtilities.VerifyThrowProjectNoAttributes(element, _unknownElementsConfiguration);
 
             UsingTaskParameterGroupElement parameterGroup = new UsingTaskParameterGroupElement(element, parent, _project);
 
@@ -489,7 +500,7 @@ namespace Microsoft.Build.Construction
                 }
                 else
                 {
-                    ProjectXmlUtilities.VerifyThrowProjectAttributes(childElement, ValidAttributesOnUsingTaskParameter);
+                    ProjectXmlUtilities.VerifyThrowProjectAttributes(childElement, ValidAttributesOnUsingTaskParameter, _unknownElementsConfiguration, "Parameter");
                     XmlUtilities.VerifyThrowProjectValidElementName(childElement);
                     ProjectUsingTaskParameterElement parameter = new ProjectUsingTaskParameterElement(childElement, parameterGroup, _project);
                     parameterGroup.AppendParentedChildNoChecks(parameter);
@@ -507,7 +518,7 @@ namespace Microsoft.Build.Construction
         /// </summary>
         private ProjectUsingTaskElement ParseProjectUsingTaskElement(XmlElementWithLocation element)
         {
-            ProjectXmlUtilities.VerifyThrowProjectAttributes(element, ValidAttributesOnUsingTask);
+            ProjectXmlUtilities.VerifyThrowProjectAttributes(element, ValidAttributesOnUsingTask, _unknownElementsConfiguration);
             ProjectErrorUtilities.VerifyThrowInvalidProject(element.GetAttribute(XMakeAttributes.taskName).Length > 0, element.Location, "ProjectTaskNameEmpty");
 
             string assemblyName = element.GetAttribute(XMakeAttributes.assemblyName);
@@ -550,13 +561,17 @@ namespace Microsoft.Build.Construction
                             ProjectXmlUtilities.ThrowProjectInvalidChildElementDueToDuplicate(childElement);
                         }
 
-                        ProjectXmlUtilities.VerifyThrowProjectAttributes(childElement, ValidAttributesOnUsingTaskBody);
+                        ProjectXmlUtilities.VerifyThrowProjectAttributes(childElement, ValidAttributesOnUsingTaskBody, _unknownElementsConfiguration, "UsingTaskBody");
 
                         child = new ProjectUsingTaskBodyElement(childElement, usingTask, _project);
                         foundTaskElement = true;
                         break;
                     default:
-                        ProjectXmlUtilities.ThrowProjectInvalidChildElement(childElement.Name, element.Name, element.Location);
+                        if (ProjectXmlUtilities.ThrowIfProjectInvalidChildElement(childElement.Name, "Task", element.Location, _unknownElementsConfiguration))
+                        {
+                            continue;
+                        }
+
                         break;
                 }
 
@@ -571,7 +586,7 @@ namespace Microsoft.Build.Construction
         /// </summary>
         private ProjectTargetElement ParseProjectTargetElement(XmlElementWithLocation element)
         {
-            ProjectXmlUtilities.VerifyThrowProjectAttributes(element, ValidAttributesOnTarget);
+            ProjectXmlUtilities.VerifyThrowProjectAttributes(element, ValidAttributesOnTarget, _unknownElementsConfiguration);
             ProjectXmlUtilities.VerifyThrowProjectRequiredAttribute(element, XMakeAttributes.name);
 
             // Orcas compat: all target names are automatically unescaped
@@ -613,9 +628,9 @@ namespace Microsoft.Build.Construction
                     case XMakeElements.onError:
                         // Previous OM accidentally didn't verify ExecuteTargets on parse,
                         // but we do, as it makes no sense
-                        ProjectXmlUtilities.VerifyThrowProjectAttributes(childElement, ValidAttributesOnOnError);
+                        ProjectXmlUtilities.VerifyThrowProjectAttributes(childElement, ValidAttributesOnOnError, _unknownElementsConfiguration);
                         ProjectXmlUtilities.VerifyThrowProjectRequiredAttribute(childElement, XMakeAttributes.executeTargets);
-                        ProjectXmlUtilities.VerifyThrowProjectNoChildElements(childElement);
+                        ProjectXmlUtilities.VerifyThrowProjectNoChildElements(childElement, _unknownElementsConfiguration);
 
                         child = onError = new ProjectOnErrorElement(childElement, target, _project);
                         break;
@@ -665,7 +680,15 @@ namespace Microsoft.Build.Construction
 
             foreach (XmlElementWithLocation childElement in ProjectXmlUtilities.GetVerifyThrowProjectChildElements(element))
             {
-                ProjectErrorUtilities.VerifyThrowInvalidProject(childElement.Name == XMakeElements.output, childElement.Location, "UnrecognizedChildElement", childElement.Name, task.Name);
+                if (childElement.Name != XMakeElements.output)
+                {
+                    if (_unknownElementsConfiguration?.CheckSkipElement("Task", childElement.Name) == true)
+                    {
+                        continue;
+                    }
+
+                    ProjectErrorUtilities.ThrowInvalidProject(childElement.Location, "UnrecognizedChildElement", childElement.Name, task.Name);
+                }
 
                 ProjectOutputElement output = ParseProjectOutputElement(childElement, task);
 
@@ -680,9 +703,9 @@ namespace Microsoft.Build.Construction
         /// </summary>
         private ProjectOutputElement ParseProjectOutputElement(XmlElementWithLocation element, ProjectTaskElement parent)
         {
-            ProjectXmlUtilities.VerifyThrowProjectAttributes(element, ValidAttributesOnOutput);
+            ProjectXmlUtilities.VerifyThrowProjectAttributes(element, ValidAttributesOnOutput, _unknownElementsConfiguration);
             ProjectXmlUtilities.VerifyThrowProjectRequiredAttribute(element, XMakeAttributes.taskParameter);
-            ProjectXmlUtilities.VerifyThrowProjectNoChildElements(element);
+            ProjectXmlUtilities.VerifyThrowProjectNoChildElements(element, _unknownElementsConfiguration);
 
             XmlAttributeWithLocation itemNameAttribute = element.GetAttributeWithLocation(XMakeAttributes.itemName);
             XmlAttributeWithLocation propertyNameAttribute = element.GetAttributeWithLocation(XMakeAttributes.propertyName);
@@ -706,7 +729,7 @@ namespace Microsoft.Build.Construction
         /// </summary>
         private ProjectItemDefinitionGroupElement ParseProjectItemDefinitionGroupElement(XmlElementWithLocation element, ProjectElementContainer parent)
         {
-            ProjectXmlUtilities.VerifyThrowProjectAttributes(element, ValidAttributesOnlyConditionAndLabel);
+            ProjectXmlUtilities.VerifyThrowProjectAttributes(element, ValidAttributesOnlyConditionAndLabel, _unknownElementsConfiguration);
 
             ProjectItemDefinitionGroupElement itemDefinitionGroup = new ProjectItemDefinitionGroupElement(element, parent, _project);
 
@@ -737,7 +760,10 @@ namespace Microsoft.Build.Construction
 
                 if (!isKnownAttribute && !isValidMetadataNameInAttribute)
                 {
-                    ProjectXmlUtilities.ThrowProjectInvalidAttribute(attribute);
+                    if (_unknownElementsConfiguration?.CheckSkipAttribute("ItemDefinition", attribute.Name) != true)
+                    {
+                        ProjectXmlUtilities.ThrowProjectInvalidAttribute(attribute);
+                    }
                 }
                 else if (isValidMetadataNameInAttribute)
                 {
@@ -749,7 +775,10 @@ namespace Microsoft.Build.Construction
                 }
                 else if (!ValidAttributesOnlyConditionAndLabel.Contains(attribute.Name))
                 {
-                    ProjectXmlUtilities.ThrowProjectInvalidAttribute(attribute);
+                    if (_unknownElementsConfiguration?.CheckSkipAttribute("ItemDefinition", attribute.Name) != true)
+                    {
+                        ProjectXmlUtilities.ThrowProjectInvalidAttribute(attribute);
+                    }
                 }
             }
 
@@ -768,7 +797,7 @@ namespace Microsoft.Build.Construction
         /// </summary>
         private ProjectChooseElement ParseProjectChooseElement(XmlElementWithLocation element, ProjectElementContainer parent, int nestingDepth)
         {
-            ProjectXmlUtilities.VerifyThrowProjectNoAttributes(element);
+            ProjectXmlUtilities.VerifyThrowProjectNoAttributes(element, _unknownElementsConfiguration);
 
             ProjectChooseElement choose = new ProjectChooseElement(element, parent, _project);
 
@@ -797,7 +826,11 @@ namespace Microsoft.Build.Construction
                         break;
 
                     default:
-                        ProjectXmlUtilities.ThrowProjectInvalidChildElement(childElement.Name, element.Name, element.Location);
+                        if (ProjectXmlUtilities.ThrowIfProjectInvalidChildElement(childElement.Name, element.Name, element.Location, _unknownElementsConfiguration))
+                        {
+                            continue;
+                        }
+
                         break;
                 }
 
@@ -828,7 +861,7 @@ namespace Microsoft.Build.Construction
         /// </summary>
         private ProjectOtherwiseElement ParseProjectOtherwiseElement(XmlElementWithLocation element, ProjectChooseElement parent, int nestingDepth)
         {
-            ProjectXmlUtilities.VerifyThrowProjectNoAttributes(element);
+            ProjectXmlUtilities.VerifyThrowProjectNoAttributes(element, _unknownElementsConfiguration);
 
             ProjectOtherwiseElement otherwise = new ProjectOtherwiseElement(element, parent, _project);
 
@@ -865,7 +898,11 @@ namespace Microsoft.Build.Construction
                         break;
 
                     default:
-                        ProjectXmlUtilities.ThrowProjectInvalidChildElement(childElement.Name, element.Name, element.Location);
+                        if (ProjectXmlUtilities.ThrowIfProjectInvalidChildElement(childElement.Name, element.Name, element.Location, _unknownElementsConfiguration))
+                        {
+                            continue;
+                        }
+
                         break;
                 }
 
@@ -880,7 +917,7 @@ namespace Microsoft.Build.Construction
         {
             // ProjectExtensions are only found in the main project file - in fact, the code used to ignore them in imported
             // files. We don't.
-            ProjectXmlUtilities.VerifyThrowProjectNoAttributes(element);
+            ProjectXmlUtilities.VerifyThrowProjectNoAttributes(element, _unknownElementsConfiguration);
 
             ProjectErrorUtilities.VerifyThrowInvalidProject(!_seenProjectExtensions, element.Location, "DuplicateProjectExtensions");
             _seenProjectExtensions = true;

--- a/src/Build/Evaluation/ProjectRootElementCacheBase.cs
+++ b/src/Build/Evaluation/ProjectRootElementCacheBase.cs
@@ -15,6 +15,13 @@ namespace Microsoft.Build.Evaluation
         public ParserIgnoreConfiguration ParserIgnoreConfiguration { get; protected set; }
 
         /// <summary>
+        /// Whether <see cref="SetParserIgnoreConfiguration"/> has already been applied to this cache. A null
+        /// <see cref="ParserIgnoreConfiguration"/> is a legitimate configuration - it is what the escape hatch
+        /// produces - so it cannot itself stand for "never set".
+        /// </summary>
+        private bool _parserIgnoreConfigurationInitialized;
+
+        /// <summary>
         /// Handler for which project root element just got added to the cache
         /// </summary>
         internal delegate void ProjectRootElementCacheAddEntryHandler(object sender, ProjectRootElementCacheAddEntryEventArgs e);
@@ -79,7 +86,16 @@ namespace Microsoft.Build.Evaluation
                 return;
             }
 
-            DiscardImplicitReferences();
+            // Entries parsed under the previous configuration may have skipped - or refused to skip - unknown
+            // attributes and elements that the new one treats differently, so they must be reparsed. A cache that
+            // has not had a configuration applied yet holds nothing parsed under a different one, so on that first
+            // initialization - which happens once per newly created cache - there is nothing to invalidate.
+            if (_parserIgnoreConfigurationInitialized)
+            {
+                DiscardImplicitReferences();
+            }
+
+            _parserIgnoreConfigurationInitialized = true;
             ParserIgnoreConfiguration = configuration;
         }
 

--- a/src/Build/Evaluation/ProjectRootElementCacheBase.cs
+++ b/src/Build/Evaluation/ProjectRootElementCacheBase.cs
@@ -12,6 +12,8 @@ namespace Microsoft.Build.Evaluation
     {
         public bool LoadProjectsReadOnly { get; protected set; }
 
+        internal UnknownElementsConfiguration UnknownElementsConfiguration { get; set; }
+
         /// <summary>
         /// Handler for which project root element just got added to the cache
         /// </summary>

--- a/src/Build/Evaluation/ProjectRootElementCacheBase.cs
+++ b/src/Build/Evaluation/ProjectRootElementCacheBase.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Build.Evaluation
     {
         public bool LoadProjectsReadOnly { get; protected set; }
 
-        internal UnknownElementsConfiguration UnknownElementsConfiguration { get; set; }
+        public UnknownElementsConfiguration UnknownElementsConfiguration { get; protected set; }
 
         /// <summary>
         /// Handler for which project root element just got added to the cache
@@ -71,6 +71,17 @@ namespace Microsoft.Build.Evaluation
         internal abstract void DiscardImplicitReferences();
 
         internal abstract void DiscardAnyWeakReference(ProjectRootElement projectRootElement);
+
+        internal void SetUnknownElementsConfiguration(UnknownElementsConfiguration configuration)
+        {
+            if (UnknownElementsConfiguration.Equals(UnknownElementsConfiguration, configuration))
+            {
+                return;
+            }
+
+            DiscardImplicitReferences();
+            UnknownElementsConfiguration = configuration;
+        }
 
         /// <summary>
         /// Raises the <see cref="ProjectRootElementDirtied"/> event.

--- a/src/Build/Evaluation/ProjectRootElementCacheBase.cs
+++ b/src/Build/Evaluation/ProjectRootElementCacheBase.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Build.Evaluation
     {
         public bool LoadProjectsReadOnly { get; protected set; }
 
-        public UnknownElementsConfiguration UnknownElementsConfiguration { get; protected set; }
+        public ParserIgnoreConfiguration ParserIgnoreConfiguration { get; protected set; }
 
         /// <summary>
         /// Handler for which project root element just got added to the cache
@@ -72,15 +72,15 @@ namespace Microsoft.Build.Evaluation
 
         internal abstract void DiscardAnyWeakReference(ProjectRootElement projectRootElement);
 
-        internal void SetUnknownElementsConfiguration(UnknownElementsConfiguration configuration)
+        internal void SetParserIgnoreConfiguration(ParserIgnoreConfiguration configuration)
         {
-            if (UnknownElementsConfiguration.Equals(UnknownElementsConfiguration, configuration))
+            if (ParserIgnoreConfiguration.Equals(ParserIgnoreConfiguration, configuration))
             {
                 return;
             }
 
             DiscardImplicitReferences();
-            UnknownElementsConfiguration = configuration;
+            ParserIgnoreConfiguration = configuration;
         }
 
         /// <summary>

--- a/src/Build/Evaluation/SimpleProjectRootElementCache.cs
+++ b/src/Build/Evaluation/SimpleProjectRootElementCache.cs
@@ -111,7 +111,9 @@ namespace Microsoft.Build.Evaluation
 
         internal override void DiscardImplicitReferences()
         {
-            throw new NotImplementedException();
+            // This cache does not track whether an entry was explicitly loaded - Get ignores isExplicitlyLoaded -
+            // so every entry it holds is an implicit reference and discarding all of them is the correct behavior.
+            Clear();
         }
 
         internal override void DiscardAnyWeakReference(ProjectRootElement projectRootElement)

--- a/src/Build/Evaluation/UnknownElementsConfiguration.cs
+++ b/src/Build/Evaluation/UnknownElementsConfiguration.cs
@@ -26,6 +26,21 @@ namespace Microsoft.Build.Evaluation
         internal const string ConfigFileName = "Directory.Parse.config";
         internal const string EnvironmentVariableName = "MSBUILD_PARSE_CONFIG";
 
+        /// <summary>
+        /// Static collection of config file paths to embed in the binlog.
+        /// Populated during config loading, consumed by BinaryLogger.Shutdown.
+        /// </summary>
+        private static ConcurrentBag<string> s_binlogEmbedPaths = new();
+
+        /// <summary>Paths collected for binlog embedding.</summary>
+        internal static IEnumerable<string> BinlogEmbedPaths => s_binlogEmbedPaths;
+
+        /// <summary>Clears the embed paths after they've been written to the binlog.</summary>
+        internal static void ClearBinlogEmbedPaths()
+        {
+            s_binlogEmbedPaths = new ConcurrentBag<string>();
+        }
+
         private Dictionary<string, HashSet<string>> _allowedAttributes;
         private Dictionary<string, HashSet<string>> _allowedChildren;
         private HashSet<string> _loadedConfigFiles;
@@ -263,6 +278,8 @@ namespace Microsoft.Build.Evaluation
             {
                 return;
             }
+
+            s_binlogEmbedPaths.Add(fullPath);
 
             try
             {

--- a/src/Build/Evaluation/UnknownElementsConfiguration.cs
+++ b/src/Build/Evaluation/UnknownElementsConfiguration.cs
@@ -26,8 +26,6 @@ namespace Microsoft.Build.Evaluation
         internal const string ConfigFileName = "Directory.Parse.config";
         internal const string EnvironmentVariableName = "MSBUILD_PARSE_CONFIG";
 
-        private const string UserProfileSubfolder = ".msbuild";
-
         private Dictionary<string, HashSet<string>> _allowedAttributes;
         private Dictionary<string, HashSet<string>> _allowedChildren;
         private HashSet<string> _loadedConfigFiles;
@@ -172,21 +170,9 @@ namespace Microsoft.Build.Evaluation
             return config;
         }
 
-        internal static UnknownElementsConfiguration LoadGlobalConfig(string? startingDirectory = null)
+        internal static UnknownElementsConfiguration LoadGlobalConfig()
         {
             var config = new UnknownElementsConfiguration();
-
-            string? msbuildExeDir = BuildEnvironmentHelper.Instance?.CurrentMSBuildToolsDirectory;
-            if (!string.IsNullOrEmpty(msbuildExeDir))
-            {
-                config.LoadFile(Path.Combine(msbuildExeDir, ConfigFileName));
-            }
-
-            string userProfile = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-            if (!string.IsNullOrEmpty(userProfile))
-            {
-                config.LoadFile(Path.Combine(userProfile, UserProfileSubfolder, ConfigFileName));
-            }
 
             string? envValue = Environment.GetEnvironmentVariable(EnvironmentVariableName);
             if (!string.IsNullOrEmpty(envValue))
@@ -199,16 +185,6 @@ namespace Microsoft.Build.Evaluation
                     {
                         config.LoadFile(trimmedPath);
                     }
-                }
-            }
-
-            // Walk up from the starting directory looking for a Directory.Parse.config
-            if (!string.IsNullOrEmpty(startingDirectory))
-            {
-                string directoryConfigPath = FileUtilities.GetPathOfFileAbove(ConfigFileName, startingDirectory!);
-                if (!string.IsNullOrEmpty(directoryConfigPath) && !config.ContainsLoadedFile(directoryConfigPath))
-                {
-                    config.LoadFile(directoryConfigPath);
                 }
             }
 

--- a/src/Build/Evaluation/UnknownElementsConfiguration.cs
+++ b/src/Build/Evaluation/UnknownElementsConfiguration.cs
@@ -51,6 +51,15 @@ namespace Microsoft.Build.Evaluation
         internal static UnknownElementsConfiguration Empty { get; } = new UnknownElementsConfiguration();
 
         /// <summary>
+        /// Returns true if this config has the same set of loaded files as the other config.
+        /// Used by worker nodes to detect if the config changed between builds.
+        /// </summary>
+        internal bool HasSameLoadedFiles(UnknownElementsConfiguration other)
+        {
+            return _loadedConfigFiles.SetEquals(other._loadedConfigFiles);
+        }
+
+        /// <summary>
         /// Checks whether the given file path has already been loaded into this configuration.
         /// </summary>
         internal bool ContainsLoadedFile(string filePath)
@@ -270,46 +279,67 @@ namespace Microsoft.Build.Evaluation
                 return;
             }
 
-            foreach (string rawLine in File.ReadLines(filePath))
+            try
             {
-                string entry = rawLine.Trim();
-                if (string.IsNullOrEmpty(entry) || entry[0] == '#')
+                var settings = new System.Xml.XmlReaderSettings { DtdProcessing = System.Xml.DtdProcessing.Prohibit };
+                var doc = new System.Xml.XmlDocument();
+                using (var stream = File.OpenRead(fullPath))
+                using (var reader = System.Xml.XmlReader.Create(stream, settings))
                 {
-                    continue;
+                    doc.Load(reader);
                 }
 
-                int firstColon = entry.IndexOf(':');
-                if (firstColon < 0)
+                System.Xml.XmlElement? root = doc.DocumentElement;
+                if (root is null || !root.Name.Equals("ParseConfig", StringComparison.OrdinalIgnoreCase))
                 {
-                    continue;
+                    return;
                 }
 
-                int secondColon = entry.IndexOf(':', firstColon + 1);
-                if (secondColon < 0 || entry.IndexOf(':', secondColon + 1) >= 0)
+                foreach (System.Xml.XmlNode child in root.ChildNodes)
                 {
-                    continue;
-                }
+                    if (child.NodeType != System.Xml.XmlNodeType.Element)
+                    {
+                        continue;
+                    }
 
-                string type = entry.Substring(0, firstColon).Trim();
-                string elementName = entry.Substring(firstColon + 1, secondColon - firstColon - 1).Trim();
-                string unknownName = entry.Substring(secondColon + 1).Trim();
+                    Dictionary<string, HashSet<string>>? target = null;
+                    if (child.Name.Equals("IgnoreAttributes", StringComparison.OrdinalIgnoreCase))
+                    {
+                        target = _allowedAttributes;
+                    }
+                    else if (child.Name.Equals("IgnoreChildren", StringComparison.OrdinalIgnoreCase))
+                    {
+                        target = _allowedChildren;
+                    }
 
-                if (type.Length == 0 || elementName.Length == 0 || unknownName.Length == 0)
-                {
-                    continue;
-                }
+                    if (target is null)
+                    {
+                        continue;
+                    }
 
-                if (type.Equals("ATTRIBUTE", StringComparison.OrdinalIgnoreCase))
-                {
-                    AddAllowedName(_allowedAttributes, elementName, unknownName);
-                }
-                else if (type.Equals("ELEMENT", StringComparison.OrdinalIgnoreCase))
-                {
-                    AddAllowedName(_allowedChildren, elementName, unknownName);
+                    foreach (System.Xml.XmlNode ignoreNode in child.ChildNodes)
+                    {
+                        if (ignoreNode.NodeType != System.Xml.XmlNodeType.Element
+                            || !ignoreNode.Name.Equals("Ignore", StringComparison.OrdinalIgnoreCase))
+                        {
+                            continue;
+                        }
+
+                        System.Xml.XmlElement ignoreElement = (System.Xml.XmlElement)ignoreNode;
+                        string elementName = ignoreElement.GetAttribute("Element");
+                        string name = ignoreElement.GetAttribute("Name");
+
+                        if (!string.IsNullOrEmpty(elementName) && !string.IsNullOrEmpty(name))
+                        {
+                            AddAllowedName(target, elementName, name);
+                        }
+                    }
                 }
             }
-
-            _loadedConfigFiles.Add(fullPath);
+            catch
+            {
+                // If the file can't be parsed as XML, silently skip it
+            }
         }
 
         private static void AddAllowedName(Dictionary<string, HashSet<string>> destination, string elementName, string unknownName)

--- a/src/Build/Evaluation/UnknownElementsConfiguration.cs
+++ b/src/Build/Evaluation/UnknownElementsConfiguration.cs
@@ -1,0 +1,326 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Microsoft.Build.BackEnd;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Shared;
+using Microsoft.Build.Shared.FileSystem;
+
+namespace Microsoft.Build.Evaluation
+{
+    /// <summary>
+    /// Manages a set of allowed unknown attributes and elements that should be silently skipped
+    /// during project parsing instead of throwing an InvalidProjectFileException.
+    /// Configuration is loaded from Directory.Parse.config files discovered additively from:
+    /// 1. Next to the MSBuild executable
+    /// 2. User profile (~/.msbuild/)
+    /// 3. MSBUILD_PARSE_CONFIG environment variable paths
+    /// </summary>
+    internal sealed class UnknownElementsConfiguration : ITranslatable
+    {
+        internal const string ConfigFileName = "Directory.Parse.config";
+        internal const string EnvironmentVariableName = "MSBUILD_PARSE_CONFIG";
+
+        private const string UserProfileSubfolder = ".msbuild";
+
+        private Dictionary<string, HashSet<string>> _allowedAttributes;
+        private Dictionary<string, HashSet<string>> _allowedChildren;
+        private HashSet<string> _loadedConfigFiles;
+        private readonly ConcurrentDictionary<string, int> _skippedItems = new(StringComparer.OrdinalIgnoreCase);
+
+        private UnknownElementsConfiguration()
+        {
+            _allowedAttributes = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
+            _allowedChildren = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
+            _loadedConfigFiles = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        }
+
+        private UnknownElementsConfiguration(ITranslator translator)
+            : this()
+        {
+            ((ITranslatable)this).Translate(translator);
+        }
+
+        internal IReadOnlyCollection<string> LoadedConfigFiles => _loadedConfigFiles;
+
+        internal static UnknownElementsConfiguration Empty { get; } = new UnknownElementsConfiguration();
+
+        /// <summary>
+        /// Checks whether the given file path has already been loaded into this configuration.
+        /// </summary>
+        internal bool ContainsLoadedFile(string filePath)
+        {
+            if (string.IsNullOrEmpty(filePath))
+            {
+                return false;
+            }
+
+            try
+            {
+                return _loadedConfigFiles.Contains(FileUtilities.NormalizePath(filePath));
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        internal bool CheckSkipAttribute(string elementName, string attributeName)
+        {
+            if (_allowedAttributes.Count == 0)
+            {
+                return false;
+            }
+
+            if (!_allowedAttributes.TryGetValue(elementName, out HashSet<string>? allowedAttributes) || !allowedAttributes.Contains(attributeName))
+            {
+                return false;
+            }
+
+            RecordSkippedItem($"Attribute:{elementName}:{attributeName}");
+            return true;
+        }
+
+        internal bool CheckSkipElement(string parentElementName, string childElementName)
+        {
+            if (_allowedChildren.Count == 0)
+            {
+                return false;
+            }
+
+            if (!_allowedChildren.TryGetValue(parentElementName, out HashSet<string>? allowedChildren) || !allowedChildren.Contains(childElementName))
+            {
+                return false;
+            }
+
+            RecordSkippedItem($"Element:{parentElementName}:{childElementName}");
+            return true;
+        }
+
+        internal string? GetSkippedSummaryMessage()
+        {
+            if (_skippedItems.IsEmpty)
+            {
+                return null;
+            }
+
+            var sb = new StringBuilder("Skipped unrecognized items allowed by Directory.Parse.config:");
+            foreach (var kvp in _skippedItems)
+            {
+                sb.Append($" {kvp.Key} ({kvp.Value} occurrence{(kvp.Value > 1 ? "s" : string.Empty)});");
+            }
+
+            sb.Length--;
+            return sb.ToString();
+        }
+
+        internal string? GetLoadedConfigsMessage()
+        {
+            if (_loadedConfigFiles.Count == 0)
+            {
+                return null;
+            }
+
+            return $"Loaded Directory.Parse.config from: {string.Join(", ", _loadedConfigFiles)}";
+        }
+
+        internal UnknownElementsConfiguration Merge(UnknownElementsConfiguration other)
+        {
+            ArgumentNullException.ThrowIfNull(other);
+
+            var merged = new UnknownElementsConfiguration();
+
+            UnionEntries(merged._allowedAttributes, _allowedAttributes);
+            UnionEntries(merged._allowedAttributes, other._allowedAttributes);
+            UnionEntries(merged._allowedChildren, _allowedChildren);
+            UnionEntries(merged._allowedChildren, other._allowedChildren);
+            merged._loadedConfigFiles.UnionWith(_loadedConfigFiles);
+            merged._loadedConfigFiles.UnionWith(other._loadedConfigFiles);
+            MergeSkippedItems(merged._skippedItems, _skippedItems);
+            MergeSkippedItems(merged._skippedItems, other._skippedItems);
+
+            return merged;
+        }
+
+        internal static UnknownElementsConfiguration LoadFromFile(string filePath)
+        {
+            var config = new UnknownElementsConfiguration();
+            config.LoadFile(filePath);
+            return config;
+        }
+
+        internal static UnknownElementsConfiguration LoadGlobalConfig(string? startingDirectory = null)
+        {
+            var config = new UnknownElementsConfiguration();
+
+            string? msbuildExeDir = BuildEnvironmentHelper.Instance?.CurrentMSBuildToolsDirectory;
+            if (!string.IsNullOrEmpty(msbuildExeDir))
+            {
+                config.LoadFile(Path.Combine(msbuildExeDir, ConfigFileName));
+            }
+
+            string userProfile = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+            if (!string.IsNullOrEmpty(userProfile))
+            {
+                config.LoadFile(Path.Combine(userProfile, UserProfileSubfolder, ConfigFileName));
+            }
+
+            string? envValue = Environment.GetEnvironmentVariable(EnvironmentVariableName);
+            if (!string.IsNullOrEmpty(envValue))
+            {
+                string[] paths = envValue.Split(new[] { Path.PathSeparator }, StringSplitOptions.RemoveEmptyEntries);
+                foreach (string path in paths)
+                {
+                    string trimmedPath = path.Trim();
+                    if (trimmedPath.Length > 0)
+                    {
+                        config.LoadFile(trimmedPath);
+                    }
+                }
+            }
+
+            // Walk up from the starting directory looking for a Directory.Parse.config
+            if (!string.IsNullOrEmpty(startingDirectory))
+            {
+                string directoryConfigPath = FileUtilities.GetPathOfFileAbove(ConfigFileName, startingDirectory!);
+                if (!string.IsNullOrEmpty(directoryConfigPath) && !config.ContainsLoadedFile(directoryConfigPath))
+                {
+                    config.LoadFile(directoryConfigPath);
+                }
+            }
+
+            return config;
+        }
+
+        void ITranslatable.Translate(ITranslator translator)
+        {
+            translator.TranslateDictionary(ref _allowedAttributes, StringComparer.OrdinalIgnoreCase, TranslateHashSetValue, HashSetValueFactory);
+            translator.TranslateDictionary(ref _allowedChildren, StringComparer.OrdinalIgnoreCase, TranslateHashSetValue, HashSetValueFactory);
+            translator.Translate(ref _loadedConfigFiles);
+        }
+
+        private static void TranslateHashSetValue(ITranslator translator, NodePacketValueFactory<HashSet<string>> factory, ref HashSet<string> value)
+        {
+            translator.Translate(ref value);
+        }
+
+        private static HashSet<string> HashSetValueFactory(ITranslator translator)
+        {
+            HashSet<string>? set = null;
+            translator.Translate(ref set);
+            return set ?? new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        }
+
+        internal static UnknownElementsConfiguration FactoryForDeserialization(ITranslator translator)
+        {
+            return new UnknownElementsConfiguration(translator);
+        }
+
+        private static void UnionEntries(Dictionary<string, HashSet<string>> destination, Dictionary<string, HashSet<string>> source)
+        {
+            foreach (var kvp in source)
+            {
+                if (!destination.TryGetValue(kvp.Key, out HashSet<string>? names))
+                {
+                    names = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                    destination[kvp.Key] = names;
+                }
+
+                names.UnionWith(kvp.Value);
+            }
+        }
+
+        private static void MergeSkippedItems(ConcurrentDictionary<string, int> destination, ConcurrentDictionary<string, int> source)
+        {
+            foreach (var kvp in source)
+            {
+                destination.AddOrUpdate(kvp.Key, kvp.Value, (_, count) => count + kvp.Value);
+            }
+        }
+
+        private void RecordSkippedItem(string key)
+        {
+            _skippedItems.AddOrUpdate(key, 1, static (_, count) => count + 1);
+        }
+
+        private void LoadFile(string filePath)
+        {
+            if (string.IsNullOrEmpty(filePath))
+            {
+                return;
+            }
+
+            string fullPath;
+            try
+            {
+                fullPath = FileUtilities.NormalizePath(filePath);
+            }
+            catch
+            {
+                return;
+            }
+
+            if (!FileSystems.Default.FileExists(fullPath) || !_loadedConfigFiles.Add(fullPath))
+            {
+                return;
+            }
+
+            foreach (string rawLine in File.ReadLines(filePath))
+            {
+                string entry = rawLine.Trim();
+                if (string.IsNullOrEmpty(entry) || entry[0] == '#')
+                {
+                    continue;
+                }
+
+                int firstColon = entry.IndexOf(':');
+                if (firstColon < 0)
+                {
+                    continue;
+                }
+
+                int secondColon = entry.IndexOf(':', firstColon + 1);
+                if (secondColon < 0 || entry.IndexOf(':', secondColon + 1) >= 0)
+                {
+                    continue;
+                }
+
+                string type = entry.Substring(0, firstColon).Trim();
+                string elementName = entry.Substring(firstColon + 1, secondColon - firstColon - 1).Trim();
+                string unknownName = entry.Substring(secondColon + 1).Trim();
+
+                if (type.Length == 0 || elementName.Length == 0 || unknownName.Length == 0)
+                {
+                    continue;
+                }
+
+                if (type.Equals("ATTRIBUTE", StringComparison.OrdinalIgnoreCase))
+                {
+                    AddAllowedName(_allowedAttributes, elementName, unknownName);
+                }
+                else if (type.Equals("ELEMENT", StringComparison.OrdinalIgnoreCase))
+                {
+                    AddAllowedName(_allowedChildren, elementName, unknownName);
+                }
+            }
+
+            _loadedConfigFiles.Add(fullPath);
+        }
+
+        private static void AddAllowedName(Dictionary<string, HashSet<string>> destination, string elementName, string unknownName)
+        {
+            if (!destination.TryGetValue(elementName, out HashSet<string>? names))
+            {
+                names = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                destination[elementName] = names;
+            }
+
+            names.Add(unknownName);
+        }
+    }
+}

--- a/src/Build/Evaluation/UnknownElementsConfiguration.cs
+++ b/src/Build/Evaluation/UnknownElementsConfiguration.cs
@@ -50,13 +50,21 @@ namespace Microsoft.Build.Evaluation
 
         internal static UnknownElementsConfiguration Empty { get; } = new UnknownElementsConfiguration();
 
-        /// <summary>
-        /// Returns true if this config has the same set of loaded files as the other config.
-        /// Used by worker nodes to detect if the config changed between builds.
-        /// </summary>
-        internal bool HasSameLoadedFiles(UnknownElementsConfiguration other)
+        public static bool Equals(UnknownElementsConfiguration? left, UnknownElementsConfiguration? right)
         {
-            return _loadedConfigFiles.SetEquals(other._loadedConfigFiles);
+            if (ReferenceEquals(left, right))
+            {
+                return true;
+            }
+            
+            if (left is null || right is null)
+            {
+                return false;
+            }
+
+            return left._loadedConfigFiles.SetEquals(right._loadedConfigFiles)
+                && CollectionHelpers.DictionaryEquals(left._allowedAttributes, right._allowedAttributes, HashSet<string>.CreateSetComparer())
+                && CollectionHelpers.DictionaryEquals(left._allowedChildren, right._allowedChildren, HashSet<string>.CreateSetComparer());
         }
 
         /// <summary>
@@ -138,20 +146,21 @@ namespace Microsoft.Build.Evaluation
             return $"Loaded Directory.Parse.config from: {string.Join(", ", _loadedConfigFiles)}";
         }
 
-        internal UnknownElementsConfiguration Merge(UnknownElementsConfiguration other)
+        internal static UnknownElementsConfiguration Merge(UnknownElementsConfiguration left, UnknownElementsConfiguration right)
         {
-            ArgumentNullException.ThrowIfNull(other);
+            ArgumentNullException.ThrowIfNull(left);
+            ArgumentNullException.ThrowIfNull(right);
 
             var merged = new UnknownElementsConfiguration();
 
-            UnionEntries(merged._allowedAttributes, _allowedAttributes);
-            UnionEntries(merged._allowedAttributes, other._allowedAttributes);
-            UnionEntries(merged._allowedChildren, _allowedChildren);
-            UnionEntries(merged._allowedChildren, other._allowedChildren);
-            merged._loadedConfigFiles.UnionWith(_loadedConfigFiles);
-            merged._loadedConfigFiles.UnionWith(other._loadedConfigFiles);
-            MergeSkippedItems(merged._skippedItems, _skippedItems);
-            MergeSkippedItems(merged._skippedItems, other._skippedItems);
+            UnionEntries(merged._allowedAttributes, left._allowedAttributes);
+            UnionEntries(merged._allowedAttributes, right._allowedAttributes);
+            UnionEntries(merged._allowedChildren, left._allowedChildren);
+            UnionEntries(merged._allowedChildren, right._allowedChildren);
+            merged._loadedConfigFiles.UnionWith(left._loadedConfigFiles);
+            merged._loadedConfigFiles.UnionWith(right._loadedConfigFiles);
+            MergeSkippedItems(merged._skippedItems, left._skippedItems);
+            MergeSkippedItems(merged._skippedItems, right._skippedItems);
 
             return merged;
         }

--- a/src/Build/Instance/TaskRegistry.cs
+++ b/src/Build/Instance/TaskRegistry.cs
@@ -320,7 +320,7 @@ namespace Microsoft.Build.Execution
 
             if (String.IsNullOrEmpty(taskFactory) || taskFactory.Equals(RegisteredTaskRecord.AssemblyTaskFactory, StringComparison.OrdinalIgnoreCase) || taskFactory.Equals(RegisteredTaskRecord.TaskHostFactory, StringComparison.OrdinalIgnoreCase))
             {
-                ProjectXmlUtilities.VerifyThrowProjectNoChildElements(projectUsingTaskXml.XmlElement);
+                ProjectXmlUtilities.VerifyThrowProjectNoChildElements(projectUsingTaskXml.XmlElement, projectUsingTaskXml.ContainingProject.ProjectRootElementCache.UnknownElementsConfiguration);
             }
 
             if (projectUsingTaskXml.AssemblyFile.Length > 0)

--- a/src/Build/Instance/TaskRegistry.cs
+++ b/src/Build/Instance/TaskRegistry.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -320,7 +320,7 @@ namespace Microsoft.Build.Execution
 
             if (String.IsNullOrEmpty(taskFactory) || taskFactory.Equals(RegisteredTaskRecord.AssemblyTaskFactory, StringComparison.OrdinalIgnoreCase) || taskFactory.Equals(RegisteredTaskRecord.TaskHostFactory, StringComparison.OrdinalIgnoreCase))
             {
-                ProjectXmlUtilities.VerifyThrowProjectNoChildElements(projectUsingTaskXml.XmlElement, projectUsingTaskXml.ContainingProject.ProjectRootElementCache.UnknownElementsConfiguration);
+                ProjectXmlUtilities.VerifyThrowProjectNoChildElements(projectUsingTaskXml.XmlElement, projectUsingTaskXml.ContainingProject.ProjectRootElementCache.ParserIgnoreConfiguration);
             }
 
             if (projectUsingTaskXml.AssemblyFile.Length > 0)

--- a/src/Build/Logging/BinaryLogger/BinaryLogger.cs
+++ b/src/Build/Logging/BinaryLogger/BinaryLogger.cs
@@ -511,6 +511,14 @@ namespace Microsoft.Build.Logging
                     projectImportsCollector.AddFile(filePath);
                 }
                 EditorConfigParser.ClearEditorConfigFilePaths();
+
+                // Write the Directory.Parse.config file paths to the log
+                foreach (var filePath in Evaluation.UnknownElementsConfiguration.BinlogEmbedPaths)
+                {
+                    projectImportsCollector.AddFile(filePath);
+                }
+                Evaluation.UnknownElementsConfiguration.ClearBinlogEmbedPaths();
+
                 projectImportsCollector.Close();
 
                 if (CollectProjectImports == ProjectImportsCollectionMode.Embed)

--- a/src/Build/Logging/BinaryLogger/BinaryLogger.cs
+++ b/src/Build/Logging/BinaryLogger/BinaryLogger.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -513,11 +513,11 @@ namespace Microsoft.Build.Logging
                 EditorConfigParser.ClearEditorConfigFilePaths();
 
                 // Write the Directory.Parse.config file paths to the log
-                foreach (var filePath in Evaluation.UnknownElementsConfiguration.BinlogEmbedPaths)
+                foreach (var filePath in Evaluation.ParserIgnoreConfiguration.BinlogEmbedPaths)
                 {
                     projectImportsCollector.AddFile(filePath);
                 }
-                Evaluation.UnknownElementsConfiguration.ClearBinlogEmbedPaths();
+                Evaluation.ParserIgnoreConfiguration.ClearBinlogEmbedPaths();
 
                 projectImportsCollector.Close();
 

--- a/src/Build/Microsoft.Build.csproj
+++ b/src/Build/Microsoft.Build.csproj
@@ -544,6 +544,7 @@
     <Compile Include="Evaluation\ProjectRootElementCache.cs" />
     <Compile Include="Evaluation\SimpleProjectRootElementCache.cs" />
     <Compile Include="Evaluation\SemiColonTokenizer.cs" />
+    <Compile Include="Evaluation\UnknownElementsConfiguration.cs" />
     <Compile Include="Evaluation\StringMetadataTable.cs" />
     <Compile Include="Evaluation\ExpressionShredder.cs" />
     <Compile Include="Evaluation\Evaluator.cs" />

--- a/src/Build/Microsoft.Build.csproj
+++ b/src/Build/Microsoft.Build.csproj
@@ -544,7 +544,7 @@
     <Compile Include="Evaluation\ProjectRootElementCache.cs" />
     <Compile Include="Evaluation\SimpleProjectRootElementCache.cs" />
     <Compile Include="Evaluation\SemiColonTokenizer.cs" />
-    <Compile Include="Evaluation\UnknownElementsConfiguration.cs" />
+    <Compile Include="Evaluation\ParserIgnoreConfiguration.cs" />
     <Compile Include="Evaluation\StringMetadataTable.cs" />
     <Compile Include="Evaluation\ExpressionShredder.cs" />
     <Compile Include="Evaluation\Evaluator.cs" />

--- a/src/Build/Xml/ProjectXmlUtilities.XmlElementChildIterator.cs
+++ b/src/Build/Xml/ProjectXmlUtilities.XmlElementChildIterator.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -97,7 +97,7 @@ namespace Microsoft.Build.Internal
                             }
                             if (_throwForInvalidNodeTypes)
                             {
-                                ThrowProjectInvalidChildElement(child.Name, _element.Name, _element.Location);
+                                ThrowIfProjectInvalidChildElement(child.Name, _element.Name, _element.Location, config: null);
                             }
                             break;
                     }

--- a/src/Build/Xml/ProjectXmlUtilities.cs
+++ b/src/Build/Xml/ProjectXmlUtilities.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Build.Internal
         /// <summary>
         /// Throw an invalid project exception if there are any child elements at all
         /// </summary>
-        internal static void VerifyThrowProjectNoChildElements(XmlElementWithLocation element, UnknownElementsConfiguration config)
+        internal static void VerifyThrowProjectNoChildElements(XmlElementWithLocation element, ParserIgnoreConfiguration config)
         {
             foreach (var child in GetVerifyThrowProjectChildElements(element))
             {
@@ -138,7 +138,7 @@ namespace Microsoft.Build.Internal
         /// <summary>
         /// If there are any attributes on the element, throws an InvalidProjectFileException complaining that the attribute is not valid on this element.
         /// </summary>
-        internal static void VerifyThrowProjectNoAttributes(XmlElementWithLocation element, UnknownElementsConfiguration config)
+        internal static void VerifyThrowProjectNoAttributes(XmlElementWithLocation element, ParserIgnoreConfiguration config)
         {
             if (element.HasAttributes)
             {
@@ -178,7 +178,7 @@ namespace Microsoft.Build.Internal
         /// Verify that all attributes on the element are on the list of legal attributes.
         /// When genericElementName is provided, only that name is checked in the config (not the actual element name).
         /// </summary>
-        internal static void VerifyThrowProjectAttributes(XmlElementWithLocation element, HashSet<string> validAttributes, UnknownElementsConfiguration config, string genericElementName = null)
+        internal static void VerifyThrowProjectAttributes(XmlElementWithLocation element, HashSet<string> validAttributes, ParserIgnoreConfiguration config, string genericElementName = null)
         {
             foreach (XmlAttributeWithLocation attribute in element.Attributes)
             {
@@ -200,7 +200,7 @@ namespace Microsoft.Build.Internal
         /// If the element is allowed, it is silently skipped.
         /// </summary>
         /// <returns>True if the element was skipped (caller should continue), false if the element was not in config and an exception was thrown.</returns>
-        internal static bool ThrowIfProjectInvalidChildElement(string name, string parentName, ElementLocation location, UnknownElementsConfiguration config)
+        internal static bool ThrowIfProjectInvalidChildElement(string name, string parentName, ElementLocation location, ParserIgnoreConfiguration config)
         {
             if (config?.CheckSkipElement(parentName, name) == true)
             {

--- a/src/Build/Xml/ProjectXmlUtilities.cs
+++ b/src/Build/Xml/ProjectXmlUtilities.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Xml;
 using Microsoft.Build.Construction;
+using Microsoft.Build.Evaluation;
 using Microsoft.Build.Framework.BuildException;
 using Microsoft.Build.Shared;
 
@@ -55,11 +56,11 @@ namespace Microsoft.Build.Internal
         /// <summary>
         /// Throw an invalid project exception if there are any child elements at all
         /// </summary>
-        internal static void VerifyThrowProjectNoChildElements(XmlElementWithLocation element)
+        internal static void VerifyThrowProjectNoChildElements(XmlElementWithLocation element, UnknownElementsConfiguration config = null)
         {
             foreach (var child in GetVerifyThrowProjectChildElements(element))
             {
-                ThrowProjectInvalidChildElement(child.Name, element.Name, element.Location);
+                ThrowIfProjectInvalidChildElement(child.Name, element.Name, element.Location, config);
             }
         }
 
@@ -70,14 +71,6 @@ namespace Microsoft.Build.Internal
         internal static void ThrowProjectInvalidChildElementDueToDuplicate(XmlElementWithLocation child)
         {
             ProjectErrorUtilities.ThrowInvalidProject(child.Location, "InvalidChildElementDueToDuplication", child.Name, child.ParentNode.Name);
-        }
-
-        /// <summary>
-        /// Throw an invalid project exception indicating that the child is not valid beneath the element
-        /// </summary>
-        internal static void ThrowProjectInvalidChildElement(string name, string parentName, ElementLocation location)
-        {
-            ProjectErrorUtilities.ThrowInvalidProject(location, "UnrecognizedChildElement", name, parentName);
         }
 
         /// <summary>
@@ -145,12 +138,17 @@ namespace Microsoft.Build.Internal
         /// <summary>
         /// If there are any attributes on the element, throws an InvalidProjectFileException complaining that the attribute is not valid on this element.
         /// </summary>
-        internal static void VerifyThrowProjectNoAttributes(XmlElementWithLocation element)
+        internal static void VerifyThrowProjectNoAttributes(XmlElementWithLocation element, UnknownElementsConfiguration config = null)
         {
             if (element.HasAttributes)
             {
                 foreach (XmlAttributeWithLocation attribute in element.Attributes)
                 {
+                    if (config?.CheckSkipAttribute(element.Name, attribute.Name) == true)
+                    {
+                        continue;
+                    }
+
                     ThrowProjectInvalidAttribute(attribute);
                 }
             }
@@ -177,14 +175,40 @@ namespace Microsoft.Build.Internal
         }
 
         /// <summary>
-        /// Verify  that all attributes on the element are on the list of legal attributes
+        /// Verify that all attributes on the element are on the list of legal attributes.
+        /// When genericElementName is provided, only that name is checked in the config (not the actual element name).
         /// </summary>
-        internal static void VerifyThrowProjectAttributes(XmlElementWithLocation element, HashSet<string> validAttributes)
+        internal static void VerifyThrowProjectAttributes(XmlElementWithLocation element, HashSet<string> validAttributes, UnknownElementsConfiguration config = null, string genericElementName = null)
         {
             foreach (XmlAttributeWithLocation attribute in element.Attributes)
             {
-                ProjectXmlUtilities.VerifyThrowProjectInvalidAttribute(validAttributes.Contains(attribute.Name), attribute);
+                if (!validAttributes.Contains(attribute.Name))
+                {
+                    string configElementName = genericElementName ?? element.Name;
+                    if (config?.CheckSkipAttribute(configElementName, attribute.Name) == true)
+                    {
+                        continue;
+                    }
+
+                    ThrowProjectInvalidAttribute(attribute);
+                }
             }
+        }
+
+        /// <summary>
+        /// Throws an InvalidProjectFileException if the child element is not allowed by configuration.
+        /// If the element is allowed, it is silently skipped.
+        /// </summary>
+        /// <returns>True if the element was skipped (caller should continue), false if the element was not in config and an exception was thrown.</returns>
+        internal static bool ThrowIfProjectInvalidChildElement(string name, string parentName, ElementLocation location, UnknownElementsConfiguration config = null)
+        {
+            if (config?.CheckSkipElement(parentName, name) == true)
+            {
+                return true;
+            }
+
+            ProjectErrorUtilities.ThrowInvalidProject(location, "UnrecognizedChildElement", name, parentName);
+            return false; // Unreachable, but needed for compiler
         }
 
         /// <summary>

--- a/src/Build/Xml/ProjectXmlUtilities.cs
+++ b/src/Build/Xml/ProjectXmlUtilities.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Build.Internal
         /// <summary>
         /// Throw an invalid project exception if there are any child elements at all
         /// </summary>
-        internal static void VerifyThrowProjectNoChildElements(XmlElementWithLocation element, UnknownElementsConfiguration config = null)
+        internal static void VerifyThrowProjectNoChildElements(XmlElementWithLocation element, UnknownElementsConfiguration config)
         {
             foreach (var child in GetVerifyThrowProjectChildElements(element))
             {
@@ -138,7 +138,7 @@ namespace Microsoft.Build.Internal
         /// <summary>
         /// If there are any attributes on the element, throws an InvalidProjectFileException complaining that the attribute is not valid on this element.
         /// </summary>
-        internal static void VerifyThrowProjectNoAttributes(XmlElementWithLocation element, UnknownElementsConfiguration config = null)
+        internal static void VerifyThrowProjectNoAttributes(XmlElementWithLocation element, UnknownElementsConfiguration config)
         {
             if (element.HasAttributes)
             {
@@ -178,7 +178,7 @@ namespace Microsoft.Build.Internal
         /// Verify that all attributes on the element are on the list of legal attributes.
         /// When genericElementName is provided, only that name is checked in the config (not the actual element name).
         /// </summary>
-        internal static void VerifyThrowProjectAttributes(XmlElementWithLocation element, HashSet<string> validAttributes, UnknownElementsConfiguration config = null, string genericElementName = null)
+        internal static void VerifyThrowProjectAttributes(XmlElementWithLocation element, HashSet<string> validAttributes, UnknownElementsConfiguration config, string genericElementName = null)
         {
             foreach (XmlAttributeWithLocation attribute in element.Attributes)
             {
@@ -200,7 +200,7 @@ namespace Microsoft.Build.Internal
         /// If the element is allowed, it is silently skipped.
         /// </summary>
         /// <returns>True if the element was skipped (caller should continue), false if the element was not in config and an exception was thrown.</returns>
-        internal static bool ThrowIfProjectInvalidChildElement(string name, string parentName, ElementLocation location, UnknownElementsConfiguration config = null)
+        internal static bool ThrowIfProjectInvalidChildElement(string name, string parentName, ElementLocation location, UnknownElementsConfiguration config)
         {
             if (config?.CheckSkipElement(parentName, name) == true)
             {

--- a/src/Framework/Traits.cs
+++ b/src/Framework/Traits.cs
@@ -276,6 +276,13 @@ namespace Microsoft.Build.Framework
         public readonly bool AlwaysEvaluateDangerousGlobs = Environment.GetEnvironmentVariable("MSBuildAlwaysEvaluateDangerousGlobs") == "1";
 
         /// <summary>
+        /// Disables automatic loading of Directory.Parse.config from global locations
+        /// (MSBuild exe directory, user profile, MSBUILD_PARSE_CONFIG env var).
+        /// When set, configuration must be explicitly provided via ProjectCollection or BuildParameters.
+        /// </summary>
+        public readonly bool DisableParseConfig = Environment.GetEnvironmentVariable("MSBUILD_DISABLE_PARSE_CONFIG") == "1";
+
+        /// <summary>
         /// Disables skipping full up to date check for immutable files. See FileClassifier class.
         /// </summary>
         public readonly bool AlwaysDoImmutableFilesUpToDateCheck = Environment.GetEnvironmentVariable("MSBUILDDONOTCACHEMODIFICATIONTIME") == "1";

--- a/src/Framework/Utilities/CollectionHelpers.cs
+++ b/src/Framework/Utilities/CollectionHelpers.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Build.Shared
             return a.ToHashSet().SetEquals(b);
         }
 
-        internal static bool DictionaryEquals<K, V>(IReadOnlyDictionary<K, V> a, IReadOnlyDictionary<K, V> b)
+        internal static bool DictionaryEquals<K, V>(IReadOnlyDictionary<K, V> a, IReadOnlyDictionary<K, V> b, IEqualityComparer<V> valueComparer = null)
         {
             if (a.Count != b.Count)
             {
@@ -68,9 +68,19 @@ namespace Microsoft.Build.Shared
                     return false;
                 }
 
-                if (!Equals(aKvp.Value, bValue))
+                if (valueComparer != null)
                 {
-                    return false;
+                    if (!valueComparer.Equals(aKvp.Value, bValue))
+                    {
+                        return false;
+                    }
+                }
+                else
+                {
+                    if (!Equals(aKvp.Value, bValue))
+                    {
+                        return false;
+                    }
                 }
             }
 

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -1708,6 +1708,9 @@ namespace Microsoft.Build.CommandLine
                 // globalProperties collection contains values only from CommandLine at this stage populated by ProcessCommandLineSwitches
                 projectCollection.PropertiesFromCommandLine = [.. globalProperties.Keys];
 
+                // Load startup-directory parse config into the collection's cache before any project is loaded.
+                projectCollection.LoadParseConfigForStartup(Environment.CurrentDirectory);
+
                 if (toolsVersion != null && !projectCollection.ContainsToolset(toolsVersion))
                 {
                     ThrowInvalidToolsVersionInitializationException(projectCollection.Toolsets, toolsVersion);
@@ -2006,6 +2009,7 @@ namespace Microsoft.Build.CommandLine
             }
             finally
             {
+                projectCollection?.UnloadParseConfigForStartup();
                 projectCollection?.Dispose();
                 FileUtilities.ClearCacheDirectory();
 

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -1708,8 +1708,8 @@ namespace Microsoft.Build.CommandLine
                 // globalProperties collection contains values only from CommandLine at this stage populated by ProcessCommandLineSwitches
                 projectCollection.PropertiesFromCommandLine = [.. globalProperties.Keys];
 
-                // Load startup-directory parse config into the collection's cache before any project is loaded.
-                projectCollection.LoadParseConfigForStartup(Environment.CurrentDirectory);
+                // Load parse config from the project file's directory before any project is loaded.
+                projectCollection.LoadParseConfigForStartup(Path.GetDirectoryName(Path.GetFullPath(projectFile)));
 
                 if (toolsVersion != null && !projectCollection.ContainsToolset(toolsVersion))
                 {

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -1703,13 +1703,11 @@ namespace Microsoft.Build.CommandLine
                     enableTargetOutputLogging: isTaskAndTargetItemLoggingRequired,
                     loadProjectsReadOnly: !isPreprocess,
                     useAsynchronousLogging: true,
-                    reuseProjectRootElementCache: s_isServerNode);
+                    reuseProjectRootElementCache: s_isServerNode,
+                    parseConfigDirectory: Path.GetDirectoryName(Path.GetFullPath(projectFile)));
 
                 // globalProperties collection contains values only from CommandLine at this stage populated by ProcessCommandLineSwitches
                 projectCollection.PropertiesFromCommandLine = [.. globalProperties.Keys];
-
-                // Load parse config from the project file's directory before any project is loaded.
-                projectCollection.LoadParseConfigForStartup(Path.GetDirectoryName(Path.GetFullPath(projectFile)));
 
                 if (toolsVersion != null && !projectCollection.ContainsToolset(toolsVersion))
                 {
@@ -2009,7 +2007,6 @@ namespace Microsoft.Build.CommandLine
             }
             finally
             {
-                projectCollection?.UnloadParseConfigForStartup();
                 projectCollection?.Dispose();
                 FileUtilities.ClearCacheDirectory();
 


### PR DESCRIPTION
Introduces a configuration mechanism that allows specific unrecognized attributes or child elements to be silently skipped during project file parsing instead of failing. See `documentation/specs/directory-parse-config.md` for more details