### PR TITLE
Release the binary log file handle when a logger fails during shutdown

### DIFF
--- a/src/Build.UnitTests/BinaryLogger_Tests.cs
+++ b/src/Build.UnitTests/BinaryLogger_Tests.cs
@@ -16,6 +16,7 @@ using Microsoft.Build.Execution;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Logging;
 using Microsoft.Build.Shared;
+using Microsoft.Build.Shared.Debugging;
 using Microsoft.Build.UnitTests.Shared;
 using Shouldly;
 using Xunit;
@@ -1182,6 +1183,132 @@ namespace Microsoft.Build.UnitTests
             replayed.Importance.ShouldBe(MessageImportance.Low);
             replayed.Message.ShouldBe("MSBuild Server node started for this build (process ID 1234).");
         }
+
+        public void Dispose()
+        {
+            _env.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// Covers the lifetime of the binary log file handle across a build.
+    /// </summary>
+    public class BinaryLoggerFileHandleTests : IDisposable
+    {
+        private readonly TestEnvironment _env;
+        private readonly string _logFile;
+
+        public BinaryLoggerFileHandleTests(ITestOutputHelper output)
+        {
+            _env = TestEnvironment.Create(output);
+            _env.WithEnvironmentInvariant();
+            _logFile = _env.ExpectFile(".binlog").Path;
+        }
+
+        /// <summary>
+        /// A logger that throws from its <see cref="IEventSource.BuildFinished"/> handler, i.e. from inside
+        /// <c>BuildManager.EndBuild</c>'s teardown.
+        /// </summary>
+        private sealed class ThrowOnBuildFinishedLogger : ILogger
+        {
+            public LoggerVerbosity Verbosity { get; set; }
+
+            public string Parameters { get; set; }
+
+            public void Initialize(IEventSource eventSource)
+                => eventSource.BuildFinished += (_, _) => throw new InvalidOperationException("Logger failed on BuildFinished.");
+
+            public void Shutdown()
+            {
+            }
+        }
+
+        /// <summary>
+        /// The binary log file handle must not outlive the build that opened it, even when another logger fails
+        /// while BuildFinished is raised. The handle is released by <see cref="ProjectCollection.Dispose"/>, but
+        /// only once <c>EndBuild</c> has shut its logging service down and thereby detached the build-time event
+        /// source from the wrapping ReusableLogger. If that shutdown is skipped, the wrapped BinaryLogger is
+        /// silently never shut down and keeps the file handle for the lifetime of the process - which permanently
+        /// wedges the log file in a long-lived MSBuild Server node that serves many builds.
+        /// </summary>
+        [Fact]
+        public void BinaryLogFileHandleIsReleasedWhenAnotherLoggerThrowsDuringShutdown()
+        {
+            // The failing logger is reported through the unhandled-exception dump; remove whatever it writes so it
+            // does not trip the ambient build-failure-file invariant.
+            string[] dumpFilesBefore = GetExceptionDumpFiles();
+            BuildManager buildManager = null;
+
+            try
+            {
+                string projectFile = _env.CreateFile(".proj", """
+                    <Project>
+                       <Target Name='Build'>
+                          <Message Text='Hello' />
+                       </Target>
+                    </Project>
+                    """).Path;
+
+                using (ProjectCollection projectCollection = new(
+                    null,
+                    [new BinaryLogger { Parameters = _logFile }, new ThrowOnBuildFinishedLogger()],
+                    ToolsetDefinitionLocations.Default))
+                {
+                    BuildParameters parameters = new(projectCollection)
+                    {
+                        Loggers = projectCollection.Loggers,
+
+                        // Match the command line, which logs synchronously. That is what makes the failing logger
+                        // surface on the thread running EndBuild rather than on the async logging thread.
+                        UseSynchronousLogging = true,
+                    };
+
+                    // Deliberately not disposed inside this scope: MSBuild Server reuses
+                    // BuildManager.DefaultBuildManager across builds and never disposes it
+                    // (XMake: "if (!s_isServerNode) BuildManager.DefaultBuildManager.Dispose()").
+                    // Disposing here would shut the logging service down as a side effect and hide the leak.
+                    buildManager = new BuildManager();
+                    buildManager.BeginBuild(parameters);
+
+                    try
+                    {
+                        buildManager
+                            .PendBuildRequest(new BuildRequestData(projectFile, new Dictionary<string, string>(), null, ["Build"], null))
+                            .Execute();
+
+                        buildManager.EndBuild();
+                    }
+                    catch (Exception)
+                    {
+                        // The failing logger is expected to surface here. This test is about the file handle.
+                    }
+                }
+
+                File.Exists(_logFile).ShouldBeTrue($"Expected '{_logFile}' to have been created.");
+
+                // An exclusive open is the assertion: it fails if any handle to the file is still open.
+                Should.NotThrow(
+                    () =>
+                    {
+                        using FileStream _ = new(_logFile, FileMode.Open, System.IO.FileAccess.ReadWrite, FileShare.None);
+                    },
+                    $"The log file '{_logFile}' is still held open after the build that created it completed.");
+            }
+            finally
+            {
+                buildManager?.Dispose();
+
+                foreach (string dumpFile in GetExceptionDumpFiles().Except(dumpFilesBefore))
+                {
+                    File.Delete(dumpFile);
+                }
+            }
+        }
+
+        private static string[] GetExceptionDumpFiles()
+            => Directory.Exists(DebugUtils.DebugDumpPath)
+                ? Directory.GetFiles(DebugUtils.DebugDumpPath, "MSBuild_*failure.txt")
+                : [];
 
         public void Dispose()
         {

--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -1192,63 +1192,74 @@ namespace Microsoft.Build.Execution
                 {
                     ILoggingService? loggingService = ((IBuildComponentHost)this).LoggingService;
 
-                    if (loggingService != null)
+                    try
                     {
-                        // Override the build success if the user specified /warnaserror and any errors were logged outside of a build submission.
-                        if (exceptionsThrownInEndBuild ||
-                            (_overallBuildSuccess && loggingService.HasBuildSubmissionLoggedErrors(BuildEventContext.InvalidSubmissionId)))
+                        if (loggingService != null)
                         {
-                            _overallBuildSuccess = false;
-                        }
-
-                        loggingService.LogBuildFinished(_overallBuildSuccess);
-
-                        if (_buildTelemetry != null)
-                        {
-                            _buildTelemetry.FinishedAt = DateTime.UtcNow;
-                            _buildTelemetry.BuildSuccess = _overallBuildSuccess;
-                            _buildTelemetry.BuildEngineVersion = ProjectCollection.Version;
-                            _buildTelemetry.BuildEngineDisplayVersion = ProjectCollection.DisplayVersion;
-                            _buildTelemetry.BuildEngineFrameworkName = NativeMethodsShared.FrameworkName;
-
-                            // Populate error categorization data from the logging service
-                            if (!_overallBuildSuccess)
+                            // Override the build success if the user specified /warnaserror and any errors were logged outside of a build submission.
+                            if (exceptionsThrownInEndBuild ||
+                                (_overallBuildSuccess && loggingService.HasBuildSubmissionLoggedErrors(BuildEventContext.InvalidSubmissionId)))
                             {
-                                loggingService.PopulateBuildTelemetryWithErrors(_buildTelemetry);
+                                _overallBuildSuccess = false;
                             }
 
-                            string? host = BuildEnvironmentState.GetHostName();
+                            loggingService.LogBuildFinished(_overallBuildSuccess);
 
-                            _buildTelemetry.BuildEngineHost = host;
-
-                            _buildTelemetry.BuildCheckEnabled = _buildParameters!.IsBuildCheckEnabled;
-                            _buildTelemetry.MultiThreadedModeEnabled = _buildParameters!.MultiThreaded;
-                            var sacState = NativeMethodsShared.GetSACState();
-                            // The Enforcement would lead to build crash - but let's have the check for completeness sake.
-                            _buildTelemetry.SACEnabled = sacState == NativeMethodsShared.SAC_State.Evaluation || sacState == NativeMethodsShared.SAC_State.Enforcement;
-
-                            loggingService.LogTelemetry(buildEventContext: null, _buildTelemetry.EventName, _buildTelemetry.GetProperties());
-
-                            // Emit per-task execution details as a separate "build/tasks/details" event.
-                            // The SDK merges these into the aggregated build/tasks telemetry event,
-                            // providing parity with the Activity-based path used by VS telemetry.
-                            if (!Traits.Instance.ExcludeTasksDetailsFromTelemetry)
+                            if (_buildTelemetry != null)
                             {
-                                Dictionary<string, string>? tasksDetailsProperties = _telemetryConsumingLogger?.WorkerNodeTelemetryData.GetTasksDetailsProperties();
-                                if (tasksDetailsProperties is not null)
+                                _buildTelemetry.FinishedAt = DateTime.UtcNow;
+                                _buildTelemetry.BuildSuccess = _overallBuildSuccess;
+                                _buildTelemetry.BuildEngineVersion = ProjectCollection.Version;
+                                _buildTelemetry.BuildEngineDisplayVersion = ProjectCollection.DisplayVersion;
+                                _buildTelemetry.BuildEngineFrameworkName = NativeMethodsShared.FrameworkName;
+
+                                // Populate error categorization data from the logging service
+                                if (!_overallBuildSuccess)
                                 {
-                                    loggingService.LogTelemetry(buildEventContext: null, TasksDetailsTelemetry.TasksDetailsEventName, tasksDetailsProperties);
+                                    loggingService.PopulateBuildTelemetryWithErrors(_buildTelemetry);
                                 }
+
+                                string? host = BuildEnvironmentState.GetHostName();
+
+                                _buildTelemetry.BuildEngineHost = host;
+
+                                _buildTelemetry.BuildCheckEnabled = _buildParameters!.IsBuildCheckEnabled;
+                                _buildTelemetry.MultiThreadedModeEnabled = _buildParameters!.MultiThreaded;
+                                var sacState = NativeMethodsShared.GetSACState();
+                                // The Enforcement would lead to build crash - but let's have the check for completeness sake.
+                                _buildTelemetry.SACEnabled = sacState == NativeMethodsShared.SAC_State.Evaluation || sacState == NativeMethodsShared.SAC_State.Enforcement;
+
+                                loggingService.LogTelemetry(buildEventContext: null, _buildTelemetry.EventName, _buildTelemetry.GetProperties());
+
+                                // Emit per-task execution details as a separate "build/tasks/details" event.
+                                // The SDK merges these into the aggregated build/tasks telemetry event,
+                                // providing parity with the Activity-based path used by VS telemetry.
+                                if (!Traits.Instance.ExcludeTasksDetailsFromTelemetry)
+                                {
+                                    Dictionary<string, string>? tasksDetailsProperties = _telemetryConsumingLogger?.WorkerNodeTelemetryData.GetTasksDetailsProperties();
+                                    if (tasksDetailsProperties is not null)
+                                    {
+                                        loggingService.LogTelemetry(buildEventContext: null, TasksDetailsTelemetry.TasksDetailsEventName, tasksDetailsProperties);
+                                    }
+                                }
+
+                                EndBuildTelemetry();
+
+                                // Clean telemetry to make it ready for next build submission.
+                                _buildTelemetry = null;
                             }
-
-                            EndBuildTelemetry();
-
-                            // Clean telemetry to make it ready for next build submission.
-                            _buildTelemetry = null;
                         }
                     }
-
-                    ShutdownLoggingService(loggingService);
+                    finally
+                    {
+                        // Shutting the logging service down is what releases logger-owned resources - notably the
+                        // BinaryLogger's file handle. It must happen even when LogBuildFinished or the telemetry
+                        // block above throws (a misbehaving logger reacting to BuildFinished is the common case),
+                        // otherwise those resources leak for the lifetime of the process. That is fatal in a
+                        // long-lived MSBuild Server node, where the leaked handle wedges the log file for every
+                        // subsequent build the node serves.
+                        ShutdownLoggingService(loggingService);
+                    }
                 }
                 finally
                 {

--- a/src/Build/Logging/BinaryLogger/BinaryLogger.cs
+++ b/src/Build/Logging/BinaryLogger/BinaryLogger.cs
@@ -503,6 +503,22 @@ namespace Microsoft.Build.Logging
             Traits.Instance.EscapeHatches.LogProjectImports = _initialLogImports;
             Traits.Instance.EnableTargetOutputLogging = _initialTargetOutputLogging;
 
+            try
+            {
+                ShutdownCore();
+            }
+            finally
+            {
+                // Flushing the import archive and copying the log to its additional destinations is best-effort,
+                // but releasing the log file handle is not: if it is skipped the handle survives for the lifetime
+                // of the process, which in a long-lived MSBuild Server node wedges the log file for every
+                // subsequent build. Close it on every path.
+                CloseStream();
+            }
+        }
+
+        private void ShutdownCore()
+        {
             if (projectImportsCollector != null)
             {
                 // Write the build check editorconfig file paths to the log
@@ -536,15 +552,7 @@ namespace Microsoft.Build.Logging
                 }
             }
 
-            if (stream != null)
-            {
-                // It's hard to determine whether we're at the end of decoding GZipStream
-                // so add an explicit 0 at the end to signify end of file
-                stream.WriteByte((byte)BinaryLogRecordKind.EndOfFile);
-                stream.Flush();
-                stream.Dispose();
-                stream = null;
-            }
+            CloseStream();
 
             // Copy the binlog file to additional destinations if specified
             if (AdditionalFilePaths != null && AdditionalFilePaths.Count > 0)
@@ -575,6 +583,30 @@ namespace Microsoft.Build.Logging
                         Console.Error.WriteLine(message);
                     }
                 }
+            }
+        }
+
+        /// <summary>
+        /// Writes the end-of-file marker and releases the log file handle. Safe to call more than once.
+        /// </summary>
+        private void CloseStream()
+        {
+            if (stream == null)
+            {
+                return;
+            }
+
+            try
+            {
+                // It's hard to determine whether we're at the end of decoding GZipStream
+                // so add an explicit 0 at the end to signify end of file
+                stream.WriteByte((byte)BinaryLogRecordKind.EndOfFile);
+                stream.Flush();
+            }
+            finally
+            {
+                stream.Dispose();
+                stream = null;
             }
         }
 


### PR DESCRIPTION
### Context

A user-visible symptom in MSBuild Server: after certain builds, the node keeps the `.binlog` file open forever. Every subsequent build served by that node fails with

```
MSBUILD : Logger error MSB4104: Failed to write to log file "out.binlog".
The process cannot access the file 'out.binlog' because it is being used by another process.
```

the file cannot be deleted, and the leaked binlog is left truncated (gzip header only, unreadable). Nothing recovers it short of killing the server — which users don't know exists.

This matters much more than it used to: `-mt` now implicitly enables MSBuild Server (`ShouldUseMSBuildServer`), so ordinary command lines land in a long-lived, reused node.

### Root cause

The binlog handle is **not** build-scoped. It is released by `ProjectCollection.Dispose()`, and only if `BuildManager.EndBuild()` ran first.

`ProjectCollection` wraps every logger in `ReusableLogger` so one `ILogger` instance can serve both the design-time (evaluation) and build-time lifetimes. Because `ILogger.Shutdown()` carries no identity, `ReusableLogger.Shutdown()` *infers* which lifetime is ending from its own state:

```csharp
if (_buildTimeEventSource != null) { /* detach build-time, keep logger alive */ }
else { _originalLogger.Shutdown(); }   // the only thing that closes the binlog
```

Balanced, ordered calls → correct. One missing call → silently wrong, permanently, with no way to detect it.

In `EndBuild`, `ShutdownLoggingService` — the call that performs the build-time detach — was the **last statement of an unguarded block** that first raises `BuildFinished` and then gathers telemetry:

```csharp
finally
{
    try
    {
        if (loggingService != null)
        {
            loggingService.LogBuildFinished(...);   // fans out to every logger
            if (_buildTelemetry != null) { /* ~40 lines of telemetry */ }
        }
        ShutdownLoggingService(loggingService);     // skipped if anything above throws
    }
    finally { ... }
}
```

A logger throwing from `BuildFinished` — something the engine tolerates everywhere else — skips it. The `BinaryLogger` is then never shut down and keeps its file handle for the lifetime of the process.

In `msbuild.exe` this was harmless: the process exits. In a resident server node it is not.

### Fix

Minimal and targeted:

1. **`BuildManager.EndBuild`** — run `ShutdownLoggingService` from a `finally` so it cannot be skipped. This restores the invariant the rest of the file already relies on; the same "on failure, shut the logging service down" compensation already exists in three other places (`InitializeLoggingService`'s inner `catch`, the `_threadException` check, and `CreateLoggingService`).
2. **`BinaryLogger.Shutdown`** — close the stream from a `finally`, so the handle is released even if the import-archive or additional-copy work throws. Same fail-open shape, contained.

No public API change; the diff in `BuildManager.cs` is mostly re-indentation.

### Verification

Regression test `BinaryLoggerFileHandleIsReleasedWhenAnotherLoggerThrowsDuringShutdown`:

- **fails** on `main` — `The log file '...binlog' is still held open after the build that created it completed`
- **passes** with the fix

The test deliberately does **not** dispose the `BuildManager`, mirroring MSBuild Server: XMake skips `BuildManager.DefaultBuildManager.Dispose()` for server nodes, and disposing it shuts the logging service down as a side effect, which hides the leak. It also uses `UseSynchronousLogging = true` to match the command line, which is what makes the failing logger surface on the thread running `EndBuild`.

End-to-end against a real server node with a locally built MSBuild:

| | before | after |
|---|---|---|
| handle after build #1 | held | released |
| binlog size | 15 bytes, `Unable to read beyond the end of the stream` | 2364 bytes, valid |
| builds #2, #3 same `-bl` path | `MSB4104` forever | succeed |
| delete the file | fails | succeeds |

Also ran the `BinaryLogger`, `BuildManager_Tests`, `ProjectCollection`, and logging suites (437 tests). Remaining failures are pre-existing and reproduce unchanged on a clean tree — 30s `ExecMSBuild` process-spawn timeouts in this environment, plus two `GraphBuild*` `ArgumentNullException` failures.

### Not addressed here (deliberately)

The deeper issue is the ownership inversion: for a build invocation, logger lifetime should be `BeginBuild`..`EndBuild`, but the binlog handle is owned by the `ProjectCollection`. For a regular CLI build that ownership is incidental — `BuildParameters(ProjectCollection)` doesn't copy loggers, and XMake round-trips them via `parameters.Loggers = projectCollection.Loggers` mainly to obtain the `ReusableLogger` wrappers. Removing that inversion (or giving `ReusableLogger` explicit owner/borrower semantics instead of inference) is a behavior-visible refactor and is out of scope for this fix.

Two adjacent issues also found while investigating, not fixed here:
- `MSB4104` doesn't fail the build — the binlog failure above still exits 0.
- If the client dies rudely (Ctrl+Break) mid-build, the server exits while the build task is still running, truncating the binlog. `OutOfProcServerNode` returns from `Run()` on `LinkStatus.Failed` without waiting for the in-flight build.
