### PR TITLE
Prototype evaluation dependency observation

### DIFF
--- a/documentation/specs/proposed/evaluation-observation-layer-design-details.md
+++ b/documentation/specs/proposed/evaluation-observation-layer-design-details.md
@@ -1,0 +1,1028 @@
+# Evaluation observation layer technical reference
+
+Status: proposed
+
+Prototype: [dotnet/msbuild#14689](https://github.com/dotnet/msbuild/pull/14689)
+
+Meeting document: [Evaluation observation layer design](evaluation-observation-layer-design.md)
+
+## Decision summary
+
+An evaluation cache may reuse an evaluated project only when every result-affecting input
+is:
+
+1. part of the candidate key;
+2. recorded as an observed dependency;
+3. covered by an authoritative provider generation; or
+4. classified non-cacheable.
+
+The observation layer records inputs while evaluation consumes them. It does not infer
+dependencies afterward from the evaluated `ProjectInstance`.
+
+The production design uses:
+
+- one explicitly passed `EvaluationObservationSession` per evaluation;
+- evaluator-native semantic interception;
+- existing MSBuild filesystem, property, property-function, source, SDK, and host seams;
+- default-deny coverage states;
+- non-cacheable fallback for opaque managed extension code;
+- validation on cache lookup as the first correctness mechanism;
+- watchers and journals only as later invalidation accelerators;
+- Detours only as a Windows verification oracle.
+
+The current prototype remains off by default, instrumentation-only, and unable to serve
+cache hits.
+
+## Design meeting guide
+
+The rest of this document is a technical reference. For the design meeting, review these
+three groups separately.
+
+### Proposed commitments for approval
+
+- Observation is evaluator-native and fail closed.
+- Per-evaluation state is passed explicitly, not stored on shared context or ambient
+  process state.
+- Coverage is default deny.
+- Opaque third-party code and unclassified property functions are non-cacheable.
+- Shared caches must replay dependencies, expose an authoritative generation, or make
+  the evaluation non-cacheable.
+- The first cache target is process-local MSBuild Server reuse.
+- Watchers and journals accelerate invalidation but do not define correctness.
+
+### Phase 1 commitments
+
+Phase 1 must:
+
+- keep observation off by default;
+- preserve evaluation and logging behavior;
+- produce one isolated report per evaluation;
+- record only filesystem operations reached through the current evaluator seam;
+- declare filesystem and all later categories incomplete;
+- measure disabled and enabled overhead;
+- keep cache hits disabled.
+
+Phase 1 must not add:
+
+- cache lookup;
+- persistence;
+- watcher/journal code;
+- a public extension API;
+- environment or Registry interception hidden behind process-global state.
+
+### Proposed later mechanisms
+
+The detailed source, property-function, environment, Registry, SDK, host, validation, and
+invalidation mechanisms below are proposals for later phases. They do not become
+implementation commitments until their corresponding phase is approved.
+
+### Deferred designs
+
+Separate proposals are required for:
+
+- a public extension dependency-reporting contract;
+- persistent-cache security and serialization;
+- cross-machine reuse;
+- exact platform event-backend selection.
+
+### Decisions required now
+
+1. Confirm the process-local MSBuild Server as the first production target.
+2. Approve default non-cacheable behavior for opaque code.
+3. Approve the phase ordering.
+4. Select benchmark workloads and the process for setting CPU/allocation/memory budgets.
+
+## Scope
+
+This document defines the target observation contract. It does not require implementing
+all categories in one pull request.
+
+### First milestone
+
+The current prototype milestone is limited to:
+
+- per-evaluation session lifetime;
+- filesystem records visible through the existing evaluator filesystem;
+- explicit coverage and non-cacheable reasons;
+- semantic and concurrency tests;
+- overhead measurement.
+
+`ReadyForCacheHits` remains false.
+
+### Later milestones
+
+Later pull requests add:
+
+- root and import source identity;
+- complete filesystem call-site routing;
+- environment and Registry observation;
+- SDK, toolset, and host-source provenance;
+- validation and an in-memory MSBuild Server cache;
+- live invalidation and persistence.
+
+## Non-goals
+
+The initial observation work does not provide:
+
+- cache lookup or materialization;
+- serialization or persistence;
+- a reverse dependency index;
+- filesystem or Registry event monitoring;
+- a public dependency-reporting API for third-party extensions;
+- transparent sandboxing of arbitrary managed code.
+
+Until a public extension contract is designed, opaque third-party code is non-cacheable.
+
+## Technical reference
+
+## Core data model
+
+### Candidate-key inputs
+
+Inputs known before evaluation select candidate entries:
+
+- project/source-provider identity;
+- complete global properties;
+- requested and effective ToolsVersion, including explicitness;
+- evaluation stage;
+- result-affecting `ProjectLoadSettings`;
+- interactive and Visual Studio mode;
+- startup directory and node count;
+- culture and UI culture;
+- OS, architecture, path comparison, and evaluation semantic identity;
+- relevant Traits, feature switches, and ChangeWaves;
+- host/provider identity.
+
+The exact key belongs to the cache design. The observation report carries the request
+snapshot used to form it.
+
+### Observed dependencies
+
+Dependencies discovered during evaluation are typed records:
+
+- project source versions;
+- file reads;
+- path probes;
+- glob and directory membership;
+- file metadata;
+- imported and live environment reads;
+- Registry values and enumerations;
+- SDK and toolset resolution;
+- stable machine/process values;
+- host document versions.
+
+### Non-cacheable inputs
+
+Examples:
+
+- an incomplete or failed observation;
+- a partial stream read without an authoritative content token;
+- a Boolean probe that cannot distinguish failure from missing;
+- unclassified property functions;
+- opaque third-party resolver or extension execution;
+- time, random, network, or arbitrary host callbacks without a stable token;
+- shared-cache results without replayable provenance.
+
+## Coverage and eligibility
+
+Define a closed `EvaluationInputCategory` enum matching the normative coverage matrix.
+The full enum is required after applying an explicit platform-applicability map. There is
+no manually selected subset of "required" categories.
+
+Static implementation coverage has:
+
+```text
+ImplementationCoverageState
+  NotImplemented   // default
+  Partial
+  Complete
+```
+
+Adding an enum member must fail a coverage test until it is explicitly classified.
+
+A completed report separately records the per-evaluation state:
+
+```text
+CategoryObservationState
+  NotExercised
+  Observed
+  Incomplete
+  NonCacheable
+```
+
+An operation in a category whose implementation coverage is not `Complete` sets that
+report category to `Incomplete`. Platform-specific `NotExercised` is permitted only when
+the semantic snapshot proves that category cannot affect evaluation on that platform.
+
+The report exposes:
+
+- category coverage states;
+- typed dependency records;
+- non-cacheable reasons;
+- dropped/incomplete record counters;
+- retained-size counters.
+
+The cache, not the observer, derives eligibility:
+
+```text
+eligible =
+  evaluation succeeded
+  AND every applicable category has implementation coverage Complete
+  AND no report category is Incomplete or NonCacheable
+  AND no non-cacheable reason exists
+  AND ObservationIncomplete is absent
+  AND no observation was dropped or truncated
+```
+
+The prototype hard-codes cache eligibility to false.
+
+## Session creation and transport
+
+### Ownership
+
+One `EvaluationObservationSession` belongs to one evaluation.
+
+It must not be stored on:
+
+- a shared or user-supplied `EvaluationContext`;
+- `ProjectCollection`;
+- a process-global observer;
+- an `AsyncLocal` used as the production transport.
+
+### Creation
+
+The session is created at each internal evaluation entry point before root source
+acquisition:
+
+- `Project` initialization or reevaluation;
+- `ProjectInstance` construction;
+- backend `BuildRequestConfiguration` project loading.
+
+The session is passed explicitly to:
+
+- project source acquisition;
+- `Evaluator`;
+- `PropertyTrackingEvaluatorDataWrapper`;
+- `Expander`;
+- `Expander.Function`;
+- an SDK resolver decorator;
+- host/source providers.
+
+Static helper and well-known-function paths receive the observer as an explicit argument.
+
+### Filesystem composition
+
+The per-evaluation filesystem is installed on an internal context clone through
+`EvaluationContext.ContextWithFileSystem`, matching the existing directory-cache
+composition pattern. The session itself is not stored on the context.
+
+```text
+physical/custom provider
+  -> existing EvaluationContext caches
+  -> host DirectoryCacheFileSystemWrapper
+  -> RecordingFileSystem
+  -> evaluator
+```
+
+### Completion
+
+Completion is an atomic boundary.
+
+- Evaluation-time observations accepted before completion are frozen into the report.
+- Project API calls after evaluation bypass recording.
+- Observation exceptions never escape into evaluation.
+- Any observation exception, allocation failure, truncation, or dropped evaluation-time
+  record sets `ObservationIncomplete`.
+- A dropped-record counter must be zero before an entry can be eligible.
+
+### Repeated-observation conflicts
+
+Deduplication never discards a different consumed value.
+
+For the same dependency identity:
+
+- an equivalent repeated result is deduplicated;
+- a more authoritative result may replace a weaker result, for example a full content
+  hash replacing an unverifiable stream marker;
+- a different value, outcome, provider identity, or completion state sets
+  `ConflictingObservation` and makes the evaluation non-cacheable;
+- diagnostic mode may retain all conflicting results, but cache eligibility never
+  selects one arbitrarily.
+
+This rule applies to environment values, file content and metadata, Registry results,
+source versions, and shared-provider generations.
+
+## Existing MSBuild mechanisms to reuse
+
+| Existing mechanism | Reuse |
+| --- | --- |
+| `EvaluationContext` | Reuse its filesystem, `FileMatcher`, and SDK resolver service. Preserve the caller's sharing policy. |
+| `ContextWithFileSystem` | Install the per-evaluation outer recorder without changing public API. |
+| Internal `IFileSystem` | Record file reads, probes, enumerations, and metadata that pass through this seam. |
+| `DirectoryCacheFileSystemWrapper` | Keep host caching semantics and record its returned value from the outer wrapper. |
+| `FileMatcher` | Record semantic glob requests and returned membership, including expansion-cache hits. A Framework-layer internal callback carries primitive glob data to a Build-layer session adapter. |
+| `ProjectRootElementCache` | Reuse source object identity and versions, but distinguish its different cache lifetimes and reload policies. |
+| `ProjectRootElement.Version` and XML change events | Observe in-memory and unsaved project source generations. |
+| `PropertyTrackingEvaluatorDataWrapper` | Observe present environment-derived property reads independently from diagnostic logging. |
+| `PropertiesUseTracker` | Observe undefined property reads that may become environment-derived properties later. |
+| `EnvironmentVariableReadEventArgs` | Preserve existing diagnostics only; do not reconstruct cache records from events. |
+| `Expander` and `Expander.Function` | Observe property functions before MSBuild escapes returned strings. |
+| `PropertyExpander.ExpandRegistryValue` | Observe classic `$(Registry:...)` syntax. |
+| `IntrinsicFunctions.GetRegistryValue*` | Observe `[MSBuild]::GetRegistryValue*` operations. |
+| `ISdkResolverService`, `SdkReference`, `SdkResult` | Decorate canonical SDK request/result processing. |
+| `BuildParameters` and `ProjectCollection.EnvironmentProperties` | Reuse the effective environment sources evaluations already consume. |
+| `BuildEventContext.EvaluationId` | Correlate one report with one evaluation. |
+| `FileUtilities` and MSBuild name comparers | Preserve platform and MSBuild comparison semantics. |
+| Existing Detours reporting | Compare process-level accesses with evaluator-native records on Windows. |
+
+## Normative coverage matrix
+
+Each row has one primary semantic owner. Lower-level records may support that owner but do
+not create a second independently validated dependency for the same consumed value.
+
+| Class | Input category | Primary owner/interceptor | Record or policy |
+| --- | --- | --- | --- |
+| Key | Project and provider identity | Evaluation entry point | Canonical identity |
+| Key | Global properties | Evaluation entry point | Complete property snapshot |
+| Key | ToolsVersion, load settings, evaluation stage, modes | Evaluation entry point | Semantic request snapshot |
+| Key | Culture, startup directory, node count | Evaluation entry point | Exact values |
+| Key | Evaluation implementation semantics | Evaluation entry point | OS/architecture/comparison/features semantic ID |
+| Observed | Root project XML | Source acquisition / PRE provider | One source identity plus version or consumed content hash |
+| Observed | Imported project XML | Import loader / PRE provider | One source identity plus version or consumed content hash |
+| Observed | Non-PRE file content | `RecordingFileSystem` or provider | Full consumed-content identity |
+| Observed | File/directory existence | `RecordingFileSystem` or typed bypass | Present/missing/failure |
+| Observed | Upward and fallback searches | Search helper | Ordered candidate probes and selected result |
+| Observed | Glob membership | `FileMatcher.GetFiles` boundary | Pattern plus returned membership fingerprint |
+| Observed | Raw directory enumeration | `RecordingFileSystem` | Request, members, completion |
+| Observed | File metadata and link identity | Filesystem/provider | Exact returned fields and provider semantics |
+| Observed | Filesystem property functions | `Expander.Function` / well-known path | Route through `IFileSystem`, record typed result, or non-cacheable |
+| Observed | Present imported environment property | Property tracking wrapper | Name and exact effective imported value |
+| Observed | Missing imported environment property | `PropertiesUseTracker` | Name and missing state |
+| Observed | Named live environment read | `Expander.Function` | Name and exact returned value/missing |
+| Observed | Full live environment enumeration | `Expander.Function` | Exact returned snapshot |
+| Observed | SDK-injected environment property | Evaluator data / SDK result | Name, injected value, and later read |
+| Observed | Engine-owned environment input | Owning provider/service | Named value or provider generation |
+| Observed | Classic Registry expression | `PropertyExpander.ExpandRegistryValue` | Exact request and returned string/outcome |
+| Observed | Registry intrinsic | `Expander.Function` and `IntrinsicFunctions` | Exact request and typed returned value/outcome |
+| Observed | Built-in Registry discovery | Typed Registry provider | Value or enumeration result |
+| Observed | SDK resolution | SDK service decorator | Canonical request/result and provenance |
+| Observed | Toolset discovery | Toolset provider | Selected result and source generation |
+| Observed | Stable ambient value | Property-function/host observer | Typed value |
+| Observed | Unsaved IDE/object-model source | Host source provider | Document identity and monotonic version |
+| Non-cacheable | Opaque third-party resolver/extension | SDK/property-function boundary | `OpaqueManagedCode` |
+| Non-cacheable | Unclassified property function | `Expander.Function` | `UnclassifiedPropertyFunction` |
+| Non-cacheable | Time, random, network, arbitrary callback | Function/host boundary | Category-specific reason |
+| Non-cacheable | Unversioned shared-cache hit | Cache boundary | `UnversionedSharedCache` |
+| Non-cacheable | Partial/failed/unverifiable read | Operation boundary | Category-specific reason |
+
+### Solution inputs
+
+Solution and solution-filter parsing are not project evaluation and must not be folded
+into a project evaluation entry.
+
+`.sln`, `.slnx`, and `.slnf` processing requires a separate candidate key and observation
+report covering:
+
+- solution/filter content;
+- selected configurations;
+- project membership and mappings;
+- generated metaproject inputs.
+
+The resulting project evaluation requests then use this document's project-level
+contract.
+
+## Filesystem observation
+
+### Call-site completeness
+
+`IFileSystem` is the primary seam, not proof of complete coverage.
+
+Evaluation-affecting code that currently calls `FileSystems.Default`,
+`FileUtilities.*NoThrow`, `System.IO`, or process-wide caches directly must be inventoried.
+Each call site must be:
+
+1. routed through the per-evaluation filesystem;
+2. observed explicitly at its semantic boundary; or
+3. classified non-cacheable.
+
+Coverage remains `Partial` while any relevant bypass exists.
+
+### Property-function I/O
+
+Filesystem property functions require explicit classification.
+
+- `[MSBuild]::FileExists` and `DirectoryExists` should use the evaluation filesystem.
+- Allowlisted `System.IO.File` and `System.IO.Directory` functions are observed at
+  `Expander.Function`.
+- A known function is routed to an equivalent `IFileSystem` operation where semantics
+  match.
+- A function that cannot be represented without changing behavior is non-cacheable.
+
+### Project source ownership
+
+Root and imported XML produce one source record owned by source acquisition or the PRE
+provider.
+
+The generic filesystem recorder must tag or suppress the corresponding lower-level read
+so one consumed XML source is not validated twice under different rules.
+
+`ProjectRootElement.Version` is authoritative for an in-memory PRE object. It is not by
+itself an authoritative disk generation when a cache has auto-reload disabled.
+
+### Probes and searches
+
+```text
+PathProbeObservation
+  path
+  requested kind: File / Directory / Either
+  Present(actual kind) / Missing / Failure
+```
+
+Missing and failure are different.
+
+Upward searches such as `GetPathOfFileAbove` and import fallback searches record:
+
+- ordered candidate paths;
+- every negative probe that affected selection;
+- the selected path, if any;
+- the search semantics.
+
+A newly created nearer file invalidates the old result.
+
+### Globs
+
+Glob observation belongs at `FileMatcher.GetFiles`, because that boundary knows:
+
+- root;
+- include/exclude pattern and `SearchAction`;
+- recursion;
+- comparison semantics;
+- final membership returned to evaluation.
+
+Record the returned membership even when it came from `FileEntryExpansionCache`.
+
+`FileMatcher.Default` and any other matcher not created with the per-evaluation callback
+remain explicit bypasses until rerouted or classified non-cacheable.
+
+The semantic record includes:
+
+```text
+GlobObservation
+  root
+  include and exclude expressions
+  SearchAction and recursion
+  comparison semantics
+  membership fingerprint
+  Complete / Partial / Failure
+```
+
+The cache representation stores:
+
+- a canonical membership fingerprint;
+- reverse-index data needed for invalidation.
+
+Full member lists are optional diagnostic data, not a required retained cache payload.
+
+### Raw enumeration
+
+The filesystem recorder still records non-glob directory enumeration:
+
+```text
+DirectoryEnumerationObservation
+  root, pattern, recursion, entity kind
+  membership fingerprint
+  Complete / Partial / Failure
+```
+
+Partial or failed enumeration is non-cacheable.
+
+### Symlinks, reparse points, and permissions
+
+Provider semantics must state whether identity follows:
+
+- the logical path;
+- the link object;
+- the resolved target;
+- both.
+
+Access/authorization failure is not missing. Until typed outcomes exist, ambiguous
+negative probes remain non-cacheable.
+
+## Environment observation
+
+Environment inputs have distinct sources and must be validated against the same source
+that evaluation consumed.
+
+### Imported environment-derived properties
+
+`ProjectCollection.EnvironmentProperties` and backend build parameters supply the
+environment-derived MSBuild property table.
+
+When observation is enabled:
+
+- property-read tracking runs independently from `Traits.Instance.LogPropertyTracking`;
+- event/binlog emission remains controlled by the existing diagnostic trait;
+- reading a present environment-derived property records its exact effective imported
+  value;
+- reading an undefined property through `PropertiesUseTracker` records a negative
+  imported-environment dependency for that property name;
+- if XML, global, command-line, toolset, or SDK data overwrote the environment-derived
+  value before the read, the read is not attributed to the original environment value.
+
+Validation compares against the next evaluation's effective imported environment table,
+not a later direct CLR environment read.
+
+### Live `System.Environment` property functions
+
+Observe raw results before MSBuild string escaping.
+
+| Operation | Policy |
+| --- | --- |
+| `GetEnvironmentVariable(name)` | Record requested name and exact returned value/missing. |
+| `GetEnvironmentVariables()` | Record the exact returned snapshot and platform comparison semantics. |
+| `ExpandEnvironmentVariables(text)` | Non-cacheable until MSBuild executes equivalent expansion against an immutable observed environment provider. Parsing `%NAME%` approximately is not sufficient. |
+| `CurrentDirectory` | Record the exact live value and repeat the same read during hit validation. |
+| Stable properties such as `OSVersion` or `ProcessorCount` | Record as typed ambient values if policy allows caching them. |
+| `TickCount`, time, random, and similar unstable values | Non-cacheable. |
+
+The overload taking `EnvironmentVariableTarget` records the target as part of the
+operation. User and machine targets require platform-specific validation.
+
+### Engine-owned environment inputs
+
+Reads that affect evaluation should move behind an owning provider or request snapshot,
+including:
+
+- toolset selection;
+- SDK resolver loading/search paths;
+- evaluator feature and trait choices;
+- node/build environment state;
+- evaluator-specific escape hatches.
+
+The record contains the named value or the authoritative provider generation.
+
+### SDK-injected environment variables
+
+`AddSdkResolvedEnvironmentVariable` can introduce values during evaluation.
+
+Record:
+
+- resolver identity;
+- variable name and injected value;
+- whether evaluation later read that property;
+- conflict with an imported value.
+
+### Opaque extension code
+
+Arbitrary managed resolver or property-function code can read:
+
+- live environment;
+- files;
+- Registry;
+- network;
+- private process state.
+
+A whole-environment snapshot does not cover those other inputs and cannot prove the exact
+value consumed during concurrent mutation.
+
+Therefore opaque third-party code is non-cacheable until a separate dependency-reporting
+contract exists.
+
+Built-in extensions become cacheable only after their ambient reads are routed through
+observable providers and covered by tests.
+
+### Environment mutation
+
+There is no portable notification for arbitrary process-environment mutation.
+
+- Engine-owned mutations must bump an internal environment generation.
+- Sessions compare the generation at start and completion.
+- A generation mismatch sets `ConflictingObservation` and makes the evaluation
+  non-cacheable.
+- Direct live reads record their returned values.
+- Out-of-band mutation by arbitrary in-process code is covered by making that code
+  non-cacheable, not by comparing start/end snapshots.
+
+### Confidentiality
+
+Environment values may contain credentials.
+
+Use two projections:
+
+1. an internal value store used only for in-memory validation;
+2. a diagnostic projection containing names, counts, and redacted keyed hashes.
+
+Raw values must not be emitted to:
+
+- normal logs;
+- binlogs;
+- telemetry;
+- node IPC diagnostics;
+- persisted manifests without a separate security design.
+
+## Registry observation
+
+### Classic syntax
+
+`$(Registry:...)` is intercepted in `PropertyExpander.ExpandRegistryValue`.
+
+Record:
+
+- original key/value request;
+- platform behavior;
+- exact returned string;
+- exception/failure outcome.
+
+Current APIs may not distinguish missing key from missing value. Do not claim that
+distinction until a single-operation typed provider supplies it authoritatively.
+
+### `[MSBuild]` intrinsics
+
+`[MSBuild]::GetRegistryValue*` is intercepted at `Expander.Function` and
+`IntrinsicFunctions`.
+
+Record before string conversion:
+
+```text
+RegistryValueObservation
+  hive/key/value request
+  ordered Registry views
+  default value
+  exact typed returned value
+  success/failure
+```
+
+If the returned default is indistinguishable from a stored value equal to that default,
+the observation records only the exact consumed result, not an invented missing state.
+
+### Built-in Registry discovery
+
+Toolset and extension discovery may enumerate keys or values.
+
+Move those reads behind an internal typed Registry provider and record:
+
+```text
+RegistryEnumerationObservation
+  hive, key, view
+  subkeys or value names returned
+  Complete / Partial / Failure
+```
+
+### Opaque Registry access
+
+Arbitrary extension Registry access is non-cacheable without a dependency contract.
+
+Registry notification may later accelerate Windows invalidation, but validation remains
+the correctness mechanism and non-Windows behavior is validated according to the actual
+MSBuild semantic returned on that platform.
+
+## SDK and toolset observation
+
+Decorate `ISdkResolverService` per evaluation.
+
+Record:
+
+```text
+SdkResolutionObservation
+  complete SdkReference
+  project/solution context
+  interactive and Visual Studio mode
+  resolver identity/version
+  success/failure
+  resolved paths/version
+  returned properties/items
+  provider generation or dependency replay token
+```
+
+### SDK cache provenance
+
+The current SDK cache can return a result without rerunning the resolver.
+
+A cache hit is observable only if it:
+
+- replays the original dependency set into the current session; or
+- supplies an authoritative generation token that covers those dependencies.
+
+Returning only `SdkResult` is insufficient.
+
+Until provenance replay exists, shared SDK-cache hits keep SDK coverage partial or make
+the evaluation non-cacheable.
+
+### Third-party resolvers
+
+Third-party resolvers are non-cacheable in the initial design. A public dependency
+contract is a separate proposal.
+
+## Shared cache provenance
+
+An outer recorder cannot see work skipped by an inner cache.
+
+Each shared cache must provide one of:
+
+1. dependency replay from the operation that populated the entry;
+2. an authoritative provider generation;
+3. a non-cacheable reason.
+
+This applies to:
+
+- `CachingFileSystemWrapper`;
+- file-existence caches;
+- `FileMatcher` expansion caches;
+- host directory caches;
+- loaded-project/PRE caches;
+- SDK resolver caches;
+- toolset/configuration caches.
+
+Any non-`Isolated` sharing policy, and any process-global cache used under any policy,
+remains non-cacheable until every reused cache satisfies this contract.
+
+## Validation and invalidation
+
+### First in-memory cache
+
+Validation on lookup is sufficient for correctness:
+
+| Dependency | Validation |
+| --- | --- |
+| Source version | Compare the same provider's monotonic version/token. |
+| File content | Compare provider generation or consumed-content hash. |
+| Path probe | Repeat the typed probe. |
+| Search | Repeat ordered probes or compare an authoritative search-root generation. |
+| Glob/directory membership | Re-enumerate or compare provider directory generation. |
+| Metadata/link field | Re-read the same field with the same semantics. |
+| Imported environment property | Compare the next effective imported property table. |
+| Live named environment read | Repeat the same CLR operation. |
+| Full environment enumeration | Compare canonical snapshots. |
+| Stable ambient value | Repeat the same ambient read, including live current directory. |
+| Registry value/enumeration | Repeat the same operation and compare typed result. |
+| SDK/toolset | Compare provider generation or replayed dependencies. |
+| Host document | Compare host document version. |
+
+### Validate-to-materialize race
+
+The server cache uses:
+
+- an immutable cached evaluation baseline;
+- a mutable deep copy or copy-on-write execution overlay per build;
+- provider invalidation epochs where the provider supports them;
+- a complete manifest check before materialization;
+- a second complete check after materialization for dependencies without an authoritative
+  epoch or snapshot fence;
+- an epoch check before validation and after materialization for versioned providers.
+
+If an epoch changes during validation/materialization, the hit is discarded.
+
+If a non-epoch dependency changes between the two checks, the hit is discarded. A
+dependency class that cannot be rechecked or fenced is non-cacheable.
+
+Concurrent requests may share the expensive first validation result per entry, but every
+waiter performs the final epoch/manifest check before receiving its materialized project.
+
+### Live invalidation
+
+Watchers, journals, and notifications are optional accelerators.
+
+A reverse index maps dependencies to entries:
+
+```text
+path -> entries
+search/glob root -> entries
+environment property name -> entries
+Registry key/value/view -> entries
+source document -> entries
+resolver/toolset generation -> entries
+```
+
+Event overflow, loss, unsupported roots, or backend failure invalidates the affected root
+set or falls back to validation. Event delivery is never the sole correctness mechanism.
+
+## Overhead model
+
+### Disabled
+
+When observation is disabled:
+
+- no session, recorder, record collections, or report are allocated;
+- evaluator entry points perform a predictable null/feature check;
+- static property-function and Registry fast paths perform at most one predictable,
+  non-allocating observer-null branch.
+
+The disabled path must preserve logging and evaluation semantics exactly.
+
+### Enabled
+
+| Interception | Additional work |
+| --- | --- |
+| Property/environment read | Name lookup and deduplicated record update |
+| Probe/metadata read | Session gate, normalization, keyed update |
+| File content | Hash only when no authoritative provider token exists |
+| Glob/directory enumeration | Membership fingerprint; optional diagnostic members |
+| Property function | Classification plus typed record or non-cacheable reason |
+| Registry value | Copy request and typed result |
+| SDK/toolset | Canonicalize request/result and replay provenance |
+| Completion | Freeze records, calculate counters, create diagnostic projection |
+
+### Primary cost risks
+
+1. Property and property-function paths are evaluation hot paths.
+2. Large glob memberships can dominate retained memory.
+3. Content hashing can duplicate provider work.
+4. Shared-cache dependency replay can retain large manifests.
+5. Locking can serialize otherwise parallel evaluation work.
+6. Validation-on-hit can erase cache benefit if every file and glob is reopened.
+7. Raw environment/Registry values increase sensitive retained memory.
+
+### Implementation guidance
+
+- Use ordinary dictionaries under a session gate unless profiling proves concurrent
+  mutation is required.
+- Deduplicate names and paths with existing MSBuild comparers.
+- Store fingerprints rather than full glob membership in cache records.
+- Retain full members only in an explicitly enabled diagnostic projection.
+- Share immutable provider/request snapshots instead of copying them per project.
+- Avoid LINQ and closures in evaluation hot paths.
+- Keep hashing outside critical sections.
+
+### Required measurements
+
+Measure:
+
+- observation disabled;
+- observation enabled by phase;
+- cache miss with complete observation;
+- valid hit including validation/materialization;
+- stale candidate followed by reevaluation.
+
+Workloads:
+
+- small SDK project;
+- property-function-heavy project;
+- glob-heavy synthetic project;
+- large real solution;
+- concurrent graph evaluation;
+- repeated MSBuild Server requests.
+
+Metrics:
+
+- wall-clock evaluation time;
+- evaluation CPU time;
+- allocated bytes;
+- GC counts;
+- peak retained memory;
+- observer lock contention;
+- records and retained bytes by category;
+- report finalization time;
+- validation and materialization time.
+
+No enabled-mode budget is selected by this document. The team must approve CPU,
+allocation, and retained-memory thresholds before observation is enabled by default.
+
+### Default-enablement gate
+
+Observation cannot become default-on until:
+
+- disabled-path regressions are below the agreed noise threshold on every acceptance
+  workload;
+- enabled-mode CPU, allocation, and retained-memory budgets are approved and met;
+- no benchmark shows observer lock contention limiting graph parallelism;
+- sensitive values are absent from logs, binlogs, telemetry, and diagnostic output;
+- all required categories have implementation coverage `Complete`;
+- cache-hit validation plus materialization remains materially cheaper than reevaluation.
+
+## Verification
+
+### Semantic tests
+
+Observation on/off must produce identical:
+
+- evaluated properties, items, metadata, and imports;
+- errors and exception types;
+- event/binlog sequence;
+- lazy enumeration behavior;
+- results under concurrent shared-context evaluation.
+
+### Coverage tests
+
+Add focused tests for:
+
+- present and missing imported environment properties;
+- overwritten environment properties;
+- SDK-injected environment properties;
+- live environment named read and enumeration;
+- opaque resolver becoming non-cacheable;
+- both Registry syntaxes;
+- Registry default-value ambiguity;
+- property-function filesystem access;
+- direct filesystem bypass inventory;
+- glob expansion-cache hits;
+- upward/fallback search dependencies;
+- PRE reload-enabled and reload-disabled policies;
+- SDK same-name/different-version and cached-result provenance;
+- observation failure and dropped-record handling.
+
+### Process-level verification
+
+Use Windows Detours to compare process-level file/environment/Registry access with
+evaluator-native records where attribution is possible.
+
+Detours does not define production semantics because it is Windows-specific,
+process-wide, and cannot represent in-memory source versions or reliably attribute all
+accesses to concurrent evaluations.
+
+Portable coverage tests should also assert or detect evaluation-affecting direct
+`FileSystems.Default` and unclassified property-function use.
+
+## Implementation phases
+
+### Phase 1: current prototype
+
+- Per-evaluation session in `Evaluator`.
+- Outer recording filesystem.
+- Typed filesystem records.
+- Atomic completion.
+- Default-deny reasons.
+- `ReadyForCacheHits = false`.
+
+### Phase 2: source and filesystem completeness
+
+- Move session creation before root source acquisition.
+- Explicit session transport.
+- Root/import source records.
+- Property-function filesystem interception.
+- Direct filesystem bypass inventory.
+- Semantic glob and search records.
+- Shared filesystem/PRE provenance.
+
+### Phase 3: environment, Registry, and ambient inputs
+
+- Independent property-read observation gate.
+- `PropertiesUseTracker` negative environment records.
+- `System.Environment` classification.
+- SDK-injected environment records.
+- Both Registry syntaxes.
+- Built-in Registry provider.
+- Stable/unstable ambient classification.
+
+### Phase 4: SDK, toolset, and hosts
+
+- SDK resolver decorator.
+- Built-in resolver instrumentation.
+- Shared SDK provenance replay.
+- Toolset source generations.
+- Host document versions.
+- Third-party resolver remains non-cacheable.
+
+### Phase 5: performance and eligibility
+
+- All required categories complete.
+- Disabled/enabled overhead accepted.
+- Cache eligibility derived from coverage/reasons.
+- Cache hits remain opt-in.
+
+### Phase 6: in-memory server cache
+
+- Candidate key and entry store.
+- Immutable evaluation baseline.
+- Validation epochs.
+- Mutable execution copy/overlay.
+- Eviction and memory budgets.
+
+### Phase 7: live invalidation and persistence
+
+- Reverse dependency index.
+- Watcher/journal acceleration.
+- Overflow recovery.
+- Serialization/versioning/security design.
+
+## Compatibility
+
+The observation-only feature is internal, opt-in, and produces no user-visible
+diagnostics by default. It does not need a ChangeWave while default build behavior and
+output remain unchanged.
+
+Serving evaluation-cache hits is a behavioral change. It must initially be opt-in behind
+a reversible feature gate or ChangeWave, with tests for:
+
+- enabled behavior;
+- `MSBuildDisableFeaturesFromVersion` opt-out behavior;
+- evaluation logging and event ordering;
+- resolver warnings and side effects;
+- object identity and mutation isolation;
+- failure fallback to normal evaluation.
+
+New warnings require separate compatibility treatment because warnings can break
+`WarnAsError` builds.
+
+## Current prototype status
+
+Draft PR #14689 currently:
+
+- creates one isolated session per evaluator;
+- records selected filesystem probes, enumerations, metadata, and reads;
+- remains off by default behind
+  `MSBUILDPROTOTYPEEVALUATIONOBSERVATION=1`;
+- preserves shared-context concurrency isolation;
+- never declares an entry ready for cache hits;
+- has no production report sink;
+- explicitly flags incomplete project XML and shared-cache provenance;
+- does not yet implement the later phases in this document.

--- a/documentation/specs/proposed/evaluation-observation-layer-design.md
+++ b/documentation/specs/proposed/evaluation-observation-layer-design.md
@@ -1,0 +1,429 @@
+# Evaluation observation layer design
+
+Status: proposed
+
+Prototype: [dotnet/msbuild#14689](https://github.com/dotnet/msbuild/pull/14689)
+
+Detailed reference:
+[Evaluation observation layer technical reference](evaluation-observation-layer-design-details.md)
+
+## Purpose
+
+An evaluation cache can reuse an evaluated project only when MSBuild knows every input
+that affected the result.
+
+The observation layer records those inputs while evaluation consumes them. It is not
+itself a cache.
+
+Every input must be:
+
+1. part of the candidate key;
+2. recorded as an observed dependency;
+3. covered by an authoritative provider generation; or
+4. classified non-cacheable.
+
+Unknown or incomplete observation fails closed.
+
+## Proposal at a glance
+
+- Create one explicitly passed `EvaluationObservationSession` per evaluation.
+- Start it before root project source acquisition.
+- Reuse existing evaluator-native interception points.
+- Keep per-evaluation state off shared `EvaluationContext` and process-global state.
+- Use default-deny category coverage.
+- Treat opaque third-party code and unclassified property functions as non-cacheable.
+- Validate dependencies on lookup in the first in-memory cache.
+- Add watchers and journals later only to avoid repeated validation work.
+- Use Detours only to verify coverage on Windows.
+
+## First milestone
+
+The current prototype milestone is intentionally small:
+
+- one isolated session per evaluation;
+- outer recording filesystem;
+- typed filesystem records;
+- explicit incomplete/non-cacheable reasons;
+- semantic, concurrency, and overhead tests;
+- no cache hits.
+
+The value of this milestone is proving the observation boundary: it shows that MSBuild
+can collect isolated, typed dependencies without changing evaluation. Cache behavior is
+deliberately deferred until the team trusts the coverage and cost model.
+
+It remains off by default behind
+`MSBUILDPROTOTYPEEVALUATIONOBSERVATION=1`.
+
+The current PR creates the session in `Evaluator`. Moving session creation before root
+source acquisition is Phase 2 work.
+
+It does not yet promise complete filesystem, environment, Registry, SDK, toolset, or host
+coverage.
+
+## Existing MSBuild code to reuse
+
+| Existing mechanism | Reuse |
+| --- | --- |
+| `EvaluationContext` and `ContextWithFileSystem` | Reuse the current filesystem and caches while installing a per-evaluation outer recorder. |
+| Internal `IFileSystem` | File reads, probes, raw enumeration, and metadata. |
+| `DirectoryCacheFileSystemWrapper` | Preserve host cache behavior; record the value returned by the wrapper. |
+| `FileMatcher` | Record semantic glob requests and returned membership, including expansion-cache hits. |
+| `ProjectRootElementCache` and `ProjectRootElement.Version` | Root/import and unsaved source identity and versions. |
+| `PropertyTrackingEvaluatorDataWrapper` | Present environment-derived property reads, independently from logging. |
+| `PropertiesUseTracker` | Undefined property reads that may become environment-derived properties later. |
+| `Expander` and `Expander.Function` | Property-function classification and observation. |
+| `PropertyExpander.ExpandRegistryValue` | Classic `$(Registry:...)` access. |
+| `IntrinsicFunctions.GetRegistryValue*` | `[MSBuild]::GetRegistryValue*` access. |
+| `ISdkResolverService`, `SdkReference`, `SdkResult` | SDK request, result, resolver identity, and cache provenance. |
+| `BuildParameters` and `ProjectCollection.EnvironmentProperties` | Effective environment sources already consumed by evaluation. |
+| Existing Detours reporting | Windows-only coverage comparison, not production semantics. |
+
+No second public filesystem abstraction is proposed.
+
+## Session ownership and transport
+
+The session is created at the internal `Project`, `ProjectInstance`, and backend project
+loading entry points.
+
+It is passed explicitly to:
+
+- project source acquisition;
+- `Evaluator`;
+- property tracking;
+- `Expander` and property functions;
+- SDK/toolset decorators;
+- host source providers.
+
+Static helpers receive an explicit observer argument.
+
+The session is not stored on:
+
+- shared or user-supplied `EvaluationContext`;
+- `ProjectCollection`;
+- a process-global singleton;
+- production `AsyncLocal` state.
+
+Observation completion is atomic. Observation failures never change evaluation behavior,
+but they set `ObservationIncomplete`, which prevents reuse.
+
+Repeated observations of the same identity must agree. Different values, outcomes, or
+provider generations set `ConflictingObservation` and make the evaluation non-cacheable.
+
+## Coverage model
+
+Use a closed `EvaluationInputCategory` enum.
+
+Static implementation coverage:
+
+```text
+NotImplemented   // default
+Partial
+Complete
+```
+
+Per-evaluation state:
+
+```text
+NotExercised
+Observed
+Incomplete
+NonCacheable
+```
+
+The full category enum is required after explicit platform applicability is applied.
+Adding a category fails a coverage test until it is classified.
+
+Cache eligibility requires:
+
+- successful evaluation;
+- every applicable implementation category `Complete`;
+- no per-report `Incomplete` or `NonCacheable` state;
+- no dropped or conflicting observation.
+
+The prototype always remains ineligible.
+
+## Input ownership
+
+| Class | Category | Primary observer |
+| --- | --- | --- |
+| Key | Project/provider identity, global properties | Evaluation entry point |
+| Key | ToolsVersion, load settings, evaluation stage, interactive/VS mode | Evaluation entry point |
+| Key | Culture, startup directory, node count, semantic feature identity | Evaluation entry point |
+| Observed | Root and imported XML | Source/PRE provider |
+| Observed | Non-PRE file reads, probes, metadata, raw enumeration | Per-evaluation filesystem |
+| Observed | Upward/fallback searches | Search helper |
+| Observed | Globs | `FileMatcher` semantic boundary |
+| Observed | Imported environment properties | Property tracking |
+| Observed | Live `System.Environment` calls | Property-function boundary |
+| Observed | Registry | Classic Registry expansion, Registry intrinsics, typed built-in provider |
+| Observed | SDK/toolset | Service/provider decorators |
+| Observed | Stable machine/process values | Property-function/host observer |
+| Observed | Unsaved IDE/object-model state | Host source provider |
+| Non-cacheable | Opaque extensions, unclassified functions, unstable ambient input | Owning invocation boundary |
+| Non-cacheable | Unversioned shared-cache result | Shared-cache boundary |
+| Non-cacheable | Partial, failed, ambiguous, or unverifiable observation | Operation boundary |
+
+Solution parsing (`.sln`, `.slnx`, `.slnf`) uses a separate key/report and feeds project
+evaluation requests into this model.
+
+## Filesystem strategy
+
+`IFileSystem` is the primary seam, but it is not proof of complete coverage.
+
+Every evaluation-affecting direct use of `FileSystems.Default`, `System.IO`, a
+`*NoThrow` helper, or a process-wide cache must be:
+
+1. routed through the per-evaluation filesystem;
+2. observed explicitly at its semantic boundary; or
+3. made non-cacheable.
+
+Important semantic observers:
+
+- source acquisition owns root/import XML identity;
+- `FileMatcher` owns glob membership, including expansion-cache hits;
+- search helpers own ordered upward/fallback probes;
+- `Expander.Function` owns filesystem property-function classification.
+
+Missing paths and missing nearer search candidates are dependencies.
+
+Glob records retain a membership fingerprint and invalidation index data. Full member
+lists are diagnostic-only.
+
+## Environment strategy
+
+Environment observation has several levels.
+
+### Imported environment-derived properties
+
+- A present `$(NAME)` read records the exact imported value.
+- An undefined property read records a negative imported-environment dependency.
+- Validation compares against the next effective imported environment-property table.
+- If another property source overwrote the environment value before the read, it is not
+  attributed to the original environment.
+- Observation tracking is independent from existing environment-read log emission.
+
+### Live `System.Environment`
+
+| Operation | Policy |
+| --- | --- |
+| `GetEnvironmentVariable(name)` | Record name and exact returned value/missing. |
+| `GetEnvironmentVariables()` | Record the exact returned environment snapshot. |
+| `ExpandEnvironmentVariables(text)` | Non-cacheable until expansion executes against an immutable observed provider. |
+| `CurrentDirectory` | Record the exact live value and repeat the same read during hit validation. |
+| Stable properties such as `ProcessorCount` | Record as typed ambient values if policy allows. |
+| Time, random, tick count, and similar unstable values | Non-cacheable. |
+
+### Engine and SDK inputs
+
+Engine-owned environment reads move behind request/provider snapshots or named providers.
+SDK-injected environment values record resolver identity, name, value, and later reads.
+
+Opaque third-party resolver or custom property-function code is non-cacheable. A full
+environment snapshot is not sufficient because such code may also read files, Registry,
+network, or private process state.
+
+There is no portable notification for arbitrary process environment mutation. Known
+engine mutations bump an environment generation; a generation mismatch makes the report
+non-cacheable.
+
+Raw environment values remain internal and must not appear in logs, binlogs, telemetry,
+or diagnostic reports.
+
+## Registry strategy
+
+Two separate paths are observed:
+
+- `$(Registry:...)` in `PropertyExpander.ExpandRegistryValue`;
+- `[MSBuild]::GetRegistryValue*` through `Expander.Function` and
+  `IntrinsicFunctions`.
+
+Records contain the exact request, views/default where applicable, returned typed value
+or string, and failure outcome.
+
+Current APIs do not always distinguish missing key from missing value or a default value
+equal to stored data. The observer records only what was authoritatively consumed until a
+typed Registry provider is introduced.
+
+Built-in Registry enumeration moves behind that provider. Opaque extension Registry
+access is non-cacheable.
+
+Registry notifications may later accelerate Windows invalidation; validation remains the
+correctness mechanism.
+
+## SDK and shared-cache strategy
+
+An SDK observer records:
+
+- complete SDK reference and project/solution context;
+- resolver identity and version;
+- success/failure;
+- resolved paths/version/properties/items;
+- dependency replay token or authoritative provider generation.
+
+An inner shared cache can skip work that an outer observer would otherwise see.
+
+Every shared cache must:
+
+1. replay the original dependency set;
+2. expose an authoritative generation; or
+3. make the evaluation non-cacheable.
+
+This applies to filesystem, glob, PRE/loaded-project, SDK, toolset, and host caches.
+
+Any non-`Isolated` sharing policy, and any process-global cache used under any policy,
+remains non-cacheable until every reused cache satisfies this contract.
+
+## Validation and invalidation
+
+The first in-memory cache validates candidate dependencies on lookup.
+
+Examples:
+
+- compare source/provider versions;
+- hash or version file content;
+- repeat typed probes and Registry operations;
+- compare glob/search generations or membership;
+- compare the next effective imported environment table;
+- repeat named live environment reads;
+- compare canonical full-environment snapshots;
+- repeat recorded ambient reads such as live current directory;
+- replay SDK/toolset dependencies.
+
+The cached evaluation baseline is immutable. Each build receives a deep copy or
+copy-on-write execution overlay.
+
+Validation uses:
+
+- a complete manifest check before materialization;
+- provider epochs where available;
+- a second complete check after materialization for dependencies without a stable epoch.
+
+Any mismatch discards the hit. A dependency that cannot be rechecked or fenced is
+non-cacheable.
+
+Watchers, journals, and Registry/host notifications are later accelerators. Overflow,
+event loss, or unsupported roots fall back to validation.
+
+## Overhead
+
+### Disabled
+
+- No session, recorder, collections, or report allocations.
+- Predictable null/feature checks at evaluation entry and instrumented static hot paths.
+- No logging or semantic changes.
+
+### Enabled
+
+| Area | Main cost |
+| --- | --- |
+| Property/environment reads | Name lookup and deduplicated record update |
+| Filesystem probes/metadata | Session gate, normalization, keyed update |
+| File content | Hashing when no authoritative provider token exists |
+| Globs/enumeration | Membership fingerprinting and optional diagnostics |
+| Property functions | Classification and typed record/non-cacheable reason |
+| Registry | Copy request and returned value |
+| SDK/toolset | Canonical request/result and provenance replay |
+| Completion | Freeze records and calculate counters |
+
+Primary risks:
+
+- property and property-function hot-path overhead;
+- glob membership memory;
+- duplicate content hashing;
+- shared-cache dependency retention;
+- observer lock contention;
+- validation cost erasing cache benefit;
+- sensitive value retention.
+
+In practice, a small project that reads a few properties should add only keyed record
+updates. A glob-heavy project can retain or hash thousands of paths, so glob membership
+and validation are expected to dominate enabled-mode cost.
+
+Implementation guidance:
+
+- prefer ordinary dictionaries under a session gate unless profiling requires otherwise;
+  the prototype deliberately uses concurrent dictionaries plus a gate until concurrency
+  measurements justify simplifying it;
+- use existing MSBuild comparers;
+- keep hashing outside locks;
+- store fingerprints rather than diagnostic member lists;
+- avoid LINQ and closures in hot paths;
+- share immutable request/provider snapshots.
+
+## Measurement gate
+
+Measure:
+
+- observation disabled and enabled;
+- cache miss;
+- valid hit including validation and materialization;
+- stale candidate followed by reevaluation.
+
+Workloads:
+
+- small SDK project;
+- property-function-heavy project;
+- glob-heavy project;
+- large real solution;
+- concurrent graph evaluation;
+- repeated Server requests.
+
+Metrics:
+
+- wall-clock and CPU evaluation time;
+- allocations, GC, and peak retained memory;
+- lock contention;
+- retained bytes by category;
+- finalization, validation, and materialization time.
+
+The team must approve CPU, allocation, and retained-memory budgets before default
+enablement. Cache-hit validation and materialization must remain materially cheaper than
+reevaluation.
+
+## Verification
+
+- Observation on/off produces identical evaluation results, errors, and log/binlog
+  sequence.
+- Coverage tests exercise every category and every known bypass.
+- New categories default to incomplete.
+- Conflicting repeated reads become non-cacheable.
+- Shared-context concurrent evaluations remain isolated.
+- Windows Detours compares process-level access with native observations where
+  attribution is possible.
+
+Detours is not the production architecture because it is Windows-specific, process-wide,
+and cannot represent semantic inputs such as in-memory project versions.
+
+## Phases
+
+1. **Current prototype:** evaluator session and filesystem records; no hits.
+2. **Source/filesystem completeness:** root/import, bypasses, property functions, globs,
+   searches, shared-cache provenance.
+3. **Environment/Registry/ambient:** property reads, live environment calls, both Registry
+   syntaxes, stable/unstable ambient classification.
+4. **SDK/toolset/host:** resolver decorator, built-in instrumentation, provenance replay,
+   host document versions.
+5. **Eligibility/performance:** complete coverage and accepted overhead.
+6. **In-memory Server cache:** key, immutable baseline, validation, execution copy,
+   eviction.
+7. **Live invalidation/persistence:** reverse index, watchers/journals, overflow recovery,
+   serialization and security.
+
+## Decisions for the meeting
+
+1. Confirm the process-local MSBuild Server as the first production target.
+2. Confirm opaque third-party code and unclassified property functions are
+   non-cacheable.
+3. Approve the phase ordering.
+4. Select benchmark workloads and the process for setting overhead budgets.
+5. Decide when a redacted diagnostic report sink is needed.
+
+## Compatibility
+
+Observation-only remains internal, opt-in, and silent, so no ChangeWave is required.
+
+Serving cache hits is a behavioral change. It must initially be opt-in behind a
+reversible feature gate or ChangeWave, with opt-out, logging, resolver, mutation
+isolation, and fallback tests.
+
+No new warnings are proposed.

--- a/src/Build.UnitTests/Definition/ProjectEvaluationContext_Tests.cs
+++ b/src/Build.UnitTests/Definition/ProjectEvaluationContext_Tests.cs
@@ -2,9 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using System.Xml;
 using Microsoft.Build.BackEnd.SdkResolution;
 using Microsoft.Build.Construction;
@@ -187,6 +189,397 @@ namespace Microsoft.Build.UnitTests.Definition
                 {
                     { _env.DefaultTestDirectory.Path, 1 }
                 });
+        }
+
+        [Fact]
+        public void EvaluationObservationCanBeDisabled()
+        {
+            int reportsCreated = 0;
+            using IDisposable scope = EvaluationObservationSession.TestOnlyConfigure(
+                enabled: false,
+                _ => reportsCreated++);
+
+            string projectFile = _env.CreateFile(
+                "disabled.proj",
+                """
+                <Project>
+                  <PropertyGroup Condition="Exists('disabled.marker')">
+                    <Observed>true</Observed>
+                  </PropertyGroup>
+                </Project>
+                """.Cleanup()).Path;
+
+            Project.FromFile(projectFile, new ProjectOptions
+            {
+                ProjectCollection = _env.CreateProjectCollection().Collection,
+            });
+
+            reportsCreated.ShouldBe(0);
+        }
+
+        [Fact]
+        public void EvaluationObservationDoesNotChangeEvaluatedState()
+        {
+            _env.CreateFile("state.marker", string.Empty);
+            _env.CreateFile("State.cs", string.Empty);
+            string projectFile = _env.CreateFile(
+                "state.proj",
+                """
+                <Project>
+                  <PropertyGroup Condition="Exists('state.marker')">
+                    <Observed>true</Observed>
+                  </PropertyGroup>
+                  <ItemGroup>
+                    <Compile Include="*.cs" />
+                  </ItemGroup>
+                </Project>
+                """.Cleanup()).Path;
+
+            Project baseline;
+            using (EvaluationObservationSession.TestOnlyConfigure(enabled: false))
+            {
+                baseline = Project.FromFile(projectFile, new ProjectOptions
+                {
+                    ProjectCollection = _env.CreateProjectCollection().Collection,
+                });
+            }
+
+            EvaluationObservationReport report = null;
+            Project observed;
+            using (EvaluationObservationSession.TestOnlyConfigure(
+                enabled: true,
+                createdReport => report = createdReport))
+            {
+                observed = Project.FromFile(projectFile, new ProjectOptions
+                {
+                    ProjectCollection = _env.CreateProjectCollection().Collection,
+                });
+            }
+
+            report.ShouldNotBeNull();
+            observed.GetPropertyValue("Observed").ShouldBe(baseline.GetPropertyValue("Observed"));
+            observed.GetItems("Compile").Select(item => item.EvaluatedInclude)
+                .ShouldBe(baseline.GetItems("Compile").Select(item => item.EvaluatedInclude));
+        }
+
+        [Fact]
+        public void EvaluationObservationRecordsProbesAndEnumerations()
+        {
+            EvaluationObservationReport report = null;
+            using IDisposable scope = EvaluationObservationSession.TestOnlyConfigure(
+                enabled: true,
+                createdReport => report = createdReport);
+
+            _env.CreateFile("Observed.cs", string.Empty);
+            string projectFile = _env.CreateFile(
+                "observed.proj",
+                """
+                <Project>
+                  <PropertyGroup Condition="Exists('missing.props')">
+                    <Imported>true</Imported>
+                  </PropertyGroup>
+                  <ItemGroup>
+                    <Compile Include="*.cs" />
+                  </ItemGroup>
+                </Project>
+                """.Cleanup()).Path;
+
+            Project project = Project.FromFile(projectFile, new ProjectOptions
+            {
+                ProjectCollection = _env.CreateProjectCollection().Collection,
+            });
+
+            report.ShouldNotBeNull();
+            report.ProjectPath.ShouldBe(projectFile);
+            report.ReadyForCacheHits.ShouldBeFalse();
+            report.EvaluationSucceeded.ShouldBeTrue();
+            (report.Reasons & EvaluationObservationReason.PrototypeCategoriesIncomplete)
+                .ShouldBe(EvaluationObservationReason.PrototypeCategoriesIncomplete);
+            (report.Reasons & EvaluationObservationReason.ProjectXmlContentNotObserved)
+                .ShouldBe(EvaluationObservationReason.ProjectXmlContentNotObserved);
+            (report.Reasons & EvaluationObservationReason.UnversionedProjectRootElementCache)
+                .ShouldBe(EvaluationObservationReason.UnversionedProjectRootElementCache);
+            (report.Reasons & EvaluationObservationReason.AmbiguousNegativeProbe)
+                .ShouldBe(EvaluationObservationReason.AmbiguousNegativeProbe);
+
+            string missingPath = Path.Combine(_env.DefaultTestDirectory.Path, "missing.props");
+            report.PathProbes.ShouldContain(observation =>
+                FileUtilities.PathsEqual(observation.Path, missingPath) &&
+                observation.Kind == EvaluationPathKind.FileOrDirectory &&
+                !observation.Exists);
+
+            string observedFile = Path.Combine(_env.DefaultTestDirectory.Path, "Observed.cs");
+            report.DirectoryEnumerations.ShouldContain(observation =>
+                FileUtilities.PathsEqual(observation.Path, _env.DefaultTestDirectory.Path) &&
+                observation.Completion == EvaluationEnumerationCompletion.Complete &&
+                observation.Entries.Any(entry => FileUtilities.PathsEqual(entry, observedFile)));
+
+            project.GetItems("Compile").ShouldContain(item =>
+                string.Equals(Path.GetFileName(item.EvaluatedInclude), "Observed.cs", StringComparison.OrdinalIgnoreCase));
+        }
+
+        [Fact]
+        public void EvaluationObservationMarksHostDirectoryCacheAsUnversioned()
+        {
+            EvaluationObservationReport report = null;
+            using IDisposable scope = EvaluationObservationSession.TestOnlyConfigure(
+                enabled: true,
+                createdReport => report = createdReport);
+
+            string projectFile = _env.CreateFile(
+                "directory-cache.proj",
+                """
+                <Project>
+                  <PropertyGroup Condition="Exists('directory-cache.marker')">
+                    <Observed>true</Observed>
+                  </PropertyGroup>
+                </Project>
+                """.Cleanup()).Path;
+
+            Project.FromFile(projectFile, new ProjectOptions
+            {
+                ProjectCollection = _env.CreateProjectCollection().Collection,
+                DirectoryCacheFactory = new Helpers.LoggingDirectoryCacheFactory(),
+            });
+
+            report.ShouldNotBeNull();
+            (report.Reasons & EvaluationObservationReason.UnversionedDirectoryCache)
+                .ShouldBe(EvaluationObservationReason.UnversionedDirectoryCache);
+        }
+
+        [Fact]
+        public void EvaluationObservationMarksSharedSdkResolverCacheAsUnversioned()
+        {
+            EvaluationObservationReport report = null;
+            using IDisposable scope = EvaluationObservationSession.TestOnlyConfigure(
+                enabled: true,
+                createdReport => report = createdReport);
+
+            string projectFile = _env.CreateFile("shared-sdk-cache.proj", "<Project />").Path;
+
+            Project.FromFile(projectFile, new ProjectOptions
+            {
+                ProjectCollection = _env.CreateProjectCollection().Collection,
+                EvaluationContext = EvaluationContext.Create(EvaluationContext.SharingPolicy.SharedSDKCache),
+            });
+
+            report.ShouldNotBeNull();
+            (report.Reasons & EvaluationObservationReason.UnversionedSdkResolverCache)
+                .ShouldBe(EvaluationObservationReason.UnversionedSdkResolverCache);
+        }
+
+        [Fact]
+        public void EvaluationObservationMarksPartialEvaluationAsIncomplete()
+        {
+            EvaluationObservationReport report = null;
+            using IDisposable scope = EvaluationObservationSession.TestOnlyConfigure(
+                enabled: true,
+                createdReport => report = createdReport);
+
+            string projectFile = _env.CreateFile("partial.proj", "<Project />").Path;
+
+            ProjectInstance.FromProjectRootElement(
+                ProjectRootElement.Open(projectFile),
+                new ProjectOptions
+                {
+                    ProjectCollection = _env.CreateProjectCollection().Collection,
+                    EvaluationStage = ProjectEvaluationStage.Properties,
+                });
+
+            report.ShouldNotBeNull();
+            (report.Reasons & EvaluationObservationReason.IncompleteEvaluationStage)
+                .ShouldBe(EvaluationObservationReason.IncompleteEvaluationStage);
+        }
+
+        [Fact]
+        public void EvaluationObservationCallbackFailureIsReportedAfterEvaluation()
+        {
+            string projectFile = _env.CreateFile(
+                "callback.proj",
+                """
+                <Project>
+                  <PropertyGroup>
+                    <Observed>true</Observed>
+                  </PropertyGroup>
+                </Project>
+                """.Cleanup()).Path;
+            Project project = null;
+
+            InvalidOperationException exception = Should.Throw<InvalidOperationException>(() =>
+            {
+                using IDisposable scope = EvaluationObservationSession.TestOnlyConfigure(
+                    enabled: true,
+                    _ => throw new ApplicationException("Callback failed."));
+
+                project = Project.FromFile(projectFile, new ProjectOptions
+                {
+                    ProjectCollection = _env.CreateProjectCollection().Collection,
+                });
+            });
+
+            exception.InnerException.ShouldBeOfType<ApplicationException>();
+            project.ShouldNotBeNull();
+            project.GetPropertyValue("Observed").ShouldBe("true");
+        }
+
+        [Fact]
+        public async Task SharedEvaluationContextProducesDisjointObservationReports()
+        {
+            var reports = new ConcurrentBag<EvaluationObservationReport>();
+            using IDisposable scope = EvaluationObservationSession.TestOnlyConfigure(
+                enabled: true,
+                reports.Add);
+
+            string firstProject = _env.CreateFile(
+                "first.proj",
+                """
+                <Project>
+                  <PropertyGroup Condition="Exists('first.marker')" />
+                </Project>
+                """.Cleanup()).Path;
+            string secondProject = _env.CreateFile(
+                "second.proj",
+                """
+                <Project>
+                  <PropertyGroup Condition="Exists('second.marker')" />
+                </Project>
+                """.Cleanup()).Path;
+
+            EvaluationContext context = EvaluationContext.Create(EvaluationContext.SharingPolicy.Shared);
+            ProjectCollection firstCollection = _env.CreateProjectCollection().Collection;
+            ProjectCollection secondCollection = _env.CreateProjectCollection().Collection;
+
+            await Task.WhenAll(
+                Task.Run(() => Project.FromFile(firstProject, new ProjectOptions
+                {
+                    ProjectCollection = firstCollection,
+                    EvaluationContext = context,
+                })),
+                Task.Run(() => Project.FromFile(secondProject, new ProjectOptions
+                {
+                    ProjectCollection = secondCollection,
+                    EvaluationContext = context,
+                })));
+
+            reports.Count.ShouldBe(2);
+
+            string firstMarker = Path.Combine(_env.DefaultTestDirectory.Path, "first.marker");
+            string secondMarker = Path.Combine(_env.DefaultTestDirectory.Path, "second.marker");
+
+            reports.Count(report =>
+                FileUtilities.PathsEqual(report.ProjectPath, firstProject) &&
+                report.PathProbes.Any(observation => FileUtilities.PathsEqual(observation.Path, firstMarker)) &&
+                !report.PathProbes.Any(observation => FileUtilities.PathsEqual(observation.Path, secondMarker)))
+                .ShouldBe(1);
+            reports.Count(report =>
+                FileUtilities.PathsEqual(report.ProjectPath, secondProject) &&
+                report.PathProbes.Any(observation => FileUtilities.PathsEqual(observation.Path, secondMarker)) &&
+                !report.PathProbes.Any(observation => FileUtilities.PathsEqual(observation.Path, firstMarker)))
+                .ShouldBe(1);
+
+            reports.ShouldAllBe(report =>
+                (report.Reasons & EvaluationObservationReason.UnversionedSharedCache) != 0);
+        }
+
+        [Fact]
+        public void RecordingFileSystemPreservesPartialEnumeration()
+        {
+            EvaluationObservationSession session = EvaluationObservationSession.CreateForTests();
+            var innerFileSystem = new PartialEnumerationFileSystem();
+            var recordingFileSystem = new RecordingFileSystem(innerFileSystem, session);
+
+            using (IEnumerator<string> enumerator = recordingFileSystem.EnumerateFiles("root").GetEnumerator())
+            {
+                enumerator.MoveNext().ShouldBeTrue();
+                enumerator.Current.ShouldBe("first.cs");
+            }
+
+            EvaluationObservationReport report = session.Complete(evaluationSucceeded: true);
+
+            innerFileSystem.EntriesProduced.ShouldBe(1);
+            report.DirectoryEnumerations.ShouldHaveSingleItem()
+                .Completion.ShouldBe(EvaluationEnumerationCompletion.Partial);
+            report.DirectoryEnumerations[0].Entries.ShouldBe(["first.cs"]);
+            (report.Reasons & EvaluationObservationReason.PartialEnumeration)
+                .ShouldBe(EvaluationObservationReason.PartialEnumeration);
+        }
+
+        [Fact]
+        public void RecordingFileSystemDoesNotRetainEnumerationAfterCompletion()
+        {
+            EvaluationObservationSession session = EvaluationObservationSession.CreateForTests();
+            var recordingFileSystem = new RecordingFileSystem(new PartialEnumerationFileSystem(), session);
+            IEnumerator<string> enumerator = recordingFileSystem.EnumerateFiles("root").GetEnumerator();
+
+            enumerator.MoveNext().ShouldBeTrue();
+            EvaluationObservationReport report = session.Complete(evaluationSucceeded: true);
+            enumerator.Dispose();
+
+            report.DirectoryEnumerations.ShouldBeEmpty();
+            session.TestOnlyRetainedObservationCount.ShouldBe(0);
+        }
+
+        [Fact]
+        public void RecordingFileSystemMarksConflictingProbeResults()
+        {
+            EvaluationObservationSession session = EvaluationObservationSession.CreateForTests();
+            var recordingFileSystem = new RecordingFileSystem(new AlternatingProbeFileSystem(), session);
+
+            recordingFileSystem.FileExists("probe").ShouldBeFalse();
+            recordingFileSystem.FileExists("probe").ShouldBeTrue();
+
+            EvaluationObservationReport report = session.Complete(evaluationSucceeded: true);
+
+            (report.Reasons & EvaluationObservationReason.AmbiguousNegativeProbe)
+                .ShouldBe(EvaluationObservationReason.AmbiguousNegativeProbe);
+            (report.Reasons & EvaluationObservationReason.ConflictingObservation)
+                .ShouldBe(EvaluationObservationReason.ConflictingObservation);
+        }
+
+        [Fact]
+        public void RecordingFileSystemRecordsMetadataAndFileReads()
+        {
+            EvaluationObservationSession session = EvaluationObservationSession.CreateForTests();
+            var recordingFileSystem = new RecordingFileSystem(new ReadAndMetadataFileSystem(), session);
+            string textPath = Path.Combine(_env.DefaultTestDirectory.Path, "text.txt");
+            string readerPath = Path.Combine(_env.DefaultTestDirectory.Path, "reader.txt");
+
+            recordingFileSystem.ReadFileAllText(textPath).ShouldBe("content");
+            recordingFileSystem.ReadFile(readerPath).ReadToEnd().ShouldBe("reader");
+            recordingFileSystem.GetAttributes(textPath).ShouldBe(FileAttributes.ReadOnly);
+            recordingFileSystem.GetLastWriteTimeUtc(textPath).ShouldBe(new DateTime(1234, DateTimeKind.Utc));
+
+            EvaluationObservationReport report = session.Complete(evaluationSucceeded: true);
+
+            EvaluationFileReadObservation textRead = report.FileReads.Single(
+                observation => FileUtilities.PathsEqual(observation.Path, textPath));
+            textRead.IsVerifiable.ShouldBeTrue();
+            textRead.ContentHash.ShouldNotBeNull();
+
+            EvaluationFileReadObservation readerRead = report.FileReads.Single(
+                observation => FileUtilities.PathsEqual(observation.Path, readerPath));
+            readerRead.IsVerifiable.ShouldBeFalse();
+            readerRead.ContentHash.ShouldBeNull();
+            report.MetadataReads.Count(observation => FileUtilities.PathsEqual(observation.Path, textPath))
+                .ShouldBe(2);
+            (report.Reasons & EvaluationObservationReason.UnverifiableFileRead)
+                .ShouldBe(EvaluationObservationReason.UnverifiableFileRead);
+        }
+
+        [Fact]
+        public void RecordingFileSystemMarksReadAndMetadataFailures()
+        {
+            EvaluationObservationSession session = EvaluationObservationSession.CreateForTests();
+            var recordingFileSystem = new RecordingFileSystem(new ThrowingFileSystem(), session);
+
+            Should.Throw<IOException>(() => recordingFileSystem.ReadFileAllText("read"));
+            Should.Throw<IOException>(() => recordingFileSystem.GetAttributes("metadata"));
+
+            EvaluationObservationReport report = session.Complete(evaluationSucceeded: false);
+
+            report.EvaluationSucceeded.ShouldBeFalse();
+            (report.Reasons & EvaluationObservationReason.ExternalOperationFailure)
+                .ShouldBe(EvaluationObservationReason.ExternalOperationFailure);
         }
 
         [Theory]
@@ -998,6 +1391,64 @@ namespace Microsoft.Build.UnitTests.Definition
                 });
 
             evaluationCount.ShouldBe(2);
+        }
+
+        private abstract class TestFileSystemBase : IFileSystem
+        {
+            public virtual TextReader ReadFile(string path) => throw new NotSupportedException();
+            public virtual Stream GetFileStream(string path, FileMode mode, FileAccess access, FileShare share) => throw new NotSupportedException();
+            public virtual string ReadFileAllText(string path) => throw new NotSupportedException();
+            public virtual byte[] ReadFileAllBytes(string path) => throw new NotSupportedException();
+            public virtual IEnumerable<string> EnumerateFiles(string path, string searchPattern = "*", SearchOption searchOption = SearchOption.TopDirectoryOnly) => throw new NotSupportedException();
+            public virtual IEnumerable<string> EnumerateDirectories(string path, string searchPattern = "*", SearchOption searchOption = SearchOption.TopDirectoryOnly) => throw new NotSupportedException();
+            public virtual IEnumerable<string> EnumerateFileSystemEntries(string path, string searchPattern = "*", SearchOption searchOption = SearchOption.TopDirectoryOnly) => throw new NotSupportedException();
+            public virtual FileAttributes GetAttributes(string path) => throw new NotSupportedException();
+            public virtual DateTime GetLastWriteTimeUtc(string path) => throw new NotSupportedException();
+            public virtual bool DirectoryExists(string path) => throw new NotSupportedException();
+            public virtual bool FileExists(string path) => throw new NotSupportedException();
+            public virtual bool FileOrDirectoryExists(string path) => throw new NotSupportedException();
+        }
+
+        private sealed class PartialEnumerationFileSystem : TestFileSystemBase
+        {
+            internal int EntriesProduced { get; private set; }
+
+            public override IEnumerable<string> EnumerateFiles(
+                string path,
+                string searchPattern = "*",
+                SearchOption searchOption = SearchOption.TopDirectoryOnly)
+            {
+                EntriesProduced++;
+                yield return "first.cs";
+                EntriesProduced++;
+                yield return "second.cs";
+            }
+        }
+
+        private sealed class AlternatingProbeFileSystem : TestFileSystemBase
+        {
+            private bool _exists;
+
+            public override bool FileExists(string path)
+            {
+                bool result = _exists;
+                _exists = true;
+                return result;
+            }
+        }
+
+        private sealed class ReadAndMetadataFileSystem : TestFileSystemBase
+        {
+            public override TextReader ReadFile(string path) => new StringReader("reader");
+            public override string ReadFileAllText(string path) => "content";
+            public override FileAttributes GetAttributes(string path) => FileAttributes.ReadOnly;
+            public override DateTime GetLastWriteTimeUtc(string path) => new(1234, DateTimeKind.Utc);
+        }
+
+        private sealed class ThrowingFileSystem : TestFileSystemBase
+        {
+            public override string ReadFileAllText(string path) => throw new IOException("Read failed.");
+            public override FileAttributes GetAttributes(string path) => throw new IOException("Metadata failed.");
         }
 
         private void EvaluateProjects(IEnumerable<string> projectContents, EvaluationContext context, Action<Project> afterEvaluationAction)

--- a/src/Build/Evaluation/Context/EvaluationObservationSession.cs
+++ b/src/Build/Evaluation/Context/EvaluationObservationSession.cs
@@ -1,0 +1,1161 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Shared.FileSystem;
+
+#nullable disable
+
+namespace Microsoft.Build.Evaluation.Context
+{
+    [Flags]
+    internal enum EvaluationObservationReason
+    {
+        None = 0,
+        PrototypeCategoriesIncomplete = 1 << 0,
+        FileContentReadsNotImplemented = 1 << 1,
+        AmbiguousNegativeProbe = 1 << 2,
+        ConflictingObservation = 1 << 3,
+        PartialEnumeration = 1 << 4,
+        ExternalOperationFailure = 1 << 5,
+        UnverifiableFileRead = 1 << 6,
+        UnversionedSharedCache = 1 << 7,
+        UnversionedFileExistenceCache = 1 << 8,
+        UnversionedGlobCache = 1 << 9,
+        UnversionedDirectoryCache = 1 << 10,
+        ProjectXmlContentNotObserved = 1 << 11,
+        UnversionedProjectRootElementCache = 1 << 12,
+        UnversionedSdkResolverCache = 1 << 13,
+        IncompleteEvaluationStage = 1 << 14,
+        UnrootedPath = 1 << 15,
+    }
+
+    internal enum EvaluationPathKind
+    {
+        File,
+        Directory,
+        FileOrDirectory,
+    }
+
+    internal enum EvaluationEnumerationKind
+    {
+        Files,
+        Directories,
+        FilesAndDirectories,
+    }
+
+    internal enum EvaluationEnumerationCompletion
+    {
+        Complete,
+        Partial,
+        Failure,
+    }
+
+    internal enum EvaluationMetadataKind
+    {
+        Attributes,
+        LastWriteTimeUtc,
+    }
+
+    internal readonly struct EvaluationPathProbeObservation
+    {
+        internal EvaluationPathProbeObservation(string path, EvaluationPathKind kind, bool exists)
+        {
+            Path = path;
+            Kind = kind;
+            Exists = exists;
+        }
+
+        internal string Path { get; }
+        internal EvaluationPathKind Kind { get; }
+        internal bool Exists { get; }
+    }
+
+    internal readonly struct EvaluationDirectoryEnumerationObservation
+    {
+        internal EvaluationDirectoryEnumerationObservation(
+            string path,
+            string searchPattern,
+            SearchOption searchOption,
+            EvaluationEnumerationKind kind,
+            string[] entries,
+            EvaluationEnumerationCompletion completion)
+        {
+            Path = path;
+            SearchPattern = searchPattern;
+            SearchOption = searchOption;
+            Kind = kind;
+            Entries = entries;
+            Completion = completion;
+        }
+
+        internal string Path { get; }
+        internal string SearchPattern { get; }
+        internal SearchOption SearchOption { get; }
+        internal EvaluationEnumerationKind Kind { get; }
+        internal string[] Entries { get; }
+        internal EvaluationEnumerationCompletion Completion { get; }
+    }
+
+    internal readonly struct EvaluationMetadataObservation
+    {
+        internal EvaluationMetadataObservation(string path, EvaluationMetadataKind kind, long value)
+        {
+            Path = path;
+            Kind = kind;
+            Value = value;
+        }
+
+        internal string Path { get; }
+        internal EvaluationMetadataKind Kind { get; }
+        internal long Value { get; }
+    }
+
+    internal readonly struct EvaluationFileReadObservation
+    {
+        internal EvaluationFileReadObservation(string path, string contentHash, bool isVerifiable)
+        {
+            Path = path;
+            ContentHash = contentHash;
+            IsVerifiable = isVerifiable;
+        }
+
+        internal string Path { get; }
+        internal string ContentHash { get; }
+        internal bool IsVerifiable { get; }
+    }
+
+    internal sealed class EvaluationObservationReport
+    {
+        internal EvaluationObservationReport(
+            int evaluationId,
+            string projectPath,
+            bool evaluationSucceeded,
+            EvaluationObservationReason reasons,
+            EvaluationPathProbeObservation[] pathProbes,
+            EvaluationDirectoryEnumerationObservation[] directoryEnumerations,
+            EvaluationMetadataObservation[] metadataReads,
+            EvaluationFileReadObservation[] fileReads)
+        {
+            EvaluationId = evaluationId;
+            ProjectPath = projectPath;
+            EvaluationSucceeded = evaluationSucceeded;
+            Reasons = reasons;
+            PathProbes = pathProbes;
+            DirectoryEnumerations = directoryEnumerations;
+            MetadataReads = metadataReads;
+            FileReads = fileReads;
+        }
+
+        internal int EvaluationId { get; }
+        internal string ProjectPath { get; }
+        internal bool EvaluationSucceeded { get; }
+        internal EvaluationObservationReason Reasons { get; }
+        internal EvaluationPathProbeObservation[] PathProbes { get; }
+        internal EvaluationDirectoryEnumerationObservation[] DirectoryEnumerations { get; }
+        internal EvaluationMetadataObservation[] MetadataReads { get; }
+        internal EvaluationFileReadObservation[] FileReads { get; }
+        internal bool ReadyForCacheHits => false;
+    }
+
+    internal sealed class EvaluationObservationSession
+    {
+        private const string ObservationEnvironmentVariable = "MSBUILDPROTOTYPEEVALUATIONOBSERVATION";
+
+        private static readonly bool s_enabled =
+            Environment.GetEnvironmentVariable(ObservationEnvironmentVariable) == "1";
+
+        private static readonly object s_testLock = new();
+        private static TestConfiguration s_testConfiguration;
+
+        private readonly int _evaluationId;
+        private readonly string _projectPath;
+        private readonly ConcurrentDictionary<PathProbeKey, bool> _pathProbes = new();
+        private readonly ConcurrentDictionary<EnumerationKey, EvaluationDirectoryEnumerationObservation> _directoryEnumerations = new();
+        private readonly ConcurrentDictionary<MetadataKey, long> _metadataReads = new();
+        private readonly ConcurrentDictionary<string, EvaluationFileReadObservation> _fileReads =
+            new(FileUtilities.PathComparer);
+        private readonly object _observationLock = new();
+
+        private int _reasons;
+        private int _completed;
+        private TestConfiguration _testConfiguration;
+
+        private EvaluationObservationSession(
+            int evaluationId,
+            string projectPath,
+            ProjectEvaluationStage evaluationStage,
+            EvaluationContext.SharingPolicy sharingPolicy,
+            bool hasDirectoryCache,
+            TestConfiguration testConfiguration)
+        {
+            _evaluationId = evaluationId;
+            _reasons = (int)(EvaluationObservationReason.PrototypeCategoriesIncomplete |
+                EvaluationObservationReason.FileContentReadsNotImplemented |
+                EvaluationObservationReason.ProjectXmlContentNotObserved |
+                EvaluationObservationReason.UnversionedProjectRootElementCache);
+            _projectPath = NormalizePath(projectPath);
+            _testConfiguration = testConfiguration;
+
+            if (sharingPolicy == EvaluationContext.SharingPolicy.Shared)
+            {
+                AddReason(EvaluationObservationReason.UnversionedSharedCache);
+            }
+
+            if (sharingPolicy != EvaluationContext.SharingPolicy.Isolated)
+            {
+                AddReason(EvaluationObservationReason.UnversionedSdkResolverCache);
+            }
+
+            if (evaluationStage != ProjectEvaluationStage.Full)
+            {
+                AddReason(EvaluationObservationReason.IncompleteEvaluationStage);
+            }
+
+            if (Traits.Instance.CacheFileExistence)
+            {
+                AddReason(EvaluationObservationReason.UnversionedFileExistenceCache);
+            }
+
+            if (Traits.Instance.MSBuildCacheFileEnumerations)
+            {
+                AddReason(EvaluationObservationReason.UnversionedGlobCache);
+            }
+
+            if (hasDirectoryCache)
+            {
+                AddReason(EvaluationObservationReason.UnversionedDirectoryCache);
+            }
+        }
+
+        internal static EvaluationObservationSession TryCreate(
+            int evaluationId,
+            string projectPath,
+            ProjectEvaluationStage evaluationStage,
+            EvaluationContext.SharingPolicy sharingPolicy,
+            bool hasDirectoryCache)
+        {
+            TestConfiguration testConfiguration = Volatile.Read(ref s_testConfiguration);
+            bool enabled = testConfiguration?.Enabled ?? s_enabled;
+
+            return enabled
+                ? new EvaluationObservationSession(
+                    evaluationId,
+                    projectPath,
+                    evaluationStage,
+                    sharingPolicy,
+                    hasDirectoryCache,
+                    testConfiguration)
+                : null;
+        }
+
+        internal static EvaluationObservationSession CreateForTests(int evaluationId = 1)
+        {
+            return new EvaluationObservationSession(
+                evaluationId,
+                projectPath: null,
+                ProjectEvaluationStage.Full,
+                EvaluationContext.SharingPolicy.Isolated,
+                hasDirectoryCache: false,
+                testConfiguration: null);
+        }
+
+        internal static IDisposable TestOnlyConfigure(
+            bool enabled,
+            Action<EvaluationObservationReport> reportCreated = null)
+        {
+            var configuration = new TestConfiguration(enabled, reportCreated);
+            lock (s_testLock)
+            {
+                Assumed.Null(s_testConfiguration, "A test observation scope is already active.");
+                Volatile.Write(ref s_testConfiguration, configuration);
+            }
+
+            return new TestScope(configuration);
+        }
+
+        internal bool IsCompleted => Volatile.Read(ref _completed) != 0;
+
+        internal int TestOnlyRetainedObservationCount
+        {
+            get
+            {
+                lock (_observationLock)
+                {
+                    return _pathProbes.Count +
+                        _directoryEnumerations.Count +
+                        _metadataReads.Count +
+                        _fileReads.Count;
+                }
+            }
+        }
+
+        internal void RecordProbe(string path, EvaluationPathKind kind, bool exists)
+        {
+            try
+            {
+                lock (_observationLock)
+                {
+                    if (IsCompleted)
+                    {
+                        return;
+                    }
+
+                    var key = new PathProbeKey(NormalizePath(path), kind);
+                    if (!_pathProbes.TryAdd(key, exists) &&
+                        _pathProbes.TryGetValue(key, out bool priorResult) &&
+                        priorResult != exists)
+                    {
+                        AddReason(EvaluationObservationReason.ConflictingObservation);
+                    }
+
+                    if (!exists)
+                    {
+                        AddReason(EvaluationObservationReason.AmbiguousNegativeProbe);
+                    }
+                }
+            }
+            catch (Exception ex) when (!ExceptionHandling.IsCriticalException(ex))
+            {
+                AddReason(EvaluationObservationReason.ExternalOperationFailure);
+            }
+        }
+
+        internal void RecordEnumeration(
+            string path,
+            string searchPattern,
+            SearchOption searchOption,
+            EvaluationEnumerationKind kind,
+            IReadOnlyList<string> entries,
+            EvaluationEnumerationCompletion completion)
+        {
+            try
+            {
+                lock (_observationLock)
+                {
+                    if (IsCompleted)
+                    {
+                        return;
+                    }
+
+                    string[] entrySnapshot = new string[entries.Count];
+                    for (int i = 0; i < entries.Count; i++)
+                    {
+                        entrySnapshot[i] = entries[i];
+                    }
+
+                    var key = new EnumerationKey(NormalizePath(path), searchPattern ?? "*", searchOption, kind);
+                    var observation = new EvaluationDirectoryEnumerationObservation(
+                        key.Path,
+                        key.SearchPattern,
+                        key.SearchOption,
+                        key.Kind,
+                        entrySnapshot,
+                        completion);
+
+                    if (!_directoryEnumerations.TryAdd(key, observation) &&
+                        _directoryEnumerations.TryGetValue(key, out EvaluationDirectoryEnumerationObservation priorObservation) &&
+                        !EnumerationResultsEqual(priorObservation, observation))
+                    {
+                        AddReason(EvaluationObservationReason.ConflictingObservation);
+                    }
+
+                    if (completion != EvaluationEnumerationCompletion.Complete)
+                    {
+                        AddReason(completion == EvaluationEnumerationCompletion.Failure
+                            ? EvaluationObservationReason.ExternalOperationFailure
+                            : EvaluationObservationReason.PartialEnumeration);
+                    }
+                }
+            }
+            catch (Exception ex) when (!ExceptionHandling.IsCriticalException(ex))
+            {
+                AddReason(EvaluationObservationReason.ExternalOperationFailure);
+            }
+        }
+
+        internal void RecordMetadata(string path, EvaluationMetadataKind kind, long value)
+        {
+            try
+            {
+                lock (_observationLock)
+                {
+                    if (IsCompleted)
+                    {
+                        return;
+                    }
+
+                    var key = new MetadataKey(NormalizePath(path), kind);
+                    if (!_metadataReads.TryAdd(key, value) &&
+                        _metadataReads.TryGetValue(key, out long priorValue) &&
+                        priorValue != value)
+                    {
+                        AddReason(EvaluationObservationReason.ConflictingObservation);
+                    }
+                }
+            }
+            catch (Exception ex) when (!ExceptionHandling.IsCriticalException(ex))
+            {
+                AddReason(EvaluationObservationReason.ExternalOperationFailure);
+            }
+        }
+
+        internal void RecordFileRead(string path, string contentHash, bool isVerifiable)
+        {
+            try
+            {
+                lock (_observationLock)
+                {
+                    if (IsCompleted)
+                    {
+                        return;
+                    }
+
+                    string normalizedPath = NormalizePath(path);
+                    var observation = new EvaluationFileReadObservation(normalizedPath, contentHash, isVerifiable);
+
+                    if (!_fileReads.TryAdd(normalizedPath, observation) &&
+                        _fileReads.TryGetValue(normalizedPath, out EvaluationFileReadObservation priorObservation))
+                    {
+                        if (priorObservation.IsVerifiable && observation.IsVerifiable)
+                        {
+                            if (!string.Equals(priorObservation.ContentHash, observation.ContentHash, StringComparison.Ordinal))
+                            {
+                                AddReason(EvaluationObservationReason.ConflictingObservation);
+                            }
+                        }
+                        else if (!priorObservation.IsVerifiable && observation.IsVerifiable)
+                        {
+                            _fileReads[normalizedPath] = observation;
+                        }
+                    }
+
+                    if (!isVerifiable)
+                    {
+                        AddReason(EvaluationObservationReason.UnverifiableFileRead);
+                    }
+                }
+            }
+            catch (Exception ex) when (!ExceptionHandling.IsCriticalException(ex))
+            {
+                AddReason(EvaluationObservationReason.ExternalOperationFailure);
+            }
+        }
+
+        internal void RecordOperationFailure()
+        {
+            lock (_observationLock)
+            {
+                if (!IsCompleted)
+                {
+                    AddReason(EvaluationObservationReason.ExternalOperationFailure);
+                }
+            }
+        }
+
+        internal EvaluationObservationReport Complete(bool evaluationSucceeded)
+        {
+            EvaluationObservationReport report;
+            TestConfiguration testConfiguration;
+            lock (_observationLock)
+            {
+                if (IsCompleted)
+                {
+                    return null;
+                }
+
+                Volatile.Write(ref _completed, 1);
+                try
+                {
+                    report = new EvaluationObservationReport(
+                        _evaluationId,
+                        _projectPath,
+                        evaluationSucceeded,
+                        (EvaluationObservationReason)Volatile.Read(ref _reasons),
+                        CreatePathProbeSnapshot(),
+                        CreateEnumerationSnapshot(),
+                        CreateMetadataSnapshot(),
+                        CreateFileReadSnapshot());
+                }
+                catch (Exception ex) when (!ExceptionHandling.IsCriticalException(ex))
+                {
+                    report = new EvaluationObservationReport(
+                        _evaluationId,
+                        _projectPath,
+                        evaluationSucceeded,
+                        (EvaluationObservationReason)Volatile.Read(ref _reasons) |
+                            EvaluationObservationReason.ExternalOperationFailure,
+                        [],
+                        [],
+                        [],
+                        []);
+                }
+
+                _pathProbes.Clear();
+                _directoryEnumerations.Clear();
+                _metadataReads.Clear();
+                _fileReads.Clear();
+                testConfiguration = Interlocked.Exchange(ref _testConfiguration, null);
+            }
+
+            try
+            {
+                testConfiguration?.ReportCreated?.Invoke(report);
+            }
+            catch (Exception ex) when (!ExceptionHandling.IsCriticalException(ex))
+            {
+                Interlocked.CompareExchange(ref testConfiguration.ReportException, ex, null);
+            }
+
+            return report;
+        }
+
+        private static string ComputeHash(byte[] content)
+        {
+            using SHA256 sha256 = SHA256.Create();
+            return Convert.ToBase64String(sha256.ComputeHash(content));
+        }
+
+        private static string ComputeHash(string content)
+        {
+            return ComputeHash(Encoding.UTF8.GetBytes(content));
+        }
+
+        internal static string ComputeTextHash(string content) => ComputeHash(content);
+        internal static string ComputeBytesHash(byte[] content) => ComputeHash(content);
+
+        private string NormalizePath(string path)
+        {
+            if (string.IsNullOrEmpty(path) || Path.IsPathRooted(path))
+            {
+                return string.IsNullOrEmpty(path) ? path : FileUtilities.GetFullPathNoThrow(path);
+            }
+
+            AddReason(EvaluationObservationReason.UnrootedPath);
+            return path;
+        }
+
+        private static bool EnumerationResultsEqual(
+            EvaluationDirectoryEnumerationObservation left,
+            EvaluationDirectoryEnumerationObservation right)
+        {
+            if (left.Completion != right.Completion || left.Entries.Length != right.Entries.Length)
+            {
+                return false;
+            }
+
+            for (int i = 0; i < left.Entries.Length; i++)
+            {
+                if (!FileUtilities.PathComparer.Equals(left.Entries[i], right.Entries[i]))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private EvaluationPathProbeObservation[] CreatePathProbeSnapshot()
+        {
+            var observations = new List<EvaluationPathProbeObservation>(_pathProbes.Count);
+            foreach (KeyValuePair<PathProbeKey, bool> observation in _pathProbes)
+            {
+                observations.Add(new EvaluationPathProbeObservation(
+                    observation.Key.Path,
+                    observation.Key.Kind,
+                    observation.Value));
+            }
+
+            EvaluationPathProbeObservation[] snapshot = observations.ToArray();
+            Array.Sort(snapshot, static (left, right) =>
+            {
+                int pathComparison = FileUtilities.PathComparer.Compare(left.Path, right.Path);
+                return pathComparison != 0 ? pathComparison : left.Kind.CompareTo(right.Kind);
+            });
+            return snapshot;
+        }
+
+        private EvaluationDirectoryEnumerationObservation[] CreateEnumerationSnapshot()
+        {
+            var observations = new List<EvaluationDirectoryEnumerationObservation>(_directoryEnumerations.Count);
+            foreach (EvaluationDirectoryEnumerationObservation observation in _directoryEnumerations.Values)
+            {
+                observations.Add(observation);
+            }
+
+            EvaluationDirectoryEnumerationObservation[] snapshot = observations.ToArray();
+            Array.Sort(snapshot, static (left, right) =>
+            {
+                int pathComparison = FileUtilities.PathComparer.Compare(left.Path, right.Path);
+                if (pathComparison != 0)
+                {
+                    return pathComparison;
+                }
+
+                int patternComparison = string.Compare(left.SearchPattern, right.SearchPattern, StringComparison.Ordinal);
+                return patternComparison != 0 ? patternComparison : left.Kind.CompareTo(right.Kind);
+            });
+            return snapshot;
+        }
+
+        private EvaluationMetadataObservation[] CreateMetadataSnapshot()
+        {
+            var observations = new List<EvaluationMetadataObservation>(_metadataReads.Count);
+            foreach (KeyValuePair<MetadataKey, long> observation in _metadataReads)
+            {
+                observations.Add(new EvaluationMetadataObservation(
+                    observation.Key.Path,
+                    observation.Key.Kind,
+                    observation.Value));
+            }
+
+            EvaluationMetadataObservation[] snapshot = observations.ToArray();
+            Array.Sort(snapshot, static (left, right) =>
+            {
+                int pathComparison = FileUtilities.PathComparer.Compare(left.Path, right.Path);
+                return pathComparison != 0 ? pathComparison : left.Kind.CompareTo(right.Kind);
+            });
+            return snapshot;
+        }
+
+        private EvaluationFileReadObservation[] CreateFileReadSnapshot()
+        {
+            var observations = new List<EvaluationFileReadObservation>(_fileReads.Count);
+            foreach (EvaluationFileReadObservation observation in _fileReads.Values)
+            {
+                observations.Add(observation);
+            }
+
+            EvaluationFileReadObservation[] snapshot = observations.ToArray();
+            Array.Sort(snapshot, static (left, right) => FileUtilities.PathComparer.Compare(left.Path, right.Path));
+            return snapshot;
+        }
+
+        private void AddReason(EvaluationObservationReason reason)
+        {
+            int priorValue;
+            int newValue;
+            do
+            {
+                priorValue = Volatile.Read(ref _reasons);
+                newValue = priorValue | (int)reason;
+            }
+            while (Interlocked.CompareExchange(ref _reasons, newValue, priorValue) != priorValue);
+        }
+
+        private readonly struct PathProbeKey : IEquatable<PathProbeKey>
+        {
+            internal PathProbeKey(string path, EvaluationPathKind kind)
+            {
+                Path = path;
+                Kind = kind;
+            }
+
+            internal string Path { get; }
+            internal EvaluationPathKind Kind { get; }
+
+            public bool Equals(PathProbeKey other)
+            {
+                return Kind == other.Kind && FileUtilities.PathComparer.Equals(Path, other.Path);
+            }
+
+            public override bool Equals(object obj) => obj is PathProbeKey other && Equals(other);
+
+            public override int GetHashCode()
+            {
+                unchecked
+                {
+                    return (FileUtilities.PathComparer.GetHashCode(Path) * 397) ^ (int)Kind;
+                }
+            }
+        }
+
+        private readonly struct EnumerationKey : IEquatable<EnumerationKey>
+        {
+            internal EnumerationKey(
+                string path,
+                string searchPattern,
+                SearchOption searchOption,
+                EvaluationEnumerationKind kind)
+            {
+                Path = path;
+                SearchPattern = searchPattern;
+                SearchOption = searchOption;
+                Kind = kind;
+            }
+
+            internal string Path { get; }
+            internal string SearchPattern { get; }
+            internal SearchOption SearchOption { get; }
+            internal EvaluationEnumerationKind Kind { get; }
+
+            public bool Equals(EnumerationKey other)
+            {
+                return SearchOption == other.SearchOption &&
+                    Kind == other.Kind &&
+                    FileUtilities.PathComparer.Equals(Path, other.Path) &&
+                    string.Equals(SearchPattern, other.SearchPattern, StringComparison.Ordinal);
+            }
+
+            public override bool Equals(object obj) => obj is EnumerationKey other && Equals(other);
+
+            public override int GetHashCode()
+            {
+                unchecked
+                {
+                    int hashCode = FileUtilities.PathComparer.GetHashCode(Path);
+                    hashCode = (hashCode * 397) ^ StringComparer.Ordinal.GetHashCode(SearchPattern);
+                    hashCode = (hashCode * 397) ^ (int)SearchOption;
+                    return (hashCode * 397) ^ (int)Kind;
+                }
+            }
+        }
+
+        private readonly struct MetadataKey : IEquatable<MetadataKey>
+        {
+            internal MetadataKey(string path, EvaluationMetadataKind kind)
+            {
+                Path = path;
+                Kind = kind;
+            }
+
+            internal string Path { get; }
+            internal EvaluationMetadataKind Kind { get; }
+
+            public bool Equals(MetadataKey other)
+            {
+                return Kind == other.Kind && FileUtilities.PathComparer.Equals(Path, other.Path);
+            }
+
+            public override bool Equals(object obj) => obj is MetadataKey other && Equals(other);
+
+            public override int GetHashCode()
+            {
+                unchecked
+                {
+                    return (FileUtilities.PathComparer.GetHashCode(Path) * 397) ^ (int)Kind;
+                }
+            }
+        }
+
+        private sealed class TestConfiguration
+        {
+            internal TestConfiguration(bool enabled, Action<EvaluationObservationReport> reportCreated)
+            {
+                Enabled = enabled;
+                ReportCreated = reportCreated;
+            }
+
+            internal bool Enabled { get; }
+            internal Action<EvaluationObservationReport> ReportCreated { get; }
+            internal Exception ReportException;
+        }
+
+        private sealed class TestScope : IDisposable
+        {
+            private readonly TestConfiguration _configuration;
+            private int _disposed;
+
+            internal TestScope(TestConfiguration configuration)
+            {
+                _configuration = configuration;
+            }
+
+            public void Dispose()
+            {
+                if (Interlocked.Exchange(ref _disposed, 1) != 0)
+                {
+                    return;
+                }
+
+                Exception reportException;
+                lock (s_testLock)
+                {
+                    Assumed.True(
+                        ReferenceEquals(s_testConfiguration, _configuration),
+                        "The active test observation scope changed unexpectedly.");
+                    Volatile.Write(ref s_testConfiguration, null);
+                    reportException = _configuration.ReportException;
+                }
+
+                if (reportException is not null)
+                {
+                    throw new InvalidOperationException(
+                        "The test evaluation-observation callback failed.",
+                        reportException);
+                }
+            }
+        }
+    }
+
+    internal sealed class RecordingFileSystem : IFileSystem
+    {
+        private readonly IFileSystem _inner;
+        private readonly EvaluationObservationSession _session;
+
+        internal RecordingFileSystem(IFileSystem inner, EvaluationObservationSession session)
+        {
+            _inner = inner;
+            _session = session;
+        }
+
+        public TextReader ReadFile(string path)
+        {
+            if (_session.IsCompleted)
+            {
+                return _inner.ReadFile(path);
+            }
+
+            try
+            {
+                TextReader reader = _inner.ReadFile(path);
+                _session.RecordFileRead(path, contentHash: null, isVerifiable: false);
+                return reader;
+            }
+            catch (Exception ex) when (!ExceptionHandling.IsCriticalException(ex))
+            {
+                _session.RecordOperationFailure();
+                throw;
+            }
+        }
+
+        public Stream GetFileStream(string path, FileMode mode, FileAccess access, FileShare share)
+        {
+            if (_session.IsCompleted)
+            {
+                return _inner.GetFileStream(path, mode, access, share);
+            }
+
+            try
+            {
+                Stream stream = _inner.GetFileStream(path, mode, access, share);
+                if ((access & FileAccess.Read) != 0)
+                {
+                    _session.RecordFileRead(path, contentHash: null, isVerifiable: false);
+                }
+
+                return stream;
+            }
+            catch (Exception ex) when (!ExceptionHandling.IsCriticalException(ex))
+            {
+                _session.RecordOperationFailure();
+                throw;
+            }
+        }
+
+        public string ReadFileAllText(string path)
+        {
+            if (_session.IsCompleted)
+            {
+                return _inner.ReadFileAllText(path);
+            }
+
+            try
+            {
+                string content = _inner.ReadFileAllText(path);
+                try
+                {
+                    _session.RecordFileRead(path, EvaluationObservationSession.ComputeTextHash(content), isVerifiable: true);
+                }
+                catch (Exception ex) when (!ExceptionHandling.IsCriticalException(ex))
+                {
+                    _session.RecordOperationFailure();
+                }
+
+                return content;
+            }
+            catch (Exception ex) when (!ExceptionHandling.IsCriticalException(ex))
+            {
+                _session.RecordOperationFailure();
+                throw;
+            }
+        }
+
+        public byte[] ReadFileAllBytes(string path)
+        {
+            if (_session.IsCompleted)
+            {
+                return _inner.ReadFileAllBytes(path);
+            }
+
+            try
+            {
+                byte[] content = _inner.ReadFileAllBytes(path);
+                try
+                {
+                    _session.RecordFileRead(path, EvaluationObservationSession.ComputeBytesHash(content), isVerifiable: true);
+                }
+                catch (Exception ex) when (!ExceptionHandling.IsCriticalException(ex))
+                {
+                    _session.RecordOperationFailure();
+                }
+
+                return content;
+            }
+            catch (Exception ex) when (!ExceptionHandling.IsCriticalException(ex))
+            {
+                _session.RecordOperationFailure();
+                throw;
+            }
+        }
+
+        public IEnumerable<string> EnumerateFiles(
+            string path,
+            string searchPattern = "*",
+            SearchOption searchOption = SearchOption.TopDirectoryOnly)
+        {
+            if (_session.IsCompleted)
+            {
+                return _inner.EnumerateFiles(path, searchPattern, searchOption);
+            }
+
+            return RecordEnumeration(
+                path,
+                searchPattern,
+                searchOption,
+                EvaluationEnumerationKind.Files,
+                static (fileSystem, p, pattern, option) => fileSystem.EnumerateFiles(p, pattern, option));
+        }
+
+        public IEnumerable<string> EnumerateDirectories(
+            string path,
+            string searchPattern = "*",
+            SearchOption searchOption = SearchOption.TopDirectoryOnly)
+        {
+            if (_session.IsCompleted)
+            {
+                return _inner.EnumerateDirectories(path, searchPattern, searchOption);
+            }
+
+            return RecordEnumeration(
+                path,
+                searchPattern,
+                searchOption,
+                EvaluationEnumerationKind.Directories,
+                static (fileSystem, p, pattern, option) => fileSystem.EnumerateDirectories(p, pattern, option));
+        }
+
+        public IEnumerable<string> EnumerateFileSystemEntries(
+            string path,
+            string searchPattern = "*",
+            SearchOption searchOption = SearchOption.TopDirectoryOnly)
+        {
+            if (_session.IsCompleted)
+            {
+                return _inner.EnumerateFileSystemEntries(path, searchPattern, searchOption);
+            }
+
+            return RecordEnumeration(
+                path,
+                searchPattern,
+                searchOption,
+                EvaluationEnumerationKind.FilesAndDirectories,
+                static (fileSystem, p, pattern, option) => fileSystem.EnumerateFileSystemEntries(p, pattern, option));
+        }
+
+        public FileAttributes GetAttributes(string path)
+        {
+            if (_session.IsCompleted)
+            {
+                return _inner.GetAttributes(path);
+            }
+
+            try
+            {
+                FileAttributes attributes = _inner.GetAttributes(path);
+                _session.RecordMetadata(path, EvaluationMetadataKind.Attributes, (long)attributes);
+                return attributes;
+            }
+            catch (Exception ex) when (!ExceptionHandling.IsCriticalException(ex))
+            {
+                _session.RecordOperationFailure();
+                throw;
+            }
+        }
+
+        public DateTime GetLastWriteTimeUtc(string path)
+        {
+            if (_session.IsCompleted)
+            {
+                return _inner.GetLastWriteTimeUtc(path);
+            }
+
+            try
+            {
+                DateTime timestamp = _inner.GetLastWriteTimeUtc(path);
+                _session.RecordMetadata(path, EvaluationMetadataKind.LastWriteTimeUtc, timestamp.Ticks);
+                return timestamp;
+            }
+            catch (Exception ex) when (!ExceptionHandling.IsCriticalException(ex))
+            {
+                _session.RecordOperationFailure();
+                throw;
+            }
+        }
+
+        public bool DirectoryExists(string path)
+        {
+            if (_session.IsCompleted)
+            {
+                return _inner.DirectoryExists(path);
+            }
+
+            try
+            {
+                bool exists = _inner.DirectoryExists(path);
+                _session.RecordProbe(path, EvaluationPathKind.Directory, exists);
+                return exists;
+            }
+            catch (Exception ex) when (!ExceptionHandling.IsCriticalException(ex))
+            {
+                _session.RecordOperationFailure();
+                throw;
+            }
+        }
+
+        public bool FileExists(string path)
+        {
+            if (_session.IsCompleted)
+            {
+                return _inner.FileExists(path);
+            }
+
+            try
+            {
+                bool exists = _inner.FileExists(path);
+                _session.RecordProbe(path, EvaluationPathKind.File, exists);
+                return exists;
+            }
+            catch (Exception ex) when (!ExceptionHandling.IsCriticalException(ex))
+            {
+                _session.RecordOperationFailure();
+                throw;
+            }
+        }
+
+        public bool FileOrDirectoryExists(string path)
+        {
+            if (_session.IsCompleted)
+            {
+                return _inner.FileOrDirectoryExists(path);
+            }
+
+            try
+            {
+                bool exists = _inner.FileOrDirectoryExists(path);
+                _session.RecordProbe(path, EvaluationPathKind.FileOrDirectory, exists);
+                return exists;
+            }
+            catch (Exception ex) when (!ExceptionHandling.IsCriticalException(ex))
+            {
+                _session.RecordOperationFailure();
+                throw;
+            }
+        }
+
+        private IEnumerable<string> RecordEnumeration(
+            string path,
+            string searchPattern,
+            SearchOption searchOption,
+            EvaluationEnumerationKind kind,
+            Func<IFileSystem, string, string, SearchOption, IEnumerable<string>> enumerate)
+        {
+            IEnumerable<string> entries;
+            try
+            {
+                entries = enumerate(_inner, path, searchPattern, searchOption);
+            }
+            catch (Exception ex) when (!ExceptionHandling.IsCriticalException(ex))
+            {
+                _session.RecordEnumeration(
+                    path,
+                    searchPattern,
+                    searchOption,
+                    kind,
+                    [],
+                    EvaluationEnumerationCompletion.Failure);
+                throw;
+            }
+
+            return RecordEnumerationIterator(path, searchPattern, searchOption, kind, entries);
+        }
+
+        private IEnumerable<string> RecordEnumerationIterator(
+            string path,
+            string searchPattern,
+            SearchOption searchOption,
+            EvaluationEnumerationKind kind,
+            IEnumerable<string> entries)
+        {
+            var observedEntries = new List<string>();
+            EvaluationEnumerationCompletion completion = EvaluationEnumerationCompletion.Partial;
+            IEnumerator<string> enumerator = null;
+
+            try
+            {
+                try
+                {
+                    enumerator = entries.GetEnumerator();
+                }
+                catch (Exception ex) when (!ExceptionHandling.IsCriticalException(ex))
+                {
+                    completion = EvaluationEnumerationCompletion.Failure;
+                    throw;
+                }
+
+                while (true)
+                {
+                    bool hasNext;
+                    try
+                    {
+                        hasNext = enumerator.MoveNext();
+                    }
+                    catch (Exception ex) when (!ExceptionHandling.IsCriticalException(ex))
+                    {
+                        completion = EvaluationEnumerationCompletion.Failure;
+                        throw;
+                    }
+
+                    if (!hasNext)
+                    {
+                        completion = EvaluationEnumerationCompletion.Complete;
+                        yield break;
+                    }
+
+                    string entry = enumerator.Current;
+                    observedEntries.Add(entry);
+                    yield return entry;
+                }
+            }
+            finally
+            {
+                try
+                {
+                    enumerator?.Dispose();
+                }
+                catch (Exception ex) when (!ExceptionHandling.IsCriticalException(ex))
+                {
+                    completion = EvaluationEnumerationCompletion.Failure;
+                    throw;
+                }
+                finally
+                {
+                    _session.RecordEnumeration(
+                        path,
+                        searchPattern,
+                        searchOption,
+                        kind,
+                        observedEntries,
+                        completion);
+                }
+            }
+        }
+    }
+}

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -399,19 +399,25 @@ namespace Microsoft.Build.Evaluation
             }
             finally
             {
-                evaluator._observationSession?.Complete(evaluationSucceeded);
-
-                IEnumerable globalProperties = null;
-                IEnumerable properties = null;
-                IEnumerable items = null;
-
-                if (evaluator._evaluationLoggingContext.LoggingService.IncludeEvaluationPropertiesAndItemsInEvaluationFinishedEvent)
+                try
                 {
-                    globalProperties = evaluator._data.GlobalPropertiesDictionary;
-                    properties = Traits.LogAllEnvironmentVariables ? evaluator._data.Properties : evaluator.FilterOutEnvironmentDerivedProperties(evaluator._data.Properties);
-                    items = evaluator._data.Items;
+                    IEnumerable globalProperties = null;
+                    IEnumerable properties = null;
+                    IEnumerable items = null;
+
+                    if (evaluator._evaluationLoggingContext.LoggingService.IncludeEvaluationPropertiesAndItemsInEvaluationFinishedEvent)
+                    {
+                        globalProperties = evaluator._data.GlobalPropertiesDictionary;
+                        properties = Traits.LogAllEnvironmentVariables ? evaluator._data.Properties : evaluator.FilterOutEnvironmentDerivedProperties(evaluator._data.Properties);
+                        items = evaluator._data.Items;
+                    }
+
+                    evaluator._evaluationLoggingContext.LogProjectEvaluationFinished(globalProperties, properties, items, evaluator._evaluationProfiler.ProfiledResult);
                 }
-                evaluator._evaluationLoggingContext.LogProjectEvaluationFinished(globalProperties, properties, items, evaluator._evaluationProfiler.ProfiledResult);
+                finally
+                {
+                    evaluator._observationSession?.Complete(evaluationSucceeded);
+                }
             }
 
             MSBuildEventSource.Log.EvaluateStop(root.ProjectFileLocation.File);

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -165,6 +165,11 @@ namespace Microsoft.Build.Evaluation
         private readonly EvaluationContext _evaluationContext;
 
         /// <summary>
+        /// Prototype dependency observations for this evaluation.
+        /// </summary>
+        private readonly EvaluationObservationSession _observationSession;
+
+        /// <summary>
         /// The environment properties with which evaluation should take place.
         /// </summary>
         private readonly PropertyDictionary<ProjectPropertyInstance> _environmentProperties;
@@ -246,52 +251,76 @@ namespace Microsoft.Build.Evaluation
             data = new PropertyTrackingEvaluatorDataWrapper<P, I, M, D>(data, _evaluationLoggingContext, Traits.Instance.LogPropertyTracking);
 
             // If the host wishes to provide a directory cache for this evaluation, create a new EvaluationContext with the right file system.
-            _evaluationContext = evaluationContext;
             IDirectoryCache directoryCache = directoryCacheFactory?.GetDirectoryCacheForEvaluation(_evaluationLoggingContext.BuildEventContext.EvaluationId);
+            IFileSystem fileSystem = evaluationContext.FileSystem;
             if (directoryCache is not null)
             {
-                IFileSystem fileSystem = new DirectoryCacheFileSystemWrapper(evaluationContext.FileSystem, directoryCache);
-                _evaluationContext = evaluationContext.ContextWithFileSystem(fileSystem);
+                fileSystem = new DirectoryCacheFileSystemWrapper(fileSystem, directoryCache);
             }
 
-            // Create containers for the evaluation results
-            data.InitializeForEvaluation(toolsetProvider, _evaluationContext, _evaluationLoggingContext);
+            _observationSession = EvaluationObservationSession.TryCreate(
+                _evaluationLoggingContext.BuildEventContext.EvaluationId,
+                projectRootElement.ProjectFileLocation.File,
+                evaluationStage,
+                evaluationContext.Policy,
+                directoryCache is not null);
 
-            _expander = new Expander<P, I>(data, data, _evaluationContext, _evaluationLoggingContext);
-
-            _data = data;
-            _itemGroupElements = new List<ProjectItemGroupElement>();
-            _itemDefinitionGroupElements = new List<ProjectItemDefinitionGroupElement>();
-            _usingTaskElements = new List<KeyValuePair<string, ProjectUsingTaskElement>>();
-            _targetElements = new List<ProjectTargetElement>();
-            _importsSeen = new Dictionary<string, ProjectImportElement>(StringComparer.OrdinalIgnoreCase);
-            _initialTargetsList = new List<string>();
-            _projectSupportsReturnsAttribute = new Dictionary<ProjectRootElement, bool>();
-            _projectRootElement = projectRootElement;
-            _loadSettings = loadSettings;
-            _evaluationStage = evaluationStage;
-            _maxNodeCount = maxNodeCount;
-            _environmentProperties = environmentProperties;
-            _propertiesFromCommandLine = propertiesFromCommandLine ?? [];
-            _itemFactory = itemFactory;
-            _projectRootElementCache = projectRootElementCache;
-            _sdkResolverService = sdkResolverService;
-            _submissionId = submissionId;
-            _evaluationProfiler = new EvaluationProfiler(profileEvaluation);
-            _isRunningInVisualStudio = string.Equals("true", _data.GlobalPropertiesDictionary.GetProperty("BuildingInsideVisualStudio")?.EvaluatedValue, StringComparison.OrdinalIgnoreCase);
-
-            // In 15.9 we added support for the global property "NuGetInteractive" to allow SDK resolvers to be interactive.
-            // In 16.0 we added the /interactive command-line argument so the line below keeps back-compat
-            _interactive = interactive || string.Equals("true", _data.GlobalPropertiesDictionary.GetProperty("NuGetInteractive")?.EvaluatedValue, StringComparison.OrdinalIgnoreCase);
-
-            // The last modified project is the project itself unless its an in-memory project
-            if (projectRootElement.FullPath != null)
+            try
             {
-                _lastModifiedProject = projectRootElement;
+                if (_observationSession is not null)
+                {
+                    fileSystem = new RecordingFileSystem(fileSystem, _observationSession);
+                }
+
+                _evaluationContext = ReferenceEquals(fileSystem, evaluationContext.FileSystem)
+                    ? evaluationContext
+                    : evaluationContext.ContextWithFileSystem(fileSystem);
+
+                // Create containers for the evaluation results
+                data.InitializeForEvaluation(toolsetProvider, _evaluationContext, _evaluationLoggingContext);
+
+                _expander = new Expander<P, I>(data, data, _evaluationContext, _evaluationLoggingContext);
+
+                _data = data;
+                _itemGroupElements = new List<ProjectItemGroupElement>();
+                _itemDefinitionGroupElements = new List<ProjectItemDefinitionGroupElement>();
+                _usingTaskElements = new List<KeyValuePair<string, ProjectUsingTaskElement>>();
+                _targetElements = new List<ProjectTargetElement>();
+                _importsSeen = new Dictionary<string, ProjectImportElement>(StringComparer.OrdinalIgnoreCase);
+                _initialTargetsList = new List<string>();
+                _projectSupportsReturnsAttribute = new Dictionary<ProjectRootElement, bool>();
+                _projectRootElement = projectRootElement;
+                _loadSettings = loadSettings;
+                _evaluationStage = evaluationStage;
+                _maxNodeCount = maxNodeCount;
+                _environmentProperties = environmentProperties;
+                _propertiesFromCommandLine = propertiesFromCommandLine ?? [];
+                _itemFactory = itemFactory;
+                _projectRootElementCache = projectRootElementCache;
+                _sdkResolverService = sdkResolverService;
+                _submissionId = submissionId;
+                _evaluationProfiler = new EvaluationProfiler(profileEvaluation);
+                _isRunningInVisualStudio = string.Equals("true", _data.GlobalPropertiesDictionary.GetProperty("BuildingInsideVisualStudio")?.EvaluatedValue, StringComparison.OrdinalIgnoreCase);
+
+                // In 15.9 we added support for the global property "NuGetInteractive" to allow SDK resolvers to be interactive.
+                // In 16.0 we added the /interactive command-line argument so the line below keeps back-compat
+                _interactive = interactive || string.Equals("true", _data.GlobalPropertiesDictionary.GetProperty("NuGetInteractive")?.EvaluatedValue, StringComparison.OrdinalIgnoreCase);
+
+                // The last modified project is the project itself unless its an in-memory project
+                if (projectRootElement.FullPath != null)
+                {
+                    _lastModifiedProject = projectRootElement;
+                }
+
+                _streamImports = new List<string>();
+                // When the imports are concatenated with a semicolon, this automatically prepends a semicolon if and only if another element is later added.
+                _streamImports.Add(string.Empty);
             }
-            _streamImports = new List<string>();
-            // When the imports are concatenated with a semicolon, this automatically prepends a semicolon if and only if another element is later added.
-            _streamImports.Add(string.Empty);
+            catch (Exception ex) when (!ExceptionHandling.IsCriticalException(ex))
+            {
+                _observationSession?.Complete(evaluationSucceeded: false);
+                throw;
+            }
         }
 
         /// <summary>
@@ -357,9 +386,11 @@ namespace Microsoft.Build.Evaluation
                 buildEventContext,
                 evaluationStage);
 
+            bool evaluationSucceeded = false;
             try
             {
                 evaluator.Evaluate();
+                evaluationSucceeded = true;
             }
             catch (PathTooLongException ex)
             {
@@ -368,6 +399,8 @@ namespace Microsoft.Build.Evaluation
             }
             finally
             {
+                evaluator._observationSession?.Complete(evaluationSucceeded);
+
                 IEnumerable globalProperties = null;
                 IEnumerable properties = null;
                 IEnumerable items = null;
@@ -378,7 +411,6 @@ namespace Microsoft.Build.Evaluation
                     properties = Traits.LogAllEnvironmentVariables ? evaluator._data.Properties : evaluator.FilterOutEnvironmentDerivedProperties(evaluator._data.Properties);
                     items = evaluator._data.Items;
                 }
-
                 evaluator._evaluationLoggingContext.LogProjectEvaluationFinished(globalProperties, properties, items, evaluator._evaluationProfiler.ProfiledResult);
             }
 

--- a/src/Build/Microsoft.Build.csproj
+++ b/src/Build/Microsoft.Build.csproj
@@ -320,6 +320,7 @@
     <Compile Include="Definition\ProjectEvaluationStage.cs" />
     <Compile Include="Definition\ToolsetLocalReader.cs" />
     <Compile Include="Evaluation\Context\EvaluationContext.cs" />
+    <Compile Include="Evaluation\Context\EvaluationObservationSession.cs" />
     <Compile Include="Evaluation\Profiler\EvaluationLocationMarkdownPrettyPrinter.cs" />
     <Compile Include="Evaluation\Profiler\EvaluationLocationPrettyPrinterBase.cs" />
     <Compile Include="Evaluation\Profiler\EvaluationLocationTabSeparatedPrettyPrinter.cs" />


### PR DESCRIPTION
### Context

This is the first implementation step toward a safe MSBuild evaluation cache. It adds evaluator-native dependency observation only; it does not serve cache hits.

The prototype is deliberately fail-closed. Every report has `ReadyForCacheHits = false`, and incomplete or unversioned input paths are represented by explicit reason flags.

### Changes

- Add one `EvaluationObservationSession` per evaluation, never on the shareable `EvaluationContext`.
- Reuse the existing internal `IFileSystem` seam through an outer `RecordingFileSystem`, composed after any host directory cache.
- Record typed file/directory probes, directory enumerations, metadata reads, and file reads.
- Preserve lazy enumeration semantics and distinguish complete, partial, and failed enumeration.
- Record project identity, evaluation success, and explicit reasons for unsupported project XML/import content, partial evaluation, shared SDK/PRE/file/glob/directory caches, ambiguous negative probes, and unverifiable reads.
- Atomically close the observation window at evaluation completion so late project API calls or delayed enumerators cannot retain or mutate observations.
- Keep observation off by default behind `MSBUILDPROTOTYPEEVALUATIONOBSERVATION=1`.
- Add focused coverage for disabled behavior, state equivalence, shared-context isolation, cache provenance, partial stages, callback failures, lazy enumeration, conflicts, metadata, content reads, operation failures, and post-completion lifetime.

### Intentional limitations

- No cache lookup or cache hit path.
- No serialization, persistence, watchers, journals, reverse index, or invalidation engine.
- Root and imported project XML content still bypasses the filesystem recorder and is explicitly marked incomplete.
- Environment, registry, SDK-resolver-private state, and other non-filesystem categories remain future observation work.
- PR1 has no production report sink; the report is currently exercised through internal tests.

### Testing

- `Microsoft.Build.Engine.UnitTests.csproj` net11 build: passed with 0 warnings and 0 errors.
- Observation-focused tests: 13 passed.
- `ProjectEvaluationContext_Tests`: 65 passed, 1 pre-existing skip.
- Broad intended Windows net11 engine run: 5,101 passed; 4 unrelated process-launch tests timed out at the existing 30-second limit:
  - `TerminalLoggerOnInvalidProjectBuild(msbuildinprocnodeState: "1")`
  - `BuildProjectWithMultipleTargetsInParallel`
  - `AssemblyLoadsDuringTaskRunLoggedWithAssemblyLoadContext`
  - `BinaryLoggerShouldEmbedFilesWithRelativePathFromChildProjects`
- Full repository build was not available locally because the installed Visual Studio is older than the repository's required version.

### Review

The final rebased diff was reviewed iteratively by the MSBuild expert reviewer and three independent rubber-duck reviewers (Opus 5, Grok 4.5, and MAI-Code-1-Flash); all reported `satisfied` with no remaining blockers.
### Design documents

- [Evaluation observation layer design](https://github.com/OvesN/msbuild/blob/dev/veronikao/evaluation-observation-prototype/documentation/specs/proposed/evaluation-observation-layer-design.md) — concise meeting document covering scope, reuse, overhead, phases, and decisions.
- [Technical reference](https://github.com/OvesN/msbuild/blob/dev/veronikao/evaluation-observation-prototype/documentation/specs/proposed/evaluation-observation-layer-design-details.md) — detailed interception, validation, concurrency, security, and testing contract.

The final documents were reviewed by the MSBuild expert reviewer and the requested Opus 5, Grok 4.5, and MAI-Code-1-Flash reviewers; all reported `satisfied` with no remaining blockers.