### PR TITLE
Expand item definition metadata when cloning items for out-of-proc task hosts

### DIFF
--- a/src/Build.UnitTests/BackEnd/MetadataEchoTask.cs
+++ b/src/Build.UnitTests/BackEnd/MetadataEchoTask.cs
@@ -1,0 +1,37 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+#nullable disable
+
+namespace Microsoft.Build.UnitTests
+{
+    /// <summary>
+    /// Returns the value of a metadata name as seen by the task itself, so tests can observe what a task
+    /// actually receives rather than what the engine would expand on its behalf.
+    /// </summary>
+    public class MetadataEchoTask : Task
+    {
+        [Required]
+        public ITaskItem[] Items { get; set; }
+
+        [Required]
+        public string MetadataName { get; set; }
+
+        [Output]
+        public string MetadataValue { get; set; }
+
+        [Output]
+        public int Pid { get; set; }
+
+        public override bool Execute()
+        {
+            MetadataValue = Items.Length > 0 ? Items[0].GetMetadata(MetadataName) : string.Empty;
+            Pid = Process.GetCurrentProcess().Id;
+            return true;
+        }
+    }
+}

--- a/src/Build.UnitTests/BackEnd/TaskHostFactory_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/TaskHostFactory_Tests.cs
@@ -37,6 +37,51 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
         }
 
         /// <summary>
+        /// An item definition metadata value that references built-in metadata (e.g. %(Filename)) is expanded
+        /// lazily on read. Verifies the expansion survives the trip to an out-of-proc task host, so a task sees
+        /// the same value it would see in-proc rather than the literal "%(Filename)".
+        /// </summary>
+        [Fact]
+        public void ItemDefinitionMetadataIsExpandedForTaskRunningInTaskHost()
+        {
+            using TestEnvironment env = TestEnvironment.Create();
+
+            string projectContents = $@"
+<Project>
+    <UsingTask TaskName=""MetadataEchoTask"" AssemblyFile=""{AssemblyLocation}"" TaskFactory=""TaskHostFactory"" />
+    <ItemDefinitionGroup>
+        <Thing>
+            <OutputName>%(Filename)</OutputName>
+        </Thing>
+    </ItemDefinitionGroup>
+    <ItemGroup>
+        <Thing Include=""hello.txt"" />
+    </ItemGroup>
+    <Target Name='Echo'>
+        <MetadataEchoTask Items=""@(Thing)"" MetadataName=""OutputName"">
+            <Output PropertyName=""Echoed"" TaskParameter=""MetadataValue"" />
+            <Output PropertyName=""TaskPid"" TaskParameter=""Pid"" />
+        </MetadataEchoTask>
+    </Target>
+</Project>";
+
+            TransientTestFile project = env.CreateFile("testProject.csproj", projectContents);
+            ProjectInstance projectInstance = new(project.Path);
+
+            BuildResult buildResult = BuildManager.DefaultBuildManager.Build(
+                new BuildParameters(),
+                new BuildRequestData(projectInstance, targetsToBuild: ["Echo"]));
+
+            buildResult.OverallResult.ShouldBe(BuildResultCode.Success);
+
+            // Guard the guard: if the task did not actually run out-of-proc this test would pass vacuously.
+            int taskPid = int.Parse(projectInstance.GetPropertyValue("TaskPid"), CultureInfo.InvariantCulture);
+            taskPid.ShouldNotBe(Process.GetCurrentProcess().Id, "Task must run in a task host for this test to be meaningful.");
+
+            projectInstance.GetPropertyValue("Echoed").ShouldBe("hello");
+        }
+
+        /// <summary>
         /// Verifies that task host nodes properly terminate after a build completes.
         /// Tests both transient (TaskHostFactory) and sidecar (AssemblyTaskFactory) task hosts
         /// with different configuration combinations.

--- a/src/Build.UnitTests/Instance/TaskItem_Tests.cs
+++ b/src/Build.UnitTests/Instance/TaskItem_Tests.cs
@@ -235,6 +235,74 @@ namespace Microsoft.Build.UnitTests.OM.Instance
         }
 
         /// <summary>
+        /// Item definition metadata referencing built-in metadata (e.g. %(Filename)) is expanded lazily when read.
+        /// The CloneCustomMetadata* methods are used when handing items to out-of-proc task hosts, so they must
+        /// return the expanded values rather than the raw item definition text.
+        /// </summary>
+        [Fact]
+        public void CloneCustomMetadataExpandsItemDefinitionMetadata()
+        {
+            string content = ObjectModelHelpers.CleanupFileContents(@"
+                <Project ToolsVersion='msbuilddefaulttoolsversion' xmlns='msbuildnamespace'>
+                  <ItemDefinitionGroup>
+                    <i>
+                      <OutputName>%(Filename)</OutputName>
+                      <Literal>unchanged</Literal>
+                    </i>
+                  </ItemDefinitionGroup>
+                  <ItemGroup>
+                    <i Include='hello.txt' />
+                  </ItemGroup>
+                </Project>");
+
+            using ProjectRootElementFromString projectRootElementFromString = new(content);
+            ProjectInstance instance = new Project(projectRootElementFromString.Project).CreateProjectInstance();
+            ProjectItemInstance item = instance.GetItems("i").Single();
+
+            // Reading a single value expands the expression.
+            ((ITaskItem)item).GetMetadata("OutputName").ShouldBe("hello");
+
+            var cloned = (Dictionary<string, string>)((ITaskItem)item).CloneCustomMetadata();
+            cloned["OutputName"].ShouldBe("hello");
+            cloned["Literal"].ShouldBe("unchanged");
+
+            var clonedEscaped = (Dictionary<string, string>)((ITaskItem2)item).CloneCustomMetadataEscaped();
+            clonedEscaped["OutputName"].ShouldBe("hello");
+            clonedEscaped["Literal"].ShouldBe("unchanged");
+        }
+
+        /// <summary>
+        /// Direct metadata takes precedence over item definition metadata, including when the item definition
+        /// value contains a lazily expanded expression.
+        /// </summary>
+        [Fact]
+        public void CloneCustomMetadataPrefersDirectMetadataOverItemDefinitionExpression()
+        {
+            string content = ObjectModelHelpers.CleanupFileContents(@"
+                <Project ToolsVersion='msbuilddefaulttoolsversion' xmlns='msbuildnamespace'>
+                  <ItemDefinitionGroup>
+                    <i>
+                      <OutputName>%(Filename)</OutputName>
+                      <OutputExtension>%(Extension)</OutputExtension>
+                    </i>
+                  </ItemDefinitionGroup>
+                  <ItemGroup>
+                    <i Include='hello.txt'>
+                      <OutputName>explicit</OutputName>
+                    </i>
+                  </ItemGroup>
+                </Project>");
+
+            using ProjectRootElementFromString projectRootElementFromString = new(content);
+            ProjectInstance instance = new Project(projectRootElementFromString.Project).CreateProjectInstance();
+            ProjectItemInstance item = instance.GetItems("i").Single();
+
+            var cloned = (Dictionary<string, string>)((ITaskItem)item).CloneCustomMetadata();
+            cloned["OutputName"].ShouldBe("explicit");
+            cloned["OutputExtension"].ShouldBe(".txt");
+        }
+
+        /// <summary>
         /// Flushing an item through a task should not mess up special characters on the metadata.
         /// </summary>
         [Fact]

--- a/src/Build/Instance/ProjectItemInstance.cs
+++ b/src/Build/Instance/ProjectItemInstance.cs
@@ -1630,11 +1630,17 @@ namespace Microsoft.Build.Execution
             public IDictionary CloneCustomMetadata()
             {
                 var metadata = MetadataCollection;
+
+                // Item definition metadata may contain expressions such as %(Filename) which are expanded lazily
+                // on read. Cloning the backing values directly would hand out the unexpanded text, so fully
+                // evaluate each entry when any item definition could contain such an expression.
+                bool expandItemDefinitionMetadata = HasAnyExpandableExpressions();
                 Dictionary<string, string> clonedMetadata = new Dictionary<string, string>(metadata.Count, MSBuildNameIgnoreCaseComparer.Default);
 
                 foreach (KeyValuePair<string, string> metadatum in metadata)
                 {
-                    clonedMetadata[metadatum.Key] = EscapingUtilities.UnescapeAll(metadatum.Value);
+                    string escapedValue = expandItemDefinitionMetadata ? GetMetadataEscaped(metadatum.Key) : metadatum.Value;
+                    clonedMetadata[metadatum.Key] = EscapingUtilities.UnescapeAll(escapedValue);
                 }
 
                 return clonedMetadata;
@@ -1647,11 +1653,14 @@ namespace Microsoft.Build.Execution
             /// <returns>The cloned metadata.</returns>
             IDictionary ITaskItem2.CloneCustomMetadataEscaped()
             {
+                // See the comment in CloneCustomMetadata: item definition metadata is expanded lazily on read,
+                // so it has to be fully evaluated here rather than copied straight out of the backing store.
+                bool expandItemDefinitionMetadata = HasAnyExpandableExpressions();
                 Dictionary<string, string> clonedMetadata = new Dictionary<string, string>(MSBuildNameIgnoreCaseComparer.Default);
 
                 foreach (KeyValuePair<string, string> metadatum in MetadataCollection)
                 {
-                    clonedMetadata[metadatum.Key] = metadatum.Value;
+                    clonedMetadata[metadatum.Key] = expandItemDefinitionMetadata ? GetMetadataEscaped(metadatum.Key) : metadatum.Value;
                 }
 
                 return clonedMetadata;

--- a/src/Build/Instance/ProjectItemInstance.cs
+++ b/src/Build/Instance/ProjectItemInstance.cs
@@ -1639,7 +1639,9 @@ namespace Microsoft.Build.Execution
 
                 foreach (KeyValuePair<string, string> metadatum in metadata)
                 {
-                    string escapedValue = expandItemDefinitionMetadata ? GetMetadataEscaped(metadatum.Key) : metadatum.Value;
+                    string escapedValue = expandItemDefinitionMetadata && Expander<ProjectProperty, ProjectItem>.ExpressionMayContainExpandableExpressions(metadatum.Value)
+                        ? GetMetadataEscaped(metadatum.Key)
+                        : metadatum.Value;
                     clonedMetadata[metadatum.Key] = EscapingUtilities.UnescapeAll(escapedValue);
                 }
 
@@ -1660,7 +1662,9 @@ namespace Microsoft.Build.Execution
 
                 foreach (KeyValuePair<string, string> metadatum in MetadataCollection)
                 {
-                    clonedMetadata[metadatum.Key] = expandItemDefinitionMetadata ? GetMetadataEscaped(metadatum.Key) : metadatum.Value;
+                    clonedMetadata[metadatum.Key] = expandItemDefinitionMetadata && Expander<ProjectProperty, ProjectItem>.ExpressionMayContainExpandableExpressions(metadatum.Value)
+                        ? GetMetadataEscaped(metadatum.Key)
+                        : metadatum.Value;
                 }
 
                 return clonedMetadata;


### PR DESCRIPTION
Fixes #14763

### Context

Metadata declared in an `<ItemDefinitionGroup>` whose value references built-in metadata — e.g. `<OutputName>%(Filename)</OutputName>` — is stored unexpanded and expanded lazily on read, by `ProjectItemInstance.TaskItem.GetMetadataEscaped()`.

`CloneCustomMetadata()` and `CloneCustomMetadataEscaped()` enumerated `MetadataCollection` directly, which yields the raw item definition text. Those are the methods `TaskParameter` uses when marshalling items to an out-of-proc task host (`src/Shared/TaskParameter.cs:588`), so a task running in a task host received the literal string `%(Filename)`.

The literal value was then stored as *direct* metadata on the deserialized item, so the late expansion could never happen again downstream. It failed silently — the task got a syntactically valid but wrong value, typically ending up embedded in a generated file path.

Only item-definition metadata was affected; metadata set directly on the item was fine, which made it look inconsistent — within one item, one value would expand and another would not.

### Changes Made

Applied the same treatment `CopyMetadataTo` → `BulkImportMetadata` already uses: when any item definition may contain an expandable expression, read each value through `GetMetadataEscaped()` so it is fully evaluated.

`HasAnyExpandableExpressions()` short-circuits to `false` when there are no item definitions, so the common path is unaffected, and both methods already materialize a `Dictionary`, so there is no allocation-profile change.

### Testing

Two regression tests in `TaskItem_Tests`, driven through real evaluation so the item definition value is genuinely stored unexpanded:

- `CloneCustomMetadataExpandsItemDefinitionMetadata` — both clone methods return the expanded value.
- `CloneCustomMetadataPrefersDirectMetadataOverItemDefinitionExpression` — direct metadata still wins over an item definition expression.

Both were confirmed to **fail without the product change and pass with it**.

Verified end-to-end with a bootstrap build against the repro from #14763, for both triggers:

| | before | after |
| --- | --- | --- |
| in-proc | `hello` | `hello` |
| `-mt` (sidecar task host) | `%(Filename)` | `hello` |
| `TaskHostFactory`, no `-mt` | `%(Filename)` | `hello` |

Suites run clean: `*TaskItem_Tests*` (15/15) and `*TaskHost*` (130 total, 0 failed, 15 skipped). Full build with 0 warnings.

### Notes

`EnumerateMetadata()` reads `MetadataCollection` raw in the same way, so binary logs show the unexpanded `%(...)` text even for correct builds. I deliberately left it out of scope here: it feeds `BuildEventArgsWriter`, `BaseConsoleLogger`, `TaskParameterEventArgs`, `LogMessagePacket` and BuildCheck, so changing it is a user-visible logging change, and it is intentionally a lazy allocation-free iterator for binlog streaming that per-key re-reads would regress. Worth a separate discussion.

This is not a recent regression — it reproduces on 18.7, 18.9 and 18.11 alike. It has become much easier to hit with `-mt`, which routes essentially every task not marked `[MSBuildMultiThreadableTask]` to a task host, so builds that previously ran such tasks in-proc now silently get literal `%(...)` values.
