### PR TITLE
[vs16.11] Disable OptProf bootstrapper

### DIFF
--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -13,6 +13,12 @@ parameters:
   displayName: Optional OptProfDrop Override
   type: string
   default: 'default'
+- name: enableOptProf
+  displayName: Enable OptProf data collection for this build
+  # vs16.11 is in servicing and no longer collects fresh OptProf data: the VS
+  # bootstrapper build (required only for OptProf collection) is disabled by default.
+  type: boolean
+  default: false
 - name: enableSigningValidation
   displayName: Enable Signing Validation
   type: boolean
@@ -77,6 +83,7 @@ extends:
           isExperimental: false
           enableComponentGovernance: true
           signTypeParameter: ${{ parameters.signTypeParameter }}
+          enableOptProf: ${{ parameters.enableOptProf }}
 
     - template: /eng/common/templates-official/post-build/post-build.yml@self
       parameters:

--- a/azure-pipelines/.vsts-dotnet-build-jobs.yml
+++ b/azure-pipelines/.vsts-dotnet-build-jobs.yml
@@ -9,6 +9,9 @@ parameters:
 - name: signTypeParameter
   type: string
   default: 'test'
+- name: enableOptProf
+  type: boolean
+  default: false
 
 jobs:
 - job: Windows_NT
@@ -61,6 +64,7 @@ jobs:
       AccessToken: '$(System.AccessToken)'
       feedSource: 'https://devdiv.pkgs.visualstudio.com/DefaultCollection/_packaging/MicroBuildToolset/nuget/v3/index.json'
     displayName: 'Install OptProf Plugin'
+    condition: and(succeeded(), ${{ parameters.enableOptProf }})
 
   # Required by MicroBuildBuildVSBootstrapper
   - task: MicroBuildSwixPlugin@4
@@ -104,7 +108,7 @@ jobs:
       toLowerCase: false
       usePat: true
     displayName: 'OptProf - Publish to Artifact Services - ProfilingInputs'
-    condition: succeeded()
+    condition: and(succeeded(), ${{ parameters.enableOptProf }})
 
   # Build VS bootstrapper
   # Generates $(Build.StagingDirectory)\MicroBuild\Output\BootstrapperInfo.json
@@ -115,7 +119,7 @@ jobs:
       manifests: $(VisualStudio.SetupManifestList)
       outputFolder: '$(Build.SourcesDirectory)\artifacts\VSSetup\$(BuildConfiguration)\Insertion'
     displayName: 'OptProf - Build VS bootstrapper'
-    condition: succeeded()
+    condition: and(succeeded(), ${{ parameters.enableOptProf }})
 
   # Publish run settings
   - task: PowerShell@2
@@ -127,7 +131,7 @@ jobs:
                 /p:BootstrapperInfoPath=$(Build.StagingDirectory)\MicroBuild\Output\BootstrapperInfo.json
                 /p:VisualStudioIbcTrainingSettingsPath=$(Build.SourcesDirectory)\eng\config\OptProf.runsettings
     displayName: 'OptProf - Build IBC training settings'
-    condition: succeeded()
+    condition: and(succeeded(), ${{ parameters.enableOptProf }})
 
   # Publish bootstrapper info
   - task: 1ES.PublishBuildArtifacts@1
@@ -136,7 +140,8 @@ jobs:
       ArtifactName: MicroBuildOutputs
       ArtifactType: Container
     displayName: 'OptProf - Publish Artifact: MicroBuildOutputs'
-    condition: succeeded()
+    # Only produced when the OptProf bootstrapper runs; skip when OptProf collection is disabled.
+    condition: and(succeeded(), ${{ parameters.enableOptProf }})
 
   - task: 1ES.PublishBuildArtifacts@1
     displayName: 'Publish Artifact: logs'
@@ -205,7 +210,7 @@ jobs:
     displayName: Tag build as ready for optimization training
     inputs:
       tags: 'ready-for-training'
-    condition: succeeded()
+    condition: and(succeeded(), ${{ parameters.enableOptProf }})
 
   - task: ms-vseng.MicroBuildTasks.521a94ea-9e68-468a-8167-6dcf361ea776.MicroBuildCleanup@1
     displayName: Execute cleanup tasks

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,7 +2,7 @@
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the MIT license. See License.txt in the project root for full license information. -->
 <Project>
   <PropertyGroup>
-    <VersionPrefix>16.11.20</VersionPrefix>
+    <VersionPrefix>16.11.21</VersionPrefix>
     <DotNetFinalVersionKind>release</DotNetFinalVersionKind>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>


### PR DESCRIPTION
Fixes the `vs16.11` official build, which fails in `OptProf - Build VS bootstrapper` with `Failed to obtain an access token from the VSDrop Managed Identity` (e.g. [build 15153038](https://dev.azure.com/devdiv/DevDiv/_build/results?buildId=15153038)). Same fix as #14105 (vs17.14) and #14861 (vs17.12); `vs16.11` is the last branch without an `enableOptProf` switch.

- Added an `enableOptProf` parameter to `.vsts-dotnet.yml`, defaulting to `false`, and threaded it to `.vsts-dotnet-build-jobs.yml`.
- Gated the OptProf-collection steps on it: `MicroBuildOptProfPlugin@6`, ProfilingInputs publish, `MicroBuildBuildVSBootstrapper@3`, `VisualStudio.BuildIbcTrainingSettings`, `MicroBuildOutputs` publish, and the `ready-for-training` tag.
- Bumped `VersionPrefix` to `16.11.21`.

Unlike vs17.12/vs17.14, no `SkipApplyOptimizationData` change is needed: `.vsts-dotnet.yml` already forces it to `true` on this branch because there is no optimization data for vs16.11. VSSetup/packages are still produced, so VS insertion is unaffected. `enableOptProf` stays a queue-time parameter.
