### PR TITLE
Remove stale BundledVersion.props update

### DIFF
--- a/src/MSBuild.Bootstrap/MSBuild.Bootstrap.csproj
+++ b/src/MSBuild.Bootstrap/MSBuild.Bootstrap.csproj
@@ -23,10 +23,6 @@
     <ProjectReference Include="..\Utilities\Microsoft.Build.Utilities.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <!-- This file is needed so the dotnet CLI knows how to map preview SDK versions to tfms (because tfms do not have preview information on them) -->
-    <!-- This is because according to semver, 2.1.0-preview is not >= 2.1.0 -->
-    <Content Include="$(DotNetRoot)sdk\$(DotNetCliVersion)\Microsoft.NETCoreSdk.BundledVersions.props" CopyToOutputDirectory="PreserveNewest" />
-
     <!-- Include NuGet build tasks -->
     <PackageReference Include="NuGet.Build.Tasks" />
     <PackageReference Include="NuGet.Build.Tasks.Console" />


### PR DESCRIPTION
This is not necessary, as the freshly installed bootstrap base will be as up-to-date as we need, so don't overwrite it.

It was being copied from the `.dotnet` sdk to a local directory, then overwriting the bootstrap:

```
6861043:                     Copying file from "S:\msbuild\.dotnet\sdk\11.0.100-preview.7.26360.111\Microsoft.NETCoreSdk.BundledVersions.props" to "S:\msbuild\artifacts\bin\MSBuild.Bootstrap\Debug\net11.0\Microsoft.NETCoreSdk.BundledVersions.props". (TaskId:6844)
6923267:                     Copying file from "S:\msbuild\artifacts\bin\MSBuild.Bootstrap\Debug\net11.0\Microsoft.NETCoreSdk.BundledVersions.props" to "S:\msbuild\artifacts\bin\bootstrap\core\sdk\11.0.100-preview.7.26360.111\Microsoft.NETCoreSdk.BundledVersions.props". (TaskId:6872)
```

And it was being copied in our net472 output, where it shouldn't ever have been used (that should find an SDK and use its copy).