### PR TITLE
[vs18.9] Disable unavailable OptProf data

### DIFF
--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -15,8 +15,10 @@ parameters:
   default: 'default'
 - name: enableOptProf
   displayName: Enable OptProf data collection for this build
+  # This servicing branch no longer has optimization data to apply and no longer
+  # collects fresh data.
   type: boolean
-  default: true
+  default: false
 - name: enableSigningValidation
   displayName: Enable Signing Validation
   type: boolean

--- a/azure-pipelines/.vsts-dotnet-build-jobs.yml
+++ b/azure-pipelines/.vsts-dotnet-build-jobs.yml
@@ -40,6 +40,7 @@ jobs:
     - output: buildArtifacts
       PathtoPublish: '$(Build.SourcesDirectory)\artifacts\official\MicroBuild\Output'
       ArtifactName: MicroBuildOutputs
+      condition: and(succeeded(), ${{ parameters.enableOptProf }})
 
     # RAINES TODO: switch to pipeline?
     - output: buildArtifacts
@@ -199,12 +200,12 @@ jobs:
 
       $paths = @(
         "log/$(BuildConfiguration)",
-        "$(Build.StagingDirectory)/MicroBuild/Output",
         "packages/$(BuildConfiguration)",
         "xsd"
       )
 
       if ("${{ parameters.enableOptProf }}" -eq "true") {
+        $paths += "$(Build.StagingDirectory)/MicroBuild/Output"
         $paths += "OptProf/$(BuildConfiguration)/Data"
         $paths += "VSSetup/$(BuildConfiguration)"
       }

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -3,7 +3,7 @@
   <Import Project="Version.Details.props" />
 
   <PropertyGroup>
-    <VersionPrefix>18.9.14</VersionPrefix><DotNetFinalVersionKind>release</DotNetFinalVersionKind><!-- Keep next to VersionPrefix to create a conflict in forward-flow -->
+    <VersionPrefix>18.9.15</VersionPrefix><DotNetFinalVersionKind>release</DotNetFinalVersionKind><!-- Keep next to VersionPrefix to create a conflict in forward-flow -->
     <PreReleaseVersionLabel>servicing</PreReleaseVersionLabel>
     <PackageValidationBaselineVersion>18.8.0-preview-26276-02</PackageValidationBaselineVersion>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>


### PR DESCRIPTION
Follows #14903 (vs18.6), #14902 (vs18.0) and #14909 (vs16.11).

### Changes Made

- Changed `enableOptProf` to default to `false`.
- Kept the existing behavior that sets `SkipApplyOptimizationData=true` when OptProf collection is disabled, avoiding the unavailable-data restore.
- Gated the `MicroBuildOutputs` artifact publish on `enableOptProf`, since it is only produced when the OptProf bootstrapper runs.
- Moved the `MicroBuild/Output` staging path into the `enableOptProf` branch of the artifact-layout check for the same reason.
- Bumped `VersionPrefix` to `18.9.15`.

### Notes
- Pipeline configuration only; no product code changes.