### PR TITLE
Reject whitespace-only path values

### DIFF
--- a/documentation/wiki/ChangeWaves.md
+++ b/documentation/wiki/ChangeWaves.md
@@ -33,6 +33,7 @@ Change wave checks around features will be removed in the release that accompani
 - [XmlPeek, XmlPoke, and XslTransformation default to prohibiting embedded DTDs](https://github.com/dotnet/msbuild/pull/14285)
 
 ### 18.10
+- [Reject path values that consist only of whitespace when they are resolved through `AbsolutePath`.](https://github.com/dotnet/msbuild/issues/14487)
 - [Resolve relative project paths against the Unix logical current directory from `PWD`, so builds under symlinked directories produce stable project full paths and related output paths.](https://github.com/dotnet/msbuild/pull/13752)
 - [Restore passes ExcludeRestorePackageImports=true as a global property so NuGet's restore no longer triggers a second evaluation of every project.](https://github.com/dotnet/msbuild/issues/14273)
 - [`-getProperty`/`-getItem` (without a target) stop evaluation after the pass that produces the requested data instead of running a full evaluation, avoiding later passes such as target registration.](https://github.com/dotnet/msbuild/pull/14290)

--- a/documentation/wiki/ChangeWaves.md
+++ b/documentation/wiki/ChangeWaves.md
@@ -33,7 +33,7 @@ Change wave checks around features will be removed in the release that accompani
 - [XmlPeek, XmlPoke, and XslTransformation default to prohibiting embedded DTDs](https://github.com/dotnet/msbuild/pull/14285)
 
 ### 18.10
-- [Reject path values that consist only of whitespace when they are resolved through `AbsolutePath`.](https://github.com/dotnet/msbuild/issues/14487)
+- [Reject path values that consist only of whitespace when they are resolved through `AbsolutePath`.](https://github.com/dotnet/msbuild/pull/14623)
 - [Resolve relative project paths against the Unix logical current directory from `PWD`, so builds under symlinked directories produce stable project full paths and related output paths.](https://github.com/dotnet/msbuild/pull/13752)
 - [Restore passes ExcludeRestorePackageImports=true as a global property so NuGet's restore no longer triggers a second evaluation of every project.](https://github.com/dotnet/msbuild/issues/14273)
 - [`-getProperty`/`-getItem` (without a target) stop evaluation after the pass that produces the requested data instead of running a full evaluation, avoiding later passes such as target registration.](https://github.com/dotnet/msbuild/pull/14290)

--- a/src/Build.UnitTests/BackEnd/RegisteredTaskExecution_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/RegisteredTaskExecution_Tests.cs
@@ -5,7 +5,6 @@ using Microsoft.Build.Framework;
 using Microsoft.Build.UnitTests;
 using Microsoft.Build.Utilities;
 using Xunit;
-using Xunit.NetCore.Extensions;
 
 #nullable enable
 
@@ -194,7 +193,6 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
         /// through <see cref="TaskEnvironment.GetAbsolutePath(string)"/> inside a task.
         /// </summary>
         [Fact]
-        [UseInvariantCulture]
         public void WhitespaceOnlyProjectPropertyPassedToGetAbsolutePathReportsActionableException()
         {
             using TestEnvironment env = TestEnvironment.Create(_output);
@@ -218,10 +216,8 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
             ObjectModelHelpers.BuildProjectExpectFailure(project, logger);
 
             logger.AssertLogContains("Received path length: 3");
-            logger.AssertLogContains("MSB4018");
-            logger.AssertLogContains(typeof(WhitespaceOnlyPathException).FullName);
-            logger.AssertLogContains("The path consists only of whitespace.");
-            logger.AssertLogContains("Specify a path that contains at least one non-whitespace character.");
+            BuildErrorEventArgs error = Assert.Single(logger.Errors);
+            Assert.Equal("MSB4018", error.Code);
         }
     }
 

--- a/src/Build.UnitTests/BackEnd/RegisteredTaskExecution_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/RegisteredTaskExecution_Tests.cs
@@ -5,6 +5,7 @@ using Microsoft.Build.Framework;
 using Microsoft.Build.UnitTests;
 using Microsoft.Build.Utilities;
 using Xunit;
+using Xunit.NetCore.Extensions;
 
 #nullable enable
 
@@ -187,6 +188,41 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
 
             logger.AssertLogContains("RegisteredEnvOnlyCtorTestTask ctor env was null: False");
         }
+
+        /// <summary>
+        /// Verifies the user-visible exception when a whitespace-only project property is consumed as a path
+        /// through <see cref="TaskEnvironment.GetAbsolutePath(string)"/> inside a task.
+        /// </summary>
+        [Fact]
+        [UseInvariantCulture]
+        public void WhitespaceOnlyProjectPropertyPassedToGetAbsolutePathReportsActionableException()
+        {
+            using TestEnvironment env = TestEnvironment.Create(_output);
+            env.SetEnvironmentVariable("MSBUILDDISABLEFEATURESFROMVERSION", null);
+            ChangeWaves.ResetStateForTests();
+            Task.RegisterTask<RegisteredWhitespacePathTestTask>();
+
+            string project = """
+                <Project DefaultTargets="Build">
+                  <PropertyGroup>
+                    <!-- Escaping preserves three spaces until task parameter binding unescapes the value. -->
+                    <WhitespacePath>%20%20%20</WhitespacePath>
+                  </PropertyGroup>
+                  <Target Name="Build">
+                    <RegisteredWhitespacePathTestTask Path="$(WhitespacePath)" />
+                  </Target>
+                </Project>
+                """;
+
+            MockLogger logger = new(_output) { AllowTaskCrashes = true };
+            ObjectModelHelpers.BuildProjectExpectFailure(project, logger);
+
+            logger.AssertLogContains("Received path length: 3");
+            logger.AssertLogContains("MSB4018");
+            logger.AssertLogContains(typeof(WhitespaceOnlyPathException).FullName);
+            logger.AssertLogContains("The path consists only of whitespace.");
+            logger.AssertLogContains("Specify a path that contains at least one non-whitespace character.");
+        }
     }
 
     /// <summary>
@@ -273,6 +309,24 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
         public override bool Execute()
         {
             Log.LogMessage(MessageImportance.High, "RegisteredEnvOnlyCtorTestTask ctor env was null: " + _ctorEnvironmentWasNull);
+            return true;
+        }
+    }
+
+    /// <summary>
+    /// A task that consumes a string as a path during execution, exposing the exception produced by
+    /// <see cref="TaskEnvironment.GetAbsolutePath(string)"/> for a whitespace-only project value.
+    /// </summary>
+    public sealed class RegisteredWhitespacePathTestTask : Task, IMultiThreadableTask
+    {
+        public string Path { get; set; } = null!;
+
+        public TaskEnvironment TaskEnvironment { get; set; } = null!;
+
+        public override bool Execute()
+        {
+            Log.LogMessage(MessageImportance.High, $"Received path length: {Path.Length}");
+            TaskEnvironment.GetAbsolutePath(Path);
             return true;
         }
     }

--- a/src/Build.UnitTests/BackEnd/TaskExecutionHost_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/TaskExecutionHost_Tests.cs
@@ -511,6 +511,21 @@ namespace Microsoft.Build.UnitTests.BackEnd
             ValidateTaskParameterNotSet("AbsolutePathParam", "@(NonExistentItem)");
         }
 
+        [Fact]
+        public void TestSetAbsolutePathParamWhitespaceOnlyReportsActionableError()
+        {
+            var parameters = GetStandardParametersDictionary(true);
+            parameters["AbsolutePathParam"] = ("   ", ElementLocation.Create("foo.proj"));
+
+            InvalidProjectFileException exception = Should.Throw<InvalidProjectFileException>(() => _host.SetTaskParameters(parameters));
+
+            exception.ErrorCode.ShouldBe("MSB4030");
+            exception.Message.ShouldContain("AbsolutePathParam");
+            exception.Message.ShouldContain(typeof(AbsolutePath).FullName);
+            exception.Message.ShouldContain("TaskBuilderTestTask");
+            exception.Message.ShouldContain("non-whitespace character");
+        }
+
         #endregion
 
         #region AbsolutePath Array Params
@@ -561,6 +576,21 @@ namespace Microsoft.Build.UnitTests.BackEnd
         public void TestSetAbsolutePathArrayParamEmptyItem()
         {
             ValidateTaskParameterNotSet("AbsolutePathArrayParam", "@(NonExistentItem)");
+        }
+
+        [Fact]
+        public void TestSetAbsolutePathArrayParamWhitespaceOnlyReportsActionableError()
+        {
+            var parameters = GetStandardParametersDictionary(true);
+            parameters["AbsolutePathArrayParam"] = ("%20%20%20", ElementLocation.Create("foo.proj"));
+
+            InvalidProjectFileException exception = Should.Throw<InvalidProjectFileException>(() => _host.SetTaskParameters(parameters));
+
+            exception.ErrorCode.ShouldBe("MSB4030");
+            exception.Message.ShouldContain("AbsolutePathArrayParam");
+            exception.Message.ShouldContain(typeof(AbsolutePath[]).FullName);
+            exception.Message.ShouldContain("TaskBuilderTestTask");
+            exception.Message.ShouldContain("non-whitespace character");
         }
 
         #endregion
@@ -631,6 +661,20 @@ namespace Microsoft.Build.UnitTests.BackEnd
         public void TestSetTaskItemIntParamEmptyItem()
         {
             ValidateTaskParameterNotSet("TaskItemIntParam", "@(NonExistentItem)");
+        }
+
+        [Fact]
+        public void TestSetTaskItemFileInfoParamWhitespaceOnlyReportsActionableError()
+        {
+            var parameters = GetStandardParametersDictionary(true);
+            parameters["TaskItemFileInfoParam"] = ("%20%20%20", ElementLocation.Create("foo.proj"));
+
+            InvalidProjectFileException exception = Should.Throw<InvalidProjectFileException>(() => _host.SetTaskParameters(parameters));
+
+            exception.ErrorCode.ShouldBe("MSB4030");
+            exception.Message.ShouldContain("TaskItemFileInfoParam");
+            exception.Message.ShouldContain("TaskBuilderTestTask");
+            exception.Message.ShouldContain("non-whitespace character");
         }
 
         #endregion

--- a/src/Build.UnitTests/BackEnd/TaskExecutionHost_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/TaskExecutionHost_Tests.cs
@@ -520,10 +520,6 @@ namespace Microsoft.Build.UnitTests.BackEnd
             InvalidProjectFileException exception = Should.Throw<InvalidProjectFileException>(() => _host.SetTaskParameters(parameters));
 
             exception.ErrorCode.ShouldBe("MSB4286");
-            exception.Message.ShouldContain("AbsolutePathParam");
-            exception.Message.ShouldContain(typeof(AbsolutePath).FullName);
-            exception.Message.ShouldContain("TaskBuilderTestTask");
-            exception.Message.ShouldContain("non-whitespace character");
         }
 
         #endregion
@@ -587,10 +583,6 @@ namespace Microsoft.Build.UnitTests.BackEnd
             InvalidProjectFileException exception = Should.Throw<InvalidProjectFileException>(() => _host.SetTaskParameters(parameters));
 
             exception.ErrorCode.ShouldBe("MSB4286");
-            exception.Message.ShouldContain("AbsolutePathArrayParam");
-            exception.Message.ShouldContain(typeof(AbsolutePath[]).FullName);
-            exception.Message.ShouldContain("TaskBuilderTestTask");
-            exception.Message.ShouldContain("non-whitespace character");
         }
 
         #endregion
@@ -672,9 +664,6 @@ namespace Microsoft.Build.UnitTests.BackEnd
             InvalidProjectFileException exception = Should.Throw<InvalidProjectFileException>(() => _host.SetTaskParameters(parameters));
 
             exception.ErrorCode.ShouldBe("MSB4286");
-            exception.Message.ShouldContain("TaskItemFileInfoParam");
-            exception.Message.ShouldContain("TaskBuilderTestTask");
-            exception.Message.ShouldContain("non-whitespace character");
         }
 
         #endregion

--- a/src/Build.UnitTests/BackEnd/TaskExecutionHost_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/TaskExecutionHost_Tests.cs
@@ -519,7 +519,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
 
             InvalidProjectFileException exception = Should.Throw<InvalidProjectFileException>(() => _host.SetTaskParameters(parameters));
 
-            exception.ErrorCode.ShouldBe("MSB4030");
+            exception.ErrorCode.ShouldBe("MSB4286");
             exception.Message.ShouldContain("AbsolutePathParam");
             exception.Message.ShouldContain(typeof(AbsolutePath).FullName);
             exception.Message.ShouldContain("TaskBuilderTestTask");
@@ -586,7 +586,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
 
             InvalidProjectFileException exception = Should.Throw<InvalidProjectFileException>(() => _host.SetTaskParameters(parameters));
 
-            exception.ErrorCode.ShouldBe("MSB4030");
+            exception.ErrorCode.ShouldBe("MSB4286");
             exception.Message.ShouldContain("AbsolutePathArrayParam");
             exception.Message.ShouldContain(typeof(AbsolutePath[]).FullName);
             exception.Message.ShouldContain("TaskBuilderTestTask");
@@ -671,7 +671,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
 
             InvalidProjectFileException exception = Should.Throw<InvalidProjectFileException>(() => _host.SetTaskParameters(parameters));
 
-            exception.ErrorCode.ShouldBe("MSB4030");
+            exception.ErrorCode.ShouldBe("MSB4286");
             exception.Message.ShouldContain("TaskItemFileInfoParam");
             exception.Message.ShouldContain("TaskBuilderTestTask");
             exception.Message.ShouldContain("non-whitespace character");

--- a/src/Build/BackEnd/TaskExecutionHost/TaskExecutionHost.cs
+++ b/src/Build/BackEnd/TaskExecutionHost/TaskExecutionHost.cs
@@ -1091,14 +1091,12 @@ namespace Microsoft.Build.BackEnd
             }
             catch (WhitespaceOnlyPathException)
             {
-                ProjectErrorUtilities.ThrowInvalidProject(
+                throw ProjectErrorUtilities.CreateInvalidProjectException(
                     parameterLocation,
                     "InvalidTaskPathParameterValueError",
                     parameter.Name,
                     parameterType.FullName,
                     _taskName);
-
-                throw;
             }
             catch (Exception ex)
             {
@@ -1628,14 +1626,12 @@ namespace Microsoft.Build.BackEnd
             }
             catch (WhitespaceOnlyPathException)
             {
-                ProjectErrorUtilities.ThrowInvalidProject(
+                throw ProjectErrorUtilities.CreateInvalidProjectException(
                     parameterLocation,
                     "InvalidTaskPathParameterValueError",
                     parameter.Name,
                     parameterType.FullName,
                     _taskName);
-
-                throw;
             }
             catch (Exception ex)
             {

--- a/src/Build/BackEnd/TaskExecutionHost/TaskExecutionHost.cs
+++ b/src/Build/BackEnd/TaskExecutionHost/TaskExecutionHost.cs
@@ -1001,14 +1001,6 @@ namespace Microsoft.Build.BackEnd
             return ValueTypeParser.Parse(value, targetType);
         }
 
-        private static bool IsPathParameterType(Type parameterType)
-        {
-            Type valueType = parameterType.IsArray ? parameterType.GetElementType() : parameterType;
-            return TaskItemTypeDetector.IsSupportedPathType(valueType)
-                || (TaskParameterTypeVerifier.TryGetSupportedTaskItemValueType(valueType, out Type taskItemValueType)
-                    && TaskItemTypeDetector.IsSupportedPathType(taskItemValueType));
-        }
-
         /// <summary>
         /// Called on the local side.
         /// </summary>
@@ -1097,6 +1089,17 @@ namespace Microsoft.Build.BackEnd
                     return InternalSetTaskParameter(parameter, finalTaskInputs);
                 }
             }
+            catch (WhitespaceOnlyPathException)
+            {
+                ProjectErrorUtilities.ThrowInvalidProject(
+                    parameterLocation,
+                    "InvalidTaskPathParameterValueError",
+                    parameter.Name,
+                    parameterType.FullName,
+                    _taskName);
+
+                throw;
+            }
             catch (Exception ex)
             {
                 if (ex is InvalidCastException || // invalid type
@@ -1104,18 +1107,6 @@ namespace Microsoft.Build.BackEnd
                     ex is FormatException || // bad string representation of a type
                     ex is OverflowException) // overflow when converting string representation of a numerical type
                 {
-                    if (ex is ArgumentException
-                        && IsPathParameterType(parameterType)
-                        && string.IsNullOrWhiteSpace(currentItem.ItemSpec))
-                    {
-                        ProjectErrorUtilities.ThrowInvalidProject(
-                            parameterLocation,
-                            "InvalidTaskPathParameterValueError",
-                            parameter.Name,
-                            parameterType.FullName,
-                            _taskName);
-                    }
-
                     ProjectErrorUtilities.ThrowInvalidProject(
                         parameterLocation,
                         "InvalidTaskParameterValueError",
@@ -1635,6 +1626,17 @@ namespace Microsoft.Build.BackEnd
                     }
                 }
             }
+            catch (WhitespaceOnlyPathException)
+            {
+                ProjectErrorUtilities.ThrowInvalidProject(
+                    parameterLocation,
+                    "InvalidTaskPathParameterValueError",
+                    parameter.Name,
+                    parameterType.FullName,
+                    _taskName);
+
+                throw;
+            }
             catch (Exception ex)
             {
                 if (ex is InvalidCastException || // invalid type
@@ -1643,18 +1645,6 @@ namespace Microsoft.Build.BackEnd
                     ex is OverflowException) // overflow when converting string representation of a numerical type
                 {
                     string expandedParameterValue = _batchBucket.Expander.ExpandIntoStringAndUnescape(parameterValue, ExpanderOptions.ExpandAll, parameterLocation);
-                    if (ex is ArgumentException
-                        && IsPathParameterType(parameterType)
-                        && string.IsNullOrWhiteSpace(expandedParameterValue))
-                    {
-                        ProjectErrorUtilities.ThrowInvalidProject(
-                            parameterLocation,
-                            "InvalidTaskPathParameterValueError",
-                            parameter.Name,
-                            parameterType.FullName,
-                            _taskName);
-                    }
-
                     ProjectErrorUtilities.ThrowInvalidProject(
                         parameterLocation,
                         "InvalidTaskParameterValueError",

--- a/src/Build/BackEnd/TaskExecutionHost/TaskExecutionHost.cs
+++ b/src/Build/BackEnd/TaskExecutionHost/TaskExecutionHost.cs
@@ -923,8 +923,15 @@ namespace Microsoft.Build.BackEnd
         /// Wraps the given <paramref name="item"/> into a <c>TaskItem&lt;T&gt;</c> where T is
         /// <paramref name="genericArgument"/>, using a cached compiled constructor delegate.
         /// </summary>
-        private static ITaskItem CreateTaskItemOfT(Type genericArgument, ITaskItem item)
+        private ITaskItem CreateTaskItemOfT(Type genericArgument, ITaskItem item)
         {
+            if (TaskItemTypeDetector.IsSupportedPathType(genericArgument))
+            {
+                // Validate the original identity before TaskItem<T> reads FullPath metadata, which can
+                // resolve a whitespace-only identity to the project directory and hide the invalid input.
+                TaskEnvironment.GetAbsolutePath(item.ItemSpec);
+            }
+
             Func<ITaskItem, ITaskItem> factory = s_taskItemOfTFactories.GetOrAdd(genericArgument, static t =>
             {
 #if NET
@@ -992,6 +999,14 @@ namespace Microsoft.Build.BackEnd
             }
 
             return ValueTypeParser.Parse(value, targetType);
+        }
+
+        private static bool IsPathParameterType(Type parameterType)
+        {
+            Type valueType = parameterType.IsArray ? parameterType.GetElementType() : parameterType;
+            return TaskItemTypeDetector.IsSupportedPathType(valueType)
+                || (TaskParameterTypeVerifier.TryGetSupportedTaskItemValueType(valueType, out Type taskItemValueType)
+                    && TaskItemTypeDetector.IsSupportedPathType(taskItemValueType));
         }
 
         /// <summary>
@@ -1089,6 +1104,18 @@ namespace Microsoft.Build.BackEnd
                     ex is FormatException || // bad string representation of a type
                     ex is OverflowException) // overflow when converting string representation of a numerical type
                 {
+                    if (ex is ArgumentException
+                        && IsPathParameterType(parameterType)
+                        && string.IsNullOrWhiteSpace(currentItem.ItemSpec))
+                    {
+                        ProjectErrorUtilities.ThrowInvalidProject(
+                            parameterLocation,
+                            "InvalidTaskPathParameterValueError",
+                            parameter.Name,
+                            parameterType.FullName,
+                            _taskName);
+                    }
+
                     ProjectErrorUtilities.ThrowInvalidProject(
                         parameterLocation,
                         "InvalidTaskParameterValueError",
@@ -1615,10 +1642,23 @@ namespace Microsoft.Build.BackEnd
                     ex is FormatException || // bad string representation of a type
                     ex is OverflowException) // overflow when converting string representation of a numerical type
                 {
+                    string expandedParameterValue = _batchBucket.Expander.ExpandIntoStringAndUnescape(parameterValue, ExpanderOptions.ExpandAll, parameterLocation);
+                    if (ex is ArgumentException
+                        && IsPathParameterType(parameterType)
+                        && string.IsNullOrWhiteSpace(expandedParameterValue))
+                    {
+                        ProjectErrorUtilities.ThrowInvalidProject(
+                            parameterLocation,
+                            "InvalidTaskPathParameterValueError",
+                            parameter.Name,
+                            parameterType.FullName,
+                            _taskName);
+                    }
+
                     ProjectErrorUtilities.ThrowInvalidProject(
                         parameterLocation,
                         "InvalidTaskParameterValueError",
-                        _batchBucket.Expander.ExpandIntoStringAndUnescape(parameterValue, ExpanderOptions.ExpandAll, parameterLocation),
+                        expandedParameterValue,
                         parameter.Name,
                         parameterType.FullName,
                         _taskName);

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -697,6 +697,10 @@
     and the type of the .NET property that corresponds to the task parameter. For example, if an int task parameter called "Count"
     is assigned the value "x", this error would be displayed: &lt;MyTask Count="x" /&gt;</comment>
   </data>
+  <data name="InvalidTaskPathParameterValueError" xml:space="preserve">
+    <value>MSB4030: The "{0}" parameter of the "{2}" task is a path of type "{1}", but its value consists only of whitespace. Specify a path containing at least one non-whitespace character, or remove the parameter if it is optional.</value>
+    <comment>{StrBegin="MSB4030: "}{0} is the task parameter name, {1} is the parameter's .NET type, and {2} is the task name. Do not localize type names or task parameter names.</comment>
+  </data>
   <data name="InvalidToolsetValueInConfigFileValue" xml:space="preserve">
     <value>MSB4137: Invalid value specified in the configuration file at "{0}". Property name or tools version name is an empty string.</value>
     <comment>{StrBegin="MSB4137: "}</comment>

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -698,8 +698,8 @@
     is assigned the value "x", this error would be displayed: &lt;MyTask Count="x" /&gt;</comment>
   </data>
   <data name="InvalidTaskPathParameterValueError" xml:space="preserve">
-    <value>MSB4030: The "{0}" parameter of the "{2}" task is a path of type "{1}", but its value consists only of whitespace. Specify a path containing at least one non-whitespace character, or remove the parameter if it is optional.</value>
-    <comment>{StrBegin="MSB4030: "}{0} is the task parameter name, {1} is the parameter's .NET type, and {2} is the task name. Do not localize type names or task parameter names.</comment>
+    <value>MSB4286: The "{0}" parameter of the "{2}" task is a path of type "{1}", but its value consists only of whitespace. Specify a path containing at least one non-whitespace character.</value>
+    <comment>{StrBegin="MSB4286: "}{0} is the task parameter name, {1} is the parameter's .NET type, and {2} is the task name. Do not localize type names or task parameter names.</comment>
   </data>
   <data name="InvalidToolsetValueInConfigFileValue" xml:space="preserve">
     <value>MSB4137: Invalid value specified in the configuration file at "{0}". Property name or tools version name is an empty string.</value>

--- a/src/Build/Resources/xlf/Strings.cs.xlf
+++ b/src/Build/Resources/xlf/Strings.cs.xlf
@@ -603,9 +603,9 @@
         <note />
       </trans-unit>
       <trans-unit id="InvalidTaskPathParameterValueError">
-        <source>MSB4030: The "{0}" parameter of the "{2}" task is a path of type "{1}", but its value consists only of whitespace. Specify a path containing at least one non-whitespace character, or remove the parameter if it is optional.</source>
-        <target state="new">MSB4030: The "{0}" parameter of the "{2}" task is a path of type "{1}", but its value consists only of whitespace. Specify a path containing at least one non-whitespace character, or remove the parameter if it is optional.</target>
-        <note>{StrBegin="MSB4030: "}{0} is the task parameter name, {1} is the parameter's .NET type, and {2} is the task name. Do not localize type names or task parameter names.</note>
+        <source>MSB4286: The "{0}" parameter of the "{2}" task is a path of type "{1}", but its value consists only of whitespace. Specify a path containing at least one non-whitespace character.</source>
+        <target state="new">MSB4286: The "{0}" parameter of the "{2}" task is a path of type "{1}", but its value consists only of whitespace. Specify a path containing at least one non-whitespace character.</target>
+        <note>{StrBegin="MSB4286: "}{0} is the task parameter name, {1} is the parameter's .NET type, and {2} is the task name. Do not localize type names or task parameter names.</note>
       </trans-unit>
       <trans-unit id="InvalidVersionFormat">
         <source>Version string was not in a correct format.</source>

--- a/src/Build/Resources/xlf/Strings.cs.xlf
+++ b/src/Build/Resources/xlf/Strings.cs.xlf
@@ -602,6 +602,11 @@
         <target state="translated">MSB4255: Následující vstupní soubory mezipaměti pro výsledky neexistují: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidTaskPathParameterValueError">
+        <source>MSB4030: The "{0}" parameter of the "{2}" task is a path of type "{1}", but its value consists only of whitespace. Specify a path containing at least one non-whitespace character, or remove the parameter if it is optional.</source>
+        <target state="new">MSB4030: The "{0}" parameter of the "{2}" task is a path of type "{1}", but its value consists only of whitespace. Specify a path containing at least one non-whitespace character, or remove the parameter if it is optional.</target>
+        <note>{StrBegin="MSB4030: "}{0} is the task parameter name, {1} is the parameter's .NET type, and {2} is the task name. Do not localize type names or task parameter names.</note>
+      </trans-unit>
       <trans-unit id="InvalidVersionFormat">
         <source>Version string was not in a correct format.</source>
         <target state="translated">Řetězec verze nemá správný formát.</target>

--- a/src/Build/Resources/xlf/Strings.de.xlf
+++ b/src/Build/Resources/xlf/Strings.de.xlf
@@ -603,9 +603,9 @@
         <note />
       </trans-unit>
       <trans-unit id="InvalidTaskPathParameterValueError">
-        <source>MSB4030: The "{0}" parameter of the "{2}" task is a path of type "{1}", but its value consists only of whitespace. Specify a path containing at least one non-whitespace character, or remove the parameter if it is optional.</source>
-        <target state="new">MSB4030: The "{0}" parameter of the "{2}" task is a path of type "{1}", but its value consists only of whitespace. Specify a path containing at least one non-whitespace character, or remove the parameter if it is optional.</target>
-        <note>{StrBegin="MSB4030: "}{0} is the task parameter name, {1} is the parameter's .NET type, and {2} is the task name. Do not localize type names or task parameter names.</note>
+        <source>MSB4286: The "{0}" parameter of the "{2}" task is a path of type "{1}", but its value consists only of whitespace. Specify a path containing at least one non-whitespace character.</source>
+        <target state="new">MSB4286: The "{0}" parameter of the "{2}" task is a path of type "{1}", but its value consists only of whitespace. Specify a path containing at least one non-whitespace character.</target>
+        <note>{StrBegin="MSB4286: "}{0} is the task parameter name, {1} is the parameter's .NET type, and {2} is the task name. Do not localize type names or task parameter names.</note>
       </trans-unit>
       <trans-unit id="InvalidVersionFormat">
         <source>Version string was not in a correct format.</source>

--- a/src/Build/Resources/xlf/Strings.de.xlf
+++ b/src/Build/Resources/xlf/Strings.de.xlf
@@ -602,6 +602,11 @@
         <target state="translated">MSB4255: Die folgenden Cachedateien für Eingabeergebnisse sind nicht vorhanden: "{0}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidTaskPathParameterValueError">
+        <source>MSB4030: The "{0}" parameter of the "{2}" task is a path of type "{1}", but its value consists only of whitespace. Specify a path containing at least one non-whitespace character, or remove the parameter if it is optional.</source>
+        <target state="new">MSB4030: The "{0}" parameter of the "{2}" task is a path of type "{1}", but its value consists only of whitespace. Specify a path containing at least one non-whitespace character, or remove the parameter if it is optional.</target>
+        <note>{StrBegin="MSB4030: "}{0} is the task parameter name, {1} is the parameter's .NET type, and {2} is the task name. Do not localize type names or task parameter names.</note>
+      </trans-unit>
       <trans-unit id="InvalidVersionFormat">
         <source>Version string was not in a correct format.</source>
         <target state="translated">Die Versionszeichenfolge liegt nicht im richtigen Format vor.</target>

--- a/src/Build/Resources/xlf/Strings.es.xlf
+++ b/src/Build/Resources/xlf/Strings.es.xlf
@@ -602,6 +602,11 @@
         <target state="translated">MSB4255: Los siguientes archivos de caché de resultados de entrada no existen: "{0}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidTaskPathParameterValueError">
+        <source>MSB4030: The "{0}" parameter of the "{2}" task is a path of type "{1}", but its value consists only of whitespace. Specify a path containing at least one non-whitespace character, or remove the parameter if it is optional.</source>
+        <target state="new">MSB4030: The "{0}" parameter of the "{2}" task is a path of type "{1}", but its value consists only of whitespace. Specify a path containing at least one non-whitespace character, or remove the parameter if it is optional.</target>
+        <note>{StrBegin="MSB4030: "}{0} is the task parameter name, {1} is the parameter's .NET type, and {2} is the task name. Do not localize type names or task parameter names.</note>
+      </trans-unit>
       <trans-unit id="InvalidVersionFormat">
         <source>Version string was not in a correct format.</source>
         <target state="translated">La cadena de versión no tenía el formato correcto.</target>

--- a/src/Build/Resources/xlf/Strings.es.xlf
+++ b/src/Build/Resources/xlf/Strings.es.xlf
@@ -603,9 +603,9 @@
         <note />
       </trans-unit>
       <trans-unit id="InvalidTaskPathParameterValueError">
-        <source>MSB4030: The "{0}" parameter of the "{2}" task is a path of type "{1}", but its value consists only of whitespace. Specify a path containing at least one non-whitespace character, or remove the parameter if it is optional.</source>
-        <target state="new">MSB4030: The "{0}" parameter of the "{2}" task is a path of type "{1}", but its value consists only of whitespace. Specify a path containing at least one non-whitespace character, or remove the parameter if it is optional.</target>
-        <note>{StrBegin="MSB4030: "}{0} is the task parameter name, {1} is the parameter's .NET type, and {2} is the task name. Do not localize type names or task parameter names.</note>
+        <source>MSB4286: The "{0}" parameter of the "{2}" task is a path of type "{1}", but its value consists only of whitespace. Specify a path containing at least one non-whitespace character.</source>
+        <target state="new">MSB4286: The "{0}" parameter of the "{2}" task is a path of type "{1}", but its value consists only of whitespace. Specify a path containing at least one non-whitespace character.</target>
+        <note>{StrBegin="MSB4286: "}{0} is the task parameter name, {1} is the parameter's .NET type, and {2} is the task name. Do not localize type names or task parameter names.</note>
       </trans-unit>
       <trans-unit id="InvalidVersionFormat">
         <source>Version string was not in a correct format.</source>

--- a/src/Build/Resources/xlf/Strings.fr.xlf
+++ b/src/Build/Resources/xlf/Strings.fr.xlf
@@ -602,6 +602,11 @@
         <target state="translated">MSB4255: Les fichiers cache des résultats d'entrée suivants n'existent pas : "{0}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidTaskPathParameterValueError">
+        <source>MSB4030: The "{0}" parameter of the "{2}" task is a path of type "{1}", but its value consists only of whitespace. Specify a path containing at least one non-whitespace character, or remove the parameter if it is optional.</source>
+        <target state="new">MSB4030: The "{0}" parameter of the "{2}" task is a path of type "{1}", but its value consists only of whitespace. Specify a path containing at least one non-whitespace character, or remove the parameter if it is optional.</target>
+        <note>{StrBegin="MSB4030: "}{0} is the task parameter name, {1} is the parameter's .NET type, and {2} is the task name. Do not localize type names or task parameter names.</note>
+      </trans-unit>
       <trans-unit id="InvalidVersionFormat">
         <source>Version string was not in a correct format.</source>
         <target state="translated">La chaîne de version n'était pas au format approprié.</target>

--- a/src/Build/Resources/xlf/Strings.fr.xlf
+++ b/src/Build/Resources/xlf/Strings.fr.xlf
@@ -603,9 +603,9 @@
         <note />
       </trans-unit>
       <trans-unit id="InvalidTaskPathParameterValueError">
-        <source>MSB4030: The "{0}" parameter of the "{2}" task is a path of type "{1}", but its value consists only of whitespace. Specify a path containing at least one non-whitespace character, or remove the parameter if it is optional.</source>
-        <target state="new">MSB4030: The "{0}" parameter of the "{2}" task is a path of type "{1}", but its value consists only of whitespace. Specify a path containing at least one non-whitespace character, or remove the parameter if it is optional.</target>
-        <note>{StrBegin="MSB4030: "}{0} is the task parameter name, {1} is the parameter's .NET type, and {2} is the task name. Do not localize type names or task parameter names.</note>
+        <source>MSB4286: The "{0}" parameter of the "{2}" task is a path of type "{1}", but its value consists only of whitespace. Specify a path containing at least one non-whitespace character.</source>
+        <target state="new">MSB4286: The "{0}" parameter of the "{2}" task is a path of type "{1}", but its value consists only of whitespace. Specify a path containing at least one non-whitespace character.</target>
+        <note>{StrBegin="MSB4286: "}{0} is the task parameter name, {1} is the parameter's .NET type, and {2} is the task name. Do not localize type names or task parameter names.</note>
       </trans-unit>
       <trans-unit id="InvalidVersionFormat">
         <source>Version string was not in a correct format.</source>

--- a/src/Build/Resources/xlf/Strings.it.xlf
+++ b/src/Build/Resources/xlf/Strings.it.xlf
@@ -603,9 +603,9 @@
         <note />
       </trans-unit>
       <trans-unit id="InvalidTaskPathParameterValueError">
-        <source>MSB4030: The "{0}" parameter of the "{2}" task is a path of type "{1}", but its value consists only of whitespace. Specify a path containing at least one non-whitespace character, or remove the parameter if it is optional.</source>
-        <target state="new">MSB4030: The "{0}" parameter of the "{2}" task is a path of type "{1}", but its value consists only of whitespace. Specify a path containing at least one non-whitespace character, or remove the parameter if it is optional.</target>
-        <note>{StrBegin="MSB4030: "}{0} is the task parameter name, {1} is the parameter's .NET type, and {2} is the task name. Do not localize type names or task parameter names.</note>
+        <source>MSB4286: The "{0}" parameter of the "{2}" task is a path of type "{1}", but its value consists only of whitespace. Specify a path containing at least one non-whitespace character.</source>
+        <target state="new">MSB4286: The "{0}" parameter of the "{2}" task is a path of type "{1}", but its value consists only of whitespace. Specify a path containing at least one non-whitespace character.</target>
+        <note>{StrBegin="MSB4286: "}{0} is the task parameter name, {1} is the parameter's .NET type, and {2} is the task name. Do not localize type names or task parameter names.</note>
       </trans-unit>
       <trans-unit id="InvalidVersionFormat">
         <source>Version string was not in a correct format.</source>

--- a/src/Build/Resources/xlf/Strings.it.xlf
+++ b/src/Build/Resources/xlf/Strings.it.xlf
@@ -602,6 +602,11 @@
         <target state="translated">MSB4255: i file della cache dei risultati di input seguenti non esistono: "{0}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidTaskPathParameterValueError">
+        <source>MSB4030: The "{0}" parameter of the "{2}" task is a path of type "{1}", but its value consists only of whitespace. Specify a path containing at least one non-whitespace character, or remove the parameter if it is optional.</source>
+        <target state="new">MSB4030: The "{0}" parameter of the "{2}" task is a path of type "{1}", but its value consists only of whitespace. Specify a path containing at least one non-whitespace character, or remove the parameter if it is optional.</target>
+        <note>{StrBegin="MSB4030: "}{0} is the task parameter name, {1} is the parameter's .NET type, and {2} is the task name. Do not localize type names or task parameter names.</note>
+      </trans-unit>
       <trans-unit id="InvalidVersionFormat">
         <source>Version string was not in a correct format.</source>
         <target state="translated">Il formato della stringa di versione non è corretto.</target>

--- a/src/Build/Resources/xlf/Strings.ja.xlf
+++ b/src/Build/Resources/xlf/Strings.ja.xlf
@@ -603,9 +603,9 @@
         <note />
       </trans-unit>
       <trans-unit id="InvalidTaskPathParameterValueError">
-        <source>MSB4030: The "{0}" parameter of the "{2}" task is a path of type "{1}", but its value consists only of whitespace. Specify a path containing at least one non-whitespace character, or remove the parameter if it is optional.</source>
-        <target state="new">MSB4030: The "{0}" parameter of the "{2}" task is a path of type "{1}", but its value consists only of whitespace. Specify a path containing at least one non-whitespace character, or remove the parameter if it is optional.</target>
-        <note>{StrBegin="MSB4030: "}{0} is the task parameter name, {1} is the parameter's .NET type, and {2} is the task name. Do not localize type names or task parameter names.</note>
+        <source>MSB4286: The "{0}" parameter of the "{2}" task is a path of type "{1}", but its value consists only of whitespace. Specify a path containing at least one non-whitespace character.</source>
+        <target state="new">MSB4286: The "{0}" parameter of the "{2}" task is a path of type "{1}", but its value consists only of whitespace. Specify a path containing at least one non-whitespace character.</target>
+        <note>{StrBegin="MSB4286: "}{0} is the task parameter name, {1} is the parameter's .NET type, and {2} is the task name. Do not localize type names or task parameter names.</note>
       </trans-unit>
       <trans-unit id="InvalidVersionFormat">
         <source>Version string was not in a correct format.</source>

--- a/src/Build/Resources/xlf/Strings.ja.xlf
+++ b/src/Build/Resources/xlf/Strings.ja.xlf
@@ -602,6 +602,11 @@
         <target state="translated">MSB4255: 以下の入力結果キャッシュ ファイルが存在しません: "{0}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidTaskPathParameterValueError">
+        <source>MSB4030: The "{0}" parameter of the "{2}" task is a path of type "{1}", but its value consists only of whitespace. Specify a path containing at least one non-whitespace character, or remove the parameter if it is optional.</source>
+        <target state="new">MSB4030: The "{0}" parameter of the "{2}" task is a path of type "{1}", but its value consists only of whitespace. Specify a path containing at least one non-whitespace character, or remove the parameter if it is optional.</target>
+        <note>{StrBegin="MSB4030: "}{0} is the task parameter name, {1} is the parameter's .NET type, and {2} is the task name. Do not localize type names or task parameter names.</note>
+      </trans-unit>
       <trans-unit id="InvalidVersionFormat">
         <source>Version string was not in a correct format.</source>
         <target state="translated">バージョン文字列の形式が正しくありません。</target>

--- a/src/Build/Resources/xlf/Strings.ko.xlf
+++ b/src/Build/Resources/xlf/Strings.ko.xlf
@@ -602,6 +602,11 @@
         <target state="translated">MSB4255: 다음 입력 결과 캐시 파일이 존재하지 않습니다. "{0}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidTaskPathParameterValueError">
+        <source>MSB4030: The "{0}" parameter of the "{2}" task is a path of type "{1}", but its value consists only of whitespace. Specify a path containing at least one non-whitespace character, or remove the parameter if it is optional.</source>
+        <target state="new">MSB4030: The "{0}" parameter of the "{2}" task is a path of type "{1}", but its value consists only of whitespace. Specify a path containing at least one non-whitespace character, or remove the parameter if it is optional.</target>
+        <note>{StrBegin="MSB4030: "}{0} is the task parameter name, {1} is the parameter's .NET type, and {2} is the task name. Do not localize type names or task parameter names.</note>
+      </trans-unit>
       <trans-unit id="InvalidVersionFormat">
         <source>Version string was not in a correct format.</source>
         <target state="translated">버전 문자열의 형식이 잘못되었습니다.</target>

--- a/src/Build/Resources/xlf/Strings.ko.xlf
+++ b/src/Build/Resources/xlf/Strings.ko.xlf
@@ -603,9 +603,9 @@
         <note />
       </trans-unit>
       <trans-unit id="InvalidTaskPathParameterValueError">
-        <source>MSB4030: The "{0}" parameter of the "{2}" task is a path of type "{1}", but its value consists only of whitespace. Specify a path containing at least one non-whitespace character, or remove the parameter if it is optional.</source>
-        <target state="new">MSB4030: The "{0}" parameter of the "{2}" task is a path of type "{1}", but its value consists only of whitespace. Specify a path containing at least one non-whitespace character, or remove the parameter if it is optional.</target>
-        <note>{StrBegin="MSB4030: "}{0} is the task parameter name, {1} is the parameter's .NET type, and {2} is the task name. Do not localize type names or task parameter names.</note>
+        <source>MSB4286: The "{0}" parameter of the "{2}" task is a path of type "{1}", but its value consists only of whitespace. Specify a path containing at least one non-whitespace character.</source>
+        <target state="new">MSB4286: The "{0}" parameter of the "{2}" task is a path of type "{1}", but its value consists only of whitespace. Specify a path containing at least one non-whitespace character.</target>
+        <note>{StrBegin="MSB4286: "}{0} is the task parameter name, {1} is the parameter's .NET type, and {2} is the task name. Do not localize type names or task parameter names.</note>
       </trans-unit>
       <trans-unit id="InvalidVersionFormat">
         <source>Version string was not in a correct format.</source>

--- a/src/Build/Resources/xlf/Strings.pl.xlf
+++ b/src/Build/Resources/xlf/Strings.pl.xlf
@@ -602,6 +602,11 @@
         <target state="translated">MSB4255: Następujące pliki wejściowej pamięci podręcznej wyników nie istnieją: „{0}”</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidTaskPathParameterValueError">
+        <source>MSB4030: The "{0}" parameter of the "{2}" task is a path of type "{1}", but its value consists only of whitespace. Specify a path containing at least one non-whitespace character, or remove the parameter if it is optional.</source>
+        <target state="new">MSB4030: The "{0}" parameter of the "{2}" task is a path of type "{1}", but its value consists only of whitespace. Specify a path containing at least one non-whitespace character, or remove the parameter if it is optional.</target>
+        <note>{StrBegin="MSB4030: "}{0} is the task parameter name, {1} is the parameter's .NET type, and {2} is the task name. Do not localize type names or task parameter names.</note>
+      </trans-unit>
       <trans-unit id="InvalidVersionFormat">
         <source>Version string was not in a correct format.</source>
         <target state="translated">Nieprawidłowy format ciągu wersji.</target>

--- a/src/Build/Resources/xlf/Strings.pl.xlf
+++ b/src/Build/Resources/xlf/Strings.pl.xlf
@@ -603,9 +603,9 @@
         <note />
       </trans-unit>
       <trans-unit id="InvalidTaskPathParameterValueError">
-        <source>MSB4030: The "{0}" parameter of the "{2}" task is a path of type "{1}", but its value consists only of whitespace. Specify a path containing at least one non-whitespace character, or remove the parameter if it is optional.</source>
-        <target state="new">MSB4030: The "{0}" parameter of the "{2}" task is a path of type "{1}", but its value consists only of whitespace. Specify a path containing at least one non-whitespace character, or remove the parameter if it is optional.</target>
-        <note>{StrBegin="MSB4030: "}{0} is the task parameter name, {1} is the parameter's .NET type, and {2} is the task name. Do not localize type names or task parameter names.</note>
+        <source>MSB4286: The "{0}" parameter of the "{2}" task is a path of type "{1}", but its value consists only of whitespace. Specify a path containing at least one non-whitespace character.</source>
+        <target state="new">MSB4286: The "{0}" parameter of the "{2}" task is a path of type "{1}", but its value consists only of whitespace. Specify a path containing at least one non-whitespace character.</target>
+        <note>{StrBegin="MSB4286: "}{0} is the task parameter name, {1} is the parameter's .NET type, and {2} is the task name. Do not localize type names or task parameter names.</note>
       </trans-unit>
       <trans-unit id="InvalidVersionFormat">
         <source>Version string was not in a correct format.</source>

--- a/src/Build/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Build/Resources/xlf/Strings.pt-BR.xlf
@@ -603,9 +603,9 @@
         <note />
       </trans-unit>
       <trans-unit id="InvalidTaskPathParameterValueError">
-        <source>MSB4030: The "{0}" parameter of the "{2}" task is a path of type "{1}", but its value consists only of whitespace. Specify a path containing at least one non-whitespace character, or remove the parameter if it is optional.</source>
-        <target state="new">MSB4030: The "{0}" parameter of the "{2}" task is a path of type "{1}", but its value consists only of whitespace. Specify a path containing at least one non-whitespace character, or remove the parameter if it is optional.</target>
-        <note>{StrBegin="MSB4030: "}{0} is the task parameter name, {1} is the parameter's .NET type, and {2} is the task name. Do not localize type names or task parameter names.</note>
+        <source>MSB4286: The "{0}" parameter of the "{2}" task is a path of type "{1}", but its value consists only of whitespace. Specify a path containing at least one non-whitespace character.</source>
+        <target state="new">MSB4286: The "{0}" parameter of the "{2}" task is a path of type "{1}", but its value consists only of whitespace. Specify a path containing at least one non-whitespace character.</target>
+        <note>{StrBegin="MSB4286: "}{0} is the task parameter name, {1} is the parameter's .NET type, and {2} is the task name. Do not localize type names or task parameter names.</note>
       </trans-unit>
       <trans-unit id="InvalidVersionFormat">
         <source>Version string was not in a correct format.</source>

--- a/src/Build/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Build/Resources/xlf/Strings.pt-BR.xlf
@@ -602,6 +602,11 @@
         <target state="translated">MSB4255: os arquivos de cache do resultado de entrada a seguir não existem: "{0}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidTaskPathParameterValueError">
+        <source>MSB4030: The "{0}" parameter of the "{2}" task is a path of type "{1}", but its value consists only of whitespace. Specify a path containing at least one non-whitespace character, or remove the parameter if it is optional.</source>
+        <target state="new">MSB4030: The "{0}" parameter of the "{2}" task is a path of type "{1}", but its value consists only of whitespace. Specify a path containing at least one non-whitespace character, or remove the parameter if it is optional.</target>
+        <note>{StrBegin="MSB4030: "}{0} is the task parameter name, {1} is the parameter's .NET type, and {2} is the task name. Do not localize type names or task parameter names.</note>
+      </trans-unit>
       <trans-unit id="InvalidVersionFormat">
         <source>Version string was not in a correct format.</source>
         <target state="translated">A cadeia de caracteres de versão não estava em um formato correto.</target>

--- a/src/Build/Resources/xlf/Strings.ru.xlf
+++ b/src/Build/Resources/xlf/Strings.ru.xlf
@@ -602,6 +602,11 @@
         <target state="translated">MSB4255: следующие входные файлы кэша результатов не существуют: "{0}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidTaskPathParameterValueError">
+        <source>MSB4030: The "{0}" parameter of the "{2}" task is a path of type "{1}", but its value consists only of whitespace. Specify a path containing at least one non-whitespace character, or remove the parameter if it is optional.</source>
+        <target state="new">MSB4030: The "{0}" parameter of the "{2}" task is a path of type "{1}", but its value consists only of whitespace. Specify a path containing at least one non-whitespace character, or remove the parameter if it is optional.</target>
+        <note>{StrBegin="MSB4030: "}{0} is the task parameter name, {1} is the parameter's .NET type, and {2} is the task name. Do not localize type names or task parameter names.</note>
+      </trans-unit>
       <trans-unit id="InvalidVersionFormat">
         <source>Version string was not in a correct format.</source>
         <target state="translated">Строка версии имела неверный формат.</target>

--- a/src/Build/Resources/xlf/Strings.ru.xlf
+++ b/src/Build/Resources/xlf/Strings.ru.xlf
@@ -603,9 +603,9 @@
         <note />
       </trans-unit>
       <trans-unit id="InvalidTaskPathParameterValueError">
-        <source>MSB4030: The "{0}" parameter of the "{2}" task is a path of type "{1}", but its value consists only of whitespace. Specify a path containing at least one non-whitespace character, or remove the parameter if it is optional.</source>
-        <target state="new">MSB4030: The "{0}" parameter of the "{2}" task is a path of type "{1}", but its value consists only of whitespace. Specify a path containing at least one non-whitespace character, or remove the parameter if it is optional.</target>
-        <note>{StrBegin="MSB4030: "}{0} is the task parameter name, {1} is the parameter's .NET type, and {2} is the task name. Do not localize type names or task parameter names.</note>
+        <source>MSB4286: The "{0}" parameter of the "{2}" task is a path of type "{1}", but its value consists only of whitespace. Specify a path containing at least one non-whitespace character.</source>
+        <target state="new">MSB4286: The "{0}" parameter of the "{2}" task is a path of type "{1}", but its value consists only of whitespace. Specify a path containing at least one non-whitespace character.</target>
+        <note>{StrBegin="MSB4286: "}{0} is the task parameter name, {1} is the parameter's .NET type, and {2} is the task name. Do not localize type names or task parameter names.</note>
       </trans-unit>
       <trans-unit id="InvalidVersionFormat">
         <source>Version string was not in a correct format.</source>

--- a/src/Build/Resources/xlf/Strings.tr.xlf
+++ b/src/Build/Resources/xlf/Strings.tr.xlf
@@ -603,9 +603,9 @@
         <note />
       </trans-unit>
       <trans-unit id="InvalidTaskPathParameterValueError">
-        <source>MSB4030: The "{0}" parameter of the "{2}" task is a path of type "{1}", but its value consists only of whitespace. Specify a path containing at least one non-whitespace character, or remove the parameter if it is optional.</source>
-        <target state="new">MSB4030: The "{0}" parameter of the "{2}" task is a path of type "{1}", but its value consists only of whitespace. Specify a path containing at least one non-whitespace character, or remove the parameter if it is optional.</target>
-        <note>{StrBegin="MSB4030: "}{0} is the task parameter name, {1} is the parameter's .NET type, and {2} is the task name. Do not localize type names or task parameter names.</note>
+        <source>MSB4286: The "{0}" parameter of the "{2}" task is a path of type "{1}", but its value consists only of whitespace. Specify a path containing at least one non-whitespace character.</source>
+        <target state="new">MSB4286: The "{0}" parameter of the "{2}" task is a path of type "{1}", but its value consists only of whitespace. Specify a path containing at least one non-whitespace character.</target>
+        <note>{StrBegin="MSB4286: "}{0} is the task parameter name, {1} is the parameter's .NET type, and {2} is the task name. Do not localize type names or task parameter names.</note>
       </trans-unit>
       <trans-unit id="InvalidVersionFormat">
         <source>Version string was not in a correct format.</source>

--- a/src/Build/Resources/xlf/Strings.tr.xlf
+++ b/src/Build/Resources/xlf/Strings.tr.xlf
@@ -602,6 +602,11 @@
         <target state="translated">MSB4255: Şu giriş sonucu önbellek dosyaları mevcut değil: "{0}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidTaskPathParameterValueError">
+        <source>MSB4030: The "{0}" parameter of the "{2}" task is a path of type "{1}", but its value consists only of whitespace. Specify a path containing at least one non-whitespace character, or remove the parameter if it is optional.</source>
+        <target state="new">MSB4030: The "{0}" parameter of the "{2}" task is a path of type "{1}", but its value consists only of whitespace. Specify a path containing at least one non-whitespace character, or remove the parameter if it is optional.</target>
+        <note>{StrBegin="MSB4030: "}{0} is the task parameter name, {1} is the parameter's .NET type, and {2} is the task name. Do not localize type names or task parameter names.</note>
+      </trans-unit>
       <trans-unit id="InvalidVersionFormat">
         <source>Version string was not in a correct format.</source>
         <target state="translated">Sürüm dizesi doğru biçimde değildi.</target>

--- a/src/Build/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hans.xlf
@@ -602,6 +602,11 @@
         <target state="translated">MSB4255: 以下输入结果缓存文件不存在:“{0}”</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidTaskPathParameterValueError">
+        <source>MSB4030: The "{0}" parameter of the "{2}" task is a path of type "{1}", but its value consists only of whitespace. Specify a path containing at least one non-whitespace character, or remove the parameter if it is optional.</source>
+        <target state="new">MSB4030: The "{0}" parameter of the "{2}" task is a path of type "{1}", but its value consists only of whitespace. Specify a path containing at least one non-whitespace character, or remove the parameter if it is optional.</target>
+        <note>{StrBegin="MSB4030: "}{0} is the task parameter name, {1} is the parameter's .NET type, and {2} is the task name. Do not localize type names or task parameter names.</note>
+      </trans-unit>
       <trans-unit id="InvalidVersionFormat">
         <source>Version string was not in a correct format.</source>
         <target state="translated">版本字符串的格式不正确。</target>

--- a/src/Build/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hans.xlf
@@ -603,9 +603,9 @@
         <note />
       </trans-unit>
       <trans-unit id="InvalidTaskPathParameterValueError">
-        <source>MSB4030: The "{0}" parameter of the "{2}" task is a path of type "{1}", but its value consists only of whitespace. Specify a path containing at least one non-whitespace character, or remove the parameter if it is optional.</source>
-        <target state="new">MSB4030: The "{0}" parameter of the "{2}" task is a path of type "{1}", but its value consists only of whitespace. Specify a path containing at least one non-whitespace character, or remove the parameter if it is optional.</target>
-        <note>{StrBegin="MSB4030: "}{0} is the task parameter name, {1} is the parameter's .NET type, and {2} is the task name. Do not localize type names or task parameter names.</note>
+        <source>MSB4286: The "{0}" parameter of the "{2}" task is a path of type "{1}", but its value consists only of whitespace. Specify a path containing at least one non-whitespace character.</source>
+        <target state="new">MSB4286: The "{0}" parameter of the "{2}" task is a path of type "{1}", but its value consists only of whitespace. Specify a path containing at least one non-whitespace character.</target>
+        <note>{StrBegin="MSB4286: "}{0} is the task parameter name, {1} is the parameter's .NET type, and {2} is the task name. Do not localize type names or task parameter names.</note>
       </trans-unit>
       <trans-unit id="InvalidVersionFormat">
         <source>Version string was not in a correct format.</source>

--- a/src/Build/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hant.xlf
@@ -603,9 +603,9 @@
         <note />
       </trans-unit>
       <trans-unit id="InvalidTaskPathParameterValueError">
-        <source>MSB4030: The "{0}" parameter of the "{2}" task is a path of type "{1}", but its value consists only of whitespace. Specify a path containing at least one non-whitespace character, or remove the parameter if it is optional.</source>
-        <target state="new">MSB4030: The "{0}" parameter of the "{2}" task is a path of type "{1}", but its value consists only of whitespace. Specify a path containing at least one non-whitespace character, or remove the parameter if it is optional.</target>
-        <note>{StrBegin="MSB4030: "}{0} is the task parameter name, {1} is the parameter's .NET type, and {2} is the task name. Do not localize type names or task parameter names.</note>
+        <source>MSB4286: The "{0}" parameter of the "{2}" task is a path of type "{1}", but its value consists only of whitespace. Specify a path containing at least one non-whitespace character.</source>
+        <target state="new">MSB4286: The "{0}" parameter of the "{2}" task is a path of type "{1}", but its value consists only of whitespace. Specify a path containing at least one non-whitespace character.</target>
+        <note>{StrBegin="MSB4286: "}{0} is the task parameter name, {1} is the parameter's .NET type, and {2} is the task name. Do not localize type names or task parameter names.</note>
       </trans-unit>
       <trans-unit id="InvalidVersionFormat">
         <source>Version string was not in a correct format.</source>

--- a/src/Build/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hant.xlf
@@ -602,6 +602,11 @@
         <target state="translated">MSB4255: 下列輸入結果快取檔案不存在: "{0}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidTaskPathParameterValueError">
+        <source>MSB4030: The "{0}" parameter of the "{2}" task is a path of type "{1}", but its value consists only of whitespace. Specify a path containing at least one non-whitespace character, or remove the parameter if it is optional.</source>
+        <target state="new">MSB4030: The "{0}" parameter of the "{2}" task is a path of type "{1}", but its value consists only of whitespace. Specify a path containing at least one non-whitespace character, or remove the parameter if it is optional.</target>
+        <note>{StrBegin="MSB4030: "}{0} is the task parameter name, {1} is the parameter's .NET type, and {2} is the task name. Do not localize type names or task parameter names.</note>
+      </trans-unit>
       <trans-unit id="InvalidVersionFormat">
         <source>Version string was not in a correct format.</source>
         <target state="translated">版本字串格式不正確。</target>

--- a/src/Framework.UnitTests/AbsolutePath_Tests.cs
+++ b/src/Framework.UnitTests/AbsolutePath_Tests.cs
@@ -88,7 +88,6 @@ namespace Microsoft.Build.UnitTests
         [InlineData("\t")]
         [InlineData("\r\n")]
         [InlineData(" \t\r\n")]
-        [UseInvariantCulture]
         public void AbsolutePath_WhitespaceOnlyWithBasePath_ShouldExplainHowToFixTheValue(string path)
         {
             using TestEnvironment env = TestEnvironment.Create();
@@ -97,14 +96,12 @@ namespace Microsoft.Build.UnitTests
 
             var exception = Should.Throw<WhitespaceOnlyPathException>(() => new AbsolutePath(path, GetTestBasePath()));
 
-            exception.Message.ShouldStartWith("The path consists only of whitespace.");
-            exception.Message.ShouldContain("non-whitespace character");
+            exception.ParamName.ShouldBe(nameof(path));
         }
 
         [Theory]
         [InlineData(" ")]
         [InlineData("\t")]
-        [UseInvariantCulture]
         public void AbsolutePath_WhitespaceOnlyWithoutBasePath_ShouldExplainHowToFixTheValue(string path)
         {
             using TestEnvironment env = TestEnvironment.Create();
@@ -113,8 +110,7 @@ namespace Microsoft.Build.UnitTests
 
             var exception = Should.Throw<WhitespaceOnlyPathException>(() => new AbsolutePath(path));
 
-            exception.Message.ShouldStartWith("The path consists only of whitespace.");
-            exception.Message.ShouldContain("non-whitespace character");
+            exception.ParamName.ShouldBe(nameof(path));
         }
 
         [Fact]

--- a/src/Framework.UnitTests/AbsolutePath_Tests.cs
+++ b/src/Framework.UnitTests/AbsolutePath_Tests.cs
@@ -83,6 +83,53 @@ namespace Microsoft.Build.UnitTests
         }
 
         [Theory]
+        [InlineData(" ")]
+        [InlineData("\t")]
+        [InlineData("\r\n")]
+        [InlineData(" \t\r\n")]
+        [UseInvariantCulture]
+        public void AbsolutePath_WhitespaceOnlyWithBasePath_ShouldExplainHowToFixTheValue(string path)
+        {
+            using TestEnvironment env = TestEnvironment.Create();
+            env.SetEnvironmentVariable("MSBUILDDISABLEFEATURESFROMVERSION", null);
+            ChangeWaves.ResetStateForTests();
+
+            var exception = Should.Throw<ArgumentException>(() => new AbsolutePath(path, GetTestBasePath()));
+
+            exception.Message.ShouldStartWith("The path consists only of whitespace.");
+            exception.Message.ShouldContain("non-whitespace character");
+        }
+
+        [Theory]
+        [InlineData(" ")]
+        [InlineData("\t")]
+        [UseInvariantCulture]
+        public void AbsolutePath_WhitespaceOnlyWithoutBasePath_ShouldExplainHowToFixTheValue(string path)
+        {
+            using TestEnvironment env = TestEnvironment.Create();
+            env.SetEnvironmentVariable("MSBUILDDISABLEFEATURESFROMVERSION", null);
+            ChangeWaves.ResetStateForTests();
+
+            var exception = Should.Throw<ArgumentException>(() => new AbsolutePath(path));
+
+            exception.Message.ShouldStartWith("The path consists only of whitespace.");
+            exception.Message.ShouldContain("non-whitespace character");
+        }
+
+        [Fact]
+        public void AbsolutePath_WhitespaceOnlyWithBasePath_ShouldBeAcceptedWhenWaveIsDisabled()
+        {
+            using TestEnvironment env = TestEnvironment.Create();
+            env.SetEnvironmentVariable("MSBUILDDISABLEFEATURESFROMVERSION", ChangeWaves.Wave18_10.ToString());
+            ChangeWaves.ResetStateForTests();
+
+            const string path = "   ";
+            AbsolutePath absolutePath = new(path, GetTestBasePath());
+
+            absolutePath.OriginalValue.ShouldBe(path);
+        }
+
+        [Theory]
         [InlineData("subfolder")]
         [InlineData("deep/nested/path")]
         [InlineData(".")]

--- a/src/Framework.UnitTests/AbsolutePath_Tests.cs
+++ b/src/Framework.UnitTests/AbsolutePath_Tests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.IO;
 using Microsoft.Build.Framework;
+using Microsoft.Build.Shared;
 using Shouldly;
 using Xunit;
 using Xunit.NetCore.Extensions;
@@ -94,7 +95,7 @@ namespace Microsoft.Build.UnitTests
             env.SetEnvironmentVariable("MSBUILDDISABLEFEATURESFROMVERSION", null);
             ChangeWaves.ResetStateForTests();
 
-            var exception = Should.Throw<ArgumentException>(() => new AbsolutePath(path, GetTestBasePath()));
+            var exception = Should.Throw<WhitespaceOnlyPathException>(() => new AbsolutePath(path, GetTestBasePath()));
 
             exception.Message.ShouldStartWith("The path consists only of whitespace.");
             exception.Message.ShouldContain("non-whitespace character");
@@ -110,10 +111,20 @@ namespace Microsoft.Build.UnitTests
             env.SetEnvironmentVariable("MSBUILDDISABLEFEATURESFROMVERSION", null);
             ChangeWaves.ResetStateForTests();
 
-            var exception = Should.Throw<ArgumentException>(() => new AbsolutePath(path));
+            var exception = Should.Throw<WhitespaceOnlyPathException>(() => new AbsolutePath(path));
 
             exception.Message.ShouldStartWith("The path consists only of whitespace.");
             exception.Message.ShouldContain("non-whitespace character");
+        }
+
+        [Fact]
+        public void ValueTypeParser_ShouldPreserveWhitespaceOnlyPathException()
+        {
+            using TestEnvironment env = TestEnvironment.Create();
+            env.SetEnvironmentVariable("MSBUILDDISABLEFEATURESFROMVERSION", null);
+            ChangeWaves.ResetStateForTests();
+
+            Should.Throw<WhitespaceOnlyPathException>(() => ValueTypeParser.Parse(" ", typeof(AbsolutePath)));
         }
 
         [Fact]

--- a/src/Framework/PathHelpers/AbsolutePath.cs
+++ b/src/Framework/PathHelpers/AbsolutePath.cs
@@ -128,7 +128,7 @@ namespace Microsoft.Build.Framework
         {
             if (ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave18_10) && string.IsNullOrWhiteSpace(path))
             {
-                throw new ArgumentException(SR.PathCannotBeWhitespace, nameof(path));
+                throw new WhitespaceOnlyPathException(nameof(path));
             }
         }
 

--- a/src/Framework/PathHelpers/AbsolutePath.cs
+++ b/src/Framework/PathHelpers/AbsolutePath.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Build.Framework
         /// Initializes a new instance of the <see cref="AbsolutePath"/> struct.
         /// </summary>
         /// <param name="path">The absolute path string.</param>
-        /// <exception cref="ArgumentException">Thrown if <paramref name="path"/> is null, empty, or not a rooted path.</exception>
+        /// <exception cref="ArgumentException">Thrown if <paramref name="path"/> is null, empty, contains only whitespace, or is not a rooted path.</exception>
         public AbsolutePath(string path)
         {
             ValidatePath(path);
@@ -78,13 +78,14 @@ namespace Microsoft.Build.Framework
         }
 
         /// <summary>
-        /// Validates that the specified file system path is non-empty and rooted.
+        /// Validates that the specified file system path is non-empty, contains a non-whitespace character, and is rooted.
         /// </summary>
-        /// <param name="path">The file system path to validate. Must not be null, empty, or a relative path.</param>
-        /// <exception cref="ArgumentException">Thrown if <paramref name="path"/> is null, empty, or not a rooted path.</exception>
+        /// <param name="path">The file system path to validate. Must not be null, empty, whitespace-only, or a relative path.</param>
+        /// <exception cref="ArgumentException">Thrown if <paramref name="path"/> is null, empty, whitespace-only, or not a rooted path.</exception>
         private static void ValidatePath(string path)
         {
             ArgumentException.ThrowIfNullOrEmpty(path);
+            ThrowIfWhitespaceOnly(path);
 
             // Path.IsPathFullyQualified is not available in .NET Standard 2.0
             // in .NET Framework it's provided by package and in .NET it's built-in
@@ -101,10 +102,11 @@ namespace Microsoft.Build.Framework
         /// </summary>
         /// <param name="path">The path to combine with the base path.</param>
         /// <param name="basePath">The base path to combine with.</param>
-        /// <exception cref="ArgumentException">Thrown if <paramref name="path"/> is null or empty.</exception>
+        /// <exception cref="ArgumentException">Thrown if <paramref name="path"/> is null, empty, or contains only whitespace.</exception>
         public AbsolutePath(string path, AbsolutePath basePath)
         {
             ArgumentException.ThrowIfNullOrEmpty(path);
+            ThrowIfWhitespaceOnly(path);
 
             // This function should not throw when path has illegal characters.
             // For .NET Framework, Microsoft.IO.Path.Combine should be used instead of System.IO.Path.Combine to achieve it.
@@ -120,6 +122,14 @@ namespace Microsoft.Build.Framework
 
             Value = combined;
             OriginalValue = path;
+        }
+
+        private static void ThrowIfWhitespaceOnly(string path)
+        {
+            if (ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave18_10) && string.IsNullOrWhiteSpace(path))
+            {
+                throw new ArgumentException(SR.PathCannotBeWhitespace, nameof(path));
+            }
         }
 
 #if NETFRAMEWORK || NET

--- a/src/Framework/PathHelpers/WhitespaceOnlyPathException.cs
+++ b/src/Framework/PathHelpers/WhitespaceOnlyPathException.cs
@@ -1,0 +1,25 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.Serialization;
+
+namespace Microsoft.Build.Framework
+{
+    [Serializable]
+    internal sealed class WhitespaceOnlyPathException : ArgumentException
+    {
+        internal WhitespaceOnlyPathException(string paramName)
+            : base(SR.PathCannotBeWhitespace, paramName)
+        {
+        }
+
+#if NET8_0_OR_GREATER
+        [Obsolete(DiagnosticId = "SYSLIB0051")]
+#endif
+        private WhitespaceOnlyPathException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
+    }
+}

--- a/src/Framework/Resources/SR.resx
+++ b/src/Framework/Resources/SR.resx
@@ -156,6 +156,9 @@
   <data name="PathMustBeRooted" xml:space="preserve">
     <value>Path must be rooted.</value>
   </data>
+  <data name="PathCannotBeWhitespace" xml:space="preserve">
+    <value>The path consists only of whitespace. Specify a path that contains at least one non-whitespace character.</value>
+  </data>
   <data name="PathTooLong" xml:space="preserve">
     <value>Path: {0} exceeds the OS max path limit. The fully qualified file name must be less than {1} characters.</value>
   </data>

--- a/src/Framework/Resources/xlf/SR.cs.xlf
+++ b/src/Framework/Resources/xlf/SR.cs.xlf
@@ -112,6 +112,11 @@
         <target state="translated">{0} provedl zápis do: {1}.</target>
         <note>{0} is the logger name. {1} is a list of full file paths separated by the current culture's list separator (followed by a space).</note>
       </trans-unit>
+      <trans-unit id="PathCannotBeWhitespace">
+        <source>The path consists only of whitespace. Specify a path that contains at least one non-whitespace character.</source>
+        <target state="new">The path consists only of whitespace. Specify a path that contains at least one non-whitespace character.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PathMustBeRooted">
         <source>Path must be rooted.</source>
         <target state="translated">Cesta musí začínat kořenem.</target>

--- a/src/Framework/Resources/xlf/SR.de.xlf
+++ b/src/Framework/Resources/xlf/SR.de.xlf
@@ -112,6 +112,11 @@
         <target state="translated">{0} hat folgendes geschrieben: {1}</target>
         <note>{0} is the logger name. {1} is a list of full file paths separated by the current culture's list separator (followed by a space).</note>
       </trans-unit>
+      <trans-unit id="PathCannotBeWhitespace">
+        <source>The path consists only of whitespace. Specify a path that contains at least one non-whitespace character.</source>
+        <target state="new">The path consists only of whitespace. Specify a path that contains at least one non-whitespace character.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PathMustBeRooted">
         <source>Path must be rooted.</source>
         <target state="translated">Der Pfad muss einen Stamm besitzen.</target>

--- a/src/Framework/Resources/xlf/SR.es.xlf
+++ b/src/Framework/Resources/xlf/SR.es.xlf
@@ -112,6 +112,11 @@
         <target state="translated">{0} escrito en: {1}</target>
         <note>{0} is the logger name. {1} is a list of full file paths separated by the current culture's list separator (followed by a space).</note>
       </trans-unit>
+      <trans-unit id="PathCannotBeWhitespace">
+        <source>The path consists only of whitespace. Specify a path that contains at least one non-whitespace character.</source>
+        <target state="new">The path consists only of whitespace. Specify a path that contains at least one non-whitespace character.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PathMustBeRooted">
         <source>Path must be rooted.</source>
         <target state="translated">Debe ser una ruta de acceso raíz.</target>

--- a/src/Framework/Resources/xlf/SR.fr.xlf
+++ b/src/Framework/Resources/xlf/SR.fr.xlf
@@ -112,6 +112,11 @@
         <target state="translated">{0} a écrit dans : {1}</target>
         <note>{0} is the logger name. {1} is a list of full file paths separated by the current culture's list separator (followed by a space).</note>
       </trans-unit>
+      <trans-unit id="PathCannotBeWhitespace">
+        <source>The path consists only of whitespace. Specify a path that contains at least one non-whitespace character.</source>
+        <target state="new">The path consists only of whitespace. Specify a path that contains at least one non-whitespace character.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PathMustBeRooted">
         <source>Path must be rooted.</source>
         <target state="translated">Le chemin doit être associé à une racine.</target>

--- a/src/Framework/Resources/xlf/SR.it.xlf
+++ b/src/Framework/Resources/xlf/SR.it.xlf
@@ -112,6 +112,11 @@
         <target state="translated">{0}scritto in: {1}</target>
         <note>{0} is the logger name. {1} is a list of full file paths separated by the current culture's list separator (followed by a space).</note>
       </trans-unit>
+      <trans-unit id="PathCannotBeWhitespace">
+        <source>The path consists only of whitespace. Specify a path that contains at least one non-whitespace character.</source>
+        <target state="new">The path consists only of whitespace. Specify a path that contains at least one non-whitespace character.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PathMustBeRooted">
         <source>Path must be rooted.</source>
         <target state="translated">Il percorso deve contenere una radice.</target>

--- a/src/Framework/Resources/xlf/SR.ja.xlf
+++ b/src/Framework/Resources/xlf/SR.ja.xlf
@@ -112,6 +112,11 @@
         <target state="translated">{0} を次の場所に書き込みました: {1}</target>
         <note>{0} is the logger name. {1} is a list of full file paths separated by the current culture's list separator (followed by a space).</note>
       </trans-unit>
+      <trans-unit id="PathCannotBeWhitespace">
+        <source>The path consists only of whitespace. Specify a path that contains at least one non-whitespace character.</source>
+        <target state="new">The path consists only of whitespace. Specify a path that contains at least one non-whitespace character.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PathMustBeRooted">
         <source>Path must be rooted.</source>
         <target state="translated">パスはルート指定パスである必要があります。</target>

--- a/src/Framework/Resources/xlf/SR.ko.xlf
+++ b/src/Framework/Resources/xlf/SR.ko.xlf
@@ -112,6 +112,11 @@
         <target state="translated">{1}이(가) {0}에 작성됨</target>
         <note>{0} is the logger name. {1} is a list of full file paths separated by the current culture's list separator (followed by a space).</note>
       </trans-unit>
+      <trans-unit id="PathCannotBeWhitespace">
+        <source>The path consists only of whitespace. Specify a path that contains at least one non-whitespace character.</source>
+        <target state="new">The path consists only of whitespace. Specify a path that contains at least one non-whitespace character.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PathMustBeRooted">
         <source>Path must be rooted.</source>
         <target state="translated">루트 경로로 지정해야 합니다.</target>

--- a/src/Framework/Resources/xlf/SR.pl.xlf
+++ b/src/Framework/Resources/xlf/SR.pl.xlf
@@ -112,6 +112,11 @@
         <target state="translated">{0} napisano do: {1}</target>
         <note>{0} is the logger name. {1} is a list of full file paths separated by the current culture's list separator (followed by a space).</note>
       </trans-unit>
+      <trans-unit id="PathCannotBeWhitespace">
+        <source>The path consists only of whitespace. Specify a path that contains at least one non-whitespace character.</source>
+        <target state="new">The path consists only of whitespace. Specify a path that contains at least one non-whitespace character.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PathMustBeRooted">
         <source>Path must be rooted.</source>
         <target state="translated">Ścieżka musi zaczynać się od katalogu głównego.</target>

--- a/src/Framework/Resources/xlf/SR.pt-BR.xlf
+++ b/src/Framework/Resources/xlf/SR.pt-BR.xlf
@@ -112,6 +112,11 @@
         <target state="translated">{0} escreveu para: {1}</target>
         <note>{0} is the logger name. {1} is a list of full file paths separated by the current culture's list separator (followed by a space).</note>
       </trans-unit>
+      <trans-unit id="PathCannotBeWhitespace">
+        <source>The path consists only of whitespace. Specify a path that contains at least one non-whitespace character.</source>
+        <target state="new">The path consists only of whitespace. Specify a path that contains at least one non-whitespace character.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PathMustBeRooted">
         <source>Path must be rooted.</source>
         <target state="translated">Caminho deve ter raiz.</target>

--- a/src/Framework/Resources/xlf/SR.ru.xlf
+++ b/src/Framework/Resources/xlf/SR.ru.xlf
@@ -112,6 +112,11 @@
         <target state="translated">{0} записал в: {1}</target>
         <note>{0} is the logger name. {1} is a list of full file paths separated by the current culture's list separator (followed by a space).</note>
       </trans-unit>
+      <trans-unit id="PathCannotBeWhitespace">
+        <source>The path consists only of whitespace. Specify a path that contains at least one non-whitespace character.</source>
+        <target state="new">The path consists only of whitespace. Specify a path that contains at least one non-whitespace character.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PathMustBeRooted">
         <source>Path must be rooted.</source>
         <target state="translated">Путь должен иметь корень.</target>

--- a/src/Framework/Resources/xlf/SR.tr.xlf
+++ b/src/Framework/Resources/xlf/SR.tr.xlf
@@ -112,6 +112,11 @@
         <target state="translated">{0}, {1} konumuna yazdı</target>
         <note>{0} is the logger name. {1} is a list of full file paths separated by the current culture's list separator (followed by a space).</note>
       </trans-unit>
+      <trans-unit id="PathCannotBeWhitespace">
+        <source>The path consists only of whitespace. Specify a path that contains at least one non-whitespace character.</source>
+        <target state="new">The path consists only of whitespace. Specify a path that contains at least one non-whitespace character.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PathMustBeRooted">
         <source>Path must be rooted.</source>
         <target state="translated">Yol kökü belirtilmelidir.</target>

--- a/src/Framework/Resources/xlf/SR.zh-Hans.xlf
+++ b/src/Framework/Resources/xlf/SR.zh-Hans.xlf
@@ -112,6 +112,11 @@
         <target state="translated">{1} 已写入: {0}</target>
         <note>{0} is the logger name. {1} is a list of full file paths separated by the current culture's list separator (followed by a space).</note>
       </trans-unit>
+      <trans-unit id="PathCannotBeWhitespace">
+        <source>The path consists only of whitespace. Specify a path that contains at least one non-whitespace character.</source>
+        <target state="new">The path consists only of whitespace. Specify a path that contains at least one non-whitespace character.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PathMustBeRooted">
         <source>Path must be rooted.</source>
         <target state="translated">路径必须是根路径。</target>

--- a/src/Framework/Resources/xlf/SR.zh-Hant.xlf
+++ b/src/Framework/Resources/xlf/SR.zh-Hant.xlf
@@ -112,6 +112,11 @@
         <target state="translated">{0} 已寫入至: {1}</target>
         <note>{0} is the logger name. {1} is a list of full file paths separated by the current culture's list separator (followed by a space).</note>
       </trans-unit>
+      <trans-unit id="PathCannotBeWhitespace">
+        <source>The path consists only of whitespace. Specify a path that contains at least one non-whitespace character.</source>
+        <target state="new">The path consists only of whitespace. Specify a path that contains at least one non-whitespace character.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PathMustBeRooted">
         <source>Path must be rooted.</source>
         <target state="translated">路徑必須為根路徑。</target>

--- a/src/Framework/ValueTypeParser.cs
+++ b/src/Framework/ValueTypeParser.cs
@@ -100,6 +100,10 @@ namespace Microsoft.Build.Shared
                 // general-purpose conversion for parameter types we don't really intend to support.
                 return Convert.ChangeType(value, targetType, CultureInfo.InvariantCulture);
             }
+            catch (WhitespaceOnlyPathException)
+            {
+                throw;
+            }
             catch (Exception ex) when (ex is FormatException || ex is InvalidCastException || ex is OverflowException || ex is ArgumentException || ex is NotSupportedException)
             {
                 throw new ArgumentException($"Cannot parse '{value}' as type {targetType.Name}.", nameof(value), ex);

--- a/src/Framework/ValueTypeParser.cs
+++ b/src/Framework/ValueTypeParser.cs
@@ -100,11 +100,8 @@ namespace Microsoft.Build.Shared
                 // general-purpose conversion for parameter types we don't really intend to support.
                 return Convert.ChangeType(value, targetType, CultureInfo.InvariantCulture);
             }
-            catch (WhitespaceOnlyPathException)
-            {
-                throw;
-            }
-            catch (Exception ex) when (ex is FormatException || ex is InvalidCastException || ex is OverflowException || ex is ArgumentException || ex is NotSupportedException)
+            catch (Exception ex) when (ex is not WhitespaceOnlyPathException
+                && (ex is FormatException || ex is InvalidCastException || ex is OverflowException || ex is ArgumentException || ex is NotSupportedException))
             {
                 throw new ArgumentException($"Cannot parse '{value}' as type {targetType.Name}.", nameof(value), ex);
             }

--- a/src/Shared/ProjectErrorUtilities.cs
+++ b/src/Shared/ProjectErrorUtilities.cs
@@ -104,6 +104,19 @@ namespace Microsoft.Build.Shared
         }
 
         /// <summary>
+        /// Creates an <see cref="InvalidProjectFileException"/> using the given location, resource, and format arguments.
+        /// </summary>
+        internal static InvalidProjectFileException CreateInvalidProjectException<T1, T2, T3>(
+            IElementLocation elementLocation,
+            string resourceName,
+            T1 arg0,
+            T2 arg1,
+            T3 arg2)
+        {
+            return CreateInvalidProjectException(null, elementLocation, resourceName, arg0, arg1, arg2);
+        }
+
+        /// <summary>
         /// Overload for two string format arguments.
         /// </summary>
         /// <param name="condition">The condition to check.</param>
@@ -252,6 +265,18 @@ namespace Microsoft.Build.Shared
         /// <param name="args">Extra arguments for formatting the error message.</param>
         private static void ThrowInvalidProject(string errorSubCategoryResourceName, IElementLocation elementLocation, string resourceName, params object[] args)
         {
+            throw CreateInvalidProjectException(errorSubCategoryResourceName, elementLocation, resourceName, args);
+        }
+
+        /// <summary>
+        /// Creates an <see cref="InvalidProjectFileException"/> using the given data.
+        /// </summary>
+        private static InvalidProjectFileException CreateInvalidProjectException(
+            string errorSubCategoryResourceName,
+            IElementLocation elementLocation,
+            string resourceName,
+            params object[] args)
+        {
             Assumed.NotNull(elementLocation);
 #if DEBUG
             if (errorSubCategoryResourceName != null)
@@ -265,7 +290,7 @@ namespace Microsoft.Build.Shared
 
             string message = ResourceUtilities.FormatResourceStringStripCodeAndKeyword(out string errorCode, out string helpKeyword, resourceName, args);
 
-            throw new InvalidProjectFileException(elementLocation.File, elementLocation.Line, elementLocation.Column, 0 /* Unknown end line */, 0 /* Unknown end column */, message, errorSubCategory, errorCode, helpKeyword);
+            return new InvalidProjectFileException(elementLocation.File, elementLocation.Line, elementLocation.Column, 0 /* Unknown end line */, 0 /* Unknown end column */, message, errorSubCategory, errorCode, helpKeyword);
         }
     }
 }


### PR DESCRIPTION
Fixes #14487

### Context

Whitespace-only path values can resolve differently across platforms and may be mistaken for the project directory.

### Changes Made

- Reject whitespace-only values in `AbsolutePath` behind change wave 18.10.
- Report an actionable MSB4286 diagnostic for typed path task parameters and items.
- Preserve the original behavior when the change wave is disabled.

### Error Output

Typed path task parameters fail during parameter binding with task and parameter context:

```text
error MSB4286: The "OutputPath" parameter of the "MyTask" task is a path of type "Microsoft.Build.Framework.AbsolutePath", but its value consists only of whitespace. Specify a path containing at least one non-whitespace character.
```

For a task that accepts a string and later passes it directly to `TaskEnvironment.GetAbsolutePath`, the exception is reported as an unhandled task failure:

```text
error MSB4018: The "MyTask" task failed unexpectedly.
Microsoft.Build.Framework.WhitespaceOnlyPathException: The path consists only of whitespace. Specify a path that contains at least one non-whitespace character. (Parameter 'path')
```

On .NET Framework, the parameter suffix is printed on a separate line as `Parameter name: path`.

### Testing

- `.\build.cmd`
- Focused Framework and Build unit tests on .NET 11
- `.\build.cmd -test` (all affected Framework and Build tests passed on .NET Framework and .NET 11; the unrelated desktop portable-task test failed because `msbuild.exe` is not available on this machine's `PATH`)
- Bootstrap sample build and `dotnet msbuild -help`

### Notes

Set `MSBUILDDISABLEFEATURESFROMVERSION=18.10` to temporarily preserve the previous behavior.
