### PR TITLE
Fix NullReferenceException reporting file accesses for detoured nodes

### DIFF
--- a/src/Build.UnitTests/BackEnd/Scheduler_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/Scheduler_Tests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading;
 using Microsoft.Build.BackEnd;
 using Microsoft.Build.Evaluation;
 using Microsoft.Build.Execution;
@@ -697,6 +698,103 @@ namespace Microsoft.Build.UnitTests.BackEnd
             // Second response is continuing execution of the parent
             Assert.Equal(ScheduleActionType.ResumeExecution, response[1].Action);
             Assert.Equal(request.ParentGlobalRequestId, response[1].Unblocker.BlockedRequestId);
+        }
+
+        /// <summary>
+        /// A node the scheduler has no executing request for has to be reported as such rather than throwing, since
+        /// the node may still be reporting file accesses for the binaries it needs in order to run.
+        /// </summary>
+        [Fact]
+        public void GetExecutingRequestByNodeReflectsTheNodesCurrentRequest()
+        {
+            // A node the scheduler has never seen has no entry at all, which must not throw.
+            _scheduler.GetExecutingRequestByNode(2).ShouldBeNull();
+
+            CreateConfiguration(1, "foo.proj");
+            BuildRequest request = CreateBuildRequest(1, 1);
+            _scheduler.ReportRequestBlocked(1, new BuildRequestBlocker(request.ParentGlobalRequestId, Array.Empty<string>(), new[] { request })).ToList();
+
+            _scheduler.GetExecutingRequestByNode(1).ShouldBe(request);
+
+            // Completing the request leaves the node's entry in place, so the node must stop reporting it.
+            _scheduler.ReportResult(1, CreateBuildResult(request, "foo", BuildResultUtilities.GetSuccessResult())).ToList();
+
+            _scheduler.GetExecutingRequestByNode(1).ShouldBe(_defaultParentRequest);
+
+            // Completing the last request leaves the node's entry in place with nothing against it. That is the exact
+            // state a file access arriving on another thread has to be able to observe without throwing.
+            _scheduler.ReportResult(1, CreateBuildResult(_defaultParentRequest, "", BuildResultUtilities.GetSuccessResult())).ToList();
+
+            _scheduler.GetExecutingRequestByNode(1).ShouldBeNull();
+        }
+
+        /// <summary>
+        /// File accesses for detoured nodes are reported on the thread draining the sandbox's report pipe, which does
+        /// not hold the BuildManager's lock, so <see cref="Scheduler.GetExecutingRequestByNode"/> has to tolerate the
+        /// node's executing request being cleared underneath it instead of throwing.
+        /// </summary>
+        [Fact]
+        public void GetExecutingRequestByNodeToleratesConcurrentRequestCompletion()
+        {
+            const int Iterations = 2000;
+
+            using CancellationTokenSource readerCancellation = new();
+            Exception readerException = null;
+            bool sawExecutingRequest = false;
+            bool sawIdleNode = false;
+
+            Thread reader = new Thread(() =>
+            {
+                try
+                {
+                    while (!readerCancellation.IsCancellationRequested)
+                    {
+                        if (_scheduler.GetExecutingRequestByNode(1) is null)
+                        {
+                            sawIdleNode = true;
+                        }
+                        else
+                        {
+                            sawExecutingRequest = true;
+                        }
+                    }
+                }
+                catch (Exception e)
+                {
+                    readerException = e;
+                }
+            })
+            {
+                IsBackground = true,
+                Name = nameof(GetExecutingRequestByNodeToleratesConcurrentRequestCompletion),
+            };
+            reader.Start();
+
+            try
+            {
+                for (int i = 0; i < Iterations && readerException is null; i++)
+                {
+                    // Cycle node 1 between executing a request and executing nothing. Completing a request stores a
+                    // null against the node, which is the value the reader must not dereference.
+                    int configId = DefaultConfigId + 1 + i;
+                    CreateConfiguration(configId, $"foo{configId}.proj");
+                    BuildRequest request = CreateBuildRequest(configId, configId);
+
+                    _scheduler.ReportRequestBlocked(1, new BuildRequestBlocker(request.ParentGlobalRequestId, Array.Empty<string>(), new[] { request })).ToList();
+                    _scheduler.ReportResult(1, CreateBuildResult(request, "foo", BuildResultUtilities.GetSuccessResult())).ToList();
+                }
+            }
+            finally
+            {
+                readerCancellation.Cancel();
+                reader.Join();
+            }
+
+            readerException.ShouldBeNull($"Reading the executing request concurrently threw: {readerException}");
+
+            // Guard against the test silently going vacuous if the scheduler stops cycling node 1.
+            sawExecutingRequest.ShouldBeTrue("The reader never observed node 1 executing a request.");
+            sawIdleNode.ShouldBeTrue("The reader never observed node 1 with no executing request.");
         }
 
         /// <summary>

--- a/src/Build/BackEnd/Components/Scheduler/IScheduler.cs
+++ b/src/Build/BackEnd/Components/Scheduler/IScheduler.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Build.BackEnd
         int GetConfigurationIdFromPlan(string configurationPath);
 
         /// <summary>
-        /// Retrieves the request executing on a node.
+        /// Retrieves the request executing on a node, or null if the node is not executing one.
         /// </summary>
         BuildRequest GetExecutingRequestByNode(int nodeId);
 

--- a/src/Build/BackEnd/Components/Scheduler/Scheduler.cs
+++ b/src/Build/BackEnd/Components/Scheduler/Scheduler.cs
@@ -329,17 +329,17 @@ namespace Microsoft.Build.BackEnd
         }
 
         /// <summary>
-        /// Retrieves the request executing on a node.
+        /// Retrieves the request executing on a node, or null if the node is not executing one.
         /// </summary>
+        /// <remarks>
+        /// Unlike the rest of the scheduler, this is reached without holding the BuildManager's lock: file accesses
+        /// for detoured nodes are reported on the thread draining the sandbox's report pipe. The node's executing
+        /// request may therefore be cleared at any point, so look it up once instead of testing and then fetching.
+        /// </remarks>
         public BuildRequest GetExecutingRequestByNode(int nodeId)
         {
-            if (!_schedulingData.IsNodeWorking(nodeId))
-            {
-                return null;
-            }
-
             SchedulableRequest request = _schedulingData.GetExecutingRequestByNode(nodeId);
-            return request.BuildRequest;
+            return request?.BuildRequest;
         }
 
         /// <summary>
@@ -2766,16 +2766,16 @@ namespace Microsoft.Build.BackEnd
 
                         foreach (int nodeId in _availableNodes.Keys)
                         {
+                            SchedulableRequest executingRequest = _schedulingData.GetExecutingRequestByNode(nodeId);
                             file.WriteLine(
                                 "Node {0} {1} ({2} assigned requests, {3} configurations)",
                                 nodeId,
-                                _schedulingData.IsNodeWorking(nodeId)
-                                    ? string.Format(
+                                executingRequest is null
+                                    ? "Idle"
+                                    : string.Format(
                                         CultureInfo.InvariantCulture,
                                         "Active ({0} executing)",
-                                        _schedulingData.GetExecutingRequestByNode(nodeId)
-                                            .BuildRequest.GlobalRequestId)
-                                    : "Idle",
+                                        executingRequest.BuildRequest.GlobalRequestId),
                                 _schedulingData.GetScheduledRequestsCountByNode(nodeId),
                                 _schedulingData.GetConfigurationsCountByNode(nodeId, false, null));
 
@@ -2788,7 +2788,7 @@ namespace Microsoft.Build.BackEnd
                             }
 
                             // If the node is idle, we want to know why.
-                            if (!_schedulingData.IsNodeWorking(nodeId))
+                            if (executingRequest is null)
                             {
                                 file.WriteLine("Top-level requests causing this node to be idle:");
 

--- a/src/Build/BackEnd/Components/Scheduler/SchedulingData.cs
+++ b/src/Build/BackEnd/Components/Scheduler/SchedulingData.cs
@@ -503,13 +503,7 @@ namespace Microsoft.Build.BackEnd
         /// </summary>
         public bool IsNodeWorking(int nodeId)
         {
-            SchedulableRequest request;
-            if (!_executingRequestByNode.TryGetValue(nodeId, out request))
-            {
-                return false;
-            }
-
-            return request != null;
+            return GetExecutingRequestByNode(nodeId) is not null;
         }
 
         /// <summary>

--- a/src/Build/BackEnd/Components/Scheduler/SchedulingData.cs
+++ b/src/Build/BackEnd/Components/Scheduler/SchedulingData.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using Microsoft.Build.Collections;
 
@@ -60,7 +61,12 @@ namespace Microsoft.Build.BackEnd
         /// <summary>
         /// Maps a node id to the currently executing request, if any.
         /// </summary>
-        private readonly Dictionary<int, SchedulableRequest> _executingRequestByNode = new Dictionary<int, SchedulableRequest>(32);
+        /// <remarks>
+        /// This is concurrent because file access reporting reads it from the thread draining a detoured node's
+        /// report pipe, which does not hold the BuildManager's lock. Writes still only ever come from the
+        /// scheduler, hence a concurrency level of 1.
+        /// </remarks>
+        private readonly ConcurrentDictionary<int, SchedulableRequest> _executingRequestByNode = new(concurrencyLevel: 1, capacity: 32);
 
         /// <summary>
         /// Maps a node id to those requests which are ready to execute, if any.
@@ -376,7 +382,7 @@ namespace Microsoft.Build.BackEnd
 
                 case SchedulableRequestState.Executing:
                     Assumed.False(_executingRequests.ContainsKey(request.BuildRequest.GlobalRequestId), $"Request with global id {request.BuildRequest.GlobalRequestId} is already executing!");
-                    Assumed.True(!_executingRequestByNode.ContainsKey(request.AssignedNode) || _executingRequestByNode[request.AssignedNode] == null, $"Node {request.AssignedNode} is currently executing a request.");
+                    Assumed.True(GetExecutingRequestByNode(request.AssignedNode) is null, $"Node {request.AssignedNode} is currently executing a request.");
 
                     _executingRequests[request.BuildRequest.GlobalRequestId] = request;
                     _executingRequestByNode[request.AssignedNode] = request;
@@ -534,11 +540,11 @@ namespace Microsoft.Build.BackEnd
         }
 
         /// <summary>
-        /// Gets the request currently executing on the node.
+        /// Gets the request currently executing on the node, or null if the node is not executing one.
         /// </summary>
         public SchedulableRequest GetExecutingRequestByNode(int nodeId)
         {
-            return _executingRequestByNode[nodeId];
+            return _executingRequestByNode.TryGetValue(nodeId, out SchedulableRequest request) ? request : null;
         }
 
         /// <summary>


### PR DESCRIPTION
`Scheduler.GetExecutingRequestByNode` read the node's executing request twice:

```csharp
if (!_schedulingData.IsNodeWorking(nodeId))
{
    return null;
}

SchedulableRequest request = _schedulingData.GetExecutingRequestByNode(nodeId);
return request.BuildRequest;
```

When a request leaves the `Executing` state the scheduler stores an explicit `null` against its node (`SchedulingData.cs:315`), so those two reads can disagree. Every other caller of the scheduler holds the `BuildManager` lock; `FileAccessManager` does not. With `/reportfileaccesses`, file accesses are reported on the thread draining the sandbox's report pipe, which races the scheduler freely, and the resulting `NullReferenceException` is unhandled on a threadpool thread, so it takes the whole build down. Reported as microsoft/MSBuildCache#160.

The fix looks the request up once and lets it be null. `FileAccessManager.ReportFileAccess` and `ReportProcess` already guard with `if (buildRequest != null)` and drop the access when the node has no executing request, which is the documented expectation there ("If the node isn't executing anything it may be accessing binaries required to run"). So the only behavior change is crash-to-drop, and that drop is the same outcome the race would have produced had it resolved a moment either side. Nothing is dropped that wasn't already. The other two test-then-fetch reads of that map, the `Assumed` in `UpdateFromState` and `DumpSchedulerState`, are folded into single lookups as well, so the map has no read left that can throw.

`_executingRequestByNode` also becomes a `ConcurrentDictionary`. That part is independent of the null: `new Dictionary<>(32)` resizes once a build has more than 32 nodes, and reading a resizing `Dictionary` from another thread gives an `IndexOutOfRangeException` or a corrupt walk rather than a stale value.

On cost, the only operation that gets slower is the write: +15ns on net472 and +12ns on net10.0, with no allocation on either (microbenchmark, 2M ops, median of 11 runs). Writes happen only in `SchedulingData.UpdateFromState`, once entering and once leaving `Executing`, so they are bounded by scheduler state transitions, on the order of tens of thousands for a large build and well under a millisecond in total. `ChangeToState` already spends more than that per transition on its `DateTime.UtcNow` (33ns on net472, 17ns on net10.0). The high-volume operation here is the read, since `GetExecutingRequestByNode` runs once per file access when `/reportfileaccesses` is on, and reads measured unchanged on net472 and about 30% faster on net10.0.

Testing: `GetExecutingRequestByNodeToleratesConcurrentRequestCompletion` is the regression guard. It reproduces the reported `NullReferenceException` at the same frame against unfixed binaries, and asserts that the reader observed both a live request and a cleared node so it cannot go vacuous. `GetExecutingRequestByNodeReflectsTheNodesCurrentRequest` pins the contract but passes at baseline, so it does not catch the bug. Full unit test suite on net472 and net11.0: one test flips fail-to-pass, no regressions.

I could not reproduce the original crash end to end (43 runs of a 2000-project build against unfixed binaries, zero hits), so the link to the field report is the matching stack frame plus the source analysis above rather than a customer repro.

`FileAccessManager` has two more reads of this shape that I left alone: `_tempDirectory` at `FileAccessManager.cs:71` and `_scheduler` at `:164`/`:167`, both nulled by `ShutdownComponent`. Same failure mode, much narrower window. I can fold them in if you'd prefer.
