### PR TITLE
Disable nullable analysis for net4x leg of multi-targeted projects

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -437,9 +437,6 @@ dotnet_diagnostic.IDE0330.severity = suggestion
 # Use implicitly typed lambda
 dotnet_diagnostic.IDE0350.severity = none
 
-#Nullable suppression is unnecessary (not when multi-targeting to net472): https://github.com/dotnet/msbuild/issues/12726
-dotnet_diagnostic.IDE0370.severity = none
-
 # Value types are incompatible with null values. https://xunit.net/xunit.analyzers/rules/xUnit1012
 dotnet_diagnostic.xUnit1012.severity = warning
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -78,6 +78,14 @@
     <RuntimeOutputPlatformTarget>AnyCPU</RuntimeOutputPlatformTarget>
   </PropertyGroup>
 
+  <!-- Many BCL APIs aren't nullable-annotated on .NET Framework, forcing null-forgiving ('!') suppressions
+       that are unneeded (and flagged by IDE0370) on the other TFMs of multi-targeted projects.
+       Disable nullable analysis for the net4x leg of such projects so those suppressions become unnecessary
+       everywhere. https://github.com/dotnet/msbuild/issues/12726 -->
+  <PropertyGroup Condition="'$(TargetFramework)' != '' and $(TargetFramework.StartsWith('net4')) and $(TargetFrameworks.Contains(';'))">
+    <Nullable>disable</Nullable>
+  </PropertyGroup>
+
   <PropertyGroup>
     <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificContentInPackage);ShipRefAssembliesToNuGetPackage</TargetsForTfmSpecificBuildOutput>
   </PropertyGroup>


### PR DESCRIPTION
## Summary

Many BCL APIs are nullable-annotated on modern .NET/netstandard but not on .NET Framework. This forces the codebase to use the null-forgiving (`!`) operator to silence nullable warnings that only fire on the net472 leg of multi-targeted projects. Those same `!` suppressions are then flagged as unnecessary (IDE0370) when the same source compiles for the other TFMs, where the APIs are annotated — a false positive that can't be fixed without breaking the net472 leg.

As a stopgap, `.editorconfig` currently disables IDE0370 repo-wide via:
```
dotnet_diagnostic.IDE0370.severity = none
```

This PR implements the fix proposed in the issue: disable nullable reference type analysis for the net4x compile pass of multi-targeted projects (`src/Directory.Build.props`), so the missing BCL annotations there no longer produce spurious warnings and the `!` suppressions become genuinely unnecessary everywhere. With the root cause fixed, the IDE0370 override in `.editorconfig` is removed so the rule reverts to its normal severity.

Existing `!` suppressions in the codebase are left as-is; IDE0370 is only a `suggestion` severity, so they won't fail the build and can be cleaned up incrementally.

- `src/Directory.Build.props`: set `<Nullable>disable</Nullable>` when the current `TargetFramework` starts with `net4` and the project multi-targets (`TargetFrameworks` contains `;`).
- `.editorconfig`: remove the now-obsolete `IDE0370.severity = none` override and its comment.

Fixes #12726

## Test plan

- [x] `.\build.cmd -msbuildEngine dotnet /p:CreateTlb=false /p:CreateBootstrap=false` — full solution build succeeds with 0 warnings/0 errors across net472, net11.0, and netstandard2.0 legs (`CreateTlb`/`CreateBootstrap` skipped only because this local machine lacks the .NET Framework SDK tools and Visual Studio; both are unrelated to this change).