### PR TITLE
Fix concurrent BuildCheck callback mutation

### DIFF
--- a/src/Build/BuildCheck/Infrastructure/BuildCheckCentralContext.cs
+++ b/src/Build/BuildCheck/Infrastructure/BuildCheckCentralContext.cs
@@ -45,13 +45,27 @@ internal sealed class BuildCheckCentralContext
 
         internal void DeregisterCheck(CheckWrapper check)
         {
-            EvaluatedPropertiesActions.RemoveAll(a => a.Item1 == check);
-            ParsedItemsActions.RemoveAll(a => a.Item1 == check);
-            EvaluatedItemsActions.RemoveAll(a => a.Item1 == check);
-            PropertyReadActions.RemoveAll(a => a.Item1 == check);
-            PropertyWriteActions.RemoveAll(a => a.Item1 == check);
-            ProjectRequestProcessingDoneActions.RemoveAll(a => a.Item1 == check);
-            BuildFinishedActions.RemoveAll(a => a.Item1 == check);
+            DeregisterCheck(EvaluatedPropertiesActions, check);
+            DeregisterCheck(ParsedItemsActions, check);
+            DeregisterCheck(EvaluatedItemsActions, check);
+            DeregisterCheck(TaskInvocationActions, check);
+            DeregisterCheck(PropertyReadActions, check);
+            DeregisterCheck(PropertyWriteActions, check);
+            DeregisterCheck(ProjectRequestProcessingDoneActions, check);
+            DeregisterCheck(BuildFinishedActions, check);
+            DeregisterCheck(EnvironmentVariableCheckDataActions, check);
+            DeregisterCheck(ProjectImportedCheckDataActions, check);
+        }
+
+        private static void DeregisterCheck<T>(
+            List<(CheckWrapper, Action<BuildCheckDataContext<T>>)> registeredCallbacks,
+            CheckWrapper check)
+            where T : CheckData
+        {
+            lock (registeredCallbacks)
+            {
+                registeredCallbacks.RemoveAll(a => a.Item1 == check);
+            }
         }
     }
 
@@ -213,8 +227,14 @@ internal sealed class BuildCheckCentralContext
     {
         string projectFullPath = checkData.ProjectFilePath;
         List<CheckWrapper>? checksToRemove = null;
+        (CheckWrapper, Action<BuildCheckDataContext<T>>)[] callbacksSnapshot;
 
-        foreach (var checkCallback in registeredCallbacks)
+        lock (registeredCallbacks)
+        {
+            callbacksSnapshot = registeredCallbacks.ToArray();
+        }
+
+        foreach (var checkCallback in callbacksSnapshot)
         {
             // Tracing - https://github.com/dotnet/msbuild/issues/9629 - we might want to account this entire block
             //  to the relevant check (with BuildCheckConfigurationEffective only the currently accounted part as being the 'core-execution' subspan)

--- a/src/Build/BuildCheck/Infrastructure/BuildCheckCentralContext.cs
+++ b/src/Build/BuildCheck/Infrastructure/BuildCheckCentralContext.cs
@@ -76,17 +76,27 @@ internal sealed class BuildCheckCentralContext
 
     // This we can potentially use to subscribe for receiving evaluated props in the
     //  build event args. However - this needs to be done early on, when checks might not be known yet
-    internal bool HasEvaluatedPropertiesActions => _globalCallbacks.EvaluatedPropertiesActions.Count > 0;
+    internal bool HasEvaluatedPropertiesActions => HasRegisteredActions(_globalCallbacks.EvaluatedPropertiesActions);
 
-    internal bool HasParsedItemsActions => _globalCallbacks.ParsedItemsActions.Count > 0;
+    internal bool HasParsedItemsActions => HasRegisteredActions(_globalCallbacks.ParsedItemsActions);
 
-    internal bool HasTaskInvocationActions => _globalCallbacks.TaskInvocationActions.Count > 0;
+    internal bool HasTaskInvocationActions => HasRegisteredActions(_globalCallbacks.TaskInvocationActions);
 
-    internal bool HasPropertyReadActions => _globalCallbacks.PropertyReadActions.Count > 0;
+    internal bool HasPropertyReadActions => HasRegisteredActions(_globalCallbacks.PropertyReadActions);
 
-    internal bool HasPropertyWriteActions => _globalCallbacks.PropertyWriteActions.Count > 0;
+    internal bool HasPropertyWriteActions => HasRegisteredActions(_globalCallbacks.PropertyWriteActions);
 
-    internal bool HasBuildFinishedActions => _globalCallbacks.BuildFinishedActions.Count > 0;
+    internal bool HasBuildFinishedActions => HasRegisteredActions(_globalCallbacks.BuildFinishedActions);
+
+    private static bool HasRegisteredActions<T>(
+        List<(CheckWrapper, Action<BuildCheckDataContext<T>>)> registeredCallbacks)
+        where T : CheckData
+    {
+        lock (registeredCallbacks)
+        {
+            return registeredCallbacks.Count > 0;
+        }
+    }
 
     internal void RegisterEnvironmentVariableReadAction(CheckWrapper check, Action<BuildCheckDataContext<EnvironmentVariableCheckData>> environmentVariableAction)
        => RegisterAction(check, environmentVariableAction, _globalCallbacks.EnvironmentVariableCheckDataActions);
@@ -246,7 +256,7 @@ internal sealed class BuildCheckCentralContext
             {
                 if (!commonConfig.IsEnabled)
                 {
-                    return;
+                    continue;
                 }
 
                 configPerRule = [commonConfig];
@@ -256,7 +266,7 @@ internal sealed class BuildCheckCentralContext
                 configPerRule = _configurationProvider.GetMergedConfigurations(projectFullPath, checkCallback.Item1.Check);
                 if (configPerRule.All(c => !c.IsEnabled))
                 {
-                    return;
+                    continue;
                 }
             }
 

--- a/src/Build/BuildCheck/Infrastructure/BuildCheckCentralContext.cs
+++ b/src/Build/BuildCheck/Infrastructure/BuildCheckCentralContext.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using Microsoft.Build.BuildCheck.Infrastructure;
 using Microsoft.Build.Shared;
 
@@ -12,6 +13,11 @@ namespace Microsoft.Build.Experimental.BuildCheck.Infrastructure;
 /// <summary>
 /// A manager of the runs of the checks - deciding based on configuration of what to run and what to postfilter.
 /// </summary>
+/// <remarks>
+/// Callback registration and deregistration publish immutable snapshots. Dispatch uses the snapshot current at its start,
+/// so an in-flight dispatch may invoke a callback after its check is deregistered. The <c>Has*Actions</c> properties are
+/// advisory and callers must rely on dispatch snapshot semantics for correctness.
+/// </remarks>
 internal sealed class BuildCheckCentralContext
 {
     private readonly IConfigurationProvider _configurationProvider;
@@ -24,47 +30,66 @@ internal sealed class BuildCheckCentralContext
         _removeChecks = removeCheck;
     }
 
-    private record CallbackRegistry(
-        List<(CheckWrapper, Action<BuildCheckDataContext<EvaluatedPropertiesCheckData>>)> EvaluatedPropertiesActions,
-#pragma warning disable CS0618 // Type or member is obsolete
-        List<(CheckWrapper, Action<BuildCheckDataContext<ParsedItemsCheckData>>)> ParsedItemsActions,
-#pragma warning restore CS0618 // Type or member is obsolete
-        List<(CheckWrapper, Action<BuildCheckDataContext<EvaluatedItemsCheckData>>)> EvaluatedItemsActions,
-        List<(CheckWrapper, Action<BuildCheckDataContext<TaskInvocationCheckData>>)> TaskInvocationActions,
-        List<(CheckWrapper, Action<BuildCheckDataContext<PropertyReadData>>)> PropertyReadActions,
-        List<(CheckWrapper, Action<BuildCheckDataContext<PropertyWriteData>>)> PropertyWriteActions,
-        List<(CheckWrapper, Action<BuildCheckDataContext<ProjectRequestProcessingDoneData>>)> ProjectRequestProcessingDoneActions,
-        List<(CheckWrapper, Action<BuildCheckDataContext<BuildFinishedCheckData>>)> BuildFinishedActions,
-        List<(CheckWrapper, Action<BuildCheckDataContext<EnvironmentVariableCheckData>>)> EnvironmentVariableCheckDataActions,
-        List<(CheckWrapper, Action<BuildCheckDataContext<ProjectImportedCheckData>>)> ProjectImportedCheckDataActions)
+    private sealed class CallbackRegistry
     {
-        public CallbackRegistry()
-            : this([], [], [], [], [], [], [], [], [], [])
+        internal CallbackCollection<EvaluatedPropertiesCheckData> EvaluatedPropertiesActions { get; } = new();
+#pragma warning disable CS0618 // Type or member is obsolete
+        internal CallbackCollection<ParsedItemsCheckData> ParsedItemsActions { get; } = new();
+#pragma warning restore CS0618 // Type or member is obsolete
+        internal CallbackCollection<EvaluatedItemsCheckData> EvaluatedItemsActions { get; } = new();
+        internal CallbackCollection<TaskInvocationCheckData> TaskInvocationActions { get; } = new();
+        internal CallbackCollection<PropertyReadData> PropertyReadActions { get; } = new();
+        internal CallbackCollection<PropertyWriteData> PropertyWriteActions { get; } = new();
+        internal CallbackCollection<ProjectRequestProcessingDoneData> ProjectRequestProcessingDoneActions { get; } = new();
+        internal CallbackCollection<BuildFinishedCheckData> BuildFinishedActions { get; } = new();
+        internal CallbackCollection<EnvironmentVariableCheckData> EnvironmentVariableCheckDataActions { get; } = new();
+        internal CallbackCollection<ProjectImportedCheckData> ProjectImportedCheckDataActions { get; } = new();
+
+        internal void DeregisterCheck(CheckWrapper check)
         {
+            EvaluatedPropertiesActions.DeregisterCheck(check);
+            ParsedItemsActions.DeregisterCheck(check);
+            EvaluatedItemsActions.DeregisterCheck(check);
+            TaskInvocationActions.DeregisterCheck(check);
+            PropertyReadActions.DeregisterCheck(check);
+            PropertyWriteActions.DeregisterCheck(check);
+            ProjectRequestProcessingDoneActions.DeregisterCheck(check);
+            BuildFinishedActions.DeregisterCheck(check);
+            EnvironmentVariableCheckDataActions.DeregisterCheck(check);
+            ProjectImportedCheckDataActions.DeregisterCheck(check);
+        }
+    }
+
+    private sealed class CallbackCollection<T>
+        where T : CheckData
+    {
+        private readonly object _writeLock = new();
+        private (CheckWrapper, Action<BuildCheckDataContext<T>>)[] _callbacks = [];
+
+        internal bool HasActions => Volatile.Read(ref _callbacks).Length > 0;
+
+        internal (CheckWrapper, Action<BuildCheckDataContext<T>>)[] Snapshot => Volatile.Read(ref _callbacks);
+
+        internal void Register(CheckWrapper check, Action<BuildCheckDataContext<T>> callback)
+        {
+            lock (_writeLock)
+            {
+                (CheckWrapper, Action<BuildCheckDataContext<T>>)[] callbacks = _callbacks;
+                Array.Resize(ref callbacks, callbacks.Length + 1);
+                callbacks[^1] = (check, callback);
+                Volatile.Write(ref _callbacks, callbacks);
+            }
         }
 
         internal void DeregisterCheck(CheckWrapper check)
         {
-            DeregisterCheck(EvaluatedPropertiesActions, check);
-            DeregisterCheck(ParsedItemsActions, check);
-            DeregisterCheck(EvaluatedItemsActions, check);
-            DeregisterCheck(TaskInvocationActions, check);
-            DeregisterCheck(PropertyReadActions, check);
-            DeregisterCheck(PropertyWriteActions, check);
-            DeregisterCheck(ProjectRequestProcessingDoneActions, check);
-            DeregisterCheck(BuildFinishedActions, check);
-            DeregisterCheck(EnvironmentVariableCheckDataActions, check);
-            DeregisterCheck(ProjectImportedCheckDataActions, check);
-        }
-
-        private static void DeregisterCheck<T>(
-            List<(CheckWrapper, Action<BuildCheckDataContext<T>>)> registeredCallbacks,
-            CheckWrapper check)
-            where T : CheckData
-        {
-            lock (registeredCallbacks)
+            lock (_writeLock)
             {
-                registeredCallbacks.RemoveAll(a => a.Item1 == check);
+                (CheckWrapper, Action<BuildCheckDataContext<T>>)[] callbacks = _callbacks;
+                if (callbacks.Any(callback => callback.Item1 == check))
+                {
+                    Volatile.Write(ref _callbacks, callbacks.Where(callback => callback.Item1 != check).ToArray());
+                }
             }
         }
     }
@@ -76,27 +101,25 @@ internal sealed class BuildCheckCentralContext
 
     // This we can potentially use to subscribe for receiving evaluated props in the
     //  build event args. However - this needs to be done early on, when checks might not be known yet
-    internal bool HasEvaluatedPropertiesActions => HasRegisteredActions(_globalCallbacks.EvaluatedPropertiesActions);
+    internal bool HasEvaluatedPropertiesActions => _globalCallbacks.EvaluatedPropertiesActions.HasActions;
 
-    internal bool HasParsedItemsActions => HasRegisteredActions(_globalCallbacks.ParsedItemsActions);
+    internal bool HasParsedItemsActions => _globalCallbacks.ParsedItemsActions.HasActions;
 
-    internal bool HasTaskInvocationActions => HasRegisteredActions(_globalCallbacks.TaskInvocationActions);
+    internal bool HasEvaluatedItemsActions => _globalCallbacks.EvaluatedItemsActions.HasActions;
 
-    internal bool HasPropertyReadActions => HasRegisteredActions(_globalCallbacks.PropertyReadActions);
+    internal bool HasTaskInvocationActions => _globalCallbacks.TaskInvocationActions.HasActions;
 
-    internal bool HasPropertyWriteActions => HasRegisteredActions(_globalCallbacks.PropertyWriteActions);
+    internal bool HasPropertyReadActions => _globalCallbacks.PropertyReadActions.HasActions;
 
-    internal bool HasBuildFinishedActions => HasRegisteredActions(_globalCallbacks.BuildFinishedActions);
+    internal bool HasPropertyWriteActions => _globalCallbacks.PropertyWriteActions.HasActions;
 
-    private static bool HasRegisteredActions<T>(
-        List<(CheckWrapper, Action<BuildCheckDataContext<T>>)> registeredCallbacks)
-        where T : CheckData
-    {
-        lock (registeredCallbacks)
-        {
-            return registeredCallbacks.Count > 0;
-        }
-    }
+    internal bool HasProjectRequestProcessingDoneActions => _globalCallbacks.ProjectRequestProcessingDoneActions.HasActions;
+
+    internal bool HasBuildFinishedActions => _globalCallbacks.BuildFinishedActions.HasActions;
+
+    internal bool HasEnvironmentVariableActions => _globalCallbacks.EnvironmentVariableCheckDataActions.HasActions;
+
+    internal bool HasProjectImportedActions => _globalCallbacks.ProjectImportedCheckDataActions.HasActions;
 
     internal void RegisterEnvironmentVariableReadAction(CheckWrapper check, Action<BuildCheckDataContext<EnvironmentVariableCheckData>> environmentVariableAction)
        => RegisterAction(check, environmentVariableAction, _globalCallbacks.EnvironmentVariableCheckDataActions);
@@ -135,7 +158,7 @@ internal sealed class BuildCheckCentralContext
     private void RegisterAction<T>(
         CheckWrapper wrappedCheck,
         Action<BuildCheckDataContext<T>> handler,
-        List<(CheckWrapper, Action<BuildCheckDataContext<T>>)> handlersRegistry)
+        CallbackCollection<T> handlersRegistry)
         where T : CheckData
     {
         void WrappedHandler(BuildCheckDataContext<T> context)
@@ -144,10 +167,7 @@ internal sealed class BuildCheckCentralContext
             handler(context);
         }
 
-        lock (handlersRegistry)
-        {
-            handlersRegistry.Add((wrappedCheck, WrappedHandler));
-        }
+        handlersRegistry.Register(wrappedCheck, WrappedHandler);
     }
 
     internal void DeregisterCheck(CheckWrapper check) => _globalCallbacks.DeregisterCheck(check);
@@ -229,7 +249,7 @@ internal sealed class BuildCheckCentralContext
         => RunRegisteredActions(_globalCallbacks.ProjectImportedCheckDataActions, projectImportedCheckData, checkContext, resultHandler);
 
     private void RunRegisteredActions<T>(
-        List<(CheckWrapper, Action<BuildCheckDataContext<T>>)> registeredCallbacks,
+        CallbackCollection<T> registeredCallbacks,
         T checkData,
         ICheckContext checkContext,
         Action<CheckWrapper, ICheckContext, CheckConfigurationEffective[], BuildCheckResult> resultHandler)
@@ -237,12 +257,7 @@ internal sealed class BuildCheckCentralContext
     {
         string projectFullPath = checkData.ProjectFilePath;
         List<CheckWrapper>? checksToRemove = null;
-        (CheckWrapper, Action<BuildCheckDataContext<T>>)[] callbacksSnapshot;
-
-        lock (registeredCallbacks)
-        {
-            callbacksSnapshot = registeredCallbacks.ToArray();
-        }
+        (CheckWrapper, Action<BuildCheckDataContext<T>>)[] callbacksSnapshot = registeredCallbacks.Snapshot;
 
         foreach (var checkCallback in callbacksSnapshot)
         {

--- a/src/Build/BuildCheck/Infrastructure/BuildEventsProcessor.cs
+++ b/src/Build/BuildCheck/Infrastructure/BuildEventsProcessor.cs
@@ -171,20 +171,17 @@ internal class BuildEventsProcessor(BuildCheckCentralContext buildCheckCentralCo
         ICheckContext checkContext,
         TaskFinishedEventArgs taskFinishedEventArgs)
     {
-        if (!_buildCheckCentralContext.HasTaskInvocationActions)
-        {
-            // No check is interested in task invocation actions -> nothing to do.
-            return;
-        }
-
         if (taskFinishedEventArgs?.BuildEventContext is not null)
         {
             TaskKey taskKey = new TaskKey(taskFinishedEventArgs.BuildEventContext);
             if (_tasksBeingExecuted.TryGetValue(taskKey, out ExecutingTaskData taskData))
             {
-                // All task parameters have been recorded by now so remove the task from the dictionary and fire the registered build check actions.
+                // Always remove completed tasks, even if the last interested check was deregistered while the task was running.
                 _tasksBeingExecuted.Remove(taskKey);
-                _buildCheckCentralContext.RunTaskInvocationActions(taskData.CheckData, checkContext, ReportResult);
+                if (_buildCheckCentralContext.HasTaskInvocationActions)
+                {
+                    _buildCheckCentralContext.RunTaskInvocationActions(taskData.CheckData, checkContext, ReportResult);
+                }
             }
         }
     }

--- a/src/BuildCheck.UnitTests/BuildCheckCentralContext_Tests.cs
+++ b/src/BuildCheck.UnitTests/BuildCheckCentralContext_Tests.cs
@@ -1,0 +1,66 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using Microsoft.Build.BuildCheck.Infrastructure;
+using Microsoft.Build.Experimental.BuildCheck;
+using Microsoft.Build.Experimental.BuildCheck.Acquisition;
+using Microsoft.Build.Experimental.BuildCheck.Infrastructure;
+using Shouldly;
+using Xunit;
+
+namespace Microsoft.Build.BuildCheck.UnitTests;
+
+public class BuildCheckCentralContext_Tests
+{
+    [Fact]
+    public void RegisteringActionDuringDispatchUsesNextDispatch()
+    {
+        var context = new BuildCheckCentralContext(
+            new EnabledConfigurationProvider(),
+            (_, _) => { });
+        using var checkRule = new CheckRuleMock("Rule");
+        var check = new CheckWrapper(checkRule, null!);
+        int originalActionRuns = 0;
+        int registeredActionRuns = 0;
+
+        context.RegisterEvaluatedPropertiesAction(
+            check,
+            _ =>
+            {
+                originalActionRuns++;
+                context.RegisterEvaluatedPropertiesAction(check, _ => registeredActionRuns++);
+            });
+
+        context.RunEvaluatedPropertiesActions(CreateCheckData(), null!, (_, _, _, _) => { });
+
+        originalActionRuns.ShouldBe(1);
+        registeredActionRuns.ShouldBe(0);
+
+        context.RunEvaluatedPropertiesActions(CreateCheckData(), null!, (_, _, _, _) => { });
+
+        originalActionRuns.ShouldBe(2);
+        registeredActionRuns.ShouldBe(1);
+    }
+
+    private static EvaluatedPropertiesCheckData CreateCheckData()
+        => new("project.proj", null, new Dictionary<string, string>(), new Dictionary<string, string>());
+
+    private sealed class EnabledConfigurationProvider : IConfigurationProvider
+    {
+        private static readonly CheckConfigurationEffective[] s_configuration =
+        [
+            new("X01234", EvaluationCheckScope.ProjectFileOnly, CheckResultSeverity.Warning),
+        ];
+
+        public void CheckCustomConfigurationDataValidity(string projectFullPath, string ruleId) { }
+
+        public CustomConfigurationData[] GetCustomConfigurations(string projectFullPath, IReadOnlyList<string> ruleIds) => [];
+
+        public CheckConfigurationEffective[] GetMergedConfigurations(string projectFullPath, Check check) => s_configuration;
+
+        public CheckConfigurationEffective[] GetMergedConfigurations(CheckConfiguration[] userConfigs, Check check) => s_configuration;
+
+        public CheckConfiguration[] GetUserConfigurations(string projectFullPath, IReadOnlyList<string> ruleIds) => [];
+    }
+}

--- a/src/BuildCheck.UnitTests/BuildCheckCentralContext_Tests.cs
+++ b/src/BuildCheck.UnitTests/BuildCheckCentralContext_Tests.cs
@@ -8,6 +8,8 @@ using System.Threading.Tasks;
 using Microsoft.Build.BuildCheck.Infrastructure;
 using Microsoft.Build.Experimental.BuildCheck;
 using Microsoft.Build.Experimental.BuildCheck.Infrastructure;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Shared;
 using Shouldly;
 using Xunit;
 
@@ -15,6 +17,9 @@ namespace Microsoft.Build.BuildCheck.UnitTests;
 
 public class BuildCheckCentralContext_Tests
 {
+    private static readonly ICheckContext s_checkContext = new NullCheckContext();
+    private static readonly IResultReporter s_resultReporter = new NullResultReporter();
+
     [Fact]
     public void RegisteringActionDuringDispatchUsesNextDispatch()
     {
@@ -22,7 +27,7 @@ public class BuildCheckCentralContext_Tests
             new EnabledConfigurationProvider(),
             (_, _) => { });
         using var checkRule = new CheckRuleMock("Rule");
-        var check = new CheckWrapper(checkRule, null!);
+        var check = new CheckWrapper(checkRule, s_resultReporter);
         int originalActionRuns = 0;
         int registeredActionRuns = 0;
 
@@ -34,12 +39,12 @@ public class BuildCheckCentralContext_Tests
                 context.RegisterEvaluatedPropertiesAction(check, _ => registeredActionRuns++);
             });
 
-        context.RunEvaluatedPropertiesActions(CreateCheckData(), null!, (_, _, _, _) => { });
+        context.RunEvaluatedPropertiesActions(CreateCheckData(), s_checkContext, (_, _, _, _) => { });
 
         originalActionRuns.ShouldBe(1);
         registeredActionRuns.ShouldBe(0);
 
-        context.RunEvaluatedPropertiesActions(CreateCheckData(), null!, (_, _, _, _) => { });
+        context.RunEvaluatedPropertiesActions(CreateCheckData(), s_checkContext, (_, _, _, _) => { });
 
         originalActionRuns.ShouldBe(2);
         registeredActionRuns.ShouldBe(1);
@@ -52,7 +57,7 @@ public class BuildCheckCentralContext_Tests
             new EnabledConfigurationProvider(),
             (_, _) => { });
         using var checkRule = new CheckRuleMock("Rule");
-        var check = new CheckWrapper(checkRule, null!);
+        var check = new CheckWrapper(checkRule, s_resultReporter);
         using var actionStarted = new ManualResetEventSlim();
         using var continueAction = new ManualResetEventSlim();
         int firstActionRuns = 0;
@@ -69,7 +74,7 @@ public class BuildCheckCentralContext_Tests
         context.RegisterEvaluatedPropertiesAction(check, _ => secondActionRuns++);
 
         Task dispatch = Task.Run(
-            () => context.RunEvaluatedPropertiesActions(CreateCheckData(), null!, (_, _, _, _) => { }));
+            () => context.RunEvaluatedPropertiesActions(CreateCheckData(), s_checkContext, (_, _, _, _) => { }));
 
         try
         {
@@ -79,15 +84,14 @@ public class BuildCheckCentralContext_Tests
         finally
         {
             continueAction.Set();
+            await dispatch;
         }
-
-        await dispatch;
 
         firstActionRuns.ShouldBe(1);
         secondActionRuns.ShouldBe(1);
         context.HasEvaluatedPropertiesActions.ShouldBeFalse();
 
-        context.RunEvaluatedPropertiesActions(CreateCheckData(), null!, (_, _, _, _) => { });
+        context.RunEvaluatedPropertiesActions(CreateCheckData(), s_checkContext, (_, _, _, _) => { });
 
         firstActionRuns.ShouldBe(1);
         secondActionRuns.ShouldBe(1);
@@ -101,18 +105,91 @@ public class BuildCheckCentralContext_Tests
             (_, _) => { });
         using var disabledCheckRule = new CheckRuleMock("Disabled");
         using var enabledCheckRule = new CheckRuleMock("Enabled");
-        var disabledCheck = new CheckWrapper(disabledCheckRule, null!);
-        var enabledCheck = new CheckWrapper(enabledCheckRule, null!);
+        var disabledCheck = new CheckWrapper(disabledCheckRule, s_resultReporter);
+        var enabledCheck = new CheckWrapper(enabledCheckRule, s_resultReporter);
         int disabledActionRuns = 0;
         int enabledActionRuns = 0;
 
         context.RegisterEvaluatedPropertiesAction(disabledCheck, _ => disabledActionRuns++);
         context.RegisterEvaluatedPropertiesAction(enabledCheck, _ => enabledActionRuns++);
 
-        context.RunEvaluatedPropertiesActions(CreateCheckData(), null!, (_, _, _, _) => { });
+        context.RunEvaluatedPropertiesActions(CreateCheckData(), s_checkContext, (_, _, _, _) => { });
 
         disabledActionRuns.ShouldBe(0);
         enabledActionRuns.ShouldBe(1);
+    }
+
+    [Fact]
+    public void DeregisterCheckClearsEveryCallbackRegistry()
+    {
+        var context = new BuildCheckCentralContext(
+            new EnabledConfigurationProvider(),
+            (_, _) => { });
+        using var checkRule = new CheckRuleMock("Rule");
+        var check = new CheckWrapper(checkRule, s_resultReporter);
+
+        context.RegisterEvaluatedPropertiesAction(check, _ => { });
+#pragma warning disable CS0618 // Type or member is obsolete
+        context.RegisterParsedItemsAction(check, _ => { });
+#pragma warning restore CS0618 // Type or member is obsolete
+        context.RegisterEvaluatedItemsAction(check, _ => { });
+        context.RegisterTaskInvocationAction(check, _ => { });
+        context.RegisterPropertyReadAction(check, _ => { });
+        context.RegisterPropertyWriteAction(check, _ => { });
+        context.RegisterProjectRequestProcessingDoneAction(check, _ => { });
+        context.RegisterBuildFinishedAction(check, _ => { });
+        context.RegisterEnvironmentVariableReadAction(check, _ => { });
+        context.RegisterProjectImportedAction(check, _ => { });
+
+        AssertAllRegistriesHaveActions(context, true);
+
+        context.DeregisterCheck(check);
+
+        AssertAllRegistriesHaveActions(context, false);
+    }
+
+    [Fact]
+    public void TaskFinishedRemovesTaskAfterLastCallbackIsDeregistered()
+    {
+        var context = new BuildCheckCentralContext(
+            new EnabledConfigurationProvider(),
+            (_, _) => { });
+        var processor = new BuildEventsProcessor(context);
+        using var checkRule = new CheckRuleMock("Rule");
+        var check = new CheckWrapper(checkRule, s_resultReporter);
+        var eventContext = new BuildEventContext(1, 2, 3, 4);
+        var taskStarted = new TaskStartedEventArgs(null, null, "project.proj", "task.dll", "Task")
+        {
+            BuildEventContext = eventContext,
+        };
+        var taskFinished = new TaskFinishedEventArgs(null, null, "project.proj", "task.dll", "Task", true)
+        {
+            BuildEventContext = eventContext,
+        };
+
+        context.RegisterTaskInvocationAction(check, _ => { });
+        processor.ProcessTaskStartedEventArgs(s_checkContext, taskStarted);
+
+        context.DeregisterCheck(check);
+        processor.ProcessTaskFinishedEventArgs(s_checkContext, taskFinished);
+
+        context.RegisterTaskInvocationAction(check, _ => { });
+        Should.NotThrow(() => processor.ProcessTaskStartedEventArgs(s_checkContext, taskStarted));
+        processor.ProcessTaskFinishedEventArgs(s_checkContext, taskFinished);
+    }
+
+    private static void AssertAllRegistriesHaveActions(BuildCheckCentralContext context, bool expected)
+    {
+        context.HasEvaluatedPropertiesActions.ShouldBe(expected);
+        context.HasParsedItemsActions.ShouldBe(expected);
+        context.HasEvaluatedItemsActions.ShouldBe(expected);
+        context.HasTaskInvocationActions.ShouldBe(expected);
+        context.HasPropertyReadActions.ShouldBe(expected);
+        context.HasPropertyWriteActions.ShouldBe(expected);
+        context.HasProjectRequestProcessingDoneActions.ShouldBe(expected);
+        context.HasBuildFinishedActions.ShouldBe(expected);
+        context.HasEnvironmentVariableActions.ShouldBe(expected);
+        context.HasProjectImportedActions.ShouldBe(expected);
     }
 
     private static EvaluatedPropertiesCheckData CreateCheckData()
@@ -155,5 +232,41 @@ public class BuildCheckCentralContext_Tests
             => GetMergedConfigurations(string.Empty, check);
 
         public CheckConfiguration[] GetUserConfigurations(string projectFullPath, IReadOnlyList<string> ruleIds) => [];
+    }
+
+    private sealed class NullResultReporter : IResultReporter
+    {
+        public void ReportResult(BuildEventArgs result, ICheckContext checkContext) { }
+    }
+
+    private sealed class NullCheckContext : ICheckContext
+    {
+        public BuildEventContext BuildEventContext => BuildEventContext.Invalid;
+
+        public void DispatchAsComment(MessageImportance importance, string messageResourceName, params object?[] messageArgs) { }
+
+        public void DispatchBuildEvent(BuildEventArgs buildEvent) { }
+
+        public void DispatchAsErrorFromText(
+            string? subcategoryResourceName,
+            string? errorCode,
+            string? helpKeyword,
+            BuildEventFileInfo file,
+            string message)
+        { }
+
+        public void DispatchAsCommentFromText(MessageImportance importance, string message) { }
+
+        public void DispatchAsWarningFromText(
+            string? subcategoryResourceName,
+            string? errorCode,
+            string? helpKeyword,
+            BuildEventFileInfo file,
+            string message)
+        { }
+
+        public void DispatchFailedAcquisitionTelemetry(string assemblyName, Exception exception) { }
+
+        public void DispatchTelemetry(BuildCheckTracingData data) { }
     }
 }

--- a/src/BuildCheck.UnitTests/BuildCheckCentralContext_Tests.cs
+++ b/src/BuildCheck.UnitTests/BuildCheckCentralContext_Tests.cs
@@ -1,10 +1,12 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Build.BuildCheck.Infrastructure;
 using Microsoft.Build.Experimental.BuildCheck;
-using Microsoft.Build.Experimental.BuildCheck.Acquisition;
 using Microsoft.Build.Experimental.BuildCheck.Infrastructure;
 using Shouldly;
 using Xunit;
@@ -43,6 +45,76 @@ public class BuildCheckCentralContext_Tests
         registeredActionRuns.ShouldBe(1);
     }
 
+    [Fact]
+    public async Task DeregisteringCheckDuringDispatchUsesCurrentSnapshot()
+    {
+        var context = new BuildCheckCentralContext(
+            new EnabledConfigurationProvider(),
+            (_, _) => { });
+        using var checkRule = new CheckRuleMock("Rule");
+        var check = new CheckWrapper(checkRule, null!);
+        using var actionStarted = new ManualResetEventSlim();
+        using var continueAction = new ManualResetEventSlim();
+        int firstActionRuns = 0;
+        int secondActionRuns = 0;
+
+        context.RegisterEvaluatedPropertiesAction(
+            check,
+            _ =>
+            {
+                firstActionRuns++;
+                actionStarted.Set();
+                continueAction.Wait();
+            });
+        context.RegisterEvaluatedPropertiesAction(check, _ => secondActionRuns++);
+
+        Task dispatch = Task.Run(
+            () => context.RunEvaluatedPropertiesActions(CreateCheckData(), null!, (_, _, _, _) => { }));
+
+        try
+        {
+            actionStarted.Wait(TimeSpan.FromSeconds(10)).ShouldBeTrue();
+            context.DeregisterCheck(check);
+        }
+        finally
+        {
+            continueAction.Set();
+        }
+
+        await dispatch;
+
+        firstActionRuns.ShouldBe(1);
+        secondActionRuns.ShouldBe(1);
+        context.HasEvaluatedPropertiesActions.ShouldBeFalse();
+
+        context.RunEvaluatedPropertiesActions(CreateCheckData(), null!, (_, _, _, _) => { });
+
+        firstActionRuns.ShouldBe(1);
+        secondActionRuns.ShouldBe(1);
+    }
+
+    [Fact]
+    public void DisabledCheckDoesNotPreventLaterActions()
+    {
+        var context = new BuildCheckCentralContext(
+            new SelectiveConfigurationProvider("Disabled"),
+            (_, _) => { });
+        using var disabledCheckRule = new CheckRuleMock("Disabled");
+        using var enabledCheckRule = new CheckRuleMock("Enabled");
+        var disabledCheck = new CheckWrapper(disabledCheckRule, null!);
+        var enabledCheck = new CheckWrapper(enabledCheckRule, null!);
+        int disabledActionRuns = 0;
+        int enabledActionRuns = 0;
+
+        context.RegisterEvaluatedPropertiesAction(disabledCheck, _ => disabledActionRuns++);
+        context.RegisterEvaluatedPropertiesAction(enabledCheck, _ => enabledActionRuns++);
+
+        context.RunEvaluatedPropertiesActions(CreateCheckData(), null!, (_, _, _, _) => { });
+
+        disabledActionRuns.ShouldBe(0);
+        enabledActionRuns.ShouldBe(1);
+    }
+
     private static EvaluatedPropertiesCheckData CreateCheckData()
         => new("project.proj", null, new Dictionary<string, string>(), new Dictionary<string, string>());
 
@@ -60,6 +132,27 @@ public class BuildCheckCentralContext_Tests
         public CheckConfigurationEffective[] GetMergedConfigurations(string projectFullPath, Check check) => s_configuration;
 
         public CheckConfigurationEffective[] GetMergedConfigurations(CheckConfiguration[] userConfigs, Check check) => s_configuration;
+
+        public CheckConfiguration[] GetUserConfigurations(string projectFullPath, IReadOnlyList<string> ruleIds) => [];
+    }
+
+    private sealed class SelectiveConfigurationProvider(string disabledCheckName) : IConfigurationProvider
+    {
+        public void CheckCustomConfigurationDataValidity(string projectFullPath, string ruleId) { }
+
+        public CustomConfigurationData[] GetCustomConfigurations(string projectFullPath, IReadOnlyList<string> ruleIds) => [];
+
+        public CheckConfigurationEffective[] GetMergedConfigurations(string projectFullPath, Check check)
+            =>
+            [
+                new(
+                    "X01234",
+                    EvaluationCheckScope.ProjectFileOnly,
+                    check.FriendlyName == disabledCheckName ? CheckResultSeverity.None : CheckResultSeverity.Warning),
+            ];
+
+        public CheckConfigurationEffective[] GetMergedConfigurations(CheckConfiguration[] userConfigs, Check check)
+            => GetMergedConfigurations(string.Empty, check);
 
         public CheckConfiguration[] GetUserConfigurations(string projectFullPath, IReadOnlyList<string> ruleIds) => [];
     }


### PR DESCRIPTION
## Summary
- replace mutable callback lists with immutable copy-on-write snapshots published through Volatile
- keep Has…Actions checks and callback dispatch lock-free and allocation-free
- deregister checks from all callback registries while preserving cleanup for tasks already in flight
- skip only the disabled callback instead of suppressing all later checks
- document snapshot and advisory-presence semantics

## Motivation
Graph builds can register or remove BuildCheck callbacks while another thread dispatches the same registry. Enumerating the mutable List<T> caused InvalidOperationException, which the logging pipeline surfaced as InternalLoggerException / MSB4166.

The previous deregistration path also left task, environment-variable, and project-import callbacks active after a check was removed. Task callback removal now keeps task-finished cleanup unconditional so in-flight tracking entries are not orphaned.

## Tests
- concurrent registration uses the next dispatch snapshot
- concurrent deregistration safely completes the current snapshot
- deregistration clears all ten callback registries
- task completion drains tracking after the last task callback is removed
- a disabled check does not suppress later enabled checks
- full Microsoft.Build.BuildCheck.UnitTests suite: **235 passed, 0 failed**

## Follow-up
- https://github.com/dotnet/msbuild/issues/14598