### PR TITLE
[vs17.11] Disable unavailable OptProf data

### DIFF
--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -15,8 +15,10 @@ parameters:
   default: 'default'
 - name: enableOptProf
   displayName: Enable OptProf data collection for this build
+  # This servicing branch no longer has optimization data to apply and no longer
+  # collects fresh data.
   type: boolean
-  default: true
+  default: false
 - name: enableSigningValidation
   displayName: Enable Signing Validation
   type: boolean

--- a/azure-pipelines/.vsts-dotnet-build-jobs.yml
+++ b/azure-pipelines/.vsts-dotnet-build-jobs.yml
@@ -151,7 +151,7 @@ jobs:
       ArtifactName: MicroBuildOutputs
       ArtifactType: Container
     displayName: 'OptProf - Publish Artifact: MicroBuildOutputs'
-    condition: succeeded()
+    condition: and(succeeded(), ${{ parameters.enableOptProf }})
 
   - task: 1ES.PublishBuildArtifacts@1
     displayName: 'Publish Artifact: logs'

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,7 +2,7 @@
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the MIT license. See License.txt in the project root for full license information. -->
 <Project>
   <PropertyGroup>
-    <VersionPrefix>17.11.66</VersionPrefix>
+    <VersionPrefix>17.11.67</VersionPrefix>
     <DotNetFinalVersionKind>release</DotNetFinalVersionKind>
     <PackageValidationBaselineVersion>17.10.4</PackageValidationBaselineVersion>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>


### PR DESCRIPTION
Depends on #14867. Merge #14867 first so the downstream OptProf pipeline does not trigger for builds without OptProf artifacts.

Related to #14861.

### Context

The latest `vs17.11` official build ([15107183](https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=15107183&view=results)) fails before compilation while restoring optimization data:

`No drops matching the specified prefix were returned`

The requested prefix is `OptimizationData/DotNet-msbuild-Trusted/vs17.11`. Previous successful `vs17.11` Windows builds used `-officialSkipApplyOptimizationData true`, and this servicing branch no longer needs to collect fresh OptProf data.

### Changes Made

- Changed `enableOptProf` to default to `false`.
- Kept the existing behavior that sets `SkipApplyOptimizationData=true` when OptProf collection is disabled, avoiding the unavailable-data restore.
- Gated `OptProf - Publish Artifact: MicroBuildOutputs` on `enableOptProf` because the bootstrapper output is not produced when collection is disabled.
- Bumped `VersionPrefix` from `17.11.66` to `17.11.67`.

### Testing

- Parsed `.vsts-dotnet.yml` and `azure-pipelines/.vsts-dotnet-build-jobs.yml` with `ConvertFrom-Yaml`.
- Parsed `eng/Versions.props` as XML.
- End-to-end validation requires the official pipeline run.

### Notes
- We can skip the OptProf because this branch only inserts into .NET SDK and not VS, so there is no risk of introducing a performance regressions in VS.