### PR TITLE
Use &lt;inheritdoc /&gt; for TaskEnvironment in ResolveCodeAnalysisRuleSet

### DIFF
--- a/src/Tasks/ResolveCodeAnalysisRuleSet.cs
+++ b/src/Tasks/ResolveCodeAnalysisRuleSet.cs
@@ -18,9 +18,7 @@ namespace Microsoft.Build.Tasks
     {
         #region Properties
 
-        /// <summary>
-        /// Gets or sets the task execution environment for thread-safe path resolution.
-        /// </summary>
+        /// <inheritdoc />
         public TaskEnvironment TaskEnvironment { get; set; } = TaskEnvironment.Fallback;
 
         /// <summary>


### PR DESCRIPTION
Follow-up to #13636 addressing @OvesN's review nit.

Replaces the hand-written `<summary>` on the `TaskEnvironment` property with `<inheritdoc />`, matching the convention used by every other task migrated to multithreaded execution (`Copy`, `Delete`, `Unzip`, `ResolveAssemblyReference`, etc.).

Doc-comment only — no behavior change.