### PR TITLE
[vs18.11] Point VS insertion and OptProf at rel/insiders

### DIFF
--- a/azure-pipelines/.vsts-dotnet-build-jobs.yml
+++ b/azure-pipelines/.vsts-dotnet-build-jobs.yml
@@ -77,7 +77,7 @@ jobs:
   - name: VisualStudio.MajorVersion
     value: 18
   - name: VisualStudio.ChannelName
-    value: 'int.main'
+    value: 'int.insiders'
   - name: VisualStudio.DropName
     value: Products/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildNumber)
 

--- a/azure-pipelines/vs-insertion.yml
+++ b/azure-pipelines/vs-insertion.yml
@@ -61,7 +61,7 @@ variables:
     ${{ if not(eq(parameters.TargetBranch, 'auto')) }}:
       value: ${{ parameters.TargetBranch }}
     ${{ else }}:
-      value: 'main'
+      value: 'rel/insiders'
   - name:  TeamName
     value: msbuild
   - name: TeamEmail


### PR DESCRIPTION
Under the VS Evergreen Branch Model, `rel/insiders` is now 18.11 while VS `main` has moved on to 18.12, so this branch's auto-insertion and OptProf settings are one milestone behind.

- `vs-insertion.yml`: auto-insert into `rel/insiders` instead of `main`.
- `.vsts-dotnet-build-jobs.yml`: build the OptProf bootstrapper from `int.insiders` instead of `int.main`, so training runs against the channel this branch actually ships in.

Note: `AutoCompleteEnabled` is only set for `main` targets, so insertions from this branch will need to be completed manually after this change.