### PR TITLE
Preserve error detail when ContinueOnError downgrades an error to a warning

### DIFF
--- a/src/Build.UnitTests/BackEnd/TaskHost_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/TaskHost_Tests.cs
@@ -233,6 +233,71 @@ namespace Microsoft.Build.UnitTests.BackEnd
         }
 
         /// <summary>
+        /// An error carrying extended data must keep that data when ContinueOnError downgrades it to a warning,
+        /// otherwise the structured payload a task attached to the error is silently lost.
+        /// </summary>
+        [Fact]
+        public void TestLogExtendedErrorEventWithContinueOnErrorPreservesExtendedData()
+        {
+            _taskHost.ContinueOnError = true;
+            _taskHost.ConvertErrorsToWarnings = true;
+
+            var error = new ExtendedBuildErrorEventArgs(
+                "myExtendedType", "SubCategory", "code", "file", 1, 2, 3, 4, "message", "Help", "Sender",
+                "https://aka.ms/help", new DateTime(2020, 1, 2, 3, 4, 5, DateTimeKind.Utc), messageArgs: null)
+            {
+                ExtendedData = /*lang=json*/ "{\"key\":\"value\"}",
+                ExtendedMetadata = new Dictionary<string, string> { { "m1", "v1" } },
+            };
+
+            _taskHost.LogErrorEvent(error);
+
+            var warning = _customLogger.LastWarning.ShouldBeOfType<ExtendedBuildWarningEventArgs>();
+            warning.ExtendedType.ShouldBe(error.ExtendedType);
+            warning.ExtendedData.ShouldBe(error.ExtendedData);
+            warning.ExtendedMetadata.ShouldBe(error.ExtendedMetadata);
+            AssertBaseFieldsMatch(error, warning);
+        }
+
+        /// <summary>
+        /// A plain error downgraded by ContinueOnError must keep the fields that are not part of the
+        /// shortest BuildWarningEventArgs constructor.
+        /// </summary>
+        [Fact]
+        public void TestLogErrorEventWithContinueOnErrorPreservesHelpLinkAndTimestamp()
+        {
+            _taskHost.ContinueOnError = true;
+            _taskHost.ConvertErrorsToWarnings = true;
+
+            var error = new BuildErrorEventArgs(
+                "SubCategory", "code", "file", 1, 2, 3, 4, "message", "Help", "Sender",
+                "https://aka.ms/help", new DateTime(2020, 1, 2, 3, 4, 5, DateTimeKind.Utc), messageArgs: null);
+
+            _taskHost.LogErrorEvent(error);
+
+            AssertBaseFieldsMatch(error, _customLogger.LastWarning);
+        }
+
+        /// <summary>
+        /// Asserts that everything the ContinueOnError downgrade is expected to carry over made it across.
+        /// </summary>
+        private static void AssertBaseFieldsMatch(BuildErrorEventArgs error, BuildWarningEventArgs warning)
+        {
+            warning.Subcategory.ShouldBe(error.Subcategory);
+            warning.Code.ShouldBe(error.Code);
+            warning.File.ShouldBe(error.File);
+            warning.LineNumber.ShouldBe(error.LineNumber);
+            warning.ColumnNumber.ShouldBe(error.ColumnNumber);
+            warning.EndLineNumber.ShouldBe(error.EndLineNumber);
+            warning.EndColumnNumber.ShouldBe(error.EndColumnNumber);
+            warning.Message.ShouldBe(error.Message);
+            warning.HelpKeyword.ShouldBe(error.HelpKeyword);
+            warning.SenderName.ShouldBe(error.SenderName);
+            warning.HelpLink.ShouldBe(error.HelpLink);
+            warning.Timestamp.ShouldBe(error.Timestamp);
+        }
+
+        /// <summary>
         /// Test that a null error event will cause an exception
         /// </summary>
         [Fact]

--- a/src/Build.UnitTests/BackEnd/TaskHost_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/TaskHost_Tests.cs
@@ -255,7 +255,10 @@ namespace Microsoft.Build.UnitTests.BackEnd
             var warning = _customLogger.LastWarning.ShouldBeOfType<ExtendedBuildWarningEventArgs>();
             warning.ExtendedType.ShouldBe(error.ExtendedType);
             warning.ExtendedData.ShouldBe(error.ExtendedData);
-            warning.ExtendedMetadata.ShouldBe(error.ExtendedMetadata);
+            // Assert the contents rather than the dictionary instance: preserving the payload is the requirement,
+            // and the implementation is free to copy the metadata for safety or serialization.
+            warning.ExtendedMetadata.ShouldNotBeNull();
+            warning.ExtendedMetadata.ShouldHaveSingleItem().ShouldBe(new KeyValuePair<string, string>("m1", "v1"));
             AssertBaseFieldsMatch(error, warning);
         }
 

--- a/src/Build/BackEnd/Components/RequestBuilder/TaskHost.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TaskHost.cs
@@ -442,17 +442,7 @@ namespace Microsoft.Build.BackEnd
                     // ContinueOnError is that a project author expects that the task might fail,
                     // but wants to ignore the failures.  This implies that we shouldn't be logging
                     // errors either, because you should never have a successful build with errors.
-                    BuildWarningEventArgs warningEvent = new BuildWarningEventArgs(
-                                e.Subcategory,
-                                e.Code,
-                                e.File,
-                                e.LineNumber,
-                                e.ColumnNumber,
-                                e.EndLineNumber,
-                                e.EndColumnNumber,
-                                e.Message,
-                                e.HelpKeyword,
-                                e.SenderName);
+                    BuildWarningEventArgs warningEvent = CreateWarningFromError(e);
 
                     warningEvent.BuildEventContext = _taskLoggingContext.BuildEventContext;
                     _taskLoggingContext.LoggingService.LogBuildEvent(warningEvent);
@@ -468,6 +458,53 @@ namespace Microsoft.Build.BackEnd
 
                 _taskLoggingContext.HasLoggedErrors = true;
             }
+        }
+
+        /// <summary>
+        /// Builds the <see cref="BuildWarningEventArgs"/> counterpart of an error that <c>ContinueOnError</c>
+        /// is downgrading. Errors carrying extended data become <see cref="ExtendedBuildWarningEventArgs"/> so the
+        /// structured payload survives; <c>ProjectFile</c> is not copied because the logging service assigns it
+        /// from the build event context.
+        /// </summary>
+        private static BuildWarningEventArgs CreateWarningFromError(BuildErrorEventArgs error)
+        {
+            if (error is IExtendedBuildEventArgs extendedError)
+            {
+                return new ExtendedBuildWarningEventArgs(
+                    extendedError.ExtendedType,
+                    error.Subcategory,
+                    error.Code,
+                    error.File,
+                    error.LineNumber,
+                    error.ColumnNumber,
+                    error.EndLineNumber,
+                    error.EndColumnNumber,
+                    error.Message,
+                    error.HelpKeyword,
+                    error.SenderName,
+                    error.HelpLink,
+                    error.RawTimestamp,
+                    messageArgs: null)
+                {
+                    ExtendedMetadata = extendedError.ExtendedMetadata,
+                    ExtendedData = extendedError.ExtendedData,
+                };
+            }
+
+            return new BuildWarningEventArgs(
+                error.Subcategory,
+                error.Code,
+                error.File,
+                error.LineNumber,
+                error.ColumnNumber,
+                error.EndLineNumber,
+                error.EndColumnNumber,
+                error.Message,
+                error.HelpKeyword,
+                error.SenderName,
+                error.HelpLink,
+                error.RawTimestamp,
+                messageArgs: null);
         }
 
         /// <summary>


### PR DESCRIPTION
When a task runs under `ContinueOnError`, `TaskHost.LogErrorEvent` converts the error into a warning. It rebuilt the warning from the shortest `BuildWarningEventArgs` constructor, so anything outside those ten fields was dropped: the help link, the original timestamp, and, for an error implementing `IExtendedBuildEventArgs`, `ExtendedType`, `ExtendedData` and `ExtendedMetadata`. 

This change downgrades errors carrying extended data to `ExtendedBuildWarningEventArgs` with the payload carried over, and preserves the help link and the original timestamp for plain errors too. `ProjectFile` is deliberately not copied, because the logging service assigns it from the build event context.
