### PR TITLE
[vs18.6] Disable unavailable OptProf data

### DIFF
--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -15,8 +15,10 @@ parameters:
   default: 'default'
 - name: enableOptProf
   displayName: Enable OptProf data collection for this build
+  # This servicing branch no longer has optimization data to apply and no longer
+  # collects fresh data.
   type: boolean
-  default: true
+  default: false
 - name: enableSigningValidation
   displayName: Enable Signing Validation
   type: boolean

--- a/azure-pipelines/.vsts-dotnet-build-jobs.yml
+++ b/azure-pipelines/.vsts-dotnet-build-jobs.yml
@@ -39,6 +39,7 @@ jobs:
     - output: buildArtifacts
       PathtoPublish: '$(Build.SourcesDirectory)\artifacts\official\MicroBuild\Output'
       ArtifactName: MicroBuildOutputs
+      condition: and(succeeded(), ${{ parameters.enableOptProf }})
 
     # RAINES TODO: switch to pipeline?
     - output: buildArtifacts
@@ -184,12 +185,12 @@ jobs:
 
       $paths = @(
         "log/$(BuildConfiguration)",
-        "$(Build.StagingDirectory)/MicroBuild/Output",
         "packages/$(BuildConfiguration)",
         "xsd"
       )
 
       if ("${{ parameters.enableOptProf }}" -eq "true") {
+        $paths += "$(Build.StagingDirectory)/MicroBuild/Output"
         $paths += "OptProf/$(BuildConfiguration)/Data"
         $paths += "VSSetup/$(BuildConfiguration)"
       }

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -3,7 +3,7 @@
   <Import Project="Version.Details.props" />
 
   <PropertyGroup>
-    <VersionPrefix>18.6.23</VersionPrefix><DotNetFinalVersionKind>release</DotNetFinalVersionKind><!-- Keep next to VersionPrefix to create a conflict in forward-flow -->
+    <VersionPrefix>18.6.24</VersionPrefix><DotNetFinalVersionKind>release</DotNetFinalVersionKind><!-- Keep next to VersionPrefix to create a conflict in forward-flow -->
     <PreReleaseVersionLabel>servicing</PreReleaseVersionLabel>
     <PackageValidationBaselineVersion>18.5.0-preview-26126-01</PackageValidationBaselineVersion>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>


### PR DESCRIPTION
Depends on #14867.

Follows #14901. Related to #14868 and #14869.

### Context

After the internal-tool restore failure fixed by #14901, the `vs18.6` official build reaches the same unavailable optimization-data restore affecting the other servicing branches:

`No drops matching the specified prefix were returned`

This servicing branch no longer has matching optimization data to apply and should no longer collect fresh OptProf data.

### Changes Made

- Changed `enableOptProf` to default to `false`.
- Kept the existing behavior that sets `SkipApplyOptimizationData=true` when OptProf collection is disabled, avoiding the unavailable-data restore.
- Gated the `MicroBuildOutputs` artifact because the bootstrapper output is not produced when collection is disabled.
- Moved the bootstrapper output into the OptProf-only artifact-move list so the build does not fail when that directory is absent.
- Bumped `VersionPrefix` from `18.6.23` to `18.6.24`.

### Testing

- Parsed `.vsts-dotnet.yml` and `azure-pipelines/.vsts-dotnet-build-jobs.yml` with `ConvertFrom-Yaml`.
- Parsed `eng/Versions.props` as XML.
- Confirmed the `MSBuild-OptProf` pipeline resolves `.opt-prof.yml` from `main`, where #14867 prevents artifact-less builds from triggering training.
- End-to-end validation requires the official pipeline run.

### Notes
- We can skip the OptProf because this branch only inserts into .NET SDK and not VS, so there is no risk of introducing a performance regressions in VS.