### PR TITLE
Add analyzer-review skills, instructions, and agent for src/TaskAnalyzer

### DIFF
--- a/.github/agents/analyzer-reviewer.agent.md
+++ b/.github/agents/analyzer-reviewer.agent.md
@@ -1,0 +1,109 @@
+---
+name: analyzer-reviewer
+description: "Reviews a PR that adds or changes a Roslyn C# analyzer, code fix, or diagnostic suppressor — especially the MSBuild thread-safe task analyzer under src/TaskAnalyzer/ (Microsoft.Build.TaskAuthoring.Analyzer, the MSBuildTaskNNNN rules). Delegates generic MSBuild-code review to the expert-reviewer agent, then layers analyzer-specific review (registration, descriptors, release tracking, false positives/negatives, code-fix compile-safety, tests) and — when the rule encodes multithreaded-task semantics — MT-domain-correctness review. Invoke for PRs touching analyzer/code-fix code or diagnostic descriptors."
+user-invokable: true
+disable-model-invocation: false
+---
+
+# Analyzer Reviewer
+
+You review pull requests that change a **Roslyn analyzer** — most often the MSBuild thread-safe task analyzer in `src/TaskAnalyzer/`. You catch the defect classes a general code reviewer misses: a **false positive that becomes a warning on every consumer's build**, a **severity change that breaks `-warnaserror`**, a **code fix that emits non-compiling code**, an **analyzer exception that silently suppresses all diagnostics**, **release-tracking drift**, and — for the MSBuild task rules — an **encoded rule that does not match multithreaded-task semantics**.
+
+The questionnaire lives in two skills. Load them, apply them, cite them by wave — do not restate them at the author.
+
+Your product is a **coverage report plus confirmed findings**, not a stream of comments. A human reads your coverage table to see *what was checked and how it was verified*, and reads your inline comments only for defects that are proven.
+
+---
+
+## Operating rules
+
+1. **Evidence or nothing.** Post a finding only when you hold concrete proof: a minimal source/config input plus a PR-head control-flow trace, a reproducing test, the exact compiler diagnostic (`CSxxxx`) from applying a fix, an exact descriptor/release/README/test value mismatch, or authoritative engine-source/spec evidence for MT semantics. **Model agreement is never proof.** If proof is unavailable after two focused attempts, mark the wave `INCOMPLETE` with the open question — never convert a hunch into a finding.
+2. **Clean is the expected result, but real defects are never suppressed.** Never invent an issue to populate a wave — and never drop or downplay a real one to keep the review short. There is **no cap and no quota** on findings: report *every* concern that clears the evidence-and-severity bar (rules 1 and 5), and only those. Three genuine BLOCKINGs is three findings. Filter on evidence and severity, never on count. Silence is not proof of work — the coverage table is.
+3. **No slop.** Do not emit praise, style, naming, formatting, preference-only, speculative-future ("a future caller might…"), or out-of-diff findings. Every finding names a specific changed line and a concrete trigger.
+4. **Read the PR head, not `main`.** New rules, descriptors, and tests exist only on the PR branch (`github-mcp-server-get_file_contents` with `ref: "refs/pull/{pr}/head"`). Never validate against `main`. Never modify the PR branch.
+5. **Severity — BLOCKING / MAJOR / MINOR only** (no NIT). A **false positive shipped at Warning or higher**, an **analyzer crash**, a **non-compiling code fix**, a **build break for `-warnaserror`**, or **wrong MT semantics in an automatic fix** is BLOCKING. A **missed detection**, **release-tracking/severity drift**, **wrong routing/injection or scope semantics**, or a **theater test** is MAJOR. A **concrete message/config inaccuracy that does not change diagnostic behavior** is MINOR. If a candidate has no observable current-PR impact, discard it.
+6. **A clean analyzer run is not evidence.** Never accept "the analyzer passes" as a reason a rule is correct, and never demand the analyzer model a dataflow/lifetime hazard it cannot (route those to `mt-migration-reviewer`).
+
+## Tool preamble
+
+Before your first tool call, state a one-paragraph plan: the changed rules/files, which waves are applicable, and how you will delegate and validate. After delegation, report which waves are running. Before posting, report the counts of confirmed / discarded / incomplete candidates. Send progress to the session, never as PR comments. Do not narrate individual file reads.
+
+---
+
+## Workflow
+
+### Phase 0 — Delegate the generic pass
+
+Invoke `@expert-reviewer` once with the PR URL, the PR-head ref/SHA, the description, linked-issue context, and the full diff. Request **analysis-only** output (no GitHub posting), and capture its findings as an **exclusion list** for the wave workers so they never re-run its dimensions (style, naming, perf, generic concurrency, compat). If it can only post independently, that posted review *is* the generic pass — record "Generic pass: posted independently by @expert-reviewer" in the coverage report, do not duplicate or re-post its findings, and continue with the analyzer waves. Its findings belong to it; your evidence-only and confirmation rules govern only your own analyzer findings. When it returns analysis-only output, surface that output **verbatim and attributed** under a "Generic review (@expert-reviewer)" heading in your Phase 4 review body — do not re-validate, re-severity, or merge it with your analyzer findings.
+
+### Phase 1 — Classify & find
+
+Read the diff. List the changed `MSBuildTaskNNNN` rules / analyzers / code fixes / descriptors / `AnalyzerReleases` files / tests. If the diff contains no supported analyzer change, stop and say so. Classify each questionnaire wave as `APPLICABLE` or `N/A` with a one-line reason; do not launch workers for `N/A` waves. Waves:
+
+- **W1 Structure / descriptors / release tracking**, **W2 Analyzer robustness & concurrency**, **W3 Detection precision (false ±)**, **W4 Code fixes**, **W5 Tests** — from `reviewing-roslyn-analyzers`.
+- **W6 MT-domain correctness** — from `reviewing-multithreaded-task-analyzers`; applicable when the diff touches an `MSBuildTaskNNNN` rule, banned-API list, `TaskEnvironment`/`AbsolutePath` handling, or `[MSBuildMultiThreadableTask]` logic.
+
+Launch **one analysis-only worker per applicable wave** (`task`, `agent_type: "general-purpose"`, a high-capability model — match the model the host pins for `@expert-reviewer`). Each worker prompt is self-contained:
+
+> You are an analysis-only worker. Do not post comments, modify the branch, or delegate further.
+> PR: `<url/number>`  ·  Head SHA/ref: `<exact>`  ·  Wave: `<N and name>`
+> Changed rules/files: `<list>`  ·  Applicable checks: `<the skill's wave checklist, verbatim>`
+> Findings already owned by the generic reviewer (exclude these): `<list>`
+> Report exactly one verdict: `CLEAN`, `ISSUES`, or `INCOMPLETE`. `CLEAN` requires every applicable check to have been evaluated. `INCOMPLETE` means evidence/tooling was unavailable — it must never become a finding. Read the PR head, not `main`. Clean is the expected outcome; do not invent an issue to populate the wave. No praise, NIT, style, or out-of-diff findings.
+> For each ISSUE:
+> ```
+> SEVERITY: BLOCKING | MAJOR | MINOR
+> RULE: MSBuildTaskNNNN (or file)
+> FILE: path  LINES: n-m
+> TRIGGER: <exact source/config/input>
+> FINDING: <false positive | false negative | crash | drift | non-compiling fix | theater test | wrong MT semantics>
+> RECOMMENDATION: <fix>
+> ```
+
+Scope guards for overlap: W2 owns Roslyn-callback, analyzer-state, and per-compilation concurrency **only**; W5 owns analyzer-specific coverage matrices and theater tests **only**. Anything the generic reviewer already covers is out of scope.
+
+### Phase 2 — Validate
+
+For each `ISSUE`, prove or disprove it against the PR-head source. Acceptable proof is a source trace, a reproducing test, an emitted compiler error, an exact value mismatch, or a spec/source citation. To run a proof test, use an **isolated, disposable worktree** and remove it afterward; if isolation is unavailable, use existing tests plus source tracing, or mark the item `INCOMPLETE`. Candidate outcomes are `CONFIRMED`, `DISPUTED`, or `UNVERIFIED`; post only `CONFIRMED`. Other models may suggest counterexamples, but agreement is not proof. (This validation governs your own analyzer findings only — you do not re-validate, re-severity, or dedup the generic reviewer's findings.)
+
+### Phase 3 — Post
+
+Deduplicate by **root cause + concrete trigger + observable impact** (treat `FILE`+`LINES` as an anchoring hint only): merge one root cause across locations into a single comment at the clearest changed line; keep distinct root causes separate even when they share a line. Post each confirmed finding as an **inline, line-anchored** comment with the concrete trigger and a `suggestion` block when the fix is a small edit. Use the host's inline-review tool; if none exists, return the drafts and mark posting incomplete. Never post a praise-only or "looks good" comment.
+
+### Phase 4 — Summary & coverage report
+
+Submit one review body containing the coverage report below — do not post a separate duplicate summary comment.
+
+```markdown
+## Analyzer review — coverage
+
+| Wave | Status | Verified / evidence |
+|---|---|---|
+| W1 Structure/release | CLEAN / ISSUES / N/A / INCOMPLETE | <e.g. "descriptor↔Unshipped↔README↔tests severities agree"; or link to finding; or reason> |
+| W2 Robustness | ... | <e.g. "no unguarded location deref; EnableConcurrentExecution present"> |
+| W3 Precision | ... | <e.g. "safe-pattern set covers alias + nested + array; edge case X fires"> |
+| W4 Code fixes | ... | <e.g. "fix withheld in static ctx; FixAll groups by property"> |
+| W5 Tests | ... | <e.g. "each new rule has positive+negative+fixed-compiles"> |
+| W6 MT semantics | ... | <e.g. "routing/injection truth-table respected; 0001/0004 stay unscoped"> |
+
+Generic MSBuild pass: <completed by @expert-reviewer / posted independently>.
+Confirmed findings: <n>.  Incomplete waves: <n and reason>.
+```
+
+`INCOMPLETE` and `N/A` never count as clean. Set the review event: any BLOCKING → **REQUEST_CHANGES**; otherwise **COMMENT**. **Never APPROVE** — you must not count as a maintainer approval. **Never resolve or dismiss a human-authored review thread.**
+
+---
+
+## What this reviewer does NOT do
+
+- Re-run the expert reviewer's dimensions, or duplicate its findings outside the attributed "Generic review (@expert-reviewer)" section.
+- Emit NIT/style/naming/praise, or demand `helpLinkUri`/localization on an internal analyzer unless the PR creates a concrete user-visible inconsistency.
+- Demand a code fix where the resolution is genuine author judgment, or treat `Info`/off-by-default rules as correctness rules.
+- Push back on a deliberate decision **not** to add/scope a rule when the author gave a coherent reason.
+
+## Cross-reference
+
+- Generic analyzer questionnaire: **reviewing-roslyn-analyzers**.
+- MT-domain questionnaire: **reviewing-multithreaded-task-analyzers**.
+- MT domain ground truth / reviewing task *migrations*: **multithreaded-task-migration** skill and **`mt-migration-reviewer`** agent.
+- Generic MSBuild code review: **`expert-reviewer`** agent.

--- a/.github/agents/analyzer-reviewer.agent.md
+++ b/.github/agents/analyzer-reviewer.agent.md
@@ -7,7 +7,7 @@ disable-model-invocation: false
 
 # Analyzer Reviewer
 
-You review pull requests that change a **Roslyn analyzer** — most often the MSBuild thread-safe task analyzer in `src/TaskAnalyzer/`. You catch the defect classes a general code reviewer misses: a **false positive that becomes a warning on every consumer's build**, a **severity change that breaks `-warnaserror`**, a **code fix that emits non-compiling code**, an **analyzer exception that silently suppresses all diagnostics**, **release-tracking drift**, and — for the MSBuild task rules — an **encoded rule that does not match multithreaded-task semantics**.
+You review pull requests that change a **Roslyn analyzer** — most often the MSBuild thread-safe task analyzer in `src/TaskAnalyzer/`. You catch the defect classes a general code reviewer misses: a **false positive that becomes a warning on every consumer's build**, a **severity change that breaks `-warnaserror`**, a **code fix that emits non-compiling code**, an **analyzer exception that leaves analysis incomplete**, **release-tracking drift**, and — for the MSBuild task rules — an **encoded rule that does not match multithreaded-task semantics**.
 
 The questionnaire lives in two skills. Load them, apply them, cite them by wave — do not restate them at the author.
 

--- a/.github/instructions/multithreaded-task-analyzer.instructions.md
+++ b/.github/instructions/multithreaded-task-analyzer.instructions.md
@@ -1,0 +1,51 @@
+---
+applyTo: "src/TaskAnalyzer/**/*.cs,src/TaskAnalyzer.Tests/**/*.cs"
+---
+
+# Multithreaded-Task Analyzer Instructions
+
+Layered on top of [roslyn-analyzers.instructions.md](./roslyn-analyzers.instructions.md). Those rules cover the analyzer *engineering*; these cover the **MSBuild multithreaded-task semantics** the `MSBuildTaskNNNN` rules encode. Every rule here is a *domain* rule — get it wrong and the analyzer is confidently incorrect. Ground truth: the `multithreaded-task-migration` skill (`plugins/mt-migration/`) and `documentation/specs/multithreading/`.
+
+## The two orthogonal signals (never conflate them)
+
+* `[MSBuildMultiThreadableTask]` = **routing**. It is the MT-safety routing signal that lets a task run **in-process** rather than in an out-of-proc TaskHost (absent other host requirements). `TaskRouter` reads it by **full type name**, `inherit: false`, off the concrete instantiated type (so a task may polyfill its own attribute). The declaration analyzer instead matches the resolved **framework attribute symbol** (`SymbolEqualityComparer`), also direct/non-inherited — mind this name-vs-identity difference when changing attribute detection.
+* `IMultiThreadableTask` = **injection**. The engine assigns the `TaskEnvironment` property **after construction**, only to instances of the interface. A public single-`TaskEnvironment` constructor is a separate mechanism: injected **during construction** (selected by signature; the constructor must assign the property itself). The interface is deliberately **not** a routing signal because `ToolTask` implements it — so interface-based rules (0013) key on the interface in the type's **own** base list, not inherited.
+* **Attribute-only** (attribute, no interface, no `TaskEnvironment` property) is a *supported declaration state* — no 0011–0014 diagnostic — and is a correct migration when the task has no file/env/process/static use (still checked by 0001–0005). No rule, message, or fix may imply the interface is always required.
+
+## What each rule class means (keep rationale intact)
+
+* **0001 (Error) — never-safe, whole-process APIs**: `Console.*` (banned at the *type* level), `Environment.Exit`/`FailFast`, `Process.Kill`, `ThreadPool.Set*`, `CultureInfo.DefaultThreadCurrent*`, `Directory.SetCurrentDirectory`. Unsafe regardless of MT → **must fire on every `ITask`; never scope-gate these.**
+* **0002 (Warning) — per-task process state with a `TaskEnvironment` replacement**: cwd, env vars, `Path.GetFullPath`/temp, `Process.Start`/`new ProcessStartInfo`.
+* **0003 (Warning) — relative path against the shared cwd**: file-system APIs on the monitored types. The monitored-type list is **knowingly incomplete** (see blind spots).
+* **0004 (Warning) — assembly loading** (version conflicts in a shared host): **review-required**, not never-safe. Unscoped like 0001 — fires on every `ITask`; don't scope-gate.
+* **0005 (Warning, `CompilationEnd`) — transitive** reach through helpers; reported at the unsafe call site with the task entry as an `AdditionalLocation`.
+* **0006–0008 (Info), 0009–0010 (Warning), 0011–0014**: typed-parameter modernization, `ITaskItem<T>` binding, and the routing/injection truth table.
+
+## Messages must be honest
+
+* State only what the engine **guarantees**. Don't assert a runtime value it doesn't set (say "MSBuild never assigns it / retains its default", not "stays `TaskEnvironment.Fallback`").
+* Never imply that applying the attribute alone makes a task safe — it is the *last* step, a claim of concurrency-safety. **Do not offer a code fix that auto-applies `[MSBuildMultiThreadableTask]`.**
+
+## Path semantics
+
+* `TaskEnvironment.GetAbsolutePath` roots against `ProjectDirectory` and **does not canonicalize** (unlike `Path.GetFullPath`). Rooting must be **unconditional** — an `IsPathRooted` gate is a bug (misses Windows drive-/root-relative forms). Recognized safe forms: `GetAbsolutePath(...)`, `AbsolutePath`/`Nullable<AbsolutePath>` implicit conversion, `FileInfo/DirectoryInfo.FullName`, `ITaskItem.GetMetadata("FullPath")`, first arg of `Path.Combine`, an already-`AbsolutePath`-typed argument.
+* Use `AbsolutePath.OriginalValue` for messages/`[Output]`, `Value` for file I/O.
+
+## TaskEnvironment injection timing
+
+* Assigned **after** construction → property initializers and constructor bodies can't use it. That is why 0008 (root a relative default in `Execute()`) and 0011 (prefer constructor injection) exist. Any fix referencing `TaskEnvironment` must be **withheld** where it can't bind: static context (CS0120), initializers (CS0236/CS0027), or a task with no `TaskEnvironment` member (`Microsoft.Build.Utilities.Task` — CS0103).
+
+## Scope & configuration
+
+* Genuinely MT-specific rules (0002/0003/0005) may be gated by `msbuild_task_analyzer.scope` (`all` | `multithreadable_only`). Keep 0001/0004 unscoped; do not gate them. Expose the option through a reachable `CompilerVisibleProperty` + `build/*.props`, not a raw dotted `build_property` name. Prefer per-rule severity config over new scope values.
+
+## Known blind spots (do not pretend to cover them)
+
+The analyzer is a partial static approximation of a dataflow+lifetime property. Out of reach **by design**: unannotated base classes (`Inherited=false`; base-class coverage may be extended over time), analyzer-invisible path consumers (`AssemblyName.GetAssemblyName`, `XDocument.Load`, `ZipFile.*`, …), DI/delegate boundaries, `RegisterTaskObject` races, process-seeded `static` fields, nested `new MyTask().Execute()`, and the behavioral-parity "8 sins". A clean analyzer run is not proof of a safe migration.
+
+## Related Documentation
+
+* [Rule catalog & rationale](../../src/TaskAnalyzer/README.md)
+* [Reviewing MT analyzer contributions (skill)](../skills/reviewing-multithreaded-task-analyzers/SKILL.md)
+* [MT task migration playbook (skill)](../../plugins/mt-migration/skills/multithreaded-task-migration/SKILL.md)
+* [Multithreading specs](../../documentation/specs/multithreading/)

--- a/.github/instructions/roslyn-analyzers.instructions.md
+++ b/.github/instructions/roslyn-analyzers.instructions.md
@@ -1,0 +1,60 @@
+---
+applyTo: "src/TaskAnalyzer/**/*.cs,src/TaskAnalyzer.Tests/**/*.cs"
+---
+
+# Roslyn Analyzer Instructions
+
+The `src/TaskAnalyzer/` project (`Microsoft.Build.TaskAuthoring.Analyzer`) is a **Roslyn C# analyzer** — `DiagnosticAnalyzer` + `CodeFixProvider` types built on `Microsoft.CodeAnalysis.Diagnostics`. It ships diagnostics `MSBuildTaskNNNN` (category `MSBuild.TaskAuthoring`) that steer task authors toward thread-safe patterns.
+
+These rules are for authoring and reviewing **the analyzer itself**. They are generic Roslyn-analyzer engineering conventions; the multithreading *semantics* the rules encode live in [multithreaded-task-analyzer.instructions.md](./multithreaded-task-analyzer.instructions.md). MSBuild's own build analyzers (BuildCheck) are a different subsystem — see [buildcheck.instructions.md](./buildcheck.instructions.md).
+
+## Analyzer Shape & Registration
+
+* Each analyzer is `[DiagnosticAnalyzer(LanguageNames.CSharp)]`, `sealed`, and stateless. `Initialize` calls `EnableConcurrentExecution()` and `ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None)` (RS1026/RS1025).
+* Resolve well-known types (`ITask`, `TaskEnvironment`, `AbsolutePath`, …) and build the banned-API lookup **once** per compilation inside `RegisterCompilationStartAction`; close over them. Never cache symbols in instance fields (RS1008).
+* Scope work per type with `RegisterSymbolStartAction`/`RegisterSymbolAction`, then `RegisterOperationAction` for per-call checks. Prefer operation/symbol actions over `RegisterSyntaxNodeAction` — they are semantic and language-agnostic.
+* Keep `AnalyzeXxx` methods `private static` — no captured instance state. Compare symbols with `SymbolEqualityComparer.Default`, never `==` (RS1024).
+* Resolve banned APIs via `DocumentationCommentId` into a `Dictionary<ISymbol, …>` for O(1) lookup. No LINQ or repeated symbol resolution on the per-operation hot path.
+
+## Diagnostics & Descriptors
+
+* IDs are constants in `DiagnosticIds`; descriptors live in `DiagnosticDescriptors.All` in declaration order. Category is always `MSBuild.TaskAuthoring`.
+* Keep **descriptor severity, `AnalyzerReleases.Unshipped.md`, the README rule table, and the test assertions in agreement.** Drift between these four is the single most common defect in this project.
+* Titles and messages end **without** a period; descriptions end **with** one (RS1031/1032/1033).
+* A descriptor reported from a `CompilationEnd` action must carry `WellKnownDiagnosticTags.CompilationEnd` (RS1037) — e.g. MSBuildTask0005.
+* `helpLinkUri` and `LocalizableResourceString`/`.resx` are not currently used (RS1015/RS1007 are off by default). If you add localization or help links, do it consistently across all descriptors.
+
+## Analyzer Release Tracking (RS2000/RS2001)
+
+* Every new rule — and every severity or category change — **must** update `AnalyzerReleases.Unshipped.md` (columns `Rule ID | Category | Severity | Notes`). A missing entry fails RS2000. New rules go in `Unshipped.md`; don't edit `Shipped.md` unless cutting a formal release.
+* `TaskAnalyzer.csproj` sets `NoWarn=…;RS1038;RS2001` (RS1038 is expected — the analyzer references `Workspaces` for code fixes; don't "fix" it). Suppressing `RS2001` means the build will **not** catch a descriptor severity that disagrees with the release file — verify severities by hand, or temporarily un-suppress `RS2001`, whenever a rule's severity changes.
+
+## Severity & Configuration
+
+* A new `Warning`-by-default rule, or a `Warning→Error` promotion, is a **breaking change** for consumers building with `-warnaserror`. Call it out explicitly; prefer `Info` for modernization suggestions. (As reference points at time of writing, MSBuildTask0001 was the sole `Error` and MSBuildTask0013 shipped disabled-by-default — verify the current descriptors rather than trusting these counts.)
+* Analysis scope is read **once** per compilation from the `msbuild_task_analyzer.scope` option (`all` | `multithreadable_only`). Consume it through a `CompilerVisibleProperty`/`build_property.*` that is actually reachable — a raw dotted `build_property` name that no `.props` exposes is a dead option.
+* Per-rule severity is user-configurable through `.editorconfig`/`.globalconfig` (`dotnet_diagnostic.<id>.severity`). Do not invent bespoke scope/config knobs when severity configuration already expresses the intent. Note that `dotnet_diagnostic.*.severity` reaches the analyzer via `SyntaxTreeOptionsProvider`, not `AnalyzerConfigOptions`.
+
+## Code Fixes
+
+* Every `CodeAction` needs a stable, non-null `EquivalenceKey` (RS1010) and the provider overrides `GetFixAllProvider` (RS1016). Per the analyzer README, `dotnet format analyzers` derives its FixAll batch from the **first** diagnostic — if the first occurrence offers no fix, the whole batch applies nothing.
+* A fix must produce **compiling** code or offer nothing. Withhold the fix where `TaskEnvironment` cannot bind: static context (CS0120), field/property/constructor initializers (CS0236/CS0027), or a task with no `TaskEnvironment` member (CS0103). Handle nested calls, named-argument order, init-only/private setters, member-name collisions (CS0102), and properties referenced across partial declarations in another document (decline rather than break).
+
+## Robustness
+
+* An analyzer must **never throw** — an exception suppresses *all* diagnostics for the compilation. Guard **locations** before reporting: a symbol may have zero `Locations`, and a `Location` from metadata has a null `SourceTree` — never index `Locations[0]` or dereference `SourceTree` unconditionally; use `Location.None` as the fallback.
+* Do not use file/environment/other non-deterministic APIs inside analyzer callbacks (RS1035).
+* Deduplicate diagnostics on the exact key you report at; report at the precise offending location (with the task entry point as an `AdditionalLocation`) so `#pragma warning disable`/`[SuppressMessage]` work where the code lives.
+
+## Tests (`src/TaskAnalyzer.Tests`)
+
+* xUnit + Shouldly. Analyzer tests use the custom `TestHelpers` harness (`compilation.WithAnalyzers(...).GetAnalyzerDiagnosticsAsync()`); code-fix tests use `CSharpCodeFixTest<>`. Inject scope via `TestAnalyzerConfigOptionsProvider` with `build_property.msbuild_task_analyzer.scope`.
+* Each rule needs: **positive** (fires), **negative** (silent), **boundary**, **safe-pattern-suppresses**, and — for fixes — **fixed-code-compiles**. Use `TestHelpers.FullyQualifiedPath` for OS-portable absolute paths.
+* A test must be able to fail for the reason it names (an MT-scope test that sets no scope, or that asserts "no feedback", is theater).
+
+## Related Documentation
+
+* [Rule catalog & rationale](../../src/TaskAnalyzer/README.md)
+* [Reviewing Roslyn analyzer contributions (skill)](../skills/reviewing-roslyn-analyzers/SKILL.md)
+* [MT semantics the rules encode](./multithreaded-task-analyzer.instructions.md)
+* [BuildCheck analyzers (different subsystem)](./buildcheck.instructions.md)

--- a/.github/instructions/roslyn-analyzers.instructions.md
+++ b/.github/instructions/roslyn-analyzers.instructions.md
@@ -42,7 +42,7 @@ These rules are for authoring and reviewing **the analyzer itself**. They are ge
 
 ## Robustness
 
-* An analyzer must **never throw** — an exception suppresses *all* diagnostics for the compilation. Guard **locations** before reporting: a symbol may have zero `Locations`, and a `Location` from metadata has a null `SourceTree` — never index `Locations[0]` or dereference `SourceTree` unconditionally; use `Location.None` as the fallback.
+* An analyzer must **never throw**. Roslyn normally reports analyzer failures as `AD0001`, and analysis can be incomplete. An exception does not necessarily remove existing diagnostics or stop unrelated analyzers. Guard **locations** before reporting: a symbol may have zero `Locations`, and a metadata location has a null `SourceTree`. Never index `Locations[0]` or dereference `SourceTree` unconditionally. Use `Location.None` when no source location exists.
 * Do not use file/environment/other non-deterministic APIs inside analyzer callbacks (RS1035).
 * Deduplicate diagnostics on the exact key you report at; report at the precise offending location (with the task entry point as an `AdditionalLocation`) so `#pragma warning disable`/`[SuppressMessage]` work where the code lives.
 

--- a/.github/skills/reviewing-multithreaded-task-analyzers/SKILL.md
+++ b/.github/skills/reviewing-multithreaded-task-analyzers/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: reviewing-multithreaded-task-analyzers
+description: "Use when reviewing a PR that adds or changes an MSBuildTaskNNNN diagnostic in the MSBuild thread-safe task analyzer (src/TaskAnalyzer/, Microsoft.Build.TaskAuthoring.Analyzer) — the rules that steer task authors toward IMultiThreadableTask / TaskEnvironment / [MSBuildMultiThreadableTask]. Layers on top of reviewing-roslyn-analyzers to judge whether the encoded rule matches MSBuild multithreaded-task semantics: attribute-vs-interface routing/injection, TaskEnvironment injection timing, AbsolutePath path-rooting, banned-API rationale, scope-gating of unscoped vs MT-specific rules, config reachability, and the hazards the analyzer cannot model by design."
+argument-hint: "Paste the analyzer PR number/URL or the MSBuildTaskNNNN rule diff to review."
+---
+
+# Reviewing Multithreaded-Task Analyzer Contributions
+
+This is the **specialized layer** on top of **reviewing-roslyn-analyzers**. That skill judges whether the analyzer is well-built (registration, descriptors, release tracking, fixes, tests). This skill judges the harder question: **does the encoded rule actually match MSBuild multithreaded-task semantics?**
+
+The single most important framing: **MT-safety is a dataflow + lifetime property** — "does any task input reach a process-global sink, through any path, at any point in the object's life?" — and it is only *partially* expressible as banned-symbol / AST rules. The analyzer is a deliberately incomplete static approximation of the ground truth. The ground truth lives in the **multithreaded-task-migration** skill; treat that skill as the specification and the analyzer as the (partial) enforcement.
+
+## When to use
+
+- A PR adds, removes, widens, narrows, or re-scopes an `MSBuildTaskNNNN` rule, its banned-API list, its safe-pattern set, its message text, or its code fix.
+- A PR changes analysis **scope** (`all` vs `multithreadable_only`) or the config surface that controls it.
+- Always run **reviewing-roslyn-analyzers** first (Waves 1–5); this skill adds **Wave 6**.
+
+Not for: reviewing a *task* being migrated to MT — that is the `mt-migration-reviewer` agent's job, driven by the `multithreaded-task-migration` skill.
+
+## Load the domain first
+
+Before judging a rule, load **multithreaded-task-migration** (the 8 compatibility sins, the leaf-API hazard table, the decoy-CWD / cross-instance test patterns). A rule is only "correct" if it rewards the shape that skill calls correct and flags the shape it calls a defect.
+
+## The MT model on one screen (verify a rule against this)
+
+**Two orthogonal signals** (`TaskRouter.NeedsTaskHostInMultiThreadedMode`, spec `documentation/specs/multithreading/thread-safe-tasks.md`):
+- **Attribute `[MSBuildMultiThreadableTask]` = routing.** It, and *only* it, lets a task run **in-process** rather than in an out-of-proc TaskHost (absent other host requirements). `TaskRouter` reads it with `inherit: false` off the concrete instantiated type, matching by **full type name** (so a task may polyfill its own attribute). The declaration analyzer instead matches the resolved **framework attribute symbol** (`SymbolEqualityComparer`), also direct/non-inherited — see the name-vs-identity discrepancy check in Wave 6.
+- **Interface `IMultiThreadableTask` = injection.** The engine assigns the `TaskEnvironment` property **after construction**, only to instances of this interface. Separately, a public single-`TaskEnvironment` constructor is injected **during construction** — the engine selects it by signature and the constructor must assign the property itself. The two mechanisms are independent.
+- The interface is deliberately **not** a routing signal because `ToolTask` implements it — routing on it would silently opt in every `ToolTask`.
+
+**Routing/injection truth table** (what 0011–0014 encode):
+
+| Attribute | Interface / TE ctor | Effect | Correct diagnostic |
+|---|---|---|---|
+| ✅ | ✅ concrete, no TE ctor | in-proc, env injected post-construction | 0011 Info — prefer ctor injection |
+| ✅ | ❌ but has (incl. inherited) a settable `TaskEnvironment` property, no TE ctor | in-proc, **engine never assigns it** → resolves against shared CWD | 0012 Warning |
+| ❌ | ✅ in own base list | correct paths but **still out-of-proc** (no perf win) | 0013 Info, off by default |
+| ✅ on a non-`ITask` class, or an abstract `ITask` class | — | attribute reaches nothing the engine routes | 0014 Warning |
+| ✅ | ❌, no TE property at all | no **declaration** diagnostic — "migrated" only if 0001–0005 + a call-chain audit are clean | none (0011–0014) |
+
+**TaskEnvironment** (`src/Framework/TaskEnvironment.cs`): `ProjectDirectory`, `GetAbsolutePath(string)→AbsolutePath`, `Get/Set/GetEnvironmentVariables`, `GetProcessStartInfo()`, static `Fallback` (backed by `MultiProcessTaskEnvironmentDriver` → delegates to real process state; the correct single-tenant default). Assigned **after construction**, so initializers/ctor bodies can't use it → the constructor-injection pattern (0011) and relative-default-in-`Execute()` (0008) exist for exactly that.
+
+**AbsolutePath** (`src/Framework/PathHelpers/AbsolutePath.cs`): `Value` (absolute) vs `OriginalValue` (input as-provided, for messages/`[Output]`); implicit→string; **does not canonicalize** (`..` unresolved unless `GetCanonicalForm()`); throws on null/empty.
+
+**Banned-API rationale = shared process state:** process-terminators / process-wide setters (Console, `Environment.Exit`, `Process.Kill`, `Directory.SetCurrentDirectory`, `DefaultThreadCurrentCulture`, `ThreadPool.Set*`) are never safe → **0001 Error**. Assembly loading (version conflicts in a shared host) is **review-required**, not never-safe → **0004 Warning**. Both 0001 and 0004 fire on **every** `ITask` regardless of scope. Per-task-varying process state (cwd, env, `Path.GetFullPath`/temp, `Process.Start`) → **0002 Warning**; relative paths against the shared cwd → **0003 Warning**; transitive reach through helpers → **0005 Warning** (`CompilationEnd`) — these three are the MT-scoped rules.
+
+---
+
+## Wave 6 — MT-domain correctness
+
+Apply after Waves 1–5. Add a **W6 — MT semantics** coverage row with `CLEAN / ISSUES / N/A / INCOMPLETE`. `CLEAN` requires all applicable checks; `INCOMPLETE` never becomes a finding. Report every rule defect proved by a concrete task shape or engine behavior; no cap or quota. The same evidence-and-noise gate applies.
+
+**Routing / injection semantics**
+- [ ] Attribute detection is **direct** (`inherit: false`) off the concrete type. Note the deliberate name-vs-identity split: `TaskRouter` matches by **full type name** (a polyfilled attribute still routes in-proc), while the declaration analyzer matches the resolved **framework attribute symbol** (a polyfilled attribute routes but is *not* seen by 0012–0014). If a rule change touches attribute detection, confirm which of the two behaviors it should follow. Injection rules key on the interface in the type's **own** base list (not inherited via `ToolTask`), or on a single-`TaskEnvironment` constructor.
+- [ ] Does the rule respect that **attribute-only** (attribute, no interface, no `TaskEnvironment` property) is a *supported declaration state*? It produces no 0011–0014 diagnostic, and is a correct migration when the task has no file/env/process/static use (still checked by 0001–0005 and a call-chain audit). A rule/message/fix implying the interface is always required is wrong — a simple task may need only the attribute and still be fully and properly migrated.
+
+**Message honesty**
+- [ ] The message/description states only what the engine **guarantees**. Don't assert a runtime value the engine doesn't set (e.g. "stays `TaskEnvironment.Fallback`" — say "MSBuild never assigns it / retains its default").
+- [ ] The message doesn't imply that applying `[MSBuildMultiThreadableTask]` alone makes a task safe. Adding the attribute is a *claim* of concurrency-safety and is the **last** step, not the fix — it is not the only thing a task needs to be MT-safe.
+- [ ] There is **no code fix that auto-applies `[MSBuildMultiThreadableTask]`.** Friction is intentional — auto-applying a safety claim without understanding the task is harmful.
+
+**Unscoped vs MT-specific (scope-gating)**
+- [ ] The **unscoped** rules — 0001 (never-safe: `Environment.Exit`/`Console.ReadLine`/…) and 0004 (review-required: assembly loading) — keep firing on **all** `ITask`; they must **not** become scope-gated. Only the genuinely MT-specific rules (0002/0003/0005: path/env/cwd) are gated to MT tasks. Name exactly which tasks a scope change newly breaks or newly ignores — a consumer updating `Microsoft.Build.Framework` must not gain un-opt-out-able build errors.
+
+**Path / AbsolutePath semantics**
+- [ ] Safe-pattern recognition matches the domain: `GetAbsolutePath` ≠ `Path.GetFullPath` (no canonicalization), and rooting must be **unconditional** — an `IsPathRooted` gate is a *bug*, not a safe pattern (misses Windows drive-/root-relative forms). Recognized safe forms: `GetAbsolutePath(...)`, `AbsolutePath` (and `Nullable<AbsolutePath>`) implicit conversion, `FileInfo/DirectoryInfo.FullName`, `ITaskItem.GetMetadata("FullPath")`, an already-`AbsolutePath`-typed argument. (Sins 5 & 7.)
+- [ ] `Path.Combine` is treated as safe only via its **first** argument (later positions restart from the last rooted segment).
+
+**TaskEnvironment binding & code-fix withholding**
+- [ ] Any fix that references `TaskEnvironment` is **withheld** where it can't bind: static context (CS0120), initializers (CS0236/CS0027), or a type whose only `ITask` implementation is `Microsoft.Build.Utilities.Task` (no `TaskEnvironment` member — CS0103).
+- [ ] Injection-timing rules (0008 relative default, 0011 ctor injection) correctly account for `TaskEnvironment` being unavailable before construction completes.
+
+**`ITaskItem<T>` binding**
+- [ ] 0009 (unsupported `T`) and 0010 (culture-sensitive `Convert.ChangeType` types) match the binder's actual supported set (`string, bool, AbsolutePath, FileInfo, DirectoryInfo` directly parsed; numeric/char/`DateTime` via invariant `Convert.ChangeType`). Open generics (`TypeKind.TypeParameter`) must be skipped.
+
+**Config reachability & cost**
+- [ ] The scope/config option is actually **reachable**. The analyzer reads `msbuild_task_analyzer.scope` from analyzer global options; a raw dotted `build_property.msbuild_task_analyzer.scope` has no reachable MSBuild property, so exposing the option needs a `CompilerVisibleProperty` + packed `build/*.props` (verify the actual wiring). Prefer existing per-rule **severity** config (`.editorconfig`/`.globalconfig`) over inventing new scope values. Note `MSBuildTask0005` runs at `CompilationEnd` with no syntax tree, so per-tree `.editorconfig` scope would disagree with it.
+- [ ] The analyzer doesn't pay for analysis it discards (e.g. building the whole transitive call graph then dropping it under a default scope).
+
+**Empirical verification**
+- [ ] Any claim about engine behavior (injection timing, what routes where, whether an env var takes effect) is **verified**, not assumed. When the semantics are subtle, ask for a test or a spec/source citation rather than trusting intuition.
+
+## Known blind spots — what the analyzer cannot model (do not accept "analyzer is clean" as proof; do not demand it model these either)
+
+The analyzer is a partial static approximation of an MT-safety property that is fundamentally dataflow + lifetime. As a calibration point, a large migration with this analyzer enabled and a clean 0/0 build can still contain real defects the analyzer cannot see. When a rule change claims to "cover" MT-safety, remember these residual hazards live outside static reach **by design**:
+- **Unannotated base classes** run multithreaded but aren't analyzed under `multithreadable_only` (`Inherited=false`); base-class coverage may be extended over time, so verify the current analyzer scope.
+- **Analyzer-invisible path consumers** not on the 0003 monitored list: `AssemblyName.GetAssemblyName`, `XDocument/XmlDocument.Load(string)`, `XmlReader/XmlWriter.Create(string)`, `ZipFile.*`, `X509CertificateLoader`, `Image.FromFile`, `Assembly.LoadFrom` (string overloads).
+- **Dataflow/lifetime hazards:** task inputs crossing a DI/interface/delegate boundary; `RegisterTaskObject`/`GetRegisteredTaskObject` races; process-state-seeded `static` fields; nested `new MyTask().Execute()`; and the behavioral-parity **8 sins** (`[Output]`/message inflation, `?? ""` control-flow changes, canonicalization/exception-type changes).
+
+So: a widened allow-list can never make the analyzer "complete" — value it as one layer, and route dataflow/lifetime review to the `mt-migration-reviewer` agent.
+
+## MT review invariants (reapply on every analyzer PR)
+
+These recur across analyzer reviews:
+
+1. No auto-fix that applies `[MSBuildMultiThreadableTask]` — it's the last step, not the fix.
+2. Messages must be MT-accurate and honest; attribute-only can be a complete migration.
+3. Keep the unscoped rules (0001 never-safe, 0004 review-required) firing on all tasks; only gate the genuinely MT-specific ones (0002/0003/0005).
+4. Minimize config surface; prefer existing severity knobs; make any option reachable.
+5. Verify engine behavior empirically before asserting it in a message, doc, or rule.
+
+## Sign-off (MT layer)
+
+- [ ] Every new/changed rule verified against the routing/injection truth table and the banned-API rationale.
+- [ ] Messages state only engine-guaranteed behavior; no rule/message/fix implies the attribute alone is sufficient.
+- [ ] Unscoped vs MT-specific scoping is correct; no un-opt-out-able new break for plain `ITask` consumers.
+- [ ] Path safe-patterns match domain semantics (no `IsPathRooted` gate; `GetAbsolutePath` ≠ canonicalize).
+- [ ] Config option is reachable; no bespoke knob where severity config suffices.
+- [ ] Residual dataflow/lifetime hazards acknowledged, not assumed covered.
+
+## Cross-references
+
+- Generic analyzer engineering: **reviewing-roslyn-analyzers** skill.
+- MT domain ground truth (sins, hazards, test patterns): **multithreaded-task-migration** skill (`plugins/mt-migration/`).
+- Reviewing a *task* migration (call-chain audit): **`mt-migration-reviewer`** agent.
+- Automated multi-wave analyzer review: **`@analyzer-reviewer`** agent (runs Waves 1–6).
+- Rule catalog: `src/TaskAnalyzer/README.md`. Spec: `documentation/specs/multithreading/`.

--- a/.github/skills/reviewing-multithreaded-task-analyzers/SKILL.md
+++ b/.github/skills/reviewing-multithreaded-task-analyzers/SKILL.md
@@ -1,26 +1,27 @@
 ---
 name: reviewing-multithreaded-task-analyzers
-description: "Use when reviewing a PR that adds or changes an MSBuildTaskNNNN diagnostic in the MSBuild thread-safe task analyzer (src/TaskAnalyzer/, Microsoft.Build.TaskAuthoring.Analyzer) — the rules that steer task authors toward IMultiThreadableTask / TaskEnvironment / [MSBuildMultiThreadableTask]. Layers on top of reviewing-roslyn-analyzers to judge whether the encoded rule matches MSBuild multithreaded-task semantics: attribute-vs-interface routing/injection, TaskEnvironment injection timing, AbsolutePath path-rooting, banned-API rationale, scope-gating of unscoped vs MT-specific rules, config reachability, and the hazards the analyzer cannot model by design."
+description: "Use when reviewing changes to MSBuildTaskNNNN diagnostics in src/TaskAnalyzer/ (Microsoft.Build.TaskAuthoring.Analyzer), including banned APIs, safe patterns, scope, messages, and fixes involving IMultiThreadableTask, TaskEnvironment, AbsolutePath, or MSBuildMultiThreadableTask."
 argument-hint: "Paste the analyzer PR number/URL or the MSBuildTaskNNNN rule diff to review."
 ---
 
 # Reviewing Multithreaded-Task Analyzer Contributions
 
-This is the **specialized layer** on top of **reviewing-roslyn-analyzers**. That skill judges whether the analyzer is well-built (registration, descriptors, release tracking, fixes, tests). This skill judges the harder question: **does the encoded rule actually match MSBuild multithreaded-task semantics?**
+This adds MSBuild domain checks to **reviewing-roslyn-analyzers**: **does the encoded rule match multithreaded-task semantics?**
 
-The single most important framing: **MT-safety is a dataflow + lifetime property** — "does any task input reach a process-global sink, through any path, at any point in the object's life?" — and it is only *partially* expressible as banned-symbol / AST rules. The analyzer is a deliberately incomplete static approximation of the ground truth. The ground truth lives in the **multithreaded-task-migration** skill; treat that skill as the specification and the analyzer as the (partial) enforcement.
+**MT-safety is a dataflow + lifetime property**: can task input reach process-global state at any point in the object's life? The analyzer enforces only part of the **multithreaded-task-migration** specification.
 
 ## When to use
 
 - A PR adds, removes, widens, narrows, or re-scopes an `MSBuildTaskNNNN` rule, its banned-API list, its safe-pattern set, its message text, or its code fix.
 - A PR changes analysis **scope** (`all` vs `multithreadable_only`) or the config surface that controls it.
-- Always run **reviewing-roslyn-analyzers** first (Waves 1–5); this skill adds **Wave 6**.
 
 Not for: reviewing a *task* being migrated to MT — that is the `mt-migration-reviewer` agent's job, driven by the `multithreaded-task-migration` skill.
 
-## Load the domain first
+## How to use
 
-Before judging a rule, load **multithreaded-task-migration** (the 8 compatibility sins, the leaf-API hazard table, the decoy-CWD / cross-instance test patterns). A rule is only "correct" if it rewards the shape that skill calls correct and flags the shape it calls a defect.
+1. Apply **reviewing-roslyn-analyzers** (Waves 1–5).
+2. Load **multithreaded-task-migration** before judging domain behavior. Use its compatibility sins, hazard table, and decoy-CWD / cross-instance test patterns.
+3. Apply Wave 6 below and add its coverage row to the generic report.
 
 ## The MT model on one screen (verify a rule against this)
 
@@ -34,7 +35,7 @@ Before judging a rule, load **multithreaded-task-migration** (the 8 compatibilit
 | Attribute | Interface / TE ctor | Effect | Correct diagnostic |
 |---|---|---|---|
 | ✅ | ✅ concrete, no TE ctor | in-proc, env injected post-construction | 0011 Info — prefer ctor injection |
-| ✅ | ❌ but has (incl. inherited) a settable `TaskEnvironment` property, no TE ctor | in-proc, **engine never assigns it** → resolves against shared CWD | 0012 Warning |
+| ✅ | ❌ but has (incl. inherited) a settable `TaskEnvironment` property, no TE ctor | in-proc, **engine never assigns it**; value depends on task code | 0012 Warning |
 | ❌ | ✅ in own base list | correct paths but **still out-of-proc** (no perf win) | 0013 Info, off by default |
 | ✅ on a non-`ITask` class, or an abstract `ITask` class | — | attribute reaches nothing the engine routes | 0014 Warning |
 | ✅ | ❌, no TE property at all | no **declaration** diagnostic — "migrated" only if 0001–0005 + a call-chain audit are clean | none (0011–0014) |
@@ -83,31 +84,12 @@ Apply after Waves 1–5. Add a **W6 — MT semantics** coverage row with `CLEAN 
 
 ## Known blind spots — what the analyzer cannot model (do not accept "analyzer is clean" as proof; do not demand it model these either)
 
-The analyzer is a partial static approximation of an MT-safety property that is fundamentally dataflow + lifetime. As a calibration point, a large migration with this analyzer enabled and a clean 0/0 build can still contain real defects the analyzer cannot see. When a rule change claims to "cover" MT-safety, remember these residual hazards live outside static reach **by design**:
+A clean analyzer run does not prove MT-safety. These residual hazards are outside its coverage **by design**:
 - **Unannotated base classes** run multithreaded but aren't analyzed under `multithreadable_only` (`Inherited=false`); base-class coverage may be extended over time, so verify the current analyzer scope.
 - **Analyzer-invisible path consumers** not on the 0003 monitored list: `AssemblyName.GetAssemblyName`, `XDocument/XmlDocument.Load(string)`, `XmlReader/XmlWriter.Create(string)`, `ZipFile.*`, `X509CertificateLoader`, `Image.FromFile`, `Assembly.LoadFrom` (string overloads).
 - **Dataflow/lifetime hazards:** task inputs crossing a DI/interface/delegate boundary; `RegisterTaskObject`/`GetRegisteredTaskObject` races; process-state-seeded `static` fields; nested `new MyTask().Execute()`; and the behavioral-parity **8 sins** (`[Output]`/message inflation, `?? ""` control-flow changes, canonicalization/exception-type changes).
 
 So: a widened allow-list can never make the analyzer "complete" — value it as one layer, and route dataflow/lifetime review to the `mt-migration-reviewer` agent.
-
-## MT review invariants (reapply on every analyzer PR)
-
-These recur across analyzer reviews:
-
-1. No auto-fix that applies `[MSBuildMultiThreadableTask]` — it's the last step, not the fix.
-2. Messages must be MT-accurate and honest; attribute-only can be a complete migration.
-3. Keep the unscoped rules (0001 never-safe, 0004 review-required) firing on all tasks; only gate the genuinely MT-specific ones (0002/0003/0005).
-4. Minimize config surface; prefer existing severity knobs; make any option reachable.
-5. Verify engine behavior empirically before asserting it in a message, doc, or rule.
-
-## Sign-off (MT layer)
-
-- [ ] Every new/changed rule verified against the routing/injection truth table and the banned-API rationale.
-- [ ] Messages state only engine-guaranteed behavior; no rule/message/fix implies the attribute alone is sufficient.
-- [ ] Unscoped vs MT-specific scoping is correct; no un-opt-out-able new break for plain `ITask` consumers.
-- [ ] Path safe-patterns match domain semantics (no `IsPathRooted` gate; `GetAbsolutePath` ≠ canonicalize).
-- [ ] Config option is reachable; no bespoke knob where severity config suffices.
-- [ ] Residual dataflow/lifetime hazards acknowledged, not assumed covered.
 
 ## Cross-references
 

--- a/.github/skills/reviewing-roslyn-analyzers/SKILL.md
+++ b/.github/skills/reviewing-roslyn-analyzers/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: reviewing-roslyn-analyzers
+description: "Use when reviewing a pull request that adds or changes a Roslyn C# analyzer, code fix, or diagnostic suppressor (DiagnosticAnalyzer / CodeFixProvider / DiagnosticSuppressor, Microsoft.CodeAnalysis.Diagnostics). Covers analyzer registration and statelessness, diagnostic descriptors, AnalyzerReleases release tracking (RS2000/RS2001), severity and WarnAsError impact, false positives/negatives and safe-pattern recognition, code-fix compile-safety and FixAll, analyzer robustness (never throw), performance, and non-theater tests."
+argument-hint: "Paste the PR number/URL or the analyzer diff to review."
+---
+
+# Reviewing Roslyn Analyzer Contributions
+
+A Roslyn analyzer is compiler-hosted, runs concurrently, is reused across compilations, and its diagnostics become part of every consumer's build. A defect is not a crashed unit test — it is a **false warning on everyone's build**, a **build break for `-warnaserror` consumers**, a **code fix that produces non-compiling code**, or an **analyzer exception that silently suppresses every diagnostic**. Review accordingly.
+
+This is the generic layer — the analyzer *engineering*. When the analyzer encodes MSBuild multithreaded-task rules (the `MSBuildTaskNNNN` diagnostics in `src/TaskAnalyzer/`), also apply **reviewing-multithreaded-task-analyzers**, which judges whether the encoded rule matches MT semantics.
+
+## When to use
+
+- A PR adds or modifies a `DiagnosticAnalyzer`, `CodeFixProvider`, `DiagnosticSuppressor`, `DiagnosticDescriptor`, or their tests.
+- A PR changes a diagnostic's **severity**, **category**, **message**, or **default-enabled** state.
+- A PR touches `AnalyzerReleases.Shipped.md` / `AnalyzerReleases.Unshipped.md`, or should have.
+
+Not for: MSBuild BuildCheck analyzers (`src/Build/BuildCheck/**` — different subsystem; see `buildcheck.instructions.md`), or reviewing task code being *migrated* to MT (use the `mt-migration-reviewer` agent).
+
+## How to use
+
+For an automated pass, invoke **`@analyzer-reviewer`**, which runs this questionnaire and reports coverage. To review by hand, walk the five waves in order and produce the coverage report below.
+
+**Report coverage first, findings second.** A human should see *what you checked* and *how you verified it*, then read only proven defects. Emit one coverage line per wave:
+
+| Wave | Status | Verified / evidence |
+|---|---|---|
+| 1 Structure/release | CLEAN · ISSUES · N/A · INCOMPLETE | what you confirmed, a link to the finding, or why verification was incomplete |
+
+Then list findings, each with `file:line`, the concrete failing input, severity, and a fix.
+
+**Evidence-and-noise gate:**
+- CLEAN is the expected result; never invent a finding to fill a wave. INCOMPLETE is an honest verdict — it must never be upgraded to a finding.
+- **No cap, no quota.** Equally, never suppress a real one to keep the review short: report *every* concern that clears the evidence + severity bar, and only those. Three real defects means three findings. Filter on evidence and severity, never on count.
+- Report a finding only with a concrete trigger: an exact source/config input, a fix output that does not compile (name the `CSxxxx`), or an exact descriptor↔release↔README↔test mismatch.
+- No praise, style, naming, formatting, preference-only, speculative-future ("a future caller might…"), or out-of-diff findings.
+
+Severity: **BLOCKING** (build break, analyzer crash, non-compiling fix, false positive at Warning-or-higher), **MAJOR** (missed detection, theater test, release-tracking/severity drift), **MINOR** (a concrete message/config inaccuracy that does not change diagnostic behavior). No NIT.
+
+---
+
+## Wave 1 — Structure, descriptors & release tracking
+
+The mechanical hygiene layer. Cheap to check, and the most frequent source of defects in practice.
+
+**CHECK — flag if:**
+- [ ] A new/changed rule is **not** reflected in `AnalyzerReleases.Unshipped.md` (columns `Rule ID | Category | Severity | Notes`). RS2000 requires it.
+- [ ] The descriptor's `defaultSeverity` disagrees with the `AnalyzerReleases` row, the README rule table, or the test assertions. **These four must move together.** The project puts `RS2001` in `NoWarn`, so the build will *not* catch this drift — verify severities by hand. (A severity change made in code but not mirrored in the release notes — or vice versa — is a common, silent drift.)
+- [ ] Diagnostic ID is not a compile-time constant, not unique, or not in `CATEGORYdddd` format (RS1017/1019/1018). Category is not the project's standard string.
+- [ ] Title or message ends with a period, or description does not (RS1031/1032/1033).
+- [ ] A rule reported from a `CompilationEnd`/`RegisterCompilationEndAction` path lacks `WellKnownDiagnosticTags.CompilationEnd` (RS1037).
+- [ ] A reported descriptor is missing from `SupportedDiagnostics` (RS1005). (`SupportedDiagnostics` should return a cached static array — a perf convention, not an RS rule.)
+- [ ] Localization/`helpLinkUri` is added to *some* descriptors but not others (RS1007/1015 are off by default — consistency, not mandate).
+
+## Wave 2 — Correctness & robustness of the analyzer itself
+
+An analyzer bug is silent and global. This wave is BLOCKING-heavy.
+
+**CHECK — flag if:**
+- [ ] Any callback can **throw**. An unhandled analyzer exception suppresses *all* diagnostics for the compilation. In particular, guard **locations** before reporting: a symbol may have zero `Locations`, and a `Location` from metadata has a null `SourceTree` — never index `Locations[0]` or dereference `SourceTree` unconditionally, and use `Location.None` as the fallback.
+- [ ] Mutable state lives in an analyzer **instance field** (RS1008). Per-compilation state must be captured in closures inside `RegisterCompilationStartAction`. `Initialize` must call `EnableConcurrentExecution()` and `ConfigureGeneratedCodeAnalysis(...)` (RS1026/1025).
+- [ ] `ISymbol` is compared with `==` instead of `SymbolEqualityComparer` (RS1024).
+- [ ] Deduplication or suppression uses a key that does **not** match where the diagnostic is reported, so distinct violations collapse or suppression misfires. Report at the precise offending location, with secondary context as an `AdditionalLocation`, so `#pragma warning disable` / `[SuppressMessage]` work where the code lives.
+- [ ] File/environment/other non-deterministic APIs are used inside analyzer callbacks (RS1035).
+
+## Wave 3 — Detection precision (false positives & false negatives)
+
+The heart of an analyzer review, and where reviewers spend the most words. An analyzer that cries wolf gets suppressed wholesale; one that misses the target gives false confidence.
+
+**For every rule the PR adds or widens, construct inputs in each cell:**
+
+| | Should fire | Should stay silent |
+|---|---|---|
+| **Direct** | the canonical violation | the canonical safe form |
+| **Edge** | the tricky shape (nested call, array, named arg, alias, inherited member) | the recognized safe pattern the analyzer must not flag |
+
+**CHECK — flag if:**
+- [ ] A **safe pattern is flagged** (false positive). Trace the analyzer's own allow-list: does it recognize the argument alias, the local-variable initializer, the implicit conversion, the base-type member, the metadata/typed accessor? (E.g. an open-generic `ITaskItem<T>` — `TypeKind.TypeParameter` — must be skipped, because an unresolved type parameter can't be judged.)
+- [ ] A **known violation is missed** (false negative) — e.g. the check keys on a syntactic shape (`==` on `.Kind`) rather than a semantic one, or on one argument position when others are also unsafe, or misses `using static`, nested calls, or members reached through a base class.
+- [ ] Widening the rule's **scope/gate** silently changes which inputs fire — especially any change that makes an always-applicable rule newly scope-gated, or vice versa. Name who newly gains/loses a diagnostic.
+- [ ] Parameter-name / metadata / attribute matching is case- or overload-sensitive in a way tests do not pin.
+
+## Wave 4 — Code fixes
+
+A code fix is applied unattended, in bulk, by `dotnet format` and IDE "Fix all". It must produce **compiling** code or offer **nothing**.
+
+**CHECK — flag if:**
+- [ ] Applying the fix can produce non-compiling code. Enumerate the contexts: nested calls (don't wrap the outer argument — CS1503), named-argument order, static context / static local / static lambda (CS0120), field/property/constructor initializers (CS0236/CS0027), a type with no accessible member the fix references (CS0103), init-only or non-public setters that can't satisfy an interface, a member-name collision (CS0102), a property referenced across partial declarations in another document. The correct behavior is to **withhold** the fix, not emit broken code.
+- [ ] Every `CodeAction` does not set a stable, non-null `EquivalenceKey` (RS1010), or the provider does not override `GetFixAllProvider` (RS1016). Per the analyzer README, `dotnet format analyzers` derives its batch from the **first** diagnostic — if that first occurrence offers no fix, the whole batch applies nothing; the fixer must group diagnostics by target property so a property is retyped exactly once (`PreferTypedParameterFixAllProvider`).
+- [ ] The fix changes program semantics (e.g. drops an overload parameter that alters behavior) rather than declining.
+
+## Wave 5 — Tests
+
+Analyzer tests are cheap to write and easy to fake. A test that cannot fail is worse than no test.
+
+**CHECK — flag if:**
+- [ ] A test **cannot fail for the reason it names** — e.g. it exercises a config path it never actually sets, or asserts "no diagnostic / no feedback" where the interesting case is a diagnostic. (E.g. a test claiming to be "independent of scope" that never sets a scope cannot fail for the reason it names.)
+- [ ] A new opt-in / config path added by the PR has no test that would fail if it silently became a no-op.
+- [ ] Any rule lacks the coverage matrix: positive, negative, boundary, safe-pattern-suppresses, and (for a fix) fixed-code-**compiles**.
+- [ ] Tests hard-code OS-specific absolute paths instead of the portable helper; or assert full localized strings instead of invariant substrings.
+
+---
+
+## Sign-off checklist
+
+- [ ] Release tracking updated; descriptor severity == release note == README == test assertion.
+- [ ] Severity choice justified; any new Warning/Error acknowledges `-warnaserror` impact.
+- [ ] No callback can throw; nullable locations guarded; stateless + concurrent-safe.
+- [ ] For each new/changed rule: a concrete should-fire and a concrete should-stay-silent input, including the edge shapes.
+- [ ] Every code fix either compiles or is withheld; FixAll/equivalence-key correct.
+- [ ] Tests can fail for the reason they name; full coverage matrix present.
+- [ ] PR is one concern (release-tracking drift and severity changes hide in bundled PRs).
+
+## Don't over-flag (avoid false alarms)
+
+- Cold-path LINQ inside `RegisterCompilationStart` (once per compilation) is fine; only flag allocation/LINQ on the per-operation/per-symbol hot path.
+- A rule that is `Info` or off-by-default is a deliberate, low-blast-radius choice — hold it to modernization-suggestion standards, not correctness-rule standards.
+- A missing code fix is acceptable when the resolution is genuinely author-judgment (e.g. MSBuildTask0009 offers none by design). Don't demand a fix that would have to guess intent.
+- `helpLinkUri`/localization absence is **not** a finding for an internal analyzer unless the PR introduces a concrete user-visible inconsistency (e.g. other descriptors carry help links and the new one doesn't).

--- a/.github/skills/reviewing-roslyn-analyzers/SKILL.md
+++ b/.github/skills/reviewing-roslyn-analyzers/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: reviewing-roslyn-analyzers
-description: "Use when reviewing a pull request that adds or changes a Roslyn C# analyzer, code fix, or diagnostic suppressor (DiagnosticAnalyzer / CodeFixProvider / DiagnosticSuppressor, Microsoft.CodeAnalysis.Diagnostics). Covers analyzer registration and statelessness, diagnostic descriptors, AnalyzerReleases release tracking (RS2000/RS2001), severity and WarnAsError impact, false positives/negatives and safe-pattern recognition, code-fix compile-safety and FixAll, analyzer robustness (never throw), performance, and non-theater tests."
+description: "Use when reviewing changes to a Roslyn C# DiagnosticAnalyzer, CodeFixProvider, DiagnosticSuppressor, diagnostic descriptor, AnalyzerReleases file, or analyzer tests. Also use for changes to diagnostic severity, configuration, or FixAll behavior."
 argument-hint: "Paste the PR number/URL or the analyzer diff to review."
 ---
 
 # Reviewing Roslyn Analyzer Contributions
 
-A Roslyn analyzer is compiler-hosted, runs concurrently, is reused across compilations, and its diagnostics become part of every consumer's build. A defect is not a crashed unit test — it is a **false warning on everyone's build**, a **build break for `-warnaserror` consumers**, a **code fix that produces non-compiling code**, or an **analyzer exception that silently suppresses every diagnostic**. Review accordingly.
+A Roslyn analyzer runs in compiler hosts, concurrently and across compilations. Defects can cause false warnings, break `-warnaserror` builds, produce non-compiling fixes, or leave analysis incomplete after an exception.
 
 This is the generic layer — the analyzer *engineering*. When the analyzer encodes MSBuild multithreaded-task rules (the `MSBuildTaskNNNN` diagnostics in `src/TaskAnalyzer/`), also apply **reviewing-multithreaded-task-analyzers**, which judges whether the encoded rule matches MT semantics.
 
@@ -20,19 +20,21 @@ Not for: MSBuild BuildCheck analyzers (`src/Build/BuildCheck/**` — different s
 
 ## How to use
 
-For an automated pass, invoke **`@analyzer-reviewer`**, which runs this questionnaire and reports coverage. To review by hand, walk the five waves in order and produce the coverage report below.
+For an automated pass, invoke **`@analyzer-reviewer`**. For a manual review:
 
-**Report coverage first, findings second.** A human should see *what you checked* and *how you verified it*, then read only proven defects. Emit one coverage line per wave:
+1. Identify changed rules, fixes, descriptors, configuration, and tests at the PR head. Mark each wave applicable or `N/A`.
+2. Work through applicable Waves 1–5 in order. Verify each candidate against source or tests. Mark missing evidence `INCOMPLETE`.
+3. Report coverage first, then proven findings with `file:line`, failing input, severity, and a fix. Include one row per wave.
+
+Use only `CLEAN`, `ISSUES`, `N/A`, or `INCOMPLETE` for coverage status, never a finding's severity:
 
 | Wave | Status | Verified / evidence |
 |---|---|---|
 | 1 Structure/release | CLEAN · ISSUES · N/A · INCOMPLETE | what you confirmed, a link to the finding, or why verification was incomplete |
 
-Then list findings, each with `file:line`, the concrete failing input, severity, and a fix.
-
 **Evidence-and-noise gate:**
 - CLEAN is the expected result; never invent a finding to fill a wave. INCOMPLETE is an honest verdict — it must never be upgraded to a finding.
-- **No cap, no quota.** Equally, never suppress a real one to keep the review short: report *every* concern that clears the evidence + severity bar, and only those. Three real defects means three findings. Filter on evidence and severity, never on count.
+- **No cap, no quota.** Report every concern that clears the evidence and severity bar, and only those.
 - Report a finding only with a concrete trigger: an exact source/config input, a fix output that does not compile (name the `CSxxxx`), or an exact descriptor↔release↔README↔test mismatch.
 - No praise, style, naming, formatting, preference-only, speculative-future ("a future caller might…"), or out-of-diff findings.
 
@@ -46,7 +48,8 @@ The mechanical hygiene layer. Cheap to check, and the most frequent source of de
 
 **CHECK — flag if:**
 - [ ] A new/changed rule is **not** reflected in `AnalyzerReleases.Unshipped.md` (columns `Rule ID | Category | Severity | Notes`). RS2000 requires it.
-- [ ] The descriptor's `defaultSeverity` disagrees with the `AnalyzerReleases` row, the README rule table, or the test assertions. **These four must move together.** The project puts `RS2001` in `NoWarn`, so the build will *not* catch this drift — verify severities by hand. (A severity change made in code but not mirrored in the release notes — or vice versa — is a common, silent drift.)
+- [ ] The descriptor's `defaultSeverity` disagrees with the `AnalyzerReleases` row, the README rule table, or the test assertions. **These four must move together.** The project puts `RS2001` in `NoWarn`, so the build will *not* catch this drift — verify severities by hand.
+- [ ] A new default-enabled Warning/Error, severity promotion, or newly enabled rule lacks justification for its `-warnaserror` impact.
 - [ ] Diagnostic ID is not a compile-time constant, not unique, or not in `CATEGORYdddd` format (RS1017/1019/1018). Category is not the project's standard string.
 - [ ] Title or message ends with a period, or description does not (RS1031/1032/1033).
 - [ ] A rule reported from a `CompilationEnd`/`RegisterCompilationEndAction` path lacks `WellKnownDiagnosticTags.CompilationEnd` (RS1037).
@@ -55,10 +58,10 @@ The mechanical hygiene layer. Cheap to check, and the most frequent source of de
 
 ## Wave 2 — Correctness & robustness of the analyzer itself
 
-An analyzer bug is silent and global. This wave is BLOCKING-heavy.
+An exception can leave analysis incomplete. This wave is BLOCKING-heavy.
 
 **CHECK — flag if:**
-- [ ] Any callback can **throw**. An unhandled analyzer exception suppresses *all* diagnostics for the compilation. In particular, guard **locations** before reporting: a symbol may have zero `Locations`, and a `Location` from metadata has a null `SourceTree` — never index `Locations[0]` or dereference `SourceTree` unconditionally, and use `Location.None` as the fallback.
+- [ ] Any callback can **throw**. Roslyn normally reports analyzer failures as `AD0001`. Do not assume an exception removes diagnostics already reported or stops unrelated analyzers. Guard **locations** before reporting: a symbol may have zero `Locations`, and a metadata location has a null `SourceTree`. Never index `Locations[0]` or dereference `SourceTree` unconditionally. Use `Location.None` when no source location exists.
 - [ ] Mutable state lives in an analyzer **instance field** (RS1008). Per-compilation state must be captured in closures inside `RegisterCompilationStartAction`. `Initialize` must call `EnableConcurrentExecution()` and `ConfigureGeneratedCodeAnalysis(...)` (RS1026/1025).
 - [ ] `ISymbol` is compared with `==` instead of `SymbolEqualityComparer` (RS1024).
 - [ ] Deduplication or suppression uses a key that does **not** match where the diagnostic is reported, so distinct violations collapse or suppression misfires. Report at the precise offending location, with secondary context as an `AdditionalLocation`, so `#pragma warning disable` / `[SuppressMessage]` work where the code lives.
@@ -95,22 +98,10 @@ A code fix is applied unattended, in bulk, by `dotnet format` and IDE "Fix all".
 Analyzer tests are cheap to write and easy to fake. A test that cannot fail is worse than no test.
 
 **CHECK — flag if:**
-- [ ] A test **cannot fail for the reason it names** — e.g. it exercises a config path it never actually sets, or asserts "no diagnostic / no feedback" where the interesting case is a diagnostic. (E.g. a test claiming to be "independent of scope" that never sets a scope cannot fail for the reason it names.)
+- [ ] A test **cannot fail for the reason it names** — e.g. it exercises a config path it never actually sets, or asserts "no diagnostic / no feedback" where the interesting case is a diagnostic.
 - [ ] A new opt-in / config path added by the PR has no test that would fail if it silently became a no-op.
 - [ ] Any rule lacks the coverage matrix: positive, negative, boundary, safe-pattern-suppresses, and (for a fix) fixed-code-**compiles**.
 - [ ] Tests hard-code OS-specific absolute paths instead of the portable helper; or assert full localized strings instead of invariant substrings.
-
----
-
-## Sign-off checklist
-
-- [ ] Release tracking updated; descriptor severity == release note == README == test assertion.
-- [ ] Severity choice justified; any new Warning/Error acknowledges `-warnaserror` impact.
-- [ ] No callback can throw; nullable locations guarded; stateless + concurrent-safe.
-- [ ] For each new/changed rule: a concrete should-fire and a concrete should-stay-silent input, including the edge shapes.
-- [ ] Every code fix either compiles or is withheld; FixAll/equivalence-key correct.
-- [ ] Tests can fail for the reason they name; full coverage matrix present.
-- [ ] PR is one concern (release-tracking drift and severity changes hide in bundled PRs).
 
 ## Don't over-flag (avoid false alarms)
 


### PR DESCRIPTION
Review guidance for the thread-safe task analyzer (`src/TaskAnalyzer/`).

Authoring analyzer code follows different principles than changing MSBuild itself, so it gets a dedicated reviewer with isolated context and rules that layers on `@expert-reviewer` rather than overloading the general one.

Draft — happy to fold/trim.