### PR TITLE
Preserve events routed through the TaskHostTask

### DIFF
--- a/documentation/wiki/ChangeWaves.md
+++ b/documentation/wiki/ChangeWaves.md
@@ -35,6 +35,9 @@ Change wave checks around features will be removed in the release that accompani
 
 ## Current Rotation of Change Waves
 
+### 18.12
+- [Events that a task logs from a TaskHost - extended errors, warnings and messages, critical messages, telemetry, and any other event kind the router did not enumerate - reach the parent process instead of being dropped.](https://github.com/dotnet/msbuild/pull/14876)
+
 ### 18.11
 - [XmlPeek, XmlPoke, and XslTransformation default to prohibiting embedded DTDs](https://github.com/dotnet/msbuild/pull/14285)
 - [Out-of-proc communication uses larger read-ahead buffers and pre-buffers TaskHost packet bodies to reduce pipe reads.](https://github.com/dotnet/msbuild/pull/14505)

--- a/src/Build.UnitTests/BackEnd/TaskRouter_IntegrationTests.cs
+++ b/src/Build.UnitTests/BackEnd/TaskRouter_IntegrationTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using Microsoft.Build.Execution;
 using Microsoft.Build.Framework;
@@ -52,32 +53,10 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
         public void NonEnlightenedTask_RunsInTaskHost_InMultiThreadedMode()
         {
             // Arrange
-            string projectContent = CreateTestProject(
-                taskName: "NonEnlightenedTestTask",
-                taskClass: "NonEnlightenedTask");
-
-            string projectFile = Path.Combine(_testProjectsDir, "NonEnlightenedTaskProject.proj");
-            File.WriteAllText(projectFile, projectContent);
-
             var logger = new MockLogger(_output);
-            var buildParameters = new BuildParameters
-            {
-                MultiThreaded = true,
-                Loggers = new[] { logger },
-                DisableInProcNode = false,
-                EnableNodeReuse = false
-            };
-
-            var buildRequestData = new BuildRequestData(
-                projectFile,
-                new Dictionary<string, string>(),
-                null,
-                new[] { "TestTarget" },
-                null);
 
             // Act
-            var buildManager = BuildManager.DefaultBuildManager;
-            var result = buildManager.Build(buildParameters, buildRequestData);
+            BuildResult result = BuildSingleTaskProject("NonEnlightenedTestTask", "NonEnlightenedTaskProject.proj", multiThreaded: true, logger);
 
             // Assert
             result.OverallResult.ShouldBe(BuildResultCode.Success);
@@ -97,32 +76,10 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
         public void TaskWithInterface_RunsInTaskHost_InMultiThreadedMode()
         {
             // Arrange
-            string projectContent = CreateTestProject(
-                taskName: "InterfaceTestTask",
-                taskClass: "TaskWithInterface");
-
-            string projectFile = Path.Combine(_testProjectsDir, "InterfaceTaskProject.proj");
-            File.WriteAllText(projectFile, projectContent);
-
             var logger = new MockLogger(_output);
-            var buildParameters = new BuildParameters
-            {
-                MultiThreaded = true,
-                Loggers = new[] { logger },
-                DisableInProcNode = false,
-                EnableNodeReuse = false
-            };
-
-            var buildRequestData = new BuildRequestData(
-                projectFile,
-                new Dictionary<string, string>(),
-                null,
-                new[] { "TestTarget" },
-                null);
 
             // Act
-            var buildManager = BuildManager.DefaultBuildManager;
-            var result = buildManager.Build(buildParameters, buildRequestData);
+            BuildResult result = BuildSingleTaskProject("InterfaceTestTask", "InterfaceTaskProject.proj", multiThreaded: true, logger);
 
             // Assert
             result.OverallResult.ShouldBe(BuildResultCode.Success);
@@ -142,32 +99,10 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
         public void TaskWithAttribute_RunsInProcess_InMultiThreadedMode()
         {
             // Arrange
-            string projectContent = CreateTestProject(
-                taskName: "AttributeTestTask",
-                taskClass: "TaskWithAttribute");
-
-            string projectFile = Path.Combine(_testProjectsDir, "AttributeTaskProject.proj");
-            File.WriteAllText(projectFile, projectContent);
-
             var logger = new MockLogger(_output);
-            var buildParameters = new BuildParameters
-            {
-                MultiThreaded = true,
-                Loggers = new[] { logger },
-                DisableInProcNode = false,
-                EnableNodeReuse = false
-            };
-
-            var buildRequestData = new BuildRequestData(
-                projectFile,
-                new Dictionary<string, string>(),
-                null,
-                new[] { "TestTarget" },
-                null);
 
             // Act
-            var buildManager = BuildManager.DefaultBuildManager;
-            var result = buildManager.Build(buildParameters, buildRequestData);
+            BuildResult result = BuildSingleTaskProject("AttributeTestTask", "AttributeTaskProject.proj", multiThreaded: true, logger);
 
             // Assert
             result.OverallResult.ShouldBe(BuildResultCode.Success);
@@ -187,32 +122,10 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
         public void NonEnlightenedTask_RunsInProcess_WhenMultiThreadedModeDisabled()
         {
             // Arrange
-            string projectContent = CreateTestProject(
-                taskName: "NonEnlightenedTestTask",
-                taskClass: "NonEnlightenedTask");
-
-            string projectFile = Path.Combine(_testProjectsDir, "NonEnlightenedTaskSingleThreaded.proj");
-            File.WriteAllText(projectFile, projectContent);
-
             var logger = new MockLogger(_output);
-            var buildParameters = new BuildParameters
-            {
-                MultiThreaded = false, // Single-threaded mode
-                Loggers = new[] { logger },
-                DisableInProcNode = false,
-                EnableNodeReuse = false
-            };
-
-            var buildRequestData = new BuildRequestData(
-                projectFile,
-                new Dictionary<string, string>(),
-                null,
-                new[] { "TestTarget" },
-                null);
 
             // Act
-            var buildManager = BuildManager.DefaultBuildManager;
-            var result = buildManager.Build(buildParameters, buildRequestData);
+            BuildResult result = BuildSingleTaskProject("NonEnlightenedTestTask", "NonEnlightenedTaskSingleThreaded.proj", multiThreaded: false, logger);
 
             // Assert
             result.OverallResult.ShouldBe(BuildResultCode.Success);
@@ -231,32 +144,10 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
         public void TaskWithInterface_RunsInProcess_WhenMultiThreadedModeDisabled()
         {
             // Arrange
-            string projectContent = CreateTestProject(
-                taskName: "InterfaceTestTask",
-                taskClass: "TaskWithInterface");
-
-            string projectFile = Path.Combine(_testProjectsDir, "InterfaceTaskSingleThreaded.proj");
-            File.WriteAllText(projectFile, projectContent);
-
             var logger = new MockLogger(_output);
-            var buildParameters = new BuildParameters
-            {
-                MultiThreaded = false, // Single-threaded mode
-                Loggers = new[] { logger },
-                DisableInProcNode = false,
-                EnableNodeReuse = false
-            };
-
-            var buildRequestData = new BuildRequestData(
-                projectFile,
-                new Dictionary<string, string>(),
-                null,
-                new[] { "TestTarget" },
-                null);
 
             // Act
-            var buildManager = BuildManager.DefaultBuildManager;
-            var result = buildManager.Build(buildParameters, buildRequestData);
+            BuildResult result = BuildSingleTaskProject("InterfaceTestTask", "InterfaceTaskSingleThreaded.proj", multiThreaded: false, logger);
 
             // Assert
             result.OverallResult.ShouldBe(BuildResultCode.Success);
@@ -289,28 +180,10 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
     </Target>
 </Project>";
 
-            string projectFile = Path.Combine(_testProjectsDir, "MixedTasksProject.proj");
-            File.WriteAllText(projectFile, projectContent);
-
             var logger = new MockLogger(_output);
-            var buildParameters = new BuildParameters
-            {
-                MultiThreaded = true,
-                Loggers = new[] { logger },
-                DisableInProcNode = false,
-                EnableNodeReuse = false
-            };
-
-            var buildRequestData = new BuildRequestData(
-                projectFile,
-                new Dictionary<string, string>(),
-                null,
-                new[] { "TestTarget" },
-                null);
 
             // Act
-            var buildManager = BuildManager.DefaultBuildManager;
-            var result = buildManager.Build(buildParameters, buildRequestData);
+            BuildResult result = BuildProject("MixedTasksProject.proj", projectContent, multiThreaded: true, logger);
 
             // Assert
             result.OverallResult.ShouldBe(BuildResultCode.Success);
@@ -347,28 +220,10 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
     </Target>
 </Project>";
 
-            string projectFile = Path.Combine(_testProjectsDir, "ExplicitTaskHostFactory.proj");
-            File.WriteAllText(projectFile, projectContent);
-
             var logger = new MockLogger(_output);
-            var buildParameters = new BuildParameters
-            {
-                MultiThreaded = true,
-                Loggers = new[] { logger },
-                DisableInProcNode = false,
-                EnableNodeReuse = false
-            };
-
-            var buildRequestData = new BuildRequestData(
-                projectFile,
-                new Dictionary<string, string>(),
-                null,
-                new[] { "TestTarget" },
-                null);
 
             // Act
-            var buildManager = BuildManager.DefaultBuildManager;
-            var result = buildManager.Build(buildParameters, buildRequestData);
+            BuildResult result = BuildProject("ExplicitTaskHostFactory.proj", projectContent, multiThreaded: true, logger);
 
             // Assert
             result.OverallResult.ShouldBe(BuildResultCode.Success);
@@ -379,6 +234,140 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
 
             // Verify task executed successfully
             logger.FullLog.ShouldContain("TaskWithAttribute executed");
+        }
+
+        [Fact]
+        public void ExtendedBuildError_RoutedThroughTaskHost_PreservesStructuredData()
+        {
+            var logger = new MockLogger(_output);
+
+            BuildResult result = BuildSingleTaskProject("ExtendedBuildErrorTestTask", "ExtendedBuildErrorProject.proj", multiThreaded: true, logger);
+
+            result.ShouldHaveFailed();
+            TaskRouterTestHelper.AssertTaskUsedTaskHost(logger, "ExtendedBuildErrorTestTask");
+            logger.Errors.Count.ShouldBe(1);
+
+            ExtendedBuildErrorEventArgs error = logger.Errors[0].ShouldBeOfType<ExtendedBuildErrorEventArgs>();
+            error.Code.ShouldBe("TEST0001");
+            error.ExtendedType.ShouldBe("cpp");
+            error.ExtendedData.ShouldBe("""{"tool":"cl.exe"}""");
+            error.ExtendedMetadata.ShouldNotBeNull();
+            error.ExtendedMetadata["source"].ShouldBe("structured-output");
+        }
+
+        /// <summary>
+        /// Companion to <see cref="ExtendedBuildError_RoutedThroughTaskHost_PreservesStructuredData"/>: the remaining
+        /// event kinds that <c>TaskHostTask</c> routes explicitly (critical messages, extended warnings, extended
+        /// messages, extended critical messages and extended custom events) must also reach the parent logger as their
+        /// concrete types with their structured payload intact.
+        /// </summary>
+        [Fact]
+        public void NonErrorExtendedEvents_RoutedThroughTaskHost_PreserveStructuredData()
+        {
+            var logger = new MockLogger(_output) { Verbosity = LoggerVerbosity.Diagnostic };
+
+            BuildResult result = BuildSingleTaskProject("ExtendedEventsTestTask", "ExtendedEventsProject.proj", multiThreaded: true, logger);
+
+            result.OverallResult.ShouldBe(BuildResultCode.Success);
+            TaskRouterTestHelper.AssertTaskUsedTaskHost(logger, "ExtendedEventsTestTask");
+            logger.Errors.ShouldBeEmpty();
+
+            // LoggingEventType.CriticalBuildMessage
+            CriticalBuildMessageEventArgs criticalMessage = logger.AllBuildEvents
+                .Where(e => e.GetType() == typeof(CriticalBuildMessageEventArgs))
+                .ShouldHaveSingleItem()
+                .ShouldBeOfType<CriticalBuildMessageEventArgs>();
+            criticalMessage.Code.ShouldBe("TEST0002");
+            criticalMessage.Message.ShouldBe("Critical message");
+
+            // LoggingEventType.ExtendedBuildWarningEvent
+            ExtendedBuildWarningEventArgs warning = logger.Warnings.ShouldHaveSingleItem().ShouldBeOfType<ExtendedBuildWarningEventArgs>();
+            warning.Code.ShouldBe("TEST0003");
+            warning.ExtendedType.ShouldBe("cpp");
+            warning.ExtendedData.ShouldBe("""{"tool":"cl.exe"}""");
+            warning.ExtendedMetadata.ShouldNotBeNull();
+            warning.ExtendedMetadata["source"].ShouldBe("structured-output");
+
+            // LoggingEventType.ExtendedBuildMessageEvent
+            ExtendedBuildMessageEventArgs message = logger.AllBuildEvents
+                .OfType<ExtendedBuildMessageEventArgs>()
+                .ShouldHaveSingleItem();
+            message.Code.ShouldBe("TEST0004");
+            message.ExtendedType.ShouldBe("cpp");
+            message.ExtendedData.ShouldBe("""{"tool":"cl.exe"}""");
+            message.ExtendedMetadata.ShouldNotBeNull();
+            message.ExtendedMetadata["source"].ShouldBe("structured-output");
+
+            // LoggingEventType.ExtendedCriticalBuildMessageEvent
+            ExtendedCriticalBuildMessageEventArgs extendedCriticalMessage = logger.AllBuildEvents
+                .OfType<ExtendedCriticalBuildMessageEventArgs>()
+                .ShouldHaveSingleItem();
+            extendedCriticalMessage.Code.ShouldBe("TEST0005");
+            extendedCriticalMessage.ExtendedType.ShouldBe("cpp");
+            extendedCriticalMessage.ExtendedData.ShouldBe("""{"tool":"cl.exe"}""");
+            extendedCriticalMessage.ExtendedMetadata.ShouldNotBeNull();
+            extendedCriticalMessage.ExtendedMetadata["source"].ShouldBe("structured-output");
+
+            // LoggingEventType.ExtendedCustomEvent
+            ExtendedCustomBuildEventArgs customEvent = logger.AllBuildEvents
+                .OfType<ExtendedCustomBuildEventArgs>()
+                .ShouldHaveSingleItem();
+            customEvent.Message.ShouldBe("Structured custom event");
+            customEvent.ExtendedType.ShouldBe("cpp");
+            customEvent.ExtendedData.ShouldBe("""{"tool":"cl.exe"}""");
+            customEvent.ExtendedMetadata.ShouldNotBeNull();
+            customEvent.ExtendedMetadata["source"].ShouldBe("structured-output");
+        }
+
+        /// <summary>
+        /// Telemetry raised by a task through <see cref="IBuildEngine5.LogTelemetry"/> must survive the TaskHost
+        /// round-trip. A task can only ever supply an event name and a property bag, so forwarding those two values
+        /// reproduces exactly what the same task would have produced in-process.
+        /// </summary>
+        [Fact]
+        public void Telemetry_RoutedThroughTaskHost_ReachesLoggers()
+        {
+            // MockLogger cannot observe telemetry: EventSourceSink routes TelemetryEventArgs to TelemetryLogged only,
+            // never to AnyEventRaised. A dedicated IEventSource2 subscriber is required.
+            var logger = new MockLogger(_output);
+            var telemetryLogger = new TelemetryCapturingLogger();
+
+            BuildResult result = BuildSingleTaskProject("TelemetryTestTask", "TelemetryProject.proj", multiThreaded: true, logger, telemetryLogger);
+
+            result.OverallResult.ShouldBe(BuildResultCode.Success);
+            TaskRouterTestHelper.AssertTaskUsedTaskHost(logger, "TelemetryTestTask");
+
+            TelemetryEventArgs telemetry = telemetryLogger.TelemetryEvents
+                .Where(e => e.EventName == "TaskHostTelemetryEvent")
+                .ShouldHaveSingleItem();
+            telemetry.Properties["tool"].ShouldBe("cl.exe");
+            telemetry.Properties["exitCode"].ShouldBe("0");
+        }
+
+        /// <summary>
+        /// The switch in <c>TaskHostTask.HandleLoggedMessage</c> is an allow-list, so any event kind without an
+        /// explicit case was silently discarded. <see cref="ExternalProjectStartedEventArgs"/> is a framework type
+        /// with its own <c>LoggingEventType</c> that a task can log through <see cref="IBuildEngine.LogCustomEvent"/>,
+        /// which makes it a representative of that whole class of dropped events. It must now reach the parent logger
+        /// as its concrete type by way of the fallback dispatch on the event's base type.
+        /// </summary>
+        [Fact]
+        public void EventKindWithoutExplicitCase_RoutedThroughTaskHost_ReachesLoggers()
+        {
+            var logger = new MockLogger(_output) { Verbosity = LoggerVerbosity.Diagnostic };
+
+            BuildResult result = BuildSingleTaskProject("UnlistedEventTestTask", "UnlistedEventProject.proj", multiThreaded: true, logger);
+
+            result.OverallResult.ShouldBe(BuildResultCode.Success);
+            TaskRouterTestHelper.AssertTaskUsedTaskHost(logger, "UnlistedEventTestTask");
+            logger.Errors.ShouldBeEmpty();
+
+            ExternalProjectStartedEventArgs externalProjectStarted = logger.AllBuildEvents
+                .OfType<ExternalProjectStartedEventArgs>()
+                .ShouldHaveSingleItem();
+            externalProjectStarted.Message.ShouldBe("External project started");
+            externalProjectStarted.ProjectFile.ShouldBe("external.proj");
+            externalProjectStarted.TargetNames.ShouldBe("Build");
         }
 
         /// <summary>
@@ -408,27 +397,10 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
     </Target>
 </Project>";
 
-            string projectFile = Path.Combine(_testProjectsDir, $"NoAssemblyLocationMismatch_{multiThreaded}.proj");
-            File.WriteAllText(projectFile, projectContent);
-
             var logger = new MockLogger(_output);
-            var buildParameters = new BuildParameters
-            {
-                MultiThreaded = multiThreaded,
-                Loggers = new[] { logger },
-                DisableInProcNode = false,
-                EnableNodeReuse = false
-            };
-
-            var buildRequestData = new BuildRequestData(
-                projectFile,
-                new Dictionary<string, string>(),
-                null,
-                new[] { "TestTarget" },
-                null);
 
             // Act
-            var result = BuildManager.DefaultBuildManager.Build(buildParameters, buildRequestData);
+            BuildResult result = BuildProject($"NoAssemblyLocationMismatch_{multiThreaded}.proj", projectContent, multiThreaded, logger);
 
             // Assert
             result.OverallResult.ShouldBe(BuildResultCode.Success);
@@ -447,7 +419,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
             logger.FullLog.ShouldNotContain(mismatchMessagePrefix);
         }
 
-        private string CreateTestProject(string taskName, string taskClass)
+        private string CreateTestProject(string taskName)
         {
             return $@"
 <Project>
@@ -458,6 +430,39 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
     </Target>
 </Project>";
         }
+
+        /// <summary>
+        /// Writes <paramref name="projectContent"/> into the test folder and builds its <c>TestTarget</c>.
+        /// Loggers are supplied by the caller so that each test can assert against them afterwards.
+        /// </summary>
+        private BuildResult BuildProject(string projectFileName, string projectContent, bool multiThreaded, params ILogger[] loggers)
+        {
+            string projectFile = Path.Combine(_testProjectsDir, projectFileName);
+            File.WriteAllText(projectFile, projectContent);
+
+            var buildParameters = new BuildParameters
+            {
+                MultiThreaded = multiThreaded,
+                Loggers = loggers,
+                DisableInProcNode = false,
+                EnableNodeReuse = false
+            };
+
+            var buildRequestData = new BuildRequestData(
+                projectFile,
+                new Dictionary<string, string>(),
+                null,
+                ["TestTarget"],
+                null);
+
+            return BuildManager.DefaultBuildManager.Build(buildParameters, buildRequestData);
+        }
+
+        /// <summary>
+        /// Builds a project whose single target invokes <paramref name="taskName"/> once.
+        /// </summary>
+        private BuildResult BuildSingleTaskProject(string taskName, string projectFileName, bool multiThreaded = true, params ILogger[] loggers)
+            => BuildProject(projectFileName, CreateTestProject(taskName), multiThreaded, loggers);
     }
 
     /// <summary>
@@ -492,6 +497,32 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
         }
     }
 
+    /// <summary>
+    /// Captures telemetry events, which <see cref="MockLogger"/> cannot observe because
+    /// <c>EventSourceSink</c> routes <see cref="TelemetryEventArgs"/> exclusively to
+    /// <see cref="IEventSource2.TelemetryLogged"/>.
+    /// </summary>
+    internal sealed class TelemetryCapturingLogger : ILogger
+    {
+        public LoggerVerbosity Verbosity { get; set; } = LoggerVerbosity.Normal;
+
+        public string Parameters { get; set; }
+
+        public List<TelemetryEventArgs> TelemetryEvents { get; } = [];
+
+        public void Initialize(IEventSource eventSource)
+        {
+            if (eventSource is IEventSource2 eventSource2)
+            {
+                eventSource2.TelemetryLogged += (sender, e) => TelemetryEvents.Add(e);
+            }
+        }
+
+        public void Shutdown()
+        {
+        }
+    }
+
     #region Test Task Implementations
 
     /// <summary>
@@ -505,6 +536,161 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
             Log.LogMessage(MessageImportance.High, "NonEnlightenedTask executed");
             return true;
         }
+    }
+
+    /// <summary>
+    /// Logs a framework event kind that <c>TaskHostTask.HandleLoggedMessage</c> has no explicit case for, so the
+    /// test can assert that the fallback dispatch forwards it instead of discarding it.
+    /// </summary>
+    public class UnlistedEventTestTask : Task
+    {
+        public override bool Execute()
+        {
+            BuildEngine.LogCustomEvent(new ExternalProjectStartedEventArgs(
+                message: "External project started",
+                helpKeyword: null,
+                senderName: nameof(UnlistedEventTestTask),
+                projectFile: "external.proj",
+                targetNames: "Build"));
+
+            return true;
+        }
+    }
+
+    /// <summary>
+    /// Logs telemetry the way a real task does, through <see cref="TaskLoggingHelper.LogTelemetry"/>.
+    /// </summary>
+    public class TelemetryTestTask : Task
+    {
+        public override bool Execute()
+        {
+            Log.LogTelemetry("TaskHostTelemetryEvent", new Dictionary<string, string>
+            {
+                ["tool"] = "cl.exe",
+                ["exitCode"] = "0"
+            });
+
+            return true;
+        }
+    }
+
+    public class ExtendedBuildErrorTestTask : Task    {
+        public override bool Execute()
+        {
+            BuildEngine.LogErrorEvent(new ExtendedBuildErrorEventArgs(
+                "cpp",
+                subcategory: null,
+                code: "TEST0001",
+                file: "source.cpp",
+                lineNumber: 1,
+                columnNumber: 2,
+                endLineNumber: 1,
+                endColumnNumber: 3,
+                message: "Structured compiler error",
+                helpKeyword: null,
+                senderName: nameof(ExtendedBuildErrorTestTask))
+            {
+                ExtendedData = """{"tool":"cl.exe"}""",
+                ExtendedMetadata = new Dictionary<string, string>
+                {
+                    ["source"] = "structured-output"
+                }
+            });
+
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Logs one instance of each non-error event kind that <c>TaskHostTask</c> routes explicitly, so the test can
+    /// assert that each survives the TaskHost round-trip as its concrete type.
+    /// </summary>
+    public class ExtendedEventsTestTask : Task
+    {
+        private const string ExtendedDataJson = """{"tool":"cl.exe"}""";
+
+        public override bool Execute()
+        {
+            Log.LogCriticalMessage(
+                subcategory: null,
+                code: "TEST0002",
+                helpKeyword: null,
+                file: "source.cpp",
+                lineNumber: 1,
+                columnNumber: 2,
+                endLineNumber: 1,
+                endColumnNumber: 3,
+                message: "Critical message");
+
+            BuildEngine.LogWarningEvent(new ExtendedBuildWarningEventArgs(
+                "cpp",
+                subcategory: null,
+                code: "TEST0003",
+                file: "source.cpp",
+                lineNumber: 1,
+                columnNumber: 2,
+                endLineNumber: 1,
+                endColumnNumber: 3,
+                message: "Structured compiler warning",
+                helpKeyword: null,
+                senderName: nameof(ExtendedEventsTestTask))
+            {
+                ExtendedData = ExtendedDataJson,
+                ExtendedMetadata = CreateMetadata()
+            });
+
+            BuildEngine.LogMessageEvent(new ExtendedBuildMessageEventArgs(
+                "cpp",
+                subcategory: null,
+                code: "TEST0004",
+                file: "source.cpp",
+                lineNumber: 1,
+                columnNumber: 2,
+                endLineNumber: 1,
+                endColumnNumber: 3,
+                message: "Structured compiler message",
+                helpKeyword: null,
+                senderName: nameof(ExtendedEventsTestTask),
+                importance: MessageImportance.High)
+            {
+                ExtendedData = ExtendedDataJson,
+                ExtendedMetadata = CreateMetadata()
+            });
+
+            BuildEngine.LogMessageEvent(new ExtendedCriticalBuildMessageEventArgs(
+                "cpp",
+                subcategory: null,
+                code: "TEST0005",
+                file: "source.cpp",
+                lineNumber: 1,
+                columnNumber: 2,
+                endLineNumber: 1,
+                endColumnNumber: 3,
+                message: "Structured critical message",
+                helpKeyword: null,
+                senderName: nameof(ExtendedEventsTestTask))
+            {
+                ExtendedData = ExtendedDataJson,
+                ExtendedMetadata = CreateMetadata()
+            });
+
+            BuildEngine.LogCustomEvent(new ExtendedCustomBuildEventArgs(
+                "cpp",
+                message: "Structured custom event",
+                helpKeyword: null,
+                senderName: nameof(ExtendedEventsTestTask))
+            {
+                ExtendedData = ExtendedDataJson,
+                ExtendedMetadata = CreateMetadata()
+            });
+
+            return true;
+        }
+
+        private static Dictionary<string, string> CreateMetadata() => new()
+        {
+            ["source"] = "structured-output"
+        };
     }
 
     /// <summary>

--- a/src/Build.UnitTests/BackEnd/TaskRouter_IntegrationTests.cs
+++ b/src/Build.UnitTests/BackEnd/TaskRouter_IntegrationTests.cs
@@ -43,6 +43,9 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
         public void Dispose()
         {
             _env.Dispose();
+
+            // The resolved wave is cached in a static, so it has to be dropped along with the environment variable.
+            ChangeWaves.ResetStateForTests();
         }
 
         /// <summary>
@@ -320,6 +323,62 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
         }
 
         /// <summary>
+        /// <c>TaskHostTask</c> is also reached without multithreading, through an explicitly requested
+        /// <c>TaskHostFactory</c>. That route swallowed extended warnings before, so the corrected routing has to be
+        /// visible there too.
+        /// </summary>
+        [Fact]
+        public void ExtendedWarning_FromExplicitTaskHostFactory_ReachesParentLogger()
+        {
+            var logger = new MockLogger(_output);
+
+            BuildResult result = BuildExtendedEventsUnderTaskHostFactory("ExtendedEventsTaskHostFactory.proj", logger);
+
+            result.OverallResult.ShouldBe(BuildResultCode.Success);
+            TaskRouterTestHelper.AssertTaskUsedTaskHost(logger, "ExtendedEventsTestTask");
+            logger.Warnings.ShouldHaveSingleItem().ShouldBeOfType<ExtendedBuildWarningEventArgs>().Code.ShouldBe("TEST0003");
+        }
+
+        /// <summary>
+        /// Opting out of Wave18_12 restores the previous behavior: the events the old switch did not enumerate are
+        /// dropped again.
+        /// </summary>
+        [Fact]
+        public void ExtendedWarning_FromExplicitTaskHostFactory_IsDroppedWhenWaveDisabled()
+        {
+            DisableWave18_12();
+            var logger = new MockLogger(_output);
+
+            BuildResult result = BuildExtendedEventsUnderTaskHostFactory("ExtendedEventsTaskHostFactoryWaveDisabled.proj", logger);
+
+            result.OverallResult.ShouldBe(BuildResultCode.Success);
+            TaskRouterTestHelper.AssertTaskUsedTaskHost(logger, "ExtendedEventsTestTask");
+            logger.Warnings.ShouldBeEmpty();
+        }
+
+        /// <summary>
+        /// The reason the opt-out exists: a warning that used to be swallowed fails a build running /warnAsError, so
+        /// a build that succeeded before this change can now fail. Disabling the wave has to bring it back.
+        /// </summary>
+        [Theory]
+        [InlineData(false, BuildResultCode.Failure)]
+        [InlineData(true, BuildResultCode.Success)]
+        public void ExtendedWarning_FromExplicitTaskHostFactory_FailsWarnAsErrorBuildUnlessWaveDisabled(bool disableWave, BuildResultCode expected)
+        {
+            if (disableWave)
+            {
+                DisableWave18_12();
+            }
+
+            var logger = new MockLogger(_output);
+
+            BuildResult result = BuildExtendedEventsUnderTaskHostFactory(
+                $"ExtendedEventsTaskHostFactoryWarnAsError_{disableWave}.proj", logger, warnAsError: true);
+
+            result.OverallResult.ShouldBe(expected);
+        }
+
+        /// <summary>
         /// Telemetry raised by a task through <see cref="IBuildEngine5.LogTelemetry"/> must survive the TaskHost
         /// round-trip. A task can only ever supply an event name and a property bag, so forwarding those two values
         /// reproduces exactly what the same task would have produced in-process.
@@ -463,6 +522,53 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
         /// </summary>
         private BuildResult BuildSingleTaskProject(string taskName, string projectFileName, bool multiThreaded = true, params ILogger[] loggers)
             => BuildProject(projectFileName, CreateTestProject(taskName), multiThreaded, loggers);
+
+        /// <summary>
+        /// Builds <see cref="ExtendedEventsTestTask"/> through an explicitly requested <c>TaskHostFactory</c>: the
+        /// pre-existing, non-multithreaded route into <c>TaskHostTask</c> that Wave18_12 gates.
+        /// </summary>
+        private BuildResult BuildExtendedEventsUnderTaskHostFactory(string projectFileName, MockLogger logger, bool warnAsError = false)
+        {
+            string projectFile = Path.Combine(_testProjectsDir, projectFileName);
+            File.WriteAllText(projectFile, $@"
+<Project>
+    <UsingTask TaskName=""ExtendedEventsTestTask"" AssemblyFile=""{Assembly.GetExecutingAssembly().Location}"" TaskFactory=""TaskHostFactory"" />
+
+    <Target Name=""TestTarget"">
+        <ExtendedEventsTestTask />
+    </Target>
+</Project>");
+
+            var buildParameters = new BuildParameters
+            {
+                MultiThreaded = false,
+                Loggers = [logger],
+                DisableInProcNode = false,
+                EnableNodeReuse = false,
+
+                // An empty set means "treat every warning as an error".
+                WarningsAsErrors = warnAsError ? new HashSet<string>() : null
+            };
+
+            var buildRequestData = new BuildRequestData(
+                projectFile,
+                new Dictionary<string, string>(),
+                null,
+                ["TestTarget"],
+                null);
+
+            return BuildManager.DefaultBuildManager.Build(buildParameters, buildRequestData);
+        }
+
+        /// <summary>
+        /// Opts out of Wave18_12 for the remainder of the test. <see cref="Dispose"/> restores the cached state.
+        /// </summary>
+        private void DisableWave18_12()
+        {
+            ChangeWaves.ResetStateForTests();
+            _env.SetEnvironmentVariable("MSBUILDDISABLEFEATURESFROMVERSION", ChangeWaves.Wave18_12.ToString());
+            BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly();
+        }
     }
 
     /// <summary>

--- a/src/Build/Instance/TaskFactories/TaskHostTask.cs
+++ b/src/Build/Instance/TaskFactories/TaskHostTask.cs
@@ -666,6 +666,19 @@ namespace Microsoft.Build.BackEnd
         /// </summary>
         private void HandleLoggedMessage(LogMessagePacket logMessagePacket)
         {
+            // Before Wave18_12 the switch below enumerated only these five event kinds and had no default case,
+            // so every other kind - extended events, critical messages, telemetry - was dropped without a trace.
+            // Surfacing them can fail a build running /warnAsError, so disabling the wave restores that behavior.
+            if (!ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave18_12)
+                && logMessagePacket.EventType is not (LoggingEventType.BuildErrorEvent
+                    or LoggingEventType.BuildWarningEvent
+                    or LoggingEventType.TaskCommandLineEvent
+                    or LoggingEventType.BuildMessageEvent
+                    or LoggingEventType.CustomEvent))
+            {
+                return;
+            }
+
             switch (logMessagePacket.EventType)
             {
                 case LoggingEventType.BuildErrorEvent:

--- a/src/Build/Instance/TaskFactories/TaskHostTask.cs
+++ b/src/Build/Instance/TaskFactories/TaskHostTask.cs
@@ -669,20 +669,41 @@ namespace Microsoft.Build.BackEnd
             switch (logMessagePacket.EventType)
             {
                 case LoggingEventType.BuildErrorEvent:
+                case LoggingEventType.ExtendedBuildErrorEvent:
                     this.BuildEngine.LogErrorEvent((BuildErrorEventArgs)logMessagePacket.NodeBuildEvent.Value.Value);
                     break;
                 case LoggingEventType.BuildWarningEvent:
+                case LoggingEventType.ExtendedBuildWarningEvent:
                     this.BuildEngine.LogWarningEvent((BuildWarningEventArgs)logMessagePacket.NodeBuildEvent.Value.Value);
                     break;
                 case LoggingEventType.TaskCommandLineEvent:
                 case LoggingEventType.BuildMessageEvent:
+                case LoggingEventType.CriticalBuildMessage:
+                case LoggingEventType.ExtendedBuildMessageEvent:
+                case LoggingEventType.ExtendedCriticalBuildMessageEvent:
                     this.BuildEngine.LogMessageEvent((BuildMessageEventArgs)logMessagePacket.NodeBuildEvent.Value.Value);
                     break;
+                case LoggingEventType.Telemetry:
+                    // A task can only ever produce telemetry through IBuildEngine5.LogTelemetry(name, properties),
+                    // so forwarding those two values reproduces exactly what an in-proc task would have logged.
+                    if (_buildEngine is IBuildEngine5 engine5)
+                    {
+                        TelemetryEventArgs telemetryEvent = (TelemetryEventArgs)logMessagePacket.NodeBuildEvent.Value.Value;
+                        engine5.LogTelemetry(telemetryEvent.EventName, telemetryEvent.Properties);
+                    }
+
+                    break;
                 case LoggingEventType.CustomEvent:
+                case LoggingEventType.ExtendedCustomEvent:
+                default:
                     BuildEventArgs buildEvent = logMessagePacket.NodeBuildEvent.Value.Value;
 
                     // "Custom events" in terms of the communications infrastructure can also be, e.g. custom error events,
                     // in which case they need to be dealt with in the same way as their base type of event.
+                    // The same dispatch also covers every event kind without an explicit case above: the task host can
+                    // only ever send what it was handed through LogErrorEvent, LogWarningEvent, LogMessageEvent or
+                    // LogCustomEvent, all of which are strongly typed, so matching on those base types is exhaustive.
+                    // Without this fallback any event type that is not enumerated above is dropped without a trace.
                     if (buildEvent is BuildErrorEventArgs buildErrorEventArgs)
                     {
                         this.BuildEngine.LogErrorEvent(buildErrorEventArgs);

--- a/src/Framework/ChangeWaves.cs
+++ b/src/Framework/ChangeWaves.cs
@@ -35,7 +35,8 @@ namespace Microsoft.Build.Framework
         internal static readonly Version Wave18_9 = new Version(18, 9);
         internal static readonly Version Wave18_10 = new Version(18, 10);
         internal static readonly Version Wave18_11 = new Version(18, 11);
-        internal static readonly Version[] AllWaves = [Wave18_4, Wave18_5, Wave18_6, Wave18_7, Wave18_8, Wave18_9, Wave18_10, Wave18_11];
+        internal static readonly Version Wave18_12 = new Version(18, 12);
+        internal static readonly Version[] AllWaves = [Wave18_4, Wave18_5, Wave18_6, Wave18_7, Wave18_8, Wave18_9, Wave18_10, Wave18_11, Wave18_12];
 
         /// <summary>
         /// Special value indicating that all features behind all Change Waves should be enabled.


### PR DESCRIPTION
Fixes #14874.

In MT mode, tasks without multithreading support run in an external TaskHost. Extended build events survive TaskHost serialization, but `TaskHostTask` only handled the base event IDs and silently dropped some of the events (for example the extended events) in the parent process. For an extended error event, the task could then return  false and produce MSB4181 instead of the original actionable diagnostic.

This change routes extended errors, warnings, messages, critical messages, and custom events through their corresponding parent logging APIs while preserving the concrete event objects and structured data. Also added the default routing based on the class hierarchy.

The TaskHost wire format is unchanged. 