### PR TITLE
[vs17.12] Disable OptProf bootstrapper

### DIFF
--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -15,8 +15,11 @@ parameters:
   default: 'default'
 - name: enableOptProf
   displayName: Enable OptProf data collection for this build
+  # vs17.12 is in servicing and no longer collects fresh OptProf data: the VS
+  # bootstrapper build (required only for OptProf collection) is disabled by default.
+  # We keep applying the last-collected optimization data (see SkipApplyOptimizationData below).
   type: boolean
-  default: true
+  default: false
 - name: enableSigningValidation
   displayName: Enable Signing Validation
   type: boolean
@@ -42,10 +45,11 @@ variables:
       value: ${{ parameters.OptProfDropName }}
     - name: SourceBranch
       value: ''
-  # Override SkipApplyOptimizationData to true when disabling OptProf data collection
-  - ${{ if eq(parameters.EnableOptProf, false) }}:
-    - name: SkipApplyOptimizationData
-      value: true
+  # NOTE (vs17.12 servicing): historically, disabling OptProf collection also forced
+  # SkipApplyOptimizationData to true (stop applying data). On this branch we intentionally
+  # decouple the two: collection is disabled, but we keep applying the last-collected
+  # optimization data so shipped binaries stay optimized. SkipApplyOptimizationData is
+  # therefore governed solely by the pipeline variable (default 'false' = apply existing data).
   - name: EnableReleaseOneLocBuild
     value: false # Disable loc for vs17.12
   - name: Codeql.Enabled

--- a/azure-pipelines/.vsts-dotnet-build-jobs.yml
+++ b/azure-pipelines/.vsts-dotnet-build-jobs.yml
@@ -140,7 +140,8 @@ jobs:
       ArtifactName: MicroBuildOutputs
       ArtifactType: Container
     displayName: 'OptProf - Publish Artifact: MicroBuildOutputs'
-    condition: succeeded()
+    # Only produced when the OptProf bootstrapper runs; skip when OptProf collection is disabled.
+    condition: and(succeeded(), ${{ parameters.enableOptProf }})
 
   - task: 1ES.PublishBuildArtifacts@1
     displayName: 'Publish Artifact: logs'
@@ -235,4 +236,3 @@ jobs:
       name: $(DncEngInternalBuildPool)
       image: $(WindowsImage)
       os: windows
-

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,7 +2,7 @@
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the MIT license. See License.txt in the project root for full license information. -->
 <Project>
   <PropertyGroup>
-    <VersionPrefix>17.12.72</VersionPrefix>
+    <VersionPrefix>17.12.73</VersionPrefix>
     <DotNetFinalVersionKind>release</DotNetFinalVersionKind>
     <PackageValidationBaselineVersion>17.11.4</PackageValidationBaselineVersion>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>


### PR DESCRIPTION
Related to #14105

### Context

The `vs17.12` official build restores and compiles successfully, then fails in `OptProf - Build VS bootstrapper` because `VSEng-VSDrop-MI` cannot obtain a managed-identity token. `vs17.12` is in servicing and no longer needs to collect fresh OptProf data.

### Changes Made

- Changed `enableOptProf` to default to `false`, disabling OptProf collection and the failing bootstrapper step.
- Preserved application of the last-collected optimization data by leaving `SkipApplyOptimizationData` governed by the pipeline variable.
- Gated `OptProf - Publish Artifact: MicroBuildOutputs` on `enableOptProf` because the bootstrapper output is not produced when collection is disabled.
- Bumped `VersionPrefix` from `17.12.72` to `17.12.73`.

### Testing

- Parsed `.vsts-dotnet.yml` and `azure-pipelines/.vsts-dotnet-build-jobs.yml` with `ConvertFrom-Yaml` and parsed `eng/Versions.props` as XML.
- Attempted `$env:MSBUILDFORCEMULTITHREADED=1; .\build.cmd -v quiet`; the locally bootstrapped .NET SDK lacked `Microsoft.NET.Sdk\tools\net472\Microsoft.NET.Build.Tasks.dll`, causing `MSB4062` before compilation.

### Notes

- `MSBuild-OptProf` definition `17389` may still resource-trigger without `MicroBuildOutputs`; its branch filtering is evaluated from its `main` default-branch configuration and requires a separate central change.
