### PR TITLE
Shut down TaskHosts with the build server

### DIFF
--- a/src/Build.UnitTests/BackEnd/NodeProviderOutOfProc_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/NodeProviderOutOfProc_Tests.cs
@@ -2,7 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Linq;
 using Microsoft.Build.BackEnd;
+using Microsoft.Build.Internal;
 using Microsoft.Build.Shared;
 using Shouldly;
 using Xunit;
@@ -145,6 +147,23 @@ namespace Microsoft.Build.UnitTests.BackEnd
             
             result.Length.ShouldBe(1);
             result[0].ShouldBeFalse();
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void ShutdownHandshakes_IncludeWorkerAndTaskHost(bool nodeReuse)
+        {
+            HandshakeOptions[] options = NodeProviderOutOfProcBase.GetShutdownHandshakes(nodeReuse)
+                .Select(handshake => handshake.HandshakeOptions)
+                .ToArray();
+
+            options.Length.ShouldBe(3);
+            options.Count(option => !Handshake.IsHandshakeOptionEnabled(option, HandshakeOptions.TaskHost)).ShouldBe(2);
+            options.Count(option => Handshake.IsHandshakeOptionEnabled(option, HandshakeOptions.TaskHost)).ShouldBe(1);
+
+            HandshakeOptions taskHostOptions = options.Single(option => Handshake.IsHandshakeOptionEnabled(option, HandshakeOptions.TaskHost));
+            Handshake.IsHandshakeOptionEnabled(taskHostOptions, HandshakeOptions.NodeReuse).ShouldBe(nodeReuse);
         }
     }
 }

--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -1507,6 +1507,8 @@ namespace Microsoft.Build.Execution
         {
             Microsoft.Build.Server.MSBuildClient.ShutdownServer(CancellationToken.None);
 
+            _taskHostNodeManager?.ShutdownConnectedNodes(enableReuse: false);
+
             _nodeManager ??= (INodeManager)((IBuildComponentHost)this).GetComponent(BuildComponentType.NodeManager);
             _nodeManager.ShutdownAllNodes();
         }

--- a/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
@@ -171,19 +171,34 @@ namespace Microsoft.Build.BackEnd
             // Search for all instances of msbuildtaskhost process and add them to the process list
             nodeProcesses.AddRange(Process.GetProcessesByName(Path.GetFileNameWithoutExtension(msbuildtaskhostExeName)));
 
+            Handshake[] shutdownHandshakes = GetShutdownHandshakes(nodeReuse);
+
             // For all processes in the list, send signal to terminate if able to connect
             foreach (Process nodeProcess in nodeProcesses)
             {
                 // A 2013 comment suggested some nodes take this long to respond, so a smaller timeout would miss nodes.
                 int timeout = 30;
 
-                // Attempt to connect to the process with the handshake without low priority.
-                Stream nodeStream = TryConnectToProcess(nodeProcess.Id, timeout, NodeProviderOutOfProc.GetHandshake(nodeReuse, false), out HandshakeResult result);
+                Stream nodeStream = null;
+                HandshakeResult result = default;
 
-                if (nodeStream == null)
+                foreach (Handshake handshake in shutdownHandshakes)
                 {
-                    // If we couldn't connect attempt to connect to the process with the handshake including low priority.
-                    nodeStream = TryConnectToProcess(nodeProcess.Id, timeout, NodeProviderOutOfProc.GetHandshake(nodeReuse, true), out result);
+                    Stream candidateStream = null;
+                    try
+                    {
+                        candidateStream = TryConnectToProcess(nodeProcess.Id, timeout, handshake, out result);
+                        if (candidateStream != null)
+                        {
+                            nodeStream = candidateStream;
+                            candidateStream = null;
+                            break;
+                        }
+                    }
+                    finally
+                    {
+                        candidateStream?.Dispose();
+                    }
                 }
 
                 if (nodeStream != null)
@@ -196,6 +211,13 @@ namespace Microsoft.Build.BackEnd
                 }
             }
         }
+
+        internal static Handshake[] GetShutdownHandshakes(bool nodeReuse) =>
+        [
+            NodeProviderOutOfProc.GetHandshake(nodeReuse, enableLowPriority: false),
+            NodeProviderOutOfProc.GetHandshake(nodeReuse, enableLowPriority: true),
+            NodeProviderOutOfProcTaskHost.GetHandshake(nodeReuse),
+        ];
 
         /// <summary>
         /// Finds or creates child processes which can act as nodes using the provided launch data.

--- a/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcTaskHost.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcTaskHost.cs
@@ -162,6 +162,12 @@ namespace Microsoft.Build.BackEnd
             }
         }
 
+        internal static Handshake GetHandshake(bool enableNodeReuse) =>
+            new(CommunicationsUtilities.GetHandshakeOptions(
+                taskHost: true,
+                taskHostParameters: TaskHostParameters.Empty,
+                nodeReuse: enableNodeReuse));
+
         /// <summary>
         /// Returns the name of the CLR2 Task Host executable
         /// </summary>

--- a/src/MSBuild.UnitTests/MSBuildServer_Tests.cs
+++ b/src/MSBuild.UnitTests/MSBuildServer_Tests.cs
@@ -66,6 +66,18 @@ namespace Microsoft.Build.Engine.UnitTests
         }
     }
 
+    public class SidecarProcessIdTask : Microsoft.Build.Utilities.Task
+    {
+        [Output]
+        public int Pid { get; set; }
+
+        public override bool Execute()
+        {
+            Pid = Process.GetCurrentProcess().Id;
+            return true;
+        }
+    }
+
     public class MSBuildServer_Tests : IDisposable
     {
         private readonly ITestOutputHelper _output;
@@ -610,6 +622,63 @@ namespace Microsoft.Build.Engine.UnitTests
             finally
             {
                 // Ensure any server we spun up is torn down even if an assertion above fails.
+                MSBuildClient.ShutdownServer(CancellationToken.None);
+            }
+        }
+
+        [Fact]
+        public void MultiThreadedNoReuseBuildDoesNotAdoptOrOrphanSidecarTaskHost()
+        {
+            PrepareIsolatedServerEnv(useServer: false);
+            TransientTestFile project = _env.CreateFile(
+                "mtNoReuseSidecarProbe.proj",
+                $"""
+                <Project>
+                  <UsingTask TaskName="SidecarProcessIdTask" AssemblyFile="{Assembly.GetExecutingAssembly().Location}" />
+                  <Target Name="Probe">
+                    <SidecarProcessIdTask>
+                      <Output PropertyName="PID" TaskParameter="Pid" />
+                    </SidecarProcessIdTask>
+                    <Message Text="[Work around GitHub issue #9667 with --interactive]TaskRanInPID=$(PID)" Importance="High" />
+                  </Target>
+                </Project>
+                """);
+
+            MSBuildClient.ShutdownServer(CancellationToken.None);
+
+            try
+            {
+                string reusableOutput = RunnerUtilities.ExecMSBuild(
+                    BuildEnvironmentHelper.Instance.CurrentMSBuildExePath,
+                    $"{project.Path} -mt",
+                    out bool reusableSuccess,
+                    false,
+                    _output);
+                reusableSuccess.ShouldBeTrue();
+                int reusableSidecarPid = ParseNumber(reusableOutput, "TaskRanInPID=");
+                _env.WithTransientProcess(reusableSidecarPid);
+
+                string noReuseOutput = RunnerUtilities.ExecMSBuild(
+                    BuildEnvironmentHelper.Instance.CurrentMSBuildExePath,
+                    $"{project.Path} -mt -nr:false",
+                    out bool noReuseSuccess,
+                    false,
+                    _output);
+                noReuseSuccess.ShouldBeTrue();
+                int noReuseTaskHostPid = ParseNumber(noReuseOutput, "TaskRanInPID=");
+                _env.WithTransientProcess(noReuseTaskHostPid);
+
+                noReuseTaskHostPid.ShouldNotBe(
+                    reusableSidecarPid,
+                    "A no-reuse build must not reconnect to a reusable sidecar that was already idle.");
+                WaitForProcessExit(noReuseTaskHostPid).ShouldBeTrue(
+                    $"TaskHost process {noReuseTaskHostPid} should exit after a no-reuse build.");
+                using Process reusableSidecar = Process.GetProcessById(reusableSidecarPid);
+                reusableSidecar.HasExited.ShouldBeFalse(
+                    "The pre-existing reusable sidecar should remain untouched by the no-reuse build.");
+            }
+            finally
+            {
                 MSBuildClient.ShutdownServer(CancellationToken.None);
             }
         }

--- a/src/MSBuild.UnitTests/OutOfProcTaskHostNode_Tests.cs
+++ b/src/MSBuild.UnitTests/OutOfProcTaskHostNode_Tests.cs
@@ -1,0 +1,34 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Build.CommandLine;
+using Microsoft.Build.Execution;
+using Shouldly;
+using Xunit;
+
+namespace Microsoft.Build.UnitTests;
+
+public class OutOfProcTaskHostNode_Tests
+{
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void ShutdownRequestTerminatesReusableTaskHost(bool reuseTaskHostNodes)
+    {
+        OutOfProcTaskHostNode.DetermineShutdownReason(
+            nodeReuse: true,
+            prepareForReuse: false,
+            reuseTaskHostNodes).ShouldBe(NodeEngineShutdownReason.BuildComplete);
+    }
+
+    [Theory]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    public void ReuseRequestKeepsReusableTaskHostAlive(bool nodeReuse, bool reuseTaskHostNodes)
+    {
+        OutOfProcTaskHostNode.DetermineShutdownReason(
+            nodeReuse,
+            prepareForReuse: true,
+            reuseTaskHostNodes).ShouldBe(NodeEngineShutdownReason.BuildCompleteReuse);
+    }
+}

--- a/src/MSBuild/OutOfProcTaskHostNode.cs
+++ b/src/MSBuild/OutOfProcTaskHostNode.cs
@@ -1329,18 +1329,20 @@ namespace Microsoft.Build.CommandLine
             // the next build performs a fresh apply rather than trusting state left over from this build.
             _lastAppliedConfigEnvironment = null;
 
-            // Sidecar TaskHost will persist after the build is done.
-            if (_nodeReuse)
-            {
-                _shutdownReason = NodeEngineShutdownReason.BuildCompleteReuse;
-            }
-            else
-            {
-                // TaskHostNodes lock assemblies with custom tasks produced by build scripts if NodeReuse is on. This causes failures if the user builds twice.
-                _shutdownReason = buildComplete.PrepareForReuse && Traits.Instance.EscapeHatches.ReuseTaskHostNodes ? NodeEngineShutdownReason.BuildCompleteReuse : NodeEngineShutdownReason.BuildComplete;
-            }
+            _shutdownReason = DetermineShutdownReason(
+                _nodeReuse,
+                buildComplete.PrepareForReuse,
+                Traits.Instance.EscapeHatches.ReuseTaskHostNodes);
             _shutdownEvent.Set();
         }
+
+        internal static NodeEngineShutdownReason DetermineShutdownReason(
+            bool nodeReuse,
+            bool prepareForReuse,
+            bool reuseTaskHostNodes) =>
+            prepareForReuse && (nodeReuse || reuseTaskHostNodes)
+                ? NodeEngineShutdownReason.BuildCompleteReuse
+                : NodeEngineShutdownReason.BuildComplete;
 
         /// <summary>
         /// Perform necessary actions to shut down the node.


### PR DESCRIPTION
## Summary

- make machine-wide node shutdown probe the TaskHost handshake in addition to worker handshakes
- terminate TaskHosts connected to the current BuildManager
- make an explicit no-reuse completion terminate a sidecar even when it was launched with node reuse
- cover handshake selection, shutdown semantics, and the -mt -nr:false sidecar lifecycle

## Verification

- targeted Build.UnitTests build and handshake tests
- targeted MSBuild.UnitTests build and TaskHost shutdown tests
- end-to-end probe confirmed -mt -nr:false does not adopt an existing reusable sidecar, its private TaskHost exits, and the pre-existing sidecar remains untouched