### PR TITLE
Reduce binary logger serialization overhead

### DIFF
--- a/src/Build.UnitTests/BuildEventArgsSerialization_Tests.cs
+++ b/src/Build.UnitTests/BuildEventArgsSerialization_Tests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -11,6 +12,8 @@ using System.Runtime.Serialization;
 using System.Text;
 using FluentAssertions;
 using Microsoft.Build.BackEnd;
+using Microsoft.Build.Evaluation;
+using Microsoft.Build.Execution;
 using Microsoft.Build.Experimental.BuildCheck;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Framework.Profiler;
@@ -19,6 +22,8 @@ using Microsoft.Build.Shared;
 using Microsoft.Build.UnitTests.BackEnd;
 using Shouldly;
 using Xunit;
+using EngineTaskItem = Microsoft.Build.Execution.ProjectItemInstance.TaskItem;
+using UtilitiesTaskItem = Microsoft.Build.Utilities.TaskItem;
 
 #nullable disable
 
@@ -969,6 +974,162 @@ namespace Microsoft.Build.UnitTests
         }
 
         [Fact]
+        public void TaskParameterSerializationReusesSharedBackingMetadata()
+        {
+            ImmutableDictionary<string, string> metadata = ImmutableDictionaryExtensions.EmptyMetadata
+                .Add("Metadata", "value%253b");
+            var first = new UtilitiesTaskItem("ItemSpec1");
+            var second = new UtilitiesTaskItem("ItemSpec2");
+            ((IMetadataContainer)first).ImportMetadata(metadata);
+            ((IMetadataContainer)second).ImportMetadata(metadata);
+            var args = new TaskParameterEventArgs(
+                TaskParameterMessageKind.TaskOutput,
+                "ParameterName",
+                "PropertyName",
+                "ItemName",
+                new ITaskItem[] { first, second },
+                logItemMetadata: true,
+                DateTime.MinValue);
+            var memoryStream = new MemoryStream();
+            using var binaryWriter = new BinaryWriter(memoryStream);
+            var writer = new BuildEventArgsWriter(binaryWriter);
+
+            writer.Write(args);
+
+#if DEBUG
+            writer.MetadataReferenceCacheHits.ShouldBe(1);
+#endif
+            Roundtrip(
+                args,
+                e => string.Join(
+                    ";",
+                    e.Items.Cast<ITaskItem>().Select(item => $"{item.ItemSpec}:{item.GetMetadata("Metadata")}")));
+        }
+
+        [Fact]
+        public void TaskParameterSerializationCachesEmptyMetadataAndFallsBackForTaskItemData()
+        {
+            var first = new UtilitiesTaskItem("ItemSpec1");
+            var second = new UtilitiesTaskItem("ItemSpec2");
+            var taskItemData = new TaskItemData(
+                "ItemSpec3",
+                new Dictionary<string, string>
+                {
+                    ["Metadata"] = "value%253b",
+                });
+            var args = new TaskParameterEventArgs(
+                TaskParameterMessageKind.TaskOutput,
+                "ParameterName",
+                "PropertyName",
+                "ItemName",
+                new ITaskItem[] { first, second, taskItemData },
+                logItemMetadata: true,
+                DateTime.MinValue);
+            var memoryStream = new MemoryStream();
+            using var binaryWriter = new BinaryWriter(memoryStream);
+            var writer = new BuildEventArgsWriter(binaryWriter);
+
+            writer.Write(args);
+
+#if DEBUG
+            writer.MetadataReferenceCacheHits.ShouldBe(0);
+#endif
+            Roundtrip(
+                args,
+                e => string.Join(
+                    ";",
+                    e.Items.Cast<ITaskItem>().Select(item => $"{item.ItemSpec}:{item.GetMetadata("Metadata")}")));
+        }
+
+        [Fact]
+        public void TaskParameterSerializationReusesItemDefinitionMetadata()
+        {
+            var project = new Project();
+            var definition = new ProjectItemDefinition(project, "MyItem");
+            definition.SetMetadataValue("Metadata", "value%253b");
+            var itemDefinitions = new List<ProjectItemDefinitionInstance>
+            {
+                new ProjectItemDefinitionInstance(definition),
+            };
+            var first = new EngineTaskItem(
+                "ItemSpec1",
+                "ItemSpec1",
+                directMetadata: null,
+                itemDefinitions,
+                projectDirectory: null,
+                immutable: false,
+                definingFileEscaped: "project.proj");
+            var second = new EngineTaskItem(
+                "ItemSpec2",
+                "ItemSpec2",
+                directMetadata: null,
+                itemDefinitions,
+                projectDirectory: null,
+                immutable: false,
+                definingFileEscaped: "project.proj");
+            var args = new TaskParameterEventArgs(
+                TaskParameterMessageKind.TaskOutput,
+                "ParameterName",
+                "PropertyName",
+                "ItemName",
+                new ITaskItem[] { first, second },
+                logItemMetadata: true,
+                DateTime.MinValue);
+            var memoryStream = new MemoryStream();
+            using var binaryWriter = new BinaryWriter(memoryStream);
+            var writer = new BuildEventArgsWriter(binaryWriter);
+
+            writer.Write(args);
+
+#if DEBUG
+            writer.MetadataReferenceCacheHits.ShouldBe(1);
+#endif
+            Roundtrip(
+                args,
+                e => string.Join(
+                    ";",
+                    e.Items.Cast<ITaskItem>().Select(item => $"{item.ItemSpec}:{item.GetMetadata("Metadata")}")));
+        }
+
+        [Fact]
+        public void TaskParameterBackingMetadataFastPathPreservesSerializedBytes()
+        {
+            ImmutableDictionary<string, string> backingMetadata = ImmutableDictionaryExtensions.EmptyMetadata
+                .Add("Metadata", "value%253b");
+            var optimizedFirst = new UtilitiesTaskItem("ItemSpec1");
+            var optimizedSecond = new UtilitiesTaskItem("ItemSpec2");
+            ((IMetadataContainer)optimizedFirst).ImportMetadata(backingMetadata);
+            ((IMetadataContainer)optimizedSecond).ImportMetadata(backingMetadata);
+
+            byte[] optimizedBytes = SerializeTaskParameter([optimizedFirst, optimizedSecond]);
+            byte[] fallbackBytes = SerializeTaskParameter(
+                [
+                    new FallbackTaskItem("ItemSpec1", "Metadata", "value%3b"),
+                    new FallbackTaskItem("ItemSpec2", "Metadata", "value%3b"),
+                ]);
+
+            optimizedBytes.ShouldBe(fallbackBytes);
+
+            static byte[] SerializeTaskParameter(ITaskItem[] items)
+            {
+                var args = new TaskParameterEventArgs(
+                    TaskParameterMessageKind.TaskOutput,
+                    "ParameterName",
+                    "PropertyName",
+                    "ItemName",
+                    items,
+                    logItemMetadata: true,
+                    DateTime.MinValue);
+                var stream = new MemoryStream();
+                using (var writer = new BinaryWriter(stream, Encoding.UTF8, leaveOpen: true))
+                {
+                    new BuildEventArgsWriter(writer).Write(args);
+                }
+                return stream.ToArray();
+            }
+        }
+
+        [Fact]
         public void RoundtripProjectEvaluationStartedEventArgs()
         {
             var projectFile = @"C:\foo\bar.proj";
@@ -1057,6 +1218,46 @@ namespace Microsoft.Build.UnitTests
 
             /// <inheritdoc />
             public IEnumerable<KeyValuePair<string, string>> EnumerateMetadata() => _metadata;
+        }
+
+        private sealed class FallbackTaskItem : ITaskItem
+        {
+            private readonly Dictionary<string, string> _metadata;
+
+            internal FallbackTaskItem(string itemSpec, string metadataName, string metadataValue)
+            {
+                ItemSpec = itemSpec;
+                _metadata = new Dictionary<string, string>
+                {
+                    [metadataName] = metadataValue,
+                };
+            }
+
+            public string ItemSpec { get; set; }
+
+            public ICollection MetadataNames => _metadata.Keys;
+
+            public int MetadataCount => _metadata.Count;
+
+            public string GetMetadata(string metadataName)
+                => _metadata.TryGetValue(metadataName, out string value) ? value : string.Empty;
+
+            public void SetMetadata(string metadataName, string metadataValue)
+                => _metadata[metadataName] = metadataValue;
+
+            public void RemoveMetadata(string metadataName)
+                => _metadata.Remove(metadataName);
+
+            public void CopyMetadataTo(ITaskItem destinationItem)
+            {
+                foreach (KeyValuePair<string, string> metadata in _metadata)
+                {
+                    destinationItem.SetMetadata(metadata.Key, metadata.Value);
+                }
+            }
+
+            public IDictionary CloneCustomMetadata()
+                => new Dictionary<string, string>(_metadata);
         }
 
         [Fact]

--- a/src/Build.UnitTests/BuildEventArgsSerialization_Tests.cs
+++ b/src/Build.UnitTests/BuildEventArgsSerialization_Tests.cs
@@ -1138,20 +1138,37 @@ namespace Microsoft.Build.UnitTests
                 ["Second"] = string.Empty,
                 ["Escaped"] = "value%3b",
             };
+            var differentMetadata = new Dictionary<string, string>(metadata)
+            {
+                ["First"] = "different",
+            };
             byte[] directBytes = SerializeTaskParameter(
                 [
                     new TaskItemData("ItemSpec1", new Dictionary<string, string>(metadata)),
                     new TaskItemData("ItemSpec2", new Dictionary<string, string>(metadata)),
-                    new TaskItemData("ItemSpec3", metadata: null),
+                    new TaskItemData("ItemSpec3", differentMetadata),
+                    new TaskItemData("ItemSpec4", metadata: null),
                 ]);
             byte[] fallbackBytes = SerializeTaskParameter(
                 [
                     new FallbackTaskItem("ItemSpec1", new Dictionary<string, string>(metadata)),
                     new FallbackTaskItem("ItemSpec2", new Dictionary<string, string>(metadata)),
-                    new FallbackTaskItem("ItemSpec3", new Dictionary<string, string>()),
+                    new FallbackTaskItem("ItemSpec3", new Dictionary<string, string>(differentMetadata)),
+                    new FallbackTaskItem("ItemSpec4", new Dictionary<string, string>()),
                 ]);
 
             directBytes.ShouldBe(fallbackBytes);
+
+            using var stream = new MemoryStream(directBytes);
+            using var reader = new BinaryReader(stream, Encoding.UTF8, leaveOpen: true);
+            using var eventArgsReader = new BuildEventArgsReader(reader, BinaryLogger.FileFormatVersion);
+            var replayedArgs = (TaskParameterEventArgs)eventArgsReader.Read();
+            replayedArgs.Items.Count.ShouldBe(4);
+            ((ITaskItem)replayedArgs.Items[0]).GetMetadata("First").ShouldBe("value");
+            ((ITaskItem)replayedArgs.Items[1]).GetMetadata("First").ShouldBe("value");
+            ((ITaskItem)replayedArgs.Items[2]).GetMetadata("First").ShouldBe("different");
+            ((ITaskItem)replayedArgs.Items[3]).MetadataCount.ShouldBe(0);
+            stream.Position.ShouldBe(stream.Length);
 
             static byte[] SerializeTaskParameter(ITaskItem[] items)
             {

--- a/src/Build.UnitTests/BuildEventArgsSerialization_Tests.cs
+++ b/src/Build.UnitTests/BuildEventArgsSerialization_Tests.cs
@@ -1167,6 +1167,9 @@ namespace Microsoft.Build.UnitTests
             ((ITaskItem)replayedArgs.Items[0]).GetMetadata("First").ShouldBe("value");
             ((ITaskItem)replayedArgs.Items[1]).GetMetadata("First").ShouldBe("value");
             ((ITaskItem)replayedArgs.Items[2]).GetMetadata("First").ShouldBe("different");
+            ((ITaskItem)replayedArgs.Items[0]).GetMetadata("Escaped").ShouldBe("value%3b");
+            ((ITaskItem)replayedArgs.Items[1]).GetMetadata("Second").ShouldBe(string.Empty);
+            ((ITaskItem)replayedArgs.Items[2]).GetMetadata("Escaped").ShouldBe("value%3b");
             ((ITaskItem)replayedArgs.Items[3]).MetadataCount.ShouldBe(0);
             stream.Position.ShouldBe(stream.Length);
 

--- a/src/Build.UnitTests/BuildEventArgsSerialization_Tests.cs
+++ b/src/Build.UnitTests/BuildEventArgsSerialization_Tests.cs
@@ -1130,6 +1130,50 @@ namespace Microsoft.Build.UnitTests
         }
 
         [Fact]
+        public void TaskParameterTaskItemDataDirectPathPreservesSerializedBytes()
+        {
+            var metadata = new Dictionary<string, string>
+            {
+                ["First"] = "value",
+                ["Second"] = string.Empty,
+                ["Escaped"] = "value%3b",
+            };
+            byte[] directBytes = SerializeTaskParameter(
+                [
+                    new TaskItemData("ItemSpec1", new Dictionary<string, string>(metadata)),
+                    new TaskItemData("ItemSpec2", new Dictionary<string, string>(metadata)),
+                    new TaskItemData("ItemSpec3", metadata: null),
+                ]);
+            byte[] fallbackBytes = SerializeTaskParameter(
+                [
+                    new FallbackTaskItem("ItemSpec1", new Dictionary<string, string>(metadata)),
+                    new FallbackTaskItem("ItemSpec2", new Dictionary<string, string>(metadata)),
+                    new FallbackTaskItem("ItemSpec3", new Dictionary<string, string>()),
+                ]);
+
+            directBytes.ShouldBe(fallbackBytes);
+
+            static byte[] SerializeTaskParameter(ITaskItem[] items)
+            {
+                var args = new TaskParameterEventArgs(
+                    TaskParameterMessageKind.TaskOutput,
+                    "ParameterName",
+                    "PropertyName",
+                    "ItemName",
+                    items,
+                    logItemMetadata: true,
+                    DateTime.MinValue);
+                var stream = new MemoryStream();
+                using (var writer = new BinaryWriter(stream, Encoding.UTF8, leaveOpen: true))
+                {
+                    new BuildEventArgsWriter(writer).Write(args);
+                }
+
+                return stream.ToArray();
+            }
+        }
+
+        [Fact]
         public void RoundtripProjectEvaluationStartedEventArgs()
         {
             var projectFile = @"C:\foo\bar.proj";
@@ -1231,6 +1275,12 @@ namespace Microsoft.Build.UnitTests
                 {
                     [metadataName] = metadataValue,
                 };
+            }
+
+            internal FallbackTaskItem(string itemSpec, Dictionary<string, string> metadata)
+            {
+                ItemSpec = itemSpec;
+                _metadata = metadata;
             }
 
             public string ItemSpec { get; set; }

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
@@ -4,9 +4,14 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Runtime.CompilerServices;
+#if FEATURE_APPDOMAIN
+using System.Runtime.Remoting;
+#endif
 using Microsoft.Build.BackEnd.Logging;
 using Microsoft.Build.Collections;
 using Microsoft.Build.Evaluation;
@@ -78,6 +83,16 @@ namespace Microsoft.Build.Logging
         /// Hashtable used for deduplicating name-value lists. Same as strings.
         /// </summary>
         private readonly Dictionary<HashKey, int> nameValueListHashes = new Dictionary<HashKey, int>();
+
+        /// <summary>
+        /// Avoid repeatedly enumerating and hashing metadata dictionaries shared through copy-on-write item clones.
+        /// </summary>
+        private readonly ConditionalWeakTable<ImmutableDictionary<string, string>, StrongBox<int>> metadataRecordIds =
+            new ConditionalWeakTable<ImmutableDictionary<string, string>, StrongBox<int>>();
+
+#if DEBUG
+        internal int MetadataReferenceCacheHits { get; private set; }
+#endif
 
         /// <summary>
         /// Index 0 is null, Index 1 is the empty string.
@@ -1142,25 +1157,61 @@ namespace Microsoft.Build.Logging
                 return;
             }
 
-            // WARNING: Can't use AddRange here because CopyOnWriteDictionary in Microsoft.Build.Utilities.v4.0.dll
-            // is broken. Microsoft.Build.Utilities.v4.0.dll loads from the GAC by XAML markup tooling and it's
-            // implementation doesn't work with AddRange because AddRange special-cases ICollection<T> and
-            // CopyOnWriteDictionary doesn't implement it properly.
-            foreach (var kvp in item.EnumerateMetadata())
+            ImmutableDictionary<string, string> backingMetadata = null;
+            IMetadataContainer metadataContainer = item as IMetadataContainer;
+            if (metadataContainer != null
+#if FEATURE_APPDOMAIN
+                && !RemotingServices.IsTransparentProxy(item)
+#endif
+                )
             {
-                nameValueListBuffer.Add(kvp);
+                SerializableMetadata serializableMetadata = metadataContainer.BackingMetadata;
+                if (serializableMetadata.HasValue)
+                {
+                    backingMetadata = serializableMetadata.Dictionary;
+                    if (backingMetadata.Count == 0)
+                    {
+                        Write((byte)0);
+                        return;
+                    }
+
+                    if (metadataRecordIds.TryGetValue(backingMetadata, out StrongBox<int> cachedRecord))
+                    {
+#if DEBUG
+                        MetadataReferenceCacheHits++;
+#endif
+                        Write(cachedRecord.Value);
+                        return;
+                    }
+
+                    foreach (KeyValuePair<string, string> kvp in backingMetadata)
+                    {
+                        nameValueListBuffer.Add(new KeyValuePair<string, string>(
+                            kvp.Key,
+                            EscapingUtilities.UnescapeAll(kvp.Value)));
+                    }
+                }
             }
 
-            // Don't sort metadata because we want the binary log to be fully roundtrippable
-            // and we need to preserve the original order.
-            // if (nameValueListBuffer.Count > 1)
-            // {
-            //    nameValueListBuffer.Sort((l, r) => StringComparer.OrdinalIgnoreCase.Compare(l.Key, r.Key));
-            // }
+            if (backingMetadata == null)
+            {
+                // WARNING: Can't use AddRange here because CopyOnWriteDictionary in Microsoft.Build.Utilities.v4.0.dll
+                // is broken. Microsoft.Build.Utilities.v4.0.dll loads from the GAC by XAML markup tooling and it's
+                // implementation doesn't work with AddRange because AddRange special-cases ICollection<T> and
+                // CopyOnWriteDictionary doesn't implement it properly.
+                foreach (var kvp in item.EnumerateMetadata())
+                {
+                    nameValueListBuffer.Add(kvp);
+                }
+            }
 
-            WriteNameValueList();
-
+            int metadataRecordId = WriteNameValueList();
             nameValueListBuffer.Clear();
+
+            if (backingMetadata != null)
+            {
+                metadataRecordIds.Add(backingMetadata, new StrongBox<int>(metadataRecordId));
+            }
         }
 
         private void WriteProperties(IEnumerable properties)
@@ -1214,12 +1265,12 @@ namespace Microsoft.Build.Logging
             }
         }
 
-        private void WriteNameValueList()
+        private int WriteNameValueList()
         {
             if (nameValueListBuffer.Count == 0)
             {
                 Write((byte)0);
-                return;
+                return 0;
             }
 
             HashKey hash = HashAllStrings(nameValueListBuffer);
@@ -1234,6 +1285,7 @@ namespace Microsoft.Build.Logging
             }
 
             Write(recordId);
+            return recordId;
         }
 
         /// <summary>

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
@@ -31,6 +31,9 @@ namespace Microsoft.Build.Logging
     /// </summary>
     internal class BuildEventArgsWriter
     {
+        private const int StringReferenceCacheSize = 256; // Must remain a power of two.
+        private const int MaxCachedStringLength = 4096;
+
         private readonly Stream originalStream;
 
         /// <summary>
@@ -83,6 +86,11 @@ namespace Microsoft.Build.Logging
         /// we'll be able to use all the information we've discovered thus far.
         /// </summary>
         private readonly Dictionary<HashKey, int> stringHashes = new Dictionary<HashKey, int>();
+
+        /// <summary>
+        /// Avoid repeatedly hashing shared string instances without retaining the full string population.
+        /// </summary>
+        private readonly StringReferenceCacheEntry[] stringReferenceCache = new StringReferenceCacheEntry[StringReferenceCacheSize];
 
         /// <summary>
         /// Hashtable used for deduplicating name-value lists. Same as strings.
@@ -1461,6 +1469,18 @@ namespace Microsoft.Build.Logging
                 return (1, default);
             }
 
+            int referenceCacheIndex = -1;
+            if (text.Length <= MaxCachedStringLength)
+            {
+                int identityHash = RuntimeHelpers.GetHashCode(text);
+                referenceCacheIndex = (identityHash ^ (identityHash >> 16)) & (StringReferenceCacheSize - 1);
+                ref StringReferenceCacheEntry cachedEntry = ref stringReferenceCache[referenceCacheIndex];
+                if (ReferenceEquals(cachedEntry.Text, text))
+                {
+                    return (cachedEntry.RecordId, cachedEntry.Hash);
+                }
+            }
+
             var hash = new HashKey(text);
             if (!stringHashes.TryGetValue(hash, out var recordId))
             {
@@ -1470,6 +1490,14 @@ namespace Microsoft.Build.Logging
                 WriteStringRecord(text);
 
                 stringRecordId += 1;
+            }
+
+            if (referenceCacheIndex >= 0)
+            {
+                ref StringReferenceCacheEntry cachedEntry = ref stringReferenceCache[referenceCacheIndex];
+                cachedEntry.RecordId = recordId;
+                cachedEntry.Hash = hash;
+                cachedEntry.Text = text;
             }
 
             return (recordId, hash);
@@ -1532,6 +1560,13 @@ namespace Microsoft.Build.Logging
                 Write(extendedData.ExtendedMetadata);
                 WriteDeduplicatedString(extendedData.ExtendedData);
             }
+        }
+
+        private struct StringReferenceCacheEntry
+        {
+            internal string Text;
+            internal int RecordId;
+            internal HashKey Hash;
         }
 
         internal readonly struct HashKey : IEquatable<HashKey>

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
@@ -1195,6 +1195,12 @@ namespace Microsoft.Build.Logging
 
             if (backingMetadata == null)
             {
+                if (item is TaskItemData taskItemData)
+                {
+                    WriteNameValueList(taskItemData.Metadata);
+                    return;
+                }
+
                 // WARNING: Can't use AddRange here because CopyOnWriteDictionary in Microsoft.Build.Utilities.v4.0.dll
                 // is broken. Microsoft.Build.Utilities.v4.0.dll loads from the GAC by XAML markup tooling and it's
                 // implementation doesn't work with AddRange because AddRange special-cases ICollection<T> and
@@ -1274,6 +1280,23 @@ namespace Microsoft.Build.Logging
             }
 
             HashKey hash = HashAllStrings(nameValueListBuffer);
+            return WriteNameValueList(hash);
+        }
+
+        private int WriteNameValueList(IEnumerable<KeyValuePair<string, string>> nameValueList)
+        {
+            HashKey hash = HashAllStrings(nameValueList);
+            if (nameValueIndexListBuffer.Count == 0)
+            {
+                Write((byte)0);
+                return 0;
+            }
+
+            return WriteNameValueList(hash);
+        }
+
+        private int WriteNameValueList(HashKey hash)
+        {
             if (!nameValueListHashes.TryGetValue(hash, out var recordId))
             {
                 recordId = nameValueRecordId;
@@ -1310,7 +1333,7 @@ namespace Microsoft.Build.Logging
             using (var _ = RedirectWritesToDifferentWriter(nameValueListBw, binaryWriter))
             {
                 Write(nameValueIndexListBuffer.Count);
-                for (int i = 0; i < nameValueListBuffer.Count; i++)
+                for (int i = 0; i < nameValueIndexListBuffer.Count; i++)
                 {
                     var kvp = nameValueIndexListBuffer[i];
                     Write(kvp.Key);
@@ -1337,6 +1360,24 @@ namespace Microsoft.Build.Logging
             for (int i = 0; i < nameValueList.Count; i++)
             {
                 var kvp = nameValueList[i];
+                var (keyIndex, keyHash) = HashString(kvp.Key);
+                var (valueIndex, valueHash) = HashString(kvp.Value);
+                hash = hash.Add(keyHash);
+                hash = hash.Add(valueHash);
+                nameValueIndexListBuffer.Add(new KeyValuePair<int, int>(keyIndex, valueIndex));
+            }
+
+            return hash;
+        }
+
+        private HashKey HashAllStrings(IEnumerable<KeyValuePair<string, string>> nameValueList)
+        {
+            HashKey hash = new HashKey();
+
+            nameValueIndexListBuffer.Clear();
+
+            foreach (KeyValuePair<string, string> kvp in nameValueList)
+            {
                 var (keyIndex, keyHash) = HashString(kvp.Key);
                 var (valueIndex, valueHash) = HashString(kvp.Value);
                 hash = hash.Add(keyHash);

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
@@ -60,6 +60,11 @@ namespace Microsoft.Build.Logging
         private readonly BinaryWriter currentRecordWriter;
 
         /// <summary>
+        /// The binary writer around the nameValueListStream.
+        /// </summary>
+        private readonly BinaryWriter nameValueListWriter;
+
+        /// <summary>
         /// The binary writer we're currently using. Is pointing at the currentRecordWriter usually,
         /// but sometimes we repoint it to the originalBinaryWriter temporarily, when writing string
         /// and name-value records.
@@ -146,6 +151,7 @@ namespace Microsoft.Build.Logging
             this.currentRecordStream = new MemoryStream(65536);
 
             this.nameValueListStream = new MemoryStream(256);
+            this.nameValueListWriter = new BinaryWriter(nameValueListStream);
 
             this.originalBinaryWriter = binaryWriter;
             this.currentRecordWriter = new BinaryWriter(currentRecordStream);
@@ -1328,9 +1334,8 @@ namespace Microsoft.Build.Logging
             // All that is redirected away from the 'currentRecordStream' - that will be flushed last
 
             nameValueListStream.SetLength(0);
-            var nameValueListBw = new BinaryWriter(nameValueListStream);
 
-            using (var _ = RedirectWritesToDifferentWriter(nameValueListBw, binaryWriter))
+            using (var _ = RedirectWritesToDifferentWriter(nameValueListWriter, binaryWriter))
             {
                 Write(nameValueIndexListBuffer.Count);
                 for (int i = 0; i < nameValueIndexListBuffer.Count; i++)

--- a/src/Framework/IMetadataContainer.cs
+++ b/src/Framework/IMetadataContainer.cs
@@ -19,6 +19,8 @@ namespace Microsoft.Build.Framework
         /// If the implementation's backing dictionary does not support copy-on-write, it should return the default struct,
         /// allowing the caller to decide whether to take the reference.
         /// This can safely be used across AppDomain boundaries.
+        /// Values use MSBuild's internal escaped representation; keys are stored verbatim.
+        /// Unescaping each value must produce the same metadata sequence and ordering as <see cref="EnumerateMetadata"/>.
         /// </remarks>
         SerializableMetadata BackingMetadata { get; }
 


### PR DESCRIPTION
Related to #10490

### Context

BinaryLogger profiling identified task-item metadata serialization, repeated metadata writer allocation, and repeated string hashing as major contributors to `/bl` overhead. This stacks four format-preserving hot-path optimizations that reduce that work without omitting log data.

### Changes Made

- Added an identity cache that reuses emitted `NameValueList` record IDs for shared immutable task-item metadata.
- Implemented a single-pass `TaskItemData` metadata path that hashes already-materialized metadata directly into string-index records.
- Reused the `BinaryWriter` associated with the reusable `NameValueList` stream.
- Added a bounded writer-local string-reference cache for repeated string instances up to 4 KiB.
- Preserved the legacy paths for custom `ITaskItem` implementations, transparent proxies, raw replay, empty metadata, escaping, and metadata ordering.
- Added focused serialization, fallback, cache, and byte-equivalence coverage in `BuildEventArgsSerializationTests`.

### Testing

- Built the full repository — 0 warnings, 0 errors.
- Ran the focused `BuildEventArgsSerializationTests` on `net11.0` and `net472` — passed.
- Built and replayed a bootstrap binary log for `src/Samples/Dependency/Dependency.csproj` — passed.
- Ran the isolated serializer benchmark — optimized won 7 of 7 comparisons, with approximately 7% lower wall and CPU time.
- Ran sequential OrchardCore GOLDWIN diagnostics:
  - normal: 133.05 seconds → 123.50 seconds, saving 9.54 seconds / 7.17%;
  - `/mt`: 94.52 seconds → 85.50 seconds, saving 9.02 seconds / 9.54%.

### Notes

- The binary log format and serialized content are unchanged; no format-version increment is required.
- The reliable Windows measurements removed 25.1% of the previous normal `/bl` overhead and 37.3% of the previous `/mt` overhead.
