### PR TITLE
Call out MSBUILD_LOGGING_ARGS

### DIFF
--- a/documentation/specs/enable-binlog-collection-by-env-var.md
+++ b/documentation/specs/enable-binlog-collection-by-env-var.md
@@ -4,7 +4,7 @@
 
 Enable binary logging in CI/CD pipelines without modifying artifacts on disk.
 
-**Proposed solution:** An environment variable that enables diagnostic logging without touching any files on disk-no response file creation, no project file modifications, no build script changes.
+**Proposed solution:** An environment variable (`MSBUILD_LOGGING_ARGS`) that enables diagnostic logging without touching any files on disk-no response file creation, no project file modifications, no build script changes.
 
 **Important for company-wide deployment:** When enabling this feature organization-wide (e.g., via CI/CD pipeline configuration), the team setting the environment variable may not be the team that owns individual codebases. Ensure stakeholders understand that builds with `/warnaserror` may be affected and be ready to mitigate this.
 

--- a/documentation/specs/enable-binlog-collection-by-env-var.md
+++ b/documentation/specs/enable-binlog-collection-by-env-var.md
@@ -4,7 +4,7 @@
 
 Enable binary logging in CI/CD pipelines without modifying artifacts on disk.
 
-**Proposed solution:** An environment variable (`MSBUILD_LOGGING_ARGS`) that enables diagnostic logging without touching any files on disk-no response file creation, no project file modifications, no build script changes.
+**Proposed solution:** An environment variable (`MSBUILD_LOGGING_ARGS`) that enables diagnostic logging without touching any files on disk—no response file creation, no project file modifications, and no build script changes.
 
 **Important for company-wide deployment:** When enabling this feature organization-wide (e.g., via CI/CD pipeline configuration), the team setting the environment variable may not be the team that owns individual codebases. Ensure stakeholders understand that builds with `/warnaserror` may be affected and be ready to mitigate this.
 


### PR DESCRIPTION
I was looking at this doc to confirm the spelling of the new environment variable, but it's not mentioned in the doc until way further down the page.