### PR TITLE
Document and configure TaskAnalyzer

### DIFF
--- a/documentation/specs/multithreading/thread-safe-tasks.md
+++ b/documentation/specs/multithreading/thread-safe-tasks.md
@@ -4,15 +4,27 @@
 
 MSBuild's current execution model assumes that tasks have exclusive control over the entire process during execution. This allows tasks to freely modify global process state such as environment variables, the current working directory, and other process-level resources. This design works well for MSBuild's approach of executing builds in separate processes for parallelization. With the introduction of multithreaded execution within a single MSBuild process, multiple tasks can now run concurrently. This requires a new task design to ensure that multiple tasks do not access/modify shared process state, and the relative paths are resolved correctly.
 
-To enable this multithreaded execution model, tasks will declare their capability to run in multiple threads within one process. These capabilities are referred to as **thread-safety** capabilities and the corresponding tasks are called **thread-safe tasks**. Thread-safe tasks must avoid using APIs that modify or depend on global process state, as this could cause conflicts when multiple tasks execute concurrently. See [Thread-Safe Tasks API Analysis Reference](thread-safe-tasks-api-analysis.md) for detailed guidelines. Task authors will also get access to a `TaskEnvironment` that provides safe alternatives to global process state APIs. For example, task authors should use `TaskEnvironment.GetAbsolutePath()` instead of `Path.GetFullPath()` to ensure correct path resolution in multithreaded scenarios.
+To enable this multithreaded execution model, tasks will declare their capability to run in multiple threads within one process. These capabilities are referred to as **thread-safety** capabilities and the corresponding tasks are called **thread-safe tasks**. Thread-safe tasks must avoid using APIs that modify or depend on global process state, as this could cause conflicts when multiple tasks execute concurrently. See [Thread-Safe Tasks API Analysis Reference](thread-safe-tasks-api-analysis.md) for detailed guidelines. Task authors also get a `TaskEnvironment` that provides safe alternatives to global process state APIs. Use `TaskEnvironment.GetAbsolutePath()` to root relative paths.
 
 Tasks that are not thread-safe can still participate in multithreaded builds. MSBuild will execute these tasks in separate TaskHost processes to provide process-level isolation.
 
+## TaskAnalyzer
+
+The `Microsoft.Build.Framework` package delivers TaskAnalyzer to C# task projects. TaskAnalyzer checks the MT contract during compilation.
+
+By default, MT-specific diagnostics apply only after a task declares MT support. This default prevents new diagnostics in regular task projects.
+
+Set `MSBuildTaskAnalyzerScope` to `all` to inspect regular tasks before migration. Set `MSBuildTaskAnalyzerEnabled` to `false` to disable TaskAnalyzer.
+
+For installation, configuration, rule actions, and migration examples, see the [TaskAnalyzer guide](../../../src/TaskAnalyzer/README.md).
+
 ## Thread-Safe Capability Indicators
 
-Task authors can declare thread-safe capabilities in two different ways:
-1. **Interface-Based Thread-Safe Capability Declaration** - Provides access to thread-safe APIs through `TaskEnvironment` to be used in the task code.
-2. **Attribute-Based Thread-Safe Capability Declaration** - Allows existing tasks to declare its ability run in multithreaded mode without code changes. It is a **compatibility bridge option**.
+Task authors use two thread-safe indicators:
+1. **`IMultiThreadableTask`** provides access to safe APIs through `TaskEnvironment`.
+2. **`MSBuildMultiThreadableTask`** permits in-process execution in MT mode.
+
+Apply `[MSBuildMultiThreadableTask]` directly to each task that can safely run in-process. Implement `IMultiThreadableTask` when the task also requires `TaskEnvironment`.
 
 Tasks that use `TaskEnvironment` cannot load in older MSBuild versions that do not support multithreading features, requiring authors to drop support for older MSBuild versions. To address this challenge, MSBuild provides a compatibility bridge that allows certain tasks targeting older MSBuild versions to participate in multithreaded builds. While correct absolute path resolution can be and should be achieved without accessing `TaskEnvironment` in tasks that use compatibility bridge options, tasks must avoid relying on environment variables or modifying global process state.
 
@@ -21,25 +33,15 @@ So, task authors who need to support older MSBuild versions will have three choi
 2. **Use compatibility bridge approaches** - Rely on MSBuild's ability to run legacy tasks in multithreaded mode without access to `TaskEnvironment`.
 3. **Accept reduced performance** - Tasks will execute more slowly than their thread-safe versions because they must run in a separate TaskHost process
 
-### Interface-Based Thread-Safe Capability Declaration
+### TaskEnvironment Access
 
-Tasks indicate thread-safety capabilities by implementing the `IMultiThreadableTask` interface.
+Tasks get `TaskEnvironment` by implementing the `IMultiThreadableTask` interface.
 
 ```csharp
 namespace Microsoft.Build.Framework;
 public interface IMultiThreadableTask : ITask
 {
     TaskEnvironment TaskEnvironment { get; set; }
-}
-```
-
-Similar to how MSBuild provides the abstract `Task` class with default implementations for the `ITask` interface, MSBuild will offer a `MultiThreadableTask` abstract class with default implementations for the `IMultiThreadableTask` interface. Task authors will only need to implement the `Execute` method for the `ITask` interface and use `TaskEnvironment` within it to create their thread-safe tasks.
-
-```csharp
-namespace Microsoft.Build.Utilities;
-public abstract class MultiThreadableTask : Task, IMultiThreadableTask
-{
-    public TaskEnvironment TaskEnvironment { get; set; } = TaskEnvironment.Fallback;
 }
 ```
 
@@ -81,20 +83,22 @@ Task authors who want to support older MSBuild versions need to:
 
 **Note:** Consider backporting `IMultiThreadableTask` to MSBuild 17.14 for graceful failure when the interface is used.
 
-### Attribute-Based Thread-Safe Capability Declaration
+### In-Process MT Execution
 
-Task authors can indicate thread-safety capabilities by marking their task classes with a specific attribute. Tasks marked with this attribute can run in multithreaded builds but do not have access to `TaskEnvironment` APIs.
+Apply the attribute directly to each task class that can run in-process. The attribute does not provide access to `TaskEnvironment`.
 
 ```csharp
 namespace Microsoft.Build.Framework;
-[AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
-internal class MSBuildMultiThreadableTaskAttribute : Attribute
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+public class MSBuildMultiThreadableTaskAttribute : Attribute
 {
     public MSBuildMultiThreadableTaskAttribute() { }
 }
 ```
 
-MSBuild detects `MSBuildMultiThreadableTaskAttribute` by its namespace and name only, ignoring the defining assembly, which allows customers to define the attribute in their own assemblies alongside their tasks. Since MSBuild does not ship the attribute, customers using newer MSBuild versions should prefer the Interface-Based Thread-Safe Capability Declaration.
+MSBuild detects `MSBuildMultiThreadableTaskAttribute` by its namespace and name only. This permits a compatibility attribute in task assemblies that target older Framework packages.
+
+New task projects can use the attribute from `Microsoft.Build.Framework`. The attribute is not inherited.
 
 For tasks to be eligible for multithreaded execution using this approach, they must satisfy the following conditions:
 - The task must not modify global process state (environment variables, working directory)
@@ -169,10 +173,18 @@ public bool Execute(...)
     AbsolutePath path = TaskEnvironment.GetAbsolutePath("SomePath");
     string content = File.ReadAllText(path);
     string content2 = File.ReadAllText(path.ToString());
-    string content3 = File.ReadAllText(path.Path);
+    string content3 = File.ReadAllText(path.Value);
     ...
 }
 ```
+
+### Temporary paths
+
+`Path.GetTempPath()` returns a temporary directory. `Path.GetTempFileName()` creates a unique, empty file.
+
+Reading `TMP` does not reproduce either method on all platforms. It also does not create a unique file.
+
+TaskEnvironment does not currently provide equivalent APIs. Pass a temporary directory to an MT task as an `AbsolutePath` input when possible.
 
 ## Appendix: Alternatives
 

--- a/src/Framework/Microsoft.Build.Framework.csproj
+++ b/src/Framework/Microsoft.Build.Framework.csproj
@@ -93,7 +93,16 @@
   <ItemGroup>
     <None Include="buildTransitive\Microsoft.Build.Framework.targets"
           Pack="true"
-          PackagePath="buildTransitive\net10.0\Microsoft.Build.Framework.targets" />
+          PackagePath="buildTransitive\net10.0\Microsoft.Build.Framework.targets;buildTransitive\$(LatestDotNetCoreForMSBuild)\Microsoft.Build.Framework.targets" />
+    <None Include="buildTransitive\Microsoft.Build.Framework.TaskAnalyzer.Root.targets"
+          Pack="true"
+          PackagePath="buildTransitive\Microsoft.Build.Framework.targets" />
+    <None Include="buildTransitive\Microsoft.Build.Framework.TaskAnalyzer.targets"
+          Pack="true"
+          PackagePath="buildTransitive\Microsoft.Build.Framework.TaskAnalyzer.targets" />
+    <None Include="buildTransitive\Microsoft.Build.Framework.TaskAnalyzer.Framework.targets"
+          Pack="true"
+          PackagePath="buildTransitive\$(FullFrameworkTFM)\Microsoft.Build.Framework.targets" />
 
     <PackageReference Include="Microsoft.CodeAnalysis.Contracts" PrivateAssets="all" />
 

--- a/src/Framework/buildTransitive/Microsoft.Build.Framework.TaskAnalyzer.Framework.targets
+++ b/src/Framework/buildTransitive/Microsoft.Build.Framework.TaskAnalyzer.Framework.targets
@@ -1,0 +1,5 @@
+<Project>
+
+  <Import Project="$(MSBuildThisFileDirectory)..\Microsoft.Build.Framework.TaskAnalyzer.targets" />
+
+</Project>

--- a/src/Framework/buildTransitive/Microsoft.Build.Framework.TaskAnalyzer.Root.targets
+++ b/src/Framework/buildTransitive/Microsoft.Build.Framework.TaskAnalyzer.Root.targets
@@ -1,0 +1,5 @@
+<Project>
+
+  <Import Project="$(MSBuildThisFileDirectory)Microsoft.Build.Framework.TaskAnalyzer.targets" />
+
+</Project>

--- a/src/Framework/buildTransitive/Microsoft.Build.Framework.TaskAnalyzer.targets
+++ b/src/Framework/buildTransitive/Microsoft.Build.Framework.TaskAnalyzer.targets
@@ -1,0 +1,8 @@
+<Project>
+
+  <ItemGroup>
+    <CompilerVisibleProperty Include="MSBuildTaskAnalyzerEnabled" />
+    <CompilerVisibleProperty Include="MSBuildTaskAnalyzerScope" />
+  </ItemGroup>
+
+</Project>

--- a/src/Framework/buildTransitive/Microsoft.Build.Framework.targets
+++ b/src/Framework/buildTransitive/Microsoft.Build.Framework.targets
@@ -1,5 +1,7 @@
 <Project>
 
+  <Import Project="$(MSBuildThisFileDirectory)..\Microsoft.Build.Framework.TaskAnalyzer.targets" />
+
   <!--
     MSBuild's trim/AOT feature switches are defined in Microsoft.Build.Framework, but a library's
     RuntimeHostConfigurationOption items do not flow to a consuming app's publish. This buildTransitive

--- a/src/MSBuild.EndToEnd.Tests/Microsoft.Build.EndToEnd.Tests.csproj
+++ b/src/MSBuild.EndToEnd.Tests/Microsoft.Build.EndToEnd.Tests.csproj
@@ -18,6 +18,8 @@
   
   <ItemGroup>
     <ProjectReference Include="..\MSBuild\MSBuild.csproj" />
+    <ProjectReference Include="..\TaskAnalyzer\TaskAnalyzer.csproj"
+                      ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\UnitTests.Shared\Microsoft.Build.UnitTests.Shared.csproj" />
     <ProjectReference Include="..\Xunit.NetCore.Extensions\Xunit.NetCore.Extensions.csproj" />
   </ItemGroup>
@@ -25,6 +27,15 @@
   <ItemGroup>
     <Compile Remove="TestAssets\**\*.cs" />
     <None Include="TestAssets\**" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="..\..\NuGet.Config"
+          Link="TestAssets\TaskAnalyzerConfiguration\NuGet.Config"
+          CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <AssemblyAttribute Include="Microsoft.Build.EndToEndTests.TaskAnalyzerTestPathsAttribute">
+      <_Parameter1>$(ArtifactsBinDir)TaskAnalyzer\$(Configuration)\netstandard2.0\Microsoft.Build.TaskAuthoring.Analyzer.dll</_Parameter1>
+    </AssemblyAttribute>
   </ItemGroup>
 
 </Project>

--- a/src/MSBuild.EndToEnd.Tests/TaskAnalyzerConfiguration_Tests.cs
+++ b/src/MSBuild.EndToEnd.Tests/TaskAnalyzerConfiguration_Tests.cs
@@ -1,0 +1,335 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Xml.Linq;
+using Microsoft.Build.UnitTests;
+using Microsoft.Build.UnitTests.Shared;
+using Shouldly;
+using Xunit;
+
+namespace Microsoft.Build.EndToEndTests;
+
+[AttributeUsage(AttributeTargets.Assembly)]
+internal sealed class TaskAnalyzerTestPathsAttribute(string analyzerPath) : Attribute
+{
+    public string AnalyzerPath { get; } = analyzerPath;
+}
+
+public sealed class TaskAnalyzerConfiguration_Tests : IDisposable
+{
+    private const string FrameworkPackagePrefix = "Microsoft.Build.Framework.";
+    private const string PackageExtension = ".nupkg";
+    private const int ProcessTimeoutMilliseconds = 180_000;
+
+    private readonly TestEnvironment _env;
+    private readonly ITestOutputHelper _output;
+    private readonly string _analyzerPath;
+
+    public TaskAnalyzerConfiguration_Tests(ITestOutputHelper output)
+    {
+        _output = output;
+        _env = TestEnvironment.Create(output);
+        _analyzerPath = Assembly.GetExecutingAssembly()
+            .GetCustomAttribute<TaskAnalyzerTestPathsAttribute>()
+            .ShouldNotBeNull()
+            .AnalyzerPath;
+    }
+
+    public void Dispose() => _env.Dispose();
+
+    [Theory]
+    [InlineData(null, null, false, true)]
+    [InlineData("true", "all", true, true)]
+    [InlineData("false", "all", false, false)]
+    [InlineData("invalid", "invalid", false, true)]
+    public void ProjectPropertiesControlAnalyzer(
+        string? enabled,
+        string? scope,
+        bool expectRegularTaskDiagnostic,
+        bool expectMtTaskDiagnostic)
+    {
+        TestProject project = CreateTestProject(enabled, scope);
+
+        string output = Build(project.ProjectPath, "/restore", out bool succeeded);
+
+        succeeded.ShouldBeTrue(output);
+        AssertTaskDiagnostic(output, "RegularTask.cs", expectRegularTaskDiagnostic);
+        AssertTaskDiagnostic(output, "MtTask.cs", expectMtTaskDiagnostic);
+        output.ShouldNotContain("SafeTask.cs(");
+    }
+
+    [Fact]
+    public void GlobalConfigEnablesMigrationMode()
+    {
+        TestProject project = CreateTestProject();
+        File.WriteAllText(
+            Path.Combine(project.Directory, ".globalconfig"),
+            """
+            is_global = true
+            msbuild_task_analyzer.scope = all
+            """);
+
+        string output = Build(project.ProjectPath, "/restore", out bool succeeded);
+
+        succeeded.ShouldBeTrue(output);
+        AssertTaskDiagnostic(output, "RegularTask.cs", expected: true);
+        AssertTaskDiagnostic(output, "MtTask.cs", expected: true);
+    }
+
+    [Fact]
+    public void DiagnosticIdCanBeSuppressed()
+    {
+        TestProject project = CreateTestProject(scope: "all");
+
+        string output = Build(project.ProjectPath, "/restore /p:NoWarn=MSBuildTask0002", out bool succeeded);
+
+        succeeded.ShouldBeTrue(output);
+        output.ShouldNotContain("MSBuildTask0002");
+    }
+
+    [Fact]
+    public void EditorConfigCanSuppressDiagnosticId()
+    {
+        TestProject project = CreateTestProject(scope: "all");
+        File.WriteAllText(
+            Path.Combine(project.Directory, ".editorconfig"),
+            """
+            root = true
+
+            [*.cs]
+            dotnet_diagnostic.MSBuildTask0002.severity = none
+            """);
+
+        string output = Build(project.ProjectPath, "/restore", out bool succeeded);
+
+        succeeded.ShouldBeTrue(output);
+        output.ShouldNotContain("MSBuildTask0002");
+    }
+
+    [Fact]
+    public void TreatWarningsAsErrorsAppliesToAnalyzerWarnings()
+    {
+        TestProject project = CreateTestProject();
+
+        string output = Build(project.ProjectPath, "/restore /p:TreatWarningsAsErrors=true", out bool succeeded);
+
+        succeeded.ShouldBeFalse();
+        output.ShouldContain("error MSBuildTask0002");
+        output.ShouldContain("MtTask.cs");
+        output.ShouldNotContain("RegularTask.cs");
+    }
+
+    [Fact]
+    public void ConfigurationWorksForSolutionBuild()
+    {
+        TestProject project = CreateTestProject(scope: "all");
+        string solutionPath = Path.Combine(project.Directory, "TaskAnalyzer.slnx");
+        File.WriteAllText(
+            solutionPath,
+            """
+            <Solution>
+              <Project Path="TaskProject.csproj" />
+            </Solution>
+            """);
+
+        string output = Build(solutionPath, "/restore", out bool succeeded);
+
+        succeeded.ShouldBeTrue(output);
+        AssertTaskDiagnostic(output, "RegularTask.cs", expected: true);
+        AssertTaskDiagnostic(output, "MtTask.cs", expected: true);
+    }
+
+    private TestProject CreateTestProject(string? enabled = null, string? scope = null)
+    {
+        string frameworkPackagePath = GetFrameworkPackagePath();
+        string frameworkVersion = GetPackageVersion(frameworkPackagePath);
+        TransientTestFolder projectFolder = _env.CreateFolder(createFolder: true);
+        string projectPath = Path.Combine(projectFolder.Path, "TaskProject.csproj");
+
+        File.WriteAllText(
+            projectPath,
+            $$"""
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>{{RunnerUtilities.LatestDotNetCoreForMSBuild}}</TargetFramework>
+                <Nullable>disable</Nullable>
+                <RestorePackagesPath>$(MSBuildProjectDirectory)\.packages</RestorePackagesPath>
+                {{CreateProperty("MSBuildTaskAnalyzerEnabled", enabled)}}
+                {{CreateProperty("MSBuildTaskAnalyzerScope", scope)}}
+              </PropertyGroup>
+
+              <ItemGroup>
+                <PackageReference Include="Microsoft.Build.Framework" Version="{{frameworkVersion}}" />
+                <Analyzer Include="{{_analyzerPath}}" />
+              </ItemGroup>
+            </Project>
+            """);
+
+        File.WriteAllText(
+            Path.Combine(projectFolder.Path, "TaskBase.cs"),
+            """
+            using Microsoft.Build.Framework;
+
+            public abstract class TaskBase : ITask
+            {
+                public IBuildEngine BuildEngine { get; set; }
+                public ITaskHost HostObject { get; set; }
+                public abstract bool Execute();
+            }
+            """);
+
+        File.WriteAllText(
+            Path.Combine(projectFolder.Path, "RegularTask.cs"),
+            """
+            using System;
+
+            public sealed class RegularTask : TaskBase
+            {
+                public override bool Execute()
+                {
+                    _ = Environment.CurrentDirectory;
+                    return true;
+                }
+            }
+            """);
+
+        File.WriteAllText(
+            Path.Combine(projectFolder.Path, "MtTask.cs"),
+            """
+            using System;
+            using Microsoft.Build.Framework;
+
+            public sealed class MtTask : TaskBase, IMultiThreadableTask
+            {
+                public TaskEnvironment TaskEnvironment { get; set; }
+
+                public override bool Execute()
+                {
+                    _ = Environment.CurrentDirectory;
+                    return true;
+                }
+            }
+            """);
+
+        File.WriteAllText(
+            Path.Combine(projectFolder.Path, "SafeTask.cs"),
+            """
+            using System.Diagnostics;
+            using System.IO;
+            using Microsoft.Build.Framework;
+
+            public sealed class SafeTask : TaskBase, IMultiThreadableTask
+            {
+                public SafeTask(TaskEnvironment taskEnvironment)
+                {
+                    TaskEnvironment = taskEnvironment;
+                }
+
+                public TaskEnvironment TaskEnvironment { get; set; }
+                public string Source { get; set; }
+                public string Destination { get; set; }
+                public string ToolPath { get; set; }
+                public string Arguments { get; set; }
+
+                public override bool Execute()
+                {
+                    string setting = TaskEnvironment.GetEnvironmentVariable("MY_SETTING");
+                    TaskEnvironment.SetEnvironmentVariable("MY_RESULT", setting);
+
+                    AbsolutePath source = TaskEnvironment.GetAbsolutePath(Source);
+                    AbsolutePath destination = TaskEnvironment.GetAbsolutePath(Destination);
+                    if (File.Exists(source))
+                    {
+                        File.Copy(source, destination);
+                    }
+
+                    ProcessStartInfo startInfo = TaskEnvironment.GetProcessStartInfo();
+                    startInfo.FileName = ToolPath;
+                    startInfo.Arguments = Arguments;
+                    using Process process = Process.Start(startInfo);
+                    process?.WaitForExit();
+                    return true;
+                }
+            }
+            """);
+
+        CreateNuGetConfig(projectFolder.Path);
+        return new TestProject(projectFolder.Path, projectPath);
+    }
+
+    private void CreateNuGetConfig(string projectDirectory)
+    {
+        string sourceConfigPath = Path.Combine(AppContext.BaseDirectory, "TestAssets", "TaskAnalyzerConfiguration", "NuGet.Config");
+        XDocument config = XDocument.Load(sourceConfigPath);
+
+        XElement packageSources = config.Root!.Element("packageSources").ShouldNotBeNull();
+        packageSources.Add(
+            new XElement(
+                "add",
+                new XAttribute("key", "local-msbuild"),
+                new XAttribute("value", RunnerUtilities.ArtifactsLocationAttribute.ArtifactsLocation)));
+
+        XElement packageSourceMapping = config.Root.Element("packageSourceMapping").ShouldNotBeNull();
+        packageSourceMapping.Add(
+            new XElement(
+                "packageSource",
+                new XAttribute("key", "local-msbuild"),
+                new XElement("package", new XAttribute("pattern", "Microsoft.Build.*")),
+                new XElement("package", new XAttribute("pattern", "Microsoft.NET.StringTools"))));
+
+        config.Save(Path.Combine(projectDirectory, "NuGet.Config"));
+    }
+
+    private string GetFrameworkPackagePath()
+    {
+        string[] packages = Directory.GetFiles(
+            RunnerUtilities.ArtifactsLocationAttribute.ArtifactsLocation,
+            $"{FrameworkPackagePrefix}*{PackageExtension}",
+            SearchOption.TopDirectoryOnly);
+
+        packages.ShouldNotBeEmpty();
+        return packages.OrderByDescending(File.GetLastWriteTimeUtc).First();
+    }
+
+    private static string GetPackageVersion(string packagePath)
+    {
+        string packageFileName = Path.GetFileName(packagePath);
+        return packageFileName.Substring(
+            FrameworkPackagePrefix.Length,
+            packageFileName.Length - FrameworkPackagePrefix.Length - PackageExtension.Length);
+    }
+
+    private string Build(string projectOrSolutionPath, string additionalArguments, out bool succeeded)
+    {
+        string output = RunnerUtilities.ExecBootstrapedMSBuild(
+            $"\"{projectOrSolutionPath}\" /nologo /verbosity:minimal /nodeReuse:false {additionalArguments}",
+            out succeeded,
+            outputHelper: _output,
+            timeoutMilliseconds: ProcessTimeoutMilliseconds);
+
+        _output.WriteLine(output);
+        return output;
+    }
+
+    private static void AssertTaskDiagnostic(string output, string sourceFile, bool expected)
+    {
+        string diagnostic = $"{sourceFile}(";
+        if (expected)
+        {
+            output.ShouldContain(diagnostic);
+        }
+        else
+        {
+            output.ShouldNotContain(diagnostic);
+        }
+    }
+
+    private static string CreateProperty(string name, string? value) =>
+        value is null ? string.Empty : $"<{name}>{value}</{name}>";
+
+    private readonly record struct TestProject(string Directory, string ProjectPath);
+}

--- a/src/TaskAnalyzer.Tests/AnalyzerConfigurationTests.cs
+++ b/src/TaskAnalyzer.Tests/AnalyzerConfigurationTests.cs
@@ -1,0 +1,109 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Shouldly;
+using Xunit;
+using static Microsoft.Build.TaskAuthoring.Analyzer.Tests.TestHelpers;
+
+namespace Microsoft.Build.TaskAuthoring.Analyzer.Tests;
+
+public class AnalyzerConfigurationTests
+{
+    private const string UnsafeMtTask = """
+        using System;
+        using Microsoft.Build.Framework;
+
+        public class MyTask : Microsoft.Build.Utilities.Task, IMultiThreadableTask
+        {
+            public TaskEnvironment TaskEnvironment { get; set; }
+
+            public override bool Execute()
+            {
+                _ = Environment.CurrentDirectory;
+                return true;
+            }
+        }
+        """;
+
+    [Theory]
+    [InlineData("false", false)]
+    [InlineData("False", false)]
+    [InlineData("true", true)]
+    [InlineData("", true)]
+    [InlineData("invalid", true)]
+    public async Task EnabledMsBuildPropertyUsesSafeDefault(string value, bool expectDiagnostic)
+    {
+        ImmutableArray<Diagnostic> diagnostics = await GetDiagnosticsAsync(
+            $"build_property.{SharedAnalyzerHelpers.EnabledPropertyKey}",
+            value);
+
+        diagnostics.Any(diagnostic => diagnostic.Id == DiagnosticIds.TaskEnvironmentRequired)
+            .ShouldBe(expectDiagnostic);
+    }
+
+    [Fact]
+    public async Task DirectGlobalConfigCanDisableAnalyzer()
+    {
+        ImmutableArray<Diagnostic> diagnostics = await GetDiagnosticsAsync(
+            SharedAnalyzerHelpers.EnabledOptionKey,
+            "false");
+
+        diagnostics.ShouldBeEmpty();
+    }
+
+    [Theory]
+    [InlineData("all", true)]
+    [InlineData("multithreadable_only", false)]
+    [InlineData("", false)]
+    [InlineData("invalid", false)]
+    public async Task ScopeMsBuildPropertyUsesSafeDefault(string value, bool expectDiagnostic)
+    {
+        const string regularTask = """
+            using System;
+
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                public override bool Execute()
+                {
+                    _ = Environment.CurrentDirectory;
+                    return true;
+                }
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await GetDiagnosticsAsync(
+            $"build_property.{SharedAnalyzerHelpers.ScopePropertyKey}",
+            value,
+            regularTask);
+
+        diagnostics.Any(diagnostic => diagnostic.Id == DiagnosticIds.TaskEnvironmentRequired)
+            .ShouldBe(expectDiagnostic);
+    }
+
+    private static Task<ImmutableArray<Diagnostic>> GetDiagnosticsAsync(string key, string value) =>
+        GetDiagnosticsAsync(key, value, UnsafeMtTask);
+
+    private static async Task<ImmutableArray<Diagnostic>> GetDiagnosticsAsync(string key, string value, string source)
+    {
+        var analyzerOptions = new AnalyzerOptions(
+            ImmutableArray<AdditionalText>.Empty,
+            new TestAnalyzerConfigOptionsProvider(new Dictionary<string, string> { [key] = value }));
+
+        var analyzers = ImmutableArray.Create<DiagnosticAnalyzer>(
+            new MultiThreadableTaskAnalyzer(),
+            new TransitiveCallChainAnalyzer(),
+            new PreferTypedParameterAnalyzer(),
+            new UnsupportedTaskItemTypeAnalyzer(),
+            new TaskEnvironmentConstructorInjectionAnalyzer());
+
+        return await CreateCompilation(source)
+            .WithAnalyzers(analyzers, analyzerOptions)
+            .GetAnalyzerDiagnosticsAsync();
+    }
+}

--- a/src/TaskAnalyzer.Tests/MultiThreadableTaskAnalyzerTests.cs
+++ b/src/TaskAnalyzer.Tests/MultiThreadableTaskAnalyzerTests.cs
@@ -1225,7 +1225,7 @@ public class MultiThreadableTaskAnalyzerTests
     }
 
     [Fact]
-    public async Task PathGetTempPath_InMultiThreadable_ProducesWarning()
+    public async Task PathGetTempPath_InMultiThreadable_NoDiagnosticUntilReplacementApiShips()
     {
         var diags = await GetDiagnosticsAsync("""
             using System.IO;
@@ -1241,11 +1241,11 @@ public class MultiThreadableTaskAnalyzerTests
             }
             """);
 
-        diags.ShouldContain(d => d.Id == DiagnosticIds.TaskEnvironmentRequired);
+        diags.ShouldNotContain(d => d.Id == DiagnosticIds.TaskEnvironmentRequired);
     }
 
     [Fact]
-    public async Task PathGetTempFileName_InMultiThreadable_ProducesWarning()
+    public async Task PathGetTempFileName_InMultiThreadable_NoDiagnosticUntilEquivalentApiShips()
     {
         var diags = await GetDiagnosticsAsync("""
             using System.IO;
@@ -1261,11 +1261,11 @@ public class MultiThreadableTaskAnalyzerTests
             }
             """);
 
-        diags.ShouldContain(d => d.Id == DiagnosticIds.TaskEnvironmentRequired);
+        diags.ShouldNotContain(d => d.Id == DiagnosticIds.TaskEnvironmentRequired);
     }
 
     [Fact]
-    public async Task EnvironmentGetFolderPath_InMultiThreadable_ProducesWarning()
+    public async Task EnvironmentGetFolderPath_InMultiThreadable_NoDiagnosticWithoutEquivalentReplacement()
     {
         var diags = await GetDiagnosticsAsync("""
             using System;
@@ -1281,7 +1281,7 @@ public class MultiThreadableTaskAnalyzerTests
             }
             """);
 
-        diags.ShouldContain(d => d.Id == DiagnosticIds.TaskEnvironmentRequired);
+        diags.ShouldNotContain(d => d.Id == DiagnosticIds.TaskEnvironmentRequired);
     }
 
     [Fact]
@@ -1339,7 +1339,7 @@ public class MultiThreadableTaskAnalyzerTests
     }
 
     [Fact]
-    public async Task ProcessStartWithPSI_InMultiThreadable_ProducesWarning()
+    public async Task ProcessStartWithTaskEnvironmentPSI_InMultiThreadable_NoDiagnostic()
     {
         var diags = await GetDiagnosticsAsync("""
             using System.Diagnostics;
@@ -1349,15 +1349,15 @@ public class MultiThreadableTaskAnalyzerTests
                 public TaskEnvironment TaskEnvironment { get; set; }
                 public override bool Execute()
                 {
-                    var psi = new ProcessStartInfo("cmd");
+                    var psi = TaskEnvironment.GetProcessStartInfo();
+                    psi.FileName = "cmd";
                     Process.Start(psi);
                     return true;
                 }
             }
             """);
 
-        // Should flag both: new ProcessStartInfo and Process.Start(ProcessStartInfo)
-        diags.Where(d => d.Id == DiagnosticIds.TaskEnvironmentRequired).Count().ShouldBeGreaterThanOrEqualTo(2);
+        diags.ShouldNotContain(d => d.Id == DiagnosticIds.TaskEnvironmentRequired);
     }
 
     // ═══════════════════════════════════════════════════════════════════════

--- a/src/TaskAnalyzer.Tests/MultiThreadableTaskAnalyzerTests.cs
+++ b/src/TaskAnalyzer.Tests/MultiThreadableTaskAnalyzerTests.cs
@@ -3,6 +3,9 @@
 
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
 using Shouldly;
 using Xunit;
 using static Microsoft.Build.TaskAuthoring.Analyzer.Tests.TestHelpers;
@@ -1869,6 +1872,225 @@ public class MultiThreadableTaskAnalyzerTests
     // ═══════════════════════════════════════════════════════════════════════
     // Scope option tests
     // ═══════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task Scope_Default_PlainTask_DoesNotGetScopedDiagnostics()
+    {
+        var diags = await GetDiagnosticsWithDefaultScopeAsync("""
+            using System;
+            using System.IO;
+            using System.Reflection;
+            public class PlainTask : Microsoft.Build.Utilities.Task
+            {
+                public override bool Execute()
+                {
+                    Console.WriteLine("test");
+                    var value = Environment.GetEnvironmentVariable("KEY");
+                    Assembly.Load("Test");
+                    return File.Exists("relative.txt");
+                }
+            }
+            """);
+
+        diags.Where(d => d.Id == DiagnosticIds.CriticalError).ShouldBeEmpty();
+        diags.Where(d => d.Id == DiagnosticIds.TaskEnvironmentRequired).ShouldBeEmpty();
+        diags.Where(d => d.Id == DiagnosticIds.FilePathRequiresAbsolute).ShouldBeEmpty();
+        diags.Where(d => d.Id == DiagnosticIds.PotentialIssue).ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task Scope_Default_MultiThreadableTask_GetsAllScopedDiagnostics()
+    {
+        var diags = await GetDiagnosticsWithDefaultScopeAsync("""
+            using System;
+            using System.IO;
+            using System.Reflection;
+            using Microsoft.Build.Framework;
+            public class MtTask : Microsoft.Build.Utilities.Task, IMultiThreadableTask
+            {
+                public TaskEnvironment TaskEnvironment { get; set; }
+                public override bool Execute()
+                {
+                    Console.WriteLine("test");
+                    var value = Environment.GetEnvironmentVariable("KEY");
+                    Assembly.Load("Test");
+                    return File.Exists("relative.txt");
+                }
+            }
+            """);
+
+        diags.Where(d => d.Id == DiagnosticIds.CriticalError).ShouldHaveSingleItem()
+            .Severity.ShouldBe(DiagnosticSeverity.Error);
+        diags.Where(d => d.Id == DiagnosticIds.TaskEnvironmentRequired).ShouldHaveSingleItem()
+            .Severity.ShouldBe(DiagnosticSeverity.Warning);
+        diags.Where(d => d.Id == DiagnosticIds.FilePathRequiresAbsolute).ShouldHaveSingleItem()
+            .Severity.ShouldBe(DiagnosticSeverity.Warning);
+        diags.Where(d => d.Id == DiagnosticIds.PotentialIssue).ShouldHaveSingleItem()
+            .Severity.ShouldBe(DiagnosticSeverity.Warning);
+    }
+
+    [Fact]
+    public async Task Scope_All_PlainTask_GetsAllScopedDiagnostics()
+    {
+        var diags = await GetDiagnosticsWithScopeAsync("""
+            using System;
+            using System.IO;
+            using System.Reflection;
+            public class PlainTask : Microsoft.Build.Utilities.Task
+            {
+                public override bool Execute()
+                {
+                    Console.WriteLine("test");
+                    var value = Environment.GetEnvironmentVariable("KEY");
+                    Assembly.Load("Test");
+                    return File.Exists("relative.txt");
+                }
+            }
+            """, SharedAnalyzerHelpers.ScopeAll);
+
+        diags.Where(d => d.Id == DiagnosticIds.CriticalError).ShouldHaveSingleItem()
+            .Severity.ShouldBe(DiagnosticSeverity.Error);
+        diags.Where(d => d.Id == DiagnosticIds.TaskEnvironmentRequired).ShouldHaveSingleItem()
+            .Severity.ShouldBe(DiagnosticSeverity.Warning);
+        diags.Where(d => d.Id == DiagnosticIds.FilePathRequiresAbsolute).ShouldHaveSingleItem()
+            .Severity.ShouldBe(DiagnosticSeverity.Warning);
+        diags.Where(d => d.Id == DiagnosticIds.PotentialIssue).ShouldHaveSingleItem()
+            .Severity.ShouldBe(DiagnosticSeverity.Warning);
+    }
+
+    [Fact]
+    public async Task Scope_GlobalConfig_All_AnalyzesPlainTask()
+    {
+        var test = new CSharpAnalyzerTest<MultiThreadableTaskAnalyzer, DefaultVerifier>
+        {
+            TestCode = """
+                using System;
+                public class PlainTask : Microsoft.Build.Utilities.Task
+                {
+                    public override bool Execute()
+                    {
+                        var value = {|#0:Environment.GetEnvironmentVariable("KEY")|};
+                        return true;
+                    }
+                }
+                """,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        };
+        test.TestState.Sources.Add(("Stubs.cs", FrameworkStubs));
+        test.TestState.AnalyzerConfigFiles.Add(("/.globalconfig", """
+            is_global = true
+            msbuild_task_analyzer.scope = all
+            """));
+        test.ExpectedDiagnostics.Add(
+            new DiagnosticResult(DiagnosticIds.TaskEnvironmentRequired, DiagnosticSeverity.Warning).WithLocation(0));
+
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task Scope_UnrecognizedValue_UsesDefault()
+    {
+        var diags = await GetDiagnosticsWithScopeAsync("""
+            using System;
+            using System.Reflection;
+            public class PlainTask : Microsoft.Build.Utilities.Task
+            {
+                public override bool Execute()
+                {
+                    Console.WriteLine("test");
+                    var value = Environment.GetEnvironmentVariable("KEY");
+                    Assembly.Load("Test");
+                    return true;
+                }
+            }
+            """, "unrecognized");
+
+        diags.Where(d => d.Id == DiagnosticIds.CriticalError).ShouldBeEmpty();
+        diags.Where(d => d.Id == DiagnosticIds.TaskEnvironmentRequired).ShouldBeEmpty();
+        diags.Where(d => d.Id == DiagnosticIds.PotentialIssue).ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task Scope_Default_PlainTask_TreatWarningsAsErrors_DoesNotGetScopedDiagnostics()
+    {
+        var diags = await GetDiagnosticsWithDefaultScopeAsync("""
+            using System;
+            using System.Reflection;
+            public class PlainTask : Microsoft.Build.Utilities.Task
+            {
+                public override bool Execute()
+                {
+                    Console.WriteLine("test");
+                    Assembly.Load("Test");
+                    return true;
+                }
+            }
+            """, ReportDiagnostic.Error);
+
+        diags.Where(d => d.Id == DiagnosticIds.CriticalError).ShouldBeEmpty();
+        diags.Where(d => d.Id == DiagnosticIds.PotentialIssue).ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task Scope_Default_MultiThreadableTask_TreatWarningsAsErrors_PromotesWarning()
+    {
+        var diags = await GetDiagnosticsWithDefaultScopeAsync("""
+            using System.Reflection;
+            using Microsoft.Build.Framework;
+            public class MtTask : Microsoft.Build.Utilities.Task, IMultiThreadableTask
+            {
+                public TaskEnvironment TaskEnvironment { get; set; }
+                public override bool Execute()
+                {
+                    Assembly.Load("Test");
+                    return true;
+                }
+            }
+            """, ReportDiagnostic.Error);
+
+        Diagnostic diagnostic = diags.Where(d => d.Id == DiagnosticIds.PotentialIssue).ShouldHaveSingleItem();
+        diagnostic.Severity.ShouldBe(DiagnosticSeverity.Error);
+        diagnostic.IsWarningAsError.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task Scope_Default_MultiThreadableAttribute_OptsTaskIn()
+    {
+        var diags = await GetDiagnosticsWithDefaultScopeAsync("""
+            using System;
+            using Microsoft.Build.Framework;
+            [MSBuildMultiThreadableTask]
+            public class MtTask : Microsoft.Build.Utilities.Task
+            {
+                public override bool Execute()
+                {
+                    var value = Environment.GetEnvironmentVariable("KEY");
+                    return true;
+                }
+            }
+            """);
+
+        diags.Where(d => d.Id == DiagnosticIds.TaskEnvironmentRequired).ShouldHaveSingleItem();
+    }
+
+    [Fact]
+    public async Task Scope_Default_AnalyzedAttribute_OptsHelperIn()
+    {
+        var diags = await GetDiagnosticsWithDefaultScopeAsync("""
+            using System;
+            using Microsoft.Build.Framework;
+            [MSBuildMultiThreadableTaskAnalyzed]
+            public class MtHelper
+            {
+                public void Execute()
+                {
+                    var value = Environment.GetEnvironmentVariable("KEY");
+                }
+            }
+            """);
+
+        diags.Where(d => d.Id == DiagnosticIds.TaskEnvironmentRequired).ShouldHaveSingleItem();
+    }
 
     [Fact]
     public async Task Scope_MultithreadableOnly_PlainTask_NoDiagnostic()

--- a/src/TaskAnalyzer.Tests/MultiThreadableTaskCodeFixProviderTests.cs
+++ b/src/TaskAnalyzer.Tests/MultiThreadableTaskCodeFixProviderTests.cs
@@ -139,13 +139,13 @@ public class MultiThreadableTaskCodeFixProviderTests
                     public TaskEnvironment TaskEnvironment { get; set; }
                     public override bool Execute()
                     {
-                        var p = TaskEnvironment.GetAbsolutePath("relative");
+                        var p = TaskEnvironment.GetAbsolutePath("relative").GetCanonicalForm().Value;
                         return true;
                     }
                 }
                 """,
             Diag(DiagnosticIds.TaskEnvironmentRequired).WithLocation(0)
-                .WithArguments("Path.GetFullPath(string)", "use TaskEnvironment.GetAbsolutePath instead")).RunAsync();
+                .WithArguments("Path.GetFullPath(string)", "use TaskEnvironment.GetAbsolutePath(path).GetCanonicalForm().Value instead")).RunAsync();
     }
 
     [Fact]

--- a/src/TaskAnalyzer.Tests/PreferTypedParameterCodeFixProviderTests.cs
+++ b/src/TaskAnalyzer.Tests/PreferTypedParameterCodeFixProviderTests.cs
@@ -326,10 +326,8 @@ public class PreferTypedParameterCodeFixProviderTests
     }
 
     [Fact]
-    public async Task Fix_0006_PathGetFullPath_RetypesToAbsolutePathAndRemovesCall()
+    public async Task Fix_0006_PathGetFullPath_RetypesToAbsolutePathAndPreservesCanonicalization()
     {
-        // Path.GetFullPath(prop) is the raw MSBuildTask0002 normalization. Retyping the property to AbsolutePath
-        // makes the value already-absolute, so the whole call collapses to the property (one-shot, no daisy-chain).
         await CreateFixTest(
             testCode: """
                 using System.IO;
@@ -354,7 +352,7 @@ public class PreferTypedParameterCodeFixProviderTests
                     public AbsolutePath InputPath { get; set; } = default;
                     public override bool Execute()
                     {
-                        var full = InputPath;
+                        var full = InputPath.GetCanonicalForm().Value;
                         return true;
                     }
                 }

--- a/src/TaskAnalyzer.Tests/RequiredTaskPropertyInitializationSuppressorTests.cs
+++ b/src/TaskAnalyzer.Tests/RequiredTaskPropertyInitializationSuppressorTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Shouldly;
@@ -30,6 +31,33 @@ public class RequiredTaskPropertyInitializationSuppressorTests
 
         diagnostics.ShouldContain(d => d.Id == "CS8618" && d.IsSuppressed);
         diagnostics.ShouldNotContain(d => d.Id == "CS8618" && !d.IsSuppressed);
+    }
+
+    [Fact]
+    public async Task DisabledAnalyzer_DoesNotSuppressRequiredPropertyDiagnostic()
+    {
+        var optionsProvider = new TestAnalyzerConfigOptionsProvider(
+            new Dictionary<string, string>
+            {
+                [$"build_property.{SharedAnalyzerHelpers.EnabledPropertyKey}"] = "false",
+            });
+
+        var diagnostics = await GetCompilerAndAnalyzerDiagnosticsAsync(
+            """
+            using Microsoft.Build.Framework;
+
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                [Required]
+                public string IldasmPath { get; set; }
+
+                public override bool Execute() => true;
+            }
+            """,
+            optionsProvider,
+            new RequiredTaskPropertyInitializationSuppressor());
+
+        diagnostics.ShouldContain(d => d.Id == "CS8618" && !d.IsSuppressed);
     }
 
     [Fact]

--- a/src/TaskAnalyzer.Tests/TestHelpers.cs
+++ b/src/TaskAnalyzer.Tests/TestHelpers.cs
@@ -53,6 +53,7 @@ internal static class TestHelpers
                 public AbsolutePath(string path) { Value = path; OriginalValue = path; }
                 public string Value { get; }
                 public string OriginalValue { get; }
+                public AbsolutePath GetCanonicalForm() => this;
                 public static implicit operator string(AbsolutePath p) => p.Value;
                 public bool Equals(AbsolutePath other) => Value == other.Value;
                 public override bool Equals(object? obj) => obj is AbsolutePath other && Equals(other);
@@ -153,13 +154,31 @@ internal static class TestHelpers
     /// Runs compiler diagnostics together with analyzers and suppressors and returns
     /// diagnostics reported for the primary test source file.
     /// </summary>
-    public static async System.Threading.Tasks.Task<ImmutableArray<Diagnostic>> GetCompilerAndAnalyzerDiagnosticsAsync(
+    public static System.Threading.Tasks.Task<ImmutableArray<Diagnostic>> GetCompilerAndAnalyzerDiagnosticsAsync(
         string source,
+        params DiagnosticAnalyzer[] analyzers)
+        => GetCompilerAndAnalyzerDiagnosticsAsync(
+            source,
+            new AnalyzerOptions(ImmutableArray<AdditionalText>.Empty),
+            analyzers);
+
+    public static System.Threading.Tasks.Task<ImmutableArray<Diagnostic>> GetCompilerAndAnalyzerDiagnosticsAsync(
+        string source,
+        AnalyzerConfigOptionsProvider optionsProvider,
+        params DiagnosticAnalyzer[] analyzers)
+        => GetCompilerAndAnalyzerDiagnosticsAsync(
+            source,
+            new AnalyzerOptions(ImmutableArray<AdditionalText>.Empty, optionsProvider),
+            analyzers);
+
+    private static async System.Threading.Tasks.Task<ImmutableArray<Diagnostic>> GetCompilerAndAnalyzerDiagnosticsAsync(
+        string source,
+        AnalyzerOptions analyzerOptions,
         params DiagnosticAnalyzer[] analyzers)
     {
         var compilation = CreateCompilation(source);
         var options = new CompilationWithAnalyzersOptions(
-            new AnalyzerOptions(ImmutableArray<AdditionalText>.Empty),
+            analyzerOptions,
             onAnalyzerException: null,
             concurrentAnalysis: true,
             logAnalyzerExecutionTime: false,
@@ -232,7 +251,7 @@ internal static class TestHelpers
 
         var globalOptions = new Dictionary<string, string>
         {
-            { $"build_property.{SharedAnalyzerHelpers.ScopeOptionKey}", scope }
+            { $"build_property.{SharedAnalyzerHelpers.ScopePropertyKey}", scope }
         };
         var optionsProvider = new TestAnalyzerConfigOptionsProvider(globalOptions);
         var options = new AnalyzerOptions(ImmutableArray<AdditionalText>.Empty, optionsProvider);
@@ -283,7 +302,7 @@ internal static class TestHelpers
 
         var globalOptions = new Dictionary<string, string>
         {
-            { $"build_property.{SharedAnalyzerHelpers.ScopeOptionKey}", scope }
+            { $"build_property.{SharedAnalyzerHelpers.ScopePropertyKey}", scope }
         };
         var optionsProvider = new TestAnalyzerConfigOptionsProvider(globalOptions);
         var options = new AnalyzerOptions(ImmutableArray<AdditionalText>.Empty, optionsProvider);

--- a/src/TaskAnalyzer.Tests/TestHelpers.cs
+++ b/src/TaskAnalyzer.Tests/TestHelpers.cs
@@ -138,34 +138,16 @@ internal static class TestHelpers
     public static MetadataReference[] GetCoreReferences() => s_coreReferences;
 
     /// <summary>
-    /// Runs the MultiThreadableTaskAnalyzer on the given source code and returns analyzer diagnostics.
-    /// Source is combined with framework stubs automatically.
+    /// Runs the MultiThreadableTaskAnalyzer in explicit all-task migration mode.
     /// </summary>
-    public static async System.Threading.Tasks.Task<ImmutableArray<Diagnostic>> GetDiagnosticsAsync(string source)
-    {
-        var compilation = CreateCompilation(source);
-        var analyzer = new MultiThreadableTaskAnalyzer();
-        var compilationWithAnalyzers = compilation.WithAnalyzers(
-            ImmutableArray.Create<DiagnosticAnalyzer>(analyzer));
-
-        var allDiags = await compilationWithAnalyzers.GetAnalyzerDiagnosticsAsync();
-        return allDiags;
-    }
+    public static System.Threading.Tasks.Task<ImmutableArray<Diagnostic>> GetDiagnosticsAsync(string source) =>
+        GetDiagnosticsWithScopeAsync(source, SharedAnalyzerHelpers.ScopeAll);
 
     /// <summary>
-    /// Runs BOTH the direct and transitive analyzers on the given source code.
+    /// Runs both the direct and transitive analyzers in explicit all-task migration mode.
     /// </summary>
-    public static async System.Threading.Tasks.Task<ImmutableArray<Diagnostic>> GetAllDiagnosticsAsync(string source)
-    {
-        var compilation = CreateCompilation(source);
-        var analyzers = ImmutableArray.Create<DiagnosticAnalyzer>(
-            new MultiThreadableTaskAnalyzer(),
-            new TransitiveCallChainAnalyzer());
-        var compilationWithAnalyzers = compilation.WithAnalyzers(analyzers);
-
-        var allDiags = await compilationWithAnalyzers.GetAnalyzerDiagnosticsAsync();
-        return allDiags;
-    }
+    public static System.Threading.Tasks.Task<ImmutableArray<Diagnostic>> GetAllDiagnosticsAsync(string source) =>
+        GetAllDiagnosticsWithScopeAsync(source, SharedAnalyzerHelpers.ScopeAll);
 
     /// <summary>
     /// Runs compiler diagnostics together with analyzers and suppressors and returns
@@ -257,6 +239,69 @@ internal static class TestHelpers
 
         var compilationWithAnalyzers = compilation.WithAnalyzers(
             ImmutableArray.Create<DiagnosticAnalyzer>(analyzer), options);
+        return await compilationWithAnalyzers.GetAnalyzerDiagnosticsAsync();
+    }
+
+    /// <summary>
+    /// Runs the MultiThreadableTaskAnalyzer without a scope option.
+    /// </summary>
+    public static async System.Threading.Tasks.Task<ImmutableArray<Diagnostic>> GetDiagnosticsWithDefaultScopeAsync(string source)
+    {
+        var compilation = CreateCompilation(source);
+        var analyzer = new MultiThreadableTaskAnalyzer();
+        var compilationWithAnalyzers = compilation.WithAnalyzers(
+            ImmutableArray.Create<DiagnosticAnalyzer>(analyzer));
+        return await compilationWithAnalyzers.GetAnalyzerDiagnosticsAsync();
+    }
+
+    /// <summary>
+    /// Runs the MultiThreadableTaskAnalyzer without a scope option and applies a general diagnostic action.
+    /// </summary>
+    public static async System.Threading.Tasks.Task<ImmutableArray<Diagnostic>> GetDiagnosticsWithDefaultScopeAsync(
+        string source,
+        ReportDiagnostic generalDiagnosticOption)
+    {
+        var compilation = CreateCompilation(source);
+        compilation = compilation.WithOptions(
+            ((CSharpCompilationOptions)compilation.Options).WithGeneralDiagnosticOption(generalDiagnosticOption));
+
+        var analyzer = new MultiThreadableTaskAnalyzer();
+        var compilationWithAnalyzers = compilation.WithAnalyzers(
+            ImmutableArray.Create<DiagnosticAnalyzer>(analyzer));
+        return await compilationWithAnalyzers.GetAnalyzerDiagnosticsAsync();
+    }
+
+    /// <summary>
+    /// Runs both the direct and transitive analyzers with a specific scope option.
+    /// </summary>
+    public static async System.Threading.Tasks.Task<ImmutableArray<Diagnostic>> GetAllDiagnosticsWithScopeAsync(string source, string scope)
+    {
+        var compilation = CreateCompilation(source);
+        var analyzers = ImmutableArray.Create<DiagnosticAnalyzer>(
+            new MultiThreadableTaskAnalyzer(),
+            new TransitiveCallChainAnalyzer());
+
+        var globalOptions = new Dictionary<string, string>
+        {
+            { $"build_property.{SharedAnalyzerHelpers.ScopeOptionKey}", scope }
+        };
+        var optionsProvider = new TestAnalyzerConfigOptionsProvider(globalOptions);
+        var options = new AnalyzerOptions(ImmutableArray<AdditionalText>.Empty, optionsProvider);
+
+        var compilationWithAnalyzers = compilation.WithAnalyzers(analyzers, options);
+        return await compilationWithAnalyzers.GetAnalyzerDiagnosticsAsync();
+    }
+
+    /// <summary>
+    /// Runs both the direct and transitive analyzers without a scope option.
+    /// </summary>
+    public static async System.Threading.Tasks.Task<ImmutableArray<Diagnostic>> GetAllDiagnosticsWithDefaultScopeAsync(string source)
+    {
+        var compilation = CreateCompilation(source);
+        var analyzers = ImmutableArray.Create<DiagnosticAnalyzer>(
+            new MultiThreadableTaskAnalyzer(),
+            new TransitiveCallChainAnalyzer());
+        var compilationWithAnalyzers = compilation.WithAnalyzers(analyzers);
         return await compilationWithAnalyzers.GetAnalyzerDiagnosticsAsync();
     }
 

--- a/src/TaskAnalyzer.Tests/TransitiveCallChainAnalyzerTests.cs
+++ b/src/TaskAnalyzer.Tests/TransitiveCallChainAnalyzerTests.cs
@@ -244,4 +244,72 @@ public class TransitiveCallChainAnalyzerTests
         msg.ShouldContain("A.Step1");
         msg.ShouldContain("B.Step2");
     }
+
+    [Fact]
+    public async Task Scope_Default_PlainTask_DoesNotGetTransitiveDiagnostic()
+    {
+        var diags = await GetAllDiagnosticsWithDefaultScopeAsync("""
+            using System;
+            public static class Helper
+            {
+                public static void Run() => Environment.GetEnvironmentVariable("KEY");
+            }
+            public class PlainTask : Microsoft.Build.Utilities.Task
+            {
+                public override bool Execute()
+                {
+                    Helper.Run();
+                    return true;
+                }
+            }
+            """);
+
+        diags.Where(d => d.Id == DiagnosticIds.TransitiveUnsafeCall).ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task Scope_Default_MultiThreadableTask_GetsTransitiveDiagnostic()
+    {
+        var diags = await GetAllDiagnosticsWithDefaultScopeAsync("""
+            using System;
+            using Microsoft.Build.Framework;
+            public static class Helper
+            {
+                public static void Run() => Environment.GetEnvironmentVariable("KEY");
+            }
+            public class MtTask : Microsoft.Build.Utilities.Task, IMultiThreadableTask
+            {
+                public TaskEnvironment TaskEnvironment { get; set; }
+                public override bool Execute()
+                {
+                    Helper.Run();
+                    return true;
+                }
+            }
+            """);
+
+        diags.Where(d => d.Id == DiagnosticIds.TransitiveUnsafeCall).ShouldHaveSingleItem();
+    }
+
+    [Fact]
+    public async Task Scope_All_PlainTask_GetsTransitiveDiagnostic()
+    {
+        var diags = await GetAllDiagnosticsWithScopeAsync("""
+            using System;
+            public static class Helper
+            {
+                public static void Run() => Environment.GetEnvironmentVariable("KEY");
+            }
+            public class PlainTask : Microsoft.Build.Utilities.Task
+            {
+                public override bool Execute()
+                {
+                    Helper.Run();
+                    return true;
+                }
+            }
+            """, SharedAnalyzerHelpers.ScopeAll);
+
+        diags.Where(d => d.Id == DiagnosticIds.TransitiveUnsafeCall).ShouldHaveSingleItem();
+    }
 }

--- a/src/TaskAnalyzer.Tests/UnsupportedTaskItemTypeAnalyzerTests.cs
+++ b/src/TaskAnalyzer.Tests/UnsupportedTaskItemTypeAnalyzerTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Shouldly;
@@ -45,7 +46,7 @@ public class UnsupportedTaskItemTypeAnalyzerTests
     [InlineData("double")]
     [InlineData("decimal")]
     [InlineData("System.DateTime")]
-    public async Task ConvertChangeTypeType_ProducesError(string typeName)
+    public async Task ConvertChangeTypeType_ProducesWarning(string typeName)
     {
         var diags = await GetUnsupportedTaskItemTypeDiagnosticsAsync($$"""
             using Microsoft.Build.Framework;
@@ -59,7 +60,7 @@ public class UnsupportedTaskItemTypeAnalyzerTests
         diags.ShouldNotContain(d => d.Id == DiagnosticIds.UnsupportedTaskItemType);
         Diagnostic diagnostic = diags.ShouldHaveSingleItem();
         diagnostic.Id.ShouldBe(DiagnosticIds.CultureSensitiveTaskItemType);
-        diagnostic.Severity.ShouldBe(Microsoft.CodeAnalysis.DiagnosticSeverity.Error);
+        diagnostic.Severity.ShouldBe(Microsoft.CodeAnalysis.DiagnosticSeverity.Warning);
         diagnostic.GetMessage().ShouldContain("Convert.ChangeType");
         diagnostic.GetMessage().ShouldContain("CultureInfo.InvariantCulture");
     }
@@ -116,7 +117,7 @@ public class UnsupportedTaskItemTypeAnalyzerTests
     // ═══════════════════════════════════════════════════════════════════════
 
     [Fact]
-    public async Task ConvertChangeTypeArray_ProducesError()
+    public async Task ConvertChangeTypeArray_ProducesWarning()
     {
         var diags = await GetUnsupportedTaskItemTypeDiagnosticsAsync("""
             using Microsoft.Build.Framework;
@@ -129,7 +130,7 @@ public class UnsupportedTaskItemTypeAnalyzerTests
 
         Diagnostic diagnostic = diags.ShouldHaveSingleItem();
         diagnostic.Id.ShouldBe(DiagnosticIds.CultureSensitiveTaskItemType);
-        diagnostic.Severity.ShouldBe(Microsoft.CodeAnalysis.DiagnosticSeverity.Error);
+        diagnostic.Severity.ShouldBe(Microsoft.CodeAnalysis.DiagnosticSeverity.Warning);
     }
 
     [Fact]
@@ -149,7 +150,7 @@ public class UnsupportedTaskItemTypeAnalyzerTests
     }
 
     [Fact]
-    public async Task ConvertChangeTypeOutputProperty_ProducesError()
+    public async Task ConvertChangeTypeOutputProperty_ProducesWarning()
     {
         var diags = await GetUnsupportedTaskItemTypeDiagnosticsAsync("""
             using Microsoft.Build.Framework;
@@ -163,7 +164,7 @@ public class UnsupportedTaskItemTypeAnalyzerTests
 
         Diagnostic diagnostic = diags.ShouldHaveSingleItem();
         diagnostic.Id.ShouldBe(DiagnosticIds.CultureSensitiveTaskItemType);
-        diagnostic.Severity.ShouldBe(Microsoft.CodeAnalysis.DiagnosticSeverity.Error);
+        diagnostic.Severity.ShouldBe(Microsoft.CodeAnalysis.DiagnosticSeverity.Warning);
     }
 
     [Fact]
@@ -201,6 +202,7 @@ public class UnsupportedTaskItemTypeAnalyzerTests
             """);
 
         diags.ShouldContain(d => d.Id == DiagnosticIds.UnsupportedTaskItemType);
+        diags.ShouldHaveSingleItem().Severity.ShouldBe(Microsoft.CodeAnalysis.DiagnosticSeverity.Error);
         diags[0].GetMessage().ShouldContain("Item");
         diags[0].GetMessage().ShouldContain("Guid");
         diags[0].GetMessage().ShouldContain("string, bool, AbsolutePath, FileInfo, DirectoryInfo");
@@ -223,6 +225,42 @@ public class UnsupportedTaskItemTypeAnalyzerTests
         diags.ShouldContain(d => d.Id == DiagnosticIds.UnsupportedTaskItemType);
         diags[0].GetMessage().ShouldContain("Duration");
         diags[0].GetMessage().ShouldContain("TimeSpan");
+    }
+
+    [Fact]
+    public async Task TypedTaskItemDiagnostics_AreIndependentOfMtScope()
+    {
+        var diags = await GetUnsupportedTaskItemTypeDiagnosticsAsync("""
+            using System;
+            using Microsoft.Build.Framework;
+            public class MyTask : Microsoft.Build.Utilities.Task, IMultiThreadableTask
+            {
+                public TaskEnvironment TaskEnvironment { get; set; }
+                public ITaskItem<Guid> Invalid { get; set; } = null!;
+                public ITaskItem<int> CultureSensitive { get; set; } = null!;
+                public override bool Execute() => true;
+            }
+            """);
+
+        diags.Where(d => d.Id == DiagnosticIds.UnsupportedTaskItemType).ShouldHaveSingleItem()
+            .Severity.ShouldBe(Microsoft.CodeAnalysis.DiagnosticSeverity.Error);
+        diags.Where(d => d.Id == DiagnosticIds.CultureSensitiveTaskItemType).ShouldHaveSingleItem()
+            .Severity.ShouldBe(Microsoft.CodeAnalysis.DiagnosticSeverity.Warning);
+    }
+
+    [Fact]
+    public async Task GenericTaskItemTypeParameter_NoDiagnostic()
+    {
+        var diags = await GetUnsupportedTaskItemTypeDiagnosticsAsync("""
+            using Microsoft.Build.Framework;
+            public class GenericTask<T> : Microsoft.Build.Utilities.Task
+            {
+                public ITaskItem<T> Item { get; set; } = null!;
+                public override bool Execute() => true;
+            }
+            """);
+
+        diags.ShouldBeEmpty();
     }
 
     [Fact]

--- a/src/TaskAnalyzer/AnalyzerReleases.Unshipped.md
+++ b/src/TaskAnalyzer/AnalyzerReleases.Unshipped.md
@@ -3,7 +3,7 @@
 Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
 MSBuildTask0001 | MSBuild.TaskAuthoring | Error | APIs that must not be used in any MSBuild task (Environment.Exit, Console.*, etc.)
-MSBuildTask0002 | MSBuild.TaskAuthoring | Warning | APIs that should use TaskEnvironment alternatives
+MSBuildTask0002 | MSBuild.TaskAuthoring | Warning | APIs that have equivalent TaskEnvironment alternatives; temporary-path methods and other APIs without equivalent replacements are not diagnosed
 MSBuildTask0003 | MSBuild.TaskAuthoring | Warning | File APIs that need absolute paths
 MSBuildTask0004 | MSBuild.TaskAuthoring | Warning | APIs that may cause issues in multithreaded task execution
 MSBuildTask0005 | MSBuild.TaskAuthoring | Warning | Transitive unsafe API usage detected in task call chain

--- a/src/TaskAnalyzer/AnalyzerReleases.Unshipped.md
+++ b/src/TaskAnalyzer/AnalyzerReleases.Unshipped.md
@@ -7,9 +7,9 @@ MSBuildTask0002 | MSBuild.TaskAuthoring | Warning | APIs that should use TaskEnv
 MSBuildTask0003 | MSBuild.TaskAuthoring | Warning | File APIs that need absolute paths
 MSBuildTask0004 | MSBuild.TaskAuthoring | Warning | APIs that may cause issues in multithreaded task execution
 MSBuildTask0005 | MSBuild.TaskAuthoring | Warning | Transitive unsafe API usage detected in task call chain
-MSBuildTask0006 | MSBuild.TaskAuthoring | Warning | Prefer typed path parameter (AbsolutePath/FileInfo/DirectoryInfo) over string (code fix available)
-MSBuildTask0007 | MSBuild.TaskAuthoring | Warning | Prefer ITaskItem<T> over manual ItemSpec parsing (code fix available)
-MSBuildTask0008 | MSBuild.TaskAuthoring | Warning | Initialize a relative default path in Execute() so TaskEnvironment can root it when the property is retyped (code fix available)
-MSBuildTask0009 | MSBuild.TaskAuthoring | Warning | ITaskItem<T> used with a type argument T that MSBuild cannot bind as a task parameter
-MSBuildTask0010 | MSBuild.TaskAuthoring | Error | ITaskItem<T> used with a type argument T that MSBuild parses through Convert.ChangeType
+MSBuildTask0006 | MSBuild.TaskAuthoring | Info | Prefer typed path parameter (AbsolutePath/FileInfo/DirectoryInfo) over string (code fix available)
+MSBuildTask0007 | MSBuild.TaskAuthoring | Info | Prefer ITaskItem<T> over manual ItemSpec parsing (code fix available)
+MSBuildTask0008 | MSBuild.TaskAuthoring | Info | Initialize a relative default path in Execute() so TaskEnvironment can root it when the property is retyped (code fix available)
+MSBuildTask0009 | MSBuild.TaskAuthoring | Error | ITaskItem<T> used with a type argument T that MSBuild cannot bind as a task parameter
+MSBuildTask0010 | MSBuild.TaskAuthoring | Warning | ITaskItem<T> used with a type argument T that MSBuild parses through Convert.ChangeType
 MSBuildTask0011 | MSBuild.TaskAuthoring | Info | Prefer constructor injection for TaskEnvironment

--- a/src/TaskAnalyzer/BannedApiDefinitions.cs
+++ b/src/TaskAnalyzer/BannedApiDefinitions.cs
@@ -94,34 +94,16 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                 // Environment variable access
                 new BannedApi("M:System.Environment.GetEnvironmentVariable(System.String)",
                     ApiCategory.TaskEnvironment, "use TaskEnvironment.GetEnvironmentVariable instead"),
-                new BannedApi("M:System.Environment.GetEnvironmentVariable(System.String,System.EnvironmentVariableTarget)",
-                    ApiCategory.TaskEnvironment, "use TaskEnvironment.GetEnvironmentVariable instead"),
                 new BannedApi("M:System.Environment.GetEnvironmentVariables",
                     ApiCategory.TaskEnvironment, "use TaskEnvironment.GetEnvironmentVariables instead"),
                 new BannedApi("M:System.Environment.SetEnvironmentVariable(System.String,System.String)",
                     ApiCategory.TaskEnvironment, "use TaskEnvironment.SetEnvironmentVariable instead"),
-                new BannedApi("M:System.Environment.SetEnvironmentVariable(System.String,System.String,System.EnvironmentVariableTarget)",
-                    ApiCategory.TaskEnvironment, "drop target parameter; use TaskEnvironment.SetEnvironmentVariable instead"),
                 new BannedApi("M:System.Environment.ExpandEnvironmentVariables(System.String)",
                     ApiCategory.TaskEnvironment, "use TaskEnvironment.GetEnvironmentVariable for individual variables instead"),
 
-                // Environment.GetFolderPath - uses process-wide state
-                new BannedApi("M:System.Environment.GetFolderPath(System.Environment.SpecialFolder)",
-                    ApiCategory.TaskEnvironment, "may be affected by environment variable overrides; use TaskEnvironment.GetEnvironmentVariable instead"),
-                new BannedApi("M:System.Environment.GetFolderPath(System.Environment.SpecialFolder,System.Environment.SpecialFolderOption)",
-                    ApiCategory.TaskEnvironment, "may be affected by environment variable overrides; use TaskEnvironment.GetEnvironmentVariable instead"),
-
                 // Path.GetFullPath
                 new BannedApi("M:System.IO.Path.GetFullPath(System.String)",
-                    ApiCategory.TaskEnvironment, "use TaskEnvironment.GetAbsolutePath instead"),
-                new BannedApi("M:System.IO.Path.GetFullPath(System.String,System.String)",
-                    ApiCategory.TaskEnvironment, "use TaskEnvironment.GetAbsolutePath instead"),
-
-                // Path.GetTempPath / GetTempFileName - depend on environment variables
-                new BannedApi("M:System.IO.Path.GetTempPath",
-                    ApiCategory.TaskEnvironment, "depends on TMP/TEMP environment variables; use TaskEnvironment.GetEnvironmentVariable(\"TMP\") instead"),
-                new BannedApi("M:System.IO.Path.GetTempFileName",
-                    ApiCategory.TaskEnvironment, "depends on TMP/TEMP environment variables; use TaskEnvironment.GetEnvironmentVariable(\"TMP\") instead"),
+                    ApiCategory.TaskEnvironment, "use TaskEnvironment.GetAbsolutePath(path).GetCanonicalForm().Value instead"),
 
                 // Process.Start - use TaskEnvironment.GetProcessStartInfo
                 new BannedApi("M:System.Diagnostics.Process.Start(System.String)",
@@ -129,8 +111,6 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                 new BannedApi("M:System.Diagnostics.Process.Start(System.String,System.String)",
                     ApiCategory.TaskEnvironment, "use TaskEnvironment.GetProcessStartInfo instead"),
                 new BannedApi("M:System.Diagnostics.Process.Start(System.String,System.Collections.Generic.IEnumerable{System.String})",
-                    ApiCategory.TaskEnvironment, "use TaskEnvironment.GetProcessStartInfo instead"),
-                new BannedApi("M:System.Diagnostics.Process.Start(System.Diagnostics.ProcessStartInfo)",
                     ApiCategory.TaskEnvironment, "use TaskEnvironment.GetProcessStartInfo instead"),
                 new BannedApi("M:System.Diagnostics.Process.Start(System.String,System.String,System.String,System.Security.SecureString,System.String)",
                     ApiCategory.TaskEnvironment, "use TaskEnvironment.GetProcessStartInfo instead"),

--- a/src/TaskAnalyzer/DiagnosticDescriptors.cs
+++ b/src/TaskAnalyzer/DiagnosticDescriptors.cs
@@ -90,7 +90,7 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
             title: "ITaskItem<T> used with unsupported type argument",
             messageFormat: "Task property '{0}' uses ITaskItem<{1}> but MSBuild cannot automatically parse '{1}' from item metadata. Use one of the directly parsed types: {2}.",
             category: "MSBuild.TaskAuthoring",
-            defaultSeverity: DiagnosticSeverity.Warning,
+            defaultSeverity: DiagnosticSeverity.Error,
             isEnabledByDefault: true,
             description: "MSBuild can only bind ITaskItem<T> properties when T is a supported type. Using an unsupported type will cause a runtime failure when MSBuild tries to bind the parameter.");
 
@@ -99,7 +99,7 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
             title: "ITaskItem<T> type argument relies on culture-sensitive conversion",
             messageFormat: "Task property '{0}' uses ITaskItem<{1}>, which MSBuild parses through Convert.ChangeType using CultureInfo.InvariantCulture. Use ITaskItem<string> and parse explicitly with a chosen culture.",
             category: "MSBuild.TaskAuthoring",
-            defaultSeverity: DiagnosticSeverity.Error,
+            defaultSeverity: DiagnosticSeverity.Warning,
             isEnabledByDefault: true,
             description: "ITaskItem<T> type arguments parsed through Convert.ChangeType use CultureInfo.InvariantCulture. Bind the item as a string and parse it explicitly with the intended culture.");
 

--- a/src/TaskAnalyzer/MultiThreadableTaskAnalyzer.cs
+++ b/src/TaskAnalyzer/MultiThreadableTaskAnalyzer.cs
@@ -46,6 +46,11 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
 
         private void OnCompilationStart(CompilationStartAnalysisContext compilationContext)
         {
+            if (!SharedAnalyzerHelpers.IsAnalyzerEnabled(compilationContext.Options.AnalyzerConfigOptionsProvider))
+            {
+                return;
+            }
+
             // Resolve well-known types
             var iTaskType = compilationContext.Compilation.GetTypeByMetadataName(WellKnownTypeNames.ITaskFullName);
             if (iTaskType is null)

--- a/src/TaskAnalyzer/MultiThreadableTaskAnalyzer.cs
+++ b/src/TaskAnalyzer/MultiThreadableTaskAnalyzer.cs
@@ -16,10 +16,9 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
     /// <summary>
     /// Roslyn analyzer that detects unsafe API usage in MSBuild task implementations.
     /// 
-    /// Scope (controlled by .editorconfig option "msbuild_task_analyzer.scope"):
-    /// - "all" (default): All rules fire on ALL ITask implementations
-    /// - "multithreadable_only": MSBuildTask0002, 0003 fire only on IMultiThreadableTask or [MSBuildMultiThreadableTask]
-    ///   (MSBuildTask0001 and MSBuildTask0004 always fire on all tasks regardless)
+    /// Scope (controlled by analyzer option "msbuild_task_analyzer.scope"):
+    /// - "multithreadable_only" (default): MSBuildTask0001-0004 report only for MT tasks and explicitly analyzed helpers
+    /// - "all": Enables MSBuildTask0001-0004 for all ITask implementations during migration
     /// 
     /// Per review feedback from @rainersigwald:
     /// - Console.* promoted to MSBuildTask0001 (always wrong in tasks)
@@ -29,8 +28,8 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
     public sealed class MultiThreadableTaskAnalyzer : DiagnosticAnalyzer
     {
         /// <summary>
-        /// The .editorconfig key controlling analysis scope.
-        /// Values: "all" (default) | "multithreadable_only"
+        /// The analyzer configuration key controlling analysis scope.
+        /// Values: "multithreadable_only" (default) | "all"
         /// </summary>
         internal const string ScopeOptionKey = SharedAnalyzerHelpers.ScopeOptionKey;
         internal const string ScopeAll = SharedAnalyzerHelpers.ScopeAll;
@@ -55,7 +54,7 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                 return;
             }
 
-            // Read scope option from .editorconfig: "all" (default) or "multithreadable_only"
+            // Read scope option: "multithreadable_only" (default) or "all"
             bool analyzeAllTasks = SharedAnalyzerHelpers.ReadAnalyzeAllTasksOption(compilationContext.Options.AnalyzerConfigOptionsProvider);
 
             var iMultiThreadableTaskType = compilationContext.Compilation.GetTypeByMetadataName(WellKnownTypeNames.IMultiThreadableTaskFullName);
@@ -97,12 +96,12 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                 // Helper classes with the attribute or tasks with [MSBuildMultiThreadableTask] are treated as IMultiThreadableTask
                 bool analyzeAsMultiThreadable = isMultiThreadableTask || hasAnalyzedAttribute || hasMultiThreadableAttribute;
 
-                // When scope is "multithreadable_only", only analyze MSBuildTask0002/0003 for multithreadable tasks
-                bool reportEnvironmentRules = analyzeAllTasks || analyzeAsMultiThreadable;
+                // The default scope reports MSBuildTask0001-0004 only for MT tasks and explicitly analyzed helpers.
+                bool reportScopedRules = analyzeAllTasks || analyzeAsMultiThreadable;
 
                 // Register operation-level analysis within this type
                 symbolStartContext.RegisterOperationAction(
-                    ctx => AnalyzeOperation(ctx, bannedApiLookup, filePathTypes, reportEnvironmentRules,
+                    ctx => AnalyzeOperation(ctx, bannedApiLookup, filePathTypes, reportScopedRules,
                         taskEnvironmentType, absolutePathType, iTaskItemType, consoleType),
                     OperationKind.Invocation,
                     OperationKind.ObjectCreation,
@@ -117,7 +116,7 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
             OperationAnalysisContext context,
             Dictionary<ISymbol, BannedApiEntry> bannedApiLookup,
             ImmutableHashSet<INamedTypeSymbol> filePathTypes,
-            bool reportEnvironmentRules,
+            bool reportScopedRules,
             INamedTypeSymbol? taskEnvironmentType,
             INamedTypeSymbol? absolutePathType,
             INamedTypeSymbol? iTaskItemType,
@@ -165,8 +164,7 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
             // Check banned API lookup (handles MSBuildTask0001, 0002, 0004)
             if (bannedApiLookup.TryGetValue(referencedSymbol, out var entry))
             {
-                // MSBuildTask0002 (TaskEnvironment) is gated by scope setting
-                if (entry.Category == BannedApiDefinitions.ApiCategory.TaskEnvironment && !reportEnvironmentRules)
+                if (!reportScopedRules)
                 {
                     return;
                 }
@@ -180,7 +178,7 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
 
             // Type-level Console ban: ANY member of System.Console is flagged.
             // This catches all Console methods/properties including ones added in newer .NET versions.
-            if (consoleType is not null)
+            if (reportScopedRules && consoleType is not null)
             {
                 var containingType = referencedSymbol.ContainingType;
                 if (containingType is not null && SymbolEqualityComparer.Default.Equals(containingType, consoleType))
@@ -198,7 +196,7 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
             }
 
             // Check file path APIs (MSBuildTask0003) - gated by scope setting
-            if (reportEnvironmentRules && !arguments.IsDefaultOrEmpty)
+            if (reportScopedRules && !arguments.IsDefaultOrEmpty)
             {
                 var method = referencedSymbol as IMethodSymbol;
                 if (method is not null)

--- a/src/TaskAnalyzer/MultiThreadableTaskCodeFixProvider.cs
+++ b/src/TaskAnalyzer/MultiThreadableTaskCodeFixProvider.cs
@@ -154,9 +154,12 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                     // Only offer fix for single-argument overload
                     if (invocation.ArgumentList.Arguments.Count == 1)
                     {
-                        RegisterSimpleReplacement(context, diagnostic, invocation,
-                            "TaskEnvironment", "GetAbsolutePath",
-                            "Use TaskEnvironment.GetAbsolutePath()");
+                        context.RegisterCodeFix(
+                            CodeAction.Create(
+                                title: "Use TaskEnvironment.GetAbsolutePath().GetCanonicalForm().Value",
+                                createChangedDocument: ct => ReplaceGetFullPathAsync(context.Document, invocation, ct),
+                                equivalenceKey: "UseTaskEnvironmentCanonicalPath"),
+                            diagnostic);
                     }
                     return;
                 }
@@ -191,6 +194,35 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                         diagnostic);
                 }
             }
+        }
+
+        private static async Task<Document> ReplaceGetFullPathAsync(
+            Document document,
+            InvocationExpressionSyntax invocation,
+            CancellationToken cancellationToken)
+        {
+            DocumentEditor editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
+            ExpressionSyntax argument = invocation.ArgumentList.Arguments[0].Expression;
+            InvocationExpressionSyntax getAbsolutePath = SyntaxFactory.InvocationExpression(
+                SyntaxFactory.MemberAccessExpression(
+                    SyntaxKind.SimpleMemberAccessExpression,
+                    SyntaxFactory.IdentifierName("TaskEnvironment"),
+                    SyntaxFactory.IdentifierName("GetAbsolutePath")),
+                SyntaxFactory.ArgumentList(
+                    SyntaxFactory.SingletonSeparatedList(
+                        SyntaxFactory.Argument(argument))));
+            InvocationExpressionSyntax getCanonicalForm = SyntaxFactory.InvocationExpression(
+                SyntaxFactory.MemberAccessExpression(
+                    SyntaxKind.SimpleMemberAccessExpression,
+                    getAbsolutePath,
+                    SyntaxFactory.IdentifierName("GetCanonicalForm")));
+            MemberAccessExpressionSyntax value = SyntaxFactory.MemberAccessExpression(
+                SyntaxKind.SimpleMemberAccessExpression,
+                getCanonicalForm,
+                SyntaxFactory.IdentifierName("Value"));
+
+            editor.ReplaceNode(invocation, value.WithTriviaFrom(invocation));
+            return editor.GetChangedDocument();
         }
 
         private static void RegisterSimpleReplacement(

--- a/src/TaskAnalyzer/PreferTypedParameterAnalyzer.cs
+++ b/src/TaskAnalyzer/PreferTypedParameterAnalyzer.cs
@@ -83,6 +83,11 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
 
         private static void OnCompilationStart(CompilationStartAnalysisContext compilationContext)
         {
+            if (!SharedAnalyzerHelpers.IsAnalyzerEnabled(compilationContext.Options.AnalyzerConfigOptionsProvider))
+            {
+                return;
+            }
+
             if (!TryResolveWellKnownTaskTypes(compilationContext.Compilation, out WellKnownTaskTypes types))
             {
                 return;

--- a/src/TaskAnalyzer/PreferTypedParameterCodeFixProvider.cs
+++ b/src/TaskAnalyzer/PreferTypedParameterCodeFixProvider.cs
@@ -562,8 +562,8 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
         /// MSBuildTask0006: rewrites the site where a retyped path property is used. Handles three shapes:
         /// <list type="bullet">
         /// <item><c>new T(prop)</c> / <c>TaskEnvironment.GetAbsolutePath(prop)</c> collapses to <c>prop</c>.</item>
-        /// <item><c>Path.GetFullPath(prop)</c> (the banned normalization) collapses to <c>prop</c> for AbsolutePath,
-        /// or <c>prop.FullName</c> for FileInfo/DirectoryInfo, since the retyped value is already absolute.</item>
+        /// <item><c>Path.GetFullPath(prop)</c> becomes <c>prop.GetCanonicalForm().Value</c> for AbsolutePath,
+        /// or <c>prop.FullName</c> for FileInfo/DirectoryInfo, preserving canonicalization.</item>
         /// <item>A raw string consumption (<c>File.Delete(prop)</c>, <c>new FileStream(prop, ...)</c>) needs no edit
         /// for AbsolutePath (it converts to string implicitly), or <c>prop.FullName</c> for FileInfo/DirectoryInfo.</item>
         /// </list>
@@ -591,12 +591,11 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                 return true;
             }
 
-            // Banned normalization site: Path.GetFullPath(prop). The retyped value is already absolute, so the
-            // whole call collapses to the property (AbsolutePath, implicitly a string) or its absolute string.
+            // Banned normalization site: Path.GetFullPath(prop). Preserve its canonicalization and string result.
             if (IsPathGetFullPathInvocation(semanticModel, propertyAccess, cancellationToken, out var getFullPath))
             {
                 ExpressionSyntax replacement = (suggestedType == "AbsolutePath"
-                        ? (ExpressionSyntax)propertyAccess.WithoutTrivia()
+                        ? AppendCanonicalValue(propertyAccess)
                         : AppendFullName(propertyAccess))
                     .WithTriviaFrom(getFullPath)
                     .WithAdditionalAnnotations(Formatter.Annotation);
@@ -632,6 +631,20 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
             }
 
             return false;
+        }
+
+        private static MemberAccessExpressionSyntax AppendCanonicalValue(ExpressionSyntax expression)
+        {
+            InvocationExpressionSyntax canonicalForm = SyntaxFactory.InvocationExpression(
+                SyntaxFactory.MemberAccessExpression(
+                    SyntaxKind.SimpleMemberAccessExpression,
+                    expression.WithoutTrivia(),
+                    SyntaxFactory.IdentifierName("GetCanonicalForm")));
+
+            return SyntaxFactory.MemberAccessExpression(
+                SyntaxKind.SimpleMemberAccessExpression,
+                canonicalForm,
+                SyntaxFactory.IdentifierName("Value"));
         }
 
         /// <summary>

--- a/src/TaskAnalyzer/README.md
+++ b/src/TaskAnalyzer/README.md
@@ -4,27 +4,56 @@ A Roslyn analyzer that detects unsafe API usage in MSBuild task implementations.
 
 The package also includes a Roslyn diagnostic suppressor for nullable warning `CS8618` on task properties marked with `Microsoft.Build.Framework.RequiredAttribute`, since MSBuild guarantees those inputs are initialized before task execution.
 
+## Audience
+
+This guide is for authors and maintainers of C# MSBuild tasks. It also supports teams that plan to migrate existing tasks to multithreaded execution.
+
+## Installation and activation
+
+TaskAnalyzer is delivered in `Microsoft.Build.Framework` package versions that contain `Microsoft.Build.TaskAuthoring.Analyzer.dll`. Add or update the package reference:
+
+```xml
+<ItemGroup>
+  <PackageReference Include="Microsoft.Build.Framework" Version="18.11.0" />
+</ItemGroup>
+```
+
+NuGet adds `Microsoft.Build.TaskAuthoring.Analyzer.dll` to the C# compiler. The analyzer runs during normal `dotnet build`, MSBuild, IDE, and solution builds.
+
+Older `Microsoft.Build.Framework` package versions do not contain TaskAnalyzer. Use a package version that includes the analyzer asset.
+
+The default scope does not apply MT-specific diagnostics to regular tasks. These diagnostics become active for these types:
+
+- Implements `IMultiThreadableTask`.
+- Declares `[MSBuildMultiThreadableTask]`.
+- Declares `[MSBuildMultiThreadableTaskAnalyzed]` on a helper type.
+- Enables migration mode explicitly.
+
+Analyzer activation does not enable in-process MT execution. Apply `[MSBuildMultiThreadableTask]` directly to each task that can safely run in-process.
+
+MSBuildTask0009 and MSBuildTask0010 always analyze typed task properties. Their findings identify task-parameter binding problems that are not specific to MT execution.
+
 ## Background
 
 MSBuild is introducing multithreaded task execution via `IMultiThreadableTask`. Tasks opting into this mode share a process and can no longer safely use process-global state like environment variables, the current directory, or `Console` output. The `TaskEnvironment` abstraction provides per-task isolated access to these resources.
 
 This analyzer catches unsafe API usage at compile time and offers code fixes to migrate to the safe `TaskEnvironment` alternatives.
 
-## Diagnostic Rules
+## Diagnostic rules
 
-| ID | Severity | Scope | Title |
-|---|---|---|---|
-| **MSBuildTask0001** | Error | MT tasks by default; all tasks in migration mode | API is never safe in MSBuild tasks |
-| **MSBuildTask0002** | Warning | MT tasks by default; all tasks in migration mode | API requires `TaskEnvironment` alternative |
-| **MSBuildTask0003** | Warning | MT tasks by default; all tasks in migration mode | File system API requires absolute path |
-| **MSBuildTask0004** | Warning | MT tasks by default; all tasks in migration mode | API may cause issues in multithreaded tasks |
-| **MSBuildTask0005** | Warning | MT tasks by default; all tasks in migration mode | Transitive unsafe API usage in task call chain |
-| **MSBuildTask0006** | Info | Tasks with `[MSBuildMultiThreadableTask]` applied directly | Prefer typed path parameter over string |
-| **MSBuildTask0007** | Info | Tasks with `[MSBuildMultiThreadableTask]` applied directly | Prefer `ITaskItem<T>` over manual ItemSpec parsing |
-| **MSBuildTask0008** | Info | Tasks with `[MSBuildMultiThreadableTask]` applied directly | Initialize a relative-default path property in `Execute()` |
-| **MSBuildTask0009** | Error | All `ITask` implementations with typed task properties | `ITaskItem<T>` used with unsupported type argument |
-| **MSBuildTask0010** | Warning | All `ITask` implementations with typed task properties | `ITaskItem<T>` relies on culture-sensitive conversion |
-| **MSBuildTask0011** | Info | Concrete `IMultiThreadableTask` implementations | Prefer constructor injection for `TaskEnvironment` |
+| ID | Severity | Scope | Cause | Corrective action |
+|---|---|---|---|---|
+| **MSBuildTask0001** | Error | MT tasks by default; regular tasks in migration mode | The task uses an API that can terminate or corrupt the MSBuild process. | Remove the API call. Use MSBuild logging and normal task failure reporting. |
+| **MSBuildTask0002** | Warning | MT tasks by default; regular tasks in migration mode | The task reads or changes process-global state. | Use the named `TaskEnvironment` replacement. |
+| **MSBuildTask0003** | Warning | MT tasks by default; regular tasks in migration mode | A file API receives a path that is not known to be absolute. | Use `TaskEnvironment.GetAbsolutePath`, `AbsolutePath`, or a typed file-system object. |
+| **MSBuildTask0004** | Warning | MT tasks by default; regular tasks in migration mode | The task loads an assembly through an API that can conflict in a shared host. | Use normal task dependencies or review the load-context design. |
+| **MSBuildTask0005** | Warning | MT tasks by default; regular tasks in migration mode | A source helper called by the task contains an unsafe API. | Follow the reported call chain and correct the underlying API use. |
+| **MSBuildTask0006** | Warning | Tasks with `[MSBuildMultiThreadableTask]` applied directly | A string task parameter is converted to a path type. | Change the property to `AbsolutePath`, `FileInfo`, or `DirectoryInfo`. |
+| **MSBuildTask0007** | Warning | Tasks with `[MSBuildMultiThreadableTask]` applied directly | The task parses `ITaskItem.ItemSpec` manually. | Change the property to `ITaskItem<T>` and use `Value`. |
+| **MSBuildTask0008** | Warning | Tasks with `[MSBuildMultiThreadableTask]` applied directly | A path property has a relative initializer that cannot use `TaskEnvironment`. | Root the guarded default in `Execute`. |
+| **MSBuildTask0009** | Error | All `ITask` implementations | `ITaskItem<T>` uses a type that MSBuild cannot bind. | Use a supported type or receive a string and parse it explicitly. |
+| **MSBuildTask0010** | Warning | All `ITask` implementations | `ITaskItem<T>` uses `Convert.ChangeType` with invariant culture. | Use string parsing when the task requires different conversion rules. |
+| **MSBuildTask0011** | Info | Concrete `IMultiThreadableTask` implementations | The task receives `TaskEnvironment` only after construction. | Add a public constructor that accepts one `TaskEnvironment`. |
 
 ### MSBuildTask0001 — Critical: No Safe Alternative
 
@@ -55,12 +84,23 @@ These APIs access process-global state that varies per task in multithreaded mod
 | `Environment.SetEnvironmentVariable()` | `TaskEnvironment.SetEnvironmentVariable()` |
 | `Environment.GetEnvironmentVariables()` | `TaskEnvironment.GetEnvironmentVariables()` |
 | `Environment.ExpandEnvironmentVariables()` | Use `TaskEnvironment.GetEnvironmentVariable()` per variable |
-| `Environment.GetFolderPath()` | Use `TaskEnvironment.GetEnvironmentVariable()` |
-| `Path.GetFullPath()` | `TaskEnvironment.GetAbsolutePath()` |
-| `Path.GetTempPath()` | `TaskEnvironment.GetEnvironmentVariable("TMP")` |
-| `Path.GetTempFileName()` | `TaskEnvironment.GetEnvironmentVariable("TMP")` |
-| `Process.Start()` (all overloads) | `TaskEnvironment.GetProcessStartInfo()` |
+| `Path.GetFullPath()` | `TaskEnvironment.GetAbsolutePath(path).GetCanonicalForm().Value` |
+| `Process.Start()` overloads that accept strings | Create a `ProcessStartInfo` with `TaskEnvironment.GetProcessStartInfo()` |
 | `new ProcessStartInfo()` (all overloads) | `TaskEnvironment.GetProcessStartInfo()` |
+
+The analyzer does not diagnose target-specific environment-variable overloads or `Environment.GetFolderPath`. `TaskEnvironment` does not provide equivalent behavior.
+
+### Temporary paths and files
+
+`Path.GetTempPath()` returns a directory path. It does not create a directory or file.
+
+`Path.GetTempFileName()` creates a unique, empty file and returns its path. Reading `TMP` does not reproduce this behavior.
+
+TaskAnalyzer does not diagnose these methods until MSBuild provides equivalent APIs. Do not replace either method with `TaskEnvironment.GetEnvironmentVariable("TMP")`.
+
+For an MT task, prefer an `AbsolutePath` input that supplies a temporary directory. If that design is not possible, do not opt the task into MT execution.
+
+Work on a task-scoped temporary directory continues in [PR #14729](https://github.com/dotnet/msbuild/pull/14729). A task-scoped temporary-file API is tracked by [issue #14723](https://github.com/dotnet/msbuild/issues/14723).
 
 ### MSBuildTask0003 — File Paths Must Be Absolute
 
@@ -130,7 +170,7 @@ public class MyTask : Task
 }
 ```
 
-The last four patterns are the same raw-string shapes that MSBuildTask0002 (`Path.GetFullPath`) and MSBuildTask0003 (a raw string flowing into a `System.IO` path parameter) flag. Surfacing them under MSBuildTask0006 as well means the property can be retyped in **one shot** instead of first applying the 0002/0003 fix (which only introduces a conversion) and then being told to apply 0006. The code fix rewrites each raw site as part of the retype: `Path.GetFullPath(prop)` collapses to `prop` (or `prop.FullName`), and a raw string consumption is fed through `prop.FullName` for `FileInfo`/`DirectoryInfo` (or left unchanged for `AbsolutePath`, which converts to `string` implicitly). Arguments already rooted through `TaskEnvironment.GetAbsolutePath`/`new AbsolutePath(...)` are not re-flagged.
+The last four patterns are the same raw-string shapes that MSBuildTask0002 (`Path.GetFullPath`) and MSBuildTask0003 (a raw string flowing into a `System.IO` path parameter) flag. Surfacing them under MSBuildTask0006 as well means the property can be retyped in **one shot** instead of first applying the 0002/0003 fix (which only introduces a conversion) and then being told to apply 0006. The code fix preserves `Path.GetFullPath` canonicalization through `GetCanonicalForm().Value`. A raw string consumption uses `prop.FullName` for `FileInfo`/`DirectoryInfo`, or the implicit string conversion for `AbsolutePath`. Arguments already rooted through `TaskEnvironment.GetAbsolutePath` or `new AbsolutePath(...)` are not re-flagged.
 
 **Not flagged:** `[Output]` properties, non-public properties, read-only properties, values from method calls or literals.
 
@@ -299,7 +339,17 @@ The default `multithreadable_only` scope prevents MT-specific warnings from affe
 | Helper class with `[MSBuildMultiThreadableTaskAnalyzed]` attribute | MSBuildTask0001–MSBuildTask0004 |
 | Regular class (no task interface or attribute) | Not analyzed |
 
-Create a `.globalconfig` file to analyze regular tasks for MSBuildTask0001–MSBuildTask0005 before MT migration:
+Set `MSBuildTaskAnalyzerScope` to `all` to analyze regular tasks before MT migration:
+
+```xml
+<PropertyGroup>
+  <MSBuildTaskAnalyzerScope>all</MSBuildTaskAnalyzerScope>
+</PropertyGroup>
+```
+
+Migration mode can add warnings and errors to existing task projects. Run it on a migration branch before you enable it for continuous integration.
+
+You can also create a `.globalconfig` file:
 
 ```ini
 is_global = true
@@ -307,6 +357,55 @@ msbuild_task_analyzer.scope = all
 ```
 
 Missing and unrecognized values use the safe `multithreadable_only` default.
+
+## Configuration
+
+Set these properties in the task project or in `Directory.Build.props`:
+
+| Property | Values | Default | Result |
+|---|---|---|---|
+| `MSBuildTaskAnalyzerEnabled` | `true`, `false` | `true` | `false` disables all TaskAnalyzer diagnostics and its `CS8618` suppression. |
+| `MSBuildTaskAnalyzerScope` | `multithreadable_only`, `all` | `multithreadable_only` | `all` enables MSBuildTask0001–MSBuildTask0005 for regular tasks. |
+
+An invalid `MSBuildTaskAnalyzerEnabled` value keeps the analyzer enabled. An invalid scope value keeps the MT-only scope.
+
+A nonempty MSBuild property takes precedence over the corresponding `.globalconfig` key. An empty property uses `.globalconfig`, then the safe default.
+
+### Disable TaskAnalyzer
+
+Disable TaskAnalyzer only when a project cannot use it:
+
+```xml
+<PropertyGroup>
+  <MSBuildTaskAnalyzerEnabled>false</MSBuildTaskAnalyzerEnabled>
+</PropertyGroup>
+```
+
+This property does not disable other Roslyn analyzers.
+
+### Suppress one diagnostic
+
+Use standard compiler configuration to suppress a diagnostic:
+
+```xml
+<PropertyGroup>
+  <NoWarn>$(NoWarn);MSBuildTask0004</NoWarn>
+</PropertyGroup>
+```
+
+You can also set `dotnet_diagnostic.MSBuildTask0004.severity = none` in `.editorconfig`.
+
+### Warnings as errors
+
+TaskAnalyzer uses standard compiler severity controls. `TreatWarningsAsErrors` changes TaskAnalyzer warnings to build errors:
+
+```xml
+<PropertyGroup>
+  <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+</PropertyGroup>
+```
+
+MSBuildTask0001 and MSBuildTask0009 are errors without this property. MSBuildTask0006–MSBuildTask0008 are warnings. MSBuildTask0011 is informational.
 
 MSBuildTask0006–MSBuildTask0008 apply only when the `[MSBuildMultiThreadableTask]` attribute is applied **directly** to the task class. The attribute is `Inherited = false`, so a task that merely derives from a base class implementing `IMultiThreadableTask` (or carrying the attribute) has not itself opted into multithreaded support and is not subject to these three rules. Input properties are collected from the task class **and its base classes**, so an `ITaskItem`/`string` input declared on a shared base task is still analyzed.
 
@@ -318,7 +417,8 @@ The `[MSBuildMultiThreadableTaskAnalyzed]` attribute allows opting helper classe
 
 - **MSBuildTask0001 and MSBuildTask0009** report as **Error** when their scope applies.
 - **MSBuildTask0002–MSBuildTask0005 and MSBuildTask0010** report as **Warning** when their scope applies.
-- **MSBuildTask0006–MSBuildTask0008 and MSBuildTask0011** report as **Info** — these are modernization suggestions, not correctness issues.
+- **MSBuildTask0006–MSBuildTask0008** report as **Warning**.
+- **MSBuildTask0011** reports as **Info**.
 
 ## Code Fixes
 
@@ -329,13 +429,13 @@ The analyzer ships with a code fix provider that offers automatic replacements:
 | MSBuildTask0002: `Environment.GetEnvironmentVariable(x)` | → `TaskEnvironment.GetEnvironmentVariable(x)` |
 | MSBuildTask0002: `Environment.SetEnvironmentVariable(x, y)` | → `TaskEnvironment.SetEnvironmentVariable(x, y)` |
 | MSBuildTask0002: `Environment.GetEnvironmentVariables()` | → `TaskEnvironment.GetEnvironmentVariables()` |
-| MSBuildTask0002: `Path.GetFullPath(x)` | → `TaskEnvironment.GetAbsolutePath(x)` |
+| MSBuildTask0002: `Path.GetFullPath(x)` | → `TaskEnvironment.GetAbsolutePath(x).GetCanonicalForm().Value` |
 | MSBuildTask0002: `Environment.CurrentDirectory` | → `TaskEnvironment.ProjectDirectory` |
 | MSBuildTask0002: `Directory.GetCurrentDirectory()` | → `TaskEnvironment.ProjectDirectory` |
 | MSBuildTask0003: `File.Exists(relativePath)` | → `File.Exists(TaskEnvironment.GetAbsolutePath(relativePath))` |
 | MSBuildTask0006: `new AbsolutePath(InputPath)` | → Retype `InputPath` to `AbsolutePath` and replace conversion with direct property usage |
 | MSBuildTask0006: `new FileInfo(FilePath)` / `new DirectoryInfo(DirPath)` | → Retype property to `FileInfo`/`DirectoryInfo` and replace conversion with direct property usage |
-| MSBuildTask0006: `Path.GetFullPath(InputPath)` | → Retype `InputPath` to `AbsolutePath` and collapse the call to the property (one-shot for the 0002 shape) |
+| MSBuildTask0006: `Path.GetFullPath(InputPath)` | → Retype `InputPath` to `AbsolutePath` and preserve canonicalization with `GetCanonicalForm().Value` |
 | MSBuildTask0006: `File.Delete(Target)` / `Directory.CreateDirectory(Folder)` | → Retype property to `FileInfo`/`DirectoryInfo` and feed the string API through `.FullName` (one-shot for the 0003 shape) |
 | MSBuildTask0007: `int.Parse(Item.ItemSpec)` | → Retype `Item` to ``ITaskItem<int>`` and replace parse with `Item.Value` |
 | MSBuildTask0007: `new FileInfo(item.ItemSpec)` in `foreach` over `ITaskItem[]` | → Retype source property to ``ITaskItem<FileInfo>[]`` and replace with `item.Value` |
@@ -358,86 +458,59 @@ The analyzer package suppresses `CS8618` for non-nullable properties when all of
 
 This lets task authors omit manual `= null!;` initializers for required MSBuild task inputs.
 
-## Installation
+## Common migrations
 
-### Project Reference (development)
-
-Reference the analyzer project directly:
-
-```xml
-<ItemGroup>
-  <ProjectReference Include="..\TaskAnalyzer\TaskAnalyzer.csproj"
-                    OutputItemType="Analyzer"
-                    ReferenceOutputAssembly="false" />
-</ItemGroup>
-```
-
-### NuGet Package (future)
-
-When packaged as a NuGet analyzer, add it as a package reference:
-
-```xml
-<ItemGroup>
-  <PackageReference Include="Microsoft.Build.TaskAuthoring.Analyzer" Version="1.0.0"
-                    PrivateAssets="all" />
-</ItemGroup>
-```
-
-### MSBuild Tasks Build
-
-To enable the analyzer in the MSBuild Tasks project build, pass `/p:BuildAnalyzer=true`:
-
-```
-dotnet build src/Tasks/Microsoft.Build.Tasks.csproj /p:BuildAnalyzer=true
-```
-
-## Example
-
-**Before** (unsafe):
+### Environment variables
 
 ```csharp
-public class CopyFiles : Task, IMultiThreadableTask
-{
-    public TaskEnvironment TaskEnvironment { get; set; }
-    public string Source { get; set; }
-    public string Destination { get; set; }
+string? value = TaskEnvironment.GetEnvironmentVariable("MY_SETTING");
+TaskEnvironment.SetEnvironmentVariable("MY_RESULT", value);
+```
 
-    public override bool Execute()
-    {
-        Console.WriteLine("Copying files...");          // ❌ MSBuildTask0001
-        var tmp = Path.GetTempPath();                    // ❌ MSBuildTask0002
-        var envVar = Environment.GetEnvironmentVariable("MY_VAR"); // ❌ MSBuildTask0002
-        File.Copy(Source, Destination);                  // ❌ MSBuildTask0003 (×2)
-        return true;
-    }
+Use `TaskEnvironment` for process-scoped variables. The target-specific `EnvironmentVariableTarget.User` and `EnvironmentVariableTarget.Machine` values have no task-scoped replacement.
+
+### Path resolution and file APIs
+
+```csharp
+AbsolutePath source = TaskEnvironment.GetAbsolutePath(Source);
+AbsolutePath destination = TaskEnvironment.GetAbsolutePath(Destination);
+
+if (File.Exists(source))
+{
+    File.Copy(source, destination);
 }
 ```
 
-**After** (safe):
+`GetAbsolutePath` resolves relative paths against `TaskEnvironment.ProjectDirectory`. Do not resolve task paths against the process working directory.
+
+`GetAbsolutePath` does not remove `.` or `..` segments. Call `GetCanonicalForm()` when code requires the canonical behavior of `Path.GetFullPath`.
+
+### Process creation
 
 ```csharp
-public class CopyFiles : Task, IMultiThreadableTask
-{
-    public TaskEnvironment TaskEnvironment { get; set; }
-    public string Source { get; set; }
-    public string Destination { get; set; }
+ProcessStartInfo startInfo = TaskEnvironment.GetProcessStartInfo();
+startInfo.FileName = TaskEnvironment.GetAbsolutePath(ToolPath);
+startInfo.Arguments = Arguments;
 
-    public override bool Execute()
-    {
-        Log.LogMessage("Copying files...");              // ✅ Use build logging
-        var tmp = TaskEnvironment.GetEnvironmentVariable("TMP"); // ✅ Per-task env
-        var envVar = TaskEnvironment.GetEnvironmentVariable("MY_VAR"); // ✅ Per-task env
-        File.Copy(                                       // ✅ Absolute paths
-            TaskEnvironment.GetAbsolutePath(Source),
-            TaskEnvironment.GetAbsolutePath(Destination));
-        return true;
-    }
-}
+using Process? process = Process.Start(startInfo);
+process?.WaitForExit();
 ```
+
+`GetProcessStartInfo` copies the task environment and project directory into the new process configuration. Resolve a relative executable path before `Process.Start`.
+
+## Known limitations
+
+- MSBuildTask0005 follows calls only when source is available in the current compilation.
+- MSBuildTask0005 does not inspect helper methods in referenced binaries.
+- MSBuildTask0005 limits call-chain traversal to prevent excessive analysis time.
+- MSBuildTask0003 recognizes common file APIs and path parameter names. It cannot prove every custom path flow.
+- Code fixes are conservative. A diagnostic can remain without an automatic fix.
+- TaskAnalyzer supports C# projects. The package path is `analyzers/dotnet/cs`.
+- Temporary-path methods have no automated recommendation until equivalent `TaskEnvironment` APIs ship.
 
 ## Tests
 
-193 tests covering all rules, safe patterns, edge cases, code fixes, and compiler diagnostic suppression:
+The test suite covers all rules, safe patterns, configuration, code fixes, and compiler diagnostic suppression:
 
 ```
 cd src/TaskAnalyzer.Tests
@@ -473,4 +546,3 @@ dotnet test
 - [Analyzer Implementation PR](https://github.com/dotnet/msbuild/pull/12143)
 - [IMultiThreadableTask Interface](../Framework/IMultiThreadableTask.cs)
 - [TaskEnvironment Class](../Framework/TaskEnvironment.cs)
-- [Migration Skill Guide](../../.github/skills/multithreaded-task-migration/SKILL.md)

--- a/src/TaskAnalyzer/README.md
+++ b/src/TaskAnalyzer/README.md
@@ -14,16 +14,16 @@ This analyzer catches unsafe API usage at compile time and offers code fixes to 
 
 | ID | Severity | Scope | Title |
 |---|---|---|---|
-| **MSBuildTask0001** | Error | All `ITask` implementations | API is never safe in MSBuild tasks |
-| **MSBuildTask0002** | Warning | All `ITask` implementations | API requires `TaskEnvironment` alternative |
-| **MSBuildTask0003** | Warning | All `ITask` implementations | File system API requires absolute path |
-| **MSBuildTask0004** | Warning | All `ITask` implementations | API may cause issues in multithreaded tasks |
-| **MSBuildTask0005** | Warning | All `ITask` implementations | Transitive unsafe API usage in task call chain |
-| **MSBuildTask0006** | Warning | Tasks with `[MSBuildMultiThreadableTask]` applied directly | Prefer typed path parameter over string |
-| **MSBuildTask0007** | Warning | Tasks with `[MSBuildMultiThreadableTask]` applied directly | Prefer `ITaskItem<T>` over manual ItemSpec parsing |
-| **MSBuildTask0008** | Warning | Tasks with `[MSBuildMultiThreadableTask]` applied directly | Initialize a relative-default path property in `Execute()` |
-| **MSBuildTask0009** | Warning | All `ITask` implementations | `ITaskItem<T>` used with unsupported type argument |
-| **MSBuildTask0010** | Error | All `ITask` implementations | `ITaskItem<T>` relies on culture-sensitive conversion |
+| **MSBuildTask0001** | Error | MT tasks by default; all tasks in migration mode | API is never safe in MSBuild tasks |
+| **MSBuildTask0002** | Warning | MT tasks by default; all tasks in migration mode | API requires `TaskEnvironment` alternative |
+| **MSBuildTask0003** | Warning | MT tasks by default; all tasks in migration mode | File system API requires absolute path |
+| **MSBuildTask0004** | Warning | MT tasks by default; all tasks in migration mode | API may cause issues in multithreaded tasks |
+| **MSBuildTask0005** | Warning | MT tasks by default; all tasks in migration mode | Transitive unsafe API usage in task call chain |
+| **MSBuildTask0006** | Info | Tasks with `[MSBuildMultiThreadableTask]` applied directly | Prefer typed path parameter over string |
+| **MSBuildTask0007** | Info | Tasks with `[MSBuildMultiThreadableTask]` applied directly | Prefer `ITaskItem<T>` over manual ItemSpec parsing |
+| **MSBuildTask0008** | Info | Tasks with `[MSBuildMultiThreadableTask]` applied directly | Initialize a relative-default path property in `Execute()` |
+| **MSBuildTask0009** | Error | All `ITask` implementations with typed task properties | `ITaskItem<T>` used with unsupported type argument |
+| **MSBuildTask0010** | Warning | All `ITask` implementations with typed task properties | `ITaskItem<T>` relies on culture-sensitive conversion |
 | **MSBuildTask0011** | Info | Concrete `IMultiThreadableTask` implementations | Prefer constructor injection for `TaskEnvironment` |
 
 ### MSBuildTask0001 — Critical: No Safe Alternative
@@ -230,19 +230,19 @@ For a reference-typed target (`FileInfo`/`DirectoryInfo`) the guard is a null-co
 
 ### MSBuildTask0009 — Unsupported `ITaskItem<T>` Type Argument
 
-When a task property is typed as `ITaskItem<T>` or `ITaskItem<T>[]` but `T` is not supported by MSBuild's task parameter binder, a **Warning** is emitted. Using an unsupported type will cause a runtime failure when MSBuild tries to bind the parameter.
+When a task property is typed as `ITaskItem<T>` or `ITaskItem<T>[]` but `T` is not supported by MSBuild's task parameter binder, an **Error** is emitted. Using an unsupported type will cause a runtime failure when MSBuild tries to bind the parameter.
 
 **Directly parsed type arguments:** `string`, `bool`, `AbsolutePath`, `FileInfo`, `DirectoryInfo`.
 
 The binder also accepts `char`, numeric primitives, `decimal`, and `DateTime`, but MSBuildTask0010 rejects those types because they rely on `Convert.ChangeType`.
 
 ```csharp
-// ⚠️ MSBuildTask0009: Task property 'Id' uses ITaskItem<Guid> but 'Guid' is not supported
+// ❌ MSBuildTask0009: Task property 'Id' uses ITaskItem<Guid> but 'Guid' is not supported
 public class MyTask : Task
 {
-    public ITaskItem<System.Guid> Id { get; set; }       // warning
-    public ITaskItem<System.TimeSpan>[] Durations { get; set; }  // warning
-    public ITaskItem<int> Count { get; set; }             // MSBuildTask0010 error
+    public ITaskItem<System.Guid> Id { get; set; }       // error
+    public ITaskItem<System.TimeSpan>[] Durations { get; set; }  // error
+    public ITaskItem<int> Count { get; set; }             // MSBuildTask0010 warning
 }
 ```
 
@@ -252,13 +252,13 @@ No code fix is offered for MSBuildTask0009 — the resolution depends on the int
 
 ### MSBuildTask0010 — Culture-Sensitive `ITaskItem<T>` Conversion
 
-MSBuild binds `ITaskItem<T>` for `char`, numeric primitives, `decimal`, and `DateTime` through `Convert.ChangeType` using `CultureInfo.InvariantCulture`. Because this implicit conversion may not match the task's intended culture, the analyzer reports an **Error** whenever one of these types is used.
+MSBuild binds `ITaskItem<T>` for `char`, numeric primitives, `decimal`, and `DateTime` through `Convert.ChangeType` using `CultureInfo.InvariantCulture`. Because this implicit conversion may not match the task's intended culture, the analyzer reports a **Warning** whenever one of these types is used.
 
 ```csharp
 public class MyTask : Task
 {
-    public ITaskItem<int> Count { get; set; }       // error
-    public ITaskItem<DateTime>[] Dates { get; set; } // error
+    public ITaskItem<int> Count { get; set; }       // warning
+    public ITaskItem<DateTime>[] Dates { get; set; } // warning
 }
 ```
 
@@ -289,15 +289,24 @@ The engine prefers this constructor when it is present. A public parameterless c
 
 ## Analysis Scope
 
-The analyzer determines what to check based on the type declaration:
+The default `multithreadable_only` scope prevents MT-specific warnings from affecting regular tasks. It recognizes `IMultiThreadableTask`, `[MSBuildMultiThreadableTask]`, and `[MSBuildMultiThreadableTaskAnalyzed]` as MT opt-ins.
 
 | Type | Rules Applied |
 |---|---|
-| Any class implementing `ITask` | MSBuildTask0001–MSBuildTask0005, MSBuildTask0009–MSBuildTask0010 |
+| Regular class implementing `ITask` | MSBuildTask0009–MSBuildTask0010 |
 | Class with `[MSBuildMultiThreadableTask]` attribute applied directly | MSBuildTask0006–MSBuildTask0008 (in addition to MSBuildTask0001–0005) |
 | Concrete class implementing `IMultiThreadableTask` without the attribute | MSBuildTask0001–MSBuildTask0005 and MSBuildTask0009–MSBuildTask0011 |
-| Helper class with `[MSBuildMultiThreadableTaskAnalyzed]` attribute | MSBuildTask0001–MSBuildTask0005 |
+| Helper class with `[MSBuildMultiThreadableTaskAnalyzed]` attribute | MSBuildTask0001–MSBuildTask0004 |
 | Regular class (no task interface or attribute) | Not analyzed |
+
+Create a `.globalconfig` file to analyze regular tasks for MSBuildTask0001–MSBuildTask0005 before MT migration:
+
+```ini
+is_global = true
+msbuild_task_analyzer.scope = all
+```
+
+Missing and unrecognized values use the safe `multithreadable_only` default.
 
 MSBuildTask0006–MSBuildTask0008 apply only when the `[MSBuildMultiThreadableTask]` attribute is applied **directly** to the task class. The attribute is `Inherited = false`, so a task that merely derives from a base class implementing `IMultiThreadableTask` (or carrying the attribute) has not itself opted into multithreaded support and is not subject to these three rules. Input properties are collected from the task class **and its base classes**, so an `ITaskItem`/`string` input declared on a shared base task is still analyzed.
 
@@ -307,10 +316,9 @@ The `[MSBuildMultiThreadableTaskAnalyzed]` attribute allows opting helper classe
 
 ### Severity Levels
 
-- **MSBuildTask0001** is always **Error** — these APIs are never safe in any MSBuild task.
-- **MSBuildTask0010** is always **Error** — task item conversions must not rely on `Convert.ChangeType`.
-- **MSBuildTask0002–MSBuildTask0009** report as **Warning**, with MSBuildTask0006–MSBuildTask0008 limited to tasks directly marked with `[MSBuildMultiThreadableTask]`.
-- **MSBuildTask0011** reports as **Info** — it is a modernization suggestion rather than a correctness issue.
+- **MSBuildTask0001 and MSBuildTask0009** report as **Error** when their scope applies.
+- **MSBuildTask0002–MSBuildTask0005 and MSBuildTask0010** report as **Warning** when their scope applies.
+- **MSBuildTask0006–MSBuildTask0008 and MSBuildTask0011** report as **Info** — these are modernization suggestions, not correctness issues.
 
 ## Code Fixes
 

--- a/src/TaskAnalyzer/RequiredTaskPropertyInitializationSuppressor.cs
+++ b/src/TaskAnalyzer/RequiredTaskPropertyInitializationSuppressor.cs
@@ -21,6 +21,11 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
 
         public override void ReportSuppressions(SuppressionAnalysisContext context)
         {
+            if (!SharedAnalyzerHelpers.IsAnalyzerEnabled(context.Options.AnalyzerConfigOptionsProvider))
+            {
+                return;
+            }
+
             var requiredAttributeType = context.Compilation.GetTypeByMetadataName(WellKnownTypeNames.RequiredAttributeFullName);
             var iTaskType = context.Compilation.GetTypeByMetadataName(WellKnownTypeNames.ITaskFullName);
             if (requiredAttributeType is null || iTaskType is null)

--- a/src/TaskAnalyzer/SharedAnalyzerHelpers.cs
+++ b/src/TaskAnalyzer/SharedAnalyzerHelpers.cs
@@ -20,9 +20,32 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
         /// The analyzer configuration key controlling analysis scope.
         /// Values: "multithreadable_only" (default) | "all"
         /// </summary>
+        internal const string EnabledOptionKey = "msbuild_task_analyzer.enabled";
+        internal const string EnabledPropertyKey = "MSBuildTaskAnalyzerEnabled";
         internal const string ScopeOptionKey = "msbuild_task_analyzer.scope";
+        internal const string ScopePropertyKey = "MSBuildTaskAnalyzerScope";
         internal const string ScopeAll = "all";
         internal const string ScopeMultiThreadableOnly = "multithreadable_only";
+
+        /// <summary>
+        /// Returns false only when the analyzer is explicitly disabled.
+        /// Missing and invalid values keep the analyzer enabled.
+        /// </summary>
+        internal static bool IsAnalyzerEnabled(AnalyzerConfigOptionsProvider optionsProvider)
+        {
+            if (optionsProvider.GlobalOptions.TryGetValue($"build_property.{EnabledPropertyKey}", out var enabledValue) &&
+                !string.IsNullOrWhiteSpace(enabledValue))
+            {
+                return !bool.TryParse(enabledValue, out bool enabled) || enabled;
+            }
+
+            if (optionsProvider.GlobalOptions.TryGetValue(EnabledOptionKey, out enabledValue))
+            {
+                return !bool.TryParse(enabledValue, out bool enabled) || enabled;
+            }
+
+            return true;
+        }
 
         /// <summary>
         /// Reads the scope option from the analyzer config options provider.
@@ -30,8 +53,13 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
         /// </summary>
         internal static bool ReadAnalyzeAllTasksOption(AnalyzerConfigOptionsProvider optionsProvider)
         {
-            if (optionsProvider.GlobalOptions.TryGetValue($"build_property.{ScopeOptionKey}", out var scopeValue) ||
-                optionsProvider.GlobalOptions.TryGetValue(ScopeOptionKey, out scopeValue))
+            if (optionsProvider.GlobalOptions.TryGetValue($"build_property.{ScopePropertyKey}", out var scopeValue) &&
+                !string.IsNullOrWhiteSpace(scopeValue))
+            {
+                return string.Equals(scopeValue, ScopeAll, StringComparison.OrdinalIgnoreCase);
+            }
+
+            if (optionsProvider.GlobalOptions.TryGetValue(ScopeOptionKey, out scopeValue))
             {
                 return string.Equals(scopeValue, ScopeAll, StringComparison.OrdinalIgnoreCase);
             }

--- a/src/TaskAnalyzer/SharedAnalyzerHelpers.cs
+++ b/src/TaskAnalyzer/SharedAnalyzerHelpers.cs
@@ -17,8 +17,8 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
     internal static class SharedAnalyzerHelpers
     {
         /// <summary>
-        /// The .editorconfig key controlling analysis scope.
-        /// Values: "all" (default) | "multithreadable_only"
+        /// The analyzer configuration key controlling analysis scope.
+        /// Values: "multithreadable_only" (default) | "all"
         /// </summary>
         internal const string ScopeOptionKey = "msbuild_task_analyzer.scope";
         internal const string ScopeAll = "all";
@@ -26,17 +26,17 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
 
         /// <summary>
         /// Reads the scope option from the analyzer config options provider.
-        /// Returns true if all tasks should be analyzed; false if only multithreadable tasks.
+        /// Returns true only when all-task migration analysis is explicitly enabled.
         /// </summary>
         internal static bool ReadAnalyzeAllTasksOption(AnalyzerConfigOptionsProvider optionsProvider)
         {
             if (optionsProvider.GlobalOptions.TryGetValue($"build_property.{ScopeOptionKey}", out var scopeValue) ||
                 optionsProvider.GlobalOptions.TryGetValue(ScopeOptionKey, out scopeValue))
             {
-                return !string.Equals(scopeValue, ScopeMultiThreadableOnly, StringComparison.OrdinalIgnoreCase);
+                return string.Equals(scopeValue, ScopeAll, StringComparison.OrdinalIgnoreCase);
             }
 
-            return true; // default: analyze all tasks
+            return false;
         }
         /// <summary>
         /// Represents a resolved banned API entry for O(1) lookup during analysis.

--- a/src/TaskAnalyzer/TaskEnvironmentConstructorInjectionAnalyzer.cs
+++ b/src/TaskAnalyzer/TaskEnvironmentConstructorInjectionAnalyzer.cs
@@ -25,6 +25,11 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
 
         private static void OnCompilationStart(CompilationStartAnalysisContext context)
         {
+            if (!SharedAnalyzerHelpers.IsAnalyzerEnabled(context.Options.AnalyzerConfigOptionsProvider))
+            {
+                return;
+            }
+
             INamedTypeSymbol? multiThreadableTaskType =
                 context.Compilation.GetTypeByMetadataName(WellKnownTypeNames.IMultiThreadableTaskFullName);
             if (multiThreadableTaskType is null)

--- a/src/TaskAnalyzer/TransitiveCallChainAnalyzer.cs
+++ b/src/TaskAnalyzer/TransitiveCallChainAnalyzer.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                 return;
             }
 
-            // Read scope option from .editorconfig
+            // Read scope option
             bool analyzeAllTasks = SharedAnalyzerHelpers.ReadAnalyzeAllTasksOption(compilationContext.Options.AnalyzerConfigOptionsProvider);
 
             var iMultiThreadableTaskType = compilationContext.Compilation.GetTypeByMetadataName(WellKnownTypeNames.IMultiThreadableTaskFullName);

--- a/src/TaskAnalyzer/TransitiveCallChainAnalyzer.cs
+++ b/src/TaskAnalyzer/TransitiveCallChainAnalyzer.cs
@@ -44,6 +44,11 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
 
         private void OnCompilationStart(CompilationStartAnalysisContext compilationContext)
         {
+            if (!SharedAnalyzerHelpers.IsAnalyzerEnabled(compilationContext.Options.AnalyzerConfigOptionsProvider))
+            {
+                return;
+            }
+
             var iTaskType = compilationContext.Compilation.GetTypeByMetadataName(WellKnownTypeNames.ITaskFullName);
             if (iTaskType is null)
             {

--- a/src/TaskAnalyzer/UnsupportedTaskItemTypeAnalyzer.cs
+++ b/src/TaskAnalyzer/UnsupportedTaskItemTypeAnalyzer.cs
@@ -95,6 +95,13 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
 
                     ITypeSymbol typeArg = namedPropertyType.TypeArguments[0];
 
+                    // A generic task can be constructed with a supported type. Its open type
+                    // parameter does not provide enough information for a binding diagnostic.
+                    if (typeArg.TypeKind == TypeKind.TypeParameter)
+                    {
+                        continue;
+                    }
+
                     if (SupportedTaskItemTypes.IsConvertChangeTypeTaskItemType(typeArg.SpecialType))
                     {
                         symbolContext.ReportDiagnostic(Diagnostic.Create(

--- a/src/TaskAnalyzer/UnsupportedTaskItemTypeAnalyzer.cs
+++ b/src/TaskAnalyzer/UnsupportedTaskItemTypeAnalyzer.cs
@@ -33,6 +33,11 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
 
         private static void OnCompilationStart(CompilationStartAnalysisContext compilationContext)
         {
+            if (!SharedAnalyzerHelpers.IsAnalyzerEnabled(compilationContext.Options.AnalyzerConfigOptionsProvider))
+            {
+                return;
+            }
+
             var iTaskType = compilationContext.Compilation.GetTypeByMetadataName(WellKnownTypeNames.ITaskFullName);
             if (iTaskType is null)
             {


### PR DESCRIPTION
Part of #14078

### Context

TaskAnalyzer needs complete task-author documentation, safe temporary-path guidance, and supported configuration controls before publication. The default behavior must protect regular tasks while allowing explicit migration analysis.

This PR depends on #14811. It is based on that PR's single commit and does not depend on or include #14812.

### Changes Made

- Adds `MSBuildTaskAnalyzerEnabled` and `MSBuildTaskAnalyzerScope` through `CompilerVisibleProperty` package targets.
- Keeps `multithreadable_only` as the safe scope default and supports `all` as explicit migration mode.
- Supports direct `.globalconfig` options, diagnostic suppression, and standard warnings-as-errors behavior.
- Removes diagnostics for temporary-path and other APIs that do not have behavior-equivalent replacements.
- Preserves `Path.GetFullPath` canonicalization in TaskAnalyzer code fixes.
- Adds a complete task-author guide and aligns the MT specification and analyzer release metadata.
- Adds unit and package-consumption coverage for project and solution builds, opt-out, scope, invalid values, `.globalconfig`, suppression, and warnings-as-errors.

### Testing

- `TaskAnalyzer.Tests`: 273 passed.
- `TaskAnalyzerConfiguration_Tests`: 18 passed across net11.0 and net472.
- `build.cmd -v quiet /p:UseSharedCompilation=false`: succeeded with 0 warnings and 0 errors.
- Bootstrap sample build and MSBuild help invocation succeeded.
- Framework package targets were inspected for net11.0 and net472.
- All relative documentation links and referenced GitHub issues and PRs were verified.

### Notes

PR #14812 separately adds the analyzer DLL to `Microsoft.Build.Framework`; this branch intentionally does not include that packaging commit.

`Path.GetTempPath()` remains undiagnosed until #14729 provides the equivalent API. `Path.GetTempFileName()` remains undiagnosed until #14723 provides a file-creating equivalent.