### PR TITLE
[vs17.8] Disable unavailable OptProf data

### DIFF
--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -13,6 +13,12 @@ parameters:
   displayName: Optional OptProfDrop Override
   type: string
   default: 'default'
+- name: enableOptProf
+  displayName: Enable OptProf data collection for this build
+  # This servicing branch no longer has optimization data to apply and no longer
+  # collects fresh data.
+  type: boolean
+  default: false
 - name: enableSigningValidation
   displayName: Enable Signing Validation
   type: boolean
@@ -38,6 +44,10 @@ variables:
       value: ${{ parameters.OptProfDropName }}
     - name: SourceBranch
       value: ''
+  # Skip applying optimization data when collection is disabled.
+  - ${{ if eq(parameters.enableOptProf, false) }}:
+    - name: SkipApplyOptimizationData
+      value: true
   - name: _DotNetArtifactsCategory
     value: .NETCore
   - name: _DotNetValidationArtifactsCategory
@@ -112,6 +122,7 @@ extends:
           isExperimental: false
           enableComponentGovernance: true
           signTypeParameter: ${{ parameters.signTypeParameter }}
+          enableOptProf: ${{ parameters.enableOptProf }}
 
     - template: /eng/common/templates-official/post-build/post-build.yml@self
       parameters:

--- a/azure-pipelines/.vsts-dotnet-build-jobs.yml
+++ b/azure-pipelines/.vsts-dotnet-build-jobs.yml
@@ -9,6 +9,10 @@ parameters:
 - name: signTypeParameter
   type: string
   default: 'test'
+- name: enableOptProf
+  type: boolean
+  # Preserve OptProf for callers that do not explicitly configure it.
+  default: true
 
 jobs:
 - job: Windows_NT
@@ -61,6 +65,7 @@ jobs:
       AccessToken: '$(System.AccessToken)'
       feedSource: 'https://devdiv.pkgs.visualstudio.com/DefaultCollection/_packaging/MicroBuildToolset/nuget/v3/index.json'
     displayName: 'Install OptProf Plugin'
+    condition: and(succeeded(), ${{ parameters.enableOptProf }})
 
   # Required by MicroBuildBuildVSBootstrapper
   - task: MicroBuildSwixPlugin@4
@@ -104,7 +109,7 @@ jobs:
       toLowerCase: false
       usePat: true
     displayName: 'OptProf - Publish to Artifact Services - ProfilingInputs'
-    condition: succeeded()
+    condition: and(succeeded(), ${{ parameters.enableOptProf }})
 
   # Build VS bootstrapper
   # Generates $(Build.StagingDirectory)\MicroBuild\Output\BootstrapperInfo.json
@@ -115,7 +120,7 @@ jobs:
       manifests: $(VisualStudio.SetupManifestList)
       outputFolder: '$(Build.SourcesDirectory)\artifacts\VSSetup\$(BuildConfiguration)\Insertion'
     displayName: 'OptProf - Build VS bootstrapper'
-    condition: succeeded()
+    condition: and(succeeded(), ${{ parameters.enableOptProf }})
 
   # Publish run settings
   - task: PowerShell@2
@@ -127,7 +132,7 @@ jobs:
                 /p:BootstrapperInfoPath=$(Build.StagingDirectory)\MicroBuild\Output\BootstrapperInfo.json
                 /p:VisualStudioIbcTrainingSettingsPath=$(Build.SourcesDirectory)\eng\config\OptProf.runsettings
     displayName: 'OptProf - Build IBC training settings'
-    condition: succeeded()
+    condition: and(succeeded(), ${{ parameters.enableOptProf }})
 
   # Publish bootstrapper info
   - task: 1ES.PublishBuildArtifacts@1
@@ -136,7 +141,7 @@ jobs:
       ArtifactName: MicroBuildOutputs
       ArtifactType: Container
     displayName: 'OptProf - Publish Artifact: MicroBuildOutputs'
-    condition: succeeded()
+    condition: and(succeeded(), ${{ parameters.enableOptProf }})
 
   - task: 1ES.PublishBuildArtifacts@1
     displayName: 'Publish Artifact: logs'
@@ -205,7 +210,7 @@ jobs:
     displayName: Tag build as ready for optimization training
     inputs:
       tags: 'ready-for-training'
-    condition: succeeded()
+    condition: and(succeeded(), ${{ parameters.enableOptProf }})
 
   - task: ms-vseng.MicroBuildTasks.521a94ea-9e68-468a-8167-6dcf361ea776.MicroBuildCleanup@1
     displayName: Execute cleanup tasks
@@ -238,4 +243,3 @@ jobs:
       name: AzurePipelines-EO
       image: 1ESPT-Windows2022
       os: windows
-

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,7 +2,7 @@
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the MIT license. See License.txt in the project root for full license information. -->
 <Project>
   <PropertyGroup>
-    <VersionPrefix>17.8.58</VersionPrefix>
+    <VersionPrefix>17.8.59</VersionPrefix>
     <DotNetFinalVersionKind>release</DotNetFinalVersionKind>
     <PackageValidationBaselineVersion>17.7.0</PackageValidationBaselineVersion>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>


### PR DESCRIPTION
Depends on #14867. Merge #14867 first so the downstream OptProf pipeline does not trigger for builds without OptProf artifacts.

Related to #14861.

### Context

The latest `vs17.8` official build ([15087653](https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=15087653&view=results)) fails before compilation while restoring optimization data:

`No drops matching the specified prefix were returned`

The requested prefix is `OptimizationData/DotNet-msbuild-Trusted/vs17.8`. All four official builds since August 17 have failed this way. An earlier build that got past restore then failed the OptProf bootstrapper because it could not obtain a VSDrop managed-identity token, so this servicing branch should stop both applying unavailable data and collecting fresh data.

### Changes Made

- Added an `enableOptProf` parameter to the official pipeline and defaulted it to `false`.
- Set `SkipApplyOptimizationData=true` when OptProf collection is disabled.
- Gated the OptProf plugin, ProfilingInputs publish, bootstrapper, training-settings generation, `MicroBuildOutputs` publish, and `ready-for-training` tag on `enableOptProf`.
- Kept the shared job-template default at `true` so the experimental pipeline preserves its existing OptProf behavior.
- Bumped `VersionPrefix` from `17.8.58` to `17.8.59`.

### Testing

- Parsed `.vsts-dotnet.yml`, `azure-pipelines/.vsts-dotnet-build-jobs.yml`, and the unchanged experimental caller with `ConvertFrom-Yaml`.
- Parsed `eng/Versions.props` as XML.
- End-to-end validation requires the official pipeline run.

### Notes
- We can skip the OptProf because this branch only inserts into .NET SDK and not VS, so there is no risk of introducing a performance regressions in VS.