### PR TITLE
[vs18.10] Build the OptProf bootstrapper from int.stable

### DIFF
--- a/azure-pipelines/.vsts-dotnet-build-jobs.yml
+++ b/azure-pipelines/.vsts-dotnet-build-jobs.yml
@@ -77,7 +77,7 @@ jobs:
   - name: VisualStudio.MajorVersion
     value: 18
   - name: VisualStudio.ChannelName
-    value: 'int.main'
+    value: 'int.stable'
   - name: VisualStudio.DropName
     value: Products/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildNumber)
 


### PR DESCRIPTION
This branch already auto-inserts into VS `rel/stable` (18.10), but OptProf still built its VS bootstrapper from `int.main`, which now tracks VS `main` (18.12) — two milestones ahead of the bits under test.

Point `VisualStudio.ChannelName` at `int.stable` so the training bootstrapper matches the insertion target.