### PR TITLE
Preserve lazy item definition metadata across the task host boundary

### DIFF
--- a/documentation/wiki/ChangeWaves.md
+++ b/documentation/wiki/ChangeWaves.md
@@ -39,6 +39,7 @@ Change wave checks around features will be removed in the release that accompani
 - [XmlPeek, XmlPoke, and XslTransformation default to prohibiting embedded DTDs](https://github.com/dotnet/msbuild/pull/14285)
 - [Out-of-proc communication uses larger read-ahead buffers and pre-buffers TaskHost packet bodies to reduce pipe reads.](https://github.com/dotnet/msbuild/pull/14505)
 - [Restore no longer discards a ProjectRootElementCache that reloads changed files from disk, so the build that follows an implicit restore does not re-parse the import closure.](https://github.com/dotnet/msbuild/pull/14558)
+- [Item definition metadata that references built-in metadata (for example `%(Filename)`) is expanded on read inside an out-of-proc task host instead of being frozen when the item crosses the process boundary, so a task observes the same values whether or not it runs in a task host.](https://github.com/dotnet/msbuild/pull/14771)
 
 ### 18.10
 - [Resolve relative project paths against the Unix logical current directory from `PWD`, so builds under symlinked directories produce stable project full paths and related output paths.](https://github.com/dotnet/msbuild/pull/13752)

--- a/documentation/wiki/ChangeWaves.md
+++ b/documentation/wiki/ChangeWaves.md
@@ -40,6 +40,7 @@ Change wave checks around features will be removed in the release that accompani
 - [Out-of-proc communication uses larger read-ahead buffers and pre-buffers TaskHost packet bodies to reduce pipe reads.](https://github.com/dotnet/msbuild/pull/14505)
 - [Restore no longer discards a ProjectRootElementCache that reloads changed files from disk, so the build that follows an implicit restore does not re-parse the import closure.](https://github.com/dotnet/msbuild/pull/14558)
 - [Item definition metadata that references built-in metadata (for example `%(Filename)`) is expanded on read inside an out-of-proc task host instead of being frozen when the item crosses the process boundary, so a task observes the same values whether or not it runs in a task host.](https://github.com/dotnet/msbuild/pull/14771)
+- [Use optimized MSBuild file specification matching and enumeration](https://github.com/dotnet/msbuild/pull/14663). Regex-backed file globs use culture-invariant case folding; set `MSBUILDUSELEGACYCULTURESENSITIVEFILEGLOBS=1` to preserve legacy current-culture folding without disabling other Wave 18.11 features.
 
 ### 18.10
 - [Resolve relative project paths against the Unix logical current directory from `PWD`, so builds under symlinked directories produce stable project full paths and related output paths.](https://github.com/dotnet/msbuild/pull/13752)

--- a/src/Build.UnitTests/BackEnd/MetadataObservationTask.cs
+++ b/src/Build.UnitTests/BackEnd/MetadataObservationTask.cs
@@ -1,0 +1,57 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+#nullable disable
+
+namespace Microsoft.Build.UnitTests
+{
+    /// <summary>
+    /// Reports the value of a metadata name as the task itself observes it, plus the id of the process the
+    /// task ran in, so tests can tell an in-proc execution apart from a task host one.
+    /// Optionally reassigns ItemSpec first, to exercise metadata that derives from it.
+    /// </summary>
+    public class MetadataObservationTask : Task
+    {
+        [Required]
+        public ITaskItem[] Items { get; set; }
+
+        [Required]
+        public string MetadataName { get; set; }
+
+        public string NewItemSpec { get; set; }
+
+        [Output]
+        public string ObservedValue { get; set; }
+
+        [Output]
+        public int TaskProcessId { get; set; }
+
+        public override bool Execute()
+        {
+            TaskProcessId = Process.GetCurrentProcess().Id;
+
+            if (Items.Length > 0)
+            {
+                ITaskItem item = Items[0];
+
+                if (!string.IsNullOrEmpty(NewItemSpec))
+                {
+                    item.ItemSpec = NewItemSpec;
+                }
+
+                ObservedValue = item.GetMetadata(MetadataName);
+            }
+            else
+            {
+                ObservedValue = string.Empty;
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/Build.UnitTests/BackEnd/TaskHostFactory_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/TaskHostFactory_Tests.cs
@@ -37,6 +37,95 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
         }
 
         /// <summary>
+        /// Item definition metadata that references built-in metadata (e.g. %(Filename)) is expanded on read so
+        /// it tracks the item spec it derives from. These tests pin the behaviour a task observes to be the same
+        /// whether or not it runs in a task host.
+        /// </summary>
+        /// <param name="useTaskHost">Whether the task runs out-of-proc.</param>
+        /// <param name="newItemSpec">If set, the task reassigns ItemSpec before reading the metadata.</param>
+        /// <param name="expected">The value the task is expected to observe.</param>
+        [Theory]
+        [InlineData(false, null, "hello")]
+        [InlineData(true, null, "hello")]
+        [InlineData(false, @"other\renamed.txt", "renamed")]
+        [InlineData(true, @"other\renamed.txt", "renamed")]
+        public void ItemDefinitionMetadataIsObservedIdenticallyInProcAndInTaskHost(bool useTaskHost, string newItemSpec, string expected)
+        {
+            using TestEnvironment env = TestEnvironment.Create();
+
+            string observed = RunMetadataObservation(env, useTaskHost, newItemSpec, out int taskProcessId);
+
+            if (useTaskHost)
+            {
+                taskProcessId.ShouldNotBe(
+                    Process.GetCurrentProcess().Id,
+                    "Task must actually run out-of-proc for this test to be meaningful.");
+            }
+
+            observed.ShouldBe(expected);
+        }
+
+        /// <summary>
+        /// Opting out of the change wave restores the previous behaviour, where item definition metadata was
+        /// flattened when the item crossed into a task host and the task saw the unexpanded expression.
+        /// </summary>
+        [Fact]
+        public void ItemDefinitionMetadataIsNotExpandedInTaskHostWhenChangeWaveDisabled()
+        {
+            using TestEnvironment env = TestEnvironment.Create();
+            ChangeWaves.ResetStateForTests();
+            env.SetEnvironmentVariable("MSBUILDDISABLEFEATURESFROMVERSION", ChangeWaves.Wave18_11.ToString());
+
+            try
+            {
+                string observed = RunMetadataObservation(env, useTaskHost: true, newItemSpec: null, out _);
+
+                observed.ShouldBe("%(Filename)");
+            }
+            finally
+            {
+                ChangeWaves.ResetStateForTests();
+            }
+        }
+
+        private static string RunMetadataObservation(TestEnvironment env, bool useTaskHost, string newItemSpec, out int taskProcessId)
+        {
+            string taskFactory = useTaskHost ? @" TaskFactory=""TaskHostFactory""" : string.Empty;
+            string newItemSpecAttribute = string.IsNullOrEmpty(newItemSpec) ? string.Empty : $@" NewItemSpec=""{newItemSpec}""";
+
+            string projectContents = $@"
+<Project>
+    <UsingTask TaskName=""MetadataObservationTask"" AssemblyFile=""{AssemblyLocation}""{taskFactory} />
+    <ItemDefinitionGroup>
+        <Thing>
+            <OutputName>%(Filename)</OutputName>
+        </Thing>
+    </ItemDefinitionGroup>
+    <ItemGroup>
+        <Thing Include=""folder\hello.txt"" />
+    </ItemGroup>
+    <Target Name='Observe'>
+        <MetadataObservationTask Items=""@(Thing)"" MetadataName=""OutputName""{newItemSpecAttribute}>
+            <Output PropertyName=""Observed"" TaskParameter=""ObservedValue"" />
+            <Output PropertyName=""TaskPid"" TaskParameter=""TaskProcessId"" />
+        </MetadataObservationTask>
+    </Target>
+</Project>";
+
+            TransientTestFile project = env.CreateFile("testProject.csproj", projectContents);
+            ProjectInstance projectInstance = new(project.Path);
+
+            BuildResult buildResult = BuildManager.DefaultBuildManager.Build(
+                new BuildParameters(),
+                new BuildRequestData(projectInstance, targetsToBuild: ["Observe"]));
+
+            buildResult.OverallResult.ShouldBe(BuildResultCode.Success);
+
+            taskProcessId = int.Parse(projectInstance.GetPropertyValue("TaskPid"), CultureInfo.InvariantCulture);
+            return projectInstance.GetPropertyValue("Observed");
+        }
+
+        /// <summary>
         /// Verifies that task host nodes properly terminate after a build completes.
         /// Tests both transient (TaskHostFactory) and sidecar (AssemblyTaskFactory) task hosts
         /// with different configuration combinations.

--- a/src/Build.UnitTests/BackEnd/TaskHostFactory_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/TaskHostFactory_Tests.cs
@@ -6,12 +6,14 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Threading;
+using Microsoft.Build.BackEnd;
+using Microsoft.Build.Evaluation;
 using Microsoft.Build.Execution;
 using Microsoft.Build.Framework;
 using Microsoft.Build.UnitTests;
 using Microsoft.Build.UnitTests.BackEnd;
-
 using Shouldly;
 using Xunit;
 
@@ -123,6 +125,71 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
 
             taskProcessId = int.Parse(projectInstance.GetPropertyValue("TaskPid"), CultureInfo.InvariantCulture);
             return projectInstance.GetPropertyValue("Observed");
+        }
+
+        /// <summary>
+        /// Item definition metadata is only carried separately when the peer understands it. Round-trips an item
+        /// through <see cref="TaskParameter"/> at each negotiated packet version and pins what the far side sees.
+        /// </summary>
+        /// <remarks>
+        /// A CLR2 task host negotiates <see langword="null"/> and only ever reads a single flattened metadata
+        /// dictionary, so nothing extra may be written for it and the values must arrive exactly as they do today.
+        /// A CLR4 task host negotiates 0 and is always the same build. A .NET task host is loaded from the SDK, so
+        /// it may be an older MSBuild and negotiate a version below the one that understands the split.
+        /// </remarks>
+        /// <param name="negotiatedPacketVersion">The negotiated packet version, or null for a CLR2 task host.</param>
+        /// <param name="expectsLazyExpansion">Whether the far side should expand metadata on read.</param>
+        [Theory]
+        [InlineData(null, false)]                                                              // CLR2 task host
+        [InlineData((byte)0, true)]                                                            // CLR4 task host
+        [InlineData((byte)5, false)]                                                           // older .NET task host
+        [InlineData(NodePacketTypeExtensions.LazyItemDefinitionMetadataMinVersion, true)]      // current .NET task host
+        public void ItemDefinitionMetadataRoundTripsAccordingToNegotiatedPacketVersion(byte? negotiatedPacketVersion, bool expectsLazyExpansion)
+        {
+            string content = ObjectModelHelpers.CleanupFileContents(@"
+                <Project ToolsVersion='msbuilddefaulttoolsversion' xmlns='msbuildnamespace'>
+                  <ItemDefinitionGroup>
+                    <i>
+                      <OutputName>%(Filename)</OutputName>
+                    </i>
+                  </ItemDefinitionGroup>
+                  <ItemGroup>
+                    <i Include='folder\hello.txt' />
+                  </ItemGroup>
+                </Project>");
+
+            using ProjectRootElementFromString projectRootElementFromString = new(content);
+            ProjectInstance instance = new Project(projectRootElementFromString.Project).CreateProjectInstance();
+            ITaskItem sourceItem = instance.GetItems("i").Single();
+
+            // In-proc, the item expands on read. This is the reference behaviour.
+            sourceItem.GetMetadata("OutputName").ShouldBe("hello");
+
+            TaskParameter parameter = new(sourceItem);
+
+            ITranslator writeTranslator = TranslationHelpers.GetWriteTranslator();
+            writeTranslator.NegotiatedPacketVersion = negotiatedPacketVersion;
+            ((ITranslatable)parameter).Translate(writeTranslator);
+
+            ITranslator readTranslator = TranslationHelpers.GetReadTranslator();
+            readTranslator.NegotiatedPacketVersion = negotiatedPacketVersion;
+            TaskParameter deserialized = TaskParameter.FactoryForDeserialization(readTranslator);
+
+            ITaskItem receivedItem = (ITaskItem)deserialized.WrappedParameter;
+
+            if (expectsLazyExpansion)
+            {
+                receivedItem.GetMetadata("OutputName").ShouldBe("hello");
+
+                // The value is still bound to the item spec, so reassigning it re-derives, as it does in-proc.
+                receivedItem.ItemSpec = @"other\renamed.txt";
+                receivedItem.GetMetadata("OutputName").ShouldBe("renamed");
+            }
+            else
+            {
+                // Older peers receive exactly what they receive today: the raw, unexpanded value.
+                receivedItem.GetMetadata("OutputName").ShouldBe("%(Filename)");
+            }
         }
 
         /// <summary>

--- a/src/Build/Instance/ProjectItemDefinitionInstance.cs
+++ b/src/Build/Instance/ProjectItemDefinitionInstance.cs
@@ -37,6 +37,17 @@ namespace Microsoft.Build.Execution
         private ImmutableDictionary<string, string> _metadata;
 
         /// <summary>
+        /// Metadata on this definition whose value may contain an expression that is expanded on read, or an empty
+        /// collection if there is none. Computed once per definition rather than per item: a definition is shared by
+        /// every item of its type, so scanning it for each of them would repeat identical work on a hot path.
+        /// </summary>
+        /// <remarks>
+        /// Invalidated by <see cref="IItemDefinition{T}.SetMetadata"/>, which is only used while the definition is
+        /// being built during evaluation.
+        /// </remarks>
+        private ImmutableDictionary<string, string> _expandableMetadata;
+
+        /// <summary>
         /// Constructs an empty project item definition instance.
         /// </summary>
         /// <param name="itemType">The type of item this definition object represents.</param>
@@ -141,6 +152,38 @@ namespace Microsoft.Build.Execution
         internal ImmutableDictionary<string, string> BackingMetadata => _metadata ?? ImmutableDictionaryExtensions.EmptyMetadata;
 
         /// <summary>
+        /// The subset of <see cref="BackingMetadata"/> whose values may contain an expression expanded on read.
+        /// Empty for the overwhelming majority of definitions.
+        /// </summary>
+        internal ImmutableDictionary<string, string> ExpandableMetadata
+        {
+            get
+            {
+                ImmutableDictionary<string, string> expandable = _expandableMetadata;
+
+                if (expandable == null)
+                {
+                    expandable = ImmutableDictionaryExtensions.EmptyMetadata;
+
+                    if (_metadata != null)
+                    {
+                        foreach (KeyValuePair<string, string> metadatum in _metadata)
+                        {
+                            if (Expander<ProjectProperty, ProjectItem>.ExpressionMayContainExpandableExpressions(metadatum.Value))
+                            {
+                                expandable = expandable.SetItem(metadatum.Key, metadatum.Value);
+                            }
+                        }
+                    }
+
+                    _expandableMetadata = expandable;
+                }
+
+                return expandable;
+            }
+        }
+
+        /// <summary>
         /// Get any metadata in the item that has the specified name,
         /// otherwise returns null
         /// </summary>
@@ -207,6 +250,7 @@ namespace Microsoft.Build.Execution
 
             ProjectMetadataInstance metadatum = new ProjectMetadataInstance(xml.Name, evaluatedValue);
             _metadata = _metadata.SetItem(xml.Name, metadatum.EvaluatedValueEscaped);
+            _expandableMetadata = null;
 
             return metadatum;
         }

--- a/src/Build/Instance/ProjectItemInstance.cs
+++ b/src/Build/Instance/ProjectItemInstance.cs
@@ -786,7 +786,8 @@ namespace Microsoft.Build.Execution
             IItem<ProjectMetadataInstance>,
             ITranslatable,
             IEquatable<TaskItem>,
-            IMetadataContainer
+            IMetadataContainer,
+            IItemDefinitionMetadataProvider
         {
             /// <summary>
             /// The source file that defined this item.
@@ -2118,6 +2119,51 @@ namespace Microsoft.Build.Execution
 
                 return null;
             }
+
+            #region IItemDefinitionMetadataProvider Members
+
+            bool IItemDefinitionMetadataProvider.HasExpandableItemDefinitionMetadata => HasAnyExpandableExpressions();
+
+            IEnumerable<KeyValuePair<string, string>> IItemDefinitionMetadataProvider.EnumerateDirectMetadataEscaped()
+            {
+                if (_directMetadata != null)
+                {
+                    foreach (KeyValuePair<string, string> metadatum in _directMetadata)
+                    {
+                        yield return metadatum;
+                    }
+                }
+            }
+
+            IEnumerable<KeyValuePair<string, string>> IItemDefinitionMetadataProvider.EnumerateItemDefinitionMetadataEscaped()
+            {
+                if (_itemDefinitions == null)
+                {
+                    yield break;
+                }
+
+                // Later definitions are lower precedence, and direct metadata masks all of them.
+                // Walk in precedence order and emit the first occurrence of each name.
+                HashSet<string> seen = new HashSet<string>(MSBuildNameIgnoreCaseComparer.Default);
+
+                for (int i = 0; i < _itemDefinitions.Count; i++)
+                {
+                    foreach (KeyValuePair<string, string> metadatum in _itemDefinitions[i].BackingMetadata)
+                    {
+                        if (_directMetadata?.ContainsKey(metadatum.Key) == true)
+                        {
+                            continue;
+                        }
+
+                        if (seen.Add(metadatum.Key))
+                        {
+                            yield return metadatum;
+                        }
+                    }
+                }
+            }
+
+            #endregion
 
             /// <summary>
             /// Checks if any of the item definitions may have expandable expressions.

--- a/src/Build/Instance/ProjectItemInstance.cs
+++ b/src/Build/Instance/ProjectItemInstance.cs
@@ -40,7 +40,8 @@ namespace Microsoft.Build.Execution
         ITranslatable,
         IMetadataContainer,
         IItemTypeDefinition,
-        IItemData
+        IItemData,
+        IItemDefinitionMetadataProvider
     {
         /// <summary>
         /// The project instance to which this item belongs.
@@ -313,6 +314,15 @@ namespace Microsoft.Build.Execution
 
         /// <inheritdoc cref="IItemData.EnumerateMetadata"/>
         IEnumerable<KeyValuePair<string, string>> IItemData.EnumerateMetadata() => ((IMetadataContainer)this).EnumerateMetadata();
+
+        bool IItemDefinitionMetadataProvider.HasExpandableItemDefinitionMetadata
+            => ((IItemDefinitionMetadataProvider)_taskItem).HasExpandableItemDefinitionMetadata;
+
+        IEnumerable<KeyValuePair<string, string>> IItemDefinitionMetadataProvider.EnumerateDirectMetadataEscaped()
+            => ((IItemDefinitionMetadataProvider)_taskItem).EnumerateDirectMetadataEscaped();
+
+        IEnumerable<KeyValuePair<string, string>> IItemDefinitionMetadataProvider.EnumerateItemDefinitionMetadataEscaped()
+            => ((IItemDefinitionMetadataProvider)_taskItem).EnumerateItemDefinitionMetadataEscaped();
 
         /// <summary>
         /// ITaskItem implementation

--- a/src/Build/Instance/ProjectItemInstance.cs
+++ b/src/Build/Instance/ProjectItemInstance.cs
@@ -318,11 +318,8 @@ namespace Microsoft.Build.Execution
         bool IItemDefinitionMetadataProvider.HasExpandableItemDefinitionMetadata
             => ((IItemDefinitionMetadataProvider)_taskItem).HasExpandableItemDefinitionMetadata;
 
-        IEnumerable<KeyValuePair<string, string>> IItemDefinitionMetadataProvider.EnumerateDirectMetadataEscaped()
-            => ((IItemDefinitionMetadataProvider)_taskItem).EnumerateDirectMetadataEscaped();
-
-        IEnumerable<KeyValuePair<string, string>> IItemDefinitionMetadataProvider.EnumerateItemDefinitionMetadataEscaped()
-            => ((IItemDefinitionMetadataProvider)_taskItem).EnumerateItemDefinitionMetadataEscaped();
+        IEnumerable<KeyValuePair<string, string>> IItemDefinitionMetadataProvider.EnumerateExpandableItemDefinitionMetadataEscaped()
+            => ((IItemDefinitionMetadataProvider)_taskItem).EnumerateExpandableItemDefinitionMetadataEscaped();
 
         /// <summary>
         /// ITaskItem implementation
@@ -2134,43 +2131,47 @@ namespace Microsoft.Build.Execution
 
             bool IItemDefinitionMetadataProvider.HasExpandableItemDefinitionMetadata => HasAnyExpandableExpressions();
 
-            IEnumerable<KeyValuePair<string, string>> IItemDefinitionMetadataProvider.EnumerateDirectMetadataEscaped()
-            {
-                if (_directMetadata != null)
-                {
-                    foreach (KeyValuePair<string, string> metadatum in _directMetadata)
-                    {
-                        yield return metadatum;
-                    }
-                }
-            }
-
-            IEnumerable<KeyValuePair<string, string>> IItemDefinitionMetadataProvider.EnumerateItemDefinitionMetadataEscaped()
+            IEnumerable<KeyValuePair<string, string>> IItemDefinitionMetadataProvider.EnumerateExpandableItemDefinitionMetadataEscaped()
             {
                 if (_itemDefinitions == null)
                 {
                     yield break;
                 }
 
-                // Later definitions are lower precedence, and direct metadata masks all of them.
-                // Walk in precedence order and emit the first occurrence of each name.
-                HashSet<string> seen = new HashSet<string>(MSBuildNameIgnoreCaseComparer.Default);
-
+                // Each definition already knows which of its values are expandable, so this walks a small
+                // precomputed set rather than rescanning every value for every item.
                 for (int i = 0; i < _itemDefinitions.Count; i++)
                 {
-                    foreach (KeyValuePair<string, string> metadatum in _itemDefinitions[i].BackingMetadata)
+                    foreach (KeyValuePair<string, string> metadatum in _itemDefinitions[i].ExpandableMetadata)
                     {
+                        // Metadata set directly on the item wins and is never expanded.
                         if (_directMetadata?.ContainsKey(metadatum.Key) == true)
                         {
                             continue;
                         }
 
-                        if (seen.Add(metadatum.Key))
+                        // Definitions are in decreasing precedence, so an earlier one already supplied this name.
+                        if (i > 0 && IsSuppliedByHigherPrecedenceDefinition(metadatum.Key, i))
                         {
-                            yield return metadatum;
+                            continue;
                         }
+
+                        yield return metadatum;
                     }
                 }
+            }
+
+            private bool IsSuppliedByHigherPrecedenceDefinition(string name, int index)
+            {
+                for (int i = 0; i < index; i++)
+                {
+                    if (_itemDefinitions[i].BackingMetadata.ContainsKey(name))
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
             }
 
             #endregion
@@ -2190,14 +2191,11 @@ namespace Microsoft.Build.Execution
                     return false;
                 }
 
-                foreach (ProjectItemDefinitionInstance item in _itemDefinitions)
+                for (int i = 0; i < _itemDefinitions.Count; i++)
                 {
-                    foreach (KeyValuePair<string, string> kvp in item.BackingMetadata)
+                    if (!_itemDefinitions[i].ExpandableMetadata.IsEmpty)
                     {
-                        if (Expander<ProjectProperty, ProjectItem>.ExpressionMayContainExpandableExpressions(kvp.Value))
-                        {
-                            return true;
-                        }
+                        return true;
                     }
                 }
 

--- a/src/Framework/BackEnd/NodePacketTypeExtensions.cs
+++ b/src/Framework/BackEnd/NodePacketTypeExtensions.cs
@@ -32,18 +32,27 @@ internal static class NodePacketTypeExtensions
     /// 5: Added delta transfer for the invariant payloads in TaskHostConfiguration / TaskHostTaskComplete:
     ///    the build process environment and the CurrentSolutionConfigurationContents solution-level configuration
     ///    blob are each sent once per connection, then only an "unchanged" marker per task.
+    /// 6: Item definition metadata that references built-in metadata (e.g. %(Filename)) is sent unexpanded
+    ///    in a separate dictionary, so it stays bound to the item spec and expands on read in the task host.
     /// 
     /// When incrementing this version, ensure compatibility with existing
     /// task hosts and update the corresponding deserialization logic.
     /// </summary>
-    public const byte PacketVersion = 5;
+    public const byte PacketVersion = 6;
 
     /// <summary>
-    /// The minimum negotiated packet version that supports delta transfer of the invariant
+    /// The minimum negotiated packet version that supports the invariant
     /// <see cref="NodePacketType.TaskHostConfiguration"/> / <see cref="NodePacketType.TaskHostTaskComplete"/>
     /// payloads (the build process environment and the CurrentSolutionConfigurationContents blob).
     /// </summary>
     public const byte EnvironmentDeltaMinVersion = 5;
+
+    /// <summary>
+    /// The minimum negotiated packet version that carries item definition metadata separately from
+    /// metadata set directly on the item, allowing built-in metadata references to be expanded on read
+    /// in the task host rather than frozen when the item crosses the process boundary.
+    /// </summary>
+    public const byte LazyItemDefinitionMetadataMinVersion = 6;
 
     // Flag bits in upper 2 bits
     private const byte ExtendedHeaderFlag = 0x40;  // Bit 6: 01000000

--- a/src/Framework/IItemDefinitionMetadataProvider.cs
+++ b/src/Framework/IItemDefinitionMetadataProvider.cs
@@ -1,0 +1,40 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+
+#nullable disable
+
+namespace Microsoft.Build.Framework
+{
+    /// <summary>
+    /// Implemented by item types that keep metadata originating in item definitions separate from
+    /// metadata set directly on the item.
+    /// </summary>
+    /// <remarks>
+    /// Item definition metadata may reference built-in metadata (for example
+    /// <c>&lt;OutputName&gt;%(Filename)&lt;/OutputName&gt;</c>). Such values are stored unexpanded and
+    /// expanded on read, so that they track the item spec they are derived from. Flattening the two
+    /// collections together loses that distinction, so anything that needs to reproduce the item
+    /// faithfully (for example marshalling it to an out-of-proc task host) has to keep them apart.
+    /// </remarks>
+    internal interface IItemDefinitionMetadataProvider
+    {
+        /// <summary>
+        /// Gets a value indicating whether any item definition metadata may contain an expression
+        /// that is expanded on read.
+        /// </summary>
+        bool HasExpandableItemDefinitionMetadata { get; }
+
+        /// <summary>
+        /// Enumerates metadata set directly on the item, escaped. These values are never expanded on read.
+        /// </summary>
+        IEnumerable<KeyValuePair<string, string>> EnumerateDirectMetadataEscaped();
+
+        /// <summary>
+        /// Enumerates metadata inherited from item definitions, escaped and <em>unexpanded</em>.
+        /// Values masked by direct metadata are not included.
+        /// </summary>
+        IEnumerable<KeyValuePair<string, string>> EnumerateItemDefinitionMetadataEscaped();
+    }
+}

--- a/src/Framework/IItemDefinitionMetadataProvider.cs
+++ b/src/Framework/IItemDefinitionMetadataProvider.cs
@@ -8,33 +8,31 @@ using System.Collections.Generic;
 namespace Microsoft.Build.Framework
 {
     /// <summary>
-    /// Implemented by item types that keep metadata originating in item definitions separate from
-    /// metadata set directly on the item.
+    /// Implemented by item types whose metadata may include item definition values that are expanded on read
+    /// rather than stored expanded.
     /// </summary>
     /// <remarks>
-    /// Item definition metadata may reference built-in metadata (for example
-    /// <c>&lt;OutputName&gt;%(Filename)&lt;/OutputName&gt;</c>). Such values are stored unexpanded and
-    /// expanded on read, so that they track the item spec they are derived from. Flattening the two
-    /// collections together loses that distinction, so anything that needs to reproduce the item
-    /// faithfully (for example marshalling it to an out-of-proc task host) has to keep them apart.
+    /// Item definition metadata may reference built-in metadata, for example
+    /// <c>&lt;OutputName&gt;%(Filename)&lt;/OutputName&gt;</c>. Such values are stored unexpanded so that they track
+    /// the item spec they derive from. Anything that needs to reproduce the item faithfully - notably marshalling
+    /// it to an out-of-proc task host - has to know which values those are, since a flattened copy freezes them.
     /// </remarks>
     internal interface IItemDefinitionMetadataProvider
     {
         /// <summary>
-        /// Gets a value indicating whether any item definition metadata may contain an expression
-        /// that is expanded on read.
+        /// Gets a value indicating whether any item definition metadata may contain an expression that is
+        /// expanded on read. When false there is nothing to preserve and the flattened form is exact.
         /// </summary>
         bool HasExpandableItemDefinitionMetadata { get; }
 
         /// <summary>
-        /// Enumerates metadata set directly on the item, escaped. These values are never expanded on read.
+        /// Enumerates only the item definition metadata that may contain an expression, escaped and unexpanded.
+        /// Values masked by metadata set directly on the item are excluded, since those win and are never expanded.
         /// </summary>
-        IEnumerable<KeyValuePair<string, string>> EnumerateDirectMetadataEscaped();
-
-        /// <summary>
-        /// Enumerates metadata inherited from item definitions, escaped and <em>unexpanded</em>.
-        /// Values masked by direct metadata are not included.
-        /// </summary>
-        IEnumerable<KeyValuePair<string, string>> EnumerateItemDefinitionMetadataEscaped();
+        /// <remarks>
+        /// Deliberately narrow: everything else is already correct in the flattened copy, so only these entries
+        /// need to be carried separately. In practice this is a small handful of values.
+        /// </remarks>
+        IEnumerable<KeyValuePair<string, string>> EnumerateExpandableItemDefinitionMetadataEscaped();
     }
 }

--- a/src/Shared/TaskParameter.cs
+++ b/src/Shared/TaskParameter.cs
@@ -571,6 +571,17 @@ namespace Microsoft.Build.BackEnd
             private Dictionary<string, string> _customEscapedMetadata = null;
 
             /// <summary>
+            /// Metadata inherited from item definitions, in escaped and <em>unexpanded</em> form.
+            /// </summary>
+            /// <remarks>
+            /// Kept separate from <see cref="_customEscapedMetadata"/> so that values referencing built-in
+            /// metadata (for example <c>%(Filename)</c>) are expanded on read against this item's current
+            /// item spec, matching what the same task would observe when running in-proc. Flattening the two
+            /// together would freeze the value at the point it crossed the process boundary.
+            /// </remarks>
+            private Dictionary<string, string> _itemDefinitionEscapedMetadata = null;
+
+            /// <summary>
             /// Cache for derivable modifier values
             /// </summary>
             private ItemSpecModifiers.Cache _cachedModifiers;
@@ -585,15 +596,35 @@ namespace Microsoft.Build.BackEnd
                     _escapedItemSpec = copyFromAsITaskItem2.EvaluatedIncludeEscaped;
                     _escapedDefiningProject = copyFromAsITaskItem2.GetMetadataValueEscaped(ItemSpecModifiers.DefiningProjectFullPath);
 
-                    IDictionary nonGenericEscapedMetadata = copyFromAsITaskItem2.CloneCustomMetadataEscaped();
-                    _customEscapedMetadata = nonGenericEscapedMetadata as Dictionary<string, string>;
-
-                    if (_customEscapedMetadata is null)
+                    // If the source keeps item definition metadata separate and some of it is expandable,
+                    // preserve that split so the values stay bound to the item spec on the other side.
+                    if (copyFrom is IItemDefinitionMetadataProvider itemDefinitionSource
+                        && itemDefinitionSource.HasExpandableItemDefinitionMetadata)
                     {
                         _customEscapedMetadata = new Dictionary<string, string>(MSBuildNameIgnoreCaseComparer.Default);
-                        foreach (DictionaryEntry entry in nonGenericEscapedMetadata)
+                        foreach (KeyValuePair<string, string> metadatum in itemDefinitionSource.EnumerateDirectMetadataEscaped())
                         {
-                            _customEscapedMetadata[(string)entry.Key] = (string)entry.Value ?? string.Empty;
+                            _customEscapedMetadata[metadatum.Key] = metadatum.Value ?? string.Empty;
+                        }
+
+                        _itemDefinitionEscapedMetadata = new Dictionary<string, string>(MSBuildNameIgnoreCaseComparer.Default);
+                        foreach (KeyValuePair<string, string> metadatum in itemDefinitionSource.EnumerateItemDefinitionMetadataEscaped())
+                        {
+                            _itemDefinitionEscapedMetadata[metadatum.Key] = metadatum.Value ?? string.Empty;
+                        }
+                    }
+                    else
+                    {
+                        IDictionary nonGenericEscapedMetadata = copyFromAsITaskItem2.CloneCustomMetadataEscaped();
+                        _customEscapedMetadata = nonGenericEscapedMetadata as Dictionary<string, string>;
+
+                        if (_customEscapedMetadata is null)
+                        {
+                            _customEscapedMetadata = new Dictionary<string, string>(MSBuildNameIgnoreCaseComparer.Default);
+                            foreach (DictionaryEntry entry in nonGenericEscapedMetadata)
+                            {
+                                _customEscapedMetadata[(string)entry.Key] = (string)entry.Value ?? string.Empty;
+                            }
                         }
                     }
                 }
@@ -684,7 +715,23 @@ namespace Microsoft.Build.BackEnd
             {
                 get
                 {
-                    List<string> metadataNames = (_customEscapedMetadata == null) ? new List<string>() : new List<string>(_customEscapedMetadata.Keys);
+                    List<string> metadataNames = new List<string>();
+
+                    if (_itemDefinitionEscapedMetadata != null)
+                    {
+                        foreach (string name in _itemDefinitionEscapedMetadata.Keys)
+                        {
+                            if (_customEscapedMetadata?.ContainsKey(name) != true)
+                            {
+                                metadataNames.Add(name);
+                            }
+                        }
+                    }
+
+                    if (_customEscapedMetadata != null)
+                    {
+                        metadataNames.AddRange(_customEscapedMetadata.Keys);
+                    }
 
                     foreach (string name in ItemSpecModifiers.All)
                     {
@@ -704,7 +751,7 @@ namespace Microsoft.Build.BackEnd
             {
                 get
                 {
-                    int count = (_customEscapedMetadata == null) ? 0 : _customEscapedMetadata.Count;
+                    int count = ((ITaskItem2)this).CloneCustomMetadataEscaped().Count;
                     return count + ItemSpecModifiers.All.Length;
                 }
             }
@@ -727,7 +774,7 @@ namespace Microsoft.Build.BackEnd
 
             public SerializableMetadata BackingMetadata => default;
 
-            public bool HasCustomMetadata => _customEscapedMetadata?.Count > 0;
+            public bool HasCustomMetadata => _customEscapedMetadata?.Count > 0 || _itemDefinitionEscapedMetadata?.Count > 0;
 
             /// <summary>
             /// Allows the values of metadata on the item to be queried.
@@ -767,12 +814,8 @@ namespace Microsoft.Build.BackEnd
                 ArgumentNullException.ThrowIfNull(metadataName);
                 ErrorUtilities.VerifyThrowArgument(!ItemSpecModifiers.IsItemSpecModifier(metadataName), "CannotChangeItemSpecModifiers", metadataName);
 
-                if (_customEscapedMetadata == null)
-                {
-                    return;
-                }
-
-                _customEscapedMetadata.Remove(metadataName);
+                _customEscapedMetadata?.Remove(metadataName);
+                _itemDefinitionEscapedMetadata?.Remove(metadataName);
             }
 
             /// <summary>
@@ -880,9 +923,65 @@ namespace Microsoft.Build.BackEnd
                 }
 
                 string metadataValue = null;
-                _customEscapedMetadata?.TryGetValue(metadataName, out metadataValue);
+                if (_customEscapedMetadata?.TryGetValue(metadataName, out metadataValue) == true)
+                {
+                    return metadataValue ?? string.Empty;
+                }
 
-                return metadataValue ?? string.Empty;
+                // Item definition metadata is stored unexpanded so that built-in metadata references stay
+                // bound to the current item spec. Expand on read, exactly as the in-proc item does.
+                if (_itemDefinitionEscapedMetadata?.TryGetValue(metadataName, out metadataValue) == true)
+                {
+                    return ExpandBuiltInMetadata(metadataValue) ?? string.Empty;
+                }
+
+                return string.Empty;
+            }
+
+            /// <summary>
+            /// Expands unqualified built-in metadata references (for example <c>%(Filename)</c>) against this
+            /// item's own item spec. Anything else, including custom metadata references, is left alone —
+            /// those are already expanded during evaluation and never reach this point unexpanded.
+            /// </summary>
+            private string ExpandBuiltInMetadata(string escapedValue)
+            {
+                if (string.IsNullOrEmpty(escapedValue) || escapedValue.IndexOf("%(", StringComparison.Ordinal) < 0)
+                {
+                    return escapedValue;
+                }
+
+                System.Text.StringBuilder builder = null;
+                int lastCopied = 0;
+                int index = escapedValue.IndexOf("%(", StringComparison.Ordinal);
+
+                while (index >= 0)
+                {
+                    int close = escapedValue.IndexOf(')', index + 2);
+                    if (close < 0)
+                    {
+                        break;
+                    }
+
+                    string name = escapedValue.Substring(index + 2, close - index - 2).Trim();
+
+                    if (ItemSpecModifiers.TryGetDerivableModifierKind(name, out ItemSpecModifierKind modifierKind))
+                    {
+                        builder ??= new System.Text.StringBuilder(escapedValue.Length);
+                        builder.Append(escapedValue, lastCopied, index - lastCopied);
+                        builder.Append(ItemSpecModifiers.GetItemSpecModifier(_escapedItemSpec, modifierKind, null, _escapedDefiningProject, ref _cachedModifiers));
+                        lastCopied = close + 1;
+                    }
+
+                    index = escapedValue.IndexOf("%(", close + 1, StringComparison.Ordinal);
+                }
+
+                if (builder == null)
+                {
+                    return escapedValue;
+                }
+
+                builder.Append(escapedValue, lastCopied, escapedValue.Length - lastCopied);
+                return builder.ToString();
             }
 
             /// <summary>
@@ -898,7 +997,27 @@ namespace Microsoft.Build.BackEnd
             /// </summary>
             IDictionary ITaskItem2.CloneCustomMetadataEscaped()
             {
-                IDictionary clonedDictionary = new Dictionary<string, string>(_customEscapedMetadata);
+                // Return the unexpanded form. The engine flattens task outputs by copying these values
+                // straight into direct metadata, and it does the same for in-proc items, so expanding here
+                // would make out-of-proc task outputs differ from in-proc ones.
+                Dictionary<string, string> clonedDictionary = new Dictionary<string, string>(MSBuildNameIgnoreCaseComparer.Default);
+
+                if (_itemDefinitionEscapedMetadata != null)
+                {
+                    foreach (KeyValuePair<string, string> metadatum in _itemDefinitionEscapedMetadata)
+                    {
+                        clonedDictionary[metadatum.Key] = metadatum.Value;
+                    }
+                }
+
+                if (_customEscapedMetadata != null)
+                {
+                    foreach (KeyValuePair<string, string> metadatum in _customEscapedMetadata)
+                    {
+                        clonedDictionary[metadatum.Key] = metadatum.Value;
+                    }
+                }
+
                 return clonedDictionary;
             }
 
@@ -917,17 +1036,17 @@ namespace Microsoft.Build.BackEnd
 #if FEATURE_APPDOMAIN
             private IEnumerable<KeyValuePair<string, string>> EnumerateMetadataEager()
             {
-                if (_customEscapedMetadata == null || _customEscapedMetadata.Count == 0)
+                IDictionary merged = ((ITaskItem2)this).CloneCustomMetadataEscaped();
+                if (merged.Count == 0)
                 {
                     return [];
                 }
 
-                var result = new KeyValuePair<string, string>[_customEscapedMetadata.Count];
+                var result = new KeyValuePair<string, string>[merged.Count];
                 int index = 0;
-                foreach (var kvp in _customEscapedMetadata)
+                foreach (KeyValuePair<string, string> kvp in (Dictionary<string, string>)merged)
                 {
-                    var unescaped = new KeyValuePair<string, string>(kvp.Key, EscapingUtilities.UnescapeAll(kvp.Value));
-                    result[index++] = unescaped;
+                    result[index++] = new KeyValuePair<string, string>(kvp.Key, EscapingUtilities.UnescapeAll(kvp.Value));
                 }
 
                 return result;
@@ -936,6 +1055,17 @@ namespace Microsoft.Build.BackEnd
 
             private IEnumerable<KeyValuePair<string, string>> EnumerateMetadataLazy()
             {
+                if (_itemDefinitionEscapedMetadata != null)
+                {
+                    foreach (KeyValuePair<string, string> kvp in _itemDefinitionEscapedMetadata)
+                    {
+                        if (_customEscapedMetadata?.ContainsKey(kvp.Key) != true)
+                        {
+                            yield return new KeyValuePair<string, string>(kvp.Key, EscapingUtilities.UnescapeAll(kvp.Value));
+                        }
+                    }
+                }
+
                 if (_customEscapedMetadata == null)
                 {
                     yield break;
@@ -969,6 +1099,7 @@ namespace Microsoft.Build.BackEnd
                 translator.Translate(ref _escapedItemSpec);
                 translator.Translate(ref _escapedDefiningProject);
                 translator.TranslateDictionary(ref _customEscapedMetadata, MSBuildNameIgnoreCaseComparer.Default);
+                translator.TranslateDictionary(ref _itemDefinitionEscapedMetadata, MSBuildNameIgnoreCaseComparer.Default);
 
                 Assumed.NotNull(_escapedItemSpec);
                 Assumed.NotNull(_customEscapedMetadata);

--- a/src/Shared/TaskParameter.cs
+++ b/src/Shared/TaskParameter.cs
@@ -1125,10 +1125,16 @@ namespace Microsoft.Build.BackEnd
             }
 
             /// <summary>
-            /// Merges item definition metadata into the direct metadata dictionary, expanding it first so that
-            /// the receiver sees resolved values rather than raw expressions. Used when the peer predates
-            /// <see cref="NodePacketTypeExtensions.LazyItemDefinitionMetadataMinVersion"/>.
+            /// Merges item definition metadata into the direct metadata dictionary, leaving values unexpanded.
+            /// Used when the peer predates <see cref="NodePacketTypeExtensions.LazyItemDefinitionMetadataMinVersion"/>
+            /// and only understands a single flattened dictionary.
             /// </summary>
+            /// <remarks>
+            /// Deliberately does not expand. An older peer cannot reproduce in-proc semantics no matter what it is
+            /// sent, and expanding here would hand it resolved values that it then returns as task outputs, making
+            /// those outputs differ from the in-proc ones. Sending the raw values keeps such a peer behaving exactly
+            /// as it does today.
+            /// </remarks>
             private void FlattenItemDefinitionMetadata()
             {
                 if (_itemDefinitionEscapedMetadata == null || _itemDefinitionEscapedMetadata.Count == 0)
@@ -1142,7 +1148,7 @@ namespace Microsoft.Build.BackEnd
                 {
                     if (!_customEscapedMetadata.ContainsKey(metadatum.Key))
                     {
-                        _customEscapedMetadata[metadatum.Key] = ExpandBuiltInMetadata(metadatum.Value);
+                        _customEscapedMetadata[metadatum.Key] = metadatum.Value;
                     }
                 }
 

--- a/src/Shared/TaskParameter.cs
+++ b/src/Shared/TaskParameter.cs
@@ -598,7 +598,8 @@ namespace Microsoft.Build.BackEnd
 
                     // If the source keeps item definition metadata separate and some of it is expandable,
                     // preserve that split so the values stay bound to the item spec on the other side.
-                    if (copyFrom is IItemDefinitionMetadataProvider itemDefinitionSource
+                    if (ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave18_11)
+                        && copyFrom is IItemDefinitionMetadataProvider itemDefinitionSource
                         && itemDefinitionSource.HasExpandableItemDefinitionMetadata)
                     {
                         _customEscapedMetadata = new Dictionary<string, string>(MSBuildNameIgnoreCaseComparer.Default);
@@ -1099,10 +1100,45 @@ namespace Microsoft.Build.BackEnd
                 translator.Translate(ref _escapedItemSpec);
                 translator.Translate(ref _escapedDefiningProject);
                 translator.TranslateDictionary(ref _customEscapedMetadata, MSBuildNameIgnoreCaseComparer.Default);
-                translator.TranslateDictionary(ref _itemDefinitionEscapedMetadata, MSBuildNameIgnoreCaseComparer.Default);
+
+                // Older task hosts do not understand the separate item definition metadata dictionary.
+                // When talking to one, fall back to sending everything flattened, as before.
+                if (translator.NegotiatedPacketVersion >= NodePacketTypeExtensions.LazyItemDefinitionMetadataMinVersion)
+                {
+                    translator.TranslateDictionary(ref _itemDefinitionEscapedMetadata, MSBuildNameIgnoreCaseComparer.Default);
+                }
+                else if (translator.Mode == TranslationDirection.WriteToStream)
+                {
+                    FlattenItemDefinitionMetadata();
+                }
 
                 Assumed.NotNull(_escapedItemSpec);
                 Assumed.NotNull(_customEscapedMetadata);
+            }
+
+            /// <summary>
+            /// Merges item definition metadata into the direct metadata dictionary, expanding it first so that
+            /// the receiver sees resolved values rather than raw expressions. Used when the peer predates
+            /// <see cref="NodePacketTypeExtensions.LazyItemDefinitionMetadataMinVersion"/>.
+            /// </summary>
+            private void FlattenItemDefinitionMetadata()
+            {
+                if (_itemDefinitionEscapedMetadata == null || _itemDefinitionEscapedMetadata.Count == 0)
+                {
+                    return;
+                }
+
+                _customEscapedMetadata ??= new Dictionary<string, string>(MSBuildNameIgnoreCaseComparer.Default);
+
+                foreach (KeyValuePair<string, string> metadatum in _itemDefinitionEscapedMetadata)
+                {
+                    if (!_customEscapedMetadata.ContainsKey(metadatum.Key))
+                    {
+                        _customEscapedMetadata[metadatum.Key] = ExpandBuiltInMetadata(metadatum.Value);
+                    }
+                }
+
+                _itemDefinitionEscapedMetadata = null;
             }
 
             internal static TaskParameterTaskItem FactoryForDeserialization(ITranslator translator)

--- a/src/Shared/TaskParameter.cs
+++ b/src/Shared/TaskParameter.cs
@@ -1099,17 +1099,25 @@ namespace Microsoft.Build.BackEnd
             {
                 translator.Translate(ref _escapedItemSpec);
                 translator.Translate(ref _escapedDefiningProject);
-                translator.TranslateDictionary(ref _customEscapedMetadata, MSBuildNameIgnoreCaseComparer.Default);
 
-                // Older task hosts do not understand the separate item definition metadata dictionary.
-                // When talking to one, fall back to sending everything flattened, as before.
-                if (translator.NegotiatedPacketVersion >= NodePacketTypeExtensions.LazyItemDefinitionMetadataMinVersion)
-                {
-                    translator.TranslateDictionary(ref _itemDefinitionEscapedMetadata, MSBuildNameIgnoreCaseComparer.Default);
-                }
-                else if (translator.Mode == TranslationDirection.WriteToStream)
+                // null = CLR2 (NET35) task host, which does not have this field compiled in.
+                // 0 = CLR4 (NET472) task host, which is the same build and understands the split.
+                // >= LazyItemDefinitionMetadataMinVersion = negotiated .NET task host.
+                bool peerUnderstandsItemDefinitionSplit =
+                    translator.NegotiatedPacketVersion is 0 or >= NodePacketTypeExtensions.LazyItemDefinitionMetadataMinVersion;
+
+                // An older peer only understands a single flattened dictionary. Fold item definition metadata
+                // into it, expanding first so the peer still observes resolved values, before anything is written.
+                if (!peerUnderstandsItemDefinitionSplit && translator.Mode == TranslationDirection.WriteToStream)
                 {
                     FlattenItemDefinitionMetadata();
+                }
+
+                translator.TranslateDictionary(ref _customEscapedMetadata, MSBuildNameIgnoreCaseComparer.Default);
+
+                if (peerUnderstandsItemDefinitionSplit)
+                {
+                    translator.TranslateDictionary(ref _itemDefinitionEscapedMetadata, MSBuildNameIgnoreCaseComparer.Default);
                 }
 
                 Assumed.NotNull(_escapedItemSpec);

--- a/src/Shared/TaskParameter.cs
+++ b/src/Shared/TaskParameter.cs
@@ -596,36 +596,29 @@ namespace Microsoft.Build.BackEnd
                     _escapedItemSpec = copyFromAsITaskItem2.EvaluatedIncludeEscaped;
                     _escapedDefiningProject = copyFromAsITaskItem2.GetMetadataValueEscaped(ItemSpecModifiers.DefiningProjectFullPath);
 
-                    // If the source keeps item definition metadata separate and some of it is expandable,
-                    // preserve that split so the values stay bound to the item spec on the other side.
+                    IDictionary nonGenericEscapedMetadata = copyFromAsITaskItem2.CloneCustomMetadataEscaped();
+                    _customEscapedMetadata = nonGenericEscapedMetadata as Dictionary<string, string>;
+
+                    if (_customEscapedMetadata is null)
+                    {
+                        _customEscapedMetadata = new Dictionary<string, string>(MSBuildNameIgnoreCaseComparer.Default);
+                        foreach (DictionaryEntry entry in nonGenericEscapedMetadata)
+                        {
+                            _customEscapedMetadata[(string)entry.Key] = (string)entry.Value ?? string.Empty;
+                        }
+                    }
+
+                    // The flattened copy above is exact for every value that is already expanded. Only values that
+                    // are expanded on read need to be carried separately, so that they stay bound to the item spec
+                    // instead of freezing at the process boundary. Usually there are none.
                     if (ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave18_11)
                         && copyFrom is IItemDefinitionMetadataProvider itemDefinitionSource
                         && itemDefinitionSource.HasExpandableItemDefinitionMetadata)
                     {
-                        _customEscapedMetadata = new Dictionary<string, string>(MSBuildNameIgnoreCaseComparer.Default);
-                        foreach (KeyValuePair<string, string> metadatum in itemDefinitionSource.EnumerateDirectMetadataEscaped())
+                        foreach (KeyValuePair<string, string> metadatum in itemDefinitionSource.EnumerateExpandableItemDefinitionMetadataEscaped())
                         {
-                            _customEscapedMetadata[metadatum.Key] = metadatum.Value ?? string.Empty;
-                        }
-
-                        _itemDefinitionEscapedMetadata = new Dictionary<string, string>(MSBuildNameIgnoreCaseComparer.Default);
-                        foreach (KeyValuePair<string, string> metadatum in itemDefinitionSource.EnumerateItemDefinitionMetadataEscaped())
-                        {
+                            _itemDefinitionEscapedMetadata ??= new Dictionary<string, string>(MSBuildNameIgnoreCaseComparer.Default);
                             _itemDefinitionEscapedMetadata[metadatum.Key] = metadatum.Value ?? string.Empty;
-                        }
-                    }
-                    else
-                    {
-                        IDictionary nonGenericEscapedMetadata = copyFromAsITaskItem2.CloneCustomMetadataEscaped();
-                        _customEscapedMetadata = nonGenericEscapedMetadata as Dictionary<string, string>;
-
-                        if (_customEscapedMetadata is null)
-                        {
-                            _customEscapedMetadata = new Dictionary<string, string>(MSBuildNameIgnoreCaseComparer.Default);
-                            foreach (DictionaryEntry entry in nonGenericEscapedMetadata)
-                            {
-                                _customEscapedMetadata[(string)entry.Key] = (string)entry.Value ?? string.Empty;
-                            }
                         }
                     }
                 }
@@ -716,23 +709,7 @@ namespace Microsoft.Build.BackEnd
             {
                 get
                 {
-                    List<string> metadataNames = new List<string>();
-
-                    if (_itemDefinitionEscapedMetadata != null)
-                    {
-                        foreach (string name in _itemDefinitionEscapedMetadata.Keys)
-                        {
-                            if (_customEscapedMetadata?.ContainsKey(name) != true)
-                            {
-                                metadataNames.Add(name);
-                            }
-                        }
-                    }
-
-                    if (_customEscapedMetadata != null)
-                    {
-                        metadataNames.AddRange(_customEscapedMetadata.Keys);
-                    }
+                    List<string> metadataNames = (_customEscapedMetadata == null) ? new List<string>() : new List<string>(_customEscapedMetadata.Keys);
 
                     foreach (string name in ItemSpecModifiers.All)
                     {
@@ -752,7 +729,7 @@ namespace Microsoft.Build.BackEnd
             {
                 get
                 {
-                    int count = ((ITaskItem2)this).CloneCustomMetadataEscaped().Count;
+                    int count = (_customEscapedMetadata == null) ? 0 : _customEscapedMetadata.Count;
                     return count + ItemSpecModifiers.All.Length;
                 }
             }
@@ -804,6 +781,9 @@ namespace Microsoft.Build.BackEnd
                 _customEscapedMetadata ??= new Dictionary<string, string>(MSBuildNameIgnoreCaseComparer.Default);
 
                 _customEscapedMetadata[metadataName] = metadataValue ?? String.Empty;
+
+                // An explicitly set value wins over the item definition it came from, and is never expanded.
+                _itemDefinitionEscapedMetadata?.Remove(metadataName);
             }
 
             /// <summary>
@@ -923,20 +903,18 @@ namespace Microsoft.Build.BackEnd
                     return ItemSpecModifiers.GetItemSpecModifier(_escapedItemSpec, modifierKind, null, _escapedDefiningProject, ref _cachedModifiers);
                 }
 
+                // Values that are expanded on read are held separately and take priority: the flattened copy holds
+                // their raw form. Anything masked by metadata set directly on the item was excluded when the item
+                // was captured, so anything present here is genuinely an unexpanded item definition value.
                 string metadataValue = null;
-                if (_customEscapedMetadata?.TryGetValue(metadataName, out metadataValue) == true)
-                {
-                    return metadataValue ?? string.Empty;
-                }
-
-                // Item definition metadata is stored unexpanded so that built-in metadata references stay
-                // bound to the current item spec. Expand on read, exactly as the in-proc item does.
                 if (_itemDefinitionEscapedMetadata?.TryGetValue(metadataName, out metadataValue) == true)
                 {
                     return ExpandBuiltInMetadata(metadataValue) ?? string.Empty;
                 }
 
-                return string.Empty;
+                _customEscapedMetadata?.TryGetValue(metadataName, out metadataValue);
+
+                return metadataValue ?? string.Empty;
             }
 
             /// <summary>
@@ -998,27 +976,9 @@ namespace Microsoft.Build.BackEnd
             /// </summary>
             IDictionary ITaskItem2.CloneCustomMetadataEscaped()
             {
-                // Return the unexpanded form. The engine flattens task outputs by copying these values
-                // straight into direct metadata, and it does the same for in-proc items, so expanding here
-                // would make out-of-proc task outputs differ from in-proc ones.
-                Dictionary<string, string> clonedDictionary = new Dictionary<string, string>(MSBuildNameIgnoreCaseComparer.Default);
-
-                if (_itemDefinitionEscapedMetadata != null)
-                {
-                    foreach (KeyValuePair<string, string> metadatum in _itemDefinitionEscapedMetadata)
-                    {
-                        clonedDictionary[metadatum.Key] = metadatum.Value;
-                    }
-                }
-
-                if (_customEscapedMetadata != null)
-                {
-                    foreach (KeyValuePair<string, string> metadatum in _customEscapedMetadata)
-                    {
-                        clonedDictionary[metadatum.Key] = metadatum.Value;
-                    }
-                }
-
+                // The backing dictionary already holds every value in its raw, unexpanded form, which is exactly
+                // what the engine flattens into task outputs for an in-proc item too.
+                IDictionary clonedDictionary = new Dictionary<string, string>(_customEscapedMetadata);
                 return clonedDictionary;
             }
 
@@ -1037,17 +997,17 @@ namespace Microsoft.Build.BackEnd
 #if FEATURE_APPDOMAIN
             private IEnumerable<KeyValuePair<string, string>> EnumerateMetadataEager()
             {
-                IDictionary merged = ((ITaskItem2)this).CloneCustomMetadataEscaped();
-                if (merged.Count == 0)
+                if (_customEscapedMetadata == null || _customEscapedMetadata.Count == 0)
                 {
                     return [];
                 }
 
-                var result = new KeyValuePair<string, string>[merged.Count];
+                var result = new KeyValuePair<string, string>[_customEscapedMetadata.Count];
                 int index = 0;
-                foreach (KeyValuePair<string, string> kvp in (Dictionary<string, string>)merged)
+                foreach (var kvp in _customEscapedMetadata)
                 {
-                    result[index++] = new KeyValuePair<string, string>(kvp.Key, EscapingUtilities.UnescapeAll(kvp.Value));
+                    var unescaped = new KeyValuePair<string, string>(kvp.Key, EscapingUtilities.UnescapeAll(kvp.Value));
+                    result[index++] = unescaped;
                 }
 
                 return result;
@@ -1056,17 +1016,6 @@ namespace Microsoft.Build.BackEnd
 
             private IEnumerable<KeyValuePair<string, string>> EnumerateMetadataLazy()
             {
-                if (_itemDefinitionEscapedMetadata != null)
-                {
-                    foreach (KeyValuePair<string, string> kvp in _itemDefinitionEscapedMetadata)
-                    {
-                        if (_customEscapedMetadata?.ContainsKey(kvp.Key) != true)
-                        {
-                            yield return new KeyValuePair<string, string>(kvp.Key, EscapingUtilities.UnescapeAll(kvp.Value));
-                        }
-                    }
-                }
-
                 if (_customEscapedMetadata == null)
                 {
                     yield break;
@@ -1099,60 +1048,21 @@ namespace Microsoft.Build.BackEnd
             {
                 translator.Translate(ref _escapedItemSpec);
                 translator.Translate(ref _escapedDefiningProject);
-
-                // null = CLR2 (NET35) task host, which does not have this field compiled in.
-                // 0 = CLR4 (NET472) task host, which is the same build and understands the split.
-                // >= LazyItemDefinitionMetadataMinVersion = negotiated .NET task host.
-                bool peerUnderstandsItemDefinitionSplit =
-                    translator.NegotiatedPacketVersion is 0 or >= NodePacketTypeExtensions.LazyItemDefinitionMetadataMinVersion;
-
-                // An older peer only understands a single flattened dictionary. Fold item definition metadata
-                // into it, expanding first so the peer still observes resolved values, before anything is written.
-                if (!peerUnderstandsItemDefinitionSplit && translator.Mode == TranslationDirection.WriteToStream)
-                {
-                    FlattenItemDefinitionMetadata();
-                }
-
                 translator.TranslateDictionary(ref _customEscapedMetadata, MSBuildNameIgnoreCaseComparer.Default);
 
-                if (peerUnderstandsItemDefinitionSplit)
+                // null = CLR2 (NET35) task host, which does not have this field compiled in.
+                // 0 = CLR4 (NET472) task host, which is the same build and understands it.
+                // >= LazyItemDefinitionMetadataMinVersion = negotiated .NET task host.
+                //
+                // For anything else the field is simply not sent. The dictionary above already carries every value
+                // in its raw form, which is exactly what such a peer receives today, so it is left unchanged.
+                if (translator.NegotiatedPacketVersion is 0 or >= NodePacketTypeExtensions.LazyItemDefinitionMetadataMinVersion)
                 {
                     translator.TranslateDictionary(ref _itemDefinitionEscapedMetadata, MSBuildNameIgnoreCaseComparer.Default);
                 }
 
                 Assumed.NotNull(_escapedItemSpec);
                 Assumed.NotNull(_customEscapedMetadata);
-            }
-
-            /// <summary>
-            /// Merges item definition metadata into the direct metadata dictionary, leaving values unexpanded.
-            /// Used when the peer predates <see cref="NodePacketTypeExtensions.LazyItemDefinitionMetadataMinVersion"/>
-            /// and only understands a single flattened dictionary.
-            /// </summary>
-            /// <remarks>
-            /// Deliberately does not expand. An older peer cannot reproduce in-proc semantics no matter what it is
-            /// sent, and expanding here would hand it resolved values that it then returns as task outputs, making
-            /// those outputs differ from the in-proc ones. Sending the raw values keeps such a peer behaving exactly
-            /// as it does today.
-            /// </remarks>
-            private void FlattenItemDefinitionMetadata()
-            {
-                if (_itemDefinitionEscapedMetadata == null || _itemDefinitionEscapedMetadata.Count == 0)
-                {
-                    return;
-                }
-
-                _customEscapedMetadata ??= new Dictionary<string, string>(MSBuildNameIgnoreCaseComparer.Default);
-
-                foreach (KeyValuePair<string, string> metadatum in _itemDefinitionEscapedMetadata)
-                {
-                    if (!_customEscapedMetadata.ContainsKey(metadatum.Key))
-                    {
-                        _customEscapedMetadata[metadatum.Key] = metadatum.Value;
-                    }
-                }
-
-                _itemDefinitionEscapedMetadata = null;
             }
 
             internal static TaskParameterTaskItem FactoryForDeserialization(ITranslator translator)


### PR DESCRIPTION
Fixes #14763.

### Goal

Align out-of-proc task execution with **current** in-proc behaviour. In-proc behaviour is treated as the reference and is not changed by this PR.

### Background

Item definition metadata that references built-in metadata — `<OutputName>%(Filename)</OutputName>` — is stored unexpanded and expanded on read, so it stays bound to the item spec it derives from.

This is the only expression form that survives evaluation. Properties and custom metadata references are baked during evaluation, so they cross a process boundary already resolved and are unaffected:

| item definition value | when it is resolved |
| --- | --- |
| `$(Configuration)_foo` | evaluation |
| `%(SomeCustomMetadata)_foo` | evaluation |
| `%(Filename)_foo` | **on read**, against the item's own spec |

### What was broken

Marshalling an item to a task host collapsed the two kinds of metadata into one dictionary. The distinction was gone, so the value could no longer be expanded and the task received the raw text.

```mermaid
flowchart LR
  subgraph ENGINE["ENGINE — ProjectItemInstance.TaskItem"]
    direction TB
    DM["<b>direct metadata</b><br/>OutputFileExtension = .cs"]
    IDM["<b>item definition metadata</b><br/>OutputName = %(Filename)<br/><i>stored unexpanded</i>"]
    READ["GetMetadata OutputName<br/>expands against ItemSpec<br/><b>hello</b> ✓"]
    IDM --> READ
  end

  FLAT["<b>CloneCustomMetadataEscaped</b><br/>both kinds collapsed into a<br/>single dictionary —<br/><i>the distinction is lost here</i>"]

  subgraph HOST["TASK HOST — TaskParameterTaskItem"]
    direction TB
    ONE["<b>one metadata dictionary</b><br/>OutputFileExtension = .cs<br/>OutputName = %(Filename)<br/><i>no notion of expand-on-read</i>"]
    READ2["GetMetadata OutputName<br/>returned verbatim<br/><b>%(Filename)</b> ✗"]
    ONE --> READ2
  end

  DM --> FLAT
  IDM --> FLAT
  FLAT -- wire --> ONE

  style READ fill:#1f7a3d,color:#fff
  style READ2 fill:#a01b1b,color:#fff
  style FLAT fill:#8a6d00,color:#fff
```

### How it is fixed

The flattened copy is kept exactly as before — it is already correct for every value that is stored expanded. Alongside it, only the values that are expanded on read are carried separately, so the receiver can still tell them apart. That is normally nothing at all, and otherwise a small handful.

```mermaid
flowchart LR
  subgraph ENGINE["ENGINE — ProjectItemInstance.TaskItem"]
    direction TB
    DM2["<b>direct metadata</b><br/>OutputFileExtension = .cs"]
    IDM2["<b>item definition metadata</b><br/>OutputName = %(Filename)<br/><i>stored unexpanded</i>"]
  end

  COPY["<b>flattened copy</b><br/><i>unchanged — already correct for<br/>values stored expanded</i>"]
  SUBSET["<b>expandable subset</b> (new)<br/><i>only values expanded on read</i><br/>OutputName = %(Filename)"]

  subgraph HOST["TASK HOST — TaskParameterTaskItem"]
    direction TB
    CUST["_customEscapedMetadata<br/>OutputFileExtension = .cs<br/>OutputName = %(Filename)"]
    IDEF["_itemDefinitionEscapedMetadata<br/>OutputName = %(Filename)"]
    READ3["GetMetadata OutputName<br/>subset first, then expand<br/>against own ItemSpec<br/><b>hello</b> ✓"]
    IDEF --> READ3
    CUST -.->|"fallback if not in subset"| READ3
  end

  DM2 --> COPY
  IDM2 --> COPY
  IDM2 --> SUBSET
  COPY -- wire --> CUST
  SUBSET -- "wire — only if peer<br/>understands it" --> IDEF

  style READ3 fill:#1f7a3d,color:#fff
  style SUBSET fill:#1f4e79,color:#fff
  style COPY fill:#4a4a4a,color:#fff
```

Reads consult the small set first and fall back to the flattened copy. `SetMetadata` writes to the flattened copy and drops the name from the small set, so an explicitly set value wins and is never expanded — same precedence as in-proc.

The values handed back to the engine stay unexpanded, so task outputs flatten exactly as they do for an in-proc item. That is what keeps downstream items identical rather than making out-of-proc *more* resolved than in-proc.

Nothing about item definitions or the expander crosses the wire. The expansion needed is `%(Name)` resolved from the item spec, and the task host already has the item spec.

### Behaviour

Measured with a task that reports what it observes, run both in-proc and under `TaskHostFactory`:

| scenario | in-proc (reference) | before | after |
| --- | --- | --- | --- |
| task reads metadata | `hello` | `%(Filename)` | `hello` |
| downstream after task output | `%(Filename)` | `%(Filename)` | `%(Filename)` |
| after the task reassigns ItemSpec | `renamed` | `%(Filename)` | `renamed` |
| two tasks sharing an item | `hello` | `%(Filename)` | `hello` |

All four now match in-proc. The in-proc column is unchanged.

### Compatibility

Gated on change wave **18.11**. Opting out via `MSBUILDDISABLEFEATURESFROMVERSION=18.11` restores the previous behaviour, verified by test and by re-running the scenarios above with the wave disabled.

`PacketVersion` goes to 6, with `LazyItemDefinitionMetadataMinVersion`. The extra field is sent only to a peer that understands it; everyone else receives the flattened copy alone, which is byte-for-byte what they receive today.

This matters most for `Runtime="NET"`, where the task host's MSBuild is resolved from the SDK and can genuinely be an older build:

| task host comes from | before | after |
| --- | --- | --- |
| SDK 10.0.111 (MSBuild 18.0) | `%(Filename)` → `%(Filename)` | unchanged |
| SDK 10.0.400-preview (MSBuild 18.9) | `%(Filename)` → `%(Filename)` | unchanged |
| matching build | `%(Filename)` → `%(Filename)` | `hello` → `renamed` |

A CLR4 task host negotiates version 0 and is always the same build, so it is treated as supporting the field, following the existing `is 0 or >= N` convention in `TaskHostConfiguration`. The CLR2 task host negotiates `null`, receives nothing extra, and compiles its own separate copy of this type — no file under `src/MSBuildTaskHost/` is touched.

### Performance

Interleaved A/B runs of two equally configured builds, 20,000 items with 21 item definition metadata each, all marshalled to a task host:

| build | min | median |
| --- | --- | --- |
| `main` | 1400 ms | 1887 ms |
| this PR | 1473 ms | 1948 ms |

Within the noise of the machine, where `main` alone ranged 1400-3260 ms.

The dictionary the source already produces is still handed over by reference, and each item definition computes its expandable subset once rather than every item of that type rescanning the shared definition — the check runs per item on the marshalling path and was already used by `CopyMetadataTo`.

### Testing

`TaskHostFactory_Tests` covers both routings with and without an `ItemSpec` reassignment, asserting the task really ran out-of-proc first so it cannot pass vacuously, plus a wave opt-out test. A round-trip test pins the wire behaviour at each negotiated packet version: `null` (CLR2), `0` (CLR4), `5` (older .NET task host), `6` (current).

Suites green: `TaskHostFactory_Tests` 18/18, `TaskParameter` 131/131, `TaskItem_Tests` 13/13, `TaskHostConfiguration` 16/16, `TaskHostTaskComplete` 10/10.

Full `Microsoft.Build.Engine.UnitTests` run: 11 failures, the same 11 that fail on a clean build of `main` on this machine — Unix-specific path tests, solution parser tests, and several 30s timeouts — so pre-existing and environmental.

### Known gaps, deliberately not addressed here

- `ExpandBuiltInMetadata` handles unqualified `%(Name)` only, not `%(Type.Name)`. Item definitions in practice use the unqualified form, but this is incomplete.
- Task outputs flatten item definition metadata unexpanded, so downstream consumers see `%(Filename)`. That is in-proc behaviour and this PR deliberately reproduces it rather than changing it. `TaskExecutionHost.GatherTaskItemOutputs` is the same code reverted in #13245 for breaking consumers, so changing it is a separate decision.
- `TaskItem.TranslateWithInterning`, used by `TargetResult` for cross-node target outputs, flattens the same way. Items returned through the `MSBuild` task's `TargetOutputs` therefore still surface `%(Filename)`, on a single node with no task host involved. Unchanged by this PR.

