### PR TITLE
Ship TaskAnalyzer with Microsoft.Build.Framework

### DIFF
--- a/src/Framework/Microsoft.Build.Framework.csproj
+++ b/src/Framework/Microsoft.Build.Framework.csproj
@@ -143,6 +143,8 @@
 
   <ItemGroup>
     <ProjectReference Include="..\StringTools\StringTools.csproj" />
+    <ProjectReference Include="..\TaskAnalyzer\TaskAnalyzer.csproj"
+                      ReferenceOutputAssembly="false" />
   </ItemGroup>
 
   <ItemGroup>
@@ -209,6 +211,18 @@
   <Target Name="IncludeTlbInPackage" BeforeTargets="_GetPackageFiles" Condition="'$(CreateTlb)' == 'true'">
     <ItemGroup>
       <_PackageFiles Include="$(ArtifactsBinDir)Microsoft.Build.Framework\$(Configuration)\net472\Microsoft.Build.Framework.tlb" PackagePath="tools/net472" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="IncludeTaskAnalyzerInPackage" BeforeTargets="_GetPackageFiles">
+    <MSBuild Projects="..\TaskAnalyzer\TaskAnalyzer.csproj"
+             Targets="GetTargetPath"
+             BuildInParallel="$(BuildInParallel)">
+      <Output TaskParameter="TargetOutputs" ItemName="_TaskAnalyzerOutput" />
+    </MSBuild>
+
+    <ItemGroup>
+      <_PackageFiles Include="@(_TaskAnalyzerOutput)" PackagePath="analyzers/dotnet/cs" />
     </ItemGroup>
   </Target>
 

--- a/src/MSBuild.EndToEnd.Tests/Microsoft.Build.EndToEnd.Tests.csproj
+++ b/src/MSBuild.EndToEnd.Tests/Microsoft.Build.EndToEnd.Tests.csproj
@@ -25,6 +25,9 @@
   <ItemGroup>
     <Compile Remove="TestAssets\**\*.cs" />
     <None Include="TestAssets\**" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="..\..\NuGet.Config"
+          Link="TestAssets\TaskAnalyzerPackage\NuGet.Config"
+          CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
 </Project>

--- a/src/MSBuild.EndToEnd.Tests/TaskAnalyzerPackage_Tests.cs
+++ b/src/MSBuild.EndToEnd.Tests/TaskAnalyzerPackage_Tests.cs
@@ -1,0 +1,251 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Xml.Linq;
+using Microsoft.Build.UnitTests;
+using Microsoft.Build.UnitTests.Shared;
+using Shouldly;
+using Xunit;
+
+namespace Microsoft.Build.EndToEndTests;
+
+public sealed class TaskAnalyzerPackage_Tests : IDisposable
+{
+    private const string AnalyzerPackagePath = "analyzers/dotnet/cs/Microsoft.Build.TaskAuthoring.Analyzer.dll";
+    private const string FrameworkPackagePrefix = "Microsoft.Build.Framework.";
+    private const string PackageExtension = ".nupkg";
+    private const int ProcessTimeoutMilliseconds = 180_000;
+
+    private readonly TestEnvironment _env;
+    private readonly ITestOutputHelper _output;
+
+    public TaskAnalyzerPackage_Tests(ITestOutputHelper output)
+    {
+        _output = output;
+        _env = TestEnvironment.Create(output);
+    }
+
+    public void Dispose() => _env.Dispose();
+
+    [Fact]
+    public void FrameworkPackageContainsTaskAnalyzerWithoutRoslynDependencies()
+    {
+        string packagePath = GetFrameworkPackagePath();
+
+        using ZipArchive package = new ZipArchive(File.OpenRead(packagePath), ZipArchiveMode.Read);
+        package.GetEntry(AnalyzerPackagePath).ShouldNotBeNull();
+
+        package.Entries
+            .Where(entry => entry.FullName.StartsWith("analyzers/", StringComparison.OrdinalIgnoreCase))
+            .Select(entry => entry.FullName)
+            .ShouldBe([AnalyzerPackagePath], ignoreOrder: true);
+
+        ZipArchiveEntry nuspecEntry = package.GetEntry("Microsoft.Build.Framework.nuspec").ShouldNotBeNull();
+        using Stream nuspecStream = nuspecEntry.Open();
+        XDocument nuspec = XDocument.Load(nuspecStream);
+
+        nuspec
+            .Descendants()
+            .Where(element => element.Name.LocalName == "dependency")
+            .Select(element => (string?)element.Attribute("id"))
+            .Where(packageId => packageId is not null && packageId.StartsWith("Microsoft.CodeAnalysis", StringComparison.OrdinalIgnoreCase))
+            .ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void FrameworkPackageActivatesTaskAnalyzer()
+    {
+        string packagePath = GetFrameworkPackagePath();
+        string packageVersion = GetPackageVersion(packagePath);
+        TransientTestFolder projectFolder = _env.CreateFolder(createFolder: true);
+        string projectPath = Path.Combine(projectFolder.Path, "TaskProject.csproj");
+        string globalConfigPath = Path.Combine(projectFolder.Path, ".globalconfig");
+
+        File.WriteAllText(
+            projectPath,
+            $$"""
+              <Project Sdk="Microsoft.NET.Sdk">
+                <PropertyGroup>
+                  <TargetFramework>{{RunnerUtilities.LatestDotNetCoreForMSBuild}}</TargetFramework>
+                  <Nullable>disable</Nullable>
+                </PropertyGroup>
+                <ItemGroup>
+                  <PackageReference Include="Microsoft.Build.Framework" Version="{{packageVersion}}" />
+                </ItemGroup>
+              </Project>
+              """);
+
+        File.WriteAllText(
+            Path.Combine(projectFolder.Path, "TaskBase.cs"),
+            """
+            using Microsoft.Build.Framework;
+
+            public abstract class TaskBase : ITask
+            {
+                public IBuildEngine BuildEngine { get; set; }
+                public ITaskHost HostObject { get; set; }
+                public abstract bool Execute();
+            }
+            """);
+
+        File.WriteAllText(
+            Path.Combine(projectFolder.Path, "RegularTask.cs"),
+            """
+            using System;
+
+            public sealed class RegularTask : TaskBase
+            {
+                public override bool Execute()
+                {
+                    _ = Environment.CurrentDirectory;
+                    return true;
+                }
+            }
+            """);
+
+        File.WriteAllText(
+            Path.Combine(projectFolder.Path, "MtTask.cs"),
+            """
+            using System;
+            using Microsoft.Build.Framework;
+
+            public sealed class MtTask : TaskBase, IMultiThreadableTask
+            {
+                public TaskEnvironment TaskEnvironment { get; set; }
+
+                public override bool Execute()
+                {
+                    _ = Environment.CurrentDirectory;
+                    return true;
+                }
+            }
+            """);
+
+        string nugetConfigPath = CreateNuGetConfig(projectFolder.Path);
+        string commonArguments = $"\"{projectPath}\" /nologo /verbosity:minimal";
+        string restoreArguments = $"/restore /p:RestoreConfigFile=\"{nugetConfigPath}\"";
+
+#if FEATURE_RUN_EXE_IN_TESTS
+        string defaultOutput = RunMSBuild($"{commonArguments} {restoreArguments}", out bool defaultBuildSucceeded);
+#else
+        string defaultOutput = RunDotNetBuild(
+            $"\"{projectPath}\" --nologo --verbosity:minimal {restoreArguments}",
+            out bool defaultBuildSucceeded);
+#endif
+        defaultBuildSucceeded.ShouldBeTrue(defaultOutput);
+        defaultOutput.ShouldContain("warning MSBuildTask0002");
+        defaultOutput.ShouldContain("MtTask.cs");
+        defaultOutput.ShouldNotContain("RegularTask.cs");
+
+        File.WriteAllText(
+            globalConfigPath,
+            """
+            is_global = true
+            msbuild_task_analyzer.scope = all
+            """);
+
+        string migrationOutput = RunMSBuild($"{commonArguments} /t:Rebuild", out bool migrationBuildSucceeded);
+        migrationBuildSucceeded.ShouldBeTrue(migrationOutput);
+        migrationOutput.ShouldContain("warning MSBuildTask0002");
+        migrationOutput.ShouldContain("MtTask.cs");
+        migrationOutput.ShouldContain("RegularTask.cs");
+
+        string suppressedOutput = RunMSBuild(
+            $"{commonArguments} /t:Rebuild /p:NoWarn=MSBuildTask0002",
+            out bool suppressedBuildSucceeded);
+        suppressedBuildSucceeded.ShouldBeTrue(suppressedOutput);
+        suppressedOutput.ShouldNotContain("MSBuildTask0002");
+
+        File.Delete(globalConfigPath);
+
+        string warningsAsErrorsOutput = RunMSBuild(
+            $"{commonArguments} /t:Rebuild /p:TreatWarningsAsErrors=true",
+            out bool warningsAsErrorsBuildSucceeded);
+        warningsAsErrorsBuildSucceeded.ShouldBeFalse();
+        warningsAsErrorsOutput.ShouldContain("error MSBuildTask0002");
+        warningsAsErrorsOutput.ShouldContain("MtTask.cs");
+        warningsAsErrorsOutput.ShouldNotContain("RegularTask.cs");
+
+        string disabledOutput = RunMSBuild(
+            $"{commonArguments} /t:Rebuild /p:RunAnalyzers=false",
+            out bool disabledBuildSucceeded);
+        disabledBuildSucceeded.ShouldBeTrue(disabledOutput);
+        disabledOutput.ShouldNotContain("MSBuildTask0002");
+    }
+
+    private string CreateNuGetConfig(string projectDirectory)
+    {
+        string sourceConfigPath = Path.Combine(AppContext.BaseDirectory, "TestAssets", "TaskAnalyzerPackage", "NuGet.Config");
+        string destinationConfigPath = Path.Combine(projectDirectory, "NuGet.Config");
+        XDocument config = XDocument.Load(sourceConfigPath);
+
+        XElement packageSources = config.Root!.Element("packageSources").ShouldNotBeNull();
+        packageSources.Add(
+            new XElement(
+                "add",
+                new XAttribute("key", "local-msbuild"),
+                new XAttribute("value", RunnerUtilities.ArtifactsLocationAttribute.ArtifactsLocation)));
+
+        XElement packageSourceMapping = config.Root.Element("packageSourceMapping").ShouldNotBeNull();
+        packageSourceMapping.Add(
+            new XElement(
+                "packageSource",
+                new XAttribute("key", "local-msbuild"),
+                new XElement("package", new XAttribute("pattern", "Microsoft.Build.*")),
+                new XElement("package", new XAttribute("pattern", "Microsoft.NET.StringTools"))));
+
+        config.Save(destinationConfigPath);
+        return destinationConfigPath;
+    }
+
+    private string GetFrameworkPackagePath()
+    {
+        string[] packages = Directory.GetFiles(
+            RunnerUtilities.ArtifactsLocationAttribute.ArtifactsLocation,
+            $"{FrameworkPackagePrefix}*{PackageExtension}",
+            SearchOption.TopDirectoryOnly);
+
+        packages.ShouldNotBeEmpty();
+        return packages.OrderByDescending(File.GetLastWriteTimeUtc).First();
+    }
+
+    private static string GetPackageVersion(string packagePath)
+    {
+        string packageFileName = Path.GetFileName(packagePath);
+        return packageFileName.Substring(
+            FrameworkPackagePrefix.Length,
+            packageFileName.Length - FrameworkPackagePrefix.Length - PackageExtension.Length);
+    }
+
+#if !FEATURE_RUN_EXE_IN_TESTS
+    private string RunDotNetBuild(string arguments, out bool succeeded)
+    {
+        string output = RunnerUtilities.RunProcessAndGetOutput(
+            RunnerUtilities.BootstrapDotnetHostPath,
+            $"build {arguments}",
+            out succeeded,
+            outputHelper: _output,
+            timeoutMilliseconds: ProcessTimeoutMilliseconds,
+            environmentVariables: RunnerUtilities.GetBootstrapMSBuildEnvironmentVariables());
+
+        _output.WriteLine(output);
+        return output;
+    }
+#endif
+
+    private string RunMSBuild(string arguments, out bool succeeded)
+    {
+        string output = RunnerUtilities.ExecBootstrapedMSBuild(
+            arguments,
+            out succeeded,
+            outputHelper: _output,
+            timeoutMilliseconds: ProcessTimeoutMilliseconds);
+
+        _output.WriteLine(output);
+        return output;
+    }
+}

--- a/src/TaskAnalyzer.Tests/MultiThreadableTaskAnalyzerTests.cs
+++ b/src/TaskAnalyzer.Tests/MultiThreadableTaskAnalyzerTests.cs
@@ -3,6 +3,9 @@
 
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
 using Shouldly;
 using Xunit;
 using static Microsoft.Build.TaskAuthoring.Analyzer.Tests.TestHelpers;
@@ -1869,6 +1872,225 @@ public class MultiThreadableTaskAnalyzerTests
     // ═══════════════════════════════════════════════════════════════════════
     // Scope option tests
     // ═══════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task Scope_Default_PlainTask_DoesNotGetScopedDiagnostics()
+    {
+        var diags = await GetDiagnosticsWithDefaultScopeAsync("""
+            using System;
+            using System.IO;
+            using System.Reflection;
+            public class PlainTask : Microsoft.Build.Utilities.Task
+            {
+                public override bool Execute()
+                {
+                    Console.WriteLine("test");
+                    var value = Environment.GetEnvironmentVariable("KEY");
+                    Assembly.Load("Test");
+                    return File.Exists("relative.txt");
+                }
+            }
+            """);
+
+        diags.Where(d => d.Id == DiagnosticIds.CriticalError).ShouldBeEmpty();
+        diags.Where(d => d.Id == DiagnosticIds.TaskEnvironmentRequired).ShouldBeEmpty();
+        diags.Where(d => d.Id == DiagnosticIds.FilePathRequiresAbsolute).ShouldBeEmpty();
+        diags.Where(d => d.Id == DiagnosticIds.PotentialIssue).ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task Scope_Default_MultiThreadableTask_GetsAllScopedDiagnostics()
+    {
+        var diags = await GetDiagnosticsWithDefaultScopeAsync("""
+            using System;
+            using System.IO;
+            using System.Reflection;
+            using Microsoft.Build.Framework;
+            public class MtTask : Microsoft.Build.Utilities.Task, IMultiThreadableTask
+            {
+                public TaskEnvironment TaskEnvironment { get; set; }
+                public override bool Execute()
+                {
+                    Console.WriteLine("test");
+                    var value = Environment.GetEnvironmentVariable("KEY");
+                    Assembly.Load("Test");
+                    return File.Exists("relative.txt");
+                }
+            }
+            """);
+
+        diags.Where(d => d.Id == DiagnosticIds.CriticalError).ShouldHaveSingleItem()
+            .Severity.ShouldBe(DiagnosticSeverity.Error);
+        diags.Where(d => d.Id == DiagnosticIds.TaskEnvironmentRequired).ShouldHaveSingleItem()
+            .Severity.ShouldBe(DiagnosticSeverity.Warning);
+        diags.Where(d => d.Id == DiagnosticIds.FilePathRequiresAbsolute).ShouldHaveSingleItem()
+            .Severity.ShouldBe(DiagnosticSeverity.Warning);
+        diags.Where(d => d.Id == DiagnosticIds.PotentialIssue).ShouldHaveSingleItem()
+            .Severity.ShouldBe(DiagnosticSeverity.Warning);
+    }
+
+    [Fact]
+    public async Task Scope_All_PlainTask_GetsAllScopedDiagnostics()
+    {
+        var diags = await GetDiagnosticsWithScopeAsync("""
+            using System;
+            using System.IO;
+            using System.Reflection;
+            public class PlainTask : Microsoft.Build.Utilities.Task
+            {
+                public override bool Execute()
+                {
+                    Console.WriteLine("test");
+                    var value = Environment.GetEnvironmentVariable("KEY");
+                    Assembly.Load("Test");
+                    return File.Exists("relative.txt");
+                }
+            }
+            """, SharedAnalyzerHelpers.ScopeAll);
+
+        diags.Where(d => d.Id == DiagnosticIds.CriticalError).ShouldHaveSingleItem()
+            .Severity.ShouldBe(DiagnosticSeverity.Error);
+        diags.Where(d => d.Id == DiagnosticIds.TaskEnvironmentRequired).ShouldHaveSingleItem()
+            .Severity.ShouldBe(DiagnosticSeverity.Warning);
+        diags.Where(d => d.Id == DiagnosticIds.FilePathRequiresAbsolute).ShouldHaveSingleItem()
+            .Severity.ShouldBe(DiagnosticSeverity.Warning);
+        diags.Where(d => d.Id == DiagnosticIds.PotentialIssue).ShouldHaveSingleItem()
+            .Severity.ShouldBe(DiagnosticSeverity.Warning);
+    }
+
+    [Fact]
+    public async Task Scope_GlobalConfig_All_AnalyzesPlainTask()
+    {
+        var test = new CSharpAnalyzerTest<MultiThreadableTaskAnalyzer, DefaultVerifier>
+        {
+            TestCode = """
+                using System;
+                public class PlainTask : Microsoft.Build.Utilities.Task
+                {
+                    public override bool Execute()
+                    {
+                        var value = {|#0:Environment.GetEnvironmentVariable("KEY")|};
+                        return true;
+                    }
+                }
+                """,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        };
+        test.TestState.Sources.Add(("Stubs.cs", FrameworkStubs));
+        test.TestState.AnalyzerConfigFiles.Add(("/.globalconfig", """
+            is_global = true
+            msbuild_task_analyzer.scope = all
+            """));
+        test.ExpectedDiagnostics.Add(
+            new DiagnosticResult(DiagnosticIds.TaskEnvironmentRequired, DiagnosticSeverity.Warning).WithLocation(0));
+
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task Scope_UnrecognizedValue_UsesDefault()
+    {
+        var diags = await GetDiagnosticsWithScopeAsync("""
+            using System;
+            using System.Reflection;
+            public class PlainTask : Microsoft.Build.Utilities.Task
+            {
+                public override bool Execute()
+                {
+                    Console.WriteLine("test");
+                    var value = Environment.GetEnvironmentVariable("KEY");
+                    Assembly.Load("Test");
+                    return true;
+                }
+            }
+            """, "unrecognized");
+
+        diags.Where(d => d.Id == DiagnosticIds.CriticalError).ShouldBeEmpty();
+        diags.Where(d => d.Id == DiagnosticIds.TaskEnvironmentRequired).ShouldBeEmpty();
+        diags.Where(d => d.Id == DiagnosticIds.PotentialIssue).ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task Scope_Default_PlainTask_TreatWarningsAsErrors_DoesNotGetScopedDiagnostics()
+    {
+        var diags = await GetDiagnosticsWithDefaultScopeAsync("""
+            using System;
+            using System.Reflection;
+            public class PlainTask : Microsoft.Build.Utilities.Task
+            {
+                public override bool Execute()
+                {
+                    Console.WriteLine("test");
+                    Assembly.Load("Test");
+                    return true;
+                }
+            }
+            """, ReportDiagnostic.Error);
+
+        diags.Where(d => d.Id == DiagnosticIds.CriticalError).ShouldBeEmpty();
+        diags.Where(d => d.Id == DiagnosticIds.PotentialIssue).ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task Scope_Default_MultiThreadableTask_TreatWarningsAsErrors_PromotesWarning()
+    {
+        var diags = await GetDiagnosticsWithDefaultScopeAsync("""
+            using System.Reflection;
+            using Microsoft.Build.Framework;
+            public class MtTask : Microsoft.Build.Utilities.Task, IMultiThreadableTask
+            {
+                public TaskEnvironment TaskEnvironment { get; set; }
+                public override bool Execute()
+                {
+                    Assembly.Load("Test");
+                    return true;
+                }
+            }
+            """, ReportDiagnostic.Error);
+
+        Diagnostic diagnostic = diags.Where(d => d.Id == DiagnosticIds.PotentialIssue).ShouldHaveSingleItem();
+        diagnostic.Severity.ShouldBe(DiagnosticSeverity.Error);
+        diagnostic.IsWarningAsError.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task Scope_Default_MultiThreadableAttribute_OptsTaskIn()
+    {
+        var diags = await GetDiagnosticsWithDefaultScopeAsync("""
+            using System;
+            using Microsoft.Build.Framework;
+            [MSBuildMultiThreadableTask]
+            public class MtTask : Microsoft.Build.Utilities.Task
+            {
+                public override bool Execute()
+                {
+                    var value = Environment.GetEnvironmentVariable("KEY");
+                    return true;
+                }
+            }
+            """);
+
+        diags.Where(d => d.Id == DiagnosticIds.TaskEnvironmentRequired).ShouldHaveSingleItem();
+    }
+
+    [Fact]
+    public async Task Scope_Default_AnalyzedAttribute_OptsHelperIn()
+    {
+        var diags = await GetDiagnosticsWithDefaultScopeAsync("""
+            using System;
+            using Microsoft.Build.Framework;
+            [MSBuildMultiThreadableTaskAnalyzed]
+            public class MtHelper
+            {
+                public void Execute()
+                {
+                    var value = Environment.GetEnvironmentVariable("KEY");
+                }
+            }
+            """);
+
+        diags.Where(d => d.Id == DiagnosticIds.TaskEnvironmentRequired).ShouldHaveSingleItem();
+    }
 
     [Fact]
     public async Task Scope_MultithreadableOnly_PlainTask_NoDiagnostic()

--- a/src/TaskAnalyzer.Tests/TestHelpers.cs
+++ b/src/TaskAnalyzer.Tests/TestHelpers.cs
@@ -138,34 +138,16 @@ internal static class TestHelpers
     public static MetadataReference[] GetCoreReferences() => s_coreReferences;
 
     /// <summary>
-    /// Runs the MultiThreadableTaskAnalyzer on the given source code and returns analyzer diagnostics.
-    /// Source is combined with framework stubs automatically.
+    /// Runs the MultiThreadableTaskAnalyzer in explicit all-task migration mode.
     /// </summary>
-    public static async System.Threading.Tasks.Task<ImmutableArray<Diagnostic>> GetDiagnosticsAsync(string source)
-    {
-        var compilation = CreateCompilation(source);
-        var analyzer = new MultiThreadableTaskAnalyzer();
-        var compilationWithAnalyzers = compilation.WithAnalyzers(
-            ImmutableArray.Create<DiagnosticAnalyzer>(analyzer));
-
-        var allDiags = await compilationWithAnalyzers.GetAnalyzerDiagnosticsAsync();
-        return allDiags;
-    }
+    public static System.Threading.Tasks.Task<ImmutableArray<Diagnostic>> GetDiagnosticsAsync(string source) =>
+        GetDiagnosticsWithScopeAsync(source, SharedAnalyzerHelpers.ScopeAll);
 
     /// <summary>
-    /// Runs BOTH the direct and transitive analyzers on the given source code.
+    /// Runs both the direct and transitive analyzers in explicit all-task migration mode.
     /// </summary>
-    public static async System.Threading.Tasks.Task<ImmutableArray<Diagnostic>> GetAllDiagnosticsAsync(string source)
-    {
-        var compilation = CreateCompilation(source);
-        var analyzers = ImmutableArray.Create<DiagnosticAnalyzer>(
-            new MultiThreadableTaskAnalyzer(),
-            new TransitiveCallChainAnalyzer());
-        var compilationWithAnalyzers = compilation.WithAnalyzers(analyzers);
-
-        var allDiags = await compilationWithAnalyzers.GetAnalyzerDiagnosticsAsync();
-        return allDiags;
-    }
+    public static System.Threading.Tasks.Task<ImmutableArray<Diagnostic>> GetAllDiagnosticsAsync(string source) =>
+        GetAllDiagnosticsWithScopeAsync(source, SharedAnalyzerHelpers.ScopeAll);
 
     /// <summary>
     /// Runs compiler diagnostics together with analyzers and suppressors and returns
@@ -257,6 +239,69 @@ internal static class TestHelpers
 
         var compilationWithAnalyzers = compilation.WithAnalyzers(
             ImmutableArray.Create<DiagnosticAnalyzer>(analyzer), options);
+        return await compilationWithAnalyzers.GetAnalyzerDiagnosticsAsync();
+    }
+
+    /// <summary>
+    /// Runs the MultiThreadableTaskAnalyzer without a scope option.
+    /// </summary>
+    public static async System.Threading.Tasks.Task<ImmutableArray<Diagnostic>> GetDiagnosticsWithDefaultScopeAsync(string source)
+    {
+        var compilation = CreateCompilation(source);
+        var analyzer = new MultiThreadableTaskAnalyzer();
+        var compilationWithAnalyzers = compilation.WithAnalyzers(
+            ImmutableArray.Create<DiagnosticAnalyzer>(analyzer));
+        return await compilationWithAnalyzers.GetAnalyzerDiagnosticsAsync();
+    }
+
+    /// <summary>
+    /// Runs the MultiThreadableTaskAnalyzer without a scope option and applies a general diagnostic action.
+    /// </summary>
+    public static async System.Threading.Tasks.Task<ImmutableArray<Diagnostic>> GetDiagnosticsWithDefaultScopeAsync(
+        string source,
+        ReportDiagnostic generalDiagnosticOption)
+    {
+        var compilation = CreateCompilation(source);
+        compilation = compilation.WithOptions(
+            ((CSharpCompilationOptions)compilation.Options).WithGeneralDiagnosticOption(generalDiagnosticOption));
+
+        var analyzer = new MultiThreadableTaskAnalyzer();
+        var compilationWithAnalyzers = compilation.WithAnalyzers(
+            ImmutableArray.Create<DiagnosticAnalyzer>(analyzer));
+        return await compilationWithAnalyzers.GetAnalyzerDiagnosticsAsync();
+    }
+
+    /// <summary>
+    /// Runs both the direct and transitive analyzers with a specific scope option.
+    /// </summary>
+    public static async System.Threading.Tasks.Task<ImmutableArray<Diagnostic>> GetAllDiagnosticsWithScopeAsync(string source, string scope)
+    {
+        var compilation = CreateCompilation(source);
+        var analyzers = ImmutableArray.Create<DiagnosticAnalyzer>(
+            new MultiThreadableTaskAnalyzer(),
+            new TransitiveCallChainAnalyzer());
+
+        var globalOptions = new Dictionary<string, string>
+        {
+            { $"build_property.{SharedAnalyzerHelpers.ScopeOptionKey}", scope }
+        };
+        var optionsProvider = new TestAnalyzerConfigOptionsProvider(globalOptions);
+        var options = new AnalyzerOptions(ImmutableArray<AdditionalText>.Empty, optionsProvider);
+
+        var compilationWithAnalyzers = compilation.WithAnalyzers(analyzers, options);
+        return await compilationWithAnalyzers.GetAnalyzerDiagnosticsAsync();
+    }
+
+    /// <summary>
+    /// Runs both the direct and transitive analyzers without a scope option.
+    /// </summary>
+    public static async System.Threading.Tasks.Task<ImmutableArray<Diagnostic>> GetAllDiagnosticsWithDefaultScopeAsync(string source)
+    {
+        var compilation = CreateCompilation(source);
+        var analyzers = ImmutableArray.Create<DiagnosticAnalyzer>(
+            new MultiThreadableTaskAnalyzer(),
+            new TransitiveCallChainAnalyzer());
+        var compilationWithAnalyzers = compilation.WithAnalyzers(analyzers);
         return await compilationWithAnalyzers.GetAnalyzerDiagnosticsAsync();
     }
 

--- a/src/TaskAnalyzer.Tests/TransitiveCallChainAnalyzerTests.cs
+++ b/src/TaskAnalyzer.Tests/TransitiveCallChainAnalyzerTests.cs
@@ -244,4 +244,72 @@ public class TransitiveCallChainAnalyzerTests
         msg.ShouldContain("A.Step1");
         msg.ShouldContain("B.Step2");
     }
+
+    [Fact]
+    public async Task Scope_Default_PlainTask_DoesNotGetTransitiveDiagnostic()
+    {
+        var diags = await GetAllDiagnosticsWithDefaultScopeAsync("""
+            using System;
+            public static class Helper
+            {
+                public static void Run() => Environment.GetEnvironmentVariable("KEY");
+            }
+            public class PlainTask : Microsoft.Build.Utilities.Task
+            {
+                public override bool Execute()
+                {
+                    Helper.Run();
+                    return true;
+                }
+            }
+            """);
+
+        diags.Where(d => d.Id == DiagnosticIds.TransitiveUnsafeCall).ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task Scope_Default_MultiThreadableTask_GetsTransitiveDiagnostic()
+    {
+        var diags = await GetAllDiagnosticsWithDefaultScopeAsync("""
+            using System;
+            using Microsoft.Build.Framework;
+            public static class Helper
+            {
+                public static void Run() => Environment.GetEnvironmentVariable("KEY");
+            }
+            public class MtTask : Microsoft.Build.Utilities.Task, IMultiThreadableTask
+            {
+                public TaskEnvironment TaskEnvironment { get; set; }
+                public override bool Execute()
+                {
+                    Helper.Run();
+                    return true;
+                }
+            }
+            """);
+
+        diags.Where(d => d.Id == DiagnosticIds.TransitiveUnsafeCall).ShouldHaveSingleItem();
+    }
+
+    [Fact]
+    public async Task Scope_All_PlainTask_GetsTransitiveDiagnostic()
+    {
+        var diags = await GetAllDiagnosticsWithScopeAsync("""
+            using System;
+            public static class Helper
+            {
+                public static void Run() => Environment.GetEnvironmentVariable("KEY");
+            }
+            public class PlainTask : Microsoft.Build.Utilities.Task
+            {
+                public override bool Execute()
+                {
+                    Helper.Run();
+                    return true;
+                }
+            }
+            """, SharedAnalyzerHelpers.ScopeAll);
+
+        diags.Where(d => d.Id == DiagnosticIds.TransitiveUnsafeCall).ShouldHaveSingleItem();
+    }
 }

--- a/src/TaskAnalyzer.Tests/UnsupportedTaskItemTypeAnalyzerTests.cs
+++ b/src/TaskAnalyzer.Tests/UnsupportedTaskItemTypeAnalyzerTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Shouldly;
@@ -45,7 +46,7 @@ public class UnsupportedTaskItemTypeAnalyzerTests
     [InlineData("double")]
     [InlineData("decimal")]
     [InlineData("System.DateTime")]
-    public async Task ConvertChangeTypeType_ProducesError(string typeName)
+    public async Task ConvertChangeTypeType_ProducesWarning(string typeName)
     {
         var diags = await GetUnsupportedTaskItemTypeDiagnosticsAsync($$"""
             using Microsoft.Build.Framework;
@@ -59,7 +60,7 @@ public class UnsupportedTaskItemTypeAnalyzerTests
         diags.ShouldNotContain(d => d.Id == DiagnosticIds.UnsupportedTaskItemType);
         Diagnostic diagnostic = diags.ShouldHaveSingleItem();
         diagnostic.Id.ShouldBe(DiagnosticIds.CultureSensitiveTaskItemType);
-        diagnostic.Severity.ShouldBe(Microsoft.CodeAnalysis.DiagnosticSeverity.Error);
+        diagnostic.Severity.ShouldBe(Microsoft.CodeAnalysis.DiagnosticSeverity.Warning);
         diagnostic.GetMessage().ShouldContain("Convert.ChangeType");
         diagnostic.GetMessage().ShouldContain("CultureInfo.InvariantCulture");
     }
@@ -116,7 +117,7 @@ public class UnsupportedTaskItemTypeAnalyzerTests
     // ═══════════════════════════════════════════════════════════════════════
 
     [Fact]
-    public async Task ConvertChangeTypeArray_ProducesError()
+    public async Task ConvertChangeTypeArray_ProducesWarning()
     {
         var diags = await GetUnsupportedTaskItemTypeDiagnosticsAsync("""
             using Microsoft.Build.Framework;
@@ -129,7 +130,7 @@ public class UnsupportedTaskItemTypeAnalyzerTests
 
         Diagnostic diagnostic = diags.ShouldHaveSingleItem();
         diagnostic.Id.ShouldBe(DiagnosticIds.CultureSensitiveTaskItemType);
-        diagnostic.Severity.ShouldBe(Microsoft.CodeAnalysis.DiagnosticSeverity.Error);
+        diagnostic.Severity.ShouldBe(Microsoft.CodeAnalysis.DiagnosticSeverity.Warning);
     }
 
     [Fact]
@@ -149,7 +150,7 @@ public class UnsupportedTaskItemTypeAnalyzerTests
     }
 
     [Fact]
-    public async Task ConvertChangeTypeOutputProperty_ProducesError()
+    public async Task ConvertChangeTypeOutputProperty_ProducesWarning()
     {
         var diags = await GetUnsupportedTaskItemTypeDiagnosticsAsync("""
             using Microsoft.Build.Framework;
@@ -163,7 +164,7 @@ public class UnsupportedTaskItemTypeAnalyzerTests
 
         Diagnostic diagnostic = diags.ShouldHaveSingleItem();
         diagnostic.Id.ShouldBe(DiagnosticIds.CultureSensitiveTaskItemType);
-        diagnostic.Severity.ShouldBe(Microsoft.CodeAnalysis.DiagnosticSeverity.Error);
+        diagnostic.Severity.ShouldBe(Microsoft.CodeAnalysis.DiagnosticSeverity.Warning);
     }
 
     [Fact]
@@ -201,6 +202,7 @@ public class UnsupportedTaskItemTypeAnalyzerTests
             """);
 
         diags.ShouldContain(d => d.Id == DiagnosticIds.UnsupportedTaskItemType);
+        diags.ShouldHaveSingleItem().Severity.ShouldBe(Microsoft.CodeAnalysis.DiagnosticSeverity.Error);
         diags[0].GetMessage().ShouldContain("Item");
         diags[0].GetMessage().ShouldContain("Guid");
         diags[0].GetMessage().ShouldContain("string, bool, AbsolutePath, FileInfo, DirectoryInfo");
@@ -223,6 +225,42 @@ public class UnsupportedTaskItemTypeAnalyzerTests
         diags.ShouldContain(d => d.Id == DiagnosticIds.UnsupportedTaskItemType);
         diags[0].GetMessage().ShouldContain("Duration");
         diags[0].GetMessage().ShouldContain("TimeSpan");
+    }
+
+    [Fact]
+    public async Task TypedTaskItemDiagnostics_AreIndependentOfMtScope()
+    {
+        var diags = await GetUnsupportedTaskItemTypeDiagnosticsAsync("""
+            using System;
+            using Microsoft.Build.Framework;
+            public class MyTask : Microsoft.Build.Utilities.Task, IMultiThreadableTask
+            {
+                public TaskEnvironment TaskEnvironment { get; set; }
+                public ITaskItem<Guid> Invalid { get; set; } = null!;
+                public ITaskItem<int> CultureSensitive { get; set; } = null!;
+                public override bool Execute() => true;
+            }
+            """);
+
+        diags.Where(d => d.Id == DiagnosticIds.UnsupportedTaskItemType).ShouldHaveSingleItem()
+            .Severity.ShouldBe(Microsoft.CodeAnalysis.DiagnosticSeverity.Error);
+        diags.Where(d => d.Id == DiagnosticIds.CultureSensitiveTaskItemType).ShouldHaveSingleItem()
+            .Severity.ShouldBe(Microsoft.CodeAnalysis.DiagnosticSeverity.Warning);
+    }
+
+    [Fact]
+    public async Task GenericTaskItemTypeParameter_NoDiagnostic()
+    {
+        var diags = await GetUnsupportedTaskItemTypeDiagnosticsAsync("""
+            using Microsoft.Build.Framework;
+            public class GenericTask<T> : Microsoft.Build.Utilities.Task
+            {
+                public ITaskItem<T> Item { get; set; } = null!;
+                public override bool Execute() => true;
+            }
+            """);
+
+        diags.ShouldBeEmpty();
     }
 
     [Fact]

--- a/src/TaskAnalyzer/AnalyzerReleases.Shipped.md
+++ b/src/TaskAnalyzer/AnalyzerReleases.Shipped.md
@@ -1,1 +1,17 @@
-; No shipped releases yet
+## Release 18.11.0
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
+MSBuildTask0001 | MSBuild.TaskAuthoring | Error | APIs that must not be used in any MSBuild task (Environment.Exit, Console.*, etc.)
+MSBuildTask0002 | MSBuild.TaskAuthoring | Warning | APIs that should use TaskEnvironment alternatives
+MSBuildTask0003 | MSBuild.TaskAuthoring | Warning | File APIs that need absolute paths
+MSBuildTask0004 | MSBuild.TaskAuthoring | Warning | APIs that may cause issues in multithreaded task execution
+MSBuildTask0005 | MSBuild.TaskAuthoring | Warning | Transitive unsafe API usage detected in task call chain
+MSBuildTask0006 | MSBuild.TaskAuthoring | Info | Prefer typed path parameter (AbsolutePath/FileInfo/DirectoryInfo) over string (code fix available)
+MSBuildTask0007 | MSBuild.TaskAuthoring | Info | Prefer ITaskItem<T> over manual ItemSpec parsing (code fix available)
+MSBuildTask0008 | MSBuild.TaskAuthoring | Info | Initialize a relative default path in Execute() so TaskEnvironment can root it when the property is retyped (code fix available)
+MSBuildTask0009 | MSBuild.TaskAuthoring | Error | ITaskItem<T> used with a type argument T that MSBuild cannot bind as a task parameter
+MSBuildTask0010 | MSBuild.TaskAuthoring | Warning | ITaskItem<T> used with a type argument T that MSBuild parses through Convert.ChangeType
+MSBuildTask0011 | MSBuild.TaskAuthoring | Info | Prefer constructor injection for TaskEnvironment

--- a/src/TaskAnalyzer/AnalyzerReleases.Unshipped.md
+++ b/src/TaskAnalyzer/AnalyzerReleases.Unshipped.md
@@ -1,15 +1,1 @@
-### New Rules
-
-Rule ID | Category | Severity | Notes
---------|----------|----------|-------
-MSBuildTask0001 | MSBuild.TaskAuthoring | Error | APIs that must not be used in any MSBuild task (Environment.Exit, Console.*, etc.)
-MSBuildTask0002 | MSBuild.TaskAuthoring | Warning | APIs that should use TaskEnvironment alternatives
-MSBuildTask0003 | MSBuild.TaskAuthoring | Warning | File APIs that need absolute paths
-MSBuildTask0004 | MSBuild.TaskAuthoring | Warning | APIs that may cause issues in multithreaded task execution
-MSBuildTask0005 | MSBuild.TaskAuthoring | Warning | Transitive unsafe API usage detected in task call chain
-MSBuildTask0006 | MSBuild.TaskAuthoring | Info | Prefer typed path parameter (AbsolutePath/FileInfo/DirectoryInfo) over string (code fix available)
-MSBuildTask0007 | MSBuild.TaskAuthoring | Info | Prefer ITaskItem<T> over manual ItemSpec parsing (code fix available)
-MSBuildTask0008 | MSBuild.TaskAuthoring | Info | Initialize a relative default path in Execute() so TaskEnvironment can root it when the property is retyped (code fix available)
-MSBuildTask0009 | MSBuild.TaskAuthoring | Error | ITaskItem<T> used with a type argument T that MSBuild cannot bind as a task parameter
-MSBuildTask0010 | MSBuild.TaskAuthoring | Warning | ITaskItem<T> used with a type argument T that MSBuild parses through Convert.ChangeType
-MSBuildTask0011 | MSBuild.TaskAuthoring | Info | Prefer constructor injection for TaskEnvironment
+; No unshipped changes

--- a/src/TaskAnalyzer/AnalyzerReleases.Unshipped.md
+++ b/src/TaskAnalyzer/AnalyzerReleases.Unshipped.md
@@ -7,9 +7,9 @@ MSBuildTask0002 | MSBuild.TaskAuthoring | Warning | APIs that should use TaskEnv
 MSBuildTask0003 | MSBuild.TaskAuthoring | Warning | File APIs that need absolute paths
 MSBuildTask0004 | MSBuild.TaskAuthoring | Warning | APIs that may cause issues in multithreaded task execution
 MSBuildTask0005 | MSBuild.TaskAuthoring | Warning | Transitive unsafe API usage detected in task call chain
-MSBuildTask0006 | MSBuild.TaskAuthoring | Warning | Prefer typed path parameter (AbsolutePath/FileInfo/DirectoryInfo) over string (code fix available)
-MSBuildTask0007 | MSBuild.TaskAuthoring | Warning | Prefer ITaskItem<T> over manual ItemSpec parsing (code fix available)
-MSBuildTask0008 | MSBuild.TaskAuthoring | Warning | Initialize a relative default path in Execute() so TaskEnvironment can root it when the property is retyped (code fix available)
-MSBuildTask0009 | MSBuild.TaskAuthoring | Warning | ITaskItem<T> used with a type argument T that MSBuild cannot bind as a task parameter
-MSBuildTask0010 | MSBuild.TaskAuthoring | Error | ITaskItem<T> used with a type argument T that MSBuild parses through Convert.ChangeType
+MSBuildTask0006 | MSBuild.TaskAuthoring | Info | Prefer typed path parameter (AbsolutePath/FileInfo/DirectoryInfo) over string (code fix available)
+MSBuildTask0007 | MSBuild.TaskAuthoring | Info | Prefer ITaskItem<T> over manual ItemSpec parsing (code fix available)
+MSBuildTask0008 | MSBuild.TaskAuthoring | Info | Initialize a relative default path in Execute() so TaskEnvironment can root it when the property is retyped (code fix available)
+MSBuildTask0009 | MSBuild.TaskAuthoring | Error | ITaskItem<T> used with a type argument T that MSBuild cannot bind as a task parameter
+MSBuildTask0010 | MSBuild.TaskAuthoring | Warning | ITaskItem<T> used with a type argument T that MSBuild parses through Convert.ChangeType
 MSBuildTask0011 | MSBuild.TaskAuthoring | Info | Prefer constructor injection for TaskEnvironment

--- a/src/TaskAnalyzer/DiagnosticDescriptors.cs
+++ b/src/TaskAnalyzer/DiagnosticDescriptors.cs
@@ -90,7 +90,7 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
             title: "ITaskItem<T> used with unsupported type argument",
             messageFormat: "Task property '{0}' uses ITaskItem<{1}> but MSBuild cannot automatically parse '{1}' from item metadata. Use one of the directly parsed types: {2}.",
             category: "MSBuild.TaskAuthoring",
-            defaultSeverity: DiagnosticSeverity.Warning,
+            defaultSeverity: DiagnosticSeverity.Error,
             isEnabledByDefault: true,
             description: "MSBuild can only bind ITaskItem<T> properties when T is a supported type. Using an unsupported type will cause a runtime failure when MSBuild tries to bind the parameter.");
 
@@ -99,7 +99,7 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
             title: "ITaskItem<T> type argument relies on culture-sensitive conversion",
             messageFormat: "Task property '{0}' uses ITaskItem<{1}>, which MSBuild parses through Convert.ChangeType using CultureInfo.InvariantCulture. Use ITaskItem<string> and parse explicitly with a chosen culture.",
             category: "MSBuild.TaskAuthoring",
-            defaultSeverity: DiagnosticSeverity.Error,
+            defaultSeverity: DiagnosticSeverity.Warning,
             isEnabledByDefault: true,
             description: "ITaskItem<T> type arguments parsed through Convert.ChangeType use CultureInfo.InvariantCulture. Bind the item as a string and parse it explicitly with the intended culture.");
 

--- a/src/TaskAnalyzer/MultiThreadableTaskAnalyzer.cs
+++ b/src/TaskAnalyzer/MultiThreadableTaskAnalyzer.cs
@@ -16,10 +16,9 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
     /// <summary>
     /// Roslyn analyzer that detects unsafe API usage in MSBuild task implementations.
     /// 
-    /// Scope (controlled by .editorconfig option "msbuild_task_analyzer.scope"):
-    /// - "all" (default): All rules fire on ALL ITask implementations
-    /// - "multithreadable_only": MSBuildTask0002, 0003 fire only on IMultiThreadableTask or [MSBuildMultiThreadableTask]
-    ///   (MSBuildTask0001 and MSBuildTask0004 always fire on all tasks regardless)
+    /// Scope (controlled by analyzer option "msbuild_task_analyzer.scope"):
+    /// - "multithreadable_only" (default): MSBuildTask0001-0004 report only for MT tasks and explicitly analyzed helpers
+    /// - "all": Enables MSBuildTask0001-0004 for all ITask implementations during migration
     /// 
     /// Per review feedback from @rainersigwald:
     /// - Console.* promoted to MSBuildTask0001 (always wrong in tasks)
@@ -29,8 +28,8 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
     public sealed class MultiThreadableTaskAnalyzer : DiagnosticAnalyzer
     {
         /// <summary>
-        /// The .editorconfig key controlling analysis scope.
-        /// Values: "all" (default) | "multithreadable_only"
+        /// The analyzer configuration key controlling analysis scope.
+        /// Values: "multithreadable_only" (default) | "all"
         /// </summary>
         internal const string ScopeOptionKey = SharedAnalyzerHelpers.ScopeOptionKey;
         internal const string ScopeAll = SharedAnalyzerHelpers.ScopeAll;
@@ -55,7 +54,7 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                 return;
             }
 
-            // Read scope option from .editorconfig: "all" (default) or "multithreadable_only"
+            // Read scope option: "multithreadable_only" (default) or "all"
             bool analyzeAllTasks = SharedAnalyzerHelpers.ReadAnalyzeAllTasksOption(compilationContext.Options.AnalyzerConfigOptionsProvider);
 
             var iMultiThreadableTaskType = compilationContext.Compilation.GetTypeByMetadataName(WellKnownTypeNames.IMultiThreadableTaskFullName);
@@ -97,12 +96,12 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                 // Helper classes with the attribute or tasks with [MSBuildMultiThreadableTask] are treated as IMultiThreadableTask
                 bool analyzeAsMultiThreadable = isMultiThreadableTask || hasAnalyzedAttribute || hasMultiThreadableAttribute;
 
-                // When scope is "multithreadable_only", only analyze MSBuildTask0002/0003 for multithreadable tasks
-                bool reportEnvironmentRules = analyzeAllTasks || analyzeAsMultiThreadable;
+                // The default scope reports MSBuildTask0001-0004 only for MT tasks and explicitly analyzed helpers.
+                bool reportScopedRules = analyzeAllTasks || analyzeAsMultiThreadable;
 
                 // Register operation-level analysis within this type
                 symbolStartContext.RegisterOperationAction(
-                    ctx => AnalyzeOperation(ctx, bannedApiLookup, filePathTypes, reportEnvironmentRules,
+                    ctx => AnalyzeOperation(ctx, bannedApiLookup, filePathTypes, reportScopedRules,
                         taskEnvironmentType, absolutePathType, iTaskItemType, consoleType),
                     OperationKind.Invocation,
                     OperationKind.ObjectCreation,
@@ -117,7 +116,7 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
             OperationAnalysisContext context,
             Dictionary<ISymbol, BannedApiEntry> bannedApiLookup,
             ImmutableHashSet<INamedTypeSymbol> filePathTypes,
-            bool reportEnvironmentRules,
+            bool reportScopedRules,
             INamedTypeSymbol? taskEnvironmentType,
             INamedTypeSymbol? absolutePathType,
             INamedTypeSymbol? iTaskItemType,
@@ -165,8 +164,7 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
             // Check banned API lookup (handles MSBuildTask0001, 0002, 0004)
             if (bannedApiLookup.TryGetValue(referencedSymbol, out var entry))
             {
-                // MSBuildTask0002 (TaskEnvironment) is gated by scope setting
-                if (entry.Category == BannedApiDefinitions.ApiCategory.TaskEnvironment && !reportEnvironmentRules)
+                if (!reportScopedRules)
                 {
                     return;
                 }
@@ -180,7 +178,7 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
 
             // Type-level Console ban: ANY member of System.Console is flagged.
             // This catches all Console methods/properties including ones added in newer .NET versions.
-            if (consoleType is not null)
+            if (reportScopedRules && consoleType is not null)
             {
                 var containingType = referencedSymbol.ContainingType;
                 if (containingType is not null && SymbolEqualityComparer.Default.Equals(containingType, consoleType))
@@ -198,7 +196,7 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
             }
 
             // Check file path APIs (MSBuildTask0003) - gated by scope setting
-            if (reportEnvironmentRules && !arguments.IsDefaultOrEmpty)
+            if (reportScopedRules && !arguments.IsDefaultOrEmpty)
             {
                 var method = referencedSymbol as IMethodSymbol;
                 if (method is not null)

--- a/src/TaskAnalyzer/README.md
+++ b/src/TaskAnalyzer/README.md
@@ -4,6 +4,18 @@ A Roslyn analyzer that detects unsafe API usage in MSBuild task implementations.
 
 The package also includes a Roslyn diagnostic suppressor for nullable warning `CS8618` on task properties marked with `Microsoft.Build.Framework.RequiredAttribute`, since MSBuild guarantees those inputs are initialized before task execution.
 
+## Installation
+
+TaskAnalyzer ships with the `Microsoft.Build.Framework` NuGet package. A C# task project that references `Microsoft.Build.Framework` automatically receives the analyzer; it does not need a separate analyzer reference.
+
+```xml
+<ItemGroup>
+  <PackageReference Include="Microsoft.Build.Framework" Version="18.11.0" />
+</ItemGroup>
+```
+
+NuGet installs the analyzer from `analyzers/dotnet/cs/Microsoft.Build.TaskAuthoring.Analyzer.dll`, and the compiler runs it during normal `dotnet build` and MSBuild builds.
+
 ## Background
 
 MSBuild is introducing multithreaded task execution via `IMultiThreadableTask`. Tasks opting into this mode share a process and can no longer safely use process-global state like environment variables, the current directory, or `Console` output. The `TaskEnvironment` abstraction provides per-task isolated access to these resources.

--- a/src/TaskAnalyzer/README.md
+++ b/src/TaskAnalyzer/README.md
@@ -14,16 +14,16 @@ This analyzer catches unsafe API usage at compile time and offers code fixes to 
 
 | ID | Severity | Scope | Title |
 |---|---|---|---|
-| **MSBuildTask0001** | Error | All `ITask` implementations | API is never safe in MSBuild tasks |
-| **MSBuildTask0002** | Warning | All `ITask` implementations | API requires `TaskEnvironment` alternative |
-| **MSBuildTask0003** | Warning | All `ITask` implementations | File system API requires absolute path |
-| **MSBuildTask0004** | Warning | All `ITask` implementations | API may cause issues in multithreaded tasks |
-| **MSBuildTask0005** | Warning | All `ITask` implementations | Transitive unsafe API usage in task call chain |
-| **MSBuildTask0006** | Warning | Tasks with `[MSBuildMultiThreadableTask]` applied directly | Prefer typed path parameter over string |
-| **MSBuildTask0007** | Warning | Tasks with `[MSBuildMultiThreadableTask]` applied directly | Prefer `ITaskItem<T>` over manual ItemSpec parsing |
-| **MSBuildTask0008** | Warning | Tasks with `[MSBuildMultiThreadableTask]` applied directly | Initialize a relative-default path property in `Execute()` |
-| **MSBuildTask0009** | Warning | All `ITask` implementations | `ITaskItem<T>` used with unsupported type argument |
-| **MSBuildTask0010** | Error | All `ITask` implementations | `ITaskItem<T>` relies on culture-sensitive conversion |
+| **MSBuildTask0001** | Error | MT tasks by default; all tasks in migration mode | API is never safe in MSBuild tasks |
+| **MSBuildTask0002** | Warning | MT tasks by default; all tasks in migration mode | API requires `TaskEnvironment` alternative |
+| **MSBuildTask0003** | Warning | MT tasks by default; all tasks in migration mode | File system API requires absolute path |
+| **MSBuildTask0004** | Warning | MT tasks by default; all tasks in migration mode | API may cause issues in multithreaded tasks |
+| **MSBuildTask0005** | Warning | MT tasks by default; all tasks in migration mode | Transitive unsafe API usage in task call chain |
+| **MSBuildTask0006** | Info | Tasks with `[MSBuildMultiThreadableTask]` applied directly | Prefer typed path parameter over string |
+| **MSBuildTask0007** | Info | Tasks with `[MSBuildMultiThreadableTask]` applied directly | Prefer `ITaskItem<T>` over manual ItemSpec parsing |
+| **MSBuildTask0008** | Info | Tasks with `[MSBuildMultiThreadableTask]` applied directly | Initialize a relative-default path property in `Execute()` |
+| **MSBuildTask0009** | Error | All `ITask` implementations with typed task properties | `ITaskItem<T>` used with unsupported type argument |
+| **MSBuildTask0010** | Warning | All `ITask` implementations with typed task properties | `ITaskItem<T>` relies on culture-sensitive conversion |
 | **MSBuildTask0011** | Info | Concrete `IMultiThreadableTask` implementations | Prefer constructor injection for `TaskEnvironment` |
 
 ### MSBuildTask0001 — Critical: No Safe Alternative
@@ -230,19 +230,19 @@ For a reference-typed target (`FileInfo`/`DirectoryInfo`) the guard is a null-co
 
 ### MSBuildTask0009 — Unsupported `ITaskItem<T>` Type Argument
 
-When a task property is typed as `ITaskItem<T>` or `ITaskItem<T>[]` but `T` is not supported by MSBuild's task parameter binder, a **Warning** is emitted. Using an unsupported type will cause a runtime failure when MSBuild tries to bind the parameter.
+When a task property is typed as `ITaskItem<T>` or `ITaskItem<T>[]` but `T` is not supported by MSBuild's task parameter binder, an **Error** is emitted. Using an unsupported type will cause a runtime failure when MSBuild tries to bind the parameter.
 
 **Directly parsed type arguments:** `string`, `bool`, `AbsolutePath`, `FileInfo`, `DirectoryInfo`.
 
 The binder also accepts `char`, numeric primitives, `decimal`, and `DateTime`, but MSBuildTask0010 rejects those types because they rely on `Convert.ChangeType`.
 
 ```csharp
-// ⚠️ MSBuildTask0009: Task property 'Id' uses ITaskItem<Guid> but 'Guid' is not supported
+// ❌ MSBuildTask0009: Task property 'Id' uses ITaskItem<Guid> but 'Guid' is not supported
 public class MyTask : Task
 {
-    public ITaskItem<System.Guid> Id { get; set; }       // warning
-    public ITaskItem<System.TimeSpan>[] Durations { get; set; }  // warning
-    public ITaskItem<int> Count { get; set; }             // MSBuildTask0010 error
+    public ITaskItem<System.Guid> Id { get; set; }       // error
+    public ITaskItem<System.TimeSpan>[] Durations { get; set; }  // error
+    public ITaskItem<int> Count { get; set; }             // MSBuildTask0010 warning
 }
 ```
 
@@ -252,13 +252,13 @@ No code fix is offered for MSBuildTask0009 — the resolution depends on the int
 
 ### MSBuildTask0010 — Culture-Sensitive `ITaskItem<T>` Conversion
 
-MSBuild binds `ITaskItem<T>` for `char`, numeric primitives, `decimal`, and `DateTime` through `Convert.ChangeType` using `CultureInfo.InvariantCulture`. Because this implicit conversion may not match the task's intended culture, the analyzer reports an **Error** whenever one of these types is used.
+MSBuild binds `ITaskItem<T>` for `char`, numeric primitives, `decimal`, and `DateTime` through `Convert.ChangeType` using `CultureInfo.InvariantCulture`. Because this implicit conversion may not match the task's intended culture, the analyzer reports a **Warning** whenever one of these types is used.
 
 ```csharp
 public class MyTask : Task
 {
-    public ITaskItem<int> Count { get; set; }       // error
-    public ITaskItem<DateTime>[] Dates { get; set; } // error
+    public ITaskItem<int> Count { get; set; }       // warning
+    public ITaskItem<DateTime>[] Dates { get; set; } // warning
 }
 ```
 
@@ -289,15 +289,24 @@ The engine prefers this constructor when it is present. A public parameterless c
 
 ## Analysis Scope
 
-The analyzer determines what to check based on the type declaration:
+The default `multithreadable_only` scope prevents MT-specific warnings from affecting regular tasks. It recognizes `IMultiThreadableTask`, `[MSBuildMultiThreadableTask]`, and `[MSBuildMultiThreadableTaskAnalyzed]` as MT opt-ins.
 
 | Type | Rules Applied |
 |---|---|
-| Any class implementing `ITask` | MSBuildTask0001–MSBuildTask0005, MSBuildTask0009–MSBuildTask0010 |
+| Regular class implementing `ITask` | MSBuildTask0009–MSBuildTask0010 |
 | Class with `[MSBuildMultiThreadableTask]` attribute applied directly | MSBuildTask0006–MSBuildTask0008 (in addition to MSBuildTask0001–0005) |
 | Concrete class implementing `IMultiThreadableTask` without the attribute | MSBuildTask0001–MSBuildTask0005 and MSBuildTask0009–MSBuildTask0011 |
-| Helper class with `[MSBuildMultiThreadableTaskAnalyzed]` attribute | MSBuildTask0001–MSBuildTask0005 |
+| Helper class with `[MSBuildMultiThreadableTaskAnalyzed]` attribute | MSBuildTask0001–MSBuildTask0004 |
 | Regular class (no task interface or attribute) | Not analyzed |
+
+Create a `.globalconfig` file to analyze regular tasks for MSBuildTask0001–MSBuildTask0005 before MT migration:
+
+```ini
+is_global = true
+msbuild_task_analyzer.scope = all
+```
+
+Missing and unrecognized values use the safe `multithreadable_only` default.
 
 MSBuildTask0006–MSBuildTask0008 apply only when the `[MSBuildMultiThreadableTask]` attribute is applied **directly** to the task class. The attribute is `Inherited = false`, so a task that merely derives from a base class implementing `IMultiThreadableTask` (or carrying the attribute) has not itself opted into multithreaded support and is not subject to these three rules. Input properties are collected from the task class **and its base classes**, so an `ITaskItem`/`string` input declared on a shared base task is still analyzed.
 
@@ -307,10 +316,9 @@ The `[MSBuildMultiThreadableTaskAnalyzed]` attribute allows opting helper classe
 
 ### Severity Levels
 
-- **MSBuildTask0001** is always **Error** — these APIs are never safe in any MSBuild task.
-- **MSBuildTask0010** is always **Error** — task item conversions must not rely on `Convert.ChangeType`.
-- **MSBuildTask0002–MSBuildTask0009** report as **Warning**, with MSBuildTask0006–MSBuildTask0008 limited to tasks directly marked with `[MSBuildMultiThreadableTask]`.
-- **MSBuildTask0011** reports as **Info** — it is a modernization suggestion rather than a correctness issue.
+- **MSBuildTask0001 and MSBuildTask0009** report as **Error** when their scope applies.
+- **MSBuildTask0002–MSBuildTask0005 and MSBuildTask0010** report as **Warning** when their scope applies.
+- **MSBuildTask0006–MSBuildTask0008 and MSBuildTask0011** report as **Info** — these are modernization suggestions, not correctness issues.
 
 ## Code Fixes
 

--- a/src/TaskAnalyzer/SharedAnalyzerHelpers.cs
+++ b/src/TaskAnalyzer/SharedAnalyzerHelpers.cs
@@ -17,8 +17,8 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
     internal static class SharedAnalyzerHelpers
     {
         /// <summary>
-        /// The .editorconfig key controlling analysis scope.
-        /// Values: "all" (default) | "multithreadable_only"
+        /// The analyzer configuration key controlling analysis scope.
+        /// Values: "multithreadable_only" (default) | "all"
         /// </summary>
         internal const string ScopeOptionKey = "msbuild_task_analyzer.scope";
         internal const string ScopeAll = "all";
@@ -26,17 +26,17 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
 
         /// <summary>
         /// Reads the scope option from the analyzer config options provider.
-        /// Returns true if all tasks should be analyzed; false if only multithreadable tasks.
+        /// Returns true only when all-task migration analysis is explicitly enabled.
         /// </summary>
         internal static bool ReadAnalyzeAllTasksOption(AnalyzerConfigOptionsProvider optionsProvider)
         {
             if (optionsProvider.GlobalOptions.TryGetValue($"build_property.{ScopeOptionKey}", out var scopeValue) ||
                 optionsProvider.GlobalOptions.TryGetValue(ScopeOptionKey, out scopeValue))
             {
-                return !string.Equals(scopeValue, ScopeMultiThreadableOnly, StringComparison.OrdinalIgnoreCase);
+                return string.Equals(scopeValue, ScopeAll, StringComparison.OrdinalIgnoreCase);
             }
 
-            return true; // default: analyze all tasks
+            return false;
         }
         /// <summary>
         /// Represents a resolved banned API entry for O(1) lookup during analysis.

--- a/src/TaskAnalyzer/TaskAnalyzer.csproj
+++ b/src/TaskAnalyzer/TaskAnalyzer.csproj
@@ -8,8 +8,7 @@
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
     <IsPackable>true</IsPackable>
     <IncludeBuildOutput>false</IncludeBuildOutput>
-    <!-- Don't ship yet, just make it available to partner repositories. -->
-    <IsShipping>false</IsShipping>
+    <IsShipping>true</IsShipping>
     <IsTestProject>false</IsTestProject>
     <!-- Suppress RS2001: our analyzer rules use custom severities -->
     <NoWarn>$(NoWarn);NU5128;RS1038;RS2001</NoWarn>

--- a/src/TaskAnalyzer/TransitiveCallChainAnalyzer.cs
+++ b/src/TaskAnalyzer/TransitiveCallChainAnalyzer.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                 return;
             }
 
-            // Read scope option from .editorconfig
+            // Read scope option
             bool analyzeAllTasks = SharedAnalyzerHelpers.ReadAnalyzeAllTasksOption(compilationContext.Options.AnalyzerConfigOptionsProvider);
 
             var iMultiThreadableTaskType = compilationContext.Compilation.GetTypeByMetadataName(WellKnownTypeNames.IMultiThreadableTaskFullName);

--- a/src/TaskAnalyzer/UnsupportedTaskItemTypeAnalyzer.cs
+++ b/src/TaskAnalyzer/UnsupportedTaskItemTypeAnalyzer.cs
@@ -95,6 +95,13 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
 
                     ITypeSymbol typeArg = namedPropertyType.TypeArguments[0];
 
+                    // A generic task can be constructed with a supported type. Its open type
+                    // parameter does not provide enough information for a binding diagnostic.
+                    if (typeArg.TypeKind == TypeKind.TypeParameter)
+                    {
+                        continue;
+                    }
+
                     if (SupportedTaskItemTypes.IsConvertChangeTypeTaskItemType(typeArg.SpecialType))
                     {
                         symbolContext.ReportDiagnostic(Diagnostic.Create(


### PR DESCRIPTION
Part of #14078

### Context

TaskAnalyzer must be delivered automatically to task authors before it can ship. This change packages the analyzer with `Microsoft.Build.Framework`, while retaining the standalone analyzer package for existing partner-repository consumption.

Depends on #14811, which establishes the safe default scope and diagnostic severities exercised by the package-consumption tests. Once #14811 merges, this PR will contain only the packaging commit.

### Changes Made

- Marked `Microsoft.Build.TaskAuthoring.Analyzer` as a shipping package.
- Added the analyzer output to `Microsoft.Build.Framework` under `analyzers/dotnet/cs`.
- Kept Roslyn implementation packages private and out of the Framework package dependencies.
- Added end-to-end package tests that consume only the locally produced `Microsoft.Build.Framework` package.
- Covered default MT-only analysis, `scope=all` migration mode, diagnostic suppression, warnings-as-errors, and analyzer opt-out.
- Exercised package consumption through both `dotnet build` and bootstrapped MSBuild.
- Moved the initial diagnostics into shipped analyzer release metadata and documented automatic installation through `Microsoft.Build.Framework`.

### Testing

- TaskAnalyzer unit tests: 262 passed, 0 failed, 0 skipped.
- Package end-to-end tests on `net11.0` and `net472`: 4 passed, 0 failed, 0 skipped.
- `Microsoft.Build.Framework` package inspection: exactly one TaskAnalyzer DLL and no bundled or declared Roslyn dependencies.
- Standalone `Microsoft.Build.TaskAuthoring.Analyzer` package generated successfully.
- `.\build.cmd -v quiet`: passed with 0 warnings and 0 errors.

### Notes

No packages were published. All package validation used local artifacts.