### PR TITLE
Add BuildCheck for WriteLinesToFile without Overwrite

### DIFF
--- a/documentation/specs/BuildCheck/Codes.md
+++ b/documentation/specs/BuildCheck/Codes.md
@@ -17,6 +17,7 @@ Report codes are chosen to conform to suggested guidelines. Those guidelines are
 | [BC0203](#bc0203----property-declared-but-never-used) | None | Project | 9.0.100 | Property declared but never used. |
 | [BC0301](#bc0301---building-from-downloads-folder) | None | Project | 9.0.300 | Building from Downloads folder. |
 | [BC0302](#bc0302---building-using-the-exec-task) | Warning | N/A | 9.0.300 | Building using the Exec task. |
+| [BC0303](#bc0303---writelinestofile-should-specify-overwrite) | Warning | N/A | 11.0.100 | WriteLinesToFile should specify Overwrite. |
 
 Notes: 
  * What does the 'N/A' scope mean? The scope of checks are only applicable and configurable in cases where evaluation-time data are being used and the source of the data is determinable and available. Otherwise the scope of whole build is always checked.
@@ -202,6 +203,13 @@ Place your projects into trusted locations - including cases when you intend to 
 "The 'Exec' task should not be used to build projects."
 
 Building projects using the dotnet/msbuild/nuget CLI in the `Exec` task is not recommended, as it spawns a separate build process that the MSBuild engine cannot track. Please use the [MSBuild task](https://learn.microsoft.com/visualstudio/msbuild/msbuild-task) instead.
+
+<a name="BC0303"></a>
+## BC0303 - WriteLinesToFile should specify Overwrite.
+
+"The 'Overwrite' parameter should be specified when using the 'WriteLinesToFile' task."
+
+The [`WriteLinesToFile` task](https://learn.microsoft.com/visualstudio/msbuild/writelinestofile-task) appends to its output file by default. This can cause duplicate content during incremental builds when the same task runs more than once. Set `Overwrite` explicitly to `true` to replace the file contents or to `false` when appending is intentional.
 
 <BR/>
 <BR/>

--- a/src/Build/BuildCheck/Checks/WriteLinesToFileBuildCheck.cs
+++ b/src/Build/BuildCheck/Checks/WriteLinesToFileBuildCheck.cs
@@ -1,0 +1,70 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+#if !FEATURE_MSIOREDIST
+using System.IO;
+#endif
+using Microsoft.Build.Collections;
+using Microsoft.Build.Shared;
+
+#if FEATURE_MSIOREDIST
+using Path = Microsoft.IO.Path;
+#endif
+
+namespace Microsoft.Build.Experimental.BuildCheck.Checks;
+
+internal sealed class WriteLinesToFileBuildCheck : Check
+{
+    private const string RuleId = "BC0303";
+    private const string TaskName = "WriteLinesToFile";
+    private const string OverwriteParameterName = "Overwrite";
+
+    public static CheckRule SupportedRule = new(
+        RuleId,
+        "WriteLinesToFileOverwrite",
+        ResourceUtilities.GetResourceString("BuildCheck_BC0303_Title")!,
+        ResourceUtilities.GetResourceString("BuildCheck_BC0303_MessageFmt")!,
+        new CheckConfiguration() { RuleId = RuleId, Severity = CheckResultSeverity.Warning });
+
+    public override string FriendlyName => "MSBuild.WriteLinesToFileBuildCheck";
+
+    internal override bool IsBuiltIn => true;
+
+    public override IReadOnlyList<CheckRule> SupportedRules { get; } = [SupportedRule];
+
+    public override void Initialize(ConfigurationContext configurationContext)
+    {
+        /* This is it - no custom configuration */
+    }
+
+    public override void RegisterActions(IBuildCheckRegistrationContext registrationContext)
+    {
+        registrationContext.RegisterTaskInvocationAction(TaskInvocationAction);
+    }
+
+    private static void TaskInvocationAction(BuildCheckDataContext<TaskInvocationCheckData> context)
+    {
+        if (MSBuildNameIgnoreCaseComparer.Default.Equals(context.Data.TaskName, TaskName)
+            && !HasOverwriteParameter(context.Data.Parameters))
+        {
+            context.ReportResult(BuildCheckResult.CreateBuiltIn(
+                SupportedRule,
+                context.Data.TaskInvocationLocation,
+                Path.GetFileName(context.Data.ProjectFilePath)));
+        }
+    }
+
+    private static bool HasOverwriteParameter(IReadOnlyDictionary<string, TaskInvocationCheckData.TaskParameter> parameters)
+    {
+        foreach (string parameterName in parameters.Keys)
+        {
+            if (MSBuildNameIgnoreCaseComparer.Default.Equals(parameterName, OverwriteParameterName))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Build/BuildCheck/Infrastructure/BuildCheckManagerProvider.cs
+++ b/src/Build/BuildCheck/Infrastructure/BuildCheckManagerProvider.cs
@@ -152,6 +152,7 @@ internal sealed class BuildCheckManagerProvider : IBuildCheckManagerProvider
                 new BuiltInCheckFactory([CopyAlwaysCheck.SupportedRule.Id], CopyAlwaysCheck.SupportedRule.DefaultConfiguration.IsEnabled ?? false, Construct<CopyAlwaysCheck>),
                 new BuiltInCheckFactory([DoubleWritesCheck.SupportedRule.Id], DoubleWritesCheck.SupportedRule.DefaultConfiguration.IsEnabled ?? false, Construct<DoubleWritesCheck>),
                 new BuiltInCheckFactory([ExecCliBuildCheck.SupportedRule.Id], ExecCliBuildCheck.SupportedRule.DefaultConfiguration.IsEnabled ?? false, Construct<ExecCliBuildCheck>),
+                new BuiltInCheckFactory([WriteLinesToFileBuildCheck.SupportedRule.Id], WriteLinesToFileBuildCheck.SupportedRule.DefaultConfiguration.IsEnabled ?? false, Construct<WriteLinesToFileBuildCheck>),
                 new BuiltInCheckFactory([NoEnvironmentVariablePropertyCheck.SupportedRule.Id], NoEnvironmentVariablePropertyCheck.SupportedRule.DefaultConfiguration.IsEnabled ?? false, Construct<NoEnvironmentVariablePropertyCheck>),
                 new BuiltInCheckFactory([EmbeddedResourceCheck.SupportedRule.Id], EmbeddedResourceCheck.SupportedRule.DefaultConfiguration.IsEnabled ?? false, Construct<EmbeddedResourceCheck>),
                 new BuiltInCheckFactory([TargetFrameworkConfusionCheck.SupportedRule.Id], TargetFrameworkConfusionCheck.SupportedRule.DefaultConfiguration.IsEnabled ?? false, Construct<TargetFrameworkConfusionCheck>),

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -2305,6 +2305,14 @@ Utilization:          {0} Average Utilization: {1:###.0}</value>
   <data name="BuildCheck_BC0302_MessageFmt" xml:space="preserve">
     <value>Task {0} from project {1} builds a project using the {2} CLI. The MSBuild task should be used instead.</value>
   </data>
+  <data name="BuildCheck_BC0303_Title" xml:space="preserve">
+    <value>The 'Overwrite' parameter should be specified when using the 'WriteLinesToFile' task.</value>
+    <comment>Terms in quotes are not to be translated.</comment>
+  </data>
+  <data name="BuildCheck_BC0303_MessageFmt" xml:space="preserve">
+    <value>The 'WriteLinesToFile' task in project {0} does not specify the 'Overwrite' parameter. Set it explicitly to 'true' to overwrite the file or 'false' to append to it.</value>
+    <comment>Terms in quotes are not to be translated.</comment>
+  </data>
   <data name="BuildCheck_BC0201_Title" xml:space="preserve">
     <value>A property that is accessed should be declared first.</value>
   </data>

--- a/src/Build/Resources/xlf/Strings.cs.xlf
+++ b/src/Build/Resources/xlf/Strings.cs.xlf
@@ -286,6 +286,16 @@
         <target state="translated">Složka Stažené soubory není důvěryhodná pro sestavování projektů.</target>
         <note />
       </trans-unit>
+      <trans-unit id="BuildCheck_BC0303_MessageFmt">
+        <source>The 'WriteLinesToFile' task in project {0} does not specify the 'Overwrite' parameter. Set it explicitly to 'true' to overwrite the file or 'false' to append to it.</source>
+        <target state="new">The 'WriteLinesToFile' task in project {0} does not specify the 'Overwrite' parameter. Set it explicitly to 'true' to overwrite the file or 'false' to append to it.</target>
+        <note>Terms in quotes are not to be translated.</note>
+      </trans-unit>
+      <trans-unit id="BuildCheck_BC0303_Title">
+        <source>The 'Overwrite' parameter should be specified when using the 'WriteLinesToFile' task.</source>
+        <target state="new">The 'Overwrite' parameter should be specified when using the 'WriteLinesToFile' task.</target>
+        <note>Terms in quotes are not to be translated.</note>
+      </trans-unit>
       <trans-unit id="BuildFinished">
         <source>Build {0} in {1}s</source>
         <target state="translated">Sestavení {0} za {1}s</target>

--- a/src/Build/Resources/xlf/Strings.de.xlf
+++ b/src/Build/Resources/xlf/Strings.de.xlf
@@ -286,6 +286,16 @@
         <target state="translated">Der Ordner "Downloads" ist für die Projekterstellung nicht vertrauenswürdig.</target>
         <note />
       </trans-unit>
+      <trans-unit id="BuildCheck_BC0303_MessageFmt">
+        <source>The 'WriteLinesToFile' task in project {0} does not specify the 'Overwrite' parameter. Set it explicitly to 'true' to overwrite the file or 'false' to append to it.</source>
+        <target state="new">The 'WriteLinesToFile' task in project {0} does not specify the 'Overwrite' parameter. Set it explicitly to 'true' to overwrite the file or 'false' to append to it.</target>
+        <note>Terms in quotes are not to be translated.</note>
+      </trans-unit>
+      <trans-unit id="BuildCheck_BC0303_Title">
+        <source>The 'Overwrite' parameter should be specified when using the 'WriteLinesToFile' task.</source>
+        <target state="new">The 'Overwrite' parameter should be specified when using the 'WriteLinesToFile' task.</target>
+        <note>Terms in quotes are not to be translated.</note>
+      </trans-unit>
       <trans-unit id="BuildFinished">
         <source>Build {0} in {1}s</source>
         <target state="translated">Build {0} in {1} Sek.</target>

--- a/src/Build/Resources/xlf/Strings.es.xlf
+++ b/src/Build/Resources/xlf/Strings.es.xlf
@@ -286,6 +286,16 @@
         <target state="translated">La carpeta descargas no es de confianza para la compilación de proyectos.</target>
         <note />
       </trans-unit>
+      <trans-unit id="BuildCheck_BC0303_MessageFmt">
+        <source>The 'WriteLinesToFile' task in project {0} does not specify the 'Overwrite' parameter. Set it explicitly to 'true' to overwrite the file or 'false' to append to it.</source>
+        <target state="new">The 'WriteLinesToFile' task in project {0} does not specify the 'Overwrite' parameter. Set it explicitly to 'true' to overwrite the file or 'false' to append to it.</target>
+        <note>Terms in quotes are not to be translated.</note>
+      </trans-unit>
+      <trans-unit id="BuildCheck_BC0303_Title">
+        <source>The 'Overwrite' parameter should be specified when using the 'WriteLinesToFile' task.</source>
+        <target state="new">The 'Overwrite' parameter should be specified when using the 'WriteLinesToFile' task.</target>
+        <note>Terms in quotes are not to be translated.</note>
+      </trans-unit>
       <trans-unit id="BuildFinished">
         <source>Build {0} in {1}s</source>
         <target state="translated">Compilación {0} en {1}s</target>

--- a/src/Build/Resources/xlf/Strings.fr.xlf
+++ b/src/Build/Resources/xlf/Strings.fr.xlf
@@ -286,6 +286,16 @@
         <target state="translated">Le dossier des téléchargements n’est pas approuvé pour la génération de projets.</target>
         <note />
       </trans-unit>
+      <trans-unit id="BuildCheck_BC0303_MessageFmt">
+        <source>The 'WriteLinesToFile' task in project {0} does not specify the 'Overwrite' parameter. Set it explicitly to 'true' to overwrite the file or 'false' to append to it.</source>
+        <target state="new">The 'WriteLinesToFile' task in project {0} does not specify the 'Overwrite' parameter. Set it explicitly to 'true' to overwrite the file or 'false' to append to it.</target>
+        <note>Terms in quotes are not to be translated.</note>
+      </trans-unit>
+      <trans-unit id="BuildCheck_BC0303_Title">
+        <source>The 'Overwrite' parameter should be specified when using the 'WriteLinesToFile' task.</source>
+        <target state="new">The 'Overwrite' parameter should be specified when using the 'WriteLinesToFile' task.</target>
+        <note>Terms in quotes are not to be translated.</note>
+      </trans-unit>
       <trans-unit id="BuildFinished">
         <source>Build {0} in {1}s</source>
         <target state="translated">Générer {0} dans {1}s</target>

--- a/src/Build/Resources/xlf/Strings.it.xlf
+++ b/src/Build/Resources/xlf/Strings.it.xlf
@@ -286,6 +286,16 @@
         <target state="translated">La cartella Dei download non è attendibile per la compilazione di progetti.</target>
         <note />
       </trans-unit>
+      <trans-unit id="BuildCheck_BC0303_MessageFmt">
+        <source>The 'WriteLinesToFile' task in project {0} does not specify the 'Overwrite' parameter. Set it explicitly to 'true' to overwrite the file or 'false' to append to it.</source>
+        <target state="new">The 'WriteLinesToFile' task in project {0} does not specify the 'Overwrite' parameter. Set it explicitly to 'true' to overwrite the file or 'false' to append to it.</target>
+        <note>Terms in quotes are not to be translated.</note>
+      </trans-unit>
+      <trans-unit id="BuildCheck_BC0303_Title">
+        <source>The 'Overwrite' parameter should be specified when using the 'WriteLinesToFile' task.</source>
+        <target state="new">The 'Overwrite' parameter should be specified when using the 'WriteLinesToFile' task.</target>
+        <note>Terms in quotes are not to be translated.</note>
+      </trans-unit>
       <trans-unit id="BuildFinished">
         <source>Build {0} in {1}s</source>
         <target state="translated">Compilazione {0} in {1}s</target>

--- a/src/Build/Resources/xlf/Strings.ja.xlf
+++ b/src/Build/Resources/xlf/Strings.ja.xlf
@@ -286,6 +286,16 @@
         <target state="translated">ダウンロード フォルダーは、プロジェクトのビルドに対して信頼されていません。</target>
         <note />
       </trans-unit>
+      <trans-unit id="BuildCheck_BC0303_MessageFmt">
+        <source>The 'WriteLinesToFile' task in project {0} does not specify the 'Overwrite' parameter. Set it explicitly to 'true' to overwrite the file or 'false' to append to it.</source>
+        <target state="new">The 'WriteLinesToFile' task in project {0} does not specify the 'Overwrite' parameter. Set it explicitly to 'true' to overwrite the file or 'false' to append to it.</target>
+        <note>Terms in quotes are not to be translated.</note>
+      </trans-unit>
+      <trans-unit id="BuildCheck_BC0303_Title">
+        <source>The 'Overwrite' parameter should be specified when using the 'WriteLinesToFile' task.</source>
+        <target state="new">The 'Overwrite' parameter should be specified when using the 'WriteLinesToFile' task.</target>
+        <note>Terms in quotes are not to be translated.</note>
+      </trans-unit>
       <trans-unit id="BuildFinished">
         <source>Build {0} in {1}s</source>
         <target state="translated">{1} 秒後に {0} をビルド</target>

--- a/src/Build/Resources/xlf/Strings.ko.xlf
+++ b/src/Build/Resources/xlf/Strings.ko.xlf
@@ -286,6 +286,16 @@
         <target state="translated">프로젝트 빌드에 대해 다운로드 폴더를 신뢰할 수 없습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="BuildCheck_BC0303_MessageFmt">
+        <source>The 'WriteLinesToFile' task in project {0} does not specify the 'Overwrite' parameter. Set it explicitly to 'true' to overwrite the file or 'false' to append to it.</source>
+        <target state="new">The 'WriteLinesToFile' task in project {0} does not specify the 'Overwrite' parameter. Set it explicitly to 'true' to overwrite the file or 'false' to append to it.</target>
+        <note>Terms in quotes are not to be translated.</note>
+      </trans-unit>
+      <trans-unit id="BuildCheck_BC0303_Title">
+        <source>The 'Overwrite' parameter should be specified when using the 'WriteLinesToFile' task.</source>
+        <target state="new">The 'Overwrite' parameter should be specified when using the 'WriteLinesToFile' task.</target>
+        <note>Terms in quotes are not to be translated.</note>
+      </trans-unit>
       <trans-unit id="BuildFinished">
         <source>Build {0} in {1}s</source>
         <target state="translated">{0} 빌드({1}초)</target>

--- a/src/Build/Resources/xlf/Strings.pl.xlf
+++ b/src/Build/Resources/xlf/Strings.pl.xlf
@@ -286,6 +286,16 @@
         <target state="translated">Folder Pobrane nie jest zaufany do kompilowania projektów.</target>
         <note />
       </trans-unit>
+      <trans-unit id="BuildCheck_BC0303_MessageFmt">
+        <source>The 'WriteLinesToFile' task in project {0} does not specify the 'Overwrite' parameter. Set it explicitly to 'true' to overwrite the file or 'false' to append to it.</source>
+        <target state="new">The 'WriteLinesToFile' task in project {0} does not specify the 'Overwrite' parameter. Set it explicitly to 'true' to overwrite the file or 'false' to append to it.</target>
+        <note>Terms in quotes are not to be translated.</note>
+      </trans-unit>
+      <trans-unit id="BuildCheck_BC0303_Title">
+        <source>The 'Overwrite' parameter should be specified when using the 'WriteLinesToFile' task.</source>
+        <target state="new">The 'Overwrite' parameter should be specified when using the 'WriteLinesToFile' task.</target>
+        <note>Terms in quotes are not to be translated.</note>
+      </trans-unit>
       <trans-unit id="BuildFinished">
         <source>Build {0} in {1}s</source>
         <target state="translated">Kompiluj {0} w {1}s</target>

--- a/src/Build/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Build/Resources/xlf/Strings.pt-BR.xlf
@@ -286,6 +286,16 @@
         <target state="translated">A pasta Downloads não é confiável para a compilação de projetos.</target>
         <note />
       </trans-unit>
+      <trans-unit id="BuildCheck_BC0303_MessageFmt">
+        <source>The 'WriteLinesToFile' task in project {0} does not specify the 'Overwrite' parameter. Set it explicitly to 'true' to overwrite the file or 'false' to append to it.</source>
+        <target state="new">The 'WriteLinesToFile' task in project {0} does not specify the 'Overwrite' parameter. Set it explicitly to 'true' to overwrite the file or 'false' to append to it.</target>
+        <note>Terms in quotes are not to be translated.</note>
+      </trans-unit>
+      <trans-unit id="BuildCheck_BC0303_Title">
+        <source>The 'Overwrite' parameter should be specified when using the 'WriteLinesToFile' task.</source>
+        <target state="new">The 'Overwrite' parameter should be specified when using the 'WriteLinesToFile' task.</target>
+        <note>Terms in quotes are not to be translated.</note>
+      </trans-unit>
       <trans-unit id="BuildFinished">
         <source>Build {0} in {1}s</source>
         <target state="translated">Construir {0} em {1}s</target>

--- a/src/Build/Resources/xlf/Strings.ru.xlf
+++ b/src/Build/Resources/xlf/Strings.ru.xlf
@@ -286,6 +286,16 @@
         <target state="translated">Папка "Загрузки" недоверена для сборки проектов.</target>
         <note />
       </trans-unit>
+      <trans-unit id="BuildCheck_BC0303_MessageFmt">
+        <source>The 'WriteLinesToFile' task in project {0} does not specify the 'Overwrite' parameter. Set it explicitly to 'true' to overwrite the file or 'false' to append to it.</source>
+        <target state="new">The 'WriteLinesToFile' task in project {0} does not specify the 'Overwrite' parameter. Set it explicitly to 'true' to overwrite the file or 'false' to append to it.</target>
+        <note>Terms in quotes are not to be translated.</note>
+      </trans-unit>
+      <trans-unit id="BuildCheck_BC0303_Title">
+        <source>The 'Overwrite' parameter should be specified when using the 'WriteLinesToFile' task.</source>
+        <target state="new">The 'Overwrite' parameter should be specified when using the 'WriteLinesToFile' task.</target>
+        <note>Terms in quotes are not to be translated.</note>
+      </trans-unit>
       <trans-unit id="BuildFinished">
         <source>Build {0} in {1}s</source>
         <target state="translated">Сборка {0} через {1} с</target>

--- a/src/Build/Resources/xlf/Strings.tr.xlf
+++ b/src/Build/Resources/xlf/Strings.tr.xlf
@@ -286,6 +286,16 @@
         <target state="translated">İndirmeler klasörü, proje oluşturma için güvenilir değil.</target>
         <note />
       </trans-unit>
+      <trans-unit id="BuildCheck_BC0303_MessageFmt">
+        <source>The 'WriteLinesToFile' task in project {0} does not specify the 'Overwrite' parameter. Set it explicitly to 'true' to overwrite the file or 'false' to append to it.</source>
+        <target state="new">The 'WriteLinesToFile' task in project {0} does not specify the 'Overwrite' parameter. Set it explicitly to 'true' to overwrite the file or 'false' to append to it.</target>
+        <note>Terms in quotes are not to be translated.</note>
+      </trans-unit>
+      <trans-unit id="BuildCheck_BC0303_Title">
+        <source>The 'Overwrite' parameter should be specified when using the 'WriteLinesToFile' task.</source>
+        <target state="new">The 'Overwrite' parameter should be specified when using the 'WriteLinesToFile' task.</target>
+        <note>Terms in quotes are not to be translated.</note>
+      </trans-unit>
       <trans-unit id="BuildFinished">
         <source>Build {0} in {1}s</source>
         <target state="translated">"{1}" sn'de {0} oluşturun</target>

--- a/src/Build/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hans.xlf
@@ -286,6 +286,16 @@
         <target state="translated">生成项目不信任下载文件夹。</target>
         <note />
       </trans-unit>
+      <trans-unit id="BuildCheck_BC0303_MessageFmt">
+        <source>The 'WriteLinesToFile' task in project {0} does not specify the 'Overwrite' parameter. Set it explicitly to 'true' to overwrite the file or 'false' to append to it.</source>
+        <target state="new">The 'WriteLinesToFile' task in project {0} does not specify the 'Overwrite' parameter. Set it explicitly to 'true' to overwrite the file or 'false' to append to it.</target>
+        <note>Terms in quotes are not to be translated.</note>
+      </trans-unit>
+      <trans-unit id="BuildCheck_BC0303_Title">
+        <source>The 'Overwrite' parameter should be specified when using the 'WriteLinesToFile' task.</source>
+        <target state="new">The 'Overwrite' parameter should be specified when using the 'WriteLinesToFile' task.</target>
+        <note>Terms in quotes are not to be translated.</note>
+      </trans-unit>
       <trans-unit id="BuildFinished">
         <source>Build {0} in {1}s</source>
         <target state="translated">在 {1} 秒内生成 {0}</target>

--- a/src/Build/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hant.xlf
@@ -286,6 +286,16 @@
         <target state="translated">專案建置不受信任的下載資料夾。</target>
         <note />
       </trans-unit>
+      <trans-unit id="BuildCheck_BC0303_MessageFmt">
+        <source>The 'WriteLinesToFile' task in project {0} does not specify the 'Overwrite' parameter. Set it explicitly to 'true' to overwrite the file or 'false' to append to it.</source>
+        <target state="new">The 'WriteLinesToFile' task in project {0} does not specify the 'Overwrite' parameter. Set it explicitly to 'true' to overwrite the file or 'false' to append to it.</target>
+        <note>Terms in quotes are not to be translated.</note>
+      </trans-unit>
+      <trans-unit id="BuildCheck_BC0303_Title">
+        <source>The 'Overwrite' parameter should be specified when using the 'WriteLinesToFile' task.</source>
+        <target state="new">The 'Overwrite' parameter should be specified when using the 'WriteLinesToFile' task.</target>
+        <note>Terms in quotes are not to be translated.</note>
+      </trans-unit>
       <trans-unit id="BuildFinished">
         <source>Build {0} in {1}s</source>
         <target state="translated">在 {1} 秒內建置 {0}</target>

--- a/src/BuildCheck.UnitTests/WriteLinesToFileBuildCheck_Tests.cs
+++ b/src/BuildCheck.UnitTests/WriteLinesToFileBuildCheck_Tests.cs
@@ -1,0 +1,73 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using Microsoft.Build.Experimental.BuildCheck;
+using Microsoft.Build.Experimental.BuildCheck.Checks;
+using Shouldly;
+using Xunit;
+
+namespace Microsoft.Build.BuildCheck.UnitTests;
+
+public sealed class WriteLinesToFileBuildCheck_Tests
+{
+    private readonly WriteLinesToFileBuildCheck _check;
+
+    private readonly MockBuildCheckRegistrationContext _registrationContext = new();
+
+    public WriteLinesToFileBuildCheck_Tests()
+    {
+        _check = new WriteLinesToFileBuildCheck();
+        _check.RegisterActions(_registrationContext);
+    }
+
+    [Theory]
+    [InlineData("WriteLinesToFile")]
+    [InlineData("writelinestofile")]
+    public void WriteLinesToFileTask_WithoutOverwrite_ShouldShowWarning(string taskName)
+    {
+        _registrationContext.TriggerTaskInvocationAction(MakeTaskInvocationData(taskName, []));
+
+        _registrationContext.Results.Count.ShouldBe(1);
+        _registrationContext.Results[0].CheckRule.Id.ShouldBe("BC0303");
+    }
+
+    [Theory]
+    [InlineData("Overwrite", true)]
+    [InlineData("Overwrite", false)]
+    [InlineData("overwrite", true)]
+    [InlineData("OVERWRITE", false)]
+    public void WriteLinesToFileTask_WithExplicitOverwrite_ShouldNotShowWarning(string parameterName, bool overwrite)
+    {
+        _registrationContext.TriggerTaskInvocationAction(MakeTaskInvocationData(
+            "WriteLinesToFile",
+            new Dictionary<string, TaskInvocationCheckData.TaskParameter>
+            {
+                { parameterName, new TaskInvocationCheckData.TaskParameter(overwrite, IsOutput: false) },
+            }));
+
+        _registrationContext.Results.Count.ShouldBe(0);
+    }
+
+    [Fact]
+    public void DifferentTask_WithoutOverwrite_ShouldNotShowWarning()
+    {
+        _registrationContext.TriggerTaskInvocationAction(MakeTaskInvocationData("Message", []));
+
+        _registrationContext.Results.Count.ShouldBe(0);
+    }
+
+    private static TaskInvocationCheckData MakeTaskInvocationData(
+        string taskName,
+        Dictionary<string, TaskInvocationCheckData.TaskParameter> parameters)
+    {
+        string projectFile = Framework.NativeMethods.IsWindows ? @"C:\fake\project.proj" : "/fake/project.proj";
+        return new TaskInvocationCheckData(
+            projectFile,
+            null,
+            Construction.ElementLocation.EmptyLocation,
+            taskName,
+            projectFile,
+            parameters);
+    }
+}


### PR DESCRIPTION
Fixes #11927

### Context

`WriteLinesToFile` defaults `Overwrite` to `false`, so repeated incremental builds can append duplicate content when `Overwrite` is omitted. This adds the proposed opt-in style check without changing existing build behavior.

### Changes Made

- Add opt-in built-in check BC0303 for `WriteLinesToFile` invocations that omit `Overwrite`.
- Preserve invocations with explicit `Overwrite="true"` or `Overwrite="false"` and match MSBuild names case-insensitively.
- Register the check and add resource strings and BuildCheck documentation.
- Add focused coverage for omitted, explicit, and case-insensitive task and parameter names.

### Testing

- `./build.sh -v quiet` - passed with zero warnings or errors.
- All 7 focused `WriteLinesToFileBuildCheck` tests - passed.
- Complete BuildCheck suite - 238 passed with zero failures and one expected Windows-only skip.
- Bootstrap sample build, help output, and end-to-end BC0303 diagnostic verification - passed.

### Notes

The check is opt-in, so existing builds are unaffected unless it is explicitly enabled.
