### PR TITLE
[vs17.11] Use WIF for internal feed authentication

### DIFF
--- a/azure-pipelines/.vsts-dotnet-build-jobs.yml
+++ b/azure-pipelines/.vsts-dotnet-build-jobs.yml
@@ -39,13 +39,18 @@ jobs:
 
   - pwsh: Set-MpPreference -DisableRealtimeMonitoring $true
 
+  - template: /eng/common/templates/steps/get-federated-access-token.yml
+    parameters:
+      federatedServiceConnection: dnceng-artifacts-feeds-read
+      outputVariableName: dnceng-artifacts-feeds-read-access-token
+
   - task: PowerShell@2
-    displayName: Setup Private Feeds Credentials
+    displayName: Setup Internal Feeds
     inputs:
       filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.ps1
-      arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $Env:Token
-    env:
-      Token: $(dn-bot-dnceng-artifact-feeds-rw)
+      arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config $(dnceng-artifacts-feeds-read-access-token)
+
+  - task: NuGetAuthenticate@1
 
 
   - task: NuGetCommand@2
@@ -248,4 +253,3 @@ jobs:
       name: $(DncEngInternalBuildPool)
       image: $(WindowsImage)
       os: windows
-

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,7 +2,7 @@
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the MIT license. See License.txt in the project root for full license information. -->
 <Project>
   <PropertyGroup>
-    <VersionPrefix>17.11.65</VersionPrefix>
+    <VersionPrefix>17.11.66</VersionPrefix>
     <DotNetFinalVersionKind>release</DotNetFinalVersionKind>
     <PackageValidationBaselineVersion>17.10.4</PackageValidationBaselineVersion>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>


### PR DESCRIPTION
## Context

Backport #14353 to vs17.11 so official builds use short-lived Workload Identity Federation credentials instead of the legacy internal-feed PAT.

## Changes Made

- Obtain a short-lived Azure DevOps token through the existing federated service connection.
- Use that token to configure internal NuGet feeds.
- Install/configure the Azure Artifacts credential provider with NuGetAuthenticate@1.
- Remove the legacy PAT reference.
- Bump the servicing version to 17.11.66.

## Testing

Validated the YAML structure, token flow, task ordering, removal of the legacy PAT reference, XML structure, and monotonic servicing-version increment.