### PR TITLE
[vs18.0] Fix internal tool restore and remove sbom import

### DIFF
--- a/azure-pipelines/.vsts-dotnet-build-jobs.yml
+++ b/azure-pipelines/.vsts-dotnet-build-jobs.yml
@@ -41,16 +41,6 @@ jobs:
 
   - template: /eng/common/templates-official/steps/enable-internal-sources.yml
 
-
-  - task: NuGetCommand@2
-    displayName: Restore internal tools
-    inputs:
-      command: restore
-      feedsToUse: config
-      restoreSolution: 'eng\common\internal\Tools.csproj'
-      nugetConfigPath: 'eng\common\internal\NuGet.config'
-      restoreDirectory: '$(Build.SourcesDirectory)\.packages'
-
   - task: MicroBuildSigningPlugin@4
     displayName: Install MicroBuild plugin
     inputs:
@@ -92,12 +82,8 @@ jobs:
               /p:GenerateSbom=true
               /p:SuppressFinalPackageVersion=${{ parameters.isExperimental }}
               /p:IsExperimental=${{ parameters.isExperimental }}
-
     displayName: Build
     condition: succeeded()
-
-  # Required by Microsoft policy
-  - template: /eng/common/templates-official/steps/generate-sbom.yml@self
 
   # Publish OptProf configuration files
   - task: 1ES.PublishArtifactsDrop@1

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -3,7 +3,7 @@
 <Project>
   <Import Project="Version.Details.props" Condition="Exists('Version.Details.props')" />
   <PropertyGroup>
-    <VersionPrefix>18.0.31</VersionPrefix><DotNetFinalVersionKind>release</DotNetFinalVersionKind>
+    <VersionPrefix>18.0.32</VersionPrefix><DotNetFinalVersionKind>release</DotNetFinalVersionKind>
     <PackageValidationBaselineVersion>17.14.8</PackageValidationBaselineVersion>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>
     <PreReleaseVersionLabel>servicing</PreReleaseVersionLabel>


### PR DESCRIPTION
1. Remove the internal tools restore step as that is already handled implicitly by the Arcade toolset
2. Remove the sbom step which is deprecated and emits an ADO warning

Test build: https://dev.azure.com/devdiv/DevDiv/_build/results?buildId=15133518&view=results