### PR TITLE
[vs17.11] Drop stale AzureDevOps-Artifact-Feeds-Pats secret group

### DIFF
--- a/.vsts-dotnet-ci.yml
+++ b/.vsts-dotnet-ci.yml
@@ -4,8 +4,6 @@ trigger:
 - vs*
 
 variables:
-- ${{ if eq(variables['System.TeamProject'], 'DevDiv') }}:
-  - group: AzureDevOps-Artifact-Feeds-Pats
 - name: cfsNugetWarnLevel
   value: warn
 - name: nugetMultiFeedWarnLevel

--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -54,7 +54,6 @@ variables:
   - name: IsExperimental
     value: ${{ startsWith(variables['Build.SourceBranch'], 'refs/heads/exp/') }}
   - group: DotNet-MSBuild-SDLValidation-Params
-  - group: AzureDevOps-Artifact-Feeds-Pats
   - name: cfsNugetWarnLevel
     value: warn
   - name: nugetMultiFeedWarnLevel

--- a/azure-pipelines/.vsts-dotnet-exp-perf.yml
+++ b/azure-pipelines/.vsts-dotnet-exp-perf.yml
@@ -45,7 +45,6 @@ variables:
   - name: Codeql.Enabled
     value: false
   - group: DotNet-MSBuild-SDLValidation-Params
-  - group: AzureDevOps-Artifact-Feeds-Pats
   - name: cfsNugetWarnLevel
     value: warn
   - name: nugetMultiFeedWarnLevel

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,7 +2,7 @@
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the MIT license. See License.txt in the project root for full license information. -->
 <Project>
   <PropertyGroup>
-    <VersionPrefix>17.11.61</VersionPrefix>
+    <VersionPrefix>17.11.62</VersionPrefix>
     <DotNetFinalVersionKind>release</DotNetFinalVersionKind>
     <PackageValidationBaselineVersion>17.10.4</PackageValidationBaselineVersion>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>


### PR DESCRIPTION
Ports https://github.com/dotnet/msbuild/pull/14710 (commit b6d968a085d1010fd04b7a65d3adb1684d297153) to this servicing branch.

The `AzureDevOps-Artifact-Feeds-Pats` variable group is no longer active, and referencing it fails the official build. It is no longer needed after https://github.com/dotnet/arcade/pull/17245.

`$(dn-bot-dnceng-artifact-feeds-rw)` is still consumed by the `Setup Private Feeds Credentials` steps and is now provided without this group, matching `main`. In `.vsts-dotnet-ci.yml` the surrounding `${{ if eq(variables['System.TeamProject'], 'DevDiv') }}` block is removed too, since it would otherwise be empty.

This is a complete, self-contained port: the same three files and four deletions as #14710, so this branch is fixed on its own without waiting for merge flow.

### Other branches

`vs16.11` only ever referenced the group in `azure-pipelines/.vsts-dotnet-exp-perf.yml` (its other two pipeline files predate the group being added), so it gets a one-file fix in #14718, which also fully covers `vs17.8`.

Branches newer than this one (`vs17.12`, `vs17.14`, `vs18.0`, `vs18.6`, `vs18.8`, `vs18.9`, `vs18.10`) all match this branch exactly. This commit cherry-picks cleanly onto each of them and leaves zero references, so they are covered by merge flow and need no separate PR.

The overlapping deletion in `.vsts-dotnet-exp-perf.yml` shared with #14718 merges cleanly (both sides remove the same line); verified that a `vs17.8` -> `vs17.11` forward-flow merge produces no conflict in any of the three pipeline files.