### PR TITLE
Enable SAC group config for MSBuild.exe.config in VS

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -25,7 +25,8 @@
     <UsingToolVSSDK>true</UsingToolVSSDK>
     <UsingToolNuGetRepack>true</UsingToolNuGetRepack>
 
-    <MicroBuildPluginsSwixBuildVersion>1.1.87</MicroBuildPluginsSwixBuildVersion>
+    <!-- Tools.csproj's SwixBuild PackageReference reads this exact property name; MicroBuildPluginsSwixBuildVersion (no Microsoft/VisualStudioEng prefix) is a different, unused property. -->
+    <MicrosoftVisualStudioEngMicroBuildPluginsSwixBuildVersion>1.1.973</MicrosoftVisualStudioEngMicroBuildPluginsSwixBuildVersion>
   </PropertyGroup>
 
   <!-- Production Dependencies -->

--- a/src/Package/MSBuild.VSSetup.Arm64/files.arm64.swr
+++ b/src/Package/MSBuild.VSSetup.Arm64/files.arm64.swr
@@ -11,7 +11,7 @@ vs.relatedProcessFiles
 
 folder InstallDir:\MSBuild\Current\Bin\arm64
   file source=$(Arm64BinPath)MSBuild.exe vs.file.ngenArchitecture=arm64
-  file source=$(Arm64BinPath)MSBuild.exe.config
+  file MSBuild.exe.config.template source=$(Arm64BinPath)MSBuild.exe.config vs.file.useGroupConfig="devenv" vs.file.overwriteBindingRedirects=yes
   file source=$(CoordinatorArm64BinPath)MSBuild.Coordinator.exe vs.file.ngenArchitecture=arm64
   file source=$(CoordinatorArm64BinPath)MSBuild.Coordinator.exe.config
 

--- a/src/Package/MSBuild.VSSetup/files.swr
+++ b/src/Package/MSBuild.VSSetup/files.swr
@@ -32,7 +32,7 @@ folder InstallDir:\MSBuild\Current\Bin
   file source=$(X86BinPath)Microsoft.Build.Utilities.Core.dll vs.file.ngenApplications="[installDir]\Common7\IDE\vsn.exe" vs.file.ngenApplications="[installDir]\MSBuild\Current\Bin\MSBuild.exe" vs.file.ngenArchitecture=all vs.file.ngenPriority=2
   file source=$(X86BinPath)Microsoft.IO.Redist.dll vs.file.ngenApplications="[installDir]\Common7\IDE\vsn.exe" vs.file.ngenApplications="[installDir]\MSBuild\Current\Bin\MSBuild.exe" vs.file.ngenArchitecture=all vs.file.ngenPriority=2
   file source=$(X86BinPath)MSBuild.exe vs.file.ngenArchitecture=x86 vs.file.ngenPriority=2
-  file source=$(X86BinPath)MSBuild.exe.config
+  file MSBuild.exe.config.template source=$(X86BinPath)MSBuild.exe.config vs.file.useGroupConfig="devenv" vs.file.overwriteBindingRedirects=yes
   file source=$(CoordinatorBinPath)MSBuild.Coordinator.exe
   file source=$(CoordinatorBinPath)MSBuild.Coordinator.exe.config
   file source=$(TaskHostBinPath)MSBuildTaskHost.exe
@@ -197,7 +197,7 @@ folder InstallDir:\MSBuild\Current\Bin\zh-Hant
 
 folder InstallDir:\MSBuild\Current\Bin\amd64
   file source=$(X64BinPath)MSBuild.exe vs.file.ngenArchitecture=x64
-  file source=$(X64BinPath)MSBuild.exe.config
+  file MSBuild.exe.config.template source=$(X64BinPath)MSBuild.exe.config vs.file.useGroupConfig="devenv" vs.file.overwriteBindingRedirects=yes
   file source=$(CoordinatorX64BinPath)MSBuild.Coordinator.exe vs.file.ngenArchitecture=x64 vs.file.ngenPriority=3
   file source=$(CoordinatorX64BinPath)MSBuild.Coordinator.exe.config
   file source=$(TaskHostX64BinPath)MSBuildTaskHost.exe


### PR DESCRIPTION
- files.swr / files.arm64.swr: install MSBuild.exe.config as MSBuild.exe.config.template with vs.file.useGroupConfig="devenv" and vs.file.overwriteBindingRedirects=yes, so it joins the devenv SAC group and its binding redirects get merged in.
- eng/Versions.props: bump MicrosoftVisualStudioEngMicroBuildPluginsSwixBuildVersion to 1.1.973 (the property Tools.csproj actually consumes) since the SAC group-config properties require this newer SwixBuild toolset. Note: 1.1.973 is not resolvable from any currently configured feed; it must already be present in the local/CI NuGet cache to restore successfully.

Fixes #

### Context


### Changes Made


### Testing


### Notes
