### PR TITLE
Preserve manifest input streams when writing manifests

### DIFF
--- a/src/Tasks.UnitTests/ManifestWriter_Tests.cs
+++ b/src/Tasks.UnitTests/ManifestWriter_Tests.cs
@@ -1,0 +1,39 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+using Microsoft.Build.Tasks.Deployment.ManifestUtilities;
+using Shouldly;
+using Xunit;
+
+namespace Microsoft.Build.Tasks.UnitTests;
+
+public class ManifestWriter_Tests
+{
+    private static string TestAssetsRootPath { get; } = Path.Combine(
+        AppContext.BaseDirectory,
+        "TestResources",
+        "Manifests");
+
+    [Fact]
+    public void WriteManifestPreservesInputStream()
+    {
+        Manifest manifest = ManifestReader.ReadManifest(
+            Path.Combine(TestAssetsRootPath, "buildIn.manifest"),
+            preserveStream: true);
+        manifest.InputStream.ShouldNotBeNull();
+        using Stream inputStream = manifest.InputStream;
+        using MemoryStream firstOutput = new();
+        using MemoryStream secondOutput = new();
+
+        ManifestWriter.WriteManifest(manifest, firstOutput);
+        inputStream.CanRead.ShouldBeTrue();
+
+        inputStream.Position = 0;
+        ManifestWriter.WriteManifest(manifest, secondOutput);
+        inputStream.CanRead.ShouldBeTrue();
+        firstOutput.Length.ShouldBeGreaterThan(0);
+        secondOutput.ToArray().ShouldBe(firstOutput.ToArray());
+    }
+}

--- a/src/Tasks/ManifestUtil/Util.cs
+++ b/src/Tasks/ManifestUtil/Util.cs
@@ -458,7 +458,12 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
 
         public static void WriteFile(string path, Stream s)
         {
-            using StreamReader r = new StreamReader(s);
+            using StreamReader r = new StreamReader(
+                s,
+                Encoding.UTF8,
+                detectEncodingFromByteOrderMarks: true,
+                bufferSize: 1024,
+                leaveOpen: true);
             WriteFile(path, r.ReadToEnd());
         }
 


### PR DESCRIPTION
Fixes #14881.

## Summary

Ensure `ManifestWriter.WriteManifest` leaves the manifest's caller-owned input stream open after writing.

PR #9983 began disposing the `StreamReader`, which also disposed the underlying manifest input stream. This caused subsequent calls to `ManifestWriter.WriteManifest` using the same manifest to fail with `Stream was not readable`.

The explicit `StreamReader` arguments preserve the previous encoding, BOM detection, and buffer-size behavior while setting `leaveOpen: true`.

## Compatibility

This restores the stream-ownership behavior from before PR #9983. No ChangeWave is needed because this is a narrow regression fix and does not change the public API surface.

## Tests

Added regression coverage that:

- writes the same manifest twice after rewinding its preserved input stream;
- verifies the input stream remains readable after each write;
- verifies both writes produce identical, non-empty output.

The regression test passes on both `net11.0` and `net472`.