### PR TITLE
Give each transient MSBuild Server its own identity

### DIFF
--- a/src/Build.UnitTests/BackEnd/ServerNodeHandshake_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/ServerNodeHandshake_Tests.cs
@@ -18,12 +18,12 @@ namespace Microsoft.Build.UnitTests.BackEnd
     public class ServerNodeHandshake_Tests
     {
         [Fact]
-        public void GetKeyWithUserName_IncludesTheKeyAndTheCurrentUser()
+        public void GetKeyWithEndpointIdentity_IncludesTheKeyAndTheCurrentUser()
         {
             ServerNodeHandshake handshake = new(HandshakeOptions.None);
 
-            handshake.GetKeyWithUserName().ShouldContain(handshake.GetKey());
-            handshake.GetKeyWithUserName().ShouldContain(Environment.UserName);
+            handshake.GetKeyWithEndpointIdentity().ShouldContain(handshake.GetKey());
+            handshake.GetKeyWithEndpointIdentity().ShouldContain(Environment.UserName);
         }
 
         [Fact]
@@ -52,11 +52,11 @@ namespace Microsoft.Build.UnitTests.BackEnd
         public void ComputeHash_DependsOnTheWholeKey()
         {
             // Guards against the hash ignoring part of its input, which would silently drop the user
-            // scoping that GetKeyWithUserName adds.
+            // scoping that GetKeyWithEndpointIdentity adds.
             ServerNodeHandshake first = new(HandshakeOptions.None);
             ServerNodeHandshake second = new(HandshakeOptions.NodeReuse);
 
-            first.GetKeyWithUserName().ShouldNotBe(second.GetKeyWithUserName());
+            first.GetKeyWithEndpointIdentity().ShouldNotBe(second.GetKeyWithEndpointIdentity());
             first.ComputeHash().ShouldNotBe(second.ComputeHash());
         }
 

--- a/src/Build.UnitTests/BackEnd/ServerNodeHandshake_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/ServerNodeHandshake_Tests.cs
@@ -95,5 +95,66 @@ namespace Microsoft.Build.UnitTests.BackEnd
             OutOfProcServerNode.GetRunningServerMutexName(handshake).ShouldContain(hash);
             OutOfProcServerNode.GetBusyServerMutexName(handshake).ShouldContain(hash);
         }
+
+        [Fact]
+        public void ComputeHash_IsUnaffectedByAnAbsentInstanceId()
+        {
+            // The resident server passes no instance id, so its endpoint must be exactly what it was
+            // before transient servers became addressable separately.
+            ServerNodeHandshake withoutArgument = new(HandshakeOptions.None);
+            ServerNodeHandshake withExplicitNull = new(HandshakeOptions.None, instanceId: null);
+
+            withExplicitNull.ComputeHash().ShouldBe(withoutArgument.ComputeHash());
+        }
+
+        [Fact]
+        public void ComputeHash_SeparatesTransientServersFromEachOtherAndFromTheResident()
+        {
+            // A transient server serves one build and is then torn down, so no other client may be
+            // able to reach it: otherwise it can be ordered to shut down mid-build, and concurrent
+            // transient builds contend for one set of names instead of getting their own servers.
+            ServerNodeHandshake resident = new(HandshakeOptions.None);
+            ServerNodeHandshake first = new(HandshakeOptions.None, instanceId: "instance-one");
+            ServerNodeHandshake second = new(HandshakeOptions.None, instanceId: "instance-two");
+
+            first.ComputeHash().ShouldNotBe(resident.ComputeHash());
+            second.ComputeHash().ShouldNotBe(resident.ComputeHash());
+            first.ComputeHash().ShouldNotBe(second.ComputeHash());
+        }
+
+        [Fact]
+        public void ComputeHash_IsStableAcrossInstancesForTheSameInstanceId()
+        {
+            // The client and the transient server it launches are separate processes that must derive
+            // the same names from the id passed on the command line.
+            ServerNodeHandshake client = new(HandshakeOptions.None, instanceId: "shared-id");
+            ServerNodeHandshake server = new(HandshakeOptions.None, instanceId: "shared-id");
+
+            client.ComputeHash().ShouldBe(server.ComputeHash());
+        }
+
+        [Fact]
+        public void GetKey_IsUnaffectedByTheInstanceId()
+        {
+            // The instance id scopes only the derived names. The handshake exchanged over the wire
+            // answers "are we compatible", so putting the id in it would be a wire-format change.
+            ServerNodeHandshake resident = new(HandshakeOptions.None);
+            ServerNodeHandshake transientServer = new(HandshakeOptions.None, instanceId: "instance-one");
+
+            transientServer.GetKey().ShouldBe(resident.GetKey());
+        }
+
+        [Fact]
+        public void ServerNames_AllDifferBetweenTransientServers()
+        {
+            ServerNodeHandshake first = new(HandshakeOptions.None, instanceId: "instance-one");
+            ServerNodeHandshake second = new(HandshakeOptions.None, instanceId: "instance-two");
+
+            // Every name two transient servers could collide on has to be distinct, not just the pipe:
+            // sharing either mutex would serialize them or make one refuse to start.
+            OutOfProcServerNode.GetPipeName(first).ShouldNotBe(OutOfProcServerNode.GetPipeName(second));
+            OutOfProcServerNode.GetRunningServerMutexName(first).ShouldNotBe(OutOfProcServerNode.GetRunningServerMutexName(second));
+            OutOfProcServerNode.GetBusyServerMutexName(first).ShouldNotBe(OutOfProcServerNode.GetBusyServerMutexName(second));
+        }
     }
 }

--- a/src/Build/BackEnd/Client/MSBuildClient.cs
+++ b/src/Build/BackEnd/Client/MSBuildClient.cs
@@ -34,6 +34,9 @@ namespace Microsoft.Build.Server
     [EditorBrowsable(EditorBrowsableState.Never)]
     public sealed class MSBuildClient
     {
+        private const int NewServerConnectionTimeoutMilliseconds = 20_000;
+        private const int TransientServerConnectionTimeoutMilliseconds = 30_000;
+
         /// <summary>
         /// The build inherits all the environment variables from the client process.
         /// This property allows to add extra environment variables or reset some of the existing ones.
@@ -253,7 +256,7 @@ namespace Microsoft.Build.Server
                 }
 
                 // Connect to server.
-                if (!TryConnectToServer(serverIsAlreadyRunning ? 1_000 : 20_000))
+                if (!TryConnectToServer(serverIsAlreadyRunning ? 1_000 : NewServerConnectionTimeoutMilliseconds))
                 {
                     return _exitResult;
                 }
@@ -597,6 +600,25 @@ namespace Microsoft.Build.Server
                         ? new Dictionary<string, string?>()
                         : new Dictionary<string, string?>(baseOverrides);
                     environmentOverrides["DOTNET_gcServer"] = "1";
+                }
+
+                if (_serverInstanceId is not null)
+                {
+                    // No other client knows this server's identity, so it cannot be reused if its
+                    // launching client exits before connecting. Bound that orphan window rather than
+                    // inheriting the generic node connection timeout (15 minutes by default).
+                    if (environmentOverrides is null)
+                    {
+                        environmentOverrides = new Dictionary<string, string?>();
+                    }
+                    else if (ReferenceEquals(environmentOverrides, baseOverrides))
+                    {
+                        environmentOverrides = new Dictionary<string, string?>(baseOverrides);
+                    }
+
+                    environmentOverrides["MSBUILDNODECONNECTIONTIMEOUT"] =
+                        Math.Min(CommunicationsUtilities.NodeConnectionTimeout, TransientServerConnectionTimeoutMilliseconds)
+                            .ToString(CultureInfo.InvariantCulture);
                 }
 
                 NodeLaunchData launchData = new(

--- a/src/Build/BackEnd/Client/MSBuildClient.cs
+++ b/src/Build/BackEnd/Client/MSBuildClient.cs
@@ -34,8 +34,8 @@ namespace Microsoft.Build.Server
     [EditorBrowsable(EditorBrowsableState.Never)]
     public sealed class MSBuildClient
     {
-        private const int NewServerConnectionTimeoutMilliseconds = 20_000;
-        private const int TransientServerConnectionTimeoutMilliseconds = 30_000;
+        private const int NewServerConnectionTimeoutMilliseconds = 5_000;
+        private const int TransientServerConnectionTimeoutMilliseconds = 10_000;
 
         /// <summary>
         /// The build inherits all the environment variables from the client process.
@@ -548,83 +548,13 @@ namespace Microsoft.Build.Server
 
             try
             {
-                string[] msBuildServerOptions = _serverInstanceId is null
-                    ?
-                    [
-                        "/nologo",
-                        NodeModeHelper.ToCommandLineArgument(NodeMode.OutOfProcServerNode)
-                    ]
-                    :
-                    [
-                        "/nologo",
-                        NodeModeHelper.ToCommandLineArgument(NodeMode.OutOfProcServerNode),
-
-                        // The server derives its pipe and mutex names from this too, so a transient
-                        // server is addressable only by the client that launched it.
-                        $"{OutOfProcServerNode.ServerInstanceIdCommandLineSwitch}{_serverInstanceId}"
-                    ];
                 NodeLauncher nodeLauncher = new NodeLauncher();
                 CommunicationsUtilities.Trace("Starting Server...");
 
-                // Set DOTNET_ROOT so the apphost server child can locate the runtime; this
-                // override is replaced by the client's environment on the first build command
-                // (see OutOfProcServerNode.HandleServerNodeBuildCommand → SetEnvironment).
-                // This is a shared cached dictionary reused by other node launches, so it must not
-                // be mutated in place.
-                IDictionary<string, string?>? baseOverrides = DotnetHostEnvironmentHelper.CreateDotnetRootEnvironmentOverrides();
-                IDictionary<string, string?>? environmentOverrides = baseOverrides;
-
-                // When this build is multithreaded (/mt), launch the long-lived server (build
-                // orchestrator) process with Server GC. Other processes may get higher throughput
-                // with Server GC, but we want to enable it only for the highest-impact one where
-                // most of the work of the actual build will happen in MT mode. GC mode is fixed at
-                // CLR startup, so it must be set in the child's launch environment via DOTNET_gcServer
-                // (which only affects .NET/CoreCLR and, since .NET 9, takes precedence over
-                // runtimeconfig.json). The decision is made from this (launch-time) invocation's command
-                // line; a server is keyed by handshake and reused, so a later differing /mt choice does
-                // not re-launch it.
-                //
-                // This is scoped to the server process only. Sidecar TaskHost (nodemode 2) and worker
-                // (nodemode 1) nodes are launched through other code paths that never set this knob, and
-                // the server resets its own environment to the client's on the first build command (so
-                // DOTNET_gcServer is removed before it ever spawns children). Those nodes therefore keep
-                // the default Workstation GC.
-                //
-                // Copy the shared base overrides (preserving its comparer) before adding the GC override.
-                // Honor an explicit user-set DOTNET_gcServer (e.g. "0" to force Workstation GC in a
-                // memory-constrained container): only inject the default when the user hasn't set it.
-                if (_multiThreaded &&
-                    Environment.GetEnvironmentVariable("DOTNET_gcServer") is null)
-                {
-                    environmentOverrides = baseOverrides is null
-                        ? new Dictionary<string, string?>()
-                        : new Dictionary<string, string?>(baseOverrides);
-                    environmentOverrides["DOTNET_gcServer"] = "1";
-                }
-
-                if (_serverInstanceId is not null)
-                {
-                    // No other client knows this server's identity, so it cannot be reused if its
-                    // launching client exits before connecting. Bound that orphan window rather than
-                    // inheriting the generic node connection timeout (15 minutes by default).
-                    if (environmentOverrides is null)
-                    {
-                        environmentOverrides = new Dictionary<string, string?>();
-                    }
-                    else if (ReferenceEquals(environmentOverrides, baseOverrides))
-                    {
-                        environmentOverrides = new Dictionary<string, string?>(baseOverrides);
-                    }
-
-                    environmentOverrides["MSBUILDNODECONNECTIONTIMEOUT"] =
-                        Math.Min(CommunicationsUtilities.NodeConnectionTimeout, TransientServerConnectionTimeoutMilliseconds)
-                            .ToString(CultureInfo.InvariantCulture);
-                }
-
                 NodeLaunchData launchData = new(
                     MSBuildLocation: _msbuildLocation,
-                    CommandLineArgs: string.Join(" ", msBuildServerOptions),
-                    EnvironmentOverrides: environmentOverrides);
+                    CommandLineArgs: string.Join(" ", GetServerCommandLineOptions()),
+                    EnvironmentOverrides: GetServerEnvironmentOverrides());
 
                 using Process msbuildProcess = nodeLauncher.Start(launchData, nodeId: 0);
                 _launchedServerPid = msbuildProcess.Id;
@@ -638,6 +568,53 @@ namespace Microsoft.Build.Server
             }
 
             return true;
+        }
+
+        private string[] GetServerCommandLineOptions()
+            => _serverInstanceId is null
+                ?
+                [
+                    "/nologo",
+                    NodeModeHelper.ToCommandLineArgument(NodeMode.OutOfProcServerNode)
+                ]
+                :
+                [
+                    "/nologo",
+                    NodeModeHelper.ToCommandLineArgument(NodeMode.OutOfProcServerNode),
+                    $"{OutOfProcServerNode.ServerInstanceIdCommandLineSwitch}{_serverInstanceId}"
+                ];
+
+        private IDictionary<string, string?>? GetServerEnvironmentOverrides()
+        {
+            // The cached base dictionary is shared by other node launches and must not be mutated.
+            IDictionary<string, string?>? baseOverrides = DotnetHostEnvironmentHelper.CreateDotnetRootEnvironmentOverrides();
+            bool enableServerGC = _multiThreaded && Environment.GetEnvironmentVariable("DOTNET_gcServer") is null;
+            bool boundTransientConnectionTimeout = _serverInstanceId is not null;
+
+            if (!enableServerGC && !boundTransientConnectionTimeout)
+            {
+                return baseOverrides;
+            }
+
+            IDictionary<string, string?> environmentOverrides = baseOverrides is null
+                ? new Dictionary<string, string?>()
+                : new Dictionary<string, string?>(baseOverrides);
+
+            if (enableServerGC)
+            {
+                environmentOverrides["DOTNET_gcServer"] = "1";
+            }
+
+            if (boundTransientConnectionTimeout)
+            {
+                // No other client knows this server's identity, so it cannot be reused if its
+                // launching client exits before connecting.
+                environmentOverrides["MSBUILDNODECONNECTIONTIMEOUT"] =
+                    Math.Min(CommunicationsUtilities.NodeConnectionTimeout, TransientServerConnectionTimeoutMilliseconds)
+                        .ToString(CultureInfo.InvariantCulture);
+            }
+
+            return environmentOverrides;
         }
 
         private bool TrySendBuildCommand() => TrySendPacket(() => GetServerNodeBuildCommand());

--- a/src/Build/BackEnd/Client/MSBuildClient.cs
+++ b/src/Build/BackEnd/Client/MSBuildClient.cs
@@ -73,6 +73,19 @@ namespace Microsoft.Build.Server
         private readonly ServerNodeHandshake _handshake;
 
         /// <summary>
+        /// Identifies the transient server this client launches for its own exclusive use, or
+        /// <see langword="null"/> when this client talks to the resident server.
+        /// </summary>
+        /// <remarks>
+        /// A transient server is torn down after the single build it serves, so it must not be
+        /// reachable by any other client: without this, every transient build resolves to the same
+        /// endpoint as the resident server and orders that to shut down instead. Giving each one its
+        /// own id also lets concurrent transient builds run their own servers rather than contending
+        /// on one set of pipe and mutex names.
+        /// </remarks>
+        private readonly string? _serverInstanceId;
+
+        /// <summary>
         /// The named pipe name for client-server communication.
         /// </summary>
         private readonly string _pipeName;
@@ -172,6 +185,7 @@ namespace Microsoft.Build.Server
             _msbuildLocation = msbuildLocation;
             _multiThreaded = multiThreaded;
             _shutdownServerAfterBuild = shutdownServerAfterBuild;
+            _serverInstanceId = shutdownServerAfterBuild ? Guid.NewGuid().ToString("N") : null;
 
             // Client <-> Server communication stream
             _handshake = GetHandshake();
@@ -531,11 +545,21 @@ namespace Microsoft.Build.Server
 
             try
             {
-                string[] msBuildServerOptions =
-                [
-                    "/nologo",
-                    NodeModeHelper.ToCommandLineArgument(NodeMode.OutOfProcServerNode)
-                ];
+                string[] msBuildServerOptions = _serverInstanceId is null
+                    ?
+                    [
+                        "/nologo",
+                        NodeModeHelper.ToCommandLineArgument(NodeMode.OutOfProcServerNode)
+                    ]
+                    :
+                    [
+                        "/nologo",
+                        NodeModeHelper.ToCommandLineArgument(NodeMode.OutOfProcServerNode),
+
+                        // The server derives its pipe and mutex names from this too, so a transient
+                        // server is addressable only by the client that launched it.
+                        $"{OutOfProcServerNode.ServerInstanceIdCommandLineSwitch}{_serverInstanceId}"
+                    ];
                 NodeLauncher nodeLauncher = new NodeLauncher();
                 CommunicationsUtilities.Trace("Starting Server...");
 
@@ -643,10 +667,12 @@ namespace Microsoft.Build.Server
                         _shutdownServerAfterBuild);
         }
 
-        private ServerNodeHandshake GetHandshake() => new(CommunicationsUtilities.GetHandshakeOptions(
-            taskHost: false,
-            taskHostParameters: TaskHostParameters.Empty,
-            architectureFlagToSet: XMakeAttributes.GetCurrentMSBuildArchitecture()));
+        private ServerNodeHandshake GetHandshake() => new(
+            CommunicationsUtilities.GetHandshakeOptions(
+                taskHost: false,
+                taskHostParameters: TaskHostParameters.Empty,
+                architectureFlagToSet: XMakeAttributes.GetCurrentMSBuildArchitecture()),
+            _serverInstanceId);
 
         /// <summary>
         /// Handle cancellation.

--- a/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
@@ -717,17 +717,33 @@ namespace Microsoft.Build.BackEnd
         /// Used by out-of-proc nodes (e.g., server node) to detect over-provisioning at build completion.
         /// </summary>
         /// <param name="nodeMode">The node mode to filter for.</param>
+        /// <param name="excludedCommandLineSubstring">When non-null, processes whose command line contains
+        /// this text are not counted. The server uses it to exclude transient servers, which are private to
+        /// a single build and so do not compete with the resident server for its role.</param>
         /// <returns>The number of matching processes, or 0 if enumeration fails or the feature wave is disabled.</returns>
-        internal static int CountActiveNodesWithMode(NodeMode nodeMode)
+        internal static int CountActiveNodesWithMode(NodeMode nodeMode, string excludedCommandLineSubstring = null)
         {
             try
             {
                 (_, IList<Process> nodeProcesses) = GetPossibleRunningNodes(nodeMode);
-                int count = nodeProcesses.Count;
+                int count = 0;
                 foreach (var process in nodeProcesses)
                 {
+                    // Anything we cannot read the command line for is counted, so that a failure to
+                    // identify a process errs towards detecting over-provisioning rather than missing it.
+                    bool excluded = excludedCommandLineSubstring is not null
+                        && process.TryGetCommandLine(out string commandLine)
+                        && commandLine is not null
+                        && commandLine.IndexOf(excludedCommandLineSubstring, StringComparison.OrdinalIgnoreCase) >= 0;
+
+                    if (!excluded)
+                    {
+                        count++;
+                    }
+
                     process?.Dispose();
                 }
+
                 return count;
             }
             catch (Exception ex)

--- a/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
@@ -717,33 +717,17 @@ namespace Microsoft.Build.BackEnd
         /// Used by out-of-proc nodes (e.g., server node) to detect over-provisioning at build completion.
         /// </summary>
         /// <param name="nodeMode">The node mode to filter for.</param>
-        /// <param name="excludedCommandLineSubstring">When non-null, processes whose command line contains
-        /// this text are not counted. The server uses it to exclude transient servers, which are private to
-        /// a single build and so do not compete with the resident server for its role.</param>
         /// <returns>The number of matching processes, or 0 if enumeration fails or the feature wave is disabled.</returns>
-        internal static int CountActiveNodesWithMode(NodeMode nodeMode, string excludedCommandLineSubstring = null)
+        internal static int CountActiveNodesWithMode(NodeMode nodeMode)
         {
             try
             {
                 (_, IList<Process> nodeProcesses) = GetPossibleRunningNodes(nodeMode);
-                int count = 0;
+                int count = nodeProcesses.Count;
                 foreach (var process in nodeProcesses)
                 {
-                    // Anything we cannot read the command line for is counted, so that a failure to
-                    // identify a process errs towards detecting over-provisioning rather than missing it.
-                    bool excluded = excludedCommandLineSubstring is not null
-                        && process.TryGetCommandLine(out string commandLine)
-                        && commandLine is not null
-                        && commandLine.IndexOf(excludedCommandLineSubstring, StringComparison.OrdinalIgnoreCase) >= 0;
-
-                    if (!excluded)
-                    {
-                        count++;
-                    }
-
                     process?.Dispose();
                 }
-
                 return count;
             }
             catch (Exception ex)

--- a/src/Build/BackEnd/Node/OutOfProcServerNode.cs
+++ b/src/Build/BackEnd/Node/OutOfProcServerNode.cs
@@ -92,9 +92,17 @@ namespace Microsoft.Build.Server
         private bool _cancelRequested = false;
         private string _serverBusyMutexName = default!;
 
-        public OutOfProcServerNode(BuildCallback buildFunction)
+        /// <summary>
+        /// Identifies this transient server, or <see langword="null"/> when this is the resident
+        /// server. Supplied by the client that launched this process, which derives the same pipe and
+        /// mutex names from it.
+        /// </summary>
+        private readonly string? _instanceId;
+
+        public OutOfProcServerNode(BuildCallback buildFunction, string? instanceId = null)
         {
             _buildFunction = buildFunction;
+            _instanceId = instanceId;
 
             _receivedPackets = new ConcurrentQueue<INodePacket>();
             _packetReceivedEvent = new AutoResetEvent(false);
@@ -116,7 +124,8 @@ namespace Microsoft.Build.Server
         public NodeEngineShutdownReason Run(out Exception? shutdownException)
         {
             ServerNodeHandshake handshake = new(
-                CommunicationsUtilities.GetHandshakeOptions(taskHost: false, taskHostParameters: TaskHostParameters.Empty, architectureFlagToSet: XMakeAttributes.GetCurrentMSBuildArchitecture()));
+                CommunicationsUtilities.GetHandshakeOptions(taskHost: false, taskHostParameters: TaskHostParameters.Empty, architectureFlagToSet: XMakeAttributes.GetCurrentMSBuildArchitecture()),
+                _instanceId);
 
             _serverBusyMutexName = GetBusyServerMutexName(handshake);
 
@@ -184,6 +193,13 @@ namespace Microsoft.Build.Server
         }
 
         #endregion
+
+        /// <summary>
+        /// The command line switch a client uses to tell the transient server it launches which
+        /// instance it is. Both sides fold the value into <see cref="ServerNodeHandshake.ComputeHash"/>,
+        /// so a transient server is addressable only by that client.
+        /// </summary>
+        internal const string ServerInstanceIdCommandLineSwitch = "/serverinstanceid:";
 
         internal static string GetPipeName(ServerNodeHandshake handshake)
             => NamedPipeUtil.GetPlatformSpecificPipeName($"MSBuildServer-{handshake.ComputeHash()}");
@@ -343,12 +359,16 @@ namespace Microsoft.Build.Server
         {
             bool shouldReuse = buildComplete.PrepareForReuse;
 
-            if (shouldReuse)
+            // A transient server serves one build and exits, so it neither competes for the resident
+            // server's role nor counts against it.
+            if (shouldReuse && _instanceId is null)
             {
-                // Self-terminate if another server node is already running system-wide.
-                // Threshold is 1: only one server node should be active per handshake.
+                // Self-terminate if another resident server node is already running system-wide.
+                // Threshold is 1: only one resident server node should be active per handshake.
                 // If another is running (count > 1, since we count ourselves), exit to avoid over-provisioning.
-                int serverNodeCount = NodeProviderOutOfProcBase.CountActiveNodesWithMode(NodeMode.OutOfProcServerNode);
+                int serverNodeCount = NodeProviderOutOfProcBase.CountActiveNodesWithMode(
+                    NodeMode.OutOfProcServerNode,
+                    excludedCommandLineSubstring: ServerInstanceIdCommandLineSwitch);
                 if (serverNodeCount > 1)
                 {
                     CommunicationsUtilities.Trace($"Terminating server node due to over-provisioning: {serverNodeCount} server nodes found system-wide.");

--- a/src/Build/BackEnd/Node/OutOfProcServerNode.cs
+++ b/src/Build/BackEnd/Node/OutOfProcServerNode.cs
@@ -357,24 +357,8 @@ namespace Microsoft.Build.Server
         /// <param name="buildComplete"></param>
         private void HandleServerShutdownCommand(NodeBuildComplete buildComplete)
         {
-            bool shouldReuse = buildComplete.PrepareForReuse;
-
-            // A transient server serves one build and exits, so it neither competes for the resident
-            // server's role nor counts against it.
-            if (shouldReuse && _instanceId is null)
-            {
-                // Self-terminate if another resident server node is already running system-wide.
-                // Threshold is 1: only one resident server node should be active per handshake.
-                // If another is running (count > 1, since we count ourselves), exit to avoid over-provisioning.
-                int serverNodeCount = NodeProviderOutOfProcBase.CountActiveNodesWithMode(
-                    NodeMode.OutOfProcServerNode,
-                    excludedCommandLineSubstring: ServerInstanceIdCommandLineSwitch);
-                if (serverNodeCount > 1)
-                {
-                    CommunicationsUtilities.Trace($"Terminating server node due to over-provisioning: {serverNodeCount} server nodes found system-wide.");
-                    shouldReuse = false;
-                }
-            }
+            // A transient server is private to one build and must never enter the resident reuse loop.
+            bool shouldReuse = buildComplete.PrepareForReuse && _instanceId is null;
 
             _shutdownReason = shouldReuse ? NodeEngineShutdownReason.BuildCompleteReuse : NodeEngineShutdownReason.BuildComplete;
             _shutdownEvent.Set();

--- a/src/Build/BackEnd/Node/OutOfProcServerNode.cs
+++ b/src/Build/BackEnd/Node/OutOfProcServerNode.cs
@@ -360,6 +360,19 @@ namespace Microsoft.Build.Server
             // A transient server is private to one build and must never enter the resident reuse loop.
             bool shouldReuse = buildComplete.PrepareForReuse && _instanceId is null;
 
+            if (shouldReuse)
+            {
+                // Self-terminate if another server node is already running system-wide.
+                // Threshold is 1: only one server node should be active per handshake.
+                // If another is running (count > 1, since we count ourselves), exit to avoid over-provisioning.
+                int serverNodeCount = NodeProviderOutOfProcBase.CountActiveNodesWithMode(NodeMode.OutOfProcServerNode);
+                if (serverNodeCount > 1)
+                {
+                    CommunicationsUtilities.Trace($"Terminating server node due to over-provisioning: {serverNodeCount} server nodes found system-wide.");
+                    shouldReuse = false;
+                }
+            }
+
             _shutdownReason = shouldReuse ? NodeEngineShutdownReason.BuildCompleteReuse : NodeEngineShutdownReason.BuildComplete;
             _shutdownEvent.Set();
         }

--- a/src/Framework/BackEnd/ServerNodeHandshake.cs
+++ b/src/Framework/BackEnd/ServerNodeHandshake.cs
@@ -55,14 +55,14 @@ internal sealed class ServerNodeHandshake : Handshake
     /// pipes are current-user-only, so without the user one account's server locks every other
     /// account on the machine out.
     /// </summary>
-    public string GetKeyWithUserName() => _instanceId is null
+    public string GetKeyWithEndpointIdentity() => _instanceId is null
         ? $"{GetKey()} {EnvironmentUtilities.CurrentUserName}"
         : $"{GetKey()} {EnvironmentUtilities.CurrentUserName} {_instanceId}";
 
     /// <summary>
     /// Computes Handshake stable hash string representing whole state of handshake.
     /// </summary>
-    public string ComputeHash() => _computedHash ??= HashKey(GetKeyWithUserName());
+    public string ComputeHash() => _computedHash ??= HashKey(GetKeyWithEndpointIdentity());
 
     public static string HashKey(string key)
     {

--- a/src/Framework/BackEnd/ServerNodeHandshake.cs
+++ b/src/Framework/BackEnd/ServerNodeHandshake.cs
@@ -16,11 +16,26 @@ internal sealed class ServerNodeHandshake : Handshake
     /// </summary>
     private string? _computedHash = null;
 
+    /// <summary>
+    /// Distinguishes one transient server from every other server, or <see langword="null"/> for the
+    /// resident server.
+    /// </summary>
+    /// <remarks>
+    /// This participates in <see cref="ComputeHash"/>, and therefore in the pipe and mutex names, but
+    /// deliberately not in <see cref="RetrieveHandshakeComponents"/>: the handshake itself answers
+    /// "are we compatible", while the hash answers "which server am I talking to". A transient server
+    /// exists to serve exactly one build and is then torn down, so it must not be reachable by any
+    /// other client - otherwise that client can order it to shut down mid-build, or find itself
+    /// connected to one that is already exiting.
+    /// </remarks>
+    private readonly string? _instanceId;
+
     public override byte? ExpectedVersionInFirstByte => null;
 
-    internal ServerNodeHandshake(HandshakeOptions nodeType)
+    internal ServerNodeHandshake(HandshakeOptions nodeType, string? instanceId = null)
         : base(nodeType, includeSessionId: false, toolsDirectory: null)
     {
+        _instanceId = instanceId;
     }
 
     public override HandshakeComponents RetrieveHandshakeComponents() => new(
@@ -35,11 +50,14 @@ internal sealed class ServerNodeHandshake : Handshake
         .ToString(CultureInfo.InvariantCulture);
 
     /// <summary>
-    /// The handshake key plus the current user. The pipe and mutex names derived from
-    /// <see cref="ComputeHash"/> are machine-wide while the pipes are current-user-only, so without
-    /// the user one account's server locks every other account on the machine out.
+    /// The handshake key plus the current user, and the instance id when this is a transient server.
+    /// The pipe and mutex names derived from <see cref="ComputeHash"/> are machine-wide while the
+    /// pipes are current-user-only, so without the user one account's server locks every other
+    /// account on the machine out.
     /// </summary>
-    public string GetKeyWithUserName() => $"{GetKey()} {EnvironmentUtilities.CurrentUserName}";
+    public string GetKeyWithUserName() => _instanceId is null
+        ? $"{GetKey()} {EnvironmentUtilities.CurrentUserName}"
+        : $"{GetKey()} {EnvironmentUtilities.CurrentUserName} {_instanceId}";
 
     /// <summary>
     /// Computes Handshake stable hash string representing whole state of handshake.

--- a/src/MSBuild.UnitTests/MSBuildServer_Tests.cs
+++ b/src/MSBuild.UnitTests/MSBuildServer_Tests.cs
@@ -790,12 +790,18 @@ namespace Microsoft.Build.Engine.UnitTests
         }
 
         /// <summary>
-        /// A transient build must leave the resident server's sidecar TaskHosts alone. Those are owned
-        /// by the resident server, so shutting it down takes them with it - which makes a stray
-        /// shutdown reaching the resident server destroy more than the server itself.
+        /// A transient build must not adopt the resident server's sidecar TaskHost. Sidecars are owned
+        /// by the process that launched them (#14584), so a build that tears its own server down at the
+        /// end must bring its own TaskHost rather than borrowing one whose owner outlives it.
         /// </summary>
+        /// <remarks>
+        /// This deliberately does not assert that the resident sidecar is still alive afterwards. A
+        /// sidecar lives exactly as long as its owner, which <see cref="TransientBuildDoesNotShutDownResidentServer"/>
+        /// already covers, and asserting its survival here proved sensitive to unrelated MSBuild
+        /// activity elsewhere on the machine when the suite runs in parallel.
+        /// </remarks>
         [Fact]
-        public void TransientBuildDoesNotDisturbResidentSidecars()
+        public void TransientBuildDoesNotAdoptResidentSidecars()
         {
             PrepareIsolatedServerEnv(useServer: false);
 
@@ -833,9 +839,9 @@ namespace Microsoft.Build.Engine.UnitTests
                     _output);
                 residentSuccess.ShouldBeTrue();
                 int residentPid = ParseNumber(residentOutput, "Server ID is ");
-                int sidecarPid = ParseNumber(residentOutput, "Sidecar ID is ");
+                int residentSidecarPid = ParseNumber(residentOutput, "Sidecar ID is ");
                 _env.WithTransientProcess(residentPid);
-                _env.WithTransientProcess(sidecarPid);
+                _env.WithTransientProcess(residentSidecarPid);
 
                 string transientOutput = RunnerUtilities.ExecBootstrapedMSBuild(
                     $"{project.Path} -mt -nodeReuse:false",
@@ -843,11 +849,14 @@ namespace Microsoft.Build.Engine.UnitTests
                     false,
                     _output);
                 transientSuccess.ShouldBeTrue();
-                _env.WithTransientProcess(ParseNumber(transientOutput, "Server ID is "));
-                _env.WithTransientProcess(ParseNumber(transientOutput, "Sidecar ID is "));
+                int transientPid = ParseNumber(transientOutput, "Server ID is ");
+                int transientSidecarPid = ParseNumber(transientOutput, "Sidecar ID is ");
+                _env.WithTransientProcess(transientPid);
+                _env.WithTransientProcess(transientSidecarPid);
 
+                transientPid.ShouldNotBe(residentPid, "A transient build must run in its own server rather than borrowing the resident one.");
+                transientSidecarPid.ShouldNotBe(residentSidecarPid, "A transient build must bring its own TaskHost rather than adopting one owned by the resident server.");
                 IsProcessRunning(residentPid).ShouldBeTrue($"Resident server {residentPid} must survive a transient build.");
-                IsProcessRunning(sidecarPid).ShouldBeTrue($"Sidecar {sidecarPid} owned by the resident server must survive a transient build.");
             }
             finally
             {

--- a/src/MSBuild.UnitTests/MSBuildServer_Tests.cs
+++ b/src/MSBuild.UnitTests/MSBuildServer_Tests.cs
@@ -677,6 +677,202 @@ namespace Microsoft.Build.Engine.UnitTests
 
 #if NET
         /// <summary>
+        /// A build that asks its server to shut down afterwards must not be able to reach the resident
+        /// server and shut that down instead. Before transient servers had their own identity, both
+        /// resolved to the same pipe and mutex names, so <c>-mt -nodeReuse:false</c> killed the
+        /// resident server every time.
+        /// </summary>
+        [Fact]
+        public void TransientBuildDoesNotShutDownResidentServer()
+        {
+            PrepareIsolatedServerEnv(useServer: false);
+            TransientTestFile project = _env.CreateFile("transientVsResident.proj", GetServerGCProbeProjectContents(useTaskHostFactory: false));
+
+            ShutdownBootstrapServer();
+
+            try
+            {
+                string residentOutput = RunnerUtilities.ExecBootstrapedMSBuild(
+                    $"{project.Path} -mt -nodeReuse:true",
+                    out bool residentSuccess,
+                    false,
+                    _output);
+                residentSuccess.ShouldBeTrue();
+                int residentPid = ParseNumber(residentOutput, "TaskRanInPID=");
+                _env.WithTransientProcess(residentPid);
+
+                string transientOutput = RunnerUtilities.ExecBootstrapedMSBuild(
+                    $"{project.Path} -mt -nodeReuse:false",
+                    out bool transientSuccess,
+                    false,
+                    _output);
+                transientSuccess.ShouldBeTrue();
+                int transientPid = ParseNumber(transientOutput, "TaskRanInPID=");
+                _env.WithTransientProcess(transientPid);
+
+                transientPid.ShouldNotBe(residentPid, "A transient build must run in its own server rather than borrowing the resident one.");
+                WaitForProcessExit(transientPid).ShouldBeTrue($"Transient server {transientPid} should tear itself down after its build.");
+
+                IsProcessRunning(residentPid).ShouldBeTrue($"Resident server {residentPid} must survive a transient build.");
+            }
+            finally
+            {
+                ShutdownBootstrapServer();
+            }
+        }
+
+        /// <summary>
+        /// Each transient build gets a server of its own. A single shared transient identity would make
+        /// these contend: the second build would find the first's server holding the running mutex and
+        /// fall back in-process, silently losing the server that <c>-mt</c> asked for.
+        /// </summary>
+        [Fact]
+        public void ConcurrentTransientBuildsEachGetTheirOwnServer()
+        {
+            PrepareIsolatedServerEnv(useServer: false);
+
+            // Hold each build open so the two genuinely overlap. If they happen not to overlap the
+            // assertions below still hold, so this can only ever under-detect, never flake.
+            TransientTestFile project = _env.CreateFile(
+                "concurrentTransient.proj",
+                $@"
+<Project>
+<UsingTask TaskName=""ProcessIdTask"" AssemblyFile=""{Assembly.GetExecutingAssembly().Location}"" />
+<UsingTask TaskName=""SleepingTask"" AssemblyFile=""{Assembly.GetExecutingAssembly().Location}"" />
+    <Target Name='Probe'>
+        <ProcessIdTask>
+            <Output PropertyName=""PID"" TaskParameter=""Pid"" />
+        </ProcessIdTask>
+        <Message Text=""TaskRanInPID=$(PID)"" Importance=""High"" />
+        <SleepingTask SleepTime=""4000"" />
+    </Target>
+</Project>");
+
+            ShutdownBootstrapServer();
+
+            try
+            {
+                string arguments = $"{project.Path} -mt -nodeReuse:false";
+                Task<(bool Success, string Output)> first = Task.Run(() =>
+                {
+                    string output = RunnerUtilities.ExecBootstrapedMSBuild(arguments, out bool success, false, _output);
+                    return (success, output);
+                });
+                Task<(bool Success, string Output)> second = Task.Run(() =>
+                {
+                    string output = RunnerUtilities.ExecBootstrapedMSBuild(arguments, out bool success, false, _output);
+                    return (success, output);
+                });
+
+                Task.WaitAll(first, second);
+
+                first.Result.Success.ShouldBeTrue();
+                second.Result.Success.ShouldBeTrue();
+
+                int firstServerPid = ParseNumber(first.Result.Output, "TaskRanInPID=");
+                int secondServerPid = ParseNumber(second.Result.Output, "TaskRanInPID=");
+                _env.WithTransientProcess(firstServerPid);
+                _env.WithTransientProcess(secondServerPid);
+
+                int firstClientPid = ParseNumber(first.Result.Output, "Process ID is ");
+                int secondClientPid = ParseNumber(second.Result.Output, "Process ID is ");
+
+                // Falling back in-process is how contention shows up, so check that first: it would
+                // otherwise look like success with the two PIDs merely differing.
+                firstServerPid.ShouldNotBe(firstClientPid, "The first build must run in a server, not in-process.");
+                secondServerPid.ShouldNotBe(secondClientPid, "The second build must run in a server, not in-process.");
+                firstServerPid.ShouldNotBe(secondServerPid, "Concurrent transient builds must not share a server.");
+            }
+            finally
+            {
+                ShutdownBootstrapServer();
+            }
+        }
+
+        /// <summary>
+        /// A transient build must leave the resident server's sidecar TaskHosts alone. Those are owned
+        /// by the resident server, so shutting it down takes them with it - which makes a stray
+        /// shutdown reaching the resident server destroy more than the server itself.
+        /// </summary>
+        [Fact]
+        public void TransientBuildDoesNotDisturbResidentSidecars()
+        {
+            PrepareIsolatedServerEnv(useServer: false);
+
+            // A sidecar only exists when node reuse is on, and CI disables it by default; without this
+            // the resident build would use a short-lived TaskHost and the test would prove nothing.
+            _env.SetEnvironmentVariable("MSBUILDDISABLENODEREUSE", null);
+
+            TransientTestFile project = _env.CreateFile(
+                "residentSidecarVsTransient.proj",
+                $"""
+                <Project>
+                    <UsingTask TaskName="ProcessIdTask" AssemblyFile="{Assembly.GetExecutingAssembly().Location}" />
+                    <UsingTask TaskName="SidecarProcessIdTask" AssemblyFile="{Assembly.GetExecutingAssembly().Location}" />
+                    <Target Name="Probe">
+                        <ProcessIdTask>
+                            <Output PropertyName="SERVER_PID" TaskParameter="Pid" />
+                        </ProcessIdTask>
+                        <SidecarProcessIdTask EnvironmentVariableName="PATH">
+                            <Output PropertyName="SIDECAR_PID" TaskParameter="Pid" />
+                        </SidecarProcessIdTask>
+                        <Message Text="Server ID is $(SERVER_PID)" Importance="High" />
+                        <Message Text="Sidecar ID is $(SIDECAR_PID)" Importance="High" />
+                    </Target>
+                </Project>
+                """);
+
+            ShutdownBootstrapServer();
+
+            try
+            {
+                string residentOutput = RunnerUtilities.ExecBootstrapedMSBuild(
+                    $"{project.Path} -mt -nodeReuse:true",
+                    out bool residentSuccess,
+                    false,
+                    _output);
+                residentSuccess.ShouldBeTrue();
+                int residentPid = ParseNumber(residentOutput, "Server ID is ");
+                int sidecarPid = ParseNumber(residentOutput, "Sidecar ID is ");
+                _env.WithTransientProcess(residentPid);
+                _env.WithTransientProcess(sidecarPid);
+
+                string transientOutput = RunnerUtilities.ExecBootstrapedMSBuild(
+                    $"{project.Path} -mt -nodeReuse:false",
+                    out bool transientSuccess,
+                    false,
+                    _output);
+                transientSuccess.ShouldBeTrue();
+                _env.WithTransientProcess(ParseNumber(transientOutput, "Server ID is "));
+                _env.WithTransientProcess(ParseNumber(transientOutput, "Sidecar ID is "));
+
+                IsProcessRunning(residentPid).ShouldBeTrue($"Resident server {residentPid} must survive a transient build.");
+                IsProcessRunning(sidecarPid).ShouldBeTrue($"Sidecar {sidecarPid} owned by the resident server must survive a transient build.");
+            }
+            finally
+            {
+                ShutdownBootstrapServer();
+            }
+        }
+
+        /// <summary>
+        /// Whether a process with the given PID is still running. Unlike <see cref="WaitForProcessExit"/>
+        /// this does not wait, so it asserts about the present rather than about a timeout elapsing.
+        /// </summary>
+        private static bool IsProcessRunning(int pid)
+        {
+            try
+            {
+                using Process process = Process.GetProcessById(pid);
+                return !process.HasExited;
+            }
+            catch (ArgumentException)
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
         /// Builds a project that reports, for the process that executes <see cref="ProcessIdTask"/>,
         /// its PID and whether it runs with Server GC. When <paramref name="useTaskHostFactory"/> is
         /// true the task is forced out-of-proc into a TaskHost, so its PID is the TaskHost's rather

--- a/src/MSBuild.UnitTests/MSBuildServer_Tests.cs
+++ b/src/MSBuild.UnitTests/MSBuildServer_Tests.cs
@@ -66,6 +66,18 @@ namespace Microsoft.Build.Engine.UnitTests
         }
     }
 
+    public class SidecarProcessIdTask : Microsoft.Build.Utilities.Task
+    {
+        [Output]
+        public int Pid { get; set; }
+
+        public override bool Execute()
+        {
+            Pid = Process.GetCurrentProcess().Id;
+            return true;
+        }
+    }
+
     public class MSBuildServer_Tests : IDisposable
     {
         private readonly ITestOutputHelper _output;
@@ -790,15 +802,13 @@ namespace Microsoft.Build.Engine.UnitTests
         }
 
         /// <summary>
-        /// A transient build must not adopt the resident server's sidecar TaskHost. Sidecars are owned
-        /// by the process that launched them (#14584), so a build that tears its own server down at the
-        /// end must bring its own TaskHost rather than borrowing one whose owner outlives it.
+        /// A transient build with node reuse disabled must not adopt the resident server's reusable
+        /// TaskHost. It must instead launch a non-reusable TaskHost for its own build.
         /// </summary>
         /// <remarks>
-        /// This deliberately does not assert that the resident sidecar is still alive afterwards. A
-        /// sidecar lives exactly as long as its owner, which <see cref="TransientBuildDoesNotShutDownResidentServer"/>
-        /// already covers, and asserting its survival here proved sensitive to unrelated MSBuild
-        /// activity elsewhere on the machine when the suite runs in parallel.
+        /// This deliberately does not assert that the resident TaskHost is still alive afterwards.
+        /// Its lifetime is independent of the server identity behavior under test, and asserting its
+        /// survival is sensitive to unrelated MSBuild activity elsewhere on the machine.
         /// </remarks>
         [Fact]
         public void TransientBuildDoesNotAdoptResidentSidecars()
@@ -819,7 +829,7 @@ namespace Microsoft.Build.Engine.UnitTests
                         <ProcessIdTask>
                             <Output PropertyName="SERVER_PID" TaskParameter="Pid" />
                         </ProcessIdTask>
-                        <SidecarProcessIdTask EnvironmentVariableName="PATH">
+                        <SidecarProcessIdTask>
                             <Output PropertyName="SIDECAR_PID" TaskParameter="Pid" />
                         </SidecarProcessIdTask>
                         <Message Text="Server ID is $(SERVER_PID)" Importance="High" />
@@ -919,6 +929,14 @@ namespace Microsoft.Build.Engine.UnitTests
             _env.SetEnvironmentVariable("COMPlus_gcServer", null);
             _env.SetEnvironmentVariable("MSBUILDUSESERVER", useServer ? "1" : null);
         }
+
+        private void ShutdownBootstrapServer()
+            => RunnerUtilities.RunProcessAndGetOutput(
+                RunnerUtilities.BootstrapDotnetHostPath,
+                "build-server shutdown",
+                out _,
+                outputHelper: _output,
+                environmentVariables: RunnerUtilities.GetBootstrapMSBuildEnvironmentVariables());
 
         /// <summary>
         /// The MSBuild server (build orchestrator) process must be launched with Server GC when the

--- a/src/MSBuild.UnitTests/MSBuildServer_Tests.cs
+++ b/src/MSBuild.UnitTests/MSBuildServer_Tests.cs
@@ -937,7 +937,7 @@ namespace Microsoft.Build.Engine.UnitTests
         private void ShutdownBootstrapServer()
             => RunnerUtilities.RunProcessAndGetOutput(
                 RunnerUtilities.BootstrapDotnetHostPath,
-                "build-server shutdown",
+                "build-server shutdown --msbuild",
                 out _,
                 outputHelper: _output,
                 environmentVariables: RunnerUtilities.GetBootstrapMSBuildEnvironmentVariables());

--- a/src/MSBuild.UnitTests/MSBuildServer_Tests.cs
+++ b/src/MSBuild.UnitTests/MSBuildServer_Tests.cs
@@ -710,8 +710,10 @@ namespace Microsoft.Build.Engine.UnitTests
                     false,
                     _output);
                 residentSuccess.ShouldBeTrue();
+                int residentClientPid = ParseNumber(residentOutput, "Process ID is ");
                 int residentPid = ParseNumber(residentOutput, "TaskRanInPID=");
                 _env.WithTransientProcess(residentPid);
+                residentPid.ShouldNotBe(residentClientPid, "The resident build must run in a server, not in-process.");
 
                 string transientOutput = RunnerUtilities.ExecBootstrapedMSBuild(
                     $"{project.Path} -mt -nodeReuse:false",
@@ -719,9 +721,11 @@ namespace Microsoft.Build.Engine.UnitTests
                     false,
                     _output);
                 transientSuccess.ShouldBeTrue();
+                int transientClientPid = ParseNumber(transientOutput, "Process ID is ");
                 int transientPid = ParseNumber(transientOutput, "TaskRanInPID=");
                 _env.WithTransientProcess(transientPid);
 
+                transientPid.ShouldNotBe(transientClientPid, "The transient build must run in a server, not in-process.");
                 transientPid.ShouldNotBe(residentPid, "A transient build must run in its own server rather than borrowing the resident one.");
                 WaitForProcessExit(transientPid).ShouldBeTrue($"Transient server {transientPid} should tear itself down after its build.");
 

--- a/src/MSBuild/CommandLine/CommandLineSwitches.cs
+++ b/src/MSBuild/CommandLine/CommandLineSwitches.cs
@@ -121,6 +121,7 @@ namespace Microsoft.Build.CommandLine.Experimental
             MultiThreaded,
             ParentPacketVersion,
             NoLogo,
+            ServerInstanceId,
             // This has to be kept as last enum value
             NumberOfParameterizedSwitches,
         }
@@ -297,7 +298,8 @@ namespace Microsoft.Build.CommandLine.Experimental
             new ParameterizedSwitchInfo(  ["featureAvailability", "fa"],        ParameterizedSwitch.FeatureAvailability,        null,                           true,           "MissingFeatureAvailabilityError",     true,   false,   "HelpMessage_46_FeatureAvailabilitySwitch"),
             new ParameterizedSwitchInfo(  ["multithreaded", "mt"],              ParameterizedSwitch.MultiThreaded,              null,                           false,          null,                                  true,   false,   "HelpMessage_49_MultiThreadedSwitch"),
             new ParameterizedSwitchInfo(  ["parentpacketversion"],              ParameterizedSwitch.ParentPacketVersion,        null,                           false,          null,                                  false,  false,   null),
-            new ParameterizedSwitchInfo(  ["nologo"],                           ParameterizedSwitch.NoLogo,                     null,                           false,          null,                                  true,   false,   "HelpMessage_5_NoLogoSwitch")
+            new ParameterizedSwitchInfo(  ["nologo"],                           ParameterizedSwitch.NoLogo,                     null,                           false,          null,                                  true,   false,   "HelpMessage_5_NoLogoSwitch"),
+            new ParameterizedSwitchInfo(  ["serverinstanceid"],                 ParameterizedSwitch.ServerInstanceId,           null,                           false,          null,                                  false,  false,   null)
             // Add to ParameterizedSwitch enum (before NumberOfParameterizedSwitches):
         };
 
@@ -473,7 +475,8 @@ namespace Microsoft.Build.CommandLine.Experimental
                     is not ParameterizedSwitch.Project
                     and not ParameterizedSwitch.NodeMode
                     and not ParameterizedSwitch.Check
-                    and not ParameterizedSwitch.ParentPacketVersion)
+                    and not ParameterizedSwitch.ParentPacketVersion
+                    and not ParameterizedSwitch.ServerInstanceId)
                 {
                     Debug.Assert(!string.IsNullOrEmpty(s_parameterizedSwitchesMap[i].resourceId), "All parameterized switches should be cross-checked against the help message strings except from project switch");
                 }

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -3145,6 +3145,18 @@ namespace Microsoft.Build.CommandLine
         }
 
         /// <summary>
+        /// Processes the server instance id switch, which a client passes to the transient server it
+        /// launches for its own exclusive use. Both sides fold it into the pipe and mutex names, so a
+        /// transient server is unreachable by anyone else.
+        /// </summary>
+        /// <param name="parameters">The command line parameters for the switch.</param>
+        /// <returns>The instance id, or null for the resident server.</returns>
+        internal static string ProcessServerInstanceIdSwitch(string[] parameters)
+            => parameters.Length > 0 && !string.IsNullOrEmpty(parameters[parameters.Length - 1])
+                ? parameters[parameters.Length - 1]
+                : null;
+
+        /// <summary>
         /// Processes the node reuse switch, the user can set node reuse to true, false or not set the switch. If the switch is
         /// not set the system will check to see if the process is being run as an administrator. This check in localnode provider
         /// will determine the node reuse setting for that case.
@@ -3434,7 +3446,7 @@ namespace Microsoft.Build.CommandLine
                             return (exitCode, exitType.ToString());
                         };
 
-                        OutOfProcServerNode serverNode = new(buildFunction);
+                        OutOfProcServerNode serverNode = new(buildFunction, ProcessServerInstanceIdSwitch(commandLineSwitches[CommandLineSwitches.ParameterizedSwitch.ServerInstanceId]));
 
                         s_isServerNode = true;
                         shutdownReason = serverNode.Run(out nodeException);

--- a/src/UnitTests.Shared/RunnerUtilities.cs
+++ b/src/UnitTests.Shared/RunnerUtilities.cs
@@ -61,6 +61,8 @@ namespace Microsoft.Build.UnitTests.Shared
         // fail to find its runtime. See eng/BootStrapMsBuild.targets.
         private static readonly string s_bootstrapDotnetHostPath = EnvironmentProvider.GetDotnetExePathFromFolder(BootstrapMsBuildBinaryLocation);
 
+        public static string BootstrapDotnetHostPath => s_bootstrapDotnetHostPath;
+
         // Architecture-specific DOTNET_ROOT_<ARCH> variables take precedence over DOTNET_ROOT for the .NET app host.
         // X86/X64/ARM64 cover every CI agent architecture; these are cleared when launching the bootstrapped MSBuild.
         private static readonly string[] s_archSpecificDotnetRootVars =


### PR DESCRIPTION
This change is standalone and based directly on `main`.

## The bug

`dotnet build -mt -nodeReuse:false` kills a resident MSBuild Server.

```text
resident after  -mt -nodeReuse:true  : 32752
server(s) after -mt -nodeReuse:false : (none)
```

A `-mt` build with node reuse off still needs a server for Server GC, but must not leave one behind. `XMake.cs` therefore sets `shutdownServerAfterBuild`, and the client tells its server to exit once the build finishes.

The process was never fresh. Resident and transient clients derived identical pipe and mutex names, so the transient client connected to the resident server and ordered it to shut down.

Before multithreaded mode used the server, node reuse being disabled disqualified server use entirely:

```csharp
bool nodeReuseDisqualifies = !nodeReuse && !multiThreaded;
```

Node reuse was a precondition for a server existing, not a dimension of its identity. `-mt` introduced a second server lifetime without giving it a distinct identity.

## The fix

A transient server carries a per-invocation instance ID generated by the client and passed to the server it launches. Resident servers pass no ID, so their endpoint identity remains unchanged.

The ID feeds `ComputeHash()`, and therefore the pipe and mutex names, but deliberately does not feed `RetrieveHandshakeComponents()`. The handshake answers "are we compatible"; the hash answers "which server am I talking to." This avoids a wire-format change.

Passing the ID on the child command line follows the existing pattern for launch-time node parameters such as `/nodemode`, `/nodereuse`, `/low`, and `/parentpacketversion`.

### Why not add only the `NodeReuse` bit to the handshake?

That would give all transient builds one shared identity. Because the pipe and every server mutex derive from that identity, concurrent transient builds could not safely coexist:

- A second client could find the first server busy and silently fall back to an in-process build, losing the server that `-mt` requested.
- A second server using the same identity would refuse to start because the running mutex is already held.
- A client could connect while the previous transient server is already shutting down.

Per-invocation IDs allow concurrent transient builds to use independent private servers.

## Lifecycle behavior

1. A resident server and multiple transient servers may coexist. Each transient server exits after its build.
2. `dotnet build-server shutdown` intentionally cannot address a transient server because its identity is private to its launching client.
3. If the client disconnects after connecting, the broken pipe terminates the transient server.
4. A client waits up to 5 seconds to connect to a newly launched server. If the client exits before connecting, the private server's connection timeout is capped at 10 seconds while honoring any lower configured timeout.
5. Transient servers never enter the resident reuse loop.
6. Resident naming, reuse, and over-provisioning behavior remain unchanged. Transient servers do not add another process-command-line scan.

## Verification

End-to-end behavior on a bootstrapped build:

| Scenario | Resident survives | Transient gets its own server |
| --- | --- | --- |
| Before | No | N/A |
| After | Yes | Yes |

Concurrency sampled while three `-mt -nodeReuse:false` builds overlapped:

```text
max concurrent servers : 3
distinct server PIDs   : 5272, 7544, 43416
servers afterward      : none
```

Coverage includes:

- `TransientBuildDoesNotShutDownResidentServer` verifies both invocations actually execute in server processes and the resident survives.
- `ConcurrentTransientBuildsEachGetTheirOwnServer` verifies concurrent builds neither share a server nor silently fall back in-process.
- `TransientBuildDoesNotAdoptResidentSidecars` verifies a build with node reuse disabled launches its own non-reusable TaskHost.
- Handshake tests pin resident-hash compatibility, transient identity separation, same-ID stability, unchanged wire handshake data, and distinct pipe and mutex names.

The transient E2E group passed five consecutive stress iterations (15 builds total). An active-build client-abort probe also confirmed that a connected private server exits promptly when its client terminates.

## Scope

This PR isolates the transient MSBuild Server used by `-mt -nodeReuse:false`. It does not introduce TaskHost ownership or change resident TaskHost lifetime policy.
