### PR TITLE
[vs18.9] Remove obsolete Publish-Build-Assets variable group import

### DIFF
--- a/azure-pipelines/.vsts-dotnet-build-jobs.yml
+++ b/azure-pipelines/.vsts-dotnet-build-jobs.yml
@@ -72,7 +72,6 @@ jobs:
       ArtifactName: AssetManifests
 
   variables:
-  - group: Publish-Build-Assets
   - name: TeamName
     value: MSBuild
   - name: VisualStudio.MajorVersion

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -3,7 +3,7 @@
   <Import Project="Version.Details.props" />
 
   <PropertyGroup>
-    <VersionPrefix>18.9.10</VersionPrefix><DotNetFinalVersionKind>release</DotNetFinalVersionKind><!-- Keep next to VersionPrefix to create a conflict in forward-flow -->
+    <VersionPrefix>18.9.11</VersionPrefix><DotNetFinalVersionKind>release</DotNetFinalVersionKind><!-- Keep next to VersionPrefix to create a conflict in forward-flow -->
     <PreReleaseVersionLabel>servicing</PreReleaseVersionLabel>
     <PackageValidationBaselineVersion>18.8.0-preview-26276-02</PackageValidationBaselineVersion>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>


### PR DESCRIPTION
Ports #14736 to the `vs18.9` servicing branch.

## Summary
- remove the obsolete `Publish-Build-Assets` variable-group import from the MSBuild build-job template
- bump `VersionPrefix` from `18.9.10` to `18.9.11`, required for a servicing change

Submitted directly against `vs18.9` rather than relying on inter-branch merge flow: the flow is serial and took ~1.5 days to propagate the comparable `AzureDevOps-Artifact-Feeds-Pats` removal (#14718 / #14719). A PR is open against every servicing branch in parallel.

## Scan of this branch
- `group: Publish-Build-Assets` occurred exactly once, in `azure-pipelines/.vsts-dotnet-build-jobs.yml`. Zero references remain after this change, repo-wide.
- `eng/common` on this branch is already on an Arcade version that no longer imports the group, so no Arcade-managed file needs touching.
- No references anywhere to the variables the group supplied (`MaestroAccessToken`, `BotAccount-dotnet-maestro-bot-PAT`, `akams-*`).
- `$(dn-bot-dnceng-artifact-feeds-rw)` is unaffected. It is not provided by this group: `.vsts-dotnet-ci.yml` on this branch and on `main` consumes it without importing any variable group, since dotnet/arcade#17245 (see #14710 / #14719).
- OneLoc credentials are unaffected; they come from `OneLocBuildVariables`, imported by Arcade's `onelocbuild.yml` template.

Related: https://dev.azure.com/dnceng/internal/_workitems/edit/12131