### PR TITLE
Correct MT routing docs and add analyzer rules for mismatched declarations

### DIFF
--- a/documentation/specs/multithreading/thread-safe-tasks.md
+++ b/documentation/specs/multithreading/thread-safe-tasks.md
@@ -10,7 +10,7 @@ Tasks that are not thread-safe can still participate in multithreaded builds. MS
 
 ## Thread-Safe Capability Indicators
 
-Task authors declare thread-safe capabilities through two mechanisms that do **different** jobs. They are not alternatives, and a fully migrated task uses both:
+Thread-safe capability is declared by a single mechanism: the `[MSBuildMultiThreadableTask]` attribute. A task may *additionally* implement the `IMultiThreadableTask` interface to gain access to thread-safe APIs. The two do **different** jobs and are not alternatives:
 
 1. **Attribute-Based Thread-Safe Capability Declaration** (`[MSBuildMultiThreadableTask]`) — the **routing** signal. This is the only thing that opts a task into running in-process; without it the task is routed to an out-of-proc TaskHost sidecar regardless of anything else it declares.
 2. **Interface-Based Thread-Safe Capability Declaration** (`IMultiThreadableTask`) — the **injection** signal. It gives the task access to thread-safe APIs through `TaskEnvironment`, which the engine assigns only to tasks implementing the interface.
@@ -22,10 +22,8 @@ Task authors declare thread-safe capabilities through two mechanisms that do **d
 
 Declaring one without the other is legal, and each half fails quietly:
 
-- **Attribute only** — a supported state. The task runs in-process without `TaskEnvironment`, which is correct for a task that does not resolve relative paths or read environment variables. If the task *does* declare a `TaskEnvironment` property, MSBuild never assigns it: the property silently retains whatever the task itself initialized it to — commonly `TaskEnvironment.Fallback`, or `null` when there is no initializer — so paths resolve against the shared process working directory. The task-authoring analyzer reports `MSBuildTask0012` for this shape.
-- **Interface only** — a useful intermediate state. The task resolves paths correctly but still pays for a TaskHost. `MSBuildTask0013` reports it, disabled by default.
-
-The interface cannot also serve as the routing signal, because `ToolTask` implements `IMultiThreadableTask`. Routing on the interface would opt in every `ToolTask`-derived task in the ecosystem, none of which have been reviewed for thread safety.
+- **Attribute only** — a complete, properly migrated state for a task that does not resolve relative paths or read environment variables. The task runs in-process without `TaskEnvironment`. If the task *does* declare a `TaskEnvironment` property, MSBuild never assigns it: the property silently retains whatever the task itself initialized it to — commonly `TaskEnvironment.Fallback`, or `null` when there is no initializer — so paths resolve against the shared process working directory. The task-authoring analyzer reports `MSBuildTask0012` for this shape.
+- **Interface only** — a useful intermediate state. The task resolves paths correctly but still pays for a TaskHost. Note that the engine does not assign the property in that TaskHost: the out-of-proc host supplies `TaskEnvironment.Fallback` to a `TaskEnvironment` constructor if the task declares one, and otherwise leaves the property at the task's own default. That is correct there, because `Fallback` is backed by `MultiProcessTaskEnvironmentDriver` and the host process is dedicated to a single task. `MSBuildTask0013` reports this shape, disabled by default.
 
 Tasks that use `TaskEnvironment` cannot load in older MSBuild versions that do not support multithreading features, requiring authors to drop support for older MSBuild versions. To address this challenge, MSBuild provides a compatibility bridge that allows certain tasks targeting older MSBuild versions to participate in multithreaded builds: the attribute is detected by name, so a task can apply it without referencing a new MSBuild assembly, and correct absolute path resolution can be and should be achieved without accessing `TaskEnvironment`. Tasks using that bridge must still avoid relying on environment variables or modifying global process state.
 
@@ -45,18 +43,6 @@ public interface IMultiThreadableTask : ITask
     TaskEnvironment TaskEnvironment { get; set; }
 }
 ```
-
-Similar to how MSBuild provides the abstract `Task` class with default implementations for the `ITask` interface, MSBuild will offer a `MultiThreadableTask` abstract class with default implementations for the `IMultiThreadableTask` interface. Task authors will only need to implement the `Execute` method for the `ITask` interface and use `TaskEnvironment` within it to create their thread-safe tasks.
-
-```csharp
-namespace Microsoft.Build.Utilities;
-public abstract class MultiThreadableTask : Task, IMultiThreadableTask
-{
-    public TaskEnvironment TaskEnvironment { get; set; } = TaskEnvironment.Fallback;
-}
-```
-
-Deriving from `MultiThreadableTask` supplies the interface but not the attribute, so a derived task must still apply `[MSBuildMultiThreadableTask]` to run in-process.
 
 Built-in MSBuild tasks initialize `TaskEnvironment` with a `MultiProcessTaskEnvironmentDriver`-backed default. This ensures tasks have a usable `TaskEnvironment` even when explicitly instantiated outside the engine (e.g., `new Copy()`) or run in the out-of-proc task host. The engine's in-proc path (`TaskExecutionHost.InitializeForBatch`) overwrites the default with the appropriate driver before `Execute()` is called.
 
@@ -109,7 +95,7 @@ public class MSBuildMultiThreadableTaskAttribute : Attribute
 }
 ```
 
-MSBuild detects `MSBuildMultiThreadableTaskAttribute` by its namespace and name only, ignoring the defining assembly, which allows customers to define the attribute in their own assemblies alongside their tasks. Because the attribute is the routing signal, every task that should run in-process must carry it — including tasks that also implement `IMultiThreadableTask`. The attribute is not inherited (`Inherited = false`, and `TaskRouter` reads it with `inherit: false`), so it must be applied to each concrete task class rather than to a shared base.
+MSBuild detects `MSBuildMultiThreadableTaskAttribute` by its namespace and name only, ignoring the defining assembly, which allows customers to define the attribute in their own assemblies alongside their tasks. The attribute is not inherited (`Inherited = false`, and `TaskRouter` reads it with `inherit: false`), so it must be applied to each concrete task class rather than to a shared base.
 
 For tasks to be eligible for multithreaded execution using this approach, they must satisfy the following conditions:
 - The task must not modify global process state (environment variables, working directory)
@@ -202,3 +188,7 @@ The main advantages of API hooking include requiring no action from task authors
 ### Alternative to Attribute-Based Thread-Safe Capability Declaration
 
 We considered making the thread-safety signal using the task declaration (for example, a `ThreadSafe="true"` attribute on `UsingTask`) so that project authors could declare compatibility without changing task assemblies. However, because older MSBuild versions treat unknown attributes in task declarations as errors, this approach would require updating older MSBuild versions or servicing them to ignore the attribute. 
+
+### Alternative: Routing on `IMultiThreadableTask` Instead of the Attribute
+
+We considered using the interface as the routing signal, so that a task implementing `IMultiThreadableTask` would run in-process without also applying the attribute. This does not work: `Microsoft.Build.Utilities.ToolTask` implements `IMultiThreadableTask`, so routing on the interface would silently opt in every `ToolTask`-derived task in the ecosystem, none of which have been reviewed for thread safety.

--- a/documentation/specs/multithreading/thread-safe-tasks.md
+++ b/documentation/specs/multithreading/thread-safe-tasks.md
@@ -22,7 +22,7 @@ Task authors declare thread-safe capabilities through two mechanisms that do **d
 
 Declaring one without the other is legal, and each half fails quietly:
 
-- **Attribute only** — a supported state. The task runs in-process without `TaskEnvironment`, which is correct for a task that does not resolve relative paths or read environment variables. If the task *does* declare a `TaskEnvironment` property, that property is never assigned and silently stays `TaskEnvironment.Fallback`, resolving every path against the shared process working directory. The task-authoring analyzer reports `MSBuildTask0012` for this shape.
+- **Attribute only** — a supported state. The task runs in-process without `TaskEnvironment`, which is correct for a task that does not resolve relative paths or read environment variables. If the task *does* declare a `TaskEnvironment` property, MSBuild never assigns it: the property silently retains whatever the task itself initialized it to — commonly `TaskEnvironment.Fallback`, or `null` when there is no initializer — so paths resolve against the shared process working directory. The task-authoring analyzer reports `MSBuildTask0012` for this shape.
 - **Interface only** — a useful intermediate state. The task resolves paths correctly but still pays for a TaskHost. `MSBuildTask0013` reports it, disabled by default.
 
 The interface cannot also serve as the routing signal, because `ToolTask` implements `IMultiThreadableTask`. Routing on the interface would opt in every `ToolTask`-derived task in the ecosystem, none of which have been reviewed for thread safety.

--- a/documentation/specs/multithreading/thread-safe-tasks.md
+++ b/documentation/specs/multithreading/thread-safe-tasks.md
@@ -10,11 +10,24 @@ Tasks that are not thread-safe can still participate in multithreaded builds. MS
 
 ## Thread-Safe Capability Indicators
 
-Task authors can declare thread-safe capabilities in two different ways:
-1. **Interface-Based Thread-Safe Capability Declaration** - Provides access to thread-safe APIs through `TaskEnvironment` to be used in the task code.
-2. **Attribute-Based Thread-Safe Capability Declaration** - Allows existing tasks to declare its ability run in multithreaded mode without code changes. It is a **compatibility bridge option**.
+Task authors declare thread-safe capabilities through two mechanisms that do **different** jobs. They are not alternatives, and a fully migrated task uses both:
 
-Tasks that use `TaskEnvironment` cannot load in older MSBuild versions that do not support multithreading features, requiring authors to drop support for older MSBuild versions. To address this challenge, MSBuild provides a compatibility bridge that allows certain tasks targeting older MSBuild versions to participate in multithreaded builds. While correct absolute path resolution can be and should be achieved without accessing `TaskEnvironment` in tasks that use compatibility bridge options, tasks must avoid relying on environment variables or modifying global process state.
+1. **Attribute-Based Thread-Safe Capability Declaration** (`[MSBuildMultiThreadableTask]`) — the **routing** signal. This is the only thing that opts a task into running in-process; without it the task is routed to an out-of-proc TaskHost sidecar regardless of anything else it declares.
+2. **Interface-Based Thread-Safe Capability Declaration** (`IMultiThreadableTask`) — the **injection** signal. It gives the task access to thread-safe APIs through `TaskEnvironment`, which the engine assigns only to tasks implementing the interface.
+
+| Declaration | Effect | Read by |
+| --- | --- | --- |
+| `[MSBuildMultiThreadableTask]` | Runs in-process instead of an out-of-proc TaskHost | `TaskRouter.NeedsTaskHostInMultiThreadedMode` |
+| `IMultiThreadableTask` | Receives a `TaskEnvironment` | `TaskExecutionHost` |
+
+Declaring one without the other is legal, and each half fails quietly:
+
+- **Attribute only** — a supported state. The task runs in-process without `TaskEnvironment`, which is correct for a task that does not resolve relative paths or read environment variables. If the task *does* declare a `TaskEnvironment` property, that property is never assigned and silently stays `TaskEnvironment.Fallback`, resolving every path against the shared process working directory. The task-authoring analyzer reports `MSBuildTask0012` for this shape.
+- **Interface only** — a useful intermediate state. The task resolves paths correctly but still pays for a TaskHost. `MSBuildTask0013` reports it, disabled by default.
+
+The interface cannot also serve as the routing signal, because `ToolTask` implements `IMultiThreadableTask`. Routing on the interface would opt in every `ToolTask`-derived task in the ecosystem, none of which have been reviewed for thread safety.
+
+Tasks that use `TaskEnvironment` cannot load in older MSBuild versions that do not support multithreading features, requiring authors to drop support for older MSBuild versions. To address this challenge, MSBuild provides a compatibility bridge that allows certain tasks targeting older MSBuild versions to participate in multithreaded builds: the attribute is detected by name, so a task can apply it without referencing a new MSBuild assembly, and correct absolute path resolution can be and should be achieved without accessing `TaskEnvironment`. Tasks using that bridge must still avoid relying on environment variables or modifying global process state.
 
 So, task authors who need to support older MSBuild versions will have three choices:
 1. **Maintain separate implementations** - Create and support both thread-safe and legacy versions of the same task.
@@ -23,7 +36,7 @@ So, task authors who need to support older MSBuild versions will have three choi
 
 ### Interface-Based Thread-Safe Capability Declaration
 
-Tasks indicate thread-safety capabilities by implementing the `IMultiThreadableTask` interface.
+Tasks gain access to `TaskEnvironment` by implementing the `IMultiThreadableTask` interface. Implementing it does not by itself cause the task to run in-process — `[MSBuildMultiThreadableTask]` is required for that.
 
 ```csharp
 namespace Microsoft.Build.Framework;
@@ -42,6 +55,8 @@ public abstract class MultiThreadableTask : Task, IMultiThreadableTask
     public TaskEnvironment TaskEnvironment { get; set; } = TaskEnvironment.Fallback;
 }
 ```
+
+Deriving from `MultiThreadableTask` supplies the interface but not the attribute, so a derived task must still apply `[MSBuildMultiThreadableTask]` to run in-process.
 
 Built-in MSBuild tasks initialize `TaskEnvironment` with a `MultiProcessTaskEnvironmentDriver`-backed default. This ensures tasks have a usable `TaskEnvironment` even when explicitly instantiated outside the engine (e.g., `new Copy()`) or run in the out-of-proc task host. The engine's in-proc path (`TaskExecutionHost.InitializeForBatch`) overwrites the default with the appropriate driver before `Execute()` is called.
 
@@ -87,14 +102,14 @@ Task authors can indicate thread-safety capabilities by marking their task class
 
 ```csharp
 namespace Microsoft.Build.Framework;
-[AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
-internal class MSBuildMultiThreadableTaskAttribute : Attribute
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+public class MSBuildMultiThreadableTaskAttribute : Attribute
 {
     public MSBuildMultiThreadableTaskAttribute() { }
 }
 ```
 
-MSBuild detects `MSBuildMultiThreadableTaskAttribute` by its namespace and name only, ignoring the defining assembly, which allows customers to define the attribute in their own assemblies alongside their tasks. Since MSBuild does not ship the attribute, customers using newer MSBuild versions should prefer the Interface-Based Thread-Safe Capability Declaration.
+MSBuild detects `MSBuildMultiThreadableTaskAttribute` by its namespace and name only, ignoring the defining assembly, which allows customers to define the attribute in their own assemblies alongside their tasks. Because the attribute is the routing signal, every task that should run in-process must carry it — including tasks that also implement `IMultiThreadableTask`. The attribute is not inherited (`Inherited = false`, and `TaskRouter` reads it with `inherit: false`), so it must be applied to each concrete task class rather than to a shared base.
 
 For tasks to be eligible for multithreaded execution using this approach, they must satisfy the following conditions:
 - The task must not modify global process state (environment variables, working directory)

--- a/src/Build/BackEnd/Components/RequestBuilder/TaskRouter.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TaskRouter.cs
@@ -16,11 +16,10 @@ namespace Microsoft.Build.BackEnd
     /// This class should only be used when in multi-threaded mode. Traditional multi-proc builds
     /// have different semantics and should not use this routing logic.
     /// <para>
-    /// The attribute is the only routing signal. Implementing <see cref="Microsoft.Build.Framework.IMultiThreadableTask"/>
-    /// does not opt a task into in-process execution: <c>Microsoft.Build.Utilities.ToolTask</c> implements that
-    /// interface, so honoring it here would silently opt in every ToolTask-derived task in the ecosystem, none of which
-    /// have been reviewed for thread safety. The interface instead controls whether the engine injects a
-    /// TaskEnvironment into the task, which TaskExecutionHost handles separately.
+    /// The attribute is the only routing signal. <see cref="Microsoft.Build.Framework.IMultiThreadableTask"/> is
+    /// deliberately not consulted here: <c>Microsoft.Build.Utilities.ToolTask</c> implements it, so honoring it
+    /// would silently opt in every ToolTask-derived task in the ecosystem. The interface instead controls
+    /// TaskEnvironment injection, which TaskExecutionHost handles separately.
     /// </para>
     /// </remarks>
     internal static class TaskRouter

--- a/src/Build/BackEnd/Components/RequestBuilder/TaskRouter.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TaskRouter.cs
@@ -8,13 +8,20 @@ namespace Microsoft.Build.BackEnd
 {
     /// <summary>
     /// Determines where a task should be executed in multi-threaded mode.
-    /// In multi-threaded execution mode, tasks implementing IMultiThreadableTask or marked with
-    /// MSBuildMultiThreadableTaskAttribute run in-process within thread nodes, while legacy tasks
-    /// are routed to sidecar TaskHost processes for isolation.
+    /// In multi-threaded execution mode, tasks marked with MSBuildMultiThreadableTaskAttribute run
+    /// in-process within thread nodes, while all other tasks are routed to sidecar TaskHost processes
+    /// for isolation.
     /// </summary>
     /// <remarks>
     /// This class should only be used when in multi-threaded mode. Traditional multi-proc builds
     /// have different semantics and should not use this routing logic.
+    /// <para>
+    /// The attribute is the only routing signal. Implementing <see cref="Microsoft.Build.Framework.IMultiThreadableTask"/>
+    /// does not opt a task into in-process execution: <c>Microsoft.Build.Utilities.ToolTask</c> implements that
+    /// interface, so honoring it here would silently opt in every ToolTask-derived task in the ecosystem, none of which
+    /// have been reviewed for thread safety. The interface instead controls whether the engine injects a
+    /// TaskEnvironment into the task, which TaskExecutionHost handles separately.
+    /// </para>
     /// </remarks>
     internal static class TaskRouter
     {

--- a/src/TaskAnalyzer.Tests/MultiThreadableTaskDeclarationAnalyzerTests.cs
+++ b/src/TaskAnalyzer.Tests/MultiThreadableTaskDeclarationAnalyzerTests.cs
@@ -173,10 +173,12 @@ public class MultiThreadableTaskDeclarationAnalyzerTests
 
     /// <summary>
     /// The attribute is not inherited (AttributeUsage sets Inherited = false) and TaskRouter reads it
-    /// with inherit: false, so a derived task does not pick it up from its base.
+    /// with inherit: false, so a derived task does not pick it up from its base. Only the base is
+    /// reported -- the derived task itself is clean, which is precisely why the diagnostic is useful:
+    /// nothing else signals that the derived task is still routed to a TaskHost.
     /// </summary>
     [Fact]
-    public async Task AttributeOnBaseIsNotInheritedByDerivedTask_DoesNotProduceDiagnostic()
+    public async Task AttributeOnAbstractBase_ReportsOnlyTheBase()
     {
         var diagnostics = await GetDiagnosticsAsync("""
             using Microsoft.Build.Framework;
@@ -193,11 +195,17 @@ public class MultiThreadableTaskDeclarationAnalyzerTests
             }
             """);
 
-        diagnostics.ShouldBeEmpty();
+        Diagnostic diagnostic = diagnostics.Single();
+        diagnostic.Id.ShouldBe(DiagnosticIds.MultiThreadableTaskAttributeHasNoEffect);
+        diagnostic.GetMessage().ShouldContain("MyTaskBase");
     }
 
+    /// <summary>
+    /// TaskRouter reads the attribute with inherit: false off the concrete type it instantiated, and it
+    /// never instantiates an abstract one, so the attribute reaches no derived task.
+    /// </summary>
     [Fact]
-    public async Task AbstractTask_DoesNotProduceDiagnostic()
+    public async Task AttributeOnAbstractTask_ProducesWarning()
     {
         var diagnostics = await GetDiagnosticsAsync("""
             using Microsoft.Build.Framework;
@@ -206,6 +214,34 @@ public class MultiThreadableTaskDeclarationAnalyzerTests
             public abstract class MyTask : Microsoft.Build.Utilities.Task
             {
                 public TaskEnvironment TaskEnvironment { get; set; } = null!;
+            }
+            """);
+
+        Diagnostic diagnostic = diagnostics.Single();
+        diagnostic.Id.ShouldBe(DiagnosticIds.MultiThreadableTaskAttributeHasNoEffect);
+        diagnostic.Severity.ShouldBe(DiagnosticSeverity.Warning);
+        diagnostic.GetMessage().ShouldContain("MyTask");
+        diagnostic.GetMessage().ShouldContain("not inherited");
+    }
+
+    /// <summary>
+    /// The correct shape: the shared base carries no attribute and each concrete task applies its own.
+    /// </summary>
+    [Fact]
+    public async Task AbstractTaskWithoutAttribute_DoesNotProduceDiagnostic()
+    {
+        var diagnostics = await GetDiagnosticsAsync("""
+            using Microsoft.Build.Framework;
+
+            public abstract class MyTaskBase : Microsoft.Build.Utilities.Task
+            {
+                public string Shared { get; set; } = "";
+            }
+
+            [MSBuildMultiThreadableTask]
+            public class MyTask : MyTaskBase
+            {
+                public override bool Execute() => true;
             }
             """);
 
@@ -230,7 +266,7 @@ public class MultiThreadableTaskDeclarationAnalyzerTests
             """);
 
         Diagnostic diagnostic = diagnostics.Single();
-        diagnostic.Id.ShouldBe(DiagnosticIds.MultiThreadableTaskAttributeOnNonTask);
+        diagnostic.Id.ShouldBe(DiagnosticIds.MultiThreadableTaskAttributeHasNoEffect);
         diagnostic.Severity.ShouldBe(DiagnosticSeverity.Warning);
         diagnostic.GetMessage().ShouldContain("NotATask");
     }
@@ -258,7 +294,7 @@ public class MultiThreadableTaskDeclarationAnalyzerTests
             """);
 
         Diagnostic diagnostic = diagnostics.Single();
-        diagnostic.Id.ShouldBe(DiagnosticIds.MultiThreadableTaskAttributeOnNonTask);
+        diagnostic.Id.ShouldBe(DiagnosticIds.MultiThreadableTaskAttributeHasNoEffect);
         diagnostic.GetMessage().ShouldContain("MyTaskHelper");
     }
 
@@ -413,7 +449,7 @@ public class MultiThreadableTaskDeclarationAnalyzerTests
             .Where(diagnostic =>
                 diagnostic.Id == DiagnosticIds.TaskEnvironmentNeverAssigned ||
                 diagnostic.Id == DiagnosticIds.MissingMultiThreadableTaskAttribute ||
-                diagnostic.Id == DiagnosticIds.MultiThreadableTaskAttributeOnNonTask)
+                diagnostic.Id == DiagnosticIds.MultiThreadableTaskAttributeHasNoEffect)
             .ToArray();
     }
 }

--- a/src/TaskAnalyzer.Tests/MultiThreadableTaskDeclarationAnalyzerTests.cs
+++ b/src/TaskAnalyzer.Tests/MultiThreadableTaskDeclarationAnalyzerTests.cs
@@ -1,0 +1,369 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Shouldly;
+using Xunit;
+using static Microsoft.Build.TaskAuthoring.Analyzer.Tests.TestHelpers;
+
+namespace Microsoft.Build.TaskAuthoring.Analyzer.Tests;
+
+public class MultiThreadableTaskDeclarationAnalyzerTests
+{
+    [Fact]
+    public async Task AttributeWithTaskEnvironmentPropertyButNoInterface_ProducesWarning()
+    {
+        var diagnostics = await GetDiagnosticsAsync("""
+            using Microsoft.Build.Framework;
+
+            [MSBuildMultiThreadableTask]
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                public TaskEnvironment TaskEnvironment { get; set; } = null!;
+                public override bool Execute() => true;
+            }
+            """);
+
+        Diagnostic diagnostic = diagnostics.Single();
+        diagnostic.Id.ShouldBe(DiagnosticIds.TaskEnvironmentNeverAssigned);
+        diagnostic.Severity.ShouldBe(DiagnosticSeverity.Warning);
+        diagnostic.GetMessage().ShouldContain("MyTask");
+    }
+
+    /// <summary>
+    /// The attribute alone is the supported compatibility-bridge state: it declares the task safe to
+    /// run in-process without giving it access to TaskEnvironment. Nothing is wrong here.
+    /// </summary>
+    [Fact]
+    public async Task AttributeWithoutTaskEnvironmentProperty_DoesNotProduceDiagnostic()
+    {
+        var diagnostics = await GetDiagnosticsAsync("""
+            using Microsoft.Build.Framework;
+
+            [MSBuildMultiThreadableTask]
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                public string Value { get; set; } = "";
+                public override bool Execute() => true;
+            }
+            """);
+
+        diagnostics.ShouldBeEmpty();
+    }
+
+    /// <summary>
+    /// The engine selects a single-parameter TaskEnvironment constructor by signature alone,
+    /// independently of IMultiThreadableTask, so this task does receive an environment.
+    /// </summary>
+    [Fact]
+    public async Task AttributeWithTaskEnvironmentConstructorButNoInterface_DoesNotProduceDiagnostic()
+    {
+        var diagnostics = await GetDiagnosticsAsync("""
+            using Microsoft.Build.Framework;
+
+            [MSBuildMultiThreadableTask]
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                public MyTask(TaskEnvironment taskEnvironment)
+                {
+                    TaskEnvironment = taskEnvironment;
+                }
+
+                public TaskEnvironment TaskEnvironment { get; set; }
+                public override bool Execute() => true;
+            }
+            """);
+
+        diagnostics.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task FullyMigratedTask_DoesNotProduceDiagnostic()
+    {
+        var diagnostics = await GetDiagnosticsAsync("""
+            using Microsoft.Build.Framework;
+
+            [MSBuildMultiThreadableTask]
+            public class MyTask : Microsoft.Build.Utilities.Task, IMultiThreadableTask
+            {
+                public TaskEnvironment TaskEnvironment { get; set; } = null!;
+                public override bool Execute() => true;
+            }
+            """);
+
+        diagnostics.ShouldBeEmpty();
+    }
+
+    /// <summary>
+    /// Interface without the attribute is a valid intermediate state, so the rule reporting it is
+    /// disabled by default.
+    /// </summary>
+    [Fact]
+    public async Task InterfaceWithoutAttribute_DoesNotProduceDiagnosticByDefault()
+    {
+        var diagnostics = await GetDiagnosticsAsync("""
+            using Microsoft.Build.Framework;
+
+            public class MyTask : Microsoft.Build.Utilities.Task, IMultiThreadableTask
+            {
+                public TaskEnvironment TaskEnvironment { get; set; } = null!;
+                public override bool Execute() => true;
+            }
+            """);
+
+        diagnostics.ShouldBeEmpty();
+    }
+
+    /// <summary>
+    /// The TaskEnvironment property is inherited from an unannotated base. The base does not implement
+    /// the interface either, so the engine still never assigns it.
+    /// </summary>
+    [Fact]
+    public async Task InheritedTaskEnvironmentPropertyWithoutInterface_ProducesWarning()
+    {
+        var diagnostics = await GetDiagnosticsAsync("""
+            using Microsoft.Build.Framework;
+
+            public abstract class MyTaskBase : Microsoft.Build.Utilities.Task
+            {
+                public TaskEnvironment TaskEnvironment { get; set; } = null!;
+            }
+
+            [MSBuildMultiThreadableTask]
+            public class MyTask : MyTaskBase
+            {
+                public override bool Execute() => true;
+            }
+            """);
+
+        Diagnostic diagnostic = diagnostics.Single();
+        diagnostic.Id.ShouldBe(DiagnosticIds.TaskEnvironmentNeverAssigned);
+        diagnostic.GetMessage().ShouldContain("MyTask");
+    }
+
+    /// <summary>
+    /// The interface is satisfied through the base type, so injection works.
+    /// </summary>
+    [Fact]
+    public async Task InterfaceImplementedOnBase_DoesNotProduceDiagnostic()
+    {
+        var diagnostics = await GetDiagnosticsAsync("""
+            using Microsoft.Build.Framework;
+
+            public abstract class MyTaskBase : Microsoft.Build.Utilities.Task, IMultiThreadableTask
+            {
+                public TaskEnvironment TaskEnvironment { get; set; } = null!;
+            }
+
+            [MSBuildMultiThreadableTask]
+            public class MyTask : MyTaskBase
+            {
+                public override bool Execute() => true;
+            }
+            """);
+
+        diagnostics.ShouldBeEmpty();
+    }
+
+    /// <summary>
+    /// The attribute is not inherited (AttributeUsage sets Inherited = false) and TaskRouter reads it
+    /// with inherit: false, so a derived task does not pick it up from its base.
+    /// </summary>
+    [Fact]
+    public async Task AttributeOnBaseIsNotInheritedByDerivedTask_DoesNotProduceDiagnostic()
+    {
+        var diagnostics = await GetDiagnosticsAsync("""
+            using Microsoft.Build.Framework;
+
+            [MSBuildMultiThreadableTask]
+            public abstract class MyTaskBase : Microsoft.Build.Utilities.Task
+            {
+                public TaskEnvironment TaskEnvironment { get; set; } = null!;
+            }
+
+            public class MyTask : MyTaskBase
+            {
+                public override bool Execute() => true;
+            }
+            """);
+
+        diagnostics.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task AbstractTask_DoesNotProduceDiagnostic()
+    {
+        var diagnostics = await GetDiagnosticsAsync("""
+            using Microsoft.Build.Framework;
+
+            [MSBuildMultiThreadableTask]
+            public abstract class MyTask : Microsoft.Build.Utilities.Task
+            {
+                public TaskEnvironment TaskEnvironment { get; set; } = null!;
+            }
+            """);
+
+        diagnostics.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task NonTaskTypeWithTaskEnvironmentProperty_DoesNotProduceDiagnostic()
+    {
+        var diagnostics = await GetDiagnosticsAsync("""
+            using Microsoft.Build.Framework;
+
+            [MSBuildMultiThreadableTask]
+            public class NotATask
+            {
+                public TaskEnvironment TaskEnvironment { get; set; } = null!;
+            }
+            """);
+
+        diagnostics.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task ReadOnlyTaskEnvironmentProperty_DoesNotProduceDiagnostic()
+    {
+        var diagnostics = await GetDiagnosticsAsync("""
+            using Microsoft.Build.Framework;
+
+            [MSBuildMultiThreadableTask]
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                public TaskEnvironment TaskEnvironment => TaskEnvironment.Fallback;
+                public override bool Execute() => true;
+            }
+            """);
+
+        diagnostics.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task PlainTask_DoesNotProduceDiagnostic()
+    {
+        var diagnostics = await GetDiagnosticsAsync("""
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                public override bool Execute() => true;
+            }
+            """);
+
+        diagnostics.ShouldBeEmpty();
+    }
+
+    /// <summary>
+    /// ToolTask implements IMultiThreadableTask and declares a TaskEnvironment property, so every
+    /// ToolTask-derived task satisfies the interface without its author declaring anything. Reporting
+    /// those would flag thousands of untouched tasks. Runs with the rule explicitly enabled so the
+    /// assertion cannot pass merely because the rule is off by default.
+    /// </summary>
+    [Fact]
+    public async Task InterfaceInheritedFromToolTaskLikeBase_DoesNotProduceDiagnostic()
+    {
+        var diagnostics = await GetDiagnosticsWithMissingAttributeRuleEnabledAsync("""
+            using Microsoft.Build.Framework;
+
+            public abstract class ToolTaskLike : Microsoft.Build.Utilities.Task, IMultiThreadableTask
+            {
+                public virtual TaskEnvironment TaskEnvironment { get; set; } = null!;
+            }
+
+            public class MyTask : ToolTaskLike
+            {
+                public override bool Execute() => true;
+            }
+            """);
+
+        diagnostics.ShouldBeEmpty();
+    }
+
+    /// <summary>
+    /// A ToolTask-derived task carrying the attribute is fully migrated: the interface and the
+    /// TaskEnvironment property both arrive through the base.
+    /// </summary>
+    [Fact]
+    public async Task AttributeOnToolTaskLikeDerivedTask_DoesNotProduceDiagnostic()
+    {
+        var diagnostics = await GetDiagnosticsWithMissingAttributeRuleEnabledAsync("""
+            using Microsoft.Build.Framework;
+
+            public abstract class ToolTaskLike : Microsoft.Build.Utilities.Task, IMultiThreadableTask
+            {
+                public virtual TaskEnvironment TaskEnvironment { get; set; } = null!;
+            }
+
+            [MSBuildMultiThreadableTask]
+            public class MyTask : ToolTaskLike
+            {
+                public override bool Execute() => true;
+            }
+            """);
+
+        diagnostics.ShouldBeEmpty();
+    }
+
+    /// <summary>
+    /// Declaring the interface in the type's own base list is an explicit opt-in, so the missing
+    /// attribute is worth reporting once the rule is enabled.
+    /// </summary>
+    [Fact]
+    public async Task DeclaredInterfaceWithoutAttribute_ProducesInfo_WhenRuleEnabled()
+    {
+        var diagnostics = await GetDiagnosticsWithMissingAttributeRuleEnabledAsync("""
+            using Microsoft.Build.Framework;
+
+            public class MyTask : Microsoft.Build.Utilities.Task, IMultiThreadableTask
+            {
+                public TaskEnvironment TaskEnvironment { get; set; } = null!;
+                public override bool Execute() => true;
+            }
+            """);
+
+        Diagnostic diagnostic = diagnostics.Single();
+        diagnostic.Id.ShouldBe(DiagnosticIds.MissingMultiThreadableTaskAttribute);
+        diagnostic.Severity.ShouldBe(DiagnosticSeverity.Info);
+        diagnostic.GetMessage().ShouldContain("MyTask");
+    }
+
+    private static async Task<Diagnostic[]> GetDiagnosticsWithMissingAttributeRuleEnabledAsync(string source)
+    {
+        CSharpCompilation compilation = CreateCompilation(source);
+        compilation = compilation.WithOptions(compilation.Options.WithSpecificDiagnosticOptions(
+            new[]
+            {
+                new KeyValuePair<string, ReportDiagnostic>(
+                    DiagnosticIds.MissingMultiThreadableTaskAttribute,
+                    ReportDiagnostic.Info),
+            }));
+
+        var diagnostics = await compilation
+            .WithAnalyzers(ImmutableArray.Create<DiagnosticAnalyzer>(new MultiThreadableTaskDeclarationAnalyzer()))
+            .GetAnalyzerDiagnosticsAsync();
+
+        return diagnostics
+            .Where(diagnostic =>
+                diagnostic.Id == DiagnosticIds.TaskEnvironmentNeverAssigned ||
+                diagnostic.Id == DiagnosticIds.MissingMultiThreadableTaskAttribute)
+            .ToArray();
+    }
+
+    private static async Task<Diagnostic[]> GetDiagnosticsAsync(string source)
+    {
+        var diagnostics = await GetCompilerAndAnalyzerDiagnosticsAsync(
+            source,
+            new MultiThreadableTaskDeclarationAnalyzer());
+
+        return diagnostics
+            .Where(diagnostic =>
+                diagnostic.Id == DiagnosticIds.TaskEnvironmentNeverAssigned ||
+                diagnostic.Id == DiagnosticIds.MissingMultiThreadableTaskAttribute)
+            .ToArray();
+    }
+}

--- a/src/TaskAnalyzer.Tests/MultiThreadableTaskDeclarationAnalyzerTests.cs
+++ b/src/TaskAnalyzer.Tests/MultiThreadableTaskDeclarationAnalyzerTests.cs
@@ -212,13 +212,62 @@ public class MultiThreadableTaskDeclarationAnalyzerTests
         diagnostics.ShouldBeEmpty();
     }
 
+    /// <summary>
+    /// TaskRouter only inspects types the engine is about to run as a task, so the attribute does
+    /// nothing on a type that is not one.
+    /// </summary>
     [Fact]
-    public async Task NonTaskTypeWithTaskEnvironmentProperty_DoesNotProduceDiagnostic()
+    public async Task AttributeOnNonTaskType_ProducesWarning()
     {
         var diagnostics = await GetDiagnosticsAsync("""
             using Microsoft.Build.Framework;
 
             [MSBuildMultiThreadableTask]
+            public class NotATask
+            {
+                public TaskEnvironment TaskEnvironment { get; set; } = null!;
+            }
+            """);
+
+        Diagnostic diagnostic = diagnostics.Single();
+        diagnostic.Id.ShouldBe(DiagnosticIds.MultiThreadableTaskAttributeOnNonTask);
+        diagnostic.Severity.ShouldBe(DiagnosticSeverity.Warning);
+        diagnostic.GetMessage().ShouldContain("NotATask");
+    }
+
+    /// <summary>
+    /// The shape the rule is really aimed at: the attribute lands on a helper type in a file that also
+    /// declares the task, so the task itself is left unmarked and still routed to a TaskHost.
+    /// </summary>
+    [Fact]
+    public async Task AttributeOnHelperTypeBesideTask_ReportsOnlyTheHelper()
+    {
+        var diagnostics = await GetDiagnosticsAsync("""
+            using Microsoft.Build.Framework;
+
+            [MSBuildMultiThreadableTask]
+            public class MyTaskHelper
+            {
+                public string Value { get; set; } = "";
+            }
+
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                public override bool Execute() => true;
+            }
+            """);
+
+        Diagnostic diagnostic = diagnostics.Single();
+        diagnostic.Id.ShouldBe(DiagnosticIds.MultiThreadableTaskAttributeOnNonTask);
+        diagnostic.GetMessage().ShouldContain("MyTaskHelper");
+    }
+
+    [Fact]
+    public async Task NonTaskTypeWithoutAttribute_DoesNotProduceDiagnostic()
+    {
+        var diagnostics = await GetDiagnosticsAsync("""
+            using Microsoft.Build.Framework;
+
             public class NotATask
             {
                 public TaskEnvironment TaskEnvironment { get; set; } = null!;
@@ -363,7 +412,8 @@ public class MultiThreadableTaskDeclarationAnalyzerTests
         return diagnostics
             .Where(diagnostic =>
                 diagnostic.Id == DiagnosticIds.TaskEnvironmentNeverAssigned ||
-                diagnostic.Id == DiagnosticIds.MissingMultiThreadableTaskAttribute)
+                diagnostic.Id == DiagnosticIds.MissingMultiThreadableTaskAttribute ||
+                diagnostic.Id == DiagnosticIds.MultiThreadableTaskAttributeOnNonTask)
             .ToArray();
     }
 }

--- a/src/TaskAnalyzer/AnalyzerReleases.Unshipped.md
+++ b/src/TaskAnalyzer/AnalyzerReleases.Unshipped.md
@@ -15,4 +15,4 @@ MSBuildTask0010 | MSBuild.TaskAuthoring | Error | ITaskItem<T> used with a type 
 MSBuildTask0011 | MSBuild.TaskAuthoring | Info | Prefer constructor injection for TaskEnvironment
 MSBuildTask0012 | MSBuild.TaskAuthoring | Warning | TaskEnvironment property is never assigned by MSBuild because the task does not implement IMultiThreadableTask
 MSBuildTask0013 | MSBuild.TaskAuthoring | Info | Task declares IMultiThreadableTask but is not marked with [MSBuildMultiThreadableTask] (disabled by default)
-MSBuildTask0014 | MSBuild.TaskAuthoring | Warning | [MSBuildMultiThreadableTask] applied to a type that is not an MSBuild task, where it has no effect
+MSBuildTask0014 | MSBuild.TaskAuthoring | Warning | [MSBuildMultiThreadableTask] applied to a type MSBuild never routes as a task -- not an ITask, or an abstract task whose attribute no subclass inherits -- where it has no effect

--- a/src/TaskAnalyzer/AnalyzerReleases.Unshipped.md
+++ b/src/TaskAnalyzer/AnalyzerReleases.Unshipped.md
@@ -15,3 +15,4 @@ MSBuildTask0010 | MSBuild.TaskAuthoring | Error | ITaskItem<T> used with a type 
 MSBuildTask0011 | MSBuild.TaskAuthoring | Info | Prefer constructor injection for TaskEnvironment
 MSBuildTask0012 | MSBuild.TaskAuthoring | Warning | TaskEnvironment property is never assigned by MSBuild because the task does not implement IMultiThreadableTask
 MSBuildTask0013 | MSBuild.TaskAuthoring | Info | Task declares IMultiThreadableTask but is not marked with [MSBuildMultiThreadableTask] (disabled by default)
+MSBuildTask0014 | MSBuild.TaskAuthoring | Warning | [MSBuildMultiThreadableTask] applied to a type that is not an MSBuild task, where it has no effect

--- a/src/TaskAnalyzer/AnalyzerReleases.Unshipped.md
+++ b/src/TaskAnalyzer/AnalyzerReleases.Unshipped.md
@@ -13,3 +13,5 @@ MSBuildTask0008 | MSBuild.TaskAuthoring | Warning | Initialize a relative defaul
 MSBuildTask0009 | MSBuild.TaskAuthoring | Warning | ITaskItem<T> used with a type argument T that MSBuild cannot bind as a task parameter
 MSBuildTask0010 | MSBuild.TaskAuthoring | Error | ITaskItem<T> used with a type argument T that MSBuild parses through Convert.ChangeType
 MSBuildTask0011 | MSBuild.TaskAuthoring | Info | Prefer constructor injection for TaskEnvironment
+MSBuildTask0012 | MSBuild.TaskAuthoring | Warning | TaskEnvironment property is never assigned because the task does not implement IMultiThreadableTask
+MSBuildTask0013 | MSBuild.TaskAuthoring | Info | Task declares IMultiThreadableTask but is not marked with [MSBuildMultiThreadableTask] (disabled by default)

--- a/src/TaskAnalyzer/AnalyzerReleases.Unshipped.md
+++ b/src/TaskAnalyzer/AnalyzerReleases.Unshipped.md
@@ -13,5 +13,5 @@ MSBuildTask0008 | MSBuild.TaskAuthoring | Warning | Initialize a relative defaul
 MSBuildTask0009 | MSBuild.TaskAuthoring | Warning | ITaskItem<T> used with a type argument T that MSBuild cannot bind as a task parameter
 MSBuildTask0010 | MSBuild.TaskAuthoring | Error | ITaskItem<T> used with a type argument T that MSBuild parses through Convert.ChangeType
 MSBuildTask0011 | MSBuild.TaskAuthoring | Info | Prefer constructor injection for TaskEnvironment
-MSBuildTask0012 | MSBuild.TaskAuthoring | Warning | TaskEnvironment property is never assigned because the task does not implement IMultiThreadableTask
+MSBuildTask0012 | MSBuild.TaskAuthoring | Warning | TaskEnvironment property is never assigned by MSBuild because the task does not implement IMultiThreadableTask
 MSBuildTask0013 | MSBuild.TaskAuthoring | Info | Task declares IMultiThreadableTask but is not marked with [MSBuildMultiThreadableTask] (disabled by default)

--- a/src/TaskAnalyzer/DiagnosticDescriptors.cs
+++ b/src/TaskAnalyzer/DiagnosticDescriptors.cs
@@ -130,6 +130,15 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
             isEnabledByDefault: false,
             description: "Only [MSBuildMultiThreadableTask] causes a task to run in-process in multithreaded mode; IMultiThreadableTask controls TaskEnvironment injection alone. Implementing the interface without the attribute is a valid intermediate state -- the task resolves paths correctly while remaining isolated in a TaskHost -- so this rule is disabled by default. Enable it once a codebase intends every multithreadable task to also be routed in-process. Only a type that declares the interface in its own base list is reported: ToolTask implements IMultiThreadableTask, so an inherited implementation says nothing about the derived task's intent.");
 
+        public static readonly DiagnosticDescriptor MultiThreadableTaskAttributeOnNonTask = new(
+            id: DiagnosticIds.MultiThreadableTaskAttributeOnNonTask,
+            title: "[MSBuildMultiThreadableTask] applied to a type that is not an MSBuild task",
+            messageFormat: "Type '{0}' is marked with [MSBuildMultiThreadableTask] but does not implement ITask, so the attribute has no effect",
+            category: "MSBuild.TaskAuthoring",
+            defaultSeverity: DiagnosticSeverity.Warning,
+            isEnabledByDefault: true,
+            description: "[MSBuildMultiThreadableTask] is read by TaskRouter to decide whether a task runs in-process or in an out-of-proc TaskHost sidecar. TaskRouter only ever inspects types the engine is about to execute as tasks, so the attribute is meaningless on a type that does not implement ITask. Applying it there usually means it was placed on a helper type, or on the wrong class of a multi-class file, leaving the actual task unmarked and still routed to a TaskHost.");
+
         public static ImmutableArray<DiagnosticDescriptor> All { get; } = ImmutableArray.Create(
             CriticalError,
             TaskEnvironmentRequired,
@@ -143,6 +152,7 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
             CultureSensitiveTaskItemType,
             PreferTaskEnvironmentConstructorInjection,
             TaskEnvironmentNeverAssigned,
-            MissingMultiThreadableTaskAttribute);
+            MissingMultiThreadableTaskAttribute,
+            MultiThreadableTaskAttributeOnNonTask);
     }
 }

--- a/src/TaskAnalyzer/DiagnosticDescriptors.cs
+++ b/src/TaskAnalyzer/DiagnosticDescriptors.cs
@@ -130,14 +130,14 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
             isEnabledByDefault: false,
             description: "Only [MSBuildMultiThreadableTask] causes a task to run in-process in multithreaded mode; IMultiThreadableTask controls TaskEnvironment injection alone. Implementing the interface without the attribute is a valid intermediate state -- the task resolves paths correctly while remaining isolated in a TaskHost -- so this rule is disabled by default. Enable it once a codebase intends every multithreadable task to also be routed in-process. Only a type that declares the interface in its own base list is reported: ToolTask implements IMultiThreadableTask, so an inherited implementation says nothing about the derived task's intent.");
 
-        public static readonly DiagnosticDescriptor MultiThreadableTaskAttributeOnNonTask = new(
-            id: DiagnosticIds.MultiThreadableTaskAttributeOnNonTask,
-            title: "[MSBuildMultiThreadableTask] applied to a type that is not an MSBuild task",
-            messageFormat: "Type '{0}' is marked with [MSBuildMultiThreadableTask] but does not implement ITask, so the attribute has no effect",
+        public static readonly DiagnosticDescriptor MultiThreadableTaskAttributeHasNoEffect = new(
+            id: DiagnosticIds.MultiThreadableTaskAttributeHasNoEffect,
+            title: "[MSBuildMultiThreadableTask] has no effect on this type",
+            messageFormat: "[MSBuildMultiThreadableTask] on type '{0}' has no effect because {1}",
             category: "MSBuild.TaskAuthoring",
             defaultSeverity: DiagnosticSeverity.Warning,
             isEnabledByDefault: true,
-            description: "[MSBuildMultiThreadableTask] is read by TaskRouter to decide whether a task runs in-process or in an out-of-proc TaskHost sidecar. TaskRouter only ever inspects types the engine is about to execute as tasks, so the attribute is meaningless on a type that does not implement ITask. Applying it there usually means it was placed on a helper type, or on the wrong class of a multi-class file, leaving the actual task unmarked and still routed to a TaskHost.");
+            description: "TaskRouter reads [MSBuildMultiThreadableTask] with inherit: false, off the concrete type the engine has just instantiated as a task. The attribute therefore only has an effect on a non-abstract class that implements ITask. On a type that is not a task, nothing ever reads it. On an abstract task, the engine never instantiates that type, and because the attribute is not inherited the concrete subclasses do not pick it up -- so every one of them is still routed to an out-of-proc TaskHost. Both shapes usually mean the attribute was applied to the wrong class: a helper type beside the real task, or a shared base instead of each task that derives from it.");
 
         public static ImmutableArray<DiagnosticDescriptor> All { get; } = ImmutableArray.Create(
             CriticalError,
@@ -153,6 +153,6 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
             PreferTaskEnvironmentConstructorInjection,
             TaskEnvironmentNeverAssigned,
             MissingMultiThreadableTaskAttribute,
-            MultiThreadableTaskAttributeOnNonTask);
+            MultiThreadableTaskAttributeHasNoEffect);
     }
 }

--- a/src/TaskAnalyzer/DiagnosticDescriptors.cs
+++ b/src/TaskAnalyzer/DiagnosticDescriptors.cs
@@ -114,12 +114,12 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
 
         public static readonly DiagnosticDescriptor TaskEnvironmentNeverAssigned = new(
             id: DiagnosticIds.TaskEnvironmentNeverAssigned,
-            title: "TaskEnvironment property is never assigned because the task does not implement IMultiThreadableTask",
-            messageFormat: "Task '{0}' declares a TaskEnvironment property but does not implement IMultiThreadableTask, so the engine never assigns it and it stays TaskEnvironment.Fallback; implement IMultiThreadableTask or add a public constructor taking a TaskEnvironment",
+            title: "TaskEnvironment property is never assigned by MSBuild because the task does not implement IMultiThreadableTask",
+            messageFormat: "Task '{0}' declares a TaskEnvironment property but does not implement IMultiThreadableTask, so MSBuild never assigns it and it retains the task's own default; implement IMultiThreadableTask, or add a public constructor taking a TaskEnvironment that assigns the property",
             category: "MSBuild.TaskAuthoring",
             defaultSeverity: DiagnosticSeverity.Warning,
             isEnabledByDefault: true,
-            description: "The MSBuild engine assigns TaskEnvironment only to tasks that implement IMultiThreadableTask, or through a public constructor that takes a single TaskEnvironment. A task that declares the property without either receives no environment: the property silently remains TaskEnvironment.Fallback and every path is resolved against the shared process working directory rather than the project directory. Because the task carries [MSBuildMultiThreadableTask] it runs in-process, which is exactly where that resolution is wrong.");
+            description: "MSBuild assigns TaskEnvironment only to tasks that implement IMultiThreadableTask, or through a public constructor that takes a single TaskEnvironment. A task that declares the property without either never receives an environment from the engine: the property silently retains whatever the task itself initialized it to -- commonly TaskEnvironment.Fallback, or null when there is no initializer -- so paths resolve against the shared process working directory rather than the project directory. Because the task carries [MSBuildMultiThreadableTask] it runs in-process, which is exactly where that resolution is wrong.");
 
         public static readonly DiagnosticDescriptor MissingMultiThreadableTaskAttribute = new(
             id: DiagnosticIds.MissingMultiThreadableTaskAttribute,

--- a/src/TaskAnalyzer/DiagnosticDescriptors.cs
+++ b/src/TaskAnalyzer/DiagnosticDescriptors.cs
@@ -112,6 +112,24 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
             isEnabledByDefault: true,
             description: "Constructor injection makes TaskEnvironment available to constructor logic and environment-dependent default initialization. The MSBuild engine prefers a public constructor with a single TaskEnvironment parameter when one is available.");
 
+        public static readonly DiagnosticDescriptor TaskEnvironmentNeverAssigned = new(
+            id: DiagnosticIds.TaskEnvironmentNeverAssigned,
+            title: "TaskEnvironment property is never assigned because the task does not implement IMultiThreadableTask",
+            messageFormat: "Task '{0}' declares a TaskEnvironment property but does not implement IMultiThreadableTask, so the engine never assigns it and it stays TaskEnvironment.Fallback; implement IMultiThreadableTask or add a public constructor taking a TaskEnvironment",
+            category: "MSBuild.TaskAuthoring",
+            defaultSeverity: DiagnosticSeverity.Warning,
+            isEnabledByDefault: true,
+            description: "The MSBuild engine assigns TaskEnvironment only to tasks that implement IMultiThreadableTask, or through a public constructor that takes a single TaskEnvironment. A task that declares the property without either receives no environment: the property silently remains TaskEnvironment.Fallback and every path is resolved against the shared process working directory rather than the project directory. Because the task carries [MSBuildMultiThreadableTask] it runs in-process, which is exactly where that resolution is wrong.");
+
+        public static readonly DiagnosticDescriptor MissingMultiThreadableTaskAttribute = new(
+            id: DiagnosticIds.MissingMultiThreadableTaskAttribute,
+            title: "Task implements IMultiThreadableTask but is not marked with [MSBuildMultiThreadableTask]",
+            messageFormat: "Task '{0}' implements IMultiThreadableTask but is not marked with [MSBuildMultiThreadableTask], so it still runs in an out-of-proc TaskHost",
+            category: "MSBuild.TaskAuthoring",
+            defaultSeverity: DiagnosticSeverity.Info,
+            isEnabledByDefault: false,
+            description: "Only [MSBuildMultiThreadableTask] causes a task to run in-process in multithreaded mode; IMultiThreadableTask controls TaskEnvironment injection alone. Implementing the interface without the attribute is a valid intermediate state -- the task resolves paths correctly while remaining isolated in a TaskHost -- so this rule is disabled by default. Enable it once a codebase intends every multithreadable task to also be routed in-process. Only a type that declares the interface in its own base list is reported: ToolTask implements IMultiThreadableTask, so an inherited implementation says nothing about the derived task's intent.");
+
         public static ImmutableArray<DiagnosticDescriptor> All { get; } = ImmutableArray.Create(
             CriticalError,
             TaskEnvironmentRequired,
@@ -123,6 +141,8 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
             InitializeRelativeDefaultInExecute,
             UnsupportedTaskItemType,
             CultureSensitiveTaskItemType,
-            PreferTaskEnvironmentConstructorInjection);
+            PreferTaskEnvironmentConstructorInjection,
+            TaskEnvironmentNeverAssigned,
+            MissingMultiThreadableTaskAttribute);
     }
 }

--- a/src/TaskAnalyzer/DiagnosticIds.cs
+++ b/src/TaskAnalyzer/DiagnosticIds.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
         /// <summary>Task implements IMultiThreadableTask but lacks [MSBuildMultiThreadableTask], so it still runs in an out-of-proc TaskHost.</summary>
         public const string MissingMultiThreadableTaskAttribute = "MSBuildTask0013";
 
-        /// <summary>[MSBuildMultiThreadableTask] is applied to a type that is not an MSBuild task, where it has no effect.</summary>
-        public const string MultiThreadableTaskAttributeOnNonTask = "MSBuildTask0014";
+        /// <summary>[MSBuildMultiThreadableTask] is applied to a type MSBuild never routes as a task, so it has no effect.</summary>
+        public const string MultiThreadableTaskAttributeHasNoEffect = "MSBuildTask0014";
     }
 }

--- a/src/TaskAnalyzer/DiagnosticIds.cs
+++ b/src/TaskAnalyzer/DiagnosticIds.cs
@@ -41,5 +41,11 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
 
         /// <summary>Task should receive TaskEnvironment through constructor injection.</summary>
         public const string PreferTaskEnvironmentConstructorInjection = "MSBuildTask0011";
+
+        /// <summary>Task declares a TaskEnvironment property but does not implement IMultiThreadableTask, so the engine never assigns it.</summary>
+        public const string TaskEnvironmentNeverAssigned = "MSBuildTask0012";
+
+        /// <summary>Task implements IMultiThreadableTask but lacks [MSBuildMultiThreadableTask], so it still runs in an out-of-proc TaskHost.</summary>
+        public const string MissingMultiThreadableTaskAttribute = "MSBuildTask0013";
     }
 }

--- a/src/TaskAnalyzer/DiagnosticIds.cs
+++ b/src/TaskAnalyzer/DiagnosticIds.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
         /// <summary>Task should receive TaskEnvironment through constructor injection.</summary>
         public const string PreferTaskEnvironmentConstructorInjection = "MSBuildTask0011";
 
-        /// <summary>Task declares a TaskEnvironment property but does not implement IMultiThreadableTask, so the engine never assigns it.</summary>
+        /// <summary>Task declares a TaskEnvironment property but does not implement IMultiThreadableTask, so MSBuild never assigns it.</summary>
         public const string TaskEnvironmentNeverAssigned = "MSBuildTask0012";
 
         /// <summary>Task implements IMultiThreadableTask but lacks [MSBuildMultiThreadableTask], so it still runs in an out-of-proc TaskHost.</summary>

--- a/src/TaskAnalyzer/DiagnosticIds.cs
+++ b/src/TaskAnalyzer/DiagnosticIds.cs
@@ -47,5 +47,8 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
 
         /// <summary>Task implements IMultiThreadableTask but lacks [MSBuildMultiThreadableTask], so it still runs in an out-of-proc TaskHost.</summary>
         public const string MissingMultiThreadableTaskAttribute = "MSBuildTask0013";
+
+        /// <summary>[MSBuildMultiThreadableTask] is applied to a type that is not an MSBuild task, where it has no effect.</summary>
+        public const string MultiThreadableTaskAttributeOnNonTask = "MSBuildTask0014";
     }
 }

--- a/src/TaskAnalyzer/MultiThreadableTaskDeclarationAnalyzer.cs
+++ b/src/TaskAnalyzer/MultiThreadableTaskDeclarationAnalyzer.cs
@@ -1,0 +1,188 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Microsoft.Build.TaskAuthoring.Analyzer
+{
+    /// <summary>
+    /// Validates that a task's two multithreading declarations agree.
+    /// <para>
+    /// <c>[MSBuildMultiThreadableTask]</c> is the routing signal: it is the only thing
+    /// <c>TaskRouter.NeedsTaskHostInMultiThreadedMode</c> reads, and without it a task runs in an
+    /// out-of-proc TaskHost sidecar. <c>IMultiThreadableTask</c> is the injection signal:
+    /// <c>TaskExecutionHost</c> assigns <c>TaskEnvironment</c> only to instances of that interface.
+    /// </para>
+    /// <para>
+    /// Declaring one without the other is legal but usually unintended, and both halves fail silently.
+    /// </para>
+    /// </summary>
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class MultiThreadableTaskDeclarationAnalyzer : DiagnosticAnalyzer
+    {
+        private const string TaskEnvironmentPropertyName = "TaskEnvironment";
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
+            ImmutableArray.Create(
+                DiagnosticDescriptors.TaskEnvironmentNeverAssigned,
+                DiagnosticDescriptors.MissingMultiThreadableTaskAttribute);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.EnableConcurrentExecution();
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.RegisterCompilationStartAction(OnCompilationStart);
+        }
+
+        private static void OnCompilationStart(CompilationStartAnalysisContext context)
+        {
+            INamedTypeSymbol? taskType = context.Compilation.GetTypeByMetadataName(WellKnownTypeNames.ITaskFullName);
+            INamedTypeSymbol? multiThreadableTaskType =
+                context.Compilation.GetTypeByMetadataName(WellKnownTypeNames.IMultiThreadableTaskFullName);
+            INamedTypeSymbol? taskEnvironmentType =
+                context.Compilation.GetTypeByMetadataName(WellKnownTypeNames.TaskEnvironmentFullName);
+            INamedTypeSymbol? attributeType =
+                context.Compilation.GetTypeByMetadataName(WellKnownTypeNames.MultiThreadableTaskAttributeFullName);
+
+            if (taskType is null || multiThreadableTaskType is null || taskEnvironmentType is null || attributeType is null)
+            {
+                return;
+            }
+
+            context.RegisterSymbolAction(
+                symbolContext => AnalyzeNamedType(
+                    symbolContext,
+                    taskType,
+                    multiThreadableTaskType,
+                    taskEnvironmentType,
+                    attributeType),
+                SymbolKind.NamedType);
+        }
+
+        private static void AnalyzeNamedType(
+            SymbolAnalysisContext context,
+            INamedTypeSymbol taskType,
+            INamedTypeSymbol multiThreadableTaskType,
+            INamedTypeSymbol taskEnvironmentType,
+            INamedTypeSymbol attributeType)
+        {
+            var type = (INamedTypeSymbol)context.Symbol;
+
+            // Abstract types are never instantiated by the engine, and the routing attribute is not
+            // inherited, so neither declaration is meaningful on them.
+            if (type.TypeKind != TypeKind.Class ||
+                type.IsAbstract ||
+                !SharedAnalyzerHelpers.ImplementsInterface(type, taskType))
+            {
+                return;
+            }
+
+            bool implementsInterface = SharedAnalyzerHelpers.ImplementsInterface(type, multiThreadableTaskType);
+            bool hasAttribute = HasMultiThreadableTaskAttribute(type, attributeType);
+
+            if (hasAttribute && !implementsInterface)
+            {
+                // The attribute on its own is a supported state: it declares a task safe to run
+                // in-process without giving it access to TaskEnvironment. Only report when the task
+                // also declares a TaskEnvironment property, which says the author expects the engine
+                // to populate it -- and it never will.
+                if (HasTaskEnvironmentProperty(type, taskEnvironmentType) &&
+                    !HasTaskEnvironmentConstructor(type, taskEnvironmentType))
+                {
+                    ReportOnType(context, DiagnosticDescriptors.TaskEnvironmentNeverAssigned, type);
+                }
+            }
+            else if (!hasAttribute && DeclaresMultiThreadableTaskInterface(type, multiThreadableTaskType))
+            {
+                ReportOnType(context, DiagnosticDescriptors.MissingMultiThreadableTaskAttribute, type);
+            }
+        }
+
+        /// <summary>
+        /// Reports whether the type opts into <c>IMultiThreadableTask</c> in its own base list, rather
+        /// than merely inheriting it.
+        /// <para>
+        /// <c>ToolTask</c> implements <c>IMultiThreadableTask</c>, so every <c>ToolTask</c>-derived task in
+        /// the ecosystem satisfies the interface without its author having declared anything. Treating an
+        /// inherited implementation as intent would report thousands of untouched tasks, which is the same
+        /// reason <c>TaskRouter</c> cannot use the interface as a routing signal.
+        /// </para>
+        /// </summary>
+        private static bool DeclaresMultiThreadableTaskInterface(
+            INamedTypeSymbol type,
+            INamedTypeSymbol multiThreadableTaskType)
+        {
+            foreach (INamedTypeSymbol declaredInterface in type.Interfaces)
+            {
+                if (SymbolEqualityComparer.Default.Equals(declaredInterface, multiThreadableTaskType))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static bool HasMultiThreadableTaskAttribute(INamedTypeSymbol type, INamedTypeSymbol attributeType)
+        {
+            // Matches TaskRouter, which reads the attribute with inherit: false.
+            foreach (AttributeData attribute in type.GetAttributes())
+            {
+                if (SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, attributeType))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static bool HasTaskEnvironmentProperty(INamedTypeSymbol type, INamedTypeSymbol taskEnvironmentType)
+        {
+            foreach (IPropertySymbol property in SharedAnalyzerHelpers.GetPropertiesIncludingBaseTypes(type))
+            {
+                if (property.Name == TaskEnvironmentPropertyName &&
+                    SymbolEqualityComparer.Default.Equals(property.Type, taskEnvironmentType) &&
+                    property.SetMethod is not null)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// The engine selects a single-parameter <c>TaskEnvironment</c> constructor by signature alone,
+        /// independently of <c>IMultiThreadableTask</c>, so such a task does receive an environment.
+        /// </summary>
+        private static bool HasTaskEnvironmentConstructor(INamedTypeSymbol type, INamedTypeSymbol taskEnvironmentType)
+        {
+            foreach (IMethodSymbol constructor in type.InstanceConstructors)
+            {
+                if (constructor.DeclaredAccessibility == Accessibility.Public &&
+                    constructor.Parameters.Length == 1 &&
+                    SymbolEqualityComparer.Default.Equals(constructor.Parameters[0].Type, taskEnvironmentType))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static void ReportOnType(SymbolAnalysisContext context, DiagnosticDescriptor descriptor, INamedTypeSymbol type)
+        {
+            foreach (Location location in type.Locations)
+            {
+                if (location.IsInSource)
+                {
+                    context.ReportDiagnostic(Diagnostic.Create(descriptor, location, type.Name));
+                    return;
+                }
+            }
+        }
+    }
+}

--- a/src/TaskAnalyzer/MultiThreadableTaskDeclarationAnalyzer.cs
+++ b/src/TaskAnalyzer/MultiThreadableTaskDeclarationAnalyzer.cs
@@ -17,8 +17,8 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
     /// </para>
     /// <para>
     /// Declaring one without the other is legal but usually unintended, and both halves fail silently.
-    /// The attribute is also reported when it is applied to a type that is not a task at all, where
-    /// nothing reads it.
+    /// The attribute is also reported when it is applied to a type MSBuild never routes as a task --
+    /// one that is not a task at all, or an abstract task whose attribute no subclass inherits.
     /// </para>
     /// </summary>
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
@@ -30,7 +30,7 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
             ImmutableArray.Create(
                 DiagnosticDescriptors.TaskEnvironmentNeverAssigned,
                 DiagnosticDescriptors.MissingMultiThreadableTaskAttribute,
-                DiagnosticDescriptors.MultiThreadableTaskAttributeOnNonTask);
+                DiagnosticDescriptors.MultiThreadableTaskAttributeHasNoEffect);
 
         public override void Initialize(AnalysisContext context)
         {
@@ -87,16 +87,26 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                 // wrong class of a multi-class file, leaving the real task unmarked.
                 if (hasAttribute)
                 {
-                    ReportOnType(context, DiagnosticDescriptors.MultiThreadableTaskAttributeOnNonTask, type);
+                    ReportNoEffect(context, type, "it does not implement ITask");
                 }
 
                 return;
             }
 
-            // Abstract types are never instantiated by the engine, and the routing attribute is not
-            // inherited, so neither declaration is meaningful on them.
+            // The engine never instantiates an abstract type, and TaskRouter reads the attribute with
+            // inherit: false off the concrete type it did instantiate. An attribute here reaches nothing:
+            // every derived task is still routed to a TaskHost. Neither MSBuildTask0012 nor
+            // MSBuildTask0013 is meaningful on an abstract type either.
             if (type.IsAbstract)
             {
+                if (hasAttribute)
+                {
+                    ReportNoEffect(
+                        context,
+                        type,
+                        "the engine never instantiates an abstract task and the attribute is not inherited, so derived tasks do not pick it up");
+                }
+
                 return;
             }
 
@@ -200,6 +210,27 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                 if (location.IsInSource)
                 {
                     context.ReportDiagnostic(Diagnostic.Create(descriptor, location, type.Name));
+                    return;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Reports that the routing attribute cannot take effect on this type, naming the reason so the
+        /// two shapes -- not a task at all, and an abstract task whose attribute no subclass inherits --
+        /// are distinguishable in the message.
+        /// </summary>
+        private static void ReportNoEffect(SymbolAnalysisContext context, INamedTypeSymbol type, string reason)
+        {
+            foreach (Location location in type.Locations)
+            {
+                if (location.IsInSource)
+                {
+                    context.ReportDiagnostic(Diagnostic.Create(
+                        DiagnosticDescriptors.MultiThreadableTaskAttributeHasNoEffect,
+                        location,
+                        type.Name,
+                        reason));
                     return;
                 }
             }

--- a/src/TaskAnalyzer/MultiThreadableTaskDeclarationAnalyzer.cs
+++ b/src/TaskAnalyzer/MultiThreadableTaskDeclarationAnalyzer.cs
@@ -17,6 +17,8 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
     /// </para>
     /// <para>
     /// Declaring one without the other is legal but usually unintended, and both halves fail silently.
+    /// The attribute is also reported when it is applied to a type that is not a task at all, where
+    /// nothing reads it.
     /// </para>
     /// </summary>
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
@@ -27,7 +29,8 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
             ImmutableArray.Create(
                 DiagnosticDescriptors.TaskEnvironmentNeverAssigned,
-                DiagnosticDescriptors.MissingMultiThreadableTaskAttribute);
+                DiagnosticDescriptors.MissingMultiThreadableTaskAttribute,
+                DiagnosticDescriptors.MultiThreadableTaskAttributeOnNonTask);
 
         public override void Initialize(AnalysisContext context)
         {
@@ -70,17 +73,34 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
         {
             var type = (INamedTypeSymbol)context.Symbol;
 
+            if (type.TypeKind != TypeKind.Class)
+            {
+                return;
+            }
+
+            bool hasAttribute = HasMultiThreadableTaskAttribute(type, attributeType);
+
+            if (!SharedAnalyzerHelpers.ImplementsInterface(type, taskType))
+            {
+                // TaskRouter only inspects types the engine is about to run as a task, so the routing
+                // attribute does nothing here. This usually means it landed on a helper type, or on the
+                // wrong class of a multi-class file, leaving the real task unmarked.
+                if (hasAttribute)
+                {
+                    ReportOnType(context, DiagnosticDescriptors.MultiThreadableTaskAttributeOnNonTask, type);
+                }
+
+                return;
+            }
+
             // Abstract types are never instantiated by the engine, and the routing attribute is not
             // inherited, so neither declaration is meaningful on them.
-            if (type.TypeKind != TypeKind.Class ||
-                type.IsAbstract ||
-                !SharedAnalyzerHelpers.ImplementsInterface(type, taskType))
+            if (type.IsAbstract)
             {
                 return;
             }
 
             bool implementsInterface = SharedAnalyzerHelpers.ImplementsInterface(type, multiThreadableTaskType);
-            bool hasAttribute = HasMultiThreadableTaskAttribute(type, attributeType);
 
             if (hasAttribute && !implementsInterface)
             {

--- a/src/TaskAnalyzer/README.md
+++ b/src/TaskAnalyzer/README.md
@@ -27,7 +27,7 @@ This analyzer catches unsafe API usage at compile time and offers code fixes to 
 | **MSBuildTask0011** | Info | Concrete `IMultiThreadableTask` implementations | Prefer constructor injection for `TaskEnvironment` |
 | **MSBuildTask0012** | Warning | Concrete tasks with `[MSBuildMultiThreadableTask]` applied directly | MSBuild never assigns the `TaskEnvironment` property |
 | **MSBuildTask0013** | Info (off by default) | Concrete tasks declaring `IMultiThreadableTask` in their own base list | Missing `[MSBuildMultiThreadableTask]`, so the task still runs out-of-proc |
-| **MSBuildTask0014** | Warning | Classes carrying `[MSBuildMultiThreadableTask]` that do not implement `ITask` | The attribute has no effect because nothing reads it |
+| **MSBuildTask0014** | Warning | Classes carrying `[MSBuildMultiThreadableTask]` that are not an `ITask`, or are abstract | The attribute has no effect because MSBuild never routes that type as a task |
 
 ### MSBuildTask0001 — Critical: No Safe Alternative
 
@@ -352,12 +352,14 @@ dotnet_diagnostic.MSBuildTask0013.severity = suggestion
 
 Inheriting the interface is deliberately not reported. `ToolTask` implements `IMultiThreadableTask`, so every `ToolTask`-derived task in the ecosystem satisfies it without its author having declared anything — the same reason `TaskRouter` cannot use the interface as a routing signal.
 
-### MSBuildTask0014 — `[MSBuildMultiThreadableTask]` on a Type That Is Not a Task
+### MSBuildTask0014 — `[MSBuildMultiThreadableTask]` Has No Effect on This Type
 
-`TaskRouter` only inspects types the engine is about to execute as a task, so the attribute is inert on anything that does not implement `ITask`:
+`TaskRouter` reads the attribute with `inherit: false`, off the concrete type the engine has just instantiated as a task. It therefore only has an effect on a **non-abstract class that implements `ITask`**. Two shapes get reported.
+
+**Not a task at all** — nothing ever reads the attribute:
 
 ```csharp
-[MSBuildMultiThreadableTask]     // ⚠️ MSBuildTask0014: not a task, nothing reads this
+[MSBuildMultiThreadableTask]     // ⚠️ MSBuildTask0014: does not implement ITask
 public class PathHelper
 {
     public string Combine(string a, string b) => Path.Combine(a, b);
@@ -369,9 +371,25 @@ public class MyTask : Task       // the actual task, still routed to a TaskHost
 }
 ```
 
-Fix by moving the attribute to the task class. The most common cause is a file that declares a task alongside helper types, where the attribute lands on the wrong one and the task is silently left unmigrated.
+**An abstract task** — the engine never instantiates this type, and because the attribute is not inherited no derived task picks it up, so every one of them still runs out-of-proc:
 
-**Scope:** Classes carrying the attribute that do not implement `ITask`. Abstract `ITask` classes are not reported by this rule.
+```csharp
+[MSBuildMultiThreadableTask]     // ⚠️ MSBuildTask0014: not inherited by MyTask
+public abstract class MyTaskBase : Task
+{
+}
+
+public class MyTask : MyTaskBase // no attribute of its own -> TaskHost
+{
+    public override bool Execute() => true;
+}
+```
+
+Fix by moving the attribute onto each concrete task class. Both shapes usually mean it was applied to the wrong class — a helper type beside the real task, or a shared base instead of the tasks deriving from it.
+
+**Scope:** Classes carrying the attribute that either do not implement `ITask` or are abstract.
+
+A concrete task that MSBuild cannot construct — no public parameterless constructor and no public single-`TaskEnvironment` constructor — is a third inert shape, but it is **not** reported. `Microsoft.Build.Utilities.Task.RegisterTask(string, Func<TaskEnvironment, ITask>)` lets a host supply an arbitrary factory, so such a task may be perfectly reachable.
 
 ## Analysis Scope
 
@@ -385,6 +403,7 @@ The analyzer determines what to check based on the type declaration:
 | Helper class with `[MSBuildMultiThreadableTaskAnalyzed]` attribute | MSBuildTask0001–MSBuildTask0005 |
 | Regular class (no task interface or attribute) | Not analyzed |
 | Class with `[MSBuildMultiThreadableTask]` that does not implement `ITask` | MSBuildTask0014 |
+| Abstract class with `[MSBuildMultiThreadableTask]` | MSBuildTask0014 |
 
 MSBuildTask0006–MSBuildTask0008 apply only when the `[MSBuildMultiThreadableTask]` attribute is applied **directly** to the task class. The attribute is `Inherited = false`, so a task that merely derives from a base class implementing `IMultiThreadableTask` (or carrying the attribute) has not itself opted into multithreaded support and is not subject to these three rules. Input properties are collected from the task class **and its base classes**, so an `ITaskItem`/`string` input declared on a shared base task is still analyzed.
 

--- a/src/TaskAnalyzer/README.md
+++ b/src/TaskAnalyzer/README.md
@@ -27,6 +27,7 @@ This analyzer catches unsafe API usage at compile time and offers code fixes to 
 | **MSBuildTask0011** | Info | Concrete `IMultiThreadableTask` implementations | Prefer constructor injection for `TaskEnvironment` |
 | **MSBuildTask0012** | Warning | Concrete tasks with `[MSBuildMultiThreadableTask]` applied directly | MSBuild never assigns the `TaskEnvironment` property |
 | **MSBuildTask0013** | Info (off by default) | Concrete tasks declaring `IMultiThreadableTask` in their own base list | Missing `[MSBuildMultiThreadableTask]`, so the task still runs out-of-proc |
+| **MSBuildTask0014** | Warning | Classes carrying `[MSBuildMultiThreadableTask]` that do not implement `ITask` | The attribute has no effect because nothing reads it |
 
 ### MSBuildTask0001 — Critical: No Safe Alternative
 
@@ -351,6 +352,27 @@ dotnet_diagnostic.MSBuildTask0013.severity = suggestion
 
 Inheriting the interface is deliberately not reported. `ToolTask` implements `IMultiThreadableTask`, so every `ToolTask`-derived task in the ecosystem satisfies it without its author having declared anything — the same reason `TaskRouter` cannot use the interface as a routing signal.
 
+### MSBuildTask0014 — `[MSBuildMultiThreadableTask]` on a Type That Is Not a Task
+
+`TaskRouter` only inspects types the engine is about to execute as a task, so the attribute is inert on anything that does not implement `ITask`:
+
+```csharp
+[MSBuildMultiThreadableTask]     // ⚠️ MSBuildTask0014: not a task, nothing reads this
+public class PathHelper
+{
+    public string Combine(string a, string b) => Path.Combine(a, b);
+}
+
+public class MyTask : Task       // the actual task, still routed to a TaskHost
+{
+    public override bool Execute() => true;
+}
+```
+
+Fix by moving the attribute to the task class. The most common cause is a file that declares a task alongside helper types, where the attribute lands on the wrong one and the task is silently left unmigrated.
+
+**Scope:** Classes carrying the attribute that do not implement `ITask`. Abstract `ITask` classes are not reported by this rule.
+
 ## Analysis Scope
 
 The analyzer determines what to check based on the type declaration:
@@ -362,6 +384,7 @@ The analyzer determines what to check based on the type declaration:
 | Concrete class implementing `IMultiThreadableTask` without the attribute | MSBuildTask0001–MSBuildTask0005 and MSBuildTask0009–MSBuildTask0011 |
 | Helper class with `[MSBuildMultiThreadableTaskAnalyzed]` attribute | MSBuildTask0001–MSBuildTask0005 |
 | Regular class (no task interface or attribute) | Not analyzed |
+| Class with `[MSBuildMultiThreadableTask]` that does not implement `ITask` | MSBuildTask0014 |
 
 MSBuildTask0006–MSBuildTask0008 apply only when the `[MSBuildMultiThreadableTask]` attribute is applied **directly** to the task class. The attribute is `Inherited = false`, so a task that merely derives from a base class implementing `IMultiThreadableTask` (or carrying the attribute) has not itself opted into multithreaded support and is not subject to these three rules. Input properties are collected from the task class **and its base classes**, so an `ITaskItem`/`string` input declared on a shared base task is still analyzed.
 
@@ -377,6 +400,7 @@ The `[MSBuildMultiThreadableTaskAnalyzed]` attribute allows opting helper classe
 - **MSBuildTask0011** reports as **Info** — it is a modernization suggestion rather than a correctness issue.
 - **MSBuildTask0012** reports as **Warning** — the `TaskEnvironment` property is silently inert, which is a correctness issue.
 - **MSBuildTask0013** is **disabled by default** — running out-of-proc is a performance characteristic, and the shape it reports is a valid intermediate migration state.
+- **MSBuildTask0014** reports as **Warning** — the attribute is inert, and the task the author meant to mark is usually still running out-of-proc.
 
 ## Code Fixes
 

--- a/src/TaskAnalyzer/README.md
+++ b/src/TaskAnalyzer/README.md
@@ -25,7 +25,7 @@ This analyzer catches unsafe API usage at compile time and offers code fixes to 
 | **MSBuildTask0009** | Warning | All `ITask` implementations | `ITaskItem<T>` used with unsupported type argument |
 | **MSBuildTask0010** | Error | All `ITask` implementations | `ITaskItem<T>` relies on culture-sensitive conversion |
 | **MSBuildTask0011** | Info | Concrete `IMultiThreadableTask` implementations | Prefer constructor injection for `TaskEnvironment` |
-| **MSBuildTask0012** | Warning | Concrete tasks with `[MSBuildMultiThreadableTask]` applied directly | `TaskEnvironment` property is never assigned |
+| **MSBuildTask0012** | Warning | Concrete tasks with `[MSBuildMultiThreadableTask]` applied directly | MSBuild never assigns the `TaskEnvironment` property |
 | **MSBuildTask0013** | Info (off by default) | Concrete tasks declaring `IMultiThreadableTask` in their own base list | Missing `[MSBuildMultiThreadableTask]`, so the task still runs out-of-proc |
 
 ### MSBuildTask0001 — Critical: No Safe Alternative
@@ -289,18 +289,19 @@ The engine prefers this constructor when it is present. A public parameterless c
 
 **Scope:** Concrete classes implementing `IMultiThreadableTask`. Abstract base classes and tasks that already declare a public single-`TaskEnvironment` constructor do not produce the diagnostic.
 
-### MSBuildTask0012 — `TaskEnvironment` Property Is Never Assigned
+### MSBuildTask0012 — MSBuild Never Assigns the `TaskEnvironment` Property
 
 `[MSBuildMultiThreadableTask]` and `IMultiThreadableTask` do different jobs. The **attribute** is the routing signal — it is the only thing that makes a task run in-process instead of in an out-of-proc TaskHost. The **interface** is the injection signal — the engine assigns `TaskEnvironment` only to tasks that implement it.
 
-Declaring the attribute and a `TaskEnvironment` property, but not the interface, produces a task that runs in-process with an environment that is never populated:
+Declaring the attribute and a `TaskEnvironment` property, but not the interface, produces a task that runs in-process with an environment MSBuild never populates:
 
 ```csharp
 [MSBuildMultiThreadableTask]
 public class MyTask : Task            // ⚠️ MSBuildTask0012: no IMultiThreadableTask
 {
-    // Never assigned by the engine. Stays TaskEnvironment.Fallback, so every path below
-    // resolves against the shared process working directory instead of the project directory.
+    // MSBuild never assigns this. It keeps whatever the task set here -- Fallback below,
+    // or null with no initializer -- so paths resolve against the shared process working
+    // directory instead of the project directory.
     public TaskEnvironment TaskEnvironment { get; set; } = TaskEnvironment.Fallback;
 
     public override bool Execute()
@@ -311,16 +312,30 @@ public class MyTask : Task            // ⚠️ MSBuildTask0012: no IMultiThread
 }
 ```
 
-Fix by implementing the interface:
+There are two ways to fix it. Implementing the interface is the usual one — it is the complete migration, and the engine assigns the property after construction:
 
 ```csharp
 [MSBuildMultiThreadableTask]
 public class MyTask : Task, IMultiThreadableTask
 ```
 
+Alternatively, declare a public constructor whose single parameter is `TaskEnvironment`. The engine selects it by signature, independently of the interface, so this works for a task that cannot implement the interface. The constructor **must assign the property itself**: without the interface there is no post-construction assignment to fall back on. Use this when the task needs the environment during construction — for example to root a default output path — which is also what [MSBuildTask0011](#msbuildtask0011--prefer-taskenvironment-constructor-injection) recommends.
+
+```csharp
+[MSBuildMultiThreadableTask]
+public class MyTask : Task
+{
+    public MyTask(TaskEnvironment taskEnvironment) => TaskEnvironment = taskEnvironment;
+
+    public TaskEnvironment TaskEnvironment { get; set; } = TaskEnvironment.Fallback;
+}
+```
+
 **Scope:** Concrete `ITask` implementations with `[MSBuildMultiThreadableTask]` applied directly, that do not implement `IMultiThreadableTask`, and that declare (or inherit) a settable `TaskEnvironment` property.
 
-The attribute **without** a `TaskEnvironment` property is a supported state and is not reported — that is the compatibility-bridge shape, correct for a task that does not resolve relative paths or read environment variables. A task declaring a public constructor whose single parameter is `TaskEnvironment` is also not reported: the engine selects that constructor by signature, independently of the interface.
+The attribute **without** a `TaskEnvironment` property is a supported state and is not reported — that is the compatibility-bridge shape, correct for a task that does not resolve relative paths or read environment variables. A task declaring a public single-`TaskEnvironment` constructor is likewise not reported, per the second fix above.
+
+Inheriting `IMultiThreadableTask` from a base class satisfies the rule: the engine's injection check is a runtime type test, so an inherited implementation receives an environment just as a directly declared one does.
 
 ### MSBuildTask0013 — Missing `[MSBuildMultiThreadableTask]`
 

--- a/src/TaskAnalyzer/README.md
+++ b/src/TaskAnalyzer/README.md
@@ -25,6 +25,8 @@ This analyzer catches unsafe API usage at compile time and offers code fixes to 
 | **MSBuildTask0009** | Warning | All `ITask` implementations | `ITaskItem<T>` used with unsupported type argument |
 | **MSBuildTask0010** | Error | All `ITask` implementations | `ITaskItem<T>` relies on culture-sensitive conversion |
 | **MSBuildTask0011** | Info | Concrete `IMultiThreadableTask` implementations | Prefer constructor injection for `TaskEnvironment` |
+| **MSBuildTask0012** | Warning | Concrete tasks with `[MSBuildMultiThreadableTask]` applied directly | `TaskEnvironment` property is never assigned |
+| **MSBuildTask0013** | Info (off by default) | Concrete tasks declaring `IMultiThreadableTask` in their own base list | Missing `[MSBuildMultiThreadableTask]`, so the task still runs out-of-proc |
 
 ### MSBuildTask0001 — Critical: No Safe Alternative
 
@@ -287,6 +289,53 @@ The engine prefers this constructor when it is present. A public parameterless c
 
 **Scope:** Concrete classes implementing `IMultiThreadableTask`. Abstract base classes and tasks that already declare a public single-`TaskEnvironment` constructor do not produce the diagnostic.
 
+### MSBuildTask0012 — `TaskEnvironment` Property Is Never Assigned
+
+`[MSBuildMultiThreadableTask]` and `IMultiThreadableTask` do different jobs. The **attribute** is the routing signal — it is the only thing that makes a task run in-process instead of in an out-of-proc TaskHost. The **interface** is the injection signal — the engine assigns `TaskEnvironment` only to tasks that implement it.
+
+Declaring the attribute and a `TaskEnvironment` property, but not the interface, produces a task that runs in-process with an environment that is never populated:
+
+```csharp
+[MSBuildMultiThreadableTask]
+public class MyTask : Task            // ⚠️ MSBuildTask0012: no IMultiThreadableTask
+{
+    // Never assigned by the engine. Stays TaskEnvironment.Fallback, so every path below
+    // resolves against the shared process working directory instead of the project directory.
+    public TaskEnvironment TaskEnvironment { get; set; } = TaskEnvironment.Fallback;
+
+    public override bool Execute()
+    {
+        string text = File.ReadAllText(TaskEnvironment.GetAbsolutePath(Input));
+        ...
+    }
+}
+```
+
+Fix by implementing the interface:
+
+```csharp
+[MSBuildMultiThreadableTask]
+public class MyTask : Task, IMultiThreadableTask
+```
+
+**Scope:** Concrete `ITask` implementations with `[MSBuildMultiThreadableTask]` applied directly, that do not implement `IMultiThreadableTask`, and that declare (or inherit) a settable `TaskEnvironment` property.
+
+The attribute **without** a `TaskEnvironment` property is a supported state and is not reported — that is the compatibility-bridge shape, correct for a task that does not resolve relative paths or read environment variables. A task declaring a public constructor whose single parameter is `TaskEnvironment` is also not reported: the engine selects that constructor by signature, independently of the interface.
+
+### MSBuildTask0013 — Missing `[MSBuildMultiThreadableTask]`
+
+A task that declares `IMultiThreadableTask` receives a `TaskEnvironment` and resolves paths correctly, but without the attribute it still runs in an out-of-proc TaskHost and gains none of the multithreading performance benefit.
+
+This is a legitimate intermediate state during migration — path handling done, thread-safety review not yet complete — so the rule is **disabled by default**. Enable it once a codebase intends every multithreadable task to also be routed in-process:
+
+```ini
+dotnet_diagnostic.MSBuildTask0013.severity = suggestion
+```
+
+**Scope:** Concrete `ITask` implementations that declare `IMultiThreadableTask` **in their own base list** and lack the attribute.
+
+Inheriting the interface is deliberately not reported. `ToolTask` implements `IMultiThreadableTask`, so every `ToolTask`-derived task in the ecosystem satisfies it without its author having declared anything — the same reason `TaskRouter` cannot use the interface as a routing signal.
+
 ## Analysis Scope
 
 The analyzer determines what to check based on the type declaration:
@@ -311,6 +360,8 @@ The `[MSBuildMultiThreadableTaskAnalyzed]` attribute allows opting helper classe
 - **MSBuildTask0010** is always **Error** — task item conversions must not rely on `Convert.ChangeType`.
 - **MSBuildTask0002–MSBuildTask0009** report as **Warning**, with MSBuildTask0006–MSBuildTask0008 limited to tasks directly marked with `[MSBuildMultiThreadableTask]`.
 - **MSBuildTask0011** reports as **Info** — it is a modernization suggestion rather than a correctness issue.
+- **MSBuildTask0012** reports as **Warning** — the `TaskEnvironment` property is silently inert, which is a correctness issue.
+- **MSBuildTask0013** is **disabled by default** — running out-of-proc is a performance characteristic, and the shape it reports is a valid intermediate migration state.
 
 ## Code Fixes
 


### PR DESCRIPTION
Fixes #14779
Fixes #14790

## The problem

`[MSBuildMultiThreadableTask]` and `IMultiThreadableTask` do **different** jobs, but both the spec and `TaskRouter`'s own doc comment described them as interchangeable alternatives:

| Declaration | Effect | Read by |
| --- | --- | --- |
| `[MSBuildMultiThreadableTask]` | Runs in-process instead of an out-of-proc TaskHost | `TaskRouter.NeedsTaskHostInMultiThreadedMode` |
| `IMultiThreadableTask` | Receives a `TaskEnvironment` | `TaskExecutionHost` |

The spec went further and told authors on newer MSBuild versions to *prefer* the interface. Following that advice produces a task that resolves paths correctly and then runs in a TaskHost anyway, gaining nothing. This tripped up a real migration of ~150 tasks across `dotnet/arcade`, `dotnet/source-build-assets` and the VMR.

The interface **cannot** be promoted to a routing signal, which was the original suggestion in #14779. `ToolTask` implements `IMultiThreadableTask` (`src/Utilities/ToolTask.cs`), so routing on it would silently opt in every `ToolTask`-derived task in the ecosystem, none of which have been reviewed for thread safety. The attribute stays the routing signal; the docs and the analyzer are what need to change.

## Documentation (#14790)

- Rewrote the spec's **Thread-Safe Capability Indicators** section around the routing/injection split. Capability is declared by the attribute alone; the interface is an additional mechanism for `TaskEnvironment` access, and a task that needs only the attribute is fully migrated.
- Removed *"customers using newer MSBuild versions should prefer the Interface-Based Thread-Safe Capability Declaration"*.
- Documented both silent failure modes, including what actually happens to an interface-only task: the out-of-proc host does **not** assign the property. It supplies `TaskEnvironment.Fallback` to a `TaskEnvironment` constructor when one is declared, and otherwise leaves the property at the task's own default. That is correct there, because `Fallback` is backed by `MultiProcessTaskEnvironmentDriver` and the host process is dedicated to a single task. Existing coverage: `TaskHost_MultiThreadableTask_Tests.InheritedTask_InTaskHost_HasUsableTaskEnvironment`.
- Removed the `MultiThreadableTask` abstract base class section — that type was never added.
- Fixed the attribute code snippet, which showed `internal class` and omitted `Inherited = false` — contradicting the text two lines below it and the actual declaration in `src/Framework/MSBuildMultiThreadableTaskAttribute.cs`.
- Rewrote the `TaskRouter` class-level doc comment to state that the attribute is the only routing signal, and why the interface is deliberately not consulted.
- Moved the "why not route on the interface" rationale into the spec's existing **Appendix: Alternatives**, where the other design alternatives already live.

## Analyzer (#14779)

Three new rules turn these mismatches into build diagnostics instead of silent runtime behaviour.

### MSBuildTask0012 — `TaskEnvironment` property is never assigned (Warning, on by default)

Fires when a task has the attribute, declares a settable `TaskEnvironment` property, and does **not** implement the interface. The engine never assigns the property, so it retains the task's own default and resolves every path against the shared process working directory — while the attribute has put the task in-process, which is exactly where that is wrong.

Two shapes are deliberately **not** reported:

- **Attribute without a `TaskEnvironment` property.** This is the supported compatibility-bridge state and is correct for a task that does not resolve relative paths or read environment variables. 26 Arcade tasks intentionally sit here.
- **Attribute plus a public single-`TaskEnvironment` constructor, without the interface.** `LoadedType` selects that constructor by signature alone, independently of the interface, so the task *does* receive an environment. Flagging it would have been a false positive.

### MSBuildTask0013 — Missing `[MSBuildMultiThreadableTask]` (Info, **off** by default)

Fires when a task declares the interface but lacks the attribute, so it still pays for a TaskHost. Off by default because that is a valid intermediate migration state — path handling done, thread-safety review not yet complete.

Only a type that declares the interface **in its own base list** is reported. Because `ToolTask` implements `IMultiThreadableTask`, keying on `AllInterfaces` would have fired on every `ToolTask` subclass in the ecosystem — the same trap as the routing bug this PR documents.

### MSBuildTask0014 — Attribute has no effect on this type (Warning, on by default)

`TaskRouter` reads `[MSBuildMultiThreadableTask]` with `inherit: false`, off the concrete type the engine has just instantiated as a task. The attribute therefore only takes effect on a **non-abstract class that implements `ITask`**. Two shapes are reported.

- **Not a task at all.** Nothing ever reads the attribute. The motivating case is a file that declares a task alongside helper types, where the attribute lands on the wrong class — leaving the real task unmarked and still routed to a TaskHost. That occurred during the Arcade migration.
- **An abstract task.** The engine never instantiates that type, and no subclass inherits the attribute, so every concrete task deriving from it is still routed out-of-proc while the base looks migrated. Usually means the attribute belongs on each derived task instead.

A concrete task MSBuild cannot construct — no public parameterless constructor and no public single-`TaskEnvironment` constructor — is a third inert shape, deliberately **not** reported: `Task.RegisterTask(string, Func<TaskEnvironment, ITask>)` lets a host supply an arbitrary factory, so such a task may be perfectly reachable.

## Validation

- `src/TaskAnalyzer` and `src/Build` build clean (0 warnings, 0 errors).
- 18 tests in `MultiThreadableTaskDeclarationAnalyzerTests`, including negative cases for both MSBuildTask0012 exclusions above, for `ToolTask`-like bases, for a non-task type without the attribute, and for an abstract base without the attribute. The `ToolTask` and `0013` tests run with the rule explicitly **enabled**, so they cannot pass trivially by virtue of the rule being off by default.
- Full `TaskAnalyzer.Tests` suite: 266/266.
