### PR TITLE
[DO NOT MERGE] Verify ComReferenceWalker test result uploads

### DIFF
--- a/src/Framework.UnitTests/Assumed_Tests.cs
+++ b/src/Framework.UnitTests/Assumed_Tests.cs
@@ -12,12 +12,6 @@ namespace Microsoft.Build.UnitTests;
 public class Assumed_Tests
 {
     [Fact]
-    public void AzureDevOpsResultUploadProbe()
-    {
-        true.ShouldBeFalse("Intentional failure to verify Azure DevOps test result uploads");
-    }
-
-    [Fact]
     public void Null_DoesNotThrow_WhenNull()
     {
         Assumed.Null<string>(null);

--- a/src/Framework.UnitTests/Assumed_Tests.cs
+++ b/src/Framework.UnitTests/Assumed_Tests.cs
@@ -12,6 +12,12 @@ namespace Microsoft.Build.UnitTests;
 public class Assumed_Tests
 {
     [Fact]
+    public void AzureDevOpsResultUploadProbe()
+    {
+        true.ShouldBeFalse("Intentional failure to verify Azure DevOps test result uploads");
+    }
+
+    [Fact]
     public void Null_DoesNotThrow_WhenNull()
     {
         Assumed.Null<string>(null);

--- a/src/Tasks.UnitTests/ComReferenceWalker_Tests.cs
+++ b/src/Tasks.UnitTests/ComReferenceWalker_Tests.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.Build.Tasks;
+using Shouldly;
 using Xunit;
 using Windows.Win32.System.Com;
 using Windows.Win32.System.Ole;
@@ -183,6 +184,8 @@ namespace Microsoft.Build.UnitTests
 
             dependencyTypeLib2.AssertAllHandlesReleased();
             dependencyTypeLib3.AssertAllHandlesReleased();
+
+            true.ShouldBeFalse("Intentional failure to verify Azure DevOps result details for ComReferenceWalker_Tests.DefinedFunction");
         }
 
         [Fact]


### PR DESCRIPTION
## Summary

Adds an intentional failure at the end of `Microsoft.Build.UnitTests.ComReferenceWalker_Tests.DefinedFunction` to inspect Azure DevOps test-result publishing for this previously uninformative flaky failure.

The expected message is `Intentional failure to verify Azure DevOps result details for ComReferenceWalker_Tests.DefinedFunction`.

## Local result

The filtered .NET Framework run reported 1 failed, 0 succeeded, and 0 skipped, including the assertion message and source location. `MSBUILDUSECOORDINATOR` was unset for local build and test execution.