### PR TITLE
Track exact source locations on evaluated items

### DIFF
--- a/src/Build.OM.UnitTests/Instance/ProjectItemInstance_Tests.cs
+++ b/src/Build.OM.UnitTests/Instance/ProjectItemInstance_Tests.cs
@@ -79,6 +79,37 @@ namespace Microsoft.Build.UnitTests.OM.Instance
             Assert.False(item.Metadata.GetEnumerator().MoveNext());
         }
 
+        [Fact]
+        public void LocationTracksOriginatingItemElement()
+        {
+            using ProjectRootElementFromString projectRootElementFromString = new(
+                """
+                <Project>
+                  <ItemGroup>
+                    <i Include="i1" />
+                  </ItemGroup>
+                </Project>
+                """);
+
+            ProjectRootElement xml = projectRootElementFromString.Project;
+            ProjectItemElement itemElement = xml.Items.Single();
+            ProjectItemInstance item = new ProjectInstance(xml).GetItems("i").Single();
+
+            TaskItemLocation? itemLocation = item.Location;
+            Assert.True(itemLocation.HasValue);
+            TaskItemLocation location = itemLocation.Value;
+            Assert.Equal(itemElement.Location.File, location.File);
+            Assert.Equal(itemElement.Location.Line, location.Line);
+            Assert.Equal(itemElement.Location.Column, location.Column);
+            Assert.Equal(location, ((ITaskItem3)item).Location.Value);
+
+            var copiedItem = new Utilities.TaskItem(item);
+            TaskItemLocation copiedLocation = copiedItem.Location.Value;
+            Assert.Equal(location.File, copiedLocation.File);
+            Assert.Equal(location.Line, copiedLocation.Line);
+            Assert.Equal(location.Column, copiedLocation.Column);
+        }
+
         /// <summary>
         /// Basic ProjectItemInstance with metadata
         /// </summary>

--- a/src/Build.UnitTests/Instance/TaskItem_Tests.cs
+++ b/src/Build.UnitTests/Instance/TaskItem_Tests.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Build.UnitTests.OM.Instance
         [Fact]
         public void Serialization()
         {
-            TaskItem item = new TaskItem("foo", "bar.proj");
+            TaskItem item = new TaskItem("foo", "bar.proj", sourceLineNumber: 12, sourceColumnNumber: 34);
             item.SetMetadata("a", "b");
 
             TranslationHelpers.GetWriteTranslator().Translate(ref item, TaskItem.FactoryForDeserialization);
@@ -61,6 +61,7 @@ namespace Microsoft.Build.UnitTests.OM.Instance
             Assert.Equal(item.MetadataCount, deserializedItem.MetadataCount);
             Assert.Equal(item.GetMetadata("a"), deserializedItem.GetMetadata("a"));
             Assert.Equal(item.GetMetadata(ItemSpecModifiers.DefiningProjectFullPath), deserializedItem.GetMetadata(ItemSpecModifiers.DefiningProjectFullPath));
+            Assert.Equal(item.Location, deserializedItem.Location);
         }
 
         /// <summary>

--- a/src/Build.UnitTests/InstanceFromRemote/FakeProjectItemElementLink.cs
+++ b/src/Build.UnitTests/InstanceFromRemote/FakeProjectItemElementLink.cs
@@ -18,11 +18,13 @@ namespace Microsoft.Build.Engine.UnitTests.InstanceFromRemote
     internal sealed class FakeProjectItemElementLink : ProjectItemElementLink
     {
         private readonly string _filePath;
+        private readonly ElementLocation _location;
 
         public FakeProjectItemElementLink(string elementName, string filePath)
         {
             ElementName = elementName ?? throw new ArgumentNullException(nameof(elementName));
             _filePath = filePath ?? throw new ArgumentNullException(nameof(filePath));
+            _location = ElementLocation.Create(filePath, 1, 1);
         }
 
         public override int Count => throw new NotImplementedException();
@@ -45,7 +47,7 @@ namespace Microsoft.Build.Engine.UnitTests.InstanceFromRemote
 
         public override ProjectElement NextSibling => throw new NotImplementedException();
 
-        public override ElementLocation Location => throw new NotImplementedException();
+        public override ElementLocation Location => _location;
 
         public override IReadOnlyCollection<XmlAttributeLink> Attributes => throw new NotImplementedException();
 

--- a/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupIntrinsicTask.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupIntrinsicTask.cs
@@ -426,7 +426,10 @@ namespace Microsoft.Build.BackEnd
 
             // Split Include on any semicolons, and take each split in turn
             var includeSplits = ExpressionShredder.SplitSemiColonSeparatedList(evaluatedInclude);
-            ProjectItemInstanceFactory itemFactory = new ProjectItemInstanceFactory(Project, originalItem.ItemType);
+            ProjectItemInstanceFactory itemFactory = new ProjectItemInstanceFactory(Project, originalItem.ItemType)
+            {
+                SourceLocation = originalItem.Location,
+            };
 
             // EngineFileUtilities.GetFileListEscaped api invocation evaluates excludes by default.
             // If the code process any expression like "@(x)", we need to handle excludes explicitly using EvaluateExcludePaths().
@@ -473,7 +476,9 @@ namespace Microsoft.Build.BackEnd
                             null,
                             null,
                             originalItem.Location.File,
-                            useItemDefinitionsWithoutModification: false));
+                            useItemDefinitionsWithoutModification: false,
+                            originalItem.Location.Line,
+                            originalItem.Location.Column));
                     }
                 }
             }

--- a/src/Build/BackEnd/Components/RequestBuilder/TaskBuilder.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TaskBuilder.cs
@@ -1223,7 +1223,10 @@ namespace Microsoft.Build.BackEnd
                     // This is an output item.
                     // Expand only with properties first, so that expressions like Include="@(foo)" will transfer the metadata of the "foo" items as well, not just their item specs.
                     var outputItemSpecs = bucket.Expander.ExpandIntoStringListLeaveEscaped(taskParameterAttribute, ExpanderOptions.ExpandPropertiesAndMetadata, taskItemInstance.TaskParameterLocation);
-                    ProjectItemInstanceFactory itemFactory = new ProjectItemInstanceFactory(_buildRequestEntry.RequestConfiguration.Project, itemName);
+                    ProjectItemInstanceFactory itemFactory = new ProjectItemInstanceFactory(_buildRequestEntry.RequestConfiguration.Project, itemName)
+                    {
+                        SourceLocation = taskItemInstance.Location,
+                    };
 
                     foreach (string outputItemSpec in outputItemSpecs)
                     {

--- a/src/Build/BackEnd/TaskExecutionHost/TaskExecutionHost.cs
+++ b/src/Build/BackEnd/TaskExecutionHost/TaskExecutionHost.cs
@@ -1801,7 +1801,7 @@ namespace Microsoft.Build.BackEnd
                             {
                                 // The common case -- all items involved are Microsoft.Build.Execution.ProjectItemInstance.TaskItems.
                                 // Furthermore, because that is true, we know by definition that they also implement ITaskItem2.
-                                newItem = new ProjectItemInstance(_projectInstance, outputTargetName, outputAsProjectItem.IncludeEscaped, parameterLocationEscaped);
+                                newItem = new ProjectItemInstance(_projectInstance, outputTargetName, outputAsProjectItem.IncludeEscaped, parameterLocationEscaped, parameterLocation.Line, parameterLocation.Column);
 
                                 newItem.SetMetadata(outputAsProjectItem.MetadataCollection); // copy-on-write!
                             }
@@ -1810,7 +1810,7 @@ namespace Microsoft.Build.BackEnd
                                 if (output is ITaskItem2 outputAsITaskItem2)
                                 {
                                     // Probably a Microsoft.Build.Utilities.TaskItem.  Not quite as good, but we can still preserve escaping.
-                                    newItem = new ProjectItemInstance(_projectInstance, outputTargetName, outputAsITaskItem2.EvaluatedIncludeEscaped, parameterLocationEscaped);
+                                    newItem = new ProjectItemInstance(_projectInstance, outputTargetName, outputAsITaskItem2.EvaluatedIncludeEscaped, parameterLocationEscaped, parameterLocation.Line, parameterLocation.Column);
 
                                     // If found, directly pass the backing copy-on-write dictionary.
                                     // Otherwise, retrieve a cloned dictionary from the task item.
@@ -1830,7 +1830,7 @@ namespace Microsoft.Build.BackEnd
                                 {
                                     // Not a ProjectItemInstance.TaskItem or even a ITaskItem2, so we have to fake it.
                                     // Setting an item spec expects the escaped value, as does setting metadata.
-                                    newItem = new ProjectItemInstance(_projectInstance, outputTargetName, EscapingUtilities.Escape(output.ItemSpec), parameterLocationEscaped);
+                                    newItem = new ProjectItemInstance(_projectInstance, outputTargetName, EscapingUtilities.Escape(output.ItemSpec), parameterLocationEscaped, parameterLocation.Line, parameterLocation.Column);
 
                                     newItem.SetMetadataOnTaskOutput(EnumerateMetadata(output.CloneCustomMetadata()));
 
@@ -1948,7 +1948,7 @@ namespace Microsoft.Build.BackEnd
                         // attempting to put an empty string into an item is a no-op.
                         if (output?.Length > 0)
                         {
-                            _batchBucket.Lookup.AddNewItem(new ProjectItemInstance(_projectInstance, outputTargetName, EscapingUtilities.Escape(output), EscapingUtilities.Escape(parameterLocation.File)));
+                            _batchBucket.Lookup.AddNewItem(new ProjectItemInstance(_projectInstance, outputTargetName, EscapingUtilities.Escape(output), EscapingUtilities.Escape(parameterLocation.File), parameterLocation.Line, parameterLocation.Column));
                         }
                     }
 

--- a/src/Build/Instance/ProjectInstance.cs
+++ b/src/Build/Instance/ProjectInstance.cs
@@ -3537,7 +3537,9 @@ namespace Microsoft.Build.Execution
                 directMetadata,
                 inheritedItemDefinitions,
                 item.Xml.ContainingProject.EscapedFullPath,
-                useItemDefinitionsWithoutModification: false);
+                useItemDefinitionsWithoutModification: false,
+                item.Xml.Location.Line,
+                item.Xml.Location.Column);
 
             return instance;
         }
@@ -3597,7 +3599,9 @@ namespace Microsoft.Build.Execution
                 directMetadata,
                 inheritedItemDefinitions,
                 item.Xml.ContainingProject.EscapedFullPath,
-                useItemDefinitionsWithoutModification: true);
+                useItemDefinitionsWithoutModification: true,
+                item.Xml.Location.Line,
+                item.Xml.Location.Column);
             return instance;
         }
 

--- a/src/Build/Instance/ProjectItemInstance.cs
+++ b/src/Build/Instance/ProjectItemInstance.cs
@@ -29,13 +29,12 @@ namespace Microsoft.Build.Execution
     /// Wraps an evaluated item for build purposes
     /// </summary>
     /// <remarks>
-    /// Does not store XML location information. That is not needed by the build process as all correctness checks
-    /// and evaluation has already been performed, so it is unnecessary bulk.
+    /// Stores the source line and column so tasks can associate diagnostics with the XML element that produced the item.
     /// </remarks>
     [DebuggerDisplay("{ItemType}={EvaluatedInclude} #DirectMetadata={DirectMetadataCount})")]
     public class ProjectItemInstance :
         IItem<ProjectMetadataInstance>,
-        ITaskItem2,
+        ITaskItem3,
         IMetadataTable,
         ITranslatable,
         IMetadataContainer,
@@ -67,8 +66,8 @@ namespace Microsoft.Build.Execution
         /// and during the build when tasks emit items.
         /// Mutability follows the project.
         /// </summary>
-        internal ProjectItemInstance(ProjectInstance project, string itemType, string includeEscaped, string definingFileEscaped)
-            : this(project, itemType, includeEscaped, includeEscaped, definingFileEscaped)
+        internal ProjectItemInstance(ProjectInstance project, string itemType, string includeEscaped, string definingFileEscaped, int sourceLineNumber = 0, int sourceColumnNumber = 0)
+            : this(project, itemType, includeEscaped, includeEscaped, definingFileEscaped, sourceLineNumber, sourceColumnNumber)
         {
         }
 
@@ -79,8 +78,8 @@ namespace Microsoft.Build.Execution
         /// and during the build when tasks emit items.
         /// Mutability follows the project.
         /// </summary>
-        internal ProjectItemInstance(ProjectInstance project, string itemType, string includeEscaped, string includeBeforeWildcardExpansionEscaped, string definingFileEscaped)
-            : this(project, itemType, includeEscaped, includeBeforeWildcardExpansionEscaped, null /* no direct metadata */, null /* need to add item definition metadata */, definingFileEscaped, useItemDefinitionsWithoutModification: false)
+        internal ProjectItemInstance(ProjectInstance project, string itemType, string includeEscaped, string includeBeforeWildcardExpansionEscaped, string definingFileEscaped, int sourceLineNumber = 0, int sourceColumnNumber = 0)
+            : this(project, itemType, includeEscaped, includeBeforeWildcardExpansionEscaped, null /* no direct metadata */, null /* need to add item definition metadata */, definingFileEscaped, useItemDefinitionsWithoutModification: false, sourceLineNumber, sourceColumnNumber)
         {
         }
 
@@ -105,9 +104,11 @@ namespace Microsoft.Build.Execution
             IReadOnlyDictionary<string, string> directMetadata,
             IList<ProjectItemDefinitionInstance> itemDefinitions,
             string definingFileEscaped,
-            bool useItemDefinitionsWithoutModification)
+            bool useItemDefinitionsWithoutModification,
+            int sourceLineNumber = 0,
+            int sourceColumnNumber = 0)
         {
-            CommonConstructor(project, itemType, includeEscaped, includeBeforeWildcardExpansionEscaped, directMetadata, itemDefinitions, definingFileEscaped, useItemDefinitionsWithoutModification);
+            CommonConstructor(project, itemType, includeEscaped, includeBeforeWildcardExpansionEscaped, directMetadata, itemDefinitions, definingFileEscaped, useItemDefinitionsWithoutModification, sourceLineNumber, sourceColumnNumber);
         }
 
         /// <summary>
@@ -121,7 +122,7 @@ namespace Microsoft.Build.Execution
         /// <remarks>
         /// Not public since the only creation scenario is setting on a project.
         /// </remarks>
-        internal ProjectItemInstance(ProjectInstance project, string itemType, string includeEscaped, IEnumerable<KeyValuePair<string, string>> directMetadata, string definingFileEscaped)
+        internal ProjectItemInstance(ProjectInstance project, string itemType, string includeEscaped, IEnumerable<KeyValuePair<string, string>> directMetadata, string definingFileEscaped, int sourceLineNumber = 0, int sourceColumnNumber = 0)
         {
             ImmutableDictionary<string, string> metadata = null;
 
@@ -131,7 +132,7 @@ namespace Microsoft.Build.Execution
                     .SetItems(directMetadata, ProjectMetadataInstance.VerifyThrowReservedName);
             }
 
-            CommonConstructor(project, itemType, includeEscaped, includeEscaped, metadata, null /* need to add item definition metadata */, definingFileEscaped, useItemDefinitionsWithoutModification: false);
+            CommonConstructor(project, itemType, includeEscaped, includeEscaped, metadata, null /* need to add item definition metadata */, definingFileEscaped, useItemDefinitionsWithoutModification: false, sourceLineNumber, sourceColumnNumber);
         }
 
         /// <summary>
@@ -170,6 +171,11 @@ namespace Microsoft.Build.Execution
         {
             get { return _project; }
         }
+
+        /// <summary>
+        /// Gets the source location of the XML element that produced this item.
+        /// </summary>
+        public TaskItemLocation? Location => _taskItem.Location;
 
         /// <summary>
         /// Item type, for example "Compile"
@@ -732,7 +738,9 @@ namespace Microsoft.Build.Execution
             IReadOnlyDictionary<string, string> directMetadata,
             IList<ProjectItemDefinitionInstance> itemDefinitions,
             string definingFileEscaped,
-            bool useItemDefinitionsWithoutModification)
+            bool useItemDefinitionsWithoutModification,
+            int sourceLineNumber,
+            int sourceColumnNumber)
         {
             ArgumentNullException.ThrowIfNull(projectToUse, "project");
             ArgumentException.ThrowIfNullOrEmpty(itemTypeToUse, "itemType");
@@ -771,7 +779,9 @@ namespace Microsoft.Build.Execution
                             inheritedItemDefinitions,
                             _project.Directory,
                             _project.IsImmutable,
-                            definingFileEscaped);
+                            definingFileEscaped,
+                            sourceLineNumber,
+                            sourceColumnNumber);
         }
 
         /// <summary>
@@ -782,7 +792,7 @@ namespace Microsoft.Build.Execution
 #if FEATURE_APPDOMAIN
             MarshalByRefObject,
 #endif
-            ITaskItem2,
+            ITaskItem3,
             IItem<ProjectMetadataInstance>,
             ITranslatable,
             IEquatable<TaskItem>,
@@ -792,6 +802,10 @@ namespace Microsoft.Build.Execution
             /// The source file that defined this item.
             /// </summary>
             private string _definingFileEscaped;
+
+            private int _sourceLineNumber;
+
+            private int _sourceColumnNumber;
 
             /// <summary>
             /// Evaluated include, escaped as necessary.
@@ -845,8 +859,8 @@ namespace Microsoft.Build.Execution
             /// <summary>
             /// Creates an instance of this class given the item-spec.
             /// </summary>
-            internal TaskItem(string includeEscaped, string definingFileEscaped)
-                : this(includeEscaped, includeEscaped, null, null, null, immutable: false, definingFileEscaped)
+            internal TaskItem(string includeEscaped, string definingFileEscaped, int sourceLineNumber = 0, int sourceColumnNumber = 0)
+                : this(includeEscaped, includeEscaped, null, null, null, immutable: false, definingFileEscaped, sourceLineNumber, sourceColumnNumber)
             {
             }
 
@@ -861,7 +875,9 @@ namespace Microsoft.Build.Execution
                               IList<ProjectItemDefinitionInstance> itemDefinitions,
                               string projectDirectory,
                               bool immutable,
-                              string definingFileEscaped) // the actual project file (or import) that defines this item.
+                              string definingFileEscaped,
+                              int sourceLineNumber = 0,
+                              int sourceColumnNumber = 0) // the actual project file (or import) that defines this item.
             {
                 ArgumentException.ThrowIfNullOrEmpty(includeEscaped);
                 ArgumentException.ThrowIfNullOrEmpty(includeBeforeWildcardExpansionEscaped);
@@ -873,6 +889,8 @@ namespace Microsoft.Build.Execution
                 _projectDirectory = projectDirectory;
                 _isImmutable = immutable;
                 _definingFileEscaped = definingFileEscaped;
+                _sourceLineNumber = sourceLineNumber;
+                _sourceColumnNumber = sourceColumnNumber;
             }
 
             /// <summary>
@@ -895,6 +913,8 @@ namespace Microsoft.Build.Execution
                 source.CopyMetadataTo(this, addOriginalItemSpec);
                 _cachedModifiers = source._cachedModifiers;
                 _definingFileEscaped = source._definingFileEscaped;
+                _sourceLineNumber = source._sourceLineNumber;
+                _sourceColumnNumber = source._sourceColumnNumber;
             }
 
             /// <summary>
@@ -912,6 +932,11 @@ namespace Microsoft.Build.Execution
             {
                 this.TranslateWithInterning(translator, interner);
             }
+
+            /// <inheritdoc/>
+            public TaskItemLocation? Location => _sourceLineNumber == 0
+                ? null
+                : new TaskItemLocation(EscapingUtilities.UnescapeAll(_definingFileEscaped), _sourceLineNumber, _sourceColumnNumber);
 
             /// <summary>
             /// Gets or sets the unescaped include, or "name", for the item.
@@ -1672,6 +1697,8 @@ namespace Microsoft.Build.Execution
                 translator.Translate(ref _includeBeforeWildcardExpansionEscaped);
                 translator.Translate(ref _isImmutable);
                 translator.Translate(ref _definingFileEscaped);
+                translator.Translate(ref _sourceLineNumber);
+                translator.Translate(ref _sourceColumnNumber);
 
                 TranslatorHelpers.Translate(
                     translator,
@@ -1890,6 +1917,8 @@ namespace Microsoft.Build.Execution
                     (capacity) => new List<ProjectItemDefinitionInstance>(capacity));
                 translator.Translate(ref _isImmutable);
                 translator.Translate(ref _includeEscaped);
+                translator.Translate(ref _sourceLineNumber);
+                translator.Translate(ref _sourceColumnNumber);
 
                 if (translator.Mode == TranslationDirection.WriteToStream)
                 {
@@ -2210,6 +2239,10 @@ namespace Microsoft.Build.Execution
                 /// </summary>
                 private ProjectInstance _project;
 
+                private int _sourceLineNumber;
+
+                private int _sourceColumnNumber;
+
                 /// <summary>
                 /// Constructor not taking an item type.
                 /// This indicates that the user of this factory should set the item type
@@ -2245,7 +2278,20 @@ namespace Microsoft.Build.Execution
                 /// </summary>
                 public ProjectItemElement ItemElement
                 {
-                    set { ItemType = value.ItemType; }
+                    set
+                    {
+                        ItemType = value.ItemType;
+                        SourceLocation = value.Location;
+                    }
+                }
+
+                internal ElementLocation SourceLocation
+                {
+                    set
+                    {
+                        _sourceLineNumber = value?.Line ?? 0;
+                        _sourceColumnNumber = value?.Column ?? 0;
+                    }
                 }
 
                 /// <summary>
@@ -2258,7 +2304,7 @@ namespace Microsoft.Build.Execution
                 {
                     Assumed.NotNullOrEmpty(ItemType);
 
-                    ProjectItemInstance item = new ProjectItemInstance(_project, ItemType, include, definingProject);
+                    ProjectItemInstance item = new ProjectItemInstance(_project, ItemType, include, definingProject, _sourceLineNumber, _sourceColumnNumber);
 
                     return item;
                 }
@@ -2291,7 +2337,7 @@ namespace Microsoft.Build.Execution
                 {
                     Assumed.NotNullOrEmpty(ItemType);
 
-                    return new ProjectItemInstance(_project, ItemType, evaluatedInclude, evaluatedIncludeBeforeWildcardExpansion, definingProject);
+                    return new ProjectItemInstance(_project, ItemType, evaluatedInclude, evaluatedIncludeBeforeWildcardExpansion, definingProject, _sourceLineNumber, _sourceColumnNumber);
                 }
 
                 /// <summary>
@@ -2344,7 +2390,7 @@ namespace Microsoft.Build.Execution
                         itemDefinitionsClone.Add(sourceItemDefinition);
                     }
 
-                    return new ProjectItemInstance(_project, ItemType, includeEscaped, includeBeforeWildcardExpansionEscaped, source._taskItem.DirectMetadata, itemDefinitionsClone, definingProject, useItemDefinitionsWithoutModification: false);
+                    return new ProjectItemInstance(_project, ItemType, includeEscaped, includeBeforeWildcardExpansionEscaped, source._taskItem.DirectMetadata, itemDefinitionsClone, definingProject, useItemDefinitionsWithoutModification: false, _sourceLineNumber, _sourceColumnNumber);
                 }
             }
 

--- a/src/Framework/ITaskItem3.cs
+++ b/src/Framework/ITaskItem3.cs
@@ -1,0 +1,18 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.InteropServices;
+
+namespace Microsoft.Build.Framework;
+
+/// <summary>
+/// Extends <see cref="ITaskItem2"/> with the source location of the XML element that produced the item.
+/// </summary>
+[ComVisible(false)]
+public interface ITaskItem3 : ITaskItem2
+{
+    /// <summary>
+    /// Gets the source location of the XML element that produced this item, or <see langword="null"/> when unavailable.
+    /// </summary>
+    TaskItemLocation? Location { get; }
+}

--- a/src/Framework/TaskItemLocation.cs
+++ b/src/Framework/TaskItemLocation.cs
@@ -1,0 +1,53 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using Microsoft.Build.Shared;
+
+namespace Microsoft.Build.Framework;
+
+/// <summary>
+/// Identifies the source location of an MSBuild item.
+/// </summary>
+[Serializable]
+public readonly struct TaskItemLocation : IMSBuildElementLocation
+{
+    private readonly string? _file;
+
+    /// <summary>
+    /// Initializes a new item source location.
+    /// </summary>
+    public TaskItemLocation(string? file, int line, int column)
+    {
+        if (line < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(line));
+        }
+
+        if (column < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(column));
+        }
+
+        _file = file;
+        Line = line;
+        Column = column;
+    }
+
+    /// <inheritdoc/>
+    public string File => _file ?? string.Empty;
+
+    /// <inheritdoc/>
+    public int Line { get; }
+
+    /// <inheritdoc/>
+    public int Column { get; }
+
+    /// <inheritdoc/>
+    public string LocationString => Line switch
+    {
+        > 0 when Column > 0 => $"{File} ({Line},{Column})",
+        > 0 => $"{File} ({Line})",
+        _ => File,
+    };
+}

--- a/src/Framework/TaskItem_T.cs
+++ b/src/Framework/TaskItem_T.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Build.Framework
     /// The identity (ItemSpec) is parsed using <see cref="ValueTypeParser"/> which handles value types,
     /// AbsolutePath, FileInfo, and DirectoryInfo.
     /// </remarks>
-    public readonly struct TaskItem<T> : ITaskItem<T>, IEquatable<TaskItem<T>>
+    public readonly struct TaskItem<T> : ITaskItem<T>, ITaskItem3, IEquatable<TaskItem<T>>
     {
         private readonly ITaskItem? _backingItem;
 
@@ -26,6 +26,9 @@ namespace Microsoft.Build.Framework
         /// Gets the strongly-typed value parsed from the item's identity.
         /// </summary>
         public T Value { get; }
+
+        /// <inheritdoc/>
+        public TaskItemLocation? Location => (_backingItem as ITaskItem3)?.Location;
 
         /// <summary>
         /// Initializes a new instance of <see cref="TaskItem{T}"/> from a strongly-typed value.

--- a/src/Utilities/TaskItem.cs
+++ b/src/Utilities/TaskItem.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Build.Utilities
 #if FEATURE_APPDOMAIN
         MarshalByRefObject,
 #endif
-        ITaskItem2,
+        ITaskItem3,
         IMetadataContainer // expose direct underlying metadata for fast access in binary logger
     {
         #region Member Data
@@ -60,6 +60,10 @@ namespace Microsoft.Build.Utilities
         /// we simply don't know enough to set it properly, so it will stay null.
         /// </summary>
         private readonly string _definingProject;
+
+        private readonly int _sourceLineNumber;
+
+        private readonly int _sourceColumnNumber;
 
         #endregion
 
@@ -162,6 +166,12 @@ namespace Microsoft.Build.Utilities
                 _definingProject = sourceItemAsITaskItem2.GetMetadataValueEscaped(ItemSpecModifiers.DefiningProjectFullPath);
             }
 
+            if (sourceItem is ITaskItem3 taskItemWithLocation && taskItemWithLocation.Location is TaskItemLocation location)
+            {
+                _sourceLineNumber = location.Line;
+                _sourceColumnNumber = location.Column;
+            }
+
             sourceItem.CopyMetadataTo(this);
         }
 
@@ -243,6 +253,11 @@ namespace Microsoft.Build.Utilities
                 _cachedModifiers.Clear();
             }
         }
+
+        /// <inheritdoc/>
+        public TaskItemLocation? Location => _sourceLineNumber == 0
+            ? null
+            : new TaskItemLocation(EscapingUtilities.UnescapeAll(_definingProject), _sourceLineNumber, _sourceColumnNumber);
 
         /// <summary>
         /// Gets or sets the escaped include, or "name", for the item.


### PR DESCRIPTION
Related to https://dev.azure.com/devdiv/DevDiv/_workitems/edit/2905535

### Context

Tasks currently receive evaluated items without the exact source XML location, preventing diagnostics such as NU1510 from navigating to the declaring `PackageReference`. Reconstructing the location later from the item type and evaluated include is ambiguous, so this records the location when the item is created.

### Changes Made

- Added `ITaskItem3.Location` and the immutable `TaskItemLocation` value type.
- Added source line and column storage to `ProjectItemInstance.TaskItem`, reusing the existing defining-project path for the file.
- Preserved item locations through evaluation snapshots, target item creation, task outputs, cloning, and node serialization.
- Preserved locations when copying items into `Microsoft.Build.Utilities.TaskItem` and `TaskItem<T>`.

### Testing

- Built the repository in Debug and Release configurations with 0 warnings and 0 errors.
- Added and ran focused tests:
  - `ProjectItemInstance_Tests.LocationTracksOriginatingItemElement` — verifies evaluated items and copied utility items retain the originating XML element location.
  - `TaskItem_Tests.Serialization` — verifies line and column survive node serialization.
  - Result: passed on `net11.0` and `net472`.
- Measured `ProjectInstance` creation with 1,000, 10,000, and 100,000 items:
  - Allocation delta: approximately 8 bytes per item.
- Measured OrchardCore at commit `e872f0f0c8e977a927f883d662d9768c86f050c3`:
  - 474 projects and 225,872 evaluated items.
  - 30 randomized fresh-process runs per variant.
  - Retained managed-memory delta: 1.66 MB, or 7.34 bytes per item.
  - Elapsed-time delta 95% confidence interval: -155 ms to +12 ms.

### Notes

- This PR exposes source locations; NuGet and potentially Project System still need to consume them for the reported warning.
- Legacy out-of-proc task parameter serialization is unchanged, so location may be unavailable after crossing that boundary.
- `Location` identifies the immediate XML element that produced the item; it is not a full provenance chain.
