### PR TITLE
Fix MT switch

### DIFF
--- a/documentation/specs/multithreading/multithreaded-msbuild.md
+++ b/documentation/specs/multithreading/multithreaded-msbuild.md
@@ -305,7 +305,7 @@ When this is a `-mt` (`-multithreaded`) build and `MSBUILDUSESERVER` is unset, M
 | unset | yes | **Yes** | `ImpliedByMt` |
 | unset | no | No | — |
 
-`-mt` is detected from the full, response-file-aware command-line parse, so it counts wherever it is supplied — command line, auto-response file, a project `Directory.Build.rsp`, an `@response` file, or `MSBUILDFORCEMULTITHREADED`. The same value decides whether an engaged server is launched with [Server GC](../../MSBuild-Server.md#garbage-collection).
+`-mt` is detected from the full, response-file-aware command-line parse, so it counts wherever it is supplied — command line, auto-response file, a project `Directory.Build.rsp`, or an `@response` file. `MSBUILDENABLEMULTITHREADED=1` enables the mode by default, while an explicit `-mt:false` disables it. `MSBUILDFORCEMULTITHREADED=1` is authoritative and enables the mode regardless of the command-line value. The resulting value decides whether an engaged server is launched with [Server GC](../../MSBuild-Server.md#garbage-collection).
 
 The proposed resident/transient routing and TaskHost lifetime model are
 specified in [MT Request Routing and TaskHost Ownership](server-taskhost-ownership.md).

--- a/documentation/wiki/MSBuild-Environment-Variables.md
+++ b/documentation/wiki/MSBuild-Environment-Variables.md
@@ -35,7 +35,7 @@ Some of the env variables listed here are unsupported, meaning there is no guara
 - `MSBUILDFORCEINLINETASKFACTORIESOUTOFPROC`
   - Set this to force all inline tasks to run out of process. It is not compatible with custom TaskFactories.
 - `MSBUILDFORCEMULTITHREADED=1`
-  - Force MSBuild to run in multi-threaded mode (using in-proc nodes for parallel build). This overrides the `-multiThreaded` / `-mt` command-line switch.
+  - Force MSBuild to run in multi-threaded mode (using in-proc nodes for parallel build). This overrides and ignores any `-multiThreaded` / `-mt` command-line switch.
 - `MSBUILDENABLEMULTITHREADED=1`
   - Enable multi-threaded mode by default while allowing an explicit `-multiThreaded:false` / `-mt:false` command-line switch to disable it.
 - `MSBUILD_CONSOLE_USE_DEFAULT_ENCODING`

--- a/documentation/wiki/MSBuild-Environment-Variables.md
+++ b/documentation/wiki/MSBuild-Environment-Variables.md
@@ -35,6 +35,8 @@ Some of the env variables listed here are unsupported, meaning there is no guara
 - `MSBUILDFORCEINLINETASKFACTORIESOUTOFPROC`
   - Set this to force all inline tasks to run out of process. It is not compatible with custom TaskFactories.
 - `MSBUILDFORCEMULTITHREADED=1`
-  - Set this to force MSBuild to run in multi-threaded mode (using in-proc nodes for parallel build), equivalent to passing `-multiThreaded` / `-mt` on the command line. Useful for opting in without modifying command lines.
+  - Force MSBuild to run in multi-threaded mode (using in-proc nodes for parallel build). This overrides the `-multiThreaded` / `-mt` command-line switch.
+- `MSBUILDENABLEMULTITHREADED=1`
+  - Enable multi-threaded mode by default while allowing an explicit `-multiThreaded:false` / `-mt:false` command-line switch to disable it.
 - `MSBUILD_CONSOLE_USE_DEFAULT_ENCODING`
   - It opts out automatic console encoding UTF-8. Make Console use default encoding in the system.

--- a/src/Framework/Traits.cs
+++ b/src/Framework/Traits.cs
@@ -46,6 +46,12 @@ namespace Microsoft.Build.Framework
         public readonly bool ForceMultiThreaded = Environment.GetEnvironmentVariable("MSBUILDFORCEMULTITHREADED") == "1";
 
         /// <summary>
+        /// Enable MSBuild multi-threaded mode by default while allowing an explicit
+        /// -multiThreaded:false / -mt:false command-line switch to disable it.
+        /// </summary>
+        public readonly bool EnableMultiThreaded = Environment.GetEnvironmentVariable("MSBUILDENABLEMULTITHREADED") == "1";
+
+        /// <summary>
         /// Do not expand wildcards that match a certain pattern
         /// </summary>
         public readonly bool UseLazyWildCardEvaluation = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("MsBuildSkipEagerWildCardEvaluationRegexes"));

--- a/src/MSBuild.UnitTests/XMake_Tests.cs
+++ b/src/MSBuild.UnitTests/XMake_Tests.cs
@@ -3323,6 +3323,54 @@ EndGlobal
             MSBuildApp.IsMultiThreadedEnabled(switches).ShouldBeTrue();
         }
 
+        [Theory]
+        [InlineData("/mt", null, true)]
+        [InlineData("/mt:true", null, true)]
+        [InlineData("/mt:false", null, false)]
+        [InlineData("/mt:false", "/mt", true)]
+        [InlineData("/mt", "/mt:false", false)]
+        [InlineData("/mt:false", "/mt:true", true)]
+        [InlineData("/mt:true", "/mt:false", false)]
+        public void MultiThreadedSwitchUsesLatestValue(string firstArgument, string secondArgument, bool expected)
+        {
+            using TestEnvironment testEnvironment = TestEnvironment.Create(_output);
+            testEnvironment.SetEnvironmentVariable("MSBUILDFORCEMULTITHREADED", null);
+
+            CommandLineSwitches switches = new CommandLineSwitches();
+            CommandLineParser parser = new CommandLineParser();
+            parser.GatherCommandLineSwitches(
+                secondArgument is null ? [firstArgument] : [firstArgument, secondArgument],
+                switches);
+
+            switches.HaveErrors().ShouldBeFalse();
+            MSBuildApp.IsMultiThreadedEnabled(switches).ShouldBe(expected);
+        }
+
+        [Fact]
+        public void MSBuildForceMultiThreadedEnvironmentVariableOverridesSwitch()
+        {
+            using TestEnvironment testEnvironment = TestEnvironment.Create(_output);
+            testEnvironment.SetEnvironmentVariable("MSBUILDFORCEMULTITHREADED", "1");
+
+            CommandLineSwitches switches = new CommandLineSwitches();
+            CommandLineParser parser = new CommandLineParser();
+            parser.GatherCommandLineSwitches(["/mt:false"], switches);
+
+            MSBuildApp.IsMultiThreadedEnabled(switches).ShouldBeTrue();
+        }
+
+        [Fact]
+        public void MultiThreadedSwitchRejectsInvalidBooleanValue()
+        {
+            CommandLineSwitches switches = new CommandLineSwitches();
+            CommandLineParser parser = new CommandLineParser();
+            parser.GatherCommandLineSwitches(["/mt:invalid"], switches);
+
+            CommandLineSwitchException exception = Should.Throw<CommandLineSwitchException>(
+                () => MSBuildApp.IsMultiThreadedEnabled(switches));
+            exception.Message.ShouldContain("MSB1072");
+        }
+
         [Fact]
         public void MSBuildForceMultiThreadedEnvironmentVariableUnsetDoesNotEnableMultiThreadedMode()
         {

--- a/src/MSBuild.UnitTests/XMake_Tests.cs
+++ b/src/MSBuild.UnitTests/XMake_Tests.cs
@@ -3316,6 +3316,7 @@ EndGlobal
             // even when the -multiThreaded / -mt switch is not passed on the command line.
             using TestEnvironment testEnvironment = TestEnvironment.Create();
             testEnvironment.SetEnvironmentVariable("MSBUILDFORCEMULTITHREADED", "1");
+            testEnvironment.SetEnvironmentVariable("MSBUILDENABLEMULTITHREADED", null);
 
             CommandLineSwitches switches = new CommandLineSwitches();
             switches.IsParameterizedSwitchSet(CommandLineSwitches.ParameterizedSwitch.MultiThreaded).ShouldBeFalse();
@@ -3335,6 +3336,7 @@ EndGlobal
         {
             using TestEnvironment testEnvironment = TestEnvironment.Create(_output);
             testEnvironment.SetEnvironmentVariable("MSBUILDFORCEMULTITHREADED", null);
+            testEnvironment.SetEnvironmentVariable("MSBUILDENABLEMULTITHREADED", null);
 
             CommandLineSwitches switches = new CommandLineSwitches();
             CommandLineParser parser = new CommandLineParser();
@@ -3351,6 +3353,7 @@ EndGlobal
         {
             using TestEnvironment testEnvironment = TestEnvironment.Create(_output);
             testEnvironment.SetEnvironmentVariable("MSBUILDFORCEMULTITHREADED", "1");
+            testEnvironment.SetEnvironmentVariable("MSBUILDENABLEMULTITHREADED", null);
 
             CommandLineSwitches switches = new CommandLineSwitches();
             CommandLineParser parser = new CommandLineParser();
@@ -3360,8 +3363,66 @@ EndGlobal
         }
 
         [Fact]
+        public void MSBuildEnableMultiThreadedEnvironmentVariableEnablesMultiThreadedModeByDefault()
+        {
+            using TestEnvironment testEnvironment = TestEnvironment.Create(_output);
+            testEnvironment.SetEnvironmentVariable("MSBUILDFORCEMULTITHREADED", null);
+            testEnvironment.SetEnvironmentVariable("MSBUILDENABLEMULTITHREADED", "1");
+
+            MSBuildApp.IsMultiThreadedEnabled(new CommandLineSwitches()).ShouldBeTrue();
+        }
+
+        [Fact]
+        public void MultiThreadedSwitchOverridesEnableEnvironmentVariable()
+        {
+            using TestEnvironment testEnvironment = TestEnvironment.Create(_output);
+            testEnvironment.SetEnvironmentVariable("MSBUILDFORCEMULTITHREADED", null);
+            testEnvironment.SetEnvironmentVariable("MSBUILDENABLEMULTITHREADED", "1");
+
+            CommandLineSwitches switches = new CommandLineSwitches();
+            CommandLineParser parser = new CommandLineParser();
+            parser.GatherCommandLineSwitches(["/mt:false"], switches);
+
+            MSBuildApp.IsMultiThreadedEnabled(switches).ShouldBeFalse();
+        }
+
+        [Theory]
+        // Auto-response-file value, command-line value, expected result. The command line has higher
+        // priority, so its value must win regardless of what the response file supplied.
+        [InlineData("/mt", "/mt:false", false)]
+        [InlineData("/mt:true", "/mt:false", false)]
+        [InlineData("/mt:false", "/mt", true)]
+        [InlineData("/mt:false", "/mt:true", true)]
+        public void MultiThreadedSwitchFromCommandLineWinsOverResponseFile(string responseFileArgument, string commandLineArgument, bool expected)
+        {
+            using TestEnvironment testEnvironment = TestEnvironment.Create(_output);
+            testEnvironment.SetEnvironmentVariable("MSBUILDFORCEMULTITHREADED", null);
+            testEnvironment.SetEnvironmentVariable("MSBUILDENABLEMULTITHREADED", null);
+
+            CommandLineParser parser = new CommandLineParser();
+
+            CommandLineSwitches switchesFromAutoResponseFile = new CommandLineSwitches();
+            parser.GatherCommandLineSwitches([responseFileArgument], switchesFromAutoResponseFile);
+
+            CommandLineSwitches switchesNotFromAutoResponseFile = new CommandLineSwitches();
+            parser.GatherCommandLineSwitches([commandLineArgument], switchesNotFromAutoResponseFile);
+
+            // Uses the production merge so a regression in response-file priority is caught here.
+            CommandLineSwitches combined = MSBuildApp.CombineSwitchesRespectingPriority(
+                switchesFromAutoResponseFile,
+                switchesNotFromAutoResponseFile,
+                string.Empty);
+
+            MSBuildApp.IsMultiThreadedEnabled(combined).ShouldBe(expected);
+        }
+
+        [Fact]
         public void MultiThreadedSwitchRejectsInvalidBooleanValue()
         {
+            using TestEnvironment testEnvironment = TestEnvironment.Create(_output);
+            testEnvironment.SetEnvironmentVariable("MSBUILDFORCEMULTITHREADED", null);
+            testEnvironment.SetEnvironmentVariable("MSBUILDENABLEMULTITHREADED", null);
+
             CommandLineSwitches switches = new CommandLineSwitches();
             CommandLineParser parser = new CommandLineParser();
             parser.GatherCommandLineSwitches(["/mt:invalid"], switches);
@@ -3377,6 +3438,7 @@ EndGlobal
             // When the env var is not set and the switch is not passed, IsMultiThreadedEnabled should return false.
             using TestEnvironment testEnvironment = TestEnvironment.Create();
             testEnvironment.SetEnvironmentVariable("MSBUILDFORCEMULTITHREADED", null);
+            testEnvironment.SetEnvironmentVariable("MSBUILDENABLEMULTITHREADED", null);
 
             CommandLineSwitches switches = new CommandLineSwitches();
             MSBuildApp.IsMultiThreadedEnabled(switches).ShouldBeFalse();
@@ -3388,6 +3450,7 @@ EndGlobal
             // The env var is only honored when set to exactly "1", matching other MSBUILDFORCE* flags.
             using TestEnvironment testEnvironment = TestEnvironment.Create();
             testEnvironment.SetEnvironmentVariable("MSBUILDFORCEMULTITHREADED", "true");
+            testEnvironment.SetEnvironmentVariable("MSBUILDENABLEMULTITHREADED", null);
 
             CommandLineSwitches switches = new CommandLineSwitches();
             MSBuildApp.IsMultiThreadedEnabled(switches).ShouldBeFalse();

--- a/src/MSBuild/CommandLine/CommandLineParser.cs
+++ b/src/MSBuild/CommandLine/CommandLineParser.cs
@@ -274,9 +274,9 @@ namespace Microsoft.Build.CommandLine.Experimental
                             }
                         }
 
-                        // Special case: for the switches "/m" (or "/maxCpuCount") and "/bl" (or "/binarylogger") we wish to pretend we saw a default argument
-                        // This allows a subsequent /m:n on the command line to override it.
-                        // We could create a new kind of switch with optional parameters, but it's a great deal of churn for this single case.
+                        // Special case: for switches with an optional parameter, pretend we saw their default argument.
+                        // This allows a subsequent explicit value on the command line to override it.
+                        // We could create a new kind of switch with optional parameters, but it would cause significant churn.
                         // Note that if no "/m" or "/maxCpuCount" switch -- either with or without parameters -- is present, then we still default to 1 cpu
                         // for backwards compatibility.
                         if (string.IsNullOrEmpty(switchParameters))
@@ -298,6 +298,11 @@ namespace Microsoft.Build.CommandLine.Experimental
                                      string.Equals(switchName, "profileevaluation", StringComparison.OrdinalIgnoreCase))
                             {
                                 switchParameters = ":no-file";
+                            }
+                            else if (string.Equals(switchName, "mt", StringComparison.OrdinalIgnoreCase) ||
+                                     string.Equals(switchName, "multithreaded", StringComparison.OrdinalIgnoreCase))
+                            {
+                                switchParameters = ":true";
                             }
                         }
 

--- a/src/MSBuild/Resources/Strings.resx
+++ b/src/MSBuild/Resources/Strings.resx
@@ -627,7 +627,7 @@
     </comment>
   </data>
   <data name="HelpMessage_49_MultiThreadedSwitch" xml:space="preserve">
-    <value>  -multithreaded
+    <value>  -multithreaded[:true|false]
                      Enables EXPERIMENTAL multi-threaded mode in MSBuild.
                      This means that MSBuild will use multiple threads
                      to build projects in parallel,
@@ -1495,6 +1495,15 @@
       LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </comment>
   </data>
+  <data name="InvalidMultiThreadedValue" xml:space="preserve">
+    <value>MSBUILD : error MSB1072: Multi-threaded mode value is not valid. {0}</value>
+    <comment>
+      {StrBegin="MSBUILD : error MSB1072: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies a value for the -multithreaded parameter that is not equivalent to Boolean.TrueString or Boolean.FalseString.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </comment>
+  </data>
   <data name="InvalidIsolateProjectsValue" xml:space="preserve">
     <value>MSBUILD : error MSB1056: Isolate projects value is not valid. {0}</value>
     <comment>
@@ -1828,7 +1837,7 @@
     <!--
         The command line message bucket is: MSB1001 - MSB1999
 
-        Next error code should be MSB1072.
+        Next error code should be MSB1073.
 
         Don't forget to update this comment after using the new code.
   -->

--- a/src/MSBuild/Resources/xlf/Strings.cs.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.cs.xlf
@@ -241,7 +241,7 @@
     </note>
       </trans-unit>
       <trans-unit id="HelpMessage_49_MultiThreadedSwitch">
-        <source>  -multithreaded
+        <source>  -multithreaded[:true|false]
                      Enables EXPERIMENTAL multi-threaded mode in MSBuild.
                      This means that MSBuild will use multiple threads
                      to build projects in parallel,
@@ -254,7 +254,7 @@
                      maxCpuCount cannot be greater than 256.
                      (Short form: -mt)
     </source>
-        <target state="translated">  -multithreaded
+        <target state="needs-review-translation">  -multithreaded
                      Povolí experimentální vícevláknový režim v nástroji MSBuild.
                      To znamená, že nástroj MSBuild bude používat více vláken
                      k paralelnímu sestavování projektů
@@ -312,6 +312,16 @@
       {StrBegin="MSBUILD : error MSB1064: "}
       UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
       This error is shown when a user specifies a value for the lowPriority parameter that is not equivalent to Boolean.TrueString or Boolean.FalseString.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidMultiThreadedValue">
+        <source>MSBUILD : error MSB1072: Multi-threaded mode value is not valid. {0}</source>
+        <target state="new">MSBUILD : error MSB1072: Multi-threaded mode value is not valid. {0}</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1072: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies a value for the -multithreaded parameter that is not equivalent to Boolean.TrueString or Boolean.FalseString.
       LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </note>
       </trans-unit>

--- a/src/MSBuild/Resources/xlf/Strings.de.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.de.xlf
@@ -241,7 +241,7 @@
     </note>
       </trans-unit>
       <trans-unit id="HelpMessage_49_MultiThreadedSwitch">
-        <source>  -multithreaded
+        <source>  -multithreaded[:true|false]
                      Enables EXPERIMENTAL multi-threaded mode in MSBuild.
                      This means that MSBuild will use multiple threads
                      to build projects in parallel,
@@ -254,7 +254,7 @@
                      maxCpuCount cannot be greater than 256.
                      (Short form: -mt)
     </source>
-        <target state="translated">  -multithreaded
+        <target state="needs-review-translation">  -multithreaded
                      Aktiviert den EXPERIMENTELLEN Multithreadmodus in MSBuild.
                      Dies bedeutet, dass MSBuild mehrere Threads verwendet,
                      um Projekte parallel zu erstellen,
@@ -312,6 +312,16 @@
       {StrBegin="MSBUILD : error MSB1064: "}
       UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
       This error is shown when a user specifies a value for the lowPriority parameter that is not equivalent to Boolean.TrueString or Boolean.FalseString.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidMultiThreadedValue">
+        <source>MSBUILD : error MSB1072: Multi-threaded mode value is not valid. {0}</source>
+        <target state="new">MSBUILD : error MSB1072: Multi-threaded mode value is not valid. {0}</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1072: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies a value for the -multithreaded parameter that is not equivalent to Boolean.TrueString or Boolean.FalseString.
       LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </note>
       </trans-unit>

--- a/src/MSBuild/Resources/xlf/Strings.es.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.es.xlf
@@ -240,7 +240,7 @@ Esta marca es experimental y puede que no funcione según lo previsto.
     </note>
       </trans-unit>
       <trans-unit id="HelpMessage_49_MultiThreadedSwitch">
-        <source>  -multithreaded
+        <source>  -multithreaded[:true|false]
                      Enables EXPERIMENTAL multi-threaded mode in MSBuild.
                      This means that MSBuild will use multiple threads
                      to build projects in parallel,
@@ -253,7 +253,7 @@ Esta marca es experimental y puede que no funcione según lo previsto.
                      maxCpuCount cannot be greater than 256.
                      (Short form: -mt)
     </source>
-        <target state="translated">  -multithreaded
+        <target state="needs-review-translation">  -multithreaded
                      Habilita el modo multiproceso EXPERIMENTAL en MSBuild.
                      Esto significa que MSBuild usará varios subprocesos
                      para compilar proyectos en paralelo,
@@ -311,6 +311,16 @@ Esta marca es experimental y puede que no funcione según lo previsto.
       {StrBegin="MSBUILD : error MSB1064: "}
       UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
       This error is shown when a user specifies a value for the lowPriority parameter that is not equivalent to Boolean.TrueString or Boolean.FalseString.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidMultiThreadedValue">
+        <source>MSBUILD : error MSB1072: Multi-threaded mode value is not valid. {0}</source>
+        <target state="new">MSBUILD : error MSB1072: Multi-threaded mode value is not valid. {0}</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1072: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies a value for the -multithreaded parameter that is not equivalent to Boolean.TrueString or Boolean.FalseString.
       LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </note>
       </trans-unit>

--- a/src/MSBuild/Resources/xlf/Strings.fr.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.fr.xlf
@@ -241,7 +241,7 @@ futures
     </note>
       </trans-unit>
       <trans-unit id="HelpMessage_49_MultiThreadedSwitch">
-        <source>  -multithreaded
+        <source>  -multithreaded[:true|false]
                      Enables EXPERIMENTAL multi-threaded mode in MSBuild.
                      This means that MSBuild will use multiple threads
                      to build projects in parallel,
@@ -254,7 +254,7 @@ futures
                      maxCpuCount cannot be greater than 256.
                      (Short form: -mt)
     </source>
-        <target state="translated">  -multithread
+        <target state="needs-review-translation">  -multithread
                      Active le mode EXPERIMENTAL multithread dans MSBuild.
                      Cela signifie que MSBuild utilisera plusieurs threads
                      pour générer des projets en parallèle,
@@ -312,6 +312,16 @@ futures
       {StrBegin="MSBUILD : error MSB1064: "}
       UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
       This error is shown when a user specifies a value for the lowPriority parameter that is not equivalent to Boolean.TrueString or Boolean.FalseString.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidMultiThreadedValue">
+        <source>MSBUILD : error MSB1072: Multi-threaded mode value is not valid. {0}</source>
+        <target state="new">MSBUILD : error MSB1072: Multi-threaded mode value is not valid. {0}</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1072: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies a value for the -multithreaded parameter that is not equivalent to Boolean.TrueString or Boolean.FalseString.
       LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </note>
       </trans-unit>

--- a/src/MSBuild/Resources/xlf/Strings.it.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.it.xlf
@@ -241,7 +241,7 @@ Questo flag è sperimentale e potrebbe non funzionare come previsto.
     </note>
       </trans-unit>
       <trans-unit id="HelpMessage_49_MultiThreadedSwitch">
-        <source>  -multithreaded
+        <source>  -multithreaded[:true|false]
                      Enables EXPERIMENTAL multi-threaded mode in MSBuild.
                      This means that MSBuild will use multiple threads
                      to build projects in parallel,
@@ -254,7 +254,7 @@ Questo flag è sperimentale e potrebbe non funzionare come previsto.
                      maxCpuCount cannot be greater than 256.
                      (Short form: -mt)
     </source>
-        <target state="translated">  -multithreading
+        <target state="needs-review-translation">  -multithreading
                      Abilitare la modalità multithread SPERIMENTALE in MSBuild.
                      Ciò significa che MSBuild userà più thread
                      per creare progetti in parallelo,
@@ -312,6 +312,16 @@ Questo flag è sperimentale e potrebbe non funzionare come previsto.
       {StrBegin="MSBUILD : error MSB1064: "}
       UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
       This error is shown when a user specifies a value for the lowPriority parameter that is not equivalent to Boolean.TrueString or Boolean.FalseString.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidMultiThreadedValue">
+        <source>MSBUILD : error MSB1072: Multi-threaded mode value is not valid. {0}</source>
+        <target state="new">MSBUILD : error MSB1072: Multi-threaded mode value is not valid. {0}</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1072: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies a value for the -multithreaded parameter that is not equivalent to Boolean.TrueString or Boolean.FalseString.
       LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </note>
       </trans-unit>

--- a/src/MSBuild/Resources/xlf/Strings.ja.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.ja.xlf
@@ -241,7 +241,7 @@
     </note>
       </trans-unit>
       <trans-unit id="HelpMessage_49_MultiThreadedSwitch">
-        <source>  -multithreaded
+        <source>  -multithreaded[:true|false]
                      Enables EXPERIMENTAL multi-threaded mode in MSBuild.
                      This means that MSBuild will use multiple threads
                      to build projects in parallel,
@@ -254,7 +254,7 @@
                      maxCpuCount cannot be greater than 256.
                      (Short form: -mt)
     </source>
-        <target state="translated">  -multithreaded
+        <target state="needs-review-translation">  -multithreaded
                      MSBuild で試験的なマルチスレッド モードを有効にします。
                      つまり、MSBuild は複数のプロセスではなく、
                      複数のスレッドを使用してプロジェクトを
@@ -312,6 +312,16 @@
       {StrBegin="MSBUILD : error MSB1064: "}
       UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
       This error is shown when a user specifies a value for the lowPriority parameter that is not equivalent to Boolean.TrueString or Boolean.FalseString.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidMultiThreadedValue">
+        <source>MSBUILD : error MSB1072: Multi-threaded mode value is not valid. {0}</source>
+        <target state="new">MSBUILD : error MSB1072: Multi-threaded mode value is not valid. {0}</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1072: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies a value for the -multithreaded parameter that is not equivalent to Boolean.TrueString or Boolean.FalseString.
       LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </note>
       </trans-unit>

--- a/src/MSBuild/Resources/xlf/Strings.ko.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.ko.xlf
@@ -241,7 +241,7 @@
     </note>
       </trans-unit>
       <trans-unit id="HelpMessage_49_MultiThreadedSwitch">
-        <source>  -multithreaded
+        <source>  -multithreaded[:true|false]
                      Enables EXPERIMENTAL multi-threaded mode in MSBuild.
                      This means that MSBuild will use multiple threads
                      to build projects in parallel,
@@ -254,7 +254,7 @@
                      maxCpuCount cannot be greater than 256.
                      (Short form: -mt)
     </source>
-        <target state="translated">  -multithreaded
+        <target state="needs-review-translation">  -multithreaded
                      MSBuild에서 실험적 다중 스레드 모드를 활성화합니다.
                      즉, MSBuild는 여러 스레드를 사용하여
                      프로젝트를 병렬로 빌드합니다.
@@ -313,6 +313,16 @@
       {StrBegin="MSBUILD : error MSB1064: "}
       UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
       This error is shown when a user specifies a value for the lowPriority parameter that is not equivalent to Boolean.TrueString or Boolean.FalseString.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidMultiThreadedValue">
+        <source>MSBUILD : error MSB1072: Multi-threaded mode value is not valid. {0}</source>
+        <target state="new">MSBUILD : error MSB1072: Multi-threaded mode value is not valid. {0}</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1072: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies a value for the -multithreaded parameter that is not equivalent to Boolean.TrueString or Boolean.FalseString.
       LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </note>
       </trans-unit>

--- a/src/MSBuild/Resources/xlf/Strings.pl.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.pl.xlf
@@ -240,7 +240,7 @@ Ta flaga jest eksperymentalna i może nie działać zgodnie z oczekiwaniami.
     </note>
       </trans-unit>
       <trans-unit id="HelpMessage_49_MultiThreadedSwitch">
-        <source>  -multithreaded
+        <source>  -multithreaded[:true|false]
                      Enables EXPERIMENTAL multi-threaded mode in MSBuild.
                      This means that MSBuild will use multiple threads
                      to build projects in parallel,
@@ -253,7 +253,7 @@ Ta flaga jest eksperymentalna i może nie działać zgodnie z oczekiwaniami.
                      maxCpuCount cannot be greater than 256.
                      (Short form: -mt)
     </source>
-        <target state="translated">  -multithreaded
+        <target state="needs-review-translation">  -multithreaded
                      Włącza tryb EKSPERYMENTALNY wielowątkowości w programie MSBuild.
                      Oznacza to, że program MSBuild będzie używać wielu wątków
                      do równoległego kompilowania projektów,
@@ -311,6 +311,16 @@ Ta flaga jest eksperymentalna i może nie działać zgodnie z oczekiwaniami.
       {StrBegin="MSBUILD : error MSB1064: "}
       UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
       This error is shown when a user specifies a value for the lowPriority parameter that is not equivalent to Boolean.TrueString or Boolean.FalseString.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidMultiThreadedValue">
+        <source>MSBUILD : error MSB1072: Multi-threaded mode value is not valid. {0}</source>
+        <target state="new">MSBUILD : error MSB1072: Multi-threaded mode value is not valid. {0}</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1072: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies a value for the -multithreaded parameter that is not equivalent to Boolean.TrueString or Boolean.FalseString.
       LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </note>
       </trans-unit>

--- a/src/MSBuild/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.pt-BR.xlf
@@ -240,7 +240,7 @@
     </note>
       </trans-unit>
       <trans-unit id="HelpMessage_49_MultiThreadedSwitch">
-        <source>  -multithreaded
+        <source>  -multithreaded[:true|false]
                      Enables EXPERIMENTAL multi-threaded mode in MSBuild.
                      This means that MSBuild will use multiple threads
                      to build projects in parallel,
@@ -253,7 +253,7 @@
                      maxCpuCount cannot be greater than 256.
                      (Short form: -mt)
     </source>
-        <target state="translated">  -multithreaded
+        <target state="needs-review-translation">  -multithreaded
                      Habilita o modo multithread EXPERIMENTAL no MSBuild.
                      Isso significa que o MSBuild usará vários threads
                      para criar projetos em paralelo,
@@ -311,6 +311,16 @@
       {StrBegin="MSBUILD : error MSB1064: "}
       UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
       This error is shown when a user specifies a value for the lowPriority parameter that is not equivalent to Boolean.TrueString or Boolean.FalseString.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidMultiThreadedValue">
+        <source>MSBUILD : error MSB1072: Multi-threaded mode value is not valid. {0}</source>
+        <target state="new">MSBUILD : error MSB1072: Multi-threaded mode value is not valid. {0}</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1072: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies a value for the -multithreaded parameter that is not equivalent to Boolean.TrueString or Boolean.FalseString.
       LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </note>
       </trans-unit>

--- a/src/MSBuild/Resources/xlf/Strings.ru.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.ru.xlf
@@ -240,7 +240,7 @@
     </note>
       </trans-unit>
       <trans-unit id="HelpMessage_49_MultiThreadedSwitch">
-        <source>  -multithreaded
+        <source>  -multithreaded[:true|false]
                      Enables EXPERIMENTAL multi-threaded mode in MSBuild.
                      This means that MSBuild will use multiple threads
                      to build projects in parallel,
@@ -253,7 +253,7 @@
                      maxCpuCount cannot be greater than 256.
                      (Short form: -mt)
     </source>
-        <target state="translated">  -multithreaded
+        <target state="needs-review-translation">  -multithreaded
                      Включает ЭКСПЕРИМЕНТАЛЬНЫЙ многопоточный режим в MSBuild.
                      Это означает, что MSBuild будет использовать несколько потоков
                      для параллельной сборки проектов
@@ -311,6 +311,16 @@
       {StrBegin="MSBUILD : error MSB1064: "}
       UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
       This error is shown when a user specifies a value for the lowPriority parameter that is not equivalent to Boolean.TrueString or Boolean.FalseString.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidMultiThreadedValue">
+        <source>MSBUILD : error MSB1072: Multi-threaded mode value is not valid. {0}</source>
+        <target state="new">MSBUILD : error MSB1072: Multi-threaded mode value is not valid. {0}</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1072: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies a value for the -multithreaded parameter that is not equivalent to Boolean.TrueString or Boolean.FalseString.
       LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </note>
       </trans-unit>

--- a/src/MSBuild/Resources/xlf/Strings.tr.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.tr.xlf
@@ -240,7 +240,7 @@
     </note>
       </trans-unit>
       <trans-unit id="HelpMessage_49_MultiThreadedSwitch">
-        <source>  -multithreaded
+        <source>  -multithreaded[:true|false]
                      Enables EXPERIMENTAL multi-threaded mode in MSBuild.
                      This means that MSBuild will use multiple threads
                      to build projects in parallel,
@@ -253,7 +253,7 @@
                      maxCpuCount cannot be greater than 256.
                      (Short form: -mt)
     </source>
-        <target state="translated">  -çok iş parçacıklı
+        <target state="needs-review-translation">  -çok iş parçacıklı
                      MSBuild’de DENEYSEL çok iş parçacıklı modu etkinleştirir.
                      Bu, MSBuild’in
                      projeleri işlemek için birden çok iş parçacığı kullanacağı,
@@ -311,6 +311,16 @@
       {StrBegin="MSBUILD : error MSB1064: "}
       UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
       This error is shown when a user specifies a value for the lowPriority parameter that is not equivalent to Boolean.TrueString or Boolean.FalseString.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidMultiThreadedValue">
+        <source>MSBUILD : error MSB1072: Multi-threaded mode value is not valid. {0}</source>
+        <target state="new">MSBUILD : error MSB1072: Multi-threaded mode value is not valid. {0}</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1072: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies a value for the -multithreaded parameter that is not equivalent to Boolean.TrueString or Boolean.FalseString.
       LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </note>
       </trans-unit>

--- a/src/MSBuild/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.zh-Hans.xlf
@@ -240,7 +240,7 @@
     </note>
       </trans-unit>
       <trans-unit id="HelpMessage_49_MultiThreadedSwitch">
-        <source>  -multithreaded
+        <source>  -multithreaded[:true|false]
                      Enables EXPERIMENTAL multi-threaded mode in MSBuild.
                      This means that MSBuild will use multiple threads
                      to build projects in parallel,
@@ -253,7 +253,7 @@
                      maxCpuCount cannot be greater than 256.
                      (Short form: -mt)
     </source>
-        <target state="translated">  -multithreaded
+        <target state="needs-review-translation">  -multithreaded
                      在 MSBuild 中启用实验性多线程模式。
                      这意味着 MSBuild 将使用多个线程
                      并行构建项目，
@@ -312,6 +312,16 @@
       {StrBegin="MSBUILD : error MSB1064: "}
       UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
       This error is shown when a user specifies a value for the lowPriority parameter that is not equivalent to Boolean.TrueString or Boolean.FalseString.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidMultiThreadedValue">
+        <source>MSBUILD : error MSB1072: Multi-threaded mode value is not valid. {0}</source>
+        <target state="new">MSBUILD : error MSB1072: Multi-threaded mode value is not valid. {0}</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1072: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies a value for the -multithreaded parameter that is not equivalent to Boolean.TrueString or Boolean.FalseString.
       LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </note>
       </trans-unit>

--- a/src/MSBuild/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.zh-Hant.xlf
@@ -241,7 +241,7 @@
     </note>
       </trans-unit>
       <trans-unit id="HelpMessage_49_MultiThreadedSwitch">
-        <source>  -multithreaded
+        <source>  -multithreaded[:true|false]
                      Enables EXPERIMENTAL multi-threaded mode in MSBuild.
                      This means that MSBuild will use multiple threads
                      to build projects in parallel,
@@ -254,7 +254,7 @@
                      maxCpuCount cannot be greater than 256.
                      (Short form: -mt)
     </source>
-        <target state="translated">  -multithreaded
+        <target state="needs-review-translation">  -multithreaded
                      在 MSBuild 中啟用實驗性多執行緒模式。
                      這表示 MSBuild 將使用多個執行緒
                      來平行建置專案，
@@ -312,6 +312,16 @@
       {StrBegin="MSBUILD : error MSB1064: "}
       UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
       This error is shown when a user specifies a value for the lowPriority parameter that is not equivalent to Boolean.TrueString or Boolean.FalseString.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidMultiThreadedValue">
+        <source>MSBUILD : error MSB1072: Multi-threaded mode value is not valid. {0}</source>
+        <target state="new">MSBUILD : error MSB1072: Multi-threaded mode value is not valid. {0}</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1072: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies a value for the -multithreaded parameter that is not equivalent to Boolean.TrueString or Boolean.FalseString.
       LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </note>
       </trans-unit>

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -2763,13 +2763,21 @@ namespace Microsoft.Build.CommandLine
         internal static bool IsMultiThreadedEnabled(CommandLineSwitches commandLineSwitches)
         {
             // Allow forcing multi-threaded mode via an environment variable, for example to opt in
-            // without modifying command lines (parallel to MSBUILDDISABLENODEREUSE for /nodeReuse).
+            // without modifying command lines.
             if (Traits.Instance.ForceMultiThreaded)
             {
                 return true;
             }
 
-            return commandLineSwitches.IsParameterizedSwitchSet(CommandLineSwitches.ParameterizedSwitch.MultiThreaded);
+            if (commandLineSwitches.IsParameterizedSwitchSet(CommandLineSwitches.ParameterizedSwitch.MultiThreaded))
+            {
+                return ProcessBooleanSwitch(
+                    commandLineSwitches[CommandLineSwitches.ParameterizedSwitch.MultiThreaded],
+                    defaultValue: true,
+                    resourceName: "InvalidMultiThreadedValue");
+            }
+
+            return false;
         }
 
         private static bool ProcessTerminalLoggerConfiguration(CommandLineSwitches commandLineSwitches, out string aggregatedParameters)

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -313,7 +313,7 @@ namespace Microsoft.Build.CommandLine
             // Perform the single authoritative command-line parse for this process. It yields:
             //   - canRunServer: whether the command line is compatible with hosting the build on the server;
             //   - multiThreaded: the response-file-aware /mt determination (includes the auto-response file,
-            //     any project Directory.Build.rsp, @response files, and MSBUILDFORCEMULTITHREADED);
+            //     any project Directory.Build.rsp, @response files, and the multi-threading environment variables);
             //   - shutdownServerAfterBuild: whether the server must tear itself down after this build;
             //   - the gathered switches, which the in-proc build path below reuses so it does not re-parse.
             bool canRunServer = CanRunServerBasedOnCommandLineSwitches(
@@ -388,7 +388,7 @@ namespace Microsoft.Build.CommandLine
         /// <param name="commandLine">Raw command-line arguments.</param>
         /// <param name="multiThreaded">Set to whether this is a multithreaded (/mt) build, determined from
         /// the fully-parsed switches (which expand response files - including any project <c>Directory.Build.rsp</c> -
-        /// and honor MSBUILDFORCEMULTITHREADED) using the same logic as the in-proc build path.</param>
+        /// and honor the multi-threading environment variables) using the same logic as the in-proc build path.</param>
         /// <param name="shutdownServerAfterBuild">Set to <see langword="true"/> when the server should tear itself
         /// down after this build instead of staying resident for reuse.</param>
         /// <param name="switchesFromAutoResponseFile">The gathered response-file switches (auto-response file plus any
@@ -2762,8 +2762,7 @@ namespace Microsoft.Build.CommandLine
 
         internal static bool IsMultiThreadedEnabled(CommandLineSwitches commandLineSwitches)
         {
-            // Allow forcing multi-threaded mode via an environment variable, for example to opt in
-            // without modifying command lines.
+            // MSBUILDFORCEMULTITHREADED is authoritative: it wins over an explicit -mt:false.
             if (Traits.Instance.ForceMultiThreaded)
             {
                 return true;
@@ -2777,7 +2776,7 @@ namespace Microsoft.Build.CommandLine
                     resourceName: "InvalidMultiThreadedValue");
             }
 
-            return false;
+            return Traits.Instance.EnableMultiThreaded;
         }
 
         private static bool ProcessTerminalLoggerConfiguration(CommandLineSwitches commandLineSwitches, out string aggregatedParameters)
@@ -3018,7 +3017,7 @@ namespace Microsoft.Build.CommandLine
             return automatedEnvironmentVariables.Any(envVar => !string.IsNullOrEmpty(Environment.GetEnvironmentVariable(envVar)));
         }
 
-        private static CommandLineSwitches CombineSwitchesRespectingPriority(CommandLineSwitches switchesFromAutoResponseFile, CommandLineSwitches switchesNotFromAutoResponseFile, string commandLine)
+        internal static CommandLineSwitches CombineSwitchesRespectingPriority(CommandLineSwitches switchesFromAutoResponseFile, CommandLineSwitches switchesNotFromAutoResponseFile, string commandLine)
         {
             // combine the auto-response file switches with the command line switches in a left-to-right manner, where the
             // auto-response file switches are on the left (default options), and the command line switches are on the


### PR DESCRIPTION
### Context
 `-multiThreaded`  /  `-mt`  was a presence-only switch: any occurrence turned multi-threaded mode on, and there was no way to turn it back off. That blocks turning MT on by default later, because users would have no opt-out — including anyone who inherits  `-mt`  from an auto-response file or a repo's  `Directory.Build.rsp` . It also meant  `-mt:false`  silently enabled MT, the opposite of what it reads like.

 MSBUILDFORCEMULTITHREADED=1  was the only environment opt-in, and it was documented as "equivalent to passing  -mt ". Once the switch can express  false , "equivalent to  -mt " and "force" are two different things and need two different knobs.

### Changes Made

1. `-mt`  is now a real boolean switch: `-mt`  and  `-mt:true`  enable;  `-mt:false`  disables. Repeated occurrences take the last value, matching  `-nodeReuse`  and  `-m` . This holds across response files as well: the command line beats the auto-response file and  `Directory.Build.rsp` .

2. Now we have two environment variables with distinct meanings
MSBUILDFORCEMULTITHREADED=1  is Authoritative — forces MT on  
MSBUILDENABLEMULTITHREADED=1 is Soft default — MT on unless told otherwise 

Resulting precedence: force env var → last  -mt  value → enable env var → off.

### Testing
New unit tests
