### PR TITLE
Report results-cache misses caused by skipped initial/default targets

### DIFF
--- a/src/Build.UnitTests/BackEnd/ResultsCache_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/ResultsCache_Tests.cs
@@ -189,6 +189,126 @@ namespace Microsoft.Build.UnitTests.BackEnd
             Assert.Equal(BuildResultCode.Success, response.Results.OverallResult);
         }
 
+        /// <summary>
+        /// A skipped initial target prevents the cached results from being reused. The response has to say which
+        /// target caused that, otherwise the cache miss is invisible.
+        /// </summary>
+        [Fact]
+        public void TestSkippedInitialTargetIsReportedAsCacheMissReason()
+        {
+            ResultsCache cache = new ResultsCache();
+            BuildRequest request = new BuildRequest(1 /* submissionId */, 0, 1, new string[] { "testTarget" }, null, BuildEventContext.Invalid, null);
+
+            BuildResult result = new BuildResult(request);
+            result.AddResultsForTarget("initialTarget", BuildResultUtilities.GetEmptySkippedTargetResult());
+            result.AddResultsForTarget("testTarget", BuildResultUtilities.GetEmptySucceedingTargetResult());
+            cache.AddResult(result);
+
+            ResultsCacheResponse response = cache.SatisfyRequest(
+                request,
+                new List<string> { "initialTarget" },
+                new List<string>(),
+                skippedResultsDoNotCauseCacheMiss: false);
+
+            response.Type.ShouldBe(ResultsCacheResponseType.NotSatisfied);
+            response.SkippedTargetCausingCacheMiss.ShouldBe("initialTarget");
+        }
+
+        /// <summary>
+        /// The same, for a default target, which is only consulted when the request specifies no targets.
+        /// </summary>
+        [Fact]
+        public void TestSkippedDefaultTargetIsReportedAsCacheMissReason()
+        {
+            ResultsCache cache = new ResultsCache();
+            BuildRequest request = new BuildRequest(1 /* submissionId */, 0, 1, Array.Empty<string>(), null, BuildEventContext.Invalid, null);
+
+            BuildResult result = new BuildResult(request);
+            result.AddResultsForTarget("defaultTarget", BuildResultUtilities.GetEmptySkippedTargetResult());
+            cache.AddResult(result);
+
+            ResultsCacheResponse response = cache.SatisfyRequest(
+                request,
+                new List<string>(),
+                new List<string> { "defaultTarget" },
+                skippedResultsDoNotCauseCacheMiss: false);
+
+            response.Type.ShouldBe(ResultsCacheResponseType.NotSatisfied);
+            response.SkippedTargetCausingCacheMiss.ShouldBe("defaultTarget");
+        }
+
+        /// <summary>
+        /// A target that has no result at all is an ordinary cache miss, not the surprising kind, so it must not be
+        /// reported as a skipped target.
+        /// </summary>
+        [Fact]
+        public void TestMissingInitialTargetIsNotReportedAsSkipped()
+        {
+            ResultsCache cache = new ResultsCache();
+            BuildRequest request = new BuildRequest(1 /* submissionId */, 0, 1, new string[] { "testTarget" }, null, BuildEventContext.Invalid, null);
+
+            BuildResult result = new BuildResult(request);
+            result.AddResultsForTarget("testTarget", BuildResultUtilities.GetEmptySucceedingTargetResult());
+            cache.AddResult(result);
+
+            ResultsCacheResponse response = cache.SatisfyRequest(
+                request,
+                new List<string> { "initialTargetWithNoResult" },
+                new List<string>(),
+                skippedResultsDoNotCauseCacheMiss: false);
+
+            response.Type.ShouldBe(ResultsCacheResponseType.NotSatisfied);
+            response.SkippedTargetCausingCacheMiss.ShouldBeNull();
+        }
+
+        /// <summary>
+        /// A satisfied request never carries a cache miss reason.
+        /// </summary>
+        [Fact]
+        public void TestSatisfiedRequestHasNoCacheMissReason()
+        {
+            ResultsCache cache = new ResultsCache();
+            BuildRequest request = new BuildRequest(1 /* submissionId */, 0, 1, new string[] { "testTarget" }, null, BuildEventContext.Invalid, null);
+
+            BuildResult result = new BuildResult(request);
+            result.AddResultsForTarget("initialTarget", BuildResultUtilities.GetEmptySucceedingTargetResult());
+            result.AddResultsForTarget("testTarget", BuildResultUtilities.GetEmptySucceedingTargetResult());
+            cache.AddResult(result);
+
+            ResultsCacheResponse response = cache.SatisfyRequest(
+                request,
+                new List<string> { "initialTarget" },
+                new List<string>(),
+                skippedResultsDoNotCauseCacheMiss: false);
+
+            response.Type.ShouldBe(ResultsCacheResponseType.Satisfied);
+            response.SkippedTargetCausingCacheMiss.ShouldBeNull();
+        }
+
+        /// <summary>
+        /// When skipped results are acceptable, a skipped initial target is not a cache miss at all.
+        /// </summary>
+        [Fact]
+        public void TestSkippedInitialTargetIsNotAMissWhenSkippedResultsAreAllowed()
+        {
+            ResultsCache cache = new ResultsCache();
+            BuildRequest request = new BuildRequest(1 /* submissionId */, 0, 1, new string[] { "testTarget" }, null, BuildEventContext.Invalid, null);
+
+            BuildResult result = new BuildResult(request);
+            result.AddResultsForTarget("initialTarget", BuildResultUtilities.GetEmptySkippedTargetResult());
+            result.AddResultsForTarget("testTarget", BuildResultUtilities.GetEmptySucceedingTargetResult());
+            cache.AddResult(result);
+
+            ResultsCacheResponse response = cache.SatisfyRequest(
+                request,
+                new List<string> { "initialTarget" },
+                new List<string>(),
+                skippedResultsDoNotCauseCacheMiss: true);
+
+            response.Type.ShouldBe(ResultsCacheResponseType.Satisfied);
+            response.SkippedTargetCausingCacheMiss.ShouldBeNull();
+        }
+
         [Fact]
         public void TestCacheOnDifferentBuildFlagsPerRequest_ProvideProjectStateAfterBuild()
         {

--- a/src/Build.UnitTests/BuildResultUtilities.cs
+++ b/src/Build.UnitTests/BuildResultUtilities.cs
@@ -22,6 +22,11 @@ namespace Microsoft.Build.Unittest
             return new TargetResult(Array.Empty<TaskItem>(), BuildResultUtilities.GetSuccessResult());
         }
 
+        public static TargetResult GetEmptySkippedTargetResult()
+        {
+            return new TargetResult(Array.Empty<TaskItem>(), BuildResultUtilities.GetSkippedResult());
+        }
+
         public static TargetResult GetNonEmptySucceedingTargetResult()
         {
             return new TargetResult(new TaskItem[1] { new TaskItem("i", "v") }, BuildResultUtilities.GetSuccessResult());

--- a/src/Build/BackEnd/Components/Caching/ResultsCache.cs
+++ b/src/Build/BackEnd/Components/Caching/ResultsCache.cs
@@ -170,7 +170,7 @@ namespace Microsoft.Build.BackEnd
                     if (AreBuildResultFlagsCompatible(request, allResults))
                     {
                         // Check for targets explicitly specified.
-                        bool explicitTargetsSatisfied = CheckResults(allResults, request.Targets, checkTargetsMissingResults: true, skippedResultsDoNotCauseCacheMiss);
+                        bool explicitTargetsSatisfied = CheckResults(allResults, request.Targets, checkTargetsMissingResults: true, skippedResultsDoNotCauseCacheMiss, out _);
 
                         if (explicitTargetsSatisfied)
                         {
@@ -178,9 +178,11 @@ namespace Microsoft.Build.BackEnd
                             response.Type = ResultsCacheResponseType.Satisfied;
 
                             // Check for the initial targets.  If we don't know what the initial targets are, we assume they are not satisfied.
-                            if (configInitialTargets == null || !CheckResults(allResults, configInitialTargets, checkTargetsMissingResults: false, skippedResultsDoNotCauseCacheMiss))
+                            string skippedInitialTarget = null;
+                            if (configInitialTargets == null || !CheckResults(allResults, configInitialTargets, checkTargetsMissingResults: false, skippedResultsDoNotCauseCacheMiss, out skippedInitialTarget))
                             {
                                 response.Type = ResultsCacheResponseType.NotSatisfied;
+                                response.SkippedTargetCausingCacheMiss = skippedInitialTarget;
                             }
 
                             // We could still be missing implicit targets, so check those...
@@ -188,9 +190,11 @@ namespace Microsoft.Build.BackEnd
                             {
                                 // Check for the default target, if necessary.  If we don't know what the default targets are, we
                                 // assume they are not satisfied.
-                                if (configDefaultTargets == null || !CheckResults(allResults, configDefaultTargets, checkTargetsMissingResults: false, skippedResultsDoNotCauseCacheMiss))
+                                string skippedDefaultTarget = null;
+                                if (configDefaultTargets == null || !CheckResults(allResults, configDefaultTargets, checkTargetsMissingResults: false, skippedResultsDoNotCauseCacheMiss, out skippedDefaultTarget))
                                 {
                                     response.Type = ResultsCacheResponseType.NotSatisfied;
+                                    response.SkippedTargetCausingCacheMiss ??= skippedDefaultTarget;
                                 }
                             }
 
@@ -303,15 +307,25 @@ namespace Microsoft.Build.BackEnd
         /// <param name="checkTargetsMissingResults">If missing targets will be checked for.</param>
         /// <param name="skippedResultsAreOK">If true, a status of "skipped" counts as having valid results
         /// for that target.  Otherwise, a skipped target is treated as equivalent to a missing target.</param>
+        /// <param name="skippedTarget">Receives the name of the first target that was rejected because it has a
+        /// skipped result. Null if no target was rejected for that reason. Used for diagnostics only.</param>
         /// <returns>False if there were missing results, true otherwise.</returns>
-        private static bool CheckResults(BuildResult result, List<string> targets, bool checkTargetsMissingResults, bool skippedResultsAreOK)
+        private static bool CheckResults(BuildResult result, List<string> targets, bool checkTargetsMissingResults, bool skippedResultsAreOK, out string skippedTarget)
         {
+            skippedTarget = null;
             bool returnValue = true;
             bool missingTargetFound = false;
             foreach (string target in targets)
             {
                 if (!result.TryGetResultsForTarget(target, out TargetResult targetResult) || (targetResult.ResultCode == TargetResultCode.Skipped && !skippedResultsAreOK))
                 {
+                    // Distinguish "we have a skipped result" from "we have no result at all". Only the former is
+                    // surprising enough to be worth reporting to the user.
+                    if (targetResult is not null && targetResult.ResultCode == TargetResultCode.Skipped)
+                    {
+                        skippedTarget ??= target;
+                    }
+
                     if (checkTargetsMissingResults)
                     {
                         missingTargetFound = true;

--- a/src/Build/BackEnd/Components/Caching/ResultsCacheResponse.cs
+++ b/src/Build/BackEnd/Components/Caching/ResultsCacheResponse.cs
@@ -39,6 +39,17 @@ namespace Microsoft.Build.BackEnd
         public BuildResult Results;
 
         /// <summary>
+        /// When the cache held results for the configuration but the request was still not satisfied because one of the
+        /// configuration's initial or default targets has a skipped result, the name of that target. Null otherwise.
+        /// </summary>
+        /// <remarks>
+        /// This is purely diagnostic. Callers use it to explain why an otherwise usable cached result had to be
+        /// rebuilt, because a conditionally skipped initial or default target is an easy thing to introduce and
+        /// an extremely hard thing to notice.
+        /// </remarks>
+        public string SkippedTargetCausingCacheMiss;
+
+        /// <summary>
         /// Constructor.
         /// </summary>
         /// <param name="type">The response type.</param>
@@ -46,6 +57,7 @@ namespace Microsoft.Build.BackEnd
         {
             Type = type;
             Results = null;
+            SkippedTargetCausingCacheMiss = null;
         }
     }
 }

--- a/src/Build/BackEnd/Components/Scheduler/Scheduler.cs
+++ b/src/Build/BackEnd/Components/Scheduler/Scheduler.cs
@@ -1772,7 +1772,7 @@ namespace Microsoft.Build.BackEnd
                 // First, determine if we have already built this request and have results for it.  If we do, we prepare the responses for it
                 // directly here.  We COULD simply report these as blocking the parent request and let the scheduler pick them up later when the parent
                 // comes back up as schedulable, but we prefer to send the results back immediately so this request can (potentially) continue uninterrupted.
-                ScheduleResponse response = TrySatisfyRequestFromCache(nodeForResults, request, skippedResultsDoNotCauseCacheMiss: _componentHost.BuildParameters.SkippedResultsDoNotCauseCacheMiss());
+                ScheduleResponse response = TrySatisfyRequestFromCache(nodeForResults, request, skippedResultsDoNotCauseCacheMiss: _componentHost.BuildParameters.SkippedResultsDoNotCauseCacheMiss(), logSkippedTargetCacheMiss: true);
                 if (response != null)
                 {
                     TraceScheduler($"Request {request.GlobalRequestId} (node request {request.NodeRequestId}) satisfied from the cache.");
@@ -2017,7 +2017,7 @@ namespace Microsoft.Build.BackEnd
         /// <summary>
         /// Attempts to get a result from the cache to satisfy the request, and returns the appropriate response if possible.
         /// </summary>
-        private ScheduleResponse TrySatisfyRequestFromCache(int nodeForResults, BuildRequest request, bool skippedResultsDoNotCauseCacheMiss)
+        private ScheduleResponse TrySatisfyRequestFromCache(int nodeForResults, BuildRequest request, bool skippedResultsDoNotCauseCacheMiss, bool logSkippedTargetCacheMiss = false)
         {
             BuildRequestConfiguration config = _configCache[request.ConfigurationId];
             ResultsCacheResponse resultsResponse = _resultsCache.SatisfyRequest(request, config.ProjectInitialTargets, config.ProjectDefaultTargets, skippedResultsDoNotCauseCacheMiss);
@@ -2027,7 +2027,32 @@ namespace Microsoft.Build.BackEnd
                 return GetResponseForResult(nodeForResults, request, resultsResponse.Results);
             }
 
+            if (logSkippedTargetCacheMiss && resultsResponse.SkippedTargetCausingCacheMiss is not null)
+            {
+                LogCacheMissDueToSkippedTarget(request, config, resultsResponse.SkippedTargetCausingCacheMiss);
+            }
+
             return null;
+        }
+
+        /// <summary>
+        /// Reports that results which were already in the cache could not be reused because one of the configuration's
+        /// initial or default targets has a skipped result, so the project has to be scheduled and built again.
+        /// </summary>
+        /// <remarks>
+        /// A conditionally skipped initial or default target is trivial to introduce and effectively invisible: it
+        /// silently disables result reuse for the whole configuration. See https://github.com/dotnet/msbuild/issues/11753.
+        /// </remarks>
+        private void LogCacheMissDueToSkippedTarget(BuildRequest request, BuildRequestConfiguration configuration, string skippedTarget)
+        {
+            _componentHost.LoggingService.LogComment(
+                request.ParentBuildEventContext ?? BuildEventContext.Invalid,
+                MessageImportance.Low,
+                "ResultsCacheMissDueToSkippedTarget",
+                configuration.ProjectFullPath,
+                skippedTarget);
+
+            TraceScheduler($"Request {request.GlobalRequestId} (node request {request.NodeRequestId}) could not be satisfied from the cache because target \"{skippedTarget}\" has a skipped result; the project will be built again.");
         }
 
         /// <returns>True if caches misses are allowed, false otherwise</returns>

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -2083,6 +2083,12 @@ Utilization:          {0} Average Utilization: {1:###.0}</value>
       LOCALIZATION: {0} is a file path. {1} is a comma-separated list of target names
     </comment>
   </data>
+  <data name="ResultsCacheMissDueToSkippedTarget" xml:space="preserve">
+    <value>Cached results for "{0}" cannot be reused because target "{1}" has a skipped result, so the project will be built again. Conditionally skipped initial and default targets prevent results from being reused.</value>
+    <comment>
+      LOCALIZATION: {0} is a file path. {1} is a target name.
+    </comment>
+  </data>
   <data name="DefaultSDKResolverError" xml:space="preserve">
     <value>MSB4276: The default SDK resolver failed to resolve SDK "{0}" because directory "{1}" did not exist.</value>
   </data>

--- a/src/Build/Resources/xlf/Strings.cs.xlf
+++ b/src/Build/Resources/xlf/Strings.cs.xlf
@@ -966,6 +966,13 @@
       's' should reflect the localized abbreviation for seconds
     </note>
       </trans-unit>
+      <trans-unit id="ResultsCacheMissDueToSkippedTarget">
+        <source>Cached results for "{0}" cannot be reused because target "{1}" has a skipped result, so the project will be built again. Conditionally skipped initial and default targets prevent results from being reused.</source>
+        <target state="new">Cached results for "{0}" cannot be reused because target "{1}" has a skipped result, so the project will be built again. Conditionally skipped initial and default targets prevent results from being reused.</target>
+        <note>
+      LOCALIZATION: {0} is a file path. {1} is a target name.
+    </note>
+      </trans-unit>
       <trans-unit id="SDKPathCheck_Failed">
         <source>The directory does not exist: {0}. .NET Runtime Task Host could not be instantiated. See https://aka.ms/nettaskhost for details on how to resolve this error.</source>
         <target state="translated">Adresář neexistuje: {0}. Nelze vytvořit instanci hostitele úloh modulu runtime .NET. Podrobnosti o řešení této chyby najdete na adrese https://aka.ms/nettaskhost.</target>

--- a/src/Build/Resources/xlf/Strings.de.xlf
+++ b/src/Build/Resources/xlf/Strings.de.xlf
@@ -966,6 +966,13 @@
       's' should reflect the localized abbreviation for seconds
     </note>
       </trans-unit>
+      <trans-unit id="ResultsCacheMissDueToSkippedTarget">
+        <source>Cached results for "{0}" cannot be reused because target "{1}" has a skipped result, so the project will be built again. Conditionally skipped initial and default targets prevent results from being reused.</source>
+        <target state="new">Cached results for "{0}" cannot be reused because target "{1}" has a skipped result, so the project will be built again. Conditionally skipped initial and default targets prevent results from being reused.</target>
+        <note>
+      LOCALIZATION: {0} is a file path. {1} is a target name.
+    </note>
+      </trans-unit>
       <trans-unit id="SDKPathCheck_Failed">
         <source>The directory does not exist: {0}. .NET Runtime Task Host could not be instantiated. See https://aka.ms/nettaskhost for details on how to resolve this error.</source>
         <target state="translated">Das Verzeichnis existiert nicht: {0}. Der .NET Runtime Task Host konnte nicht instanziiert werden. Weitere Informationen zum Beheben dieses Fehlers finden Sie unter https://aka.ms/nettaskhost.</target>

--- a/src/Build/Resources/xlf/Strings.es.xlf
+++ b/src/Build/Resources/xlf/Strings.es.xlf
@@ -966,6 +966,13 @@
       's' should reflect the localized abbreviation for seconds
     </note>
       </trans-unit>
+      <trans-unit id="ResultsCacheMissDueToSkippedTarget">
+        <source>Cached results for "{0}" cannot be reused because target "{1}" has a skipped result, so the project will be built again. Conditionally skipped initial and default targets prevent results from being reused.</source>
+        <target state="new">Cached results for "{0}" cannot be reused because target "{1}" has a skipped result, so the project will be built again. Conditionally skipped initial and default targets prevent results from being reused.</target>
+        <note>
+      LOCALIZATION: {0} is a file path. {1} is a target name.
+    </note>
+      </trans-unit>
       <trans-unit id="SDKPathCheck_Failed">
         <source>The directory does not exist: {0}. .NET Runtime Task Host could not be instantiated. See https://aka.ms/nettaskhost for details on how to resolve this error.</source>
         <target state="translated">El directorio no existe: {0}. No se pudo crear una instancia del host de tareas en tiempo de ejecución de .NET. Consulte https://aka.ms/nettaskhost para obtener más información sobre cómo resolver este error.</target>

--- a/src/Build/Resources/xlf/Strings.fr.xlf
+++ b/src/Build/Resources/xlf/Strings.fr.xlf
@@ -966,6 +966,13 @@
       's' should reflect the localized abbreviation for seconds
     </note>
       </trans-unit>
+      <trans-unit id="ResultsCacheMissDueToSkippedTarget">
+        <source>Cached results for "{0}" cannot be reused because target "{1}" has a skipped result, so the project will be built again. Conditionally skipped initial and default targets prevent results from being reused.</source>
+        <target state="new">Cached results for "{0}" cannot be reused because target "{1}" has a skipped result, so the project will be built again. Conditionally skipped initial and default targets prevent results from being reused.</target>
+        <note>
+      LOCALIZATION: {0} is a file path. {1} is a target name.
+    </note>
+      </trans-unit>
       <trans-unit id="SDKPathCheck_Failed">
         <source>The directory does not exist: {0}. .NET Runtime Task Host could not be instantiated. See https://aka.ms/nettaskhost for details on how to resolve this error.</source>
         <target state="translated">Le répertoire n’existe pas : {0}. Impossible d’instancier l’hôte de tâches du runtime .NET. Pour plus d’informations sur la résolution de cette erreur, consultez https://aka.ms/nettaskhost.</target>

--- a/src/Build/Resources/xlf/Strings.it.xlf
+++ b/src/Build/Resources/xlf/Strings.it.xlf
@@ -966,6 +966,13 @@
       's' should reflect the localized abbreviation for seconds
     </note>
       </trans-unit>
+      <trans-unit id="ResultsCacheMissDueToSkippedTarget">
+        <source>Cached results for "{0}" cannot be reused because target "{1}" has a skipped result, so the project will be built again. Conditionally skipped initial and default targets prevent results from being reused.</source>
+        <target state="new">Cached results for "{0}" cannot be reused because target "{1}" has a skipped result, so the project will be built again. Conditionally skipped initial and default targets prevent results from being reused.</target>
+        <note>
+      LOCALIZATION: {0} is a file path. {1} is a target name.
+    </note>
+      </trans-unit>
       <trans-unit id="SDKPathCheck_Failed">
         <source>The directory does not exist: {0}. .NET Runtime Task Host could not be instantiated. See https://aka.ms/nettaskhost for details on how to resolve this error.</source>
         <target state="translated">La directory non esiste: {0}. Non è possibile creare un'istanza dell'host attività di runtime .NET. Per informazioni dettagliate su come risolvere l'errore, vedere https://aka.ms/nettaskhost.</target>

--- a/src/Build/Resources/xlf/Strings.ja.xlf
+++ b/src/Build/Resources/xlf/Strings.ja.xlf
@@ -966,6 +966,13 @@
       's' should reflect the localized abbreviation for seconds
     </note>
       </trans-unit>
+      <trans-unit id="ResultsCacheMissDueToSkippedTarget">
+        <source>Cached results for "{0}" cannot be reused because target "{1}" has a skipped result, so the project will be built again. Conditionally skipped initial and default targets prevent results from being reused.</source>
+        <target state="new">Cached results for "{0}" cannot be reused because target "{1}" has a skipped result, so the project will be built again. Conditionally skipped initial and default targets prevent results from being reused.</target>
+        <note>
+      LOCALIZATION: {0} is a file path. {1} is a target name.
+    </note>
+      </trans-unit>
       <trans-unit id="SDKPathCheck_Failed">
         <source>The directory does not exist: {0}. .NET Runtime Task Host could not be instantiated. See https://aka.ms/nettaskhost for details on how to resolve this error.</source>
         <target state="translated">ディレクトリが存在しません: {0}。.NET ランタイム タスク ホストをインスタンス化できませんでした。このエラーを解決する方法の詳細については、https://aka.ms/nettaskhost を参照してください。</target>

--- a/src/Build/Resources/xlf/Strings.ko.xlf
+++ b/src/Build/Resources/xlf/Strings.ko.xlf
@@ -966,6 +966,13 @@
       's' should reflect the localized abbreviation for seconds
     </note>
       </trans-unit>
+      <trans-unit id="ResultsCacheMissDueToSkippedTarget">
+        <source>Cached results for "{0}" cannot be reused because target "{1}" has a skipped result, so the project will be built again. Conditionally skipped initial and default targets prevent results from being reused.</source>
+        <target state="new">Cached results for "{0}" cannot be reused because target "{1}" has a skipped result, so the project will be built again. Conditionally skipped initial and default targets prevent results from being reused.</target>
+        <note>
+      LOCALIZATION: {0} is a file path. {1} is a target name.
+    </note>
+      </trans-unit>
       <trans-unit id="SDKPathCheck_Failed">
         <source>The directory does not exist: {0}. .NET Runtime Task Host could not be instantiated. See https://aka.ms/nettaskhost for details on how to resolve this error.</source>
         <target state="translated">디렉터리가 존재하지 않습니다. {0}. .NET 런타임 태스크 호스트를 인스턴스화할 수 없습니다. 이 오류를 해결하는 방법에 대한 자세한 내용은 https://aka.ms/nettaskhost를 참조하세요.</target>

--- a/src/Build/Resources/xlf/Strings.pl.xlf
+++ b/src/Build/Resources/xlf/Strings.pl.xlf
@@ -966,6 +966,13 @@
       's' should reflect the localized abbreviation for seconds
     </note>
       </trans-unit>
+      <trans-unit id="ResultsCacheMissDueToSkippedTarget">
+        <source>Cached results for "{0}" cannot be reused because target "{1}" has a skipped result, so the project will be built again. Conditionally skipped initial and default targets prevent results from being reused.</source>
+        <target state="new">Cached results for "{0}" cannot be reused because target "{1}" has a skipped result, so the project will be built again. Conditionally skipped initial and default targets prevent results from being reused.</target>
+        <note>
+      LOCALIZATION: {0} is a file path. {1} is a target name.
+    </note>
+      </trans-unit>
       <trans-unit id="SDKPathCheck_Failed">
         <source>The directory does not exist: {0}. .NET Runtime Task Host could not be instantiated. See https://aka.ms/nettaskhost for details on how to resolve this error.</source>
         <target state="translated">Katalog nie istnieje: {0}. Nie można utworzyć wystąpienia hosta zadań środowiska uruchomieniowego platformy .NET. Zobacz witrynę https://aka.ms/nettaskhost, aby uzyskać szczegółowe informacje na temat sposobu rozwiązania tego błędu.</target>

--- a/src/Build/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Build/Resources/xlf/Strings.pt-BR.xlf
@@ -966,6 +966,13 @@
       's' should reflect the localized abbreviation for seconds
     </note>
       </trans-unit>
+      <trans-unit id="ResultsCacheMissDueToSkippedTarget">
+        <source>Cached results for "{0}" cannot be reused because target "{1}" has a skipped result, so the project will be built again. Conditionally skipped initial and default targets prevent results from being reused.</source>
+        <target state="new">Cached results for "{0}" cannot be reused because target "{1}" has a skipped result, so the project will be built again. Conditionally skipped initial and default targets prevent results from being reused.</target>
+        <note>
+      LOCALIZATION: {0} is a file path. {1} is a target name.
+    </note>
+      </trans-unit>
       <trans-unit id="SDKPathCheck_Failed">
         <source>The directory does not exist: {0}. .NET Runtime Task Host could not be instantiated. See https://aka.ms/nettaskhost for details on how to resolve this error.</source>
         <target state="translated">O diretório não existe: {0}. Não foi possível criar uma instância do Host de Tarefa do Runtime do .NET. Veja https://aka.ms/nettaskhost para obter detalhes sobre como resolver este erro.</target>

--- a/src/Build/Resources/xlf/Strings.ru.xlf
+++ b/src/Build/Resources/xlf/Strings.ru.xlf
@@ -966,6 +966,13 @@
       's' should reflect the localized abbreviation for seconds
     </note>
       </trans-unit>
+      <trans-unit id="ResultsCacheMissDueToSkippedTarget">
+        <source>Cached results for "{0}" cannot be reused because target "{1}" has a skipped result, so the project will be built again. Conditionally skipped initial and default targets prevent results from being reused.</source>
+        <target state="new">Cached results for "{0}" cannot be reused because target "{1}" has a skipped result, so the project will be built again. Conditionally skipped initial and default targets prevent results from being reused.</target>
+        <note>
+      LOCALIZATION: {0} is a file path. {1} is a target name.
+    </note>
+      </trans-unit>
       <trans-unit id="SDKPathCheck_Failed">
         <source>The directory does not exist: {0}. .NET Runtime Task Host could not be instantiated. See https://aka.ms/nettaskhost for details on how to resolve this error.</source>
         <target state="translated">Каталог не существует: {0}. Не удалось создать экземпляр узла задач среды выполнения .NET. Подробности об устранении этой ошибки см. на странице https://aka.ms/nettaskhost.</target>

--- a/src/Build/Resources/xlf/Strings.tr.xlf
+++ b/src/Build/Resources/xlf/Strings.tr.xlf
@@ -966,6 +966,13 @@
       's' should reflect the localized abbreviation for seconds
     </note>
       </trans-unit>
+      <trans-unit id="ResultsCacheMissDueToSkippedTarget">
+        <source>Cached results for "{0}" cannot be reused because target "{1}" has a skipped result, so the project will be built again. Conditionally skipped initial and default targets prevent results from being reused.</source>
+        <target state="new">Cached results for "{0}" cannot be reused because target "{1}" has a skipped result, so the project will be built again. Conditionally skipped initial and default targets prevent results from being reused.</target>
+        <note>
+      LOCALIZATION: {0} is a file path. {1} is a target name.
+    </note>
+      </trans-unit>
       <trans-unit id="SDKPathCheck_Failed">
         <source>The directory does not exist: {0}. .NET Runtime Task Host could not be instantiated. See https://aka.ms/nettaskhost for details on how to resolve this error.</source>
         <target state="translated">Dizin mevcut değil: {0}. .NET Çalışma Zamanı Görev Ana Bilgisayarı başlatılamadı. Bu hatayı çözmeyle ilgili ayrıntılar için https://aka.ms/nettaskhost adresini inceleyin.</target>

--- a/src/Build/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hans.xlf
@@ -966,6 +966,13 @@
       's' should reflect the localized abbreviation for seconds
     </note>
       </trans-unit>
+      <trans-unit id="ResultsCacheMissDueToSkippedTarget">
+        <source>Cached results for "{0}" cannot be reused because target "{1}" has a skipped result, so the project will be built again. Conditionally skipped initial and default targets prevent results from being reused.</source>
+        <target state="new">Cached results for "{0}" cannot be reused because target "{1}" has a skipped result, so the project will be built again. Conditionally skipped initial and default targets prevent results from being reused.</target>
+        <note>
+      LOCALIZATION: {0} is a file path. {1} is a target name.
+    </note>
+      </trans-unit>
       <trans-unit id="SDKPathCheck_Failed">
         <source>The directory does not exist: {0}. .NET Runtime Task Host could not be instantiated. See https://aka.ms/nettaskhost for details on how to resolve this error.</source>
         <target state="translated">目录不存在: {0}。无法实例化 .NET 运行时任务主机。有关如何解决此错误的详细信息，请参阅 https://aka.ms/nettaskhost。</target>

--- a/src/Build/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hant.xlf
@@ -966,6 +966,13 @@
       's' should reflect the localized abbreviation for seconds
     </note>
       </trans-unit>
+      <trans-unit id="ResultsCacheMissDueToSkippedTarget">
+        <source>Cached results for "{0}" cannot be reused because target "{1}" has a skipped result, so the project will be built again. Conditionally skipped initial and default targets prevent results from being reused.</source>
+        <target state="new">Cached results for "{0}" cannot be reused because target "{1}" has a skipped result, so the project will be built again. Conditionally skipped initial and default targets prevent results from being reused.</target>
+        <note>
+      LOCALIZATION: {0} is a file path. {1} is a target name.
+    </note>
+      </trans-unit>
       <trans-unit id="SDKPathCheck_Failed">
         <source>The directory does not exist: {0}. .NET Runtime Task Host could not be instantiated. See https://aka.ms/nettaskhost for details on how to resolve this error.</source>
         <target state="translated">目錄不存在: {0}。無法執行個體化 .NET 執行階段工作主機。如需如何解決此錯誤的詳細資料，請參閱 https://aka.ms/nettaskhost。</target>


### PR DESCRIPTION
Fixes the observability half of #11753.

## Problem

`ResultsCache.SatisfyRequest` treats a `Skipped` target result as equivalent to a *missing* one:

```csharp
if (!result.TryGetResultsForTarget(target, out TargetResult targetResult) ||
    (targetResult.ResultCode == TargetResultCode.Skipped && !skippedResultsAreOK))
```

`skippedResultsAreOK` comes from `BuildParameters.SkippedResultsDoNotCauseCacheMiss()`, which is only true under `ProjectIsolationMode.True`. So in a normal build, **a single conditionally skipped initial or default target permanently disables results-cache reuse for that entire configuration** — every later request for the project misses the cache and is scheduled and built again.

Two things make this nasty:

1. **It is trivial to introduce.** `InitialTargets` on an imported `<Project>` aggregates into every importing project, so adding one conditional initial target to a widely imported `.props`/`.targets` file applies it to the whole repo.
2. **It is completely silent.** There is no message, no `-v:diag` output, nothing in the binlog. The only symptom is that things get slower — or, in the re-entrant case, that an already-in-flight result stops masking an invalid recursive build and you get a confusing `MSB4006` circular dependency error instead.

We just hit exactly that in the .NET VMR: arcade's `Workarounds.targets` gained `InitialTargets="NormalizeNetCoreSdkRootCasing"`, whose condition is false on Linux. Every arcade project in the VMR silently lost cache reuse, and one re-entrant `<MSBuild>` call that had worked for years started failing with `MSB4006`. It took a long time to track down, precisely because nothing reports the miss. Note that arcade had already been told about this pattern once before (dotnet/arcade#15743) and it came back.

## Change

Make the miss observable. No semantic change to caching.

- `ResultsCache.CheckResults` gains `out string skippedTarget`, recording the first target rejected *because it had a skipped result*, as distinct from having no result at all. Only the former is worth reporting.
- `ResultsCacheResponse` carries the new `SkippedTargetCausingCacheMiss` field.
- `Scheduler.TrySatisfyRequestFromCache` gains an opt-in `logSkippedTargetCacheMiss` flag, enabled at exactly one call site (the "request first received" path) so a request is reported once rather than on every scheduling pass.

Output:

```
Cached results for "/repo/src/Foo/Foo.csproj" cannot be reused because target
"NormalizeNetCoreSdkRootCasing" has a skipped result, so the project will be
built again. Conditionally skipped initial and default targets prevent results
from being reused.
```

Also emitted to `TraceScheduler` for `MSBUILDDEBUGSCHEDULER` traces.

## Not a breaking change

Per `AGENTS.md`, adding new warnings or errors is an unacceptable breaking change. This is a **`MessageImportance.Low` message only** — invisible at default, `-v:m` and `-v:n`, visible at `-v:diag` and in binlogs, where the people debugging this actually look. Nothing is added on the satisfied path.

## Relationship to the semantic fixes discussed in #11753

Complementary, not competing. @AR-May's attempt to accept skipped results as valid was blocked by `BuildManager_Tests.OverlappingBuildSubmissions_OnlyOneSucceeds`, and the 2026-07-16 grooming comment suggests letting the scheduler determine a result is available without first acquiring execution time on the original node. Both remain open; this PR does not constrain either, and it makes the impact measurable in binlogs first — which is a prerequisite for prioritising them.

(For the record, the blocking test exercises an *explicitly requested* target, not an initial target. A successful initial target is already never re-evaluated; only skipped ones are. That asymmetry suggests a narrower semantic fix is possible later, but it is out of scope here.)

## Consumer-side fix

dotnet/arcade#17329 removes the offending `InitialTargets` condition, and dotnet/dotnet#8276 fixes the resulting VMR build failure.

## Testing

Five new `ResultsCache_Tests` covering: skipped initial target reported, skipped default target reported, *missing* initial target not misreported as skipped, satisfied request reports nothing, and nothing reported when `skippedResultsDoNotCauseCacheMiss` is set.

Verified end-to-end against a real repro with a bootstrap SDK — the message appears both in the perf case (project rebuilt twice) and immediately before the `MSB4006` in the re-entrant case. Confirmed no false positives: an initial target that actually runs produces zero messages, as does a first-time build.

`ResultsCache_Tests` (23), `Scheduler_Tests` (32) and `OverlappingBuildSubmissions_OnlyOneSucceeds` all pass.