### PR TITLE
[vs18.0] Disable unavailable OptProf data

### DIFF
--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -15,8 +15,10 @@ parameters:
   default: 'default'
 - name: enableOptProf
   displayName: Enable OptProf data collection for this build
+  # This servicing branch no longer has optimization data to apply and no longer
+  # collects fresh data.
   type: boolean
-  default: true
+  default: false
 - name: enableSigningValidation
   displayName: Enable Signing Validation
   type: boolean

--- a/azure-pipelines/.vsts-dotnet-build-jobs.yml
+++ b/azure-pipelines/.vsts-dotnet-build-jobs.yml
@@ -126,7 +126,7 @@ jobs:
       ArtifactName: MicroBuildOutputs
       ArtifactType: Container
     displayName: 'OptProf - Publish Artifact: MicroBuildOutputs'
-    condition: succeeded()
+    condition: and(succeeded(), ${{ parameters.enableOptProf }})
 
   - task: 1ES.PublishBuildArtifacts@1
     displayName: 'Publish Artifact: logs'

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -3,7 +3,7 @@
 <Project>
   <Import Project="Version.Details.props" Condition="Exists('Version.Details.props')" />
   <PropertyGroup>
-    <VersionPrefix>18.0.32</VersionPrefix><DotNetFinalVersionKind>release</DotNetFinalVersionKind>
+    <VersionPrefix>18.0.33</VersionPrefix><DotNetFinalVersionKind>release</DotNetFinalVersionKind>
     <PackageValidationBaselineVersion>17.14.8</PackageValidationBaselineVersion>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>
     <PreReleaseVersionLabel>servicing</PreReleaseVersionLabel>


### PR DESCRIPTION
Depends on #14867.

Related to #14868 and #14869.

### Context

The latest `vs18.0` official build ([15150034](https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=15150034&view=results)) fails before compilation while restoring optimization data:

`No drops matching the specified prefix were returned`

This servicing branch no longer has matching optimization data to apply and should no longer collect fresh OptProf data.

### Changes Made

- Changed `enableOptProf` to default to `false`.
- Kept the existing behavior that sets `SkipApplyOptimizationData=true` when OptProf collection is disabled, avoiding the unavailable-data restore.
- Gated `OptProf - Publish Artifact: MicroBuildOutputs` because the bootstrapper output is not produced when collection is disabled.
- Bumped `VersionPrefix` from `18.0.32` to `18.0.33`.

### Testing

- Parsed `.vsts-dotnet.yml` and `azure-pipelines/.vsts-dotnet-build-jobs.yml` with `ConvertFrom-Yaml`.
- Parsed `eng/Versions.props` as XML.
- Confirmed the `MSBuild-OptProf` pipeline resolves `.opt-prof.yml` from `main`, where #14867 prevents artifact-less builds from triggering training.
- End-to-end validation requires the official pipeline run.
### Notes
- We can skip the OptProf because this branch only inserts into .NET SDK and not VS, so there is no risk of introducing a performance regressions in VS.