### PR TITLE
[vs16.11] Update Microsoft.DotNet.Arcade.Sdk and SourceBuild.Tasks versions

### DIFF
--- a/eng/SourceBuildPrebuiltBaseline.xml
+++ b/eng/SourceBuildPrebuiltBaseline.xml
@@ -24,9 +24,9 @@
     <Usage Id="Microsoft.Diagnostics.NETCore.Client" Version="0.2.61701" />
     <Usage Id="Microsoft.Diagnostics.Runtime" Version="1.1.57604" />
     <Usage Id="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.49" />
-    <Usage Id="Microsoft.DotNet.Arcade.Sdk" Version="6.0.0-beta.25468.4" />
+    <Usage Id="Microsoft.DotNet.Arcade.Sdk" Version="6.0.0-beta.26423.3" />
     <Usage Id="Microsoft.DotNet.PlatformAbstractions" Version="2.1.0" />
-    <Usage Id="Microsoft.DotNet.SourceBuild.Tasks" Version="6.0.0-beta.25468.4" IsDirectDependency="true" IsAutoReferenced="true" />
+    <Usage Id="Microsoft.DotNet.SourceBuild.Tasks" Version="6.0.0-beta.26423.3" IsDirectDependency="true" IsAutoReferenced="true" />
     <Usage Id="Microsoft.DotNet.XliffTasks" Version="1.0.0-beta.21431.1" IsDirectDependency="true" IsAutoReferenced="true" />
     <Usage Id="Microsoft.Extensions.DependencyModel" Version="5.0.0" IsDirectDependency="true" />
     <Usage Id="Microsoft.Net.Compilers.Toolset" Version="3.9.0-2.20574.26" IsDirectDependency="true" IsAutoReferenced="true" />


### PR DESCRIPTION
Fix reported prebuilts in the SB job: https://dev.azure.com/devdiv/DevDiv/DevDiv%20Team/_build/results?buildId=15151911&view=logs&j=2f0d093c-1064-5c86-fc5b-b7b1eca8e66a&t=d2b639a6-cb19-5f1f-66fd-8047f66b3026&l=145