### PR TITLE
Add case-insensitive item glob request coverage

### DIFF
--- a/src/Build.UnitTests/Evaluation/ItemGlobs_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/ItemGlobs_Tests.cs
@@ -70,6 +70,21 @@ public sealed class ItemGlobs_Tests(ITestOutputHelper output)
     }
 
     [Fact]
+    public void RequestedItemTypesAreMatchedCaseInsensitively()
+    {
+        var project = CreateProject("""
+                <PropertyGroup>
+                    <MSBuildProvideItemGlobs>compile</MSBuildProvideItemGlobs>
+                </PropertyGroup>
+                <ItemGroup>
+                    <Compile Include="*.cs" />
+                </ItemGroup>
+            """);
+
+        GlobItemsFor(project, "Compile").Single().GetMetadataValue("Include").ShouldBe("*.cs");
+    }
+
+    [Fact]
     public void IncludeExcludeAndRemoveCaptured()
     {
         var project = CreateProject("""

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -2774,7 +2774,7 @@ namespace Microsoft.Build.Evaluation
 
             _itemGlobRequestedTypes = new HashSet<string>(
                 ExpressionShredder.SplitSemiColonSeparatedList(provideProperty.EvaluatedValue),
-                StringComparer.OrdinalIgnoreCase);
+                MSBuildNameIgnoreCaseComparer.Default);
             _itemGlobElements = new List<ProjectItemElement>();
         }
 

--- a/src/MSBuild/MSBuild/Microsoft.Build.CommonTypes.xsd
+++ b/src/MSBuild/MSBuild/Microsoft.Build.CommonTypes.xsd
@@ -1223,6 +1223,36 @@ elementFormDefault="qualified">
             </xs:complexContent>
         </xs:complexType>
     </xs:element>
+    <xs:element name="MSBuildItemGlob" substitutionGroup="msb:Item">
+        <xs:annotation>
+            <xs:documentation><!-- _locID_text="MSBuildItemGlob" _locComment="" -->Synthesized by the engine for each item type listed in MSBuildProvideItemGlobs. Each item's identity is the item type; its metadata carry the unevaluated include/exclude/remove glob patterns of one item element.</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="msb:SimpleItemType">
+                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                        <xs:choice>
+                            <xs:element name="Include">
+                                <xs:annotation>
+                                    <xs:documentation><!-- _locID_text="MSBuildItemGlob_Include" _locComment="" -->The include glob pattern(s) of the item element (semicolon-separated, wildcards preserved).</xs:documentation>
+                                </xs:annotation>
+                            </xs:element>
+                            <xs:element name="Exclude">
+                                <xs:annotation>
+                                    <xs:documentation><!-- _locID_text="MSBuildItemGlob_Exclude" _locComment="" -->The exclude pattern(s) that apply to the include (semicolon-separated; literals and globs).</xs:documentation>
+                                </xs:annotation>
+                            </xs:element>
+                            <xs:element name="Remove">
+                                <xs:annotation>
+                                    <xs:documentation><!-- _locID_text="MSBuildItemGlob_Remove" _locComment="" -->The remove pattern(s) that apply to the include (semicolon-separated; literals and globs).</xs:documentation>
+                                </xs:annotation>
+                            </xs:element>
+                        </xs:choice>
+                    </xs:sequence>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
     <xs:element name="WebReferences" type="msb:SimpleItemType" substitutionGroup="msb:Item">
         <xs:annotation>
             <xs:documentation><!-- _locID_text="WebReferences" _locComment="" -->Name of Web References folder to display in user interface</xs:documentation>
@@ -1949,7 +1979,7 @@ elementFormDefault="qualified">
     </xs:element>
     <xs:element name="MSBuildProvideItemGlobs" type="msb:StringPropertyType" substitutionGroup="msb:Property">
         <xs:annotation>
-            <xs:documentation><!-- _locID_text="MSBuildProvideItemGlobs" _locComment="" -->A semicolon-separated list of item types (e.g. 'Compile;Content'). For each listed item type, the engine synthesizes MSBuildItemGlob items exposing the unevaluated include/exclude/remove glob patterns of that item type. Do not use generated MSBuildItemGlob items to influence the build process.</xs:documentation>
+          <xs:documentation><!-- _locID_text="MSBuildProvideItemGlobs" _locComment="" -->A semicolon-separated list of item types (e.g. 'Compile;Content'). For each listed item type, the engine synthesizes MSBuildItemGlob items exposing the unevaluated include/exclude/remove glob patterns of that item type. Do not use generated MSBuildItemGlob items to influence the build process.</xs:documentation>
         </xs:annotation>
     </xs:element>
     <xs:element name="MSBuildTreatWarningsAsErrors" type="msb:StringPropertyType" substitutionGroup="msb:Property">


### PR DESCRIPTION
Stacked on top of #14389.

This adds test coverage for case-insensitive item-glob request matching while leaving the existing PR branch unchanged.