### PR TITLE
Remove obsolete Publish-Build-Assets variable group import

### DIFF
--- a/azure-pipelines/.vsts-dotnet-build-jobs.yml
+++ b/azure-pipelines/.vsts-dotnet-build-jobs.yml
@@ -72,7 +72,6 @@ jobs:
       ArtifactName: AssetManifests
 
   variables:
-  - group: Publish-Build-Assets
   - name: TeamName
     value: MSBuild
   - name: VisualStudio.MajorVersion


### PR DESCRIPTION
## Summary
- remove the obsolete `Publish-Build-Assets` variable-group import from the MSBuild build-job template
- retain OneLoc credentials through the existing `OneLocBuildVariables` import

The repository does not directly consume the remaining variables from `Publish-Build-Assets`.

## Validation
- confirmed no `group: Publish-Build-Assets` imports remain
- confirmed no direct references remain to the obsolete publishing, Maestro, or aka.ms variables

Related: https://dev.azure.com/dnceng/internal/_workitems/edit/12131