### PR TITLE
Fix NormalizePath and other intrinsic functions in multithreaded mode

### DIFF
--- a/src/Build.UnitTests/Evaluation/Expander_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/Expander_Tests.cs
@@ -5565,6 +5565,265 @@ $(
         // =====================================================================
 
         [Fact]
+        public void NormalizePath_RelativePath_ResolvesFromThreadWorkingDirectory()
+        {
+            using var env = TestEnvironment.Create(_output);
+            var correctDir = env.CreateFolder(createFolder: true);
+            var wrongDir = env.CreateFolder(createFolder: true);
+
+            string result = ExpandWithThreadWorkingDirectory(env,
+                "$([MSBuild]::NormalizePath('obj', 'file.txt'))", correctDir.Path, wrongDir.Path);
+
+            result.ShouldBe(Path.Combine(correctDir.Path, "obj", "file.txt"));
+        }
+
+        [Fact]
+        public void NormalizePath_ParentSegment_ResolvesFromThreadWorkingDirectory()
+        {
+            using var env = TestEnvironment.Create(_output);
+            var correctDir = env.CreateFolder(createFolder: true);
+            var wrongDir = env.CreateFolder(createFolder: true);
+
+            string result = ExpandWithThreadWorkingDirectory(env,
+                "$([MSBuild]::NormalizePath('obj', '..', 'file.txt'))", correctDir.Path, wrongDir.Path);
+
+            result.ShouldBe(Path.Combine(correctDir.Path, "file.txt"));
+        }
+
+        [UnixOnlyFact]
+        public void NormalizePath_BackslashRootedPath_MatchesNonMultithreadedResult()
+        {
+            using var env = TestEnvironment.Create(_output);
+            var projectDir = env.CreateFolder(createFolder: true);
+            var wrongDir = env.CreateFolder(createFolder: true);
+
+            // Baseline: non-mt mode, where the process current directory is the project directory.
+            env.SetCurrentDirectory(projectDir.Path);
+            string expected = IntrinsicFunctions.NormalizePath(@"\tmp\file.txt");
+
+            // -mt mode must agree: on Unix a backslash is an ordinary filename character, so resolution
+            // must not normalize separators or it would silently point at a different file.
+            string result = ExpandWithThreadWorkingDirectory(env,
+                @"$([MSBuild]::NormalizePath('\tmp\file.txt'))", projectDir.Path, wrongDir.Path);
+
+            result.ShouldBe(expected);
+        }
+
+        [Fact]
+        public void NormalizePath_BackslashSeparatedPath_MatchesNonMultithreadedResult()
+        {
+            using var env = TestEnvironment.Create(_output);
+            var projectDir = env.CreateFolder(createFolder: true);
+            var wrongDir = env.CreateFolder(createFolder: true);
+
+            env.SetCurrentDirectory(projectDir.Path);
+            string expected = IntrinsicFunctions.NormalizePath(@"obj\..\file.txt");
+
+            string result = ExpandWithThreadWorkingDirectory(env,
+                @"$([MSBuild]::NormalizePath('obj\..\file.txt'))", projectDir.Path, wrongDir.Path);
+
+            result.ShouldBe(expected);
+        }
+
+        [Fact]
+        public void MSBuildFileExists_BackslashSeparatedPath_MatchesNonMultithreadedResult()
+        {
+            using var env = TestEnvironment.Create(_output);
+            var projectDir = env.CreateFolder(createFolder: true);
+            var wrongDir = env.CreateFolder(createFolder: true);
+
+            Directory.CreateDirectory(Path.Combine(projectDir.Path, "sub"));
+            File.WriteAllText(Path.Combine(projectDir.Path, "sub", "marker.txt"), "x");
+
+            // FileExists applies no separator normalization in either mode, so both must agree.
+            env.SetCurrentDirectory(projectDir.Path);
+            string expected = IntrinsicFunctions.FileExists(@"sub\marker.txt").ToString();
+
+            string result = ExpandWithThreadWorkingDirectory(env,
+                @"$([MSBuild]::FileExists('sub\marker.txt'))", projectDir.Path, wrongDir.Path);
+
+            result.ShouldBe(expected);
+        }
+
+        [WindowsOnlyFact]
+        public void NormalizePath_DriveRelativePath_ResolvesFromThreadWorkingDirectory()
+        {
+            using var env = TestEnvironment.Create(_output);
+            var correctDir = env.CreateFolder(createFolder: true);
+            var wrongDir = env.CreateFolder(createFolder: true);
+            string drive = Path.GetPathRoot(correctDir.Path).Substring(0, 2);
+
+            string result = ExpandWithThreadWorkingDirectory(env,
+                $"$([MSBuild]::NormalizePath('{drive}obj', 'file.txt'))", correctDir.Path, wrongDir.Path);
+
+            result.ShouldBe(Path.Combine(correctDir.Path, "obj", "file.txt"));
+        }
+
+        [Fact]
+        public void NormalizePath_AbsolutePath_IgnoresThreadWorkingDirectory()
+        {
+            using var env = TestEnvironment.Create(_output);
+            var correctDir = env.CreateFolder(createFolder: true);
+            var absoluteDir = env.CreateFolder(createFolder: true);
+
+            string absolutePath = Path.Combine(absoluteDir.Path, "file.txt");
+            string result = ExpandWithThreadWorkingDirectory(env,
+                $"$([MSBuild]::NormalizePath('{absolutePath}'))", correctDir.Path);
+
+            result.ShouldBe(absolutePath);
+        }
+
+        [Fact]
+        public void NormalizePath_WithoutThreadWorkingDirectory_UsesProcessWorkingDirectory()
+        {
+            using var env = TestEnvironment.Create(_output);
+            var processDir = env.CreateFolder(createFolder: true);
+            env.SetCurrentDirectory(processDir.Path);
+
+            string result = ExpandWithThreadWorkingDirectory(env,
+                "$([MSBuild]::NormalizePath('obj', 'file.txt'))", null);
+
+            result.ShouldBe(Path.Combine(processDir.Path, "obj", "file.txt"));
+        }
+
+        [Fact]
+        public void NormalizePath_EmptyPath_ThrowsArgumentException()
+        {
+            Should.Throw<ArgumentException>(() => IntrinsicFunctions.NormalizePath([]));
+        }
+
+        [Fact]
+        public void NormalizePath_NullPathArray_ThrowsArgumentNullException()
+        {
+            Should.Throw<ArgumentNullException>(() => IntrinsicFunctions.NormalizePath((string[])null));
+        }
+
+        [Fact]
+        public void NormalizePath_IllegalPath_ThrowsArgumentException()
+        {
+            using var env = TestEnvironment.Create(_output);
+            var correctDir = env.CreateFolder(createFolder: true);
+            env.WithTransientTestState(new TransientThreadWorkingDirectory(correctDir.Path));
+
+            // Resolution against the thread working directory intentionally swallows the invalid-path
+            // exception (so that non-throwing intrinsics such as FileExists keep working); NormalizePath
+            // is still expected to surface it, matching non-mt behavior.
+            Should.Throw<ArgumentException>(() => IntrinsicFunctions.NormalizePath("bad\0path"));
+        }
+
+        [Fact]
+        public void NormalizeDirectory_RelativePath_ResolvesFromThreadWorkingDirectory()
+        {
+            using var env = TestEnvironment.Create(_output);
+            var correctDir = env.CreateFolder(createFolder: true);
+            var wrongDir = env.CreateFolder(createFolder: true);
+
+            string result = ExpandWithThreadWorkingDirectory(env,
+                "$([MSBuild]::NormalizeDirectory('obj'))", correctDir.Path, wrongDir.Path);
+
+            result.ShouldBe(Path.Combine(correctDir.Path, "obj") + Path.DirectorySeparatorChar);
+        }
+
+        [Fact]
+        public void MSBuildFileExists_RelativePath_ResolvesFromThreadWorkingDirectory()
+        {
+            using var env = TestEnvironment.Create(_output);
+            var correctDir = env.CreateFolder(createFolder: true);
+            var wrongDir = env.CreateFolder(createFolder: true);
+
+            File.WriteAllText(Path.Combine(correctDir.Path, "marker.txt"), "x");
+
+            ExpandWithThreadWorkingDirectory(env,
+                "$([MSBuild]::FileExists('marker.txt'))", correctDir.Path, wrongDir.Path)
+                .ShouldBe("True");
+            ExpandWithThreadWorkingDirectory(env,
+                "$([MSBuild]::FileExists('absent.txt'))", correctDir.Path, wrongDir.Path)
+                .ShouldBe("False");
+        }
+
+        [UnixOnlyFact]
+        public void MSBuildFileExists_BackslashRootedPath_MatchesNonMultithreadedResult()
+        {
+            using var env = TestEnvironment.Create(_output);
+            var projectDir = env.CreateFolder(createFolder: true);
+            var wrongDir = env.CreateFolder(createFolder: true);
+
+            // FileExistsNoThrow normalizes separators internally, so on Unix '\tmp\x' is rooted by the
+            // time the probe happens. Resolution must not treat it as relative to the project directory.
+            Directory.CreateDirectory(Path.Combine(projectDir.Path, "tmp"));
+            File.WriteAllText(Path.Combine(projectDir.Path, "tmp", "decoy.txt"), "x");
+
+            env.SetCurrentDirectory(projectDir.Path);
+            string expected = IntrinsicFunctions.FileExists(@"\tmp\decoy.txt").ToString();
+
+            string result = ExpandWithThreadWorkingDirectory(env,
+                @"$([MSBuild]::FileExists('\tmp\decoy.txt'))", projectDir.Path, wrongDir.Path);
+
+            result.ShouldBe(expected);
+        }
+
+        [Fact]
+        public void MSBuildDirectoryExists_RelativePath_ResolvesFromThreadWorkingDirectory()
+        {
+            using var env = TestEnvironment.Create(_output);
+            var correctDir = env.CreateFolder(createFolder: true);
+            var wrongDir = env.CreateFolder(createFolder: true);
+
+            Directory.CreateDirectory(Path.Combine(correctDir.Path, "obj"));
+
+            ExpandWithThreadWorkingDirectory(env,
+                "$([MSBuild]::DirectoryExists('obj'))", correctDir.Path, wrongDir.Path)
+                .ShouldBe("True");
+            ExpandWithThreadWorkingDirectory(env,
+                "$([MSBuild]::DirectoryExists('absent'))", correctDir.Path, wrongDir.Path)
+                .ShouldBe("False");
+        }
+
+        [Fact]
+        public void GetDirectoryNameOfFileAbove_RelativeStartingDirectory_ResolvesFromThreadWorkingDirectory()
+        {
+            using var env = TestEnvironment.Create(_output);
+            var correctDir = env.CreateFolder(createFolder: true);
+            var wrongDir = env.CreateFolder(createFolder: true);
+
+            File.WriteAllText(Path.Combine(correctDir.Path, "marker.txt"), "x");
+
+            string result = ExpandWithThreadWorkingDirectory(env,
+                "$([MSBuild]::GetDirectoryNameOfFileAbove('.', 'marker.txt'))", correctDir.Path, wrongDir.Path);
+
+            result.ShouldBe(correctDir.Path);
+        }
+
+        [Fact]
+        public void GetPathOfFileAbove_RelativeStartingDirectory_ResolvesFromThreadWorkingDirectory()
+        {
+            using var env = TestEnvironment.Create(_output);
+            var correctDir = env.CreateFolder(createFolder: true);
+            var wrongDir = env.CreateFolder(createFolder: true);
+
+            File.WriteAllText(Path.Combine(correctDir.Path, "marker.txt"), "x");
+
+            string result = ExpandWithThreadWorkingDirectory(env,
+                "$([MSBuild]::GetPathOfFileAbove('marker.txt', '.'))", correctDir.Path, wrongDir.Path);
+
+            result.ShouldBe(Path.Combine(correctDir.Path, "marker.txt"));
+        }
+
+        [Fact]
+        public void MakeRelative_RelativeBasePath_ResolvesFromThreadWorkingDirectory()
+        {
+            using var env = TestEnvironment.Create(_output);
+            var correctDir = env.CreateFolder(createFolder: true);
+            var wrongDir = env.CreateFolder(createFolder: true);
+
+            string target = Path.Combine(correctDir.Path, "marker.txt");
+            string result = ExpandWithThreadWorkingDirectory(env,
+                $"$([MSBuild]::MakeRelative('obj', '{target}'))", correctDir.Path, wrongDir.Path);
+
+            result.ShouldBe(Path.Combine("..", "marker.txt"));
+        }
+
+        [Fact]
         public void FileReadAllText_RelativePath_ResolvesFromThreadWorkingDirectory()
         {
             using var env = TestEnvironment.Create(_output);

--- a/src/Build.UnitTests/Evaluation/Expander_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/Expander_Tests.cs
@@ -5810,17 +5810,30 @@ $(
         }
 
         [Fact]
-        public void MakeRelative_RelativeBasePath_ResolvesFromThreadWorkingDirectory()
+        public void RegisterBuildCheck_RelativePath_ResolvesFromThreadWorkingDirectory()
         {
             using var env = TestEnvironment.Create(_output);
             var correctDir = env.CreateFolder(createFolder: true);
             var wrongDir = env.CreateFolder(createFolder: true);
+            File.WriteAllText(Path.Combine(correctDir.Path, "check.dll"), string.Empty);
 
-            string target = Path.Combine(correctDir.Path, "marker.txt");
-            string result = ExpandWithThreadWorkingDirectory(env,
-                $"$([MSBuild]::MakeRelative('obj', '{target}'))", correctDir.Path, wrongDir.Path);
+            var logger = new MockLogger();
+            ILoggingService loggingService = LoggingService.CreateLoggingService(LoggerMode.Synchronous, 1);
+            loggingService.RegisterLogger(logger);
+            var loggingContext = new MockLoggingContext(
+                loggingService,
+                new BuildEventContext(0, 0, BuildEventContext.InvalidProjectContextId, 0, 0));
 
-            result.ShouldBe(Path.Combine("..", "marker.txt"));
+            env.WithTransientTestState(new TransientThreadWorkingDirectory(correctDir.Path));
+            env.SetCurrentDirectory(wrongDir.Path);
+
+            string result = new Expander<ProjectPropertyInstance, ProjectItemInstance>(
+                    new PropertyDictionary<ProjectPropertyInstance>(), FileSystems.Default, loggingContext)
+                .ExpandIntoStringLeaveEscaped("$([MSBuild]::RegisterBuildCheck('check.dll'))", ExpanderOptions.ExpandProperties, MockElementLocation.Instance);
+
+            result.ShouldBe(bool.TrueString);
+            var acquisition = logger.AllBuildEvents.ShouldHaveSingleItem().ShouldBeOfType<BuildCheckAcquisitionEventArgs>();
+            acquisition.AcquisitionPath.ShouldBe(Path.Combine(correctDir.Path, "check.dll"));
         }
 
         [Fact]

--- a/src/Build.UnitTests/Evaluation/Expander_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/Expander_Tests.cs
@@ -5560,6 +5560,18 @@ $(
             return expander.ExpandIntoStringLeaveEscaped(expression, ExpanderOptions.ExpandProperties, MockElementLocation.Instance);
         }
 
+        /// <summary>
+        /// Helper: set the process current directory and return it as the OS reports it. On macOS the test
+        /// temp folder is reached through a symlink (/var -> /private/var), and only the reported form matches
+        /// what resolution against the process current directory produces, so tests that compare -mt output
+        /// against non-mt output must build both sides from this rather than from the TestEnvironment path.
+        /// </summary>
+        private static string SetCurrentDirectoryCanonical(TestEnvironment env, string path)
+        {
+            env.SetCurrentDirectory(path);
+            return Directory.GetCurrentDirectory();
+        }
+
         // =====================================================================
         // Category A: -mt mode tests for default-allowed File methods
         // =====================================================================
@@ -5598,13 +5610,13 @@ $(
             var wrongDir = env.CreateFolder(createFolder: true);
 
             // Baseline: non-mt mode, where the process current directory is the project directory.
-            env.SetCurrentDirectory(projectDir.Path);
+            string projectDirPath = SetCurrentDirectoryCanonical(env, projectDir.Path);
             string expected = IntrinsicFunctions.NormalizePath(@"\tmp\file.txt");
 
             // -mt mode must agree: on Unix a backslash is an ordinary filename character, so resolution
             // must not normalize separators or it would silently point at a different file.
             string result = ExpandWithThreadWorkingDirectory(env,
-                @"$([MSBuild]::NormalizePath('\tmp\file.txt'))", projectDir.Path, wrongDir.Path);
+                @"$([MSBuild]::NormalizePath('\tmp\file.txt'))", projectDirPath, wrongDir.Path);
 
             result.ShouldBe(expected);
         }
@@ -5616,11 +5628,11 @@ $(
             var projectDir = env.CreateFolder(createFolder: true);
             var wrongDir = env.CreateFolder(createFolder: true);
 
-            env.SetCurrentDirectory(projectDir.Path);
+            string projectDirPath = SetCurrentDirectoryCanonical(env, projectDir.Path);
             string expected = IntrinsicFunctions.NormalizePath(@"obj\..\file.txt");
 
             string result = ExpandWithThreadWorkingDirectory(env,
-                @"$([MSBuild]::NormalizePath('obj\..\file.txt'))", projectDir.Path, wrongDir.Path);
+                @"$([MSBuild]::NormalizePath('obj\..\file.txt'))", projectDirPath, wrongDir.Path);
 
             result.ShouldBe(expected);
         }
@@ -5678,12 +5690,12 @@ $(
         {
             using var env = TestEnvironment.Create(_output);
             var processDir = env.CreateFolder(createFolder: true);
-            env.SetCurrentDirectory(processDir.Path);
+            string processDirPath = SetCurrentDirectoryCanonical(env, processDir.Path);
 
             string result = ExpandWithThreadWorkingDirectory(env,
                 "$([MSBuild]::NormalizePath('obj', 'file.txt'))", null);
 
-            result.ShouldBe(Path.Combine(processDir.Path, "obj", "file.txt"));
+            result.ShouldBe(Path.Combine(processDirPath, "obj", "file.txt"));
         }
 
         [Fact]

--- a/src/Build.UnitTests/Evaluation/Expander_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/Expander_Tests.cs
@@ -5635,7 +5635,7 @@ $(
             Directory.CreateDirectory(Path.Combine(projectDir.Path, "sub"));
             File.WriteAllText(Path.Combine(projectDir.Path, "sub", "marker.txt"), "x");
 
-            // FileExists applies no separator normalization in either mode, so both must agree.
+            // FileExistsNoThrow normalizes separators internally, so both non-mt and -mt must agree.
             env.SetCurrentDirectory(projectDir.Path);
             string expected = IntrinsicFunctions.FileExists(@"sub\marker.txt").ToString();
 

--- a/src/Build/Evaluation/IntrinsicFunctions.cs
+++ b/src/Build/Evaluation/IntrinsicFunctions.cs
@@ -343,7 +343,7 @@ namespace Microsoft.Build.Evaluation
         /// <returns>relative path (can be the full path)</returns>
         public static string MakeRelative(string basePath, string path)
         {
-            string result = FileUtilities.MakeRelative(ResolveAgainstThreadWorkingDirectory(basePath), path);
+            string result = FileUtilities.MakeRelative(basePath, path);
 
             return result;
         }
@@ -759,7 +759,7 @@ namespace Microsoft.Build.Evaluation
 
         public static bool RegisterBuildCheck(string projectPath, string pathToAssembly, LoggingContext loggingContext)
         {
-            pathToAssembly = FileUtilities.GetFullPathNoThrow(pathToAssembly);
+            pathToAssembly = FileUtilities.GetFullPathNoThrow(ResolveAgainstThreadWorkingDirectory(pathToAssembly));
             if (FileSystems.Default.FileExists(pathToAssembly))
             {
                 loggingContext.LogBuildEvent(new BuildCheckAcquisitionEventArgs(pathToAssembly, projectPath));

--- a/src/Build/Evaluation/IntrinsicFunctions.cs
+++ b/src/Build/Evaluation/IntrinsicFunctions.cs
@@ -343,7 +343,7 @@ namespace Microsoft.Build.Evaluation
         /// <returns>relative path (can be the full path)</returns>
         public static string MakeRelative(string basePath, string path)
         {
-            string result = FileUtilities.MakeRelative(basePath, path);
+            string result = FileUtilities.MakeRelative(ResolveAgainstThreadWorkingDirectory(basePath), path);
 
             return result;
         }
@@ -357,7 +357,7 @@ namespace Microsoft.Build.Evaluation
         /// <returns>The full path of the directory containing the file if it is found, otherwise an empty string. </returns>
         public static string GetDirectoryNameOfFileAbove(string startingDirectory, string fileName, IFileSystem fileSystem)
         {
-            return FileUtilities.GetDirectoryNameOfFileAbove(startingDirectory, fileName, fileSystem);
+            return FileUtilities.GetDirectoryNameOfFileAbove(ResolveAgainstThreadWorkingDirectory(startingDirectory), fileName, fileSystem);
         }
 
         /// <summary>
@@ -370,7 +370,7 @@ namespace Microsoft.Build.Evaluation
         /// <returns>The full path of the file if it is found, otherwise an empty string.</returns>
         public static string GetPathOfFileAbove(string file, string startingDirectory, IFileSystem fileSystem)
         {
-            return FileUtilities.GetPathOfFileAbove(file, startingDirectory, fileSystem);
+            return FileUtilities.GetPathOfFileAbove(file, ResolveAgainstThreadWorkingDirectory(startingDirectory), fileSystem);
         }
 
         /// <summary>
@@ -534,7 +534,7 @@ namespace Microsoft.Build.Evaluation
         /// <returns></returns>
         public static bool FileExists(string path)
         {
-            return FileUtilities.FileExistsNoThrow(path);
+            return FileUtilities.FileExistsNoThrow(FixSeparatorsAndResolveAgainstThreadWorkingDirectory(path));
         }
 
         /// <summary>
@@ -544,8 +544,25 @@ namespace Microsoft.Build.Evaluation
         /// <returns></returns>
         public static bool DirectoryExists(string path)
         {
-            return FileUtilities.DirectoryExistsNoThrow(path);
+            return FileUtilities.DirectoryExistsNoThrow(FixSeparatorsAndResolveAgainstThreadWorkingDirectory(path));
         }
+
+        /// <summary>
+        /// As <see cref="ResolveAgainstThreadWorkingDirectory"/>, but normalizes directory separators first.
+        /// </summary>
+        /// <remarks>
+        /// Resolving turns on a rootedness test, and that test has to be asked in the same separator form the
+        /// callee's own resolution uses, or the two disagree about whether the path is relative. On Unix
+        /// <c>\tmp\x</c> is relative before separators are fixed and rooted after. <c>FileExistsNoThrow</c> and
+        /// <c>DirectoryExistsNoThrow</c> fix first and let the OS resolve the rest, so they see it as rooted
+        /// and we have to fix to match. <see cref="FileUtilities.NormalizePath(string)"/> and the other callees
+        /// resolve the raw string before fixing it, so they see it as relative and
+        /// <see cref="ResolveAgainstThreadWorkingDirectory"/> has to leave it alone. What is at stake is which
+        /// question gets asked, not the separators handed back, which the callee normalizes either way.
+        /// <see cref="FileUtilities.FixFilePath(string)"/> is a no-op on Windows, so this only ever bites on Unix.
+        /// </remarks>
+        private static string FixSeparatorsAndResolveAgainstThreadWorkingDirectory(string path)
+            => ResolveAgainstThreadWorkingDirectory(FileUtilities.FixFilePath(path));
 
         /// <summary>
         /// Gets the canonicalized full path of the provided path and ensures it contains the correct directory separator characters for the current operating system.
@@ -554,7 +571,27 @@ namespace Microsoft.Build.Evaluation
         /// <returns>A canonicalized full path with the correct directory separators.</returns>
         public static string NormalizePath(params string[] path)
         {
-            return FileUtilities.NormalizePath(path);
+            return FileUtilities.NormalizePath(ResolveAgainstThreadWorkingDirectory(Path.Combine(path)));
+        }
+
+        /// <summary>
+        /// In multithreaded (<c>-mt</c>) mode every project gets its own thread-local working directory while the
+        /// process-wide current directory is shared, so a relative path must be resolved against
+        /// <see cref="FileUtilities.CurrentThreadWorkingDirectory"/> rather than against the process current
+        /// directory, which may belong to an unrelated project and would silently produce a valid-looking but
+        /// wrong absolute path.
+        /// </summary>
+        /// <param name="path">The path to resolve. May be null, empty, or already fully qualified.</param>
+        /// <returns>The resolved path, or <paramref name="path"/> unchanged when no resolution is needed.</returns>
+        private static string ResolveAgainstThreadWorkingDirectory(string path)
+        {
+            if (string.IsNullOrEmpty(FileUtilities.CurrentThreadWorkingDirectory))
+            {
+                return path;
+            }
+
+            AbsolutePath? resolvedPath = FileUtilities.MakeFullPathFromThreadWorkingDirectory(path);
+            return resolvedPath?.Value ?? path;
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #14872.

In MT mode, each project uses a thread-local working directory while the process current directory is shared. `[MSBuild]::NormalizePath` and other intrinsic functions ignored the thread-local directory and resolved relative paths against the process directory, which could produce valid-looking absolute paths rooted under the wrong project or host directory.

This change combines the path arguments, resolves relative paths against `FileUtilities.CurrentThreadWorkingDirectory` when available, and then applies the existing normalization. Non-MT behavior and already-absolute paths remain unchanged.
