### PR TITLE
Reduce PropertyDictionary lock allocations

### DIFF
--- a/src/Build.UnitTests/Collections/OMcollections_tests.cs
+++ b/src/Build.UnitTests/Collections/OMcollections_tests.cs
@@ -104,9 +104,9 @@ namespace Microsoft.Build.UnitTests.OM.Collections
             int deserializedMarker = 0;
             readTranslator.Translate(ref deserializedMarker);
 
-            Assert.Equal(3, properties.Count);
-            Assert.Equal(2, deserializedProperties.Count);
-            Assert.Equal(marker, deserializedMarker);
+            properties.Count.ShouldBe(3);
+            deserializedProperties.Count.ShouldBe(2);
+            deserializedMarker.ShouldBe(marker);
         }
 
         [Fact]
@@ -123,9 +123,9 @@ namespace Microsoft.Build.UnitTests.OM.Collections
             properties.Remove(p1.Name);
             properties.Set(GetPropertyInstance("p3", "v3"));
 
-            Assert.Equal(2, snapshot.Length);
-            Assert.Contains(p1, snapshot);
-            Assert.Contains(p2, snapshot);
+            snapshot.Length.ShouldBe(2);
+            snapshot.ShouldContain(p1);
+            snapshot.ShouldContain(p2);
         }
 
         [Fact]
@@ -138,7 +138,7 @@ namespace Microsoft.Build.UnitTests.OM.Collections
                 return property;
             }).ToList();
 
-            Assert.Equal(2, copied.Count);
+            copied.Count.ShouldBe(2);
 
             properties = CreateProperties();
             ProjectPropertyInstance p1 = properties["p1"];
@@ -149,7 +149,7 @@ namespace Microsoft.Build.UnitTests.OM.Collections
             });
             p1.EvaluatedValue = "changed";
 
-            Assert.Contains("v1", filtered);
+            filtered.ShouldContain("v1");
 
             properties = CreateProperties();
             List<PropertyData> enumerated = [];
@@ -159,7 +159,7 @@ namespace Microsoft.Build.UnitTests.OM.Collections
                 properties.Set(GetPropertyInstance("p3", "v3"));
             }
 
-            Assert.Equal(2, enumerated.Count);
+            enumerated.Count.ShouldBe(2);
 
             static PropertyDictionary<ProjectPropertyInstance> CreateProperties()
             {

--- a/src/Build.UnitTests/Collections/OMcollections_tests.cs
+++ b/src/Build.UnitTests/Collections/OMcollections_tests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using Microsoft.Build.BackEnd;
 using Microsoft.Build.Collections;
@@ -81,6 +82,92 @@ namespace Microsoft.Build.UnitTests.OM.Collections
             TranslationHelpers.GetReadTranslator().TranslateDictionary<PropertyDictionary<ProjectPropertyInstance>, ProjectPropertyInstance>(ref deserializedProperties, ProjectPropertyInstance.FactoryForDeserialization);
 
             Assert.Equal(properties, deserializedProperties);
+        }
+
+        [Fact]
+        public void PropertyDictionarySpecializedSerializationUsesSingleSnapshot()
+        {
+            var properties = new PropertyDictionary<ProjectPropertyInstance>();
+            properties.Set(GetPropertyInstance("p1", "v1"));
+            properties.Set(GetPropertyInstance("p2", "v2"));
+
+            using var stream = new MutatingMemoryStream(() => properties.Set(GetPropertyInstance("p3", "v3")));
+            ITranslator writeTranslator = BinaryTranslator.GetWriteTranslator(stream);
+            writeTranslator.TranslateProjectPropertyInstanceDictionary(ref properties);
+            int marker = 0x12345678;
+            writeTranslator.Translate(ref marker);
+
+            stream.Position = 0;
+            PropertyDictionary<ProjectPropertyInstance> deserializedProperties = null;
+            ITranslator readTranslator = BinaryTranslator.GetReadTranslator(stream, InterningBinaryReader.PoolingBuffer);
+            readTranslator.TranslateProjectPropertyInstanceDictionary(ref deserializedProperties);
+            int deserializedMarker = 0;
+            readTranslator.Translate(ref deserializedMarker);
+
+            Assert.Equal(3, properties.Count);
+            Assert.Equal(2, deserializedProperties.Count);
+            Assert.Equal(marker, deserializedMarker);
+        }
+
+        [Fact]
+        public void PropertyDictionarySnapshotRemainsStableAfterMutation()
+        {
+            var properties = new PropertyDictionary<ProjectPropertyInstance>();
+            ProjectPropertyInstance p1 = GetPropertyInstance("p1", "v1");
+            ProjectPropertyInstance p2 = GetPropertyInstance("p2", "v2");
+            properties.Set(p1);
+            properties.Set(p2);
+
+            ProjectPropertyInstance[] snapshot = properties.GetSnapshot();
+
+            properties.Remove(p1.Name);
+            properties.Set(GetPropertyInstance("p3", "v3"));
+
+            Assert.Equal(2, snapshot.Length);
+            Assert.Contains(p1, snapshot);
+            Assert.Contains(p2, snapshot);
+        }
+
+        [Fact]
+        public void PropertyDictionaryProjectedSnapshotsAllowMutation()
+        {
+            PropertyDictionary<ProjectPropertyInstance> properties = CreateProperties();
+            List<ProjectPropertyInstance> copied = properties.GetCopyOnReadEnumerable(property =>
+            {
+                properties.Set(GetPropertyInstance("p3", "v3"));
+                return property;
+            }).ToList();
+
+            Assert.Equal(2, copied.Count);
+
+            properties = CreateProperties();
+            ProjectPropertyInstance p1 = properties["p1"];
+            IEnumerable<string> filtered = properties.Filter(_ => true, property =>
+            {
+                properties.Set(GetPropertyInstance("p3", "v3"));
+                return property.EvaluatedValue;
+            });
+            p1.EvaluatedValue = "changed";
+
+            Assert.Contains("v1", filtered);
+
+            properties = CreateProperties();
+            List<PropertyData> enumerated = [];
+            foreach (PropertyData property in properties.Enumerate())
+            {
+                enumerated.Add(property);
+                properties.Set(GetPropertyInstance("p3", "v3"));
+            }
+
+            Assert.Equal(2, enumerated.Count);
+
+            static PropertyDictionary<ProjectPropertyInstance> CreateProperties()
+            {
+                var result = new PropertyDictionary<ProjectPropertyInstance>();
+                result.Set(GetPropertyInstance("p1", "v1"));
+                result.Set(GetPropertyInstance("p2", "v2"));
+                return result;
+            }
         }
 
         /// <summary>
@@ -324,6 +411,34 @@ namespace Microsoft.Build.UnitTests.OM.Collections
             ProjectItemInstance item = projectInstance.AddItem(itemType, evaluatedInclude);
 
             return item;
+        }
+
+        private sealed class MutatingMemoryStream(Action mutation) : MemoryStream
+        {
+            private bool _mutated;
+
+            public override void Write(byte[] buffer, int offset, int count)
+            {
+                MutateBeforeWritingPropertyCount(count);
+                base.Write(buffer, offset, count);
+            }
+
+#if NET
+            public override void Write(ReadOnlySpan<byte> buffer)
+            {
+                MutateBeforeWritingPropertyCount(buffer.Length);
+                base.Write(buffer);
+            }
+#endif
+
+            private void MutateBeforeWritingPropertyCount(int byteCount)
+            {
+                if (!_mutated && byteCount == sizeof(int))
+                {
+                    _mutated = true;
+                    mutation();
+                }
+            }
         }
 
         /// <summary>

--- a/src/Build/BackEnd/Components/Communications/TranslatorExtensions.cs
+++ b/src/Build/BackEnd/Components/Communications/TranslatorExtensions.cs
@@ -48,10 +48,11 @@ namespace Microsoft.Build.BackEnd
             }
             else // TranslationDirection.WriteToStream
             {
-                int count = value.Count;
+                ProjectPropertyInstance[] properties = value.GetSnapshot();
+                int count = properties.Length;
                 translator.Translate(ref count);
 
-                foreach (ProjectPropertyInstance instance in value)
+                foreach (ProjectPropertyInstance instance in properties)
                 {
                     ProjectPropertyInstance instanceForSerialization = instance;
                     translator.Translate(ref instanceForSerialization, ProjectPropertyInstance.FactoryForDeserialization);

--- a/src/Build/Collections/PropertyDictionary.cs
+++ b/src/Build/Collections/PropertyDictionary.cs
@@ -2,13 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Buffers;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Threading;
 using Microsoft.Build.Evaluation;
 using Microsoft.Build.Framework;
-using Microsoft.Build.Internal;
 using Microsoft.Build.Shared;
 
 #nullable disable
@@ -28,9 +27,9 @@ namespace Microsoft.Build.Collections
     /// Really a Dictionary&lt;string, T&gt; where the key (the name) is obtained from IKeyed.Key.
     /// Is not observable, so if clients wish to observe modifications they must mediate them themselves and
     /// either not expose this collection or expose it through a readonly wrapper.
-    /// Uses ReaderWriterLockSlim to allow multiple concurrent readers while preventing deadlocks that can occur
-    /// with exclusive locks during enumeration.
-    /// 
+    /// Access to the mutable backing collection is synchronized on the collection itself. Callers that need to
+    /// enumerate concurrently with mutation must use a snapshot.
+    ///
     /// Since we use the mutable ignore case comparer we need to make sure that we lock our self before we call the comparer since the comparer can call back
     /// into this dictionary which could cause a deadlock if another thread is also accessing another method in the dictionary.
     /// </remarks>
@@ -44,11 +43,6 @@ namespace Microsoft.Build.Collections
         /// </summary>
         [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
         private readonly IRetrievableValuedEntryHashSet<T> _properties;
-
-        /// <summary>
-        /// Reader-writer lock to prevent deadlocks during enumeration.
-        /// </summary>
-        private readonly ReaderWriterLockSlim _lock = new(LockRecursionPolicy.SupportsRecursion);
 
         /// <summary>
         /// Creates empty dictionary.
@@ -122,7 +116,7 @@ namespace Microsoft.Build.Collections
         {
             get
             {
-                using (_lock.EnterDisposableReadLock())
+                lock (_properties)
                 {
                     return _properties.Values;
                 }
@@ -148,7 +142,7 @@ namespace Microsoft.Build.Collections
         {
             get
             {
-                using (_lock.EnterDisposableReadLock())
+                lock (_properties)
                 {
                     return ((ICollection<T>)_properties).Count;
                 }
@@ -188,7 +182,7 @@ namespace Microsoft.Build.Collections
                 // We don't want to check for a zero length name here, since that is a valid name
                 // and should return a null instance which will be interpreted as blank
                 T projectProperty;
-                using (_lock.EnterDisposableReadLock())
+                lock (_properties)
                 {
                     _properties.TryGetValue(name, out projectProperty);
                 }
@@ -209,7 +203,15 @@ namespace Microsoft.Build.Collections
         /// </summary>
         public IEnumerable<TResult> GetCopyOnReadEnumerable<TResult>(Func<T, TResult> selector)
         {
-            return new CopyOnReadEnumerable<T, TResult>(this, _properties, selector);
+            return EnumerateSnapshot(selector);
+        }
+
+        private IEnumerable<TResult> EnumerateSnapshot<TResult>(Func<T, TResult> selector)
+        {
+            foreach (TResult result in GetProjectedSnapshot(null, selector))
+            {
+                yield return result;
+            }
         }
 
         /// <summary>
@@ -226,7 +228,7 @@ namespace Microsoft.Build.Collections
         /// </summary>
         public void Clear()
         {
-            using (_lock.EnterDisposableWriteLock())
+            lock (_properties)
             {
                 ((ICollection<T>)_properties).Clear();
             }
@@ -238,27 +240,24 @@ namespace Microsoft.Build.Collections
         /// </summary>
         public IEnumerator<T> GetEnumerator()
         {
-            using (_lock.EnterDisposableReadLock())
+            // PERF: Prefer the struct enumerator from the concrete hash set to avoid the allocation
+            // caused by boxing when iterating _properties.Values through the ICollection<T> interface.
+            // This fast path is the common case and hot (e.g. per-item metadata enumeration during
+            // ProjectInstance creation): all metadata and normally-constructed property dictionaries
+            // are backed by RetrievableValuedEntryHashSet<T>. The else branch only covers the rare
+            // linked/immutable-project converter types that also implement IRetrievableValuedEntryHashSet<T>.
+            if (_properties is RetrievableValuedEntryHashSet<T> hashSet)
             {
-                // PERF: Prefer the struct enumerator from the concrete hash set to avoid the allocation
-                // caused by boxing when iterating _properties.Values through the ICollection<T> interface.
-                // This fast path is the common case and hot (e.g. per-item metadata enumeration during
-                // ProjectInstance creation): all metadata and normally-constructed property dictionaries
-                // are backed by RetrievableValuedEntryHashSet<T>. The else branch only covers the rare
-                // linked/immutable-project converter types that also implement IRetrievableValuedEntryHashSet<T>.
-                if (_properties is RetrievableValuedEntryHashSet<T> hashSet)
+                foreach (T item in hashSet)
                 {
-                    foreach (T item in hashSet)
-                    {
-                        yield return item;
-                    }
+                    yield return item;
                 }
-                else
+            }
+            else
+            {
+                foreach (T item in _properties.Values)
                 {
-                    foreach (T item in _properties.Values)
-                    {
-                        yield return item;
-                    }
+                    yield return item;
                 }
             }
         }
@@ -288,20 +287,18 @@ namespace Microsoft.Build.Collections
                 return true;
             }
 
-            if (Count != other.Count)
+            T[] properties = GetSnapshot();
+            if (properties.Length != other.Count)
             {
                 return false;
             }
 
-            using (_lock.EnterDisposableReadLock())
+            foreach (T leftProp in properties)
             {
-                foreach (T leftProp in _properties.Values)
+                T rightProp = other[leftProp.Key];
+                if (rightProp?.Equals(leftProp) != true)
                 {
-                    T rightProp = other[leftProp.Key];
-                    if (rightProp?.Equals(leftProp) != true)
-                    {
-                        return false;
-                    }
+                    return false;
                 }
             }
 
@@ -325,7 +322,7 @@ namespace Microsoft.Build.Collections
         /// </summary>
         public T GetProperty(string name, int startIndex, int endIndex)
         {
-            using (_lock.EnterDisposableReadLock())
+            lock (_properties)
             {
                 return _properties.Get(name, startIndex, endIndex - startIndex + 1);
             }
@@ -378,7 +375,7 @@ namespace Microsoft.Build.Collections
         /// </summary>
         bool IDictionary<string, T>.ContainsKey(string key)
         {
-            using (_lock.EnterDisposableReadLock())
+            lock (_properties)
             {
                 return _properties.ContainsKey(key);
             }
@@ -427,7 +424,7 @@ namespace Microsoft.Build.Collections
         /// </summary>
         bool ICollection<KeyValuePair<string, T>>.Contains(KeyValuePair<string, T> item)
         {
-            using (_lock.EnterDisposableReadLock())
+            lock (_properties)
             {
                 if (_properties.TryGetValue(item.Key, out T value))
                 {
@@ -468,7 +465,7 @@ namespace Microsoft.Build.Collections
         /// <inheritdoc/>
         void ICollection<T>.CopyTo(T[] array, int arrayIndex)
         {
-            using (_lock.EnterDisposableWriteLock())
+            lock (_properties)
             {
                 _properties.CopyTo(array, arrayIndex);
             }
@@ -486,13 +483,7 @@ namespace Microsoft.Build.Collections
         /// </summary>
         IEnumerator<KeyValuePair<string, T>> IEnumerable<KeyValuePair<string, T>>.GetEnumerator()
         {
-            using (_lock.EnterDisposableReadLock())
-            {
-                foreach (KeyValuePair<string, T> kvp in (IEnumerable<KeyValuePair<string, T>>)_properties)
-                {
-                    yield return kvp;
-                }
-            }
+            return ((IEnumerable<KeyValuePair<string, T>>)_properties).GetEnumerator();
         }
 
         #endregion
@@ -506,7 +497,7 @@ namespace Microsoft.Build.Collections
         {
             ArgumentException.ThrowIfNullOrEmpty(name);
 
-            using (_lock.EnterDisposableWriteLock())
+            lock (_properties)
             {
                 bool result = _properties.Remove(name);
                 return result;
@@ -522,7 +513,7 @@ namespace Microsoft.Build.Collections
         {
             ArgumentNullException.ThrowIfNull(projectProperty);
 
-            using (_lock.EnterDisposableWriteLock())
+            lock (_properties)
             {
                 _properties[projectProperty.Key] = projectProperty;
             }
@@ -561,7 +552,7 @@ namespace Microsoft.Build.Collections
         /// </summary>
         internal Dictionary<string, string> ToDictionary()
         {
-            using (_lock.EnterDisposableReadLock())
+            lock (_properties)
             {
                 var dictionary = new Dictionary<string, string>(((ICollection<T>)_properties).Count, MSBuildNameIgnoreCaseComparer.Default);
 
@@ -574,6 +565,25 @@ namespace Microsoft.Build.Collections
             }
         }
 
+        /// <summary>
+        /// Returns a stable snapshot for callers that enumerate concurrently with mutation.
+        /// </summary>
+        internal T[] GetSnapshot()
+        {
+            lock (_properties)
+            {
+                int count = ((ICollection<T>)_properties).Count;
+                if (count == 0)
+                {
+                    return [];
+                }
+
+                var snapshot = new T[count];
+                _properties.CopyTo(snapshot);
+                return snapshot;
+            }
+        }
+
         internal IDictionary<string, string> ToReadOnlyDictionary()
         {
             return _properties is IValueDictionaryConverter converter
@@ -583,13 +593,7 @@ namespace Microsoft.Build.Collections
 
         internal IEnumerable<PropertyData> Enumerate()
         {
-            using (_lock.EnterDisposableReadLock())
-            {
-                foreach (var kvp in (ICollection<T>)_properties)
-                {
-                    yield return new(kvp.Key, EscapingUtilities.UnescapeAll(kvp.EscapedValue));
-                }
-            }
+            return EnumerateSnapshot(static property => new PropertyData(property.Key, EscapingUtilities.UnescapeAll(property.EscapedValue)));
         }
 
         internal void Enumerate(Action<string, string> keyValueCallback)
@@ -602,36 +606,39 @@ namespace Microsoft.Build.Collections
 
         internal IEnumerable<TResult> Filter<TResult>(Func<T, bool> filter, Func<T, TResult> selector)
         {
-            using (_lock.EnterDisposableReadLock())
+            return GetProjectedSnapshot(filter, selector);
+        }
+
+        private List<TResult> GetProjectedSnapshot<TResult>(Func<T, bool> filter, Func<T, TResult> selector)
+        {
+            T[] properties = null;
+            int count = 0;
+            try
             {
-                // PERF: Prefer using struct enumerators from the concrete types to avoid allocations.
-                // RetrievableValuedEntryHashSet implements a struct enumerator.
-                if (_properties is RetrievableValuedEntryHashSet<T> hashSet)
+                lock (_properties)
                 {
-                    List<TResult> result = new(hashSet.Count);
-                    foreach (T property in hashSet)
-                    {
-                        if (filter(property))
-                        {
-                            result.Add(selector(property));
-                        }
-                    }
-
-                    return result;
+                    count = ((ICollection<T>)_properties).Count;
+                    properties = ArrayPool<T>.Shared.Rent(count);
+                    _properties.CopyTo(properties);
                 }
-                else
-                {
-                    ICollection<T> propertiesCollection = _properties;
-                    List<TResult> result = new(propertiesCollection.Count);
-                    foreach (T property in propertiesCollection)
-                    {
-                        if (filter(property))
-                        {
-                            result.Add(selector(property));
-                        }
-                    }
 
-                    return result;
+                List<TResult> result = new(count);
+                for (int i = 0; i < count; i++)
+                {
+                    T property = properties[i];
+                    if (filter is null || filter(property))
+                    {
+                        result.Add(selector(property));
+                    }
+                }
+
+                return result;
+            }
+            finally
+            {
+                if (properties is not null)
+                {
+                    ArrayPool<T>.Shared.Return(properties, clearArray: true);
                 }
             }
         }

--- a/src/Build/Collections/PropertyDictionary.cs
+++ b/src/Build/Collections/PropertyDictionary.cs
@@ -638,7 +638,8 @@ namespace Microsoft.Build.Collections
             {
                 if (properties is not null)
                 {
-                    ArrayPool<T>.Shared.Return(properties, clearArray: true);
+                    Array.Clear(properties, 0, count);
+                    ArrayPool<T>.Shared.Return(properties, clearArray: false);
                 }
             }
         }


### PR DESCRIPTION
Fixes #14769

### Context

PR #12264 added a per-instance `ReaderWriterLockSlim` to `PropertyDictionary<T>` to protect concurrent enumeration. `PropertyDictionary<T>` is created frequently during evaluation and project-instance construction, so the eager lock contributes substantial allocation overhead.

### Changes Made

- Replaced the per-instance `ReaderWriterLockSlim` with synchronization on the existing backing collection for point operations.
- Added `GetSnapshot()` for stable concurrent enumeration without retaining a collection lock.
- Updated `TranslateProjectPropertyInstanceDictionary` to serialize the count and entries from the same snapshot.
- Added pooled projected snapshots for callback-based enumeration so delegates run outside collection locks.
- Added regression coverage for concurrent serialization, snapshot stability, callback mutation, and projected-value timing.

### Testing

- Built with `.\build.cmd -v quiet` — 0 warnings, 0 errors.
- Added and ran focused tests in `OMcollections_Tests`:
  - `PropertyDictionarySpecializedSerializationUsesSingleSnapshot` — verifies mutation after the serialized count does not corrupt the stream.
  - `PropertyDictionarySnapshotRemainsStableAfterMutation` — verifies subsequent dictionary mutations do not alter a snapshot.
  - `PropertyDictionaryProjectedSnapshotsAllowMutation` — verifies callback-driven enumeration permits mutation and captures projected values consistently.
  - Result: 15 passed, 0 failed.