### PR TITLE
[DNR] Cache property function parse results

### DIFF
--- a/src/Build/BackEnd/Node/OutOfProcNode.cs
+++ b/src/Build/BackEnd/Node/OutOfProcNode.cs
@@ -508,6 +508,7 @@ namespace Microsoft.Build.Execution
                     CommunicationsUtilities.Trace($"Failed to restore the original environment: {ex}.");
                 }
                 Traits.UpdateFromEnvironment();
+                PropertyFunctionDescriptorCache.Clear();
             }
             try
             {
@@ -749,6 +750,7 @@ namespace Microsoft.Build.Execution
             }
 
             Traits.UpdateFromEnvironment();
+            PropertyFunctionDescriptorCache.Clear();
             DotnetHostEnvironmentHelper.ClearBootstrapDotnetRootEnvironment(_buildParameters.BuildProcessEnvironment);
 
             // We want to make sure the global project collection has the toolsets which were defined on the parent

--- a/src/Build/BackEnd/Node/OutOfProcServerNode.cs
+++ b/src/Build/BackEnd/Node/OutOfProcServerNode.cs
@@ -10,6 +10,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Build.BackEnd;
 using Microsoft.Build.BackEnd.Logging;
+using Microsoft.Build.Evaluation;
 using Microsoft.Build.Execution;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Framework.Telemetry;
@@ -421,6 +422,11 @@ namespace Microsoft.Build.Server
 
             CommunicationsUtilities.SetEnvironment(command.BuildProcessEnvironment);
             Traits.UpdateFromEnvironment();
+
+            // The incoming environment can flip FeatureSwitches.EnableAllPropertyFunctions, which
+            // changes which types a property function body is allowed to resolve to, so parses
+            // cached for a previous build request on this reused node must not be reused.
+            PropertyFunctionDescriptorCache.Clear();
 
             Thread.CurrentThread.CurrentCulture = command.Culture;
             Thread.CurrentThread.CurrentUICulture = command.UICulture;

--- a/src/Build/Evaluation/Expander.Function.cs
+++ b/src/Build/Evaluation/Expander.Function.cs
@@ -167,6 +167,31 @@ internal partial class Expander<P, I>
         }
 
         /// <summary>
+        /// Construct a function from a previously cached parse of the same function body, binding
+        /// it to the current expansion's context. Every expansion gets its own Function because
+        /// Execute mutates instance state (it augments the binding flags and may narrow the
+        /// receiver type); only the immutable parse result is shared.
+        /// </summary>
+        internal Function(
+            PropertyFunctionDescriptor descriptor,
+            PropertiesUseTracker propertiesUseTracker,
+            IFileSystem fileSystem,
+            LoggingContext loggingContext)
+            : this(
+                descriptor.ReceiverType,
+                descriptor.Expression,
+                descriptor.Receiver,
+                descriptor.MethodName,
+                descriptor.Arguments,
+                descriptor.BindingFlags,
+                descriptor.Remainder,
+                propertiesUseTracker,
+                fileSystem,
+                loggingContext)
+        {
+        }
+
+        /// <summary>
         /// Part of the extraction may result in the name of the property
         /// This accessor is used by the Expander
         /// Examples of expression root:
@@ -213,6 +238,18 @@ internal partial class Expander<P, I>
         {
             // Used to aggregate all the components needed for a Function
             FunctionBuilder functionBuilder = new FunctionBuilder { FileSystem = fileSystem, LoggingContext = loggingContext };
+
+            // Parsing a function body is a pure function of the body text and the receiver's runtime
+            // type, so the result can be reused across expansions and across evaluations. The receiver
+            // type is part of the key because it selects the parse branch below.
+            Type receiverTypeKey = propertyValue?.GetType();
+
+            if (PropertyFunctionDescriptorCache.TryGet(expressionFunction, receiverTypeKey, out PropertyFunctionDescriptor cachedDescriptor))
+            {
+                return cachedDescriptor is null
+                    ? null
+                    : new Function(cachedDescriptor, propertiesUseTracker, fileSystem, loggingContext);
+            }
 
             // By default the expression root is the whole function expression
             ReadOnlySpan<char> expressionRoot = expressionFunction == null ? ReadOnlySpan<char>.Empty : expressionFunction.AsSpan();
@@ -294,6 +331,7 @@ internal partial class Expander<P, I>
                 if (methodStartIndex == -1)
                 {
                     // We don't have a function invocation in the expression root, return null
+                    PropertyFunctionDescriptorCache.Add(expressionFunction, receiverTypeKey, null);
                     return null;
                 }
 
@@ -321,6 +359,9 @@ internal partial class Expander<P, I>
 
                 ConstructFunction(elementLocation, expressionFunction, argumentStartIndex, methodStartIndex, ref functionBuilder);
             }
+
+            PropertyFunctionDescriptor descriptor = functionBuilder.BuildDescriptor();
+            PropertyFunctionDescriptorCache.Add(expressionFunction, receiverTypeKey, descriptor);
 
             return functionBuilder.Build();
         }

--- a/src/Build/Evaluation/Expander.FunctionBuilder.cs
+++ b/src/Build/Evaluation/Expander.FunctionBuilder.cs
@@ -109,5 +109,21 @@ internal partial class Expander<P, I>
                 FileSystem,
                 LoggingContext);
         }
+
+        /// <summary>
+        /// Captures the value-independent part of the parse so it can be cached and reused by
+        /// later expansions of the same function body against the same receiver type.
+        /// </summary>
+        internal readonly PropertyFunctionDescriptor BuildDescriptor()
+        {
+            return new PropertyFunctionDescriptor(
+                ReceiverType,
+                Expression,
+                Receiver,
+                Name,
+                Arguments,
+                BindingFlags,
+                Remainder);
+        }
     }
 }

--- a/src/Build/Evaluation/PropertyFunctionDescriptor.cs
+++ b/src/Build/Evaluation/PropertyFunctionDescriptor.cs
@@ -1,0 +1,169 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using System;
+using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using System.Threading;
+
+namespace Microsoft.Build.Evaluation;
+
+/// <summary>
+///  The value-independent result of parsing a property function body such as
+///  <c>[MSBuild]::EnsureTrailingSlash($(Dir))</c> or <c>SomeProperty.ToLower()</c>.
+/// </summary>
+/// <remarks>
+///  Parsing a property function body is a pure function of the body text and the receiver's
+///  runtime type: it resolves the receiver type, method name, unexpanded argument strings and
+///  binding flags, none of which depend on the values those arguments will later expand to.
+///  Argument expansion and invocation happen later, in <c>Function.Execute</c>, against a
+///  per-call context. Separating the two lets the parse result be shared while each expansion
+///  still gets its own mutable <c>Function</c>.
+/// </remarks>
+internal sealed class PropertyFunctionDescriptor
+{
+    /// <summary>
+    ///  Backing field for <see cref="ReceiverType"/>, annotated so the annotation flows to
+    ///  <c>Function</c>'s constructor rather than producing an IL2072 at the hand-off.
+    /// </summary>
+    [DynamicallyAccessedMembers(
+        DynamicallyAccessedMemberTypes.PublicConstructors |
+        DynamicallyAccessedMemberTypes.PublicMethods |
+        DynamicallyAccessedMemberTypes.PublicProperties |
+        DynamicallyAccessedMemberTypes.PublicFields)]
+    private readonly Type _receiverType;
+
+    internal PropertyFunctionDescriptor(
+        [DynamicallyAccessedMembers(
+            DynamicallyAccessedMemberTypes.PublicConstructors |
+            DynamicallyAccessedMemberTypes.PublicMethods |
+            DynamicallyAccessedMemberTypes.PublicProperties |
+            DynamicallyAccessedMemberTypes.PublicFields)] Type receiverType,
+        string expression,
+        string? receiver,
+        string methodName,
+        string[]? arguments,
+        BindingFlags bindingFlags,
+        string? remainder)
+    {
+        _receiverType = receiverType;
+        Expression = expression;
+        Receiver = receiver;
+        MethodName = methodName;
+        Arguments = arguments;
+        BindingFlags = bindingFlags;
+        Remainder = remainder;
+    }
+
+    [DynamicallyAccessedMembers(
+        DynamicallyAccessedMemberTypes.PublicConstructors |
+        DynamicallyAccessedMemberTypes.PublicMethods |
+        DynamicallyAccessedMemberTypes.PublicProperties |
+        DynamicallyAccessedMemberTypes.PublicFields)]
+    internal Type ReceiverType => _receiverType;
+
+    internal string Expression { get; }
+
+    internal string? Receiver { get; }
+
+    internal string MethodName { get; }
+
+    /// <summary>
+    ///  The unexpanded argument strings. Read-only in practice: <c>Function.Execute</c> only
+    ///  reads this array and writes the expanded values into a fresh array of its own.
+    /// </summary>
+    internal string[]? Arguments { get; }
+
+    internal BindingFlags BindingFlags { get; }
+
+    internal string? Remainder { get; }
+}
+
+/// <summary>
+///  Caches <see cref="PropertyFunctionDescriptor"/> instances so that a given property function
+///  body is parsed and bound once per receiver type rather than on every expansion.
+/// </summary>
+/// <remarks>
+///  This mirrors the long-standing parsed-expression-tree cache in <see cref="ConditionEvaluator"/>,
+///  including its size-capped flush policy: the hit rate is very high in normal builds, and the
+///  cost of repopulating after a flush is small compared to the cost of an unbounded cache in
+///  pathological cases (for example randomly generated configuration names in VS stress runs).
+/// </remarks>
+internal static class PropertyFunctionDescriptorCache
+{
+    /// <summary>
+    ///  Matches the threshold used for cached condition expression trees.
+    /// </summary>
+    private const int CacheSizeThreshold = 3000;
+
+    private static volatile ConcurrentDictionary<Key, PropertyFunctionDescriptor?> s_cache = new();
+
+    /// <summary>
+    ///  Approximate entry count, maintained separately because
+    ///  <see cref="ConcurrentDictionary{TKey, TValue}.Count"/> acquires every bucket lock and
+    ///  would turn the flush check into a contention point under multithreaded evaluation.
+    ///  Same approach as <c>ConditionEvaluator</c>'s <c>OptimisticSize</c>.
+    /// </summary>
+    private static int s_optimisticSize;
+
+    /// <summary>
+    ///  A parse is fully determined by the body text plus the receiver's runtime type. The type
+    ///  must be part of the key because it selects the parse branch: a <see langword="null"/>
+    ///  receiver means a static call or a chain root, an <see cref="Array"/> receiver selects
+    ///  <c>GetValue</c> for an indexer, a <see cref="string"/> receiver selects <c>get_Chars</c>,
+    ///  and anything else selects <c>get_Item</c>.
+    /// </summary>
+    private readonly struct Key : IEquatable<Key>
+    {
+        private readonly string _body;
+        private readonly Type? _receiverType;
+
+        internal Key(string body, Type? receiverType)
+        {
+            _body = body;
+            _receiverType = receiverType;
+        }
+
+        public bool Equals(Key other)
+            => _receiverType == other._receiverType && string.Equals(_body, other._body, StringComparison.Ordinal);
+
+        public override bool Equals(object? obj) => obj is Key other && Equals(other);
+
+        public override int GetHashCode()
+        {
+            int hash = StringComparer.Ordinal.GetHashCode(_body);
+            return _receiverType is null ? hash : (hash * 397) ^ _receiverType.GetHashCode();
+        }
+    }
+
+    internal static bool TryGet(string body, Type? receiverType, out PropertyFunctionDescriptor? descriptor)
+        => s_cache.TryGetValue(new Key(body, receiverType), out descriptor);
+
+    internal static void Add(string body, Type? receiverType, PropertyFunctionDescriptor? descriptor)
+    {
+        if (s_optimisticSize > CacheSizeThreshold)
+        {
+            Clear();
+        }
+
+        Interlocked.Increment(ref s_optimisticSize);
+        s_cache[new Key(body, receiverType)] = descriptor;
+    }
+
+    /// <summary>
+    ///  Drops every cached parse. Must be called whenever the environment backing
+    ///  <c>FeatureSwitches.EnableAllPropertyFunctions</c> may have changed, because that switch
+    ///  decides whether a type outside the curated allowlist is resolvable, and it is read live
+    ///  on every access. A reusable MSBuild Server node serves successive build requests with
+    ///  different environments, so without this a descriptor parsed while the switch was on
+    ///  would still be served after it was turned off.
+    /// </summary>
+    internal static void Clear()
+    {
+        s_cache = new ConcurrentDictionary<Key, PropertyFunctionDescriptor?>();
+        Interlocked.Exchange(ref s_optimisticSize, 0);
+    }
+}

--- a/src/Build/Microsoft.Build.csproj
+++ b/src/Build/Microsoft.Build.csproj
@@ -203,6 +203,7 @@
     <Compile Include="Evaluation\Expander.PropertyExpander.cs" />
     <Compile Include="Evaluation\Expander.SpanBasedConcatenator.cs" />
     <Compile Include="Evaluation\ExpanderOptions.cs" />
+    <Compile Include="Evaluation\PropertyFunctionDescriptor.cs" />
     <Compile Include="Evaluation\IItemTypeDefinition.cs" />
     <Compile Include="Evaluation\IntrinsicFunctionOverload.cs" />
     <Compile Include="Evaluation\PropertiesUseTracker.cs" />


### PR DESCRIPTION
Parsing a property function body like `$([MSBuild]::EnsureTrailingSlash($(Dir)))` resolves the receiver type, method name, argument strings and binding flags. That depends only on the body text and the receiver's runtime type, never on the values the arguments expand to — but it is redone on every expansion.

This caches that parse as an immutable `PropertyFunctionDescriptor` keyed by `(body text, receiver type)`. Receiver type is in the key because it picks the parse branch (`null` = static/chain root, `Array` = `GetValue`, `string` = `get_Chars`, else `get_Item`).

`Function.Execute` mutates its instance (ORs in `Static`/`Instance`, can narrow `_receiverType`), so each expansion still builds its own `Function` from the shared descriptor. Only the parse is shared.

Same shape as the existing parsed-expression-tree cache in `ConditionEvaluator`, including the 3,000-entry flush and the `OptimisticSize` counter that avoids `ConcurrentDictionary.Count` taking every bucket lock.

Follow-up to #14697, which left allocation and architectural work to later PRs. Base `67e01fd37` already contains it.

## Benchmarks

`PropertyFunctionExpansionBenchmark` (#14660), .NET 11 RyuJIT x64. Baseline `67e01fd37` → `df193c52d`.

| Method | Mean | Time | Allocated |
|---|---:|---:|---:|
| Property *(control, no function)* | 64.61 → 63.26 ns | -2.1% | 0 → 0 B |
| Static | 1,024.79 → 656.28 ns | **-36.0%** | 448 → 304 B |
| StaticWithPropertyArguments | 4,378.64 → 3,825.14 ns | **-12.6%** | 2,056 → 1,904 B |
| StaticPath | 1,023.91 → 619.17 ns | **-39.5%** | 528 → 376 B |
| Instance | 580.26 → 511.31 ns | **-11.9%** | 328 → 272 B |
| InstanceWithArgument | 702.12 → 505.26 ns | **-28.0%** | 320 → 248 B |
| InstanceWithOverload | 1,136.96 → 530.25 ns | **-53.4%** | 440 → 288 B |
| InstanceWithPropertyArgument | 1,104.07 → 667.93 ns | **-39.5%** | 464 → 312 B |
| ChainedInstance | 1,197.76 → 948.84 ns | **-20.8%** | 664 → 472 B |
| Nested | 8,598.01 → 7,273.86 ns | **-15.4%** | 4,144 → 3,840 B |
| Intrinsic | 846.99 → 351.32 ns | **-58.5%** | 464 → 296 B |
| IntrinsicArithmetic | 646.21 → 247.45 ns | **-61.7%** | 400 → 256 B |
| Multiple | 2,114.03 → 1,439.73 ns | **-31.9%** | 1,048 → 608 B |

Every function shape improves in time and allocation; the no-function control is flat. Hit rate is 98.95% on a web project (419 calls/evaluation, 198 distinct bodies). Bodies are fresh substrings each time (18,855 distinct references for 198 values), so the key must be by value.

## Correctness

Evaluated output identical (946 properties, 751 items dumped and compared). `Expander_Tests` 447/439 pass, `*PropertyFunction*` 22/22 pass, 0 build warnings including trimming.

The cache is cleared at the three `Traits.UpdateFromEnvironment()` call sites: `FeatureSwitches.EnableAllPropertyFunctions` is read live from the environment and decides whether a type outside the allowlist resolves, while a reused server node serves successive builds with different environments. Without the flush, a descriptor parsed while that switch was on would still be served after it was off.

## Concurrency

Measured with many projects evaluating concurrently in one process against a shared `ProjectCollection`, which is what `-mt` does. Paired rounds, arm order alternated:

| Threads | Paired median | Rounds won | Allocation |
|---:|---:|---:|---:|
| 8 | -2.0% | 7/10 | -60 KB/eval (10/10 rounds) |
| 16 | -2.6% | 7/8 | -62 KB/eval (8/8 rounds) |

No contention regression: hits are lock-free `ConcurrentDictionary` reads, and only the 198 misses take a bucket lock. Allocation improves in every single round at both thread counts.

## Not validated

- Whole-evaluation impact. An end-to-end harness showed -3.4% serially, but that does not reconcile with the per-call numbers (~419 calls × ~450 ns ≈ 0.2 ms) and the harness ran on a noisy shared VM. Treat the benchmark table as the result; the concurrency numbers above are from the same harness and carry the same caveat, so read them as "no regression" rather than as a precise win.