### PR TITLE
Resolve PathLike MatchOnMetadata against the thread working directory

### DIFF
--- a/src/Build.UnitTests/BackEnd/IntrinsicTask_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/IntrinsicTask_Tests.cs
@@ -1879,6 +1879,49 @@ namespace Microsoft.Build.UnitTests.BackEnd
         }
 
         [Fact]
+        public void RemoveWithPathLikeMatchOnMetadataResolvesRelativeMetadataAgainstThreadWorkingDirectory()
+        {
+            using TestEnvironment env = TestEnvironment.Create();
+
+            TransientTestFolder projectFolder = env.CreateFolder(createFolder: true);
+            TransientTestFolder decoyFolder = env.CreateFolder(createFolder: true);
+
+            // In -mt mode each project gets a thread-local working directory while the process current
+            // directory keeps pointing at whoever launched the build, so it must not influence matching.
+            env.SetCurrentDirectory(decoyFolder.Path);
+            string originalThreadWorkingDirectory = FileUtilities.CurrentThreadWorkingDirectory;
+            FileUtilities.CurrentThreadWorkingDirectory = projectFolder.Path;
+
+            try
+            {
+                string content = ObjectModelHelpers.CleanupFileContents(
+                    $@"<Project ToolsVersion='msbuilddefaulttoolsversion' xmlns='msbuildnamespace'>
+                    <Target Name='t'>
+                        <ItemGroup>
+                            <I1 Include='a1' M1='{projectFolder.Path}\sub\file.txt'/>
+
+                            <I2 Include='a2' M1='sub\file.txt'/>
+                            <I2 Include='b2' M1='other\file.txt'/>
+
+                            <I2 Remove='@(I1)' MatchOnMetadata='M1' MatchOnMetadataOptions='PathLike' />
+                        </ItemGroup>
+                    </Target></Project>");
+
+                IntrinsicTask task = CreateIntrinsicTask(content);
+                Lookup lookup = LookupHelpers.CreateEmptyLookup();
+                ExecuteTask(task, lookup);
+
+                // Resolved against the thread working directory, 'a2' denotes the same file as I1 and is
+                // removed. 'b2' denotes a different file and survives regardless of the base directory.
+                lookup.GetItems("I2").Select(i => i.EvaluatedInclude).ShouldBe(new[] { "b2" });
+            }
+            finally
+            {
+                FileUtilities.CurrentThreadWorkingDirectory = originalThreadWorkingDirectory;
+            }
+        }
+
+        [Fact]
         public void RemoveWithItemReferenceOnIntrinsicMatchingMetadata()
         {
             string content = ObjectModelHelpers.CleanupFileContents(

--- a/src/Build/Evaluation/ItemSpec.cs
+++ b/src/Build/Evaluation/ItemSpec.cs
@@ -575,7 +575,21 @@ namespace Microsoft.Build.Evaluation
                 options == MatchOnMetadataOptions.CaseInsensitive || FileUtilities.PathComparison == StringComparison.OrdinalIgnoreCase ? StringComparer.OrdinalIgnoreCase :
                 StringComparer.Ordinal;
             _children = new Dictionary<string, MetadataTrie<P, I>>(comparer);
-            _normalize = options == MatchOnMetadataOptions.PathLike ? (Func<string, string>)(p => FileUtilities.NormalizePathForComparisonNoThrow(p, Environment.CurrentDirectory)) : p => p;
+            if (options == MatchOnMetadataOptions.PathLike)
+            {
+                // In multithreaded (-mt) mode each project gets its own thread-local working directory while the
+                // process current directory is shared, so relative metadata must be rooted against the former or it
+                // resolves under an unrelated project and comparisons silently stop matching.
+                string baseDirectory = FileUtilities.CurrentThreadWorkingDirectory is { Length: > 0 } threadWorkingDirectory
+                    ? threadWorkingDirectory
+                    : Environment.CurrentDirectory;
+                _normalize = p => FileUtilities.NormalizePathForComparisonNoThrow(p, baseDirectory);
+            }
+            else
+            {
+                _normalize = p => p;
+            }
+
             foreach (ItemSpec<P, I>.ItemExpressionFragment frag in itemSpec.Fragments)
             {
                 foreach (ItemSpec<P, I>.ReferencedItem referencedItem in frag.ReferencedItems)


### PR DESCRIPTION
Fixes #14915

### Context

`MetadataTrie` normalizes `PathLike` metadata with `Environment.CurrentDirectory`. In `-mt` mode each project gets a thread-local working directory while the process current directory stays wherever the build was launched from, so a relative metadata value is rooted under an unrelated directory.

The result is a silently different build: an item `Remove` that matches under `-m` stops matching under `-mt`, with no error or warning.

Every other `NormalizePathForComparisonNoThrow` call site already passes a project directory — `ItemSpec.cs:343` (the same feature, single-metadata path), `LazyItemEvaluator.cs:157/387/443`, `FileSpecMatchTester.cs:36/65`. This call site was the lone outlier.

### Changes Made

`MetadataTrie` now roots relative metadata against `FileUtilities.CurrentThreadWorkingDirectory` when one is set, falling back to `Environment.CurrentDirectory` otherwise. This matches the pattern already used in `Expander.ItemExpander.Transforms.cs:122`.

`CurrentThreadWorkingDirectory` is null outside `-mt`, so non-multithreaded behavior is unchanged.

The base directory is now read once when the trie is built rather than on every normalization call, which also removes a repeated `Environment.CurrentDirectory` read from the matching loop.

### Testing

Added `RemoveWithPathLikeMatchOnMetadataResolvesRelativeMetadataAgainstThreadWorkingDirectory`, which sets a thread working directory and points the process current directory at a decoy folder, then matches an absolute metadata value against its relative equivalent.

Verified red/green against this commit:

- Without the `ItemSpec.cs` change the test fails with `["a2", "b2"]` instead of `["b2"]` — the item that should have been removed survives, which is exactly the reported symptom.
- With the change it passes.

Also run green: full `IntrinsicTask_Tests` (141), `Build.OM.UnitTests` `MatchOnMetadata` (4).

End-to-end check with a real build, invoked from a directory that is not the project directory:

```xml
<Target Name="Probe">
  <ItemGroup>
    <ExecA Include="itemA"><M>$(MSBuildProjectDirectory)\objdir\x.txt</M></ExecA>
    <ExecB Include="itemB"><M>objdir\x.txt</M></ExecB>
    <ExecA Remove="@(ExecB)" MatchOnMetadata="M" MatchOnMetadataOptions="PathLike" />
  </ItemGroup>
</Target>
```

| | before | after |
| --- | --- | --- |
| `-m` | removed | removed |
| `-mt` | **kept** | removed |

### Notes

Found while reviewing #14875, which fixes the same class of bug for `[MSBuild]::` intrinsic property functions. This call site is outside that PR's scope, so it is fixed separately here.
