### PR TITLE
[vs16.11] Remove reference to deleted DotNet-Symbol-Publish variable group

### DIFF
--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -24,7 +24,6 @@ parameters:
 
 variables:
   - group: DotNet-Blob-Feed
-  - group: DotNet-Symbol-Publish
   # if OptProfDrop is not set, string '$(OptProfDrop)' will be passed to the build script.
   - name: OptProfDrop
     value: ''


### PR DESCRIPTION
The `DotNet-Symbol-Publish` variable group was deleted from DevDiv around 2026-08-18, so the official build now fails at YAML load time before any job runs ([build 15087575](https://dev.azure.com/devdiv/DevDiv/_build/results?buildId=15087575)): `Variable group  was not found or is not authorized for use.` (AzDO renders the name as blank when the group does not exist at all.)

- Drop `- group: DotNet-Symbol-Publish` from `.vsts-dotnet.yml`.

The `PublishToSymbolServer` / `DotNetSymbolServerTokenMsdl` / `DotNetSymbolServerTokenSymWeb` arguments that consumed the group are intentionally kept, so they can be rewired once a replacement variable group is available. This matches `vs17.8`, which already references the same PAT variables without declaring the group and builds successfully ([build 15132441](https://dev.azure.com/devdiv/DevDiv/_build/results?buildId=15132441)): the unresolved `$(microsoft-symbol-server-pat)` is expanded by PowerShell as a subexpression, logging a non-fatal `CommandNotFoundException` and passing an empty token.

Symbols continue to reach the symbol servers through `DotNetPublishUsingPipelines=true`, which publishes PDBs to the `PdbArtifacts` container and the asset manifest to BAR for the post-build (`publishingInfraVersion: 3`) darc publishing flow.
