### PR TITLE
Fix BuildCheck rule configuration and task name casing bug

### DIFF
--- a/documentation/specs/BuildCheck/Codes.md
+++ b/documentation/specs/BuildCheck/Codes.md
@@ -15,7 +15,7 @@ Report codes are chosen to conform to suggested guidelines. Those guidelines are
 | [BC0201](#bc0201---usage-of-undefined-property) | Warning | Project | 9.0.100 | Usage of undefined property. |
 | [BC0202](#bc0202---property-first-declared-after-it-was-used) | Warning | Project | 9.0.100 | Property first declared after it was used. |
 | [BC0203](#bc0203----property-declared-but-never-used) | None | Project | 9.0.100 | Property declared but never used. |
-| [BC0301](#bc0301---building-from-downloads-folder) | None | Project | 9.0.300 | Building from Downloads folder. |
+| [BC0301](#bc0301---building-from-downloads-folder) | Error | Project | 9.0.300 | Building from Downloads folder. |
 | [BC0302](#bc0302---building-using-the-exec-task) | Warning | N/A | 9.0.300 | Building using the Exec task. |
 
 Notes: 

--- a/src/Build/BuildCheck/Checks/DoubleWritesCheck.cs
+++ b/src/Build/BuildCheck/Checks/DoubleWritesCheck.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.IO;
 #endif
 using System.Linq;
+using Microsoft.Build.Collections;
 using Microsoft.Build.Shared;
 using static Microsoft.Build.Experimental.BuildCheck.TaskInvocationCheckData;
 
@@ -49,14 +50,22 @@ internal sealed class DoubleWritesCheck : Check
     private void TaskInvocationAction(BuildCheckDataContext<TaskInvocationCheckData> context)
     {
         // This check uses a hard-coded list of tasks known to write files.
-        switch (context.Data.TaskName)
+        // Task names are matched case-insensitively - MSBuild resolves task names without regard to casing,
+        // so the logged name carries whatever casing the project author used.
+        string taskName = context.Data.TaskName;
+
+        if (IsTask(taskName, "Csc") || IsTask(taskName, "Vbc") || IsTask(taskName, "Fsc"))
         {
-            case "Csc":
-            case "Vbc":
-            case "Fsc": CheckCompilerTask(context); break;
-            case "Copy": CheckCopyTask(context); break;
+            CheckCompilerTask(context);
+        }
+        else if (IsTask(taskName, "Copy"))
+        {
+            CheckCopyTask(context);
         }
     }
+
+    private static bool IsTask(string taskName, string expectedTaskName)
+        => MSBuildNameIgnoreCaseComparer.Default.Equals(taskName, expectedTaskName);
 
     private void CheckCompilerTask(BuildCheckDataContext<TaskInvocationCheckData> context)
     {

--- a/src/Build/BuildCheck/Checks/DoubleWritesCheck.cs
+++ b/src/Build/BuildCheck/Checks/DoubleWritesCheck.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections.Frozen;
 using System.Collections.Generic;
 #if !FEATURE_MSIOREDIST
 using System.IO;
@@ -47,6 +48,11 @@ internal sealed class DoubleWritesCheck : Check
     /// </summary>
     private readonly Dictionary<string, (string projectFilePath, string taskName)> _filesWritten = new(StringComparer.CurrentCultureIgnoreCase);
 
+    /// <summary>
+    /// Compiler tasks known to write files.
+    /// </summary>
+    private static readonly FrozenSet<string> s_compilerTaskNames = new[] { "Csc", "Vbc", "Fsc" }.ToFrozenSet(MSBuildNameIgnoreCaseComparer.Default);
+
     private void TaskInvocationAction(BuildCheckDataContext<TaskInvocationCheckData> context)
     {
         // This check uses a hard-coded list of tasks known to write files.
@@ -54,18 +60,15 @@ internal sealed class DoubleWritesCheck : Check
         // so the logged name carries whatever casing the project author used.
         string taskName = context.Data.TaskName;
 
-        if (IsTask(taskName, "Csc") || IsTask(taskName, "Vbc") || IsTask(taskName, "Fsc"))
+        if (s_compilerTaskNames.Contains(taskName))
         {
             CheckCompilerTask(context);
         }
-        else if (IsTask(taskName, "Copy"))
+        else if (MSBuildNameIgnoreCaseComparer.Default.Equals(taskName, "Copy"))
         {
             CheckCopyTask(context);
         }
     }
-
-    private static bool IsTask(string taskName, string expectedTaskName)
-        => MSBuildNameIgnoreCaseComparer.Default.Equals(taskName, expectedTaskName);
 
     private void CheckCompilerTask(BuildCheckDataContext<TaskInvocationCheckData> context)
     {

--- a/src/Build/BuildCheck/Checks/ExecCliBuildCheck.cs
+++ b/src/Build/BuildCheck/Checks/ExecCliBuildCheck.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 #if !FEATURE_MSIOREDIST
 using System.IO;
 #endif
+using Microsoft.Build.Collections;
 using Microsoft.Build.Shared;
 
 #if FEATURE_MSIOREDIST
@@ -61,7 +62,9 @@ internal sealed class ExecCliBuildCheck : Check
 
     private static void TaskInvocationAction(BuildCheckDataContext<TaskInvocationCheckData> context)
     {
-        if (context.Data.TaskName == ExecTaskName
+        // Task names are matched case-insensitively - MSBuild resolves task names without regard to casing,
+        // so the logged name carries whatever casing the project author used.
+        if (MSBuildNameIgnoreCaseComparer.Default.Equals(context.Data.TaskName, ExecTaskName)
             && context.Data.Parameters.TryGetValue(CommandParameterName, out TaskInvocationCheckData.TaskParameter? commandArgument))
         {
             var execCommandValue = commandArgument.Value?.ToString() ?? string.Empty;

--- a/src/Build/BuildCheck/Checks/PropertiesUsageCheck.cs
+++ b/src/Build/BuildCheck/Checks/PropertiesUsageCheck.cs
@@ -58,7 +58,7 @@ internal class PropertiesUsageCheck : WorkerNodeCheck
         _unusedPropertyEnabled = config.IsEnabled;
         _unusedPropertyScope = config.EvaluationCheckScope;
 
-        config = configurationContext.CheckConfig.FirstOrDefault(c => c.RuleId == _usedBeforeInitializedRule.Id)
+        config = configurationContext.CheckConfig.FirstOrDefault(c => c.RuleId == _initializedAfterUsedRule.Id)
                  ?? CheckConfigurationEffective.Default;
 
         _initializedAfterUseEnabled = config.IsEnabled;

--- a/src/Build/BuildCheck/Infrastructure/BuildEventsProcessor.cs
+++ b/src/Build/BuildCheck/Infrastructure/BuildEventsProcessor.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.Build.Collections;
 using Microsoft.Build.Construction;
 using Microsoft.Build.Evaluation;
 using Microsoft.Build.Framework;
@@ -149,7 +150,9 @@ internal class BuildEventsProcessor(BuildCheckCentralContext buildCheckCentralCo
 
             // Add a new entry to _tasksBeingExecuted. TaskParameters are initialized empty and will be recorded
             // based on TaskParameterEventArgs we receive later.
-            Dictionary<string, TaskInvocationCheckData.TaskParameter> taskParameters = new();
+            // Parameter names are MSBuild names - compare them case-insensitively so checks are not sensitive
+            // to the casing a project author happened to use.
+            Dictionary<string, TaskInvocationCheckData.TaskParameter> taskParameters = new(MSBuildNameIgnoreCaseComparer.Default);
 
             ExecutingTaskData taskData = new()
             {

--- a/src/BuildCheck.UnitTests/DoubleWritesAnalyzer_Tests.cs
+++ b/src/BuildCheck.UnitTests/DoubleWritesAnalyzer_Tests.cs
@@ -54,9 +54,32 @@ namespace Microsoft.Build.BuildCheck.UnitTests
         }
 
         [Theory]
+        [InlineData("Copy")]
+        [InlineData("copy")]
+        [InlineData("COPY")]
+        public void TestCopyTask_TaskNameCasingIsIgnored(string taskName)
+        {
+            _registrationContext.TriggerTaskInvocationAction(MakeTaskInvocationData(taskName, new Dictionary<string, TaskInvocationCheckData.TaskParameter>
+                {
+                    { "SourceFiles", new TaskInvocationCheckData.TaskParameter("source1", IsOutput: false) },
+                    { "DestinationFolder", new TaskInvocationCheckData.TaskParameter("outdir", IsOutput: false) },
+                }));
+            _registrationContext.TriggerTaskInvocationAction(MakeTaskInvocationData(taskName, new Dictionary<string, TaskInvocationCheckData.TaskParameter>
+                {
+                    { "SourceFiles", new TaskInvocationCheckData.TaskParameter("source1", IsOutput: false) },
+                    { "DestinationFiles", new TaskInvocationCheckData.TaskParameter(Path.Combine("outdir", "source1"), IsOutput: false) },
+                }));
+
+            _registrationContext.Results.Count.ShouldBe(1);
+            _registrationContext.Results[0].CheckRule.Id.ShouldBe("BC0102");
+        }
+
+        [Theory]
         [InlineData("Csc")]
         [InlineData("Vbc")]
         [InlineData("Fsc")]
+        [InlineData("csc")]
+        [InlineData("VBC")]
         public void TestCompilerTask(string taskName)
         {
             for (int i = 0; i < 2; i++)

--- a/src/BuildCheck.UnitTests/EndToEndTests.cs
+++ b/src/BuildCheck.UnitTests/EndToEndTests.cs
@@ -66,6 +66,31 @@ public class EndToEndTests : IDisposable
         Regex.Matches(output, "BC0203 .* Property").Count.ShouldBe(2);
     }
 
+    [Fact]
+    public void PropertiesUsageCheck_RulesAreIndependentlyConfigurable()
+    {
+        PrepareSampleProjectsAndConfig(
+            buildInOutOfProcessNode: false,
+            out TransientTestFile projectFile,
+            out TransientTestFile editorconfigFile,
+            "PropsCheckTest.csproj");
+
+        // Turning BC0201 off must not turn BC0202 off - they are separately configurable rules
+        //  that happen to be implemented by a single check.
+        File.WriteAllText(
+            editorconfigFile.Path,
+            File.ReadAllText(editorconfigFile.Path)
+                .Replace("build_check.BC0201.Severity=warning", "build_check.BC0201.Severity=none"));
+
+        string output = RunnerUtilities.ExecBootstrapedMSBuild($"{projectFile.Path} -check", out bool success, timeoutMilliseconds: timeoutInMilliseconds);
+        _env.Output.WriteLine(output);
+        _env.Output.WriteLine("=========================");
+        success.ShouldBeTrue(output);
+
+        output.ShouldNotContain("BC0201");
+        output.ShouldMatch(@"BC0202: .* Property: 'MyPropT2'");
+    }
+
     [Theory]
     // The culture is not set explicitly, but the extension is a known culture
     //  - a buildcheck warning will occur, but otherwise works

--- a/src/BuildCheck.UnitTests/ExecCliBuildCheck_Tests.cs
+++ b/src/BuildCheck.UnitTests/ExecCliBuildCheck_Tests.cs
@@ -89,6 +89,32 @@ namespace Microsoft.Build.BuildCheck.UnitTests
             _registrationContext.Results.Count.ShouldBe(0);
         }
 
+        [Theory]
+        [InlineData("Exec")]
+        [InlineData("exec")]
+        [InlineData("EXEC")]
+        public void ExecTask_WithDifferingTaskNameCasing_ShouldShowWarning(string taskName)
+        {
+            _registrationContext.TriggerTaskInvocationAction(MakeTaskInvocationData(taskName, new Dictionary<string, TaskInvocationCheckData.TaskParameter>
+            {
+                { "Command", new TaskInvocationCheckData.TaskParameter("dotnet build", IsOutput: false) },
+            }));
+
+            _registrationContext.Results.Count.ShouldBe(1);
+            _registrationContext.Results[0].CheckRule.Id.ShouldBe("BC0302");
+        }
+
+        [Fact]
+        public void DifferentTask_WithBuildCommand_ShouldNotShowWarning()
+        {
+            _registrationContext.TriggerTaskInvocationAction(MakeTaskInvocationData("Message", new Dictionary<string, TaskInvocationCheckData.TaskParameter>
+            {
+                { "Command", new TaskInvocationCheckData.TaskParameter("dotnet build", IsOutput: false) },
+            }));
+
+            _registrationContext.Results.Count.ShouldBe(0);
+        }
+
         private TaskInvocationCheckData MakeTaskInvocationData(string taskName, Dictionary<string, TaskInvocationCheckData.TaskParameter> parameters)
         {
             string projectFile = Framework.NativeMethods.IsWindows ? @"C:\fake\project.proj" : "/fake/project.proj";

--- a/src/BuildCheck.UnitTests/TaskInvocationAnalysisDataTests.cs
+++ b/src/BuildCheck.UnitTests/TaskInvocationAnalysisDataTests.cs
@@ -122,6 +122,26 @@ namespace Microsoft.Build.BuildCheck.UnitTests
         }
 
         [Theory]
+        [InlineData("Text")]
+        [InlineData("text")]
+        [InlineData("TEXT")]
+        [InlineData("tExT")]
+        public void ReportsTaskParametersKeyedCaseInsensitively(string parameterName)
+        {
+            BuildProject("<Message Text='Hello'/>");
+
+            s_testCheck!.CheckData.Count.ShouldBe(1);
+            var data = s_testCheck.CheckData[0];
+
+            // Parameter names are MSBuild names, so a check must be able to look them up without
+            // knowing the casing the task author declared the property with.
+            data.Parameters.ContainsKey(parameterName).ShouldBeTrue();
+            data.Parameters.TryGetValue(parameterName, out var parameter).ShouldBeTrue();
+            parameter.ShouldNotBeNull().Value.ShouldBe("Hello");
+            data.Parameters[parameterName].Value.ShouldBe("Hello");
+        }
+
+        [Theory]
         [InlineData("<Output TaskParameter='CombinedPaths' ItemName='OutputDirectories' />")]
         [InlineData("<Output TaskParameter='CombinedPaths' PropertyName='OutputDirectories' />")]
         public void ReportsComplexTaskParameters(string outputElement)


### PR DESCRIPTION
### Context
Four BuildCheck bugs found and fixed:
- `PropertiesUsageCheck` read BC0202's config from BC0201's rule id.
- `ExecCliBuildCheck` and `DoubleWritesCheck` compared task names ordinally.
- Docs: `Codes.md` listed BC0301's default severity as `None`; it is `Error`.

### Testing
New tests added
