### PR TITLE
Avoid materializing lazy messages in Terminal Logger

### DIFF
--- a/src/Build.UnitTests/TerminalLogger_Tests.cs
+++ b/src/Build.UnitTests/TerminalLogger_Tests.cs
@@ -570,6 +570,92 @@ namespace Microsoft.Build.UnitTests
             return Verify(_outputWriter.ToString(), _settings).UniqueForOSPlatform();
         }
 
+        [Theory]
+        [InlineData(false, LoggerVerbosity.Normal, MessageImportance.Low)]
+        [InlineData(true, LoggerVerbosity.Normal, MessageImportance.Low)]
+        [InlineData(true, LoggerVerbosity.Quiet, MessageImportance.High)]
+        public void MessageRaised_DoesNotFormatFilteredMessages(bool useRemoteNode, LoggerVerbosity verbosity, MessageImportance importance)
+        {
+            _remoteTerminalLogger.Verbosity = verbosity;
+            var message = new BuildMessageEventArgs("Message {0}", null, null, importance, DateTime.UtcNow, "argument")
+            {
+                BuildEventContext = MakeBuildEventContext(),
+            };
+
+            MockBuildEventSink eventSource = useRemoteNode ? _remoteNodeEventSource : _centralNodeEventSource;
+            eventSource.InvokeMessageRaised(message);
+
+            message.RawArguments.ShouldNotBeNull();
+        }
+
+        [Fact]
+        public void TerminalLogger_DoesNotMutateRenderedEvents()
+        {
+            _terminallogger.Verbosity = LoggerVerbosity.Diagnostic;
+            object[] messageArguments = ["argument"];
+            object[] warningArguments = ["argument"];
+            object[] errorArguments = ["argument"];
+            var message = new BuildMessageEventArgs("Message {0}", null, null, MessageImportance.High, DateTime.UtcNow, messageArguments)
+            {
+                BuildEventContext = MakeBuildEventContext(),
+            };
+            var warning = new BuildWarningEventArgs("", "TESTWARNING", "", 0, 0, 0, 0, "Warning {0}", "keyword", "sender", DateTime.UtcNow, warningArguments)
+            {
+                BuildEventContext = MakeBuildEventContext(),
+            };
+            var error = new BuildErrorEventArgs("", "TESTERROR", "", 0, 0, 0, 0, "Error {0}", "keyword", "sender", DateTime.UtcNow, errorArguments)
+            {
+                BuildEventContext = MakeBuildEventContext(),
+            };
+
+            InvokeLoggerCallbacksForSimpleProject(succeeded: false, () =>
+            {
+                _centralNodeEventSource.InvokeMessageRaised(message);
+                _centralNodeEventSource.InvokeWarningRaised(warning);
+                _centralNodeEventSource.InvokeErrorRaised(error);
+
+                message.RawArguments.ShouldBeSameAs(messageArguments);
+                warning.RawArguments.ShouldBeSameAs(warningArguments);
+                error.RawArguments.ShouldBeSameAs(errorArguments);
+            });
+
+            string output = _outputWriter.ToString();
+            output.ShouldContain("Message argument");
+            output.ShouldContain("Warning argument");
+            output.ShouldContain("Error argument");
+        }
+
+        [Theory]
+        [InlineData("TLTESTPASSED", LoggerVerbosity.Normal)]
+        [InlineData("TLTESTSKIPPED", LoggerVerbosity.Normal)]
+        [InlineData("TLTESTFINISH", LoggerVerbosity.Normal)]
+        [InlineData("TLTESTOUTPUT", LoggerVerbosity.Quiet)]
+        [InlineData("TLTESTOUTPUT", LoggerVerbosity.Normal)]
+        public void MessageRaised_DoesNotMutateStructuredTestMessages(string extendedType, LoggerVerbosity verbosity)
+        {
+            _terminallogger.Verbosity = verbosity;
+            object[] arguments = ["argument"];
+            var message = new ExtendedBuildMessageEventArgs(extendedType, "Message {0}", null, null, MessageImportance.High, DateTime.UtcNow, arguments)
+            {
+                BuildEventContext = MakeBuildEventContext(),
+                ExtendedMetadata = new Dictionary<string, string?>
+                {
+                    ["displayName"] = "testName",
+                    ["localizedResult"] = "result",
+                    ["total"] = "1",
+                    ["passed"] = "1",
+                    ["skipped"] = "0",
+                    ["failed"] = "0",
+                },
+            };
+
+            InvokeLoggerCallbacksForTestProject(succeeded: true, () =>
+            {
+                _centralNodeEventSource.InvokeMessageRaised(message);
+                message.RawArguments.ShouldBeSameAs(arguments);
+            });
+        }
+
         [Fact]
         public Task PrintRestore_Failed()
         {

--- a/src/Build/Logging/TerminalLogger/ForwardingTerminalLogger.cs
+++ b/src/Build/Logging/TerminalLogger/ForwardingTerminalLogger.cs
@@ -108,18 +108,17 @@ public sealed partial class ForwardingTerminalLogger : IForwardingLogger
 
     public void MessageRaised(object sender, BuildMessageEventArgs e)
     {
-        if (e.BuildEventContext is null)
+        // Never forward messages if the verbosity is quiet. High-priority messages are always collected by the central
+        // node, while normal-priority messages are only collected if the verbosity is more verbose than normal.
+        if (e.BuildEventContext is null ||
+            Verbosity == LoggerVerbosity.Quiet ||
+            (e.Importance != MessageImportance.High &&
+             (e.Importance != MessageImportance.Normal || Verbosity <= LoggerVerbosity.Normal)))
         {
             return;
         }
 
-        if (e.Message is not null &&
-            // Never forward messages if the verbosity is quiet
-            Verbosity != LoggerVerbosity.Quiet &&
-            // High-priority messages are always collected by the central node
-            (e.Importance == MessageImportance.High
-            // Normmal-priority messages are only collected if the verbosity is more verbose than normal
-            || (e.Importance == MessageImportance.Normal && Verbosity > LoggerVerbosity.Normal)))
+        if (e.RawMessage is not null)
         {
             BuildEventRedirector?.ForwardEvent(e);
         }

--- a/src/Build/Logging/TerminalLogger/TerminalLogger.cs
+++ b/src/Build/Logging/TerminalLogger/TerminalLogger.cs
@@ -715,7 +715,7 @@ public sealed partial class TerminalLogger : INodeLogger
         switch (e)
         {
             case BuildCanceledEventArgs cancelEvent:
-                RenderImmediateMessage(cancelEvent.Message!);
+                RenderImmediateMessage(cancelEvent.FormatMessageWithoutMutation()!);
                 break;
             case ProjectEvaluationStartedEventArgs _evalStart:
                 break;
@@ -1196,16 +1196,22 @@ public sealed partial class TerminalLogger : INodeLogger
     private void MessageRaised(object sender, BuildMessageEventArgs e)
     {
         var buildEventContext = e.BuildEventContext;
-        if (buildEventContext is null)
+        if (buildEventContext is null || e.Importance != MessageImportance.High)
         {
             return;
         }
-        string? message = e.Message;
 
-        if (message is not null && e.Importance == MessageImportance.High)
+        bool hasProject = _projects.TryGetValue(new ProjectContext(buildEventContext), out TerminalProjectInfo? project);
+        if (hasProject && project!.IsTestProject && e is IExtendedBuildEventArgs extendedMessage)
         {
-            bool hasProject = _projects.TryGetValue(new ProjectContext(buildEventContext), out TerminalProjectInfo? project);
+            HandleTestMessage(e, extendedMessage, buildEventContext, project);
+            return;
+        }
 
+        string? message = e.FormatMessageWithoutMutation();
+
+        if (message is not null)
+        {
             // Detect project output path by matching high-importance messages against the "$(MSBuildProjectName) -> ..."
             // pattern used by the CopyFilesToOutputDirectory target.
             int index = message.IndexOf(FilePathPattern, StringComparison.Ordinal);
@@ -1215,7 +1221,7 @@ public sealed partial class TerminalLogger : INodeLogger
                 if (!projectFileName.IsEmpty &&
                     message.AsSpan().StartsWith(Path.GetFileNameWithoutExtension(projectFileName)) && hasProject)
                 {
-                    ReadOnlyMemory<char> outputPath = e.Message.AsMemory().Slice(index + 4);
+                    ReadOnlyMemory<char> outputPath = message.AsMemory().Slice(index + 4);
                     project!.OutputPath = outputPath;
                     return;
                 }
@@ -1238,79 +1244,8 @@ public sealed partial class TerminalLogger : INodeLogger
                         // The SDK will log the high-pri "not-a-warning" message NETSDK1057
                         // when it's a preview version up to MaxCPUCount times, but that's
                         // an implementation detail--the user cares about at most one.
-                        RenderImmediateMessage(FormatSimpleMessageWithoutFileData(e, DoubleIndentation));
+                        RenderImmediateMessage(FormatSimpleMessageWithoutFileData(e, message, DoubleIndentation));
                         _loggedPreviewMessage = true;
-                    }
-                    return;
-                }
-            }
-
-            if (hasProject && project!.IsTestProject)
-            {
-                int nodeIndex = NodeIndexForContext(buildEventContext);
-                EnsureNodeCapacity(nodeIndex);
-                TerminalNodeStatus? node = _nodes[nodeIndex];
-
-                // Consumes test update messages produced by VSTest and MSTest runner.
-                if (e is IExtendedBuildEventArgs extendedMessage)
-                {
-                    switch (extendedMessage.ExtendedType)
-                    {
-                        case "TLTESTPASSED":
-                            {
-                                if (node != null)
-                                {
-                                    string indicator = extendedMessage.ExtendedMetadata!["localizedResult"]!;
-                                    string displayName = extendedMessage.ExtendedMetadata!["displayName"]!;
-
-                                    var status = new TerminalNodeStatus(node.Project, node.TargetFramework, node.RuntimeIdentifier, TerminalColor.Green, indicator, displayName, project.Stopwatch);
-                                    UpdateNodeStatus(buildEventContext, status);
-                                }
-                                break;
-                            }
-
-                        case "TLTESTSKIPPED":
-                            {
-                                if (node != null)
-                                {
-                                    string indicator = extendedMessage.ExtendedMetadata!["localizedResult"]!;
-                                    string displayName = extendedMessage.ExtendedMetadata!["displayName"]!;
-
-                                    var status = new TerminalNodeStatus(node.Project, node.TargetFramework, node.RuntimeIdentifier, TerminalColor.Yellow, indicator, displayName, project.Stopwatch);
-                                    UpdateNodeStatus(buildEventContext, status);
-                                }
-                                break;
-                            }
-
-                        case "TLTESTFINISH":
-                            {
-                                // Collect test run summary.
-                                if (Verbosity > LoggerVerbosity.Quiet)
-                                {
-                                    _ = int.TryParse(extendedMessage.ExtendedMetadata!["total"]!, out int total);
-                                    _ = int.TryParse(extendedMessage.ExtendedMetadata!["passed"]!, out int passed);
-                                    _ = int.TryParse(extendedMessage.ExtendedMetadata!["skipped"]!, out int skipped);
-                                    _ = int.TryParse(extendedMessage.ExtendedMetadata!["failed"]!, out int failed);
-
-                                    _testRunSummaries.Add(new TestSummary(total, passed, skipped, failed));
-
-                                    _testEndTime = _testEndTime == null
-                                            ? e.Timestamp
-                                            : e.Timestamp > _testEndTime
-                                                ? e.Timestamp : _testEndTime;
-                                }
-
-                                break;
-                            }
-
-                        case "TLTESTOUTPUT":
-                            {
-                                if (e.Message != null && Verbosity > LoggerVerbosity.Quiet)
-                                {
-                                    RenderImmediateMessage(e.Message);
-                                }
-                                break;
-                            }
                     }
                     return;
                 }
@@ -1325,7 +1260,7 @@ public sealed partial class TerminalLogger : INodeLogger
 
                 if (hasProject)
                 {
-                    project!.AddBuildMessage(TerminalMessageSeverity.Message, FormatInformationalMessage(e));
+                    project!.AddBuildMessage(TerminalMessageSeverity.Message, FormatInformationalMessage(e, message));
                 }
                 else
                 {
@@ -1333,6 +1268,77 @@ public sealed partial class TerminalLogger : INodeLogger
                     RenderImmediateMessage(message);
                 }
             }
+        }
+    }
+
+    private void HandleTestMessage(
+        BuildMessageEventArgs e,
+        IExtendedBuildEventArgs extendedMessage,
+        BuildEventContext buildEventContext,
+        TerminalProjectInfo project)
+    {
+        int nodeIndex = NodeIndexForContext(buildEventContext);
+        EnsureNodeCapacity(nodeIndex);
+        TerminalNodeStatus? node = _nodes[nodeIndex];
+
+        // Consumes test update messages produced by VSTest and MSTest runner.
+        switch (extendedMessage.ExtendedType)
+        {
+            case "TLTESTPASSED":
+                {
+                    if (node != null)
+                    {
+                        string indicator = extendedMessage.ExtendedMetadata!["localizedResult"]!;
+                        string displayName = extendedMessage.ExtendedMetadata!["displayName"]!;
+
+                        var status = new TerminalNodeStatus(node.Project, node.TargetFramework, node.RuntimeIdentifier, TerminalColor.Green, indicator, displayName, project.Stopwatch);
+                        UpdateNodeStatus(buildEventContext, status);
+                    }
+                    break;
+                }
+
+            case "TLTESTSKIPPED":
+                {
+                    if (node != null)
+                    {
+                        string indicator = extendedMessage.ExtendedMetadata!["localizedResult"]!;
+                        string displayName = extendedMessage.ExtendedMetadata!["displayName"]!;
+
+                        var status = new TerminalNodeStatus(node.Project, node.TargetFramework, node.RuntimeIdentifier, TerminalColor.Yellow, indicator, displayName, project.Stopwatch);
+                        UpdateNodeStatus(buildEventContext, status);
+                    }
+                    break;
+                }
+
+            case "TLTESTFINISH":
+                {
+                    // Collect test run summary.
+                    if (Verbosity > LoggerVerbosity.Quiet)
+                    {
+                        _ = int.TryParse(extendedMessage.ExtendedMetadata!["total"]!, out int total);
+                        _ = int.TryParse(extendedMessage.ExtendedMetadata!["passed"]!, out int passed);
+                        _ = int.TryParse(extendedMessage.ExtendedMetadata!["skipped"]!, out int skipped);
+                        _ = int.TryParse(extendedMessage.ExtendedMetadata!["failed"]!, out int failed);
+
+                        _testRunSummaries.Add(new TestSummary(total, passed, skipped, failed));
+
+                        _testEndTime = _testEndTime == null
+                            ? e.Timestamp
+                            : e.Timestamp > _testEndTime
+                                ? e.Timestamp : _testEndTime;
+                    }
+
+                    break;
+                }
+
+            case "TLTESTOUTPUT":
+                {
+                    if (Verbosity > LoggerVerbosity.Quiet && e.FormatMessageWithoutMutation() is string message)
+                    {
+                        RenderImmediateMessage(message);
+                    }
+                    break;
+                }
         }
     }
 
@@ -1355,11 +1361,12 @@ public sealed partial class TerminalLogger : INodeLogger
     private void WarningRaised(object sender, BuildWarningEventArgs e)
     {
         BuildEventContext? buildEventContext = e.BuildEventContext;
+        string? message = e.FormatMessageWithoutMutation();
 
         // auth provider messages are 'global' in nature and should be a) immediate reported, and b) not re-reported in the summary.
-        if (IsAuthProviderMessage(e.Message))
+        if (IsAuthProviderMessage(message))
         {
-            RenderImmediateMessage(FormatWarningMessage(e, Indentation));
+            RenderImmediateMessage(FormatWarningMessage(e, message, Indentation));
             return;
         }
 
@@ -1370,19 +1377,19 @@ public sealed partial class TerminalLogger : INodeLogger
             // but we don't early return so that the project also tracks it.
             if (IsImmediateWarning(e.Code) && Verbosity > LoggerVerbosity.Quiet)
             {
-                RenderImmediateMessage(FormatWarningMessage(e, Indentation));
+                RenderImmediateMessage(FormatWarningMessage(e, message, Indentation));
             }
 
             // This is the general case - _most_ warnings are not immediate, so we add them to the project summary
             // and display them in the per-project and final summary.
             // In quiet mode, we still accumulate so they can be shown in project-grouped form later.
-            project.AddBuildMessage(TerminalMessageSeverity.Warning, FormatWarningMessage(e, TripleIndentation));
+            project.AddBuildMessage(TerminalMessageSeverity.Warning, FormatWarningMessage(e, message, TripleIndentation));
         }
         else
         {
             // It is necessary to display warning messages reported by MSBuild,
             // even if it's not tracked in _projects collection.
-            RenderImmediateMessage(FormatWarningMessage(e, Indentation));
+            RenderImmediateMessage(FormatWarningMessage(e, message, Indentation));
             _buildWarningsCount++;
         }
     }
@@ -1444,20 +1451,21 @@ public sealed partial class TerminalLogger : INodeLogger
     private void ErrorRaised(object sender, BuildErrorEventArgs e)
     {
         BuildEventContext? buildEventContext = e.BuildEventContext;
+        string? message = e.FormatMessageWithoutMutation();
 
         if (buildEventContext is not null
             && _projects.TryGetValue(new ProjectContext(buildEventContext), out TerminalProjectInfo? project))
         {
             // Always accumulate errors in the project, even in quiet mode, so they can be shown
             // in project-grouped form later.
-            project.AddBuildMessage(TerminalMessageSeverity.Error, FormatErrorMessage(e, TripleIndentation));
+            project.AddBuildMessage(TerminalMessageSeverity.Error, FormatErrorMessage(e, message, TripleIndentation));
         }
         else
         {
             // It is necessary to display error messages reported by MSBuild, even if it's not tracked in _projects collection.
             // For nicer formatting, any messages from the engine we strip the file portion from.
             bool hasMSBuildPlaceholderLocation = e.File.Equals("MSBUILD", StringComparison.Ordinal);
-            RenderImmediateMessage(FormatErrorMessage(e, Indentation, requireFileAndLinePortion: !hasMSBuildPlaceholderLocation));
+            RenderImmediateMessage(FormatErrorMessage(e, message, Indentation, requireFileAndLinePortion: !hasMSBuildPlaceholderLocation));
             _buildErrorsCount++;
         }
     }
@@ -1626,10 +1634,10 @@ public sealed partial class TerminalLogger : INodeLogger
             : path;
     }
 
-    private string FormatWarningMessage(BuildWarningEventArgs e, string indent) => FormatEventMessage(
+    private string FormatWarningMessage(BuildWarningEventArgs e, string? message, string indent) => FormatEventMessage(
                 category: AnsiCodes.Colorize("warning", TerminalColor.Yellow),
                 subcategory: e.Subcategory,
-                message: e.Message,
+                message,
                 code: AnsiCodes.Colorize(CreateLink(GenerateLinkForWarning(e), e.Code), TerminalColor.Yellow),
                 file: HighlightFileName(e.File),
                 lineNumber: e.LineNumber,
@@ -1639,10 +1647,10 @@ public sealed partial class TerminalLogger : INodeLogger
                 indent,
                 terminalWidth: Terminal.Width);
 
-    private string FormatInformationalMessage(BuildMessageEventArgs e) => FormatEventMessage(
+    private string FormatInformationalMessage(BuildMessageEventArgs e, string? message) => FormatEventMessage(
                 category: null,
                 subcategory: e.Subcategory,
-                message: e.Message,
+                message,
                 code: CreateLink(GenerateLinkForMessage(e), e.Code),
                 file: HighlightFileName(e.File),
                 lineNumber: e.LineNumber,
@@ -1659,10 +1667,10 @@ public sealed partial class TerminalLogger : INodeLogger
     /// messages that lack a specific project context, such as the .NET
     /// SDK's 'preview version' message, while not removing the code.
     /// </summary>
-    private string FormatSimpleMessageWithoutFileData(BuildMessageEventArgs e, string indent) => FormatEventMessage(
+    private string FormatSimpleMessageWithoutFileData(BuildMessageEventArgs e, string? message, string indent) => FormatEventMessage(
                 category: AnsiCodes.Colorize("info", TerminalColor.Default),
                 subcategory: null,
-                message: e.Message,
+                message,
                 code: AnsiCodes.Colorize(e.Code, TerminalColor.Default),
                 file: null,
                 lineNumber: 0,
@@ -1674,10 +1682,10 @@ public sealed partial class TerminalLogger : INodeLogger
                 requireFileAndLinePortion: false,
                 prependIndentation: true);
 
-    private string FormatErrorMessage(BuildErrorEventArgs e, string indent, bool requireFileAndLinePortion = true) => FormatEventMessage(
+    private string FormatErrorMessage(BuildErrorEventArgs e, string? message, string indent, bool requireFileAndLinePortion = true) => FormatEventMessage(
                 category: AnsiCodes.Colorize("error", TerminalColor.Red),
                 subcategory: e.Subcategory,
-                message: e.Message,
+                message,
                 code: AnsiCodes.Colorize(CreateLink(GenerateLinkForError(e), e.Code), TerminalColor.Red),
                 file: HighlightFileName(e.File),
                 lineNumber: e.LineNumber,

--- a/src/Build/Logging/TerminalLogger/TerminalLogger.cs
+++ b/src/Build/Logging/TerminalLogger/TerminalLogger.cs
@@ -1218,8 +1218,9 @@ public sealed partial class TerminalLogger : INodeLogger
             if (index > 0)
             {
                 var projectFileName = Path.GetFileName(e.ProjectFile.AsSpan());
-                if (!projectFileName.IsEmpty &&
-                    message.AsSpan().StartsWith(Path.GetFileNameWithoutExtension(projectFileName)) && hasProject)
+                if (hasProject &&
+                    !projectFileName.IsEmpty &&
+                    message.AsSpan().StartsWith(Path.GetFileNameWithoutExtension(projectFileName)))
                 {
                     ReadOnlyMemory<char> outputPath = message.AsMemory().Slice(index + 4);
                     project!.OutputPath = outputPath;
@@ -1238,15 +1239,11 @@ public sealed partial class TerminalLogger : INodeLogger
             {
                 if (e.Code == "NETSDK1057" && !_loggedPreviewMessage)
                 {
-                    // ensure we only log the preview message once for the entire build.
-                    if (!_loggedPreviewMessage)
-                    {
-                        // The SDK will log the high-pri "not-a-warning" message NETSDK1057
-                        // when it's a preview version up to MaxCPUCount times, but that's
-                        // an implementation detail--the user cares about at most one.
-                        RenderImmediateMessage(FormatSimpleMessageWithoutFileData(e, message, DoubleIndentation));
-                        _loggedPreviewMessage = true;
-                    }
+                    // The SDK will log the high-pri "not-a-warning" message NETSDK1057
+                    // when it's a preview version up to MaxCPUCount times, but that's
+                    // an implementation detail--the user cares about at most one.
+                    RenderImmediateMessage(FormatSimpleMessageWithoutFileData(e, message, DoubleIndentation));
+                    _loggedPreviewMessage = true;
                     return;
                 }
             }
@@ -1637,20 +1634,20 @@ public sealed partial class TerminalLogger : INodeLogger
     private string FormatWarningMessage(BuildWarningEventArgs e, string? message, string indent) => FormatEventMessage(
                 category: AnsiCodes.Colorize("warning", TerminalColor.Yellow),
                 subcategory: e.Subcategory,
-                message,
+                message: message,
                 code: AnsiCodes.Colorize(CreateLink(GenerateLinkForWarning(e), e.Code), TerminalColor.Yellow),
                 file: HighlightFileName(e.File),
                 lineNumber: e.LineNumber,
                 endLineNumber: e.EndLineNumber,
                 columnNumber: e.ColumnNumber,
                 endColumnNumber: e.EndColumnNumber,
-                indent,
+                indent: indent,
                 terminalWidth: Terminal.Width);
 
     private string FormatInformationalMessage(BuildMessageEventArgs e, string? message) => FormatEventMessage(
                 category: null,
                 subcategory: e.Subcategory,
-                message,
+                message: message,
                 code: CreateLink(GenerateLinkForMessage(e), e.Code),
                 file: HighlightFileName(e.File),
                 lineNumber: e.LineNumber,
@@ -1670,14 +1667,14 @@ public sealed partial class TerminalLogger : INodeLogger
     private string FormatSimpleMessageWithoutFileData(BuildMessageEventArgs e, string? message, string indent) => FormatEventMessage(
                 category: AnsiCodes.Colorize("info", TerminalColor.Default),
                 subcategory: null,
-                message,
+                message: message,
                 code: AnsiCodes.Colorize(e.Code, TerminalColor.Default),
                 file: null,
                 lineNumber: 0,
                 endLineNumber: 0,
                 columnNumber: 0,
                 endColumnNumber: 0,
-                indent,
+                indent: indent,
                 terminalWidth: Terminal.Width,
                 requireFileAndLinePortion: false,
                 prependIndentation: true);
@@ -1685,14 +1682,14 @@ public sealed partial class TerminalLogger : INodeLogger
     private string FormatErrorMessage(BuildErrorEventArgs e, string? message, string indent, bool requireFileAndLinePortion = true) => FormatEventMessage(
                 category: AnsiCodes.Colorize("error", TerminalColor.Red),
                 subcategory: e.Subcategory,
-                message,
+                message: message,
                 code: AnsiCodes.Colorize(CreateLink(GenerateLinkForError(e), e.Code), TerminalColor.Red),
                 file: HighlightFileName(e.File),
                 lineNumber: e.LineNumber,
                 endLineNumber: e.EndLineNumber,
                 columnNumber: e.ColumnNumber,
                 endColumnNumber: e.EndColumnNumber,
-                indent,
+                indent: indent,
                 terminalWidth: Terminal.Width,
                 requireFileAndLinePortion: requireFileAndLinePortion);
 

--- a/src/Framework.UnitTests/BuildMessageEventArgs_Tests.cs
+++ b/src/Framework.UnitTests/BuildMessageEventArgs_Tests.cs
@@ -4,6 +4,7 @@
 using System;
 
 using Microsoft.Build.Framework;
+using Shouldly;
 using Xunit;
 
 #nullable disable
@@ -34,6 +35,19 @@ namespace Microsoft.Build.UnitTests
             bmea = new BuildMessageEventArgs(null, null, null, 0, 0, 0, 0, null, null, null, MessageImportance.Low);
             bmea = new BuildMessageEventArgs(null, null, null, 0, 0, 0, 0, null, null, null, MessageImportance.Low, DateTime.Now);
             bmea = new BuildMessageEventArgs(null, null, null, 0, 0, 0, 0, null, null, null, MessageImportance.Low, DateTime.Now, null);
+        }
+
+        [Fact]
+        public void FormatMessageWithoutMutationPreservesArguments()
+        {
+            object[] arguments = ["argument"];
+            var eventArgs = new BuildMessageEventArgs("Message {0}", null, null, MessageImportance.High, DateTime.Now, arguments);
+
+            eventArgs.FormatMessageWithoutMutation().ShouldBe("Message argument");
+            eventArgs.RawArguments.ShouldBeSameAs(arguments);
+
+            eventArgs.Message.ShouldBe("Message argument");
+            eventArgs.RawArguments.ShouldBeNull();
         }
 
         /// <summary>

--- a/src/Framework/LazyFormattedBuildEventArgs.cs
+++ b/src/Framework/LazyFormattedBuildEventArgs.cs
@@ -101,6 +101,22 @@ namespace Microsoft.Build.Framework
         }
 
         /// <summary>
+        /// Formats the message without replacing the stored arguments.
+        /// </summary>
+        internal string? FormatMessageWithoutMutation()
+        {
+            object? argsOrMessage = argumentsOrFormattedMessage;
+            if (argsOrMessage is string formattedMessage)
+            {
+                return formattedMessage;
+            }
+
+            return argsOrMessage is object[] { Length: > 0 } arguments && base.Message is not null
+                ? FormatString(base.Message, arguments)
+                : base.Message;
+        }
+
+        /// <summary>
         /// Serializes to a stream through a binary writer.
         /// </summary>
         /// <param name="writer">Binary writer which is attached to the stream the event will be serialized into.</param>

--- a/src/Framework/LazyFormattedBuildEventArgs.cs
+++ b/src/Framework/LazyFormattedBuildEventArgs.cs
@@ -103,6 +103,9 @@ namespace Microsoft.Build.Framework
         /// <summary>
         /// Formats the message without replacing the stored arguments.
         /// </summary>
+        /// <remarks>
+        /// Use this in fast-acting terminal-log scenarios to avoid materializing the `<see cref="Message"/>` in a way that pollutes the binlog.
+        /// </remarks>
         internal string? FormatMessageWithoutMutation()
         {
             object? argsOrMessage = argumentsOrFormattedMessage;


### PR DESCRIPTION
## Summary

`LazyFormattedBuildEventArgs.Message` is not an observationally pure getter: after rendering the message, it [replaces the event's stored argument array with the formatted string](https://github.com/dotnet/msbuild/blob/595f954ca815c354b1bf7bb1a3906740bc4e9e56/src/Framework/LazyFormattedBuildEventArgs.cs#L92-L96). That destructive mutation is visible to every logger that receives the same event. If Terminal Logger reads `Message` first, subsequent loggers—including Binary Logger—can lose the original raw message arguments and observe a materially different event.

This PR prevents Terminal Logger from causing that mutation:

- adds a non-mutating formatter for lazy build events
- filters messages before rendering them, so ignored events remain untouched
- uses non-mutating rendering throughout Terminal Logger and its forwarding path
- preserves raw message arguments for subsequent loggers and binary serialization
- covers filtered, structured, forwarded, warning, and error event paths

## Testing

- adds unit coverage for non-mutating formatting and Terminal Logger event handling