### PR TITLE
[vs17.11] Remove obsolete Publish-Build-Assets variable group import

### DIFF
--- a/azure-pipelines/.vsts-dotnet-build-jobs.yml
+++ b/azure-pipelines/.vsts-dotnet-build-jobs.yml
@@ -23,7 +23,6 @@ jobs:
   timeoutInMinutes: 180
 
   variables:
-  - group: Publish-Build-Assets
   - name: TeamName
     value: MSBuild
   - name: VisualStudio.MajorVersion

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,7 +2,7 @@
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the MIT license. See License.txt in the project root for full license information. -->
 <Project>
   <PropertyGroup>
-    <VersionPrefix>17.11.63</VersionPrefix>
+    <VersionPrefix>17.11.64</VersionPrefix>
     <DotNetFinalVersionKind>release</DotNetFinalVersionKind>
     <PackageValidationBaselineVersion>17.10.4</PackageValidationBaselineVersion>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>


### PR DESCRIPTION
Ports #14736 to the `vs17.11` servicing branch.

## Summary
- remove the obsolete `Publish-Build-Assets` variable-group import from the MSBuild build-job template
- bump `VersionPrefix` from `17.11.63` to `17.11.64`, required for a servicing change

Submitted directly against `vs17.11` rather than relying on inter-branch merge flow: the flow is serial and took ~1.5 days to propagate the comparable `AzureDevOps-Artifact-Feeds-Pats` removal (#14718 / #14719). A PR is open against every servicing branch in parallel.

## Scan of this branch
- `group: Publish-Build-Assets` occurred exactly once, in `azure-pipelines/.vsts-dotnet-build-jobs.yml`. Zero references remain after this change, repo-wide.
- `eng/common` on this branch is already on an Arcade version that no longer imports the group, so no Arcade-managed file needs touching.
- No references anywhere to the variables the group supplied (`MaestroAccessToken`, `BotAccount-dotnet-maestro-bot-PAT`, `akams-*`).
- `$(dn-bot-dnceng-artifact-feeds-rw)` is unaffected. It is not provided by this group: `.vsts-dotnet-ci.yml` on this branch and on `main` consumes it without importing any variable group, since dotnet/arcade#17245 (see #14710 / #14719).
- OneLoc credentials are unaffected; they come from `OneLocBuildVariables`, imported by Arcade's `onelocbuild.yml` template.

Related: https://dev.azure.com/dnceng/internal/_workitems/edit/12131