### PR TITLE
Revert "Add multi-threading option to build response file"

### DIFF
--- a/Directory.Build.rsp
+++ b/Directory.Build.rsp
@@ -1,1 +1,1 @@
-/verbosity:minimal /m /clp:Summary /mt
+/verbosity:minimal /m /clp:Summary


### PR DESCRIPTION
Reverts dotnet/msbuild#14837

Some arcade tasks that directly log to the console via the System.Console APIs to set ADO variables aren't compatible with -mt yet.