### PR TITLE
Detach build event tracking logic

### DIFF
--- a/src/Build.UnitTests/BuildEventTracker_Tests.cs
+++ b/src/Build.UnitTests/BuildEventTracker_Tests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using Microsoft.Build.CommandLine.UnitTests;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Logging;
 using Shouldly;
@@ -18,8 +19,8 @@ public class BuildEventTracker_Tests
     {
         var eventSource = new MockBuildEventSink(0);
         var tracker = new BuildEventTracker();
-        var correlatedProjects = new List<BuildEventTracker.ProjectSnapshot?>();
-        BuildEventTracker.ProjectSnapshot? startedProject = null;
+        var correlatedProjects = new List<BuildEventTracker.TrackedProject?>();
+        BuildEventTracker.TrackedProject? startedProject = null;
 
         tracker.ProjectStartedTracked += project => startedProject = project;
         tracker.ProjectFinishedTracked += (project, _) => correlatedProjects.Add(project);
@@ -55,7 +56,6 @@ public class BuildEventTracker_Tests
             BuildEventContext = context,
         });
 
-        eventSource.InvokeProjectFinished(new ProjectFinishedEventArgs(null, null, "built.proj", true) { BuildEventContext = context });
         eventSource.InvokeTargetStarted(new TargetStartedEventArgs(null, null, "Build", "built.proj", "built.targets") { BuildEventContext = context });
         eventSource.InvokeTargetFinished(new TargetFinishedEventArgs(null, null, "Build", "built.proj", "built.targets", true) { BuildEventContext = context });
         eventSource.InvokeTaskStarted(new TaskStartedEventArgs(null, null, "built.proj", "task.dll", "Task") { BuildEventContext = context });
@@ -63,6 +63,7 @@ public class BuildEventTracker_Tests
         eventSource.InvokeMessageRaised(new BuildMessageEventArgs("message", null, null, MessageImportance.High) { BuildEventContext = context });
         eventSource.InvokeWarningRaised(new BuildWarningEventArgs(null, "CODE", null, 0, 0, 0, 0, "warning", null, null) { BuildEventContext = context });
         eventSource.InvokeErrorRaised(new BuildErrorEventArgs(null, "CODE", null, 0, 0, 0, 0, "error", null, null) { BuildEventContext = context });
+        eventSource.InvokeProjectFinished(new ProjectFinishedEventArgs(null, null, "built.proj", true) { BuildEventContext = context });
 
         startedProject.ShouldNotBeNull();
         startedProject.ProjectContextId.ShouldBe(3);
@@ -81,7 +82,7 @@ public class BuildEventTracker_Tests
     {
         var eventSource = new MockBuildEventSink(0);
         var tracker = new BuildEventTracker();
-        var correlatedProjects = new List<BuildEventTracker.ProjectSnapshot?>();
+        var correlatedProjects = new List<BuildEventTracker.TrackedProject?>();
 
         tracker.WarningTracked += (project, _) => correlatedProjects.Add(project);
         tracker.Attach(eventSource);
@@ -153,6 +154,107 @@ public class BuildEventTracker_Tests
         eventSource.InvokeWarningRaised(new BuildWarningEventArgs(null, "CODE", null, 0, 0, 0, 0, "warning", null, null));
 
         warningCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public void MaintainsProjectLifecycleState()
+    {
+        var eventSource = new MockBuildEventSink(0);
+        var stopwatch = new MockStopwatch();
+        var tracker = new BuildEventTracker
+        {
+            StopwatchFactory = () => stopwatch,
+        };
+        BuildEventTracker.TrackedProject? trackedProject = null;
+
+        tracker.ProjectStartedTracked += project => trackedProject = project;
+        tracker.Attach(eventSource);
+
+        BuildEventContext context = CreateContext(evaluationId: 1, projectContextId: 2, nodeId: 3);
+        eventSource.InvokeProjectStarted(CreateProjectStartedEvent("built.proj", context));
+
+        trackedProject.ShouldNotBeNull();
+        trackedProject.Stopwatch.ShouldBe(stopwatch);
+        stopwatch.IsStarted.ShouldBeTrue();
+        trackedProject.CurrentTarget.ShouldBeNull();
+        trackedProject.Succeeded.ShouldBeNull();
+        trackedProject.WarningCount.ShouldBe(0);
+        trackedProject.ErrorCount.ShouldBe(0);
+
+        eventSource.InvokeTargetStarted(new TargetStartedEventArgs(null, null, "Build", "built.proj", "built.targets")
+        {
+            BuildEventContext = context,
+        });
+
+        trackedProject.CurrentTarget.ShouldBe("Build");
+
+        eventSource.InvokeTaskStarted(new TaskStartedEventArgs(null, null, "built.proj", "task.dll", "MSBuild")
+        {
+            BuildEventContext = context,
+        });
+
+        stopwatch.IsStarted.ShouldBeFalse();
+
+        eventSource.InvokeTaskFinished(new TaskFinishedEventArgs(null, null, "built.proj", "task.dll", "MSBuild", true)
+        {
+            BuildEventContext = context,
+        });
+
+        stopwatch.IsStarted.ShouldBeTrue();
+
+        eventSource.InvokeWarningRaised(CreateWarningEvent(context));
+        eventSource.InvokeErrorRaised(new BuildErrorEventArgs(null, "CODE", null, 0, 0, 0, 0, "error", null, null)
+        {
+            BuildEventContext = context,
+        });
+
+        trackedProject.WarningCount.ShouldBe(1);
+        trackedProject.ErrorCount.ShouldBe(1);
+
+        eventSource.InvokeProjectFinished(new ProjectFinishedEventArgs(null, null, "built.proj", true)
+        {
+            BuildEventContext = context,
+        });
+
+        trackedProject.Succeeded.ShouldBe(true);
+        stopwatch.IsStarted.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void KeepsRestoreProjectTimingActiveDuringMSBuildTasks()
+    {
+        var eventSource = new MockBuildEventSink(0);
+        var stopwatch = new MockStopwatch();
+        var tracker = new BuildEventTracker
+        {
+            StopwatchFactory = () => stopwatch,
+        };
+
+        tracker.Attach(eventSource);
+
+        BuildEventContext context = CreateContext(evaluationId: 1, projectContextId: 2, nodeId: 3);
+        eventSource.InvokeProjectStarted(new ProjectStartedEventArgs(
+            string.Empty,
+            string.Empty,
+            "built.proj",
+            "Restore",
+            new Dictionary<string, string>(),
+            new List<DictionaryEntry>())
+        {
+            BuildEventContext = context,
+        });
+
+        eventSource.InvokeTaskStarted(new TaskStartedEventArgs(null, null, "built.proj", "task.dll", "MSBuild")
+        {
+            BuildEventContext = context,
+        });
+        stopwatch.IsStarted.ShouldBeTrue();
+
+        eventSource.InvokeTaskFinished(new TaskFinishedEventArgs(null, null, "built.proj", "task.dll", "MSBuild", true)
+        {
+            BuildEventContext = context,
+        });
+        stopwatch.IsStarted.ShouldBeTrue();
     }
 
     private static BuildEventContext CreateContext(int evaluationId, int projectContextId, int nodeId)

--- a/src/Build.UnitTests/BuildEventTracker_Tests.cs
+++ b/src/Build.UnitTests/BuildEventTracker_Tests.cs
@@ -221,40 +221,48 @@ public class BuildEventTracker_Tests
     }
 
     [Fact]
-    public void KeepsRestoreProjectTimingActiveDuringMSBuildTasks()
+    public void OnlyKeepsInitialRestoreTimingActiveDuringMSBuildTasks()
     {
         var eventSource = new MockBuildEventSink(0);
-        var stopwatch = new MockStopwatch();
+        MockStopwatch[] stopwatches = [new(), new()];
+        int stopwatchIndex = 0;
         var tracker = new BuildEventTracker
         {
-            StopwatchFactory = () => stopwatch,
+            StopwatchFactory = () => stopwatches[stopwatchIndex++],
         };
 
         tracker.Attach(eventSource);
+        eventSource.InvokeBuildStarted(new BuildStartedEventArgs(string.Empty, string.Empty));
 
-        BuildEventContext context = CreateContext(evaluationId: 1, projectContextId: 2, nodeId: 3);
-        eventSource.InvokeProjectStarted(new ProjectStartedEventArgs(
-            string.Empty,
-            string.Empty,
-            "built.proj",
-            "Restore",
-            new Dictionary<string, string>(),
-            new List<DictionaryEntry>())
+        BuildEventContext initialRestoreContext = CreateContext(evaluationId: 1, projectContextId: 2, nodeId: 3);
+        eventSource.InvokeProjectStarted(CreateProjectStartedEvent("initial.proj", initialRestoreContext, "Restore"));
+        eventSource.InvokeTaskStarted(new TaskStartedEventArgs(null, null, "initial.proj", "task.dll", "MSBuild")
         {
-            BuildEventContext = context,
+            BuildEventContext = initialRestoreContext,
+        });
+        stopwatches[0].IsStarted.ShouldBeTrue();
+        eventSource.InvokeTaskFinished(new TaskFinishedEventArgs(null, null, "initial.proj", "task.dll", "MSBuild", true)
+        {
+            BuildEventContext = initialRestoreContext,
+        });
+        stopwatches[0].IsStarted.ShouldBeTrue();
+        eventSource.InvokeProjectFinished(new ProjectFinishedEventArgs(null, null, "initial.proj", true)
+        {
+            BuildEventContext = initialRestoreContext,
         });
 
-        eventSource.InvokeTaskStarted(new TaskStartedEventArgs(null, null, "built.proj", "task.dll", "MSBuild")
+        BuildEventContext laterRestoreContext = CreateContext(evaluationId: 4, projectContextId: 5, nodeId: 3);
+        eventSource.InvokeProjectStarted(CreateProjectStartedEvent("later.proj", laterRestoreContext, "Restore"));
+        eventSource.InvokeTaskStarted(new TaskStartedEventArgs(null, null, "later.proj", "task.dll", "MSBuild")
         {
-            BuildEventContext = context,
+            BuildEventContext = laterRestoreContext,
         });
-        stopwatch.IsStarted.ShouldBeTrue();
-
-        eventSource.InvokeTaskFinished(new TaskFinishedEventArgs(null, null, "built.proj", "task.dll", "MSBuild", true)
+        stopwatches[1].IsStarted.ShouldBeFalse();
+        eventSource.InvokeTaskFinished(new TaskFinishedEventArgs(null, null, "later.proj", "task.dll", "MSBuild", true)
         {
-            BuildEventContext = context,
+            BuildEventContext = laterRestoreContext,
         });
-        stopwatch.IsStarted.ShouldBeTrue();
+        stopwatches[1].IsStarted.ShouldBeTrue();
     }
 
     private static BuildEventContext CreateContext(int evaluationId, int projectContextId, int nodeId)
@@ -267,12 +275,15 @@ public class BuildEventTracker_Tests
             targetId: 1,
             taskId: 1);
 
-    private static ProjectStartedEventArgs CreateProjectStartedEvent(string projectFile, BuildEventContext context)
+    private static ProjectStartedEventArgs CreateProjectStartedEvent(
+        string projectFile,
+        BuildEventContext context,
+        string targetNames = "Build")
         => new(
             string.Empty,
             string.Empty,
             projectFile,
-            "Build",
+            targetNames,
             new Dictionary<string, string>(),
             new List<DictionaryEntry>())
         {

--- a/src/Build.UnitTests/BuildEventTracker_Tests.cs
+++ b/src/Build.UnitTests/BuildEventTracker_Tests.cs
@@ -19,8 +19,8 @@ public class BuildEventTracker_Tests
     {
         var eventSource = new MockBuildEventSink(0);
         var tracker = new BuildEventTracker();
-        var correlatedProjects = new List<BuildEventTracker.TrackedProject?>();
-        BuildEventTracker.TrackedProject? startedProject = null;
+        var correlatedProjects = new List<BuildEventTracker.ProjectSnapshot?>();
+        BuildEventTracker.ProjectSnapshot? startedProject = null;
 
         tracker.ProjectStartedTracked += project => startedProject = project;
         tracker.ProjectFinishedTracked += (project, _) => correlatedProjects.Add(project);
@@ -66,15 +66,16 @@ public class BuildEventTracker_Tests
         eventSource.InvokeProjectFinished(new ProjectFinishedEventArgs(null, null, "built.proj", true) { BuildEventContext = context });
 
         startedProject.ShouldNotBeNull();
-        startedProject.ProjectContextId.ShouldBe(3);
-        startedProject.NodeId.ShouldBe(4);
-        startedProject.EvaluationId.ShouldBe(2);
-        startedProject.ProjectFile.ShouldBe("built.proj");
-        startedProject.EvaluationProjectFile.ShouldBe("evaluated.proj");
-        startedProject.TargetFramework.ShouldBe("net11.0");
-        startedProject.RuntimeIdentifier.ShouldBe("win-x64");
+        BuildEventTracker.ProjectSnapshot projectStartedSnapshot = startedProject.Value;
+        projectStartedSnapshot.ProjectContextId.ShouldBe(3);
+        projectStartedSnapshot.NodeId.ShouldBe(4);
+        projectStartedSnapshot.EvaluationId.ShouldBe(2);
+        projectStartedSnapshot.ProjectFile.ShouldBe("built.proj");
+        projectStartedSnapshot.EvaluationProjectFile.ShouldBe("evaluated.proj");
+        projectStartedSnapshot.TargetFramework.ShouldBe("net11.0");
+        projectStartedSnapshot.RuntimeIdentifier.ShouldBe("win-x64");
         correlatedProjects.Count.ShouldBe(8);
-        correlatedProjects.ShouldAllBe(project => project == startedProject);
+        correlatedProjects.ShouldAllBe(project => project.HasValue && project.Value.ContextKey == projectStartedSnapshot.ContextKey);
     }
 
     [Fact]
@@ -82,7 +83,7 @@ public class BuildEventTracker_Tests
     {
         var eventSource = new MockBuildEventSink(0);
         var tracker = new BuildEventTracker();
-        var correlatedProjects = new List<BuildEventTracker.TrackedProject?>();
+        var correlatedProjects = new List<BuildEventTracker.ProjectSnapshot?>();
 
         tracker.WarningTracked += (project, _) => correlatedProjects.Add(project);
         tracker.Attach(eventSource);
@@ -165,28 +166,41 @@ public class BuildEventTracker_Tests
         {
             StopwatchFactory = () => stopwatch,
         };
-        BuildEventTracker.TrackedProject? trackedProject = null;
+        BuildEventTracker.ProjectSnapshot? startedProject = null;
+        BuildEventTracker.ProjectSnapshot? targetStartedProject = null;
+        BuildEventTracker.ProjectSnapshot? taskStartedProject = null;
+        BuildEventTracker.ProjectSnapshot? taskFinishedProject = null;
+        BuildEventTracker.ProjectSnapshot? warningProject = null;
+        BuildEventTracker.ProjectSnapshot? errorProject = null;
+        BuildEventTracker.ProjectSnapshot? finishedProject = null;
 
-        tracker.ProjectStartedTracked += project => trackedProject = project;
+        tracker.ProjectStartedTracked += project => startedProject = project;
+        tracker.TargetStartedTracked += (project, _) => targetStartedProject = project;
+        tracker.TaskStartedTracked += (project, _) => taskStartedProject = project;
+        tracker.TaskFinishedTracked += (project, _) => taskFinishedProject = project;
+        tracker.WarningTracked += (project, _) => warningProject = project;
+        tracker.ErrorTracked += (project, _) => errorProject = project;
+        tracker.ProjectFinishedTracked += (project, _) => finishedProject = project;
         tracker.Attach(eventSource);
 
         BuildEventContext context = CreateContext(evaluationId: 1, projectContextId: 2, nodeId: 3);
         eventSource.InvokeProjectStarted(CreateProjectStartedEvent("built.proj", context));
 
-        trackedProject.ShouldNotBeNull();
-        trackedProject.Stopwatch.ShouldBe(stopwatch);
+        startedProject.ShouldNotBeNull();
         stopwatch.IsStarted.ShouldBeTrue();
-        trackedProject.CurrentTarget.ShouldBeNull();
-        trackedProject.Succeeded.ShouldBeNull();
-        trackedProject.WarningCount.ShouldBe(0);
-        trackedProject.ErrorCount.ShouldBe(0);
+        startedProject.Value.CurrentTarget.ShouldBeNull();
+        startedProject.Value.Succeeded.ShouldBeNull();
+        startedProject.Value.WarningCount.ShouldBe(0);
+        startedProject.Value.ErrorCount.ShouldBe(0);
+        startedProject.Value.IsTimingActive.ShouldBeTrue();
 
         eventSource.InvokeTargetStarted(new TargetStartedEventArgs(null, null, "Build", "built.proj", "built.targets")
         {
             BuildEventContext = context,
         });
 
-        trackedProject.CurrentTarget.ShouldBe("Build");
+        targetStartedProject.ShouldNotBeNull();
+        targetStartedProject.Value.CurrentTarget.ShouldBe("Build");
 
         eventSource.InvokeTaskStarted(new TaskStartedEventArgs(null, null, "built.proj", "task.dll", "MSBuild")
         {
@@ -194,6 +208,8 @@ public class BuildEventTracker_Tests
         });
 
         stopwatch.IsStarted.ShouldBeFalse();
+        taskStartedProject.ShouldNotBeNull();
+        taskStartedProject.Value.IsTimingActive.ShouldBeFalse();
 
         eventSource.InvokeTaskFinished(new TaskFinishedEventArgs(null, null, "built.proj", "task.dll", "MSBuild", true)
         {
@@ -201,6 +217,8 @@ public class BuildEventTracker_Tests
         });
 
         stopwatch.IsStarted.ShouldBeTrue();
+        taskFinishedProject.ShouldNotBeNull();
+        taskFinishedProject.Value.IsTimingActive.ShouldBeTrue();
 
         eventSource.InvokeWarningRaised(CreateWarningEvent(context));
         eventSource.InvokeErrorRaised(new BuildErrorEventArgs(null, "CODE", null, 0, 0, 0, 0, "error", null, null)
@@ -208,16 +226,27 @@ public class BuildEventTracker_Tests
             BuildEventContext = context,
         });
 
-        trackedProject.WarningCount.ShouldBe(1);
-        trackedProject.ErrorCount.ShouldBe(1);
+        warningProject.ShouldNotBeNull();
+        warningProject.Value.WarningCount.ShouldBe(1);
+        warningProject.Value.ErrorCount.ShouldBe(0);
+        errorProject.ShouldNotBeNull();
+        errorProject.Value.WarningCount.ShouldBe(1);
+        errorProject.Value.ErrorCount.ShouldBe(1);
 
         eventSource.InvokeProjectFinished(new ProjectFinishedEventArgs(null, null, "built.proj", true)
         {
             BuildEventContext = context,
         });
 
-        trackedProject.Succeeded.ShouldBe(true);
+        finishedProject.ShouldNotBeNull();
+        finishedProject.Value.Succeeded.ShouldBe(true);
+        finishedProject.Value.IsTimingActive.ShouldBeFalse();
         stopwatch.IsStarted.ShouldBeFalse();
+
+        startedProject.Value.CurrentTarget.ShouldBeNull();
+        startedProject.Value.Succeeded.ShouldBeNull();
+        startedProject.Value.WarningCount.ShouldBe(0);
+        startedProject.Value.ErrorCount.ShouldBe(0);
     }
 
     [Fact]

--- a/src/Build.UnitTests/BuildEventTracker_Tests.cs
+++ b/src/Build.UnitTests/BuildEventTracker_Tests.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Build.UnitTests;
 public class BuildEventTracker_Tests
 {
     [Fact]
-    public void CorrelatesProjectScopedEventsWithEvaluationData()
+    public void EventCallbacks_ProjectEvents_CorrelateWithEvaluationData()
     {
         var eventSource = new MockBuildEventSink(0);
         var tracker = new BuildEventTracker();
@@ -79,7 +79,7 @@ public class BuildEventTracker_Tests
     }
 
     [Fact]
-    public void ReportsNullCorrelationForUnknownAndClearedProjectContexts()
+    public void EventCallbacks_UnknownAndClearedProjectContexts_ReportNullCorrelation()
     {
         var eventSource = new MockBuildEventSink(0);
         var tracker = new BuildEventTracker();
@@ -112,7 +112,7 @@ public class BuildEventTracker_Tests
     }
 
     [Fact]
-    public void DistinguishesSameProjectContextIdOnDifferentNodes()
+    public void EventCallbacks_SameProjectContextIdOnDifferentNodes_DistinguishProjects()
     {
         var eventSource = new MockBuildEventSink(0);
         var tracker = new BuildEventTracker();
@@ -133,51 +133,58 @@ public class BuildEventTracker_Tests
     }
 
     [Fact]
-    public void TracksBuildDurationAndStopsTrackingAfterDetach()
+    public void Detach_AllEvents_StopTracking()
     {
         var eventSource = new MockBuildEventSink(0);
         var tracker = new BuildEventTracker();
         BuildEventTracker.BuildFinishedSnapshot? finishedBuild = null;
-        int warningCount = 0;
+        int trackedEventCount = 0;
 
-        tracker.BuildFinishedTracked += build => finishedBuild = build;
-        tracker.WarningTracked += (_, _) => warningCount++;
+        tracker.BuildStartedTracked += _ => trackedEventCount++;
+        tracker.BuildFinishedTracked += build =>
+        {
+            finishedBuild = build;
+            trackedEventCount++;
+        };
+        tracker.ProjectStartedTracked += _ => trackedEventCount++;
+        tracker.ProjectFinishedTracked += (_, _) => trackedEventCount++;
+        tracker.TargetStartedTracked += (_, _) => trackedEventCount++;
+        tracker.TargetFinishedTracked += (_, _) => trackedEventCount++;
+        tracker.TaskStartedTracked += (_, _) => trackedEventCount++;
+        tracker.TaskFinishedTracked += (_, _) => trackedEventCount++;
+        tracker.StatusEventTracked += _ => trackedEventCount++;
+        tracker.MessageTracked += (_, _) => trackedEventCount++;
+        tracker.WarningTracked += (_, _) => trackedEventCount++;
+        tracker.ErrorTracked += (_, _) => trackedEventCount++;
         tracker.Attach(eventSource);
 
         DateTime startTime = new(2026, 8, 6, 10, 0, 0);
-        eventSource.InvokeBuildStarted(new BuildStartedEventArgs(string.Empty, string.Empty, startTime));
-        eventSource.InvokeBuildFinished(new BuildFinishedEventArgs(string.Empty, string.Empty, true, startTime.AddSeconds(5)));
+        BuildEventContext context = CreateContext(evaluationId: 1, projectContextId: 2, nodeId: 3);
+        RaiseAllTrackedEvents(eventSource, context, startTime);
 
         finishedBuild.ShouldNotBeNull();
         finishedBuild.Value.Duration.ShouldBe(TimeSpan.FromSeconds(5));
+        trackedEventCount.ShouldBe(12);
 
         tracker.Detach();
-        eventSource.InvokeWarningRaised(new BuildWarningEventArgs(null, "CODE", null, 0, 0, 0, 0, "warning", null, null));
+        RaiseAllTrackedEvents(eventSource, context, startTime);
 
-        warningCount.ShouldBe(0);
+        trackedEventCount.ShouldBe(12);
     }
 
     [Fact]
-    public void MaintainsProjectLifecycleState()
+    public void EventCallbacks_ProjectLifecycle_ProduceImmutableSnapshots()
     {
         var eventSource = new MockBuildEventSink(0);
-        var stopwatch = new MockStopwatch();
-        var tracker = new BuildEventTracker
-        {
-            StopwatchFactory = () => stopwatch,
-        };
+        var tracker = new BuildEventTracker();
         BuildEventTracker.ProjectSnapshot? startedProject = null;
         BuildEventTracker.ProjectSnapshot? targetStartedProject = null;
-        BuildEventTracker.ProjectSnapshot? taskStartedProject = null;
-        BuildEventTracker.ProjectSnapshot? taskFinishedProject = null;
         BuildEventTracker.ProjectSnapshot? warningProject = null;
         BuildEventTracker.ProjectSnapshot? errorProject = null;
         BuildEventTracker.ProjectSnapshot? finishedProject = null;
 
         tracker.ProjectStartedTracked += project => startedProject = project;
         tracker.TargetStartedTracked += (project, _) => targetStartedProject = project;
-        tracker.TaskStartedTracked += (project, _) => taskStartedProject = project;
-        tracker.TaskFinishedTracked += (project, _) => taskFinishedProject = project;
         tracker.WarningTracked += (project, _) => warningProject = project;
         tracker.ErrorTracked += (project, _) => errorProject = project;
         tracker.ProjectFinishedTracked += (project, _) => finishedProject = project;
@@ -187,12 +194,10 @@ public class BuildEventTracker_Tests
         eventSource.InvokeProjectStarted(CreateProjectStartedEvent("built.proj", context));
 
         startedProject.ShouldNotBeNull();
-        stopwatch.IsStarted.ShouldBeTrue();
         startedProject.Value.CurrentTarget.ShouldBeNull();
         startedProject.Value.Succeeded.ShouldBeNull();
         startedProject.Value.WarningCount.ShouldBe(0);
         startedProject.Value.ErrorCount.ShouldBe(0);
-        startedProject.Value.IsTimingActive.ShouldBeTrue();
 
         eventSource.InvokeTargetStarted(new TargetStartedEventArgs(null, null, "Build", "built.proj", "built.targets")
         {
@@ -201,24 +206,6 @@ public class BuildEventTracker_Tests
 
         targetStartedProject.ShouldNotBeNull();
         targetStartedProject.Value.CurrentTarget.ShouldBe("Build");
-
-        eventSource.InvokeTaskStarted(new TaskStartedEventArgs(null, null, "built.proj", "task.dll", "MSBuild")
-        {
-            BuildEventContext = context,
-        });
-
-        stopwatch.IsStarted.ShouldBeFalse();
-        taskStartedProject.ShouldNotBeNull();
-        taskStartedProject.Value.IsTimingActive.ShouldBeFalse();
-
-        eventSource.InvokeTaskFinished(new TaskFinishedEventArgs(null, null, "built.proj", "task.dll", "MSBuild", true)
-        {
-            BuildEventContext = context,
-        });
-
-        stopwatch.IsStarted.ShouldBeTrue();
-        taskFinishedProject.ShouldNotBeNull();
-        taskFinishedProject.Value.IsTimingActive.ShouldBeTrue();
 
         eventSource.InvokeWarningRaised(CreateWarningEvent(context));
         eventSource.InvokeErrorRaised(new BuildErrorEventArgs(null, "CODE", null, 0, 0, 0, 0, "error", null, null)
@@ -240,8 +227,6 @@ public class BuildEventTracker_Tests
 
         finishedProject.ShouldNotBeNull();
         finishedProject.Value.Succeeded.ShouldBe(true);
-        finishedProject.Value.IsTimingActive.ShouldBeFalse();
-        stopwatch.IsStarted.ShouldBeFalse();
 
         startedProject.Value.CurrentTarget.ShouldBeNull();
         startedProject.Value.Succeeded.ShouldBeNull();
@@ -250,48 +235,173 @@ public class BuildEventTracker_Tests
     }
 
     [Fact]
-    public void OnlyKeepsInitialRestoreTimingActiveDuringMSBuildTasks()
+    public void Attach_CalledAgain_DetachesPreviousEventSource()
+    {
+        var firstEventSource = new MockBuildEventSink(0);
+        var secondEventSource = new MockBuildEventSink(1);
+        var tracker = new BuildEventTracker();
+        int warningCount = 0;
+
+        tracker.WarningTracked += (_, _) => warningCount++;
+        tracker.Attach(firstEventSource);
+        tracker.Attach(firstEventSource);
+        firstEventSource.InvokeWarningRaised(CreateWarningEvent(CreateContext(1, 2, 3)));
+
+        tracker.Attach(secondEventSource);
+        firstEventSource.InvokeWarningRaised(CreateWarningEvent(CreateContext(1, 2, 3)));
+        secondEventSource.InvokeWarningRaised(CreateWarningEvent(CreateContext(1, 2, 3)));
+
+        warningCount.ShouldBe(2);
+    }
+
+    [Fact]
+    public void BuildStarted_CachedEvaluation_ClearsEvaluationData()
     {
         var eventSource = new MockBuildEventSink(0);
-        MockStopwatch[] stopwatches = [new(), new()];
-        int stopwatchIndex = 0;
-        var tracker = new BuildEventTracker
-        {
-            StopwatchFactory = () => stopwatches[stopwatchIndex++],
-        };
+        var tracker = new BuildEventTracker();
+        var startedProjects = new List<BuildEventTracker.ProjectSnapshot>();
+        BuildEventContext firstContext = CreateContext(evaluationId: 1, projectContextId: 2, nodeId: 3);
+        BuildEventContext secondContext = CreateContext(evaluationId: 1, projectContextId: 4, nodeId: 3);
 
+        tracker.ProjectStartedTracked += startedProjects.Add;
         tracker.Attach(eventSource);
+
         eventSource.InvokeBuildStarted(new BuildStartedEventArgs(string.Empty, string.Empty));
+        eventSource.InvokeStatusEventRaised(CreateEvaluationFinishedEvent("evaluated.proj", firstContext));
+        eventSource.InvokeProjectStarted(CreateProjectStartedEvent("built.proj", firstContext));
+        eventSource.InvokeProjectFinished(new ProjectFinishedEventArgs(null, null, "built.proj", true)
+        {
+            BuildEventContext = firstContext,
+        });
+        eventSource.InvokeBuildFinished(new BuildFinishedEventArgs(string.Empty, string.Empty, true));
 
-        BuildEventContext initialRestoreContext = CreateContext(evaluationId: 1, projectContextId: 2, nodeId: 3);
-        eventSource.InvokeProjectStarted(CreateProjectStartedEvent("initial.proj", initialRestoreContext, "Restore"));
-        eventSource.InvokeTaskStarted(new TaskStartedEventArgs(null, null, "initial.proj", "task.dll", "MSBuild")
-        {
-            BuildEventContext = initialRestoreContext,
-        });
-        stopwatches[0].IsStarted.ShouldBeTrue();
-        eventSource.InvokeTaskFinished(new TaskFinishedEventArgs(null, null, "initial.proj", "task.dll", "MSBuild", true)
-        {
-            BuildEventContext = initialRestoreContext,
-        });
-        stopwatches[0].IsStarted.ShouldBeTrue();
-        eventSource.InvokeProjectFinished(new ProjectFinishedEventArgs(null, null, "initial.proj", true)
-        {
-            BuildEventContext = initialRestoreContext,
-        });
+        eventSource.InvokeBuildStarted(new BuildStartedEventArgs(string.Empty, string.Empty));
+        eventSource.InvokeProjectStarted(CreateProjectStartedEvent("built.proj", secondContext));
 
-        BuildEventContext laterRestoreContext = CreateContext(evaluationId: 4, projectContextId: 5, nodeId: 3);
-        eventSource.InvokeProjectStarted(CreateProjectStartedEvent("later.proj", laterRestoreContext, "Restore"));
-        eventSource.InvokeTaskStarted(new TaskStartedEventArgs(null, null, "later.proj", "task.dll", "MSBuild")
+        startedProjects.Count.ShouldBe(2);
+        startedProjects[1].EvaluationProjectFile.ShouldBeNull();
+        startedProjects[1].TargetFramework.ShouldBeNull();
+        startedProjects[1].RuntimeIdentifier.ShouldBeNull();
+    }
+
+    [Fact]
+    public void EvaluationFinished_RepeatedEvaluationId_KeepsFirstEvaluation()
+    {
+        var eventSource = new MockBuildEventSink(0);
+        var tracker = new BuildEventTracker();
+        BuildEventTracker.ProjectSnapshot? startedProject = null;
+        BuildEventContext context = CreateContext(evaluationId: 1, projectContextId: 2, nodeId: 3);
+
+        tracker.ProjectStartedTracked += project => startedProject = project;
+        tracker.Attach(eventSource);
+
+        eventSource.InvokeStatusEventRaised(CreateEvaluationFinishedEvent("first.proj", context));
+        eventSource.InvokeStatusEventRaised(new ProjectEvaluationFinishedEventArgs
         {
-            BuildEventContext = laterRestoreContext,
+            ProjectFile = "second.proj",
+            Properties = new Dictionary<string, string>
+            {
+                ["TargetFramework"] = "net12.0",
+                ["RuntimeIdentifier"] = "linux-x64",
+            },
+            BuildEventContext = context,
         });
-        stopwatches[1].IsStarted.ShouldBeFalse();
-        eventSource.InvokeTaskFinished(new TaskFinishedEventArgs(null, null, "later.proj", "task.dll", "MSBuild", true)
+        eventSource.InvokeProjectStarted(CreateProjectStartedEvent("built.proj", context));
+
+        startedProject.ShouldNotBeNull();
+        startedProject.Value.EvaluationProjectFile.ShouldBe("first.proj");
+        startedProject.Value.TargetFramework.ShouldBe("net11.0");
+        startedProject.Value.RuntimeIdentifier.ShouldBe("win-x64");
+    }
+
+    [Fact]
+    public void EventCallbacks_NullBuildEventContext_DoNotCorrelateProject()
+    {
+        var eventSource = new MockBuildEventSink(0);
+        var tracker = new BuildEventTracker();
+        int projectStartedCount = 0;
+        int statusEventCount = 0;
+        BuildEventTracker.ProjectSnapshot? warningProject = null;
+
+        tracker.ProjectStartedTracked += _ => projectStartedCount++;
+        tracker.StatusEventTracked += _ => statusEventCount++;
+        tracker.WarningTracked += (project, _) => warningProject = project;
+        tracker.Attach(eventSource);
+
+        eventSource.InvokeStatusEventRaised(new ProjectEvaluationFinishedEventArgs
         {
-            BuildEventContext = laterRestoreContext,
+            ProjectFile = "evaluated.proj",
+            Properties = new Dictionary<string, string>(),
         });
-        stopwatches[1].IsStarted.ShouldBeTrue();
+        eventSource.InvokeProjectStarted(new ProjectStartedEventArgs(
+            string.Empty,
+            string.Empty,
+            "built.proj",
+            "Build",
+            new Dictionary<string, string>(),
+            new List<DictionaryEntry>()));
+        eventSource.InvokeWarningRaised(new BuildWarningEventArgs(
+            null,
+            "CODE",
+            null,
+            0,
+            0,
+            0,
+            0,
+            "warning",
+            null,
+            null));
+
+        projectStartedCount.ShouldBe(0);
+        statusEventCount.ShouldBe(1);
+        warningProject.ShouldBeNull();
+    }
+
+    private static void RaiseAllTrackedEvents(
+        MockBuildEventSink eventSource,
+        BuildEventContext context,
+        DateTime startTime)
+    {
+        eventSource.InvokeBuildStarted(new BuildStartedEventArgs(string.Empty, string.Empty, startTime));
+        eventSource.InvokeStatusEventRaised(new ProjectEvaluationStartedEventArgs
+        {
+            BuildEventContext = context,
+        });
+        eventSource.InvokeProjectStarted(CreateProjectStartedEvent("built.proj", context));
+        eventSource.InvokeTargetStarted(new TargetStartedEventArgs(null, null, "Build", "built.proj", "built.targets")
+        {
+            BuildEventContext = context,
+        });
+        eventSource.InvokeTargetFinished(new TargetFinishedEventArgs(null, null, "Build", "built.proj", "built.targets", true)
+        {
+            BuildEventContext = context,
+        });
+        eventSource.InvokeTaskStarted(new TaskStartedEventArgs(null, null, "built.proj", "task.dll", "Task")
+        {
+            BuildEventContext = context,
+        });
+        eventSource.InvokeTaskFinished(new TaskFinishedEventArgs(null, null, "built.proj", "task.dll", "Task", true)
+        {
+            BuildEventContext = context,
+        });
+        eventSource.InvokeMessageRaised(new BuildMessageEventArgs("message", null, null, MessageImportance.High)
+        {
+            BuildEventContext = context,
+        });
+        eventSource.InvokeWarningRaised(CreateWarningEvent(context));
+        eventSource.InvokeErrorRaised(new BuildErrorEventArgs(null, "CODE", null, 0, 0, 0, 0, "error", null, null)
+        {
+            BuildEventContext = context,
+        });
+        eventSource.InvokeProjectFinished(new ProjectFinishedEventArgs(null, null, "built.proj", true)
+        {
+            BuildEventContext = context,
+        });
+        eventSource.InvokeBuildFinished(new BuildFinishedEventArgs(
+            string.Empty,
+            string.Empty,
+            true,
+            startTime.AddSeconds(5)));
     }
 
     private static BuildEventContext CreateContext(int evaluationId, int projectContextId, int nodeId)
@@ -322,6 +432,20 @@ public class BuildEventTracker_Tests
     private static BuildWarningEventArgs CreateWarningEvent(BuildEventContext context)
         => new(null, "CODE", null, 0, 0, 0, 0, "warning", null, null)
         {
+            BuildEventContext = context,
+        };
+
+    private static ProjectEvaluationFinishedEventArgs CreateEvaluationFinishedEvent(
+        string projectFile,
+        BuildEventContext context)
+        => new()
+        {
+            ProjectFile = projectFile,
+            Properties = new Dictionary<string, string>
+            {
+                ["TargetFramework"] = "net11.0",
+                ["RuntimeIdentifier"] = "win-x64",
+            },
             BuildEventContext = context,
         };
 }

--- a/src/Build.UnitTests/BuildEventTracker_Tests.cs
+++ b/src/Build.UnitTests/BuildEventTracker_Tests.cs
@@ -1,0 +1,185 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Logging;
+using Shouldly;
+using Xunit;
+
+namespace Microsoft.Build.UnitTests;
+
+public class BuildEventTracker_Tests
+{
+    [Fact]
+    public void CorrelatesProjectScopedEventsWithEvaluationData()
+    {
+        var eventSource = new MockBuildEventSink(0);
+        var tracker = new BuildEventTracker();
+        var correlatedProjects = new List<BuildEventTracker.ProjectSnapshot?>();
+        BuildEventTracker.ProjectSnapshot? startedProject = null;
+
+        tracker.ProjectStartedTracked += project => startedProject = project;
+        tracker.ProjectFinishedTracked += (project, _) => correlatedProjects.Add(project);
+        tracker.TargetStartedTracked += (project, _) => correlatedProjects.Add(project);
+        tracker.TargetFinishedTracked += (project, _) => correlatedProjects.Add(project);
+        tracker.TaskStartedTracked += (project, _) => correlatedProjects.Add(project);
+        tracker.TaskFinishedTracked += (project, _) => correlatedProjects.Add(project);
+        tracker.MessageTracked += (project, _) => correlatedProjects.Add(project);
+        tracker.WarningTracked += (project, _) => correlatedProjects.Add(project);
+        tracker.ErrorTracked += (project, _) => correlatedProjects.Add(project);
+        tracker.Attach(eventSource);
+
+        BuildEventContext context = CreateContext(evaluationId: 2, projectContextId: 3, nodeId: 4);
+        eventSource.InvokeBuildStarted(new BuildStartedEventArgs(string.Empty, string.Empty));
+        eventSource.InvokeStatusEventRaised(new ProjectEvaluationFinishedEventArgs
+        {
+            ProjectFile = "evaluated.proj",
+            Properties = new Dictionary<string, string>
+            {
+                ["TargetFramework"] = "net11.0",
+                ["RuntimeIdentifier"] = "win-x64",
+            },
+            BuildEventContext = context,
+        });
+        eventSource.InvokeProjectStarted(new ProjectStartedEventArgs(
+            string.Empty,
+            string.Empty,
+            "built.proj",
+            "Build",
+            new Dictionary<string, string>(),
+            new List<DictionaryEntry>())
+        {
+            BuildEventContext = context,
+        });
+
+        eventSource.InvokeProjectFinished(new ProjectFinishedEventArgs(null, null, "built.proj", true) { BuildEventContext = context });
+        eventSource.InvokeTargetStarted(new TargetStartedEventArgs(null, null, "Build", "built.proj", "built.targets") { BuildEventContext = context });
+        eventSource.InvokeTargetFinished(new TargetFinishedEventArgs(null, null, "Build", "built.proj", "built.targets", true) { BuildEventContext = context });
+        eventSource.InvokeTaskStarted(new TaskStartedEventArgs(null, null, "built.proj", "task.dll", "Task") { BuildEventContext = context });
+        eventSource.InvokeTaskFinished(new TaskFinishedEventArgs(null, null, "built.proj", "task.dll", "Task", true) { BuildEventContext = context });
+        eventSource.InvokeMessageRaised(new BuildMessageEventArgs("message", null, null, MessageImportance.High) { BuildEventContext = context });
+        eventSource.InvokeWarningRaised(new BuildWarningEventArgs(null, "CODE", null, 0, 0, 0, 0, "warning", null, null) { BuildEventContext = context });
+        eventSource.InvokeErrorRaised(new BuildErrorEventArgs(null, "CODE", null, 0, 0, 0, 0, "error", null, null) { BuildEventContext = context });
+
+        startedProject.ShouldNotBeNull();
+        startedProject.ProjectContextId.ShouldBe(3);
+        startedProject.NodeId.ShouldBe(4);
+        startedProject.EvaluationId.ShouldBe(2);
+        startedProject.ProjectFile.ShouldBe("built.proj");
+        startedProject.EvaluationProjectFile.ShouldBe("evaluated.proj");
+        startedProject.TargetFramework.ShouldBe("net11.0");
+        startedProject.RuntimeIdentifier.ShouldBe("win-x64");
+        correlatedProjects.Count.ShouldBe(8);
+        correlatedProjects.ShouldAllBe(project => project == startedProject);
+    }
+
+    [Fact]
+    public void ReportsNullCorrelationForUnknownAndClearedProjectContexts()
+    {
+        var eventSource = new MockBuildEventSink(0);
+        var tracker = new BuildEventTracker();
+        var correlatedProjects = new List<BuildEventTracker.ProjectSnapshot?>();
+
+        tracker.WarningTracked += (project, _) => correlatedProjects.Add(project);
+        tracker.Attach(eventSource);
+
+        BuildEventContext context = CreateContext(evaluationId: 1, projectContextId: 2, nodeId: 3);
+        BuildWarningEventArgs warning = new(null, "CODE", null, 0, 0, 0, 0, "warning", null, null)
+        {
+            BuildEventContext = context,
+        };
+
+        eventSource.InvokeWarningRaised(warning);
+        eventSource.InvokeProjectStarted(new ProjectStartedEventArgs(
+            string.Empty,
+            string.Empty,
+            "built.proj",
+            "Build",
+            new Dictionary<string, string>(),
+            new List<DictionaryEntry>())
+        {
+            BuildEventContext = context,
+        });
+        eventSource.InvokeBuildStarted(new BuildStartedEventArgs(string.Empty, string.Empty));
+        eventSource.InvokeWarningRaised(warning);
+
+        correlatedProjects.ShouldBe([null, null]);
+    }
+
+    [Fact]
+    public void DistinguishesSameProjectContextIdOnDifferentNodes()
+    {
+        var eventSource = new MockBuildEventSink(0);
+        var tracker = new BuildEventTracker();
+        var correlatedProjectFiles = new List<string?>();
+
+        tracker.WarningTracked += (project, _) => correlatedProjectFiles.Add(project?.ProjectFile);
+        tracker.Attach(eventSource);
+
+        BuildEventContext firstContext = CreateContext(evaluationId: 1, projectContextId: 7, nodeId: 1);
+        BuildEventContext secondContext = CreateContext(evaluationId: 2, projectContextId: 7, nodeId: 2);
+
+        eventSource.InvokeProjectStarted(CreateProjectStartedEvent("first.proj", firstContext));
+        eventSource.InvokeProjectStarted(CreateProjectStartedEvent("second.proj", secondContext));
+        eventSource.InvokeWarningRaised(CreateWarningEvent(firstContext));
+        eventSource.InvokeWarningRaised(CreateWarningEvent(secondContext));
+
+        correlatedProjectFiles.ShouldBe(["first.proj", "second.proj"]);
+    }
+
+    [Fact]
+    public void TracksBuildDurationAndStopsTrackingAfterDetach()
+    {
+        var eventSource = new MockBuildEventSink(0);
+        var tracker = new BuildEventTracker();
+        BuildEventTracker.BuildFinishedSnapshot? finishedBuild = null;
+        int warningCount = 0;
+
+        tracker.BuildFinishedTracked += build => finishedBuild = build;
+        tracker.WarningTracked += (_, _) => warningCount++;
+        tracker.Attach(eventSource);
+
+        DateTime startTime = new(2026, 8, 6, 10, 0, 0);
+        eventSource.InvokeBuildStarted(new BuildStartedEventArgs(string.Empty, string.Empty, startTime));
+        eventSource.InvokeBuildFinished(new BuildFinishedEventArgs(string.Empty, string.Empty, true, startTime.AddSeconds(5)));
+
+        finishedBuild.ShouldNotBeNull();
+        finishedBuild.Value.Duration.ShouldBe(TimeSpan.FromSeconds(5));
+
+        tracker.Detach();
+        eventSource.InvokeWarningRaised(new BuildWarningEventArgs(null, "CODE", null, 0, 0, 0, 0, "warning", null, null));
+
+        warningCount.ShouldBe(0);
+    }
+
+    private static BuildEventContext CreateContext(int evaluationId, int projectContextId, int nodeId)
+        => new(
+            submissionId: -1,
+            nodeId,
+            evaluationId,
+            projectInstanceId: -1,
+            projectContextId,
+            targetId: 1,
+            taskId: 1);
+
+    private static ProjectStartedEventArgs CreateProjectStartedEvent(string projectFile, BuildEventContext context)
+        => new(
+            string.Empty,
+            string.Empty,
+            projectFile,
+            "Build",
+            new Dictionary<string, string>(),
+            new List<DictionaryEntry>())
+        {
+            BuildEventContext = context,
+        };
+
+    private static BuildWarningEventArgs CreateWarningEvent(BuildEventContext context)
+        => new(null, "CODE", null, 0, 0, 0, 0, "warning", null, null)
+        {
+            BuildEventContext = context,
+        };
+}

--- a/src/Build.UnitTests/TerminalLogger_Tests.cs
+++ b/src/Build.UnitTests/TerminalLogger_Tests.cs
@@ -895,6 +895,100 @@ namespace Microsoft.Build.UnitTests
             }
         }
 
+        [Fact]
+        public void Initialize_CalledTwice_DoesNotDuplicateTrackedEvents()
+        {
+            _terminallogger.Initialize(_centralNodeEventSource, _nodeCount);
+
+            _centralNodeEventSource.InvokeBuildStarted(MakeBuildStartedEventArgs());
+            _centralNodeEventSource.InvokeStatusEventRaised(MakeProjectEvalFinishedArgs(_projectFile));
+            _centralNodeEventSource.InvokeProjectStarted(MakeProjectStartedEventArgs(_projectFile));
+            _centralNodeEventSource.InvokeWarningRaised(MakeWarningEventArgs("Reported once"));
+            _centralNodeEventSource.InvokeProjectFinished(MakeProjectFinishedEventArgs(_projectFile, succeeded: true));
+
+            int occurrenceCount = _outputWriter.ToString()
+                .Split(["Reported once"], StringSplitOptions.None)
+                .Length - 1;
+            occurrenceCount.ShouldBe(1);
+        }
+
+        [Fact]
+        public void BuildStarted_SecondRestoreBuild_DoesNotRestartProjectTimingForMSBuildTask()
+        {
+            var stopwatches = new List<MockStopwatch>();
+            _terminallogger._createStopwatch = () =>
+            {
+                var stopwatch = new MockStopwatch();
+                stopwatches.Add(stopwatch);
+                return stopwatch;
+            };
+
+            BuildEventContext firstContext = MakeBuildEventContext(evalId: 1, projectContextId: 1);
+            _centralNodeEventSource.InvokeBuildStarted(MakeBuildStartedEventArgs());
+            _centralNodeEventSource.InvokeStatusEventRaised(MakeProjectEvalFinishedArgs(_projectFile, buildEventContext: firstContext));
+            _centralNodeEventSource.InvokeProjectStarted(MakeProjectStartedEventArgs(_projectFile, "Restore", firstContext));
+            _centralNodeEventSource.InvokeProjectFinished(MakeProjectFinishedEventArgs(
+                _projectFile,
+                succeeded: true,
+                buildEventContext: firstContext));
+            _centralNodeEventSource.InvokeBuildFinished(MakeBuildFinishedEventArgs(true, firstContext));
+
+            BuildEventContext secondContext = MakeBuildEventContext(evalId: 1, projectContextId: 2);
+            _centralNodeEventSource.InvokeBuildStarted(MakeBuildStartedEventArgs(secondContext));
+            _centralNodeEventSource.InvokeStatusEventRaised(MakeProjectEvalFinishedArgs(_projectFile2, buildEventContext: secondContext));
+            _centralNodeEventSource.InvokeProjectStarted(MakeProjectStartedEventArgs(_projectFile2, "Restore", secondContext));
+
+            stopwatches.Count.ShouldBe(2);
+            stopwatches[1].ElapsedSeconds.ShouldBe(0.1);
+
+            _centralNodeEventSource.InvokeTaskStarted(MakeTaskStartedEventArgs(_projectFile2, "MSBuild", secondContext));
+
+            stopwatches[1].IsStarted.ShouldBeTrue();
+            stopwatches[1].ElapsedSeconds.ShouldBe(0.1);
+
+            _centralNodeEventSource.InvokeTaskFinished(MakeTaskFinishedEventArgs(_projectFile2, "MSBuild", true, secondContext));
+            _centralNodeEventSource.InvokeProjectFinished(MakeProjectFinishedEventArgs(_projectFile2, true, secondContext));
+            _centralNodeEventSource.InvokeBuildFinished(MakeBuildFinishedEventArgs(true, secondContext));
+        }
+
+        [Fact]
+        public void ProjectStarted_UnicodeRestoreLookalike_IsNotTreatedAsRestore()
+        {
+            var stopwatch = new MockStopwatch();
+            _terminallogger._createStopwatch = () => stopwatch;
+
+            BuildEventContext context = MakeBuildEventContext();
+            _centralNodeEventSource.InvokeBuildStarted(MakeBuildStartedEventArgs(context));
+            _centralNodeEventSource.InvokeStatusEventRaised(MakeProjectEvalFinishedArgs(_projectFile, buildEventContext: context));
+            _centralNodeEventSource.InvokeProjectStarted(MakeProjectStartedEventArgs(_projectFile, "\u0152estore", context));
+            _centralNodeEventSource.InvokeTaskStarted(MakeTaskStartedEventArgs(_projectFile, "MSBuild", context));
+
+            stopwatch.IsStarted.ShouldBeFalse();
+        }
+
+        [Fact]
+        public void TaskEvents_UnicodeMSBuildLookalike_AreNotTreatedAsMSBuild()
+        {
+            var stopwatch = new MockStopwatch();
+            _terminallogger._createStopwatch = () => stopwatch;
+
+            BuildEventContext context = MakeBuildEventContext();
+            _centralNodeEventSource.InvokeBuildStarted(MakeBuildStartedEventArgs(context));
+            _centralNodeEventSource.InvokeStatusEventRaised(MakeProjectEvalFinishedArgs(_projectFile, buildEventContext: context));
+            _centralNodeEventSource.InvokeProjectStarted(MakeProjectStartedEventArgs(_projectFile, buildEventContext: context));
+
+            _centralNodeEventSource.InvokeTaskStarted(MakeTaskStartedEventArgs(_projectFile, "\u014DSBuild", context));
+            stopwatch.IsStarted.ShouldBeTrue();
+
+            _centralNodeEventSource.InvokeTaskStarted(MakeTaskStartedEventArgs(_projectFile, "MSBuild", context));
+            stopwatch.IsStarted.ShouldBeFalse();
+
+            _centralNodeEventSource.InvokeTaskFinished(MakeTaskFinishedEventArgs(_projectFile, "\u014DSBuild", true, context));
+            stopwatch.IsStarted.ShouldBeFalse();
+
+            _centralNodeEventSource.InvokeTaskFinished(MakeTaskFinishedEventArgs(_projectFile, "MSBuild", true, context));
+            stopwatch.IsStarted.ShouldBeTrue();
+        }
 
         [Fact]
         public async Task DisplayNodesOverwritesWithNewTargetFramework()

--- a/src/Build/Logging/BuildEventTracker.cs
+++ b/src/Build/Logging/BuildEventTracker.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections.Generic;
 using Microsoft.Build.Framework;
 
 namespace Microsoft.Build.Logging;
@@ -12,7 +13,7 @@ internal sealed class BuildEventTracker
 
     internal readonly record struct BuildFinishedSnapshot(DateTime Timestamp, TimeSpan Duration, bool Succeeded);
 
-    internal readonly record struct ProjectStartedSnapshot(
+    internal sealed record ProjectSnapshot(
         int ProjectContextId,
         int NodeId,
         int EvaluationId,
@@ -20,7 +21,10 @@ internal sealed class BuildEventTracker
         string? TargetNames,
         string? EvaluationProjectFile,
         string? TargetFramework,
-        string? RuntimeIdentifier);
+        string? RuntimeIdentifier)
+    {
+        internal ProjectContextKey ContextKey => new(NodeId, ProjectContextId);
+    }
 
     private IEventSource? _eventSource;
 
@@ -28,37 +32,35 @@ internal sealed class BuildEventTracker
 
     internal event Action<BuildFinishedSnapshot>? BuildFinishedTracked;
 
-    internal event Action<ProjectStartedSnapshot>? ProjectStartedTracked;
+    internal event Action<ProjectSnapshot>? ProjectStartedTracked;
 
-    internal event Action<ProjectFinishedEventArgs>? ProjectFinishedTracked;
+    internal event Action<ProjectSnapshot?, ProjectFinishedEventArgs>? ProjectFinishedTracked;
 
-    internal event Action<TargetStartedEventArgs>? TargetStartedTracked;
+    internal event Action<ProjectSnapshot?, TargetStartedEventArgs>? TargetStartedTracked;
 
-    internal event Action<TargetFinishedEventArgs>? TargetFinishedTracked;
+    internal event Action<ProjectSnapshot?, TargetFinishedEventArgs>? TargetFinishedTracked;
 
-    internal event Action<TaskStartedEventArgs>? TaskStartedTracked;
+    internal event Action<ProjectSnapshot?, TaskStartedEventArgs>? TaskStartedTracked;
 
-    internal event Action<TaskFinishedEventArgs>? TaskFinishedTracked;
+    internal event Action<ProjectSnapshot?, TaskFinishedEventArgs>? TaskFinishedTracked;
 
     internal event Action<BuildStatusEventArgs>? StatusEventTracked;
 
-    internal event Action<BuildMessageEventArgs>? MessageTracked;
+    internal event Action<ProjectSnapshot?, BuildMessageEventArgs>? MessageTracked;
 
-    internal event Action<BuildWarningEventArgs>? WarningTracked;
+    internal event Action<ProjectSnapshot?, BuildWarningEventArgs>? WarningTracked;
 
-    internal event Action<BuildErrorEventArgs>? ErrorTracked;
-
-    private DateTime _buildStartTime;
+    internal event Action<ProjectSnapshot?, BuildErrorEventArgs>? ErrorTracked;
 
     internal DateTime BuildStartTime { get; private set; }
 
     /// <summary>
-    /// A wrapper over the project context ID passed to us in <see cref="IEventSource"/> logger events.
+    /// Identifies a project request context across all build nodes.
     /// </summary>
-    internal record struct ProjectContext(int Id)
+    internal readonly record struct ProjectContextKey(int NodeId, int ProjectContextId)
     {
-        public ProjectContext(BuildEventContext context)
-            : this(context.ProjectContextId)
+        public ProjectContextKey(BuildEventContext context)
+            : this(context.NodeId, context.ProjectContextId)
         {
         }
     }
@@ -66,7 +68,7 @@ internal sealed class BuildEventTracker
     /// <summary>
     /// A wrapper over the evaluation context ID passed to us in <see cref="IEventSource"/> logger events.
     /// </summary>
-    internal record struct EvalContext(int Id)
+    internal readonly record struct EvalContext(int Id)
     {
         public EvalContext(BuildEventContext context)
             : this(context.EvaluationId)
@@ -78,22 +80,13 @@ internal sealed class BuildEventTracker
     /// Tracks the status of all relevant projects seen so far.
     /// </summary>
     /// <remarks>
-    /// Keyed by an ID that gets passed to logger callbacks, this allows us to quickly look up the corresponding project.
+    /// Keyed by the node and node-unique project context ID passed to logger callbacks.
     /// </remarks>
-    private readonly Dictionary<ProjectContext, TerminalProjectInfo> _projects = [];
+    private readonly Dictionary<ProjectContextKey, ProjectSnapshot> _projects = [];
 
     private readonly Dictionary<EvalContext, EvalProjectInfo> _projectEvaluations = [];
 
-    /// <summary>
-    /// Tracks the work currently being done by build nodes. Null means the node is not doing any work worth reporting.
-    /// </summary>
-    /// <remarks>
-    /// There is no locking around access to this data structure despite it being accessed concurrently by multiple threads.
-    /// However, reads and writes to locations in an array is atomic, so locking is not required.
-    /// </remarks>
-    private TerminalNodeStatus?[] _nodes = Array.Empty<TerminalNodeStatus>();
-
-    public void Attach(IEventSource eventSource)
+    internal void Attach(IEventSource eventSource)
     {
         ArgumentNullException.ThrowIfNull(eventSource);
 
@@ -135,6 +128,9 @@ internal sealed class BuildEventTracker
 
     private void OnBuildStarted(object sender, BuildStartedEventArgs e)
     {
+        _projects.Clear();
+        _projectEvaluations.Clear();
+
         BuildStartTime = e.Timestamp;
         BuildStartedTracked?.Invoke(new BuildStartedSnapshot(e.Timestamp));
     }
@@ -143,13 +139,13 @@ internal sealed class BuildEventTracker
     {
         BuildFinishedTracked?.Invoke(new BuildFinishedSnapshot(
             e.Timestamp,
-            e.Timestamp - _buildStartTime,
+            e.Timestamp - BuildStartTime,
             e.Succeeded));
     }
 
     private void OnProjectStarted(object sender, ProjectStartedEventArgs e)
     {
-        var buildEventContext = e.BuildEventContext;
+        BuildEventContext? buildEventContext = e.BuildEventContext;
         if (buildEventContext is null)
         {
             return;
@@ -157,7 +153,7 @@ internal sealed class BuildEventTracker
 
         _projectEvaluations.TryGetValue(new EvalContext(buildEventContext), out EvalProjectInfo evalInfo);
 
-        ProjectStartedTracked?.Invoke(new ProjectStartedSnapshot(
+        ProjectSnapshot project = new(
             buildEventContext.ProjectContextId,
             buildEventContext.NodeId,
             buildEventContext.EvaluationId,
@@ -165,32 +161,35 @@ internal sealed class BuildEventTracker
             e.TargetNames,
             evalInfo.ProjectFile,
             evalInfo.TargetFramework,
-            evalInfo.RuntimeIdentifier));
+            evalInfo.RuntimeIdentifier);
+
+        _projects[project.ContextKey] = project;
+        ProjectStartedTracked?.Invoke(project);
     }
 
     private void OnProjectFinished(object sender, ProjectFinishedEventArgs e)
     {
-        ProjectFinishedTracked?.Invoke(e);
+        ProjectFinishedTracked?.Invoke(CorrelateProject(e), e);
     }
 
     private void OnTargetStarted(object sender, TargetStartedEventArgs e)
     {
-        TargetStartedTracked?.Invoke(e);
+        TargetStartedTracked?.Invoke(CorrelateProject(e), e);
     }
 
     private void OnTargetFinished(object sender, TargetFinishedEventArgs e)
     {
-        TargetFinishedTracked?.Invoke(e);
+        TargetFinishedTracked?.Invoke(CorrelateProject(e), e);
     }
 
     private void OnTaskStarted(object sender, TaskStartedEventArgs e)
     {
-        TaskStartedTracked?.Invoke(e);
+        TaskStartedTracked?.Invoke(CorrelateProject(e), e);
     }
 
     private void OnTaskFinished(object sender, TaskFinishedEventArgs e)
     {
-        TaskFinishedTracked?.Invoke(e);
+        TaskFinishedTracked?.Invoke(CorrelateProject(e), e);
     }
 
     private void OnStatusEventRaised(object sender, BuildStatusEventArgs e)
@@ -205,20 +204,20 @@ internal sealed class BuildEventTracker
 
     private void OnMessageRaised(object sender, BuildMessageEventArgs e)
     {
-        MessageTracked?.Invoke(e);
+        MessageTracked?.Invoke(CorrelateProject(e), e);
     }
 
     private void OnWarningRaised(object sender, BuildWarningEventArgs e)
     {
-        WarningTracked?.Invoke(e);
+        WarningTracked?.Invoke(CorrelateProject(e), e);
     }
 
     private void OnErrorRaised(object sender, BuildErrorEventArgs e)
     {
-        ErrorTracked?.Invoke(e);
+        ErrorTracked?.Invoke(CorrelateProject(e), e);
     }
 
-    public void CaptureEvalContext(ProjectEvaluationFinishedEventArgs evalFinish)
+    private void CaptureEvalContext(ProjectEvaluationFinishedEventArgs evalFinish)
     {
         var buildEventContext = evalFinish.BuildEventContext;
         if (buildEventContext is null)
@@ -249,147 +248,19 @@ internal sealed class BuildEventTracker
                         break;
                 }
             }
-            var evalInfo = new EvalProjectInfo(new TerminalLogger.EvalContext(buildEventContext), evalFinish.ProjectFile, tfm, rid);
+            var evalInfo = new EvalProjectInfo(evalFinish.ProjectFile, tfm, rid);
             _projectEvaluations[c] = evalInfo;
         }
     }
+
+    private ProjectSnapshot? CorrelateProject(BuildEventArgs e)
+    {
+        BuildEventContext? buildEventContext = e.BuildEventContext;
+        return buildEventContext is not null
+            && _projects.TryGetValue(
+                new ProjectContextKey(buildEventContext),
+                out ProjectSnapshot? project)
+                    ? project
+                    : null;
+    }
 }
-
-//  BuildEventTracker 
-// Subscribe to events; correlate evaluation/project/target/task contexts; maintain lifecycle state; 
-// expose normalized callbacks/snapshots
-
-// TerminalLogger
-// Render live node progress, ANSI output, hyperlinks, restore/test summaries, terminal-width behavior     
-
-
-// Subscribe to events
-
-//  TerminalLogger.Initialize  directly registers its handlers:
-
-//  TerminalLogger.cs:457-468 
-
-// eventSource.BuildStarted += BuildStarted;
-// eventSource.BuildFinished += BuildFinished;
-// eventSource.ProjectStarted += ProjectStarted;
-// eventSource.ProjectFinished += ProjectFinished;
-// eventSource.TargetStarted += TargetStarted;
-// eventSource.TargetFinished += TargetFinished;
-// eventSource.TaskStarted += TaskStarted;
-// eventSource.TaskFinished += TaskFinished;
-// eventSource.StatusEventRaised += StatusEventRaised;
-// eventSource.MessageRaised += MessageRaised;
-// eventSource.WarningRaised += WarningRaised;
-// eventSource.ErrorRaised += ErrorRaised;
-
-// This subscription logic could move into  BuildEventTracker.Attach(IEventSource) .
-
-
-
-
-
-// Correlate contexts
-
-// Context keys are defined at:
-
-//  TerminalLogger.cs:57-73 
-
-// internal record struct ProjectContext(int Id);
-// internal record struct EvalContext(int Id);
-
-// Tracked state is stored at:
-
-//  TerminalLogger.cs:113-124 
-
-// private readonly Dictionary<ProjectContext, TerminalProjectInfo> _projects = [];
-// private readonly Dictionary<EvalContext, EvalProjectInfo> _projectEvaluations = [];
-// private TerminalNodeStatus?[] _nodes = [];
-
-// Evaluation-to-project correlation happens through:
-
-// •  CaptureEvalContext : lines  904-937 
-// •  ProjectStarted : lines  742-780 
-
-// The evaluation is first stored by  EvaluationId , then retrieved when a project with the corresponding evaluation starts.
-
-// Project-scoped events repeatedly resolve their project through:
-
-// _projects.TryGetValue(
-//     new ProjectContext(buildEventContext),
-//     out TerminalProjectInfo? project);
-
-// This occurs in target, task, message, warning, and error handlers.
-
-// The current target correlation is limited:  TargetStarted  stores the target name in  project.CurrentTarget . There is not yet a general target/task model keyed by  TargetId  and  TaskId .
-
-
-
-
-
-
-
-
-// Maintain lifecycle state
-
-// Project creation and timing:
-
-//  TerminalLogger.cs:742-780 
-
-// TerminalProjectInfo projectInfo = new(c, evalInfo, ...);
-// _projects[c] = projectInfo;
-
-// Project completion:
-
-//  TerminalLogger.cs:786-805 
-
-// project.Succeeded = e.Succeeded;
-// project.Stopwatch.Stop();
-
-// Target state:
-
-//  TerminalLogger.cs:1063-1092 
-
-// project.Stopwatch.Start();
-// project.CurrentTarget = targetName;
-// UpdateNodeStatus(buildEventContext, nodeStatus);
-
-// Task yielding/resuming is handled at lines  1167-1197 . In particular, the  MSBuild  task temporarily stops project timing and marks the node idle.
-
-// Diagnostic state is maintained by  TerminalProjectInfo :
-
-//  TerminalProjectInfo.cs:91-150 
-
-// public string? CurrentTarget { get; set; }
-// public bool Succeeded { get; set; }
-// public int ErrorCount { get; private set; }
-// public int WarningCount { get; private set; }
-// public IReadOnlyList<TerminalBuildMessage>? BuildMessages => _buildMessages;
-
-// public void AddBuildMessage(...)
-
-// Warnings and errors are associated with projects in:
-
-// •  WarningRaised :  TerminalLogger.cs:1363-1394 
-// •  ErrorRaised :  TerminalLogger.cs:1452-1468 
-
-// Expose normalized callbacks or snapshots
-
-// This functionality does not currently exist.
-
-//  TerminalLogger  updates its private state and immediately renders from the same handlers. For example,  ProjectFinished  both completes project state and writes terminal output.
-
-// The extraction would need to introduce something like:
-
-// tracker.ProjectStarted += OnProjectStarted;
-// tracker.ProjectUpdated += OnProjectUpdated;
-// tracker.DiagnosticRaised += OnDiagnosticRaised;
-// tracker.ProjectFinished += OnProjectFinished;
-
-// with presentation-neutral models such as:
-
-// ProjectSnapshot
-// DiagnosticSnapshot
-// TargetSnapshot
-// TaskSnapshot
-
-// That is the main new abstraction: converting TerminalLogger’s private mutable state into read-only information consumable by both  TerminalLogger  and  CiLoggerBase .

--- a/src/Build/Logging/BuildEventTracker.cs
+++ b/src/Build/Logging/BuildEventTracker.cs
@@ -9,22 +9,105 @@ namespace Microsoft.Build.Logging;
 
 internal sealed class BuildEventTracker
 {
+    private const string MSBuildTaskName = "MSBuild";
+    private const string RestoreTargetName = "Restore";
+
+    internal sealed class TrackedProject
+    {
+        private readonly StopwatchAbstraction _stopwatch;
+
+        internal TrackedProject(
+            ProjectContextKey contextKey,
+            int evaluationId,
+            string? projectFile,
+            string? targetNames,
+            string? evaluationProjectFile,
+            string? targetFramework,
+            string? runtimeIdentifier,
+            StopwatchAbstraction stopwatch)
+        {
+            ContextKey = contextKey;
+            EvaluationId = evaluationId;
+            ProjectFile = projectFile;
+            TargetNames = targetNames;
+            EvaluationProjectFile = evaluationProjectFile;
+            TargetFramework = targetFramework;
+            RuntimeIdentifier = runtimeIdentifier;
+            _stopwatch = stopwatch;
+
+            _stopwatch.Start();
+        }
+
+        internal ProjectContextKey ContextKey { get; }
+
+        internal int ProjectContextId => ContextKey.ProjectContextId;
+
+        internal int NodeId => ContextKey.NodeId;
+
+        internal int EvaluationId { get; }
+
+        internal string? ProjectFile { get; }
+
+        internal string? TargetNames { get; }
+
+        internal string? EvaluationProjectFile { get; }
+
+        internal string? TargetFramework { get; }
+
+        internal string? RuntimeIdentifier { get; }
+
+        internal string? CurrentTarget { get; private set; }
+
+        internal bool? Succeeded { get; private set; }
+
+        internal int ErrorCount { get; private set; }
+
+        internal int WarningCount { get; private set; }
+
+        internal bool HasErrorsOrWarnings => ErrorCount > 0 || WarningCount > 0;
+
+        internal double ElapsedSeconds => _stopwatch.ElapsedSeconds;
+
+        internal StopwatchAbstraction Stopwatch => _stopwatch;
+
+        internal void StartTarget(string targetName)
+        {
+            CurrentTarget = targetName;
+            _stopwatch.Start();
+        }
+
+        internal void Yield()
+        {
+            _stopwatch.Stop();
+        }
+
+        internal void Resume()
+        {
+            _stopwatch.Start();
+        }
+
+        internal void AddWarning()
+        {
+            WarningCount++;
+        }
+
+        internal void AddError()
+        {
+            ErrorCount++;
+        }
+
+        internal void Finish(bool succeeded)
+        {
+            Succeeded = succeeded;
+            _stopwatch.Stop();
+        }
+    }
+
+    internal Func<StopwatchAbstraction>? StopwatchFactory { get; set; }
+
     internal readonly record struct BuildStartedSnapshot(DateTime Timestamp);
 
     internal readonly record struct BuildFinishedSnapshot(DateTime Timestamp, TimeSpan Duration, bool Succeeded);
-
-    internal sealed record ProjectSnapshot(
-        int ProjectContextId,
-        int NodeId,
-        int EvaluationId,
-        string? ProjectFile,
-        string? TargetNames,
-        string? EvaluationProjectFile,
-        string? TargetFramework,
-        string? RuntimeIdentifier)
-    {
-        internal ProjectContextKey ContextKey => new(NodeId, ProjectContextId);
-    }
 
     private IEventSource? _eventSource;
 
@@ -32,25 +115,25 @@ internal sealed class BuildEventTracker
 
     internal event Action<BuildFinishedSnapshot>? BuildFinishedTracked;
 
-    internal event Action<ProjectSnapshot>? ProjectStartedTracked;
+    internal event Action<TrackedProject>? ProjectStartedTracked;
 
-    internal event Action<ProjectSnapshot?, ProjectFinishedEventArgs>? ProjectFinishedTracked;
+    internal event Action<TrackedProject?, ProjectFinishedEventArgs>? ProjectFinishedTracked;
 
-    internal event Action<ProjectSnapshot?, TargetStartedEventArgs>? TargetStartedTracked;
+    internal event Action<TrackedProject?, TargetStartedEventArgs>? TargetStartedTracked;
 
-    internal event Action<ProjectSnapshot?, TargetFinishedEventArgs>? TargetFinishedTracked;
+    internal event Action<TrackedProject?, TargetFinishedEventArgs>? TargetFinishedTracked;
 
-    internal event Action<ProjectSnapshot?, TaskStartedEventArgs>? TaskStartedTracked;
+    internal event Action<TrackedProject?, TaskStartedEventArgs>? TaskStartedTracked;
 
-    internal event Action<ProjectSnapshot?, TaskFinishedEventArgs>? TaskFinishedTracked;
+    internal event Action<TrackedProject?, TaskFinishedEventArgs>? TaskFinishedTracked;
 
     internal event Action<BuildStatusEventArgs>? StatusEventTracked;
 
-    internal event Action<ProjectSnapshot?, BuildMessageEventArgs>? MessageTracked;
+    internal event Action<TrackedProject?, BuildMessageEventArgs>? MessageTracked;
 
-    internal event Action<ProjectSnapshot?, BuildWarningEventArgs>? WarningTracked;
+    internal event Action<TrackedProject?, BuildWarningEventArgs>? WarningTracked;
 
-    internal event Action<ProjectSnapshot?, BuildErrorEventArgs>? ErrorTracked;
+    internal event Action<TrackedProject?, BuildErrorEventArgs>? ErrorTracked;
 
     internal DateTime BuildStartTime { get; private set; }
 
@@ -82,7 +165,7 @@ internal sealed class BuildEventTracker
     /// <remarks>
     /// Keyed by the node and node-unique project context ID passed to logger callbacks.
     /// </remarks>
-    private readonly Dictionary<ProjectContextKey, ProjectSnapshot> _projects = [];
+    private readonly Dictionary<ProjectContextKey, TrackedProject> _projects = [];
 
     private readonly Dictionary<EvalContext, EvalProjectInfo> _projectEvaluations = [];
 
@@ -153,15 +236,17 @@ internal sealed class BuildEventTracker
 
         _projectEvaluations.TryGetValue(new EvalContext(buildEventContext), out EvalProjectInfo evalInfo);
 
-        ProjectSnapshot project = new(
-            buildEventContext.ProjectContextId,
-            buildEventContext.NodeId,
+        StopwatchAbstraction stopwatch = StopwatchFactory?.Invoke() ?? new SystemStopwatch();
+
+        TrackedProject project = new(
+            new ProjectContextKey(buildEventContext),
             buildEventContext.EvaluationId,
             e.ProjectFile,
             e.TargetNames,
             evalInfo.ProjectFile,
             evalInfo.TargetFramework,
-            evalInfo.RuntimeIdentifier);
+            evalInfo.RuntimeIdentifier,
+            stopwatch);
 
         _projects[project.ContextKey] = project;
         ProjectStartedTracked?.Invoke(project);
@@ -169,12 +254,16 @@ internal sealed class BuildEventTracker
 
     private void OnProjectFinished(object sender, ProjectFinishedEventArgs e)
     {
-        ProjectFinishedTracked?.Invoke(CorrelateProject(e), e);
+        TrackedProject? project = CorrelateProject(e);
+        project?.Finish(e.Succeeded);
+        ProjectFinishedTracked?.Invoke(project, e);
     }
 
     private void OnTargetStarted(object sender, TargetStartedEventArgs e)
     {
-        TargetStartedTracked?.Invoke(CorrelateProject(e), e);
+        TrackedProject? project = CorrelateProject(e);
+        project?.StartTarget(e.TargetName);
+        TargetStartedTracked?.Invoke(project, e);
     }
 
     private void OnTargetFinished(object sender, TargetFinishedEventArgs e)
@@ -184,12 +273,28 @@ internal sealed class BuildEventTracker
 
     private void OnTaskStarted(object sender, TaskStartedEventArgs e)
     {
-        TaskStartedTracked?.Invoke(CorrelateProject(e), e);
+        TrackedProject? project = CorrelateProject(e);
+        if (project is not null
+            && project.TargetNames != RestoreTargetName
+            && e.TaskName == MSBuildTaskName)
+        {
+            project.Yield();
+        }
+        TaskStartedTracked?.Invoke(project, e);
     }
 
     private void OnTaskFinished(object sender, TaskFinishedEventArgs e)
     {
-        TaskFinishedTracked?.Invoke(CorrelateProject(e), e);
+        TrackedProject? project = CorrelateProject(e);
+
+        if (project is not null
+            && project.TargetNames != RestoreTargetName
+            && e.TaskName == MSBuildTaskName)
+        {
+            project.Resume();
+        }
+
+        TaskFinishedTracked?.Invoke(project, e);
     }
 
     private void OnStatusEventRaised(object sender, BuildStatusEventArgs e)
@@ -209,12 +314,16 @@ internal sealed class BuildEventTracker
 
     private void OnWarningRaised(object sender, BuildWarningEventArgs e)
     {
-        WarningTracked?.Invoke(CorrelateProject(e), e);
+        TrackedProject? project = CorrelateProject(e);
+        project?.AddWarning();
+        WarningTracked?.Invoke(project, e);
     }
 
     private void OnErrorRaised(object sender, BuildErrorEventArgs e)
     {
-        ErrorTracked?.Invoke(CorrelateProject(e), e);
+        TrackedProject? project = CorrelateProject(e);
+        project?.AddError();
+        ErrorTracked?.Invoke(project, e);
     }
 
     private void CaptureEvalContext(ProjectEvaluationFinishedEventArgs evalFinish)
@@ -253,13 +362,13 @@ internal sealed class BuildEventTracker
         }
     }
 
-    private ProjectSnapshot? CorrelateProject(BuildEventArgs e)
+    private TrackedProject? CorrelateProject(BuildEventArgs e)
     {
         BuildEventContext? buildEventContext = e.BuildEventContext;
         return buildEventContext is not null
             && _projects.TryGetValue(
                 new ProjectContextKey(buildEventContext),
-                out ProjectSnapshot? project)
+                out TrackedProject? project)
                     ? project
                     : null;
     }

--- a/src/Build/Logging/BuildEventTracker.cs
+++ b/src/Build/Logging/BuildEventTracker.cs
@@ -110,6 +110,8 @@ internal sealed class BuildEventTracker
     internal readonly record struct BuildFinishedSnapshot(DateTime Timestamp, TimeSpan Duration, bool Succeeded);
 
     private IEventSource? _eventSource;
+    private ProjectContextKey? _initialRestoreContext;
+    private bool _initialRestoreFinished;
 
     internal event Action<BuildStartedSnapshot>? BuildStartedTracked;
 
@@ -213,6 +215,8 @@ internal sealed class BuildEventTracker
     {
         _projects.Clear();
         _projectEvaluations.Clear();
+        _initialRestoreContext = null;
+        _initialRestoreFinished = false;
 
         BuildStartTime = e.Timestamp;
         BuildStartedTracked?.Invoke(new BuildStartedSnapshot(e.Timestamp));
@@ -249,13 +253,31 @@ internal sealed class BuildEventTracker
             stopwatch);
 
         _projects[project.ContextKey] = project;
+
+        if (!_initialRestoreFinished
+            && _initialRestoreContext is null
+            && project.TargetNames == RestoreTargetName)
+        {
+            _initialRestoreContext = project.ContextKey;
+        }
+
         ProjectStartedTracked?.Invoke(project);
     }
 
     private void OnProjectFinished(object sender, ProjectFinishedEventArgs e)
     {
         TrackedProject? project = CorrelateProject(e);
-        project?.Finish(e.Succeeded);
+        if (project is not null)
+        {
+            project.Finish(e.Succeeded);
+
+            if (project.ContextKey == _initialRestoreContext)
+            {
+                _initialRestoreContext = null;
+                _initialRestoreFinished = true;
+            }
+        }
+
         ProjectFinishedTracked?.Invoke(project, e);
     }
 
@@ -275,7 +297,7 @@ internal sealed class BuildEventTracker
     {
         TrackedProject? project = CorrelateProject(e);
         if (project is not null
-            && project.TargetNames != RestoreTargetName
+            && _initialRestoreContext is null
             && e.TaskName == MSBuildTaskName)
         {
             project.Yield();
@@ -288,7 +310,7 @@ internal sealed class BuildEventTracker
         TrackedProject? project = CorrelateProject(e);
 
         if (project is not null
-            && project.TargetNames != RestoreTargetName
+            && _initialRestoreContext is null
             && e.TaskName == MSBuildTaskName)
         {
             project.Resume();

--- a/src/Build/Logging/BuildEventTracker.cs
+++ b/src/Build/Logging/BuildEventTracker.cs
@@ -1,0 +1,395 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using Microsoft.Build.Framework;
+
+namespace Microsoft.Build.Logging;
+
+internal sealed class BuildEventTracker
+{
+    internal readonly record struct BuildStartedSnapshot(DateTime Timestamp);
+
+    internal readonly record struct BuildFinishedSnapshot(DateTime Timestamp, TimeSpan Duration, bool Succeeded);
+
+    internal readonly record struct ProjectStartedSnapshot(
+        int ProjectContextId,
+        int NodeId,
+        int EvaluationId,
+        string? ProjectFile,
+        string? TargetNames,
+        string? EvaluationProjectFile,
+        string? TargetFramework,
+        string? RuntimeIdentifier);
+
+    private IEventSource? _eventSource;
+
+    internal event Action<BuildStartedSnapshot>? BuildStartedTracked;
+
+    internal event Action<BuildFinishedSnapshot>? BuildFinishedTracked;
+
+    internal event Action<ProjectStartedSnapshot>? ProjectStartedTracked;
+
+    internal event Action<ProjectFinishedEventArgs>? ProjectFinishedTracked;
+
+    internal event Action<TargetStartedEventArgs>? TargetStartedTracked;
+
+    internal event Action<TargetFinishedEventArgs>? TargetFinishedTracked;
+
+    internal event Action<TaskStartedEventArgs>? TaskStartedTracked;
+
+    internal event Action<TaskFinishedEventArgs>? TaskFinishedTracked;
+
+    internal event Action<BuildStatusEventArgs>? StatusEventTracked;
+
+    internal event Action<BuildMessageEventArgs>? MessageTracked;
+
+    internal event Action<BuildWarningEventArgs>? WarningTracked;
+
+    internal event Action<BuildErrorEventArgs>? ErrorTracked;
+
+    private DateTime _buildStartTime;
+
+    internal DateTime BuildStartTime { get; private set; }
+
+    /// <summary>
+    /// A wrapper over the project context ID passed to us in <see cref="IEventSource"/> logger events.
+    /// </summary>
+    internal record struct ProjectContext(int Id)
+    {
+        public ProjectContext(BuildEventContext context)
+            : this(context.ProjectContextId)
+        {
+        }
+    }
+
+    /// <summary>
+    /// A wrapper over the evaluation context ID passed to us in <see cref="IEventSource"/> logger events.
+    /// </summary>
+    internal record struct EvalContext(int Id)
+    {
+        public EvalContext(BuildEventContext context)
+            : this(context.EvaluationId)
+        {
+        }
+    }
+
+    /// <summary>
+    /// Tracks the status of all relevant projects seen so far.
+    /// </summary>
+    /// <remarks>
+    /// Keyed by an ID that gets passed to logger callbacks, this allows us to quickly look up the corresponding project.
+    /// </remarks>
+    private readonly Dictionary<ProjectContext, TerminalProjectInfo> _projects = [];
+
+    private readonly Dictionary<EvalContext, EvalProjectInfo> _projectEvaluations = [];
+
+    /// <summary>
+    /// Tracks the work currently being done by build nodes. Null means the node is not doing any work worth reporting.
+    /// </summary>
+    /// <remarks>
+    /// There is no locking around access to this data structure despite it being accessed concurrently by multiple threads.
+    /// However, reads and writes to locations in an array is atomic, so locking is not required.
+    /// </remarks>
+    private TerminalNodeStatus?[] _nodes = Array.Empty<TerminalNodeStatus>();
+
+    public void Attach(IEventSource eventSource)
+    {
+        ArgumentNullException.ThrowIfNull(eventSource);
+
+        _eventSource = eventSource;
+
+        eventSource.BuildStarted += OnBuildStarted;
+        eventSource.BuildFinished += OnBuildFinished;
+        eventSource.ProjectStarted += OnProjectStarted;
+        eventSource.ProjectFinished += OnProjectFinished;
+        eventSource.TargetStarted += OnTargetStarted;
+        eventSource.TargetFinished += OnTargetFinished;
+        eventSource.TaskStarted += OnTaskStarted;
+        eventSource.TaskFinished += OnTaskFinished;
+        eventSource.StatusEventRaised += OnStatusEventRaised;
+        eventSource.MessageRaised += OnMessageRaised;
+        eventSource.WarningRaised += OnWarningRaised;
+        eventSource.ErrorRaised += OnErrorRaised;
+    }
+
+    internal void Detach()
+    {
+        if (_eventSource is not null)
+        {
+            _eventSource.BuildStarted -= OnBuildStarted;
+            _eventSource.BuildFinished -= OnBuildFinished;
+            _eventSource.ProjectStarted -= OnProjectStarted;
+            _eventSource.ProjectFinished -= OnProjectFinished;
+            _eventSource.TargetStarted -= OnTargetStarted;
+            _eventSource.TargetFinished -= OnTargetFinished;
+            _eventSource.TaskStarted -= OnTaskStarted;
+            _eventSource.TaskFinished -= OnTaskFinished;
+            _eventSource.StatusEventRaised -= OnStatusEventRaised;
+            _eventSource.MessageRaised -= OnMessageRaised;
+            _eventSource.WarningRaised -= OnWarningRaised;
+            _eventSource.ErrorRaised -= OnErrorRaised;
+            _eventSource = null;
+        }
+    }
+
+    private void OnBuildStarted(object sender, BuildStartedEventArgs e)
+    {
+        BuildStartTime = e.Timestamp;
+        BuildStartedTracked?.Invoke(new BuildStartedSnapshot(e.Timestamp));
+    }
+
+    private void OnBuildFinished(object sender, BuildFinishedEventArgs e)
+    {
+        BuildFinishedTracked?.Invoke(new BuildFinishedSnapshot(
+            e.Timestamp,
+            e.Timestamp - _buildStartTime,
+            e.Succeeded));
+    }
+
+    private void OnProjectStarted(object sender, ProjectStartedEventArgs e)
+    {
+        var buildEventContext = e.BuildEventContext;
+        if (buildEventContext is null)
+        {
+            return;
+        }
+
+        _projectEvaluations.TryGetValue(new EvalContext(buildEventContext), out EvalProjectInfo evalInfo);
+
+        ProjectStartedTracked?.Invoke(new ProjectStartedSnapshot(
+            buildEventContext.ProjectContextId,
+            buildEventContext.NodeId,
+            buildEventContext.EvaluationId,
+            e.ProjectFile,
+            e.TargetNames,
+            evalInfo.ProjectFile,
+            evalInfo.TargetFramework,
+            evalInfo.RuntimeIdentifier));
+    }
+
+    private void OnProjectFinished(object sender, ProjectFinishedEventArgs e)
+    {
+        ProjectFinishedTracked?.Invoke(e);
+    }
+
+    private void OnTargetStarted(object sender, TargetStartedEventArgs e)
+    {
+        TargetStartedTracked?.Invoke(e);
+    }
+
+    private void OnTargetFinished(object sender, TargetFinishedEventArgs e)
+    {
+        TargetFinishedTracked?.Invoke(e);
+    }
+
+    private void OnTaskStarted(object sender, TaskStartedEventArgs e)
+    {
+        TaskStartedTracked?.Invoke(e);
+    }
+
+    private void OnTaskFinished(object sender, TaskFinishedEventArgs e)
+    {
+        TaskFinishedTracked?.Invoke(e);
+    }
+
+    private void OnStatusEventRaised(object sender, BuildStatusEventArgs e)
+    {
+        if (e is ProjectEvaluationFinishedEventArgs evalFinish)
+        {
+            CaptureEvalContext(evalFinish);
+        }
+
+        StatusEventTracked?.Invoke(e);
+    }
+
+    private void OnMessageRaised(object sender, BuildMessageEventArgs e)
+    {
+        MessageTracked?.Invoke(e);
+    }
+
+    private void OnWarningRaised(object sender, BuildWarningEventArgs e)
+    {
+        WarningTracked?.Invoke(e);
+    }
+
+    private void OnErrorRaised(object sender, BuildErrorEventArgs e)
+    {
+        ErrorTracked?.Invoke(e);
+    }
+
+    public void CaptureEvalContext(ProjectEvaluationFinishedEventArgs evalFinish)
+    {
+        var buildEventContext = evalFinish.BuildEventContext;
+        if (buildEventContext is null)
+        {
+            return;
+        }
+
+        EvalContext c = new(buildEventContext);
+
+        if (!_projectEvaluations.TryGetValue(c, out EvalProjectInfo _))
+        {
+            string? tfm = null;
+            string? rid = null;
+            foreach (var property in evalFinish.EnumerateProperties())
+            {
+                if (tfm is not null && rid is not null)
+                {
+                    // We already have both properties, no need to continue.
+                    break;
+                }
+                switch (property.Name)
+                {
+                    case "TargetFramework":
+                        tfm = property.Value;
+                        break;
+                    case "RuntimeIdentifier":
+                        rid = property.Value;
+                        break;
+                }
+            }
+            var evalInfo = new EvalProjectInfo(new TerminalLogger.EvalContext(buildEventContext), evalFinish.ProjectFile, tfm, rid);
+            _projectEvaluations[c] = evalInfo;
+        }
+    }
+}
+
+//  BuildEventTracker 
+// Subscribe to events; correlate evaluation/project/target/task contexts; maintain lifecycle state; 
+// expose normalized callbacks/snapshots
+
+// TerminalLogger
+// Render live node progress, ANSI output, hyperlinks, restore/test summaries, terminal-width behavior     
+
+
+// Subscribe to events
+
+//  TerminalLogger.Initialize  directly registers its handlers:
+
+//  TerminalLogger.cs:457-468 
+
+// eventSource.BuildStarted += BuildStarted;
+// eventSource.BuildFinished += BuildFinished;
+// eventSource.ProjectStarted += ProjectStarted;
+// eventSource.ProjectFinished += ProjectFinished;
+// eventSource.TargetStarted += TargetStarted;
+// eventSource.TargetFinished += TargetFinished;
+// eventSource.TaskStarted += TaskStarted;
+// eventSource.TaskFinished += TaskFinished;
+// eventSource.StatusEventRaised += StatusEventRaised;
+// eventSource.MessageRaised += MessageRaised;
+// eventSource.WarningRaised += WarningRaised;
+// eventSource.ErrorRaised += ErrorRaised;
+
+// This subscription logic could move into  BuildEventTracker.Attach(IEventSource) .
+
+
+
+
+
+// Correlate contexts
+
+// Context keys are defined at:
+
+//  TerminalLogger.cs:57-73 
+
+// internal record struct ProjectContext(int Id);
+// internal record struct EvalContext(int Id);
+
+// Tracked state is stored at:
+
+//  TerminalLogger.cs:113-124 
+
+// private readonly Dictionary<ProjectContext, TerminalProjectInfo> _projects = [];
+// private readonly Dictionary<EvalContext, EvalProjectInfo> _projectEvaluations = [];
+// private TerminalNodeStatus?[] _nodes = [];
+
+// Evaluation-to-project correlation happens through:
+
+// •  CaptureEvalContext : lines  904-937 
+// •  ProjectStarted : lines  742-780 
+
+// The evaluation is first stored by  EvaluationId , then retrieved when a project with the corresponding evaluation starts.
+
+// Project-scoped events repeatedly resolve their project through:
+
+// _projects.TryGetValue(
+//     new ProjectContext(buildEventContext),
+//     out TerminalProjectInfo? project);
+
+// This occurs in target, task, message, warning, and error handlers.
+
+// The current target correlation is limited:  TargetStarted  stores the target name in  project.CurrentTarget . There is not yet a general target/task model keyed by  TargetId  and  TaskId .
+
+
+
+
+
+
+
+
+// Maintain lifecycle state
+
+// Project creation and timing:
+
+//  TerminalLogger.cs:742-780 
+
+// TerminalProjectInfo projectInfo = new(c, evalInfo, ...);
+// _projects[c] = projectInfo;
+
+// Project completion:
+
+//  TerminalLogger.cs:786-805 
+
+// project.Succeeded = e.Succeeded;
+// project.Stopwatch.Stop();
+
+// Target state:
+
+//  TerminalLogger.cs:1063-1092 
+
+// project.Stopwatch.Start();
+// project.CurrentTarget = targetName;
+// UpdateNodeStatus(buildEventContext, nodeStatus);
+
+// Task yielding/resuming is handled at lines  1167-1197 . In particular, the  MSBuild  task temporarily stops project timing and marks the node idle.
+
+// Diagnostic state is maintained by  TerminalProjectInfo :
+
+//  TerminalProjectInfo.cs:91-150 
+
+// public string? CurrentTarget { get; set; }
+// public bool Succeeded { get; set; }
+// public int ErrorCount { get; private set; }
+// public int WarningCount { get; private set; }
+// public IReadOnlyList<TerminalBuildMessage>? BuildMessages => _buildMessages;
+
+// public void AddBuildMessage(...)
+
+// Warnings and errors are associated with projects in:
+
+// •  WarningRaised :  TerminalLogger.cs:1363-1394 
+// •  ErrorRaised :  TerminalLogger.cs:1452-1468 
+
+// Expose normalized callbacks or snapshots
+
+// This functionality does not currently exist.
+
+//  TerminalLogger  updates its private state and immediately renders from the same handlers. For example,  ProjectFinished  both completes project state and writes terminal output.
+
+// The extraction would need to introduce something like:
+
+// tracker.ProjectStarted += OnProjectStarted;
+// tracker.ProjectUpdated += OnProjectUpdated;
+// tracker.DiagnosticRaised += OnDiagnosticRaised;
+// tracker.ProjectFinished += OnProjectFinished;
+
+// with presentation-neutral models such as:
+
+// ProjectSnapshot
+// DiagnosticSnapshot
+// TargetSnapshot
+// TaskSnapshot
+
+// That is the main new abstraction: converting TerminalLogger’s private mutable state into read-only information consumable by both  TerminalLogger  and  CiLoggerBase .

--- a/src/Build/Logging/BuildEventTracker.cs
+++ b/src/Build/Logging/BuildEventTracker.cs
@@ -12,11 +12,11 @@ internal sealed class BuildEventTracker
     private const string MSBuildTaskName = "MSBuild";
     private const string RestoreTargetName = "Restore";
 
-    internal sealed class TrackedProject
+    private sealed class TrackedProjectState
     {
         private readonly StopwatchAbstraction _stopwatch;
 
-        internal TrackedProject(
+        internal TrackedProjectState(
             ProjectContextKey contextKey,
             int evaluationId,
             string? projectFile,
@@ -64,26 +64,25 @@ internal sealed class BuildEventTracker
 
         internal int WarningCount { get; private set; }
 
-        internal bool HasErrorsOrWarnings => ErrorCount > 0 || WarningCount > 0;
-
-        internal double ElapsedSeconds => _stopwatch.ElapsedSeconds;
-
-        internal StopwatchAbstraction Stopwatch => _stopwatch;
+        internal bool IsTimingActive { get; private set; } = true;
 
         internal void StartTarget(string targetName)
         {
             CurrentTarget = targetName;
             _stopwatch.Start();
+            IsTimingActive = true;
         }
 
         internal void Yield()
         {
             _stopwatch.Stop();
+            IsTimingActive = false;
         }
 
         internal void Resume()
         {
             _stopwatch.Start();
+            IsTimingActive = true;
         }
 
         internal void AddWarning()
@@ -100,7 +99,23 @@ internal sealed class BuildEventTracker
         {
             Succeeded = succeeded;
             _stopwatch.Stop();
+            IsTimingActive = false;
         }
+
+        internal ProjectSnapshot CreateSnapshot() => new(
+            ContextKey,
+            EvaluationId,
+            ProjectFile,
+            TargetNames,
+            EvaluationProjectFile,
+            TargetFramework,
+            RuntimeIdentifier,
+            CurrentTarget,
+            Succeeded,
+            ErrorCount,
+            WarningCount,
+            TimeSpan.FromSeconds(_stopwatch.ElapsedSeconds),
+            IsTimingActive);
     }
 
     internal Func<StopwatchAbstraction>? StopwatchFactory { get; set; }
@@ -108,6 +123,31 @@ internal sealed class BuildEventTracker
     internal readonly record struct BuildStartedSnapshot(DateTime Timestamp);
 
     internal readonly record struct BuildFinishedSnapshot(DateTime Timestamp, TimeSpan Duration, bool Succeeded);
+
+    /// <summary>
+    /// Immutable project lifecycle state captured when a tracked event is raised.
+    /// </summary>
+    internal readonly record struct ProjectSnapshot(
+        ProjectContextKey ContextKey,
+        int EvaluationId,
+        string? ProjectFile,
+        string? TargetNames,
+        string? EvaluationProjectFile,
+        string? TargetFramework,
+        string? RuntimeIdentifier,
+        string? CurrentTarget,
+        bool? Succeeded,
+        int ErrorCount,
+        int WarningCount,
+        TimeSpan Duration,
+        bool IsTimingActive)
+    {
+        internal int ProjectContextId => ContextKey.ProjectContextId;
+
+        internal int NodeId => ContextKey.NodeId;
+
+        internal bool HasErrorsOrWarnings => ErrorCount > 0 || WarningCount > 0;
+    }
 
     private IEventSource? _eventSource;
     private ProjectContextKey? _initialRestoreContext;
@@ -117,25 +157,25 @@ internal sealed class BuildEventTracker
 
     internal event Action<BuildFinishedSnapshot>? BuildFinishedTracked;
 
-    internal event Action<TrackedProject>? ProjectStartedTracked;
+    internal event Action<ProjectSnapshot>? ProjectStartedTracked;
 
-    internal event Action<TrackedProject?, ProjectFinishedEventArgs>? ProjectFinishedTracked;
+    internal event Action<ProjectSnapshot?, ProjectFinishedEventArgs>? ProjectFinishedTracked;
 
-    internal event Action<TrackedProject?, TargetStartedEventArgs>? TargetStartedTracked;
+    internal event Action<ProjectSnapshot?, TargetStartedEventArgs>? TargetStartedTracked;
 
-    internal event Action<TrackedProject?, TargetFinishedEventArgs>? TargetFinishedTracked;
+    internal event Action<ProjectSnapshot?, TargetFinishedEventArgs>? TargetFinishedTracked;
 
-    internal event Action<TrackedProject?, TaskStartedEventArgs>? TaskStartedTracked;
+    internal event Action<ProjectSnapshot?, TaskStartedEventArgs>? TaskStartedTracked;
 
-    internal event Action<TrackedProject?, TaskFinishedEventArgs>? TaskFinishedTracked;
+    internal event Action<ProjectSnapshot?, TaskFinishedEventArgs>? TaskFinishedTracked;
 
     internal event Action<BuildStatusEventArgs>? StatusEventTracked;
 
-    internal event Action<TrackedProject?, BuildMessageEventArgs>? MessageTracked;
+    internal event Action<ProjectSnapshot?, BuildMessageEventArgs>? MessageTracked;
 
-    internal event Action<TrackedProject?, BuildWarningEventArgs>? WarningTracked;
+    internal event Action<ProjectSnapshot?, BuildWarningEventArgs>? WarningTracked;
 
-    internal event Action<TrackedProject?, BuildErrorEventArgs>? ErrorTracked;
+    internal event Action<ProjectSnapshot?, BuildErrorEventArgs>? ErrorTracked;
 
     internal DateTime BuildStartTime { get; private set; }
 
@@ -167,7 +207,7 @@ internal sealed class BuildEventTracker
     /// <remarks>
     /// Keyed by the node and node-unique project context ID passed to logger callbacks.
     /// </remarks>
-    private readonly Dictionary<ProjectContextKey, TrackedProject> _projects = [];
+    private readonly Dictionary<ProjectContextKey, TrackedProjectState> _projects = [];
 
     private readonly Dictionary<EvalContext, EvalProjectInfo> _projectEvaluations = [];
 
@@ -242,7 +282,7 @@ internal sealed class BuildEventTracker
 
         StopwatchAbstraction stopwatch = StopwatchFactory?.Invoke() ?? new SystemStopwatch();
 
-        TrackedProject project = new(
+        TrackedProjectState project = new(
             new ProjectContextKey(buildEventContext),
             buildEventContext.EvaluationId,
             e.ProjectFile,
@@ -261,12 +301,12 @@ internal sealed class BuildEventTracker
             _initialRestoreContext = project.ContextKey;
         }
 
-        ProjectStartedTracked?.Invoke(project);
+        ProjectStartedTracked?.Invoke(project.CreateSnapshot());
     }
 
     private void OnProjectFinished(object sender, ProjectFinishedEventArgs e)
     {
-        TrackedProject? project = CorrelateProject(e);
+        TrackedProjectState? project = CorrelateProject(e);
         if (project is not null)
         {
             project.Finish(e.Succeeded);
@@ -278,36 +318,36 @@ internal sealed class BuildEventTracker
             }
         }
 
-        ProjectFinishedTracked?.Invoke(project, e);
+        ProjectFinishedTracked?.Invoke(project?.CreateSnapshot(), e);
     }
 
     private void OnTargetStarted(object sender, TargetStartedEventArgs e)
     {
-        TrackedProject? project = CorrelateProject(e);
+        TrackedProjectState? project = CorrelateProject(e);
         project?.StartTarget(e.TargetName);
-        TargetStartedTracked?.Invoke(project, e);
+        TargetStartedTracked?.Invoke(project?.CreateSnapshot(), e);
     }
 
     private void OnTargetFinished(object sender, TargetFinishedEventArgs e)
     {
-        TargetFinishedTracked?.Invoke(CorrelateProject(e), e);
+        TargetFinishedTracked?.Invoke(CorrelateProject(e)?.CreateSnapshot(), e);
     }
 
     private void OnTaskStarted(object sender, TaskStartedEventArgs e)
     {
-        TrackedProject? project = CorrelateProject(e);
+        TrackedProjectState? project = CorrelateProject(e);
         if (project is not null
             && _initialRestoreContext is null
             && e.TaskName == MSBuildTaskName)
         {
             project.Yield();
         }
-        TaskStartedTracked?.Invoke(project, e);
+        TaskStartedTracked?.Invoke(project?.CreateSnapshot(), e);
     }
 
     private void OnTaskFinished(object sender, TaskFinishedEventArgs e)
     {
-        TrackedProject? project = CorrelateProject(e);
+        TrackedProjectState? project = CorrelateProject(e);
 
         if (project is not null
             && _initialRestoreContext is null
@@ -316,7 +356,7 @@ internal sealed class BuildEventTracker
             project.Resume();
         }
 
-        TaskFinishedTracked?.Invoke(project, e);
+        TaskFinishedTracked?.Invoke(project?.CreateSnapshot(), e);
     }
 
     private void OnStatusEventRaised(object sender, BuildStatusEventArgs e)
@@ -331,21 +371,21 @@ internal sealed class BuildEventTracker
 
     private void OnMessageRaised(object sender, BuildMessageEventArgs e)
     {
-        MessageTracked?.Invoke(CorrelateProject(e), e);
+        MessageTracked?.Invoke(CorrelateProject(e)?.CreateSnapshot(), e);
     }
 
     private void OnWarningRaised(object sender, BuildWarningEventArgs e)
     {
-        TrackedProject? project = CorrelateProject(e);
+        TrackedProjectState? project = CorrelateProject(e);
         project?.AddWarning();
-        WarningTracked?.Invoke(project, e);
+        WarningTracked?.Invoke(project?.CreateSnapshot(), e);
     }
 
     private void OnErrorRaised(object sender, BuildErrorEventArgs e)
     {
-        TrackedProject? project = CorrelateProject(e);
+        TrackedProjectState? project = CorrelateProject(e);
         project?.AddError();
-        ErrorTracked?.Invoke(project, e);
+        ErrorTracked?.Invoke(project?.CreateSnapshot(), e);
     }
 
     private void CaptureEvalContext(ProjectEvaluationFinishedEventArgs evalFinish)
@@ -384,13 +424,13 @@ internal sealed class BuildEventTracker
         }
     }
 
-    private TrackedProject? CorrelateProject(BuildEventArgs e)
+    private TrackedProjectState? CorrelateProject(BuildEventArgs e)
     {
         BuildEventContext? buildEventContext = e.BuildEventContext;
         return buildEventContext is not null
             && _projects.TryGetValue(
                 new ProjectContextKey(buildEventContext),
-                out TrackedProject? project)
+                out TrackedProjectState? project)
                     ? project
                     : null;
     }

--- a/src/Build/Logging/BuildEventTracker.cs
+++ b/src/Build/Logging/BuildEventTracker.cs
@@ -7,11 +7,11 @@ using Microsoft.Build.Framework;
 
 namespace Microsoft.Build.Logging;
 
+/// <summary>
+/// Correlates build events with immutable project lifecycle snapshots.
+/// </summary>
 internal sealed class BuildEventTracker
 {
-    private const string MSBuildTaskName = "MSBuild";
-    private const string RestoreTargetName = "Restore";
-
     private readonly record struct EvalProjectInfo(
         string? ProjectFile,
         string? TargetFramework,
@@ -19,8 +19,6 @@ internal sealed class BuildEventTracker
 
     private sealed class TrackedProjectState
     {
-        private readonly StopwatchAbstraction _stopwatch;
-
         internal TrackedProjectState(
             ProjectContextKey contextKey,
             int evaluationId,
@@ -28,8 +26,7 @@ internal sealed class BuildEventTracker
             string? targetNames,
             string? evaluationProjectFile,
             string? targetFramework,
-            string? runtimeIdentifier,
-            StopwatchAbstraction stopwatch)
+            string? runtimeIdentifier)
         {
             ContextKey = contextKey;
             EvaluationId = evaluationId;
@@ -38,9 +35,6 @@ internal sealed class BuildEventTracker
             EvaluationProjectFile = evaluationProjectFile;
             TargetFramework = targetFramework;
             RuntimeIdentifier = runtimeIdentifier;
-            _stopwatch = stopwatch;
-
-            _stopwatch.Start();
         }
 
         internal ProjectContextKey ContextKey { get; }
@@ -69,25 +63,9 @@ internal sealed class BuildEventTracker
 
         internal int WarningCount { get; private set; }
 
-        internal bool IsTimingActive { get; private set; } = true;
-
         internal void StartTarget(string targetName)
         {
             CurrentTarget = targetName;
-            _stopwatch.Start();
-            IsTimingActive = true;
-        }
-
-        internal void Yield()
-        {
-            _stopwatch.Stop();
-            IsTimingActive = false;
-        }
-
-        internal void Resume()
-        {
-            _stopwatch.Start();
-            IsTimingActive = true;
         }
 
         internal void AddWarning()
@@ -103,8 +81,6 @@ internal sealed class BuildEventTracker
         internal void Finish(bool succeeded)
         {
             Succeeded = succeeded;
-            _stopwatch.Stop();
-            IsTimingActive = false;
         }
 
         internal ProjectSnapshot CreateSnapshot() => new(
@@ -118,12 +94,8 @@ internal sealed class BuildEventTracker
             CurrentTarget,
             Succeeded,
             ErrorCount,
-            WarningCount,
-            TimeSpan.FromSeconds(_stopwatch.ElapsedSeconds),
-            IsTimingActive);
+            WarningCount);
     }
-
-    internal Func<StopwatchAbstraction>? StopwatchFactory { get; set; }
 
     internal readonly record struct BuildStartedSnapshot(DateTime Timestamp);
 
@@ -143,9 +115,7 @@ internal sealed class BuildEventTracker
         string? CurrentTarget,
         bool? Succeeded,
         int ErrorCount,
-        int WarningCount,
-        TimeSpan Duration,
-        bool IsTimingActive)
+        int WarningCount)
     {
         internal int ProjectContextId => ContextKey.ProjectContextId;
 
@@ -155,8 +125,6 @@ internal sealed class BuildEventTracker
     }
 
     private IEventSource? _eventSource;
-    private ProjectContextKey? _initialRestoreContext;
-    private bool _initialRestoreFinished;
 
     internal event Action<BuildStartedSnapshot>? BuildStartedTracked;
 
@@ -220,6 +188,7 @@ internal sealed class BuildEventTracker
     {
         ArgumentNullException.ThrowIfNull(eventSource);
 
+        Detach();
         _eventSource = eventSource;
 
         eventSource.BuildStarted += OnBuildStarted;
@@ -260,8 +229,6 @@ internal sealed class BuildEventTracker
     {
         _projects.Clear();
         _projectEvaluations.Clear();
-        _initialRestoreContext = null;
-        _initialRestoreFinished = false;
 
         BuildStartTime = e.Timestamp;
         BuildStartedTracked?.Invoke(new BuildStartedSnapshot(e.Timestamp));
@@ -285,8 +252,6 @@ internal sealed class BuildEventTracker
 
         _projectEvaluations.TryGetValue(new EvalContext(buildEventContext), out EvalProjectInfo evalInfo);
 
-        StopwatchAbstraction stopwatch = StopwatchFactory?.Invoke() ?? new SystemStopwatch();
-
         TrackedProjectState project = new(
             new ProjectContextKey(buildEventContext),
             buildEventContext.EvaluationId,
@@ -294,17 +259,9 @@ internal sealed class BuildEventTracker
             e.TargetNames,
             evalInfo.ProjectFile,
             evalInfo.TargetFramework,
-            evalInfo.RuntimeIdentifier,
-            stopwatch);
+            evalInfo.RuntimeIdentifier);
 
         _projects[project.ContextKey] = project;
-
-        if (!_initialRestoreFinished
-            && _initialRestoreContext is null
-            && project.TargetNames == RestoreTargetName)
-        {
-            _initialRestoreContext = project.ContextKey;
-        }
 
         ProjectStartedTracked?.Invoke(project.CreateSnapshot());
     }
@@ -315,12 +272,6 @@ internal sealed class BuildEventTracker
         if (project is not null)
         {
             project.Finish(e.Succeeded);
-
-            if (project.ContextKey == _initialRestoreContext)
-            {
-                _initialRestoreContext = null;
-                _initialRestoreFinished = true;
-            }
         }
 
         ProjectFinishedTracked?.Invoke(project?.CreateSnapshot(), e);
@@ -341,26 +292,12 @@ internal sealed class BuildEventTracker
     private void OnTaskStarted(object sender, TaskStartedEventArgs e)
     {
         TrackedProjectState? project = CorrelateProject(e);
-        if (project is not null
-            && _initialRestoreContext is null
-            && e.TaskName == MSBuildTaskName)
-        {
-            project.Yield();
-        }
         TaskStartedTracked?.Invoke(project?.CreateSnapshot(), e);
     }
 
     private void OnTaskFinished(object sender, TaskFinishedEventArgs e)
     {
         TrackedProjectState? project = CorrelateProject(e);
-
-        if (project is not null
-            && _initialRestoreContext is null
-            && e.TaskName == MSBuildTaskName)
-        {
-            project.Resume();
-        }
-
         TaskFinishedTracked?.Invoke(project?.CreateSnapshot(), e);
     }
 

--- a/src/Build/Logging/BuildEventTracker.cs
+++ b/src/Build/Logging/BuildEventTracker.cs
@@ -12,6 +12,11 @@ internal sealed class BuildEventTracker
     private const string MSBuildTaskName = "MSBuild";
     private const string RestoreTargetName = "Restore";
 
+    private readonly record struct EvalProjectInfo(
+        string? ProjectFile,
+        string? TargetFramework,
+        string? RuntimeIdentifier);
+
     private sealed class TrackedProjectState
     {
         private readonly StopwatchAbstraction _stopwatch;

--- a/src/Build/Logging/TerminalLogger/TerminalLogger.cs
+++ b/src/Build/Logging/TerminalLogger/TerminalLogger.cs
@@ -208,6 +208,7 @@ public sealed partial class TerminalLogger : INodeLogger
     internal TerminalLogger()
     {
         Terminal = new Terminal();
+        SubscribeToTrackedEvents();
     }
 
     internal TerminalLogger(LoggerVerbosity verbosity) : this()
@@ -222,6 +223,7 @@ public sealed partial class TerminalLogger : INodeLogger
     {
         Terminal = terminal;
         _manualRefresh = true;
+        SubscribeToTrackedEvents();
     }
 
     /// <summary>
@@ -419,18 +421,6 @@ public sealed partial class TerminalLogger : INodeLogger
         // Detect if we're in replay mode
         _isReplayMode = eventSource is IBinaryLogReplaySource;
 
-        _eventTracker.BuildStartedTracked += OnBuildStarted;
-        _eventTracker.BuildFinishedTracked += OnBuildFinished;
-        _eventTracker.ProjectStartedTracked += OnProjectStarted;
-        _eventTracker.ProjectFinishedTracked += ProjectFinished;
-        _eventTracker.TargetStartedTracked += TargetStarted;
-        _eventTracker.TargetFinishedTracked += TargetFinished;
-        _eventTracker.TaskStartedTracked += TaskStarted;
-        _eventTracker.TaskFinishedTracked += TaskFinished;
-        _eventTracker.StatusEventTracked += StatusEventRaised;
-        _eventTracker.MessageTracked += MessageRaised;
-        _eventTracker.WarningTracked += WarningRaised;
-        _eventTracker.ErrorTracked += ErrorRaised;
         _eventTracker.Attach(eventSource);
 
         if (eventSource is IEventSource4 eventSource4)
@@ -520,18 +510,6 @@ public sealed partial class TerminalLogger : INodeLogger
     public void Shutdown()
     {
         _eventTracker.Detach();
-        _eventTracker.BuildStartedTracked -= OnBuildStarted;
-        _eventTracker.BuildFinishedTracked -= OnBuildFinished;
-        _eventTracker.ProjectStartedTracked -= OnProjectStarted;
-        _eventTracker.ProjectFinishedTracked -= ProjectFinished;
-        _eventTracker.TargetStartedTracked -= TargetStarted;
-        _eventTracker.TargetFinishedTracked -= TargetFinished;
-        _eventTracker.TaskStartedTracked -= TaskStarted;
-        _eventTracker.TaskFinishedTracked -= TaskFinished;
-        _eventTracker.StatusEventTracked -= StatusEventRaised;
-        _eventTracker.MessageTracked -= MessageRaised;
-        _eventTracker.WarningTracked -= WarningRaised;
-        _eventTracker.ErrorTracked -= ErrorRaised;
 
         NativeMethodsShared.RestoreConsoleMode(_originalConsoleMode);
 
@@ -560,6 +538,10 @@ public sealed partial class TerminalLogger : INodeLogger
     /// </summary>
     private void OnBuildStarted(BuildEventTracker.BuildStartedSnapshot _)
     {
+        _restoreContext = null;
+        _restoreFinished = false;
+        _restoreFailed = false;
+
         if (!_manualRefresh && _showNodesDisplay)
         {
             _refresher = new Thread(ThreadProc);
@@ -705,8 +687,6 @@ public sealed partial class TerminalLogger : INodeLogger
                 break;
             case ProjectEvaluationStartedEventArgs _evalStart:
                 break;
-            case ProjectEvaluationFinishedEventArgs:
-                break;
             case LoggersRegisteredEventArgs loggerEvent:
                 _registeredLoggers.AddRange(loggerEvent.Loggers);
                 break;
@@ -731,7 +711,7 @@ public sealed partial class TerminalLogger : INodeLogger
         TerminalProjectInfo projectInfo = new(project, _createStopwatch?.Invoke() ?? new SystemStopwatch());
         _projects[project.ContextKey] = projectInfo;
 
-        if (project.TargetNames == "Restore" && !_restoreFinished)
+        if (string.Equals(project.TargetNames, "Restore", StringComparison.OrdinalIgnoreCase) && !_restoreFinished)
         {
             _restoreContext = project.ContextKey;
 
@@ -781,7 +761,7 @@ public sealed partial class TerminalLogger : INodeLogger
             return;
         }
 
-        project.Update(trackedProject.Value);
+        project.Finish(e.Succeeded);
 
         // In quiet mode, only show projects with errors or warnings.
         // In higher verbosity modes, show projects based on other criteria.
@@ -1010,7 +990,7 @@ public sealed partial class TerminalLogger : INodeLogger
         {
             string projectFile = Path.GetFileNameWithoutExtension(e.ProjectFile);
 
-            project.Update(projectSnapshot);
+            project.ResumeTiming();
             string targetName = projectSnapshot.CurrentTarget ?? e.TargetName;
             if (targetName == CachePluginStartTarget)
             {
@@ -1106,16 +1086,16 @@ public sealed partial class TerminalLogger : INodeLogger
     private void TaskStarted(BuildEventTracker.ProjectSnapshot? trackedProject, TaskStartedEventArgs e)
     {
         if (_restoreContext is null
-            && e.TaskName == MSBuildTaskName
+            && string.Equals(e.TaskName, MSBuildTaskName, StringComparison.OrdinalIgnoreCase)
             && trackedProject is not null)
         {
+            // This will yield the node, so preemptively mark it idle.
+            UpdateNodeStatus(trackedProject.Value.NodeId, null);
+
             if (TryGetProject(trackedProject, out TerminalProjectInfo? project))
             {
-                project.Update(trackedProject.Value);
+                project.YieldTiming();
             }
-
-            // This will yield the node, so preemptively mark it idle
-            UpdateNodeStatus(trackedProject.Value.NodeId, null);
         }
     }
 
@@ -1125,15 +1105,16 @@ public sealed partial class TerminalLogger : INodeLogger
     private void TaskFinished(BuildEventTracker.ProjectSnapshot? trackedProject, TaskFinishedEventArgs e)
     {
         if (_restoreContext is null
-            && e.TaskName == MSBuildTaskName
-            && TryGetProject(trackedProject, out TerminalProjectInfo? project))
+            && string.Equals(e.TaskName, MSBuildTaskName, StringComparison.OrdinalIgnoreCase)
+            && trackedProject is BuildEventTracker.ProjectSnapshot projectSnapshot
+            && TryGetProject(projectSnapshot, out TerminalProjectInfo? project))
         {
-            project.Update(trackedProject!.Value);
+            project.ResumeTiming();
             string projectFile = Path.GetFileNameWithoutExtension(e.ProjectFile);
-            string targetName = trackedProject.Value.CurrentTarget ?? "";
+            string targetName = projectSnapshot.CurrentTarget ?? "";
 
             TerminalNodeStatus nodeStatus = new(projectFile, project.TargetFramework, project.RuntimeIdentifier, GetDisplayTargetName(targetName), project.Stopwatch);
-            UpdateNodeStatus(trackedProject.Value.NodeId, nodeStatus);
+            UpdateNodeStatus(projectSnapshot.NodeId, nodeStatus);
         }
     }
 
@@ -1403,6 +1384,22 @@ public sealed partial class TerminalLogger : INodeLogger
     }
 
     #endregion
+
+    private void SubscribeToTrackedEvents()
+    {
+        _eventTracker.BuildStartedTracked += OnBuildStarted;
+        _eventTracker.BuildFinishedTracked += OnBuildFinished;
+        _eventTracker.ProjectStartedTracked += OnProjectStarted;
+        _eventTracker.ProjectFinishedTracked += ProjectFinished;
+        _eventTracker.TargetStartedTracked += TargetStarted;
+        _eventTracker.TargetFinishedTracked += TargetFinished;
+        _eventTracker.TaskStartedTracked += TaskStarted;
+        _eventTracker.TaskFinishedTracked += TaskFinished;
+        _eventTracker.StatusEventTracked += StatusEventRaised;
+        _eventTracker.MessageTracked += MessageRaised;
+        _eventTracker.WarningTracked += WarningRaised;
+        _eventTracker.ErrorTracked += ErrorRaised;
+    }
 
     #region Refresher thread implementation
 

--- a/src/Build/Logging/TerminalLogger/TerminalLogger.cs
+++ b/src/Build/Logging/TerminalLogger/TerminalLogger.cs
@@ -45,28 +45,6 @@ public sealed partial class TerminalLogger : INodeLogger
 
     private static readonly string[] newLineStrings = { "\r\n", "\n" };
 
-    /// <summary>
-    /// A wrapper over the project context ID passed to us in <see cref="IEventSource"/> logger events.
-    /// </summary>
-    internal record struct ProjectContext(int Id)
-    {
-        public ProjectContext(BuildEventContext context)
-            : this(context.ProjectContextId)
-        {
-        }
-    }
-
-    /// <summary>
-    /// A wrapper over the evaluation context ID passed to us in <see cref="IEventSource"/> logger events.
-    /// </summary>
-    internal record struct EvalContext(int Id)
-    {
-        public EvalContext(BuildEventContext context)
-            : this(context.EvaluationId)
-        {
-        }
-    }
-
     private readonly record struct TestSummary(int Total, int Passed, int Skipped, int Failed);
 
     /// <summary>
@@ -102,11 +80,9 @@ public sealed partial class TerminalLogger : INodeLogger
     /// Tracks the status of all relevant projects seen so far.
     /// </summary>
     /// <remarks>
-    /// Keyed by an ID that gets passed to logger callbacks, this allows us to quickly look up the corresponding project.
+    /// Keyed by the node and node-unique project context ID passed to logger callbacks.
     /// </remarks>
-    private readonly Dictionary<ProjectContext, TerminalProjectInfo> _projects = [];
-
-    private readonly Dictionary<EvalContext, EvalProjectInfo> _projectEvaluations = [];
+    private readonly Dictionary<BuildEventTracker.ProjectContextKey, TerminalProjectInfo> _projects = [];
 
     /// <summary>
     /// Tracks the work currently being done by build nodes. Null means the node is not doing any work worth reporting.
@@ -146,7 +122,7 @@ public sealed partial class TerminalLogger : INodeLogger
     /// The project build context corresponding to the <c>Restore</c> initial target, or null if the build is currently
     /// not restoring.
     /// </summary>
-    private ProjectContext? _restoreContext;
+    private BuildEventTracker.ProjectContextKey? _restoreContext;
 
     /// <summary>
     /// True if we're replaying a binary log. In this mode, we may encounter NodeIds higher than the initial node count.
@@ -729,7 +705,7 @@ public sealed partial class TerminalLogger : INodeLogger
                 break;
             case ProjectEvaluationStartedEventArgs _evalStart:
                 break;
-            case ProjectEvaluationFinishedEventArgs evalFinish:
+            case ProjectEvaluationFinishedEventArgs:
                 break;
             case LoggersRegisteredEventArgs loggerEvent:
                 _registeredLoggers.AddRange(loggerEvent.Loggers);
@@ -740,14 +716,13 @@ public sealed partial class TerminalLogger : INodeLogger
     /// <summary>
     /// The tracked project-start callback.
     /// </summary>
-    private void OnProjectStarted(BuildEventTracker.ProjectStartedSnapshot project)
+    private void OnProjectStarted(BuildEventTracker.ProjectSnapshot project)
     {
-        ProjectContext c = new(project.ProjectContextId);
+        BuildEventTracker.ProjectContextKey contextKey = project.ContextKey;
 
         if (_restoreContext is null)
         {
             EvalProjectInfo evalInfo = new(
-                new EvalContext(project.EvaluationId),
                 project.EvaluationProjectFile,
                 project.TargetFramework,
                 project.RuntimeIdentifier);
@@ -755,30 +730,42 @@ public sealed partial class TerminalLogger : INodeLogger
             // Per-project metaproj files (e.g. MyProject.csproj.metaproj) are constructed
             // directly without evaluation, so they won't have a matching ProjectEvaluationFinished event.
             System.Diagnostics.Debug.Assert(
-                evalInfo != default || FileUtilities.IsMetaprojectFilename(project.ProjectFile),
+                project.EvaluationProjectFile is not null || FileUtilities.IsMetaprojectFilename(project.ProjectFile),
                 "EvalProjectInfo should have been captured before ProjectStarted");
 
-            TerminalProjectInfo projectInfo = new(c, evalInfo, _createStopwatch?.Invoke());
-            _projects[c] = projectInfo;
+            TerminalProjectInfo projectInfo = new(contextKey, evalInfo, _createStopwatch?.Invoke());
+            _projects[contextKey] = projectInfo;
 
             // First ever restore in the build is starting.
             if (project.TargetNames == "Restore" && !_restoreFinished)
             {
-                _restoreContext = c;
-                int nodeIndex = project.NodeId - 1;
-                EnsureNodeCapacity(nodeIndex);
-                _nodes[nodeIndex] = new TerminalNodeStatus(project.ProjectFile!, project.TargetFramework, project.RuntimeIdentifier, "Restore", _projects[c].Stopwatch);
+                _restoreContext = contextKey;
+                UpdateNodeStatus(
+                    project.NodeId,
+                    new TerminalNodeStatus(project.ProjectFile!, project.TargetFramework, project.RuntimeIdentifier, "Restore", _projects[contextKey].Stopwatch));
             }
         }
+    }
+
+    private bool TryGetProject(
+        BuildEventTracker.ProjectSnapshot? trackedProject,
+        [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out TerminalProjectInfo? project)
+    {
+        if (trackedProject is null)
+        {
+            project = null;
+            return false;
+        }
+
+        return _projects.TryGetValue(trackedProject.ContextKey, out project);
     }
 
     /// <summary>
     /// The <see cref="IEventSource.ProjectFinished"/> callback.
     /// </summary>
-    private void ProjectFinished(ProjectFinishedEventArgs e)
+    private void ProjectFinished(BuildEventTracker.ProjectSnapshot? trackedProject, ProjectFinishedEventArgs e)
     {
-        var buildEventContext = e.BuildEventContext;
-        if (buildEventContext is null)
+        if (trackedProject is null)
         {
             return;
         }
@@ -786,146 +773,111 @@ public sealed partial class TerminalLogger : INodeLogger
         // Mark node idle until something uses it again
         if (_restoreContext is null)
         {
-            UpdateNodeStatus(buildEventContext, null);
+            UpdateNodeStatus(trackedProject.NodeId, null);
         }
 
-        ProjectContext c = new(buildEventContext);
-
-        if (_projects.TryGetValue(c, out TerminalProjectInfo? project))
-        {
-            project.Succeeded = e.Succeeded;
-            project.Stopwatch.Stop();
-
-            // In quiet mode, only show projects with errors or warnings.
-            // In higher verbosity modes, show projects based on other criteria.
-            if (Verbosity == LoggerVerbosity.Quiet && !project.HasErrorsOrWarnings)
-            {
-                // Still need to update counts even if not displaying
-                _buildErrorsCount += project.ErrorCount;
-                _buildWarningsCount += project.WarningCount;
-                return;
-            }
-
-            lock (_lock)
-            {
-                Terminal.BeginUpdate();
-                try
-                {
-                    EraseNodes();
-
-                    string duration = project.Stopwatch.ElapsedSeconds.ToString("F1");
-                    ReadOnlyMemory<char>? outputPath = project.OutputPath;
-
-                    // Build result. One of 'failed', 'succeeded with warnings', or 'succeeded' depending on the build result and diagnostic messages
-                    // reported during build.
-                    string buildResult = GetBuildResultString(project.Succeeded, project.ErrorCount, project.WarningCount);
-
-                    // Check if we're done restoring.
-                    if (c == _restoreContext)
-                    {
-                        if (e.Succeeded)
-                        {
-                            if (project.HasErrorsOrWarnings)
-                            {
-                                Terminal.WriteLine(ResourceUtilities.FormatResourceStringIgnoreCodeAndKeyword("RestoreCompleteWithMessage",
-                                    buildResult,
-                                    duration));
-                            }
-                            else
-                            {
-                                Terminal.WriteLine(ResourceUtilities.FormatResourceStringIgnoreCodeAndKeyword("RestoreComplete",
-                                    duration));
-                            }
-                        }
-                        else
-                        {
-                            // It will be reported after build finishes.
-                            _restoreFailed = true;
-                        }
-
-                        _restoreContext = null;
-                        _restoreFinished = true;
-                    }
-                    // If this was a notable project build, we print it as completed only if it's produced an output or warnings/error.
-                    // If this is a test project, print it always, so user can see either a success or failure, otherwise success is hidden
-                    // and it is hard to see if project finished, or did not run at all.
-                    // In quiet mode, we show the project header if there are errors/warnings (already checked above).
-                    else if (project.OutputPath is not null || project.BuildMessages is not null || project.IsTestProject)
-                    {
-                        // Show project build complete and its output
-                        string projectFinishedHeader = GetProjectFinishedHeader(project, buildResult, duration);
-                        Terminal.Write(projectFinishedHeader);
-
-                        // Print the output path as a link if we have it.
-                        if (outputPath is { } outputPathSpan)
-                        {
-                            (string? projectDisplayPath, var urlLink) = DetermineOutputPathToRender(outputPathSpan, _initialWorkingDirectory.AsMemory(), project.SourceRoot);
-                            Terminal.WriteLine(ResourceUtilities.FormatResourceStringIgnoreCodeAndKeyword("ProjectFinished_OutputPath", CreateLink(urlLink, projectDisplayPath.ToString())));
-                        }
-                        else
-                        {
-                            Terminal.WriteLine(string.Empty);
-                        }
-                    }
-
-                    // Print diagnostic output under the Project -> Output line.
-                    if (project.BuildMessages is not null)
-                    {
-                        foreach (TerminalBuildMessage buildMessage in project.BuildMessages)
-                        {
-                            Terminal.WriteLine($"{DoubleIndentation}{buildMessage.Message}");
-                        }
-                    }
-
-                    _buildErrorsCount += project.ErrorCount;
-                    _buildWarningsCount += project.WarningCount;
-
-                    if (_showNodesDisplay && Verbosity > LoggerVerbosity.Quiet)
-                    {
-                        DisplayNodes();
-                    }
-                }
-                finally
-                {
-                    Terminal.EndUpdate();
-                }
-            }
-        }
-    }
-
-    private void CaptureEvalContext(ProjectEvaluationFinishedEventArgs evalFinish)
-    {
-        var buildEventContext = evalFinish.BuildEventContext;
-        if (buildEventContext is null)
+        BuildEventTracker.ProjectContextKey contextKey = trackedProject.ContextKey;
+        if (!TryGetProject(trackedProject, out TerminalProjectInfo? project))
         {
             return;
         }
 
-        EvalContext c = new(buildEventContext);
+        project.Succeeded = e.Succeeded;
+        project.Stopwatch.Stop();
 
-        if (!_projectEvaluations.TryGetValue(c, out EvalProjectInfo _))
+        // In quiet mode, only show projects with errors or warnings.
+        // In higher verbosity modes, show projects based on other criteria.
+        if (Verbosity == LoggerVerbosity.Quiet && !project.HasErrorsOrWarnings)
         {
-            string? tfm = null;
-            string? rid = null;
-            foreach (var property in evalFinish.EnumerateProperties())
+            // Still need to update counts even if not displaying
+            _buildErrorsCount += project.ErrorCount;
+            _buildWarningsCount += project.WarningCount;
+            return;
+        }
+
+        lock (_lock)
+        {
+            Terminal.BeginUpdate();
+            try
             {
-                if (tfm is not null && rid is not null)
+                EraseNodes();
+
+                string duration = project.Stopwatch.ElapsedSeconds.ToString("F1");
+                ReadOnlyMemory<char>? outputPath = project.OutputPath;
+
+                // Build result. One of 'failed', 'succeeded with warnings', or 'succeeded' depending on the build result and diagnostic messages
+                // reported during build.
+                string buildResult = GetBuildResultString(project.Succeeded, project.ErrorCount, project.WarningCount);
+
+                // Check if we're done restoring.
+                if (contextKey == _restoreContext)
                 {
-                    // We already have both properties, no need to continue.
-                    break;
+                    if (e.Succeeded)
+                    {
+                        if (project.HasErrorsOrWarnings)
+                        {
+                            Terminal.WriteLine(ResourceUtilities.FormatResourceStringIgnoreCodeAndKeyword("RestoreCompleteWithMessage",
+                                buildResult,
+                                duration));
+                        }
+                        else
+                        {
+                            Terminal.WriteLine(ResourceUtilities.FormatResourceStringIgnoreCodeAndKeyword("RestoreComplete",
+                                duration));
+                        }
+                    }
+                    else
+                    {
+                        // It will be reported after build finishes.
+                        _restoreFailed = true;
+                    }
+
+                    _restoreContext = null;
+                    _restoreFinished = true;
                 }
-                switch (property.Name)
+                // If this was a notable project build, we print it as completed only if it's produced an output or warnings/error.
+                // If this is a test project, print it always, so user can see either a success or failure, otherwise success is hidden
+                // and it is hard to see if project finished, or did not run at all.
+                // In quiet mode, we show the project header if there are errors/warnings (already checked above).
+                else if (project.OutputPath is not null || project.BuildMessages is not null || project.IsTestProject)
                 {
-                    case "TargetFramework":
-                        tfm = property.Value;
-                        break;
-                    case "RuntimeIdentifier":
-                        rid = property.Value;
-                        break;
+                    // Show project build complete and its output
+                    string projectFinishedHeader = GetProjectFinishedHeader(project, buildResult, duration);
+                    Terminal.Write(projectFinishedHeader);
+
+                    // Print the output path as a link if we have it.
+                    if (outputPath is { } outputPathSpan)
+                    {
+                        (string? projectDisplayPath, var urlLink) = DetermineOutputPathToRender(outputPathSpan, _initialWorkingDirectory.AsMemory(), project.SourceRoot);
+                        Terminal.WriteLine(ResourceUtilities.FormatResourceStringIgnoreCodeAndKeyword("ProjectFinished_OutputPath", CreateLink(urlLink, projectDisplayPath.ToString())));
+                    }
+                    else
+                    {
+                        Terminal.WriteLine(string.Empty);
+                    }
+                }
+
+                // Print diagnostic output under the Project -> Output line.
+                if (project.BuildMessages is not null)
+                {
+                    foreach (TerminalBuildMessage buildMessage in project.BuildMessages)
+                    {
+                        Terminal.WriteLine($"{DoubleIndentation}{buildMessage.Message}");
+                    }
+                }
+
+                _buildErrorsCount += project.ErrorCount;
+                _buildWarningsCount += project.WarningCount;
+
+                if (_showNodesDisplay && Verbosity > LoggerVerbosity.Quiet)
+                {
+                    DisplayNodes();
                 }
             }
-            var evalInfo = new EvalProjectInfo(c, evalFinish.ProjectFile, tfm, rid);
-            _projectEvaluations[c] = evalInfo;
+            finally
+            {
+                Terminal.EndUpdate();
+            }
         }
     }
 
@@ -1052,10 +1004,10 @@ public sealed partial class TerminalLogger : INodeLogger
     /// <summary>
     /// The <see cref="IEventSource.TargetStarted"/> callback.
     /// </summary>
-    private void TargetStarted(TargetStartedEventArgs e)
+    private void TargetStarted(BuildEventTracker.ProjectSnapshot? trackedProject, TargetStartedEventArgs e)
     {
-        var buildEventContext = e.BuildEventContext;
-        if (_restoreContext is null && buildEventContext is not null && _projects.TryGetValue(new ProjectContext(buildEventContext), out TerminalProjectInfo? project))
+        if (_restoreContext is null
+            && TryGetProject(trackedProject, out TerminalProjectInfo? project))
         {
             project.Stopwatch.Start();
 
@@ -1081,13 +1033,13 @@ public sealed partial class TerminalLogger : INodeLogger
             }
 
             TerminalNodeStatus nodeStatus = new(projectFile, project.TargetFramework, project.RuntimeIdentifier, GetDisplayTargetName(targetName), project.Stopwatch);
-            UpdateNodeStatus(buildEventContext, nodeStatus);
+            UpdateNodeStatus(trackedProject!.NodeId, nodeStatus);
         }
     }
 
-    private void UpdateNodeStatus(BuildEventContext buildEventContext, TerminalNodeStatus? nodeStatus)
+    private void UpdateNodeStatus(int nodeId, TerminalNodeStatus? nodeStatus)
     {
-        int nodeIndex = NodeIndexForContext(buildEventContext);
+        int nodeIndex = NodeIndexForNode(nodeId);
         EnsureNodeCapacity(nodeIndex);
         _nodes[nodeIndex] = nodeStatus;
     }
@@ -1116,23 +1068,22 @@ public sealed partial class TerminalLogger : INodeLogger
     /// <summary>
     /// The <see cref="IEventSource.TargetFinished"/> callback. Unused.
     /// </summary>
-    private void TargetFinished(TargetFinishedEventArgs e)
+    private void TargetFinished(BuildEventTracker.ProjectSnapshot? trackedProject, TargetFinishedEventArgs e)
     {
         // For cache plugin projects which result in a cache hit, ensure the output path is set
         // to the item spec corresponding to the GetTargetPath target upon completion.
-        var buildEventContext = e.BuildEventContext;
         var targetOutputs = e.TargetOutputs;
-        if (_restoreContext is not null || buildEventContext is null)
+        if (_restoreContext is not null
+            || !TryGetProject(trackedProject, out TerminalProjectInfo? project))
         {
             return;
         }
 
         if (targetOutputs is not null
                 && _hasUsedCache
-                && e.TargetName == "GetTargetPath"
-                && _projects.TryGetValue(new ProjectContext(buildEventContext), out TerminalProjectInfo? project))
+                && e.TargetName == "GetTargetPath")
         {
-            if (project is not null && project.IsCachePluginProject)
+            if (project.IsCachePluginProject)
             {
                 foreach (ITaskItem output in targetOutputs)
                 {
@@ -1143,7 +1094,6 @@ public sealed partial class TerminalLogger : INodeLogger
         }
         else if (targetOutputs is not null
             && e.TargetName == "InitializeSourceRootMappedPaths"
-            && _projects.TryGetValue(new ProjectContext(buildEventContext), out project)
             && project.SourceRoot is null)
         {
             project.SourceRoot =
@@ -1156,15 +1106,16 @@ public sealed partial class TerminalLogger : INodeLogger
     /// <summary>
     /// The <see cref="IEventSource.TaskStarted"/> callback.
     /// </summary>
-    private void TaskStarted(TaskStartedEventArgs e)
+    private void TaskStarted(BuildEventTracker.ProjectSnapshot? trackedProject, TaskStartedEventArgs e)
     {
-        var buildEventContext = e.BuildEventContext;
-        if (_restoreContext is null && buildEventContext is not null && e.TaskName == MSBuildTaskName)
+        if (_restoreContext is null
+            && e.TaskName == MSBuildTaskName
+            && trackedProject is not null)
         {
             // This will yield the node, so preemptively mark it idle
-            UpdateNodeStatus(buildEventContext, null);
+            UpdateNodeStatus(trackedProject.NodeId, null);
 
-            if (_projects.TryGetValue(new ProjectContext(buildEventContext), out TerminalProjectInfo? project))
+            if (TryGetProject(trackedProject, out TerminalProjectInfo? project))
             {
                 project.Stopwatch.Stop();
             }
@@ -1174,11 +1125,11 @@ public sealed partial class TerminalLogger : INodeLogger
     /// <summary>
     /// The <see cref="IEventSource.TaskFinished"/> callback.
     /// </summary>
-    private void TaskFinished(TaskFinishedEventArgs e)
+    private void TaskFinished(BuildEventTracker.ProjectSnapshot? trackedProject, TaskFinishedEventArgs e)
     {
-        var buildEventContext = e.BuildEventContext;
-        if (_restoreContext is null && buildEventContext is not null && e.TaskName == MSBuildTaskName
-            && _projects.TryGetValue(new ProjectContext(buildEventContext), out TerminalProjectInfo? project))
+        if (_restoreContext is null
+            && e.TaskName == MSBuildTaskName
+            && TryGetProject(trackedProject, out TerminalProjectInfo? project))
         {
             project.Stopwatch.Start();
 
@@ -1186,17 +1137,16 @@ public sealed partial class TerminalLogger : INodeLogger
             string targetName = project.CurrentTarget ?? "";
 
             TerminalNodeStatus nodeStatus = new(projectFile, project.TargetFramework, project.RuntimeIdentifier, GetDisplayTargetName(targetName), project.Stopwatch);
-            UpdateNodeStatus(buildEventContext, nodeStatus);
+            UpdateNodeStatus(trackedProject!.NodeId, nodeStatus);
         }
     }
 
     /// <summary>
     /// The <see cref="IEventSource.MessageRaised"/> callback.
     /// </summary>
-    private void MessageRaised(BuildMessageEventArgs e)
+    private void MessageRaised(BuildEventTracker.ProjectSnapshot? trackedProject, BuildMessageEventArgs e)
     {
-        var buildEventContext = e.BuildEventContext;
-        if (buildEventContext is null)
+        if (e.BuildEventContext is null)
         {
             return;
         }
@@ -1204,7 +1154,7 @@ public sealed partial class TerminalLogger : INodeLogger
 
         if (message is not null && e.Importance == MessageImportance.High)
         {
-            bool hasProject = _projects.TryGetValue(new ProjectContext(buildEventContext), out TerminalProjectInfo? project);
+            bool hasProject = TryGetProject(trackedProject, out TerminalProjectInfo? project);
 
             // Detect project output path by matching high-importance messages against the "$(MSBuildProjectName) -> ..."
             // pattern used by the CopyFilesToOutputDirectory target.
@@ -1247,7 +1197,7 @@ public sealed partial class TerminalLogger : INodeLogger
 
             if (hasProject && project!.IsTestProject)
             {
-                int nodeIndex = NodeIndexForContext(buildEventContext);
+                int nodeIndex = NodeIndexForNode(trackedProject!.NodeId);
                 EnsureNodeCapacity(nodeIndex);
                 TerminalNodeStatus? node = _nodes[nodeIndex];
 
@@ -1264,7 +1214,7 @@ public sealed partial class TerminalLogger : INodeLogger
                                     string displayName = extendedMessage.ExtendedMetadata!["displayName"]!;
 
                                     var status = new TerminalNodeStatus(node.Project, node.TargetFramework, node.RuntimeIdentifier, TerminalColor.Green, indicator, displayName, project.Stopwatch);
-                                    UpdateNodeStatus(buildEventContext, status);
+                                    UpdateNodeStatus(trackedProject.NodeId, status);
                                 }
                                 break;
                             }
@@ -1277,7 +1227,7 @@ public sealed partial class TerminalLogger : INodeLogger
                                     string displayName = extendedMessage.ExtendedMetadata!["displayName"]!;
 
                                     var status = new TerminalNodeStatus(node.Project, node.TargetFramework, node.RuntimeIdentifier, TerminalColor.Yellow, indicator, displayName, project.Stopwatch);
-                                    UpdateNodeStatus(buildEventContext, status);
+                                    UpdateNodeStatus(trackedProject.NodeId, status);
                                 }
                                 break;
                             }
@@ -1352,10 +1302,8 @@ public sealed partial class TerminalLogger : INodeLogger
     /// <summary>
     /// The <see cref="IEventSource.WarningRaised"/> callback.
     /// </summary>
-    private void WarningRaised(BuildWarningEventArgs e)
+    private void WarningRaised(BuildEventTracker.ProjectSnapshot? trackedProject, BuildWarningEventArgs e)
     {
-        BuildEventContext? buildEventContext = e.BuildEventContext;
-
         // auth provider messages are 'global' in nature and should be a) immediate reported, and b) not re-reported in the summary.
         if (IsAuthProviderMessage(e.Message))
         {
@@ -1363,8 +1311,7 @@ public sealed partial class TerminalLogger : INodeLogger
             return;
         }
 
-        if (buildEventContext is not null
-            && _projects.TryGetValue(new ProjectContext(buildEventContext), out TerminalProjectInfo? project))
+        if (TryGetProject(trackedProject, out TerminalProjectInfo? project))
         {
             // If the warning is not a 'global' auth provider message, but is immediate, we render it immediately
             // but we don't early return so that the project also tracks it.
@@ -1441,12 +1388,9 @@ public sealed partial class TerminalLogger : INodeLogger
     /// <summary>
     /// The <see cref="IEventSource.ErrorRaised"/> callback.
     /// </summary>
-    private void ErrorRaised(BuildErrorEventArgs e)
+    private void ErrorRaised(BuildEventTracker.ProjectSnapshot? trackedProject, BuildErrorEventArgs e)
     {
-        BuildEventContext? buildEventContext = e.BuildEventContext;
-
-        if (buildEventContext is not null
-            && _projects.TryGetValue(new ProjectContext(buildEventContext), out TerminalProjectInfo? project))
+        if (TryGetProject(trackedProject, out TerminalProjectInfo? project))
         {
             // Always accumulate errors in the project, even in quiet mode, so they can be shown
             // in project-grouped form later.
@@ -1602,12 +1546,12 @@ public sealed partial class TerminalLogger : INodeLogger
     }
 
     /// <summary>
-    /// Returns the <see cref="_nodes"/> index corresponding to the given <see cref="BuildEventContext"/>.
+    /// Returns the <see cref="_nodes"/> index corresponding to the given node ID.
     /// </summary>
-    private int NodeIndexForContext(BuildEventContext context)
+    private static int NodeIndexForNode(int nodeId)
     {
         // Node IDs reported by the build are 1-based.
-        return context.NodeId - 1;
+        return nodeId - 1;
     }
 
     /// <summary>

--- a/src/Build/Logging/TerminalLogger/TerminalLogger.cs
+++ b/src/Build/Logging/TerminalLogger/TerminalLogger.cs
@@ -59,7 +59,11 @@ public sealed partial class TerminalLogger : INodeLogger
     internal const TerminalColor TargetFrameworkColor = TerminalColor.Cyan;
     internal const TerminalColor RuntimeIdentifierColor = TerminalColor.Magenta;
 
-    internal Func<StopwatchAbstraction>? _createStopwatch = null;
+    internal Func<StopwatchAbstraction>? _createStopwatch
+    {
+        get => _eventTracker.StopwatchFactory;
+        set => _eventTracker.StopwatchFactory = value;
+    }
 
     /// <summary>
     /// Name of target that identifies the project cache plugin run has just started.
@@ -716,39 +720,38 @@ public sealed partial class TerminalLogger : INodeLogger
     /// <summary>
     /// The tracked project-start callback.
     /// </summary>
-    private void OnProjectStarted(BuildEventTracker.ProjectSnapshot project)
+    private void OnProjectStarted(BuildEventTracker.TrackedProject project)
     {
-        BuildEventTracker.ProjectContextKey contextKey = project.ContextKey;
-
-        if (_restoreContext is null)
+        if (_restoreContext is not null)
         {
-            EvalProjectInfo evalInfo = new(
-                project.EvaluationProjectFile,
-                project.TargetFramework,
-                project.RuntimeIdentifier);
+            return;
+        }
 
-            // Per-project metaproj files (e.g. MyProject.csproj.metaproj) are constructed
-            // directly without evaluation, so they won't have a matching ProjectEvaluationFinished event.
-            System.Diagnostics.Debug.Assert(
-                project.EvaluationProjectFile is not null || FileUtilities.IsMetaprojectFilename(project.ProjectFile),
-                "EvalProjectInfo should have been captured before ProjectStarted");
+        System.Diagnostics.Debug.Assert(
+            project.EvaluationProjectFile is not null
+                || FileUtilities.IsMetaprojectFilename(project.ProjectFile),
+            "Evaluation information should be captured before ProjectStarted.");
 
-            TerminalProjectInfo projectInfo = new(contextKey, evalInfo, _createStopwatch?.Invoke());
-            _projects[contextKey] = projectInfo;
+        TerminalProjectInfo projectInfo = new(project);
+        _projects[project.ContextKey] = projectInfo;
 
-            // First ever restore in the build is starting.
-            if (project.TargetNames == "Restore" && !_restoreFinished)
-            {
-                _restoreContext = contextKey;
-                UpdateNodeStatus(
-                    project.NodeId,
-                    new TerminalNodeStatus(project.ProjectFile!, project.TargetFramework, project.RuntimeIdentifier, "Restore", _projects[contextKey].Stopwatch));
-            }
+        if (project.TargetNames == "Restore" && !_restoreFinished)
+        {
+            _restoreContext = project.ContextKey;
+
+            UpdateNodeStatus(
+                project.NodeId,
+                new TerminalNodeStatus(
+                    project.ProjectFile!,
+                    project.TargetFramework,
+                    project.RuntimeIdentifier,
+                    "Restore",
+                    projectInfo.Stopwatch));
         }
     }
 
     private bool TryGetProject(
-        BuildEventTracker.ProjectSnapshot? trackedProject,
+        BuildEventTracker.TrackedProject? trackedProject,
         [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out TerminalProjectInfo? project)
     {
         if (trackedProject is null)
@@ -763,7 +766,7 @@ public sealed partial class TerminalLogger : INodeLogger
     /// <summary>
     /// The <see cref="IEventSource.ProjectFinished"/> callback.
     /// </summary>
-    private void ProjectFinished(BuildEventTracker.ProjectSnapshot? trackedProject, ProjectFinishedEventArgs e)
+    private void ProjectFinished(BuildEventTracker.TrackedProject? trackedProject, ProjectFinishedEventArgs e)
     {
         if (trackedProject is null)
         {
@@ -781,9 +784,6 @@ public sealed partial class TerminalLogger : INodeLogger
         {
             return;
         }
-
-        project.Succeeded = e.Succeeded;
-        project.Stopwatch.Stop();
 
         // In quiet mode, only show projects with errors or warnings.
         // In higher verbosity modes, show projects based on other criteria.
@@ -1004,17 +1004,14 @@ public sealed partial class TerminalLogger : INodeLogger
     /// <summary>
     /// The <see cref="IEventSource.TargetStarted"/> callback.
     /// </summary>
-    private void TargetStarted(BuildEventTracker.ProjectSnapshot? trackedProject, TargetStartedEventArgs e)
+    private void TargetStarted(BuildEventTracker.TrackedProject? trackedProject, TargetStartedEventArgs e)
     {
         if (_restoreContext is null
             && TryGetProject(trackedProject, out TerminalProjectInfo? project))
         {
-            project.Stopwatch.Start();
-
             string projectFile = Path.GetFileNameWithoutExtension(e.ProjectFile);
 
-            string targetName = e.TargetName;
-            project.CurrentTarget = targetName;
+            string targetName = trackedProject!.CurrentTarget ?? e.TargetName;
             if (targetName == CachePluginStartTarget)
             {
                 project.IsCachePluginProject = true;
@@ -1068,7 +1065,7 @@ public sealed partial class TerminalLogger : INodeLogger
     /// <summary>
     /// The <see cref="IEventSource.TargetFinished"/> callback. Unused.
     /// </summary>
-    private void TargetFinished(BuildEventTracker.ProjectSnapshot? trackedProject, TargetFinishedEventArgs e)
+    private void TargetFinished(BuildEventTracker.TrackedProject? trackedProject, TargetFinishedEventArgs e)
     {
         // For cache plugin projects which result in a cache hit, ensure the output path is set
         // to the item spec corresponding to the GetTargetPath target upon completion.
@@ -1106,7 +1103,7 @@ public sealed partial class TerminalLogger : INodeLogger
     /// <summary>
     /// The <see cref="IEventSource.TaskStarted"/> callback.
     /// </summary>
-    private void TaskStarted(BuildEventTracker.ProjectSnapshot? trackedProject, TaskStartedEventArgs e)
+    private void TaskStarted(BuildEventTracker.TrackedProject? trackedProject, TaskStartedEventArgs e)
     {
         if (_restoreContext is null
             && e.TaskName == MSBuildTaskName
@@ -1114,27 +1111,20 @@ public sealed partial class TerminalLogger : INodeLogger
         {
             // This will yield the node, so preemptively mark it idle
             UpdateNodeStatus(trackedProject.NodeId, null);
-
-            if (TryGetProject(trackedProject, out TerminalProjectInfo? project))
-            {
-                project.Stopwatch.Stop();
-            }
         }
     }
 
     /// <summary>
     /// The <see cref="IEventSource.TaskFinished"/> callback.
     /// </summary>
-    private void TaskFinished(BuildEventTracker.ProjectSnapshot? trackedProject, TaskFinishedEventArgs e)
+    private void TaskFinished(BuildEventTracker.TrackedProject? trackedProject, TaskFinishedEventArgs e)
     {
         if (_restoreContext is null
             && e.TaskName == MSBuildTaskName
             && TryGetProject(trackedProject, out TerminalProjectInfo? project))
         {
-            project.Stopwatch.Start();
-
             string projectFile = Path.GetFileNameWithoutExtension(e.ProjectFile);
-            string targetName = project.CurrentTarget ?? "";
+            string targetName = trackedProject!.CurrentTarget ?? "";
 
             TerminalNodeStatus nodeStatus = new(projectFile, project.TargetFramework, project.RuntimeIdentifier, GetDisplayTargetName(targetName), project.Stopwatch);
             UpdateNodeStatus(trackedProject!.NodeId, nodeStatus);
@@ -1144,7 +1134,7 @@ public sealed partial class TerminalLogger : INodeLogger
     /// <summary>
     /// The <see cref="IEventSource.MessageRaised"/> callback.
     /// </summary>
-    private void MessageRaised(BuildEventTracker.ProjectSnapshot? trackedProject, BuildMessageEventArgs e)
+    private void MessageRaised(BuildEventTracker.TrackedProject? trackedProject, BuildMessageEventArgs e)
     {
         if (e.BuildEventContext is null)
         {
@@ -1302,7 +1292,7 @@ public sealed partial class TerminalLogger : INodeLogger
     /// <summary>
     /// The <see cref="IEventSource.WarningRaised"/> callback.
     /// </summary>
-    private void WarningRaised(BuildEventTracker.ProjectSnapshot? trackedProject, BuildWarningEventArgs e)
+    private void WarningRaised(BuildEventTracker.TrackedProject? trackedProject, BuildWarningEventArgs e)
     {
         // auth provider messages are 'global' in nature and should be a) immediate reported, and b) not re-reported in the summary.
         if (IsAuthProviderMessage(e.Message))
@@ -1388,7 +1378,7 @@ public sealed partial class TerminalLogger : INodeLogger
     /// <summary>
     /// The <see cref="IEventSource.ErrorRaised"/> callback.
     /// </summary>
-    private void ErrorRaised(BuildEventTracker.ProjectSnapshot? trackedProject, BuildErrorEventArgs e)
+    private void ErrorRaised(BuildEventTracker.TrackedProject? trackedProject, BuildErrorEventArgs e)
     {
         if (TryGetProject(trackedProject, out TerminalProjectInfo? project))
         {

--- a/src/Build/Logging/TerminalLogger/TerminalLogger.cs
+++ b/src/Build/Logging/TerminalLogger/TerminalLogger.cs
@@ -32,6 +32,8 @@ namespace Microsoft.Build.Logging;
 /// </remarks>
 public sealed partial class TerminalLogger : INodeLogger
 {
+    private readonly BuildEventTracker _eventTracker = new();
+
     private const string FilePathPattern = " -> ";
     private const string MSBuildTaskName = "MSBuild";
 
@@ -114,11 +116,6 @@ public sealed partial class TerminalLogger : INodeLogger
     /// However, reads and writes to locations in an array is atomic, so locking is not required.
     /// </remarks>
     private TerminalNodeStatus?[] _nodes = Array.Empty<TerminalNodeStatus>();
-
-    /// <summary>
-    /// The timestamp of the <see cref="IEventSource.BuildStarted"/> event.
-    /// </summary>
-    private DateTime _buildStartTime;
 
     /// <summary>
     /// The working directory when the build starts, to trim relative output paths.
@@ -446,18 +443,19 @@ public sealed partial class TerminalLogger : INodeLogger
         // Detect if we're in replay mode
         _isReplayMode = eventSource is IBinaryLogReplaySource;
 
-        eventSource.BuildStarted += BuildStarted;
-        eventSource.BuildFinished += BuildFinished;
-        eventSource.ProjectStarted += ProjectStarted;
-        eventSource.ProjectFinished += ProjectFinished;
-        eventSource.TargetStarted += TargetStarted;
-        eventSource.TargetFinished += TargetFinished;
-        eventSource.TaskStarted += TaskStarted;
-        eventSource.TaskFinished += TaskFinished;
-        eventSource.StatusEventRaised += StatusEventRaised;
-        eventSource.MessageRaised += MessageRaised;
-        eventSource.WarningRaised += WarningRaised;
-        eventSource.ErrorRaised += ErrorRaised;
+        _eventTracker.BuildStartedTracked += OnBuildStarted;
+        _eventTracker.BuildFinishedTracked += OnBuildFinished;
+        _eventTracker.ProjectStartedTracked += OnProjectStarted;
+        _eventTracker.ProjectFinishedTracked += ProjectFinished;
+        _eventTracker.TargetStartedTracked += TargetStarted;
+        _eventTracker.TargetFinishedTracked += TargetFinished;
+        _eventTracker.TaskStartedTracked += TaskStarted;
+        _eventTracker.TaskFinishedTracked += TaskFinished;
+        _eventTracker.StatusEventTracked += StatusEventRaised;
+        _eventTracker.MessageTracked += MessageRaised;
+        _eventTracker.WarningTracked += WarningRaised;
+        _eventTracker.ErrorTracked += ErrorRaised;
+        _eventTracker.Attach(eventSource);
 
         if (eventSource is IEventSource4 eventSource4)
         {
@@ -545,6 +543,20 @@ public sealed partial class TerminalLogger : INodeLogger
     /// <inheritdoc/>
     public void Shutdown()
     {
+        _eventTracker.Detach();
+        _eventTracker.BuildStartedTracked -= OnBuildStarted;
+        _eventTracker.BuildFinishedTracked -= OnBuildFinished;
+        _eventTracker.ProjectStartedTracked -= OnProjectStarted;
+        _eventTracker.ProjectFinishedTracked -= ProjectFinished;
+        _eventTracker.TargetStartedTracked -= TargetStarted;
+        _eventTracker.TargetFinishedTracked -= TargetFinished;
+        _eventTracker.TaskStartedTracked -= TaskStarted;
+        _eventTracker.TaskFinishedTracked -= TaskFinished;
+        _eventTracker.StatusEventTracked -= StatusEventRaised;
+        _eventTracker.MessageTracked -= MessageRaised;
+        _eventTracker.WarningTracked -= WarningRaised;
+        _eventTracker.ErrorTracked -= ErrorRaised;
+
         NativeMethodsShared.RestoreConsoleMode(_originalConsoleMode);
 
         _cts.Cancel();
@@ -568,9 +580,9 @@ public sealed partial class TerminalLogger : INodeLogger
     #region Logger callbacks
 
     /// <summary>
-    /// The <see cref="IEventSource.BuildStarted"/> callback.
+    /// The tracked build-start callback.
     /// </summary>
-    private void BuildStarted(object sender, BuildStartedEventArgs e)
+    private void OnBuildStarted(BuildEventTracker.BuildStartedSnapshot _)
     {
         if (!_manualRefresh && _showNodesDisplay)
         {
@@ -579,8 +591,6 @@ public sealed partial class TerminalLogger : INodeLogger
             _refresher.Start();
         }
 
-        _buildStartTime = e.Timestamp;
-
         if (Terminal.SupportsProgressReporting && Verbosity != LoggerVerbosity.Quiet)
         {
             Terminal.Write(AnsiCodes.SetProgressIndeterminate);
@@ -588,9 +598,9 @@ public sealed partial class TerminalLogger : INodeLogger
     }
 
     /// <summary>
-    /// The <see cref="IEventSource.BuildFinished"/> callback.
+    /// The tracked build-finished callback.
     /// </summary>
-    private void BuildFinished(object sender, BuildFinishedEventArgs e)
+    private void OnBuildFinished(BuildEventTracker.BuildFinishedSnapshot build)
     {
         _cts.Cancel();
         _refresher?.Join();
@@ -600,8 +610,8 @@ public sealed partial class TerminalLogger : INodeLogger
         {
             if (Verbosity > LoggerVerbosity.Quiet)
             {
-                string duration = (e.Timestamp - _buildStartTime).TotalSeconds.ToString("F1");
-                string buildResult = GetBuildResultString(e.Succeeded, _buildErrorsCount, _buildWarningsCount);
+                string duration = build.Duration.TotalSeconds.ToString("F1");
+                string buildResult = GetBuildResultString(build.Succeeded, _buildErrorsCount, _buildWarningsCount);
 
                 Terminal.WriteLine("");
                 if (_testRunSummaries.Any())
@@ -710,7 +720,7 @@ public sealed partial class TerminalLogger : INodeLogger
         Terminal.WriteLine(string.Empty);
     }
 
-    private void StatusEventRaised(object sender, BuildStatusEventArgs e)
+    private void StatusEventRaised(BuildStatusEventArgs e)
     {
         switch (e)
         {
@@ -720,7 +730,6 @@ public sealed partial class TerminalLogger : INodeLogger
             case ProjectEvaluationStartedEventArgs _evalStart:
                 break;
             case ProjectEvaluationFinishedEventArgs evalFinish:
-                CaptureEvalContext(evalFinish);
                 break;
             case LoggersRegisteredEventArgs loggerEvent:
                 _registeredLoggers.AddRange(loggerEvent.Loggers);
@@ -729,45 +738,36 @@ public sealed partial class TerminalLogger : INodeLogger
     }
 
     /// <summary>
-    /// The <see cref="IEventSource.ProjectStarted"/> callback.
+    /// The tracked project-start callback.
     /// </summary>
-    private void ProjectStarted(object sender, ProjectStartedEventArgs e)
+    private void OnProjectStarted(BuildEventTracker.ProjectStartedSnapshot project)
     {
-        if (e.BuildEventContext is null)
-        {
-            return;
-        }
-
-        ProjectContext c = new(e.BuildEventContext);
+        ProjectContext c = new(project.ProjectContextId);
 
         if (_restoreContext is null)
         {
-            EvalContext evalContext = new(e.BuildEventContext);
-            string? targetFramework = null;
-            string? runtimeIdentifier = null;
-            
-            if (_projectEvaluations.TryGetValue(evalContext, out EvalProjectInfo evalInfo))
-            {
-                targetFramework = evalInfo.TargetFramework;
-                runtimeIdentifier = evalInfo.RuntimeIdentifier;
-            }
+            EvalProjectInfo evalInfo = new(
+                new EvalContext(project.EvaluationId),
+                project.EvaluationProjectFile,
+                project.TargetFramework,
+                project.RuntimeIdentifier);
 
             // Per-project metaproj files (e.g. MyProject.csproj.metaproj) are constructed
             // directly without evaluation, so they won't have a matching ProjectEvaluationFinished event.
             System.Diagnostics.Debug.Assert(
-                evalInfo != default || FileUtilities.IsMetaprojectFilename(e.ProjectFile),
+                evalInfo != default || FileUtilities.IsMetaprojectFilename(project.ProjectFile),
                 "EvalProjectInfo should have been captured before ProjectStarted");
 
             TerminalProjectInfo projectInfo = new(c, evalInfo, _createStopwatch?.Invoke());
             _projects[c] = projectInfo;
 
             // First ever restore in the build is starting.
-            if (e.TargetNames == "Restore" && !_restoreFinished)
+            if (project.TargetNames == "Restore" && !_restoreFinished)
             {
                 _restoreContext = c;
-                int nodeIndex = NodeIndexForContext(e.BuildEventContext);
+                int nodeIndex = project.NodeId - 1;
                 EnsureNodeCapacity(nodeIndex);
-                _nodes[nodeIndex] = new TerminalNodeStatus(e.ProjectFile!, targetFramework, runtimeIdentifier, "Restore", _projects[c].Stopwatch);
+                _nodes[nodeIndex] = new TerminalNodeStatus(project.ProjectFile!, project.TargetFramework, project.RuntimeIdentifier, "Restore", _projects[c].Stopwatch);
             }
         }
     }
@@ -775,7 +775,7 @@ public sealed partial class TerminalLogger : INodeLogger
     /// <summary>
     /// The <see cref="IEventSource.ProjectFinished"/> callback.
     /// </summary>
-    private void ProjectFinished(object sender, ProjectFinishedEventArgs e)
+    private void ProjectFinished(ProjectFinishedEventArgs e)
     {
         var buildEventContext = e.BuildEventContext;
         if (buildEventContext is null)
@@ -1052,7 +1052,7 @@ public sealed partial class TerminalLogger : INodeLogger
     /// <summary>
     /// The <see cref="IEventSource.TargetStarted"/> callback.
     /// </summary>
-    private void TargetStarted(object sender, TargetStartedEventArgs e)
+    private void TargetStarted(TargetStartedEventArgs e)
     {
         var buildEventContext = e.BuildEventContext;
         if (_restoreContext is null && buildEventContext is not null && _projects.TryGetValue(new ProjectContext(buildEventContext), out TerminalProjectInfo? project))
@@ -1116,7 +1116,7 @@ public sealed partial class TerminalLogger : INodeLogger
     /// <summary>
     /// The <see cref="IEventSource.TargetFinished"/> callback. Unused.
     /// </summary>
-    private void TargetFinished(object sender, TargetFinishedEventArgs e)
+    private void TargetFinished(TargetFinishedEventArgs e)
     {
         // For cache plugin projects which result in a cache hit, ensure the output path is set
         // to the item spec corresponding to the GetTargetPath target upon completion.
@@ -1156,7 +1156,7 @@ public sealed partial class TerminalLogger : INodeLogger
     /// <summary>
     /// The <see cref="IEventSource.TaskStarted"/> callback.
     /// </summary>
-    private void TaskStarted(object sender, TaskStartedEventArgs e)
+    private void TaskStarted(TaskStartedEventArgs e)
     {
         var buildEventContext = e.BuildEventContext;
         if (_restoreContext is null && buildEventContext is not null && e.TaskName == MSBuildTaskName)
@@ -1174,7 +1174,7 @@ public sealed partial class TerminalLogger : INodeLogger
     /// <summary>
     /// The <see cref="IEventSource.TaskFinished"/> callback.
     /// </summary>
-    private void TaskFinished(object sender, TaskFinishedEventArgs e)
+    private void TaskFinished(TaskFinishedEventArgs e)
     {
         var buildEventContext = e.BuildEventContext;
         if (_restoreContext is null && buildEventContext is not null && e.TaskName == MSBuildTaskName
@@ -1193,7 +1193,7 @@ public sealed partial class TerminalLogger : INodeLogger
     /// <summary>
     /// The <see cref="IEventSource.MessageRaised"/> callback.
     /// </summary>
-    private void MessageRaised(object sender, BuildMessageEventArgs e)
+    private void MessageRaised(BuildMessageEventArgs e)
     {
         var buildEventContext = e.BuildEventContext;
         if (buildEventContext is null)
@@ -1352,7 +1352,7 @@ public sealed partial class TerminalLogger : INodeLogger
     /// <summary>
     /// The <see cref="IEventSource.WarningRaised"/> callback.
     /// </summary>
-    private void WarningRaised(object sender, BuildWarningEventArgs e)
+    private void WarningRaised(BuildWarningEventArgs e)
     {
         BuildEventContext? buildEventContext = e.BuildEventContext;
 
@@ -1441,7 +1441,7 @@ public sealed partial class TerminalLogger : INodeLogger
     /// <summary>
     /// The <see cref="IEventSource.ErrorRaised"/> callback.
     /// </summary>
-    private void ErrorRaised(object sender, BuildErrorEventArgs e)
+    private void ErrorRaised(BuildErrorEventArgs e)
     {
         BuildEventContext? buildEventContext = e.BuildEventContext;
 

--- a/src/Build/Logging/TerminalLogger/TerminalLogger.cs
+++ b/src/Build/Logging/TerminalLogger/TerminalLogger.cs
@@ -59,11 +59,7 @@ public sealed partial class TerminalLogger : INodeLogger
     internal const TerminalColor TargetFrameworkColor = TerminalColor.Cyan;
     internal const TerminalColor RuntimeIdentifierColor = TerminalColor.Magenta;
 
-    internal Func<StopwatchAbstraction>? _createStopwatch
-    {
-        get => _eventTracker.StopwatchFactory;
-        set => _eventTracker.StopwatchFactory = value;
-    }
+    internal Func<StopwatchAbstraction>? _createStopwatch;
 
     /// <summary>
     /// Name of target that identifies the project cache plugin run has just started.
@@ -720,7 +716,7 @@ public sealed partial class TerminalLogger : INodeLogger
     /// <summary>
     /// The tracked project-start callback.
     /// </summary>
-    private void OnProjectStarted(BuildEventTracker.TrackedProject project)
+    private void OnProjectStarted(BuildEventTracker.ProjectSnapshot project)
     {
         if (_restoreContext is not null)
         {
@@ -732,7 +728,7 @@ public sealed partial class TerminalLogger : INodeLogger
                 || FileUtilities.IsMetaprojectFilename(project.ProjectFile),
             "Evaluation information should be captured before ProjectStarted.");
 
-        TerminalProjectInfo projectInfo = new(project);
+        TerminalProjectInfo projectInfo = new(project, _createStopwatch?.Invoke() ?? new SystemStopwatch());
         _projects[project.ContextKey] = projectInfo;
 
         if (project.TargetNames == "Restore" && !_restoreFinished)
@@ -751,7 +747,7 @@ public sealed partial class TerminalLogger : INodeLogger
     }
 
     private bool TryGetProject(
-        BuildEventTracker.TrackedProject? trackedProject,
+        BuildEventTracker.ProjectSnapshot? trackedProject,
         [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out TerminalProjectInfo? project)
     {
         if (trackedProject is null)
@@ -760,13 +756,13 @@ public sealed partial class TerminalLogger : INodeLogger
             return false;
         }
 
-        return _projects.TryGetValue(trackedProject.ContextKey, out project);
+        return _projects.TryGetValue(trackedProject.Value.ContextKey, out project);
     }
 
     /// <summary>
     /// The <see cref="IEventSource.ProjectFinished"/> callback.
     /// </summary>
-    private void ProjectFinished(BuildEventTracker.TrackedProject? trackedProject, ProjectFinishedEventArgs e)
+    private void ProjectFinished(BuildEventTracker.ProjectSnapshot? trackedProject, ProjectFinishedEventArgs e)
     {
         if (trackedProject is null)
         {
@@ -776,14 +772,16 @@ public sealed partial class TerminalLogger : INodeLogger
         // Mark node idle until something uses it again
         if (_restoreContext is null)
         {
-            UpdateNodeStatus(trackedProject.NodeId, null);
+            UpdateNodeStatus(trackedProject.Value.NodeId, null);
         }
 
-        BuildEventTracker.ProjectContextKey contextKey = trackedProject.ContextKey;
+        BuildEventTracker.ProjectContextKey contextKey = trackedProject.Value.ContextKey;
         if (!TryGetProject(trackedProject, out TerminalProjectInfo? project))
         {
             return;
         }
+
+        project.Update(trackedProject.Value);
 
         // In quiet mode, only show projects with errors or warnings.
         // In higher verbosity modes, show projects based on other criteria.
@@ -1004,14 +1002,16 @@ public sealed partial class TerminalLogger : INodeLogger
     /// <summary>
     /// The <see cref="IEventSource.TargetStarted"/> callback.
     /// </summary>
-    private void TargetStarted(BuildEventTracker.TrackedProject? trackedProject, TargetStartedEventArgs e)
+    private void TargetStarted(BuildEventTracker.ProjectSnapshot? trackedProject, TargetStartedEventArgs e)
     {
         if (_restoreContext is null
+            && trackedProject is BuildEventTracker.ProjectSnapshot projectSnapshot
             && TryGetProject(trackedProject, out TerminalProjectInfo? project))
         {
             string projectFile = Path.GetFileNameWithoutExtension(e.ProjectFile);
 
-            string targetName = trackedProject!.CurrentTarget ?? e.TargetName;
+            project.Update(projectSnapshot);
+            string targetName = projectSnapshot.CurrentTarget ?? e.TargetName;
             if (targetName == CachePluginStartTarget)
             {
                 project.IsCachePluginProject = true;
@@ -1030,7 +1030,7 @@ public sealed partial class TerminalLogger : INodeLogger
             }
 
             TerminalNodeStatus nodeStatus = new(projectFile, project.TargetFramework, project.RuntimeIdentifier, GetDisplayTargetName(targetName), project.Stopwatch);
-            UpdateNodeStatus(trackedProject!.NodeId, nodeStatus);
+            UpdateNodeStatus(projectSnapshot.NodeId, nodeStatus);
         }
     }
 
@@ -1065,7 +1065,7 @@ public sealed partial class TerminalLogger : INodeLogger
     /// <summary>
     /// The <see cref="IEventSource.TargetFinished"/> callback. Unused.
     /// </summary>
-    private void TargetFinished(BuildEventTracker.TrackedProject? trackedProject, TargetFinishedEventArgs e)
+    private void TargetFinished(BuildEventTracker.ProjectSnapshot? trackedProject, TargetFinishedEventArgs e)
     {
         // For cache plugin projects which result in a cache hit, ensure the output path is set
         // to the item spec corresponding to the GetTargetPath target upon completion.
@@ -1103,38 +1103,44 @@ public sealed partial class TerminalLogger : INodeLogger
     /// <summary>
     /// The <see cref="IEventSource.TaskStarted"/> callback.
     /// </summary>
-    private void TaskStarted(BuildEventTracker.TrackedProject? trackedProject, TaskStartedEventArgs e)
+    private void TaskStarted(BuildEventTracker.ProjectSnapshot? trackedProject, TaskStartedEventArgs e)
     {
         if (_restoreContext is null
             && e.TaskName == MSBuildTaskName
             && trackedProject is not null)
         {
+            if (TryGetProject(trackedProject, out TerminalProjectInfo? project))
+            {
+                project.Update(trackedProject.Value);
+            }
+
             // This will yield the node, so preemptively mark it idle
-            UpdateNodeStatus(trackedProject.NodeId, null);
+            UpdateNodeStatus(trackedProject.Value.NodeId, null);
         }
     }
 
     /// <summary>
     /// The <see cref="IEventSource.TaskFinished"/> callback.
     /// </summary>
-    private void TaskFinished(BuildEventTracker.TrackedProject? trackedProject, TaskFinishedEventArgs e)
+    private void TaskFinished(BuildEventTracker.ProjectSnapshot? trackedProject, TaskFinishedEventArgs e)
     {
         if (_restoreContext is null
             && e.TaskName == MSBuildTaskName
             && TryGetProject(trackedProject, out TerminalProjectInfo? project))
         {
+            project.Update(trackedProject!.Value);
             string projectFile = Path.GetFileNameWithoutExtension(e.ProjectFile);
-            string targetName = trackedProject!.CurrentTarget ?? "";
+            string targetName = trackedProject.Value.CurrentTarget ?? "";
 
             TerminalNodeStatus nodeStatus = new(projectFile, project.TargetFramework, project.RuntimeIdentifier, GetDisplayTargetName(targetName), project.Stopwatch);
-            UpdateNodeStatus(trackedProject!.NodeId, nodeStatus);
+            UpdateNodeStatus(trackedProject.Value.NodeId, nodeStatus);
         }
     }
 
     /// <summary>
     /// The <see cref="IEventSource.MessageRaised"/> callback.
     /// </summary>
-    private void MessageRaised(BuildEventTracker.TrackedProject? trackedProject, BuildMessageEventArgs e)
+    private void MessageRaised(BuildEventTracker.ProjectSnapshot? trackedProject, BuildMessageEventArgs e)
     {
         if (e.BuildEventContext is null)
         {
@@ -1187,7 +1193,7 @@ public sealed partial class TerminalLogger : INodeLogger
 
             if (hasProject && project!.IsTestProject)
             {
-                int nodeIndex = NodeIndexForNode(trackedProject!.NodeId);
+                int nodeIndex = NodeIndexForNode(trackedProject!.Value.NodeId);
                 EnsureNodeCapacity(nodeIndex);
                 TerminalNodeStatus? node = _nodes[nodeIndex];
 
@@ -1204,7 +1210,7 @@ public sealed partial class TerminalLogger : INodeLogger
                                     string displayName = extendedMessage.ExtendedMetadata!["displayName"]!;
 
                                     var status = new TerminalNodeStatus(node.Project, node.TargetFramework, node.RuntimeIdentifier, TerminalColor.Green, indicator, displayName, project.Stopwatch);
-                                    UpdateNodeStatus(trackedProject.NodeId, status);
+                                    UpdateNodeStatus(trackedProject.Value.NodeId, status);
                                 }
                                 break;
                             }
@@ -1217,7 +1223,7 @@ public sealed partial class TerminalLogger : INodeLogger
                                     string displayName = extendedMessage.ExtendedMetadata!["displayName"]!;
 
                                     var status = new TerminalNodeStatus(node.Project, node.TargetFramework, node.RuntimeIdentifier, TerminalColor.Yellow, indicator, displayName, project.Stopwatch);
-                                    UpdateNodeStatus(trackedProject.NodeId, status);
+                                    UpdateNodeStatus(trackedProject.Value.NodeId, status);
                                 }
                                 break;
                             }
@@ -1292,7 +1298,7 @@ public sealed partial class TerminalLogger : INodeLogger
     /// <summary>
     /// The <see cref="IEventSource.WarningRaised"/> callback.
     /// </summary>
-    private void WarningRaised(BuildEventTracker.TrackedProject? trackedProject, BuildWarningEventArgs e)
+    private void WarningRaised(BuildEventTracker.ProjectSnapshot? trackedProject, BuildWarningEventArgs e)
     {
         // auth provider messages are 'global' in nature and should be a) immediate reported, and b) not re-reported in the summary.
         if (IsAuthProviderMessage(e.Message))
@@ -1378,7 +1384,7 @@ public sealed partial class TerminalLogger : INodeLogger
     /// <summary>
     /// The <see cref="IEventSource.ErrorRaised"/> callback.
     /// </summary>
-    private void ErrorRaised(BuildEventTracker.TrackedProject? trackedProject, BuildErrorEventArgs e)
+    private void ErrorRaised(BuildEventTracker.ProjectSnapshot? trackedProject, BuildErrorEventArgs e)
     {
         if (TryGetProject(trackedProject, out TerminalProjectInfo? project))
         {

--- a/src/Build/Logging/TerminalLogger/TerminalProjectInfo.cs
+++ b/src/Build/Logging/TerminalLogger/TerminalProjectInfo.cs
@@ -8,14 +8,6 @@ using System.Linq;
 namespace Microsoft.Build.Logging;
 
 /// <summary>
-/// A struct containing relevant evaluation-time data that may not be knowable just from ProjectStart events.
-/// </summary>
-/// <param name="ProjectFile"></param>
-/// <param name="TargetFramework"></param>
-/// <param name="RuntimeIdentifier"></param>
-internal readonly record struct EvalProjectInfo(string? ProjectFile, string? TargetFramework, string? RuntimeIdentifier);
-
-/// <summary>
 /// Represents a project being built.
 /// </summary>
 internal sealed class TerminalProjectInfo
@@ -33,6 +25,8 @@ internal sealed class TerminalProjectInfo
         ProjectFile = project.EvaluationProjectFile;
         TargetFramework = project.TargetFramework;
         RuntimeIdentifier = project.RuntimeIdentifier;
+        ErrorCount = project.ErrorCount;
+        WarningCount = project.WarningCount;
         Stopwatch = stopwatch;
 
         if (project.IsTimingActive)
@@ -74,12 +68,12 @@ internal sealed class TerminalProjectInfo
     /// <summary>
     /// The number of errors included in the terminal summary.
     /// </summary>
-    public int ErrorCount => GetBuildMessageCount(TerminalMessageSeverity.Error);
+    public int ErrorCount { get; private set; }
 
     /// <summary>
     /// The number of warnings included in the terminal summary.
     /// </summary>
-    public int WarningCount => GetBuildMessageCount(TerminalMessageSeverity.Warning);
+    public int WarningCount { get; private set; }
 
     /// <summary>
     /// True when the project has error or warning build messages; otherwise false.
@@ -123,6 +117,8 @@ internal sealed class TerminalProjectInfo
     internal void Update(BuildEventTracker.ProjectSnapshot project)
     {
         Succeeded = project.Succeeded == true;
+        ErrorCount = project.ErrorCount;
+        WarningCount = project.WarningCount;
 
         if (project.IsTimingActive)
         {
@@ -145,12 +141,4 @@ internal sealed class TerminalProjectInfo
             : BuildMessages.Where(message =>
                 message.Severity is TerminalMessageSeverity.Error or TerminalMessageSeverity.Warning);
     }
-
-private int GetBuildMessageCount(TerminalMessageSeverity severity) =>
-    severity switch
-    {
-        TerminalMessageSeverity.Error => Project.ErrorCount,
-        TerminalMessageSeverity.Warning => Project.WarningCount,
-        _ => 0,
-    };
 }

--- a/src/Build/Logging/TerminalLogger/TerminalProjectInfo.cs
+++ b/src/Build/Logging/TerminalLogger/TerminalProjectInfo.cs
@@ -10,14 +10,10 @@ namespace Microsoft.Build.Logging;
 /// <summary>
 /// A struct containing relevant evaluation-time data that may not be knowable just from ProjectStart events.
 /// </summary>
-/// <param name="context"></param>
 /// <param name="ProjectFile"></param>
 /// <param name="TargetFramework"></param>
 /// <param name="RuntimeIdentifier"></param>
-internal record struct EvalProjectInfo(TerminalLogger.EvalContext context, string? ProjectFile, string? TargetFramework, string? RuntimeIdentifier)
-{
-    public readonly int Id => context.Id;
-}
+internal readonly record struct EvalProjectInfo(string? ProjectFile, string? TargetFramework, string? RuntimeIdentifier);
 
 /// <summary>
 /// Represents a project being built.
@@ -29,13 +25,13 @@ internal sealed class TerminalProjectInfo
     /// <summary>
     /// Initialized a new <see cref="TerminalProjectInfo"/> with the given <paramref name="evalInfo"/> .
     /// </summary>
-    /// <param name="context">The ProjectContext of this project execution.</param>
+    /// <param name="contextKey">The project context key of this project execution.</param>
     /// <param name="evalInfo">A subset of the interesting eval-time data for this running project</param>
     /// <param name="stopwatch">A stopwatch to time the build of the project.</param>
-    public TerminalProjectInfo(TerminalLogger.ProjectContext context, EvalProjectInfo evalInfo, StopwatchAbstraction? stopwatch)
+    public TerminalProjectInfo(BuildEventTracker.ProjectContextKey contextKey, EvalProjectInfo evalInfo, StopwatchAbstraction? stopwatch)
     {
         _evalInfo = evalInfo;
-        _context = context;
+        _contextKey = contextKey;
 
         if (stopwatch is not null)
         {
@@ -51,7 +47,7 @@ internal sealed class TerminalProjectInfo
     /// <summary>
     /// The int value of the ProjectContext id of this project execution.
     /// </summary>
-    public int Id => _context.Id;
+    public int Id => _contextKey.ProjectContextId;
 
     /// <summary>
     /// The full path to the project file.
@@ -82,7 +78,7 @@ internal sealed class TerminalProjectInfo
     /// The runtime identifier of the project or null if platform-agnostic.
     /// </summary>
     public string? RuntimeIdentifier => _evalInfo.RuntimeIdentifier;
-    private readonly TerminalLogger.ProjectContext _context;
+    private readonly BuildEventTracker.ProjectContextKey _contextKey;
     private readonly EvalProjectInfo _evalInfo;
 
     /// <summary>

--- a/src/Build/Logging/TerminalLogger/TerminalProjectInfo.cs
+++ b/src/Build/Logging/TerminalLogger/TerminalProjectInfo.cs
@@ -124,22 +124,11 @@ internal sealed class TerminalProjectInfo
                 message.Severity is TerminalMessageSeverity.Error or TerminalMessageSeverity.Warning);
     }
 
-    private int GetBuildMessageCount(TerminalMessageSeverity severity)
+private int GetBuildMessageCount(TerminalMessageSeverity severity) =>
+    severity switch
     {
-        if (_buildMessages is null)
-        {
-            return 0;
-        }
-
-        int count = 0;
-        foreach (TerminalBuildMessage message in _buildMessages)
-        {
-            if (message.Severity == severity)
-            {
-                count++;
-            }
-        }
-
-        return count;
-    }
+        TerminalMessageSeverity.Error => Project.ErrorCount,
+        TerminalMessageSeverity.Warning => Project.WarningCount,
+        _ => 0,
+    };
 }

--- a/src/Build/Logging/TerminalLogger/TerminalProjectInfo.cs
+++ b/src/Build/Logging/TerminalLogger/TerminalProjectInfo.cs
@@ -26,42 +26,50 @@ internal sealed class TerminalProjectInfo
     /// Initializes a new <see cref="TerminalProjectInfo"/> for the tracked project.
     /// </summary>
     /// <param name="project">The tracked project.</param>
-    public TerminalProjectInfo(BuildEventTracker.TrackedProject project)
+    /// <param name="stopwatch">The stopwatch used for terminal rendering.</param>
+    public TerminalProjectInfo(BuildEventTracker.ProjectSnapshot project, StopwatchAbstraction stopwatch)
     {
-        Project = project;
-    }
+        Id = project.ProjectContextId;
+        ProjectFile = project.EvaluationProjectFile;
+        TargetFramework = project.TargetFramework;
+        RuntimeIdentifier = project.RuntimeIdentifier;
+        Stopwatch = stopwatch;
 
-    internal BuildEventTracker.TrackedProject Project { get; }
+        if (project.IsTimingActive)
+        {
+            Stopwatch.Start();
+        }
+    }
 
     /// <summary>
     /// The int value of the ProjectContext id of this project execution.
     /// </summary>
-    public int Id => Project.ProjectContextId;
+    public int Id { get; }
 
     /// <summary>
     /// The full path to the project file.
     /// </summary>
-    public string? ProjectFile => Project.EvaluationProjectFile;
+    public string? ProjectFile { get; }
 
     /// <summary>
     /// A stopwatch to time the build of the project.
     /// </summary>
-    public StopwatchAbstraction Stopwatch => Project.Stopwatch;
+    public StopwatchAbstraction Stopwatch { get; }
 
     /// <summary>
     /// The target framework of the project or null if not multi-targeting.
     /// </summary>
-    public string? TargetFramework => Project.TargetFramework;
+    public string? TargetFramework { get; }
 
     /// <summary>
     /// The runtime identifier of the project or null if platform-agnostic.
     /// </summary>
-    public string? RuntimeIdentifier => Project.RuntimeIdentifier;
+    public string? RuntimeIdentifier { get; }
 
     /// <summary>
     /// True if the project built successfully; otherwise false.
     /// </summary>
-    public bool Succeeded => Project.Succeeded == true;
+    public bool Succeeded { get; private set; }
 
     /// <summary>
     /// The number of errors included in the terminal summary.
@@ -110,6 +118,20 @@ internal sealed class TerminalProjectInfo
     {
         _buildMessages ??= [];
         _buildMessages.Add(new TerminalBuildMessage(severity, message));
+    }
+
+    internal void Update(BuildEventTracker.ProjectSnapshot project)
+    {
+        Succeeded = project.Succeeded == true;
+
+        if (project.IsTimingActive)
+        {
+            Stopwatch.Start();
+        }
+        else
+        {
+            Stopwatch.Stop();
+        }
     }
 
     /// <summary>

--- a/src/Build/Logging/TerminalLogger/TerminalProjectInfo.cs
+++ b/src/Build/Logging/TerminalLogger/TerminalProjectInfo.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Build.Logging;
 internal sealed class TerminalProjectInfo
 {
     private List<TerminalBuildMessage>? _buildMessages;
+    private int _errorCount;
+    private int _warningCount;
 
     /// <summary>
     /// Initializes a new <see cref="TerminalProjectInfo"/> for the tracked project.
@@ -26,11 +28,7 @@ internal sealed class TerminalProjectInfo
         TargetFramework = project.TargetFramework;
         RuntimeIdentifier = project.RuntimeIdentifier;
         Stopwatch = stopwatch;
-
-        if (project.IsTimingActive)
-        {
-            Stopwatch.Start();
-        }
+        Stopwatch.Start();
     }
 
     /// <summary>
@@ -66,12 +64,12 @@ internal sealed class TerminalProjectInfo
     /// <summary>
     /// The number of errors included in the terminal summary.
     /// </summary>
-    public int ErrorCount => GetBuildMessageCount(TerminalMessageSeverity.Error);
+    public int ErrorCount => _errorCount;
 
     /// <summary>
     /// The number of warnings included in the terminal summary.
     /// </summary>
-    public int WarningCount => GetBuildMessageCount(TerminalMessageSeverity.Warning);
+    public int WarningCount => _warningCount;
 
     /// <summary>
     /// True when the project has error or warning build messages; otherwise false.
@@ -110,21 +108,27 @@ internal sealed class TerminalProjectInfo
     {
         _buildMessages ??= [];
         _buildMessages.Add(new TerminalBuildMessage(severity, message));
+
+        switch (severity)
+        {
+            case TerminalMessageSeverity.Error:
+                _errorCount++;
+                break;
+            case TerminalMessageSeverity.Warning:
+                _warningCount++;
+                break;
+        }
     }
 
-    internal void Update(BuildEventTracker.ProjectSnapshot project)
+    internal void Finish(bool succeeded)
     {
-        Succeeded = project.Succeeded == true;
-
-        if (project.IsTimingActive)
-        {
-            Stopwatch.Start();
-        }
-        else
-        {
-            Stopwatch.Stop();
-        }
+        Succeeded = succeeded;
+        Stopwatch.Stop();
     }
+
+    internal void ResumeTiming() => Stopwatch.Start();
+
+    internal void YieldTiming() => Stopwatch.Stop();
 
     /// <summary>
     /// Filters the build messages to only include errors and warnings.
@@ -136,24 +140,5 @@ internal sealed class TerminalProjectInfo
             ? []
             : BuildMessages.Where(message =>
                 message.Severity is TerminalMessageSeverity.Error or TerminalMessageSeverity.Warning);
-    }
-
-    private int GetBuildMessageCount(TerminalMessageSeverity severity)
-    {
-        if (_buildMessages is null)
-        {
-            return 0;
-        }
-
-        int count = 0;
-        foreach (TerminalBuildMessage message in _buildMessages)
-        {
-            if (message.Severity == severity)
-            {
-                count++;
-            }
-        }
-
-        return count;
     }
 }

--- a/src/Build/Logging/TerminalLogger/TerminalProjectInfo.cs
+++ b/src/Build/Logging/TerminalLogger/TerminalProjectInfo.cs
@@ -25,8 +25,6 @@ internal sealed class TerminalProjectInfo
         ProjectFile = project.EvaluationProjectFile;
         TargetFramework = project.TargetFramework;
         RuntimeIdentifier = project.RuntimeIdentifier;
-        ErrorCount = project.ErrorCount;
-        WarningCount = project.WarningCount;
         Stopwatch = stopwatch;
 
         if (project.IsTimingActive)
@@ -68,12 +66,12 @@ internal sealed class TerminalProjectInfo
     /// <summary>
     /// The number of errors included in the terminal summary.
     /// </summary>
-    public int ErrorCount { get; private set; }
+    public int ErrorCount => GetBuildMessageCount(TerminalMessageSeverity.Error);
 
     /// <summary>
     /// The number of warnings included in the terminal summary.
     /// </summary>
-    public int WarningCount { get; private set; }
+    public int WarningCount => GetBuildMessageCount(TerminalMessageSeverity.Warning);
 
     /// <summary>
     /// True when the project has error or warning build messages; otherwise false.
@@ -117,8 +115,6 @@ internal sealed class TerminalProjectInfo
     internal void Update(BuildEventTracker.ProjectSnapshot project)
     {
         Succeeded = project.Succeeded == true;
-        ErrorCount = project.ErrorCount;
-        WarningCount = project.WarningCount;
 
         if (project.IsTimingActive)
         {
@@ -140,5 +136,24 @@ internal sealed class TerminalProjectInfo
             ? []
             : BuildMessages.Where(message =>
                 message.Severity is TerminalMessageSeverity.Error or TerminalMessageSeverity.Warning);
+    }
+
+    private int GetBuildMessageCount(TerminalMessageSeverity severity)
+    {
+        if (_buildMessages is null)
+        {
+            return 0;
+        }
+
+        int count = 0;
+        foreach (TerminalBuildMessage message in _buildMessages)
+        {
+            if (message.Severity == severity)
+            {
+                count++;
+            }
+        }
+
+        return count;
     }
 }

--- a/src/Build/Logging/TerminalLogger/TerminalProjectInfo.cs
+++ b/src/Build/Logging/TerminalLogger/TerminalProjectInfo.cs
@@ -23,41 +23,60 @@ internal sealed class TerminalProjectInfo
     private List<TerminalBuildMessage>? _buildMessages;
 
     /// <summary>
-    /// Initialized a new <see cref="TerminalProjectInfo"/> with the given <paramref name="evalInfo"/> .
+    /// Initializes a new <see cref="TerminalProjectInfo"/> for the tracked project.
     /// </summary>
-    /// <param name="contextKey">The project context key of this project execution.</param>
-    /// <param name="evalInfo">A subset of the interesting eval-time data for this running project</param>
-    /// <param name="stopwatch">A stopwatch to time the build of the project.</param>
-    public TerminalProjectInfo(BuildEventTracker.ProjectContextKey contextKey, EvalProjectInfo evalInfo, StopwatchAbstraction? stopwatch)
+    /// <param name="project">The tracked project.</param>
+    public TerminalProjectInfo(BuildEventTracker.TrackedProject project)
     {
-        _evalInfo = evalInfo;
-        _contextKey = contextKey;
-
-        if (stopwatch is not null)
-        {
-            stopwatch.Start();
-            Stopwatch = stopwatch;
-        }
-        else
-        {
-            Stopwatch = SystemStopwatch.StartNew();
-        }
+        Project = project;
     }
+
+    internal BuildEventTracker.TrackedProject Project { get; }
 
     /// <summary>
     /// The int value of the ProjectContext id of this project execution.
     /// </summary>
-    public int Id => _contextKey.ProjectContextId;
+    public int Id => Project.ProjectContextId;
 
     /// <summary>
     /// The full path to the project file.
     /// </summary>
-    public string? ProjectFile => _evalInfo.ProjectFile;
+    public string? ProjectFile => Project.EvaluationProjectFile;
 
     /// <summary>
     /// A stopwatch to time the build of the project.
     /// </summary>
-    public StopwatchAbstraction Stopwatch { get; }
+    public StopwatchAbstraction Stopwatch => Project.Stopwatch;
+
+    /// <summary>
+    /// The target framework of the project or null if not multi-targeting.
+    /// </summary>
+    public string? TargetFramework => Project.TargetFramework;
+
+    /// <summary>
+    /// The runtime identifier of the project or null if platform-agnostic.
+    /// </summary>
+    public string? RuntimeIdentifier => Project.RuntimeIdentifier;
+
+    /// <summary>
+    /// True if the project built successfully; otherwise false.
+    /// </summary>
+    public bool Succeeded => Project.Succeeded == true;
+
+    /// <summary>
+    /// The number of errors included in the terminal summary.
+    /// </summary>
+    public int ErrorCount => GetBuildMessageCount(TerminalMessageSeverity.Error);
+
+    /// <summary>
+    /// The number of warnings included in the terminal summary.
+    /// </summary>
+    public int WarningCount => GetBuildMessageCount(TerminalMessageSeverity.Warning);
+
+    /// <summary>
+    /// True when the project has error or warning build messages; otherwise false.
+    /// </summary>
+    public bool HasErrorsOrWarnings => ErrorCount > 0 || WarningCount > 0;
 
     /// <summary>
     /// Full path to the primary output of the project, if known.
@@ -70,23 +89,6 @@ internal sealed class TerminalProjectInfo
     public ReadOnlyMemory<char>? SourceRoot { get; set; }
 
     /// <summary>
-    /// The target framework of the project or null if not multi-targeting.
-    /// </summary>
-    public string? TargetFramework => _evalInfo.TargetFramework;
-
-    /// <summary>
-    /// The runtime identifier of the project or null if platform-agnostic.
-    /// </summary>
-    public string? RuntimeIdentifier => _evalInfo.RuntimeIdentifier;
-    private readonly BuildEventTracker.ProjectContextKey _contextKey;
-    private readonly EvalProjectInfo _evalInfo;
-
-    /// <summary>
-    /// The name of the target currently being executed.
-    /// </summary>
-    public string? CurrentTarget { get; set; }
-
-    /// <summary>
     /// True when the project has run target with name "_TestRunStart" defined in <see cref="TerminalLogger._testStartTarget"/>.
     /// </summary>
     public bool IsTestProject { get; set; }
@@ -95,26 +97,6 @@ internal sealed class TerminalProjectInfo
     /// True when the project has run target with name "_CachePluginRunStart".
     /// </summary>
     public bool IsCachePluginProject { get; set; }
-
-    /// <summary>
-    /// True if project built successfully; otherwise false.
-    /// </summary>
-    public bool Succeeded { get; set; }
-
-    /// <summary>
-    /// The number of errors raised during the build of the project.
-    /// </summary>
-    public int ErrorCount { get; private set; }
-
-    /// <summary>
-    /// The number of warnings raised during the build of the project.
-    /// </summary>
-    public int WarningCount { get; private set; }
-
-    /// <summary>
-    /// True when the project has error or warning build messages; otherwise false.
-    /// </summary>
-    public bool HasErrorsOrWarnings => ErrorCount > 0 || WarningCount > 0;
 
     /// <summary>
     /// A lazily initialized list of build messages/warnings/errors raised during the build.
@@ -126,17 +108,8 @@ internal sealed class TerminalProjectInfo
     /// </summary>
     public void AddBuildMessage(TerminalMessageSeverity severity, string message)
     {
-        _buildMessages ??= new List<TerminalBuildMessage>();
+        _buildMessages ??= [];
         _buildMessages.Add(new TerminalBuildMessage(severity, message));
-
-        if (severity == TerminalMessageSeverity.Error)
-        {
-            ErrorCount++;
-        }
-        else if (severity == TerminalMessageSeverity.Warning)
-        {
-            WarningCount++;
-        }
     }
 
     /// <summary>
@@ -145,10 +118,28 @@ internal sealed class TerminalProjectInfo
     /// <returns>A sequence of error and warning build messages.</returns>
     public IEnumerable<TerminalBuildMessage> GetBuildErrorAndWarningMessages()
     {
-        return BuildMessages is null ?
-            Enumerable.Empty<TerminalBuildMessage>() :
-            BuildMessages.Where(message =>
-                message.Severity == TerminalMessageSeverity.Error ||
-                message.Severity == TerminalMessageSeverity.Warning);
+        return BuildMessages is null
+            ? []
+            : BuildMessages.Where(message =>
+                message.Severity is TerminalMessageSeverity.Error or TerminalMessageSeverity.Warning);
+    }
+
+    private int GetBuildMessageCount(TerminalMessageSeverity severity)
+    {
+        if (_buildMessages is null)
+        {
+            return 0;
+        }
+
+        int count = 0;
+        foreach (TerminalBuildMessage message in _buildMessages)
+        {
+            if (message.Severity == severity)
+            {
+                count++;
+            }
+        }
+
+        return count;
     }
 }

--- a/src/Build/Microsoft.Build.csproj
+++ b/src/Build/Microsoft.Build.csproj
@@ -217,6 +217,7 @@
     <Compile Include="IElementLocation.cs" />
     <Compile Include="Instance\IPropertyElementWithLocation.cs" />
     <Compile Include="Logging\BuildEventArgsExtensions.cs" />
+    <Compile Include="Logging\BuildEventTracker.cs" />
     <Compile Include="Logging\TerminalLogger\**\*.cs" />
     <Compile Include="Logging\ReusableLogger.cs" />
     <Compile Include="TelemetryInfra\InternalTelemetryConsumingLogger.cs" />


### PR DESCRIPTION
Fixes #14651

### Context

`TerminalLogger` previously owned both build-event processing and terminal presentation. A CI logger needs the same correlated project state. Duplicating that logic would make the loggers inconsistent.

This change adds `BuildEventTracker` as a presentation-neutral event-processing layer. It keeps the public logging behavior unchanged.

`BuildEventTracker`:

- subscribes to build events;
- correlates evaluation, project, target, task, and node contexts;
- owns mutable project lifecycle and diagnostic state;
- provides immutable project snapshots.

`TerminalLogger` now consumes tracker callbacks and owns only terminal behavior. This behavior includes live progress, ANSI output, links, timing, and summaries.

### Design decisions

- Lifecycle callbacks receive immutable snapshots.
- High-volume callbacks receive context keys. Consumers can filter events before they request snapshots.
- Project keys include `NodeId` because `ProjectContextId` is local to a node.
- Tracker state remains available during build-finished callbacks and is cleared afterward.
- Terminal-specific warning exclusions do not change the tracker diagnostic counts.

These rules keep one source of truth for correlated project state. They also let future CI loggers apply different filtering and presentation rules.

### Changes

- Added `BuildEventTracker`.
- Migrated `TerminalLogger` to tracker callbacks.
- Removed duplicate project lifecycle and diagnostic state from `TerminalProjectInfo`.
- Preserved restore timing and project-yield behavior.
- Applied case-insensitive `MSBuild` task matching to central and forwarding loggers.
- Preserved terminal resize handling from #14370.

### Testing

- Added event correlation, snapshot, lifecycle, cleanup, and multi-node tests.
- Added Terminal Logger compatibility and forwarding tests.
- Verified the focused tracker and Terminal Logger tests on .NET and .NET Framework.

### Notes

This is an internal refactoring. It does not add public API or intentionally change console or binary logger output.
