### PR TITLE
Add aliases for configuration and test parameters in build scripts

### DIFF
--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -1,8 +1,8 @@
 [CmdletBinding(PositionalBinding=$false)]
 Param(
   [string] $msbuildEngine,
-  [string] $configuration = "Debug",
-  [switch] $test,
+  [string][Alias('c')] $configuration = "Debug",
+  [switch][Alias('t')] $test,
   [switch] $ci,
   [switch][Alias('bl')] $binaryLog,
   [switch][Alias('nobl')] $excludeCIBinarylog,

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -2,6 +2,7 @@
 Param(
   [string] $msbuildEngine,
   [string][Alias('c')] $configuration = "Debug",
+  [string][Alias('v')] $verbosity,
   [switch][Alias('t')] $test,
   [switch] $ci,
   [switch][Alias('bl')] $binaryLog,
@@ -18,6 +19,11 @@ $buildScript = Join-Path $PSScriptRoot 'common\build.ps1'
 $commonBuildArgs = @('-configuration', $configuration) + $properties
 
 # Forward the argument if supplied. Needs to be done for all above explicit parameters that should be passed to the build.
+if ($verbosity) {
+  $commonBuildArgs += '-verbosity'
+  $commonBuildArgs += $verbosity
+}
+
 if ($msbuildEngine) {
   $commonBuildArgs += '-msbuildEngine'
   $commonBuildArgs += $msbuildEngine

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -25,11 +25,11 @@ scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
 while [[ $# -gt 0 ]]; do
   lowerI="$(echo $1 | awk '{print tolower($0)}')"
   case "$lowerI" in
-    --configuration)
+    --configuration|-c)
       configuration=$2
       shift 2
       ;;
-    --test)
+    --test|-t)
       test=true
       shift 1
       ;;


### PR DESCRIPTION
PR #14361 changed the top-level build scripts to invoke the repository-specific  `eng/build.ps1`  and  `eng/build.sh`  wrappers instead of calling the Arcade build scripts directly.

Before that refactoring,  `-c`  and  `-t`  were supported by  `eng/common/build.ps1`  and  `eng/common/build.sh` . The new wrappers retained the configuration  and  test  parameters, but did not retain their short aliases.

On Windows, this caused  `build.cmd -c Release`  to fail because PowerShell interpreted  `-c`  as ambiguous between  `-configuration`  and  `-ci`.
