### PR TITLE
[vs16.11] Drop stale AzureDevOps-Artifact-Feeds-Pats secret group

### DIFF
--- a/azure-pipelines/.vsts-dotnet-exp-perf.yml
+++ b/azure-pipelines/.vsts-dotnet-exp-perf.yml
@@ -40,7 +40,6 @@ variables:
   - name: Codeql.Enabled
     value: false
   - group: DotNet-MSBuild-SDLValidation-Params
-  - group: AzureDevOps-Artifact-Feeds-Pats
   - name: cfsNugetWarnLevel
     value: warn
   - name: nugetMultiFeedWarnLevel

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,7 +2,7 @@
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the MIT license. See License.txt in the project root for full license information. -->
 <Project>
   <PropertyGroup>
-    <VersionPrefix>16.11.17</VersionPrefix>
+    <VersionPrefix>16.11.18</VersionPrefix>
     <DotNetFinalVersionKind>release</DotNetFinalVersionKind>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>


### PR DESCRIPTION
Ports https://github.com/dotnet/msbuild/pull/14710 (commit b6d968a085d1010fd04b7a65d3adb1684d297153) to this servicing branch.

The `AzureDevOps-Artifact-Feeds-Pats` variable group is no longer active, and referencing it fails the official build. It is no longer needed after https://github.com/dotnet/arcade/pull/17245.

`$(dn-bot-dnceng-artifact-feeds-rw)` is still consumed by the `Setup Private Feeds Credentials` steps and is now provided without this group, matching `main`.

### Why only one file here

Unlike `main`, this branch references the group in exactly one place. Its `.vsts-dotnet-ci.yml` and `.vsts-dotnet.yml` predate the group being added, so there is nothing to remove there. This change therefore fully removes the group from `vs16.11`.

### Other branches

This commit also fully covers `vs17.8`, which has the same single reference, so `vs17.8` needs no separate PR and is handled by merge flow.

`vs17.11` and everything newer reference the group in all three files and are handled by #14719, which is a complete self-contained port of #14710.