### PR TITLE
Fix argument forwarding and stage logging in eng/build.ps1

### DIFF
--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -27,6 +27,10 @@ Param(
 $pwshPath = (Get-Process -Id $PID).Path
 $buildScript = Join-Path $PSScriptRoot 'common\build.ps1'
 
+# The build script path is single-quoted for the `pwsh -Command` re-parse below, so any single quote
+# in the repo path has to be doubled to stay inside the quoted string.
+$quotedBuildScript = "'" + ($buildScript -replace "'", "''") + "'"
+
 # The stage builds run out-of-proc so that stage 2 doesn't inherit stage 1's state variables, but
 # they are invoked through `pwsh -Command` rather than `pwsh -File`. `-File` passes every argument
 # as a literal string, which typed parameters such as `[bool] $nodeReuse` and `[bool] $msbuildMultiThreaded`
@@ -43,16 +47,17 @@ function Get-QuotedArguments([string[]] $arguments) {
 function Get-BuildCommand([string[]] $arguments) {
   # Default to a failure exit code so that an error which prevents the script from running at all
   # (e.g. a parameter binding failure) isn't reported as success by the trailing `exit`.
-  "`$global:LASTEXITCODE = 1`n& '$($buildScript -replace "'", "''")' $(Get-QuotedArguments $arguments)`nexit `$LASTEXITCODE"
+  "`$global:LASTEXITCODE = 1`n& $quotedBuildScript $(Get-QuotedArguments $arguments)`nexit `$LASTEXITCODE"
 }
 
 # The command as it's displayed to the user: just the invocation, without the exit code plumbing
 # that Get-BuildCommand wraps around it.
 function Get-BuildCommandForDisplay([string[]] $arguments) {
-  "& '$buildScript' $(Get-QuotedArguments $arguments)"
+  "& $quotedBuildScript $(Get-QuotedArguments $arguments)"
 }
 
-# Forward every explicitly supplied parameter to the Arcade build. Only bound parameters are forwarded,
+# Forward every explicitly supplied parameter to the Arcade build. Apart from -configuration, which is
+# always passed on because this script uses it for its own paths, only bound parameters are forwarded,
 # so parameters the caller didn't pass keep their Arcade defaults instead of being pinned to this
 # script's. Parameters listed here are handled by this script and must not be forwarded verbatim.
 $locallyHandledParameters = @('configuration', 'test', 'stage2', 'stage2Argument', 'binaryLogName', 'properties')
@@ -117,9 +122,7 @@ if ($test -and -not $stage2) {
 
 # Log the stage 1 build command so that it's clear which arguments flow to it.
 $stage1Command = Get-BuildCommand $buildArgs
-# if ($stage2) {
-  Write-Host "Stage 1 build: $(Get-BuildCommandForDisplay $buildArgs)"
-# }
+Write-Host "Stage 1 build: $(Get-BuildCommandForDisplay $buildArgs)"
 
 & $pwshPath -NoLogo -NoProfile -ExecutionPolicy ByPass -Command $stage1Command
 

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -1,11 +1,23 @@
+# Only parameters that this script has to see itself are declared here; everything else flows through
+# $properties untouched and is forwarded verbatim, so Arcade parameters keep working without being
+# mirrored. Two of them are declared purely to stop PowerShell from claiming the argument first:
+# without '-verbosity', '-v minimal' binds to the common '-Verbose' switch and 'minimal' arrives as a
+# bare property, and without '-build', Arcade's '-b' prefix-matches '-binaryLog' and silently turns a
+# build request into a binary log request.
+# Keep this list to [string] and [switch] parameters. A [bool] parameter (Arcade has several, such as
+# -nodeReuse and -msbuildMultiThreaded) would need special handling, because it forwards as 'True'
+# or 'False', which re-parses as a string rather than as a boolean; leaving those undeclared lets
+# Arcade bind them from $properties directly, as '-nodeReuse 0' or '-nodeReuse $false'.
 [CmdletBinding(PositionalBinding=$false)]
 Param(
-  [string] $msbuildEngine,
   [string][Alias('c')] $configuration = "Debug",
   [string][Alias('v')] $verbosity,
+  [string] $msbuildEngine,
+  [switch][Alias('b')] $build,
   [switch][Alias('t')] $test,
   [switch] $ci,
   [switch][Alias('bl')] $binaryLog,
+  [string][Alias('bln')] $binaryLogName,
   [switch][Alias('nobl')] $excludeCIBinarylog,
   [switch] $stage2,
   [string[]] $stage2Argument = @(),
@@ -21,38 +33,63 @@ $buildScript = Join-Path $PSScriptRoot 'common\build.ps1'
 # can't bind to. `-Command` re-parses the arguments as PowerShell, so `-mt 1` arrives as an integer.
 # Quote anything that isn't a simple token so it survives that re-parse intact
 # (e.g. '-warnnotaserror NU1901;NU1902;NU1903', where ';' would otherwise separate statements).
-function Get-BuildCommand([string[]] $arguments) {
+function Get-QuotedArguments([string[]] $arguments) {
   $quoted = $arguments | ForEach-Object {
     if ($_ -match '^[\w\-/\\.:=+]+$') { $_ } else { "'" + ($_ -replace "'", "''") + "'" }
   }
+  $quoted -join ' '
+}
+
+function Get-BuildCommand([string[]] $arguments) {
   # Default to a failure exit code so that an error which prevents the script from running at all
   # (e.g. a parameter binding failure) isn't reported as success by the trailing `exit`.
-  "`$global:LASTEXITCODE = 1`n& '$($buildScript -replace "'", "''")' $($quoted -join ' ')`nexit `$LASTEXITCODE"
+  "`$global:LASTEXITCODE = 1`n& '$($buildScript -replace "'", "''")' $(Get-QuotedArguments $arguments)`nexit `$LASTEXITCODE"
+}
+
+# The command as it's displayed to the user: just the invocation, without the exit code plumbing
+# that Get-BuildCommand wraps around it.
+function Get-BuildCommandForDisplay([string[]] $arguments) {
+  "& '$buildScript' $(Get-QuotedArguments $arguments)"
+}
+
+# Forward every explicitly supplied parameter to the Arcade build. Only bound parameters are forwarded,
+# so parameters the caller didn't pass keep their Arcade defaults instead of being pinned to this
+# script's. Parameters listed here are handled by this script and must not be forwarded verbatim.
+$locallyHandledParameters = @('configuration', 'test', 'stage2', 'stage2Argument', 'binaryLogName', 'properties')
+
+function Get-ForwardedArguments($boundParameters) {
+  $forwarded = @()
+  foreach ($parameter in $boundParameters.GetEnumerator()) {
+    if (($locallyHandledParameters -contains $parameter.Key) -or
+        ([System.Management.Automation.PSCmdlet]::CommonParameters -contains $parameter.Key) -or
+        ([System.Management.Automation.PSCmdlet]::OptionalCommonParameters -contains $parameter.Key)) {
+      continue
+    }
+
+    $value = $parameter.Value
+    if ($value -is [switch]) {
+      # Every Arcade switch defaults to off, so an explicit '-switch:$false' needs nothing forwarded.
+      if ($value.IsPresent) {
+        $forwarded += "-$($parameter.Key)"
+      }
+    }
+    else {
+      $forwarded += "-$($parameter.Key)"
+      $forwarded += [string] $value
+    }
+  }
+
+  $forwarded
 }
 
 # Arguments common to the stage1 and stage2 builds, including any caller-supplied $properties.
-$commonBuildArgs = @('-configuration', $configuration) + $properties
+# The binary log name is deliberately not part of this set: each stage gets its own name below.
+$commonBuildArgs = @('-configuration', $configuration) + (Get-ForwardedArguments $PSBoundParameters)
 
-# Forward the argument if supplied. Needs to be done for all above explicit parameters that should be passed to the build.
-if ($verbosity) {
-  $commonBuildArgs += '-verbosity'
-  $commonBuildArgs += $verbosity
-}
-
-if ($msbuildEngine) {
-  $commonBuildArgs += '-msbuildEngine'
-  $commonBuildArgs += $msbuildEngine
-}
-
-# Forward the binary-log-related switches to both the stage 1 and stage 2 builds.
-if ($ci) {
-  $commonBuildArgs += '-ci'
-}
-if ($binaryLog) {
-  $commonBuildArgs += '-binaryLog'
-}
-if ($excludeCIBinarylog) {
-  $commonBuildArgs += '-excludeCIBinarylog'
+# Guarded because $properties is $null rather than an empty array when no extra arguments were passed,
+# which would otherwise append an empty argument to the build command.
+if ($properties) {
+  $commonBuildArgs += $properties
 }
 
 # Supplying stage2Arguments implies a multi-stage build
@@ -61,6 +98,11 @@ if ($stage2Argument.Count -gt 0) {
 }
 
 $buildArgs = $commonBuildArgs
+
+if ($binaryLogName) {
+  $buildArgs += '-binaryLogName'
+  $buildArgs += $binaryLogName
+}
 
 # If the caller requested a multi-stage build, add the -prepareMachine switch to the stage 1 build so that it kills any lingering processes from stage 1 before stage 2 starts.
 # Also disable the pipeline set result masking for stage 1 so that a stage 1 failure surfaces its real exit code to this wrapper (stage 2 is the terminal build that reports the pipeline result).
@@ -75,9 +117,9 @@ if ($test -and -not $stage2) {
 
 # Log the stage 1 build command so that it's clear which arguments flow to it.
 $stage1Command = Get-BuildCommand $buildArgs
-if ($stage2) {
-  Write-Host "Stage 1 build: $stage1Command"
-}
+# if ($stage2) {
+  Write-Host "Stage 1 build: $(Get-BuildCommandForDisplay $buildArgs)"
+# }
 
 & $pwshPath -NoLogo -NoProfile -ExecutionPolicy ByPass -Command $stage1Command
 
@@ -172,7 +214,11 @@ $stage2BuildArgs = $commonBuildArgs
 # suppressed with -excludeCIBinarylog.
 if (($ci -or $binaryLog) -and -not $excludeCIBinarylog) {
   $stage2BuildArgs += '-binaryLogName'
-  $stage2BuildArgs += 'Build.stage2.binlog'
+  $stage2BuildArgs += if ($binaryLogName) {
+    "$([System.IO.Path]::GetFileNameWithoutExtension($binaryLogName)).stage2$([System.IO.Path]::GetExtension($binaryLogName))"
+  } else {
+    'Build.stage2.binlog'
+  }
 }
 
 # Only run tests in stage2 when supplying the '-test' switch in a multi-stage build.
@@ -183,7 +229,7 @@ if ($test) {
 $stage2BuildArgs += $stage2Args
 
 $stage2Command = Get-BuildCommand $stage2BuildArgs
-Write-Host "Stage 2 build: $stage2Command"
+Write-Host "Stage 2 build: $(Get-BuildCommandForDisplay $stage2BuildArgs)"
 # Needs to run out-of-proc to not inherit the stage 1 build's state variables.
 & $pwshPath -NoLogo -NoProfile -ExecutionPolicy ByPass -Command $stage2Command
 


### PR DESCRIPTION
### Context

`build.cmd -v minimal` currently prints the wrapper's internal command string and then silently ignores the verbosity:

```
> build.cmd -v minimal
Stage 1 build: $global:LASTEXITCODE = 1
& 'C:\git\msbuild2\eng\common\build.ps1' -configuration Debug -restore -build minimal
exit $LASTEXITCODE
```

Two separate problems are visible there: the log line leaks exit-code plumbing, and `minimal` arrives as a bare property instead of `-verbosity minimal`.

### Changes

**Logging.** The quoting logic is split out of `Get-BuildCommand`, so the logged text is just the Arcade invocation, without the `$global:LASTEXITCODE = 1` prologue and trailing `exit $LASTEXITCODE`.

**Argument forwarding.** PowerShell binds arguments against this script's parameters before they are ever forwarded, so undeclared Arcade arguments could be swallowed or misrouted:

| Argument | Previous behavior |
| --- | --- |
| `-v minimal` | bound the common `-Verbose` switch; `minimal` leaked in as a bare property |
| `-b` (Arcade's `-build`) | prefix-matched the local `-binaryLog`, silently turning a build into a binlog request |

`-verbosity` and `-build` are now declared so those arguments bind to the right parameter, and every bound parameter is forwarded generically from `$PSBoundParameters` instead of per-parameter `if` blocks.

Only parameters this script actually reads are declared. Everything else flows through `$properties` verbatim and is bound by Arcade, which keeps Arcade's `[bool]` parameters (`-nodeReuse`, `-msbuildMultiThreaded`, `-warnAsError`) working without mirroring them here — mirroring them would require marshalling, since `True`/`False` re-parse as strings rather than booleans through `pwsh -Command`.

**Two smaller fixes.** `-binaryLogName My.binlog` now yields `My.stage2.binlog` for stage 2 rather than forwarding one name to both stages, and an empty argument is no longer appended when no extra properties are passed.

### Testing

- Swept all 35 Arcade parameters plus every alias through the wrapper into a stub that reports what bound: 0 failures.
- Verified the CI invocations produce identical stage 1 / stage 2 command lines (`-ci -test -stage2Argument /mt`, `-ci -test -stage2Argument '/p:RunQuarantinedTests=true'`).
- Verified pass-through of `/p:Foo=Bar`, `-warnnotaserror 'NU1901;NU1902'`, `-mt 1`, `-nodeReuse 0`, `-sign -pack -publish`, `-pb -projects`.
- Ran a real `build.cmd -v quiet`: build succeeded and the verbosity took effect.
