### PR TITLE
Drop stale secret group

### DIFF
--- a/.vsts-dotnet-ci.yml
+++ b/.vsts-dotnet-ci.yml
@@ -10,8 +10,6 @@ trigger:
     - .github/**
 
 variables:
-- ${{ if eq(variables['System.TeamProject'], 'DevDiv') }}:
-  - group: AzureDevOps-Artifact-Feeds-Pats
 - name: cfsNugetWarnLevel
   value: warn
 - name: nugetMultiFeedWarnLevel

--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -65,7 +65,6 @@ variables:
   - name: Codeql.Enabled
     value: true
   - group: DotNet-MSBuild-SDLValidation-Params
-  - group: AzureDevOps-Artifact-Feeds-Pats
   - name: cfsNugetWarnLevel
     value: warn
   - name: nugetMultiFeedWarnLevel

--- a/azure-pipelines/.vsts-dotnet-exp-perf.yml
+++ b/azure-pipelines/.vsts-dotnet-exp-perf.yml
@@ -41,7 +41,6 @@ variables:
   - name: Codeql.Enabled
     value: false
   - group: DotNet-MSBuild-SDLValidation-Params
-  - group: AzureDevOps-Artifact-Feeds-Pats
   - name: cfsNugetWarnLevel
     value: warn
   - name: nugetMultiFeedWarnLevel


### PR DESCRIPTION
Fix the official build by removing this group that should no longer be needed after https://github.com/dotnet/arcade/pull/17245. Similar to https://github.com/dotnet/arcade/pull/17259.

Exp job was an easy test and got past the failure point: https://dev.azure.com/devdiv/DevDiv/_build/results?buildId=14979069