### PR TITLE
Harden typed task parameter infrastructure

### DIFF
--- a/src/Build.UnitTests/BuildEventArgsSerialization_Tests.cs
+++ b/src/Build.UnitTests/BuildEventArgsSerialization_Tests.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Runtime.Serialization;
 using System.Text;
 using FluentAssertions;
 using Microsoft.Build.BackEnd;
@@ -873,6 +874,98 @@ namespace Microsoft.Build.UnitTests
                 e => e.LineNumber.ToString(),
                 e => e.ColumnNumber.ToString(),
                 e => TranslationHelpers.GetItemsString(e.Items));
+        }
+
+        [Fact]
+        public void AbsolutePathTaskParameterTextUsesOriginalValue()
+        {
+            var basePath = new AbsolutePath(Path.GetFullPath("."));
+            var path = new AbsolutePath("input.txt", basePath);
+
+            ItemGroupLoggingHelper.GetStringFromParameterValue(path).ShouldBe("input.txt");
+        }
+
+        [Fact]
+        public void TaskParameterEventForwardingPreservesAbsolutePathOriginalValue()
+        {
+            TaskParameterEventArgs args = CreateAbsolutePathTaskParameterEventArgs();
+            var memoryStream = new MemoryStream();
+            using (var binaryWriter = new BinaryWriter(memoryStream, Encoding.UTF8, leaveOpen: true))
+            {
+                args.WriteToStream(binaryWriter);
+            }
+
+            memoryStream.Position = 0;
+#pragma warning disable SYSLIB0050 // Required to exercise the legacy event forwarding deserializer.
+            var forwardedArgs = (TaskParameterEventArgs)FormatterServices.GetUninitializedObject(typeof(TaskParameterEventArgs));
+#pragma warning restore SYSLIB0050
+            using (var binaryReader = new BinaryReader(memoryStream, Encoding.UTF8, leaveOpen: true))
+            {
+                forwardedArgs.CreateFromStream(binaryReader, version: 0);
+            }
+
+            forwardedArgs.Items.Count.ShouldBe(1);
+            ((ITaskItem)forwardedArgs.Items[0]).ItemSpec.ShouldBe("input.txt");
+        }
+
+        [Fact]
+        public void BinaryLogSerializationPreservesAbsolutePathOriginalValue()
+        {
+            TaskParameterEventArgs args = CreateAbsolutePathTaskParameterEventArgs();
+            var memoryStream = new MemoryStream();
+            using (var binaryWriter = new BinaryWriter(memoryStream, Encoding.UTF8, leaveOpen: true))
+            {
+                new BuildEventArgsWriter(binaryWriter).Write(args);
+            }
+
+            memoryStream.Position = 0;
+            using var reader = new BinaryReader(memoryStream, Encoding.UTF8, leaveOpen: true);
+            using var eventArgsReader = new BuildEventArgsReader(reader, BinaryLogger.FileFormatVersion);
+            var replayedArgs = (TaskParameterEventArgs)eventArgsReader.Read();
+
+            replayedArgs.Items.Count.ShouldBe(1);
+            ((ITaskItem)replayedArgs.Items[0]).ItemSpec.ShouldBe("input.txt");
+            replayedArgs.Message.ShouldContain("input.txt");
+            replayedArgs.Message.ShouldNotContain(Path.GetFullPath("input.txt"));
+        }
+
+        [Fact]
+        public void BinaryLogSerializationWritesEmptyItemSpecForDefaultAbsolutePath()
+        {
+            var args = new TaskParameterEventArgs(
+                TaskParameterMessageKind.TaskInput,
+                "File",
+                propertyName: null,
+                "File",
+                new object[] { default(AbsolutePath) },
+                logItemMetadata: false,
+                DateTime.MinValue);
+            var memoryStream = new MemoryStream();
+            using (var binaryWriter = new BinaryWriter(memoryStream, Encoding.UTF8, leaveOpen: true))
+            {
+                new BuildEventArgsWriter(binaryWriter).Write(args);
+            }
+
+            memoryStream.Position = 0;
+            using var reader = new BinaryReader(memoryStream, Encoding.UTF8, leaveOpen: true);
+            using var eventArgsReader = new BuildEventArgsReader(reader, BinaryLogger.FileFormatVersion);
+            var replayedArgs = (TaskParameterEventArgs)eventArgsReader.Read();
+
+            replayedArgs.Items.Count.ShouldBe(1);
+            ((ITaskItem)replayedArgs.Items[0]).ItemSpec.ShouldBe(string.Empty);
+        }
+
+        private static TaskParameterEventArgs CreateAbsolutePathTaskParameterEventArgs()
+        {
+            var basePath = new AbsolutePath(Path.GetFullPath("."));
+            return new TaskParameterEventArgs(
+                TaskParameterMessageKind.TaskInput,
+                "File",
+                propertyName: null,
+                "File",
+                new object[] { new AbsolutePath("input.txt", basePath) },
+                logItemMetadata: false,
+                DateTime.MinValue);
         }
 
         [Fact]

--- a/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupLoggingHelper.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupLoggingHelper.cs
@@ -243,6 +243,14 @@ namespace Microsoft.Build.BackEnd
                     keyValuePairList.Clear();
                 }
             }
+            else if (parameterValue is AbsolutePath absolutePath)
+            {
+                sb.Append(absolutePath.OriginalValue);
+            }
+            else if (TaskItemTypeDetector.IsSupportedPathType(parameterValue.GetType()))
+            {
+                sb.Append(ValueTypeParser.ToString(parameterValue));
+            }
             else if (parameterValue.GetType().IsValueType)
             {
                 sb.Append((string)Convert.ChangeType(parameterValue, typeof(string), CultureInfo.CurrentCulture));

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
@@ -987,6 +987,11 @@ namespace Microsoft.Build.Logging
                         Write((byte)0);
                     }
                 }
+                else if (item is AbsolutePath absolutePath)
+                {
+                    WriteDeduplicatedString(absolutePath.OriginalValue ?? string.Empty);
+                    Write(0);
+                }
                 else
                 {
                     WriteDeduplicatedString(item?.ToString() ?? ""); // itemspec

--- a/src/Framework/TaskItem_T.cs
+++ b/src/Framework/TaskItem_T.cs
@@ -70,8 +70,15 @@ namespace Microsoft.Build.Framework
         /// <summary>Returns the FullPath metadata value if non-empty, otherwise falls back to itemSpec.</summary>
         private static string GetFullPathOrItemSpec(ITaskItem item, string itemSpec)
         {
-            string fullPath = item.GetMetadata("FullPath");
-            return !string.IsNullOrEmpty(fullPath) ? fullPath : itemSpec;
+            try
+            {
+                string fullPath = item.GetMetadata("FullPath");
+                return !string.IsNullOrEmpty(fullPath) ? fullPath : itemSpec;
+            }
+            catch (InvalidOperationException ex)
+            {
+                throw new ArgumentException($"Cannot create TaskItem<{typeof(T).Name}> from the provided item.", nameof(item), ex);
+            }
         }
 
         /// <summary>

--- a/src/Framework/TaskParameterEventArgs.cs
+++ b/src/Framework/TaskParameterEventArgs.cs
@@ -220,6 +220,11 @@ namespace Microsoft.Build.Framework
                     writer.Write7BitEncodedInt(0);
                 }
             }
+            else if (item is AbsolutePath absolutePath)
+            {
+                writer.Write(absolutePath.OriginalValue ?? string.Empty);
+                writer.Write7BitEncodedInt(0);
+            }
             else // string or ValueType
             {
                 writer.Write(item?.ToString() ?? "");

--- a/src/Utilities.UnitTests/TaskItem_Tests.cs
+++ b/src/Utilities.UnitTests/TaskItem_Tests.cs
@@ -487,6 +487,14 @@ namespace Microsoft.Build.UnitTests
         }
 
         [Fact]
+        public void FromITaskItem_InvalidPath_ThrowsArgumentException()
+        {
+            var backingItem = new TaskItem("bad\0path");
+
+            Should.Throw<ArgumentException>(() => new TaskItem<AbsolutePath>(backingItem));
+        }
+
+        [Fact]
         public void FromITaskItem_NonPathType_UsesItemSpec()
         {
             var backingItem = new TaskItem("42");


### PR DESCRIPTION


### Context

These issues were found while migrating real in-box tasks to typed parameters. Direct task tests passed, but real MSBuild binding, malformed inputs, logging, event forwarding, and binlog replay exposed infrastructure gaps.

### Changes Made

- **Malformed typed-item paths could escape as unhandled exceptions.**
  `TaskItem<T>` derives path values from `FullPath`; malformed values could throw `InvalidOperationException`, bypassing normal parameter-binding error handling. The constructor now converts this to `ArgumentException`, allowing MSBuild to report MSB4030.

  Real-world reproduction:

  ```xml
  <GetFileHash Files="bad%00path" />
  ```

  Before the fix, binding `ITaskItem<AbsolutePath>[]` could terminate the node with an unhandled exception while evaluating `FullPath`. After the fix, the project receives:

  ```text
  MSB4030: "bad path" is an invalid value for the "Files" parameter of the "GetFileHash" task.
  ```

- **Logging of `AbsolutePath` task parameters could crash or inflate paths.**
  `ItemGroupLoggingHelper` treated `AbsolutePath` as an arbitrary value type and called `Convert.ChangeType`, which throws because `AbsolutePath` is not `IConvertible`. Now we log absolute path correctly, using originally passed path in logs `AbsolutePath.OriginalValue`.

  Real-world reproduction:

  ```xml
  <VerifyFileHash File="input.txt"
                  Hash="3306EA2566F10A3C4071D8BADFB92A83D4F1D428555B4936D21C10F4F775B351" />
  ```

  With task-input logging enabled, MSBuild attempted to format the bound `AbsolutePath` and failed with:

  ```text
  InvalidCastException: Object must implement IConvertible.
  MSB4166: Child node exited prematurely.
  ```

  The fixed output remains relative:

  ```text
  Task Parameter:File=input.txt
  ```

- **Forwarded task-parameter events lost relative path values.**
  `TaskParameterEventArgs` serialized `AbsolutePath` through `ToString()`, replacing a value such as `input.txt` with its absolute form. Forwarding now serializes `OriginalValue`.

  Real-world example:

  ```text
  Originating node: Task Parameter:File=input.txt
  Receiving node:   Task Parameter:File=C:\repo\input.txt
  ```

  A distributed logger could therefore observe a different value depending on which node produced the event. Forwarded events now retain `input.txt`.

- **Binlog task-parameter serialization lost relative path values.**
  `BuildEventArgsWriter` had the same `ToString()` behavior, so replayed binlogs differed from live output. Binlog serialization now preserves `OriginalValue`.

  Real-world example:

  ```text
  Live build:      Task Parameter:File=input.txt
  Replayed binlog: Task Parameter:File=C:\repo\input.txt
  ```

  The live and replayed event streams now contain the same relative value.

### Testing

Each fix has a dedicated regression test:

- `FromITaskItem_InvalidPath_ThrowsArgumentException`
- `AbsolutePathTaskParameterTextUsesOriginalValue`
- `TaskParameterEventForwardingPreservesAbsolutePathOriginalValue`
- `BinaryLogSerializationPreservesAbsolutePathOriginalValue`
- `BinaryLogSerializationWritesEmptyItemSpecForDefaultAbsolutePath`

All dedicated tests pass on net11.0 and net472. The full Debug build also succeeds.

### Notes

This PR contains only typed-parameter infrastructure fixes. The task migrations and user documentation are in the stacked PR [OvesN/msbuild#6](https://github.com/OvesN/msbuild/pull/6).