### PR TITLE
Fix Dependabot ignore rule to match gh-aw-actions sub-path actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,6 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     ignore:
-      - dependency-name: "github/gh-aw-actions" # Managed by gh aw compile. Version-locked to the gh-aw compiler; do not bump.
+      - dependency-name: "github/gh-aw-actions/*" # Managed by gh aw compile. Version-locked to the gh-aw compiler; do not bump.
     schedule:
       interval: "weekly"


### PR DESCRIPTION
The ignore rule for `github/gh-aw-actions` stopped matching: Dependabot began treating sub-path actions as separate dependencies.

Since then four Dependabot bumps have slipped through and broken the agentic workflows. #14842, #14870 and #14935 were the repairs.

These pins are generated by `gh aw compile` and must not be bumped on their own.

### Changes Made

- Use the wildcard form documented by gh-aw, which also matches `/setup` and `/setup-cli`.
