### PR TITLE
Stop NGen for SAC assemblies

### DIFF
--- a/src/Package/MSBuild.VSSetup/files.swr
+++ b/src/Package/MSBuild.VSSetup/files.swr
@@ -42,22 +42,36 @@ folder InstallDir:\MSBuild\Current\Bin
   file source=$(X86BinPath)BuildXL.Utilities.Core.dll
   file source=$(X86BinPath)Microsoft.VisualStudio.SolutionPersistence.dll vs.file.ngenApplications="[installDir]\MSBuild\Current\Bin\amd64\MSBuild.exe" vs.file.ngenArchitecture=all vs.file.ngenPriority=3
   file source=$(X86BinPath)RuntimeContracts.dll
-  file source=$(X86BinPath)System.Buffers.dll vs.file.ngenApplications="[installDir]\MSBuild\Current\Bin\MSBuild.exe" vs.file.ngenArchitecture=all vs.file.ngenPriority=2
+  # This assembly is in the devenv SAC. MSBuild in Visual Studio uses that copy; remove this packaged copy in a future version after compatibility is confirmed.
+  file source=$(X86BinPath)System.Buffers.dll
   file source=$(X86BinPath)System.Formats.Nrbf.dll vs.file.ngenApplications="[installDir]\MSBuild\Current\Bin\MSBuild.exe" vs.file.ngenArchitecture=all vs.file.ngenPriority=2
-  file source=$(X86BinPath)System.IO.Pipelines.dll vs.file.ngenApplications="[installDir]\MSBuild\Current\Bin\MSBuild.exe" vs.file.ngenArchitecture=all vs.file.ngenPriority=2
-  file source=$(X86BinPath)System.Memory.dll vs.file.ngenApplications="[installDir]\MSBuild\Current\Bin\MSBuild.exe" vs.file.ngenArchitecture=all vs.file.ngenPriority=2
-  file source=$(X86BinPath)System.Reflection.Metadata.dll vs.file.ngenApplications="[installDir]\MSBuild\Current\Bin\MSBuild.exe" vs.file.ngenArchitecture=all vs.file.ngenPriority=2
-  file source=$(X86BinPath)System.Reflection.MetadataLoadContext.dll vs.file.ngenApplications="[installDir]\MSBuild\Current\Bin\MSBuild.exe" vs.file.ngenArchitecture=all vs.file.ngenPriority=3
-  file source=$(X86BinPath)System.Text.Json.dll vs.file.ngenApplications="[installDir]\MSBuild\Current\Bin\MSBuild.exe" vs.file.ngenArchitecture=all vs.file.ngenPriority=2
+  # This assembly is in the devenv SAC. MSBuild in Visual Studio uses that copy; remove this packaged copy in a future version after compatibility is confirmed.
+  file source=$(X86BinPath)System.IO.Pipelines.dll
+  # This assembly is in the devenv SAC. MSBuild in Visual Studio uses that copy; remove this packaged copy in a future version after compatibility is confirmed.
+  file source=$(X86BinPath)System.Memory.dll
+  # This assembly is in the devenv SAC. MSBuild in Visual Studio uses that copy; remove this packaged copy in a future version after compatibility is confirmed.
+  file source=$(X86BinPath)System.Reflection.Metadata.dll
+  # This assembly is in the devenv SAC. MSBuild in Visual Studio uses that copy; remove this packaged copy in a future version after compatibility is confirmed.
+  file source=$(X86BinPath)System.Reflection.MetadataLoadContext.dll
+  # This assembly is in the devenv SAC. MSBuild in Visual Studio uses that copy; remove this packaged copy in a future version after compatibility is confirmed.
+  file source=$(X86BinPath)System.Text.Json.dll
+  # This assembly is in the devenv SAC. MSBuild in Visual Studio uses that copy; remove this packaged copy in a future version after compatibility is confirmed.
   file source=$(X86BinPath)System.Threading.Channels.dll
-  file source=$(X86BinPath)Microsoft.Bcl.AsyncInterfaces.dll vs.file.ngenApplications="[installDir]\MSBuild\Current\Bin\MSBuild.exe" vs.file.ngenArchitecture=all vs.file.ngenPriority=2
-  file source=$(X86BinPath)System.Text.Encodings.Web.dll vs.file.ngenApplications="[installDir]\MSBuild\Current\Bin\MSBuild.exe" vs.file.ngenArchitecture=all vs.file.ngenPriority=2
-  file source=$(X86BinPath)System.Threading.Tasks.Extensions.dll vs.file.ngenApplications="[installDir]\MSBuild\Current\Bin\MSBuild.exe" vs.file.ngenArchitecture=all vs.file.ngenPriority=2
-  file source=$(X86BinPath)System.Numerics.Vectors.dll vs.file.ngenApplications="[installDir]\MSBuild\Current\Bin\MSBuild.exe" vs.file.ngenArchitecture=all vs.file.ngenPriority=2
+  # This assembly is in the devenv SAC. MSBuild in Visual Studio uses that copy; remove this packaged copy in a future version after compatibility is confirmed.
+  file source=$(X86BinPath)Microsoft.Bcl.AsyncInterfaces.dll
+  # This assembly is in the devenv SAC. MSBuild in Visual Studio uses that copy; remove this packaged copy in a future version after compatibility is confirmed.
+  file source=$(X86BinPath)System.Text.Encodings.Web.dll
+  # This assembly is in the devenv SAC. MSBuild in Visual Studio uses that copy; remove this packaged copy in a future version after compatibility is confirmed.
+  file source=$(X86BinPath)System.Threading.Tasks.Extensions.dll
+  # This assembly is in the devenv SAC. MSBuild in Visual Studio uses that copy; remove this packaged copy in a future version after compatibility is confirmed.
+  file source=$(X86BinPath)System.Numerics.Vectors.dll
   file source=$(X86BinPath)System.Resources.Extensions.dll vs.file.ngenApplications="[installDir]\MSBuild\Current\Bin\MSBuild.exe" vs.file.ngenArchitecture=all vs.file.ngenPriority=3
-  file source=$(X86BinPath)System.Runtime.CompilerServices.Unsafe.dll vs.file.ngenApplications="[installDir]\MSBuild\Current\Bin\MSBuild.exe" vs.file.ngenArchitecture=all vs.file.ngenPriority=2
-  file source=$(X86BinPath)System.Threading.Tasks.Dataflow.dll vs.file.ngenApplications="[installDir]\MSBuild\Current\Bin\MSBuild.exe" vs.file.ngenArchitecture=all vs.file.ngenPriority=2
-  file source=$(X86BinPath)System.Collections.Immutable.dll vs.file.ngenApplications="[installDir]\MSBuild\Current\Bin\MSBuild.exe" vs.file.ngenArchitecture=all vs.file.ngenPriority=2
+  # This assembly is in the devenv SAC. MSBuild in Visual Studio uses that copy; remove this packaged copy in a future version after compatibility is confirmed.
+  file source=$(X86BinPath)System.Runtime.CompilerServices.Unsafe.dll
+  # This assembly is in the devenv SAC. MSBuild in Visual Studio uses that copy; remove this packaged copy in a future version after compatibility is confirmed.
+  file source=$(X86BinPath)System.Threading.Tasks.Dataflow.dll
+  # This assembly is in the devenv SAC. MSBuild in Visual Studio uses that copy; remove this packaged copy in a future version after compatibility is confirmed.
+  file source=$(X86BinPath)System.Collections.Immutable.dll
   file source=$(X86BinPath)Microsoft.Bcl.HashCode.dll
   file source=$(X86BinPath)Microsoft.NET.StringTools.dll vs.file.ngenArchitecture=all
   file source=$(TaskHostBinPath)Microsoft.NET.StringTools.net35.dll
@@ -89,8 +103,10 @@ folder InstallDir:\MSBuild\Current\Bin
   file source=$(X86BinPath)Microsoft.ServiceModel.targets
   file source=$(X86BinPath)Microsoft.WinFx.targets
   file source=$(X86BinPath)Microsoft.WorkflowBuildExtensions.targets
-  file source=$(X86BinPath)Microsoft.VisualStudio.Utilities.Internal.dll vs.file.ngenApplications="[installDir]\MSBuild\Current\Bin\amd64\MSBuild.exe" vs.file.ngenArchitecture=all vs.file.ngenPriority=3
-  file source=$(X86BinPath)Newtonsoft.Json.dll vs.file.ngenApplications="[installDir]\MSBuild\Current\Bin\amd64\MSBuild.exe" vs.file.ngenArchitecture=all vs.file.ngenPriority=2
+  # This assembly is in the devenv SAC. MSBuild in Visual Studio uses that copy; remove this packaged copy in a future version after compatibility is confirmed.
+  file source=$(X86BinPath)Microsoft.VisualStudio.Utilities.Internal.dll
+  # This assembly is in the devenv SAC. MSBuild in Visual Studio uses that copy; remove this packaged copy in a future version after compatibility is confirmed.
+  file source=$(X86BinPath)Newtonsoft.Json.dll
 
 folder InstallDir:\MSBuild\Current\Bin\MSBuild
   file source=$(X86BinPath)\MSBuild\Microsoft.Build.Core.xsd
@@ -208,22 +224,35 @@ folder InstallDir:\MSBuild\Current\Bin\amd64
   file source=$(FrameworkBinPath)x64\Microsoft.Build.Framework.tlb
   file source=$(X86BinPath)Microsoft.Build.Tasks.Core.dll vs.file.ngenArchitecture=all
   file source=$(X86BinPath)Microsoft.Build.Utilities.Core.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)System.Buffers.dll vs.file.ngenArchitecture=all
+  # This assembly is in the devenv SAC. MSBuild in Visual Studio uses that copy; remove this packaged copy in a future version after compatibility is confirmed.
+  file source=$(X86BinPath)System.Buffers.dll
   file source=$(X86BinPath)System.Formats.Nrbf.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)System.IO.Pipelines.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)System.Memory.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)System.Reflection.Metadata.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)System.Reflection.MetadataLoadContext.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)System.Text.Json.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)Microsoft.Bcl.AsyncInterfaces.dll vs.file.ngenArchitecture=all
+  # This assembly is in the devenv SAC. MSBuild in Visual Studio uses that copy; remove this packaged copy in a future version after compatibility is confirmed.
+  file source=$(X86BinPath)System.IO.Pipelines.dll
+  # This assembly is in the devenv SAC. MSBuild in Visual Studio uses that copy; remove this packaged copy in a future version after compatibility is confirmed.
+  file source=$(X86BinPath)System.Memory.dll
+  # This assembly is in the devenv SAC. MSBuild in Visual Studio uses that copy; remove this packaged copy in a future version after compatibility is confirmed.
+  file source=$(X86BinPath)System.Reflection.Metadata.dll
+  # This assembly is in the devenv SAC. MSBuild in Visual Studio uses that copy; remove this packaged copy in a future version after compatibility is confirmed.
+  file source=$(X86BinPath)System.Reflection.MetadataLoadContext.dll
+  # This assembly is in the devenv SAC. MSBuild in Visual Studio uses that copy; remove this packaged copy in a future version after compatibility is confirmed.
+  file source=$(X86BinPath)System.Text.Json.dll
+  # This assembly is in the devenv SAC. MSBuild in Visual Studio uses that copy; remove this packaged copy in a future version after compatibility is confirmed.
+  file source=$(X86BinPath)Microsoft.Bcl.AsyncInterfaces.dll
   file source=$(X86BinPath)Microsoft.IO.Redist.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)System.Text.Encodings.Web.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)System.Threading.Tasks.Extensions.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)System.Numerics.Vectors.dll vs.file.ngenArchitecture=all
+  # This assembly is in the devenv SAC. MSBuild in Visual Studio uses that copy; remove this packaged copy in a future version after compatibility is confirmed.
+  file source=$(X86BinPath)System.Text.Encodings.Web.dll
+  # This assembly is in the devenv SAC. MSBuild in Visual Studio uses that copy; remove this packaged copy in a future version after compatibility is confirmed.
+  file source=$(X86BinPath)System.Threading.Tasks.Extensions.dll
+  # This assembly is in the devenv SAC. MSBuild in Visual Studio uses that copy; remove this packaged copy in a future version after compatibility is confirmed.
+  file source=$(X86BinPath)System.Numerics.Vectors.dll
   file source=$(X86BinPath)System.Resources.Extensions.dll
-  file source=$(X86BinPath)System.Runtime.CompilerServices.Unsafe.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)System.Threading.Tasks.Dataflow.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)System.Collections.Immutable.dll vs.file.ngenArchitecture=all
+  # This assembly is in the devenv SAC. MSBuild in Visual Studio uses that copy; remove this packaged copy in a future version after compatibility is confirmed.
+  file source=$(X86BinPath)System.Runtime.CompilerServices.Unsafe.dll
+  # This assembly is in the devenv SAC. MSBuild in Visual Studio uses that copy; remove this packaged copy in a future version after compatibility is confirmed.
+  file source=$(X86BinPath)System.Threading.Tasks.Dataflow.dll
+  # This assembly is in the devenv SAC. MSBuild in Visual Studio uses that copy; remove this packaged copy in a future version after compatibility is confirmed.
+  file source=$(X86BinPath)System.Collections.Immutable.dll
   file source=$(X86BinPath)Microsoft.Bcl.HashCode.dll
   file source=$(X86BinPath)Microsoft.NET.StringTools.dll vs.file.ngenArchitecture=all
   file source=$(TaskHostBinPath)Microsoft.NET.StringTools.net35.dll

--- a/src/Package/MSBuild.VSSetup/files.swr
+++ b/src/Package/MSBuild.VSSetup/files.swr
@@ -34,7 +34,7 @@ folder InstallDir:\MSBuild\Current\Bin
   file source=$(X86BinPath)MSBuild.exe vs.file.ngenArchitecture=x86 vs.file.ngenPriority=2
   file MSBuild.exe.config.template source=$(X86BinPath)MSBuild.exe.config vs.file.useGroupConfig="devenv" vs.file.overwriteBindingRedirects=yes
   file source=$(CoordinatorBinPath)MSBuild.Coordinator.exe
-  file source=$(CoordinatorBinPath)MSBuild.Coordinator.exe.config
+  file MSBuild.Coordinator.exe.config.template source=$(CoordinatorBinPath)MSBuild.Coordinator.exe.config vs.file.useGroupConfig="devenv" vs.file.overwriteBindingRedirects=yes
   file source=$(TaskHostBinPath)MSBuildTaskHost.exe
   file source=$(TaskHostBinPath)MSBuildTaskHost.exe.config
   file source=$(X86BinPath)BuildXL.Native.dll
@@ -215,7 +215,8 @@ folder InstallDir:\MSBuild\Current\Bin\amd64
   file source=$(X64BinPath)MSBuild.exe vs.file.ngenArchitecture=x64
   file MSBuild.exe.config.template source=$(X64BinPath)MSBuild.exe.config vs.file.useGroupConfig="devenv" vs.file.overwriteBindingRedirects=yes
   file source=$(CoordinatorX64BinPath)MSBuild.Coordinator.exe vs.file.ngenArchitecture=x64 vs.file.ngenPriority=3
-  file source=$(CoordinatorX64BinPath)MSBuild.Coordinator.exe.config
+  file MSBuild.Coordinator.exe.config.template source=$(CoordinatorX64BinPath)MSBuild.Coordinator.exe.config vs.file.useGroupConfig="devenv" vs.file.overwriteBindingRedirects=yes
+
   file source=$(TaskHostX64BinPath)MSBuildTaskHost.exe
   file source=$(TaskHostX64BinPath)MSBuildTaskHost.exe.config
 


### PR DESCRIPTION
Since adding the support to use assemblies to the SAC, no longer need to mark them for ngen for VS