### PR TITLE
Add decoy-CWD test for GetAssembliesMetadata multithreaded migration

### DIFF
--- a/src/Tasks.UnitTests/GetAssembliesMetadata_Tests.cs
+++ b/src/Tasks.UnitTests/GetAssembliesMetadata_Tests.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Microsoft.Build.Framework;
 using Microsoft.Build.UnitTests;
 using Microsoft.Build.UnitTests.Shared;
 using Shouldly;
@@ -81,6 +82,68 @@ namespace Microsoft.Build.Tasks.UnitTests
             t.AssembliesMetadata[0].GetMetadata("Culture").ShouldBeEmpty();
             t.AssembliesMetadata[0].GetMetadata("TargetFrameworkMoniker").ShouldBeEmpty();
             t.AssembliesMetadata[0].GetMetadata("DefaultAlias").ShouldBe("mscorlib");
+            t.AssembliesMetadata[0].GetMetadata("PublicHexKey").ShouldBe("00000000000000000400000000000000");
+        }
+    }
+
+    /// <summary>
+    /// Isolated because <see cref="AssemblyPathIsResolvedAgainstProjectDirectoryNotCurrentDirectory"/> mutates the
+    /// process-wide current directory, which cannot be done safely while other collections run concurrently.
+    /// Only this test needs the serialization, so it lives apart from <see cref="GetAssembliesMetadata_Tests"/>.
+    /// </summary>
+    [CollectionDefinition(Name, DisableParallelization = true)]
+    public class GetAssembliesMetadataCurrentDirectoryCollection
+    {
+        public const string Name = nameof(GetAssembliesMetadataCurrentDirectoryCollection);
+    }
+
+    [Collection(GetAssembliesMetadataCurrentDirectoryCollection.Name)]
+    public class GetAssembliesMetadata_CurrentDirectory_Tests
+    {
+        private readonly ITestOutputHelper _testOutput;
+
+        public GetAssembliesMetadata_CurrentDirectory_Tests(ITestOutputHelper testOutput)
+        {
+            _testOutput = testOutput;
+        }
+
+        /// <summary>
+        /// Regression test for the multithreaded migration: a relative assembly path must resolve against the task's
+        /// <see cref="TaskEnvironment"/> project directory, not the process current directory. The current directory is
+        /// pointed at a decoy folder that contains no assembly at all, so the task can only succeed if it absolutizes
+        /// the input against the project directory.
+        /// </summary>
+        [Fact]
+        public void AssemblyPathIsResolvedAgainstProjectDirectoryNotCurrentDirectory()
+        {
+            using TestEnvironment env = TestEnvironment.Create(_testOutput);
+            TransientTestFolder projectFolder = env.CreateFolder();
+            TransientTestFolder decoyFolder = env.CreateFolder();
+
+            string pathToWinFolder = Environment.GetFolderPath(Environment.SpecialFolder.Windows);
+            string sourceAssemblyPath = Path.Combine(pathToWinFolder, "Microsoft.NET", "Framework", "v4.0.30319", "mscorlib.dll");
+            Directory.CreateDirectory(Path.Combine(projectFolder.Path, "libs"));
+            File.Copy(sourceAssemblyPath, Path.Combine(projectFolder.Path, "libs", "mscorlib.dll"));
+
+            // The decoy is deliberately empty: if the task resolved against the current directory it would find nothing.
+            env.SetCurrentDirectory(decoyFolder.Path);
+
+            GetAssembliesMetadata t = new()
+            {
+                TaskEnvironment = TaskEnvironment.CreateWithProjectDirectoryAndEnvironment(projectFolder.Path),
+                AssemblyPaths = [@"libs\mscorlib.dll"],
+            };
+
+            bool isSuccess = t.Execute();
+
+            isSuccess.ShouldBeTrue();
+            t.AssembliesMetadata.Length.ShouldBe(1);
+
+            // The ItemSpec must stay the exact user-supplied relative path, not the absolutized form used to read metadata.
+            t.AssembliesMetadata[0].ItemSpec.ShouldBe(@"libs\mscorlib.dll");
+            t.AssembliesMetadata[0].GetMetadata("AssemblyName").ShouldBe("mscorlib");
+            t.AssembliesMetadata[0].GetMetadata("IsAssembly").ShouldBe("True");
+            t.AssembliesMetadata[0].GetMetadata("RuntimeVersion").ShouldBe("v4.0.30319");
             t.AssembliesMetadata[0].GetMetadata("PublicHexKey").ShouldBe("00000000000000000400000000000000");
         }
     }


### PR DESCRIPTION
Follow-up to #13637, addressing @AlesProkop''s review request: "Consider adding a decoy test to expand test coverage."

Test-only change; `src/Tasks/GetAssembliesMetadata.cs` is untouched.

## What the test does

`GetAssembliesMetadata_Tests.AssemblyPathIsResolvedAgainstProjectDirectoryNotCurrentDirectory` follows Pattern A (decoy-CWD) from the MT migration skill:

- Two `TransientTestFolder`s from a `TestEnvironment`: a project folder containing `libs\mscorlib.dll` (copied from the framework directory), and an empty decoy folder.
- The process current directory is pointed at the **decoy** via `env.SetCurrentDirectory(...)` (auto-restored on dispose).
- The task gets `TaskEnvironment.CreateWithProjectDirectoryAndEnvironment(projectFolder.Path)` and the relative input `libs\mscorlib.dll`.
- Asserts the metadata is read successfully, and that the output `ItemSpec` is still the original relative user-supplied path `libs\mscorlib.dll` — the explicit compatibility guarantee of the migration (`attributes.AssemblyFullPath = assemblyPath`), not the absolutized form used for I/O.

Because `Directory.SetCurrentDirectory` is process-global, the test class is pinned to a new non-parallel xUnit collection (`GetAssembliesMetadataCollection`, `DisableParallelization = true`). There was no pre-existing non-parallel collection definition in the repo to reuse.

## Mutation verification

Locally reverted the absolutization in `GetAssembliesMetadata.Execute()` (`string absoluteAssemblyPath = assemblyPath;` instead of `TaskEnvironment.GetAbsolutePath(assemblyPath)`), rebuilt, and the new test failed as expected:

```
Shouldly.ShouldAssertException : t.AssembliesMetadata.Length
    should be
1
    but was
0
```

The temporary revert was discarded; with the committed code all 3 `GetAssembliesMetadata` tests pass on net472.

## TFM gating

Kept the existing `#if NETFRAMEWORK` gate. `AssemblyInformation.GetAssemblyMetadata()` — the only way this task reads metadata — is itself compiled under `#if !FEATURE_ASSEMBLYLOADCONTEXT`, so there is no .NET Core code path to test. Un-gating would not compile/run on net10.0. `dotnet test` therefore reports "Zero tests ran" for the net10.0 test host, same as before this change.