### PR TITLE
Keep project active through post-build telemetry

### DIFF
--- a/src/Build.UnitTests/BackEnd/BuildRequestConfiguration_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/BuildRequestConfiguration_Tests.cs
@@ -700,25 +700,32 @@ namespace Microsoft.Build.UnitTests.BackEnd
                 IsCacheable = true,
             };
 
-            configuration.CacheIfPossible();
-            configuration.IsCached.ShouldBeTrue();
-
-            using (configuration.AcquireProjectInstanceUsage())
+            try
             {
-                configuration.IsCached.ShouldBeFalse();
+                configuration.CacheIfPossible();
+                configuration.IsCached.ShouldBeTrue();
 
                 using (configuration.AcquireProjectInstanceUsage())
                 {
-                    Task.Run(configuration.CacheIfPossible).GetAwaiter().GetResult();
+                    configuration.IsCached.ShouldBeFalse();
+
+                    using (configuration.AcquireProjectInstanceUsage())
+                    {
+                        Task.Run(configuration.CacheIfPossible).GetAwaiter().GetResult();
+                        configuration.IsCached.ShouldBeFalse();
+                    }
+
+                    configuration.CacheIfPossible();
                     configuration.IsCached.ShouldBeFalse();
                 }
 
                 configuration.CacheIfPossible();
-                configuration.IsCached.ShouldBeFalse();
+                configuration.IsCached.ShouldBeTrue();
             }
-
-            configuration.CacheIfPossible();
-            configuration.IsCached.ShouldBeTrue();
+            finally
+            {
+                configuration.ClearCacheFile();
+            }
         }
 
         [Fact]

--- a/src/Build.UnitTests/BackEnd/BuildRequestConfiguration_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/BuildRequestConfiguration_Tests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using System.Xml;
 using Microsoft.Build.BackEnd;
 using Microsoft.Build.Collections;
@@ -674,6 +675,51 @@ namespace Microsoft.Build.UnitTests.BackEnd
             clone.ProjectEvaluationId.ShouldBe(expectedEvalId);
         }
 
+        [Fact]
+        public void ProjectInstanceUsagePreventsConfigurationCaching()
+        {
+            string projectBody = """
+                <Project ToolsVersion='msbuilddefaulttoolsversion' xmlns='msbuildnamespace'>
+                    <Target Name='Build' />
+                </Project>
+                """.Cleanup();
+
+            using var collection = new ProjectCollection();
+            using ProjectFromString projectFromString = new(
+                projectBody,
+                new Dictionary<string, string>(),
+                ObjectModelHelpers.MSBuildDefaultToolsVersion,
+                collection);
+            Project project = projectFromString.Project;
+            project.FullPath = "foo";
+            ProjectInstance instance = project.CreateProjectInstance();
+
+            BuildRequestConfiguration configuration = new(new BuildRequestData(instance, [], null), "2.0")
+            {
+                ConfigurationId = 1,
+                IsCacheable = true,
+            };
+
+            configuration.CacheIfPossible();
+            configuration.IsCached.ShouldBeTrue();
+
+            using (configuration.EnterProjectInstanceUsage())
+            {
+                configuration.IsCached.ShouldBeFalse();
+
+                using (configuration.EnterProjectInstanceUsage())
+                {
+                    Task.Run(configuration.CacheIfPossible).GetAwaiter().GetResult();
+                    configuration.IsCached.ShouldBeFalse();
+                }
+
+                configuration.CacheIfPossible();
+                configuration.IsCached.ShouldBeFalse();
+            }
+
+            configuration.CacheIfPossible();
+            configuration.IsCached.ShouldBeTrue();
+        }
 
         [Fact]
         public void TestProjectEvaluationIdPreservedAcrossTranslateForFutureUse()

--- a/src/Build.UnitTests/BackEnd/BuildRequestConfiguration_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/BuildRequestConfiguration_Tests.cs
@@ -713,6 +713,11 @@ namespace Microsoft.Build.UnitTests.BackEnd
                 {
                     await Task.Run(configuration.CacheIfPossible);
                     configuration.IsCached.ShouldBeFalse();
+
+                    // Caching nulls these out, so assert the project state itself and not just the flag.
+                    instance.GlobalPropertiesDictionary.ShouldNotBeNull();
+                    instance.PropertiesToBuildWith.ShouldNotBeNull();
+                    instance.ItemsToBuildWith.ShouldNotBeNull();
                 }
 
                 configuration.CacheIfPossible();

--- a/src/Build.UnitTests/BackEnd/BuildRequestConfiguration_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/BuildRequestConfiguration_Tests.cs
@@ -676,7 +676,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
         }
 
         [Fact]
-        public void ProjectInstanceUsagePreventsConfigurationCaching()
+        public async Task CacheIfPossible_WhileProjectInstanceUsageIsHeld_DoesNotCache()
         {
             string projectBody = """
                 <Project ToolsVersion='msbuilddefaulttoolsversion' xmlns='msbuildnamespace'>
@@ -684,7 +684,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
                 </Project>
                 """.Cleanup();
 
-            using var collection = new ProjectCollection();
+            ProjectCollection collection = _env.CreateProjectCollection().Collection;
             using ProjectFromString projectFromString = new(
                 projectBody,
                 new Dictionary<string, string>(),
@@ -700,32 +700,39 @@ namespace Microsoft.Build.UnitTests.BackEnd
                 IsCacheable = true,
             };
 
-            try
+            _env.WithTransientTestState(new TransientConfigurationCacheFile(configuration));
+
+            configuration.CacheIfPossible();
+            configuration.IsCached.ShouldBeTrue();
+
+            using (configuration.AcquireProjectInstanceUsage())
             {
-                configuration.CacheIfPossible();
-                configuration.IsCached.ShouldBeTrue();
+                configuration.IsCached.ShouldBeFalse();
 
                 using (configuration.AcquireProjectInstanceUsage())
                 {
-                    configuration.IsCached.ShouldBeFalse();
-
-                    using (configuration.AcquireProjectInstanceUsage())
-                    {
-                        Task.Run(configuration.CacheIfPossible).GetAwaiter().GetResult();
-                        configuration.IsCached.ShouldBeFalse();
-                    }
-
-                    configuration.CacheIfPossible();
+                    await Task.Run(configuration.CacheIfPossible);
                     configuration.IsCached.ShouldBeFalse();
                 }
 
                 configuration.CacheIfPossible();
-                configuration.IsCached.ShouldBeTrue();
+                configuration.IsCached.ShouldBeFalse();
             }
-            finally
+
+            configuration.CacheIfPossible();
+            configuration.IsCached.ShouldBeTrue();
+        }
+
+        private sealed class TransientConfigurationCacheFile : TransientTestState
+        {
+            private readonly BuildRequestConfiguration _configuration;
+
+            internal TransientConfigurationCacheFile(BuildRequestConfiguration configuration)
             {
-                configuration.ClearCacheFile();
+                _configuration = configuration;
             }
+
+            public override void Revert() => _configuration.ClearCacheFile();
         }
 
         [Fact]

--- a/src/Build.UnitTests/BackEnd/BuildRequestConfiguration_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/BuildRequestConfiguration_Tests.cs
@@ -703,11 +703,11 @@ namespace Microsoft.Build.UnitTests.BackEnd
             configuration.CacheIfPossible();
             configuration.IsCached.ShouldBeTrue();
 
-            using (configuration.EnterProjectInstanceUsage())
+            using (configuration.AcquireProjectInstanceUsage())
             {
                 configuration.IsCached.ShouldBeFalse();
 
-                using (configuration.EnterProjectInstanceUsage())
+                using (configuration.AcquireProjectInstanceUsage())
                 {
                     Task.Run(configuration.CacheIfPossible).GetAwaiter().GetResult();
                     configuration.IsCached.ShouldBeFalse();

--- a/src/Build.UnitTests/BackEnd/RequestBuilder_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/RequestBuilder_Tests.cs
@@ -247,6 +247,48 @@ namespace Microsoft.Build.UnitTests.BackEnd
         }
 
         [Fact]
+        public void BuildProject_ConfigurationCacheSweepDuringBuild_DoesNotCacheConfiguration()
+        {
+            BuildRequestConfiguration configuration = CreateTestProject(1);
+            try
+            {
+                TestTargetBuilder targetBuilder = (TestTargetBuilder)_host.GetComponent(BuildComponentType.TargetBuilder);
+                IConfigCache configCache = (IConfigCache)_host.GetComponent(BuildComponentType.ConfigCache);
+
+                configCache.AddConfiguration(configuration);
+
+                BuildRequest request = CreateNewBuildRequest(1, new string[1] { "target1" });
+                BuildRequestEntry entry = new BuildRequestEntry(request, configuration, CreateStubTaskEnvironment());
+                BuildResult result = new BuildResult(request);
+                result.AddResultsForTarget("target1", GetEmptySuccessfulTargetResult());
+                targetBuilder.SetResultsToReturn(result);
+
+                bool? cachedDuringBuild = null;
+
+                // Simulate the BuildRequestEngine memory pressure sweep running on another thread while
+                // the request builder is still using the project instance of the configuration it builds.
+                targetBuilder.ActionBeforeReturningResult = () =>
+                {
+                    Task.Run(() => configCache.WriteConfigurationsToDisk()).GetAwaiter().GetResult();
+                    cachedDuringBuild = configuration.IsCached;
+                };
+
+                _requestBuilder.BuildRequest(GetNodeLoggingContext(), entry);
+
+                WaitForEvent(_buildRequestCompletedEvent, "Build Request Completed");
+
+                cachedDuringBuild.ShouldBe(false);
+                _buildRequestCompleted_Entry.Result.Exception.ShouldBeNull();
+                Assert.Equal(BuildResultCode.Success, _buildRequestCompleted_Entry.Result.OverallResult);
+            }
+            finally
+            {
+                configuration.ClearCacheFile();
+                DeleteTestProject(configuration);
+            }
+        }
+
+        [Fact]
         public void RequestThreadProcEventsIncludeRequestContext()
         {
             using TestEnvironment env = TestEnvironment.Create(_output);
@@ -500,6 +542,12 @@ namespace Microsoft.Build.UnitTests.BackEnd
             _cache.AddResult(result);
         }
 
+        /// <summary>
+        /// Invoked right before the cached result is returned, allowing tests to observe the state
+        /// of the build while the request builder is still building the project.
+        /// </summary>
+        internal Action ActionBeforeReturningResult { get; set; }
+
         internal void SetNewBuildRequests(FullyQualifiedBuildRequest[] requests)
         {
             _newRequests = requests;
@@ -547,8 +595,9 @@ namespace Microsoft.Build.UnitTests.BackEnd
                 }
             }
 
-            return Task<BuildResult>.FromResult(_cache.GetResultForRequest(entry.Request));
-        }
+            ActionBeforeReturningResult?.Invoke();
+
+            return Task<BuildResult>.FromResult(_cache.GetResultForRequest(entry.Request));        }
 
         #endregion
 

--- a/src/Build/BackEnd/Components/BuildRequestEngine/BuildRequestEngine.cs
+++ b/src/Build/BackEnd/Components/BuildRequestEngine/BuildRequestEngine.cs
@@ -382,10 +382,11 @@ namespace Microsoft.Build.BackEnd
                         BuildResult resultToReport = new BuildResult(request, result, null);
                         BuildRequestConfiguration config = ((IConfigCache)_componentHost.GetComponent(BuildComponentType.ConfigCache))[request.ConfigurationId];
 
-                        // Retrieve the config if it has been cached, since this would contain our instance data.  It is safe to do this outside of a lock
-                        // since only one thread can run in the BuildRequestEngine at a time, and it is EvaluateRequestStates which would cause us to
-                        // cache configurations if we are running out of memory.
-                        config.RetrieveFromCache();
+                        // Retrieve the project if it is cached and keep it in memory while preparing the result for
+                        // transfer. Multiple in-proc request engines share the configuration cache, so another engine
+                        // may run a memory-pressure sweep concurrently.
+                        using BuildRequestConfiguration.ProjectInstanceUsageScope projectInstanceUsage =
+                            config.AcquireProjectInstanceUsage();
                         ((IBuildResults)resultToReport).SavedCurrentDirectory = config.SavedCurrentDirectory;
                         ((IBuildResults)resultToReport).SavedEnvironmentVariables = config.SavedEnvironmentVariables;
                         if ((request.BuildRequestDataFlags & BuildRequestDataFlags.IgnoreExistingProjectState) != BuildRequestDataFlags.IgnoreExistingProjectState)

--- a/src/Build/BackEnd/Components/ProjectCache/ProjectCacheService.cs
+++ b/src/Build/BackEnd/Components/ProjectCache/ProjectCacheService.cs
@@ -490,11 +490,9 @@ namespace Microsoft.Build.ProjectCache
                 return false;
             }
 
-            // We need to retrieve the configuration if it's already loaded in order to access the Project property below.
-            if (buildRequestConfiguration.IsCached)
-            {
-                buildRequestConfiguration.RetrieveFromCache();
-            }
+            // Retrieve the project if it is cached and keep it in memory while checking its cache descriptors.
+            using BuildRequestConfiguration.ProjectInstanceUsageScope projectInstanceUsage =
+                buildRequestConfiguration.AcquireProjectInstanceUsage();
 
             // Check if there are any project cache items defined in the project
             return GetProjectCacheDescriptors(buildRequestConfiguration.Project).Any();
@@ -839,15 +837,13 @@ namespace Microsoft.Build.ProjectCache
                 return;
             }
 
-            // If the ProjectInstance was evicted to disk to save memory, restore it before accessing
-            // the Project property below (whose getter asserts !IsCached).
-            if (requestConfiguration.IsCached)
+            List<ProjectCacheDescriptor> projectCacheDescriptors;
+            // Retrieve the project if it is cached and keep it in memory while determining which plugins apply.
+            using (requestConfiguration.AcquireProjectInstanceUsage())
             {
-                requestConfiguration.RetrieveFromCache();
+                projectCacheDescriptors = GetProjectCacheDescriptors(requestConfiguration.Project).ToList();
             }
 
-            // Filter to plugins which apply to the project, if any
-            List<ProjectCacheDescriptor> projectCacheDescriptors = GetProjectCacheDescriptors(requestConfiguration.Project).ToList();
             if (projectCacheDescriptors.Count == 0)
             {
                 return;

--- a/src/Build/BackEnd/Components/ProjectCache/ProjectCacheService.cs
+++ b/src/Build/BackEnd/Components/ProjectCache/ProjectCacheService.cs
@@ -528,6 +528,12 @@ namespace Microsoft.Build.ProjectCache
 
             async ValueTask<(CacheResult Result, int ProjectContextId)> ProcessCacheRequestAsync()
             {
+                // The configuration cache is shared with the in-proc node's BuildRequestEngine, which may run a
+                // memory-pressure sweep on its own thread. Keep the project in memory for this entire operation:
+                // the ProjectInstance below is handed to the plugin and is used until the query completes.
+                using BuildRequestConfiguration.ProjectInstanceUsageScope projectInstanceUsage =
+                    cacheRequest.Configuration.AcquireProjectInstanceUsage();
+
                 EvaluateProjectIfNecessary(cacheRequest.Submission, cacheRequest.Configuration);
 
                 BuildRequestData buildRequest = new BuildRequestData(

--- a/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
@@ -1143,8 +1143,11 @@ namespace Microsoft.Build.BackEnd
         {
             Assumed.NotNull(_targetBuilder, "Target builder is null");
 
+            // MT request engines share the configuration cache. A configuration becomes cacheable after its last
+            // target, but post-build telemetry still accesses its ProjectInstance. Keep the project in memory
+            // for this entire operation so another request cannot cache it during execution.
             using BuildRequestConfiguration.ProjectInstanceUsageScope projectInstanceUsage =
-                _requestEntry.RequestConfiguration.EnterProjectInstanceUsage();
+                _requestEntry.RequestConfiguration.AcquireProjectInstanceUsage();
 
             // We consider this the entrypoint for the project build for purposes of BuildCheck processing
             bool isRestoring = _requestEntry.RequestConfiguration.GlobalProperties[MSBuildConstants.MSBuildIsRestoring] is not null;

--- a/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
@@ -1143,12 +1143,6 @@ namespace Microsoft.Build.BackEnd
         {
             Assumed.NotNull(_targetBuilder, "Target builder is null");
 
-            // MT request engines share the configuration cache. A configuration becomes cacheable after its last
-            // target, but post-build telemetry still accesses its ProjectInstance. Keep the project in memory
-            // for this entire operation so another request cannot cache it during execution.
-            using BuildRequestConfiguration.ProjectInstanceUsageScope projectInstanceUsage =
-                _requestEntry.RequestConfiguration.AcquireProjectInstanceUsage();
-
             // We consider this the entrypoint for the project build for purposes of BuildCheck processing
             bool isRestoring = _requestEntry.RequestConfiguration.GlobalProperties[MSBuildConstants.MSBuildIsRestoring] is not null;
 
@@ -1158,10 +1152,15 @@ namespace Microsoft.Build.BackEnd
 
             buildCheckManager?.SetDataSource(BuildCheckDataSource.BuildExecution);
 
-            // Make sure it is null before loading the configuration into the request, because if there is a problem
-            // we do not wand to have an invalid projectLoggingContext floating around. Also if this is null the error will be
-            // logged with the node logging context
+            // Make sure it is null before loading or restoring the configuration so an invalid context is not reused.
+            // The failure paths below create a temporary project logging context before propagating the error.
             _projectLoggingContext = null;
+
+            // MT request engines share the configuration cache. A configuration becomes cacheable after its last
+            // target, but post-build telemetry still accesses its ProjectInstance. Keep the project in memory
+            // for this entire operation so another request cannot cache it during execution.
+            using BuildRequestConfiguration.ProjectInstanceUsageScope projectInstanceUsage =
+                AcquireProjectInstanceUsageWithProjectLoggingContext();
 
             try
             {
@@ -1198,11 +1197,7 @@ namespace Microsoft.Build.BackEnd
             catch
             {
                 // make sure that any errors thrown by a child project are logged in the context of their parent project: create a temporary projectLoggingContext
-                _projectLoggingContext = new ProjectLoggingContext(
-                    _nodeLoggingContext,
-                    _requestEntry.Request,
-                    _requestEntry.RequestConfiguration.ProjectFullPath,
-                    _requestEntry.RequestConfiguration.ToolsVersion);
+                CreateTemporaryProjectLoggingContext();
 
                 throw;
             }
@@ -1316,6 +1311,28 @@ namespace Microsoft.Build.BackEnd
 
                 return resultFromTargetBuilder;
             }
+        }
+
+        private BuildRequestConfiguration.ProjectInstanceUsageScope AcquireProjectInstanceUsageWithProjectLoggingContext()
+        {
+            try
+            {
+                return _requestEntry.RequestConfiguration.AcquireProjectInstanceUsage();
+            }
+            catch
+            {
+                CreateTemporaryProjectLoggingContext();
+                throw;
+            }
+        }
+
+        private void CreateTemporaryProjectLoggingContext()
+        {
+            _projectLoggingContext = new ProjectLoggingContext(
+                _nodeLoggingContext,
+                _requestEntry.Request,
+                _requestEntry.RequestConfiguration.ProjectFullPath,
+                _requestEntry.RequestConfiguration.ToolsVersion);
         }
 
         private void UpdateStatisticsPostBuild()

--- a/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
@@ -1156,9 +1156,9 @@ namespace Microsoft.Build.BackEnd
             // The failure paths below create a temporary project logging context before propagating the error.
             _projectLoggingContext = null;
 
-            // MT request engines share the configuration cache. A configuration becomes cacheable after its last
-            // target, but post-build telemetry still accesses its ProjectInstance. Keep the project in memory
-            // for this entire operation so another request cannot cache it during execution.
+            // The configuration cache is shared across the node and may be swept for memory pressure on a
+            // BuildRequestEngine thread. A configuration becomes cacheable after its last target, but post-build
+            // telemetry still accesses its ProjectInstance, so keep the project in memory for this entire operation.
             using BuildRequestConfiguration.ProjectInstanceUsageScope projectInstanceUsage =
                 AcquireProjectInstanceUsageWithProjectLoggingContext();
 

--- a/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
@@ -1143,6 +1143,9 @@ namespace Microsoft.Build.BackEnd
         {
             Assumed.NotNull(_targetBuilder, "Target builder is null");
 
+            using BuildRequestConfiguration.ProjectInstanceUsageScope projectInstanceUsage =
+                _requestEntry.RequestConfiguration.EnterProjectInstanceUsage();
+
             // We consider this the entrypoint for the project build for purposes of BuildCheck processing
             bool isRestoring = _requestEntry.RequestConfiguration.GlobalProperties[MSBuildConstants.MSBuildIsRestoring] is not null;
 
@@ -1211,7 +1214,7 @@ namespace Microsoft.Build.BackEnd
             {
                 // Determine the set of targets we need to build
                 (string name, TargetBuiltReason reason)[] allTargets = _requestEntry.RequestConfiguration
-   .GetTargetsUsedToBuildRequest(_requestEntry.Request).ToArray();
+                    .GetTargetsUsedToBuildRequest(_requestEntry.Request).ToArray();
                 if (MSBuildEventSource.Log.IsEnabled())
                 {
                     MSBuildEventSource.Log.BuildProjectStart(_requestEntry.RequestConfiguration.ProjectFullPath, string.Join(", ", allTargets));
@@ -1221,8 +1224,6 @@ namespace Microsoft.Build.BackEnd
                 // Make sure to extract known immutable folders from properties and register them for fast up-to-date check
                 ConfigureKnownImmutableFolders();
 
-                // See comment on Microsoft.Build.Internal.Utilities.GenerateToolsVersionToUse
-                _requestEntry.RequestConfiguration.RetrieveFromCache();
                 if (_requestEntry.RequestConfiguration.Project.UsingDifferentToolsVersionFromProjectFile)
                 {
                     _projectLoggingContext.LogComment(MessageImportance.Low,

--- a/src/Build/BackEnd/Shared/BuildRequestConfiguration.cs
+++ b/src/Build/BackEnd/Shared/BuildRequestConfiguration.cs
@@ -126,6 +126,11 @@ namespace Microsoft.Build.BackEnd
         private Dictionary<string, int> _activelyBuildingTargets;
 
         /// <summary>
+        /// The number of operations currently using the in-memory project state.
+        /// </summary>
+        private int _projectInstanceUsageCount;
+
+        /// <summary>
         /// The node where this configuration's master results are stored.
         /// </summary>
         private int _resultsNodeId = Scheduler.InvalidNodeId;
@@ -640,6 +645,38 @@ namespace Microsoft.Build.BackEnd
                                                                       new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase));
 
         /// <summary>
+        /// Ensures the <see cref="ProjectInstance"/> is available and prevents it from being cached
+        /// until the returned scope is disposed. The synchronization lock is not held for the scope lifetime.
+        /// </summary>
+        internal ProjectInstanceUsageScope EnterProjectInstanceUsage() => new(this);
+
+        internal readonly struct ProjectInstanceUsageScope : IDisposable
+        {
+            private readonly BuildRequestConfiguration _configuration;
+
+            internal ProjectInstanceUsageScope(BuildRequestConfiguration configuration)
+            {
+                _configuration = configuration;
+
+                lock (_configuration._syncLock)
+                {
+                    _configuration.RetrieveFromCache();
+                    Assumed.False(_configuration.IsCached, "Configuration could not be retrieved before accessing the project.");
+                    _configuration._projectInstanceUsageCount++;
+                }
+            }
+
+            public void Dispose()
+            {
+                lock (_configuration._syncLock)
+                {
+                    Assumed.True(_configuration._projectInstanceUsageCount > 0, "No active ProjectInstance usage to complete.");
+                    _configuration._projectInstanceUsageCount--;
+                }
+            }
+        }
+
+        /// <summary>
         /// Holds a snapshot of the environment at the time we blocked.
         /// </summary>
         public FrozenDictionary<string, string> SavedEnvironmentVariables
@@ -725,7 +762,7 @@ namespace Microsoft.Build.BackEnd
         {
             lock (_syncLock)
             {
-                if (IsActivelyBuilding || IsCached || !IsLoaded || !IsCacheable)
+                if (_projectInstanceUsageCount > 0 || IsActivelyBuilding || IsCached || !IsLoaded || !IsCacheable)
                 {
                     return;
                 }

--- a/src/Build/BackEnd/Shared/BuildRequestConfiguration.cs
+++ b/src/Build/BackEnd/Shared/BuildRequestConfiguration.cs
@@ -648,6 +648,10 @@ namespace Microsoft.Build.BackEnd
         /// Keeps the <see cref="ProjectInstance"/> in memory while the caller uses it, preventing a concurrent
         /// memory-pressure cache sweep. Retrieves the project first if it was already cached.
         /// </summary>
+        /// <remarks>
+        /// The usage count belongs to this configuration. A shallow clone that shares the same
+        /// <see cref="ProjectInstance"/> has independent synchronization and usage tracking.
+        /// </remarks>
         internal ProjectInstanceUsageScope AcquireProjectInstanceUsage() => new(this);
 
         /// <summary>
@@ -672,6 +676,8 @@ namespace Microsoft.Build.BackEnd
 
             public void Dispose()
             {
+                Assumed.NotNull(_configuration, "ProjectInstance usage scope was not initialized.");
+
                 lock (_configuration._syncLock)
                 {
                     Assumed.True(_configuration._projectInstanceUsageCount > 0, "No active ProjectInstance usage to complete.");

--- a/src/Build/BackEnd/Shared/BuildRequestConfiguration.cs
+++ b/src/Build/BackEnd/Shared/BuildRequestConfiguration.cs
@@ -645,11 +645,15 @@ namespace Microsoft.Build.BackEnd
                                                                       new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase));
 
         /// <summary>
-        /// Ensures the <see cref="ProjectInstance"/> is available and prevents it from being cached
-        /// until the returned scope is disposed. The synchronization lock is not held for the scope lifetime.
+        /// Keeps the <see cref="ProjectInstance"/> in memory while the caller uses it, preventing a concurrent
+        /// memory-pressure cache sweep. Retrieves the project first if it was already cached.
         /// </summary>
-        internal ProjectInstanceUsageScope EnterProjectInstanceUsage() => new(this);
+        internal ProjectInstanceUsageScope AcquireProjectInstanceUsage() => new(this);
 
+        /// <summary>
+        /// Tracks one active <see cref="ProjectInstance"/> consumer. Consume with <see langword="using"/>;
+        /// do not dispose copies.
+        /// </summary>
         internal readonly struct ProjectInstanceUsageScope : IDisposable
         {
             private readonly BuildRequestConfiguration _configuration;


### PR DESCRIPTION
Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

### Context
Under memory pressure, MSBuild serializes inactive project configurations to disk to reduce memory use.  `CacheIfPossible()`  previously considered a configuration safe to cache once it had no actively executing targets.

In multithreaded mode, multiple request engines run in the same process and share the configuration cache. After a project's last target completed, another request engine could sweep the configuration while the original request was still executing post-build telemetry.  `UpdateStatisticsPostBuild()`  then accessed  `RequestConfiguration.Project` , which fails when the configuration is cached:
```
 MSB0001: Internal MSBuild Error: We shouldn't be accessing the ProjectInstance when the configuration is cached.
```

Traditional multiprocess builds do not normally expose this race because each worker process owns a separate configuration cache, and its memory sweep does not run concurrently in the middle of that request's  `BuildProject()`  execution.

### Changes Made
Add a scoped  `ProjectInstance`  usage counter to  `BuildRequestConfiguration` :

 - Entering the scope retrieves the project if it was previously cached and increments the usage count under the configuration lock.
 -  `CacheIfPossible()`  skips configurations with active project usage.
 - Disposing the scope decrements the count under the same lock.
 - The counter supports nested or overlapping usage.

 `BuildProject()`  holds this scope for its full lifetime, ensuring the project remains available through post-build telemetry.

Why protect the whole  `BuildProject()`  operation?

A narrower set of scopes would leave short intervals where an MT cache sweep could serialize the project, only for the next scope to immediately retrieve it. Protecting the complete operation avoids that unnecessary disk churn.

The memory-retention impact is limited:

 - In MT mode, the potentially long cross-node results-transfer wait is skipped because all thread nodes share the same results cache.
 - Target execution already sets  `IsCacheable = false` , so the long-running portion of  `BuildProject()`  was already protected from caching.
 - In non-MT mode, another request engine cannot concurrently sweep this configuration: other workers have separate caches, and the current engine processes its completion-triggered sweep only after  `BuildProject()`  returns. The scope therefore changes no practical caching behavior there beyond small lock/counter overhead.
 
### Testing
Added unit test `ProjectInstanceUsagePreventsConfigurationCaching`. Unfortunately can not create a deterministic regression test for the error. 

