### PR TITLE
Directory.Parse.config: resolve once per build and bind it to the ProjectRootElementCache (alternative to #14588)

### DIFF
--- a/documentation/specs/directory-parse-config.md
+++ b/documentation/specs/directory-parse-config.md
@@ -74,10 +74,8 @@ This matches how `Directory.Build.rsp` is discovered (`CommandLineParser.GetProj
 `Directory.Build.props` and `Directory.Solution.props` are located.
 
 **First found wins.** There is no layering: a `Directory.Parse.config` in a subdirectory replaces one
-higher up rather than adding to it. Layering would borrow a per-file notion from `.editorconfig`, but a
-build resolves exactly one configuration, so there is nothing to compose across. A nearer file that
-omits a permission granted by a farther one fails loudly, with MSB4066/MSB4067 naming the attribute or
-element.
+higher up rather than adding to it. A nearer file that omits a permission granted by a farther one fails
+loudly, with MSB4066/MSB4067 naming the attribute or element.
 
 There are no machine-wide or environment-variable sources. Whether a project loads should not depend on
 state that is not in source control.

--- a/documentation/specs/directory-parse-config.md
+++ b/documentation/specs/directory-parse-config.md
@@ -2,128 +2,129 @@
 
 ## Summary
 
-MSBuild now supports a configuration file (`Directory.Parse.config`) that allows specific unrecognized attributes or child elements to be silently skipped during project parsing, instead of throwing `InvalidProjectFileException` (MSB4066/MSB4067).
+MSBuild supports a configuration file (`Directory.Parse.config`) that allows specific unrecognized
+attributes or child elements to be silently skipped during project parsing, instead of throwing
+`InvalidProjectFileException` (MSB4066/MSB4067).
 
-This enables compatibility scenarios where project files may include attributes/elements intended for newer MSBuild versions or third-party tools that can still build without those attributes/elements.
+This enables compatibility scenarios where project files include attributes or elements intended for
+newer MSBuild versions or third-party tools, and the build is still correct without them.
 
-## Configuration File Format
+## Configuration file format
 
-`Directory.Parse.config` is a plain text file with one entry per line:
+`Directory.Parse.config` is an XML file, consistent with MSBuild itself and with the other `.config`
+files in the ecosystem (`NuGet.config`, `app.config`):
 
+```xml
+<ParseConfig>
+  <!-- Permit an attribute on a given element -->
+  <AllowAttribute Element="Target" Name="CustomAttr" />
+
+  <!-- Permit a child element beneath a given parent -->
+  <AllowElement Parent="Project" Name="ToolConfiguration" />
+</ParseConfig>
 ```
-# Lines starting with # are comments
-# Empty lines are ignored
 
-# Format: Type:Name:AllowedName
-Attribute:Target:CustomAttr
-Element:Project:CustomElement
-Attribute:PropertyGroup:NewFeatureFlag
-```
+Element and attribute names are matched case-insensitively.
 
-- **Type**: Either `Attribute` or `Element` (case-insensitive)
-- **Name**:  `Attribute`: the name/type of the element; `Element`: the name/type of the parent element
-- **AllowedName**: The name of the attribute or child element to allow
+Permissions are granted per name. There is no way to express "tolerate anything": an unrecognized
+name that is not listed still produces MSB4066/MSB4067, so ordinary typos remain errors.
 
-Matching is case-insensitive.
-Invalid lines (wrong format, unknown type, wrong number of colons) are silently ignored.
+### Diagnostics
 
-For more details on `Name`:
+Two categories of problem are reported at low importance during evaluation rather than failing the
+build:
 
-### Valid Attribute Names
+- **Unrecognized directives** (an element under `<ParseConfig>` this engine does not know) are
+  ignored, so that a future MSBuild can add directives without older engines rejecting the file.
+- **Malformed directives** (a known directive missing a required attribute) are ignored and reported.
 
-For attributes the `Name` can be the name of the following MSBuild elements:
-- `Target`
-- `PropertyGroup`
-- `ItemGroup`
-- `Import`
-- `ImportGroup`
-- `UsingTask`
-- `OnError`
-- `Output`
-- `Choose`
-- `Otherwise`
-- `ProjectExtensions`
+A file that is not well-formed XML contributes nothing at all — no partial configuration is applied —
+and the parse error is reported.
 
-Although the following are not elements, they can be specified to target attributes on these types of elements:
+Reporting both means a typo such as `<AlowAttribute>` shows up in the log rather than presenting later
+as an apparently unrelated MSB4066.
+
+### Valid `Element` values for `AllowAttribute`
+
+- `Target`, `PropertyGroup`, `ItemGroup`, `Import`, `ImportGroup`, `UsingTask`, `OnError`, `Output`,
+  `Choose`, `Otherwise`, `ProjectExtensions`
+
+The following are not elements, but may be specified to target attributes on those kinds of element:
+
 - `Property`: attributes on elements inside a `PropertyGroup`
-- `Item`: attributes on elements inside a `ItemGroup`
+- `Item`: attributes on elements inside an `ItemGroup`
 - `Metadata`: attributes on elements inside an `Item` or `ItemDefinitionGroup`
-- `Parameter`: attributes on elements in a ParameterGroup inside a UsingTask
-- `UsingTaskBody`: attributes on Task elements inside a UsingTask
+- `Parameter`: attributes on elements in a `ParameterGroup` inside a `UsingTask`
+- `UsingTaskBody`: attributes on `Task` elements inside a `UsingTask`
 
-### Valid Element Names
+### Valid `Parent` values for `AllowElement`
 
-The following names can be specified:
-- `Project`
-- `Import`
-- `ImportGroup`
-- `UsingTask`
-- `OnError`
-- `Output`
-- `Choose`
-- `When`
-- `Otherwise`
+- `Project`, `Import`, `ImportGroup`, `UsingTask`, `OnError`, `Output`, `Choose`, `When`, `Otherwise`
 
-The following cannot be specified since their children are by definition always valid:
-- `Target`
-- `PropertyGroup`
-- `ItemGroup`
-- `ProjectExtensions`
+`Target`, `PropertyGroup`, `ItemGroup` and `ProjectExtensions` cannot be specified because their
+children are open-ended by definition and are already accepted.
 
-## Discovery and Loading
+## Discovery
 
-Configuration files are discovered and merged additively:
+The configuration is resolved **once per build**, anchored on the directory of the **entry project**,
+by walking up to the nearest `Directory.Parse.config`. The current working directory is used only when
+no project was specified.
 
-1. **Global config at build start**
-   - Next to the MSBuild executable
-   - User profile: `%USERPROFILE%\.msbuild\Directory.Parse.config` (Windows) or `$HOME/.msbuild/Directory.Parse.config` (Unix)
-   - Paths listed in `MSBUILD_PARSE_CONFIG`, split using the platform path separator
-   - The startup directory of MSBuild
+This matches how `Directory.Build.rsp` is discovered (`CommandLineParser.GetProjectDirectory`), and how
+`Directory.Build.props` and `Directory.Solution.props` are located.
 
-2. **Directory-specific config at evaluation start**
-   - MSBuild walks up from the project file's directory looking for `Directory.Parse.config`
-   - If found and that file was not already loaded globally, it is loaded and merged for that evaluation
+**First found wins.** There is no layering: a `Directory.Parse.config` in a subdirectory replaces one
+higher up rather than adding to it. Layering would borrow a per-file notion from `.editorconfig`, but a
+build resolves exactly one configuration, so there is nothing to compose across. A nearer file that
+omits a permission granted by a farther one fails loudly, with MSB4066/MSB4067 naming the attribute or
+element.
 
-## Centralized Loading (BuildManager)
+There are no machine-wide or environment-variable sources. Whether a project loads should not depend on
+state that is not in source control.
 
-In a normal build flow, the main node loads global config once during `BuildManager.BeginBuild()`. The config is:
-- Stored on `BuildParameters.UnknownElementsConfiguration`
-- Serialized to worker nodes via the standard `ITranslatable` mechanism
-- Set on the shared `ProjectRootElementCache`, so parsing uses the same configuration
+Set `MSBUILD_DISABLE_PARSE_CONFIG=1` to disable the feature entirely.
 
-At evaluation start, MSBuild may merge in one additional `Directory.Parse.config` discovered from the project file's directory walk.
+## One build, one set of rules
 
-Users of the `ProjectCollection` API can also set `ProjectCollection.UnknownElementsConfiguration` directly, which flows into `BuildParameters` when builds are started.
+Because the configuration is anchored on the entry project, a single build has exactly one set of parse
+rules. Building a project in a directory that has no `Directory.Parse.config` means nothing is permitted
+anywhere in that build, even for referenced projects whose own directories contain one.
+
+This is what makes rules from one workspace unable to leak into another.
+
+## Ownership and lifetime
+
+The resolved configuration is an immutable object with a content-based identity. Two configurations
+permitting the same names are interchangeable; any difference in permitted names is a different identity.
+
+`ProjectRootElementCache` takes the configuration as a **constructor parameter** and keeps it for its
+lifetime. A cache therefore can never hold elements parsed under differing rules. Where a cache outlives
+a build, the configuration is compared and the cache is replaced when it differs, rather than mutated:
+
+| Path | Collection | Cache | Behaviour |
+|---|---|---|---|
+| CLI, no server | fresh per build | fresh per build | nothing to do |
+| MSBuild Server | fresh per build | static, reused | identity checked before adopting `s_projectRootElementCache` |
+| Worker nodes | n/a | process-static, reused | identity checked in `OutOfProcNode.HandleNodeConfiguration`; cache replaced on mismatch |
+| Long-lived host (VS) | persists with loaded projects | persists | resolved from the first project loaded and then frozen; re-resolved only while no projects are loaded |
+
+Editing `Directory.Parse.config` changes its identity, so the next build re-parses under the new rules.
+No node recycling or cache invalidation logic is required.
+
+The configuration is carried on `BuildParameters` purely so that it reaches worker nodes via
+`NodeConfiguration`; worker nodes never perform their own directory walk, so the main node and every
+worker always agree about how a given file parses.
+
+## Hosts
+
+Hosts that know nothing about this feature — notably Visual Studio — are supported without any host-side
+change: a `ProjectCollection` that was not given a configuration resolves one from the directory of the
+first project loaded into it.
+
+Note that permitted names are tolerated by the engine but will still be flagged by the Visual Studio XML
+editor, whose IntelliSense is driven by the XSDs shipped in the Visual Studio installation.
 
 ## Logging
 
-During evaluation, two low-importance messages can be logged to the binary log:
-
-- **Config files loaded**: Lists all discovered and loaded config file paths.
-- **Skipped items summary**: Lists all unrecognized attributes/elements that were skipped, with occurrence counts. This is logged after evaluation work has completed so it reflects actual skips from that evaluation.
-
-Example log messages:
-```
-Loaded Directory.Parse.config from: C:\repo\Directory.Parse.config, C:\Users\me\.msbuild\Directory.Parse.config
-Skipped unrecognized items allowed by Directory.Parse.config: Attribute:Target:CustomAttr (2 occurrences); Element:Project:Widget (1 occurrence)
-```
-
-## Examples
-
-### Allow a custom attribute on Target elements
-
-Directory.Parse.config:
-```
-Attribute:Target:CustomAttr
-```
-
-This allows `<Target Name="Build" CustomAttr="value">` without error.
-
-### Allow a custom child element under Project
-
-Directory.Parse.config:
-```
-Element:Project:ToolConfiguration
-```
-
-This allows `<ToolConfiguration ... />` as a direct child of `<Project>` without error.
+During evaluation, low-importance messages report the config file that was loaded and a summary of the
+names actually skipped, so a binary log shows both which rules applied and whether they were used.

--- a/documentation/specs/directory-parse-config.md
+++ b/documentation/specs/directory-parse-config.md
@@ -1,0 +1,129 @@
+# Directory.Parse.config — Ignoring Unexpected Attributes and Elements
+
+## Summary
+
+MSBuild now supports a configuration file (`Directory.Parse.config`) that allows specific unrecognized attributes or child elements to be silently skipped during project parsing, instead of throwing `InvalidProjectFileException` (MSB4066/MSB4067).
+
+This enables compatibility scenarios where project files may include attributes/elements intended for newer MSBuild versions or third-party tools that can still build without those attributes/elements.
+
+## Configuration File Format
+
+`Directory.Parse.config` is a plain text file with one entry per line:
+
+```
+# Lines starting with # are comments
+# Empty lines are ignored
+
+# Format: Type:Name:AllowedName
+Attribute:Target:CustomAttr
+Element:Project:CustomElement
+Attribute:PropertyGroup:NewFeatureFlag
+```
+
+- **Type**: Either `Attribute` or `Element` (case-insensitive)
+- **Name**:  `Attribute`: the name/type of the element; `Element`: the name/type of the parent element
+- **AllowedName**: The name of the attribute or child element to allow
+
+Matching is case-insensitive.
+Invalid lines (wrong format, unknown type, wrong number of colons) are silently ignored.
+
+For more details on `Name`:
+
+### Valid Attribute Names
+
+For attributes the `Name` can be the name of the following MSBuild elements:
+- `Target`
+- `PropertyGroup`
+- `ItemGroup`
+- `Import`
+- `ImportGroup`
+- `UsingTask`
+- `OnError`
+- `Output`
+- `Choose`
+- `Otherwise`
+- `ProjectExtensions`
+
+Although the following are not elements, they can be specified to target attributes on these types of elements:
+- `Property`: attributes on elements inside a `PropertyGroup`
+- `Item`: attributes on elements inside a `ItemGroup`
+- `Metadata`: attributes on elements inside an `Item` or `ItemDefinitionGroup`
+- `Parameter`: attributes on elements in a ParameterGroup inside a UsingTask
+- `UsingTaskBody`: attributes on Task elements inside a UsingTask
+
+### Valid Element Names
+
+The following names can be specified:
+- `Project`
+- `Import`
+- `ImportGroup`
+- `UsingTask`
+- `OnError`
+- `Output`
+- `Choose`
+- `When`
+- `Otherwise`
+
+The following cannot be specified since their children are by definition always valid:
+- `Target`
+- `PropertyGroup`
+- `ItemGroup`
+- `ProjectExtensions`
+
+## Discovery and Loading
+
+Configuration files are discovered and merged additively:
+
+1. **Global config at build start**
+   - Next to the MSBuild executable
+   - User profile: `%USERPROFILE%\.msbuild\Directory.Parse.config` (Windows) or `$HOME/.msbuild/Directory.Parse.config` (Unix)
+   - Paths listed in `MSBUILD_PARSE_CONFIG`, split using the platform path separator
+   - The startup directory of MSBuild
+
+2. **Directory-specific config at evaluation start**
+   - MSBuild walks up from the project file's directory looking for `Directory.Parse.config`
+   - If found and that file was not already loaded globally, it is loaded and merged for that evaluation
+
+## Centralized Loading (BuildManager)
+
+In a normal build flow, the main node loads global config once during `BuildManager.BeginBuild()`. The config is:
+- Stored on `BuildParameters.UnknownElementsConfiguration`
+- Serialized to worker nodes via the standard `ITranslatable` mechanism
+- Set on the shared `ProjectRootElementCache`, so parsing uses the same configuration
+
+At evaluation start, MSBuild may merge in one additional `Directory.Parse.config` discovered from the project file's directory walk.
+
+Users of the `ProjectCollection` API can also set `ProjectCollection.UnknownElementsConfiguration` directly, which flows into `BuildParameters` when builds are started.
+
+## Logging
+
+During evaluation, two low-importance messages can be logged to the binary log:
+
+- **Config files loaded**: Lists all discovered and loaded config file paths.
+- **Skipped items summary**: Lists all unrecognized attributes/elements that were skipped, with occurrence counts. This is logged after evaluation work has completed so it reflects actual skips from that evaluation.
+
+Example log messages:
+```
+Loaded Directory.Parse.config from: C:\repo\Directory.Parse.config, C:\Users\me\.msbuild\Directory.Parse.config
+Skipped unrecognized items allowed by Directory.Parse.config: Attribute:Target:CustomAttr (2 occurrences); Element:Project:Widget (1 occurrence)
+```
+
+## Examples
+
+### Allow a custom attribute on Target elements
+
+Directory.Parse.config:
+```
+Attribute:Target:CustomAttr
+```
+
+This allows `<Target Name="Build" CustomAttr="value">` without error.
+
+### Allow a custom child element under Project
+
+Directory.Parse.config:
+```
+Element:Project:ToolConfiguration
+```
+
+This allows `<ToolConfiguration ... />` as a direct child of `<Project>` without error.

--- a/src/Build.UnitTests/Evaluation/UnknownElementsConfiguration_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/UnknownElementsConfiguration_Tests.cs
@@ -106,41 +106,82 @@ Attribute:Target:ValidOne
         }
 
         [Fact]
-        public void MergeCombinesEntriesAndDeduplicatesFiles()
+        public void NearestConfigWinsAndChainIsMerged()
         {
-            string configPath = Path.Combine(_testDir, UnknownElementsConfiguration.ConfigFileName);
-            File.WriteAllText(configPath, "Attribute:Target:Foo\n");
+            // repo root permits Foo, subdirectory permits Bar; a project in the subdirectory gets both.
+            string subDir = Path.Combine(_testDir, "sub");
+            Directory.CreateDirectory(subDir);
 
-            string extraConfigPath = Path.Combine(_testDir, "extra.config");
-            File.WriteAllText(extraConfigPath, "Element:Project:CustomThing\n");
+            File.WriteAllText(Path.Combine(_testDir, UnknownElementsConfiguration.ConfigFileName), "Attribute:Target:Foo\n");
+            File.WriteAllText(Path.Combine(subDir, UnknownElementsConfiguration.ConfigFileName), "Attribute:Target:Bar\n");
 
-            var merged = UnknownElementsConfiguration.LoadFromFile(configPath)
-                .Merge(UnknownElementsConfiguration.LoadFromFile(extraConfigPath))
-                .Merge(UnknownElementsConfiguration.LoadFromFile(configPath));
+            var config = UnknownElementsConfiguration.Resolve(subDir);
 
-            merged.CheckSkipAttribute("Target", "Foo").ShouldBeTrue();
-            merged.CheckSkipElement("Project", "CustomThing").ShouldBeTrue();
-            merged.LoadedConfigFiles.Count.ShouldBe(2);
+            config.CheckSkipAttribute("Target", "Foo").ShouldBeTrue();
+            config.CheckSkipAttribute("Target", "Bar").ShouldBeTrue();
+            config.LoadedConfigFiles.Count.ShouldBe(2);
         }
 
         [Fact]
-        public void LoadGlobalConfigLoadsEnvironmentVariablePaths()
+        public void RootTrueStopsTheUpwardWalk()
         {
-            string envConfigPath = Path.Combine(_testDir, "env.config");
-            File.WriteAllText(envConfigPath, "Element:Project:CustomThing\n");
+            string subDir = Path.Combine(_testDir, "sub");
+            Directory.CreateDirectory(subDir);
 
-            string oldEnv = Environment.GetEnvironmentVariable(UnknownElementsConfiguration.EnvironmentVariableName);
-            try
-            {
-                Environment.SetEnvironmentVariable(UnknownElementsConfiguration.EnvironmentVariableName, envConfigPath);
-                var config = UnknownElementsConfiguration.LoadGlobalConfig();
+            File.WriteAllText(Path.Combine(_testDir, UnknownElementsConfiguration.ConfigFileName), "Attribute:Target:Foo\n");
+            File.WriteAllText(Path.Combine(subDir, UnknownElementsConfiguration.ConfigFileName), "root = true\nAttribute:Target:Bar\n");
 
-                config.CheckSkipElement("Project", "CustomThing").ShouldBeTrue();
-            }
-            finally
-            {
-                Environment.SetEnvironmentVariable(UnknownElementsConfiguration.EnvironmentVariableName, oldEnv);
-            }
+            var config = UnknownElementsConfiguration.Resolve(subDir);
+
+            config.CheckSkipAttribute("Target", "Bar").ShouldBeTrue();
+            config.CheckSkipAttribute("Target", "Foo").ShouldBeFalse();
+            config.LoadedConfigFiles.Count.ShouldBe(1);
+        }
+
+        [Fact]
+        public void IdentityIsContentBasedNotPathBased()
+        {
+            string dirA = Path.Combine(_testDir, "a");
+            string dirB = Path.Combine(_testDir, "b");
+            string dirC = Path.Combine(_testDir, "c");
+            Directory.CreateDirectory(dirA);
+            Directory.CreateDirectory(dirB);
+            Directory.CreateDirectory(dirC);
+
+            File.WriteAllText(Path.Combine(dirA, UnknownElementsConfiguration.ConfigFileName), "root=true\nAttribute:Target:Foo\n");
+            File.WriteAllText(Path.Combine(dirB, UnknownElementsConfiguration.ConfigFileName), "root=true\nAttribute:Target:Foo\n");
+            File.WriteAllText(Path.Combine(dirC, UnknownElementsConfiguration.ConfigFileName), "root=true\nAttribute:Target:Other\n");
+
+            var a = UnknownElementsConfiguration.Resolve(dirA);
+            var b = UnknownElementsConfiguration.Resolve(dirB);
+            var c = UnknownElementsConfiguration.Resolve(dirC);
+
+            // Same rules from different files are interchangeable, so a cache can be shared between them.
+            a.Equals(b).ShouldBeTrue();
+            a.Identity.ShouldBe(b.Identity);
+
+            // Different rules must never share a cache.
+            a.Equals(c).ShouldBeFalse();
+        }
+
+        [Fact]
+        public void EmptyConfigurationsShareTheCanonicalIdentity()
+        {
+            UnknownElementsConfiguration.Resolve(_testDir).Equals(UnknownElementsConfiguration.Empty).ShouldBeTrue();
+            UnknownElementsConfiguration.Empty.IsEmpty.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void MalformedEntriesAreReportedRatherThanSilentlyDropped()
+        {
+            string configPath = Path.Combine(_testDir, UnknownElementsConfiguration.ConfigFileName);
+            File.WriteAllText(configPath, "Attribute:Target:Foo\nAttribuet:Target:Typo\n");
+
+            var config = UnknownElementsConfiguration.LoadFromFile(configPath);
+
+            config.CheckSkipAttribute("Target", "Foo").ShouldBeTrue();
+            config.GetMalformedEntriesMessage().ShouldNotBeNull();
+            config.GetMalformedEntriesMessage().ShouldContain("Attribuet:Target:Typo");
         }
 
         [Fact]

--- a/src/Build.UnitTests/Evaluation/UnknownElementsConfiguration_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/UnknownElementsConfiguration_Tests.cs
@@ -1,0 +1,274 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+using Microsoft.Build.Exceptions;
+using Microsoft.Build.Evaluation;
+using Shouldly;
+using Xunit;
+
+#nullable disable
+
+namespace Microsoft.Build.UnitTests.Evaluation
+{
+    public class UnknownElementsConfiguration_Tests : IDisposable
+    {
+        private readonly string _testDir;
+
+        public UnknownElementsConfiguration_Tests()
+        {
+            _testDir = Path.Combine(Path.GetTempPath(), "MSBuildTest_UnknownElements_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_testDir);
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(_testDir))
+            {
+                Directory.Delete(_testDir, recursive: true);
+            }
+        }
+
+        [Fact]
+        public void ParsesValidConfigFile()
+        {
+            string configPath = Path.Combine(_testDir, UnknownElementsConfiguration.ConfigFileName);
+            File.WriteAllText(configPath, @"
+# This is a comment
+Attribute:Target:Foo
+Element:Project:CustomThing
+
+Attribute:PropertyGroup:Bar
+");
+
+            var config = UnknownElementsConfiguration.LoadFromFile(configPath);
+
+            config.LoadedConfigFiles.Count.ShouldBe(1);
+            config.CheckSkipAttribute("Target", "Foo").ShouldBeTrue();
+            config.CheckSkipElement("Project", "CustomThing").ShouldBeTrue();
+            config.CheckSkipAttribute("PropertyGroup", "Bar").ShouldBeTrue();
+        }
+
+        [Fact]
+        public void IsCaseInsensitive()
+        {
+            string configPath = Path.Combine(_testDir, UnknownElementsConfiguration.ConfigFileName);
+            File.WriteAllText(configPath, "Attribute:Target:Foo\n");
+
+            var config = UnknownElementsConfiguration.LoadFromFile(configPath);
+
+            config.CheckSkipAttribute("target", "foo").ShouldBeTrue();
+            config.CheckSkipAttribute("TARGET", "FOO").ShouldBeTrue();
+            config.CheckSkipAttribute("Target", "Foo").ShouldBeTrue();
+        }
+
+        [Fact]
+        public void RejectsNonAllowedItems()
+        {
+            string configPath = Path.Combine(_testDir, UnknownElementsConfiguration.ConfigFileName);
+            File.WriteAllText(configPath, "Attribute:Target:Foo\n");
+
+            var config = UnknownElementsConfiguration.LoadFromFile(configPath);
+
+            config.CheckSkipAttribute("Target", "Bar").ShouldBeFalse();
+            config.CheckSkipElement("Target", "Foo").ShouldBeFalse();
+            config.CheckSkipAttribute("ItemGroup", "Foo").ShouldBeFalse();
+        }
+
+        [Fact]
+        public void IgnoresInvalidLines()
+        {
+            string configPath = Path.Combine(_testDir, UnknownElementsConfiguration.ConfigFileName);
+            File.WriteAllText(configPath, @"
+# Comment
+InvalidType:Target:Foo
+Attribute:Target
+Attribute
+:Target:Foo
+Attribute:Target:Foo:ExtraColon
+Attribute:Target:ValidOne
+");
+
+            var config = UnknownElementsConfiguration.LoadFromFile(configPath);
+
+            config.CheckSkipAttribute("Target", "ValidOne").ShouldBeTrue();
+            config.CheckSkipAttribute("Target", "Foo").ShouldBeFalse();
+        }
+
+        [Fact]
+        public void ReturnsEmptyWhenNoConfigExists()
+        {
+            var config = UnknownElementsConfiguration.LoadFromFile(Path.Combine(_testDir, UnknownElementsConfiguration.ConfigFileName));
+
+            config.LoadedConfigFiles.Count.ShouldBe(0);
+            config.CheckSkipAttribute("Target", "Foo").ShouldBeFalse();
+        }
+
+        [Fact]
+        public void MergeCombinesEntriesAndDeduplicatesFiles()
+        {
+            string configPath = Path.Combine(_testDir, UnknownElementsConfiguration.ConfigFileName);
+            File.WriteAllText(configPath, "Attribute:Target:Foo\n");
+
+            string extraConfigPath = Path.Combine(_testDir, "extra.config");
+            File.WriteAllText(extraConfigPath, "Element:Project:CustomThing\n");
+
+            var merged = UnknownElementsConfiguration.LoadFromFile(configPath)
+                .Merge(UnknownElementsConfiguration.LoadFromFile(extraConfigPath))
+                .Merge(UnknownElementsConfiguration.LoadFromFile(configPath));
+
+            merged.CheckSkipAttribute("Target", "Foo").ShouldBeTrue();
+            merged.CheckSkipElement("Project", "CustomThing").ShouldBeTrue();
+            merged.LoadedConfigFiles.Count.ShouldBe(2);
+        }
+
+        [Fact]
+        public void LoadGlobalConfigLoadsEnvironmentVariablePaths()
+        {
+            string envConfigPath = Path.Combine(_testDir, "env.config");
+            File.WriteAllText(envConfigPath, "Element:Project:CustomThing\n");
+
+            string oldEnv = Environment.GetEnvironmentVariable(UnknownElementsConfiguration.EnvironmentVariableName);
+            try
+            {
+                Environment.SetEnvironmentVariable(UnknownElementsConfiguration.EnvironmentVariableName, envConfigPath);
+                var config = UnknownElementsConfiguration.LoadGlobalConfig();
+
+                config.CheckSkipElement("Project", "CustomThing").ShouldBeTrue();
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(UnknownElementsConfiguration.EnvironmentVariableName, oldEnv);
+            }
+        }
+
+        [Fact]
+        public void RecordsSkippedItems()
+        {
+            string configPath = Path.Combine(_testDir, UnknownElementsConfiguration.ConfigFileName);
+            File.WriteAllText(configPath, "Attribute:Target:Foo\n");
+
+            var config = UnknownElementsConfiguration.LoadFromFile(configPath);
+
+            config.GetSkippedSummaryMessage().ShouldBeNull();
+
+            config.CheckSkipAttribute("Target", "Foo");
+            config.CheckSkipAttribute("Target", "Foo");
+
+            string summary = config.GetSkippedSummaryMessage();
+            summary.ShouldNotBeNull();
+            summary.ShouldContain("Attribute:Target:Foo");
+            summary.ShouldContain("2 occurrences");
+        }
+
+        [Fact]
+        public void GetLoadedConfigsMessageReturnsNullWhenEmpty()
+        {
+            var config = UnknownElementsConfiguration.LoadFromFile(Path.Combine(_testDir, UnknownElementsConfiguration.ConfigFileName));
+            config.GetLoadedConfigsMessage().ShouldBeNull();
+        }
+
+        [Fact]
+        public void GetLoadedConfigsMessageListsFiles()
+        {
+            string configPath = Path.Combine(_testDir, UnknownElementsConfiguration.ConfigFileName);
+            File.WriteAllText(configPath, "Attribute:Target:Foo\n");
+
+            var config = UnknownElementsConfiguration.LoadFromFile(configPath);
+
+            string message = config.GetLoadedConfigsMessage();
+            message.ShouldNotBeNull();
+            message.ShouldContain(_testDir);
+        }
+
+        [Fact]
+        public void AllowedAttributeDoesNotThrowDuringParsing()
+        {
+            string configPath = Path.Combine(_testDir, UnknownElementsConfiguration.ConfigFileName);
+            File.WriteAllText(configPath, "Attribute:Target:CustomAttr\n");
+
+            string projectContent = @"
+<Project>
+  <Target Name=""Build"" CustomAttr=""hello"">
+  </Target>
+</Project>";
+
+            string projectFile = Path.Combine(_testDir, "test.proj");
+            File.WriteAllText(projectFile, projectContent);
+
+            using (var projectCollection = CreateProjectCollection(UnknownElementsConfiguration.LoadFromFile(configPath)))
+            {
+                var project = new Project(projectFile, null, null, projectCollection);
+                project.ShouldNotBeNull();
+            }
+        }
+
+        [Fact]
+        public void NonAllowedAttributeStillThrows()
+        {
+            string projectContent = @"
+<Project>
+  <Target Name=""Build"" BogusAttr=""hello"">
+  </Target>
+</Project>";
+
+            string projectFile = Path.Combine(_testDir, "test.proj");
+            File.WriteAllText(projectFile, projectContent);
+
+            using (var projectCollection = CreateProjectCollection(UnknownElementsConfiguration.LoadFromFile(Path.Combine(_testDir, UnknownElementsConfiguration.ConfigFileName))))
+            {
+                Should.Throw<InvalidProjectFileException>(() => new Project(projectFile, null, null, projectCollection));
+            }
+        }
+
+        [Fact]
+        public void AllowedChildElementDoesNotThrowDuringParsing()
+        {
+            string configPath = Path.Combine(_testDir, UnknownElementsConfiguration.ConfigFileName);
+            File.WriteAllText(configPath, "Element:Project:CustomElement\n");
+
+            string projectContent = @"
+<Project>
+  <CustomElement />
+  <Target Name=""Build"">
+  </Target>
+</Project>";
+
+            string projectFile = Path.Combine(_testDir, "test.proj");
+            File.WriteAllText(projectFile, projectContent);
+
+            using (var projectCollection = CreateProjectCollection(UnknownElementsConfiguration.LoadFromFile(configPath)))
+            {
+                var project = new Project(projectFile, null, null, projectCollection);
+                project.ShouldNotBeNull();
+            }
+        }
+
+        [Fact]
+        public void NonAllowedChildElementStillThrows()
+        {
+            string projectContent = @"
+<Project>
+  <BogusElement />
+  <Target Name=""Build"">
+  </Target>
+</Project>";
+
+            string projectFile = Path.Combine(_testDir, "test.proj");
+            File.WriteAllText(projectFile, projectContent);
+
+            using (var projectCollection = CreateProjectCollection(UnknownElementsConfiguration.LoadFromFile(Path.Combine(_testDir, UnknownElementsConfiguration.ConfigFileName))))
+            {
+                Should.Throw<InvalidProjectFileException>(() => new Project(projectFile, null, null, projectCollection));
+            }
+        }
+
+        private static ProjectCollection CreateProjectCollection(UnknownElementsConfiguration config)
+        {
+            var projectCollection = new ProjectCollection();
+            projectCollection.UnknownElementsConfiguration = config;
+            return projectCollection;
+        }
+    }
+}

--- a/src/Build.UnitTests/Evaluation/UnknownElementsConfiguration_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/UnknownElementsConfiguration_Tests.cs
@@ -30,16 +30,21 @@ namespace Microsoft.Build.UnitTests.Evaluation
             }
         }
 
+        private string WriteConfig(string directory, string body)
+        {
+            string configPath = Path.Combine(directory, UnknownElementsConfiguration.ConfigFileName);
+            File.WriteAllText(configPath, $"<ParseConfig>{body}</ParseConfig>");
+            return configPath;
+        }
+
         [Fact]
         public void ParsesValidConfigFile()
         {
-            string configPath = Path.Combine(_testDir, UnknownElementsConfiguration.ConfigFileName);
-            File.WriteAllText(configPath, @"
-# This is a comment
-Attribute:Target:Foo
-Element:Project:CustomThing
-
-Attribute:PropertyGroup:Bar
+            string configPath = WriteConfig(_testDir, @"
+  <!-- a comment -->
+  <AllowAttribute Element=""Target"" Name=""Foo"" />
+  <AllowElement Parent=""Project"" Name=""CustomThing"" />
+  <AllowAttribute Element=""PropertyGroup"" Name=""Bar"" />
 ");
 
             var config = UnknownElementsConfiguration.LoadFromFile(configPath);
@@ -53,8 +58,7 @@ Attribute:PropertyGroup:Bar
         [Fact]
         public void IsCaseInsensitive()
         {
-            string configPath = Path.Combine(_testDir, UnknownElementsConfiguration.ConfigFileName);
-            File.WriteAllText(configPath, "Attribute:Target:Foo\n");
+            string configPath = WriteConfig(_testDir, @"<AllowAttribute Element=""Target"" Name=""Foo"" />");
 
             var config = UnknownElementsConfiguration.LoadFromFile(configPath);
 
@@ -66,8 +70,7 @@ Attribute:PropertyGroup:Bar
         [Fact]
         public void RejectsNonAllowedItems()
         {
-            string configPath = Path.Combine(_testDir, UnknownElementsConfiguration.ConfigFileName);
-            File.WriteAllText(configPath, "Attribute:Target:Foo\n");
+            string configPath = WriteConfig(_testDir, @"<AllowAttribute Element=""Target"" Name=""Foo"" />");
 
             var config = UnknownElementsConfiguration.LoadFromFile(configPath);
 
@@ -77,23 +80,46 @@ Attribute:PropertyGroup:Bar
         }
 
         [Fact]
-        public void IgnoresInvalidLines()
+        public void UnrecognizedDirectivesAreIgnoredButReported()
         {
-            string configPath = Path.Combine(_testDir, UnknownElementsConfiguration.ConfigFileName);
-            File.WriteAllText(configPath, @"
-# Comment
-InvalidType:Target:Foo
-Attribute:Target
-Attribute
-:Target:Foo
-Attribute:Target:Foo:ExtraColon
-Attribute:Target:ValidOne
+            // Forward compatibility: a directive a newer MSBuild defines must not fail this engine,
+            // but it is reported so that a typo remains diagnosable.
+            string configPath = WriteConfig(_testDir, @"
+  <AllowMetadata Item=""Compile"" Name=""Future"" />
+  <AllowAttribute Element=""Target"" Name=""ValidOne"" />
 ");
 
             var config = UnknownElementsConfiguration.LoadFromFile(configPath);
 
             config.CheckSkipAttribute("Target", "ValidOne").ShouldBeTrue();
-            config.CheckSkipAttribute("Target", "Foo").ShouldBeFalse();
+            config.GetMalformedEntriesMessage().ShouldContain("AllowMetadata");
+        }
+
+        [Fact]
+        public void DirectivesMissingRequiredAttributesAreReported()
+        {
+            string configPath = WriteConfig(_testDir, @"
+  <AllowAttribute Element=""Target"" />
+  <AllowElement Name=""Orphan"" />
+  <AllowAttribute Element=""Target"" Name=""ValidOne"" />
+");
+
+            var config = UnknownElementsConfiguration.LoadFromFile(configPath);
+
+            config.CheckSkipAttribute("Target", "ValidOne").ShouldBeTrue();
+            config.GetMalformedEntriesMessage().ShouldNotBeNull();
+        }
+
+        [Fact]
+        public void MalformedXmlIsReportedRatherThanThrowing()
+        {
+            string configPath = Path.Combine(_testDir, UnknownElementsConfiguration.ConfigFileName);
+            File.WriteAllText(configPath, "<ParseConfig><AllowAttribute Element=\"Target\" Name=\"Foo\" ></ParseConfig>");
+
+            var config = UnknownElementsConfiguration.LoadFromFile(configPath);
+
+            config.IsEmpty.ShouldBeTrue();
+            config.GetMalformedEntriesMessage().ShouldNotBeNull();
         }
 
         [Fact]
@@ -106,30 +132,15 @@ Attribute:Target:ValidOne
         }
 
         [Fact]
-        public void NearestConfigWinsAndChainIsMerged()
+        public void NearestConfigWinsEntirelyWithNoLayering()
         {
-            // repo root permits Foo, subdirectory permits Bar; a project in the subdirectory gets both.
+            // Discovery is first-found-wins, matching Directory.Build.props / .rsp. A nearer file replaces a
+            // farther one outright; it does not add to it.
             string subDir = Path.Combine(_testDir, "sub");
             Directory.CreateDirectory(subDir);
 
-            File.WriteAllText(Path.Combine(_testDir, UnknownElementsConfiguration.ConfigFileName), "Attribute:Target:Foo\n");
-            File.WriteAllText(Path.Combine(subDir, UnknownElementsConfiguration.ConfigFileName), "Attribute:Target:Bar\n");
-
-            var config = UnknownElementsConfiguration.Resolve(subDir);
-
-            config.CheckSkipAttribute("Target", "Foo").ShouldBeTrue();
-            config.CheckSkipAttribute("Target", "Bar").ShouldBeTrue();
-            config.LoadedConfigFiles.Count.ShouldBe(2);
-        }
-
-        [Fact]
-        public void RootTrueStopsTheUpwardWalk()
-        {
-            string subDir = Path.Combine(_testDir, "sub");
-            Directory.CreateDirectory(subDir);
-
-            File.WriteAllText(Path.Combine(_testDir, UnknownElementsConfiguration.ConfigFileName), "Attribute:Target:Foo\n");
-            File.WriteAllText(Path.Combine(subDir, UnknownElementsConfiguration.ConfigFileName), "root = true\nAttribute:Target:Bar\n");
+            WriteConfig(_testDir, @"<AllowAttribute Element=""Target"" Name=""Foo"" />");
+            WriteConfig(subDir, @"<AllowAttribute Element=""Target"" Name=""Bar"" />");
 
             var config = UnknownElementsConfiguration.Resolve(subDir);
 
@@ -138,6 +149,18 @@ Attribute:Target:ValidOne
             config.LoadedConfigFiles.Count.ShouldBe(1);
         }
 
+        [Fact]
+        public void ResolveFindsConfigInAnAncestorDirectory()
+        {
+            string subDir = Path.Combine(_testDir, "a", "b", "c");
+            Directory.CreateDirectory(subDir);
+
+            WriteConfig(_testDir, @"<AllowAttribute Element=""Target"" Name=""Foo"" />");
+
+            var config = UnknownElementsConfiguration.Resolve(subDir);
+
+            config.CheckSkipAttribute("Target", "Foo").ShouldBeTrue();
+        }
         [Fact]
         public void IdentityIsContentBasedNotPathBased()
         {
@@ -148,9 +171,9 @@ Attribute:Target:ValidOne
             Directory.CreateDirectory(dirB);
             Directory.CreateDirectory(dirC);
 
-            File.WriteAllText(Path.Combine(dirA, UnknownElementsConfiguration.ConfigFileName), "root=true\nAttribute:Target:Foo\n");
-            File.WriteAllText(Path.Combine(dirB, UnknownElementsConfiguration.ConfigFileName), "root=true\nAttribute:Target:Foo\n");
-            File.WriteAllText(Path.Combine(dirC, UnknownElementsConfiguration.ConfigFileName), "root=true\nAttribute:Target:Other\n");
+            WriteConfig(dirA, @"<AllowAttribute Element=""Target"" Name=""Foo"" />");
+            WriteConfig(dirB, @"<AllowAttribute Element=""Target"" Name=""Foo"" />");
+            WriteConfig(dirC, @"<AllowAttribute Element=""Target"" Name=""Other"" />");
 
             var a = UnknownElementsConfiguration.Resolve(dirA);
             var b = UnknownElementsConfiguration.Resolve(dirB);
@@ -175,20 +198,20 @@ Attribute:Target:ValidOne
         public void MalformedEntriesAreReportedRatherThanSilentlyDropped()
         {
             string configPath = Path.Combine(_testDir, UnknownElementsConfiguration.ConfigFileName);
-            File.WriteAllText(configPath, "Attribute:Target:Foo\nAttribuet:Target:Typo\n");
+            File.WriteAllText(configPath, @"<ParseConfig><AllowAttribute Element=""Target"" Name=""Foo"" /><Attribuet Element=""Target"" Name=""Typo"" /></ParseConfig>");
 
             var config = UnknownElementsConfiguration.LoadFromFile(configPath);
 
             config.CheckSkipAttribute("Target", "Foo").ShouldBeTrue();
             config.GetMalformedEntriesMessage().ShouldNotBeNull();
-            config.GetMalformedEntriesMessage().ShouldContain("Attribuet:Target:Typo");
+            config.GetMalformedEntriesMessage().ShouldContain("Attribuet");
         }
 
         [Fact]
         public void RecordsSkippedItems()
         {
             string configPath = Path.Combine(_testDir, UnknownElementsConfiguration.ConfigFileName);
-            File.WriteAllText(configPath, "Attribute:Target:Foo\n");
+            WriteConfig(_testDir, @"<AllowAttribute Element=""Target"" Name=""Foo"" />");
 
             var config = UnknownElementsConfiguration.LoadFromFile(configPath);
 
@@ -214,7 +237,7 @@ Attribute:Target:ValidOne
         public void GetLoadedConfigsMessageListsFiles()
         {
             string configPath = Path.Combine(_testDir, UnknownElementsConfiguration.ConfigFileName);
-            File.WriteAllText(configPath, "Attribute:Target:Foo\n");
+            WriteConfig(_testDir, @"<AllowAttribute Element=""Target"" Name=""Foo"" />");
 
             var config = UnknownElementsConfiguration.LoadFromFile(configPath);
 
@@ -227,7 +250,7 @@ Attribute:Target:ValidOne
         public void AllowedAttributeDoesNotThrowDuringParsing()
         {
             string configPath = Path.Combine(_testDir, UnknownElementsConfiguration.ConfigFileName);
-            File.WriteAllText(configPath, "Attribute:Target:CustomAttr\n");
+            WriteConfig(_testDir, @"<AllowAttribute Element=""Target"" Name=""CustomAttr"" />");
 
             string projectContent = @"
 <Project>
@@ -267,7 +290,7 @@ Attribute:Target:ValidOne
         public void AllowedChildElementDoesNotThrowDuringParsing()
         {
             string configPath = Path.Combine(_testDir, UnknownElementsConfiguration.ConfigFileName);
-            File.WriteAllText(configPath, "Element:Project:CustomElement\n");
+            WriteConfig(_testDir, @"<AllowElement Parent=""Project"" Name=""CustomElement"" />");
 
             string projectContent = @"
 <Project>

--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -618,6 +618,12 @@ namespace Microsoft.Build.Execution
                 // Initialize additional build parameters.
                 _buildParameters.BuildId = GetNextBuildId();
 
+                if (_buildParameters.UnknownElementsConfiguration is null && !Traits.Instance.EscapeHatches.DisableParseConfig)
+                {
+                    _buildParameters.UnknownElementsConfiguration = UnknownElementsConfiguration.LoadGlobalConfig(BuildParameters.StartupDirectory);
+                    _buildParameters.ProjectRootElementCache.UnknownElementsConfiguration = _buildParameters.UnknownElementsConfiguration;
+                }
+
                 if (_buildParameters.UsesCachedResults() && _buildParameters.ProjectIsolationMode == ProjectIsolationMode.False)
                 {
                     // If input or output caches are used and the project isolation mode is set to

--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -212,6 +212,12 @@ namespace Microsoft.Build.Execution
         /// Once that has happened, we use the provided one, rather than our default.
         /// </summary>
         private bool _acquiredProjectRootElementCacheFromProjectInstance;
+
+        /// <summary>
+        /// Set once the parse configuration has been resolved for the current build, so that the upward
+        /// directory walk happens exactly once no matter how many submissions are executed.
+        /// </summary>
+        private bool _parseConfigurationResolved;
 
         /// <summary>
         /// The project started event handler
@@ -618,11 +624,11 @@ namespace Microsoft.Build.Execution
                 // Initialize additional build parameters.
                 _buildParameters.BuildId = GetNextBuildId();
 
-                if (_buildParameters.UnknownElementsConfiguration is null && !Traits.Instance.EscapeHatches.DisableParseConfig)
-                {
-                    _buildParameters.UnknownElementsConfiguration = UnknownElementsConfiguration.LoadGlobalConfig(BuildParameters.StartupDirectory);
-                    _buildParameters.ProjectRootElementCache.UnknownElementsConfiguration = _buildParameters.UnknownElementsConfiguration;
-                }
+                // The parse configuration is owned by the ProjectRootElementCache: it is fixed when the cache
+                // is constructed, so a cache can never hold elements parsed under differing rules. It is
+                // carried on BuildParameters purely so that it reaches worker nodes via NodeConfiguration.
+                _buildParameters.UnknownElementsConfiguration =
+                    _buildParameters.ProjectRootElementCache?.UnknownElementsConfiguration ?? UnknownElementsConfiguration.Empty;
 
                 if (_buildParameters.UsesCachedResults() && _buildParameters.ProjectIsolationMode == ProjectIsolationMode.False)
                 {
@@ -845,7 +851,7 @@ namespace Microsoft.Build.Execution
                         config.ResultsNodeId = Scheduler.InvalidNodeId;
                     }
 
-                    _buildParameters.ProjectRootElementCache.DiscardImplicitReferences();
+                    _buildParameters!.ProjectRootElementCache!.DiscardImplicitReferences();
                 }
             }
         }
@@ -1607,6 +1613,8 @@ namespace Microsoft.Build.Execution
                         _buildParameters!.ProjectRootElementCache =
                             new ProjectRootElementCache(false /* do not automatically reload from disk */);
                     }
+
+                    ResolveParseConfigurationForBuild(submission);
 
                     VerifyStateInternal(BuildManagerState.Building);
 
@@ -2497,6 +2505,7 @@ namespace Microsoft.Build.Execution
             _executionCancellationTokenSource?.Dispose();
             _executionCancellationTokenSource = null;
             _nodeConfiguration = null;
+            _parseConfigurationResolved = false;
             _buildSubmissions.Clear();
 
             _scheduler?.Reset();
@@ -3106,6 +3115,78 @@ namespace Microsoft.Build.Execution
 
                 _noActiveSubmissionsEvent?.Set();
             }
+        }
+
+        /// <summary>
+        /// Retrieves the configuration structure for a node.
+        /// </summary>
+        /// <summary>
+        /// Resolves <c>Directory.Parse.config</c> once per build, anchored on the directory of the entry
+        /// project, and binds the build to a cache carrying that configuration.
+        /// </summary>
+        /// <remarks>
+        /// This runs before any project is parsed, so the resulting rules apply to the entry project itself
+        /// and to everything it imports. Anchoring on the project rather than the current directory matches
+        /// how <c>Directory.Build.rsp</c> is discovered by the command line.
+        ///
+        /// A <see cref="ProjectRootElementCache"/> is bound to one configuration for its lifetime, so applying
+        /// a different configuration means replacing the cache. That is only done when the current cache was
+        /// not supplied by a caller who may already have parsed projects into it: a cache adopted from a
+        /// <see cref="ProjectInstance"/>, or one belonging to a <see cref="ProjectCollection"/> that already
+        /// resolved its own configuration, is left alone.
+        /// </remarks>
+        private void ResolveParseConfigurationForBuild(BuildSubmission submission)
+        {
+            if (_parseConfigurationResolved || Traits.Instance.EscapeHatches.DisableParseConfig)
+            {
+                return;
+            }
+
+            _parseConfigurationResolved = true;
+
+            if (_acquiredProjectRootElementCacheFromProjectInstance)
+            {
+                // The cache belongs to the caller's ProjectInstance and may already hold parsed elements.
+                return;
+            }
+
+            ProjectRootElementCacheBase? currentCache = _buildParameters!.ProjectRootElementCache;
+            if (currentCache?.UnknownElementsConfiguration?.IsEmpty == false)
+            {
+                // A configuration was already established (for example by a ProjectCollection resolving from
+                // the first project loaded into it). Respect it rather than resolving a second time.
+                return;
+            }
+
+            string? projectFullPath = submission.BuildRequestData?.ProjectFullPath;
+            if (string.IsNullOrEmpty(projectFullPath))
+            {
+                return;
+            }
+
+            string? anchorDirectory;
+            try
+            {
+                anchorDirectory = Path.GetDirectoryName(projectFullPath);
+            }
+            catch
+            {
+                return;
+            }
+
+            UnknownElementsConfiguration parseConfig = UnknownElementsConfiguration.Resolve(anchorDirectory);
+            if (parseConfig.IsEmpty)
+            {
+                return;
+            }
+
+            _buildParameters.ProjectRootElementCache = new ProjectRootElementCache(
+                autoReloadFromDisk: false,
+                loadProjectsReadOnly: currentCache?.LoadProjectsReadOnly ?? false,
+                unknownElementsConfiguration: parseConfig);
+
+            // Carried on BuildParameters purely so that worker nodes receive it via NodeConfiguration.
+            _buildParameters.UnknownElementsConfiguration = parseConfig;
         }
 
         /// <summary>

--- a/src/Build/BackEnd/BuildManager/BuildParameters.cs
+++ b/src/Build/BackEnd/BuildManager/BuildParameters.cs
@@ -237,6 +237,12 @@ namespace Microsoft.Build.Execution
         private bool _reportFileAccesses;
 
         /// <summary>
+        /// The configuration for allowed unknown attributes/elements during parsing.
+        /// Loaded on the main node and serialized to worker nodes.
+        /// </summary>
+        private UnknownElementsConfiguration _unknownElementsConfiguration;
+
+        /// <summary>
         /// Constructor for those who intend to set all properties themselves.
         /// </summary>
         public BuildParameters()
@@ -262,6 +268,7 @@ namespace Microsoft.Build.Execution
 
             _globalProperties = new PropertyDictionary<ProjectPropertyInstance>(projectCollection.GlobalPropertiesCollection);
             _propertiesFromCommandLine = projectCollection.PropertiesFromCommandLine;
+            _unknownElementsConfiguration = projectCollection.UnknownElementsConfiguration;
         }
 
         /// <summary>
@@ -330,6 +337,7 @@ namespace Microsoft.Build.Execution
             IsTelemetryEnabled = other.IsTelemetryEnabled;
             ProjectCacheDescriptor = other.ProjectCacheDescriptor;
             _enableTargetOutputLogging = other.EnableTargetOutputLogging;
+            _unknownElementsConfiguration = other._unknownElementsConfiguration;
         }
 
         /// <summary>
@@ -823,6 +831,16 @@ namespace Microsoft.Build.Execution
         }
 
         /// <summary>
+        /// Gets or sets the configuration for allowed unknown attributes/elements during parsing.
+        /// When set, this configuration is used for parsing and evaluation.
+        /// </summary>
+        internal UnknownElementsConfiguration UnknownElementsConfiguration
+        {
+            get => _unknownElementsConfiguration;
+            set => _unknownElementsConfiguration = value;
+        }
+
+        /// <summary>
         /// Gets or sets a value indicating if the build is allowed to interact with the user.
         /// </summary>
         public bool Interactive
@@ -994,6 +1012,7 @@ namespace Microsoft.Build.Execution
             translator.Translate(ref _reportFileAccesses);
             translator.Translate(ref _enableTargetOutputLogging);
             translator.Translate(ref _multiThreaded);
+            translator.Translate(ref _unknownElementsConfiguration, UnknownElementsConfiguration.FactoryForDeserialization);
 
             // ProjectRootElementCache is not transmitted.
             // ResetCaches is not transmitted.

--- a/src/Build/BackEnd/Node/OutOfProcNode.cs
+++ b/src/Build/BackEnd/Node/OutOfProcNode.cs
@@ -715,6 +715,19 @@ namespace Microsoft.Build.Execution
             // Grab the system parameters.
             _buildParameters = configuration.BuildParameters;
 
+            // The parse configuration is resolved once by the entry point and travels in BuildParameters.
+            // A ProjectRootElementCache is bound to one configuration for its lifetime, so when this reused
+            // node is handed a build with different parse rules we replace the cache rather than mutate it --
+            // otherwise elements parsed under the previous build's rules would be served to this one.
+            UnknownElementsConfiguration parseConfig = _buildParameters.UnknownElementsConfiguration ?? UnknownElementsConfiguration.Empty;
+            if (s_projectRootElementCacheBase == null || !parseConfig.Equals(s_projectRootElementCacheBase.UnknownElementsConfiguration))
+            {
+                s_projectRootElementCacheBase = new ProjectRootElementCache(
+                    autoReloadFromDisk: true,
+                    loadProjectsReadOnly: false,
+                    unknownElementsConfiguration: parseConfig);
+            }
+
             _buildParameters.ProjectRootElementCache = s_projectRootElementCacheBase;
 
             // Snapshot the current environment

--- a/src/Build/Construction/ProjectRootElement.cs
+++ b/src/Build/Construction/ProjectRootElement.cs
@@ -181,7 +181,7 @@ namespace Microsoft.Build.Construction
 
             XmlDocumentWithLocation document = LoadDocument(xmlReader, preserveFormatting);
 
-            ProjectParser.Parse(document, this);
+            ProjectParser.Parse(document, this, ProjectRootElementCache.UnknownElementsConfiguration);
         }
 
         private readonly bool _isEphemeral = false;
@@ -217,7 +217,7 @@ namespace Microsoft.Build.Construction
                 document.Load(xr);
             }
 
-            ProjectParser.Parse(document, this);
+            ProjectParser.Parse(document, this, ProjectRootElementCache.UnknownElementsConfiguration);
         }
 
         /// <summary>
@@ -241,7 +241,7 @@ namespace Microsoft.Build.Construction
 
             XmlDocumentWithLocation document = LoadDocument(path, preserveFormatting, projectRootElementCache.LoadProjectsReadOnly);
 
-            ProjectParser.Parse(document, this);
+            ProjectParser.Parse(document, this, ProjectRootElementCache.UnknownElementsConfiguration);
         }
 
         /// <summary>
@@ -261,7 +261,7 @@ namespace Microsoft.Build.Construction
             _directory = Environment.CurrentDirectory;
             IncrementVersion();
 
-            ProjectParser.Parse(document, this);
+            ProjectParser.Parse(document, this, ProjectRootElementCache.UnknownElementsConfiguration);
         }
 
         /// <summary>
@@ -273,7 +273,7 @@ namespace Microsoft.Build.Construction
         /// </remarks>
         private ProjectRootElement(XmlDocumentWithLocation document)
         {
-            ProjectParser.Parse(document, this);
+            ProjectParser.Parse(document, this, ProjectRootElementCache.UnknownElementsConfiguration);
         }
 
         /// <summary>
@@ -1721,7 +1721,7 @@ namespace Microsoft.Build.Construction
 
             RemoveAllChildren();
 
-            ProjectParser.Parse(newDocument, this);
+            ProjectParser.Parse(newDocument, this, ProjectRootElementCache.UnknownElementsConfiguration);
 
             MarkDirty("Project reloaded", null);
         }

--- a/src/Build/Definition/ProjectCollection.cs
+++ b/src/Build/Definition/ProjectCollection.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Threading;
@@ -207,6 +208,8 @@ namespace Microsoft.Build.Evaluation
 
         private UnknownElementsConfiguration _unknownElementsConfiguration;
 
+        private bool _parseConfigurationExplicitlySet;
+
         /// <summary>
         /// LoggingService Logger mode.
         /// If Asynchronous mode is used
@@ -368,12 +371,20 @@ namespace Microsoft.Build.Evaluation
             ToolsetLocations = toolsetDefinitionLocations;
             MaxNodeCount = maxNodeCount;
 
+            // When no configuration was supplied by the caller (the CLI resolves one from the entry project's
+            // directory and passes it in), the collection resolves lazily on first project load so that hosts
+            // which know nothing about this feature still honour a repo's Directory.Parse.config.
+            UnknownElementsConfiguration parseConfig = _unknownElementsConfiguration ?? UnknownElementsConfiguration.Empty;
+
             if (Traits.Instance.UseSimpleProjectRootElementCacheConcurrency)
             {
-                ProjectRootElementCache = new SimpleProjectRootElementCache();
+                ProjectRootElementCache = new SimpleProjectRootElementCache(parseConfig);
             }
-            else if (reuseProjectRootElementCache && s_projectRootElementCache != null)
+            else if (reuseProjectRootElementCache && s_projectRootElementCache != null
+                     && parseConfig.Equals(s_projectRootElementCache.UnknownElementsConfiguration))
             {
+                // Only adopt the cache carried over from a previous MSBuild Server build when it was populated
+                // under the same parse rules; otherwise its elements were parsed under a different grammar.
                 ProjectRootElementCache = s_projectRootElementCache;
             }
             else
@@ -382,19 +393,14 @@ namespace Microsoft.Build.Evaluation
                 // If we are not reusing, cache will be released at end of build and as we do not support project files will changes during build
                 // we do not need to auto reload.
                 bool autoReloadFromDisk = reuseProjectRootElementCache;
-                ProjectRootElementCache = new ProjectRootElementCache(autoReloadFromDisk, loadProjectsReadOnly);
+                ProjectRootElementCache = new ProjectRootElementCache(autoReloadFromDisk, loadProjectsReadOnly, parseConfig);
                 if (reuseProjectRootElementCache)
                 {
                     s_projectRootElementCache = ProjectRootElementCache;
                 }
             }
 
-            // Load the global Directory.Parse.config unless explicitly provided or disabled.
-            if (_unknownElementsConfiguration is null && !Traits.Instance.EscapeHatches.DisableParseConfig)
-            {
-                _unknownElementsConfiguration = UnknownElementsConfiguration.LoadGlobalConfig();
-                ProjectRootElementCache.UnknownElementsConfiguration = _unknownElementsConfiguration;
-            }
+            _unknownElementsConfiguration = ProjectRootElementCache.UnknownElementsConfiguration;
 
             OnlyLogCriticalEvents = onlyLogCriticalEvents;
             EnableTargetOutputLogging = enableTargetOutputLogging;
@@ -573,17 +579,76 @@ namespace Microsoft.Build.Evaluation
         public ICollection<string> PropertiesFromCommandLine { get; set; }
 
         /// <summary>
-        /// Gets or sets the configuration for allowed unknown attributes/elements during parsing.
-        /// When set, this configuration will be used by builds started from this collection.
+        /// Gets or sets the parse configuration used by projects loaded into this collection.
         /// </summary>
+        /// <remarks>
+        /// Setting this replaces <see cref="ProjectRootElementCache"/>, because a cache is bound to one
+        /// configuration for its lifetime. That is only safe while no projects are loaded, since loaded
+        /// <see cref="Project"/> objects hold <see cref="Construction.ProjectRootElement"/> references the
+        /// cache tracks.
+        /// </remarks>
         internal UnknownElementsConfiguration UnknownElementsConfiguration
         {
             get => _unknownElementsConfiguration;
             set
             {
-                _unknownElementsConfiguration = value;
-                ProjectRootElementCache.UnknownElementsConfiguration = value;
+                _parseConfigurationExplicitlySet = true;
+                ApplyParseConfiguration(value ?? UnknownElementsConfiguration.Empty);
             }
+        }
+
+        /// <summary>
+        /// Rebinds this collection, and therefore its cache, to a parse configuration.
+        /// </summary>
+        private void ApplyParseConfiguration(UnknownElementsConfiguration value)
+        {
+            if (value.Equals(_unknownElementsConfiguration))
+            {
+                return;
+            }
+
+            // Loaded projects reference elements parsed under the current configuration; swapping the cache
+            // underneath them would orphan those references. Callers are expected to use a separate
+            // ProjectCollection for a different set of rules.
+            if (_loadedProjects.Count > 0)
+            {
+                return;
+            }
+
+            _unknownElementsConfiguration = value;
+            ProjectRootElementCache = Traits.Instance.UseSimpleProjectRootElementCacheConcurrency
+                ? new SimpleProjectRootElementCache(value)
+                : new ProjectRootElementCache(autoReloadFromDisk: false, loadProjectsReadOnly: ProjectRootElementCache.LoadProjectsReadOnly, unknownElementsConfiguration: value);
+        }
+
+        /// <summary>
+        /// Resolves the parse configuration from the directory of the first project loaded, unless a caller
+        /// supplied one explicitly. This is what lets hosts that know nothing about Directory.Parse.config
+        /// (notably Visual Studio) still honour a repository's rules without any host-side change. Once a
+        /// project is loaded the configuration is frozen; it is re-resolved only when the collection is empty
+        /// again, which is the state a long-lived host is in between solutions.
+        /// </summary>
+        private void EnsureParseConfigurationResolved(string projectFilePath)
+        {
+            if (_parseConfigurationExplicitlySet
+                || Traits.Instance.EscapeHatches.DisableParseConfig
+                || string.IsNullOrEmpty(projectFilePath)
+                || _loadedProjects.Count > 0)
+            {
+                return;
+            }
+
+            string projectDirectory;
+            try
+            {
+                projectDirectory = Path.GetDirectoryName(projectFilePath);
+            }
+            catch
+            {
+                return;
+            }
+
+            ApplyParseConfiguration(UnknownElementsConfiguration.Resolve(projectDirectory));
         }
 
         /// <summary>
@@ -1092,7 +1157,7 @@ namespace Microsoft.Build.Evaluation
         /// - So that the owner of this project collection can force the XML to be loaded again
         /// from disk, by doing <see cref="UnloadAllProjects"/>.
         /// </summary>
-        internal ProjectRootElementCacheBase ProjectRootElementCache { get; }
+        internal ProjectRootElementCacheBase ProjectRootElementCache { get; private set; }
 
         /// <summary>
         /// Escape a string using MSBuild escaping format. For example, "%3b" for ";".
@@ -1277,6 +1342,8 @@ namespace Microsoft.Build.Evaluation
         {
             ArgumentException.ThrowIfNullOrEmpty(fileName);
             fileName = FileUtilities.NormalizePath(fileName);
+
+            EnsureParseConfigurationResolved(fileName);
 
             // Serialize loads for the same project path to avoid races where multiple threads create equivalent
             // projects concurrently. Loads for different paths can proceed in parallel.

--- a/src/Build/Definition/ProjectCollection.cs
+++ b/src/Build/Definition/ProjectCollection.cs
@@ -205,6 +205,8 @@ namespace Microsoft.Build.Evaluation
         /// </summary>
         private int _maxNodeCount;
 
+        private UnknownElementsConfiguration _unknownElementsConfiguration;
+
         /// <summary>
         /// LoggingService Logger mode.
         /// If Asynchronous mode is used
@@ -387,6 +389,13 @@ namespace Microsoft.Build.Evaluation
                 }
             }
 
+            // Load the global Directory.Parse.config unless explicitly provided or disabled.
+            if (_unknownElementsConfiguration is null && !Traits.Instance.EscapeHatches.DisableParseConfig)
+            {
+                _unknownElementsConfiguration = UnknownElementsConfiguration.LoadGlobalConfig();
+                ProjectRootElementCache.UnknownElementsConfiguration = _unknownElementsConfiguration;
+            }
+
             OnlyLogCriticalEvents = onlyLogCriticalEvents;
             EnableTargetOutputLogging = enableTargetOutputLogging;
 
@@ -562,6 +571,20 @@ namespace Microsoft.Build.Evaluation
         /// Properties passed from the command line (e.g. by using /p:).
         /// </summary>
         public ICollection<string> PropertiesFromCommandLine { get; set; }
+
+        /// <summary>
+        /// Gets or sets the configuration for allowed unknown attributes/elements during parsing.
+        /// When set, this configuration will be used by builds started from this collection.
+        /// </summary>
+        internal UnknownElementsConfiguration UnknownElementsConfiguration
+        {
+            get => _unknownElementsConfiguration;
+            set
+            {
+                _unknownElementsConfiguration = value;
+                ProjectRootElementCache.UnknownElementsConfiguration = value;
+            }
+        }
 
         /// <summary>
         /// The default tools version of this project collection. Projects use this tools version if they

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -179,8 +179,6 @@ namespace Microsoft.Build.Evaluation
         /// </summary>
         private readonly ProjectRootElementCacheBase _projectRootElementCache;
 
-        private UnknownElementsConfiguration _unknownElementsConfiguration;
-
         /// <summary>
         /// The logging context to be used and piped down throughout evaluation.
         /// </summary>
@@ -296,35 +294,30 @@ namespace Microsoft.Build.Evaluation
             _streamImports.Add(string.Empty);
         }
 
-        private void InitializeUnknownElementsConfiguration()
+        /// <summary>
+        /// Logs which Directory.Parse.config files contributed to this build, and any entries in them that
+        /// could not be understood. The configuration itself is resolved once at the start of the build and
+        /// carried on the cache; nothing is resolved or merged here.
+        /// </summary>
+        private void LogParseConfigDiagnostics()
         {
-            _unknownElementsConfiguration = _projectRootElementCache.UnknownElementsConfiguration;
-
-            if (Traits.Instance.EscapeHatches.DisableParseConfig || string.IsNullOrEmpty(_projectRootElement.FullPath))
+            UnknownElementsConfiguration parseConfig = _projectRootElementCache.UnknownElementsConfiguration;
+            if (parseConfig is null)
             {
                 return;
             }
 
-            string projectConfigPath = FileUtilities.GetPathOfFileAbove(UnknownElementsConfiguration.ConfigFileName, _projectRootElement.DirectoryPath);
-            if (string.IsNullOrEmpty(projectConfigPath))
+            string configMessage = parseConfig.GetLoadedConfigsMessage();
+            if (configMessage is not null)
             {
-                return;
+                _evaluationLoggingContext.LogCommentFromText(MessageImportance.Low, configMessage);
             }
 
-            if (_unknownElementsConfiguration is null)
+            string malformedMessage = parseConfig.GetMalformedEntriesMessage();
+            if (malformedMessage is not null)
             {
-                _unknownElementsConfiguration = UnknownElementsConfiguration.LoadFromFile(projectConfigPath);
+                _evaluationLoggingContext.LogCommentFromText(MessageImportance.Normal, malformedMessage);
             }
-            else if (!_unknownElementsConfiguration.ContainsLoadedFile(projectConfigPath))
-            {
-                _unknownElementsConfiguration = _unknownElementsConfiguration.Merge(UnknownElementsConfiguration.LoadFromFile(projectConfigPath));
-            }
-            else
-            {
-                return;
-            }
-
-            _projectRootElementCache.UnknownElementsConfiguration = _unknownElementsConfiguration;
         }
 
         /// <summary>
@@ -412,7 +405,7 @@ namespace Microsoft.Build.Evaluation
                     items = evaluator._data.Items;
                 }
 
-                string skippedMessage = evaluator._unknownElementsConfiguration?.GetSkippedSummaryMessage();
+                string skippedMessage = evaluator._projectRootElementCache.UnknownElementsConfiguration?.GetSkippedSummaryMessage();
                 if (skippedMessage is not null)
                 {
                     evaluator._evaluationLoggingContext.LogCommentFromText(MessageImportance.Low, skippedMessage);
@@ -688,13 +681,7 @@ namespace Microsoft.Build.Evaluation
                 _data.EvaluationId = _evaluationLoggingContext.BuildEventContext.EvaluationId;
                 _evaluationLoggingContext.LogProjectEvaluationStarted();
 
-                InitializeUnknownElementsConfiguration();
-
-                string configMessage = _unknownElementsConfiguration?.GetLoadedConfigsMessage();
-                if (configMessage is not null)
-                {
-                    _evaluationLoggingContext.LogCommentFromText(MessageImportance.Low, configMessage);
-                }
+                LogParseConfigDiagnostics();
 
                 // Track loads only after start of evaluation was actually logged
                 using var assemblyLoadsTracker =

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -179,6 +179,8 @@ namespace Microsoft.Build.Evaluation
         /// </summary>
         private readonly ProjectRootElementCacheBase _projectRootElementCache;
 
+        private UnknownElementsConfiguration _unknownElementsConfiguration;
+
         /// <summary>
         /// The logging context to be used and piped down throughout evaluation.
         /// </summary>
@@ -294,6 +296,37 @@ namespace Microsoft.Build.Evaluation
             _streamImports.Add(string.Empty);
         }
 
+        private void InitializeUnknownElementsConfiguration()
+        {
+            _unknownElementsConfiguration = _projectRootElementCache.UnknownElementsConfiguration;
+
+            if (Traits.Instance.EscapeHatches.DisableParseConfig || string.IsNullOrEmpty(_projectRootElement.FullPath))
+            {
+                return;
+            }
+
+            string projectConfigPath = FileUtilities.GetPathOfFileAbove(UnknownElementsConfiguration.ConfigFileName, _projectRootElement.DirectoryPath);
+            if (string.IsNullOrEmpty(projectConfigPath))
+            {
+                return;
+            }
+
+            if (_unknownElementsConfiguration is null)
+            {
+                _unknownElementsConfiguration = UnknownElementsConfiguration.LoadFromFile(projectConfigPath);
+            }
+            else if (!_unknownElementsConfiguration.ContainsLoadedFile(projectConfigPath))
+            {
+                _unknownElementsConfiguration = _unknownElementsConfiguration.Merge(UnknownElementsConfiguration.LoadFromFile(projectConfigPath));
+            }
+            else
+            {
+                return;
+            }
+
+            _projectRootElementCache.UnknownElementsConfiguration = _unknownElementsConfiguration;
+        }
+
         /// <summary>
         /// Delegate passed to methods to provide basic expression evaluation
         /// ability, without having a language service.
@@ -377,6 +410,12 @@ namespace Microsoft.Build.Evaluation
                     globalProperties = evaluator._data.GlobalPropertiesDictionary;
                     properties = Traits.LogAllEnvironmentVariables ? evaluator._data.Properties : evaluator.FilterOutEnvironmentDerivedProperties(evaluator._data.Properties);
                     items = evaluator._data.Items;
+                }
+
+                string skippedMessage = evaluator._unknownElementsConfiguration?.GetSkippedSummaryMessage();
+                if (skippedMessage is not null)
+                {
+                    evaluator._evaluationLoggingContext.LogCommentFromText(MessageImportance.Low, skippedMessage);
                 }
 
                 evaluator._evaluationLoggingContext.LogProjectEvaluationFinished(globalProperties, properties, items, evaluator._evaluationProfiler.ProfiledResult);
@@ -648,6 +687,14 @@ namespace Microsoft.Build.Evaluation
                 Assumed.Equal(_data.EvaluationId, BuildEventContext.InvalidEvaluationId, "There is no prior evaluation ID. The evaluator data needs to be reset at this point");
                 _data.EvaluationId = _evaluationLoggingContext.BuildEventContext.EvaluationId;
                 _evaluationLoggingContext.LogProjectEvaluationStarted();
+
+                InitializeUnknownElementsConfiguration();
+
+                string configMessage = _unknownElementsConfiguration?.GetLoadedConfigsMessage();
+                if (configMessage is not null)
+                {
+                    _evaluationLoggingContext.LogCommentFromText(MessageImportance.Low, configMessage);
+                }
 
                 // Track loads only after start of evaluation was actually logged
                 using var assemblyLoadsTracker =

--- a/src/Build/Evaluation/ProjectParser.cs
+++ b/src/Build/Evaluation/ProjectParser.cs
@@ -1,9 +1,10 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;
 using System.Xml;
+using Microsoft.Build.Evaluation;
 using Microsoft.Build.Eventing;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
@@ -85,6 +86,8 @@ namespace Microsoft.Build.Construction
         /// </summary>
         private readonly XmlDocumentWithLocation _document;
 
+        private readonly UnknownElementsConfiguration _unknownElementsConfiguration;
+
         /// <summary>
         /// Whether a ProjectExtensions node has been encountered already.
         /// It's not supposed to appear more than once.
@@ -94,13 +97,14 @@ namespace Microsoft.Build.Construction
         /// <summary>
         /// Private constructor to give static semantics
         /// </summary>
-        private ProjectParser(XmlDocumentWithLocation document, ProjectRootElement project)
+        private ProjectParser(XmlDocumentWithLocation document, ProjectRootElement project, UnknownElementsConfiguration unknownElementsConfiguration)
         {
             Assumed.NotNull(project);
             Assumed.NotNull(document);
 
             _document = document;
             _project = project;
+            _unknownElementsConfiguration = unknownElementsConfiguration;
         }
 
         /// <summary>
@@ -111,11 +115,11 @@ namespace Microsoft.Build.Construction
         /// The code markers here used to be around the Project class constructor in the old code.
         /// In the new code, that's not very interesting; we are repurposing to wrap parsing the XML.
         /// </remarks>
-        internal static void Parse(XmlDocumentWithLocation document, ProjectRootElement projectRootElement)
+        internal static void Parse(XmlDocumentWithLocation document, ProjectRootElement projectRootElement, UnknownElementsConfiguration unknownElementsConfiguration)
         {
             MSBuildEventSource.Log.ParseStart(projectRootElement.ProjectFileLocation.File);
             {
-                ProjectParser parser = new ProjectParser(document, projectRootElement);
+                ProjectParser parser = new ProjectParser(document, projectRootElement, unknownElementsConfiguration);
                 parser.Parse();
             }
             MSBuildEventSource.Log.ParseStop(projectRootElement.ProjectFileLocation.File);
@@ -204,7 +208,11 @@ namespace Microsoft.Build.Construction
                         break;
 
                     default:
-                        ProjectXmlUtilities.ThrowProjectInvalidChildElement(childElement.Name, childElement.ParentNode.Name, childElement.Location);
+                        if (ProjectXmlUtilities.ThrowIfProjectInvalidChildElement(childElement.Name, childElement.ParentNode.Name, childElement.Location, _unknownElementsConfiguration))
+                        {
+                            continue;
+                        }
+
                         break;
                 }
             }
@@ -215,13 +223,13 @@ namespace Microsoft.Build.Construction
         /// </summary>
         private ProjectPropertyGroupElement ParseProjectPropertyGroupElement(XmlElementWithLocation element, ProjectElementContainer parent)
         {
-            ProjectXmlUtilities.VerifyThrowProjectAttributes(element, ValidAttributesOnlyConditionAndLabel);
+            ProjectXmlUtilities.VerifyThrowProjectAttributes(element, ValidAttributesOnlyConditionAndLabel, _unknownElementsConfiguration);
 
             ProjectPropertyGroupElement propertyGroup = new ProjectPropertyGroupElement(element, parent, _project);
 
             foreach (XmlElementWithLocation childElement in ProjectXmlUtilities.GetVerifyThrowProjectChildElements(element))
             {
-                ProjectXmlUtilities.VerifyThrowProjectAttributes(childElement, ValidAttributesOnlyConditionAndLabel);
+                ProjectXmlUtilities.VerifyThrowProjectAttributes(childElement, ValidAttributesOnlyConditionAndLabel, _unknownElementsConfiguration, "Property");
                 XmlUtilities.VerifyThrowProjectValidElementName(childElement);
                 ProjectErrorUtilities.VerifyThrowInvalidProject(!XMakeElements.ReservedItemNames.Contains(childElement.Name) && !ReservedPropertyNames.IsReservedProperty(childElement.Name), childElement.Location, "CannotModifyReservedProperty", childElement.Name);
 
@@ -239,7 +247,7 @@ namespace Microsoft.Build.Construction
         /// </summary>
         private ProjectItemGroupElement ParseProjectItemGroupElement(XmlElementWithLocation element, ProjectElementContainer parent)
         {
-            ProjectXmlUtilities.VerifyThrowProjectAttributes(element, ValidAttributesOnlyConditionAndLabel);
+            ProjectXmlUtilities.VerifyThrowProjectAttributes(element, ValidAttributesOnlyConditionAndLabel, _unknownElementsConfiguration);
 
             ProjectItemGroupElement itemGroup = new ProjectItemGroupElement(element, parent, _project);
 
@@ -320,7 +328,10 @@ namespace Microsoft.Build.Construction
 
                 if (!isKnownAttribute && !isValidMetadataNameInAttribute)
                 {
-                    ProjectXmlUtilities.ThrowProjectInvalidAttribute(attribute);
+                    if (_unknownElementsConfiguration?.CheckSkipAttribute("Item", attribute.Name) != true)
+                    {
+                        ProjectXmlUtilities.ThrowProjectInvalidAttribute(attribute);
+                    }
                 }
                 else if (isValidMetadataNameInAttribute)
                 {
@@ -392,7 +403,7 @@ namespace Microsoft.Build.Construction
         /// </summary>
         private ProjectMetadataElement ParseProjectMetadataElement(XmlElementWithLocation element, ProjectElementContainer parent)
         {
-            ProjectXmlUtilities.VerifyThrowProjectAttributes(element, ValidAttributesOnlyConditionAndLabel);
+            ProjectXmlUtilities.VerifyThrowProjectAttributes(element, ValidAttributesOnlyConditionAndLabel, _unknownElementsConfiguration, "Metadata");
 
             XmlUtilities.VerifyThrowProjectValidElementName(element);
 
@@ -420,7 +431,7 @@ namespace Microsoft.Build.Construction
         /// <returns>A ProjectImportGroupElement derived from the XML element passed in</returns>
         private ProjectImportGroupElement ParseProjectImportGroupElement(XmlElementWithLocation element, ProjectRootElement parent)
         {
-            ProjectXmlUtilities.VerifyThrowProjectAttributes(element, ValidAttributesOnlyConditionAndLabel);
+            ProjectXmlUtilities.VerifyThrowProjectAttributes(element, ValidAttributesOnlyConditionAndLabel, _unknownElementsConfiguration);
 
             ProjectImportGroupElement importGroup = new ProjectImportGroupElement(element, parent, _project);
 
@@ -453,9 +464,9 @@ namespace Microsoft.Build.Construction
                 parent,
                 element);
 
-            ProjectXmlUtilities.VerifyThrowProjectAttributes(element, ValidAttributesOnImport);
+            ProjectXmlUtilities.VerifyThrowProjectAttributes(element, ValidAttributesOnImport, _unknownElementsConfiguration);
             ProjectXmlUtilities.VerifyThrowProjectRequiredAttribute(element, XMakeAttributes.project);
-            ProjectXmlUtilities.VerifyThrowProjectNoChildElements(element);
+            ProjectXmlUtilities.VerifyThrowProjectNoChildElements(element, _unknownElementsConfiguration);
 
             SdkReference sdk = null;
             if (element.HasAttribute(XMakeAttributes.sdk))
@@ -475,7 +486,7 @@ namespace Microsoft.Build.Construction
         private UsingTaskParameterGroupElement ParseUsingTaskParameterGroupElement(XmlElementWithLocation element, ProjectElementContainer parent)
         {
             // There should be no attributes
-            ProjectXmlUtilities.VerifyThrowProjectNoAttributes(element);
+            ProjectXmlUtilities.VerifyThrowProjectNoAttributes(element, _unknownElementsConfiguration);
 
             UsingTaskParameterGroupElement parameterGroup = new UsingTaskParameterGroupElement(element, parent, _project);
 
@@ -489,7 +500,7 @@ namespace Microsoft.Build.Construction
                 }
                 else
                 {
-                    ProjectXmlUtilities.VerifyThrowProjectAttributes(childElement, ValidAttributesOnUsingTaskParameter);
+                    ProjectXmlUtilities.VerifyThrowProjectAttributes(childElement, ValidAttributesOnUsingTaskParameter, _unknownElementsConfiguration, "Parameter");
                     XmlUtilities.VerifyThrowProjectValidElementName(childElement);
                     ProjectUsingTaskParameterElement parameter = new ProjectUsingTaskParameterElement(childElement, parameterGroup, _project);
                     parameterGroup.AppendParentedChildNoChecks(parameter);
@@ -507,7 +518,7 @@ namespace Microsoft.Build.Construction
         /// </summary>
         private ProjectUsingTaskElement ParseProjectUsingTaskElement(XmlElementWithLocation element)
         {
-            ProjectXmlUtilities.VerifyThrowProjectAttributes(element, ValidAttributesOnUsingTask);
+            ProjectXmlUtilities.VerifyThrowProjectAttributes(element, ValidAttributesOnUsingTask, _unknownElementsConfiguration);
             ProjectErrorUtilities.VerifyThrowInvalidProject(element.GetAttribute(XMakeAttributes.taskName).Length > 0, element.Location, "ProjectTaskNameEmpty");
 
             string assemblyName = element.GetAttribute(XMakeAttributes.assemblyName);
@@ -550,13 +561,17 @@ namespace Microsoft.Build.Construction
                             ProjectXmlUtilities.ThrowProjectInvalidChildElementDueToDuplicate(childElement);
                         }
 
-                        ProjectXmlUtilities.VerifyThrowProjectAttributes(childElement, ValidAttributesOnUsingTaskBody);
+                        ProjectXmlUtilities.VerifyThrowProjectAttributes(childElement, ValidAttributesOnUsingTaskBody, _unknownElementsConfiguration, "UsingTaskBody");
 
                         child = new ProjectUsingTaskBodyElement(childElement, usingTask, _project);
                         foundTaskElement = true;
                         break;
                     default:
-                        ProjectXmlUtilities.ThrowProjectInvalidChildElement(childElement.Name, element.Name, element.Location);
+                        if (ProjectXmlUtilities.ThrowIfProjectInvalidChildElement(childElement.Name, "Task", element.Location, _unknownElementsConfiguration))
+                        {
+                            continue;
+                        }
+
                         break;
                 }
 
@@ -571,7 +586,7 @@ namespace Microsoft.Build.Construction
         /// </summary>
         private ProjectTargetElement ParseProjectTargetElement(XmlElementWithLocation element)
         {
-            ProjectXmlUtilities.VerifyThrowProjectAttributes(element, ValidAttributesOnTarget);
+            ProjectXmlUtilities.VerifyThrowProjectAttributes(element, ValidAttributesOnTarget, _unknownElementsConfiguration);
             ProjectXmlUtilities.VerifyThrowProjectRequiredAttribute(element, XMakeAttributes.name);
 
             // Orcas compat: all target names are automatically unescaped
@@ -613,9 +628,9 @@ namespace Microsoft.Build.Construction
                     case XMakeElements.onError:
                         // Previous OM accidentally didn't verify ExecuteTargets on parse,
                         // but we do, as it makes no sense
-                        ProjectXmlUtilities.VerifyThrowProjectAttributes(childElement, ValidAttributesOnOnError);
+                        ProjectXmlUtilities.VerifyThrowProjectAttributes(childElement, ValidAttributesOnOnError, _unknownElementsConfiguration);
                         ProjectXmlUtilities.VerifyThrowProjectRequiredAttribute(childElement, XMakeAttributes.executeTargets);
-                        ProjectXmlUtilities.VerifyThrowProjectNoChildElements(childElement);
+                        ProjectXmlUtilities.VerifyThrowProjectNoChildElements(childElement, _unknownElementsConfiguration);
 
                         child = onError = new ProjectOnErrorElement(childElement, target, _project);
                         break;
@@ -665,7 +680,15 @@ namespace Microsoft.Build.Construction
 
             foreach (XmlElementWithLocation childElement in ProjectXmlUtilities.GetVerifyThrowProjectChildElements(element))
             {
-                ProjectErrorUtilities.VerifyThrowInvalidProject(childElement.Name == XMakeElements.output, childElement.Location, "UnrecognizedChildElement", childElement.Name, task.Name);
+                if (childElement.Name != XMakeElements.output)
+                {
+                    if (_unknownElementsConfiguration?.CheckSkipElement("Task", childElement.Name) == true)
+                    {
+                        continue;
+                    }
+
+                    ProjectErrorUtilities.ThrowInvalidProject(childElement.Location, "UnrecognizedChildElement", childElement.Name, task.Name);
+                }
 
                 ProjectOutputElement output = ParseProjectOutputElement(childElement, task);
 
@@ -680,9 +703,9 @@ namespace Microsoft.Build.Construction
         /// </summary>
         private ProjectOutputElement ParseProjectOutputElement(XmlElementWithLocation element, ProjectTaskElement parent)
         {
-            ProjectXmlUtilities.VerifyThrowProjectAttributes(element, ValidAttributesOnOutput);
+            ProjectXmlUtilities.VerifyThrowProjectAttributes(element, ValidAttributesOnOutput, _unknownElementsConfiguration);
             ProjectXmlUtilities.VerifyThrowProjectRequiredAttribute(element, XMakeAttributes.taskParameter);
-            ProjectXmlUtilities.VerifyThrowProjectNoChildElements(element);
+            ProjectXmlUtilities.VerifyThrowProjectNoChildElements(element, _unknownElementsConfiguration);
 
             XmlAttributeWithLocation itemNameAttribute = element.GetAttributeWithLocation(XMakeAttributes.itemName);
             XmlAttributeWithLocation propertyNameAttribute = element.GetAttributeWithLocation(XMakeAttributes.propertyName);
@@ -706,7 +729,7 @@ namespace Microsoft.Build.Construction
         /// </summary>
         private ProjectItemDefinitionGroupElement ParseProjectItemDefinitionGroupElement(XmlElementWithLocation element, ProjectElementContainer parent)
         {
-            ProjectXmlUtilities.VerifyThrowProjectAttributes(element, ValidAttributesOnlyConditionAndLabel);
+            ProjectXmlUtilities.VerifyThrowProjectAttributes(element, ValidAttributesOnlyConditionAndLabel, _unknownElementsConfiguration);
 
             ProjectItemDefinitionGroupElement itemDefinitionGroup = new ProjectItemDefinitionGroupElement(element, parent, _project);
 
@@ -737,7 +760,10 @@ namespace Microsoft.Build.Construction
 
                 if (!isKnownAttribute && !isValidMetadataNameInAttribute)
                 {
-                    ProjectXmlUtilities.ThrowProjectInvalidAttribute(attribute);
+                    if (_unknownElementsConfiguration?.CheckSkipAttribute("ItemDefinition", attribute.Name) != true)
+                    {
+                        ProjectXmlUtilities.ThrowProjectInvalidAttribute(attribute);
+                    }
                 }
                 else if (isValidMetadataNameInAttribute)
                 {
@@ -749,7 +775,10 @@ namespace Microsoft.Build.Construction
                 }
                 else if (!ValidAttributesOnlyConditionAndLabel.Contains(attribute.Name))
                 {
-                    ProjectXmlUtilities.ThrowProjectInvalidAttribute(attribute);
+                    if (_unknownElementsConfiguration?.CheckSkipAttribute("ItemDefinition", attribute.Name) != true)
+                    {
+                        ProjectXmlUtilities.ThrowProjectInvalidAttribute(attribute);
+                    }
                 }
             }
 
@@ -768,7 +797,7 @@ namespace Microsoft.Build.Construction
         /// </summary>
         private ProjectChooseElement ParseProjectChooseElement(XmlElementWithLocation element, ProjectElementContainer parent, int nestingDepth)
         {
-            ProjectXmlUtilities.VerifyThrowProjectNoAttributes(element);
+            ProjectXmlUtilities.VerifyThrowProjectNoAttributes(element, _unknownElementsConfiguration);
 
             ProjectChooseElement choose = new ProjectChooseElement(element, parent, _project);
 
@@ -797,7 +826,11 @@ namespace Microsoft.Build.Construction
                         break;
 
                     default:
-                        ProjectXmlUtilities.ThrowProjectInvalidChildElement(childElement.Name, element.Name, element.Location);
+                        if (ProjectXmlUtilities.ThrowIfProjectInvalidChildElement(childElement.Name, element.Name, element.Location, _unknownElementsConfiguration))
+                        {
+                            continue;
+                        }
+
                         break;
                 }
 
@@ -828,7 +861,7 @@ namespace Microsoft.Build.Construction
         /// </summary>
         private ProjectOtherwiseElement ParseProjectOtherwiseElement(XmlElementWithLocation element, ProjectChooseElement parent, int nestingDepth)
         {
-            ProjectXmlUtilities.VerifyThrowProjectNoAttributes(element);
+            ProjectXmlUtilities.VerifyThrowProjectNoAttributes(element, _unknownElementsConfiguration);
 
             ProjectOtherwiseElement otherwise = new ProjectOtherwiseElement(element, parent, _project);
 
@@ -865,7 +898,11 @@ namespace Microsoft.Build.Construction
                         break;
 
                     default:
-                        ProjectXmlUtilities.ThrowProjectInvalidChildElement(childElement.Name, element.Name, element.Location);
+                        if (ProjectXmlUtilities.ThrowIfProjectInvalidChildElement(childElement.Name, element.Name, element.Location, _unknownElementsConfiguration))
+                        {
+                            continue;
+                        }
+
                         break;
                 }
 
@@ -880,7 +917,7 @@ namespace Microsoft.Build.Construction
         {
             // ProjectExtensions are only found in the main project file - in fact, the code used to ignore them in imported
             // files. We don't.
-            ProjectXmlUtilities.VerifyThrowProjectNoAttributes(element);
+            ProjectXmlUtilities.VerifyThrowProjectNoAttributes(element, _unknownElementsConfiguration);
 
             ProjectErrorUtilities.VerifyThrowInvalidProject(!_seenProjectExtensions, element.Location, "DuplicateProjectExtensions");
             _seenProjectExtensions = true;

--- a/src/Build/Evaluation/ProjectRootElementCache.cs
+++ b/src/Build/Evaluation/ProjectRootElementCache.cs
@@ -147,7 +147,8 @@ namespace Microsoft.Build.Evaluation
         /// <summary>
         /// Creates an empty cache.
         /// </summary>
-        internal ProjectRootElementCache(bool autoReloadFromDisk, bool loadProjectsReadOnly = false)
+        internal ProjectRootElementCache(bool autoReloadFromDisk, bool loadProjectsReadOnly = false, UnknownElementsConfiguration unknownElementsConfiguration = null)
+            : base(unknownElementsConfiguration)
         {
             DebugTraceCache("Constructing with autoreload from disk: ", autoReloadFromDisk);
 

--- a/src/Build/Evaluation/ProjectRootElementCacheBase.cs
+++ b/src/Build/Evaluation/ProjectRootElementCacheBase.cs
@@ -12,7 +12,22 @@ namespace Microsoft.Build.Evaluation
     {
         public bool LoadProjectsReadOnly { get; protected set; }
 
-        internal UnknownElementsConfiguration UnknownElementsConfiguration { get; set; }
+        /// <summary>
+        /// The parse configuration every element in this cache was parsed under.
+        /// </summary>
+        /// <remarks>
+        /// Deliberately settable only at construction. A cache instance is bound to one configuration for
+        /// its lifetime, which makes it impossible to hold elements parsed under differing rules. Reuse
+        /// points that outlive a build (worker nodes, the MSBuild server) compare
+        /// <see cref="Evaluation.UnknownElementsConfiguration.Identity"/> and construct a new cache when it
+        /// differs, rather than mutating this one.
+        /// </remarks>
+        internal UnknownElementsConfiguration UnknownElementsConfiguration { get; }
+
+        protected ProjectRootElementCacheBase(UnknownElementsConfiguration unknownElementsConfiguration)
+        {
+            UnknownElementsConfiguration = unknownElementsConfiguration ?? UnknownElementsConfiguration.Empty;
+        }
 
         /// <summary>
         /// Handler for which project root element just got added to the cache

--- a/src/Build/Evaluation/ProjectRootElementCacheBase.cs
+++ b/src/Build/Evaluation/ProjectRootElementCacheBase.cs
@@ -12,6 +12,8 @@ namespace Microsoft.Build.Evaluation
     {
         public bool LoadProjectsReadOnly { get; protected set; }
 
+        internal UnknownElementsConfiguration UnknownElementsConfiguration { get; set; }
+
         /// <summary>
         /// Handler for which project root element just got added to the cache
         /// </summary>

--- a/src/Build/Evaluation/SimpleProjectRootElementCache.cs
+++ b/src/Build/Evaluation/SimpleProjectRootElementCache.cs
@@ -27,7 +27,8 @@ namespace Microsoft.Build.Evaluation
     {
         private readonly ConcurrentDictionary<string, ProjectRootElement> _cache;
 
-        internal SimpleProjectRootElementCache()
+        internal SimpleProjectRootElementCache(UnknownElementsConfiguration unknownElementsConfiguration = null)
+            : base(unknownElementsConfiguration)
         {
             _cache = new ConcurrentDictionary<string, ProjectRootElement>(StringComparer.OrdinalIgnoreCase);
             LoadProjectsReadOnly = true;

--- a/src/Build/Evaluation/UnknownElementsConfiguration.cs
+++ b/src/Build/Evaluation/UnknownElementsConfiguration.cs
@@ -52,6 +52,20 @@ namespace Microsoft.Build.Evaluation
         /// </summary>
         private readonly ConcurrentDictionary<string, int> _skippedItems = new(StringComparer.OrdinalIgnoreCase);
 
+        /// <summary>
+        /// Config files resolved during this process, so that <c>BinaryLogger</c> can embed their contents.
+        /// A binary log that records which rules applied, but not what those rules were, cannot explain why a
+        /// project parsed the way it did. Mirrors how BuildCheck surfaces resolved <c>.editorconfig</c> files.
+        /// </summary>
+        private static ConcurrentBag<string> s_resolvedConfigFilePaths = new();
+
+        internal static IEnumerable<string> ResolvedConfigFilePaths => s_resolvedConfigFilePaths;
+
+        /// <summary>
+        /// Clears the collected paths after they have been embedded in the binary log.
+        /// </summary>
+        internal static void ClearResolvedConfigFilePaths() => s_resolvedConfigFilePaths = new ConcurrentBag<string>();
+
         private UnknownElementsConfiguration()
         {
             _allowedAttributes = FrozenDictionary<string, FrozenSet<string>>.Empty;
@@ -126,6 +140,7 @@ namespace Microsoft.Build.Evaluation
             if (file.Exists)
             {
                 loadedFiles.Add(file.FullPath);
+                s_resolvedConfigFilePaths.Add(file.FullPath);
 
                 foreach (string problem in file.Problems)
                 {

--- a/src/Build/Evaluation/UnknownElementsConfiguration.cs
+++ b/src/Build/Evaluation/UnknownElementsConfiguration.cs
@@ -3,41 +3,62 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using Microsoft.Build.BackEnd;
 using Microsoft.Build.Framework;
-using Microsoft.Build.Shared;
 using Microsoft.Build.Shared.FileSystem;
 
 namespace Microsoft.Build.Evaluation
 {
     /// <summary>
-    /// Manages a set of allowed unknown attributes and elements that should be silently skipped
-    /// during project parsing instead of throwing an InvalidProjectFileException.
-    /// Configuration is loaded from Directory.Parse.config files discovered additively from:
-    /// 1. Next to the MSBuild executable
-    /// 2. User profile (~/.msbuild/)
-    /// 3. MSBUILD_PARSE_CONFIG environment variable paths
+    /// An immutable set of allowed unknown attributes and elements that are silently skipped during
+    /// project parsing instead of throwing an InvalidProjectFileException (MSB4066/MSB4067).
     /// </summary>
-    internal sealed class UnknownElementsConfiguration : ITranslatable
+    /// <remarks>
+    /// The configuration is resolved exactly once per build, anchored on the entry project's directory,
+    /// by walking up for <c>Directory.Parse.config</c> files. The walk stops at a file declaring
+    /// <c>root = true</c>; entries from nearer files win over farther ones.
+    ///
+    /// Instances are immutable and carry a content-based <see cref="Identity"/>. A
+    /// <see cref="ProjectRootElementCache"/> is constructed with one configuration and keeps it for its
+    /// lifetime, so a cache can never hold elements parsed under differing rules. Reuse points
+    /// (worker nodes, the MSBuild server) compare <see cref="Identity"/> and replace the cache when it
+    /// differs rather than mutating shared state.
+    /// </remarks>
+    internal sealed class UnknownElementsConfiguration : ITranslatable, IEquatable<UnknownElementsConfiguration>
     {
         internal const string ConfigFileName = "Directory.Parse.config";
-        internal const string EnvironmentVariableName = "MSBUILD_PARSE_CONFIG";
 
-        private const string UserProfileSubfolder = ".msbuild";
+        private const string AttributeTypeName = "Attribute";
+        private const string ElementTypeName = "Element";
+        private const string RootKeyName = "root";
 
-        private Dictionary<string, HashSet<string>> _allowedAttributes;
-        private Dictionary<string, HashSet<string>> _allowedChildren;
+        private FrozenDictionary<string, FrozenSet<string>> _allowedAttributes;
+        private FrozenDictionary<string, FrozenSet<string>> _allowedChildren;
         private HashSet<string> _loadedConfigFiles;
+        private HashSet<string> _malformedEntries;
+
+        /// <summary>
+        /// Content-based identity. Empty string for a configuration that permits nothing, so every
+        /// build without a config file shares one identity and behaves exactly as it did before.
+        /// </summary>
+        private string _identity;
+
+        /// <summary>
+        /// Diagnostic-only counters. Not part of <see cref="Identity"/> or equality.
+        /// </summary>
         private readonly ConcurrentDictionary<string, int> _skippedItems = new(StringComparer.OrdinalIgnoreCase);
 
         private UnknownElementsConfiguration()
         {
-            _allowedAttributes = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
-            _allowedChildren = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
+            _allowedAttributes = FrozenDictionary<string, FrozenSet<string>>.Empty;
+            _allowedChildren = FrozenDictionary<string, FrozenSet<string>>.Empty;
             _loadedConfigFiles = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            _malformedEntries = new HashSet<string>(StringComparer.Ordinal);
+            _identity = string.Empty;
         }
 
         private UnknownElementsConfiguration(ITranslator translator)
@@ -46,28 +67,125 @@ namespace Microsoft.Build.Evaluation
             ((ITranslatable)this).Translate(translator);
         }
 
-        internal IReadOnlyCollection<string> LoadedConfigFiles => _loadedConfigFiles;
-
+        /// <summary>
+        /// The configuration that permits nothing. Used wherever no config file applies, so callers
+        /// never have to deal with null.
+        /// </summary>
         internal static UnknownElementsConfiguration Empty { get; } = new UnknownElementsConfiguration();
 
+        internal string Identity => _identity;
+
+        internal bool IsEmpty => _identity.Length == 0;
+
+        internal IReadOnlyCollection<string> LoadedConfigFiles => _loadedConfigFiles;
+
         /// <summary>
-        /// Checks whether the given file path has already been loaded into this configuration.
+        /// Resolves the configuration that applies to a build anchored at <paramref name="startingDirectory"/>,
+        /// which should be the directory of the entry project (or the current directory when no project
+        /// was specified). Walks up collecting <c>Directory.Parse.config</c> files, nearest first,
+        /// stopping at one that declares <c>root = true</c>.
         /// </summary>
-        internal bool ContainsLoadedFile(string filePath)
+        internal static UnknownElementsConfiguration Resolve(string? startingDirectory)
         {
-            if (string.IsNullOrEmpty(filePath))
+            if (string.IsNullOrEmpty(startingDirectory) || Traits.Instance.EscapeHatches.DisableParseConfig)
             {
-                return false;
+                return Empty;
             }
 
-            try
+            List<string> chain = DiscoverConfigFiles(startingDirectory!);
+            return chain.Count == 0 ? Empty : LoadFromFiles(chain);
+        }
+
+        /// <summary>
+        /// Returns the config files applying to <paramref name="startingDirectory"/>, ordered nearest first.
+        /// </summary>
+        private static List<string> DiscoverConfigFiles(string startingDirectory)
+        {
+            List<string> chain = new();
+
+            string? searchDirectory = startingDirectory;
+            while (!string.IsNullOrEmpty(searchDirectory))
             {
-                return _loadedConfigFiles.Contains(FileUtilities.NormalizePath(filePath));
+                string configPath;
+                try
+                {
+                    configPath = FileUtilities.GetPathOfFileAbove(ConfigFileName, searchDirectory);
+                }
+                catch
+                {
+                    break;
+                }
+
+                if (string.IsNullOrEmpty(configPath))
+                {
+                    break;
+                }
+
+                chain.Add(configPath);
+
+                if (IsRootConfig(configPath))
+                {
+                    break;
+                }
+
+                // Continue searching from the parent of the directory that contained the file we just found.
+                searchDirectory = Path.GetDirectoryName(Path.GetDirectoryName(configPath));
             }
-            catch
+
+            return chain;
+        }
+
+        /// <summary>
+        /// Builds a configuration from a single config file. Convenience for tests and callers that already
+        /// know the exact file.
+        /// </summary>
+        internal static UnknownElementsConfiguration LoadFromFile(string filePath)
+            => LoadFromFiles(new[] { filePath });
+
+        /// <summary>
+        /// Builds a configuration from an ordered list of config file paths, nearest first.
+        /// Entries are applied farthest-first so nearer files take precedence.
+        /// </summary>
+        internal static UnknownElementsConfiguration LoadFromFiles(IReadOnlyList<string> configFilePathsNearestFirst)
+        {
+            ArgumentNullException.ThrowIfNull(configFilePathsNearestFirst);
+
+            Dictionary<string, HashSet<string>> attributes = NewNameMap();
+            Dictionary<string, HashSet<string>> children = NewNameMap();
+            HashSet<string> loadedFiles = new(StringComparer.OrdinalIgnoreCase);
+            HashSet<string> malformed = new(StringComparer.Ordinal);
+
+            for (int i = configFilePathsNearestFirst.Count - 1; i >= 0; i--)
             {
-                return false;
+                LoadFile(configFilePathsNearestFirst[i], attributes, children, loadedFiles, malformed);
             }
+
+            if (attributes.Count == 0 && children.Count == 0)
+            {
+                // Nothing was permitted; still surface which files were read so diagnostics are accurate,
+                // but keep the canonical empty identity so caches remain shared.
+                UnknownElementsConfiguration emptyWithProvenance = new();
+                emptyWithProvenance._loadedConfigFiles = loadedFiles;
+                emptyWithProvenance._malformedEntries = malformed;
+                return emptyWithProvenance;
+            }
+
+            UnknownElementsConfiguration config = new();
+            config.Initialize(attributes, children, loadedFiles, malformed);
+            return config;
+        }
+
+        private void Initialize(
+            Dictionary<string, HashSet<string>> attributes,
+            Dictionary<string, HashSet<string>> children,
+            HashSet<string> loadedFiles,
+            HashSet<string> malformed)
+        {
+            _allowedAttributes = Freeze(attributes);
+            _allowedChildren = Freeze(children);
+            _loadedConfigFiles = loadedFiles;
+            _malformedEntries = malformed;
+            _identity = ComputeIdentity(attributes, children);
         }
 
         internal bool CheckSkipAttribute(string elementName, string attributeName)
@@ -77,12 +195,12 @@ namespace Microsoft.Build.Evaluation
                 return false;
             }
 
-            if (!_allowedAttributes.TryGetValue(elementName, out HashSet<string>? allowedAttributes) || !allowedAttributes.Contains(attributeName))
+            if (!_allowedAttributes.TryGetValue(elementName, out FrozenSet<string>? allowedAttributes) || !allowedAttributes.Contains(attributeName))
             {
                 return false;
             }
 
-            RecordSkippedItem($"Attribute:{elementName}:{attributeName}");
+            RecordSkippedItem($"{AttributeTypeName}:{elementName}:{attributeName}");
             return true;
         }
 
@@ -93,12 +211,12 @@ namespace Microsoft.Build.Evaluation
                 return false;
             }
 
-            if (!_allowedChildren.TryGetValue(parentElementName, out HashSet<string>? allowedChildren) || !allowedChildren.Contains(childElementName))
+            if (!_allowedChildren.TryGetValue(parentElementName, out FrozenSet<string>? allowedChildren) || !allowedChildren.Contains(childElementName))
             {
                 return false;
             }
 
-            RecordSkippedItem($"Element:{parentElementName}:{childElementName}");
+            RecordSkippedItem($"{ElementTypeName}:{parentElementName}:{childElementName}");
             return true;
         }
 
@@ -109,8 +227,8 @@ namespace Microsoft.Build.Evaluation
                 return null;
             }
 
-            var sb = new StringBuilder("Skipped unrecognized items allowed by Directory.Parse.config:");
-            foreach (var kvp in _skippedItems)
+            StringBuilder sb = new("Skipped unrecognized items allowed by Directory.Parse.config:");
+            foreach (KeyValuePair<string, int> kvp in _skippedItems)
             {
                 sb.Append($" {kvp.Key} ({kvp.Value} occurrence{(kvp.Value > 1 ? "s" : string.Empty)});");
             }
@@ -129,79 +247,50 @@ namespace Microsoft.Build.Evaluation
             return $"Loaded Directory.Parse.config from: {string.Join(", ", _loadedConfigFiles)}";
         }
 
-        internal UnknownElementsConfiguration Merge(UnknownElementsConfiguration other)
+        /// <summary>
+        /// Lines that looked like entries but could not be understood. Surfaced so that a typo in a
+        /// config file does not silently present as an unrelated MSB4066/MSB4067.
+        /// </summary>
+        internal string? GetMalformedEntriesMessage()
         {
-            ArgumentNullException.ThrowIfNull(other);
+            if (_malformedEntries.Count == 0)
+            {
+                return null;
+            }
 
-            var merged = new UnknownElementsConfiguration();
-
-            UnionEntries(merged._allowedAttributes, _allowedAttributes);
-            UnionEntries(merged._allowedAttributes, other._allowedAttributes);
-            UnionEntries(merged._allowedChildren, _allowedChildren);
-            UnionEntries(merged._allowedChildren, other._allowedChildren);
-            merged._loadedConfigFiles.UnionWith(_loadedConfigFiles);
-            merged._loadedConfigFiles.UnionWith(other._loadedConfigFiles);
-            MergeSkippedItems(merged._skippedItems, _skippedItems);
-            MergeSkippedItems(merged._skippedItems, other._skippedItems);
-
-            return merged;
+            return $"Ignored malformed Directory.Parse.config entries: {string.Join("; ", _malformedEntries)}";
         }
 
-        internal static UnknownElementsConfiguration LoadFromFile(string filePath)
-        {
-            var config = new UnknownElementsConfiguration();
-            config.LoadFile(filePath);
-            return config;
-        }
+        public bool Equals(UnknownElementsConfiguration? other)
+            => other is not null && string.Equals(_identity, other._identity, StringComparison.Ordinal);
 
-        internal static UnknownElementsConfiguration LoadGlobalConfig(string? startingDirectory = null)
-        {
-            var config = new UnknownElementsConfiguration();
+        public override bool Equals(object? obj) => Equals(obj as UnknownElementsConfiguration);
 
-            string? msbuildExeDir = BuildEnvironmentHelper.Instance?.CurrentMSBuildToolsDirectory;
-            if (!string.IsNullOrEmpty(msbuildExeDir))
-            {
-                config.LoadFile(Path.Combine(msbuildExeDir, ConfigFileName));
-            }
-
-            string userProfile = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-            if (!string.IsNullOrEmpty(userProfile))
-            {
-                config.LoadFile(Path.Combine(userProfile, UserProfileSubfolder, ConfigFileName));
-            }
-
-            string? envValue = Environment.GetEnvironmentVariable(EnvironmentVariableName);
-            if (!string.IsNullOrEmpty(envValue))
-            {
-                string[] paths = envValue.Split(new[] { Path.PathSeparator }, StringSplitOptions.RemoveEmptyEntries);
-                foreach (string path in paths)
-                {
-                    string trimmedPath = path.Trim();
-                    if (trimmedPath.Length > 0)
-                    {
-                        config.LoadFile(trimmedPath);
-                    }
-                }
-            }
-
-            // Walk up from the starting directory looking for a Directory.Parse.config
-            if (!string.IsNullOrEmpty(startingDirectory))
-            {
-                string directoryConfigPath = FileUtilities.GetPathOfFileAbove(ConfigFileName, startingDirectory!);
-                if (!string.IsNullOrEmpty(directoryConfigPath) && !config.ContainsLoadedFile(directoryConfigPath))
-                {
-                    config.LoadFile(directoryConfigPath);
-                }
-            }
-
-            return config;
-        }
+        public override int GetHashCode() => StringComparer.Ordinal.GetHashCode(_identity);
 
         void ITranslatable.Translate(ITranslator translator)
         {
-            translator.TranslateDictionary(ref _allowedAttributes, StringComparer.OrdinalIgnoreCase, TranslateHashSetValue, HashSetValueFactory);
-            translator.TranslateDictionary(ref _allowedChildren, StringComparer.OrdinalIgnoreCase, TranslateHashSetValue, HashSetValueFactory);
+            Dictionary<string, HashSet<string>> attributes = Thaw(_allowedAttributes);
+            Dictionary<string, HashSet<string>> children = Thaw(_allowedChildren);
+
+            translator.TranslateDictionary(ref attributes, StringComparer.OrdinalIgnoreCase, TranslateHashSetValue, HashSetValueFactory);
+            translator.TranslateDictionary(ref children, StringComparer.OrdinalIgnoreCase, TranslateHashSetValue, HashSetValueFactory);
             translator.Translate(ref _loadedConfigFiles);
+            translator.Translate(ref _malformedEntries);
+
+            if (translator.Mode == TranslationDirection.ReadFromStream)
+            {
+                Initialize(
+                    attributes ?? NewNameMap(),
+                    children ?? NewNameMap(),
+                    _loadedConfigFiles ?? new HashSet<string>(StringComparer.OrdinalIgnoreCase),
+                    _malformedEntries ?? new HashSet<string>(StringComparer.Ordinal));
+            }
+        }
+
+        internal static UnknownElementsConfiguration FactoryForDeserialization(ITranslator translator)
+        {
+            return new UnknownElementsConfiguration(translator);
         }
 
         private static void TranslateHashSetValue(ITranslator translator, NodePacketValueFactory<HashSet<string>> factory, ref HashSet<string> value)
@@ -216,30 +305,63 @@ namespace Microsoft.Build.Evaluation
             return set ?? new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         }
 
-        internal static UnknownElementsConfiguration FactoryForDeserialization(ITranslator translator)
-        {
-            return new UnknownElementsConfiguration(translator);
-        }
+        private static Dictionary<string, HashSet<string>> NewNameMap()
+            => new(StringComparer.OrdinalIgnoreCase);
 
-        private static void UnionEntries(Dictionary<string, HashSet<string>> destination, Dictionary<string, HashSet<string>> source)
+        private static FrozenDictionary<string, FrozenSet<string>> Freeze(Dictionary<string, HashSet<string>> source)
         {
-            foreach (var kvp in source)
+            if (source.Count == 0)
             {
-                if (!destination.TryGetValue(kvp.Key, out HashSet<string>? names))
-                {
-                    names = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-                    destination[kvp.Key] = names;
-                }
-
-                names.UnionWith(kvp.Value);
+                return FrozenDictionary<string, FrozenSet<string>>.Empty;
             }
+
+            Dictionary<string, FrozenSet<string>> frozenValues = new(source.Count, StringComparer.OrdinalIgnoreCase);
+            foreach (KeyValuePair<string, HashSet<string>> kvp in source)
+            {
+                frozenValues[kvp.Key] = kvp.Value.ToFrozenSet(StringComparer.OrdinalIgnoreCase);
+            }
+
+            return frozenValues.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
         }
 
-        private static void MergeSkippedItems(ConcurrentDictionary<string, int> destination, ConcurrentDictionary<string, int> source)
+        private static Dictionary<string, HashSet<string>> Thaw(FrozenDictionary<string, FrozenSet<string>> source)
         {
-            foreach (var kvp in source)
+            Dictionary<string, HashSet<string>> result = new(source.Count, StringComparer.OrdinalIgnoreCase);
+            foreach (KeyValuePair<string, FrozenSet<string>> kvp in source)
             {
-                destination.AddOrUpdate(kvp.Key, kvp.Value, (_, count) => count + kvp.Value);
+                result[kvp.Key] = new HashSet<string>(kvp.Value, StringComparer.OrdinalIgnoreCase);
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// A stable, order-independent rendering of the permitted names. Two configurations reached via
+        /// different files but permitting the same names are interchangeable and share a cache.
+        /// </summary>
+        private static string ComputeIdentity(Dictionary<string, HashSet<string>> attributes, Dictionary<string, HashSet<string>> children)
+        {
+            if (attributes.Count == 0 && children.Count == 0)
+            {
+                return string.Empty;
+            }
+
+            List<string> entries = new();
+            AppendEntries(entries, AttributeTypeName, attributes);
+            AppendEntries(entries, ElementTypeName, children);
+            entries.Sort(StringComparer.OrdinalIgnoreCase);
+
+            return string.Join("\n", entries);
+
+            static void AppendEntries(List<string> entries, string type, Dictionary<string, HashSet<string>> source)
+            {
+                foreach (KeyValuePair<string, HashSet<string>> kvp in source)
+                {
+                    foreach (string name in kvp.Value)
+                    {
+                        entries.Add($"{type}:{kvp.Key}:{name}");
+                    }
+                }
             }
         }
 
@@ -248,7 +370,60 @@ namespace Microsoft.Build.Evaluation
             _skippedItems.AddOrUpdate(key, 1, static (_, count) => count + 1);
         }
 
-        private void LoadFile(string filePath)
+        /// <summary>
+        /// Returns true if the config file declares <c>root = true</c>, which terminates the upward walk.
+        /// </summary>
+        private static bool IsRootConfig(string filePath)
+        {
+            try
+            {
+                foreach (string rawLine in File.ReadLines(filePath))
+                {
+                    if (TryParseRootDeclaration(rawLine, out bool isRoot))
+                    {
+                        return isRoot;
+                    }
+                }
+            }
+            catch (Exception e) when (ExceptionHandling.IsIoRelatedException(e))
+            {
+                // A config we cannot read simply does not terminate the walk.
+            }
+
+            return false;
+        }
+
+        private static bool TryParseRootDeclaration(string rawLine, out bool isRoot)
+        {
+            isRoot = false;
+
+            string entry = rawLine.Trim();
+            if (entry.Length == 0 || entry[0] == '#')
+            {
+                return false;
+            }
+
+            int equals = entry.IndexOf('=');
+            if (equals < 0)
+            {
+                return false;
+            }
+
+            if (!entry.AsSpan(0, equals).Trim().Equals(RootKeyName.AsSpan(), StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            isRoot = entry.AsSpan(equals + 1).Trim().Equals(bool.TrueString.AsSpan(), StringComparison.OrdinalIgnoreCase);
+            return true;
+        }
+
+        private static void LoadFile(
+            string filePath,
+            Dictionary<string, HashSet<string>> attributes,
+            Dictionary<string, HashSet<string>> children,
+            HashSet<string> loadedFiles,
+            HashSet<string> malformed)
         {
             if (string.IsNullOrEmpty(filePath))
             {
@@ -265,51 +440,80 @@ namespace Microsoft.Build.Evaluation
                 return;
             }
 
-            if (!FileSystems.Default.FileExists(fullPath) || !_loadedConfigFiles.Add(fullPath))
+            if (!FileSystems.Default.FileExists(fullPath) || !loadedFiles.Add(fullPath))
             {
                 return;
             }
 
-            foreach (string rawLine in File.ReadLines(filePath))
+            IEnumerable<string> lines;
+            try
             {
-                string entry = rawLine.Trim();
-                if (string.IsNullOrEmpty(entry) || entry[0] == '#')
-                {
-                    continue;
-                }
-
-                int firstColon = entry.IndexOf(':');
-                if (firstColon < 0)
-                {
-                    continue;
-                }
-
-                int secondColon = entry.IndexOf(':', firstColon + 1);
-                if (secondColon < 0 || entry.IndexOf(':', secondColon + 1) >= 0)
-                {
-                    continue;
-                }
-
-                string type = entry.Substring(0, firstColon).Trim();
-                string elementName = entry.Substring(firstColon + 1, secondColon - firstColon - 1).Trim();
-                string unknownName = entry.Substring(secondColon + 1).Trim();
-
-                if (type.Length == 0 || elementName.Length == 0 || unknownName.Length == 0)
-                {
-                    continue;
-                }
-
-                if (type.Equals("ATTRIBUTE", StringComparison.OrdinalIgnoreCase))
-                {
-                    AddAllowedName(_allowedAttributes, elementName, unknownName);
-                }
-                else if (type.Equals("ELEMENT", StringComparison.OrdinalIgnoreCase))
-                {
-                    AddAllowedName(_allowedChildren, elementName, unknownName);
-                }
+                lines = File.ReadAllLines(fullPath);
+            }
+            catch (Exception e) when (ExceptionHandling.IsIoRelatedException(e))
+            {
+                return;
             }
 
-            _loadedConfigFiles.Add(fullPath);
+            foreach (string rawLine in lines)
+            {
+                string entry = rawLine.Trim();
+                if (entry.Length == 0 || entry[0] == '#')
+                {
+                    continue;
+                }
+
+                if (TryParseRootDeclaration(entry, out _))
+                {
+                    continue;
+                }
+
+                if (!TryParseEntry(entry, out bool isAttribute, out string elementName, out string unknownName))
+                {
+                    // Recorded rather than dropped: a typo here would otherwise present as an
+                    // unrelated MSB4066/MSB4067 with no hint that the config was at fault.
+                    malformed.Add($"{fullPath}: {entry}");
+                    continue;
+                }
+
+                AddAllowedName(isAttribute ? attributes : children, elementName, unknownName);
+            }
+        }
+
+        private static bool TryParseEntry(string entry, out bool isAttribute, out string elementName, out string unknownName)
+        {
+            isAttribute = false;
+            elementName = string.Empty;
+            unknownName = string.Empty;
+
+            int firstColon = entry.IndexOf(':');
+            if (firstColon < 0)
+            {
+                return false;
+            }
+
+            int secondColon = entry.IndexOf(':', firstColon + 1);
+            if (secondColon < 0 || entry.IndexOf(':', secondColon + 1) >= 0)
+            {
+                return false;
+            }
+
+            string type = entry.Substring(0, firstColon).Trim();
+            elementName = entry.Substring(firstColon + 1, secondColon - firstColon - 1).Trim();
+            unknownName = entry.Substring(secondColon + 1).Trim();
+
+            if (elementName.Length == 0 || unknownName.Length == 0)
+            {
+                return false;
+            }
+
+            if (type.Equals(AttributeTypeName, StringComparison.OrdinalIgnoreCase))
+            {
+                isAttribute = true;
+                return true;
+            }
+
+            return type.Equals(ElementTypeName, StringComparison.OrdinalIgnoreCase);
         }
 
         private static void AddAllowedName(Dictionary<string, HashSet<string>> destination, string elementName, string unknownName)

--- a/src/Build/Evaluation/UnknownElementsConfiguration.cs
+++ b/src/Build/Evaluation/UnknownElementsConfiguration.cs
@@ -1,0 +1,326 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Microsoft.Build.BackEnd;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Shared;
+using Microsoft.Build.Shared.FileSystem;
+
+namespace Microsoft.Build.Evaluation
+{
+    /// <summary>
+    /// Manages a set of allowed unknown attributes and elements that should be silently skipped
+    /// during project parsing instead of throwing an InvalidProjectFileException.
+    /// Configuration is loaded from Directory.Parse.config files discovered additively from:
+    /// 1. Next to the MSBuild executable
+    /// 2. User profile (~/.msbuild/)
+    /// 3. MSBUILD_PARSE_CONFIG environment variable paths
+    /// </summary>
+    internal sealed class UnknownElementsConfiguration : ITranslatable
+    {
+        internal const string ConfigFileName = "Directory.Parse.config";
+        internal const string EnvironmentVariableName = "MSBUILD_PARSE_CONFIG";
+
+        private const string UserProfileSubfolder = ".msbuild";
+
+        private Dictionary<string, HashSet<string>> _allowedAttributes;
+        private Dictionary<string, HashSet<string>> _allowedChildren;
+        private HashSet<string> _loadedConfigFiles;
+        private readonly ConcurrentDictionary<string, int> _skippedItems = new(StringComparer.OrdinalIgnoreCase);
+
+        private UnknownElementsConfiguration()
+        {
+            _allowedAttributes = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
+            _allowedChildren = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
+            _loadedConfigFiles = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        }
+
+        private UnknownElementsConfiguration(ITranslator translator)
+            : this()
+        {
+            ((ITranslatable)this).Translate(translator);
+        }
+
+        internal IReadOnlyCollection<string> LoadedConfigFiles => _loadedConfigFiles;
+
+        internal static UnknownElementsConfiguration Empty { get; } = new UnknownElementsConfiguration();
+
+        /// <summary>
+        /// Checks whether the given file path has already been loaded into this configuration.
+        /// </summary>
+        internal bool ContainsLoadedFile(string filePath)
+        {
+            if (string.IsNullOrEmpty(filePath))
+            {
+                return false;
+            }
+
+            try
+            {
+                return _loadedConfigFiles.Contains(FileUtilities.NormalizePath(filePath));
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        internal bool CheckSkipAttribute(string elementName, string attributeName)
+        {
+            if (_allowedAttributes.Count == 0)
+            {
+                return false;
+            }
+
+            if (!_allowedAttributes.TryGetValue(elementName, out HashSet<string>? allowedAttributes) || !allowedAttributes.Contains(attributeName))
+            {
+                return false;
+            }
+
+            RecordSkippedItem($"Attribute:{elementName}:{attributeName}");
+            return true;
+        }
+
+        internal bool CheckSkipElement(string parentElementName, string childElementName)
+        {
+            if (_allowedChildren.Count == 0)
+            {
+                return false;
+            }
+
+            if (!_allowedChildren.TryGetValue(parentElementName, out HashSet<string>? allowedChildren) || !allowedChildren.Contains(childElementName))
+            {
+                return false;
+            }
+
+            RecordSkippedItem($"Element:{parentElementName}:{childElementName}");
+            return true;
+        }
+
+        internal string? GetSkippedSummaryMessage()
+        {
+            if (_skippedItems.IsEmpty)
+            {
+                return null;
+            }
+
+            var sb = new StringBuilder("Skipped unrecognized items allowed by Directory.Parse.config:");
+            foreach (var kvp in _skippedItems)
+            {
+                sb.Append($" {kvp.Key} ({kvp.Value} occurrence{(kvp.Value > 1 ? "s" : string.Empty)});");
+            }
+
+            sb.Length--;
+            return sb.ToString();
+        }
+
+        internal string? GetLoadedConfigsMessage()
+        {
+            if (_loadedConfigFiles.Count == 0)
+            {
+                return null;
+            }
+
+            return $"Loaded Directory.Parse.config from: {string.Join(", ", _loadedConfigFiles)}";
+        }
+
+        internal UnknownElementsConfiguration Merge(UnknownElementsConfiguration other)
+        {
+            ArgumentNullException.ThrowIfNull(other);
+
+            var merged = new UnknownElementsConfiguration();
+
+            UnionEntries(merged._allowedAttributes, _allowedAttributes);
+            UnionEntries(merged._allowedAttributes, other._allowedAttributes);
+            UnionEntries(merged._allowedChildren, _allowedChildren);
+            UnionEntries(merged._allowedChildren, other._allowedChildren);
+            merged._loadedConfigFiles.UnionWith(_loadedConfigFiles);
+            merged._loadedConfigFiles.UnionWith(other._loadedConfigFiles);
+            MergeSkippedItems(merged._skippedItems, _skippedItems);
+            MergeSkippedItems(merged._skippedItems, other._skippedItems);
+
+            return merged;
+        }
+
+        internal static UnknownElementsConfiguration LoadFromFile(string filePath)
+        {
+            var config = new UnknownElementsConfiguration();
+            config.LoadFile(filePath);
+            return config;
+        }
+
+        internal static UnknownElementsConfiguration LoadGlobalConfig(string? startingDirectory = null)
+        {
+            var config = new UnknownElementsConfiguration();
+
+            string? msbuildExeDir = BuildEnvironmentHelper.Instance?.CurrentMSBuildToolsDirectory;
+            if (!string.IsNullOrEmpty(msbuildExeDir))
+            {
+                config.LoadFile(Path.Combine(msbuildExeDir, ConfigFileName));
+            }
+
+            string userProfile = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+            if (!string.IsNullOrEmpty(userProfile))
+            {
+                config.LoadFile(Path.Combine(userProfile, UserProfileSubfolder, ConfigFileName));
+            }
+
+            string? envValue = Environment.GetEnvironmentVariable(EnvironmentVariableName);
+            if (!string.IsNullOrEmpty(envValue))
+            {
+                string[] paths = envValue.Split(new[] { Path.PathSeparator }, StringSplitOptions.RemoveEmptyEntries);
+                foreach (string path in paths)
+                {
+                    string trimmedPath = path.Trim();
+                    if (trimmedPath.Length > 0)
+                    {
+                        config.LoadFile(trimmedPath);
+                    }
+                }
+            }
+
+            // Walk up from the starting directory looking for a Directory.Parse.config
+            if (!string.IsNullOrEmpty(startingDirectory))
+            {
+                string directoryConfigPath = FileUtilities.GetPathOfFileAbove(ConfigFileName, startingDirectory!);
+                if (!string.IsNullOrEmpty(directoryConfigPath) && !config.ContainsLoadedFile(directoryConfigPath))
+                {
+                    config.LoadFile(directoryConfigPath);
+                }
+            }
+
+            return config;
+        }
+
+        void ITranslatable.Translate(ITranslator translator)
+        {
+            translator.TranslateDictionary(ref _allowedAttributes, StringComparer.OrdinalIgnoreCase, TranslateHashSetValue, HashSetValueFactory);
+            translator.TranslateDictionary(ref _allowedChildren, StringComparer.OrdinalIgnoreCase, TranslateHashSetValue, HashSetValueFactory);
+            translator.Translate(ref _loadedConfigFiles);
+        }
+
+        private static void TranslateHashSetValue(ITranslator translator, NodePacketValueFactory<HashSet<string>> factory, ref HashSet<string> value)
+        {
+            translator.Translate(ref value);
+        }
+
+        private static HashSet<string> HashSetValueFactory(ITranslator translator)
+        {
+            HashSet<string>? set = null;
+            translator.Translate(ref set);
+            return set ?? new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        }
+
+        internal static UnknownElementsConfiguration FactoryForDeserialization(ITranslator translator)
+        {
+            return new UnknownElementsConfiguration(translator);
+        }
+
+        private static void UnionEntries(Dictionary<string, HashSet<string>> destination, Dictionary<string, HashSet<string>> source)
+        {
+            foreach (var kvp in source)
+            {
+                if (!destination.TryGetValue(kvp.Key, out HashSet<string>? names))
+                {
+                    names = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                    destination[kvp.Key] = names;
+                }
+
+                names.UnionWith(kvp.Value);
+            }
+        }
+
+        private static void MergeSkippedItems(ConcurrentDictionary<string, int> destination, ConcurrentDictionary<string, int> source)
+        {
+            foreach (var kvp in source)
+            {
+                destination.AddOrUpdate(kvp.Key, kvp.Value, (_, count) => count + kvp.Value);
+            }
+        }
+
+        private void RecordSkippedItem(string key)
+        {
+            _skippedItems.AddOrUpdate(key, 1, static (_, count) => count + 1);
+        }
+
+        private void LoadFile(string filePath)
+        {
+            if (string.IsNullOrEmpty(filePath))
+            {
+                return;
+            }
+
+            string fullPath;
+            try
+            {
+                fullPath = FileUtilities.NormalizePath(filePath);
+            }
+            catch
+            {
+                return;
+            }
+
+            if (!FileSystems.Default.FileExists(fullPath) || !_loadedConfigFiles.Add(fullPath))
+            {
+                return;
+            }
+
+            foreach (string rawLine in File.ReadLines(filePath))
+            {
+                string entry = rawLine.Trim();
+                if (string.IsNullOrEmpty(entry) || entry[0] == '#')
+                {
+                    continue;
+                }
+
+                int firstColon = entry.IndexOf(':');
+                if (firstColon < 0)
+                {
+                    continue;
+                }
+
+                int secondColon = entry.IndexOf(':', firstColon + 1);
+                if (secondColon < 0 || entry.IndexOf(':', secondColon + 1) >= 0)
+                {
+                    continue;
+                }
+
+                string type = entry.Substring(0, firstColon).Trim();
+                string elementName = entry.Substring(firstColon + 1, secondColon - firstColon - 1).Trim();
+                string unknownName = entry.Substring(secondColon + 1).Trim();
+
+                if (type.Length == 0 || elementName.Length == 0 || unknownName.Length == 0)
+                {
+                    continue;
+                }
+
+                if (type.Equals("ATTRIBUTE", StringComparison.OrdinalIgnoreCase))
+                {
+                    AddAllowedName(_allowedAttributes, elementName, unknownName);
+                }
+                else if (type.Equals("ELEMENT", StringComparison.OrdinalIgnoreCase))
+                {
+                    AddAllowedName(_allowedChildren, elementName, unknownName);
+                }
+            }
+
+            _loadedConfigFiles.Add(fullPath);
+        }
+
+        private static void AddAllowedName(Dictionary<string, HashSet<string>> destination, string elementName, string unknownName)
+        {
+            if (!destination.TryGetValue(elementName, out HashSet<string>? names))
+            {
+                names = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                destination[elementName] = names;
+            }
+
+            names.Add(unknownName);
+        }
+    }
+}

--- a/src/Build/Evaluation/UnknownElementsConfiguration.cs
+++ b/src/Build/Evaluation/UnknownElementsConfiguration.cs
@@ -20,8 +20,8 @@ namespace Microsoft.Build.Evaluation
     /// </summary>
     /// <remarks>
     /// The configuration is resolved exactly once per build, anchored on the entry project's directory,
-    /// by walking up for <c>Directory.Parse.config</c> files. The walk stops at a file declaring
-    /// <c>root = true</c>; entries from nearer files win over farther ones.
+    /// by walking up to the nearest <c>Directory.Parse.config</c>. First found wins: there is no layering,
+    /// matching how <c>Directory.Build.props</c> and <c>Directory.Build.rsp</c> are discovered.
     ///
     /// Instances are immutable and carry a content-based <see cref="Identity"/>. A
     /// <see cref="ProjectRootElementCache"/> is constructed with one configuration and keeps it for its
@@ -86,10 +86,10 @@ namespace Microsoft.Build.Evaluation
         /// </summary>
         /// <remarks>
         /// First found wins, with no layering, matching how <c>Directory.Build.props</c>,
-        /// <c>Directory.Build.rsp</c> and <c>Directory.Solution.props</c> are discovered. Layering would be
-        /// borrowing a per-file notion from <c>.editorconfig</c>, but a build resolves exactly one
-        /// configuration, so there is nothing for it to compose across. A nearer file that omits a permission
-        /// granted by a farther one fails loudly, with MSB4066/MSB4067 naming the attribute or element.
+        /// <c>Directory.Build.rsp</c> and <c>Directory.Solution.props</c> are discovered. Layering was
+        /// considered and rejected: a build resolves exactly one configuration, so there is nothing for it
+        /// to compose across. A nearer file that omits a permission granted by a farther one fails loudly,
+        /// with MSB4066/MSB4067 naming the attribute or element.
         /// </remarks>
         internal static UnknownElementsConfiguration Resolve(string? startingDirectory)
         {

--- a/src/Build/Evaluation/UnknownElementsConfiguration.cs
+++ b/src/Build/Evaluation/UnknownElementsConfiguration.cs
@@ -7,6 +7,7 @@ using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
+using System.Xml;
 using Microsoft.Build.BackEnd;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared.FileSystem;
@@ -34,7 +35,6 @@ namespace Microsoft.Build.Evaluation
 
         private const string AttributeTypeName = "Attribute";
         private const string ElementTypeName = "Element";
-        private const string RootKeyName = "root";
 
         private FrozenDictionary<string, FrozenSet<string>> _allowedAttributes;
         private FrozenDictionary<string, FrozenSet<string>> _allowedChildren;
@@ -82,9 +82,15 @@ namespace Microsoft.Build.Evaluation
         /// <summary>
         /// Resolves the configuration that applies to a build anchored at <paramref name="startingDirectory"/>,
         /// which should be the directory of the entry project (or the current directory when no project
-        /// was specified). Walks up collecting <c>Directory.Parse.config</c> files, nearest first,
-        /// stopping at one that declares <c>root = true</c>.
+        /// was specified). Walks up for the nearest <c>Directory.Parse.config</c> and uses that one.
         /// </summary>
+        /// <remarks>
+        /// First found wins, with no layering, matching how <c>Directory.Build.props</c>,
+        /// <c>Directory.Build.rsp</c> and <c>Directory.Solution.props</c> are discovered. Layering would be
+        /// borrowing a per-file notion from <c>.editorconfig</c>, but a build resolves exactly one
+        /// configuration, so there is nothing for it to compose across. A nearer file that omits a permission
+        /// granted by a farther one fails loudly, with MSB4066/MSB4067 naming the attribute or element.
+        /// </remarks>
         internal static UnknownElementsConfiguration Resolve(string? startingDirectory)
         {
             if (string.IsNullOrEmpty(startingDirectory) || Traits.Instance.EscapeHatches.DisableParseConfig)
@@ -92,72 +98,44 @@ namespace Microsoft.Build.Evaluation
                 return Empty;
             }
 
-            List<string> chain = DiscoverConfigFiles(startingDirectory!);
-            return chain.Count == 0 ? Empty : LoadFromFiles(chain);
-        }
-
-        /// <summary>
-        /// Returns the config files applying to <paramref name="startingDirectory"/>, ordered nearest first.
-        /// </summary>
-        private static List<string> DiscoverConfigFiles(string startingDirectory)
-        {
-            List<string> chain = new();
-
-            string? searchDirectory = startingDirectory;
-            while (!string.IsNullOrEmpty(searchDirectory))
+            string configPath;
+            try
             {
-                string configPath;
-                try
-                {
-                    configPath = FileUtilities.GetPathOfFileAbove(ConfigFileName, searchDirectory);
-                }
-                catch
-                {
-                    break;
-                }
-
-                if (string.IsNullOrEmpty(configPath))
-                {
-                    break;
-                }
-
-                chain.Add(configPath);
-
-                if (IsRootConfig(configPath))
-                {
-                    break;
-                }
-
-                // Continue searching from the parent of the directory that contained the file we just found.
-                searchDirectory = Path.GetDirectoryName(Path.GetDirectoryName(configPath));
+                configPath = FileUtilities.GetPathOfFileAbove(ConfigFileName, startingDirectory!);
+            }
+            catch
+            {
+                return Empty;
             }
 
-            return chain;
+            return string.IsNullOrEmpty(configPath) ? Empty : LoadFromFile(configPath);
         }
 
         /// <summary>
-        /// Builds a configuration from a single config file. Convenience for tests and callers that already
-        /// know the exact file.
+        /// Builds a configuration from a single config file.
         /// </summary>
         internal static UnknownElementsConfiguration LoadFromFile(string filePath)
-            => LoadFromFiles(new[] { filePath });
-
-        /// <summary>
-        /// Builds a configuration from an ordered list of config file paths, nearest first.
-        /// Entries are applied farthest-first so nearer files take precedence.
-        /// </summary>
-        internal static UnknownElementsConfiguration LoadFromFiles(IReadOnlyList<string> configFilePathsNearestFirst)
         {
-            ArgumentNullException.ThrowIfNull(configFilePathsNearestFirst);
+            ParsedConfigFile file = ParsedConfigFile.Read(filePath);
 
             Dictionary<string, HashSet<string>> attributes = NewNameMap();
             Dictionary<string, HashSet<string>> children = NewNameMap();
             HashSet<string> loadedFiles = new(StringComparer.OrdinalIgnoreCase);
             HashSet<string> malformed = new(StringComparer.Ordinal);
 
-            for (int i = configFilePathsNearestFirst.Count - 1; i >= 0; i--)
+            if (file.Exists)
             {
-                LoadFile(configFilePathsNearestFirst[i], attributes, children, loadedFiles, malformed);
+                loadedFiles.Add(file.FullPath);
+
+                foreach (string problem in file.Problems)
+                {
+                    malformed.Add(problem);
+                }
+
+                foreach ((bool isAttribute, string owner, string name) in file.Entries)
+                {
+                    AddAllowedName(isAttribute ? attributes : children, owner, name);
+                }
             }
 
             if (attributes.Count == 0 && children.Count == 0)
@@ -370,152 +348,6 @@ namespace Microsoft.Build.Evaluation
             _skippedItems.AddOrUpdate(key, 1, static (_, count) => count + 1);
         }
 
-        /// <summary>
-        /// Returns true if the config file declares <c>root = true</c>, which terminates the upward walk.
-        /// </summary>
-        private static bool IsRootConfig(string filePath)
-        {
-            try
-            {
-                foreach (string rawLine in File.ReadLines(filePath))
-                {
-                    if (TryParseRootDeclaration(rawLine, out bool isRoot))
-                    {
-                        return isRoot;
-                    }
-                }
-            }
-            catch (Exception e) when (ExceptionHandling.IsIoRelatedException(e))
-            {
-                // A config we cannot read simply does not terminate the walk.
-            }
-
-            return false;
-        }
-
-        private static bool TryParseRootDeclaration(string rawLine, out bool isRoot)
-        {
-            isRoot = false;
-
-            string entry = rawLine.Trim();
-            if (entry.Length == 0 || entry[0] == '#')
-            {
-                return false;
-            }
-
-            int equals = entry.IndexOf('=');
-            if (equals < 0)
-            {
-                return false;
-            }
-
-            if (!entry.AsSpan(0, equals).Trim().Equals(RootKeyName.AsSpan(), StringComparison.OrdinalIgnoreCase))
-            {
-                return false;
-            }
-
-            isRoot = entry.AsSpan(equals + 1).Trim().Equals(bool.TrueString.AsSpan(), StringComparison.OrdinalIgnoreCase);
-            return true;
-        }
-
-        private static void LoadFile(
-            string filePath,
-            Dictionary<string, HashSet<string>> attributes,
-            Dictionary<string, HashSet<string>> children,
-            HashSet<string> loadedFiles,
-            HashSet<string> malformed)
-        {
-            if (string.IsNullOrEmpty(filePath))
-            {
-                return;
-            }
-
-            string fullPath;
-            try
-            {
-                fullPath = FileUtilities.NormalizePath(filePath);
-            }
-            catch
-            {
-                return;
-            }
-
-            if (!FileSystems.Default.FileExists(fullPath) || !loadedFiles.Add(fullPath))
-            {
-                return;
-            }
-
-            IEnumerable<string> lines;
-            try
-            {
-                lines = File.ReadAllLines(fullPath);
-            }
-            catch (Exception e) when (ExceptionHandling.IsIoRelatedException(e))
-            {
-                return;
-            }
-
-            foreach (string rawLine in lines)
-            {
-                string entry = rawLine.Trim();
-                if (entry.Length == 0 || entry[0] == '#')
-                {
-                    continue;
-                }
-
-                if (TryParseRootDeclaration(entry, out _))
-                {
-                    continue;
-                }
-
-                if (!TryParseEntry(entry, out bool isAttribute, out string elementName, out string unknownName))
-                {
-                    // Recorded rather than dropped: a typo here would otherwise present as an
-                    // unrelated MSB4066/MSB4067 with no hint that the config was at fault.
-                    malformed.Add($"{fullPath}: {entry}");
-                    continue;
-                }
-
-                AddAllowedName(isAttribute ? attributes : children, elementName, unknownName);
-            }
-        }
-
-        private static bool TryParseEntry(string entry, out bool isAttribute, out string elementName, out string unknownName)
-        {
-            isAttribute = false;
-            elementName = string.Empty;
-            unknownName = string.Empty;
-
-            int firstColon = entry.IndexOf(':');
-            if (firstColon < 0)
-            {
-                return false;
-            }
-
-            int secondColon = entry.IndexOf(':', firstColon + 1);
-            if (secondColon < 0 || entry.IndexOf(':', secondColon + 1) >= 0)
-            {
-                return false;
-            }
-
-            string type = entry.Substring(0, firstColon).Trim();
-            elementName = entry.Substring(firstColon + 1, secondColon - firstColon - 1).Trim();
-            unknownName = entry.Substring(secondColon + 1).Trim();
-
-            if (elementName.Length == 0 || unknownName.Length == 0)
-            {
-                return false;
-            }
-
-            if (type.Equals(AttributeTypeName, StringComparison.OrdinalIgnoreCase))
-            {
-                isAttribute = true;
-                return true;
-            }
-
-            return type.Equals(ElementTypeName, StringComparison.OrdinalIgnoreCase);
-        }
-
         private static void AddAllowedName(Dictionary<string, HashSet<string>> destination, string elementName, string unknownName)
         {
             if (!destination.TryGetValue(elementName, out HashSet<string>? names))
@@ -525,6 +357,163 @@ namespace Microsoft.Build.Evaluation
             }
 
             names.Add(unknownName);
+        }
+
+        /// <summary>
+        /// One <c>Directory.Parse.config</c> file, read from disk.
+        /// </summary>
+        /// <remarks>
+        /// The format is XML, matching both MSBuild itself and the other <c>.config</c> files in the
+        /// ecosystem (<c>NuGet.config</c>, <c>app.config</c>):
+        /// <code>
+        /// &lt;ParseConfig&gt;
+        ///   &lt;AllowAttribute Element="Target" Name="CustomAttr" /&gt;
+        ///   &lt;AllowElement Parent="Project" Name="ToolConfiguration" /&gt;
+        /// &lt;/ParseConfig&gt;
+        /// </code>
+        /// Unrecognised elements are ignored rather than rejected, so a future MSBuild can add directives
+        /// without older engines failing on files that use them. They are still reported, so that a typo
+        /// does not silently present later as an unrelated MSB4066/MSB4067.
+        /// </remarks>
+        private sealed class ParsedConfigFile
+        {
+            private const string RootElementName = "ParseConfig";
+            private const string AllowAttributeElementName = "AllowAttribute";
+            private const string AllowElementElementName = "AllowElement";
+            private const string ElementAttributeName = "Element";
+            private const string ParentAttributeName = "Parent";
+            private const string NameAttributeName = "Name";
+
+            private ParsedConfigFile(string fullPath, bool exists)
+            {
+                FullPath = fullPath;
+                Exists = exists;
+                Entries = new List<(bool, string, string)>();
+                Problems = new List<string>();
+            }
+
+            internal string FullPath { get; }
+
+            internal bool Exists { get; }
+
+            internal List<(bool IsAttribute, string Owner, string Name)> Entries { get; }
+
+            internal List<string> Problems { get; }
+
+            internal static ParsedConfigFile Read(string filePath)
+            {
+                string fullPath;
+                try
+                {
+                    fullPath = FileUtilities.NormalizePath(filePath);
+                }
+                catch
+                {
+                    return new ParsedConfigFile(filePath ?? string.Empty, exists: false);
+                }
+
+                if (!FileSystems.Default.FileExists(fullPath))
+                {
+                    return new ParsedConfigFile(fullPath, exists: false);
+                }
+
+                ParsedConfigFile result = new(fullPath, exists: true);
+
+                // DTD processing and external resolution are disabled: this file is read very early, from a
+                // repository that may not be trusted, and it has no need for either.
+                XmlReaderSettings settings = new()
+                {
+                    DtdProcessing = DtdProcessing.Prohibit,
+                    XmlResolver = null,
+                    IgnoreComments = true,
+                    IgnoreWhitespace = true,
+                    IgnoreProcessingInstructions = true,
+                    CloseInput = true,
+                };
+
+                try
+                {
+                    // The Stream overload is required by this repository's banned-API rules.
+                    using FileStream stream = File.OpenRead(fullPath);
+                    using XmlReader reader = XmlReader.Create(stream, settings);
+                    result.ReadDocument(reader);
+                }
+                catch (XmlException e)
+                {
+                    // A file that is not well-formed is not trusted at all: discard anything read before the
+                    // error rather than applying a partial configuration.
+                    result.Entries.Clear();
+                    result.Problems.Add($"{fullPath}: {e.Message}");
+                }
+                catch (Exception e) when (ExceptionHandling.IsIoRelatedException(e))
+                {
+                    // A config we cannot read contributes nothing and does not terminate the walk.
+                    return new ParsedConfigFile(fullPath, exists: false);
+                }
+
+                return result;
+            }
+
+            private void ReadDocument(XmlReader reader)
+            {
+                if (!reader.ReadToFollowing(RootElementName))
+                {
+                    Problems.Add($"{FullPath}: expected a <{RootElementName}> root element.");
+                    return;
+                }
+
+                if (reader.IsEmptyElement)
+                {
+                    return;
+                }
+
+                int depth = reader.Depth;
+                while (reader.Read())
+                {
+                    if (reader.NodeType == XmlNodeType.EndElement && reader.Depth <= depth)
+                    {
+                        break;
+                    }
+
+                    if (reader.NodeType != XmlNodeType.Element || reader.Depth != depth + 1)
+                    {
+                        continue;
+                    }
+
+                    ReadDirective(reader);
+                }
+            }
+
+            private void ReadDirective(XmlReader reader)
+            {
+                string directive = reader.LocalName;
+
+                if (string.Equals(directive, AllowAttributeElementName, StringComparison.OrdinalIgnoreCase))
+                {
+                    AddEntry(isAttribute: true, reader.GetAttribute(ElementAttributeName), reader.GetAttribute(NameAttributeName), directive, ElementAttributeName);
+                }
+                else if (string.Equals(directive, AllowElementElementName, StringComparison.OrdinalIgnoreCase))
+                {
+                    AddEntry(isAttribute: false, reader.GetAttribute(ParentAttributeName), reader.GetAttribute(NameAttributeName), directive, ParentAttributeName);
+                }
+                else
+                {
+                    // Forward compatibility: a directive this engine does not know is not an error, because a
+                    // newer MSBuild may define it. Reported so typos remain diagnosable.
+                    Problems.Add($"{FullPath}: ignored unrecognized directive <{directive}>.");
+                }
+            }
+
+            private void AddEntry(bool isAttribute, string? owner, string? name, string directive, string ownerAttributeName)
+            {
+                if (string.IsNullOrWhiteSpace(owner) || string.IsNullOrWhiteSpace(name))
+                {
+                    Problems.Add($"{FullPath}: <{directive}> requires non-empty {ownerAttributeName} and {NameAttributeName} attributes.");
+                    return;
+                }
+
+                Entries.Add((isAttribute, owner!.Trim(), name!.Trim()));
+            }
         }
     }
 }

--- a/src/Build/Instance/TaskRegistry.cs
+++ b/src/Build/Instance/TaskRegistry.cs
@@ -320,7 +320,9 @@ namespace Microsoft.Build.Execution
 
             if (String.IsNullOrEmpty(taskFactory) || taskFactory.Equals(RegisteredTaskRecord.AssemblyTaskFactory, StringComparison.OrdinalIgnoreCase) || taskFactory.Equals(RegisteredTaskRecord.TaskHostFactory, StringComparison.OrdinalIgnoreCase))
             {
-                ProjectXmlUtilities.VerifyThrowProjectNoChildElements(projectUsingTaskXml.XmlElement);
+                ProjectXmlUtilities.VerifyThrowProjectNoChildElements(
+                    projectUsingTaskXml.XmlElement,
+                    projectUsingTaskXml.ContainingProject.ProjectRootElementCache?.UnknownElementsConfiguration);
             }
 
             if (projectUsingTaskXml.AssemblyFile.Length > 0)

--- a/src/Build/Logging/BinaryLogger/BinaryLogger.cs
+++ b/src/Build/Logging/BinaryLogger/BinaryLogger.cs
@@ -1,10 +1,11 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
+using Microsoft.Build.Evaluation;
 using Microsoft.Build.Experimental.BuildCheck.Infrastructure.EditorConfig;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Framework.Telemetry;
@@ -511,6 +512,15 @@ namespace Microsoft.Build.Logging
                     projectImportsCollector.AddFile(filePath);
                 }
                 EditorConfigParser.ClearEditorConfigFilePaths();
+
+                // Directory.Parse.config decides whether projects parse at all, so its contents belong in the
+                // log alongside the message naming which file applied.
+                foreach (var filePath in UnknownElementsConfiguration.ResolvedConfigFilePaths)
+                {
+                    projectImportsCollector.AddFile(filePath);
+                }
+                UnknownElementsConfiguration.ClearResolvedConfigFilePaths();
+
                 projectImportsCollector.Close();
 
                 if (CollectProjectImports == ProjectImportsCollectionMode.Embed)

--- a/src/Build/Microsoft.Build.csproj
+++ b/src/Build/Microsoft.Build.csproj
@@ -543,6 +543,7 @@
     <Compile Include="Evaluation\ProjectRootElementCache.cs" />
     <Compile Include="Evaluation\SimpleProjectRootElementCache.cs" />
     <Compile Include="Evaluation\SemiColonTokenizer.cs" />
+    <Compile Include="Evaluation\UnknownElementsConfiguration.cs" />
     <Compile Include="Evaluation\StringMetadataTable.cs" />
     <Compile Include="Evaluation\ExpressionShredder.cs" />
     <Compile Include="Evaluation\Evaluator.cs" />

--- a/src/Build/Xml/ProjectXmlUtilities.XmlElementChildIterator.cs
+++ b/src/Build/Xml/ProjectXmlUtilities.XmlElementChildIterator.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -97,7 +97,7 @@ namespace Microsoft.Build.Internal
                             }
                             if (_throwForInvalidNodeTypes)
                             {
-                                ThrowProjectInvalidChildElement(child.Name, _element.Name, _element.Location);
+                                ThrowIfProjectInvalidChildElement(child.Name, _element.Name, _element.Location, config: null);
                             }
                             break;
                     }

--- a/src/Build/Xml/ProjectXmlUtilities.cs
+++ b/src/Build/Xml/ProjectXmlUtilities.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Xml;
 using Microsoft.Build.Construction;
+using Microsoft.Build.Evaluation;
 using Microsoft.Build.Framework.BuildException;
 using Microsoft.Build.Shared;
 
@@ -55,11 +56,11 @@ namespace Microsoft.Build.Internal
         /// <summary>
         /// Throw an invalid project exception if there are any child elements at all
         /// </summary>
-        internal static void VerifyThrowProjectNoChildElements(XmlElementWithLocation element)
+        internal static void VerifyThrowProjectNoChildElements(XmlElementWithLocation element, UnknownElementsConfiguration config = null)
         {
             foreach (var child in GetVerifyThrowProjectChildElements(element))
             {
-                ThrowProjectInvalidChildElement(child.Name, element.Name, element.Location);
+                ThrowIfProjectInvalidChildElement(child.Name, element.Name, element.Location, config);
             }
         }
 
@@ -70,14 +71,6 @@ namespace Microsoft.Build.Internal
         internal static void ThrowProjectInvalidChildElementDueToDuplicate(XmlElementWithLocation child)
         {
             ProjectErrorUtilities.ThrowInvalidProject(child.Location, "InvalidChildElementDueToDuplication", child.Name, child.ParentNode.Name);
-        }
-
-        /// <summary>
-        /// Throw an invalid project exception indicating that the child is not valid beneath the element
-        /// </summary>
-        internal static void ThrowProjectInvalidChildElement(string name, string parentName, ElementLocation location)
-        {
-            ProjectErrorUtilities.ThrowInvalidProject(location, "UnrecognizedChildElement", name, parentName);
         }
 
         /// <summary>
@@ -145,12 +138,17 @@ namespace Microsoft.Build.Internal
         /// <summary>
         /// If there are any attributes on the element, throws an InvalidProjectFileException complaining that the attribute is not valid on this element.
         /// </summary>
-        internal static void VerifyThrowProjectNoAttributes(XmlElementWithLocation element)
+        internal static void VerifyThrowProjectNoAttributes(XmlElementWithLocation element, UnknownElementsConfiguration config = null)
         {
             if (element.HasAttributes)
             {
                 foreach (XmlAttributeWithLocation attribute in element.Attributes)
                 {
+                    if (config?.CheckSkipAttribute(element.Name, attribute.Name) == true)
+                    {
+                        continue;
+                    }
+
                     ThrowProjectInvalidAttribute(attribute);
                 }
             }
@@ -177,14 +175,40 @@ namespace Microsoft.Build.Internal
         }
 
         /// <summary>
-        /// Verify  that all attributes on the element are on the list of legal attributes
+        /// Verify that all attributes on the element are on the list of legal attributes.
+        /// When genericElementName is provided, only that name is checked in the config (not the actual element name).
         /// </summary>
-        internal static void VerifyThrowProjectAttributes(XmlElementWithLocation element, HashSet<string> validAttributes)
+        internal static void VerifyThrowProjectAttributes(XmlElementWithLocation element, HashSet<string> validAttributes, UnknownElementsConfiguration config = null, string genericElementName = null)
         {
             foreach (XmlAttributeWithLocation attribute in element.Attributes)
             {
-                ProjectXmlUtilities.VerifyThrowProjectInvalidAttribute(validAttributes.Contains(attribute.Name), attribute);
+                if (!validAttributes.Contains(attribute.Name))
+                {
+                    string configElementName = genericElementName ?? element.Name;
+                    if (config?.CheckSkipAttribute(configElementName, attribute.Name) == true)
+                    {
+                        continue;
+                    }
+
+                    ThrowProjectInvalidAttribute(attribute);
+                }
             }
+        }
+
+        /// <summary>
+        /// Throws an InvalidProjectFileException if the child element is not allowed by configuration.
+        /// If the element is allowed, it is silently skipped.
+        /// </summary>
+        /// <returns>True if the element was skipped (caller should continue), false if the element was not in config and an exception was thrown.</returns>
+        internal static bool ThrowIfProjectInvalidChildElement(string name, string parentName, ElementLocation location, UnknownElementsConfiguration config = null)
+        {
+            if (config?.CheckSkipElement(parentName, name) == true)
+            {
+                return true;
+            }
+
+            ProjectErrorUtilities.ThrowInvalidProject(location, "UnrecognizedChildElement", name, parentName);
+            return false; // Unreachable, but needed for compiler
         }
 
         /// <summary>

--- a/src/Build/Xml/ProjectXmlUtilities.cs
+++ b/src/Build/Xml/ProjectXmlUtilities.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Build.Internal
         /// <summary>
         /// Throw an invalid project exception if there are any child elements at all
         /// </summary>
-        internal static void VerifyThrowProjectNoChildElements(XmlElementWithLocation element, UnknownElementsConfiguration config = null)
+        internal static void VerifyThrowProjectNoChildElements(XmlElementWithLocation element, UnknownElementsConfiguration config)
         {
             foreach (var child in GetVerifyThrowProjectChildElements(element))
             {
@@ -138,7 +138,7 @@ namespace Microsoft.Build.Internal
         /// <summary>
         /// If there are any attributes on the element, throws an InvalidProjectFileException complaining that the attribute is not valid on this element.
         /// </summary>
-        internal static void VerifyThrowProjectNoAttributes(XmlElementWithLocation element, UnknownElementsConfiguration config = null)
+        internal static void VerifyThrowProjectNoAttributes(XmlElementWithLocation element, UnknownElementsConfiguration config)
         {
             if (element.HasAttributes)
             {
@@ -178,7 +178,7 @@ namespace Microsoft.Build.Internal
         /// Verify that all attributes on the element are on the list of legal attributes.
         /// When genericElementName is provided, only that name is checked in the config (not the actual element name).
         /// </summary>
-        internal static void VerifyThrowProjectAttributes(XmlElementWithLocation element, HashSet<string> validAttributes, UnknownElementsConfiguration config = null, string genericElementName = null)
+        internal static void VerifyThrowProjectAttributes(XmlElementWithLocation element, HashSet<string> validAttributes, UnknownElementsConfiguration config, string genericElementName = null)
         {
             foreach (XmlAttributeWithLocation attribute in element.Attributes)
             {
@@ -200,7 +200,7 @@ namespace Microsoft.Build.Internal
         /// If the element is allowed, it is silently skipped.
         /// </summary>
         /// <returns>True if the element was skipped (caller should continue), false if the element was not in config and an exception was thrown.</returns>
-        internal static bool ThrowIfProjectInvalidChildElement(string name, string parentName, ElementLocation location, UnknownElementsConfiguration config = null)
+        internal static bool ThrowIfProjectInvalidChildElement(string name, string parentName, ElementLocation location, UnknownElementsConfiguration config)
         {
             if (config?.CheckSkipElement(parentName, name) == true)
             {

--- a/src/Framework/Traits.cs
+++ b/src/Framework/Traits.cs
@@ -279,6 +279,13 @@ namespace Microsoft.Build.Framework
         public readonly bool AlwaysEvaluateDangerousGlobs = Environment.GetEnvironmentVariable("MSBuildAlwaysEvaluateDangerousGlobs") == "1";
 
         /// <summary>
+        /// Disables automatic loading of Directory.Parse.config from global locations
+        /// (MSBuild exe directory, user profile, MSBUILD_PARSE_CONFIG env var).
+        /// When set, configuration must be explicitly provided via ProjectCollection or BuildParameters.
+        /// </summary>
+        public readonly bool DisableParseConfig = Environment.GetEnvironmentVariable("MSBUILD_DISABLE_PARSE_CONFIG") == "1";
+
+        /// <summary>
         /// Disables skipping full up to date check for immutable files. See FileClassifier class.
         /// </summary>
         public readonly bool AlwaysDoImmutableFilesUpToDateCheck = Environment.GetEnvironmentVariable("MSBUILDDONOTCACHEMODIFICATIONTIME") == "1";


### PR DESCRIPTION
> **Draft / alternative implementation.** This builds on @benwitmanmsft's work in #14588 — the first commit here is that PR unchanged. It keeps that PR's semantic model and parse-site integration, and replaces the ownership and lifetime model. Opened for comparison; if the approach is agreed it may be simpler to fold these commits into #14588 than to merge this separately.

## Why

I built #14588 and tried to break it with two workspaces holding different `Directory.Parse.config` rules. Four issues reproduced, all with controls ([details and repros](https://github.com/dotnet/msbuild/pull/14588#issuecomment-5143606783)):

1. **The entry project never received its own configuration** — only files imported during evaluation did. `ProjectCollection`'s constructor assigned a non-null (empty) config, so the `is null` guard in `BuildManager.BeginBuild` never fired and the startup-directory walk was unreachable; the per-project walk in `Evaluator` ran after the entry project had already been parsed.
2. **Cross-pollination between workspaces, order-dependent** — `ws1` then `ws2` in one process: `ws2` accepted a name only `ws1` permits. Reversed: correct. Same inputs, opposite results.
3. **Shared-import cache poisoning** — a file imported by both workspaces, parsed permissively for `ws1`, was reused for `ws2`.
4. **Cross-process leak via reused worker nodes** — control 0/8 succeeded, after `ws1` primed the nodes 8/8 succeeded.

All three of 2–4 come from one thing: the effective configuration was mutable state accumulated on a `ProjectRootElementCache` whose lifetime is the process, not a property of the code being built.

## What changed

**The configuration is resolved once per build and bound to the cache.**

- `UnknownElementsConfiguration` is immutable, frozen, and carries a content-based `Identity`. Two configurations permitting the same names are interchangeable; any difference is a different identity.
- `ProjectRootElementCache` takes it as a **constructor parameter** and keeps it for its lifetime, so a cache cannot hold elements parsed under differing rules. The invariant is structural rather than maintained by convention.
- Resolution happens once in `BuildManager`, anchored on the **entry project's directory**, matching how `Directory.Build.rsp` is discovered (`CommandLineParser.GetProjectDirectory`).
- Where a cache outlives a build, the identity is compared and the cache **replaced** rather than mutated — `OutOfProcNode.HandleNodeConfiguration` (beside the existing environment-variable reset, which solves the same problem for the same reason), and `ProjectCollection` before adopting the static cache reused across MSBuild Server builds.
- `Evaluator.InitializeUnknownElementsConfiguration` is deleted. It was the source of 2–4.

Because identity is content-based, editing a config file changes it, so the next build re-parses under the new rules — no invalidation logic, no staleness checks, no node recycling. When no config file exists anywhere the identity is a constant, so behaviour and cost are unchanged for builds that do not use the feature.

**Hosts need no changes.** A `ProjectCollection` given no configuration resolves one from the directory of the first project loaded and then freezes it, re-resolving only while no projects are loaded. That is what lets Visual Studio honour a repository's rules without a VS-side change — important, because otherwise a repository adopting this would build on the command line and fail to load in the IDE.

**The configuration file is XML**, consistent with MSBuild itself and with `NuGet.config` / `app.config`:

```xml
<ParseConfig>
  <AllowAttribute Element="Target" Name="CustomAttr" />
  <AllowElement Parent="Project" Name="ToolConfiguration" />
</ParseConfig>
```

Unrecognized directives are ignored *and reported*, so a newer MSBuild can add directives without older engines rejecting the file, while a typo such as `<AlowAttribute>` still shows up rather than presenting later as an apparently unrelated MSB4066. A file that is not well-formed contributes nothing rather than a partial configuration.

**Discovery is first-found-wins**, matching `Directory.Build.props`, `Directory.Build.rsp` and `Directory.Solution.props`. An earlier revision layered configs with an `.editorconfig`-style `root` terminator; that borrowed a per-file notion, but a build resolves exactly one configuration, so there was nothing to compose across. Losing an inherited *permission* also fails loudly with MSB4066/MSB4067 naming the attribute, unlike losing an inherited property.

**Machine-global sources are removed** (next to the executable, `~/.msbuild/`, `MSBUILD_PARSE_CONFIG`). Whether a project loads should not depend on state that is not in source control. `MSBUILD_DISABLE_PARSE_CONFIG=1` still disables the feature.

**`ProjectXmlUtilities` parameters are required** rather than defaulting to `null`. That immediately surfaced `TaskRegistry` validating `UsingTask` children at task-registration time without the configuration — a documented `Element:UsingTask:Foo` would have been honoured during parse and then thrown MSB4067 later during evaluation.

## Consequence worth agreeing on explicitly

Anchoring on the entry project means **a build has exactly one set of parse rules**. Building a project in a directory with no `Directory.Parse.config` means nothing is permitted anywhere in that build, even for referenced projects whose own directory has one. This is what makes leaks unrepresentable, but it is a visible semantic and is called out in the spec.

## Verification

Reproduction workspaces: `ws1` permits `Alpha`, `ws2` permits `Beta`, a shared `common.props` uses `Alpha`.

| Scenario | #14588 | Here |
|---|---|---|
| Entry project gets its own config | ✗ | ✓ |
| `ws2` alone | fails ✓ | fails ✓ |
| `ws1` → `ws2`, one process | **leaks** | no leak |
| `ws1` tree, 4 reused worker nodes | 8/8 pass | 8/8 pass |
| `ws2` on nodes primed by `ws1` | **8/8 pass** | **0/8 pass, 8/8 fail** |
| Rules swap back (`ws1` again) | — | 8/8 pass |

Worker-node reuse was confirmed by observing the four persistent `MSBuild` processes between invocations.

`build.cmd` is green on both target frameworks and the 19 `UnknownElementsConfiguration_Tests` pass. Eleven failures in `Microsoft.Build.Engine.UnitTests` are pre-existing: I stashed these changes, rebuilt, and confirmed they fail identically on #14588 alone (Unix path tests on Windows, 30s timeouts, and a null `GlobalPropertiesLookup` in `GraphBuildRequestData`).

## Not addressed

- **MSBuild Server is untested end to end.** `MSBUILDUSESERVER=1` did not engage in my runs. The identity check is in place at `ProjectCollection`'s constructor, where `reuseProjectRootElementCache: s_isServerNode` adopts the static cache, but it has not been exercised.
- **Visual Studio still red-squiggles permitted names**, since IntelliSense is driven by the XSDs shipped in the VS installation. Called out in the spec as a known limitation; a real fix is a VS-side change.
- Diagnostics are logged as plain comments rather than allocated `MSBxxxx` resources.
