### PR TITLE
Fix template path in quarantine pipeline

### DIFF
--- a/azure-pipelines/quarantine.yml
+++ b/azure-pipelines/quarantine.yml
@@ -64,6 +64,10 @@ jobs:
     demands: ImageOverride -equals windows.vs2026preview.scout.amd64.open
   timeoutInMinutes: 120
   steps:
+  # The definition defaults to a shallow (depth 1) fetch, but
+  # check-documentation-only-change.yml diffs HEAD against HEAD~1, so fetch the parent too.
+  - checkout: self
+    fetchDepth: 2
   - template: check-documentation-only-change.yml
   - task: BatchScript@1
     displayName: Build (quarantined tests only)
@@ -115,6 +119,10 @@ jobs:
     demands: ImageOverride -equals Build.Ubuntu.2204.Amd64.Open
   timeoutInMinutes: 120
   steps:
+  # The definition defaults to a shallow (depth 1) fetch, but
+  # check-documentation-only-change.yml diffs HEAD against HEAD~1, so fetch the parent too.
+  - checkout: self
+    fetchDepth: 2
   - template: check-documentation-only-change.yml
   - bash: sudo apt-get update
   - bash: sudo apt-get install -y libxml2
@@ -156,6 +164,10 @@ jobs:
     vmImage: 'macOS-latest'
   timeoutInMinutes: 120
   steps:
+  # The definition defaults to a shallow (depth 1) fetch, but
+  # check-documentation-only-change.yml diffs HEAD against HEAD~1, so fetch the parent too.
+  - checkout: self
+    fetchDepth: 2
   - template: check-documentation-only-change.yml
   - bash: . 'build.sh' --ci --test --stage2Argument '/p:RunQuarantinedTests=true'
     displayName: Build (quarantined tests only)

--- a/azure-pipelines/quarantine.yml
+++ b/azure-pipelines/quarantine.yml
@@ -64,7 +64,7 @@ jobs:
     demands: ImageOverride -equals windows.vs2026preview.scout.amd64.open
   timeoutInMinutes: 120
   steps:
-  - template: azure-pipelines/check-documentation-only-change.yml
+  - template: check-documentation-only-change.yml
   - task: BatchScript@1
     displayName: Build (quarantined tests only)
     inputs:
@@ -115,7 +115,7 @@ jobs:
     demands: ImageOverride -equals Build.Ubuntu.2204.Amd64.Open
   timeoutInMinutes: 120
   steps:
-  - template: azure-pipelines/check-documentation-only-change.yml
+  - template: check-documentation-only-change.yml
   - bash: sudo apt-get update
   - bash: sudo apt-get install -y libxml2
   - bash: . 'build.sh' --ci --test --stage2Argument '/p:RunQuarantinedTests=true'
@@ -156,7 +156,7 @@ jobs:
     vmImage: 'macOS-latest'
   timeoutInMinutes: 120
   steps:
-  - template: azure-pipelines/check-documentation-only-change.yml
+  - template: check-documentation-only-change.yml
   - bash: . 'build.sh' --ci --test --stage2Argument '/p:RunQuarantinedTests=true'
     displayName: Build (quarantined tests only)
     condition: or(ne(variables['Build.Reason'], 'PullRequest'), eq(variables.onlyDocChanged, 0))


### PR DESCRIPTION
The [quarantine pipeline](https://dev.azure.com/dnceng-public/public/_build?definitionId=344) has not run since #14371 (~50 days!). It fails
while parsing YAML.

Cause: `template:` paths resolve relative to the file that contains them.
`quarantine.yml` is already in `azure-pipelines/`, so the extra prefix pointed to
a folder that does not exist.
