### PR TITLE
Expand built-in metadata references in the task host

### DIFF
--- a/src/Build.UnitTests/BackEnd/ItemDefinitionMetadataInTaskHost_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/ItemDefinitionMetadataInTaskHost_Tests.cs
@@ -1,0 +1,109 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Microsoft.Build.Execution;
+using Microsoft.Build.UnitTests;
+using Shouldly;
+using Xunit;
+
+#nullable disable
+
+namespace Microsoft.Build.Engine.UnitTests.BackEnd
+{
+    /// <summary>
+    /// Item definition metadata referencing built-in metadata, such as <c>%(Filename)</c>, is stored unexpanded
+    /// and substituted when the metadata is read. These tests assert that a task observes the same value whether
+    /// it runs in-proc or in a task host.
+    /// Regression tests for https://github.com/dotnet/msbuild/issues/14763.
+    /// </summary>
+    public sealed class ItemDefinitionMetadataInTaskHost_Tests
+    {
+        private static string AssemblyLocation { get; } =
+            typeof(ItemDefinitionMetadataInTaskHost_Tests).Assembly.Location
+            ?? Path.Combine(AppContext.BaseDirectory, "Microsoft.Build.Engine.UnitTests.dll");
+
+        private readonly ITestOutputHelper _output;
+
+        public ItemDefinitionMetadataInTaskHost_Tests(ITestOutputHelper output) => _output = output;
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void MetadataReferencingBuiltInMetadataIsExpandedForTheTask(bool useTaskHost)
+        {
+            Observe("%(Filename)", useTaskHost).ShouldBe("hello");
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void MetadataReferencingBuiltInMetadataFollowsReassignedItemSpec(bool useTaskHost)
+        {
+            Observe("%(Filename)", useTaskHost, newItemSpec: @"other\renamed.txt").ShouldBe("renamed");
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void MetadataOverriddenOnTheItemWinsOverTheItemDefinition(bool useTaskHost)
+        {
+            Observe("%(Filename)", useTaskHost, itemOverride: "explicit").ShouldBe("explicit");
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void EscapedMetadataReferenceIsNotExpanded(bool useTaskHost)
+        {
+            Observe("%25(Filename)", useTaskHost).ShouldBe("%(Filename)");
+        }
+
+        /// <summary>
+        /// Runs a task against an item whose definition carries <paramref name="definitionValue"/> and returns the
+        /// value the task itself observed, having asserted the task ran where the test intended.
+        /// </summary>
+        private string Observe(string definitionValue, bool useTaskHost, string newItemSpec = null, string itemOverride = null)
+        {
+            using TestEnvironment env = TestEnvironment.Create(_output);
+
+            string project = $"""
+                <Project>
+                  <UsingTask TaskName="MetadataObservationTask" AssemblyFile="{AssemblyLocation}"{(useTaskHost ? @" TaskFactory=""TaskHostFactory""" : string.Empty)} />
+                  <ItemDefinitionGroup>
+                    <Thing>
+                      <NameMeta>{definitionValue}</NameMeta>
+                    </Thing>
+                  </ItemDefinitionGroup>
+                  <ItemGroup>
+                    <Thing Include="folder\hello.txt">
+                      {(itemOverride is null ? string.Empty : $"<NameMeta>{itemOverride}</NameMeta>")}
+                    </Thing>
+                  </ItemGroup>
+                  <Target Name="Observe">
+                    <MetadataObservationTask Items="@(Thing)" MetadataName="NameMeta" NewItemSpec="{newItemSpec}">
+                      <Output PropertyName="ObservedValue" TaskParameter="ObservedValue" />
+                      <Output PropertyName="TaskProcessId" TaskParameter="TaskProcessId" />
+                    </MetadataObservationTask>
+                  </Target>
+                </Project>
+                """;
+
+            ProjectInstance projectInstance = new(env.CreateFile("test.proj", project).Path);
+
+            BuildResult result = BuildManager.DefaultBuildManager.Build(
+                new BuildParameters { EnableNodeReuse = false },
+                new BuildRequestData(projectInstance, targetsToBuild: ["Observe"]));
+
+            result.OverallResult.ShouldBe(BuildResultCode.Success);
+
+            int taskProcessId = int.Parse(projectInstance.GetPropertyValue("TaskProcessId"));
+            bool ranOutOfProc = taskProcessId != Process.GetCurrentProcess().Id;
+            ranOutOfProc.ShouldBe(useTaskHost, $"the task was expected to run {(useTaskHost ? "in a task host" : "in-proc")}");
+
+            return projectInstance.GetPropertyValue("ObservedValue");
+        }
+    }
+}

--- a/src/Build.UnitTests/BackEnd/ItemDefinitionMetadataInTaskHost_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/ItemDefinitionMetadataInTaskHost_Tests.cs
@@ -14,9 +14,9 @@ using Xunit;
 namespace Microsoft.Build.Engine.UnitTests.BackEnd
 {
     /// <summary>
-    /// Item definition metadata referencing built-in metadata, such as <c>%(Filename)</c>, is stored unexpanded
-    /// and substituted when the metadata is read. These tests assert that a task observes the same value whether
-    /// it runs in-proc or in a task host.
+    /// Metadata inherited from an item definition, such as <c>%(Filename)</c>, is stored unexpanded and expanded
+    /// when it is read. These tests assert that a task observes the same value whether it runs in-proc or in a
+    /// task host.
     /// Regression tests for https://github.com/dotnet/msbuild/issues/14763.
     /// </summary>
     public sealed class ItemDefinitionMetadataInTaskHost_Tests

--- a/src/Build.UnitTests/BackEnd/MetadataObservationTask.cs
+++ b/src/Build.UnitTests/BackEnd/MetadataObservationTask.cs
@@ -1,0 +1,57 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+#nullable disable
+
+namespace Microsoft.Build.UnitTests
+{
+    /// <summary>
+    /// Reports the value of a metadata name as the task itself observes it, plus the id of the process the
+    /// task ran in, so tests can tell an in-proc execution apart from a task host one.
+    /// Optionally reassigns ItemSpec first, to exercise metadata that derives from it.
+    /// </summary>
+    public class MetadataObservationTask : Task
+    {
+        [Required]
+        public ITaskItem[] Items { get; set; }
+
+        [Required]
+        public string MetadataName { get; set; }
+
+        public string NewItemSpec { get; set; }
+
+        [Output]
+        public string ObservedValue { get; set; }
+
+        [Output]
+        public int TaskProcessId { get; set; }
+
+        public override bool Execute()
+        {
+            TaskProcessId = Process.GetCurrentProcess().Id;
+
+            if (Items.Length > 0)
+            {
+                ITaskItem item = Items[0];
+
+                if (!string.IsNullOrEmpty(NewItemSpec))
+                {
+                    item.ItemSpec = NewItemSpec;
+                }
+
+                ObservedValue = item.GetMetadata(MetadataName);
+            }
+            else
+            {
+                ObservedValue = string.Empty;
+            }
+
+            return true;
+        }
+    }
+}
+

--- a/src/Framework.UnitTests/BuiltInMetadataExpander_Tests.cs
+++ b/src/Framework.UnitTests/BuiltInMetadataExpander_Tests.cs
@@ -127,5 +127,31 @@ namespace Microsoft.Build.UnitTests
         [InlineData("%(%(Filename)", "%(hello")]
         public void FindsAReferenceNestedInsideOneThatDoesNotResolve(string value, string expected)
             => Expand(value).ShouldBe(expected);
+
+        /// <summary>
+        /// The scan looks for '%' alone and tests the next character, because a single character search
+        /// vectorizes. These cases pin that it still agrees with searching for "%(" directly.
+        /// </summary>
+        [Theory]
+        [InlineData("", -1)]
+        [InlineData("%", -1)]
+        [InlineData("no marker here", -1)]
+        [InlineData("100% done", -1)]
+        [InlineData("50%", -1)]
+        [InlineData("%(", 0)]
+        [InlineData("a%(", 1)]
+        [InlineData("%x%(", 2)]
+        [InlineData("%%%(", 2)]
+        [InlineData("%a%b%(c", 4)]
+        [InlineData("trailing%", -1)]
+        public void FindsTheMetadataMarker(string value, int expected)
+            => BuiltInMetadataExpander.IndexOfMetadataMarker(value, 0).ShouldBe(expected);
+
+        [Theory]
+        [InlineData("%(Filename)%(Extension)", 11, 11)]
+        [InlineData("%(Filename)plain", 11, -1)]
+        [InlineData("abc", 3, -1)]
+        public void FindsTheMetadataMarkerFromAStartIndex(string value, int startIndex, int expected)
+            => BuiltInMetadataExpander.IndexOfMetadataMarker(value, startIndex).ShouldBe(expected);
     }
 }

--- a/src/Framework.UnitTests/BuiltInMetadataExpander_Tests.cs
+++ b/src/Framework.UnitTests/BuiltInMetadataExpander_Tests.cs
@@ -1,0 +1,131 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.IO;
+using Microsoft.Build.Framework;
+using Shouldly;
+using Xunit;
+
+#nullable enable
+
+namespace Microsoft.Build.UnitTests
+{
+    /// <summary>
+    /// Tests for <see cref="BuiltInMetadataExpander"/>, which expands references such as <c>%(Filename)</c> when
+    /// an item is read after it crossed a process boundary.
+    /// </summary>
+    public class BuiltInMetadataExpander_Tests
+    {
+        private static readonly string s_sep = Path.DirectorySeparatorChar.ToString();
+        private static readonly string s_itemSpec = $"folder{Path.DirectorySeparatorChar}hello.txt";
+
+        private static string? Expand(string? value, string? recursiveDir = null, string? itemSpec = null)
+        {
+            ItemSpecModifiers.Cache cache = default;
+
+            return BuiltInMetadataExpander.Expand(
+                value,
+                itemSpec ?? s_itemSpec,
+                escapedDefiningProject: "project.proj",
+                escapedRecursiveDir: recursiveDir,
+                ref cache);
+        }
+
+        [Theory]
+        [InlineData("%(Filename)", "hello")]
+        [InlineData("%(Extension)", ".txt")]
+        [InlineData("%(Identity)", @"folder\hello.txt")]
+        [InlineData("a%(Filename)b", "ahellob")]
+        [InlineData("%(Filename)%(Extension)", "hello.txt")]
+        [InlineData("%(Filename)%(Filename)", "hellohello")]
+        [InlineData("%(Filename)trailing", "hellotrailing")]
+        [InlineData("leading%(Filename)", "leadinghello")]
+        public void ExpandsBuiltInMetadata(string value, string expected)
+            => Expand(value).ShouldBe(expected.Replace(@"\", s_sep));
+
+        [Theory]
+        [InlineData("%( Filename )", "hello")]
+        [InlineData("%(  Filename  )", "hello")]
+        [InlineData("%(FILENAME)", "hello")]
+        [InlineData("%(filename)", "hello")]
+        public void AcceptsWhitespaceAndAnyCasing(string value, string expected)
+            => Expand(value).ShouldBe(expected);
+
+        [Theory]
+        // No reference at all.
+        [InlineData("")]
+        [InlineData("plain text")]
+        [InlineData("100% done")]
+        // Not a well formed reference.
+        [InlineData("%(Filename")]
+        [InlineData("a%(")]
+        [InlineData("%()")]
+        [InlineData("%(  )")]
+        [InlineData("%((Filename)")]
+        [InlineData("%(Fi lename)")]
+        // A name that is not built-in metadata. Evaluation expands custom metadata, so a value that reaches
+        // this point with one left in it is text.
+        [InlineData("%(NotAModifier)")]
+        public void LeavesEverythingElseAsItIs(string value)
+            => Expand(value).ShouldBe(value);
+
+        [Fact]
+        public void ReturnsNullForNull()
+            => Expand(null).ShouldBeNull();
+
+        /// <summary>
+        /// A value with nothing to expand must come back as the same instance, not a copy. Metadata is read on
+        /// hot paths, and most values have no reference in them.
+        /// </summary>
+        [Fact]
+        public void DoesNotAllocateWhenThereIsNothingToExpand()
+        {
+            string value = "no reference here";
+
+            Expand(value).ShouldBeSameAs(value);
+            Expand("%(NotAModifier)").ShouldBeSameAs("%(NotAModifier)");
+        }
+
+        /// <summary>
+        /// RecursiveDir comes from the wildcard the item was expanded from, so it is supplied rather than derived.
+        /// </summary>
+        [Theory]
+        [InlineData(@"sub1\sub2\", @"out\sub1\sub2\hello.txt")]
+        [InlineData("", @"out\hello.txt")]
+        [InlineData(null, @"out\hello.txt")]
+        public void UsesTheSuppliedRecursiveDir(string? recursiveDir, string expected)
+            => Expand(@"out\%(RecursiveDir)%(Filename)%(Extension)".Replace(@"\", s_sep), recursiveDir?.Replace(@"\", s_sep))
+                .ShouldBe(expected.Replace(@"\", s_sep));
+
+        /// <summary>
+        /// The expander derives from the item spec it is given, so the same value gives a different result for a
+        /// different item. This is why metadata is expanded on each read instead of one time.
+        /// </summary>
+        [Fact]
+        public void DerivesFromTheGivenItemSpec()
+        {
+            Expand("%(Filename)", itemSpec: $"other{s_sep}renamed.md").ShouldBe("renamed");
+            Expand("%(Extension)", itemSpec: $"other{s_sep}renamed.md").ShouldBe(".md");
+        }
+
+        /// <summary>
+        /// A reference that is not the first thing in the value must still be found after an earlier reference
+        /// failed to parse.
+        /// </summary>
+        [Theory]
+        [InlineData("%(NotAModifier)%(Filename)", "%(NotAModifier)hello")]
+        [InlineData("%(Filename)%(NotAModifier)", "hello%(NotAModifier)")]
+        [InlineData("%(Fi lename)%(Filename)", "%(Fi lename)hello")]
+        public void FindsLaterReferencesAfterOneThatDoesNotResolve(string value, string expected)
+            => Expand(value).ShouldBe(expected);
+
+        /// <summary>
+        /// An unterminated reference must not hide a well formed one that follows it inside the same text.
+        /// </summary>
+        [Theory]
+        [InlineData("%(foo%(Filename)", "%(foohello")]
+        [InlineData("%(%(Filename)", "%(hello")]
+        public void FindsAReferenceNestedInsideOneThatDoesNotResolve(string value, string expected)
+            => Expand(value).ShouldBe(expected);
+    }
+}

--- a/src/Framework/BuiltInMetadataExpander.cs
+++ b/src/Framework/BuiltInMetadataExpander.cs
@@ -7,26 +7,23 @@ using Microsoft.NET.StringTools;
 namespace Microsoft.Build.Framework;
 
 /// <summary>
-///  Substitutes built-in metadata references, such as <c>%(Filename)</c>, with the values they denote for a
-///  given item.
+///  Expands built-in metadata references, such as <c>%(Filename)</c>, against an item.
 /// </summary>
 /// <remarks>
-///  <para>
-///   Item definition metadata may reference built-in metadata. Such values are stored unexpanded so that they
-///   follow the item they are read from, and are substituted whenever the metadata is read.
-///  </para>
-///  <para>
-///   This is a deliberately minimal substitute for the evaluation expander, which also handles properties, item
-///   vectors, custom metadata, transforms and truncation. Built-in metadata references are the only expression
-///   form that survives evaluation unexpanded. It lives here because the evaluation expander is internal to
-///   <c>Microsoft.Build</c>, while this is needed by <c>MSBuild</c> and <c>Microsoft.Build.Tasks</c> as well.
-///  </para>
+///  A deliberately minimal stand-in for the evaluation expander, which also handles properties, item vectors,
+///  custom metadata, transforms and truncation. Built-in metadata references are the only expression form that
+///  survives evaluation unexpanded, so they are the only one that can reach a task host still unexpanded. This
+///  lives in Framework because the evaluation expander is internal to <c>Microsoft.Build</c>, while this is needed
+///  by <c>MSBuild</c> and <c>Microsoft.Build.Tasks</c> too.
+///
+///  Keep in step with <c>Expander.ExpandIntoStringLeaveEscaped</c> under <c>ExpanderOptions.ExpandBuiltInMetadata</c>,
+///  which is what <c>ProjectItemInstance.TaskItem.GetMetadataEscaped</c> uses for the same job in-proc.
 /// </remarks>
 internal static class BuiltInMetadataExpander
 {
     /// <summary>
     ///  Expands every built-in metadata reference in <paramref name="escapedValue"/> against the given item.
-    ///  Anything else, including a reference that cannot be satisfied, is left untouched.
+    ///  Anything else, including a reference that cannot be satisfied, is left as it is.
     /// </summary>
     /// <param name="escapedValue">The escaped value to expand.</param>
     /// <param name="escapedItemSpec">The escaped item spec that built-in metadata is derived from.</param>
@@ -35,7 +32,7 @@ internal static class BuiltInMetadataExpander
     ///  The item's RecursiveDir, which comes from the wildcard the item was expanded from rather than the item spec.
     /// </param>
     /// <param name="cache">Cache of already derived modifier values for this item.</param>
-    /// <returns>The value with built-in metadata references substituted.</returns>
+    /// <returns>The value with built-in metadata references expanded.</returns>
     internal static string? Expand(
         string? escapedValue,
         string escapedItemSpec,
@@ -93,9 +90,9 @@ internal static class BuiltInMetadataExpander
 
     /// <summary>
     ///  Reads the metadata name between <c>%(</c> and its closing parenthesis and resolves it to a built-in
-    ///  metadata kind, tolerating surrounding whitespace as the evaluation expander does. A name qualified by an
-    ///  item type is rejected, since the engine resolves built-in metadata against an untyped table and so never
-    ///  satisfies one either.
+    ///  metadata kind, allowing surrounding whitespace as the evaluation expander does. A name qualified by an item
+    ///  type is rejected, since the engine resolves built-in metadata against a table with no item type and so
+    ///  never satisfies one either.
     /// </summary>
     private static bool TryGetModifier(string value, int start, int end, out ItemSpecModifierKind kind)
     {

--- a/src/Framework/BuiltInMetadataExpander.cs
+++ b/src/Framework/BuiltInMetadataExpander.cs
@@ -1,0 +1,120 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using Microsoft.NET.StringTools;
+
+namespace Microsoft.Build.Framework;
+
+/// <summary>
+///  Substitutes built-in metadata references, such as <c>%(Filename)</c>, with the values they denote for a
+///  given item.
+/// </summary>
+/// <remarks>
+///  <para>
+///   Item definition metadata may reference built-in metadata. Such values are stored unexpanded so that they
+///   follow the item they are read from, and are substituted whenever the metadata is read.
+///  </para>
+///  <para>
+///   This is a deliberately minimal substitute for the evaluation expander, which also handles properties, item
+///   vectors, custom metadata, transforms and truncation. Built-in metadata references are the only expression
+///   form that survives evaluation unexpanded. It lives here because the evaluation expander is internal to
+///   <c>Microsoft.Build</c>, while this is needed by <c>MSBuild</c> and <c>Microsoft.Build.Tasks</c> as well.
+///  </para>
+/// </remarks>
+internal static class BuiltInMetadataExpander
+{
+    /// <summary>
+    ///  Expands every built-in metadata reference in <paramref name="escapedValue"/> against the given item.
+    ///  Anything else, including a reference that cannot be satisfied, is left untouched.
+    /// </summary>
+    /// <param name="escapedValue">The escaped value to expand.</param>
+    /// <param name="escapedItemSpec">The escaped item spec that built-in metadata is derived from.</param>
+    /// <param name="escapedDefiningProject">The escaped path of the project that defined the item.</param>
+    /// <param name="escapedRecursiveDir">
+    ///  The item's RecursiveDir, which comes from the wildcard the item was expanded from rather than the item spec.
+    /// </param>
+    /// <param name="cache">Cache of already derived modifier values for this item.</param>
+    /// <returns>The value with built-in metadata references substituted.</returns>
+    internal static string? Expand(
+        string? escapedValue,
+        string escapedItemSpec,
+        string? escapedDefiningProject,
+        string? escapedRecursiveDir,
+        ref ItemSpecModifiers.Cache cache)
+    {
+        int index = escapedValue is null ? -1 : escapedValue.IndexOf("%(", StringComparison.Ordinal);
+
+        if (index < 0)
+        {
+            return escapedValue;
+        }
+
+        SpanBasedStringBuilder? builder = null;
+        int copiedUpTo = 0;
+
+        try
+        {
+            while (index >= 0)
+            {
+                int closingParenthesis = escapedValue!.IndexOf(')', index + 2);
+
+                if (closingParenthesis < 0)
+                {
+                    break;
+                }
+
+                if (TryGetModifier(escapedValue, index + 2, closingParenthesis, out ItemSpecModifierKind kind))
+                {
+                    builder ??= Strings.GetSpanBasedStringBuilder();
+                    builder.Append(escapedValue, copiedUpTo, index - copiedUpTo);
+                    builder.Append(kind is ItemSpecModifierKind.RecursiveDir
+                        ? escapedRecursiveDir ?? string.Empty
+                        : ItemSpecModifiers.GetItemSpecModifier(escapedItemSpec, kind, currentDirectory: null, escapedDefiningProject, ref cache));
+                    copiedUpTo = closingParenthesis + 1;
+                }
+
+                index = escapedValue.IndexOf("%(", closingParenthesis + 1, StringComparison.Ordinal);
+            }
+
+            if (builder is null)
+            {
+                return escapedValue;
+            }
+
+            builder.Append(escapedValue!, copiedUpTo, escapedValue!.Length - copiedUpTo);
+            return builder.ToString();
+        }
+        finally
+        {
+            builder?.Dispose();
+        }
+    }
+
+    /// <summary>
+    ///  Reads the metadata name between <c>%(</c> and its closing parenthesis and resolves it to a built-in
+    ///  metadata kind, tolerating surrounding whitespace as the evaluation expander does. A name qualified by an
+    ///  item type is rejected, since the engine resolves built-in metadata against an untyped table and so never
+    ///  satisfies one either.
+    /// </summary>
+    private static bool TryGetModifier(string value, int start, int end, out ItemSpecModifierKind kind)
+    {
+        while (start < end && char.IsWhiteSpace(value[start]))
+        {
+            start++;
+        }
+
+        while (end > start && char.IsWhiteSpace(value[end - 1]))
+        {
+            end--;
+        }
+
+        if (end <= start)
+        {
+            kind = default;
+            return false;
+        }
+
+        return ItemSpecModifiers.TryGetModifierKind(value.Substring(start, end - start), out kind);
+    }
+}

--- a/src/Framework/BuiltInMetadataExpander.cs
+++ b/src/Framework/BuiltInMetadataExpander.cs
@@ -54,6 +54,7 @@ internal static class BuiltInMetadataExpander
         {
             while (index >= 0)
             {
+                // No closing parenthesis anywhere after this point means no reference can close, so stop.
                 int closingParenthesis = escapedValue!.IndexOf(')', index + 2);
 
                 if (closingParenthesis < 0)
@@ -69,9 +70,16 @@ internal static class BuiltInMetadataExpander
                         ? escapedRecursiveDir ?? string.Empty
                         : ItemSpecModifiers.GetItemSpecModifier(escapedItemSpec, kind, currentDirectory: null, escapedDefiningProject, ref cache));
                     copiedUpTo = closingParenthesis + 1;
-                }
 
-                index = escapedValue.IndexOf("%(", closingParenthesis + 1, StringComparison.Ordinal);
+                    index = escapedValue.IndexOf("%(", copiedUpTo, StringComparison.Ordinal);
+                }
+                else
+                {
+                    // This "%(" does not start a reference. Resume just after it rather than after the
+                    // parenthesis, because a well formed reference can begin inside the text it spanned,
+                    // as in "%(foo%(Filename)". The evaluation expander advances the same way.
+                    index = escapedValue.IndexOf("%(", index + 2, StringComparison.Ordinal);
+                }
             }
 
             if (builder is null)

--- a/src/Framework/BuiltInMetadataExpander.cs
+++ b/src/Framework/BuiltInMetadataExpander.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using Microsoft.NET.StringTools;
 
 namespace Microsoft.Build.Framework;
@@ -40,7 +39,7 @@ internal static class BuiltInMetadataExpander
         string? escapedRecursiveDir,
         ref ItemSpecModifiers.Cache cache)
     {
-        int index = escapedValue is null ? -1 : escapedValue.IndexOf("%(", StringComparison.Ordinal);
+        int index = escapedValue is null ? -1 : IndexOfMetadataMarker(escapedValue, 0);
 
         if (index < 0)
         {
@@ -71,14 +70,14 @@ internal static class BuiltInMetadataExpander
                         : ItemSpecModifiers.GetItemSpecModifier(escapedItemSpec, kind, currentDirectory: null, escapedDefiningProject, ref cache));
                     copiedUpTo = closingParenthesis + 1;
 
-                    index = escapedValue.IndexOf("%(", copiedUpTo, StringComparison.Ordinal);
+                    index = IndexOfMetadataMarker(escapedValue, copiedUpTo);
                 }
                 else
                 {
                     // This "%(" does not start a reference. Resume just after it rather than after the
                     // parenthesis, because a well formed reference can begin inside the text it spanned,
                     // as in "%(foo%(Filename)". The evaluation expander advances the same way.
-                    index = escapedValue.IndexOf("%(", index + 2, StringComparison.Ordinal);
+                    index = IndexOfMetadataMarker(escapedValue, index + 2);
                 }
             }
 
@@ -94,6 +93,35 @@ internal static class BuiltInMetadataExpander
         {
             builder?.Dispose();
         }
+    }
+
+    /// <summary>
+    ///  Finds the first <c>%(</c> at or after <paramref name="startIndex"/>, or -1 if there is none.
+    ///  Does not check that a well formed reference follows it.
+    /// </summary>
+    /// <remarks>
+    ///  <c>IndexOf(char)</c> vectorizes, and is significantly faster than an ordinal two-character search when
+    ///  the marker is absent, which is the usual case for a metadata value. So look for <c>%</c> alone and test
+    ///  the next character separately.
+    /// </remarks>
+    internal static int IndexOfMetadataMarker(string value, int startIndex)
+    {
+        int markerIndex = value.IndexOf('%', startIndex);
+
+        // A marker in the last position has no room for the parenthesis.
+        while (markerIndex >= 0 && markerIndex < value.Length - 1)
+        {
+            int nextIndex = markerIndex + 1;
+
+            if (value[nextIndex] == '(')
+            {
+                return markerIndex;
+            }
+
+            markerIndex = value.IndexOf('%', nextIndex);
+        }
+
+        return -1;
     }
 
     /// <summary>

--- a/src/Shared/TaskParameter.cs
+++ b/src/Shared/TaskParameter.cs
@@ -576,6 +576,12 @@ namespace Microsoft.Build.BackEnd
             private ItemSpecModifiers.Cache _cachedModifiers;
 
             /// <summary>
+            /// Names of metadata written on this item after it was received. Their values are literal, so they are
+            /// never expanded on read.
+            /// </summary>
+            private HashSet<string> _locallySetMetadata = null;
+
+            /// <summary>
             /// Constructor for serialization
             /// </summary>
             internal TaskParameterTaskItem(ITaskItem copyFrom)
@@ -756,6 +762,9 @@ namespace Microsoft.Build.BackEnd
                 _customEscapedMetadata ??= new Dictionary<string, string>(MSBuildNameIgnoreCaseComparer.Default);
 
                 _customEscapedMetadata[metadataName] = metadataValue ?? String.Empty;
+
+                _locallySetMetadata ??= new HashSet<string>(MSBuildNameIgnoreCaseComparer.Default);
+                _locallySetMetadata.Add(metadataName);
             }
 
             /// <summary>
@@ -773,6 +782,7 @@ namespace Microsoft.Build.BackEnd
                 }
 
                 _customEscapedMetadata.Remove(metadataName);
+                _locallySetMetadata?.Remove(metadataName);
             }
 
             /// <summary>
@@ -882,7 +892,24 @@ namespace Microsoft.Build.BackEnd
                 string metadataValue = null;
                 _customEscapedMetadata?.TryGetValue(metadataName, out metadataValue);
 
-                return metadataValue ?? string.Empty;
+                if (metadataValue is null)
+                {
+                    return string.Empty;
+                }
+
+                // Item definition metadata referencing built-in metadata is stored unexpanded and substituted on read
+                // so that it tracks the item it is read from. Definition and directly set metadata arrive here
+                // flattened into a single dictionary, so the distinction is instead carried by the value itself:
+                // anything expanded during evaluation has no reference left to substitute. Metadata a task sets is
+                // literal, so it is excluded.
+                if (metadataValue.IndexOf("%(", StringComparison.Ordinal) < 0 || _locallySetMetadata?.Contains(metadataName) == true)
+                {
+                    return metadataValue;
+                }
+
+                _customEscapedMetadata.TryGetValue(ItemSpecModifiers.RecursiveDir, out string escapedRecursiveDir);
+
+                return BuiltInMetadataExpander.Expand(metadataValue, _escapedItemSpec, _escapedDefiningProject, escapedRecursiveDir, ref _cachedModifiers);
             }
 
             /// <summary>

--- a/src/Shared/TaskParameter.cs
+++ b/src/Shared/TaskParameter.cs
@@ -546,6 +546,16 @@ namespace Microsoft.Build.BackEnd
         /// <summary>
         /// Super simple ITaskItem derivative that we can use as a container for read items.
         /// </summary>
+        /// <remarks>
+        /// This is a flattened view of an engine item. An engine item keeps metadata set directly on the item apart
+        /// from metadata inherited from an item definition, and expands only the latter on read, so that a value such
+        /// as <c>%(Filename)</c> follows the item it is read from. Both kinds arrive here in one dictionary, so that
+        /// origin is recovered instead: a value that evaluation already expanded has no <c>%(</c> left in it, and a
+        /// value the task itself writes is recorded as it is written.
+        ///
+        /// Reads that hand a value to a task expand; reads that hand back the whole collection do not, so a value
+        /// returns to the engine as it left. Keep any new accessor on the side of the one it resembles.
+        /// </remarks>
         private class TaskParameterTaskItem :
 #if FEATURE_APPDOMAIN
             MarshalByRefObject,
@@ -576,10 +586,9 @@ namespace Microsoft.Build.BackEnd
             private ItemSpecModifiers.Cache _cachedModifiers;
 
             /// <summary>
-            /// Names of metadata written on this item after it was received. Their values are literal, so they are
-            /// never expanded on read.
+            /// Names of metadata the task wrote on this item. Their values are read as stored.
             /// </summary>
-            private HashSet<string> _locallySetMetadata = null;
+            private HashSet<string> _writtenByTask = null;
 
             /// <summary>
             /// Constructor for serialization
@@ -624,12 +633,11 @@ namespace Microsoft.Build.BackEnd
                     }
                 }
 
-                // RecursiveDir is a built-in metadata that cannot be derived from the item spec alone -
-                // it requires the original wildcard pattern (_includeBeforeWildcardExpansionEscaped).
-                // When crossing process boundaries (e.g., to TaskHost in -mt mode), built-in metadata
-                // is not included in CloneCustomMetadataEscaped(). Explicitly preserve RecursiveDir
-                // as custom metadata so it survives serialization.
-                // See https://github.com/dotnet/msbuild/issues/13140
+                // RecursiveDir cannot be derived from the item spec, only from the wildcard the item was expanded
+                // from, and CloneCustomMetadataEscaped() does not return built-in metadata. Carry it over explicitly
+                // so it survives the boundary. See https://github.com/dotnet/msbuild/issues/13140.
+                // Written straight to the dictionary rather than through SetMetadata: this is the item being built,
+                // not a task writing to it, and the value is already expanded.
                 if (copyFrom is ITaskItem2 copyFromForRecursiveDir)
                 {
                     string recursiveDirEscaped = copyFromForRecursiveDir.GetMetadataValueEscaped(ItemSpecModifiers.RecursiveDir);
@@ -765,11 +773,11 @@ namespace Microsoft.Build.BackEnd
 
                 _customEscapedMetadata[metadataName] = metadataValue ?? String.Empty;
 
-                // Only a value that would otherwise be substituted on read has to be remembered as literal.
-                if (metadataValue?.IndexOf("%(", StringComparison.Ordinal) >= 0)
+                // Only a value that would otherwise be expanded on read has to be remembered.
+                if (IsUnexpanded(metadataValue))
                 {
-                    _locallySetMetadata ??= new HashSet<string>(MSBuildNameIgnoreCaseComparer.Default);
-                    _locallySetMetadata.Add(metadataName);
+                    _writtenByTask ??= new HashSet<string>(MSBuildNameIgnoreCaseComparer.Default);
+                    _writtenByTask.Add(metadataName);
                 }
             }
 
@@ -788,7 +796,7 @@ namespace Microsoft.Build.BackEnd
                 }
 
                 _customEscapedMetadata.Remove(metadataName);
-                _locallySetMetadata?.Remove(metadataName);
+                _writtenByTask?.Remove(metadataName);
             }
 
             /// <summary>
@@ -815,12 +823,12 @@ namespace Microsoft.Build.BackEnd
                     IEnumerable<KeyValuePair<string, string>> metadataToImport = _customEscapedMetadata
                         .Where(metadatum => string.IsNullOrEmpty(destinationItem.GetMetadata(metadatum.Key)));
 
-                    // The destination has no notion of a value awaiting substitution, so hand it finished values,
-                    // as an engine item does when copying onto an item a task can reach.
-                    if (HasAnyExpandableExpressions())
+                    // The destination has no notion of an unexpanded value, so hand it expanded ones, as an engine
+                    // item does when copying onto an item a task can reach.
+                    if (HasUnexpandedMetadata())
                     {
                         metadataToImport = metadataToImport
-                            .Select(metadatum => new KeyValuePair<string, string>(metadatum.Key, Substitute(metadatum.Key, metadatum.Value)));
+                            .Select(metadatum => new KeyValuePair<string, string>(metadatum.Key, ExpandIfFromItemDefinition(metadatum.Key, metadatum.Value)));
                     }
 
 #if FEATURE_APPDOMAIN
@@ -841,7 +849,7 @@ namespace Microsoft.Build.BackEnd
 
                         if (String.IsNullOrEmpty(value))
                         {
-                            destinationItem.SetMetadata(entry.Key, Substitute(entry.Key, entry.Value));
+                            destinationItem.SetMetadata(entry.Key, ExpandIfFromItemDefinition(entry.Key, entry.Value));
                         }
                     }
                 }
@@ -911,40 +919,44 @@ namespace Microsoft.Build.BackEnd
                     return string.Empty;
                 }
 
-                // Item definition metadata referencing built-in metadata is stored unexpanded and substituted on read
-                // so that it tracks the item it is read from. Definition and directly set metadata arrive here
-                // flattened into a single dictionary, so the distinction is instead carried by the value itself:
-                // anything expanded during evaluation has no reference left to substitute. Metadata a task sets is
-                // literal, so it is excluded.
-                return Substitute(metadataName, metadataValue);
+                return ExpandIfFromItemDefinition(metadataName, metadataValue);
             }
 
             /// <summary>
-            /// Substitutes any built-in metadata references in a stored metadata value, unless the value was
-            /// written by the task and is therefore literal.
+            /// Expands a stored value if it came from an item definition, and returns it as stored otherwise.
             /// </summary>
-            private string Substitute(string metadataName, string escapedValue)
+            private string ExpandIfFromItemDefinition(string metadataName, string escapedValue)
             {
-                if (escapedValue.IndexOf("%(", StringComparison.Ordinal) < 0 || _locallySetMetadata?.Contains(metadataName) == true)
+                if (!IsUnexpanded(escapedValue) || _writtenByTask?.Contains(metadataName) == true)
                 {
                     return escapedValue;
                 }
 
+                // RecursiveDir comes from the wildcard the item was expanded from, not from the item spec, so it is
+                // read from the item's own metadata rather than derived.
                 _customEscapedMetadata.TryGetValue(ItemSpecModifiers.RecursiveDir, out string escapedRecursiveDir);
 
                 return BuiltInMetadataExpander.Expand(escapedValue, _escapedItemSpec, _escapedDefiningProject, escapedRecursiveDir, ref _cachedModifiers);
             }
 
             /// <summary>
-            /// Indicates whether any stored value may contain a built-in metadata reference awaiting substitution.
+            /// Indicates whether a value still holds a built-in metadata reference, and so was never expanded.
+            /// Evaluation expands every other expression form, so this is what distinguishes a value inherited from
+            /// an item definition from one set directly on the item.
             /// </summary>
-            private bool HasAnyExpandableExpressions()
+            private static bool IsUnexpanded(string escapedValue)
+                => escapedValue?.IndexOf("%(", StringComparison.Ordinal) >= 0;
+
+            /// <summary>
+            /// Indicates whether any stored value is still unexpanded.
+            /// </summary>
+            private bool HasUnexpandedMetadata()
             {
                 if (_customEscapedMetadata is not null)
                 {
                     foreach (KeyValuePair<string, string> metadatum in _customEscapedMetadata)
                     {
-                        if (metadatum.Value.IndexOf("%(", StringComparison.Ordinal) >= 0)
+                        if (IsUnexpanded(metadatum.Value))
                         {
                             return true;
                         }

--- a/src/Shared/TaskParameter.cs
+++ b/src/Shared/TaskParameter.cs
@@ -678,6 +678,7 @@ namespace Microsoft.Build.BackEnd
                 set
                 {
                     _escapedItemSpec = value;
+                    _cachedModifiers.Clear();
                 }
             }
 
@@ -728,6 +729,7 @@ namespace Microsoft.Build.BackEnd
                 set
                 {
                     _escapedItemSpec = value;
+                    _cachedModifiers.Clear();
                 }
             }
 
@@ -763,8 +765,12 @@ namespace Microsoft.Build.BackEnd
 
                 _customEscapedMetadata[metadataName] = metadataValue ?? String.Empty;
 
-                _locallySetMetadata ??= new HashSet<string>(MSBuildNameIgnoreCaseComparer.Default);
-                _locallySetMetadata.Add(metadataName);
+                // Only a value that would otherwise be substituted on read has to be remembered as literal.
+                if (metadataValue?.IndexOf("%(", StringComparison.Ordinal) >= 0)
+                {
+                    _locallySetMetadata ??= new HashSet<string>(MSBuildNameIgnoreCaseComparer.Default);
+                    _locallySetMetadata.Add(metadataName);
+                }
             }
 
             /// <summary>
@@ -809,6 +815,14 @@ namespace Microsoft.Build.BackEnd
                     IEnumerable<KeyValuePair<string, string>> metadataToImport = _customEscapedMetadata
                         .Where(metadatum => string.IsNullOrEmpty(destinationItem.GetMetadata(metadatum.Key)));
 
+                    // The destination has no notion of a value awaiting substitution, so hand it finished values,
+                    // as an engine item does when copying onto an item a task can reach.
+                    if (HasAnyExpandableExpressions())
+                    {
+                        metadataToImport = metadataToImport
+                            .Select(metadatum => new KeyValuePair<string, string>(metadatum.Key, Substitute(metadatum.Key, metadatum.Value)));
+                    }
+
 #if FEATURE_APPDOMAIN
                     if (RemotingServices.IsTransparentProxy(destinationItem))
                     {
@@ -827,7 +841,7 @@ namespace Microsoft.Build.BackEnd
 
                         if (String.IsNullOrEmpty(value))
                         {
-                            destinationItem.SetMetadata(entry.Key, entry.Value);
+                            destinationItem.SetMetadata(entry.Key, Substitute(entry.Key, entry.Value));
                         }
                     }
                 }
@@ -902,14 +916,42 @@ namespace Microsoft.Build.BackEnd
                 // flattened into a single dictionary, so the distinction is instead carried by the value itself:
                 // anything expanded during evaluation has no reference left to substitute. Metadata a task sets is
                 // literal, so it is excluded.
-                if (metadataValue.IndexOf("%(", StringComparison.Ordinal) < 0 || _locallySetMetadata?.Contains(metadataName) == true)
+                return Substitute(metadataName, metadataValue);
+            }
+
+            /// <summary>
+            /// Substitutes any built-in metadata references in a stored metadata value, unless the value was
+            /// written by the task and is therefore literal.
+            /// </summary>
+            private string Substitute(string metadataName, string escapedValue)
+            {
+                if (escapedValue.IndexOf("%(", StringComparison.Ordinal) < 0 || _locallySetMetadata?.Contains(metadataName) == true)
                 {
-                    return metadataValue;
+                    return escapedValue;
                 }
 
                 _customEscapedMetadata.TryGetValue(ItemSpecModifiers.RecursiveDir, out string escapedRecursiveDir);
 
-                return BuiltInMetadataExpander.Expand(metadataValue, _escapedItemSpec, _escapedDefiningProject, escapedRecursiveDir, ref _cachedModifiers);
+                return BuiltInMetadataExpander.Expand(escapedValue, _escapedItemSpec, _escapedDefiningProject, escapedRecursiveDir, ref _cachedModifiers);
+            }
+
+            /// <summary>
+            /// Indicates whether any stored value may contain a built-in metadata reference awaiting substitution.
+            /// </summary>
+            private bool HasAnyExpandableExpressions()
+            {
+                if (_customEscapedMetadata is not null)
+                {
+                    foreach (KeyValuePair<string, string> metadatum in _customEscapedMetadata)
+                    {
+                        if (metadatum.Value.IndexOf("%(", StringComparison.Ordinal) >= 0)
+                        {
+                            return true;
+                        }
+                    }
+                }
+
+                return false;
             }
 
             /// <summary>

--- a/src/Shared/TaskParameter.cs
+++ b/src/Shared/TaskParameter.cs
@@ -586,7 +586,7 @@ namespace Microsoft.Build.BackEnd
             private ItemSpecModifiers.Cache _cachedModifiers;
 
             /// <summary>
-            /// Names of metadata the task wrote on this item. Their values are read as stored.
+            /// Names of metadata the task wrote on this item. The values of these metadata are returned without expansion.
             /// </summary>
             private HashSet<string> _writtenByTask = null;
 
@@ -820,16 +820,12 @@ namespace Microsoft.Build.BackEnd
                 if (_customEscapedMetadata != null && destinationItem is IMetadataContainer destinationItemAsMetadataContainer)
                 {
                     // The destination implements IMetadataContainer so we can use the ImportMetadata bulk-set operation.
-                    IEnumerable<KeyValuePair<string, string>> metadataToImport = _customEscapedMetadata
-                        .Where(metadatum => string.IsNullOrEmpty(destinationItem.GetMetadata(metadatum.Key)));
-
                     // The destination has no notion of an unexpanded value, so hand it expanded ones, as an engine
-                    // item does when copying onto an item a task can reach.
-                    if (HasUnexpandedMetadata())
-                    {
-                        metadataToImport = metadataToImport
-                            .Select(metadatum => new KeyValuePair<string, string>(metadatum.Key, ExpandIfFromItemDefinition(metadatum.Key, metadatum.Value)));
-                    }
+                    // item does when copying onto an item a task can reach. ExpandIfFromItemDefinition returns the
+                    // value it was given when there is nothing to expand, which is the usual case.
+                    IEnumerable<KeyValuePair<string, string>> metadataToImport = _customEscapedMetadata
+                        .Where(metadatum => string.IsNullOrEmpty(destinationItem.GetMetadata(metadatum.Key)))
+                        .Select(metadatum => new KeyValuePair<string, string>(metadatum.Key, ExpandIfFromItemDefinition(metadatum.Key, metadatum.Value)));
 
 #if FEATURE_APPDOMAIN
                     if (RemotingServices.IsTransparentProxy(destinationItem))
@@ -945,26 +941,7 @@ namespace Microsoft.Build.BackEnd
             /// an item definition from one set directly on the item.
             /// </summary>
             private static bool IsUnexpanded(string escapedValue)
-                => escapedValue?.IndexOf("%(", StringComparison.Ordinal) >= 0;
-
-            /// <summary>
-            /// Indicates whether any stored value is still unexpanded.
-            /// </summary>
-            private bool HasUnexpandedMetadata()
-            {
-                if (_customEscapedMetadata is not null)
-                {
-                    foreach (KeyValuePair<string, string> metadatum in _customEscapedMetadata)
-                    {
-                        if (IsUnexpanded(metadatum.Value))
-                        {
-                            return true;
-                        }
-                    }
-                }
-
-                return false;
-            }
+                => escapedValue is not null && BuiltInMetadataExpander.IndexOfMetadataMarker(escapedValue, 0) >= 0;
 
             /// <summary>
             /// Sets the exact metadata value given to the metadata name requested.

--- a/src/Shared/UnitTests/TaskParameter_Tests.cs
+++ b/src/Shared/UnitTests/TaskParameter_Tests.cs
@@ -711,6 +711,67 @@ namespace Microsoft.Build.UnitTests
             RoundTrip(item).GetMetadata("NameMeta").ShouldBe(expected);
         }
 
+        /// <summary>
+        /// A task that clones its input, whether through <c>CopyMetadataTo</c> or the copy constructor that calls
+        /// it, must get the same values the engine item hands out. The destination has no notion of a value
+        /// awaiting substitution, so the copy has to be made with finished values.
+        /// </summary>
+        [Fact]
+        public void CopyingMetadataSubstitutesReferencesAcrossTaskHostBoundary()
+        {
+            ProjectItemInstanceTaskItem item = CreateItemWithDefinitionMetadata("NameMeta", "%(Filename)");
+            ITaskItem marshalled = RoundTrip(item);
+
+            new TaskItem(item).GetMetadata("NameMeta").ShouldBe("hello");
+            new TaskItem(marshalled).GetMetadata("NameMeta").ShouldBe("hello");
+
+            TaskItem viaCopyFromEngineItem = new("dest");
+            TaskItem viaCopyFromMarshalledItem = new("dest");
+
+            item.CopyMetadataTo(viaCopyFromEngineItem);
+            marshalled.CopyMetadataTo(viaCopyFromMarshalledItem);
+
+            viaCopyFromEngineItem.GetMetadata("NameMeta").ShouldBe("hello");
+            viaCopyFromMarshalledItem.GetMetadata("NameMeta").ShouldBe("hello");
+        }
+
+        /// <summary>
+        /// A value the task wrote is literal, so cloning has to carry it across as written.
+        /// </summary>
+        [Fact]
+        public void MetadataSetByTheTaskIsCopiedLiterally()
+        {
+            ProjectItemInstanceTaskItem item = CreateItemWithDefinitionMetadata("NameMeta", "%(Filename)");
+            ITaskItem marshalled = RoundTrip(item);
+
+            item.SetMetadata("Local", "%(Filename)");
+            marshalled.SetMetadata("Local", "%(Filename)");
+
+            new TaskItem(marshalled).GetMetadata("Local").ShouldBe(new TaskItem(item).GetMetadata("Local"));
+        }
+
+        /// <summary>
+        /// Metadata derived from the item's path is cached, so reassigning ItemSpec has to invalidate it. Otherwise
+        /// a value read before the move leaks into one read after it.
+        /// </summary>
+        [Fact]
+        public void ReassigningItemSpecInvalidatesCachedPathMetadataAcrossTaskHostBoundary()
+        {
+            ProjectItemInstanceTaskItem item = CreateItemWithDefinitionMetadata("PathMeta", "%(Directory)");
+            ITaskItem marshalled = RoundTrip(item);
+
+            // Read first so that anything derived from the original path is cached.
+            item.GetMetadata("FullPath").ShouldBe(marshalled.GetMetadata("FullPath"));
+
+            string renamed = $"other{Path.DirectorySeparatorChar}renamed.txt";
+            item.ItemSpec = renamed;
+            marshalled.ItemSpec = renamed;
+
+            marshalled.GetMetadata("FullPath").ShouldBe(item.GetMetadata("FullPath"));
+            marshalled.GetMetadata("Directory").ShouldBe(item.GetMetadata("Directory"));
+            marshalled.GetMetadata("PathMeta").ShouldBe(item.GetMetadata("PathMeta"));
+        }
+
         private static ProjectItemInstanceTaskItem CreateItemWithDefinitionMetadata(string name, string escapedValue)
         {
             string itemSpec = $"folder{Path.DirectorySeparatorChar}hello.txt";

--- a/src/Shared/UnitTests/TaskParameter_Tests.cs
+++ b/src/Shared/UnitTests/TaskParameter_Tests.cs
@@ -608,8 +608,8 @@ namespace Microsoft.Build.UnitTests
 
         /// <summary>
         /// Regression test for https://github.com/dotnet/msbuild/issues/14763
-        /// Item definition metadata referencing built-in metadata is stored unexpanded and substituted on read,
-        /// so a task must observe the same value whether or not the item crossed the TaskHost boundary.
+        /// Metadata inherited from an item definition is stored unexpanded and expanded on read, so a task must
+        /// observe the same value whether or not the item crossed the TaskHost boundary.
         /// </summary>
         [Theory]
         [InlineData("%(Filename)", "hello")]
@@ -618,7 +618,7 @@ namespace Microsoft.Build.UnitTests
         [InlineData("pre-%(Filename)-post", "pre-hello-post")]
         [InlineData("%(Filename)%(Extension)", "hello.txt")]
         [InlineData("no expression", "no expression")]
-        // An escaped reference is literal text rather than an expression.
+        // An escaped reference is text, not an expression.
         [InlineData("%25(Filename)", "%(Filename)")]
         // Malformed references are not expressions either.
         [InlineData("%(Filename", "%(Filename")]
@@ -634,7 +634,7 @@ namespace Microsoft.Build.UnitTests
 
         /// <summary>
         /// A task that reassigns ItemSpec sees item definition metadata re-derived from the new spec. That must
-        /// hold on both sides of the TaskHost boundary, so the value cannot simply be substituted up front.
+        /// hold on both sides of the TaskHost boundary, so the value cannot simply be expanded up front.
         /// </summary>
         [Fact]
         public void ItemDefinitionMetadataFollowsReassignedItemSpecAcrossTaskHostBoundary()
@@ -652,10 +652,10 @@ namespace Microsoft.Build.UnitTests
         }
 
         /// <summary>
-        /// A value a task writes on the item is literal, matching what the same task would read back in-proc.
+        /// A value the task writes is read back as stored, matching what the same task would see in-proc.
         /// </summary>
         [Fact]
-        public void MetadataSetByTheTaskIsNotExpanded()
+        public void MetadataWrittenByTheTaskIsNotExpanded()
         {
             ITaskItem marshalled = RoundTrip(CreateItemWithDefinitionMetadata("NameMeta", "%(Filename)"));
 
@@ -714,10 +714,10 @@ namespace Microsoft.Build.UnitTests
         /// <summary>
         /// A task that clones its input, whether through <c>CopyMetadataTo</c> or the copy constructor that calls
         /// it, must get the same values the engine item hands out. The destination has no notion of a value
-        /// awaiting substitution, so the copy has to be made with finished values.
+        /// unexpanded value, so the copy has to be made with expanded ones.
         /// </summary>
         [Fact]
-        public void CopyingMetadataSubstitutesReferencesAcrossTaskHostBoundary()
+        public void CopyingMetadataExpandsReferencesAcrossTaskHostBoundary()
         {
             ProjectItemInstanceTaskItem item = CreateItemWithDefinitionMetadata("NameMeta", "%(Filename)");
             ITaskItem marshalled = RoundTrip(item);
@@ -736,10 +736,10 @@ namespace Microsoft.Build.UnitTests
         }
 
         /// <summary>
-        /// A value the task wrote is literal, so cloning has to carry it across as written.
+        /// A value the task wrote is read as stored, so cloning has to carry it across as written.
         /// </summary>
         [Fact]
-        public void MetadataSetByTheTaskIsCopiedLiterally()
+        public void MetadataWrittenByTheTaskIsCopiedAsStored()
         {
             ProjectItemInstanceTaskItem item = CreateItemWithDefinitionMetadata("NameMeta", "%(Filename)");
             ITaskItem marshalled = RoundTrip(item);
@@ -770,6 +770,92 @@ namespace Microsoft.Build.UnitTests
             marshalled.GetMetadata("FullPath").ShouldBe(item.GetMetadata("FullPath"));
             marshalled.GetMetadata("Directory").ShouldBe(item.GetMetadata("Directory"));
             marshalled.GetMetadata("PathMeta").ShouldBe(item.GetMetadata("PathMeta"));
+        }
+
+        /// <summary>
+        /// The expansion here is a deliberately minimal stand-in for the evaluation expander, so it has to agree
+        /// with it for every built-in metadata name, including any added later. Driving the theory from
+        /// <see cref="ItemSpecModifiers.All"/> rather than a fixed list is what keeps that true over time.
+        /// </summary>
+        [Theory]
+        [MemberData(nameof(AllItemSpecModifiers))]
+        public void EveryBuiltInMetadataReferenceReadsTheSameAcrossTaskHostBoundary(string modifier)
+        {
+            // A wildcard origin so that RecursiveDir is a real value rather than empty on both sides.
+            string sep = Path.DirectorySeparatorChar.ToString();
+
+            ProjectItemDefinitionInstance definition = new(
+                "Thing",
+                ImmutableDictionaryExtensions.EmptyMetadata.SetItem("NameMeta", $"[%({modifier})]"));
+
+            ProjectItemInstanceTaskItem item = new(
+                includeEscaped: $"tree{sep}sub1{sep}sub2{sep}hello.txt",
+                includeBeforeWildcardExpansionEscaped: $"tree{sep}**{sep}*.txt",
+                directMetadata: null,
+                itemDefinitions: [definition],
+                projectDirectory: Directory.GetCurrentDirectory(),
+                immutable: false,
+                definingFileEscaped: "test.proj");
+
+            string expected = item.GetMetadata("NameMeta");
+
+            // The time-based modifiers read the file system and are empty for an item that does not exist. They go
+            // through the same shared call as the rest, so equality is still worth asserting, but only the others
+            // can be required to resolve to something.
+            if (!modifier.EndsWith("Time", StringComparison.Ordinal))
+            {
+                expected.ShouldNotBe("[]", $"%({modifier}) should resolve to something for this test to mean anything");
+            }
+
+            RoundTrip(item).GetMetadata("NameMeta").ShouldBe(expected, $"for %({modifier})");
+        }
+
+        public static TheoryData<string> AllItemSpecModifiers
+        {
+            get
+            {
+                TheoryData<string> data = [];
+
+                foreach (string modifier in ItemSpecModifiers.All)
+                {
+                    data.Add(modifier);
+                }
+
+                return data;
+            }
+        }
+
+        /// <summary>
+        /// A reference qualified by an item type is left as written. The engine resolves built-in metadata against
+        /// a table with no item type, so a qualified reference never matches and evaluates to an empty string;
+        /// expanding to empty here instead would mean blanking any text of that shape. This pins the difference so
+        /// that it stays a decision rather than an accident.
+        /// </summary>
+        [Theory]
+        [InlineData("%(Thing.Filename)")]
+        [InlineData("%( Thing.Filename )")]
+        [InlineData("%(Other.Filename)")]
+        public void QualifiedMetadataReferenceIsLeftAsWritten(string definitionValue)
+        {
+            ProjectItemInstanceTaskItem item = CreateItemWithDefinitionMetadata("NameMeta", definitionValue);
+
+            item.GetMetadata("NameMeta").ShouldBe("");
+            RoundTrip(item).GetMetadata("NameMeta").ShouldBe(definitionValue);
+        }
+
+        /// <summary>
+        /// Only values the task writes are read as stored. Nothing on the receiving path may record metadata that
+        /// way, or item definition values would stop being expanded.
+        /// </summary>
+        [Fact]
+        public void ReceivingAnItemDoesNotMarkItsMetadataAsWrittenByTheTask()
+        {
+            ITaskItem marshalled = RoundTrip(CreateItemWithDefinitionMetadata("NameMeta", "%(Filename)"));
+
+            marshalled.GetMetadata("NameMeta").ShouldBe("hello");
+
+            // A second hop must not change that either.
+            RoundTrip(marshalled).GetMetadata("NameMeta").ShouldBe("hello");
         }
 
         private static ProjectItemInstanceTaskItem CreateItemWithDefinitionMetadata(string name, string escapedValue)

--- a/src/Shared/UnitTests/TaskParameter_Tests.cs
+++ b/src/Shared/UnitTests/TaskParameter_Tests.cs
@@ -665,7 +665,8 @@ namespace Microsoft.Build.UnitTests
             marshalled.GetMetadata("NameMeta").ShouldBe("%(Filename)");
             marshalled.GetMetadata("Other").ShouldBe("%(Filename)");
 
-            // Removing the task's value uncovers the item definition value again.
+            // The two origins were flattened into one dictionary when the item crossed the boundary, so removal
+            // leaves nothing behind. An engine item would uncover the item definition value here.
             marshalled.RemoveMetadata("NameMeta");
             marshalled.GetMetadata("NameMeta").ShouldBe("");
         }
@@ -713,8 +714,8 @@ namespace Microsoft.Build.UnitTests
 
         /// <summary>
         /// A task that clones its input, whether through <c>CopyMetadataTo</c> or the copy constructor that calls
-        /// it, must get the same values the engine item hands out. The destination has no notion of a value
-        /// unexpanded value, so the copy has to be made with expanded ones.
+        /// it, must get the same values the engine item hands out. The destination has no notion of an unexpanded
+        /// value, so the copy has to be made with expanded ones.
         /// </summary>
         [Fact]
         public void CopyingMetadataExpandsReferencesAcrossTaskHostBoundary()

--- a/src/Shared/UnitTests/TaskParameter_Tests.cs
+++ b/src/Shared/UnitTests/TaskParameter_Tests.cs
@@ -607,6 +607,137 @@ namespace Microsoft.Build.UnitTests
         }
 
         /// <summary>
+        /// Regression test for https://github.com/dotnet/msbuild/issues/14763
+        /// Item definition metadata referencing built-in metadata is stored unexpanded and substituted on read,
+        /// so a task must observe the same value whether or not the item crossed the TaskHost boundary.
+        /// </summary>
+        [Theory]
+        [InlineData("%(Filename)", "hello")]
+        [InlineData("%( Filename )", "hello")]
+        [InlineData("%(filename)", "hello")]
+        [InlineData("pre-%(Filename)-post", "pre-hello-post")]
+        [InlineData("%(Filename)%(Extension)", "hello.txt")]
+        [InlineData("no expression", "no expression")]
+        // An escaped reference is literal text rather than an expression.
+        [InlineData("%25(Filename)", "%(Filename)")]
+        // Malformed references are not expressions either.
+        [InlineData("%(Filename", "%(Filename")]
+        [InlineData("a%(", "a%(")]
+        [InlineData("%()", "%()")]
+        public void ItemDefinitionMetadataReadsTheSameAcrossTaskHostBoundary(string definitionValue, string expected)
+        {
+            ProjectItemInstanceTaskItem item = CreateItemWithDefinitionMetadata("NameMeta", definitionValue);
+
+            item.GetMetadata("NameMeta").ShouldBe(expected);
+            RoundTrip(item).GetMetadata("NameMeta").ShouldBe(expected);
+        }
+
+        /// <summary>
+        /// A task that reassigns ItemSpec sees item definition metadata re-derived from the new spec. That must
+        /// hold on both sides of the TaskHost boundary, so the value cannot simply be substituted up front.
+        /// </summary>
+        [Fact]
+        public void ItemDefinitionMetadataFollowsReassignedItemSpecAcrossTaskHostBoundary()
+        {
+            string renamed = $"other{Path.DirectorySeparatorChar}renamed.txt";
+
+            ProjectItemInstanceTaskItem item = CreateItemWithDefinitionMetadata("NameMeta", "%(Filename)");
+            ITaskItem marshalled = RoundTrip(item);
+
+            item.ItemSpec = renamed;
+            marshalled.ItemSpec = renamed;
+
+            item.GetMetadata("NameMeta").ShouldBe("renamed");
+            marshalled.GetMetadata("NameMeta").ShouldBe("renamed");
+        }
+
+        /// <summary>
+        /// A value a task writes on the item is literal, matching what the same task would read back in-proc.
+        /// </summary>
+        [Fact]
+        public void MetadataSetByTheTaskIsNotExpanded()
+        {
+            ITaskItem marshalled = RoundTrip(CreateItemWithDefinitionMetadata("NameMeta", "%(Filename)"));
+
+            marshalled.SetMetadata("NameMeta", "%(Filename)");
+            marshalled.SetMetadata("Other", "%(Filename)");
+
+            marshalled.GetMetadata("NameMeta").ShouldBe("%(Filename)");
+            marshalled.GetMetadata("Other").ShouldBe("%(Filename)");
+
+            // Removing the task's value uncovers the item definition value again.
+            marshalled.RemoveMetadata("NameMeta");
+            marshalled.GetMetadata("NameMeta").ShouldBe("");
+        }
+
+        /// <summary>
+        /// Bulk metadata reads report values unexpanded, matching what an engine item reports in-proc.
+        /// </summary>
+        [Fact]
+        public void BulkMetadataReadsMatchEngineItemAcrossTaskHostBoundary()
+        {
+            ProjectItemInstanceTaskItem item = CreateItemWithDefinitionMetadata("NameMeta", "%(Filename)");
+            ITaskItem marshalled = RoundTrip(item);
+
+            ((IDictionary)((ITaskItem2)item).CloneCustomMetadataEscaped())["NameMeta"].ShouldBe("%(Filename)");
+            ((IDictionary)((ITaskItem2)marshalled).CloneCustomMetadataEscaped())["NameMeta"].ShouldBe("%(Filename)");
+        }
+
+        /// <summary>
+        /// RecursiveDir comes from the wildcard the item was expanded from rather than from the item spec, so it
+        /// has to be resolved from the item's own metadata to keep patterns such as
+        /// <c>out\%(RecursiveDir)%(Filename)%(Extension)</c> producing the same path on both sides of the boundary.
+        /// </summary>
+        [Fact]
+        public void RecursiveDirReferenceIsExpandedAcrossTaskHostBoundary()
+        {
+            string sep = Path.DirectorySeparatorChar.ToString();
+            string expected = $"out{sep}sub1{sep}sub2{sep}hello.txt";
+
+            ProjectItemDefinitionInstance definition = new(
+                "Thing",
+                ImmutableDictionaryExtensions.EmptyMetadata.SetItem("NameMeta", $"out{sep}%(RecursiveDir)%(Filename)%(Extension)"));
+
+            ProjectItemInstanceTaskItem item = new(
+                includeEscaped: $"tree{sep}sub1{sep}sub2{sep}hello.txt",
+                includeBeforeWildcardExpansionEscaped: $"tree{sep}**{sep}*.txt",
+                directMetadata: null,
+                itemDefinitions: [definition],
+                projectDirectory: Directory.GetCurrentDirectory(),
+                immutable: false,
+                definingFileEscaped: "test.proj");
+
+            item.GetMetadata("NameMeta").ShouldBe(expected);
+            RoundTrip(item).GetMetadata("NameMeta").ShouldBe(expected);
+        }
+
+        private static ProjectItemInstanceTaskItem CreateItemWithDefinitionMetadata(string name, string escapedValue)
+        {
+            string itemSpec = $"folder{Path.DirectorySeparatorChar}hello.txt";
+
+            ProjectItemDefinitionInstance definition = new(
+                "Thing",
+                ImmutableDictionaryExtensions.EmptyMetadata.SetItem(name, escapedValue));
+
+            return new ProjectItemInstanceTaskItem(
+                includeEscaped: itemSpec,
+                includeBeforeWildcardExpansionEscaped: itemSpec,
+                directMetadata: null,
+                itemDefinitions: [definition],
+                projectDirectory: Directory.GetCurrentDirectory(),
+                immutable: false,
+                definingFileEscaped: "test.proj");
+        }
+
+        private static ITaskItem RoundTrip(ITaskItem item)
+        {
+            TaskParameter t = new(item);
+            ((ITranslatable)t).Translate(TranslationHelpers.GetWriteTranslator());
+
+            return (ITaskItem)TaskParameter.FactoryForDeserialization(TranslationHelpers.GetReadTranslator()).WrappedParameter;
+        }
+
+        /// <summary>
         /// Regression test for https://github.com/dotnet/msbuild/issues/13140
         /// RecursiveDir (built-in, non-derivable metadata) must survive TaskParameter
         /// serialization, which is the TaskHost boundary crossed in -mt mode.


### PR DESCRIPTION
Fixes #14763.

## The problem

A task that runs in a task host reads item metadata differently than the same task in the MSBuild process.

A project defines metadata on an item definition:

```xml
<ItemDefinitionGroup>
  <PreprocessCompile>
    <OutputName>%(Filename)</OutputName>
  </PreprocessCompile>
</ItemDefinitionGroup>
```

A task in the MSBuild process reads `OutputName` as `hello`. The same task in a task host reads `%(Filename)`. One build wrote a file path that ended with `\%(Filename).cs`.

The defect is old. It is easy to find now, because `-mt` sends almost all tasks to a task host.

## Terms

This description uses these terms. Each term has one meaning.

| Term | Meaning |
| --- | --- |
| task host | A separate process that runs a task. |
| engine item | `ProjectItemInstance.TaskItem`. The item type that the engine uses. |
| marshalled item | `TaskParameterTaskItem`. The item type that crosses a process boundary. |
| direct metadata | Metadata that the project sets on the item. A task can also write it. |
| definition metadata | Metadata that the item gets from an `ItemDefinitionGroup`. |
| to expand | To replace a reference such as `%(Filename)` with its value. |
| unexpanded | The value still contains `%(...)`. |
| origin | Direct or definition. See concept 1. |

## Three concepts

Read these first. The rest of this description follows from them.

### Concept 1: origin

An engine item keeps two groups of metadata. The origin of a value controls how the item reads that value.

| Origin | How the item reads it | Example |
| --- | --- | --- |
| **Direct** — the project sets it on the item, or a task writes it later | as stored. Direct metadata wins over definition metadata. | `OutputFileExtension` = `.cs` |
| **Definition** — the item gets it from an `ItemDefinitionGroup` | expanded, against this item, at the time of the read | `OutputName` = `%(Filename)`, stored as text, read as `hello` |

The item expands definition metadata at each read. The item does not expand it one time and keep the result. This is necessary. A task can change `ItemSpec`, and then `%(Filename)` must give a new value.

### Concept 2: the boundary discards the origin

```mermaid
flowchart LR
    subgraph BEFORE["Engine item: two groups"]
        direction TB
        D1["Direct<br/>OutputFileExtension = .cs"]
        I1["Definition<br/>OutputName = %(Filename)"]
    end

    subgraph AFTER["Marshalled item: one dictionary"]
        direction TB
        M1["OutputFileExtension = .cs"]
        M2["OutputName = %(Filename)"]
    end

    BEFORE -->|"CloneCustomMetadataEscaped()"| AFTER
```

`CloneCustomMetadataEscaped()` copies both groups into one dictionary. The marshalled item receives that dictionary. Thus the marshalled item does not know the origin of a value.

But the value still shows its origin. Evaluation expands all other expression types. Only a built-in metadata reference stays unexpanded. Thus a value that still contains `%(...)` is definition metadata. One exception exists. See limit 1 below.

The marshalled item uses this fact to find the origin again. This is the key point of the change. The alternative is to send the origin across the boundary. That alternative changes the serialized data, and a serialization change cannot go into a servicing branch.

### Concept 3: how the task host finds the origin

```mermaid
flowchart TB
    V["a stored value"] --> Q1{"did the task write it,<br/>after the task host<br/>received the item?"}
    Q1 -->|yes| P1["<b>Direct</b> — known<br/>recorded at the write"]
    Q1 -->|no| Q2{"is the value unexpanded?<br/>does it contain %(...)?"}
    Q2 -->|no| P2["<b>Direct</b> — known<br/>evaluation expanded it already"]
    Q2 -->|yes| P3["<b>Definition</b> — assumed"]
    P1 --> R1(["read as stored"])
    P2 --> R2(["read as stored"])
    P3 --> R3(["read expanded"])
    P3 -.->|"the one wrong result"| W["direct metadata that contains %(...)<br/>as stored text. It arrives here only<br/>after a task output made the item flat."]
```

Two questions give the origin. The first question has a known answer. The second question has an assumed answer.

The code uses these names:

| Name | Purpose |
| --- | --- |
| `_writtenByTask` | The first question. |
| `IsUnexpanded` | The second question. |
| `ExpandIfFromItemDefinition` | The full decision. |

Not all reads use this decision. The next table gives the rule.

| Reads that give a value to a task | Reads that give the full collection |
| --- | --- |
| `GetMetadata`, `GetMetadataValueEscaped`, `CopyMetadataTo`, and the `TaskItem` copy constructor that calls it | `CloneCustomMetadata`, `CloneCustomMetadataEscaped`, `EnumerateMetadata` |
| **expand** | **do not expand** |
| The task gets a complete value. The destination of a copy cannot hold an unexpanded value. | These reads copy the collection of the engine item. The value goes back to the engine without a change. |

If you add an accessor, put it on the side of the accessor that it resembles. The type-level comment in the code gives this rule.

## The changes

Each row is a way for a task to detect that it runs in a task host. All rows were measured. The test ran the same task two times: in the MSBuild process, and with `TaskHostFactory`. The item is `folder\hello.txt`. The definition sets `NameMeta` to `%(Filename)`.

| # | Difference | In process | In task host, before | Change that corrects it |
| --- | --- | --- | --- | --- |
| 1 | The task reads the metadata. | `hello` | `%(Filename)` | `GetMetadataValueEscaped` calls `ExpandIfFromItemDefinition`. This is concept 3. |
| 2 | The task changes `ItemSpec`, then reads again. | `renamed` | `%(Filename)` | The same change. The item expands at each read, thus the value follows `ItemSpec`. |
| 3 | The definition uses `%(RecursiveDir)`, for example `out\%(RecursiveDir)%(Filename)%(Extension)`. | `out\sub1\sub2\hello.txt` | `out\%(RecursiveDir)hello.txt` | The item reads `RecursiveDir` from its own metadata. `RecursiveDir` comes from the wildcard, not from `ItemSpec`. |
| 4 | The task copies its input with `new TaskItem(input)` or `CopyMetadataTo`. | `hello` | `%(Filename)` | `CopyMetadataTo` expands. This is what `BulkImportMetadata` does on the engine item. |
| 5 | The task reads `%(FullPath)`, changes `ItemSpec`, then reads again. | the new path | the old path | Both `ItemSpec` setters call `_cachedModifiers.Clear()`. The engine item does this already. |

Two notes on that table.

Row 4 is important. Many tasks create `new TaskItem(input)`. Without this change, the defect stays for those tasks.

Row 5 is an old defect, not a new one. The released MSBuild gives the same old path for a direct `%(FullPath)` read after a change to `ItemSpec`. This change corrects it, because concept 3 would otherwise put the same defect into definition metadata.

These conditions do not change:

| Condition | In process | In task host | Reason |
| --- | --- | --- | --- |
| The item sets the metadata directly. | `explicit` | `explicit` | Direct metadata wins in both processes. |
| The value is `%25(Filename)`. | `%(Filename)` | `%(Filename)` | Escaped text is not an expression. |
| The task writes `%(Filename)`, then reads it. | `%(Filename)` | `%(Filename)` | `_writtenByTask`. This is question 1 of concept 3. |
| The task writes `%(Filename)`, then copies the item. | `%(Filename)` | `%(Filename)` | The same. The copy keeps the value. |
| The project reads the item after a task output. | `%(Filename)` | `%(Filename)` | Reads that give the full collection do not expand. |

## Two known limits

**Limit 1. Direct metadata that contains `%(...)` as text, after a task output.**

`GatherTaskItemOutputs` makes task outputs flat in the MSBuild process. After that, such a value looks the same as definition metadata. The task host then expands it.

To find this limit, a build must do all of these steps:

1. A task writes `%(Filename)` as text.
2. The task returns the item.
3. A second task reads the value.
4. The build compares the value against text that contains `%(`.

Steps 1 to 3 keep the correct value inside one task. Only step 4 can show the difference. No MSBuild code expands `%(...)` in metadata after evaluation. Thus the value is text that has no function. To remove this limit, the change must add data to the serialized item.

**Limit 2. A reference with an item type, for example `%(Thing.Filename)`.**

The engine uses a metadata table that has no item type. Thus such a reference gives an empty value in the MSBuild process. The task host keeps the text.

An empty value here is not better. It would remove all text of that shape. This condition is the same as before the change. A test holds this decision.

## Compatibility

The change does not modify the serialized data. Thus there is no version negotiation and no packet version increase. A task host from older sources runs older code and does not change its behavior.

`TaskParameter` is used only when items cross a process boundary. The four users are `TaskHostConfiguration`, `TaskHostTaskComplete`, `TaskHostBuildResponse`, and the RAR node. Thus the change does not affect a task in the MSBuild process.

The CLR2 task host has its own copy of `TaskParameter`. The change does not affect it.

**No change wave.** The change replaces two kinds of value: text that no build can use, and an old path. A project cannot select the task host under `-mt`. Thus no build selected the current behavior. A change wave also stops a clean backport, because the current wave does not exist in the servicing branches.

The backport was tested. Both commits go into `vs18.9` and `vs18.10` with no conflict. Both branches build and pass the tests. On a `vs18.9` build, the example gives `hello`. The released 18.9.1 gives `%(Filename)`.

## Tests

`TaskParameter_Tests` covers the five differences above. It also covers escaped text, spaces in a reference, an incomplete reference, collection reads, and a second boundary crossing. Most tests compare the marshalled item against the engine item. They do not use a fixed value. Thus the two item types cannot become different without a test failure.

One test is a theory over `ItemSpecModifiers.All`. A new modifier gets a test automatically.

`ItemDefinitionMetadataInTaskHost_Tests` runs a task in a real task host. Each test asserts the process of the task, then compares the value against the value from the MSBuild process.

Each change was removed one time to confirm that its own test fails. The `RecursiveDir` code was also tested with a mutation.
