### PR TITLE
Require ready-for-training tag for OptProf

### DIFF
--- a/.opt-prof.yml
+++ b/.opt-prof.yml
@@ -14,9 +14,13 @@ resources:
   pipelines:
   - pipeline: ComponentBuildUnderTest
     source: MSBuild\MSBuild # The name of the pipeline that produces the artifact
+    tags:
+      - ready-for-training
     trigger:
       branches:
         - vs*
+      tags:
+        - ready-for-training
   - pipeline: DartLab
     project: DevDiv
     source: DartLab


### PR DESCRIPTION
### Context

The `MSBuild-OptProf` pipeline consumes `MicroBuildOutputs` and OptProf run settings from successful MSBuild official builds. Servicing branches can disable OptProf collection, so those builds no longer produce the required artifacts.

The pipeline resource currently triggers for every successful `vs*` build, and scheduled or manual runs can select an artifact-less build.

### Changes Made

- Require the producer build to have the `ready-for-training` tag when selecting a pipeline resource for scheduled or manual runs.
- Require the same tag for pipeline-completion triggers.
- Preserve triggering for successful OptProf-enabled builds, which add this tag after producing the required artifacts.

### Testing

- Parsed `.opt-prof.yml` with `ConvertFrom-Yaml`.
- Verified the producer adds `ready-for-training` only when the build succeeds and `enableOptProf` is enabled.
- End-to-end validation requires tagged and untagged official pipeline runs.