### PR TITLE
[vs17.14] Use WIF for internal feed authentication

### DIFF
--- a/azure-pipelines/.vsts-dotnet-build-jobs.yml
+++ b/azure-pipelines/.vsts-dotnet-build-jobs.yml
@@ -39,13 +39,7 @@ jobs:
 
   - pwsh: Set-MpPreference -DisableRealtimeMonitoring $true
 
-  - task: PowerShell@2
-    displayName: Setup Private Feeds Credentials
-    inputs:
-      filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.ps1
-      arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $Env:Token
-    env:
-      Token: $(dn-bot-dnceng-artifact-feeds-rw)
+  - template: /eng/common/templates-official/steps/enable-internal-sources.yml
 
 
   - task: NuGetCommand@2

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,7 +2,7 @@
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the MIT license. See License.txt in the project root for full license information. -->
 <Project>
   <PropertyGroup>
-    <VersionPrefix>17.14.58</VersionPrefix>
+    <VersionPrefix>17.14.59</VersionPrefix>
     <DotNetFinalVersionKind>release</DotNetFinalVersionKind>
     <PackageValidationBaselineVersion>17.13.9</PackageValidationBaselineVersion>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>


### PR DESCRIPTION
## Context

Backport #14353 to vs17.14 so official builds use short-lived Workload Identity Federation credentials instead of the legacy internal-feed PAT.

## Changes Made

- Replace the inline PAT-based feed setup with the existing official enable-internal-sources template.
- Remove the legacy PAT reference.
- Match the authentication migration already merged in #14353.
- Bump the servicing version to 17.14.59.

## Testing

Validated the #14353-equivalent YAML change, referenced helper availability, XML structure, and monotonic servicing-version increment.